### PR TITLE
feat(trusty-mpm): documentation-style bundled skill — SLD-grounded per-type guides + base-engineer reference

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -19,6 +19,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- bundled `documentation-style` skill: a two-tier (`SKILL.md` + 6 `references/*.md`) SLD-grounded style guide covering the four-axis Why/What/Test + opt-in Spec-References inline doc model, per-artifact-type conventions (spec, README, file-level, class/module, method/function, block/inline), and context-economy guidance — defers to DOC-38 for the actual reference grammar rather than restating it (Annex B follow-up F2). `BASE-ENGINEER.md`'s Deliverables Checklist now points engineers at it, and declares `skills: [documentation-style]` in frontmatter so every engineer-family agent picks it up via the existing DOC-42 union-across-chain compose merge (closes #2911)
 - adopt DOC-38 policy + sld-lint gate (closes #2853, #2854) ([#2863](https://github.com/bobmatnyc/trusty-tools/pull/2863)) ([`580c9a7`](https://github.com/bobmatnyc/trusty-tools/commit/580c9a7d08e873d9706c6b05cfe83eafb2befbfa))
 
 ### Fixed

--- a/crates/trusty-mpm/src/assets/agents/BASE-ENGINEER.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-ENGINEER.md
@@ -2,6 +2,7 @@
 name: base-engineer
 role: base-engineer
 extends: base-agent
+skills: [documentation-style]
 ---
 
 # BASE-ENGINEER — Foundation for all engineer agents
@@ -185,6 +186,9 @@ Before returning, re-read the prompt for "Deliverables" / "Requirements" /
 - [ ] Working code — all provided/required tests pass.
 - [ ] Your own tests — edge cases and error paths.
 - [ ] Docs — what it does, how to run it, key decisions (when the prompt asks).
+      Follow the `documentation-style` skill for per-artifact-type conventions
+      (file/class/method/block) and, where the project defines specs, its
+      spec-link-back convention (e.g. this repo's DOC-38 SLD).
 - [ ] Project config present if standalone.
 - [ ] Build passes — run the full verify command before returning:
       `cargo check --all-targets && cargo test && cargo clippy -- -D warnings`.

--- a/crates/trusty-mpm/src/assets/skills/documentation-style.md
+++ b/crates/trusty-mpm/src/assets/skills/documentation-style.md
@@ -1,0 +1,127 @@
+---
+name: documentation-style
+description: "SLD-grounded per-artifact-type documentation style guide: the four-axis Why/What/Test + Spec-References inline model, plus focused conventions for specs, READMEs, files, classes, methods/functions, and block comments. Use when writing or reviewing any documentation artifact."
+user-invocable: false
+version: "1.0.0"
+category: agent-reference
+tags: [documentation, sld, spec-linked-documentation, style-guide, agent-reference]
+effort: medium
+spec_refs:
+  - id: SPEC-SLD-02~draft
+    path: docs/specs/spec-linked-documentation.md
+    anchor: SPEC-SLD-02~draft
+    note: "Canonical spec-reference grammar this skill's Spec-References guidance defers to; this skill restates none of it."
+---
+# Documentation Style
+
+Per-artifact-type documentation conventions, unified around one model: every
+doc comment carries **Why**, **What**, and **Test** (this project's mandatory
+triple where it applies), plus an optional fourth axis — a **Spec References**
+link-back — when, and only when, a real spec governs the artifact.
+
+This skill is a style guide, not a linkage standard. Where a project defines a
+spec-linked-documentation (SLD) convention, this skill **defers to it and
+restates none of its grammar**. In this repo that convention is DOC-38
+(`docs/specs/spec-linked-documentation.md`) — read it directly for the actual
+reference grammar, frontmatter schema, and per-language idioms. If your
+project has no such convention, skip the Spec References axis entirely; the
+Why/What/Test triple (or your project's equivalent) stands on its own.
+
+## The Four-Axis Model
+
+| Axis | Answers | Mandatory? |
+|---|---|---|
+| **Why** | What problem does this solve? What's the motivation? | Yes, on every public item |
+| **What** | What does it mechanically do? | Yes, on every public item |
+| **Test** | Where is this proven? (backtick-quoted test name(s)) | Yes, where the project enforces it |
+| **Spec References** | Which spec section governs this, if any? | **Opt-in** — only when a real spec governs it |
+
+**Why**/**What**/**Test** are unchanged by anything below — they stay exactly
+what your project's convention already defines. **Spec References** is a
+fourth, *additive* axis: a separate block within the same doc comment,
+introduced by its own marker, never a replacement for the other three.
+
+A fully-compliant Rust doc comment, all four axes present:
+
+```rust
+/// Why: <motivation>
+/// What: <mechanical description>
+/// Test: `test_name_a`, `test_name_b`
+///
+/// # Spec References
+/// - [`SPEC-FOO-01~draft`](docs/specs/foo.md#SPEC-FOO-01~draft)
+pub fn my_function() { … }
+```
+
+**Never fabricate a spec link.** Add `# Spec References` (inline) or
+`spec_refs:` (Markdown frontmatter) only when a spec genuinely governs the
+item. An item with no governing spec simply omits the block — that is the
+correct, complete state, not an oversight to "fix" by inventing a link to
+satisfy a checklist.
+
+## Per-Type Guides
+
+Each artifact type gets a focused reference under `references/` — read the one
+that matches what you're writing, not the whole set.
+
+| Type | Reference | Covers |
+|---|---|---|
+| Spec (behavior-contract document) | [spec.md](references/spec.md) | Header block, numbering, anchors, lifecycle |
+| README | [readme.md](references/readme.md) | Entry-point orientation for humans and agents |
+| File-level | [file-level.md](references/file-level.md) | Module/file header docs (`//!`, docstrings) |
+| Class/Module (struct/trait/type) | [class.md](references/class.md) | Type-level contracts, invariants, thread-safety |
+| Method/Function | [method-function.md](references/method-function.md) | Callable contracts — pre/postconditions, `Test:` pointers |
+| Block/Inline | [block-inline.md](references/block-inline.md) | Trailing/preceding line comments |
+
+## Context-Economy Principles
+
+Documentation competes for the same context window an agent uses to reason
+about the task. Treat every line of doc as a cost, not a free good:
+
+- **Say less.** State the contract; don't narrate the implementation.
+- **Say it once.** Don't restate at the file level what the function-level doc
+  already says, or restate what the type signature already shows.
+- **Link out.** Point to the deeper reference (a `references/*.md` file, a
+  spec section) instead of inlining it. Progressive disclosure keeps the
+  entry point dense and the detail one hop away.
+
+A factorial study on coding-agent instruction files found file *structure*
+(length, placement, section architecture) had no detectable effect on
+instruction adherence, while compliance measurably degrades as more content
+accumulates within a session. Treat this as a caveat against assuming any
+particular formatting trick helps, not as license to skip Why/What/Test — the
+economy argument is about redundancy, not about omitting the mandatory axes.
+
+## Anti-Patterns (ported from `api-documentation`)
+
+- **Redundant comments** — `i = i + 1  // increment i` adds zero information;
+  a *why* comment (`// skip header row`) survives refactors that change the
+  *how*.
+- **Outdated documentation** — a doc comment that no longer matches the code
+  it describes is worse than no comment; it actively misleads.
+- **Implementation, not contract** — `"""Uses bubble sort to sort users."""`
+  documents *how*; `"""Returns users sorted alphabetically by name."""`
+  documents *what*. Callers need the contract, not the algorithm.
+
+## Quick Checklist
+
+```
+□ Public APIs carry Why/What/Test (or the project's equivalent triple)
+□ Spec References added only where a spec genuinely governs the item
+□ Parameters, returns, and errors documented
+□ Usage example provided where non-obvious
+□ File-level doc states why the file exists, not just what's in it
+□ No comment restates what the next line or the signature already shows
+□ Docs updated in the same change as the code they describe
+```
+
+## Related Skills
+
+- **[api-documentation](../api-documentation/SKILL.md)** — general per-language
+  docstring/JSDoc/Godoc examples this skill's `method-function.md` builds on.
+- **[contract-driven-testing](../contract-driven-testing/SKILL.md)** — deriving
+  tests from the preconditions/postconditions a Method/Function doc states.
+
+## Spec References
+
+- [`SPEC-SLD-02~draft`](../../../../../docs/specs/spec-linked-documentation.md#SPEC-SLD-02~draft) — the canonical spec-reference grammar (inline and frontmatter forms) this skill's Spec-References guidance defers to.

--- a/crates/trusty-mpm/src/assets/skills/documentation-style/references/block-inline.md
+++ b/crates/trusty-mpm/src/assets/skills/documentation-style/references/block-inline.md
@@ -1,0 +1,54 @@
+# Block / Inline Comments
+
+> **Part of**: [Documentation Style](../SKILL.md)
+> **Category**: documentation
+> **Reading Level**: Beginner
+
+## Purpose
+
+A block or inline comment explains **why** a specific non-obvious line or
+block does what it does — it never restates the line in English. This is the
+single highest-leverage rule in this entire skill for context-window
+economy: a redundant comment is pure token tax with zero information gain,
+for a human reviewer or an agent alike.
+
+## Required Elements
+
+A trailing or preceding comment, used only where the code is genuinely
+tricky — per the Google C++/Go style guidance: comment coding tricks,
+non-obvious ordering, or why an alternative approach wasn't chosen. Not on
+every line, and not by default.
+
+## Spec Link-Back Rule
+
+Generally none. Block comments are too fine-grained for a spec anchor — DOC-38
+has no block-granularity reference form. If a block genuinely implements a
+specific spec clause, that context belongs in the *enclosing function's*
+`# Spec References` block (see [method-function.md](method-function.md)), not
+a block-level one.
+
+## Agentic Considerations
+
+Reserve inline comments for exactly the cases a diff reviewer — human or
+agent — would otherwise stop and ask "wait, why?" A comment that doesn't
+clear that bar is subtracting value: it adds tokens to every future read of
+this file without adding information.
+
+## Anti-Patterns
+
+```python
+# Bad: Obvious comment adds no value
+i = i + 1  # Increment i
+
+# Good: Comment explains WHY
+i = i + 1  # Skip header row
+```
+
+(Verbatim from the `api-documentation` skill — reuse this example; it is the
+canonical illustration of the rule.)
+
+- **Comments that duplicate the very next line.** If the comment and the code
+  say the same thing in two languages, delete the comment.
+- **Comments that describe *how* instead of *why*.** A *how* comment goes
+  stale the moment the implementation changes; a *why* comment survives
+  refactors that change the how but not the reason.

--- a/crates/trusty-mpm/src/assets/skills/documentation-style/references/class.md
+++ b/crates/trusty-mpm/src/assets/skills/documentation-style/references/class.md
@@ -1,0 +1,76 @@
+# Class / Module Documentation
+
+> **Part of**: [Documentation Style](../SKILL.md)
+> **Category**: documentation
+> **Reading Level**: Intermediate
+
+## Purpose
+
+A class, struct, trait, or module doc states the **contract the type
+upholds** — invariants, thread-safety, lifecycle — not its field list. The
+compiler (or the type system, in a typed language) already shows the field
+list; documentation earns its cost by stating what the type system does
+*not* enforce.
+
+## Required Elements
+
+- The Why/What/Test triple, plus a usage example.
+- Invariants and thread-safety notes, stated explicitly wherever they are
+  **not** obvious from the type signature — this is exactly where
+  documentation value is highest and most often skipped.
+
+A worked example (Python, adapted from the `api-documentation` skill):
+
+```python
+class UserManager:
+    """
+    Manages user accounts and authentication.
+
+    Attributes:
+        db: Database connection instance
+        cache: Redis cache for session management
+
+    Example:
+        >>> manager = UserManager(db=get_db(), cache=get_cache())
+        >>> user = manager.create_user("john@example.com", "password")
+
+    Thread Safety:
+        This class is thread-safe. Multiple threads can safely call
+        methods concurrently.
+
+    Note:
+        All passwords are automatically hashed using bcrypt before
+        storage. Never pass pre-hashed passwords to methods.
+    """
+```
+
+The same shape applies to a Rust `struct`/`trait`: Why/What/Test in the
+`///` block, an `# Examples` section, and an explicit note on any invariant
+or thread-safety property the type system doesn't already guarantee.
+
+## Spec Link-Back Rule
+
+Where a project uses spec-linked documentation, place the `# Spec References`
+block above the `struct`/`trait`/`impl`, immediately after Why/What/Test,
+when the type's behavior is genuinely spec-governed. Not every type needs
+this — a plain data-transfer struct with no governing spec should carry no
+block. When in doubt whether a type *should* be spec-linked, that doubt is
+itself worth surfacing (a comment, a follow-up issue) rather than resolved by
+guessing a link.
+
+## Agentic Considerations
+
+An agent editing a method on this type needs the *invariant* stated at the
+type level, so it doesn't have to re-derive it by reading every call site.
+State what the compiler does not already enforce; do not restate what it
+does — a `pub id: u64` field needs no doc comment explaining "this is a u64
+holding the id."
+
+## Anti-Patterns
+
+- **Documenting field types.** Redundant with the struct definition the
+  reader is already looking at.
+- **Omitting invariants enforced only by convention, not the compiler.**
+  This is the single most common and most costly omission — the type system
+  can't catch a caller violating it, so the doc comment is the only
+  enforcement mechanism available.

--- a/crates/trusty-mpm/src/assets/skills/documentation-style/references/file-level.md
+++ b/crates/trusty-mpm/src/assets/skills/documentation-style/references/file-level.md
@@ -1,0 +1,52 @@
+# File-Level Documentation
+
+> **Part of**: [Documentation Style](../SKILL.md)
+> **Category**: documentation
+> **Reading Level**: Beginner
+
+## Purpose
+
+File-level documentation states what this file is for and *why it exists as
+a separate unit* — module-level orientation, not a restatement of its
+contents. It is the highest-value doc for an agent doing file-level triage:
+front-load "why this file exists" so relevance can be judged before opening
+the body.
+
+## Required Elements
+
+- Rust: the `//!` inner-doc idiom at the top of the module — this repo's
+  existing convention, unchanged by spec-linked documentation (per DOC-38
+  §3.1, where a project uses it).
+- Non-Rust languages: the equivalent module-header docstring/comment form —
+  a one-sentence abstract (the `\brief`-equivalent) followed by longer
+  discussion in separate paragraphs, per the Doxygen/LLVM convention.
+- Avoid restating what's already inferable from the filename or the public
+  API surface — the file header earns its cost by adding context the
+  signature list can't.
+
+## Spec Link-Back Rule
+
+Where a project uses spec-linked documentation, a file whose behavior is
+spec-governed carries a `# Spec References` block (inline idiom) immediately
+below the file-level Why/What prose — introduced by a marker line whose
+stripped text is exactly "Spec References". Scoping follows a
+nearest-preceding-marker rule: a file may carry zero, one, or (rarely) both a
+module-level block and additional per-item blocks further down. Omit the
+block entirely when nothing in the file is spec-governed.
+
+## Agentic Considerations
+
+This is the doc an agent reads *first* when triaging a file it hasn't opened
+yet. A strong file header lets an agent decide relevance — "is this the file
+I need to touch?" — without reading the body. Two things make this decision
+fast: a clear *why this file is separate* statement, and, when present, its
+spec linkage (so the agent knows immediately whether a spec constrains any
+change here).
+
+## Anti-Patterns
+
+- **Headers that restate the filename.** `//! This file contains the User
+  struct.` tells the reader nothing they didn't already know from the path.
+- **Excessively long headers that duplicate in-body docs.** If the file
+  header repeats what each item's own doc comment already says, one of the
+  two will drift; keep the header to file-scoped orientation only.

--- a/crates/trusty-mpm/src/assets/skills/documentation-style/references/method-function.md
+++ b/crates/trusty-mpm/src/assets/skills/documentation-style/references/method-function.md
@@ -1,0 +1,104 @@
+# Method / Function Documentation
+
+> **Part of**: [Documentation Style](../SKILL.md)
+> **Category**: documentation
+> **Reading Level**: Intermediate
+
+Methods and functions share one reference here because their documentation
+contract is identical — the difference is only whether the callable is bound
+to a type. Everything below applies equally to a free function and a method.
+
+## Purpose
+
+Document the **contract** — preconditions, postconditions, error
+conditions — for a callable, not its algorithm. A caller needs to know what
+to pass and what comes back; they don't need (and shouldn't have to read) how
+the result is computed.
+
+## Required Elements
+
+- **Why/What/Test** where the project mandates it: `Why` states the
+  motivation, `What` states the mechanical behavior, `Test` names the actual
+  test(s) proving it — as backtick-quoted names a mechanical checker can
+  verify still exist (see "The `Test:` Pointer", below).
+- A one-line summary in third-person-singular-present ("Returns…", "Computes
+  …") — the rustdoc convention, portable to any docstring style.
+- Full sentences, not fragments.
+- An `# Examples` section with a runnable snippet wherever the call isn't
+  self-evident from the signature.
+- `# Errors` / `# Panics` sections (or your language's equivalent) whenever
+  the function can fail or panic.
+
+## The Reconciled Four-Axis Example
+
+Why/What/Test and a Spec-References link-back are not competing
+conventions — they compose. `Why` and `What` stay exactly what your project's
+convention defines; `Test` is a third, orthogonal axis pointing at executable
+proof; `Spec References` is a fourth, *additive* axis — a separate block
+within the same doc comment, present only when a spec genuinely governs the
+item:
+
+```rust
+/// Why: <motivation>
+/// What: <mechanical description>
+/// Test: `test_name_a`, `test_name_b`
+///
+/// # Spec References
+/// - [`SPEC-FOO-01~draft`](docs/specs/foo.md#SPEC-FOO-01~draft)
+pub fn my_function() { … }
+```
+
+Add the `# Spec References` block only when a spec genuinely governs this
+callable — never to satisfy a checklist.
+
+## The `Test:` Pointer
+
+Where the project mechanically checks `Test:` pointers against real test
+names (this repo's `scripts/check_test_pointers.sh`), the pointer is a direct
+jump target from a doc claim to its executable proof — closing the loop
+between "this is documented to do X" and "here is where X is verified." A
+`Test:` pointer that rots (renamed or deleted test, doc comment left stale)
+is exactly the failure mode that check exists to catch — two real incidents
+in this repo's history were caught only by human reviewers before the gate
+existed.
+
+## Spec Link-Back Rule
+
+The `# Spec References` block in a doc comment is the primary use case for
+spec-linked documentation in code: a function implementing a specific spec
+clause declares it, immediately below Why/What/Test, in the file's native
+comment idiom (Rust `///`, Python docstring, JSDoc, etc. — see your project's
+SLD convention for the exact per-language grammar; this reference restates
+none of it).
+
+## Agentic Considerations
+
+State preconditions and postconditions explicitly — this is contract-driven
+documentation, and it feeds directly into contract-driven testing: an agent
+deriving tests from a function's stated contract needs the contract written
+down, not re-derived from the implementation. An agent modifying this
+function later needs to know what it must preserve; the doc comment is where
+that's recorded. A `Test:` pointer additionally gives that agent a
+mechanically-verified jump target straight to the coverage, rather than a
+manual search.
+
+## Anti-Patterns
+
+- **Documenting *how* instead of *what*.**
+  ```python
+  # Bad: documents HOW (implementation)
+  def sort_users(users):
+      """Uses bubble sort algorithm to sort users."""
+
+  # Good: documents WHAT (contract)
+  def sort_users(users):
+      """Returns users sorted alphabetically by name."""
+  ```
+  The caller doesn't care about the algorithm; they care about the
+  guarantee.
+- **A rotting `Test:` pointer** — a doc comment naming a test that was
+  renamed or deleted, silently decoupling the claim from its proof.
+- **Restating parameter types the signature already shows.** If the
+  signature is `fn discount(price: f64, pct: f64) -> f64`, the doc doesn't
+  need "price is a float" — it needs the units, the valid range, and what
+  happens at the boundary.

--- a/crates/trusty-mpm/src/assets/skills/documentation-style/references/readme.md
+++ b/crates/trusty-mpm/src/assets/skills/documentation-style/references/readme.md
@@ -1,0 +1,59 @@
+# README Documentation
+
+> **Part of**: [Documentation Style](../SKILL.md)
+> **Category**: documentation
+> **Reading Level**: Beginner
+
+## Purpose
+
+A README is entry-point orientation — for a human deciding whether to use
+this project, and for an agent's first pass over a repo or crate before it
+opens anything else. It answers "why would I use this, how do I install it,
+how do I use it" — not the full API reference.
+
+## Required Elements
+
+Blending `standard-readme` conventions with a Diátaxis lens (README = mostly
+*tutorial*, plus a *reference* pointer — never the full reference inline):
+
+- A short description (ideally under 120 characters) stating what the
+  project does.
+- **Installation** — copy-pasteable, no missing prerequisites assumed.
+- **Quick Start / usage example** — a runnable snippet before any prose.
+- A **Configuration** table (option, type, default, description) when the
+  project has runtime configuration.
+- An **API reference pointer** — link out, don't inline the full surface.
+- **Contributing** and **License** sections.
+
+## Spec Link-Back Rule
+
+A README is Markdown, so where the project uses spec-linked documentation, it
+declares references canonically via `spec_refs:` frontmatter at the top of
+the file — for example, a crate README pointing at the spec document
+governing that crate. An optional informative `## Spec References` visible
+section may echo the same link for readability on a code-hosting site; where
+the two disagree, frontmatter wins. Omit both entirely when no spec governs
+the README's subject.
+
+## Agentic Considerations
+
+- **One concept per section**, with consistent H2/H3 hierarchy, so a
+  chunk-retrieval or RAG agent can pull a complete, self-contained unit
+  instead of a fragment that needs surrounding context to make sense.
+- **Quick-start code before prose.** An agent triaging "how do I use this"
+  should find a runnable example within the first screen, not after several
+  paragraphs of background.
+- Consider an `llms.txt`-style summary for large repos, so an agent doing
+  repo-level triage doesn't have to read every README to build an inventory.
+
+## Anti-Patterns
+
+- **Burying install/usage under marketing prose.** Lead with what the reader
+  needs to act, not why the project is great.
+- **A wall of text with no headers** — retrieval-hostile for both humans
+  skimming and agents chunk-retrieving.
+- **Duplicating the full API reference inline** instead of linking to it —
+  guarantees the two copies drift.
+- **Letting the README drift from the spec it summarizes.** Without a
+  `spec_refs:` link, there is no mechanical way to catch this drift — that is
+  precisely the gap the frontmatter link closes.

--- a/crates/trusty-mpm/src/assets/skills/documentation-style/references/spec.md
+++ b/crates/trusty-mpm/src/assets/skills/documentation-style/references/spec.md
@@ -1,0 +1,65 @@
+# Spec Documentation
+
+> **Part of**: [Documentation Style](../SKILL.md)
+> **Category**: documentation
+> **Reading Level**: Intermediate
+
+## Purpose
+
+A spec is a behavior-contract document governing a subsystem. It is the
+**target** of spec-link-back references from code, config, and other
+Markdown — never a source pointing somewhere else for its own behavior
+(though it may point at a spec it *builds on*; see below).
+
+## Required Elements
+
+Where a project uses DOC-38-style spec-linked documentation, a conformant
+spec carries (see `docs/specs/spec-linked-documentation.md` §4 for the
+normative rules — this reference restates none of them):
+
+- A title line: `# DOC-N — Title`, where `N` is assigned by **scanning the
+  spec catalog for the next free number**, never by trusting a stale "next
+  free" note.
+- A bold-field header block: **Status**, **Subsystem**, **Owner**,
+  **Last-updated**, **Spec ID** (required); **Epic**, **Builds on**,
+  **Cross-ref** (optional).
+- Every governed section carries an anchor in the form
+  `{#SPEC-{SUBSYSTEM}-{NN}~{rev}}`.
+- A catalog row in the repository's spec index (e.g. `docs/specs/README.md`).
+- A `Draft → Accepted → Superseded` lifecycle per section, expressed through
+  the `~rev` suffix (`~draft → ~v1 → ~v2`, or a named tag like `~approved`).
+
+If your project uses a different spec convention (or none), adapt the shape
+above — the point is a stable ID, an anchor, and a catalog entry, however
+your project spells them.
+
+## Spec Link-Back Rule
+
+Specs generally sit at the top of the reference graph and don't link back to
+something above them. A spec **may** carry `spec_refs:` frontmatter pointing
+at a spec it explicitly builds on or extends — this is the same mechanism
+code uses, applied to the spec document itself. Numbering is always
+scan-before-claim; never trust a catalog's cached "next free number" hint,
+which can and does drift out of sync with reality.
+
+## Agentic Considerations
+
+- **`{NN}` is opaque.** Don't infer document structure or reading order from
+  the numeric ID sequence — IDs are assigned by scan order, not narrative
+  order.
+- **`{rev}` is an open token**, not a closed enum of `draft`/`v1`/`v2`. A
+  resolver (human or agent) must not reject an unrecognized `~<token>` — new
+  named tags (e.g. `~approved`) are valid.
+- **One decision per record, immutable.** Architecture Decision Records
+  (Nygard format: Title / Context / Decision / Status / Consequences) are the
+  reference shape for the "decision" subtype of spec — amend by superseding a
+  record with a new one, never by editing history in place.
+
+## Anti-Patterns
+
+- **Reusing a colliding ID** instead of scanning for the next free number —
+  this has caused real numbering collisions in this repo's own spec catalog.
+- **Metadata leaking into `spec_refs:` frontmatter.** Frontmatter is
+  references-only; it never duplicates the bold-field header block.
+- **Trusting a catalog's cached hint** over an actual scan of existing spec
+  files — the hint is documentation, not ground truth.

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -76,6 +76,10 @@ mod tests_behavior_2890_skills;
 mod tests_behavior_2903_skills;
 
 #[cfg(test)]
+#[path = "tests_behavior_2911_documentation_style_tests.rs"]
+mod tests_behavior_2911_documentation_style;
+
+#[cfg(test)]
 #[path = "tests_projects.rs"]
 mod tests_projects;
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_2911_documentation_style_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_2911_documentation_style_tests.rs
@@ -1,0 +1,91 @@
+//! End-to-end deploy proof for issue #2911's `documentation-style` bundled
+//! skill — companion file, following the existing
+//! `tests_behavior_2890_skills`/`tests_behavior_2903_skills` split
+//! convention (kept separate so no single file grows past its production/test
+//! SLOC cap; this file is itself capped at 1500 SLOC as a test file).
+//!
+//! Why: mirrors `tests_behavior_2903_skills_tests.rs`'s rationale exactly —
+//! a skill asset file existing under `src/assets/skills/` is NOT sufficient
+//! for it to ship; only `ALL` (`bundle_all.rs`) registration makes
+//! `deploy_all_skill_tiers` see it, and the multi-file skill-directory
+//! extension (epic #2902 constraint #2, reused here) adds a SECOND failure
+//! mode: a `references/*.md` file could be registered in `ALL` yet still
+//! never land on disk if the deploy machinery only copied the entry-point
+//! `SKILL.md`. Only observing files land in a real deployed `.claude/skills/`
+//! tree — via the exact two-step path `tm install` uses — proves both
+//! concerns are actually resolved for this skill.
+//! What: `documentation_style_lands_in_deployed_dot_claude_skills` calls
+//! `install_to` then `deploy_all_skill_tiers` (matching
+//! `skill_port_batch1_sample_lands_in_deployed_dot_claude_skills` in
+//! `tests_behavior_2903_skills_tests.rs`) against a temp framework root, then
+//! reads back the entry `SKILL.md` and all 6 `references/*.md` files from the
+//! deployed directory, asserting content is byte-identical to the
+//! `include_str!`-embedded constants.
+//! Test: this IS the test module.
+
+use trusty_mpm::core::bundle::{
+    DOCUMENTATION_STYLE, DOCUMENTATION_STYLE_BLOCK_INLINE, DOCUMENTATION_STYLE_CLASS,
+    DOCUMENTATION_STYLE_FILE_LEVEL, DOCUMENTATION_STYLE_METHOD_FUNCTION,
+    DOCUMENTATION_STYLE_README, DOCUMENTATION_STYLE_SPEC,
+};
+
+use crate::commands::install::install_to;
+
+#[test]
+fn documentation_style_lands_in_deployed_dot_claude_skills() {
+    let dir = tempfile::tempdir().unwrap();
+    let paths = trusty_mpm::core::paths::FrameworkPaths::under(dir.path());
+
+    // Step 1: `tm install`'s first half — write every bundled artifact
+    // (including the 7 documentation-style entries) under the framework root.
+    install_to(&paths, false).unwrap();
+
+    // Step 2: `tm install`'s second half — the SAME multi-tier orchestrator
+    // that copies the framework-root skill sources into `.claude/skills/`.
+    let result = trusty_mpm::core::skill_tiers::deploy_all_skill_tiers(
+        &paths.skill_source_dir(),
+        &paths.user_skill_source_dir(),
+        &paths.claude_skills_dir(),
+        |_| true,
+    )
+    .unwrap()
+    .stats;
+
+    assert!(
+        result.deployed.contains(&"documentation-style".to_string()),
+        "documentation-style must be deployed; got {:?}",
+        result.deployed
+    );
+    assert!(
+        result
+            .deployed
+            .contains(&"documentation-style/references/method-function.md".to_string()),
+        "documentation-style's reference files must deploy alongside it; got {:?}",
+        result.deployed
+    );
+
+    // Entry point AND every references/*.md sibling must land, at the
+    // multi-file layout (`<dest>/<name>/references/<file>.md`, alongside
+    // `<dest>/<name>/SKILL.md`).
+    let skill_dir = paths.claude_skills_dir().join("documentation-style");
+    assert_eq!(
+        std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap(),
+        DOCUMENTATION_STYLE,
+    );
+    for (file_name, expected) in [
+        ("spec.md", DOCUMENTATION_STYLE_SPEC),
+        ("readme.md", DOCUMENTATION_STYLE_README),
+        ("file-level.md", DOCUMENTATION_STYLE_FILE_LEVEL),
+        ("class.md", DOCUMENTATION_STYLE_CLASS),
+        ("method-function.md", DOCUMENTATION_STYLE_METHOD_FUNCTION),
+        ("block-inline.md", DOCUMENTATION_STYLE_BLOCK_INLINE),
+    ] {
+        let ref_path = skill_dir.join("references").join(file_name);
+        assert!(
+            ref_path.is_file(),
+            "expected reference file at {}",
+            ref_path.display()
+        );
+        assert_eq!(std::fs::read_to_string(&ref_path).unwrap(), expected);
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
@@ -334,8 +334,12 @@ fn install_then_deploy_deploys_skills() {
     // skill-port batch 1: 25 upstream universal/ skill entry points + 68
     // references/*.md files carried alongside multi-file skills; see
     // `tests_behavior_2903_skills_tests.rs` for the dedicated deep
-    // assertions, kept out of this file for the same SLOC-cap reason).
-    // 21 + 2 + 93 = 116. See `bundle_tm_skills.rs`/`bundle.rs`
+    // assertions, kept out of this file for the same SLOC-cap reason) + 7
+    // (issue #2911: the `documentation-style` bundled skill — entry SKILL.md
+    // plus 6 references/*.md files; see
+    // `tests_behavior_2911_documentation_style_tests.rs` for the dedicated
+    // deep assertions, kept out of this file for the same SLOC-cap reason).
+    // 21 + 2 + 93 + 7 = 123. See `bundle_tm_skills.rs`/`bundle.rs`
     // (CODE_REVIEW_STANDARDS, CONTRACT_DRIVEN_TESTING)/`bundle_all.rs::ALL`
     // for the authoritative list.
     // Stats report stems (no .md suffix) because each skill lands as
@@ -362,10 +366,10 @@ fn install_then_deploy_deploys_skills() {
     );
     assert_eq!(
         result.deployed.len(),
-        116,
-        "expected 116 skill files deployed (19 /tm- portfolio + tm-doctor + tm overview \
-         + code-review-standards + contract-driven-testing + 93 skill-port batch-1 entries); \
-         got {:?}",
+        123,
+        "expected 123 skill files deployed (19 /tm- portfolio + tm-doctor + tm overview \
+         + code-review-standards + contract-driven-testing + 93 skill-port batch-1 entries \
+         + 7 documentation-style entries); got {:?}",
         result.deployed
     );
     assert!(result.skipped.is_empty());

--- a/crates/trusty-mpm/src/core/bundle.rs
+++ b/crates/trusty-mpm/src/core/bundle.rs
@@ -187,6 +187,17 @@ pub const MPM_AGENT_MANAGER_AGENT: &str = include_str!("../assets/agents/mpm-age
 /// Concrete mpm-skills-manager agent — skill lifecycle and recommendations (`extends: base-agent`).
 pub const MPM_SKILLS_MANAGER_AGENT: &str = include_str!("../assets/agents/mpm-skills-manager.md");
 
+// --- Issue #2911: `documentation-style` bundled skill (SLD-grounded
+// per-artifact-type documentation conventions) — own module, kept separate
+// from the batch-1 groups since it lands independently of epic #2902.
+#[path = "bundle_skills_documentation_style.rs"]
+mod skills_documentation_style_inner;
+pub use skills_documentation_style_inner::{
+    DOCUMENTATION_STYLE, DOCUMENTATION_STYLE_BLOCK_INLINE, DOCUMENTATION_STYLE_CLASS,
+    DOCUMENTATION_STYLE_FILE_LEVEL, DOCUMENTATION_STYLE_METHOD_FUNCTION,
+    DOCUMENTATION_STYLE_README, DOCUMENTATION_STYLE_SPEC,
+};
+
 // --- Skill-port batch 1 (issue #2903, epic #2902): 25 upstream universal/
 // skills, split across 4 modules by category to stay under the 500-SLOC cap.
 #[path = "bundle_skills_batch1_debugging.rs"]

--- a/crates/trusty-mpm/src/core/bundle_all.rs
+++ b/crates/trusty-mpm/src/core/bundle_all.rs
@@ -466,4 +466,32 @@ pub const ALL: &[BundledArtifact] = &[
     overwrite("skills/artifacts-builder.md", ARTIFACTS_BUILDER),
     overwrite("skills/model-context-builder.md", MODEL_CONTEXT_BUILDER),
     overwrite("skills/xlsx.md", XLSX),
+    // --- BEGIN issue #2911: documentation-style bundled skill (append-only;
+    // sibling PR #2913 owns the ALL table above this marker) ---
+    overwrite("skills/documentation-style.md", DOCUMENTATION_STYLE),
+    overwrite(
+        "skills/documentation-style/references/spec.md",
+        DOCUMENTATION_STYLE_SPEC,
+    ),
+    overwrite(
+        "skills/documentation-style/references/readme.md",
+        DOCUMENTATION_STYLE_README,
+    ),
+    overwrite(
+        "skills/documentation-style/references/file-level.md",
+        DOCUMENTATION_STYLE_FILE_LEVEL,
+    ),
+    overwrite(
+        "skills/documentation-style/references/class.md",
+        DOCUMENTATION_STYLE_CLASS,
+    ),
+    overwrite(
+        "skills/documentation-style/references/method-function.md",
+        DOCUMENTATION_STYLE_METHOD_FUNCTION,
+    ),
+    overwrite(
+        "skills/documentation-style/references/block-inline.md",
+        DOCUMENTATION_STYLE_BLOCK_INLINE,
+    ),
+    // --- END issue #2911 ---
 ];

--- a/crates/trusty-mpm/src/core/bundle_skills_documentation_style.rs
+++ b/crates/trusty-mpm/src/core/bundle_skills_documentation_style.rs
@@ -1,0 +1,100 @@
+//! `documentation-style` bundled skill (issue #2911) — SLD-grounded
+//! per-artifact-type documentation conventions.
+//!
+//! Why: `docs/specs/spec-linked-documentation.md` (DOC-38) Annex B names
+//! authoring the `spec-linked-docs` (and `spec-authoring`) skills as
+//! follow-up F2. This module ships the consolidation of that brief: one
+//! bundled skill covering the four-axis Why/What/Test + opt-in Spec
+//! References inline model, plus per-artifact-type guides (spec, README,
+//! file-level, class, method/function, block/inline) — split into its own
+//! file (rather than folded into an existing batch-1 module) to keep the
+//! addition isolable and independently reviewable, and to stay well under
+//! the 500-SLOC production cap.
+//! What: `pub const` strings for the skill's entry `SKILL.md` and its six
+//! `references/*.md` files, embedded at compile time via `include_str!`.
+//! Re-exported by `bundle.rs`.
+//! Test: `bundle_tests.rs` — `bundle_table_is_complete`,
+//! `documentation_style_skill_is_in_bundle`,
+//! `documentation_style_references_land_on_disk`.
+
+/// `documentation-style` skill entry point (issue #2911).
+///
+/// Why: registration in [`crate::core::bundle_all::ALL`] (not just the asset
+/// file existing under `src/assets/skills/`) is what makes
+/// `deploy_all_skill_tiers` actually ship it — the tm-doctor.md orphaning
+/// lesson (`bundle_tm_skills.rs`'s module doc) applies here too.
+/// What: embedded markdown skill file deployed to
+/// `skills/documentation-style.md`.
+/// Test: `bundle_table_is_complete`, `documentation_style_skill_is_in_bundle`.
+pub const DOCUMENTATION_STYLE: &str = include_str!("../assets/skills/documentation-style.md");
+
+/// `documentation-style` reference file `references/spec.md` (issue #2911).
+///
+/// Why: progressive disclosure — Claude Code loads this file on demand
+/// alongside the entry-point `SKILL.md`, not up front.
+/// What: embedded markdown reference file deployed alongside
+/// `documentation-style`'s `SKILL.md` at
+/// `skills/documentation-style/references/spec.md`.
+/// Test: `bundle_table_is_complete`, `documentation_style_references_land_on_disk`.
+pub const DOCUMENTATION_STYLE_SPEC: &str =
+    include_str!("../assets/skills/documentation-style/references/spec.md");
+
+/// `documentation-style` reference file `references/readme.md` (issue #2911).
+///
+/// Why: progressive disclosure — Claude Code loads this file on demand
+/// alongside the entry-point `SKILL.md`, not up front.
+/// What: embedded markdown reference file deployed alongside
+/// `documentation-style`'s `SKILL.md` at
+/// `skills/documentation-style/references/readme.md`.
+/// Test: `bundle_table_is_complete`, `documentation_style_references_land_on_disk`.
+pub const DOCUMENTATION_STYLE_README: &str =
+    include_str!("../assets/skills/documentation-style/references/readme.md");
+
+/// `documentation-style` reference file `references/file-level.md` (issue #2911).
+///
+/// Why: progressive disclosure — Claude Code loads this file on demand
+/// alongside the entry-point `SKILL.md`, not up front.
+/// What: embedded markdown reference file deployed alongside
+/// `documentation-style`'s `SKILL.md` at
+/// `skills/documentation-style/references/file-level.md`.
+/// Test: `bundle_table_is_complete`, `documentation_style_references_land_on_disk`.
+pub const DOCUMENTATION_STYLE_FILE_LEVEL: &str =
+    include_str!("../assets/skills/documentation-style/references/file-level.md");
+
+/// `documentation-style` reference file `references/class.md` (issue #2911).
+///
+/// Why: progressive disclosure — Claude Code loads this file on demand
+/// alongside the entry-point `SKILL.md`, not up front.
+/// What: embedded markdown reference file deployed alongside
+/// `documentation-style`'s `SKILL.md` at
+/// `skills/documentation-style/references/class.md`.
+/// Test: `bundle_table_is_complete`, `documentation_style_references_land_on_disk`.
+pub const DOCUMENTATION_STYLE_CLASS: &str =
+    include_str!("../assets/skills/documentation-style/references/class.md");
+
+/// `documentation-style` reference file `references/method-function.md`
+/// (issue #2911).
+///
+/// Why: progressive disclosure — Claude Code loads this file on demand
+/// alongside the entry-point `SKILL.md`, not up front. Method and function
+/// guidance ship as one file (not two) — their documentation contract is
+/// identical, differing only in whether the callable is bound to a type; see
+/// the PR description for this call.
+/// What: embedded markdown reference file deployed alongside
+/// `documentation-style`'s `SKILL.md` at
+/// `skills/documentation-style/references/method-function.md`.
+/// Test: `bundle_table_is_complete`, `documentation_style_references_land_on_disk`.
+pub const DOCUMENTATION_STYLE_METHOD_FUNCTION: &str =
+    include_str!("../assets/skills/documentation-style/references/method-function.md");
+
+/// `documentation-style` reference file `references/block-inline.md`
+/// (issue #2911).
+///
+/// Why: progressive disclosure — Claude Code loads this file on demand
+/// alongside the entry-point `SKILL.md`, not up front.
+/// What: embedded markdown reference file deployed alongside
+/// `documentation-style`'s `SKILL.md` at
+/// `skills/documentation-style/references/block-inline.md`.
+/// Test: `bundle_table_is_complete`, `documentation_style_references_land_on_disk`.
+pub const DOCUMENTATION_STYLE_BLOCK_INLINE: &str =
+    include_str!("../assets/skills/documentation-style/references/block-inline.md");

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -87,6 +87,15 @@ fn constants_are_non_empty() {
     assert!(!TM_ISSUES_PRUNE.trim().is_empty());
     assert!(!TM_CLI_OPERATIONS.trim().is_empty());
     assert!(!WHAT_IS_TRUSTY_MPM.trim().is_empty());
+    // --- BEGIN issue #2911: documentation-style bundled skill (append-only) ---
+    assert!(!DOCUMENTATION_STYLE.trim().is_empty());
+    assert!(!DOCUMENTATION_STYLE_SPEC.trim().is_empty());
+    assert!(!DOCUMENTATION_STYLE_README.trim().is_empty());
+    assert!(!DOCUMENTATION_STYLE_FILE_LEVEL.trim().is_empty());
+    assert!(!DOCUMENTATION_STYLE_CLASS.trim().is_empty());
+    assert!(!DOCUMENTATION_STYLE_METHOD_FUNCTION.trim().is_empty());
+    assert!(!DOCUMENTATION_STYLE_BLOCK_INLINE.trim().is_empty());
+    // --- END issue #2911 ---
 }
 
 #[test]
@@ -346,11 +355,14 @@ fn bundle_table_is_complete() {
     //   condition-based-waiting, model-context-builder, test-quality-inspector,
     //   testing-anti-patterns, webapp-testing, api-documentation, xlsx,
     //   code-production-process. 71 + 93 = 164.
-    assert_eq!(ALL.len(), 164);
+    // Issue #2911 (7): documentation-style bundled skill — entry SKILL.md plus
+    //   6 references/*.md files (spec, readme, file-level, class,
+    //   method-function, block-inline). 164 + 7 = 171.
+    assert_eq!(ALL.len(), 171);
     let mut paths: Vec<&str> = ALL.iter().map(|a| a.rel_path).collect();
     paths.sort_unstable();
     paths.dedup();
-    assert_eq!(paths.len(), 164, "artifact paths must be unique");
+    assert_eq!(paths.len(), 171, "artifact paths must be unique");
     for artifact in ALL {
         assert!(!artifact.rel_path.is_empty());
         assert!(!artifact.contents.trim().is_empty());
@@ -1000,5 +1012,76 @@ fn pm_authority_doctrine_survives_composition() {
         composed_normalized.contains("never merge red or pending CI"),
         "composed version-control is missing its own PR-workflow \
          objective-safety-gate (red/pending CI) text"
+    );
+}
+
+#[test]
+fn documentation_style_skill_is_in_bundle() {
+    // Issue #2911: the documentation-style entry SKILL.md must be present in
+    // `ALL` — mirrors `tm_doctor_skill_is_wired_into_bundle` and
+    // `skill_port_batch1_skills_are_in_bundle` above: a source file existing
+    // under `src/assets/skills/` is not sufficient, only `ALL` registration
+    // makes `deploy_all_skill_tiers` ship it.
+    assert!(
+        ALL.iter()
+            .any(|a| a.rel_path == "skills/documentation-style.md"),
+        "documentation-style.md must be present in the ALL bundle table"
+    );
+    assert!(DOCUMENTATION_STYLE.starts_with("---\n"));
+    assert!(DOCUMENTATION_STYLE.contains("name: documentation-style"));
+    // SLD self-compliance (DOC-38 §2.5): the entry SKILL.md carries
+    // `spec_refs:` frontmatter pointing at the grammar section it defers to,
+    // with `anchor` equal to `id` per DOC-38's self-check rule.
+    assert!(DOCUMENTATION_STYLE.contains("spec_refs:"));
+    assert!(DOCUMENTATION_STYLE.contains("id: SPEC-SLD-02~draft"));
+    assert!(DOCUMENTATION_STYLE.contains("anchor: SPEC-SLD-02~draft"));
+}
+
+#[test]
+fn documentation_style_references_land_on_disk() {
+    // Issue #2911: all 6 references/*.md files must be SEPARATE `ALL` entries
+    // alongside the entry-point SKILL.md — mirrors
+    // `skill_port_batch1_references_land_on_disk`. Real deploy-reachability
+    // (landing under a deployed `.claude/skills/documentation-style/references/`)
+    // is proven end-to-end in `tests_behavior_2911_documentation_style_tests.rs`.
+    assert!(
+        ALL.iter()
+            .any(|a| a.rel_path == "skills/documentation-style.md")
+    );
+    for rel_path in [
+        "skills/documentation-style/references/spec.md",
+        "skills/documentation-style/references/readme.md",
+        "skills/documentation-style/references/file-level.md",
+        "skills/documentation-style/references/class.md",
+        "skills/documentation-style/references/method-function.md",
+        "skills/documentation-style/references/block-inline.md",
+    ] {
+        assert!(
+            ALL.iter().any(|a| a.rel_path == rel_path),
+            "{rel_path} must be present in the ALL bundle table"
+        );
+    }
+}
+
+#[test]
+fn documentation_style_unions_into_engineer_family_via_base_engineer() {
+    // Issue #2911: BASE-ENGINEER.md now declares `skills: [documentation-style]`;
+    // compose_agent's DOC-42 union-across-chain merge (builder.rs
+    // `merge_frontmatter`) must propagate it into every concrete engineer-family
+    // agent composed from the REAL bundled asset files, not a synthetic fixture.
+    use crate::core::agent_builder::compose_agent;
+    use std::path::Path;
+
+    let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("src")
+        .join("assets")
+        .join("agents");
+
+    let composed = compose_agent("rust-engineer", &assets_dir)
+        .expect("compose_agent(rust-engineer) must succeed");
+    assert!(
+        composed.contains("documentation-style"),
+        "composed rust-engineer is missing the BASE-ENGINEER-declared \
+         documentation-style skill (union-across-chain, DOC-42): {composed}"
     );
 }


### PR DESCRIPTION
## Summary

Implements issue #2911: the bundled `documentation-style` skill (SLD-grounded per-artifact-type doc style guides) plus a BASE-ENGINEER.md inline-doc reference. Authored per the research brief on #2911 (sections A–E); follows the batch-1 (#2903/#2915) multi-file skill layout now on main.

- **New two-tier bundled skill** `documentation-style`: entry `crates/trusty-mpm/src/assets/skills/documentation-style.md` (~127 lines) + 6 `references/*.md` files (`spec.md`, `readme.md`, `file-level.md`, `class.md`, `method-function.md`, `block-inline.md`).
  - The four-axis inline model: Why/What/Test (unchanged, mandatory) + opt-in `# Spec References` (DOC-38 §3.1), including the exact reconciled Rust example from the research brief.
  - Explicit "never fabricate a spec link" rule.
  - Per-type pointers into `references/`, context-economy principles (say less, say it once, link out), and the arXiv structure-vs-adherence caveat cited as a nuance, not a prescription.
  - Ported (and cited as source) the upstream `api-documentation` skill's anti-pattern trio and quick checklist.
  - Method and function guidance ship as **one** file (`method-function.md`), not two — their documentation contract is identical (pre/postconditions, `Test:` pointer mechanics), differing only in whether the callable is bound to a type. Noted here per the brief's "your call, note it in the PR."
- **`BASE-ENGINEER.md`**: expanded the Deliverables Checklist docs bullet with the brief's proposed stack-neutral wording, referencing the skill by name; added `skills: [documentation-style]` to its frontmatter (flow-style inline array). Verified this parses and unions into every engineer-family agent via the existing DOC-42 union-across-chain compose merge (new test `documentation_style_unions_into_engineer_family_via_base_engineer`, exercised against the real bundled `rust-engineer.md` asset file).
- **Bundle wiring**: new `crates/trusty-mpm/src/core/bundle_skills_documentation_style.rs` module (7 `include_str!` consts), re-exported from `bundle.rs`, registered in `bundle_all.rs::ALL` in an append-only delimited block. `bundle_tests.rs` count assertion updated 164 → 171 (+7), plus two dedicated tests (`documentation_style_skill_is_in_bundle`, `documentation_style_references_land_on_disk`). Extended the deploy-reachability behavior-test family with a new file, `tests_behavior_2911_documentation_style_tests.rs`, mirroring `tests_behavior_2903_skills_tests.rs`'s real install→deploy→read-back proof for the multi-file case. Also fixed the `tests_behavior_a.rs` hard-coded deploy-count assertion (116 → 123).

## SLD self-compliance

The entry `documentation-style.md` carries canonical `spec_refs:` frontmatter (per DOC-38 §2.5) pointing at `SPEC-SLD-02~draft` (the canonical spec-reference grammar section, §2, which includes the frontmatter form) — `anchor` equals `id` per DOC-38's self-check — plus an informative visible `## Spec References` section for GitHub navigability.

Investigated `scripts/check_sld.sh` / `crates/trusty-sld-lint/src/discover.rs` behavior first: the linter's spec-doc frontmatter scan is currently scoped to `docs/specs/**/*.md` only, and its code-file scan (`crates/**`) only covers non-Markdown `CODE_EXTENSIONS` — so `crates/trusty-mpm/src/assets/skills/**/*.md` is **outside the linter's current scan scope** and this frontmatter is not yet mechanically enforced. There's no parsing conflict with the skill's own catalog frontmatter (name/description/version/category/effort/tags) — it's one YAML frontmatter block, skills have no strict-schema parser (confirmed no `deny_unknown_fields` struct exists for skill frontmatter) — so I used the canonical frontmatter form rather than falling back to the informative-only form, since DOC-38 §2.5 makes frontmatter canonical for `.md` regardless of current linter scan scope. Local verification: `bash scripts/check_sld.sh` passes clean (2443 code files scanned, 0 errors), and the YAML parses correctly with `anchor == id`.

## Gate (all pass, evidence below)

```
$ cargo build --workspace
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 11s

$ cargo test -p trusty-mpm
test result: ok. 3229 passed; 0 failed; 5 ignored
test result: ok. 1015 passed; 0 failed; 1 ignored   (tm bin, x2 targets)
... (all other test binaries ok, 0 failed)

$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 11s   (no -D warnings errors)

$ cargo fmt --check
(clean, no diff)

$ bash scripts/check_line_cap.sh
line-cap: 9 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 35 spec doc(s) + 2443 code file(s); 0 error(s), 0 warning(s)
```

## Deviations from the brief

- Six reference files instead of a literal seven-file split — `method.md`/`function.md` merged into `method-function.md` (brief explicitly allowed this "your call" and the skeleton in section (B) already treated Method/Function as one combined topic).
- SLD self-compliance used the canonical frontmatter form (not the informative-only fallback) despite the linter's current scan-scope gap — see the SLD self-compliance note above for the reasoning.

## Coordination note (sibling #2913)

Kept the `ALL` table addition in `bundle_all.rs`, the `constants_are_non_empty` addition, and the count-assertion comment in `bundle_tests.rs` in clearly-delimited `--- BEGIN/END issue #2911 ---` append-only blocks per the coordination instructions. Confirmed before pushing: `origin/main` is still at `9e861f30` (unchanged since branching) — sibling PR #2913 has not landed yet, so no rebase/recount was needed this round. Did not touch `BASE-AGENT.md` (sibling's file).

Refs DOC-38, DOC-42, #2902.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p trusty-mpm` (full suite, including new deploy-reachability + union tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`
- [x] `bash scripts/check_test_pointers.sh`
- [x] `bash scripts/check_sld.sh`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools