### PR TITLE
fix(trusty-code): attach telemetry on empty-content search fallback + correct CHANGELOG constant name

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -235,7 +235,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   spends a later one's budget. Exhausting it is now **recoverable** — it no
   longer stops the PM loop, matching the precedent set by #2683/#2805's
   post-completion refusal. The cap's actual purpose is preserved by a new
-  run-wide `MAX_ENGINEER_INVOCATIONS = 12` ceiling (4× the per-delegation
+  run-wide `MAX_FAILED_INVOCATIONS = 12` ceiling (4× the per-delegation
   budget): a genuinely failing engineer stays bounded, and only that ceiling —
   a condition no fresh delegation could clear — latches the loop-stopping
   signal. Not a #2805 regression; #2805 fixed the *symptom* and remains correct

--- a/crates/trusty-code/src/tools/trusty_search.rs
+++ b/crates/trusty-code/src/tools/trusty_search.rs
@@ -528,7 +528,8 @@ impl ToolExecutor for TrustySearchTool {
     /// generic tool events still narrate them.
     /// Test: `tests::execute_fail_open_when_binary_absent`,
     /// `tests::execute_rejects_malformed_args_recoverably`,
-    /// `tests::resolved_lane_reports_lexical_when_the_retry_served_it`.
+    /// `tests::resolved_lane_reports_lexical_when_the_retry_served_it`,
+    /// `tests::execute_attaches_telemetry_when_lane_reply_has_no_text`.
     async fn execute(&self, args: Value) -> ToolResult {
         let started = std::time::Instant::now();
         let parsed: SearchArgs = match serde_json::from_value(args) {
@@ -618,7 +619,8 @@ impl ToolExecutor for TrustySearchTool {
                 .with_telemetry(telemetry(SearchLane::resolved(mode, false), &text)),
             None => ToolResult::ok(format!(
                 "trusty-search returned no results. {FALLBACK_HINT}"
-            )),
+            ))
+            .with_telemetry(telemetry(SearchLane::resolved(mode, false), "")),
         }
     }
 }

--- a/crates/trusty-code/src/tools/trusty_search_tests.rs
+++ b/crates/trusty-code/src/tools/trusty_search_tests.rs
@@ -316,3 +316,107 @@ async fn fail_open_paths_report_no_telemetry() {
         "an absent daemon is not a search with zero hits"
     );
 }
+
+// ── execute: lane reached but reply carries no extractable text ────────────
+
+/// Spawn a minimal fake MCP stdio server as a throwaway executable shell
+/// script.
+///
+/// Why: exercising `execute()`'s "lane reached, but the reply had no
+/// extractable text" arm end-to-end requires a process that speaks just
+/// enough MCP to complete the handshake plus two `tools/call` round-trips
+/// (`list_indexes`, then the lane call itself) — `TrustySearchTool` always
+/// drives a real `StdioMcpClient` subprocess, so there is no lighter-weight
+/// seam to fake this at.
+/// What: writes an executable POSIX shell script that replies to the Nth
+/// request line it sees (matched only by the presence of an `"id":` field,
+/// so the handshake's `notifications/initialized` notification — which has
+/// no id — is silently skipped) with the Nth canned response, verbatim.
+/// Test: `execute_attaches_telemetry_when_lane_reply_has_no_text`.
+#[cfg(unix)]
+fn write_fake_mcp_server(responses: &[Value; 3]) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script = format!(
+        "#!/bin/sh\ni=0\nwhile IFS= read -r line; do\n  case \"$line\" in\n    *'\"id\":'*)\n      i=$((i + 1))\n      case \"$i\" in\n        1) printf '%s\\n' '{}' ;;\n        2) printf '%s\\n' '{}' ;;\n        3) printf '%s\\n' '{}' ;;\n      esac\n      ;;\n  esac\ndone\n",
+        responses[0], responses[1], responses[2],
+    );
+
+    let path = std::env::temp_dir().join(format!(
+        "tcode-fake-mcp-{}-{}.sh",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    std::fs::write(&path, script).expect("write fake mcp script");
+    let mut perms = std::fs::metadata(&path)
+        .expect("stat fake mcp script")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).expect("chmod fake mcp script");
+    path
+}
+
+/// Why: `execute`'s doc comment promises every path that actually reaches a
+/// lane attaches a `SearchTelemetry`. The `mcp_text(&result) == None` arm — a
+/// lane reply that is otherwise successful (no `isError`) but carries a
+/// `content` item with no `text` field — previously attached none, silently
+/// breaking that invariant even though a real search genuinely happened.
+/// What: drives `execute()` against a fake MCP server that completes the
+/// handshake, answers `list_indexes` with an empty list (so `grep` mode needs
+/// no index), then answers the `grep` call with a textless `content` item.
+/// Asserts `execute()` still fails open (a successful, non-error `ToolResult`)
+/// AND now attaches telemetry for this arm.
+/// Test: this test.
+#[tokio::test]
+#[cfg(unix)]
+async fn execute_attaches_telemetry_when_lane_reply_has_no_text() {
+    let init_resp = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "serverInfo": { "name": "fake-trusty-search", "version": "0.0.0" },
+            "protocolVersion": "2024-11-05"
+        }
+    });
+    let list_indexes_resp = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": { "content": [{ "type": "text", "text": "{\"indexes\":[]}" }] }
+    });
+    let grep_resp = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        // No "text" field on the content item — this is what makes
+        // `mcp_text` return `None` despite a genuinely successful,
+        // non-error lane reply.
+        "result": { "content": [{ "type": "text" }] }
+    });
+
+    let script_path = write_fake_mcp_server(&[init_resp, list_indexes_resp, grep_resp]);
+    let tool = TrustySearchTool::new(std::env::temp_dir()).with_binary(
+        script_path
+            .to_str()
+            .expect("utf8 fake mcp script path")
+            .to_string(),
+    );
+
+    let result = tool
+        .execute(json!({ "query": "TODO", "mode": "grep" }))
+        .await;
+
+    let _ = std::fs::remove_file(&script_path);
+
+    assert!(
+        !result.is_error(),
+        "a malformed-but-successful lane reply is still fail-open success: {}",
+        result.content()
+    );
+    assert!(
+        result.telemetry().is_some(),
+        "execute()'s doc comment promises every lane-reached path attaches \
+         telemetry, but the no-extractable-text arm attached none"
+    );
+}


### PR DESCRIPTION
## Summary
- `crates/trusty-code/src/tools/trusty_search.rs`: the `mcp_text(&result) == None` fallback arm in `execute()` reaches a lane successfully (no `isError`) but the reply's `content` item carries no `text` field. This arm previously attached no `SearchTelemetry`, silently contradicting the doc comment's invariant that every lane-reached path attaches telemetry (so a `SearchPerformed` event fires). Fixed by mirroring the success arm: `.with_telemetry(telemetry(SearchLane::resolved(mode, false), ""))`.
- `crates/trusty-code/CHANGELOG.md`: corrected a dangling prose reference to `MAX_ENGINEER_INVOCATIONS`, which `redelegation.rs` renamed to `MAX_FAILED_INVOCATIONS`. The old name no longer existed as a real symbol anywhere in the tree — pure docs drift.

Both issues were flagged by code-critic during the #2856/#2862 review leg.

## Test plan
- [x] `cargo build -p trusty-code` — clean
- [x] `cargo test -p trusty-code --lib` — 1065 passed, 0 failed (includes new `execute_attaches_telemetry_when_lane_reply_has_no_text`, which drives `execute()` against a fake MCP stdio server returning a textless content item and asserts telemetry is now attached)
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 9 allowlisted, 0 violations
- [x] `grep -rn MAX_ENGINEER_INVOCATIONS crates/` — zero matches tree-wide

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-mpm