### PR TITLE
feat: surface/warm trusty-search index readiness for daily-driver sessions

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Surface trusty-search index readiness to daily-driver task sessions: after warming the project's index at task start, `ensure_project_indexed_in_background` now probes `GET /indexes/{id}/status` (via the shared `trusty_common::search_readiness::log_index_readiness`) and emits one stderr line describing which lanes are ready — `warn` while semantic embedding is still warming (expect lexical-only results), `info` once it is ready — so a session is never silently querying a not-yet-ready index ([#2784](https://github.com/bobmatnyc/trusty-tools/issues/2784))
+
 ## [0.1.0] — 2026-07-09
 
 ### Added

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -80,14 +80,29 @@ const ENGINEER_AGENT_NAME: &str = "python-engineer";
 /// Spawns a detached OS thread that calls the shared helper (which itself runs
 /// the blocking HTTP on its own short-timeout threads) and returns immediately,
 /// so the caller never waits on the network.
+/// After warming, this also SURFACES the resulting index readiness to the
+/// session (issue #2784): a cold-indexed large repo has a real semantic
+/// warm-up window (lexical ready in seconds, semantic embedding `InProgress`
+/// for minutes), so a daily-driver `tcode` session that starts querying
+/// immediately would otherwise get lexical-only results with no signal. The
+/// detached thread probes `GET /indexes/{id}/status` right after triggering the
+/// warm and emits ONE `tracing` line (via the shared
+/// [`trusty_common::search_readiness::log_index_readiness`]) describing which
+/// lanes are ready — `warn` while semantic is still warming, `info` once it is
+/// ready. Same fail-open contract: no daemon ⇒ no log, never a block.
+///
 /// Test: the promoted helper's fail-open + no-daemon + non-git-root behaviour is
-/// unit-tested in `trusty_common::search_index::tests`. This thin spawn wrapper
-/// is side-effect-only (detached thread) and has no return to assert; see
+/// unit-tested in `trusty_common::search_index::tests`; the readiness probe/parse
+/// in `trusty_common::search_readiness::tests`. This thin spawn wrapper is
+/// side-effect-only (detached thread) and has no return to assert; see
 /// `spawns_indexing_thread_for_non_git_project_path` for the one thing it IS
 /// mechanically checked for here — that it never short-circuits before spawning.
 pub(crate) fn ensure_project_indexed_in_background(project: PathBuf) {
     std::thread::spawn(move || {
+        // Warm first, then surface the readiness the warm produced so the
+        // session knows whether a semantic search is trustworthy yet (#2784).
         let _ = trusty_common::search_index::ensure_project_indexed(&project);
+        trusty_common::search_readiness::log_index_readiness(&project);
     });
 }
 

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `search_readiness` module (behind the `search-index` feature): a shared trusty-search index readiness probe so a daily-driver session can *surface* whether a project's index is ready per lane (lexical/semantic/graph) instead of silently querying a not-yet-warm index — `parse_readiness` (pure status→snapshot map), `probe_index_readiness` (fail-open `GET /indexes/{id}/status`), and `log_index_readiness` (one stderr line) ([#2784](https://github.com/bobmatnyc/trusty-tools/issues/2784))
 - telegram module (rebase) ([#2729](https://github.com/bobmatnyc/trusty-tools/pull/2729)) ([`142675f`](https://github.com/bobmatnyc/trusty-tools/commit/142675fe01cc83b63497578611581921192a850b))
 - implement Slack search + reactions with two-token model ([#2726](https://github.com/bobmatnyc/trusty-tools/pull/2726)) ([`6e4e7d9`](https://github.com/bobmatnyc/trusty-tools/commit/6e4e7d9d8b18ba602f588e700142032789018142))
 - implement Slack send + read tools; extract SlackFormatter to trusty-common ([#2722](https://github.com/bobmatnyc/trusty-tools/pull/2722)) ([`847a0c3`](https://github.com/bobmatnyc/trusty-tools/commit/847a0c334e1a8822a7d31696b48946e538aca7cc))

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -426,6 +426,23 @@ pub use index_id::{derive_index_id, find_git_root, resolve_project_root};
 #[cfg(feature = "search-index")]
 pub mod search_index;
 
+/// Shared trusty-search index READINESS probe (issue #2784), gated behind the
+/// `search-index` feature alongside the warming helper it complements.
+///
+/// Why: [`search_index::ensure_project_indexed`] *warms* a project's index at
+/// task start but never told the session whether it was actually ready — so a
+/// daily-driver session could silently query during the semantic warm-up
+/// window and get lexical-only results with no signal. This module adds the
+/// missing *surfacing* half so both crates that warm (trusty-code, trusty-mpm)
+/// can also report readiness from the ONE shared implementation.
+/// What: exposes [`search_readiness::probe_index_readiness`] (fail-open probe),
+/// the pure [`search_readiness::parse_readiness`] mapper, and
+/// [`search_readiness::log_index_readiness`] (one stderr line surfacing lane
+/// readiness to the session).
+/// Test: `cargo test -p trusty-common --features search-index -- search_readiness::tests`.
+#[cfg(feature = "search-index")]
+pub mod search_readiness;
+
 /// Canonical tmux-session naming shared by both session managers (SPEC-ONESM-01).
 ///
 /// Why: trusty-mpm's `SessionManager` and trusty-agents' `TmManager` both create

--- a/crates/trusty-common/src/search_readiness.rs
+++ b/crates/trusty-common/src/search_readiness.rs
@@ -1,0 +1,345 @@
+//! Shared trusty-search index READINESS probe (issue #2784).
+//!
+//! Why: cold-indexing a large repo has a real semantic-warm-up window — the
+//! lexical (BM25) lane comes up in seconds, but semantic embedding of a large
+//! monorepo can stay `InProgress` for many minutes on `trusty-embedderd`. A
+//! daily-driver session (a `tcode` task, a `trusty-mpm` session) that starts
+//! working immediately searches BEFORE the semantic lane is ready and silently
+//! gets lexical-only results with no signal that the index is still warming.
+//! [`crate::search_index::ensure_project_indexed`] already *warms* the index
+//! (find-or-create + freshness-gated reindex) at task start; this module adds
+//! the missing half — *surfacing* the resulting readiness to the session so it
+//! is not operating blind against a not-yet-ready index. Per the workspace
+//! common-entry-point rule the primitive lives here, in one shared module, so
+//! every caller reads the exact same `GET /indexes/{id}/status` contract.
+//!
+//! What: [`parse_readiness`] is a pure map from a `/status` JSON body to a small
+//! [`IndexReadiness`] snapshot (lifecycle status + per-lane ready flags derived
+//! from the daemon's `search_capabilities` array). [`probe_index_readiness`]
+//! resolves the daemon address and canonical index id, does one short-timeout
+//! blocking `GET` on a dedicated OS thread (safe to call from inside a tokio
+//! runtime, mirroring [`crate::search_index`]'s HTTP helpers), and parses the
+//! body — returning `None`, never an error, whenever the daemon is unreachable,
+//! the id is not derivable, or the probe fails (fail-open by design, exactly
+//! like the warming path). [`log_index_readiness`] is the session-facing
+//! surface: it probes and emits ONE `tracing` line (to stderr, per the daemon
+//! stdout-cleanliness rule) describing what a search will and won't yet find.
+//!
+//! Test: `parse_readiness_*`, `summary_*`, and
+//! `probe_index_readiness_none_when_daemon_down` in the `tests` module below.
+
+use std::path::Path;
+
+/// The daemon `search_capabilities` token present once the lexical (BM25) lane
+/// is queryable.
+const CAP_LEXICAL: &str = "bm25";
+/// The `search_capabilities` token present once the semantic (vector) lane is
+/// queryable.
+const CAP_SEMANTIC: &str = "vector";
+/// The `search_capabilities` token present once the symbol-graph (KG) lane is
+/// queryable.
+const CAP_GRAPH: &str = "kg";
+
+/// Coarse readiness snapshot of a trusty-search index (issue #2784).
+///
+/// Why: a session needs a single, cheap-to-render value that answers "can I
+/// trust a semantic search yet, or am I still lexical-only?" without every
+/// caller re-parsing the daemon's status JSON or knowing the
+/// `search_capabilities` token spelling.
+/// What: the canonical `index_id`, the daemon's coarse `lifecycle_status`
+/// string (`created` → `walking` → `indexed_lexical` → `indexed_vector` →
+/// `ready`, or `failed`), the durable `chunk_count`, and the three per-lane
+/// ready flags derived from `search_capabilities`.
+/// Test: constructed and asserted throughout the `tests` module.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IndexReadiness {
+    /// Canonical trusty-search index id the readiness pertains to.
+    pub index_id: String,
+    /// Daemon coarse lifecycle status string (back-compat `status` field).
+    pub lifecycle_status: String,
+    /// Durable chunk count reported by the daemon (0 while still empty).
+    pub chunk_count: u64,
+    /// Lexical / BM25 lane is queryable (`"bm25"` in `search_capabilities`).
+    pub lexical_ready: bool,
+    /// Semantic / vector lane is queryable (`"vector"` in `search_capabilities`).
+    pub semantic_ready: bool,
+    /// Symbol-graph / KG lane is queryable (`"kg"` in `search_capabilities`).
+    pub graph_ready: bool,
+}
+
+impl IndexReadiness {
+    /// Whether the semantic lane is up, i.e. hybrid/vector search is trustworthy.
+    ///
+    /// Why: the whole point of #2784 is the gap between "lexical ready" and
+    /// "semantic ready"; this is the single predicate a caller checks to decide
+    /// whether it is still operating in the lexical-only warm-up window.
+    /// What: alias for `semantic_ready`, named for the caller's intent.
+    /// Test: `summary_flags_semantic_pending_during_warmup`.
+    pub fn semantic_search_ready(&self) -> bool {
+        self.semantic_ready
+    }
+
+    /// One-line, human-readable readiness summary for a session log.
+    ///
+    /// Why: [`log_index_readiness`] needs a compact, information-dense string a
+    /// developer reading the session's stderr can act on ("semantic still
+    /// warming — expect lexical-only hits for a bit").
+    /// What: names the index, the coarse lifecycle status, the chunk count, and
+    /// the ready/pending state of each lane.
+    /// Test: `summary_reports_all_lanes_ready`,
+    /// `summary_flags_semantic_pending_during_warmup`.
+    pub fn summary(&self) -> String {
+        let lane = |ready: bool| if ready { "ready" } else { "pending" };
+        format!(
+            "trusty-search index '{}': {} ({} chunks) — lexical {}, semantic {}, graph {}",
+            self.index_id,
+            self.lifecycle_status,
+            self.chunk_count,
+            lane(self.lexical_ready),
+            lane(self.semantic_ready),
+            lane(self.graph_ready),
+        )
+    }
+}
+
+/// Pure map from a `GET /indexes/{id}/status` JSON body to an
+/// [`IndexReadiness`] snapshot (issue #2784).
+///
+/// Why: keeping the parse pure makes the readiness rule unit-testable without a
+/// live daemon — [`probe_index_readiness`] is otherwise all I/O — and pins the
+/// `search_capabilities` token spelling in one place.
+/// What: reads the coarse `status` string (defaulting to `"unknown"` when
+/// absent/malformed), the durable `chunk_count` (defaulting to 0), and derives
+/// the three per-lane flags from membership in the `search_capabilities` array.
+/// Never fails: any missing/mistyped field degrades to a conservative
+/// not-ready default rather than erroring.
+/// Test: `parse_readiness_reads_capabilities_and_status`,
+/// `parse_readiness_defaults_when_fields_absent`.
+pub fn parse_readiness(index_id: &str, status: &serde_json::Value) -> IndexReadiness {
+    let lifecycle_status = status
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+    let chunk_count = status
+        .get("chunk_count")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let has_cap = |token: &str| {
+        status
+            .get("search_capabilities")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|caps| {
+                caps.iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .any(|c| c == token)
+            })
+    };
+    IndexReadiness {
+        index_id: index_id.to_string(),
+        lifecycle_status,
+        chunk_count,
+        lexical_ready: has_cap(CAP_LEXICAL),
+        semantic_ready: has_cap(CAP_SEMANTIC),
+        graph_ready: has_cap(CAP_GRAPH),
+    }
+}
+
+/// Best-effort probe of a project's trusty-search index readiness (issue #2784).
+///
+/// Why: a session wants to know, at start, whether the index it is about to
+/// query is fully warm or still building — but must NEVER be blocked or aborted
+/// by a slow/absent daemon (the same fail-open contract the warming path
+/// honours). Returning `Option` (not `Result`) keeps every failure mode — no
+/// daemon, undrivable id, HTTP error, non-2xx, unparseable body — a quiet
+/// `None` at the call site.
+/// What: resolves the canonical `(root, index_id)` the way
+/// [`crate::search_index::ensure_project_indexed`] does (so this always targets
+/// the same index the warming path created), discovers the daemon base URL, and
+/// — on a dedicated OS thread with a ~1.5s overall / 750ms connect cap (safe
+/// from inside a tokio runtime, mirroring the `search_index` HTTP helpers) —
+/// does one `GET {base}/indexes/{id}/status`, parsing a 2xx body via
+/// [`parse_readiness`]. `None` on any non-success, transport error, or when the
+/// id/daemon can't be resolved.
+/// Test: `probe_index_readiness_none_when_daemon_down` (daemon-down path); the
+/// parse of a live body is covered by [`parse_readiness`]'s own tests.
+pub fn probe_index_readiness(project_root: &Path) -> Option<IndexReadiness> {
+    let root = crate::resolve_project_root(project_root);
+    let index_id = crate::derive_index_id(&root);
+    if index_id.trim().is_empty() {
+        return None;
+    }
+    let base = crate::resolve_daemon_base_url("trusty-search")?;
+    let status_url = format!("{base}/indexes/{index_id}/status");
+
+    // Blocking reqwest inside a tokio runtime panics on runtime drop; run it on
+    // a dedicated OS thread (joined here) exactly like search_index's helpers.
+    let body: serde_json::Value = std::thread::spawn(move || {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_millis(1500))
+            .connect_timeout(std::time::Duration::from_millis(750))
+            .build()
+            .ok()?;
+        let resp = client.get(&status_url).send().ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        resp.json::<serde_json::Value>().ok()
+    })
+    .join()
+    .ok()
+    .flatten()?;
+
+    Some(parse_readiness(&index_id, &body))
+}
+
+/// Probe a project's index readiness and surface it to the session as ONE log
+/// line (issue #2784).
+///
+/// Why: this is the session-facing half of #2784. A daily-driver session that
+/// starts querying during the semantic warm-up window otherwise gets
+/// lexical-only results with no signal; a single readiness line on stderr tells
+/// the developer what a search will and won't yet find, so a not-yet-ready
+/// index is never silent. Fail-open: a `None` probe (no daemon, etc.) logs
+/// nothing — surfacing readiness must never itself become noise or a blocker.
+/// What: calls [`probe_index_readiness`]; on `Some`, logs [`IndexReadiness::summary`]
+/// at `info` when the semantic lane is ready and at `warn` while it is still
+/// warming (so the warm-up window is the one that stands out). Writes via
+/// `tracing`, which the daemons route to stderr, keeping stdout clean for MCP
+/// JSON-RPC framing.
+/// Test: side-effect-only (emits a log, no return to assert); its logic is
+/// [`probe_index_readiness`] + [`IndexReadiness::summary`], both unit-tested.
+pub fn log_index_readiness(project_root: &Path) {
+    if let Some(readiness) = probe_index_readiness(project_root) {
+        if readiness.semantic_search_ready() {
+            tracing::info!("{}", readiness.summary());
+        } else {
+            tracing::warn!(
+                "{} — semantic search still warming; expect lexical-only results until it is ready",
+                readiness.summary()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_readiness_reads_capabilities_and_status() {
+        // A mid-warm-up body: lexical up, semantic still building.
+        let body = json!({
+            "status": "indexed_lexical",
+            "chunk_count": 4096,
+            "search_capabilities": ["bm25", "literal", "exact_match"],
+        });
+        let r = parse_readiness("trusty-tools", &body);
+        assert_eq!(r.index_id, "trusty-tools");
+        assert_eq!(r.lifecycle_status, "indexed_lexical");
+        assert_eq!(r.chunk_count, 4096);
+        assert!(r.lexical_ready, "bm25 present ⇒ lexical ready");
+        assert!(!r.semantic_ready, "no vector cap ⇒ semantic not ready");
+        assert!(!r.graph_ready);
+    }
+
+    #[test]
+    fn parse_readiness_all_lanes_ready() {
+        let body = json!({
+            "status": "ready",
+            "chunk_count": 50_000,
+            "search_capabilities": ["bm25", "literal", "exact_match", "vector", "kg"],
+        });
+        let r = parse_readiness("big-repo", &body);
+        assert!(r.lexical_ready && r.semantic_ready && r.graph_ready);
+        assert!(r.semantic_search_ready());
+    }
+
+    #[test]
+    fn parse_readiness_defaults_when_fields_absent() {
+        // Empty object: every field degrades to a conservative not-ready value.
+        let r = parse_readiness("x", &json!({}));
+        assert_eq!(r.lifecycle_status, "unknown");
+        assert_eq!(r.chunk_count, 0);
+        assert!(!r.lexical_ready && !r.semantic_ready && !r.graph_ready);
+    }
+
+    #[test]
+    fn parse_readiness_ignores_malformed_capabilities() {
+        // A non-array `search_capabilities` must not panic or falsely report ready.
+        let r = parse_readiness("x", &json!({ "search_capabilities": "bm25" }));
+        assert!(!r.lexical_ready);
+    }
+
+    #[test]
+    fn summary_reports_all_lanes_ready() {
+        let r = IndexReadiness {
+            index_id: "repo".into(),
+            lifecycle_status: "ready".into(),
+            chunk_count: 10,
+            lexical_ready: true,
+            semantic_ready: true,
+            graph_ready: true,
+        };
+        let s = r.summary();
+        assert!(s.contains("'repo'"));
+        assert!(s.contains("ready (10 chunks)"));
+        assert!(s.contains("semantic ready"));
+    }
+
+    #[test]
+    fn summary_flags_semantic_pending_during_warmup() {
+        let r = IndexReadiness {
+            index_id: "repo".into(),
+            lifecycle_status: "indexed_lexical".into(),
+            chunk_count: 7,
+            lexical_ready: true,
+            semantic_ready: false,
+            graph_ready: false,
+        };
+        assert!(!r.semantic_search_ready());
+        let s = r.summary();
+        assert!(s.contains("lexical ready"));
+        assert!(s.contains("semantic pending"));
+    }
+
+    #[test]
+    fn probe_index_readiness_none_for_root() {
+        // The filesystem root derives an empty id ⇒ no probe, `None`.
+        assert_eq!(probe_index_readiness(Path::new("/")), None);
+    }
+
+    #[test]
+    fn probe_index_readiness_none_when_daemon_down() {
+        // Point the data dir at an empty temp dir so `resolve_daemon_base_url`
+        // finds no address file ⇒ daemon-down path returns `None`, never an
+        // error. `ENV_LOCK` serialises the process-global override against
+        // sibling env-mutating tests, matching `search_index`'s tests.
+        let _guard = crate::data_dir::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let pid = std::process::id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let data_dir = std::env::temp_dir().join(format!("trusty-readiness-data-{pid}-{nanos}"));
+        std::fs::create_dir_all(&data_dir).unwrap();
+        // SAFETY: guarded by ENV_LOCK; removed below before returning.
+        unsafe {
+            std::env::set_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV, &data_dir);
+        }
+
+        let project = data_dir.join("proj");
+        std::fs::create_dir_all(project.join(".git")).unwrap();
+        let readiness = probe_index_readiness(&project);
+
+        unsafe {
+            std::env::remove_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV);
+        }
+        let _ = std::fs::remove_dir_all(&data_dir);
+
+        assert_eq!(readiness, None, "daemon down ⇒ None, never an error");
+    }
+}


### PR DESCRIPTION
## Summary

Cold-indexing a large repo has a real semantic warm-up window: the lexical
(BM25) lane comes up in seconds (~24s on a 50K-chunk monorepo) while semantic
embedding stays `InProgress` for 20+ minutes on `trusty-embedderd`. A
daily-driver `tcode` session that starts querying immediately would silently
get **lexical-only** results with no signal that the index is still warming.

`trusty_common::search_index::ensure_project_indexed` already **warms** the
index at task start (find-or-create + freshness-gated reindex). This PR adds the
missing **surfacing** half so a session knows whether a semantic search is
trustworthy yet.

## What changed

**New shared primitive — `trusty_common::search_readiness`** (behind the
existing `search-index` feature, alongside the warming helper it complements):
- `parse_readiness(index_id, status_json) -> IndexReadiness` — pure map from a
  `GET /indexes/{id}/status` body to a coarse per-lane snapshot (lexical /
  semantic / graph ready flags derived from the daemon's `search_capabilities`
  array, plus lifecycle status + chunk count). Unit-tested without a daemon.
- `probe_index_readiness(project_root) -> Option<IndexReadiness>` — resolves the
  same canonical `(root, index_id)` the warming path targets, does one
  short-timeout blocking `GET` on a dedicated OS thread (safe from inside a
  tokio runtime), and parses it. Fail-open: any failure ⇒ `None`, never an error.
- `log_index_readiness(project_root)` — the session-facing surface: probes and
  emits **one** `tracing` line (to stderr, keeping stdout clean for MCP framing)
  — `warn` while semantic is still warming (expect lexical-only results),
  `info` once it is ready.

**tcode wiring** — `run_task::ensure_project_indexed_in_background` now calls
`log_index_readiness` right after warming, on the same detached task-start
thread, so a daily-driver session is never silently querying a not-yet-ready
index.

**Layer choice:** the readiness primitive lives in trusty-common (API layer)
per the workspace common-entry-point rule, so both crates that warm (trusty-code
now, trusty-mpm later) read the exact same `/status` contract; tcode consumes it
at its task-start hook.

Scope note: this is #2784 (proactively getting-to-ready + surfacing readiness),
distinct from the lexical-fallback behavior (#2783) and the already-fixed
transient-failure bug (#2785 / PR #2796).

## Verification

- `cargo build -p trusty-common --features search-index` / `-p trusty-code` — clean
- `cargo test -p trusty-common --features search-index --lib -- search_readiness` — 8 passed, 0 failed
- `cargo test -p trusty-code` — 916 passed, 0 failed, 4 ignored
- `cargo clippy … -- -D warnings` (both crates) — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 9 allowlisted, 0 violations (new module 197 SLOC)

Closes #2784

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools