### PR TITLE
feat(trusty-code): session.get_readiness query RPC for late-attaching UI clients (DOC-39 §5.6)

### DIFF
--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -470,6 +470,12 @@ pub enum Event {
     /// individually. `index_id`/`lifecycle_status`/`chunk_count` are `None`
     /// exactly when `state == "unavailable"` (nothing was probed). `summary` is
     /// the same human-readable line the stderr log carries.
+    /// (DOC-39 §5.6 Slice D) This event is EMITTED ONCE, at task start — a
+    /// client that attaches after it fired sees nothing. `session.get_readiness`
+    /// is the query counterpart: it returns the last-recorded
+    /// [`IndexReadinessSnapshot`] (this variant's fields, minus `session_id`)
+    /// for late attachers, so "what is readiness right now" doesn't depend on
+    /// having been subscribed at the right moment.
     /// Test: `session::registry::registry_tests::record_index_readiness_*`,
     /// `session::registry::registry_tests::warming_index_is_distinguishable_from_ready_with_zero_hits`.
     IndexReadiness {
@@ -532,6 +538,39 @@ pub enum Event {
 
     // -- Keepalive --
     Ping,
+}
+
+/// A cached snapshot of the `Event::IndexReadiness` payload (DOC-39 §5.6
+/// Slice D — `session.get_readiness` query RPC).
+///
+/// Why: `Event::IndexReadiness` above is emitted exactly once, at task start
+/// — a fire-once event, not a queryable value. A UI client that attaches to
+/// a session AFTER that one-time probe fired has no way to ask "what is the
+/// readiness state right now"; it can only ever see events that arrive while
+/// it happens to be subscribed. This struct is the field-for-field twin of
+/// `Event::IndexReadiness`'s payload (deliberately excluding `session_id`,
+/// which is contextual to the cache slot it lives in, not the event) so
+/// `SessionRegistry` can cache the last-recorded probe per session and
+/// `session.get_readiness` can hand it back verbatim to a late-attaching
+/// client — one shape for both the streamed event and the query response,
+/// with no independent field-naming to drift out of sync.
+/// What: every field name and type matches the corresponding field on
+/// `Event::IndexReadiness` exactly. `SessionRegistry::record_index_readiness`
+/// builds one of these first and derives the `Event::IndexReadiness` it
+/// publishes from it, so the two can never disagree.
+/// Test: `session::registry_tests::record_index_readiness_caches_snapshot_*`,
+/// `session::protocol_readiness::tests::*`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IndexReadinessSnapshot {
+    /// `"ready"` | `"warming"` | `"unavailable"` — see `Event::IndexReadiness`.
+    pub state: String,
+    pub index_id: Option<String>,
+    pub lifecycle_status: Option<String>,
+    pub chunk_count: Option<u64>,
+    pub lexical_ready: bool,
+    pub semantic_ready: bool,
+    pub graph_ready: bool,
+    pub summary: String,
 }
 
 impl Event {

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -558,8 +558,8 @@ pub enum Event {
 /// `Event::IndexReadiness` exactly. `SessionRegistry::record_index_readiness`
 /// builds one of these first and derives the `Event::IndexReadiness` it
 /// publishes from it, so the two can never disagree.
-/// Test: `session::registry_tests::record_index_readiness_caches_snapshot_*`,
-/// `session::protocol_readiness::tests::*`.
+/// Test: `session::registry_tests::record_index_readiness_caches_snapshot_for_late_query`,
+/// `session::protocol_readiness::tests::get_readiness_returns_probed_snapshot_after_recording`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IndexReadinessSnapshot {
     /// `"ready"` | `"warming"` | `"unavailable"` — see `Event::IndexReadiness`.

--- a/crates/trusty-code/src/session/protocol.rs
+++ b/crates/trusty-code/src/session/protocol.rs
@@ -5,19 +5,22 @@
 //! CLI (and later TUI/TELGUI/REST) never touch `SessionRegistry` directly.
 //! What: [`register`] wires `session.create`, `session.list`,
 //! `session.status`, `session.send`, `session.attach`, `session.detach`,
-//! `session.cancel`, (#2058) `session.get_transcript`, and (#2350)
-//! `session.set_goal`/`session.clear_goal`/`session.get_goals` onto a
-//! [`Router`], all closed over the SAME `Arc<SessionRegistry>` so every
-//! method sees a consistent view. Each handler parses its typed `params`,
-//! forwards to the matching `SessionRegistry` method, and maps the result
-//! onto the JSON-RPC result shape the vision spec's §4.3 examples describe.
+//! `session.cancel`, (#2058) `session.get_transcript`, (#2350)
+//! `session.set_goal`/`session.clear_goal`/`session.get_goals`, and
+//! (DOC-39 §5.6 Slice D) `session.get_readiness` onto a [`Router`], all
+//! closed over the SAME `Arc<SessionRegistry>` so every method sees a
+//! consistent view. Each handler parses its typed `params`, forwards to the
+//! matching `SessionRegistry` method, and maps the result onto the JSON-RPC
+//! result shape the vision spec's §4.3 examples describe.
 //! The three goal methods' handler bodies live in the sibling
-//! `protocol_goals` module (kept out of this file purely for the 500-SLOC
-//! cap — see that module's docs), but are registered here alongside every
-//! other `session.*` method so this remains the one place listing the full
-//! surface.
+//! `protocol_goals` module, and `session.get_readiness`'s in the sibling
+//! `protocol_readiness` module (both kept out of this file purely for the
+//! 500-SLOC cap — see each module's docs), but are registered here alongside
+//! every other `session.*` method so this remains the one place listing the
+//! full surface.
 //! Test: `protocol::tests::*` (parameter validation, error mapping);
-//! `protocol_goals::tests::*` (the three goal methods); the full
+//! `protocol_goals::tests::*` (the three goal methods);
+//! `protocol_readiness::tests::*` (`session.get_readiness`); the full
 //! attach/detach streaming behaviour is covered by `session::registry_tests`
 //! (registry-level) and `tests/session_e2e.rs`/`tests/task_e2e.rs`
 //! (API-driven, real daemon).
@@ -138,6 +141,15 @@ pub fn register(router: &mut Router, registry: Arc<SessionRegistry>) {
         move |params: Value, ctx: ConnectionContext| {
             let r = r.clone();
             async move { protocol_goals::get_goals(&r, params, ctx).await }
+        },
+    );
+
+    let r = registry.clone();
+    router.register(
+        "session.get_readiness",
+        move |params: Value, ctx: ConnectionContext| {
+            let r = r.clone();
+            async move { protocol_readiness::get_readiness(&r, params, ctx).await }
         },
     );
 }
@@ -378,6 +390,11 @@ async fn get_transcript(
 #[path = "protocol_goals.rs"]
 mod protocol_goals;
 
+/// `session.get_readiness` (DOC-39 §5.6 Slice D), split into its own file for
+/// the same 500-SLOC-cap reason as `protocol_goals` above.
+#[path = "protocol_readiness.rs"]
+mod protocol_readiness;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -410,6 +427,7 @@ mod tests {
             ("session.detach", json!({"session_id": session.id})),
             ("session.get_transcript", json!({"session_id": session.id})),
             ("session.get_goals", json!({"session_id": session.id})),
+            ("session.get_readiness", json!({"session_id": session.id})),
         ];
         for (method, params) in cases {
             let req = Request {

--- a/crates/trusty-code/src/session/protocol_readiness.rs
+++ b/crates/trusty-code/src/session/protocol_readiness.rs
@@ -1,0 +1,94 @@
+//! `session.get_readiness` handler (DOC-39 §5.6 Slice D). Split out of
+//! `protocol.rs` purely to keep that production file under the crate's
+//! 500-SLOC cap — this is a child module of `protocol` (declared via
+//! `#[path = ...] mod protocol_readiness;`), so it shares full access to
+//! `protocol`'s private `SessionIdParams`/`parse` helpers exactly as if this
+//! handler were still defined in that file.
+//!
+//! Why: `Event::IndexReadiness` (`crate::events`) is emitted exactly once, at
+//! task start, from `task::executor`'s background-indexing observer. A UI
+//! client that attaches to a session AFTER that one-time probe fired has no
+//! way to ask "what is the readiness state right now" — only a stream it may
+//! have missed. This is the query half a previous PR (#2861) left unshipped:
+//! the event-only side existed, but nothing let a late-attaching client
+//! retrieve the state it never streamed.
+//! What: [`get_readiness`] forwards to `SessionRegistry::get_readiness`,
+//! returning its `ReadinessQuery` (`{"status":"probed", ...snapshot fields}`
+//! or `{"status":"never_probed"}`) verbatim as the JSON-RPC result.
+//! Test: `tests::*` in this module.
+
+use super::*;
+
+/// `session.get_readiness(session_id) -> ReadinessQuery` (DOC-39 §5.6 Slice D).
+///
+/// Why: the query counterpart to the fire-once `Event::IndexReadiness` — see
+/// module docs.
+/// What: `-32007 session_not_found` if `session_id` is unknown; otherwise
+/// `SessionRegistry::get_readiness`'s `ReadinessQuery` verbatim — either the
+/// cached snapshot (`status: "probed"`) or the typed "nothing recorded yet"
+/// result (`status: "never_probed"`), never a bare `null`.
+/// Test: `tests::get_readiness_returns_probed_snapshot_after_recording`,
+/// `tests::get_readiness_never_probed_session_returns_never_probed`,
+/// `tests::get_readiness_unknown_session_maps_to_session_not_found`.
+pub(super) async fn get_readiness(
+    registry: &SessionRegistry,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: SessionIdParams = parse(params, "session.get_readiness")?;
+    Ok(json!(registry.get_readiness(&p.session_id)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    fn test_ctx() -> ConnectionContext {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    /// A session with no recorded probe returns the typed `never_probed`
+    /// result, not an error or a bare `null`.
+    #[tokio::test]
+    async fn get_readiness_never_probed_session_returns_never_probed() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let result = get_readiness(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "never_probed");
+    }
+
+    /// Once a probe has been recorded, `session.get_readiness` returns it
+    /// with `status: "probed"` and the snapshot fields alongside.
+    #[tokio::test]
+    async fn get_readiness_returns_probed_snapshot_after_recording() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        registry
+            .record_index_readiness(&session.id, None, "no daemon")
+            .unwrap();
+
+        let result = get_readiness(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "probed");
+        assert_eq!(result["state"], "unavailable");
+        assert_eq!(result["summary"], "no daemon");
+    }
+
+    /// An unknown session must map to `-32007 session_not_found`.
+    #[tokio::test]
+    async fn get_readiness_unknown_session_maps_to_session_not_found() {
+        let registry = SessionRegistry::new();
+        let err = get_readiness(&registry, json!({"session_id": "nope"}), test_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+}

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 use crate::agent_loop::Transcript;
 use crate::binding::ProjectBinding;
-use crate::events::{Event, SessionEventEnvelope};
+use crate::events::{Event, IndexReadinessSnapshot, SessionEventEnvelope};
 use crate::jsonrpc::{NotifySender, RpcError};
 use crate::mode::HarnessMode;
 use crate::perf::TokenUsage;
@@ -106,6 +106,14 @@ struct SessionEntry {
     /// reused for the life of the session (see `memory_sink` module docs for
     /// why its background drain task must outlive any single run).
     memory_sink: Option<Arc<super::memory_sink::TurnMemorySink>>,
+    /// (DOC-39 §5.6 Slice D) The most recently recorded `IndexReadiness`
+    /// probe for this session — last-writer-wins, overwritten by every new
+    /// `record_index_readiness` call. `None` until the session's first probe
+    /// lands (or forever, for a session whose `task.run` never indexes —
+    /// e.g. projectless). This is the storage `session.get_readiness` reads
+    /// so a client that attaches AFTER the one-time `Event::IndexReadiness`
+    /// fired can still retrieve the current state.
+    readiness: Option<IndexReadinessSnapshot>,
 }
 
 /// #2056: bookkeeping for one in-flight background task execution.
@@ -205,6 +213,7 @@ impl SessionRegistry {
                     cost_usd: None,
                     pm_transcript: None,
                     memory_sink: None,
+                    readiness: None,
                 },
             );
         }

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -53,8 +53,8 @@ const READINESS_STATE_UNAVAILABLE: &str = "unavailable";
 /// `tag = "type"` convention) so the wire shape is
 /// `{"status":"probed","state":...,"index_id":...,...}` for a session with a
 /// recorded snapshot, or `{"status":"never_probed"}` for one with none.
-/// Test: `registry_tests::get_readiness_returns_cached_snapshot`,
-/// `registry_tests::get_readiness_never_probed_session_returns_never_probed`.
+/// Test: `registry_tests::record_index_readiness_caches_snapshot_for_late_query`,
+/// `protocol_readiness::tests::get_readiness_never_probed_session_returns_never_probed`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum ReadinessQuery {
@@ -164,8 +164,8 @@ impl SessionRegistry {
     /// never a bare `null` — if no `record_index_readiness` call has happened
     /// yet (e.g. a projectless session, or one queried before its background
     /// indexing probe completes).
-    /// Test: `registry_tests::get_readiness_returns_cached_snapshot`,
-    /// `registry_tests::get_readiness_never_probed_session_returns_never_probed`,
+    /// Test: `registry_tests::record_index_readiness_caches_snapshot_for_late_query`,
+    /// `protocol_readiness::tests::get_readiness_never_probed_session_returns_never_probed`,
     /// `registry_tests::get_readiness_unknown_session_errors`.
     pub fn get_readiness(&self, id: &str) -> Result<ReadinessQuery, RpcError> {
         self.ensure_exists(id)?;

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -19,10 +19,13 @@
 //! `registry_tests::record_progress_publishes_event`,
 //! `registry_tests::record_message_publishes_event`.
 
+use serde::Serialize;
+
 use super::*;
 use crate::tools::telemetry::{RecallTelemetry, SearchTelemetry};
 
 use crate::agent_loop::ContextBudgetSnapshot;
+use crate::events::IndexReadinessSnapshot;
 
 /// `Event::IndexReadiness.state` when the semantic lane is queryable — an
 /// empty search result IS evidence of absence.
@@ -33,6 +36,33 @@ const READINESS_STATE_WARMING: &str = "warming";
 /// `Event::IndexReadiness.state` when no index could be probed at all (no
 /// daemon / no derivable id) — likewise not evidence of absence.
 const READINESS_STATE_UNAVAILABLE: &str = "unavailable";
+
+/// `session.get_readiness`'s response payload (DOC-39 §5.6 Slice D).
+///
+/// Why: a session's readiness is a single cached value, not a collection —
+/// `session.get_goals`'s "empty array means nothing yet" convention doesn't
+/// fit here, and a bare `Option` serialising to `null` would be exactly the
+/// kind of untyped "nothing yet" signal the design explicitly rules out (a
+/// consumer can't tell "never probed" from "probed, and every field happens
+/// to be absent" without a discriminant). This is a thin, tagged wrapper
+/// around [`IndexReadinessSnapshot`] — the SAME struct
+/// `SessionRegistry::record_index_readiness` caches and `Event::IndexReadiness`
+/// derives from — so the query and event surfaces can never independently
+/// drift on field names.
+/// What: `#[serde(tag = "status")]` (internally tagged, matching `Event`'s own
+/// `tag = "type"` convention) so the wire shape is
+/// `{"status":"probed","state":...,"index_id":...,...}` for a session with a
+/// recorded snapshot, or `{"status":"never_probed"}` for one with none.
+/// Test: `registry_tests::get_readiness_returns_cached_snapshot`,
+/// `registry_tests::get_readiness_never_probed_session_returns_never_probed`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ReadinessQuery {
+    /// A probe has landed for this session; wraps the last-recorded snapshot.
+    Probed(IndexReadinessSnapshot),
+    /// No `record_index_readiness` call has ever landed for this session.
+    NeverProbed,
+}
 
 impl SessionRegistry {
     /// Record a project's trusty-search index readiness (issue #2784's
@@ -53,9 +83,14 @@ impl SessionRegistry {
     /// `semantic_search_ready()` and `"warming"` otherwise, carrying the
     /// per-lane flags through verbatim. Errors with `session_not_found` if `id`
     /// is unknown.
+    /// (DOC-39 §5.6 Slice D) Also caches the resulting [`IndexReadinessSnapshot`]
+    /// on the session (last-writer-wins), so a client that attaches AFTER this
+    /// one-time event fires can still retrieve it via
+    /// [`Self::get_readiness`]/`session.get_readiness`.
     /// Test: `registry_tests::record_index_readiness_warming_publishes_event`,
     /// `registry_tests::record_index_readiness_ready_publishes_event`,
-    /// `registry_tests::record_index_readiness_unavailable_publishes_event`.
+    /// `registry_tests::record_index_readiness_unavailable_publishes_event`,
+    /// `registry_tests::record_index_readiness_caches_snapshot_for_late_query`.
     pub fn record_index_readiness(
         &self,
         id: &str,
@@ -63,9 +98,8 @@ impl SessionRegistry {
         summary: &str,
     ) -> Result<(), RpcError> {
         self.ensure_exists(id)?;
-        let event = match readiness {
-            Some(r) => Event::IndexReadiness {
-                session_id: id.to_string(),
+        let snapshot = match readiness {
+            Some(r) => IndexReadinessSnapshot {
                 state: if r.semantic_search_ready() {
                     READINESS_STATE_READY
                 } else {
@@ -80,8 +114,7 @@ impl SessionRegistry {
                 graph_ready: r.graph_ready,
                 summary: summary.to_string(),
             },
-            None => Event::IndexReadiness {
-                session_id: id.to_string(),
+            None => IndexReadinessSnapshot {
                 state: READINESS_STATE_UNAVAILABLE.to_string(),
                 index_id: None,
                 lifecycle_status: None,
@@ -92,8 +125,56 @@ impl SessionRegistry {
                 summary: summary.to_string(),
             },
         };
-        self.record(id, event);
+        {
+            let mut sessions = self.lock();
+            if let Some(entry) = sessions.get_mut(id) {
+                entry.readiness = Some(snapshot.clone());
+            }
+        }
+        self.record(
+            id,
+            Event::IndexReadiness {
+                session_id: id.to_string(),
+                state: snapshot.state,
+                index_id: snapshot.index_id,
+                lifecycle_status: snapshot.lifecycle_status,
+                chunk_count: snapshot.chunk_count,
+                lexical_ready: snapshot.lexical_ready,
+                semantic_ready: snapshot.semantic_ready,
+                graph_ready: snapshot.graph_ready,
+                summary: snapshot.summary,
+            },
+        );
         Ok(())
+    }
+
+    /// `session.get_readiness`: return the last-recorded index-readiness
+    /// probe for a session, for clients that attach after the one-time
+    /// `Event::IndexReadiness` already fired (DOC-39 §5.6 Slice D).
+    ///
+    /// Why: [`Self::record_index_readiness`] emits its event exactly once, at
+    /// task start (see `run_task::ensure_project_indexed_in_background`'s
+    /// call site in `task::executor`). A UI that connects even a moment later
+    /// has no query surface to ask "what is the readiness state right now" —
+    /// only a stream it may have missed. This is that query surface.
+    /// What: `Err(session_not_found)` if `id` is unknown. Otherwise
+    /// [`ReadinessQuery::Probed`] wrapping the cached [`IndexReadinessSnapshot`]
+    /// if a probe has ever landed for this session, or
+    /// [`ReadinessQuery::NeverProbed`] — a distinct, clearly-typed state,
+    /// never a bare `null` — if no `record_index_readiness` call has happened
+    /// yet (e.g. a projectless session, or one queried before its background
+    /// indexing probe completes).
+    /// Test: `registry_tests::get_readiness_returns_cached_snapshot`,
+    /// `registry_tests::get_readiness_never_probed_session_returns_never_probed`,
+    /// `registry_tests::get_readiness_unknown_session_errors`.
+    pub fn get_readiness(&self, id: &str) -> Result<ReadinessQuery, RpcError> {
+        self.ensure_exists(id)?;
+        Ok(self
+            .lock()
+            .get(id)
+            .and_then(|e| e.readiness.clone())
+            .map(ReadinessQuery::Probed)
+            .unwrap_or(ReadinessQuery::NeverProbed))
     }
 
     /// Record one turn's working-context budget measurement (epic #2343).

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -1494,6 +1494,54 @@ async fn record_index_readiness_unknown_session_errors() {
     assert!(registry.record_index_readiness("nope", None, "x").is_err());
 }
 
+/// (DOC-39 §5.6 Slice D) `record_index_readiness` must cache the snapshot it
+/// records, so a LATER `get_readiness` call — without ever re-subscribing to
+/// the event stream — retrieves the exact same state.
+///
+/// Why: this is the registry-level half of the late-attaching-client
+/// guarantee: `Event::IndexReadiness` fires once and is easy to miss, so the
+/// cache `record_index_readiness` writes (not the event itself) is what
+/// `get_readiness` reads back. Exercised directly at the `SessionRegistry`
+/// level (no JSON-RPC handler in between) so a regression in the caching
+/// assignment itself — as opposed to the protocol layer's passthrough — is
+/// caught here.
+/// What: records a `Some(IndexReadiness)` probe, then calls `get_readiness`
+/// and asserts it returns `ReadinessQuery::Probed` with `state`/`summary`
+/// matching what was just recorded.
+/// Test: this test.
+#[tokio::test]
+async fn record_index_readiness_caches_snapshot_for_late_query() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let r = readiness("ready", 128, true, true);
+    registry
+        .record_index_readiness(&session.id, Some(&r), &r.summary())
+        .unwrap();
+
+    let queried = registry.get_readiness(&session.id).unwrap();
+    match queried {
+        events::ReadinessQuery::Probed(snapshot) => {
+            assert_eq!(snapshot.state, "ready");
+            assert_eq!(snapshot.summary, r.summary());
+            assert!(snapshot.semantic_ready);
+        }
+        events::ReadinessQuery::NeverProbed => {
+            panic!("expected a cached snapshot after record_index_readiness, got NeverProbed")
+        }
+    }
+}
+
+/// `get_readiness` against an unknown session must error, not panic —
+/// mirrors every other registry method's `session_not_found` convention.
+/// Test: this test.
+#[tokio::test]
+async fn get_readiness_unknown_session_errors() {
+    let registry = SessionRegistry::new();
+    let err = registry.get_readiness("nope").unwrap_err();
+    assert_eq!(err.code, -32007);
+}
+
 /// `record_context_budget` must publish a `ContextBudget` event mapping the
 /// snapshot field-for-field.
 #[tokio::test]

--- a/crates/trusty-code/tests/readiness_e2e.rs
+++ b/crates/trusty-code/tests/readiness_e2e.rs
@@ -1,0 +1,201 @@
+//! API-driven end-to-end test for DOC-39 §5.6 Slice D's
+//! `session.get_readiness` query RPC.
+//!
+//! Why: `Event::IndexReadiness` (see `tests/task_e2e.rs`'s module docs for the
+//! shared #2056 `task.run` background-indexing context) is emitted exactly
+//! ONCE, at task start. A previous PR (#2861) shipped that event-only side;
+//! nothing let a client that attaches AFTER the probe fired retrieve the
+//! state it never streamed. This test drives the REAL `tcode serve --http`
+//! daemon (never `trusty_code`'s Rust API directly — the same black-box
+//! discipline `tests/task_e2e.rs`/`tests/session_e2e.rs` follow) and proves
+//! the query surface actually closes that gap, using `TCODE_MOCK_LLM=echo`
+//! for deterministic, offline `task.run` execution.
+//! What: [`late_attaching_client_can_query_cached_readiness`] runs a task
+//! through one HTTP "connection" (a `reqwest::Client`) until its background
+//! indexing probe lands, then queries `session.get_readiness` from a SECOND,
+//! brand-new `reqwest::Client` that never called `session.attach` or made any
+//! prior request for this session — proving a late attacher sees the exact
+//! cached state the original probe recorded, not a re-probe or a drifted
+//! copy. [`never_probed_session_returns_never_probed_over_the_wire`] proves
+//! the OTHER half: a session that has never run a task (so no probe has ever
+//! landed) returns the typed `{"status":"never_probed"}` result — never an
+//! error, never a bare `null` — over the real wire.
+//! Test: this file IS the test; see `support` for the process/protocol
+//! plumbing shared with `session_e2e.rs`/`task_e2e.rs`.
+
+mod support;
+
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use support::{project_with_agents, spawn_http_daemon, spawn_http_daemon_with_env};
+
+/// Bounded polling budget for waiting on the detached background-indexing
+/// probe to land: `probe_index_readiness` itself has a 1500ms request
+/// timeout plus a 750ms connect timeout (see
+/// `trusty_common::search_readiness`), so this generously outlasts even a
+/// worst-case fail-open probe against an unreachable daemon.
+const READINESS_POLL_ROUNDS: usize = 100;
+const READINESS_POLL_INTERVAL: Duration = Duration::from_millis(150);
+
+/// POST one JSON-RPC request to `rpc_url` and parse the response body.
+async fn call_rpc(
+    client: &reqwest::Client,
+    rpc_url: &str,
+    id: i64,
+    method: &str,
+    params: Value,
+) -> Value {
+    client
+        .post(rpc_url)
+        .json(&json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params}))
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("POST {method} failed: {e}"))
+        .json()
+        .await
+        .unwrap_or_else(|e| panic!("parse {method} response failed: {e}"))
+}
+
+/// Poll `session.get_readiness` on `client` until it reports
+/// `status: "probed"`, returning that `result` value.
+///
+/// Why: `task.run`'s background indexing probe (`run_task::
+/// ensure_project_indexed_in_background`) runs on a detached thread and
+/// records asynchronously — there is no guarantee it has landed by the time
+/// `task.run` itself returns, so the test must poll rather than assume
+/// immediate availability. Bounded so a genuine regression (the probe never
+/// lands, or `session.get_readiness` never flips to `"probed"`) fails fast
+/// instead of hanging the suite.
+async fn poll_until_probed(client: &reqwest::Client, rpc_url: &str, session_id: &str) -> Value {
+    for round in 0..READINESS_POLL_ROUNDS {
+        let resp = call_rpc(
+            client,
+            rpc_url,
+            1000 + round as i64,
+            "session.get_readiness",
+            json!({"session_id": session_id}),
+        )
+        .await;
+        assert!(resp["error"].is_null(), "get_readiness failed: {resp}");
+        if resp["result"]["status"] == "probed" {
+            return resp["result"].clone();
+        }
+        tokio::time::sleep(READINESS_POLL_INTERVAL).await;
+    }
+    panic!("gave up waiting for an index_readiness probe to land for session {session_id}");
+}
+
+/// THE point of this slice: a client that attaches to a session AFTER its
+/// one-time `Event::IndexReadiness` probe already fired must still be able
+/// to retrieve the current readiness state via `session.get_readiness`.
+#[tokio::test]
+async fn late_attaching_client_can_query_cached_readiness() {
+    let project = project_with_agents();
+    let daemon = spawn_http_daemon_with_env(
+        project.path(),
+        &[(
+            trusty_code::task::mock_llm::MOCK_LLM_ENV,
+            trusty_code::task::mock_llm::MOCK_LLM_ECHO,
+        )],
+    )
+    .await;
+    let rpc_url = format!("{}/rpc", daemon.base_url);
+
+    // 1. Run a task on the ORIGINAL client "connection" — this is the run
+    // whose background indexing probe fires `Event::IndexReadiness` exactly
+    // once, and whose readiness this connection never re-reads via
+    // `session.attach` (proving the cache — not a live subscription — is
+    // what the late client below actually reads).
+    let original_client = reqwest::Client::new();
+    let run_resp = call_rpc(
+        &original_client,
+        &rpc_url,
+        1,
+        "task.run",
+        json!({"task_description": "say hi"}),
+    )
+    .await;
+    assert!(run_resp["error"].is_null(), "task.run failed: {run_resp}");
+    let session_id = run_resp["result"]["session_id"]
+        .as_str()
+        .expect("task.run must return a session_id")
+        .to_string();
+
+    // 2. Poll (still on the original client) until the probe has landed,
+    // capturing exactly what it recorded so the late query below can be
+    // compared against it.
+    let probed_by_original = poll_until_probed(&original_client, &rpc_url, &session_id).await;
+    assert_eq!(probed_by_original["status"], "probed");
+    assert!(
+        probed_by_original["state"].is_string(),
+        "a probed snapshot must carry a state: {probed_by_original}"
+    );
+
+    // 3. A FRESH client — a brand-new connection that made none of the
+    // above calls and never `session.attach`ed — must retrieve the SAME
+    // cached snapshot from a single `session.get_readiness` call.
+    let late_client = reqwest::Client::new();
+    let late_resp = call_rpc(
+        &late_client,
+        &rpc_url,
+        1,
+        "session.get_readiness",
+        json!({"session_id": session_id}),
+    )
+    .await;
+    assert!(
+        late_resp["error"].is_null(),
+        "late get_readiness failed: {late_resp}"
+    );
+    assert_eq!(
+        late_resp["result"], probed_by_original,
+        "a late-attaching client must see the exact same cached readiness snapshot \
+         the original probe recorded, not a re-probe or a drifted copy"
+    );
+
+    daemon.shutdown_via_sigterm_and_assert_clean_exit().await;
+}
+
+/// A session with no `task.run` ever executed against it has had no
+/// background indexing probe, so `session.get_readiness` must return the
+/// typed `never_probed` result — not an error, not a bare `null`.
+#[tokio::test]
+async fn never_probed_session_returns_never_probed_over_the_wire() {
+    let daemon = spawn_http_daemon().await;
+    let client = reqwest::Client::new();
+    let rpc_url = format!("{}/rpc", daemon.base_url);
+
+    let create_resp = call_rpc(
+        &client,
+        &rpc_url,
+        1,
+        "session.create",
+        json!({"task": "never runs a task"}),
+    )
+    .await;
+    assert!(
+        create_resp["error"].is_null(),
+        "create failed: {create_resp}"
+    );
+    let session_id = create_resp["result"]["id"]
+        .as_str()
+        .expect("session.create must return an id")
+        .to_string();
+
+    let readiness_resp = call_rpc(
+        &client,
+        &rpc_url,
+        2,
+        "session.get_readiness",
+        json!({"session_id": session_id}),
+    )
+    .await;
+    assert!(
+        readiness_resp["error"].is_null(),
+        "get_readiness failed: {readiness_resp}"
+    );
+    assert_eq!(readiness_resp["result"], json!({"status": "never_probed"}));
+
+    daemon.shutdown_via_sigterm_and_assert_clean_exit().await;
+}


### PR DESCRIPTION
## Problem

Index readiness is currently EVENT-ONLY. `Event::IndexReadiness` (`crates/trusty-code/src/events.rs`) is emitted exactly ONCE, at task start, via `run_task::ensure_project_indexed_in_background`'s observer callback wired in `task::executor`. A UI client that attaches to a session AFTER that one-time probe fired has no way to ask "what is the readiness state right now" — there was only a fire-once event, no query surface. A previous PR (#2861) shipped the event side only; this slice is the missing query half (DOC-39 §5.6).

## Design

- **`crate::events::IndexReadinessSnapshot`** (`src/events.rs`): a plain struct that is a field-for-field twin of `Event::IndexReadiness`'s payload (everything except `session_id`, which is contextual to the cache slot, not the event). Field names are identical and cannot drift, since `record_index_readiness` now builds this struct FIRST and derives the `Event::IndexReadiness` it publishes from it (rather than constructing the event fields independently) — the wire shape of `Event::IndexReadiness` is unchanged (still the same flat, non-nested fields) so no existing pattern-matching tests needed to change.
- **`SessionEntry.readiness: Option<IndexReadinessSnapshot>`** (`src/session/registry.rs`): session-scoped, last-writer-wins cache, set inside `record_index_readiness` (`src/session/registry_events.rs`) at the same point the event is recorded.
- **`SessionRegistry::get_readiness`** (`src/session/registry_events.rs`): returns a typed `ReadinessQuery` enum — `Probed(IndexReadinessSnapshot)` or `NeverProbed` — internally tagged (`#[serde(tag = "status")]`, matching `Event`'s own tagging convention) so the wire shape is `{"status":"probed", state:..., ...}` or `{"status":"never_probed"}`. No bare `null`, mirroring — but adapted from — `session.get_goals`'s "typed empty state" convention (goals uses `[]` since it's a collection; readiness is a scalar, so it gets its own discriminated variant instead).
- **`session.get_readiness` JSON-RPC method** (`src/session/protocol_readiness.rs`, wired in `src/session/protocol.rs`): parallel in shape/registration/error-handling to `session.get_goals` — same `SessionIdParams`, same `-32007 session_not_found` mapping, same handler/module split for the 500-SLOC cap.

## Test plan

- `crates/trusty-code/tests/readiness_e2e.rs` (new): drives the real `tcode serve --http` daemon with `TCODE_MOCK_LLM=echo`.
  - `late_attaching_client_can_query_cached_readiness`: runs a task on one `reqwest::Client`, polls `session.get_readiness` until the background probe lands, then queries from a brand-new `reqwest::Client` that never called `session.attach` or made any prior request for the session — asserts it gets back the exact same cached snapshot.
  - `never_probed_session_returns_never_probed_over_the_wire`: a session created via `session.create` (no `task.run`) returns `{"status":"never_probed"}` exactly, not an error or null.
- Existing `session_e2e.rs` and `task_e2e.rs` suites verified unaffected.
- Unit coverage in `registry_tests.rs`/`protocol_readiness.rs`'s own `#[cfg(test)]` module for the registry- and protocol-level behavior.

```
cargo build -p trusty-code                                    -> clean
cargo test -p trusty-code --lib                                -> 1067 passed; 0 failed; 4 ignored
cargo test -p trusty-code --test session_e2e                   -> 2 passed
cargo test -p trusty-code --test readiness_e2e                 -> 2 passed
cargo test -p trusty-code --test task_e2e                      -> 6 passed
cargo clippy -p trusty-code --all-targets -- -D warnings       -> clean
cargo fmt --check                                              -> clean
bash scripts/check_line_cap.sh                                 -> 9 allowlisted, 0 violations - OK
```

Refs DOC-39 §5.6.