### PR TITLE
fix(deps): bump lru and jsonwebtoken to patched versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -5165,17 +5166,20 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
+ "aws-lc-rs",
  "base64 0.22.1",
+ "getrandom 0.2.17",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -5558,6 +5562,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -6284,7 +6297,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7545,7 +7558,7 @@ dependencies = [
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -7951,7 +7964,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -8155,7 +8168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8167,7 +8180,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8325,7 +8338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8793,6 +8806,15 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -10667,7 +10689,7 @@ dependencies = [
  "indexmap 2.14.0",
  "libc",
  "local-ip-address",
- "lru",
+ "lru 0.16.4",
  "mime_guess",
  "notify 8.2.0",
  "notify-debouncer-mini 0.6.0",
@@ -10903,7 +10925,7 @@ dependencies = [
  "keyring",
  "kuzu",
  "libc",
- "lru",
+ "lru 0.16.4",
  "ort",
  "parking_lot",
  "petgraph 0.8.3",
@@ -11110,7 +11132,7 @@ dependencies = [
  "http-body-util",
  "jsonwebtoken",
  "libc",
- "lru",
+ "lru 0.16.4",
  "nix 0.29.0",
  "notify 6.1.1",
  "parking_lot",
@@ -11240,7 +11262,7 @@ dependencies = [
  "indicatif 0.17.11",
  "linfa",
  "linfa-clustering",
- "lru",
+ "lru 0.16.4",
  "metrics",
  "metrics-exporter-prometheus",
  "ndarray 0.15.6",
@@ -11531,6 +11553,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 tracing-appender = "0.2"
 fastembed = { version = "5", default-features = false }
-lru = "0.12"
+lru = "0.16"
 parking_lot = "0.12"
 dirs = "5"
 colored = "2"
@@ -100,7 +100,12 @@ tower-http = { version = "0.6", features = ["cors", "trace", "compression-gzip"]
 thiserror = "1"
 chrono = { version = "0.4", features = ["serde"] }
 base64 = "0.22"
-jsonwebtoken = "9"
+# jsonwebtoken 10 splits the crypto backend behind a feature flag (no backend
+# in default features). We select `aws_lc_rs` (already built via aws-smithy) so
+# RS256 works, and avoid `rust_crypto` which would pull in the `rsa` crate
+# (RUSTSEC-2023-0071 Marvin advisory). `use_pem` stays on via default features
+# for `EncodingKey::from_rsa_pem`. See #2765 (GHSA-h395-gr6q-cpjc).
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 sha2 = "0.10"
 # Gzip decompression for prebuilt-binary tarballs (trusty-installer Phase 2).

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+## [Unreleased]
+
+### Fixed
+
+- bump `lru` 0.12 → 0.16, fixing RUSTSEC-2026-0002 (`IterMut` violates Stacked Borrows, GHSA-rhfx-m35p-ff5j); no call-site changes needed ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`e62b454`](https://github.com/bobmatnyc/trusty-tools/commit/e62b4540d39c5a442d05e849197157932f37e664))

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -121,7 +121,7 @@ rand = "0.8"
 similar = { version = "2", features = ["text"] }
 petgraph = { version = "0.8", features = ["serde-1"] }
 libc = "0.2"
-lru = "0.12"
+lru = "0.16"
 
 # Stable plugin surface shared with external agent crates. Defined in its own
 # crate (rather than in trusty-agents/lib.rs) to break the trusty-agents ↔ agent-plugin

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -16,6 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- bump `lru` 0.12 → 0.16, fixing RUSTSEC-2026-0002 (`IterMut` violates Stacked Borrows, GHSA-rhfx-m35p-ff5j); no call-site changes needed ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`e62b454`](https://github.com/bobmatnyc/trusty-tools/commit/e62b4540d39c5a442d05e849197157932f37e664))
 - framework workflow conventions — per-session session log, issue/PR assignee+label defaults, trusty-mpm attribution footer ([#2737](https://github.com/bobmatnyc/trusty-tools/pull/2737)) ([`3089600`](https://github.com/bobmatnyc/trusty-tools/commit/3089600b475cc464329132e5f7523536bb730797))
 ## [Unreleased]
 

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - bare `tm` inside a decommissioned managed tmux session now relaunches in place instead of reconnecting to itself (closes #2777) ([#2780](https://github.com/bobmatnyc/trusty-tools/pull/2780))
+- bump `jsonwebtoken` 9 → 10 (`aws_lc_rs` backend), fixing GHSA-h395-gr6q-cpjc; migrated the test-only JWT decode-without-verification call site to `jsonwebtoken::dangerous::insecure_decode` (closes #2765) ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`e62b454`](https://github.com/bobmatnyc/trusty-tools/commit/e62b4540d39c5a442d05e849197157932f37e664))
 - resolve managed MCP registry from real home in fleet-session injector ([#2761](https://github.com/bobmatnyc/trusty-tools/pull/2761)) ([`7c04f1f`](https://github.com/bobmatnyc/trusty-tools/commit/7c04f1f845432edd6b1fb488103a1aba9939fb3c))
 - never traverse $HOME/TCC-protected folders (closes #2759) ([#2760](https://github.com/bobmatnyc/trusty-tools/pull/2760)) ([`74fe7f3`](https://github.com/bobmatnyc/trusty-tools/commit/74fe7f3c682cb5b0c648b63585c44ee47aa6d652))
 - positive stdio field allowlist for fleet native-MCP injection ([#2739](https://github.com/bobmatnyc/trusty-tools/pull/2739)) ([#2755](https://github.com/bobmatnyc/trusty-tools/pull/2755)) ([`e3a5c68`](https://github.com/bobmatnyc/trusty-tools/commit/e3a5c684cc25028202f6ece1a262f515fa3b43da))

--- a/crates/trusty-mpm/src/daemon/bug_report/token.rs
+++ b/crates/trusty-mpm/src/daemon/bug_report/token.rs
@@ -875,18 +875,12 @@ mod tests {
         let claims = AppJwtClaims::new(999, now);
         let jwt_str = encode_jwt_rs256(&pem, &claims).expect("encode should succeed");
 
-        // Decode without verification to inspect claims.
-        let decoded = jsonwebtoken::decode::<AppJwtClaims>(
-            &jwt_str,
-            &jsonwebtoken::DecodingKey::from_secret(b""),
-            &{
-                let mut v = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::RS256);
-                v.insecure_disable_signature_validation();
-                v.validate_exp = false;
-                v
-            },
-        )
-        .expect("decode should succeed with disabled validation");
+        // Decode without verification to inspect claims. jsonwebtoken 10
+        // deprecated `Validation::insecure_disable_signature_validation` in
+        // favour of the explicit `dangerous::insecure_decode`, which performs no
+        // signature or expiry checks (safe here: test-only claim inspection).
+        let decoded = jsonwebtoken::dangerous::insecure_decode::<AppJwtClaims>(&jwt_str)
+            .expect("decode should succeed with disabled validation");
 
         assert_eq!(decoded.claims.iss, "999");
         assert_eq!(decoded.claims.iat, now);

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- bump `jsonwebtoken` 9 → 10 (`aws_lc_rs` backend), fixing GHSA-h395-gr6q-cpjc; migrated the test-only JWT decode-without-verification call site to `jsonwebtoken::dangerous::insecure_decode` (closes #2765) ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`e62b454`](https://github.com/bobmatnyc/trusty-tools/commit/e62b4540d39c5a442d05e849197157932f37e664))
+
 ## [0.9.0] — 2026-07-11
 
 ### Added

--- a/crates/trusty-review/src/integrations/github/auth/app.rs
+++ b/crates/trusty-review/src/integrations/github/auth/app.rs
@@ -236,13 +236,11 @@ mod tests {
         let app_id = "99999";
         let token = mint_app_jwt(app_id, TEST_RSA_PEM).expect("mint_app_jwt should succeed");
 
-        // Decode without signature verification to inspect claims.
-        let mut validation = jsonwebtoken::Validation::new(Algorithm::RS256);
-        validation.insecure_disable_signature_validation();
-        validation.set_required_spec_claims(&[] as &[&str]);
-
-        let decoding_key = jsonwebtoken::DecodingKey::from_secret(&[]);
-        let decoded = jsonwebtoken::decode::<AppJwtClaims>(&token, &decoding_key, &validation)
+        // Decode without signature verification to inspect claims. jsonwebtoken
+        // 10 deprecated `Validation::insecure_disable_signature_validation` in
+        // favour of the explicit `dangerous::insecure_decode`, which performs no
+        // signature or claim validation (safe here: test-only claim inspection).
+        let decoded = jsonwebtoken::dangerous::insecure_decode::<AppJwtClaims>(&token)
             .expect("decoding JWT claims should succeed");
 
         // iss must match the app_id.

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- bump `lru` 0.12 → 0.16, fixing RUSTSEC-2026-0002 (`IterMut` violates Stacked Borrows, GHSA-rhfx-m35p-ff5j); no call-site changes needed ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`e62b454`](https://github.com/bobmatnyc/trusty-tools/commit/e62b4540d39c5a442d05e849197157932f37e664))
+
 ## [0.32.4] — 2026-07-13
 
 Note: `trusty-search-v0.32.3` was published without a corresponding git tag,

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -130,7 +130,7 @@ redb = { workspace = true }
 redb2 = { package = "redb", version = "2.6" }
 dashmap = "5"
 petgraph = "0.6"
-lru = "0.12"
+lru = "0.16"
 # Clustering deps are only compiled when the `clustering` feature is enabled.
 # Why: linfa + ndarray pull in a deep BLAS/numerical stack that significantly
 # slows cold compile time even though only `core::concept_cluster` consumes


### PR DESCRIPTION
## Summary

Bumps two Dependabot-flagged security dependencies:

- **`lru` 0.12.5 -> 0.16.3** — fixes RUSTSEC-2026-0002 (`IterMut` violates Stacked Borrows, invalidating an internal pointer). Bumped the direct caret pins in root `Cargo.toml` (`[workspace.dependencies]`), `crates/trusty-agents/Cargo.toml`, and `crates/trusty-search/Cargo.toml` (`trusty-common` already used the workspace dep). No call-site changes were needed — the `LruCache` API surface in use (`new`, `get`, `put`, `peek`, `pop`, `get_mut`, `push`, `len`) is unchanged from 0.12 through 0.16.
- **`jsonwebtoken` 9.3.1 -> 10.4.0** — fixes GHSA-h395-gr6q-cpjc. jsonwebtoken 10 moved the crypto backend behind a feature flag (no backend is enabled by default), so I added `features = ["aws_lc_rs"]` in the root workspace dep — `aws-lc-rs` was already resolved in the lock via the `aws-smithy-*` stack, so this adds no new dependency tree. I deliberately avoided the `rust_crypto` feature, which would pull in the `rsa` crate and its own Marvin-attack advisory (RUSTSEC-2023-0071) — that would trade one security issue for another.

## Alerts resolved

- #45 (medium, Cargo.lock, GHSA-h395-gr6q-cpjc) — **fully resolved**, closes #2765.
- #49 (low, `crates/trusty-search/Cargo.toml`, GHSA-rhfx-m35p-ff5j) — resolved.
- #1 (low, `crates/trusty-agents/Cargo.toml`, GHSA-rhfx-m35p-ff5j) — resolved.
- #44 (low, Cargo.lock, GHSA-rhfx-m35p-ff5j) — **NOT resolved**. `ratatui 0.29.0` still pins `lru = "^0.12.0"` transitively, so `lru 0.12.5` remains in `Cargo.lock` alongside our now-patched `0.16.4`. `ratatui 0.30.2` drops the `lru` dependency entirely, but bumping ratatui is a separate major-version TUI migration across `trusty-agents`, `trusty-mpm`, and `trusty-common` (all gate `ratatui` behind optional `tui`/`monitor-tui` features) — out of scope here. #2764 is therefore only partially resolved and is **not closed** by this PR; findings are posted as a comment on that issue instead.

## API changes made

- `jsonwebtoken::Validation::insecure_disable_signature_validation` is deprecated in 10.x (`-D deprecated` under `-D warnings` treats it as a hard error) in favour of the explicit `jsonwebtoken::dangerous::insecure_decode::<T>(token)`. Migrated the two test-only decode-without-verification call sites:
  - `crates/trusty-mpm/src/daemon/bug_report/token.rs` (`tests::jwt_claims_sign_verify`)
  - `crates/trusty-review/src/integrations/github/auth/app.rs` (`tests::jwt_claims_correctness`)
  Both now call `insecure_decode` directly (single-arg, no `DecodingKey`/`Validation` needed) since these tests only inspect claims, never verify signatures.
- No production `encode`/sign-path changes were needed in either crate — `EncodingKey::from_rsa_pem` + `Header::new(Algorithm::RS256)` + `encode()` are unchanged in 10.x.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p trusty-common` — 151 passed, 0 failed
- [x] `cargo test -p trusty-review` — 51 passed, 0 failed (incl. `jwt_claims_correctness`)
- [x] `cargo test -p trusty-mpm` — 3184 lib + 40 integration passed, 0 failed (incl. `jwt_claims_sign_verify`)
- [x] `cargo test -p trusty-agents` — 1783 + 6 + 4 + 2 + 2 passed, 0 failed
- [x] `cargo test -p trusty-search` — 1058 lib + 24 integration passed, 0 failed
- [x] `cargo clippy -p trusty-common/-p trusty-review/-p trusty-mpm/-p trusty-agents/-p trusty-search --all-targets -- -D warnings` — clean on all five
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations

Closes #2765

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools