### PR TITLE
fix(trusty-code): repoint doc-comment Test pointers after #2898 rename (fix main doc-pointer lint)

### DIFF
--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -887,8 +887,9 @@ struct RecordingSink {
     /// (DOC-39 AC-13) `(agent, agent_id)` pairs seen by `tool_started`, in
     /// call order — kept separate from `calls` so every pre-existing test
     /// asserting `calls`'s string format is untouched; only
-    /// `concurrently_delegated_same_named_agents_get_distinct_ids` reads
-    /// this.
+    /// `sequential_delegations_to_same_named_agent_get_distinct_ids` and
+    /// `concurrently_delegated_same_named_agents_get_distinct_ids_under_tokio_join`
+    /// read this.
     started_ids: Mutex<Vec<(String, String)>>,
 }
 

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -144,7 +144,7 @@ impl StdioSession {
     /// variant (e.g. `trusty_code::task::mock_llm::MOCK_LLM_ECHO_FANOUT`)
     /// while keeping `spawn_with_mock_llm` itself unchanged for every other
     /// e2e file.
-    /// Test: `agent_id_e2e::two_same_named_delegations_get_distinct_agent_ids`.
+    /// Test: `agent_id_e2e::fanned_out_same_named_delegations_get_distinct_agent_ids_over_the_wire`.
     pub fn spawn_with_mock_llm_variant(project: &std::path::Path, mock_llm_value: &str) -> Self {
         Self::spawn_inner(Some(project), Some(mock_llm_value), None)
     }


### PR DESCRIPTION
## Summary

PR #2898 (squash `3167f9c8`, stable per-spawn `agent_id`) renamed three
`agent_id` tests but left `Test:` (and related prose) doc-comment pointers
citing the OLD names, which now resolve to nothing — this broke the
`Test: doc-comment pointer lint` CI gate on `main`.

Renames from #2898:
- `concurrently_delegated_same_named_agents_get_distinct_ids` → `sequential_delegations_to_same_named_agent_get_distinct_ids`
- `concurrently_spawned_same_named_loops_get_distinct_agent_ids` → `sequentially_spawned_same_named_loops_get_distinct_agent_ids`
- `two_same_named_delegations_get_distinct_agent_ids` → `fanned_out_same_named_delegations_get_distinct_agent_ids_over_the_wire`

Fixed dangling pointers (found via `git grep` for the old names plus a
scoped re-implementation of `scripts/check_test_pointers.sh`'s extraction/
candidate-name algorithm run directly against `crates/trusty-code`, cross-
checked against every current `fn`/`mod` in the crate):

- `crates/trusty-code/tests/support/mod.rs:147` — `Test:` pointer cited
  `agent_id_e2e::two_same_named_delegations_get_distinct_agent_ids` (no
  longer exists) → repointed to
  `agent_id_e2e::fanned_out_same_named_delegations_get_distinct_agent_ids_over_the_wire`.
- `crates/trusty-code/src/runner/tests.rs:890` — a struct-field doc comment
  (not a `Test:`-tagged pointer, so not mechanically gated, but still rotted
  doc drift from the same rename) claimed only
  `concurrently_delegated_same_named_agents_get_distinct_ids` reads
  `RecordingSink::started_ids`; that name no longer exists and, as it turns
  out, BOTH current tests read the field
  (`sequential_delegations_to_same_named_agent_get_distinct_ids` and
  `concurrently_delegated_same_named_agents_get_distinct_ids_under_tokio_join`)
  — updated to name both.

No other dangling pointers from the #2898 rename were found. All other
`concurrently_delegated_same_named_agents_get_distinct_ids_under_tokio_join`-
suffixed citations in `sink_events.rs`, `runner/tests.rs`, and
`agent_id_e2e.rs` already correctly cite the real (unrenamed) test of that
name. A scoped cross-check of every `Test:` pointer in `crates/trusty-code`
against the crate's real `fn`/`mod` set turned up no NEW violations beyond
the two above; every other flagged name was already grandfathered in
`.test-pointer-allowlist.tsv` (pre-existing, unrelated to #2898).

## Test plan

- [x] `cargo build -p trusty-code` — clean
- [x] `cargo test -p trusty-code --lib` — `1077 passed; 0 failed; 4 ignored`
- [x] `cargo fmt --check` — clean (no diff)
- [x] Verified both fixed pointers resolve to real `fn`s in-crate; confirmed
      via a scoped reimplementation of `check_test_pointers.sh`'s
      extraction/candidate algorithm that no other #2898-introduced dangling
      pointer exists in `crates/trusty-code`
- [ ] Full-workspace `bash scripts/check_test_pointers.sh` (the CI gate
      itself) — kicked off in background during this session; takes 8+ min
      over all 21 crates. CI will run it authoritatively on this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools