### PR TITLE
feat(trusty-code): projectless mode + unified project binding (UI Phase-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10871,6 +10871,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "dirs 5.0.1",
  "futures-util",
  "globset",
  "ignore",

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,7 +8,77 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING — projectless mode + one typed project binding (UI Phase-1).**
+  "Project" was one concept split across two disagreeing API surfaces:
+  `task.run` took a REQUIRED `project: PathBuf` (`task/protocol.rs:48`), while
+  `session.create` took an untyped, free-form `project: Option<String>` LABEL
+  (`session/protocol.rs:157`) that was never validated, never bound, and
+  disconnected from the path `task.run` demanded — a label that could not be
+  indexed and a path that could not be omitted, i.e. two halves of one missing
+  object. Because the path was required, a **projectless** workstream was
+  inexpressible, and the shell's entry screen (spec DOC-39 §4.2/§5.5 screen 7a,
+  "Open a project" — a workstream that exists BEFORE a project is chosen) was
+  literally unimplementable. Both surfaces now converge on one typed
+  `binding::ProjectBinding` with the spec's **three** states:
+
+  | State | Indexing | Git affordances |
+  |---|---|---|
+  | `projectless` — no directory bound (chat/planning) | none | none |
+  | `directory` — bound, non-git (#2728/#2747) | **yes** | none |
+  | `git_repo` — bound git worktree | yes | full |
+
+  **Binding is NOT gated on `.git`.** The design proposal's own text ("binds the
+  moment work touches files in a git repo") is wrong and contradicts shipped
+  behaviour: it would exclude the non-git working dirs (#2728) and OS temp dirs
+  (#2747) we deliberately support. A non-git directory BINDS and INDEXES; the
+  git/non-git split decides only which git affordances are offered, never
+  whether the project binds. Git detection is now a single implementation
+  (`binding::is_git_worktree`), which `run_task::diff` delegates to, so a
+  `git_repo` binding can never disagree with the diff strategy.
+
+  What projectless does with the three things that assumed a project — each a
+  defined behaviour, never a panic: indexing is **skipped**; the project-scoped
+  memory palace is **skipped** (`memory_sink_for` takes `Option<&Path>` and
+  returns `None` — the scratch root is deliberately NOT substituted, which would
+  mint an orphaned palace per run); and the fs/bash tools are rooted at an
+  **ephemeral scratch dir**, discarded when the run ends and logged at `warn` to
+  stderr so a projectless write is observable rather than silent. `CLAUDE.md`,
+  catch-up, skills, and the `settings.json` mode tier already degraded to
+  "absent" and needed no projectless special-casing.
+
+  Breaking-change surface, and why each is safe or deliberate:
+  - **`task.run`'s JSON-RPC params are UNCHANGED** — its `project` was a
+    `register()` argument (daemon-scoped), never a request field, so no
+    JSON-RPC caller breaks. Its response gains a `binding` object.
+  - **Rust API (breaking):** `serve::{build_router, run_stdio, run_http}` and
+    `task::protocol::register` take `ProjectBinding` instead of `PathBuf`;
+    `TaskRunParams.project` → `.binding`; `SessionRegistry::create`'s third
+    param is a `ProjectBinding`; `mode::resolve_mode` takes `Option<&Path>`.
+  - **`session.create` wire (breaking, deliberate):** `project` is now a project
+    PATH, not a decorative label — a string that names no directory returns
+    `-32003 invalid_argument`. Erroring is the point: silently accepting a
+    "project" that binds and indexes nothing is the exact failure this
+    reconciliation ends. Omitting `project` remains valid and means projectless.
+  - `Session` gains a typed `binding`; its `project` field survives as a
+    display label but is now DERIVED from the binding (`ProjectBinding::label`),
+    so the two can never again disagree. `binding` is `#[serde(default)]`, so an
+    older payload without it reads back as projectless.
+
+  Being breaking at the Rust-API and `session.create`-semantics level, the next
+  release must be **0.3.0** (pre-1.0: minor = breaking), not a patch bump.
+  ([#2855](https://github.com/bobmatnyc/trusty-tools/pull/2855), spec DOC-39
+  §4.2/§5.5, ACs 2.1–2.4 / 16.1–16.3)
+
 ### Added
+
+- **`tcode serve --project` is now OPTIONAL** — omit it to serve projectless.
+  Given, it must be an existing directory (validated at the boundary with an
+  actionable hint, rather than failing later as a confusing per-task error); it
+  need NOT be a git repo. A projectless daemon resolves agents from the
+  user-level `~/.claude/agents` rather than the process CWD, which would
+  silently bind a directory the operator never chose.
 
 - **Build provenance in `--version` and `tcode_report.json`** — `tcode --version`
   now prints the git SHA and commit date alongside the semver

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -56,6 +56,14 @@ reqwest = { workspace = true }
 # Bash tool: process-group kill on Unix (setsid / kill syscalls)
 libc = { workspace = true }
 
+# `binding::ProjectBinding::agents_dir`: a projectless daemon has no project
+# root to resolve `.claude/agents` from, so it falls back to the USER-level
+# `~/.claude/agents` (Claude Code's own user-level agents location). Falling
+# back to the process CWD instead would silently bind to a directory the
+# operator never chose — the exact implicit-binding bug `ProjectBinding` exists
+# to prevent.
+dirs = { workspace = true }
+
 # verify_gate (#2279): matches a `bash` tool call's command against the
 # finalized test-invocation patterns (`pytest\s+\S+`, `cargo test`, …).
 # Also powers the `grep` exploration tool's content regex matching (#1027).

--- a/crates/trusty-code/src/binding/mod.rs
+++ b/crates/trusty-code/src/binding/mod.rs
@@ -1,0 +1,317 @@
+//! Project binding — the ONE typed object `task.run` and `session.create`
+//! converge on (spec DOC-39 §4.2/§5.5, ACs 2.1–2.4 and 16.1–16.3).
+//!
+//! Why: "project" was one concept split across two disagreeing API surfaces.
+//! `task.run` took a REQUIRED `project: PathBuf` (`task/protocol.rs:48`), which
+//! made a projectless workstream — Bob-mandated, and the entry state screen 7a
+//! renders — literally impossible to express. `session.create` took an untyped,
+//! free-form `project: Option<String>` label (`session/protocol.rs:157`) that was
+//! never validated, never bound, and disconnected from the path `task.run`
+//! demanded. A label that cannot be indexed and a path that cannot be omitted are
+//! two halves of one missing object. [`ProjectBinding`] is that object.
+//!
+//! What: a three-state enum, matching the spec's §4.2 table exactly:
+//!
+//! | State | Indexing | Git affordances |
+//! |---|---|---|
+//! | [`ProjectBinding::None`] — projectless | none | none |
+//! | [`ProjectBinding::Directory`] — bound, non-git | **yes** | none |
+//! | [`ProjectBinding::GitRepo`] — bound, git worktree | yes | full |
+//!
+//! **Binding is NOT gated on `.git`.** The design proposal this spec corrects
+//! claimed work binds "the moment work touches files in a git repo"; that rule
+//! would exclude the non-git working dirs (#2728) and OS temp dirs (#2747) we
+//! deliberately support and have already shipped. `Directory` is a first-class
+//! BOUND state that indexes — it is emphatically not a synonym for projectless.
+//! The git/non-git split exists only to decide which *git affordances* are
+//! offered, never whether the project binds or indexes.
+//!
+//! Test: `binding::tests::*`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Value, json};
+
+/// A workstream's project binding — zero or one project, in one of three states.
+///
+/// Why: see the module docs — this is the single typed object that replaces
+/// `task.run`'s un-omittable path and `session.create`'s un-indexable label.
+/// What: [`None`](ProjectBinding::None) is projectless (chat/planning; no index,
+/// no diff target, no project-scoped memory palace). The two bound variants both
+/// carry a canonical root and both index; they differ ONLY in whether git
+/// affordances are available.
+/// Test: `binding::tests::*`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum ProjectBinding {
+    /// Projectless — no directory bound. Chat/planning only.
+    #[default]
+    None,
+    /// Bound to a plain directory that is NOT a git worktree (#2728/#2747).
+    /// Indexes; git affordances are hidden, never faked.
+    Directory(PathBuf),
+    /// Bound to a git worktree. Indexes; full git affordances.
+    GitRepo(PathBuf),
+}
+
+/// The wire `state` discriminant for [`ProjectBinding::None`].
+pub const STATE_PROJECTLESS: &str = "projectless";
+/// The wire `state` discriminant for [`ProjectBinding::Directory`].
+pub const STATE_DIRECTORY: &str = "directory";
+/// The wire `state` discriminant for [`ProjectBinding::GitRepo`].
+pub const STATE_GIT_REPO: &str = "git_repo";
+
+/// Why a path could not be resolved into a bound [`ProjectBinding`].
+///
+/// Why: `session.create`'s old free-form label accepted anything — `"my-app"`
+/// bound nothing and indexed nothing, and the caller was never told. Now that the
+/// label IS the binding, a path that cannot bind must say so loudly rather than
+/// degrade into a lie. Callers map this onto `-32003 invalid_argument`.
+/// What: the two ways a supplied path fails to name a bindable project root.
+/// Test: `binding::tests::resolve_rejects_missing_path`,
+/// `binding::tests::resolve_rejects_file_path`.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum BindingError {
+    /// The path does not exist on disk.
+    #[error("project path does not exist: {0}")]
+    NotFound(PathBuf),
+    /// The path exists but is not a directory.
+    #[error("project path is not a directory: {0}")]
+    NotADirectory(PathBuf),
+}
+
+impl ProjectBinding {
+    /// Classify an optional project path into one of the three binding states.
+    ///
+    /// Why: the single entry point every API surface funnels through, so
+    /// `task.run` and `session.create` can never again disagree about what a
+    /// project is or how one is recognised.
+    /// What: `None` ⇒ [`ProjectBinding::None`] (projectless — the supported,
+    /// non-error case). `Some(p)` ⇒ an existing directory classified as
+    /// [`GitRepo`](ProjectBinding::GitRepo) when [`is_git_worktree`] says so,
+    /// else [`Directory`](ProjectBinding::Directory) — a BOUND, indexing state,
+    /// not a fallback to projectless. A `Some(p)` naming a nonexistent path or a
+    /// non-directory is a [`BindingError`], never a silent downgrade to
+    /// projectless: omitting a project is a deliberate choice, whereas naming one
+    /// that cannot bind is a caller mistake, and collapsing the two would hide it.
+    /// The root is canonicalised when the filesystem allows, so two spellings of
+    /// one project (`.`, `/abs/path`, a symlink) yield one binding.
+    /// Test: `binding::tests::resolve_none_is_projectless`,
+    /// `binding::tests::resolve_plain_dir_binds_as_directory`,
+    /// `binding::tests::resolve_git_repo_binds_as_git_repo`,
+    /// `binding::tests::resolve_rejects_missing_path`,
+    /// `binding::tests::resolve_rejects_file_path`.
+    pub fn resolve(path: Option<PathBuf>) -> Result<Self, BindingError> {
+        let Some(path) = path else {
+            return Ok(Self::None);
+        };
+        if !path.exists() {
+            return Err(BindingError::NotFound(path));
+        }
+        if !path.is_dir() {
+            return Err(BindingError::NotADirectory(path));
+        }
+        // Canonicalise best-effort: a failure here (permissions, a race) is not
+        // a reason to reject a directory we already confirmed exists.
+        let root = path.canonicalize().unwrap_or(path);
+        if is_git_worktree(&root) {
+            Ok(Self::GitRepo(root))
+        } else {
+            Ok(Self::Directory(root))
+        }
+    }
+
+    /// The bound project root, or `None` when projectless.
+    ///
+    /// Why: every consumer that needs a real directory (fs tools, `CLAUDE.md`
+    /// loading, indexing) asks here, and the `Option` makes "there may be no
+    /// project" impossible to forget at the type level — which is exactly the
+    /// bug the old required `PathBuf` encoded.
+    /// What: `Some(&Path)` for both bound variants; `None` for projectless.
+    /// Test: `binding::tests::root_is_none_only_when_projectless`.
+    pub fn root(&self) -> Option<&Path> {
+        match self {
+            Self::None => Option::None,
+            Self::Directory(p) | Self::GitRepo(p) => Some(p),
+        }
+    }
+
+    /// Whether a project is bound at all (either bound state).
+    ///
+    /// Why: the index/diff/palace decisions key off "is there a project", NOT
+    /// off "is it git" — conflating those two is precisely the proposal's error.
+    /// What: `false` only for [`ProjectBinding::None`].
+    /// Test: `binding::tests::non_git_dir_is_bound_and_indexes`.
+    pub fn is_bound(&self) -> bool {
+        !matches!(self, Self::None)
+    }
+
+    /// Whether git affordances (branch, PR, dirty-tree) are available.
+    ///
+    /// Why: the ONLY question the git/non-git split is allowed to answer. It
+    /// must never be used to decide whether to bind or index (AC-2.2/AC-2.3).
+    /// What: `true` only for [`ProjectBinding::GitRepo`].
+    /// Test: `binding::tests::non_git_dir_is_bound_and_indexes`,
+    /// `binding::tests::resolve_git_repo_binds_as_git_repo`.
+    pub fn is_git(&self) -> bool {
+        matches!(self, Self::GitRepo(_))
+    }
+
+    /// Whether this binding's project should be indexed (AC-2.3).
+    ///
+    /// Why: names the rule in one place so no call site re-derives it and
+    /// accidentally reintroduces the git-only gate.
+    /// What: identical to [`is_bound`](Self::is_bound) — **both** bound states
+    /// index, git or not. Projectless does not.
+    /// Test: `binding::tests::non_git_dir_is_bound_and_indexes`,
+    /// `binding::tests::projectless_does_not_index`.
+    pub fn should_index(&self) -> bool {
+        self.is_bound()
+    }
+
+    /// The wire `state` discriminant for this binding.
+    ///
+    /// Why: the SPA renders three distinct states (§4.2) and needs to tell them
+    /// apart without inferring from the presence of a path.
+    /// What: one of [`STATE_PROJECTLESS`], [`STATE_DIRECTORY`], [`STATE_GIT_REPO`].
+    /// Test: `binding::tests::wire_shape_round_trips_each_state`.
+    pub fn state(&self) -> &'static str {
+        match self {
+            Self::None => STATE_PROJECTLESS,
+            Self::Directory(_) => STATE_DIRECTORY,
+            Self::GitRepo(_) => STATE_GIT_REPO,
+        }
+    }
+
+    /// A human display label for the bound project, or `None` when projectless.
+    ///
+    /// Why: preserves `Session.project`'s existing `Option<String>` wire field —
+    /// which is now DERIVED from the binding rather than being an independent,
+    /// unvalidated source of truth. That derivation is the whole reconciliation:
+    /// the label still exists for humans, but it can no longer disagree with the
+    /// path, because there is only one path and the label is computed from it.
+    /// What: the root's display string; `None` for projectless.
+    /// Test: `binding::tests::label_is_derived_from_root`.
+    pub fn label(&self) -> Option<String> {
+        self.root().map(|p| p.display().to_string())
+    }
+
+    /// The agents directory this binding resolves `<agent>.toml` from.
+    ///
+    /// Why: a projectless daemon still runs a PM and still needs agent configs;
+    /// with no project root there is no project-scoped `.claude/agents` to read,
+    /// so it must fall back rather than fail. Falling back to the process CWD
+    /// would silently bind to a directory the operator never chose — the exact
+    /// implicit-binding bug this type exists to prevent — so it falls back to the
+    /// USER-level location instead.
+    /// What: bound ⇒ [`crate::agents::locate_agents_dir`] on the project root
+    /// (the `.claude/agents` → `.open-mpm/agents` convention). Projectless ⇒ the
+    /// same convention rooted at `$HOME`, i.e. `~/.claude/agents`, matching
+    /// Claude Code's user-level agents location. With no resolvable home
+    /// directory, degrades to a bare relative `.claude/agents` — which simply
+    /// will not exist, surfacing as a normal "PM config error" rather than a panic.
+    /// Test: `binding::tests::agents_dir_uses_project_root_when_bound`,
+    /// `binding::tests::projectless_agents_dir_is_user_level`.
+    pub fn agents_dir(&self) -> PathBuf {
+        match self.root() {
+            Some(root) => crate::agents::locate_agents_dir(root),
+            Option::None => match dirs::home_dir() {
+                Some(home) => crate::agents::locate_agents_dir(&home),
+                Option::None => PathBuf::from(".claude").join("agents"),
+            },
+        }
+    }
+
+    /// The JSON wire representation: `{ "state": …, "root": … }`.
+    ///
+    /// Why: the SPA needs the state discriminant explicitly rather than
+    /// inferring projectless from a null path (AC-2.1) — an absent `root` and a
+    /// `projectless` state are the same fact today, but only the discriminant
+    /// stays honest if a future state carries no path for a different reason.
+    /// What: `root` is `null` for projectless, the display path otherwise.
+    /// Test: `binding::tests::wire_shape_round_trips_each_state`.
+    pub fn to_json(&self) -> Value {
+        json!({ "state": self.state(), "root": self.label() })
+    }
+}
+
+impl Serialize for ProjectBinding {
+    /// Serialise via [`ProjectBinding::to_json`] so the wire shape is defined
+    /// in exactly one place.
+    ///
+    /// Why: `Session` derives `Serialize`; without this the enum would emit
+    /// serde's default externally-tagged shape and drift from `to_json`.
+    /// What: delegates to [`ProjectBinding::to_json`].
+    /// Test: `binding::tests::serialize_matches_to_json`.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.to_json().serialize(serializer)
+    }
+}
+
+/// The `{ state, root }` wire shape, used only as [`ProjectBinding`]'s
+/// deserialization intermediate.
+#[derive(Deserialize)]
+struct BindingWire {
+    state: String,
+    #[serde(default)]
+    root: Option<PathBuf>,
+}
+
+impl<'de> Deserialize<'de> for ProjectBinding {
+    /// Reconstruct a binding from its wire shape.
+    ///
+    /// Why: `Session` derives `Deserialize`, so its `binding` field needs one.
+    /// What: reconstructs from the EXPLICIT `state` discriminant and does NOT
+    /// re-probe the filesystem — deserializing a value must not depend on
+    /// whether a path still exists or is still a git repo on THIS machine, which
+    /// would make a round-trip lossy (a `GitRepo` read back on a host without
+    /// the repo would silently become a `Directory`). A bound state missing its
+    /// `root`, or an unknown discriminant, is a hard error rather than a silent
+    /// downgrade to projectless.
+    /// Test: `binding::tests::deserialize_round_trips_without_touching_disk`,
+    /// `binding::tests::deserialize_rejects_bound_state_without_root`.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let wire = BindingWire::deserialize(deserializer)?;
+        let root = |w: Option<PathBuf>| {
+            w.ok_or_else(|| {
+                D::Error::custom(format!("binding state `{}` requires a root", wire.state))
+            })
+        };
+        match wire.state.as_str() {
+            STATE_PROJECTLESS => Ok(Self::None),
+            STATE_DIRECTORY => Ok(Self::Directory(root(wire.root.clone())?)),
+            STATE_GIT_REPO => Ok(Self::GitRepo(root(wire.root.clone())?)),
+            other => Err(D::Error::custom(format!(
+                "unknown project binding state `{other}` (expected one of \
+                 `{STATE_PROJECTLESS}`, `{STATE_DIRECTORY}`, `{STATE_GIT_REPO}`)"
+            ))),
+        }
+    }
+}
+
+/// Whether `root` is inside a git worktree.
+///
+/// Why: the ONE git-detection implementation in the crate. `run_task::diff`'s
+/// snapshot logic needs the identical answer this binding classifies on; two
+/// independent probes could disagree and produce a `GitRepo` binding whose diff
+/// silently took the non-git file-map path.
+/// What: shells out to `git -C <root> rev-parse --is-inside-work-tree`. Fail-open
+/// to `false` — no git binary, a non-repo, or any error means "no git
+/// affordances", which is a fully supported bound state (§4.2), never an error.
+/// Test: `binding::tests::resolve_git_repo_binds_as_git_repo`,
+/// `binding::tests::resolve_plain_dir_binds_as_directory`.
+pub fn is_git_worktree(root: &Path) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true")
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/binding/tests.rs
+++ b/crates/trusty-code/src/binding/tests.rs
@@ -1,0 +1,275 @@
+//! Unit tests for [`crate::binding`] — the three binding states (§4.2).
+//!
+//! Why: this module is the correction the spec makes to the design proposal
+//! ("binds the moment work touches files in a git repo"). The non-git case is
+//! therefore not an edge case here — it is the load-bearing assertion, and
+//! `non_git_dir_is_bound_and_indexes` is the test that would fail if anyone
+//! reintroduced the git-only gate.
+//! What: covers `resolve`'s five outcomes, the bound/git/index predicates, the
+//! agents-dir fallback, and the wire shape.
+//! Test: this file.
+
+use super::*;
+use std::process::Command;
+
+/// Initialise a real git repo in `dir` (the classification shells out to git,
+/// so a fake `.git` directory would not be honest here).
+fn init_git_repo(dir: &Path) {
+    let ok = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .arg("init")
+        .output()
+        .expect("git init must run")
+        .status
+        .success();
+    assert!(ok, "git init must succeed");
+}
+
+/// `resolve(None)` is projectless — the supported state, NOT an error (AC-2.1).
+#[test]
+fn resolve_none_is_projectless() {
+    let binding = ProjectBinding::resolve(None).expect("projectless must resolve, never error");
+    assert_eq!(binding, ProjectBinding::None);
+    assert!(!binding.is_bound(), "projectless must not be bound");
+    assert!(!binding.is_git(), "projectless has no git affordances");
+    assert_eq!(binding.root(), None, "projectless has no root");
+}
+
+/// A plain (non-git) directory binds as `Directory` — a BOUND state (AC-2.2).
+#[test]
+fn resolve_plain_dir_binds_as_directory() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let binding =
+        ProjectBinding::resolve(Some(tmp.path().to_path_buf())).expect("a plain dir must bind");
+    assert!(
+        matches!(binding, ProjectBinding::Directory(_)),
+        "a non-git dir must bind as Directory, got {binding:?}"
+    );
+}
+
+/// A git worktree binds as `GitRepo` and reports git affordances.
+#[test]
+fn resolve_git_repo_binds_as_git_repo() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    init_git_repo(tmp.path());
+    let binding =
+        ProjectBinding::resolve(Some(tmp.path().to_path_buf())).expect("a git repo must bind");
+    assert!(
+        matches!(binding, ProjectBinding::GitRepo(_)),
+        "a git worktree must bind as GitRepo, got {binding:?}"
+    );
+    assert!(binding.is_git(), "a git repo must offer git affordances");
+    assert!(binding.is_bound());
+    assert!(binding.should_index());
+}
+
+/// **The correction, asserted.** A non-git directory is BOUND and INDEXES; it is
+/// not projectless and must not be treated as such (AC-2.2/AC-2.3, #2728/#2747).
+/// This is the test that fails if the git-only binding gate is reintroduced.
+#[test]
+fn non_git_dir_is_bound_and_indexes() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let binding = ProjectBinding::resolve(Some(tmp.path().to_path_buf())).expect("must bind");
+
+    assert!(
+        binding.is_bound(),
+        "a non-git dir MUST bind — binding is not gated on .git (#2728/#2747)"
+    );
+    assert!(
+        binding.should_index(),
+        "a non-git dir MUST index — indexing is not gated on .git (AC-2.3)"
+    );
+    assert!(
+        !binding.is_git(),
+        "a non-git dir must NOT claim git affordances — they are hidden, not faked"
+    );
+    assert_ne!(
+        binding,
+        ProjectBinding::None,
+        "a non-git dir is NOT projectless"
+    );
+}
+
+/// Projectless is the ONLY state that does not index (AC-2.1).
+#[test]
+fn projectless_does_not_index() {
+    assert!(
+        !ProjectBinding::None.should_index(),
+        "projectless has no project to index"
+    );
+}
+
+/// A `Some(path)` that does not exist is a caller error, never a silent
+/// downgrade to projectless — omitting a project and naming a bad one are
+/// different facts and must not collapse into one.
+#[test]
+fn resolve_rejects_missing_path() {
+    let missing = PathBuf::from("/definitely/not/a/real/path/xyzzy-42");
+    let err = ProjectBinding::resolve(Some(missing.clone()))
+        .expect_err("a nonexistent path must not resolve");
+    assert_eq!(err, BindingError::NotFound(missing));
+}
+
+/// A `Some(path)` naming a FILE is a caller error (the old untyped label would
+/// have accepted this happily and bound nothing).
+#[test]
+fn resolve_rejects_file_path() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let file = tmp.path().join("not-a-dir.txt");
+    std::fs::write(&file, "x").expect("write");
+    let err = ProjectBinding::resolve(Some(file)).expect_err("a file path must not resolve");
+    assert!(
+        matches!(err, BindingError::NotADirectory(_)),
+        "expected NotADirectory, got {err:?}"
+    );
+}
+
+/// `root()` returns `None` exactly for projectless, and `Some` for both bound
+/// states — the git/non-git split must not affect whether a root exists.
+#[test]
+fn root_is_none_only_when_projectless() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dir = ProjectBinding::Directory(tmp.path().to_path_buf());
+    let git = ProjectBinding::GitRepo(tmp.path().to_path_buf());
+
+    assert_eq!(ProjectBinding::None.root(), None);
+    assert_eq!(dir.root(), Some(tmp.path()));
+    assert_eq!(git.root(), Some(tmp.path()));
+}
+
+/// The `Session.project` label is DERIVED from the binding's root — it can no
+/// longer be an independent value that disagrees with the path.
+#[test]
+fn label_is_derived_from_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let binding = ProjectBinding::Directory(tmp.path().to_path_buf());
+    assert_eq!(binding.label(), Some(tmp.path().display().to_string()));
+    assert_eq!(
+        ProjectBinding::None.label(),
+        None,
+        "projectless must have no label"
+    );
+}
+
+/// A bound binding resolves agents from the PROJECT's `.claude/agents`.
+#[test]
+fn agents_dir_uses_project_root_when_bound() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents).expect("mkdir");
+    let binding = ProjectBinding::Directory(tmp.path().to_path_buf());
+    assert_eq!(binding.agents_dir(), agents);
+}
+
+/// A projectless daemon still needs agent configs; it falls back to the
+/// USER-level `~/.claude/agents` rather than the process CWD, which would
+/// silently bind to a directory the operator never chose.
+#[test]
+fn projectless_agents_dir_is_user_level() {
+    let Some(home) = dirs::home_dir() else {
+        // No home dir on this machine: the documented degraded path.
+        assert_eq!(
+            ProjectBinding::None.agents_dir(),
+            PathBuf::from(".claude").join("agents")
+        );
+        return;
+    };
+    let dir = ProjectBinding::None.agents_dir();
+    assert!(
+        dir.starts_with(&home),
+        "projectless agents_dir must be user-level ({}), got {}",
+        home.display(),
+        dir.display()
+    );
+    assert!(
+        !dir.starts_with(std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/nonexistent"))),
+        "projectless must NOT implicitly bind agents to the process CWD"
+    );
+}
+
+/// The wire shape carries an explicit `state` discriminant for all three states,
+/// so the SPA never has to infer projectless from a null path.
+#[test]
+fn wire_shape_round_trips_each_state() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().display().to_string();
+
+    let none = ProjectBinding::None.to_json();
+    assert_eq!(none["state"], STATE_PROJECTLESS);
+    assert!(none["root"].is_null(), "projectless must have a null root");
+
+    let dir = ProjectBinding::Directory(tmp.path().to_path_buf()).to_json();
+    assert_eq!(dir["state"], STATE_DIRECTORY);
+    assert_eq!(dir["root"], root);
+
+    let git = ProjectBinding::GitRepo(tmp.path().to_path_buf()).to_json();
+    assert_eq!(git["state"], STATE_GIT_REPO);
+    assert_eq!(git["root"], root);
+}
+
+/// `Serialize` must agree with `to_json` — `Session` derives `Serialize`, so a
+/// drift here would silently change the `session.*` wire shape.
+#[test]
+fn serialize_matches_to_json() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let binding = ProjectBinding::GitRepo(tmp.path().to_path_buf());
+    let via_serde = serde_json::to_value(&binding).expect("serialize");
+    assert_eq!(via_serde, binding.to_json());
+}
+
+/// `is_git_worktree` fails open to `false` for a nonexistent path — a missing
+/// directory means "no git affordances", never a panic.
+#[test]
+fn is_git_worktree_fails_open_for_missing_path() {
+    assert!(!is_git_worktree(Path::new("/definitely/not/here/xyzzy-42")));
+}
+
+/// Deserialization must reconstruct from the explicit `state` discriminant and
+/// NOT re-probe the filesystem: a `GitRepo` read back on a host that lacks the
+/// repo must stay a `GitRepo`, or the round-trip is lossy.
+#[test]
+fn deserialize_round_trips_without_touching_disk() {
+    let phantom = PathBuf::from("/definitely/not/here/xyzzy-42");
+    for original in [
+        ProjectBinding::None,
+        ProjectBinding::Directory(phantom.clone()),
+        ProjectBinding::GitRepo(phantom.clone()),
+    ] {
+        let json = serde_json::to_value(&original).expect("serialize");
+        let back: ProjectBinding = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(
+            back, original,
+            "round-trip must preserve the state even for a path that does not exist on this host"
+        );
+    }
+}
+
+/// A bound state without a `root`, or an unknown discriminant, is a hard error
+/// — never a silent downgrade to projectless.
+#[test]
+fn deserialize_rejects_bound_state_without_root() {
+    let err = serde_json::from_value::<ProjectBinding>(serde_json::json!({"state": "git_repo"}))
+        .expect_err("a bound state with no root must not deserialize");
+    assert!(
+        err.to_string().contains("requires a root"),
+        "unexpected error: {err}"
+    );
+
+    let err = serde_json::from_value::<ProjectBinding>(
+        serde_json::json!({"state": "bogus", "root": "/x"}),
+    )
+    .expect_err("an unknown state must not deserialize");
+    assert!(
+        err.to_string().contains("unknown project binding state"),
+        "unexpected error: {err}"
+    );
+}
+
+/// `Default` must be projectless — a `Session` deserialized from an older
+/// payload with no `binding` field reads back as projectless rather than
+/// inventing a binding.
+#[test]
+fn default_is_projectless() {
+    assert_eq!(ProjectBinding::default(), ProjectBinding::None);
+}

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -183,6 +183,7 @@ mod tests {
             task: "do the thing".to_string(),
             agent: Some("pm".to_string()),
             project: None,
+            binding: crate::binding::ProjectBinding::None,
             status,
             created_at: Utc::now(),
             mode: None,

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -230,6 +230,20 @@ pub mod provider;
 /// Test: `project_context::tests::*`.
 pub mod project_context;
 
+/// The typed project binding — projectless / non-git dir / git repo.
+///
+/// Why: "project" was one concept split across two disagreeing API surfaces —
+/// `task.run` demanded a path it could not omit, `session.create` accepted a
+/// label it could not index. Projectless was therefore inexpressible, which made
+/// the shell's entry state (spec DOC-39 screen 7a) unimplementable. This module
+/// is the single object both surfaces now converge on.
+/// What: `ProjectBinding` (`None` | `Directory` | `GitRepo`), `BindingError`,
+/// and `is_git_worktree` — the crate's one git-detection implementation.
+/// Binding is NOT gated on `.git`: a non-git directory is a bound, indexing
+/// state (#2728/#2747).
+/// Test: `binding::tests::*`.
+pub mod binding;
+
 // ── Phase 4 orchestration layer (per #1028) ──
 
 /// Multi-turn agent loop driving an LLM through tool calls to completion.

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -70,8 +70,16 @@ enum Command {
     /// simultaneous — see `trusty_code::serve` module docs).
     Serve {
         /// Path to the project root (must contain a `.claude/` directory).
+        ///
+        /// OPTIONAL: omit it to serve PROJECTLESS — a first-class state for
+        /// chat/planning before a project is chosen, and the state the shell's
+        /// entry screen renders. A projectless daemon indexes nothing, has no
+        /// diff target, and scopes no memory palace; agents resolve from the
+        /// user-level `~/.claude/agents`. The path must be an existing
+        /// directory when given; it need NOT be a git repo (a plain directory
+        /// binds and indexes just like a repo, minus git affordances).
         #[arg(long, short, value_name = "PATH")]
-        project: PathBuf,
+        project: Option<PathBuf>,
 
         /// Serve JSON-RPC 2.0 over stdio (NDJSON on stdin/stdout), matching
         /// the trusty-memory/trusty-search MCP stdio convention.
@@ -414,14 +422,34 @@ async fn run_thin_client(
 /// (SIGTERM/SIGINT, or stdin EOF for `--stdio`), logging to stderr only.
 /// Neither flag given prints actionable usage and exits 1 rather than
 /// silently doing nothing.
+/// `project` is optional: `None` serves PROJECTLESS. It is resolved into a
+/// typed `ProjectBinding` HERE, at the boundary, so an unusable `--project`
+/// (missing, or not a directory) fails fast with an actionable message rather
+/// than surfacing later as a confusing per-task error.
 /// Test: exercised manually (`tcode serve --project . --stdio` /
-/// `--http [--port N]`); `trusty_code::serve::tests`,
-/// `serve::transport::tests`, and `serve::http::tests` cover the
-/// router/transport logic this delegates to.
-async fn run_serve(project: PathBuf, stdio: bool, http: bool, port: Option<u16>) -> Result<()> {
+/// `tcode serve --stdio` projectless / `--http [--port N]`);
+/// `trusty_code::serve::tests`, `serve::transport::tests`, and
+/// `serve::http::tests` cover the router/transport logic this delegates to.
+async fn run_serve(
+    project: Option<PathBuf>,
+    stdio: bool,
+    http: bool,
+    port: Option<u16>,
+) -> Result<()> {
+    let binding = match trusty_code::binding::ProjectBinding::resolve(project) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("tcode serve: {e}");
+            eprintln!(
+                "hint: pass an existing directory to --project, or omit --project \
+                 entirely to serve projectless (chat/planning; no index, no diff)."
+            );
+            process::exit(1);
+        }
+    };
     if http {
         let port = port.unwrap_or(trusty_code::serve::DEFAULT_HTTP_PORT);
-        if let Err(e) = trusty_code::serve::run_http(project, port).await {
+        if let Err(e) = trusty_code::serve::run_http(binding, port).await {
             eprintln!("tcode serve --http: fatal error: {e:#}");
             process::exit(1);
         }
@@ -429,7 +457,7 @@ async fn run_serve(project: PathBuf, stdio: bool, http: bool, port: Option<u16>)
     }
 
     if stdio {
-        if let Err(e) = trusty_code::serve::run_stdio(project).await {
+        if let Err(e) = trusty_code::serve::run_stdio(binding).await {
             eprintln!("tcode serve --stdio: fatal error: {e:#}");
             process::exit(1);
         }
@@ -439,7 +467,7 @@ async fn run_serve(project: PathBuf, stdio: bool, http: bool, port: Option<u16>)
     eprintln!(
         "tcode serve: pick a transport — `--stdio` (NDJSON on stdin/stdout) or \
          `--http [--port N]` (POST /rpc + GET /health) [project={}]",
-        project.display()
+        binding.label().unwrap_or_else(|| "<projectless>".into())
     );
     process::exit(1);
 }

--- a/crates/trusty-code/src/mode.rs
+++ b/crates/trusty-code/src/mode.rs
@@ -117,12 +117,18 @@ impl HarnessMode {
 /// made explicit: an invalid value at ANY tier is treated exactly like an
 /// absent one, falling through to the next tier, rather than hard-erroring
 /// the whole call) is skipped.
+/// `project_root` is `Option` because a projectless workstream has no project
+/// and therefore no `.claude/settings.json` tier to consult — that tier is
+/// simply skipped, exactly as an absent file already was. Projectless is a
+/// supported state, never an error, so it still resolves a mode (env var, then
+/// the request's own `mode`, then the default).
 /// Test: `mode::tests::env_var_wins_over_everything`,
 /// `mode::tests::task_param_wins_over_settings_json`,
 /// `mode::tests::settings_json_wins_over_default`,
 /// `mode::tests::default_when_nothing_set`,
-/// `mode::tests::invalid_env_var_falls_through_to_next_tier`.
-pub fn resolve_mode(task_param: Option<&str>, project_root: &Path) -> HarnessMode {
+/// `mode::tests::invalid_env_var_falls_through_to_next_tier`,
+/// `mode::tests::projectless_skips_settings_tier_and_still_resolves`.
+pub fn resolve_mode(task_param: Option<&str>, project_root: Option<&Path>) -> HarnessMode {
     if let Some(mode) = std::env::var(MODE_ENV_VAR)
         .ok()
         .and_then(|v| HarnessMode::parse_lenient(&v))
@@ -132,7 +138,7 @@ pub fn resolve_mode(task_param: Option<&str>, project_root: &Path) -> HarnessMod
     if let Some(mode) = task_param.and_then(HarnessMode::parse_lenient) {
         return mode;
     }
-    if let Some(mode) = read_settings_json_mode(project_root) {
+    if let Some(mode) = project_root.and_then(read_settings_json_mode) {
         return mode;
     }
     HarnessMode::default()
@@ -251,7 +257,29 @@ mod tests {
     async fn default_when_nothing_set() {
         let project = project_with_settings(None);
         with_env_mode(None, || {
-            assert_eq!(resolve_mode(None, project.path()), HarnessMode::DailyDriver);
+            assert_eq!(
+                resolve_mode(None, Some(project.path())),
+                HarnessMode::DailyDriver
+            );
+        })
+        .await;
+    }
+
+    /// A projectless run has no `.claude/settings.json` tier to read; it must
+    /// still resolve a mode from the remaining tiers rather than error.
+    #[tokio::test]
+    async fn projectless_skips_settings_tier_and_still_resolves() {
+        with_env_mode(None, || {
+            assert_eq!(
+                resolve_mode(None, None),
+                HarnessMode::DailyDriver,
+                "projectless must fall through to the default, not error"
+            );
+            assert_eq!(
+                resolve_mode(Some("parity"), None),
+                HarnessMode::Parity,
+                "the request's own mode must still apply when projectless"
+            );
         })
         .await;
     }
@@ -260,7 +288,10 @@ mod tests {
     async fn settings_json_wins_over_default() {
         let project = project_with_settings(Some(r#"{"code_harness": {"mode": "parity"}}"#));
         with_env_mode(None, || {
-            assert_eq!(resolve_mode(None, project.path()), HarnessMode::Parity);
+            assert_eq!(
+                resolve_mode(None, Some(project.path())),
+                HarnessMode::Parity
+            );
         })
         .await;
     }
@@ -270,7 +301,7 @@ mod tests {
         let project = project_with_settings(Some(r#"{"code_harness": {"mode": "parity"}}"#));
         with_env_mode(None, || {
             assert_eq!(
-                resolve_mode(Some("daily-driver"), project.path()),
+                resolve_mode(Some("daily-driver"), Some(project.path())),
                 HarnessMode::DailyDriver
             );
         })
@@ -282,7 +313,7 @@ mod tests {
         let project = project_with_settings(Some(r#"{"code_harness": {"mode": "daily-driver"}}"#));
         with_env_mode(Some("parity"), || {
             assert_eq!(
-                resolve_mode(Some("daily-driver"), project.path()),
+                resolve_mode(Some("daily-driver"), Some(project.path())),
                 HarnessMode::Parity
             );
         })
@@ -294,7 +325,7 @@ mod tests {
         let project = project_with_settings(None);
         with_env_mode(Some("not-a-real-mode"), || {
             assert_eq!(
-                resolve_mode(Some("parity"), project.path()),
+                resolve_mode(Some("parity"), Some(project.path())),
                 HarnessMode::Parity
             );
         })

--- a/crates/trusty-code/src/run_task/diff.rs
+++ b/crates/trusty-code/src/run_task/diff.rs
@@ -108,18 +108,16 @@ pub fn diff_snapshots(before: &Snapshot, after: &Snapshot) -> String {
 
 /// Whether `root` is inside a git work tree.
 ///
-/// Why: Chooses the snapshot strategy; a git repo gets a real tree-diff.
-/// What: Runs `git rev-parse --is-inside-work-tree` and checks for a `true`
-/// stdout. Any failure (git absent, not a repo) yields `false`.
-/// Test: Indirect via snapshot tests.
+/// Why: Chooses the snapshot strategy; a git repo gets a real tree-diff. This
+/// is a thin alias for [`crate::binding::is_git_worktree`] rather than a second
+/// implementation: `ProjectBinding` classifies `GitRepo` vs `Directory` on that
+/// exact probe, and two independent git checks could disagree — producing a
+/// `GitRepo` binding whose diff silently took the non-git file-map path.
+/// What: delegates; fails open to `false` (git absent, not a repo).
+/// Test: Indirect via snapshot tests; the probe itself in
+/// `binding::tests::is_git_worktree_fails_open_for_missing_path`.
 fn is_git_repo(root: &Path) -> bool {
-    Command::new("git")
-        .arg("-C")
-        .arg(root)
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .output()
-        .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true")
-        .unwrap_or(false)
+    crate::binding::is_git_worktree(root)
 }
 
 /// Capture the FULL on-disk working-tree state (tracked changes + untracked

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -370,7 +370,7 @@ mod tests {
     #[tokio::test]
     async fn http_session_events_sse_streams_replay() {
         let (router, sessions) = router_and_sessions();
-        let session = sessions.create("t".to_string(), None, None);
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         let app = build_axum_router(router, sessions);
 
         let resp = app

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -37,14 +37,13 @@ pub mod http;
 pub mod methods;
 pub mod transport;
 
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 use tracing::info;
 
-use crate::agents::locate_agents_dir;
+use crate::binding::ProjectBinding;
 use crate::jsonrpc::Router;
 use crate::session::SessionRegistry;
 
@@ -86,15 +85,24 @@ pub const DEFAULT_HTTP_PORT: u16 = 7881;
 /// What: builds an empty `Router` + a fresh `SessionRegistry`, calls
 /// `methods::register`, `crate::session::protocol::register`, and
 /// `crate::task::protocol::register` on them, and returns both.
+///
+/// `binding` is the daemon's project binding. Its `None` (projectless) state is
+/// what makes the shell's entry screen implementable: previously `build_router`
+/// took a required `PathBuf`, so a daemon could not even START without a
+/// project, and `task.run` could not be called without one. `agents_dir` now
+/// resolves via `ProjectBinding::agents_dir`, which falls back to the
+/// user-level `~/.claude/agents` when projectless rather than to the process
+/// CWD (which would silently bind a directory nobody chose).
 /// Test: `run_stdio_router_recognises_proof_of_life_methods`,
-/// `build_router_wires_session_methods`, `build_router_wires_task_run`.
-pub fn build_router(project: PathBuf) -> (Router, Arc<SessionRegistry>) {
+/// `build_router_wires_session_methods`, `build_router_wires_task_run`,
+/// `build_router_is_projectless_without_a_project`.
+pub fn build_router(binding: ProjectBinding) -> (Router, Arc<SessionRegistry>) {
     let sessions = Arc::new(SessionRegistry::new());
-    let agents_dir = locate_agents_dir(&project);
+    let agents_dir = binding.agents_dir();
     let mut router = Router::new();
     methods::register(&mut router);
     crate::session::protocol::register(&mut router, sessions.clone());
-    crate::task::protocol::register(&mut router, sessions.clone(), project, agents_dir);
+    crate::task::protocol::register(&mut router, sessions.clone(), binding, agents_dir);
     (router, sessions)
 }
 
@@ -110,9 +118,13 @@ pub fn build_router(project: PathBuf) -> (Router, Arc<SessionRegistry>) {
 /// Test: `run_stdio_router_recognises_proof_of_life_methods` covers the
 /// router assembly; the transport loop itself is covered by
 /// `transport::tests`.
-pub async fn run_stdio(project: PathBuf) -> Result<()> {
-    info!(project = %project.display(), "tcode serve --stdio: starting");
-    let (router, sessions) = build_router(project);
+pub async fn run_stdio(binding: ProjectBinding) -> Result<()> {
+    info!(
+        binding = binding.state(),
+        project = binding.label().unwrap_or_else(|| "<projectless>".into()),
+        "tcode serve --stdio: starting"
+    );
+    let (router, sessions) = build_router(binding);
     transport::run_stdio_loop(router).await?;
     sessions.shutdown_executions(SHUTDOWN_GRACE).await;
     info!("tcode serve --stdio: stopped");
@@ -130,9 +142,14 @@ pub async fn run_stdio(project: PathBuf) -> Result<()> {
 /// [`SHUTDOWN_GRACE`]) — see [`run_stdio`]'s docs for why.
 /// Test: `run_stdio_router_recognises_proof_of_life_methods` covers the
 /// shared router assembly; `http::tests` cover the routing/dispatch logic.
-pub async fn run_http(project: PathBuf, port: u16) -> Result<()> {
-    info!(project = %project.display(), port, "tcode serve --http: starting");
-    let (router, sessions) = build_router(project);
+pub async fn run_http(binding: ProjectBinding, port: u16) -> Result<()> {
+    info!(
+        binding = binding.state(),
+        project = binding.label().unwrap_or_else(|| "<projectless>".into()),
+        port,
+        "tcode serve --http: starting"
+    );
+    let (router, sessions) = build_router(binding);
     http::run_http(router, sessions.clone(), port).await?;
     sessions.shutdown_executions(SHUTDOWN_GRACE).await;
     info!("tcode serve --http: stopped");
@@ -154,7 +171,9 @@ mod tests {
     #[tokio::test]
     async fn run_stdio_router_recognises_proof_of_life_methods() {
         let project = tempfile::tempdir().expect("project tempdir");
-        let (router, _sessions) = build_router(project.path().to_path_buf());
+        let (router, _sessions) = build_router(
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        );
         for method in ["ping", "health"] {
             let req = Request {
                 jsonrpc: Some("2.0".to_string()),
@@ -176,8 +195,10 @@ mod tests {
     #[tokio::test]
     async fn build_router_wires_session_methods() {
         let project = tempfile::tempdir().expect("project tempdir");
-        let (router, sessions) = build_router(project.path().to_path_buf());
-        let session = sessions.create("t".to_string(), None, None);
+        let (router, sessions) = build_router(
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        );
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let req = Request {
             jsonrpc: Some("2.0".to_string()),
@@ -202,7 +223,34 @@ mod tests {
         assert_eq!(DEFAULT_HTTP_PORT, 7881);
     }
 
-    /// `build_router` must also wire `task.run` (#2056).
+    /// The daemon must ASSEMBLE with no project bound — `build_router` took a
+    /// required `PathBuf` before, so a projectless daemon could not exist and
+    /// the shell had no entry state to render. `task.run` must be wired just
+    /// the same in that state.
+    #[tokio::test]
+    async fn build_router_is_projectless_without_a_project() {
+        let (router, _sessions) = build_router(ProjectBinding::None);
+        for method in ["task.run", "session.create", "session.list"] {
+            let req = Request {
+                jsonrpc: Some("2.0".to_string()),
+                id: Some(json!(1)),
+                method: method.to_string(),
+                params: Some(json!({})),
+            };
+            let resp = router.dispatch(req, &test_ctx()).await;
+            // Params are deliberately empty, so an `invalid_params`/
+            // `invalid_argument` is fine and expected — the ONE thing that must
+            // not happen is `-32601 Method not found`, which would mean a
+            // projectless daemon serves a different method surface.
+            if let Some(err) = resp.error {
+                assert_ne!(
+                    err.code, -32601,
+                    "{method} must be wired on a projectless daemon, got method-not-found"
+                );
+            }
+        }
+    }
+
     #[tokio::test]
     async fn build_router_wires_task_run() {
         let project = tempfile::tempdir().expect("project tempdir");
@@ -234,7 +282,9 @@ mod tests {
                 crate::task::mock_llm::MOCK_LLM_ECHO,
             );
         }
-        let (router, sessions) = build_router(project.path().to_path_buf());
+        let (router, sessions) = build_router(
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        );
         let req = Request {
             jsonrpc: Some("2.0".to_string()),
             id: Some(json!(1)),

--- a/crates/trusty-code/src/session/model.rs
+++ b/crates/trusty-code/src/session/model.rs
@@ -96,17 +96,33 @@ impl SessionStatus {
 /// that has never run a task has no mode, mirroring the same "`None` means
 /// not yet run" convention `session::transcript::TranscriptRecord` already
 /// uses for `cost_usd`.
-/// Test: `model::tests::session_round_trips_through_json`.
+///
+/// `binding` is the session's TYPED project binding (spec DOC-39 §5.5) — the
+/// single object `task.run` and `session.create` now converge on. `project`
+/// survives as the human display label but is no longer an independent source
+/// of truth: it is DERIVED from `binding` (`ProjectBinding::label`) and so can
+/// never again disagree with it. That derivation is the whole reconciliation —
+/// previously `session.create` took a free-form label that was never validated
+/// and never bound, while `task.run` took a path the label knew nothing about.
+/// Test: `model::tests::session_round_trips_through_json`,
+/// `model::tests::projectless_session_round_trips`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub id: String,
     pub task: String,
     pub agent: Option<String>,
+    /// Display label, derived from `binding` — see the struct docs. Kept for
+    /// wire compatibility with existing `session.list`/`session.status`
+    /// consumers that read a project name.
     pub project: Option<String>,
     pub status: SessionStatus,
     pub created_at: DateTime<Utc>,
     #[serde(default)]
     pub mode: Option<crate::mode::HarnessMode>,
+    /// The typed three-state project binding. Defaults to projectless so an
+    /// older persisted/serialized `Session` without the field still reads back.
+    #[serde(default)]
+    pub binding: crate::binding::ProjectBinding,
 }
 
 #[cfg(test)]
@@ -180,6 +196,7 @@ mod tests {
             task: "do the thing".to_string(),
             agent: Some("engineer".to_string()),
             project: None,
+            binding: crate::binding::ProjectBinding::None,
             status: SessionStatus::Running,
             created_at: Utc::now(),
             mode: Some(crate::mode::HarnessMode::DailyDriver),
@@ -195,5 +212,44 @@ mod tests {
         assert_eq!(back.id, session.id);
         assert_eq!(back.status, session.status);
         assert_eq!(back.mode, session.mode);
+    }
+}
+
+#[cfg(test)]
+mod binding_model_tests {
+    use super::*;
+
+    /// A projectless `Session` must round-trip, and a payload with NO `binding`
+    /// field at all must read back as projectless rather than failing.
+    #[test]
+    fn projectless_session_round_trips() {
+        let session = Session {
+            id: "s-1".to_string(),
+            task: "t".to_string(),
+            agent: None,
+            project: None,
+            binding: crate::binding::ProjectBinding::None,
+            status: SessionStatus::Running,
+            created_at: Utc::now(),
+            mode: None,
+        };
+        let value = serde_json::to_value(&session).expect("serialize");
+        assert_eq!(value["binding"]["state"], "projectless");
+
+        let back: Session = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(back.binding, crate::binding::ProjectBinding::None);
+
+        // An older payload predating the `binding` field must still read back.
+        let legacy = serde_json::json!({
+            "id": "s-2", "task": "t", "agent": null, "project": null,
+            "status": "running", "created_at": Utc::now(),
+        });
+        let back: Session =
+            serde_json::from_value(legacy).expect("legacy payload must deserialize");
+        assert_eq!(
+            back.binding,
+            crate::binding::ProjectBinding::None,
+            "a missing binding field must default to projectless"
+        );
     }
 }

--- a/crates/trusty-code/src/session/protocol.rs
+++ b/crates/trusty-code/src/session/protocol.rs
@@ -22,12 +22,14 @@
 //! (registry-level) and `tests/session_e2e.rs`/`tests/task_e2e.rs`
 //! (API-driven, real daemon).
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use serde::Deserialize;
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 
+use crate::binding::ProjectBinding;
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 
 use super::registry::SessionRegistry;
@@ -148,13 +150,16 @@ struct SessionIdParams {
 }
 
 /// `params` shape for `session.create`.
+///
+/// `project` is now a project PATH, not the free-form label it used to be — see
+/// [`create`]'s docs for the reconciliation and its compatibility implications.
 #[derive(Deserialize)]
 struct CreateParams {
     task: String,
     #[serde(default)]
     agent: Option<String>,
     #[serde(default)]
-    project: Option<String>,
+    project: Option<PathBuf>,
 }
 
 /// `params` shape for `session.send`.
@@ -174,11 +179,30 @@ fn parse<T: DeserializeOwned>(params: Value, method: &str) -> Result<T, RpcError
 ///
 /// Why: mints a brand-new daemon-owned session.
 /// What: validates `task` is non-empty (`-32003 invalid_argument`
-/// otherwise), then delegates to `SessionRegistry::create`. The returned
-/// `Session` already has `status: "running"` — see `session::model`'s docs
-/// on why M1 has no queued/created-but-not-running state.
+/// otherwise), resolves `project` into a typed [`ProjectBinding`], then
+/// delegates to `SessionRegistry::create`. The returned `Session` already has
+/// `status: "running"` — see `session::model`'s docs on why M1 has no
+/// queued/created-but-not-running state.
+///
+/// **The `project` reconciliation (spec DOC-39 §5.5, AC-16.2).** This param was
+/// an untyped, free-form `Option<String>` LABEL: never validated, never bound,
+/// not enumerable, and disconnected from the `PathBuf` `task.run` demanded. One
+/// concept lived on two surfaces that could not agree. It is now the same
+/// `ProjectBinding` `task.run` uses, resolved from a project PATH.
+///
+/// This is a deliberate BREAKING change to this method's contract: a caller that
+/// previously passed a decorative label (`"my-app"`) now receives
+/// `-32003 invalid_argument` unless that string names a real directory. Erroring
+/// is the point — silently accepting a label that binds nothing and indexes
+/// nothing is exactly the failure this reconciliation exists to end, and a
+/// caller who learns their "project" was never real is strictly better off than
+/// one who never finds out. Omitting `project` entirely remains valid and means
+/// PROJECTLESS — a supported state, never an error (AC-2.1).
 /// Test: `protocol::tests::create_rejects_empty_task`,
-/// `protocol::tests::create_returns_running_session`.
+/// `protocol::tests::create_returns_running_session`,
+/// `protocol::tests::create_without_project_is_projectless`,
+/// `protocol::tests::create_binds_a_real_directory`,
+/// `protocol::tests::create_rejects_a_label_that_is_not_a_directory`.
 async fn create(
     registry: &SessionRegistry,
     params: Value,
@@ -188,7 +212,9 @@ async fn create(
     if p.task.trim().is_empty() {
         return Err(RpcError::invalid_argument("task must not be empty"));
     }
-    let session = registry.create(p.task, p.agent, p.project);
+    let binding = ProjectBinding::resolve(p.project)
+        .map_err(|e| RpcError::invalid_argument(format!("session.create: {e}")))?;
+    let session = registry.create(p.task, p.agent, binding);
     Ok(json!(session))
 }
 
@@ -371,7 +397,7 @@ mod tests {
         let mut router = Router::new();
         register(&mut router, registry.clone());
 
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let cases: &[(&str, Value)] = &[
             ("session.list", json!({})),
@@ -425,7 +451,7 @@ mod tests {
         let registry = Arc::new(SessionRegistry::new());
         let mut router = Router::new();
         register(&mut router, registry.clone());
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         for method in ["session.set_goal", "session.clear_goal"] {
             let req = Request {
@@ -468,7 +494,7 @@ mod tests {
     #[tokio::test]
     async fn list_returns_sessions_key() {
         let registry = SessionRegistry::new();
-        registry.create("a".to_string(), None, None);
+        registry.create("a".to_string(), None, crate::binding::ProjectBinding::None);
         let result = list(&registry, Value::Null, test_ctx()).await.unwrap();
         assert_eq!(result["sessions"].as_array().unwrap().len(), 1);
     }
@@ -499,7 +525,7 @@ mod tests {
     #[tokio::test]
     async fn get_transcript_on_never_run_session_is_empty() {
         let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         let result = get_transcript(&registry, json!({"session_id": session.id}), test_ctx())
             .await
             .unwrap();
@@ -559,7 +585,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_executing_session_requests_cooperative_cancel() {
         let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         let flag = registry.begin_execution(&session.id).unwrap();
 
         let result = cancel(&registry, json!({"session_id": &session.id}), test_ctx())
@@ -574,5 +600,68 @@ mod tests {
             flag.load(std::sync::atomic::Ordering::Relaxed),
             "the shared cancel flag must have been set"
         );
+    }
+}
+
+#[cfg(test)]
+mod binding_tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    fn ctx() -> ConnectionContext {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    /// Omitting `project` is VALID and means projectless — a supported state,
+    /// never an error (AC-2.1). This is the entry state screen 7a renders.
+    #[tokio::test]
+    async fn create_without_project_is_projectless() {
+        let registry = SessionRegistry::new();
+        let value = create(&registry, json!({"task": "just chat"}), ctx())
+            .await
+            .expect("omitting project must be valid");
+
+        assert_eq!(value["binding"]["state"], "projectless");
+        assert!(value["binding"]["root"].is_null());
+        assert!(
+            value["project"].is_null(),
+            "projectless must derive no label"
+        );
+    }
+
+    /// A real directory binds, and the derived label matches the binding — the
+    /// reconciliation in one assertion (AC-16.2).
+    #[tokio::test]
+    async fn create_binds_a_real_directory() {
+        let registry = SessionRegistry::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let value = create(
+            &registry,
+            json!({"task": "t", "project": dir.path().to_string_lossy()}),
+            ctx(),
+        )
+        .await
+        .expect("a real directory must bind");
+
+        // A non-git tempdir binds as `directory` — NOT projectless (#2728).
+        assert_eq!(value["binding"]["state"], "directory");
+        assert_eq!(
+            value["project"], value["binding"]["root"],
+            "the label must be derived from the binding root, not independent of it"
+        );
+    }
+
+    /// The old free-form label is now rejected: `"my-app"` names no directory,
+    /// so it can bind nothing and index nothing. Erroring is the point — see
+    /// `create`'s docs. This is the deliberate breaking change.
+    #[tokio::test]
+    async fn create_rejects_a_label_that_is_not_a_directory() {
+        let registry = SessionRegistry::new();
+        let err = create(&registry, json!({"task": "t", "project": "my-app"}), ctx())
+            .await
+            .expect_err("a decorative label must no longer be silently accepted");
+
+        assert_eq!(err.code, -32003, "expected invalid_argument, got {err:?}");
     }
 }

--- a/crates/trusty-code/src/session/protocol_goals.rs
+++ b/crates/trusty-code/src/session/protocol_goals.rs
@@ -118,7 +118,7 @@ mod tests {
     #[tokio::test]
     async fn set_goal_writes_operator_goal() {
         let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         seed_pm_transcript(&registry, &session.id);
 
         let result = set_goal(
@@ -143,7 +143,7 @@ mod tests {
     #[tokio::test]
     async fn set_goal_out_of_range_slot_maps_to_invalid_argument() {
         let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         seed_pm_transcript(&registry, &session.id);
 
         let err = set_goal(
@@ -175,7 +175,7 @@ mod tests {
     #[tokio::test]
     async fn clear_goal_clears_operator_goal() {
         let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         seed_pm_transcript(&registry, &session.id);
         set_goal(
             &registry,
@@ -204,7 +204,7 @@ mod tests {
     #[tokio::test]
     async fn clear_goal_out_of_range_slot_maps_to_invalid_argument() {
         let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         seed_pm_transcript(&registry, &session.id);
 
         let err = clear_goal(
@@ -221,7 +221,7 @@ mod tests {
     #[tokio::test]
     async fn get_goals_returns_goals_key() {
         let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         let result = get_goals(&registry, json!({"session_id": session.id}), test_ctx())
             .await
             .unwrap();
@@ -233,7 +233,7 @@ mod tests {
     #[tokio::test]
     async fn get_goals_on_never_run_session_is_empty() {
         let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         let result = get_goals(&registry, json!({"session_id": session.id}), test_ctx())
             .await
             .unwrap();

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -39,6 +39,7 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::agent_loop::Transcript;
+use crate::binding::ProjectBinding;
 use crate::events::{Event, SessionEventEnvelope};
 use crate::jsonrpc::{NotifySender, RpcError};
 use crate::mode::HarnessMode;
@@ -170,14 +171,21 @@ impl SessionRegistry {
     /// `Event::SessionStatusChanged` (`seq = 2`). Returns the
     /// post-transition snapshot (so the caller sees `status: "running"`,
     /// not the momentary `"created"`).
-    /// Test: `registry_tests::create_publishes_started_and_status_events`.
-    pub fn create(&self, task: String, agent: Option<String>, project: Option<String>) -> Session {
+    /// `binding` replaces what was an untyped `project: Option<String>` label.
+    /// The label still exists on the wire (`Session.project`) but is now DERIVED
+    /// from the binding via `ProjectBinding::label`, so the two can never
+    /// disagree — see `Session`'s docs. `ProjectBinding::None` (projectless) is
+    /// a fully supported binding, not a missing one.
+    /// Test: `registry_tests::create_publishes_started_and_status_events`,
+    /// `registry_tests::create_derives_project_label_from_binding`.
+    pub fn create(&self, task: String, agent: Option<String>, binding: ProjectBinding) -> Session {
         let id = Uuid::new_v4().to_string();
         let session = Session {
             id: id.clone(),
             task,
             agent,
-            project: project.clone(),
+            project: binding.label(),
+            binding,
             status: SessionStatus::Created,
             created_at: Utc::now(),
             mode: None,
@@ -204,7 +212,10 @@ impl SessionRegistry {
             &id,
             Event::SessionStarted {
                 session_id: id.clone(),
-                project: project.unwrap_or_default(),
+                // The binding-derived label. Projectless yields `""`, exactly
+                // as an absent `project` label already did before the binding
+                // existed — no wire change for this event.
+                project: session.project.clone().unwrap_or_default(),
             },
         );
         self.transition(&id, SessionStatus::Running);

--- a/crates/trusty-code/src/session/registry_memory_sink.rs
+++ b/crates/trusty-code/src/session/registry_memory_sink.rs
@@ -48,9 +48,23 @@ impl SessionRegistry {
     /// binding is fixed for its lifetime, mirroring
     /// `Self::begin_pm_transcript`'s analogous "the system prompt is fixed
     /// after the first call" rule.
+    /// `project_dir` is `None` for a PROJECTLESS session, which returns `None`:
+    /// a memory palace is project-scoped by construction, so with no project
+    /// there is nothing to scope one to. This is a deliberate skip, not a
+    /// degradation — the caller must NOT substitute the run's scratch root,
+    /// since deriving a palace id from a throwaway temp path would mint a fresh,
+    /// orphaned palace on every projectless run. The whole sink is already
+    /// fail-open and fire-and-forget, so its absence costs a projectless run
+    /// nothing but the durable turn record it has no home for anyway.
     /// Test: `registry_tests::memory_sink_for_reuses_the_same_sink_across_calls`,
-    /// `registry_tests::memory_sink_for_unknown_session_returns_none`.
-    pub fn memory_sink_for(&self, id: &str, project_dir: &Path) -> Option<Arc<TurnMemorySink>> {
+    /// `registry_tests::memory_sink_for_unknown_session_returns_none`,
+    /// `registry_tests::memory_sink_for_projectless_session_returns_none`.
+    pub fn memory_sink_for(
+        &self,
+        id: &str,
+        project_dir: Option<&Path>,
+    ) -> Option<Arc<TurnMemorySink>> {
+        let project_dir = project_dir?;
         let mut sessions = self.lock();
         let entry = sessions.get_mut(id)?;
         if entry.memory_sink.is_none() {

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -48,13 +48,25 @@ async fn create_publishes_started_and_status_events() {
     let registry = SessionRegistry::new();
     let mut events = crate::events::subscribe();
 
-    let session = registry.create("do the thing".to_string(), None, Some("proj".to_string()));
+    let project_dir = tempfile::tempdir().expect("project tempdir");
+    let binding = crate::binding::ProjectBinding::resolve(Some(project_dir.path().to_path_buf()))
+        .expect("tempdir must bind");
+    let expected_label = binding.label().expect("a bound project has a label");
+
+    let session = registry.create("do the thing".to_string(), None, binding);
     assert_eq!(session.status, SessionStatus::Running);
 
     let first = next_event_for(&mut events, &session.id).await;
     assert_eq!(first.seq, 1);
     assert_eq!(first.kind, "session_started");
-    assert!(matches!(first.event, Event::SessionStarted { project, .. } if project == "proj"));
+    // The event's `project` label is now DERIVED from the binding rather than
+    // being an independently-supplied string, so it must equal the binding's
+    // own label exactly — that equality IS the reconciliation (AC-16.2).
+    assert!(
+        matches!(first.event, Event::SessionStarted { ref project, .. } if *project == expected_label),
+        "SessionStarted.project must be the binding-derived label {expected_label:?}, got {:?}",
+        first.event
+    );
 
     let second = next_event_for(&mut events, &session.id).await;
     assert_eq!(second.seq, 2);
@@ -67,8 +79,8 @@ async fn create_publishes_started_and_status_events() {
 #[tokio::test]
 async fn list_returns_every_created_session() {
     let registry = SessionRegistry::new();
-    registry.create("a".to_string(), None, None);
-    registry.create("b".to_string(), None, None);
+    registry.create("a".to_string(), None, crate::binding::ProjectBinding::None);
+    registry.create("b".to_string(), None, crate::binding::ProjectBinding::None);
     assert_eq!(registry.list().len(), 2);
 }
 
@@ -84,7 +96,7 @@ async fn status_returns_not_found_for_unknown_id() {
 #[tokio::test]
 async fn send_publishes_input_event() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     registry.send(&session.id, "hello").unwrap();
@@ -108,7 +120,7 @@ async fn send_unknown_session_errors() {
 #[tokio::test]
 async fn cancel_transitions_to_cancelled_and_publishes() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     let cancelled = registry.cancel(&session.id).unwrap();
@@ -149,7 +161,7 @@ async fn cancel_unknown_session_errors() {
 #[tokio::test]
 async fn attach_returns_ring_buffer_replay() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     registry.send(&session.id, "one").unwrap();
 
     let (tx, _rx) = notify_channel();
@@ -170,7 +182,7 @@ async fn attach_returns_ring_buffer_replay() {
 #[tokio::test]
 async fn attach_forwards_live_events_until_detach() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let connection_id = Uuid::new_v4();
     let (tx, mut rx) = notify_channel();
 
@@ -217,7 +229,7 @@ async fn attach_forwards_live_events_until_detach() {
 #[tokio::test]
 async fn attach_replay_then_live_seq_is_contiguous() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     registry.send(&session.id, "before-attach").unwrap();
 
     let (tx, mut rx) = notify_channel();
@@ -257,7 +269,7 @@ async fn attach_unknown_session_errors() {
 #[tokio::test]
 async fn detach_without_prior_attach_is_a_noop() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     registry.detach(&session.id, Uuid::new_v4()).unwrap();
 }
 
@@ -274,7 +286,7 @@ async fn detach_unknown_session_errors() {
 #[tokio::test]
 async fn replay_returns_ring_buffer_without_attaching() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let replay = registry.replay(&session.id).unwrap();
     assert_eq!(replay.len(), 2); // SessionStarted + SessionStatusChanged(running)
 }
@@ -283,7 +295,7 @@ async fn replay_returns_ring_buffer_without_attaching() {
 #[tokio::test]
 async fn ring_buffer_drops_oldest_when_full() {
     let registry = SessionRegistry::with_capacity(2);
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     // Ring already has 2 entries (SessionStarted, StatusChanged running) at
     // capacity 2; one more push must evict the oldest (SessionStarted).
     registry.send(&session.id, "evicts-started").unwrap();
@@ -308,7 +320,7 @@ async fn ring_buffer_drops_oldest_when_full() {
 #[tokio::test]
 async fn record_tool_started_publishes_event() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     registry
@@ -329,7 +341,7 @@ async fn record_tool_started_publishes_event() {
 #[tokio::test]
 async fn record_tool_finished_publishes_event() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     registry
@@ -348,7 +360,7 @@ async fn record_tool_finished_publishes_event() {
 #[tokio::test]
 async fn record_tool_error_publishes_event() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     registry
@@ -364,7 +376,7 @@ async fn record_tool_error_publishes_event() {
 #[tokio::test]
 async fn record_log_publishes_event() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     registry
@@ -382,7 +394,7 @@ async fn record_log_publishes_event() {
 #[tokio::test]
 async fn record_progress_publishes_event() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     registry
@@ -398,7 +410,7 @@ async fn record_progress_publishes_event() {
 #[tokio::test]
 async fn record_message_publishes_event() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     registry.record_message(&session.id, "hello world").unwrap();
@@ -465,7 +477,7 @@ async fn begin_execution_unknown_session_errors() {
 #[tokio::test]
 async fn begin_execution_rejects_terminal_session() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     registry.cancel(&session.id).unwrap();
 
     let err = registry.begin_execution(&session.id).unwrap_err();
@@ -480,7 +492,7 @@ async fn begin_execution_rejects_terminal_session() {
 #[tokio::test]
 async fn begin_execution_rejects_second_overlapping_run() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let _first = registry.begin_execution(&session.id).unwrap();
     let err = registry.begin_execution(&session.id).unwrap_err();
@@ -498,7 +510,7 @@ async fn begin_execution_rejects_second_overlapping_run() {
 #[tokio::test]
 async fn request_cancel_returns_false_when_idle() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     assert!(!registry.request_cancel(&session.id).unwrap());
 }
 
@@ -507,7 +519,7 @@ async fn request_cancel_returns_false_when_idle() {
 #[tokio::test]
 async fn request_cancel_sets_flag_when_executing() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     assert!(!registry.is_executing(&session.id));
 
     let cancel = registry.begin_execution(&session.id).unwrap();
@@ -541,7 +553,7 @@ async fn request_cancel_unknown_session_errors() {
 #[tokio::test]
 async fn begin_execution_resumes_a_finished_session() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let _first = registry.begin_execution(&session.id).unwrap();
     registry.finish_execution(&session.id);
@@ -578,21 +590,21 @@ async fn begin_execution_resumes_a_finished_session() {
 async fn begin_execution_still_rejects_cancelled_failed_and_deadline_exceeded() {
     let registry = SessionRegistry::new();
 
-    let cancelled = registry.create("t".to_string(), None, None);
+    let cancelled = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     registry.cancel(&cancelled.id).unwrap();
     assert_eq!(
         registry.begin_execution(&cancelled.id).unwrap_err().code,
         -32003
     );
 
-    let failed = registry.create("t".to_string(), None, None);
+    let failed = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     registry.finish(&failed.id, SessionStatus::Failed).unwrap();
     assert_eq!(
         registry.begin_execution(&failed.id).unwrap_err().code,
         -32003
     );
 
-    let deadline = registry.create("t".to_string(), None, None);
+    let deadline = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     registry
         .finish(&deadline.id, SessionStatus::DeadlineExceeded)
         .unwrap();
@@ -609,7 +621,7 @@ async fn begin_execution_still_rejects_cancelled_failed_and_deadline_exceeded() 
 #[tokio::test]
 async fn begin_pm_transcript_seeds_on_first_call() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let transcript = registry
         .begin_pm_transcript(&session.id, "you are the pm", "first task")
@@ -629,7 +641,7 @@ async fn begin_pm_transcript_seeds_on_first_call() {
 #[tokio::test]
 async fn begin_pm_transcript_appends_on_second_call() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let mut transcript = registry
         .begin_pm_transcript(&session.id, "you are the pm", "first task")
@@ -677,14 +689,14 @@ async fn begin_pm_transcript_unknown_session_errors() {
 #[tokio::test]
 async fn memory_sink_for_reuses_the_same_sink_across_calls() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let project_dir = tempfile::TempDir::new().unwrap();
 
     let first = registry
-        .memory_sink_for(&session.id, project_dir.path())
+        .memory_sink_for(&session.id, Some(project_dir.path()))
         .expect("first call constructs a sink");
     let second = registry
-        .memory_sink_for(&session.id, project_dir.path())
+        .memory_sink_for(&session.id, Some(project_dir.path()))
         .expect("second call reuses the sink");
 
     assert!(
@@ -701,7 +713,7 @@ async fn memory_sink_for_unknown_session_returns_none() {
     let project_dir = tempfile::TempDir::new().unwrap();
     assert!(
         registry
-            .memory_sink_for("nope", project_dir.path())
+            .memory_sink_for("nope", Some(project_dir.path()))
             .is_none()
     );
 }
@@ -711,7 +723,7 @@ async fn memory_sink_for_unknown_session_returns_none() {
 #[tokio::test]
 async fn set_run_outcome_stores_transcript_and_usage() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let turns = vec![crate::run_task::TurnRecord {
         role: "pm".to_string(),
@@ -744,7 +756,7 @@ async fn set_run_outcome_stores_transcript_and_usage() {
 #[tokio::test]
 async fn set_run_outcome_accumulates_across_two_calls() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let run_one_turn = crate::run_task::TurnRecord {
         role: "pm".to_string(),
@@ -799,7 +811,7 @@ async fn set_run_outcome_accumulates_across_two_calls() {
 #[tokio::test]
 async fn get_transcript_on_never_run_session_is_empty() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let transcript = registry.get_transcript(&session.id).unwrap();
     assert_eq!(transcript.session_id, session.id);
@@ -836,7 +848,7 @@ async fn get_transcript_unknown_session_errors() {
 #[tokio::test]
 async fn get_transcript_reports_compaction_events() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let mut transcript = registry
         .begin_pm_transcript(&session.id, "you are the pm", "first task")
@@ -855,7 +867,7 @@ async fn get_transcript_reports_compaction_events() {
 #[tokio::test]
 async fn set_mode_stores_on_session() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     assert_eq!(session.mode, None, "a fresh session has no mode yet");
 
     registry
@@ -884,7 +896,7 @@ async fn set_mode_unknown_session_errors() {
 #[tokio::test]
 async fn shutdown_executions_awaits_cancelled_tasks() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let cancel = registry.begin_execution(&session.id).unwrap();
 
     let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -910,7 +922,7 @@ async fn shutdown_executions_awaits_cancelled_tasks() {
 #[tokio::test]
 async fn finish_transitions_and_publishes_session_done() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     let finished = registry
@@ -935,7 +947,7 @@ async fn finish_transitions_and_publishes_session_done() {
 #[tokio::test]
 async fn finish_is_idempotent_on_terminal_session() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     registry
         .finish(&session.id, SessionStatus::Finished)
         .unwrap();
@@ -977,7 +989,7 @@ fn seed_pm_transcript(registry: &SessionRegistry, id: &str) {
 #[tokio::test]
 async fn set_goal_writes_operator_source() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     seed_pm_transcript(&registry, &session.id);
 
     registry.set_goal(&session.id, 2, "ship it").unwrap();
@@ -995,7 +1007,7 @@ async fn set_goal_writes_operator_source() {
 #[tokio::test]
 async fn set_goal_no_transcript_yet_errors() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let err = registry.set_goal(&session.id, 1, "x").unwrap_err();
     assert_eq!(err.code, -32003);
@@ -1007,7 +1019,7 @@ async fn set_goal_no_transcript_yet_errors() {
 #[tokio::test]
 async fn set_goal_out_of_range_slot_errors() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     seed_pm_transcript(&registry, &session.id);
 
     assert_eq!(
@@ -1031,7 +1043,7 @@ async fn set_goal_unknown_session_errors() {
 #[tokio::test]
 async fn clear_goal_clears_slot() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     seed_pm_transcript(&registry, &session.id);
     registry.set_goal(&session.id, 3, "temp").unwrap();
 
@@ -1045,7 +1057,7 @@ async fn clear_goal_clears_slot() {
 #[tokio::test]
 async fn clear_goal_no_transcript_yet_errors() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let err = registry.clear_goal(&session.id, 1).unwrap_err();
     assert_eq!(err.code, -32003);
@@ -1056,7 +1068,7 @@ async fn clear_goal_no_transcript_yet_errors() {
 #[tokio::test]
 async fn clear_goal_out_of_range_slot_errors() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     seed_pm_transcript(&registry, &session.id);
 
     assert_eq!(
@@ -1072,7 +1084,7 @@ async fn clear_goal_out_of_range_slot_errors() {
 #[tokio::test]
 async fn get_goals_returns_operator_and_model_sources() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     seed_pm_transcript(&registry, &session.id);
 
     registry.set_goal(&session.id, 2, "operator goal").unwrap();
@@ -1117,7 +1129,7 @@ async fn get_goals_returns_operator_and_model_sources() {
 #[tokio::test]
 async fn get_goals_on_never_run_session_is_empty() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     assert!(registry.get_goals(&session.id).unwrap().is_empty());
 }
@@ -1135,7 +1147,7 @@ async fn get_goals_unknown_session_errors() {
 #[tokio::test]
 async fn get_transcript_round_trips_goal_state() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     seed_pm_transcript(&registry, &session.id);
     registry
         .set_goal(&session.id, 4, "finish the migration")
@@ -1162,8 +1174,47 @@ async fn get_transcript_round_trips_goal_state() {
 #[tokio::test]
 async fn get_transcript_goals_empty_on_never_run_session() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let record = registry.get_transcript(&session.id).unwrap();
     assert!(record.goals.is_empty());
+}
+
+/// `create` must DERIVE `Session.project` from the binding rather than accept an
+/// independent label — the two can no longer disagree (AC-16.2).
+#[tokio::test]
+async fn create_derives_project_label_from_binding() {
+    let registry = SessionRegistry::new();
+    let project_dir = tempfile::tempdir().expect("project tempdir");
+    let binding = crate::binding::ProjectBinding::resolve(Some(project_dir.path().to_path_buf()))
+        .expect("tempdir must bind");
+
+    let session = registry.create("t".to_string(), None, binding.clone());
+    assert_eq!(
+        session.project,
+        binding.label(),
+        "the label must be the binding's own label, not an independent string"
+    );
+    assert_eq!(session.binding, binding);
+
+    let projectless = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    assert_eq!(
+        projectless.project, None,
+        "projectless must derive no label"
+    );
+    assert_eq!(projectless.binding, crate::binding::ProjectBinding::None);
+}
+
+/// A PROJECTLESS session must get NO memory sink: a palace is project-scoped by
+/// construction, so with no project there is nothing to scope one to. This must
+/// be a clean `None`, not a panic and not a palace derived from a scratch path.
+#[tokio::test]
+async fn memory_sink_for_projectless_session_returns_none() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    assert!(
+        registry.memory_sink_for(&session.id, None).is_none(),
+        "a projectless session must have no project-scoped memory palace"
+    );
 }

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -30,7 +30,7 @@
 //! Test: `task::executor::tests::*`; the full flow end-to-end (a real
 //! subprocess) in `tests/task_e2e.rs`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -41,6 +41,7 @@ use crate::agent_loop::{
     AgentLoop, AgentLoopConfig, CompactionConfig, ToolEventSink, resolve_cadence_config,
 };
 use crate::agents::AgentConfig;
+use crate::binding::ProjectBinding;
 use crate::jsonrpc::RpcError;
 use crate::llm::{DebugCaptureSink, LlmClientTrait, wrap_with_debug_capture};
 use crate::mode::HarnessMode;
@@ -80,19 +81,23 @@ pub const ENGINEER_AGENT_NAME: &str = "python-engineer";
 /// handler stays a thin params-parsing shim.
 /// What: `session_id` must already exist in the registry (created by the
 /// caller — see `task::protocol::task_run`); `agent_name` is the top-level
-/// (PM) agent, `task` is the free-form request text, `project`/`agents_dir`
-/// mirror `run_task::RunTaskParams`, and `model_override` pins the
+/// (PM) agent, `task` is the free-form request text, `agents_dir` mirrors
+/// `run_task::RunTaskParams`, and `model_override` pins the
 /// DELEGATED ENGINEER's model for this run only (mirrors `run_task`'s
 /// `--engineer-model`). `mode` (#2059) is the ALREADY-RESOLVED `HarnessMode`
 /// (`task::protocol::task_run` resolves it via `crate::mode::resolve_mode`
 /// before constructing this — resolution is a request-parsing concern, not
-/// an execution one).
+/// an execution one). `binding` replaces what was a required `project:
+/// PathBuf`; see [`run_and_record`]'s docs for what each of its three states
+/// does to indexing, the memory palace, and the tools' working root.
 #[derive(Debug, Clone)]
 pub struct TaskRunParams {
     pub session_id: String,
     pub task: String,
     pub agent_name: String,
-    pub project: PathBuf,
+    /// This run's project binding — projectless, a non-git directory, or a git
+    /// repo. `ProjectBinding::None` is a fully supported state, not an error.
+    pub binding: ProjectBinding,
     pub agents_dir: PathBuf,
     pub model_override: Option<String>,
     pub mode: HarnessMode,
@@ -162,22 +167,83 @@ pub fn spawn_task_run(
 /// write to trusty-memory (`chat_turn_append` + `memory_remember`); see
 /// `session::memory_sink` module docs for the fail-open contract and the
 /// per-run (not yet per-turn) enqueue granularity this ticket settles for.
+///
+/// **Projectless (`ProjectBinding::None`).** Three things assume a project, and
+/// each gets a DEFINED behaviour rather than a panic: indexing is **skipped**
+/// (nothing to index); the project-scoped memory palace is **skipped** (no
+/// project to scope one to — `memory_sink_for` takes `Option<&Path>` and returns
+/// `None`); and the fs/bash tools, which need a real directory to be
+/// constructible at all, are rooted at an **ephemeral scratch dir** discarded
+/// when the run ends. The scratch root is the deliberate choice over dropping
+/// the tools entirely: an engineer with no file tools fails in confusing ways,
+/// whereas a throwaway root keeps chat/planning coherent while guaranteeing
+/// nothing lands in a project the operator never chose. It is logged at `warn`
+/// (stderr) so a projectless write is observable, never silent. `CLAUDE.md`,
+/// catch-up, skills, and the settings.json mode tier all already degrade to
+/// "absent" for a directory that has none, so they need no projectless
+/// special-casing — they simply find nothing in the scratch root.
 async fn run_and_record(
     registry: Arc<SessionRegistry>,
     llm: Arc<dyn LlmClientTrait>,
     params: TaskRunParams,
     cancel: Arc<AtomicBool>,
 ) {
+    let session_id = params.session_id.clone();
+
+    // Resolve the working root BEFORE anything else: every step below needs a
+    // real directory, and projectless has none. `_scratch` must stay alive for
+    // the whole run — dropping a `TempDir` deletes it — so it is bound here,
+    // not inside the `else` arm.
+    let _scratch = match params.binding.root() {
+        Some(_) => None,
+        None => match tempfile::tempdir() {
+            Ok(dir) => {
+                tracing::warn!(
+                    session_id = %session_id,
+                    scratch_root = %dir.path().display(),
+                    "projectless run: no project bound — file tools are rooted at an \
+                     ephemeral scratch dir that is DISCARDED when this run ends, and \
+                     nothing is indexed. Bind a project to persist work."
+                );
+                Some(dir)
+            }
+            Err(e) => {
+                finish_with_failure(
+                    &registry,
+                    &session_id,
+                    &format!("projectless scratch root error: {e}"),
+                )
+                .await;
+                return;
+            }
+        },
+    };
+    let work_root: PathBuf = match (params.binding.root(), &_scratch) {
+        (Some(root), _) => root.to_path_buf(),
+        (None, Some(dir)) => dir.path().to_path_buf(),
+        // Unreachable: the match above binds `_scratch` to `Some` for exactly
+        // the `None` root case, returning early on failure. Handled rather than
+        // `unwrap`ped per the crate's no-panic-in-library rule.
+        (None, None) => {
+            finish_with_failure(&registry, &session_id, "projectless scratch root missing").await;
+            return;
+        }
+    };
+
     // Trusty-search-first discovery (PR B): at task START, best-effort/detached,
     // ensure the working project is indexed so the delegated engineer's
     // `search`/`grep` tools are useful while this run proceeds. Fail-open,
     // non-blocking, and git-optional (git is a nice-to-have, not required) —
     // reuses the ONE shared helper (see
     // `run_task::ensure_project_indexed_in_background`) so the daemon and CLI
-    // paths can never diverge.
-    crate::run_task::ensure_project_indexed_in_background(params.project.clone());
+    // paths can never diverge. Gated on `should_index` so a projectless run
+    // never indexes its throwaway scratch root — note the gate is
+    // `should_index`, i.e. "is a project bound", NOT "is it git": a non-git
+    // directory DOES index (#2728/#2747).
+    if params.binding.should_index() {
+        crate::run_task::ensure_project_indexed_in_background(work_root.clone());
+    }
 
-    let session_id = params.session_id.clone();
     let transcript: SharedTranscript = Arc::new(Mutex::new(Vec::new()));
     let sink: Arc<dyn ToolEventSink> = Arc::new(SessionToolEventSink::new(
         Arc::clone(&registry),
@@ -201,7 +267,7 @@ async fn run_and_record(
         }
     };
 
-    let project_context = load_project_context(&params.project);
+    let project_context = load_project_context(&work_root);
     let pm_model = resolve_model(&pm_config, None);
     let engineer_model = resolve_engineer_model(&params);
 
@@ -214,19 +280,25 @@ async fn run_and_record(
     // DailyDriver mode only, register `use_skill` so the PM can lazily fetch
     // a skill's full body on demand. Parity never sees the catalog or the
     // tool — see `assemble_system_prompt_for_mode`'s docs.
-    let skills_catalog = daily_driver_skills_catalog(&params);
+    let skills_catalog = daily_driver_skills_catalog(&params, &work_root);
 
     let engineer_runner = build_engineer_runner(
         wrap_with_debug_capture(Arc::clone(&llm), ENGINEER_AGENT_NAME, debug_sink.as_ref()),
         &params,
-        project_context.clone(),
-        skills_catalog.as_ref().map(|(catalog, _)| catalog.clone()),
+        &work_root,
+        EngineerPromptContext {
+            project_context: project_context.clone(),
+            skills_catalog: skills_catalog.as_ref().map(|(catalog, _)| catalog.clone()),
+        },
         Arc::clone(&transcript),
         Arc::clone(&sink),
         Arc::clone(&cancel),
     );
 
-    let catchup_ctx = crate::catchup::pm_catchup_context(&params.project).await;
+    // Catch-up is already git-optional and fail-open (it degrades to `None` for
+    // a directory with no history), so the projectless scratch root needs no
+    // special-casing here — it simply yields no digest.
+    let catchup_ctx = crate::catchup::pm_catchup_context(&work_root).await;
     let pm_system = assemble_system_prompt_for_mode(
         params.mode,
         &pm_config,
@@ -267,7 +339,11 @@ async fn run_and_record(
     // calling it twice in one run just returns the same `Arc` both times.
     // Independent of the `pm_transcript`/`goals` fetch above (#2347) — the
     // two features don't touch each other's state, so either order works.
-    let memory_sink = registry.memory_sink_for(&session_id, &params.project);
+    // Projectless has no project to scope a memory palace to, so this yields
+    // `None` — see `memory_sink_for`'s `Option<&Path>` contract. The scratch
+    // root is deliberately NOT passed: deriving a palace id from a throwaway
+    // temp path would mint a fresh, orphaned palace on every projectless run.
+    let memory_sink = registry.memory_sink_for(&session_id, params.binding.root());
 
     // #2072: `finish_task` gives the PM a structured, schema-validated way to
     // signal completion alongside the delegate tool. (#2347) `set_goal`/
@@ -324,7 +400,7 @@ async fn run_and_record(
             // loop (`build_engineer_runner` below) and `run_task`'s legacy
             // one-shot/bake-off path both keep the default `None` — zero
             // behaviour change there, per #2346's explicit scope.
-            cadence: Some(resolve_cadence_config(&params.project)),
+            cadence: Some(resolve_cadence_config(&work_root)),
             ..AgentLoopConfig::default()
         },
         pm_llm,
@@ -423,15 +499,27 @@ async fn run_and_record(
 /// this function's arity under clippy's `too_many_arguments` gate; the
 /// resolver is pure given the same `params.deadline_secs`/env state, so a
 /// second call is not a correctness risk.
+///
+/// `work_root` is the directory the engineer's fs/bash tools are scoped to: the
+/// bound project root, or — when projectless — the run's ephemeral scratch dir
+/// (see [`run_and_record`]). It is passed explicitly rather than read off
+/// `params` because the scratch root does not exist until the run begins.
+/// [`EngineerPromptContext`] bundles the two prompt strings that already
+/// travelled together, keeping this function's arity under clippy's
+/// `too_many_arguments` gate now that `work_root` is threaded in.
 fn build_engineer_runner(
     llm: Arc<dyn LlmClientTrait>,
     params: &TaskRunParams,
-    project_context: Option<String>,
-    skills_catalog: Option<String>,
+    work_root: &Path,
+    prompt: EngineerPromptContext,
     transcript: SharedTranscript,
     sink: Arc<dyn ToolEventSink>,
     cancel: Arc<AtomicBool>,
 ) -> Arc<dyn AgentRunner> {
+    let EngineerPromptContext {
+        project_context,
+        skills_catalog,
+    } = prompt;
     let engineer_llm: Arc<dyn LlmClientTrait> = Arc::new(RecordingLlmClient::new(
         llm,
         ENGINEER_AGENT_NAME,
@@ -439,7 +527,7 @@ fn build_engineer_runner(
     ));
 
     let factory: Arc<dyn RegistryFactory> = Arc::new(ProjectToolFactory {
-        project: params.project.clone(),
+        project: work_root.to_path_buf(),
         mode: params.mode,
     });
 
@@ -457,7 +545,25 @@ fn build_engineer_runner(
     apply_engineer_model_override(Arc::new(runner), params)
 }
 
-/// Discover the (cheap, metadata-only) skill catalog for `params.project` and
+/// The two prompt-context strings the delegated engineer's system prompt is
+/// assembled from.
+///
+/// Why: both are `Option<String>`, are always produced and consumed together,
+/// and are positionally adjacent — bundling them removes a real
+/// easy-to-transpose-the-arguments hazard and keeps
+/// [`build_engineer_runner`]'s arity under clippy's `too_many_arguments` gate
+/// now that `work_root` must also be threaded through for projectless runs.
+/// What: `project_context` is the project's `CLAUDE.md` (`None` when absent —
+/// always the case projectless, since the scratch root has none);
+/// `skills_catalog` is the rendered `.claude/skills/` metadata catalog
+/// (`None` in `Parity` mode or when empty).
+/// Test: exercised via `task::executor::tests::*`'s engineer-runner paths.
+struct EngineerPromptContext {
+    project_context: Option<String>,
+    skills_catalog: Option<String>,
+}
+
+/// Discover the (cheap, metadata-only) skill catalog under `work_root` and
 /// build a resolver over it — but only in `HarnessMode::DailyDriver`.
 ///
 /// Why: #2069's scope note is explicit — "Parity mode should NOT
@@ -466,13 +572,18 @@ fn build_engineer_runner(
 /// inject the catalog into the prompt.
 /// What: Returns `None` for `HarnessMode::Parity` or when the project has no
 /// (or an empty) skill catalog; otherwise `Some((rendered_catalog,
-/// resolver))` — the resolver backs the `use_skill` tool registration.
+/// resolver))` — the resolver backs the `use_skill` tool registration. A
+/// projectless run passes its scratch root, which has no `.claude/skills/`, so
+/// this naturally yields `None` without a projectless special case.
 /// Test: `task::executor::tests::daily_driver_skills_catalog_*`.
-fn daily_driver_skills_catalog(params: &TaskRunParams) -> Option<(String, Arc<dyn SkillResolver>)> {
+fn daily_driver_skills_catalog(
+    params: &TaskRunParams,
+    work_root: &Path,
+) -> Option<(String, Arc<dyn SkillResolver>)> {
     if params.mode != HarnessMode::DailyDriver {
         return None;
     }
-    let skills_dir = locate_skills_dir(&params.project);
+    let skills_dir = locate_skills_dir(work_root);
     let resolver: Arc<dyn SkillResolver> = Arc::new(FsSkillResolver::new(skills_dir));
     let catalog = format_skill_catalog(&resolver.metadata());
     if catalog.is_empty() {

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -38,7 +38,8 @@ fn params(agents: &TempDir, project: &TempDir, session_id: &str) -> TaskRunParam
         session_id: session_id.to_string(),
         task: "do something".to_string(),
         agent_name: "pm".to_string(),
-        project: project.path().to_path_buf(),
+        binding: crate::binding::ProjectBinding::resolve(Some(project.path().to_path_buf()))
+            .expect("tempdir must bind"),
         agents_dir: agents.path().to_path_buf(),
         model_override: None,
         mode: crate::mode::HarnessMode::default(),
@@ -51,7 +52,7 @@ fn params(agents: &TempDir, project: &TempDir, session_id: &str) -> TaskRunParam
 #[tokio::test]
 async fn spawn_task_run_rejects_second_overlapping_run() {
     let registry = Arc::new(SessionRegistry::new());
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let agents = agents_dir();
     let project = tempfile::tempdir().expect("project tempdir");
     let llm: Arc<dyn LlmClientTrait> = Arc::new(EchoLlmClient::new());
@@ -100,7 +101,8 @@ fn resolve_engineer_model_falls_back_when_config_missing() {
         session_id: "s".to_string(),
         task: "do something".to_string(),
         agent_name: "pm".to_string(),
-        project: empty_agents.path().to_path_buf(),
+        binding: crate::binding::ProjectBinding::resolve(Some(empty_agents.path().to_path_buf()))
+            .expect("tempdir must bind"),
         agents_dir: empty_agents.path().to_path_buf(),
         model_override: None,
         mode: crate::mode::HarnessMode::default(),
@@ -128,7 +130,9 @@ fn daily_driver_skills_catalog_none_in_parity() {
     let mut p = params(&agents, &project, "s");
     p.mode = crate::mode::HarnessMode::Parity;
 
-    assert!(daily_driver_skills_catalog(&p).is_none());
+    assert!(
+        daily_driver_skills_catalog(&p, p.binding.root().expect("bound in this test")).is_none()
+    );
 }
 
 /// `daily_driver_skills_catalog` returns `None` when the project has no
@@ -141,7 +145,9 @@ fn daily_driver_skills_catalog_none_when_no_skills_dir() {
     let mut p = params(&agents, &project, "s");
     p.mode = crate::mode::HarnessMode::DailyDriver;
 
-    assert!(daily_driver_skills_catalog(&p).is_none());
+    assert!(
+        daily_driver_skills_catalog(&p, p.binding.root().expect("bound in this test")).is_none()
+    );
 }
 
 /// A project's `.claude/settings.json` `code_harness.cadence_turns` override
@@ -182,7 +188,9 @@ async fn settings_json_cadence_turns_override_reaches_resolver() {
         .expect("write settings.json");
 
         let p = params(&agents, &project, "s");
-        let cfg = crate::agent_loop::resolve_cadence_config(&p.project);
+        let cfg = crate::agent_loop::resolve_cadence_config(
+            p.binding.root().expect("bound in this test"),
+        );
         assert_eq!(cfg.cadence_turns, 3);
         assert_ne!(
             cfg.cadence_turns,
@@ -209,7 +217,9 @@ fn daily_driver_skills_catalog_some_when_skills_exist() {
     let mut p = params(&agents, &project, "s");
     p.mode = crate::mode::HarnessMode::DailyDriver;
 
-    let (catalog, resolver) = daily_driver_skills_catalog(&p).expect("catalog present");
+    let (catalog, resolver) =
+        daily_driver_skills_catalog(&p, p.binding.root().expect("bound in this test"))
+            .expect("catalog present");
     assert!(catalog.contains("demo: Demo skill"));
     assert_eq!(resolver.resolve("demo").as_deref(), Some("full body"));
 }
@@ -362,7 +372,7 @@ impl LlmClientTrait for DeadlineTriggerLlm {
 #[tokio::test]
 async fn spawn_task_run_deadline_exceeded_is_distinct_and_preserves_usage() {
     let registry = Arc::new(SessionRegistry::new());
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let agents = agents_dir();
     let project = tempfile::tempdir().expect("project tempdir");
 
@@ -464,7 +474,7 @@ async fn wait_for_terminal(registry: &SessionRegistry, id: &str) {
 #[tokio::test]
 async fn spawn_task_run_second_call_after_finish_appends_to_cumulative_transcript() {
     let registry = Arc::new(SessionRegistry::new());
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let agents = agents_dir();
     let project = tempfile::tempdir().expect("project tempdir");
 
@@ -572,7 +582,7 @@ impl LlmClientTrait for SchemaCapturingLlm {
 #[tokio::test]
 async fn session_path_registers_recall_session_tool() {
     let registry = Arc::new(SessionRegistry::new());
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let agents = agents_dir();
     let project = tempfile::tempdir().expect("project tempdir");
 

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+use crate::binding::ProjectBinding;
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 use crate::session::SessionRegistry;
 
@@ -39,20 +40,25 @@ use super::mock_llm::build_llm_client;
 ///
 /// Why: the one place that wires the method, mirroring
 /// `session::protocol::register`'s role for `session.*`.
-/// What: closes over `registry`, `project`, and `agents_dir` — all shared,
-/// cheap to clone (`Arc`/`PathBuf`) per call.
-/// Test: `task::protocol::tests::register_wires_task_run`.
+/// What: closes over `registry`, `binding`, and `agents_dir` — all shared,
+/// cheap to clone (`Arc`/`PathBuf`) per call. `binding` replaces what was a
+/// REQUIRED `project: PathBuf`: a `PathBuf` cannot express "no project", so the
+/// projectless state the shell's entry screen renders was unreachable — the
+/// daemon could not be started, let alone run a task, without one. It is now a
+/// [`ProjectBinding`], whose `None` variant is that state.
+/// Test: `task::protocol::tests::register_wires_task_run`,
+/// `task::protocol::tests::register_wires_task_run_projectless`.
 pub fn register(
     router: &mut Router,
     registry: Arc<SessionRegistry>,
-    project: PathBuf,
+    binding: ProjectBinding,
     agents_dir: PathBuf,
 ) {
     router.register("task.run", move |params: Value, _ctx: ConnectionContext| {
         let registry = Arc::clone(&registry);
-        let project = project.clone();
+        let binding = binding.clone();
         let agents_dir = agents_dir.clone();
-        async move { task_run(registry, params, project, agents_dir).await }
+        async move { task_run(registry, params, binding, agents_dir).await }
     });
 }
 
@@ -119,7 +125,7 @@ struct TaskRunRequestParams {
 async fn task_run(
     registry: Arc<SessionRegistry>,
     params: Value,
-    project: PathBuf,
+    binding: ProjectBinding,
     agents_dir: PathBuf,
 ) -> Result<Value, RpcError> {
     let p: TaskRunRequestParams = serde_json::from_value(params)
@@ -140,13 +146,13 @@ async fn task_run(
             let session = registry.create(
                 p.task_description.clone(),
                 Some(agent_name.clone()),
-                Some(project.display().to_string()),
+                binding.clone(),
             );
             session.id
         }
     };
 
-    let mode = crate::mode::resolve_mode(p.mode.as_deref(), &project);
+    let mode = crate::mode::resolve_mode(p.mode.as_deref(), binding.root());
     registry.set_mode(&session_id, mode)?;
 
     let llm = build_llm_client()?;
@@ -154,7 +160,7 @@ async fn task_run(
         session_id: session_id.clone(),
         task: p.task_description,
         agent_name,
-        project,
+        binding: binding.clone(),
         agents_dir,
         model_override: p.model_override,
         mode,
@@ -162,7 +168,12 @@ async fn task_run(
     };
     spawn_task_run(registry, llm, task_params)?;
 
-    Ok(json!({ "session_id": session_id, "status": "running", "mode": mode.as_str() }))
+    Ok(json!({
+        "session_id": session_id,
+        "status": "running",
+        "mode": mode.as_str(),
+        "binding": binding.to_json(),
+    }))
 }
 
 #[cfg(test)]
@@ -209,7 +220,7 @@ mod tests {
         register(
             &mut router,
             registry,
-            project.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             agents.path().to_path_buf(),
         );
 
@@ -231,6 +242,52 @@ mod tests {
         assert_eq!(resp.result.unwrap()["status"], "running");
     }
 
+    /// `task.run` must be callable with NO project bound at all (AC-16.1) —
+    /// the change that makes the shell's entry screen (7a) implementable. This
+    /// call was impossible before: `register` took a required `PathBuf`.
+    #[tokio::test]
+    async fn register_wires_task_run_projectless() {
+        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation; serialized by the lock above.
+        unsafe {
+            std::env::set_var(
+                super::super::mock_llm::MOCK_LLM_ENV,
+                super::super::mock_llm::MOCK_LLM_ECHO,
+            );
+        }
+        let registry = Arc::new(SessionRegistry::new());
+        let agents = agents_dir();
+        let mut router = Router::new();
+        register(
+            &mut router,
+            registry,
+            ProjectBinding::None,
+            agents.path().to_path_buf(),
+        );
+
+        let req = Request {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(json!(1)),
+            method: "task.run".to_string(),
+            params: Some(json!({"task_description": "just chat"})),
+        };
+        let resp = router.dispatch(req, &test_ctx()).await;
+        unsafe {
+            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+        }
+        assert!(
+            resp.error.is_none(),
+            "projectless task.run must succeed, got {:?}",
+            resp.error
+        );
+        let result = resp.result.expect("a result");
+        assert_eq!(result["status"], "running");
+        assert_eq!(
+            result["binding"]["state"], "projectless",
+            "task.run must report the projectless binding back to the caller: {result}"
+        );
+    }
+
     /// An empty `task_description` must map to `-32003 invalid_argument`.
     #[tokio::test]
     async fn task_run_rejects_empty_task_description() {
@@ -240,7 +297,7 @@ mod tests {
         let err = task_run(
             registry,
             json!({"task_description": "   "}),
-            project.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await
@@ -265,7 +322,7 @@ mod tests {
         let result = task_run(
             Arc::clone(&registry),
             json!({"task_description": "say hi"}),
-            project.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await;
@@ -314,7 +371,7 @@ mod tests {
         let value = task_run(
             Arc::clone(&registry),
             json!({"task_description": "say hi"}),
-            project.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await
@@ -338,7 +395,8 @@ mod tests {
         let value2 = task_run(
             Arc::clone(&registry2),
             json!({"task_description": "say hi"}),
-            project2.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project2.path().to_path_buf()))
+                .expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await
@@ -351,7 +409,8 @@ mod tests {
         let value3 = task_run(
             Arc::clone(&registry3),
             json!({"task_description": "say hi", "mode": "daily-driver"}),
-            project2.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project2.path().to_path_buf()))
+                .expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await
@@ -369,7 +428,8 @@ mod tests {
         let value4 = task_run(
             Arc::clone(&registry4),
             json!({"task_description": "say hi", "mode": "daily-driver"}),
-            project2.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project2.path().to_path_buf()))
+                .expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await
@@ -395,7 +455,7 @@ mod tests {
         let err = task_run(
             registry,
             json!({"task_description": "say hi", "session_id": "does-not-exist"}),
-            project.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await
@@ -415,14 +475,18 @@ mod tests {
             );
         }
         let registry = Arc::new(SessionRegistry::new());
-        let existing = registry.create("say hi".to_string(), None, None);
+        let existing = registry.create(
+            "say hi".to_string(),
+            None,
+            crate::binding::ProjectBinding::None,
+        );
         let agents = agents_dir();
         let project = tempfile::tempdir().expect("project tempdir");
 
         let result = task_run(
             Arc::clone(&registry),
             json!({"task_description": "say hi", "session_id": existing.id}),
-            project.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await;
@@ -458,7 +522,7 @@ mod tests {
         let first = task_run(
             Arc::clone(&registry),
             json!({"task_description": "say hi"}),
-            project.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await
@@ -481,7 +545,7 @@ mod tests {
         let second = task_run(
             Arc::clone(&registry),
             json!({"task_description": "say hi again", "session_id": session_id}),
-            project.path().to_path_buf(),
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             agents.path().to_path_buf(),
         )
         .await;

--- a/crates/trusty-code/src/task/sink.rs
+++ b/crates/trusty-code/src/task/sink.rs
@@ -107,7 +107,7 @@ mod tests {
     #[tokio::test]
     async fn forwards_started_finished_and_error() {
         let registry = Arc::new(SessionRegistry::new());
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         let sink = SessionToolEventSink::new(Arc::clone(&registry), session.id.clone());
         let mut events = crate::events::subscribe();
 

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -68,6 +68,34 @@ pub fn project_with_agents() -> tempfile::TempDir {
     tmp
 }
 
+/// A fake `$HOME` containing `~/.claude/agents/{pm,python-engineer}.toml`.
+///
+/// Why: a PROJECTLESS daemon has no project root to resolve `.claude/agents`
+/// from, so `ProjectBinding::agents_dir` falls back to the USER-level
+/// `~/.claude/agents`. Pointing the child's `$HOME` at a fixture lets the
+/// projectless e2e resolve real agent configs hermetically — and exercises that
+/// user-level fallback itself, rather than depending on whatever happens to be
+/// in the developer's real home directory.
+/// What: same two agent configs `project_with_agents` writes, rooted at
+/// `<tmp>/.claude/agents` and intended to be passed as the child's `HOME`.
+/// Test: used by `task_e2e::projectless_task_runs_end_to_end`.
+pub fn home_with_user_level_agents() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("home tempdir");
+    let agents = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents).expect("mkdir user-level agents");
+    std::fs::write(
+        agents.join("pm.toml"),
+        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"You are the PM. Delegate work to python-engineer.\"\n",
+    )
+    .expect("write pm.toml");
+    std::fs::write(
+        agents.join("python-engineer.toml"),
+        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n",
+    )
+    .expect("write python-engineer.toml");
+    tmp
+}
+
 /// A running `tcode serve --stdio` subprocess with line-buffered stdin/stdout.
 ///
 /// Why: the STDIO half of the API-driven e2e coverage — every call in
@@ -89,7 +117,7 @@ impl StdioSession {
     /// (logs aren't asserted on here), `kill_on_drop` so a panicking test
     /// still reaps the child instead of leaking a process.
     pub fn spawn() -> Self {
-        Self::spawn_inner(std::path::Path::new("."), false)
+        Self::spawn_inner(Some(std::path::Path::new(".")), false, None)
     }
 
     /// Spawn `tcode serve --stdio` rooted at `project`, with
@@ -98,15 +126,37 @@ impl StdioSession {
     /// requiring a live `OPENROUTER_API_KEY` — the mandatory offline
     /// black-box path for `tests/task_e2e.rs`.
     pub fn spawn_with_mock_llm(project: &std::path::Path) -> Self {
-        Self::spawn_inner(project, true)
+        Self::spawn_inner(Some(project), true, None)
     }
 
-    fn spawn_inner(project: &std::path::Path, mock_llm: bool) -> Self {
+    /// Spawn `tcode serve --stdio` with NO `--project` — a PROJECTLESS daemon.
+    ///
+    /// Why: this is the state screen 7a renders and the one that was previously
+    /// impossible to even start: `--project` was a required `PathBuf`. That the
+    /// daemon accepts this invocation at all is half of what the projectless
+    /// e2e proves.
+    /// What: omits `--project` entirely and points the child's `HOME` at
+    /// `home` so the user-level `~/.claude/agents` fallback resolves the
+    /// fixture's agent configs hermetically. `TCODE_MOCK_LLM=echo` as usual.
+    /// Test: `task_e2e::projectless_task_runs_end_to_end`.
+    pub fn spawn_projectless_with_mock_llm(home: &std::path::Path) -> Self {
+        Self::spawn_inner(None, true, Some(home))
+    }
+
+    fn spawn_inner(
+        project: Option<&std::path::Path>,
+        mock_llm: bool,
+        home: Option<&std::path::Path>,
+    ) -> Self {
         let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_tcode"));
-        cmd.arg("serve")
-            .arg("--project")
-            .arg(project)
-            .arg("--stdio");
+        cmd.arg("serve");
+        if let Some(project) = project {
+            cmd.arg("--project").arg(project);
+        }
+        cmd.arg("--stdio");
+        if let Some(home) = home {
+            cmd.env("HOME", home);
+        }
         if mock_llm {
             cmd.env(
                 trusty_code::task::mock_llm::MOCK_LLM_ENV,

--- a/crates/trusty-code/tests/task_e2e.rs
+++ b/crates/trusty-code/tests/task_e2e.rs
@@ -267,3 +267,124 @@ async fn task_run_then_get_transcript_exposes_turns_usage_and_cost() {
 
     daemon.shutdown_via_eof_and_assert_clean_exit().await;
 }
+
+// ── Projectless + the three binding states (spec DOC-39 §4.2/§5.5) ────────────
+
+/// **The Bob-mandated state, end to end.** A daemon started with NO `--project`
+/// must run a task to completion without panicking.
+///
+/// Why: this exact invocation was IMPOSSIBLE before — `tcode serve`'s
+/// `--project` was a required `PathBuf` and `task.run`'s project a required
+/// path, so the shell's entry screen (7a) had no reachable API state to render.
+/// Both halves are proven here: the daemon starts projectless, and `task.run`
+/// runs against it.
+/// What: spawns projectless with `$HOME` pointed at a user-level agents fixture
+/// (the documented projectless `agents_dir` fallback), runs a task to
+/// completion, and asserts the session reports the `projectless` binding state
+/// with a null root and finishes cleanly.
+#[tokio::test]
+async fn projectless_task_runs_end_to_end() {
+    let home = support::home_with_user_level_agents();
+    let mut daemon = StdioSession::spawn_projectless_with_mock_llm(home.path());
+
+    let session_id = run_task_to_completion(&mut daemon, "just chat, no project").await;
+
+    let status = daemon
+        .call(3, "session.status", json!({"session_id": session_id}))
+        .await;
+    assert!(status["error"].is_null(), "session.status failed: {status}");
+    let result = &status["result"];
+
+    assert_eq!(
+        result["binding"]["state"], "projectless",
+        "a daemon started without --project must report the projectless binding: {result}"
+    );
+    assert!(
+        result["binding"]["root"].is_null(),
+        "projectless must carry a null root: {result}"
+    );
+    assert!(
+        result["project"].is_null(),
+        "projectless must have no derived project label: {result}"
+    );
+    assert_eq!(
+        result["status"], "finished",
+        "a projectless run must reach `finished`, not fail: {result}"
+    );
+
+    daemon.shutdown_via_eof_and_assert_clean_exit().await;
+}
+
+/// A NON-GIT directory must BIND (state `directory`) — it must NOT be treated
+/// as projectless.
+///
+/// Why: this is the correction the spec makes to the design proposal, whose own
+/// text says binding happens "the moment work touches files in a git repo".
+/// That git-only rule would exclude the non-git working dirs (#2728) and temp
+/// dirs (#2747) we deliberately ship. `project_with_agents` returns a plain
+/// tempdir with no `.git`, so this asserts the shipped behaviour over the wire.
+#[tokio::test]
+async fn non_git_project_binds_as_directory_not_projectless() {
+    let project = project_with_agents();
+    let mut daemon = StdioSession::spawn_with_mock_llm(project.path());
+
+    let session_id = run_task_to_completion(&mut daemon, "say hi").await;
+    let status = daemon
+        .call(3, "session.status", json!({"session_id": session_id}))
+        .await;
+    let result = &status["result"];
+
+    assert_eq!(
+        result["binding"]["state"], "directory",
+        "a non-git dir MUST bind as `directory` — binding is not gated on .git: {result}"
+    );
+    assert_ne!(
+        result["binding"]["state"], "projectless",
+        "a non-git dir is NOT projectless: {result}"
+    );
+    assert!(
+        !result["binding"]["root"].is_null(),
+        "a bound non-git dir must carry its root: {result}"
+    );
+    assert!(
+        !result["project"].is_null(),
+        "a bound project must have a derived label: {result}"
+    );
+
+    daemon.shutdown_via_eof_and_assert_clean_exit().await;
+}
+
+/// A GIT repo must bind as `git_repo` — the third state, distinguished from a
+/// plain directory so git-only affordances can be offered (and, for the other
+/// two states, hidden rather than faked).
+#[tokio::test]
+async fn git_project_binds_as_git_repo() {
+    let project = project_with_agents();
+    let ok = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project.path())
+        .arg("init")
+        .output()
+        .expect("git init must run")
+        .status
+        .success();
+    assert!(ok, "git init must succeed");
+
+    let mut daemon = StdioSession::spawn_with_mock_llm(project.path());
+    let session_id = run_task_to_completion(&mut daemon, "say hi").await;
+    let status = daemon
+        .call(3, "session.status", json!({"session_id": session_id}))
+        .await;
+    let result = &status["result"];
+
+    assert_eq!(
+        result["binding"]["state"], "git_repo",
+        "a git worktree must bind as `git_repo`: {result}"
+    );
+    assert!(
+        !result["binding"]["root"].is_null(),
+        "a bound git repo must carry its root: {result}"
+    );
+
+    daemon.shutdown_via_eof_and_assert_clean_exit().await;
+}


### PR DESCRIPTION
## Why this is Phase 1, not later

Bob: **"We should support projectless mode."**

`task.run`'s `project` was a **required** `PathBuf` (`task/protocol.rs:48`), so a projectless workstream was **inexpressible** — the daemon could not even *start* without a project. The UI proposal's entry screen (7a, "Open a project" — a workstream that exists BEFORE a project is chosen) was therefore **literally unimplementable**: every other Phase-1 surface renders inside a shell whose entry state did not exist. This is a blocking API change, not a product nicety.

## The two disagreeing surfaces — what I did

| Surface | Before | After |
|---|---|---|
| `task.run` | `project: PathBuf` — **required**, a real path | `ProjectBinding` (a `register()` arg, so **JSON-RPC params are unchanged**) |
| `session.create` | `project: Option<String>` — an **untyped free-form label**: not validated, not bound, not enumerable | the **same** `ProjectBinding`, resolved from a project **path** |

A label that cannot be indexed and a path that cannot be omitted are two halves of one missing object. They now converge on one typed `binding::ProjectBinding`.

**`session.create`'s label, explicitly:** it is now a **path**. A decorative label (`"my-app"`) that names no directory returns `-32003 invalid_argument`. Erroring is the point — silently accepting a "project" that binds and indexes nothing is the exact failure this reconciliation ends, and a caller who learns their project was never real is strictly better off than one who never finds out. Omitting `project` remains valid and means **projectless**. `Session.project` survives as a display label but is now **derived** from the binding (`ProjectBinding::label`), so the two can never again disagree.

## The three binding states

| State | Indexing | Git affordances |
|---|---|---|
| `projectless` — no directory bound (chat/planning) | none | none |
| `directory` — bound, **non-git** (#2728/#2747) | **yes** | none |
| `git_repo` — bound git worktree | yes | full |

**The proposal's own text is wrong and I did not implement it.** It says binding happens "the moment work touches files in a git repo". That git-only rule contradicts shipped behavior — it would exclude the non-git working dirs (#2728) and OS temp dirs (#2747) we deliberately support. **A non-git directory BINDS and INDEXES.** The git/non-git split decides only which git *affordances* are offered, never whether the project binds. `binding::tests::non_git_dir_is_bound_and_indexes` is the test that fails if anyone reintroduces the gate.

Git detection is now a **single** implementation (`binding::is_git_worktree`) which `run_task::diff` delegates to — two independent probes could disagree and produce a `GitRepo` binding whose diff silently took the non-git file-map path.

## How far I took bind-later, and why

**Not implemented; the hook is specified instead.** Bind-on-first-file-touch needs the fs tools to report upward into a **workstream domain object** that the spec explicitly defers out of Phase 1 (§6.3 — "the largest item in the spec"). Building it now would mean designing that object under a Phase-1 label. `ProjectBinding` is the object a future `session.bind` returns, so nothing is painted into a corner: bind-later becomes "swap the binding + re-point the work root". Today the binding is established at daemon startup (`tcode serve --project` is now optional), which is the smallest change that makes 7a implementable.

**Clone-from-URL:** out of scope per the spec (§6.3); noted as a follow-up.

## What breaks when there is no project — traced

Each of the three assumptions gets a **defined behaviour, never a panic**:

- **Indexing** (`run_task/mod.rs:100-107`, spawned unconditionally at `executor.rs:178`) — now gated on `should_index()`. Note the gate is *"is a project bound"*, **not** *"is it git"*.
- **Memory palace** — `memory_sink_for` takes `Option<&Path>` and returns `None`. The scratch root is deliberately **not** substituted: deriving a palace id from a throwaway temp path would mint a fresh **orphaned palace on every projectless run**.
- **Work root** — fs/bash tools need a real directory to be constructible at all, so a projectless run gets an **ephemeral scratch dir**, discarded at run end and logged at `warn` (stderr) so a projectless write is *observable, not silent*. Chosen over dropping the tools entirely: an engineer with no file tools fails confusingly, whereas a throwaway root keeps chat/planning coherent while guaranteeing nothing lands in a project the operator never chose.
- **Diff** — `capture_snapshot` already falls back to a file-content map when not in git, and lives only on the CLI `run-task` path (`run_task/mod.rs:298`), which keeps a required project. Untouched.
- **CLAUDE.md, catch-up, skills, settings.json mode tier** — all already degrade to "absent" for a directory that has none, so they needed **no** projectless special-casing.

## API compatibility

- **`task.run`'s JSON-RPC params are UNCHANGED** — `project` was a `register()` argument (daemon-scoped), never a request field. **No JSON-RPC caller breaks.** Response gains a `binding` object.
- **Rust API (breaking):** `serve::{build_router, run_stdio, run_http}`, `task::protocol::register`, `TaskRunParams.project` → `.binding`, `SessionRegistry::create`, `mode::resolve_mode`.
- **`session.create` wire (breaking, deliberate):** see above.
- `Session.binding` is `#[serde(default)]`, so an older payload without it reads back as projectless.

trusty-code 0.2.0 is live on crates.io. Being breaking at the Rust-API and `session.create`-semantics level, **the next release must be 0.3.0** (pre-1.0: minor = breaking), not a patch bump. Left at 0.2.0 with an `[Unreleased]` CHANGELOG entry stating this.

## Gates

`cargo build` / `clippy -D warnings` / `fmt --check` / `check_line_cap.sh` all clean. Full suite green: **979 passed; 0 failed; 4 ignored** plus all integration suites.

**Flake ownership — checked, not assumed.** I am in #2843's blast radius (those tests assert on `report.exit`/`report.diff`). Every failure observed across runs was confined to exactly the three named flakes. I built a **clean `origin/main` worktree with none of my code** and looped it: `exit_code_reflects_run_failure` and `repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap` **failed 3/8 runs there too**. They also pass 6/6 in isolation, and the failing test drives `execute_run_task` with a `ScriptedLlm` and never touches `ProjectBinding` — my only change reaching that path is `is_git_repo` delegating to a byte-identical implementation, which cannot flip `RunFailure`→`Partial`. **Not my regression.**

## Tests

- `projectless_task_runs_end_to_end` — daemon spawned with **no `--project`** (previously impossible), runs to `finished`, reports `projectless`/null root. `$HOME` points at a user-level agents fixture, which also exercises the `~/.claude/agents` fallback.
- `non_git_project_binds_as_directory_not_projectless` — the proposal's bug, asserted against.
- `git_project_binds_as_git_repo` — real `git init`.
- Plus `binding::tests::*` (17), the `session.create` reconciliation, projectless palace/mode/round-trip.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools