### PR TITLE
feat(trusty-mpm): auto-nudge idle-parked managed sessions

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -9,7 +9,7 @@
 # Regenerate with: scripts/check_line_cap.sh --update  (use --seed only to bootstrap).
 crates/trusty-console/src/server.rs	922
 crates/trusty-git-analytics/src/collect/collector.rs	766
-crates/trusty-mpm/src/daemon/api.rs	1271
+crates/trusty-mpm/src/daemon/api.rs	1272
 crates/trusty-mpm/src/daemon/api/control_routes.rs	543
 crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	1218
 crates/trusty-mpm/src/daemon/mcp_backend.rs	564

--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -9,7 +9,7 @@
 # Regenerate with: scripts/check_line_cap.sh --update  (use --seed only to bootstrap).
 crates/trusty-console/src/server.rs	922
 crates/trusty-git-analytics/src/collect/collector.rs	766
-crates/trusty-mpm/src/daemon/api.rs	1272
+crates/trusty-mpm/src/daemon/api.rs	1271
 crates/trusty-mpm/src/daemon/api/control_routes.rs	543
 crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	1218
 crates/trusty-mpm/src/daemon/mcp_backend.rs	564

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - require a per-PR CHANGELOG.md entry in the default workflow (bundled `tm-pr-workflow` skill, `PM_INSTRUCTIONS.md`, `WORKFLOW.md`, `BASE-AGENT.md`); PM treats a missing entry as a review-gate failure and the precedence rule vs. `scripts/generate-changelog.sh`/git-cliff is documented in `.trusty-mpm/INSTRUCTIONS.md` ([#2790](https://github.com/bobmatnyc/trusty-tools/pull/2790))
+- opt-in auto-nudge for idle-parked managed sessions: daemon injects a foreground-block instruction when a parked agent has no live children, with per-session cap and cooldown (#2621) ([#2781](https://github.com/bobmatnyc/trusty-tools/pull/2781))
 
 ### Fixed
 

--- a/crates/trusty-mpm/src/core/config.rs
+++ b/crates/trusty-mpm/src/core/config.rs
@@ -347,6 +347,15 @@ pub struct MpmConfig {
     /// Set `enabled = true` to activate the background idle-reaper loop.
     #[serde(default)]
     pub idle_auto_stop: IdleAutoStopConfig,
+
+    /// `[idle_nudge]` — opt-in auto-nudge for idle-parked sessions (#2621).
+    ///
+    /// Absent section → `enabled = false` (feature OFF, zero behavior change).
+    /// Set `enabled = true` to let the daemon nudge parked managed sessions. The
+    /// section type lives in [`crate::core::idle_nudge`] alongside the pure
+    /// decision logic and ledger it configures.
+    #[serde(default)]
+    pub idle_nudge: crate::core::idle_nudge::IdleNudgeConfig,
 }
 
 // ──────────────────────────────────────────────
@@ -802,6 +811,39 @@ enabled = true
         assert_eq!(cfg.idle_auto_stop.poll_interval_secs, 300);
         assert_eq!(cfg.idle_auto_stop.idle_consecutive_threshold, 3);
         assert_eq!(cfg.idle_auto_stop.done_consecutive_threshold, 1);
+    }
+
+    #[test]
+    fn config_idle_nudge_section_parses() {
+        // Absent → disabled defaults (#2621, zero behavior change); a full
+        // section overrides every field; a partial section (only `enabled`)
+        // keeps the caps and message at their conservative defaults.
+        let dir = tempfile::TempDir::new().unwrap();
+        let absent = load_from_str(dir.path(), "");
+        assert!(!absent.idle_nudge.enabled, "must default to disabled");
+        assert_eq!(absent.idle_nudge.max_nudges_per_session, 2);
+        assert_eq!(absent.idle_nudge.cooldown_secs, 300);
+        assert_eq!(
+            absent.idle_nudge.message,
+            crate::core::idle_nudge::DEFAULT_NUDGE_MESSAGE
+        );
+        let full = load_from_str(
+            dir.path(),
+            "[idle_nudge]\nenabled = true\nmax_nudges_per_session = 1\ncooldown_secs = 60\nmessage = \"resume now\"\n",
+        );
+        assert!(full.idle_nudge.enabled);
+        assert_eq!(full.idle_nudge.max_nudges_per_session, 1);
+        assert_eq!(full.idle_nudge.cooldown_secs, 60);
+        assert_eq!(full.idle_nudge.message, "resume now");
+
+        let partial = load_from_str(dir.path(), "[idle_nudge]\nenabled = true\n");
+        assert!(partial.idle_nudge.enabled);
+        assert_eq!(partial.idle_nudge.max_nudges_per_session, 2);
+        assert_eq!(partial.idle_nudge.cooldown_secs, 300);
+        assert_eq!(
+            partial.idle_nudge.message,
+            crate::core::idle_nudge::DEFAULT_NUDGE_MESSAGE
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/idle_nudge.rs
+++ b/crates/trusty-mpm/src/core/idle_nudge.rs
@@ -1,0 +1,528 @@
+//! Pure decision logic and per-session ledger for the idle-park auto-nudge
+//! (#2621, follow-up to #2610 / PR #2620).
+//!
+//! Why: `core::idle_parking` detects that a delegated agent ended its turn with
+//! monitor/notification "waiting" language after backgrounding a long command —
+//! a stall a stopped agent can never recover from on its own. #2621 asks the
+//! daemon to auto-nudge such a session instead of waiting for a human to notice.
+//! Doing that safely needs three things kept OUT of the effectful daemon code so
+//! they can be unit-tested without a tmux/session-manager: the canonical nudge
+//! message, a per-session ledger that bounds how often any one session is
+//! nudged, and a single pure predicate that folds every safety rail into one
+//! [`NudgeDecision`]. This module owns exactly those.
+//! What: [`DEFAULT_NUDGE_MESSAGE`] is the injected text; [`NudgeLedger`] tracks
+//! `(count, last_nudge_at)` per session id and prunes stale entries;
+//! [`decide_nudge`] is the pure gate — it returns [`NudgeDecision::Nudge`] only
+//! when the feature is enabled, the turn genuinely parked, the session has no
+//! live tracked children, the per-session nudge cap is not exhausted, and the
+//! cooldown since the last nudge has elapsed; otherwise it returns
+//! [`NudgeDecision::Skip`] with the specific [`SkipReason`]. Nothing here does
+//! any I/O.
+//! Test: the inline `tests` module below.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// `[idle_nudge]` config section — opt-in auto-nudge for idle-parked sessions.
+///
+/// Why: delegated agents in tm-managed sessions repeatedly "idle-park" — they
+/// end a turn with monitor/notification "waiting" language after backgrounding a
+/// long command, then sit idle forever because a stopped agent can never be
+/// re-woken by the thing it is waiting on. A human has had to notice and send a
+/// manual nudge. This section lets the daemon do it automatically, bounded by
+/// conservative caps. It lives HERE (not in `core::config`) alongside the
+/// [`decide_nudge`] logic and [`NudgeLedger`] it configures, so the whole
+/// feature — type, decision, and ledger — is one cohesive, testable unit;
+/// `MpmConfig` merely embeds it as the `[idle_nudge]` field.
+/// What: `enabled` (default `false`, zero behavior change) turns the feature on;
+/// `max_nudges_per_session` caps re-nudges so a stuck session is never spammed
+/// (`0` disables as firmly as `enabled = false`); `cooldown_secs` is the minimum
+/// gap between two nudges to the SAME session; `message` is the literal text
+/// injected (defaults to [`DEFAULT_NUDGE_MESSAGE`]).
+/// Test: `config_idle_nudge_defaults`, `config_idle_nudge_section_parses` in
+/// `core::config`; the field semantics via every `decide_nudge` test below.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IdleNudgeConfig {
+    /// Whether the daemon auto-nudges idle-parked managed sessions.
+    ///
+    /// `false` (default) → feature is OFF, zero behavior change. `true` → a
+    /// parking `Stop`/`SubagentStop` with no live tracked children triggers a
+    /// nudge into the correlated managed session's pane.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Maximum number of auto-nudges delivered to any single session.
+    ///
+    /// Why: a session that stays parked despite a nudge must not be nudged in an
+    /// unbounded loop. Once this many nudges have been sent to a session the
+    /// daemon stops nudging it (a human must intervene). Default: 2.
+    #[serde(default = "IdleNudgeConfig::default_max_nudges_per_session")]
+    pub max_nudges_per_session: u32,
+
+    /// Minimum seconds between two nudges to the SAME session.
+    ///
+    /// Why: several parking hooks can fire close together (e.g. a `SubagentStop`
+    /// followed by the parent `Stop`); the cooldown collapses that burst into a
+    /// single nudge. Default: 300 s (5 min).
+    #[serde(default = "IdleNudgeConfig::default_cooldown_secs")]
+    pub cooldown_secs: u64,
+
+    /// The literal text injected into a parked pane (submitted with Enter).
+    ///
+    /// Defaults to [`DEFAULT_NUDGE_MESSAGE`], a short foreground-block
+    /// instruction citing #2621.
+    #[serde(default = "IdleNudgeConfig::default_message")]
+    pub message: String,
+}
+
+impl IdleNudgeConfig {
+    fn default_max_nudges_per_session() -> u32 {
+        2
+    }
+    fn default_cooldown_secs() -> u64 {
+        300
+    }
+    fn default_message() -> String {
+        DEFAULT_NUDGE_MESSAGE.to_string()
+    }
+}
+
+impl Default for IdleNudgeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_nudges_per_session: Self::default_max_nudges_per_session(),
+            cooldown_secs: Self::default_cooldown_secs(),
+            message: Self::default_message(),
+        }
+    }
+}
+
+/// The default text injected into a parked pane, submitted with Enter.
+///
+/// Why: the nudge must do more than say "you stalled" — it must correct the
+/// exact anti-pattern (#2501/#2610): the agent backgrounded a watch and ended
+/// its turn. The message tells it to block in the FOREGROUND and keep its turn
+/// open, which is the behavior the bundled agent guidance already prescribes.
+/// What: a `'static` instruction string citing #2621 so an operator reading the
+/// pane knows the message was machine-injected, not typed by a human.
+/// Test: `config_idle_nudge_defaults` (in `core::config`) asserts the config
+/// default equals this constant; `default_message_mentions_foreground` below.
+pub const DEFAULT_NUDGE_MESSAGE: &str = "[trusty-mpm auto-nudge #2621] Your last turn ended with \
+language that parks the task waiting on a background monitor/notification, but a stopped agent \
+cannot be re-woken by the thing it is waiting on. Resume NOW: block in the FOREGROUND (re-run the \
+gate, or `gh pr checks <n> --watch`) and do not end your turn until it actually completes. If you \
+are genuinely blocked on a human decision, say so explicitly instead.";
+
+/// Per-session record of how many nudges were sent and when the last one fired.
+///
+/// Why: the two spam guards — a hard per-session cap and a cooldown between
+/// nudges — both need this small piece of history. Keeping it a plain `Copy`
+/// value makes [`decide_nudge`] pure (it reads a snapshot) and the ledger a
+/// trivial map.
+/// What: `count` is the number of nudges delivered to the session so far;
+/// `last_nudge_at` is the UTC instant of the most recent one (`None` before the
+/// first).
+/// Test: `cap_blocks_after_max`, `cooldown_blocks_within_window`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NudgeRecord {
+    /// Number of nudges already delivered to this session.
+    pub count: u32,
+    /// When the most recent nudge was delivered, or `None` if never.
+    pub last_nudge_at: Option<DateTime<Utc>>,
+}
+
+/// Why a nudge was NOT sent — the diagnostic half of [`NudgeDecision`].
+///
+/// Why: every skip path is a distinct, log-worthy reason; an enum keeps the
+/// daemon's structured logging and the unit tests aligned on one vocabulary
+/// instead of stringly-typed reasons.
+/// What: one variant per safety rail, in the order [`decide_nudge`] checks them.
+/// Test: `disabled_skips`, `not_parking_skips`, `live_children_skips`,
+/// `cap_blocks_after_max`, `cooldown_blocks_within_window`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipReason {
+    /// The `[idle_nudge]` feature is disabled (`enabled = false`).
+    Disabled,
+    /// The turn-end did not actually park (no parking phrase was detected).
+    NotParking,
+    /// The session still has live tracked children — it is not truly stalled.
+    HasLiveChildren,
+    /// The per-session nudge cap (`max_nudges_per_session`) is exhausted.
+    CapExhausted,
+    /// A nudge fired too recently; the cooldown window has not elapsed.
+    WithinCooldown,
+}
+
+impl SkipReason {
+    /// A stable lowercase tag for structured logging (`"disabled"`, …).
+    ///
+    /// Why: the daemon logs the skip reason as a field; a stable tag keeps log
+    /// queries robust against `Debug`-format churn.
+    /// What: maps each variant to a fixed `&'static str`.
+    /// Test: `skip_reason_tags_are_stable`.
+    pub fn tag(self) -> &'static str {
+        match self {
+            SkipReason::Disabled => "disabled",
+            SkipReason::NotParking => "not_parking",
+            SkipReason::HasLiveChildren => "has_live_children",
+            SkipReason::CapExhausted => "cap_exhausted",
+            SkipReason::WithinCooldown => "within_cooldown",
+        }
+    }
+}
+
+/// The verdict of [`decide_nudge`]: nudge the session, or skip with a reason.
+///
+/// Why: the caller must both act (inject) and log (why/why-not); a two-variant
+/// enum carries both without a side channel.
+/// What: `Nudge` means all rails passed; `Skip(reason)` names the first rail
+/// that failed.
+/// Test: covered by every `decide_nudge` test below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NudgeDecision {
+    /// All safety rails passed — deliver the nudge.
+    Nudge,
+    /// Do not nudge; `.0` is the first rail that failed.
+    Skip(SkipReason),
+}
+
+impl NudgeDecision {
+    /// Whether this decision is [`NudgeDecision::Nudge`].
+    ///
+    /// Why: the common caller branch is "did we decide to nudge?"; a helper
+    /// reads better than a `matches!` at each call site.
+    /// What: `true` for `Nudge`, `false` for any `Skip`.
+    /// Test: `enabled_and_parking_and_idle_nudges`.
+    pub fn should_nudge(self) -> bool {
+        matches!(self, NudgeDecision::Nudge)
+    }
+}
+
+/// Decide whether to nudge a parked session, folding in every safety rail (pure).
+///
+/// Why: concentrating the gate in one side-effect-free function makes the
+/// conservative posture the issue demands — disable-able, cap-bounded,
+/// cooldown-bounded, never-nudge-a-busy-session — auditable and unit-testable
+/// without any daemon plumbing. The daemon layer computes the three runtime
+/// inputs (`parking`, `has_live_children`, and the session's [`NudgeRecord`])
+/// and defers the decision entirely to this function.
+/// What: returns [`NudgeDecision::Nudge`] iff, in order: the feature is
+/// `enabled`; the turn actually `parking`ed; the session has NO live tracked
+/// children (`!has_live_children`); the prior nudge `count` is `<`
+/// `max_nudges_per_session`; and either no nudge has fired yet OR at least
+/// `cooldown_secs` have elapsed since `last_nudge_at` at `now`. The first failing
+/// rail yields the matching [`NudgeDecision::Skip`]. A `max_nudges_per_session`
+/// of `0` disables nudging as firmly as `enabled = false`.
+/// Test: `disabled_skips`, `not_parking_skips`, `live_children_skips`,
+/// `cap_blocks_after_max`, `cooldown_blocks_within_window`,
+/// `enabled_and_parking_and_idle_nudges`, `nudge_allowed_after_cooldown`.
+pub fn decide_nudge(
+    cfg: &IdleNudgeConfig,
+    parking: bool,
+    has_live_children: bool,
+    record: &NudgeRecord,
+    now: DateTime<Utc>,
+) -> NudgeDecision {
+    if !cfg.enabled {
+        return NudgeDecision::Skip(SkipReason::Disabled);
+    }
+    if !parking {
+        return NudgeDecision::Skip(SkipReason::NotParking);
+    }
+    if has_live_children {
+        return NudgeDecision::Skip(SkipReason::HasLiveChildren);
+    }
+    if record.count >= cfg.max_nudges_per_session {
+        return NudgeDecision::Skip(SkipReason::CapExhausted);
+    }
+    if let Some(last) = record.last_nudge_at {
+        let elapsed = now.signed_duration_since(last);
+        if elapsed < Duration::seconds(cfg.cooldown_secs as i64) {
+            return NudgeDecision::Skip(SkipReason::WithinCooldown);
+        }
+    }
+    NudgeDecision::Nudge
+}
+
+/// In-memory, per-session ledger of nudge history.
+///
+/// Why: the cap and cooldown rails need history that survives across hook
+/// receipts but NOT across a daemon restart — a restart resetting the counters
+/// only re-arms the (already conservative) nudge, never spams. A plain map keyed
+/// by session id is enough; it lives behind a lock in `DaemonState`.
+/// What: wraps `HashMap<Uuid, NudgeRecord>`. [`snapshot`](Self::snapshot) reads a
+/// session's current record (default when unseen); [`record_nudge`](Self::record_nudge)
+/// bumps the count and stamps the time; [`prune`](Self::prune) drops entries for
+/// sessions no longer live so the map cannot grow without bound.
+/// Test: `ledger_snapshot_defaults_when_unseen`, `ledger_record_bumps_count`,
+/// `ledger_prune_drops_stale`.
+#[derive(Debug, Default)]
+pub struct NudgeLedger {
+    records: HashMap<Uuid, NudgeRecord>,
+}
+
+impl NudgeLedger {
+    /// Create an empty ledger.
+    ///
+    /// Why: constructed once and held in `DaemonState`.
+    /// What: zero-initialised map.
+    /// Test: `ledger_snapshot_defaults_when_unseen`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Read the current [`NudgeRecord`] for `session`, defaulting when unseen.
+    ///
+    /// Why: [`decide_nudge`] needs the session's history as a snapshot; a
+    /// never-nudged session reads as the zero record.
+    /// What: returns a copy of the stored record, or `NudgeRecord::default()`.
+    /// Test: `ledger_snapshot_defaults_when_unseen`, `ledger_record_bumps_count`.
+    pub fn snapshot(&self, session: Uuid) -> NudgeRecord {
+        self.records.get(&session).copied().unwrap_or_default()
+    }
+
+    /// Record that a nudge was delivered to `session` at `now`.
+    ///
+    /// Why: after a successful inject the ledger must reflect the new count and
+    /// timestamp so the next decision sees the updated cap/cooldown state.
+    /// What: increments `count` (saturating) and sets `last_nudge_at = now` for
+    /// the session, inserting a fresh record when unseen.
+    /// Test: `ledger_record_bumps_count`.
+    pub fn record_nudge(&mut self, session: Uuid, now: DateTime<Utc>) {
+        let entry = self.records.entry(session).or_default();
+        entry.count = entry.count.saturating_add(1);
+        entry.last_nudge_at = Some(now);
+    }
+
+    /// Drop ledger entries for sessions not in `live`.
+    ///
+    /// Why: a long-lived daemon must not accumulate records for sessions that
+    /// have ended; pruning against the current live set bounds the map.
+    /// What: `HashMap::retain` keeping only keys present in `live`.
+    /// Test: `ledger_prune_drops_stale`.
+    pub fn prune(&mut self, live: &std::collections::HashSet<Uuid>) {
+        self.records.retain(|id, _| live.contains(id));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_cfg() -> IdleNudgeConfig {
+        IdleNudgeConfig {
+            enabled: true,
+            max_nudges_per_session: 2,
+            cooldown_secs: 300,
+            message: "nudge".into(),
+        }
+    }
+
+    #[test]
+    fn default_message_mentions_foreground() {
+        // The canonical message must correct the actual anti-pattern.
+        let m = DEFAULT_NUDGE_MESSAGE.to_lowercase();
+        assert!(m.contains("foreground"), "must tell the agent to block");
+        assert!(m.contains("#2621"), "must be attributable to the feature");
+    }
+
+    #[test]
+    fn skip_reason_tags_are_stable() {
+        assert_eq!(SkipReason::Disabled.tag(), "disabled");
+        assert_eq!(SkipReason::NotParking.tag(), "not_parking");
+        assert_eq!(SkipReason::HasLiveChildren.tag(), "has_live_children");
+        assert_eq!(SkipReason::CapExhausted.tag(), "cap_exhausted");
+        assert_eq!(SkipReason::WithinCooldown.tag(), "within_cooldown");
+    }
+
+    #[test]
+    fn disabled_skips() {
+        // Feature OFF is the firmest rail — it wins even when everything else
+        // would nudge.
+        let mut cfg = enabled_cfg();
+        cfg.enabled = false;
+        let d = decide_nudge(&cfg, true, false, &NudgeRecord::default(), Utc::now());
+        assert_eq!(d, NudgeDecision::Skip(SkipReason::Disabled));
+        assert!(!d.should_nudge());
+    }
+
+    #[test]
+    fn not_parking_skips() {
+        // A clean turn-end must never be nudged.
+        let cfg = enabled_cfg();
+        let d = decide_nudge(&cfg, false, false, &NudgeRecord::default(), Utc::now());
+        assert_eq!(d, NudgeDecision::Skip(SkipReason::NotParking));
+    }
+
+    #[test]
+    fn live_children_skips() {
+        // A session that still has live tracked children is doing work — the
+        // "no live children" precondition (#2621 design note) must suppress it.
+        let cfg = enabled_cfg();
+        let d = decide_nudge(&cfg, true, true, &NudgeRecord::default(), Utc::now());
+        assert_eq!(d, NudgeDecision::Skip(SkipReason::HasLiveChildren));
+    }
+
+    #[test]
+    fn enabled_and_parking_and_idle_nudges() {
+        // All rails pass on a never-nudged, parked, child-free session.
+        let cfg = enabled_cfg();
+        let d = decide_nudge(&cfg, true, false, &NudgeRecord::default(), Utc::now());
+        assert_eq!(d, NudgeDecision::Nudge);
+        assert!(d.should_nudge());
+    }
+
+    #[test]
+    fn cap_blocks_after_max() {
+        // Once `count` reaches the cap, no further nudge — a stuck session is
+        // never spammed in a loop.
+        let cfg = enabled_cfg(); // max = 2
+        let now = Utc::now();
+        // count == max → blocked.
+        let rec = NudgeRecord {
+            count: 2,
+            // Old enough that the cooldown would otherwise have elapsed, proving
+            // the cap — not the cooldown — is what blocks here.
+            last_nudge_at: Some(now - Duration::seconds(10_000)),
+        };
+        assert_eq!(
+            decide_nudge(&cfg, true, false, &rec, now),
+            NudgeDecision::Skip(SkipReason::CapExhausted)
+        );
+        // count just under the cap → still allowed (cooldown elapsed).
+        let rec = NudgeRecord {
+            count: 1,
+            last_nudge_at: Some(now - Duration::seconds(10_000)),
+        };
+        assert_eq!(
+            decide_nudge(&cfg, true, false, &rec, now),
+            NudgeDecision::Nudge
+        );
+    }
+
+    #[test]
+    fn cap_of_zero_disables() {
+        // `max_nudges_per_session = 0` must block from the first receipt.
+        let mut cfg = enabled_cfg();
+        cfg.max_nudges_per_session = 0;
+        assert_eq!(
+            decide_nudge(&cfg, true, false, &NudgeRecord::default(), Utc::now()),
+            NudgeDecision::Skip(SkipReason::CapExhausted)
+        );
+    }
+
+    #[test]
+    fn cooldown_blocks_within_window() {
+        // A nudge that fired 60 s ago (< 300 s cooldown) must suppress a second.
+        let cfg = enabled_cfg();
+        let now = Utc::now();
+        let rec = NudgeRecord {
+            count: 1,
+            last_nudge_at: Some(now - Duration::seconds(60)),
+        };
+        assert_eq!(
+            decide_nudge(&cfg, true, false, &rec, now),
+            NudgeDecision::Skip(SkipReason::WithinCooldown)
+        );
+    }
+
+    #[test]
+    fn nudge_allowed_after_cooldown() {
+        // Past the cooldown (and under the cap) the next nudge is allowed.
+        let cfg = enabled_cfg();
+        let now = Utc::now();
+        let rec = NudgeRecord {
+            count: 1,
+            last_nudge_at: Some(now - Duration::seconds(301)),
+        };
+        assert_eq!(
+            decide_nudge(&cfg, true, false, &rec, now),
+            NudgeDecision::Nudge
+        );
+    }
+
+    #[test]
+    fn ledger_snapshot_defaults_when_unseen() {
+        let ledger = NudgeLedger::new();
+        let rec = ledger.snapshot(Uuid::new_v4());
+        assert_eq!(rec, NudgeRecord::default());
+        assert_eq!(rec.count, 0);
+        assert!(rec.last_nudge_at.is_none());
+    }
+
+    #[test]
+    fn ledger_record_bumps_count() {
+        let mut ledger = NudgeLedger::new();
+        let id = Uuid::new_v4();
+        let t0 = Utc::now();
+        ledger.record_nudge(id, t0);
+        let rec = ledger.snapshot(id);
+        assert_eq!(rec.count, 1);
+        assert_eq!(rec.last_nudge_at, Some(t0));
+        let t1 = t0 + Duration::seconds(500);
+        ledger.record_nudge(id, t1);
+        let rec = ledger.snapshot(id);
+        assert_eq!(rec.count, 2);
+        assert_eq!(rec.last_nudge_at, Some(t1));
+    }
+
+    #[test]
+    fn ledger_prune_drops_stale() {
+        let mut ledger = NudgeLedger::new();
+        let live_id = Uuid::new_v4();
+        let stale_id = Uuid::new_v4();
+        let now = Utc::now();
+        ledger.record_nudge(live_id, now);
+        ledger.record_nudge(stale_id, now);
+        let live = std::collections::HashSet::from([live_id]);
+        ledger.prune(&live);
+        assert_eq!(ledger.snapshot(live_id).count, 1, "live entry survives");
+        assert_eq!(
+            ledger.snapshot(stale_id),
+            NudgeRecord::default(),
+            "stale entry pruned back to default"
+        );
+    }
+
+    /// End-to-end rail ordering: the full happy path then each rail's override,
+    /// proving `decide_nudge` short-circuits at the first failing rail.
+    #[test]
+    fn rails_short_circuit_in_order() {
+        let cfg = enabled_cfg();
+        let now = Utc::now();
+        // Disabled beats not-parking beats live-children beats cap beats cooldown.
+        let mut disabled = cfg.clone();
+        disabled.enabled = false;
+        assert_eq!(
+            decide_nudge(
+                &disabled,
+                false,
+                true,
+                &NudgeRecord {
+                    count: 99,
+                    last_nudge_at: Some(now)
+                },
+                now
+            ),
+            NudgeDecision::Skip(SkipReason::Disabled)
+        );
+        // Enabled but not parking, with live children + exhausted cap → NotParking wins.
+        assert_eq!(
+            decide_nudge(
+                &cfg,
+                false,
+                true,
+                &NudgeRecord {
+                    count: 99,
+                    last_nudge_at: Some(now)
+                },
+                now
+            ),
+            NudgeDecision::Skip(SkipReason::NotParking)
+        );
+    }
+}

--- a/crates/trusty-mpm/src/core/idle_nudge.rs
+++ b/crates/trusty-mpm/src/core/idle_nudge.rs
@@ -141,14 +141,19 @@ pub struct NudgeRecord {
 /// daemon's structured logging and the unit tests aligned on one vocabulary
 /// instead of stringly-typed reasons.
 /// What: one variant per safety rail, in the order [`decide_nudge`] checks them.
-/// Test: `disabled_skips`, `not_parking_skips`, `live_children_skips`,
-/// `cap_blocks_after_max`, `cooldown_blocks_within_window`.
+/// Test: `disabled_skips`, `not_parking_skips`, `human_wait_skips`,
+/// `live_children_skips`, `cap_blocks_after_max`, `cooldown_blocks_within_window`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SkipReason {
     /// The `[idle_nudge]` feature is disabled (`enabled = false`).
     Disabled,
     /// The turn-end did not actually park (no parking phrase was detected).
     NotParking,
+    /// The parking phrase addresses a HUMAN ("let me know once…", "ping me
+    /// when…"), not a monitor/notification — a legitimate user-wait that #2621
+    /// requires the auto-nudge to never interrupt (code-critic HIGH 1). See
+    /// [`crate::core::idle_parking::is_nudge_eligible`].
+    HumanWait,
     /// The session still has live tracked children — it is not truly stalled.
     HasLiveChildren,
     /// The per-session nudge cap (`max_nudges_per_session`) is exhausted.
@@ -168,6 +173,7 @@ impl SkipReason {
         match self {
             SkipReason::Disabled => "disabled",
             SkipReason::NotParking => "not_parking",
+            SkipReason::HumanWait => "human_wait",
             SkipReason::HasLiveChildren => "has_live_children",
             SkipReason::CapExhausted => "cap_exhausted",
             SkipReason::WithinCooldown => "within_cooldown",
@@ -206,23 +212,26 @@ impl NudgeDecision {
 ///
 /// Why: concentrating the gate in one side-effect-free function makes the
 /// conservative posture the issue demands — disable-able, cap-bounded,
-/// cooldown-bounded, never-nudge-a-busy-session — auditable and unit-testable
-/// without any daemon plumbing. The daemon layer computes the three runtime
-/// inputs (`parking`, `has_live_children`, and the session's [`NudgeRecord`])
-/// and defers the decision entirely to this function.
+/// cooldown-bounded, never-nudge-a-busy-session, never-nudge-a-human-wait —
+/// auditable and unit-testable without any daemon plumbing. The daemon layer
+/// computes the three runtime inputs (`phrase`, `has_live_children`, and the
+/// session's [`NudgeRecord`]) and defers the decision entirely to this function.
 /// What: returns [`NudgeDecision::Nudge`] iff, in order: the feature is
-/// `enabled`; the turn actually `parking`ed; the session has NO live tracked
-/// children (`!has_live_children`); the prior nudge `count` is `<`
-/// `max_nudges_per_session`; and either no nudge has fired yet OR at least
-/// `cooldown_secs` have elapsed since `last_nudge_at` at `now`. The first failing
-/// rail yields the matching [`NudgeDecision::Skip`]. A `max_nudges_per_session`
-/// of `0` disables nudging as firmly as `enabled = false`.
-/// Test: `disabled_skips`, `not_parking_skips`, `live_children_skips`,
-/// `cap_blocks_after_max`, `cooldown_blocks_within_window`,
+/// `enabled`; `phrase` is `Some` (the turn actually parked) AND
+/// [`crate::core::idle_parking::is_nudge_eligible`] accepts it (excludes a
+/// human-addressed wait like "let me know once…" — #2621 code-critic HIGH 1);
+/// the session has NO live tracked children (`!has_live_children`); the prior
+/// nudge `count` is `<` `max_nudges_per_session`; and either no nudge has fired
+/// yet OR at least `cooldown_secs` have elapsed since `last_nudge_at` at `now`.
+/// The first failing rail yields the matching [`NudgeDecision::Skip`]. A
+/// `max_nudges_per_session` of `0` disables nudging as firmly as
+/// `enabled = false`.
+/// Test: `disabled_skips`, `not_parking_skips`, `human_wait_skips`,
+/// `live_children_skips`, `cap_blocks_after_max`, `cooldown_blocks_within_window`,
 /// `enabled_and_parking_and_idle_nudges`, `nudge_allowed_after_cooldown`.
 pub fn decide_nudge(
     cfg: &IdleNudgeConfig,
-    parking: bool,
+    phrase: Option<&str>,
     has_live_children: bool,
     record: &NudgeRecord,
     now: DateTime<Utc>,
@@ -230,8 +239,11 @@ pub fn decide_nudge(
     if !cfg.enabled {
         return NudgeDecision::Skip(SkipReason::Disabled);
     }
-    if !parking {
+    let Some(phrase) = phrase else {
         return NudgeDecision::Skip(SkipReason::NotParking);
+    };
+    if !crate::core::idle_parking::is_nudge_eligible(phrase) {
+        return NudgeDecision::Skip(SkipReason::HumanWait);
     }
     if has_live_children {
         return NudgeDecision::Skip(SkipReason::HasLiveChildren);
@@ -257,9 +269,14 @@ pub fn decide_nudge(
 /// What: wraps `HashMap<Uuid, NudgeRecord>`. [`snapshot`](Self::snapshot) reads a
 /// session's current record (default when unseen); [`record_nudge`](Self::record_nudge)
 /// bumps the count and stamps the time; [`prune`](Self::prune) drops entries for
-/// sessions no longer live so the map cannot grow without bound.
+/// sessions no longer live so the map cannot grow without bound. Production
+/// callers MUST call [`prune`](Self::prune) periodically — it is not automatic —
+/// which `daemon::idle_nudge::run_nudge` does on every nudge attempt, keyed off
+/// the same `SessionManager::list()` call it already makes to correlate the
+/// hook's Claude session id.
 /// Test: `ledger_snapshot_defaults_when_unseen`, `ledger_record_bumps_count`,
-/// `ledger_prune_drops_stale`.
+/// `ledger_prune_drops_stale`; `daemon::idle_nudge::run_nudge_prunes_stale_entries`
+/// exercises the production wiring end to end.
 #[derive(Debug, Default)]
 pub struct NudgeLedger {
     records: HashMap<Uuid, NudgeRecord>,
@@ -330,10 +347,17 @@ mod tests {
         assert!(m.contains("#2621"), "must be attributable to the feature");
     }
 
+    /// A machine-wait phrase (nudge-eligible per `core::idle_parking`), used as
+    /// the standard "genuinely parked" input across these tests.
+    const MACHINE_PHRASE: &str = "i'll wait for the";
+    /// A human-addressed phrase (NOT nudge-eligible), used by `human_wait_skips`.
+    const HUMAN_PHRASE: &str = "let me know once";
+
     #[test]
     fn skip_reason_tags_are_stable() {
         assert_eq!(SkipReason::Disabled.tag(), "disabled");
         assert_eq!(SkipReason::NotParking.tag(), "not_parking");
+        assert_eq!(SkipReason::HumanWait.tag(), "human_wait");
         assert_eq!(SkipReason::HasLiveChildren.tag(), "has_live_children");
         assert_eq!(SkipReason::CapExhausted.tag(), "cap_exhausted");
         assert_eq!(SkipReason::WithinCooldown.tag(), "within_cooldown");
@@ -345,17 +369,39 @@ mod tests {
         // would nudge.
         let mut cfg = enabled_cfg();
         cfg.enabled = false;
-        let d = decide_nudge(&cfg, true, false, &NudgeRecord::default(), Utc::now());
+        let d = decide_nudge(
+            &cfg,
+            Some(MACHINE_PHRASE),
+            false,
+            &NudgeRecord::default(),
+            Utc::now(),
+        );
         assert_eq!(d, NudgeDecision::Skip(SkipReason::Disabled));
         assert!(!d.should_nudge());
     }
 
     #[test]
     fn not_parking_skips() {
-        // A clean turn-end must never be nudged.
+        // A clean turn-end (no phrase at all) must never be nudged.
         let cfg = enabled_cfg();
-        let d = decide_nudge(&cfg, false, false, &NudgeRecord::default(), Utc::now());
+        let d = decide_nudge(&cfg, None, false, &NudgeRecord::default(), Utc::now());
         assert_eq!(d, NudgeDecision::Skip(SkipReason::NotParking));
+    }
+
+    #[test]
+    fn human_wait_skips() {
+        // A parking phrase that addresses a HUMAN ("let me know once…") must
+        // never be nudged — #2621 code-critic HIGH 1: never nudge a legitimate
+        // user-wait, even though it still counts as "parking" for logging.
+        let cfg = enabled_cfg();
+        let d = decide_nudge(
+            &cfg,
+            Some(HUMAN_PHRASE),
+            false,
+            &NudgeRecord::default(),
+            Utc::now(),
+        );
+        assert_eq!(d, NudgeDecision::Skip(SkipReason::HumanWait));
     }
 
     #[test]
@@ -363,15 +409,28 @@ mod tests {
         // A session that still has live tracked children is doing work — the
         // "no live children" precondition (#2621 design note) must suppress it.
         let cfg = enabled_cfg();
-        let d = decide_nudge(&cfg, true, true, &NudgeRecord::default(), Utc::now());
+        let d = decide_nudge(
+            &cfg,
+            Some(MACHINE_PHRASE),
+            true,
+            &NudgeRecord::default(),
+            Utc::now(),
+        );
         assert_eq!(d, NudgeDecision::Skip(SkipReason::HasLiveChildren));
     }
 
     #[test]
     fn enabled_and_parking_and_idle_nudges() {
-        // All rails pass on a never-nudged, parked, child-free session.
+        // All rails pass on a never-nudged, parked, child-free session with a
+        // machine-wait phrase.
         let cfg = enabled_cfg();
-        let d = decide_nudge(&cfg, true, false, &NudgeRecord::default(), Utc::now());
+        let d = decide_nudge(
+            &cfg,
+            Some(MACHINE_PHRASE),
+            false,
+            &NudgeRecord::default(),
+            Utc::now(),
+        );
         assert_eq!(d, NudgeDecision::Nudge);
         assert!(d.should_nudge());
     }
@@ -390,7 +449,7 @@ mod tests {
             last_nudge_at: Some(now - Duration::seconds(10_000)),
         };
         assert_eq!(
-            decide_nudge(&cfg, true, false, &rec, now),
+            decide_nudge(&cfg, Some(MACHINE_PHRASE), false, &rec, now),
             NudgeDecision::Skip(SkipReason::CapExhausted)
         );
         // count just under the cap → still allowed (cooldown elapsed).
@@ -399,7 +458,7 @@ mod tests {
             last_nudge_at: Some(now - Duration::seconds(10_000)),
         };
         assert_eq!(
-            decide_nudge(&cfg, true, false, &rec, now),
+            decide_nudge(&cfg, Some(MACHINE_PHRASE), false, &rec, now),
             NudgeDecision::Nudge
         );
     }
@@ -410,7 +469,13 @@ mod tests {
         let mut cfg = enabled_cfg();
         cfg.max_nudges_per_session = 0;
         assert_eq!(
-            decide_nudge(&cfg, true, false, &NudgeRecord::default(), Utc::now()),
+            decide_nudge(
+                &cfg,
+                Some(MACHINE_PHRASE),
+                false,
+                &NudgeRecord::default(),
+                Utc::now()
+            ),
             NudgeDecision::Skip(SkipReason::CapExhausted)
         );
     }
@@ -425,7 +490,7 @@ mod tests {
             last_nudge_at: Some(now - Duration::seconds(60)),
         };
         assert_eq!(
-            decide_nudge(&cfg, true, false, &rec, now),
+            decide_nudge(&cfg, Some(MACHINE_PHRASE), false, &rec, now),
             NudgeDecision::Skip(SkipReason::WithinCooldown)
         );
     }
@@ -440,7 +505,7 @@ mod tests {
             last_nudge_at: Some(now - Duration::seconds(301)),
         };
         assert_eq!(
-            decide_nudge(&cfg, true, false, &rec, now),
+            decide_nudge(&cfg, Some(MACHINE_PHRASE), false, &rec, now),
             NudgeDecision::Nudge
         );
     }
@@ -489,40 +554,41 @@ mod tests {
     }
 
     /// End-to-end rail ordering: the full happy path then each rail's override,
-    /// proving `decide_nudge` short-circuits at the first failing rail.
+    /// proving `decide_nudge` short-circuits at the first failing rail —
+    /// Disabled > NotParking > HumanWait > HasLiveChildren > cap/cooldown.
     #[test]
     fn rails_short_circuit_in_order() {
         let cfg = enabled_cfg();
         let now = Utc::now();
-        // Disabled beats not-parking beats live-children beats cap beats cooldown.
+        let exhausted = NudgeRecord {
+            count: 99,
+            last_nudge_at: Some(now),
+        };
+
+        // Disabled beats everything, even a human-addressed phrase.
         let mut disabled = cfg.clone();
         disabled.enabled = false;
         assert_eq!(
-            decide_nudge(
-                &disabled,
-                false,
-                true,
-                &NudgeRecord {
-                    count: 99,
-                    last_nudge_at: Some(now)
-                },
-                now
-            ),
+            decide_nudge(&disabled, Some(HUMAN_PHRASE), true, &exhausted, now),
             NudgeDecision::Skip(SkipReason::Disabled)
         );
-        // Enabled but not parking, with live children + exhausted cap → NotParking wins.
+        // Enabled but no phrase at all, with live children + exhausted cap →
+        // NotParking wins over the later rails.
         assert_eq!(
-            decide_nudge(
-                &cfg,
-                false,
-                true,
-                &NudgeRecord {
-                    count: 99,
-                    last_nudge_at: Some(now)
-                },
-                now
-            ),
+            decide_nudge(&cfg, None, true, &exhausted, now),
             NudgeDecision::Skip(SkipReason::NotParking)
+        );
+        // Enabled, a human-addressed phrase, with live children + exhausted cap
+        // → HumanWait wins over the later rails.
+        assert_eq!(
+            decide_nudge(&cfg, Some(HUMAN_PHRASE), true, &exhausted, now),
+            NudgeDecision::Skip(SkipReason::HumanWait)
+        );
+        // Enabled, machine-wait phrase, live children, exhausted cap →
+        // HasLiveChildren wins over the cap rail.
+        assert_eq!(
+            decide_nudge(&cfg, Some(MACHINE_PHRASE), true, &exhausted, now),
+            NudgeDecision::Skip(SkipReason::HasLiveChildren)
         );
     }
 }

--- a/crates/trusty-mpm/src/core/idle_nudge.rs
+++ b/crates/trusty-mpm/src/core/idle_nudge.rs
@@ -42,8 +42,8 @@ use uuid::Uuid;
 /// (`0` disables as firmly as `enabled = false`); `cooldown_secs` is the minimum
 /// gap between two nudges to the SAME session; `message` is the literal text
 /// injected (defaults to [`DEFAULT_NUDGE_MESSAGE`]).
-/// Test: `config_idle_nudge_defaults`, `config_idle_nudge_section_parses` in
-/// `core::config`; the field semantics via every `decide_nudge` test below.
+/// Test: `config_idle_nudge_section_parses` in `core::config`; the field
+/// semantics via every `decide_nudge` test below.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct IdleNudgeConfig {
     /// Whether the daemon auto-nudges idle-parked managed sessions.
@@ -109,8 +109,9 @@ impl Default for IdleNudgeConfig {
 /// open, which is the behavior the bundled agent guidance already prescribes.
 /// What: a `'static` instruction string citing #2621 so an operator reading the
 /// pane knows the message was machine-injected, not typed by a human.
-/// Test: `config_idle_nudge_defaults` (in `core::config`) asserts the config
-/// default equals this constant; `default_message_mentions_foreground` below.
+/// Test: `config_idle_nudge_section_parses` (in `core::config`) asserts the
+/// config default equals this constant; `default_message_mentions_foreground`
+/// below.
 pub const DEFAULT_NUDGE_MESSAGE: &str = "[trusty-mpm auto-nudge #2621] Your last turn ended with \
 language that parks the task waiting on a background monitor/notification, but a stopped agent \
 cannot be re-woken by the thing it is waiting on. Resume NOW: block in the FOREGROUND (re-run the \
@@ -275,8 +276,9 @@ pub fn decide_nudge(
 /// the same `SessionManager::list()` call it already makes to correlate the
 /// hook's Claude session id.
 /// Test: `ledger_snapshot_defaults_when_unseen`, `ledger_record_bumps_count`,
-/// `ledger_prune_drops_stale`; `daemon::idle_nudge::run_nudge_prunes_stale_entries`
-/// exercises the production wiring end to end.
+/// `ledger_prune_drops_stale`;
+/// `daemon::idle_nudge::run_nudge_prunes_stale_ledger_entries` exercises the
+/// production wiring end to end.
 #[derive(Debug, Default)]
 pub struct NudgeLedger {
     records: HashMap<Uuid, NudgeRecord>,

--- a/crates/trusty-mpm/src/core/idle_parking.rs
+++ b/crates/trusty-mpm/src/core/idle_parking.rs
@@ -69,6 +69,50 @@ const PARKING_PHRASES: &[&str] = &[
     "will resume once",
 ];
 
+/// The subset of [`PARKING_PHRASES`] that address a HUMAN, not a machine watcher.
+///
+/// Why (#2621 code-critic finding, HIGH 1): "let me know once you approve the
+/// deploy" and "I'll wait for the CI notification" both trip [`detect_idle_parking`]
+/// — and should: both are worth a passive warning/log entry. But only the second
+/// is a genuine idle-park (a stopped agent waiting on a self-spawned watcher that
+/// can never re-wake it); the first is a legitimate, in-scope wait on a HUMAN
+/// decision, which #2621 explicitly requires the auto-nudge to never interrupt.
+/// These four phrases are the ones that name a person as the addressee ("let me
+/// know", "notify me", "ping me") rather than a monitor/notification/CI system, so
+/// they are excluded from nudge eligibility while remaining in the passive
+/// detection/log list unchanged.
+/// What: an exact-match subset of [`PARKING_PHRASES`]; see [`is_nudge_eligible`].
+/// Test: `human_addressed_phrases_are_not_nudge_eligible`,
+/// `machine_wait_phrases_are_nudge_eligible`.
+const HUMAN_ADDRESSED_PHRASES: &[&str] = &[
+    "let me know once",
+    "let me know when the",
+    "notify me when",
+    "ping me when",
+];
+
+/// Is `phrase` eligible to trigger an auto-nudge, or only a passive warning/log?
+///
+/// Why: #2621's auto-nudge must "never nudge a legitimate user-wait". Detection
+/// (this module) stays high-recall and advisory for every [`PARKING_PHRASES`]
+/// entry — a false positive there costs only a spurious warning. Auto-injection
+/// is a real action taken on a human's behalf, so it needs a STRICTER subset:
+/// machine-wait phrases only, excluding [`HUMAN_ADDRESSED_PHRASES`]. Callers that
+/// only log/warn (the `tm hook` stderr line, the daemon's surfacing log) should
+/// use [`detect_idle_parking`]/[`detect_idle_parking_in_transcript`] directly and
+/// ignore this gate; callers that actually inject text into a pane (the #2621
+/// auto-nudge) must additionally require `is_nudge_eligible(phrase)`.
+/// What: `true` for any phrase NOT in [`HUMAN_ADDRESSED_PHRASES`]. A phrase that
+/// never matched [`PARKING_PHRASES`] at all is nonsensical input for this
+/// function but still returns `true` (fail-open on the "is this human-addressed"
+/// question) — callers only ever pass a phrase that `detect_idle_parking` itself
+/// returned, so this case does not arise in practice.
+/// Test: `human_addressed_phrases_are_not_nudge_eligible`,
+/// `machine_wait_phrases_are_nudge_eligible`.
+pub fn is_nudge_eligible(phrase: &str) -> bool {
+    !HUMAN_ADDRESSED_PHRASES.contains(&phrase)
+}
+
 /// Scan an agent's final assistant text for idle-parking language.
 ///
 /// Why: a delegated agent that ends its turn with "monitoring the checks" or
@@ -203,6 +247,51 @@ mod tests {
             assert!(
                 detect_idle_parking(s).is_some(),
                 "incident message must be flagged: {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn human_addressed_phrases_are_not_nudge_eligible() {
+        // A wait on a HUMAN decision must still be detected (for the passive
+        // warning/log) but must NEVER qualify for auto-nudge injection (#2621
+        // code-critic HIGH 1: "never nudge a legitimate user-wait").
+        let msg =
+            "Deploy config is ready. Let me know once you approve the deploy and I'll ship it.";
+        let phrase = detect_idle_parking(msg).expect("must still be flagged for logging");
+        assert_eq!(phrase, "let me know once");
+        assert!(
+            !is_nudge_eligible(phrase),
+            "a human-addressed phrase must not be nudge-eligible"
+        );
+
+        for phrase in HUMAN_ADDRESSED_PHRASES {
+            assert!(
+                !is_nudge_eligible(phrase),
+                "{phrase:?} must be excluded from nudge eligibility"
+            );
+        }
+    }
+
+    #[test]
+    fn machine_wait_phrases_are_nudge_eligible() {
+        // A genuine machine/monitor wait — the actual idle-park anti-pattern —
+        // must remain nudge-eligible.
+        let msg = "I'll wait for the CI notification before continuing.";
+        let phrase = detect_idle_parking(msg).expect("must be flagged");
+        assert_eq!(phrase, "i'll wait for the");
+        assert!(
+            is_nudge_eligible(phrase),
+            "a machine-wait phrase must remain nudge-eligible"
+        );
+
+        for phrase in PARKING_PHRASES {
+            if HUMAN_ADDRESSED_PHRASES.contains(phrase) {
+                continue;
+            }
+            assert!(
+                is_nudge_eligible(phrase),
+                "{phrase:?} is not human-addressed and must be nudge-eligible"
             );
         }
     }

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -43,6 +43,7 @@ pub mod gh_identity;
 pub mod git_identity;
 pub mod home_trust_seed;
 pub mod hook;
+pub mod idle_nudge;
 pub mod idle_parking;
 pub mod instruction_overrides;
 pub mod instruction_pipeline;

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -1297,12 +1297,11 @@ pub async fn ingest_hook(
         handle_session_end(&state, &post.session_id).await;
     }
 
-    // #2621: surface + auto-nudge a turn-end the `tm hook` handler flagged as
-    // idle-parking (`core::idle_parking`, #2610/PR #2620). The gate and the
-    // off-hot-path `tokio::spawn` live in `idle_nudge` so this stays one line.
-    crate::daemon::idle_nudge::spawn_if_parked(&state, post.event, &post.session_id, &post.payload);
-
-    match HookService::new(&state).process(session, post.event, post.payload) {
+    // #2621 (code-critic MEDIUM): the idle-park surface+auto-nudge dispatch
+    // lives inside `HookService::process` (daemon/services/hook_service.rs),
+    // not here — this grandfathered handler is already at its line-cap budget,
+    // and `HookService` already has the same event/session/payload inputs.
+    match HookService::new(Arc::clone(&state)).process(session, post.event, post.payload) {
         HookDecision::Block { reason } => Err(DaemonError::OverseerBlocked { reason }),
         _ => Ok(Json(HookAcceptedResponse {
             accepted: post.event,

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -1297,6 +1297,11 @@ pub async fn ingest_hook(
         handle_session_end(&state, &post.session_id).await;
     }
 
+    // #2621: surface + auto-nudge a turn-end the `tm hook` handler flagged as
+    // idle-parking (`core::idle_parking`, #2610/PR #2620). The gate and the
+    // off-hot-path `tokio::spawn` live in `idle_nudge` so this stays one line.
+    crate::daemon::idle_nudge::spawn_if_parked(&state, post.event, &post.session_id, &post.payload);
+
     match HookService::new(&state).process(session, post.event, post.payload) {
         HookDecision::Block { reason } => Err(DaemonError::OverseerBlocked { reason }),
         _ => Ok(Json(HookAcceptedResponse {

--- a/crates/trusty-mpm/src/daemon/idle_nudge.rs
+++ b/crates/trusty-mpm/src/daemon/idle_nudge.rs
@@ -1,0 +1,447 @@
+//! Daemon-side auto-nudge for idle-parked managed sessions (#2621).
+//!
+//! Why: `core::idle_parking` (shipped in #2610/PR #2620) already flags a
+//! `Stop`/`SubagentStop` whose final assistant message parks the task on a
+//! background monitor/notification, and forwards `payload.idle_parking` to the
+//! daemon. Until now the daemon only recorded the flag; a human still had to
+//! notice the stall and send a manual nudge. This module closes that loop: when
+//! a parking hook arrives it correlates the Claude session to a managed session,
+//! checks the conservative safety rails, and injects a short foreground-block
+//! instruction into the parked pane — the same message a human PM was typing by
+//! hand. It is opt-in (`[idle_nudge].enabled = false` by default) and bounded by
+//! a per-session cap and cooldown so a stuck session is never spammed.
+//! What: [`has_live_children`] is the pure "is the session still working?"
+//! predicate over its delegation list; [`run_nudge`] is the injectable core —
+//! correlate → gate ([`crate::core::idle_nudge::decide_nudge`]) → inject →
+//! record — returning a [`NudgeOutcome`] for logging and tests;
+//! [`maybe_nudge_parked_session`] is the thin `DaemonState` entry point the
+//! `ingest_hook` handler spawns off the hot path. All decision logic lives in
+//! the pure `core::idle_nudge`; this module owns only the effects (config load,
+//! session-manager correlation, tmux inject) and the structured surfacing logs.
+//! Test: `has_live_children_*`, `run_nudge_*` in the inline `tests` module.
+
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use tracing::{info, warn};
+
+use crate::core::agent::{Delegation, DelegationStatus};
+use crate::core::config::MpmConfig;
+use crate::core::hook::HookEvent;
+use crate::core::idle_nudge::{IdleNudgeConfig, NudgeDecision, NudgeLedger, decide_nudge};
+use crate::core::session::SessionId;
+use crate::core::sm::control::Submit;
+use crate::daemon::state::DaemonState;
+use crate::session_manager::{ManagedSessionState, SessionManager};
+
+/// Does this session still have live tracked children? (pure)
+///
+/// Why: the #2621 design note requires the "no live tracked children"
+/// precondition so a session that is genuinely still working — one whose
+/// delegated subagents are mid-flight — is never nudged as if it were stalled.
+/// A leaf engineer agent (the common dogfooding park) has no live children, so
+/// this returns `false` and the nudge proceeds; a PM with a running delegation
+/// returns `true` and is left alone.
+/// What: `true` iff any delegation is [`DelegationStatus::Queued`] or
+/// [`DelegationStatus::Running`]. `Completed`/`Failed`/`Cancelled` delegations
+/// are terminal and do not count. An empty list (no tracked delegations at all)
+/// is `false` — the conservative default that lets a leaf agent be nudged.
+/// Test: `has_live_children_true_for_running`, `has_live_children_false_when_terminal`,
+/// `has_live_children_false_when_empty`.
+pub fn has_live_children(delegations: &[Delegation]) -> bool {
+    delegations.iter().any(|d| {
+        matches!(
+            d.status,
+            DelegationStatus::Queued | DelegationStatus::Running
+        )
+    })
+}
+
+/// The result of one nudge attempt, for structured logging and tests.
+///
+/// Why: `run_nudge` both acts and must explain what it did (or why it did not);
+/// a single enum carries the outcome without a side channel and gives the unit
+/// tests a precise assertion target.
+/// What: correlation miss, a skip with its [`crate::core::idle_nudge::SkipReason`],
+/// a successful nudge, or an inject failure carrying the error text.
+/// Test: every `run_nudge_*` test asserts on this.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NudgeOutcome {
+    /// No Active managed session correlates to the hook's Claude session id —
+    /// the parked runtime is unmanaged, so there is no pane to nudge.
+    NoManagedSession,
+    /// A safety rail suppressed the nudge; `.0` names the first rail that failed.
+    Skipped(crate::core::idle_nudge::SkipReason),
+    /// The nudge was injected into the pane.
+    Nudged,
+    /// The nudge decision passed but the tmux inject failed; `.0` is the error.
+    InjectFailed(String),
+}
+
+/// Correlate → gate → inject → record for one parking hook (injectable core).
+///
+/// Why: keeping the effectful sequence in one function that takes its
+/// collaborators explicitly (manager, ledger, delegations, config) — rather than
+/// reaching into `DaemonState` — makes it unit-testable against a
+/// `FakeNoopTmuxDriver` exactly like `idle_reaper::run_one_sweep`, with no real
+/// tmux and no on-disk config.
+/// What: (1) finds the single Active managed session whose `claude_session_id`
+/// matches `claude_session_id` (→ [`NudgeOutcome::NoManagedSession`] when none);
+/// (2) computes [`has_live_children`] from `delegations`; (3) under the ledger
+/// lock, snapshots the session's [`crate::core::idle_nudge::NudgeRecord`] and
+/// runs [`decide_nudge`] (with `parking = true` — the caller only invokes this
+/// on a real park); (4) on [`NudgeDecision::Nudge`] records the delivery in the
+/// ledger *before* releasing the lock (so a concurrent second parking hook
+/// cannot double-nudge) and then injects `cfg.message` with [`Submit::Enter`];
+/// (5) returns the [`NudgeOutcome`]. The record-before-inject ordering means a
+/// failed inject still consumes one nudge budget slot — a deliberately
+/// conservative bias toward fewer nudges. Bumps `last_activity_at` via the
+/// manager's normal `inject` path.
+/// Test: `run_nudge_injects_when_idle_and_enabled`,
+/// `run_nudge_skips_when_disabled`, `run_nudge_skips_when_live_children`,
+/// `run_nudge_no_managed_session`, `run_nudge_respects_cap`.
+pub async fn run_nudge(
+    mgr: &SessionManager,
+    ledger: &parking_lot::Mutex<NudgeLedger>,
+    delegations: &[Delegation],
+    cfg: &IdleNudgeConfig,
+    claude_session_id: &str,
+    now: DateTime<Utc>,
+) -> NudgeOutcome {
+    // 1. Correlate the Claude session id to an Active managed session.
+    let records = mgr.list().await;
+    let Some(record) = records.iter().find(|r| {
+        matches!(r.state, ManagedSessionState::Active)
+            && r.claude_session_id.as_deref() == Some(claude_session_id)
+    }) else {
+        return NudgeOutcome::NoManagedSession;
+    };
+    let managed_id = record.id;
+
+    // 2. Precondition: is the session still working?
+    let live_children = has_live_children(delegations);
+
+    // 3. Gate under the ledger lock; record the delivery before releasing it so a
+    //    concurrent parking hook for the same session cannot double-nudge.
+    let decision = {
+        let mut guard = ledger.lock();
+        let snapshot = guard.snapshot(managed_id.0);
+        let decision = decide_nudge(cfg, true, live_children, &snapshot, now);
+        if decision == NudgeDecision::Nudge {
+            guard.record_nudge(managed_id.0, now);
+        }
+        decision
+    };
+
+    match decision {
+        NudgeDecision::Skip(reason) => NudgeOutcome::Skipped(reason),
+        NudgeDecision::Nudge => match mgr.inject(&managed_id, &cfg.message, Submit::Enter).await {
+            Ok(()) => NudgeOutcome::Nudged,
+            Err(e) => NudgeOutcome::InjectFailed(e.to_string()),
+        },
+    }
+}
+
+/// Spawn the surface-and-nudge task iff this hook is a flagged park (#2621).
+///
+/// Why: the `ingest_hook` handler must trigger the nudge without adding latency
+/// to (or a failure path onto) the hook response, and without bloating the
+/// already-oversized `api.rs`. Concentrating the "is this a park?" gate and the
+/// `tokio::spawn` here keeps the handler's footprint to a single call.
+/// What: returns immediately unless `event` is `Stop`/`SubagentStop` AND
+/// `payload["idle_parking"] == true` (the flag `tm hook` sets via
+/// `core::idle_parking`). When it matches, it clones the owned data the detached
+/// task needs (`session_id`, optional `idle_parking_phrase`) and spawns
+/// [`maybe_nudge_parked_session`]. Fire-and-forget — the task's own best-effort
+/// logging is the only observation of its result.
+/// Test: the gate is trivial routing; the spawned work is covered by the
+/// `run_nudge_*` tests. Exercised end to end by any daemon integration test that
+/// posts a parking `Stop` hook.
+pub fn spawn_if_parked(
+    state: &Arc<DaemonState>,
+    event: HookEvent,
+    session_id: &str,
+    payload: &serde_json::Value,
+) {
+    if !matches!(event, HookEvent::Stop | HookEvent::SubagentStop) {
+        return;
+    }
+    if payload
+        .get("idle_parking")
+        .and_then(serde_json::Value::as_bool)
+        != Some(true)
+    {
+        return;
+    }
+    let state = Arc::clone(state);
+    let session_id = session_id.to_string();
+    let phrase = payload
+        .get("idle_parking_phrase")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    tokio::spawn(async move {
+        maybe_nudge_parked_session(&state, &session_id, phrase.as_deref()).await;
+    });
+}
+
+/// `DaemonState` entry point: surface a park and auto-nudge if enabled (#2621).
+///
+/// Why: the `ingest_hook` handler spawns this off the request hot path when a
+/// `Stop`/`SubagentStop` arrives with `payload.idle_parking = true`. It performs
+/// the daemon-side surfacing (a loud structured `warn!` so the stall is visible
+/// in the daemon log / event stream even when nudging is off) and, when the
+/// feature is enabled, drives [`run_nudge`] against the live session manager.
+/// What: emits the surfacing log; loads `[idle_nudge]` via
+/// [`MpmConfig::load_default`]; resolves the session manager and this session's
+/// tracked delegations (keyed by the Claude session UUID); calls [`run_nudge`];
+/// and logs the [`NudgeOutcome`]. Entirely best-effort — every failure path is
+/// logged and swallowed so it can never affect the hook response. A
+/// non-UUID `claude_session_id` (or one with no tracked delegations) simply
+/// yields an empty delegation list, which is the safe default.
+/// Test: exercised indirectly by `run_nudge_*`; the config-load + surfacing shell
+/// is side-effect-only (a `tracing` log + `DaemonState` reads).
+pub async fn maybe_nudge_parked_session(
+    state: &Arc<DaemonState>,
+    claude_session_id: &str,
+    phrase: Option<&str>,
+) {
+    // Daemon-side surfacing (#2621 part 1): make the park a first-class, greppable
+    // signal in the daemon log regardless of whether nudging is enabled.
+    warn!(
+        target: "trusty_mpm::idle_parking",
+        session = %claude_session_id,
+        phrase = phrase.unwrap_or("<unknown>"),
+        "idle-parking detected on a managed session turn-end (#2621); a stopped agent cannot be re-woken by a self-spawned monitor"
+    );
+
+    let cfg = MpmConfig::load_default().idle_nudge;
+    if !cfg.enabled {
+        info!(
+            target: "trusty_mpm::idle_parking",
+            session = %claude_session_id,
+            "auto-nudge disabled ([idle_nudge].enabled = false); surfaced only"
+        );
+        return;
+    }
+
+    let delegations = uuid::Uuid::parse_str(claude_session_id)
+        .map(|u| state.delegations_for(SessionId(u)))
+        .unwrap_or_default();
+
+    let mgr = state.session_manager().await;
+    let outcome = run_nudge(
+        &mgr,
+        state.nudge_ledger(),
+        &delegations,
+        &cfg,
+        claude_session_id,
+        Utc::now(),
+    )
+    .await;
+
+    match &outcome {
+        NudgeOutcome::Nudged => info!(
+            target: "trusty_mpm::idle_parking",
+            session = %claude_session_id,
+            "auto-nudged idle-parked managed session (#2621)"
+        ),
+        NudgeOutcome::Skipped(reason) => info!(
+            target: "trusty_mpm::idle_parking",
+            session = %claude_session_id,
+            reason = reason.tag(),
+            "auto-nudge skipped (#2621)"
+        ),
+        NudgeOutcome::NoManagedSession => info!(
+            target: "trusty_mpm::idle_parking",
+            session = %claude_session_id,
+            "auto-nudge skipped: no Active managed session correlates to this Claude session (#2621)"
+        ),
+        NudgeOutcome::InjectFailed(e) => warn!(
+            target: "trusty_mpm::idle_parking",
+            session = %claude_session_id,
+            error = %e,
+            "auto-nudge inject failed (#2621)"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent::{Delegation, ModelTier};
+    use crate::core::idle_nudge::SkipReason;
+    use crate::core::session::SessionId;
+    use crate::session_manager::{FakeNoopTmuxDriver, ManagedSessionId};
+    use tempfile::TempDir;
+
+    fn enabled_cfg() -> IdleNudgeConfig {
+        IdleNudgeConfig {
+            enabled: true,
+            max_nudges_per_session: 2,
+            cooldown_secs: 300,
+            message: "resume in the foreground now".into(),
+        }
+    }
+
+    fn delegation_with(status: DelegationStatus) -> Delegation {
+        let mut d = Delegation::new(
+            SessionId::new(),
+            None,
+            "rust-engineer",
+            ModelTier::Sonnet,
+            "x",
+        );
+        d.status = status;
+        d
+    }
+
+    #[test]
+    fn has_live_children_true_for_running() {
+        assert!(has_live_children(&[delegation_with(
+            DelegationStatus::Running
+        )]));
+        assert!(has_live_children(&[delegation_with(
+            DelegationStatus::Queued
+        )]));
+    }
+
+    #[test]
+    fn has_live_children_false_when_terminal() {
+        assert!(!has_live_children(&[
+            delegation_with(DelegationStatus::Completed),
+            delegation_with(DelegationStatus::Failed),
+            delegation_with(DelegationStatus::Cancelled),
+        ]));
+    }
+
+    #[test]
+    fn has_live_children_false_when_empty() {
+        assert!(!has_live_children(&[]));
+    }
+
+    /// Build a manager with one Active managed session correlated to a Claude
+    /// session id. Mirrors the `idle_reaper` sweep-test scaffold: create →
+    /// stop → resume drives the record to Active under the no-op tmux driver.
+    async fn manager_with_active_correlated(
+        dir: &TempDir,
+        claude_id: &str,
+    ) -> (Arc<SessionManager>, ManagedSessionId) {
+        let mgr = SessionManager::new(dir.path(), Arc::new(FakeNoopTmuxDriver))
+            .await
+            .expect("manager");
+        let rec = mgr
+            .create(
+                "parked task".into(),
+                Some(dir.path().to_path_buf()),
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("create");
+        mgr.stop(&rec.id).await.expect("stop");
+        mgr.resume(&rec.id).await.expect("resume");
+        mgr.set_claude_session_id(&rec.id, claude_id)
+            .await
+            .expect("set claude id");
+        (Arc::new(mgr), rec.id)
+    }
+
+    #[tokio::test]
+    async fn run_nudge_injects_when_idle_and_enabled() {
+        let dir = TempDir::new().unwrap();
+        let claude_id = uuid::Uuid::new_v4().to_string();
+        let (mgr, id) = manager_with_active_correlated(&dir, &claude_id).await;
+        let ledger = parking_lot::Mutex::new(NudgeLedger::new());
+        let cfg = enabled_cfg();
+        let now = Utc::now();
+
+        let outcome = run_nudge(&mgr, &ledger, &[], &cfg, &claude_id, now).await;
+        assert_eq!(outcome, NudgeOutcome::Nudged);
+        // The ledger must record exactly one delivery for the managed session.
+        assert_eq!(ledger.lock().snapshot(id.0).count, 1);
+    }
+
+    #[tokio::test]
+    async fn run_nudge_skips_when_disabled() {
+        let dir = TempDir::new().unwrap();
+        let claude_id = uuid::Uuid::new_v4().to_string();
+        let (mgr, id) = manager_with_active_correlated(&dir, &claude_id).await;
+        let ledger = parking_lot::Mutex::new(NudgeLedger::new());
+        let mut cfg = enabled_cfg();
+        cfg.enabled = false;
+
+        let outcome = run_nudge(&mgr, &ledger, &[], &cfg, &claude_id, Utc::now()).await;
+        assert_eq!(outcome, NudgeOutcome::Skipped(SkipReason::Disabled));
+        assert_eq!(
+            ledger.lock().snapshot(id.0).count,
+            0,
+            "no delivery recorded"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_nudge_skips_when_live_children() {
+        let dir = TempDir::new().unwrap();
+        let claude_id = uuid::Uuid::new_v4().to_string();
+        let (mgr, _id) = manager_with_active_correlated(&dir, &claude_id).await;
+        let ledger = parking_lot::Mutex::new(NudgeLedger::new());
+        let cfg = enabled_cfg();
+        let children = [delegation_with(DelegationStatus::Running)];
+
+        let outcome = run_nudge(&mgr, &ledger, &children, &cfg, &claude_id, Utc::now()).await;
+        assert_eq!(outcome, NudgeOutcome::Skipped(SkipReason::HasLiveChildren));
+    }
+
+    #[tokio::test]
+    async fn run_nudge_no_managed_session() {
+        let dir = TempDir::new().unwrap();
+        // Correlate the manager to a DIFFERENT claude id than we nudge with.
+        let (mgr, _id) =
+            manager_with_active_correlated(&dir, &uuid::Uuid::new_v4().to_string()).await;
+        let ledger = parking_lot::Mutex::new(NudgeLedger::new());
+        let cfg = enabled_cfg();
+
+        let outcome = run_nudge(
+            &mgr,
+            &ledger,
+            &[],
+            &cfg,
+            &uuid::Uuid::new_v4().to_string(),
+            Utc::now(),
+        )
+        .await;
+        assert_eq!(outcome, NudgeOutcome::NoManagedSession);
+    }
+
+    #[tokio::test]
+    async fn run_nudge_respects_cap() {
+        let dir = TempDir::new().unwrap();
+        let claude_id = uuid::Uuid::new_v4().to_string();
+        let (mgr, id) = manager_with_active_correlated(&dir, &claude_id).await;
+        let ledger = parking_lot::Mutex::new(NudgeLedger::new());
+        let mut cfg = enabled_cfg();
+        cfg.max_nudges_per_session = 1;
+        cfg.cooldown_secs = 0; // isolate the cap from the cooldown
+
+        // First nudge lands.
+        let now = Utc::now();
+        assert_eq!(
+            run_nudge(&mgr, &ledger, &[], &cfg, &claude_id, now).await,
+            NudgeOutcome::Nudged
+        );
+        // Second (cooldown elapsed) is blocked by the per-session cap.
+        let outcome = run_nudge(
+            &mgr,
+            &ledger,
+            &[],
+            &cfg,
+            &claude_id,
+            now + chrono::Duration::seconds(1),
+        )
+        .await;
+        assert_eq!(outcome, NudgeOutcome::Skipped(SkipReason::CapExhausted));
+        assert_eq!(ledger.lock().snapshot(id.0).count, 1, "cap holds at 1");
+    }
+}

--- a/crates/trusty-mpm/src/daemon/idle_nudge.rs
+++ b/crates/trusty-mpm/src/daemon/idle_nudge.rs
@@ -78,38 +78,56 @@ pub enum NudgeOutcome {
     InjectFailed(String),
 }
 
-/// Correlate → gate → inject → record for one parking hook (injectable core).
+/// Correlate → prune → gate → inject → record for one parking hook (injectable
+/// core).
 ///
 /// Why: keeping the effectful sequence in one function that takes its
 /// collaborators explicitly (manager, ledger, delegations, config) — rather than
 /// reaching into `DaemonState` — makes it unit-testable against a
 /// `FakeNoopTmuxDriver` exactly like `idle_reaper::run_one_sweep`, with no real
 /// tmux and no on-disk config.
-/// What: (1) finds the single Active managed session whose `claude_session_id`
-/// matches `claude_session_id` (→ [`NudgeOutcome::NoManagedSession`] when none);
-/// (2) computes [`has_live_children`] from `delegations`; (3) under the ledger
-/// lock, snapshots the session's [`crate::core::idle_nudge::NudgeRecord`] and
-/// runs [`decide_nudge`] (with `parking = true` — the caller only invokes this
-/// on a real park); (4) on [`NudgeDecision::Nudge`] records the delivery in the
-/// ledger *before* releasing the lock (so a concurrent second parking hook
-/// cannot double-nudge) and then injects `cfg.message` with [`Submit::Enter`];
-/// (5) returns the [`NudgeOutcome`]. The record-before-inject ordering means a
+/// What: (1) lists all managed sessions and immediately
+/// [`NudgeLedger::prune`]s the ledger down to that live set — this is the
+/// ONLY production call site that prunes the ledger (#2621 code-critic HIGH
+/// 2), so it must run on every attempt regardless of the outcome below, not
+/// just on a successful correlation; (2) finds the single Active managed
+/// session whose `claude_session_id` matches `claude_session_id` (→
+/// [`NudgeOutcome::NoManagedSession`] when none); (3) computes
+/// [`has_live_children`] from `delegations`; (4) under the ledger lock,
+/// snapshots the session's [`crate::core::idle_nudge::NudgeRecord`] and runs
+/// [`decide_nudge`] with `phrase` (the caller only invokes this on a real
+/// park, so `phrase` is normally `Some`; `decide_nudge` itself rejects a
+/// human-addressed phrase via [`crate::core::idle_parking::is_nudge_eligible`]);
+/// (5) on [`NudgeDecision::Nudge`] records the delivery in the ledger *before*
+/// releasing the lock (so a concurrent second parking hook cannot
+/// double-nudge) and then injects `cfg.message` with [`Submit::Enter`]; (6)
+/// returns the [`NudgeOutcome`]. The record-before-inject ordering means a
 /// failed inject still consumes one nudge budget slot — a deliberately
 /// conservative bias toward fewer nudges. Bumps `last_activity_at` via the
 /// manager's normal `inject` path.
 /// Test: `run_nudge_injects_when_idle_and_enabled`,
 /// `run_nudge_skips_when_disabled`, `run_nudge_skips_when_live_children`,
-/// `run_nudge_no_managed_session`, `run_nudge_respects_cap`.
+/// `run_nudge_skips_human_wait_phrase`, `run_nudge_no_managed_session`,
+/// `run_nudge_respects_cap`, `run_nudge_prunes_stale_ledger_entries`.
 pub async fn run_nudge(
     mgr: &SessionManager,
     ledger: &parking_lot::Mutex<NudgeLedger>,
     delegations: &[Delegation],
     cfg: &IdleNudgeConfig,
     claude_session_id: &str,
+    phrase: Option<&str>,
     now: DateTime<Utc>,
 ) -> NudgeOutcome {
-    // 1. Correlate the Claude session id to an Active managed session.
+    // 1. Correlate the Claude session id to an Active managed session, and — on
+    //    the SAME `mgr.list()` call — prune the ledger to the current live set
+    //    (#2621 code-critic HIGH 2: this is the only place `prune` is called in
+    //    production; it must run unconditionally, before the correlation
+    //    outcome is known, so the ledger never grows unbounded even for
+    //    sessions that stop correlating).
     let records = mgr.list().await;
+    let live_ids: std::collections::HashSet<uuid::Uuid> = records.iter().map(|r| r.id.0).collect();
+    ledger.lock().prune(&live_ids);
+
     let Some(record) = records.iter().find(|r| {
         matches!(r.state, ManagedSessionState::Active)
             && r.claude_session_id.as_deref() == Some(claude_session_id)
@@ -126,7 +144,7 @@ pub async fn run_nudge(
     let decision = {
         let mut guard = ledger.lock();
         let snapshot = guard.snapshot(managed_id.0);
-        let decision = decide_nudge(cfg, true, live_children, &snapshot, now);
+        let decision = decide_nudge(cfg, phrase, live_children, &snapshot, now);
         if decision == NudgeDecision::Nudge {
             guard.record_nudge(managed_id.0, now);
         }
@@ -235,6 +253,7 @@ pub async fn maybe_nudge_parked_session(
         &delegations,
         &cfg,
         claude_session_id,
+        phrase,
         Utc::now(),
     )
     .await;
@@ -273,6 +292,13 @@ mod tests {
     use crate::core::session::SessionId;
     use crate::session_manager::{FakeNoopTmuxDriver, ManagedSessionId};
     use tempfile::TempDir;
+
+    /// A machine-wait phrase (nudge-eligible), the standard "genuinely parked"
+    /// input for these tests. Must match a `core::idle_parking::PARKING_PHRASES`
+    /// entry that is NOT in `HUMAN_ADDRESSED_PHRASES`.
+    const MACHINE_PHRASE: &str = "i'll wait for the";
+    /// A human-addressed phrase (NOT nudge-eligible) for `run_nudge_skips_human_wait_phrase`.
+    const HUMAN_PHRASE: &str = "let me know once";
 
     fn enabled_cfg() -> IdleNudgeConfig {
         IdleNudgeConfig {
@@ -357,7 +383,16 @@ mod tests {
         let cfg = enabled_cfg();
         let now = Utc::now();
 
-        let outcome = run_nudge(&mgr, &ledger, &[], &cfg, &claude_id, now).await;
+        let outcome = run_nudge(
+            &mgr,
+            &ledger,
+            &[],
+            &cfg,
+            &claude_id,
+            Some(MACHINE_PHRASE),
+            now,
+        )
+        .await;
         assert_eq!(outcome, NudgeOutcome::Nudged);
         // The ledger must record exactly one delivery for the managed session.
         assert_eq!(ledger.lock().snapshot(id.0).count, 1);
@@ -372,7 +407,16 @@ mod tests {
         let mut cfg = enabled_cfg();
         cfg.enabled = false;
 
-        let outcome = run_nudge(&mgr, &ledger, &[], &cfg, &claude_id, Utc::now()).await;
+        let outcome = run_nudge(
+            &mgr,
+            &ledger,
+            &[],
+            &cfg,
+            &claude_id,
+            Some(MACHINE_PHRASE),
+            Utc::now(),
+        )
+        .await;
         assert_eq!(outcome, NudgeOutcome::Skipped(SkipReason::Disabled));
         assert_eq!(
             ledger.lock().snapshot(id.0).count,
@@ -390,8 +434,46 @@ mod tests {
         let cfg = enabled_cfg();
         let children = [delegation_with(DelegationStatus::Running)];
 
-        let outcome = run_nudge(&mgr, &ledger, &children, &cfg, &claude_id, Utc::now()).await;
+        let outcome = run_nudge(
+            &mgr,
+            &ledger,
+            &children,
+            &cfg,
+            &claude_id,
+            Some(MACHINE_PHRASE),
+            Utc::now(),
+        )
+        .await;
         assert_eq!(outcome, NudgeOutcome::Skipped(SkipReason::HasLiveChildren));
+    }
+
+    #[tokio::test]
+    async fn run_nudge_skips_human_wait_phrase() {
+        // #2621 code-critic HIGH 1: a session parked on a HUMAN-addressed wait
+        // ("let me know once…") must never be nudged end to end, even though it
+        // correlates cleanly and has no live children.
+        let dir = TempDir::new().unwrap();
+        let claude_id = uuid::Uuid::new_v4().to_string();
+        let (mgr, id) = manager_with_active_correlated(&dir, &claude_id).await;
+        let ledger = parking_lot::Mutex::new(NudgeLedger::new());
+        let cfg = enabled_cfg();
+
+        let outcome = run_nudge(
+            &mgr,
+            &ledger,
+            &[],
+            &cfg,
+            &claude_id,
+            Some(HUMAN_PHRASE),
+            Utc::now(),
+        )
+        .await;
+        assert_eq!(outcome, NudgeOutcome::Skipped(SkipReason::HumanWait));
+        assert_eq!(
+            ledger.lock().snapshot(id.0).count,
+            0,
+            "a human-wait skip must not consume a nudge budget slot"
+        );
     }
 
     #[tokio::test]
@@ -409,6 +491,7 @@ mod tests {
             &[],
             &cfg,
             &uuid::Uuid::new_v4().to_string(),
+            Some(MACHINE_PHRASE),
             Utc::now(),
         )
         .await;
@@ -428,7 +511,16 @@ mod tests {
         // First nudge lands.
         let now = Utc::now();
         assert_eq!(
-            run_nudge(&mgr, &ledger, &[], &cfg, &claude_id, now).await,
+            run_nudge(
+                &mgr,
+                &ledger,
+                &[],
+                &cfg,
+                &claude_id,
+                Some(MACHINE_PHRASE),
+                now
+            )
+            .await,
             NudgeOutcome::Nudged
         );
         // Second (cooldown elapsed) is blocked by the per-session cap.
@@ -438,10 +530,56 @@ mod tests {
             &[],
             &cfg,
             &claude_id,
+            Some(MACHINE_PHRASE),
             now + chrono::Duration::seconds(1),
         )
         .await;
         assert_eq!(outcome, NudgeOutcome::Skipped(SkipReason::CapExhausted));
         assert_eq!(ledger.lock().snapshot(id.0).count, 1, "cap holds at 1");
+    }
+
+    #[tokio::test]
+    async fn run_nudge_prunes_stale_ledger_entries() {
+        // #2621 code-critic HIGH 2: `run_nudge` must prune the ledger against the
+        // CURRENT managed-session set on every call, not just accumulate entries
+        // for the lifetime of the daemon. Build a ledger with a stale entry (a
+        // UUID no managed session will ever correlate to) alongside a real,
+        // correlated session; after one `run_nudge` call the stale entry must be
+        // gone while the real session's own record survives.
+        let dir = TempDir::new().unwrap();
+        let claude_id = uuid::Uuid::new_v4().to_string();
+        let (mgr, id) = manager_with_active_correlated(&dir, &claude_id).await;
+        let ledger = parking_lot::Mutex::new(NudgeLedger::new());
+        let stale_id = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        ledger.lock().record_nudge(stale_id, now);
+        ledger
+            .lock()
+            .record_nudge(id.0, now - chrono::Duration::seconds(10_000));
+
+        let cfg = enabled_cfg();
+        let outcome = run_nudge(
+            &mgr,
+            &ledger,
+            &[],
+            &cfg,
+            &claude_id,
+            Some(MACHINE_PHRASE),
+            now,
+        )
+        .await;
+        assert_eq!(outcome, NudgeOutcome::Nudged);
+
+        let guard = ledger.lock();
+        assert_eq!(
+            guard.snapshot(stale_id),
+            crate::core::idle_nudge::NudgeRecord::default(),
+            "stale ledger entry for a non-existent session must be pruned"
+        );
+        assert_eq!(
+            guard.snapshot(id.0).count,
+            2,
+            "the real session's record survives pruning and reflects this nudge"
+        );
     }
 }

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -18,6 +18,7 @@ pub mod discover;
 pub mod discovery;
 pub mod doctor;
 pub mod error;
+pub mod idle_nudge;
 pub mod idle_reaper;
 pub mod llm_overseer;
 pub mod lock;

--- a/crates/trusty-mpm/src/daemon/services/hook_service.rs
+++ b/crates/trusty-mpm/src/daemon/services/hook_service.rs
@@ -7,12 +7,15 @@
 //! `overseer_context` functions that lived in `api.rs`.
 //! What: [`HookDecision`] is the daemon-facing verdict; [`HookService`] builds
 //! the [`OverseerContext`] from a raw payload, consults the configured
-//! overseer, audits the verdict, applies output optimization, and records the
-//! event in the ring buffer. [`FileChanged`](HookEvent::FileChanged) events are
-//! pre-filtered by [`is_coding_file`] so OS / browser noise never enters the
-//! ring buffer.
+//! overseer, audits the verdict, applies output optimization, dispatches the
+//! idle-park auto-nudge (`daemon::idle_nudge::spawn_if_parked`, #2621), and
+//! records the event in the ring buffer. [`FileChanged`](HookEvent::FileChanged)
+//! events are pre-filtered by [`is_coding_file`] so OS / browser noise never
+//! enters the ring buffer.
 //! Test: `cargo test -p trusty-mpm-daemon services::hook` covers the
 //! disabled-overseer fast path, the decision conversion, and the file filter.
+
+use std::sync::Arc;
 
 use crate::core::hook::{HookEvent, HookEventRecord};
 use crate::core::overseer::{OverseerContext, OverseerDecision};
@@ -179,18 +182,22 @@ impl HookDecision {
 
 /// Hook event processing over the shared daemon state.
 ///
-/// Why: a borrowed facade — the handler builds one per request and delegates
-/// the whole relay pipeline to it, so `ingest_hook` shrinks to a few lines.
-/// What: holds a borrow of [`DaemonState`]; [`process`](Self::process) runs the
-/// overseer-audit-optimize-record pipeline for one event.
+/// Why: the handler builds one per request and delegates the whole relay
+/// pipeline to it, so `ingest_hook` shrinks to a few lines. Owns an `Arc`
+/// (rather than borrowing `&DaemonState`, as it did before #2621) because
+/// [`process`](Self::process) dispatches the idle-park auto-nudge
+/// (`daemon::idle_nudge::spawn_if_parked`) onto a detached `tokio::spawn` task,
+/// which needs an owned, 'static handle to outlive the request.
+/// What: holds an [`Arc<DaemonState>`]; [`process`](Self::process) runs the
+/// overseer-audit-optimize-nudge-record pipeline for one event.
 /// Test: the module's `#[cfg(test)]` suite.
-pub struct HookService<'s> {
-    state: &'s DaemonState,
+pub struct HookService {
+    state: Arc<DaemonState>,
 }
 
-impl<'s> HookService<'s> {
+impl HookService {
     /// Build a service bound to `state`.
-    pub fn new(state: &'s DaemonState) -> Self {
+    pub fn new(state: Arc<DaemonState>) -> Self {
         Self { state }
     }
 
@@ -198,8 +205,9 @@ impl<'s> HookService<'s> {
     ///
     /// Why: this is the daemon's full hook pipeline — consult the overseer on
     /// tool-use events (auditing every verdict), compress `PostToolUse` output,
-    /// then append the event to the ring buffer. Keeping it in one method makes
-    /// the order of those steps explicit and testable.
+    /// trigger the idle-park auto-nudge, then append the event to the ring
+    /// buffer. Keeping it in one method makes the order of those steps explicit
+    /// and testable.
     /// What: builds an [`OverseerContext`], runs the overseer when it is
     /// enabled, records the event (unless blocked), and returns the verdict. A
     /// `Block` short-circuits before the event is recorded.
@@ -225,6 +233,20 @@ impl<'s> HookService<'s> {
                 tracing::info!("overseer auto-response for {session:?}: {text}");
             }
         }
+
+        // 1b (#2621, code-critic MEDIUM): surface + auto-nudge a turn-end
+        // flagged as idle-parking. Lives here (not the already-oversized,
+        // grandfathered `api.rs::ingest_hook`) because this is the daemon's one
+        // hook-processing pipeline and already has the event/session/payload
+        // this needs; `spawn_if_parked` itself no-ops for any event other than
+        // `Stop`/`SubagentStop` with `payload.idle_parking == true`, spawning a
+        // detached task off this synchronous method.
+        crate::daemon::idle_nudge::spawn_if_parked(
+            &self.state,
+            event,
+            &session.0.to_string(),
+            &payload,
+        );
 
         // 2. PostToolUse: compress tool output before it enters the ring buffer.
         if event == HookEvent::PostToolUse {
@@ -339,13 +361,13 @@ mod tests {
     fn process_records_event_with_disabled_overseer() {
         // With the overseer disabled (the default), a known event must be
         // recorded and the verdict is Allow.
-        let state = DaemonState::new();
+        let state = Arc::new(DaemonState::new());
         let id = SessionId::new();
         let mut s = Session::new(id, "/tmp/p", ControlModel::Tmux, None);
         s.status = SessionStatus::Active;
         state.register_session(s);
 
-        let svc = HookService::new(&state);
+        let svc = HookService::new(Arc::clone(&state));
         let decision = svc.process(
             id,
             HookEvent::PreToolUse,
@@ -431,13 +453,13 @@ mod tests {
     fn file_changed_noise_is_not_recorded() {
         // A Chrome temp-file `FileChanged` event must be silently dropped and
         // must not appear in the ring buffer.
-        let state = DaemonState::new();
+        let state = Arc::new(DaemonState::new());
         let id = SessionId::new();
         let mut s = Session::new(id, "/tmp/p", ControlModel::Tmux, None);
         s.status = SessionStatus::Active;
         state.register_session(s);
 
-        let svc = HookService::new(&state);
+        let svc = HookService::new(Arc::clone(&state));
         let decision = svc.process(
             id,
             HookEvent::FileChanged,
@@ -454,13 +476,13 @@ mod tests {
     fn file_changed_source_file_is_recorded() {
         // A Rust source file must pass through the filter and enter the ring
         // buffer unchanged.
-        let state = DaemonState::new();
+        let state = Arc::new(DaemonState::new());
         let id = SessionId::new();
         let mut s = Session::new(id, "/tmp/p", ControlModel::Tmux, None);
         s.status = SessionStatus::Active;
         state.register_session(s);
 
-        let svc = HookService::new(&state);
+        let svc = HookService::new(Arc::clone(&state));
         let decision = svc.process(
             id,
             HookEvent::FileChanged,
@@ -476,13 +498,13 @@ mod tests {
     fn non_file_changed_events_bypass_filter() {
         // Non-FileChanged events must always be recorded regardless of any
         // payload content — the filter is FileChanged-only.
-        let state = DaemonState::new();
+        let state = Arc::new(DaemonState::new());
         let id = SessionId::new();
         let mut s = Session::new(id, "/tmp/p", ControlModel::Tmux, None);
         s.status = SessionStatus::Active;
         state.register_session(s);
 
-        let svc = HookService::new(&state);
+        let svc = HookService::new(Arc::clone(&state));
         let decision = svc.process(id, HookEvent::SessionStart, serde_json::json!({}));
         assert_eq!(decision, HookDecision::Allow);
         assert_eq!(state.recent_hook_events().len(), 1);

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -328,11 +328,18 @@ pub struct DaemonState {
     /// lock) lets the `ingest_hook` nudge path read a session's
     /// [`crate::core::idle_nudge::NudgeRecord`] and record deliveries without a
     /// new subsystem. In-memory only — a restart resetting the counters only
-    /// re-arms the already-conservative nudge, never spams.
-    /// What: a [`crate::core::idle_nudge::NudgeLedger`] keyed by the daemon
-    /// [`SessionId`]'s UUID.
-    /// Test: `daemon::idle_nudge` unit tests exercise the decide→record path; the
-    /// ledger's own semantics are covered by `core::idle_nudge` tests.
+    /// re-arms the already-conservative nudge, never spams. Growth is bounded:
+    /// `daemon::idle_nudge::run_nudge` prunes entries for any session no longer
+    /// known to the session store on every nudge attempt (#2621 code-critic
+    /// HIGH 2), so this never accumulates permanent per-session entries for the
+    /// daemon's lifetime.
+    /// What: a [`crate::core::idle_nudge::NudgeLedger`] keyed by the managed
+    /// session's [`crate::session_manager::ManagedSessionId`] inner UUID — NOT
+    /// this daemon's own [`SessionId`] (the two are distinct id spaces; the
+    /// nudge always targets a tmux-managed session, correlated via
+    /// `claude_session_id`).
+    /// Test: `daemon::idle_nudge` unit tests exercise the decide→record→prune
+    /// path; the ledger's own semantics are covered by `core::idle_nudge` tests.
     pub(super) nudge_ledger: parking_lot::Mutex<crate::core::idle_nudge::NudgeLedger>,
 }
 

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -320,6 +320,20 @@ pub struct DaemonState {
     /// Test: `crate::daemon::managed_routes::provision_status` tests exercise
     /// the async state machine through the router.
     pub provisioning: crate::daemon::provisioning::ProvisioningRegistry,
+    /// Per-session idle-park auto-nudge ledger (#2621).
+    ///
+    /// Why: the auto-nudge spam guards — a per-session cap and a cooldown — need
+    /// history that survives across hook receipts but not across a daemon
+    /// restart. Owning it here (behind a `parking_lot::Mutex`, like `optimizer`'s
+    /// lock) lets the `ingest_hook` nudge path read a session's
+    /// [`crate::core::idle_nudge::NudgeRecord`] and record deliveries without a
+    /// new subsystem. In-memory only — a restart resetting the counters only
+    /// re-arms the already-conservative nudge, never spams.
+    /// What: a [`crate::core::idle_nudge::NudgeLedger`] keyed by the daemon
+    /// [`SessionId`]'s UUID.
+    /// Test: `daemon::idle_nudge` unit tests exercise the decide→record path; the
+    /// ledger's own semantics are covered by `core::idle_nudge` tests.
+    pub(super) nudge_ledger: parking_lot::Mutex<crate::core::idle_nudge::NudgeLedger>,
 }
 
 impl Default for DaemonState {
@@ -412,6 +426,7 @@ impl DaemonState {
             supervised: std::sync::atomic::AtomicBool::new(true),
             manager,
             provisioning: crate::daemon::provisioning::ProvisioningRegistry::default(),
+            nudge_ledger: parking_lot::Mutex::new(crate::core::idle_nudge::NudgeLedger::new()),
         }
     }
 
@@ -479,6 +494,7 @@ impl DaemonState {
             supervised: std::sync::atomic::AtomicBool::new(true),
             manager,
             provisioning: crate::daemon::provisioning::ProvisioningRegistry::default(),
+            nudge_ledger: parking_lot::Mutex::new(crate::core::idle_nudge::NudgeLedger::new()),
         }
     }
 
@@ -494,6 +510,19 @@ impl DaemonState {
     /// `with_root` a tempdir and asserts the handler reads it.
     pub fn framework_root(&self) -> &std::path::Path {
         &self.framework_root
+    }
+
+    /// The idle-park auto-nudge ledger (#2621).
+    ///
+    /// Why: the `ingest_hook` nudge path (`daemon::idle_nudge`) lives outside the
+    /// `state` module, so it needs a public handle to the `pub(super)` ledger to
+    /// read a session's [`crate::core::idle_nudge::NudgeRecord`] and record a
+    /// delivery under the same lock.
+    /// What: returns a reference to the `parking_lot::Mutex`-guarded
+    /// [`crate::core::idle_nudge::NudgeLedger`].
+    /// Test: `daemon::idle_nudge` tests lock and mutate it via this accessor.
+    pub fn nudge_ledger(&self) -> &parking_lot::Mutex<crate::core::idle_nudge::NudgeLedger> {
+        &self.nudge_ledger
     }
 
     /// Whether this daemon process is currently considered safely supervised


### PR DESCRIPTION
## Summary

Closes #2621. Follow-up to #2610 / PR #2620, which shipped **detection + a stderr warning** for idle-parking — a delegated agent ending its turn with monitor/notification "waiting" language after backgrounding a long command, then sitting idle forever because a stopped agent can never be re-woken by the thing it is waiting on. Until now the daemon only recorded the `idle_parking` flag; a human PM still had to notice the stall and type a manual nudge. This PR closes the loop.

## Detection heuristic (as implemented)

Per issue comment 4984128989 and the #2620 design notes:

1. A `Stop` / `SubagentStop` hook arrives whose payload carries the existing `idle_parking = true` flag (set by `tm hook` via `core::idle_parking`; unchanged detection phrase list from #2620).
2. The hook's Claude session id correlates to an **Active managed session** (reusing the `claude_session_id` correlation `handle_session_end` already uses). No correlation → no pane to nudge → skip.
3. **Human-wait vs machine-wait (added in the fix round below):** the matched phrase must be nudge-eligible — `core::idle_parking::is_nudge_eligible` excludes the subset of phrases that address a HUMAN ("let me know once…", "let me know when the…", "notify me when…", "ping me when…"). Those phrases still trip passive detection/logging unchanged (a false positive there only costs a spurious log line), but a human-addressed wait is a legitimate in-scope wait that must never be interrupted by an auto-nudge. Only a machine/monitor-wait phrase (e.g. "i'll wait for the [CI notification]", "standing by", "monitoring the checks") is nudge-eligible.
4. The session has **no live tracked children** — no `Queued`/`Running` delegation (`daemon::idle_nudge::has_live_children`). This is the "stall is real, not a legitimate mid-watch" precondition from the design note: a leaf engineer agent (the common dogfooding park) has none and is nudged; a PM whose subagent is still running is left alone.
5. Only then is `cfg.message` (a foreground-block instruction) injected into the parked pane via the existing `SessionManager::inject` path (Enter-submitted).

## Config surface — `[idle_nudge]`

| key | default | meaning |
|---|---|---|
| `enabled` | `false` | feature OFF by default (zero behavior change) |
| `max_nudges_per_session` | `2` | hard cap; `0` disables. Never loops |
| `cooldown_secs` | `300` | minimum gap between two nudges to one session |
| `message` | foreground-block instruction citing #2621 | injected text |

## Safety rails (conservative by construction)

- **Opt-in** — disabled by default.
- **Human-wait exclusion** — a human-addressed parking phrase (`SkipReason::HumanWait`) is never nudged, even though it is still detected/logged for observability.
- **Cap + cooldown** — no nudge-spam loop; a stuck session gets at most `max_nudges_per_session` nudges, spaced by the cooldown, then a human must intervene.
- **No-live-children precondition** — never nudges a still-working session.
- **Managed-only** — only Active sessions that correlate to a Claude session id; unmanaged/standalone runtimes are never touched.
- **Bounded ledger** — the per-session nudge ledger is pruned against the live managed-session set on every attempt (`daemon::idle_nudge::run_nudge`), so it cannot accumulate permanent entries for the daemon's lifetime.
- **Off the hot path** — the whole correlate→prune→gate→inject runs in a `tokio::spawn`, entirely best-effort; it can never add latency to or fail the hook response.

## Architecture

- `core::idle_nudge` — **pure**: `IdleNudgeConfig`, `NudgeLedger` (per-session cap/cooldown history + `prune`), `DEFAULT_NUDGE_MESSAGE`, and `decide_nudge` (now takes the matched `phrase: Option<&str>` instead of a bare bool, folding in the human-wait exclusion via `core::idle_parking::is_nudge_eligible`) into one `NudgeDecision`. Fully unit-tested with no I/O.
- `core::idle_parking` — gains `HUMAN_ADDRESSED_PHRASES` and `is_nudge_eligible(phrase)`, the stricter nudge-eligibility gate layered on top of the existing (unchanged) high-recall detection phrase list.
- `daemon::idle_nudge` — **effectful**: `has_live_children` (pure predicate), `run_nudge` (injectable correlate→prune→gate→inject→record, tested against `FakeNoopTmuxDriver` like `idle_reaper`), `maybe_nudge_parked_session` + `spawn_if_parked` (the dispatch entry point) and the daemon-side surfacing logs.
- `[idle_nudge]` embedded in `MpmConfig`; `DaemonState` owns the ledger (keyed by `ManagedSessionId`'s inner UUID).
- `daemon::services::hook_service::HookService::process` (not `api.rs`) dispatches `spawn_if_parked` — `HookService` now owns an `Arc<DaemonState>` (was a borrowed `&'s DaemonState`) so it can hand an owned handle to the detached task. `api.rs::ingest_hook` is unchanged from before this feature.

## Surfacing (#2621 part 1)

A loud, greppable structured `warn!(target: "trusty_mpm::idle_parking", …)` fires on every detected park regardless of whether nudging is enabled, plus per-outcome `info!` (nudged / skipped-reason / no-managed-session / inject-failed). The Stop/SubagentStop event with its `idle_parking` payload continues to land in the hook ring buffer. A dashboard/TUI "parked" badge is the larger deferred surfacing piece the issue itself flags and is not included here (the issue de-prioritizes TUI vs the API-layer nudge).

## Fix round (code-critic WARN → addressed)

- **HIGH 1 (never nudge a legitimate human-wait):** fixed as described above — `is_nudge_eligible` + `SkipReason::HumanWait`. New tests prove `"Let me know once you approve the deploy…"` is detected/logged but skipped as `HumanWait`, while `"I'll wait for the CI notification"` still nudges (`core::idle_parking::human_addressed_phrases_are_not_nudge_eligible` / `machine_wait_phrases_are_nudge_eligible`; `core::idle_nudge::human_wait_skips`; `daemon::idle_nudge::run_nudge_skips_human_wait_phrase`).
- **HIGH 2 (ledger never pruned):** fixed — `run_nudge` now calls `NudgeLedger::prune` against the live managed-session set on every attempt, reusing the `SessionManager::list()` call it already makes to correlate. New test `run_nudge_prunes_stale_ledger_entries` proves a stale entry is dropped while a real session's record survives.
- **MEDIUM (api.rs line-cap bump):** fixed — the dispatch moved into `HookService::process`; `.line-cap-allowlist.tsv`'s `api.rs` budget is back to its original **1271** (no bump).
- **LOW (doc says `SessionId`, means `ManagedSessionId`):** fixed — `DaemonState::nudge_ledger` doc now correctly names `ManagedSessionId`'s inner UUID.

## Tests

33 unit tests total (25 original + 8 from the fix round): the pure `decide_nudge` rails + ledger + prune (`core::idle_nudge`), the human-wait/machine-wait split (`core::idle_parking`), `has_live_children` + `run_nudge` end-to-end against a no-op tmux driver including the human-wait skip and the prune wiring (`daemon::idle_nudge`), and `[idle_nudge]` config parsing. Full `cargo test -p trusty-mpm` green (3212 lib tests, 0 failed); clippy `-D warnings` clean; fmt clean; line-cap OK with the allowlist unchanged from before this PR.

A `## [Unreleased] / ### Added` entry was added to `crates/trusty-mpm/CHANGELOG.md` per standing convention.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
