### PR TITLE
feat(trusty-code): add .md agent loader via trusty-agents-common compose machinery, alongside TOML

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -164,7 +164,6 @@ crates/trusty-code/src/agent_loop/transcript.rs	push_response_appends_assistant
 crates/trusty-code/src/agents/config.rs	agent_config_llm_params
 crates/trusty-code/src/agents/config.rs	agent_config_runner_kind
 crates/trusty-code/src/agents/config.rs	agent_config_system_prompt
-crates/trusty-code/src/agents/mod.rs	discover_agents_skips_non_toml
 crates/trusty-code/src/events.rs	ast_operation_round_trips_through_subscribe
 crates/trusty-code/src/jsonrpc/error.rs	rpc_error_domain_sets_error_type_in_data
 crates/trusty-code/src/llm/client_trait.rs	llm_client_implements_trait

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Markdown+frontmatter `.md` agent loader, dark-launched alongside TOML
+  (#2897, epic #2892, Slice B).** `agents::md_loader::load_md_agent` composes
+  a `.md` agent source file's `extends:` chain via
+  `trusty-agents-common::agents::builder::compose_agent` (Slice A, #2952) and
+  projects the result onto tcode's existing `AgentConfig`: `model` ->
+  `agent.model`, `max_tokens` -> `llm.max_tokens`, `tools:
+  Option<Vec<String>>` -> `ToolsConfig.allowed` (a direct map — both sides
+  share identical `None`=all-allowed / `Some([])`=deny-all /
+  `Some(list)`=allowlist semantics), and the composed prose body ->
+  `system_prompt.content`. The composed frontmatter's HR-1 role-derived
+  `initialPrompt` enrichment (keyed off trusty-mpm's role table, which
+  collides by name with tcode's `engineer`/`qa` roles) is guaranteed to never
+  leak into `system_prompt.content` — the body extraction only reads past the
+  closing frontmatter fence and the public `AgentMetadata` projection has no
+  `initial_prompt` field at all. `discover_agents`/`load_all_agents` now scan
+  and load both `*.toml` and `*.md` agent files; when both exist for the same
+  agent name, the `.toml` deterministically wins (a warning is logged). Purely
+  additive and behavior-preserving — the TOML loader is unchanged; TOML
+  retirement is a later slice (D).
 - **Engineer receives `use_skill` on the `--legacy-in-process`/`run_task` path (#2942).** The `python-engineer` role's tool registry (`ProjectToolFactory` in `run_task/mod.rs`) now conditionally registers `UseSkillTool` alongside its other project tools when a `SkillResolver` is available, so the engineer can fetch a skill's full body mid-turn instead of relying solely on the catalog summary baked into its system prompt.
 - **Native skill discovery on the `--legacy-in-process`/bake-off `run-task` path (#2924).** The `use_skill` tool and the `.claude/skills/` catalog now reach the PM's prompt and tool registry on `run_task::execute_run_task`, not just the daemon/thin-client path — a PM run through `run-task` can now discover and load project skills the same way a daemon session already could.
 - **Embedded default agents & skills, disk-first with embedded fallback

--- a/crates/trusty-code/src/agents/md_loader.rs
+++ b/crates/trusty-code/src/agents/md_loader.rs
@@ -1,0 +1,359 @@
+//! Markdown+frontmatter agent loader for tcode, DARK-LAUNCHED alongside the
+//! TOML loader (issue #2897, epic #2892, Slice B).
+//!
+//! Why: trusty-agents-common's `agents::builder` compose machinery (Slice A,
+//! #2952) already resolves `extends:` inheritance chains for trusty-mpm's
+//! `.md` agent format and now carries `max_tokens`/`tools` frontmatter fields
+//! that mirror tcode's TOML `AgentConfig` schema. Rather than fork a second
+//! `.md` parser, tcode reuses that composer and projects its output onto its
+//! existing `AgentConfig`. This is purely additive: the TOML loader
+//! (`AgentConfig::load`) is untouched, and both formats coexist through this
+//! slice. TOML retirement is Slice D.
+//! What: [`load_md_agent`] reads a `.md` agent source file, calls
+//! `trusty_agents_common::agents::builder::compose_agent` to resolve its
+//! `extends:` chain into one flattened document, projects the composed
+//! frontmatter (via `agents::metadata::agent_metadata_from_str`) and prose
+//! body onto tcode's `AgentConfig`.
+//! Test: `parallel_fixture_equivalence` (same agent authored as `.toml` and
+//! `.md` load to field-identical configs), `tools_projection_*` (the
+//! `Option<Vec<String>>` direct-map), `hr1_initial_prompt_not_leaked_into_body`
+//! (the HR-1 guard).
+
+use std::path::Path;
+
+use trusty_agents_common::agents::builder::compose_agent;
+use trusty_agents_common::agents::metadata::{AgentMetadata, agent_metadata_from_str};
+
+use super::config::{AgentConfig, AgentInfo, LlmParams, SystemPrompt, ToolsConfig};
+
+/// Load a tcode [`AgentConfig`] from a `.md` agent source file.
+///
+/// Why: primary entry point for the `.md` loader, mirroring
+/// `AgentConfig::load`'s role for the TOML path — both take a file path and
+/// return a fully-populated `AgentConfig` or a descriptive error.
+/// What: resolves `path`'s parent directory as the `extends:` source dir and
+/// its file stem as the agent name, composes the inheritance chain via
+/// `compose_agent`, then projects the result via [`project_to_agent_config`].
+/// A missing parent directory, an unreadable file stem, or any
+/// `AgentBuildError` (not found, cycle, depth exceeded, malformed
+/// frontmatter) is surfaced as a descriptive `anyhow::Error` — never a panic —
+/// matching `AgentConfig::load`'s fallibility contract so `load_all_agents`
+/// can handle both loaders identically.
+/// Test: `parallel_fixture_equivalence`, `load_md_agent_missing_file_errors`,
+/// `load_md_agent_with_extends_resolves_chain`.
+pub fn load_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
+    let source_dir = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("agent file {} has no parent directory", path.display()))?;
+    let name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| anyhow::anyhow!("agent file {} has no usable file stem", path.display()))?;
+
+    let composed = compose_agent(name, source_dir).map_err(|e| {
+        anyhow::anyhow!(
+            "failed to compose agent '{name}' from {}: {e}",
+            path.display()
+        )
+    })?;
+
+    let metadata = agent_metadata_from_str(&composed);
+    let body = extract_body(&composed);
+
+    Ok(project_to_agent_config(name, metadata, body))
+}
+
+/// Strip the leading YAML frontmatter block from a composed agent document.
+///
+/// Why: `compose_agent`'s merged frontmatter block may carry an HR-1-injected
+/// `initialPrompt` (auto-derived from the agent's `role:`, keyed off
+/// trusty-mpm's role table — see
+/// `trusty_agents_common::agents::builder::merge_frontmatter`'s "HR-1 Part B"
+/// enrichment). tcode's own role vocabulary (`engineer`/`qa`) collides with
+/// that table, so an mpm-role-derived `initialPrompt` must NEVER leak into
+/// tcode's `system_prompt.content` — tcode's system prompt is the composed
+/// PROSE BODY only, exactly as the TOML loader's `system_prompt.content` is a
+/// hand-authored prompt with no injected preamble. `AgentMetadata` (the
+/// public frontmatter projection this module also uses) already omits
+/// `initial_prompt`/`resource_tier` entirely, so there is no accessor that
+/// could leak it into the projection; this function provides the second,
+/// independent guarantee on the body side by never inspecting the
+/// frontmatter block's contents at all — it locates the closing fence
+/// structurally and returns only what follows.
+/// What: `compose_agent`'s output always opens with a `---` line; this scans
+/// past it to the next `---` line and returns everything after, trimmed. A
+/// document with no opening fence (defensive fallback; `compose_agent` always
+/// emits one) returns the whole string trimmed.
+/// Test: `hr1_initial_prompt_not_leaked_into_body`, `extract_body_strips_frontmatter`.
+fn extract_body(composed: &str) -> String {
+    let mut lines = composed.lines();
+    match lines.next() {
+        Some(first) if first.trim() == "---" => {}
+        _ => return composed.trim().to_string(),
+    }
+
+    let mut in_frontmatter = true;
+    let mut body_lines: Vec<&str> = Vec::new();
+    for line in lines {
+        if in_frontmatter {
+            if line.trim() == "---" {
+                in_frontmatter = false;
+            }
+            continue;
+        }
+        body_lines.push(line);
+    }
+    body_lines.join("\n").trim().to_string()
+}
+
+/// Project a composed `.md` agent's metadata + body onto tcode's `AgentConfig`.
+///
+/// Why: centralises the frontmatter -> TOML-schema field mapping so
+/// `load_md_agent` stays a thin IO/compose wrapper.
+/// What:
+/// - `name` -> `agent.name` (falls back to the file-stem `default_name` when
+///   the frontmatter declares no `name:`, mirroring how a source file is
+///   identified by its filename).
+/// - `role`/`description` -> `agent.role`/`agent.description` (direct map).
+/// - `model` -> `agent.model` (the higher-precedence slot per
+///   `provider::routing::resolve_model`; `llm.model_override` is left unset —
+///   the `.md` frontmatter has exactly one model concept, matching how the
+///   TOML fixtures set `[agent].model` and leave `[llm].model_override` unset).
+/// - `max_tokens` -> `llm.max_tokens` (direct map).
+/// - `tools: Option<Vec<String>>` -> `ToolsConfig.allowed` (DIRECT map — both
+///   sides share identical `None`=all-allowed / `Some([])`=deny-all /
+///   `Some(list)`=allowlist semantics, per `Frontmatter::tools`'s doc comment
+///   and `runner::in_process`'s `agent.tools.as_ref().and_then(|t|
+///   t.allowed.as_ref())` consumer, which treats an absent `[tools]` section
+///   (outer `None`) and a present-but-unset `allowed` identically — so always
+///   wrapping in `Some(ToolsConfig { allowed })` is safe and matches the
+///   instructed direct-map).
+/// - composed prose body -> `system_prompt.content`.
+/// - `skills:` -> intentionally DROPPED. `SystemPrompt::append_skills` exists
+///   in tcode's schema but has no consumer anywhere in the codebase (verified:
+///   `grep -rn append_skills crates/trusty-code/src` only shows the field
+///   declaration and TOML asset literals that set it — nothing reads it). The
+///   shared frontmatter's `skills:` list is real and populated
+///   (DOC-42/#2889), but mapping it into a dead field would fabricate a
+///   consumer that doesn't exist. Left as a gap for a future slice that adds
+///   an actual skills consumer to tcode.
+fn project_to_agent_config(default_name: &str, meta: AgentMetadata, body: String) -> AgentConfig {
+    AgentConfig {
+        agent: AgentInfo {
+            name: meta.name.unwrap_or_else(|| default_name.to_string()),
+            role: meta.role,
+            model: meta.model,
+            description: meta.description,
+        },
+        llm: LlmParams {
+            temperature: None,
+            max_tokens: meta.max_tokens,
+            model_override: None,
+        },
+        system_prompt: SystemPrompt {
+            content: body,
+            // Gap: no tcode consumer for agent-declared skills yet — see the
+            // doc comment above. Left empty rather than mapping into a dead
+            // field.
+            append_skills: Vec::new(),
+        },
+        tools: Some(ToolsConfig {
+            allowed: meta.tools,
+        }),
+        runner: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `.md` agent with no `extends:` composes and projects cleanly.
+    ///
+    /// Why: the base case — a self-contained agent, no inheritance chain.
+    /// What: writes a single `.md` file, loads it, asserts every projected
+    /// field.
+    /// Test: this test.
+    #[test]
+    fn load_md_agent_base_case() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("solo.md"),
+            "---\nname: solo\nrole: engineer\ndescription: A lone agent\nmodel: sonnet\nmax_tokens: 4096\ntools: [read_file, grep]\n---\n\nYou are a solo agent.\n",
+        )
+        .expect("write");
+
+        let cfg = load_md_agent(&tmp.path().join("solo.md")).expect("load");
+        assert_eq!(cfg.agent.name, "solo");
+        assert_eq!(cfg.agent.role.as_deref(), Some("engineer"));
+        assert_eq!(cfg.agent.description.as_deref(), Some("A lone agent"));
+        assert_eq!(cfg.agent.model.as_deref(), Some("sonnet"));
+        assert_eq!(cfg.llm.max_tokens, Some(4096));
+        assert_eq!(cfg.system_prompt.content, "You are a solo agent.");
+        assert_eq!(
+            cfg.tools.and_then(|t| t.allowed),
+            Some(vec!["read_file".to_string(), "grep".to_string()])
+        );
+    }
+
+    /// `tools:` projects with identical `Option<Vec<String>>` semantics on
+    /// both sides: absent key -> `None` (all allowed), `tools: []` ->
+    /// `Some([])` (deny-all), `tools: [a, b]` -> `Some([a, b])` (allowlist).
+    ///
+    /// Why: this is the load-bearing contract from Slice A (#2952) — a naive
+    /// `is_empty()` check would collapse deny-all into "inherit"/"allow-all".
+    /// What: three fixtures, one per case.
+    /// Test: this test.
+    #[test]
+    fn tools_projection_absent_is_none() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("a.md"),
+            "---\nname: a\nrole: engineer\n---\n\nBody.\n",
+        )
+        .expect("write");
+        let cfg = load_md_agent(&tmp.path().join("a.md")).expect("load");
+        assert_eq!(cfg.tools.and_then(|t| t.allowed), None);
+    }
+
+    #[test]
+    fn tools_projection_empty_list_is_deny_all() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("a.md"),
+            "---\nname: a\nrole: engineer\ntools: []\n---\n\nBody.\n",
+        )
+        .expect("write");
+        let cfg = load_md_agent(&tmp.path().join("a.md")).expect("load");
+        assert_eq!(cfg.tools.and_then(|t| t.allowed), Some(vec![]));
+    }
+
+    #[test]
+    fn tools_projection_list_is_allowlist() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("a.md"),
+            "---\nname: a\nrole: engineer\ntools: [read_file, grep]\n---\n\nBody.\n",
+        )
+        .expect("write");
+        let cfg = load_md_agent(&tmp.path().join("a.md")).expect("load");
+        assert_eq!(
+            cfg.tools.and_then(|t| t.allowed),
+            Some(vec!["read_file".to_string(), "grep".to_string()])
+        );
+    }
+
+    /// HR-1 GUARD: a `.md` agent declaring `role: engineer` must NOT get an
+    /// mpm-role-derived `initialPrompt` injected into its `system_prompt.content`.
+    ///
+    /// Why: `merge_frontmatter`'s HR-1 Part B enrichment auto-injects
+    /// `initialPrompt: "Begin implementation. ..."` for `role: engineer` (and
+    /// a distinct prompt for `role: qa`) because trusty-mpm agents rely on
+    /// that injection. tcode's roles collide with that same table by name,
+    /// but tcode's system prompt is the composed PROSE BODY only — the
+    /// injected `initialPrompt` lives in the frontmatter block, which
+    /// `extract_body` never inspects, and `AgentMetadata` (the frontmatter
+    /// projection) has no `initial_prompt` field at all. This test proves
+    /// both guarantees hold end-to-end.
+    /// What: an `engineer`-role agent whose body is a short known string;
+    /// asserts `system_prompt.content` equals exactly that string with no
+    /// HR-1 preamble prepended or appended.
+    /// Test: this test.
+    #[test]
+    fn hr1_initial_prompt_not_leaked_into_body() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("eng.md"),
+            "---\nname: eng\nrole: engineer\n---\n\nYou write Rust code.\n",
+        )
+        .expect("write");
+
+        let cfg = load_md_agent(&tmp.path().join("eng.md")).expect("load");
+        assert_eq!(
+            cfg.system_prompt.content, "You write Rust code.",
+            "HR-1's role-derived initialPrompt must not leak into the body"
+        );
+        assert!(
+            !cfg.system_prompt.content.contains("Begin implementation"),
+            "HR-1's engineer-role initialPrompt text must not appear anywhere in the body"
+        );
+    }
+
+    /// `extends:` chains resolve through `compose_agent` exactly as
+    /// trusty-mpm's own `.md` agents do.
+    ///
+    /// Why: proves the composer is genuinely reused, not reimplemented.
+    /// What: a base + child fixture; the child's `AgentConfig` carries the
+    /// base's body concatenated before the child's, and the child's
+    /// `max_tokens` wins (scalar child-wins merge).
+    /// Test: this test.
+    #[test]
+    fn load_md_agent_with_extends_resolves_chain() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("base-x.md"),
+            "---\nname: base-x\nmax_tokens: 1000\n---\n\nBase instructions.\n",
+        )
+        .expect("write");
+        std::fs::write(
+            tmp.path().join("child.md"),
+            "---\nname: child\nextends: base-x\nmax_tokens: 2000\n---\n\nChild instructions.\n",
+        )
+        .expect("write");
+
+        let cfg = load_md_agent(&tmp.path().join("child.md")).expect("load");
+        assert_eq!(cfg.agent.name, "child");
+        assert_eq!(cfg.llm.max_tokens, Some(2000), "child max_tokens wins");
+        assert!(cfg.system_prompt.content.contains("Base instructions."));
+        assert!(cfg.system_prompt.content.contains("Child instructions."));
+    }
+
+    /// A missing `.md` file surfaces a descriptive error, never a panic.
+    ///
+    /// Why: matches `AgentConfig::load`'s fallibility contract so
+    /// `load_all_agents` can `filter_map` over both loaders identically.
+    /// What: `load_md_agent` on a nonexistent path returns `Err`.
+    /// Test: this test.
+    #[test]
+    fn load_md_agent_missing_file_errors() {
+        let result = load_md_agent(Path::new("/nonexistent/agents/dir/ghost.md"));
+        assert!(result.is_err());
+    }
+
+    /// Parallel-fixture equivalence: the SAME agent authored as `.toml` and
+    /// as `.md` load to field-identical `AgentConfig`s.
+    ///
+    /// Why: the acceptance criterion for Slice B — both formats must produce
+    /// the same runtime behavior for an operator migrating a config.
+    /// What: hand-authors matching TOML and `.md` fixtures (same name, model,
+    /// max_tokens, tools, and system-prompt body), loads both, and asserts
+    /// `model`, `max_tokens`, `tools.allowed`, and `system_prompt.content`
+    /// are equal.
+    /// Test: this test.
+    #[test]
+    fn parallel_fixture_equivalence() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        std::fs::write(
+            tmp.path().join("twin.toml"),
+            "[agent]\nname = \"twin\"\nrole = \"engineer\"\nmodel = \"sonnet\"\n\n[llm]\nmax_tokens = 8192\n\n[system_prompt]\ncontent = \"You are a twin agent.\"\n\n[tools]\nallowed = [\"read_file\", \"grep\"]\n",
+        )
+        .expect("write toml");
+        std::fs::write(
+            tmp.path().join("twin.md"),
+            "---\nname: twin\nrole: engineer\nmodel: sonnet\nmax_tokens: 8192\ntools: [read_file, grep]\n---\n\nYou are a twin agent.\n",
+        )
+        .expect("write md");
+
+        let toml_cfg = AgentConfig::load(&tmp.path().join("twin.toml")).expect("load toml");
+        let md_cfg = load_md_agent(&tmp.path().join("twin.md")).expect("load md");
+
+        assert_eq!(toml_cfg.agent.model, md_cfg.agent.model);
+        assert_eq!(toml_cfg.llm.max_tokens, md_cfg.llm.max_tokens);
+        assert_eq!(
+            toml_cfg.tools.and_then(|t| t.allowed),
+            md_cfg.tools.and_then(|t| t.allowed)
+        );
+        assert_eq!(toml_cfg.system_prompt.content, md_cfg.system_prompt.content);
+    }
+}

--- a/crates/trusty-code/src/agents/md_loader.rs
+++ b/crates/trusty-code/src/agents/md_loader.rs
@@ -356,4 +356,70 @@ mod tests {
         );
         assert_eq!(toml_cfg.system_prompt.content, md_cfg.system_prompt.content);
     }
+
+    /// `extract_body` closes the frontmatter block on the FIRST `---` fence
+    /// only and never re-enters — a `---` line appearing later, inside the
+    /// prose body (a markdown horizontal rule between two paragraphs), must
+    /// survive verbatim in `system_prompt.content` rather than being mistaken
+    /// for a second frontmatter delimiter.
+    ///
+    /// Why: code-critic finding on PR #2954 — this is the highest-risk edge
+    /// case in the fence-scanning loop (`in_frontmatter` flips to `false` and
+    /// stays `false`), and had no regression pin.
+    /// What: a `.md` fixture whose body contains a paragraph, a bare `---`
+    /// horizontal-rule line, then a second paragraph. Loads through the real
+    /// `compose_agent` -> `load_md_agent` path (not `extract_body` in
+    /// isolation) so the assertion exercises the actual composed output.
+    /// Asserts the horizontal rule is present verbatim as its own line in the
+    /// resulting body.
+    /// Test: this test.
+    #[test]
+    fn interior_horizontal_rule_survives_in_body() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("hr.md"),
+            "---\nname: hr\nrole: engineer\n---\n\nFirst paragraph.\n\n---\n\nSecond paragraph.\n",
+        )
+        .expect("write");
+
+        let cfg = load_md_agent(&tmp.path().join("hr.md")).expect("load");
+        assert!(
+            cfg.system_prompt
+                .content
+                .lines()
+                .any(|line| line.trim() == "---"),
+            "interior horizontal rule must survive verbatim as its own line; got: {:?}",
+            cfg.system_prompt.content
+        );
+        assert!(cfg.system_prompt.content.contains("First paragraph."));
+        assert!(cfg.system_prompt.content.contains("Second paragraph."));
+    }
+
+    /// A `.md` agent with a valid frontmatter block and NO prose body after
+    /// the closing fence projects to an EMPTY `system_prompt.content` — no
+    /// panic, no leftover blank lines, no stray `---`.
+    ///
+    /// Why: code-critic finding on PR #2954 — the frontmatter-only/empty-body
+    /// case is the other edge of the fence-scanning loop and had no
+    /// regression pin.
+    /// What: a `.md` fixture whose closing fence is the last line of the
+    /// file. Loads through the real `compose_agent` -> `load_md_agent` path.
+    /// Asserts `system_prompt.content == ""`.
+    /// Test: this test.
+    #[test]
+    fn frontmatter_only_agent_has_empty_body() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("empty.md"),
+            "---\nname: empty\nrole: engineer\n---\n",
+        )
+        .expect("write");
+
+        let cfg = load_md_agent(&tmp.path().join("empty.md")).expect("load");
+        assert_eq!(
+            cfg.system_prompt.content, "",
+            "frontmatter-only agent must project to an empty body, got: {:?}",
+            cfg.system_prompt.content
+        );
+    }
 }

--- a/crates/trusty-code/src/agents/md_loader.rs
+++ b/crates/trusty-code/src/agents/md_loader.rs
@@ -84,7 +84,9 @@ pub fn load_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
 /// past it to the next `---` line and returns everything after, trimmed. A
 /// document with no opening fence (defensive fallback; `compose_agent` always
 /// emits one) returns the whole string trimmed.
-/// Test: `hr1_initial_prompt_not_leaked_into_body`, `extract_body_strips_frontmatter`.
+/// Test: `hr1_initial_prompt_not_leaked_into_body`,
+/// `interior_horizontal_rule_survives_in_body`,
+/// `frontmatter_only_agent_has_empty_body`.
 fn extract_body(composed: &str) -> String {
     let mut lines = composed.lines();
     match lines.next() {

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -3,54 +3,112 @@
 //! Why: Sub-agents (and the PM itself) are defined declaratively in TOML files
 //! under `.claude/agents/` so model, prompt, and LLM parameters can evolve
 //! without code changes. This module is the assembly point for config types
-//! and the discovery helpers.
+//! and the discovery helpers. As of #2897 (epic #2892, Slice B) a Markdown+
+//! frontmatter `.md` loader ([`md_loader`]) is DARK-LAUNCHED alongside the
+//! TOML loader — both formats are discovered and loaded; TOML retirement is
+//! a later slice (D).
 //! What: Re-exports `AgentConfig` and all nested config types from `config`;
-//! provides `discover_agents` for scanning an agents directory, and
-//! `load_all_agents` for loading every config in it. `load_all_agents` falls
-//! back to `crate::assets::DEFAULT_AGENTS` (#2895) when the *parsed* result is
-//! empty — not merely when no `.toml` paths were discovered — so a
-//! `.claude/agents/` dir that exists but holds only unparseable TOML still
+//! provides `discover_agents` for scanning an agents directory (now `*.toml`
+//! AND `*.md`), and `load_all_agents` for loading every config in it,
+//! dispatching to the TOML or `.md` loader by extension. `load_all_agents`
+//! falls back to `crate::assets::DEFAULT_AGENTS` (#2895) when the *parsed*
+//! result is empty — not merely when no paths were discovered — so a
+//! `.claude/agents/` dir that exists but holds only unparseable configs still
 //! yields a usable `engineer`/`qa-agent`/`code-reviewer` set instead of
 //! silently starting with zero agents. A disk directory with even one
 //! successfully-parsed config is treated as the project opting in to its own
 //! catalog, so it is used as-is and the embedded defaults are not merged in.
-//! Test: `discover_agents` tests place TOML files in a tempdir and verify the
-//! returned list. `AgentConfig::load` tests read individual files.
+//! Test: `discover_agents` tests place TOML/`.md` files in a tempdir and
+//! verify the returned list. `AgentConfig::load` tests read individual TOML
+//! files; `md_loader`'s own tests cover the `.md` path.
 //! `load_all_agents_falls_back_to_embedded_when_disk_empty`,
 //! `load_all_agents_falls_back_to_embedded_when_disk_all_invalid`, and
 //! `load_all_agents_disk_wins_when_present` cover the fallback threshold.
 
 pub mod config;
+pub mod md_loader;
 
 pub use config::{
     AgentConfig, AgentInfo, LlmParams, RunnerConfig, RunnerKind, SystemPrompt, ToolsConfig,
 };
+pub use md_loader::load_md_agent;
 
+use std::collections::HashMap;
 use std::path::Path;
 
 /// Discover all agent configs in the given directory.
 ///
 /// Why: tcode needs to know which agents are available before the PM loop
-/// starts so it can validate `delegate_to_agent` calls pre-flight.
-/// What: Scans `dir/*.toml` and returns `(name, path)` pairs sorted by name.
-/// Files that fail to parse are skipped with a tracing warning.
-/// Test: `discover_agents_finds_tomls`, `discover_agents_skips_non_toml`.
+/// starts so it can validate `delegate_to_agent` calls pre-flight. As of
+/// #2897 both `.toml` (existing) and `.md` (dark-launched) source files are
+/// discovered, since both loaders coexist this slice.
+/// What: Scans `dir/*.toml` and `dir/*.md`, keyed by file stem (the agent
+/// name), and returns `(name, path)` pairs sorted by name. When BOTH a
+/// `<name>.toml` and `<name>.md` exist for the same agent name — an edge
+/// case, not the common single-format-per-agent path — the `.toml` wins
+/// deterministically and a warning is logged: the TOML loader is the
+/// established, still-authoritative format during this dark launch (`.md`
+/// retirement of TOML is Slice D), so an operator who has not yet migrated
+/// a given agent keeps getting the config they already have.
+/// Test: `discover_agents_finds_tomls`, `discover_agents_finds_md`,
+/// `discover_agents_toml_wins_on_collision`.
 pub fn discover_agents(dir: &Path) -> Vec<(String, std::path::PathBuf)> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         tracing::debug!("agents dir not found or unreadable: {}", dir.display());
         return vec![];
     };
-    let mut agents: Vec<(String, std::path::PathBuf)> = entries
-        .flatten()
-        .filter_map(|e| {
-            let p = e.path();
-            if p.extension().and_then(|x| x.to_str()) == Some("toml") {
-                let name = p.file_stem()?.to_str()?.to_string();
-                Some((name, p))
-            } else {
-                None
+
+    // `is_toml` tracked per entry so a same-name `.toml`/`.md` collision can
+    // be resolved deterministically (TOML wins) regardless of directory
+    // iteration order.
+    let mut by_name: HashMap<String, (std::path::PathBuf, bool)> = HashMap::new();
+    for entry in entries.flatten() {
+        let p = entry.path();
+        let ext = p.extension().and_then(|x| x.to_str());
+        let is_toml = ext == Some("toml");
+        let is_md = ext == Some("md");
+        if !is_toml && !is_md {
+            continue;
+        }
+        let Some(name) = p.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let name = name.to_string();
+
+        match by_name.get(&name) {
+            None => {
+                by_name.insert(name, (p, is_toml));
             }
-        })
+            Some((existing_path, existing_is_toml)) => {
+                if *existing_is_toml {
+                    // Existing entry is already the winning `.toml`; an `.md`
+                    // for the same name loses.
+                    tracing::warn!(
+                        "agent '{name}' has both {} and {} — using the .toml \
+                         (established format wins during the .md dark launch)",
+                        existing_path.display(),
+                        p.display()
+                    );
+                } else if is_toml {
+                    // The `.md` seen first loses to this later `.toml`.
+                    tracing::warn!(
+                        "agent '{name}' has both {} and {} — using the .toml \
+                         (established format wins during the .md dark launch)",
+                        p.display(),
+                        existing_path.display()
+                    );
+                    by_name.insert(name, (p, is_toml));
+                }
+                // Two entries of the same extension for one stem cannot occur
+                // (distinct filenames with identical stem+ext collide on
+                // disk), so no other branch is reachable.
+            }
+        }
+    }
+
+    let mut agents: Vec<(String, std::path::PathBuf)> = by_name
+        .into_iter()
+        .map(|(name, (p, _))| (name, p))
         .collect();
     agents.sort_by(|a, b| a.0.cmp(&b.0));
     agents
@@ -61,29 +119,37 @@ pub fn discover_agents(dir: &Path) -> Vec<(String, std::path::PathBuf)> {
 /// Why: Startup needs a map of all available agents; individual parse errors
 /// should not crash the whole harness. A project that has not yet created
 /// `.claude/agents/`, has created it but left it empty, or has populated it
-/// with only unparseable TOML must not start with zero agents — see the
+/// with only unparseable configs must not start with zero agents — see the
 /// embedded-fallback note below.
-/// What: Calls `discover_agents`, then `AgentConfig::load` on each,
-/// collecting only the successfully parsed configs (failures are logged at
-/// WARN level and skipped). The fallback threshold is the *parsed* result
-/// being empty, not merely `discover_agents` finding no paths — a directory
-/// full of `.toml` files that all fail to parse must fall back exactly like
-/// an empty or missing directory does. Any single successfully-parsed disk
-/// config is treated as the project's own catalog and used as-is, never
+/// What: Calls `discover_agents`, then dispatches each discovered path to
+/// `AgentConfig::load` (`.toml`) or [`md_loader::load_md_agent`] (`.md`) by
+/// extension, collecting only the successfully parsed configs (failures are
+/// logged at WARN level and skipped). The fallback threshold is the *parsed*
+/// result being empty, not merely `discover_agents` finding no paths — a
+/// directory full of configs that all fail to parse must fall back exactly
+/// like an empty or missing directory does. Any single successfully-parsed
+/// disk config is treated as the project's own catalog and used as-is, never
 /// merged with the embedded set. Falls back to `load_embedded_default_agents`
 /// when parsing yields nothing. Disk agents always win when present.
 /// Test: `load_all_agents_skips_invalid`,
 /// `load_all_agents_falls_back_to_embedded_when_disk_empty`,
 /// `load_all_agents_falls_back_to_embedded_when_disk_all_invalid`,
-/// `load_all_agents_disk_wins_when_present`.
+/// `load_all_agents_disk_wins_when_present`, `load_all_agents_loads_md_agents`.
 pub fn load_all_agents(dir: &Path) -> Vec<AgentConfig> {
     let parsed: Vec<AgentConfig> = discover_agents(dir)
         .into_iter()
-        .filter_map(|(name, path)| match AgentConfig::load(&path) {
-            Ok(cfg) => Some(cfg),
-            Err(e) => {
-                tracing::warn!("skipping agent '{name}': {e}");
-                None
+        .filter_map(|(name, path)| {
+            let loaded = if path.extension().and_then(|e| e.to_str()) == Some("md") {
+                md_loader::load_md_agent(&path)
+            } else {
+                AgentConfig::load(&path)
+            };
+            match loaded {
+                Ok(cfg) => Some(cfg),
+                Err(e) => {
+                    tracing::warn!("skipping agent '{name}': {e}");
+                    None
+                }
             }
         })
         .collect();
@@ -148,8 +214,11 @@ mod tests {
 
     /// `discover_agents` finds TOML files and returns sorted (name, path) pairs.
     ///
-    /// Why: Verify the scanning and sorting logic.
-    /// What: Place two TOML + one non-TOML in a tempdir; assert two results in order.
+    /// Why: Verify the scanning and sorting logic. Uses a `.txt` file (not
+    /// `.md`) as the "irrelevant extension" fixture — since #2897, `.md` is a
+    /// legitimate discovered agent format, not an ignorable extension.
+    /// What: Place two TOML + one `.txt` in a tempdir; assert two results in
+    /// order.
     /// Test: This test.
     #[test]
     fn discover_agents_finds_tomls() {
@@ -164,11 +233,59 @@ mod tests {
             "[agent]\nname=\"engineer\"\n",
         )
         .expect("write");
-        std::fs::write(tmp.path().join("README.md"), "docs").expect("write");
+        std::fs::write(tmp.path().join("README.txt"), "docs").expect("write");
 
         let agents = discover_agents(tmp.path());
         let names: Vec<&str> = agents.iter().map(|(n, _)| n.as_str()).collect();
         assert_eq!(names, vec!["engineer", "qa-agent"], "sorted by name");
+    }
+
+    /// `discover_agents` also finds `.md` files (#2897 dark launch), sorted
+    /// alongside `.toml` results by name.
+    ///
+    /// Why: both formats must coexist in discovery this slice.
+    /// What: one `.toml` + one `.md`, distinct names; both are discovered.
+    /// Test: this test.
+    #[test]
+    fn discover_agents_finds_md() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("engineer.toml"),
+            "[agent]\nname=\"engineer\"\n",
+        )
+        .expect("write");
+        std::fs::write(
+            tmp.path().join("md-agent.md"),
+            "---\nname: md-agent\n---\n\nBody.\n",
+        )
+        .expect("write");
+
+        let agents = discover_agents(tmp.path());
+        let names: Vec<&str> = agents.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["engineer", "md-agent"], "sorted by name");
+    }
+
+    /// When both a `<name>.toml` and `<name>.md` exist for the same agent
+    /// name, the `.toml` deterministically wins (established format, during
+    /// the `.md` dark launch).
+    ///
+    /// Why: pins the collision-resolution policy so it can't silently flip
+    /// with `HashMap` iteration order.
+    /// What: `dup.toml` and `dup.md`, both named `dup`; `discover_agents`
+    /// returns exactly one `dup` entry pointing at the `.toml` path.
+    /// Test: this test.
+    #[test]
+    fn discover_agents_toml_wins_on_collision() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let toml_path = tmp.path().join("dup.toml");
+        std::fs::write(&toml_path, "[agent]\nname=\"dup\"\n").expect("write toml");
+        std::fs::write(tmp.path().join("dup.md"), "---\nname: dup\n---\n\nBody.\n")
+            .expect("write md");
+
+        let agents = discover_agents(tmp.path());
+        assert_eq!(agents.len(), 1, "collision must resolve to one entry");
+        assert_eq!(agents[0].0, "dup");
+        assert_eq!(agents[0].1, toml_path, "the .toml path must win");
     }
 
     /// `discover_agents` returns empty when the directory does not exist.
@@ -260,6 +377,43 @@ mod tests {
         let agents = load_all_agents(tmp.path());
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].agent.name, "custom");
+    }
+
+    /// `load_all_agents` loads `.md` agents alongside `.toml` agents (#2897
+    /// dark launch) — both dispatch through the same discover/load/collect
+    /// pipeline.
+    ///
+    /// Why: proves `load_all_agents` actually routes `.md` paths to
+    /// `md_loader::load_md_agent`, not just that `discover_agents` finds them.
+    /// What: one `.toml` agent + one `.md` agent on disk; both appear in the
+    /// loaded result with correctly projected fields.
+    /// Test: this test.
+    #[test]
+    fn load_all_agents_loads_md_agents() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("toml-agent.toml"),
+            "[agent]\nname=\"toml-agent\"\n",
+        )
+        .expect("write toml");
+        std::fs::write(
+            tmp.path().join("md-agent.md"),
+            "---\nname: md-agent\nmodel: sonnet\n---\n\nAn md-format agent.\n",
+        )
+        .expect("write md");
+
+        let agents = load_all_agents(tmp.path());
+        let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
+        assert_eq!(agents.len(), 2, "both formats must load");
+        assert!(names.contains(&"toml-agent"));
+        assert!(names.contains(&"md-agent"));
+
+        let md_cfg = agents
+            .iter()
+            .find(|a| a.agent.name == "md-agent")
+            .expect("md-agent present");
+        assert_eq!(md_cfg.agent.model.as_deref(), Some("sonnet"));
+        assert_eq!(md_cfg.system_prompt.content, "An md-format agent.");
     }
 
     /// `locate_agents_dir` prefers `.claude/agents`, falls back to


### PR DESCRIPTION
## Summary

Slice B of the #2897 tcode agent-format unification (epic #2892): gives
trusty-code (tcode) a Markdown+frontmatter (`.md`) agent loader that reuses
trusty-agents-common's compose machinery (Slice A, #2952), DARK-LAUNCHED
alongside the existing TOML loader. Both formats work after this slice; TOML
retirement is Slice D. Purely additive and behavior-preserving.

## Entry point used

`trusty-agents-common::agents::builder::compose_agent(name, source_dir) ->
Result<String, AgentBuildError>` resolves the `extends:` chain into one
flattened Markdown document (merged frontmatter block + concatenated body).
`trusty-agents-common::agents::metadata::agent_metadata_from_str(&composed) ->
AgentMetadata` then parses the public, stable-shaped frontmatter projection
(`name`/`role`/`description`/`model`/`extends`/`skills`/`max_tokens`/`tools`)
from that same string. These are the only two public entry points
trusty-agents-common exposes for this — `Frontmatter` and `split_frontmatter`
are `pub(crate)`, so `md_loader.rs` extracts the body itself by scanning past
the closing `---` fence (mirrors `split_frontmatter`'s delimiter logic without
needing the key/value grammar, since field extraction already comes from
`AgentMetadata`).

## Projection mapping (`crates/trusty-code/src/agents/md_loader.rs`)

| Frontmatter (via `AgentMetadata`) | tcode `AgentConfig` field |
|---|---|
| `name` (falls back to file stem) | `agent.name` |
| `role` | `agent.role` |
| `description` | `agent.description` |
| `model` | `agent.model` (matches the TOML fixtures' `[agent].model`, the higher-precedence slot per `provider::routing::resolve_model`) |
| `max_tokens` | `llm.max_tokens` |
| `tools: Option<Vec<String>>` | `ToolsConfig.allowed` — **direct map**. Both sides share identical `None`=all-allowed / `Some([])`=deny-all / `Some(list)`=allowlist semantics (this is exactly why Slice A made `tools` an `Option`, not a bare `Vec`). Always wrapped in `Some(ToolsConfig { allowed })` — safe because `runner::in_process` consumes it via `agent.tools.as_ref().and_then(|t| t.allowed.as_ref())`, which treats an absent `[tools]` section and a present-but-unset `allowed` identically. |
| composed prose body | `system_prompt.content` |
| `skills:` | **dropped**, see gap note below |

## The `skills:` gap

`SystemPrompt::append_skills: Vec<String>` exists in tcode's schema but has
**no consumer anywhere in the codebase** — verified via
`grep -rn append_skills crates/trusty-code/src`, which only shows the field
declaration and the three bundled TOML assets that set it (never read back).
The shared frontmatter's `skills:` list is real and populated (DOC-42,
#2889), but per the scoping instructions I did not invent a consumer for it
in this slice — dropped with a doc comment explaining the gap, left for a
future slice that adds an actual skills consumer to tcode.

## TOML-vs-`.md` collision precedence

`discover_agents` now scans both `*.toml` and `*.md`. In the edge case where
both `<name>.toml` and `<name>.md` exist for the same agent name, the
**`.toml` deterministically wins** (a `tracing::warn!` is logged) — it's the
established, still-authoritative format during this dark launch. `HashMap`
iteration order is not relied on; the winner is picked explicitly regardless
of directory scan order. `load_all_agents` dispatches each discovered path to
the TOML or `.md` loader by extension.

## HR-1 `initialPrompt` guard

`compose_agent`'s merge step (`merge_frontmatter`, in trusty-agents-common)
auto-injects a role-derived `initialPrompt` into the frontmatter block for
`role: engineer`/`role: qa`/etc. (HR-1 Part B, keyed off trusty-mpm's role
table) — and tcode's own role vocabulary collides with that table by name.
Two independent guarantees keep this from leaking into
`system_prompt.content`:

1. `AgentMetadata` (the public frontmatter projection) has **no
   `initial_prompt` field at all** — there's no accessor that could carry it
   through.
2. `md_loader::extract_body` never inspects the frontmatter block's
   *contents* — it locates the closing `---` fence structurally and returns
   only what follows, so the injected `initialPrompt` (which lives inside the
   frontmatter block) is structurally excluded from the body.

Verified by `hr1_initial_prompt_not_leaked_into_body`, a `role: engineer`
`.md` fixture whose `system_prompt.content` is asserted to equal exactly its
authored body with no HR-1 preamble text present anywhere.

## Tests added

- `md_loader.rs`: `load_md_agent_base_case`, `tools_projection_absent_is_none`,
  `tools_projection_empty_list_is_deny_all`, `tools_projection_list_is_allowlist`,
  `hr1_initial_prompt_not_leaked_into_body`,
  `load_md_agent_with_extends_resolves_chain`,
  `load_md_agent_missing_file_errors`, **`parallel_fixture_equivalence`**
  (the same agent authored as `.toml` and `.md`, field-identical
  `model`/`max_tokens`/`tools.allowed`/`system_prompt.content`).
- `agents/mod.rs`: `discover_agents_finds_md`,
  `discover_agents_toml_wins_on_collision`, `load_all_agents_loads_md_agents`.
  Also fixed a pre-existing test (`discover_agents_finds_tomls`) that used a
  `README.md` fixture to exercise "non-agent-extension" behavior — `.md` is
  now a legitimate discovered extension, so the fixture was switched to
  `.txt`.

## Verification (scoped; workspace `cargo test --workspace` was NOT run, per
instructions — it exceeds the 10-min bash timeout)

```
$ cargo build -p trusty-code --all-targets
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s   (clean)

$ cargo test -p trusty-code
test result: ok. 1108 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out

$ cargo clippy -p trusty-code --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s   (0 warnings)

$ cargo fmt --check
(no diff)

$ bash scripts/check_line_cap.sh
line-cap: 9 allowlisted, 0 violations — OK.
```

Note: `run_task::tests::exit_code_reflects_run_failure` intermittently fails
under full parallel test-suite runs (a `catchup: could not reach
trusty-memory at http://127.0.0.1:19999` network-timing race against other
parallel tests) — reproduced identically against unmodified `origin/main`
(stashed my changes and reran), and passes reliably every time in isolation
(`--test-threads=1`, 5/5 runs) and in the two full-suite runs shown above.
Pre-existing flake, unrelated to this change.

refs #2897 refs #2892

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools