### PR TITLE
fix(trusty-gworkspace): LOW hardening — token-in-error redaction + bounds (#2751)

### DIFF
--- a/crates/trusty-gworkspace/src/api/auth/manager.rs
+++ b/crates/trusty-gworkspace/src/api/auth/manager.rs
@@ -18,7 +18,7 @@ use chrono::{Duration, Utc};
 use serde::Deserialize;
 
 use super::models::{OAuthToken, StoredToken};
-use super::oauth::errors::refresh_failure_message;
+use super::oauth::errors::{redact_token_response, refresh_failure_message};
 use super::storage::TokenStorage;
 use crate::api::constants::OAUTH_TOKEN_URL;
 
@@ -106,8 +106,11 @@ impl OAuthManager {
                 refresh_failure_message(status, &body, profile)
             ));
         }
-        let parsed: GoogleTokenResponse =
-            serde_json::from_str(&body).with_context(|| format!("parse token response: {body}"))?;
+        // NB: `body` here is a 2xx token response containing access/refresh
+        // tokens; on the (practically unreachable) parse failure it must be
+        // redacted, never embedded verbatim, before entering the error chain.
+        let parsed: GoogleTokenResponse = serde_json::from_str(&body)
+            .with_context(|| format!("parse token response: {}", redact_token_response(&body)))?;
 
         let expires_in = parsed.expires_in.unwrap_or(3600);
         let new_token = OAuthToken {

--- a/crates/trusty-gworkspace/src/api/auth/oauth/errors.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/errors.rs
@@ -15,7 +15,11 @@
 //! Test: `sanitizes_oauth_error_json`, `sanitizes_oauth_error_json_without_description`,
 //! `truncates_unparseable_body`, `detects_invalid_grant`, `ignores_non_invalid_grant`,
 //! `refresh_failure_message_names_profile_and_setup_command`,
-//! `refresh_failure_message_non_invalid_grant_has_no_hint`.
+//! `refresh_failure_message_non_invalid_grant_has_no_hint`,
+//! `redacts_token_values_in_json_body`, `redacts_non_json_token_body`,
+//! `redacts_nested_token_value`, `redacts_token_in_array`,
+//! `redacts_token_under_non_sensitive_key`, `redacts_root_level_token_string`,
+//! `redacts_root_level_token_array`.
 
 use serde::Deserialize;
 
@@ -37,18 +41,8 @@ struct OAuthErrorBody {
 /// Maximum characters of an unparseable error body to surface.
 const MAX_ERROR_BODY_CHARS: usize = 200;
 
-/// JSON key fragments whose values may be bearer credentials and must never be
-/// echoed into an error string.
-///
-/// Why: A *token* response body (from the `authorization_code` / `refresh_token`
-/// exchanges) carries `access_token`, `refresh_token`, and `id_token`. If such a
-/// body ever fails to deserialize into the typed struct it would otherwise be
-/// embedded verbatim in a `parse token response: {body}` error — leaking the
-/// live credential into logs or crash reports. Any key containing one of these
-/// fragments (case-insensitive) has its value replaced before surfacing.
-/// What: Substrings matched against lower-cased JSON object keys.
-/// Test: `redacts_token_values_in_json_body`.
-const SENSITIVE_KEY_FRAGMENTS: [&str; 4] = ["token", "secret", "password", "assertion"];
+/// Sentinel substituted for every JSON string leaf during redaction.
+const REDACTED_PLACEHOLDER: &str = "<redacted>";
 
 /// Truncate `s` to at most `max` characters, appending an ellipsis when cut.
 ///
@@ -67,27 +61,33 @@ fn truncate_chars(s: &str, max: usize) -> String {
     }
 }
 
-/// Recursively replace the value of any credential-named key with `<redacted>`.
+/// Recursively replace every JSON *string* value with [`REDACTED_PLACEHOLDER`],
+/// at any depth, regardless of its key or position.
 ///
-/// Why: A token-response body is JSON whose credential fields must not survive
-/// into an error string; walking the whole tree covers nested objects/arrays.
-/// What: For every object entry whose (lower-cased) key contains a
-/// [`SENSITIVE_KEY_FRAGMENTS`] substring, replaces its value with the string
-/// `<redacted>`; otherwise recurses into the value.
-/// Test: `redacts_token_values_in_json_body`.
+/// Why: Key-name matching (e.g. "redact only keys containing `token`") is not a
+/// safe invariant — a token can appear as a root-level JSON string
+/// (`"ya29.xxx"`, no key at all), inside an array, or under an innocuously
+/// named key. The only value-shape that is safe to assert is "no string leaf
+/// survives": numbers/bools/null carry no credential risk, and preserving
+/// object keys + overall structure keeps the diagnostic useful without ever
+/// risking a token. Object *keys* are left intact (they're a fixed vocabulary
+/// like `access_token`, `expires_in`, not attacker/credential data); only
+/// *values* are scrubbed.
+/// What: Object values and array elements are redacted recursively; a
+/// `Value::String` becomes `REDACTED_PLACEHOLDER`; numbers/bools/null/objects/
+/// arrays are otherwise preserved (structurally) so the shape stays useful for
+/// diagnostics.
+/// Test: `redacts_token_values_in_json_body`, `redacts_nested_token_value`,
+/// `redacts_token_in_array`, `redacts_token_under_non_sensitive_key`,
+/// `redacts_root_level_token_string`, `redacts_root_level_token_array`.
 fn redact_sensitive_values(value: &mut serde_json::Value) {
     match value {
+        serde_json::Value::String(_) => {
+            *value = serde_json::Value::String(REDACTED_PLACEHOLDER.to_string());
+        }
         serde_json::Value::Object(map) => {
-            for (key, val) in map.iter_mut() {
-                let lower = key.to_ascii_lowercase();
-                if SENSITIVE_KEY_FRAGMENTS
-                    .iter()
-                    .any(|frag| lower.contains(frag))
-                {
-                    *val = serde_json::Value::String("<redacted>".to_string());
-                } else {
-                    redact_sensitive_values(val);
-                }
+            for val in map.values_mut() {
+                redact_sensitive_values(val);
             }
         }
         serde_json::Value::Array(items) => {
@@ -95,23 +95,31 @@ fn redact_sensitive_values(value: &mut serde_json::Value) {
                 redact_sensitive_values(item);
             }
         }
+        // Numbers, bools, null carry no credential risk — left as-is.
         _ => {}
     }
 }
 
 /// Produce a safe, bounded diagnostic for a *token-response* body that failed to
-/// parse, guaranteeing no bearer credential is embedded verbatim.
+/// parse, guaranteeing no raw string value (and therefore no bearer credential)
+/// is embedded verbatim.
 ///
 /// Why: On the 2xx success path the token endpoint returns a body containing
 /// `access_token`/`refresh_token`. Deserializing it into the typed struct is
 /// practically always successful, but if it ever fails the raw body must NOT be
 /// echoed into the `parse token response` error — that would surface a live
-/// token. This routes every such body through key-based redaction (for JSON) or
-/// full suppression (for non-JSON, which could itself be a raw token).
-/// What: Parses `body` as JSON and scrubs credential-named values via
-/// [`redact_sensitive_values`], returning the bounded scrubbed shape; when the
-/// body is not JSON, returns only its byte length (never its content).
-/// Test: `redacts_token_values_in_json_body`, `redacts_non_json_token_body`.
+/// token, whether it appears as an object value, an array element, or the
+/// entire body being a bare JSON string. This routes every such body through
+/// whole-tree string redaction (for JSON) or full suppression (for non-JSON,
+/// which could itself be a raw token with no JSON structure at all).
+/// What: Parses `body` as JSON and scrubs every string leaf via
+/// [`redact_sensitive_values`] (including a root-level string/array), returning
+/// the bounded scrubbed shape; when the body is not JSON, returns only its byte
+/// length (never its content).
+/// Test: `redacts_token_values_in_json_body`, `redacts_non_json_token_body`,
+/// `redacts_nested_token_value`, `redacts_token_in_array`,
+/// `redacts_token_under_non_sensitive_key`, `redacts_root_level_token_string`,
+/// `redacts_root_level_token_array`.
 pub(crate) fn redact_token_response(body: &str) -> String {
     match serde_json::from_str::<serde_json::Value>(body) {
         Ok(mut value) => {
@@ -267,6 +275,61 @@ mod tests {
         assert!(
             redacted.contains("expires_in"),
             "shape retained: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redacts_nested_token_value() {
+        // A token nested under a non-top-level key must still be redacted —
+        // redaction is value-gated (every string leaf), not key-gated.
+        let body = r#"{"data":{"inner":"ya29.SECRET"}}"#;
+        let redacted = redact_token_response(body);
+        assert!(
+            !redacted.contains("ya29.SECRET"),
+            "nested string value must not survive: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redacts_token_in_array() {
+        let body = r#"{"items":["ya29.SECRET"]}"#;
+        let redacted = redact_token_response(body);
+        assert!(
+            !redacted.contains("ya29.SECRET"),
+            "array element must not survive: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redacts_token_under_non_sensitive_key() {
+        // The key name gives no hint that the value is a credential — value
+        // gating must catch this even though no key-fragment matches.
+        let body = r#"{"blob":"ya29.SECRET"}"#;
+        let redacted = redact_token_response(body);
+        assert!(
+            !redacted.contains("ya29.SECRET"),
+            "value under a non-sensitive key must not survive: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redacts_root_level_token_string() {
+        // Valid JSON with no object/key at all — a bare quoted token string.
+        let body = r#""ya29.SECRET""#;
+        let redacted = redact_token_response(body);
+        assert!(
+            !redacted.contains("ya29.SECRET"),
+            "root-level string body must not survive: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redacts_root_level_token_array() {
+        let body = r#"["ya29.SECRET"]"#;
+        let redacted = redact_token_response(body);
+        assert!(
+            !redacted.contains("ya29.SECRET"),
+            "root-level array element must not survive: {redacted}"
         );
     }
 

--- a/crates/trusty-gworkspace/src/api/auth/oauth/errors.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/errors.rs
@@ -37,6 +37,91 @@ struct OAuthErrorBody {
 /// Maximum characters of an unparseable error body to surface.
 const MAX_ERROR_BODY_CHARS: usize = 200;
 
+/// JSON key fragments whose values may be bearer credentials and must never be
+/// echoed into an error string.
+///
+/// Why: A *token* response body (from the `authorization_code` / `refresh_token`
+/// exchanges) carries `access_token`, `refresh_token`, and `id_token`. If such a
+/// body ever fails to deserialize into the typed struct it would otherwise be
+/// embedded verbatim in a `parse token response: {body}` error — leaking the
+/// live credential into logs or crash reports. Any key containing one of these
+/// fragments (case-insensitive) has its value replaced before surfacing.
+/// What: Substrings matched against lower-cased JSON object keys.
+/// Test: `redacts_token_values_in_json_body`.
+const SENSITIVE_KEY_FRAGMENTS: [&str; 4] = ["token", "secret", "password", "assertion"];
+
+/// Truncate `s` to at most `max` characters, appending an ellipsis when cut.
+///
+/// Why: Both the unparseable-body fallback and a well-formed but arbitrarily
+/// long `error_description` must be length-bounded so a single error cannot
+/// balloon a log line unbounded.
+/// What: Returns `s` unchanged when within `max` chars, otherwise the first
+/// `max` chars followed by `...`.
+/// Test: `caps_long_error_description`, `truncates_unparseable_body`.
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() > max {
+        let head: String = s.chars().take(max).collect();
+        format!("{head}...")
+    } else {
+        s.to_string()
+    }
+}
+
+/// Recursively replace the value of any credential-named key with `<redacted>`.
+///
+/// Why: A token-response body is JSON whose credential fields must not survive
+/// into an error string; walking the whole tree covers nested objects/arrays.
+/// What: For every object entry whose (lower-cased) key contains a
+/// [`SENSITIVE_KEY_FRAGMENTS`] substring, replaces its value with the string
+/// `<redacted>`; otherwise recurses into the value.
+/// Test: `redacts_token_values_in_json_body`.
+fn redact_sensitive_values(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                let lower = key.to_ascii_lowercase();
+                if SENSITIVE_KEY_FRAGMENTS
+                    .iter()
+                    .any(|frag| lower.contains(frag))
+                {
+                    *val = serde_json::Value::String("<redacted>".to_string());
+                } else {
+                    redact_sensitive_values(val);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items.iter_mut() {
+                redact_sensitive_values(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Produce a safe, bounded diagnostic for a *token-response* body that failed to
+/// parse, guaranteeing no bearer credential is embedded verbatim.
+///
+/// Why: On the 2xx success path the token endpoint returns a body containing
+/// `access_token`/`refresh_token`. Deserializing it into the typed struct is
+/// practically always successful, but if it ever fails the raw body must NOT be
+/// echoed into the `parse token response` error — that would surface a live
+/// token. This routes every such body through key-based redaction (for JSON) or
+/// full suppression (for non-JSON, which could itself be a raw token).
+/// What: Parses `body` as JSON and scrubs credential-named values via
+/// [`redact_sensitive_values`], returning the bounded scrubbed shape; when the
+/// body is not JSON, returns only its byte length (never its content).
+/// Test: `redacts_token_values_in_json_body`, `redacts_non_json_token_body`.
+pub(crate) fn redact_token_response(body: &str) -> String {
+    match serde_json::from_str::<serde_json::Value>(body) {
+        Ok(mut value) => {
+            redact_sensitive_values(&mut value);
+            truncate_chars(&value.to_string(), MAX_ERROR_BODY_CHARS)
+        }
+        Err(_) => format!("<non-JSON body redacted, {} bytes>", body.len()),
+    }
+}
+
 /// Extract a safe, bounded error message from a Google OAuth error response.
 ///
 /// Why: The raw response body can be arbitrary third-party text (an HTML
@@ -44,23 +129,30 @@ const MAX_ERROR_BODY_CHARS: usize = 200;
 /// error chain and may be printed to the terminal or captured in crash
 /// reports. Surfacing only the structured `error`/`error_description` (or a
 /// short truncated fallback) keeps that surface bounded and predictable.
-/// What: Parses `body` as `{"error": "...", "error_description": "..."}`;
-/// falls back to a message truncated to [`MAX_ERROR_BODY_CHARS`] characters
-/// when the body isn't that shape.
-/// Test: `sanitizes_oauth_error_json`, `truncates_unparseable_body`.
+/// What: Parses `body` as `{"error": "...", "error_description": "..."}` and
+/// caps `error_description` at [`MAX_ERROR_BODY_CHARS`] characters (a well-formed
+/// but arbitrarily long description must not surface in full); falls back to a
+/// message truncated to the same bound when the body isn't that shape.
+/// Test: `sanitizes_oauth_error_json`, `caps_long_error_description`,
+/// `truncates_unparseable_body`.
 pub(crate) fn sanitize_oauth_error(status: reqwest::StatusCode, body: &str) -> String {
     if let Ok(parsed) = serde_json::from_str::<OAuthErrorBody>(body) {
         return match parsed.error_description {
-            Some(desc) => format!("{status} {}: {desc}", parsed.error),
+            Some(desc) => format!(
+                "{status} {}: {}",
+                parsed.error,
+                truncate_chars(&desc, MAX_ERROR_BODY_CHARS)
+            ),
             None => format!("{status} {}", parsed.error),
         };
     }
-    let char_count = body.chars().count();
-    let truncated: String = body.chars().take(MAX_ERROR_BODY_CHARS).collect();
-    if char_count > MAX_ERROR_BODY_CHARS {
-        format!("{status} (unparseable error body, truncated): {truncated}...")
+    if body.chars().count() > MAX_ERROR_BODY_CHARS {
+        format!(
+            "{status} (unparseable error body, truncated): {}",
+            truncate_chars(body, MAX_ERROR_BODY_CHARS)
+        )
     } else {
-        format!("{status} (unparseable error body): {truncated}")
+        format!("{status} (unparseable error body): {body}")
     }
 }
 
@@ -130,6 +222,67 @@ mod tests {
             r#"{"error":"invalid_grant"}"#,
         );
         assert!(msg.contains("invalid_grant"));
+    }
+
+    #[test]
+    fn caps_long_error_description() {
+        let long_desc = "e".repeat(500);
+        let body = format!(r#"{{"error":"invalid_request","error_description":"{long_desc}"}}"#);
+        let msg = sanitize_oauth_error(reqwest::StatusCode::BAD_REQUEST, &body);
+        assert!(msg.contains("invalid_request"));
+        assert!(
+            msg.chars().count() < long_desc.len(),
+            "error_description must be bounded, got {} chars",
+            msg.chars().count()
+        );
+        assert!(
+            msg.contains("..."),
+            "truncated description must be marked: {msg}"
+        );
+    }
+
+    #[test]
+    fn redacts_token_values_in_json_body() {
+        // A synthetic 2xx token body that fails typed parsing (expires_in is a
+        // string, not a number) yet carries live-looking credentials.
+        let body = r#"{"access_token":"ya29.SUPER_SECRET_ACCESS","refresh_token":"1//SUPER_SECRET_REFRESH","id_token":"eyJ.SECRET_ID","token_type":"Bearer","expires_in":"not-a-number"}"#;
+        let redacted = redact_token_response(body);
+        assert!(
+            !redacted.contains("SUPER_SECRET_ACCESS"),
+            "access_token value must not survive: {redacted}"
+        );
+        assert!(
+            !redacted.contains("SUPER_SECRET_REFRESH"),
+            "refresh_token value must not survive: {redacted}"
+        );
+        assert!(
+            !redacted.contains("SECRET_ID"),
+            "id_token value must not survive: {redacted}"
+        );
+        assert!(
+            redacted.contains("<redacted>"),
+            "credential values must be replaced with a redaction marker: {redacted}"
+        );
+        // Non-sensitive structure is retained for diagnostics.
+        assert!(
+            redacted.contains("expires_in"),
+            "shape retained: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redacts_non_json_token_body() {
+        // A non-JSON body could itself be a raw token; never echo its content.
+        let body = "ya29.RAW_TOKEN_STRING_NOT_JSON";
+        let redacted = redact_token_response(body);
+        assert!(
+            !redacted.contains("RAW_TOKEN_STRING_NOT_JSON"),
+            "non-JSON body content must not survive: {redacted}"
+        );
+        assert!(
+            redacted.contains("bytes"),
+            "reports only length: {redacted}"
+        );
     }
 
     #[test]

--- a/crates/trusty-gworkspace/src/api/auth/oauth/flow/mod.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/flow/mod.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use tracing::{info, warn};
 
 use super::callback;
-use super::errors::sanitize_oauth_error;
+use super::errors::{redact_token_response, sanitize_oauth_error};
 use super::pkce::{self, Pkce};
 use crate::api::auth::models::{OAuthToken, StoredToken, TokenMetadata};
 use crate::api::auth::storage::TokenStorage;
@@ -404,7 +404,11 @@ async fn exchange_code(
             sanitize_oauth_error(status, &body)
         ));
     }
-    serde_json::from_str(&body).with_context(|| format!("parse token response: {body}"))
+    // NB: `body` here is a 2xx token response containing access/refresh tokens;
+    // on the (practically unreachable) parse failure it must be redacted, never
+    // embedded verbatim, before entering the error chain.
+    serde_json::from_str(&body)
+        .with_context(|| format!("parse token response: {}", redact_token_response(&body)))
 }
 
 /// Resolve the account email: `id_token` claim first, then userinfo endpoint.

--- a/crates/trusty-gworkspace/src/cli/doctor.rs
+++ b/crates/trusty-gworkspace/src/cli/doctor.rs
@@ -74,14 +74,26 @@ pub async fn run(storage: &TokenStorage) -> Result<()> {
     println!("Per-profile refresh-token health:");
     match &creds {
         Some(creds) => {
-            let http = reqwest::Client::builder()
-                .timeout(PROBE_TIMEOUT)
-                .build()
-                .unwrap_or_default();
-            for (name, email, _is_default) in &accounts {
-                let result = probe_profile(&http, storage, creds, name).await;
-                for line in health_lines(name, email.as_deref(), &result) {
-                    println!("{line}");
+            // Never fall back to `Client::default()` on builder failure: that
+            // client has no request timeout, so a hung endpoint would stall
+            // doctor indefinitely. If the bounded client can't be built, report
+            // every profile as Unknown rather than probe without a timeout.
+            match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
+                Ok(http) => {
+                    for (name, email, _is_default) in &accounts {
+                        let result = probe_profile(&http, storage, creds, name).await;
+                        for line in health_lines(name, email.as_deref(), &result) {
+                            println!("{line}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("      Could not build a bounded HTTP client: {e}");
+                    for (name, email, _is_default) in &accounts {
+                        for line in health_lines(name, email.as_deref(), &ProbeResult::Unknown) {
+                            println!("{line}");
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Route the success-path token-response parse error (`manager.rs:110`, `flow/mod.rs:407`) through a new `redact_token_response` helper instead of embedding the raw 2xx body verbatim — a token/secret-named JSON key is replaced with `<redacted>`; a non-JSON body is reported only by byte length. Practically unreachable today (a 2xx token body always parses), but closes the last token-adjacent error surface.
- `doctor.rs`: never fall back to an unbounded `Client::default()` when the timeout-bounded client builder fails — report every profile `Unknown` and log the error instead.
- `sanitize_oauth_error`: cap `error_description` at `MAX_ERROR_BODY_CHARS` (200) so a well-formed but arbitrarily long description can't balloon a log line.

## Test plan
- [x] `cargo build -p trusty-gworkspace`
- [x] `cargo test -p trusty-gworkspace` — 220 passed, 0 failed (incl. new `redacts_token_values_in_json_body`, `redacts_non_json_token_body`, `caps_long_error_description`)
- [x] `cargo clippy -p trusty-gworkspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling pointers

Closes #2751

🤖 Generated with [Claude Code](https://claude.com/claude-code)