### PR TITLE
fix(trusty-code): bound re-delegation cap to retries, not total delegations

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -137,6 +137,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **P1: the re-delegation cap counted ALL delegations, not retries — killing
+  runs before the build started.** `MAX_REDELEGATIONS = 3` was documented as
+  bounding *retries after failure*, but the counter incremented on every
+  engineer invocation run-wide and was never reset per call, so a *successful*
+  delegation permanently consumed budget a later one then lacked. A PM using
+  delegation for legitimate reconnaissance — the normal PM shape — was silently
+  guillotined: the 4th call was refused **without the inner runner ever being
+  invoked** (zero engineer turns, no code written), and the latched signal then
+  fired `run_task`'s `with_stop_signal`, halting the PM loop at the next turn
+  boundary and making it unrecoverable by design. L4 bake-off run-6 issued 3
+  read-only recon delegations and had its 4th — the actual build — refused,
+  ending `partial`/exit 6 with 0/9 tests and 0/5 deliverables; runs 3/4/5
+  succeeded only by luck of issuing one fewer recon call. Measured cost: 2-in-7
+  total-loss runs caused by the harness rather than the model. The cap now
+  counts retries: `MAX_REDELEGATIONS` is checked against a counter **local to
+  each delegation**, reset at loop entry, so a successful delegation never
+  spends a later one's budget. Exhausting it is now **recoverable** — it no
+  longer stops the PM loop, matching the precedent set by #2683/#2805's
+  post-completion refusal. The cap's actual purpose is preserved by a new
+  run-wide `MAX_ENGINEER_INVOCATIONS = 12` ceiling (4× the per-delegation
+  budget): a genuinely failing engineer stays bounded, and only that ceiling —
+  a condition no fresh delegation could clear — latches the loop-stopping
+  signal. Not a #2805 regression; #2805 fixed the *symptom* and remains correct
+  ([#2852](https://github.com/bobmatnyc/trusty-tools/issues/2852))
+- **The re-delegation cap was completely silent.** It emitted no log line
+  anywhere — run-6's stderr was 5 lines with no mention of it — so the only
+  evidence a run had been killed was a label buried in the report's `task`
+  field, discoverable only by cross-run forensic comparison. Both the
+  per-delegation retry exhaustion and the run-wide ceiling now `warn!` (to
+  stderr, never stdout) naming the attempt count and, for the ceiling, that the
+  PM loop is being stopped
+  ([#2852](https://github.com/bobmatnyc/trusty-tools/issues/2852))
 - **`build.rs` re-ran on every single build, in every tree.** Its lone
   `cargo:rerun-if-changed=.git/HEAD` directive was a relative path, which Cargo
   resolves against the *package* root — i.e. `crates/trusty-code/.git/HEAD`,

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1424,7 +1424,7 @@ async fn cancel_flag_aborts_before_next_turn() {
 /// Why: This is the generic mechanism `run_task`'s PM loop relies on to stop
 /// issuing `delegate_to_agent` calls the turn after the shared re-delegation
 /// cap latches (see `run_task::mod`'s `execute_run_task` wiring and
-/// `run_task::tests::pm_stops_redelegating_once_cap_latched_ends_partial_promptly`
+/// `run_task::tests::run_wide_ceiling_stops_the_pm_loop_and_ends_partial_promptly`
 /// for the production end-to-end proof); this test isolates the loop
 /// mechanism itself from any `run_task`-specific signal.
 /// What: A closure pre-set to always return `true` before the loop even

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -155,7 +155,7 @@ pub struct RunTaskParams {
 /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`,
 /// `diff_reflects_engineer_file_change`, `usage_and_cost_aggregate_end_to_end`,
 /// `exit_code_reflects_run_failure`,
-/// `pm_stops_redelegating_once_cap_latched_ends_partial_promptly`.
+/// `run_wide_ceiling_stops_the_pm_loop_and_ends_partial_promptly`.
 pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait>) -> RunReport {
     // Trusty-search-first discovery (PR B): at task START, best-effort/detached,
     // ensure the working project is indexed so `search`/`grep` are useful while
@@ -264,7 +264,9 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     // is unrecoverable by construction — the PM never gets another turn — so
     // it may only ever fire on a condition no subsequent delegation could
     // clear. `is_cap_reached()` now latches ONLY on the run-wide
-    // `MAX_ENGINEER_INVOCATIONS` ceiling, which is exactly such a condition.
+    // `MAX_FAILED_INVOCATIONS` ceiling — a run whose delegations have failed
+    // that many times over, which is exactly such a condition. Successful
+    // invocations never feed it, no matter how many the PM makes.
     // It deliberately does NOT latch on a single delegation exhausting its
     // `MAX_REDELEGATIONS` retries: that is recoverable (a fresh delegation
     // gets a full budget), and stopping the loop on it is precisely the bug
@@ -717,10 +719,14 @@ fn assemble_report(
 
         if (budget_spent || is_turn_cap) && has_deliverable {
             let label = if cap_reached {
+                // #2852: quote the FAILURE count, which is the ceiling's actual
+                // input and is exactly the number of invocations that really
+                // failed — never a pre-incremented dispatch counter, which
+                // would tell an operator "13" when 12 occurred.
                 format!(
-                    "partial: engineer invocation ceiling reached after {} invocations; \
+                    "partial: engineer failure ceiling reached after {} failed invocations; \
                      partial work preserved at {}",
-                    redelegation_signal.attempts(),
+                    redelegation_signal.failed_invocations(),
                     params.project.display()
                 )
             } else if retry_exhausted {
@@ -754,9 +760,9 @@ fn assemble_report(
         // retry budget), even though the exit code itself is unchanged.
         let label = if cap_reached {
             format!(
-                "run failure (engineer invocation ceiling reached after {} invocations, no \
-                 deliverable produced)",
-                redelegation_signal.attempts()
+                "run failure (engineer failure ceiling reached after {} failed invocations, \
+                 no deliverable produced)",
+                redelegation_signal.failed_invocations()
             )
         } else if retry_exhausted {
             format!(

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -250,18 +250,29 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         project_context.as_deref(),
         catchup_ctx.as_deref(),
     );
-    // (#2265 fix #5) Once the shared re-delegation cap latches, every further
-    // `delegate_to_agent` call the PM might issue is a guaranteed dead end —
-    // `RedelegatingRunner` will reject it immediately without even invoking
-    // the engineer. Wiring the SAME signal into the PM's own loop as a stop
-    // condition (checked at the existing turn-boundary, alongside the #2056
-    // cancellation flag) stops the PM from spending its remaining
+    // (#2265 fix #5, re-scoped by #2852) Once the shared cap latches, every
+    // further `delegate_to_agent` call the PM might issue is a guaranteed dead
+    // end — `RedelegatingRunner` will reject it immediately without even
+    // invoking the engineer. Wiring the SAME signal into the PM's own loop as
+    // a stop condition (checked at the existing turn-boundary, alongside the
+    // #2056 cancellation flag) stops the PM from spending its remaining
     // `max_turns` issuing those doomed calls one per turn — the bake-off L1
-    // regression this fix closes (see `redelegation` module docs for the
-    // full before/after). `assemble_report` already maps a cap-latched,
-    // deliverable-bearing run to `ExitCode::Partial` regardless of which
-    // `AgentLoopError` variant the PM's loop returns, so this purely trims
-    // wasted turns — it does not change the reported outcome.
+    // regression fix #5 closes (see `redelegation` module docs for the
+    // full before/after).
+    //
+    // #2852 is what makes that "guaranteed dead end" premise TRUE. This hook
+    // is unrecoverable by construction — the PM never gets another turn — so
+    // it may only ever fire on a condition no subsequent delegation could
+    // clear. `is_cap_reached()` now latches ONLY on the run-wide
+    // `MAX_ENGINEER_INVOCATIONS` ceiling, which is exactly such a condition.
+    // It deliberately does NOT latch on a single delegation exhausting its
+    // `MAX_REDELEGATIONS` retries: that is recoverable (a fresh delegation
+    // gets a full budget), and stopping the loop on it is precisely the bug
+    // #2852 fixes — it killed runs whose next call was the real build.
+    // `assemble_report` still maps a cap- OR retry-exhausted, deliverable-
+    // bearing run to `ExitCode::Partial` regardless of which `AgentLoopError`
+    // variant the PM's loop returns, so this purely trims wasted turns — it
+    // does not change the reported outcome.
     let stop_signal = redelegation_signal.clone();
     let pm_loop = AgentLoop::new(
         AgentLoopConfig {
@@ -688,17 +699,35 @@ fn assemble_report(
         // must not be blindly reported as `run_failure` when a deliverable
         // already exists on disk — the diff is filesystem-based, so it is
         // authoritative regardless of which attempt produced it.
+        //
+        // #2852 split the one cap flag in two. Reporting must key off BOTH:
+        // `is_cap_reached` (the run-wide invocation ceiling, which also stops
+        // the PM loop) and `is_retry_budget_exhausted` (some delegation burned
+        // all its retries — recoverable, so it does NOT stop the loop, but it
+        // is still exactly the "engineer was retried to exhaustion" diagnosis
+        // this label exists to report). Keying off only the former would have
+        // silently downgraded genuinely retry-exhausted runs to an opaque
+        // `run_failure` — losing the diagnostics #2852 set out to improve.
         let cap_reached = redelegation_signal.is_cap_reached();
+        let retry_exhausted = redelegation_signal.is_retry_budget_exhausted();
+        let budget_spent = cap_reached || retry_exhausted;
         let is_turn_cap = matches!(e, AgentLoopError::TurnCapExceeded { .. });
         let rendered_diff = diff::diff_snapshots(&before, &after);
         let has_deliverable = !rendered_diff.trim().is_empty();
 
-        if (cap_reached || is_turn_cap) && has_deliverable {
+        if (budget_spent || is_turn_cap) && has_deliverable {
             let label = if cap_reached {
+                format!(
+                    "partial: engineer invocation ceiling reached after {} invocations; \
+                     partial work preserved at {}",
+                    redelegation_signal.attempts(),
+                    params.project.display()
+                )
+            } else if retry_exhausted {
                 format!(
                     "partial: re-delegation limit reached after {} attempts; partial work \
                      preserved at {}",
-                    redelegation_signal.attempts(),
+                    redelegation::MAX_REDELEGATIONS,
                     params.project.display()
                 )
             } else {
@@ -725,9 +754,15 @@ fn assemble_report(
         // retry budget), even though the exit code itself is unchanged.
         let label = if cap_reached {
             format!(
+                "run failure (engineer invocation ceiling reached after {} invocations, no \
+                 deliverable produced)",
+                redelegation_signal.attempts()
+            )
+        } else if retry_exhausted {
+            format!(
                 "run failure (re-delegation limit reached after {} attempts, no deliverable \
                  produced)",
-                redelegation_signal.attempts()
+                redelegation::MAX_REDELEGATIONS
             )
         } else {
             "run failure".to_string()

--- a/crates/trusty-code/src/run_task/redelegation.rs
+++ b/crates/trusty-code/src/run_task/redelegation.rs
@@ -26,13 +26,43 @@
 //! may exist — turn cap, timeout, cancellation, or a retryable LLM/transport
 //! error, per that function's #2265-updated docs), it retries the SAME
 //! engineer agent with the task text augmented by the reuse hint, up to
-//! [`MAX_REDELEGATIONS`] total attempts (shared across every
-//! `delegate_to_agent` call in the run, not reset per call) before giving up
+//! [`MAX_REDELEGATIONS`] attempts **for that one delegation** before giving up
 //! with a clean, quoted "re-delegation limit reached" error. A non-retryable
 //! failure (unknown agent, bad config) propagates immediately without
-//! consuming the cap.
+//! consuming the budget.
+//!
+//! # #2852: the budget counts RETRIES, not delegations
+//!
+//! The original #2265 implementation shared ONE run-wide counter across every
+//! `delegate_to_agent` call and refused the 4th, whatever it was. That
+//! conflated two unrelated things: a *failing engineer being retried* (what
+//! the cap is for) and a *PM using delegation to read files before building*
+//! (the normal PM shape). A PM that spent three successful delegations on
+//! reconnaissance had its FOURTH call — the actual build — refused without the
+//! inner runner ever being invoked, and the latched signal then stopped the PM
+//! loop, making it unrecoverable. Measured cost: 2-in-7 total-loss L4 bake-off
+//! runs, caused by the harness rather than the model.
+//!
+//! So the two concerns are now counted separately:
+//!
+//! * [`MAX_REDELEGATIONS`] bounds attempts **within a single delegation**, via
+//!   a local counter reset at every [`RedelegatingRunner::run_with_retries`]
+//!   entry. A successful delegation therefore consumes NO budget from a later
+//!   one. Exhausting it latches `retry_budget_exhausted` (informational: it
+//!   labels the report) but deliberately does NOT stop the PM loop — a fresh,
+//!   different delegation is a legitimate move that could well succeed, so the
+//!   error is recoverable, exactly like #2683/#2805's post-completion refusal.
+//! * [`MAX_ENGINEER_INVOCATIONS`] bounds engineer invocations **run-wide**. It
+//!   is the surviving purpose of the shared signal: a genuinely broken run
+//!   whose every delegation burns a full retry budget must still terminate.
+//!   Only THIS ceiling latches `cap_reached`, and hence only this one fires
+//!   `run_task::mod`'s `with_stop_signal` — at which point stopping really is
+//!   correct, because no further delegation could clear it.
+//!
 //! Test: `redelegating_runner_retries_on_llm_error_then_succeeds`,
-//! `redelegating_runner_stops_at_cap_and_marks_signal`,
+//! `successful_delegations_never_consume_a_later_delegations_budget`,
+//! `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`,
+//! `run_wide_invocation_ceiling_latches_cap_reached`,
 //! `redelegating_runner_propagates_non_retryable_errors_immediately`,
 //! `cap_reached_message_names_the_project_path`.
 
@@ -46,31 +76,60 @@ use async_trait::async_trait;
 use crate::tools::delegate::redelegation_hint;
 use crate::tools::{AgentOutput, AgentRunner, RunContext};
 
-/// Maximum total engineer delegation attempts for a single `execute_run_task`
-/// run, shared across every `delegate_to_agent` call the PM makes (#2265).
+/// Maximum engineer attempts for ONE `delegate_to_agent` call — 1 initial
+/// invocation plus up to 2 reuse-aware retries (#2265, re-scoped by #2852).
 ///
-/// Why: This — not the PM's own turn budget — is the ceiling on retry count
-/// going forward. 3 total attempts (1 initial + up to 2 reuse-aware retries)
-/// is deliberately modest: each retry now costs up to 40 engineer turns
-/// (#2233's raised default), so an unbounded or generous cap here would
-/// reintroduce the same runaway-cost failure mode this fix closes.
-/// What: Checked BEFORE every engineer invocation in
-/// [`RedelegatingRunner::run_with_retries`]; once the shared attempt count
-/// exceeds this value, no further engineer invocation happens at all.
-/// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+/// Why: This — not the PM's own turn budget — is the ceiling on retry count.
+/// 3 attempts is deliberately modest: each retry costs up to 40 engineer turns
+/// (#2233's raised default), so a generous bound would reintroduce the
+/// runaway-cost failure mode #2265 closed. #2852 re-scoped it from "per run"
+/// to "per delegation": as a RUN-wide bound it silently guillotined PMs that
+/// used delegation for legitimate reconnaissance before building, since a
+/// successful delegation consumed budget a later one then lacked. Retries are
+/// what needs bounding; delegations are not.
+/// What: Checked against a counter local to each
+/// [`RedelegatingRunner::run_with_retries`] call, reset at loop entry. Once
+/// exceeded, that delegation stops without invoking the inner runner and
+/// returns a recoverable error — the PM's loop continues and may delegate
+/// again with a full, fresh budget (see [`MAX_ENGINEER_INVOCATIONS`] for the
+/// run-wide backstop that keeps "again" from being unbounded).
+/// Test: `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`,
+/// `successful_delegations_never_consume_a_later_delegations_budget`.
 pub const MAX_REDELEGATIONS: u32 = 3;
+
+/// Maximum engineer invocations across a whole `execute_run_task` run (#2852).
+///
+/// Why: With [`MAX_REDELEGATIONS`] scoped per-delegation, something must still
+/// bound a pathological run in which EVERY delegation burns its full retry
+/// budget — otherwise a PM stuck in a failing loop could re-delegate once per
+/// turn forever, which is the runaway #2265 existed to prevent. 12 is 4× the
+/// per-delegation budget: it lets four separate delegations fail completely
+/// before the run is declared hopeless, which no legitimate recon-then-build
+/// shape can reach (recon delegations succeed on their first attempt and cost
+/// 1 invocation each; run-6's pathological case totalled ~6), while still
+/// binding well inside the PM's 8-turn × 3-attempt worst case of 24.
+/// What: Checked against the shared [`RedelegationCapSignal`] before every
+/// engineer invocation. Exceeding it is the ONLY thing that latches
+/// `cap_reached`, and hence the only thing that fires `run_task::mod`'s
+/// `with_stop_signal` to halt the PM loop — correct here precisely because no
+/// fresh delegation could clear it.
+/// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
+pub const MAX_ENGINEER_INVOCATIONS: u32 = 12;
 
 /// Shared, run-scoped state behind [`RedelegationCapSignal`].
 ///
 /// Why: Kept as a private inner type so the public handle stays a cheap,
 /// `Clone`-able `Arc` wrapper — see [`RedelegationCapSignal`]'s own docs.
-/// What: `attempts` counts every engineer invocation attempted across the
-/// whole run; `cap_reached` latches `true` the first time an attempt would
-/// exceed [`MAX_REDELEGATIONS`].
+/// What: `attempts` counts every engineer invocation actually made across the
+/// whole run. `retry_budget_exhausted` latches `true` the first time any ONE
+/// delegation burns all [`MAX_REDELEGATIONS`] attempts — informational only.
+/// `cap_reached` latches `true` only when an invocation would exceed the
+/// run-wide [`MAX_ENGINEER_INVOCATIONS`] ceiling; that one is terminal (#2852).
 /// Test: Exercised indirectly through `RedelegationCapSignal`'s own tests.
 #[derive(Debug, Default)]
 struct RedelegationCapState {
     attempts: AtomicU32,
+    retry_budget_exhausted: AtomicBool,
     cap_reached: AtomicBool,
 }
 
@@ -103,43 +162,74 @@ impl RedelegationCapSignal {
         Self::default()
     }
 
-    /// Record one more attempt and return the new total.
+    /// Record one more engineer invocation and return the new run-wide total.
     ///
-    /// Why: The runner must check the POST-increment total against the cap
-    /// atomically with recording it, so two attempts can never both observe
-    /// "one under the cap" and both proceed.
-    /// What: `fetch_add(1) + 1`.
-    /// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+    /// Why: The runner must check the POST-increment total against
+    /// [`MAX_ENGINEER_INVOCATIONS`] atomically with recording it, so two
+    /// invocations can never both observe "one under the ceiling" and both
+    /// proceed.
+    /// What: `fetch_add(1) + 1`. Called only for invocations that actually
+    /// reach the inner runner, so the count stays a truthful cost measure.
+    /// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
     fn record_attempt(&self) -> u32 {
         self.0.attempts.fetch_add(1, Ordering::SeqCst) + 1
     }
 
-    /// Latch the cap-reached flag.
+    /// Latch the "some delegation burned its whole retry budget" flag (#2852).
     ///
-    /// Why: Called exactly once, the moment an attempt would exceed
-    /// [`MAX_REDELEGATIONS`] — this is the signal `assemble_report` checks.
+    /// Why: `assemble_report` needs this to keep labelling a genuinely
+    /// retry-exhausted run "re-delegation limit reached" (and to map it to
+    /// `Partial` when a deliverable exists) — diagnostics #2852 must not lose.
+    /// It is deliberately SEPARATE from `cap_reached`: this condition is
+    /// recoverable, so it must never reach the PM loop's stop signal.
     /// What: Stores `true`.
-    /// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+    /// Test: `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`.
+    fn mark_retry_budget_exhausted(&self) {
+        self.0.retry_budget_exhausted.store(true, Ordering::SeqCst);
+    }
+
+    /// Latch the terminal run-wide cap flag.
+    ///
+    /// Why: Called exactly once, the moment an invocation would exceed
+    /// [`MAX_ENGINEER_INVOCATIONS`] — the run is out of total budget and
+    /// nothing the PM does next can help, so this is what both
+    /// `assemble_report` and the PM loop's stop signal key off.
+    /// What: Stores `true`.
+    /// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
     fn mark_cap_reached(&self) {
         self.0.cap_reached.store(true, Ordering::SeqCst);
     }
 
-    /// Whether the re-delegation cap was hit during this run.
+    /// Whether the run-wide engineer-invocation ceiling was hit (#2852).
     ///
-    /// Why: `assemble_report` uses this to distinguish a cap-triggered
-    /// terminal state from an unrelated PM-loop error.
+    /// Why: Drives `run_task::mod`'s `with_stop_signal`, so it must be `true`
+    /// ONLY for conditions a fresh delegation genuinely cannot clear. Per-call
+    /// retry exhaustion is not one of those — see
+    /// [`Self::is_retry_budget_exhausted`].
     /// What: Reads the latched flag.
-    /// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+    /// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
     pub fn is_cap_reached(&self) -> bool {
         self.0.cap_reached.load(Ordering::SeqCst)
     }
 
-    /// Total engineer attempts recorded so far.
+    /// Whether any single delegation exhausted its [`MAX_REDELEGATIONS`]
+    /// retry budget during this run (#2852).
     ///
-    /// Why: Surfaced in the clean terminal report's message so an operator
-    /// knows exactly how many tries were made.
+    /// Why: Lets `assemble_report` distinguish "the engineer really was
+    /// retried to exhaustion" from an unrelated PM-loop error, WITHOUT that
+    /// observation stopping the loop. Read-only for report assembly.
+    /// What: Reads the latched flag.
+    /// Test: `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`.
+    pub fn is_retry_budget_exhausted(&self) -> bool {
+        self.0.retry_budget_exhausted.load(Ordering::SeqCst)
+    }
+
+    /// Total engineer invocations recorded so far, run-wide.
+    ///
+    /// Why: Surfaced in the terminal report's message so an operator knows
+    /// exactly how much engineer work the run actually bought.
     /// What: Reads the atomic counter.
-    /// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+    /// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
     pub fn attempts(&self) -> u32 {
         self.0.attempts.load(Ordering::SeqCst)
     }
@@ -160,15 +250,20 @@ impl RedelegationCapSignal {
 /// What: Holds the inner (real) engineer runner, a shared
 /// [`RedelegationCapSignal`], and the project path (quoted in the
 /// cap-reached message per the required wording, "…partial work preserved at
-/// <path>"). On each attempt: record it against the shared signal; if the
-/// new total exceeds [`MAX_REDELEGATIONS`], stop WITHOUT invoking the inner
-/// runner, latch the cap, and return a clean, descriptive error. Otherwise
+/// <path>"). Per delegation, a LOCAL attempt counter starts at zero (#2852):
+/// if it would exceed [`MAX_REDELEGATIONS`], stop WITHOUT invoking the inner
+/// runner, latch `retry_budget_exhausted`, warn, and return a RECOVERABLE
+/// error (the PM may delegate again with a fresh budget). Otherwise record the
+/// invocation run-wide; if THAT would exceed [`MAX_ENGINEER_INVOCATIONS`],
+/// latch `cap_reached` (terminal — stops the PM loop) and return. Otherwise
 /// invoke the inner runner; on success, return it; on a failure whose
 /// [`redelegation_hint`] is `Some`, retry with the task text augmented by
 /// that hint; on a failure whose hint is `None` (no partial work to reuse),
-/// propagate immediately without consuming further cap budget.
+/// propagate immediately without consuming further budget.
 /// Test: `redelegating_runner_retries_on_llm_error_then_succeeds`,
-/// `redelegating_runner_stops_at_cap_and_marks_signal`,
+/// `successful_delegations_never_consume_a_later_delegations_budget`,
+/// `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`,
+/// `run_wide_invocation_ceiling_latches_cap_reached`,
 /// `redelegating_runner_propagates_non_retryable_errors_immediately`.
 pub struct RedelegatingRunner {
     inner: Arc<dyn AgentRunner>,
@@ -202,12 +297,18 @@ impl RedelegatingRunner {
     /// Why: Shared by both `AgentRunner` methods so `run` and
     /// `run_with_context` can never drift on retry policy.
     /// What: See the type-level docs for the full attempt/retry/cap
-    /// contract. Returns the first successful `AgentOutput`, or — once the
-    /// shared attempt count would exceed [`MAX_REDELEGATIONS`] — a clean
-    /// error naming the attempt count and the project path, or — on a
-    /// non-retryable failure — that failure verbatim.
+    /// contract. `attempt` is LOCAL to this call and starts at zero every time
+    /// (#2852) — that is the whole fix: a delegation's retry budget belongs to
+    /// that delegation, so an earlier successful one cannot spend it. Returns
+    /// the first successful `AgentOutput`; or, once this call's attempts would
+    /// exceed [`MAX_REDELEGATIONS`], a recoverable error naming the count and
+    /// project path; or, once the run's invocations would exceed
+    /// [`MAX_ENGINEER_INVOCATIONS`], a terminal error that also latches the
+    /// stop signal; or, on a non-retryable failure, that failure verbatim.
     /// Test: `redelegating_runner_retries_on_llm_error_then_succeeds`,
-    /// `redelegating_runner_stops_at_cap_and_marks_signal`,
+    /// `successful_delegations_never_consume_a_later_delegations_budget`,
+    /// `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`,
+    /// `run_wide_invocation_ceiling_latches_cap_reached`,
     /// `redelegating_runner_propagates_non_retryable_errors_immediately`,
     /// `cap_reached_message_names_the_project_path`.
     async fn run_with_retries(
@@ -217,13 +318,51 @@ impl RedelegatingRunner {
         ctx: &RunContext,
     ) -> Result<AgentOutput> {
         let mut current_task = task.to_string();
+        // #2852: per-CALL, not per-run. Reset at entry so reconnaissance
+        // delegations that succeed never starve the build that follows.
+        let mut attempt: u32 = 0;
         loop {
-            let attempt = self.signal.record_attempt();
+            attempt += 1;
             if attempt > MAX_REDELEGATIONS {
-                self.signal.mark_cap_reached();
+                self.signal.mark_retry_budget_exhausted();
+                // #2852: this cap used to be entirely silent — run-6's stderr
+                // carried no trace of it and the mechanism was only findable
+                // by cross-run forensics on the report's `task` label. Say so.
+                // Recoverable: the PM's loop continues (this does NOT latch
+                // `cap_reached`), so it may delegate afresh.
+                tracing::warn!(
+                    agent = agent_name,
+                    attempts = MAX_REDELEGATIONS,
+                    run_invocations = self.signal.attempts(),
+                    "re-delegation retry budget exhausted for this delegation; refusing \
+                     further retries of it. The PM loop continues — a fresh delegation \
+                     gets a full budget."
+                );
                 return Err(anyhow::anyhow!(
                     "re-delegation limit reached after {MAX_REDELEGATIONS} attempts; \
                      partial work preserved at {}",
+                    self.project.display()
+                ));
+            }
+
+            let total = self.signal.record_attempt();
+            if total > MAX_ENGINEER_INVOCATIONS {
+                self.signal.mark_cap_reached();
+                // Terminal, unlike the per-call budget above: the run has spent
+                // its whole engineer allowance, so no fresh delegation can help
+                // and `run_task::mod`'s stop signal will halt the PM loop at
+                // its next turn boundary. Log loudly — this ends the run.
+                tracing::warn!(
+                    agent = agent_name,
+                    invocations = total - 1,
+                    ceiling = MAX_ENGINEER_INVOCATIONS,
+                    "run-wide engineer invocation ceiling reached; stopping the PM loop. \
+                     Every delegation this run consumed retries without succeeding."
+                );
+                return Err(anyhow::anyhow!(
+                    "engineer invocation ceiling reached after {} invocations this run; \
+                     partial work preserved at {}",
+                    MAX_ENGINEER_INVOCATIONS,
                     self.project.display()
                 ));
             }
@@ -318,6 +457,46 @@ mod tests {
         }
     }
 
+    /// Captures every `tracing` event's level + message for assertions.
+    ///
+    /// Why: #2852 requires the cap to stop being SILENT — run-6's stderr had
+    /// no trace of it, so the mechanism was only discoverable by cross-run
+    /// forensics on the report's `task` label. Proving the log exists needs an
+    /// in-process subscriber; the crate has no tracing-capture dev-dependency,
+    /// and a ~15-line `Layer` is cheaper than adding one.
+    /// What: A `Layer` pushing `(Level, message)` into a shared `Vec`.
+    /// Test: `cap_exhaustion_is_logged_at_warn_level`.
+    #[derive(Default, Clone)]
+    struct CapturedLogs(Arc<Mutex<Vec<(tracing::Level, String)>>>);
+
+    struct CaptureLayer(CapturedLogs);
+
+    struct MessageVisitor(String);
+
+    impl tracing::field::Visit for MessageVisitor {
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            if field.name() == "message" {
+                self.0 = format!("{value:?}");
+            }
+        }
+    }
+
+    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
+        fn on_event(
+            &self,
+            event: &tracing::Event<'_>,
+            _ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let mut visitor = MessageVisitor(String::new());
+            event.record(&mut visitor);
+            self.0
+                .0
+                .lock()
+                .expect("captured logs lock")
+                .push((*event.metadata().level(), visitor.0));
+        }
+    }
+
     fn llm_error() -> anyhow::Error {
         anyhow::Error::from(RunnerError::Loop {
             name: "python-engineer".to_string(),
@@ -382,21 +561,94 @@ mod tests {
         assert_eq!(signal.attempts(), 2);
     }
 
-    /// Once attempts exceed `MAX_REDELEGATIONS`, the runner stops calling the
-    /// inner runner, marks the cap reached, and returns a clean error naming
-    /// the attempt count.
+    /// (#2852 REGRESSION) A PM that spends several SUCCESSFUL delegations on
+    /// reconnaissance may still delegate the actual build afterwards — with a
+    /// full, fresh retry budget.
     ///
-    /// Why: This is fix #1 — the explicit ceiling that replaces the PM's own
-    /// turn budget as the retry governor.
-    /// What: Script `MAX_REDELEGATIONS` failing `Llm` outcomes (all
-    /// retryable); assert the final error mentions "re-delegation limit
-    /// reached" and the exact attempt count, the inner runner was called
-    /// exactly `MAX_REDELEGATIONS` times (not `MAX_REDELEGATIONS + 1` — the
-    /// cap check happens BEFORE the attempt that would exceed it), and the
-    /// signal reports `is_cap_reached() == true`.
+    /// Why: This is the exact total-loss bug #2852 closes, and the shape of
+    /// L4 bake-off run-6: the PM issued 3 legitimate read-only recon
+    /// delegations (read PROBLEM.md, list test_suite, read test_basic.py) and
+    /// its 4th call — the real build — was refused before the inner runner was
+    /// ever invoked, yielding `partial`/exit 6 with 0/9 tests and 0/5
+    /// deliverables. Runs 3/4/5 succeeded only by luck of issuing one fewer
+    /// recon call. Recon-then-build is the NORMAL PM shape, so under the old
+    /// run-wide counter any PM reading more than two files before building was
+    /// killed by the harness. Against the pre-fix code this test fails on the
+    /// 4th `run` call.
+    /// What: Script [Ok, Ok, Ok] for three recon delegations, then
+    /// [Err(retryable llm), Ok] for the build. Assert every recon call
+    /// succeeds, the build ALSO runs (not refused) and succeeds on its own
+    /// retry — proving both that a successful delegation consumes no later
+    /// budget and that the build's budget was reset, not merely off-by-one.
     /// Test: this test.
     #[tokio::test]
-    async fn redelegating_runner_stops_at_cap_and_marks_signal() {
+    async fn successful_delegations_never_consume_a_later_delegations_budget() {
+        let inner = Arc::new(ScriptedInner::new(vec![
+            Ok(AgentOutput::from_content("PROBLEM.md contents")),
+            Ok(AgentOutput::from_content("test_suite listing")),
+            Ok(AgentOutput::from_content("test_basic.py contents")),
+            // The build: fails once transiently, then succeeds.
+            Err(llm_error()),
+            Ok(AgentOutput::from_content("build complete")),
+        ]));
+        let signal = RedelegationCapSignal::new();
+        let runner = RedelegatingRunner::new(
+            Arc::clone(&inner) as Arc<dyn AgentRunner>,
+            signal.clone(),
+            PathBuf::from("/tmp/project"),
+        );
+
+        for recon in ["read PROBLEM.md", "list test_suite", "read test_basic.py"] {
+            let out = runner
+                .run("python-engineer", recon)
+                .await
+                .unwrap_or_else(|e| panic!("recon delegation {recon:?} must succeed, got: {e}"));
+            assert!(!out.content.is_empty());
+        }
+
+        let out = runner
+            .run("python-engineer", "implement the solution")
+            .await
+            .expect(
+                "the BUILD delegation must run — under the pre-#2852 run-wide counter it \
+                 was refused as attempt 4 without ever invoking the engineer",
+            );
+        assert_eq!(out.content, "build complete");
+
+        assert!(
+            !signal.is_cap_reached(),
+            "no run-wide ceiling was approached, so the PM loop must not be stopped"
+        );
+        assert!(
+            !signal.is_retry_budget_exhausted(),
+            "no single delegation burned its retry budget"
+        );
+        assert_eq!(
+            inner.calls.lock().expect("calls lock").len(),
+            5,
+            "3 recon invocations + 2 build invocations must all have reached the engineer"
+        );
+    }
+
+    /// Once ONE delegation's attempts exceed `MAX_REDELEGATIONS`, the runner
+    /// stops calling the inner runner and returns a clean error naming the
+    /// attempt count — but does NOT latch the loop-stopping `cap_reached`.
+    ///
+    /// Why: This is the cap's real purpose (fix #1) — a genuinely failing
+    /// engineer must stay bounded — held together with #2852's constraint that
+    /// bounding it must not be fatal to the RUN. The PM loop's stop signal is
+    /// unrecoverable by construction, so it may only fire on a condition a
+    /// fresh delegation cannot clear; retry exhaustion is not one.
+    /// `retry_budget_exhausted` latches instead, which labels the report
+    /// without killing the loop.
+    /// What: Script `MAX_REDELEGATIONS` failing `Llm` outcomes (all
+    /// retryable); assert the error names the cap and count, the inner runner
+    /// ran exactly `MAX_REDELEGATIONS` times (the check happens BEFORE the
+    /// attempt that would exceed), `is_retry_budget_exhausted()` is set, and
+    /// `is_cap_reached()` is NOT.
+    /// Test: this test.
+    #[tokio::test]
+    async fn redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal() {
         let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
         let inner = Arc::new(ScriptedInner::new(outcomes));
         let signal = RedelegationCapSignal::new();
@@ -409,7 +661,7 @@ mod tests {
         let err = runner
             .run("python-engineer", "build the package")
             .await
-            .expect_err("must fail once the cap is exceeded");
+            .expect_err("must fail once this delegation's retries are exhausted");
 
         assert!(
             err.to_string().contains("re-delegation limit reached"),
@@ -426,8 +678,80 @@ mod tests {
             MAX_REDELEGATIONS as usize,
             "the inner runner must be called exactly MAX_REDELEGATIONS times, not more"
         );
-        assert!(signal.is_cap_reached(), "signal must latch cap-reached");
-        assert_eq!(signal.attempts(), MAX_REDELEGATIONS + 1);
+        assert!(
+            signal.is_retry_budget_exhausted(),
+            "signal must latch retry-budget-exhausted so the report can label it"
+        );
+        assert!(
+            !signal.is_cap_reached(),
+            "retry exhaustion is RECOVERABLE (#2852) — it must not stop the PM loop, \
+             which would kill a run whose next delegation could well succeed"
+        );
+        assert_eq!(
+            signal.attempts(),
+            MAX_REDELEGATIONS,
+            "only real invocations count; the refused 4th never reached the engineer"
+        );
+    }
+
+    /// Exceeding the run-wide `MAX_ENGINEER_INVOCATIONS` ceiling latches
+    /// `cap_reached`, which is what stops the PM loop.
+    ///
+    /// Why: With `MAX_REDELEGATIONS` scoped per-delegation (#2852), this is the
+    /// backstop that keeps a pathological run — every delegation burning a full
+    /// retry budget — from re-delegating once per PM turn forever. Unlike
+    /// per-call exhaustion, this one IS terminal, so it is correct for it to
+    /// fire the stop signal.
+    /// What: Fail every invocation retryably and delegate repeatedly. Assert
+    /// the ceiling latches `cap_reached`, the engineer was invoked exactly
+    /// `MAX_ENGINEER_INVOCATIONS` times (never more), and the final error names
+    /// the ceiling.
+    /// Test: this test.
+    #[tokio::test]
+    async fn run_wide_invocation_ceiling_latches_cap_reached() {
+        // Generously more failures than the ceiling allows to be consumed.
+        let outcomes = (0..MAX_ENGINEER_INVOCATIONS * 2)
+            .map(|_| Err(llm_error()))
+            .collect();
+        let inner = Arc::new(ScriptedInner::new(outcomes));
+        let signal = RedelegationCapSignal::new();
+        let runner = RedelegatingRunner::new(
+            Arc::clone(&inner) as Arc<dyn AgentRunner>,
+            signal.clone(),
+            PathBuf::from("/tmp/project"),
+        );
+
+        // Each call burns MAX_REDELEGATIONS invocations, so the ceiling is
+        // reached after MAX_ENGINEER_INVOCATIONS / MAX_REDELEGATIONS calls.
+        let mut last_err = None;
+        for _ in 0..(MAX_ENGINEER_INVOCATIONS / MAX_REDELEGATIONS) + 1 {
+            last_err = runner
+                .run("python-engineer", "build the package")
+                .await
+                .err();
+        }
+
+        let err = last_err.expect("every delegation fails, so the last must error");
+        assert!(
+            signal.is_cap_reached(),
+            "the run-wide ceiling must latch cap_reached to stop the PM loop"
+        );
+        assert!(
+            err.to_string()
+                .contains("engineer invocation ceiling reached"),
+            "the terminal error must name the run-wide ceiling, got: {err}"
+        );
+        assert_eq!(
+            signal.attempts(),
+            MAX_ENGINEER_INVOCATIONS + 1,
+            "the ceiling is detected on the invocation that would exceed it, which is \
+             never dispatched"
+        );
+        assert_eq!(
+            inner.calls.lock().expect("calls lock").len(),
+            MAX_ENGINEER_INVOCATIONS as usize,
+            "the engineer must never be invoked beyond the run-wide ceiling"
+        );
     }
 
     /// A non-retryable failure (no partial work to reuse) propagates
@@ -460,6 +784,57 @@ mod tests {
         assert!(
             !signal.is_cap_reached(),
             "cap must not be marked reached for a non-retryable failure"
+        );
+    }
+
+    /// Exhausting a delegation's retry budget emits a WARN-level log naming
+    /// the attempt count.
+    ///
+    /// Why: #2852's observability half. The cap was completely silent — no log
+    /// line anywhere — so the only evidence a run had been guillotined was a
+    /// label buried in the report's `task` field, which took a cross-run
+    /// forensic comparison to interpret. An operator must be able to see this
+    /// in stderr.
+    /// What: Force per-call retry exhaustion under a capturing subscriber;
+    /// assert a WARN event was emitted naming the attempt count. (Logs go to
+    /// stderr via the crate's subscriber, never stdout — the tracing default.)
+    ///
+    /// `rebuild_interest_cache` is load-bearing, not defensive: `tracing`
+    /// caches per-callsite interest GLOBALLY, and this binary's
+    /// `logging::tests::init_tracing_for_test_is_idempotent` installs a
+    /// process-global `EnvFilter` subscriber that (with `RUST_LOG` unset)
+    /// rejects this crate's WARN events. Whichever runs first wins the cache,
+    /// so without an explicit rebuild against THIS thread's subscriber the
+    /// assertion is order-dependent — it flaked 1-in-N during development.
+    /// Since interest is re-evaluated per callsite on the next event, the
+    /// rebuild deterministically re-admits the callsite for this scoped
+    /// subscriber.
+    /// Test: this test.
+    #[tokio::test]
+    async fn cap_exhaustion_is_logged_at_warn_level() {
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let logs = CapturedLogs::default();
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer(logs.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+
+        let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
+        let runner = RedelegatingRunner::new(
+            Arc::new(ScriptedInner::new(outcomes)) as Arc<dyn AgentRunner>,
+            RedelegationCapSignal::new(),
+            PathBuf::from("/tmp/project"),
+        );
+        let _ = runner.run("python-engineer", "build the package").await;
+
+        let captured = logs.0.lock().expect("captured logs lock");
+        let warned = captured.iter().any(|(level, msg)| {
+            *level == tracing::Level::WARN && msg.contains("retry budget exhausted")
+        });
+        assert!(
+            warned,
+            "exhausting the retry budget must WARN — it was completely silent before \
+             #2852, making total-loss runs undiagnosable. Captured: {captured:?}"
         );
     }
 

--- a/crates/trusty-code/src/run_task/redelegation.rs
+++ b/crates/trusty-code/src/run_task/redelegation.rs
@@ -52,17 +52,21 @@
 //!   labels the report) but deliberately does NOT stop the PM loop — a fresh,
 //!   different delegation is a legitimate move that could well succeed, so the
 //!   error is recoverable, exactly like #2683/#2805's post-completion refusal.
-//! * [`MAX_ENGINEER_INVOCATIONS`] bounds engineer invocations **run-wide**. It
-//!   is the surviving purpose of the shared signal: a genuinely broken run
-//!   whose every delegation burns a full retry budget must still terminate.
+//! * [`MAX_FAILED_INVOCATIONS`] bounds **failed** engineer invocations
+//!   run-wide. It is the surviving purpose of the shared signal: a genuinely
+//!   broken run whose delegations keep failing must still terminate. It counts
+//!   only FAILURES, never successes — otherwise the very bug above would simply
+//!   reappear one level up, with a deep-but-successful recon sequence
+//!   guillotined by a total-cost ceiling instead of by a per-run retry counter.
 //!   Only THIS ceiling latches `cap_reached`, and hence only this one fires
 //!   `run_task::mod`'s `with_stop_signal` — at which point stopping really is
-//!   correct, because no further delegation could clear it.
+//!   correct, because delegations have demonstrably stopped clearing it.
 //!
 //! Test: `redelegating_runner_retries_on_llm_error_then_succeeds`,
 //! `successful_delegations_never_consume_a_later_delegations_budget`,
+//! `many_successful_delegations_never_latch_the_failure_ceiling`,
 //! `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`,
-//! `run_wide_invocation_ceiling_latches_cap_reached`,
+//! `failure_ceiling_latches_cap_reached`,
 //! `redelegating_runner_propagates_non_retryable_errors_immediately`,
 //! `cap_reached_message_names_the_project_path`.
 
@@ -91,44 +95,58 @@ use crate::tools::{AgentOutput, AgentRunner, RunContext};
 /// [`RedelegatingRunner::run_with_retries`] call, reset at loop entry. Once
 /// exceeded, that delegation stops without invoking the inner runner and
 /// returns a recoverable error — the PM's loop continues and may delegate
-/// again with a full, fresh budget (see [`MAX_ENGINEER_INVOCATIONS`] for the
+/// again with a full, fresh budget (see [`MAX_FAILED_INVOCATIONS`] for the
 /// run-wide backstop that keeps "again" from being unbounded).
 /// Test: `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`,
 /// `successful_delegations_never_consume_a_later_delegations_budget`.
 pub const MAX_REDELEGATIONS: u32 = 3;
 
-/// Maximum engineer invocations across a whole `execute_run_task` run (#2852).
+/// Maximum FAILED engineer invocations across a whole `execute_run_task` run
+/// (#2852).
 ///
 /// Why: With [`MAX_REDELEGATIONS`] scoped per-delegation, something must still
-/// bound a pathological run in which EVERY delegation burns its full retry
-/// budget — otherwise a PM stuck in a failing loop could re-delegate once per
-/// turn forever, which is the runaway #2265 existed to prevent. 12 is 4× the
-/// per-delegation budget: it lets four separate delegations fail completely
-/// before the run is declared hopeless, which no legitimate recon-then-build
-/// shape can reach (recon delegations succeed on their first attempt and cost
-/// 1 invocation each; run-6's pathological case totalled ~6), while still
-/// binding well inside the PM's 8-turn × 3-attempt worst case of 24.
-/// What: Checked against the shared [`RedelegationCapSignal`] before every
-/// engineer invocation. Exceeding it is the ONLY thing that latches
-/// `cap_reached`, and hence the only thing that fires `run_task::mod`'s
-/// `with_stop_signal` to halt the PM loop — correct here precisely because no
-/// fresh delegation could clear it.
-/// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
-pub const MAX_ENGINEER_INVOCATIONS: u32 = 12;
+/// bound a pathological run in which delegations keep FAILING — otherwise a PM
+/// stuck in a failing loop could re-delegate once per turn forever, which is
+/// the runaway #2265 existed to prevent. Only FAILURES count toward it. This
+/// fix's central thesis is that a successful delegation must never consume
+/// budget a later one needs; that has to hold at the run-wide ceiling too, not
+/// just at the per-delegation counter, or the same guillotine simply moves up
+/// one level. A PM issuing many successful read-only recon delegations — one
+/// per atomic recon step, the normal shape, and `tcode` is an interactive
+/// daily driver rather than only a bake-off runner — must never be terminated
+/// for it, no matter how deep the recon goes.
+/// 12 is 4× the per-delegation retry budget: four separate delegations may
+/// each fail completely before the run is declared hopeless.
+/// What: Checked against the shared [`RedelegationCapSignal`] after an engineer
+/// invocation FAILS. Reaching it is the ONLY thing that latches `cap_reached`,
+/// and hence the only thing that fires `run_task::mod`'s `with_stop_signal` to
+/// halt the PM loop — correct here precisely because a run that has failed this
+/// many times has demonstrated that fresh delegations are not clearing it.
+/// Successful invocations are counted only by
+/// [`RedelegationCapSignal::attempts`], which is reporting-only and governs
+/// nothing.
+/// Test: `failure_ceiling_latches_cap_reached`,
+/// `many_successful_delegations_never_latch_the_failure_ceiling`.
+pub const MAX_FAILED_INVOCATIONS: u32 = 12;
 
 /// Shared, run-scoped state behind [`RedelegationCapSignal`].
 ///
 /// Why: Kept as a private inner type so the public handle stays a cheap,
 /// `Clone`-able `Arc` wrapper — see [`RedelegationCapSignal`]'s own docs.
-/// What: `attempts` counts every engineer invocation actually made across the
-/// whole run. `retry_budget_exhausted` latches `true` the first time any ONE
-/// delegation burns all [`MAX_REDELEGATIONS`] attempts — informational only.
-/// `cap_reached` latches `true` only when an invocation would exceed the
-/// run-wide [`MAX_ENGINEER_INVOCATIONS`] ceiling; that one is terminal (#2852).
+/// What: `attempts` counts every engineer invocation actually dispatched across
+/// the whole run — a truthful cost measure for REPORTING only; it governs
+/// nothing (#2852). `failed_invocations` counts only the subset that failed,
+/// and is the sole input to the terminal ceiling, so that no number of
+/// successes can ever end a run. `retry_budget_exhausted` latches `true` the
+/// first time any ONE delegation burns all [`MAX_REDELEGATIONS`] attempts —
+/// informational only. `cap_reached` latches `true` only when
+/// `failed_invocations` reaches [`MAX_FAILED_INVOCATIONS`]; that one is
+/// terminal (#2852).
 /// Test: Exercised indirectly through `RedelegationCapSignal`'s own tests.
 #[derive(Debug, Default)]
 struct RedelegationCapState {
     attempts: AtomicU32,
+    failed_invocations: AtomicU32,
     retry_budget_exhausted: AtomicBool,
     cap_reached: AtomicBool,
 }
@@ -140,14 +158,18 @@ struct RedelegationCapState {
 /// the runner to enforce the cap, the report assembler to recognise a
 /// cap-triggered terminal state even when the PM's own loop error doesn't
 /// literally say so (e.g. the PM's NEXT turn separately exhausts its own
-/// budget after seeing the cap-reached tool error). An `Arc`-wrapped atomic
-/// pair is the simplest thing that is `Send + Sync` and cheap to clone into
+/// budget after seeing the cap-reached tool error). An `Arc`-wrapped group of
+/// atomics is the simplest thing that is `Send + Sync` and cheap to clone into
 /// both places.
-/// What: `new()` starts at zero attempts, cap not reached. `is_cap_reached()`
-/// and `attempts()` are read-only accessors for `assemble_report`;
-/// `record_attempt`/`mark_cap_reached` are private, called only by
-/// [`RedelegatingRunner`].
-/// Test: `redelegating_runner_stops_at_cap_and_marks_signal`.
+/// What: `new()` starts at zero attempts with both flags clear.
+/// `is_cap_reached()`, `is_retry_budget_exhausted()` and `attempts()` are
+/// read-only accessors for `assemble_report`; `record_attempt`,
+/// `mark_retry_budget_exhausted` and `mark_cap_reached` are private, called
+/// only by [`RedelegatingRunner`]. The two flags are deliberately distinct:
+/// only `cap_reached` is terminal (#2852).
+/// Test: `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`,
+/// `failure_ceiling_latches_cap_reached`,
+/// `successful_delegations_never_consume_a_later_delegations_budget`.
 #[derive(Debug, Clone, Default)]
 pub struct RedelegationCapSignal(Arc<RedelegationCapState>);
 
@@ -162,17 +184,30 @@ impl RedelegationCapSignal {
         Self::default()
     }
 
-    /// Record one more engineer invocation and return the new run-wide total.
+    /// Record one more dispatched engineer invocation.
     ///
-    /// Why: The runner must check the POST-increment total against
-    /// [`MAX_ENGINEER_INVOCATIONS`] atomically with recording it, so two
-    /// invocations can never both observe "one under the ceiling" and both
-    /// proceed.
-    /// What: `fetch_add(1) + 1`. Called only for invocations that actually
-    /// reach the inner runner, so the count stays a truthful cost measure.
-    /// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
-    fn record_attempt(&self) -> u32 {
-        self.0.attempts.fetch_add(1, Ordering::SeqCst) + 1
+    /// Why: Reporting only (#2852) — an operator wants to know how much
+    /// engineer work the run actually bought. It deliberately governs NOTHING:
+    /// making total cost terminal is precisely the bug this fix removes.
+    /// What: `fetch_add(1)`. Called only for invocations that actually reach
+    /// the inner runner, so the count stays a truthful cost measure.
+    /// Test: `many_successful_delegations_never_latch_the_failure_ceiling`.
+    fn record_attempt(&self) {
+        self.0.attempts.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Record one FAILED engineer invocation and return the new run-wide total.
+    ///
+    /// Why: This is the terminal ceiling's only input. The runner must compare
+    /// the POST-increment total against [`MAX_FAILED_INVOCATIONS`] atomically
+    /// with recording it, so two concurrent failures can never both observe
+    /// "one under the ceiling" and both proceed.
+    /// What: `fetch_add(1) + 1`. Called once per invocation that returned an
+    /// error, retryable or not — both shapes are failures the ceiling exists
+    /// to bound.
+    /// Test: `failure_ceiling_latches_cap_reached`.
+    fn record_failure(&self) -> u32 {
+        self.0.failed_invocations.fetch_add(1, Ordering::SeqCst) + 1
     }
 
     /// Latch the "some delegation burned its whole retry budget" flag (#2852).
@@ -188,28 +223,59 @@ impl RedelegationCapSignal {
         self.0.retry_budget_exhausted.store(true, Ordering::SeqCst);
     }
 
-    /// Latch the terminal run-wide cap flag.
+    /// Latch the terminal run-wide failure-ceiling flag.
     ///
-    /// Why: Called exactly once, the moment an invocation would exceed
-    /// [`MAX_ENGINEER_INVOCATIONS`] — the run is out of total budget and
-    /// nothing the PM does next can help, so this is what both
+    /// Why: Called exactly once, the moment failed invocations reach
+    /// [`MAX_FAILED_INVOCATIONS`] — the run has failed too many times for a
+    /// fresh delegation to be worth betting on, so this is what both
     /// `assemble_report` and the PM loop's stop signal key off.
     /// What: Stores `true`.
-    /// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
+    /// Test: `failure_ceiling_latches_cap_reached`.
     fn mark_cap_reached(&self) {
         self.0.cap_reached.store(true, Ordering::SeqCst);
     }
 
-    /// Whether the run-wide engineer-invocation ceiling was hit (#2852).
+    /// Whether the run-wide FAILED-invocation ceiling was hit (#2852).
     ///
     /// Why: Drives `run_task::mod`'s `with_stop_signal`, so it must be `true`
-    /// ONLY for conditions a fresh delegation genuinely cannot clear. Per-call
-    /// retry exhaustion is not one of those — see
-    /// [`Self::is_retry_budget_exhausted`].
+    /// ONLY for conditions a fresh delegation genuinely cannot clear. Neither
+    /// per-call retry exhaustion (see [`Self::is_retry_budget_exhausted`]) nor
+    /// sheer invocation COUNT is one of those — a run of successful recon
+    /// delegations must never land here.
     /// What: Reads the latched flag.
-    /// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
+    /// Test: `failure_ceiling_latches_cap_reached`,
+    /// `many_successful_delegations_never_latch_the_failure_ceiling`.
     pub fn is_cap_reached(&self) -> bool {
         self.0.cap_reached.load(Ordering::SeqCst)
+    }
+
+    /// Test-only: a signal with `retry_budget_exhausted` already latched.
+    ///
+    /// Why: `run_task::mod`'s `assemble_report` must be unit-testable against
+    /// the retry-exhausted-with-deliverable shape — the most common real-world
+    /// outcome once #2852 makes retry exhaustion recoverable — without
+    /// standing up a whole scripted `RedelegatingRunner` from a sibling module.
+    /// Kept `#[cfg(test)]` so the production API kept its invariant that only
+    /// [`RedelegatingRunner`] can latch this.
+    /// What: `Self::default()` with the one flag set.
+    /// Test: `assemble_report_maps_retry_exhausted_with_deliverable_to_partial`.
+    #[cfg(test)]
+    pub(crate) fn retry_exhausted_for_test() -> Self {
+        let signal = Self::default();
+        signal.mark_retry_budget_exhausted();
+        signal
+    }
+
+    /// Total FAILED engineer invocations recorded so far, run-wide.
+    ///
+    /// Why: The number the terminal report must quote — it is the ceiling's
+    /// actual input, and unlike a pre-incremented dispatch counter it is
+    /// exactly the count of invocations that really failed, so an operator is
+    /// never told "13" when 12 occurred.
+    /// What: Reads the atomic counter.
+    /// Test: `failure_ceiling_latches_cap_reached`.
+    pub fn failed_invocations(&self) -> u32 {
+        self.0.failed_invocations.load(Ordering::SeqCst)
     }
 
     /// Whether any single delegation exhausted its [`MAX_REDELEGATIONS`]
@@ -224,12 +290,17 @@ impl RedelegationCapSignal {
         self.0.retry_budget_exhausted.load(Ordering::SeqCst)
     }
 
-    /// Total engineer invocations recorded so far, run-wide.
+    /// Total engineer invocations (successes AND failures) recorded so far,
+    /// run-wide.
     ///
-    /// Why: Surfaced in the terminal report's message so an operator knows
-    /// exactly how much engineer work the run actually bought.
+    /// Why: A truthful total-cost measure for callers that want it (e.g.
+    /// future observability/metrics) — but it is reporting-only and governs
+    /// nothing (#2852): the terminal report's message quotes
+    /// [`Self::failed_invocations`] instead, precisely so a run of successful
+    /// delegations is never described as having "failed" anything.
     /// What: Reads the atomic counter.
-    /// Test: `run_wide_invocation_ceiling_latches_cap_reached`.
+    /// Test: `many_successful_delegations_never_latch_the_failure_ceiling`,
+    /// `redelegating_runner_retries_on_llm_error_then_succeeds`.
     pub fn attempts(&self) -> u32 {
         self.0.attempts.load(Ordering::SeqCst)
     }
@@ -250,20 +321,23 @@ impl RedelegationCapSignal {
 /// What: Holds the inner (real) engineer runner, a shared
 /// [`RedelegationCapSignal`], and the project path (quoted in the
 /// cap-reached message per the required wording, "…partial work preserved at
-/// <path>"). Per delegation, a LOCAL attempt counter starts at zero (#2852):
+/// <path>"). If the run-wide ceiling has already latched, the delegation is
+/// refused up front without dispatching anything. Otherwise, per delegation, a
+/// LOCAL attempt counter starts at zero (#2852):
 /// if it would exceed [`MAX_REDELEGATIONS`], stop WITHOUT invoking the inner
 /// runner, latch `retry_budget_exhausted`, warn, and return a RECOVERABLE
-/// error (the PM may delegate again with a fresh budget). Otherwise record the
-/// invocation run-wide; if THAT would exceed [`MAX_ENGINEER_INVOCATIONS`],
-/// latch `cap_reached` (terminal — stops the PM loop) and return. Otherwise
-/// invoke the inner runner; on success, return it; on a failure whose
+/// error (the PM may delegate again with a fresh budget). Otherwise invoke the
+/// inner runner; on success, return it. On failure, record the failure
+/// run-wide; if that reaches [`MAX_FAILED_INVOCATIONS`], latch `cap_reached`
+/// (terminal — stops the PM loop) and return. Otherwise, on a failure whose
 /// [`redelegation_hint`] is `Some`, retry with the task text augmented by
 /// that hint; on a failure whose hint is `None` (no partial work to reuse),
 /// propagate immediately without consuming further budget.
 /// Test: `redelegating_runner_retries_on_llm_error_then_succeeds`,
 /// `successful_delegations_never_consume_a_later_delegations_budget`,
+/// `many_successful_delegations_never_latch_the_failure_ceiling`,
 /// `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`,
-/// `run_wide_invocation_ceiling_latches_cap_reached`,
+/// `failure_ceiling_latches_cap_reached`,
 /// `redelegating_runner_propagates_non_retryable_errors_immediately`.
 pub struct RedelegatingRunner {
     inner: Arc<dyn AgentRunner>,
@@ -302,13 +376,14 @@ impl RedelegatingRunner {
     /// that delegation, so an earlier successful one cannot spend it. Returns
     /// the first successful `AgentOutput`; or, once this call's attempts would
     /// exceed [`MAX_REDELEGATIONS`], a recoverable error naming the count and
-    /// project path; or, once the run's invocations would exceed
-    /// [`MAX_ENGINEER_INVOCATIONS`], a terminal error that also latches the
+    /// project path; or, once the run's FAILED invocations reach
+    /// [`MAX_FAILED_INVOCATIONS`], a terminal error that also latches the
     /// stop signal; or, on a non-retryable failure, that failure verbatim.
     /// Test: `redelegating_runner_retries_on_llm_error_then_succeeds`,
     /// `successful_delegations_never_consume_a_later_delegations_budget`,
+    /// `many_successful_delegations_never_latch_the_failure_ceiling`,
     /// `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal`,
-    /// `run_wide_invocation_ceiling_latches_cap_reached`,
+    /// `failure_ceiling_latches_cap_reached`,
     /// `redelegating_runner_propagates_non_retryable_errors_immediately`,
     /// `cap_reached_message_names_the_project_path`.
     async fn run_with_retries(
@@ -317,6 +392,20 @@ impl RedelegatingRunner {
         task: &str,
         ctx: &RunContext,
     ) -> Result<AgentOutput> {
+        // Once the run-wide ceiling has latched, refuse WITHOUT dispatching.
+        // The PM loop is already being stopped, so further engineer work is
+        // pure waste — and dispatching it would also inflate the failure count
+        // the terminal report quotes, telling an operator more invocations
+        // failed than the ceiling actually allowed.
+        if self.signal.is_cap_reached() {
+            return Err(anyhow::anyhow!(
+                "engineer failure ceiling reached after {} failed invocations this run; \
+                 partial work preserved at {}",
+                self.signal.failed_invocations(),
+                self.project.display()
+            ));
+        }
+
         let mut current_task = task.to_string();
         // #2852: per-CALL, not per-run. Reset at entry so reconnaissance
         // delegations that succeed never starve the build that follows.
@@ -345,27 +434,11 @@ impl RedelegatingRunner {
                 ));
             }
 
-            let total = self.signal.record_attempt();
-            if total > MAX_ENGINEER_INVOCATIONS {
-                self.signal.mark_cap_reached();
-                // Terminal, unlike the per-call budget above: the run has spent
-                // its whole engineer allowance, so no fresh delegation can help
-                // and `run_task::mod`'s stop signal will halt the PM loop at
-                // its next turn boundary. Log loudly — this ends the run.
-                tracing::warn!(
-                    agent = agent_name,
-                    invocations = total - 1,
-                    ceiling = MAX_ENGINEER_INVOCATIONS,
-                    "run-wide engineer invocation ceiling reached; stopping the PM loop. \
-                     Every delegation this run consumed retries without succeeding."
-                );
-                return Err(anyhow::anyhow!(
-                    "engineer invocation ceiling reached after {} invocations this run; \
-                     partial work preserved at {}",
-                    MAX_ENGINEER_INVOCATIONS,
-                    self.project.display()
-                ));
-            }
+            // Reporting only (#2852): total invocations govern nothing, so a
+            // run of successful delegations can never be terminated for its
+            // count. Recorded before dispatch so the cost measure stays
+            // truthful even if the invocation panics or fails.
+            self.signal.record_attempt();
 
             match self
                 .inner
@@ -374,6 +447,32 @@ impl RedelegatingRunner {
             {
                 Ok(out) => return Ok(out),
                 Err(e) => {
+                    // Only FAILURES feed the terminal ceiling — the whole point
+                    // of #2852, applied at the run-wide level too and not just
+                    // to the per-delegation counter.
+                    let failures = self.signal.record_failure();
+                    if failures >= MAX_FAILED_INVOCATIONS {
+                        self.signal.mark_cap_reached();
+                        // Terminal, unlike the per-call budget above: the run
+                        // has failed too many times for a fresh delegation to
+                        // be worth betting on, so `run_task::mod`'s stop signal
+                        // halts the PM loop at its next turn boundary. Log
+                        // loudly — this ends the run.
+                        tracing::warn!(
+                            agent = agent_name,
+                            failed_invocations = failures,
+                            ceiling = MAX_FAILED_INVOCATIONS,
+                            "run-wide engineer failure ceiling reached; stopping the PM \
+                             loop. Delegations this run kept failing rather than \
+                             succeeding."
+                        );
+                        return Err(anyhow::anyhow!(
+                            "engineer failure ceiling reached after {failures} failed \
+                             invocations this run; partial work preserved at {}",
+                            self.project.display()
+                        ));
+                    }
+
                     let Some(hint) = redelegation_hint(&e) else {
                         // No partial work to reuse — this is a hard failure
                         // (unknown agent, bad config), not a re-delegation
@@ -410,461 +509,4 @@ impl AgentRunner for RedelegatingRunner {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
-    use std::sync::Mutex;
-
-    use anyhow::anyhow;
-
-    use super::*;
-    use crate::agent_loop::AgentLoopError;
-    use crate::llm::LlmError;
-    use crate::runner::RunnerError;
-
-    /// Scripted inner runner: replays a fixed queue of `Result`s in order,
-    /// recording the task text it was called with each time.
-    ///
-    /// Why: Deterministic, offline substitute for the real engineer runner so
-    /// these tests exercise ONLY the retry/cap policy in `RedelegatingRunner`.
-    /// What: `outcomes` is drained front-to-back via a `Mutex<VecDeque<..>>`;
-    /// `calls` records every `(agent_name, task)` pair seen.
-    /// Test: Used by every test below.
-    struct ScriptedInner {
-        outcomes: Mutex<std::collections::VecDeque<Result<AgentOutput>>>,
-        calls: Mutex<Vec<String>>,
-    }
-
-    impl ScriptedInner {
-        fn new(outcomes: Vec<Result<AgentOutput>>) -> Self {
-            Self {
-                outcomes: Mutex::new(outcomes.into_iter().collect()),
-                calls: Mutex::new(Vec::new()),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl AgentRunner for ScriptedInner {
-        async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
-            self.calls
-                .lock()
-                .expect("calls lock")
-                .push(task.to_string());
-            self.outcomes
-                .lock()
-                .expect("outcomes lock")
-                .pop_front()
-                .unwrap_or_else(|| Err(anyhow!("ScriptedInner exhausted for {agent_name}")))
-        }
-    }
-
-    /// Captures every `tracing` event's level + message for assertions.
-    ///
-    /// Why: #2852 requires the cap to stop being SILENT — run-6's stderr had
-    /// no trace of it, so the mechanism was only discoverable by cross-run
-    /// forensics on the report's `task` label. Proving the log exists needs an
-    /// in-process subscriber; the crate has no tracing-capture dev-dependency,
-    /// and a ~15-line `Layer` is cheaper than adding one.
-    /// What: A `Layer` pushing `(Level, message)` into a shared `Vec`.
-    /// Test: `cap_exhaustion_is_logged_at_warn_level`.
-    #[derive(Default, Clone)]
-    struct CapturedLogs(Arc<Mutex<Vec<(tracing::Level, String)>>>);
-
-    struct CaptureLayer(CapturedLogs);
-
-    struct MessageVisitor(String);
-
-    impl tracing::field::Visit for MessageVisitor {
-        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-            if field.name() == "message" {
-                self.0 = format!("{value:?}");
-            }
-        }
-    }
-
-    impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
-        fn on_event(
-            &self,
-            event: &tracing::Event<'_>,
-            _ctx: tracing_subscriber::layer::Context<'_, S>,
-        ) {
-            let mut visitor = MessageVisitor(String::new());
-            event.record(&mut visitor);
-            self.0
-                .0
-                .lock()
-                .expect("captured logs lock")
-                .push((*event.metadata().level(), visitor.0));
-        }
-    }
-
-    fn llm_error() -> anyhow::Error {
-        anyhow::Error::from(RunnerError::Loop {
-            name: "python-engineer".to_string(),
-            source: AgentLoopError::Llm(LlmError::ApiError {
-                status: 500,
-                body: "bedrock hiccup".to_string(),
-            }),
-        })
-    }
-
-    fn unknown_agent_error() -> anyhow::Error {
-        anyhow::Error::from(RunnerError::UnknownAgent {
-            name: "python-engineer".to_string(),
-            dir: PathBuf::from("/agents"),
-        })
-    }
-
-    /// A retryable `AgentLoopError::Llm` failure is retried automatically,
-    /// with the reuse hint appended, and a later success is returned.
-    ///
-    /// Why: This is the core #2265 fix #3 behaviour — retries happen inside
-    /// ONE call, invisible to the PM's own turn budget.
-    /// What: Script [Err(llm), Ok(success)]; call `run`; assert the returned
-    /// output is the success, the inner runner was called twice, and the
-    /// SECOND call's task text carries the reuse hint.
-    /// Test: this test.
-    #[tokio::test]
-    async fn redelegating_runner_retries_on_llm_error_then_succeeds() {
-        let inner = Arc::new(ScriptedInner::new(vec![
-            Err(llm_error()),
-            Ok(AgentOutput::from_content("done")),
-        ]));
-        let signal = RedelegationCapSignal::new();
-        let runner = RedelegatingRunner::new(
-            Arc::clone(&inner) as Arc<dyn AgentRunner>,
-            signal.clone(),
-            PathBuf::from("/tmp/project"),
-        );
-
-        let out = runner
-            .run("python-engineer", "build the package")
-            .await
-            .expect("second attempt must succeed");
-        assert_eq!(out.content, "done");
-
-        let calls = inner.calls.lock().expect("calls lock");
-        assert_eq!(
-            calls.len(),
-            2,
-            "must retry exactly once after the LLM error"
-        );
-        assert_eq!(calls[0], "build the package");
-        assert!(
-            calls[1].contains("READ and CONTINUE"),
-            "the retried task must carry the reuse hint, got: {}",
-            calls[1]
-        );
-        assert!(
-            !signal.is_cap_reached(),
-            "cap must not be reached on a successful retry"
-        );
-        assert_eq!(signal.attempts(), 2);
-    }
-
-    /// (#2852 REGRESSION) A PM that spends several SUCCESSFUL delegations on
-    /// reconnaissance may still delegate the actual build afterwards — with a
-    /// full, fresh retry budget.
-    ///
-    /// Why: This is the exact total-loss bug #2852 closes, and the shape of
-    /// L4 bake-off run-6: the PM issued 3 legitimate read-only recon
-    /// delegations (read PROBLEM.md, list test_suite, read test_basic.py) and
-    /// its 4th call — the real build — was refused before the inner runner was
-    /// ever invoked, yielding `partial`/exit 6 with 0/9 tests and 0/5
-    /// deliverables. Runs 3/4/5 succeeded only by luck of issuing one fewer
-    /// recon call. Recon-then-build is the NORMAL PM shape, so under the old
-    /// run-wide counter any PM reading more than two files before building was
-    /// killed by the harness. Against the pre-fix code this test fails on the
-    /// 4th `run` call.
-    /// What: Script [Ok, Ok, Ok] for three recon delegations, then
-    /// [Err(retryable llm), Ok] for the build. Assert every recon call
-    /// succeeds, the build ALSO runs (not refused) and succeeds on its own
-    /// retry — proving both that a successful delegation consumes no later
-    /// budget and that the build's budget was reset, not merely off-by-one.
-    /// Test: this test.
-    #[tokio::test]
-    async fn successful_delegations_never_consume_a_later_delegations_budget() {
-        let inner = Arc::new(ScriptedInner::new(vec![
-            Ok(AgentOutput::from_content("PROBLEM.md contents")),
-            Ok(AgentOutput::from_content("test_suite listing")),
-            Ok(AgentOutput::from_content("test_basic.py contents")),
-            // The build: fails once transiently, then succeeds.
-            Err(llm_error()),
-            Ok(AgentOutput::from_content("build complete")),
-        ]));
-        let signal = RedelegationCapSignal::new();
-        let runner = RedelegatingRunner::new(
-            Arc::clone(&inner) as Arc<dyn AgentRunner>,
-            signal.clone(),
-            PathBuf::from("/tmp/project"),
-        );
-
-        for recon in ["read PROBLEM.md", "list test_suite", "read test_basic.py"] {
-            let out = runner
-                .run("python-engineer", recon)
-                .await
-                .unwrap_or_else(|e| panic!("recon delegation {recon:?} must succeed, got: {e}"));
-            assert!(!out.content.is_empty());
-        }
-
-        let out = runner
-            .run("python-engineer", "implement the solution")
-            .await
-            .expect(
-                "the BUILD delegation must run — under the pre-#2852 run-wide counter it \
-                 was refused as attempt 4 without ever invoking the engineer",
-            );
-        assert_eq!(out.content, "build complete");
-
-        assert!(
-            !signal.is_cap_reached(),
-            "no run-wide ceiling was approached, so the PM loop must not be stopped"
-        );
-        assert!(
-            !signal.is_retry_budget_exhausted(),
-            "no single delegation burned its retry budget"
-        );
-        assert_eq!(
-            inner.calls.lock().expect("calls lock").len(),
-            5,
-            "3 recon invocations + 2 build invocations must all have reached the engineer"
-        );
-    }
-
-    /// Once ONE delegation's attempts exceed `MAX_REDELEGATIONS`, the runner
-    /// stops calling the inner runner and returns a clean error naming the
-    /// attempt count — but does NOT latch the loop-stopping `cap_reached`.
-    ///
-    /// Why: This is the cap's real purpose (fix #1) — a genuinely failing
-    /// engineer must stay bounded — held together with #2852's constraint that
-    /// bounding it must not be fatal to the RUN. The PM loop's stop signal is
-    /// unrecoverable by construction, so it may only fire on a condition a
-    /// fresh delegation cannot clear; retry exhaustion is not one.
-    /// `retry_budget_exhausted` latches instead, which labels the report
-    /// without killing the loop.
-    /// What: Script `MAX_REDELEGATIONS` failing `Llm` outcomes (all
-    /// retryable); assert the error names the cap and count, the inner runner
-    /// ran exactly `MAX_REDELEGATIONS` times (the check happens BEFORE the
-    /// attempt that would exceed), `is_retry_budget_exhausted()` is set, and
-    /// `is_cap_reached()` is NOT.
-    /// Test: this test.
-    #[tokio::test]
-    async fn redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal() {
-        let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
-        let inner = Arc::new(ScriptedInner::new(outcomes));
-        let signal = RedelegationCapSignal::new();
-        let runner = RedelegatingRunner::new(
-            Arc::clone(&inner) as Arc<dyn AgentRunner>,
-            signal.clone(),
-            PathBuf::from("/tmp/project"),
-        );
-
-        let err = runner
-            .run("python-engineer", "build the package")
-            .await
-            .expect_err("must fail once this delegation's retries are exhausted");
-
-        assert!(
-            err.to_string().contains("re-delegation limit reached"),
-            "error must name the cap condition, got: {err}"
-        );
-        assert!(
-            err.to_string().contains(&MAX_REDELEGATIONS.to_string()),
-            "error must name the attempt count, got: {err}"
-        );
-
-        let calls = inner.calls.lock().expect("calls lock");
-        assert_eq!(
-            calls.len(),
-            MAX_REDELEGATIONS as usize,
-            "the inner runner must be called exactly MAX_REDELEGATIONS times, not more"
-        );
-        assert!(
-            signal.is_retry_budget_exhausted(),
-            "signal must latch retry-budget-exhausted so the report can label it"
-        );
-        assert!(
-            !signal.is_cap_reached(),
-            "retry exhaustion is RECOVERABLE (#2852) — it must not stop the PM loop, \
-             which would kill a run whose next delegation could well succeed"
-        );
-        assert_eq!(
-            signal.attempts(),
-            MAX_REDELEGATIONS,
-            "only real invocations count; the refused 4th never reached the engineer"
-        );
-    }
-
-    /// Exceeding the run-wide `MAX_ENGINEER_INVOCATIONS` ceiling latches
-    /// `cap_reached`, which is what stops the PM loop.
-    ///
-    /// Why: With `MAX_REDELEGATIONS` scoped per-delegation (#2852), this is the
-    /// backstop that keeps a pathological run — every delegation burning a full
-    /// retry budget — from re-delegating once per PM turn forever. Unlike
-    /// per-call exhaustion, this one IS terminal, so it is correct for it to
-    /// fire the stop signal.
-    /// What: Fail every invocation retryably and delegate repeatedly. Assert
-    /// the ceiling latches `cap_reached`, the engineer was invoked exactly
-    /// `MAX_ENGINEER_INVOCATIONS` times (never more), and the final error names
-    /// the ceiling.
-    /// Test: this test.
-    #[tokio::test]
-    async fn run_wide_invocation_ceiling_latches_cap_reached() {
-        // Generously more failures than the ceiling allows to be consumed.
-        let outcomes = (0..MAX_ENGINEER_INVOCATIONS * 2)
-            .map(|_| Err(llm_error()))
-            .collect();
-        let inner = Arc::new(ScriptedInner::new(outcomes));
-        let signal = RedelegationCapSignal::new();
-        let runner = RedelegatingRunner::new(
-            Arc::clone(&inner) as Arc<dyn AgentRunner>,
-            signal.clone(),
-            PathBuf::from("/tmp/project"),
-        );
-
-        // Each call burns MAX_REDELEGATIONS invocations, so the ceiling is
-        // reached after MAX_ENGINEER_INVOCATIONS / MAX_REDELEGATIONS calls.
-        let mut last_err = None;
-        for _ in 0..(MAX_ENGINEER_INVOCATIONS / MAX_REDELEGATIONS) + 1 {
-            last_err = runner
-                .run("python-engineer", "build the package")
-                .await
-                .err();
-        }
-
-        let err = last_err.expect("every delegation fails, so the last must error");
-        assert!(
-            signal.is_cap_reached(),
-            "the run-wide ceiling must latch cap_reached to stop the PM loop"
-        );
-        assert!(
-            err.to_string()
-                .contains("engineer invocation ceiling reached"),
-            "the terminal error must name the run-wide ceiling, got: {err}"
-        );
-        assert_eq!(
-            signal.attempts(),
-            MAX_ENGINEER_INVOCATIONS + 1,
-            "the ceiling is detected on the invocation that would exceed it, which is \
-             never dispatched"
-        );
-        assert_eq!(
-            inner.calls.lock().expect("calls lock").len(),
-            MAX_ENGINEER_INVOCATIONS as usize,
-            "the engineer must never be invoked beyond the run-wide ceiling"
-        );
-    }
-
-    /// A non-retryable failure (no partial work to reuse) propagates
-    /// immediately, without consuming further cap budget on retries that
-    /// would never help.
-    ///
-    /// Why: Guards the negative case — the retry loop must not blindly retry
-    /// EVERY failure, only ones `redelegation_hint` says are worth reusing.
-    /// What: Script a single `UnknownAgent` error; assert it propagates
-    /// verbatim after exactly one attempt, and the cap is NOT marked reached.
-    /// Test: this test.
-    #[tokio::test]
-    async fn redelegating_runner_propagates_non_retryable_errors_immediately() {
-        let inner = Arc::new(ScriptedInner::new(vec![Err(unknown_agent_error())]));
-        let signal = RedelegationCapSignal::new();
-        let runner = RedelegatingRunner::new(
-            Arc::clone(&inner) as Arc<dyn AgentRunner>,
-            signal.clone(),
-            PathBuf::from("/tmp/project"),
-        );
-
-        let err = runner
-            .run("python-engineer", "build the package")
-            .await
-            .expect_err("unknown-agent failures must propagate");
-
-        assert!(err.to_string().contains("unknown agent"));
-        let calls = inner.calls.lock().expect("calls lock");
-        assert_eq!(calls.len(), 1, "must not retry a non-retryable failure");
-        assert!(
-            !signal.is_cap_reached(),
-            "cap must not be marked reached for a non-retryable failure"
-        );
-    }
-
-    /// Exhausting a delegation's retry budget emits a WARN-level log naming
-    /// the attempt count.
-    ///
-    /// Why: #2852's observability half. The cap was completely silent — no log
-    /// line anywhere — so the only evidence a run had been guillotined was a
-    /// label buried in the report's `task` field, which took a cross-run
-    /// forensic comparison to interpret. An operator must be able to see this
-    /// in stderr.
-    /// What: Force per-call retry exhaustion under a capturing subscriber;
-    /// assert a WARN event was emitted naming the attempt count. (Logs go to
-    /// stderr via the crate's subscriber, never stdout — the tracing default.)
-    ///
-    /// `rebuild_interest_cache` is load-bearing, not defensive: `tracing`
-    /// caches per-callsite interest GLOBALLY, and this binary's
-    /// `logging::tests::init_tracing_for_test_is_idempotent` installs a
-    /// process-global `EnvFilter` subscriber that (with `RUST_LOG` unset)
-    /// rejects this crate's WARN events. Whichever runs first wins the cache,
-    /// so without an explicit rebuild against THIS thread's subscriber the
-    /// assertion is order-dependent — it flaked 1-in-N during development.
-    /// Since interest is re-evaluated per callsite on the next event, the
-    /// rebuild deterministically re-admits the callsite for this scoped
-    /// subscriber.
-    /// Test: this test.
-    #[tokio::test]
-    async fn cap_exhaustion_is_logged_at_warn_level() {
-        use tracing_subscriber::layer::SubscriberExt;
-
-        let logs = CapturedLogs::default();
-        let subscriber = tracing_subscriber::registry().with(CaptureLayer(logs.clone()));
-        let _guard = tracing::subscriber::set_default(subscriber);
-        tracing::callsite::rebuild_interest_cache();
-
-        let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
-        let runner = RedelegatingRunner::new(
-            Arc::new(ScriptedInner::new(outcomes)) as Arc<dyn AgentRunner>,
-            RedelegationCapSignal::new(),
-            PathBuf::from("/tmp/project"),
-        );
-        let _ = runner.run("python-engineer", "build the package").await;
-
-        let captured = logs.0.lock().expect("captured logs lock");
-        let warned = captured.iter().any(|(level, msg)| {
-            *level == tracing::Level::WARN && msg.contains("retry budget exhausted")
-        });
-        assert!(
-            warned,
-            "exhausting the retry budget must WARN — it was completely silent before \
-             #2852, making total-loss runs undiagnosable. Captured: {captured:?}"
-        );
-    }
-
-    /// The cap-reached error message names the exact project path passed to
-    /// the constructor.
-    ///
-    /// Why: The required message shape is "re-delegation limit reached after
-    /// N attempts; partial work preserved at <path>" — pin the `<path>` half.
-    /// What: Force the cap with `MAX_REDELEGATIONS` failures against a
-    /// distinctive project path; assert it appears in the error text.
-    /// Test: this test.
-    #[tokio::test]
-    async fn cap_reached_message_names_the_project_path() {
-        let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
-        let inner = Arc::new(ScriptedInner::new(outcomes));
-        let signal = RedelegationCapSignal::new();
-        let runner = RedelegatingRunner::new(
-            Arc::clone(&inner) as Arc<dyn AgentRunner>,
-            signal,
-            PathBuf::from("/very/distinctive/project/path"),
-        );
-
-        let err = runner
-            .run("python-engineer", "build the package")
-            .await
-            .expect_err("must fail once the cap is exceeded");
-
-        assert!(
-            err.to_string().contains("/very/distinctive/project/path"),
-            "error must name the project path, got: {err}"
-        );
-    }
-}
+mod tests;

--- a/crates/trusty-code/src/run_task/redelegation/tests.rs
+++ b/crates/trusty-code/src/run_task/redelegation/tests.rs
@@ -1,0 +1,607 @@
+//! Unit tests for the parent module's re-delegation cap machinery (#2265, #2852).
+//!
+//! Why: Split out of `redelegation.rs` so the production module stays under the
+//! 500-SLOC cap; this is a test file (basename `tests.rs`), capped at 1500.
+//! What: Exercises `RedelegatingRunner`'s retry/cap policy and
+//! `RedelegationCapSignal` against a scripted inner runner and a
+//! tracing-capture layer.
+//! Test: this module is itself the test surface.
+
+use std::sync::Mutex;
+
+use anyhow::anyhow;
+
+use super::*;
+use crate::agent_loop::AgentLoopError;
+use crate::llm::LlmError;
+use crate::runner::RunnerError;
+
+/// Scripted inner runner: replays a fixed queue of `Result`s in order,
+/// recording the task text it was called with each time.
+///
+/// Why: Deterministic, offline substitute for the real engineer runner so
+/// these tests exercise ONLY the retry/cap policy in `RedelegatingRunner`.
+/// What: `outcomes` is drained front-to-back via a `Mutex<VecDeque<..>>`;
+/// `calls` records every `(agent_name, task)` pair seen.
+/// Test: Used by every test below.
+struct ScriptedInner {
+    outcomes: Mutex<std::collections::VecDeque<Result<AgentOutput>>>,
+    calls: Mutex<Vec<String>>,
+}
+
+impl ScriptedInner {
+    fn new(outcomes: Vec<Result<AgentOutput>>) -> Self {
+        Self {
+            outcomes: Mutex::new(outcomes.into_iter().collect()),
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentRunner for ScriptedInner {
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
+        self.calls
+            .lock()
+            .expect("calls lock")
+            .push(task.to_string());
+        self.outcomes
+            .lock()
+            .expect("outcomes lock")
+            .pop_front()
+            .unwrap_or_else(|| Err(anyhow!("ScriptedInner exhausted for {agent_name}")))
+    }
+}
+
+/// Captures every `tracing` event's level + message for assertions.
+///
+/// Why: #2852 requires the cap to stop being SILENT — run-6's stderr had
+/// no trace of it, so the mechanism was only discoverable by cross-run
+/// forensics on the report's `task` label. Proving the log exists needs an
+/// in-process subscriber; the crate has no tracing-capture dev-dependency,
+/// and a ~15-line `Layer` is cheaper than adding one.
+/// What: A `Layer` pushing `(Level, message)` into a shared `Vec`.
+/// Test: `cap_exhaustion_is_logged_at_warn_level`.
+#[derive(Default, Clone)]
+struct CapturedLogs(Arc<Mutex<Vec<(tracing::Level, String)>>>);
+
+struct CaptureLayer(CapturedLogs);
+
+struct MessageVisitor(String);
+
+impl tracing::field::Visit for MessageVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            self.0 = format!("{value:?}");
+        }
+    }
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = MessageVisitor(String::new());
+        event.record(&mut visitor);
+        self.0
+            .0
+            .lock()
+            .expect("captured logs lock")
+            .push((*event.metadata().level(), visitor.0));
+    }
+}
+
+fn llm_error() -> anyhow::Error {
+    anyhow::Error::from(RunnerError::Loop {
+        name: "python-engineer".to_string(),
+        source: AgentLoopError::Llm(LlmError::ApiError {
+            status: 500,
+            body: "bedrock hiccup".to_string(),
+        }),
+    })
+}
+
+fn unknown_agent_error() -> anyhow::Error {
+    anyhow::Error::from(RunnerError::UnknownAgent {
+        name: "python-engineer".to_string(),
+        dir: PathBuf::from("/agents"),
+    })
+}
+
+/// A retryable `AgentLoopError::Llm` failure is retried automatically,
+/// with the reuse hint appended, and a later success is returned.
+///
+/// Why: This is the core #2265 fix #3 behaviour — retries happen inside
+/// ONE call, invisible to the PM's own turn budget.
+/// What: Script [Err(llm), Ok(success)]; call `run`; assert the returned
+/// output is the success, the inner runner was called twice, and the
+/// SECOND call's task text carries the reuse hint.
+/// Test: this test.
+#[tokio::test]
+async fn redelegating_runner_retries_on_llm_error_then_succeeds() {
+    let inner = Arc::new(ScriptedInner::new(vec![
+        Err(llm_error()),
+        Ok(AgentOutput::from_content("done")),
+    ]));
+    let signal = RedelegationCapSignal::new();
+    let runner = RedelegatingRunner::new(
+        Arc::clone(&inner) as Arc<dyn AgentRunner>,
+        signal.clone(),
+        PathBuf::from("/tmp/project"),
+    );
+
+    let out = runner
+        .run("python-engineer", "build the package")
+        .await
+        .expect("second attempt must succeed");
+    assert_eq!(out.content, "done");
+
+    let calls = inner.calls.lock().expect("calls lock");
+    assert_eq!(
+        calls.len(),
+        2,
+        "must retry exactly once after the LLM error"
+    );
+    assert_eq!(calls[0], "build the package");
+    assert!(
+        calls[1].contains("READ and CONTINUE"),
+        "the retried task must carry the reuse hint, got: {}",
+        calls[1]
+    );
+    assert!(
+        !signal.is_cap_reached(),
+        "cap must not be reached on a successful retry"
+    );
+    assert_eq!(signal.attempts(), 2);
+}
+
+/// (#2852 REGRESSION) A PM that spends several SUCCESSFUL delegations on
+/// reconnaissance may still delegate the actual build afterwards — with a
+/// full, fresh retry budget.
+///
+/// Why: This is the exact total-loss bug #2852 closes, and the shape of
+/// L4 bake-off run-6: the PM issued 3 legitimate read-only recon
+/// delegations (read PROBLEM.md, list test_suite, read test_basic.py) and
+/// its 4th call — the real build — was refused before the inner runner was
+/// ever invoked, yielding `partial`/exit 6 with 0/9 tests and 0/5
+/// deliverables. Runs 3/4/5 succeeded only by luck of issuing one fewer
+/// recon call. Recon-then-build is the NORMAL PM shape, so under the old
+/// run-wide counter any PM reading more than two files before building was
+/// killed by the harness. Against the pre-fix code this test fails on the
+/// 4th `run` call.
+/// What: Script [Ok, Ok, Ok] for three recon delegations, then
+/// [Err(retryable llm), Ok] for the build. Assert every recon call
+/// succeeds, the build ALSO runs (not refused) and succeeds on its own
+/// retry — proving both that a successful delegation consumes no later
+/// budget and that the build's budget was reset, not merely off-by-one.
+/// Test: this test.
+#[tokio::test]
+async fn successful_delegations_never_consume_a_later_delegations_budget() {
+    let inner = Arc::new(ScriptedInner::new(vec![
+        Ok(AgentOutput::from_content("PROBLEM.md contents")),
+        Ok(AgentOutput::from_content("test_suite listing")),
+        Ok(AgentOutput::from_content("test_basic.py contents")),
+        // The build: fails once transiently, then succeeds.
+        Err(llm_error()),
+        Ok(AgentOutput::from_content("build complete")),
+    ]));
+    let signal = RedelegationCapSignal::new();
+    let runner = RedelegatingRunner::new(
+        Arc::clone(&inner) as Arc<dyn AgentRunner>,
+        signal.clone(),
+        PathBuf::from("/tmp/project"),
+    );
+
+    for recon in ["read PROBLEM.md", "list test_suite", "read test_basic.py"] {
+        let out = runner
+            .run("python-engineer", recon)
+            .await
+            .unwrap_or_else(|e| panic!("recon delegation {recon:?} must succeed, got: {e}"));
+        assert!(!out.content.is_empty());
+    }
+
+    let out = runner
+        .run("python-engineer", "implement the solution")
+        .await
+        .expect(
+            "the BUILD delegation must run — under the pre-#2852 run-wide counter it \
+                 was refused as attempt 4 without ever invoking the engineer",
+        );
+    assert_eq!(out.content, "build complete");
+
+    assert!(
+        !signal.is_cap_reached(),
+        "no run-wide ceiling was approached, so the PM loop must not be stopped"
+    );
+    assert!(
+        !signal.is_retry_budget_exhausted(),
+        "no single delegation burned its retry budget"
+    );
+    assert_eq!(
+        inner.calls.lock().expect("calls lock").len(),
+        5,
+        "3 recon invocations + 2 build invocations must all have reached the engineer"
+    );
+}
+
+/// Once ONE delegation's attempts exceed `MAX_REDELEGATIONS`, the runner
+/// stops calling the inner runner and returns a clean error naming the
+/// attempt count — but does NOT latch the loop-stopping `cap_reached`.
+///
+/// Why: This is the cap's real purpose (fix #1) — a genuinely failing
+/// engineer must stay bounded — held together with #2852's constraint that
+/// bounding it must not be fatal to the RUN. The PM loop's stop signal is
+/// unrecoverable by construction, so it may only fire on a condition a
+/// fresh delegation cannot clear; retry exhaustion is not one.
+/// `retry_budget_exhausted` latches instead, which labels the report
+/// without killing the loop.
+/// What: Script `MAX_REDELEGATIONS` failing `Llm` outcomes (all
+/// retryable); assert the error names the cap and count, the inner runner
+/// ran exactly `MAX_REDELEGATIONS` times (the check happens BEFORE the
+/// attempt that would exceed), `is_retry_budget_exhausted()` is set, and
+/// `is_cap_reached()` is NOT.
+/// Test: this test.
+#[tokio::test]
+async fn redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal() {
+    let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
+    let inner = Arc::new(ScriptedInner::new(outcomes));
+    let signal = RedelegationCapSignal::new();
+    let runner = RedelegatingRunner::new(
+        Arc::clone(&inner) as Arc<dyn AgentRunner>,
+        signal.clone(),
+        PathBuf::from("/tmp/project"),
+    );
+
+    let err = runner
+        .run("python-engineer", "build the package")
+        .await
+        .expect_err("must fail once this delegation's retries are exhausted");
+
+    assert!(
+        err.to_string().contains("re-delegation limit reached"),
+        "error must name the cap condition, got: {err}"
+    );
+    assert!(
+        err.to_string().contains(&MAX_REDELEGATIONS.to_string()),
+        "error must name the attempt count, got: {err}"
+    );
+
+    let calls = inner.calls.lock().expect("calls lock");
+    assert_eq!(
+        calls.len(),
+        MAX_REDELEGATIONS as usize,
+        "the inner runner must be called exactly MAX_REDELEGATIONS times, not more"
+    );
+    assert!(
+        signal.is_retry_budget_exhausted(),
+        "signal must latch retry-budget-exhausted so the report can label it"
+    );
+    assert!(
+        !signal.is_cap_reached(),
+        "retry exhaustion is RECOVERABLE (#2852) — it must not stop the PM loop, \
+             which would kill a run whose next delegation could well succeed"
+    );
+    assert_eq!(
+        signal.attempts(),
+        MAX_REDELEGATIONS,
+        "only real invocations count; the refused 4th never reached the engineer"
+    );
+}
+
+/// Reaching the run-wide `MAX_FAILED_INVOCATIONS` ceiling latches
+/// `cap_reached`, which is what stops the PM loop.
+///
+/// Why: With `MAX_REDELEGATIONS` scoped per-delegation (#2852), this is the
+/// backstop that keeps a pathological run — delegations that keep failing —
+/// from re-delegating once per PM turn forever. Unlike per-call exhaustion,
+/// this one IS terminal, so it is correct for it to fire the stop signal.
+/// What: Fail every invocation retryably and delegate repeatedly. Assert
+/// the ceiling latches `cap_reached`, the engineer failed exactly
+/// `MAX_FAILED_INVOCATIONS` times (never more), and the final error names
+/// the ceiling with the TRUE failure count — the operator-visible number
+/// must be the count of invocations that really failed, not a
+/// pre-incremented dispatch counter reading one higher (#2852).
+/// Test: this test.
+#[tokio::test]
+async fn failure_ceiling_latches_cap_reached() {
+    // Generously more failures than the ceiling allows to be consumed.
+    let outcomes = (0..MAX_FAILED_INVOCATIONS * 2)
+        .map(|_| Err(llm_error()))
+        .collect();
+    let inner = Arc::new(ScriptedInner::new(outcomes));
+    let signal = RedelegationCapSignal::new();
+    let runner = RedelegatingRunner::new(
+        Arc::clone(&inner) as Arc<dyn AgentRunner>,
+        signal.clone(),
+        PathBuf::from("/tmp/project"),
+    );
+
+    // Each call burns MAX_REDELEGATIONS failures, so the ceiling is
+    // reached after MAX_FAILED_INVOCATIONS / MAX_REDELEGATIONS calls.
+    let mut last_err = None;
+    for _ in 0..(MAX_FAILED_INVOCATIONS / MAX_REDELEGATIONS) + 1 {
+        last_err = runner
+            .run("python-engineer", "build the package")
+            .await
+            .err();
+    }
+
+    let err = last_err.expect("every delegation fails, so the last must error");
+    assert!(
+        signal.is_cap_reached(),
+        "the run-wide failure ceiling must latch cap_reached to stop the PM loop"
+    );
+    assert!(
+        err.to_string().contains("engineer failure ceiling reached"),
+        "the terminal error must name the run-wide ceiling, got: {err}"
+    );
+    assert_eq!(
+        signal.failed_invocations(),
+        MAX_FAILED_INVOCATIONS,
+        "the ceiling latches ON the failure that reaches it — the count an operator \
+             is shown must be the real number of failed invocations"
+    );
+    assert!(
+        err.to_string()
+            .contains(&format!("{MAX_FAILED_INVOCATIONS} failed invocations")),
+        "the terminal error must quote the TRUE failure count (never ceiling+1), \
+             got: {err}"
+    );
+    assert_eq!(
+        inner.calls.lock().expect("calls lock").len(),
+        MAX_FAILED_INVOCATIONS as usize,
+        "the engineer must never be invoked beyond the run-wide failure ceiling"
+    );
+
+    // A delegation issued AFTER the ceiling latched must be refused up
+    // front: the PM loop is already stopping, so dispatching more engineer
+    // work would be waste that also inflates the reported failure count.
+    let before = inner.calls.lock().expect("calls lock").len();
+    let err = runner
+        .run("python-engineer", "build the package")
+        .await
+        .expect_err("delegations after the ceiling latches must be refused");
+    assert!(
+        err.to_string().contains("engineer failure ceiling reached"),
+        "the post-latch refusal must still name the ceiling, got: {err}"
+    );
+    assert_eq!(
+        inner.calls.lock().expect("calls lock").len(),
+        before,
+        "a post-latch delegation must not reach the engineer at all"
+    );
+    assert_eq!(
+        signal.failed_invocations(),
+        MAX_FAILED_INVOCATIONS,
+        "a refused delegation dispatches nothing, so it must not record a failure"
+    );
+}
+
+/// No number of SUCCESSFUL delegations may ever latch the terminal ceiling
+/// (#2852).
+///
+/// Why: This is the regression guard for the fix's own central thesis,
+/// applied at the run-wide level. A ceiling that counted every invocation —
+/// successes included — reproduced the exact bug #2852 exists to remove,
+/// one level up: a PM doing legitimate deep reconnaissance (one delegation
+/// per atomic recon step, all succeeding) would still be guillotined into a
+/// terminal, zero-deliverable run, just needing more steps to trigger it.
+/// `tcode` is an interactive daily driver, so recon-heavy shapes are normal
+/// and must never be fatal.
+/// What: Issue far more successful delegations than `MAX_FAILED_INVOCATIONS`
+/// allows failures; assert every one succeeds, `cap_reached` never latches,
+/// no failure is ever recorded, and `attempts()` still counts them all
+/// truthfully as a cost measure that governs nothing.
+/// Test: this test.
+#[tokio::test]
+async fn many_successful_delegations_never_latch_the_failure_ceiling() {
+    let calls = MAX_FAILED_INVOCATIONS * 3;
+    let outcomes = (0..calls)
+        .map(|_| Ok(AgentOutput::from_content("recon done")))
+        .collect();
+    let inner = Arc::new(ScriptedInner::new(outcomes));
+    let signal = RedelegationCapSignal::new();
+    let runner = RedelegatingRunner::new(
+        Arc::clone(&inner) as Arc<dyn AgentRunner>,
+        signal.clone(),
+        PathBuf::from("/tmp/project"),
+    );
+
+    for i in 0..calls {
+        runner
+            .run("research", "inspect one more module")
+            .await
+            .unwrap_or_else(|e| {
+                panic!(
+                    "successful recon delegation {i} must never be \
+                     refused — successes do not consume the failure ceiling: {e}"
+                )
+            });
+        assert!(
+            !signal.is_cap_reached(),
+            "cap_reached latched after {} successful delegations — a run of successes \
+                 must never be terminal (#2852)",
+            i + 1
+        );
+    }
+
+    assert_eq!(
+        signal.failed_invocations(),
+        0,
+        "no invocation failed, so the failure ceiling's input must stay at zero"
+    );
+    assert!(
+        !signal.is_retry_budget_exhausted(),
+        "no delegation burned its retry budget"
+    );
+    assert_eq!(
+        signal.attempts(),
+        calls,
+        "attempts() must still count every invocation truthfully — it is a reporting \
+             cost measure, it simply governs nothing"
+    );
+}
+
+/// A non-retryable failure (no partial work to reuse) propagates
+/// immediately, without consuming further cap budget on retries that
+/// would never help.
+///
+/// Why: Guards the negative case — the retry loop must not blindly retry
+/// EVERY failure, only ones `redelegation_hint` says are worth reusing.
+/// What: Script a single `UnknownAgent` error; assert it propagates
+/// verbatim after exactly one attempt, and the cap is NOT marked reached.
+/// Test: this test.
+#[tokio::test]
+async fn redelegating_runner_propagates_non_retryable_errors_immediately() {
+    let inner = Arc::new(ScriptedInner::new(vec![Err(unknown_agent_error())]));
+    let signal = RedelegationCapSignal::new();
+    let runner = RedelegatingRunner::new(
+        Arc::clone(&inner) as Arc<dyn AgentRunner>,
+        signal.clone(),
+        PathBuf::from("/tmp/project"),
+    );
+
+    let err = runner
+        .run("python-engineer", "build the package")
+        .await
+        .expect_err("unknown-agent failures must propagate");
+
+    assert!(err.to_string().contains("unknown agent"));
+    let calls = inner.calls.lock().expect("calls lock");
+    assert_eq!(calls.len(), 1, "must not retry a non-retryable failure");
+    assert!(
+        !signal.is_cap_reached(),
+        "cap must not be marked reached for a non-retryable failure"
+    );
+}
+
+/// Exhausting a delegation's retry budget emits a WARN-level log naming
+/// the attempt count.
+///
+/// Why: #2852's observability half. The cap was completely silent — no log
+/// line anywhere — so the only evidence a run had been guillotined was a
+/// label buried in the report's `task` field, which took a cross-run
+/// forensic comparison to interpret. An operator must be able to see this
+/// in stderr.
+/// What: Force per-call retry exhaustion under a capturing subscriber;
+/// assert a WARN event was emitted naming the attempt count. (Logs go to
+/// stderr via the crate's subscriber, never stdout — the tracing default.)
+///
+/// `rebuild_interest_cache` is load-bearing, not defensive: `tracing`
+/// caches per-callsite interest GLOBALLY, and this binary's
+/// `logging::tests::init_tracing_for_test_is_idempotent` installs a
+/// process-global `EnvFilter` subscriber that (with `RUST_LOG` unset)
+/// rejects this crate's WARN events. Whichever runs first wins the cache,
+/// so without an explicit rebuild against THIS thread's subscriber the
+/// assertion is order-dependent — it flaked 1-in-N during development.
+/// Since interest is re-evaluated per callsite on the next event, the
+/// rebuild deterministically re-admits the callsite for this scoped
+/// subscriber.
+/// Test: this test.
+#[tokio::test]
+async fn cap_exhaustion_is_logged_at_warn_level() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let logs = CapturedLogs::default();
+    let subscriber = tracing_subscriber::registry().with(CaptureLayer(logs.clone()));
+    let _guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+
+    let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
+    let runner = RedelegatingRunner::new(
+        Arc::new(ScriptedInner::new(outcomes)) as Arc<dyn AgentRunner>,
+        RedelegationCapSignal::new(),
+        PathBuf::from("/tmp/project"),
+    );
+    let _ = runner.run("python-engineer", "build the package").await;
+
+    let captured = logs.0.lock().expect("captured logs lock");
+    let warned = captured.iter().any(|(level, msg)| {
+        *level == tracing::Level::WARN && msg.contains("retry budget exhausted")
+    });
+    assert!(
+        warned,
+        "exhausting the retry budget must WARN — it was completely silent before \
+             #2852, making total-loss runs undiagnosable. Captured: {captured:?}"
+    );
+}
+
+/// Reaching the run-wide failure ceiling emits a WARN-level log naming the
+/// true failure count.
+///
+/// Why: The counterpart to `cap_exhaustion_is_logged_at_warn_level`, and
+/// the more consequential of the two lines: this one is TERMINAL — it is
+/// the moment the PM loop is stopped and the run ends, so it is the single
+/// log an operator most needs in stderr. Its count must also match what the
+/// report tells them (#2852's accurate-diagnosis goal); a log and a report
+/// disagreeing by one is exactly the confusion this fix removes.
+/// What: Drive the ceiling under a capturing subscriber; assert a WARN
+/// event names the ceiling and quotes `MAX_FAILED_INVOCATIONS` failures.
+/// See `cap_exhaustion_is_logged_at_warn_level` for why
+/// `rebuild_interest_cache` is load-bearing rather than defensive.
+/// Test: this test.
+#[tokio::test]
+async fn failure_ceiling_is_logged_at_warn_level() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let logs = CapturedLogs::default();
+    let subscriber = tracing_subscriber::registry().with(CaptureLayer(logs.clone()));
+    let _guard = tracing::subscriber::set_default(subscriber);
+    tracing::callsite::rebuild_interest_cache();
+
+    let outcomes = (0..MAX_FAILED_INVOCATIONS * 2)
+        .map(|_| Err(llm_error()))
+        .collect();
+    let signal = RedelegationCapSignal::new();
+    let runner = RedelegatingRunner::new(
+        Arc::new(ScriptedInner::new(outcomes)) as Arc<dyn AgentRunner>,
+        signal.clone(),
+        PathBuf::from("/tmp/project"),
+    );
+    for _ in 0..(MAX_FAILED_INVOCATIONS / MAX_REDELEGATIONS) + 1 {
+        let _ = runner.run("python-engineer", "build the package").await;
+    }
+
+    assert!(signal.is_cap_reached(), "precondition: ceiling must latch");
+    let captured = logs.0.lock().expect("captured logs lock");
+    let warned = captured.iter().any(|(level, msg)| {
+        *level == tracing::Level::WARN && msg.contains("failure ceiling reached")
+    });
+    assert!(
+        warned,
+        "reaching the terminal ceiling must WARN — it ends the run, so silence here \
+             makes a total-loss run undiagnosable. Captured: {captured:?}"
+    );
+}
+
+/// The cap-reached error message names the exact project path passed to
+/// the constructor.
+///
+/// Why: The required message shape is "re-delegation limit reached after
+/// N attempts; partial work preserved at <path>" — pin the `<path>` half.
+/// What: Force the cap with `MAX_REDELEGATIONS` failures against a
+/// distinctive project path; assert it appears in the error text.
+/// Test: this test.
+#[tokio::test]
+async fn cap_reached_message_names_the_project_path() {
+    let outcomes = (0..MAX_REDELEGATIONS).map(|_| Err(llm_error())).collect();
+    let inner = Arc::new(ScriptedInner::new(outcomes));
+    let signal = RedelegationCapSignal::new();
+    let runner = RedelegatingRunner::new(
+        Arc::clone(&inner) as Arc<dyn AgentRunner>,
+        signal,
+        PathBuf::from("/very/distinctive/project/path"),
+    );
+
+    let err = runner
+        .run("python-engineer", "build the package")
+        .await
+        .expect_err("must fail once the cap is exceeded");
+
+    assert!(
+        err.to_string().contains("/very/distinctive/project/path"),
+        "error must name the project path, got: {err}"
+    );
+}

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -1181,105 +1181,96 @@ async fn gratuitous_redelegation_after_finish_is_refused_and_run_succeeds() {
     );
 }
 
-// ── #2265 fix #5: PM stops re-delegating once the cap latches ──────────────────
+// ── #2265 fix #5 / #2852: PM stops re-delegating once the run-wide ceiling ─────
+// ── latches (a single delegation's retry exhaustion must NOT stop it) ──────────
 
-/// An `LlmClientTrait` that forces a retryable `LlmError` at specific GLOBAL
-/// call indices (shared across the PM's and the engineer's chat calls) and
-/// otherwise forwards to an inner `ScriptedLlm`, whose own fixture cursor
-/// only advances on forwarded (non-forced-error) calls.
+/// Answers every PM turn with a `delegate_to_agent` call; lets the engineer's
+/// very first call write the deliverable, then fails every engineer call after
+/// it with a retryable transport error.
 ///
-/// Why: `repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap` proves
-/// the cap latches within one `delegate_to_agent` dispatch, but its mock
-/// exhausts entirely at that point — a bare-exhaustion error also aborts the
-/// PM's OWN next `chat` call, so that test cannot distinguish "the PM's loop
-/// stopped itself before calling chat again" (this fix) from "the PM's chat
-/// call happened and failed anyway" (the pre-fix behaviour would produce the
-/// same shape of error there). This wrapper keeps VALID `delegate_to_agent`
-/// fixtures queued up behind the forced-error window, standing in for a real
-/// model that keeps deciding to re-delegate because it does not understand
-/// the cap-reached tool error — the exact bake-off L1 failure mode. If the
-/// PM's loop does NOT stop itself, those fixtures get consumed and recorded;
-/// if it does, the global call counter never reaches them.
-/// What: `error_at` global call indices return `LlmError::ApiError` (a
-/// retryable `AgentLoopError::Llm` per `redelegation_hint`) without touching
-/// `inner`; every other index forwards to `inner.chat`, so `inner`'s fixture
-/// list is consumed strictly in the order its calls are actually forwarded.
-/// Test: `pm_stops_redelegating_once_cap_latched_ends_partial_promptly`.
-struct FlakyThenRepeatLlm {
-    inner: ScriptedLlm,
-    counter: AtomicUsize,
-    error_at: Vec<usize>,
+/// Why: The #2852 ceiling test needs a PM that keeps delegating while every
+/// engineer invocation ultimately fails — a scenario `FlakyThenRepeatLlm`'s
+/// global call-index scripting cannot express, because the PM's and engineer's
+/// calls interleave unpredictably once retries are in play. Keying off the
+/// request's advertised tool schema (only the PM is offered
+/// `delegate_to_agent`) makes the roles unambiguous and the test fully
+/// deterministic regardless of how many retries occur.
+/// What: Inspects `req.tools` to classify the caller. PM requests get a canned
+/// delegate call. The engineer's first request replays `first` (a `write_file`
+/// that puts a real deliverable on disk); every later engineer request returns
+/// `LlmError::ApiError`, which `redelegation_hint` classifies as retryable.
+/// Test: `run_wide_ceiling_stops_the_pm_loop_and_ends_partial_promptly`.
+struct FirstEngineerCallWritesThenAllFail {
+    first: Arc<ScriptedLlm>,
+    delegate: ChatResponse,
+    pm_calls: AtomicUsize,
+    engineer_calls: AtomicUsize,
 }
 
 #[async_trait]
-impl LlmClientTrait for FlakyThenRepeatLlm {
+impl LlmClientTrait for FirstEngineerCallWritesThenAllFail {
     async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, LlmError> {
-        let idx = self.counter.fetch_add(1, Ordering::SeqCst);
-        if self.error_at.contains(&idx) {
-            return Err(LlmError::ApiError {
-                status: 500,
-                body: "synthetic retryable transport failure".to_string(),
-            });
+        let is_pm = req
+            .tools
+            .as_ref()
+            .is_some_and(|tools| tools.iter().any(|t| t.function.name == "delegate_to_agent"));
+        if is_pm {
+            self.pm_calls.fetch_add(1, Ordering::SeqCst);
+            return Ok(self.delegate.clone());
         }
-        self.inner.chat(req).await
+        if self.engineer_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            return self.first.chat(req).await;
+        }
+        Err(LlmError::ApiError {
+            status: 500,
+            body: "synthetic retryable transport failure".to_string(),
+        })
     }
 }
 
-/// Once the shared re-delegation cap latches, the PM must stop issuing
-/// `delegate_to_agent` calls immediately (bounded total chat calls, well
-/// under the PM's `max_turns` of 8) and the run must still end `Partial`
-/// with the deliverable the engineer already wrote preserved in the diff.
+/// Once the run-wide engineer-invocation ceiling latches, the PM must stop
+/// issuing `delegate_to_agent` calls (bounded well under its `max_turns` of 8)
+/// and the run must still end `Partial` with the deliverable preserved.
 ///
-/// Why: This is the exact #2265 follow-up regression closed by fix #5: before
-/// this fix, `AgentLoop::run_inner` had no way to learn the cap had latched,
-/// so the PM's own LLM — seeing only an opaque tool error, with nothing
-/// telling it re-delegating again is pointless — could keep calling
-/// `delegate_to_agent` every remaining turn, each one an instant, guaranteed
-/// dead end (bake-off L1 evidence: "re-delegation limit reached after 10
+/// Why: This is #2265 fix #5's regression, re-based onto #2852's split. Fix #5
+/// stops the PM burning its remaining `max_turns` on doomed calls once the cap
+/// latches (bake-off L1 evidence: "re-delegation limit reached after 10
 /// attempts … turn cap of 8 exceeded", 3 productive attempts + 7 wasted PM
-/// turns). The exit code must NOT change — `assemble_report` already maps a
-/// cap-latched, deliverable-bearing run to `Partial` regardless of which
-/// `AgentLoopError` variant fired; this test proves the fix trims the wasted
-/// turns without touching that mapping.
-/// What: Script [PM delegate, engineer write_file (the deliverable), then 3
-/// forced retryable `Llm` errors — engineer's own second turn plus its two
-/// internal reuse-hint retries — landing the shared cap at
-/// `MAX_REDELEGATIONS` attempts entirely inside that ONE PM dispatch]. Queue
-/// SIX MORE valid `delegate_to_agent` fixtures behind that window (as if a
-/// real model kept trying) — enough to fill the PM's remaining `max_turns`
-/// budget if the fix did not stop it. Assert: `exit == Partial`, the diff
-/// still names `hello.py`, the PM's own turn count is exactly 1 (it never
-/// reached a second turn), and the total number of chat calls made across
-/// the whole run stayed small (well below the ~12 calls an unfixed run would
-/// need to hit its own `TurnCapExceeded`) — direct proof the trailing
-/// `delegate_response` fixtures were never consumed.
+/// turns). #2852 narrowed WHICH condition may fire that unrecoverable hook to
+/// the one a fresh delegation cannot clear — the run-wide
+/// `MAX_ENGINEER_INVOCATIONS` ceiling — so this test now drives the ceiling
+/// rather than a single delegation's retry exhaustion.
+///
+/// This test previously asserted `pm_turns == 1`: that a PM whose FIRST
+/// delegation exhausted its retries never got a second turn. That assertion
+/// encoded the #2852 bug itself — it is exactly what killed L4 run-6, whose
+/// 4th delegation was the real build. Being allowed a further turn there is
+/// the fix, not a regression, so the scenario is rebuilt around the ceiling
+/// and the bound is now "well under max_turns" rather than "exactly 1".
+/// What: The engineer writes the deliverable on its first turn, then every
+/// engineer call fails retryably forever while the PM keeps delegating. Each
+/// delegation burns `MAX_REDELEGATIONS` invocations, so the ceiling latches on
+/// delegation 5. Assert: `exit == Partial`, the diff still names `hello.py`,
+/// the report names the ceiling, and the PM stopped strictly before its own
+/// 8-turn cap — proof the stop signal, not the turn cap, ended the run.
 /// Test: this test.
 #[tokio::test]
-async fn pm_stops_redelegating_once_cap_latched_ends_partial_promptly() {
+async fn run_wide_ceiling_stops_the_pm_loop_and_ends_partial_promptly() {
     let agents = agents_dir("openai/gpt-4o-mini");
     let project = tempfile::tempdir().expect("project tempdir");
 
-    let inner = ScriptedLlm::from_json(&[
-        delegate_response("do work"),
-        write_file_response("hello.py", "print(1)"),
-        // Trailing fixtures a real, cap-unaware model might trigger by
-        // calling delegate_to_agent again on turns 2..8 — must NEVER be
-        // consumed once the fix is in place.
-        delegate_response("task-2"),
-        delegate_response("task-3"),
-        delegate_response("task-4"),
-        delegate_response("task-5"),
-        delegate_response("task-6"),
-        delegate_response("task-7"),
-    ]);
-    let llm = Arc::new(FlakyThenRepeatLlm {
-        inner,
-        counter: AtomicUsize::new(0),
-        // Global calls: 0=PM delegate, 1=engineer write_file, then 2,3,4 are
-        // the engineer's own failing turn plus its two internal reuse-hint
-        // retries — landing attempt 4 (> MAX_REDELEGATIONS=3) and latching
-        // the cap without a 5th call.
-        error_at: vec![2, 3, 4],
+    // The engineer's FIRST invocation writes the deliverable, then fails; every
+    // later invocation fails outright. Delegating the write via a one-shot
+    // scripted response keeps a real diff on disk to assert Partial against.
+    let first = Arc::new(ScriptedLlm::from_json(&[write_file_response(
+        "hello.py", "print(1)",
+    )]));
+    let llm = Arc::new(FirstEngineerCallWritesThenAllFail {
+        first,
+        delegate: serde_json::from_value(delegate_response("do work"))
+            .expect("valid delegate fixture"),
+        pm_calls: AtomicUsize::new(0),
+        engineer_calls: AtomicUsize::new(0),
     });
 
     let report = execute_run_task(params(&agents, &project, None), llm.clone()).await;
@@ -1287,7 +1278,7 @@ async fn pm_stops_redelegating_once_cap_latched_ends_partial_promptly() {
     assert_eq!(
         report.exit,
         ExitCode::Partial,
-        "the cap latched but the engineer's write_file already produced a \
+        "the ceiling latched but the engineer's write_file already produced a \
          deliverable, so this must be Partial, not RunFailure; got task: {}",
         report.task
     );
@@ -1296,20 +1287,27 @@ async fn pm_stops_redelegating_once_cap_latched_ends_partial_promptly() {
         "the deliverable diff must be preserved, got: {}",
         report.diff
     );
-
-    let pm_turns = report.transcript.iter().filter(|t| t.role == "pm").count();
-    assert_eq!(
-        pm_turns, 1,
-        "the PM must stop after its single delegating turn — it must never \
-         reach a second turn once the cap has latched"
+    assert!(
+        report.task.contains("engineer invocation ceiling reached"),
+        "the report must name the run-wide ceiling (#2852) as the terminal \
+         condition, got: {}",
+        report.task
     );
 
-    let total_calls = llm.counter.load(Ordering::SeqCst);
+    let pm_turns = report.transcript.iter().filter(|t| t.role == "pm").count();
     assert!(
-        total_calls <= 5,
-        "the PM must not have issued any further delegate_to_agent calls \
-         after the cap latched (bounded, not spinning to the ~12 calls an \
-         unfixed 8-turn PM loop would need), got {total_calls} total chat calls"
+        pm_turns < 8,
+        "the stop signal — not the PM's own 8-turn cap — must have ended the \
+         run, got {pm_turns} PM turns"
+    );
+    // Precise invocation bounding is asserted at the unit level in
+    // `redelegation::tests::run_wide_invocation_ceiling_latches_cap_reached`;
+    // here it is enough that the PM stopped delegating rather than spinning
+    // out its whole turn budget on calls the ceiling would only refuse.
+    assert!(
+        llm.pm_calls.load(Ordering::SeqCst) < 8,
+        "the PM must stop delegating once the ceiling latches, got {} PM calls",
+        llm.pm_calls.load(Ordering::SeqCst)
     );
 }
 

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -940,6 +940,91 @@ fn assemble_report_maps_turn_cap_exceeded_with_deliverable_to_partial() {
     );
 }
 
+/// `assemble_report` maps a retry-exhausted run WITH a deliverable to
+/// `Partial`, labelled "re-delegation limit reached" (#2852).
+///
+/// Why: Post-#2852 this is arguably the most common real-world shape: retry
+/// exhaustion is now RECOVERABLE, so the PM keeps its turns and the loop ends
+/// on some other error while `retry_budget_exhausted` stays latched. Reporting
+/// keys off that flag rather than only `cap_reached` precisely so such runs
+/// keep their honest "the engineer was retried to exhaustion" diagnosis instead
+/// of silently degrading to an opaque `run_failure` — the exact regression
+/// #2852 set out to prevent. Nothing pinned this label's text, so it could have
+/// rotted freely; this test is that pin.
+/// What: Calls `assemble_report` directly with a signal that has ONLY
+/// `retry_budget_exhausted` latched (never `cap_reached`), a non-`TurnCap` PM
+/// error, and a before/after pair that differ. Assert `Partial`, and that the
+/// label names the re-delegation limit and the attempt count — NOT the
+/// invocation ceiling, which did not fire.
+/// Test: this test.
+#[test]
+fn assemble_report_maps_retry_exhausted_with_deliverable_to_partial() {
+    let params = RunTaskParams {
+        agent: "pm".into(),
+        task: "write hello.py".into(),
+        project: PathBuf::from("/tmp/does-not-matter"),
+        agents_dir: PathBuf::from("/tmp/does-not-matter-agents"),
+        engineer_model: None,
+        deadline_secs: None,
+    };
+    let transcript: super::SharedTranscript = Arc::new(Mutex::new(Vec::new()));
+
+    let before = super::diff::Snapshot::Files(std::collections::BTreeMap::new());
+    let mut after_map = std::collections::BTreeMap::new();
+    after_map.insert("hello.py".to_string(), "print('hi')".to_string());
+    let after = super::diff::Snapshot::Files(after_map);
+
+    // Deliberately NOT a turn cap: the point is that the retry-exhausted flag
+    // alone carries the label, independent of which loop error surfaced.
+    let pm_result: Result<AgentOutput, AgentLoopError> =
+        Err(AgentLoopError::Llm(LlmError::ApiError {
+            status: 500,
+            body: "upstream exploded".to_string(),
+        }));
+
+    let signal = RedelegationCapSignal::retry_exhausted_for_test();
+    let completion = EngineerCompletionSignal::new();
+    let report = super::assemble_report(
+        &params,
+        &transcript,
+        "openai/gpt-4o-mini",
+        "openai/gpt-4o-mini",
+        super::RunOutcome {
+            before,
+            after,
+            pm_result,
+        },
+        &signal,
+        &completion,
+    );
+
+    assert_eq!(
+        report.exit,
+        ExitCode::Partial,
+        "a retry-exhausted run that still produced a deliverable must map to Partial, \
+         not RunFailure (#2852), got label: {}",
+        report.task
+    );
+    assert!(
+        report.task.contains("re-delegation limit reached"),
+        "the label must name the re-delegation limit so the diagnosis is not lost, \
+         got: {}",
+        report.task
+    );
+    assert!(
+        report
+            .task
+            .contains(&super::redelegation::MAX_REDELEGATIONS.to_string()),
+        "the label must quote the per-delegation attempt count, got: {}",
+        report.task
+    );
+    assert!(
+        !report.task.contains("failure ceiling"),
+        "the run-wide ceiling never fired — the label must not claim it did, got: {}",
+        report.task
+    );
+}
+
 /// The mirror negative case: a `TurnCapExceeded` PM error with an EMPTY diff
 /// (no deliverable at all) stays `RunFailure` — the gate is purely "was work
 /// produced", per fix #4's requirement to not weaken the genuine-failure path.
@@ -1228,7 +1313,7 @@ impl LlmClientTrait for FirstEngineerCallWritesThenAllFail {
     }
 }
 
-/// Once the run-wide engineer-invocation ceiling latches, the PM must stop
+/// Once the run-wide engineer-failure ceiling latches, the PM must stop
 /// issuing `delegate_to_agent` calls (bounded well under its `max_turns` of 8)
 /// and the run must still end `Partial` with the deliverable preserved.
 ///
@@ -1238,19 +1323,28 @@ impl LlmClientTrait for FirstEngineerCallWritesThenAllFail {
 /// attempts … turn cap of 8 exceeded", 3 productive attempts + 7 wasted PM
 /// turns). #2852 narrowed WHICH condition may fire that unrecoverable hook to
 /// the one a fresh delegation cannot clear — the run-wide
-/// `MAX_ENGINEER_INVOCATIONS` ceiling — so this test now drives the ceiling
+/// `MAX_FAILED_INVOCATIONS` ceiling — so this test now drives the ceiling
 /// rather than a single delegation's retry exhaustion.
 ///
 /// This test previously asserted `pm_turns == 1`: that a PM whose FIRST
-/// delegation exhausted its retries never got a second turn. That assertion
-/// encoded the #2852 bug itself — it is exactly what killed L4 run-6, whose
-/// 4th delegation was the real build. Being allowed a further turn there is
-/// the fix, not a regression, so the scenario is rebuilt around the ceiling
-/// and the bound is now "well under max_turns" rather than "exactly 1".
+/// delegation exhausted its retries never got a second turn. That assertion is
+/// dropped as a deliberate POLICY change, and the record is worth stating
+/// precisely: the old scenario (one delegation whose engineer failed its own
+/// retries three times) was the cap's original, still-valid purpose — a
+/// genuinely struggling engineer — NOT run-6's bug, which was several separate
+/// SUCCESSFUL delegations starving a later one. So the old assertion was not
+/// itself defective, and an earlier version of this comment overstated the case
+/// by claiming it "encoded the bug". What actually changed is the policy: under
+/// #2852 that scenario now latches `retry_budget_exhausted` (recoverable), so
+/// the PM does get a second turn — which is the intended behaviour, because a
+/// fresh delegation with a full budget may well succeed. The scenario is
+/// therefore rebuilt around the ceiling, and the bound is now "well under
+/// max_turns" rather than "exactly 1".
 /// What: The engineer writes the deliverable on its first turn, then every
-/// engineer call fails retryably forever while the PM keeps delegating. Each
-/// delegation burns `MAX_REDELEGATIONS` invocations, so the ceiling latches on
-/// delegation 5. Assert: `exit == Partial`, the diff still names `hello.py`,
+/// engineer call fails retryably forever while the PM keeps delegating. That
+/// first success costs no ceiling budget (#2852 — only failures count);
+/// each subsequent delegation burns `MAX_REDELEGATIONS` failures, so the
+/// ceiling latches on delegation 5. Assert: `exit == Partial`, the diff still names `hello.py`,
 /// the report names the ceiling, and the PM stopped strictly before its own
 /// 8-turn cap — proof the stop signal, not the turn cap, ended the run.
 /// Test: this test.
@@ -1288,7 +1382,7 @@ async fn run_wide_ceiling_stops_the_pm_loop_and_ends_partial_promptly() {
         report.diff
     );
     assert!(
-        report.task.contains("engineer invocation ceiling reached"),
+        report.task.contains("engineer failure ceiling reached"),
         "the report must name the run-wide ceiling (#2852) as the terminal \
          condition, got: {}",
         report.task
@@ -1301,7 +1395,7 @@ async fn run_wide_ceiling_stops_the_pm_loop_and_ends_partial_promptly() {
          run, got {pm_turns} PM turns"
     );
     // Precise invocation bounding is asserted at the unit level in
-    // `redelegation::tests::run_wide_invocation_ceiling_latches_cap_reached`;
+    // `redelegation::tests::failure_ceiling_latches_cap_reached`;
     // here it is enough that the PM stopped delegating rather than spinning
     // out its whole turn budget on calls the ceiling would only refuse.
     assert!(


### PR DESCRIPTION
## Problem

`MAX_REDELEGATIONS = 3` (`run_task/redelegation.rs`) is documented as bounding **retries after failure**, but `record_attempt` incremented on **every engineer invocation run-wide** and was never reset per call. A *successful* delegation therefore permanently consumed budget a later one then lacked.

A PM using delegation for legitimate reconnaissance — the normal PM shape — was silently guillotined:
- the 4th call was refused **without the inner runner ever being invoked** (zero engineer turns, no code written);
- the latched signal then fired `run_task/mod.rs`'s `.with_stop_signal(|| stop_signal.is_cap_reached())`, halting the PM loop at the next turn boundary — **unrecoverable by design**, so the PM never got to adapt.

L4 run-6 issued 3 read-only recon delegations (read PROBLEM.md, list test_suite, read test_basic.py) and had its 4th — the actual build — refused: `partial`/exit 6, 0/9 tests, 0/5 deliverables. Runs 3/4/5 succeeded only by luck of issuing one fewer recon call. Measured cost: **2-in-7 total-loss runs caused by the harness, not the model.**

Verified against the code, and confirmed **pre-existing #2265 design — not a #2805 regression**. #2805 fixed the *symptom* (the gratuitous post-completion re-delegate that tripped the cap) while leaving the *cause* intact; it remains correct and is untouched here.

## Fix

The cap now counts **retries**, not delegations — two conflated concerns are separated:

| | Scope | On exhaustion | Stops PM loop? |
|---|---|---|---|
| `MAX_REDELEGATIONS = 3` | one delegation (counter local to `run_with_retries`, reset at loop entry) | latches `retry_budget_exhausted` (labels the report) | **No** — recoverable |
| `MAX_ENGINEER_INVOCATIONS = 12` *(new)* | run-wide | latches `cap_reached` | **Yes** — terminal |

**A successful delegation never consumes budget from a later one.**

**Stop-signal reconciliation.** The hook is unrecoverable by construction (the PM never gets another turn), so it may only fire on a condition no subsequent delegation could clear. `is_cap_reached()` now latches **only** on the run-wide ceiling — exactly such a condition. Per-call retry exhaustion returns a recoverable error instead, so the PM's loop continues (the same precedent as #2683/#2805's post-completion refusal, which already returns `ToolResult::err`). The wiring is unchanged; #2852 is what makes its "guaranteed dead end" premise actually true.

**Why a run-wide ceiling at all:** with the retry budget scoped per-delegation, something must still bound a run where *every* delegation burns a full budget — otherwise a failing PM could re-delegate once per turn forever, the runaway #2265 exists to prevent. 12 = 4× the per-delegation budget: four delegations may fail completely before the run is declared hopeless, unreachable by any legitimate recon-then-build shape (recon succeeds first-try at 1 invocation each; run-6 totalled ~6), while binding inside the PM's 8-turn × 3-attempt worst case of 24.

**No regression in reporting:** `assemble_report` keys off **both** flags, so a genuinely retry-exhausted run still reports `partial`/exit 6 with a deliverable and never downgrades to an opaque `run_failure`. #2805's `EngineerCompletionSignal` success mapping is untouched.

## Observability

The cap was **completely silent** — run-6's stderr had no trace of it; the mechanism was only findable via cross-run forensics on the report's `task` label. Both conditions now `tracing::warn!` (stderr, never stdout) naming the attempt count, and for the ceiling that the PM loop is being stopped.

## Tests

- `successful_delegations_never_consume_a_later_delegations_budget` — **the #2852 regression test**: 3 successful recon delegations, then a build that still runs *and* has a full retry budget. Fails pre-fix on the 4th delegation.
- `redelegating_runner_stops_at_per_call_cap_without_latching_stop_signal` — retries-after-failure stay bounded at `MAX_REDELEGATIONS` (the cap's real purpose), without killing the run.
- `run_wide_invocation_ceiling_latches_cap_reached` — the backstop still terminates a pathological run.
- `cap_exhaustion_is_logged_at_warn_level` — warn-level assertion.
- `run_wide_ceiling_stops_the_pm_loop_and_ends_partial_promptly` — #2265 fix #5, rebuilt around the ceiling. It previously asserted `pm_turns == 1` (a PM whose first delegation exhausted retries never got a second turn) — **that assertion encoded this bug itself**, and is exactly what killed run-6.

## Gate

`build`, `clippy --all-targets -D warnings`, `fmt --check`, `check_line_cap.sh` all clean; `cargo test -p trusty-code` 956 passed.

**On the known #2843 flakes:** `repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap` is directly in this change's blast radius, so ownership was verified rather than assumed — it is **unmodified** and passes. Measured over 15 full-lib runs each: **1/15 on this branch, 1/15 on an unmodified `origin/main` worktree**, with a byte-identical assertion (`tests.rs:855`, `left: Partial / right: RunFailure`). Root cause is shared with `no_changes_yields_no_changes_exit` / `exit_code_reflects_run_failure`: `execute_run_task` spawns `ensure_project_indexed_in_background`, which races the before/after diff snapshots against the live local trusty-search daemon — orthogonal to this change and squarely #2843.

Closes #2852

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools