### PR TITLE
chore(trusty-code): bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10864,7 +10864,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-code"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [0.2.0] — 2026-07-16
 
 ### Added
 

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-code"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version.workspace = true
 # license.workspace resolves to "MIT"; LICENSE is kept in-crate for correctness.


### PR DESCRIPTION
## Summary

- Bump `trusty-code` (binary `tcode`) from `0.1.0` → `0.2.0` (minor — new
  backward-compatible capabilities, no breaking changes).
- Releases four already-merged, live-validated fixes now on `origin/main`:
  - trusty-search index-readiness surfacing for daily-driver sessions
    (#2802, closes #2784)
  - `search_code` lexical fallback when the semantic index stage isn't ready
    (#2801, closes #2783)
  - redundant full-suite test re-run suppression (#2804, closes #2682)
  - bounded PM re-delegation to prevent a degenerate delegate loop (#2805,
    closes #2683)
- CHANGELOG: converted the hand-written `[Unreleased]` section into
  `[0.2.0] — 2026-07-16`. Also manually de-duplicated a bogus full-history
  block that `scripts/generate-changelog.sh` prepended (known issue #2793 —
  git-cliff has no `trusty-code-v0.1.0` tag to scope against, so
  `--unreleased` walked the entire crate history instead of just the delta).

## Investigation: does trusty-common need a release first?

No. PR #2802 added the `search_readiness` module to `trusty-common` (behind
`search-index`), which trusty-code consumes. Verified:
- `trusty-common-v0.23.2` tag (commit `d1db7bed`) was cut *after* PR #2802
  merged (`326aece2`), and `git rev-parse trusty-common-v0.23.2:crates/trusty-common`
  equals `git rev-parse origin/main:crates/trusty-common` (identical tree
  hash) — zero trusty-common code changes since the published 0.23.2.
- crates.io confirms `trusty-common 0.23.2` has been live since
  2026-07-16T04:35:11Z, and it already contains `search_readiness.rs`.
- Root `[workspace.dependencies]` pins
  `trusty-common = { path = "crates/trusty-common", version = "0.23.2" }`,
  so trusty-code's published `Cargo.toml` will require `trusty-common = "0.23.2"`
  (caret) — already satisfiable from crates.io today.

So this PR ships trusty-code alone; trusty-common stays at 0.23.2.

## Test plan

- [x] `cargo build -p trusty-code` — clean
- [x] `cargo test -p trusty-code` — 969 passed, 0 failed, 4 ignored
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations
- [ ] CI green
- [ ] `cargo publish -p trusty-code` from merged main
- [ ] `cargo install --path crates/trusty-code --locked` + `tcode --version` verified post-publish

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools