### PR TITLE
feat(trusty-code): wire skill catalog + use_skill into the --legacy-in-process run_task path (closes #2924)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Native skill discovery on the `--legacy-in-process`/bake-off `run-task` path (#2924).** The `use_skill` tool and the `.claude/skills/` catalog now reach the PM's prompt and tool registry on `run_task::execute_run_task`, not just the daemon/thin-client path — a PM run through `run-task` can now discover and load project skills the same way a daemon session already could.
 - **Stable per-spawn `agent_id` for event attribution (DOC-39 AC-13.1/13.2).**
   Agent attribution on the event stream was keyed only by `agent: String` (the
   agent-config name), so two concurrently-delegated same-named agents (e.g.

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -21,7 +21,7 @@ mod report;
 #[cfg(test)]
 mod tests;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -31,16 +31,18 @@ use async_trait::async_trait;
 use crate::agent_loop::{AgentLoop, AgentLoopConfig, AgentLoopError, CompactionConfig};
 use crate::agents::AgentConfig;
 use crate::llm::{DebugCaptureSink, LlmClientTrait, wrap_with_debug_capture};
+use crate::mode::HarnessMode;
 use crate::project_context::load_project_context;
-use crate::prompt::assemble_system_prompt;
+use crate::prompt::assemble_system_prompt_for_mode;
 use crate::provider::{
     resolve_context_window, resolve_deadline_secs, resolve_max_tokens, resolve_model,
 };
 use crate::runner::{InProcessAgentRunner, RegistryFactory};
+use crate::skills::{FsSkillResolver, format_skill_catalog, locate_skills_dir};
 use crate::tools::{
     AgentOutput, AgentRunner, BashTool, DelegateToAgentTool, EditTool, EngineerCompletionSignal,
-    FinishTaskTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, RunContext, ToolRegistry,
-    TrustySearchTool, WriteFileTool, WriteFilesTool,
+    FinishTaskTool, GlobTool, GrepTool, ListDirTool, ReadFileTool, RunContext, SkillResolver,
+    ToolRegistry, TrustySearchTool, UseSkillTool, WriteFileTool, WriteFilesTool,
 };
 
 pub use recorder::{RecordingLlmClient, SharedTranscript, TurnRecord};
@@ -143,6 +145,32 @@ pub(crate) fn ensure_project_indexed_in_background(
 /// Test: `run_task::tests::background_indexing_invokes_readiness_observer`.
 pub(crate) type ReadinessObserver =
     Box<dyn FnOnce(Option<trusty_common::search_readiness::IndexReadiness>) + Send>;
+
+/// Discover the (cheap, metadata-only) skill catalog under `project` and build
+/// a resolver over it (#2924).
+///
+/// Why: this legacy one-shot/bake-off CLI path (`execute_run_task`) predates
+/// #2059's `HarnessMode` plumbing and has no `--mode` flag or `RunTaskParams`
+/// field to thread a resolved mode through — unlike `task::executor`'s
+/// `daily_driver_skills_catalog`, which gates on `HarnessMode::Parity` to
+/// protect that path's benchmark-fairness guarantee, this path never runs in
+/// `Parity` at all, so it always resolves the catalog as if it were
+/// `HarnessMode::DailyDriver` outright, with no mode check needed.
+/// What: Returns `None` when `project` has no (or an empty) `.claude/skills/`
+/// catalog; otherwise `Some((rendered_catalog, resolver))` — the resolver
+/// backs the PM's `use_skill` tool registration and the rendered catalog
+/// feeds `assemble_system_prompt_for_mode`.
+/// Test: `run_task::tests::use_skill_on_legacy_path_reaches_pm_and_transcript`.
+fn daily_driver_skills_catalog(project: &Path) -> Option<(String, Arc<dyn SkillResolver>)> {
+    let skills_dir = locate_skills_dir(project);
+    let resolver: Arc<dyn SkillResolver> = Arc::new(FsSkillResolver::new(skills_dir));
+    let catalog = format_skill_catalog(&resolver.metadata());
+    if catalog.is_empty() {
+        None
+    } else {
+        Some((catalog, resolver))
+    }
+}
 
 /// Inputs to a single `run-task` invocation, parsed from the CLI.
 ///
@@ -247,12 +275,21 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     // all-tests-passing run as `partial`/exit-6.
     let completion_signal = EngineerCompletionSignal::new();
 
+    // #2924: discover the (cheap, metadata-only) skill catalog and, mirroring
+    // `task::executor::run_and_record`'s DailyDriver-only wiring, register
+    // `use_skill` so the PM can lazily fetch a skill's full body on demand.
+    // This CLI path has no `--mode`/Parity guarantee to protect (see
+    // `daily_driver_skills_catalog`'s own docs), so it always resolves the
+    // catalog as if running under `HarnessMode::DailyDriver`.
+    let skills_catalog = daily_driver_skills_catalog(&params.project);
+
     // Build the engineer runner, scoped to the project working dir, sharing the
     // transcript (engineer turns are tagged "python-engineer").
     let engineer_runner = build_engineer_runner(
         wrap_with_debug_capture(Arc::clone(&llm), ENGINEER_AGENT_NAME, debug_sink.as_ref()),
         &params,
         project_context.clone(),
+        skills_catalog.as_ref().map(|(catalog, _)| catalog.clone()),
         Arc::clone(&transcript),
         deadline_secs,
         redelegation_signal.clone(),
@@ -271,6 +308,12 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
             .with_completion_signal(completion_signal.clone()),
     ));
     pm_registry.register(Arc::new(FinishTaskTool::new()));
+    // #2924: mirrors `task::executor::run_and_record` — only the PM registers
+    // `use_skill`; the delegated engineer inherits the catalog/prompt but not
+    // the tool itself.
+    if let Some((_, resolver)) = &skills_catalog {
+        pm_registry.register(Arc::new(UseSkillTool::new(Arc::clone(resolver))));
+    }
 
     // The PM's loop uses a transcript-recording client tagged "pm".
     let pm_llm: Arc<dyn LlmClientTrait> = Arc::new(RecordingLlmClient::new(
@@ -285,10 +328,15 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     // the section.  Sub-agents are NOT wired here; only the PM receives this digest.
     let catchup_ctx = crate::catchup::pm_catchup_context(&params.project).await;
 
-    let pm_system = assemble_system_prompt(
+    // #2924: mirrors `task::executor::run_and_record` — always resolves as
+    // `HarnessMode::DailyDriver` (see `daily_driver_skills_catalog`'s docs
+    // for why this path never needs to resolve `Parity`).
+    let pm_system = assemble_system_prompt_for_mode(
+        HarnessMode::DailyDriver,
         &pm_config,
         project_context.as_deref(),
         catchup_ctx.as_deref(),
+        skills_catalog.as_ref().map(|(catalog, _)| catalog.as_str()),
     );
     // (#2265 fix #5, re-scoped by #2852) Once the shared cap latches, every
     // further `delegate_to_agent` call the PM might issue is a guaranteed dead
@@ -409,11 +457,19 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
 /// What: Returns an `Arc<dyn AgentRunner>` the `DelegateToAgentTool` dispatches
 /// to. The engineer's own LLM turns are recorded under the "python-engineer" role.
 /// `redelegation_signal` is shared with `assemble_report` via the caller.
-/// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`.
+/// `skills_catalog` (#2924) is the same rendered metadata catalog the PM's own
+/// prompt gets, threaded through so the delegated engineer's DailyDriver
+/// prompt also sees it — mirrors `task::executor::build_engineer_runner`,
+/// including that wiring the `use_skill` *tool* into the engineer's own
+/// per-delegation registry (`ProjectToolFactory::build`) is deliberately
+/// deferred, exactly as the daemon path defers it.
+/// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`,
+/// `run_task::tests::use_skill_on_legacy_path_reaches_pm_and_transcript`.
 fn build_engineer_runner(
     llm: Arc<dyn LlmClientTrait>,
     params: &RunTaskParams,
     project_context: Option<String>,
+    skills_catalog: Option<String>,
     transcript: SharedTranscript,
     deadline_secs: u64,
     redelegation_signal: RedelegationCapSignal,
@@ -429,9 +485,16 @@ fn build_engineer_runner(
     });
 
     let mut runner = InProcessAgentRunner::new(engineer_llm, factory, params.agents_dir.clone())
-        .with_timeout_secs(deadline_secs);
+        .with_timeout_secs(deadline_secs)
+        // #2924: mirrors `task::executor::build_engineer_runner` — this path
+        // always resolves as `HarnessMode::DailyDriver` (see
+        // `daily_driver_skills_catalog`'s docs).
+        .with_mode(HarnessMode::DailyDriver);
     if let Some(ctx) = project_context {
         runner = runner.with_project_context(ctx);
+    }
+    if let Some(catalog) = skills_catalog {
+        runner = runner.with_skills_catalog(catalog);
     }
     let pinned = apply_engineer_model_override(Arc::new(runner), params);
     Arc::new(redelegation::RedelegatingRunner::new(

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -1603,3 +1603,82 @@ fn background_indexing_invokes_readiness_observer() {
     rx.recv_timeout(std::time::Duration::from_secs(10))
         .expect("the readiness observer must be invoked, even when nothing is probeable");
 }
+
+/// A response where the assistant calls `use_skill(name)` (#2924).
+fn use_skill_response(name: &str) -> Value {
+    json!({
+        "id": "gen-use-skill",
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call-use-skill",
+                    "type": "function",
+                    "function": {
+                        "name": "use_skill",
+                        "arguments": json!({"name": name}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 25, "completion_tokens": 6, "total_tokens": 31}
+    })
+}
+
+/// The `--legacy-in-process`/bake-off `run_task` path (`execute_run_task`)
+/// wires the skill catalog and `use_skill` tool into the PM's registry the
+/// same way the daemon path (`task::executor::run_and_record`) already does
+/// (#2924) — before this fix, `daily_driver_skills_catalog` and
+/// `UseSkillTool` registration existed ONLY on the daemon path, so a PM
+/// running through this CLI path could never discover or invoke a project
+/// skill at all.
+///
+/// Why: mirrors `runner::tests::skills_catalog_reaches_daily_driver_prompt`,
+/// but proves the wiring at the `execute_run_task` orchestration layer
+/// (config → prompt → registry → transcript), not just at the
+/// `InProcessAgentRunner` builder layer that test already covers.
+/// What: seeds a project with `.claude/skills/demo/SKILL.md`; scripts the PM
+/// to call `use_skill(name: "demo")` on its first turn, then stop; asserts
+/// the resolved skill body reached the tool result (via the recorded
+/// transcript's tool call) and that some `TurnRecord.tool_calls` contains
+/// `"use_skill"`.
+/// Test: this test.
+#[tokio::test]
+async fn use_skill_on_legacy_path_reaches_pm_and_transcript() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let skills_dir = project.path().join(".claude").join("skills").join("demo");
+    std::fs::create_dir_all(&skills_dir).expect("mkdir skill dir");
+    std::fs::write(
+        skills_dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: Demo skill\n---\nfull demo body\n",
+    )
+    .expect("write SKILL.md");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        use_skill_response("demo"),
+        stop_response("pm: loaded the demo skill"),
+    ]));
+
+    let report = execute_run_task(params(&agents, &project, None), llm.clone()).await;
+
+    // The PM's own prompt must have advertised the catalog and the tool.
+    let names = llm.first_tool_names();
+    assert!(
+        names.contains(&"use_skill".to_string()),
+        "PM registry must advertise use_skill when a skill catalog resolves; got {names:?}"
+    );
+
+    // The recorded transcript must show the PM actually calling use_skill.
+    let saw_use_skill = report
+        .transcript
+        .iter()
+        .any(|turn| turn.tool_calls.iter().any(|name| name == "use_skill"));
+    assert!(
+        saw_use_skill,
+        "some TurnRecord.tool_calls must contain \"use_skill\"; transcript was: {:?}",
+        report.transcript
+    );
+}


### PR DESCRIPTION
## Summary

Wires the skill catalog + `use_skill` tool into `run_task::execute_run_task` (the `--legacy-in-process`/bake-off path), mirroring the wiring `task::executor::run_and_record` (the daemon/thin-client path) already had since #2069. Before this fix, native skill discovery only fired on the daemon path — the telemetried `run_task` path never discovered `.claude/skills/`, never advertised `use_skill`, and never injected the catalog into the PM's prompt.

## Changes (crate: trusty-code, file: `crates/trusty-code/src/run_task/mod.rs`)

- **New helper `daily_driver_skills_catalog(project: &Path)`** — discovers `.claude/skills/` the same way `task::executor::daily_driver_skills_catalog` does (`locate_skills_dir` + `FsSkillResolver` + `format_skill_catalog`). This CLI path has no `--mode` flag and no `Parity` guarantee to protect (it's always effectively daily-driver), so it resolves the catalog unconditionally rather than threading a `HarnessMode` param through `RunTaskParams`.
- **`build_engineer_runner`** — now takes an explicit `skills_catalog: Option<String>` param and calls `.with_mode(HarnessMode::DailyDriver)` + `.with_skills_catalog(catalog)` on the `InProcessAgentRunner`.
- **`execute_run_task`** — replaced `assemble_system_prompt(...)` with `assemble_system_prompt_for_mode(HarnessMode::DailyDriver, ..., skills_catalog.as_deref())`.
- **`pm_registry`** — registers `UseSkillTool::new(resolver)` when the catalog resolves `Some` — only the PM gets the tool (the engineer inherits the catalog/prompt only), exactly mirroring `task::executor::run_and_record`.

Scope: additive only, `run_task` module. `task/executor.rs` (daemon path) and `mode.rs` are untouched.

## Test

Added `run_task::tests::use_skill_on_legacy_path_reaches_pm_and_transcript`, mirroring `runner::tests::skills_catalog_reaches_daily_driver_prompt` but proving the wiring at the `execute_run_task` orchestration layer: seeds a tempdir project with `.claude/skills/demo/SKILL.md`, scripts a mock LLM where the PM calls `use_skill(name: "demo")` then stops, and asserts both that the PM's wire-level tool schema advertises `use_skill` and that some `TurnRecord.tool_calls` in the returned report's transcript contains `"use_skill"`.

## Verification (scoped gates, raw output)

```
$ cargo build -p trusty-code --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.18s

$ cargo test -p trusty-code
test result: ok. 1088 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 1.86s
... (all further test binaries: 0 failed)
test run_task::tests::use_skill_on_legacy_path_reaches_pm_and_transcript ... ok

$ cargo clippy -p trusty-code --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.09s   (exit 0)

$ cargo fmt --check
(exit 0)

$ bash scripts/check_line_cap.sh
line-cap: 9 allowlisted, 0 violations — OK.
```

Closes #2924
Refs #2892

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools