### PR TITLE
feat(trusty-code): per-hit path+score on SearchPerformed for search-audit UI (DOC-39)

### DIFF
--- a/crates/trusty-code/src/agent_loop/tests/sink_events.rs
+++ b/crates/trusty-code/src/agent_loop/tests/sink_events.rs
@@ -231,6 +231,7 @@ impl ToolExecutor for TelemetryTool {
                 lane: "semantic".to_string(),
                 query: "q".to_string(),
                 hit_count: Some(4),
+                hits: vec![],
                 latency_ms: 3,
             },
         ))

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -268,6 +268,7 @@ mod tests {
             lane: "lexical".to_string(),
             query: "where is auth".to_string(),
             hit_count: Some(3),
+            hits: vec![],
             latency_ms: 42,
         }));
         assert!(line.contains("[python-engineer]"), "{line}");

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -137,6 +137,35 @@ pub struct RecalledMemory {
     pub run_id: Option<String>,
 }
 
+/// One search hit's path and relevance score, as parsed from a
+/// `search_code` call's underlying trusty-search response (UI "what drove
+/// this" search-audit detail — DOC-39 Slice B).
+///
+/// Why: [`Event::SearchPerformed`]'s `hit_count` tells the UI HOW MANY files
+/// a search touched but not WHICH ones — the audit trail's whole point is
+/// tracing a change back to the exact files that surfaced it, and a bare
+/// count cannot answer "was it this file". `tools::trusty_search` already
+/// walks every hit out of the raw MCP response once to COUNT it; this struct
+/// carries the same per-hit path/score it already has in hand from that SAME
+/// walk, so no second parse pass is needed.
+/// What: `path` is the hit's index-relative path when the lane reports one,
+/// falling back to its absolute path otherwise (see
+/// `tools::trusty_search::parse_search_hits` for exactly which JSON key is
+/// read per lane). `score` is the lane's relevance score reinterpreted as
+/// `f64` (matches `serde_json::Value::as_f64`'s own numeric representation,
+/// regardless of the daemon's internal `f32`/`f64`); it defaults to `0.0`
+/// for lanes (e.g. `grep`) whose hits carry no score at all — a real hit
+/// that is merely unscored, never fabricated data.
+/// Test: `search_hit_round_trips_through_json`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchHit {
+    /// The hit's path, as reported by the trusty-search lane that served it.
+    pub path: String,
+    /// The lane's relevance score for this hit, or `0.0` when the lane
+    /// reports no score (e.g. `grep`).
+    pub score: f64,
+}
+
 /// Real-time event types streamed to UI clients (browser, future Tauri).
 ///
 /// Why: A single tagged enum keeps wire-format evolution tractable —
@@ -266,7 +295,8 @@ pub enum Event {
 
     // -- Structured retrieval telemetry (UI Phase 1) --
     /// A `search_code` call resolved to a concrete trusty-search lane and
-    /// returned `hit_count` hits in `latency_ms` (UI Phase 1).
+    /// returned `hit_count` hits (each with its `path`/`score` in `hits`) in
+    /// `latency_ms` (UI Phase 1; `hits` added DOC-39 Slice B).
     ///
     /// Why: `ToolStarted`/`ToolFinished` carry only TRUNCATED STRING
     /// PREVIEWS of a search's arguments and rendered result text. The UI's
@@ -274,7 +304,9 @@ pub enum Event {
     /// that drove it — which needs the search's real routed lane, its hit
     /// count, and its cost as DATA, not as a prefix of prose the UI would
     /// have to re-parse. Emitted ALONGSIDE (never instead of) the generic
-    /// tool events, so every existing consumer is unaffected.
+    /// tool events, so every existing consumer is unaffected. `hits` extends
+    /// this the same way: the search-audit UI needs to know WHICH files a
+    /// search touched, not just how many.
     /// What: `lane` is the lane trusty-search ACTUALLY served, which is not
     /// always the mode the model asked for: a `semantic`/`symbol` query that
     /// hits a still-building index transparently retries on the lexical lane
@@ -282,9 +314,13 @@ pub enum Event {
     /// `lane: "lexical"` — see `tools::trusty_search`'s `SearchLane`.
     /// `hit_count` is `None` when the lane served results whose shape this
     /// crate could not count (never a silent zero, which would read as "no
-    /// hits"). `latency_ms` measures the whole tool call, retry included.
+    /// hits"); `hits` is `[]` in that same uncountable case. Both come from
+    /// the SAME parse of the tool's response — see
+    /// `tools::trusty_search::parse_search_hits`. `latency_ms` measures the
+    /// whole tool call, retry included.
     /// Test: `session::registry::registry_tests::record_search_performed_publishes_event`,
-    /// `tools::trusty_search_tests::resolved_lane_reports_lexical_when_the_retry_served_it`.
+    /// `tools::trusty_search_tests::resolved_lane_reports_lexical_when_the_retry_served_it`,
+    /// `search_hit_round_trips_through_json`.
     SearchPerformed {
         session_id: String,
         agent: String,
@@ -296,6 +332,12 @@ pub enum Event {
         lane: String,
         query: String,
         hit_count: Option<usize>,
+        /// Per-hit path + score, in the order the lane returned them
+        /// (DOC-39 Slice B). `#[serde(default)]` — absent on any transcript
+        /// recorded before this field existed, mirroring `agent_id`'s
+        /// old-transcript-compatibility contract.
+        #[serde(default)]
+        hits: Vec<SearchHit>,
         latency_ms: u64,
     },
     /// A `recall_session` call recalled `results` from durable memory, each

--- a/crates/trusty-code/src/events_tests.rs
+++ b/crates/trusty-code/src/events_tests.rs
@@ -139,6 +139,7 @@ fn kind_matches_serde_tag_for_every_variant() {
             lane: "semantic".into(),
             query: "where is auth".into(),
             hit_count: Some(3),
+            hits: vec![],
             latency_ms: 42,
         },
         Event::MemoryRecalled {
@@ -309,7 +310,7 @@ fn recalled_memory_deserializes_without_text_or_run_id() {
 }
 
 /// `SearchPerformed` must round-trip, including an uncountable
-/// (`hit_count: None`) result.
+/// (`hit_count: None`) result and its (empty, in the uncountable case) `hits`.
 #[test]
 fn search_performed_round_trips_through_json() {
     let event = Event::SearchPerformed {
@@ -319,6 +320,7 @@ fn search_performed_round_trips_through_json() {
         lane: "lexical".into(),
         query: "where is auth".into(),
         hit_count: None,
+        hits: vec![],
         latency_ms: 17,
     };
     let envelope = SessionEventEnvelope::new("s1".into(), 5, Utc::now(), event);
@@ -330,13 +332,109 @@ fn search_performed_round_trips_through_json() {
         value["event"]["hit_count"].is_null(),
         "an uncountable hit count must stay null, never coerce to 0"
     );
+    assert_eq!(value["event"]["hits"], serde_json::json!([]));
 
     let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
     assert!(matches!(
         back.event,
-        Event::SearchPerformed { hit_count, latency_ms, lane, .. }
-            if hit_count.is_none() && latency_ms == 17 && lane == "lexical"
+        Event::SearchPerformed { hit_count, latency_ms, lane, hits, .. }
+            if hit_count.is_none() && latency_ms == 17 && lane == "lexical" && hits.is_empty()
     ));
+}
+
+/// `SearchPerformed.hits` must round-trip each hit's `path` AND `score`
+/// (DOC-39 Slice B) — the search-audit UI's whole point is telling hits
+/// apart by both fields, not just knowing how many there were.
+#[test]
+fn search_performed_hits_round_trip_through_json() {
+    let event = Event::SearchPerformed {
+        session_id: "s1".into(),
+        agent: "python-engineer".into(),
+        agent_id: "eng-1".into(),
+        lane: "semantic".into(),
+        query: "where is auth".into(),
+        hit_count: Some(2),
+        hits: vec![
+            SearchHit {
+                path: "src/auth.rs".into(),
+                score: 0.87,
+            },
+            SearchHit {
+                path: "src/session/session.rs".into(),
+                score: 0.52,
+            },
+        ],
+        latency_ms: 9,
+    };
+    let envelope = SessionEventEnvelope::new("s1".into(), 6, Utc::now(), event);
+    let value = serde_json::to_value(&envelope).unwrap();
+
+    assert_eq!(value["event"]["hits"][0]["path"], "src/auth.rs");
+    assert_eq!(value["event"]["hits"][0]["score"], 0.87);
+    assert_eq!(value["event"]["hits"][1]["path"], "src/session/session.rs");
+    assert_eq!(value["event"]["hits"][1]["score"], 0.52);
+
+    let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
+    let Event::SearchPerformed { hits, .. } = back.event else {
+        panic!("expected SearchPerformed");
+    };
+    assert_eq!(
+        hits,
+        vec![
+            SearchHit {
+                path: "src/auth.rs".into(),
+                score: 0.87,
+            },
+            SearchHit {
+                path: "src/session/session.rs".into(),
+                score: 0.52,
+            },
+        ]
+    );
+}
+
+/// A `SearchPerformed` transcript recorded BEFORE `hits` existed (DOC-39
+/// Slice B) must still deserialize — the whole point of `#[serde(default)]`,
+/// mirroring `tool_started_without_agent_id_field_still_deserializes`.
+#[test]
+fn search_performed_without_hits_field_still_deserializes() {
+    let legacy_json = serde_json::json!({
+        "type": "search_performed",
+        "session_id": "s1",
+        "agent": "python-engineer",
+        "agent_id": "eng-1",
+        "lane": "grep",
+        "query": "where is auth",
+        "hit_count": 3,
+        "latency_ms": 12
+    });
+    let event: Event = serde_json::from_value(legacy_json)
+        .expect("a SearchPerformed payload recorded before `hits` existed must still deserialize");
+    let Event::SearchPerformed {
+        hits, hit_count, ..
+    } = event
+    else {
+        panic!("expected SearchPerformed");
+    };
+    assert!(
+        hits.is_empty(),
+        "serde(default) yields an empty Vec for a pre-existing record"
+    );
+    assert_eq!(hit_count, Some(3));
+}
+
+/// `SearchHit` itself must round-trip through JSON with `path`/`score` intact.
+#[test]
+fn search_hit_round_trips_through_json() {
+    let hit = SearchHit {
+        path: "src/auth.rs".into(),
+        score: 0.87,
+    };
+    let value = serde_json::to_value(&hit).unwrap();
+    assert_eq!(value["path"], "src/auth.rs");
+    assert_eq!(value["score"], 0.87);
+    let back: SearchHit = serde_json::from_value(value).unwrap();
+    assert_eq!(back, hit);
 }
 
 /// A `ToolStarted` transcript recorded BEFORE `agent_id` existed (DOC-39

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -311,8 +311,9 @@ impl SessionRegistry {
         Ok(())
     }
 
-    /// Record a `search_code` call's real lane + hit count + latency
-    /// (UI Phase 1). See [`crate::events::Event::SearchPerformed`].
+    /// Record a `search_code` call's real lane + hit count + per-hit
+    /// path/score + latency (UI Phase 1; `hits` added DOC-39 Slice B). See
+    /// [`crate::events::Event::SearchPerformed`].
     ///
     /// Why: emitted ALONGSIDE the generic tool events so the UI can trace a
     /// change back to the searches that drove it without re-parsing prose.
@@ -337,6 +338,7 @@ impl SessionRegistry {
                 lane: telemetry.lane.clone(),
                 query: telemetry.query.clone(),
                 hit_count: telemetry.hit_count,
+                hits: telemetry.hits.clone(),
                 latency_ms: telemetry.latency_ms,
             },
         );

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -321,6 +321,26 @@ fn search_telemetry(lane: &str, hit_count: Option<usize>) -> crate::tools::Searc
         lane: lane.to_string(),
         query: "where is auth".to_string(),
         hit_count,
+        hits: vec![],
+        latency_ms: 12,
+    }
+}
+
+/// Build a `SearchTelemetry` carrying real `(path, score)` hits (DOC-39
+/// Slice B), for the test that proves `hits` — not just `hit_count` —
+/// survives `record_search_performed`.
+fn search_telemetry_with_hits(hits: &[(&str, f64)]) -> crate::tools::SearchTelemetry {
+    crate::tools::SearchTelemetry {
+        lane: "semantic".to_string(),
+        query: "where is auth".to_string(),
+        hit_count: Some(hits.len()),
+        hits: hits
+            .iter()
+            .map(|(path, score)| crate::events::SearchHit {
+                path: (*path).to_string(),
+                score: *score,
+            })
+            .collect(),
         latency_ms: 12,
     }
 }
@@ -375,6 +395,52 @@ async fn record_search_performed_publishes_event() {
                 && hit_count == Some(7)
                 && latency_ms == 12
     ));
+}
+
+/// `record_search_performed` must publish each hit's `path` AND `score` in
+/// `hits`, not just `hit_count` (DOC-39 Slice B) — the search-audit UI's
+/// whole point is knowing WHICH files a search touched.
+///
+/// Why: `hit_count` alone predates this ticket; a regression that keeps
+/// threading `hit_count` but drops `hits` would pass every pre-existing
+/// assertion while still failing the requirement this event exists to serve.
+#[tokio::test]
+async fn record_search_performed_publishes_hits_with_path_and_score() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let mut events = crate::events::subscribe();
+
+    registry
+        .record_search_performed(
+            &session.id,
+            "python-engineer",
+            "eng-1",
+            &search_telemetry_with_hits(&[("src/auth.rs", 0.87), ("src/session/session.rs", 0.52)]),
+        )
+        .unwrap();
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    let Event::SearchPerformed {
+        hits, hit_count, ..
+    } = envelope.event
+    else {
+        panic!("expected SearchPerformed");
+    };
+    assert_eq!(hit_count, Some(2));
+    assert_eq!(
+        hits,
+        vec![
+            crate::events::SearchHit {
+                path: "src/auth.rs".to_string(),
+                score: 0.87
+            },
+            crate::events::SearchHit {
+                path: "src/session/session.rs".to_string(),
+                score: 0.52
+            },
+        ],
+        "each hit's path AND score must survive record_search_performed"
+    );
 }
 
 /// `record_memory_recalled` must publish a `MemoryRecalled` event preserving

--- a/crates/trusty-code/src/task/mock_llm.rs
+++ b/crates/trusty-code/src/task/mock_llm.rs
@@ -54,6 +54,15 @@ pub const MOCK_LLM_ECHO_FANOUT: &str = "echo-fanout";
 /// opt-in value, same pattern as [`MOCK_LLM_ECHO_FANOUT`].
 pub const MOCK_LLM_ECHO_RECALL: &str = "echo-recall";
 
+/// The `TCODE_MOCK_LLM` value that selects [`SearchEchoLlmClient`] (DOC-39
+/// Slice B).
+///
+/// Why: neither [`EchoLlmClient`] nor [`FanoutEchoLlmClient`]'s scripts ever
+/// call `search_code` — the mandatory real-wire e2e proof that
+/// `Event::SearchPerformed.hits` carries real per-hit path/score data needs
+/// a script that does.
+pub const MOCK_LLM_ECHO_SEARCH: &str = "echo-search";
+
 /// Build the `Arc<dyn LlmClientTrait>` `task.run` executions share.
 ///
 /// Why: the single seam that decides "real model or offline mock" — kept
@@ -61,8 +70,9 @@ pub const MOCK_LLM_ECHO_RECALL: &str = "echo-recall";
 /// once and is easy to find.
 /// What: if [`MOCK_LLM_ENV`] is set to [`MOCK_LLM_ECHO`], returns an
 /// [`EchoLlmClient`]; if set to [`MOCK_LLM_ECHO_FANOUT`] (DOC-39 AC-13),
-/// returns a [`FanoutEchoLlmClient`]. Otherwise builds a real
-/// `DispatchingLlmClient` — routing
+/// returns a [`FanoutEchoLlmClient`]; if set to [`MOCK_LLM_ECHO_SEARCH`]
+/// (DOC-39 Slice B), returns a [`SearchEchoLlmClient`]. Otherwise builds a
+/// real `DispatchingLlmClient` — routing
 /// `bedrock/*` slugs to AWS Bedrock, `fireworks/*` to Fireworks, and everything
 /// else to OpenRouter (#1021 phase 1; #2406). Construction touches no
 /// credentials: the OpenAI-dialect providers resolve their key lazily via the
@@ -78,6 +88,7 @@ pub fn build_llm_client() -> Result<Arc<dyn LlmClientTrait>, RpcError> {
         Some(MOCK_LLM_ECHO) => return Ok(Arc::new(EchoLlmClient::new())),
         Some(MOCK_LLM_ECHO_FANOUT) => return Ok(Arc::new(FanoutEchoLlmClient::new())),
         Some(MOCK_LLM_ECHO_RECALL) => return Ok(Arc::new(RecallEchoLlmClient::new())),
+        Some(MOCK_LLM_ECHO_SEARCH) => return Ok(Arc::new(SearchEchoLlmClient::new())),
         _ => {}
     }
     Ok(Arc::new(DispatchingLlmClient::new()))
@@ -415,6 +426,93 @@ fn recall_response() -> Value {
     })
 }
 
