### PR TITLE
feat(trusty-code): recalled text + run_id on MemoryRecalled for memory-provenance UI (DOC-39)

### DIFF
--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -283,10 +283,14 @@ mod tests {
                 crate::events::RecalledMemory {
                     score: 0.9,
                     injected: true,
+                    text: "injected memory".to_string(),
+                    run_id: None,
                 },
                 crate::events::RecalledMemory {
                     score: 0.41,
                     injected: false,
+                    text: "held-back memory".to_string(),
+                    run_id: None,
                 },
             ],
         }));

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -91,16 +91,34 @@ pub const UNATTRIBUTED_AGENT: &str = "unknown";
 pub const UNATTRIBUTED_AGENT_ID: &str = "unknown";
 
 /// One memory recalled by `recall_session`, with the flag that says whether
-/// it actually reached the model (UI Phase 1).
+/// it actually reached the model (UI Phase 1; `text`/`run_id` added for
+/// DOC-39 Slice C — the "what memory drove this / what was held back"
+/// context-construction debugging view).
 ///
 /// Why: see [`Event::MemoryRecalled`] — `injected` is the whole point of the
 /// event. `score` rides along because the UI renders it beside the memory
 /// ("41% · held"), and re-deriving it client-side is impossible: it is the
-/// memory daemon's own relevance score.
+/// memory daemon's own relevance score. Before DOC-39 Slice C, `text` was
+/// dropped at this exact boundary: `tools::recall_session::render_results`
+/// always had the recalled content in hand (it is what gets rendered/token-
+/// budgeted), but only the score and injected flag escaped into telemetry —
+/// so a held-back memory could be COUNTED but never READ by the UI, which
+/// defeats the "what was held back" debugging surface's entire point.
 /// What: `score` is trusty-memory's relevance score for the query, verbatim.
 /// `injected` is `true` when the tool's rendered result text included this
-/// result whole, `false` when its token budget dropped it.
-/// Test: `recalled_memory_round_trips_through_json`.
+/// result whole, `false` when its token budget dropped it. `text` is the
+/// recalled memory's raw content (untruncated — the same string
+/// `render_results` reads from `content`), empty string when the source
+/// entry carried no readable content rather than panicking. `run_id` is the
+/// originating run/session identifier the daemon result was tagged with,
+/// when the daemon's response carries one; `None` when absent (the current
+/// `trusty-memory` `memory_recall` response shape does not yet emit this
+/// field — see `docs/specs/trusty-code-harness-ui.md` §5.3 — so `None` is
+/// the expected value today, not a parsing failure). Both new fields are
+/// `#[serde(default)]` so a ring-buffer/transcript entry recorded before this
+/// ticket still deserializes.
+/// Test: `recalled_memory_round_trips_through_json`,
+/// `tools::recall_session::tests::telemetry_carries_recalled_text_and_run_id`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RecalledMemory {
     /// trusty-memory's relevance score for this result, as returned.
@@ -108,6 +126,15 @@ pub struct RecalledMemory {
     /// Whether this result entered the model's context (`false` = recalled
     /// but held back by the tool's token budget).
     pub injected: bool,
+    /// The recalled memory's raw text content (DOC-39 Slice C). Empty string
+    /// when the source entry carried no readable `content`.
+    #[serde(default)]
+    pub text: String,
+    /// The originating run/session id the daemon tagged this result with, if
+    /// any (DOC-39 Slice C). `None` when the daemon response carries no such
+    /// field — see the struct docs.
+    #[serde(default)]
+    pub run_id: Option<String>,
 }
 
 /// Real-time event types streamed to UI clients (browser, future Tauri).

--- a/crates/trusty-code/src/events_tests.rs
+++ b/crates/trusty-code/src/events_tests.rs
@@ -149,6 +149,8 @@ fn kind_matches_serde_tag_for_every_variant() {
             results: vec![RecalledMemory {
                 score: 0.41,
                 injected: false,
+                text: "PKCE required".into(),
+                run_id: None,
             }],
         },
         Event::Log {
@@ -202,13 +204,15 @@ fn kind_matches_serde_tag_for_every_variant() {
 
 /// The UI-Phase-1 structured events must survive a full envelope
 /// round-trip with every field intact — including each recalled memory's
-/// `injected` flag.
+/// `injected` flag and (DOC-39 Slice C) its recalled `text` and `run_id`.
 ///
 /// Why: these events reach the UI over SSE and through `session.attach`'s
 /// ring-buffer replay, both of which serialize. A field that silently
 /// failed to round-trip would strand the UI's whole differentiating
 /// surface. `hit_count: None` is covered explicitly because `Option`
-/// round-tripping is where a shape regression would most plausibly hide.
+/// round-tripping is where a shape regression would most plausibly hide;
+/// `run_id: None` on the held-back entry covers the same risk for Slice C's
+/// new optional field.
 /// Test: this test.
 #[test]
 fn recalled_memory_round_trips_through_json() {
@@ -221,10 +225,14 @@ fn recalled_memory_round_trips_through_json() {
             RecalledMemory {
                 score: 0.93,
                 injected: true,
+                text: "PKCE is required for the OAuth flow".into(),
+                run_id: Some("run-42".into()),
             },
             RecalledMemory {
                 score: 0.41,
                 injected: false,
+                text: "held-back memory text".into(),
+                run_id: None,
             },
         ],
     };
@@ -236,6 +244,15 @@ fn recalled_memory_round_trips_through_json() {
     assert_eq!(value["event"]["agent_id"], "pm-1");
     assert_eq!(value["event"]["results"][1]["injected"], false);
     assert_eq!(value["event"]["results"][1]["score"], 0.41);
+    assert_eq!(
+        value["event"]["results"][1]["text"], "held-back memory text",
+        "the held-back result's TEXT must be present on the wire"
+    );
+    assert_eq!(value["event"]["results"][0]["run_id"], "run-42");
+    assert_eq!(
+        value["event"]["results"][1]["run_id"],
+        serde_json::Value::Null
+    );
 
     let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
     let Event::MemoryRecalled {
@@ -254,14 +271,40 @@ fn recalled_memory_round_trips_through_json() {
         vec![
             RecalledMemory {
                 score: 0.93,
-                injected: true
+                injected: true,
+                text: "PKCE is required for the OAuth flow".into(),
+                run_id: Some("run-42".into()),
             },
             RecalledMemory {
                 score: 0.41,
-                injected: false
+                injected: false,
+                text: "held-back memory text".into(),
+                run_id: None,
             },
         ],
         "the injected/held-back split must survive the wire"
+    );
+}
+
+/// A `RecalledMemory` recorded before DOC-39 Slice C (no `text`/`run_id` on
+/// the wire) must still deserialize, defaulting the new fields.
+///
+/// Why: `#[serde(default)]` on both new fields is the back-compat contract —
+/// a ring-buffer entry or persisted transcript recorded by an older binary
+/// must not fail to load just because Slice C added fields.
+/// Test: this test.
+#[test]
+fn recalled_memory_deserializes_without_text_or_run_id() {
+    let old_shape = serde_json::json!({"score": 0.5, "injected": true});
+    let back: RecalledMemory = serde_json::from_value(old_shape).unwrap();
+    assert_eq!(
+        back,
+        RecalledMemory {
+            score: 0.5,
+            injected: true,
+            text: String::new(),
+            run_id: None,
+        }
     );
 }
 

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -334,6 +334,8 @@ fn recall_telemetry(results: &[(f64, bool)]) -> crate::tools::RecallTelemetry {
             .map(|(score, injected)| crate::events::RecalledMemory {
                 score: *score,
                 injected: *injected,
+                text: String::new(),
+                run_id: None,
             })
             .collect(),
     }
@@ -416,11 +418,15 @@ async fn record_memory_recalled_publishes_event() {
         vec![
             crate::events::RecalledMemory {
                 score: 0.9,
-                injected: true
+                injected: true,
+                text: String::new(),
+                run_id: None,
             },
             crate::events::RecalledMemory {
                 score: 0.41,
-                injected: false
+                injected: false,
+                text: String::new(),
+                run_id: None,
             },
         ],
         "both the scores and the injected/held-back split must survive emission"

--- a/crates/trusty-code/src/task/mock_llm.rs
+++ b/crates/trusty-code/src/task/mock_llm.rs
@@ -44,6 +44,16 @@ pub const MOCK_LLM_ECHO: &str = "echo";
 /// the fan-out shape sees it.
 pub const MOCK_LLM_ECHO_FANOUT: &str = "echo-fanout";
 
+/// The `TCODE_MOCK_LLM` value that selects [`RecallEchoLlmClient`] (DOC-39
+/// Slice C).
+///
+/// Why: neither [`EchoLlmClient`] nor [`FanoutEchoLlmClient`]'s scripts ever
+/// call `recall_session` — Slice C's e2e proof (recalled TEXT + `run_id`
+/// reaching `Event::MemoryRecalled` for a HELD-BACK result) needs the PM to
+/// issue that call against a mock trusty-memory backend, so this is its own
+/// opt-in value, same pattern as [`MOCK_LLM_ECHO_FANOUT`].
+pub const MOCK_LLM_ECHO_RECALL: &str = "echo-recall";
+
 /// Build the `Arc<dyn LlmClientTrait>` `task.run` executions share.
 ///
 /// Why: the single seam that decides "real model or offline mock" — kept
@@ -67,6 +77,7 @@ pub fn build_llm_client() -> Result<Arc<dyn LlmClientTrait>, RpcError> {
     match std::env::var(MOCK_LLM_ENV).ok().as_deref() {
         Some(MOCK_LLM_ECHO) => return Ok(Arc::new(EchoLlmClient::new())),
         Some(MOCK_LLM_ECHO_FANOUT) => return Ok(Arc::new(FanoutEchoLlmClient::new())),
+        Some(MOCK_LLM_ECHO_RECALL) => return Ok(Arc::new(RecallEchoLlmClient::new())),
         _ => {}
     }
     Ok(Arc::new(DispatchingLlmClient::new()))
@@ -319,6 +330,91 @@ fn bash_response_named(call_id: &str, command: &str) -> Value {
     })
 }
 
+/// A deterministic, scripted `LlmClientTrait` exercising the PM calling
+/// `recall_session` (DOC-39 Slice C's e2e proof).
+///
+/// Why: [`EchoLlmClient`] and [`FanoutEchoLlmClient`]'s scripts never call
+/// `recall_session`, so neither can drive the wire proof that a HELD-BACK
+/// recall result's actual TEXT (not just its score) reaches
+/// `Event::MemoryRecalled`. This script has the PM call `recall_session`
+/// exactly once, then stop — `tests/recall_content_e2e.rs` pairs it with a
+/// mock trusty-memory backend (`TRUSTY_MEMORY_URL` override) that returns one
+/// huge, high-scored result and one small, lower-scored result so the tool's
+/// own token budget drops the second one whole (mirroring
+/// `tools::recall_session`'s own budget tests) — the held-back case this
+/// slice must prove survives onto the wire.
+/// What: an atomic cursor over a fixed 2-response script:
+///
+/// 1. PM calls `recall_session(query="pkce oauth flow")`.
+/// 2. PM stops with final text.
+///
+/// Running past the script's end returns an `LlmError` rather than panicking.
+/// Test: `task::mock_llm::tests::recall_script_drives_a_single_recall_call`;
+/// exercised end-to-end (as a real subprocess) by
+/// `tests/recall_content_e2e.rs`.
+pub struct RecallEchoLlmClient {
+    cursor: AtomicUsize,
+}
+
+impl RecallEchoLlmClient {
+    /// Construct a fresh client at the start of its script.
+    pub fn new() -> Self {
+        Self {
+            cursor: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl Default for RecallEchoLlmClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl LlmClientTrait for RecallEchoLlmClient {
+    async fn chat(&self, _req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
+        let fixture = match idx {
+            0 => recall_response(),
+            1 => stop_response("pm: recalled what I needed"),
+            _ => {
+                return Err(LlmError::MissingConfig(format!(
+                    "RecallEchoLlmClient script exhausted at call {idx}"
+                )));
+            }
+        };
+        serde_json::from_value(fixture).map_err(|e| {
+            LlmError::MissingConfig(format!(
+                "RecallEchoLlmClient: invalid scripted fixture: {e}"
+            ))
+        })
+    }
+}
+
+/// Turn 1 fixture: the PM calls `recall_session` once.
+fn recall_response() -> Value {
+    json!({
+        "id": "mock-recall",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-recall",
+                    "type": "function",
+                    "function": {
+                        "name": "recall_session",
+                        "arguments": json!({"query": "pkce oauth flow"}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 30, "completion_tokens": 10, "total_tokens": 40}
+    })
+}
+
 /// Serializes every test in this crate that sets/reads the process-wide
 /// [`MOCK_LLM_ENV`] var — `cargo test` runs tests in parallel within one
 /// binary, and an unguarded `set_var`/`remove_var` pair would race across
@@ -409,6 +505,34 @@ mod tests {
 
         let turn6 = client.chat(&req).await.expect("turn 6 (pm stop)");
         assert!(turn6.first_tool_calls().is_empty());
+
+        let err = client.chat(&req).await;
+        assert!(err.is_err(), "the script must not silently repeat");
+    }
+
+    /// (DOC-39 Slice C) The recall script must drive exactly the
+    /// recall -> stop shape `tests/recall_content_e2e.rs` relies on.
+    #[tokio::test]
+    async fn recall_script_drives_a_single_recall_call() {
+        let client = RecallEchoLlmClient::new();
+        let req = ChatRequest {
+            model: "mock".to_string(),
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            tool_choice: None,
+            usage: None,
+        };
+
+        let turn1 = client.chat(&req).await.expect("turn 1");
+        let calls = turn1.first_tool_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].function.name, "recall_session");
+        assert!(calls[0].function.arguments.contains("pkce"));
+
+        let turn2 = client.chat(&req).await.expect("turn 2 (pm stop)");
+        assert!(turn2.first_tool_calls().is_empty());
 
         let err = client.chat(&req).await;
         assert!(err.is_err(), "the script must not silently repeat");

--- a/crates/trusty-code/src/task/sink.rs
+++ b/crates/trusty-code/src/task/sink.rs
@@ -290,6 +290,8 @@ mod tests {
                 results: vec![crate::events::RecalledMemory {
                     score: 0.4,
                     injected: false,
+                    text: "held back".to_string(),
+                    run_id: None,
                 }],
             }),
         )

--- a/crates/trusty-code/src/tools/recall_session.rs
+++ b/crates/trusty-code/src/tools/recall_session.rs
@@ -197,18 +197,26 @@ fn render_results(query: &str, results: &[Value]) -> (String, usize) {
 }
 
 /// Build the structured account of what was recalled and what reached the
-/// model (UI Phase 1).
+/// model (UI Phase 1; `text`/`run_id` added for DOC-39 Slice C).
 ///
 /// Why: this is the whole point of `Event::MemoryRecalled` — the UI renders
 /// held-back memories ("41% · held") beside injected ones, and only this
-/// tool ever knows which was which.
+/// tool ever knows which was which. Slice C extends that to the memory-
+/// provenance debugging surface ("what memory drove this / what was held
+/// back"), which needs the actual recalled TEXT, not just a score — a held
+/// -back result the UI can only count but never read is not debuggable.
 /// What: `results` is the filtered/capped, score-sorted list; the first
 /// `injected_count` of them entered context (see [`render_results`]) and the
 /// rest were recalled but dropped whole by the token budget. A result whose
 /// entry carries no numeric `score` reports `0.0` rather than being omitted
 /// — the UI must still see that the memory was recalled and held back.
+/// `text`/`run_id` are read from the SAME already-parsed `content` value
+/// `render_results` reads from (no second parse): `text` falls back to an
+/// empty string, `run_id` to `None`, when the entry carries no such field —
+/// never a panic.
 /// Test: `tests::telemetry_marks_budget_dropped_results_held_back`,
-/// `tests::telemetry_marks_all_injected_when_within_budget`.
+/// `tests::telemetry_marks_all_injected_when_within_budget`,
+/// `tests::telemetry_carries_recalled_text_and_run_id`.
 fn recall_telemetry(query: &str, results: &[Value], injected_count: usize) -> RecallTelemetry {
     RecallTelemetry {
         query: query.to_string(),
@@ -218,6 +226,12 @@ fn recall_telemetry(query: &str, results: &[Value], injected_count: usize) -> Re
             .map(|(i, r)| RecalledMemory {
                 score: r.get("score").and_then(Value::as_f64).unwrap_or(0.0),
                 injected: i < injected_count,
+                text: r
+                    .get("content")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+                run_id: r.get("run_id").and_then(Value::as_str).map(str::to_string),
             })
             .collect(),
     }
@@ -343,387 +357,6 @@ impl ToolExecutor for RecallSessionTool {
     }
 }
 
-// ── Tests ─────────────────────────────────────────────────────────────────────
-
 #[cfg(test)]
-mod tests {
-    use std::sync::{Arc, Mutex};
-
-    use axum::extract::State;
-    use axum::routing::post;
-    use axum::{Json, Router};
-    use tokio::net::TcpListener;
-
-    use super::*;
-
-    /// A `memory_recall` result entry with `content`/`score`/`tags`.
-    fn result_entry(content: &str, score: f64, tags: &[&str]) -> Value {
-        json!({
-            "drawer_id": "00000000-0000-0000-0000-000000000000",
-            "content": content,
-            "score": score,
-            "layer": 1,
-            "tags": tags,
-            "importance": 0.5,
-            "drawer_type": "session_note",
-        })
-    }
-
-    /// Wrap a `serialize_recall`-shaped body as the real spike-verified
-    /// `tools/call` envelope: the inner JSON STRINGIFIED inside
-    /// `content[0].text`.
-    fn tools_call_envelope(palace: &str, query: &str, results: Vec<Value>) -> Value {
-        let inner = json!({"palace": palace, "query": query, "results": results}).to_string();
-        json!({"content": [{"type": "text", "text": inner}]})
-    }
-
-    // NOTE (#2424): the envelope-unwrap unit tests moved with the helper to
-    // `crate::memory_envelope::tests` when `parse_recall_envelope` was
-    // promoted to the shared `parse_tools_call_envelope`.
-
-    // ── `filter_and_cap` ─────────────────────────────────────────────────
-
-    #[test]
-    fn filter_and_cap_keeps_only_tagged_results_in_order() {
-        let results = vec![
-            result_entry("a", 0.9, &["session:s1", "turn"]),
-            result_entry("b", 0.8, &["session:other", "turn"]),
-            result_entry("c", 0.7, &["session:s1", "turn"]),
-        ];
-        let filtered = filter_and_cap(&results, "session:s1", 10);
-        assert_eq!(filtered.len(), 2);
-        assert_eq!(filtered[0]["content"], "a");
-        assert_eq!(filtered[1]["content"], "c");
-    }
-
-    #[test]
-    fn filter_and_cap_respects_top_k() {
-        let results = vec![
-            result_entry("a", 0.9, &["session:s1"]),
-            result_entry("b", 0.8, &["session:s1"]),
-            result_entry("c", 0.7, &["session:s1"]),
-        ];
-        let filtered = filter_and_cap(&results, "session:s1", 2);
-        assert_eq!(filtered.len(), 2);
-        assert_eq!(filtered[0]["content"], "a");
-        assert_eq!(filtered[1]["content"], "b");
-    }
-
-    // ── `render_results` ─────────────────────────────────────────────────
-
-    #[test]
-    fn render_drops_whole_lowest_scored_entries_over_budget() {
-        // Each "x" repeated 4 chars ~ 1 token by the chars/4 heuristic.
-        // Build one huge entry that alone exceeds the budget, followed by a
-        // small one; expect the small one dropped, not mid-text truncated.
-        let huge = "x".repeat((TOKEN_BUDGET + 100) * 4);
-        let results = vec![result_entry(&huge, 0.9, &["session:s1"]), {
-            let mut r = result_entry("small tail entry", 0.8, &["session:s1"]);
-            r["content"] = json!("small tail entry");
-            r
-        }];
-        let (rendered, injected_count) = render_results("q", &results);
-        assert!(
-            rendered.contains(&huge),
-            "first entry always included whole"
-        );
-        assert!(
-            !rendered.contains("small tail entry"),
-            "second (lower-scored) entry must be dropped whole, not merged/truncated in"
-        );
-        assert_eq!(injected_count, 1, "only the first entry entered context");
-    }
-
-    #[test]
-    fn render_includes_all_entries_within_budget() {
-        let results = vec![
-            result_entry("first", 0.9, &["session:s1"]),
-            result_entry("second", 0.8, &["session:s1"]),
-        ];
-        let (rendered, injected_count) = render_results("q", &results);
-        assert!(rendered.contains("first"));
-        assert!(rendered.contains("second"));
-        assert_eq!(
-            injected_count, 2,
-            "both entries fit, so both entered context"
-        );
-    }
-
-    // ── telemetry (UI Phase 1) ───────────────────────────────────────────
-
-    /// Extract the `RecallTelemetry` a result carries, or panic.
-    fn recall_telemetry_of(result: &ToolResult) -> &RecallTelemetry {
-        match result.telemetry() {
-            Some(ToolTelemetry::Recall(t)) => t,
-            other => panic!("expected recall telemetry, got {other:?}"),
-        }
-    }
-
-    /// A result the token budget dropped must be reported as recalled but
-    /// NOT injected — the UI's "41% · held" surface.
-    ///
-    /// Why: THE point of `Event::MemoryRecalled`. The tool has always known
-    /// which results its budget dropped; before this ticket that knowledge
-    /// died inside the rendered text. `injected: false` must mean exactly
-    /// "recalled but not entered into context".
-    /// What: two results where the first alone busts the budget; assert the
-    /// second is present in the telemetry, flagged held-back, with its score.
-    /// Test: this test.
-    #[test]
-    fn telemetry_marks_budget_dropped_results_held_back() {
-        let huge = "x".repeat((TOKEN_BUDGET + 100) * 4);
-        let results = vec![
-            result_entry(&huge, 0.9, &["session:s1"]),
-            result_entry("held back", 0.41, &["session:s1"]),
-        ];
-        let (_text, injected_count) = render_results("q", &results);
-        let telemetry = recall_telemetry("q", &results, injected_count);
-
-        assert_eq!(
-            telemetry.results,
-            vec![
-                RecalledMemory {
-                    score: 0.9,
-                    injected: true
-                },
-                RecalledMemory {
-                    score: 0.41,
-                    injected: false
-                },
-            ],
-            "a budget-dropped result must still be REPORTED, flagged held-back \
-             — dropping it from the telemetry too would hide it from the UI \
-             entirely, which is the exact opposite of the requirement"
-        );
-    }
-
-    /// Every result that fit the budget must be reported injected.
-    #[test]
-    fn telemetry_marks_all_injected_when_within_budget() {
-        let results = vec![
-            result_entry("first", 0.9, &["session:s1"]),
-            result_entry("second", 0.8, &["session:s1"]),
-        ];
-        let (_text, injected_count) = render_results("q", &results);
-        let telemetry = recall_telemetry("q", &results, injected_count);
-
-        assert!(
-            telemetry.results.iter().all(|r| r.injected),
-            "both fit, so both entered context: {:?}",
-            telemetry.results
-        );
-        assert_eq!(telemetry.query, "q");
-    }
-
-    /// `execute` must attach telemetry whose injected flags agree with the
-    /// text it actually returned (UI Phase 1).
-    ///
-    /// Why: an end-to-end guard that the render and the telemetry can never
-    /// disagree about what the model saw — the failure mode a UI could not
-    /// detect on its own.
-    /// Test: this test.
-    #[tokio::test]
-    async fn execute_attaches_telemetry_matching_the_rendered_text() {
-        let results = vec![
-            result_entry("visible one", 0.9, &["session:s1", "turn"]),
-            result_entry("visible two", 0.7, &["session:s1", "turn"]),
-        ];
-        let (base_url, _captured) = spawn_recall_mock(results).await;
-        let tool = RecallSessionTool::new("s1", base_url, "p");
-
-        let result = tool.execute(json!({"query": "foo"})).await;
-        let telemetry = recall_telemetry_of(&result);
-
-        assert_eq!(telemetry.query, "foo");
-        assert_eq!(telemetry.results.len(), 2);
-        for (i, r) in telemetry.results.iter().enumerate() {
-            assert!(r.injected, "result {i} is in the text, so it is injected");
-        }
-        assert!(result.content().contains("visible one"));
-        assert!(result.content().contains("visible two"));
-    }
-
-    /// The fail-open paths must attach no telemetry — nothing was recalled.
-    ///
-    /// Why: emitting a `MemoryRecalled` with an empty result set for an
-    /// unreachable daemon would tell the UI "we recalled nothing relevant"
-    /// when the truth is "we could not look". Those are different facts.
-    /// Test: this test.
-    #[tokio::test]
-    async fn fail_open_paths_report_no_telemetry() {
-        let tool = RecallSessionTool::new("s1", "http://127.0.0.1:1", "p");
-        let result = tool.execute(json!({"query": "anything"})).await;
-        assert!(!result.is_error());
-        assert!(
-            result.telemetry().is_none(),
-            "an unreachable daemon is not a recall with zero results"
-        );
-    }
-
-    /// Dropping a lowest-scored result for budget emits an INFO-level log
-    /// naming the dropped/included counts (#2857).
-    ///
-    /// Why: the budget truncation this module implements is exactly the
-    /// "recall_session: token-budget truncation dropping lowest-scored
-    /// results" site this ticket names as audited — the model silently
-    /// receives fewer memories than requested, which must be diagnosable
-    /// from stderr.
-    /// What: Same over-budget scenario as
-    /// `render_drops_whole_lowest_scored_entries_over_budget`, captured via
-    /// `crate::test_support::begin_capture`/`captured_at_least`.
-    /// Test: this test.
-    #[test]
-    fn render_drop_logs_info() {
-        crate::test_support::begin_capture();
-
-        let huge = "x".repeat((TOKEN_BUDGET + 100) * 4);
-        let results = vec![
-            result_entry(&huge, 0.9, &["session:s1"]),
-            result_entry("small tail entry", 0.8, &["session:s1"]),
-        ];
-        render_results("q", &results);
-
-        let captured = crate::test_support::captured_at_least(tracing::Level::INFO);
-        assert!(
-            captured.iter().any(|m| m.contains("token budget exceeded")),
-            "expected an info-level budget-drop log, got: {captured:?}"
-        );
-    }
-
-    // ── schema ───────────────────────────────────────────────────────────
-
-    #[test]
-    fn schema_has_required_fields() {
-        let tool = RecallSessionTool::new("s1", "http://x", "p");
-        let schema = tool.schema();
-        let params = &schema["function"]["parameters"];
-        assert_eq!(schema["function"]["name"], RECALL_SESSION_TOOL_NAME);
-        let required: Vec<&str> = params["required"]
-            .as_array()
-            .expect("required array")
-            .iter()
-            .filter_map(|v| v.as_str())
-            .collect();
-        assert_eq!(required, vec!["query"]);
-        assert_eq!(params["additionalProperties"], json!(false));
-    }
-
-    // ── `execute` end-to-end against a mock daemon ───────────────────────
-
-    /// One captured `/rpc` call: JSON-RPC `method` + `params`.
-    type Captured = Arc<Mutex<Vec<(String, Value)>>>;
-
-    /// Spin up a mock `/rpc` server that always replies with the
-    /// spike-verified `tools/call` envelope shape for `memory_recall`,
-    /// capturing every request's method/params.
-    async fn spawn_recall_mock(results: Vec<Value>) -> (String, Captured) {
-        let captured: Captured = Arc::new(Mutex::new(Vec::new()));
-        let store = Arc::clone(&captured);
-        let results_state = Arc::new(results);
-
-        async fn handle(
-            State((store, results)): State<(Captured, Arc<Vec<Value>>)>,
-            Json(body): Json<Value>,
-        ) -> Json<Value> {
-            let method = body["method"].as_str().unwrap_or_default().to_string();
-            let params = body["params"].clone();
-            store
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .push((method, params.clone()));
-            let palace = params["arguments"]["palace"]
-                .as_str()
-                .unwrap_or_default()
-                .to_string();
-            let query = params["arguments"]["query"]
-                .as_str()
-                .unwrap_or_default()
-                .to_string();
-            let envelope = tools_call_envelope(&palace, &query, (*results).clone());
-            Json(json!({"jsonrpc": "2.0", "id": 1, "result": envelope}))
-        }
-
-        let app = Router::new()
-            .route("/rpc", post(handle))
-            .with_state((store, results_state));
-        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
-        let addr = listener.local_addr().expect("addr");
-        tokio::spawn(async move {
-            let _ = axum::serve(listener, app).await;
-        });
-        (format!("http://{addr}"), captured)
-    }
-
-    #[tokio::test]
-    async fn execute_returns_only_session_tagged_results() {
-        let results = vec![
-            result_entry("mine: file is at src/foo.rs", 0.9, &["session:s1", "turn"]),
-            result_entry("other session's note", 0.8, &["session:s2", "turn"]),
-            result_entry("mine again", 0.7, &["session:s1", "turn"]),
-        ];
-        let (base_url, _captured) = spawn_recall_mock(results).await;
-        let tool = RecallSessionTool::new("s1", base_url, "p");
-
-        let result = tool.execute(json!({"query": "foo"})).await;
-        assert!(!result.is_error());
-        assert!(result.content().contains("src/foo.rs"));
-        assert!(result.content().contains("mine again"));
-        assert!(!result.content().contains("other session's note"));
-    }
-
-    #[tokio::test]
-    async fn execute_over_fetches_top_k_times_factor() {
-        let (base_url, captured) = spawn_recall_mock(vec![]).await;
-        let tool = RecallSessionTool::new("s1", base_url, "p");
-
-        let _ = tool.execute(json!({"query": "foo", "top_k": 3})).await;
-
-        let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        assert_eq!(calls.len(), 1);
-        let (method, params) = &calls[0];
-        assert_eq!(method, "tools/call");
-        assert_eq!(params["name"], "memory_recall");
-        assert_eq!(params["arguments"]["top_k"], json!(3 * OVER_FETCH_FACTOR));
-    }
-
-    #[tokio::test]
-    async fn execute_clamps_top_k_to_max() {
-        let (base_url, captured) = spawn_recall_mock(vec![]).await;
-        let tool = RecallSessionTool::new("s1", base_url, "p");
-
-        let _ = tool.execute(json!({"query": "foo", "top_k": 999})).await;
-
-        let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
-        assert_eq!(
-            calls[0].1["arguments"]["top_k"],
-            json!(MAX_TOP_K * OVER_FETCH_FACTOR)
-        );
-    }
-
-    #[tokio::test]
-    async fn execute_is_fail_open_on_unreachable_daemon() {
-        let tool = RecallSessionTool::new("s1", "http://127.0.0.1:1", "p");
-        let result = tool.execute(json!({"query": "anything"})).await;
-        assert!(!result.is_error(), "must not surface as a tool error");
-        assert!(result.content().contains("unavailable"));
-    }
-
-    #[tokio::test]
-    async fn execute_rejects_malformed_args_recoverably() {
-        let tool = RecallSessionTool::new("s1", "http://127.0.0.1:1", "p");
-        let result = tool.execute(json!({"top_k": 3})).await; // missing 'query'
-        assert!(result.is_error());
-        assert!(!result.is_fatal());
-    }
-
-    #[tokio::test]
-    async fn execute_empty_when_no_session_tagged_results() {
-        let results = vec![result_entry("belongs elsewhere", 0.9, &["session:other"])];
-        let (base_url, _captured) = spawn_recall_mock(results).await;
-        let tool = RecallSessionTool::new("s1", base_url, "p");
-
-        let result = tool.execute(json!({"query": "anything"})).await;
-        assert!(!result.is_error());
-        assert!(result.content().contains("No session memory found"));
-    }
-}
+#[path = "recall_session_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/tools/recall_session_tests.rs
+++ b/crates/trusty-code/src/tools/recall_session_tests.rs
@@ -1,0 +1,437 @@
+//! Unit tests for `tools::recall_session` — split out of `recall_session.rs`
+//! per the crate's `_tests.rs` sibling-file convention (see
+//! `events`/`events_tests` and `session::registry`/`registry_tests` for
+//! precedent) so the tool's growing test surface (DOC-39 Slice C added
+//! `text`/`run_id` coverage) doesn't push the production file past its
+//! 500-SLOC cap — test files carry the 1500-SLOC cap.
+//! What: covers `filter_and_cap`, `render_results`, `recall_telemetry`
+//! (including DOC-39 Slice C's `text`/`run_id` extraction), the tool's
+//! schema, and `execute` end-to-end against an in-process mock trusty-memory
+//! `/rpc` server.
+//! Test: this module is itself the test surface.
+
+use std::sync::{Arc, Mutex};
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use tokio::net::TcpListener;
+
+use super::*;
+
+/// A `memory_recall` result entry with `content`/`score`/`tags`.
+fn result_entry(content: &str, score: f64, tags: &[&str]) -> Value {
+    json!({
+        "drawer_id": "00000000-0000-0000-0000-000000000000",
+        "content": content,
+        "score": score,
+        "layer": 1,
+        "tags": tags,
+        "importance": 0.5,
+        "drawer_type": "session_note",
+    })
+}
+
+/// Wrap a `serialize_recall`-shaped body as the real spike-verified
+/// `tools/call` envelope: the inner JSON STRINGIFIED inside
+/// `content[0].text`.
+fn tools_call_envelope(palace: &str, query: &str, results: Vec<Value>) -> Value {
+    let inner = json!({"palace": palace, "query": query, "results": results}).to_string();
+    json!({"content": [{"type": "text", "text": inner}]})
+}
+
+// NOTE (#2424): the envelope-unwrap unit tests moved with the helper to
+// `crate::memory_envelope::tests` when `parse_recall_envelope` was
+// promoted to the shared `parse_tools_call_envelope`.
+
+// ── `filter_and_cap` ─────────────────────────────────────────────────
+
+#[test]
+fn filter_and_cap_keeps_only_tagged_results_in_order() {
+    let results = vec![
+        result_entry("a", 0.9, &["session:s1", "turn"]),
+        result_entry("b", 0.8, &["session:other", "turn"]),
+        result_entry("c", 0.7, &["session:s1", "turn"]),
+    ];
+    let filtered = filter_and_cap(&results, "session:s1", 10);
+    assert_eq!(filtered.len(), 2);
+    assert_eq!(filtered[0]["content"], "a");
+    assert_eq!(filtered[1]["content"], "c");
+}
+
+#[test]
+fn filter_and_cap_respects_top_k() {
+    let results = vec![
+        result_entry("a", 0.9, &["session:s1"]),
+        result_entry("b", 0.8, &["session:s1"]),
+        result_entry("c", 0.7, &["session:s1"]),
+    ];
+    let filtered = filter_and_cap(&results, "session:s1", 2);
+    assert_eq!(filtered.len(), 2);
+    assert_eq!(filtered[0]["content"], "a");
+    assert_eq!(filtered[1]["content"], "b");
+}
+
+// ── `render_results` ─────────────────────────────────────────────────
+
+#[test]
+fn render_drops_whole_lowest_scored_entries_over_budget() {
+    // Each "x" repeated 4 chars ~ 1 token by the chars/4 heuristic.
+    // Build one huge entry that alone exceeds the budget, followed by a
+    // small one; expect the small one dropped, not mid-text truncated.
+    let huge = "x".repeat((TOKEN_BUDGET + 100) * 4);
+    let results = vec![result_entry(&huge, 0.9, &["session:s1"]), {
+        let mut r = result_entry("small tail entry", 0.8, &["session:s1"]);
+        r["content"] = json!("small tail entry");
+        r
+    }];
+    let (rendered, injected_count) = render_results("q", &results);
+    assert!(
+        rendered.contains(&huge),
+        "first entry always included whole"
+    );
+    assert!(
+        !rendered.contains("small tail entry"),
+        "second (lower-scored) entry must be dropped whole, not merged/truncated in"
+    );
+    assert_eq!(injected_count, 1, "only the first entry entered context");
+}
+
+#[test]
+fn render_includes_all_entries_within_budget() {
+    let results = vec![
+        result_entry("first", 0.9, &["session:s1"]),
+        result_entry("second", 0.8, &["session:s1"]),
+    ];
+    let (rendered, injected_count) = render_results("q", &results);
+    assert!(rendered.contains("first"));
+    assert!(rendered.contains("second"));
+    assert_eq!(
+        injected_count, 2,
+        "both entries fit, so both entered context"
+    );
+}
+
+// ── telemetry (UI Phase 1) ───────────────────────────────────────────
+
+/// Extract the `RecallTelemetry` a result carries, or panic.
+fn recall_telemetry_of(result: &ToolResult) -> &RecallTelemetry {
+    match result.telemetry() {
+        Some(ToolTelemetry::Recall(t)) => t,
+        other => panic!("expected recall telemetry, got {other:?}"),
+    }
+}
+
+/// A result the token budget dropped must be reported as recalled but
+/// NOT injected — the UI's "41% · held" surface.
+///
+/// Why: THE point of `Event::MemoryRecalled`. The tool has always known
+/// which results its budget dropped; before this ticket that knowledge
+/// died inside the rendered text. `injected: false` must mean exactly
+/// "recalled but not entered into context".
+/// What: two results where the first alone busts the budget; assert the
+/// second is present in the telemetry, flagged held-back, with its score.
+/// Test: this test.
+#[test]
+fn telemetry_marks_budget_dropped_results_held_back() {
+    let huge = "x".repeat((TOKEN_BUDGET + 100) * 4);
+    let results = vec![
+        result_entry(&huge, 0.9, &["session:s1"]),
+        result_entry("held back", 0.41, &["session:s1"]),
+    ];
+    let (_text, injected_count) = render_results("q", &results);
+    let telemetry = recall_telemetry("q", &results, injected_count);
+
+    assert_eq!(
+        telemetry.results,
+        vec![
+            RecalledMemory {
+                score: 0.9,
+                injected: true,
+                text: huge.clone(),
+                run_id: None,
+            },
+            RecalledMemory {
+                score: 0.41,
+                injected: false,
+                text: "held back".to_string(),
+                run_id: None,
+            },
+        ],
+        "a budget-dropped result must still be REPORTED, flagged held-back \
+         — dropping it from the telemetry too would hide it from the UI \
+         entirely, which is the exact opposite of the requirement"
+    );
+}
+
+/// The whole point of DOC-39 Slice C: a result the token budget dropped
+/// must still carry its actual recalled TEXT in the telemetry, not just
+/// a score — otherwise the "what was held back" UI surface can count a
+/// held-back memory but never let an operator read it.
+///
+/// Why: `recall_telemetry` reads `text`/`run_id` from the SAME `content`
+/// value `render_results` already parses (`result_entry`'s `content`
+/// field). `run_id` is not part of the current daemon response shape, so
+/// it must default to `None` without panicking, never `unwrap`.
+/// What: two results where the first alone busts the budget; assert the
+/// held-back second entry's telemetry carries its full text and a `None`
+/// `run_id`, and the injected first entry carries its own text too.
+/// Test: this test.
+#[test]
+fn telemetry_carries_recalled_text_and_run_id() {
+    let huge = "x".repeat((TOKEN_BUDGET + 100) * 4);
+    let results = vec![
+        result_entry(&huge, 0.9, &["session:s1"]),
+        result_entry("PKCE required for the OAuth flow", 0.41, &["session:s1"]),
+    ];
+    let (_text, injected_count) = render_results("q", &results);
+    let telemetry = recall_telemetry("q", &results, injected_count);
+
+    assert_eq!(telemetry.results.len(), 2);
+    assert_eq!(telemetry.results[0].text, huge, "injected result's text");
+    assert!(telemetry.results[0].injected);
+    assert_eq!(telemetry.results[0].run_id, None);
+
+    let held_back = &telemetry.results[1];
+    assert!(!held_back.injected, "second entry must be held back");
+    assert_eq!(
+        held_back.text, "PKCE required for the OAuth flow",
+        "the held-back result's TEXT must still be present — the whole \
+         point of the 'what was held back' UI surface is reading it"
+    );
+    assert_eq!(
+        held_back.run_id, None,
+        "run_id defaults to None (never panics) when the daemon result \
+         carries no such field"
+    );
+}
+
+/// Every result that fit the budget must be reported injected.
+#[test]
+fn telemetry_marks_all_injected_when_within_budget() {
+    let results = vec![
+        result_entry("first", 0.9, &["session:s1"]),
+        result_entry("second", 0.8, &["session:s1"]),
+    ];
+    let (_text, injected_count) = render_results("q", &results);
+    let telemetry = recall_telemetry("q", &results, injected_count);
+
+    assert!(
+        telemetry.results.iter().all(|r| r.injected),
+        "both fit, so both entered context: {:?}",
+        telemetry.results
+    );
+    assert_eq!(telemetry.query, "q");
+}
+
+/// `execute` must attach telemetry whose injected flags agree with the
+/// text it actually returned (UI Phase 1).
+///
+/// Why: an end-to-end guard that the render and the telemetry can never
+/// disagree about what the model saw — the failure mode a UI could not
+/// detect on its own.
+/// Test: this test.
+#[tokio::test]
+async fn execute_attaches_telemetry_matching_the_rendered_text() {
+    let results = vec![
+        result_entry("visible one", 0.9, &["session:s1", "turn"]),
+        result_entry("visible two", 0.7, &["session:s1", "turn"]),
+    ];
+    let (base_url, _captured) = spawn_recall_mock(results).await;
+    let tool = RecallSessionTool::new("s1", base_url, "p");
+
+    let result = tool.execute(json!({"query": "foo"})).await;
+    let telemetry = recall_telemetry_of(&result);
+
+    assert_eq!(telemetry.query, "foo");
+    assert_eq!(telemetry.results.len(), 2);
+    for (i, r) in telemetry.results.iter().enumerate() {
+        assert!(r.injected, "result {i} is in the text, so it is injected");
+    }
+    assert!(result.content().contains("visible one"));
+    assert!(result.content().contains("visible two"));
+}
+
+/// The fail-open paths must attach no telemetry — nothing was recalled.
+///
+/// Why: emitting a `MemoryRecalled` with an empty result set for an
+/// unreachable daemon would tell the UI "we recalled nothing relevant"
+/// when the truth is "we could not look". Those are different facts.
+/// Test: this test.
+#[tokio::test]
+async fn fail_open_paths_report_no_telemetry() {
+    let tool = RecallSessionTool::new("s1", "http://127.0.0.1:1", "p");
+    let result = tool.execute(json!({"query": "anything"})).await;
+    assert!(!result.is_error());
+    assert!(
+        result.telemetry().is_none(),
+        "an unreachable daemon is not a recall with zero results"
+    );
+}
+
+/// Dropping a lowest-scored result for budget emits an INFO-level log
+/// naming the dropped/included counts (#2857).
+///
+/// Why: the budget truncation this module implements is exactly the
+/// "recall_session: token-budget truncation dropping lowest-scored
+/// results" site this ticket names as audited — the model silently
+/// receives fewer memories than requested, which must be diagnosable
+/// from stderr.
+/// What: Same over-budget scenario as
+/// `render_drops_whole_lowest_scored_entries_over_budget`, captured via
+/// `crate::test_support::begin_capture`/`captured_at_least`.
+/// Test: this test.
+#[test]
+fn render_drop_logs_info() {
+    crate::test_support::begin_capture();
+
+    let huge = "x".repeat((TOKEN_BUDGET + 100) * 4);
+    let results = vec![
+        result_entry(&huge, 0.9, &["session:s1"]),
+        result_entry("small tail entry", 0.8, &["session:s1"]),
+    ];
+    render_results("q", &results);
+
+    let captured = crate::test_support::captured_at_least(tracing::Level::INFO);
+    assert!(
+        captured.iter().any(|m| m.contains("token budget exceeded")),
+        "expected an info-level budget-drop log, got: {captured:?}"
+    );
+}
+
+// ── schema ───────────────────────────────────────────────────────────
+
+#[test]
+fn schema_has_required_fields() {
+    let tool = RecallSessionTool::new("s1", "http://x", "p");
+    let schema = tool.schema();
+    let params = &schema["function"]["parameters"];
+    assert_eq!(schema["function"]["name"], RECALL_SESSION_TOOL_NAME);
+    let required: Vec<&str> = params["required"]
+        .as_array()
+        .expect("required array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    assert_eq!(required, vec!["query"]);
+    assert_eq!(params["additionalProperties"], json!(false));
+}
+
+// ── `execute` end-to-end against a mock daemon ───────────────────────
+
+/// One captured `/rpc` call: JSON-RPC `method` + `params`.
+type Captured = Arc<Mutex<Vec<(String, Value)>>>;
+
+/// Spin up a mock `/rpc` server that always replies with the
+/// spike-verified `tools/call` envelope shape for `memory_recall`,
+/// capturing every request's method/params.
+async fn spawn_recall_mock(results: Vec<Value>) -> (String, Captured) {
+    let captured: Captured = Arc::new(Mutex::new(Vec::new()));
+    let store = Arc::clone(&captured);
+    let results_state = Arc::new(results);
+
+    async fn handle(
+        State((store, results)): State<(Captured, Arc<Vec<Value>>)>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let method = body["method"].as_str().unwrap_or_default().to_string();
+        let params = body["params"].clone();
+        store
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push((method, params.clone()));
+        let palace = params["arguments"]["palace"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let query = params["arguments"]["query"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let envelope = tools_call_envelope(&palace, &query, (*results).clone());
+        Json(json!({"jsonrpc": "2.0", "id": 1, "result": envelope}))
+    }
+
+    let app = Router::new()
+        .route("/rpc", post(handle))
+        .with_state((store, results_state));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), captured)
+}
+
+#[tokio::test]
+async fn execute_returns_only_session_tagged_results() {
+    let results = vec![
+        result_entry("mine: file is at src/foo.rs", 0.9, &["session:s1", "turn"]),
+        result_entry("other session's note", 0.8, &["session:s2", "turn"]),
+        result_entry("mine again", 0.7, &["session:s1", "turn"]),
+    ];
+    let (base_url, _captured) = spawn_recall_mock(results).await;
+    let tool = RecallSessionTool::new("s1", base_url, "p");
+
+    let result = tool.execute(json!({"query": "foo"})).await;
+    assert!(!result.is_error());
+    assert!(result.content().contains("src/foo.rs"));
+    assert!(result.content().contains("mine again"));
+    assert!(!result.content().contains("other session's note"));
+}
+
+#[tokio::test]
+async fn execute_over_fetches_top_k_times_factor() {
+    let (base_url, captured) = spawn_recall_mock(vec![]).await;
+    let tool = RecallSessionTool::new("s1", base_url, "p");
+
+    let _ = tool.execute(json!({"query": "foo", "top_k": 3})).await;
+
+    let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    assert_eq!(calls.len(), 1);
+    let (method, params) = &calls[0];
+    assert_eq!(method, "tools/call");
+    assert_eq!(params["name"], "memory_recall");
+    assert_eq!(params["arguments"]["top_k"], json!(3 * OVER_FETCH_FACTOR));
+}
+
+#[tokio::test]
+async fn execute_clamps_top_k_to_max() {
+    let (base_url, captured) = spawn_recall_mock(vec![]).await;
+    let tool = RecallSessionTool::new("s1", base_url, "p");
+
+    let _ = tool.execute(json!({"query": "foo", "top_k": 999})).await;
+
+    let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    assert_eq!(
+        calls[0].1["arguments"]["top_k"],
+        json!(MAX_TOP_K * OVER_FETCH_FACTOR)
+    );
+}
+
+#[tokio::test]
+async fn execute_is_fail_open_on_unreachable_daemon() {
+    let tool = RecallSessionTool::new("s1", "http://127.0.0.1:1", "p");
+    let result = tool.execute(json!({"query": "anything"})).await;
+    assert!(!result.is_error(), "must not surface as a tool error");
+    assert!(result.content().contains("unavailable"));
+}
+
+#[tokio::test]
+async fn execute_rejects_malformed_args_recoverably() {
+    let tool = RecallSessionTool::new("s1", "http://127.0.0.1:1", "p");
+    let result = tool.execute(json!({"top_k": 3})).await; // missing 'query'
+    assert!(result.is_error());
+    assert!(!result.is_fatal());
+}
+
+#[tokio::test]
+async fn execute_empty_when_no_session_tagged_results() {
+    let results = vec![result_entry("belongs elsewhere", 0.9, &["session:other"])];
+    let (base_url, _captured) = spawn_recall_mock(results).await;
+    let tool = RecallSessionTool::new("s1", base_url, "p");
+
+    let result = tool.execute(json!({"query": "anything"})).await;
+    assert!(!result.is_error());
+    assert!(result.content().contains("No session memory found"));
+}

--- a/crates/trusty-code/tests/recall_content_e2e.rs
+++ b/crates/trusty-code/tests/recall_content_e2e.rs
@@ -1,0 +1,274 @@
+//! End-to-end acceptance proof for DOC-39 Slice C (recalled TEXT + `run_id`
+//! on `Event::MemoryRecalled`) — the mandatory API-driven e2e gate for this
+//! slice (Bob's standing testability directive).
+//!
+//! Why: the "what memory drove this / what was held back" UI surface (e.g.
+//! "PKCE required… 41% · held") needs the ACTUAL recalled text of a held-back
+//! result, not just its score and the `injected: false` flag —
+//! `tools::recall_session::recall_telemetry` and `events::RecalledMemory`'s
+//! new `text`/`run_id` fields are already covered by unit tests
+//! (`tools::recall_session::tests::telemetry_carries_recalled_text_and_run_id`,
+//! `events_tests::recalled_memory_round_trips_through_json`), but those never
+//! drive the REAL wire: the real `tcode serve --stdio` binary, a real
+//! `recall_session` tool call, a real (mocked) trusty-memory HTTP backend,
+//! and the real `session.attach` event stream. This is that proof.
+//!
+//! Uses `TCODE_MOCK_LLM=echo-recall`
+//! ([`trusty_code::task::mock_llm::RecallEchoLlmClient`]) so the PM issues
+//! exactly one `recall_session` tool call, no live model/API key required,
+//! and `TRUSTY_MEMORY_URL` (`trusty_common::mcp::memory_rpc::TRUSTY_MEMORY_URL_ENV`)
+//! pointed at an in-process mock trusty-memory `/rpc` server that returns two
+//! results: one huge, high-scored entry that alone busts `recall_session`'s
+//! token budget (so it alone is INJECTED), and one small, lower-scored entry
+//! that is therefore HELD BACK whole — mirroring
+//! `tools::recall_session::tests::telemetry_marks_budget_dropped_results_held_back`'s
+//! shape, but observed over the real wire instead of asserted in-process. The
+//! injected entry also carries a `run_id` in the mocked daemon response, to
+//! prove that field threads through end-to-end too when present.
+//!
+//! What: spawns the real `tcode serve --stdio` binary, runs `task.run` +
+//! `session.attach`, drains the replay + live event stream to
+//! `session_done`, then asserts the ONE `memory_recalled` event's `results`
+//! carry: the injected entry's full text AND `run_id`, and — the whole point
+//! of this slice — the HELD-BACK entry's full text (proving the "what was
+//! held back" debugging surface is reachable over the wire), with `run_id`
+//! gracefully absent (`null`) rather than panicking when the daemon response
+//! carries none.
+//! Test: this module is itself the test surface.
+
+mod support;
+
+use axum::extract::State;
+use axum::routing::post;
+use axum::{Json, Router};
+use serde_json::{Value, json};
+use support::{StdioSession, find_session_event, project_with_agents};
+use tokio::net::TcpListener;
+use tokio::sync::watch;
+
+/// The huge entry's recalled text — long enough (see `recall_session`'s own
+/// `TOKEN_BUDGET = 4000` chars/4 heuristic) that it alone exceeds the token
+/// budget, forcing the second, smaller entry to be dropped whole rather than
+/// merged/truncated in.
+fn huge_injected_text() -> String {
+    "PKCE keystone context. ".repeat(1000)
+}
+
+/// The text of the result the token budget must hold back whole — this is
+/// the exact string the test asserts survives onto `Event::MemoryRecalled`.
+const HELD_BACK_TEXT: &str = "PKCE required for the OAuth token exchange — held back by budget";
+
+/// The `run_id` the mocked daemon attaches to the INJECTED result, to prove
+/// the field threads through end-to-end when present.
+const INJECTED_RUN_ID: &str = "run-e2e-slice-c";
+
+/// Spin up a mock trusty-memory `/rpc` server that answers ANY `memory_recall`
+/// call with the fixed two-result fixture described in the module docs.
+///
+/// Why: `recall_session`'s client-side filter (`filter_and_cap`) only keeps
+/// results tagged `session:<the real, daemon-assigned session id>` — a value
+/// this test cannot know until AFTER `task.run` responds. Rather than racing
+/// the mock server's startup against the daemon discovering the real session
+/// id, the handler `.await`s a [`watch::Receiver`] until the test driver
+/// publishes the real tag (via the returned [`watch::Sender`]) — so the mock
+/// is correct regardless of scheduling, never a flaky race.
+/// What: returns `(base_url, tag_tx)`; the caller must call
+/// `tag_tx.send(Some(format!("session:{session_id}")))` once it knows the
+/// real session id, before the daemon's `recall_session` call is expected to
+/// resolve.
+async fn spawn_recall_mock_daemon() -> (String, watch::Sender<Option<String>>) {
+    let (tag_tx, tag_rx) = watch::channel(None::<String>);
+
+    async fn handle(
+        State(mut rx): State<watch::Receiver<Option<String>>>,
+        Json(_body): Json<Value>,
+    ) -> Json<Value> {
+        // Block until the test driver knows the real session id and
+        // publishes the matching tag — see the function's own docs.
+        let tag = loop {
+            if let Some(tag) = rx.borrow().clone() {
+                break tag;
+            }
+            if rx.changed().await.is_err() {
+                break String::new();
+            }
+        };
+
+        let results = vec![
+            json!({
+                "content": huge_injected_text(),
+                "score": 0.93,
+                "tags": [tag, "turn"],
+                "run_id": INJECTED_RUN_ID,
+            }),
+            json!({
+                "content": HELD_BACK_TEXT,
+                "score": 0.41,
+                "tags": [tag, "turn"],
+                // Deliberately no `run_id` — proves the tool defaults to
+                // `None` rather than panicking when the daemon omits it.
+            }),
+        ];
+        let inner =
+            json!({"palace": "p", "query": "pkce oauth flow", "results": results}).to_string();
+        let envelope = json!({"content": [{"type": "text", "text": inner}]});
+        Json(json!({"jsonrpc": "2.0", "id": 1, "result": envelope}))
+    }
+
+    let app = Router::new().route("/rpc", post(handle)).with_state(tag_rx);
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), tag_tx)
+}
+
+/// Drive `task.run` -> `session.attach` -> read-until-`session_done`,
+/// returning every session event's full JSON envelope (not just its `kind`
+/// like `support::run_task_to_completion` — this test needs the
+/// `memory_recalled` event's full `results` payload).
+async fn run_recall_task_to_completion(
+    daemon: &mut StdioSession,
+    tag_tx: &watch::Sender<Option<String>>,
+) -> Vec<Value> {
+    let run_resp = daemon
+        .call(
+            1,
+            "task.run",
+            json!({"task_description": "recall what we know about the pkce oauth flow"}),
+        )
+        .await;
+    assert!(run_resp["error"].is_null(), "task.run failed: {run_resp}");
+    let session_id = run_resp["result"]["session_id"]
+        .as_str()
+        .expect("task.run must return a session_id")
+        .to_string();
+
+    // Now that the real session id is known, publish the matching tag so the
+    // mock daemon's client-side `session:<id>` filter keeps both results.
+    let _ = tag_tx.send(Some(format!("session:{session_id}")));
+
+    let attach_resp = daemon
+        .call(2, "session.attach", json!({"session_id": session_id}))
+        .await;
+    assert!(
+        attach_resp["error"].is_null(),
+        "attach failed: {attach_resp}"
+    );
+    let mut envelopes: Vec<Value> = attach_resp["result"]["events"]
+        .as_array()
+        .expect("attach must return a replay events array")
+        .clone();
+
+    let mut iterations = 0;
+    let is_done = |envs: &[Value]| {
+        envs.iter()
+            .any(|e| e["kind"].as_str() == Some("session_done"))
+    };
+    while !is_done(&envelopes) {
+        iterations += 1;
+        assert!(
+            iterations < 20,
+            "gave up waiting for session_done after {iterations} read rounds; \
+             envelopes so far: {envelopes:?}"
+        );
+        let lines = daemon.read_lines(20).await;
+        assert!(
+            !lines.is_empty(),
+            "timed out waiting for more events; envelopes so far: {envelopes:?}"
+        );
+        for line in &lines {
+            if let Some(envelope) = find_session_event(line, &session_id) {
+                envelopes.push(envelope);
+            }
+        }
+    }
+
+    envelopes
+}
+
+/// DOC-39 Slice C's direct acceptance proof: a HELD-BACK recall result's
+/// actual TEXT (not just its score) must reach `Event::MemoryRecalled` over
+/// the real wire, and a `run_id` on the injected result must survive too.
+///
+/// Why: this is the exact "what memory drove this / what was held back"
+/// debugging gap Slice C closes — before this ticket, `RecalledMemory` only
+/// carried `score`/`injected`, so a held-back memory could be COUNTED by a
+/// UI but never READ. Proven here against the real subprocess daemon per
+/// Bob's mandatory API-driven e2e directive, not just the in-process unit
+/// tests in `tools::recall_session::tests` and `events_tests`.
+/// What: spawns the daemon with `TCODE_MOCK_LLM=echo-recall` and
+/// `TRUSTY_MEMORY_URL` pointed at the mock trusty-memory server, runs the
+/// scripted recall task to completion, finds the one `memory_recalled`
+/// event, and asserts: exactly two results; the injected (first) result
+/// carries its full text and `run_id`; the held-back (second) result carries
+/// its full text with `injected: false` and a `null` `run_id`.
+/// Test: this test.
+#[tokio::test]
+async fn held_back_recall_result_carries_its_text_and_run_id_over_the_wire() {
+    let (mock_base_url, tag_tx) = spawn_recall_mock_daemon().await;
+    let project = project_with_agents();
+    let mut daemon = StdioSession::spawn_with_mock_llm_variant_and_env(
+        project.path(),
+        trusty_code::task::mock_llm::MOCK_LLM_ECHO_RECALL,
+        &[(
+            trusty_common::mcp::memory_rpc::TRUSTY_MEMORY_URL_ENV,
+            &mock_base_url,
+        )],
+    );
+
+    let envelopes = run_recall_task_to_completion(&mut daemon, &tag_tx).await;
+
+    let recall_events: Vec<&Value> = envelopes
+        .iter()
+        .filter(|e| e["kind"].as_str() == Some("memory_recalled"))
+        .collect();
+    assert_eq!(
+        recall_events.len(),
+        1,
+        "expected exactly one memory_recalled event; got: {recall_events:?}\n\
+         all envelopes: {envelopes:?}"
+    );
+
+    let results = recall_events[0]["event"]["results"]
+        .as_array()
+        .expect("results must be an array");
+    assert_eq!(
+        results.len(),
+        2,
+        "expected both the injected and held-back result to be REPORTED \
+         (only rendering, not telemetry, drops the held-back one): {results:?}"
+    );
+
+    let injected = &results[0];
+    assert_eq!(injected["injected"], true);
+    assert_eq!(
+        injected["text"].as_str().unwrap_or_default(),
+        huge_injected_text(),
+        "the injected result's full text must reach the wire"
+    );
+    assert_eq!(
+        injected["run_id"].as_str(),
+        Some(INJECTED_RUN_ID),
+        "a run_id present on the daemon response must thread through"
+    );
+
+    let held_back = &results[1];
+    assert_eq!(
+        held_back["injected"], false,
+        "the second (lower-scored, over-budget) result must be held back"
+    );
+    assert_eq!(
+        held_back["text"].as_str().unwrap_or_default(),
+        HELD_BACK_TEXT,
+        "THE point of this slice: a held-back result's actual TEXT must \
+         still reach Event::MemoryRecalled, not just its score"
+    );
+    assert_eq!(
+        held_back["run_id"],
+        Value::Null,
+        "run_id must gracefully default to null (never panic) when the \
+         daemon response carries no such field"
+    );
+}

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -117,7 +117,7 @@ impl StdioSession {
     /// (logs aren't asserted on here), `kill_on_drop` so a panicking test
     /// still reaps the child instead of leaking a process.
     pub fn spawn() -> Self {
-        Self::spawn_inner(Some(std::path::Path::new(".")), None, None)
+        Self::spawn_inner(Some(std::path::Path::new(".")), None, None, &[])
     }
 
     /// Spawn `tcode serve --stdio` rooted at `project`, with
@@ -130,6 +130,7 @@ impl StdioSession {
             Some(project),
             Some(trusty_code::task::mock_llm::MOCK_LLM_ECHO),
             None,
+            &[],
         )
     }
 
@@ -146,7 +147,28 @@ impl StdioSession {
     /// e2e file.
     /// Test: `agent_id_e2e::fanned_out_same_named_delegations_get_distinct_agent_ids_over_the_wire`.
     pub fn spawn_with_mock_llm_variant(project: &std::path::Path, mock_llm_value: &str) -> Self {
-        Self::spawn_inner(Some(project), Some(mock_llm_value), None)
+        Self::spawn_inner(Some(project), Some(mock_llm_value), None, &[])
+    }
+
+    /// Like [`Self::spawn_with_mock_llm_variant`], additionally setting
+    /// `envs` in the child's environment (DOC-39 Slice C).
+    ///
+    /// Why: `tests/recall_content_e2e.rs` needs to point the daemon's
+    /// `recall_session` tool at a MOCK trusty-memory backend (via
+    /// `TRUSTY_MEMORY_URL`, `trusty_common::mcp::memory_rpc::TRUSTY_MEMORY_URL_ENV`)
+    /// rather than a real daemon — no prior e2e scenario in this crate needed
+    /// to override an env var beyond the mock-LLM selector, so this is the
+    /// general form that adds that capability without touching any other
+    /// `spawn_*` caller.
+    /// What: identical to `spawn_with_mock_llm_variant`, plus every
+    /// `(key, value)` pair in `envs` set on the child.
+    /// Test: `recall_content_e2e::held_back_recall_result_carries_its_text_and_run_id_over_the_wire`.
+    pub fn spawn_with_mock_llm_variant_and_env(
+        project: &std::path::Path,
+        mock_llm_value: &str,
+        envs: &[(&str, &str)],
+    ) -> Self {
+        Self::spawn_inner(Some(project), Some(mock_llm_value), None, envs)
     }
 
     /// Spawn `tcode serve --stdio` with NO `--project` — a PROJECTLESS daemon.
@@ -164,6 +186,7 @@ impl StdioSession {
             None,
             Some(trusty_code::task::mock_llm::MOCK_LLM_ECHO),
             Some(home),
+            &[],
         )
     }
 
@@ -171,6 +194,7 @@ impl StdioSession {
         project: Option<&std::path::Path>,
         mock_llm_value: Option<&str>,
         home: Option<&std::path::Path>,
+        envs: &[(&str, &str)],
     ) -> Self {
         let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_tcode"));
         cmd.arg("serve");
@@ -183,6 +207,9 @@ impl StdioSession {
         }
         if let Some(value) = mock_llm_value {
             cmd.env(trusty_code::task::mock_llm::MOCK_LLM_ENV, value);
+        }
+        for (key, value) in envs {
+            cmd.env(key, value);
         }
         let mut child = cmd
             .stdin(Stdio::piped())


### PR DESCRIPTION
## Summary

Slice C of the trusty-code UI-API work (DOC-39): extends memory-recall telemetry so `Event::MemoryRecalled`'s per-item payload carries the recalled TEXT and its `run_id`, not just a score + `injected` flag. This is what the "what memory drove this / what was held back" context-construction debugging surface (e.g. "PKCE required… 41% · held") needs — before this change a held-back recall result could be *counted* by a UI client but never *read*.

- `events.rs`: `RecalledMemory` gains `text: String` and `run_id: Option<String>`, both `#[serde(default)]` for wire back-compat with older transcripts/ring-buffer entries.
- `tools/recall_session.rs`: `recall_telemetry()` sources `text`/`run_id` from the SAME already-parsed `content` `Value` that `render_results` reads (no second parse) — `text` defaults to `""`, `run_id` to `None`, never `unwrap`. Split the growing `#[cfg(test)] mod tests` out into a `recall_session_tests.rs` sibling file (matching the crate's `events.rs`/`events_tests.rs` and `registry.rs`/`registry_tests.rs` convention) to stay under the 500-SLOC production cap.
- `session/registry_events.rs`'s `record_memory_recalled` already clones the whole `RecalledMemory` list through unchanged — no signature change needed there.
- `task/mock_llm.rs`: new `RecallEchoLlmClient` (`TCODE_MOCK_LLM=echo-recall`) scripts the PM issuing exactly one `recall_session` call, for offline/deterministic e2e coverage (no live model/API key).
- `tests/support/mod.rs`: `StdioSession::spawn_with_mock_llm_variant_and_env` lets an e2e test set extra child env vars (`TRUSTY_MEMORY_URL`) alongside the mock-LLM selector — needed to point `recall_session` at a mock trusty-memory backend.
- `tests/recall_content_e2e.rs` (new, **real-wire e2e per Bob's testability directive**): spawns the real `tcode serve --stdio` binary against an in-process mock trusty-memory `/rpc` server returning one huge/high-scored result (alone busts the token budget, so it's INJECTED, and carries a `run_id`) and one small/lower-scored result that is therefore HELD BACK whole. Asserts the emitted `MemoryRecalled` event's `results` carry: the injected entry's text + `run_id`, and — the whole point of this slice — the held-back entry's full text, with `run_id` gracefully `null` when absent.

## Test plan

- [x] `cargo build -p trusty-code` — clean
- [x] `cargo test -p trusty-code --lib` — 1080 passed, 0 failed, 4 ignored (clean run; saw two different intermittent failures in unrelated `run_task::tests::*` across two prior runs, both pass individually and under `--test-threads=1` — pre-existing #2880-style flake, unrelated to this diff)
- [x] `cargo test -p trusty-code --tests` (all e2e binaries) — every binary green, including the new `recall_content_e2e` (1 passed) — asserts the held-back result's TEXT reaches the wire
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `9 allowlisted, 0 violations — OK`
- [x] Verified every changed file's `Test:` doc-comment pointer resolves to a real `fn` (doc-pointer discipline)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools