### PR TITLE
feat(trusty-code): attributed + structured tool telemetry events (UI Phase-1 API)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -150,6 +150,54 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   from context, not from the record*. Emitted only by the PM's persistent-session
   loop — cadence's PM-only gating (`AgentLoopConfig.cadence` defaults `None`) is
   unchanged, so a delegated engineer loop never emits.
+- **Agent attribution on every tool event (UI Phase-1 API)** — `ToolStarted`,
+  `ToolFinished`, and `ToolError` now carry an `agent` field naming the agent
+  that dispatched the call. Previously a client could only guess whether a tool
+  call came from the PM or a delegated engineer by interleaving the event stream
+  against `AgentSpawned`/`AgentDone` ordering — fragile inference that breaks as
+  soon as their calls overlap, and the reason the UI could not answer "which
+  agent drove this change?". The name is a per-call PARAMETER on
+  `agent_loop::ToolEventSink` rather than sink state, because ONE
+  `Arc<dyn ToolEventSink>` is shared by the PM's loop and every delegated
+  sub-agent's loop (`task::executor::run_and_record` clones the same handle into
+  both), so a sink carrying its own name could only ever report one of them. The
+  dispatching `AgentLoop` is the only layer that knows its own identity, so it
+  passes it per call — declared via the new `AgentLoop::with_agent`, wired at
+  both production sites (PM: `params.agent_name`, default `"pm"`; delegated
+  sub-agents: the runner's `agent_name`). `agent` is the agent NAME, matching the
+  key the rest of the taxonomy already uses (`AgentSpawned.agent`,
+  `PmDelegating.agent`, `LlmRequested.agent_name`), so the UI can join them
+  directly; loops that declare no agent emit the documented
+  `events::UNATTRIBUTED_AGENT` (`"unknown"`) sentinel rather than an empty string
+- **`search_performed` event — structured search telemetry** — a new `Event`
+  variant carrying `{agent, lane, query, hit_count, latency_ms}`, emitted by
+  `search_code` ALONGSIDE (never instead of) the generic tool events, so existing
+  consumers see an unchanged stream. `lane` is the lane trusty-search ACTUALLY
+  served, not the mode the model requested: a `semantic`/`symbol` query against a
+  still-building index transparently retries on the lexical lane
+  ([#2783](https://github.com/bobmatnyc/trusty-tools/issues/2783)) and now
+  reports `lane: "lexical"` rather than claiming a semantic search that never
+  ran. `hit_count` is `null` when the payload shape could not be counted — never
+  a misleading `0`, which would read as "no hits". The fail-open paths (absent
+  daemon, no index) attach no telemetry at all: they never reached a lane, so
+  there is no search to report
+- **`memory_recalled` event — structured recall telemetry with the `injected`
+  flag** — a new `Event` variant carrying
+  `{agent, query, results: [{score, injected}]}`, emitted by `recall_session`.
+  `injected: false` means exactly "recalled but not entered into context": the
+  tool drops WHOLE lowest-scored results to fit its token budget, and that
+  decision — plus every result's score — previously died inside the tool's
+  rendered text. This is what lets a UI show which memories reached the model and
+  which were held back
+- **`ToolResult::with_telemetry` / `ToolResult::telemetry`** — the seam that
+  carries a tool's structured account (`tools::telemetry::ToolTelemetry`) to the
+  agent loop, which forwards it to the new `ToolEventSink::tool_telemetry` hook.
+  Tools stay pure functions of their arguments — no sink, no session, no agent
+  name — so attribution keeps ONE source of truth and each tool stays unit-
+  testable without a bus. `ToolResult::Success` is now a struct variant
+  (`{text, telemetry}`); `ToolResult::ok`/`content`/`is_error` are unchanged, so
+  no tool call site moved. `tool_telemetry` has a default no-op body, leaving
+  every pre-existing sink impl compiling untouched
 - **Build provenance in `--version` and `tcode_report.json`** — `tcode --version`
   now prints the git SHA and commit date alongside the semver
   (`tcode 0.2.0 (b20adfca 2026-07-16)`), and `tcode_report.json` carries a

--- a/crates/trusty-code/src/agent_loop/budget_tests.rs
+++ b/crates/trusty-code/src/agent_loop/budget_tests.rs
@@ -32,9 +32,9 @@ impl BudgetSink {
 
 #[async_trait]
 impl ToolEventSink for BudgetSink {
-    async fn tool_started(&self, _call_id: &str, _tool: &str, _args_preview: &str) {}
-    async fn tool_finished(&self, _c: &str, _t: &str, _s: bool, _r: &str) {}
-    async fn tool_error(&self, _call_id: &str, _tool: &str, _error: &str) {}
+    async fn tool_started(&self, _agent: &str, _call_id: &str, _tool: &str, _args_preview: &str) {}
+    async fn tool_finished(&self, _agent: &str, _c: &str, _t: &str, _s: bool, _r: &str) {}
+    async fn tool_error(&self, _agent: &str, _call_id: &str, _tool: &str, _error: &str) {}
 
     async fn context_budget(&self, snapshot: &ContextBudgetSnapshot) {
         self.snapshots

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -204,6 +204,11 @@ pub struct AgentLoop {
     llm: Arc<dyn LlmClientTrait>,
     registry: Arc<ToolRegistry>,
     sink: Option<Arc<dyn ToolEventSink>>,
+    /// (UI Phase 1) The name of the agent this loop runs as, stamped on every
+    /// tool event so a UI can tell the PM's calls from a delegated
+    /// engineer's. `None` falls back to `events::UNATTRIBUTED_AGENT` — see
+    /// [`Self::with_agent`].
+    agent: Option<String>,
     cancel: Option<Arc<AtomicBool>>,
     stop_signal: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
     finish_gate: Option<FinishGate>,
@@ -241,6 +246,7 @@ impl AgentLoop {
             llm,
             registry,
             sink: None,
+            agent: None,
             cancel: None,
             stop_signal: None,
             finish_gate: None,
@@ -253,10 +259,43 @@ impl AgentLoop {
     /// Why: Lets a daemon-driven run make its tool activity observable to a
     /// `session.attach`ed client without forking the dispatch loop.
     /// What: Builder-style setter; returns `self` for chaining.
-    /// Test: `agent_loop::tests::sink_receives_started_then_finished_in_order`.
+    /// Test: `agent_loop::tests::sink_events::sink_receives_started_then_finished_in_order`.
     pub fn with_tool_event_sink(mut self, sink: Arc<dyn ToolEventSink>) -> Self {
         self.sink = Some(sink);
         self
+    }
+
+    /// Declare which agent this loop runs as, for tool-event attribution
+    /// (UI Phase 1).
+    ///
+    /// Why: one `ToolEventSink` is shared by the PM's loop and every
+    /// delegated sub-agent's loop, so the sink cannot know who is calling it
+    /// — only the loop does. Without this, a UI can attribute a tool call
+    /// only by interleaving the event stream against `AgentSpawned`/
+    /// `AgentDone` ordering, which is exactly the fragile inference this
+    /// ticket removes.
+    /// What: `name` should match the name the rest of the taxonomy already
+    /// uses for this agent (`LlmRequested.agent_name`, `AgentSpawned.agent`,
+    /// `PmDelegating.agent`) so the UI can join them; the two production
+    /// delegation sites pass `params.agent_name` (PM) and the runner's
+    /// `agent_name` (sub-agent) for exactly that reason. Unset loops emit
+    /// `events::UNATTRIBUTED_AGENT`.
+    /// Test: `agent_loop::tests::sink_events::sink_events_are_attributed_to_the_agent`,
+    /// `agent_loop::tests::sink_events::unattributed_loop_emits_unknown_agent`.
+    pub fn with_agent(mut self, name: impl Into<String>) -> Self {
+        self.agent = Some(name.into());
+        self
+    }
+
+    /// This loop's attribution name, or `events::UNATTRIBUTED_AGENT`.
+    ///
+    /// Why: every sink call needs it; centralising the fallback keeps the
+    /// sentinel in one place.
+    /// Test: `agent_loop::tests::sink_events::unattributed_loop_emits_unknown_agent`.
+    fn agent_name(&self) -> &str {
+        self.agent
+            .as_deref()
+            .unwrap_or(crate::events::UNATTRIBUTED_AGENT)
     }
 
     /// Attach a cancellation flag checked once per turn boundary (#2056).
@@ -559,8 +598,8 @@ impl AgentLoop {
     /// single run's stderr.
     /// Test: `agent_loop::tests::recoverable_tool_error_continues`,
     /// `agent_loop::tests::malformed_tool_arguments_report_recoverable_error_and_loop_continues`,
-    /// `sink_receives_started_then_finished_in_order`,
-    /// `sink_receives_tool_error_for_fatal_failures`,
+    /// `tests::sink_events::sink_receives_started_then_finished_in_order`,
+    /// `tests::sink_events::sink_receives_tool_error_for_fatal_failures`,
     /// `explicit_finish_task_terminates_loop_with_structured_summary`,
     /// `malformed_finish_task_repairs_then_terminates`,
     /// `finish_task_missing_required_field_is_recoverable_not_terminal`,
@@ -590,7 +629,8 @@ impl AgentLoop {
             };
 
             if let Some(sink) = &self.sink {
-                sink.tool_started(&call.id, tool, &args.to_string()).await;
+                sink.tool_started(self.agent_name(), &call.id, tool, &args.to_string())
+                    .await;
             }
 
             // #2682: short-circuit a redundant full-suite re-run BEFORE
@@ -634,7 +674,7 @@ impl AgentLoop {
             }
 
             if let Some(sink) = &self.sink {
-                notify_result(sink.as_ref(), &call.id, tool, &result).await;
+                notify_result(sink.as_ref(), self.agent_name(), &call.id, tool, &result).await;
             }
 
             transcript.push_tool_result(&call.id, tool, result.content());
@@ -668,9 +708,10 @@ impl AgentLoop {
     ) {
         let message = error.to_string();
         if let Some(sink) = &self.sink {
-            sink.tool_started(call_id, tool, "<invalid-arguments>")
+            let agent = self.agent_name();
+            sink.tool_started(agent, call_id, tool, "<invalid-arguments>")
                 .await;
-            sink.tool_error(call_id, tool, &message).await;
+            sink.tool_error(agent, call_id, tool, &message).await;
         }
         transcript.push_tool_result(call_id, tool, &message);
     }
@@ -1045,14 +1086,30 @@ fn schema_tool_name(schema: &Value) -> &str {
 /// distinguished by `success`, matching #2055's `ToolFinished{success}`/
 /// `ToolError` taxonomy split.
 /// What: `is_fatal()` -> `tool_error`; otherwise -> `tool_finished(!is_error())`.
-/// Test: `agent_loop::tests::sink_receives_started_then_finished_in_order`,
-/// `sink_receives_tool_error_for_fatal_failures`.
-async fn notify_result(sink: &dyn ToolEventSink, call_id: &str, tool: &str, result: &ToolResult) {
+/// (UI Phase 1) Any structured telemetry the tool attached to its result is
+/// then forwarded via `tool_telemetry` — AFTER the generic hook, and never in
+/// place of it, so existing consumers see the exact same stream they always
+/// did and the structured event is purely additive. `agent` attributes every
+/// hook to the dispatching loop's agent.
+/// Test: `agent_loop::tests::sink_events::sink_receives_started_then_finished_in_order`,
+/// `tests::sink_events::sink_receives_tool_error_for_fatal_failures`,
+/// `tests::sink_events::sink_receives_tool_telemetry_with_agent`.
+async fn notify_result(
+    sink: &dyn ToolEventSink,
+    agent: &str,
+    call_id: &str,
+    tool: &str,
+    result: &ToolResult,
+) {
     if result.is_fatal() {
-        sink.tool_error(call_id, tool, result.content()).await;
-    } else {
-        sink.tool_finished(call_id, tool, !result.is_error(), result.content())
+        sink.tool_error(agent, call_id, tool, result.content())
             .await;
+    } else {
+        sink.tool_finished(agent, call_id, tool, !result.is_error(), result.content())
+            .await;
+    }
+    if let Some(telemetry) = result.telemetry() {
+        sink.tool_telemetry(agent, call_id, tool, telemetry).await;
     }
 }
 

--- a/crates/trusty-code/src/agent_loop/sink.rs
+++ b/crates/trusty-code/src/agent_loop/sink.rs
@@ -18,6 +18,8 @@
 
 use async_trait::async_trait;
 
+use crate::tools::telemetry::ToolTelemetry;
+
 /// One turn's working-context budget measurement, handed to
 /// [`ToolEventSink::context_budget`].
 ///
@@ -53,24 +55,39 @@ pub struct ContextBudgetSnapshot {
 /// Why: The only way to make an agent loop's tool activity observable to an
 /// external subscriber (a `session.attach`ed client) without forking the loop
 /// or the tool registry.
-/// What: Three hooks, one per #2055 taxonomy kind; `call_id` is the
-/// `ToolCall::id` the model assigned, correlating start/finish/error for the
-/// same invocation. All are `&self` (not `&mut self`) so a sink can be shared
-/// as `Arc<dyn ToolEventSink>` across a PM loop and every delegated sub-agent
-/// loop.
+/// What: Four hooks; `call_id` is the `ToolCall::id` the model assigned,
+/// correlating every hook for the same invocation. All are `&self` (not
+/// `&mut self`) so a sink can be shared as `Arc<dyn ToolEventSink>` across a
+/// PM loop and every delegated sub-agent loop.
+///
+/// (UI Phase 1) Every hook takes `agent` — the name of the agent whose loop
+/// is dispatching. It is a PARAMETER rather than sink state precisely BECAUSE
+/// one sink instance is shared by the PM's loop and every delegated
+/// sub-agent's loop (see `task::executor::run_and_record`, which clones one
+/// `Arc` into both): a sink that stored its own agent name could only ever
+/// report one of them. The calling `AgentLoop` is the only layer that knows
+/// which agent it is, so it passes its identity per call — see
+/// `AgentLoop::with_agent`.
 /// Test: `crate::task::sink::tests::*`.
 #[async_trait]
 pub trait ToolEventSink: Send + Sync {
     /// A tool invocation is about to run.
-    async fn tool_started(&self, call_id: &str, tool: &str, args_preview: &str);
+    async fn tool_started(&self, agent: &str, call_id: &str, tool: &str, args_preview: &str);
 
     /// A tool invocation completed (successfully or with a recoverable error —
     /// `success` distinguishes the two). Use [`Self::tool_error`] instead for an
     /// exceptional (non-recoverable) failure.
-    async fn tool_finished(&self, call_id: &str, tool: &str, success: bool, result_preview: &str);
+    async fn tool_finished(
+        &self,
+        agent: &str,
+        call_id: &str,
+        tool: &str,
+        success: bool,
+        result_preview: &str,
+    );
 
     /// A tool invocation raised an exceptional (non-recoverable) error.
-    async fn tool_error(&self, call_id: &str, tool: &str, error: &str);
+    async fn tool_error(&self, agent: &str, call_id: &str, tool: &str, error: &str);
 
     /// The working-context budget was measured at a turn boundary (epic
     /// #2343).
@@ -88,5 +105,25 @@ pub trait ToolEventSink: Send + Sync {
     /// implementation compiles and behaves exactly as before.
     async fn context_budget(&self, snapshot: &ContextBudgetSnapshot) {
         let _ = snapshot;
+    }
+
+    /// A tool reported structured telemetry about what it actually did
+    /// (UI Phase 1) — a real search lane, or which recalled memories entered
+    /// context. Fires IN ADDITION to [`Self::tool_finished`], never instead
+    /// of it, so existing consumers of the generic tool events are unaffected.
+    ///
+    /// Why: a default no-op body keeps every pre-existing sink impl (and
+    /// every test double) compiling unchanged — only sinks that actually
+    /// serve the UI need to override it.
+    /// What: `telemetry` is the tool's own account, carried on its
+    /// `ToolResult`; see `crate::tools::telemetry`.
+    /// Test: `crate::task::sink::tests::forwards_search_and_recall_telemetry`.
+    async fn tool_telemetry(
+        &self,
+        _agent: &str,
+        _call_id: &str,
+        _tool: &str,
+        _telemetry: &ToolTelemetry,
+    ) {
     }
 }

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1216,6 +1216,10 @@ mod batched_multi_tool;
 // live in a focused child module to keep this file under its SLOC cap.
 mod write_batch;
 
+// (UI Phase 1) Agent-attribution + structured-telemetry forwarding guards live
+// in a focused child module to keep this file under its SLOC cap.
+mod sink_events;
+
 /// Live OpenRouter test: trivial task through the real client + a real tool.
 ///
 /// Why: End-to-end confidence that the loop drives a real model to a final
@@ -1274,115 +1278,7 @@ async fn agent_loop_live() {
     );
 }
 
-// ── #2056: ToolEventSink + cancellation ─────────────────────────────────────────
-
-/// A `ToolEventSink` that records every call as a tagged string, in order.
-///
-/// Why: The sink's whole purpose is call-order + argument fidelity; recording
-/// each hook as `"started:name"` / `"finished:name:success"` / `"error:name"`
-/// lets a test assert the exact sequence with one `Vec<String>` comparison.
-struct RecordingSink {
-    calls: Mutex<Vec<String>>,
-}
-
-impl RecordingSink {
-    fn new() -> Self {
-        Self {
-            calls: Mutex::new(Vec::new()),
-        }
-    }
-
-    fn calls(&self) -> Vec<String> {
-        self.calls.lock().expect("lock poisoned").clone()
-    }
-}
-
-#[async_trait]
-impl ToolEventSink for RecordingSink {
-    async fn tool_started(&self, call_id: &str, tool: &str, _args_preview: &str) {
-        self.calls
-            .lock()
-            .expect("lock poisoned")
-            .push(format!("started:{tool}:{call_id}"));
-    }
-
-    async fn tool_finished(&self, call_id: &str, tool: &str, success: bool, _result_preview: &str) {
-        self.calls
-            .lock()
-            .expect("lock poisoned")
-            .push(format!("finished:{tool}:{call_id}:{success}"));
-    }
-
-    async fn tool_error(&self, call_id: &str, tool: &str, _error: &str) {
-        self.calls
-            .lock()
-            .expect("lock poisoned")
-            .push(format!("error:{tool}:{call_id}"));
-    }
-}
-
-/// A sink must observe `tool_started` then `tool_finished(success=true)`, in
-/// that order, for a successful dispatch.
-///
-/// Why: This is the exact sequence #2056's daemon-driven task execution relies
-/// on to stream live `tool_started`/`tool_finished` events to an attached
-/// client — a regression here would silently break that observability.
-/// What: Script [tool_call, stop]; attach a `RecordingSink`; assert its call
-/// log is exactly `["started:echo:call-1", "finished:echo:call-1:true"]`.
-/// Test: this test.
-#[tokio::test]
-async fn sink_receives_started_then_finished_in_order() {
-    let llm = Arc::new(ScriptedLlm::from_json(&[
-        tool_call_response("call-1", "hi"),
-        stop_response("done"),
-    ]));
-    let registry = registry_with_echo(false);
-    let sink = Arc::new(RecordingSink::new());
-
-    let agent =
-        make_loop(llm, registry, AgentLoopConfig::default()).with_tool_event_sink(sink.clone());
-    agent
-        .run("sys", "task")
-        .await
-        .expect("loop should complete");
-
-    assert_eq!(
-        sink.calls(),
-        vec!["started:echo:call-1", "finished:echo:call-1:true"]
-    );
-}
-
-/// A recoverable `ToolResult::Error` must notify `tool_finished(success=false)`,
-/// NOT `tool_error` — only a fatal/non-recoverable error is exceptional.
-///
-/// Why: #2055's taxonomy reserves `tool_error` for exceptional failures (tool
-/// crash/timeout); an ordinary recoverable tool error (the model can retry) is
-/// still a "the tool finished, unsuccessfully" event, not an exceptional one.
-/// What: Script a tool call against the failing echo tool (`EchoTool { fail:
-/// true }`, which returns `ToolResult::err` — recoverable); assert the sink saw
-/// `finished:...:false`, never `error:...`.
-/// Test: this test.
-#[tokio::test]
-async fn sink_recoverable_error_is_finished_not_error() {
-    let llm = Arc::new(ScriptedLlm::from_json(&[
-        tool_call_response("call-1", "hi"),
-        stop_response("done"),
-    ]));
-    let registry = registry_with_echo(true);
-    let sink = Arc::new(RecordingSink::new());
-
-    let agent =
-        make_loop(llm, registry, AgentLoopConfig::default()).with_tool_event_sink(sink.clone());
-    agent
-        .run("sys", "task")
-        .await
-        .expect("loop should complete");
-
-    assert_eq!(
-        sink.calls(),
-        vec!["started:echo:call-1", "finished:echo:call-1:false"]
-    );
-}
+// ── #2056: cancellation (the ToolEventSink guards live in `tests::sink_events`) ──
 
 /// A set cancellation flag must abort the loop with `AgentLoopError::Cancelled`
 /// before the next turn's LLM call — never mid-tool-call.

--- a/crates/trusty-code/src/agent_loop/tests/sink_events.rs
+++ b/crates/trusty-code/src/agent_loop/tests/sink_events.rs
@@ -1,0 +1,373 @@
+//! (UI Phase 1) `ToolEventSink` guards: call ordering, agent attribution, and
+//! structured-telemetry forwarding.
+//!
+//! Why: the UI's core bet is that a change is explained by the agent, the
+//! searches, and the memories that produced it. That needs two things this
+//! module pins: every tool event must name WHICH agent dispatched it (the PM
+//! and a delegated engineer share ONE `ToolEventSink`, so ordering-based
+//! inference is not enough), and a tool's structured telemetry must reach the
+//! sink ADDITIVELY — the generic tool events must keep firing unchanged so
+//! existing consumers are untouched. Split into this focused child module
+//! (from `agent_loop::tests`) to keep the parent file under its SLOC cap while
+//! reusing its scripted-LLM harness verbatim via `use super::*`.
+//! What: owns `RecordingSink` (every sink assertion in the crate's loop tests
+//! now lives here) and reuses the parent module's `ScriptedLlm`,
+//! `registry_with_echo`, and `make_loop` helpers via `use super::*`.
+//! Test: this module is itself the test surface.
+
+use super::*;
+
+/// A `ToolEventSink` that records every call as a tagged string, in order.
+///
+/// Why: The sink's whole purpose is call-order + argument fidelity; recording
+/// each hook as `"started:agent:tool:call_id"` /
+/// `"finished:agent:tool:call_id:success"` / `"error:agent:tool:call_id"` /
+/// `"telemetry:agent:tool:call_id:kind"` lets a test assert the exact
+/// sequence AND (UI Phase 1) its attribution with one `Vec<String>`
+/// comparison.
+struct RecordingSink {
+    calls: Mutex<Vec<String>>,
+}
+
+impl RecordingSink {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn calls(&self) -> Vec<String> {
+        self.calls.lock().expect("lock poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl ToolEventSink for RecordingSink {
+    async fn tool_started(&self, agent: &str, call_id: &str, tool: &str, _args_preview: &str) {
+        self.calls
+            .lock()
+            .expect("lock poisoned")
+            .push(format!("started:{agent}:{tool}:{call_id}"));
+    }
+
+    async fn tool_finished(
+        &self,
+        agent: &str,
+        call_id: &str,
+        tool: &str,
+        success: bool,
+        _result_preview: &str,
+    ) {
+        self.calls
+            .lock()
+            .expect("lock poisoned")
+            .push(format!("finished:{agent}:{tool}:{call_id}:{success}"));
+    }
+
+    async fn tool_error(&self, agent: &str, call_id: &str, tool: &str, _error: &str) {
+        self.calls
+            .lock()
+            .expect("lock poisoned")
+            .push(format!("error:{agent}:{tool}:{call_id}"));
+    }
+
+    async fn tool_telemetry(
+        &self,
+        agent: &str,
+        call_id: &str,
+        tool: &str,
+        telemetry: &crate::tools::telemetry::ToolTelemetry,
+    ) {
+        let kind = match telemetry {
+            crate::tools::telemetry::ToolTelemetry::Search(t) => format!("search:{}", t.lane),
+            crate::tools::telemetry::ToolTelemetry::Recall(t) => {
+                format!("recall:{}", t.results.iter().filter(|r| r.injected).count())
+            }
+        };
+        self.calls
+            .lock()
+            .expect("lock poisoned")
+            .push(format!("telemetry:{agent}:{tool}:{call_id}:{kind}"));
+    }
+}
+
+/// A sink must observe `tool_started` then `tool_finished(success=true)`, in
+/// that order, for a successful dispatch.
+///
+/// Why: This is the exact sequence #2056's daemon-driven task execution relies
+/// on to stream live `tool_started`/`tool_finished` events to an attached
+/// client — a regression here would silently break that observability.
+/// What: Script [tool_call, stop]; attach a `RecordingSink`; assert its call
+/// log is exactly `["started:unknown:echo:call-1",
+/// "finished:unknown:echo:call-1:true"]` — `unknown` because this loop sets
+/// no agent (see `unattributed_loop_emits_unknown_agent`).
+/// Test: this test.
+#[tokio::test]
+async fn sink_receives_started_then_finished_in_order() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("call-1", "hi"),
+        stop_response("done"),
+    ]));
+    let registry = registry_with_echo(false);
+    let sink = Arc::new(RecordingSink::new());
+
+    let agent =
+        make_loop(llm, registry, AgentLoopConfig::default()).with_tool_event_sink(sink.clone());
+    agent
+        .run("sys", "task")
+        .await
+        .expect("loop should complete");
+
+    assert_eq!(
+        sink.calls(),
+        vec![
+            "started:unknown:echo:call-1",
+            "finished:unknown:echo:call-1:true"
+        ]
+    );
+}
+
+/// A recoverable `ToolResult::Error` must notify `tool_finished(success=false)`,
+/// NOT `tool_error` — only a fatal/non-recoverable error is exceptional.
+///
+/// Why: #2055's taxonomy reserves `tool_error` for exceptional failures (tool
+/// crash/timeout); an ordinary recoverable tool error (the model can retry) is
+/// still a "the tool finished, unsuccessfully" event, not an exceptional one.
+/// What: Script a tool call against the failing echo tool (`EchoTool { fail:
+/// true }`, which returns `ToolResult::err` — recoverable); assert the sink saw
+/// `finished:...:false`, never `error:...`.
+/// Test: this test.
+#[tokio::test]
+async fn sink_recoverable_error_is_finished_not_error() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("call-1", "hi"),
+        stop_response("done"),
+    ]));
+    let registry = registry_with_echo(true);
+    let sink = Arc::new(RecordingSink::new());
+
+    let agent =
+        make_loop(llm, registry, AgentLoopConfig::default()).with_tool_event_sink(sink.clone());
+    agent
+        .run("sys", "task")
+        .await
+        .expect("loop should complete");
+
+    assert_eq!(
+        sink.calls(),
+        vec![
+            "started:unknown:echo:call-1",
+            "finished:unknown:echo:call-1:false"
+        ]
+    );
+}
+
+/// A tool whose result carries structured telemetry, standing in for
+/// `search_code`/`recall_session` without needing a live daemon.
+///
+/// Why: the loop's forwarding contract (telemetry reaches `tool_telemetry`,
+/// attributed, AFTER the generic hook) is independent of which real tool
+/// produced it, so it is tested here against a stub and separately against
+/// each real tool's own telemetry-shaping tests.
+/// What: returns a fixed `SearchTelemetry` on every call.
+/// Test: `sink_receives_tool_telemetry_with_agent`.
+struct TelemetryTool;
+
+#[async_trait]
+impl ToolExecutor for TelemetryTool {
+    fn name(&self) -> &str {
+        "echo"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "echo",
+                "description": "Echo the provided text back.",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "text": { "type": "string" } },
+                    "required": ["text"]
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, _args: Value) -> ToolResult {
+        ToolResult::ok("searched").with_telemetry(crate::tools::telemetry::ToolTelemetry::Search(
+            crate::tools::telemetry::SearchTelemetry {
+                lane: "semantic".to_string(),
+                query: "q".to_string(),
+                hit_count: Some(4),
+                latency_ms: 3,
+            },
+        ))
+    }
+}
+
+/// Every tool event must be attributed to the agent the loop was told it is
+/// running as (UI Phase 1).
+///
+/// Why: THE keystone of the UI's Phase-1 API — without it a client cannot say
+/// which agent drove a change except by fragile `AgentSpawned`/`AgentDone`
+/// stream-ordering inference. A PM and a delegated engineer share one sink,
+/// so the name must ride on each call.
+/// What: run a loop declared as `pm`; assert every recorded hook carries `pm`.
+/// Test: this test.
+#[tokio::test]
+async fn sink_events_are_attributed_to_the_agent() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("call-1", "hi"),
+        stop_response("done"),
+    ]));
+    let registry = registry_with_echo(false);
+    let sink = Arc::new(RecordingSink::new());
+
+    make_loop(llm, registry, AgentLoopConfig::default())
+        .with_tool_event_sink(sink.clone())
+        .with_agent("pm")
+        .run("sys", "task")
+        .await
+        .expect("loop should complete");
+
+    assert_eq!(
+        sink.calls(),
+        vec!["started:pm:echo:call-1", "finished:pm:echo:call-1:true"]
+    );
+}
+
+/// Two loops sharing ONE sink must attribute their calls to their OWN agents
+/// (UI Phase 1).
+///
+/// Why: this is the exact production topology — `task::executor` clones one
+/// `Arc<dyn ToolEventSink>` into the PM's loop and the delegated engineer's
+/// runner. The requirement is that a UI can tell the two apart on the merged
+/// stream; this test is that requirement, stated directly.
+/// What: drive a `pm`-declared loop and a `python-engineer`-declared loop
+/// against the same sink; assert the merged log distinguishes them.
+/// Test: this test.
+#[tokio::test]
+async fn pm_and_delegated_engineer_are_distinguishable_on_one_sink() {
+    let sink = Arc::new(RecordingSink::new());
+
+    for agent in ["pm", "python-engineer"] {
+        let llm = Arc::new(ScriptedLlm::from_json(&[
+            tool_call_response("call-1", "hi"),
+            stop_response("done"),
+        ]));
+        make_loop(llm, registry_with_echo(false), AgentLoopConfig::default())
+            .with_tool_event_sink(sink.clone())
+            .with_agent(agent)
+            .run("sys", "task")
+            .await
+            .expect("loop should complete");
+    }
+
+    assert_eq!(
+        sink.calls(),
+        vec![
+            "started:pm:echo:call-1",
+            "finished:pm:echo:call-1:true",
+            "started:python-engineer:echo:call-1",
+            "finished:python-engineer:echo:call-1:true",
+        ],
+        "the PM's and the engineer's calls must be distinguishable even though \
+         they share one sink AND reuse the same call_id"
+    );
+}
+
+/// A loop with no declared agent must emit the documented sentinel, never an
+/// empty string (UI Phase 1).
+///
+/// Why: a blank agent chip in a UI is indistinguishable from a genuine empty
+/// name; an explicit `unknown` is a visible wiring bug instead of a silent one.
+/// Test: this test.
+#[tokio::test]
+async fn unattributed_loop_emits_unknown_agent() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("call-1", "hi"),
+        stop_response("done"),
+    ]));
+    let sink = Arc::new(RecordingSink::new());
+
+    make_loop(llm, registry_with_echo(false), AgentLoopConfig::default())
+        .with_tool_event_sink(sink.clone())
+        .run("sys", "task")
+        .await
+        .expect("loop should complete");
+
+    assert!(
+        sink.calls()
+            .iter()
+            .all(|c| c.contains(crate::events::UNATTRIBUTED_AGENT)),
+        "unattributed loops must emit the sentinel: {:?}",
+        sink.calls()
+    );
+}
+
+/// A tool's structured telemetry must reach `tool_telemetry`, attributed, and
+/// ONLY IN ADDITION to the generic tool events (UI Phase 1).
+///
+/// Why: the structured events are additive by design — existing consumers of
+/// `tool_started`/`tool_finished` must see the exact same stream they always
+/// did, so a UI can adopt the new events incrementally.
+/// What: dispatch a tool returning `SearchTelemetry`; assert the sink saw
+/// started -> finished -> telemetry, in that order, all attributed.
+/// Test: this test.
+#[tokio::test]
+async fn sink_receives_tool_telemetry_with_agent() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("call-1", "hi"),
+        stop_response("done"),
+    ]));
+    let mut reg = ToolRegistry::new();
+    reg.register(Arc::new(TelemetryTool));
+    let sink = Arc::new(RecordingSink::new());
+
+    make_loop(llm, Arc::new(reg), AgentLoopConfig::default())
+        .with_tool_event_sink(sink.clone())
+        .with_agent("python-engineer")
+        .run("sys", "task")
+        .await
+        .expect("loop should complete");
+
+    assert_eq!(
+        sink.calls(),
+        vec![
+            "started:python-engineer:echo:call-1",
+            "finished:python-engineer:echo:call-1:true",
+            "telemetry:python-engineer:echo:call-1:search:semantic",
+        ],
+        "telemetry must be ADDITIVE — the generic events must still fire, \
+         unchanged, before it"
+    );
+}
+
+/// A tool that reports no telemetry must not trigger the hook at all
+/// (UI Phase 1).
+///
+/// Why: guards the "costs nothing when absent" property — every non-retrieval
+/// tool must leave the stream exactly as it was pre-ticket.
+/// Test: this test.
+#[tokio::test]
+async fn tools_without_telemetry_emit_no_telemetry_event() {
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("call-1", "hi"),
+        stop_response("done"),
+    ]));
+    let sink = Arc::new(RecordingSink::new());
+
+    make_loop(llm, registry_with_echo(false), AgentLoopConfig::default())
+        .with_tool_event_sink(sink.clone())
+        .with_agent("pm")
+        .run("sys", "task")
+        .await
+        .expect("loop should complete");
+
+    assert!(
+        !sink.calls().iter().any(|c| c.starts_with("telemetry:")),
+        "a tool with no telemetry must not emit a structured event: {:?}",
+        sink.calls()
+    );
+}

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -70,19 +70,48 @@ pub fn render_event_line(envelope: &SessionEventEnvelope) -> String {
         Event::SessionStatusChanged { status, .. } => format!("status -> {status}"),
         Event::SessionDone { status, .. } => format!("done ({status})"),
         Event::SessionCancelled { .. } => "cancelled".to_string(),
+        // (UI Phase 1) `agent` prefixes every tool line so an attached CLI
+        // shows WHO made each call — the same attribution the SPA renders.
         Event::ToolStarted {
-            tool, args_preview, ..
-        } => format!("tool_started  {tool}  {args_preview}"),
+            agent,
+            tool,
+            args_preview,
+            ..
+        } => format!("tool_started  [{agent}] {tool}  {args_preview}"),
         Event::ToolFinished {
+            agent,
             tool,
             success,
             result_preview,
             ..
         } => format!(
-            "tool_finished {tool}  {} {result_preview}",
+            "tool_finished [{agent}] {tool}  {} {result_preview}",
             if *success { "ok" } else { "error" }
         ),
-        Event::ToolError { tool, error, .. } => format!("tool_error    {tool}  {error}"),
+        Event::ToolError {
+            agent, tool, error, ..
+        } => format!("tool_error    [{agent}] {tool}  {error}"),
+        Event::SearchPerformed {
+            agent,
+            lane,
+            query,
+            hit_count,
+            latency_ms,
+            ..
+        } => format!(
+            "search        [{agent}] {lane}  \"{query}\"  {} hits  {latency_ms}ms",
+            hit_count.map_or_else(|| "?".to_string(), |c| c.to_string())
+        ),
+        Event::MemoryRecalled {
+            agent,
+            query,
+            results,
+            ..
+        } => format!(
+            "recall        [{agent}] \"{query}\"  {} injected / {} recalled",
+            results.iter().filter(|r| r.injected).count(),
+            results.len()
+        ),
         Event::Message { text, .. } => text.clone(),
         Event::Log { level, message, .. } => format!("[{level}] {message}"),
         Event::Progress {
@@ -216,6 +245,7 @@ mod tests {
     fn render_event_line_covers_key_variants() {
         let line = render_event_line(&envelope(Event::ToolStarted {
             session_id: "s-1".to_string(),
+            agent: "python-engineer".to_string(),
             tool: "bash".to_string(),
             call_id: "c1".to_string(),
             args_preview: "echo hi".to_string(),
@@ -223,6 +253,44 @@ mod tests {
         assert!(line.contains("tool_started"));
         assert!(line.contains("bash"));
         assert!(line.contains("echo hi"));
+        assert!(
+            line.contains("[python-engineer]"),
+            "an attached CLI must show WHO made the call: {line}"
+        );
+
+        // (UI Phase 1) The two structured retrieval events render their own
+        // lines rather than degrading to the generic `[kind]` fallback.
+        let line = render_event_line(&envelope(Event::SearchPerformed {
+            session_id: "s-1".to_string(),
+            agent: "python-engineer".to_string(),
+            lane: "lexical".to_string(),
+            query: "where is auth".to_string(),
+            hit_count: Some(3),
+            latency_ms: 42,
+        }));
+        assert!(line.contains("[python-engineer]"), "{line}");
+        assert!(line.contains("lexical"), "the REAL routed lane: {line}");
+        assert!(line.contains("3 hits"), "{line}");
+
+        let line = render_event_line(&envelope(Event::MemoryRecalled {
+            session_id: "s-1".to_string(),
+            agent: "pm".to_string(),
+            query: "pkce".to_string(),
+            results: vec![
+                crate::events::RecalledMemory {
+                    score: 0.9,
+                    injected: true,
+                },
+                crate::events::RecalledMemory {
+                    score: 0.41,
+                    injected: false,
+                },
+            ],
+        }));
+        assert!(
+            line.contains("1 injected / 2 recalled"),
+            "the injected/held-back split is the point: {line}"
+        );
 
         let line = render_event_line(&envelope(Event::SessionDone {
             session_id: "s-1".to_string(),

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -30,8 +30,10 @@
 //! any thread carrying envelopes, helpers to publish and subscribe, and a
 //! `__OMPM_EVENT__ <json>\n` stderr-relay protocol so events emitted by
 //! `--workflow` subprocesses can be re-broadcast by the parent API server.
-//! Test: `events::publish` round-trips through `subscribe()`. The relay
-//! prefix is stable so the parent stderr reader can detect and re-publish.
+//! Test: see `events_tests` (sibling file, `#[cfg(test)]`) — `events::publish`
+//! round-trips through `subscribe()`, `kind()` is pinned against the serde tag
+//! for every variant, and the relay prefix is stable so the parent stderr
+//! reader can detect and re-publish.
 
 use std::sync::OnceLock;
 
@@ -57,6 +59,41 @@ pub const EVENT_LINE_PREFIX: &str = "__OMPM_EVENT__ ";
 /// memory bounded (~256KB at 256 bytes/event) while tolerating slow SSE
 /// subscribers without dropping recent events under typical load.
 const CHANNEL_CAPACITY: usize = 1024;
+
+/// The `agent` attribution value used when a tool event's `AgentLoop` was
+/// never told which agent it is running as (UI Phase 1).
+///
+/// Why: attribution is a builder opt-in (`AgentLoop::with_agent`), so a loop
+/// built by a caller that predates it — or by a test — still has to emit
+/// SOMETHING. An explicit, documented sentinel is strictly better than an
+/// empty string, which a UI would render as a blank agent chip and could not
+/// tell apart from a genuine empty name. Every PRODUCTION construction site
+/// sets a real name, so this value appearing in a live stream is a wiring
+/// bug worth seeing rather than hiding.
+/// What: the literal `"unknown"`; joins against nothing in the agent-keyed
+/// taxonomy, which is the point.
+/// Test: `agent_loop::tests::sink_events::unattributed_loop_emits_unknown_agent`.
+pub const UNATTRIBUTED_AGENT: &str = "unknown";
+
+/// One memory recalled by `recall_session`, with the flag that says whether
+/// it actually reached the model (UI Phase 1).
+///
+/// Why: see [`Event::MemoryRecalled`] — `injected` is the whole point of the
+/// event. `score` rides along because the UI renders it beside the memory
+/// ("41% · held"), and re-deriving it client-side is impossible: it is the
+/// memory daemon's own relevance score.
+/// What: `score` is trusty-memory's relevance score for the query, verbatim.
+/// `injected` is `true` when the tool's rendered result text included this
+/// result whole, `false` when its token budget dropped it.
+/// Test: `recalled_memory_round_trips_through_json`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RecalledMemory {
+    /// trusty-memory's relevance score for this result, as returned.
+    pub score: f64,
+    /// Whether this result entered the model's context (`false` = recalled
+    /// but held back by the tool's token budget).
+    pub injected: bool,
+}
 
 /// Real-time event types streamed to UI clients (browser, future Tauri).
 ///
@@ -125,11 +162,19 @@ pub enum Event {
     ///
     /// Why: `call_id` correlates this with the matching `ToolFinished`/
     /// `ToolError` when a session runs multiple tool calls in sequence or
-    /// concurrently.
+    /// concurrently. `agent` (UI Phase 1) is the attribution key: without it
+    /// a client can only guess WHICH agent made a call by interleaving this
+    /// stream with `AgentSpawned`/`AgentDone` ordering, which breaks the
+    /// moment the PM and a delegated engineer have overlapping calls. It is
+    /// the agent NAME (not a synthetic id) so it joins directly against the
+    /// pre-existing `LlmRequested`/`LlmResponded.agent_name` and
+    /// `AgentSpawned`/`AgentDone`/`PmDelegating.agent` keys — see
+    /// [`UNATTRIBUTED_AGENT`] for the fallback when a loop runs unattributed.
     /// What: `args_preview` is truncated via `preview()` before emission.
     /// Test: `session::registry::registry_tests::record_tool_started_publishes_event`.
     ToolStarted {
         session_id: String,
+        agent: String,
         tool: String,
         call_id: String,
         args_preview: String,
@@ -137,8 +182,10 @@ pub enum Event {
     /// A tool invocation completed (success or failure signalled by `success`,
     /// not a separate error variant — use `ToolError` for exceptional
     /// failures the caller wants to narrate distinctly, e.g. a timeout).
+    /// `agent` attributes the call — see [`Event::ToolStarted`].
     ToolFinished {
         session_id: String,
+        agent: String,
         tool: String,
         call_id: String,
         success: bool,
@@ -147,11 +194,66 @@ pub enum Event {
     /// A tool invocation raised an exceptional error (as opposed to
     /// completing with `success: false`) — e.g. the tool process crashed or
     /// timed out rather than returning a normal failure result.
+    /// `agent` attributes the call — see [`Event::ToolStarted`].
     ToolError {
         session_id: String,
+        agent: String,
         tool: String,
         call_id: String,
         error: String,
+    },
+
+    // -- Structured retrieval telemetry (UI Phase 1) --
+    /// A `search_code` call resolved to a concrete trusty-search lane and
+    /// returned `hit_count` hits in `latency_ms` (UI Phase 1).
+    ///
+    /// Why: `ToolStarted`/`ToolFinished` carry only TRUNCATED STRING
+    /// PREVIEWS of a search's arguments and rendered result text. The UI's
+    /// core bet is that a change is explained by the searches and memories
+    /// that drove it — which needs the search's real routed lane, its hit
+    /// count, and its cost as DATA, not as a prefix of prose the UI would
+    /// have to re-parse. Emitted ALONGSIDE (never instead of) the generic
+    /// tool events, so every existing consumer is unaffected.
+    /// What: `lane` is the lane trusty-search ACTUALLY served, which is not
+    /// always the mode the model asked for: a `semantic`/`symbol` query that
+    /// hits a still-building index transparently retries on the lexical lane
+    /// (issue #2783), and that degraded reality is reported as
+    /// `lane: "lexical"` — see `tools::trusty_search`'s `SearchLane`.
+    /// `hit_count` is `None` when the lane served results whose shape this
+    /// crate could not count (never a silent zero, which would read as "no
+    /// hits"). `latency_ms` measures the whole tool call, retry included.
+    /// Test: `session::registry::registry_tests::record_search_performed_publishes_event`,
+    /// `tools::trusty_search_tests::telemetry_reports_lexical_fallback_lane`.
+    SearchPerformed {
+        session_id: String,
+        agent: String,
+        lane: String,
+        query: String,
+        hit_count: Option<usize>,
+        latency_ms: u64,
+    },
+    /// A `recall_session` call recalled `results` from durable memory, each
+    /// flagged with whether it actually ENTERED the model's context
+    /// (UI Phase 1).
+    ///
+    /// Why: the differentiating UI surface distinguishes memories that were
+    /// injected into context from ones that were recalled but HELD BACK —
+    /// rendered as e.g. "PKCE required… 41% · held" next to the injected
+    /// ones. `recall_session` has always known both the scores and which
+    /// results its token budget dropped, but that knowledge died inside the
+    /// tool's rendered text. This is the event that lets it out.
+    /// What: `results` is ordered highest-score-first (the order the daemon
+    /// returned and the tool preserved). `injected: false` means EXACTLY
+    /// "recalled but not entered into context" — the tool drops WHOLE
+    /// lowest-scored results to fit its token budget, so a held-back result
+    /// is one the model never saw.
+    /// Test: `session::registry::registry_tests::record_memory_recalled_publishes_event`,
+    /// `tools::recall_session::tests::telemetry_marks_budget_dropped_results_held_back`.
+    MemoryRecalled {
+        session_id: String,
+        agent: String,
+        query: String,
+        results: Vec<RecalledMemory>,
     },
 
     // -- Diagnostics / progress / generic message (#2055 taxonomy) --
@@ -450,6 +552,8 @@ impl Event {
             | Event::ToolStarted { session_id, .. }
             | Event::ToolFinished { session_id, .. }
             | Event::ToolError { session_id, .. }
+            | Event::SearchPerformed { session_id, .. }
+            | Event::MemoryRecalled { session_id, .. }
             | Event::Log { session_id, .. }
             | Event::Progress { session_id, .. }
             | Event::Message { session_id, .. }
@@ -499,6 +603,8 @@ impl Event {
             Event::ToolStarted { .. } => "tool_started",
             Event::ToolFinished { .. } => "tool_finished",
             Event::ToolError { .. } => "tool_error",
+            Event::SearchPerformed { .. } => "search_performed",
+            Event::MemoryRecalled { .. } => "memory_recalled",
             Event::Log { .. } => "log",
             Event::Progress { .. } => "progress",
             Event::Message { .. } => "message",
@@ -666,208 +772,5 @@ pub fn preview(s: &str, max: usize) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn event_serializes_with_type_tag() {
-        let ev = Event::PmThinking {
-            session_id: "s1".into(),
-            text: "considering options".into(),
-        };
-        let s = serde_json::to_string(&ev).unwrap();
-        assert!(s.contains("\"type\":\"pm_thinking\""), "{s}");
-        assert!(s.contains("\"session_id\":\"s1\""), "{s}");
-    }
-
-    #[test]
-    fn ping_roundtrips() {
-        let s = serde_json::to_string(&Event::Ping).unwrap();
-        let back: Event = serde_json::from_str(&s).unwrap();
-        assert!(matches!(back, Event::Ping));
-    }
-
-    #[test]
-    fn session_id_returns_correct_field() {
-        let ev = Event::AgentMessage {
-            session_id: "abc".into(),
-            agent: "python".into(),
-            text: "hi".into(),
-        };
-        assert_eq!(ev.session_id(), Some("abc"));
-        assert_eq!(Event::Ping.session_id(), None);
-    }
-
-    #[test]
-    fn bus_is_singleton() {
-        let a = bus();
-        let b = bus();
-        // Two senders to the same channel: a message sent on `a` should be
-        // visible to a receiver from `b`.
-        let mut rx = b.subscribe();
-        let envelope = SessionEventEnvelope::new("s-bus".into(), 1, Utc::now(), Event::Ping);
-        let _ = a.send(envelope);
-        // Drain via try_recv to avoid an async runtime in this sync test.
-        let got = rx.try_recv().expect("expected an envelope");
-        assert!(matches!(got.event, Event::Ping));
-    }
-
-    #[tokio::test]
-    async fn publish_round_trips_through_subscribe() {
-        let mut rx = subscribe();
-        let envelope = SessionEventEnvelope::new(
-            "t1".into(),
-            1,
-            Utc::now(),
-            Event::SessionStarted {
-                session_id: "t1".into(),
-                project: "demo".into(),
-            },
-        );
-        publish(envelope);
-        let got = rx.recv().await.unwrap();
-        assert_eq!(got.session_id, "t1");
-        assert_eq!(got.seq, 1);
-        assert_eq!(got.kind, "session_started");
-        match got.event {
-            Event::SessionStarted {
-                session_id,
-                project,
-            } => {
-                assert_eq!(session_id, "t1");
-                assert_eq!(project, "demo");
-            }
-            other => panic!("unexpected event: {other:?}"),
-        }
-    }
-
-    /// `kind()` must match the serde `"type"` tag for every variant — the
-    /// guard `SessionEventEnvelope::new`'s doc comment references.
-    #[test]
-    fn kind_matches_serde_tag_for_every_variant() {
-        let samples: Vec<Event> = vec![
-            Event::SessionStarted {
-                session_id: "s".into(),
-                project: "p".into(),
-            },
-            Event::SessionDone {
-                session_id: "s".into(),
-                status: "done".into(),
-            },
-            Event::SessionCancelled {
-                session_id: "s".into(),
-            },
-            Event::SessionStatusChanged {
-                session_id: "s".into(),
-                status: "running".into(),
-            },
-            Event::SessionInput {
-                session_id: "s".into(),
-                input: "hi".into(),
-            },
-            Event::ToolStarted {
-                session_id: "s".into(),
-                tool: "bash".into(),
-                call_id: "c1".into(),
-                args_preview: "ls".into(),
-            },
-            Event::ToolFinished {
-                session_id: "s".into(),
-                tool: "bash".into(),
-                call_id: "c1".into(),
-                success: true,
-                result_preview: "ok".into(),
-            },
-            Event::ToolError {
-                session_id: "s".into(),
-                tool: "bash".into(),
-                call_id: "c1".into(),
-                error: "boom".into(),
-            },
-            Event::Log {
-                session_id: "s".into(),
-                level: "info".into(),
-                message: "m".into(),
-            },
-            Event::Progress {
-                session_id: "s".into(),
-                message: "m".into(),
-                percent: None,
-            },
-            Event::Message {
-                session_id: "s".into(),
-                text: "hi".into(),
-            },
-            Event::IndexReadiness {
-                session_id: "s".into(),
-                state: "warming".into(),
-                index_id: Some("repo".into()),
-                lifecycle_status: Some("indexed_lexical".into()),
-                chunk_count: Some(7),
-                lexical_ready: true,
-                semantic_ready: false,
-                graph_ready: false,
-                summary: "warming".into(),
-            },
-            Event::ContextBudget {
-                session_id: "s".into(),
-                context_window_tokens: 200_000,
-                overhead_tokens: 1_000,
-                overhead_cap_tokens: 80_000,
-                working_context_pct: 99,
-                overhead_pct: 1,
-                within_budget: true,
-                compaction_fired: false,
-                compaction_rounds: 0,
-            },
-            Event::Ping,
-        ];
-        for ev in samples {
-            let value = serde_json::to_value(&ev).unwrap();
-            let wire_type = value["type"].as_str().unwrap_or("ping");
-            assert_eq!(
-                ev.kind(),
-                wire_type,
-                "kind() drifted from the serde tag for {ev:?}"
-            );
-        }
-    }
-
-    /// `SessionEventEnvelope` must round-trip through JSON with every field
-    /// present, and `kind` must be derived from `event.kind()`.
-    #[test]
-    fn session_event_envelope_round_trips_through_json() {
-        let event = Event::SessionInput {
-            session_id: "s1".into(),
-            input: "hello".into(),
-        };
-        let envelope = SessionEventEnvelope::new("s1".into(), 7, Utc::now(), event);
-
-        let value = serde_json::to_value(&envelope).unwrap();
-        assert_eq!(value["session_id"], "s1");
-        assert_eq!(value["seq"], 7);
-        assert_eq!(value["kind"], "session_input");
-        assert_eq!(value["event"]["type"], "session_input");
-        assert!(value["at"].is_string());
-
-        let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
-        assert_eq!(back.session_id, "s1");
-        assert_eq!(back.seq, 7);
-    }
-
-    #[test]
-    fn preview_truncates_at_char_boundary() {
-        assert_eq!(preview("hi", 5), "hi");
-        let out = preview("abcdef", 3);
-        assert_eq!(out.chars().count(), 4); // 3 + ellipsis
-        assert!(out.starts_with("abc"));
-        assert!(out.ends_with('\u{2026}'));
-    }
-
-    #[test]
-    fn event_line_prefix_is_stable() {
-        // Lock in the wire constant — changing it breaks the parent/child
-        // relay protocol.
-        assert_eq!(EVENT_LINE_PREFIX, "__OMPM_EVENT__ ");
-    }
-}
+#[path = "events_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -223,7 +223,7 @@ pub enum Event {
     /// crate could not count (never a silent zero, which would read as "no
     /// hits"). `latency_ms` measures the whole tool call, retry included.
     /// Test: `session::registry::registry_tests::record_search_performed_publishes_event`,
-    /// `tools::trusty_search_tests::telemetry_reports_lexical_fallback_lane`.
+    /// `tools::trusty_search_tests::resolved_lane_reports_lexical_when_the_retry_served_it`.
     SearchPerformed {
         session_id: String,
         agent: String,

--- a/crates/trusty-code/src/events_tests.rs
+++ b/crates/trusty-code/src/events_tests.rs
@@ -1,0 +1,320 @@
+//! Unit tests for the `events` wire taxonomy.
+//!
+//! Why: split out of `events.rs` per the crate's `_tests.rs` sibling-file
+//! convention (see `session::registry_tests` for precedent) so the event
+//! taxonomy's test surface can grow with the taxonomy without pushing the
+//! production file past its 500-SLOC cap — test files carry the 1500-SLOC cap.
+//! What: covers the serde `type`-tag wire shape, `kind()`/serde-tag parity for
+//! every variant, envelope round-tripping (including the UI-Phase-1 structured
+//! retrieval events), and the stderr relay prefix.
+//! Test: this module is itself the test surface.
+
+use super::*;
+
+#[test]
+fn event_serializes_with_type_tag() {
+    let ev = Event::PmThinking {
+        session_id: "s1".into(),
+        text: "considering options".into(),
+    };
+    let s = serde_json::to_string(&ev).unwrap();
+    assert!(s.contains("\"type\":\"pm_thinking\""), "{s}");
+    assert!(s.contains("\"session_id\":\"s1\""), "{s}");
+}
+
+#[test]
+fn ping_roundtrips() {
+    let s = serde_json::to_string(&Event::Ping).unwrap();
+    let back: Event = serde_json::from_str(&s).unwrap();
+    assert!(matches!(back, Event::Ping));
+}
+
+#[test]
+fn session_id_returns_correct_field() {
+    let ev = Event::AgentMessage {
+        session_id: "abc".into(),
+        agent: "python".into(),
+        text: "hi".into(),
+    };
+    assert_eq!(ev.session_id(), Some("abc"));
+    assert_eq!(Event::Ping.session_id(), None);
+}
+
+#[test]
+fn bus_is_singleton() {
+    let a = bus();
+    let b = bus();
+    // Two senders to the same channel: a message sent on `a` should be
+    // visible to a receiver from `b`.
+    let mut rx = b.subscribe();
+    let envelope = SessionEventEnvelope::new("s-bus".into(), 1, Utc::now(), Event::Ping);
+    let _ = a.send(envelope);
+    // Drain via try_recv to avoid an async runtime in this sync test.
+    let got = rx.try_recv().expect("expected an envelope");
+    assert!(matches!(got.event, Event::Ping));
+}
+
+#[tokio::test]
+async fn publish_round_trips_through_subscribe() {
+    let mut rx = subscribe();
+    let envelope = SessionEventEnvelope::new(
+        "t1".into(),
+        1,
+        Utc::now(),
+        Event::SessionStarted {
+            session_id: "t1".into(),
+            project: "demo".into(),
+        },
+    );
+    publish(envelope);
+    let got = rx.recv().await.unwrap();
+    assert_eq!(got.session_id, "t1");
+    assert_eq!(got.seq, 1);
+    assert_eq!(got.kind, "session_started");
+    match got.event {
+        Event::SessionStarted {
+            session_id,
+            project,
+        } => {
+            assert_eq!(session_id, "t1");
+            assert_eq!(project, "demo");
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+/// `kind()` must match the serde `"type"` tag for every variant — the
+/// guard `SessionEventEnvelope::new`'s doc comment references.
+#[test]
+fn kind_matches_serde_tag_for_every_variant() {
+    let samples: Vec<Event> = vec![
+        Event::SessionStarted {
+            session_id: "s".into(),
+            project: "p".into(),
+        },
+        Event::SessionDone {
+            session_id: "s".into(),
+            status: "done".into(),
+        },
+        Event::SessionCancelled {
+            session_id: "s".into(),
+        },
+        Event::SessionStatusChanged {
+            session_id: "s".into(),
+            status: "running".into(),
+        },
+        Event::SessionInput {
+            session_id: "s".into(),
+            input: "hi".into(),
+        },
+        Event::ToolStarted {
+            session_id: "s".into(),
+            agent: "pm".into(),
+            tool: "bash".into(),
+            call_id: "c1".into(),
+            args_preview: "ls".into(),
+        },
+        Event::ToolFinished {
+            session_id: "s".into(),
+            agent: "pm".into(),
+            tool: "bash".into(),
+            call_id: "c1".into(),
+            success: true,
+            result_preview: "ok".into(),
+        },
+        Event::ToolError {
+            session_id: "s".into(),
+            agent: "pm".into(),
+            tool: "bash".into(),
+            call_id: "c1".into(),
+            error: "boom".into(),
+        },
+        Event::SearchPerformed {
+            session_id: "s".into(),
+            agent: "python-engineer".into(),
+            lane: "semantic".into(),
+            query: "where is auth".into(),
+            hit_count: Some(3),
+            latency_ms: 42,
+        },
+        Event::MemoryRecalled {
+            session_id: "s".into(),
+            agent: "pm".into(),
+            query: "pkce".into(),
+            results: vec![RecalledMemory {
+                score: 0.41,
+                injected: false,
+            }],
+        },
+        Event::Log {
+            session_id: "s".into(),
+            level: "info".into(),
+            message: "m".into(),
+        },
+        Event::Progress {
+            session_id: "s".into(),
+            message: "m".into(),
+            percent: None,
+        },
+        Event::Message {
+            session_id: "s".into(),
+            text: "hi".into(),
+        },
+        Event::IndexReadiness {
+            session_id: "s".into(),
+            state: "warming".into(),
+            index_id: Some("repo".into()),
+            lifecycle_status: Some("indexed_lexical".into()),
+            chunk_count: Some(7),
+            lexical_ready: true,
+            semantic_ready: false,
+            graph_ready: false,
+            summary: "warming".into(),
+        },
+        Event::ContextBudget {
+            session_id: "s".into(),
+            context_window_tokens: 200_000,
+            overhead_tokens: 1_000,
+            overhead_cap_tokens: 80_000,
+            working_context_pct: 99,
+            overhead_pct: 1,
+            within_budget: true,
+            compaction_fired: false,
+            compaction_rounds: 0,
+        },
+        Event::Ping,
+    ];
+    for ev in samples {
+        let value = serde_json::to_value(&ev).unwrap();
+        let wire_type = value["type"].as_str().unwrap_or("ping");
+        assert_eq!(
+            ev.kind(),
+            wire_type,
+            "kind() drifted from the serde tag for {ev:?}"
+        );
+    }
+}
+
+/// The UI-Phase-1 structured events must survive a full envelope
+/// round-trip with every field intact — including each recalled memory's
+/// `injected` flag.
+///
+/// Why: these events reach the UI over SSE and through `session.attach`'s
+/// ring-buffer replay, both of which serialize. A field that silently
+/// failed to round-trip would strand the UI's whole differentiating
+/// surface. `hit_count: None` is covered explicitly because `Option`
+/// round-tripping is where a shape regression would most plausibly hide.
+/// Test: this test.
+#[test]
+fn recalled_memory_round_trips_through_json() {
+    let event = Event::MemoryRecalled {
+        session_id: "s1".into(),
+        agent: "pm".into(),
+        query: "pkce".into(),
+        results: vec![
+            RecalledMemory {
+                score: 0.93,
+                injected: true,
+            },
+            RecalledMemory {
+                score: 0.41,
+                injected: false,
+            },
+        ],
+    };
+    let envelope = SessionEventEnvelope::new("s1".into(), 4, Utc::now(), event);
+    let value = serde_json::to_value(&envelope).unwrap();
+
+    assert_eq!(value["kind"], "memory_recalled");
+    assert_eq!(value["event"]["agent"], "pm");
+    assert_eq!(value["event"]["results"][1]["injected"], false);
+    assert_eq!(value["event"]["results"][1]["score"], 0.41);
+
+    let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
+    let Event::MemoryRecalled { results, agent, .. } = back.event else {
+        panic!("expected MemoryRecalled");
+    };
+    assert_eq!(agent, "pm");
+    assert_eq!(
+        results,
+        vec![
+            RecalledMemory {
+                score: 0.93,
+                injected: true
+            },
+            RecalledMemory {
+                score: 0.41,
+                injected: false
+            },
+        ],
+        "the injected/held-back split must survive the wire"
+    );
+}
+
+/// `SearchPerformed` must round-trip, including an uncountable
+/// (`hit_count: None`) result.
+#[test]
+fn search_performed_round_trips_through_json() {
+    let event = Event::SearchPerformed {
+        session_id: "s1".into(),
+        agent: "python-engineer".into(),
+        lane: "lexical".into(),
+        query: "where is auth".into(),
+        hit_count: None,
+        latency_ms: 17,
+    };
+    let envelope = SessionEventEnvelope::new("s1".into(), 5, Utc::now(), event);
+    let value = serde_json::to_value(&envelope).unwrap();
+
+    assert_eq!(value["kind"], "search_performed");
+    assert_eq!(value["event"]["lane"], "lexical");
+    assert!(
+        value["event"]["hit_count"].is_null(),
+        "an uncountable hit count must stay null, never coerce to 0"
+    );
+
+    let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
+    assert!(matches!(
+        back.event,
+        Event::SearchPerformed { hit_count, latency_ms, lane, .. }
+            if hit_count.is_none() && latency_ms == 17 && lane == "lexical"
+    ));
+}
+
+/// `SessionEventEnvelope` must round-trip through JSON with every field
+/// present, and `kind` must be derived from `event.kind()`.
+#[test]
+fn session_event_envelope_round_trips_through_json() {
+    let event = Event::SessionInput {
+        session_id: "s1".into(),
+        input: "hello".into(),
+    };
+    let envelope = SessionEventEnvelope::new("s1".into(), 7, Utc::now(), event);
+
+    let value = serde_json::to_value(&envelope).unwrap();
+    assert_eq!(value["session_id"], "s1");
+    assert_eq!(value["seq"], 7);
+    assert_eq!(value["kind"], "session_input");
+    assert_eq!(value["event"]["type"], "session_input");
+    assert!(value["at"].is_string());
+
+    let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
+    assert_eq!(back.session_id, "s1");
+    assert_eq!(back.seq, 7);
+}
+
+#[test]
+fn preview_truncates_at_char_boundary() {
+    assert_eq!(preview("hi", 5), "hi");
+    let out = preview("abcdef", 3);
+    assert_eq!(out.chars().count(), 4); // 3 + ellipsis
+    assert!(out.starts_with("abc"));
+    assert!(out.ends_with('\u{2026}'));
+}
+
+#[test]
+fn event_line_prefix_is_stable() {
+    // Lock in the wire constant — changing it breaks the parent/child
+    // relay protocol.
+    assert_eq!(EVENT_LINE_PREFIX, "__OMPM_EVENT__ ");
+}

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -339,6 +339,12 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
         Arc::new(pm_registry),
     )
     .with_stop_signal(Arc::new(move || stop_signal.is_cap_reached()))
+    // (UI Phase 1) Attribute the PM's tool events. Inert on this legacy
+    // one-shot/bake-off CLI path — it attaches no `ToolEventSink`, so nothing
+    // reads the attribution today. Set anyway so the identity is correct the
+    // moment a sink ever is attached here, rather than silently emitting
+    // `UNATTRIBUTED_AGENT`.
+    .with_agent("pm")
     // #2279: the PM never calls `bash` itself (its registry above is
     // `delegate_to_agent` + `finish_task` only), so its verify-before-finish
     // gate must scan the delegated engineer's transcript instead of its

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -398,7 +398,14 @@ impl InProcessAgentRunner {
             // repeated "one final run to confirm" passes. Same single
             // construction site, so both `run_task` and `task::executor`
             // delegations get it.
-            .with_redundant_run_suppression();
+            .with_redundant_run_suppression()
+            // (UI Phase 1) Attribute this sub-agent's tool events to itself.
+            // This is the ONE production construction site for every delegated
+            // sub-agent loop (both `run_task` and `task::executor` delegate
+            // through this runner), and the sink it shares with the PM below is
+            // the same `Arc` — so this call is what makes a delegated
+            // engineer's tool calls distinguishable from the PM's.
+            .with_agent(agent_name);
         if let Some(sink) = &self.sink {
             agent_loop = agent_loop.with_tool_event_sink(Arc::clone(sink));
         }

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -888,25 +888,32 @@ struct RecordingSink {
 
 #[async_trait]
 impl ToolEventSink for RecordingSink {
-    async fn tool_started(&self, call_id: &str, tool: &str, _args_preview: &str) {
+    async fn tool_started(&self, agent: &str, call_id: &str, tool: &str, _args_preview: &str) {
         self.calls
             .lock()
             .expect("lock poisoned")
-            .push(format!("started:{tool}:{call_id}"));
+            .push(format!("started:{agent}:{tool}:{call_id}"));
     }
 
-    async fn tool_finished(&self, call_id: &str, tool: &str, success: bool, _result_preview: &str) {
+    async fn tool_finished(
+        &self,
+        agent: &str,
+        call_id: &str,
+        tool: &str,
+        success: bool,
+        _result_preview: &str,
+    ) {
         self.calls
             .lock()
             .expect("lock poisoned")
-            .push(format!("finished:{tool}:{call_id}:{success}"));
+            .push(format!("finished:{agent}:{tool}:{call_id}:{success}"));
     }
 
-    async fn tool_error(&self, call_id: &str, tool: &str, _error: &str) {
+    async fn tool_error(&self, agent: &str, call_id: &str, tool: &str, _error: &str) {
         self.calls
             .lock()
             .expect("lock poisoned")
-            .push(format!("error:{tool}:{call_id}"));
+            .push(format!("error:{agent}:{tool}:{call_id}"));
     }
 }
 
@@ -917,7 +924,9 @@ impl ToolEventSink for RecordingSink {
 /// the same sink the delegating (PM) loop uses; this is the propagation seam
 /// that makes that possible.
 /// What: Script [tool_call("mytool"), stop]; attach a `RecordingSink` to the
-/// runner; assert it saw `started`/`finished` for `mytool`.
+/// runner; assert it saw `started`/`finished` for `mytool`, ATTRIBUTED
+/// (UI Phase 1) to `python-engineer` — the delegated agent — rather than to
+/// the PM that shares this same sink instance.
 /// Test: this test.
 #[tokio::test]
 async fn sink_reaches_delegated_loop() {
@@ -945,7 +954,13 @@ async fn sink_reaches_delegated_loop() {
 
     assert_eq!(
         sink.calls.lock().expect("lock poisoned").as_slice(),
-        ["started:mytool:call-1", "finished:mytool:call-1:true"]
+        [
+            "started:python-engineer:mytool:call-1",
+            "finished:python-engineer:mytool:call-1:true"
+        ],
+        "the runner must attribute a delegated sub-agent's tool events to \
+         that sub-agent — the sink is shared with the PM, so an unattributed \
+         (or PM-attributed) event here would make the two indistinguishable"
     );
 }
 

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -20,6 +20,7 @@
 //! `registry_tests::record_message_publishes_event`.
 
 use super::*;
+use crate::tools::telemetry::{RecallTelemetry, SearchTelemetry};
 
 use crate::agent_loop::ContextBudgetSnapshot;
 
@@ -138,11 +139,14 @@ impl SessionRegistry {
     /// or bus directly.
     /// What: errors with `session_not_found` if `id` is unknown; `args_preview`
     /// is truncated via `crate::events::preview` before emission so a large
-    /// argument payload can't blow the ring buffer / wire size.
+    /// argument payload can't blow the ring buffer / wire size. `agent`
+    /// (UI Phase 1) is the dispatching agent's name — see
+    /// [`crate::events::Event::ToolStarted`].
     /// Test: `registry_tests::record_tool_started_publishes_event`.
     pub fn record_tool_started(
         &self,
         id: &str,
+        agent: &str,
         tool: &str,
         call_id: &str,
         args: &str,
@@ -152,6 +156,7 @@ impl SessionRegistry {
             id,
             Event::ToolStarted {
                 session_id: id.to_string(),
+                agent: agent.to_string(),
                 tool: tool.to_string(),
                 call_id: call_id.to_string(),
                 args_preview: crate::events::preview(args, 500),
@@ -166,6 +171,7 @@ impl SessionRegistry {
     pub fn record_tool_finished(
         &self,
         id: &str,
+        agent: &str,
         tool: &str,
         call_id: &str,
         success: bool,
@@ -176,6 +182,7 @@ impl SessionRegistry {
             id,
             Event::ToolFinished {
                 session_id: id.to_string(),
+                agent: agent.to_string(),
                 tool: tool.to_string(),
                 call_id: call_id.to_string(),
                 success,
@@ -191,6 +198,7 @@ impl SessionRegistry {
     pub fn record_tool_error(
         &self,
         id: &str,
+        agent: &str,
         tool: &str,
         call_id: &str,
         error: &str,
@@ -200,9 +208,66 @@ impl SessionRegistry {
             id,
             Event::ToolError {
                 session_id: id.to_string(),
+                agent: agent.to_string(),
                 tool: tool.to_string(),
                 call_id: call_id.to_string(),
                 error: error.to_string(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Record a `search_code` call's real lane + hit count + latency
+    /// (UI Phase 1). See [`crate::events::Event::SearchPerformed`].
+    ///
+    /// Why: emitted ALONGSIDE the generic tool events so the UI can trace a
+    /// change back to the searches that drove it without re-parsing prose.
+    /// What: same existence guard + ring-buffer/sequencing path as every
+    /// other `record_*`, so a structured event replays on `session.attach`
+    /// exactly like the generic ones.
+    /// Test: `registry_tests::record_search_performed_publishes_event`.
+    pub fn record_search_performed(
+        &self,
+        id: &str,
+        agent: &str,
+        telemetry: &SearchTelemetry,
+    ) -> Result<(), RpcError> {
+        self.ensure_exists(id)?;
+        self.record(
+            id,
+            Event::SearchPerformed {
+                session_id: id.to_string(),
+                agent: agent.to_string(),
+                lane: telemetry.lane.clone(),
+                query: telemetry.query.clone(),
+                hit_count: telemetry.hit_count,
+                latency_ms: telemetry.latency_ms,
+            },
+        );
+        Ok(())
+    }
+
+    /// Record a `recall_session` call's results and which ones entered
+    /// context (UI Phase 1). See [`crate::events::Event::MemoryRecalled`].
+    ///
+    /// Why: the `injected` flag is the UI's differentiating surface —
+    /// injected memories vs ones recalled and held back.
+    /// What: as [`Self::record_search_performed`].
+    /// Test: `registry_tests::record_memory_recalled_publishes_event`.
+    pub fn record_memory_recalled(
+        &self,
+        id: &str,
+        agent: &str,
+        telemetry: &RecallTelemetry,
+    ) -> Result<(), RpcError> {
+        self.ensure_exists(id)?;
+        self.record(
+            id,
+            Event::MemoryRecalled {
+                session_id: id.to_string(),
+                agent: agent.to_string(),
+                query: telemetry.query.clone(),
+                results: telemetry.results.clone(),
             },
         );
         Ok(())

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -349,7 +349,7 @@ fn recall_telemetry(results: &[(f64, bool)]) -> crate::tools::RecallTelemetry {
 #[tokio::test]
 async fn record_search_performed_publishes_event() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     registry
@@ -382,7 +382,7 @@ async fn record_search_performed_publishes_event() {
 #[tokio::test]
 async fn record_memory_recalled_publishes_event() {
     let registry = SessionRegistry::new();
-    let session = registry.create("t".to_string(), None, None);
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     let mut events = crate::events::subscribe();
 
     registry

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -315,6 +315,113 @@ async fn ring_buffer_drops_oldest_when_full() {
     assert_eq!(seqs, vec![2, 3]);
 }
 
+/// Build a `SearchTelemetry` for the UI-Phase-1 record tests.
+fn search_telemetry(lane: &str, hit_count: Option<usize>) -> crate::tools::SearchTelemetry {
+    crate::tools::SearchTelemetry {
+        lane: lane.to_string(),
+        query: "where is auth".to_string(),
+        hit_count,
+        latency_ms: 12,
+    }
+}
+
+/// Build a `RecallTelemetry` from `(score, injected)` pairs.
+fn recall_telemetry(results: &[(f64, bool)]) -> crate::tools::RecallTelemetry {
+    crate::tools::RecallTelemetry {
+        query: "pkce".to_string(),
+        results: results
+            .iter()
+            .map(|(score, injected)| crate::events::RecalledMemory {
+                score: *score,
+                injected: *injected,
+            })
+            .collect(),
+    }
+}
+
+/// `record_search_performed` must publish a `SearchPerformed` event carrying
+/// the real routed lane, hit count, latency, and agent attribution
+/// (UI Phase 1).
+///
+/// Why: this is the structured search signal the UI joins against a change to
+/// answer "what search drove this?" — it must survive the same
+/// record -> sequence -> publish path as every other event.
+#[tokio::test]
+async fn record_search_performed_publishes_event() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    let mut events = crate::events::subscribe();
+
+    registry
+        .record_search_performed(
+            &session.id,
+            "python-engineer",
+            &search_telemetry("grep", Some(7)),
+        )
+        .unwrap();
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert_eq!(envelope.kind, "search_performed");
+    assert!(matches!(
+        envelope.event,
+        Event::SearchPerformed { agent, lane, query, hit_count, latency_ms, .. }
+            if agent == "python-engineer"
+                && lane == "grep"
+                && query == "where is auth"
+                && hit_count == Some(7)
+                && latency_ms == 12
+    ));
+}
+
+/// `record_memory_recalled` must publish a `MemoryRecalled` event preserving
+/// each result's score AND its `injected` flag (UI Phase 1).
+///
+/// Why: `injected` is the differentiating surface — a UI renders held-back
+/// memories beside injected ones. Losing the flag anywhere in the emission
+/// path collapses that distinction.
+#[tokio::test]
+async fn record_memory_recalled_publishes_event() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, None);
+    let mut events = crate::events::subscribe();
+
+    registry
+        .record_memory_recalled(
+            &session.id,
+            "pm",
+            &recall_telemetry(&[(0.9, true), (0.41, false)]),
+        )
+        .unwrap();
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert_eq!(envelope.kind, "memory_recalled");
+    let Event::MemoryRecalled {
+        agent,
+        query,
+        results,
+        ..
+    } = envelope.event
+    else {
+        panic!("expected MemoryRecalled");
+    };
+    assert_eq!(agent, "pm");
+    assert_eq!(query, "pkce");
+    assert_eq!(
+        results,
+        vec![
+            crate::events::RecalledMemory {
+                score: 0.9,
+                injected: true
+            },
+            crate::events::RecalledMemory {
+                score: 0.41,
+                injected: false
+            },
+        ],
+        "both the scores and the injected/held-back split must survive emission"
+    );
+}
+
 /// `record_tool_started` must publish a `ToolStarted` event with a
 /// truncated `args_preview`.
 #[tokio::test]
@@ -324,15 +431,15 @@ async fn record_tool_started_publishes_event() {
     let mut events = crate::events::subscribe();
 
     registry
-        .record_tool_started(&session.id, "bash", "call-1", "ls -la")
+        .record_tool_started(&session.id, "pm", "bash", "call-1", "ls -la")
         .unwrap();
 
     let envelope = next_event_for(&mut events, &session.id).await;
     assert_eq!(envelope.kind, "tool_started");
     assert!(matches!(
         envelope.event,
-        Event::ToolStarted { tool, call_id, args_preview, .. }
-            if tool == "bash" && call_id == "call-1" && args_preview == "ls -la"
+        Event::ToolStarted { agent, tool, call_id, args_preview, .. }
+            if agent == "pm" && tool == "bash" && call_id == "call-1" && args_preview == "ls -la"
     ));
 }
 
@@ -345,14 +452,15 @@ async fn record_tool_finished_publishes_event() {
     let mut events = crate::events::subscribe();
 
     registry
-        .record_tool_finished(&session.id, "bash", "call-1", true, "done")
+        .record_tool_finished(&session.id, "pm", "bash", "call-1", true, "done")
         .unwrap();
 
     let envelope = next_event_for(&mut events, &session.id).await;
     assert_eq!(envelope.kind, "tool_finished");
     assert!(matches!(
         envelope.event,
-        Event::ToolFinished { success, result_preview, .. } if success && result_preview == "done"
+        Event::ToolFinished { agent, success, result_preview, .. }
+            if agent == "pm" && success && result_preview == "done"
     ));
 }
 
@@ -364,12 +472,15 @@ async fn record_tool_error_publishes_event() {
     let mut events = crate::events::subscribe();
 
     registry
-        .record_tool_error(&session.id, "bash", "call-1", "timed out")
+        .record_tool_error(&session.id, "pm", "bash", "call-1", "timed out")
         .unwrap();
 
     let envelope = next_event_for(&mut events, &session.id).await;
     assert_eq!(envelope.kind, "tool_error");
-    assert!(matches!(envelope.event, Event::ToolError { error, .. } if error == "timed out"));
+    assert!(matches!(
+        envelope.event,
+        Event::ToolError { agent, error, .. } if agent == "pm" && error == "timed out"
+    ));
 }
 
 /// `record_log` must publish a `Log` event.
@@ -427,21 +538,35 @@ async fn record_plumbing_methods_reject_unknown_session() {
     let registry = SessionRegistry::new();
     assert_eq!(
         registry
-            .record_tool_started("nope", "t", "c", "a")
+            .record_tool_started("nope", "pm", "t", "c", "a")
             .unwrap_err()
             .code,
         -32007
     );
     assert_eq!(
         registry
-            .record_tool_finished("nope", "t", "c", true, "r")
+            .record_tool_finished("nope", "pm", "t", "c", true, "r")
             .unwrap_err()
             .code,
         -32007
     );
     assert_eq!(
         registry
-            .record_tool_error("nope", "t", "c", "e")
+            .record_tool_error("nope", "pm", "t", "c", "e")
+            .unwrap_err()
+            .code,
+        -32007
+    );
+    assert_eq!(
+        registry
+            .record_search_performed("nope", "pm", &search_telemetry("semantic", Some(1)))
+            .unwrap_err()
+            .code,
+        -32007
+    );
+    assert_eq!(
+        registry
+            .record_memory_recalled("nope", "pm", &recall_telemetry(&[(0.9, true)]))
             .unwrap_err()
             .code,
         -32007

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -436,6 +436,12 @@ async fn run_and_record(
         Arc::new(pm_registry),
     )
     .with_tool_event_sink(Arc::clone(&sink))
+    // (UI Phase 1) Attribute this loop's tool events to the PM. `sink` is the
+    // SAME `Arc` handed to `build_engineer_runner` above, so without this the
+    // PM's and the engineer's tool calls arrive on one stream indistinguishable
+    // from each other. `params.agent_name` (default `"pm"`) is the name the
+    // rest of the taxonomy already uses for this agent.
+    .with_agent(params.agent_name.clone())
     .with_cancel_flag(Arc::clone(&cancel))
     // #2279: mirrors `run_task::execute_run_task`'s own wiring — the PM
     // never calls `bash` itself, so its verify-before-finish gate scans the

--- a/crates/trusty-code/src/task/sink.rs
+++ b/crates/trusty-code/src/task/sink.rs
@@ -21,6 +21,7 @@ use async_trait::async_trait;
 
 use crate::agent_loop::{ContextBudgetSnapshot, ToolEventSink};
 use crate::session::SessionRegistry;
+use crate::tools::telemetry::ToolTelemetry;
 
 /// Forwards `AgentLoop` tool-dispatch hooks to a specific session's
 /// `SessionRegistry::record_tool_*` calls (#2056).
@@ -47,33 +48,73 @@ impl SessionToolEventSink {
 
 #[async_trait]
 impl ToolEventSink for SessionToolEventSink {
-    async fn tool_started(&self, call_id: &str, tool: &str, args_preview: &str) {
+    async fn tool_started(&self, agent: &str, call_id: &str, tool: &str, args_preview: &str) {
         if let Err(e) =
             self.registry
-                .record_tool_started(&self.session_id, tool, call_id, args_preview)
+                .record_tool_started(&self.session_id, agent, tool, call_id, args_preview)
         {
-            tracing::warn!(session_id = %self.session_id, tool, call_id, "record_tool_started failed: {e}");
+            tracing::warn!(session_id = %self.session_id, agent, tool, call_id, "record_tool_started failed: {e}");
         }
     }
 
-    async fn tool_finished(&self, call_id: &str, tool: &str, success: bool, result_preview: &str) {
+    async fn tool_finished(
+        &self,
+        agent: &str,
+        call_id: &str,
+        tool: &str,
+        success: bool,
+        result_preview: &str,
+    ) {
         if let Err(e) = self.registry.record_tool_finished(
             &self.session_id,
+            agent,
             tool,
             call_id,
             success,
             result_preview,
         ) {
-            tracing::warn!(session_id = %self.session_id, tool, call_id, "record_tool_finished failed: {e}");
+            tracing::warn!(session_id = %self.session_id, agent, tool, call_id, "record_tool_finished failed: {e}");
         }
     }
 
-    async fn tool_error(&self, call_id: &str, tool: &str, error: &str) {
-        if let Err(e) = self
-            .registry
-            .record_tool_error(&self.session_id, tool, call_id, error)
+    async fn tool_error(&self, agent: &str, call_id: &str, tool: &str, error: &str) {
+        if let Err(e) =
+            self.registry
+                .record_tool_error(&self.session_id, agent, tool, call_id, error)
         {
-            tracing::warn!(session_id = %self.session_id, tool, call_id, "record_tool_error failed: {e}");
+            tracing::warn!(session_id = %self.session_id, agent, tool, call_id, "record_tool_error failed: {e}");
+        }
+    }
+
+    /// Fan a tool's structured telemetry out to the matching #UI-Phase-1
+    /// `record_*` call.
+    ///
+    /// Why: the variant-to-record mapping belongs here, in the daemon-glue
+    /// layer, rather than in `agent_loop` (which must not know about
+    /// `SessionRegistry`) or in the tools (which must not know about
+    /// sessions at all).
+    /// What: same log-and-swallow contract as the hooks above — a vanished
+    /// session must never derail a run.
+    /// Test: `tests::forwards_search_and_recall_telemetry`.
+    async fn tool_telemetry(
+        &self,
+        agent: &str,
+        call_id: &str,
+        tool: &str,
+        telemetry: &ToolTelemetry,
+    ) {
+        let recorded = match telemetry {
+            ToolTelemetry::Search(t) => {
+                self.registry
+                    .record_search_performed(&self.session_id, agent, t)
+            }
+            ToolTelemetry::Recall(t) => {
+                self.registry
+                    .record_memory_recalled(&self.session_id, agent, t)
+            }
+        };
+        if let Err(e) = recorded {
+            tracing::warn!(session_id = %self.session_id, agent, tool, call_id, "record tool telemetry failed: {e}");
         }
     }
 
@@ -116,7 +157,8 @@ mod tests {
     }
 
     /// Each hook must forward to the matching `record_tool_*` call and
-    /// publish the corresponding #2055 event kind.
+    /// publish the corresponding #2055 event kind, carrying the agent it was
+    /// called with (UI Phase 1).
     #[tokio::test]
     async fn forwards_started_finished_and_error() {
         let registry = Arc::new(SessionRegistry::new());
@@ -124,17 +166,108 @@ mod tests {
         let sink = SessionToolEventSink::new(Arc::clone(&registry), session.id.clone());
         let mut events = crate::events::subscribe();
 
-        sink.tool_started("call-1", "bash", "echo hi").await;
+        sink.tool_started("pm", "call-1", "bash", "echo hi").await;
         let ev = next_event_for(&mut events, &session.id).await;
         assert_eq!(ev.kind, "tool_started");
+        assert!(
+            matches!(ev.event, crate::events::Event::ToolStarted { agent, .. } if agent == "pm")
+        );
 
-        sink.tool_finished("call-1", "bash", true, "hi").await;
+        sink.tool_finished("pm", "call-1", "bash", true, "hi").await;
         let ev = next_event_for(&mut events, &session.id).await;
         assert_eq!(ev.kind, "tool_finished");
 
-        sink.tool_error("call-1", "bash", "boom").await;
+        sink.tool_error("pm", "call-1", "bash", "boom").await;
         let ev = next_event_for(&mut events, &session.id).await;
         assert_eq!(ev.kind, "tool_error");
+    }
+
+    /// ONE shared sink instance must attribute events to whichever agent
+    /// calls it (UI Phase 1).
+    ///
+    /// Why: this is the whole reason `agent` is a per-call PARAMETER rather
+    /// than sink state — `task::executor::run_and_record` clones ONE `Arc` of
+    /// this sink into both the PM's loop and the delegated engineer's runner.
+    /// A sink that carried its own agent name could only ever report one of
+    /// them, leaving the two indistinguishable on the stream.
+    #[tokio::test]
+    async fn one_shared_sink_attributes_each_caller_separately() {
+        let registry = Arc::new(SessionRegistry::new());
+        let session = registry.create("t".to_string(), None, None);
+        let sink: Arc<dyn ToolEventSink> = Arc::new(SessionToolEventSink::new(
+            Arc::clone(&registry),
+            session.id.clone(),
+        ));
+        // Two clones of the ONE Arc, exactly as production wires it.
+        let pm_view = Arc::clone(&sink);
+        let engineer_view = Arc::clone(&sink);
+        let mut events = crate::events::subscribe();
+
+        pm_view
+            .tool_started("pm", "c1", "delegate_to_agent", "{}")
+            .await;
+        let ev = next_event_for(&mut events, &session.id).await;
+        assert!(
+            matches!(ev.event, crate::events::Event::ToolStarted { agent, .. } if agent == "pm")
+        );
+
+        engineer_view
+            .tool_started("python-engineer", "c2", "bash", "cargo test")
+            .await;
+        let ev = next_event_for(&mut events, &session.id).await;
+        assert!(
+            matches!(ev.event, crate::events::Event::ToolStarted { agent, .. }
+                if agent == "python-engineer"),
+            "a shared sink must report the CALLER's agent, not one fixed name"
+        );
+    }
+
+    /// `tool_telemetry` must fan each variant out to its matching structured
+    /// event (UI Phase 1).
+    #[tokio::test]
+    async fn forwards_search_and_recall_telemetry() {
+        let registry = Arc::new(SessionRegistry::new());
+        let session = registry.create("t".to_string(), None, None);
+        let sink = SessionToolEventSink::new(Arc::clone(&registry), session.id.clone());
+        let mut events = crate::events::subscribe();
+
+        sink.tool_telemetry(
+            "python-engineer",
+            "c1",
+            "search_code",
+            &ToolTelemetry::Search(crate::tools::SearchTelemetry {
+                lane: "lexical".to_string(),
+                query: "q".to_string(),
+                hit_count: Some(2),
+                latency_ms: 5,
+            }),
+        )
+        .await;
+        let ev = next_event_for(&mut events, &session.id).await;
+        assert_eq!(ev.kind, "search_performed");
+        assert!(
+            matches!(ev.event, crate::events::Event::SearchPerformed { agent, lane, .. }
+                if agent == "python-engineer" && lane == "lexical")
+        );
+
+        sink.tool_telemetry(
+            "pm",
+            "c2",
+            "recall_session",
+            &ToolTelemetry::Recall(crate::tools::RecallTelemetry {
+                query: "q".to_string(),
+                results: vec![crate::events::RecalledMemory {
+                    score: 0.4,
+                    injected: false,
+                }],
+            }),
+        )
+        .await;
+        let ev = next_event_for(&mut events, &session.id).await;
+        assert_eq!(ev.kind, "memory_recalled");
+        assert!(
+            matches!(ev.event, crate::events::Event::MemoryRecalled { agent, .. } if agent == "pm")
+        );
     }
 
     /// Hooks against an unknown session must not panic (they log and
@@ -143,9 +276,21 @@ mod tests {
     async fn unknown_session_does_not_panic() {
         let registry = Arc::new(SessionRegistry::new());
         let sink = SessionToolEventSink::new(registry, "does-not-exist".to_string());
-        sink.tool_started("c", "bash", "x").await;
-        sink.tool_finished("c", "bash", true, "x").await;
-        sink.tool_error("c", "bash", "x").await;
+        sink.tool_started("pm", "c", "bash", "x").await;
+        sink.tool_finished("pm", "c", "bash", true, "x").await;
+        sink.tool_error("pm", "c", "bash", "x").await;
+        sink.tool_telemetry(
+            "pm",
+            "c",
+            "search_code",
+            &ToolTelemetry::Search(crate::tools::SearchTelemetry {
+                lane: "semantic".to_string(),
+                query: "q".to_string(),
+                hit_count: None,
+                latency_ms: 1,
+            }),
+        )
+        .await;
         sink.context_budget(&budget_snapshot()).await;
     }
 

--- a/crates/trusty-code/src/task/sink.rs
+++ b/crates/trusty-code/src/task/sink.rs
@@ -193,7 +193,7 @@ mod tests {
     #[tokio::test]
     async fn one_shared_sink_attributes_each_caller_separately() {
         let registry = Arc::new(SessionRegistry::new());
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         let sink: Arc<dyn ToolEventSink> = Arc::new(SessionToolEventSink::new(
             Arc::clone(&registry),
             session.id.clone(),
@@ -227,7 +227,7 @@ mod tests {
     #[tokio::test]
     async fn forwards_search_and_recall_telemetry() {
         let registry = Arc::new(SessionRegistry::new());
-        let session = registry.create("t".to_string(), None, None);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
         let sink = SessionToolEventSink::new(Arc::clone(&registry), session.id.clone());
         let mut events = crate::events::subscribe();
 

--- a/crates/trusty-code/src/tools/mod.rs
+++ b/crates/trusty-code/src/tools/mod.rs
@@ -31,6 +31,7 @@ pub mod goals;
 pub mod recall_session;
 pub mod registry;
 pub mod skill;
+pub mod telemetry;
 pub mod traits;
 pub mod trusty_search;
 
@@ -50,6 +51,7 @@ pub use goals::{CLEAR_GOAL_TOOL_NAME, ClearGoalTool, SET_GOAL_TOOL_NAME, SetGoal
 pub use recall_session::{RECALL_SESSION_TOOL_NAME, RecallSessionTool};
 pub use registry::ToolRegistry;
 pub use skill::{USE_SKILL_TOOL_NAME, UseSkillTool};
+pub use telemetry::{RecallTelemetry, SearchTelemetry, ToolTelemetry};
 pub use traits::{
     AgentOutput, AgentRunner, HistoryMessage, RunContext, SearchProvider, SearchResult,
     ServiceTier, SkillResolver, ToolExecutor, ToolResult,

--- a/crates/trusty-code/src/tools/recall_session.rs
+++ b/crates/trusty-code/src/tools/recall_session.rs
@@ -40,7 +40,9 @@ use tracing::warn;
 use trusty_common::mcp::memory_rpc::call_memory_tool_at;
 
 use crate::agent_loop::estimate_tokens;
+use crate::events::RecalledMemory;
 use crate::memory_envelope::{parse_tools_call_envelope, tools_call_params};
+use crate::tools::telemetry::{RecallTelemetry, ToolTelemetry};
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
 /// The tool's registered/advertised name.
@@ -154,8 +156,16 @@ fn filter_and_cap(results: &[Value], tag: &str, top_k: usize) -> Vec<Value> {
 /// asked for, so an operator diagnosing "the model missed a fact it should
 /// have recalled" needs this visible from stderr, not just inferable from
 /// the rendered text length.
-/// Test: `tests::render_drops_whole_lowest_scored_entries_over_budget`.
-fn render_results(query: &str, results: &[Value]) -> String {
+///
+/// (UI Phase 1) Also returns HOW MANY leading results made it into that
+/// text. Because the loop takes a strict prefix (it `break`s at the first
+/// over-budget entry rather than skipping it and trying the next), the
+/// included set is always `results[..injected_count]` — so one count fully
+/// describes the injected/held-back split, and
+/// [`recall_telemetry`] turns it into the per-result `injected` flags.
+/// Test: `tests::render_drops_whole_lowest_scored_entries_over_budget`,
+/// `tests::render_includes_all_entries_within_budget`.
+fn render_results(query: &str, results: &[Value]) -> (String, usize) {
     let mut entries: Vec<String> = Vec::new();
     let mut budget_used = 0usize;
     for r in results {
@@ -176,10 +186,41 @@ fn render_results(query: &str, results: &[Value]) -> String {
             "recall_session: token budget exceeded — dropping lowest-scored result(s)"
         );
     }
-    format!(
-        "Session memory results for \"{query}\":\n\n{}",
-        entries.join("\n\n---\n\n")
+    let injected_count = entries.len();
+    (
+        format!(
+            "Session memory results for \"{query}\":\n\n{}",
+            entries.join("\n\n---\n\n")
+        ),
+        injected_count,
     )
+}
+
+/// Build the structured account of what was recalled and what reached the
+/// model (UI Phase 1).
+///
+/// Why: this is the whole point of `Event::MemoryRecalled` — the UI renders
+/// held-back memories ("41% · held") beside injected ones, and only this
+/// tool ever knows which was which.
+/// What: `results` is the filtered/capped, score-sorted list; the first
+/// `injected_count` of them entered context (see [`render_results`]) and the
+/// rest were recalled but dropped whole by the token budget. A result whose
+/// entry carries no numeric `score` reports `0.0` rather than being omitted
+/// — the UI must still see that the memory was recalled and held back.
+/// Test: `tests::telemetry_marks_budget_dropped_results_held_back`,
+/// `tests::telemetry_marks_all_injected_when_within_budget`.
+fn recall_telemetry(query: &str, results: &[Value], injected_count: usize) -> RecallTelemetry {
+    RecallTelemetry {
+        query: query.to_string(),
+        results: results
+            .iter()
+            .enumerate()
+            .map(|(i, r)| RecalledMemory {
+                score: r.get("score").and_then(Value::as_f64).unwrap_or(0.0),
+                injected: i < injected_count,
+            })
+            .collect(),
+    }
 }
 
 #[async_trait]
@@ -290,7 +331,15 @@ impl ToolExecutor for RecallSessionTool {
             ));
         }
 
-        ToolResult::ok(render_results(&parsed.query, &filtered))
+        // (UI Phase 1) The render decides the injected/held-back split; the
+        // telemetry reports it. Both derive from the SAME call so they can
+        // never disagree about what the model actually saw.
+        let (text, injected_count) = render_results(&parsed.query, &filtered);
+        ToolResult::ok(text).with_telemetry(ToolTelemetry::Recall(recall_telemetry(
+            &parsed.query,
+            &filtered,
+            injected_count,
+        )))
     }
 }
 
@@ -373,7 +422,7 @@ mod tests {
             r["content"] = json!("small tail entry");
             r
         }];
-        let rendered = render_results("q", &results);
+        let (rendered, injected_count) = render_results("q", &results);
         assert!(
             rendered.contains(&huge),
             "first entry always included whole"
@@ -382,6 +431,7 @@ mod tests {
             !rendered.contains("small tail entry"),
             "second (lower-scored) entry must be dropped whole, not merged/truncated in"
         );
+        assert_eq!(injected_count, 1, "only the first entry entered context");
     }
 
     #[test]
@@ -390,9 +440,124 @@ mod tests {
             result_entry("first", 0.9, &["session:s1"]),
             result_entry("second", 0.8, &["session:s1"]),
         ];
-        let rendered = render_results("q", &results);
+        let (rendered, injected_count) = render_results("q", &results);
         assert!(rendered.contains("first"));
         assert!(rendered.contains("second"));
+        assert_eq!(
+            injected_count, 2,
+            "both entries fit, so both entered context"
+        );
+    }
+
+    // ── telemetry (UI Phase 1) ───────────────────────────────────────────
+
+    /// Extract the `RecallTelemetry` a result carries, or panic.
+    fn recall_telemetry_of(result: &ToolResult) -> &RecallTelemetry {
+        match result.telemetry() {
+            Some(ToolTelemetry::Recall(t)) => t,
+            other => panic!("expected recall telemetry, got {other:?}"),
+        }
+    }
+
+    /// A result the token budget dropped must be reported as recalled but
+    /// NOT injected — the UI's "41% · held" surface.
+    ///
+    /// Why: THE point of `Event::MemoryRecalled`. The tool has always known
+    /// which results its budget dropped; before this ticket that knowledge
+    /// died inside the rendered text. `injected: false` must mean exactly
+    /// "recalled but not entered into context".
+    /// What: two results where the first alone busts the budget; assert the
+    /// second is present in the telemetry, flagged held-back, with its score.
+    /// Test: this test.
+    #[test]
+    fn telemetry_marks_budget_dropped_results_held_back() {
+        let huge = "x".repeat((TOKEN_BUDGET + 100) * 4);
+        let results = vec![
+            result_entry(&huge, 0.9, &["session:s1"]),
+            result_entry("held back", 0.41, &["session:s1"]),
+        ];
+        let (_text, injected_count) = render_results("q", &results);
+        let telemetry = recall_telemetry("q", &results, injected_count);
+
+        assert_eq!(
+            telemetry.results,
+            vec![
+                RecalledMemory {
+                    score: 0.9,
+                    injected: true
+                },
+                RecalledMemory {
+                    score: 0.41,
+                    injected: false
+                },
+            ],
+            "a budget-dropped result must still be REPORTED, flagged held-back \
+             — dropping it from the telemetry too would hide it from the UI \
+             entirely, which is the exact opposite of the requirement"
+        );
+    }
+
+    /// Every result that fit the budget must be reported injected.
+    #[test]
+    fn telemetry_marks_all_injected_when_within_budget() {
+        let results = vec![
+            result_entry("first", 0.9, &["session:s1"]),
+            result_entry("second", 0.8, &["session:s1"]),
+        ];
+        let (_text, injected_count) = render_results("q", &results);
+        let telemetry = recall_telemetry("q", &results, injected_count);
+
+        assert!(
+            telemetry.results.iter().all(|r| r.injected),
+            "both fit, so both entered context: {:?}",
+            telemetry.results
+        );
+        assert_eq!(telemetry.query, "q");
+    }
+
+    /// `execute` must attach telemetry whose injected flags agree with the
+    /// text it actually returned (UI Phase 1).
+    ///
+    /// Why: an end-to-end guard that the render and the telemetry can never
+    /// disagree about what the model saw — the failure mode a UI could not
+    /// detect on its own.
+    /// Test: this test.
+    #[tokio::test]
+    async fn execute_attaches_telemetry_matching_the_rendered_text() {
+        let results = vec![
+            result_entry("visible one", 0.9, &["session:s1", "turn"]),
+            result_entry("visible two", 0.7, &["session:s1", "turn"]),
+        ];
+        let (base_url, _captured) = spawn_recall_mock(results).await;
+        let tool = RecallSessionTool::new("s1", base_url, "p");
+
+        let result = tool.execute(json!({"query": "foo"})).await;
+        let telemetry = recall_telemetry_of(&result);
+
+        assert_eq!(telemetry.query, "foo");
+        assert_eq!(telemetry.results.len(), 2);
+        for (i, r) in telemetry.results.iter().enumerate() {
+            assert!(r.injected, "result {i} is in the text, so it is injected");
+        }
+        assert!(result.content().contains("visible one"));
+        assert!(result.content().contains("visible two"));
+    }
+
+    /// The fail-open paths must attach no telemetry — nothing was recalled.
+    ///
+    /// Why: emitting a `MemoryRecalled` with an empty result set for an
+    /// unreachable daemon would tell the UI "we recalled nothing relevant"
+    /// when the truth is "we could not look". Those are different facts.
+    /// Test: this test.
+    #[tokio::test]
+    async fn fail_open_paths_report_no_telemetry() {
+        let tool = RecallSessionTool::new("s1", "http://127.0.0.1:1", "p");
+        let result = tool.execute(json!({"query": "anything"})).await;
+        assert!(!result.is_error());
+        assert!(
+            result.telemetry().is_none(),
+            "an unreachable daemon is not a recall with zero results"
+        );
     }
 
     /// Dropping a lowest-scored result for budget emits an INFO-level log

--- a/crates/trusty-code/src/tools/telemetry.rs
+++ b/crates/trusty-code/src/tools/telemetry.rs
@@ -1,0 +1,80 @@
+//! Structured telemetry a tool reports ALONGSIDE its rendered text (UI Phase 1).
+//!
+//! Why: the retrieval tools already know things the UI needs and the event
+//! stream throws away. `search_code` knows which trusty-search lane actually
+//! served a query, how many hits came back, and what it cost;
+//! `recall_session` knows every result's score and which ones its token
+//! budget dropped. Today all of that is flattened into prose and then
+//! TRUNCATED into an `args_preview`/`result_preview` string. This module is
+//! the escape hatch: a tool returns structured data attached to its
+//! [`crate::tools::ToolResult`], and the agent loop — the one layer that
+//! knows WHICH agent is running and owns the `ToolEventSink` — forwards it.
+//!
+//! The alternative (handing every tool a sink plus its own agent name at
+//! construction) was rejected: it would make each tool's attribution an
+//! independent copy of the loop's, free to drift, and would force the
+//! fail-open retrieval tools to grow a second reason to fail. Tools stay
+//! pure functions of their arguments — unit-testable with no sink, no
+//! session, and no bus — and attribution keeps ONE source of truth.
+//! What: [`ToolTelemetry`] is the tool -> loop payload, one variant per
+//! structured event kind. It is deliberately NOT the wire type: the wire
+//! types live in `crate::events` and are built from this by the sink, which
+//! is where `session_id` and `agent` get stamped on.
+//! Test: `crate::agent_loop::tests::sink_events::sink_receives_tool_telemetry_with_agent`
+//! (forwarding), plus each tool's own `telemetry_*` tests (production).
+
+use crate::events::RecalledMemory;
+
+/// Structured data a tool reports about what it actually did (UI Phase 1).
+///
+/// Why: see the module docs — this is the seam that lets a tool's internal
+/// knowledge (real search lane, per-memory scores, what entered context)
+/// reach the event stream as DATA instead of dying inside its rendered text.
+/// What: one variant per structured event kind; `None` on a `ToolResult`
+/// means "this tool has nothing structured to say", which is every tool but
+/// the two retrieval tools.
+/// Test: `tools::traits::tests::tool_result_carries_optional_telemetry`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ToolTelemetry {
+    /// A `search_code` call — becomes `Event::SearchPerformed`.
+    Search(SearchTelemetry),
+    /// A `recall_session` call — becomes `Event::MemoryRecalled`.
+    Recall(RecallTelemetry),
+}
+
+/// What a `search_code` call actually did (UI Phase 1).
+///
+/// Why: the UI traces a change back to the searches that drove it, which
+/// needs the REAL lane rather than the mode the model requested — those
+/// differ whenever a not-yet-built index forces a lexical retry (#2783).
+/// What: `lane` is the lane that served the results; `hit_count` is `None`
+/// when the result shape could not be counted (never a misleading `0`);
+/// `latency_ms` covers the whole call including any retry.
+/// Test: `tools::trusty_search_tests::telemetry_reports_lexical_fallback_lane`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchTelemetry {
+    /// The trusty-search lane that actually served this query.
+    pub lane: String,
+    /// The query as the model asked it.
+    pub query: String,
+    /// Hits returned, or `None` when uncountable.
+    pub hit_count: Option<usize>,
+    /// Wall-clock duration of the whole tool call.
+    pub latency_ms: u64,
+}
+
+/// What a `recall_session` call recalled, and what reached the model
+/// (UI Phase 1).
+///
+/// Why: `injected` is the differentiating signal — see
+/// [`crate::events::Event::MemoryRecalled`].
+/// What: `results` stays in the daemon's score-sorted (highest-first) order.
+/// Test: `tools::recall_session::tests::telemetry_marks_budget_dropped_results_held_back`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RecallTelemetry {
+    /// The query as the model asked it.
+    pub query: String,
+    /// Every recalled result, score-sorted highest-first, each flagged with
+    /// whether it entered context.
+    pub results: Vec<RecalledMemory>,
+}

--- a/crates/trusty-code/src/tools/telemetry.rs
+++ b/crates/trusty-code/src/tools/telemetry.rs
@@ -50,7 +50,7 @@ pub enum ToolTelemetry {
 /// What: `lane` is the lane that served the results; `hit_count` is `None`
 /// when the result shape could not be counted (never a misleading `0`);
 /// `latency_ms` covers the whole call including any retry.
-/// Test: `tools::trusty_search_tests::telemetry_reports_lexical_fallback_lane`.
+/// Test: `tools::trusty_search_tests::resolved_lane_reports_lexical_when_the_retry_served_it`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SearchTelemetry {
     /// The trusty-search lane that actually served this query.

--- a/crates/trusty-code/src/tools/traits.rs
+++ b/crates/trusty-code/src/tools/traits.rs
@@ -16,6 +16,8 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::tools::telemetry::ToolTelemetry;
+
 // ── ToolResult ──────────────────────────────────────────────────────────────
 
 /// Structured result of a tool execution.
@@ -25,26 +27,76 @@ use serde_json::Value;
 /// explain the failure in its final answer). A structured error lets the caller
 /// surface failure back to the LLM as a `tool_result` with `is_error: true`
 /// while keeping the loop running.
-/// What: `Success(String)` carries a successful textual result; `Error` carries
-/// a message plus a `recoverable` flag.
+/// What: `Success` carries a successful textual result plus (UI Phase 1) an
+/// optional [`ToolTelemetry`] side-channel; `Error` carries a message plus a
+/// `recoverable` flag.
 /// Test: `ToolResult::err(...).is_error()` is true; `ok(...).content()` returns
 /// the success string. Exercised in `tools::registry` and delegate tests.
 #[derive(Debug)]
 pub enum ToolResult {
-    /// Tool executed successfully; inner string is the textual result.
-    Success(String),
+    /// Tool executed successfully.
+    ///
+    /// `text` is the textual result fed back to the model. `telemetry`
+    /// (UI Phase 1) is the structured account of what the tool actually did,
+    /// which the agent loop forwards to its `ToolEventSink` — see
+    /// `crate::tools::telemetry` for why this rides on the result rather than
+    /// each tool holding a sink. `None` for every tool that has nothing
+    /// structured to report, which is all but the retrieval tools.
+    Success {
+        text: String,
+        telemetry: Option<Box<ToolTelemetry>>,
+    },
     /// Tool failed; `message` describes why; `recoverable` advises the LLM loop.
     Error { message: String, recoverable: bool },
 }
 
 impl ToolResult {
-    /// Construct a successful result.
+    /// Construct a successful result with no telemetry.
     ///
-    /// Why: Single canonical happy-path constructor used by every tool.
-    /// What: Wraps `s` in `Success`.
+    /// Why: Single canonical happy-path constructor used by every tool. Tools
+    /// with structured telemetry chain [`Self::with_telemetry`] onto this
+    /// rather than needing a second constructor.
+    /// What: Wraps `s` in `Success` with `telemetry: None`.
     /// Test: Trivially exercised by every successful tool execute().
     pub fn ok(s: impl Into<String>) -> Self {
-        ToolResult::Success(s.into())
+        ToolResult::Success {
+            text: s.into(),
+            telemetry: None,
+        }
+    }
+
+    /// Attach structured telemetry to a successful result (UI Phase 1).
+    ///
+    /// Why: lets a tool report what it actually did (real search lane, which
+    /// memories entered context) without knowing which agent runs it or
+    /// owning an event sink — see `crate::tools::telemetry`'s module docs.
+    /// What: builder-style; a no-op on an `Error` result, because the event
+    /// shapes this feeds describe work that produced results, and an errored
+    /// tool has none to describe — its failure is already narrated by
+    /// `ToolFinished`/`ToolError`.
+    /// Test: `tests::tool_result_carries_optional_telemetry`,
+    /// `tests::with_telemetry_is_a_no_op_on_error`.
+    pub fn with_telemetry(self, telemetry: ToolTelemetry) -> Self {
+        match self {
+            ToolResult::Success { text, .. } => ToolResult::Success {
+                text,
+                telemetry: Some(Box::new(telemetry)),
+            },
+            error => error,
+        }
+    }
+
+    /// The structured telemetry this result carries, if any (UI Phase 1).
+    ///
+    /// Why: the agent loop reads this after every dispatch to decide whether
+    /// to emit a structured event alongside the generic tool events.
+    /// What: `None` for errors and for any tool that reported none.
+    /// Test: `tests::tool_result_carries_optional_telemetry`.
+    pub fn telemetry(&self) -> Option<&ToolTelemetry> {
+        match self {
+            ToolResult::Success { telemetry, .. } => telemetry.as_deref(),
+            ToolResult::Error { .. } => None,
+        }
     }
 
     /// Construct a recoverable error.
@@ -107,7 +159,7 @@ impl ToolResult {
     ///       `ToolResult::err("oops").content()` == "oops".
     pub fn content(&self) -> &str {
         match self {
-            ToolResult::Success(s) => s.as_str(),
+            ToolResult::Success { text, .. } => text.as_str(),
             ToolResult::Error { message, .. } => message.as_str(),
         }
     }
@@ -486,6 +538,54 @@ mod tests {
         assert!(fatal.is_error());
         assert!(fatal.is_fatal());
         assert_eq!(fatal.content(), "crash");
+    }
+
+    /// A successful result must carry telemetry when a tool attaches it, and
+    /// none by default (UI Phase 1).
+    ///
+    /// Why: `None` by default is what keeps every non-retrieval tool's
+    /// behaviour byte-identical to pre-ticket.
+    /// Test: this test.
+    #[test]
+    fn tool_result_carries_optional_telemetry() {
+        use crate::tools::telemetry::{SearchTelemetry, ToolTelemetry};
+
+        assert!(
+            ToolResult::ok("plain").telemetry().is_none(),
+            "tools that report nothing structured must stay unaffected"
+        );
+
+        let telemetry = ToolTelemetry::Search(SearchTelemetry {
+            lane: "semantic".to_string(),
+            query: "q".to_string(),
+            hit_count: Some(3),
+            latency_ms: 7,
+        });
+        let result = ToolResult::ok("hits").with_telemetry(telemetry.clone());
+        assert_eq!(result.telemetry(), Some(&telemetry));
+        assert_eq!(result.content(), "hits", "the text must be untouched");
+    }
+
+    /// Attaching telemetry to an error must be a no-op (UI Phase 1).
+    ///
+    /// Why: the structured events describe work that produced results; an
+    /// errored tool has none to describe, and its failure is already narrated
+    /// by `ToolFinished`/`ToolError`.
+    /// Test: this test.
+    #[test]
+    fn with_telemetry_is_a_no_op_on_error() {
+        use crate::tools::telemetry::{SearchTelemetry, ToolTelemetry};
+
+        let result =
+            ToolResult::err("boom").with_telemetry(ToolTelemetry::Search(SearchTelemetry {
+                lane: "semantic".to_string(),
+                query: "q".to_string(),
+                hit_count: None,
+                latency_ms: 1,
+            }));
+        assert!(result.is_error());
+        assert!(result.telemetry().is_none());
+        assert_eq!(result.content(), "boom");
     }
 
     /// Verify `AgentOutput::summary_or_content` fallback.

--- a/crates/trusty-code/src/tools/trusty_search.rs
+++ b/crates/trusty-code/src/tools/trusty_search.rs
@@ -43,6 +43,7 @@ use tokio::sync::{Mutex, OnceCell};
 use tracing::warn;
 use trusty_common::stdio_mcp_client::StdioMcpClient;
 
+use crate::tools::telemetry::{SearchTelemetry, ToolTelemetry};
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
 /// The tool's registered/advertised name.
@@ -333,6 +334,93 @@ async fn lexical_fallback(
     mcp_text(&result)
 }
 
+/// The trusty-search lane that ACTUALLY served a query (UI Phase 1).
+///
+/// Why: the mode the model asks for and the lane that answers are not the
+/// same thing — a `semantic`/`symbol` query against a still-building index
+/// transparently retries on the lexical lane (#2783). Reporting the
+/// requested mode would tell the UI a comfortable lie about how a change was
+/// discovered; this reports what happened.
+/// What: `label()` is the stable wire string carried by
+/// `Event::SearchPerformed.lane`. `Lexical` is only ever reached via the
+/// stage-not-ready retry — it is not a mode the model can request.
+/// Test: `tests::lane_labels_are_stable`,
+/// `tests::telemetry_reports_lexical_fallback_lane`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchLane {
+    /// `search_semantic` — embedding similarity.
+    Semantic,
+    /// `search_kg` — call-graph expansion around a symbol.
+    Symbol,
+    /// `grep` — regex/literal over indexed files.
+    Grep,
+    /// `search_lexical` — the degraded lane served during index warm-up.
+    Lexical,
+}
+
+impl SearchLane {
+    /// Resolve the lane a requested `mode` routes to (before any retry).
+    ///
+    /// Why: `build_call`'s mode matching and the telemetry lane must never
+    /// drift apart; both derive from this one mapping.
+    /// What: mirrors `build_call` exactly, including its "anything unknown is
+    /// semantic" default.
+    /// Test: `tests::lane_from_mode_matches_build_call_routing`.
+    fn from_mode(mode: &str) -> Self {
+        match mode {
+            "grep" => SearchLane::Grep,
+            "symbol" => SearchLane::Symbol,
+            _ => SearchLane::Semantic,
+        }
+    }
+
+    /// Resolve the lane that ACTUALLY served a query.
+    ///
+    /// Why: the one place the "which lane really answered?" question is
+    /// decided, so the answer the telemetry reports cannot drift from what
+    /// `execute` did — and so the lexical-retry case is unit-testable without
+    /// a live trusty-search daemon and a half-built index.
+    /// What: a stage-not-ready retry means the LEXICAL lane served the
+    /// results, whatever the model asked for; otherwise the requested mode's
+    /// lane did.
+    /// Test: `tests::resolved_lane_reports_lexical_when_the_retry_served_it`.
+    fn resolved(mode: &str, lexical_fallback_used: bool) -> Self {
+        if lexical_fallback_used {
+            SearchLane::Lexical
+        } else {
+            SearchLane::from_mode(mode)
+        }
+    }
+
+    /// The stable wire label for this lane.
+    fn label(self) -> &'static str {
+        match self {
+            SearchLane::Semantic => "semantic",
+            SearchLane::Symbol => "symbol",
+            SearchLane::Grep => "grep",
+            SearchLane::Lexical => "lexical",
+        }
+    }
+}
+
+/// Count the hits in a trusty-search result payload (UI Phase 1).
+///
+/// Why: the UI renders "N hits" beside a search, and the count is otherwise
+/// only recoverable by re-parsing the tool's rendered prose.
+/// What: every trusty-search lane wraps its payload as a JSON object with an
+/// array under `results`, `hits`, or `matches` — the three keys observed
+/// across the semantic/KG/grep/lexical lanes. Returns `None` when `text` is
+/// not JSON or carries no recognisable array, so an uncountable shape is
+/// reported honestly as "unknown" rather than as a misleading `0`.
+/// Test: `tests::count_hits_reads_each_lane_shape`,
+/// `tests::count_hits_is_none_for_unrecognised_payloads`.
+fn count_hits(text: &str) -> Option<usize> {
+    let body: Value = serde_json::from_str(text).ok()?;
+    ["results", "hits", "matches"]
+        .iter()
+        .find_map(|key| body.get(*key).and_then(Value::as_array).map(Vec::len))
+}
+
 /// Build the MCP arguments for `mode`, returning the tool name + params.
 ///
 /// Why: keeps `execute` linear — each mode maps to one trusty-search lane with
@@ -432,12 +520,17 @@ impl ToolExecutor for TrustySearchTool {
     /// naming the mode and lane, so an operator can tell from stderr that a
     /// run's discovery quality was degraded, matching this method's other
     /// two `tracing::warn!` sites for a hard call failure / in-band error.
+    /// (UI Phase 1) Every path that actually reached a lane attaches a
+    /// [`SearchTelemetry`] carrying the REAL routed lane, the hit count, and
+    /// the whole call's latency — see [`SearchLane`]. The fail-open paths
+    /// (no daemon, no index, lane error with no usable retry) attach none:
+    /// they never reached a lane, so there is no search to report; the
+    /// generic tool events still narrate them.
     /// Test: `tests::execute_fail_open_when_binary_absent`,
-    /// `tests::execute_rejects_malformed_args_recoverably`; the lexical-
-    /// fallback branch itself is exercised end-to-end only where a live
-    /// daemon is available (`lexical_fallback`'s own doc), with its decision
-    /// predicate covered by `tests::should_lexical_fallback_only_for_stage_not_ready`.
+    /// `tests::execute_rejects_malformed_args_recoverably`,
+    /// `tests::resolved_lane_reports_lexical_when_the_retry_served_it`.
     async fn execute(&self, args: Value) -> ToolResult {
+        let started = std::time::Instant::now();
         let parsed: SearchArgs = match serde_json::from_value(args) {
             Ok(p) => p,
             Err(e) => {
@@ -449,6 +542,18 @@ impl ToolExecutor for TrustySearchTool {
         };
         let top_k = parsed.top_k.unwrap_or(DEFAULT_TOP_K).clamp(1, MAX_TOP_K);
         let mode = parsed.mode.as_deref().unwrap_or("semantic");
+
+        // (UI Phase 1) Stamp the telemetry from the lane that ACTUALLY served
+        // the query, measured at the moment of return so `latency_ms` covers
+        // any transparent retry too.
+        let telemetry = |lane: SearchLane, text: &str| {
+            ToolTelemetry::Search(SearchTelemetry {
+                lane: lane.label().to_string(),
+                query: parsed.query.clone(),
+                hit_count: count_hits(text),
+                latency_ms: started.elapsed().as_millis() as u64,
+            })
+        };
 
         let Some(session) = self.session().await else {
             return ToolResult::ok(FALLBACK_HINT.to_string());
@@ -490,10 +595,13 @@ impl ToolExecutor for TrustySearchTool {
                     "search_code: {lane_label} index not ready (STAGE_NOT_READY, #2783) — \
                      serving degraded lexical results instead"
                 );
+                // The requested lane did NOT serve this — the lexical lane
+                // did. Report that, not the mode the model asked for.
                 return ToolResult::ok(format!(
                     "trusty-search's {lane_label} index is still building; \
                      showing lexical (exact-match) results instead:\n{text}"
-                ));
+                ))
+                .with_telemetry(telemetry(SearchLane::resolved(mode, true), &text));
             }
             warn!(
                 tool,
@@ -506,7 +614,8 @@ impl ToolExecutor for TrustySearchTool {
         }
 
         match mcp_text(&result) {
-            Some(text) => ToolResult::ok(format!("trusty-search ({mode}) results:\n{text}")),
+            Some(text) => ToolResult::ok(format!("trusty-search ({mode}) results:\n{text}"))
+                .with_telemetry(telemetry(SearchLane::resolved(mode, false), &text)),
             None => ToolResult::ok(format!(
                 "trusty-search returned no results. {FALLBACK_HINT}"
             )),

--- a/crates/trusty-code/src/tools/trusty_search.rs
+++ b/crates/trusty-code/src/tools/trusty_search.rs
@@ -345,7 +345,7 @@ async fn lexical_fallback(
 /// `Event::SearchPerformed.lane`. `Lexical` is only ever reached via the
 /// stage-not-ready retry — it is not a mode the model can request.
 /// Test: `tests::lane_labels_are_stable`,
-/// `tests::telemetry_reports_lexical_fallback_lane`.
+/// `tests::resolved_lane_reports_lexical_when_the_retry_served_it`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SearchLane {
     /// `search_semantic` — embedding similarity.

--- a/crates/trusty-code/src/tools/trusty_search_tests.rs
+++ b/crates/trusty-code/src/tools/trusty_search_tests.rs
@@ -224,3 +224,95 @@ async fn execute_rejects_malformed_args_recoverably() {
     assert!(result.is_error());
     assert!(!result.is_fatal());
 }
+
+// ── UI Phase 1: lane resolution + hit counting + telemetry ──────────────────
+
+/// Why: the requested `mode` must map to the SAME lane `build_call` routes to
+/// — if these two ever disagree, the telemetry reports a lane that never ran.
+#[test]
+fn lane_from_mode_matches_build_call_routing() {
+    // The MCP tool name `build_call` picks IS the lane, so asserting the pair
+    // agree pins them together.
+    for (mode, expect_lane, expect_tool) in [
+        ("grep", SearchLane::Grep, "grep"),
+        ("symbol", SearchLane::Symbol, "search_kg"),
+        ("semantic", SearchLane::Semantic, "search_semantic"),
+        // An unknown mode defaults to semantic in BOTH.
+        ("nonsense", SearchLane::Semantic, "search_semantic"),
+    ] {
+        assert_eq!(SearchLane::from_mode(mode), expect_lane, "lane for {mode}");
+        let (tool, _params) = build_call(mode, "q", 5, Some("idx")).expect("routes");
+        assert_eq!(tool, expect_tool, "build_call tool for {mode}");
+    }
+}
+
+/// Why: the lane labels are wire values on `Event::SearchPerformed.lane`; a UI
+/// switches on them, so they must not drift.
+#[test]
+fn lane_labels_are_stable() {
+    assert_eq!(SearchLane::Semantic.label(), "semantic");
+    assert_eq!(SearchLane::Symbol.label(), "symbol");
+    assert_eq!(SearchLane::Grep.label(), "grep");
+    assert_eq!(SearchLane::Lexical.label(), "lexical");
+}
+
+/// Why: THE requirement — the event must carry the lane that ACTUALLY served
+/// the query, not the one the model asked for. When a still-building index
+/// forces the lexical retry (#2783), a `semantic` request is really answered
+/// by the lexical lane, and reporting "semantic" would tell the UI a
+/// comfortable lie about how the code was discovered.
+#[test]
+fn resolved_lane_reports_lexical_when_the_retry_served_it() {
+    // Retry fired: whatever was asked, LEXICAL answered.
+    assert_eq!(
+        SearchLane::resolved("semantic", true),
+        SearchLane::Lexical,
+        "a semantic query served by the lexical retry is a LEXICAL search"
+    );
+    assert_eq!(SearchLane::resolved("symbol", true), SearchLane::Lexical);
+
+    // No retry: the requested lane answered.
+    assert_eq!(
+        SearchLane::resolved("semantic", false),
+        SearchLane::Semantic
+    );
+    assert_eq!(SearchLane::resolved("symbol", false), SearchLane::Symbol);
+    assert_eq!(SearchLane::resolved("grep", false), SearchLane::Grep);
+}
+
+/// Why: the UI renders a hit count; each lane wraps its payload differently,
+/// so the counter must read all the observed shapes.
+#[test]
+fn count_hits_reads_each_lane_shape() {
+    assert_eq!(count_hits(r#"{"results":[{"a":1},{"a":2}]}"#), Some(2));
+    assert_eq!(count_hits(r#"{"hits":[{"a":1}]}"#), Some(1));
+    assert_eq!(count_hits(r#"{"matches":[]}"#), Some(0));
+}
+
+/// Why: an uncountable payload must report `None`, never `0` — "we could not
+/// count" and "there were no hits" are different facts, and a UI showing a
+/// confident `0 hits` for the former would be wrong.
+#[test]
+fn count_hits_is_none_for_unrecognised_payloads() {
+    assert_eq!(count_hits("not json at all"), None);
+    assert_eq!(count_hits(r#"{"unexpected":"shape"}"#), None);
+    assert_eq!(
+        count_hits(r#"{"results":"not-an-array"}"#),
+        None,
+        "a non-array under a known key is uncountable, not empty"
+    );
+}
+
+/// Why: the fail-open paths never reached a lane, so there is no search to
+/// report — a `SearchPerformed` event for them would invent a search that
+/// never happened.
+#[tokio::test]
+async fn fail_open_paths_report_no_telemetry() {
+    let tool = TrustySearchTool::new(std::env::temp_dir())
+        .with_binary("trusty-search-definitely-not-installed-xyzzy");
+    let result = tool.execute(json!({ "query": "how does auth work" })).await;
+    assert!(
+        result.telemetry().is_none(),
+        "an absent daemon is not a search with zero hits"
+    );
+}


### PR DESCRIPTION
## Why

The tcode UI's core bet is that a change is explained by **the agent, the searches, and the memories that produced it** — prompts are thin. The event stream could not support that:

- tool events named **no agent** — a client could only guess whether a call came from the PM or a delegated engineer by interleaving the stream against `AgentSpawned`/`AgentDone` ordering, which breaks the moment their calls overlap;
- `search_code` and `recall_session` flattened everything they knew into **truncated string previews**.

Per the binding principle — *the UI is a thin client; anything it needs is a daemon API* — this makes all three facts first-class events.

## 1. Agent attribution (the keystone)

`ToolStarted` / `ToolFinished` / `ToolError` gain an `agent` field.

**`agent` is a per-call PARAMETER on `ToolEventSink`, not sink state.** This is the load-bearing design point: ONE `Arc<dyn ToolEventSink>` is shared by the PM's loop and every delegated sub-agent's loop (`task::executor::run_and_record` clones the same handle into both), so a sink carrying its own name could only ever report one of them. The dispatching `AgentLoop` is the only layer that knows its own identity, so it passes it per call — declared via the new `AgentLoop::with_agent`, wired at both production sites (PM: `params.agent_name`, default `"pm"`; sub-agents: the runner's `agent_name`, the single construction site both entry points delegate through).

### agent_name vs stable agent_id — decision

**Chose `agent: String` (the NAME).** The prior investigation flagged name-keying as "not a stable join key", and that's fair — but for Phase 1 the name is the *right* trade:

- Every agent-keyed variant in this taxonomy already uses the name (`AgentSpawned.agent`, `PmDelegating.agent`, `LlmRequested.agent_name`). A stable id would introduce a **third** correlation scheme and leave the UI joining names *and* ids.
- `call_id` already uniquely correlates a single invocation's start/finish/error, so an id buys nothing for the tool-lifecycle events themselves.
- A real id means threading identity through delegation and re-keying the existing agent events — a larger, separate change.

**Accepted Phase-1 limitation, stated plainly:** two *concurrent* agents with the same name would be indistinguishable. Today they can't be (one PM, sequential delegations). If parallel same-name delegation lands, a stable id should be introduced and the existing `agent_name`-keyed variants unified with it in the same change — not bolted on beside them. Nothing here is left inconsistent: every agent-keyed event in this crate uses the same key.

## 2 & 3. Structured retrieval events — **additive**

Emitted **alongside, never instead of**, the generic tool events, so every existing consumer sees a byte-identical stream and a UI can adopt these incrementally. (Chosen deliberately per the brief's "prefer additive"; nothing was removed.)

- **`search_performed{agent, lane, query, hit_count, latency_ms}}`** — `lane` is the lane trusty-search **actually served**. A `semantic`/`symbol` query against a still-building index transparently retries on the lexical lane (#2783), and that degraded reality now reports `lane: "lexical"` instead of claiming a semantic search that never ran. `hit_count` is `null` when the payload shape can't be counted — never a misleading `0`, which reads as "no hits".
- **`memory_recalled{agent, query, results:[{score, injected}]}`** — **`injected: false` means exactly "recalled but not entered into context"**. `recall_session` has always known the scores and which results its token budget dropped whole; that knowledge died inside the rendered text. This is the UI's differentiating surface ("PKCE required… 41% · held").

The fail-open paths (absent daemon, no index, unreachable memory) attach **no** telemetry — they never reached a lane, so there is no search to report. "We couldn't look" and "we found nothing" are different facts.

## How the data escapes the tools

Tools report via `ToolResult::with_telemetry`; the loop forwards it to the new `ToolEventSink::tool_telemetry` hook. **Tools stay pure functions of their arguments** — no sink, no session, no agent name — so attribution keeps ONE source of truth and each tool remains unit-testable without a bus. The rejected alternative (handing every tool a sink + its own agent name) would have made each tool's attribution an independent copy of the loop's, free to drift.

`ToolResult::Success` becomes a struct variant (`{text, telemetry}`); `ok`/`content`/`is_error` are unchanged, so **no tool call site moved**. `tool_telemetry` has a default no-op body, so every pre-existing sink impl compiles untouched.

## Tests

Beyond the required cases, the two load-bearing assertions were **mutation-tested** — each genuinely fails when the behaviour is broken, rather than passing vacuously:

- mis-attributing the engineer's loop as `pm` → `runner::tests::sink_reaches_delegated_loop` FAILS;
- flagging every recalled memory `injected: true` → `telemetry_marks_budget_dropped_results_held_back` FAILS.

Coverage: attribution for **both** the PM and a delegated engineer (including two loops sharing one sink, reusing the same `call_id`); the search event carrying the real routed lane (incl. the lexical-retry case, made testable by extracting the pure `SearchLane::resolved`); the recall event's `injected` flag with a held-back case; JSON round-trips for both new events (they must survive SSE **and** ring-buffer replay); and guards that telemetry is additive and absent for non-retrieval tools.

## Gate — all green

```
cargo build -p trusty-code                              Finished
cargo test -p trusty-code                               976 passed; 0 failed; 4 ignored (+ 8 suites ok)
cargo clippy -p trusty-code --all-targets -- -D warnings  Finished (exit 0)
cargo fmt --check                                       exit 0
bash scripts/check_line_cap.sh                          9 allowlisted, 0 violations — OK
```

The three known flakes (#2843) all **ran and passed**; my diff touches none of that mechanism.

## Notes for the reviewer

- **Contradicts the brief:** in *this crate* `LlmRequested`/`LlmResponded`/`AgentSpawned`/`PmDelegating` are **defined but never constructed** — the emitters live in `trusty-agents`, which has its own separate `Event` enum. So trusty-code's live stream today is only the tool events; the `agent_name` join target the brief describes is aspirational here. Attribution is still name-keyed for forward-consistency, but the UI should know those variants don't yet fire from tcode.
- **Also contradicts the brief:** the real routed lanes are **four**, not three — `search_code` can serve `lexical` via the #2783 retry.
- Two convention-driven splits were needed to stay under the SLOC caps (`events.rs` tests → `events_tests.rs` sibling; sink guards → `agent_loop::tests::sink_events`). Both follow existing in-crate precedent; all 8 pre-existing `events.rs` tests were verified preserved.
- The remote branch already held an earlier **WIP salvage of this same ticket**. Rather than force-push over it, it's merged as an ancestor (`-s ours`) with the completed tree taking precedence — my tree is a strict superset of it, verified unchanged by the merge, and the gate was re-run afterward.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools