### PR TITLE
feat(trusty-code): register use_skill on the engineer registry (legacy run_task path)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Engineer receives `use_skill` on the `--legacy-in-process`/`run_task` path (#2942).** The `python-engineer` role's tool registry (`ProjectToolFactory` in `run_task/mod.rs`) now conditionally registers `UseSkillTool` alongside its other project tools when a `SkillResolver` is available, so the engineer can fetch a skill's full body mid-turn instead of relying solely on the catalog summary baked into its system prompt.
 - **Native skill discovery on the `--legacy-in-process`/bake-off `run-task` path (#2924).** The `use_skill` tool and the `.claude/skills/` catalog now reach the PM's prompt and tool registry on `run_task::execute_run_task`, not just the daemon/thin-client path — a PM run through `run-task` can now discover and load project skills the same way a daemon session already could.
 - **Embedded default agents & skills, disk-first with embedded fallback
   (#2895).** A project with no `.claude/agents/` and/or `.claude/skills/`

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -289,12 +289,16 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     let skills_catalog = daily_driver_skills_catalog(&params.project);
 
     // Build the engineer runner, scoped to the project working dir, sharing the
-    // transcript (engineer turns are tagged "python-engineer").
+    // transcript (engineer turns are tagged "python-engineer"). The full
+    // `(catalog, resolver)` pair is threaded through (rather than just the
+    // catalog string) so `ProjectToolFactory` can register `use_skill` against
+    // the SAME resolver instance the catalog was rendered from (experimental,
+    // refs #2892).
     let engineer_runner = build_engineer_runner(
         wrap_with_debug_capture(Arc::clone(&llm), ENGINEER_AGENT_NAME, debug_sink.as_ref()),
         &params,
         project_context.clone(),
-        skills_catalog.as_ref().map(|(catalog, _)| catalog.clone()),
+        skills_catalog.clone(),
         Arc::clone(&transcript),
         deadline_secs,
         redelegation_signal.clone(),
@@ -462,19 +466,23 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
 /// What: Returns an `Arc<dyn AgentRunner>` the `DelegateToAgentTool` dispatches
 /// to. The engineer's own LLM turns are recorded under the "python-engineer" role.
 /// `redelegation_signal` is shared with `assemble_report` via the caller.
-/// `skills_catalog` (#2924) is the same rendered metadata catalog the PM's own
-/// prompt gets, threaded through so the delegated engineer's DailyDriver
-/// prompt also sees it — mirrors `task::executor::build_engineer_runner`,
-/// including that wiring the `use_skill` *tool* into the engineer's own
-/// per-delegation registry (`ProjectToolFactory::build`) is deliberately
-/// deferred, exactly as the daemon path defers it.
+/// `skills_catalog` (#2924) is the same rendered `(catalog, resolver)` pair the
+/// PM's own prompt/registry are built from, threaded through so the delegated
+/// engineer's DailyDriver prompt also sees the catalog text AND — as of this
+/// experimental change (refs #2892) — so `ProjectToolFactory` can register
+/// `use_skill` against the SAME resolver instance, rather than a second,
+/// independently-constructed one. This is a deliberate divergence from
+/// `task::executor::build_engineer_runner`, which still defers wiring
+/// `use_skill` into the engineer's own per-delegation registry; see that
+/// function's docs for the daemon path's reasoning.
 /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer`,
-/// `run_task::tests::use_skill_on_legacy_path_reaches_pm_and_transcript`.
+/// `run_task::tests::use_skill_on_legacy_path_reaches_pm_and_transcript`,
+/// `run_task::tests::use_skill_on_legacy_path_reaches_engineer_and_transcript`.
 fn build_engineer_runner(
     llm: Arc<dyn LlmClientTrait>,
     params: &RunTaskParams,
     project_context: Option<String>,
-    skills_catalog: Option<String>,
+    skills_catalog: Option<(String, Arc<dyn SkillResolver>)>,
     transcript: SharedTranscript,
     deadline_secs: u64,
     redelegation_signal: RedelegationCapSignal,
@@ -487,6 +495,9 @@ fn build_engineer_runner(
 
     let factory: Arc<dyn RegistryFactory> = Arc::new(ProjectToolFactory {
         project: params.project.clone(),
+        skill_resolver: skills_catalog
+            .as_ref()
+            .map(|(_, resolver)| Arc::clone(resolver)),
     });
 
     let mut runner = InProcessAgentRunner::new(engineer_llm, factory, params.agents_dir.clone())
@@ -498,7 +509,7 @@ fn build_engineer_runner(
     if let Some(ctx) = project_context {
         runner = runner.with_project_context(ctx);
     }
-    if let Some(catalog) = skills_catalog {
+    if let Some((catalog, _)) = skills_catalog {
         runner = runner.with_skills_catalog(catalog);
     }
     let pinned = apply_engineer_model_override(Arc::new(runner), params);
@@ -517,14 +528,23 @@ fn build_engineer_runner(
 /// `write_files` (#2681 batch write), `edit`, the `glob`/`grep`/`list_dir`
 /// exploration tools (#1027), and `bash` all scoped to `self.project`, so the
 /// engineer operates only inside the project working tree; `finish_task` has no
-/// filesystem footprint and needs no scoping.
+/// filesystem footprint and needs no scoping. `skill_resolver` (experimental,
+/// refs #2892) is the SAME `Arc<dyn SkillResolver>` the PM's own `use_skill`
+/// tool and the rendered catalog were built from — `None` when
+/// `daily_driver_skills_catalog` found no project skills, mirroring the PM's
+/// own conditional registration in `execute_run_task`.
 /// What: Implements `RegistryFactory::build`, returning an `Arc<ToolRegistry>`
 /// with every tool; the runner then gates them by the engineer's
-/// `tools.allowed`.
+/// `tools.allowed`. When `skill_resolver` is `Some`, `use_skill` is registered
+/// too, so the delegated engineer can lazily fetch a skill's full body on
+/// demand, the same way the PM already can (#2924).
 /// Test: `run_task::tests::end_to_end_pm_delegates_to_engineer` (the engineer's
-/// `write_file` actually writes into the project).
+/// `write_file` actually writes into the project);
+/// `run_task::tests::use_skill_on_legacy_path_reaches_engineer_and_transcript`
+/// (the engineer's `use_skill` registration and invocation).
 struct ProjectToolFactory {
     project: PathBuf,
+    skill_resolver: Option<Arc<dyn SkillResolver>>,
 }
 
 #[async_trait]
@@ -558,6 +578,12 @@ impl RegistryFactory for ProjectToolFactory {
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),
         )));
         reg.register(Arc::new(FinishTaskTool::new()));
+        // Experimental (refs #2892): mirrors the PM's own conditional
+        // `use_skill` registration in `execute_run_task` — only when a skill
+        // catalog actually resolved for this project.
+        if let Some(resolver) = &self.skill_resolver {
+            reg.register(Arc::new(UseSkillTool::new(Arc::clone(resolver))));
+        }
         Arc::new(reg)
     }
 }

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -22,8 +22,10 @@ use tempfile::TempDir;
 
 use super::{ExitCode, RedelegationCapSignal, RunTaskParams, execute_run_task};
 use crate::agent_loop::AgentLoopError;
+use crate::agents::AgentConfig;
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
-use crate::tools::{AgentOutput, EngineerCompletionSignal};
+use crate::runner::RegistryFactory;
+use crate::tools::{AgentOutput, EngineerCompletionSignal, RunContext};
 
 // ── Scripted offline LLM ───────────────────────────────────────────────────────
 
@@ -1752,5 +1754,48 @@ async fn use_skill_on_legacy_path_reaches_engineer_and_transcript() {
         "some \"python-engineer\" TurnRecord.tool_calls must contain \"use_skill\"; \
          transcript was: {:?}",
         report.transcript
+    );
+}
+
+/// Negative counterpart to `use_skill_on_legacy_path_reaches_engineer_and_transcript`
+/// (code-critic finding on PR #2943): asserts the ELSE branch of
+/// `ProjectToolFactory::build` — when `skill_resolver` is `None`, the
+/// engineer's advertised registry must NOT include `use_skill`.
+///
+/// Why: the positive test above proves `Some(resolver)` registers `use_skill`;
+/// nothing asserted the inverse. Driving this end-to-end via `execute_run_task`
+/// is impractical/flaky here because the #2895 embedded-skill fallback (see
+/// `skills::mod`'s `FsSkillResolver`/`format_skill_catalog` docs) makes
+/// `daily_driver_skills_catalog` resolve a non-empty catalog for almost any
+/// real project directory, so `skill_resolver` is virtually never `None` on
+/// the full end-to-end path. Constructing `ProjectToolFactory` directly and
+/// calling `RegistryFactory::build` is the clean, direct way to exercise the
+/// `None` branch in isolation without fighting that fallback.
+/// What: builds a `ProjectToolFactory` with `skill_resolver: None` against an
+/// empty project tempdir, calls `.build()` with default `AgentConfig`/
+/// `RunContext`, and asserts the resulting `ToolRegistry` does not contain
+/// `"use_skill"`, while sanity-checking a known-always-present tool
+/// (`"finish_task"`) IS present — guarding against a broken/empty registry
+/// vacuously satisfying the absence assertion.
+/// Test: this test.
+#[tokio::test]
+async fn use_skill_absent_from_engineer_when_no_skills() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let factory = super::ProjectToolFactory {
+        project: project.path().to_path_buf(),
+        skill_resolver: None,
+    };
+
+    let registry = factory
+        .build(&AgentConfig::default(), &RunContext::default())
+        .await;
+
+    assert!(
+        !registry.contains("use_skill"),
+        "engineer registry must NOT advertise use_skill when skill_resolver is None"
+    );
+    assert!(
+        registry.contains("finish_task"),
+        "sanity check: registry should still contain other always-present tools"
     );
 }

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -93,6 +93,19 @@ impl ScriptedLlm {
             .cloned()
             .expect("at least one request recorded")
     }
+
+    /// The tool-schema names advertised on the request at `idx` (0-based, call
+    /// order) — lets a test reach a non-first turn's advertised schema, e.g.
+    /// the delegated engineer's first turn (request idx 1, right after the
+    /// PM's own delegate call at idx 0).
+    fn tool_names_at(&self, idx: usize) -> Vec<String> {
+        self.tool_names
+            .lock()
+            .expect("tool_names lock")
+            .get(idx)
+            .cloned()
+            .unwrap_or_else(|| panic!("no request recorded at idx {idx}"))
+    }
 }
 
 #[async_trait]
@@ -1679,6 +1692,65 @@ async fn use_skill_on_legacy_path_reaches_pm_and_transcript() {
     assert!(
         saw_use_skill,
         "some TurnRecord.tool_calls must contain \"use_skill\"; transcript was: {:?}",
+        report.transcript
+    );
+}
+
+/// Experimental (refs #2892): the delegated ENGINEER's own per-delegation
+/// registry (`ProjectToolFactory::build`) now also registers `use_skill`,
+/// backed by the SAME resolver the PM's catalog/tool were built from —
+/// mirrors `use_skill_on_legacy_path_reaches_pm_and_transcript` above, but
+/// scripts the ENGINEER (not the PM) to be the one that calls `use_skill`.
+///
+/// Why: before this change, only the PM could fetch a skill's full body on
+/// this legacy/bake-off CLI path; the delegated engineer received the
+/// catalog text in its prompt (`build_engineer_runner`'s
+/// `.with_skills_catalog`) but had no tool to act on it.
+/// What: seeds a project with `.claude/skills/demo/SKILL.md`; scripts
+/// [PM delegate, engineer use_skill, engineer stop, PM stop]. Asserts (1) the
+/// tool schema advertised on the engineer's first request (call idx 1, right
+/// after the PM's own delegate call at idx 0) includes `"use_skill"`, and (2)
+/// some `TurnRecord` tagged `"python-engineer"` has a `tool_calls` entry for
+/// `"use_skill"`.
+/// Test: this test.
+#[tokio::test]
+async fn use_skill_on_legacy_path_reaches_engineer_and_transcript() {
+    let agents = agents_dir("openai/gpt-4o-mini");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let skills_dir = project.path().join(".claude").join("skills").join("demo");
+    std::fs::create_dir_all(&skills_dir).expect("mkdir skill dir");
+    std::fs::write(
+        skills_dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: Demo skill\n---\nfull demo body\n",
+    )
+    .expect("write SKILL.md");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        delegate_response("use the demo skill"),
+        use_skill_response("demo"),
+        stop_response("engineer: loaded the demo skill"),
+        stop_response("pm: task complete"),
+    ]));
+
+    let report = execute_run_task(params(&agents, &project, None), llm.clone()).await;
+
+    // The engineer's own registry (advertised on its first request, idx 1 —
+    // idx 0 is the PM's delegate_to_agent turn) must include use_skill.
+    let names = llm.tool_names_at(1);
+    assert!(
+        names.contains(&"use_skill".to_string()),
+        "engineer registry must advertise use_skill when a skill catalog resolves; got {names:?}"
+    );
+
+    // The recorded transcript must show the ENGINEER (not just the PM)
+    // actually calling use_skill.
+    let saw_engineer_use_skill = report.transcript.iter().any(|turn| {
+        turn.role == "python-engineer" && turn.tool_calls.iter().any(|name| name == "use_skill")
+    });
+    assert!(
+        saw_engineer_use_skill,
+        "some \"python-engineer\" TurnRecord.tool_calls must contain \"use_skill\"; \
+         transcript was: {:?}",
         report.transcript
     );
 }


### PR DESCRIPTION
Promotes the validated experiment: gives the ENGINEER (python-engineer role) the use_skill tool on the --legacy-in-process path. PR #2925 gave it only to the PM, but the PM delegates all coding, so use_skill fired 0x in run-21. With this change the engineer fired use_skill 3x unprompted in an experimental L4 run (run-22, this commit) — confirming the tool-holder was the blocker.

## Change (crates/trusty-code/src/run_task/mod.rs)
- execute_run_task passes the full (String, Arc<dyn SkillResolver>) skills-catalog tuple into build_engineer_runner.
- build_engineer_runner threads the resolver into a new skill_resolver field on ProjectToolFactory.
- ProjectToolFactory::build conditionally registers UseSkillTool for the engineer when a resolver is present (mirrors the PM conditional; no skills => no tool).
- Daemon path (task/executor.rs) deliberately NOT mirrored (HarnessMode/Parity byte-identical-surface gating).

## Tests / gates
- New unit test: use_skill_on_legacy_path_reaches_engineer_and_transcript (engineer schema advertises use_skill + a python-engineer TurnRecord calls it).
- Scoped gate green: build, 1096 tests, clippy, fmt, line-cap (run_task/mod.rs 420/500 SLOC).

## Validation
L4 run-22, bedrock/claude-sonnet-4-6, legacy-in-process: 9/9 tests, engineer fired use_skill 3x (turns 4-5), PM 0x.

Closes #2942
Refs #2892