### PR TITLE
docs(trusty-mpm): fix stale session_launch test comments

### DIFF
--- a/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
@@ -946,9 +946,11 @@ fn inject_native_resolves_managed_registry_from_real_home() {
     // `<workspace>/.trusty-tools/trusty-mpm/claude-config/.claude.json` (never
     // present in a fresh clone) and silently injected nothing — invisible in CI
     // because the older tests only drove the hermetic `_from` core against a
-    // tempdir. This test drives the ACTUAL `for_managed_workspace` construction
-    // + real-home resolution end-to-end: it FAILS against the old (fw-relative)
-    // code and PASSES after the fix.
+    // tempdir. This test builds `fw` via `for_managed_workspace` only to assert
+    // (as a precondition below) that the fw-relative path the OLD code read is
+    // empty, then drives the real-`$HOME` resolution the PRODUCTION injector
+    // actually uses: it FAILS against the old (fw-relative) code and PASSES
+    // after the fix.
     let home = tempdir().unwrap();
     let ws_root = tempdir().unwrap();
     // A realistic managed workspace path: <root>/<owner>/<repo>/<session-id>.

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -1418,9 +1418,11 @@ fn prepare_session_preseeds_enabled_mcp_servers() {
 
     prepare_session(&fw, project).expect("prep succeeds");
 
-    // prepare_session seeds the operator's real ~/.claude.json via
-    // preseed_workspace_trust_home, so re-derive the per-workspace approval list
-    // by reading .mcp.json directly and asserting both injected servers landed.
+    // prepare_session seeds `tmp_home/.claude.json` (the temp home, via the
+    // `$HOME` override above) via preseed_workspace_trust_home — NOT the
+    // operator's real `~/.claude.json` — so re-derive the per-workspace
+    // approval list by reading .mcp.json directly and asserting both injected
+    // servers landed.
     let mcp: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(project.join(".mcp.json")).unwrap()).unwrap();
     let servers = mcp["mcpServers"].as_object().expect("mcpServers object");


### PR DESCRIPTION
## Summary
- Fixes 2 LOW doc-comment nits flagged in the #2756/#2761 review, follow-up to that review. Docs-only, zero behavior change.
- `crates/trusty-mpm/src/core/session_launch/tests.rs`: `prepare_session_preseeds_enabled_mcp_servers` comment claimed prepare_session seeds the operator's real `~/.claude.json` — false, since the test overrides `$HOME` to a tempdir. Reworded to say it seeds `tmp_home/.claude.json`.
- `crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs`: `inject_native_resolves_managed_registry_from_real_home` comment overstated that the test drives `for_managed_workspace` construction end-to-end for resolution — in fact `fw` is only used for the precondition assert; the production `inject_native_trusty_mcps` no longer takes `fw` and resolves purely from real `$HOME`. Reworded to describe that accurately.

## Test plan
- [x] `cargo build -p trusty-mpm`
- [x] `cargo test -p trusty-mpm` (confirmed both affected tests still pass: `prepare_session_preseeds_enabled_mcp_servers`, `inject_native_resolves_managed_registry_from_real_home`; full suite 3184 passed / 0 failed)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)