### PR TITLE
chore(release): bump trusty-gworkspace to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11007,7 +11007,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-gworkspace"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/crates/tc-services/Cargo.toml
+++ b/crates/tc-services/Cargo.toml
@@ -25,7 +25,7 @@ trusty-cto-db = { path = "../trusty-cto-db", version = "0.1.3" }
 reqwest = { workspace = true }
 # `trusty-gworkspace` provides the authenticated Google API client; the
 # `gworkspace` module is a thin schema-emission + dispatch bridge over it.
-trusty-gworkspace = { path = "../trusty-gworkspace", version = "0.2.0" }
+trusty-gworkspace = { path = "../trusty-gworkspace", version = "0.2.1" }
 # `async-openai` is intentionally NOT a dependency: tc-services only emits
 # OpenAI-compatible function schemas as `serde_json::Value`. Hosts that need
 # the typed async-openai representation (e.g. open-mpm) own that bridge.

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-gworkspace"
-version = "0.2.0"
+version = "0.2.1"
 publish = false
 edition = "2024" # edition 2024 required: let-chains used in api/client.rs, api/services/gmail/, api/services/docs/ (issue #258)
 description = "Google Workspace MCP server for the Trusty suite"


### PR DESCRIPTION
## Summary
- Patch bump trusty-gworkspace 0.2.0 -> 0.2.1 following the #2751 hardening fix (token-in-error redaction + bounds, merged in #2778).
- Sync the tc-services dependent pin (crates/tc-services/Cargo.toml) from 0.2.0 -> 0.2.1.
- Install-only release (publish = false); no crates.io publish.

## Test plan
- [x] `cargo test -p trusty-gworkspace` — 225 + 2 passed, 0 failed
- [x] `cargo clippy -p trusty-gworkspace -p tc-services --all-targets -- -D warnings` — clean