### PR TITLE
feat(trusty-code): reduce redundant full-suite test re-runs

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -11,6 +11,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Surface trusty-search index readiness to daily-driver task sessions: after warming the project's index at task start, `ensure_project_indexed_in_background` now probes `GET /indexes/{id}/status` (via the shared `trusty_common::search_readiness::log_index_readiness`) and emits one stderr line describing which lanes are ready — `warn` while semantic embedding is still warming (expect lexical-only results), `info` once it is ready — so a session is never silently querying a not-yet-ready index ([#2784](https://github.com/bobmatnyc/trusty-tools/issues/2784))
+- **Redundant full-suite test re-run suppression (`redundant_run`)** — the
+  complement to the `verify_gate` (#2279): where that guarantees the suite runs
+  at least once, this stops it running more than needed. When an identical
+  `bash` test command already passed and no code has changed since (no
+  `write_file`/`write_files`/`edit` and no other shell command in between), the
+  agent loop short-circuits the re-run with an explanatory sentinel result
+  instead of spawning the suite, so the delegated engineer stops burning turns
+  on repeated "one final run to confirm" passes. Opt-in via
+  `AgentLoop::with_redundant_run_suppression`, attached at the single
+  delegated-engineer construction site alongside the verify gate. The `BASE`
+  preamble additionally instructs the model that one clean run after the last
+  code change is sufficient and not to repeat identical confirmation runs
+  (preamble bumped to `1.7.0`). (#2682)
+
+---
 
 ### Changed
 

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -207,6 +207,14 @@ pub struct AgentLoop {
     cancel: Option<Arc<AtomicBool>>,
     stop_signal: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
     finish_gate: Option<FinishGate>,
+    /// (#2682) When `true`, a `bash` test invocation that
+    /// `crate::redundant_run::is_redundant_test_rerun` judges redundant (an
+    /// identical suite already passed and nothing changed since) is
+    /// short-circuited with `crate::redundant_run::REDUNDANT_RERUN_MESSAGE`
+    /// instead of being spawned. Default `false` (a pure no-op for every call
+    /// site that never opts in); attached at the delegated-engineer
+    /// construction site via [`Self::with_redundant_run_suppression`].
+    suppress_redundant_reruns: bool,
 }
 
 impl AgentLoop {
@@ -236,6 +244,7 @@ impl AgentLoop {
             cancel: None,
             stop_signal: None,
             finish_gate: None,
+            suppress_redundant_reruns: false,
         }
     }
 
@@ -303,6 +312,25 @@ impl AgentLoop {
     /// `agent_loop::tests::finish_gate_inert_without_named_test_command`.
     pub fn with_finish_gate(mut self, gate: FinishGate) -> Self {
         self.finish_gate = Some(gate);
+        self
+    }
+
+    /// Enable redundant full-suite test re-run suppression (#2682).
+    ///
+    /// Why: The complement to [`Self::with_finish_gate`]'s verify gate — where
+    /// that guarantees the suite runs at least once, this stops it running more
+    /// than needed. Opt-in (default `false`) and attached at the same single
+    /// delegated-engineer construction site (`runner::in_process`) so both
+    /// gates bracket the same loop; call sites that never opt in are a pure
+    /// no-op.
+    /// What: Builder-style setter; returns `self` for chaining. When set,
+    /// [`Self::dispatch_all`] consults
+    /// [`crate::redundant_run::is_redundant_test_rerun`] before spawning a
+    /// `bash` test command and short-circuits a redundant one.
+    /// Test: `agent_loop::tests::redundant_test_rerun_is_suppressed`,
+    /// `agent_loop::tests::test_rerun_after_edit_is_not_suppressed`.
+    pub fn with_redundant_run_suppression(mut self) -> Self {
+        self.suppress_redundant_reruns = true;
         self
     }
 
@@ -558,7 +586,23 @@ impl AgentLoop {
                 sink.tool_started(&call.id, tool, &args.to_string()).await;
             }
 
-            let mut result = self.registry.dispatch_gated(tool, args.clone(), None).await;
+            // #2682: short-circuit a redundant full-suite re-run BEFORE
+            // spawning it — an identical test command already passed earlier
+            // and nothing has changed since (see `redundant_run`). The prior
+            // pass still stands, so re-running only burns a turn's wall-clock;
+            // returning a normal (non-error) sentinel result keeps the loop
+            // calm and nudges the model to finish rather than re-confirm. Only
+            // ever fires when explicitly enabled via
+            // `with_redundant_run_suppression`, so no other call site is
+            // affected.
+            let mut result = if self.suppress_redundant_reruns
+                && crate::redundant_run::is_test_bash_call(call)
+                && crate::redundant_run::is_redundant_test_rerun(&transcript.messages(), &call.id)
+            {
+                ToolResult::ok(crate::redundant_run::REDUNDANT_RERUN_MESSAGE.to_string())
+            } else {
+                self.registry.dispatch_gated(tool, args.clone(), None).await
+            };
 
             // #2279: a `finish_task` call that otherwise SUCCEEDED is still
             // subject to the verify-before-finish gate, if one is attached.

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1508,6 +1508,10 @@ async fn finish_task_full_shape_propagates_into_output() {
 // live in a focused child module to keep this file under its SLOC cap.
 mod gate_intercept;
 
+// #2682 redundant full-suite re-run suppression wiring tests live in a focused
+// child module to keep this file under its SLOC cap.
+mod redundant_rerun;
+
 // Batched multi-tool-per-turn regression guards (round-trip reduction) live in
 // a focused child module to keep this file under its SLOC cap.
 mod batched_multi_tool;

--- a/crates/trusty-code/src/agent_loop/tests/redundant_rerun.rs
+++ b/crates/trusty-code/src/agent_loop/tests/redundant_rerun.rs
@@ -1,0 +1,196 @@
+//! End-to-end agent-loop tests for the #2682 redundant full-suite re-run
+//! suppression path.
+//!
+//! Why: `redundant_run::tests` prove the pure predicate in isolation; these
+//! tests prove the WIRING — that `AgentLoop::dispatch_all`, once
+//! `with_redundant_run_suppression` is attached, actually short-circuits a
+//! redundant `bash` test re-run with the sentinel result instead of spawning
+//! the suite, and that a genuinely-needed post-change run still fires. Split
+//! into this focused child module (like the sibling `gate_intercept`) to keep
+//! the parent test file under its SLOC cap while reusing its scripted-LLM
+//! harness verbatim via `use super::*`.
+//! What: Reuses the parent module's `ScriptedLlm`, `bash_call_response`,
+//! `registry_with_finish_task_and_bash`, and `make_loop` helpers. The test
+//! command is `echo cargo test` — it matches `verify_gate::is_test_command`
+//! (it contains the `cargo test` shape) yet, unlike a real `cargo test`, exits
+//! 0 deterministically with no dependency on an installed test runner.
+//! Test: this module is itself the test surface.
+
+use super::*;
+
+/// Build a response fixture in which the assistant calls an arbitrary tool by
+/// name with `{}` arguments — used here to inject a `write_file`-named call
+/// (a code-mutating tool) between two test runs. The call need not dispatch
+/// successfully: it lands in the transcript via `push_response` regardless, and
+/// the redundancy fold classifies it by NAME, so an unregistered tool that
+/// reports a recoverable error still correctly invalidates the passing
+/// baseline.
+fn named_tool_call_response(call_id: &str, tool: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": "gen-tool",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": { "name": tool, "arguments": "{}" }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 6, "completion_tokens": 4, "total_tokens": 10 }
+    })
+}
+
+/// Whether any request in `requests` carries a `tool`-role message answering
+/// `call_id` whose content satisfies `pred`.
+fn tool_result_matches(
+    requests: &[Vec<crate::llm::ChatMessage>],
+    call_id: &str,
+    pred: impl Fn(&str) -> bool,
+) -> bool {
+    requests.iter().flatten().any(|m| {
+        m.role == "tool"
+            && m.tool_call_id.as_deref() == Some(call_id)
+            && m.content.as_deref().is_some_and(&pred)
+    })
+}
+
+/// With suppression enabled, a SECOND identical test run over unchanged code is
+/// short-circuited: the suite is never spawned and the model receives the
+/// [`crate::redundant_run::REDUNDANT_RERUN_MESSAGE`] sentinel instead.
+///
+/// Why: This is #2682's core acceptance behaviour — the redundant "one final
+/// run to confirm" pass must cost no real execution once the prior run passed
+/// and nothing changed.
+/// What: Script [bash (passes), bash (identical, redundant), finish_task] with
+/// suppression attached; assert the first run's REAL result (`exit_code: 0`)
+/// reached the model but the second call's result is the sentinel, never a
+/// fresh `exit_code` line.
+/// Test: this test.
+#[tokio::test]
+async fn redundant_test_rerun_is_suppressed() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        bash_call_response("b1", "echo cargo test"),
+        bash_call_response("b2", "echo cargo test"),
+        finish_task_call_response("f1", r#"{"status": "completed", "summary": "done"}"#),
+    ]));
+    let registry = registry_with_finish_task_and_bash();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default())
+        .with_redundant_run_suppression();
+
+    let out = agent
+        .run("system prompt", "run cargo test, then finish")
+        .await
+        .expect("loop terminates on finish_task");
+
+    assert_eq!(llm.calls(), 3, "both bash turns plus the finish turn run");
+    assert_eq!(out.summary.as_deref(), Some("done"));
+
+    let requests = llm.requests();
+    // The FIRST run actually executed — its real bash output reached the model.
+    assert!(
+        tool_result_matches(&requests, "b1", |c| c.contains("exit_code: 0")),
+        "the first test run must actually execute"
+    );
+    // The SECOND run was suppressed — the model saw the sentinel, not a fresh
+    // execution result.
+    assert!(
+        tool_result_matches(&requests, "b2", |c| c
+            == crate::redundant_run::REDUNDANT_RERUN_MESSAGE),
+        "the redundant second run must be short-circuited with the sentinel"
+    );
+    assert!(
+        !tool_result_matches(&requests, "b2", |c| c.contains("exit_code:")),
+        "the suppressed run must NOT carry a real exit_code line"
+    );
+}
+
+/// A test run AFTER a code-mutating tool call is NOT suppressed — the
+/// genuinely-needed post-change run still fires for real.
+///
+/// Why: The acceptance criteria require "the single final run must still occur
+/// after the last code change"; a `write_file`/`edit` between runs must defeat
+/// suppression.
+/// What: Script [bash (passes), write_file, bash (identical), finish_task] with
+/// suppression attached; assert the second bash call produced a REAL
+/// `exit_code: 0` result and NOT the sentinel.
+/// Test: this test.
+#[tokio::test]
+async fn test_rerun_after_edit_is_not_suppressed() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        bash_call_response("b1", "echo cargo test"),
+        named_tool_call_response("w1", "write_file"),
+        bash_call_response("b2", "echo cargo test"),
+        finish_task_call_response("f1", r#"{"status": "completed", "summary": "done"}"#),
+    ]));
+    let registry = registry_with_finish_task_and_bash();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default())
+        .with_redundant_run_suppression();
+
+    let out = agent
+        .run("system prompt", "run cargo test, then finish")
+        .await
+        .expect("loop terminates on finish_task");
+
+    assert_eq!(
+        llm.calls(),
+        4,
+        "both bash turns, the write turn, and finish run"
+    );
+    assert_eq!(out.summary.as_deref(), Some("done"));
+
+    let requests = llm.requests();
+    // The post-write run must have actually executed — a real exit_code line,
+    // never the suppression sentinel.
+    assert!(
+        tool_result_matches(&requests, "b2", |c| c.contains("exit_code: 0")),
+        "a test run after a write_file must actually execute"
+    );
+    assert!(
+        !tool_result_matches(&requests, "b2", |c| c
+            == crate::redundant_run::REDUNDANT_RERUN_MESSAGE),
+        "a post-change run must NOT be suppressed"
+    );
+}
+
+/// With suppression DISABLED (the default), an identical re-run is NOT
+/// short-circuited — the opt-in flag is the only thing that activates the
+/// behaviour.
+///
+/// Why: Every existing call site that never opts in must be a pure no-op; this
+/// is the negative control proving suppression is genuinely gated on the
+/// builder flag, not always-on.
+/// What: The same redundant script as `redundant_test_rerun_is_suppressed` but
+/// WITHOUT `with_redundant_run_suppression`; assert the second run executed for
+/// real (no sentinel).
+/// Test: this test.
+#[tokio::test]
+async fn rerun_not_suppressed_when_flag_absent() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        bash_call_response("b1", "echo cargo test"),
+        bash_call_response("b2", "echo cargo test"),
+        finish_task_call_response("f1", r#"{"status": "completed", "summary": "done"}"#),
+    ]));
+    let registry = registry_with_finish_task_and_bash();
+    // NOTE: no `.with_redundant_run_suppression()`.
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default());
+
+    agent
+        .run("system prompt", "run cargo test, then finish")
+        .await
+        .expect("loop terminates on finish_task");
+
+    let requests = llm.requests();
+    assert!(
+        tool_result_matches(&requests, "b2", |c| c.contains("exit_code: 0")),
+        "without the opt-in flag the second run must execute for real"
+    );
+    assert!(
+        !tool_result_matches(&requests, "b2", |c| c
+            == crate::redundant_run::REDUNDANT_RERUN_MESSAGE),
+        "the sentinel must never appear when suppression is disabled"
+    );
+}

--- a/crates/trusty-code/src/agent_loop/tests/redundant_rerun.rs
+++ b/crates/trusty-code/src/agent_loop/tests/redundant_rerun.rs
@@ -156,6 +156,51 @@ async fn test_rerun_after_edit_is_not_suppressed() {
     );
 }
 
+/// A DIFFERENTLY-SCOPED second run is NOT suppressed — suppression requires
+/// command IDENTITY, so a broader command that never actually ran still
+/// executes (#2804 review).
+///
+/// Why: The stale-green bug the review caught — a narrow run passing must never
+/// suppress a broader run. This is the end-to-end wiring proof that the
+/// identity check reaches the dispatch loop.
+/// What: Script [bash `echo cargo test` (passes), bash `echo cargo test
+/// --workspace` (broader, different string), finish_task] with suppression
+/// attached; assert the second run produced a REAL `exit_code: 0` result and
+/// NOT the sentinel.
+/// Test: this test.
+#[tokio::test]
+async fn differently_scoped_rerun_is_not_suppressed() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        bash_call_response("b1", "echo cargo test"),
+        bash_call_response("b2", "echo cargo test --workspace"),
+        finish_task_call_response("f1", r#"{"status": "completed", "summary": "done"}"#),
+    ]));
+    let registry = registry_with_finish_task_and_bash();
+    let agent = make_loop(llm.clone(), registry, AgentLoopConfig::default())
+        .with_redundant_run_suppression();
+
+    let out = agent
+        .run("system prompt", "run the tests, then finish")
+        .await
+        .expect("loop terminates on finish_task");
+
+    assert_eq!(llm.calls(), 3, "both bash turns plus the finish turn run");
+    assert_eq!(out.summary.as_deref(), Some("done"));
+
+    let requests = llm.requests();
+    // The broader second run must have actually executed — a real exit_code
+    // line, never the suppression sentinel.
+    assert!(
+        tool_result_matches(&requests, "b2", |c| c.contains("exit_code: 0")),
+        "a differently-scoped run must actually execute"
+    );
+    assert!(
+        !tool_result_matches(&requests, "b2", |c| c
+            == crate::redundant_run::REDUNDANT_RERUN_MESSAGE),
+        "a differently-scoped run must NOT be suppressed"
+    );
+}
+
 /// With suppression DISABLED (the default), an identical re-run is NOT
 /// short-circuited — the opt-in flag is the only thing that activates the
 /// behaviour.

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -286,6 +286,19 @@ pub mod run_task;
 /// Test: `verify_gate::tests::*`.
 pub mod verify_gate;
 
+/// Redundant full-suite test re-run suppression (#2682): the complement to
+/// [`verify_gate`] — it stops the suite running MORE than it needs to.
+///
+/// Why: (bake-off L1 diagnosis) The engineer re-runs the full suite 7-14x per
+/// run as repeated "one final run to confirm" passes, even when no code has
+/// changed since the last clean pass, inflating tcode's turn count far above
+/// claude-code's on the same challenge.
+/// What: The pure `is_redundant_test_rerun` predicate the agent loop consults
+/// (when suppression is enabled) to short-circuit a redundant test re-run with
+/// [`redundant_run::REDUNDANT_RERUN_MESSAGE`] instead of spawning the suite.
+/// Test: `redundant_run::tests::*`.
+pub mod redundant_run;
+
 /// DOC-28 catch-up context injection for the PM prompt (#1762, PR2).
 ///
 /// Why: The PM agent needs recent project-activity context (paused sessions,

--- a/crates/trusty-code/src/prompt/preamble.rs
+++ b/crates/trusty-code/src/prompt/preamble.rs
@@ -94,6 +94,12 @@ an existing suite goes unrun is not verification.
 - Never claim tests passed without having actually executed a test command and \
 observed its output. If you could not run the suite, say so explicitly instead \
 of asserting an unverified result.
+- ONE clean run of the suite after your LAST code change is sufficient \
+verification. Once it passes and you have made no further edits, do NOT re-run \
+the same suite again \"just to confirm\" — a repeated identical run over \
+unchanged code produces the same result and only wastes a turn. Re-run only \
+after you actually change something (an edit, a new file, a config change) that \
+a fresh run would exercise; otherwise proceed to finish.
 
 ## Testable design
 

--- a/crates/trusty-code/src/prompt/tests.rs
+++ b/crates/trusty-code/src/prompt/tests.rs
@@ -221,6 +221,34 @@ fn base_preamble_requires_running_project_test_suite_before_finishing() {
     );
 }
 
+/// `BASE_PREAMBLE` tells the model that ONE clean run after the last code
+/// change is sufficient and to NOT repeat identical confirmation runs over
+/// unchanged code (#2682 bake-off L1 diagnosis: the engineer re-ran the full
+/// suite 7-14x per run as repeated "one final run to confirm" passes,
+/// inflating turn counts far above claude-code's).
+///
+/// Why: This is the prompt-side half of #2682 (the structural half is
+/// `redundant_run`) — a general turn-efficiency nudge that applies to every
+/// agent's assembled prompt, so it belongs in the model-agnostic BASE preamble
+/// beside the neighbouring verification instructions.
+/// What: Asserts the preamble states one clean run is sufficient and forbids a
+/// redundant re-run over unchanged code.
+/// Test: this test.
+#[test]
+fn base_preamble_discourages_redundant_test_reruns() {
+    assert!(
+        BASE_PREAMBLE.contains(
+            "ONE clean run of the suite after your LAST code change is \
+sufficient"
+        ),
+        "must state one clean post-change run is sufficient verification"
+    );
+    assert!(
+        BASE_PREAMBLE.contains("do NOT re-run the same suite again"),
+        "must forbid repeating an identical confirmation run over unchanged code"
+    );
+}
+
 /// `BASE_PREAMBLE` nudges toward pure, unit-testable core functions with I/O
 /// kept in thin wrappers (#2279 improvement 2, bake-off L2 diagnosis: tcode
 /// fused `git` invocation directly into `parse_git_log`, making it untestable
@@ -335,7 +363,7 @@ fn base_preamble_version_is_semver_shaped() {
 /// Expected FNV-1a-style fold of [`BASE_PREAMBLE`]'s bytes, folded with its
 /// byte length. Regenerate this whenever the preamble legitimately changes
 /// (see [`base_preamble_hash_tripwire`] for the contributor instructions).
-const EXPECTED_PREAMBLE_HASH: u64 = 0x513f_fb3d_a209_0524;
+const EXPECTED_PREAMBLE_HASH: u64 = 0x1f38_9491_3735_48ff;
 
 /// Test-time guard coupling `BASE_PREAMBLE` *content* to its version constant.
 ///

--- a/crates/trusty-code/src/prompt/version.rs
+++ b/crates/trusty-code/src/prompt/version.rs
@@ -18,4 +18,4 @@
 /// `BASE_PREAMBLE` text so reports referencing an old run remain interpretable.
 /// Test: `prompt::tests::base_preamble_version_is_semver_shaped` asserts the
 /// three-component shape.
-pub const BASE_PREAMBLE_VERSION: &str = "1.6.0";
+pub const BASE_PREAMBLE_VERSION: &str = "1.7.0";

--- a/crates/trusty-code/src/redundant_run.rs
+++ b/crates/trusty-code/src/redundant_run.rs
@@ -11,11 +11,15 @@
 //! clean full-suite pass after the last code change, no more and no less.
 //! What: [`is_redundant_test_rerun`] is a pure predicate over a loop's
 //! transcript. A proposed `bash` test invocation is redundant iff the most
-//! recent prior test invocation already PASSED and nothing that could have
-//! changed the tree (a `write_file`/`write_files`/`edit`, or any non-test
-//! `bash` command) has run since. The predicate reuses `verify_gate`'s
-//! `is_test_command` / `bash_command_from_call` so the two gates can never
-//! drift on what counts as a test invocation. `agent_loop::AgentLoop`'s
+//! recent prior test invocation ran the BYTE-IDENTICAL command, already PASSED,
+//! and nothing that could have changed the tree (a `write_file`/`write_files`/
+//! `edit`, or any non-test `bash` command) has run since. Command identity is
+//! load-bearing (#2804 review): a narrow run passing (`cargo test -p a`) must
+//! never suppress a broader/different one (`cargo test --workspace`,
+//! `cargo test -p b`) that never actually ran, nor may a compile-only
+//! `cargo test --no-run` suppress the real subsequent run. The predicate reuses
+//! `verify_gate`'s `is_test_command` / `bash_command_from_call` so the two
+//! gates can never drift on what counts as a test invocation. `agent_loop::AgentLoop`'s
 //! dispatch loop consults it (when suppression is enabled via
 //! `AgentLoop::with_redundant_run_suppression`) and, on a match, short-circuits
 //! the dispatch with [`REDUNDANT_RERUN_MESSAGE`] instead of actually spawning
@@ -36,12 +40,16 @@ use crate::verify_gate::{bash_command_from_call, is_test_command};
 /// invite another confirmation run. Phrasing it as a normal (non-error)
 /// result keeps the loop calm: nothing failed, the prior pass still stands.
 /// What: A fixed, model-facing sentence explaining the suppression and the
-/// invariant it relies on (last pass still valid, no code changed since).
+/// invariant it relies on — the SAME command already passed and no code has
+/// changed since. It is only ever emitted for a byte-identical re-run (see
+/// [`is_redundant_test_rerun`]), so "this exact command" is always accurate.
 /// Test: `redundant_run::tests::suppression_message_is_informative`.
-pub const REDUNDANT_RERUN_MESSAGE: &str = "skipped: this test suite already passed earlier in \
-this session and no code has changed since (no write_file/edit and no other shell command ran \
-between that passing run and this one). Re-running it would produce the same result and cost a \
-turn. The prior clean pass still stands — proceed to finish the task rather than re-confirming.";
+pub const REDUNDANT_RERUN_MESSAGE: &str = "skipped: this exact test command already passed \
+earlier in this session and no code has changed since (no write_file/edit and no other shell \
+command ran between that passing run and this one). Re-running the identical command would \
+produce the same result and cost a turn. The prior clean pass still stands — proceed to finish \
+the task, or run a DIFFERENT (e.g. broader) command if you need to verify something the passing \
+run did not cover.";
 
 /// Tool names that are pure read-only discovery and therefore CANNOT
 /// invalidate a passing test baseline.
@@ -107,53 +115,83 @@ fn call_result_passed(messages: &[ChatMessage], call_id: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Fold one completed tool `call` into the running "is the last test pass still
-/// valid" baseline.
+/// Fold one completed tool `call` into the running baseline: the exact command
+/// string of the most recent test run that PASSED with nothing state-changing
+/// since, or `None`.
 ///
 /// Why: Centralises the single rule that decides, per tool call, whether a
-/// prior clean test pass survives it — so the scan in
-/// [`is_redundant_test_rerun`] stays a thin ordered fold.
-/// What: A `bash` test command SETS the baseline to whether that run passed
-/// (`call_result_passed`); any other `bash` command CLEARS it (a shell command
-/// may have mutated the tree); a [`READ_ONLY_TOOLS`] call leaves it unchanged;
-/// every other tool CLEARS it (conservative — treat unknown effects as
-/// state-changing).
+/// prior clean test pass survives it — and, critically (#2804 review),
+/// remembers WHICH command passed so a later re-run is only suppressed when it
+/// is byte-identical. A bare `bool` would wrongly suppress a broader/different
+/// command (`cargo test --workspace`) just because a narrower one
+/// (`cargo test -- foo`) passed.
+/// What: A passing `bash` test command SETS the baseline to `Some(command)`; a
+/// FAILING test command CLEARS it (`None`); any other `bash` command CLEARS it
+/// (a shell command may have mutated the tree); a [`READ_ONLY_TOOLS`] call
+/// leaves it unchanged; every other tool CLEARS it (conservative — treat
+/// unknown effects as state-changing).
 /// Test: exercised via `is_redundant_test_rerun` across
 /// `redundant_run::tests::*`.
-fn fold_call(baseline_passing: &mut bool, call: &ToolCall, messages: &[ChatMessage]) {
+fn fold_call(baseline: &mut Option<String>, call: &ToolCall, messages: &[ChatMessage]) {
     if let Some(command) = bash_command_from_call(call) {
-        *baseline_passing = is_test_command(&command) && call_result_passed(messages, &call.id);
+        *baseline = (is_test_command(&command) && call_result_passed(messages, &call.id))
+            .then_some(command);
         return;
     }
     if READ_ONLY_TOOLS.contains(&call.function.name.as_str()) {
         return;
     }
-    *baseline_passing = false;
+    *baseline = None;
+}
+
+/// Whether two shell command strings are the "same" test invocation for
+/// suppression purposes.
+///
+/// Why: Suppression must require command IDENTITY (#2804 review): re-running a
+/// DIFFERENT command — a broader scope, a different package, a previously
+/// compile-only `--no-run` now actually executing — is a genuinely-needed run,
+/// never redundant. Defaulting to exact match (not a fuzzy/normalized one)
+/// keeps the gate conservative: a false "same" verdict would suppress a real
+/// run, so anything short of certainty must read as "different".
+/// What: Exact string equality after trimming leading/trailing whitespace only
+/// — the sole normalization, so a stray surrounding space cannot force an
+/// otherwise-identical re-run to execute. Internal differences (flags, paths,
+/// package selectors, `--no-run`) are all preserved and therefore all count as
+/// a different command.
+/// Test: `redundant_run::tests::different_test_command_after_pass_is_not_redundant`,
+/// `redundant_run::tests::passing_prior_run_makes_rerun_redundant`.
+fn same_test_command(baseline: &str, pending: &str) -> bool {
+    baseline.trim() == pending.trim()
 }
 
 /// Whether the pending `bash` test call `current_call_id` would be a redundant
-/// re-run of a suite that already passed with nothing changed since.
+/// re-run: the SAME command already passed with nothing changed since.
 ///
 /// Why: This is the gate `agent_loop::AgentLoop::dispatch_all` consults before
 /// spawning a test suite — the whole point of #2682. It must be conservative:
 /// a `true` result suppresses a real execution, so a false positive would hide
 /// a genuinely-needed run. The predicate therefore only returns `true` when a
-/// prior run demonstrably PASSED and every tool call since is demonstrably
-/// non-mutating.
+/// prior run demonstrably PASSED, every tool call since is demonstrably
+/// non-mutating, AND (#2804 review) the pending command is byte-identical to
+/// that passing command — a broader or otherwise-different command is never
+/// suppressed.
 /// What: Folds every assistant tool call in `messages`, in order, up to (but
 /// excluding) the call identified by `current_call_id` — the proposed re-run
-/// itself, and anything after it, is irrelevant — tracking whether the most
-/// recent test run left a still-valid passing baseline. Returns that final
-/// baseline. Because the proposed call's own (not-yet-recorded) result is
-/// never consulted, and any same-turn write/edit BEFORE it clears the baseline,
-/// the answer reflects tree state exactly as of just before the re-run.
+/// itself, and anything after it, is irrelevant — tracking the exact command
+/// of the most recent still-valid passing test run (or `None`). On reaching
+/// the pending call, extracts ITS command and returns `true` only when a
+/// baseline command exists and [`same_test_command`] holds. Because the
+/// proposed call's own (not-yet-recorded) result is never consulted, and any
+/// same-turn write/edit BEFORE it clears the baseline, the answer reflects tree
+/// state exactly as of just before the re-run.
 /// Test: `redundant_run::tests::passing_prior_run_makes_rerun_redundant`,
+/// `redundant_run::tests::different_test_command_after_pass_is_not_redundant`,
 /// `redundant_run::tests::failing_prior_run_is_not_redundant`,
 /// `redundant_run::tests::edit_between_runs_defeats_suppression`,
 /// `redundant_run::tests::no_prior_run_is_not_redundant`,
 /// `redundant_run::tests::same_turn_edit_before_rerun_defeats_suppression`.
 pub fn is_redundant_test_rerun(messages: &[ChatMessage], current_call_id: &str) -> bool {
-    let mut baseline_passing = false;
+    let mut baseline: Option<String> = None;
     for message in messages {
         if message.role != "assistant" {
             continue;
@@ -163,12 +201,18 @@ pub fn is_redundant_test_rerun(messages: &[ChatMessage], current_call_id: &str) 
         };
         for call in calls {
             if call.id == current_call_id {
-                return baseline_passing;
+                return match (baseline.as_deref(), bash_command_from_call(call)) {
+                    (Some(passed), Some(pending)) => same_test_command(passed, &pending),
+                    _ => false,
+                };
             }
-            fold_call(&mut baseline_passing, call, messages);
+            fold_call(&mut baseline, call, messages);
         }
     }
-    baseline_passing
+    // The pending call was not found in the transcript — fail safe (never
+    // suppress a call we cannot locate). In practice `dispatch_all` always
+    // passes a `call.id` present in the just-pushed assistant turn.
+    false
 }
 
 /// Whether `call` is a `bash` invocation of a test command — the cheap
@@ -277,6 +321,66 @@ mod tests {
             assistant(vec![bash_call("t1", "cargo test -p trusty-code")]),
             bash_result("t1", 0),
             assistant(vec![bash_call("t2", "cargo test -p trusty-code")]),
+        ];
+        assert!(is_redundant_test_rerun(&messages, "t2"));
+    }
+
+    /// A DIFFERENT test command after a pass is NOT redundant — suppression
+    /// requires command IDENTITY (#2804 review).
+    ///
+    /// Why: A narrow run passing (`cargo test -p a`) must never suppress a
+    /// broader/different run (`cargo test -p b`, `cargo test --workspace`) that
+    /// was never actually executed — that would silently skip real coverage.
+    /// What: Turn 1 runs `cargo test -p a` and passes; turn 2 proposes
+    /// `cargo test -p b`; assert NOT redundant. The reverse (same command) is
+    /// covered by `passing_prior_run_makes_rerun_redundant`.
+    /// Test: this test.
+    #[test]
+    fn different_test_command_after_pass_is_not_redundant() {
+        let messages = vec![
+            assistant(vec![bash_call("t1", "cargo test -p a")]),
+            bash_result("t1", 0),
+            assistant(vec![bash_call("t2", "cargo test -p b")]),
+        ];
+        assert!(!is_redundant_test_rerun(&messages, "t2"));
+    }
+
+    /// A `--no-run` compile-only pass does NOT suppress a subsequent REAL run
+    /// of the same suite — because the real run's command string differs
+    /// (#2804 review, secondary concern).
+    ///
+    /// Why: `cargo test --no-run` compiles but executes zero tests, then exits
+    /// 0. Command-identity matching already prevents it suppressing a genuine
+    /// `cargo test` run: the two command strings are not equal, so the gate
+    /// treats them as different runs — no special-casing of `--no-run` needed.
+    /// What: Turn 1 runs `cargo test --no-run` (exit 0); turn 2 proposes the
+    /// real `cargo test`; assert NOT redundant.
+    /// Test: this test.
+    #[test]
+    fn compile_only_pass_does_not_suppress_real_run() {
+        let messages = vec![
+            assistant(vec![bash_call("t1", "cargo test --no-run")]),
+            bash_result("t1", 0),
+            assistant(vec![bash_call("t2", "cargo test")]),
+        ];
+        assert!(!is_redundant_test_rerun(&messages, "t2"));
+    }
+
+    /// Surrounding whitespace does not defeat identity — a re-run of the SAME
+    /// command with a stray leading/trailing space is still redundant.
+    ///
+    /// Why: `same_test_command` trims outer whitespace only, so a trivially
+    /// re-emitted command is still recognised while every internal difference
+    /// (flags, scope) is preserved.
+    /// What: Turn 1 `cargo test` passes; turn 2 proposes `  cargo test ` (outer
+    /// spaces); assert redundant.
+    /// Test: this test.
+    #[test]
+    fn outer_whitespace_does_not_defeat_identity() {
+        let messages = vec![
+            assistant(vec![bash_call("t1", "cargo test")]),
+            bash_result("t1", 0),
+            assistant(vec![bash_call("t2", "  cargo test ")]),
         ];
         assert!(is_redundant_test_rerun(&messages, "t2"));
     }

--- a/crates/trusty-code/src/redundant_run.rs
+++ b/crates/trusty-code/src/redundant_run.rs
@@ -1,0 +1,418 @@
+//! Redundant full-suite test re-run suppression (#2682).
+//!
+//! Why: (bake-off L1 diagnosis) The delegated engineer re-runs the full test
+//! suite 7-14x per run, typically framed as "one final run to confirm", even
+//! when NO code has changed since the last clean pass. Each redundant re-run
+//! burns a whole turn (and the suite's wall-clock cost), inflating tcode's
+//! turn count (~33-49) far above claude-code's (~15) on the same challenge.
+//! The sibling verify-before-finish gate (#2279) guarantees the suite runs at
+//! LEAST once; this module is its complement — it stops the suite running MORE
+//! than it needs to. Together they bracket the correct behaviour: exactly one
+//! clean full-suite pass after the last code change, no more and no less.
+//! What: [`is_redundant_test_rerun`] is a pure predicate over a loop's
+//! transcript. A proposed `bash` test invocation is redundant iff the most
+//! recent prior test invocation already PASSED and nothing that could have
+//! changed the tree (a `write_file`/`write_files`/`edit`, or any non-test
+//! `bash` command) has run since. The predicate reuses `verify_gate`'s
+//! `is_test_command` / `bash_command_from_call` so the two gates can never
+//! drift on what counts as a test invocation. `agent_loop::AgentLoop`'s
+//! dispatch loop consults it (when suppression is enabled via
+//! `AgentLoop::with_redundant_run_suppression`) and, on a match, short-circuits
+//! the dispatch with [`REDUNDANT_RERUN_MESSAGE`] instead of actually spawning
+//! the suite — saving the turn's wall-clock cost and nudging the model to
+//! proceed to finish.
+//! Test: `redundant_run::tests::*`, plus
+//! `agent_loop::tests::redundant_test_rerun_is_suppressed` and
+//! `agent_loop::tests::test_rerun_after_edit_is_not_suppressed`.
+
+use crate::llm::{ChatMessage, ToolCall};
+use crate::tools::BASH_TOOL_NAME;
+use crate::verify_gate::{bash_command_from_call, is_test_command};
+
+/// The `ToolResult` text returned in place of a suppressed redundant re-run.
+///
+/// Why: The model must understand WHY its test command produced no fresh
+/// output, so it stops retrying and moves on — a silent no-op would just
+/// invite another confirmation run. Phrasing it as a normal (non-error)
+/// result keeps the loop calm: nothing failed, the prior pass still stands.
+/// What: A fixed, model-facing sentence explaining the suppression and the
+/// invariant it relies on (last pass still valid, no code changed since).
+/// Test: `redundant_run::tests::suppression_message_is_informative`.
+pub const REDUNDANT_RERUN_MESSAGE: &str = "skipped: this test suite already passed earlier in \
+this session and no code has changed since (no write_file/edit and no other shell command ran \
+between that passing run and this one). Re-running it would produce the same result and cost a \
+turn. The prior clean pass still stands — proceed to finish the task rather than re-confirming.";
+
+/// Tool names that are pure read-only discovery and therefore CANNOT
+/// invalidate a passing test baseline.
+///
+/// Why: Between a clean test pass and a redundant re-run the model typically
+/// does nothing, or merely re-reads files — none of which changes the tree, so
+/// none of which makes a re-run non-redundant. Anything NOT on this allowlist
+/// (a write, an edit, an arbitrary shell command, a skill load, a delegation)
+/// is treated as potentially state-changing, which errs toward RUNNING the
+/// suite — the conservative, correctness-first default the acceptance criteria
+/// demand ("the single final run must still occur after the last code change").
+/// What: The read-only file/discovery tools registered in the engineer's tool
+/// set. `bash` is deliberately absent — a `bash` call is classified by its
+/// command (a test command preserves the baseline; any other command is
+/// treated as potentially mutating).
+/// Test: `redundant_run::tests::read_only_activity_keeps_run_redundant`,
+/// `redundant_run::tests::non_test_bash_between_runs_defeats_suppression`.
+const READ_ONLY_TOOLS: &[&str] = &[
+    "read_file",
+    "grep",
+    "glob",
+    "list_dir",
+    "search_code",
+    "recall_session",
+];
+
+/// Whether a `bash` tool-result's captured output indicates the command exited
+/// 0 (the suite PASSED).
+///
+/// Why: Only a PASSING prior run makes a re-run redundant — re-running a suite
+/// that last FAILED is legitimate (the model may have fixed something, or may
+/// be re-reading the failure), so the gate must never suppress it. The bash
+/// tool always appends a final `exit_code: N` line to its captured output
+/// (`tools::bash`), which is the one reliable pass/fail signal available from
+/// the transcript.
+/// What: `true` iff the result text, trimmed of trailing whitespace, ends with
+/// exactly `exit_code: 0`. `exit_code: 10` / `exit_code: 1` and the
+/// suppression sentinel (which carries no `exit_code:` line) all read as "not
+/// a pass".
+/// Test: `redundant_run::tests::exit_zero_reads_as_pass`,
+/// `redundant_run::tests::nonzero_and_missing_exit_read_as_not_pass`.
+fn test_result_passed(result_content: &str) -> bool {
+    result_content.trim_end().ends_with("exit_code: 0")
+}
+
+/// Whether the `tool`-role result answering `call_id` in `messages` reports a
+/// passing exit.
+///
+/// Why: A test invocation only establishes a passing baseline once its result
+/// has actually been recorded and shows exit 0; a call whose result is not yet
+/// present (e.g. the proposed re-run itself, mid-dispatch) must not count.
+/// What: Finds the first `tool` message whose `tool_call_id == call_id` and
+/// applies [`test_result_passed`] to its content; `false` when absent.
+/// Test: exercised via `is_redundant_test_rerun` in
+/// `redundant_run::tests::passing_prior_run_makes_rerun_redundant`,
+/// `redundant_run::tests::failing_prior_run_is_not_redundant`.
+fn call_result_passed(messages: &[ChatMessage], call_id: &str) -> bool {
+    messages
+        .iter()
+        .find(|m| m.role == "tool" && m.tool_call_id.as_deref() == Some(call_id))
+        .and_then(|m| m.content.as_deref())
+        .map(test_result_passed)
+        .unwrap_or(false)
+}
+
+/// Fold one completed tool `call` into the running "is the last test pass still
+/// valid" baseline.
+///
+/// Why: Centralises the single rule that decides, per tool call, whether a
+/// prior clean test pass survives it — so the scan in
+/// [`is_redundant_test_rerun`] stays a thin ordered fold.
+/// What: A `bash` test command SETS the baseline to whether that run passed
+/// (`call_result_passed`); any other `bash` command CLEARS it (a shell command
+/// may have mutated the tree); a [`READ_ONLY_TOOLS`] call leaves it unchanged;
+/// every other tool CLEARS it (conservative — treat unknown effects as
+/// state-changing).
+/// Test: exercised via `is_redundant_test_rerun` across
+/// `redundant_run::tests::*`.
+fn fold_call(baseline_passing: &mut bool, call: &ToolCall, messages: &[ChatMessage]) {
+    if let Some(command) = bash_command_from_call(call) {
+        *baseline_passing = is_test_command(&command) && call_result_passed(messages, &call.id);
+        return;
+    }
+    if READ_ONLY_TOOLS.contains(&call.function.name.as_str()) {
+        return;
+    }
+    *baseline_passing = false;
+}
+
+/// Whether the pending `bash` test call `current_call_id` would be a redundant
+/// re-run of a suite that already passed with nothing changed since.
+///
+/// Why: This is the gate `agent_loop::AgentLoop::dispatch_all` consults before
+/// spawning a test suite — the whole point of #2682. It must be conservative:
+/// a `true` result suppresses a real execution, so a false positive would hide
+/// a genuinely-needed run. The predicate therefore only returns `true` when a
+/// prior run demonstrably PASSED and every tool call since is demonstrably
+/// non-mutating.
+/// What: Folds every assistant tool call in `messages`, in order, up to (but
+/// excluding) the call identified by `current_call_id` — the proposed re-run
+/// itself, and anything after it, is irrelevant — tracking whether the most
+/// recent test run left a still-valid passing baseline. Returns that final
+/// baseline. Because the proposed call's own (not-yet-recorded) result is
+/// never consulted, and any same-turn write/edit BEFORE it clears the baseline,
+/// the answer reflects tree state exactly as of just before the re-run.
+/// Test: `redundant_run::tests::passing_prior_run_makes_rerun_redundant`,
+/// `redundant_run::tests::failing_prior_run_is_not_redundant`,
+/// `redundant_run::tests::edit_between_runs_defeats_suppression`,
+/// `redundant_run::tests::no_prior_run_is_not_redundant`,
+/// `redundant_run::tests::same_turn_edit_before_rerun_defeats_suppression`.
+pub fn is_redundant_test_rerun(messages: &[ChatMessage], current_call_id: &str) -> bool {
+    let mut baseline_passing = false;
+    for message in messages {
+        if message.role != "assistant" {
+            continue;
+        }
+        let Some(calls) = message.tool_calls.as_ref() else {
+            continue;
+        };
+        for call in calls {
+            if call.id == current_call_id {
+                return baseline_passing;
+            }
+            fold_call(&mut baseline_passing, call, messages);
+        }
+    }
+    baseline_passing
+}
+
+/// Whether `call` is a `bash` invocation of a test command — the cheap
+/// pre-filter `dispatch_all` applies before the fuller
+/// [`is_redundant_test_rerun`] transcript scan.
+///
+/// Why: Only a `bash` test call can ever be a redundant re-run, so the dispatch
+/// loop should not pay for the transcript scan on every other tool call.
+/// What: `true` iff `call` names [`BASH_TOOL_NAME`] and its extracted command
+/// [`is_test_command`].
+/// Test: `redundant_run::tests::is_test_bash_call_true_only_for_test_bash`.
+pub fn is_test_bash_call(call: &ToolCall) -> bool {
+    call.function.name == BASH_TOOL_NAME
+        && bash_command_from_call(call).is_some_and(|c| is_test_command(&c))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::FunctionCall;
+
+    /// Build a `bash` tool call with the given id and command.
+    fn bash_call(id: &str, command: &str) -> ToolCall {
+        ToolCall {
+            id: id.into(),
+            kind: "function".into(),
+            function: FunctionCall {
+                name: BASH_TOOL_NAME.into(),
+                arguments: serde_json::json!({ "command": command }).to_string(),
+            },
+        }
+    }
+
+    /// Build a non-`bash` tool call (e.g. `write_file`, `read_file`).
+    fn tool_call(id: &str, name: &str) -> ToolCall {
+        ToolCall {
+            id: id.into(),
+            kind: "function".into(),
+            function: FunctionCall {
+                name: name.into(),
+                arguments: "{}".into(),
+            },
+        }
+    }
+
+    /// An assistant turn carrying the given tool calls.
+    fn assistant(calls: Vec<ToolCall>) -> ChatMessage {
+        ChatMessage {
+            role: "assistant".into(),
+            content: None,
+            tool_calls: Some(calls),
+            tool_call_id: None,
+            name: None,
+            cache_control: None,
+        }
+    }
+
+    /// A `tool`-role result answering `call_id` with a bash-shaped body ending
+    /// in `exit_code: {code}`.
+    fn bash_result(call_id: &str, code: i32) -> ChatMessage {
+        ChatMessage::tool_result(
+            call_id,
+            BASH_TOOL_NAME,
+            format!("stdout:\nok\nexit_code: {code}"),
+        )
+    }
+
+    /// [`test_result_passed`] treats a trailing `exit_code: 0` as a pass.
+    ///
+    /// Why: Exit 0 is the one pass signal the bash tool guarantees.
+    /// What: Assert on a realistic passing bash body.
+    /// Test: this test.
+    #[test]
+    fn exit_zero_reads_as_pass() {
+        assert!(test_result_passed("stdout:\n5 passed\nexit_code: 0"));
+        assert!(test_result_passed("exit_code: 0\n"));
+    }
+
+    /// [`test_result_passed`] rejects non-zero and missing exit codes.
+    ///
+    /// Why: A failing or unknown run must never establish a passing baseline —
+    /// and `exit_code: 10` must not be mistaken for `exit_code: 0`.
+    /// What: Non-zero exits, the suppression sentinel, and empty text.
+    /// Test: this test.
+    #[test]
+    fn nonzero_and_missing_exit_read_as_not_pass() {
+        assert!(!test_result_passed("stderr:\nFAILED\nexit_code: 1"));
+        assert!(!test_result_passed("exit_code: 10"));
+        assert!(!test_result_passed(REDUNDANT_RERUN_MESSAGE));
+        assert!(!test_result_passed(""));
+    }
+
+    /// A passing prior run with nothing since makes an identical re-run
+    /// redundant.
+    ///
+    /// Why: This is the core acceptance behaviour — the exact "one final run to
+    /// confirm" loop the ticket eliminates.
+    /// What: Turn 1 runs `cargo test` and it passes (exit 0); turn 2 proposes
+    /// `cargo test` again with nothing in between; assert redundant.
+    /// Test: this test.
+    #[test]
+    fn passing_prior_run_makes_rerun_redundant() {
+        let messages = vec![
+            assistant(vec![bash_call("t1", "cargo test -p trusty-code")]),
+            bash_result("t1", 0),
+            assistant(vec![bash_call("t2", "cargo test -p trusty-code")]),
+        ];
+        assert!(is_redundant_test_rerun(&messages, "t2"));
+    }
+
+    /// A FAILING prior run makes a re-run NOT redundant.
+    ///
+    /// Why: The model may re-run a failing suite legitimately; suppressing it
+    /// would hide the failure and break the loop's self-correction.
+    /// What: Turn 1's `cargo test` exits 1; turn 2 proposes it again; assert
+    /// NOT redundant.
+    /// Test: this test.
+    #[test]
+    fn failing_prior_run_is_not_redundant() {
+        let messages = vec![
+            assistant(vec![bash_call("t1", "cargo test")]),
+            bash_result("t1", 1),
+            assistant(vec![bash_call("t2", "cargo test")]),
+        ];
+        assert!(!is_redundant_test_rerun(&messages, "t2"));
+    }
+
+    /// A `write_file`/`edit` between a passing run and a re-run defeats
+    /// suppression — the genuinely-needed post-change run still fires.
+    ///
+    /// Why: This is the correctness guarantee the acceptance criteria name:
+    /// "the single final run must still occur after the last code change".
+    /// What: pass → `edit` → propose re-run; assert NOT redundant.
+    /// Test: this test.
+    #[test]
+    fn edit_between_runs_defeats_suppression() {
+        let messages = vec![
+            assistant(vec![bash_call("t1", "cargo test")]),
+            bash_result("t1", 0),
+            assistant(vec![tool_call("e1", "edit")]),
+            ChatMessage::tool_result("e1", "edit", "edited"),
+            assistant(vec![bash_call("t2", "cargo test")]),
+        ];
+        assert!(!is_redundant_test_rerun(&messages, "t2"));
+    }
+
+    /// Read-only activity (read_file/grep/glob) between a passing run and a
+    /// re-run keeps the re-run redundant.
+    ///
+    /// Why: Re-reading files changes nothing on disk, so a re-run after only
+    /// reads is still a wasted confirmation.
+    /// What: pass → `read_file` + `grep` → propose re-run; assert redundant.
+    /// Test: this test.
+    #[test]
+    fn read_only_activity_keeps_run_redundant() {
+        let messages = vec![
+            assistant(vec![bash_call("t1", "pytest tests/ -v")]),
+            bash_result("t1", 0),
+            assistant(vec![tool_call("r1", "read_file"), tool_call("g1", "grep")]),
+            ChatMessage::tool_result("r1", "read_file", "..."),
+            ChatMessage::tool_result("g1", "grep", "..."),
+            assistant(vec![bash_call("t2", "pytest tests/ -v")]),
+        ];
+        assert!(is_redundant_test_rerun(&messages, "t2"));
+    }
+
+    /// A non-test `bash` command between runs defeats suppression.
+    ///
+    /// Why: An arbitrary shell command (`sed -i`, `git checkout`, a build) may
+    /// mutate the tree, so a subsequent test run is not provably redundant.
+    /// What: pass → `bash: git checkout .` → propose re-run; assert NOT
+    /// redundant.
+    /// Test: this test.
+    #[test]
+    fn non_test_bash_between_runs_defeats_suppression() {
+        let messages = vec![
+            assistant(vec![bash_call("t1", "cargo test")]),
+            bash_result("t1", 0),
+            assistant(vec![bash_call("b1", "git checkout .")]),
+            bash_result("b1", 0),
+            assistant(vec![bash_call("t2", "cargo test")]),
+        ];
+        assert!(!is_redundant_test_rerun(&messages, "t2"));
+    }
+
+    /// With no prior test run at all, the first run is never redundant.
+    ///
+    /// Why: The first execution is always genuinely needed — the gate must be
+    /// inert until a baseline exists.
+    /// What: A single proposed `cargo test` with empty history; assert NOT
+    /// redundant.
+    /// Test: this test.
+    #[test]
+    fn no_prior_run_is_not_redundant() {
+        let messages = vec![assistant(vec![bash_call("t1", "cargo test")])];
+        assert!(!is_redundant_test_rerun(&messages, "t1"));
+    }
+
+    /// A same-turn edit emitted BEFORE the re-run (batched) defeats
+    /// suppression.
+    ///
+    /// Why: The model can batch `edit` + `cargo test` in one turn; the edit
+    /// must invalidate the prior baseline even though it shares the proposed
+    /// run's turn.
+    /// What: pass → [turn: `edit` then `cargo test`]; propose the same-turn
+    /// `cargo test`; assert NOT redundant.
+    /// Test: this test.
+    #[test]
+    fn same_turn_edit_before_rerun_defeats_suppression() {
+        let messages = vec![
+            assistant(vec![bash_call("t1", "cargo test")]),
+            bash_result("t1", 0),
+            assistant(vec![tool_call("e1", "edit"), bash_call("t2", "cargo test")]),
+        ];
+        assert!(!is_redundant_test_rerun(&messages, "t2"));
+    }
+
+    /// [`is_test_bash_call`] is true only for a `bash` call whose command is a
+    /// test command.
+    ///
+    /// Why: The dispatch-loop pre-filter must not trip on a non-`bash` tool or
+    /// a non-test shell command.
+    /// What: A test bash call (true), a non-test bash call (false), a
+    /// `write_file` call (false).
+    /// Test: this test.
+    #[test]
+    fn is_test_bash_call_true_only_for_test_bash() {
+        assert!(is_test_bash_call(&bash_call("a", "cargo test")));
+        assert!(!is_test_bash_call(&bash_call("b", "git status")));
+        assert!(!is_test_bash_call(&tool_call("c", "write_file")));
+    }
+
+    /// The suppression message names the invariant it relies on so the model
+    /// can trust it.
+    ///
+    /// Why: A vague message would invite the very re-run it means to prevent.
+    /// What: Assert the sentinel mentions "already passed" and "proceed to
+    /// finish".
+    /// Test: this test.
+    #[test]
+    fn suppression_message_is_informative() {
+        assert!(REDUNDANT_RERUN_MESSAGE.contains("already passed"));
+        assert!(REDUNDANT_RERUN_MESSAGE.contains("proceed to finish"));
+    }
+}

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -391,7 +391,14 @@ impl InProcessAgentRunner {
             // sub-agent loop (both `run_task` and `task::executor` delegate
             // through this runner), so wiring it here covers both entry
             // points without duplicating the attachment at each call site.
-            .with_finish_gate(crate::verify_gate::default_finish_gate());
+            .with_finish_gate(crate::verify_gate::default_finish_gate())
+            // #2682: the complement to the verify gate above — suppress a
+            // redundant full-suite re-run once the suite has passed and nothing
+            // has changed since, so the engineer stops burning turns on
+            // repeated "one final run to confirm" passes. Same single
+            // construction site, so both `run_task` and `task::executor`
+            // delegations get it.
+            .with_redundant_run_suppression();
         if let Some(sink) = &self.sink {
             agent_loop = agent_loop.with_tool_event_sink(Arc::clone(sink));
         }


### PR DESCRIPTION
## Problem

The delegated engineer re-runs the full test suite 7-14x per bake-off L1 run as repeated "one final run to confirm" passes, even when no code has changed since the last clean pass — inflating tcode's turn count (~33-49) far above claude-code's (~15) on the same challenge (#2682).

## Approach

Two complementary levers, both scoped to the delegated-engineer loop:

1. **Structural gate — new `redundant_run` module** (the complement to the `verify_gate`, #2279). `is_redundant_test_rerun` is a pure predicate over the loop's transcript: a proposed `bash` test invocation is redundant iff the most recent prior test invocation already **passed** (exit 0) and nothing that could have changed the tree (a `write_file`/`write_files`/`edit`, or any non-test `bash` command) has run since. It reuses `verify_gate`'s `is_test_command` / `bash_command_from_call` so the two gates can never drift. `AgentLoop::dispatch_all` consults it (opt-in via `with_redundant_run_suppression`, attached at the single delegated-engineer construction site in `runner::in_process` alongside the verify gate) and, on a match, short-circuits the dispatch with an explanatory sentinel result instead of spawning the suite.

2. **Prompt nudge — BASE preamble** now states that one clean run after the last code change is sufficient and to not repeat identical confirmation runs (preamble bumped `1.6.0` → `1.7.0`).

## Correctness

Conservative by design: any write/edit or arbitrary shell command between runs defeats suppression, so the **single final run after the last code change always still fires** — satisfying the acceptance criterion "no loss of correctness confidence". Suppression is opt-in, so every existing call site is unaffected.

## Tests

- `redundant_run::tests::*` — 11 unit tests over the pure predicate (passing/failing prior run, edit/read-only/non-test-bash between runs, same-turn batched edit, no-prior-run, exit-code parsing).
- `agent_loop::tests::redundant_rerun::*` — 3 end-to-end wiring tests proving dispatch short-circuits a redundant run, still executes a post-write run, and is a no-op when the flag is absent.
- `prompt::tests::base_preamble_discourages_redundant_test_reruns` — locks the preamble guidance.

Gates: `cargo build`, `cargo test -p trusty-code` (931 lib + all integration binaries, 0 failures single-threaded), `cargo clippy -p trusty-code --all-targets -- -D warnings`, `cargo fmt --check`, and `scripts/check_line_cap.sh` all pass.

Closes #2682

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools