### PR TITLE
feat(trusty-code): daemon-side directory inspection API (UI Phase-1)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -80,6 +80,45 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   user-level `~/.claude/agents` rather than the process CWD, which would
   silently bind a directory the operator never chose.
 
+- **Daemon-side directory inspection API (`fs.list_dir`) for the UI's project
+  picker (UI Phase-1, screen 7a)** — a new `fs.*` JSON-RPC namespace on `/rpc`,
+  alongside `session.*`/`task.*`. `fs.list_dir(path?, include_hidden?)` returns
+  `{path, display_path, parent, entries[{name, path, is_dir, is_git_repo}]}`.
+  The UI is a thin client — no UI target touches the filesystem directly,
+  **including Tauri** (which could, but must not: that would let the desktop
+  build do something the web build cannot, forking one UI into two behaviours) —
+  so browsing local disk to pick a project has to be a daemon call. One response
+  serves both jobs: `display_path`/`parent` drive the breadcrumb and
+  up-navigation, while `is_git_repo` is simultaneously 7a's `git` badge and the
+  discriminator for the three-state project binding model (projectless → non-git
+  dir → git repo). A non-git directory is a first-class success with
+  `is_git_repo: false`, never an error (#2728). `~` is expanded and paths
+  canonicalized server-side, matching the `expand_tilde` convention already used
+  in `trusty-mpm` and `trusty-agents`; `path` defaults to `~` so the projectless
+  cold start is just `fs.list_dir({})`.
+  - Git-ness handles **both** on-disk shapes: `.git` as a directory, and `.git`
+    as a FILE carrying a `gitdir:` pointer — which is what a linked worktree (and
+    a submodule) has. An `is_dir()`-only check badges every worktree as non-git;
+    that is the bug PR #2839 hit in `build.rs`, and this workspace's own
+    checkouts are linked worktrees. Detection is two `stat`s (plus one small read
+    for the rare `.git`-file) rather than a `git rev-parse` subprocess per entry,
+    because this runs across every row of a directory on an interactive picker's
+    hot path.
+  - Errors are typed and distinguishable rather than stringly, reusing the vision
+    spec's existing §13.2 taxonomy instead of inventing `fs`-specific codes:
+    `-32002 not_found` (no such path), `-32003 invalid_argument` (path is a
+    file), `-32001 permission_denied` (OS refusal), `-32603 internal` (other IO).
+    New `RpcError::not_found`/`permission_denied` constructors back the first
+    two.
+  - **No path guard, deliberately** — no denylist, sandbox root, or permission
+    layer, and no macOS TCC state machine. tcode is a local app: the daemon runs
+    as the user with the user's own entitlements, so a listing discloses nothing
+    `ls` would not. Decisively, the same API already exposes `task.run`, which
+    executes arbitrary code as the user — guarding browse while that sits one
+    method away is ceremony, not security. An OS-level refusal is reported as an
+    ordinary typed error. Recorded as a module doc comment so it is not later
+    "fixed".
+
 - **Build provenance in `--version` and `tcode_report.json`** — `tcode --version`
   now prints the git SHA and commit date alongside the semver
   (`tcode 0.2.0 (b20adfca 2026-07-16)`), and `tcode_report.json` carries a

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -62,6 +62,7 @@ libc = { workspace = true }
 # back to the process CWD instead would silently bind to a directory the
 # operator never chose — the exact implicit-binding bug `ProjectBinding` exists
 # to prevent.
+# fs_browse: `~` expansion + home-collapsed breadcrumbs for the UI's picker
 dirs = { workspace = true }
 
 # verify_gate (#2279): matches a `bash` tool call's command against the

--- a/crates/trusty-code/src/fs_browse/mod.rs
+++ b/crates/trusty-code/src/fs_browse/mod.rs
@@ -44,6 +44,7 @@
 
 pub mod protocol;
 
+use std::io::Read as _;
 use std::path::{Path, PathBuf};
 
 use serde::Serialize;
@@ -197,28 +198,44 @@ fn collapse_home(path: &Path) -> String {
 ///
 /// What: `.git` as a directory → repo. `.git` as a file → repo only if it
 /// actually carries git's documented `gitdir:` pointer, so a coincidental file
-/// named `.git` does not earn a badge. Anything else (including a metadata
-/// error, e.g. a permission refusal on the probe) → `false`.
+/// named `.git` does not earn a badge. The pointer check reads only the first
+/// 64 bytes of the file rather than the whole thing — `gitdir: <path>\n` is
+/// always well under that, and this runs on the picker's hot path across every
+/// entry, so an unbounded `read_to_string` on a `.git` that happens to be a
+/// large coincidental file (not a real pointer) would be an avoidable stall.
+/// Anything else (including a metadata error, e.g. a permission refusal on the
+/// probe) → `false`.
 ///
 /// **Why not shell out to `git rev-parse`** (as `run_task::diff::is_git_repo`
 /// does): that costs one subprocess PER ENTRY, and this runs across every entry
 /// of a directory on an interactive picker's hot path — a 200-entry `~/code` at
 /// ~5ms a spawn is a second of latency for a badge. Two `stat`s and, only for
-/// the rare `.git`-as-file, one small read gets the same answer. `rev-parse`
-/// stays the right tool in `diff.rs`, which asks once per run about one root.
+/// the rare `.git`-as-file, one small bounded read gets the same answer.
+/// `rev-parse` stays the right tool in `diff.rs`, which asks once per run about
+/// one root.
 ///
 /// Note this deliberately answers "is `dir` a repo ROOT", not "is `dir` inside a
 /// work tree" — the picker badges repos, and a plain subdirectory of a repo is
 /// not itself one to bind to.
 /// Test: `tests::git_dir_is_detected`, `tests::linked_worktree_gitfile_is_detected`,
-/// `tests::bogus_dot_git_file_is_not_a_repo`, `tests::non_git_dir_is_reported_as_non_git`.
+/// `tests::bogus_dot_git_file_is_not_a_repo`, `tests::non_git_dir_is_reported_as_non_git`,
+/// `tests::large_dot_git_file_is_not_a_repo`, `tests::gitdir_pointer_at_exactly_the_read_bound`.
 fn is_git_repo(dir: &Path) -> bool {
     let dot_git = dir.join(".git");
     // `metadata` follows symlinks, matching how git itself resolves `.git`.
     match std::fs::metadata(&dot_git) {
         Ok(m) if m.is_dir() => true,
-        Ok(m) if m.is_file() => std::fs::read_to_string(&dot_git)
-            .map(|s| s.trim_start().starts_with("gitdir:"))
+        // Bounded read: `gitdir: <path>` is always well under 64 bytes, and this
+        // runs per-entry on the picker's hot path — never read a coincidental
+        // large file in full just to check its first few bytes.
+        Ok(m) if m.is_file() => std::fs::File::open(&dot_git)
+            .and_then(|mut f| {
+                let mut buf = [0u8; 64];
+                let n = f.read(&mut buf)?;
+                Ok(String::from_utf8_lossy(&buf[..n])
+                    .trim_start()
+                    .starts_with("gitdir:"))
+            })
             .unwrap_or(false),
         _ => false,
     }
@@ -257,7 +274,17 @@ fn classify_io(err: std::io::Error, path: &str) -> ListDirError {
 /// picker's order is stable and does not depend on the OS's readdir order.
 /// An entry whose metadata cannot be read is included with `is_dir: false`
 /// rather than dropped — a listing that silently omits rows is worse than one
-/// that shows an unbadged entry.
+/// that shows an unbadged entry. Likewise, an entry that `read_dir`'s iterator
+/// itself fails to produce (a per-entry OS fault mid-enumeration) is skipped
+/// with a `tracing::warn!` rather than failing the whole listing — the same
+/// best-effort philosophy, just one layer up. This skip path has no dedicated
+/// test: triggering a per-entry `read_dir` iteration error deterministically
+/// requires a TOCTOU race (e.g. another process removing an entry between
+/// `readdir` returning its name and the kernel stat'ing it) that cannot be
+/// reproduced portably in a unit test without faking the OS boundary; the
+/// existing coverage for `list_dir`'s other per-entry fallback (metadata read
+/// failure → `is_dir: false`, see `tests::*` above) exercises the same
+/// best-effort code shape.
 /// Test: `tests::*`.
 pub fn list_dir(path: &str, include_hidden: bool) -> Result<DirListing, ListDirError> {
     let expanded = expand_tilde(path)?;
@@ -273,7 +300,21 @@ pub fn list_dir(path: &str, include_hidden: bool) -> Result<DirListing, ListDirE
 
     let mut entries = Vec::new();
     for entry in read {
-        let entry = entry.map_err(|e| classify_io(e, &resolved_str))?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(e) => {
+                // A per-entry enumeration fault (e.g. a file vanishing mid-scan) is
+                // best-effort: skip that row rather than failing the whole listing,
+                // matching the "an unbadged entry beats a missing one" philosophy
+                // above.
+                tracing::warn!(
+                    dir = %resolved_str,
+                    error = %e,
+                    "skipping unreadable directory entry"
+                );
+                continue;
+            }
+        };
         let name = entry.file_name().to_string_lossy().into_owned();
         if !include_hidden && name.starts_with('.') {
             continue;

--- a/crates/trusty-code/src/fs_browse/mod.rs
+++ b/crates/trusty-code/src/fs_browse/mod.rs
@@ -1,0 +1,310 @@
+//! Daemon-side directory inspection for the UI's project picker (UI Phase-1).
+//!
+//! Why: the UI is a THIN CLIENT — "the UI communicates with the daemon; all UI
+//! services talk to the daemon, the daemon provides all functionality". No UI
+//! target touches the local filesystem directly, **including Tauri** (which
+//! technically could, but must not: doing so would make the Tauri build capable
+//! of something the web build isn't, forking the UI into two behaviours). So
+//! "browse my disk to pick a project" has to be a daemon API, and this module
+//! is it. One call serves both jobs the picker needs: rendering the folder list
+//! (screen 7a — breadcrumb + a `git` badge per entry) AND feeding tcode's
+//! three-state project binding model (projectless → non-git dir → git repo),
+//! because [`DirEntryInfo::is_git_repo`] is exactly the discriminator that model
+//! keys on. A non-git directory is a FIRST-CLASS, supported state here, never an
+//! error — #2728 removed the git-repo short-circuit precisely so tcode indexes
+//! non-git working dirs, and #2747 extended that to temp dirs.
+//!
+//! What: [`list_dir`] resolves a (possibly `~`-relative) path, then returns a
+//! [`DirListing`] — the resolved path, a tilde-collapsed `display_path` for the
+//! breadcrumb, the `parent` for up-navigation, and the sorted `entries`, each
+//! carrying `name`/`path`/`is_dir`/`is_git_repo`. Failures are the typed
+//! [`ListDirError`], distinguishable rather than stringly.
+//!
+//! ## No path guard here, deliberately — do not "fix" this
+//!
+//! There is no denylist, allowlist, sandbox root, or permission layer on the
+//! path argument, and that is a decision, not an oversight. tcode is a LOCAL
+//! app: the daemon runs as the user, with the user's own OS entitlements, so a
+//! directory listing discloses nothing the user could not already get from `ls`
+//! in their own shell. Decisively: the same API already exposes `task.run`,
+//! which executes ARBITRARY CODE as the user. `list_dir` is strictly less
+//! powerful than a capability sitting right beside it — guarding browse while
+//! `task.run` is one method away is ceremony, not security. There is likewise no
+//! macOS TCC permission-state machine: the app inherits whatever entitlements it
+//! is granted, and an OS-level refusal surfaces as an ordinary typed error
+//! ([`ListDirError::PermissionDenied`]) rather than a bespoke permission model.
+//!
+//! Note for anyone reaching for a precedent: trusty-search's
+//! `allow_sensitive_path` (#2747) is NOT one. That guards INDEXING — file
+//! CONTENT leaving the machine for an embedder — which is a categorically
+//! different act from listing path names locally.
+//!
+//! Test: `fs_browse::tests::*` (resolution, git-ness incl. the linked-worktree
+//! `.git`-as-file shape, error distinguishability, 7a response shape).
+
+pub mod protocol;
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+/// A single entry in a [`DirListing`] — one row of screen 7a's picker.
+///
+/// Why: carries exactly the four fields 7a renders and the binding model
+/// consumes: the label (`name`), the value to navigate/bind to (`path`),
+/// whether it can be descended into (`is_dir`), and whether it draws the `git`
+/// badge vs. the `—` placeholder (`is_git_repo`).
+/// What: `path` is absolute and already resolved; `is_git_repo` is always
+/// `false` for a non-directory (a file cannot be a repo).
+/// Test: `tests::lists_entries_with_names_and_paths`,
+/// `tests::non_git_dir_is_reported_as_non_git`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DirEntryInfo {
+    /// The entry's file name — 7a's row label (e.g. `acme-api`).
+    pub name: String,
+    /// Absolute path to the entry; what the client passes back to navigate
+    /// into it or to bind it as the project root.
+    pub path: String,
+    /// Whether the entry is a directory (symlinks are followed).
+    pub is_dir: bool,
+    /// Whether the entry is a git repository — 7a's `git` badge, and the
+    /// non-git → git discriminator of the three-state binding model. See
+    /// [`is_git_repo`] for how this is determined.
+    pub is_git_repo: bool,
+}
+
+/// The result of a successful [`list_dir`] — everything screen 7a needs to
+/// render one view of the picker.
+///
+/// Why: a bare `Vec<DirEntryInfo>` would force the client to re-derive
+/// navigation state it cannot compute without filesystem access it does not
+/// have. The listed directory has to describe itself: where it resolved to
+/// (`path` — `~`/`..` are resolved server-side), how to caption it (`display_path`),
+/// and where "up" goes (`parent`).
+/// What: `path` is the canonical absolute directory; `display_path` is `path`
+/// with the home prefix collapsed back to `~` for the breadcrumb (7a shows
+/// `~/code / acme-api /`, which the client renders by splitting this on `/`);
+/// `parent` is `None` only at the filesystem root, which is precisely when the
+/// client must disable its up-affordance.
+/// Test: `tests::listing_shape_supports_breadcrumb_and_badges`,
+/// `tests::parent_is_none_at_filesystem_root`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DirListing {
+    /// Canonical absolute path of the directory that was listed.
+    pub path: String,
+    /// `path` with the user's home collapsed to `~` — the breadcrumb caption.
+    pub display_path: String,
+    /// Absolute path of the parent, or `None` at the filesystem root.
+    pub parent: Option<String>,
+    /// Entries, directories first, then case-insensitively by name.
+    pub entries: Vec<DirEntryInfo>,
+}
+
+/// Why a [`list_dir`] call failed, in distinguishable variants.
+///
+/// Why: the picker reacts differently per cause — a typo'd path is a
+/// recoverable inline message, a permission refusal is an OS-level prompt, an
+/// unexpected IO fault is a bug report. A stringly error would force the client
+/// to substring-match to tell those apart. Each variant maps to a distinct
+/// JSON-RPC code in `protocol::to_rpc_error`.
+/// What: `NotFound`/`NotADirectory`/`PermissionDenied` are the three
+/// caller-actionable cases; `Io` is the residual OS fault; `NoHome` covers a
+/// `~` path on a system with no resolvable home directory.
+/// Test: `tests::nonexistent_path_is_not_found`,
+/// `tests::file_path_is_not_a_directory`,
+/// `tests::unreadable_dir_is_permission_denied`.
+#[derive(Debug, thiserror::Error)]
+pub enum ListDirError {
+    /// The path does not exist.
+    #[error("path not found: {0}")]
+    NotFound(String),
+    /// The path exists but is a file, not a directory.
+    #[error("not a directory: {0}")]
+    NotADirectory(String),
+    /// The OS refused access. tcode inherits the user's entitlements — this is
+    /// reported, never worked around (see module docs).
+    #[error("permission denied: {0}")]
+    PermissionDenied(String),
+    /// Any other OS-level IO failure.
+    #[error("io error reading {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    /// A `~`-relative path was given but no home directory could be resolved.
+    #[error("cannot expand `~` — no home directory for this user: {0}")]
+    NoHome(String),
+}
+
+/// Expand a leading `~` against the user's home directory.
+///
+/// Why: the picker's breadcrumb speaks in `~/code`, and an operator typing a
+/// path into it expects shell semantics. This mirrors the expansion the rest of
+/// the workspace already does (`trusty-mpm`'s `managed_root::expand_tilde`,
+/// `trusty-agents`' `repl::commands::connect::expand_tilde`) so tcode is
+/// consistent with its siblings rather than inventing a third convention.
+/// What: `~` and `~/...` expand against `dirs::home_dir`; `~user` is NOT
+/// supported (no workspace precedent does it either) and is left verbatim, as
+/// is every non-`~` path. Returns `NoHome` only when expansion was actually
+/// required and home is unresolvable.
+/// Test: `tests::tilde_expands_to_home`, `tests::tilde_bare_expands_to_home`,
+/// `tests::absolute_path_is_left_alone`.
+fn expand_tilde(raw: &str) -> Result<PathBuf, ListDirError> {
+    if raw != "~" && !raw.starts_with("~/") {
+        return Ok(PathBuf::from(raw));
+    }
+    let home = dirs::home_dir().ok_or_else(|| ListDirError::NoHome(raw.to_string()))?;
+    Ok(match raw.strip_prefix("~/") {
+        Some(rest) => home.join(rest),
+        None => home,
+    })
+}
+
+/// Collapse a leading home-directory prefix back to `~` for display.
+///
+/// Why: the inverse of [`expand_tilde`], so the breadcrumb reads `~/code`
+/// rather than `/Users/masa/code` — screen 7a's caption. Purely cosmetic: the
+/// client always navigates with the absolute `path`, never with this string.
+/// What: returns `~` / `~/rest` when `path` is under home, else `path`
+/// unchanged (including when home cannot be resolved at all).
+/// Test: `tests::display_path_collapses_home_to_tilde`.
+fn collapse_home(path: &Path) -> String {
+    let Some(home) = dirs::home_dir() else {
+        return path.display().to_string();
+    };
+    if path == home {
+        return "~".to_string();
+    }
+    match path.strip_prefix(&home) {
+        Ok(rest) => format!("~/{}", rest.display()),
+        Err(_) => path.display().to_string(),
+    }
+}
+
+/// Whether `dir` is a git repository.
+///
+/// Why: this is 7a's `git` badge and the binding model's non-git → git
+/// discriminator, so it has to be right on the shapes this repo actually
+/// contains — and this workspace lives in linked worktrees.
+///
+/// **The subtlety:** in a linked git worktree (and in a submodule), `.git` is a
+/// FILE containing a `gitdir: <path>` pointer, NOT a directory. Testing
+/// `.git.is_dir()` therefore reports every worktree as non-git — exactly the bug
+/// PR #2839 hit in `build.rs`, and the same latent bug still sitting in
+/// `trusty_common::project_discovery::inspect_project_dir`. This function
+/// handles BOTH shapes.
+///
+/// What: `.git` as a directory → repo. `.git` as a file → repo only if it
+/// actually carries git's documented `gitdir:` pointer, so a coincidental file
+/// named `.git` does not earn a badge. Anything else (including a metadata
+/// error, e.g. a permission refusal on the probe) → `false`.
+///
+/// **Why not shell out to `git rev-parse`** (as `run_task::diff::is_git_repo`
+/// does): that costs one subprocess PER ENTRY, and this runs across every entry
+/// of a directory on an interactive picker's hot path — a 200-entry `~/code` at
+/// ~5ms a spawn is a second of latency for a badge. Two `stat`s and, only for
+/// the rare `.git`-as-file, one small read gets the same answer. `rev-parse`
+/// stays the right tool in `diff.rs`, which asks once per run about one root.
+///
+/// Note this deliberately answers "is `dir` a repo ROOT", not "is `dir` inside a
+/// work tree" — the picker badges repos, and a plain subdirectory of a repo is
+/// not itself one to bind to.
+/// Test: `tests::git_dir_is_detected`, `tests::linked_worktree_gitfile_is_detected`,
+/// `tests::bogus_dot_git_file_is_not_a_repo`, `tests::non_git_dir_is_reported_as_non_git`.
+fn is_git_repo(dir: &Path) -> bool {
+    let dot_git = dir.join(".git");
+    // `metadata` follows symlinks, matching how git itself resolves `.git`.
+    match std::fs::metadata(&dot_git) {
+        Ok(m) if m.is_dir() => true,
+        Ok(m) if m.is_file() => std::fs::read_to_string(&dot_git)
+            .map(|s| s.trim_start().starts_with("gitdir:"))
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+
+/// Map an OS IO error onto the typed [`ListDirError`] for `path`.
+///
+/// Why: keeps the `NotFound`/`PermissionDenied`/`Io` triage in one place so
+/// `list_dir`'s two fallible syscalls classify failures identically.
+/// What: matches `ErrorKind::NotFound`/`PermissionDenied`, else `Io`.
+/// Test: exercised via `tests::nonexistent_path_is_not_found` and
+/// `tests::unreadable_dir_is_permission_denied`.
+fn classify_io(err: std::io::Error, path: &str) -> ListDirError {
+    match err.kind() {
+        std::io::ErrorKind::NotFound => ListDirError::NotFound(path.to_string()),
+        std::io::ErrorKind::PermissionDenied => ListDirError::PermissionDenied(path.to_string()),
+        _ => ListDirError::Io {
+            path: path.to_string(),
+            source: err,
+        },
+    }
+}
+
+/// List `path`, returning everything the picker needs to render it.
+///
+/// Why: the single daemon-side primitive behind screen 7a — see module docs for
+/// why this is an API at all rather than UI-local filesystem access, and for why
+/// it carries no path guard.
+/// What: expands `~`, canonicalizes (resolving `..`, symlinks, and relative
+/// segments — so a client can navigate up by passing `parent`, or by passing
+/// `<path>/..`), rejects a non-directory, then reads the entries. `include_hidden`
+/// gates dot-entries: `false` (the picker default) hides them, since 7a lists
+/// project folders and a user's home is otherwise mostly dotfile noise; `true`
+/// is the escape hatch for reaching a genuinely hidden project directory.
+/// Entries are sorted directories-first then case-insensitively by name, so the
+/// picker's order is stable and does not depend on the OS's readdir order.
+/// An entry whose metadata cannot be read is included with `is_dir: false`
+/// rather than dropped — a listing that silently omits rows is worse than one
+/// that shows an unbadged entry.
+/// Test: `tests::*`.
+pub fn list_dir(path: &str, include_hidden: bool) -> Result<DirListing, ListDirError> {
+    let expanded = expand_tilde(path)?;
+    let resolved = std::fs::canonicalize(&expanded)
+        .map_err(|e| classify_io(e, &expanded.display().to_string()))?;
+    let resolved_str = resolved.display().to_string();
+
+    if !resolved.is_dir() {
+        return Err(ListDirError::NotADirectory(resolved_str));
+    }
+
+    let read = std::fs::read_dir(&resolved).map_err(|e| classify_io(e, &resolved_str))?;
+
+    let mut entries = Vec::new();
+    for entry in read {
+        let entry = entry.map_err(|e| classify_io(e, &resolved_str))?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !include_hidden && name.starts_with('.') {
+            continue;
+        }
+        let entry_path = entry.path();
+        // `metadata` (not `file_type`) so a symlink to a directory lists as a
+        // directory — the picker cares about the target, as `cd` would.
+        let is_dir = std::fs::metadata(&entry_path)
+            .map(|m| m.is_dir())
+            .unwrap_or(false);
+        entries.push(DirEntryInfo {
+            name,
+            path: entry_path.display().to_string(),
+            is_dir,
+            is_git_repo: is_dir && is_git_repo(&entry_path),
+        });
+    }
+
+    entries.sort_by(|a, b| {
+        b.is_dir
+            .cmp(&a.is_dir)
+            .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+    });
+
+    Ok(DirListing {
+        display_path: collapse_home(&resolved),
+        parent: resolved.parent().map(|p| p.display().to_string()),
+        path: resolved_str,
+        entries,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-code/src/fs_browse/protocol.rs
+++ b/crates/trusty-code/src/fs_browse/protocol.rs
@@ -1,0 +1,283 @@
+//! `fs.*` JSON-RPC method handlers — the daemon's directory inspection surface.
+//!
+//! Why: screen 7a's folder picker needs to browse the local disk, and the UI is
+//! a thin client that never touches the filesystem itself (see the parent
+//! module's docs for the full rationale, including why no path guard belongs
+//! here). Reaching it over `/rpc` alongside `session.*`/`task.*` — rather than
+//! as a new REST resource — keeps the API exactly what it is today: one
+//! JSON-RPC endpoint, three HTTP routes.
+//! What: [`register`] wires `fs.list_dir` onto a [`Router`]. The handler parses
+//! typed params, forwards to [`super::list_dir`], and maps
+//! [`super::ListDirError`] onto the vision spec's §13.2 domain taxonomy via
+//! [`to_rpc_error`] — reusing the codes already in the table rather than
+//! inventing `fs`-specific ones.
+//! Test: `protocol::tests::*`.
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::jsonrpc::{ConnectionContext, Router, RpcError};
+
+use super::ListDirError;
+
+/// `params` shape for `fs.list_dir`.
+///
+/// Why: both fields are optional so the picker's very first call — the
+/// projectless cold start, where the client has no path to offer — is simply
+/// `fs.list_dir({})`.
+/// What: `path` defaults to `~` (the natural place to start browsing for
+/// projects); `include_hidden` defaults to `false`.
+/// Test: `tests::omitted_path_defaults_to_home`.
+#[derive(Deserialize)]
+struct ListDirParams {
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    include_hidden: Option<bool>,
+}
+
+/// Register every `fs.*` method onto `router`.
+///
+/// Why: mirrors `session::protocol::register` / `task::protocol::register` —
+/// the one place listing this namespace's full surface, so `serve::build_router`
+/// stays a one-line call per group.
+/// What: registers `"fs.list_dir"`. Unlike the `session.*`/`task.*` groups this
+/// takes no shared state: a directory listing is a pure function of the
+/// filesystem at call time, with no registry to close over.
+/// Test: `tests::register_wires_fs_list_dir`.
+pub fn register(router: &mut Router) {
+    router.register("fs.list_dir", list_dir);
+}
+
+/// Map a typed [`ListDirError`] onto the vision spec's §13.2 error taxonomy.
+///
+/// Why: the picker must distinguish causes without substring-matching a
+/// message; every variant gets a distinct code carrying a stable
+/// `data.error_type`. These are the spec's EXISTING codes — a missing path is
+/// the same `not_found` (-32002) an unknown agent is, and an OS refusal is the
+/// same `permission_denied` (-32001) an RBAC refusal is — so no `fs`-specific
+/// code enters the table.
+/// What: `NotFound` → -32002 `not_found`; `PermissionDenied` → -32001
+/// `permission_denied`; `NotADirectory`/`NoHome` → -32003 `invalid_argument`
+/// (the caller named a path that is semantically wrong for this method);
+/// `Io` → -32603 `internal` (an OS fault is not the caller's error).
+/// Test: `tests::nonexistent_path_maps_to_not_found`,
+/// `tests::file_path_maps_to_invalid_argument`,
+/// `tests::errors_are_distinguishable_by_code`.
+fn to_rpc_error(err: ListDirError) -> RpcError {
+    let message = err.to_string();
+    match err {
+        ListDirError::NotFound(_) => RpcError::not_found(message),
+        ListDirError::PermissionDenied(_) => RpcError::permission_denied(message),
+        ListDirError::NotADirectory(_) | ListDirError::NoHome(_) => {
+            RpcError::invalid_argument(message)
+        }
+        ListDirError::Io { .. } => RpcError::internal(message),
+    }
+}
+
+/// `fs.list_dir(path?, include_hidden?) -> DirListing` (UI Phase-1, screen 7a).
+///
+/// Why: the daemon-side folder picker — the only way a thin UI client can browse
+/// the local disk to choose a project root. One call answers both of 7a's
+/// questions: what to draw (breadcrumb + rows + `git` badges) and what each row
+/// would bind to (a git repo, or an equally-supported non-git directory).
+/// What: `path` defaults to `~`; `~` is expanded and the path canonicalized
+/// server-side, so a client navigates up by passing the previous response's
+/// `parent`. Returns [`super::DirListing`] serialized whole — `{path,
+/// display_path, parent, entries[]}`. Error codes per [`to_rpc_error`]. Note a
+/// non-git directory is a normal success with `is_git_repo: false`, NOT an
+/// error (#2728).
+/// Test: `tests::lists_a_directory`, `tests::omitted_path_defaults_to_home`,
+/// `tests::response_shape_supports_7a_rendering`.
+async fn list_dir(params: Value, _ctx: ConnectionContext) -> Result<Value, RpcError> {
+    // `params` is absent for a no-argument call; treat that as `{}` so
+    // `fs.list_dir()` and `fs.list_dir({})` behave identically.
+    let params = if params.is_null() { json!({}) } else { params };
+    let p: ListDirParams = serde_json::from_value(params)
+        .map_err(|e| RpcError::invalid_params(format!("fs.list_dir: {e}")))?;
+
+    let path = p.path.as_deref().unwrap_or("~");
+    let listing = super::list_dir(path, p.include_hidden.unwrap_or(false)).map_err(to_rpc_error)?;
+
+    serde_json::to_value(listing)
+        .map_err(|e| RpcError::internal(format!("fs.list_dir: serializing listing: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    fn test_ctx() -> ConnectionContext {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    /// `fs.list_dir` on a real directory returns its entries.
+    #[tokio::test]
+    async fn lists_a_directory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(tmp.path().join("alpha")).expect("mkdir");
+
+        let result = list_dir(
+            json!({"path": tmp.path().display().to_string()}),
+            test_ctx(),
+        )
+        .await
+        .expect("list_dir must succeed");
+
+        assert_eq!(result["entries"][0]["name"], "alpha");
+        assert_eq!(result["entries"][0]["is_dir"], true);
+    }
+
+    /// An omitted `path` must default to the user's home rather than erroring —
+    /// the projectless cold-start call is `fs.list_dir({})`.
+    #[tokio::test]
+    async fn omitted_path_defaults_to_home() {
+        let Some(home) = dirs::home_dir() else {
+            return; // no home on this box; nothing to assert
+        };
+        let result = list_dir(json!({}), test_ctx())
+            .await
+            .expect("default list_dir must succeed");
+        let expected = std::fs::canonicalize(&home).unwrap_or(home);
+        assert_eq!(result["path"], expected.display().to_string());
+        assert_eq!(result["display_path"], "~");
+    }
+
+    /// Absent `params` (a no-argument call) must behave like `{}`.
+    #[tokio::test]
+    async fn null_params_are_treated_as_empty_object() {
+        if dirs::home_dir().is_none() {
+            return;
+        }
+        let result = list_dir(Value::Null, test_ctx())
+            .await
+            .expect("null params must succeed");
+        assert_eq!(result["display_path"], "~");
+    }
+
+    /// The response must carry everything screen 7a renders: a breadcrumb
+    /// caption, an up-target, and per-row name/path/is_dir/git-badge state.
+    #[tokio::test]
+    async fn response_shape_supports_7a_rendering() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("acme-api");
+        std::fs::create_dir(&repo).expect("mkdir");
+        std::fs::create_dir(repo.join(".git")).expect("mkdir .git");
+        std::fs::create_dir(tmp.path().join("scratch")).expect("mkdir");
+
+        let result = list_dir(
+            json!({"path": tmp.path().display().to_string()}),
+            test_ctx(),
+        )
+        .await
+        .expect("list_dir must succeed");
+
+        // Breadcrumb + up-navigation.
+        assert!(result["display_path"].is_string());
+        assert!(result["parent"].is_string());
+
+        // `acme-api  git` and `scratch  —` — both rows present, badge only on
+        // the repo, and each row carries the path the client binds/navigates to.
+        let entries = result["entries"].as_array().expect("entries array");
+        let acme = entries
+            .iter()
+            .find(|e| e["name"] == "acme-api")
+            .expect("acme-api row");
+        let scratch = entries
+            .iter()
+            .find(|e| e["name"] == "scratch")
+            .expect("scratch row");
+        assert_eq!(acme["is_git_repo"], true);
+        assert_eq!(scratch["is_git_repo"], false);
+        assert!(acme["path"].is_string());
+        assert_eq!(acme["is_dir"], true);
+    }
+
+    /// A nonexistent path must map to `-32002 not_found`.
+    #[tokio::test]
+    async fn nonexistent_path_maps_to_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("no-such-dir");
+
+        let err = list_dir(json!({"path": missing.display().to_string()}), test_ctx())
+            .await
+            .expect_err("must fail");
+        assert_eq!(err.code, -32002);
+        assert_eq!(err.data, Some(json!({"error_type": "not_found"})));
+    }
+
+    /// A path that exists but is a FILE must map to `-32003 invalid_argument`,
+    /// distinct from the not-found code.
+    #[tokio::test]
+    async fn file_path_maps_to_invalid_argument() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("a.txt");
+        std::fs::write(&file, "x").expect("write");
+
+        let err = list_dir(json!({"path": file.display().to_string()}), test_ctx())
+            .await
+            .expect_err("must fail");
+        assert_eq!(err.code, -32003);
+        assert_eq!(err.data, Some(json!({"error_type": "invalid_argument"})));
+    }
+
+    /// The three caller-actionable failures must be tellable apart by code —
+    /// the whole point of the typed error (a client must not substring-match).
+    #[test]
+    fn errors_are_distinguishable_by_code() {
+        let not_found = to_rpc_error(ListDirError::NotFound("/x".into()));
+        let not_dir = to_rpc_error(ListDirError::NotADirectory("/x".into()));
+        let denied = to_rpc_error(ListDirError::PermissionDenied("/x".into()));
+        let io = to_rpc_error(ListDirError::Io {
+            path: "/x".into(),
+            source: std::io::Error::other("boom"),
+        });
+
+        assert_eq!(not_found.code, -32002);
+        assert_eq!(not_dir.code, -32003);
+        assert_eq!(denied.code, -32001);
+        assert_eq!(io.code, -32603);
+
+        let codes = [not_found.code, not_dir.code, denied.code, io.code];
+        let mut unique = codes.to_vec();
+        unique.sort_unstable();
+        unique.dedup();
+        assert_eq!(unique.len(), codes.len(), "every cause needs its own code");
+    }
+
+    /// Malformed params (wrong type) must be rejected as invalid params rather
+    /// than silently defaulting.
+    #[tokio::test]
+    async fn wrong_typed_params_are_rejected() {
+        let err = list_dir(json!({"path": 42}), test_ctx())
+            .await
+            .expect_err("must fail");
+        assert_eq!(err.code, -32602);
+    }
+
+    /// `register` must wire `fs.list_dir` so the router recognises it.
+    #[tokio::test]
+    async fn register_wires_fs_list_dir() {
+        use trusty_common::mcp::Request;
+
+        let mut router = Router::new();
+        register(&mut router);
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let req = Request {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(json!(1)),
+            method: "fs.list_dir".to_string(),
+            params: Some(json!({"path": tmp.path().display().to_string()})),
+        };
+        let resp = router.dispatch(req, &test_ctx()).await;
+        assert!(
+            resp.error.is_none(),
+            "fs.list_dir must be registered, got {:?}",
+            resp.error
+        );
+    }
+}

--- a/crates/trusty-code/src/fs_browse/tests.rs
+++ b/crates/trusty-code/src/fs_browse/tests.rs
@@ -156,6 +156,37 @@ fn bogus_dot_git_file_is_not_a_repo() {
     assert!(!is_git_repo(&dir));
 }
 
+/// A large `.git` FILE that is not a real pointer must not earn a badge, and
+/// the bounded 64-byte read must not choke on (or need to read) the rest of it.
+#[test]
+fn large_dot_git_file_is_not_a_repo() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("not-a-repo");
+    std::fs::create_dir(&dir).expect("mkdir");
+    // Well over the 64-byte read bound, and not a `gitdir:` pointer.
+    std::fs::write(dir.join(".git"), "x".repeat(10_000)).expect("write");
+
+    assert!(!is_git_repo(&dir));
+}
+
+/// A `gitdir:` pointer whose content sits right at (and just past) the 64-byte
+/// read bound is still detected — the bound must not truncate a real pointer.
+#[test]
+fn gitdir_pointer_at_exactly_the_read_bound() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("worktree-at-bound");
+    std::fs::create_dir(&dir).expect("mkdir");
+    // "gitdir: " (8 bytes) + a path long enough to push the whole line past
+    // 64 bytes — the prefix itself must still land within the first 64 bytes.
+    let long_path = format!("/very/long/path/to/main/.git/worktrees/{}", "x".repeat(40));
+    std::fs::write(dir.join(".git"), format!("gitdir: {long_path}\n")).expect("write");
+
+    assert!(
+        is_git_repo(&dir),
+        "a gitdir: pointer must be detected even when the full line exceeds the read bound"
+    );
+}
+
 /// A plain directory with no `.git` is a first-class NON-GIT entry (7a's
 /// `scratch  —` row) — reported, never an error (#2728).
 #[test]

--- a/crates/trusty-code/src/fs_browse/tests.rs
+++ b/crates/trusty-code/src/fs_browse/tests.rs
@@ -1,0 +1,356 @@
+//! Unit tests for `fs_browse` — path resolution, git-ness detection (including
+//! the linked-worktree `.git`-as-file shape), typed-error distinguishability,
+//! and the 7a response shape.
+
+use super::*;
+
+/// A directory's entries are returned with their names and absolute paths.
+#[test]
+fn lists_entries_with_names_and_paths() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir(tmp.path().join("alpha")).expect("mkdir");
+    std::fs::write(tmp.path().join("beta.txt"), "x").expect("write");
+
+    let listing = list_dir(&tmp.path().display().to_string(), false).expect("list must succeed");
+
+    let names: Vec<&str> = listing.entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, vec!["alpha", "beta.txt"], "dirs sort before files");
+    assert!(listing.entries[0].is_dir);
+    assert!(!listing.entries[1].is_dir);
+    assert!(
+        listing.entries[0].path.ends_with("alpha"),
+        "entry path must be absolute: {}",
+        listing.entries[0].path
+    );
+}
+
+/// Entries sort directories-first, then case-insensitively — a stable picker
+/// order that does not inherit the OS's readdir order.
+#[test]
+fn entries_sort_dirs_first_then_case_insensitively() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    for d in ["Zebra", "apple"] {
+        std::fs::create_dir(tmp.path().join(d)).expect("mkdir");
+    }
+    std::fs::write(tmp.path().join("aaa.txt"), "x").expect("write");
+
+    let listing = list_dir(&tmp.path().display().to_string(), false).expect("list must succeed");
+    let names: Vec<&str> = listing.entries.iter().map(|e| e.name.as_str()).collect();
+    assert_eq!(names, vec!["apple", "Zebra", "aaa.txt"]);
+}
+
+/// Hidden entries are omitted by default and included on request.
+#[test]
+fn hidden_entries_are_gated_by_include_hidden() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir(tmp.path().join(".hidden")).expect("mkdir");
+    std::fs::create_dir(tmp.path().join("visible")).expect("mkdir");
+
+    let default = list_dir(&tmp.path().display().to_string(), false).expect("list");
+    assert_eq!(default.entries.len(), 1);
+    assert_eq!(default.entries[0].name, "visible");
+
+    let with_hidden = list_dir(&tmp.path().display().to_string(), true).expect("list");
+    assert_eq!(with_hidden.entries.len(), 2);
+}
+
+// ── git-ness ────────────────────────────────────────────────────────────────
+
+/// A conventional repo — `.git` as a DIRECTORY — earns the badge.
+#[test]
+fn git_dir_is_detected() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path().join("acme-api");
+    std::fs::create_dir(&repo).expect("mkdir");
+    std::fs::create_dir(repo.join(".git")).expect("mkdir .git");
+
+    let listing = list_dir(&tmp.path().display().to_string(), false).expect("list");
+    assert!(listing.entries[0].is_git_repo);
+}
+
+/// REGRESSION (the `.git`-as-file subtlety, cf. PR #2839): in a LINKED WORKTREE
+/// `.git` is a FILE holding a `gitdir:` pointer, not a directory. An
+/// `is_dir()`-based check reports such a worktree as non-git — this repo's own
+/// checkouts are linked worktrees, so that bug would badge them all `—`.
+#[test]
+fn linked_worktree_gitfile_is_detected() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let worktree = tmp.path().join("feature-wt");
+    std::fs::create_dir(&worktree).expect("mkdir");
+    // Exactly what `git worktree add` writes.
+    std::fs::write(
+        worktree.join(".git"),
+        "gitdir: /Users/dev/main/.git/worktrees/feature-wt\n",
+    )
+    .expect("write .git file");
+
+    assert!(
+        is_git_repo(&worktree),
+        "a linked worktree's `.git` FILE must count as a repo"
+    );
+
+    let listing = list_dir(&tmp.path().display().to_string(), false).expect("list");
+    assert!(
+        listing.entries[0].is_git_repo,
+        "the worktree row must carry the git badge"
+    );
+}
+
+/// A real `git worktree add`, if git is available — proves the detector against
+/// git's actual on-disk output rather than only our hand-written fixture.
+#[test]
+fn real_linked_worktree_is_detected() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let main = tmp.path().join("main");
+    std::fs::create_dir(&main).expect("mkdir");
+
+    // `false` on any failure (git absent, sandboxed) so the test skips rather
+    // than failing for reasons unrelated to the detector.
+    let git = |args: &[&str], cwd: &std::path::Path| {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(cwd)
+            .args(args)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+
+    // Skip if git is absent or the repo cannot be initialised in this sandbox.
+    for args in [
+        &["init", "-q"][..],
+        &["config", "user.email", "t@example.com"][..],
+        &["config", "user.name", "t"][..],
+        &["commit", "-q", "--allow-empty", "-m", "init"][..],
+    ] {
+        if !git(args, &main) {
+            return;
+        }
+    }
+    let wt = tmp.path().join("wt");
+    if !git(
+        &["worktree", "add", "-q", &wt.display().to_string(), "-d"],
+        &main,
+    ) {
+        return;
+    }
+
+    assert!(
+        wt.join(".git").is_file(),
+        "precondition: git writes `.git` as a FILE in a linked worktree"
+    );
+    assert!(
+        is_git_repo(&wt),
+        "a real linked worktree must be detected as a repo"
+    );
+}
+
+/// A file named `.git` that is NOT a git pointer must not earn a badge.
+#[test]
+fn bogus_dot_git_file_is_not_a_repo() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = tmp.path().join("not-a-repo");
+    std::fs::create_dir(&dir).expect("mkdir");
+    std::fs::write(dir.join(".git"), "just some notes\n").expect("write");
+
+    assert!(!is_git_repo(&dir));
+}
+
+/// A plain directory with no `.git` is a first-class NON-GIT entry (7a's
+/// `scratch  —` row) — reported, never an error (#2728).
+#[test]
+fn non_git_dir_is_reported_as_non_git() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir(tmp.path().join("scratch")).expect("mkdir");
+
+    let listing = list_dir(&tmp.path().display().to_string(), false).expect("list must succeed");
+    assert_eq!(listing.entries[0].name, "scratch");
+    assert!(!listing.entries[0].is_git_repo);
+}
+
+/// A FILE never claims to be a repo, even next to a `.git` sibling.
+#[test]
+fn file_entries_are_never_git_repos() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(tmp.path().join("readme.md"), "x").expect("write");
+
+    let listing = list_dir(&tmp.path().display().to_string(), false).expect("list");
+    assert!(!listing.entries[0].is_dir);
+    assert!(!listing.entries[0].is_git_repo);
+}
+
+// ── shape / navigation ──────────────────────────────────────────────────────
+
+/// The listing carries the breadcrumb caption, the up-target, and the badge
+/// state 7a renders (`~/code / acme-api /` + `acme-api  git` / `scratch  —`).
+#[test]
+fn listing_shape_supports_breadcrumb_and_badges() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path().join("acme-api");
+    std::fs::create_dir(&repo).expect("mkdir");
+    std::fs::create_dir(repo.join(".git")).expect("mkdir");
+    std::fs::create_dir(tmp.path().join("scratch")).expect("mkdir");
+
+    let listing = list_dir(&tmp.path().display().to_string(), false).expect("list");
+
+    // Breadcrumb: a caption the client splits on `/`.
+    assert!(!listing.display_path.is_empty());
+    assert!(listing.display_path.contains('/'));
+    // Up-navigation: parent is present below the filesystem root.
+    assert!(listing.parent.is_some());
+    // Badges.
+    let by_name = |n: &str| listing.entries.iter().find(|e| e.name == n).expect("row");
+    assert!(by_name("acme-api").is_git_repo);
+    assert!(!by_name("scratch").is_git_repo);
+}
+
+/// `parent` is `None` exactly at the filesystem root — the one case where the
+/// client must disable its up-affordance.
+#[test]
+fn parent_is_none_at_filesystem_root() {
+    let listing = list_dir("/", false).expect("root must list");
+    assert_eq!(listing.path, "/");
+    assert!(listing.parent.is_none());
+}
+
+/// A client navigates up by passing the previous response's `parent` back in.
+#[test]
+fn parent_round_trips_as_a_list_target() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let child = tmp.path().join("child");
+    std::fs::create_dir(&child).expect("mkdir");
+
+    let listing = list_dir(&child.display().to_string(), false).expect("list child");
+    let parent = listing.parent.expect("child has a parent");
+    let up = list_dir(&parent, false).expect("parent must list");
+
+    assert!(up.entries.iter().any(|e| e.name == "child"));
+}
+
+/// `..` segments are resolved server-side, so relative navigation works too.
+#[test]
+fn dotdot_segments_are_resolved() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let child = tmp.path().join("child");
+    std::fs::create_dir(&child).expect("mkdir");
+
+    let listing = list_dir(&format!("{}/..", child.display()), false).expect("list");
+    let expected = std::fs::canonicalize(tmp.path()).expect("canonicalize");
+    assert_eq!(listing.path, expected.display().to_string());
+}
+
+// ── tilde ───────────────────────────────────────────────────────────────────
+
+/// `~/x` expands against the home directory.
+#[test]
+fn tilde_expands_to_home() {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    assert_eq!(expand_tilde("~/code").expect("expand"), home.join("code"));
+}
+
+/// A bare `~` expands to the home directory itself.
+#[test]
+fn tilde_bare_expands_to_home() {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    assert_eq!(expand_tilde("~").expect("expand"), home);
+}
+
+/// Non-tilde paths pass through untouched — including a path merely CONTAINING
+/// a tilde, which must not be mangled.
+#[test]
+fn absolute_path_is_left_alone() {
+    assert_eq!(
+        expand_tilde("/abs/path").expect("expand"),
+        PathBuf::from("/abs/path")
+    );
+    assert_eq!(
+        expand_tilde("/tmp/we~ird").expect("expand"),
+        PathBuf::from("/tmp/we~ird")
+    );
+}
+
+/// `display_path` collapses the home prefix back to `~` for the breadcrumb.
+#[test]
+fn display_path_collapses_home_to_tilde() {
+    let Some(home) = dirs::home_dir() else {
+        return;
+    };
+    assert_eq!(collapse_home(&home), "~");
+    assert_eq!(collapse_home(&home.join("code")), "~/code");
+    assert_eq!(collapse_home(Path::new("/etc")), "/etc");
+}
+
+/// Listing `~` succeeds and captions itself `~`.
+#[test]
+fn tilde_path_lists_home() {
+    if dirs::home_dir().is_none() {
+        return;
+    }
+    let listing = list_dir("~", false).expect("home must list");
+    assert_eq!(listing.display_path, "~");
+}
+
+// ── errors ──────────────────────────────────────────────────────────────────
+
+/// A nonexistent path is `NotFound`, not a generic IO error.
+#[test]
+fn nonexistent_path_is_not_found() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let missing = tmp.path().join("nope");
+
+    let err = list_dir(&missing.display().to_string(), false).expect_err("must fail");
+    assert!(
+        matches!(err, ListDirError::NotFound(_)),
+        "expected NotFound, got {err:?}"
+    );
+}
+
+/// An existing FILE is `NotADirectory` — distinct from `NotFound`, because the
+/// picker's remedy differs (the path is real, just not browsable).
+#[test]
+fn file_path_is_not_a_directory() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let file = tmp.path().join("a.txt");
+    std::fs::write(&file, "x").expect("write");
+
+    let err = list_dir(&file.display().to_string(), false).expect_err("must fail");
+    assert!(
+        matches!(err, ListDirError::NotADirectory(_)),
+        "expected NotADirectory, got {err:?}"
+    );
+}
+
+/// An unreadable directory surfaces as `PermissionDenied` — the OS's refusal is
+/// reported as an ordinary typed error, with no bespoke permission model on top
+/// (see module docs).
+#[cfg(unix)]
+#[test]
+fn unreadable_dir_is_permission_denied() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Running as root defeats mode bits — the OS never refuses, so there is
+    // nothing to assert.
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let locked = tmp.path().join("locked");
+    std::fs::create_dir(&locked).expect("mkdir");
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).expect("chmod 000");
+
+    let result = list_dir(&locked.display().to_string(), false);
+
+    // Restore before asserting so the tempdir can always clean itself up.
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).expect("chmod 755");
+
+    let err = result.expect_err("an unreadable dir must fail");
+    assert!(
+        matches!(err, ListDirError::PermissionDenied(_)),
+        "expected PermissionDenied, got {err:?}"
+    );
+}

--- a/crates/trusty-code/src/jsonrpc/error.rs
+++ b/crates/trusty-code/src/jsonrpc/error.rs
@@ -113,6 +113,30 @@ impl RpcError {
         )
     }
 
+    /// Build a `-32002 not_found` error (vision spec §13.2).
+    ///
+    /// Why: the spec's general "the thing you named does not exist" code,
+    /// distinct from the session-specific `-32007 session_not_found` — used by
+    /// methods whose subject is not a session (e.g. `fs.list_dir` on a path
+    /// that isn't there).
+    /// What: `data.error_type = "not_found"`.
+    /// Test: `rpc_error_not_found_sets_code_and_type`.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::domain(-32002, "not_found", message)
+    }
+
+    /// Build a `-32001 permission_denied` error (vision spec §13.2).
+    ///
+    /// Why: the spec's "caller lacks permission" code. tcode adds no permission
+    /// layer of its own — it runs as the user with the user's entitlements — so
+    /// this reports an OS-level refusal (e.g. an unreadable directory) rather
+    /// than a policy decision tcode made.
+    /// What: `data.error_type = "permission_denied"`.
+    /// Test: `rpc_error_permission_denied_sets_code_and_type`.
+    pub fn permission_denied(message: impl Into<String>) -> Self {
+        Self::domain(-32001, "permission_denied", message)
+    }
+
     /// Build a `-32003 invalid_argument` error (vision spec §13.2).
     ///
     /// Why: the spec's domain-level "malformed request" code, distinct from
@@ -188,6 +212,23 @@ mod tests {
         assert_eq!(e.code, -32007);
         assert!(e.message.contains("s-123"));
         assert_eq!(e.data, Some(json!({"error_type": "session_not_found"})));
+    }
+
+    /// `not_found` must use the spec's `-32002` code and tag `error_type`.
+    #[test]
+    fn rpc_error_not_found_sets_code_and_type() {
+        let e = RpcError::not_found("path not found: /x");
+        assert_eq!(e.code, -32002);
+        assert_eq!(e.data, Some(json!({"error_type": "not_found"})));
+    }
+
+    /// `permission_denied` must use the spec's `-32001` code and tag
+    /// `error_type`.
+    #[test]
+    fn rpc_error_permission_denied_sets_code_and_type() {
+        let e = RpcError::permission_denied("permission denied: /x");
+        assert_eq!(e.code, -32001);
+        assert_eq!(e.data, Some(json!({"error_type": "permission_denied"})));
     }
 
     /// `invalid_argument` must use the spec's `-32003` code and tag

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -380,6 +380,18 @@ pub mod jsonrpc;
 /// `serve::transport::tests::*`, `serve::http::tests::*`.
 pub mod serve;
 
+/// Daemon-side directory inspection for the UI's project picker (UI Phase-1).
+///
+/// Why: the UI is a thin client — no UI target (web OR Tauri) touches the
+/// filesystem directly, so browsing the local disk to pick a project has to be
+/// a daemon API. One call serves both the picker's rendering (screen 7a's
+/// breadcrumb + per-entry `git` badge) and the three-state project binding
+/// model (projectless → non-git dir → git repo).
+/// What: `list_dir`, `DirListing`, `DirEntryInfo`, `ListDirError`, and
+/// `fs_browse::protocol::register` (wires `fs.list_dir` onto a `Router`).
+/// Test: `fs_browse::tests::*`, `fs_browse::protocol::tests::*`.
+pub mod fs_browse;
+
 /// Daemon-owned session model + attach/detach protocol (#2054, Axiom 4).
 ///
 /// Why: "The Daemon OWNS Sessions; CLI Attaches Over the API" — sessions

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -82,8 +82,12 @@ pub const DEFAULT_HTTP_PORT: u16 = 7881;
 /// `agents_dir` from it via `crate::agents::locate_agents_dir` (the same
 /// `.claude/agents` / `.open-mpm/agents` convention `tcode run-task` uses)
 /// and passes both down to spawned executions.
+/// `fs.list_dir` (UI Phase-1) is the one group that needs NO shared state — a
+/// directory listing is a pure function of the filesystem at call time — so it
+/// registers with neither `sessions` nor `project`.
 /// What: builds an empty `Router` + a fresh `SessionRegistry`, calls
-/// `methods::register`, `crate::session::protocol::register`, and
+/// `methods::register`, `crate::session::protocol::register`,
+/// `crate::fs_browse::protocol::register`, and
 /// `crate::task::protocol::register` on them, and returns both.
 ///
 /// `binding` is the daemon's project binding. Its `None` (projectless) state is
@@ -95,13 +99,15 @@ pub const DEFAULT_HTTP_PORT: u16 = 7881;
 /// CWD (which would silently bind a directory nobody chose).
 /// Test: `run_stdio_router_recognises_proof_of_life_methods`,
 /// `build_router_wires_session_methods`, `build_router_wires_task_run`,
-/// `build_router_is_projectless_without_a_project`.
+/// `build_router_is_projectless_without_a_project`,
+/// `build_router_wires_fs_list_dir`.
 pub fn build_router(binding: ProjectBinding) -> (Router, Arc<SessionRegistry>) {
     let sessions = Arc::new(SessionRegistry::new());
     let agents_dir = binding.agents_dir();
     let mut router = Router::new();
     methods::register(&mut router);
     crate::session::protocol::register(&mut router, sessions.clone());
+    crate::fs_browse::protocol::register(&mut router);
     crate::task::protocol::register(&mut router, sessions.clone(), binding, agents_dir);
     (router, sessions)
 }
@@ -213,6 +219,29 @@ mod tests {
             resp.error
         );
         assert_eq!(resp.result.unwrap()["id"], session.id);
+    }
+
+    /// `build_router` must also wire `fs.list_dir` (UI Phase-1), so the UI's
+    /// project picker is reachable over the same `/rpc` endpoint as everything
+    /// else.
+    #[tokio::test]
+    async fn build_router_wires_fs_list_dir() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let (router, _sessions) = build_router(project.path().to_path_buf());
+
+        let req = Request {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(json!(1)),
+            method: "fs.list_dir".to_string(),
+            params: Some(json!({"path": project.path().display().to_string()})),
+        };
+        let resp = router.dispatch(req, &test_ctx()).await;
+        assert!(
+            resp.error.is_none(),
+            "fs.list_dir must be registered, got {:?}",
+            resp.error
+        );
+        assert!(resp.result.expect("result")["entries"].is_array());
     }
 
     /// `DEFAULT_HTTP_PORT` must stay the documented value (7881) so a

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -227,7 +227,9 @@ mod tests {
     #[tokio::test]
     async fn build_router_wires_fs_list_dir() {
         let project = tempfile::tempdir().expect("project tempdir");
-        let (router, _sessions) = build_router(project.path().to_path_buf());
+        let (router, _sessions) = build_router(
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        );
 
         let req = Request {
             jsonrpc: Some("2.0".to_string()),


### PR DESCRIPTION
## Why

tcode's Phase-1 UI is an SPA (web/Tauri) over the daemon, on the binding principle: **the UI communicates with the daemon; all UI services talk to the daemon, the daemon provides all functionality.** The UI is a THIN CLIENT — no local filesystem access in any UI target, **including Tauri**. Tauri technically could read the disk directly, but must not: that would let the desktop build do something the web build cannot, forking one UI into two behaviours. So browsing the filesystem to pick a project has to be a daemon API. This is what makes the same UI work identically under both targets.

## The method

`fs.list_dir` — a new `fs.*` JSON-RPC namespace on `POST /rpc`, alongside `session.*`/`task.*`. No new REST surface: the API stays three HTTP routes.

**Request** — both fields optional, so the projectless cold start (client has no path to offer) is just `fs.list_dir({})`:

```jsonc
{"path": "~/code", "include_hidden": false}   // path defaults to "~"
```

**Response:**

```jsonc
{
  "path": "/Users/masa/code",     // canonical, absolute
  "display_path": "~/code",       // breadcrumb caption; client splits on "/"
  "parent": "/Users/masa",        // up-navigation; null ONLY at filesystem root
  "entries": [
    {"name": "acme-api", "path": "/Users/masa/code/acme-api", "is_dir": true, "is_git_repo": true}
  ]
}
```

### Why this shape

A bare `Vec<entry>` would force the client to re-derive navigation state it cannot compute — it has no filesystem access, by design. So the directory describes itself: where it resolved to, how to caption it, and where "up" goes. `parent` is `null` exactly at the root, which is precisely when the client disables its up-affordance; a client navigates up by passing the previous response's `parent` straight back.

**The leverage the brief asked for:** `is_git_repo` is simultaneously screen 7a's `git` badge AND the discriminator for the three-state project binding model (projectless → non-git dir → git repo). One endpoint, both jobs — the picker and the binding decision read the same field. Consistent with #2728/#2747, a non-git directory is a **first-class success** with `is_git_repo: false`, never an error.

`~` expansion and canonicalization happen server-side (the client can't do either), matching the `expand_tilde` convention already in `trusty-mpm` and `trusty-agents` rather than inventing a third. Entries sort dirs-first then case-insensitively, so picker order doesn't inherit the OS's readdir order.

## Git-ness — and the `.git`-as-file subtlety

**Handled.** In a linked worktree (and a submodule) `.git` is a **FILE** holding a `gitdir:` pointer, not a directory. `is_dir()` on `.git` badges every worktree as non-git — the bug PR #2839 hit in `build.rs`, and this workspace's own checkouts *are* linked worktrees. Both shapes are handled: `.git` as a dir → repo; `.git` as a file → repo only if it actually carries the `gitdir:` pointer (so a coincidental file named `.git` earns nothing).

**Why not `git rev-parse`** (as `run_task::diff::is_git_repo` does): one subprocess *per entry*, on an interactive picker's hot path — a 200-entry `~/code` at ~5ms/spawn is a second of latency for a badge. Two stats plus one small read for the rare `.git`-file gets the same answer. `rev-parse` stays right in `diff.rs`, which asks once per run about one root.

Covered by both a hand-written fixture and a **real `git worktree add`** test (verified genuinely exercised, not silently skipped).

> Sidenote, not touched here: `trusty_common::project_discovery::inspect_project_dir:140` still does `has_git: dir.join(".git").is_dir()` — the same latent bug, in another crate. Out of scope; flagging it.

## Errors — typed, distinguishable, spec-taxonomy

Reuses the vision spec's **existing** §13.2 codes rather than inventing `fs`-specific ones:

| Cause | Code | `error_type` |
|---|---|---|
| No such path | `-32002` | `not_found` |
| Path is a file | `-32003` | `invalid_argument` |
| OS refusal | `-32001` | `permission_denied` |
| Other IO | `-32603` | `internal` |

New `RpcError::not_found` / `::permission_denied` constructors back the first two. A test asserts all four codes are mutually distinct — a client must never substring-match a message.

## No path guard — deliberate, and documented so it isn't "fixed"

No denylist, allowlist, sandbox root, or permission layer; no macOS TCC state machine. Per Bob's direction, and recorded as a module doc comment with the reasoning: tcode is a **local app** whose daemon runs as the user with the user's own entitlements, so a directory listing discloses nothing the user couldn't already get from `ls`. Decisively — **the same API already exposes `task.run`, which executes arbitrary code as the user.** `list_dir` is strictly less powerful than a capability sitting one method away; guarding browse while `task.run` is right there is ceremony, not security. An OS-level refusal surfaces as an ordinary typed error, not a bespoke permission model.

The doc comment also explicitly records that trusty-search's `allow_sensitive_path` (#2747) is **not** a precedent here: that guards INDEXING — content leaving the machine for an embedder — a categorically different act from listing path names locally.

## Verification

Beyond unit tests, driven end-to-end against a live `tcode serve --http` on a demo tree built to mirror screen 7a. It renders 7a exactly:

```
acme-api        git      (.git dir)
data-pipeline   git      (REAL linked worktree — .git is a FILE)
marketing-site  git      (.git dir)
scratch         —        (is_git_repo: false)
```

Error paths hit live too, including a **real macOS TCC refusal** on `/Library/Application Support/com.apple.TCC` surfacing as an ordinary `-32001 permission_denied` — the inherit-entitlements design working exactly as intended, unplanned.

**Gates:** `build` / `test` (986 lib + 3 bin + 23 integration, `--no-fail-fast` exit 0) / `clippy -D warnings` (exit 0) / `fmt --check` (exit 0) / `check_line_cap.sh` (0 violations) — all green. 30 new tests.

**On #2843:** the three known-flaky `run_task` tests surfaced during this work. Ownership checked honestly rather than assumed — I **stashed my changes entirely and ran clean `origin/main` six times**, where the *same three* tests flake with the same signature. Pre-existing, not mine; no `fs_browse` test ever failed across ~15 full-suite runs.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools