### PR TITLE
fix(trusty-gworkspace): MCP server self-refresh fallback to oauth_client.json + stale project-token-shadow warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11103,6 +11103,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11108,6 +11108,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tracing-test",
  "trusty-common",
  "uuid",
 ]

--- a/crates/trusty-gworkspace/CHANGELOG.md
+++ b/crates/trusty-gworkspace/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+## [Unreleased]
+
+### Fixed
+
+- MCP server self-refresh in tm-managed sessions — `OAuthManager::from_env()`
+  previously returned `None` (refresh disabled) whenever
+  `GOOGLE_OAUTH_CLIENT_ID`/`GOOGLE_OAUTH_CLIENT_SECRET` env vars were absent,
+  which is every tm-managed session; every such session's access token
+  therefore 401'd against Google roughly an hour after each re-auth with no
+  self-healing. `from_env()` now falls back to
+  `~/.gworkspace-mcp/oauth_client.json` (the same source `setup`/`doctor`
+  already read, via the shared `resolve_client_creds` helper) when the env
+  vars are absent; env vars still win when present. Logs a warning (instead
+  of failing silently) only when neither source yields credentials, closes
+  #2946.
+- stale project-level token shadowing now warns — `TokenStorage::load()`'s
+  documented project-overrides-user precedence is unchanged, but when a
+  project-level `<cwd>/.gworkspace-mcp/tokens.json` entry is expired while
+  the user-level entry it shadows for the same profile is still valid, a
+  loud warning now names both paths instead of silently serving the stale
+  override forever.

--- a/crates/trusty-gworkspace/CHANGELOG.md
+++ b/crates/trusty-gworkspace/CHANGELOG.md
@@ -24,5 +24,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   documented project-overrides-user precedence is unchanged, but when a
   project-level `<cwd>/.gworkspace-mcp/tokens.json` entry is expired while
   the user-level entry it shadows for the same profile is still valid, a
-  loud warning now names both paths instead of silently serving the stale
-  override forever.
+  structured warning now names both paths instead of silently serving the
+  stale override forever. `load()` is on the per-request hot path
+  (`BaseClient::get_access_token` calls it on every MCP tool invocation, plus
+  again on 401 retry), so the warning is throttled to at most once per
+  profile per process rather than repeating on every call.

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -29,3 +29,9 @@ tracing = { workspace = true }
 dirs = { workspace = true }
 clap = { workspace = true }
 open = { workspace = true }
+
+[dev-dependencies]
+# serial_test: env-mutating tests (HOME override for oauth_client.json
+# fallback resolution) must run serially to avoid races across parallel
+# test threads.
+serial_test = { workspace = true }

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -35,3 +35,8 @@ open = { workspace = true }
 # fallback resolution) must run serially to avoid races across parallel
 # test threads.
 serial_test = { workspace = true }
+# tracing-test: captures real tracing::warn! emissions for the
+# stale-project-token-shadow throttling tests (storage.rs). Not in
+# [workspace.dependencies]; pinned locally, matching the existing
+# trusty-git-analytics precedent.
+tracing-test = "0.2"

--- a/crates/trusty-gworkspace/src/api/auth/manager.rs
+++ b/crates/trusty-gworkspace/src/api/auth/manager.rs
@@ -16,9 +16,11 @@
 use anyhow::{Context, Result, anyhow};
 use chrono::{Duration, Utc};
 use serde::Deserialize;
+use tracing::warn;
 
 use super::models::{OAuthToken, StoredToken};
 use super::oauth::errors::{redact_token_response, refresh_failure_message};
+use super::oauth::resolve_client_creds;
 use super::storage::TokenStorage;
 use crate::api::constants::OAUTH_TOKEN_URL;
 
@@ -39,9 +41,12 @@ struct GoogleTokenResponse {
 ///
 /// Why: Encapsulates Google's OAuth client credentials so `BaseClient` only
 /// needs to call one method to get a fresh token.
-/// What: Reads `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` env
-/// vars on construction. `refresh` performs the HTTP exchange.
-/// Test: Construction is covered by `from_env_returns_none_when_missing`.
+/// What: Resolves `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` env
+/// vars first, falling back to `~/.gworkspace-mcp/oauth_client.json` (see
+/// `from_env`), on construction. `refresh` performs the HTTP exchange.
+/// Test: Construction is covered by `from_env_falls_back_to_oauth_client_json`,
+/// `from_env_returns_none_when_both_absent`, and
+/// `from_env_prefers_env_vars_over_file`.
 pub struct OAuthManager {
     http: reqwest::Client,
     client_id: String,
@@ -49,18 +54,38 @@ pub struct OAuthManager {
 }
 
 impl OAuthManager {
-    /// Construct from env vars, returning `Ok(None)` when both are absent
-    /// (read-only token mode — refresh disabled).
+    /// Construct from env vars, falling back to `oauth_client.json` on disk.
+    ///
+    /// Why: Issue #2946 — no tm-managed session sets
+    /// `GOOGLE_OAUTH_CLIENT_ID`/`SECRET`, so `from_env` previously always
+    /// returned `None` there, silently disabling self-refresh: every
+    /// tm-managed MCP server ran read-only-token mode and 401'd on Google
+    /// once the access token expired (~1h). `setup`/`doctor` already resolve
+    /// client credentials with an env-first, file-fallback strategy via
+    /// `resolve_client_creds`; reusing it here (rather than duplicating the
+    /// parse logic) gives the refresh path the same fallback for free.
+    /// What: Delegates to [`resolve_client_creds`] (env vars win when
+    /// present, else reads `~/.gworkspace-mcp/oauth_client.json`). Returns
+    /// `Ok(None)` — with a warning logged — only when neither source yields
+    /// credentials (read-only token mode: refresh disabled).
+    /// Test: `from_env_falls_back_to_oauth_client_json`,
+    /// `from_env_returns_none_when_both_absent`,
+    /// `from_env_prefers_env_vars_over_file`.
     pub fn from_env() -> Result<Option<Self>> {
-        let id = std::env::var("GOOGLE_OAUTH_CLIENT_ID").ok();
-        let secret = std::env::var("GOOGLE_OAUTH_CLIENT_SECRET").ok();
-        match (id, secret) {
-            (Some(client_id), Some(client_secret)) => Ok(Some(Self {
+        match resolve_client_creds() {
+            Ok(creds) => Ok(Some(Self {
                 http: reqwest::Client::new(),
-                client_id,
-                client_secret,
+                client_id: creds.client_id,
+                client_secret: creds.client_secret,
             })),
-            _ => Ok(None),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "no OAuth client credentials found (env vars or oauth_client.json); \
+                     token refresh disabled — expired tokens will not self-refresh"
+                );
+                Ok(None)
+            }
         }
     }
 
@@ -132,5 +157,133 @@ impl OAuthManager {
         storage.save(&all)?;
 
         Ok(new_token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::path::PathBuf;
+
+    /// Env vars mutated by the fallback tests below; captured/restored as a
+    /// group so a panic mid-test never leaks a fake `HOME` or client id into
+    /// later tests.
+    const MUTATED_ENV_VARS: &[&str] = &[
+        "HOME",
+        "GOOGLE_OAUTH_CLIENT_ID",
+        "GOOGLE_OAUTH_CLIENT_SECRET",
+    ];
+
+    /// RAII guard that snapshots and restores a fixed set of env vars, even
+    /// on panic.
+    ///
+    /// Why: `from_env`'s fallback path reads `HOME` (via `dirs::home_dir`)
+    /// indirectly through `resolve_client_creds`; testing it in-process means
+    /// mutating real process env state, which must never leak across tests
+    /// (issue #2946 fallback tests run `#[serial]` for the same reason).
+    /// What: Captures each var's current value on construction; `Drop`
+    /// restores it (`set_var` if it was present, `remove_var` if absent).
+    /// Test: exercised by every test in this module — a leaked var would
+    /// make a later, unrelated test flaky.
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn capture(vars: &[&'static str]) -> Self {
+            let saved = vars.iter().map(|&v| (v, std::env::var(v).ok())).collect();
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.saved {
+                // SAFETY: every caller of `EnvGuard` runs under `#[serial]`,
+                // so no other thread reads/writes these vars concurrently.
+                match v {
+                    Some(val) => unsafe { std::env::set_var(k, val) },
+                    None => unsafe { std::env::remove_var(k) },
+                }
+            }
+        }
+    }
+
+    /// Build a fresh temp dir with a `.gworkspace-mcp/` subdir, never
+    /// touching the real `~/.gworkspace-mcp`.
+    fn fresh_temp_home(label: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("gw-manager-{label}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(dir.join(".gworkspace-mcp")).expect("mkdir temp home");
+        dir
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_falls_back_to_oauth_client_json() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        // SAFETY: serialised via #[serial]; EnvGuard restores on drop.
+        unsafe {
+            std::env::remove_var("GOOGLE_OAUTH_CLIENT_ID");
+            std::env::remove_var("GOOGLE_OAUTH_CLIENT_SECRET");
+        }
+        let home = fresh_temp_home("fallback");
+        std::fs::write(
+            home.join(".gworkspace-mcp").join("oauth_client.json"),
+            r#"{"client_id":"file-id","client_secret":"file-secret"}"#,
+        )
+        .expect("write oauth_client.json");
+        // SAFETY: see above.
+        unsafe { std::env::set_var("HOME", &home) };
+
+        let mgr = OAuthManager::from_env()
+            .expect("from_env should not error")
+            .expect("oauth_client.json fallback should enable refresh");
+        assert_eq!(mgr.client_id, "file-id");
+        assert_eq!(mgr.client_secret, "file-secret");
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_returns_none_when_both_absent() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        // SAFETY: see EnvGuard doc.
+        unsafe {
+            std::env::remove_var("GOOGLE_OAUTH_CLIENT_ID");
+            std::env::remove_var("GOOGLE_OAUTH_CLIENT_SECRET");
+        }
+        let home = fresh_temp_home("absent");
+        // SAFETY: see EnvGuard doc.
+        unsafe { std::env::set_var("HOME", &home) };
+
+        let mgr = OAuthManager::from_env().expect("from_env should not error (warn, not error)");
+        assert!(
+            mgr.is_none(),
+            "refresh must stay disabled with neither env vars nor oauth_client.json present"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_prefers_env_vars_over_file() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        let home = fresh_temp_home("precedence");
+        std::fs::write(
+            home.join(".gworkspace-mcp").join("oauth_client.json"),
+            r#"{"client_id":"file-id","client_secret":"file-secret"}"#,
+        )
+        .expect("write oauth_client.json");
+        // SAFETY: see EnvGuard doc.
+        unsafe {
+            std::env::set_var("HOME", &home);
+            std::env::set_var("GOOGLE_OAUTH_CLIENT_ID", "env-id");
+            std::env::set_var("GOOGLE_OAUTH_CLIENT_SECRET", "env-secret");
+        }
+
+        let mgr = OAuthManager::from_env()
+            .expect("from_env should not error")
+            .expect("env vars should enable refresh");
+        assert_eq!(mgr.client_id, "env-id", "env vars must win over the file");
+        assert_eq!(mgr.client_secret, "env-secret");
     }
 }

--- a/crates/trusty-gworkspace/src/api/auth/storage.rs
+++ b/crates/trusty-gworkspace/src/api/auth/storage.rs
@@ -4,13 +4,18 @@
 //! CLI (which performs the interactive OAuth flow) and this Rust MCP server.
 //! What: Reads/writes a `HashMap<profile_name, StoredToken>` JSON object.
 //! Two-tier lookup: project-level `./.gworkspace-mcp/tokens.json` first,
-//! then `~/.gworkspace-mcp/tokens.json`.
+//! then `~/.gworkspace-mcp/tokens.json`. `load()` warns loudly (without
+//! changing the override contract) when a project-level entry shadowing a
+//! profile is expired while the user-level entry it hides is still valid
+//! (issue #2946 — a stale worktree-local override otherwise silently wins
+//! and re-poisons `save()` on every re-auth).
 //! Test: see integration test `tests/auth_models.rs`.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use tracing::warn;
 
 use super::models::StoredToken;
 use crate::api::constants::DEFAULT_PROFILE;
@@ -76,10 +81,39 @@ impl TokenStorage {
     }
 
     /// Load merged tokens: user-level base, project-level overrides.
+    ///
+    /// Why: Preserves the documented override contract (project always wins
+    /// per profile key) so existing project-scoped setups keep working
+    /// unchanged. But a project override that is itself stale — e.g. minted
+    /// once inside a worktree and never refreshed since — silently wins over
+    /// a healthy user-level token and recreates the exact 401 loop from
+    /// issue #2946 with no signal to the operator. This surfaces that case
+    /// loudly instead of staying silent, without touching precedence.
+    /// What: Merges project-level entries over user-level per profile key;
+    /// before merging, logs a `tracing::warn!` (via
+    /// [`stale_shadow_warning`]) for every profile where the project-level
+    /// entry is expired while the user-level entry it shadows is not.
+    /// Test: `load_warns_when_project_shadow_is_stale` (log emission is
+    /// exercised via `stale_shadow_warning` directly — see its own tests —
+    /// plus `load_still_prefers_project_override_after_warning` for the
+    /// unchanged-precedence contract).
     pub fn load(&self) -> Result<HashMap<String, StoredToken>> {
         let mut merged = Self::load_from(&self.user_path).unwrap_or_default();
-        if let Some(p) = &self.project_path {
-            let project_tokens = Self::load_from(p).unwrap_or_default();
+        if let Some(project_path) = &self.project_path {
+            let project_tokens = Self::load_from(project_path).unwrap_or_default();
+            for (profile, project_token) in &project_tokens {
+                if let Some(user_token) = merged.get(profile)
+                    && let Some(msg) = stale_shadow_warning(
+                        profile,
+                        project_token,
+                        user_token,
+                        project_path,
+                        &self.user_path,
+                    )
+                {
+                    warn!("{msg}");
+                }
+            }
             merged.extend(project_tokens);
         }
         Ok(merged)
@@ -166,6 +200,45 @@ impl TokenStorage {
     }
 }
 
+/// Build a warning message when a project-level token entry shadows a
+/// user-level one for the same profile while itself being stale.
+///
+/// Why: Isolated as a pure predicate/formatter (no I/O, no logging) so the
+/// exact condition and wording are directly unit-testable without a temp
+/// filesystem — mirrors the `refresh_failure_message` pattern in
+/// `oauth::errors`.
+/// What: Returns `Some(message)` naming both paths and both `expires_at`
+/// timestamps when `project` is expired and `user` is not; `None` in every
+/// other case (both fresh, both stale, or the project entry is the fresher
+/// one) — those cases are not the silent-stale-shadow failure mode this
+/// guards against.
+/// Test: `warns_when_project_stale_and_user_fresh`,
+/// `no_warning_when_both_fresh`, `no_warning_when_both_stale`,
+/// `no_warning_when_project_is_fresher`.
+fn stale_shadow_warning(
+    profile: &str,
+    project: &StoredToken,
+    user: &StoredToken,
+    project_path: &Path,
+    user_path: &Path,
+) -> Option<String> {
+    if project.token.is_expired() && !user.token.is_expired() {
+        Some(format!(
+            "profile '{profile}': project-level tokens.json override at {} is EXPIRED \
+             (expires_at={}) but shadows a valid user-level token at {} (expires_at={}) — \
+             serving the STALE override per the documented project-overrides-user contract. \
+             Run setup from this directory, or remove {} to fall through to the fresher token.",
+            project_path.display(),
+            project.token.expires_at,
+            user_path.display(),
+            user.token.expires_at,
+            project_path.display(),
+        ))
+    } else {
+        None
+    }
+}
+
 impl Default for TokenStorage {
     fn default() -> Self {
         Self::new()
@@ -238,5 +311,115 @@ mod tests {
             Some("user@example.com")
         );
         assert!(loaded["primary"].metadata.is_default);
+    }
+
+    /// Build a `StoredToken` expiring `expires_in_secs` from now (negative =
+    /// already expired) for the stale-shadow-warning tests below.
+    fn make_stored(expires_in_secs: i64) -> StoredToken {
+        StoredToken {
+            version: 1,
+            metadata: crate::api::auth::models::TokenMetadata {
+                service_name: "test".into(),
+                provider: "google".into(),
+                created_at: chrono::Utc::now(),
+                last_refreshed: None,
+                email: Some("user@example.com".into()),
+                is_default: false,
+            },
+            token: crate::api::auth::models::OAuthToken {
+                access_token: "a".into(),
+                refresh_token: Some("r".into()),
+                expires_at: chrono::Utc::now() + chrono::Duration::seconds(expires_in_secs),
+                scopes: vec!["openid".into()],
+                token_type: "Bearer".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn warns_when_project_stale_and_user_fresh() {
+        let project = make_stored(-3600);
+        let user = make_stored(3600);
+        let msg = stale_shadow_warning(
+            "work",
+            &project,
+            &user,
+            Path::new("/proj/.gworkspace-mcp/tokens.json"),
+            Path::new("/home/user/.gworkspace-mcp/tokens.json"),
+        )
+        .expect("must warn: project stale, user fresh");
+        assert!(msg.contains("work"));
+        assert!(msg.contains("/proj/.gworkspace-mcp/tokens.json"));
+        assert!(msg.contains("/home/user/.gworkspace-mcp/tokens.json"));
+        assert!(msg.contains("EXPIRED"));
+    }
+
+    #[test]
+    fn no_warning_when_both_fresh() {
+        let project = make_stored(3600);
+        let user = make_stored(7200);
+        assert!(
+            stale_shadow_warning("work", &project, &user, Path::new("p"), Path::new("u")).is_none()
+        );
+    }
+
+    #[test]
+    fn no_warning_when_both_stale() {
+        // Both stale is not the silent-shadow failure mode — the caller gets
+        // an expired token either way, so no extra signal is needed here.
+        let project = make_stored(-3600);
+        let user = make_stored(-7200);
+        assert!(
+            stale_shadow_warning("work", &project, &user, Path::new("p"), Path::new("u")).is_none()
+        );
+    }
+
+    #[test]
+    fn no_warning_when_project_is_fresher() {
+        let project = make_stored(3600);
+        let user = make_stored(-3600);
+        assert!(
+            stale_shadow_warning("work", &project, &user, Path::new("p"), Path::new("u")).is_none()
+        );
+    }
+
+    #[test]
+    fn load_still_prefers_project_override_after_warning() {
+        // Regression guard for the precedence contract: this fix only adds a
+        // warning, it does not change which entry wins (see PR body) — a
+        // stale project override must still be served, just noisily.
+        let dir = std::env::temp_dir().join(format!("gw-storage-shadow-{}", uuid::Uuid::new_v4()));
+        let user_dir = dir.join("user");
+        let project_dir = dir.join("project");
+        std::fs::create_dir_all(&user_dir).unwrap();
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let user_path = user_dir.join("tokens.json");
+        let project_path = project_dir.join("tokens.json");
+
+        let mut user_tokens = HashMap::new();
+        user_tokens.insert("work".to_string(), make_stored(3600));
+        std::fs::write(&user_path, serde_json::to_string(&user_tokens).unwrap()).unwrap();
+
+        let mut project_tokens = HashMap::new();
+        let mut stale = make_stored(-3600);
+        stale.token.access_token = "stale-access-token".into();
+        project_tokens.insert("work".to_string(), stale);
+        std::fs::write(
+            &project_path,
+            serde_json::to_string(&project_tokens).unwrap(),
+        )
+        .unwrap();
+
+        let storage = TokenStorage {
+            user_path,
+            project_path: Some(project_path),
+        };
+
+        let loaded = storage.load().unwrap();
+        assert_eq!(
+            loaded["work"].token.access_token, "stale-access-token",
+            "project override must still win per the documented contract \
+             (warn, don't change precedence)"
+        );
     }
 }

--- a/crates/trusty-gworkspace/src/api/auth/storage.rs
+++ b/crates/trusty-gworkspace/src/api/auth/storage.rs
@@ -11,10 +11,12 @@
 //! and re-poisons `save()` on every re-auth).
 //! Test: see integration test `tests/auth_models.rs`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
 use tracing::warn;
 
 use super::models::StoredToken;
@@ -25,12 +27,15 @@ use crate::api::constants::DEFAULT_PROFILE;
 /// Why: Matches Python `TokenStorage` semantics — project-level overrides
 /// user-level, while user-level is the durable fallback.
 /// What: Holds the user-level path (always `~/.gworkspace-mcp/tokens.json`)
-/// and an optional project-level path (`./.gworkspace-mcp/tokens.json`).
+/// and an optional project-level path (`./.gworkspace-mcp/tokens.json`), plus
+/// a `warned_stale_shadows` set throttling the stale-shadow warning in
+/// [`TokenStorage::load`] to once per profile per process (see its doc).
 /// Test: integration test reads a temp file.
 #[derive(Debug, Clone)]
 pub struct TokenStorage {
     user_path: PathBuf,
     project_path: Option<PathBuf>,
+    warned_stale_shadows: Arc<Mutex<HashSet<String>>>,
 }
 
 impl TokenStorage {
@@ -58,6 +63,7 @@ impl TokenStorage {
         Self {
             user_path,
             project_path,
+            warned_stale_shadows: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -66,6 +72,7 @@ impl TokenStorage {
         Self {
             user_path: path,
             project_path: None,
+            warned_stale_shadows: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -88,35 +95,85 @@ impl TokenStorage {
     /// once inside a worktree and never refreshed since — silently wins over
     /// a healthy user-level token and recreates the exact 401 loop from
     /// issue #2946 with no signal to the operator. This surfaces that case
-    /// loudly instead of staying silent, without touching precedence.
+    /// loudly instead of staying silent, without touching precedence. `load`
+    /// sits on the per-request hot path (`BaseClient::get_access_token` calls
+    /// it via `get_profile`/`get_default` on every MCP tool invocation, plus
+    /// again on the 401-retry path), so the warning is throttled to once per
+    /// profile per process by [`TokenStorage::warn_stale_shadow_once`]
+    /// (PR #2949 review) — otherwise a persistent stale shadow would repeat
+    /// the multi-line warning on every single call.
     /// What: Merges project-level entries over user-level per profile key;
-    /// before merging, logs a `tracing::warn!` (via
-    /// [`stale_shadow_warning`]) for every profile where the project-level
-    /// entry is expired while the user-level entry it shadows is not.
-    /// Test: `load_warns_when_project_shadow_is_stale` (log emission is
-    /// exercised via `stale_shadow_warning` directly — see its own tests —
-    /// plus `load_still_prefers_project_override_after_warning` for the
-    /// unchanged-precedence contract).
+    /// before merging, warns (at most once per profile) for every profile
+    /// where the project-level entry is expired while the user-level entry
+    /// it shadows is not.
+    /// Test: `load_warns_when_project_shadow_is_stale` (warning fires),
+    /// `load_does_not_rewarn_on_second_load` (throttled to once), plus
+    /// `load_still_prefers_project_override_after_warning` for the
+    /// unchanged-precedence contract.
     pub fn load(&self) -> Result<HashMap<String, StoredToken>> {
         let mut merged = Self::load_from(&self.user_path).unwrap_or_default();
         if let Some(project_path) = &self.project_path {
             let project_tokens = Self::load_from(project_path).unwrap_or_default();
             for (profile, project_token) in &project_tokens {
-                if let Some(user_token) = merged.get(profile)
-                    && let Some(msg) = stale_shadow_warning(
-                        profile,
-                        project_token,
-                        user_token,
-                        project_path,
-                        &self.user_path,
-                    )
-                {
-                    warn!("{msg}");
+                if let Some(user_token) = merged.get(profile) {
+                    self.warn_stale_shadow_once(profile, project_token, user_token, project_path);
                 }
             }
             merged.extend(project_tokens);
         }
         Ok(merged)
+    }
+
+    /// Emit the stale-project-shadow warning for `profile`, at most once per
+    /// profile for the lifetime of this `TokenStorage` (and every clone of
+    /// it, since `warned_stale_shadows` is `Arc`-shared).
+    ///
+    /// Why: Isolated out of `load()` so the throttling mechanism (an
+    /// insert-returns-false-if-present check on a shared `HashSet`) is a
+    /// single, obviously-correct spot, and so the structured `tracing::warn!`
+    /// call site (house style: named fields, not a preformatted string) is
+    /// separate from the pure stale/fresh decision in
+    /// [`stale_shadow_warning`].
+    /// What: Computes [`stale_shadow_warning`]; on `Some`, inserts `profile`
+    /// into `warned_stale_shadows` and only logs when the insert reports the
+    /// profile was newly added (i.e. this is the first time this process has
+    /// seen this exact stale shadow for this profile). A poisoned mutex
+    /// (only reachable if a prior holder panicked mid-lock) recovers via
+    /// `into_inner` rather than propagating — a missed dedup entry is
+    /// harmless (one extra warning), unlike propagating a panic through the
+    /// hot read path.
+    /// Test: `load_warns_when_project_shadow_is_stale`,
+    /// `load_does_not_rewarn_on_second_load`.
+    fn warn_stale_shadow_once(
+        &self,
+        profile: &str,
+        project: &StoredToken,
+        user: &StoredToken,
+        project_path: &Path,
+    ) {
+        let Some(info) = stale_shadow_warning(project, user, project_path, &self.user_path) else {
+            return;
+        };
+        let mut warned = self
+            .warned_stale_shadows
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !warned.insert(profile.to_string()) {
+            return; // already warned for this profile this process
+        }
+        drop(warned);
+        warn!(
+            profile = %profile,
+            project_path = %info.project_path.display(),
+            project_expires_at = %info.project_expires_at,
+            user_path = %info.user_path.display(),
+            user_expires_at = %info.user_expires_at,
+            "project-level tokens.json override is EXPIRED but shadows a valid user-level \
+             token for this profile — serving the STALE override per the documented \
+             project-overrides-user contract. Run setup from this directory, or remove the \
+             project override, to use the fresher token. (This warning fires once per \
+             profile per process.)"
+        );
     }
 
     /// Save tokens to the primary write path (project if known, else user).
@@ -200,40 +257,51 @@ impl TokenStorage {
     }
 }
 
-/// Build a warning message when a project-level token entry shadows a
-/// user-level one for the same profile while itself being stale.
+/// Structured detail of a stale project-level shadow, for the `tracing::warn!`
+/// fields in [`TokenStorage::warn_stale_shadow_once`].
 ///
-/// Why: Isolated as a pure predicate/formatter (no I/O, no logging) so the
-/// exact condition and wording are directly unit-testable without a temp
-/// filesystem — mirrors the `refresh_failure_message` pattern in
-/// `oauth::errors`.
-/// What: Returns `Some(message)` naming both paths and both `expires_at`
-/// timestamps when `project` is expired and `user` is not; `None` in every
-/// other case (both fresh, both stale, or the project entry is the fresher
-/// one) — those cases are not the silent-stale-shadow failure mode this
-/// guards against.
+/// Why: Split out of the message-formatting version of this check so `load`
+/// can log with named fields (house style) instead of a single preformatted
+/// string, while [`stale_shadow_warning`] stays a pure, directly-testable
+/// decision function.
+/// What: Owned copies of both paths and both `expires_at` timestamps.
+/// Test: covered transitively via [`stale_shadow_warning`]'s own tests and
+/// `load_warns_when_project_shadow_is_stale`.
+struct StaleShadowInfo {
+    project_path: PathBuf,
+    project_expires_at: DateTime<Utc>,
+    user_path: PathBuf,
+    user_expires_at: DateTime<Utc>,
+}
+
+/// Decide whether a project-level token entry shadows a user-level one for
+/// the same profile while itself being stale.
+///
+/// Why: Isolated as a pure predicate (no I/O, no logging) so the exact
+/// condition is directly unit-testable without a temp filesystem or a
+/// tracing-capturing test harness — mirrors the `refresh_failure_message`
+/// pattern in `oauth::errors`.
+/// What: Returns `Some(StaleShadowInfo)` naming both paths and both
+/// `expires_at` timestamps when `project` is expired and `user` is not;
+/// `None` in every other case (both fresh, both stale, or the project entry
+/// is the fresher one) — those cases are not the silent-stale-shadow failure
+/// mode this guards against.
 /// Test: `warns_when_project_stale_and_user_fresh`,
 /// `no_warning_when_both_fresh`, `no_warning_when_both_stale`,
 /// `no_warning_when_project_is_fresher`.
 fn stale_shadow_warning(
-    profile: &str,
     project: &StoredToken,
     user: &StoredToken,
     project_path: &Path,
     user_path: &Path,
-) -> Option<String> {
+) -> Option<StaleShadowInfo> {
     if project.token.is_expired() && !user.token.is_expired() {
-        Some(format!(
-            "profile '{profile}': project-level tokens.json override at {} is EXPIRED \
-             (expires_at={}) but shadows a valid user-level token at {} (expires_at={}) — \
-             serving the STALE override per the documented project-overrides-user contract. \
-             Run setup from this directory, or remove {} to fall through to the fresher token.",
-            project_path.display(),
-            project.token.expires_at,
-            user_path.display(),
-            user.token.expires_at,
-            project_path.display(),
-        ))
+        Some(StaleShadowInfo {
+            project_path: project_path.to_path_buf(),
+            project_expires_at: project.token.expires_at,
+            user_path: user_path.to_path_buf(),
+            user_expires_at: user.token.expires_at,
+        })
     } else {
         None
     }
@@ -340,27 +408,30 @@ mod tests {
     fn warns_when_project_stale_and_user_fresh() {
         let project = make_stored(-3600);
         let user = make_stored(3600);
-        let msg = stale_shadow_warning(
-            "work",
+        let info = stale_shadow_warning(
             &project,
             &user,
             Path::new("/proj/.gworkspace-mcp/tokens.json"),
             Path::new("/home/user/.gworkspace-mcp/tokens.json"),
         )
         .expect("must warn: project stale, user fresh");
-        assert!(msg.contains("work"));
-        assert!(msg.contains("/proj/.gworkspace-mcp/tokens.json"));
-        assert!(msg.contains("/home/user/.gworkspace-mcp/tokens.json"));
-        assert!(msg.contains("EXPIRED"));
+        assert_eq!(
+            info.project_path,
+            Path::new("/proj/.gworkspace-mcp/tokens.json")
+        );
+        assert_eq!(
+            info.user_path,
+            Path::new("/home/user/.gworkspace-mcp/tokens.json")
+        );
+        assert_eq!(info.project_expires_at, project.token.expires_at);
+        assert_eq!(info.user_expires_at, user.token.expires_at);
     }
 
     #[test]
     fn no_warning_when_both_fresh() {
         let project = make_stored(3600);
         let user = make_stored(7200);
-        assert!(
-            stale_shadow_warning("work", &project, &user, Path::new("p"), Path::new("u")).is_none()
-        );
+        assert!(stale_shadow_warning(&project, &user, Path::new("p"), Path::new("u")).is_none());
     }
 
     #[test]
@@ -369,26 +440,26 @@ mod tests {
         // an expired token either way, so no extra signal is needed here.
         let project = make_stored(-3600);
         let user = make_stored(-7200);
-        assert!(
-            stale_shadow_warning("work", &project, &user, Path::new("p"), Path::new("u")).is_none()
-        );
+        assert!(stale_shadow_warning(&project, &user, Path::new("p"), Path::new("u")).is_none());
     }
 
     #[test]
     fn no_warning_when_project_is_fresher() {
         let project = make_stored(3600);
         let user = make_stored(-3600);
-        assert!(
-            stale_shadow_warning("work", &project, &user, Path::new("p"), Path::new("u")).is_none()
-        );
+        assert!(stale_shadow_warning(&project, &user, Path::new("p"), Path::new("u")).is_none());
     }
 
-    #[test]
-    fn load_still_prefers_project_override_after_warning() {
-        // Regression guard for the precedence contract: this fix only adds a
-        // warning, it does not change which entry wins (see PR body) — a
-        // stale project override must still be served, just noisily.
-        let dir = std::env::temp_dir().join(format!("gw-storage-shadow-{}", uuid::Uuid::new_v4()));
+    /// Build a two-tier temp `TokenStorage` (separate user/project dirs) with
+    /// a `work` profile present on both sides, and write the given
+    /// user/project token maps to disk. Shared by the precedence and
+    /// warn-capture tests below.
+    fn temp_shadowed_storage(
+        label: &str,
+        user_expires_in_secs: i64,
+        project_expires_in_secs: i64,
+    ) -> TokenStorage {
+        let dir = std::env::temp_dir().join(format!("gw-storage-{label}-{}", uuid::Uuid::new_v4()));
         let user_dir = dir.join("user");
         let project_dir = dir.join("project");
         std::fs::create_dir_all(&user_dir).unwrap();
@@ -397,23 +468,32 @@ mod tests {
         let project_path = project_dir.join("tokens.json");
 
         let mut user_tokens = HashMap::new();
-        user_tokens.insert("work".to_string(), make_stored(3600));
+        user_tokens.insert("work".to_string(), make_stored(user_expires_in_secs));
         std::fs::write(&user_path, serde_json::to_string(&user_tokens).unwrap()).unwrap();
 
         let mut project_tokens = HashMap::new();
-        let mut stale = make_stored(-3600);
-        stale.token.access_token = "stale-access-token".into();
-        project_tokens.insert("work".to_string(), stale);
+        let mut project_stored = make_stored(project_expires_in_secs);
+        project_stored.token.access_token = "stale-access-token".into();
+        project_tokens.insert("work".to_string(), project_stored);
         std::fs::write(
             &project_path,
             serde_json::to_string(&project_tokens).unwrap(),
         )
         .unwrap();
 
-        let storage = TokenStorage {
+        TokenStorage {
             user_path,
             project_path: Some(project_path),
-        };
+            warned_stale_shadows: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    #[test]
+    fn load_still_prefers_project_override_after_warning() {
+        // Regression guard for the precedence contract: this fix only adds a
+        // warning, it does not change which entry wins (see PR body) — a
+        // stale project override must still be served, just noisily.
+        let storage = temp_shadowed_storage("precedence", 3600, -3600);
 
         let loaded = storage.load().unwrap();
         assert_eq!(
@@ -421,5 +501,43 @@ mod tests {
             "project override must still win per the documented contract \
              (warn, don't change precedence)"
         );
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn load_warns_when_project_shadow_is_stale() {
+        let storage = temp_shadowed_storage("warns", 3600, -3600);
+
+        storage.load().unwrap();
+
+        assert!(logs_contain("work"));
+        assert!(logs_contain("STALE"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn load_does_not_rewarn_on_second_load() {
+        // PR #2949 review (HIGH): load() sits on the per-request hot path —
+        // an unthrottled warn would repeat on every single MCP tool call.
+        // Two loads on the same TokenStorage must produce exactly one
+        // stale-shadow warning, not two.
+        let storage = temp_shadowed_storage("norewarn", 3600, -3600);
+
+        storage.load().unwrap();
+        storage.load().unwrap();
+
+        logs_assert(|lines: &[&str]| {
+            let count = lines
+                .iter()
+                .filter(|l| l.contains("STALE") && l.contains("work"))
+                .count();
+            if count == 1 {
+                Ok(())
+            } else {
+                Err(format!(
+                    "expected exactly 1 stale-shadow warning after two load() calls, found {count}"
+                ))
+            }
+        });
     }
 }


### PR DESCRIPTION
## Summary

Closes #2946 (definitive-root-cause scope from the latest issue comment, not the original in-memory-client-reload proposal).

Two stacked bugs, both in `crates/trusty-gworkspace/src/api/auth/`:

1. **Self-refresh silently disabled in every tm-managed session** (`manager.rs`, primary fix). `OAuthManager::from_env()` required `GOOGLE_OAUTH_CLIENT_ID`/`GOOGLE_OAUTH_CLIENT_SECRET` env vars and returned `None` otherwise — no tm-managed session sets them, so every such session ran in read-only-token mode: `get_access_token()` logged a warn and returned the expired token, which Google 401s roughly an hour after each re-auth. `from_env()` now delegates to the existing `resolve_client_creds()` helper (`api/auth/oauth/flow/mod.rs`, already used by `setup`/`doctor`) instead of duplicating its env→file fallback logic. Env vars still win when present; only the file-fallback path is new here. A warning is now logged (instead of failing silently) only when neither source yields credentials.

2. **Stale project-level token shadowing goes unsignaled** (`storage.rs`, secondary/guardrail fix). `TokenStorage::load()` merges `./.gworkspace-mcp/tokens.json` (project) over `~/.gworkspace-mcp/tokens.json` (user) per profile key. When the project-level entry for a profile is expired but the user-level entry it shadows is still valid, `load()` now logs a loud `tracing::warn!` naming both paths and both `expires_at` timestamps.

### Design decision: precedence NOT changed

The issue text called out "optionally prefer the non-expired entry ... if you change precedence, cover it thoroughly with tests and call it out in the PR body." I deliberately did **not** change precedence — the documented project-overrides-user contract is preserved exactly as before; a stale project override still wins and is still served. Only a warning was added. Rationale: changing precedence is a judgment call with a real chance of surprising existing project-scoped setups (e.g. a project intentionally pinned to a specific, possibly-currently-expired-but-about-to-be-refreshed profile), and the issue explicitly named "warn" as the minimal safe version. `load_still_prefers_project_override_after_warning` is a regression test asserting the stale project entry is still what callers get.

### Tests added

`manager.rs` (env/file fallback, `#[serial]` + HOME-override RAII guard, following the existing `trusty-mpm` `HomeGuard` convention — never touches the real `~/.gworkspace-mcp`):
- `from_env_falls_back_to_oauth_client_json` — env absent, file present → refresh enabled from file creds
- `from_env_returns_none_when_both_absent` — both absent → `None` (warn path)
- `from_env_prefers_env_vars_over_file` — both present → env vars win

`storage.rs` (pure-predicate tests + one filesystem integration test, all via temp dirs):
- `warns_when_project_stale_and_user_fresh` / `no_warning_when_both_fresh` / `no_warning_when_both_stale` / `no_warning_when_project_is_fresher` — `stale_shadow_warning()` predicate/message correctness
- `load_still_prefers_project_override_after_warning` — precedence-unchanged regression guard

## Test plan

- [x] `cargo test -p trusty-gworkspace` — 233 + 2 passed, 0 failed (raw output captured in dev session)
- [x] `cargo clippy -p trusty-gworkspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `9 allowlisted, 0 violations — OK`
- [x] `cargo check --workspace` — clean (no cross-crate breakage)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools