### PR TITLE
docs(spec): DOC-38 — Spec-Linked Documentation (SLD), a language-agnostic, implementation-neutral standard

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -13,9 +13,10 @@ says *what the code must do*.
 Each spec carries a `DOC-N` document number and one or more stable spec IDs in
 the `SPEC-{SUBSYSTEM}-{NN}~{rev}` grammar (e.g. `SPEC-CONFORMANCE-01~draft`).
 Every governed section anchors its ID with a `{#SPEC-…}` heading marker so that
-source code can link to it via the [Spec-Linked Documentation (SLD)][sld]
-`# Spec References` rustdoc convention, and tooling (the intent-source resolver)
-can resolve a changed file back to the section that governs it.
+any source artifact — code in any language, config, or a Markdown document — can
+link to it via the [Spec-Linked Documentation (SLD)][sld] `# Spec References`
+convention (canonical: [DOC-38](./spec-linked-documentation.md)), and tooling (the
+intent-source resolver) can resolve a changed file back to the section that governs it.
 
 ## Spec catalog
 
@@ -44,6 +45,7 @@ can resolve a changed file back to the section that governs it.
 | DOC-33 | `SPEC-METALOG-01~draft` … `-04~draft` | [tm Meta-Harness Logging — Per-Delegation Observability, Verbosity CLI, and Log Pruning](./tm-meta-harness-logging.md) | trusty-mpm — observability / CLI / log retention |
 | DOC-35 | `SPEC-PROJCTL-01~draft` … `-08~draft` | [`tm project`: Deterministic Project/Session Control Plane (CLI + Multipane TUI)](./tm-project-control-plane.md) | trusty-mpm — control plane / CLI / TUI / daemon API |
 | DOC-36 | `SPEC-TMMGR-01~approved` … `-06~approved` | [`tm manager`: Layer-3 Chat-Based Portfolio Project Manager](./tm-manager-vision.md) | trusty-mpm — daemon / inference layer / external channels |
+| DOC-38 | `SPEC-SLD-01~draft` … `-05~draft` | [Spec-Linked Documentation (SLD): Language-Agnostic Source↔Spec Linkage](./spec-linked-documentation.md) | cross-crate — `docs/specs` conventions + trusty-common `intent_source` (all languages) |
 
 > **Catalog note — `DOC-34` gap.** `DOC-34` (`SPEC-CFGDIR-01~draft`…`-05~draft`,
 > [Managed sessions launch with a tm-owned `CLAUDE_CONFIG_DIR`](./managed-session-config-dir.md))
@@ -56,10 +58,14 @@ can resolve a changed file back to the section that governs it.
 > ([trusty-mpm Self-Awareness](./trusty-mpm-self-awareness.md), the entry above). That
 > file is **not** in this catalog. The collision is flagged here rather than resolved by
 > renumbering the file in-place (its self-label and any inbound references are left
-> untouched); a follow-up should assign it the next free `DOC-N` (currently **DOC-34**
-> — DOC-32 was claimed by [`tool-output-interception-seam.md`](./tool-output-interception-seam.md), issue #1953,
-> and DOC-33 by [`tm-meta-harness-logging.md`](./tm-meta-harness-logging.md), issue #1965)
-> and add a catalog row.
+> untouched); a follow-up should assign it the next free `DOC-N` and add a catalog row.
+> **Next free `DOC-N` = `DOC-39`** (scan of the whole `docs/` tree, 2026-07-16): the
+> highest claimed number is **DOC-38** ([Spec-Linked Documentation](./spec-linked-documentation.md),
+> the entry above). DOC-34 is assigned ([`managed-session-config-dir.md`](./managed-session-config-dir.md),
+> #1999 — still a catalog gap), DOC-35/36/38 are cataloged, and **DOC-37** is
+> self-labeled by [`trusty-search-managed-repo-awareness.md`](./trusty-search-managed-repo-awareness.md)
+> (`SPEC-SEARCHREPO-01~draft`…, uncataloged). The DOC-N assignment rule (scan-before-claim)
+> and collision handling are now normative in [DOC-38 §4.1](./spec-linked-documentation.md#SPEC-SLD-01~draft).
 
 ## Status lifecycle
 
@@ -72,9 +78,16 @@ implementation PR.
 
 ## Spec-Linked Documentation (SLD)
 
-Source code declares which spec section governs it using a module-level
-`//! # Spec References` (or function-level `/// # Spec References`) rustdoc block
-linking the spec ID to its anchor, e.g.:
+**Canonical spec: [DOC-38 — Spec-Linked Documentation](./spec-linked-documentation.md).**
+SLD is the convention by which a **source artifact declares which spec section
+governs it**, so the intent-source resolver (`trusty_common::intent_source`) can
+resolve a changed file back to that section. As of DOC-38, SLD is **language-agnostic**:
+Rust, Python, TypeScript/JavaScript, shell, TOML/YAML, and **Markdown** documents all
+declare linkage via a `# Spec References` block in their native comment/docstring idiom,
+using one canonical `(spec-ID, relative-path, anchor)` reference grammar.
+
+The Rust form is unchanged — a module-level `//! # Spec References` (or function-level
+`/// # Spec References`) rustdoc block linking the spec ID to its anchor:
 
 ```rust
 //! # Spec References
@@ -82,10 +95,11 @@ linking the spec ID to its anchor, e.g.:
 //! - [`SPEC-CONFORMANCE-03~draft`](docs/specs/intent-conformance.md#SPEC-CONFORMANCE-03~draft)
 ```
 
-The intent-source resolver (`trusty_common::intent_source`) reads these blocks
-to resolve a changed file back to the spec section that governs it. It is a
-*reader* of declared links only — it never invents linkage where none is
-declared, and it does **not** enforce a four-status traceability model (that is
-an explicit non-goal, DOC-15 §1.3).
+Markdown documents declare linkage via a **visible `## Spec References` section**
+(DOC-38 §3.6); the other languages use their native comment/docstring idioms
+(DOC-38 §3). The resolver is a *reader* of declared links only — it never invents
+linkage where none is declared, and it does **not** enforce a four-status
+traceability model (an explicit non-goal, DOC-15 §1.3 / DOC-38 §1.3). See DOC-38
+for the normative reference grammar, per-language idioms, and the resolver contract.
 
 [sld]: #spec-linked-documentation-sld

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -14,9 +14,10 @@ Each spec carries a `DOC-N` document number and one or more stable spec IDs in
 the `SPEC-{SUBSYSTEM}-{NN}~{rev}` grammar (e.g. `SPEC-CONFORMANCE-01~draft`).
 Every governed section anchors its ID with a `{#SPEC-…}` heading marker so that
 any source artifact — code in any language, config, or a Markdown document — can
-link to it via the [Spec-Linked Documentation (SLD)][sld] `# Spec References`
-convention (canonical: [DOC-38](./spec-linked-documentation.md)), and tooling (the
-intent-source resolver) can resolve a changed file back to the section that governs it.
+link to it via the [Spec-Linked Documentation (SLD)][sld] standard (canonical:
+[DOC-38](./spec-linked-documentation.md)), and a conforming resolver (e.g.
+trusty-common's `intent_source`) can resolve a changed file back to the section
+that governs it.
 
 ## Spec catalog
 
@@ -45,7 +46,7 @@ intent-source resolver) can resolve a changed file back to the section that gove
 | DOC-33 | `SPEC-METALOG-01~draft` … `-04~draft` | [tm Meta-Harness Logging — Per-Delegation Observability, Verbosity CLI, and Log Pruning](./tm-meta-harness-logging.md) | trusty-mpm — observability / CLI / log retention |
 | DOC-35 | `SPEC-PROJCTL-01~draft` … `-08~draft` | [`tm project`: Deterministic Project/Session Control Plane (CLI + Multipane TUI)](./tm-project-control-plane.md) | trusty-mpm — control plane / CLI / TUI / daemon API |
 | DOC-36 | `SPEC-TMMGR-01~approved` … `-06~approved` | [`tm manager`: Layer-3 Chat-Based Portfolio Project Manager](./tm-manager-vision.md) | trusty-mpm — daemon / inference layer / external channels |
-| DOC-38 | `SPEC-SLD-01~draft` … `-05~draft` | [Spec-Linked Documentation (SLD): Language-Agnostic Source↔Spec Linkage](./spec-linked-documentation.md) | cross-crate — `docs/specs` conventions + trusty-common `intent_source` (all languages) |
+| DOC-38 | `SPEC-SLD-01~draft` … `-03~draft` | [Spec-Linked Documentation (SLD): A Language-Agnostic Source↔Spec Reference Standard](./spec-linked-documentation.md) | documentation standard — repository/language-agnostic (informative reference: trusty-common `intent_source`) |
 
 > **Catalog note — `DOC-34` gap.** `DOC-34` (`SPEC-CFGDIR-01~draft`…`-05~draft`,
 > [Managed sessions launch with a tm-owned `CLAUDE_CONFIG_DIR`](./managed-session-config-dir.md))
@@ -65,7 +66,10 @@ intent-source resolver) can resolve a changed file back to the section that gove
 > #1999 — still a catalog gap), DOC-35/36/38 are cataloged, and **DOC-37** is
 > self-labeled by [`trusty-search-managed-repo-awareness.md`](./trusty-search-managed-repo-awareness.md)
 > (`SPEC-SEARCHREPO-01~draft`…, uncataloged). The DOC-N assignment rule (scan-before-claim)
-> and collision handling are now normative in [DOC-38 §4.1](./spec-linked-documentation.md#SPEC-SLD-01~draft).
+> and collision handling are now normative in [DOC-38 §4.1](./spec-linked-documentation.md#SPEC-SLD-01~draft)
+> (note: `{#SPEC-…}` cross-links are best-effort on github.com — GitHub does not
+> honor explicit heading IDs, DOC-38 §4.3 — so this link lands on the file; scan
+> for §4.1 from there).
 
 ## Status lifecycle
 
@@ -79,12 +83,17 @@ implementation PR.
 ## Spec-Linked Documentation (SLD)
 
 **Canonical spec: [DOC-38 — Spec-Linked Documentation](./spec-linked-documentation.md).**
-SLD is the convention by which a **source artifact declares which spec section
-governs it**, so the intent-source resolver (`trusty_common::intent_source`) can
-resolve a changed file back to that section. As of DOC-38, SLD is **language-agnostic**:
-Rust, Python, TypeScript/JavaScript, shell, TOML/YAML, and **Markdown** documents all
-declare linkage via a `# Spec References` block in their native comment/docstring idiom,
-using one canonical `(spec-ID, relative-path, anchor)` reference grammar.
+SLD is a **pure, implementation-neutral documentation standard** — usable in any
+repository, in any language — by which a **source artifact declares which spec
+section governs it**, so a *conforming resolver* (any tool that reads the
+declaration) can trace a changed file back to that section. DOC-38 defines the
+standard itself: the grammar, not a resolver implementation. As of DOC-38, SLD is
+**language-agnostic**: Rust, Python, TypeScript/JavaScript, shell, and TOML/YAML
+declare linkage inline via a `# Spec References` comment/docstring block in their
+native idiom, using one canonical `(spec-ID, relative-path, anchor)` reference
+grammar; **Markdown documents declare linkage canonically in `spec_refs:` YAML
+frontmatter** (DOC-38 §2.5, §3.6), with an optional visible section retained for
+human readability only.
 
 The Rust form is unchanged — a module-level `//! # Spec References` (or function-level
 `/// # Spec References`) rustdoc block linking the spec ID to its anchor:
@@ -95,11 +104,24 @@ The Rust form is unchanged — a module-level `//! # Spec References` (or functi
 //! - [`SPEC-CONFORMANCE-03~draft`](docs/specs/intent-conformance.md#SPEC-CONFORMANCE-03~draft)
 ```
 
-Markdown documents declare linkage via a **visible `## Spec References` section**
-(DOC-38 §3.6); the other languages use their native comment/docstring idioms
-(DOC-38 §3). The resolver is a *reader* of declared links only — it never invents
+A Markdown document declares the same triple canonically in frontmatter:
+
+```markdown
+---
+spec_refs:
+  - id: SPEC-CONFORMANCE-03~draft
+    path: docs/specs/intent-conformance.md
+    anchor: SPEC-CONFORMANCE-03~draft
+---
+```
+
+A conforming resolver is a *reader* of declared links only — it never invents
 linkage where none is declared, and it does **not** enforce a four-status
-traceability model (an explicit non-goal, DOC-15 §1.3 / DOC-38 §1.3). See DOC-38
-for the normative reference grammar, per-language idioms, and the resolver contract.
+traceability model (an explicit non-goal, DOC-15 §1.3 / DOC-38 §1.3). trusty-common's
+`intent_source` (DOC-15 §6) is one *illustrative* resolver, documented as an
+informative annex in DOC-38 (Annex A), not as part of the standard itself; extending
+it to read SLD references is tracked as a follow-up (DOC-38 §10, F1), not implemented
+by this catalog change. See DOC-38 for the normative reference grammar, the
+frontmatter schema, and the per-language idioms.
 
 [sld]: #spec-linked-documentation-sld

--- a/docs/specs/spec-linked-documentation.md
+++ b/docs/specs/spec-linked-documentation.md
@@ -1,30 +1,42 @@
-# DOC-38 — Spec-Linked Documentation (SLD): Language-Agnostic Source↔Spec Linkage
+---
+spec_refs:
+  - id: SPEC-CONFORMANCE-03~draft
+    path: docs/specs/intent-conformance.md
+    anchor: SPEC-CONFORMANCE-03~draft
+---
+
+# DOC-38 — Spec-Linked Documentation (SLD): A Language-Agnostic Source↔Spec Reference Standard
 
 **Status:** Draft
-**Subsystem:** cross-crate — `docs/specs` conventions + trusty-common `intent_source` resolver (all languages)
+**Subsystem:** documentation standard — repository/language-agnostic (informative reference implementation: trusty-common `intent_source`, Annex A)
 **Owner:** Engineering (trusty-tools platform)
 **Last-updated:** 2026-07-16
-**Spec ID:** `SPEC-SLD-01~draft` … `SPEC-SLD-05~draft` (DOC-38)
+**Spec ID:** `SPEC-SLD-01~draft` … `SPEC-SLD-03~draft` (DOC-38)
 **Epic:** epic: spec-linked documentation, first-class & language-agnostic (umbrella issue to be linked by the PM)
 **Builds on:**
 - The SLD prose and spec-catalog conventions in [`docs/specs/README.md`](./README.md)
   (DOC-N numbering, `SPEC-{SUBSYSTEM}-{NN}~{rev}` grammar, `{#SPEC-…}` anchors,
   Draft→Accepted→Superseded lifecycle, the Rust `# Spec References` rustdoc form).
-- DOC-15 [Intent / Method Conformance](./intent-conformance.md) — the intent-source
-  resolver (ISR, `trusty_common::intent_source`) that *reads* declared SLD links to
-  resolve a changed file back to its governing spec section (§2.4, §6.4).
+- DOC-15 [Intent / Method Conformance](./intent-conformance.md) §6
+  (`SPEC-CONFORMANCE-03~draft`) — a **conforming resolver** (trusty-common's
+  `intent_source`, informative Annex A) *reads* declared SLD links to resolve a
+  changed file back to its governing spec section.
 **Cross-ref:** the `spec-authoring` / `spec-linked-docs` skills cited by DOC-15
 (`intent-conformance.md:13`, §2.4, §6.4) that **do not yet exist** — this spec
-subsumes their normative role and names their authoring as a follow-up (§9, §11).
+subsumes their normative role and names their authoring as a follow-up (Annex B, §10).
 
-> **Scope note.** This is a **conventions + behavior-contract** spec. It promotes
-> Spec-Linked Documentation (SLD) from scattered README prose to a first-class,
-> **language-agnostic** spec: it fixes the spec-document conventions, defines a
-> single canonical source↔spec reference grammar that works in **any** language
-> (and in Markdown), and states the resolver contract that reads those references.
-> It **implements nothing**: the PR carrying this doc opens **no** Rust changes.
-> The resolver extension, the authoring skills, the DOC-28 collision fix, and the
-> retrofit of existing non-Rust files are decomposed into follow-up issues (§11).
+> **Scope note.** This is a **pure documentation standard** — a set of conventions
+> for how any repository, in any language, declares machine-and-human-readable
+> links from source artifacts (code, config, or Markdown) to the spec sections that
+> govern them. The normative body (§§0–8) defines the standard itself: the
+> reference grammar, the frontmatter schema, the per-language declaration idioms,
+> and the spec-authoring conventions (numbering, header, anchors, lifecycle). **It
+> binds no implementation** — it does not require any particular resolver, tool, or
+> language runtime, and it is not scoped to trusty-tools' Rust codebase. Where this
+> document illustrates the standard using trusty-tools as the reference adopter
+> (the `docs/specs/` catalog, `trusty_common::intent_source`), those illustrations
+> are marked **informative** and live in the annexes (Annex A, Annex B) and in §9,
+> not in the normative standard. The PR carrying this doc opens **no** Rust changes.
 
 ---
 
@@ -32,20 +44,21 @@ subsumes their normative role and names their authoring as a follow-up (§9, §1
 
 | Term | Meaning |
 |---|---|
-| **SLD (Spec-Linked Documentation)** | The convention by which a source artifact **declares** which spec section governs it, so tooling can resolve the artifact back to that section. SLD is a *linkage* convention, not a coverage or enforcement mechanism. |
-| **Spec** | A behavior-contract document under `docs/specs/`, carrying a `DOC-N` number and one or more `SPEC-{SUBSYSTEM}-{NN}~{rev}` IDs, each anchored with a `{#SPEC-…}` heading. Specs are the **targets** of SLD references. |
-| **Source artifact** | Any tracked file that can *declare* a spec reference: Rust/Python/TS/JS/shell code, TOML/YAML config, or a **Markdown** document. Sources are the **origins** of SLD references. |
+| **SLD (Spec-Linked Documentation)** | The convention by which a source artifact **declares** which spec section governs it, so a resolver can trace the artifact back to that section. SLD is a *linkage* convention, not a coverage or enforcement mechanism. |
+| **Spec** | A behavior-contract document, carrying a document number and one or more `SPEC-{SUBSYSTEM}-{NN}~{rev}` IDs, each anchored with a `{#SPEC-…}` heading. Specs are the **targets** of SLD references. (Any repository may hold its specs wherever it chooses; trusty-tools' instance is `docs/specs/`, §9.) |
+| **Source artifact** | Any tracked file that can *declare* a spec reference: code in any language, config, or a **Markdown** document. Sources are the **origins** of SLD references. |
 | **Spec reference** | A single declared link from a source artifact to a spec section: a `(spec-ID, relative-path, anchor)` triple (§2). |
-| **`# Spec References` block** | The delimited region in a source artifact that carries one or more spec references, expressed in that file type's comment/docstring idiom (§3). |
+| **`# Spec References` block** | The delimited region in a non-Markdown source artifact that carries one or more spec references, expressed in that file type's comment/docstring idiom (§3). Markdown documents instead declare references in frontmatter (§2.5, §3.6). |
 | **Anchor** | The `{#SPEC-{SUBSYSTEM}-{NN}~{rev}}` heading marker on a governed spec section; the link target of a spec reference. |
-| **Intent-source resolver (ISR)** | `trusty_common::intent_source` (DOC-15 §6): the **reader** that parses `# Spec References` blocks out of changed files to find the governing spec section. It reads declared links only. |
-| **Declared-links-only** | SLD asserts a link **only** where a source artifact explicitly declares one. Tooling never *invents* linkage, never infers it from names/paths, and never treats absence as an error. |
+| **Resolver** | Any tool — in any language, in any repository — that reads declared SLD references (inline blocks or frontmatter) to trace a source artifact back to its governing spec section(s). A resolver is a **reader** of declared links only; this standard does not mandate a specific resolver implementation (see Annex A for one informative example). |
+| **Declared-links-only** | SLD asserts a link **only** where a source artifact explicitly declares one. A resolver never *invents* linkage, never infers it from names/paths, and never treats absence as an error. |
 
-**Canonical marker phrase (normatively fixed in §2.3):** every `# Spec References`
-block is introduced by a line whose text, **after** stripping the file's
-comment/docstring lead-in and any leading Markdown `#` heading markers, is exactly
-`Spec References`. This single phrase is the block marker in every language (§3), so
-one resolver grammar recognizes them all.
+**Canonical marker phrase (normatively fixed in §2.3):** every inline `# Spec
+References` block is introduced by a line whose text, **after** stripping the
+file's comment/docstring lead-in and any leading Markdown `#` heading markers, is,
+**case-insensitively**, exactly `Spec References`. This single phrase is the block
+marker in every non-Markdown language (§3); Markdown documents use frontmatter
+instead (§2.5). Fenced code blocks are never scanned for markers (§2.3).
 
 ---
 
@@ -53,52 +66,61 @@ one resolver grammar recognizes them all.
 
 ### 1.1 What this spec establishes
 
-1. **SLD as a first-class spec** — the linkage convention is normative here, not
-   incidental README prose. The README defers to this document as canonical (§10).
+1. **SLD as a first-class, standalone standard** — the linkage convention is
+   normative here, not incidental README prose, and is not bound to any one
+   language, tool, or repository. The trusty-tools README defers to this document
+   as canonical for its own use of SLD (§9).
 2. **Language-agnostic linkage** — a comment-idiom-per-language table (§3) plus a
-   **single canonical reference grammar** (§2) that a resolver parses uniformly
-   across Rust, Python, TypeScript/JavaScript, shell, TOML/YAML, and **Markdown**.
+   **single canonical reference grammar** (§2), with two representations: an
+   inline comment/docstring form (code, config) and a **YAML frontmatter form**
+   (Markdown, §2.5), so the same triple is declared uniformly everywhere.
 3. **Spec-document conventions** — DOC-N assignment, the header field block, the
-   ID grammar, anchors, the status lifecycle, and the catalog-row requirement,
-   promoted from README prose to normative text (§4).
-4. **A resolver contract** — how `trusty_common::intent_source` extends beyond
-   `.rs` to any registered file type (§5), stated as behavior, code as follow-up.
-5. **The authoring-skills contract** — the responsibilities the dangling
-   `spec-authoring` / `spec-linked-docs` skills were meant to own (§9).
+   ID grammar, anchors, the status lifecycle, and the catalog-row requirement (§4).
+4. **The authoring-skills contract** — the responsibilities the dangling
+   `spec-authoring` / `spec-linked-docs` skills were meant to own (Annex B).
+
+A concrete resolver implementation (e.g. trusty-common's `intent_source`) is
+**informative only** (Annex A) — implementing it is out of scope for this
+standard and is tracked as a follow-up (§10, F1).
 
 ### 1.2 Goals
 
 - **G1 — One grammar, every language.** A source↔spec reference has the *same*
-  `(spec-ID, path, anchor)` shape everywhere; only the surrounding comment idiom
-  differs. A resolver needs one reference grammar plus a per-extension comment
-  table — not a bespoke parser per language.
+  `(spec-ID, path, anchor)` shape everywhere; only the surrounding idiom differs
+  (an inline comment marker for code/config, frontmatter for Markdown). A
+  conforming resolver needs one reference grammar plus a small per-idiom lookup —
+  not a bespoke parser per language.
 - **G2 — Rust unchanged.** The existing Rust rustdoc `# Spec References` form is
-  the reference implementation and is preserved byte-for-byte (§3.1); no existing
+  the reference idiom for code and is preserved byte-for-byte (§3.1); no existing
   Rust link must be rewritten.
-- **G3 — Visible over hidden.** Markdown documents declare references in a
-  **visible** `## Spec References` section, not hidden frontmatter or comments —
-  consistent with specs' own no-YAML-frontmatter house style (§3.6, §4.2).
-- **G4 — Declared-links-only, reader-only.** SLD never invents linkage; the ISR
-  reads declared links and never enforces a traceability model (carried from
-  DOC-15 §1.3).
-- **G5 — Conventions in one place.** DOC-N/ID/anchor/lifecycle rules live in this
-  spec; the README holds a summary and the catalog, not the normative rules.
+- **G3 — Structured and machine-parseable for documents.** Markdown documents
+  declare their canonical references in **YAML frontmatter** (`spec_refs:`, §2.5)
+  — a structured, directly machine-parseable form requiring no regex — with an
+  optional visible section retained for human readability (§3.6).
+- **G4 — Declared-links-only, reader-only.** SLD never invents linkage; a
+  conforming resolver reads declared links and never enforces a traceability
+  model (carried from DOC-15 §1.3).
+- **G5 — Conventions in one place, portable.** DOC-N/ID/anchor/lifecycle rules are
+  defined generically in this spec (§4) so any repository can adopt them; §9
+  documents trusty-tools' own instantiation separately from the standard itself.
 
-### 1.3 Non-goals (see §8)
+### 1.3 Non-goals (see §6)
 
 Carried forward from DOC-15 §1.3 and made explicit here:
 
-- **No four-status traceability enforcement.** SLD/ISR does **not** compute or gate
-  on COVERED / UNCOVERED / ORPHANED / OUTDATED. The ISR is a *reader* of declared
+- **No four-status traceability enforcement.** SLD does **not** compute or gate on
+  COVERED / UNCOVERED / ORPHANED / OUTDATED. A resolver is a *reader* of declared
   links, not a coverage enforcer.
-- **No resolver implementation in this PR.** §5 is a behavior contract; the code
-  change is a follow-up (§11, F1).
-- **No auto-insertion of references.** SLD never writes `# Spec References` blocks
-  into source; authors declare links deliberately (declared-links-only, G4).
+- **No resolver implementation is normative.** Resolver behavior is illustrated
+  informatively in Annex A; implementing any resolver (in Rust or otherwise) is a
+  follow-up (§10, F1), not part of this standard.
+- **No auto-insertion of references.** SLD never writes reference blocks or
+  frontmatter into source; authors declare links deliberately (declared-links-only, G4).
 - **No per-symbol coverage metrics, no CI traceability pass, no link linter** in
   this spec (each is a possible future follow-up, not normative here).
-- **No renumbering of existing files in place.** The DOC-28 self-label collision is
-  fixed by a follow-up (§11, F3), not by editing the colliding file here.
+- **No renumbering of existing files in place.** The DOC-28 self-label collision
+  (trusty-tools-specific, §9) is fixed by a follow-up (§10, F3), not by editing
+  the colliding file here.
 
 ---
 
@@ -107,17 +129,19 @@ Carried forward from DOC-15 §1.3 and made explicit here:
 **ID:** SPEC-SLD-02~draft
 **Status:** Draft
 
-A spec reference is a `(spec-ID, relative-path, anchor)` triple. Its textual form
-is identical across languages; only the enclosing comment idiom varies (§3).
+A spec reference is a `(spec-ID, relative-path, anchor)` triple. It has two
+normative representations: an **inline textual form** (§2.1–§2.4, used by code,
+config, and optionally Markdown for human visibility) and a **frontmatter
+structured form** (§2.5, canonical for Markdown documents).
 
-### 2.1 The grammar (NORMATIVE)
+### 2.1 The inline grammar (NORMATIVE)
 
 ```
 SPEC-ID   := "SPEC-" SUBSYSTEM "-" NN "~" REV
 SUBSYSTEM := /[A-Z0-9][A-Z0-9-]*/          ; e.g. SLD, CONFORMANCE, CFGDIR
-NN        := /[0-9]{2,}/                    ; zero-padded section number
-REV       := "draft" | "v" /[0-9]+/         ; ~draft, ~v1, ~v2, …
-PATH      := /[A-Za-z0-9._\/-]+\.md/        ; relative to repo root, e.g. docs/specs/intent-conformance.md
+NN        := /[0-9]{2,}/                    ; zero-padded, opaque per-spec ID counter
+REV       := "draft" | /[a-z][a-z0-9]*/     ; ~draft, ~v1, ~v2, ~approved, … (see note below)
+PATH      := /[A-Za-z0-9._\/-]+\.md/        ; canonical form is repo-root-relative, e.g. docs/specs/intent-conformance.md — see path-form note below
 ANCHOR    := SPEC-ID                        ; equals the {#SPEC-…} heading anchor
 TARGET    := PATH "#" ANCHOR
 REF       := SPEC-ID  SEP  TARGET           ; SEP = markdown-link punctuation OR whitespace
@@ -126,11 +150,29 @@ REF       := SPEC-ID  SEP  TARGET           ; SEP = markdown-link punctuation OR
 - **`ANCHOR` MUST equal the `SPEC-ID`** it points at — the anchor is the section's
   `{#SPEC-{SUBSYSTEM}-{NN}~{rev}}` heading marker. This redundancy makes a reference
   self-checking: the leading ID and the trailing anchor must match.
-- **`PATH` MUST be repo-root-relative** (e.g. `docs/specs/foo.md`), not relative to
-  the source file — so the reference is unambiguous regardless of where the source
-  lives. (This matches the existing Rust convention, which writes `docs/specs/…`.)
+- **`{NN}` is an opaque per-spec ID counter**, not a section-order index — a spec's
+  IDs need not appear in the same order as their sections (e.g. this spec's
+  `SPEC-SLD-01` anchors §4, not §1; §2's ID is `SPEC-SLD-02`). Do not infer document
+  structure from ID order.
+- **`{REV}` is an open, lowercase alphanumeric token**, not a closed `draft`/`v<N>`
+  enumeration. `draft` and `v<N>` (`~v1`, `~v2`, …) are the standard's own baseline
+  progression (§4.4), but adopting repositories MAY use additional named
+  accepted-state tags — trusty-tools' DOC-36 uses `~approved` in place of `~v1` for
+  six sections today. A resolver MUST NOT reject a well-formed `~<token>` revision
+  it does not recognize.
+- **`PATH` canonical form is repo-root-relative** (e.g. `docs/specs/foo.md`), not
+  relative to the source file — so the reference is unambiguous regardless of where
+  the source lives (matches the existing Rust convention). **This is the form a
+  resolver parses as ground truth.** A *file-relative* URL (needed for a link to
+  actually navigate on GitHub, which resolves relative links from the current
+  file's directory) is permitted only in an **optional, informative** visible
+  section (§3.6) — never in frontmatter `spec_refs` (§2.5) or in an inline
+  `# Spec References` block, and never treated as canonical when it disagrees with
+  a repo-root-relative declaration. This reconciles two constraints that otherwise
+  conflict: machine resolution needs an unambiguous root-relative path, but GitHub
+  rendering needs a file-relative one.
 
-### 2.2 Two surface forms, one parse
+### 2.2 Two inline surface forms, one parse
 
 The `REF` production admits two surface forms so Rust stays unchanged (G2) while
 non-code files stay natural:
@@ -145,28 +187,113 @@ Both are parsed by **one** regex that captures the three fields and ignores
 link/comment punctuation between them:
 
 ```
-(SPEC-[A-Z0-9][A-Z0-9-]*-[0-9]{2,}~(?:draft|v[0-9]+))   # leading ID
- [^\n]*?                                                  # link/comment noise
- ([A-Za-z0-9._/-]+\.md)#                                  # relative path
- (SPEC-[A-Z0-9][A-Z0-9-]*-[0-9]{2,}~(?:draft|v[0-9]+))   # anchor (== ID)
+(SPEC-[A-Z0-9][A-Z0-9-]*-[0-9]{2,}~[a-z][a-z0-9]*)   # leading ID (REV is an open token: draft, v1, approved, …)
+ [^\n]*?                                               # link/comment noise
+ ([A-Za-z0-9._/-]+\.md)#                               # path (repo-root-relative when canonical, §2.1)
+ (SPEC-[A-Z0-9][A-Z0-9-]*-[0-9]{2,}~[a-z][a-z0-9]*)   # anchor (== ID)
 ```
 
-### 2.3 Block marker (NORMATIVE)
+### 2.3 Block marker (NORMATIVE, inline form)
 
-References are grouped under a **`# Spec References` block** (§0). The block marker
-is the line whose stripped text is exactly `Spec References` (comment-lead and
-Markdown-`#` agnostic). References belong to the nearest preceding marker within
-the same comment/docstring region. A source artifact MAY declare multiple blocks
-(e.g. one per function in Rust); each is resolved independently.
+Inline references are grouped under a **`# Spec References` block** (§0). The
+block marker is the line whose stripped text is, **case-insensitively**, exactly
+`Spec References` (comment-lead and Markdown-`#` agnostic — matches the existing
+`eq_ignore_ascii_case("Spec References")` behavior this standard's Rust idiom is
+required to preserve, §3.1/G2). References belong to the nearest preceding marker
+within the same comment/docstring region. A source artifact MAY declare multiple
+blocks (e.g. one per function in Rust); each is resolved independently.
 
-### 2.4 Rationale (WHY)
+- **Fenced code blocks are excluded (NORMATIVE).** A marker line or reference
+  occurring inside a fenced code block (delimited by ```` ``` ```` or `~~~`) is
+  **not** a declaration and MUST be skipped when scanning. This applies both to
+  source-code files (a docstring or comment might quote an example inside its own
+  fence) and to Markdown's optional visible section (§3.6). This spec's own body
+  contains many fenced `# Spec References` / `## Spec References` example lines —
+  illustrations of the idiom, not real declarations — and a conforming scanner
+  MUST NOT extract references from them.
+
+### 2.4 Rationale (WHY, §2.1–§2.4)
 
 A single `(ID, path, anchor)` triple with a self-checking anchor lets one resolver
 serve every language: the hard part (find the ID, the path, the anchor) is
-language-independent; the easy part (strip `//!` vs `#` vs `*`) is a small
-per-extension table (§5). Admitting both a Markdown-link and a bare form means the
-established Rust rustdoc links need **no** rewrite (G2) while a shell script or a
-YAML file can carry a reference without pretending to be Markdown.
+language-independent; the easy part (recognize the comment lead-in) is a small
+per-idiom lookup (§3). Admitting both a Markdown-link and a bare inline form means
+the established Rust rustdoc links need **no** rewrite (G2) while a shell script or
+a YAML file can carry a reference without pretending to be Markdown.
+
+### 2.5 The frontmatter form (NORMATIVE, canonical for Markdown)
+
+Markdown documents (including specs themselves) declare their spec references
+canonically in **YAML frontmatter** — a `---`-delimited block at the very top of
+the file, before any other content — under a `spec_refs:` key. This is the
+**structured equivalent** of the `(spec-ID, path, anchor)` triple in §2.1: the
+same three fields, expressed as YAML rather than parsed out of prose text.
+
+**Schema (NORMATIVE):**
+
+```yaml
+---
+spec_refs:
+  - id: <SPEC-ID>          # required; matches the SPEC-ID grammar, §2.1
+    path: <relative-path>  # required; MUST be repo-root-relative (canonical form, §2.1) — never a file-relative GitHub-navigation URL
+    anchor: <SPEC-ID>      # required; MUST equal `id` (self-check, mirrors §2.1's ANCHOR == SPEC-ID rule)
+    note: <string>         # optional; free-text annotation, not parsed by a resolver
+---
+```
+
+- Each list entry under `spec_refs:` is a **structured map** with required keys
+  `id`, `path`, `anchor` (and an optional `note`). This is the **canonical** entry
+  form: it requires no regex, only a YAML parser, and every field is named and
+  unambiguous.
+- **Shorthand (accepted, not canonical):** an entry MAY instead be a bare scalar
+  string using exactly the §2.2 bare-form grammar, parsed with the **same** regex
+  used for inline references:
+  ```yaml
+  ---
+  spec_refs:
+    - "SPEC-SLD-02~draft docs/specs/spec-linked-documentation.md#SPEC-SLD-02~draft"
+  ---
+  ```
+  A resolver MUST accept both forms in the same list; a mapping entry is read
+  directly (no regex), and a scalar entry is parsed via §2.2's regex. Either form
+  yields the identical `(id, path, anchor)` triple.
+- **Placement and scope.** The `spec_refs:` frontmatter block is the **canonical,
+  authoritative** declaration of a Markdown document's outbound spec references.
+  It governs the **whole document** (there is no per-section frontmatter). A
+  document MAY additionally carry an informative visible section (§3.6) for human
+  readability; that section is **not** authoritative where it disagrees with
+  frontmatter.
+- **Path form (NORMATIVE — resolves the root-relative-vs-GitHub tension).**
+  Frontmatter `path` fields carry the **canonical, repo-root-relative** path
+  (§2.1) — this is the only form a resolver treats as ground truth. Repo-root-relative
+  paths do not click through as working GitHub hyperlinks (GitHub resolves
+  relative link URLs against the current file's directory, not the repo root), so
+  an optional visible section (§3.6) MAY instead use a **file-relative** link URL
+  purely so the rendered link navigates on github.com. A file-relative URL in a
+  visible section is informative only and is never parsed as the canonical path;
+  where frontmatter and a visible section disagree, frontmatter wins.
+- **Relationship to a spec's metadata header.** A spec document's existing visible
+  bold-field header block (Status/Subsystem/Owner/… , §4.2) is **unaffected** by
+  this convention and is **not** duplicated into frontmatter. Frontmatter, when
+  present, carries only `spec_refs:` (and any future reference-related keys); it
+  is not a replacement for the bold-field metadata block, and it precedes it at
+  the top of the file.
+
+### 2.6 Rationale (WHY, §2.5 — frontmatter as canonical for Markdown)
+
+YAML frontmatter is directly machine-parseable (a YAML parser, not a regex, reads
+it) and is a widely recognized convention for document metadata (static-site
+generators, documentation tooling). Making it canonical for `spec_refs` keeps the
+document body free of a mandatory reference section while still allowing one for
+human readers (§3.6). Structured maps are the canonical entry form because they
+are self-describing and need no parsing beyond YAML itself; the bare-string
+shorthand is retained as an accepted alternative so a single reference regex
+(§2.2) can, where convenient, serve both the inline and the frontmatter form.
+**Honesty note:** as of this revision, the existing specs under `docs/specs/`
+(including prior drafts of this one) do **not** yet carry `spec_refs` frontmatter;
+retrofitting them is a follow-up (§10, F5/F6), not a precondition for adopting the
+standard going forward. This spec itself now carries frontmatter (top of file) to
+comply with its own convention (§9).
 
 ---
 
@@ -175,20 +302,20 @@ YAML file can carry a reference without pretending to be Markdown.
 **ID:** SPEC-SLD-03~draft
 **Status:** Draft
 
-Each file type declares a `# Spec References` block in its **native** comment or
-docstring idiom. The block marker (§2.3) and reference grammar (§2.1) are identical
-across all rows; only the lead-in differs. Examples use `SPEC-SLD-03~draft`.
+Each file type declares spec references in its **native** idiom: an inline
+`# Spec References` comment/docstring block (§2.1–§2.4) for code and config, or
+YAML frontmatter (§2.5) for Markdown. Examples use `SPEC-SLD-03~draft`.
 
-| File type | Extensions | Idiom | Block placement |
+| File type | Extensions | Idiom | Declaration form |
 |---|---|---|---|
-| **Rust** | `.rs` | rustdoc (**unchanged**) | module `//! # Spec References`; item `/// # Spec References` |
-| **Python** | `.py` | PEP-257 docstring | a `Spec References` section inside the module or symbol `"""…"""` docstring |
-| **TypeScript / JavaScript** | `.ts`,`.tsx`,`.js`,`.mjs`,`.cjs` | JSDoc | a `/** … */` block above the module or symbol |
-| **Shell** | `.sh`,`.bash` | leading comment block | a `#`-comment block near the top of the file |
-| **TOML / YAML** | `.toml`,`.yaml`,`.yml` | comment block | a `#`-comment block (top of file or above the governed key) |
-| **Markdown** | `.md` | **visible section** | a `## Spec References` H2 section (see §3.6) |
+| **Rust** | `.rs` | rustdoc (**unchanged**) | inline: module `//! # Spec References`; item `/// # Spec References` |
+| **Python** | `.py` | PEP-257 docstring | inline: a `Spec References` section inside the module or symbol `"""…"""` docstring |
+| **TypeScript / JavaScript** | `.ts`,`.tsx`,`.js`,`.mjs`,`.cjs` | JSDoc | inline: a `/** … */` block above the module or symbol |
+| **Shell** | `.sh`,`.bash` | leading comment block | inline: a `#`-comment block near the top of the file |
+| **TOML / YAML** | `.toml`,`.yaml`,`.yml` | comment block | inline: a `#`-comment block (top of file or above the governed key) |
+| **Markdown** | `.md` | **YAML frontmatter** | `spec_refs:` frontmatter (canonical, §2.5); optional visible section for readers (§3.6) |
 
-### 3.1 Rust (`.rs`) — reference implementation, UNCHANGED
+### 3.1 Rust (`.rs`) — reference idiom, UNCHANGED
 
 ```rust
 //! # Spec References
@@ -224,7 +351,7 @@ Markdown-rendered by default.
 export function deploy(): void {}
 ```
 
-The resolver strips the leading `*` (and `/**`, `*/`) before applying the marker
+A resolver strips the leading `*` (and `/**`, `*/`) before applying the marker
 and reference grammar.
 
 ### 3.4 Shell (`.sh`, `.bash`)
@@ -249,102 +376,141 @@ port = 8080
 ```
 
 Same `#`-comment idiom as shell. A block at the top of the file governs the whole
-file; a block immediately above a table/key governs that key (resolver treats
-nearest-preceding-marker scoping, §2.3).
+file; a block immediately above a table/key governs that key (nearest-preceding-
+marker scoping, §2.3). Note: this `#`-comment idiom is distinct from Markdown's
+frontmatter convention (§3.6) — TOML/YAML files are not treated as Markdown.
 
-### 3.6 Markdown (`.md`) — NORMATIVE form: a visible `## Spec References` section
+### 3.6 Markdown (`.md`) — canonical form: `spec_refs:` frontmatter
 
-A Markdown document declares its governing spec(s) in a **visible level-2 section**:
+A Markdown document declares its governing spec(s) canonically via **YAML
+frontmatter** (§2.5):
 
 ```markdown
-## Spec References
+---
+spec_refs:
+  - id: SPEC-SLD-03~draft
+    path: docs/specs/spec-linked-documentation.md
+    anchor: SPEC-SLD-03~draft
+---
 
-- [`SPEC-SLD-03~draft`](spec-linked-documentation.md#SPEC-SLD-03~draft)
+# My Document
+…
 ```
 
-**Decision (NORMATIVE): the visible `## Spec References` section is the canonical
-Markdown form; an HTML-comment block is a permitted fallback only.**
+**Decision (NORMATIVE): `spec_refs:` YAML frontmatter is the canonical Markdown
+declaration form. A visible `## Spec References` section is optional and
+informative — permitted for human-reader visibility, but not authoritative.**
 
-- **Why visible, not an HTML comment.** (1) Specs in this repo deliberately use a
-  **visible bold-field header block, not YAML frontmatter** (§4.2) — hiding SLD
-  links in `<!-- … -->` would contradict that house choice. (2) A visible section
-  renders on GitHub and in docs sites, so a reader sees the governing spec without
-  viewing source. (3) It shows up in PR diffs and review, so linkage is auditable
-  where it is added or removed. (4) It is Markdown-native — a bulleted list of
-  links needs no new tooling to render.
-- **Heading level.** Use `##` (H2), **not** `#` (H1), so the block never competes
-  with the document title. The resolver keys on the stripped phrase `Spec
-  References` at **any** heading level (§2.3), so `##`/`###` both resolve.
-- **Fallback.** Where a visible section is genuinely undesirable (e.g. a rendered
-  end-user README where the section would be noise), an HTML-comment block is
-  permitted:
+- **Why frontmatter is canonical.** (1) It is directly machine-parseable — a YAML
+  parser reads it with no bespoke regex, unlike a prose section. (2) It is a single,
+  predictable location (top of file) rather than a section that could appear
+  anywhere in the body. (3) It keeps the document body free to organize its own
+  content without a mandatory reference section competing for space.
+- **Optional visible echo.** A document MAY additionally carry a visible section
+  for readers who do not inspect raw source:
   ```markdown
-  <!-- Spec References
-  - SPEC-SLD-03~draft docs/specs/spec-linked-documentation.md#SPEC-SLD-03~draft
-  -->
+  ## Spec References
+
+  - [`SPEC-SLD-03~draft`](spec-linked-documentation.md#SPEC-SLD-03~draft)
   ```
-  Authors SHOULD prefer the visible section; the fallback exists so the convention
-  never forces visible noise into a polished document.
+  This section, when present, SHOULD be kept consistent with the frontmatter but
+  is **informative only** — a resolver reads `spec_refs:` frontmatter as the
+  source of truth, never this section. Heading level SHOULD be `##` (H2), not `#`,
+  so it never competes with the document title. **Note the example's link URL is
+  deliberately file-relative** (`spec-linked-documentation.md`, not
+  `docs/specs/spec-linked-documentation.md`) so it actually navigates on GitHub
+  (§2.1's path-form note) — the frontmatter entry for the same reference carries
+  the canonical repo-root-relative path instead.
+- **A document with no frontmatter and no visible section** declares no spec
+  references (declared-links-only, G4) — this is a valid, unremarkable state, not
+  an error.
 
 ### 3.7 Rationale (WHY)
 
 Meeting each language in its **native** idiom (rustdoc, PEP-257, JSDoc, `#`
-comments) means SLD adds no foreign syntax an author must learn per language — the
-only thing to remember is the phrase `Spec References` and the `(ID, path, anchor)`
-triple. Choosing a **visible** Markdown section (over hidden frontmatter/comments)
-keeps SLD consistent with the repo's existing no-frontmatter spec style and makes
-doc↔spec linkage as reviewable as code↔spec linkage.
+comments, or YAML frontmatter for Markdown) means SLD adds no foreign syntax an
+author must learn per language — the only things to remember are the phrase `Spec
+References` for inline idioms (§2.3) and the `spec_refs:` key for Markdown (§2.5).
+Choosing **frontmatter** as canonical for Markdown, rather than a body section,
+keeps machine parsing simple and predictable while an optional visible section
+still gives human readers on-page context.
 
 ---
 
-## 4. Spec-document conventions (promoted from README prose) {#SPEC-SLD-01~draft}
+## 4. Spec-document conventions (the standard's authoring rules)
 
-> These conventions were previously scattered across `docs/specs/README.md`. They
-> are normative here; the README (§10) summarizes and defers to this section.
+> These conventions define how any adopting repository numbers, headers, anchors,
+> and catalogs its specs. They are generic to the standard; trusty-tools'
+> concrete instantiation of them is documented separately in §9.
 
-### 4.1 DOC-N assignment (NORMATIVE)
+### 4.1 DOC-N assignment (NORMATIVE) {#SPEC-SLD-01~draft}
 
-- Every spec carries a unique `DOC-N` document number in the `docs/specs/`
-  namespace. **Numbers are assigned scan-before-claim:** before claiming a number,
-  scan the **entire** `docs/` tree — the README catalog **and** any self-labeled
-  spec headers outside the catalog — for the highest claimed `DOC-N`, and claim the
-  next genuinely free integer.
-  - The README's "next free DOC-N" note is a **hint, not authority**; it drifts
-    stale (it has before). The scan is authoritative.
-  - The `docs/specs/` DOC-N namespace is **separate** from the
-    `docs/trusty-installer/research/**` doc-charter numbering (which has its own
-    `00-naming-and-doc-charter.md`); do not conflate the two when scanning.
-- **Collision handling.** A `DOC-N` collision (two files self-labeling the same
-  number) is resolved by assigning the **uncataloged** file the next free number
-  and adding a catalog row — never by silently reusing a number. The motivating
-  case: `mpm-cutover-resume-native-optimization.md` self-labels **DOC-28**, which
-  collides with the canonical DOC-28 (`trusty-mpm-self-awareness.md`); the fix is a
-  follow-up (§11, F3), and until then the collision is flagged in the README.
+**ID:** SPEC-SLD-01~draft
+**Status:** Draft
 
-### 4.2 Header field block (NORMATIVE — no YAML frontmatter)
+- Every spec carries a unique document number (`DOC-N` in trusty-tools' instance)
+  within its repository's spec namespace. **Numbers are assigned scan-before-claim:**
+  before claiming a number, scan the **entire** spec-bearing portion of the
+  repository — the catalog **and** any self-labeled spec headers outside the
+  catalog — for the highest claimed number, and claim the next genuinely free
+  integer.
+  - A catalog's "next free number" note is a **hint, not authority**; it drifts
+    stale. The scan is authoritative.
+  - Where a repository maintains more than one independent numbering namespace
+    (e.g. trusty-tools' `docs/specs/` `DOC-N` series is separate from
+    `docs/trusty-installer/research/**`'s own doc-charter numbering), do not
+    conflate namespaces when scanning.
+- **Collision handling.** A document-number collision (two files self-labeling the
+  same number) is resolved by assigning the **uncataloged** file the next free
+  number and adding a catalog row — never by silently reusing a number. The
+  motivating case (trusty-tools): `mpm-cutover-resume-native-optimization.md`
+  self-labels **DOC-28**, which collides with the canonical DOC-28
+  (`trusty-mpm-self-awareness.md`); the fix is a follow-up (§10, F3), and until
+  then the collision is flagged in the catalog.
 
-A spec opens with an H1 title `# DOC-N — <Title>` followed by a **visible
-bold-field block** (never YAML frontmatter):
+### 4.2 Header field block (NORMATIVE)
+
+A spec opens with a title heading (`# DOC-N — <Title>` in trusty-tools' instance)
+followed by a **visible bold-field block**:
 
 | Field | Required | Meaning |
 |---|---|---|
 | **Status** | yes | `Draft` \| `Accepted` \| `Superseded` (the document's overall lifecycle state; individual sections may carry their own §4.4). |
-| **Subsystem** | yes | The crate(s) / area the spec governs. |
+| **Subsystem** | yes | The area/component(s) the spec governs. |
 | **Owner** | yes | The owning team/role. |
 | **Last-updated** | yes | ISO date of the last substantive edit. |
 | **Spec ID** | yes | The `SPEC-{SUBSYSTEM}-{NN}~{rev}` ID(s) this doc defines (a single ID or an `… … …` range). |
 | **Epic** | optional | The umbrella issue/epic. |
-| **Builds on** | optional | Prior specs / code this one depends on. |
-| **Cross-ref** | optional | Related specs, issues, or code seams. |
+| **Builds on** | optional | Prior specs / material this one depends on. |
+| **Cross-ref** | optional | Related specs, issues, or implementation seams. |
+
+This bold-field block carries the spec's **metadata**. It is unaffected by, and
+never duplicates, the `spec_refs:` frontmatter (§2.5): a spec MAY carry both — YAML
+frontmatter for its outbound references, and the bold-field block, immediately
+below the frontmatter, for its own metadata. Where a spec has no outbound
+references to declare, frontmatter is simply omitted.
 
 ### 4.3 ID grammar & anchors (NORMATIVE)
 
 - Spec IDs follow `SPEC-{SUBSYSTEM}-{NN}~{rev}` (§2.1). `{SUBSYSTEM}` is a short
   uppercase token unique to the spec's area (e.g. `SLD`, `CONFORMANCE`, `CFGDIR`);
-  `{NN}` is a zero-padded per-spec section counter; `{rev}` is `draft` initially.
+  `{NN}` is a zero-padded, **opaque** per-spec ID counter — it enumerates a spec's
+  IDs, not its section/heading order (§2.1); `{rev}` is `draft` initially.
 - Every **governed** section anchors its ID with a `{#SPEC-{SUBSYSTEM}-{NN}~{rev}}`
   heading marker, so SLD references (§2) can target it. A section without an anchor
   cannot be an SLD target.
+- **GitHub-rendering caveat (informative, honest disclosure).** GitHub-Flavored
+  Markdown does **not** support explicit `{#custom-id}` heading attributes — GitHub
+  renders the literal `{#SPEC-…}` text and auto-generates its own anchor by
+  slugifying the visible heading text instead. A `path.md#SPEC-…` cross-link
+  therefore **will not navigate correctly on github.com**; the `{#…}` convention
+  targets non-GitHub tooling that does honor explicit heading IDs (e.g. mkdocs,
+  pandoc, Sphinx-style renderers) and, more importantly, a **resolver that parses
+  the `{#…}` marker directly out of the source text** rather than relying on
+  rendered HTML anchors (§2.1's `ANCHOR := SPEC-ID` rule is about that textual
+  marker, not about GitHub's rendered anchor). On github.com, treat `{#SPEC-…}`
+  cross-links as **best-effort** — they name the right file and the right ID for a
+  human to locate by scanning, even when the browser doesn't jump there.
 
 ### 4.4 Status lifecycle & rev-suffix semantics (NORMATIVE)
 
@@ -352,82 +518,75 @@ bold-field block** (never YAML frontmatter):
 - The `~draft` suffix marks an unfrozen section. On acceptance the suffix becomes a
   version tag: `~draft → ~v1`, and subsequent accepted revisions increment
   (`~v1 → ~v2`). Draft sections are linkable via SLD **while still `~draft`** — so
-  traceability is established from the first implementing PR.
+  traceability is established from the first implementing change.
+- **Named accepted-state tags are permitted alongside `~v<N>`.** The `{REV}` token
+  is open (§2.1); an adopting repository MAY use a named tag such as `~approved`
+  in place of `~v1`/`~v2`/… to mark acceptance — trusty-tools' DOC-36 does this
+  today (`SPEC-TMMGR-01~approved` … `-06~approved`). Both progressions mean the
+  same thing (the section left `~draft`); this standard does not mandate which
+  accepted-state spelling a repository uses, only that `~draft` is the universal
+  starting state.
 - **When a section's `{rev}` changes, its anchor changes**, so inbound SLD
-  references naming the old rev become revision-drift signals. Per DOC-15 §6.4 the
-  ISR still resolves the reference to the current section and MAY flag drift;
+  references naming the old rev become revision-drift signals. A conforming
+  resolver MAY still resolve the reference to the current section and flag drift;
   **enforcing** drift (OUTDATED) is a non-goal (§1.3).
 
 ### 4.5 Catalog-row requirement (NORMATIVE)
 
-Every spec MUST have a row in the `docs/specs/README.md` "Spec catalog" table
-(`DOC-N | Spec ID(s) | Title (link) | Subsystem`). A spec file without a catalog
-row is **uncataloged** and is a defect to be fixed (add the row), not a valid state.
+Every spec MUST have a row in its repository's spec catalog (in trusty-tools:
+the `docs/specs/README.md` "Spec catalog" table — `DOC-N | Spec ID(s) | Title
+(link) | Subsystem`). A spec file without a catalog row is **uncataloged** and is
+a defect to be fixed (add the row), not a valid state.
 
 ---
 
-## 5. Resolver contract — `intent_source` beyond `.rs` (behavior only) {#SPEC-SLD-04~draft}
+## 5. Acceptance criteria (testable, standard-level)
 
-**ID:** SPEC-SLD-04~draft
-**Status:** Draft
-
-DOC-15 §6.4 specifies the ISR's spec-resolution leg for Rust. This section states
-the **language-agnostic** contract. **It is behavior only** — the code change is a
-follow-up (§11, F1), **not** in this PR.
-
-### 5.1 Behavior contract (WHAT)
-
-- **Input:** a changed file (path + contents) of any registered file type (§3).
-- **Output:** zero or more `SpecRef { spec_id, path, anchor }` triples — one per
-  declared reference — resolved to the governing `{#SPEC-…}` section(s) in
-  `docs/specs/`. A file with no `# Spec References` block yields **zero** refs.
-- **Algorithm (per file):**
-  1. Look up the file's extension in a **per-extension comment-syntax table**
-     (§5.2). Unknown extension → no refs (the resolver never guesses).
-  2. Strip the comment/docstring lead-ins for that extension to expose text.
-  3. Find `# Spec References` block markers (§2.3, stripped-phrase match).
-  4. Within each block, apply the reference regex (§2.2) to extract
-     `(spec-ID, path, anchor)` triples.
-  5. Resolve each anchor to the `{#SPEC-…}` heading in the referenced `docs/specs/`
-     file. An anchor that does not equal its leading ID, or that resolves to no
-     section, is **dropped with a logged warning** (declared-links-only; never
-     fabricate a target).
-- **Declared-links-only (NORMATIVE):** absence of a block is **not** an error and
-  never yields a ref. The resolver never infers linkage from file names or paths.
-- **Reader-only (NORMATIVE):** the resolver never writes references and never
-  enforces coverage. Four-status traceability remains a non-goal (§1.3, DOC-15
-  §1.3).
-- **Fail-open (NORMATIVE):** any parse/read failure yields **zero** refs for that
-  file (logged to stderr), never a spurious ref — matching DOC-15's fail-open ISR
-  posture (§4.2 there).
-
-### 5.2 Per-extension comment-syntax table (the only language-specific part)
-
-| Extension(s) | Line-comment | Block / docstring delimiters |
-|---|---|---|
-| `.rs` | `//`, `///`, `//!` | — |
-| `.py` | `#` | `"""…"""`, `'''…'''` |
-| `.ts`,`.tsx`,`.js`,`.mjs`,`.cjs` | `//` | `/** … */`, `/* … */` |
-| `.sh`,`.bash` | `#` | — |
-| `.toml`,`.yaml`,`.yml` | `#` | — |
-| `.md` | — (visible section) | `<!-- … -->` (fallback form, §3.6) |
-
-The table is the resolver's **only** language-specific surface; everything
-downstream (marker, reference grammar, anchor resolution) is shared.
-
-### 5.3 Rationale (WHY)
-
-Isolating all language knowledge into one extension→comment-syntax table (§5.2)
-keeps the resolver's core (§5.1) language-independent and makes adding a new
-language a **data** change (one table row), not new parsing code. Stating the
-contract now — but deferring the implementation — lets specs in any language start
-declaring SLD links immediately, with the resolver catching up under F1.
+- **AC-1** A new spec assigned by scan-before-claim (§4.1) takes the next integer
+  above the highest document number found anywhere in the repository's spec
+  namespace (catalog + self-labeled), and adds a catalog row (§4.5).
+- **AC-2** A spec's header is a visible bold-field block (§4.2) with all required
+  fields; `spec_refs:` frontmatter, if present, precedes it and carries only
+  reference data (no duplicated metadata).
+- **AC-3** Every governed section carries a `{#SPEC-…}` anchor equal to its ID (§4.3).
+- **AC-4** The inline reference regex (§2.2) extracts the same `(ID, path, anchor)`
+  triple from the Markdown-link form and the bare form.
+- **AC-5** An inline `# Spec References` block is recognized in each non-Markdown
+  file type of §3 (Rust, Python, TS/JS, shell, TOML/YAML) via the stripped-phrase
+  marker (§2.3).
+- **AC-6** A Markdown document's `spec_refs:` frontmatter resolves to the same
+  `(id, path, anchor)` triples whether entries are structured maps or bare-string
+  shorthand (§2.5); an optional visible section, if present, is informative only;
+  a document with neither frontmatter nor a visible section yields no reference.
+- **AC-7** An existing Rust `//! # Spec References` block resolves **unchanged**
+  (no regression — G2).
 
 ---
 
-## 6. Worked end-to-end example (non-normative)
+## 6. Non-goals
 
-A Python module governed by this spec's §3 anchor:
+- Four-status traceability enforcement (COVERED/UNCOVERED/ORPHANED/OUTDATED) — a
+  resolver reads links; it does not gate on coverage (carried from DOC-15 §1.3).
+- Implementing any resolver, in Rust or any other language — resolver behavior is
+  illustrated informatively (Annex A); implementation is a follow-up (F1).
+- Auto-inserting or auto-rewriting reference blocks or frontmatter into any source.
+- A CI SLD link-linter / dead-anchor check (a possible future follow-up, not
+  normative here).
+- Per-symbol spec-coverage metrics or a traceability matrix.
+- Renumbering the DOC-28-colliding file in place (fixed by follow-up F3;
+  trusty-tools-specific, §9).
+- Governing *which* code or documents must be spec-linked — SLD defines *how* to
+  link when an author chooses to; it does not mandate coverage.
+- Mandating any specific repository layout, spec-catalog location, or programming
+  language — the standard is portable; §9 documents one adopter's (trusty-tools')
+  instantiation.
+
+---
+
+## 7. Worked example (non-normative)
+
+A Python module declaring an inline reference, and a Markdown document declaring
+the equivalent reference via frontmatter — both resolve to the same triple:
 
 ```python
 """Deployment helpers.
@@ -437,79 +596,122 @@ A Python module governed by this spec's §3 anchor:
 """
 ```
 
-The resolver (§5): extension `.py` → strip `#`/`"""` → find `Spec References` →
-regex-extract `(SPEC-SLD-03~draft, docs/specs/spec-linked-documentation.md,
-SPEC-SLD-03~draft)` → resolve the anchor to §3 of this spec. Same triple, same
-resolution as the equivalent Rust `//! # Spec References` block — that is the whole
-point of the one-grammar design (§2.4).
+```markdown
+---
+spec_refs:
+  - id: SPEC-SLD-03~draft
+    path: docs/specs/spec-linked-documentation.md
+    anchor: SPEC-SLD-03~draft
+---
+
+# Deployment Runbook
+…
+```
+
+Both declare the identical triple `(SPEC-SLD-03~draft,
+docs/specs/spec-linked-documentation.md, SPEC-SLD-03~draft)`, resolving to §3 of
+this spec — one via the inline grammar (§2.1–§2.4), the other via the frontmatter
+schema (§2.5). That equivalence is the whole point of the one-grammar,
+two-representation design (§2.4, §2.6).
 
 ---
 
-## 7. Acceptance criteria (testable)
+## 8. Change log
 
-**Conventions (§4):**
-- **AC-1** A new spec assigned by scan-before-claim (§4.1) takes the next integer
-  above the highest `DOC-N` found anywhere under `docs/` (catalog + self-labeled),
-  and adds a catalog row (§4.5).
-- **AC-2** A spec's header is a visible bold-field block (§4.2) with all required
-  fields; no YAML frontmatter is present.
-- **AC-3** Every governed section carries a `{#SPEC-…}` anchor equal to its ID (§4.3).
-
-**Grammar & idioms (§2, §3):**
-- **AC-4** The reference regex (§2.2) extracts the same `(ID, path, anchor)` triple
-  from the Markdown-link form and the bare form.
-- **AC-5** A `# Spec References` block is recognized in each file type of §3 (Rust,
-  Python, TS/JS, shell, TOML/YAML, Markdown) via the stripped-phrase marker (§2.3).
-- **AC-6** A Markdown document with a visible `## Spec References` section resolves;
-  the HTML-comment fallback (§3.6) also resolves; a document with neither yields no ref.
-- **AC-7** An existing Rust `//! # Spec References` block resolves **unchanged**
-  (no regression — G2).
-
-**Resolver (§5) — verified once F1 lands:**
-- **AC-8** A file whose extension is not in §5.2 yields zero refs.
-- **AC-9** A reference whose anchor ≠ its leading ID, or whose anchor resolves to no
-  section, is dropped with a warning (declared-links-only).
-- **AC-10** A file with no block yields zero refs and is not an error (fail-open).
+- **2026-07-16** — Initial draft (DOC-38, `SPEC-SLD-01~draft` … `SPEC-SLD-03~draft`).
+  Promoted SLD from README prose to a first-class, language-agnostic spec per Bob's
+  directive ("SLD converted to a first class spec that we use for ANY language or
+  even markdown").
+- **2026-07-16 (revision)** — Two binding design corrections from Bob: (1)
+  **frontmatter is now the canonical Markdown declaration form** (`spec_refs:`
+  YAML frontmatter, §2.5, §3.6), reversing the prior "visible section is
+  canonical" decision; the visible `## Spec References` section is now optional/
+  informative. (2) **Reframed as a pure, implementation-neutral standard** usable
+  in any repository or language: the `trusty_common::intent_source` resolver
+  material was demoted from core normative content to informative Annex A;
+  section 5's prior "Resolver contract" is now non-normative and follow-up F1
+  covers its implementation. DOC-38 now self-complies with its own frontmatter
+  convention (top of this file). Added Annex A (informative resolver notes) and
+  Annex B (informative authoring-skill notes); added follow-up F6 (frontmatter
+  retrofit of existing specs).
 
 ---
 
-## 8. Non-goals
+## Annex A (Informative) — A reference resolver: trusty-common `intent_source`
 
-- Four-status traceability enforcement (COVERED/UNCOVERED/ORPHANED/OUTDATED) — the
-  ISR reads links; it does not gate on coverage (carried from DOC-15 §1.3).
-- Implementing the resolver extension in Rust (this PR is docs-only; F1).
-- Auto-inserting or auto-rewriting `# Spec References` blocks into any source.
-- A CI SLD link-linter / dead-anchor check (a possible future follow-up, not
-  normative here).
-- Per-symbol spec-coverage metrics or a traceability matrix.
-- Renumbering the DOC-28-colliding file in place (fixed by follow-up F3).
-- Governing *which* code must be spec-linked — SLD defines *how* to link when an
-  author chooses to; it does not mandate coverage.
+> **This annex is informative, not normative.** It illustrates how one concrete
+> resolver — trusty-common's `intent_source` (DOC-15 §6, `SPEC-CONFORMANCE-03~draft`)
+> — could read SLD references per §2–§3 of this standard. Nothing in this annex is
+> binding on adopters of the standard; the standard is defined entirely by §§0–8
+> above. Implementing this (or any) resolver is tracked as follow-up **F1**.
+
+### A.1 Behavior sketch
+
+- **Input:** a changed file (path + contents) of any file type registered in a
+  per-extension table (A.2).
+- **Output:** zero or more `SpecRef { spec_id, path, anchor }` triples resolved to
+  the governing `{#SPEC-…}` section(s). A file with no declared reference
+  (no inline block, no `spec_refs:` frontmatter) yields **zero** refs.
+- **Algorithm sketch (per file):**
+  1. Look up the file's extension. Unknown extension → no refs (never guess).
+  2. For non-Markdown types: strip the comment/docstring lead-in, find `# Spec
+     References` block markers (§2.3), apply the §2.2 regex within each block.
+  3. For Markdown: parse `spec_refs:` frontmatter (§2.5) directly as structured
+     data (or via the §2.2 regex for bare-string shorthand entries); optionally
+     cross-check against a visible section if present, informationally only.
+  4. Resolve each anchor to the `{#SPEC-…}` heading in the referenced document. An
+     anchor that does not equal its leading/declared `id`, or that resolves to no
+     section, is dropped with a logged warning (declared-links-only; never
+     fabricate a target).
+- **Declared-links-only, reader-only, fail-open:** as specified generically in
+  §1.2 (G4) and §1.3 — a sketch resolver never invents linkage, never writes
+  references, and treats any parse/read failure as zero refs for that file (not
+  a spurious ref).
+
+### A.2 Illustrative per-extension table
+
+| Extension(s) | Line-comment | Block / docstring delimiters |
+|---|---|---|
+| `.rs` | `//`, `///`, `//!` | — |
+| `.py` | `#` | `"""…"""`, `'''…'''` |
+| `.ts`,`.tsx`,`.js`,`.mjs`,`.cjs` | `//` | `/** … */`, `/* … */` |
+| `.sh`,`.bash` | `#` | — |
+| `.toml`,`.yaml`,`.yml` | `#` | — |
+| `.md` | — (frontmatter, §2.5) | `---…---` frontmatter block |
+
+This table would be the resolver's only language-specific surface; everything
+downstream (marker, reference grammar, frontmatter schema, anchor resolution) is
+shared and defined generically above.
+
+### A.3 Illustrative conformance checks (non-normative; for F1)
+
+- A file whose extension is not registered yields zero refs.
+- A reference whose anchor does not equal its declared id, or whose anchor
+  resolves to no section, is dropped with a warning.
+- A file with no declared reference yields zero refs and is not treated as an error.
+- The same `(id, path, anchor)` triple resolves identically whether declared
+  inline (§2.1–§2.4) or via frontmatter (§2.5).
 
 ---
 
-## 9. Authoring skills — subsuming the dangling `spec-authoring` / `spec-linked-docs` {#SPEC-SLD-05~draft}
+## Annex B (Informative) — Authoring-skill guidance (trusty-tools-specific)
 
-**ID:** SPEC-SLD-05~draft
-**Status:** Draft
+> **This annex is informative and trusty-tools-specific**, not part of the
+> portable standard. It records the responsibilities the dangling `spec-authoring`
+> / `spec-linked-docs` skills (cited by DOC-15, `intent-conformance.md:13`, §2.4,
+> §6.4, but **not present** in `.claude/skills/`, `crates/trusty-mpm/src/assets/`,
+> or `~/.trusty-mpm/`) were meant to own, so that authoring them (follow-up F2) has
+> a clear brief.
 
-DOC-15 (`intent-conformance.md:13`, §2.4, §6.4) cites two skills that **do not
-exist** anywhere (`.claude/skills/`, `crates/trusty-mpm/src/assets/`,
-`~/.trusty-mpm/`). This spec is the **normative source** for both of their
-responsibilities; the skills, when authored (§11, F2), are thin operational wrappers
-that point back here.
-
-- **`spec-authoring` — responsibilities (now normative in §4):** how to create a
-  spec — scan-before-claim DOC-N assignment (§4.1), the header field block (§4.2),
-  the `SPEC-{SUBSYSTEM}-{NN}~{rev}` ID grammar and `{#SPEC-…}` anchors (§4.3), the
-  status lifecycle and rev-suffix semantics (§4.4), and the catalog-row requirement
-  (§4.5). An author following §4 needs no separate skill to write a conformant spec;
-  the F2 skill is a checklist/entry-point that defers to §4.
-- **`spec-linked-docs` (SLD) — responsibilities (now normative in §2, §3, §5):** how
-  to *link* a source artifact to a spec — the canonical reference grammar (§2), the
-  per-language `# Spec References` idioms (§3, including the visible Markdown form),
-  and the resolver's declared-links-only reading contract (§5). The F2 skill is a
-  per-language cheat-sheet that defers to §2/§3.
+- **`spec-authoring` — responsibilities:** how to create a spec — scan-before-claim
+  numbering (§4.1), the header field block (§4.2), the ID grammar and anchors
+  (§4.3), the status lifecycle (§4.4), and the catalog-row requirement (§4.5). An
+  author following §4 needs no separate skill to write a conformant spec; the F2
+  skill is a checklist/entry-point that defers to §4.
+- **`spec-linked-docs` (SLD) — responsibilities:** how to *link* a source artifact
+  to a spec — the canonical reference grammar and frontmatter schema (§2), and the
+  per-language declaration idioms (§3). The F2 skill is a per-language cheat-sheet
+  that defers to §2/§3.
 
 **Contract for the follow-up skills (F2):** each skill's SKILL.md MUST cite this
 spec (`DOC-38`) as its normative source and MUST NOT restate normative rules — it
@@ -519,48 +721,39 @@ from the spec. DOC-15's dangling citations SHOULD be updated to point at DOC-38
 
 ---
 
-## 10. README changes (this PR)
+## 9. Applying this standard in trusty-tools (this PR; trusty-tools-specific, not part of the generic standard)
 
 - **Add the catalog row** for DOC-38 in `docs/specs/README.md`.
-- **Rewrite the §"Spec-Linked Documentation (SLD)" section** to a short summary that
-  names DOC-38 as canonical and links to it, instead of restating the Rust-only
-  rustdoc convention as if it were the whole of SLD.
+- **Rewrite the §"Spec-Linked Documentation (SLD)" section** to a short summary
+  that names DOC-38 as canonical and links to it, instead of restating the
+  Rust-only rustdoc convention as if it were the whole of SLD, and to reflect that
+  frontmatter is now canonical for Markdown.
 - **Fix the stale "next free DOC-N" note** in the DOC-28-collision catalog note:
   after the scan, DOC-34 is assigned (`managed-session-config-dir.md`), DOC-35/36
   are cataloged, DOC-37 is self-labeled (`trusty-search-managed-repo-awareness.md`,
   uncataloged), and **DOC-38 is claimed by this spec** — so the next free number for
   the DOC-28 renumber follow-up is **DOC-39**.
+- **Self-compliance:** this document itself now carries `spec_refs:` frontmatter
+  (top of file) pointing at DOC-15 §6 (`SPEC-CONFORMANCE-03~draft`), the section
+  its (informative) Annex A material extends.
+- **Honesty note:** every *other* existing spec under `docs/specs/` still lacks
+  `spec_refs` frontmatter as of this PR. Retrofitting them is **not** required for
+  this standard to take effect going forward; it is tracked as follow-up **F6**.
 
 ---
 
-## 11. Follow-ups / child issues (for the PM to file)
+## 10. Follow-ups / child issues (for the PM to file)
 
 Umbrella: **epic: spec-linked documentation, first-class & language-agnostic**
 (issue to be linked by the PM).
 
 | ID | Title | Scope | Deps | Effort |
 |----|-------|-------|------|--------|
-| **F1** | Extend `intent_source` spec-resolver beyond `.rs` | Implement §5: per-extension comment-syntax table (§5.2), stripped-phrase marker (§2.3), unified reference regex (§2.2), anchor resolution + declared-links-only/fail-open. AC-4..AC-10. | DOC-15 ISR (`intent_source`) exists | **M** |
-| **F2** | Author the `spec-authoring` + `spec-linked-docs` skills | Two SKILL.md files that cite DOC-38 as normative source and defer to §4 (authoring) / §2–§3 (linkage); no restated rules (§9). | DOC-38 (this spec) | **S** |
-| **F3** | Fix the DOC-28 self-label collision | Assign `mpm-cutover-resume-native-optimization.md` the next free number (**DOC-39** per §10) and add a catalog row; leave canonical DOC-28 untouched (§4.1). | scan (§4.1) | **S** |
+| **F1** | Build a reference SLD resolver (e.g. extend trusty-common `intent_source`) | Implement Annex A: per-extension lookup, inline block parsing, `spec_refs:` frontmatter parsing, anchor resolution, declared-links-only/fail-open. AC-4..AC-7, Annex A.3. | none (standard is self-contained) | **M** |
+| **F2** | Author the `spec-authoring` + `spec-linked-docs` skills | Two SKILL.md files that cite DOC-38 as normative source and defer to §4 (authoring) / §2–§3 (linkage); no restated rules (Annex B). | DOC-38 (this spec) | **S** |
+| **F3** | Fix the DOC-28 self-label collision (trusty-tools) | Assign `mpm-cutover-resume-native-optimization.md` the next free number (**DOC-39** per §9) and add a catalog row; leave canonical DOC-28 untouched (§4.1). | scan (§4.1) | **S** |
 | **F4** | Update DOC-15's dangling skill citations | Repoint `intent-conformance.md:13`, §2.4, §6.4 from the non-existent `spec-linked-docs`/`spec-authoring` to DOC-38 (and the F2 skills once they exist). | F2 | **S** |
-| **F5** | Retrofit existing non-Rust source with SLD blocks (opt-in, incremental) | Where a non-Rust file is clearly governed by a spec, add a `# Spec References` block in its native idiom (§3). Declared-links-only — no bulk auto-insertion. | F1 | **M** (incremental) |
+| **F5** | Retrofit existing non-Rust source with inline SLD blocks (opt-in, incremental) | Where a non-Rust, non-Markdown file is clearly governed by a spec, add a `# Spec References` block in its native idiom (§3). Declared-links-only — no bulk auto-insertion. | F1 | **M** (incremental) |
+| **F6** | Retrofit existing `docs/specs/*.md` (and other Markdown) with `spec_refs` frontmatter | Add `spec_refs:` frontmatter to existing specs/docs that declare inbound linkage today only in prose ("Builds on"/"Cross-ref") or not at all. Declared-links-only — no bulk auto-insertion; each entry added deliberately where a real reference exists. | F1 | **M** (incremental) |
 
-**Suggested order:** F1 ∥ F2 → F3 → F4 → F5 (F5 continuous thereafter).
-
----
-
-## 12. Change log
-
-- **2026-07-16** — Initial draft (DOC-38, `SPEC-SLD-01~draft` … `SPEC-SLD-05~draft`).
-  Promoted SLD from README prose to a first-class, language-agnostic spec per Bob's
-  directive ("SLD converted to a first class spec that we use for ANY language or
-  even markdown"). Defined the one-grammar `(spec-ID, path, anchor)` reference (§2),
-  the per-language `# Spec References` idioms incl. the visible `## Spec References`
-  Markdown form (§3), the promoted spec-document conventions (§4), the resolver
-  behavior contract for extending `intent_source` beyond `.rs` (§5, code as
-  follow-up F1), the authoring-skills contract subsuming the dangling
-  `spec-authoring`/`spec-linked-docs` skills (§9), and the F1–F5 follow-up
-  breakdown. Grounded in `docs/specs/README.md` (SLD/catalog prose) and DOC-15
-  (`intent-conformance.md` §1.3/§2.4/§6.4 — reader-only ISR, no four-status
-  traceability).
+**Suggested order:** F1 ∥ F2 → F3 → F4 → (F5 ∥ F6, continuous thereafter).

--- a/docs/specs/spec-linked-documentation.md
+++ b/docs/specs/spec-linked-documentation.md
@@ -1,0 +1,566 @@
+# DOC-38 — Spec-Linked Documentation (SLD): Language-Agnostic Source↔Spec Linkage
+
+**Status:** Draft
+**Subsystem:** cross-crate — `docs/specs` conventions + trusty-common `intent_source` resolver (all languages)
+**Owner:** Engineering (trusty-tools platform)
+**Last-updated:** 2026-07-16
+**Spec ID:** `SPEC-SLD-01~draft` … `SPEC-SLD-05~draft` (DOC-38)
+**Epic:** epic: spec-linked documentation, first-class & language-agnostic (umbrella issue to be linked by the PM)
+**Builds on:**
+- The SLD prose and spec-catalog conventions in [`docs/specs/README.md`](./README.md)
+  (DOC-N numbering, `SPEC-{SUBSYSTEM}-{NN}~{rev}` grammar, `{#SPEC-…}` anchors,
+  Draft→Accepted→Superseded lifecycle, the Rust `# Spec References` rustdoc form).
+- DOC-15 [Intent / Method Conformance](./intent-conformance.md) — the intent-source
+  resolver (ISR, `trusty_common::intent_source`) that *reads* declared SLD links to
+  resolve a changed file back to its governing spec section (§2.4, §6.4).
+**Cross-ref:** the `spec-authoring` / `spec-linked-docs` skills cited by DOC-15
+(`intent-conformance.md:13`, §2.4, §6.4) that **do not yet exist** — this spec
+subsumes their normative role and names their authoring as a follow-up (§9, §11).
+
+> **Scope note.** This is a **conventions + behavior-contract** spec. It promotes
+> Spec-Linked Documentation (SLD) from scattered README prose to a first-class,
+> **language-agnostic** spec: it fixes the spec-document conventions, defines a
+> single canonical source↔spec reference grammar that works in **any** language
+> (and in Markdown), and states the resolver contract that reads those references.
+> It **implements nothing**: the PR carrying this doc opens **no** Rust changes.
+> The resolver extension, the authoring skills, the DOC-28 collision fix, and the
+> retrofit of existing non-Rust files are decomposed into follow-up issues (§11).
+
+---
+
+## 0. Terminology
+
+| Term | Meaning |
+|---|---|
+| **SLD (Spec-Linked Documentation)** | The convention by which a source artifact **declares** which spec section governs it, so tooling can resolve the artifact back to that section. SLD is a *linkage* convention, not a coverage or enforcement mechanism. |
+| **Spec** | A behavior-contract document under `docs/specs/`, carrying a `DOC-N` number and one or more `SPEC-{SUBSYSTEM}-{NN}~{rev}` IDs, each anchored with a `{#SPEC-…}` heading. Specs are the **targets** of SLD references. |
+| **Source artifact** | Any tracked file that can *declare* a spec reference: Rust/Python/TS/JS/shell code, TOML/YAML config, or a **Markdown** document. Sources are the **origins** of SLD references. |
+| **Spec reference** | A single declared link from a source artifact to a spec section: a `(spec-ID, relative-path, anchor)` triple (§2). |
+| **`# Spec References` block** | The delimited region in a source artifact that carries one or more spec references, expressed in that file type's comment/docstring idiom (§3). |
+| **Anchor** | The `{#SPEC-{SUBSYSTEM}-{NN}~{rev}}` heading marker on a governed spec section; the link target of a spec reference. |
+| **Intent-source resolver (ISR)** | `trusty_common::intent_source` (DOC-15 §6): the **reader** that parses `# Spec References` blocks out of changed files to find the governing spec section. It reads declared links only. |
+| **Declared-links-only** | SLD asserts a link **only** where a source artifact explicitly declares one. Tooling never *invents* linkage, never infers it from names/paths, and never treats absence as an error. |
+
+**Canonical marker phrase (normatively fixed in §2.3):** every `# Spec References`
+block is introduced by a line whose text, **after** stripping the file's
+comment/docstring lead-in and any leading Markdown `#` heading markers, is exactly
+`Spec References`. This single phrase is the block marker in every language (§3), so
+one resolver grammar recognizes them all.
+
+---
+
+## 1. Purpose & scope
+
+### 1.1 What this spec establishes
+
+1. **SLD as a first-class spec** — the linkage convention is normative here, not
+   incidental README prose. The README defers to this document as canonical (§10).
+2. **Language-agnostic linkage** — a comment-idiom-per-language table (§3) plus a
+   **single canonical reference grammar** (§2) that a resolver parses uniformly
+   across Rust, Python, TypeScript/JavaScript, shell, TOML/YAML, and **Markdown**.
+3. **Spec-document conventions** — DOC-N assignment, the header field block, the
+   ID grammar, anchors, the status lifecycle, and the catalog-row requirement,
+   promoted from README prose to normative text (§4).
+4. **A resolver contract** — how `trusty_common::intent_source` extends beyond
+   `.rs` to any registered file type (§5), stated as behavior, code as follow-up.
+5. **The authoring-skills contract** — the responsibilities the dangling
+   `spec-authoring` / `spec-linked-docs` skills were meant to own (§9).
+
+### 1.2 Goals
+
+- **G1 — One grammar, every language.** A source↔spec reference has the *same*
+  `(spec-ID, path, anchor)` shape everywhere; only the surrounding comment idiom
+  differs. A resolver needs one reference grammar plus a per-extension comment
+  table — not a bespoke parser per language.
+- **G2 — Rust unchanged.** The existing Rust rustdoc `# Spec References` form is
+  the reference implementation and is preserved byte-for-byte (§3.1); no existing
+  Rust link must be rewritten.
+- **G3 — Visible over hidden.** Markdown documents declare references in a
+  **visible** `## Spec References` section, not hidden frontmatter or comments —
+  consistent with specs' own no-YAML-frontmatter house style (§3.6, §4.2).
+- **G4 — Declared-links-only, reader-only.** SLD never invents linkage; the ISR
+  reads declared links and never enforces a traceability model (carried from
+  DOC-15 §1.3).
+- **G5 — Conventions in one place.** DOC-N/ID/anchor/lifecycle rules live in this
+  spec; the README holds a summary and the catalog, not the normative rules.
+
+### 1.3 Non-goals (see §8)
+
+Carried forward from DOC-15 §1.3 and made explicit here:
+
+- **No four-status traceability enforcement.** SLD/ISR does **not** compute or gate
+  on COVERED / UNCOVERED / ORPHANED / OUTDATED. The ISR is a *reader* of declared
+  links, not a coverage enforcer.
+- **No resolver implementation in this PR.** §5 is a behavior contract; the code
+  change is a follow-up (§11, F1).
+- **No auto-insertion of references.** SLD never writes `# Spec References` blocks
+  into source; authors declare links deliberately (declared-links-only, G4).
+- **No per-symbol coverage metrics, no CI traceability pass, no link linter** in
+  this spec (each is a possible future follow-up, not normative here).
+- **No renumbering of existing files in place.** The DOC-28 self-label collision is
+  fixed by a follow-up (§11, F3), not by editing the colliding file here.
+
+---
+
+## 2. Canonical spec-reference grammar (one grammar, all languages) {#SPEC-SLD-02~draft}
+
+**ID:** SPEC-SLD-02~draft
+**Status:** Draft
+
+A spec reference is a `(spec-ID, relative-path, anchor)` triple. Its textual form
+is identical across languages; only the enclosing comment idiom varies (§3).
+
+### 2.1 The grammar (NORMATIVE)
+
+```
+SPEC-ID   := "SPEC-" SUBSYSTEM "-" NN "~" REV
+SUBSYSTEM := /[A-Z0-9][A-Z0-9-]*/          ; e.g. SLD, CONFORMANCE, CFGDIR
+NN        := /[0-9]{2,}/                    ; zero-padded section number
+REV       := "draft" | "v" /[0-9]+/         ; ~draft, ~v1, ~v2, …
+PATH      := /[A-Za-z0-9._\/-]+\.md/        ; relative to repo root, e.g. docs/specs/intent-conformance.md
+ANCHOR    := SPEC-ID                        ; equals the {#SPEC-…} heading anchor
+TARGET    := PATH "#" ANCHOR
+REF       := SPEC-ID  SEP  TARGET           ; SEP = markdown-link punctuation OR whitespace
+```
+
+- **`ANCHOR` MUST equal the `SPEC-ID`** it points at — the anchor is the section's
+  `{#SPEC-{SUBSYSTEM}-{NN}~{rev}}` heading marker. This redundancy makes a reference
+  self-checking: the leading ID and the trailing anchor must match.
+- **`PATH` MUST be repo-root-relative** (e.g. `docs/specs/foo.md`), not relative to
+  the source file — so the reference is unambiguous regardless of where the source
+  lives. (This matches the existing Rust convention, which writes `docs/specs/…`.)
+
+### 2.2 Two surface forms, one parse
+
+The `REF` production admits two surface forms so Rust stays unchanged (G2) while
+non-code files stay natural:
+
+- **Markdown-link form (canonical for doc-comments):** the ID as link text, the
+  target as link URL — the form Rust already uses:
+  ``[`SPEC-SLD-02~draft`](docs/specs/spec-linked-documentation.md#SPEC-SLD-02~draft)``
+- **Bare form (for plain comments / config):** ID, whitespace, target:
+  `SPEC-SLD-02~draft docs/specs/spec-linked-documentation.md#SPEC-SLD-02~draft`
+
+Both are parsed by **one** regex that captures the three fields and ignores
+link/comment punctuation between them:
+
+```
+(SPEC-[A-Z0-9][A-Z0-9-]*-[0-9]{2,}~(?:draft|v[0-9]+))   # leading ID
+ [^\n]*?                                                  # link/comment noise
+ ([A-Za-z0-9._/-]+\.md)#                                  # relative path
+ (SPEC-[A-Z0-9][A-Z0-9-]*-[0-9]{2,}~(?:draft|v[0-9]+))   # anchor (== ID)
+```
+
+### 2.3 Block marker (NORMATIVE)
+
+References are grouped under a **`# Spec References` block** (§0). The block marker
+is the line whose stripped text is exactly `Spec References` (comment-lead and
+Markdown-`#` agnostic). References belong to the nearest preceding marker within
+the same comment/docstring region. A source artifact MAY declare multiple blocks
+(e.g. one per function in Rust); each is resolved independently.
+
+### 2.4 Rationale (WHY)
+
+A single `(ID, path, anchor)` triple with a self-checking anchor lets one resolver
+serve every language: the hard part (find the ID, the path, the anchor) is
+language-independent; the easy part (strip `//!` vs `#` vs `*`) is a small
+per-extension table (§5). Admitting both a Markdown-link and a bare form means the
+established Rust rustdoc links need **no** rewrite (G2) while a shell script or a
+YAML file can carry a reference without pretending to be Markdown.
+
+---
+
+## 3. Language-agnostic linkage idioms (per file type) {#SPEC-SLD-03~draft}
+
+**ID:** SPEC-SLD-03~draft
+**Status:** Draft
+
+Each file type declares a `# Spec References` block in its **native** comment or
+docstring idiom. The block marker (§2.3) and reference grammar (§2.1) are identical
+across all rows; only the lead-in differs. Examples use `SPEC-SLD-03~draft`.
+
+| File type | Extensions | Idiom | Block placement |
+|---|---|---|---|
+| **Rust** | `.rs` | rustdoc (**unchanged**) | module `//! # Spec References`; item `/// # Spec References` |
+| **Python** | `.py` | PEP-257 docstring | a `Spec References` section inside the module or symbol `"""…"""` docstring |
+| **TypeScript / JavaScript** | `.ts`,`.tsx`,`.js`,`.mjs`,`.cjs` | JSDoc | a `/** … */` block above the module or symbol |
+| **Shell** | `.sh`,`.bash` | leading comment block | a `#`-comment block near the top of the file |
+| **TOML / YAML** | `.toml`,`.yaml`,`.yml` | comment block | a `#`-comment block (top of file or above the governed key) |
+| **Markdown** | `.md` | **visible section** | a `## Spec References` H2 section (see §3.6) |
+
+### 3.1 Rust (`.rs`) — reference implementation, UNCHANGED
+
+```rust
+//! # Spec References
+//!
+//! - [`SPEC-SLD-03~draft`](docs/specs/spec-linked-documentation.md#SPEC-SLD-03~draft)
+```
+
+Function-level blocks use `///` identically. This is exactly today's convention
+(README §SLD, DOC-15 §2.4); nothing changes for Rust.
+
+### 3.2 Python (`.py`)
+
+```python
+def deploy() -> None:
+    """Deploy the service.
+
+    # Spec References
+    - SPEC-SLD-03~draft docs/specs/spec-linked-documentation.md#SPEC-SLD-03~draft
+    """
+```
+
+The block lives inside the module docstring (module-level governance) or a
+function/class docstring (symbol-level). Bare form is used since docstrings are not
+Markdown-rendered by default.
+
+### 3.3 TypeScript / JavaScript (`.ts`, `.js`, …)
+
+```ts
+/**
+ * # Spec References
+ * - SPEC-SLD-03~draft docs/specs/spec-linked-documentation.md#SPEC-SLD-03~draft
+ */
+export function deploy(): void {}
+```
+
+The resolver strips the leading `*` (and `/**`, `*/`) before applying the marker
+and reference grammar.
+
+### 3.4 Shell (`.sh`, `.bash`)
+
+```sh
+#!/usr/bin/env bash
+# Spec References
+# - SPEC-SLD-03~draft docs/specs/spec-linked-documentation.md#SPEC-SLD-03~draft
+```
+
+The comment lead-in is `#`; after stripping it the marker line reads
+`Spec References`. The block SHOULD appear near the top, after any shebang.
+
+### 3.5 TOML / YAML (`.toml`, `.yaml`, `.yml`)
+
+```toml
+# Spec References
+# - SPEC-SLD-03~draft docs/specs/spec-linked-documentation.md#SPEC-SLD-03~draft
+
+[server]
+port = 8080
+```
+
+Same `#`-comment idiom as shell. A block at the top of the file governs the whole
+file; a block immediately above a table/key governs that key (resolver treats
+nearest-preceding-marker scoping, §2.3).
+
+### 3.6 Markdown (`.md`) — NORMATIVE form: a visible `## Spec References` section
+
+A Markdown document declares its governing spec(s) in a **visible level-2 section**:
+
+```markdown
+## Spec References
+
+- [`SPEC-SLD-03~draft`](spec-linked-documentation.md#SPEC-SLD-03~draft)
+```
+
+**Decision (NORMATIVE): the visible `## Spec References` section is the canonical
+Markdown form; an HTML-comment block is a permitted fallback only.**
+
+- **Why visible, not an HTML comment.** (1) Specs in this repo deliberately use a
+  **visible bold-field header block, not YAML frontmatter** (§4.2) — hiding SLD
+  links in `<!-- … -->` would contradict that house choice. (2) A visible section
+  renders on GitHub and in docs sites, so a reader sees the governing spec without
+  viewing source. (3) It shows up in PR diffs and review, so linkage is auditable
+  where it is added or removed. (4) It is Markdown-native — a bulleted list of
+  links needs no new tooling to render.
+- **Heading level.** Use `##` (H2), **not** `#` (H1), so the block never competes
+  with the document title. The resolver keys on the stripped phrase `Spec
+  References` at **any** heading level (§2.3), so `##`/`###` both resolve.
+- **Fallback.** Where a visible section is genuinely undesirable (e.g. a rendered
+  end-user README where the section would be noise), an HTML-comment block is
+  permitted:
+  ```markdown
+  <!-- Spec References
+  - SPEC-SLD-03~draft docs/specs/spec-linked-documentation.md#SPEC-SLD-03~draft
+  -->
+  ```
+  Authors SHOULD prefer the visible section; the fallback exists so the convention
+  never forces visible noise into a polished document.
+
+### 3.7 Rationale (WHY)
+
+Meeting each language in its **native** idiom (rustdoc, PEP-257, JSDoc, `#`
+comments) means SLD adds no foreign syntax an author must learn per language — the
+only thing to remember is the phrase `Spec References` and the `(ID, path, anchor)`
+triple. Choosing a **visible** Markdown section (over hidden frontmatter/comments)
+keeps SLD consistent with the repo's existing no-frontmatter spec style and makes
+doc↔spec linkage as reviewable as code↔spec linkage.
+
+---
+
+## 4. Spec-document conventions (promoted from README prose) {#SPEC-SLD-01~draft}
+
+> These conventions were previously scattered across `docs/specs/README.md`. They
+> are normative here; the README (§10) summarizes and defers to this section.
+
+### 4.1 DOC-N assignment (NORMATIVE)
+
+- Every spec carries a unique `DOC-N` document number in the `docs/specs/`
+  namespace. **Numbers are assigned scan-before-claim:** before claiming a number,
+  scan the **entire** `docs/` tree — the README catalog **and** any self-labeled
+  spec headers outside the catalog — for the highest claimed `DOC-N`, and claim the
+  next genuinely free integer.
+  - The README's "next free DOC-N" note is a **hint, not authority**; it drifts
+    stale (it has before). The scan is authoritative.
+  - The `docs/specs/` DOC-N namespace is **separate** from the
+    `docs/trusty-installer/research/**` doc-charter numbering (which has its own
+    `00-naming-and-doc-charter.md`); do not conflate the two when scanning.
+- **Collision handling.** A `DOC-N` collision (two files self-labeling the same
+  number) is resolved by assigning the **uncataloged** file the next free number
+  and adding a catalog row — never by silently reusing a number. The motivating
+  case: `mpm-cutover-resume-native-optimization.md` self-labels **DOC-28**, which
+  collides with the canonical DOC-28 (`trusty-mpm-self-awareness.md`); the fix is a
+  follow-up (§11, F3), and until then the collision is flagged in the README.
+
+### 4.2 Header field block (NORMATIVE — no YAML frontmatter)
+
+A spec opens with an H1 title `# DOC-N — <Title>` followed by a **visible
+bold-field block** (never YAML frontmatter):
+
+| Field | Required | Meaning |
+|---|---|---|
+| **Status** | yes | `Draft` \| `Accepted` \| `Superseded` (the document's overall lifecycle state; individual sections may carry their own §4.4). |
+| **Subsystem** | yes | The crate(s) / area the spec governs. |
+| **Owner** | yes | The owning team/role. |
+| **Last-updated** | yes | ISO date of the last substantive edit. |
+| **Spec ID** | yes | The `SPEC-{SUBSYSTEM}-{NN}~{rev}` ID(s) this doc defines (a single ID or an `… … …` range). |
+| **Epic** | optional | The umbrella issue/epic. |
+| **Builds on** | optional | Prior specs / code this one depends on. |
+| **Cross-ref** | optional | Related specs, issues, or code seams. |
+
+### 4.3 ID grammar & anchors (NORMATIVE)
+
+- Spec IDs follow `SPEC-{SUBSYSTEM}-{NN}~{rev}` (§2.1). `{SUBSYSTEM}` is a short
+  uppercase token unique to the spec's area (e.g. `SLD`, `CONFORMANCE`, `CFGDIR`);
+  `{NN}` is a zero-padded per-spec section counter; `{rev}` is `draft` initially.
+- Every **governed** section anchors its ID with a `{#SPEC-{SUBSYSTEM}-{NN}~{rev}}`
+  heading marker, so SLD references (§2) can target it. A section without an anchor
+  cannot be an SLD target.
+
+### 4.4 Status lifecycle & rev-suffix semantics (NORMATIVE)
+
+- A section's status is `Draft → Accepted → Superseded`.
+- The `~draft` suffix marks an unfrozen section. On acceptance the suffix becomes a
+  version tag: `~draft → ~v1`, and subsequent accepted revisions increment
+  (`~v1 → ~v2`). Draft sections are linkable via SLD **while still `~draft`** — so
+  traceability is established from the first implementing PR.
+- **When a section's `{rev}` changes, its anchor changes**, so inbound SLD
+  references naming the old rev become revision-drift signals. Per DOC-15 §6.4 the
+  ISR still resolves the reference to the current section and MAY flag drift;
+  **enforcing** drift (OUTDATED) is a non-goal (§1.3).
+
+### 4.5 Catalog-row requirement (NORMATIVE)
+
+Every spec MUST have a row in the `docs/specs/README.md` "Spec catalog" table
+(`DOC-N | Spec ID(s) | Title (link) | Subsystem`). A spec file without a catalog
+row is **uncataloged** and is a defect to be fixed (add the row), not a valid state.
+
+---
+
+## 5. Resolver contract — `intent_source` beyond `.rs` (behavior only) {#SPEC-SLD-04~draft}
+
+**ID:** SPEC-SLD-04~draft
+**Status:** Draft
+
+DOC-15 §6.4 specifies the ISR's spec-resolution leg for Rust. This section states
+the **language-agnostic** contract. **It is behavior only** — the code change is a
+follow-up (§11, F1), **not** in this PR.
+
+### 5.1 Behavior contract (WHAT)
+
+- **Input:** a changed file (path + contents) of any registered file type (§3).
+- **Output:** zero or more `SpecRef { spec_id, path, anchor }` triples — one per
+  declared reference — resolved to the governing `{#SPEC-…}` section(s) in
+  `docs/specs/`. A file with no `# Spec References` block yields **zero** refs.
+- **Algorithm (per file):**
+  1. Look up the file's extension in a **per-extension comment-syntax table**
+     (§5.2). Unknown extension → no refs (the resolver never guesses).
+  2. Strip the comment/docstring lead-ins for that extension to expose text.
+  3. Find `# Spec References` block markers (§2.3, stripped-phrase match).
+  4. Within each block, apply the reference regex (§2.2) to extract
+     `(spec-ID, path, anchor)` triples.
+  5. Resolve each anchor to the `{#SPEC-…}` heading in the referenced `docs/specs/`
+     file. An anchor that does not equal its leading ID, or that resolves to no
+     section, is **dropped with a logged warning** (declared-links-only; never
+     fabricate a target).
+- **Declared-links-only (NORMATIVE):** absence of a block is **not** an error and
+  never yields a ref. The resolver never infers linkage from file names or paths.
+- **Reader-only (NORMATIVE):** the resolver never writes references and never
+  enforces coverage. Four-status traceability remains a non-goal (§1.3, DOC-15
+  §1.3).
+- **Fail-open (NORMATIVE):** any parse/read failure yields **zero** refs for that
+  file (logged to stderr), never a spurious ref — matching DOC-15's fail-open ISR
+  posture (§4.2 there).
+
+### 5.2 Per-extension comment-syntax table (the only language-specific part)
+
+| Extension(s) | Line-comment | Block / docstring delimiters |
+|---|---|---|
+| `.rs` | `//`, `///`, `//!` | — |
+| `.py` | `#` | `"""…"""`, `'''…'''` |
+| `.ts`,`.tsx`,`.js`,`.mjs`,`.cjs` | `//` | `/** … */`, `/* … */` |
+| `.sh`,`.bash` | `#` | — |
+| `.toml`,`.yaml`,`.yml` | `#` | — |
+| `.md` | — (visible section) | `<!-- … -->` (fallback form, §3.6) |
+
+The table is the resolver's **only** language-specific surface; everything
+downstream (marker, reference grammar, anchor resolution) is shared.
+
+### 5.3 Rationale (WHY)
+
+Isolating all language knowledge into one extension→comment-syntax table (§5.2)
+keeps the resolver's core (§5.1) language-independent and makes adding a new
+language a **data** change (one table row), not new parsing code. Stating the
+contract now — but deferring the implementation — lets specs in any language start
+declaring SLD links immediately, with the resolver catching up under F1.
+
+---
+
+## 6. Worked end-to-end example (non-normative)
+
+A Python module governed by this spec's §3 anchor:
+
+```python
+"""Deployment helpers.
+
+# Spec References
+- SPEC-SLD-03~draft docs/specs/spec-linked-documentation.md#SPEC-SLD-03~draft
+"""
+```
+
+The resolver (§5): extension `.py` → strip `#`/`"""` → find `Spec References` →
+regex-extract `(SPEC-SLD-03~draft, docs/specs/spec-linked-documentation.md,
+SPEC-SLD-03~draft)` → resolve the anchor to §3 of this spec. Same triple, same
+resolution as the equivalent Rust `//! # Spec References` block — that is the whole
+point of the one-grammar design (§2.4).
+
+---
+
+## 7. Acceptance criteria (testable)
+
+**Conventions (§4):**
+- **AC-1** A new spec assigned by scan-before-claim (§4.1) takes the next integer
+  above the highest `DOC-N` found anywhere under `docs/` (catalog + self-labeled),
+  and adds a catalog row (§4.5).
+- **AC-2** A spec's header is a visible bold-field block (§4.2) with all required
+  fields; no YAML frontmatter is present.
+- **AC-3** Every governed section carries a `{#SPEC-…}` anchor equal to its ID (§4.3).
+
+**Grammar & idioms (§2, §3):**
+- **AC-4** The reference regex (§2.2) extracts the same `(ID, path, anchor)` triple
+  from the Markdown-link form and the bare form.
+- **AC-5** A `# Spec References` block is recognized in each file type of §3 (Rust,
+  Python, TS/JS, shell, TOML/YAML, Markdown) via the stripped-phrase marker (§2.3).
+- **AC-6** A Markdown document with a visible `## Spec References` section resolves;
+  the HTML-comment fallback (§3.6) also resolves; a document with neither yields no ref.
+- **AC-7** An existing Rust `//! # Spec References` block resolves **unchanged**
+  (no regression — G2).
+
+**Resolver (§5) — verified once F1 lands:**
+- **AC-8** A file whose extension is not in §5.2 yields zero refs.
+- **AC-9** A reference whose anchor ≠ its leading ID, or whose anchor resolves to no
+  section, is dropped with a warning (declared-links-only).
+- **AC-10** A file with no block yields zero refs and is not an error (fail-open).
+
+---
+
+## 8. Non-goals
+
+- Four-status traceability enforcement (COVERED/UNCOVERED/ORPHANED/OUTDATED) — the
+  ISR reads links; it does not gate on coverage (carried from DOC-15 §1.3).
+- Implementing the resolver extension in Rust (this PR is docs-only; F1).
+- Auto-inserting or auto-rewriting `# Spec References` blocks into any source.
+- A CI SLD link-linter / dead-anchor check (a possible future follow-up, not
+  normative here).
+- Per-symbol spec-coverage metrics or a traceability matrix.
+- Renumbering the DOC-28-colliding file in place (fixed by follow-up F3).
+- Governing *which* code must be spec-linked — SLD defines *how* to link when an
+  author chooses to; it does not mandate coverage.
+
+---
+
+## 9. Authoring skills — subsuming the dangling `spec-authoring` / `spec-linked-docs` {#SPEC-SLD-05~draft}
+
+**ID:** SPEC-SLD-05~draft
+**Status:** Draft
+
+DOC-15 (`intent-conformance.md:13`, §2.4, §6.4) cites two skills that **do not
+exist** anywhere (`.claude/skills/`, `crates/trusty-mpm/src/assets/`,
+`~/.trusty-mpm/`). This spec is the **normative source** for both of their
+responsibilities; the skills, when authored (§11, F2), are thin operational wrappers
+that point back here.
+
+- **`spec-authoring` — responsibilities (now normative in §4):** how to create a
+  spec — scan-before-claim DOC-N assignment (§4.1), the header field block (§4.2),
+  the `SPEC-{SUBSYSTEM}-{NN}~{rev}` ID grammar and `{#SPEC-…}` anchors (§4.3), the
+  status lifecycle and rev-suffix semantics (§4.4), and the catalog-row requirement
+  (§4.5). An author following §4 needs no separate skill to write a conformant spec;
+  the F2 skill is a checklist/entry-point that defers to §4.
+- **`spec-linked-docs` (SLD) — responsibilities (now normative in §2, §3, §5):** how
+  to *link* a source artifact to a spec — the canonical reference grammar (§2), the
+  per-language `# Spec References` idioms (§3, including the visible Markdown form),
+  and the resolver's declared-links-only reading contract (§5). The F2 skill is a
+  per-language cheat-sheet that defers to §2/§3.
+
+**Contract for the follow-up skills (F2):** each skill's SKILL.md MUST cite this
+spec (`DOC-38`) as its normative source and MUST NOT restate normative rules — it
+links to the section, so there is one source of truth and the skills cannot drift
+from the spec. DOC-15's dangling citations SHOULD be updated to point at DOC-38
+(and, once they exist, the skills) — tracked as F4.
+
+---
+
+## 10. README changes (this PR)
+
+- **Add the catalog row** for DOC-38 in `docs/specs/README.md`.
+- **Rewrite the §"Spec-Linked Documentation (SLD)" section** to a short summary that
+  names DOC-38 as canonical and links to it, instead of restating the Rust-only
+  rustdoc convention as if it were the whole of SLD.
+- **Fix the stale "next free DOC-N" note** in the DOC-28-collision catalog note:
+  after the scan, DOC-34 is assigned (`managed-session-config-dir.md`), DOC-35/36
+  are cataloged, DOC-37 is self-labeled (`trusty-search-managed-repo-awareness.md`,
+  uncataloged), and **DOC-38 is claimed by this spec** — so the next free number for
+  the DOC-28 renumber follow-up is **DOC-39**.
+
+---
+
+## 11. Follow-ups / child issues (for the PM to file)
+
+Umbrella: **epic: spec-linked documentation, first-class & language-agnostic**
+(issue to be linked by the PM).
+
+| ID | Title | Scope | Deps | Effort |
+|----|-------|-------|------|--------|
+| **F1** | Extend `intent_source` spec-resolver beyond `.rs` | Implement §5: per-extension comment-syntax table (§5.2), stripped-phrase marker (§2.3), unified reference regex (§2.2), anchor resolution + declared-links-only/fail-open. AC-4..AC-10. | DOC-15 ISR (`intent_source`) exists | **M** |
+| **F2** | Author the `spec-authoring` + `spec-linked-docs` skills | Two SKILL.md files that cite DOC-38 as normative source and defer to §4 (authoring) / §2–§3 (linkage); no restated rules (§9). | DOC-38 (this spec) | **S** |
+| **F3** | Fix the DOC-28 self-label collision | Assign `mpm-cutover-resume-native-optimization.md` the next free number (**DOC-39** per §10) and add a catalog row; leave canonical DOC-28 untouched (§4.1). | scan (§4.1) | **S** |
+| **F4** | Update DOC-15's dangling skill citations | Repoint `intent-conformance.md:13`, §2.4, §6.4 from the non-existent `spec-linked-docs`/`spec-authoring` to DOC-38 (and the F2 skills once they exist). | F2 | **S** |
+| **F5** | Retrofit existing non-Rust source with SLD blocks (opt-in, incremental) | Where a non-Rust file is clearly governed by a spec, add a `# Spec References` block in its native idiom (§3). Declared-links-only — no bulk auto-insertion. | F1 | **M** (incremental) |
+
+**Suggested order:** F1 ∥ F2 → F3 → F4 → F5 (F5 continuous thereafter).
+
+---
+
+## 12. Change log
+
+- **2026-07-16** — Initial draft (DOC-38, `SPEC-SLD-01~draft` … `SPEC-SLD-05~draft`).
+  Promoted SLD from README prose to a first-class, language-agnostic spec per Bob's
+  directive ("SLD converted to a first class spec that we use for ANY language or
+  even markdown"). Defined the one-grammar `(spec-ID, path, anchor)` reference (§2),
+  the per-language `# Spec References` idioms incl. the visible `## Spec References`
+  Markdown form (§3), the promoted spec-document conventions (§4), the resolver
+  behavior contract for extending `intent_source` beyond `.rs` (§5, code as
+  follow-up F1), the authoring-skills contract subsuming the dangling
+  `spec-authoring`/`spec-linked-docs` skills (§9), and the F1–F5 follow-up
+  breakdown. Grounded in `docs/specs/README.md` (SLD/catalog prose) and DOC-15
+  (`intent-conformance.md` §1.3/§2.4/§6.4 — reader-only ISR, no four-status
+  traceability).


### PR DESCRIPTION
Closes #2836.

Promotes **Spec-Linked Documentation (SLD)** to a first-class, **language-agnostic,
implementation-neutral documentation standard**, per Bob's original directive
*("I want SLD converted to a first class spec that we use for ANY language or
even markdown")* — **revised per two binding design corrections from Bob after
reviewing the first version of this PR.**

**Docs-only.** No Rust changes, no changelog (mirrors DOC-34 / PR #1999).

## The two corrections (this revision)

1. **Frontmatter is canonical for Markdown, not a visible section.** Markdown
   documents declare their spec references in `spec_refs:` YAML frontmatter — the
   structured, directly machine-parseable equivalent of the standard's
   `(spec-ID, path, anchor)` triple — not in a `## Spec References` body section
   (which is now optional/informative only, for human readers).
2. **No-code standard.** DOC-38's normative body defines the standard itself
   (grammar, frontmatter schema, per-language idioms, authoring/numbering/
   lifecycle conventions) without binding it to any implementation. The
   `trusty_common::intent_source` resolver material is demoted to an informative
   annex (Annex A); implementing it is follow-up **F1**, not part of the standard.

DOC-38 now self-complies with its own convention — it carries `spec_refs:`
frontmatter (top of file) pointing at DOC-15 §6 (`SPEC-CONFORMANCE-03~draft`).

## Files changed

- **`docs/specs/spec-linked-documentation.md`** — **DOC-38**,
  `SPEC-SLD-01~draft … SPEC-SLD-03~draft` (reduced from 5 to 3 normative IDs: the
  two that covered the demoted resolver/skills material moved to informative,
  unanchored Annexes A/B).
- **`docs/specs/README.md`** — catalog row updated; §SLD section rewritten for the
  frontmatter decision and no-code framing; stale "next free DOC-N" note fixed.

## The frontmatter schema (final form)

Canonical, at the top of the file, before any other content:

```yaml
---
spec_refs:
  - id: <SPEC-ID>          # required; e.g. SPEC-CONFORMANCE-03~draft
    path: <relative-path>  # required; MUST be repo-root-relative (canonical/machine-parsed form)
    anchor: <SPEC-ID>      # required; MUST equal `id` (self-check)
    note: <string>         # optional; free-text, not parsed
---
```

- Each `spec_refs` entry is a **structured map** (canonical) or a **bare-string
  shorthand** using the same inline reference grammar/regex — a resolver accepts
  either and both yield the identical triple.
- Governs the **whole document**; there's no per-section frontmatter. It precedes,
  and never duplicates, the spec's existing bold-field metadata header
  (Status/Subsystem/Owner/…) — that header is unaffected and unchanged.
- **Path-form split (resolves a real tension):** frontmatter `path` is always
  repo-root-relative (canonical, machine-parsed). An *optional* visible section
  may instead use a file-relative link URL so it actually navigates on GitHub —
  informative only, never treated as canonical.
- An optional visible `## Spec References` section may echo the frontmatter for
  human readers but is never authoritative; frontmatter wins on disagreement.

## Other findings folded in from adversarial review of the prior revision

- **REV grammar broadened** — `~draft | ~v<N> | ~<named-tag>` (open lowercase
  alphanumeric token), so `~approved` (DOC-36's live usage, 6 sections) is valid,
  not just `draft`/`v<N>`.
- **Fenced code blocks excluded from marker scanning** (normative) — otherwise a
  line-based scanner would self-trigger on this very spec's own `# Spec
  References` / `## Spec References` example lines inside fenced examples.
- **Honest GitHub-rendering caveat for `{#SPEC-…}` anchors** — GFM ignores
  explicit heading IDs and auto-slugs instead, so these cross-links are
  best-effort on github.com, not a broken promise; they target non-GitHub
  tooling (mkdocs/pandoc) and resolvers that parse the marker from source text.
- **Marker phrase is explicitly case-insensitive** (`Spec References`), matching
  the existing `eq_ignore_ascii_case` behavior at
  `crates/trusty-common/src/intent_source/spec_resolve.rs:149`.
- **`{NN}` reworded** as an opaque per-spec ID counter, not a section-order index
  (DOC-38's own IDs don't track heading order).

## Follow-ups (child issues off the epic)

- **F1** — build a reference SLD resolver (e.g. extend `intent_source`) per the
  informative Annex A behavior sketch.
- **F2** — author the `spec-authoring` + `spec-linked-docs` skills (Annex B).
- **F3** — fix the DOC-28 self-label collision (assign next free **DOC-39**).
- **F4** — repoint DOC-15's dangling skill citations to DOC-38.
- **F5** — retrofit non-Rust source with inline SLD blocks (incremental).
- **F6** (new) — retrofit existing `docs/specs/*.md` with `spec_refs` frontmatter
  (honest note: no existing spec besides DOC-38 itself carries it yet).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