+/// A deterministic, scripted `LlmClientTrait` exercising the engineer's
+/// `search_code` tool (DOC-39 Slice B's mandatory real-wire e2e proof that
+/// `Event::SearchPerformed.hits` carries real per-hit path/score data, not
+/// just a count).
+///
+/// Why: [`EchoLlmClient`]'s script only ever calls `bash`, so it cannot drive
+/// `search_code` at all. This client's fixed script is otherwise identical
+/// in shape (delegate once, one tool call, two stops) so it composes with
+/// the same daemon-driving harness `tests/task_e2e.rs` already uses.
+/// What: an atomic cursor over a fixed 4-response script:
+///
+/// 1. PM calls `delegate_to_agent(python-engineer, ...)`.
+/// 2. Engineer calls `search_code(query="where does auth live", mode="semantic")`.
+/// 3. Engineer stops with final text.
+/// 4. PM stops with final text.
+///
+/// Running past the script's end returns an `LlmError` rather than
+/// panicking, mirroring [`EchoLlmClient`].
+/// Test: `task::mock_llm::tests::search_script_drives_full_delegation_flow`;
+/// exercised end-to-end (as a real subprocess, against a fake trusty-search
+/// MCP binary) by `tests/search_hits_e2e.rs`.
+pub struct SearchEchoLlmClient {
+    cursor: AtomicUsize,
+}
+
+impl SearchEchoLlmClient {
+    /// Construct a fresh client at the start of its script.
+    pub fn new() -> Self {
+        Self {
+            cursor: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl Default for SearchEchoLlmClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl LlmClientTrait for SearchEchoLlmClient {
+    async fn chat(&self, _req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
+        let fixture = match idx {
+            0 => delegate_response(),
+            1 => search_code_response(),
+            2 => stop_response("engineer: found it"),
+            3 => stop_response("pm: task complete"),
+            _ => {
+                return Err(LlmError::MissingConfig(format!(
+                    "SearchEchoLlmClient script exhausted at call {idx}"
+                )));
+            }
+        };
+        serde_json::from_value(fixture).map_err(|e| {
+            LlmError::MissingConfig(format!(
+                "SearchEchoLlmClient: invalid scripted fixture: {e}"
+            ))
+        })
+    }
+}
+
+/// Turn 2 fixture (search variant): the engineer calls `search_code` instead
+/// of `bash` — the whole reason [`SearchEchoLlmClient`] exists.
+fn search_code_response() -> Value {
+    json!({
+        "id": "mock-search",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-search",
+                    "type": "function",
+                    "function": {
+                        "name": "search_code",
+                        "arguments": json!({"query": "where does auth live", "mode": "semantic"}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 20, "completion_tokens": 8, "total_tokens": 28}
+    })
+}
+
 /// Serializes every test in this crate that sets/reads the process-wide
 /// [`MOCK_LLM_ENV`] var — `cargo test` runs tests in parallel within one
 /// binary, and an unguarded `set_var`/`remove_var` pair would race across
@@ -533,6 +631,41 @@ mod tests {
 
         let turn2 = client.chat(&req).await.expect("turn 2 (pm stop)");
         assert!(turn2.first_tool_calls().is_empty());
+
+        let err = client.chat(&req).await;
+        assert!(err.is_err(), "the script must not silently repeat");
+    }
+
+    /// (DOC-39 Slice B) The search script must drive exactly the
+    /// delegate -> search_code -> stop -> stop shape
+    /// `tests/search_hits_e2e.rs` relies on.
+    #[tokio::test]
+    async fn search_script_drives_full_delegation_flow() {
+        let client = SearchEchoLlmClient::new();
+        let req = ChatRequest {
+            model: "mock".to_string(),
+            messages: vec![],
+            temperature: None,
+            max_tokens: None,
+            tools: None,
+            tool_choice: None,
+            usage: None,
+        };
+
+        let turn1 = client.chat(&req).await.expect("turn 1");
+        assert_eq!(
+            turn1.first_tool_calls()[0].function.name,
+            "delegate_to_agent"
+        );
+
+        let turn2 = client.chat(&req).await.expect("turn 2");
+        assert_eq!(turn2.first_tool_calls()[0].function.name, "search_code");
+
+        let turn3 = client.chat(&req).await.expect("turn 3");
+        assert!(turn3.first_tool_calls().is_empty());
+
+        let turn4 = client.chat(&req).await.expect("turn 4");
+        assert!(turn4.first_tool_calls().is_empty());
 
         let err = client.chat(&req).await;
         assert!(err.is_err(), "the script must not silently repeat");

--- a/crates/trusty-code/src/task/sink.rs
+++ b/crates/trusty-code/src/task/sink.rs
@@ -269,6 +269,7 @@ mod tests {
                 lane: "lexical".to_string(),
                 query: "q".to_string(),
                 hit_count: Some(2),
+                hits: vec![],
                 latency_ms: 5,
             }),
         )
@@ -324,6 +325,7 @@ mod tests {
                 lane: "semantic".to_string(),
                 query: "q".to_string(),
                 hit_count: None,
+                hits: vec![],
                 latency_ms: 1,
             }),
         )

--- a/crates/trusty-code/src/tools/telemetry.rs
+++ b/crates/trusty-code/src/tools/telemetry.rs
@@ -23,7 +23,7 @@
 //! Test: `crate::agent_loop::tests::sink_events::sink_receives_tool_telemetry_with_agent`
 //! (forwarding), plus each tool's own `telemetry_*` tests (production).
 
-use crate::events::RecalledMemory;
+use crate::events::{RecalledMemory, SearchHit};
 
 /// Structured data a tool reports about what it actually did (UI Phase 1).
 ///
@@ -49,7 +49,9 @@ pub enum ToolTelemetry {
 /// differ whenever a not-yet-built index forces a lexical retry (#2783).
 /// What: `lane` is the lane that served the results; `hit_count` is `None`
 /// when the result shape could not be counted (never a misleading `0`);
-/// `latency_ms` covers the whole call including any retry.
+/// `hits` carries each result's path + score from that SAME parse (DOC-39
+/// Slice B — `[]` in the uncountable case); `latency_ms` covers the whole
+/// call including any retry.
 /// Test: `tools::trusty_search_tests::resolved_lane_reports_lexical_when_the_retry_served_it`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SearchTelemetry {
@@ -59,6 +61,9 @@ pub struct SearchTelemetry {
     pub query: String,
     /// Hits returned, or `None` when uncountable.
     pub hit_count: Option<usize>,
+    /// Per-hit path + score, in the order the lane returned them (DOC-39
+    /// Slice B). Empty when `hit_count` is `None` (uncountable payload).
+    pub hits: Vec<SearchHit>,
     /// Wall-clock duration of the whole tool call.
     pub latency_ms: u64,
 }

--- a/crates/trusty-code/src/tools/traits.rs
+++ b/crates/trusty-code/src/tools/traits.rs
@@ -559,6 +559,7 @@ mod tests {
             lane: "semantic".to_string(),
             query: "q".to_string(),
             hit_count: Some(3),
+            hits: vec![],
             latency_ms: 7,
         });
         let result = ToolResult::ok("hits").with_telemetry(telemetry.clone());
@@ -581,6 +582,7 @@ mod tests {
                 lane: "semantic".to_string(),
                 query: "q".to_string(),
                 hit_count: None,
+                hits: vec![],
                 latency_ms: 1,
             }));
         assert!(result.is_error());

--- a/crates/trusty-code/src/tools/trusty_search.rs
+++ b/crates/trusty-code/src/tools/trusty_search.rs
@@ -32,7 +32,8 @@
 //! `tests::is_mcp_error_detects_error_flag`,
 //! `tests::is_stage_not_ready_detects_meta_code`,
 //! `tests::should_lexical_fallback_only_for_stage_not_ready`,
-//! `tests::lexical_params_matches_search_lexical_schema`.
+//! `tests::lexical_params_matches_search_lexical_schema`,
+//! `tests::parse_search_hits_reads_each_lane_shape` (DOC-39 Slice B).
 
 use std::path::{Path, PathBuf};
 
@@ -43,6 +44,7 @@ use tokio::sync::{Mutex, OnceCell};
 use tracing::warn;
 use trusty_common::stdio_mcp_client::StdioMcpClient;
 
+use crate::events::SearchHit;
 use crate::tools::telemetry::{SearchTelemetry, ToolTelemetry};
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
@@ -403,22 +405,53 @@ impl SearchLane {
     }
 }
 
-/// Count the hits in a trusty-search result payload (UI Phase 1).
+/// Parse the hit count AND each hit's path/score from a trusty-search result
+/// payload, in one JSON parse (UI Phase 1; `hits` added DOC-39 Slice B).
 ///
-/// Why: the UI renders "N hits" beside a search, and the count is otherwise
-/// only recoverable by re-parsing the tool's rendered prose.
+/// Why: the UI renders "N hits" beside a search (`hit_count`) and the
+/// search-audit surface needs to know WHICH files those hits were
+/// (`hits`) — both are only recoverable from the same parsed array, so
+/// this walks it once for both rather than re-parsing `text` a second time.
 /// What: every trusty-search lane wraps its payload as a JSON object with an
 /// array under `results`, `hits`, or `matches` — the three keys observed
-/// across the semantic/KG/grep/lexical lanes. Returns `None` when `text` is
-/// not JSON or carries no recognisable array, so an uncountable shape is
-/// reported honestly as "unknown" rather than as a misleading `0`.
-/// Test: `tests::count_hits_reads_each_lane_shape`,
-/// `tests::count_hits_is_none_for_unrecognised_payloads`.
-fn count_hits(text: &str) -> Option<usize> {
-    let body: Value = serde_json::from_str(text).ok()?;
-    ["results", "hits", "matches"]
+/// across the semantic/KG/grep/lexical lanes. Returns `(None, vec![])` when
+/// `text` is not JSON or carries no recognisable array, so an uncountable
+/// shape is reported honestly as "unknown" rather than as a misleading `0`.
+/// Each array item's path is read from `path` (trusty-search's portable
+/// root-relative `CodeChunk` field), falling back to `file` (its absolute
+/// path, and the ONLY path field `grep`'s `GrepMatch` shape carries); an item
+/// with neither is skipped — a hit the UI cannot point at is not worth
+/// reporting. Score is read from `score`, defaulting to `0.0` for shapes
+/// (e.g. `grep`) that carry none at all.
+/// Test: `tests::parse_search_hits_reads_each_lane_shape`,
+/// `tests::parse_search_hits_is_none_for_unrecognised_payloads`,
+/// `tests::parse_search_hits_falls_back_to_file_and_defaults_missing_score`,
+/// `tests::parse_search_hits_skips_items_with_no_path_or_file`.
+fn parse_search_hits(text: &str) -> (Option<usize>, Vec<SearchHit>) {
+    let Ok(body) = serde_json::from_str::<Value>(text) else {
+        return (None, Vec::new());
+    };
+    let Some(items) = ["results", "hits", "matches"]
         .iter()
-        .find_map(|key| body.get(*key).and_then(Value::as_array).map(Vec::len))
+        .find_map(|key| body.get(*key).and_then(Value::as_array))
+    else {
+        return (None, Vec::new());
+    };
+    let hits = items
+        .iter()
+        .filter_map(|item| {
+            let path = item
+                .get("path")
+                .and_then(Value::as_str)
+                .or_else(|| item.get("file").and_then(Value::as_str))?;
+            let score = item.get("score").and_then(Value::as_f64).unwrap_or(0.0);
+            Some(SearchHit {
+                path: path.to_string(),
+                score,
+            })
+        })
+        .collect();
+    (Some(items.len()), hits)
 }
 
 /// Build the MCP arguments for `mode`, returning the tool name + params.
@@ -548,10 +581,12 @@ impl ToolExecutor for TrustySearchTool {
         // the query, measured at the moment of return so `latency_ms` covers
         // any transparent retry too.
         let telemetry = |lane: SearchLane, text: &str| {
+            let (hit_count, hits) = parse_search_hits(text);
             ToolTelemetry::Search(SearchTelemetry {
                 lane: lane.label().to_string(),
                 query: parsed.query.clone(),
-                hit_count: count_hits(text),
+                hit_count,
+                hits,
                 latency_ms: started.elapsed().as_millis() as u64,
             })
         };

--- a/crates/trusty-code/src/tools/trusty_search_tests.rs
+++ b/crates/trusty-code/src/tools/trusty_search_tests.rs
@@ -281,25 +281,98 @@ fn resolved_lane_reports_lexical_when_the_retry_served_it() {
 }
 
 /// Why: the UI renders a hit count; each lane wraps its payload differently,
-/// so the counter must read all the observed shapes.
+/// so the counter must read all the observed shapes. Each item's `path`
+/// (the `CodeChunk` shape) must also be collected (DOC-39 Slice B).
 #[test]
-fn count_hits_reads_each_lane_shape() {
-    assert_eq!(count_hits(r#"{"results":[{"a":1},{"a":2}]}"#), Some(2));
-    assert_eq!(count_hits(r#"{"hits":[{"a":1}]}"#), Some(1));
-    assert_eq!(count_hits(r#"{"matches":[]}"#), Some(0));
+fn parse_search_hits_reads_each_lane_shape() {
+    assert_eq!(
+        parse_search_hits(
+            r#"{"results":[{"path":"a.rs","score":0.9},{"path":"b.rs","score":0.4}]}"#
+        ),
+        (
+            Some(2),
+            vec![
+                SearchHit {
+                    path: "a.rs".into(),
+                    score: 0.9
+                },
+                SearchHit {
+                    path: "b.rs".into(),
+                    score: 0.4
+                },
+            ]
+        )
+    );
+    assert_eq!(
+        parse_search_hits(r#"{"hits":[{"path":"c.rs","score":1.0}]}"#),
+        (
+            Some(1),
+            vec![SearchHit {
+                path: "c.rs".into(),
+                score: 1.0
+            }]
+        )
+    );
+    assert_eq!(parse_search_hits(r#"{"matches":[]}"#), (Some(0), vec![]));
 }
 
 /// Why: an uncountable payload must report `None`, never `0` — "we could not
 /// count" and "there were no hits" are different facts, and a UI showing a
-/// confident `0 hits` for the former would be wrong.
+/// confident `0 hits` for the former would be wrong. `hits` must stay empty
+/// in lockstep.
 #[test]
-fn count_hits_is_none_for_unrecognised_payloads() {
-    assert_eq!(count_hits("not json at all"), None);
-    assert_eq!(count_hits(r#"{"unexpected":"shape"}"#), None);
+fn parse_search_hits_is_none_for_unrecognised_payloads() {
+    assert_eq!(parse_search_hits("not json at all"), (None, vec![]));
     assert_eq!(
-        count_hits(r#"{"results":"not-an-array"}"#),
-        None,
+        parse_search_hits(r#"{"unexpected":"shape"}"#),
+        (None, vec![])
+    );
+    assert_eq!(
+        parse_search_hits(r#"{"results":"not-an-array"}"#),
+        (None, vec![]),
         "a non-array under a known key is uncountable, not empty"
+    );
+}
+
+/// Why: `grep`'s `GrepMatch` shape carries `file`, never `path` or `score` —
+/// the path must fall back to `file` and the score must default to `0.0`
+/// rather than dropping the hit entirely (DOC-39 Slice B).
+#[test]
+fn parse_search_hits_falls_back_to_file_and_defaults_missing_score() {
+    let (count, hits) = parse_search_hits(
+        r#"{"matches":[{"file":"src/main.rs","line":10},{"file":"src/lib.rs","line":2}]}"#,
+    );
+    assert_eq!(count, Some(2));
+    assert_eq!(
+        hits,
+        vec![
+            SearchHit {
+                path: "src/main.rs".into(),
+                score: 0.0
+            },
+            SearchHit {
+                path: "src/lib.rs".into(),
+                score: 0.0
+            },
+        ]
+    );
+}
+
+/// Why: a hit with neither `path` nor `file` cannot be pointed at by the UI —
+/// it must be skipped rather than fabricating an empty path (DOC-39 Slice B).
+#[test]
+fn parse_search_hits_skips_items_with_no_path_or_file() {
+    let (count, hits) =
+        parse_search_hits(r#"{"results":[{"score":0.5},{"path":"src/ok.rs","score":0.1}]}"#);
+    // `count` mirrors the raw array length (matches pre-existing `hit_count`
+    // semantics), while `hits` only carries the pointable ones.
+    assert_eq!(count, Some(2));
+    assert_eq!(
+        hits,
+        vec![SearchHit {
+            path: "src/ok.rs".into(),
+            score: 0.1
+        }]
     );
 }
 

--- a/crates/trusty-code/tests/search_hits_e2e.rs
+++ b/crates/trusty-code/tests/search_hits_e2e.rs
@@ -1,0 +1,249 @@
+//! End-to-end acceptance proof for DOC-39 Slice B (per-hit path+score on
+//! `Event::SearchPerformed`) — the mandatory API-driven e2e gate for this
+//! slice.
+//!
+//! Why: the Search audit trail / "what drove this" UI needs to know WHICH
+//! files a `search_code` call touched, not just how many. Unit tests already
+//! pin the parsing (`tools::trusty_search::tests::parse_search_hits_*`) and
+//! the in-process threading
+//! (`session::registry::registry_tests::record_search_performed_publishes_hits_with_path_and_score`),
+//! but Bob's standing testability directive requires the capability also be
+//! proven reachable over the REAL wire, against a real (subprocess) daemon —
+//! this is that proof.
+//! What: spawns the real `tcode serve --stdio` binary with a FAKE
+//! `trusty-search` MCP server substituted onto its `PATH` (a POSIX shell
+//! script that speaks just enough MCP to answer `initialize`, `list_indexes`,
+//! and `search_semantic` with a canned, KNOWN result set — see
+//! [`write_fake_trusty_search`]), drives `TCODE_MOCK_LLM=echo-search`'s
+//! scripted PM -> engineer `search_code` call
+//! ([`trusty_code::task::mock_llm::SearchEchoLlmClient`]) to completion, and
+//! asserts the resulting `SearchPerformed` event's `hits` array matches that
+//! canned result set by BOTH `path` AND `score` — not merely `hit_count`.
+//! Test: this module is itself the test surface.
+
+mod support;
+
+use serde_json::{Value, json};
+use support::{StdioSession, find_session_event, project_with_agents};
+
+/// The canned search hits the fake trusty-search server's `search_semantic`
+/// reply carries — the known result set every assertion in this file checks
+/// `hits` against.
+const FAKE_HITS: &[(&str, f64)] = &[("src/auth.rs", 0.87), ("src/session/session.rs", 0.52)];
+
+/// Write a fake `trusty-search` MCP server, executable at
+/// `<dir>/trusty-search`, answering `initialize`, `list_indexes` (with one
+/// index whose `root_path` is `project_root`), and `search_semantic` (with
+/// [`FAKE_HITS`]) in that fixed order.
+///
+/// Why: `tools::trusty_search::TrustySearchTool` always spawns the literal
+/// binary name `trusty-search` resolved via `PATH` — its `with_binary`
+/// override is `#[cfg(test)]`-only and unreachable from this crate-external
+/// integration test — so the only seam to substitute a fake server is a
+/// same-named executable placed earlier on the spawned daemon's `PATH` (see
+/// `support::StdioSession::spawn_with_mock_llm_variant_and_envs`).
+/// What: mirrors `tools::trusty_search::tests::write_fake_mcp_server`'s
+/// shape — a POSIX shell script that replies to the Nth request line
+/// carrying an `"id":` field with the Nth canned response, verbatim, so the
+/// handshake's `notifications/initialized` notification (no `id`) is
+/// silently skipped. `root_path` is the ALREADY-canonicalized project root
+/// (matching `ProjectBinding::resolve`'s own canonicalization) so
+/// `tools::trusty_search::pick_index`'s exact-match branch resolves it
+/// without relying on a second independent canonicalization agreeing
+/// byte-for-byte.
+/// Test: exercised by this module's own e2e test.
+#[cfg(unix)]
+fn write_fake_trusty_search(dir: &std::path::Path, project_root: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+
+    let canonical_root = std::fs::canonicalize(project_root)
+        .expect("canonicalize project root")
+        .to_str()
+        .expect("utf8 project root")
+        .to_string();
+
+    let init_resp = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "serverInfo": { "name": "fake-trusty-search", "version": "0.0.0" },
+            "protocolVersion": "2024-11-05"
+        }
+    });
+    let list_indexes_body = json!({
+        "indexes": [{ "id": "test-idx", "root_path": canonical_root, "size_bytes": 0 }]
+    })
+    .to_string();
+    let list_indexes_resp = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": { "content": [{ "type": "text", "text": list_indexes_body }] }
+    });
+    let search_body = json!({
+        "results": FAKE_HITS
+            .iter()
+            .map(|(path, score)| json!({ "path": path, "score": score }))
+            .collect::<Vec<_>>()
+    })
+    .to_string();
+    let search_resp = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "result": { "content": [{ "type": "text", "text": search_body }] }
+    });
+
+    let script = format!(
+        "#!/bin/sh\ni=0\nwhile IFS= read -r line; do\n  case \"$line\" in\n    *'\"id\":'*)\n      i=$((i + 1))\n      case \"$i\" in\n        1) printf '%s\\n' '{}' ;;\n        2) printf '%s\\n' '{}' ;;\n        3) printf '%s\\n' '{}' ;;\n      esac\n      ;;\n  esac\ndone\n",
+        init_resp, list_indexes_resp, search_resp,
+    );
+
+    let path = dir.join("trusty-search");
+    std::fs::write(&path, script).expect("write fake trusty-search script");
+    let mut perms = std::fs::metadata(&path)
+        .expect("stat fake trusty-search script")
+        .permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).expect("chmod fake trusty-search script");
+}
+
+/// Drive `task.run` -> `session.attach` -> read-until-`session_done` using
+/// the `echo-search` mock LLM script, returning every session event's full
+/// JSON envelope (not just its `kind`, unlike `support::run_task_to_completion`
+/// — this test needs each envelope's `event.hits` field). Mirrors
+/// `agent_id_e2e::run_fanout_task_to_completion`.
+async fn run_search_task_to_completion(daemon: &mut StdioSession) -> Vec<Value> {
+    let run_resp = daemon
+        .call(
+            1,
+            "task.run",
+            json!({"task_description": "find where auth lives"}),
+        )
+        .await;
+    assert!(run_resp["error"].is_null(), "task.run failed: {run_resp}");
+    let session_id = run_resp["result"]["session_id"]
+        .as_str()
+        .expect("task.run must return a session_id")
+        .to_string();
+
+    let attach_resp = daemon
+        .call(2, "session.attach", json!({"session_id": session_id}))
+        .await;
+    assert!(
+        attach_resp["error"].is_null(),
+        "attach failed: {attach_resp}"
+    );
+    let mut envelopes: Vec<Value> = attach_resp["result"]["events"]
+        .as_array()
+        .expect("attach must return a replay events array")
+        .clone();
+
+    let mut iterations = 0;
+    let is_done = |envs: &[Value]| {
+        envs.iter()
+            .any(|e| e["kind"].as_str() == Some("session_done"))
+    };
+    while !is_done(&envelopes) {
+        iterations += 1;
+        assert!(
+            iterations < 20,
+            "gave up waiting for session_done after {iterations} read rounds; \
+             envelopes so far: {envelopes:?}"
+        );
+        let lines = daemon.read_lines(20).await;
+        assert!(
+            !lines.is_empty(),
+            "timed out waiting for more events; envelopes so far: {envelopes:?}"
+        );
+        for line in &lines {
+            if let Some(envelope) = find_session_event(line, &session_id) {
+                envelopes.push(envelope);
+            }
+        }
+    }
+
+    envelopes
+}
+
+/// DOC-39 Slice B's direct acceptance proof: `search_code`'s
+/// `Event::SearchPerformed.hits` must carry each hit's REAL `path` AND
+/// `score` from the underlying trusty-search response — not merely a
+/// `hit_count` — over the REAL JSON-RPC wire against a (mock) trusty-search
+/// MCP backend.
+///
+/// Why: this is the exact requirement the ticket's testability directive
+/// states — "a test that only checks `hit_count` does NOT satisfy this
+/// task". Uses `TCODE_MOCK_LLM=echo-search`
+/// (`trusty_code::task::mock_llm::SearchEchoLlmClient`) for a deterministic,
+/// key-free run scripting the PM delegating to `python-engineer`, which
+/// calls `search_code(query="where does auth live", mode="semantic")`
+/// against the fake trusty-search server (see [`write_fake_trusty_search`])
+/// substituted onto the daemon's `PATH`.
+/// What: spawns the daemon rooted at a throwaway project with the fake
+/// server on `PATH`, runs the scripted task to completion, finds the
+/// `search_performed` event, and asserts its `hits` array equals
+/// [`FAKE_HITS`] exactly (both `path` and `score` per entry, in order) —
+/// the assertion this whole file exists to make.
+/// Test: this test.
+#[tokio::test]
+#[cfg(unix)]
+async fn search_code_hit_paths_and_scores_reach_the_search_performed_event() {
+    let project = project_with_agents();
+    let fake_search_dir = tempfile::tempdir().expect("fake trusty-search dir");
+    write_fake_trusty_search(fake_search_dir.path(), project.path());
+
+    let fake_search_dir_str = fake_search_dir
+        .path()
+        .to_str()
+        .expect("utf8 fake trusty-search dir");
+    let real_path = std::env::var("PATH").unwrap_or_default();
+    let patched_path = format!("{fake_search_dir_str}:{real_path}");
+
+    let mut daemon = StdioSession::spawn_with_mock_llm_variant_and_envs(
+        project.path(),
+        trusty_code::task::mock_llm::MOCK_LLM_ECHO_SEARCH,
+        &[("PATH", &patched_path)],
+    );
+
+    let envelopes = run_search_task_to_completion(&mut daemon).await;
+
+    let search_events: Vec<&Value> = envelopes
+        .iter()
+        .filter(|e| e["kind"].as_str() == Some("search_performed"))
+        .collect();
+
+    assert_eq!(
+        search_events.len(),
+        1,
+        "expected exactly one search_performed event; got: {search_events:?}\n\
+         all envelopes: {envelopes:?}"
+    );
+
+    let event = &search_events[0]["event"];
+    assert_eq!(event["agent"].as_str(), Some("python-engineer"));
+    assert_eq!(
+        event["hit_count"].as_u64(),
+        Some(FAKE_HITS.len() as u64),
+        "hit_count must match the real result set's size: {event:?}"
+    );
+
+    let hits = event["hits"].as_array().expect("hits must be an array");
+    assert_eq!(
+        hits.len(),
+        FAKE_HITS.len(),
+        "hits length must match hit_count: {hits:?}"
+    );
+    for (got, (expected_path, expected_score)) in hits.iter().zip(FAKE_HITS.iter()) {
+        assert_eq!(
+            got["path"].as_str(),
+            Some(*expected_path),
+            "DOC-39 Slice B: hit path must match the real trusty-search result set, \
+             not just hit_count: {got:?}"
+        );
+        assert_eq!(
+            got["score"].as_f64(),
+            Some(*expected_score),
+            "DOC-39 Slice B: hit score must match the real trusty-search result set, \
+             not just hit_count: {got:?}"
+        );
+    }
+}

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -117,7 +117,7 @@ impl StdioSession {
     /// (logs aren't asserted on here), `kill_on_drop` so a panicking test
     /// still reaps the child instead of leaking a process.
     pub fn spawn() -> Self {
-        Self::spawn_inner(Some(std::path::Path::new(".")), None, None, &[])
+        Self::spawn_inner(Some(std::path::Path::new(".")), None, None, &[], &[])
     }
 
     /// Spawn `tcode serve --stdio` rooted at `project`, with
@@ -130,6 +130,7 @@ impl StdioSession {
             Some(project),
             Some(trusty_code::task::mock_llm::MOCK_LLM_ECHO),
             None,
+            &[],
             &[],
         )
     }
@@ -147,7 +148,7 @@ impl StdioSession {
     /// e2e file.
     /// Test: `agent_id_e2e::fanned_out_same_named_delegations_get_distinct_agent_ids_over_the_wire`.
     pub fn spawn_with_mock_llm_variant(project: &std::path::Path, mock_llm_value: &str) -> Self {
-        Self::spawn_inner(Some(project), Some(mock_llm_value), None, &[])
+        Self::spawn_inner(Some(project), Some(mock_llm_value), None, &[], &[])
     }
 
     /// Like [`Self::spawn_with_mock_llm_variant`], additionally setting
@@ -168,7 +169,26 @@ impl StdioSession {
         mock_llm_value: &str,
         envs: &[(&str, &str)],
     ) -> Self {
-        Self::spawn_inner(Some(project), Some(mock_llm_value), None, envs)
+        Self::spawn_inner(Some(project), Some(mock_llm_value), None, envs, &[])
+    }
+
+    /// Like [`Self::spawn_with_mock_llm_variant`] but also sets `extra_envs`
+    /// in the child's environment (DOC-39 Slice B).
+    ///
+    /// Why: `tests/search_hits_e2e.rs` needs the spawned `tcode` daemon to
+    /// resolve `trusty-search` (the binary `tools::trusty_search` spawns) to
+    /// a FAKE MCP server script instead of a real trusty-search install —
+    /// the only seam for that is prepending a fixture directory to the
+    /// child's `PATH`. No other e2e scenario needs extra env vars, so this
+    /// stays a separate opt-in form rather than growing every existing call
+    /// site's arity.
+    /// Test: `search_hits_e2e::search_code_hit_paths_and_scores_reach_the_search_performed_event`.
+    pub fn spawn_with_mock_llm_variant_and_envs(
+        project: &std::path::Path,
+        mock_llm_value: &str,
+        extra_envs: &[(&str, &str)],
+    ) -> Self {
+        Self::spawn_inner(Some(project), Some(mock_llm_value), None, &[], extra_envs)
     }
 
     /// Spawn `tcode serve --stdio` with NO `--project` — a PROJECTLESS daemon.
@@ -187,6 +207,7 @@ impl StdioSession {
             Some(trusty_code::task::mock_llm::MOCK_LLM_ECHO),
             Some(home),
             &[],
+            &[],
         )
     }
 
@@ -195,9 +216,13 @@ impl StdioSession {
         mock_llm_value: Option<&str>,
         home: Option<&std::path::Path>,
         envs: &[(&str, &str)],
+        extra_envs: &[(&str, &str)],
     ) -> Self {
         let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_tcode"));
         cmd.arg("serve");
+        for (key, value) in extra_envs {
+            cmd.env(key, value);
+        }
         if let Some(project) = project {
             cmd.arg("--project").arg(project);
         }


### PR DESCRIPTION
## Summary

Slice B of DOC-39's search-audit UI work: extends `Event::SearchPerformed`
(which already carries `hit_count` and, since #2898, `agent_id`) with a new
`hits: Vec<SearchHit>` field carrying each search hit's `path` and `score` —
so the "what drove this" audit trail can tell the UI **which** files a
search touched, not just how many.

## What changed

- **`crates/trusty-code/src/events.rs`** — new public `SearchHit { path: String, score: f64 }`
  struct (Why/What/Test doc comment); `SearchPerformed` gains
  `#[serde(default)] hits: Vec<SearchHit>`. `hit_count` is unchanged and kept
  independently populated for back-compat. Additive/non-breaking: old
  recorded transcripts without `hits` still deserialize (see
  `search_performed_without_hits_field_still_deserializes`).
- **`crates/trusty-code/src/tools/telemetry.rs`** — matching `hits: Vec<SearchHit>`
  field on `SearchTelemetry`, reusing `SearchHit` the same way `RecallTelemetry`
  already reuses `RecalledMemory`.
- **`crates/trusty-code/src/tools/trusty_search.rs`** — `count_hits` replaced by
  `parse_search_hits`, which walks the SAME parsed JSON array **once** to
  produce both the hit count and each hit's `path` (read from `path`, falling
  back to `file` for `grep`'s `GrepMatch` shape which carries no `path`) and
  `score` (`f64` via `serde_json::Value::as_f64`, defaulting to `0.0` for
  lanes like `grep` that report no score at all). No second parse pass.
- **`crates/trusty-code/src/session/registry_events.rs`** — `record_search_performed`
  threads `hits` through to the recorded `Event::SearchPerformed`.
- Every existing `SearchTelemetry`/`Event::SearchPerformed` construction site
  across the crate (tests in `traits.rs`, `agent_loop/tests/sink_events.rs`,
  `task/sink.rs`, `cli_client/render.rs`, `events_tests.rs`,
  `session/registry_tests.rs`) updated for the new field.

## New struct/field shapes

```rust
pub struct SearchHit {
    pub path: String,
    pub score: f64,
}
```

```rust
SearchPerformed {
    session_id: String,
    agent: String,
    #[serde(default)]
    agent_id: String,
    lane: String,
    query: String,
    hit_count: Option<usize>,
    #[serde(default)]
    hits: Vec<SearchHit>,
    latency_ms: u64,
},
```

## E2E coverage (mandatory real-wire proof)

`crates/trusty-code/tests/search_hits_e2e.rs` spawns the real `tcode serve --stdio`
binary with a **fake trusty-search MCP server** substituted onto its `PATH`
(a POSIX shell script answering `initialize`/`list_indexes`/`search_semantic`
with a known result set), drives a new `TCODE_MOCK_LLM=echo-search` script
(`SearchEchoLlmClient` in `task/mock_llm.rs`) that delegates to
`python-engineer`, which calls `search_code`, and asserts the resulting
`SearchPerformed` event's `hits` array matches the fake server's known result
set by **both `path` AND `score`** — not merely `hit_count`.

## Test plan

- [x] `cargo build -p trusty-code`
- [x] `cargo test -p trusty-code --lib` (1084 passed, 0 failed, 4 ignored)
- [x] `cargo test -p trusty-code --test search_hits_e2e` (1 passed)
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `bash scripts/check_line_cap.sh` (0 violations)

Refs DOC-39, #2898.

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)