### PR TITLE
fix(trusty-code): bound PM re-delegation to prevent degenerate delegate loop

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -21,6 +21,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   so conceptual discovery still works during the embedding warm-up window
   (#2783).
 
+### Fixed
+
+- Bound PM re-delegation so a degenerate delegate loop cannot mislabel a
+  complete run. Once a delegated engineer reports an explicit successful
+  `finish_task` completion, the PM's `delegate_to_agent` tool refuses any
+  further re-delegation (nudging it to `finish_task` instead), and
+  `run_task`'s report assembler now reports `success`/`no_changes` — never
+  `partial`/exit-6 or `deadline_exceeded` — for a run the engineer already
+  completed, regardless of how the PM's own loop later terminated. This closes
+  the data-integrity bug where a gratuitous post-`finish_task` re-verify round
+  that ran out of turns/time corrupted run status and telemetry on a
+  fully-passing, all-tests-green run (#2683).
+
 ---
 
 ## [0.1.0] — 2026-07-09

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -1018,10 +1018,13 @@ fn build_output(transcript: &Transcript, perf: &PerfCollector) -> AgentOutput {
 /// — if `finish_args` deserialises into a `FinishTaskArgs` (it always should,
 /// since `dispatch_all` only calls this after a successful `finish_task`
 /// dispatch, which itself required a successful deserialisation) — overwrites
-/// `content` with [`crate::tools::render_finish_summary`] and sets `summary` to
-/// the model's own one-line `summary` field. On the (should-be-unreachable)
-/// deserialisation failure, falls back to the transcript-derived content
-/// `build_output` already computed, rather than panicking.
+/// `content` with [`crate::tools::render_finish_summary`], sets `summary` to
+/// the model's own one-line `summary` field, and (#2683) records the reported
+/// `status` in `finish_status` so a delegating caller can distinguish an
+/// explicit successful completion from any other termination. On the
+/// (should-be-unreachable) deserialisation failure, falls back to the
+/// transcript-derived content `build_output` already computed, rather than
+/// panicking.
 /// Test: `agent_loop::tests::explicit_finish_task_terminates_loop_with_structured_summary`.
 fn build_finish_output(
     transcript: &Transcript,
@@ -1032,6 +1035,7 @@ fn build_finish_output(
     if let Ok(parsed) = serde_json::from_value::<FinishTaskArgs>(finish_args.clone()) {
         output.summary = Some(parsed.summary.clone());
         output.content = crate::tools::render_finish_summary(&parsed);
+        output.finish_status = Some(parsed.status);
     }
     output
 }

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -38,9 +38,9 @@ use crate::provider::{
 };
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
 use crate::tools::{
-    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, FinishTaskTool, GlobTool,
-    GrepTool, ListDirTool, ReadFileTool, RunContext, ToolRegistry, TrustySearchTool, WriteFileTool,
-    WriteFilesTool,
+    AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, EngineerCompletionSignal,
+    FinishTaskTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, RunContext, ToolRegistry,
+    TrustySearchTool, WriteFileTool, WriteFilesTool,
 };
 
 pub use recorder::{RecordingLlmClient, SharedTranscript, TurnRecord};
@@ -198,6 +198,15 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     // subsequently does.
     let redelegation_signal = RedelegationCapSignal::new();
 
+    // (#2683) The engineer-completion latch is shared between the PM's
+    // `DelegateToAgentTool` (which sets it when a delegation returns an explicit
+    // successful `finish_task`, and refuses any subsequent re-delegation once
+    // set) and `assemble_report` below (which reports success rather than
+    // partial for a run the engineer already completed). This is what stops a
+    // gratuitous post-finish re-verify round from mislabeling a complete,
+    // all-tests-passing run as `partial`/exit-6.
+    let completion_signal = EngineerCompletionSignal::new();
+
     // Build the engineer runner, scoped to the project working dir, sharing the
     // transcript (engineer turns are tagged "python-engineer").
     let engineer_runner = build_engineer_runner(
@@ -216,7 +225,10 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     // agents dir.
     let mut pm_registry = ToolRegistry::new();
     pm_registry.register(Arc::new(
-        DelegateToAgentTool::new(engineer_runner).with_config_dir(params.agents_dir.clone()),
+        DelegateToAgentTool::new(engineer_runner)
+            .with_config_dir(params.agents_dir.clone())
+            // (#2683) refuse a re-delegation once the engineer has completed.
+            .with_completion_signal(completion_signal.clone()),
     ));
     pm_registry.register(Arc::new(FinishTaskTool::new()));
 
@@ -307,6 +319,7 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
             pm_result,
         },
         &redelegation_signal,
+        &completion_signal,
     )
 }
 
@@ -573,20 +586,29 @@ struct RunOutcome {
 /// Why: Centralises the mapping from (PM loop result, before/after snapshots) to a
 /// `RunReport` with the correct exit code so the success / no-change / failure
 /// branches never drift.
-/// What: On a PM-loop error → `DeadlineExceeded` when the error is specifically
-/// `AgentLoopError::Timeout` (#2207 — distinct from a genuine failure so a
-/// caller can tell "timed out" from "errored"). (#2265 fix #4) Otherwise, when
-/// the error is `AgentLoopError::TurnCapExceeded` OR `redelegation_signal`
-/// reports the re-delegation cap (fix #1) was hit, the diff is computed
-/// (filesystem-based, independent of which turn/attempt produced it) and — if
-/// it is non-empty, i.e. a deliverable actually exists on disk — the outcome
-/// is `ExitCode::Partial`, NOT `RunFailure`; trusty-code cannot generically
-/// verify correctness, so this gates purely on "work was produced", leaving
-/// the downstream bake-off harness to score correctness itself. Every other
-/// PM-loop error (a hard `Llm`/`Cancelled` failure, or ANY error with an empty
-/// diff — including a cap/turn-cap hit that produced nothing) still maps to
-/// `RunFailure`, preserving that path for genuine no-output failures. On
-/// success → compute the diff; empty diff → `NoChanges`, else `Success`.
+/// What: (#2683) FIRST — before any error-variant branching — if
+/// `completion_signal` reports the delegated engineer already returned an
+/// EXPLICIT successful `finish_task` completion, the task is genuinely done:
+/// the outcome is `Success` (or `NoChanges` for an empty diff), NEVER
+/// `Partial`/`DeadlineExceeded`/`RunFailure`, regardless of how the PM's own
+/// loop later terminated. This is the data-integrity fix for the bug where a
+/// gratuitous post-finish re-delegation that then ran out of turns/time
+/// mislabeled a complete, all-tests-passing run as `partial`/exit-6. On a
+/// PM-loop error with NO such completion → `DeadlineExceeded` when the error is
+/// specifically `AgentLoopError::Timeout` (#2207 — distinct from a genuine
+/// failure so a caller can tell "timed out" from "errored"). (#2265 fix #4)
+/// Otherwise, when the error is `AgentLoopError::TurnCapExceeded` OR
+/// `redelegation_signal` reports the re-delegation cap (fix #1) was hit, the
+/// diff is computed (filesystem-based, independent of which turn/attempt
+/// produced it) and — if it is non-empty, i.e. a deliverable actually exists on
+/// disk — the outcome is `ExitCode::Partial`, NOT `RunFailure`; trusty-code
+/// cannot generically verify correctness, so this gates purely on "work was
+/// produced", leaving the downstream bake-off harness to score correctness
+/// itself. Every other PM-loop error (a hard `Llm`/`Cancelled` failure, or ANY
+/// error with an empty diff — including a cap/turn-cap hit that produced
+/// nothing) still maps to `RunFailure`, preserving that path for genuine
+/// no-output failures. On success → compute the diff; empty diff → `NoChanges`,
+/// else `Success`.
 /// Usage and cost are aggregated from the transcript and priced PER ROLE —
 /// `pm_model` for `"pm"` turns, `engineer_model` for the delegated engineer's
 /// — per the #1475 bug 1 fix (`aggregate_usage_per_role`), not blended under
@@ -603,6 +625,7 @@ fn assemble_report(
     engineer_model: &str,
     outcome: RunOutcome,
     redelegation_signal: &RedelegationCapSignal,
+    completion_signal: &EngineerCompletionSignal,
 ) -> RunReport {
     let RunOutcome {
         before,
@@ -610,6 +633,35 @@ fn assemble_report(
         pm_result,
     } = outcome;
     let turns = drain_transcript(transcript);
+
+    // #2683: the authoritative success signal. If the delegated engineer
+    // already reported an EXPLICIT successful `finish_task` completion, the
+    // task is genuinely done — a gratuitous post-finish re-delegation that
+    // subsequently ran the PM's loop out of turns/time (or hit any other
+    // terminal error) must NOT mislabel this complete, correct run as
+    // `partial`/`deadline_exceeded`/`run_failure`. The on-disk diff is the
+    // authoritative deliverable regardless of which turn produced it: a
+    // non-empty diff is `Success`, an empty one is `NoChanges`. This is checked
+    // FIRST, before any PM-error-variant branching, so it overrides every one
+    // of them.
+    if completion_signal.is_completed() {
+        let (usage, cost) = aggregate_usage_per_role(&turns, pm_model, engineer_model);
+        let rendered_diff = diff::diff_snapshots(&before, &after);
+        let exit = if rendered_diff.trim().is_empty() {
+            ExitCode::NoChanges
+        } else {
+            ExitCode::Success
+        };
+        return RunReport {
+            agent: params.agent.clone(),
+            task: params.task.clone(),
+            diff: rendered_diff,
+            transcript: turns,
+            usage,
+            cost_usd: Some(cost),
+            exit,
+        };
+    }
 
     // A PM-loop error is a runtime failure (or, #2207, a deadline; or, #2265,
     // a turn-cap/re-delegation-cap hit that still produced a deliverable);

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -23,7 +23,7 @@ use tempfile::TempDir;
 use super::{ExitCode, RedelegationCapSignal, RunTaskParams, execute_run_task};
 use crate::agent_loop::AgentLoopError;
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
-use crate::tools::AgentOutput;
+use crate::tools::{AgentOutput, EngineerCompletionSignal};
 
 // ── Scripted offline LLM ───────────────────────────────────────────────────────
 
@@ -907,6 +907,7 @@ fn assemble_report_maps_turn_cap_exceeded_with_deliverable_to_partial() {
     });
 
     let signal = RedelegationCapSignal::new();
+    let completion = EngineerCompletionSignal::new();
     let report = super::assemble_report(
         &params,
         &transcript,
@@ -918,6 +919,7 @@ fn assemble_report_maps_turn_cap_exceeded_with_deliverable_to_partial() {
             pm_result,
         },
         &signal,
+        &completion,
     );
 
     assert_eq!(
@@ -968,6 +970,7 @@ fn assemble_report_keeps_turn_cap_exceeded_with_no_deliverable_as_run_failure() 
     });
 
     let signal = RedelegationCapSignal::new();
+    let completion = EngineerCompletionSignal::new();
     let report = super::assemble_report(
         &params,
         &transcript,
@@ -979,6 +982,7 @@ fn assemble_report_keeps_turn_cap_exceeded_with_no_deliverable_as_run_failure() 
             pm_result,
         },
         &signal,
+        &completion,
     );
 
     assert_eq!(
@@ -987,6 +991,194 @@ fn assemble_report_keeps_turn_cap_exceeded_with_no_deliverable_as_run_failure() 
         "a TurnCapExceeded PM error with NO deliverable must stay RunFailure (fix #4)"
     );
     let _ = &report;
+}
+
+// ── #2683: a completed engineer must never be mislabeled `partial`/exit-6 ──────
+
+/// (#2683) `assemble_report` maps a PM-loop `TurnCapExceeded` error to
+/// `Success` — NOT `Partial` — when the delegated engineer already reported an
+/// explicit successful `finish_task` completion AND a deliverable is on disk.
+///
+/// Why: This is the exact data-integrity bug the issue's 2026-07-15 recurrence
+/// comment reports: the engineer finished with all tests passing, then the PM
+/// fired one more gratuitous re-verify `delegate_to_agent` round that ran the
+/// PM's loop out of turns, and the complete, correct run was mislabeled
+/// `partial`/exit-6, corrupting run status/telemetry. A satisfied task must
+/// report success.
+/// What: Calls `assemble_report` directly with a `TurnCapExceeded` `pm_result`,
+/// a before/after `Snapshot` pair that differ (one new file), and a
+/// completion signal that has latched. Assert `exit == Success` and the diff is
+/// preserved.
+/// Test: this test.
+#[test]
+fn assemble_report_maps_completed_engineer_with_deliverable_to_success() {
+    let params = RunTaskParams {
+        agent: "pm".into(),
+        task: "write hello.py".into(),
+        project: PathBuf::from("/tmp/does-not-matter"),
+        agents_dir: PathBuf::from("/tmp/does-not-matter-agents"),
+        engineer_model: None,
+        deadline_secs: None,
+    };
+    let transcript: super::SharedTranscript = Arc::new(Mutex::new(Vec::new()));
+
+    let before = super::diff::Snapshot::Files(std::collections::BTreeMap::new());
+    let mut after_map = std::collections::BTreeMap::new();
+    after_map.insert("hello.py".to_string(), "print('hi')".to_string());
+    let after = super::diff::Snapshot::Files(after_map);
+
+    // The PM loop ran out of turns on the gratuitous re-verify round …
+    let pm_result: Result<AgentOutput, AgentLoopError> = Err(AgentLoopError::TurnCapExceeded {
+        max_turns: 8,
+        partial: Box::new(AgentOutput::from_content("partial pm output")),
+    });
+
+    let signal = RedelegationCapSignal::new();
+    // … but the engineer already reported a successful completion.
+    let completion = EngineerCompletionSignal::new();
+    completion.mark_completed();
+
+    let report = super::assemble_report(
+        &params,
+        &transcript,
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o-mini",
+        super::RunOutcome {
+            before,
+            after,
+            pm_result,
+        },
+        &signal,
+        &completion,
+    );
+
+    assert_eq!(
+        report.exit,
+        ExitCode::Success,
+        "a completed engineer with a real deliverable must report Success, never \
+         Partial, even when the PM's loop later hit its turn cap (#2683); task: {}",
+        report.task
+    );
+    assert!(
+        report.diff.contains("hello.py"),
+        "the completed deliverable's diff must still be rendered, got: {}",
+        report.diff
+    );
+}
+
+/// (#2683) A completed engineer with an EMPTY diff maps to `NoChanges`, not
+/// `RunFailure` — a satisfied, no-op task is still a success outcome.
+///
+/// Why: Guards the empty-diff arm of the completion override so a genuinely
+/// completed run that happened to change nothing is not conflated with a crash.
+/// What: Same as above but before == after (no change); assert `NoChanges`.
+/// Test: this test.
+#[test]
+fn assemble_report_maps_completed_engineer_without_deliverable_to_no_changes() {
+    let params = RunTaskParams {
+        agent: "pm".into(),
+        task: "analyze the repo".into(),
+        project: PathBuf::from("/tmp/does-not-matter"),
+        agents_dir: PathBuf::from("/tmp/does-not-matter-agents"),
+        engineer_model: None,
+        deadline_secs: None,
+    };
+    let transcript: super::SharedTranscript = Arc::new(Mutex::new(Vec::new()));
+
+    let before = super::diff::Snapshot::Files(std::collections::BTreeMap::new());
+    let after = super::diff::Snapshot::Files(std::collections::BTreeMap::new());
+
+    let pm_result: Result<AgentOutput, AgentLoopError> = Err(AgentLoopError::TurnCapExceeded {
+        max_turns: 8,
+        partial: Box::new(AgentOutput::from_content("partial pm output")),
+    });
+
+    let signal = RedelegationCapSignal::new();
+    let completion = EngineerCompletionSignal::new();
+    completion.mark_completed();
+
+    let report = super::assemble_report(
+        &params,
+        &transcript,
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o-mini",
+        super::RunOutcome {
+            before,
+            after,
+            pm_result,
+        },
+        &signal,
+        &completion,
+    );
+
+    assert_eq!(
+        report.exit,
+        ExitCode::NoChanges,
+        "a completed engineer that changed nothing must be NoChanges, not RunFailure (#2683)"
+    );
+}
+
+/// (#2683) End-to-end: after the engineer completes via `finish_task`, a
+/// gratuitous PM re-delegation is REFUSED (the engineer is not re-invoked) and
+/// the run reports `Success` rather than `partial`.
+///
+/// Why: Proves both halves of the fix through the real `execute_run_task`
+/// wiring: (b) the `DelegateToAgentTool` refuses re-delegation once the
+/// completion signal latches, and the data-integrity half — a complete run is
+/// labeled Success even when the PM keeps trying to re-delegate.
+/// What: Script [PM delegate, engineer write_file, engineer finish_task
+/// (completed), PM delegate AGAIN (must be refused — engineer NOT re-invoked),
+/// PM finish_task]. Assert `exit == Success`, the diff names `hello.py`, the
+/// engineer was invoked exactly once (exactly two `python-engineer` turns), and
+/// no wasted engineer round was spent (exactly five total chat calls).
+/// Test: this test.
+#[tokio::test]
+async fn gratuitous_redelegation_after_finish_is_refused_and_run_succeeds() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        delegate_response("create hello.py"),
+        write_file_response("hello.py", "print('hi')"),
+        finish_task_response("completed", "wrote hello.py, all good"),
+        // The PM gratuitously re-delegates to "re-verify" — this must be
+        // refused by the delegate tool, so the engineer is NEVER re-invoked
+        // (the next scripted response is the PM's own finish_task, not an
+        // engineer turn).
+        delegate_response("re-verify hello.py once more"),
+        finish_task_response("completed", "confirmed complete"),
+    ]));
+
+    let report = execute_run_task(params(&agents, &project, None), llm.clone()).await;
+
+    assert_eq!(
+        report.exit,
+        ExitCode::Success,
+        "a completed run must report Success even with a gratuitous re-delegation, \
+         never partial; task: {}",
+        report.task
+    );
+    assert!(
+        report.diff.contains("hello.py"),
+        "the deliverable diff must be preserved, got: {}",
+        report.diff
+    );
+
+    let engineer_turns = report
+        .transcript
+        .iter()
+        .filter(|t| t.role == "python-engineer")
+        .count();
+    assert_eq!(
+        engineer_turns, 2,
+        "the engineer must be invoked exactly once (write_file + finish_task); a \
+         second, refused delegation must never reach it, got {engineer_turns} engineer turns"
+    );
+    assert_eq!(
+        llm.models_seen().len(),
+        5,
+        "no wasted engineer round: the refused re-delegation must not spend a chat call"
+    );
 }
 
 // ── #2265 fix #5: PM stops re-delegating once the cap latches ──────────────────

--- a/crates/trusty-code/src/tools/delegate.rs
+++ b/crates/trusty-code/src/tools/delegate.rs
@@ -31,13 +31,15 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use crate::agent_loop::AgentLoopError;
 use crate::runner::RunnerError;
-use crate::tools::traits::{AgentRunner, ToolExecutor, ToolResult};
+use crate::tools::finish_task::FinishStatus;
+use crate::tools::traits::{AgentOutput, AgentRunner, ToolExecutor, ToolResult};
 
 /// Detect whether an `AgentRunner` failure means the sub-agent's OWN attempt
 /// may have left partial work already on disk (turn cap, timeout,
@@ -99,20 +101,87 @@ pub(crate) fn redelegation_hint(err: &anyhow::Error) -> Option<&'static str> {
     }
 }
 
+/// Run-scoped latch recording that a delegated engineer already reported an
+/// EXPLICIT successful completion (`finish_task` with `status: completed`)
+/// during this run (#2683).
+///
+/// Why: The bake-off regression this closes is a PM that, after the engineer
+/// already called `finish_task` with all tests passing, fires ONE MORE
+/// gratuitous `delegate_to_agent` "re-verify" round; when that extra round
+/// then runs out of turns / wall-clock time, the run terminated mid-round and
+/// was mislabeled `partial`/exit-6 even though a complete, correct,
+/// all-tests-passing deliverable already sat on disk — corrupting run
+/// status/telemetry (issue #2683 recurrence comment, 2026-07-15). This shared
+/// latch is the authoritative "the task is genuinely done" signal: once set,
+/// [`DelegateToAgentTool`] refuses further re-delegation (part b of the fix)
+/// and `run_task::assemble_report` reports success rather than partial (the
+/// data-integrity half). Modeled as a cheap `Arc<AtomicBool>` handle,
+/// mirroring `run_task::redelegation::RedelegationCapSignal`, so the tool (the
+/// setter) and the report assembler (the reader) observe the SAME state.
+/// What: `new()` starts un-latched; `mark_completed` latches it (set only by
+/// [`DelegateToAgentTool::execute`] when the delegated runner returns an
+/// `AgentOutput` whose `finish_status` is `Some(FinishStatus::Completed)`);
+/// `is_completed` reads it. `Clone` shares the same underlying flag.
+/// Test: `tools::delegate::tests::completion_signal_latches_on_completed_finish`,
+/// `tools::delegate::tests::completion_signal_ignores_non_completed_finish`,
+/// `tools::delegate::tests::delegate_refused_once_engineer_completed`.
+#[derive(Debug, Clone, Default)]
+pub struct EngineerCompletionSignal(Arc<AtomicBool>);
+
+impl EngineerCompletionSignal {
+    /// Build a fresh, un-latched signal for one run.
+    ///
+    /// Why: Each `execute_run_task` call needs its OWN signal — a prior run's
+    /// completion must never leak into a later run's report.
+    /// What: `Self::default()`.
+    /// Test: `completion_signal_latches_on_completed_finish`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Latch the "engineer completed successfully" flag.
+    ///
+    /// Why: Called exactly once, the first time a delegation returns an explicit
+    /// successful `finish_task` completion.
+    /// What: Stores `true` with `SeqCst` (paired with `is_completed`'s load).
+    /// Test: `completion_signal_latches_on_completed_finish`.
+    pub(crate) fn mark_completed(&self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+
+    /// Whether a delegated engineer has already completed successfully.
+    ///
+    /// Why: [`DelegateToAgentTool::execute`] reads this to refuse a gratuitous
+    /// re-delegation, and `run_task::assemble_report` reads it to report
+    /// success instead of partial.
+    /// What: Loads the latched flag.
+    /// Test: `completion_signal_latches_on_completed_finish`.
+    pub fn is_completed(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
 /// Tool executor that delegates a task to a named sub-agent.
 ///
 /// Why: Encapsulates the `delegate_to_agent` tool so the PM loop registers a
 /// single `Arc<dyn ToolExecutor>` rather than branching on the tool name inline.
-/// What: Holds an `AgentRunner` for subprocess/in-process dispatch and an
-/// optional `config_dir` for pre-flight agent name validation.
+/// What: Holds an `AgentRunner` for subprocess/in-process dispatch, an optional
+/// `config_dir` for pre-flight agent name validation, and (#2683) an optional
+/// shared [`EngineerCompletionSignal`] used to refuse a re-delegation once the
+/// engineer has already reported a successful `finish_task` completion.
 /// Test: `unknown_agent_returns_helpful_error`, `known_agent_reaches_runner`,
-/// `no_config_dir_skips_validation`.
+/// `no_config_dir_skips_validation`, `delegate_refused_once_engineer_completed`.
 pub struct DelegateToAgentTool {
     runner: Arc<dyn AgentRunner>,
     /// Directory holding `<agent>.toml` files. When `Some`, `execute()` rejects
     /// calls whose `agent_name` does not have a matching TOML. When `None`,
     /// validation is skipped (legacy / test mode).
     config_dir: Option<PathBuf>,
+    /// Shared, run-scoped completion latch (#2683). When `Some` and already
+    /// latched, `execute()` refuses further delegation with a recoverable error
+    /// that nudges the PM to call `finish_task`. When `None` (the default /
+    /// legacy path), the refusal behaviour is disabled entirely.
+    completion_signal: Option<EngineerCompletionSignal>,
 }
 
 impl DelegateToAgentTool {
@@ -128,6 +197,7 @@ impl DelegateToAgentTool {
         Self {
             runner,
             config_dir: None,
+            completion_signal: None,
         }
     }
 
@@ -141,6 +211,25 @@ impl DelegateToAgentTool {
     /// Test: `unknown_agent_returns_helpful_error`.
     pub fn with_config_dir(mut self, dir: PathBuf) -> Self {
         self.config_dir = Some(dir);
+        self
+    }
+
+    /// Attach a shared [`EngineerCompletionSignal`] so a re-delegation after a
+    /// successful engineer completion is refused (#2683).
+    ///
+    /// Why: Once the delegated engineer has reported an explicit successful
+    /// `finish_task` completion, any further `delegate_to_agent` call is the
+    /// gratuitous post-finish re-delegation that mislabels a complete run as
+    /// `partial`; refusing it (and nudging the PM to `finish_task` instead) is
+    /// the "do not re-delegate once the finish gate is satisfied" half of the
+    /// fix. `run_task::execute_run_task` shares the SAME signal instance with
+    /// `assemble_report`.
+    /// What: Builder-style setter; returns `self` for chaining. When unset (the
+    /// default), the refusal behaviour is disabled and this tool behaves
+    /// exactly as before.
+    /// Test: `delegate_refused_once_engineer_completed`.
+    pub fn with_completion_signal(mut self, signal: EngineerCompletionSignal) -> Self {
+        self.completion_signal = Some(signal);
         self
     }
 
@@ -204,6 +293,26 @@ impl ToolExecutor for DelegateToAgentTool {
     }
 
     async fn execute(&self, args: Value) -> ToolResult {
+        // #2683: once the delegated engineer has already reported a successful
+        // `finish_task` completion, refuse any further delegation BEFORE
+        // parsing/validating args or invoking the runner. This is the "do not
+        // re-delegate once the finish gate is satisfied" half of the fix: the
+        // deliverable is on disk and the task is done, so a re-verify round is
+        // gratuitous — nudge the PM to `finish_task` instead of spawning
+        // another engineer loop that can only end the run mid-round and
+        // mislabel it `partial`. Recoverable (not fatal) so the PM's loop
+        // continues and can act on the guidance.
+        if let Some(signal) = &self.completion_signal
+            && signal.is_completed()
+        {
+            return ToolResult::err(
+                "delegate_to_agent refused: the delegated engineer already reported a \
+                 successful completion (finish_task with status=completed) for this run. \
+                 The deliverable is on disk and the task is done — do NOT re-delegate to \
+                 re-verify. Call finish_task now to report the result.",
+            );
+        }
+
         let Some(agent_name) = args.get("agent_name").and_then(Value::as_str) else {
             return ToolResult::err("delegate_to_agent: missing 'agent_name'");
         };
@@ -247,7 +356,16 @@ impl ToolExecutor for DelegateToAgentTool {
         }
 
         match self.runner.run(agent_name, task).await {
-            Ok(out) => ToolResult::ok(out.content),
+            Ok(out) => {
+                // #2683: latch the run-scoped completion signal when the engineer
+                // terminated via an EXPLICIT successful `finish_task` — the
+                // authoritative "task is genuinely done" signal both the refusal
+                // above and `run_task::assemble_report` key off. A `failed` /
+                // `cancelled` finish, or a plain no-tool-call stop, does NOT
+                // latch it: those leave re-delegation legitimately available.
+                self.mark_completion_if_finished(&out);
+                ToolResult::ok(out.content)
+            }
             Err(e) => {
                 let hint = redelegation_hint(&e).unwrap_or("");
                 ToolResult::err(format!("sub-agent '{agent_name}' failed: {e:#}{hint}"))
@@ -256,447 +374,27 @@ impl ToolExecutor for DelegateToAgentTool {
     }
 }
 
+impl DelegateToAgentTool {
+    /// Latch the shared completion signal iff `out` represents an explicit
+    /// successful `finish_task` completion (#2683).
+    ///
+    /// Why: Factored out of `execute` so the "what counts as a successful
+    /// completion" rule lives in one named place and is unit-testable.
+    /// What: No-op when no `completion_signal` is attached; otherwise latches it
+    /// only when `out.finish_status == Some(FinishStatus::Completed)`.
+    /// Test: `completion_signal_latches_on_completed_finish`,
+    /// `completion_signal_ignores_non_completed_finish`.
+    fn mark_completion_if_finished(&self, out: &AgentOutput) {
+        if let Some(signal) = &self.completion_signal
+            && out.finish_status == Some(FinishStatus::Completed)
+        {
+            signal.mark_completed();
+        }
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use anyhow::Result;
-    use async_trait::async_trait;
-    use serde_json::json;
-
-    use super::{DelegateToAgentTool, redelegation_hint};
-    use crate::agent_loop::AgentLoopError;
-    use crate::llm::LlmError;
-    use crate::runner::RunnerError;
-    use crate::tools::traits::{AgentOutput, AgentRunner, ToolExecutor};
-
-    /// Recording mock runner.
-    ///
-    /// Why: Tests need to verify the runner was (or was not) invoked.
-    /// What: Records `(agent_name, task)` pairs in a Mutex-guarded Vec.
-    /// Test: `known_agent_reaches_runner`, `no_config_dir_skips_validation`.
-    struct RecordingRunner {
-        invoked: std::sync::Mutex<Vec<(String, String)>>,
-    }
-
-    #[async_trait]
-    impl AgentRunner for RecordingRunner {
-        async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
-            self.invoked
-                .lock()
-                .expect("lock poisoned")
-                .push((agent_name.to_string(), task.to_string()));
-            Ok(AgentOutput::from_content("ok"))
-        }
-    }
-
-    /// An unknown agent name returns a structured error listing available agents,
-    /// and the runner is NOT invoked.
-    ///
-    /// Why: Guards against hallucinated agent names causing confusing IO errors.
-    /// What: Calls `execute({"agent_name":"ghost",...})` with a tempdir
-    /// containing only `engineer.toml`; expects error with "ghost" and "engineer".
-    /// Test: This test.
-    #[tokio::test]
-    async fn unknown_agent_returns_helpful_error() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(
-            tmp.path().join("engineer.toml"),
-            "[agent]\nname = \"engineer\"\n",
-        )
-        .expect("write");
-        std::fs::write(
-            tmp.path().join("qa-agent.toml"),
-            "[agent]\nname = \"qa-agent\"\n",
-        )
-        .expect("write");
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool =
-            DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
-
-        let result = tool
-            .execute(json!({"agent_name": "ghost", "task": "do something"}))
-            .await;
-
-        assert!(result.is_error(), "must reject unknown agent");
-        let msg = result.content();
-        assert!(
-            msg.contains("Unknown agent 'ghost'"),
-            "error must name the unknown agent, got: {msg}"
-        );
-        assert!(
-            msg.contains("engineer") && msg.contains("qa-agent"),
-            "error must list available agents, got: {msg}"
-        );
-        assert!(
-            msg.contains("native tools"),
-            "error must clarify native-vs-agent, got: {msg}"
-        );
-        assert!(
-            runner.invoked.lock().expect("lock").is_empty(),
-            "runner must not be called when validation fails"
-        );
-    }
-
-    /// A valid agent name passes validation and reaches the runner.
-    ///
-    /// Why: Verify the happy-path dispatch contract.
-    /// What: Register `engineer.toml`, dispatch with `agent_name="engineer"`.
-    /// Test: This test.
-    #[tokio::test]
-    async fn known_agent_reaches_runner() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(
-            tmp.path().join("engineer.toml"),
-            "[agent]\nname = \"engineer\"\n",
-        )
-        .expect("write");
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool =
-            DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
-
-        let result = tool
-            .execute(json!({"agent_name": "engineer", "task": "do the thing"}))
-            .await;
-
-        assert!(
-            !result.is_error(),
-            "valid agent should succeed: {}",
-            result.content()
-        );
-        let invoked = runner.invoked.lock().expect("lock");
-        assert_eq!(invoked.len(), 1, "runner should be called exactly once");
-        assert_eq!(invoked[0].0, "engineer");
-    }
-
-    /// Without `with_config_dir`, validation is skipped — the runner is invoked.
-    ///
-    /// Why: Preserves backward compatibility with callers that don't need
-    /// pre-flight validation (e.g. integration tests).
-    /// What: Construct tool without config_dir; any agent name reaches the runner.
-    /// Test: This test.
-    #[tokio::test]
-    async fn no_config_dir_skips_validation() {
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone());
-
-        let result = tool
-            .execute(json!({"agent_name": "anything-goes", "task": "do it"}))
-            .await;
-
-        assert!(!result.is_error(), "legacy mode should bypass validation");
-        assert_eq!(runner.invoked.lock().expect("lock").len(), 1);
-    }
-
-    /// Missing `agent_name` field returns a structured error.
-    ///
-    /// Why: Guard against malformed LLM function call arguments.
-    /// What: `execute({})` without `agent_name` key.
-    /// Test: This test.
-    #[tokio::test]
-    async fn missing_agent_name_returns_error() {
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner);
-        let result = tool.execute(json!({"task": "something"})).await;
-        assert!(result.is_error());
-        assert!(result.content().contains("missing 'agent_name'"));
-    }
-
-    /// A path-traversal agent name is rejected before any filesystem access.
-    ///
-    /// Why: The LLM supplies `agent_name` which is joined into a filesystem path.
-    /// A crafted name like `../../etc/passwd` must be caught before the join to
-    /// prevent escaping the agents config directory.
-    /// What: Calls `execute` with a traversal string; asserts error and runner
-    /// not invoked.
-    /// Test: This test.
-    #[tokio::test]
-    async fn path_traversal_agent_name_is_rejected() {
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        // No config_dir — traversal guard fires before config check.
-        let tool = DelegateToAgentTool::new(runner.clone());
-
-        for bad_name in &[
-            "../../etc/passwd",
-            "../sibling",
-            "agent/sub",
-            "agent name",
-            "",
-        ] {
-            let result = tool
-                .execute(json!({"agent_name": bad_name, "task": "do it"}))
-                .await;
-            assert!(
-                result.is_error(),
-                "traversal/invalid name '{bad_name}' must be rejected"
-            );
-            assert!(
-                result.content().contains("Invalid agent name"),
-                "error must describe the problem, got: {}",
-                result.content()
-            );
-        }
-        assert!(
-            runner.invoked.lock().expect("lock").is_empty(),
-            "runner must never be called for invalid names"
-        );
-    }
-
-    /// A valid agent name passes the sanitisation guard and reaches the runner.
-    ///
-    /// Why: Confirms the allowlist does not over-reject legitimate names.
-    /// What: `execute({"agent_name":"engineer",...})` without config_dir; runner
-    /// is called once.
-    /// Test: This test.
-    #[tokio::test]
-    async fn valid_agent_name_passes_sanitization() {
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone());
-
-        for good_name in &["engineer", "qa-agent", "python_engineer", "rust-2024"] {
-            let result = tool
-                .execute(json!({"agent_name": good_name, "task": "do it"}))
-                .await;
-            assert!(
-                !result.is_error(),
-                "valid name '{good_name}' must be accepted: {}",
-                result.content()
-            );
-        }
-        assert_eq!(
-            runner.invoked.lock().expect("lock").len(),
-            4,
-            "runner must be called for each valid name"
-        );
-    }
-
-    /// Mock runner that always fails with a caller-supplied error.
-    ///
-    /// Why: `redelegation_hint` tests need to control exactly which
-    /// `RunnerError`/`AgentLoopError` shape `execute()` observes, without
-    /// driving a real `AgentLoop`.
-    /// What: `run` always returns `Err` built from the stored `anyhow::Error`
-    /// factory (a `Fn` so each call gets a fresh error, since `anyhow::Error`
-    /// is not `Clone`).
-    /// Test: `redelegation_hint_present_on_turn_cap_exceeded` and siblings.
-    struct FailingRunner<F: Fn() -> anyhow::Error + Send + Sync> {
-        make_err: F,
-    }
-
-    #[async_trait]
-    impl<F: Fn() -> anyhow::Error + Send + Sync> AgentRunner for FailingRunner<F> {
-        async fn run(&self, _agent_name: &str, _task: &str) -> Result<AgentOutput> {
-            Err((self.make_err)())
-        }
-    }
-
-    /// A `TurnCapExceeded` sub-agent failure carries the reuse/continue
-    /// directive in the tool's error text.
-    ///
-    /// Why: This is the core bake-off L1 fix — the PM must see an automatic,
-    /// structured instruction to inspect and reuse partial work instead of
-    /// relying on its own free text remembering to ask for it.
-    /// What: `FailingRunner` returns `RunnerError::Loop` wrapping
-    /// `AgentLoopError::TurnCapExceeded`; assert the rendered error mentions
-    /// both re-delegation and reading/continuing existing work.
-    /// Test: this test.
-    #[tokio::test]
-    async fn redelegation_hint_present_on_turn_cap_exceeded() {
-        let runner = Arc::new(FailingRunner {
-            make_err: || {
-                anyhow::Error::from(RunnerError::Loop {
-                    name: "engineer".to_string(),
-                    source: AgentLoopError::TurnCapExceeded {
-                        max_turns: 8,
-                        partial: Box::new(AgentOutput::from_content("partial work")),
-                    },
-                })
-            },
-        });
-        let tool = DelegateToAgentTool::new(runner);
-
-        let result = tool
-            .execute(json!({"agent_name": "engineer", "task": "build the package"}))
-            .await;
-
-        assert!(result.is_error());
-        let msg = result.content();
-        assert!(
-            msg.contains("READ and CONTINUE"),
-            "must instruct the PM to reuse existing work, got: {msg}"
-        );
-        assert!(
-            msg.contains("already written real, partial progress"),
-            "must explain why re-delegation should not start over, got: {msg}"
-        );
-    }
-
-    /// A `Timeout` sub-agent failure gets the same reuse/continue directive.
-    ///
-    /// Why: A wall-clock timeout carries partial work exactly like a turn-cap
-    /// abort (per `AgentLoopError`'s own docs); the hint must not be
-    /// TurnCapExceeded-specific.
-    /// What: `FailingRunner` returns `RunnerError::Loop` wrapping
-    /// `AgentLoopError::Timeout`.
-    /// Test: this test.
-    #[tokio::test]
-    async fn redelegation_hint_present_on_timeout() {
-        let runner = Arc::new(FailingRunner {
-            make_err: || {
-                anyhow::Error::from(RunnerError::Loop {
-                    name: "engineer".to_string(),
-                    source: AgentLoopError::Timeout {
-                        timeout_secs: 120,
-                        partial: Box::new(AgentOutput::from_content("partial work")),
-                    },
-                })
-            },
-        });
-        let tool = DelegateToAgentTool::new(runner);
-
-        let result = tool
-            .execute(json!({"agent_name": "engineer", "task": "build the package"}))
-            .await;
-
-        assert!(result.is_error());
-        assert!(result.content().contains("READ and CONTINUE"));
-    }
-
-    /// A `Cancelled` sub-agent failure gets the same reuse/continue directive.
-    ///
-    /// What: `FailingRunner` returns `RunnerError::Loop` wrapping
-    /// `AgentLoopError::Cancelled`.
-    /// Test: this test.
-    #[tokio::test]
-    async fn redelegation_hint_present_on_cancelled() {
-        let runner = Arc::new(FailingRunner {
-            make_err: || {
-                anyhow::Error::from(RunnerError::Loop {
-                    name: "engineer".to_string(),
-                    source: AgentLoopError::Cancelled {
-                        partial: Box::new(AgentOutput::from_content("partial work")),
-                    },
-                })
-            },
-        });
-        let tool = DelegateToAgentTool::new(runner);
-
-        let result = tool
-            .execute(json!({"agent_name": "engineer", "task": "build the package"}))
-            .await;
-
-        assert!(result.is_error());
-        assert!(result.content().contains("READ and CONTINUE"));
-    }
-
-    /// An `UnknownAgent` runner failure gets NO reuse directive — there is no
-    /// partial work to reuse when the agent config never resolved.
-    ///
-    /// Why: The hint must not fire indiscriminately on every failure; guard
-    /// the negative case.
-    /// What: `FailingRunner` returns `RunnerError::UnknownAgent`.
-    /// Test: this test.
-    #[tokio::test]
-    async fn redelegation_hint_absent_on_unknown_agent() {
-        let runner = Arc::new(FailingRunner {
-            make_err: || {
-                anyhow::Error::from(RunnerError::UnknownAgent {
-                    name: "ghost".to_string(),
-                    dir: std::path::PathBuf::from("/agents"),
-                })
-            },
-        });
-        let tool = DelegateToAgentTool::new(runner);
-
-        let result = tool
-            .execute(json!({"agent_name": "ghost", "task": "build the package"}))
-            .await;
-
-        assert!(result.is_error());
-        assert!(
-            !result.content().contains("READ and CONTINUE"),
-            "no partial work exists for an unresolved agent config, got: {}",
-            result.content()
-        );
-    }
-
-    /// A plain LLM/transport failure gets the SAME reuse/continue directive
-    /// (#2265 fix #2: this is the dominant bake-off failure mode, previously
-    /// excluded from the hint).
-    ///
-    /// Why: A recoverable Bedrock/transport error aborting the engineer's
-    /// sub-loop is the dominant failure mode observed in the bake-off
-    /// transcripts; the reuse hint must fire here too so re-delegation checks
-    /// for and continues from files already on disk instead of restarting
-    /// exploration from scratch.
-    /// What: `FailingRunner` returns `RunnerError::Loop` wrapping
-    /// `AgentLoopError::Llm`; assert the hint is present.
-    /// Test: this test.
-    #[tokio::test]
-    async fn redelegation_hint_present_on_llm_error() {
-        let runner = Arc::new(FailingRunner {
-            make_err: || {
-                anyhow::Error::from(RunnerError::Loop {
-                    name: "engineer".to_string(),
-                    source: AgentLoopError::Llm(LlmError::ApiError {
-                        status: 500,
-                        body: "internal error".to_string(),
-                    }),
-                })
-            },
-        });
-        let tool = DelegateToAgentTool::new(runner);
-
-        let result = tool
-            .execute(json!({"agent_name": "engineer", "task": "build the package"}))
-            .await;
-
-        assert!(result.is_error());
-        assert!(
-            result.content().contains("READ and CONTINUE"),
-            "an LLM/transport error must ALSO carry the reuse directive (#2265), got: {}",
-            result.content()
-        );
-    }
-
-    /// `redelegation_hint` itself (unit-level, not through the tool) returns
-    /// `Some` for `AgentLoopError::Llm` (#2265 fix #2).
-    ///
-    /// Why: The tool-level test above proves the end-to-end wiring; this test
-    /// pins the specific function contract directly, matching the task's
-    /// required "redelegation_hint(AgentLoopError::Llm) now returns
-    /// Some(<reuse hint>)" assertion.
-    /// What: Builds a `RunnerError::Loop` wrapping `AgentLoopError::Llm`,
-    /// calls `redelegation_hint` directly, asserts `Some`.
-    /// Test: this test.
-    #[test]
-    fn redelegation_hint_fn_returns_some_for_llm_error() {
-        let err = anyhow::Error::from(RunnerError::Loop {
-            name: "engineer".to_string(),
-            source: AgentLoopError::Llm(LlmError::ApiError {
-                status: 503,
-                body: "bedrock throttled".to_string(),
-            }),
-        });
-        assert!(
-            redelegation_hint(&err).is_some(),
-            "redelegation_hint must return Some for AgentLoopError::Llm (#2265)"
-        );
-    }
-}
+#[path = "delegate_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/tools/delegate_tests.rs
+++ b/crates/trusty-code/src/tools/delegate_tests.rs
@@ -1,0 +1,577 @@
+//! Unit tests for `tools::delegate` — extracted to a sibling test file so
+//! the production module stays under the 500-SLOC cap while the tests live
+//! under the 1500-SLOC test cap (mirrors `goals_tests.rs`, #2683).
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::json;
+
+use super::{DelegateToAgentTool, EngineerCompletionSignal, redelegation_hint};
+use crate::agent_loop::AgentLoopError;
+use crate::llm::LlmError;
+use crate::runner::RunnerError;
+use crate::tools::finish_task::FinishStatus;
+use crate::tools::traits::{AgentOutput, AgentRunner, ToolExecutor};
+
+/// Recording mock runner.
+///
+/// Why: Tests need to verify the runner was (or was not) invoked.
+/// What: Records `(agent_name, task)` pairs in a Mutex-guarded Vec.
+/// Test: `known_agent_reaches_runner`, `no_config_dir_skips_validation`.
+struct RecordingRunner {
+    invoked: std::sync::Mutex<Vec<(String, String)>>,
+}
+
+#[async_trait]
+impl AgentRunner for RecordingRunner {
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
+        self.invoked
+            .lock()
+            .expect("lock poisoned")
+            .push((agent_name.to_string(), task.to_string()));
+        Ok(AgentOutput::from_content("ok"))
+    }
+}
+
+/// An unknown agent name returns a structured error listing available agents,
+/// and the runner is NOT invoked.
+///
+/// Why: Guards against hallucinated agent names causing confusing IO errors.
+/// What: Calls `execute({"agent_name":"ghost",...})` with a tempdir
+/// containing only `engineer.toml`; expects error with "ghost" and "engineer".
+/// Test: This test.
+#[tokio::test]
+async fn unknown_agent_returns_helpful_error() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("engineer.toml"),
+        "[agent]\nname = \"engineer\"\n",
+    )
+    .expect("write");
+    std::fs::write(
+        tmp.path().join("qa-agent.toml"),
+        "[agent]\nname = \"qa-agent\"\n",
+    )
+    .expect("write");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
+
+    let result = tool
+        .execute(json!({"agent_name": "ghost", "task": "do something"}))
+        .await;
+
+    assert!(result.is_error(), "must reject unknown agent");
+    let msg = result.content();
+    assert!(
+        msg.contains("Unknown agent 'ghost'"),
+        "error must name the unknown agent, got: {msg}"
+    );
+    assert!(
+        msg.contains("engineer") && msg.contains("qa-agent"),
+        "error must list available agents, got: {msg}"
+    );
+    assert!(
+        msg.contains("native tools"),
+        "error must clarify native-vs-agent, got: {msg}"
+    );
+    assert!(
+        runner.invoked.lock().expect("lock").is_empty(),
+        "runner must not be called when validation fails"
+    );
+}
+
+/// A valid agent name passes validation and reaches the runner.
+///
+/// Why: Verify the happy-path dispatch contract.
+/// What: Register `engineer.toml`, dispatch with `agent_name="engineer"`.
+/// Test: This test.
+#[tokio::test]
+async fn known_agent_reaches_runner() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("engineer.toml"),
+        "[agent]\nname = \"engineer\"\n",
+    )
+    .expect("write");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
+
+    let result = tool
+        .execute(json!({"agent_name": "engineer", "task": "do the thing"}))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "valid agent should succeed: {}",
+        result.content()
+    );
+    let invoked = runner.invoked.lock().expect("lock");
+    assert_eq!(invoked.len(), 1, "runner should be called exactly once");
+    assert_eq!(invoked[0].0, "engineer");
+}
+
+/// Without `with_config_dir`, validation is skipped — the runner is invoked.
+///
+/// Why: Preserves backward compatibility with callers that don't need
+/// pre-flight validation (e.g. integration tests).
+/// What: Construct tool without config_dir; any agent name reaches the runner.
+/// Test: This test.
+#[tokio::test]
+async fn no_config_dir_skips_validation() {
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone());
+
+    let result = tool
+        .execute(json!({"agent_name": "anything-goes", "task": "do it"}))
+        .await;
+
+    assert!(!result.is_error(), "legacy mode should bypass validation");
+    assert_eq!(runner.invoked.lock().expect("lock").len(), 1);
+}
+
+/// Missing `agent_name` field returns a structured error.
+///
+/// Why: Guard against malformed LLM function call arguments.
+/// What: `execute({})` without `agent_name` key.
+/// Test: This test.
+#[tokio::test]
+async fn missing_agent_name_returns_error() {
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner);
+    let result = tool.execute(json!({"task": "something"})).await;
+    assert!(result.is_error());
+    assert!(result.content().contains("missing 'agent_name'"));
+}
+
+/// A path-traversal agent name is rejected before any filesystem access.
+///
+/// Why: The LLM supplies `agent_name` which is joined into a filesystem path.
+/// A crafted name like `../../etc/passwd` must be caught before the join to
+/// prevent escaping the agents config directory.
+/// What: Calls `execute` with a traversal string; asserts error and runner
+/// not invoked.
+/// Test: This test.
+#[tokio::test]
+async fn path_traversal_agent_name_is_rejected() {
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    // No config_dir — traversal guard fires before config check.
+    let tool = DelegateToAgentTool::new(runner.clone());
+
+    for bad_name in &[
+        "../../etc/passwd",
+        "../sibling",
+        "agent/sub",
+        "agent name",
+        "",
+    ] {
+        let result = tool
+            .execute(json!({"agent_name": bad_name, "task": "do it"}))
+            .await;
+        assert!(
+            result.is_error(),
+            "traversal/invalid name '{bad_name}' must be rejected"
+        );
+        assert!(
+            result.content().contains("Invalid agent name"),
+            "error must describe the problem, got: {}",
+            result.content()
+        );
+    }
+    assert!(
+        runner.invoked.lock().expect("lock").is_empty(),
+        "runner must never be called for invalid names"
+    );
+}
+
+/// A valid agent name passes the sanitisation guard and reaches the runner.
+///
+/// Why: Confirms the allowlist does not over-reject legitimate names.
+/// What: `execute({"agent_name":"engineer",...})` without config_dir; runner
+/// is called once.
+/// Test: This test.
+#[tokio::test]
+async fn valid_agent_name_passes_sanitization() {
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone());
+
+    for good_name in &["engineer", "qa-agent", "python_engineer", "rust-2024"] {
+        let result = tool
+            .execute(json!({"agent_name": good_name, "task": "do it"}))
+            .await;
+        assert!(
+            !result.is_error(),
+            "valid name '{good_name}' must be accepted: {}",
+            result.content()
+        );
+    }
+    assert_eq!(
+        runner.invoked.lock().expect("lock").len(),
+        4,
+        "runner must be called for each valid name"
+    );
+}
+
+/// Mock runner that always fails with a caller-supplied error.
+///
+/// Why: `redelegation_hint` tests need to control exactly which
+/// `RunnerError`/`AgentLoopError` shape `execute()` observes, without
+/// driving a real `AgentLoop`.
+/// What: `run` always returns `Err` built from the stored `anyhow::Error`
+/// factory (a `Fn` so each call gets a fresh error, since `anyhow::Error`
+/// is not `Clone`).
+/// Test: `redelegation_hint_present_on_turn_cap_exceeded` and siblings.
+struct FailingRunner<F: Fn() -> anyhow::Error + Send + Sync> {
+    make_err: F,
+}
+
+#[async_trait]
+impl<F: Fn() -> anyhow::Error + Send + Sync> AgentRunner for FailingRunner<F> {
+    async fn run(&self, _agent_name: &str, _task: &str) -> Result<AgentOutput> {
+        Err((self.make_err)())
+    }
+}
+
+/// A `TurnCapExceeded` sub-agent failure carries the reuse/continue
+/// directive in the tool's error text.
+///
+/// Why: This is the core bake-off L1 fix — the PM must see an automatic,
+/// structured instruction to inspect and reuse partial work instead of
+/// relying on its own free text remembering to ask for it.
+/// What: `FailingRunner` returns `RunnerError::Loop` wrapping
+/// `AgentLoopError::TurnCapExceeded`; assert the rendered error mentions
+/// both re-delegation and reading/continuing existing work.
+/// Test: this test.
+#[tokio::test]
+async fn redelegation_hint_present_on_turn_cap_exceeded() {
+    let runner = Arc::new(FailingRunner {
+        make_err: || {
+            anyhow::Error::from(RunnerError::Loop {
+                name: "engineer".to_string(),
+                source: AgentLoopError::TurnCapExceeded {
+                    max_turns: 8,
+                    partial: Box::new(AgentOutput::from_content("partial work")),
+                },
+            })
+        },
+    });
+    let tool = DelegateToAgentTool::new(runner);
+
+    let result = tool
+        .execute(json!({"agent_name": "engineer", "task": "build the package"}))
+        .await;
+
+    assert!(result.is_error());
+    let msg = result.content();
+    assert!(
+        msg.contains("READ and CONTINUE"),
+        "must instruct the PM to reuse existing work, got: {msg}"
+    );
+    assert!(
+        msg.contains("already written real, partial progress"),
+        "must explain why re-delegation should not start over, got: {msg}"
+    );
+}
+
+/// A `Timeout` sub-agent failure gets the same reuse/continue directive.
+///
+/// Why: A wall-clock timeout carries partial work exactly like a turn-cap
+/// abort (per `AgentLoopError`'s own docs); the hint must not be
+/// TurnCapExceeded-specific.
+/// What: `FailingRunner` returns `RunnerError::Loop` wrapping
+/// `AgentLoopError::Timeout`.
+/// Test: this test.
+#[tokio::test]
+async fn redelegation_hint_present_on_timeout() {
+    let runner = Arc::new(FailingRunner {
+        make_err: || {
+            anyhow::Error::from(RunnerError::Loop {
+                name: "engineer".to_string(),
+                source: AgentLoopError::Timeout {
+                    timeout_secs: 120,
+                    partial: Box::new(AgentOutput::from_content("partial work")),
+                },
+            })
+        },
+    });
+    let tool = DelegateToAgentTool::new(runner);
+
+    let result = tool
+        .execute(json!({"agent_name": "engineer", "task": "build the package"}))
+        .await;
+
+    assert!(result.is_error());
+    assert!(result.content().contains("READ and CONTINUE"));
+}
+
+/// A `Cancelled` sub-agent failure gets the same reuse/continue directive.
+///
+/// What: `FailingRunner` returns `RunnerError::Loop` wrapping
+/// `AgentLoopError::Cancelled`.
+/// Test: this test.
+#[tokio::test]
+async fn redelegation_hint_present_on_cancelled() {
+    let runner = Arc::new(FailingRunner {
+        make_err: || {
+            anyhow::Error::from(RunnerError::Loop {
+                name: "engineer".to_string(),
+                source: AgentLoopError::Cancelled {
+                    partial: Box::new(AgentOutput::from_content("partial work")),
+                },
+            })
+        },
+    });
+    let tool = DelegateToAgentTool::new(runner);
+
+    let result = tool
+        .execute(json!({"agent_name": "engineer", "task": "build the package"}))
+        .await;
+
+    assert!(result.is_error());
+    assert!(result.content().contains("READ and CONTINUE"));
+}
+
+/// An `UnknownAgent` runner failure gets NO reuse directive — there is no
+/// partial work to reuse when the agent config never resolved.
+///
+/// Why: The hint must not fire indiscriminately on every failure; guard
+/// the negative case.
+/// What: `FailingRunner` returns `RunnerError::UnknownAgent`.
+/// Test: this test.
+#[tokio::test]
+async fn redelegation_hint_absent_on_unknown_agent() {
+    let runner = Arc::new(FailingRunner {
+        make_err: || {
+            anyhow::Error::from(RunnerError::UnknownAgent {
+                name: "ghost".to_string(),
+                dir: std::path::PathBuf::from("/agents"),
+            })
+        },
+    });
+    let tool = DelegateToAgentTool::new(runner);
+
+    let result = tool
+        .execute(json!({"agent_name": "ghost", "task": "build the package"}))
+        .await;
+
+    assert!(result.is_error());
+    assert!(
+        !result.content().contains("READ and CONTINUE"),
+        "no partial work exists for an unresolved agent config, got: {}",
+        result.content()
+    );
+}
+
+/// A plain LLM/transport failure gets the SAME reuse/continue directive
+/// (#2265 fix #2: this is the dominant bake-off failure mode, previously
+/// excluded from the hint).
+///
+/// Why: A recoverable Bedrock/transport error aborting the engineer's
+/// sub-loop is the dominant failure mode observed in the bake-off
+/// transcripts; the reuse hint must fire here too so re-delegation checks
+/// for and continues from files already on disk instead of restarting
+/// exploration from scratch.
+/// What: `FailingRunner` returns `RunnerError::Loop` wrapping
+/// `AgentLoopError::Llm`; assert the hint is present.
+/// Test: this test.
+#[tokio::test]
+async fn redelegation_hint_present_on_llm_error() {
+    let runner = Arc::new(FailingRunner {
+        make_err: || {
+            anyhow::Error::from(RunnerError::Loop {
+                name: "engineer".to_string(),
+                source: AgentLoopError::Llm(LlmError::ApiError {
+                    status: 500,
+                    body: "internal error".to_string(),
+                }),
+            })
+        },
+    });
+    let tool = DelegateToAgentTool::new(runner);
+
+    let result = tool
+        .execute(json!({"agent_name": "engineer", "task": "build the package"}))
+        .await;
+
+    assert!(result.is_error());
+    assert!(
+        result.content().contains("READ and CONTINUE"),
+        "an LLM/transport error must ALSO carry the reuse directive (#2265), got: {}",
+        result.content()
+    );
+}
+
+/// `redelegation_hint` itself (unit-level, not through the tool) returns
+/// `Some` for `AgentLoopError::Llm` (#2265 fix #2).
+///
+/// Why: The tool-level test above proves the end-to-end wiring; this test
+/// pins the specific function contract directly, matching the task's
+/// required "redelegation_hint(AgentLoopError::Llm) now returns
+/// Some(<reuse hint>)" assertion.
+/// What: Builds a `RunnerError::Loop` wrapping `AgentLoopError::Llm`,
+/// calls `redelegation_hint` directly, asserts `Some`.
+/// Test: this test.
+#[test]
+fn redelegation_hint_fn_returns_some_for_llm_error() {
+    let err = anyhow::Error::from(RunnerError::Loop {
+        name: "engineer".to_string(),
+        source: AgentLoopError::Llm(LlmError::ApiError {
+            status: 503,
+            body: "bedrock throttled".to_string(),
+        }),
+    });
+    assert!(
+        redelegation_hint(&err).is_some(),
+        "redelegation_hint must return Some for AgentLoopError::Llm (#2265)"
+    );
+}
+
+/// Mock runner returning an `AgentOutput` with a caller-chosen
+/// `finish_status`, recording whether it was invoked (#2683).
+///
+/// Why: The completion-signal tests need to control the exact
+/// `finish_status` the delegate tool observes on a successful delegation,
+/// and the refusal test needs to prove the runner is NOT invoked once the
+/// signal has latched.
+/// What: `run` records the invocation and returns an `AgentOutput` carrying
+/// `finish_status`.
+/// Test: `completion_signal_latches_on_completed_finish` and siblings.
+struct FinishingRunner {
+    finish_status: Option<FinishStatus>,
+    invoked: std::sync::Mutex<u32>,
+}
+
+#[async_trait]
+impl AgentRunner for FinishingRunner {
+    async fn run(&self, _agent_name: &str, _task: &str) -> Result<AgentOutput> {
+        *self.invoked.lock().expect("invoked lock") += 1;
+        let mut out = AgentOutput::from_content("engineer finished");
+        out.finish_status = self.finish_status;
+        Ok(out)
+    }
+}
+
+/// A delegation whose engineer returned `finish_status == Completed`
+/// latches the shared completion signal (#2683).
+///
+/// Why: This is the authoritative "task is genuinely done" signal that both
+/// the re-delegation refusal and `run_task::assemble_report`'s
+/// success-not-partial mapping key off; it must latch on an explicit
+/// successful completion.
+/// What: Run the tool once with a `Completed` finish; assert the signal is
+/// latched afterwards.
+/// Test: this test.
+#[tokio::test]
+async fn completion_signal_latches_on_completed_finish() {
+    let runner = Arc::new(FinishingRunner {
+        finish_status: Some(FinishStatus::Completed),
+        invoked: std::sync::Mutex::new(0),
+    });
+    let signal = EngineerCompletionSignal::new();
+    let tool = DelegateToAgentTool::new(runner).with_completion_signal(signal.clone());
+
+    let result = tool
+        .execute(json!({"agent_name": "engineer", "task": "build it"}))
+        .await;
+
+    assert!(!result.is_error(), "a completed delegation must succeed");
+    assert!(
+        signal.is_completed(),
+        "a Completed finish_task must latch the completion signal"
+    );
+}
+
+/// A delegation that ended any other way (a `failed`/`cancelled` finish, or
+/// no explicit finish at all) does NOT latch the completion signal (#2683).
+///
+/// Why: Re-delegation must stay legitimately available when the engineer did
+/// not actually succeed — latching on a non-success would wrongly suppress a
+/// warranted retry and could report a failed run as a success.
+/// What: Run the tool with a `Failed` finish and, separately, with no
+/// finish status; assert the signal stays un-latched in both cases.
+/// Test: this test.
+#[tokio::test]
+async fn completion_signal_ignores_non_completed_finish() {
+    for status in [
+        Some(FinishStatus::Failed),
+        Some(FinishStatus::Cancelled),
+        None,
+    ] {
+        let runner = Arc::new(FinishingRunner {
+            finish_status: status,
+            invoked: std::sync::Mutex::new(0),
+        });
+        let signal = EngineerCompletionSignal::new();
+        let tool = DelegateToAgentTool::new(runner).with_completion_signal(signal.clone());
+
+        let _ = tool
+            .execute(json!({"agent_name": "engineer", "task": "attempt it"}))
+            .await;
+
+        assert!(
+            !signal.is_completed(),
+            "finish_status {status:?} must not latch the completion signal"
+        );
+    }
+}
+
+/// Once the completion signal has latched, a further `delegate_to_agent`
+/// call is refused with a recoverable error and the runner is NOT invoked
+/// (#2683).
+///
+/// Why: This is the "do not re-delegate once the finish gate is satisfied"
+/// half of the fix — the gratuitous post-finish re-verify round that
+/// mislabels a complete run as `partial` must never reach the engineer at
+/// all.
+/// What: Pre-latch the signal, then call `execute`; assert the result is a
+/// recoverable error naming `finish_task`, and the runner's invocation
+/// count stays zero.
+/// Test: this test.
+#[tokio::test]
+async fn delegate_refused_once_engineer_completed() {
+    let runner = Arc::new(FinishingRunner {
+        finish_status: Some(FinishStatus::Completed),
+        invoked: std::sync::Mutex::new(0),
+    });
+    let signal = EngineerCompletionSignal::new();
+    signal.mark_completed();
+    let tool = DelegateToAgentTool::new(runner.clone()).with_completion_signal(signal);
+
+    let result = tool
+        .execute(json!({"agent_name": "engineer", "task": "re-verify the work"}))
+        .await;
+
+    assert!(
+        result.is_error(),
+        "a post-completion delegation must be refused"
+    );
+    assert!(
+        !result.is_fatal(),
+        "the refusal must be recoverable, not fatal"
+    );
+    let msg = result.content();
+    assert!(
+        msg.contains("refused") && msg.contains("finish_task"),
+        "the refusal must nudge the PM to finish_task, got: {msg}"
+    );
+    assert_eq!(
+        *runner.invoked.lock().expect("invoked lock"),
+        0,
+        "the runner must never be invoked once the engineer has completed"
+    );
+}

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -38,9 +38,9 @@ pub mod trusty_search;
 #[allow(unused_imports)]
 pub use bash::{BASH_TOOL_NAME, BashTool};
 #[allow(unused_imports)]
-pub use delegate::DelegateToAgentTool;
+pub use delegate::{DelegateToAgentTool, EngineerCompletionSignal};
 pub use finish_task::{
-    FINISH_TASK_TOOL_NAME, FinishTaskArgs, FinishTaskTool, render_finish_summary,
+    FINISH_TASK_TOOL_NAME, FinishStatus, FinishTaskArgs, FinishTaskTool, render_finish_summary,
 };
 pub use fs::{
     EditTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, WRITE_FILES_TOOL_NAME, WriteFileTool,

--- a/crates/trusty-code/src/tools/traits.rs
+++ b/crates/trusty-code/src/tools/traits.rs
@@ -193,10 +193,19 @@ pub struct RunContext {
 ///
 /// Why: Downstream phases need a concise `summary` for template substitution
 /// while also needing the full `content` for file extraction. Bundling them
-/// avoids separate trait methods.
+/// avoids separate trait methods. (#2683) A delegated engineer's caller (the
+/// PM's `delegate_to_agent` tool) also needs to know whether the agent
+/// terminated by an EXPLICIT, successful `finish_task` completion — that is the
+/// authoritative "the task is genuinely done" signal used to prevent a
+/// gratuitous post-finish re-delegation from mislabeling a complete run.
 /// What: `content` is raw agent output; `summary` is the extracted `## Summary`
-/// section (or a prefix fallback).
-/// Test: Constructed from IPC result messages in integration paths.
+/// section (or a prefix fallback); `finish_status` (#2683) is `Some` only when
+/// the loop ended via an accepted `finish_task` call, carrying that call's
+/// reported status.
+/// Test: Constructed from IPC result messages in integration paths;
+/// `finish_status` propagation is covered by
+/// `agent_loop::tests::explicit_finish_task_terminates_loop_with_structured_summary`
+/// and `tools::delegate::tests::completion_signal_latches_on_completed_finish`.
 #[derive(Debug, Clone)]
 pub struct AgentOutput {
     /// Raw output from the agent.
@@ -205,19 +214,25 @@ pub struct AgentOutput {
     pub summary: Option<String>,
     /// Aggregated LLM token usage for this invocation.
     pub usage: crate::perf::TokenUsage,
+    /// The status of an explicit `finish_task` completion, if the loop ended
+    /// via one (#2683). `None` when the run ended any other way (turn cap,
+    /// timeout, a plain no-tool-call stop, or an error).
+    pub finish_status: Option<crate::tools::finish_task::FinishStatus>,
 }
 
 impl AgentOutput {
     /// Build from content alone; summary/usage will be defaults.
     ///
     /// Why: Convenience constructor for simple agent results.
-    /// What: Sets `content`, leaves `summary` None, `usage` zeroed.
+    /// What: Sets `content`, leaves `summary` None, `usage` zeroed, and
+    /// `finish_status` None (no explicit finish observed).
     /// Test: Used in mock runners throughout this crate's tests.
     pub fn from_content(content: impl Into<String>) -> Self {
         Self {
             content: content.into(),
             summary: None,
             usage: crate::perf::TokenUsage::default(),
+            finish_status: None,
         }
     }
 
@@ -484,6 +499,7 @@ mod tests {
             content: "full content".into(),
             summary: Some("short summary".into()),
             usage: TokenUsage::default(),
+            finish_status: None,
         };
         assert_eq!(with_summary.summary_or_content(), "short summary");
 


### PR DESCRIPTION
## Problem

In L1/L2/L4 bake-off runs the PM could degenerate into a re-delegation loop, and — worse, per the issue's 2026-07-15 recurrence comment — a run where the delegated engineer **already completed successfully** (`finish_task`, all tests passing) got mislabeled `tcode_status: partial` / `exit_code: 6`. The PM fired one more gratuitous "re-verify" `delegate_to_agent` round; when that round ran the PM's loop out of turns/wall-clock time, `run_task` reported a complete, correct, all-tests-green run as `partial`, corrupting run status/telemetry. This is a data-integrity bug, not just wasted turns.

## Fix

Both halves the issue asks for:

**(b) Do not re-delegate once the finish gate is satisfied.** A run-scoped `EngineerCompletionSignal` latches when a delegation returns an `AgentOutput` whose new `finish_status == Completed` (set in `agent_loop::build_finish_output`). The PM's `DelegateToAgentTool` refuses any subsequent `delegate_to_agent` with a recoverable error nudging the PM to call `finish_task` instead — the engineer is never gratuitously re-invoked.

**Data integrity.** `run_task::assemble_report` now checks the completion latch **first**: a completed engineer maps to `Success` (non-empty diff) or `NoChanges` (empty diff) — never `Partial`/`DeadlineExceeded`/`RunFailure` — regardless of how the PM's own loop later terminated.

**(a) Bounded retries** are still enforced by the existing `MAX_REDELEGATIONS` cap (`run_task::redelegation`), unchanged.

## Notes

- `delegate.rs`'s inline tests were extracted to a sibling `delegate_tests.rs` (test-classified, 1500-SLOC cap) so the production module stays under the 500-SLOC cap, mirroring the crate's `goals_tests.rs`/`trusty_search_tests.rs` convention.

## Tests

6 new, reproducing the mislabel/loop and proving the fix:
- `delegate_tests`: `completion_signal_latches_on_completed_finish`, `completion_signal_ignores_non_completed_finish`, `delegate_refused_once_engineer_completed`
- `run_task`: `assemble_report_maps_completed_engineer_with_deliverable_to_success`, `..._without_deliverable_to_no_changes`, `gratuitous_redelegation_after_finish_is_refused_and_run_succeeds`

## Verification

- `cargo build -p trusty-code` — clean
- `cargo test -p trusty-code` — `922 passed; 0 failed` (lib) + all integration suites green
- `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — `0 violations`

Closes #2683

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools