### PR TITLE
refactor(trusty-code): depend on trusty-agents-common, dedup ServiceTier/RunContext/HistoryMessage (closes #2893)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10725,6 +10725,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "trusty-agents-common",
  "trusty-common",
  "uuid",
 ]

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -42,6 +42,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **trusty-code now depends on `trusty-agents-common`; `ServiceTier`,
+  `RunContext`, and `HistoryMessage` are re-exported instead of redeclared
+  (#2893, epic #2892).** `crates/trusty-code/src/tools/traits.rs` re-declared
+  ~150 lines of trait/type definitions that already exist in
+  `trusty-agents-common` (the same crate `trusty-agents` already re-exports
+  these from). `ServiceTier` and `RunContext` were byte-identical;
+  `HistoryMessage` was a strict field subset. All three are now
+  `pub use trusty_agents_common::...` re-exports — no behavior change.
+  `ToolExecutor`/`ToolResult` and `AgentRunner`/`AgentOutput` intentionally
+  stay LOCAL: tcode's `ToolResult` carries a `telemetry` field (#2862) and
+  `AgentOutput` carries a `finish_status` field (#2683, whose `usage:
+  TokenUsage` also carries a `cost_usd` field, #50) that the shared
+  definitions lack, and unifying them would require either a much larger
+  events-module move or changes to every `trusty-agents`/`cto-assistant`
+  call site — out of scope for this behavior-preserving refactor.
 - **BREAKING — projectless mode + one typed project binding (UI Phase-1).**
   "Project" was one concept split across two disagreeing API surfaces:
   `task.run` took a REQUIRED `project: PathBuf` (`task/protocol.rs:48`), while

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -44,6 +44,11 @@ tracing-subscriber = { workspace = true }
 # Phase 2: async trait dispatch for ToolExecutor, AgentRunner, SearchProvider
 async-trait = { workspace = true }
 
+# #2893 (epic #2892): shared `ServiceTier`/`RunContext`/`HistoryMessage` types,
+# deduped from tools/traits.rs against the canonical definitions trusty-agents
+# already re-exports from here (see crates/trusty-agents/src/tools/traits.rs).
+trusty-agents-common = { workspace = true }
+
 # Phase 3: TOML config parsing for AgentConfig
 toml = { workspace = true }
 

--- a/crates/trusty-code/src/tools/traits.rs
+++ b/crates/trusty-code/src/tools/traits.rs
@@ -6,15 +6,47 @@
 //! the workflow engine and PM loop testable.
 //! What: Defines `ToolExecutor`, `AgentRunner`, `SearchProvider`, and
 //! `SkillResolver`. All are object-safe (`dyn`-able) and `Send + Sync`.
+//!
+//! `ServiceTier` and `RunContext`/`HistoryMessage` are byte-for-byte identical
+//! to the canonical definitions in `trusty-agents-common` (the same crate
+//! `trusty-agents` already re-exports these from — see
+//! `crates/trusty-agents/src/tools/traits.rs`) and are re-exported here rather
+//! than redeclared (#2893, epic #2892).
+//!
+//! `ToolExecutor`/`ToolResult` and `AgentRunner`/`AgentOutput` stay LOCAL,
+//! deliberately NOT deduped against `trusty-agents-common`, because tcode's
+//! versions carry fields the shared ones lack and that must not regress:
+//! `ToolResult::Success.telemetry` (`Option<Box<ToolTelemetry>>`, #2862) and
+//! `AgentOutput.finish_status` (`Option<FinishStatus>`, #2683; whose
+//! `AgentOutput.usage: crate::perf::TokenUsage` also carries a `cost_usd`
+//! field the shared `TokenUsage` lacks, #50). Unifying either would require
+//! either type-erasing tcode's telemetry (`ToolTelemetry` depends on
+//! `crate::events::{SearchHit, RecalledMemory}`, which are not portable to
+//! the shared crate without a much larger events-module move) or extending
+//! `trusty-agents-common`'s `TokenUsage`/`AgentOutput` and updating every
+//! `trusty-agents`/`cto-assistant` call site that pattern-matches
+//! `ToolResult::Success` — a real design decision outside this
+//! behavior-preserving refactor's scope. See PR discussion for #2893.
 //! Test: Mock impls of each trait are constructed in unit tests for
 //! `ToolRegistry`, delegating commands, and related code.
-
-use std::path::PathBuf;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+// Why: `ServiceTier` and the `AgentRunner` DI seam types (`RunContext`,
+//      `HistoryMessage`) are byte-identical (or a strict derive superset) of
+//      trusty-agents-common's canonical definitions — re-exporting instead of
+//      redeclaring eliminates ~40 duplicate lines without any behavior change
+//      (#2893). `AgentOutput`/`AgentRunner` stay local (see module docs above)
+//      so `HistoryMessage` here is the shared type used by the LOCAL
+//      `AgentRunner` trait below, not `trusty_agents_common::runner::AgentRunner`.
+// What: Re-exports the RBAC tier enum and the runner-context/history types.
+// Test: All existing `ServiceTier`/`RunContext`/`HistoryMessage` references in
+//       this crate resolve unchanged; `cargo test -p trusty-code` passes.
+pub use trusty_agents_common::ServiceTier;
+pub use trusty_agents_common::runner::{HistoryMessage, RunContext};
 
 use crate::tools::telemetry::ToolTelemetry;
 
@@ -166,25 +198,10 @@ impl ToolResult {
 }
 
 // ── ToolExecutor ─────────────────────────────────────────────────────────────
-
-/// Access tiers controlling which users/transports may invoke a tool.
-///
-/// Why: tcode exposes tools over multiple surfaces (CLI, API, TUI). Some tools
-/// (memory writes, shell exec) are unsafe for untrusted callers. `ServiceTier`
-/// provides a stable ladder that tools can declare their restrictions against.
-/// What: Ordered by trust level — `All` is the highest-privilege tier.
-/// Test: `rbac::tests::*` cover tier matching logic.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ServiceTier {
-    /// Trusted operator — full tool access.
-    #[default]
-    All,
-    /// Analytics/reporting callers — read-heavy, no mutations.
-    Analytics,
-    /// Read-only callers — can only observe state.
-    ReadOnly,
-}
+//
+// `ServiceTier` (access tiers controlling which users/transports may invoke a
+// tool) is re-exported from `trusty-agents-common` above (#2893) rather than
+// redeclared here.
 
 /// Object-safe executor interface for a single named tool.
 ///
@@ -218,26 +235,10 @@ pub trait ToolExecutor: Send + Sync {
 }
 
 // ── RunContext ───────────────────────────────────────────────────────────────
-
-/// Per-invocation context threaded from orchestrator to agent runner.
-///
-/// Why: Passing per-call directives (assigned file, turn budget, working dir)
-/// as a `RunContext` instead of via `std::env::set_var` is sound under
-/// multi-threaded tokio — env mutation is not thread-safe in Rust 2024.
-/// What: Carries optional overrides; runners apply them to child processes via
-/// `Command::env` / `Command::current_dir`.
-/// Test: Exercised in `AgentRunner` trait tests (`test_run_with_history_forwards_ctx`).
-#[derive(Debug, Default, Clone)]
-pub struct RunContext {
-    /// Path to scope any file-writing tool to for this call.
-    pub assigned_file: Option<PathBuf>,
-    /// Max-turns cap override for this invocation.
-    pub max_turns_override: Option<u32>,
-    /// Working directory for the subprocess.
-    pub working_dir: Option<PathBuf>,
-    /// LLM model override for this invocation.
-    pub model: Option<String>,
-}
+//
+// `RunContext` (per-invocation context threaded from orchestrator to agent
+// runner) is re-exported from `trusty-agents-common::runner` above (#2893)
+// rather than redeclared here — the two definitions were byte-identical.
 
 // ── AgentOutput ──────────────────────────────────────────────────────────────
 
@@ -350,18 +351,14 @@ pub trait AgentRunner: Send + Sync {
 }
 
 // ── HistoryMessage ───────────────────────────────────────────────────────────
-
-/// A prior conversation turn forwarded to persistent-session agents.
-///
-/// Why: Persistent-session runners replay history on each subprocess restart
-/// so the sub-agent preserves conversational context.
-/// What: `role` is `"user"` or `"assistant"`; `content` is the turn text.
-/// Test: Used in `AgentRunner::run_with_history` signature.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HistoryMessage {
-    pub role: String,
-    pub content: String,
-}
+//
+// `HistoryMessage` (a prior conversation turn forwarded to persistent-session
+// agents, used by `AgentRunner::run_with_history` below) is re-exported from
+// `trusty-agents-common::runner` above (#2893) rather than redeclared here —
+// tcode's fields (`role`, `content`) were a strict subset of the shared type
+// (which additionally derives `PartialEq`/`Eq` and adds `user()`/`assistant()`
+// constructors). Not to be confused with `crate::ipc::HistoryMessage`, a
+// separate NDJSON wire type for the PM<->sub-agent IPC protocol.
 
 // ── SearchProvider ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

tcode now depends on `trusty-agents-common` and re-exports its `ServiceTier`, `RunContext`, and `HistoryMessage` from `crates/trusty-code/src/tools/traits.rs` instead of redeclaring them — mirroring the pattern `trusty-agents` already uses (`crates/trusty-agents/src/tools/traits.rs:9-40`).

- `Cargo.toml`: adds `trusty-agents-common = { workspace = true }` (already a `[workspace.dependencies]` path dep, version `0.2.1`; no new dependency cycle — verified `trusty-agents-common` has no path back to `trusty-code`).
- `tools/traits.rs`: deletes the local `ServiceTier` enum, `RunContext` struct, and `HistoryMessage` struct; adds `pub use trusty_agents_common::ServiceTier;` and `pub use trusty_agents_common::runner::{HistoryMessage, RunContext};`.

Closes #2893. Refs #2892 (epic).

## What was deduped vs. kept local

**Verified byte-identical / strict-superset — deduped via re-export:**
- `ServiceTier` — identical 3 variants, identical serde attrs; shared version additionally derives `Hash` (superset, non-breaking).
- `RunContext` — identical 4 fields, identical types and derives.
- `HistoryMessage` — tcode's `{role, content}` was a strict field subset of the shared type (which adds `PartialEq`/`Eq` and `user()`/`assistant()` constructors). Confirmed `run_with_history` is only exercised by the trait's own regression test in this crate today (no production caller), so this re-export is zero-risk. Not to be confused with the separate `crate::ipc::HistoryMessage` IPC wire type, which is untouched.

**Investigated and kept LOCAL — divergent, not safe to force-dedupe:**
- `ToolExecutor` / `ToolResult` — tcode's `ToolResult::Success` carries a `telemetry: Option<Box<ToolTelemetry>>` field (#2862 UI Phase 1) that `trusty-agents-common::ToolResult` (a `Success(String)` tuple variant, no telemetry) lacks. `ToolTelemetry` itself depends on `crate::events::{SearchHit, RecalledMemory}` — tcode-specific event types not portable into `trusty-agents-common` without a much larger events-module move.
- `AgentRunner` / `AgentOutput` — tcode's `AgentOutput` carries a `finish_status: Option<FinishStatus>` field (#2683) that the shared `AgentOutput` lacks. Digging further: tcode's `AgentOutput.usage: crate::perf::TokenUsage` type *itself* carries an extra `cost_usd: Option<f64>` field (#50) beyond `trusty-agents-common::perf::TokenUsage` — and that field is live production data (`run_task/report.rs` sums `turn.usage.cost_usd` for cost reporting). The issue's "byte-identical" claim did not hold for `AgentOutput` once I traced the `TokenUsage` type transitively.

Extending either shared type is possible (the issue's own WRINKLE section anticipated the `ToolResult` case and offered an escape hatch: "if extending is too invasive, report the specific conflict before proceeding") but requires either type-erasure/generics in a trait shared with `trusty-agents` + `cto-assistant`, or moving tcode's events/perf machinery into `trusty-agents-common` — both real design decisions, and the `TokenUsage`/`AgentOutput` fix cascades into `crates/trusty-code/src/perf/` and `run_task/report.rs`, outside this PR's assigned scope (`tools/traits.rs` + `Cargo.toml` only, to avoid colliding with a sibling in-flight worktree touching `run_task/mod.rs`). Per the issue's own STOP condition, I did not force these two dedups. Full reasoning is captured in the module doc comment in `traits.rs`.

This still delivers the epic's keystone requirement — **tcode now depends on `trusty-agents-common`** — unblocking #2892's downstream work, while eliminating the two/three types that were genuinely safe to dedupe today.

## Verification (crate-scoped; `cargo test --workspace` intentionally not run — exceeds bash timeout)

```
cargo build -p trusty-code -p trusty-agents-common --all-targets
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 01s   (0 errors, 0 warnings)

cargo test -p trusty-code
test result: ok. 1095 passed; 0 failed; 4 ignored (lib)
+ all integration test binaries: ok (session_e2e, task_e2e, etc.)

cargo test -p trusty-agents-common
test result: ok. 249 passed; 0 failed (unaffected — no source changes in this crate)

cargo clippy -p trusty-code -p trusty-agents-common --all-targets -- -D warnings
Finished, 0 warnings

cargo fmt --check
exit 0, clean

bash scripts/check_line_cap.sh
line-cap: 9 allowlisted, 0 violations — OK.
```

Note: two `run_task::tests::*` tests flaked once on an unrelated environmental issue (a local `trusty-memory` RPC connection / stray `.trusty-search` index artifact from a prior run) — confirmed pre-existing by stashing this PR's changes and reproducing a *different* transient failure on the unmodified baseline. A clean re-run with this PR's changes applied passed all 1095 lib tests with 0 failures.

## Test plan

- [x] `cargo build -p trusty-code -p trusty-agents-common --all-targets`
- [x] `cargo test -p trusty-code` (1095 passed, 0 failed)
- [x] `cargo test -p trusty-agents-common` (249 passed, 0 failed)
- [x] `cargo clippy -p trusty-code -p trusty-agents-common --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`
- [x] `CHANGELOG.md` updated (`crates/trusty-code/CHANGELOG.md` — no source changes to `trusty-agents-common` in this PR, so no changelog entry needed there)

Not merging — leaving for code-critic review + green CI per PM workflow.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools