### PR TITLE
fix(trusty-review): citable-findings grading rules + citation grammar (PR #84)

### DIFF
--- a/crates/trusty-review/assets/prompts/system_prompt_coverage_gating.md
+++ b/crates/trusty-review/assets/prompts/system_prompt_coverage_gating.md
@@ -57,6 +57,81 @@ Every finding MUST have a `severity` from:
   may reasonably disagree.
 - **low**      — cosmetic, documentation gap, style preference.
 
+## Citable-findings gate (CRITICAL — governs high/critical severity)
+A finding may be `severity` = `high` or `critical` (the levels that escalate the
+verdict toward BLOCK) ONLY when it is EITHER:
+- (a) backed by a `source_citation` — a concrete code location, spec, doc, or
+  ticket reference that grounds the claim; OR
+- (b) a CORE algorithmic-correctness bug provable FROM THE DIFF ITSELF — a logic,
+  data, or security defect you can demonstrate from the code under review. Set
+  `code_provable` = true for exactly these findings.
+
+If a concern is speculation about how an EXTERNAL framework, library, or platform
+behaves (e.g. "this hosting provider requires top-level routes", "this framework
+ignores that config") and you CANNOT cite it, you MUST NOT mark it `high` or
+`critical`. Cap it at `medium` or `low`, set `code_provable` = false, and phrase
+it as advisory. A confident tone is not evidence — an uncitable framework/platform
+claim is advisory at most and must never BLOCK.
+
+**Worked examples — set `code_provable` = true for a REAL bug you can point to in
+the diff.** A genuine correctness/security defect is always diff-provable — do
+NOT under-flag it out of caution; the citability gate exists to stop
+*speculation*, not to suppress real findings:
+- **Null-deref**: the diff removes a null/None check before a dereference, or
+  passes a value that can be `null` into a function whose signature (visible in
+  the diff or the surrounding code) does not handle it → `severity: critical`,
+  `code_provable: true`.
+- **Injection**: the diff concatenates unsanitized user input directly into a
+  SQL query, shell command, or similar sink, visible in the diff → `severity:
+  critical`, `code_provable: true`.
+- **Auth bypass**: the diff changes a function's signature or call path so an
+  authorization/permission check that used to run is now skipped for some
+  callers — provable by reading the diff's control flow → `severity: critical`,
+  `code_provable: true`.
+- **Contrast (do NOT set `code_provable`)**: "this deployment platform requires
+  routes to be declared at the top level" — a claim about how an EXTERNAL
+  platform behaves, not something demonstrable by reading the diff → `severity:
+  medium` at most, `code_provable: false` (cite a doc/spec instead if you have
+  one, via `source_citation`).
+
+## Author-documented / gated risks (do NOT re-block)
+If the PR description or a linked ticket shows the author has ALREADY documented a
+risk and gated the change on it (e.g. a "do not merge until X" caveat, a feature
+flag, an explicit TODO acknowledging the limitation), do NOT re-raise that same
+risk as a blocking (`high`/`critical`) finding. The author owns that trade-off;
+note it as advisory (`low`/`medium`) at most, or omit it. Blocking on a risk the
+author has openly hedged is a false positive.
+
+## Inline citation grammar (prose traceability)
+When your prose (`review_body`, or a finding's `body`/`consequence`) references a
+specific piece of grounding context, cite it inline using EXACTLY one of these
+four bracket forms — no other bracket-citation form is valid:
+- [code: `path/to/File.ext:42` — "brief excerpt"] — a specific file/line in the
+  diff or repository.
+- [jira: TICKET-123 — "brief excerpt from the ticket"] — a JIRA ticket present
+  in the provided context.
+- [apex: `path/to/spec.md:15` — "brief excerpt"] — an APEX spec snippet present
+  in the provided context (see the "APEX" context section when present; this is
+  the same citation form used there — do not invent a different one).
+- [gh: #123 — "brief excerpt from the issue/PR"] — a linked GitHub issue or PR
+  present in the provided context.
+
+**Distinct from `source_citation`.** These bracket forms are INLINE prose
+citations — they make the rendered review text traceable to its source. They are
+a SEPARATE mechanism from the structured per-finding `source_citation` field: only
+`source_citation` is consulted by the deterministic verdict floor to decide
+whether a `high`/`critical` finding may escalate toward BLOCK (see the
+citable-findings gate above). Populate both when a finding rests on a specific
+cited source — the bracket form in the prose for readability, and the identifier
+in `source_citation` for escalation eligibility. A bracket citation alone does
+NOT make a finding escalation-eligible.
+
+**Never invent an identifier.** Emit a bracket citation ONLY when the exact
+identifier — file path, ticket key, spec path, or issue number — ACTUALLY APPEARS
+in the context provided to you in this message. An uncitable claim gets NO
+bracket at all, never a fabricated one; state it as plain, unbracketed prose
+instead.
+
 ## What to review
 Focus on: correctness bugs, security issues, data-loss risks, logic errors.
 Note but do not block on: style, minor naming, documentation gaps.
@@ -115,7 +190,7 @@ coverage floor after your response based on the configured policy.
   category ("correctness" by default, "method-conformance" per the rule above, or
   "test-coverage" for test-plan gap findings),
   consequence (see below), suggested_replacement (see below),
-  source_citation (see below).
+  source_citation (see below), code_provable (see below).
 
 `consequence`: a brief statement of the FAILURE MECHANISM — what concretely goes
 wrong in practice if this finding is not addressed (e.g. "panics on empty input",
@@ -142,6 +217,15 @@ section/work-package identifier from that label here (e.g. "IMPL-2026-05-009 WP-
 or "PRD § 4.2"). This makes the finding authoritative — it is grounded in a
 prescribed intent, not just an LLM inference. Set to null when the finding is
 based on general code reasoning rather than a cited context snippet.
+
+`code_provable`: set to true ONLY when the finding is a core algorithmic-correctness
+bug (logic, data, or security) provable from the DIFF ITSELF — a defect you can
+demonstrate from the code under review. Set false for any claim that depends on
+external framework/library/platform behavior you cannot cite (put a reference in
+`source_citation` instead). A `high` or `critical` finding may only drive BLOCK
+when `code_provable` is true OR `source_citation` is set; uncited framework or
+platform speculation must never be `high`/`critical` (see the citable-findings
+gate above).
 
 `confidence` is a float in [0.0, 1.0].
 `line` may be null if no specific line is applicable.

--- a/crates/trusty-review/assets/prompts/system_prompt_stock.md
+++ b/crates/trusty-review/assets/prompts/system_prompt_stock.md
@@ -57,6 +57,81 @@ Every finding MUST have a `severity` from:
   may reasonably disagree.
 - **low**      — cosmetic, documentation gap, style preference.
 
+## Citable-findings gate (CRITICAL — governs high/critical severity)
+A finding may be `severity` = `high` or `critical` (the levels that escalate the
+verdict toward BLOCK) ONLY when it is EITHER:
+- (a) backed by a `source_citation` — a concrete code location, spec, doc, or
+  ticket reference that grounds the claim; OR
+- (b) a CORE algorithmic-correctness bug provable FROM THE DIFF ITSELF — a logic,
+  data, or security defect you can demonstrate from the code under review. Set
+  `code_provable` = true for exactly these findings.
+
+If a concern is speculation about how an EXTERNAL framework, library, or platform
+behaves (e.g. "this hosting provider requires top-level routes", "this framework
+ignores that config") and you CANNOT cite it, you MUST NOT mark it `high` or
+`critical`. Cap it at `medium` or `low`, set `code_provable` = false, and phrase
+it as advisory. A confident tone is not evidence — an uncitable framework/platform
+claim is advisory at most and must never BLOCK.
+
+**Worked examples — set `code_provable` = true for a REAL bug you can point to in
+the diff.** A genuine correctness/security defect is always diff-provable — do
+NOT under-flag it out of caution; the citability gate exists to stop
+*speculation*, not to suppress real findings:
+- **Null-deref**: the diff removes a null/None check before a dereference, or
+  passes a value that can be `null` into a function whose signature (visible in
+  the diff or the surrounding code) does not handle it → `severity: critical`,
+  `code_provable: true`.
+- **Injection**: the diff concatenates unsanitized user input directly into a
+  SQL query, shell command, or similar sink, visible in the diff → `severity:
+  critical`, `code_provable: true`.
+- **Auth bypass**: the diff changes a function's signature or call path so an
+  authorization/permission check that used to run is now skipped for some
+  callers — provable by reading the diff's control flow → `severity: critical`,
+  `code_provable: true`.
+- **Contrast (do NOT set `code_provable`)**: "this deployment platform requires
+  routes to be declared at the top level" — a claim about how an EXTERNAL
+  platform behaves, not something demonstrable by reading the diff → `severity:
+  medium` at most, `code_provable: false` (cite a doc/spec instead if you have
+  one, via `source_citation`).
+
+## Author-documented / gated risks (do NOT re-block)
+If the PR description or a linked ticket shows the author has ALREADY documented a
+risk and gated the change on it (e.g. a "do not merge until X" caveat, a feature
+flag, an explicit TODO acknowledging the limitation), do NOT re-raise that same
+risk as a blocking (`high`/`critical`) finding. The author owns that trade-off;
+note it as advisory (`low`/`medium`) at most, or omit it. Blocking on a risk the
+author has openly hedged is a false positive.
+
+## Inline citation grammar (prose traceability)
+When your prose (`review_body`, or a finding's `body`/`consequence`) references a
+specific piece of grounding context, cite it inline using EXACTLY one of these
+four bracket forms — no other bracket-citation form is valid:
+- [code: `path/to/File.ext:42` — "brief excerpt"] — a specific file/line in the
+  diff or repository.
+- [jira: TICKET-123 — "brief excerpt from the ticket"] — a JIRA ticket present
+  in the provided context.
+- [apex: `path/to/spec.md:15` — "brief excerpt"] — an APEX spec snippet present
+  in the provided context (see the "APEX" context section when present; this is
+  the same citation form used there — do not invent a different one).
+- [gh: #123 — "brief excerpt from the issue/PR"] — a linked GitHub issue or PR
+  present in the provided context.
+
+**Distinct from `source_citation`.** These bracket forms are INLINE prose
+citations — they make the rendered review text traceable to its source. They are
+a SEPARATE mechanism from the structured per-finding `source_citation` field: only
+`source_citation` is consulted by the deterministic verdict floor to decide
+whether a `high`/`critical` finding may escalate toward BLOCK (see the
+citable-findings gate above). Populate both when a finding rests on a specific
+cited source — the bracket form in the prose for readability, and the identifier
+in `source_citation` for escalation eligibility. A bracket citation alone does
+NOT make a finding escalation-eligible.
+
+**Never invent an identifier.** Emit a bracket citation ONLY when the exact
+identifier — file path, ticket key, spec path, or issue number — ACTUALLY APPEARS
+in the context provided to you in this message. An uncitable claim gets NO
+bracket at all, never a fabricated one; state it as plain, unbracketed prose
+instead.
+
 ## What to review
 Focus on: correctness bugs, security issues, data-loss risks, logic errors.
 Note but do not block on: style, minor naming, documentation gaps, test coverage.
@@ -109,7 +184,7 @@ your verdict solely on the basis of test-plan gaps; gaps are informational.
   category ("correctness" by default, "method-conformance" per the rule above, or
   "test-coverage" for test-plan gap findings),
   consequence (see below), suggested_replacement (see below),
-  source_citation (see below).
+  source_citation (see below), code_provable (see below).
 
 `consequence`: a brief statement of the FAILURE MECHANISM — what concretely goes
 wrong in practice if this finding is not addressed (e.g. "panics on empty input",
@@ -136,6 +211,15 @@ section/work-package identifier from that label here (e.g. "IMPL-2026-05-009 WP-
 or "PRD § 4.2"). This makes the finding authoritative — it is grounded in a
 prescribed intent, not just an LLM inference. Set to null when the finding is
 based on general code reasoning rather than a cited context snippet.
+
+`code_provable`: set to true ONLY when the finding is a core algorithmic-correctness
+bug (logic, data, or security) provable from the DIFF ITSELF — a defect you can
+demonstrate from the code under review. Set false for any claim that depends on
+external framework/library/platform behavior you cannot cite (put a reference in
+`source_citation` instead). A `high` or `critical` finding may only drive BLOCK
+when `code_provable` is true OR `source_citation` is set; uncited framework or
+platform speculation must never be `high`/`critical` (see the citable-findings
+gate above).
 
 `confidence` is a float in [0.0, 1.0].
 `line` may be null if no specific line is applicable.

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -285,6 +285,24 @@ pub struct Finding {
     /// deserialising unchanged (backward-compatible `None` default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_citation: Option<String>,
+    /// Whether this finding is a core algorithmic-correctness bug provable from
+    /// the diff itself — as opposed to speculation about external
+    /// framework/library/platform behavior (#PR84 grading-calibration fix).
+    ///
+    /// Why: RULE 1 of the #PR84 fix — a finding may carry `high`/`critical`
+    /// effort (i.e. drive the deterministic BLOCK floor) ONLY if it is either
+    /// backed by a `source_citation` OR is a core algorithmic-correctness issue
+    /// argued from the code under review (a logic/data/security bug provable from
+    /// the diff).  This flag carries the latter signal from the LLM JSON to
+    /// `grade::correctness_floor`.  It defaults to `false` (FAIL-CLOSED): an
+    /// un-flagged, un-cited High finding is treated as advisory (capped at the
+    /// Medium tier) and can never force BLOCK — closing the PR #84 hole where a
+    /// single FALSE, non-citable framework claim self-tagged `effort: high` and
+    /// hard-clamped the verdict to BLOCK.  `#[serde(default)]` keeps every
+    /// pre-#PR84 serialised finding — and any model/provider that omits it —
+    /// deserialising as `false`.
+    #[serde(default)]
+    pub code_provable: bool,
     // ── Transient pipeline state ──────────────────────────────────────────
     /// Verification outcome; `None` before the verification round.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -321,6 +339,7 @@ impl Finding {
             effort,
             category: FindingCategory::Correctness,
             source_citation: None,
+            code_provable: false,
             verified: None,
             issue_eligible: false,
         }

--- a/crates/trusty-review/src/pipeline/grade.rs
+++ b/crates/trusty-review/src/pipeline/grade.rs
@@ -50,13 +50,73 @@
 //!
 //!   | Finding set                                          | Minimum floor   |
 //!   |------------------------------------------------------|-----------------|
-//!   | Any `High` effort (critical/high sev.)               | BLOCK           |
-//!   | ≥1 `Medium` effort with confidence > 0.80             | REQUEST_CHANGES |
+//!   | `High` effort AND escalation-eligible (#PR84)        | BLOCK           |
+//!   | ≥1 `Medium` effort with confidence > 0.80, OR a       | REQUEST_CHANGES |
+//!   |   citability-demoted `High` (confidence > 0.80)      |                 |
 //!   | Only `Low` effort or no floor-counting findings      | APPROVE         |
 //!
-//!   The model can never soften a Critical, High, or confident-Medium finding
-//!   below the floor — none of the three tiers above are subject to the
-//!   APPROVE-review_body reconciliation cap.
+//!   The model can never soften an escalation-eligible Critical/High or a
+//!   confident-Medium finding below the floor. #PR84 (citability gate): a `High`
+//!   finding drives the BLOCK floor ONLY when it is escalation-eligible — backed
+//!   by a `source_citation` OR flagged `code_provable` (a core
+//!   algorithmic-correctness bug provable from the diff). A non-citable, non-diff-
+//!   provable `High` finding (external framework/library/platform speculation) is
+//!   demoted to the advisory Medium tier and can NEVER force BLOCK — see
+//!   `is_escalation_eligible` / `drives_block_floor`.
+//!
+//! ### Every BLOCK-emitting site is gated (adversarial-review follow-up)
+//!
+//! An initial version of the #PR84 fix gated ONLY `correctness_floor` (the
+//! severity floor), which left THREE other paths able to reproduce the exact
+//! PR #84 mis-grade unchanged:
+//!
+//!   1. **Model-proposed / grade-implied BLOCK** — `stricter_of(model_proposed,
+//!      floor)` can only RAISE the verdict toward the floor; it could never LOWER
+//!      a model self-reported `verdict:"BLOCK"` (or grade `"F"`, via
+//!      `derive_verdict_with_grade`'s `effective_model`) that itself rested on a
+//!      disqualified High.  **Fixed** in `derive_verdict_with` (this function) —
+//!      see the `has_disqualified_high` sanitization below.  Because this is the
+//!      single choke point every other verdict-deriving call site funnels
+//!      through (`derive_verdict_with_grade`, `mapreduce::reduce`'s worst-chunk
+//!      seed, `verify::rederive_verdict`'s baseline), the fix propagates to all
+//!      of them automatically.
+//!   2. **Map-reduce synthesis floor** (`mapreduce::synthesis::apply_synthesis_floor`)
+//!      — a hand-rolled floor for large diffs that does NOT call `derive_verdict`
+//!      at all; it tested bare `f.effort == Effort::High`.  **Fixed** — now uses
+//!      `drives_block_floor` (Tier 1) with a `correctness_floor`-equivalent
+//!      confidence-gated demotion (Tier 1.5) for a disqualified High.
+//!   3. **Verification re-derivation** (`verify::rederive_verdict`'s
+//!      `any_confirmed_high` baseline selector) — bare `f.effort == Effort::High`
+//!      picked path (a) (preserve `primary_verdict` as a hard floor) regardless
+//!      of citability.  **Fixed** — now requires `drives_block_floor`; a
+//!      confirmed-but-disqualified High falls through to path (a2) instead,
+//!      which still independently re-derives via `derive_verdict` (so it is NOT
+//!      silently dropped, just no longer treated as an unconditional floor).
+//!
+//! ### Second-round adversarial-review fixes (grade consistency + downgrade scope)
+//!
+//! A follow-up review of the four fixes above found two more issues, both fixed:
+//!
+//!   - **MEDIUM — grade/verdict disagreement after a RULE 2 downgrade.** When
+//!     RULE 2 downgrades a self-reported BLOCK, the model's original `grade`
+//!     (e.g. `"F"`) was left untouched by `letter_grade::clamp_grade_to_verdict`,
+//!     which only clamps a grade that is too OPTIMISTIC for the actual
+//!     verdict — a grade too SEVERE (like `F` next to a downgraded
+//!     REQUEST_CHANGES) passed through unchanged, rendering a contradictory
+//!     "Grade: F — Request Changes" heading.  **Fixed**: `derive_verdict_with_grade`
+//!     now calls `letter_grade::reconcile_grade_with_verdict`, which handles
+//!     BOTH directions.
+//!   - **LOW — downgrade scope was broader than necessary.** The RULE 2
+//!     sanitize originally fired on `has_disqualified_high && !has_high` alone,
+//!     which could strip an otherwise-valid, Medium-grounded self-reported
+//!     BLOCK whenever an UNRELATED disqualified High happened to also be
+//!     present.  **Fixed**: the sanitize now additionally requires
+//!     `severity_floor` over the substantive set with disqualified Highs
+//!     excluded to be `Approve` (no OTHER independent grounds) before
+//!     downgrading — see `no_independent_grounds` below. Tested by
+//!     `pr84_disqualified_high_does_not_strip_block_grounded_by_independent_medium`
+//!     and `pr84_disqualified_high_with_only_low_effort_companion_still_downgrades`
+//!     (grade_tests.rs).
 //!
 //! `Verdict::Unknown` is always preserved (pass-through) — the model has
 //! signalled the diff was unassessable and no rule applies.
@@ -109,10 +169,35 @@
 //! `low_confidence_high_effort_finding_still_drives_floor` (PR #1350),
 //! `refuted_high_effort_finding_is_still_excluded` (PR #1350).
 
+use std::sync::LazyLock;
+
+use regex::Regex;
 use tracing::debug;
 
 use crate::models::{Effort, Finding, FindingCategory, Verdict, VerifyOutcome};
-use crate::pipeline::letter_grade::{Grade, clamp_grade_to_verdict, verdict_for_grade};
+use crate::pipeline::letter_grade::{Grade, reconcile_grade_with_verdict, verdict_for_grade};
+
+/// Citation-grammar pattern a `source_citation` must match to be treated as
+/// escalation-eligible (RULE 1 hardening, #PR84 adversarial-review follow-up).
+///
+/// Why: the original #PR84 fix accepted ANY non-blank `source_citation` string,
+/// so a model could re-open the BLOCK floor with a junk/vague string (e.g. "see
+/// the docs", "trust me") that carries no verifiable grounding. Requiring the
+/// citation to match one of the four grammar shapes the prompt actually teaches
+/// (`code:`, `jira:`, `apex:`, `gh:` — see the inline citation grammar in the
+/// system prompt) closes that reopening. This is a SHAPE check only — it does
+/// NOT cross-reference the cited identifier against the actual diff/context
+/// (that would require plumbing the diff/context into `derive_verdict`, a much
+/// larger change); flagged as a residual gap for follow-up validation.
+/// What: matches any of — a `path:line` reference (e.g. `src/handler.ts:42`), a
+/// ticket key (e.g. `IMPL-2026-05-009`, `TICKET-123`), a bare GitHub reference
+/// (`#123`), or a spec-section mark (e.g. `PRD § 4.2`).
+/// Test: `pr84_junk_citation_does_not_reopen_block`,
+/// `high_finding_with_source_citation_still_blocks`.
+static CITATION_GRAMMAR_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"[\w./-]+\.[A-Za-z0-9]+:\d+|\b[A-Z][A-Z0-9]+-\d+\b|#\d+|§\s*\d")
+        .expect("citation grammar regex is a valid literal")
+});
 
 // ─── Confidence thresholds ────────────────────────────────────────────────────
 
@@ -306,6 +391,21 @@ impl Thresholds {
     }
 }
 
+/// Resolve the current `FLOOR_MIN_CONFIDENCE` calibration threshold from the
+/// process environment (adversarial-review follow-up).
+///
+/// Why: the map-reduce synthesis floor (`mapreduce::synthesis::apply_synthesis_floor`)
+/// demotes an ungated High finding to the same confidence-gated REQUEST_CHANGES
+/// tier `correctness_floor` Tier 2 gives it — both floors must apply the SAME
+/// bar, including any operator override via `TRUSTY_REVIEW_FLOOR_MIN_CONFIDENCE`
+/// (#1597), or the two floors could disagree at the threshold boundary.
+/// What: returns `Thresholds::from_env().floor_min`.
+/// Test: exercised transitively by `synthesis_high_confidence_demoted_high_floors_to_request_changes`
+/// in `synthesis_tests.rs`.
+pub(crate) fn floor_min_confidence() -> f32 {
+    Thresholds::from_env().floor_min
+}
+
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /// Compute the final review verdict from the model-proposed verdict and findings.
@@ -384,11 +484,76 @@ fn derive_verdict_with(
         .collect();
 
     // Low-confidence override (ceiling): if ALL substantive findings are advisory-
-    // only (confidence ≤ threshold) AND none are High-effort, the batch is noise.
-    // Override the model down to APPROVE — this specifically prevents APPROVE*
-    // over-fire (Fix 4).  High-effort findings escape this gate: a confirmed
-    // bug with low confidence should still BLOCK, not disappear.
-    let has_high = substantive.iter().any(|f| is_high_severity(f));
+    // only (confidence ≤ threshold) AND none are BLOCK-floor-driving, the batch is
+    // noise.  Override the model down to APPROVE — this specifically prevents
+    // APPROVE* over-fire (Fix 4).  Only an escalation-eligible High finding (cited
+    // or diff-provable) escapes this gate: a confirmed bug with low confidence
+    // should still BLOCK, not disappear.  #PR84: a non-citable High finding
+    // (external framework/platform speculation) is NOT eligible, so it no longer
+    // keeps the batch out of the APPROVE override — it is advisory, not a blocker.
+    let has_high = substantive.iter().any(|f| drives_block_floor(f));
+
+    // #PR84 RULE 2 (adversarial-review crux fix): a model self-reported — or
+    // grade-implied, via `derive_verdict_with_grade`'s `effective_model` —
+    // proposed BLOCK is ITSELF subject to the citability gate, not just the
+    // floor below.  Without this, `stricter_of(model_proposed, floor)` can only
+    // RAISE the verdict from the floor toward the model's proposal; it can never
+    // LOWER a model-proposed BLOCK, so a model that self-reports
+    // `verdict:"BLOCK"` (or `grade:"F"`) purely on the strength of an uncited,
+    // non-diff-provable High finding — the exact PR #84 shape — would pass BLOCK
+    // through completely ungated.  Downgrade the proposal to REQUEST_CHANGES when
+    // a disqualified (high-severity, NOT escalation-eligible) finding is present,
+    // no escalation-eligible High finding is ALSO present to independently
+    // justify BLOCK, AND — adversarial-review LOW-severity scope fix — no OTHER
+    // (non-disqualified) substantive finding independently grounds at least an
+    // advisory-level concern on its own.
+    //
+    // The third condition matters: `has_disqualified_high && !has_high` ALONE
+    // would strip an otherwise-valid self-reported BLOCK whenever a purely
+    // UNRELATED disqualified High happens to co-occur with genuine, separate
+    // grounds (e.g. a confident Medium finding) — an adversarial review found
+    // this could over-fire.  Recomputing `severity_floor` over the substantive
+    // set with disqualified Highs removed answers "is there ANY OTHER reason to
+    // trust the model's escalation, independent of the disqualified finding?" —
+    // if yes (the reduced floor clears APPROVE), the model's BLOCK is preserved
+    // exactly as `grade_model_block_kept_when_no_critical_finding` already
+    // expects; only a disqualified High with NO other grounds at all (the PR #84
+    // shape) triggers the downgrade.
+    //
+    // Deliberately scoped to "a disqualified High finding is present" — NOT
+    // merely "no eligible High finding at all" — so this does not touch:
+    //   - `verify::rederive_verdict`'s infra-failure preservation (path c),
+    //     which intentionally keeps `primary_verdict` on verifier infra failure
+    //     (#726) independent of citability, and is invoked with an EMPTY
+    //     `survivors` list when the only finding was excluded as
+    //     ErrorRefuted/TruncationRefuted — there is no disqualified High for
+    //     this gate to see, so BLOCK correctly survives;
+    //   - a model that escalates to BLOCK past a bare Medium finding (no High
+    //     at all) — a pre-#PR84 "model knows more" pattern unrelated to High-
+    //     severity citability (`grade_model_block_kept_when_no_critical_finding`).
+    let has_disqualified_high = substantive.iter().any(|f| is_disqualified_high(f));
+    let non_disqualified_substantive: Vec<&Finding> = substantive
+        .iter()
+        .filter(|f| !is_disqualified_high(f))
+        .copied()
+        .collect();
+    let no_independent_grounds =
+        severity_floor(&non_disqualified_substantive, thresholds) == Verdict::Approve;
+    let model_proposed = if model_proposed == Verdict::Block
+        && has_disqualified_high
+        && !has_high
+        && no_independent_grounds
+    {
+        debug!(
+            "model-proposed BLOCK rests solely on a disqualified (uncited, \
+             non-diff-provable) High finding, with no other independent grounds \
+             — downgrading to REQUEST_CHANGES (#PR84 RULE 2)"
+        );
+        Verdict::RequestChanges
+    } else {
+        model_proposed
+    };
+
     let threshold = thresholds.low_confidence;
     let all_low_confidence =
         !substantive.is_empty() && substantive.iter().all(|f| f.confidence <= threshold);
@@ -484,8 +649,78 @@ fn is_substantive(f: &Finding, thresholds: &Thresholds) -> bool {
 /// Test: `is_high_severity_matches_high_effort`,
 /// `low_confidence_high_effort_finding_still_drives_floor` (#1350),
 /// `floor_excludes_refuted_and_low_confidence_findings` (#1343).
-fn is_high_severity(f: &Finding) -> bool {
+pub(crate) fn is_high_severity(f: &Finding) -> bool {
     f.effort == Effort::High
+}
+
+/// Return `true` when a finding clears the citability gate and is therefore
+/// eligible to drive the deterministic BLOCK floor (RULE 1, #PR84 calibration).
+///
+/// Why: PR #84 (`duetto-eve-agents` #84) was graded BLOCK/F on a SINGLE finding
+/// the model self-tagged `effort: high` — a FALSE, non-citable claim about
+/// Vercel's routing (contradicted by Vercel's docs and disproven in prod).  The
+/// floor trusted the model's self-reported effort unconditionally and hard-clamped
+/// to BLOCK with no citability check.  The rule: a high/critical finding may
+/// escalate toward BLOCK ONLY if it is either (a) backed by a non-empty
+/// `source_citation` (code location / spec / doc / ticket) OR (b) a CORE
+/// algorithmic-correctness issue argued from the diff itself (a logic/data/security
+/// bug provable from the code under review, flagged `code_provable`).  Non-citable
+/// speculation about external framework/library/platform behavior is NOT eligible;
+/// it is capped at the advisory (Medium) tier and can never force BLOCK.
+/// What: returns true iff `source_citation` is present, non-blank, AND matches
+/// [`CITATION_GRAMMAR_RE`] (a junk/vague string no longer qualifies — hardened
+/// per the adversarial-review follow-up, see the regex doc comment) OR
+/// `code_provable` is set.  Deliberately narrow — this is the ONLY relaxation of
+/// the BLOCK floor and it must not weaken it beyond the two #PR84 rules.
+/// Test: `pr84_uncited_high_finding_does_not_block`,
+/// `high_finding_with_source_citation_still_blocks`,
+/// `high_finding_code_provable_still_blocks`,
+/// `pr84_junk_citation_does_not_reopen_block`.
+pub(crate) fn is_escalation_eligible(f: &Finding) -> bool {
+    let cited = f
+        .source_citation
+        .as_deref()
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+        .is_some_and(|c| CITATION_GRAMMAR_RE.is_match(c));
+    cited || f.code_provable
+}
+
+/// Return `true` when a finding drives the deterministic BLOCK floor: it is
+/// high-severity AND escalation-eligible (RULE 2, #PR84 calibration).
+///
+/// Why: the BLOCK floor must not clamp to BLOCK on a high-effort finding that
+/// fails the citability gate (uncited AND not core-algorithmic-correctness).
+/// Because the floor previously trusted the model's self-reported `effort`
+/// unconditionally, a prompt-only change is not self-enforcing — this predicate is
+/// the deterministic backstop.  A high finding that is NOT escalation-eligible is
+/// demoted to the advisory (Medium) tier by `correctness_floor` rather than
+/// driving BLOCK.  Reused verbatim by the map-reduce synthesis floor
+/// (`mapreduce::synthesis::apply_synthesis_floor`) and the model-proposed-BLOCK
+/// sanitization below, so every BLOCK-emitting site in the pipeline applies the
+/// SAME gate (adversarial-review follow-up — see the module doc's "sites gated"
+/// list).
+/// What: returns `is_high_severity(f) && is_escalation_eligible(f)`.
+/// Test: `pr84_uncited_high_finding_does_not_block` and its citation/code-provable
+/// controls.
+pub(crate) fn drives_block_floor(f: &Finding) -> bool {
+    is_high_severity(f) && is_escalation_eligible(f)
+}
+
+/// Return `true` when a finding is a "disqualified High" — high-severity but
+/// FAILING the citability gate (RULE 1) — the finding class RULE 2 demotes to
+/// the advisory tier instead of letting it drive BLOCK.
+///
+/// Why: this exact predicate was previously inlined at three call sites
+/// (`correctness_floor`'s Tier 2, `derive_verdict_with`'s RULE 2 sanitize scope
+/// check, and the map-reduce synthesis floor's Tier 1.5) — naming it once keeps
+/// all three in agreement and gives a single place to audit the "disqualified"
+/// definition (adversarial-review follow-up, Duplicate Elimination).
+/// What: returns `is_high_severity(f) && !is_escalation_eligible(f)`.
+/// Test: covered transitively by every `#PR84` test in this module and
+/// `synthesis_tests.rs`.
+pub(crate) fn is_disqualified_high(f: &Finding) -> bool {
+    is_high_severity(f) && !is_escalation_eligible(f)
 }
 
 // ─── Floor computation ────────────────────────────────────────────────────────
@@ -554,31 +789,46 @@ fn severity_floor(findings: &[&Finding], thresholds: &Thresholds) -> Verdict {
 /// showed requiring a SECOND corroborating Medium finding before escalating was
 /// the single largest source of the reviewer under-firing REQUEST_CHANGES.
 /// What: applies the three-tier rule set over correctness findings:
-///   1. Any `High`-effort finding → BLOCK
+///   1. Any escalation-eligible `High`-effort finding → BLOCK.  #PR84: a High
+///      finding drives BLOCK ONLY when it clears the citability gate
+///      (`is_escalation_eligible` — cited OR `code_provable`); a non-citable,
+///      non-diff-provable High finding is demoted to Tier 2 (advisory) and can
+///      never force BLOCK.
 ///   2. ≥1 high-confidence (`confidence > FLOOR_MIN_CONFIDENCE`) Medium-effort
-///      finding → REQUEST_CHANGES
+///      finding — OR a High finding demoted by the #PR84 citability gate —
+///      → REQUEST_CHANGES
 ///   3. Only `Low` / no floor-counting findings → APPROVE
 ///
 /// Test: `grade_two_medium_yields_request_changes`,
 ///       `grade_one_medium_yields_request_changes` (#1876),
-///       `grade_advisory_medium_below_floor_threshold_does_not_escalate`.
+///       `grade_advisory_medium_below_floor_threshold_does_not_escalate`,
+///       `pr84_uncited_high_finding_does_not_block`,
+///       `high_finding_with_source_citation_still_blocks`.
 fn correctness_floor(findings: &[&&Finding], thresholds: &Thresholds) -> Verdict {
     if findings.is_empty() {
         return Verdict::Approve;
     }
 
-    // Partition findings by effort tier.
-    let has_high = findings.iter().any(|f| is_high_severity(f));
+    // Partition findings by effort tier.  #PR84: a High-effort finding only
+    // drives the BLOCK floor when it clears the citability gate (cited OR
+    // `code_provable`).  A non-citable, non-diff-provable High finding is external
+    // framework/platform speculation — it is demoted to the advisory (Medium) tier
+    // below and can never force BLOCK.
+    let has_block_high = findings.iter().any(|f| drives_block_floor(f));
 
     // Only count Medium findings whose confidence clears the floor threshold
-    // (#1015: advisory-tier Medium findings must not force REQUEST_CHANGES).
+    // (#1015: advisory-tier Medium findings must not force REQUEST_CHANGES).  A
+    // High finding demoted by the #PR84 citability gate (high-severity but NOT
+    // escalation-eligible) is treated as a Medium here — it may raise the floor to
+    // REQUEST_CHANGES when it is confident, but never to BLOCK.
     let medium_floor = thresholds.floor_min;
-    let has_confident_medium = findings
-        .iter()
-        .any(|f| f.effort == Effort::Medium && f.confidence > medium_floor);
+    let has_confident_medium = findings.iter().any(|f| {
+        let advisory_medium = f.effort == Effort::Medium || is_disqualified_high(f);
+        advisory_medium && f.confidence > medium_floor
+    });
 
-    // Tier 1: any High-effort (critical/high severity) → BLOCK floor.
-    if has_high {
+    // Tier 1: any escalation-eligible High-effort (critical/high severity) → BLOCK.
+    if has_block_high {
         return Verdict::Block;
     }
 
@@ -662,9 +912,13 @@ fn stricter_of(a: Verdict, b: Verdict) -> Verdict {
 /// Special case: when `model_proposed == Unknown`, it is preserved unconditionally
 /// (the model could not assess the diff; grade/floor do not apply).
 ///
-/// Also returns the final grade, clamped by `clamp_grade_to_verdict` so the grade
-/// and verdict never disagree in the output — EXCEPT for `Verdict::Unknown`, which
-/// returns `None` (no letter grade).
+/// Also returns the final grade, reconciled by `letter_grade::reconcile_grade_with_verdict`
+/// (adversarial-review MEDIUM fix — supersedes a bare `clamp_grade_to_verdict` call,
+/// which only handled a grade too OPTIMISTIC for the final verdict; RULE 2 above can
+/// now make `final_verdict` MILDER than what `grade` implies, e.g. self-reported
+/// `grade:"F"` downgraded to REQUEST_CHANGES, so the reconciliation must also cap an
+/// over-severe grade DOWN to agree) so the grade and verdict never disagree in the
+/// output — EXCEPT for `Verdict::Unknown`, which returns `None` (no letter grade).
 ///
 /// ## UNKNOWN ⇒ no letter grade (#1474)
 ///
@@ -711,10 +965,13 @@ pub fn derive_verdict_with_grade(
     // Step 3: apply the severity floor over the effective model proposal.
     let final_verdict = derive_verdict(effective_model, findings);
 
-    // Clamp the grade so it is consistent with the final verdict.  `final_verdict`
-    // is never Unknown here (the Unknown branch returned above), so the clamp always
+    // Reconcile the grade so it is consistent with the final verdict IN BOTH
+    // DIRECTIONS (adversarial-review MEDIUM fix): too-optimistic (existing
+    // `clamp_grade_to_verdict` behaviour) AND too-severe (new — RULE 2 can
+    // downgrade `final_verdict` below what `grade` implies).  `final_verdict`
+    // is never Unknown here (the Unknown branch returned above), so this always
     // yields a real letter grade.
-    let final_grade = clamp_grade_to_verdict(grade, &final_verdict);
+    let final_grade = reconcile_grade_with_verdict(grade, &final_verdict);
 
     (final_verdict, Some(final_grade))
 }

--- a/crates/trusty-review/src/pipeline/grade_tests.rs
+++ b/crates/trusty-review/src/pipeline/grade_tests.rs
@@ -13,8 +13,39 @@ use super::*;
 use crate::models::{Finding, FindingCategory, VerifyOutcome};
 use crate::pipeline::letter_grade::Grade;
 
+/// A finding that is escalation-eligible by default (`code_provable = true`).
+///
+/// Why: these floor tests assert the behaviour of GENUINE findings — a real
+/// correctness/security bug provable from the diff.  Under the #PR84 citability
+/// gate such a finding must be cited or `code_provable` to drive the BLOCK floor,
+/// so the shared helper marks findings `code_provable` to preserve the tests'
+/// original intent ("a real High finding blocks").  The gate itself — that a
+/// non-citable, non-diff-provable High finding is capped at advisory — is
+/// exercised separately by `speculative_finding` (see the #PR84 tests below).
 fn finding(effort: Effort, confidence: f32) -> Finding {
-    Finding::new("src/lib.rs", "test", "desc", "", confidence, effort)
+    let mut f = Finding::new("src/lib.rs", "test", "desc", "", confidence, effort);
+    f.code_provable = true;
+    f
+}
+
+/// A finding with NO escalation grounding: no `source_citation` and NOT
+/// `code_provable` — external framework/library/platform speculation, the PR #84
+/// failure mode.  Under the #PR84 citability gate such a finding may never drive
+/// the BLOCK floor, even at High effort.
+fn speculative_finding(effort: Effort, confidence: f32) -> Finding {
+    // `Finding::new` already defaults `code_provable` to false and
+    // `source_citation` to None; spelled out here for the readers of these tests.
+    let mut f = Finding::new(
+        "src/lib.rs",
+        "framework-claim",
+        "desc",
+        "",
+        confidence,
+        effort,
+    );
+    f.code_provable = false;
+    f.source_citation = None;
+    f
 }
 
 /// Build a method-conformance finding (#1359) at a given effort + confidence.
@@ -1206,5 +1237,422 @@ fn parse_threshold_rejects_invalid_and_out_of_range() {
     assert!(
         approx(parse_threshold(Some("NaN"), 0.5), 0.5),
         "non-finite (NaN) input must fall back to the default"
+    );
+}
+
+// ── #PR84 citability gate (RULE 1 + RULE 2) ──────────────────────────────────
+//
+// Regression coverage for the `duetto-eve-agents` PR #84 mis-grade: trusty-review
+// returned BLOCK / Grade F on a SINGLE finding it self-tagged `effort: high`,
+// `confidence: 0.65`, `verified: confirmed` — a FALSE, non-citable claim about
+// Vercel routing behaviour (contradicted by Vercel's docs, disproven in prod).
+// The deterministic floor trusted the model's self-reported `effort`
+// unconditionally and hard-clamped to BLOCK with no citability check.
+//
+// RULE 1 — a finding may drive the BLOCK floor at high/critical effort ONLY when
+// it is cited (`source_citation`) OR a core-algorithmic-correctness bug provable
+// from the diff (`code_provable`).  RULE 2 — the deterministic BLOCK floor must
+// NOT clamp to BLOCK on a high-effort finding that fails RULE 1.
+
+/// `is_escalation_eligible` truth table (the RULE 1 gate).
+#[test]
+fn is_escalation_eligible_gate_truth_table() {
+    // Uncited, not diff-provable → NOT eligible (the PR #84 shape).
+    assert!(!is_escalation_eligible(&speculative_finding(
+        Effort::High,
+        0.9
+    )));
+
+    // Backed by a non-blank source_citation → eligible.
+    let mut cited = speculative_finding(Effort::High, 0.9);
+    cited.source_citation = Some("src/handler.ts:42".to_string());
+    assert!(is_escalation_eligible(&cited));
+
+    // A blank/whitespace citation is NOT a citation → still NOT eligible.
+    let mut blank = speculative_finding(Effort::High, 0.9);
+    blank.source_citation = Some("   ".to_string());
+    assert!(!is_escalation_eligible(&blank));
+
+    // Flagged code_provable (core algorithmic-correctness) → eligible.
+    let mut provable = speculative_finding(Effort::High, 0.9);
+    provable.code_provable = true;
+    assert!(is_escalation_eligible(&provable));
+}
+
+/// RULE 2 (the PR #84 reproduction): an uncited, non-diff-provable High finding
+/// at confidence 0.65 must NOT force BLOCK.
+///
+/// Why: this is the exact failure — a single `effort: high`, `confidence: 0.65`,
+/// no `source_citation`, not `code_provable` finding hard-clamped the verdict to
+/// BLOCK.  Under the citability gate the finding is advisory.
+///
+/// Softened per adversarial-review item 7: this test no longer hard-pins the
+/// exact non-BLOCK tier.  The real PR #84 finding was `verified: Confirmed`
+/// (confidence not demoted by verification), and a deployment may tune
+/// `TRUSTY_REVIEW_LOW_CONFIDENCE_THRESHOLD` (#1597) away from the 0.65 default —
+/// either could move this specific boundary case between APPROVE and
+/// REQUEST_CHANGES without ever reopening BLOCK.  The invariant this test pins
+/// is `!= Block`; the confidence-boundary companion below additionally checks
+/// just above the override line.
+/// What: model APPROVE* + one speculative High@0.65 → never BLOCK.
+#[test]
+fn pr84_uncited_high_finding_does_not_block() {
+    let findings = vec![speculative_finding(Effort::High, 0.65)];
+    let verdict = derive_verdict(Verdict::ApproveWithReservations, &findings);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "#PR84: an uncited, non-diff-provable High finding must NOT force BLOCK"
+    );
+    assert!(
+        matches!(
+            verdict,
+            Verdict::Approve | Verdict::ApproveWithReservations | Verdict::RequestChanges
+        ),
+        "must land in a non-blocking tier, got {verdict:?}"
+    );
+}
+
+/// Confidence-boundary companion (adversarial-review item 7): just ABOVE the
+/// low-confidence override line (0.65 default), the same uncited High finding
+/// still never reaches BLOCK — the override no longer applies at this
+/// confidence, but RULE 1's citability gate independently caps it below BLOCK.
+#[test]
+fn pr84_uncited_high_finding_just_above_low_confidence_boundary_never_blocks() {
+    let findings = vec![speculative_finding(Effort::High, 0.66)];
+    let verdict = derive_verdict(Verdict::ApproveWithReservations, &findings);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "#PR84: an uncited High finding just above the low-confidence override \
+         line must still never reach BLOCK"
+    );
+}
+
+/// RULE 1 cap: even a CONFIDENT (> 0.80) uncited, non-diff-provable High finding
+/// escalates no further than REQUEST_CHANGES (advisory) — never BLOCK.
+///
+/// Why: RULE 1 caps non-citable framework/platform speculation at low/medium; a
+/// demoted High is treated as a Medium in the floor, so a high-confidence one can
+/// reach REQUEST_CHANGES but the BLOCK tier stays closed to it.
+#[test]
+fn pr84_confident_uncited_high_caps_at_request_changes() {
+    let findings = vec![speculative_finding(Effort::High, 0.85)];
+    let verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::RequestChanges,
+        "#PR84: a confident uncited High is capped at advisory REQUEST_CHANGES"
+    );
+    assert_ne!(verdict, Verdict::Block, "#PR84: it must never reach BLOCK");
+}
+
+/// RULE 2 control (citation): a High finding backed by a `source_citation` STILL
+/// drives the BLOCK floor exactly as before — the gate does not weaken genuine,
+/// grounded blockers.
+#[test]
+fn high_finding_with_source_citation_still_blocks() {
+    let mut f = speculative_finding(Effort::High, 0.65);
+    f.source_citation = Some("src/handler.ts:42".to_string());
+    let verdict = derive_verdict(Verdict::ApproveWithReservations, &[f]);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "a cited High finding must still drive the BLOCK floor"
+    );
+}
+
+/// RULE 2 control (code_provable): a High finding flagged as a core
+/// algorithmic-correctness bug provable from the diff STILL drives BLOCK.
+#[test]
+fn high_finding_code_provable_still_blocks() {
+    let mut f = speculative_finding(Effort::High, 0.65);
+    f.code_provable = true;
+    let verdict = derive_verdict(Verdict::Approve, &[f]);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "a diff-provable High finding must still drive the BLOCK floor"
+    );
+}
+
+/// RULE 2 (author-gated carve-out — deterministic backstop): a risk the PR author
+/// has already documented and gated is, by its nature, non-citable framework
+/// speculation.  The prompt is the primary enforcement (it can read the PR
+/// description and must not re-raise such a risk as blocking); this test shows the
+/// deterministic citability gate is a hard backstop — even a very confident
+/// uncited framework risk can never reach BLOCK, only advisory REQUEST_CHANGES.
+#[test]
+fn pr84_author_gated_framework_risk_does_not_block() {
+    let findings = vec![speculative_finding(Effort::High, 0.95)];
+    let verdict = derive_verdict(Verdict::ApproveWithReservations, &findings);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "#PR84: an author-gated (non-citable) framework risk must never BLOCK"
+    );
+}
+
+// ── #PR84 adversarial-review follow-up: RULE 2 real entry point (item 3) ─────
+//
+// An adversarial review of the first #PR84 fix found the citability gate lived
+// ONLY in `correctness_floor` — `stricter_of(model_proposed, floor)` can only
+// RAISE the verdict from the floor, never LOWER a model self-reported BLOCK.
+// PR #84's review self-reported `verdict: BLOCK`, `grade: F` — the tests above
+// call `derive_verdict(ApproveWithReservations, ...)`, a verdict PR #84 never
+// actually proposed, so they could not have caught this.  These tests reproduce
+// the REAL self-report shape through `derive_verdict_with_grade`, the entry
+// point `runner_helpers.rs` actually calls.
+
+/// The exact PR #84 self-report (`verdict: BLOCK`, `grade: F`) on a single
+/// uncited, non-diff-provable High@0.65 finding must not survive the real
+/// entry point — and (adversarial-review MEDIUM fix) the returned GRADE must
+/// agree with the downgraded verdict, not still read `F`.
+///
+/// At this exact confidence (0.65), `derive_verdict_with`'s pre-existing
+/// low-confidence override collapses the verdict all the way to `Approve`.
+/// Before the MEDIUM fix, `clamp_grade_to_verdict(F, Approve)` left the grade
+/// at `F` unchanged ("APPROVE accepts any grade" only handled the "too
+/// optimistic" direction), producing a contradictory "Grade: F — Approve"
+/// pairing. `letter_grade::reconcile_grade_with_verdict` now also handles the
+/// "too severe" direction, raising the grade to the floor of the ACTUAL
+/// verdict's band.
+#[test]
+fn pr84_real_entry_point_self_reported_block_does_not_survive() {
+    let findings = vec![speculative_finding(Effort::High, 0.65)];
+    let (verdict, grade) = derive_verdict_with_grade(Verdict::Block, Grade::F, &findings);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "#PR84 RULE 2: a self-reported BLOCK/F resting solely on an uncited, \
+         non-diff-provable High finding must not survive derive_verdict_with_grade \
+         — the real entry point the runner calls"
+    );
+    assert_ne!(
+        grade,
+        Some(Grade::F),
+        "adversarial-review MEDIUM fix: the grade must be reconciled consistent \
+         with the downgraded verdict, not still read F"
+    );
+    let g = grade.expect("grade must be Some for a non-Unknown verdict");
+    assert!(
+        verdict_for_grade(g).ordinal() <= verdict.ordinal(),
+        "the grade's implied verdict ({:?}) must never be stricter than the \
+         actual verdict ({verdict:?})",
+        verdict_for_grade(g)
+    );
+}
+
+/// THE CRUX FIX (item 3 acceptance criterion): at a confidence ABOVE the
+/// low-confidence override line — unlike the 0.65 boundary case above, which the
+/// override independently collapses regardless of RULE 2 — a model
+/// self-reported BLOCK/F on an uncited High finding passes COMPLETELY ungated
+/// WITHOUT the RULE 2 sanitization in `derive_verdict_with`:
+/// `stricter_of(Block, floor)` always picks BLOCK regardless of what the floor
+/// computes, because `stricter_of` can only raise a verdict, never lower a
+/// stricter model-proposed one.  This is the test that flips from FAILING (pre
+/// RULE 2 fix) to PASSING (post fix) — confirmed by running it against the
+/// pre-fix code path in the adversarial-review round.
+///
+/// Also asserts the returned GRADE (adversarial-review MEDIUM fix): the
+/// original test ignored `_grade`, which is how the "Grade: F — Request
+/// Changes" contradiction slipped through review.
+#[test]
+fn pr84_real_entry_point_self_reported_block_confident_uncited_downgrades() {
+    let findings = vec![speculative_finding(Effort::High, 0.85)];
+    let (verdict, grade) = derive_verdict_with_grade(Verdict::Block, Grade::F, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::RequestChanges,
+        "#PR84 RULE 2 crux: a confident (>0.65) self-reported BLOCK/F resting \
+         solely on an uncited, non-diff-provable High finding must downgrade to \
+         REQUEST_CHANGES — without RULE 2 this returns BLOCK unconditionally"
+    );
+    assert_ne!(verdict, Verdict::Block);
+    assert_ne!(
+        grade,
+        Some(Grade::F),
+        "adversarial-review MEDIUM fix: grade F must not survive alongside a \
+         downgraded REQUEST_CHANGES verdict — 'Grade: F — Request Changes' is a \
+         contradictory heading posting.rs would otherwise render"
+    );
+    let g = grade.expect("grade must be Some for a non-Unknown verdict");
+    assert!(
+        verdict_for_grade(g).ordinal() <= verdict.ordinal(),
+        "the grade's implied verdict ({:?}) must never be stricter than the \
+         actual verdict ({verdict:?})",
+        verdict_for_grade(g)
+    );
+}
+
+/// Control: a citable/diff-provable High finding STILL forces BLOCK through the
+/// real entry point, keeping BOTH `verdict: Block` AND `grade: F` — RULE 2 (and
+/// its MEDIUM grade-reconciliation companion) must not weaken a genuine,
+/// grounded self-reported BLOCK.
+#[test]
+fn pr84_real_entry_point_self_reported_block_with_citation_still_blocks() {
+    let mut f = speculative_finding(Effort::High, 0.85);
+    f.source_citation = Some("src/handler.ts:42".to_string());
+    let (verdict, grade) = derive_verdict_with_grade(Verdict::Block, Grade::F, &[f]);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "a cited High finding must still BLOCK through derive_verdict_with_grade"
+    );
+    assert_eq!(
+        grade,
+        Some(Grade::F),
+        "a genuine, grounded BLOCK must keep grade F — the MEDIUM fix must not \
+         soften a legitimately consistent BLOCK/F pairing"
+    );
+}
+
+// ── #PR84 adversarial-review follow-up: recall lock (item 4) ─────────────────
+
+/// A genuine, high-confidence auth-bypass finding correctly flagged
+/// `code_provable: true` (as the strengthened prompt instructs — see the stock
+/// system prompt's citable-findings-gate worked example) still drives BLOCK.
+/// Locks the RECALL path: the citability gate must not cost real detection when
+/// the model correctly self-tags a genuine bug.
+#[test]
+fn code_provable_auth_bypass_locks_recall_to_block() {
+    let mut f = speculative_finding(Effort::High, 0.95);
+    f.code_provable = true;
+    let verdict = derive_verdict(Verdict::Block, &[f]);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "a high-confidence auth-bypass finding correctly flagged code_provable \
+         must still BLOCK — locks the recall path for genuine bugs"
+    );
+}
+
+/// Companion (the residual tradeoff, made explicit): the SAME auth-bypass
+/// finding, but with `code_provable` omitted (defaults to `false` via
+/// `#[serde(default)]` — the non-strict Bedrock provider path) is demoted from
+/// BLOCK.  This is the accepted "no BLOCK without empirical proof" tradeoff
+/// (fail-open on citability is intentional per RULE 2); the strengthened prompt
+/// wording (worked example) is the mitigation, not a deterministic guarantee —
+/// flagged for dry-run/shadow validation.
+#[test]
+fn code_provable_omitted_demotes_auth_bypass_from_block() {
+    let f = speculative_finding(Effort::High, 0.95); // code_provable defaults false
+    let verdict = derive_verdict(Verdict::Block, &[f]);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "#PR84 residual tradeoff: an uncited High finding with code_provable \
+         omitted (non-strict provider default) is demoted — even a genuine bug \
+         is capped at advisory unless the model sets code_provable or cites it"
+    );
+}
+
+// ── #PR84 adversarial-review follow-up: junk-citation hardening (item 5) ─────
+
+/// A junk/vague `source_citation` that does NOT match the citation grammar (no
+/// path:line, ticket key, `#issue`, or spec section) must NOT reopen the BLOCK
+/// floor — closes the reopening an adversarial review found in the original
+/// "any non-blank string qualifies" rule.
+#[test]
+fn pr84_junk_citation_does_not_reopen_block() {
+    let mut f = speculative_finding(Effort::High, 0.9);
+    f.source_citation = Some("see the docs, trust me".to_string());
+    assert!(
+        !is_escalation_eligible(&f),
+        "a junk citation with no grammar-matching identifier must not qualify"
+    );
+    let verdict = derive_verdict(Verdict::Block, &[f]);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "#PR84: a junk/vague source_citation must not reopen the BLOCK floor"
+    );
+}
+
+/// Grammar-matching citation shapes DO qualify — the hardening is a shape check,
+/// not a blanket rejection of citations.
+#[test]
+fn citation_grammar_accepts_documented_shapes() {
+    let shapes = [
+        "src/handler.ts:42",     // path:line
+        "IMPL-2026-05-009 WP-9", // ticket key (prompt's own documented example)
+        "TICKET-123",            // bare ticket key
+        "#123",                  // GitHub issue/PR
+        "PRD § 4.2",             // spec section
+    ];
+    for shape in shapes {
+        let mut f = speculative_finding(Effort::High, 0.9);
+        f.source_citation = Some(shape.to_string());
+        assert!(
+            is_escalation_eligible(&f),
+            "citation shape {shape:?} must match the citation grammar"
+        );
+    }
+}
+
+// ── #PR84 adversarial-review follow-up: downgrade-scope tightening (item 2/LOW) ─
+//
+// The RULE 2 sanitize (`has_disqualified_high && !has_high`) previously fired
+// whenever ANY disqualified High co-occurred with a model-proposed BLOCK — even
+// when the model's BLOCK was independently grounded by OTHER, genuine evidence
+// (e.g. a confident Medium finding).  An unrelated disqualified High could strip
+// an otherwise-valid, Medium-grounded self-reported BLOCK.  Fixed (the
+// "preferred" option from the review): the sanitize now ALSO requires that
+// `severity_floor` over the substantive set WITH disqualified Highs excluded is
+// `Approve` — i.e. no other finding independently grounds even an advisory-level
+// concern — before downgrading.
+
+/// The exact PR #84 shape (disqualified High is the SOLE grounds) still
+/// downgrades — the scope tightening must not defang the crux fix.
+#[test]
+fn pr84_sole_disqualified_high_still_downgrades() {
+    let findings = vec![speculative_finding(Effort::High, 0.85)];
+    let verdict = derive_verdict(Verdict::Block, &findings);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "a disqualified High with NO other grounds must still downgrade a \
+         self-reported BLOCK"
+    );
+}
+
+/// The LOW-severity fix itself: an UNRELATED disqualified High must NOT strip a
+/// self-reported BLOCK that is independently grounded by a confident,
+/// non-disqualified Medium finding — the Medium alone already floors to at
+/// least REQUEST_CHANGES, so the model's BLOCK is trusted exactly as
+/// `grade_model_block_kept_when_no_critical_finding` already expects when no
+/// disqualified High is involved at all.
+#[test]
+fn pr84_disqualified_high_does_not_strip_block_grounded_by_independent_medium() {
+    let findings = vec![
+        finding(Effort::Medium, 0.9),            // genuine, independent grounds
+        speculative_finding(Effort::High, 0.85), // unrelated disqualified High
+    ];
+    let verdict = derive_verdict(Verdict::Block, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "#PR84 LOW fix: an unrelated disqualified High must not strip a \
+         self-reported BLOCK that is independently grounded by a confident, \
+         non-disqualified Medium finding"
+    );
+}
+
+/// Companion: when the ONLY other findings are Low-effort (no meaningful
+/// independent grounds), the disqualified High still downgrades the BLOCK — a
+/// Low finding does not count as "independent grounds" any more than no
+/// finding at all.
+#[test]
+fn pr84_disqualified_high_with_only_low_effort_companion_still_downgrades() {
+    let findings = vec![
+        finding(Effort::Low, 0.9),
+        speculative_finding(Effort::High, 0.85),
+    ];
+    let verdict = derive_verdict(Verdict::Block, &findings);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "a Low-effort companion finding provides no independent grounds — the \
+         disqualified High must still downgrade the BLOCK"
     );
 }

--- a/crates/trusty-review/src/pipeline/letter_grade.rs
+++ b/crates/trusty-review/src/pipeline/letter_grade.rs
@@ -277,6 +277,67 @@ pub fn clamp_grade_to_verdict(grade: Grade, actual_verdict: &Verdict) -> Grade {
     }
 }
 
+/// Reconcile a grade with an already-decided verdict in BOTH directions
+/// (#PR84 RULE 2 adversarial-review MEDIUM fix).
+///
+/// Why: `clamp_grade_to_verdict` only clamps a grade that is too OPTIMISTIC
+/// relative to `actual_verdict` (implies a MILDER verdict than what actually
+/// happened) — correct pre-RULE-2, when `grade::derive_verdict` could only
+/// STRICTEN the model/grade-implied verdict via the severity floor, never
+/// soften it, so the actual verdict was never milder than what a strict grade
+/// implied. RULE 2 (`grade::derive_verdict_with`'s citability gate on a
+/// self-reported BLOCK) — and the pre-existing low-confidence override — can
+/// now produce a `final_verdict` MILDER than what `grade` implies: e.g. the
+/// model self-reports `grade: "F"` (implies BLOCK) on a single uncited,
+/// non-diff-provable High finding; RULE 2 downgrades the verdict to
+/// REQUEST_CHANGES, but `clamp_grade_to_verdict(F, RequestChanges)` leaves `F`
+/// UNCHANGED — `is_at_least_as_strict(Block, RequestChanges)` is `true`, so the
+/// early-return guard skips clamping entirely — producing a contradictory
+/// "Grade: F — Request Changes" heading in the posted review (`posting.rs`
+/// renders both), violating the documented invariant that grade and verdict
+/// never disagree except UNKNOWN.
+/// What: when `grade`'s implied verdict is STRICTER than `actual_verdict`,
+/// returns the WORST (strictest) grade still within `actual_verdict`'s band —
+/// the mirror of `clamp_grade_to_verdict`'s "cap to the BEST grade in band"
+/// direction. Otherwise delegates to [`clamp_grade_to_verdict`] unchanged
+/// (handles the "too optimistic" direction and the already-consistent case
+/// identically to before this fix).
+/// Test: `pr84_real_entry_point_self_reported_block_confident_uncited_downgrades`
+/// (grade_tests.rs — the reproduction), `reconcile_grade_caps_too_strict_grade_down`,
+/// `reconcile_grade_delegates_when_too_optimistic`,
+/// `reconcile_grade_noop_when_consistent` (letter_grade_tests.rs).
+pub fn reconcile_grade_with_verdict(grade: Grade, actual_verdict: &Verdict) -> Grade {
+    let grade_verdict = verdict_for_grade(grade);
+    if verdict_ordinal(&grade_verdict) > verdict_ordinal(actual_verdict) {
+        // Grade is too STRICT (severe) for the actual verdict — raise it to the
+        // worst grade still consistent with `actual_verdict`'s band.
+        floor_grade_for_verdict(actual_verdict)
+    } else {
+        // Grade is already consistent, or too OPTIMISTIC — existing clamp
+        // handles both (a no-op in the "already consistent" case).
+        clamp_grade_to_verdict(grade, actual_verdict)
+    }
+}
+
+/// The WORST (strictest) grade still within `verdict`'s band — the floor,
+/// mirroring `clamp_grade_to_verdict`'s per-band ceiling (the best grade).
+///
+/// Why: needed by [`reconcile_grade_with_verdict`] to raise an over-severe
+/// grade (e.g. `F`) up to the strictest grade that still agrees with a milder
+/// `actual_verdict` (e.g. `D-` for REQUEST_CHANGES) rather than leaving it
+/// inconsistent.
+/// What: `APPROVE → B-`, `APPROVE* → C-`, `REQUEST_CHANGES → D-`,
+/// `BLOCK`/`UNKNOWN → F`.
+/// Test: `reconcile_grade_caps_too_strict_grade_down`.
+fn floor_grade_for_verdict(verdict: &Verdict) -> Grade {
+    match verdict {
+        Verdict::Approve => Grade::BMinus,
+        Verdict::ApproveWithReservations => Grade::CMinus,
+        Verdict::RequestChanges => Grade::DMinus,
+        Verdict::Block | Verdict::Unknown => Grade::F,
+    }
+}
+
 // ─── Shallow-clean-review detection (#1877) ──────────────────────────────────
 
 /// Heuristic output-token floor per character of diff sent to the reviewer,

--- a/crates/trusty-review/src/pipeline/letter_grade_tests.rs
+++ b/crates/trusty-review/src/pipeline/letter_grade_tests.rs
@@ -221,6 +221,82 @@ fn clamp_grade_to_verdict_stricter_grade_kept() {
     assert_eq!(clamped, Grade::DMinus);
 }
 
+// ── reconcile_grade_with_verdict (#PR84 RULE 2 adversarial-review MEDIUM fix) ──
+
+/// The reproduction: grade `F` (implies BLOCK) alongside an actual verdict of
+/// REQUEST_CHANGES (RULE 2 downgraded a self-reported BLOCK) must be capped
+/// DOWN to the strictest grade still consistent with REQUEST_CHANGES (D-) —
+/// NOT left at F.  `clamp_grade_to_verdict` alone leaves it at F (verified: the
+/// bare `clamp_grade_to_verdict(F, RequestChanges)` call below still returns F,
+/// confirming this is genuinely a new code path, not a redundant assertion).
+#[test]
+fn reconcile_grade_caps_too_strict_grade_down() {
+    // Confirms clamp_grade_to_verdict alone does NOT fix this (the bug this
+    // test guards against).
+    assert_eq!(
+        clamp_grade_to_verdict(Grade::F, &Verdict::RequestChanges),
+        Grade::F,
+        "sanity: clamp_grade_to_verdict alone leaves an over-severe grade unchanged"
+    );
+
+    let reconciled = reconcile_grade_with_verdict(Grade::F, &Verdict::RequestChanges);
+    assert_eq!(
+        reconciled,
+        Grade::DMinus,
+        "an over-severe grade F must be raised to D- (the floor of the \
+         REQUEST_CHANGES band) when the actual verdict is only REQUEST_CHANGES"
+    );
+    assert_eq!(verdict_for_grade(reconciled), Verdict::RequestChanges);
+}
+
+/// Every band's floor grade, for completeness.
+#[test]
+fn reconcile_grade_caps_too_strict_grade_down_every_band() {
+    assert_eq!(
+        reconcile_grade_with_verdict(Grade::F, &Verdict::Approve),
+        Grade::BMinus
+    );
+    assert_eq!(
+        reconcile_grade_with_verdict(Grade::F, &Verdict::ApproveWithReservations),
+        Grade::CMinus
+    );
+    assert_eq!(
+        reconcile_grade_with_verdict(Grade::F, &Verdict::RequestChanges),
+        Grade::DMinus
+    );
+    assert_eq!(
+        reconcile_grade_with_verdict(Grade::F, &Verdict::Block),
+        Grade::F
+    );
+}
+
+/// The "too optimistic" direction still delegates to `clamp_grade_to_verdict`
+/// unchanged — this fix must not alter existing behaviour for that direction.
+#[test]
+fn reconcile_grade_delegates_when_too_optimistic() {
+    assert_eq!(
+        reconcile_grade_with_verdict(Grade::A, &Verdict::Block),
+        clamp_grade_to_verdict(Grade::A, &Verdict::Block),
+    );
+    assert_eq!(
+        reconcile_grade_with_verdict(Grade::A, &Verdict::Block),
+        Grade::F
+    );
+}
+
+/// A grade already consistent with the actual verdict is returned unchanged.
+#[test]
+fn reconcile_grade_noop_when_consistent() {
+    assert_eq!(
+        reconcile_grade_with_verdict(Grade::BMinus, &Verdict::Approve),
+        Grade::BMinus
+    );
+    assert_eq!(
+        reconcile_grade_with_verdict(Grade::F, &Verdict::Block),
+        Grade::F
+    );
+}
+
 // ── is_shallow_clean_review (#1877) ───────────────────────────────────────────
 
 /// A large diff (well above the min-diff-len floor) approved with zero

--- a/crates/trusty-review/src/pipeline/mapreduce/reduce_tests.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/reduce_tests.rs
@@ -16,8 +16,17 @@ fn cfg() -> MapReduceConfig {
     MapReduceConfig::default()
 }
 
+/// A finding that is escalation-eligible by default (`code_provable = true`).
+///
+/// Why: (#PR84 adversarial-review follow-up) `derive_verdict`'s BLOCK floor now
+/// requires a High-effort finding to be escalation-eligible (cited or
+/// diff-provable) to drive BLOCK.  These reduce-stage tests model GENUINE,
+/// diff-provable bugs (e.g. an auth-bypass description), so the shared helper
+/// marks them `code_provable` to preserve each test's original intent.
 fn finding(file: &str, kind: &str, desc: &str, conf: f32, effort: Effort) -> Finding {
-    Finding::new(file, kind, desc, "", conf, effort)
+    let mut f = Finding::new(file, kind, desc, "", conf, effort);
+    f.code_provable = true;
+    f
 }
 
 fn reviewed(file: &str, verdict: Verdict, findings: Vec<Finding>) -> MapOutcome {

--- a/crates/trusty-review/src/pipeline/mapreduce/synthesis.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/synthesis.rs
@@ -13,9 +13,12 @@
 //! makes ONE additional LLM call asking the model to judge the PR holistically
 //! (given the deduped finding list and per-chunk verdicts), and returns a new
 //! `ReducedReview` whose `verdict`, `grade`, and `summary` come from the synthesis
-//! response.  The two-tier safety floor is re-applied after synthesis (#1665):
-//! any non-refuted `Effort::High` finding floors the verdict to at least BLOCK;
-//! failing that, a mechanical BLOCK floors the synthesis verdict to at least
+//! response.  The safety floor is re-applied after synthesis (#1665; re-gated for
+//! the #PR84 adversarial-review follow-up): any non-refuted, escalation-eligible
+//! High finding (cited or diff-provable — see `grade::drives_block_floor`) floors
+//! the verdict to at least BLOCK; a disqualified (uncited, non-diff-provable)
+//! High is demoted to at least REQUEST_CHANGES when confident, never BLOCK;
+//! failing both, a mechanical BLOCK floors the synthesis verdict to at least
 //! REQUEST_CHANGES (so synthesis cannot de-escalate BLOCK to APPROVE/APPROVE*).
 //! The count-based Medium floor is deliberately omitted — the LLM has already
 //! holistically judged those findings.  Any synthesis error causes a graceful
@@ -32,7 +35,7 @@ use tracing::{debug, info, warn};
 use crate::{
     config::mapreduce::MapReduceConfig,
     llm::{ChatMessage, LlmProvider, LlmRequest},
-    models::{Effort, Finding, Verdict},
+    models::{Finding, Verdict},
     pipeline::{letter_grade::Grade, mapreduce::map::MapContext},
 };
 
@@ -262,64 +265,85 @@ struct ParsedSynthesis {
 
 // ─── Two-tier synthesis floor ─────────────────────────────────────────────────
 
-/// Apply the two-tier synthesis floor after the synthesis LLM call (#1665).
+/// Apply the citability-gated synthesis floor after the synthesis LLM call
+/// (#1665; re-gated for the #PR84 adversarial-review follow-up).
 ///
 /// Why: the synthesis LLM has holistically judged the PR; re-applying the full
 /// `derive_verdict` (which includes the count-based `≥2 Medium →
 /// REQUEST_CHANGES` floor) would undo the calibration the synthesis was designed
-/// to provide.  Two non-negotiable floors remain (#1665, decided policy):
+/// to provide.  Non-negotiable floors remain (#1665, decided policy), now gated
+/// by the SAME citability rule as `grade::correctness_floor` — this is a live
+/// path for large diffs (`runner.rs` → `run_mapreduce_branch` →
+/// `synthesize_review`), and an adversarial review found the original bare
+/// `f.effort == Effort::High` test here left the exact PR #84 mis-grade fully
+/// reproducible on this path even after `correctness_floor` was fixed:
 ///
-///   **Tier 1 — High finding → BLOCK:**
-///   ANY non-refuted `Effort::High` finding must floor the verdict to at least
-///   BLOCK.  Critical findings cannot be forgiven by synthesis — that would be a
-///   safety hole.  This matches the unified path's `correctness_floor` semantics
-///   (`Effort::High` is the only severity above Medium; there is no separate
-///   `Critical` variant).
+///   **Tier 1 — escalation-eligible High finding → BLOCK:**
+///   ANY non-refuted High finding that is escalation-eligible
+///   (`grade::drives_block_floor` — cited or `code_provable`) must floor the
+///   verdict to at least BLOCK.  Critical, well-grounded findings cannot be
+///   forgiven by synthesis — that would be a safety hole.
+///
+///   **Tier 1.5 — disqualified High finding, confident → REQUEST_CHANGES:**
+///   A High finding that FAILS the citability gate (uncited, non-diff-provable —
+///   the PR #84 shape) can never floor to BLOCK here, mirroring
+///   `correctness_floor` Tier 2's demoted-High treatment exactly: when its
+///   confidence clears `grade::floor_min_confidence()`, it still floors to at
+///   least REQUEST_CHANGES (advisory, not silently dropped).
 ///
 ///   **Tier 2 — mechanical BLOCK → at least REQUEST_CHANGES:**
-///   If no High finding is present but the mechanical (pre-synthesis) verdict was
-///   `Verdict::Block`, synthesis may de-escalate BLOCK → REQUEST_CHANGES but MUST
-///   NOT de-escalate BLOCK → APPROVE or APPROVE*.  A per-chunk BLOCK without a
-///   High finding is typically driven by a Medium-count heuristic; an LLM
-///   holistically judging those nits minor is permitted — but the human reviewer
-///   must at minimum be informed via REQUEST_CHANGES, not silently APPROVED.
+///   If neither tier above applies but the mechanical (pre-synthesis) verdict
+///   was `Verdict::Block`, synthesis may de-escalate BLOCK → REQUEST_CHANGES but
+///   MUST NOT de-escalate BLOCK → APPROVE or APPROVE*.  (`mechanical_verdict`
+///   itself already passed through `derive_verdict`'s own #PR84 gate, so this
+///   tier cannot reintroduce an ungated BLOCK.)
 ///
-///   **Tier 3 — no floor:** when neither condition above applies, synthesis may
-///   soften the verdict freely (e.g. REQUEST_CHANGES → APPROVE is allowed for
-///   non-BLOCK mechanical verdicts with no High findings).
+///   **Tier 3 — no floor:** when no condition above applies, synthesis may
+///   soften the verdict freely.
 ///
 /// What: given `synthesized` (the LLM's raw output), `findings` (the deduped
 /// finding set), and `mechanical_verdict` (the deterministic pre-synthesis
 /// verdict captured before synthesis ran):
-///   - Returns `BLOCK` when `has_unrefuted_high`.
-///   - Returns `max_by_ordinal(synthesized, REQUEST_CHANGES)` when
-///     `mechanical_verdict == Block` (and no High finding).
+///   - Returns `BLOCK` when an unrefuted, escalation-eligible High is present.
+///   - Returns `max_by_ordinal(synthesized, REQUEST_CHANGES)` when a disqualified
+///     High is present at confident confidence, or when `mechanical_verdict ==
+///     Block`.
 ///   - Otherwise returns `synthesized` unchanged.
 ///
 /// Test: `synthesis_high_severity_still_floors`,
 /// `synthesis_block_without_high_finding_floors_to_request_changes`,
-/// `synthesis_mechanical_rc_allows_full_softening` in synthesis_tests.rs.
+/// `synthesis_mechanical_rc_allows_full_softening`,
+/// `synthesis_pr84_uncited_high_does_not_block` (adversarial-review follow-up),
+/// `synthesis_confident_uncited_high_floors_to_request_changes` in
+/// synthesis_tests.rs.
 pub(crate) fn apply_synthesis_floor(
     synthesized: Verdict,
     findings: &[Finding],
     mechanical_verdict: &Verdict,
 ) -> Verdict {
     use crate::models::VerifyOutcome;
+    use crate::pipeline::grade::{
+        drives_block_floor, floor_min_confidence, is_escalation_eligible, is_high_severity,
+    };
 
-    // A refuted finding is disproven — never counts toward any floor.
-    let has_unrefuted_high = findings.iter().any(|f| {
-        f.effort == Effort::High
-            && !matches!(
-                f.verified,
-                Some(VerifyOutcome::Refuted)
-                    | Some(VerifyOutcome::ErrorRefuted { .. })
-                    | Some(VerifyOutcome::TruncationRefuted)
-            )
-    });
+    let not_refuted = |f: &&Finding| {
+        !matches!(
+            f.verified,
+            Some(VerifyOutcome::Refuted)
+                | Some(VerifyOutcome::ErrorRefuted { .. })
+                | Some(VerifyOutcome::TruncationRefuted)
+        )
+    };
+
+    // #PR84 RULE 1/2: only an escalation-eligible (cited or diff-provable)
+    // unrefuted High finding floors to BLOCK — mirrors `correctness_floor`
+    // Tier 1 exactly.  A refuted finding is disproven — never counts toward any
+    // floor, gated or not.
+    let has_unrefuted_high = findings.iter().filter(not_refuted).any(drives_block_floor);
 
     if has_unrefuted_high {
-        // Tier 1: BLOCK is the minimum for a critical finding — take the stricter
-        // of the synthesized verdict and BLOCK.
+        // Tier 1: BLOCK is the minimum for a critical, well-grounded finding —
+        // take the stricter of the synthesized verdict and BLOCK.
         if synthesized.ordinal() < Verdict::Block.ordinal() {
             debug!(
                 synthesis_verdict = %synthesized,
@@ -330,9 +354,31 @@ pub(crate) fn apply_synthesis_floor(
         return synthesized;
     }
 
+    // Tier 1.5 (#PR84 adversarial-review follow-up): a High finding that FAILS
+    // the citability gate (uncited, non-diff-provable) can never floor to BLOCK
+    // — but it is not silently dropped either.  Mirrors `correctness_floor`
+    // Tier 2's demoted-High treatment: when confident enough
+    // (`confidence > floor_min_confidence()`), it still floors to at least
+    // REQUEST_CHANGES.
+    let has_confident_disqualified_high = findings.iter().filter(not_refuted).any(|f| {
+        is_high_severity(f) && !is_escalation_eligible(f) && f.confidence > floor_min_confidence()
+    });
+
+    if has_confident_disqualified_high && synthesized.ordinal() < Verdict::RequestChanges.ordinal()
+    {
+        debug!(
+            synthesis_verdict = %synthesized,
+            "synthesis floor tier-1.5: confident High finding failed the citability \
+             gate (uncited, non-diff-provable) — demoted to REQUEST_CHANGES, not BLOCK \
+             (#PR84 adversarial-review follow-up)"
+        );
+        return Verdict::RequestChanges;
+    }
+
     if *mechanical_verdict == Verdict::Block {
-        // Tier 2: mechanical BLOCK without High finding — synthesis may de-escalate
-        // BLOCK → REQUEST_CHANGES but NOT further toward APPROVE.
+        // Tier 2: mechanical BLOCK without an escalation-eligible High finding —
+        // synthesis may de-escalate BLOCK → REQUEST_CHANGES but NOT further
+        // toward APPROVE.
         if synthesized.ordinal() < Verdict::RequestChanges.ordinal() {
             debug!(
                 synthesis_verdict = %synthesized,

--- a/crates/trusty-review/src/pipeline/mapreduce/synthesis_tests.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/synthesis_tests.rs
@@ -96,7 +96,23 @@ fn stats_one_reviewed() -> MapReduceStats {
     }
 }
 
+/// A finding that is escalation-eligible by default (`code_provable = true`).
+///
+/// Why: (#PR84 adversarial-review follow-up) `apply_synthesis_floor`'s Tier 1
+/// now requires a High-effort finding to be escalation-eligible (cited or
+/// diff-provable — `grade::drives_block_floor`) to drive BLOCK.  These tests
+/// model GENUINE, diff-provable bugs, so the shared helper marks them
+/// `code_provable` to preserve each test's original intent.  The dedicated
+/// #PR84-shape regression tests below use `speculative_finding` instead.
 fn finding(kind: &str, desc: &str, effort: Effort, conf: f32) -> Finding {
+    let mut f = Finding::new("src/a.rs", kind, desc, "", conf, effort);
+    f.code_provable = true;
+    f
+}
+
+/// A finding with NO escalation grounding — external framework/library/platform
+/// speculation, the PR #84 failure mode (adversarial-review follow-up).
+fn speculative_finding(kind: &str, desc: &str, effort: Effort, conf: f32) -> Finding {
     Finding::new("src/a.rs", kind, desc, "", conf, effort)
 }
 
@@ -212,6 +228,79 @@ async fn synthesis_high_severity_still_floors() {
         result.verdict,
         Verdict::Block,
         "High-severity safety floor must prevent synthesis from softening to APPROVE"
+    );
+}
+
+/// #PR84 adversarial-review follow-up (item 1, CRITICAL): the map-reduce
+/// synthesis floor is a live path for large diffs (`runner.rs` →
+/// `run_mapreduce_branch` → `synthesize_review`) that does NOT call
+/// `derive_verdict` at all — it is a hand-rolled floor.  An adversarial review
+/// found the original bare `f.effort == Effort::High` test here left the exact
+/// PR #84 mis-grade fully reproducible on this path even after
+/// `grade::correctness_floor` was fixed.  Reproduces the PR #84 shape (a single
+/// uncited, non-diff-provable High finding) through `apply_synthesis_floor` and
+/// asserts it does NOT force BLOCK.
+#[tokio::test]
+async fn synthesis_pr84_uncited_high_does_not_block() {
+    let findings = vec![speculative_finding(
+        "framework-claim",
+        "unsupported framework routing claim",
+        Effort::High,
+        0.95,
+    )];
+    let reduced = reduced_with_findings(Verdict::Block, findings);
+
+    // Synthesis tries to soften to APPROVE.
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm::new(
+        r#"{"verdict":"APPROVE","grade":"A","summary":"Looks fine overall."}"#,
+    ));
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg()).await;
+
+    assert_ne!(
+        result.verdict,
+        Verdict::Block,
+        "#PR84: an uncited, non-diff-provable High finding must NOT force BLOCK \
+         through the map-reduce synthesis floor"
+    );
+}
+
+/// #PR84 adversarial-review follow-up (item 1) companion: a CONFIDENT
+/// (`> floor_min_confidence()`) uncited High finding demotes to at least
+/// REQUEST_CHANGES through the synthesis floor's Tier 1.5 — mirroring
+/// `correctness_floor` Tier 2's demoted-High treatment — never BLOCK, and never
+/// silently dropped either.
+#[tokio::test]
+async fn synthesis_confident_uncited_high_floors_to_request_changes() {
+    let findings = vec![speculative_finding(
+        "framework-claim",
+        "unsupported framework routing claim",
+        Effort::High,
+        0.95,
+    )];
+    let reduced = reduced_with_findings(Verdict::Approve, findings);
+
+    // Synthesis tries to soften all the way to APPROVE.
+    let llm: Arc<dyn LlmProvider> = Arc::new(FixedLlm::new(
+        r#"{"verdict":"APPROVE","grade":"A","summary":"Looks fine overall."}"#,
+    ));
+    let pm = pr_meta();
+    let context = ReviewContext::default();
+    let voice = VoiceConfig::default();
+    let c = ctx(&pm, &context, &voice);
+
+    let result = synthesize_review(reduced, &llm, &c, &cfg()).await;
+
+    assert_eq!(
+        result.verdict,
+        Verdict::RequestChanges,
+        "#PR84: a confident uncited High finding must floor to REQUEST_CHANGES \
+         (Tier 1.5) through the synthesis path, never BLOCK and never silently \
+         dropped to APPROVE"
     );
 }
 

--- a/crates/trusty-review/src/pipeline/parser.rs
+++ b/crates/trusty-review/src/pipeline/parser.rs
@@ -107,6 +107,13 @@ struct LlmFinding {
     /// fixture — still parse.
     #[serde(default)]
     source_citation: Option<String>,
+    /// Core-algorithmic-correctness flag (#PR84): `true` when the model asserts
+    /// this is a logic/data/security bug provable from the diff itself (not
+    /// external framework/platform speculation).  `#[serde(default)]` → `false`
+    /// (fail-closed) so models that omit it — and every pre-#PR84 fixture — still
+    /// parse and are treated as non-escalation-eligible unless cited.
+    #[serde(default)]
+    code_provable: bool,
 }
 
 // ─── Parsed output ────────────────────────────────────────────────────────────
@@ -353,6 +360,10 @@ fn convert_llm_finding(f: LlmFinding) -> Finding {
     // Carry the spec/ticket source citation through (#1419); normalise
     // empty/whitespace-only strings to None.
     finding.source_citation = f.source_citation.filter(|s| !s.trim().is_empty());
+    // Carry the core-algorithmic-correctness flag through (#PR84); the verdict
+    // floor uses it (OR a source_citation) to decide whether a High finding may
+    // drive the BLOCK floor.
+    finding.code_provable = f.code_provable;
     finding
 }
 

--- a/crates/trusty-review/src/pipeline/prompt.rs
+++ b/crates/trusty-review/src/pipeline/prompt.rs
@@ -161,6 +161,19 @@ pub fn review_response_schema() -> ResponseSchema {
                         "suggested_replacement": {
                             "type": ["string", "null"],
                             "description": "EXACT replacement code for the line(s) at `line`, suitable for a one-click GitHub suggestion block. Provide ONLY when the fix is a concrete code replacement that maps to specific line(s) at this location; otherwise null and describe the fix in `body`. Do NOT include a code fence or surrounding prose — just the literal replacement line(s)."
+                        },
+                        // `code_provable` (#PR84) is a plain boolean added to
+                        // `required` by `enforce_strict_mode` for OpenAI strict.
+                        // It is the core-algorithmic-correctness gate: only a
+                        // `code_provable` OR `source_citation`-backed finding may
+                        // drive the deterministic BLOCK floor at high/critical
+                        // severity (see the prompt's citability rule). Non-strict
+                        // providers / older models that omit it funnel through the
+                        // SAME serde path where `LlmFinding.code_provable` is
+                        // `#[serde(default)]` → `false` (fail-closed).
+                        "code_provable": {
+                            "type": "boolean",
+                            "description": "Set true ONLY when this is a core algorithmic-correctness bug (logic, data, or security) provable from the DIFF ITSELF — a defect you can demonstrate from the code under review. Set false for any claim that rests on external framework/library/platform behavior you cannot cite (put a citation in source_citation instead). A high/critical-severity finding may only BLOCK when code_provable is true OR source_citation is set; uncited framework/platform speculation must NOT be high/critical."
                         }
                     }
                 }

--- a/crates/trusty-review/src/pipeline/prompt_templates.rs
+++ b/crates/trusty-review/src/pipeline/prompt_templates.rs
@@ -64,9 +64,13 @@ mod tests {
         assert!(!SYSTEM_PROMPT_STOCK.ends_with('\n'));
         assert!(!SYSTEM_PROMPT_COVERAGE_GATING.ends_with('\n'));
 
-        // Frozen byte lengths of the original inline literals.
-        assert_eq!(SYSTEM_PROMPT_STOCK.len(), 8811);
-        assert_eq!(SYSTEM_PROMPT_COVERAGE_GATING.len(), 9127);
+        // Frozen byte lengths (updated in #PR84: both prompts gained the
+        // citable-findings gate + author-gated rule + the `code_provable` field
+        // docs; then the daemon-native inline citation grammar — Gap #1 of the
+        // #PR84 follow-up; then the `code_provable` worked examples —
+        // adversarial-review item 4).
+        assert_eq!(SYSTEM_PROMPT_STOCK.len(), 14104);
+        assert_eq!(SYSTEM_PROMPT_COVERAGE_GATING.len(), 14420);
 
         // The coverage-gating variant is distinguished by its coverage-floor note.
         assert!(SYSTEM_PROMPT_COVERAGE_GATING.contains("deterministic\ncoverage floor"));

--- a/crates/trusty-review/src/pipeline/prompt_tests.rs
+++ b/crates/trusty-review/src/pipeline/prompt_tests.rs
@@ -562,6 +562,7 @@ fn review_schema_is_openai_strict_compliant() {
         [
             "body",
             "category",
+            "code_provable",
             "confidence",
             "consequence",
             "file",

--- a/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_mapreduce_tests.rs
@@ -89,7 +89,7 @@ impl LlmProvider for RecordingReviewer {
             // after an LLM synthesis pass.  A Medium finding might be holistically
             // softened by synthesis (the intended calibration); a High finding must
             // ALWAYS floor to BLOCK/REQUEST_CHANGES regardless of synthesis (#1663).
-            r#"{"verdict":"BLOCK","summary":"critical bug","findings":[{"title":"auth-bypass","body":"the build() signature changed and a caller passes null — auth check skipped","severity":"high","confidence":0.95,"file":"src/big.rs","line":1}]}"#
+            r#"{"verdict":"BLOCK","summary":"critical bug","findings":[{"title":"auth-bypass","body":"the build() signature changed and a caller passes null — auth check skipped","severity":"high","confidence":0.95,"file":"src/big.rs","line":1,"code_provable":true}]}"#
         } else {
             r#"{"verdict":"APPROVE","summary":"ok","findings":[]}"#
         };

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -1433,7 +1433,7 @@ async fn envelope_grade_stays_block_when_high_effort_confirmed_1486() {
     let llm_response = r#"Review with confirmed critical finding.
 
 ```json
-{"verdict":"APPROVE","grade":"B-","summary":"Mostly OK","findings":[{"title":"Auth bypass","body":"line 10","severity":"high","confidence":0.95,"file":"src/auth.rs","line":10}]}
+{"verdict":"APPROVE","grade":"B-","summary":"Mostly OK","findings":[{"title":"Auth bypass","body":"line 10","severity":"high","confidence":0.95,"file":"src/auth.rs","line":10,"code_provable":true}]}
 ```"#;
     let (source, _tmp) = local_diff_source("+fn auth(t: &str) {}\n");
     let config = default_config();

--- a/crates/trusty-review/src/pipeline/verify.rs
+++ b/crates/trusty-review/src/pipeline/verify.rs
@@ -48,8 +48,11 @@ use crate::{
         BLOCK_VERDICT_MIN_CONFIDENCE, VERIFY_CANDIDATE_MIN_CONFIDENCE, VERIFY_REFUTED_CONFIDENCE,
     },
     llm::{LlmError, LlmProvider},
-    models::{Effort, Finding, Verdict, VerifyOutcome},
-    pipeline::{grade::derive_verdict, verify_prompt::build_verify_request},
+    models::{Finding, Verdict, VerifyOutcome},
+    pipeline::{
+        grade::{derive_verdict, drives_block_floor},
+        verify_prompt::build_verify_request,
+    },
 };
 
 /// Maximum number of verifier calls to run concurrently.
@@ -267,11 +270,24 @@ fn rederive_verdict(
         .cloned()
         .collect();
 
-    // Does any confirmed (surviving) finding have High effort?
+    // Does any confirmed (surviving) finding drive the BLOCK floor — i.e. is it
+    // High-effort AND escalation-eligible (cited or diff-provable)?
+    //
+    // #PR84 adversarial-review follow-up: this previously used a bare
+    // `f.effort == Effort::High` check, so a CONFIRMED-but-disqualified (uncited,
+    // non-diff-provable) High finding — exactly PR #84's shape post-verification
+    // (`verified: Confirmed`, no citation) — routed to path (a) below and pinned
+    // `primary_verdict` (e.g. a self-reported BLOCK) as a HARD floor.
+    // `derive_verdict`'s own #PR84 gate (in `grade.rs`) already prevents that
+    // baseline from surviving as an outright ungated BLOCK, but path (a) vs (a2)
+    // selection should agree with the unified path's citability rule on its own
+    // merits — using `drives_block_floor` here keeps this call site consistent
+    // with `correctness_floor` / the map-reduce synthesis floor rather than
+    // relying solely on the downstream `derive_verdict` safety net.
     let any_confirmed_high = survivors
         .iter()
         .filter(|f| matches!(f.verified, Some(VerifyOutcome::Confirmed)))
-        .any(|f| f.effort == Effort::High);
+        .any(drives_block_floor);
 
     // Four-way baseline selection (see Why above):
     //  a)  confirmed + at least one High-effort confirmed

--- a/crates/trusty-review/src/pipeline/verify_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_tests.rs
@@ -94,6 +94,11 @@ impl LlmProvider for FailingVerifier {
 fn finding(effort: Effort, confidence: f32) -> Finding {
     let mut f = Finding::new("src/a.rs", "logic", "a bug", "fix it", confidence, effort);
     f.line = Some(10);
+    // #PR84: a genuine High finding must be escalation-eligible (cited or
+    // diff-provable) to drive the BLOCK floor.  These verification tests model
+    // real, diff-provable correctness bugs, so mark them `code_provable` to
+    // preserve their pre-#PR84 BLOCK-floor behaviour.
+    f.code_provable = true;
     f
 }
 
@@ -224,6 +229,36 @@ fn rederive_keeps_confirmed_block() {
         verdict,
         Verdict::Block,
         "a confirmed High finding must keep the BLOCK floor (path a)"
+    );
+}
+
+/// #PR84 adversarial-review follow-up (item 6): a CONFIRMED High finding that
+/// FAILS the citability gate (uncited, non-diff-provable — the exact PR #84
+/// shape post-verification: `verified: Confirmed`, no `source_citation`, not
+/// `code_provable`) must NOT pin `primary_verdict` as a hard BLOCK floor via
+/// path (a) — `any_confirmed_high` now requires `drives_block_floor`, so this
+/// routes to path (a2) instead, which independently re-derives via
+/// `derive_verdict` rather than treating the disqualified confirmation as an
+/// unconditional floor.
+///
+/// Why: previously `any_confirmed_high` used a bare `f.effort == Effort::High`
+/// check, so this exact scenario selected path (a) and pinned `primary_verdict`
+/// (here, a self-reported BLOCK) regardless of citability.  `derive_verdict`'s
+/// own #PR84 RULE 2 gate provides a downstream safety net that already prevents
+/// an outright ungated BLOCK from this path, but the path (a) vs (a2) baseline
+/// selection should independently agree with the citability rule rather than
+/// relying solely on that downstream net.
+#[test]
+fn rederive_confirmed_but_disqualified_high_does_not_pin_block() {
+    let mut f = finding(Effort::High, 0.95);
+    f.code_provable = false; // disqualify: no citation, not diff-provable
+    apply_outcome(&mut f, VerifyOutcome::Confirmed);
+    let verdict = rederive_verdict(Verdict::Block, true, false, &[f]);
+    assert_ne!(
+        verdict,
+        Verdict::Block,
+        "#PR84: a confirmed-but-disqualified (uncited, non-diff-provable) High \
+         finding must not pin primary_verdict as a hard BLOCK floor via path (a)"
     );
 }
 


### PR DESCRIPTION
## Summary

Gates every BLOCK-emitting site in `trusty-review` (model verdict, grade→verdict
mapping, correctness floor, map-reduce synthesis floor, verify re-derivation) on
citability: a BLOCK/Grade-F resting solely on disqualified (uncited AND not
`code_provable`) high-severity findings is downgraded to `REQUEST_CHANGES` with
the grade re-clamped in-band.

- Adds a `code_provable` finding field (default `false`, fail-closed) to
  distinguish core algorithmic-correctness findings from framework speculation.
- Requires `source_citation` to match a citation-grammar shape.
- Adds the inline `[code:]`/`[jira:]`/`[apex:]`/`[gh:]` citation grammar to the
  daemon's base system prompt.
- Encodes the two Duetto grading rules: citable-or-core-correctness, and no
  BLOCK without empirical proof.

Fixes the grading miscalibration identified in PR #84.

## Verification

- `cargo build -p trusty-review` and `cargo test -p trusty-review`: 1380/1380 tests pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- 3 rounds of code review completed prior to this PR

## Known residuals (disclosed, not blocking)

- Junk-citation detection is grammar-shape-only for now (pending diff cross-ref
  to verify citations actually point at real lines).
- `code_provable` recall depends on the model populating the field correctly —
  worth watching in dry-run before fully trusting the downgrade path.

## Test plan

- [x] `cargo test -p trusty-review` — 1380/1380 passing (pre-verified)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (pre-verified)
- [x] `cargo fmt --check` — clean (pre-verified)
- [ ] Watch dry-run grading output post-merge for `code_provable` recall accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)