### PR TITLE
fix(trusty-mpm): reconcile zombie-Active sessions on in-place relaunch instead of 409 dead-end

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- bare `tm` inside a zombie-`Active` managed session (agent exited but the record still reads `Active`) now reconciles-and-relaunches in place via the caller's pane-identity proof-of-death instead of dead-ending on a 409; the fallback hint no longer suggests a bare `claude` (which loses the managed config) and points at `tm sessions resume <id>` (closes #2794)
 - bare `tm` inside a decommissioned managed tmux session now relaunches in place instead of reconnecting to itself (closes #2777) ([#2780](https://github.com/bobmatnyc/trusty-tools/pull/2780))
 - resolve managed MCP registry from real home in fleet-session injector ([#2761](https://github.com/bobmatnyc/trusty-tools/pull/2761)) ([`7c04f1f`](https://github.com/bobmatnyc/trusty-tools/commit/7c04f1f845432edd6b1fb488103a1aba9939fb3c))
 - never traverse $HOME/TCC-protected folders (closes #2759) ([#2760](https://github.com/bobmatnyc/trusty-tools/pull/2760)) ([`74fe7f3`](https://github.com/bobmatnyc/trusty-tools/commit/74fe7f3c682cb5b0c648b63585c44ee47aa6d652))

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -106,12 +106,24 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
             // this pane's own foreground command (the caller's pane_id is
             // forwarded so the daemon treats it as idle). It still refuses
             // when the runtime is genuinely live in a SIBLING window.
+            //
+            // #2794: we are HERE only because `pane_identity_confirmed` proved,
+            // via the stable tmux `pane_id`, that this process is inside
+            // `record`'s OWN pane — and the agent has provably exited (a live
+            // agent could not have handed this pane back to a shell for bare
+            // `tm` to run in). That is authoritative proof-of-death the daemon's
+            // tmux-pane liveness probe cannot see, so forward it
+            // (`pane_confirmed_dead = true`): it lets the daemon reconcile a
+            // zombie-`Active` record whose pane still reads busy (the requesting
+            // `tm`, or a not-yet-reaped child) instead of 409-dead-ending — the
+            // reported bug. A genuinely live SIBLING window still blocks it.
             match super::guided_inplace::run_inplace_relaunch(
                 client,
                 url,
                 &record.id,
                 record.clone(),
                 current_pane_id.as_deref(),
+                true,
             )
             .await
             {
@@ -164,12 +176,18 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
             // never an unconditional exec.
             NestedFallbackAction::RelaunchInPlace => {
                 let current_pane_id = super::tmux_attach::current_tmux_pane_id();
+                // #2794: this is a session-name-only match (pane identity NOT
+                // confirmed), so we have no proof-of-death for a specific pane —
+                // pass `false` and let the daemon's ordinary probe decide. The
+                // dead states that reach here (stopped/decommissioned) reactivate
+                // directly anyway; `errored` falls to the probe path unchanged.
                 match super::guided_inplace::run_inplace_relaunch(
                     client,
                     url,
                     &record.id,
                     record.clone(),
                     current_pane_id.as_deref(),
+                    false,
                 )
                 .await
                 {
@@ -555,32 +573,34 @@ pub(crate) fn nested_guard_notice(name: &str) -> String {
     format!("not nesting a new session here; reconnecting to '{name}' instead…")
 }
 
-/// Actionable hint (#2789) printed when bare `tm` runs inside a managed
-/// session's OWN pane (pane identity confirmed) but the in-place relaunch could
-/// not proceed.
+/// Actionable hint (#2789, corrected #2794) printed when bare `tm` runs inside
+/// a managed session's OWN pane (pane identity confirmed) but the in-place
+/// relaunch could not proceed.
 ///
 /// Why: reconnecting to the very session whose pane the operator is already
 /// inside is a `switch-client` no-op that strands them in a bare shell — the
 /// reported dead-end (`tm-cto-01` transcript). When the in-place relaunch
 /// cannot run (a genuinely live sibling window, a daemon predating the
 /// caller-pane reconcile, or a failed `exec`), the honest response is to tell
-/// the operator how to relaunch the agent in THIS pane themselves rather than
-/// pretend a reconnect happened.
-/// What: a single-line hint. When `record.claude_session_id` is present, it
-/// suggests `claude --resume <id>` (resume the exact conversation); otherwise a
-/// bare `claude`. Pure — takes an already-fetched record, returns the string.
-/// Test: `inplace_self_relaunch_hint_uses_resume_when_session_id_present`,
-/// `inplace_self_relaunch_hint_bare_claude_when_no_session_id`.
+/// the operator how to relaunch the agent themselves. #2794: the prior wording
+/// suggested a bare `claude` (or `claude --resume <id>`), which is WRONG — a
+/// raw `claude` launches OUTSIDE the managed session, dropping the tm-owned
+/// `CLAUDE_CONFIG_DIR`, the agent roster, and the persona (the DOC-34 managed
+/// config). The managed relaunch is `tm sessions resume <id>`, which re-spawns
+/// the runtime with the full managed environment intact — that is the only
+/// correct advice, so the hint always points there.
+/// What: a single-line hint suggesting `tm sessions resume <managed-id>`
+/// (`record.id`, the managed session id — NOT the claude conversation id). Pure
+/// — takes an already-fetched record, returns the string.
+/// Test: `inplace_self_relaunch_hint_suggests_managed_resume`,
+/// `inplace_self_relaunch_hint_never_suggests_bare_claude`.
 pub(crate) fn inplace_self_relaunch_hint(
     record: &trusty_mpm::client::ManagedSessionSummary,
 ) -> String {
-    let relaunch = match record.claude_session_id.as_deref() {
-        Some(sid) if !sid.trim().is_empty() => format!("claude --resume {sid}"),
-        _ => "claude".to_string(),
-    };
     format!(
         "tm: you are already inside this session's pane — its agent has exited; \
-         relaunch it here with:  {relaunch}"
+         relaunch it as a managed session with:  tm sessions resume {}",
+        record.id
     )
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -107,16 +107,21 @@ pub(crate) async fn run_guided_default(client: &reqwest::Client, url: &str) -> a
             // forwarded so the daemon treats it as idle). It still refuses
             // when the runtime is genuinely live in a SIBLING window.
             //
-            // #2794: we are HERE only because `pane_identity_confirmed` proved,
-            // via the stable tmux `pane_id`, that this process is inside
-            // `record`'s OWN pane — and the agent has provably exited (a live
-            // agent could not have handed this pane back to a shell for bare
-            // `tm` to run in). That is authoritative proof-of-death the daemon's
-            // tmux-pane liveness probe cannot see, so forward it
-            // (`pane_confirmed_dead = true`): it lets the daemon reconcile a
+            // #2794: we are HERE only because `pane_identity_confirmed` matched
+            // the stable tmux `pane_id`, so this process is inside `record`'s
+            // OWN pane. `pane_id` identity alone is not PROOF the agent has
+            // exited — any child process of the pane (including a live agent
+            // that shelled out to run bare `tm`) inherits the same `pane_id` —
+            // so this is the ordinary interactive-relaunch case: the operator's
+            // shell has handed this pane back to bare `tm`, which is what
+            // happens when the agent has exited. We forward that as a
+            // self-asserted claim (`pane_confirmed_dead = true`, NOT
+            // independently verified by the daemon) so it can reconcile a
             // zombie-`Active` record whose pane still reads busy (the requesting
             // `tm`, or a not-yet-reaped child) instead of 409-dead-ending — the
-            // reported bug. A genuinely live SIBLING window still blocks it.
+            // reported bug. The claim is bounded, not a bare pass: an
+            // INDEPENDENT sibling-pane liveness check on the daemon still
+            // refuses when the runtime is genuinely live in a SIBLING window.
             match super::guided_inplace::run_inplace_relaunch(
                 client,
                 url,

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -306,12 +306,13 @@ async fn fetch_managed_session_until_stopped(
 /// pane — whose foreground command is the requesting `tm` itself — as idle
 /// instead of counting it as a live runtime and returning 409. When
 /// `pane_confirmed_dead` is set (#2794), a `?pane_confirmed_dead=true` param is
-/// also forwarded: it tells the daemon the caller has INDEPENDENTLY confirmed
-/// (via stable tmux `pane_id`, `guided::pane_identity_confirmed`) that it is
-/// this record's OWN pane and the agent has exited, so the reconcile overrides
-/// its tmux-pane liveness probe for the caller's own pane — closing the residual
-/// zombie-`Active` 409 dead-end where the probe still counted the requesting
-/// `tm` (or a not-yet-reaped child) as live.
+/// also forwarded: it tells the daemon the caller is asserting — matched via
+/// stable tmux `pane_id`, `guided::pane_identity_confirmed`, not independently
+/// re-verified by the daemon — that it is this record's OWN pane and the agent
+/// has exited, so the reconcile trusts that claim over its tmux-pane liveness
+/// probe for the caller's own pane (bounded by an independent sibling-pane
+/// check, #2157) — closing the residual zombie-`Active` 409 dead-end where the
+/// probe still counted the requesting `tm` (or a not-yet-reaped child) as live.
 /// Test: I/O path; not unit-tested (requires a live daemon).
 async fn reactivate_managed_session(
     client: &reqwest::Client,

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -304,19 +304,30 @@ async fn fetch_managed_session_until_stopped(
 /// When `caller_pane_id` is `Some`, it is forwarded as a `?caller_pane_id=`
 /// query param (#2789) so the daemon's stale-`Active` reconcile can treat THIS
 /// pane — whose foreground command is the requesting `tm` itself — as idle
-/// instead of counting it as a live runtime and returning 409.
+/// instead of counting it as a live runtime and returning 409. When
+/// `pane_confirmed_dead` is set (#2794), a `?pane_confirmed_dead=true` param is
+/// also forwarded: it tells the daemon the caller has INDEPENDENTLY confirmed
+/// (via stable tmux `pane_id`, `guided::pane_identity_confirmed`) that it is
+/// this record's OWN pane and the agent has exited, so the reconcile overrides
+/// its tmux-pane liveness probe for the caller's own pane — closing the residual
+/// zombie-`Active` 409 dead-end where the probe still counted the requesting
+/// `tm` (or a not-yet-reaped child) as live.
 /// Test: I/O path; not unit-tested (requires a live daemon).
 async fn reactivate_managed_session(
     client: &reqwest::Client,
     url: &str,
     id: &str,
     caller_pane_id: Option<&str>,
+    pane_confirmed_dead: bool,
 ) -> bool {
     let mut req = client
         .post(format!("{url}/api/v1/sessions/managed/{id}/reactivate"))
         .timeout(PROBE_TIMEOUT);
     if let Some(pane_id) = caller_pane_id.filter(|s| !s.is_empty()) {
         req = req.query(&[("caller_pane_id", pane_id)]);
+    }
+    if pane_confirmed_dead {
+        req = req.query(&[("pane_confirmed_dead", "true")]);
     }
     let result = req.send().await;
     match result {
@@ -455,6 +466,7 @@ pub(crate) async fn run_inplace_relaunch(
     id: &str,
     record: trusty_mpm::client::ManagedSessionSummary,
     caller_pane_id: Option<&str>,
+    pane_confirmed_dead: bool,
 ) -> InPlaceOutcome {
     eprintln!("tm: this pane belongs to managed session {id} — relaunching in place…");
 
@@ -505,7 +517,10 @@ pub(crate) async fn run_inplace_relaunch(
     // a refused/failed reactivate aborts rather than proceeding to exec.
     // #2789: forward this pane's own id so the daemon's stale-`Active`
     // reconcile does not count the requesting `tm` process as a live runtime.
-    if !reactivate_managed_session(client, url, id, caller_pane_id).await {
+    // #2794: `pane_confirmed_dead` additionally carries the caller's
+    // proof-of-death for a zombie-`Active` record whose pane the probe would
+    // otherwise still read as busy.
+    if !reactivate_managed_session(client, url, id, caller_pane_id, pane_confirmed_dead).await {
         return InPlaceOutcome::FallThrough;
     }
 
@@ -599,8 +614,19 @@ pub(crate) async fn try_inplace_relaunch(
                 );
                 return None;
             }
-            match run_inplace_relaunch(client, url, &env_id, record, current_pane_id.as_deref())
-                .await
+            // #2794: this env-var path only selects `InPlace` for a record
+            // already CONFIRMED `Stopped` (see `plan_inplace`), so `mark_
+            // reactivated` succeeds directly and the proof-of-death reconcile is
+            // never reached — pass `false`.
+            match run_inplace_relaunch(
+                client,
+                url,
+                &env_id,
+                record,
+                current_pane_id.as_deref(),
+                false,
+            )
+            .await
             {
                 InPlaceOutcome::Result(r) => Some(r),
                 InPlaceOutcome::FallThrough => {

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -320,7 +320,7 @@ fn plan_inplace_none_when_resolved_but_not_stopped() {
 async fn reactivate_confirms_success_on_2xx() {
     let (url, hits) = spawn_mock("HTTP/1.1 200 OK").await;
     let client = reqwest::Client::new();
-    let ok = reactivate_managed_session(&client, &url, TEST_ID, None).await;
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, None, false).await;
     assert!(ok, "a 2xx response must confirm reactivation");
     assert_eq!(hits.load(Ordering::SeqCst), 1);
 }
@@ -332,7 +332,7 @@ async fn reactivate_aborts_on_409_conflict() {
     // rather than proceeding to exec.
     let (url, _hits) = spawn_mock("HTTP/1.1 409 Conflict").await;
     let client = reqwest::Client::new();
-    let ok = reactivate_managed_session(&client, &url, TEST_ID, None).await;
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, None, false).await;
     assert!(!ok, "409 must NOT be treated as a confirmed reactivate");
 }
 
@@ -340,7 +340,7 @@ async fn reactivate_aborts_on_409_conflict() {
 async fn reactivate_aborts_on_404_not_found() {
     let (url, _hits) = spawn_mock("HTTP/1.1 404 Not Found").await;
     let client = reqwest::Client::new();
-    let ok = reactivate_managed_session(&client, &url, TEST_ID, None).await;
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, None, false).await;
     assert!(!ok, "404 must NOT be treated as a confirmed reactivate");
 }
 
@@ -350,7 +350,7 @@ async fn reactivate_aborts_on_unreachable_daemon() {
     // refused, exercising the network-error branch without waiting out
     // the full PROBE_TIMEOUT.
     let client = reqwest::Client::new();
-    let ok = reactivate_managed_session(&client, "http://127.0.0.1:1", TEST_ID, None).await;
+    let ok = reactivate_managed_session(&client, "http://127.0.0.1:1", TEST_ID, None, false).await;
     assert!(
         !ok,
         "an unreachable daemon must NOT be treated as a confirmed reactivate"
@@ -366,12 +366,36 @@ async fn reactivate_forwards_caller_pane_id_query() {
     // pane id is present.
     let (url, request_line) = spawn_capturing_mock("HTTP/1.1 200 OK").await;
     let client = reqwest::Client::new();
-    let ok = reactivate_managed_session(&client, &url, TEST_ID, Some("%3")).await;
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, Some("%3"), false).await;
     assert!(ok, "a 2xx response must confirm reactivation");
     let line = request_line.lock().expect("lock").clone();
     assert!(
         line.contains("caller_pane_id=%253"),
         "the request line must carry the URL-encoded caller_pane_id (%3 -> %253); got: {line}"
+    );
+    assert!(
+        !line.contains("pane_confirmed_dead"),
+        "pane_confirmed_dead=false must not be forwarded; got: {line}"
+    );
+}
+
+#[tokio::test]
+async fn reactivate_forwards_pane_confirmed_dead_query() {
+    // #2794: when the caller has confirmed pane identity (proof-of-death), the
+    // request must carry `?pane_confirmed_dead=true` so the daemon's reconcile
+    // overrides its tmux-pane liveness probe for the caller's OWN pane.
+    let (url, request_line) = spawn_capturing_mock("HTTP/1.1 200 OK").await;
+    let client = reqwest::Client::new();
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, Some("%3"), true).await;
+    assert!(ok, "a 2xx response must confirm reactivation");
+    let line = request_line.lock().expect("lock").clone();
+    assert!(
+        line.contains("pane_confirmed_dead=true"),
+        "a pane-confirmed-dead caller must forward the proof-of-death param; got: {line}"
+    );
+    assert!(
+        line.contains("caller_pane_id=%253"),
+        "the caller_pane_id must still accompany the proof-of-death param; got: {line}"
     );
 }
 
@@ -381,7 +405,7 @@ async fn reactivate_omits_caller_pane_id_query_when_absent() {
     // caller_pane_id, and the request must carry no such query param.
     let (url, request_line) = spawn_capturing_mock("HTTP/1.1 200 OK").await;
     let client = reqwest::Client::new();
-    let ok = reactivate_managed_session(&client, &url, TEST_ID, None).await;
+    let ok = reactivate_managed_session(&client, &url, TEST_ID, None, false).await;
     assert!(ok);
     let line = request_line.lock().expect("lock").clone();
     assert!(
@@ -431,7 +455,7 @@ async fn run_inplace_relaunch_never_reactivates_when_command_build_fails() {
     };
     let client = reqwest::Client::new();
 
-    let outcome = run_inplace_relaunch(&client, &url, TEST_ID, record, None).await;
+    let outcome = run_inplace_relaunch(&client, &url, TEST_ID, record, None, false).await;
 
     assert!(
         matches!(outcome, InPlaceOutcome::Result(Err(_))),

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -1943,16 +1943,19 @@ fn nested_guard_notice_mentions_reconnect_target() {
 }
 
 #[test]
-fn inplace_self_relaunch_hint_uses_resume_when_session_id_present() {
-    // #2789: when the record carries a claude_session_id, the honest
-    // self-relaunch hint must offer `claude --resume <id>` so the operator
-    // resumes the exact conversation instead of a self-switch no-op.
+fn inplace_self_relaunch_hint_suggests_managed_resume() {
+    // #2794: the honest self-relaunch hint must point at the MANAGED relaunch
+    // `tm sessions resume <managed-id>` — re-spawning the runtime with the
+    // tm-owned CLAUDE_CONFIG_DIR, roster, and persona intact — keyed on the
+    // managed session id (`record.id`), NOT the claude conversation id.
     let mut record = make_session("tm-cto-01", "active", None);
+    // A claude_session_id must NOT leak into the hint — the managed id is what
+    // `tm sessions resume` takes.
     record.claude_session_id = Some("bfc69db6-cb98-4aa7-a07d-89fd69ba710b".to_string());
     let hint = inplace_self_relaunch_hint(&record);
     assert!(
-        hint.contains("claude --resume bfc69db6-cb98-4aa7-a07d-89fd69ba710b"),
-        "hint must suggest resuming the exact claude session: {hint:?}"
+        hint.contains(&format!("tm sessions resume {}", record.id)),
+        "hint must suggest the managed `tm sessions resume <id>`: {hint:?}"
     );
     assert!(
         hint.contains("already inside this session's pane"),
@@ -1961,21 +1964,22 @@ fn inplace_self_relaunch_hint_uses_resume_when_session_id_present() {
 }
 
 #[test]
-fn inplace_self_relaunch_hint_bare_claude_when_no_session_id() {
-    // Without a claude_session_id (or a blank one) the hint falls back to a
-    // bare `claude` rather than emitting `claude --resume ` with an empty arg.
-    let mut record = make_session("tm-cto-01", "active", None);
-    record.claude_session_id = None;
-    let hint = inplace_self_relaunch_hint(&record);
-    assert!(
-        hint.contains("claude") && !hint.contains("--resume"),
-        "hint must suggest a bare `claude` when no session id is known: {hint:?}"
-    );
-
-    record.claude_session_id = Some("   ".to_string());
-    let hint_blank = inplace_self_relaunch_hint(&record);
-    assert!(
-        !hint_blank.contains("--resume"),
-        "a blank claude_session_id must not produce `claude --resume`: {hint_blank:?}"
-    );
+fn inplace_self_relaunch_hint_never_suggests_bare_claude() {
+    // #2794 regression guard: a bare `claude` (or `claude --resume <id>`)
+    // launches OUTSIDE the managed session, dropping the tm-owned config —
+    // the hint must NEVER suggest it, with or without a claude_session_id.
+    for sid in [None, Some("abc123".to_string()), Some("   ".to_string())] {
+        let mut record = make_session("tm-cto-01", "active", None);
+        record.claude_session_id = sid.clone();
+        let hint = inplace_self_relaunch_hint(&record);
+        assert!(
+            !hint.contains("claude"),
+            "hint must never mention a bare `claude` (loses managed config); \
+             sid={sid:?}: {hint:?}"
+        );
+        assert!(
+            hint.contains("tm sessions resume"),
+            "hint must always point at the managed resume; sid={sid:?}: {hint:?}"
+        );
+    }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
@@ -46,7 +46,8 @@ use super::{parse_id, record_to_summary};
 /// What: an optional `caller_pane_id` (tmux's `%N`). Absent for non-tmux or
 /// pre-#2789 clients, in which case reconciliation behaves exactly as before.
 /// The `pane_confirmed_dead` flag (#2790-follow-up) carries the CLI's
-/// independent proof-of-death — see its field doc and
+/// self-asserted proof-of-death claim — see its field doc for the trust-model
+/// discussion (accepted, not independently verified) — and
 /// [`should_reconcile_stale_active`].
 /// Test: `should_reconcile_stale_active_true_when_only_caller_pane_busy`,
 /// `should_reconcile_stale_active_true_when_confirmed_dead_and_pane_missing`.
@@ -56,17 +57,24 @@ pub struct ReactivateQuery {
     /// from (the pane about to `exec` `claude` in place).
     #[serde(default)]
     pub caller_pane_id: Option<String>,
-    /// Set by an in-place-relaunch client that has INDEPENDENTLY confirmed, via
-    /// tmux's stable `pane_id` (`bin/tm`'s `guided::pane_identity_confirmed`),
-    /// that it is running inside THIS record's OWN pane and observed the agent
-    /// exit. That is authoritative proof-of-death the daemon's own tmux-pane
-    /// liveness probe cannot see (the requesting `tm` is that pane's foreground
-    /// command; a just-exited agent may leave a not-yet-reaped child; a racing
-    /// `list-panes` may momentarily omit the pane). When `true`,
-    /// [`should_reconcile_stale_active`] trusts it over the probe for the
-    /// caller's OWN pane while still refusing if a genuinely live SIBLING pane
-    /// keeps the tmux session busy (#2157). Absent/false for every pre-existing
-    /// client, preserving the prior probe-only behavior.
+    /// Set by an in-place-relaunch client that has matched tmux's stable
+    /// `pane_id` (`bin/tm`'s `guided::pane_identity_confirmed`) against the
+    /// record and is asserting — a CLIENT SELF-ASSERTION, not something the
+    /// daemon independently verifies (no process/ancestry check) — that it is
+    /// running inside THIS record's OWN pane and observed the agent exit. Like
+    /// every other managed-session state transition this daemon accepts from a
+    /// caller (resume/stop/decommission included), the assertion is trusted
+    /// under the localhost/single-operator threat model this daemon runs
+    /// under, not treated as a cryptographically-verified fact. It is still
+    /// bounded, not a free pass: the pane match can be wrong in ways the
+    /// daemon's own tmux-pane liveness probe cannot see (the requesting `tm` is
+    /// that pane's foreground command; a just-exited agent may leave a
+    /// not-yet-reaped child; a racing `list-panes` may momentarily omit the
+    /// pane), so when `true`, [`should_reconcile_stale_active`] trusts it OVER
+    /// the probe only for the caller's OWN pane, while an INDEPENDENT
+    /// sibling-pane liveness check still refuses if a genuinely live SIBLING
+    /// pane keeps the tmux session busy (#2157). Absent/false for every
+    /// pre-existing client, preserving the prior probe-only behavior.
     #[serde(default)]
     pub pane_confirmed_dead: bool,
 }
@@ -150,9 +158,14 @@ pub async fn reactivate_managed_session(
 /// (a still-live pane — including a genuinely different, still-active sibling
 /// window in the SAME tmux session, #2157 — keeps the existing 409 refusal,
 /// preserving that safety boundary). `pane_confirmed_dead` forwards the CLI's
-/// proof-of-death (see [`ReactivateQuery::pane_confirmed_dead`]) so a caller
-/// provably inside the record's OWN pane reconciles even when the tmux-pane
-/// probe would false-positive on that pane. On confirmation, calls
+/// self-asserted claim (see [`ReactivateQuery::pane_confirmed_dead`] for the
+/// trust-model discussion — it is accepted, not independently re-verified,
+/// same as this daemon accepts any other client-originated state-transition
+/// request) that it is inside the record's OWN pane and observed the agent
+/// exit, so a caller matching that description reconciles even when the
+/// tmux-pane probe would false-positive on that pane — bounded by the SAME
+/// independent sibling-pane liveness check every other path here uses. On
+/// confirmation, calls
 /// [`SessionManager::mark_runtime_exited_stopped`] then
 /// [`SessionManager::mark_reactivated`]; any failure at either step (tmux
 /// discovery, pane listing, or either state transition) also yields `None` so
@@ -209,23 +222,29 @@ async fn reconcile_stale_active_then_reactivate(
 /// trust assumption — while every OTHER (sibling) pane is checked unchanged, so
 /// a genuinely live sibling window still blocks the reconcile.
 /// #2794: `caller_pane_confirmed_dead` (from
-/// [`ReactivateQuery::pane_confirmed_dead`]) is the CLI's authoritative
-/// proof-of-death. `find_runtime_exited` requires the record's tmux session to
-/// be PRESENT in `panes` AND every one of its panes to read idle — a
-/// conservative rule that is correct for the periodic reaper but leaves a
-/// residual gap for the in-place-relaunch caller: its OWN pane can read busy in
-/// ways [`neutralize_caller_pane`] cannot always repair (a racing `list-panes`
-/// omitting the pane entirely, or a not-yet-reaped agent child the probe still
-/// counts). Bob's #2794 repro (a zombie-`Active` record that only reconciled
-/// minutes later once the reaper independently caught up) is exactly that gap.
-/// When the CLI has PROVEN via stable `pane_id` that it is this record's own
-/// pane (`bin/tm`'s `guided::pane_identity_confirmed`) and observed the agent
-/// exit, that proof overrides the probe for the caller's OWN pane: reconcile as
-/// long as no genuinely different SIBLING pane keeps the session live (the
-/// #2157 boundary). This never requires the session to be "present", so the
-/// missing-pane race no longer strands the operator — and it stays SAFE because
-/// the caller could not be `pane_identity_confirmed` inside a session that had
-/// actually disappeared.
+/// [`ReactivateQuery::pane_confirmed_dead`]) is the CLI's self-asserted claim
+/// — NOT independently verified by the daemon (no process/ancestry check) —
+/// that it is this record's OWN pane and the agent has exited, accepted under
+/// the same localhost/single-operator trust model this daemon already extends
+/// to every other client-originated state transition (resume/stop/
+/// decommission), and bounded by an INDEPENDENT sibling-pane liveness check
+/// (below), not taken as a bare capability grant. `find_runtime_exited`
+/// requires the record's tmux session to be PRESENT in `panes` AND every one
+/// of its panes to read idle — a conservative rule that is correct for the
+/// periodic reaper but leaves a residual gap for the in-place-relaunch caller:
+/// its OWN pane can read busy in ways [`neutralize_caller_pane`] cannot always
+/// repair (a racing `list-panes` omitting the pane entirely, or a not-yet-reaped
+/// agent child the probe still counts). Bob's #2794 repro (a zombie-`Active`
+/// record that only reconciled minutes later once the reaper independently
+/// caught up) is exactly that gap. When the CLI asserts, via stable `pane_id`
+/// (`bin/tm`'s `guided::pane_identity_confirmed`), that it is this record's own
+/// pane and observed the agent exit, that assertion is trusted OVER the probe
+/// for the caller's OWN pane: reconcile as long as no genuinely different
+/// SIBLING pane keeps the session live (the #2157 boundary, independently
+/// re-checked here regardless of the assertion). This never requires the
+/// session to be "present", so the missing-pane race no longer strands the
+/// operator, while the sibling check keeps a stale or mistaken assertion from
+/// silently overriding a genuinely live different window.
 ///
 /// What: `true` when `record.state == Active` AND either — (a)
 /// `caller_pane_confirmed_dead` is set with a non-blank `caller_pane_id` and no
@@ -244,6 +263,7 @@ async fn reconcile_stale_active_then_reactivate(
 /// `should_reconcile_stale_active_true_when_only_caller_pane_busy`,
 /// `should_reconcile_stale_active_false_when_sibling_pane_live_despite_caller`,
 /// `should_reconcile_stale_active_true_when_confirmed_dead_and_pane_missing`,
+/// `should_reconcile_stale_active_true_when_confirmed_dead_and_caller_pane_busy`,
 /// `should_reconcile_stale_active_false_when_confirmed_dead_but_sibling_live`,
 /// `should_reconcile_stale_active_ignores_confirmed_dead_without_caller_pane`.
 pub(crate) fn should_reconcile_stale_active(
@@ -258,11 +278,13 @@ pub(crate) fn should_reconcile_stale_active(
     }
     let neutralized = neutralize_caller_pane(panes, caller_pane_id);
     if caller_pane_confirmed_dead && caller_pane_id.is_some_and(|s| !s.is_empty()) {
-        // Proof-of-death path: the caller's own pane is authoritatively idle
-        // (already neutralized above); reconcile unless a SIBLING pane keeps the
-        // session live. Deliberately does NOT gate on session presence, so a
-        // pane momentarily missing from `list-panes` cannot block a caller
-        // provably inside the record's pane.
+        // Self-asserted proof-of-death path: the caller's own pane is trusted
+        // as idle (already neutralized above) on the caller's say-so, accepted
+        // under this daemon's localhost/single-operator trust model; reconcile
+        // unless an INDEPENDENTLY checked SIBLING pane keeps the session live.
+        // Deliberately does NOT gate on session presence, so a pane momentarily
+        // missing from `list-panes` cannot block a caller asserting it is
+        // inside the record's pane.
         return !session_has_live_pane(&record.tmux_name, &neutralized, probe);
     }
     !find_runtime_exited(std::slice::from_ref(record), &neutralized, probe).is_empty()

--- a/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reactivate.rs
@@ -23,7 +23,7 @@ use axum::{
 use serde::Deserialize;
 
 use crate::daemon::orphan_gc::{ChildLivenessProbe, PaneInfo, ProcessTreeProbe};
-use crate::daemon::runtime_reap::find_runtime_exited;
+use crate::daemon::runtime_reap::{find_runtime_exited, session_has_live_pane};
 use crate::daemon::state::DaemonState;
 use crate::session_manager::{
     ManagedError, ManagedSessionId, ManagedSessionState, SessionManager, SessionRecord,
@@ -45,13 +45,30 @@ use super::{parse_id, record_to_summary};
 /// one self-referential pane from the liveness check.
 /// What: an optional `caller_pane_id` (tmux's `%N`). Absent for non-tmux or
 /// pre-#2789 clients, in which case reconciliation behaves exactly as before.
-/// Test: `should_reconcile_stale_active_true_when_only_caller_pane_busy`.
+/// The `pane_confirmed_dead` flag (#2790-follow-up) carries the CLI's
+/// independent proof-of-death — see its field doc and
+/// [`should_reconcile_stale_active`].
+/// Test: `should_reconcile_stale_active_true_when_only_caller_pane_busy`,
+/// `should_reconcile_stale_active_true_when_confirmed_dead_and_pane_missing`.
 #[derive(Debug, Default, Deserialize)]
 pub struct ReactivateQuery {
     /// The stable tmux `pane_id` of the pane the reactivate request originates
     /// from (the pane about to `exec` `claude` in place).
     #[serde(default)]
     pub caller_pane_id: Option<String>,
+    /// Set by an in-place-relaunch client that has INDEPENDENTLY confirmed, via
+    /// tmux's stable `pane_id` (`bin/tm`'s `guided::pane_identity_confirmed`),
+    /// that it is running inside THIS record's OWN pane and observed the agent
+    /// exit. That is authoritative proof-of-death the daemon's own tmux-pane
+    /// liveness probe cannot see (the requesting `tm` is that pane's foreground
+    /// command; a just-exited agent may leave a not-yet-reaped child; a racing
+    /// `list-panes` may momentarily omit the pane). When `true`,
+    /// [`should_reconcile_stale_active`] trusts it over the probe for the
+    /// caller's OWN pane while still refusing if a genuinely live SIBLING pane
+    /// keeps the tmux session busy (#2157). Absent/false for every pre-existing
+    /// client, preserving the prior probe-only behavior.
+    #[serde(default)]
+    pub pane_confirmed_dead: bool,
 }
 
 /// POST /api/v1/sessions/managed/{id}/reactivate — flip Stopped -> Active IN
@@ -100,6 +117,7 @@ pub async fn reactivate_managed_session(
             &mgr,
             &id,
             params.caller_pane_id.as_deref(),
+            params.pane_confirmed_dead,
         )
         .await
         {
@@ -131,7 +149,10 @@ pub async fn reactivate_managed_session(
 /// session — EXCEPT the caller's own pane (`caller_pane_id`, #2789) — is idle
 /// (a still-live pane — including a genuinely different, still-active sibling
 /// window in the SAME tmux session, #2157 — keeps the existing 409 refusal,
-/// preserving that safety boundary). On confirmation, calls
+/// preserving that safety boundary). `pane_confirmed_dead` forwards the CLI's
+/// proof-of-death (see [`ReactivateQuery::pane_confirmed_dead`]) so a caller
+/// provably inside the record's OWN pane reconciles even when the tmux-pane
+/// probe would false-positive on that pane. On confirmation, calls
 /// [`SessionManager::mark_runtime_exited_stopped`] then
 /// [`SessionManager::mark_reactivated`]; any failure at either step (tmux
 /// discovery, pane listing, or either state transition) also yields `None` so
@@ -143,13 +164,20 @@ async fn reconcile_stale_active_then_reactivate(
     mgr: &SessionManager,
     id: &ManagedSessionId,
     caller_pane_id: Option<&str>,
+    pane_confirmed_dead: bool,
 ) -> Option<SessionRecord> {
     let record = mgr.get(id).await.ok()?;
     let panes = crate::daemon::tmux::TmuxDriver::discover()
         .ok()?
         .list_managed_panes()
         .ok()?;
-    if !should_reconcile_stale_active(&record, &panes, caller_pane_id, &ProcessTreeProbe) {
+    if !should_reconcile_stale_active(
+        &record,
+        &panes,
+        caller_pane_id,
+        pane_confirmed_dead,
+        &ProcessTreeProbe,
+    ) {
         return None;
     }
     mgr.mark_runtime_exited_stopped(id).await.ok()?;
@@ -180,29 +208,63 @@ async fn reconcile_stale_active_then_reactivate(
 /// `claude`, treating the caller's own pane as idle is SOUND, not merely a
 /// trust assumption — while every OTHER (sibling) pane is checked unchanged, so
 /// a genuinely live sibling window still blocks the reconcile.
-/// What: `true` only when `record.state == Active` AND `find_runtime_exited`
-/// (scoped to just this one record, over the caller-neutralized pane list)
-/// selects it — i.e. its tmux session has at least one present pane and NONE of
-/// them (other than the caller's own) are still running an agent.
-/// `false` for every other state (Provisioning/Errored/Decommissioned — those
-/// fall through to the ordinary 409, matching `mark_reactivated`'s Stopped-only
-/// contract) and for a missing/still-live-sibling pane.
+/// #2794: `caller_pane_confirmed_dead` (from
+/// [`ReactivateQuery::pane_confirmed_dead`]) is the CLI's authoritative
+/// proof-of-death. `find_runtime_exited` requires the record's tmux session to
+/// be PRESENT in `panes` AND every one of its panes to read idle — a
+/// conservative rule that is correct for the periodic reaper but leaves a
+/// residual gap for the in-place-relaunch caller: its OWN pane can read busy in
+/// ways [`neutralize_caller_pane`] cannot always repair (a racing `list-panes`
+/// omitting the pane entirely, or a not-yet-reaped agent child the probe still
+/// counts). Bob's #2794 repro (a zombie-`Active` record that only reconciled
+/// minutes later once the reaper independently caught up) is exactly that gap.
+/// When the CLI has PROVEN via stable `pane_id` that it is this record's own
+/// pane (`bin/tm`'s `guided::pane_identity_confirmed`) and observed the agent
+/// exit, that proof overrides the probe for the caller's OWN pane: reconcile as
+/// long as no genuinely different SIBLING pane keeps the session live (the
+/// #2157 boundary). This never requires the session to be "present", so the
+/// missing-pane race no longer strands the operator — and it stays SAFE because
+/// the caller could not be `pane_identity_confirmed` inside a session that had
+/// actually disappeared.
+///
+/// What: `true` when `record.state == Active` AND either — (a)
+/// `caller_pane_confirmed_dead` is set with a non-blank `caller_pane_id` and no
+/// SIBLING pane in the record's tmux session is still live (over the
+/// caller-neutralized list); or (b) the ordinary `find_runtime_exited` (scoped
+/// to just this record, over the caller-neutralized pane list) selects it — its
+/// tmux session has at least one present pane and NONE (other than the caller's
+/// own) are still running an agent. `false` for every other state
+/// (Provisioning/Errored/Decommissioned — those fall through to the ordinary
+/// 409, matching `mark_reactivated`'s Stopped-only contract) and, on the
+/// probe-only path (b), for a missing/still-live-sibling pane.
 /// Test: `should_reconcile_stale_active_true_when_active_and_idle`,
 /// `should_reconcile_stale_active_false_when_pane_still_live`,
 /// `should_reconcile_stale_active_false_when_pane_missing`,
 /// `should_reconcile_stale_active_false_when_not_active`,
 /// `should_reconcile_stale_active_true_when_only_caller_pane_busy`,
-/// `should_reconcile_stale_active_false_when_sibling_pane_live_despite_caller`.
+/// `should_reconcile_stale_active_false_when_sibling_pane_live_despite_caller`,
+/// `should_reconcile_stale_active_true_when_confirmed_dead_and_pane_missing`,
+/// `should_reconcile_stale_active_false_when_confirmed_dead_but_sibling_live`,
+/// `should_reconcile_stale_active_ignores_confirmed_dead_without_caller_pane`.
 pub(crate) fn should_reconcile_stale_active(
     record: &SessionRecord,
     panes: &[PaneInfo],
     caller_pane_id: Option<&str>,
+    caller_pane_confirmed_dead: bool,
     probe: &dyn ChildLivenessProbe,
 ) -> bool {
     if record.state != ManagedSessionState::Active {
         return false;
     }
     let neutralized = neutralize_caller_pane(panes, caller_pane_id);
+    if caller_pane_confirmed_dead && caller_pane_id.is_some_and(|s| !s.is_empty()) {
+        // Proof-of-death path: the caller's own pane is authoritatively idle
+        // (already neutralized above); reconcile unless a SIBLING pane keeps the
+        // session live. Deliberately does NOT gate on session presence, so a
+        // pane momentarily missing from `list-panes` cannot block a caller
+        // provably inside the record's pane.
+        return !session_has_live_pane(&record.tmux_name, &neutralized, probe);
+    }
     !find_runtime_exited(std::slice::from_ref(record), &neutralized, probe).is_empty()
 }
 
@@ -311,6 +373,7 @@ mod tests {
             &record,
             &panes,
             None,
+            false,
             &AlwaysIdleProbe
         ));
     }
@@ -325,6 +388,7 @@ mod tests {
             &record,
             &panes,
             None,
+            false,
             &AlwaysIdleProbe
         ));
     }
@@ -341,6 +405,7 @@ mod tests {
             &record,
             &panes,
             None,
+            false,
             &AlwaysIdleProbe
         ));
     }
@@ -354,6 +419,7 @@ mod tests {
             &record,
             &[],
             None,
+            false,
             &AlwaysIdleProbe
         ));
     }
@@ -371,7 +437,7 @@ mod tests {
             record.state = state.clone();
             let panes = vec![pane("tm-demo", "zsh")];
             assert!(
-                !should_reconcile_stale_active(&record, &panes, None, &AlwaysIdleProbe),
+                !should_reconcile_stale_active(&record, &panes, None, false, &AlwaysIdleProbe),
                 "state {state} must not be reconciled"
             );
         }
@@ -388,12 +454,12 @@ mod tests {
         let record = active_record("tm-cto-01");
         let panes = vec![pane_with_id("tm-cto-01", "tm", "%3")];
         assert!(
-            !should_reconcile_stale_active(&record, &panes, None, &AlwaysIdleProbe),
+            !should_reconcile_stale_active(&record, &panes, None, false, &AlwaysIdleProbe),
             "pre-#2789 behavior (no caller_pane_id): the caller's own `tm` pane \
              is still (wrongly) seen as live"
         );
         assert!(
-            should_reconcile_stale_active(&record, &panes, Some("%3"), &AlwaysIdleProbe),
+            should_reconcile_stale_active(&record, &panes, Some("%3"), false, &AlwaysIdleProbe),
             "#2789: naming the caller's own pane must let its session reconcile"
         );
     }
@@ -409,7 +475,7 @@ mod tests {
             pane_with_id("tm-cto-01", "claude", "%4"), // genuinely live sibling
         ];
         assert!(
-            !should_reconcile_stale_active(&record, &panes, Some("%3"), &AlwaysIdleProbe),
+            !should_reconcile_stale_active(&record, &panes, Some("%3"), false, &AlwaysIdleProbe),
             "a live sibling pane must still block reconcile even when the \
              caller's own pane is excluded"
         );
@@ -423,8 +489,74 @@ mod tests {
         let record = active_record("tm-demo");
         let panes = vec![pane_with_id("tm-demo", "claude", "%1")];
         assert!(
-            !should_reconcile_stale_active(&record, &panes, Some("%99"), &AlwaysIdleProbe),
+            !should_reconcile_stale_active(&record, &panes, Some("%99"), false, &AlwaysIdleProbe),
             "an unmatched caller_pane_id must not force any pane idle"
+        );
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_true_when_confirmed_dead_and_pane_missing() {
+        // #2794 core repro: the caller has PROVEN (CLI-side pane_identity_
+        // confirmed) it is inside this record's OWN pane and the agent exited,
+        // but `list-panes` momentarily reports NO pane for the session (a race
+        // the probe-only path treats as "session gone" → 409, the reported
+        // dead-end). Proof-of-death must reconcile anyway — there is no sibling
+        // to protect.
+        let record = active_record("tm-mcp-services-01");
+        assert!(
+            !should_reconcile_stale_active(&record, &[], Some("%5"), false, &AlwaysIdleProbe),
+            "without proof-of-death, a missing pane keeps the ordinary 409"
+        );
+        assert!(
+            should_reconcile_stale_active(&record, &[], Some("%5"), true, &AlwaysIdleProbe),
+            "#2794: a pane-confirmed-dead caller reconciles even when \
+             list-panes omits its pane"
+        );
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_true_when_confirmed_dead_and_caller_pane_busy() {
+        // The exact zombie-Active shape: the record still reads Active and the
+        // caller's own pane reports `tm` (its foreground command), which the
+        // probe reads as live. Proof-of-death overrides the probe for the
+        // caller's OWN pane.
+        let record = active_record("tm-mcp-services-01");
+        let panes = vec![pane_with_id("tm-mcp-services-01", "tm", "%5")];
+        assert!(
+            should_reconcile_stale_active(&record, &panes, Some("%5"), true, &AlwaysIdleProbe),
+            "#2794: pane-confirmed-dead reconciles its own busy `tm` pane"
+        );
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_false_when_confirmed_dead_but_sibling_live() {
+        // Proof-of-death for the caller's OWN pane must NOT override a genuinely
+        // live claude in a DIFFERENT window of the same tmux session (#2157).
+        let record = active_record("tm-mcp-services-01");
+        let panes = vec![
+            pane_with_id("tm-mcp-services-01", "tm", "%5"), // caller's own pane
+            pane_with_id("tm-mcp-services-01", "claude", "%6"), // live sibling
+        ];
+        assert!(
+            !should_reconcile_stale_active(&record, &panes, Some("%5"), true, &AlwaysIdleProbe),
+            "a live sibling window must still block reconcile despite proof-of-death"
+        );
+    }
+
+    #[test]
+    fn should_reconcile_stale_active_ignores_confirmed_dead_without_caller_pane() {
+        // The proof-of-death shortcut requires a concrete caller_pane_id — the
+        // flag alone (no pane id, or a blank one) must fall back to the ordinary
+        // probe-based path, never a blanket reconcile.
+        let record = active_record("tm-demo");
+        let panes = vec![pane("tm-demo", "claude")];
+        assert!(
+            !should_reconcile_stale_active(&record, &panes, None, true, &AlwaysIdleProbe),
+            "pane_confirmed_dead without a caller_pane_id must not reconcile a live pane"
+        );
+        assert!(
+            !should_reconcile_stale_active(&record, &panes, Some(""), true, &AlwaysIdleProbe),
+            "a blank caller_pane_id must not trigger the proof-of-death shortcut"
         );
     }
 }


### PR DESCRIPTION
## What

Bare `tm` run inside a managed session's OWN pane — after its agent exited but while the record still reads `Active` (a **zombie**: the periodic reaper has not yet flipped it to `Stopped`) — dead-ended:

```
tm: this pane belongs to managed session e99bcc7f-... — relaunching in place…
tm: daemon refused to reactivate session e99bcc7f-... (409 Conflict) — aborting in-place relaunch, falling back to the guided picker
tm: in-place relaunch unavailable for 'tm-mcp-services-01' (state=active)
tm: you are already inside this session's pane — its agent has exited; relaunch it here with:  claude
```

The pane-identity-confirmed in-place path asked the daemon to reactivate; the daemon 409'd the `Active` record because its tmux-pane liveness probe still counted the requesting `tm` process (the pane's own foreground command) — and a not-yet-reaped child — as a live runtime. Only the reaper, minutes later once the `tm` process had exited and the pane read as a bare shell, caught up. The CLI then printed a **wrong** hint suggesting a bare `claude`, which launches OUTSIDE the managed session, dropping the tm-owned `CLAUDE_CONFIG_DIR`, agent roster, and persona (DOC-34 managed config).

This is the `Active`/zombie sibling of the **decommissioned** dead-end fixed by #2780.

## Fix

**Forward the CLI's proof-of-death to the daemon reconcile.** The pane-identity-confirmed branch already proves, via the stable tmux `pane_id` (`guided::pane_identity_confirmed`), that this process is inside the record's OWN pane and the agent has exited (a live agent could not have handed the pane back to a shell). That is authoritative proof-of-death the daemon's probe cannot see.

- **CLI** (`guided.rs`/`guided_inplace.rs`): the pane-confirmed branch forwards a new `?pane_confirmed_dead=true` reactivate param.
- **Daemon** (`reactivate.rs`): `should_reconcile_stale_active` gains a `caller_pane_confirmed_dead` flag. When set (with a concrete `caller_pane_id`), it reconciles the zombie-`Active` (flip `Active→Stopped`, then reactivate) as long as **no genuinely live SIBLING pane** keeps the tmux session busy (#2157 boundary preserved) — even if `list-panes` reports the caller's pane busy or omits it in a race. Without the flag, behavior is unchanged (probe-only).
- **Hint** (`inplace_self_relaunch_hint`): in every fallback case it now points at the managed `tm sessions resume <id>`, never a bare `claude`.

## Decision-flow change

| Scenario (bare `tm`, inside record's own pane, agent exited) | Before | After |
|---|---|---|
| record `Stopped` | in-place relaunch ✓ | unchanged ✓ |
| record still `Active` (zombie), pane reads busy | reactivate → **409 → dead-end**, hint = `claude` | `pane_confirmed_dead` → reconcile → reactivate → **relaunch in place ✓** |
| genuinely live agent in a SIBLING window | 409 refusal | 409 refusal (unchanged), hint = `tm sessions resume <id>` |

## Tests (failing-first on the pure seams)

- `should_reconcile_stale_active_true_when_confirmed_dead_and_pane_missing`, `..._and_caller_pane_busy`, `..._false_when_confirmed_dead_but_sibling_live`, `..._ignores_confirmed_dead_without_caller_pane` (daemon predicate)
- `reactivate_forwards_pane_confirmed_dead_query` (CLI forwards the param)
- `inplace_self_relaunch_hint_suggests_managed_resume`, `inplace_self_relaunch_hint_never_suggests_bare_claude` (corrected hint)

## Gate

- `cargo build -p trusty-mpm` ✓
- `cargo test -p trusty-mpm` — 0 failed ✓
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — exit 0 ✓
- `cargo fmt --check` — exit 0 ✓
- `bash scripts/check_line_cap.sh` — 0 violations ✓
- `bash scripts/check_test_pointers.sh` — exit 0 ✓

Closes #2794.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
