### PR TITLE
chore(release): trusty-mpm 0.19.18 + trusty-common 0.23.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11115,7 +11115,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.19.17"
+version = "0.19.18"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6297,7 +6297,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10893,7 +10893,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # First published to crates.io at version 0.1.0.
 trusty-code = { path = "crates/trusty-code" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.2.1" }
-trusty-common = { path = "crates/trusty-common", version = "0.23.1" }
+trusty-common = { path = "crates/trusty-common", version = "0.23.2" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.8" }

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -20,7 +20,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - harden mid-task incremental index-file updates against transient send failures under sustained load: reuse one pooled HTTP client per write batch (connection keep-alive) and retry transport-level `send()` failures with bounded exponential backoff ([#2785](https://github.com/bobmatnyc/trusty-tools/issues/2785))
 - bump `lru` 0.12 → 0.16, fixing RUSTSEC-2026-0002 (`IterMut` violates Stacked Borrows, GHSA-rhfx-m35p-ff5j); no call-site changes needed ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`e62b454`](https://github.com/bobmatnyc/trusty-tools/commit/e62b4540d39c5a442d05e849197157932f37e664))
 - framework workflow conventions — per-session session log, issue/PR assignee+label defaults, trusty-mpm attribution footer ([#2737](https://github.com/bobmatnyc/trusty-tools/pull/2737)) ([`3089600`](https://github.com/bobmatnyc/trusty-tools/commit/3089600b475cc464329132e5f7523536bb730797))
-## [Unreleased]
 
 ### Added
 
@@ -31,7 +30,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - convert closed-set literals to typed constructs (PR 1: zero-behavior batch) ([#2704](https://github.com/bobmatnyc/trusty-tools/pull/2704)) ([`3b65103`](https://github.com/bobmatnyc/trusty-tools/commit/3b651033f92e619c65bb1aaa77168213e3306b4b))
-## [Unreleased]
 
 ### Added
 
@@ -43,7 +41,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - credential hardening + registry default-model errors (closes #2474, #2475, #2510) ([#2539](https://github.com/bobmatnyc/trusty-tools/pull/2539)) ([`58f36ca`](https://github.com/bobmatnyc/trusty-tools/commit/58f36cadef0fa1d38e0f15ed1984a956b21131c5))
-## [Unreleased]
 
 ### Added
 
@@ -63,17 +60,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - mount config command on all 10 primary binaries ([#2528](https://github.com/bobmatnyc/trusty-tools/pull/2528)) ([`a58ea52`](https://github.com/bobmatnyc/trusty-tools/commit/a58ea5223167553f0d90fb5258d582d510dca316))
-## [Unreleased]
 
 ### Fixed
 
 - idle-to-disk palace eviction + unpin dream scheduler + configurable max-open ([#2276](https://github.com/bobmatnyc/trusty-tools/pull/2276)) ([`0e8e504`](https://github.com/bobmatnyc/trusty-tools/commit/0e8e50440cea09a8f5eedf2c7bba9613f96cd8a8))
-## [Unreleased]
 
 ### Added
 
 - capture tmux window id at session pause and reattach on resume ([#2269](https://github.com/bobmatnyc/trusty-tools/pull/2269)) ([`1959738`](https://github.com/bobmatnyc/trusty-tools/commit/1959738450d9a1b7adaf707d9d5980d6365fe4a7))
-## [Unreleased]
 
 ### Added
 
@@ -90,12 +84,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - re-cut common 0.22.1 / embedderd 0.3.6 / search 0.32.2 to escape #2209 crates.io version collision ([#2236](https://github.com/bobmatnyc/trusty-tools/pull/2236)) ([`805a458`](https://github.com/bobmatnyc/trusty-tools/commit/805a458a67a69983b84ec4012436dc00b0e22e35))
-## [Unreleased]
 
 ### Added
 
 - manage trusty-search index lifecycle for session worktrees ([#2094](https://github.com/bobmatnyc/trusty-tools/pull/2094)) ([`299e993`](https://github.com/bobmatnyc/trusty-tools/commit/299e9931edd2b7faf9236bd5ccc3b6ddb038329d))
 
+
+### Added
+
+- extract managed-session naming to trusty-common; trusty-agents adopts it (DOC-33 Phase 1, SPEC-ONESM-01) ([#1989](https://github.com/bobmatnyc/trusty-tools/pull/1989)) ([`025941d`](https://github.com/bobmatnyc/trusty-tools/commit/025941dfe68b7806f1f7f6b82bc06923d1cd5b9e))
 ## [0.22.1] — 2026-07-08
 
 ### Changed
@@ -107,11 +104,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - auto-fall back to CPU when CoreML embedder init hangs; stop leaking blocked ORT threads ([#2127](https://github.com/bobmatnyc/trusty-tools/pull/2127)) ([`f7dc2dd`](https://github.com/bobmatnyc/trusty-tools/commit/f7dc2dd20524ee9d1a9c6146245aaacc5d1e7b2b))
 - reach trusty-memory over discovered JSON-RPC, never a hardcoded port ([#2040](https://github.com/bobmatnyc/trusty-tools/pull/2040)) ([`e0f41c5`](https://github.com/bobmatnyc/trusty-tools/commit/e0f41c51f1baa7ddf0e427cb5c7e86cbe9bba5fa))
 - verify_installed_binary checks ~/.local/bin and $CARGO_HOME ([#2042](https://github.com/bobmatnyc/trusty-tools/pull/2042)) ([`e0d2c7b`](https://github.com/bobmatnyc/trusty-tools/commit/e0d2c7bc8dc2c06cd6a004b777454dd129dc7b5b))
-## [Unreleased]
-
-### Added
-
-- extract managed-session naming to trusty-common; trusty-agents adopts it (DOC-33 Phase 1, SPEC-ONESM-01) ([#1989](https://github.com/bobmatnyc/trusty-tools/pull/1989)) ([`025941d`](https://github.com/bobmatnyc/trusty-tools/commit/025941dfe68b7806f1f7f6b82bc06923d1cd5b9e))
 ## [0.19.0] — 2026-07-03
 
 ### Added

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -10,6 +10,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - `search_readiness` module (behind the `search-index` feature): a shared trusty-search index readiness probe so a daily-driver session can *surface* whether a project's index is ready per lane (lexical/semantic/graph) instead of silently querying a not-yet-warm index — `parse_readiness` (pure status→snapshot map), `probe_index_readiness` (fail-open `GET /indexes/{id}/status`), and `log_index_readiness` (one stderr line) ([#2784](https://github.com/bobmatnyc/trusty-tools/issues/2784))
+- incremental re-index of files written during a task ([#2758](https://github.com/bobmatnyc/trusty-tools/pull/2758)) ([`a68e4c4`](https://github.com/bobmatnyc/trusty-tools/commit/a68e4c45f6be1662e09380bb335d586ea45afdfd))
+
+### Fixed
+
+- harden mid-task incremental index-file updates against transient send failures ([#2796](https://github.com/bobmatnyc/trusty-tools/pull/2796)) ([`1f8b569`](https://github.com/bobmatnyc/trusty-tools/commit/1f8b56924db6534d6b67811c39d8862dc53cc606))
+- bump lru and jsonwebtoken to patched versions ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`298df87`](https://github.com/bobmatnyc/trusty-tools/commit/298df87e6a5b5e96874ea2866509303df14712bc))
+
+### Changed
+
+- collapse stacked Unreleased headings (trusty-mpm, trusty-common) ([`95b16c8`](https://github.com/bobmatnyc/trusty-tools/commit/95b16c8c468084ce0e2a46eac8a4acf99cfab823))
+
+### Added
+
 - telegram module (rebase) ([#2729](https://github.com/bobmatnyc/trusty-tools/pull/2729)) ([`142675f`](https://github.com/bobmatnyc/trusty-tools/commit/142675fe01cc83b63497578611581921192a850b))
 - implement Slack search + reactions with two-token model ([#2726](https://github.com/bobmatnyc/trusty-tools/pull/2726)) ([`6e4e7d9`](https://github.com/bobmatnyc/trusty-tools/commit/6e4e7d9d8b18ba602f588e700142032789018142))
 - implement Slack send + read tools; extract SlackFormatter to trusty-common ([#2722](https://github.com/bobmatnyc/trusty-tools/pull/2722)) ([`847a0c3`](https://github.com/bobmatnyc/trusty-tools/commit/847a0c334e1a8822a7d31696b48946e538aca7cc))

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.23.1"
+version = "0.23.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,23 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- require a per-PR CHANGELOG.md entry in the default workflow (bundled `tm-pr-workflow` skill, `PM_INSTRUCTIONS.md`, `WORKFLOW.md`, `BASE-AGENT.md`); PM treats a missing entry as a review-gate failure and the precedence rule vs. `scripts/generate-changelog.sh`/git-cliff is documented in `.trusty-mpm/INSTRUCTIONS.md` ([#2790](https://github.com/bobmatnyc/trusty-tools/pull/2790))
-- opt-in auto-nudge for idle-parked managed sessions: daemon injects a foreground-block instruction when a parked agent has no live children, with per-session cap and cooldown (#2621) ([#2781](https://github.com/bobmatnyc/trusty-tools/pull/2781))
-
-### Fixed
-
-- bare `tm` inside a zombie-`Active` managed session (agent exited but the record still reads `Active`) now reconciles-and-relaunches in place via the caller's pane-identity proof-of-death instead of dead-ending on a 409; the fallback hint no longer suggests a bare `claude` (which loses the managed config) and points at `tm sessions resume <id>` (closes #2794)
-- bare `tm` inside a decommissioned managed tmux session now relaunches in place instead of reconnecting to itself (closes #2777) ([#2780](https://github.com/bobmatnyc/trusty-tools/pull/2780))
-- bump `jsonwebtoken` 9 → 10 (`aws_lc_rs` backend), fixing GHSA-h395-gr6q-cpjc; migrated the test-only JWT decode-without-verification call site to `jsonwebtoken::dangerous::insecure_decode` (closes #2765) ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`e62b454`](https://github.com/bobmatnyc/trusty-tools/commit/e62b4540d39c5a442d05e849197157932f37e664))
-- resolve managed MCP registry from real home in fleet-session injector ([#2761](https://github.com/bobmatnyc/trusty-tools/pull/2761)) ([`7c04f1f`](https://github.com/bobmatnyc/trusty-tools/commit/7c04f1f845432edd6b1fb488103a1aba9939fb3c))
-- never traverse $HOME/TCC-protected folders (closes #2759) ([#2760](https://github.com/bobmatnyc/trusty-tools/pull/2760)) ([`74fe7f3`](https://github.com/bobmatnyc/trusty-tools/commit/74fe7f3c682cb5b0c648b63585c44ee47aa6d652))
-- positive stdio field allowlist for fleet native-MCP injection ([#2739](https://github.com/bobmatnyc/trusty-tools/pull/2739)) ([#2755](https://github.com/bobmatnyc/trusty-tools/pull/2755)) ([`e3a5c68`](https://github.com/bobmatnyc/trusty-tools/commit/e3a5c684cc25028202f6ece1a262f515fa3b43da))
-## [Unreleased]
-
-### Added
-
 - propagate native trusty MCP servers to fleet sessions ([#2739](https://github.com/bobmatnyc/trusty-tools/pull/2739)) ([#2748](https://github.com/bobmatnyc/trusty-tools/pull/2748)) ([`0a87f1d`](https://github.com/bobmatnyc/trusty-tools/commit/0a87f1d70e97fd630bd997db8f17a98d64ca00d4))
-## [Unreleased]
 
 ### Added
 
@@ -36,7 +20,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - reconcile zombie-active sessions on in-place relaunch (closes #2743) ([#2744](https://github.com/bobmatnyc/trusty-tools/pull/2744)) ([`f1552c7`](https://github.com/bobmatnyc/trusty-tools/commit/f1552c72e4f20afda74466f97865845660d18a30))
 - pm_guard recognizes git global flags and stops scanning quoted content ([#2741](https://github.com/bobmatnyc/trusty-tools/pull/2741)) ([`6e29e25`](https://github.com/bobmatnyc/trusty-tools/commit/6e29e253c073cb889bdbfce5e99d05d16e6d1fe2))
 - framework workflow conventions — per-session session log, issue/PR assignee+label defaults, trusty-mpm attribution footer ([#2737](https://github.com/bobmatnyc/trusty-tools/pull/2737)) ([`3089600`](https://github.com/bobmatnyc/trusty-tools/commit/3089600b475cc464329132e5f7523536bb730797))
-## [Unreleased]
 
 ### Added
 
@@ -46,13 +29,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - DispositionReason enum replaces stringly-typed disposition reasons ([#2705](https://github.com/bobmatnyc/trusty-tools/pull/2705)) ([`e7970c8`](https://github.com/bobmatnyc/trusty-tools/commit/e7970c87541d774aa25c315f27da7fee656be492))
 - convert closed-set literals to typed constructs (PR 1: zero-behavior batch) ([#2704](https://github.com/bobmatnyc/trusty-tools/pull/2704)) ([`3b65103`](https://github.com/bobmatnyc/trusty-tools/commit/3b651033f92e619c65bb1aaa77168213e3306b4b))
-## [Unreleased]
 
 ### Fixed
 
 - picker launch-new switches client safely and exits instead of hanging ([#2680](https://github.com/bobmatnyc/trusty-tools/pull/2680)) ([`3de0647`](https://github.com/bobmatnyc/trusty-tools/commit/3de0647452f0e77a67aa20c52c8d9610474b8de8))
 - pm_guard allows read-only sed/awk pipe segments ([#2677](https://github.com/bobmatnyc/trusty-tools/pull/2677)) ([`3881639`](https://github.com/bobmatnyc/trusty-tools/commit/38816393f9d836b79e08c8efd4642fd21f3a6e5f))
-## [Unreleased]
 
 ### Fixed
 
@@ -64,7 +45,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - split bin/tm/cli.rs into cli/ modules ([#2650](https://github.com/bobmatnyc/trusty-tools/pull/2650)) ([`53eb4a6`](https://github.com/bobmatnyc/trusty-tools/commit/53eb4a67f3cec9ba4f9d23ddf65243d20974d5ec))
-## [Unreleased]
 
 ### Added
 
@@ -73,7 +53,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - harden agents against idle parking — never end a turn to wait (closes #2610) ([#2620](https://github.com/bobmatnyc/trusty-tools/pull/2620)) ([`cbcfd17`](https://github.com/bobmatnyc/trusty-tools/commit/cbcfd17e797c6db80074e1254dfefb5f1f8fb3c1))
-## [Unreleased]
 
 ### Added
 
@@ -84,7 +63,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - pm_guard permits PM single-file writes to non-source paths ([#2606](https://github.com/bobmatnyc/trusty-tools/pull/2606)) ([`3c6f9f7`](https://github.com/bobmatnyc/trusty-tools/commit/3c6f9f705760f1e94a37f6b9d966b45bf483c2ed))
-## [Unreleased]
 
 ### Added
 
@@ -93,7 +71,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - session restart returns 500 for stopped session whose workspace is gone (closes #2577) ([#2594](https://github.com/bobmatnyc/trusty-tools/pull/2594)) ([`f2270f1`](https://github.com/bobmatnyc/trusty-tools/commit/f2270f1f2effb417aaf460f21b56c311d3403b34))
-## [Unreleased]
 
 ### Added
 
@@ -104,18 +81,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - retire duplicate Bedrock ports onto trusty-common::inference ([#2567](https://github.com/bobmatnyc/trusty-tools/pull/2567)) ([`31c9fc0`](https://github.com/bobmatnyc/trusty-tools/commit/31c9fc0467adfda65b702c7433ceded01e0cf884))
-## [Unreleased]
 
 ### Fixed
 
 - reconcile agent roster drift across deploy destinations ([#2547](https://github.com/bobmatnyc/trusty-tools/pull/2547)) ([`8d8b042`](https://github.com/bobmatnyc/trusty-tools/commit/8d8b04230a646f8c7941754c7cd4684f57d32089))
 - pane-scope session capture reads to the recorded harness pane ([#2545](https://github.com/bobmatnyc/trusty-tools/pull/2545)) ([`18bf5b2`](https://github.com/bobmatnyc/trusty-tools/commit/18bf5b28f8ee47491c3660593195b5ca02ec8883))
-## [Unreleased]
 
 ### Fixed
 
 - guided-default cwd's own repo wins over an ancestor ([#2542](https://github.com/bobmatnyc/trusty-tools/pull/2542)) ([#2543](https://github.com/bobmatnyc/trusty-tools/pull/2543)) ([`51f5041`](https://github.com/bobmatnyc/trusty-tools/commit/51f50417e23c76a4bea4beabc854c4e75cacd526))
-## [Unreleased]
 
 ### Added
 
@@ -177,18 +151,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - add trusty-mpm package metadata + repoint trusty-search CI badge to monorepo ([#2292](https://github.com/bobmatnyc/trusty-tools/pull/2292)) ([`cba43a5`](https://github.com/bobmatnyc/trusty-tools/commit/cba43a5698c03ea611f731b6a5bef0809547a93f))
 
-## [0.19.4] — 2026-07-09
-
-### Changed
-
-- Add crates.io package metadata (keywords/categories/homepage/readme).
-
-## [Unreleased]
 
 ### Fixed
 
 - probe live tmux/process for session liveness, not the stored state field ([#2275](https://github.com/bobmatnyc/trusty-tools/pull/2275)) ([`b5f8b6b`](https://github.com/bobmatnyc/trusty-tools/commit/b5f8b6b7b941b5f8939918f592374e0b4bd76d28))
-## [Unreleased]
 
 ### Added
 
@@ -198,8 +164,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - correct banner two_panel right-column no-inner-border rendering ([#2258](https://github.com/bobmatnyc/trusty-tools/pull/2258)) ([`6b9ae4a`](https://github.com/bobmatnyc/trusty-tools/commit/6b9ae4ab17ce0a07b2f69bfb14d3b477c8db6fbe))
 - keep resumed panes rooted at the workspace, not $HOME ([#2254](https://github.com/bobmatnyc/trusty-tools/pull/2254)) ([`d2c1edf`](https://github.com/bobmatnyc/trusty-tools/commit/d2c1edf4431b0cba3e94f558fc13fc9c40786307))
-## [Unreleased]
-## [Unreleased]
 
 ### Added
 
@@ -215,12 +179,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - re-cut as 0.19.1: depends on trusty-common 0.22.2 (0.19.0 was git-tagged but
   never published to crates.io, so republishing the same content under a new
   patch version rather than moving an existing tag). Ships #2214/#2229/#2230/#2231.
-## [Unreleased]
 
 ### Added
 
 - seed outputStyle/statusLine into tm-owned config dir ([#2215](https://github.com/bobmatnyc/trusty-tools/pull/2215)) ([`2ebb6e1`](https://github.com/bobmatnyc/trusty-tools/commit/2ebb6e19993524aae4df038041c4c1d1cdc64dd0))
-## [Unreleased]
 
 ### Added
 
@@ -245,27 +207,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Documentation
 
 - bundled architecture doc for memory-MCP, session/worktree, search-index ([#2096](https://github.com/bobmatnyc/trusty-tools/pull/2096)) ([`d82e15a`](https://github.com/bobmatnyc/trusty-tools/commit/d82e15ae9367a4c17cdd8fb714e053eb6da9cab7))
-## [Unreleased]
 
 ### Added
 
-- statusline renders context >50% in red ([#2099](https://github.com/bobmatnyc/trusty-tools/pull/2099)) ([`a821b9d`](https://github.com/bobmatnyc/trusty-tools/commit/a821b9da89d7c076dfb4557094f632859b53642e))
-- manage trusty-search index lifecycle for session worktrees ([#2094](https://github.com/bobmatnyc/trusty-tools/pull/2094)) ([`299e993`](https://github.com/bobmatnyc/trusty-tools/commit/299e9931edd2b7faf9236bd5ccc3b6ddb038329d))
-- project config stores preferred gh user; default gh ops to it ([#2087](https://github.com/bobmatnyc/trusty-tools/pull/2087)) ([`d49e385`](https://github.com/bobmatnyc/trusty-tools/commit/d49e385826c0befb0d4cece01a032c71e67e1aa3))
-- name managed-session worktrees by tmux session name, not UUID ([#2076](https://github.com/bobmatnyc/trusty-tools/pull/2076)) ([`39abd2e`](https://github.com/bobmatnyc/trusty-tools/commit/39abd2e02b47e5b4e739ad30de57c33cfdf4dc54))
 
 ### Fixed
 
-- guarantee PM delegation persona loads (CLAUDE.md carrier + project-tier output-style + daemon-adapter system-prompt injection) ([#2129](https://github.com/bobmatnyc/trusty-tools/pull/2129)) ([`3a071a0`](https://github.com/bobmatnyc/trusty-tools/commit/3a071a0a2897911279433522d2564cb532f310be))
-- pm_guard exempts native delegated sub-agent edits; retire global UNRESTRICTED bypass ([#2107](https://github.com/bobmatnyc/trusty-tools/pull/2107)) ([`0f413d0`](https://github.com/bobmatnyc/trusty-tools/commit/0f413d0c5d611178dbd5344475ae61ba5fa21213))
-- PM summarizes orchestration in prose instead of raw pm_summary JSON ([#2045](https://github.com/bobmatnyc/trusty-tools/pull/2045)) ([`53731f4`](https://github.com/bobmatnyc/trusty-tools/commit/53731f4849436607cdef55237680a230c798d94f))
-- statusline shows tmux session name instead of worktree UUID branch ([#2035](https://github.com/bobmatnyc/trusty-tools/pull/2035)) ([`bbafad1`](https://github.com/bobmatnyc/trusty-tools/commit/bbafad11063accc2631be4fd97cb610c13152faa))
-- reach trusty-memory over discovered JSON-RPC, never a hardcoded port ([#2040](https://github.com/bobmatnyc/trusty-tools/pull/2040)) ([`e0f41c5`](https://github.com/bobmatnyc/trusty-tools/commit/e0f41c51f1baa7ddf0e427cb5c7e86cbe9bba5fa))
 
 ### Documentation
 
-- bundled architecture doc for memory-MCP, session/worktree, search-index ([#2096](https://github.com/bobmatnyc/trusty-tools/pull/2096)) ([`d82e15a`](https://github.com/bobmatnyc/trusty-tools/commit/d82e15ae9367a4c17cdd8fb714e053eb6da9cab7))
-## [Unreleased]
 
 ### Added
 
@@ -291,7 +241,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - auto-reconcile zombie sessions on guided resume instead of erroring (closes #2001) ([#2004](https://github.com/bobmatnyc/trusty-tools/pull/2004)) ([`f635216`](https://github.com/bobmatnyc/trusty-tools/commit/f635216c4b1e6edf7463b2202283c2b39e0e180e))
 - statusline shows user/repo, drops duplicate session-id branch ([#1991](https://github.com/bobmatnyc/trusty-tools/pull/1991)) ([`58f5b1f`](https://github.com/bobmatnyc/trusty-tools/commit/58f5b1f9df62dfae183389f5e279d8579f07de13))
 - graceful CLI session termination + managed-session delegation gating ([#1979](https://github.com/bobmatnyc/trusty-tools/pull/1979)) ([`139bde2`](https://github.com/bobmatnyc/trusty-tools/commit/139bde2938f8edf33cd71df1d0a2b2a09ef1580c))
-## [Unreleased]
 
 ### Added
 
@@ -336,6 +285,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - hoist compress::tool_output from trusty-agents ([#1959](https://github.com/bobmatnyc/trusty-tools/pull/1959)) ([#1968](https://github.com/bobmatnyc/trusty-tools/pull/1968)) ([`7cf93b9`](https://github.com/bobmatnyc/trusty-tools/commit/7cf93b9ab3918aff316238bdfe540a4053aa971d))
 - split inproject.rs to satisfy 500-SLOC production cap ([#1898](https://github.com/bobmatnyc/trusty-tools/pull/1898)) ([`43066c2`](https://github.com/bobmatnyc/trusty-tools/commit/43066c2a30cd9bdc6513554caff9ad2da54defd2))
+
+### Changed: CLI command group `session` → `sessions` (issue #1394)
+
+The top-level CLI command group was renamed from the singular `session` to the
+plural **`sessions`** to match the `/api/v1/sessions/*` HTTP API surface. Every
+subcommand is now invoked under the plural name, e.g. `tm sessions tui`,
+`tm sessions ls`, `tm sessions new`.
+
+- The singular `session` spelling is **removed entirely** — it is not retained
+  as an alias. Invoking `tm session …` now fails with an
+  unrecognized-subcommand error. Update any scripts or muscle memory to
+  `tm sessions …`.
+- This is a CLI-only change; the HTTP API (already `/api/v1/sessions/*`) and the
+  separate `session-manager` / `sm` coordinator command are unaffected.
+
+### Deprecated: verbose managed session-lifecycle verbs (issue #1205)
+
+The managed session-lifecycle CLI verbs were renamed to the cleaner, symmetric
+`stop` / `resume` / `decommission` family. The old verbose verbs still work but
+now emit a one-line deprecation notice to **stderr** on every invocation and
+will be removed in a future release.
+
+| Deprecated verb | Use instead | Behavior |
+|-----------------|-------------|----------|
+| `tm sessions runtime-stop <id>` | `tm sessions stop <id>` | Stop the runtime, keep the workspace (resumable) |
+| `tm sessions managed-stop <id>` | `tm sessions stop <id>` | Same as `runtime-stop` |
+| `tm sessions managed-resume <id>` | `tm sessions resume <id>` | Re-spawn the runtime in the existing workspace |
+
+- The deprecated verbs are hidden from `tm sessions --help` but continue to parse
+  for backward compatibility.
+- Each deprecated invocation prints `warning: '<old>' is deprecated; use '<new>'`
+  to stderr; stdout stays clean for scripts.
+- `tm sessions decommission <id>` (terminal teardown: remove workspace from disk)
+  is unchanged.
+
+## [0.19.4] — 2026-07-09
+
+### Changed
+
+- Add crates.io package metadata (keywords/categories/homepage/readme).
+
 ## [0.14.0] — 2026-07-01
 
 ### Added
@@ -558,42 +548,6 @@ that its instructions never loaded ([#1855](https://github.com/bobmatnyc/trusty-
   `tm` and `trusty-mpm` only. Install the console with
   `cargo install trusty-console`. This is part of the single-owner-per-binary
   fix for the cargo binary-ownership collisions (#1262).
-
-## [Unreleased]
-
-### Changed: CLI command group `session` → `sessions` (issue #1394)
-
-The top-level CLI command group was renamed from the singular `session` to the
-plural **`sessions`** to match the `/api/v1/sessions/*` HTTP API surface. Every
-subcommand is now invoked under the plural name, e.g. `tm sessions tui`,
-`tm sessions ls`, `tm sessions new`.
-
-- The singular `session` spelling is **removed entirely** — it is not retained
-  as an alias. Invoking `tm session …` now fails with an
-  unrecognized-subcommand error. Update any scripts or muscle memory to
-  `tm sessions …`.
-- This is a CLI-only change; the HTTP API (already `/api/v1/sessions/*`) and the
-  separate `session-manager` / `sm` coordinator command are unaffected.
-
-### Deprecated: verbose managed session-lifecycle verbs (issue #1205)
-
-The managed session-lifecycle CLI verbs were renamed to the cleaner, symmetric
-`stop` / `resume` / `decommission` family. The old verbose verbs still work but
-now emit a one-line deprecation notice to **stderr** on every invocation and
-will be removed in a future release.
-
-| Deprecated verb | Use instead | Behavior |
-|-----------------|-------------|----------|
-| `tm sessions runtime-stop <id>` | `tm sessions stop <id>` | Stop the runtime, keep the workspace (resumable) |
-| `tm sessions managed-stop <id>` | `tm sessions stop <id>` | Same as `runtime-stop` |
-| `tm sessions managed-resume <id>` | `tm sessions resume <id>` | Re-spawn the runtime in the existing workspace |
-
-- The deprecated verbs are hidden from `tm sessions --help` but continue to parse
-  for backward compatibility.
-- Each deprecated invocation prints `warning: '<old>' is deprecated; use '<new>'`
-  to stderr; stdout stays clean for scripts.
-- `tm sessions decommission <id>` (terminal teardown: remove workspace from disk)
-  is unchanged.
 
 ## [0.5.0] — 2026-05-28
 

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,7 +9,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- auto-nudge idle-parked managed sessions ([#2781](https://github.com/bobmatnyc/trusty-tools/pull/2781)) ([`be2ec11`](https://github.com/bobmatnyc/trusty-tools/commit/be2ec1107a56bd1c25e07c9fa146717399effd23))
+- require per-PR changelog updates in the default workflow ([#2790](https://github.com/bobmatnyc/trusty-tools/pull/2790)) ([`238f07e`](https://github.com/bobmatnyc/trusty-tools/commit/238f07e8f77b2290afc1c42939e7802e5d8a5074))
 - propagate native trusty MCP servers to fleet sessions ([#2739](https://github.com/bobmatnyc/trusty-tools/pull/2739)) ([#2748](https://github.com/bobmatnyc/trusty-tools/pull/2748)) ([`0a87f1d`](https://github.com/bobmatnyc/trusty-tools/commit/0a87f1d70e97fd630bd997db8f17a98d64ca00d4))
+
+### Fixed
+
+- reconcile zombie-Active sessions on in-place relaunch instead of 409 dead-end ([#2795](https://github.com/bobmatnyc/trusty-tools/pull/2795)) ([`5ef199a`](https://github.com/bobmatnyc/trusty-tools/commit/5ef199a920374ab6ac3e97b3aac8b08374915b1d))
+- bump `jsonwebtoken` 9 → 10 (`aws_lc_rs` backend), fixing GHSA-h395-gr6q-cpjc; migrated the test-only JWT decode-without-verification call site to `jsonwebtoken::dangerous::insecure_decode` (closes #2765) ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`298df87`](https://github.com/bobmatnyc/trusty-tools/commit/298df87e6a5b5e96874ea2866509303df14712bc))
+- relaunch decommissioned managed session on bare tm instead of reconnect-to-self ([#2780](https://github.com/bobmatnyc/trusty-tools/pull/2780)) ([`b6f1783`](https://github.com/bobmatnyc/trusty-tools/commit/b6f1783a6e7ad78fb42c332f50ed86e2fb8e2bfd))
+- resolve managed MCP registry from real home in fleet-session injector ([#2761](https://github.com/bobmatnyc/trusty-tools/pull/2761)) ([`7c04f1f`](https://github.com/bobmatnyc/trusty-tools/commit/7c04f1f845432edd6b1fb488103a1aba9939fb3c))
+- never traverse $HOME/TCC-protected folders (closes #2759) ([#2760](https://github.com/bobmatnyc/trusty-tools/pull/2760)) ([`74fe7f3`](https://github.com/bobmatnyc/trusty-tools/commit/74fe7f3c682cb5b0c648b63585c44ee47aa6d652))
+- positive stdio field allowlist for fleet native-MCP injection ([#2739](https://github.com/bobmatnyc/trusty-tools/pull/2739)) ([#2755](https://github.com/bobmatnyc/trusty-tools/pull/2755)) ([`e3a5c68`](https://github.com/bobmatnyc/trusty-tools/commit/e3a5c684cc25028202f6ece1a262f515fa3b43da))
+
+### Changed
+
+- collapse stacked Unreleased headings (trusty-mpm, trusty-common) ([`95b16c8`](https://github.com/bobmatnyc/trusty-tools/commit/95b16c8c468084ce0e2a46eac8a4acf99cfab823))
+
+### Documentation
+
+- correct stale session_launch test comments ([#2779](https://github.com/bobmatnyc/trusty-tools/pull/2779)) ([`3371828`](https://github.com/bobmatnyc/trusty-tools/commit/33718282bc3e3da4da6f84ff6681d84cd2859a26))
+
+### Added
+
 
 ### Added
 

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.19.17"
+version = "0.19.18"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Cuts `trusty-mpm` 0.19.17 → 0.19.18, shipping 8 PRs merged since the last release: two relaunch/reconcile fixes (#2780, #2795), the idle-park auto-nudge (#2781), the per-PR changelog workflow requirement (#2790), a jsonwebtoken/lru security bump (#2782), fleet-session MCP registry/allowlist fixes (#2761, #2760, #2755), and a docs fix (#2779).
- Cuts `trusty-common` 0.23.1 → 0.23.2 first: trusty-mpm enables trusty-common's `search-index` feature and calls `trusty_common::search_index` directly (`session_manager/search_gc.rs`); PR #2796 hardened that module (pooled client + retry-with-backoff) after 0.23.1 was published, so trusty-mpm's crates.io dependency requirement is bumped to `0.23.2` alongside the workspace path dep so a fresh `cargo install trusty-mpm` actually pulls the fix.
- Release-prep cleanup (part of #2788's backfill): collapsed the stacked/duplicated `## [Unreleased]` headings in both crates' `CHANGELOG.md` (23 in trusty-mpm, 9+1 in trusty-common) into a single consolidated section each — no content lost, verified via PR-number diff against the originals.

## Test plan
- [x] `cargo check -p trusty-common` / `cargo check -p trusty-mpm` — clean
- [x] `cargo test -p trusty-common --features search-index` — 167 passed, 0 failed, 6 ignored
- [x] `cargo test -p trusty-mpm` — 0 failed across all 34 test binaries
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-mpm` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [ ] CI green (pending)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools