### PR TITLE
feat(trusty-mpm): require per-PR changelog updates in the default workflow

### DIFF
--- a/.trusty-mpm/INSTRUCTIONS.md
+++ b/.trusty-mpm/INSTRUCTIONS.md
@@ -305,6 +305,52 @@ versions by version number.
 8. Publish: `cargo publish -p <crate-name>` (or `SKIP_UI_BUILD=1 cargo publish` for UI-embedding crates).
 9. Build and install: `cargo install --path crates/<dir> --locked`.
 
+### Per-PR Changelog Requirement (framework default — issue #2005-class, changelogs-stale directive)
+
+🔴 **Every PR that touches a crate's `src/**` adds a hand-written entry to that
+crate's `CHANGELOG.md`, in the same PR.** Add one bullet per user-visible
+change under the topmost `## [Unreleased]` heading (create that heading —
+directly below the `---`/header block — if the file has none yet). Match the
+existing bullet style, e.g.:
+
+```
+- fix pm_guard quoted-content scanning (closes #2741) ([#2744](https://github.com/bobmatnyc/trusty-tools/pull/2744))
+```
+
+The commit-hash link segment is optional in hand-written bullets — git-cliff
+adds it automatically when it regenerates the section at release time (see
+below). Docs-only and CI-only PRs may skip this step. A PR that changes crate
+source and lands without a changelog entry is a **review-gate failure**, the
+same tier as a failing `cargo test`/`cargo clippy` gate — the trusty-review
+gate or PM blocks merge until the entry is added, no "trivial change"
+exception.
+
+**Interaction rule with `scripts/generate-changelog.sh` / git-cliff (read, not
+guessed — see the script): do not let both mechanisms coexist unresolved.**
+`scripts/generate-changelog.sh` (invoked by `scripts/bump-version.sh` at
+release time) runs `git cliff --unreleased --prepend <crate>/CHANGELOG.md`.
+This regenerates a **fresh** `## [Unreleased]` section straight from
+conventional-commit git log and blindly **prepends** it — it never reads,
+merges, or dedupes against whatever hand-written content is already sitting
+under the file's existing `## [Unreleased]` heading. Left unresolved, this
+produces exactly the duplicate/stacked `## [Unreleased]` sections already
+visible in several crate changelogs today (e.g.
+`crates/trusty-mpm/CHANGELOG.md`, `crates/trusty-search/CHANGELOG.md`) — each
+release-time run stacks another overlapping section on top instead of
+replacing the draft.
+
+Precedence: **git-cliff-generated content is canonical at release time and
+supersedes the hand-written draft — it replaces, it does not merge.** Before
+running `scripts/bump-version.sh <crate-dir> <level>` (or
+`scripts/generate-changelog.sh` directly), delete the hand-maintained bullets
+under that crate's topmost `## [Unreleased]` heading (the heading itself may
+stay empty or be removed — `generate-changelog.sh` recreates it). git-cliff
+regenerates equivalent-or-better entries (with PR + commit-hash links) from
+the same merged commits, so nothing is lost — the hand-written section is a
+live staging area between releases, never a second permanent copy. This is a
+process rule only; `scripts/bump-version.sh` and `scripts/generate-changelog.sh`
+need no code change to honor it.
+
 🟢 **`tga` tag aliases (issue #1128):** `trusty-git-analytics` publishes to
 crates.io under the short package name `tga`. The binary-release workflow
 (`.github/workflows/release.yml`) accepts **both** tag forms — `tga-v<version>`

--- a/.trusty-mpm/INSTRUCTIONS.md
+++ b/.trusty-mpm/INSTRUCTIONS.md
@@ -337,19 +337,38 @@ produces exactly the duplicate/stacked `## [Unreleased]` sections already
 visible in several crate changelogs today (e.g.
 `crates/trusty-mpm/CHANGELOG.md`, `crates/trusty-search/CHANGELOG.md`) — each
 release-time run stacks another overlapping section on top instead of
-replacing the draft.
+replacing the draft. **Until #2793 lands** (tracks teaching
+`generate-changelog.sh` to replace/dedupe the `[Unreleased]` section instead
+of blindly prepending), `scripts/bump-version.sh` fails loudly with a fix hint
+if it detects more than one `## [Unreleased]` heading after the prepend, as a
+stopgap against silently shipping a duplicated changelog.
 
 Precedence: **git-cliff-generated content is canonical at release time and
 supersedes the hand-written draft — it replaces, it does not merge.** Before
 running `scripts/bump-version.sh <crate-dir> <level>` (or
-`scripts/generate-changelog.sh` directly), delete the hand-maintained bullets
-under that crate's topmost `## [Unreleased]` heading (the heading itself may
-stay empty or be removed — `generate-changelog.sh` recreates it). git-cliff
-regenerates equivalent-or-better entries (with PR + commit-hash links) from
-the same merged commits, so nothing is lost — the hand-written section is a
-live staging area between releases, never a second permanent copy. This is a
-process rule only; `scripts/bump-version.sh` and `scripts/generate-changelog.sh`
-need no code change to honor it.
+`scripts/generate-changelog.sh` directly):
+
+1. **Diff first, don't just delete.** `cliff.toml`'s `commit_preprocessors`
+   only linkify `(#NNN)` references in the commit **subject** line — commit
+   bodies are dropped (`split_commits = false`, subject-only template; see
+   `cliff.toml`'s own KNOWN LIMITATION note). git-cliff regenerates from the
+   squash-commit **subject only**, so it does **not** reliably reproduce
+   hand-written nuance that lived in a PR description or commit body but never
+   made it into the squash subject (a GHSA id, a specific config value, an
+   edge case called out by hand). **Do not assume "nothing is lost."** Run
+   `scripts/generate-changelog.sh <crate-dir> <tag-prefix> --stdout` and diff
+   it against the hand-written draft; any bullet/nuance the generated output
+   doesn't cover must be manually re-added to `CHANGELOG.md` *after*
+   generation, not assumed to be redundant.
+2. Fold whatever nuance you can into the squash-commit subject itself before
+   merging (so git-cliff captures it for future runs), and only then delete
+   the hand-maintained bullets under the crate's topmost `## [Unreleased]`
+   heading (the heading itself may stay empty or be removed —
+   `generate-changelog.sh` recreates it).
+
+This is a process rule; `scripts/generate-changelog.sh` needs no code change
+to honor it, but `scripts/bump-version.sh` now includes the stopgap duplicate-
+heading guard described above (see #2793 for the real fix).
 
 🟢 **`tga` tag aliases (issue #1128):** `trusty-git-analytics` publishes to
 crates.io under the short package name `tga`. The binary-release workflow

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,7 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- require a per-PR CHANGELOG.md entry in the default workflow (bundled `tm-pr-workflow` skill, `PM_INSTRUCTIONS.md`, `WORKFLOW.md`, `BASE-AGENT.md`); PM treats a missing entry as a review-gate failure and the precedence rule vs. `scripts/generate-changelog.sh`/git-cliff is documented in `.trusty-mpm/INSTRUCTIONS.md`
+- require a per-PR CHANGELOG.md entry in the default workflow (bundled `tm-pr-workflow` skill, `PM_INSTRUCTIONS.md`, `WORKFLOW.md`, `BASE-AGENT.md`); PM treats a missing entry as a review-gate failure and the precedence rule vs. `scripts/generate-changelog.sh`/git-cliff is documented in `.trusty-mpm/INSTRUCTIONS.md` ([#2790](https://github.com/bobmatnyc/trusty-tools/pull/2790))
 
 ### Fixed
 

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- require a per-PR CHANGELOG.md entry in the default workflow (bundled `tm-pr-workflow` skill, `PM_INSTRUCTIONS.md`, `WORKFLOW.md`, `BASE-AGENT.md`); PM treats a missing entry as a review-gate failure and the precedence rule vs. `scripts/generate-changelog.sh`/git-cliff is documented in `.trusty-mpm/INSTRUCTIONS.md`
+
 ### Fixed
 
 - resolve managed MCP registry from real home in fleet-session injector ([#2761](https://github.com/bobmatnyc/trusty-tools/pull/2761)) ([`7c04f1f`](https://github.com/bobmatnyc/trusty-tools/commit/7c04f1f845432edd6b1fb488103a1aba9939fb3c))

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -39,6 +39,12 @@ forbidding language in general; it exempts delegation-routing language only.
 - Reference issues in the body (`Closes #N`) to auto-close on merge.
 - Check `git status` before starting; never force-push to a shared branch
   without explicit instruction; leave the working tree clean.
+- Every PR that changes a package's source adds one bullet per user-visible
+  change to that package's `CHANGELOG.md`, under an `## [Unreleased]` heading
+  (create it if missing). Match the file's existing bullet style. Docs-only /
+  CI-only PRs may skip this. A missing entry is a review-gate failure, not
+  optional polish — see `tm-pr-workflow` for the merge-gate detail and how
+  this interacts with any project-specific changelog-generation tooling.
 
 ## Memory & Context Routing
 

--- a/crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md
+++ b/crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md
@@ -178,7 +178,7 @@ See WORKFLOW.md for details. Summary:
 |-------|-------|------|-----------|
 | 1. Research | Research | Findings documented | User provides explicit instructions, simple task, language/approach known |
 | 2. Code Analysis | Code Analysis | APPROVED / NEEDS_IMPROVEMENT / BLOCKED | Change is < 100 lines, no architectural impact |
-| 3. Implementation | Engineer (per lang detect) | Tests pass, files tracked | -- |
+| 3. Implementation | Engineer (per lang detect) | Tests pass, files tracked, CHANGELOG updated | Docs-only/CI-only change |
 | 4. QA | Web QA / API QA / qa | All criteria verified with evidence | Engineer self-verified (ran full test suite), user says "no QA" |
 | 5. Documentation | Documentation Agent | Docs updated | No public API changes, internal refactor only |
 
@@ -302,6 +302,11 @@ delegation prompt.
 **[SKILL: tm-pr-workflow]**
 
 All pushes to main/master require feature branch + PR. Delegate to Version Control agent.
+
+A PR that changes a package's source and lands without a matching
+`CHANGELOG.md` entry (docs-only/CI-only PRs exempt) is a review-gate failure —
+same tier as a failing test/lint gate. See `tm-pr-workflow` for the rule and
+the required wording.
 
 ## Ticketing Integration
 

--- a/crates/trusty-mpm/src/assets/instructions/WORKFLOW.md
+++ b/crates/trusty-mpm/src/assets/instructions/WORKFLOW.md
@@ -32,7 +32,9 @@ Return: Approval status with specific recommendations
 
 ### Phase 3: Implementation
 **Agent**: Selected via delegation matrix
-**Requirements**: Complete code, error handling, basic test proof
+**Requirements**: Complete code, error handling, basic test proof, CHANGELOG.md
+entry for the changed package (one bullet per user-visible change, under
+`## [Unreleased]`) — skip only for docs-only/CI-only changes
 
 ### Phase 4: QA (MANDATORY)
 **Agent**: API QA (APIs), Web QA (UI), qa (general)

--- a/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
@@ -59,6 +59,27 @@ When a user asks to "commit to main" / "push to main" / "merge to main",
 proactively translate: "Creating feature branch workflow instead" — don't
 wait for a git error to correct course.
 
+## Changelog Requirement (Before Merge)
+
+Changelogs go stale when updating them is left to "sometime at release" — so
+it is part of every PR, not a separate chore:
+
+- Every PR that changes a package's source adds one bullet per user-visible
+  change to that package's `CHANGELOG.md`, under the topmost `## [Unreleased]`
+  heading (create the heading if the file has none yet). Match the file's
+  existing bullet style and wording. Docs-only / CI-only PRs may skip this.
+- A PR that changes source and lands without a matching changelog entry is a
+  **review-gate failure** — the same tier as a failing build/test/lint gate.
+  Treat it exactly like CB#8 (QA gate): block the merge, delegate back to the
+  Engineer to add the entry, don't wave it through as "trivial."
+- If the project has automated changelog-generation tooling (e.g. a
+  conventional-commits generator run at release time), that tooling and these
+  hand-written per-PR entries can conflict — it may regenerate a section from
+  git log without knowing about, merging, or deduping against what's already
+  written by hand. Check the project's own instructions (root `CLAUDE.md` /
+  `.trusty-mpm/INSTRUCTIONS.md`) for the precedence rule before assuming the
+  two coexist safely; do not invent one on the fly.
+
 ## The trusty-review Gate
 
 Before merge, delegate to the review gate:

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -214,8 +214,12 @@ main() {
   if [[ "${unreleased_count}" -gt 1 ]]; then
     echo "ERROR: ${changelog} now has ${unreleased_count} '## [Unreleased]' headings." >&2
     echo "       generate-changelog.sh prepended a fresh section without an existing" >&2
-    echo "       hand-written draft being cleared first (see issue #2793). Manually" >&2
-    echo "       merge/dedupe the sections in ${changelog}, then re-run this script." >&2
+    echo "       hand-written draft being cleared first (see issue #2793)." >&2
+    echo "       crates/${crate_dir}/Cargo.toml has ALREADY been bumped to ${next} by" >&2
+    echo "       this run — after manually merging/dedupe-ing the sections in" >&2
+    echo "       ${changelog}, do NOT re-run this script (it would double-bump); commit" >&2
+    echo "       directly, or \`git checkout crates/${crate_dir}/Cargo.toml\` first if" >&2
+    echo "       you want to start over." >&2
     exit 1
   fi
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -203,6 +203,22 @@ main() {
   echo "Staging unreleased CHANGELOG section via generate-changelog.sh ..." >&2
   "${changelog_script}" "${crate_dir}" "${prefix}"
 
+  # Stopgap guard (issue #2793 tracks the real fix): generate-changelog.sh's
+  # `git cliff --prepend` blindly inserts a fresh "## [Unreleased]" section
+  # without checking whether one is already there (e.g. a hand-written
+  # per-PR draft that was never cleared first). Fail loudly here rather than
+  # silently shipping a duplicated changelog.
+  local changelog="${crate_path}/CHANGELOG.md"
+  local unreleased_count
+  unreleased_count=$(grep -c '^## \[Unreleased\]' "${changelog}") || true
+  if [[ "${unreleased_count}" -gt 1 ]]; then
+    echo "ERROR: ${changelog} now has ${unreleased_count} '## [Unreleased]' headings." >&2
+    echo "       generate-changelog.sh prepended a fresh section without an existing" >&2
+    echo "       hand-written draft being cleared first (see issue #2793). Manually" >&2
+    echo "       merge/dedupe the sections in ${changelog}, then re-run this script." >&2
+    exit 1
+  fi
+
   # Print — but DO NOT RUN — the manual tag/push commands (human stays in loop).
   local tag="${prefix}-v${next}"
   echo "" >&2


### PR DESCRIPTION
## Why

Bob's directive: "changelogs are stale — include updating changelogs with
every merged PR." This makes the per-PR changelog update part of the
**default** trusty-mpm workflow (the framework's bundled instructions), not
just a project-local note — so every project a trusty-mpm session manages
inherits the rule.

## The convention (added to bundled framework assets)

- Every PR that changes a package's source adds one bullet per user-visible
  change to that package's `CHANGELOG.md`, under the topmost `## [Unreleased]`
  heading (create the heading if the file has none yet). Match the file's
  existing bullet style.
- Docs-only / CI-only PRs may skip this step.
- A PR that changes source and lands without a matching changelog entry is a
  **review-gate failure** — same tier as a failing build/test/lint gate. The
  trusty-review gate / PM blocks merge until the entry is added — no
  "trivial change" exception.

## Where it landed

Framework-bundled (stack-neutral, ships to every project):
- `crates/trusty-mpm/src/assets/agents/BASE-AGENT.md` — Git Workflow bullet
  (every agent inherits this)
- `crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md` — PR Workflow
  section + the 5-phase workflow gate table (Phase 3 Implementation now
  requires "CHANGELOG updated")
- `crates/trusty-mpm/src/assets/instructions/WORKFLOW.md` — Phase 3
  Implementation requirements
- `crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md` — new "Changelog
  Requirement (Before Merge)" section with the full rule + gate wording

Project-specific (trusty-tools' own `.trusty-mpm/INSTRUCTIONS.md`, since
CLAUDE.md was migrated there in #2300):
- New "Per-PR Changelog Requirement" subsection under "Git Tag / Release
  Convention" with the concrete generate-changelog.sh interaction rule below.

`crates/trusty-mpm/CHANGELOG.md` also gets an `## [Unreleased]` entry for this
very change (eating the dogfood in this PR).

## The generate-changelog.sh / git-cliff interaction rule (read the scripts, not guessed)

`scripts/generate-changelog.sh` (invoked by `scripts/bump-version.sh` at
release time) runs `git cliff --unreleased --prepend <crate>/CHANGELOG.md`.
This regenerates a **fresh** `## [Unreleased]` section directly from
conventional-commit git log and blindly **prepends** it — it never reads,
merges, or dedupes against whatever hand-written content already sits under
the file's existing `## [Unreleased]` heading.

Left unresolved, this is exactly what produced the duplicate/stacked
`## [Unreleased]` sections already visible today in
`crates/trusty-mpm/CHANGELOG.md`, `crates/trusty-search/CHANGELOG.md`, and
others — each release-time run stacks another overlapping section on top
instead of replacing the draft.

**Precedence: git-cliff-generated content is canonical at release time and
supersedes the hand-written draft — it replaces, it does not merge.** Before
running `scripts/bump-version.sh <crate-dir> <level>` (or
`scripts/generate-changelog.sh` directly), delete the hand-maintained bullets
under that crate's topmost `## [Unreleased]` heading first. git-cliff
regenerates equivalent-or-better entries (with PR + commit-hash links) from
the same merged commits, so nothing is lost. This is a process rule only —
`scripts/bump-version.sh` / `scripts/generate-changelog.sh` need no code
change.

## Follow-ups filed (not built here, per scope)

- #2787 — mechanical CI enforcement: a PR touching `crates/<name>/src/**`
  must also touch `crates/<name>/CHANGELOG.md`, with a `no-changelog` skip
  label for exempt PRs.
- #2788 — stale-changelog backfill audit: enumerate crates whose
  CHANGELOG.md lags their git history (including the stacked-Unreleased
  issue above) and propose the backfill mechanism.

## Verification

```
cargo build -p trusty-mpm         → Finished, 0 errors
cargo test -p trusty-mpm bundle   → 33 passed; 0 failed (asset-content tests)
cargo fmt --check                 → clean (only nightly-feature warnings, pre-existing)
bash scripts/check_line_cap.sh    → line-cap: 9 allowlisted, 0 violations — OK.
```

No source-code / behavior changes — this PR is documentation/instructions
only (plus the trusty-mpm CHANGELOG.md entry).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools