### PR TITLE
docs(trusty-code): DOC-39 — harness UI functional spec

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -47,6 +47,7 @@ that governs it.
 | DOC-35 | `SPEC-PROJCTL-01~draft` … `-08~draft` | [`tm project`: Deterministic Project/Session Control Plane (CLI + Multipane TUI)](./tm-project-control-plane.md) | trusty-mpm — control plane / CLI / TUI / daemon API |
 | DOC-36 | `SPEC-TMMGR-01~approved` … `-06~approved` | [`tm manager`: Layer-3 Chat-Based Portfolio Project Manager](./tm-manager-vision.md) | trusty-mpm — daemon / inference layer / external channels |
 | DOC-38 | `SPEC-SLD-01~draft` … `-03~draft` | [Spec-Linked Documentation (SLD): A Language-Agnostic Source↔Spec Reference Standard](./spec-linked-documentation.md) | documentation standard — repository/language-agnostic (informative reference: trusty-common `intent_source`) |
+| DOC-39 | `SPEC-TCUI-01~draft` … `-08~draft` | [trusty-code Harness UI: Context-First Interactive Surface](./trusty-code-harness-ui.md) | trusty-code — API surface (JSON-RPC + events); SPA (web/Tauri) client downstream |
 
 > **Catalog note — `DOC-34` gap.** `DOC-34` (`SPEC-CFGDIR-01~draft`…`-05~draft`,
 > [Managed sessions launch with a tm-owned `CLAUDE_CONFIG_DIR`](./managed-session-config-dir.md))
@@ -60,9 +61,13 @@ that governs it.
 > file is **not** in this catalog. The collision is flagged here rather than resolved by
 > renumbering the file in-place (its self-label and any inbound references are left
 > untouched); a follow-up should assign it the next free `DOC-N` and add a catalog row.
-> **Next free `DOC-N` = `DOC-39`** (scan of the whole `docs/` tree, 2026-07-16): the
-> highest claimed number is **DOC-38** ([Spec-Linked Documentation](./spec-linked-documentation.md),
-> the entry above). DOC-34 is assigned ([`managed-session-config-dir.md`](./managed-session-config-dir.md),
+> **Next free `DOC-N` = `DOC-40`** (re-scan of the whole `docs/` tree, 2026-07-16): the
+> highest claimed number is now **DOC-39** ([trusty-code Harness UI](./trusty-code-harness-ui.md),
+> the entry above), which claimed the previously-free DOC-39 per the scan-before-claim
+> rule ([DOC-38 §4.1](./spec-linked-documentation.md) — a catalog's "next free" note is a
+> *hint, not authority*; the scan is authoritative). **DOC-38 §10 F3** (the DOC-28
+> renumber follow-up) names DOC-39 as its target — that is now stale and F3 must re-scan
+> and take **DOC-40**. DOC-34 is assigned ([`managed-session-config-dir.md`](./managed-session-config-dir.md),
 > #1999 — still a catalog gap), DOC-35/36/38 are cataloged, and **DOC-37** is
 > self-labeled by [`trusty-search-managed-repo-awareness.md`](./trusty-search-managed-repo-awareness.md)
 > (`SPEC-SEARCHREPO-01~draft`…, uncataloged). The DOC-N assignment rule (scan-before-claim)

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -47,7 +47,7 @@ that governs it.
 | DOC-35 | `SPEC-PROJCTL-01~draft` … `-08~draft` | [`tm project`: Deterministic Project/Session Control Plane (CLI + Multipane TUI)](./tm-project-control-plane.md) | trusty-mpm — control plane / CLI / TUI / daemon API |
 | DOC-36 | `SPEC-TMMGR-01~approved` … `-06~approved` | [`tm manager`: Layer-3 Chat-Based Portfolio Project Manager](./tm-manager-vision.md) | trusty-mpm — daemon / inference layer / external channels |
 | DOC-38 | `SPEC-SLD-01~draft` … `-03~draft` | [Spec-Linked Documentation (SLD): A Language-Agnostic Source↔Spec Reference Standard](./spec-linked-documentation.md) | documentation standard — repository/language-agnostic (informative reference: trusty-common `intent_source`) |
-| DOC-39 | `SPEC-TCUI-01~draft` … `-08~draft` | [trusty-code Harness UI: Context-First Interactive Surface](./trusty-code-harness-ui.md) | trusty-code — API surface (JSON-RPC + events); SPA (web/Tauri) client downstream |
+| DOC-39 | `SPEC-TCUI-01~draft` … `-09~draft` | [trusty-code Harness UI: Context-First Interactive Surface](./trusty-code-harness-ui.md) | trusty-code — API surface (JSON-RPC + events); SPA (web/Tauri) client downstream |
 
 > **Catalog note — `DOC-34` gap.** `DOC-34` (`SPEC-CFGDIR-01~draft`…`-05~draft`,
 > [Managed sessions launch with a tm-owned `CLAUDE_CONFIG_DIR`](./managed-session-config-dir.md))

--- a/docs/specs/trusty-code-harness-ui.md
+++ b/docs/specs/trusty-code-harness-ui.md
@@ -4,13 +4,15 @@
 **Subsystem:** trusty-code — API surface (JSON-RPC + events) primarily; SPA (web/Tauri) client downstream
 **Owner:** Engineering (trusty-code)
 **Last-updated:** 2026-07-16
-**Spec ID:** `SPEC-TCUI-01~draft` … `SPEC-TCUI-08~draft` (DOC-39)
+**Spec ID:** `SPEC-TCUI-01~draft` … `SPEC-TCUI-09~draft` (DOC-39)
 **Epic:** trusty-code interactive harness UI (umbrella issue to be linked by the PM)
 **Builds on:**
 - [`docs/trusty-code/vision-and-architecture-spec.md`](../trusty-code/vision-and-architecture-spec.md)
   — Axiom 3 (§, line 84): **layer priority API → CLI → TUI → Web**; "UIs are deferred
   thin clients … contain NO logic of their own". This spec is that axiom applied: its
-  normative core is the **API delta**, not the pixels.
+  normative core is the **API delta**, not the pixels. §2.1 restates that axiom as an
+  **architectural constraint** rather than a build order, and is binding over every
+  other section of this document.
 - [`docs/trusty-code/parity-spec.md`](../trusty-code/parity-spec.md) — normative for
   cross-model *comparison runs* only; the bake-off is how a harness is **scored**, not
   what one **is** (§1.2).
@@ -74,13 +76,17 @@ The parity/bake-off harness is **how you score a harness, not what one is**. Com
 runs remain normative under the parity spec and are unaffected by this document.
 
 **Platform: an SPA (web/Tauri) driving our API.** Not a TUI, not a terminal renderer.
+"Driving our API" is the whole of it: **web and Tauri are two shells over one daemon, and
+differ in packaging only** (§2.1). The slash in "web/Tauri" is not a fork.
 
 ### 1.3 Non-goals
 
 The proposal has no non-goals. A spec must. **Out of scope for this document:**
 
 1. **Not a general-purpose IDE.** The Project/IDE half (10a) is scope-flagged, not
-   scope-committed (§7, Q4). trusty-code does not compete with VS Code.
+   scope-committed (§7, Q4). trusty-code does not compete with VS Code. If it ships, its
+   file reads are **daemon-served** like everything else (§2.1) — an IDE half is not a
+   licence for the UI to touch the disk.
 2. **Not a replacement for `trusty-mpm`.** No tmux, no multi-project daemon, no
    worktree orchestration. One tcode instance per project (vision spec §1).
 3. **Not multi-user / not collaborative.** Single-operator. Auth and tenancy are
@@ -107,6 +113,55 @@ is **always present** and renders either an *empty* state (no project, tabs lock
 muted status) or a *hydrated* one. **Cold start is the empty state of the same shell,
 not a different screen** (principle 4). Screen 7a is that empty state; it is a designed
 state, not an error screen (PDF §7).
+
+### 2.1 Foundational constraint — the UI communicates with the daemon {#SPEC-TCUI-09~draft}
+
+**ID:** SPEC-TCUI-09~draft
+**Status:** Draft
+**Owner directive (Bob).** Binding over every other section of this document.
+
+> **The UI communicates with the daemon. All UI services talk to the daemon; the daemon
+> provides all functionality.**
+
+This is **stronger than the layer-priority rule** it derives from. Axiom 3
+(API → CLI → TUI → Web) reads as a **process** — an ordering, a thing you do *first*.
+Stated as **architecture**, it is not about sequence at all: it is a statement about
+**where functionality is permitted to live**. Ordering is a consequence; the constraint
+is the point.
+
+**C-1 — The UI is a THIN CLIENT.** No business logic, no local capability, no direct
+filesystem, process, or git access **in any UI target**. The UI renders daemon state and
+issues daemon calls. That is its entire job.
+
+**C-2 — The daemon is the single source of functionality.** Anything the UI needs MUST
+exist as a daemon API — a JSON-RPC method, an event, or both. **If a screen needs
+something the daemon cannot answer, that is an API gap to specify — never a UI-side
+workaround.** This spec's §5 is that rule applied: every UI need is resolved to an API
+delta, and a need with no API is recorded as MISSING rather than absorbed by the client.
+
+**C-3 — Corollary: no capability divergence between targets.** A feature MUST NOT exist
+in one UI target and not another. This makes **"web vs Tauri" moot at the functional
+level**: both are shells over the same daemon API and MUST be behaviorally identical.
+Any difference between them is a packaging difference, never a capability one.
+
+**C-4 — Corollary: Tauri MUST NOT use native fs/dialog APIs, even though it can.**
+Reaching for `@tauri-apps/plugin-fs` or a native folder dialog is **not permitted as a
+functional path**. It is not a shortcut — it places functionality in the UI layer and
+manufactures exactly the divergence C-3 forbids: the web target would then be missing a
+capability that no daemon API provides, and the gap would be invisible until someone
+opened the app in a browser. A native dialog MAY be used **only as a cosmetic shell over
+the same daemon-provided data** — the picker's contents, git-ness, and paths still come
+from `project.list_dir` (§5.8). The moment it sources its own data it is a violation.
+
+**AC-19.1** No UI target reads the filesystem, spawns a process, or shells out to `git`
+directly. Every such fact arrives from a daemon call or event.
+**AC-19.2** A capability matrix of web vs Tauri is **empty by construction** — any row
+in it is a spec violation, not a platform note.
+**AC-19.3** Client-side derivation of a value the daemon owns is a violation, not an
+optimization (see §5.6 AC-17.1's "not recomputed", which is this rule applied early).
+
+> **This constraint resolves §7's Q2 (web vs Tauri) rather than answering it** — the fork
+> dissolves instead of being decided. See §7 Q2, now **RESOLVED**.
 
 ---
 
@@ -230,6 +285,45 @@ header switcher and status bar (7b).
 These MUST converge on **one** typed project binding owned by the workstream. A label
 that cannot be indexed and a path that cannot be omitted are two halves of one missing
 object. See §5.5.
+
+#### 4.2.1 Directory inspection — the 7a picker is a daemon capability
+
+**The 7a local-folder picker renders a directory tree. Under §2.1 that tree MUST come
+from the daemon** (`project.list_dir`, §5.8) — not from Tauri's native fs, not from a
+browser file-input, not from a native folder dialog (§2.1 C-4).
+
+> **The daemon is already local.** This was previously treated as a platform question —
+> *"a browser cannot walk `~/code/`, so does web lose project-open?"* (the old §7 Q2). The
+> question dissolves once the constraint is applied: **directory inspection is an API
+> concern, not a platform capability.** The daemon runs on the operator's machine and can
+> already read the disk. Serve it from the daemon and **both targets get it identically**
+> — which is C-3, and which is why 7a is no longer at risk of being a Tauri-only screen.
+
+**Requirement.** The picker MUST render, per entry: the entry **name**, whether it is a
+**directory**, and its **git-ness** — plus a **breadcrumb** of the current path
+(7a: `~/code / acme-api /`). A git entry renders the `git` badge; a non-git entry renders
+`—` (7a's `scratch` row).
+
+**The leverage — one endpoint serves two jobs.** Git-ness is not picker decoration: it
+**feeds §4.2's three-state binding model directly**. The same field that draws the badge
+decides the binding:
+
+| `list_dir` entry | Badge (7a) | Binding on select (§4.2) |
+|---|---|---|
+| `git: true` | `git` | **Bound · git repo** — full git affordances |
+| `git: false`, `is_dir: true` | `—` | **Bound · non-git** — indexed, git affordances hidden |
+| *(nothing selected)* | — | **Projectless** |
+
+So the picker and the binding decision are **one API call**, not two subsystems that
+must agree. This is also why the git-only rule the proposal states (and §4.2 corrects) is
+not merely wrong in principle — it is contradicted by the very screen that would have to
+implement it: 7a renders `scratch` as a **selectable** non-git entry.
+
+**AC-2.5** The picker's entries, git-ness, and breadcrumb are **daemon-served**
+(`project.list_dir`). No UI target enumerates the filesystem itself.
+**AC-2.6** Selecting a `git: false` directory binds **Bound · non-git** and MUST NOT
+error — non-git binding already ships (#2728/#2747, `run_task/mod.rs:100-107`).
+**AC-2.7** The picker behaves **identically** in web and Tauri (§2.1 C-3).
 
 ### 4.3 Index readiness is first-class {#SPEC-TCUI-04~draft}
 
@@ -397,6 +491,10 @@ the banner is the cheapest way to hold it.
 **AC-7.2** Every row shows lane badge, query, hit count, latency, **requesting agent**,
 and age (10d). This requires §5.2 + §5.3.
 **AC-7.3** ⌘K find is scoped to the bound project and is unavailable when projectless.
+**AC-7.4** ⌘K find is a **daemon query** (§2.1 C-1). It MUST NOT be backed by a
+client-side file list or a shadow index — "jump to a file/symbol/memory" is a question
+about the indexed project, which is daemon-owned state. The UI sends the term and renders
+the answer.
 
 ### 4.8 Attribution everywhere
 
@@ -476,6 +574,18 @@ record. The seam MUST NOT surface as a gap, an error, or a silent truncation.
 **AC-11.3** The SSE ring replay MUST be used for the **live tail only**, never presented
 as complete history.
 
+> **§2.1 names the tempting shortcut here.** trusty-memory is a *separate service* with
+> its own reachable surface, so "page history straight from trusty-memory" looks like a
+> free win. **It is a C-2 violation:** it makes the UI a client of two backends, teaches it
+> which store answers which turn range, and puts the ring-vs-durable retention seam —
+> genuine domain logic (AC-11.6) — inside the client. **The client talks to the tcode
+> daemon and nothing else**; tcode owns the dual-store read and hands back one coherent
+> history. The two backing stores are an implementation fact of the daemon, not a fact the
+> UI is allowed to know.
+
+**AC-11.8** History paging is served by a **tcode daemon** method. No UI target queries
+trusty-memory (or any other service) directly — one daemon, one client (§2.1 C-2).
+
 **Requirement — the compaction boundary is a visible, honest object.**
 
 When cadence compression fires (N=8, `agent_loop/cadence.rs::maybe_cadence_compress`),
@@ -539,6 +649,11 @@ name, from a **snapshot RPC** — not by folding events.
 every deterministic feature lands in the HTTP API BEFORE any UI surfaces it. This
 section is therefore the normative core of the spec; the pixels are downstream.**
 
+**And per §2.1, "before" understates it: the API is not merely first, it is the _only_
+place functionality may live.** Every MISSING row in §5.1 is therefore a hard blocker on
+its screen — never an invitation for the client to cover the gap itself. A UI need with no
+API is an unbuilt feature, not a UI problem.
+
 ### 5.0 Today's surface (verified at `origin/main`)
 
 **The API is 3 HTTP routes** (`serve/http.rs:96-98`):
@@ -567,8 +682,9 @@ JSON-RPC method or a new/extended `Event` variant.
 | 8 | Agent roster (10b, 11a) | `session.get_agents` snapshot + `model` field | **PARTIAL** | Event-folding is an acceptable stopgap |
 | 9 | Workstream list/resume (7a/7b switcher) | Workstream domain object + persistence + `workstream.list` | **MISSING** | Domain + storage (§4B) |
 | 10 | Workflow lanes (10e) | Branch/PR/dirty-tree subsystem | **MISSING** | New subsystem, nothing to build on |
-| 11 | Clone-from-URL (7a) | `project.clone_from_url` | **MISSING** | Not present anywhere |
-| 12 | Streaming cost (header `$0.31`) | Per-turn cost event | **PARTIAL** | Tokens stream; cost only aggregates at run-end |
+| 11 | Clone-from-URL (7a) | `project.clone_from_url` | **MISSING** | Not present anywhere. Daemon capability when it lands (§5.8) |
+| 12 | Streaming cost (header `$0.31`) | Per-turn cost event | **PARTIAL** | Tokens stream; cost only aggregates at run-end. **Must be a daemon event** — §2.1 forbids client-side pricing (§7 Q6) |
+| 13 | Local-folder picker + binding (7a, §4.2.1) | `project.list_dir{path}` → entries `{name,path,display_path,is_dir,git}` | **MISSING** | New RPC on the existing `/rpc` route (§5.8). **Phase 1** |
 
 ### 5.2 Tool attribution — one schema change unlocks the rest
 
@@ -653,6 +769,16 @@ session.get_agents() -> { agents: [{ agent_id, name, model, state, task, todos, 
 acceptable Phase-1 substitute** (§6.3) — the ring replay makes it correct-enough for a
 single-operator client, which is why this is not a Phase-1 blocker.
 
+> **§2.1 tension — acknowledged, time-boxed, and now on the clock.** Event-folding is the
+> one place this spec knowingly leaves derivation in the client: "who is running?" is
+> daemon-owned state that the UI reconstructs. It survives Phase 1 on a **bounded
+> rationale** — the fold is over a ring the daemon replays, is small, and has exactly one
+> consumer. But it is **the shape C-1 forbids**, and it degrades precisely when the ring
+> evicts (§4A) — the roster silently loses agents the daemon still knows about. Two targets
+> folding independently is also two chances to fold differently (C-3).
+> **`session.get_agents` (§5.4) is the principled endpoint; the fold is a Phase-1 loan,
+> not a design.** Recorded so the deferral in §6.3 is read as debt, not as approval.
+
 ### 5.5 Project binding (PARTIAL — the two surfaces must converge)
 
 ```rust
@@ -691,6 +817,85 @@ No branch, PR, dirty-tree, or unpushed concept exists. `Phase*` events are inter
 harness phases; `verify_gate.rs` gates `finish_task` on a test command only. 10e needs a
 git+forge integration subsystem built from zero. **Deferred (§6.3).**
 
+### 5.8 Directory inspection — `project.list_dir` (NEW, Phase 1)
+
+Serves the 7a picker (§4.2.1) and, with the same response, the §4.2 binding decision.
+Namespaced `project.*` to match the `session.*` / `task.*` convention already registered
+in `session/protocol.rs:45-81`; it is a new method on the existing `POST /rpc` route —
+**no new HTTP route** (§5.0's 3-route surface is unchanged).
+
+```rust
+// Request
+project.list_dir({
+    path: Option<String>,   // absolute path; None => daemon's default root(s)
+})
+
+// Response
+{
+    path: String,            // canonical absolute path listed, e.g. "/Users/bob/code"
+    display_path: String,    // home-abbreviated, e.g. "~/code"  — powers the breadcrumb
+    parent: Option<String>,  // absolute parent path; None at a root (disables "up")
+    entries: [
+        {
+            name: String,          // "acme-api"
+            path: String,          // "/Users/bob/code/acme-api"
+            display_path: String,  // "~/code/acme-api"
+            is_dir: bool,          // true => expandable (7a's ▸ arrow)
+            git: bool,             // true => `git` badge; false => `—`
+        }
+    ]
+}
+```
+
+**Field notes (normative):**
+
+- **`git`** is "is this entry itself a git working tree" (a `.git` entry directly
+  inside it) — **not** "is it inside one". 7a's `acme-api`/`marketing-site`/`data-pipeline`
+  are `true`; `scratch` is `false`. This is the field §4.2.1's binding table keys on.
+- **`display_path` is daemon-owned, not a client string-trim.** The UI **cannot** know
+  `$HOME` — it has no environment (§2.1 C-1). Abbreviating `/Users/bob/code` → `~/code`
+  is daemon knowledge, so the daemon serves it. Sorting/filtering entries is pure
+  presentation and stays in the client; deriving `~` is not.
+- **`path: None`** returns the daemon's default root(s) rather than erroring, so the
+  picker has a defined cold-start entry point without the client inventing one.
+- **`entries: []` simply means the directory is empty.** There is no result-state enum:
+  unreadable or nonexistent paths are **ordinary JSON-RPC errors**, exactly as a local app
+  surfaces a failed `ls`. See the guard note below for why nothing more elaborate is
+  specified here.
+
+**AC-20.1** `project.list_dir` returns entry name, path, `is_dir`, and `git` for every
+entry — the minimum 7a renders.
+**AC-20.2** `git` distinguishes a git working tree from a plain directory, and that same
+value drives §4.2's binding state. One call, both jobs.
+**AC-20.3** The breadcrumb renders from `display_path` / `parent`, not from client-side
+`$HOME` inference.
+
+> **No path-guard layer — deliberate, do not "fix" this** (owner directive, Bob).
+> **tcode is a local app; the daemon runs as the operator with the operator's own
+> entitlements.** A directory listing exposes nothing the operator cannot already `ls`.
+> Decisively: **the daemon already exposes `task.run`, which executes arbitrary code as
+> the operator.** `project.list_dir` is **strictly less powerful than what the API already
+> permits** — bolting a denylist onto browse while `task.run` sits beside it is ceremony,
+> not security: it does not move the threat boundary.
+>
+> **The #2747 / trusty-search `allow_sensitive_path` precedent does NOT transfer here.**
+> That denylist guards **indexing** — file *contents* leaving the machine for an embedder
+> — which is a categorically different act from *listing paths*. Do not cite it as
+> precedent for this method.
+>
+> **macOS TCC:** the app inherits whatever entitlements it is granted, as any local app
+> does. **No bespoke permission-state machine and no designed "permission needed" state**
+> — those are not in this spec's empty/degraded-state inventory. (Index readiness, §4.3,
+> **stays** in that inventory: it is a real degraded state and is Phase 1.)
+
+**Clone-from-URL stays deferred (§6.3) — but it is a DAEMON capability when it lands.**
+7a's second card ("GitHub URL → Clone & attach") is out of Phase 1 for the reason already
+recorded: it exists nowhere, is purely additive, and local-folder binding already covers
+the mandated projectless→bound path. That deferral is unchanged by §2.1. What §2.1 *does*
+settle is **where it lands when it lands**: cloning a repo is filesystem-and-process work,
+so it is `project.clone_from_url` on the daemon (§5.1 #11) — **never** a UI-side git
+operation, and never Tauri-native. Deferring it therefore costs nothing architecturally.
+
 ---
 
 ## 6. Phased delivery
@@ -702,11 +907,13 @@ that ships pixels ahead of its events is not a phase; it is a mock.
 
 ### 6.2 **Phase 1 cut line** — the smallest surface that unlocks the differentiated core
 
-**Phase 1 is five event/RPC changes and almost no UI.** It is chosen to unlock exactly
+**Phase 1 is six event/RPC changes and almost no UI.** It is chosen to unlock exactly
 what makes this harness different from a linear stream — **provenance, the search audit
-trail, memory injected-vs-held, readiness, and the context budget** — and nothing else.
-Every item is already computed in the runtime and discarded at a boundary; Phase 1 is
-mostly **un-discarding values we already have**.
+trail, memory injected-vs-held, readiness, and the context budget** — plus the one call
+that makes the entry screen reachable at all. Items 1–5 are already computed in the
+runtime and discarded at a boundary; that part of Phase 1 is mostly **un-discarding
+values we already have**. Item 6 is the exception and is new code — small, and load-bearing
+for 7a (§6.2.1).
 
 | # | Item | Why in Phase 1 | Size |
 |---|---|---|---|
@@ -715,11 +922,12 @@ mostly **un-discarding values we already have**.
 | **3** | `Event::MemoryRecalled { query, results:[{score, injected}], agent_id }` (§5.3) | Injected-vs-held is the most literal form of the core bet; scores already exist internally. | S |
 | **4** | Surface `IndexReadiness` as event + RPC (§5.6) | Pure wiring — already computed, stderr-only. Without it, search results are untrustworthy by construction. | S |
 | **5** | Stop discarding `CadenceOutcome` → emit working-context ratio (§5.6) | One return value. Makes "it never ends" falsifiable. | S |
+| **6** | `project.list_dir` — daemon-served directory inspection (§5.8) | **7a's picker has no other legal source** (§2.1 C-4 bars Tauri-native fs). Ships with projectless (§6.2.1): that pair is what makes the entry screen reachable. Its `git` field also drives §4.2's binding, so it is not picker-only. | S |
 
 **Phase 1 UI:** the status bar (readiness + budget), the 8b inline monitor card, the
-10d Search tab, and the **goal-slot panel** (§6.2.1). These are the surfaces that
-require **no** new domain object — they render Phase 1's events against today's
-non-durable registry.
+10d Search tab, the **goal-slot panel** (§6.2.1), and the **7a local-folder picker**
+(§4.2.1). These are the surfaces that require **no** new domain object — they render
+Phase 1's events against today's non-durable registry.
 
 #### 6.2.1 Projectless — **Bob mandated it; here is where it lands and why**
 
@@ -733,6 +941,11 @@ non-durable registry.
   unreachable**, because `task.run` cannot be called without a project. Screen 7a is
   literally unimplementable. Every other Phase-1 surface renders inside a shell whose
   entry state does not exist.
+- **7a is blocked twice, and `project.list_dir` (§5.8) clears the second block.**
+  Projectless makes the screen *reachable*; the picker makes it *actionable* — a 7a you
+  can enter but whose folder list has no legal data source is still not a screen. Under
+  §2.1 C-4 the Tauri-native shortcut that would have unblocked it is barred, so the two
+  ship together or 7a ships in neither target.
 - It **de-risks the binding model early**: the three states (§4.2) are the correction
   this spec makes to the proposal, and the cost of discovering that reconciliation is
   wrong is far lower now than after the workstream object is built on top of it.
@@ -749,8 +962,8 @@ the Workflow tab, the IDE half, or clone-from-URL.
 | **Workstream persistence** (§4B) | Real **domain + storage** work — deciding what a workstream *is*, not adding an endpoint. The largest item in the spec. Phase 1 ships value on the existing registry without it. |
 | **Per-line diff attribution UI** (10a gutter) | **Depends on §5.2** (`agent_id`). Ship the schema first; the gutter is a downstream consumer. |
 | **Workflow / delivery pipeline** (10e) | **New subsystem, nothing to build on** — no branch/PR/dirty-tree concept exists anywhere (§5.7). Also git-only, so it needs §4.2 settled first. |
-| **Agent roster snapshot** (10b) | **Event-folding is an acceptable substitute** — the SSE ring replay renders a correct roster for a single-operator client. Real cost, low marginal value now. |
-| **Clone-from-URL** (7a) | Does not exist anywhere; pure additive scope with no dependents. Local-folder binding covers the mandated projectless→bound path. |
+| **Agent roster snapshot** (10b) | **Event-folding is an acceptable substitute** — the SSE ring replay renders a correct roster for a single-operator client. Real cost, low marginal value now. **Carries a §2.1 tension: the fold is a loan, not a design** (§5.4). |
+| **Clone-from-URL** (7a) | Does not exist anywhere; pure additive scope with no dependents. Local-folder binding (`project.list_dir`, §5.8) covers the mandated projectless→bound path. **When it lands it is `project.clone_from_url` on the daemon — never a UI-side git op** (§5.8). |
 | **Monitor columns** (9b) | Demoted to transient trace mode (§4.6.1); the 8b inline card delivers the same trace at full width. |
 
 ### 6.4 Phase 2+
@@ -770,13 +983,38 @@ holds the **rationale for the 8a/8b and 9a/9b options** this spec had to reconst
 from pixels (§4.6). If it exists, it should be committed alongside the PDF and this
 spec's §4.6/§4.6.1 conclusions re-checked against it. **Owner: design.**
 
-**Q2 — Platform split: web vs Tauri — what actually differs?** "SPA (web/Tauri)" is
-settled as the platform, but the two are not the same product. Undecided: local
-filesystem access for the IDE half (10a) and the 7a local-folder browser — a browser
-cannot walk `~/code/`; does web lose project-open entirely, or proxy it through the
-daemon? Also: OS keychain vs browser storage for tokens, and whether the daemon is
-assumed local (`localhost`) or remote. **This gates §4.2's local-folder picker.**
-**Owner: Bob.**
+**Q2 — Platform split: web vs Tauri — what actually differs? — RESOLVED.**
+*Resolution (Bob): "Tauri can walk a local directory? But we should be able to provide an
+API to inspect directories."*
+
+**The fork dissolves; it was not decided.** The question assumed directory access was a
+**platform capability**, so the two targets had to differ. It is an **API concern**: the
+daemon is **already local** and already reads the disk. Serve directory inspection from
+the daemon (`project.list_dir`, §5.8) and **both targets get it identically**.
+
+What follows:
+
+- **Nothing differs functionally.** Per §2.1 C-3, a capability in one target and not the
+  other is a spec violation. Web and Tauri are shells over one daemon API and MUST be
+  behaviorally identical; the difference is packaging, not capability.
+- **No Phase-1 surface is invalidated.** The prior draft flagged that 7a's picker might
+  not survive the web target. It survives in both — the picker is `project.list_dir`, and
+  the same `git` field also drives §4.2's binding (§4.2.1).
+- **Tauri-native fs/dialog is barred, not merely unnecessary** (§2.1 C-4). An earlier
+  framing called a native picker "optional polish"; that was **wrong** under §2.1 — it
+  would relocate functionality into the UI layer and create the very divergence C-3
+  forbids. A native dialog is permitted only as a **cosmetic shell over daemon-provided
+  data**.
+- **The IDE half (10a)** is unaffected by platform and remains scoped by **Q4** — if it
+  ships, its file reads are daemon-served like everything else. Q2 never gated it; Q4 does.
+- **The daemon is assumed local.** tcode is a local app (§5.8): one instance per project
+  (§1.3 non-goal 2), running as the operator with the operator's own entitlements. Remote
+  daemons are out of scope for this spec.
+- **Still open, and belongs to Q3, not here:** token storage (OS keychain vs browser
+  storage) is an *auth* question. It is the one place a real web-vs-desktop difference may
+  surface — and it surfaces as an **identity-model** question (Q3), not a capability split.
+
+**Owner: Bob. → RESOLVED 2026-07-16.**
 
 **Q3 — Auth / multi-user.** Wholly unaddressed by the proposal. 7a's header renders
 "**OAuth login**" and 7a's GitHub-URL card says private repos "use your **connected
@@ -800,11 +1038,20 @@ version/CAS (`session/protocol_goals.rs`). A model write can silently clobber an
 operator edit mid-turn. Acceptable, or does the operator source win until cleared?
 **Owner: engineering.**
 
-**Q6 — Streaming cost.** The header renders live cost (`$0.02 → $1.42` across screens),
-but dollar cost only aggregates at run-end (`aggregate_usage_per_role` →
-`registry.set_run_outcome`). Tokens stream live (`LlmRequested{prompt_tokens}`,
-`LlmResponded{completion_tokens, latency_ms}`). Compute cost client-side from streaming
-tokens, or add a streaming cost event? **Owner: engineering.**
+**Q6 — Streaming cost — NARROWED by §2.1.** The header renders live cost
+(`$0.02 → $1.42` across screens), but dollar cost only aggregates at run-end
+(`aggregate_usage_per_role` → `registry.set_run_outcome`). Tokens stream live
+(`LlmRequested{prompt_tokens}`, `LlmResponded{completion_tokens, latency_ms}`).
+
+> **§2.1 eliminates one of the two options.** This was posed as "compute cost client-side
+> from streaming tokens, **or** add a streaming cost event?" **The first option is now a
+> violation** — token→dollar conversion needs a per-model pricing table, which is business
+> logic and daemon-owned state; putting it in the client is exactly C-1, and would drift
+> per target the moment one shell updated its table (C-3). **A streaming cost event is
+> therefore the only conforming answer.**
+
+The remaining question is scope, not architecture: emit cost per `LlmResponded`, or a
+periodic `Event::CostUpdated` aggregate? **Owner: engineering.**
 
 **Q7 — Non-PM context budget.** Cadence is PM-only by construction
 (`AgentLoopConfig.cadence` defaults `None`; only `task/executor.rs:327` sets `Some`).
@@ -852,9 +1099,28 @@ This is carried forward verbatim because it is the one piece of the visual syste
 | **F1** | Add the DOC-39 catalog row to `docs/specs/README.md` and refresh its stale "next free `DOC-N`" note to **DOC-40**. | this spec |
 | **F2** | Commit the missing interactive wireframe doc (§7 Q1); re-check §4.6/§4.6.1 against it. | design |
 | **F3** | File the Phase-1 issues (§6.2) under the UI epic, sequenced with §5.2 first. | this spec |
-| **F4** | Resolve Q2/Q3/Q4 (platform, auth, IDE scope) before Phase 2 planning. | Bob |
+| **F4** | Resolve ~~Q2~~/Q3/Q4 (~~platform~~, auth, IDE scope) before Phase 2 planning. **Q2 is RESOLVED** (§7); Q3/Q4 remain. | Bob |
+| **F6** | File the `project.list_dir` Phase-1 issue (§5.8), paired with projectless (§6.2.1) — 7a needs both to be a screen. | this spec |
+| **F7** | Q6's client-side-cost option is now a §2.1 violation; scope the streaming cost **event** instead. | engineering |
 | **F5** | Note for DOC-38 §10 F3 (DOC-28 renumber): DOC-39 is now **claimed by this spec**; that follow-up must re-scan and take **DOC-40**. | DOC-38 |
 
 ## Changelog
 
 - **2026-07-16** — Initial draft (DOC-39, `SPEC-TCUI-01~draft` … `SPEC-TCUI-08~draft`).
+- **2026-07-16** — **Daemon-is-everything amendment** (owner directive, Bob). Adds §2.1
+  `SPEC-TCUI-09~draft` — *"The UI communicates with the daemon; the daemon provides all
+  functionality"* — as a foundational **architectural** constraint (C-1 thin client, C-2
+  daemon-as-sole-source, C-3 no capability divergence, C-4 no Tauri-native fs/dialog), and
+  propagates it: **Q2 RESOLVED** (the web/Tauri fork dissolves — directory inspection is an
+  API concern, not a platform capability); new **§4.2.1** (the 7a picker is daemon-served,
+  and its `git` field drives §4.2's binding — one call, two jobs); new **§5.8**
+  `project.list_dir` **added to the Phase-1 cut line** (now six items), paired with
+  projectless because 7a is blocked twice; **Q6 narrowed** (client-side cost computation is
+  now a violation → streaming cost event is the only conforming answer); **AC-11.8** (no
+  direct trusty-memory access from the client); **AC-7.4** (⌘K find is a daemon query);
+  **§5.4** roster event-folding recorded as a time-boxed §2.1 loan rather than a design.
+  Records why `project.list_dir` carries **no path-guard layer**: tcode is a local app and
+  the daemon already exposes `task.run` (arbitrary code as the operator), so a listing is
+  strictly less powerful — and #2747's `allow_sensitive_path` guards *indexing*, not path
+  listing, so it is not precedent here. No TCC permission-state machine; index readiness
+  (§4.3) remains the empty/degraded-state inventory's real member.

--- a/docs/specs/trusty-code-harness-ui.md
+++ b/docs/specs/trusty-code-harness-ui.md
@@ -275,16 +275,25 @@ MUST **hide** (not fake, not error) git-only affordances.
 **AC-2.4** The project name attaches to the workstream on bind and appears in the
 header switcher and status bar (7b).
 
-**API reconciliation (the two surfaces disagree today):**
+**API reconciliation (the two surfaces disagree today) — corrected:**
 
-- `task.run` takes `project: PathBuf` — **REQUIRED** (`task/protocol.rs:48`). Projectless
-  is therefore **impossible today**. It MUST become `Option<PathBuf>`.
-- `session.create` takes `project: Option<String>` — an **untyped label**
-  (`protocol.rs:157`), disconnected from the path `task.run` demands.
+- `task.run`'s per-request params carry **no project field at all** —
+  `TaskRunRequestParams` (`task/protocol.rs:61-91`) has none. The `project: PathBuf` at
+  `task/protocol.rs:48` is a parameter to `register()`, wired **once at daemon-boot time**:
+  `serve::build_router(project: PathBuf)` (`serve/mod.rs:91`) receives it from the process's
+  own startup arguments and passes it once into
+  `task::protocol::register(&mut router, sessions.clone(), project, agents_dir)`
+  (`serve/mod.rs:97`), which closes over it for the life of the router. Projectless is
+  therefore **not a request-DTO type swap** — it is a **daemon-bootstrap / binding-lifecycle**
+  change: `build_router` (and everything it wires) MUST accept an absent binding, and every
+  session the daemon creates for the life of that process inherits it.
+- `session.create` takes `project: Option<String>` — an **untyped, per-request label**
+  (`protocol.rs:157`), disconnected from the path baked into the daemon at boot.
 
-These MUST converge on **one** typed project binding owned by the workstream. A label
-that cannot be indexed and a path that cannot be omitted are two halves of one missing
-object. See §5.5.
+These MUST converge on **one** typed project binding, resolved **once when the daemon
+starts** and carried by every session it creates for that process's lifetime. A
+per-request label that cannot be indexed and a boot-time path that cannot be omitted are
+two halves of one missing object, on two different lifecycles. See §5.5.
 
 #### 4.2.1 Directory inspection — the 7a picker is a daemon capability
 
@@ -781,19 +790,31 @@ single-operator client, which is why this is not a Phase-1 blocker.
 
 ### 5.5 Project binding (PARTIAL — the two surfaces must converge)
 
+**Corrected model** (§4.2) — this is a **daemon-bootstrap / binding-lifecycle** change,
+not a per-request DTO type swap: `task.run` never had a project field on its request
+params, so there is no request type to widen. The change is to what the daemon is
+willing to *start* without, and to what every session it creates then inherits.
+
 ```rust
-// task/protocol.rs:48 — REQUIRED today; projectless is impossible
-project: PathBuf            →  project: Option<ProjectBinding>
-// protocol.rs:157 — untyped label, disconnected from the path above
-project: Option<String>     →  project: Option<ProjectBinding>
+// task/protocol.rs:48 — register()'s parameter, bound ONCE at daemon-boot time via
+// serve/mod.rs:91 build_router(project: PathBuf) → serve/mod.rs:97
+// task::protocol::register(&mut router, sessions, project, agents_dir).
+// TaskRunRequestParams (task/protocol.rs:61-91) carries no project field to change.
+project: PathBuf            →  binding: ProjectBinding   // register()'s / build_router()'s param
+
+// protocol.rs:157 — untyped, PER-REQUEST label, disconnected from the boot-time path above
+project: Option<String>     →  project: Option<PathBuf>  // resolved into ProjectBinding per call
 
 enum ProjectBinding { None, Directory(PathBuf), GitRepo(PathBuf) }  // §4.2's three states
 ```
 
-**AC-16.1** `task.run` accepts **no project** and the daemon runs projectless.
-**AC-16.2** `session.create` and `task.run` share **one** binding type. Today one takes a
-path it cannot omit and the other a label it cannot index; that is one object split in
-half across two surfaces.
+**AC-16.1** The daemon itself MUST be startable with **no project bound** — `build_router`
+and `register` MUST accept an absent binding — since `task.run`'s own request params never
+carried one to begin with; a session created against such a daemon is projectless.
+**AC-16.2** `session.create`'s per-request binding and the daemon's boot-time binding share
+**one** typed binding. Today one is a boot-time path that cannot be omitted and the other
+is a per-request label that cannot be indexed; that is one object split in half across two
+surfaces on two different lifecycles (process-lifetime vs. per-call).
 **AC-16.3** The binding distinguishes non-git from git (§4.2) — non-git indexing already
 ships (#2728/#2747, `run_task/mod.rs:100-107`).
 
@@ -933,9 +954,15 @@ Phase 1's events against today's non-durable registry.
 
 **Projectless is Phase 1.** Rationale, stated deliberately:
 
-- It is a **type change, not a subsystem** — `project: PathBuf` → `Option<...>`
-  (`task/protocol.rs:48`) plus reconciling `session.create`'s untyped label (§5.5).
-  Small, mechanical, and testable.
+- It is a **daemon-bootstrap / binding-lifecycle change, not a request-DTO type swap**
+  (§4.2, §5.5) — `task/protocol.rs:48`'s `project: PathBuf` is `register()`'s parameter,
+  wired once at process startup via `serve::build_router` (`serve/mod.rs:91,97`), not a
+  field on `task.run`'s own request params. Making it optional touches the daemon's
+  startup path (CLI arg parsing → `build_router` → `register`) and how an absent binding
+  then propagates to every session the process creates — plus reconciling
+  `session.create`'s untyped per-request label (§5.5) onto that same typed binding. Still
+  Phase-1-sized and still mechanical, but it is a boot-time binding-lifecycle concern, not
+  a leaf-node signature edit — size and review it accordingly.
 - It is **load-bearing for the shell**: principle 4 says cold start is the empty state
   of the same shell. **Today the empty state is not merely unstyled — it is
   unreachable**, because `task.run` cannot be called without a project. Screen 7a is
@@ -1124,3 +1151,18 @@ This is carried forward verbatim because it is the one piece of the visual syste
   strictly less powerful — and #2747's `allow_sensitive_path` guards *indexing*, not path
   listing, so it is not precedent here. No TCC permission-state machine; index readiness
   (§4.3) remains the empty/degraded-state inventory's real member.
+- **2026-07-16** — **Review-fix amendment** (PR #2855 review). Corrects §4.2, §5.5, and
+  §6.2.1's claim that `task.run` "takes `project: PathBuf` — REQUIRED (`task/protocol.rs:48`)"
+  as a per-request field: `task/protocol.rs:48` is `register()`'s parameter, wired **once at
+  daemon-boot time** (`serve::build_router`, `serve/mod.rs:91,97`) — `TaskRunRequestParams`
+  (`task/protocol.rs:61-91`) never carried a project field to begin with. Projectless is
+  therefore a **daemon-bootstrap / binding-lifecycle** change, not the request-DTO
+  `project: PathBuf → Option<ProjectBinding>` type swap the spec previously described; §6.2.1's
+  "a type change, not a subsystem — small, mechanical, testable" sizing claim is corrected to
+  match. The corrected binding model matches what **PR #2860** (`feat-tcode-api-projectless`,
+  open) actually implements: a `binding::ProjectBinding` enum (`None` / `Directory(PathBuf)` /
+  `GitRepo(PathBuf)` — exactly §4.2's three states) threaded as `ProjectBinding` (not
+  `Option<ProjectBinding>`) through `build_router`/`task::protocol::register` at boot time, and
+  `session.create`'s `CreateParams.project` retyped from the untyped label to `Option<PathBuf>`
+  resolved per-call via `ProjectBinding::resolve`. Also syncs the `docs/specs/README.md`
+  DOC-39 catalog row to `SPEC-TCUI-01~draft` … `-09~draft` (it had not been bumped for §2.1).

--- a/docs/specs/trusty-code-harness-ui.md
+++ b/docs/specs/trusty-code-harness-ui.md
@@ -1,0 +1,860 @@
+# DOC-39 — trusty-code Harness UI: Context-First Interactive Surface
+
+**Status:** Draft
+**Subsystem:** trusty-code — API surface (JSON-RPC + events) primarily; SPA (web/Tauri) client downstream
+**Owner:** Engineering (trusty-code)
+**Last-updated:** 2026-07-16
+**Spec ID:** `SPEC-TCUI-01~draft` … `SPEC-TCUI-08~draft` (DOC-39)
+**Epic:** trusty-code interactive harness UI (umbrella issue to be linked by the PM)
+**Builds on:**
+- [`docs/trusty-code/vision-and-architecture-spec.md`](../trusty-code/vision-and-architecture-spec.md)
+  — Axiom 3 (§, line 84): **layer priority API → CLI → TUI → Web**; "UIs are deferred
+  thin clients … contain NO logic of their own". This spec is that axiom applied: its
+  normative core is the **API delta**, not the pixels.
+- [`docs/trusty-code/parity-spec.md`](../trusty-code/parity-spec.md) — normative for
+  cross-model *comparison runs* only; the bake-off is how a harness is **scored**, not
+  what one **is** (§1.2).
+- Infinite Sessions epic **#2343** (LIVE, PM-only) — memory dual-write, cadence
+  compression, goal slots, working-context budget.
+- `docs/trusty-code/UI/Harness UI Rethink Proposal Explainer.pdf` (the design handoff:
+  core bet, 10 principles, visual system, tokens, shell skeleton) and its companion
+  `handoff/` screens 7a–11b. **Design input, not a behavior contract** — where the
+  proposal conflicts with shipped behavior, this spec corrects it and says so (§4.2).
+
+**Cross-ref:** the proposal's referenced "interactive wireframe doc (turns 1–11,
+options linked by id)" is **absent from the repository** — it likely holds the 8a/8b
+and 9a/9b option rationale this spec had to reconstruct from the artifacts (§7, Q1).
+
+> **Scope note.** This is a **functional spec**, not a design doc. It states what the
+> product must do — domain objects, state transitions, the API surface each UI need
+> requires, and acceptance criteria — without prescribing the implementation. It
+> deliberately does **not** restate the visual system: tokens, shell skeleton, and
+> component CSS are owned by the design handoff PDF (§3–§6) and referenced here (§8).
+> The PR carrying this doc opens **no** Rust changes.
+
+---
+
+## 1. Purpose, core bet, and non-goals
+
+### 1.1 The core bet {#SPEC-TCUI-01~draft}
+
+**ID:** SPEC-TCUI-01~draft
+**Status:** Draft
+
+Traditional coding-agent UIs are a **linear stream of work**. When agents fan out and
+prompts are one line, the stream stops answering the only question that matters:
+**"what actually drove this change?"** Prompts are thin. The real drivers are **memory
+recalls** and **semantic/text/graph search**.
+
+So the harness is **context-first**: every view is built to trace a change back to the
+memory, the search hits, and the agent that produced it (PDF §1).
+
+This has a direct, non-obvious consequence that governs the whole spec:
+
+> **The differentiated surface of this product is provenance, and provenance lives in
+> the event stream — not in the layout.** trusty-code already runs the searches, scores
+> the recalls, and attributes the agents. It just **throws that information away at the
+> event boundary** (§5). The mockups are not blocked on design; they are blocked on a
+> handful of event fields. That is why Phase 1 (§6.2) is an event-schema change and
+> contains almost no UI.
+
+### 1.2 Product framing — settled, not an open question
+
+**trusty-code was always meant to be an interactive product. All coding harnesses are.
+This is not an open question and this spec does not relitigate it.**
+
+The one-shot `run-task` CLI is **current implementation state, not the destination**.
+The existing vision spec already says so in its own voice — "NOT a one-shot CLI tool
+(the `run-task` CLI is one of many entry points; the daemon is primary)" and "a
+foundation for later UI layers: TUI, TELGUI, REST — all thin clients over the same
+JSON-RPC surface" (vision-and-architecture-spec.md §1). The UI is the **missing surface
+of the product trusty-code was always meant to be**.
+
+The parity/bake-off harness is **how you score a harness, not what one is**. Comparison
+runs remain normative under the parity spec and are unaffected by this document.
+
+**Platform: an SPA (web/Tauri) driving our API.** Not a TUI, not a terminal renderer.
+
+### 1.3 Non-goals
+
+The proposal has no non-goals. A spec must. **Out of scope for this document:**
+
+1. **Not a general-purpose IDE.** The Project/IDE half (10a) is scope-flagged, not
+   scope-committed (§7, Q4). trusty-code does not compete with VS Code.
+2. **Not a replacement for `trusty-mpm`.** No tmux, no multi-project daemon, no
+   worktree orchestration. One tcode instance per project (vision spec §1).
+3. **Not multi-user / not collaborative.** Single-operator. Auth and tenancy are
+   unaddressed by the proposal and remain unaddressed here (§7, Q3).
+4. **No visual-system invention.** Tokens, palette, and shell markup are the PDF's
+   (§8). This spec adds no new design language.
+5. **Not a workflow/delivery engine.** Surfacing PR/branch state (principle 9) requires
+   a subsystem that does not exist (§5.7); it is specified as a domain need and
+   explicitly deferred out of Phase 1 (§6.3).
+6. **No new persistence engine.** Workstream durability (§4.10) names a requirement and
+   a prerequisite; it does not pick a store.
+
+---
+
+## 2. Product framing → what the shell must be
+
+Two nested scopes, read top-to-bottom (PDF §2, principle 3):
+
+- **App context** — the header: branding + the workstream switcher.
+- **Workstream context** — the service nav below it.
+
+Everything on screen is one or the other. The chrome (header, service nav, status line)
+is **always present** and renders either an *empty* state (no project, tabs locked,
+muted status) or a *hydrated* one. **Cold start is the empty state of the same shell,
+not a different screen** (principle 4). Screen 7a is that empty state; it is a designed
+state, not an error screen (PDF §7).
+
+---
+
+## 3. Domain model {#SPEC-TCUI-02~draft}
+
+**ID:** SPEC-TCUI-02~draft
+**Status:** Draft
+
+The proposal introduces vocabulary that does not exist in the runtime. Naming which
+objects are **NEW** vs **EXISTING** is the single highest-value thing this spec does —
+it converts "the UI is behind" into "these four domain objects are missing."
+
+| Object | Runtime status | Definition |
+|---|---|---|
+| **Workstream** | **NEW** — no such symbol exists | The unit of work. An infinite thread with state `active · idle · closed` that you *pick up*, never "start over". Name is **inferred** from what you're doing. **N per project.** Resumable across daemon restarts. |
+| **Project** | **PARTIAL** — two disagreeing surfaces | A codebase a workstream may bind to. **Three** binding states (§4.2), not two. |
+| **Agent** | **PARTIAL** — events exist, no roster | A named worker (PM, Auth, Schema, Test) with a model, a task, todos, and file artifacts. |
+| **Monitor** | **NEW** — pure client concept | A live view of one service (Search / Memory / Agents) with a **lifecycle** (§4.6), not a layout choice. |
+| **Goal slot** | **EXISTING** — API already shipped | One of exactly **5** durable goal texts, each `Model`- or `Operator`-authored. The mechanism that makes "the workstream never ends" true. **Zero UI surface today** (§4.5). |
+| **Artifact** | **PARTIAL** — implied by events | A file a specific agent changed, deep-linkable into the activity viewer with back-nav. |
+
+### 3.1 Workstream (NEW)
+
+- **State:** `active | idle | closed`. Inferred, not set by the operator.
+- **Name:** inferred from the first task ("Token rotation hardening"); mutable.
+- **Cardinality:** N per project; a workstream binds to **0 or 1** project (§4.2).
+- **Durability:** MUST survive daemon restart (§4.10). This is the hard part.
+
+> **Workstream ≠ session.** Today's `SessionRegistry` is a `HashMap` behind a `Mutex`
+> whose own module doc says persistence is "(Phase 2+, out of scope)"
+> (`session/registry.rs:1-12`). A daemon restart loses the session list — though
+> trusty-memory retains turn history via the dual-write sink. **An infinite thread on
+> top of a non-durable registry is a contradiction**, and it is the reason workstream
+> persistence is called out as a *prerequisite domain object* rather than an endpoint
+> (§4.10).
+
+### 3.2 Agent (PARTIAL)
+
+`AgentSpawned` / `AgentStarted` / `AgentDone` / `AgentFailed` / `PmDelegating` events
+exist (`events.rs:186-211,312-316`). What's missing for the 10b roster:
+
+- **No snapshot endpoint** — a late-joining client cannot ask "who is running?"; it
+  must fold the event stream from the SSE ring buffer.
+- **No `model` field** on any agent event. 10b renders `sonnet` on the PM card. Model
+  appears only on `LlmRequested`/`LlmResponded`, correlated by **`agent_name` string**
+  rather than a stable id.
+- **No stable `agent_id`.** String-name correlation is the root cause of the
+  attribution gap (§5.2) — it is why Phase 1 leads with an id, not a UI.
+
+### 3.3 Goal slot (EXISTING — and already exposed)
+
+`agent_loop/goals.rs`: `GoalSlots = [Option<GoalSlot>; 5]`, where
+`GoalSlot { text, source: Model | Operator, updated_at }`. The model writes via
+`tools/goals.rs` (`set_goal` / `clear_goal`); slots render at message position **[1]**.
+
+**The API already exists** (`session/protocol_goals.rs:39-95`):
+
+- `session.set_goal(session_id, slot, text) -> {}` — operator writes use
+  `source:"operator"`; last-write-wins.
+- `session.clear_goal(session_id, slot) -> {}`
+- `session.get_goals() -> { goals: [{ slot, text, source, updated_at }] }`
+
+This is the **only** major mechanism in this spec that needs **no** API work — it needs
+a place to live in the shell (§4.5).
+
+---
+
+## 4. The 10 design principles as functional requirements
+
+The PDF states 10 principles as design intent. Restated here as requirements with
+acceptance criteria, **corrected where they conflict with shipped behavior**.
+
+### 4.1 The workstream is the unit, and it never ends
+
+**Requirement.** The unit of work is a workstream, not a session. It has state
+`active | idle | closed`, an inferred name, and is picked up rather than restarted.
+
+**AC-1.1** A workstream survives daemon restart and reappears in the switcher with its
+state and name intact. *(Blocked on §4.10 — this is the prerequisite, not a nicety.)*
+**AC-1.2** State is **inferred** from activity, never a manual control.
+**AC-1.3** Name is inferred from the first task; operator-editable.
+**AC-1.4** "Never ends" is only true if context is managed indefinitely — see §4.5
+(goal slots + budget) and §4.7 (thread at turn 500). A principle-1 claim with no
+context-budget surface is **unfalsifiable to the operator**; the budget indicator is
+what makes it visible.
+
+### 4.2 The project is inferred, not chosen — **CORRECTED** {#SPEC-TCUI-03~draft}
+
+**ID:** SPEC-TCUI-03~draft
+**Status:** Draft
+
+> **The proposal is wrong here, and it matters.** PDF §2 principle 2 says: "the moment
+> work touches files **in a git repo** it binds to that project." That git-only rule
+> **excludes non-git directories (#2728) and temp directories (#2747) — both of which
+> we deliberately support and have already shipped.** `run_task/mod.rs:100-107` indexes
+> the project **regardless of git**. Binding MUST NOT be gated on `.git`.
+
+**Requirement — three binding states, not two:**
+
+| State | Meaning | Indexing | Git affordances |
+|---|---|---|---|
+| **Projectless** | No directory bound. Chat/planning only. **Bob-mandated; MUST be supported.** | none | none |
+| **Bound · non-git** | A plain directory or temp dir (#2728/#2747). Files are read/written and **indexed**. | **yes** | **none** — no branch, no PR, no dirty-tree |
+| **Bound · git repo** | A git working tree. | yes | full (workflow lane, §4.9) |
+
+**AC-2.1** A workstream MUST be creatable and usable with **no project bound**, and the
+shell MUST render its empty state (7a) rather than an error.
+**AC-2.2** Binding occurs when work touches files in **any** directory — git or not.
+**AC-2.3** A non-git bound project MUST index and MUST surface readiness (§4.3), and
+MUST **hide** (not fake, not error) git-only affordances.
+**AC-2.4** The project name attaches to the workstream on bind and appears in the
+header switcher and status bar (7b).
+
+**API reconciliation (the two surfaces disagree today):**
+
+- `task.run` takes `project: PathBuf` — **REQUIRED** (`task/protocol.rs:48`). Projectless
+  is therefore **impossible today**. It MUST become `Option<PathBuf>`.
+- `session.create` takes `project: Option<String>` — an **untyped label**
+  (`protocol.rs:157`), disconnected from the path `task.run` demands.
+
+These MUST converge on **one** typed project binding owned by the workstream. A label
+that cannot be indexed and a path that cannot be omitted are two halves of one missing
+object. See §5.5.
+
+### 4.3 Index readiness is first-class {#SPEC-TCUI-04~draft}
+
+**ID:** SPEC-TCUI-04~draft
+**Status:** Draft
+
+**Requirement.** The operator MUST be able to tell whether search results are
+trustworthy *before* trusting them. Readiness is a status-bar indicator plus a
+first-class empty/degraded state.
+
+> **Pure wiring — the value is already computed and then dropped on the floor.**
+> `trusty_common::search_readiness::log_index_readiness` (called at
+> `run_task/mod.rs:105`) computes real per-lane `IndexReadiness` and then only
+> `tracing::info!/warn!`s it. **It is stderr-only.** An SPA cannot read stderr.
+
+**AC-3.1** Per-lane readiness (semantic / text / graph) is retrievable via RPC and
+pushed as an event on change.
+**AC-3.2** The status bar renders readiness; a degraded/empty index is a **designed
+state** (PDF §7: "empty states are first-class … the same shell, not error screens").
+**AC-3.3** A search returning nothing **because the index is cold** MUST be
+distinguishable from one returning nothing **because there are no hits**. Conflating
+these two is the failure this requirement exists to prevent.
+
+### 4.4 Consistent-but-dynamic chrome
+
+**Requirement.** Header, service nav, and status line are always present, rendering an
+*empty* or *hydrated* state. Cold start is the empty state of the same shell.
+
+**AC-4.1** No screen replaces the shell. Every state in §4.2 is the same DOM.
+**AC-4.2** Tabs render **locked** (not hidden) when projectless — the operator sees what
+binding would unlock.
+
+### 4.5 Goal slots, todos, and the context budget — **THE MISSING SURFACE** {#SPEC-TCUI-05~draft}
+
+**ID:** SPEC-TCUI-05~draft
+**Status:** Draft
+
+> **Gap.** Goal slots, todos, and the working-context budget appear in **no mockup** —
+> yet they are the mechanism that makes principle 1 ("it never ends") *true*, and the
+> goal-slot API is **already shipped** (§3.3). The proposal designed the infinite
+> thread and omitted the machinery that makes it infinite.
+
+**Requirement — goal slots.** The shell MUST render the 5 goal slots as **workstream
+context** (the service-nav scope, per principle 3 — goals are per-workstream, not
+per-app).
+
+**AC-5.1** Exactly **5** slots render, including empty ones. The fixed cardinality is
+the point: it is a **budget**, and an invisible budget is not a budget.
+**AC-5.2** Each slot shows its `source` — **`Model` vs `Operator` must be visually
+distinct**. The operator has to know whether the agent set that goal or they did.
+The visual system already carries this: amber `--accent` is "inferred" (PDF §3).
+**AC-5.3** Slots are **operator-editable** in place → `session.set_goal` /
+`session.clear_goal`. Last-write-wins; a concurrent model write MAY silently overwrite
+an operator edit (§7, Q5).
+**AC-5.4** `updated_at` renders as relative time.
+**AC-5.5 (no API work required).** `session.get_goals` + set/clear already exist
+(`session/protocol_goals.rs:39-95`). **Goal slots are pure UI wiring.**
+
+**Requirement — todos.** 10b already renders per-agent todo checklists (`Rotate refresh
+token in createSession` ✓, `Revoke server-side token on logout` ☐). These MUST be
+per-agent, not global, and MUST be readable from the roster (§5.4).
+
+**Requirement — working-context indicator.** The shell MUST surface the
+**≥60% working-context floor / ≤40% overhead cap** (`cadence.rs::enforce_budget` vs
+`overhead_cap_tokens = context_window * 40/100`).
+
+> **The ratio is computed and then discarded.** `cadence::maybe_cadence_compress`
+> returns `CadenceOutcome { fired, rounds, within_budget }` (`cadence.rs:218`) whose own
+> doc comment says it exists **"for observability/tests"** — and observability never
+> consumes it. `AgentLoop::maybe_cadence_compress` (`agent_loop/mod.rs:739`) calls it at
+> **`mod.rs:747` and drops the return value on the floor**; the turn-boundary call site
+> at `mod.rs:470` invokes that `()`-returning wrapper. Nothing is logged, evented, or
+> exposed. **Un-discarding one return value is the whole task.**
+
+**AC-5.6** The status bar renders the working-context ratio, sourced from a real
+`CadenceOutcome`, not an estimate recomputed in the client.
+**AC-5.7** `within_budget == false` (the documented floor: the active zone alone exceeds
+the cap after full compaction) MUST be visible — red `--gap` per the token map.
+**AC-5.8** A compaction firing (`fired == true`) MUST be observable in the thread (§4.7).
+**AC-5.9 — cadence is PM-only today.** `AgentLoopConfig.cadence` defaults `None`; only
+`task/executor.rs:327` sets `Some`. The indicator MUST render "not applicable" for
+non-PM agents rather than implying an unmanaged context.
+
+### 4.6 Services are first-class — and 8a/8b is a **lifecycle, not an A/B** {#SPEC-TCUI-06~draft}
+
+**ID:** SPEC-TCUI-06~draft
+**Status:** Draft
+
+> **8a vs 8b is a false A/B.** They are presented as competing layouts. They are not.
+> Read the artifacts: **8a's cards say `live`** and its rail says `PM searching · 1
+> recall`; **8b's cards say `done · 240ms`** and its rail says `answered · 2 recalls
+> used`. Those are the **same monitor at two points in time**. Choosing between them
+> is a category error — you need both, in order.
+
+**Requirement — the monitor lifecycle (normative):**
+
+1. **Live** → the monitor renders in the **docked right rail** (8a) while the service
+   is running. Streaming, ephemeral, attention-seeking.
+2. **Settled** → on completion it **collapses into a compact inline card in the thread**
+   (8b) as the **durable record** of what drove that turn. Permanent, scannable,
+   scrolls away with its turn.
+
+This is the only reading consistent with the core bet: the docked rail answers *"what
+is happening now?"*; the inline card answers *"what drove this change?"* — and the
+second question is the product.
+
+**9a/9b are rungs on the same ladder, not rivals.** PDF §2 principle 5 already states a
+**progressive-disclosure ladder**: `live dot → mini activity dropdown → pinnable monitor
+column`. 9a **is** rung 2; 9b **is** rung 3. The proposal states the ladder in prose and
+then presents its rungs as options.
+
+**AC-6.1** A running service renders a live dot in its nav tab (rung 1).
+**AC-6.2** Clicking the dot opens the mini activity dropdown (rung 2 = 9a).
+**AC-6.3** A live monitor docks to the right rail (8a) and, on settle, MUST collapse
+into an inline thread card (8b) preserving lane, query, hit count, and latency.
+**AC-6.4** The inline card is **durable** — it survives scrollback and is part of the
+turn's permanent record.
+**AC-6.5** Pinning promotes a monitor to a column (rung 3 = 9b), subject to §4.6.1.
+
+#### 4.6.1 Monitor columns (9b) — **demote to a transient trace mode** (RECOMMENDATION)
+
+**9b does not survive its own screenshot.** At 3 pinned monitors the thread is squeezed
+to roughly **25%** of the pane and the PM's answer visibly degrades to a truncated
+*"Short version: logout clears the cookie but never revokes the rotated token."* Compare
+8b, where the same answer is a full paragraph with a follow-up and two action buttons
+(`Fan out Auth + Test` / `Show the diff first`). **The layout ate the product.**
+
+The CSS confirms this is structural, not a tuning issue: `.svcol { flex:1 }` with
+`.svcol.chat { flex:1.25 }` (PDF §6) gives the thread a **1.25/4.25 ≈ 29%** share at
+three monitors. `flex:1.25` is not a fix; it is a rounding error against the thread's
+own content.
+
+**Recommendation (normative):** monitor columns are a **transient trace mode** —
+deliberately entered to audit a fan-out, deliberately exited. **Not a daily driver
+layout, and never the default.**
+
+**Justification.** (a) The thread is where the product's answer lives; a layout whose
+own mockup shows the answer degrading is disqualified as a default. (b) Principle 5's
+ladder makes columns rung **3** — the *deepest* rung, i.e. the exceptional case, not
+the resting state. (c) The 8b inline card **already delivers the trace** in the thread
+at full width, which is exactly what pinning was reaching for — columns are largely
+redundant once the lifecycle (§4.6) exists. (d) Nothing is lost: the operator opts in
+when auditing and drops back out.
+
+**AC-6.6** Monitor columns MUST NOT be the default layout.
+**AC-6.7** Entering column mode is explicit; exiting restores the thread to full width.
+**AC-6.8** The navigator rail collapses to make room (PDF §6: `.wsrail.collapsed`).
+
+### 4.7 "Search" is two different things — keep them apart
+
+**Requirement.** Two distinct surfaces that must never merge:
+
+- **Literal find** — jump to a file/symbol/memory. Lives in the **Project page as a ⌘K
+  box** (10a). Operator-driven.
+- **The Search tab** — the **audit trail of agent search operations**
+  (semantic/text/graph), each attributed to the requesting agent (10d). **Provenance,
+  not a search field.**
+
+10d makes this explicit in the UI itself: *"'Search' here isn't a box you type in… This
+tab is the audit trail of the searches your agents performed."* That a screen needs a
+banner to explain what it is not is a signal worth heeding — but the split is right, and
+the banner is the cheapest way to hold it.
+
+**AC-7.1** The Search tab has **no input field**.
+**AC-7.2** Every row shows lane badge, query, hit count, latency, **requesting agent**,
+and age (10d). This requires §5.2 + §5.3.
+**AC-7.3** ⌘K find is scoped to the bound project and is unavailable when projectless.
+
+### 4.8 Attribution everywhere
+
+**Requirement.** Memory entries show **who requested** them; search operations show the
+**requesting agent**; changed lines carry an **agent tag**; recalls are **scored** and
+marked **injected vs held back**.
+
+This is the core bet made literal, and it is **the single largest API gap** (§5.2–§5.3).
+
+**AC-8.1** Every search op, recall, and tool call carries a stable `agent_id`.
+**AC-8.2** Recalls render their score and their **injected vs held-back** status (8a/8b
+render `92% match · → injected` and `41% match · held back`).
+**AC-8.3** Memory entries render `requested by <Agent>`, workstream, and recall count
+(10c).
+**AC-8.4** Changed lines carry an agent tag in the gutter, **distinct from git status**
+(PDF §7). *(Depends on AC-8.1; not Phase 1 — §6.3.)*
+
+### 4.9 Workflow guards delivery — **new subsystem, deferred**
+
+**Requirement.** A per-workstream `spec → epic → issue → branch → PR → review → deploy`
+pipeline, newest first, side-scrolling, explicitly flagging **missing stages** and
+surfacing **PRs awaiting merge, unpushed commits, uncommitted files** (10e), so a
+fan-out cannot quietly skip review or deploy.
+
+> **Nothing to build on.** There is **no branch, PR, dirty-tree, or unpushed concept
+> anywhere in trusty-code**. `Phase*` events track *internal harness phases*, not
+> delivery stages. `verify_gate.rs` gates `finish_task` on "did you run the named test
+> command" — that is a test gate, not a delivery gate. This is a **new subsystem**, and
+> it is git-only (undefined for the non-git binding state, §4.2).
+
+**AC-9.1** Lanes render per workstream, newest first, side-scrolling independently.
+**AC-9.2** Missing stages are explicit (10e renders `— / no epic` in red `--gap`).
+**AC-9.3** A "needs attention" banner aggregates open PRs, unpushed commits, dirty files.
+**AC-9.4** The Workflow tab is **hidden** for non-git and projectless workstreams (§4.2).
+
+### 4.10 Back-nav preserves the trail
+
+**Requirement.** Any deep-link (artifact → viewer, event dot → pane) keeps a breadcrumb
+back to where you clicked, so exploring provenance never strands you.
+
+11b shows the shape: `← Back | Agents · Auth Agent / session.ts` with `opened from agent
+artifact`.
+
+**AC-10.1** Every deep-link pushes a breadcrumb naming its origin.
+**AC-10.2** Back returns to the exact prior scroll position and tab.
+**AC-10.3** Agent file artifacts link into the **activity viewer**, never the IDE tree
+(PDF §7, principle 8) — from an agent you care about the **change**, not the tree.
+
+---
+
+## 4A. The infinite thread at turn 500 {#SPEC-TCUI-07~draft}
+
+**ID:** SPEC-TCUI-07~draft
+**Status:** Draft
+
+> **Gap.** Every mockup shows a thread with **2–3 turns**. The workstream is infinite.
+> Nothing in the proposal says what turn 500 looks like — and the three mechanisms that
+> make turn 500 possible (compaction, the memory dual-write, the SSE ring buffer) each
+> leave a visible seam the operator will hit.
+
+**Requirement — virtualization.** The thread MUST virtualize; only the visible window
+renders. Turn count MUST NOT bound client memory or paint cost.
+
+**Requirement — pagination.** History MUST page **backwards on demand** from the durable
+record, not from the event ring buffer.
+
+> **`GET /sessions/{id}/events` replays a ring buffer, then streams** (`serve/http.rs:98`).
+> A **ring buffer is not history** — it is bounded and evicts. At turn 500 the early
+> turns are **gone from the ring but present in trusty-memory** (the `TurnMemorySink`
+> dual-write, `session/memory_sink.rs`, on by default via `task/executor.rs:270,380`).
+> The thread therefore has **two backing stores with different retention**, and the
+> client MUST NOT confuse them: the ring is *live tail*, trusty-memory is *history*.
+
+**AC-11.1** The thread virtualizes; turn 500 paints in the same budget as turn 5.
+**AC-11.2** Scrolling back past the ring buffer pages from the trusty-memory durable
+record. The seam MUST NOT surface as a gap, an error, or a silent truncation.
+**AC-11.3** The SSE ring replay MUST be used for the **live tail only**, never presented
+as complete history.
+
+**Requirement — the compaction boundary is a visible, honest object.**
+
+When cadence compression fires (N=8, `agent_loop/cadence.rs::maybe_cadence_compress`),
+turns above the active zone are **summarized and the originals leave the model's
+context**. The operator's mental model breaks if the thread silently rewrites itself.
+
+**AC-11.4** A compaction boundary renders as an **explicit horizontal marker** in the
+thread — e.g. *"12 turns compacted · ~8.4k tokens reclaimed"* — at the point it fired.
+**AC-11.5** The marker is **expandable**: the original turns are still in trusty-memory
+and MUST be retrievable on click. **Compaction removes turns from the model's context,
+not from the record** — the UI MUST make that distinction legible, because it is the
+entire reason the dual-write exists.
+**AC-11.6** The marker distinguishes **compacted** (summarized, recoverable) from
+**evicted-from-ring** (live tail gone, still in memory). Same visual seam, different
+cause.
+**AC-11.7** Cadence is PM-only (§4.5, AC-5.9); non-PM threads show no boundaries because
+none fire — not because they are hidden.
+
+---
+
+## 4B. Workstream durability — a prerequisite, not an endpoint {#SPEC-TCUI-08~draft}
+
+**ID:** SPEC-TCUI-08~draft
+**Status:** Draft
+
+> **The collision.** "The workstream never ends" (principle 1) sits directly on top of a
+> `SessionRegistry` that is a `HashMap` behind a `Mutex`, whose module doc states
+> persistence is **"(Phase 2+, out of scope)"** (`session/registry.rs:1-12`). **A daemon
+> restart loses the session list.** trusty-memory retains the *turn history* via the
+> dual-write — so the paradox today is that the **conversation outlives the workstream
+> that contained it**.
+
+**A workstream requires:**
+
+1. **Restart-surviving** — id, name, state, and project binding persist across daemon
+   restarts and are restored on boot.
+2. **Project-scoped** — N workstreams per project; the switcher groups by project (7a
+   renders exactly this: `acme-api` with 3 workstreams, `data-pipeline` with *"no active
+   workstreams"*).
+3. **Listable** — enumerable without replaying an event stream.
+4. **Resumable** — picked up, not restarted (principle 1).
+
+**AC-12.1** A workstream MUST be recoverable after `tcode serve` restarts.
+**AC-12.2** The switcher lists workstreams grouped by project, with state and inferred
+name, from a **snapshot RPC** — not by folding events.
+**AC-12.3** Turn history reattaches to its workstream on resume.
+
+> **This is flagged as a PREREQUISITE DOMAIN OBJECT, not an endpoint.** The temptation
+> is to "add `workstream.list`". That is backwards: there is no workstream to list.
+> This is a domain + storage change — deciding what a workstream *is*, where it lives,
+> and how it is keyed — with an RPC as its *consequence*. **It is the single largest
+> item in this spec and the reason it is not in Phase 1** (§6.3). Sequencing an
+> event-schema change (Phase 1) ahead of it is deliberate: provenance ships value on
+> the existing non-durable registry; durability does not block it.
+
+---
+
+## 5. API surface — THE CORE
+
+**Per the binding layer-priority rule (vision spec Axiom 3: API → CLI → TUI → Web),
+every deterministic feature lands in the HTTP API BEFORE any UI surfaces it. This
+section is therefore the normative core of the spec; the pixels are downstream.**
+
+### 5.0 Today's surface (verified at `origin/main`)
+
+**The API is 3 HTTP routes** (`serve/http.rs:96-98`):
+
+| Route | Purpose |
+|---|---|
+| `POST /rpc` | All JSON-RPC (`session.*`, `task.*`) |
+| `GET /health` | Health |
+| `GET /sessions/{id}/events` | SSE — replays the ring buffer, then streams |
+
+**There is no REST resource surface.** The event taxonomy is `crate::events::Event`
+(`events.rs:75`, ~30 variants). Every UI need below routes through either a new
+JSON-RPC method or a new/extended `Event` variant.
+
+### 5.1 Summary — UI need → API delta
+
+| # | UI need (screen) | Required API | Today | Delta |
+|---|---|---|---|---|
+| 1 | Per-tool agent attribution (10a gutter, 10d, 11a) | `agent_id` on `ToolStarted/ToolFinished/ToolError` | **MISSING** | Add `agent_id` + call-context to `ToolEventSink` |
+| 2 | Search audit trail (10d, 8a/8b) | `Event::SearchPerformed{lane,query,hit_count,latency_ms,agent_id}` | **MISSING** | New structured event |
+| 3 | Memory recall w/ score + injected (8a/8b, 10c) | `Event::MemoryRecalled{query,results:[{score,injected}],agent_id}` | **MISSING** | New structured event |
+| 4 | Index readiness (status bar, 7a) | `IndexReadiness` as event + RPC | **MISSING** (stderr-only) | Surface computed value |
+| 5 | Working-context budget (status bar) | `Event::ContextBudget{working_pct,overhead_pct,within_budget,fired}` | **MISSING** (discarded) | Stop dropping `CadenceOutcome` |
+| 6 | Goal slots (§4.5) | `session.get_goals` / `set_goal` / `clear_goal` | **EXISTS** | **none — UI wiring only** |
+| 7 | Projectless + binding (7a, §4.2) | `task.run` `project` → optional; unify with `session.create` | **PARTIAL** | Type change + reconciliation |
+| 8 | Agent roster (10b, 11a) | `session.get_agents` snapshot + `model` field | **PARTIAL** | Event-folding is an acceptable stopgap |
+| 9 | Workstream list/resume (7a/7b switcher) | Workstream domain object + persistence + `workstream.list` | **MISSING** | Domain + storage (§4B) |
+| 10 | Workflow lanes (10e) | Branch/PR/dirty-tree subsystem | **MISSING** | New subsystem, nothing to build on |
+| 11 | Clone-from-URL (7a) | `project.clone_from_url` | **MISSING** | Not present anywhere |
+| 12 | Streaming cost (header `$0.31`) | Per-turn cost event | **PARTIAL** | Tokens stream; cost only aggregates at run-end |
+
+### 5.2 Tool attribution — one schema change unlocks the rest
+
+**Today.** `ToolEventSink::tool_started(call_id, tool, args_preview)` and
+`tool_finished(call_id, tool, success, result_preview)` (`agent_loop/sink.rs:35,40`)
+have **no agent parameter**. The agent that ran a tool is structurally unrecoverable
+downstream — it was never passed in.
+
+**Required.**
+
+```rust
+async fn tool_started(&self, call_id: &str, tool: &str, args_preview: &str, agent_id: &AgentId);
+async fn tool_finished(&self, call_id: &str, tool: &str, success: bool, result_preview: &str, agent_id: &AgentId);
+```
+
+with `agent_id` propagated onto `Event::ToolStarted / ToolFinished / ToolError`
+(`events.rs:131-146`).
+
+> **This is the keystone.** Principle 7 ("attribution everywhere"), the 10a gutter tags,
+> the 10d requesting-agent column, and 11a's artifact links are **all** downstream of
+> this one field. It is also a **prerequisite for #2 and #3** — a search event without
+> an `agent_id` cannot populate 10d. Ship it first (§6.2).
+
+**AC-13.1** A stable `agent_id` (not an `agent_name` string) identifies every tool call.
+**AC-13.2** Name-based correlation is **removed** as a correlation mechanism, not
+supplemented. Two agents may share a name; ids are the fix.
+
+### 5.3 Structured search + recall events
+
+**Today — search.** `tools/trusty_search.rs` routes `search_code` to **real lanes**
+(semantic/text/graph). But the events emitted are generic `ToolStarted/ToolFinished`
+carrying `args_preview` / `result_preview` — **truncated display strings**
+(`events.rs:131-146`). The lane, the hit count, and the latency are **destroyed at the
+event boundary**. 10d cannot be built by parsing a truncated preview string, and should
+not be attempted.
+
+```rust
+Event::SearchPerformed {
+    agent_id: AgentId,
+    lane: SearchLane,      // Semantic | Text | Graph
+    query: String,
+    hit_count: usize,
+    latency_ms: u64,
+    hits: Vec<SearchHit>,  // { path, score } — powers 8a/8b relevance bars
+}
+```
+
+**Today — recall.** Scores exist **inside** `tools/recall_session.rs` but never escape
+the rendered text. **There is no `MemoryRecalled` event at all.** The injected-vs-held
+distinction — which 8a, 8b, 9b, and 10c all render, and which is the most literal
+expression of the core bet in the entire proposal — **exists nowhere in the API.**
+
+```rust
+Event::MemoryRecalled {
+    agent_id: AgentId,
+    query: String,
+    vectors_queried: usize,
+    results: Vec<RecallResult>, // { text, score, injected: bool, run_id }
+}
+```
+
+**AC-14.1** Lane, query, hit count, and latency are **structured fields**, never parsed
+from a preview string.
+**AC-14.2** Every recall result carries `score` and `injected: bool`.
+**AC-14.3** `injected` reflects **what actually entered the model's context** — not what
+was returned by the query. A held-back recall is the operator's evidence that the
+harness *chose*; conflating the two silently voids the core bet.
+
+### 5.4 Agent roster (PARTIAL — event-folding is acceptable for now)
+
+`AgentSpawned/AgentStarted/AgentDone/AgentFailed/PmDelegating` exist
+(`events.rs:186-211,312-316`). Missing: a snapshot endpoint, and `model` on the agent
+events (10b renders `sonnet`; model lives only on `LlmRequested/LlmResponded`,
+correlated by `agent_name` **string**).
+
+```rust
+session.get_agents() -> { agents: [{ agent_id, name, model, state, task, todos, files_changed }] }
+```
+
+**AC-15.1** `model` is carried on agent lifecycle events, not correlated by name.
+**AC-15.2** A late-joining client can render the roster. **Folding the SSE replay is an
+acceptable Phase-1 substitute** (§6.3) — the ring replay makes it correct-enough for a
+single-operator client, which is why this is not a Phase-1 blocker.
+
+### 5.5 Project binding (PARTIAL — the two surfaces must converge)
+
+```rust
+// task/protocol.rs:48 — REQUIRED today; projectless is impossible
+project: PathBuf            →  project: Option<ProjectBinding>
+// protocol.rs:157 — untyped label, disconnected from the path above
+project: Option<String>     →  project: Option<ProjectBinding>
+
+enum ProjectBinding { None, Directory(PathBuf), GitRepo(PathBuf) }  // §4.2's three states
+```
+
+**AC-16.1** `task.run` accepts **no project** and the daemon runs projectless.
+**AC-16.2** `session.create` and `task.run` share **one** binding type. Today one takes a
+path it cannot omit and the other a label it cannot index; that is one object split in
+half across two surfaces.
+**AC-16.3** The binding distinguishes non-git from git (§4.2) — non-git indexing already
+ships (#2728/#2747, `run_task/mod.rs:100-107`).
+
+### 5.6 Index readiness + context budget (pure wiring)
+
+```rust
+session.get_readiness() -> { lanes: [{ lane, state, doc_count, last_indexed_at }] }
+Event::IndexReadinessChanged { lanes: [...] }
+Event::ContextBudget { working_pct, overhead_pct, within_budget, fired, rounds }
+```
+
+**AC-17.1** Readiness is served from the **same** `IndexReadiness` value
+`log_index_readiness` already computes (`run_task/mod.rs:105`) — not recomputed.
+**AC-17.2** `ContextBudget` is emitted from the **real** `CadenceOutcome` returned at
+`agent_loop/mod.rs:747` and currently discarded. The wrapper
+(`AgentLoop::maybe_cadence_compress`, `mod.rs:739`) must return it rather than `()`.
+
+### 5.7 Workflow / delivery (MISSING — new subsystem)
+
+No branch, PR, dirty-tree, or unpushed concept exists. `Phase*` events are internal
+harness phases; `verify_gate.rs` gates `finish_task` on a test command only. 10e needs a
+git+forge integration subsystem built from zero. **Deferred (§6.3).**
+
+---
+
+## 6. Phased delivery
+
+### 6.1 Sequencing principle
+
+Per the layer-priority rule, phases are cut by **API delta**, not by screen. A phase
+that ships pixels ahead of its events is not a phase; it is a mock.
+
+### 6.2 **Phase 1 cut line** — the smallest surface that unlocks the differentiated core
+
+**Phase 1 is five event/RPC changes and almost no UI.** It is chosen to unlock exactly
+what makes this harness different from a linear stream — **provenance, the search audit
+trail, memory injected-vs-held, readiness, and the context budget** — and nothing else.
+Every item is already computed in the runtime and discarded at a boundary; Phase 1 is
+mostly **un-discarding values we already have**.
+
+| # | Item | Why in Phase 1 | Size |
+|---|---|---|---|
+| **1** | `agent_id` + call-context on `ToolEventSink` → `Event::ToolStarted/ToolFinished/ToolError` (§5.2) | **The keystone.** One schema change unlocks all attribution; #2 and #3 depend on it. | M |
+| **2** | `Event::SearchPerformed { lane, query, hit_count, latency_ms, agent_id }` (§5.3) | The Search tab (10d) **is** the audit trail; lanes are already routed, only the event is missing. | S |
+| **3** | `Event::MemoryRecalled { query, results:[{score, injected}], agent_id }` (§5.3) | Injected-vs-held is the most literal form of the core bet; scores already exist internally. | S |
+| **4** | Surface `IndexReadiness` as event + RPC (§5.6) | Pure wiring — already computed, stderr-only. Without it, search results are untrustworthy by construction. | S |
+| **5** | Stop discarding `CadenceOutcome` → emit working-context ratio (§5.6) | One return value. Makes "it never ends" falsifiable. | S |
+
+**Phase 1 UI:** the status bar (readiness + budget), the 8b inline monitor card, the
+10d Search tab, and the **goal-slot panel** (§6.2.1). These are the surfaces that
+require **no** new domain object — they render Phase 1's events against today's
+non-durable registry.
+
+#### 6.2.1 Projectless — **Bob mandated it; here is where it lands and why**
+
+**Projectless is Phase 1.** Rationale, stated deliberately:
+
+- It is a **type change, not a subsystem** — `project: PathBuf` → `Option<...>`
+  (`task/protocol.rs:48`) plus reconciling `session.create`'s untyped label (§5.5).
+  Small, mechanical, and testable.
+- It is **load-bearing for the shell**: principle 4 says cold start is the empty state
+  of the same shell. **Today the empty state is not merely unstyled — it is
+  unreachable**, because `task.run` cannot be called without a project. Screen 7a is
+  literally unimplementable. Every other Phase-1 surface renders inside a shell whose
+  entry state does not exist.
+- It **de-risks the binding model early**: the three states (§4.2) are the correction
+  this spec makes to the proposal, and the cost of discovering that reconciliation is
+  wrong is far lower now than after the workstream object is built on top of it.
+- Deferring it would invert the layer-priority rule — the SPA's **first screen** would
+  be blocked on an API change we chose not to make.
+
+**Phase 1 explicitly does NOT include:** the workstream domain object, monitor columns,
+the Workflow tab, the IDE half, or clone-from-URL.
+
+### 6.3 Explicitly NOT Phase 1 (with reasons)
+
+| Item | Why deferred |
+|---|---|
+| **Workstream persistence** (§4B) | Real **domain + storage** work — deciding what a workstream *is*, not adding an endpoint. The largest item in the spec. Phase 1 ships value on the existing registry without it. |
+| **Per-line diff attribution UI** (10a gutter) | **Depends on §5.2** (`agent_id`). Ship the schema first; the gutter is a downstream consumer. |
+| **Workflow / delivery pipeline** (10e) | **New subsystem, nothing to build on** — no branch/PR/dirty-tree concept exists anywhere (§5.7). Also git-only, so it needs §4.2 settled first. |
+| **Agent roster snapshot** (10b) | **Event-folding is an acceptable substitute** — the SSE ring replay renders a correct roster for a single-operator client. Real cost, low marginal value now. |
+| **Clone-from-URL** (7a) | Does not exist anywhere; pure additive scope with no dependents. Local-folder binding covers the mandated projectless→bound path. |
+| **Monitor columns** (9b) | Demoted to transient trace mode (§4.6.1); the 8b inline card delivers the same trace at full width. |
+
+### 6.4 Phase 2+
+
+Workstream durability (§4B) → agent roster snapshot + `model` → thread virtualization &
+compaction boundaries (§4A) → workflow subsystem (§4.9) → IDE half (pending §7 Q4) →
+clone-from-URL → monitor columns as an opt-in trace mode.
+
+---
+
+## 7. Open questions
+
+**Q1 — The missing wireframe doc.** The PDF's closing line pairs it with an
+"**interactive wireframe doc (turns 1–11, options linked by id)**". **That document is
+not in the repository** — only the PDF and `handoff/` (14 PNGs, 7a–11b). It very likely
+holds the **rationale for the 8a/8b and 9a/9b options** this spec had to reconstruct
+from pixels (§4.6). If it exists, it should be committed alongside the PDF and this
+spec's §4.6/§4.6.1 conclusions re-checked against it. **Owner: design.**
+
+**Q2 — Platform split: web vs Tauri — what actually differs?** "SPA (web/Tauri)" is
+settled as the platform, but the two are not the same product. Undecided: local
+filesystem access for the IDE half (10a) and the 7a local-folder browser — a browser
+cannot walk `~/code/`; does web lose project-open entirely, or proxy it through the
+daemon? Also: OS keychain vs browser storage for tokens, and whether the daemon is
+assumed local (`localhost`) or remote. **This gates §4.2's local-folder picker.**
+**Owner: Bob.**
+
+**Q3 — Auth / multi-user.** Wholly unaddressed by the proposal. 7a's header renders
+"**OAuth login**" and 7a's GitHub-URL card says private repos "use your **connected
+token**" — implying an identity model that does not exist. Single-operator is assumed
+throughout this spec (§1.3) and stated as a non-goal, but if the SPA is served over a
+network, "no auth" is a decision, not a default. **Owner: Bob.**
+
+**Q4 — Is the IDE half (10a) in scope at all?** Principle 8 routes agent artifacts to
+the **activity viewer, not the tree** — and PDF §7 restates it ("not the IDE"). 11a/11b
+confirm: artifacts deep-link into the changed-files viewer with back-nav. So the IDE
+tree + editor + ⌘K find (10a) serves only *operator-initiated browsing* — a large
+surface (tree, editor, gutter tags, syntax highlighting) whose only unique contribution
+is literal find (§4.7). **Recommendation: defer 10a entirely; ⌘K find can attach to the
+activity viewer.** If deferred, principle 7's gutter attribution (AC-8.4) loses its
+only home and should be re-scoped to the 10f/11b diff view — which already renders
+`Auth Agent · edited 2m ago` and a **"WHAT DROVE THIS"** panel. Notably, **10f/11b
+already deliver the core bet's payoff without the IDE.** **Owner: Bob.**
+
+**Q5 — Goal-slot write conflicts.** `session.set_goal` is **last-write-wins** with no
+version/CAS (`session/protocol_goals.rs`). A model write can silently clobber an
+operator edit mid-turn. Acceptable, or does the operator source win until cleared?
+**Owner: engineering.**
+
+**Q6 — Streaming cost.** The header renders live cost (`$0.02 → $1.42` across screens),
+but dollar cost only aggregates at run-end (`aggregate_usage_per_role` →
+`registry.set_run_outcome`). Tokens stream live (`LlmRequested{prompt_tokens}`,
+`LlmResponded{completion_tokens, latency_ms}`). Compute cost client-side from streaming
+tokens, or add a streaming cost event? **Owner: engineering.**
+
+**Q7 — Non-PM context budget.** Cadence is PM-only by construction
+(`AgentLoopConfig.cadence` defaults `None`; only `task/executor.rs:327` sets `Some`).
+Sub-agents run **unmanaged** contexts. Is that intended long-term, or does the budget
+indicator (§4.5) need a per-agent story once fan-out is routine? **Owner: engineering.**
+
+---
+
+## 8. Visual system
+
+**Owned by the design handoff, not restated here.** See
+`docs/trusty-code/UI/Harness UI Rethink Proposal Explainer.pdf`:
+
+- **§3 Visual system** — warm "engineering paper", not a dark IDE; ink-drawn borders.
+- **§4 Suggested tokens** — the `:root` custom properties (`--desk`, `--panel`,
+  `--chrome`, `--ink`, `--accent`, `--search`, `--done`, `--gap`, `--mono`, `--sans`).
+- **§5 Shell skeleton** — one flex column: header → service nav → body (rail + active
+  pane) → status line.
+- **§6 Key component CSS** — `.mon`, `.hit`, `.recall.injected`, `.svcols`, `.wsrail`.
+
+**The role mapping is normative even though the palette is not.** Accent = selection /
+current / **inferred**; blue = search / in-progress; green = done / active / shipped;
+red = gaps / blocked / dirty. Colors are OKLCH-friendly and may be re-saturated per
+platform **without breaking the role mapping** (PDF §7). The `--mono` / `--sans` split
+is load-bearing: monospace for **all** system metadata (ids, paths, counts, status),
+sans for prose. That split is the main way the eye separates *content* from *telemetry*
+— and in a context-first harness, telemetry **is** the product's evidence.
+
+### 8.1 The nesting note — keep it, and assert it
+
+> **`.statusbar` MUST be a sibling of `.body`** (a direct child of `.app`), **never
+> inside `.body`** — otherwise it steals the rail's row width and squishes the pane.
+> The PDF's own words: *"This bit us twice in the wireframe; assert it in a test."*
+
+**AC-18.1** A DOM/structural test asserts `.statusbar` is not a descendant of `.body`.
+This is carried forward verbatim because it is the one piece of the visual system with a
+**testable invariant** — and it already regressed twice.
+
+---
+
+## 9. Follow-ups
+
+| ID | Item | Depends on |
+|---|---|---|
+| **F1** | Add the DOC-39 catalog row to `docs/specs/README.md` and refresh its stale "next free `DOC-N`" note to **DOC-40**. | this spec |
+| **F2** | Commit the missing interactive wireframe doc (§7 Q1); re-check §4.6/§4.6.1 against it. | design |
+| **F3** | File the Phase-1 issues (§6.2) under the UI epic, sequenced with §5.2 first. | this spec |
+| **F4** | Resolve Q2/Q3/Q4 (platform, auth, IDE scope) before Phase 2 planning. | Bob |
+| **F5** | Note for DOC-38 §10 F3 (DOC-28 renumber): DOC-39 is now **claimed by this spec**; that follow-up must re-scan and take **DOC-40**. | DOC-38 |
+
+## Changelog
+
+- **2026-07-16** — Initial draft (DOC-39, `SPEC-TCUI-01~draft` … `SPEC-TCUI-08~draft`).


### PR DESCRIPTION
Turns the **Harness UI Rethink** design proposal (`docs/trusty-code/UI/` — 6pp PDF + 14 handoff screens) into an implementable **functional spec**, and fills the gaps it leaves open.

**Doc:** `docs/specs/trusty-code-harness-ui.md` — DOC-39, `SPEC-TCUI-01~draft` … `SPEC-TCUI-08~draft`

### Why the core is the API, not the pixels

Per the binding layer-priority rule (vision spec Axiom 3, `vision-and-architecture-spec.md:84` — **API → CLI → TUI → Web**), every deterministic feature lands in the API before any UI surfaces it. So §5 maps each UI need to the JSON-RPC method / `Event` variant it requires, with today's state (EXISTS / PARTIAL / MISSING) and the concrete delta.

The governing finding: **the differentiated surface of this product is provenance, and provenance is already computed and then thrown away at the event boundary.** The mockups aren't blocked on design — they're blocked on a handful of event fields.

### The 7 gaps, resolved

1. **Goal slots / todos / context budget** (§4.5) — no UI surface in any mockup, yet they make "the workstream never ends" true. Goal-slot RPCs **already ship** (`session/protocol_goals.rs:39-95`) → pure UI wiring: 5 slots, model-vs-operator source, operator-editable. The ≥60%/≤40% ratio needs `CadenceOutcome` un-discarded — its own doc says it exists *"for observability/tests"*, and it's dropped at `agent_loop/mod.rs:747`.
2. **Projectless + binding** (§4.2) — **corrects the proposal**: PDF §2's "binds when work touches files *in a git repo*" excludes the non-git and temp-dir indexing we deliberately ship (#2728/#2747). Specifies **three** states: projectless → non-git dir → git repo. `task.run`'s required `project: PathBuf` must become optional and reconcile with `session.create`'s untyped label — one object currently split across two disagreeing surfaces.
3. **Index readiness** (§4.3) — pure wiring; already computed, stderr-only. A cold index must be distinguishable from zero hits.
4. **8a vs 8b is a false A/B** (§4.6) — 8a says `live`, 8b says `done · 240ms`; the rails say `PM searching` vs `answered · 2 recalls used`. It's a **lifecycle**: live in the docked rail → collapses to an inline thread card as the durable record. 9a/9b are **rungs** on PDF §5's disclosure ladder, not rivals.
5. **9b monitor columns → transient trace mode** (§4.6.1) — the mockup squeezes the thread to ~25% and the PM answer visibly degrades to *"Short version:"*; `.svcol.chat{flex:1.25}` yields ~29% at 3 monitors. The layout ate the product. 8b already delivers the trace at full width.
6. **Thread at turn 500** (§4A) — virtualization + backwards pagination. The SSE ring buffer **is not history** (it evicts; trusty-memory retains) — two backing stores, different retention. Compaction boundaries render as explicit, expandable markers: compaction removes turns from *context*, not from the *record*.
7. **Workstream durability** (§4B) — the infinite thread collides with a `SessionRegistry` whose own doc says persistence is *"(Phase 2+, out of scope)"*. Today the **conversation outlives the workstream that contained it**. Flagged as a **prerequisite domain object**, not an endpoint.

### Phase 1 cut line

Five event/RPC changes, almost no UI — mostly un-discarding values the runtime already has:

1. `agent_id` + call-context on `ToolEventSink` → `Event::ToolStarted/ToolFinished/ToolError` (**the keystone**; #2 and #3 depend on it)
2. `Event::SearchPerformed { lane, query, hit_count, latency_ms, agent_id }`
3. `Event::MemoryRecalled { query, results:[{score, injected}], agent_id }`
4. `IndexReadiness` as event + RPC
5. Stop discarding `CadenceOutcome` → emit the working-context ratio

**Projectless is Phase 1** (owner-mandated, placed deliberately): it's a type change, not a subsystem — and screen 7a is otherwise *unimplementable*, since `task.run` cannot be called without a project today.

**Explicitly NOT Phase 1:** workstream persistence (domain+storage), per-line diff attribution (depends on #1), workflow/delivery (new subsystem, nothing to build on), agent roster snapshot (event-folding is an acceptable substitute), clone-from-URL.

### Open questions surfaced

The referenced **interactive wireframe doc is absent from the repo** (likely holds the 8a/8b + 9a/9b option rationale); web-vs-Tauri split (a browser can't walk `~/code/` — gates the 7a folder picker); auth/multi-user (7a renders "OAuth login" implying an identity model that doesn't exist); **whether the IDE half (10a) is in scope at all** given §8 routes agents to the activity viewer — 10f/11b already deliver the core bet's payoff without it; goal-slot last-write-wins conflicts; streaming cost; non-PM unmanaged contexts.

### Notes

- Also adds the DOC-39 catalog row and refreshes the catalog's stale *"next free DOC-N"* note → **DOC-40**. DOC-38 §10 F3 (the DOC-28 renumber) named DOC-39 as its target; that hint is now stale and F3 must re-scan — exactly the drift DOC-38 §4.1 anticipates ("a catalog's next-free note is a hint, not authority").
- **Docs only** — no `.rs` touched, so no cargo or line-cap gate applies. Extracted handoff PNGs were **not** committed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools