### PR TITLE
fix(trusty-mpm): relaunch decommissioned managed session on bare tm instead of reconnect-to-self

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- bare `tm` inside a decommissioned managed tmux session now relaunches in place instead of reconnecting to itself (closes #2777) ([#2780](https://github.com/bobmatnyc/trusty-tools/pull/2780))
 - resolve managed MCP registry from real home in fleet-session injector ([#2761](https://github.com/bobmatnyc/trusty-tools/pull/2761)) ([`7c04f1f`](https://github.com/bobmatnyc/trusty-tools/commit/7c04f1f845432edd6b1fb488103a1aba9939fb3c))
 - never traverse $HOME/TCC-protected folders (closes #2759) ([#2760](https://github.com/bobmatnyc/trusty-tools/pull/2760)) ([`74fe7f3`](https://github.com/bobmatnyc/trusty-tools/commit/74fe7f3c682cb5b0c648b63585c44ee47aa6d652))
 - positive stdio field allowlist for fleet native-MCP injection ([#2739](https://github.com/bobmatnyc/trusty-tools/pull/2739)) ([#2755](https://github.com/bobmatnyc/trusty-tools/pull/2755)) ([`e3a5c68`](https://github.com/bobmatnyc/trusty-tools/commit/e3a5c684cc25028202f6ece1a262f515fa3b43da))

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -149,21 +149,63 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
             }
         }
 
-        // Session-name-only match: the operator is in a DIFFERENT pane/window of
-        // the SAME tmux session (not the record's own pane), so a switch-client
-        // reconnect to the managed session is legitimate — not a self no-op.
-        // Preserve the pre-existing refuse+reconnect behavior for that case.
-        // Terminal entry point (not a loop) — the `AttachOutcome` only matters to
-        // a looping caller like `run_tty_picker` (#2678); here, the hand-off (or
-        // fail-closed skip) is this call's whole job, so discard it.
-        eprintln!(
-            "tm: this tmux session ('{}') is already a managed session (state={}) — {}",
-            record.name,
-            record.state,
-            nested_guard_notice(&record.name)
-        );
-        super::guided_resume::resume_guided_session(client, url, &record).await?;
-        return Ok(());
+        // Session-name-only match: the operator is in the SAME tmux session but
+        // NOT (provably) the record's own pane. #2777: split on liveness.
+        match nested_fallback_action(&record.state) {
+            // Dead session (decommissioned/stopped/errored): a switch-client
+            // reconnect to the session the operator is already inside is a
+            // guaranteed no-op dead-end (the reported bug). Relaunch the agent in
+            // THIS pane via the same daemon-authorized primitive the
+            // pane-confirmed branch above uses. Safe WITHOUT pane-identity
+            // confirmation precisely because a dead session has no live runtime
+            // anywhere to hijack (the whole point of that gate) — and the
+            // daemon's `reactivate` round-trip remains the sole authority: a
+            // refusal folds into `FallThrough` → an honest self-relaunch hint,
+            // never an unconditional exec.
+            NestedFallbackAction::RelaunchInPlace => {
+                let current_pane_id = super::tmux_attach::current_tmux_pane_id();
+                match super::guided_inplace::run_inplace_relaunch(
+                    client,
+                    url,
+                    &record.id,
+                    record.clone(),
+                    current_pane_id.as_deref(),
+                )
+                .await
+                {
+                    super::guided_inplace::InPlaceOutcome::Result(Ok(())) => return Ok(()),
+                    super::guided_inplace::InPlaceOutcome::Result(Err(e)) => {
+                        eprintln!("tm: in-place relaunch failed ({e})");
+                        eprintln!("{}", inplace_self_relaunch_hint(&record));
+                        return Ok(());
+                    }
+                    super::guided_inplace::InPlaceOutcome::FallThrough => {
+                        eprintln!(
+                            "tm: in-place relaunch unavailable for '{}' (state={})",
+                            record.name, record.state
+                        );
+                        eprintln!("{}", inplace_self_relaunch_hint(&record));
+                        return Ok(());
+                    }
+                }
+            }
+            // Live session: a sibling window may hold the live runtime, so a
+            // switch-client reconnect legitimately brings it forward — not a self
+            // no-op. Preserve the pre-existing refuse+reconnect behavior.
+            // Terminal entry point (not a loop) — the `AttachOutcome` only matters
+            // to a looping caller like `run_tty_picker` (#2678); here, the
+            // hand-off (or fail-closed skip) is this call's whole job, so discard it.
+            NestedFallbackAction::Reconnect => {
+                eprintln!(
+                    "tm: this tmux session ('{}') is already a managed session (state={}) — {}",
+                    record.name,
+                    record.state,
+                    nested_guard_notice(&record.name)
+                );
+                super::guided_resume::resume_guided_session(client, url, &record).await?;
+                return Ok(());
+            }
+        }
     }
 
     let cwd = std::env::current_dir().context("cannot resolve current directory")?;
@@ -415,6 +457,50 @@ pub(crate) fn pane_identity_confirmed(
     match (current_pane_id, record_pane_id) {
         (Some(cur), Some(rec)) => cur == rec,
         _ => false,
+    }
+}
+
+/// The action the nested-session guard takes when it matched a record by tmux
+/// SESSION name but could NOT confirm pane-level identity
+/// ([`pane_identity_confirmed`] was `false`).
+///
+/// Why: the pre-#2777 fallback ALWAYS reconnected (switch-client) to the matched
+/// session. That is correct when the session has a live runtime in a sibling
+/// window — the switch brings it forward. But when the session is DEAD
+/// (decommissioned/stopped/errored), there is no live runtime anywhere in that
+/// tmux session, so a switch-client to the session the operator is already
+/// inside is a guaranteed no-op dead-end (the reported bug: bare `tm` inside a
+/// `decommissioned` `tm-apex-01` printed "switching client to session
+/// 'tm-apex-01'" and stranded the operator in the bare shell). Splitting the two
+/// cases lets the dead case relaunch the agent in place instead.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum NestedFallbackAction {
+    /// The matched session has no live runtime — relaunch the agent in the
+    /// current pane (a reconnect would be a self no-op).
+    RelaunchInPlace,
+    /// The matched session may have a live runtime in a sibling window —
+    /// switch-client reconnect brings it forward.
+    Reconnect,
+}
+
+/// Pure decision for the nested-guard fallback: relaunch-in-place vs reconnect,
+/// derived solely from the matched record's `state`.
+///
+/// Why: isolating the classification from the daemon/tmux I/O makes the
+/// dead-vs-live decision exhaustively unit-testable (#2777), mirroring the
+/// `switch_decision`-style pure seam pattern (#2680).
+/// What: dead/tombstone states with no live runtime
+/// (`decommissioned`/`stopped`/`errored`) →
+/// [`NestedFallbackAction::RelaunchInPlace`]; every other state
+/// (`active`/`provisioning`/`running`/unknown) → the safe default
+/// [`NestedFallbackAction::Reconnect`], preserving the pre-#2777 behavior for a
+/// possibly-live sibling window.
+/// Test: `nested_fallback_action_relaunches_dead_states`,
+/// `nested_fallback_action_reconnects_live_states` in `tests_behavior_c_tests.rs`.
+pub(crate) fn nested_fallback_action(state: &str) -> NestedFallbackAction {
+    match state {
+        "decommissioned" | "stopped" | "errored" => NestedFallbackAction::RelaunchInPlace,
+        _ => NestedFallbackAction::Reconnect,
     }
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -394,24 +394,52 @@ async fn nested_session_guard(
 /// Why: isolating the match rule from the daemon round-trip and the tmux
 /// shell-out makes the actual guard DECISION exhaustively unit-testable
 /// without a live daemon or tmux server.
-/// What: returns the first record whose `name` (tmux session name) equals
-/// `current_session_name`, OR whose `id` equals `env_session_id` — either
-/// match is sufficient (the env id is belt-and-suspenders for the rare case
-/// where the session was renamed after spawn). `None` when both inputs are
-/// `None`/non-matching, which includes the "not inside tmux" case (callers
-/// pass `current_session_name: None` then).
+///
+/// #2790 code-critic HIGH: tmux SESSION NAMES ARE RECYCLED after a session is
+/// decommissioned (`session_manager::manager`'s name-reuse policy) — a plain
+/// `.find()` over ALL candidates (including tombstones) can therefore return a
+/// STALE `Decommissioned` record for a name that a genuinely LIVE session now
+/// also owns, which would drive `RelaunchInPlace` against the wrong (dead)
+/// record while a live session sharing that name sits in a sibling pane — the
+/// exact hijack class #2456/#2680 fixed elsewhere.
+/// [`SessionManager::capture_pane_by_tmux_name`] (`session_manager/manager.rs`)
+/// already carries the identical guard for the same reason (idle-reaper pane
+/// capture) — this mirrors it.
+/// What: collects every record matching `current_session_name` OR
+/// `env_session_id`, then prefers the most-recently-created (`created_at`,
+/// RFC3339 — lexicographically sortable) NON-`Decommissioned` match. Only when
+/// NO candidate is non-`Decommissioned` does it fall back to the
+/// most-recently-created `Decommissioned` candidate — the legitimate #2777
+/// repro case (a decommissioned session's OWN, not-yet-recycled name). `None`
+/// when both inputs are `None`/non-matching, which includes the "not inside
+/// tmux" case (callers pass `current_session_name: None` then).
 /// Test: `nested_managed_match_by_session_name`,
 /// `nested_managed_match_by_env_id`, `nested_managed_match_none_when_no_match`,
-/// `nested_managed_match_none_when_both_inputs_absent`.
+/// `nested_managed_match_none_when_both_inputs_absent`,
+/// `nested_managed_match_prefers_live_over_recycled_decommissioned_name`,
+/// `nested_managed_match_falls_back_to_decommissioned_when_no_live_candidate`,
+/// `nested_managed_match_prefers_most_recent_live_among_multiple`.
 pub(crate) fn nested_managed_match<'a>(
     current_session_name: Option<&str>,
     env_session_id: Option<&str>,
     records: &'a [trusty_mpm::client::ManagedSessionSummary],
 ) -> Option<&'a trusty_mpm::client::ManagedSessionSummary> {
-    records.iter().find(|r| {
+    let is_candidate = move |r: &&trusty_mpm::client::ManagedSessionSummary| {
         current_session_name.is_some_and(|n| n == r.name)
             || env_session_id.is_some_and(|id| id == r.id)
-    })
+    };
+
+    records
+        .iter()
+        .filter(is_candidate)
+        .filter(|r| r.state != "decommissioned")
+        .max_by_key(|r| r.created_at.clone().unwrap_or_default())
+        .or_else(|| {
+            records
+                .iter()
+                .filter(is_candidate)
+                .max_by_key(|r| r.created_at.clone().unwrap_or_default())
+        })
 }
 
 /// Pure predicate (#2456 review finding 1, ROUND 2 — the round-1 env-var

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -425,18 +425,30 @@ pub(crate) enum InPlaceOutcome {
 /// (cwd/binary resolution) or post-reactivate (`exec` itself failing) alike
 /// — as a fall-back-to-reconnect condition, matching that call site's
 /// pre-#2453 behavior of never hard-failing.
-/// What, IN ORDER (#2027 exec-ordering fix): (1) prints a one-line notice;
-/// (2) resolves the workdir and builds the resume argv via
+/// What, IN ORDER (#2027 exec-ordering fix, extended by #2790): (1) prints a
+/// one-line notice; (2) resolves the workdir; (2a) #2790 CRITICAL:
+/// verifies the resolved workdir EXISTS ON DISK — a Decommissioned record's
+/// workspace may have been removed by `decommission()` while the record's
+/// `workspace_path`/`cwd` still names it; a missing directory returns
+/// [`InPlaceOutcome::FallThrough`] here, BEFORE any daemon call, so a
+/// known-gone workspace can never be masked by a durably-committed `Active`
+/// record; (3) builds the resume argv via
 /// [`trusty_mpm::runtime::build_inplace_resume_command`] (the SAME
 /// `--resume`-existence-check → `--continue`/fresh-spawn fallback logic the
 /// tmux-pane resume path uses, #2013) — this is PURE/local (resolving the
 /// `claude` binary can fail with `BinaryNotFound`) and runs BEFORE any daemon
 /// mutation, so a missing binary never flips the record to a false `Active`;
-/// (3) reactivates the record on the daemon (step 3 of #2023 C — see
+/// (4) reactivates the record on the daemon (step 3 of #2023 C — see
 /// [`reactivate_managed_session`]), immediately before exec — on a
 /// refused/failed reactivate this returns [`InPlaceOutcome::FallThrough`]
-/// rather than proceeding; (4) execs `claude` in place.
+/// rather than proceeding; (5) execs `claude` in place.
 /// Test: I/O path; not unit-tested (requires a live daemon + real `claude`).
+/// The workdir-existence gate (2a) is exercised via `run_inplace_relaunch`'s
+/// I/O surface only (needs the daemon + tmux + `claude`); the FSM invariant it
+/// protects is separately proven at the daemon layer (defense-in-depth, so the
+/// guard holds even for a future caller that skips this CLI-side check) by
+/// `mark_reactivated_refuses_when_workspace_removed_by_decommission` in
+/// `session_manager::reactivate_tests`.
 pub(crate) async fn run_inplace_relaunch(
     client: &reqwest::Client,
     url: &str,
@@ -456,6 +468,26 @@ pub(crate) async fn run_inplace_relaunch(
         Ok(cwd) => cwd,
         Err(e) => return InPlaceOutcome::Result(Err(e)),
     };
+
+    // #2790 code-critic CRITICAL: a Decommissioned record's workspace may have
+    // been deleted from disk by `decommission()` (the FSM invariant in
+    // `session_manager::record` — only Decommissioned means the workspace is
+    // gone) while `workspace_path`/`cwd` on the record still names the
+    // now-removed path. Confirm the resolved directory ACTUALLY EXISTS before
+    // any daemon mutation: reactivating (which durably flips the record to
+    // `Active`) then discovering the `cd`/exec target is gone would commit a
+    // ghost `Active` record that can never be attached to again. Folding a
+    // missing workspace into `FallThrough` here — zero daemon calls made —
+    // keeps the invariant intact and routes the operator to the same honest
+    // self-relaunch hint a refused reactivate would.
+    if !cwd.is_dir() {
+        eprintln!(
+            "tm: workspace for session {id} no longer exists on disk ({}) — cannot relaunch in \
+             place",
+            cwd.display()
+        );
+        return InPlaceOutcome::FallThrough;
+    }
 
     let resume = match trusty_mpm::runtime::build_inplace_resume_command(
         &cwd,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -1738,6 +1738,75 @@ fn nested_managed_match_finds_record_missing_from_source_id_filtered_list() {
     );
 }
 
+/// Build a [`make_session`] summary with an explicit `created_at` (RFC3339),
+/// for tests that need to control recency ordering.
+fn make_session_at(
+    name: &str,
+    state: &str,
+    created_at: &str,
+) -> trusty_mpm::client::ManagedSessionSummary {
+    let mut s = make_session(name, state, None);
+    s.created_at = Some(created_at.to_string());
+    s
+}
+
+#[test]
+fn nested_managed_match_prefers_live_over_recycled_decommissioned_name() {
+    // #2790 code-critic HIGH: tmux session names are RECYCLED after
+    // decommission. A stale Decommissioned tombstone sharing a name with a
+    // genuinely LIVE session must never win the match — liveness takes STRICT
+    // precedence over recency (not just "usually more recent"). Proven here by
+    // giving the tombstone a LATER created_at than the live record — an
+    // adversarial ordering the pre-#2790 plain `.find()` would have been
+    // vulnerable to depending on iteration/list order.
+    let mut decommissioned =
+        make_session_at("tm-proj-01", "decommissioned", "2026-03-01T00:00:00Z");
+    decommissioned.id = "old-id".to_string();
+    let mut live = make_session_at("tm-proj-01", "active", "2026-01-01T00:00:00Z");
+    live.id = "new-id".to_string();
+    let sessions = vec![decommissioned, live];
+
+    let matched = nested_managed_match(Some("tm-proj-01"), None, &sessions);
+    assert_eq!(
+        matched.map(|s| s.id.as_str()),
+        Some("new-id"),
+        "a live record must win over a decommissioned one sharing the same \
+         recycled name, even when the tombstone's created_at is later"
+    );
+}
+
+#[test]
+fn nested_managed_match_falls_back_to_decommissioned_when_no_live_candidate() {
+    // The legitimate #2777 repro: the ONLY record sharing this tmux session
+    // name IS the decommissioned session itself (its name has not yet been
+    // recycled by a new session) — the guard must still match it so the
+    // in-place revive path can run.
+    let sessions = vec![make_session("tm-apex-01", "decommissioned", None)];
+    let matched = nested_managed_match(Some("tm-apex-01"), None, &sessions);
+    assert_eq!(
+        matched.map(|s| s.name.as_str()),
+        Some("tm-apex-01"),
+        "must fall back to the decommissioned record when no live candidate \
+         shares its name"
+    );
+}
+
+#[test]
+fn nested_managed_match_prefers_most_recent_live_among_multiple() {
+    // Belt-and-suspenders: when MULTIPLE non-decommissioned candidates somehow
+    // share a name (should not normally happen, but the guard must still be
+    // deterministic), the most recently created one wins — mirroring
+    // `capture_pane_by_tmux_name`'s `max_by_key(created_at)` convention.
+    let mut older = make_session_at("tm-proj-02", "active", "2026-01-01T00:00:00Z");
+    older.id = "older-id".to_string();
+    let mut newer = make_session_at("tm-proj-02", "active", "2026-02-01T00:00:00Z");
+    newer.id = "newer-id".to_string();
+    let sessions = vec![older, newer];
+
+    let matched = nested_managed_match(Some("tm-proj-02"), None, &sessions);
+    assert_eq!(matched.map(|s| s.id.as_str()), Some("newer-id"));
+}
+
 // ── pane_identity_confirmed (#2456 review finding 1, ROUND 2) ────────────────
 // The cross-pane-hijack guard: `nested_managed_match` alone only proves the
 // tmux SESSION matches (every window/pane in that session shares the same

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -26,10 +26,11 @@ use crate::commands::first_run::needs_first_run_clone;
 /// racing `needs_first_run_clone_returns_some_when_no_clone`.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
-    CwdProject, classify_cwd_project, cwd_owns_git_entry, derive_project, fallback_protected,
-    github_host, inplace_self_relaunch_hint, is_github_remote, ls_tree_reports_tracked_dir,
-    nested_guard_notice, nested_managed_match, non_github_refusal_message, pane_identity_confirmed,
-    print_non_tty_hint, print_project_context, tty_gate, untracked_ancestor_message,
+    CwdProject, NestedFallbackAction, classify_cwd_project, cwd_owns_git_entry, derive_project,
+    fallback_protected, github_host, inplace_self_relaunch_hint, is_github_remote,
+    ls_tree_reports_tracked_dir, nested_fallback_action, nested_guard_notice, nested_managed_match,
+    non_github_refusal_message, pane_identity_confirmed, print_non_tty_hint, print_project_context,
+    tty_gate, untracked_ancestor_message,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{ResumeAction, is_zombie, needs_restart, plan_resume};
@@ -1801,6 +1802,43 @@ fn pane_identity_confirmed_false_when_inherited_env_but_different_pane_id() {
         sibling_window_current_pane_id,
         healed_record_pane_id
     ));
+}
+
+// ── nested_fallback_action (#2777 decommissioned-relaunch dead-end fix) ──────
+// When the nested-session guard matched by tmux SESSION name but could NOT
+// confirm pane identity, the pre-#2777 fallback ALWAYS reconnected
+// (switch-client) — a no-op dead-end when the session is DEAD (the operator is
+// already inside the session being "reconnected" to, and nothing live is there).
+// `nested_fallback_action` splits dead states (relaunch in place) from
+// possibly-live states (reconnect a sibling window).
+
+#[test]
+fn nested_fallback_action_relaunches_dead_states() {
+    // The reported bug: bare `tm` inside a `decommissioned` session must NOT
+    // switch-client to itself. Stopped/errored share the "no live runtime" trait
+    // and must relaunch in place too rather than take the destructive daemon
+    // /resume path a plain reconnect would reach.
+    for state in ["decommissioned", "stopped", "errored"] {
+        assert_eq!(
+            nested_fallback_action(state),
+            NestedFallbackAction::RelaunchInPlace,
+            "dead state {state:?} must relaunch in place, not switch-client to self"
+        );
+    }
+}
+
+#[test]
+fn nested_fallback_action_reconnects_live_states() {
+    // A possibly-live session (its runtime may be in a genuinely different
+    // sibling window of the same tmux session) must keep the switch-client
+    // reconnect — that is NOT a self no-op, it brings the live pane forward.
+    for state in ["active", "provisioning", "running", "some-future-state"] {
+        assert_eq!(
+            nested_fallback_action(state),
+            NestedFallbackAction::Reconnect,
+            "possibly-live state {state:?} must reconnect (default), not relaunch"
+        );
+    }
 }
 
 // ── nested_guard_notice (sibling-window hijack fix, follow-up to #2456) ─────

--- a/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
@@ -65,7 +65,10 @@ pub struct ReactivateQuery {
 /// pane. This route gives that path a dedicated, non-destructive transition —
 /// [`crate::session_manager::SessionManager::mark_reactivated`] only flips the
 /// record's state.
-/// What: 404 when the id is unknown; on a non-`Stopped` record, tries
+/// What: 404 when the id is unknown; `mark_reactivated` accepts `Stopped` or
+/// `Decommissioned` (#2777 — reviving a decommissioned session's lingering pane
+/// in place, see `mark_reactivated`'s doc); on any OTHER non-reactivatable
+/// state, tries
 /// [`reconcile_stale_active_then_reactivate`] (#2453) before giving up — this
 /// closes the up-to-60s window where a pane's `claude` process has already
 /// exited but the periodic reap tick (or a racing `SessionEnd` hook) has not

--- a/crates/trusty-mpm/src/session_manager/reactivate.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate.rs
@@ -5,11 +5,12 @@
 //! `adopt.rs` (sibling `impl SessionManager` blocks), this file isolates the
 //! one write-path the bare-`tm` in-pane relaunch needs.
 //! What: one inherent method, `SessionManager::mark_reactivated` — flips a
-//! `Stopped` record back to `Active` with no `create_session`/`kill_session`
-//! call, unlike [`SessionManager::resume`] (which always recreates the tmux
-//! session).
+//! `Stopped` OR `Decommissioned` (#2777) record back to `Active` with no
+//! `create_session`/`kill_session` call, unlike [`SessionManager::resume`]
+//! (which always recreates the tmux session).
 //! Test: `mark_reactivated_flips_stopped_to_active`,
-//! `mark_reactivated_rejects_non_stopped` in `super::tests`.
+//! `mark_reactivated_flips_decommissioned_to_active`,
+//! `mark_reactivated_rejects_non_stopped` in `super::reactivate_tests`.
 
 use chrono::Utc;
 use tracing::info;
@@ -31,23 +32,39 @@ impl SessionManager {
     /// is about to relaunch into it. This method gives the in-pane path its own
     /// non-destructive transition: flip the record back to `Active` and nothing
     /// else — no `create_session`, no `kill_session`, no pane snapshot.
-    /// What: requires the record be `Stopped` (any other state is an
-    /// [`ManagedError::InvalidState`] — in particular, an `Active` record must
-    /// not be silently re-marked Active by a stray call); sets
+    /// What: requires the record be `Stopped` OR `Decommissioned` (any other
+    /// state is an [`ManagedError::InvalidState`] — in particular, an `Active`
+    /// record must not be silently re-marked Active by a stray call); sets
     /// `state = Active` and refreshes `last_activity_at`, then persists.
+    ///
+    /// `Decommissioned` is accepted (issue #2777) for the bare-`tm`-inside-a-
+    /// decommissioned-session case: after a session is decommissioned, its tmux
+    /// pane can linger as a bare shell printing "run `tm` to relaunch this
+    /// session". When the operator does exactly that from INSIDE that pane, a
+    /// switch-client reconnect to the session they are already in is a no-op
+    /// dead-end. Reviving the tombstone IN PLACE — with no tmux mutation, so the
+    /// operator's current pane survives to `exec` `claude` into it — is the only
+    /// non-destructive way to honor that on-screen instruction. The revive is an
+    /// explicit, in-pane operator action, never automatic; if decommission had
+    /// removed the workspace, the subsequent in-place `exec`'s `cd` fails and the
+    /// caller falls back to an actionable hint (`bin/tm`'s `guided_inplace`).
     /// Test: `mark_reactivated_flips_stopped_to_active`,
+    /// `mark_reactivated_flips_decommissioned_to_active`,
     /// `mark_reactivated_rejects_non_stopped`.
     pub async fn mark_reactivated(
         &self,
         id: &ManagedSessionId,
     ) -> Result<SessionRecord, ManagedError> {
         let mut record = self.get(id).await?;
-        if record.state != ManagedSessionState::Stopped {
+        if !matches!(
+            record.state,
+            ManagedSessionState::Stopped | ManagedSessionState::Decommissioned
+        ) {
             return Err(ManagedError::InvalidState(
                 id.to_string(),
                 format!(
-                    "cannot reactivate a session in state '{}'; only Stopped sessions can be \
-                     reactivated in place",
+                    "cannot reactivate a session in state '{}'; only Stopped or Decommissioned \
+                     sessions can be reactivated in place",
                     record.state
                 ),
             ));

--- a/crates/trusty-mpm/src/session_manager/reactivate.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate.rs
@@ -46,11 +46,27 @@ impl SessionManager {
     /// operator's current pane survives to `exec` `claude` into it — is the only
     /// non-destructive way to honor that on-screen instruction. The revive is an
     /// explicit, in-pane operator action, never automatic; if decommission had
-    /// removed the workspace, the subsequent in-place `exec`'s `cd` fails and the
-    /// caller falls back to an actionable hint (`bin/tm`'s `guided_inplace`).
+    /// removed the workspace, the resolved directory fails the on-disk
+    /// existence guard below and the state is never flipped — the caller falls
+    /// back to an actionable hint (`bin/tm`'s `guided_inplace`).
+    ///
+    /// Defense-in-depth (#2790 code-critic CRITICAL/MEDIUM): `decommission()`
+    /// unconditionally clears `workspace_path` to `None` on tombstone — even
+    /// for the unowned/#1840 skip-deletion case where the directory was NEVER
+    /// actually removed — so `workspace_path` alone cannot distinguish
+    /// "physically gone" from "never tracked separately". The field that is
+    /// NEVER cleared, and the one the in-place relaunch actually resumes into
+    /// (`workspace_path.or(cwd)` in `bin/tm`'s
+    /// `guided_inplace::run_inplace_relaunch`), is the original spawn `cwd`.
+    /// This method independently refuses the state flip — the daemon-side
+    /// authority, regardless of what any CLI-side pre-check does or omits —
+    /// when that resolved directory no longer exists on disk, so a corrupted
+    /// `Active` ghost record (workspace gone, state says running) can never be
+    /// committed to the store.
     /// Test: `mark_reactivated_flips_stopped_to_active`,
     /// `mark_reactivated_flips_decommissioned_to_active`,
-    /// `mark_reactivated_rejects_non_stopped`.
+    /// `mark_reactivated_rejects_non_stopped`,
+    /// `mark_reactivated_refuses_when_workspace_removed_by_decommission`.
     pub async fn mark_reactivated(
         &self,
         id: &ManagedSessionId,
@@ -69,6 +85,21 @@ impl SessionManager {
                 ),
             ));
         }
+
+        let resume_dir = record
+            .workspace_path
+            .as_deref()
+            .unwrap_or(record.cwd.as_path());
+        if !resume_dir.is_dir() {
+            return Err(ManagedError::InvalidState(
+                id.to_string(),
+                format!(
+                    "cannot reactivate session '{id}': workspace '{}' no longer exists on disk",
+                    resume_dir.display()
+                ),
+            ));
+        }
+
         record.state = ManagedSessionState::Active;
         record.last_activity_at = Some(Utc::now());
         self.store.write().await.upsert(record.clone()).await?;

--- a/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
@@ -71,8 +71,71 @@ async fn mark_reactivated_flips_stopped_to_active() {
     assert_eq!(after.state, ManagedSessionState::Active);
 }
 
-/// `mark_reactivated` must reject any state other than `Stopped` — in
-/// particular it must not silently re-mark an already-`Active` session.
+/// `mark_reactivated` must also flip a `Decommissioned` record back to `Active`
+/// IN PLACE, with no tmux mutation (#2777).
+///
+/// Why: after a session is decommissioned, its tmux pane can linger as a bare
+/// shell printing "run `tm` to relaunch this session". When the operator does
+/// exactly that from inside that pane, a switch-client reconnect to the session
+/// they are already in is a no-op dead-end. Reviving the tombstone in place —
+/// no `create_session`/`kill_session` — is the only non-destructive way to
+/// honor that on-screen instruction (the pane survives to `exec` `claude`).
+/// What: seeds a record, forces it `Decommissioned` via `set_workspace`, then
+/// asserts `mark_reactivated` flips it to `Active` and calls neither
+/// `create_session` nor `kill_session`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn mark_reactivated_flips_decommissioned_to_active() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_dir.path().to_owned()),
+            None,
+            Some(workspace_dir.path().to_owned()),
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+
+    mgr.set_workspace(
+        &record.id,
+        workspace_dir.path().to_owned(),
+        ManagedSessionState::Decommissioned,
+    )
+    .await
+    .expect("force Decommissioned");
+
+    let kill_calls_before = fake.kill_calls.lock().unwrap().len();
+    let create_calls_before = fake.create_cwd_calls.lock().unwrap().len();
+
+    let reactivated = mgr
+        .mark_reactivated(&record.id)
+        .await
+        .expect("reactivate decommissioned");
+    assert_eq!(
+        reactivated.state,
+        ManagedSessionState::Active,
+        "mark_reactivated must flip Decommissioned -> Active (#2777)"
+    );
+    assert_eq!(
+        fake.kill_calls.lock().unwrap().len(),
+        kill_calls_before,
+        "mark_reactivated must NEVER call kill_session"
+    );
+    assert_eq!(
+        fake.create_cwd_calls.lock().unwrap().len(),
+        create_calls_before,
+        "mark_reactivated must NEVER call create_session"
+    );
+}
+
+/// `mark_reactivated` must reject any state other than `Stopped`/`Decommissioned`
+/// — in particular it must not silently re-mark an already-`Active` session.
 ///
 /// Why: this guards against a stray/duplicate reactivate call (e.g. two
 /// bare-`tm` invocations racing in the same pane) silently succeeding twice.

--- a/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
@@ -3,15 +3,17 @@
 //! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; this
 //! in-place-reactivation coverage lives here (mirroring `restart_tests.rs`)
 //! so neither file grows past its limit.
-//! What: proves `mark_reactivated` flips `Stopped` -> `Active` WITHOUT ever
-//! calling `create_session`/`kill_session`, and rejects a non-`Stopped`
-//! record.
+//! What: proves `mark_reactivated` flips `Stopped`/`Decommissioned` (#2777) ->
+//! `Active` WITHOUT ever calling `create_session`/`kill_session`, rejects a
+//! non-reactivatable state, and (#2790) refuses the flip when the resolved
+//! workspace no longer exists on disk (the real `decommission()` teardown
+//! path, not just a harmless forced-state fixture).
 //! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
 
 use tempfile::TempDir;
 
 use super::manager::ManagedError;
-use super::record::ManagedSessionState;
+use super::record::{ManagedSessionId, ManagedSessionState};
 use super::tests::make_manager;
 
 /// `mark_reactivated` must flip a `Stopped` record back to `Active` WITHOUT
@@ -131,6 +133,87 @@ async fn mark_reactivated_flips_decommissioned_to_active() {
         fake.create_cwd_calls.lock().unwrap().len(),
         create_calls_before,
         "mark_reactivated must NEVER call create_session"
+    );
+}
+
+/// `mark_reactivated` must REFUSE to flip a `Decommissioned` record to
+/// `Active` when the workspace it would resume into no longer exists on disk
+/// (#2790 code-critic CRITICAL/MEDIUM) — proven through the REAL
+/// `decommission_with_root` teardown path, not the harmless
+/// `set_workspace`-forced fixture (which leaves `workspace_path` pointing at
+/// an existing tempdir).
+///
+/// Why: `decommission()` unconditionally clears `workspace_path` to `None` on
+/// tombstone, so `workspace_path` alone cannot tell the daemon whether the
+/// directory was actually removed. The guard in `mark_reactivated` falls back
+/// to the record's ORIGINAL spawn `cwd` — the same field the in-place-relaunch
+/// CLI path resumes into — and must refuse the state flip when THAT directory
+/// is gone, so a corrupted `Active` ghost record (workspace gone, state says
+/// running) can never be committed to the store, regardless of caller.
+/// What: creates an OWNED session whose `cwd`/`workspace_path` live inside a
+/// managed root, decommissions it for REAL (the workspace is actually removed
+/// from disk), then asserts `mark_reactivated` returns `InvalidState` and that
+/// the persisted record is STILL `Decommissioned` (no state flip occurred).
+/// Test: this function IS the test.
+#[tokio::test]
+async fn mark_reactivated_refuses_when_workspace_removed_by_decommission() {
+    let dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    // Workspace INSIDE a temp "managed root" so decommission's path-containment
+    // guard (`is_safe_to_remove`) passes and the directory is actually deleted —
+    // mirrors `manager_decommission_removes_workspace`'s setup.
+    let managed_root = TempDir::new().unwrap();
+    let workspace_path = managed_root.path().join("owner").join("repo").join("sess");
+    std::fs::create_dir_all(&workspace_path).unwrap();
+
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "task".into(),
+            Some(workspace_path.clone()),
+            None,
+            Some(workspace_path.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            true, // owned: SM provisioned, so decommission actually removes it
+        )
+        .await
+        .expect("create");
+
+    let (tombstone, workspace_removed) = mgr
+        .decommission_with_root(&record.id, managed_root.path())
+        .await
+        .expect("decommission");
+    assert!(
+        workspace_removed,
+        "precondition: the workspace must actually be removed from disk"
+    );
+    assert_eq!(tombstone.state, ManagedSessionState::Decommissioned);
+    assert!(
+        !workspace_path.exists(),
+        "precondition: workspace directory must be gone from disk"
+    );
+
+    let err = mgr
+        .mark_reactivated(&record.id)
+        .await
+        .expect_err("reactivating a session whose workspace is gone must fail");
+    assert!(
+        matches!(err, ManagedError::InvalidState(_, _)),
+        "expected InvalidState, got {err:?}"
+    );
+
+    let after = mgr
+        .get(&record.id)
+        .await
+        .expect("get after refused reactivate");
+    assert_eq!(
+        after.state,
+        ManagedSessionState::Decommissioned,
+        "the record must NOT be flipped to Active when its workspace is gone"
     );
 }
 


### PR DESCRIPTION
## Problem

Bare `tm` run **inside** a managed tmux session whose managed state is `decommissioned` printed (Bob, tm 0.19.17):

```
tm: run `tm` to relaunch this session
… > tm
tm: this tmux session ('tm-apex-01') is already a managed session (state=decommissioned) — not nesting a new session here; reconnecting to 'tm-apex-01' instead…
tm: switching client to session 'tm-apex-01'
```

The pane's trailing echo promises "run `tm` to relaunch this session", but bare `tm` hit the nested-session guard, could not confirm pane identity (a decommissioned record has no matching `pane_id`), and took the session-name-only fallback → `resume_guided_session` → `plan_resume("decommissioned", tmux_live=true)` → `Attach` → `switch-client` to the session the operator is already inside. A guaranteed no-op dead-end; the session is never relaunched.

## Fix

**CLI (`bin/tm/commands/guided.rs`)** — new pure seam `nested_fallback_action(state)` (mirrors the `switch_decision`-style testable-decision pattern of #2680). In the guard's pane-unconfirmed fallback, split on liveness instead of always reconnecting.

**Daemon (`session_manager::mark_reactivated`)** — accepts `Decommissioned` as well as `Stopped`, flipping to `Active` in place with **no** tmux mutation, so `run_inplace_relaunch` can revive a decommissioned session's lingering pane non-destructively (aligns with #2148 / #2001 semantics).

### Code-critic BLOCK round (fixed in this push, head `028164d1`)

Three findings from the first review pass, all fixed:

- **CRITICAL** — `decommission()` always clears `workspace_path` to `None` on tombstone (even when the directory itself was never removed, the unowned/#1840 skip-deletion case) while the record's original spawn `cwd` stays stale. The old flow reactivated (durably committing `state=Active`) BEFORE checking whether the resolved directory actually existed — for an ordinary deleted-worktree decommissioned session this could commit a corrupted **ghost `Active` record** whose subsequent `exec`/`cd` then fails, violating the FSM invariant that only `Decommissioned` means the workspace is gone. **Fix**: `run_inplace_relaunch` now verifies the resolved directory exists on disk BEFORE any daemon call — a missing directory folds into `FallThrough` (honest hint, zero daemon mutation). Defense-in-depth: `mark_reactivated` independently refuses the state flip when `workspace_path.or(cwd)` doesn't exist, so the invariant holds even for a future caller that skips the CLI-side check.
- **HIGH** — tmux session names are RECYCLED after decommission; `nested_managed_match` matched by name via a plain `.find()` with no tombstone filter or recency ordering, so it could match a stale `Decommissioned` record for a name a genuinely live session now owns — the #2456/#2680 hijack class. **Fix**: `nested_managed_match` now prefers the most-recently-created NON-decommissioned candidate (mirroring `capture_pane_by_tmux_name`'s `max_by_key(created_at)` guard), falling back to a decommissioned candidate only when no live one shares the name.
- **MEDIUM** — added `mark_reactivated_refuses_when_workspace_removed_by_decommission`, which goes through the REAL `decommission_with_root` teardown (not the `set_workspace`-forced fixture that leaves an intact tempdir) and asserts no state flip when the workspace is actually gone.

## Decision table (nested guard, pane identity NOT confirmed) — updated preconditions

| Matched record state (after tombstone-filtered, most-recent match) | Precondition | Action |
|---|---|---|
| `decommissioned` | resolved `workspace_path.or(cwd)` directory EXISTS on disk | **RelaunchInPlace** → `run_inplace_relaunch` (daemon `mark_reactivated` flips Decommissioned→Active in place) |
| `decommissioned` | resolved directory is GONE (worktree was actually deleted) | **RelaunchInPlace attempted → FallThrough** (existence check fails before any daemon call) → honest self-relaunch hint, zero mutation |
| `decommissioned`, but a LIVE record shares the (recycled) tmux name | n/a — `nested_managed_match` prefers the live record | matched record is the LIVE one, not the tombstone → normal live-state handling below |
| `stopped` | resolved directory exists (expected — Stopped means workspace intact) | **RelaunchInPlace** → `run_inplace_relaunch` |
| `errored` | n/a | **RelaunchInPlace attempted** → daemon refuses reactivate → honest self-relaunch hint (no misleading no-op) |
| `active` / `provisioning` / `running` / unknown | n/a | **Reconnect** (unchanged) — a live runtime may be in a sibling window; switch-client legitimately brings it forward |

The daemon `reactivate` round-trip remains the sole authority: a refusal (missing workspace OR a genuinely live sibling) folds into `FallThrough` → an actionable self-relaunch hint, never an unconditional `exec`. Relaunch is only ever reached for an operator sitting inside the session's own still-alive tmux session who explicitly typed `tm`.

## Tests
- `nested_fallback_action_relaunches_dead_states`, `nested_fallback_action_reconnects_live_states` (pure decision, failing-test-first)
- `mark_reactivated_flips_decommissioned_to_active` (daemon in-place revive, no `create_session`/`kill_session`)
- `mark_reactivated_refuses_when_workspace_removed_by_decommission` (CRITICAL/MEDIUM fix — real `decommission_with_root` teardown, asserts no state flip)
- `nested_managed_match_prefers_live_over_recycled_decommissioned_name`, `nested_managed_match_falls_back_to_decommissioned_when_no_live_candidate`, `nested_managed_match_prefers_most_recent_live_among_multiple` (HIGH fix)
- Existing `mark_reactivated_rejects_non_stopped` still passes (Active still rejected)

## Gate (crate-scoped, latest push)
- `cargo build -p trusty-mpm`: OK
- `cargo test -p trusty-mpm`: 3186 + 999 lib/bin + integration, 0 failed
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: exit 0
- `cargo fmt --check`: exit 0
- `scripts/check_line_cap.sh`: 0 violations (guided.rs, guided_inplace.rs, reactivate.rs all under cap)

## Changelog
Added a `CHANGELOG.md` entry under `[Unreleased]` / `Fixed` per standing project convention.

Closes #2777

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
