### PR TITLE
feat(trusty-code)!: retire TOML agent loader, .md-only (closes #2897)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -182,8 +182,6 @@ crates/trusty-code/src/provider/openrouter.rs	supports_native_tools_claude
 crates/trusty-code/src/provider/traits.rs	bedrock_does_not_support_prompt_caching
 crates/trusty-code/src/rbac/mod.rs	default_is_local_cli_all
 crates/trusty-code/src/run_task/mod.rs	diff_reflects_engineer_file_change
-crates/trusty-code/src/run_task/mod.rs	resolve_agent_model_slug_falls_back_when_config_missing
-crates/trusty-code/src/run_task/mod.rs	resolve_agent_model_slug_honours_override
 crates/trusty-code/src/run_task/recorder.rs	recorder_flags_ran_test_command_on_matching_bash_call
 crates/trusty-code/src/runner/in_process.rs	with_timeout_secs_overrides_only_timeout
 crates/trusty-code/src/serve/http.rs	http_session_events_sse_streams_replay_then_live_event

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10945,7 +10945,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "toml 0.8.23",
  "tower",
  "tracing",
  "tracing-subscriber",

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -83,6 +83,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **BREAKING — the TOML agent loader is retired; `.claude/agents/*.toml` is
+  no longer read at all (#2897, epic #2892, Slice D).** `AgentConfig::load`
+  and `AgentConfig::from_toml_str` are deleted, along with the `toml` crate
+  dependency. `discover_agents` now globs `*.md` ONLY — a project whose
+  `.claude/agents/` still holds `.toml` files gets a LOUD, aggregated
+  `tracing::warn!` naming every orphaned file and pointing at the new
+  converter script, then those files are skipped (never parsed, never
+  erroring). If disk holds nothing but orphaned `.toml` (or nothing at all),
+  `load_all_agents` falls back to the embedded `engineer`/`qa-agent`/
+  `code-reviewer` defaults exactly as it does for an empty directory — a
+  project is never left with zero agents. **Migration:** run
+  `scripts/migrate-tcode-agents-toml-to-md.py <path-to-.toml-or-dir>` to
+  convert existing `.toml` agents to the `.md`+frontmatter format (dark-launched
+  in Slice B, #2897) that has been the primary format since Slice C; delete
+  the `.toml` sources once you've reviewed the generated `.md`. This
+  completes the #2897 epic (#2892): TOML -> `.md` is now a one-way door.
 - **trusty-code now depends on `trusty-agents-common`; `ServiceTier`,
   `RunContext`, and `HistoryMessage` are re-exported instead of redeclared
   (#2893, epic #2892).** `crates/trusty-code/src/tools/traits.rs` re-declared

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -49,8 +49,6 @@ async-trait = { workspace = true }
 # already re-exports from here (see crates/trusty-agents/src/tools/traits.rs).
 trusty-agents-common = { workspace = true }
 
-# Phase 3: TOML config parsing for AgentConfig
-toml = { workspace = true }
 
 # Structured error types for library code (FsError, LlmError, etc.)
 thiserror = { workspace = true }

--- a/crates/trusty-code/src/agents/config.rs
+++ b/crates/trusty-code/src/agents/config.rs
@@ -1,20 +1,31 @@
 //! Agent configuration schema for tcode.
 //!
-//! Why: Sub-agents (and the PM itself) are defined declaratively in TOML so
-//! model, prompt, and LLM parameters can evolve without code changes.
-//! What: `AgentConfig` and all nested config types, deserializable from the
-//! `.claude/agents/<name>.toml` format compatible with Claude Code sub-agents.
-//! Test: `AgentConfig::from_toml_str` on inline TOML succeeds and round-trips.
+//! Why: Sub-agents (and the PM itself) are defined declaratively so model,
+//! prompt, and LLM parameters can evolve without code changes. As of #2897
+//! Slice D, the on-disk source format is Markdown+frontmatter
+//! (`.claude/agents/<name>.md`) ONLY — the original TOML loader
+//! (`AgentConfig::from_toml_str`/`AgentConfig::load`) has been retired; see
+//! `agents::md_loader` for the current loader and
+//! `scripts/migrate-tcode-agents-toml-to-md.py` for the one-time converter a
+//! project with pre-#2897 `.toml` agent files should run.
+//! What: `AgentConfig` and all nested config types. These are pure data
+//! structs — format-agnostic — that `agents::md_loader::project_to_agent_config`
+//! populates from a composed `.md` document's frontmatter + body.
+//! Test: `agent_config_default_is_empty`, `runner_kind_defaults_to_in_process`;
+//! the loading path itself is covered by `agents::md_loader::tests::*`.
 
 use serde::{Deserialize, Serialize};
 
-/// Top-level agent configuration loaded from `<name>.toml`.
+/// Top-level agent configuration.
 ///
 /// Why: Declarative agent configs let operators define or override agents
 /// without touching Rust code.
 /// What: `agent` carries identity/role; `llm` carries model/token params;
 /// `system_prompt` carries the prompt text; optional sections add capabilities.
-/// Test: `agent_config_roundtrip`, `agent_config_minimal`.
+/// Populated by `agents::md_loader::project_to_agent_config` from a composed
+/// `.md` agent document.
+/// Test: `agent_config_default_is_empty`; `agents::md_loader::tests::*` cover
+/// the actual field-projection contract end-to-end.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AgentConfig {
     /// Core identity fields.
@@ -33,34 +44,12 @@ pub struct AgentConfig {
     pub runner: Option<RunnerConfig>,
 }
 
-impl AgentConfig {
-    /// Parse an `AgentConfig` from a TOML string.
-    ///
-    /// Why: Useful in tests and for in-process loading of bundled config.
-    /// What: Delegates to `toml::from_str`.
-    /// Test: `agent_config_roundtrip`.
-    pub fn from_toml_str(s: &str) -> Result<Self, toml::de::Error> {
-        toml::from_str(s)
-    }
-
-    /// Load an `AgentConfig` from a TOML file on disk.
-    ///
-    /// Why: Primary entry point for the agent loader during harness startup.
-    /// What: Reads the file, then calls `from_toml_str`.
-    /// Test: Integration tests place a TOML file in a tempdir and call this.
-    pub fn load(path: &std::path::Path) -> anyhow::Result<Self> {
-        let src = std::fs::read_to_string(path)
-            .map_err(|e| anyhow::anyhow!("failed to read agent config {}: {e}", path.display()))?;
-        toml::from_str(&src)
-            .map_err(|e| anyhow::anyhow!("invalid agent config {}: {e}", path.display()))
-    }
-}
-
 /// Core identity fields for an agent.
 ///
 /// Why: Every agent needs a stable `name` (the dispatch key) and `model`.
 /// What: `name`, optional `role`, optional `model`.
-/// Test: `agent_config_minimal` asserts that `name` is loaded.
+/// Test: `agent_config_default_is_empty` asserts the zero-value default;
+/// `agents::md_loader::tests::load_md_agent_base_case` covers real loading.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AgentInfo {
     /// The agent's dispatch key (e.g. `"engineer"`, `"python-engineer"`).
@@ -152,7 +141,7 @@ pub struct RunnerConfig {
 /// What: `InProcess` is the default (drives the sub-agent's `AgentLoop` in the
 /// same process — see `crate::runner::InProcessAgentRunner`); `SubProcess` spawns
 /// a new process via NDJSON IPC; `ClaudeCode` wraps the `claude` CLI binary.
-/// Test: `runner_kind_deserializes`, `runner_kind_defaults_to_in_process`.
+/// Test: `runner_kind_defaults_to_in_process`.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum RunnerKind {
@@ -171,85 +160,25 @@ pub enum RunnerKind {
 mod tests {
     use super::*;
 
-    const MINIMAL_TOML: &str = r#"
-[agent]
-name = "engineer"
-"#;
-
-    const FULL_TOML: &str = r#"
-[agent]
-name = "python-engineer"
-role = "engineer"
-model = "anthropic/claude-sonnet-4-6"
-description = "Python software engineer"
-
-[llm]
-temperature = 0.2
-max_tokens = 8192
-
-[system_prompt]
-content = "You are a Python expert."
-
-[tools]
-allowed = ["delegate_to_agent", "search_code"]
-
-[runner]
-kind = "claude_code"
-"#;
-
-    /// Minimal config with only `[agent].name` parses successfully.
+    /// `AgentConfig::default()` yields the expected all-empty baseline.
     ///
-    /// Why: Operators should be able to define a minimal agent without
-    /// specifying every optional field.
-    /// What: `from_toml_str(MINIMAL_TOML)` returns `Ok` with `name == "engineer"`.
-    /// Test: This test.
+    /// Why: #2897 Slice D retired the TOML parsing tests (`from_toml_str`
+    /// itself is gone); the actual frontmatter -> `AgentConfig` field mapping
+    /// is now covered end-to-end by `agents::md_loader::tests::*`
+    /// (`load_md_agent_base_case`, `parallel fixture` field assertions,
+    /// etc.). What remains testable in THIS module is the plain-data
+    /// `Default` contract every construction path relies on.
+    /// What: every field is the type's zero value; `tools`/`runner` are
+    /// `None`.
+    /// Test: this test.
     #[test]
-    fn agent_config_minimal() {
-        let cfg = AgentConfig::from_toml_str(MINIMAL_TOML).expect("parse minimal");
-        assert_eq!(cfg.agent.name, "engineer");
+    fn agent_config_default_is_empty() {
+        let cfg = AgentConfig::default();
+        assert_eq!(cfg.agent.name, "");
         assert!(cfg.agent.model.is_none());
         assert!(cfg.tools.is_none());
-    }
-
-    /// Full config round-trips through TOML parsing.
-    ///
-    /// Why: Verify all fields are decoded correctly.
-    /// What: `from_toml_str(FULL_TOML)` round-trips all fields.
-    /// Test: This test.
-    #[test]
-    fn agent_config_roundtrip() {
-        let cfg = AgentConfig::from_toml_str(FULL_TOML).expect("parse full");
-        assert_eq!(cfg.agent.name, "python-engineer");
-        assert_eq!(
-            cfg.agent.model.as_deref(),
-            Some("anthropic/claude-sonnet-4-6")
-        );
-        assert_eq!(cfg.llm.temperature, Some(0.2));
-        assert_eq!(cfg.llm.max_tokens, Some(8192));
-        assert_eq!(cfg.system_prompt.content, "You are a Python expert.");
-        let allowed = cfg.tools.as_ref().and_then(|t| t.allowed.as_ref());
-        let expected: Vec<String> =
-            vec!["delegate_to_agent".to_string(), "search_code".to_string()];
-        assert_eq!(allowed.map(|v| v.as_slice()), Some(expected.as_slice()));
-        assert_eq!(
-            cfg.runner.as_ref().map(|r| &r.kind),
-            Some(&RunnerKind::ClaudeCode)
-        );
-    }
-
-    /// `RunnerKind` deserializes from `snake_case` strings via a TOML wrapper table.
-    ///
-    /// Why: Verify the serde rename_all contract.
-    /// What: Parse a `[runner]` table with `kind = "claude_code"` → `RunnerKind::ClaudeCode`.
-    /// Test: This test.
-    #[test]
-    fn runner_kind_deserializes() {
-        #[derive(serde::Deserialize)]
-        struct Wrapper {
-            kind: RunnerKind,
-        }
-        let w: Wrapper = toml::from_str("kind = \"claude_code\"").expect("parse runner kind");
-        assert_eq!(w.kind, RunnerKind::ClaudeCode);
+        assert!(cfg.runner.is_none());
+        assert_eq!(cfg.system_prompt.content, "");
     }
 
     /// `RunnerKind` defaults to `InProcess` (the real default since #1029).
@@ -257,16 +186,17 @@ kind = "claude_code"
     /// Why: The acceptance criterion for #1029 makes the in-process runner the
     /// production default; a regression that flipped it back to `SubProcess`
     /// would silently route every undeclared agent through the wrong backend.
-    /// What: `RunnerKind::default()` equals `InProcess`; an agent config with no
-    /// `[runner]` table leaves `runner` `None` (callers treat absence as default).
+    /// What: `RunnerKind::default()` equals `InProcess`; a default-constructed
+    /// `AgentConfig` (mirroring an agent with no `[runner]`/no runner
+    /// frontmatter) leaves `runner` `None` (callers treat absence as default).
     /// Test: this test.
     #[test]
     fn runner_kind_defaults_to_in_process() {
         assert_eq!(RunnerKind::default(), RunnerKind::InProcess);
-        let cfg = AgentConfig::from_toml_str(MINIMAL_TOML).expect("parse minimal");
+        let cfg = AgentConfig::default();
         assert!(
             cfg.runner.is_none(),
-            "absent [runner] leaves runner None; callers apply the InProcess default"
+            "absent runner config leaves runner None; callers apply the InProcess default"
         );
     }
 }

--- a/crates/trusty-code/src/agents/md_loader.rs
+++ b/crates/trusty-code/src/agents/md_loader.rs
@@ -1,15 +1,14 @@
-//! Markdown+frontmatter agent loader for tcode, DARK-LAUNCHED alongside the
-//! TOML loader (issue #2897, epic #2892, Slice B), and now also the loader
-//! for tcode's own EMBEDDED default agents (Slice C).
+//! Markdown+frontmatter agent loader for tcode — the ONLY on-disk agent
+//! source format as of #2897 Slice D (epic #2892). It was DARK-LAUNCHED
+//! alongside the (now-retired) TOML loader in Slice B, and became the loader
+//! for tcode's own EMBEDDED default agents in Slice C.
 //!
 //! Why: trusty-agents-common's `agents::builder` compose machinery (Slice A,
 //! #2952) already resolves `extends:` inheritance chains for trusty-mpm's
 //! `.md` agent format and now carries `max_tokens`/`tools` frontmatter fields
-//! that mirror tcode's TOML `AgentConfig` schema. Rather than fork a second
-//! `.md` parser, tcode reuses that composer and projects its output onto its
-//! existing `AgentConfig`. This is purely additive: the TOML loader
-//! (`AgentConfig::load`) is untouched, and both formats coexist through this
-//! slice. TOML retirement is Slice D. Slice C (#2897) additionally routes
+//! that mirror tcode's `AgentConfig` schema. Rather than fork a second `.md`
+//! parser, tcode reuses that composer and projects its output onto its
+//! existing `AgentConfig`. Slice C (#2897) additionally routes
 //! `crate::assets::DEFAULT_AGENTS`'s embedded fallback through this module:
 //! the embedded strings have no source directory to resolve an `extends:`
 //! chain against (they are compiled-in `&'static str`, not files on disk), so
@@ -26,11 +25,10 @@
 //! frontmatter (via `agents::metadata::agent_metadata_from_str`) and prose
 //! body onto tcode's `AgentConfig`. [`project_embedded_md`] does the same
 //! projection for an in-memory `&'static str` with no `extends:` resolution.
-//! Test: `parallel_fixture_equivalence` (same agent authored as `.toml` and
-//! `.md` load to field-identical configs), `tools_projection_*` (the
+//! Test: `load_md_agent_base_case`, `tools_projection_*` (the
 //! `Option<Vec<String>>` direct-map), `hr1_initial_prompt_not_leaked_into_body`
 //! (the HR-1 guard), `assets::tests::*` (embedded-default field-identity vs.
-//! the retired TOML fixtures).
+//! the retired TOML fixtures, kept as a historical regression pin).
 
 use std::path::Path;
 
@@ -41,18 +39,16 @@ use super::config::{AgentConfig, AgentInfo, LlmParams, SystemPrompt, ToolsConfig
 
 /// Load a tcode [`AgentConfig`] from a `.md` agent source file.
 ///
-/// Why: primary entry point for the `.md` loader, mirroring
-/// `AgentConfig::load`'s role for the TOML path — both take a file path and
-/// return a fully-populated `AgentConfig` or a descriptive error.
+/// Why: the primary entry point for the (now sole) agent loader — takes a
+/// file path and returns a fully-populated `AgentConfig` or a descriptive
+/// error.
 /// What: resolves `path`'s parent directory as the `extends:` source dir and
 /// its file stem as the agent name, composes the inheritance chain via
 /// `compose_agent`, then projects the result via [`project_to_agent_config`].
 /// A missing parent directory, an unreadable file stem, or any
 /// `AgentBuildError` (not found, cycle, depth exceeded, malformed
-/// frontmatter) is surfaced as a descriptive `anyhow::Error` — never a panic —
-/// matching `AgentConfig::load`'s fallibility contract so `load_all_agents`
-/// can handle both loaders identically.
-/// Test: `parallel_fixture_equivalence`, `load_md_agent_missing_file_errors`,
+/// frontmatter) is surfaced as a descriptive `anyhow::Error` — never a panic.
+/// Test: `load_md_agent_base_case`, `load_md_agent_missing_file_errors`,
 /// `load_md_agent_with_extends_resolves_chain`.
 pub fn load_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
     let source_dir = path
@@ -351,8 +347,9 @@ mod tests {
 
     /// A missing `.md` file surfaces a descriptive error, never a panic.
     ///
-    /// Why: matches `AgentConfig::load`'s fallibility contract so
-    /// `load_all_agents` can `filter_map` over both loaders identically.
+    /// Why: `load_all_agents` needs a fallible, never-panicking contract so
+    /// it can `filter_map` a directory listing without one bad path
+    /// crashing the whole scan.
     /// What: `load_md_agent` on a nonexistent path returns `Err`.
     /// Test: this test.
     #[test]
@@ -361,41 +358,42 @@ mod tests {
         assert!(result.is_err());
     }
 
-    /// Parallel-fixture equivalence: the SAME agent authored as `.toml` and
-    /// as `.md` load to field-identical `AgentConfig`s.
+    /// A full-fidelity `.md` fixture projects every field the schema exposes
+    /// in one document (name, role, model, max_tokens, tools, system-prompt
+    /// body) — the successor to Slice B's retired
+    /// `parallel_fixture_equivalence` (which additionally compared against a
+    /// hand-authored TOML twin; #2897 Slice D removed the TOML loader that
+    /// comparison depended on, so this test keeps the full-field-set
+    /// assertion on the `.md` fixture alone).
     ///
-    /// Why: the acceptance criterion for Slice B — both formats must produce
-    /// the same runtime behavior for an operator migrating a config.
-    /// What: hand-authors matching TOML and `.md` fixtures (same name, model,
-    /// max_tokens, tools, and system-prompt body), loads both, and asserts
-    /// `model`, `max_tokens`, `tools.allowed`, and `system_prompt.content`
-    /// are equal.
+    /// Why: pins that every projected field — not just the ones individual
+    /// narrower tests each cover — round-trips together from one realistic
+    /// agent document.
+    /// What: one `.md` fixture setting every field; asserts `model`,
+    /// `max_tokens`, `tools.allowed`, and `system_prompt.content` all match
+    /// the authored values.
     /// Test: this test.
     #[test]
-    fn parallel_fixture_equivalence() {
+    fn full_fidelity_md_fixture_projects_every_field() {
         let tmp = tempfile::tempdir().expect("tempdir");
 
-        std::fs::write(
-            tmp.path().join("twin.toml"),
-            "[agent]\nname = \"twin\"\nrole = \"engineer\"\nmodel = \"sonnet\"\n\n[llm]\nmax_tokens = 8192\n\n[system_prompt]\ncontent = \"You are a twin agent.\"\n\n[tools]\nallowed = [\"read_file\", \"grep\"]\n",
-        )
-        .expect("write toml");
         std::fs::write(
             tmp.path().join("twin.md"),
             "---\nname: twin\nrole: engineer\nmodel: sonnet\nmax_tokens: 8192\ntools: [read_file, grep]\n---\n\nYou are a twin agent.\n",
         )
         .expect("write md");
 
-        let toml_cfg = AgentConfig::load(&tmp.path().join("twin.toml")).expect("load toml");
-        let md_cfg = load_md_agent(&tmp.path().join("twin.md")).expect("load md");
+        let cfg = load_md_agent(&tmp.path().join("twin.md")).expect("load md");
 
-        assert_eq!(toml_cfg.agent.model, md_cfg.agent.model);
-        assert_eq!(toml_cfg.llm.max_tokens, md_cfg.llm.max_tokens);
+        assert_eq!(cfg.agent.name, "twin");
+        assert_eq!(cfg.agent.role.as_deref(), Some("engineer"));
+        assert_eq!(cfg.agent.model.as_deref(), Some("sonnet"));
+        assert_eq!(cfg.llm.max_tokens, Some(8192));
         assert_eq!(
-            toml_cfg.tools.and_then(|t| t.allowed),
-            md_cfg.tools.and_then(|t| t.allowed)
+            cfg.tools.and_then(|t| t.allowed),
+            Some(vec!["read_file".to_string(), "grep".to_string()])
         );
-        assert_eq!(toml_cfg.system_prompt.content, md_cfg.system_prompt.content);
+        assert_eq!(cfg.system_prompt.content, "You are a twin agent.");
     }
 
     /// `extract_body` closes the frontmatter block on the FIRST `---` fence

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -1,26 +1,29 @@
 //! Agent configuration loading and types for tcode.
 //!
-//! Why: Sub-agents (and the PM itself) are defined declaratively in TOML files
-//! under `.claude/agents/` so model, prompt, and LLM parameters can evolve
-//! without code changes. This module is the assembly point for config types
-//! and the discovery helpers. As of #2897 (epic #2892, Slice B) a Markdown+
-//! frontmatter `.md` loader ([`md_loader`]) is DARK-LAUNCHED alongside the
-//! TOML loader — both formats are discovered and loaded; TOML retirement is
-//! a later slice (D).
+//! Why: Sub-agents (and the PM itself) are defined declaratively under
+//! `.claude/agents/` so model, prompt, and LLM parameters can evolve without
+//! code changes. This module is the assembly point for config types and the
+//! discovery helpers. As of #2897 Slice D the on-disk source format is
+//! Markdown+frontmatter (`.md`) ONLY — the TOML loader that was
+//! DARK-LAUNCHED alongside `.md` in Slice B (#2897) has been retired.
+//! Pre-#2897 projects with `.claude/agents/*.toml` files must convert them;
+//! see [`discover_agents`]'s orphaned-`.toml` warning and
+//! `scripts/migrate-tcode-agents-toml-to-md.py`.
 //! What: Re-exports `AgentConfig` and all nested config types from `config`;
-//! provides `discover_agents` for scanning an agents directory (now `*.toml`
-//! AND `*.md`), and `load_all_agents` for loading every config in it,
-//! dispatching to the TOML or `.md` loader by extension. `load_all_agents`
-//! falls back to `crate::assets::DEFAULT_AGENTS` (#2895) when the *parsed*
-//! result is empty — not merely when no paths were discovered — so a
-//! `.claude/agents/` dir that exists but holds only unparseable configs still
-//! yields a usable `engineer`/`qa-agent`/`code-reviewer` set instead of
-//! silently starting with zero agents. A disk directory with even one
+//! provides `discover_agents` for scanning an agents directory (`*.md`
+//! only — a coexisting `*.toml` is warned about and skipped, never parsed),
+//! and `load_all_agents` for loading every discovered `.md` config.
+//! `load_all_agents` falls back to `crate::assets::DEFAULT_AGENTS` (#2895)
+//! when the *parsed* result is empty — not merely when no paths were
+//! discovered — so a `.claude/agents/` dir that exists but holds only
+//! unparseable (or exclusively orphaned-`.toml`) configs still yields a
+//! usable `engineer`/`qa-agent`/`code-reviewer` set instead of silently
+//! starting with zero agents. A disk directory with even one
 //! successfully-parsed config is treated as the project opting in to its own
 //! catalog, so it is used as-is and the embedded defaults are not merged in.
-//! Test: `discover_agents` tests place TOML/`.md` files in a tempdir and
-//! verify the returned list. `AgentConfig::load` tests read individual TOML
-//! files; `md_loader`'s own tests cover the `.md` path.
+//! Test: `discover_agents` tests place `.md` (and, for the orphan-warning
+//! path, `.toml`) files in a tempdir and verify the returned list;
+//! `md_loader`'s own tests cover the loader itself.
 //! `load_all_agents_falls_back_to_embedded_when_disk_empty`,
 //! `load_all_agents_falls_back_to_embedded_when_disk_all_invalid`, and
 //! `load_all_agents_disk_wins_when_present` cover the fallback threshold.
@@ -33,85 +36,78 @@ pub use config::{
 };
 pub use md_loader::load_md_agent;
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Discover all agent configs in the given directory.
 ///
 /// Why: tcode needs to know which agents are available before the PM loop
 /// starts so it can validate `delegate_to_agent` calls pre-flight. As of
-/// #2897 both `.toml` (existing) and `.md` (dark-launched) source files are
-/// discovered, since both loaders coexist this slice.
-/// What: Scans `dir/*.toml` and `dir/*.md`, keyed by file stem (the agent
-/// name), and returns `(name, path)` pairs sorted by name. When BOTH a
-/// `<name>.toml` and `<name>.md` exist for the same agent name — an edge
-/// case, not the common single-format-per-agent path — the `.toml` wins
-/// deterministically and a warning is logged: the TOML loader is the
-/// established, still-authoritative format during this dark launch (`.md`
-/// retirement of TOML is Slice D), so an operator who has not yet migrated
-/// a given agent keeps getting the config they already have.
-/// Test: `discover_agents_finds_tomls`, `discover_agents_finds_md`,
-/// `discover_agents_toml_wins_on_collision`.
-pub fn discover_agents(dir: &Path) -> Vec<(String, std::path::PathBuf)> {
+/// #2897 Slice D, `.toml` is no longer a loadable format — a project that
+/// has not migrated yet must be told LOUDLY, not silently ignored, or its
+/// agents would appear to vanish with no diagnostic.
+/// What: Scans `dir/*.md` and returns `(name, path)` pairs sorted by
+/// file-stem name. Any `dir/*.toml` file found in the SAME scan is never
+/// parsed and never appears in the returned list; instead every orphaned
+/// `.toml` path found in this call is named in ONE aggregated
+/// `tracing::warn!` pointing at the migration script — one call per
+/// `discover_agents` invocation (not one per file) so a directory with
+/// several un-migrated files does not spam the log, and no process-global
+/// latch is used (the crate convention is no global/`Once`-gated state for
+/// plain helpers — see repo `CLAUDE.md`), so the warning fires again on
+/// every subsequent scan for as long as the orphaned file remains.
+/// Test: `discover_agents_finds_md`, `discover_agents_ignores_toml`,
+/// `discover_agents_warns_on_orphaned_toml`,
+/// `discover_agents_missing_dir_is_empty`.
+pub fn discover_agents(dir: &Path) -> Vec<(String, PathBuf)> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         tracing::debug!("agents dir not found or unreadable: {}", dir.display());
         return vec![];
     };
 
-    // `is_toml` tracked per entry so a same-name `.toml`/`.md` collision can
-    // be resolved deterministically (TOML wins) regardless of directory
-    // iteration order.
-    let mut by_name: HashMap<String, (std::path::PathBuf, bool)> = HashMap::new();
+    let mut agents: Vec<(String, PathBuf)> = Vec::new();
+    let mut orphaned_toml: Vec<PathBuf> = Vec::new();
     for entry in entries.flatten() {
         let p = entry.path();
-        let ext = p.extension().and_then(|x| x.to_str());
-        let is_toml = ext == Some("toml");
-        let is_md = ext == Some("md");
-        if !is_toml && !is_md {
-            continue;
-        }
-        let Some(name) = p.file_stem().and_then(|s| s.to_str()) else {
-            continue;
-        };
-        let name = name.to_string();
-
-        match by_name.get(&name) {
-            None => {
-                by_name.insert(name, (p, is_toml));
-            }
-            Some((existing_path, existing_is_toml)) => {
-                if *existing_is_toml {
-                    // Existing entry is already the winning `.toml`; an `.md`
-                    // for the same name loses.
-                    tracing::warn!(
-                        "agent '{name}' has both {} and {} — using the .toml \
-                         (established format wins during the .md dark launch)",
-                        existing_path.display(),
-                        p.display()
-                    );
-                } else if is_toml {
-                    // The `.md` seen first loses to this later `.toml`.
-                    tracing::warn!(
-                        "agent '{name}' has both {} and {} — using the .toml \
-                         (established format wins during the .md dark launch)",
-                        p.display(),
-                        existing_path.display()
-                    );
-                    by_name.insert(name, (p, is_toml));
+        match p.extension().and_then(|x| x.to_str()) {
+            Some("md") => {
+                if let Some(name) = p.file_stem().and_then(|s| s.to_str()) {
+                    agents.push((name.to_string(), p));
                 }
-                // Two entries of the same extension for one stem cannot occur
-                // (distinct filenames with identical stem+ext collide on
-                // disk), so no other branch is reachable.
             }
+            Some("toml") => orphaned_toml.push(p),
+            _ => {}
         }
     }
 
-    let mut agents: Vec<(String, std::path::PathBuf)> = by_name
-        .into_iter()
-        .map(|(name, (p, _))| (name, p))
-        .collect();
+    warn_on_orphaned_toml(&orphaned_toml);
+
     agents.sort_by(|a, b| a.0.cmp(&b.0));
     agents
+}
+
+/// Emit one aggregated warning naming every orphaned `.toml` agent file found
+/// in a single [`discover_agents`] scan.
+///
+/// Why: factored out of `discover_agents` so the "one call, every filename"
+/// aggregation rule (see that function's doc) is a single, independently
+/// readable/testable unit rather than inline branching.
+/// What: no-op when `orphaned` is empty; otherwise one `tracing::warn!`
+/// naming issue #2897, every orphaned path (comma-joined), and the
+/// migration script.
+/// Test: `discover_agents_warns_on_orphaned_toml`.
+fn warn_on_orphaned_toml(orphaned: &[PathBuf]) {
+    if orphaned.is_empty() {
+        return;
+    }
+    let names = orphaned
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    tracing::warn!(
+        "trusty-code no longer loads TOML agents (#2897). Found {names} — convert \
+         with scripts/migrate-tcode-agents-toml-to-md.py. See CHANGELOG."
+    );
 }
 
 /// Load all agent configs from the given directory, skipping parse errors.
@@ -119,37 +115,32 @@ pub fn discover_agents(dir: &Path) -> Vec<(String, std::path::PathBuf)> {
 /// Why: Startup needs a map of all available agents; individual parse errors
 /// should not crash the whole harness. A project that has not yet created
 /// `.claude/agents/`, has created it but left it empty, or has populated it
-/// with only unparseable configs must not start with zero agents — see the
-/// embedded-fallback note below.
-/// What: Calls `discover_agents`, then dispatches each discovered path to
-/// `AgentConfig::load` (`.toml`) or [`md_loader::load_md_agent`] (`.md`) by
-/// extension, collecting only the successfully parsed configs (failures are
-/// logged at WARN level and skipped). The fallback threshold is the *parsed*
-/// result being empty, not merely `discover_agents` finding no paths — a
-/// directory full of configs that all fail to parse must fall back exactly
-/// like an empty or missing directory does. Any single successfully-parsed
-/// disk config is treated as the project's own catalog and used as-is, never
+/// with only unparseable (or, post-#2897, only orphaned-`.toml`) configs must
+/// not start with zero agents — see the embedded-fallback note below.
+/// What: Calls `discover_agents` (which already excludes `.toml` paths — see
+/// its doc), then dispatches every discovered `.md` path to
+/// [`md_loader::load_md_agent`], collecting only the successfully parsed
+/// configs (failures are logged at WARN level and skipped). The fallback
+/// threshold is the *parsed* result being empty, not merely `discover_agents`
+/// finding no paths — a directory full of configs that all fail to parse (or
+/// that holds nothing but orphaned `.toml` files) must fall back exactly like
+/// an empty or missing directory does. Any single successfully-parsed disk
+/// config is treated as the project's own catalog and used as-is, never
 /// merged with the embedded set. Falls back to `load_embedded_default_agents`
 /// when parsing yields nothing. Disk agents always win when present.
 /// Test: `load_all_agents_skips_invalid`,
 /// `load_all_agents_falls_back_to_embedded_when_disk_empty`,
 /// `load_all_agents_falls_back_to_embedded_when_disk_all_invalid`,
-/// `load_all_agents_disk_wins_when_present`, `load_all_agents_loads_md_agents`.
+/// `load_all_agents_falls_back_when_disk_has_only_orphaned_toml`,
+/// `load_all_agents_disk_wins_when_present`.
 pub fn load_all_agents(dir: &Path) -> Vec<AgentConfig> {
     let parsed: Vec<AgentConfig> = discover_agents(dir)
         .into_iter()
-        .filter_map(|(name, path)| {
-            let loaded = if path.extension().and_then(|e| e.to_str()) == Some("md") {
-                md_loader::load_md_agent(&path)
-            } else {
-                AgentConfig::load(&path)
-            };
-            match loaded {
-                Ok(cfg) => Some(cfg),
-                Err(e) => {
-                    tracing::warn!("skipping agent '{name}': {e}");
-                    None
-                }
+        .filter_map(|(name, path)| match md_loader::load_md_agent(&path) {
+            Ok(cfg) => Some(cfg),
+            Err(e) => {
+                tracing::warn!("skipping agent '{name}': {e}");
+                None
             }
         })
         .collect();
@@ -190,8 +181,8 @@ fn load_embedded_default_agents() -> Vec<AgentConfig> {
 /// identically whether driven from the CLI or the daemon.
 /// What: returns the first of the two conventional directories that exists;
 /// falls back to `.claude/agents` (which may not exist yet — callers that
-/// need it to exist check separately, e.g. via `AgentConfig::load`'s own
-/// error).
+/// need it to exist check separately, e.g. via [`md_loader::load_md_agent`]'s
+/// own error).
 /// Test: `agents::tests::locate_agents_dir_prefers_claude_then_open_mpm_then_default`.
 pub fn locate_agents_dir(project_root: &Path) -> std::path::PathBuf {
     let claude_agents = project_root.join(".claude").join("agents");
@@ -212,25 +203,25 @@ pub fn locate_agents_dir(project_root: &Path) -> std::path::PathBuf {
 mod tests {
     use super::*;
 
-    /// `discover_agents` finds TOML files and returns sorted (name, path) pairs.
+    /// `discover_agents` finds `.md` files and returns sorted (name, path)
+    /// pairs.
     ///
-    /// Why: Verify the scanning and sorting logic. Uses a `.txt` file (not
-    /// `.md`) as the "irrelevant extension" fixture — since #2897, `.md` is a
-    /// legitimate discovered agent format, not an ignorable extension.
-    /// What: Place two TOML + one `.txt` in a tempdir; assert two results in
+    /// Why: Verify the scanning and sorting logic. Uses a `.txt` file as the
+    /// "irrelevant extension" fixture.
+    /// What: Place two `.md` + one `.txt` in a tempdir; assert two results in
     /// order.
     /// Test: This test.
     #[test]
-    fn discover_agents_finds_tomls() {
+    fn discover_agents_finds_md() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::write(
-            tmp.path().join("qa-agent.toml"),
-            "[agent]\nname=\"qa-agent\"\n",
+            tmp.path().join("qa-agent.md"),
+            "---\nname: qa-agent\n---\n\nBody.\n",
         )
         .expect("write");
         std::fs::write(
-            tmp.path().join("engineer.toml"),
-            "[agent]\nname=\"engineer\"\n",
+            tmp.path().join("engineer.md"),
+            "---\nname: engineer\n---\n\nBody.\n",
         )
         .expect("write");
         std::fs::write(tmp.path().join("README.txt"), "docs").expect("write");
@@ -240,14 +231,16 @@ mod tests {
         assert_eq!(names, vec!["engineer", "qa-agent"], "sorted by name");
     }
 
-    /// `discover_agents` also finds `.md` files (#2897 dark launch), sorted
-    /// alongside `.toml` results by name.
+    /// A `.toml` file in the agents dir is never discovered as an agent
+    /// (#2897 Slice D — TOML is retired, not merely deprioritised).
     ///
-    /// Why: both formats must coexist in discovery this slice.
-    /// What: one `.toml` + one `.md`, distinct names; both are discovered.
+    /// Why: pins that the format cutover is a hard exclusion, not a
+    /// collision-resolution tiebreak (which is what Slice B/C had).
+    /// What: one `.md` + one `.toml`, distinct names; only the `.md` name
+    /// appears in the result.
     /// Test: this test.
     #[test]
-    fn discover_agents_finds_md() {
+    fn discover_agents_ignores_toml() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::write(
             tmp.path().join("engineer.toml"),
@@ -262,30 +255,50 @@ mod tests {
 
         let agents = discover_agents(tmp.path());
         let names: Vec<&str> = agents.iter().map(|(n, _)| n.as_str()).collect();
-        assert_eq!(names, vec!["engineer", "md-agent"], "sorted by name");
+        assert_eq!(names, vec!["md-agent"], "the .toml file must be excluded");
     }
 
-    /// When both a `<name>.toml` and `<name>.md` exist for the same agent
-    /// name, the `.toml` deterministically wins (established format, during
-    /// the `.md` dark launch).
+    /// An orphaned `.toml` agent file triggers one aggregated WARN-level log
+    /// naming the file(s) and the migration script (#2897 Slice D).
     ///
-    /// Why: pins the collision-resolution policy so it can't silently flip
-    /// with `HashMap` iteration order.
-    /// What: `dup.toml` and `dup.md`, both named `dup`; `discover_agents`
-    /// returns exactly one `dup` entry pointing at the `.toml` path.
+    /// Why: silently dropping a project's pre-#2897 `.toml` agents (rather
+    /// than warning) would make them appear to vanish with no diagnostic —
+    /// the whole point of the migration-warning requirement.
+    /// What: two orphaned `.toml` files, no `.md`; asserts the captured
+    /// WARN-level log names both file stems, issue `#2897`, and the
+    /// converter script path.
     /// Test: this test.
     #[test]
-    fn discover_agents_toml_wins_on_collision() {
+    fn discover_agents_warns_on_orphaned_toml() {
+        crate::test_support::begin_capture();
+
         let tmp = tempfile::tempdir().expect("tempdir");
-        let toml_path = tmp.path().join("dup.toml");
-        std::fs::write(&toml_path, "[agent]\nname=\"dup\"\n").expect("write toml");
-        std::fs::write(tmp.path().join("dup.md"), "---\nname: dup\n---\n\nBody.\n")
-            .expect("write md");
+        std::fs::write(
+            tmp.path().join("legacy-a.toml"),
+            "[agent]\nname=\"legacy-a\"\n",
+        )
+        .expect("write");
+        std::fs::write(
+            tmp.path().join("legacy-b.toml"),
+            "[agent]\nname=\"legacy-b\"\n",
+        )
+        .expect("write");
 
         let agents = discover_agents(tmp.path());
-        assert_eq!(agents.len(), 1, "collision must resolve to one entry");
-        assert_eq!(agents[0].0, "dup");
-        assert_eq!(agents[0].1, toml_path, "the .toml path must win");
+        assert!(agents.is_empty(), "orphaned .toml files are never agents");
+
+        let captured = crate::test_support::captured_at_least(tracing::Level::WARN);
+        let warning = captured
+            .iter()
+            .find(|m| m.contains("no longer loads TOML agents"))
+            .unwrap_or_else(|| panic!("expected an orphaned-.toml warning, got: {captured:?}"));
+        assert!(warning.contains("legacy-a.toml"), "got: {warning}");
+        assert!(warning.contains("legacy-b.toml"), "got: {warning}");
+        assert!(warning.contains("#2897"), "got: {warning}");
+        assert!(
+            warning.contains("scripts/migrate-tcode-agents-toml-to-md.py"),
+            "got: {warning}"
+        );
     }
 
     /// `discover_agents` returns empty when the directory does not exist.
@@ -299,20 +312,29 @@ mod tests {
         assert!(agents.is_empty());
     }
 
-    /// `load_all_agents` skips files with invalid TOML.
+    /// `load_all_agents` skips files with invalid `.md` frontmatter.
     ///
     /// Why: A single bad config should not crash the harness.
-    /// What: Place one valid + one invalid TOML; `load_all_agents` returns 1 entry.
+    /// What: Place one valid + one malformed `.md`; `load_all_agents` returns
+    /// the one entry that parsed.
     /// Test: This test.
     #[test]
     fn load_all_agents_skips_invalid() {
         let tmp = tempfile::tempdir().expect("tempdir");
         std::fs::write(
-            tmp.path().join("engineer.toml"),
-            "[agent]\nname=\"engineer\"\n",
+            tmp.path().join("engineer.md"),
+            "---\nname: engineer\n---\n\nBody.\n",
         )
         .expect("write");
-        std::fs::write(tmp.path().join("broken.toml"), "<<NOT TOML>>").expect("write");
+        // `extends:` a base that does not exist — a real `compose_agent`
+        // failure, unlike a TOML syntax error, since the `.md` loader has no
+        // "unparseable syntax" failure mode of its own (frontmatter degrades
+        // to empty defaults rather than erroring — see `md_loader`'s docs).
+        std::fs::write(
+            tmp.path().join("broken.md"),
+            "---\nname: broken\nextends: does-not-exist\n---\n\nBody.\n",
+        )
+        .expect("write");
 
         let agents = load_all_agents(tmp.path());
         assert_eq!(agents.len(), 1);
@@ -320,9 +342,8 @@ mod tests {
     }
 
     /// `load_all_agents` falls back to the embedded defaults when the disk
-    /// directory has no `.toml` files (missing dir and empty-but-existing
-    /// dir both hit this branch, since `discover_agents` returns `[]` for
-    /// both).
+    /// directory has no `.md` files (missing dir and empty-but-existing dir
+    /// both hit this branch, since `discover_agents` returns `[]` for both).
     ///
     /// Why: This is the whole point of #2895 — a fresh project must not
     /// start with zero agents.
@@ -337,22 +358,49 @@ mod tests {
         assert_eq!(names, vec!["engineer", "qa-agent", "code-reviewer"]);
     }
 
-    /// A `.claude/agents/` dir that exists and holds `.toml` files, but every
+    /// A `.claude/agents/` dir that exists and holds `.md` files, but every
     /// one of them fails to parse, must fall back to the embedded defaults
     /// exactly like a missing/empty dir does — not silently return zero
     /// agents (code-critic finding, #2895 follow-up).
     ///
     /// Why: The fallback threshold is the *parsed* result being empty, not
-    /// merely `discover_agents` finding no `.toml` paths. Keying on paths
+    /// merely `discover_agents` finding no `.md` paths. Keying on paths
     /// alone would defeat the "never zero agents" goal for a directory that
     /// exists but is entirely malformed.
-    /// What: One `broken.toml` (invalid TOML) on disk, nothing else;
-    /// `load_all_agents` returns the three bundled defaults, not `[]`.
+    /// What: One `broken.md` (an `extends:` cycle — a real `compose_agent`
+    /// failure) on disk, nothing else; `load_all_agents` returns the three
+    /// bundled defaults, not `[]`.
     /// Test: this test.
     #[test]
     fn load_all_agents_falls_back_to_embedded_when_disk_all_invalid() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(tmp.path().join("broken.toml"), "<<NOT TOML>>").expect("write");
+        std::fs::write(
+            tmp.path().join("broken.md"),
+            "---\nname: broken\nextends: broken\n---\n\nBody.\n",
+        )
+        .expect("write");
+
+        let agents = load_all_agents(tmp.path());
+        let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
+        assert_eq!(names, vec!["engineer", "qa-agent", "code-reviewer"]);
+    }
+
+    /// A directory holding ONLY orphaned `.toml` agents (no `.md` at all)
+    /// must fall back to the embedded defaults exactly like an empty
+    /// directory does — the warning fires, but the project still gets a
+    /// usable agent set (#2897 Slice D).
+    ///
+    /// Why: pins that the orphan-warning path and the never-zero-agents
+    /// fallback compose correctly: warning is a side effect, not a
+    /// substitute for a real agent.
+    /// What: one `legacy.toml` on disk, no `.md`; `load_all_agents` returns
+    /// the three bundled defaults.
+    /// Test: this test.
+    #[test]
+    fn load_all_agents_falls_back_when_disk_has_only_orphaned_toml() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("legacy.toml"), "[agent]\nname=\"legacy\"\n")
+            .expect("write");
 
         let agents = load_all_agents(tmp.path());
         let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
@@ -365,55 +413,21 @@ mod tests {
     /// Why: Pins the fallback threshold (empty disk scan only) so a project
     /// that has deliberately curated a single custom agent is not silently
     /// joined by three more it did not ask for.
-    /// What: One `custom.toml` on disk; `load_all_agents` returns exactly
-    /// that one config, not four.
+    /// What: One `custom.md` on disk; `load_all_agents` returns exactly that
+    /// one config, not four.
     /// Test: this test.
     #[test]
     fn load_all_agents_disk_wins_when_present() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(tmp.path().join("custom.toml"), "[agent]\nname=\"custom\"\n")
-            .expect("write");
+        std::fs::write(
+            tmp.path().join("custom.md"),
+            "---\nname: custom\n---\n\nBody.\n",
+        )
+        .expect("write");
 
         let agents = load_all_agents(tmp.path());
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].agent.name, "custom");
-    }
-
-    /// `load_all_agents` loads `.md` agents alongside `.toml` agents (#2897
-    /// dark launch) — both dispatch through the same discover/load/collect
-    /// pipeline.
-    ///
-    /// Why: proves `load_all_agents` actually routes `.md` paths to
-    /// `md_loader::load_md_agent`, not just that `discover_agents` finds them.
-    /// What: one `.toml` agent + one `.md` agent on disk; both appear in the
-    /// loaded result with correctly projected fields.
-    /// Test: this test.
-    #[test]
-    fn load_all_agents_loads_md_agents() {
-        let tmp = tempfile::tempdir().expect("tempdir");
-        std::fs::write(
-            tmp.path().join("toml-agent.toml"),
-            "[agent]\nname=\"toml-agent\"\n",
-        )
-        .expect("write toml");
-        std::fs::write(
-            tmp.path().join("md-agent.md"),
-            "---\nname: md-agent\nmodel: sonnet\n---\n\nAn md-format agent.\n",
-        )
-        .expect("write md");
-
-        let agents = load_all_agents(tmp.path());
-        let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
-        assert_eq!(agents.len(), 2, "both formats must load");
-        assert!(names.contains(&"toml-agent"));
-        assert!(names.contains(&"md-agent"));
-
-        let md_cfg = agents
-            .iter()
-            .find(|a| a.agent.name == "md-agent")
-            .expect("md-agent present");
-        assert_eq!(md_cfg.agent.model.as_deref(), Some("sonnet"));
-        assert_eq!(md_cfg.system_prompt.content, "An md-format agent.");
     }
 
     /// `locate_agents_dir` prefers `.claude/agents`, falls back to

--- a/crates/trusty-code/src/assets/mod.rs
+++ b/crates/trusty-code/src/assets/mod.rs
@@ -11,9 +11,10 @@
 //! `skills::discover_skill_metadata`'s embedded-fallback branches).
 //! What: [`EmbeddedAgent`]/[`DEFAULT_AGENTS`] — the three default agent
 //! configs (`engineer`, `qa-agent`, `code-reviewer`), authored as Markdown+
-//! frontmatter (`.md`) as of #2897 Slice C (previously native TOML; the TOML
-//! loader for USER `.claude/agents/*.toml` configs is untouched and stays
-//! until Slice D). The embedded fallback projects each `.md` string onto
+//! frontmatter (`.md`) as of #2897 Slice C (previously native TOML; Slice D
+//! subsequently retired the TOML loader for USER `.claude/agents/*.toml`
+//! configs entirely — see `agents::mod`'s docs). The embedded fallback
+//! projects each `.md` string onto
 //! tcode's `AgentConfig` via `agents::md_loader::project_embedded_md`, which
 //! shares its frontmatter->`AgentConfig` mapping with the disk `.md` loader
 //! (`agents::md_loader::load_md_agent`) — see that module's docs.

--- a/crates/trusty-code/src/binding/mod.rs
+++ b/crates/trusty-code/src/binding/mod.rs
@@ -198,7 +198,7 @@ impl ProjectBinding {
         self.root().map(|p| p.display().to_string())
     }
 
-    /// The agents directory this binding resolves `<agent>.toml` from.
+    /// The agents directory this binding resolves `<agent>.md` from.
     ///
     /// Why: a projectless daemon still runs a PM and still needs agent configs;
     /// with no project root there is no project-scoped `.claude/agents` to read,

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -46,7 +46,8 @@
 //!
 //! Phase 3 public surface (agents + LLM layer, per #642):
 //!
-//! * [`agents`] — `AgentConfig` TOML schema, `discover_agents`, `load_all_agents`.
+//! * [`agents`] — `AgentConfig` schema (loaded from `.md`), `discover_agents`,
+//!   `load_all_agents`.
 //! * [`identity`] — `CallerIdentity`, `RecallCeiling` for memory scoping.
 //! * [`logging`] — tracing init helpers (`init_tracing`, `init_tracing_for_test`).
 //!
@@ -165,9 +166,9 @@ pub mod assets;
 
 /// Agent configuration loading.
 ///
-/// Why: Sub-agents are defined declaratively in TOML files under
-/// `.claude/agents/` so model, prompt, and parameters can evolve without code
-/// changes.
+/// Why: Sub-agents are defined declaratively in Markdown+frontmatter files
+/// under `.claude/agents/` (#2897 Slice D — TOML retired) so model, prompt,
+/// and parameters can evolve without code changes.
 /// What: `AgentConfig`, `AgentInfo`, `LlmParams`, `SystemPrompt`, `ToolsConfig`,
 /// `RunnerConfig`, `RunnerKind`, `discover_agents`, `load_all_agents`.
 /// Test: `agents::tests::*`.

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -119,7 +119,7 @@ enum Command {
     /// and some callers may depend on its diff-report output, which the
     /// daemon-driven path does not (yet) compute.
     RunTask {
-        /// Agent name as declared in `.claude/agents/<name>.toml` (e.g. `pm`).
+        /// Agent name as declared in `.claude/agents/<name>.md` (e.g. `pm`).
         agent: String,
 
         /// Free-form task description passed to the agent's system prompt.
@@ -475,7 +475,7 @@ async fn run_serve(
 /// Validate that `agent_name` contains only safe filesystem characters.
 ///
 /// Why: The agent name is joined into a filesystem path
-/// (`<agents_dir>/<agent_name>.toml`). Without this guard a crafted name such
+/// (`<agents_dir>/<agent_name>.md`). Without this guard a crafted name such
 /// as `../../etc/passwd` escapes the agents directory and enables path
 /// traversal. Restricting to `[a-zA-Z0-9_-]` is safe, predictable, and covers
 /// every real agent name in use.
@@ -665,7 +665,7 @@ mod tests {
 
     /// A path-traversal agent name is rejected.
     ///
-    /// Why: Guards the `agents_dir.join(format!("{agent_name}.toml"))` path
+    /// Why: Guards the `agents_dir.join(format!("{agent_name}.md"))` path
     /// construction in the run-task pipeline against names that escape the agents
     /// directory.
     /// What: Asserts that `../../etc/passwd` and similar strings fail validation.

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -29,7 +29,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::agent_loop::{AgentLoop, AgentLoopConfig, AgentLoopError, CompactionConfig};
-use crate::agents::AgentConfig;
+use crate::agents::{AgentConfig, md_loader};
 use crate::llm::{DebugCaptureSink, LlmClientTrait, wrap_with_debug_capture};
 use crate::mode::HarnessMode;
 use crate::project_context::load_project_context;
@@ -182,7 +182,7 @@ fn daily_driver_skills_catalog(project: &Path) -> Option<(String, Arc<dyn SkillR
 /// Why: Bundling the inputs keeps `execute_run_task`'s signature stable as flags
 /// are added and lets the binary layer construct one value from clap.
 /// What: `agent` is the top-level (PM) agent name; `task` is the request; `project`
-/// is the canonical project root; `agents_dir` is where `<agent>.toml` live;
+/// is the canonical project root; `agents_dir` is where `<agent>.md` live;
 /// `engineer_model` is the optional per-run engineer model override (#1035).
 /// Test: `run_task::tests` build these directly.
 #[derive(Debug, Clone)]
@@ -193,7 +193,7 @@ pub struct RunTaskParams {
     pub task: String,
     /// Canonical project root.
     pub project: PathBuf,
-    /// Directory holding `<agent>.toml` configs.
+    /// Directory holding `<agent>.md` configs.
     pub agents_dir: PathBuf,
     /// Optional per-run engineer model override (#1035). `None` routes the
     /// engineer via its own config model.
@@ -248,7 +248,7 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
 
     // Load the PM config; a missing/invalid config is a configuration error.
     let pm_config =
-        match AgentConfig::load(&params.agents_dir.join(format!("{}.toml", params.agent))) {
+        match md_loader::load_md_agent(&params.agents_dir.join(format!("{}.md", params.agent))) {
             Ok(cfg) => cfg,
             Err(e) => return config_error_report(&params, &transcript, &format!("{e:#}")),
         };
@@ -623,13 +623,13 @@ fn apply_engineer_model_override(
 /// pricing step. Shared with the daemon path (`task::executor`'s own
 /// `resolve_engineer_model`, which now delegates here) so the two paths
 /// can never independently drift on how per-role pricing resolves a model.
-/// What: loads `<agents_dir>/<agent_name>.toml`; on any load failure
-/// (missing/invalid file) falls back to the literal string `"unknown"` —
-/// `crate::perf::cost_usd` degrades gracefully (Sonnet-equivalent pricing)
-/// for an unrecognised model rather than erroring, so a missing agent
-/// config degrades pricing accuracy, not the whole run. When
-/// `model_override` is `Some`, it wins over the config's own model (mirrors
-/// `RunContext`'s override precedence).
+/// What: loads `<agents_dir>/<agent_name>.md` (#2897 Slice D); on any load
+/// failure (missing/invalid file) falls back to the literal string
+/// `"unknown"` — `crate::perf::cost_usd` degrades gracefully
+/// (Sonnet-equivalent pricing) for an unrecognised model rather than
+/// erroring, so a missing agent config degrades pricing accuracy, not the
+/// whole run. When `model_override` is `Some`, it wins over the config's own
+/// model (mirrors `RunContext`'s override precedence).
 /// Test: `run_task::tests::resolve_agent_model_slug_falls_back_when_config_missing`,
 /// `run_task::tests::resolve_agent_model_slug_honours_override`.
 pub fn resolve_agent_model_slug(
@@ -637,8 +637,8 @@ pub fn resolve_agent_model_slug(
     agent_name: &str,
     model_override: Option<&str>,
 ) -> String {
-    let path = agents_dir.join(format!("{agent_name}.toml"));
-    let Ok(config) = AgentConfig::load(&path) else {
+    let path = agents_dir.join(format!("{agent_name}.md"));
+    let Ok(config) = md_loader::load_md_agent(&path) else {
         return "unknown".to_string();
     };
     match model_override {

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -8,8 +8,8 @@
 //! so no network call is ever made.
 //! What: A `ScriptedLlm` replays a queue of `ChatResponse`s; because the PM and
 //! engineer share one inner client, the script is consumed in call order
-//! (PM-turn-1, engineer-turn-1, …). Fixtures build agents-dir TOMLs and a project
-//! dir; tests assert on the returned `RunReport`.
+//! (PM-turn-1, engineer-turn-1, …). Fixtures build agents-dir `.md` agents and a
+//! project dir; tests assert on the returned `RunReport`.
 //! Test: this module is itself the test surface.
 
 use std::path::PathBuf;
@@ -20,7 +20,9 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use super::{ExitCode, RedelegationCapSignal, RunTaskParams, execute_run_task};
+use super::{
+    ExitCode, RedelegationCapSignal, RunTaskParams, execute_run_task, resolve_agent_model_slug,
+};
 use crate::agent_loop::AgentLoopError;
 use crate::agents::AgentConfig;
 use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
@@ -260,26 +262,27 @@ fn stop_response_with_model(text: &str, model: &str) -> Value {
     })
 }
 
-/// Build an agents dir with `pm.toml` and `python-engineer.toml`.
+/// Build an agents dir with `pm.md` and `python-engineer.md`.
 ///
-/// Why: `run-task` loads the PM config from `<agents_dir>/pm.toml` and the
-/// engineer from `<agents_dir>/python-engineer.toml`; tests need both on disk.
-/// What: Writes both TOMLs (engineer pinned to `engineer_model`) and returns the
-/// tempdir.
+/// Why: `run-task` loads the PM config from `<agents_dir>/pm.md` and the
+/// engineer from `<agents_dir>/python-engineer.md` (#2897 Slice D); tests
+/// need both on disk.
+/// What: Writes both `.md` agents (engineer pinned to `engineer_model`) and
+/// returns the tempdir.
 fn agents_dir(engineer_model: &str) -> TempDir {
     let tmp = tempfile::tempdir().expect("agents tempdir");
     std::fs::write(
-        tmp.path().join("pm.toml"),
-        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"You are the PM.\"\n",
+        tmp.path().join("pm.md"),
+        "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM.\n",
     )
-    .expect("write pm.toml");
+    .expect("write pm.md");
     std::fs::write(
-        tmp.path().join("python-engineer.toml"),
+        tmp.path().join("python-engineer.md"),
         format!(
-            "[agent]\nname = \"python-engineer\"\nmodel = \"{engineer_model}\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n"
+            "---\nname: python-engineer\nmodel: {engineer_model}\n---\n\nYou are a Python engineer.\n"
         ),
     )
-    .expect("write python-engineer.toml");
+    .expect("write python-engineer.md");
     tmp
 }
 
@@ -362,27 +365,26 @@ async fn end_to_end_pm_delegates_to_engineer() {
 /// Why: `execute_run_task` previously built the PM's `AgentLoopConfig` via
 /// `AgentLoopConfig { model: pm_model, ..AgentLoopConfig::default() }`,
 /// dropping `pm_config.llm.max_tokens` entirely so every PM turn was capped at
-/// the hard-coded default regardless of what `pm.toml` declared. This is the
-/// end-to-end regression guard: a `pm.toml` with `[llm].max_tokens = 8192`
-/// must produce a `ChatRequest.max_tokens` of `8192`, never the old 1024.
-/// What: `pm.toml` declares `[llm].max_tokens = 8192`; script a single PM stop
-/// turn; assert the scripted client observed `Some(8192)`.
+/// the hard-coded default regardless of what `pm.md` declared. This is the
+/// end-to-end regression guard: a `pm.md` with `max_tokens: 8192` must
+/// produce a `ChatRequest.max_tokens` of `8192`, never the old 1024.
+/// What: `pm.md` declares `max_tokens: 8192`; script a single PM stop turn;
+/// assert the scripted client observed `Some(8192)`.
 /// Test: this test.
 #[tokio::test]
 async fn pm_llm_max_tokens_reaches_chat_request() {
     let agents = tempfile::tempdir().expect("agents tempdir");
     std::fs::write(
-        agents.path().join("pm.toml"),
-        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n\
-         [llm]\nmax_tokens = 8192\n\
-         [system_prompt]\ncontent = \"You are the PM.\"\n",
+        agents.path().join("pm.md"),
+        "---\nname: pm\nmodel: openai/gpt-4o-mini\nmax_tokens: 8192\n---\n\n\
+         You are the PM.\n",
     )
-    .expect("write pm.toml");
+    .expect("write pm.md");
     std::fs::write(
-        agents.path().join("python-engineer.toml"),
-        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n",
+        agents.path().join("python-engineer.md"),
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\nYou are a Python engineer.\n",
     )
-    .expect("write python-engineer.toml");
+    .expect("write python-engineer.md");
     let project = tempfile::tempdir().expect("project tempdir");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[stop_response(
@@ -502,7 +504,7 @@ async fn no_changes_yields_no_changes_exit() {
 /// A missing PM config is a configuration error (no panic, distinct exit code).
 ///
 /// Why: Bad configuration must produce a faithful `ConfigError`, not a crash.
-/// What: Point the params at an agents dir with no `pm.toml`; assert
+/// What: Point the params at an agents dir with no `pm.md`; assert
 /// exit=ConfigError.
 /// Test: this test.
 #[tokio::test]
@@ -527,8 +529,51 @@ async fn missing_pm_config_is_config_error() {
     assert_eq!(
         report.exit,
         ExitCode::ConfigError,
-        "missing pm.toml must be a config error"
+        "missing pm.md must be a config error"
     );
+}
+
+/// `resolve_agent_model_slug` degrades to `"unknown"` when the agent's `.md`
+/// config is missing, rather than panicking or propagating an error.
+///
+/// Why: pricing (`crate::perf::cost_usd`) must degrade gracefully for an
+/// unrecognised model, not abort the whole run over a missing/renamed agent
+/// config — see this function's own doc comment.
+/// What: an empty agents dir, no `ghost.md`; asserts the literal string
+/// `"unknown"`.
+/// Test: this test.
+#[test]
+fn resolve_agent_model_slug_falls_back_when_config_missing() {
+    let empty_agents = tempfile::tempdir().expect("agents tempdir");
+    let slug = resolve_agent_model_slug(empty_agents.path(), "ghost", None);
+    assert_eq!(slug, "unknown");
+}
+
+/// `resolve_agent_model_slug`'s `model_override` wins over the agent
+/// config's own `model:`.
+///
+/// Why: mirrors `RunContext`'s override precedence — a per-run
+/// `--engineer-model` swap must be reflected in the PRICED model, not just
+/// the one that actually drove the loop.
+/// What: `python-engineer.md` pins `openai/gpt-4o-mini`; pass
+/// `Some("deepseek/deepseek-chat")` as the override; asserts the override
+/// slug wins.
+/// Test: this test.
+#[test]
+fn resolve_agent_model_slug_honours_override() {
+    let agents = tempfile::tempdir().expect("agents tempdir");
+    std::fs::write(
+        agents.path().join("python-engineer.md"),
+        "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n\nengineer\n",
+    )
+    .expect("write python-engineer.md");
+
+    let slug = resolve_agent_model_slug(
+        agents.path(),
+        "python-engineer",
+        Some("deepseek/deepseek-chat"),
+    );
+    assert_eq!(slug, "deepseek/deepseek-chat");
 }
 
 /// A PM loop that errors (scripted client exhausts on a tool-call turn) yields

--- a/crates/trusty-code/src/runner/error.rs
+++ b/crates/trusty-code/src/runner/error.rs
@@ -21,8 +21,9 @@ use crate::agent_loop::AgentLoopError;
 /// does not exist" (recoverable, surface to the model) from "the agent's loop
 /// blew up" (propagate). Bundling them in one enum keeps the runner's signature
 /// a single `Result<_, RunnerError>`.
-/// What: `UnknownAgent` and `ConfigLoad` cover resolving the agent's TOML;
-/// `Loop` wraps an `AgentLoopError` from the multi-turn loop.
+/// What: `UnknownAgent` and `ConfigLoad` cover resolving the agent's `.md`
+/// config (#2897 Slice D); `Loop` wraps an `AgentLoopError` from the
+/// multi-turn loop.
 /// Test: `runner::tests::*` exercise `UnknownAgent` and `Loop` paths.
 #[derive(Debug, thiserror::Error)]
 pub enum RunnerError {
@@ -31,7 +32,7 @@ pub enum RunnerError {
     UnknownAgent {
         /// The requested agent slug.
         name: String,
-        /// The directory that was searched for `<name>.toml`.
+        /// The directory that was searched for `<name>.md`.
         dir: PathBuf,
     },
 

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -27,7 +27,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::agent_loop::{AgentLoop, AgentLoopConfig, ToolEventSink};
-use crate::agents::AgentConfig;
+use crate::agents::{AgentConfig, md_loader};
 use crate::llm::LlmClientTrait;
 use crate::mode::HarnessMode;
 use crate::prompt::assemble_system_prompt_for_mode;
@@ -133,7 +133,7 @@ impl Default for InProcessRunnerConfig {
 /// roll engineer cost up into the PM's transcript (#1030).
 /// What: Holds the shared LLM client, a `RegistryFactory`, the agents config
 /// directory, optional project context, and the default loop budget. For each
-/// `run`, it loads `<config_dir>/<agent_name>.toml`, asks the factory for the
+/// `run`, it loads `<config_dir>/<agent_name>.md`, asks the factory for the
 /// agent's tools, gates them by `tools.allowed`, resolves the model and
 /// assembled system prompt, then runs an `AgentLoop` and returns its output.
 /// Test: `runner::tests::*` cover the full delegation path offline.
@@ -295,22 +295,24 @@ impl InProcessAgentRunner {
     /// Load the agent config for `agent_name` from the config directory.
     ///
     /// Why: Each delegation targets a named agent; its model, prompt, and
-    /// `tools.allowed` come from `<config_dir>/<agent_name>.toml`. Distinguishing
-    /// "no such file" (`UnknownAgent`) from "file present but unparseable"
+    /// `tools.allowed` come from `<config_dir>/<agent_name>.md` (#2897 Slice D
+    /// — `.toml` is no longer a loadable source). Distinguishing "no such
+    /// file" (`UnknownAgent`) from "file present but unparseable"
     /// (`ConfigLoad`) gives the caller actionable errors.
     /// What: Builds the path, returns `UnknownAgent` if it does not exist, else
-    /// loads it (mapping a parse failure to `ConfigLoad`).
+    /// loads it via [`md_loader::load_md_agent`] (mapping a parse/compose
+    /// failure to `ConfigLoad`).
     /// Test: `runner::tests::unknown_agent_errors`,
     /// `runner::tests::delegate_runs_engineer_loop`.
     fn load_agent(&self, agent_name: &str) -> Result<AgentConfig, RunnerError> {
-        let path = self.config_dir.join(format!("{agent_name}.toml"));
+        let path = self.config_dir.join(format!("{agent_name}.md"));
         if !path.exists() {
             return Err(RunnerError::UnknownAgent {
                 name: agent_name.to_string(),
                 dir: self.config_dir.clone(),
             });
         }
-        AgentConfig::load(&path).map_err(|source| RunnerError::ConfigLoad {
+        md_loader::load_md_agent(&path).map_err(|source| RunnerError::ConfigLoad {
             name: agent_name.to_string(),
             source,
         })
@@ -491,8 +493,9 @@ impl AgentRunner for InProcessAgentRunner {
 /// Why: Callers (e.g. the orchestrator wiring the delegate tool) sometimes need
 /// to pre-check an agent name without constructing a runner; exposing the same
 /// path rule the runner uses keeps the two in lockstep.
-/// What: Returns `true` iff `<dir>/<name>.toml` exists.
+/// What: Returns `true` iff `<dir>/<name>.md` exists (#2897 Slice D — `.toml`
+/// is no longer a loadable source).
 /// Test: `runner::tests::agent_config_exists_detects_present_and_absent`.
 pub fn agent_config_exists(dir: &Path, name: &str) -> bool {
-    dir.join(format!("{name}.toml")).exists()
+    dir.join(format!("{name}.md")).exists()
 }

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -216,14 +216,16 @@ fn stop_response(text: &str) -> Value {
 
 // ── Fixtures: an agents config dir ───────────────────────────────────────────
 
-/// Create a temp agents dir containing a `python-engineer.toml`.
+/// Create a temp agents dir containing a `python-engineer.md`.
 ///
-/// Why: The runner loads `<dir>/<agent>.toml`; tests need a real file on disk.
-/// What: Writes `python-engineer.toml` with the given body and returns the dir.
+/// Why: The runner loads `<dir>/<agent>.md` (#2897 Slice D); tests need a
+/// real file on disk.
+/// What: Writes `python-engineer.md` with the given frontmatter+body and
+/// returns the dir.
 /// Test: Used by most runner tests.
 fn agents_dir_with(body: &str, agent: &str) -> TempDir {
     let tmp = tempfile::tempdir().expect("tempdir");
-    std::fs::write(tmp.path().join(format!("{agent}.toml")), body).expect("write agent toml");
+    std::fs::write(tmp.path().join(format!("{agent}.md")), body).expect("write agent md");
     tmp
 }
 
@@ -303,7 +305,7 @@ fn default_max_turns_is_generous() {
 /// Test: this test.
 #[test]
 fn agent_config_exists_detects_present_and_absent() {
-    let tmp = agents_dir_with("[agent]\nname = \"python-engineer\"\n", "python-engineer");
+    let tmp = agents_dir_with("---\nname: python-engineer\n---\n", "python-engineer");
     assert!(super::agent_config_exists(tmp.path(), "python-engineer"));
     assert!(!super::agent_config_exists(tmp.path(), "ghost"));
 }
@@ -322,14 +324,8 @@ fn agent_config_exists_detects_present_and_absent() {
 /// Test: this test.
 #[tokio::test]
 async fn delegate_runs_engineer_loop() {
-    let body = r#"
-[agent]
-name = "python-engineer"
-model = "deepseek/deepseek-chat"
-
-[system_prompt]
-content = "You are a Python engineer."
-"#;
+    let body = "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\n\
+                You are a Python engineer.\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[
@@ -387,17 +383,8 @@ content = "You are a Python engineer."
 /// Test: this test.
 #[tokio::test]
 async fn engineer_llm_max_tokens_reaches_chat_request() {
-    let body = r#"
-[agent]
-name = "python-engineer"
-model = "deepseek/deepseek-chat"
-
-[llm]
-max_tokens = 8192
-
-[system_prompt]
-content = "You are a Python engineer."
-"#;
+    let body = "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n\
+                max_tokens: 8192\n---\n\nYou are a Python engineer.\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("engineer done")]));
@@ -466,14 +453,8 @@ async fn unknown_agent_errors() {
 /// Test: this test.
 #[tokio::test]
 async fn tools_allowed_is_enforced() {
-    let body = r#"
-[agent]
-name = "python-engineer"
-model = "openai/gpt-4o-mini"
-
-[tools]
-allowed = ["allowed_tool"]
-"#;
+    let body = "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n\
+                tools: [allowed_tool]\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     // Model tries to call the DENIED tool, then concludes.
@@ -509,11 +490,7 @@ allowed = ["allowed_tool"]
 /// Test: this test.
 #[tokio::test]
 async fn no_allowlist_permits_all() {
-    let body = r#"
-[agent]
-name = "python-engineer"
-model = "openai/gpt-4o-mini"
-"#;
+    let body = "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[
@@ -546,7 +523,7 @@ model = "openai/gpt-4o-mini"
 /// Test: this test.
 #[tokio::test]
 async fn usage_rolls_up_to_output() {
-    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let body = "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[
@@ -583,7 +560,7 @@ async fn usage_rolls_up_to_output() {
 /// Test: this test.
 #[tokio::test]
 async fn run_context_overrides_model() {
-    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n";
+    let body = "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
@@ -617,7 +594,7 @@ async fn run_context_overrides_model() {
 /// Test: this test.
 #[tokio::test]
 async fn run_context_overrides_max_turns() {
-    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let body = "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     // Always-tool-call: the loop never converges, so only the cap stops it.
@@ -669,7 +646,7 @@ async fn run_context_overrides_max_turns() {
 /// Test: this test.
 #[tokio::test]
 async fn with_timeout_secs_shortens_the_deadline() {
-    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let body = "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(SleepyLlm {
@@ -711,7 +688,7 @@ async fn with_timeout_secs_shortens_the_deadline() {
 /// Test: this test.
 #[tokio::test]
 async fn with_timeout_secs_preserves_configured_max_turns() {
-    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let body = "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[
@@ -753,7 +730,8 @@ async fn with_timeout_secs_preserves_configured_max_turns() {
 /// Test: this test.
 #[tokio::test]
 async fn project_context_reaches_prompt() {
-    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"AGENT-PROMPT-MARKER\"\n";
+    let body =
+        "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n\nAGENT-PROMPT-MARKER\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
@@ -788,7 +766,7 @@ async fn project_context_reaches_prompt() {
 /// Test: this test.
 #[tokio::test]
 async fn skills_catalog_reaches_daily_driver_prompt() {
-    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let body = "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
@@ -818,7 +796,7 @@ async fn skills_catalog_reaches_daily_driver_prompt() {
 /// Test: this test.
 #[tokio::test]
 async fn skills_catalog_ignored_in_parity() {
-    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let body = "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("done")]));
@@ -856,7 +834,7 @@ async fn skills_catalog_ignored_in_parity() {
 /// Test: this test.
 #[tokio::test]
 async fn with_mode_completes_a_delegated_run_in_both_modes() {
-    let body = "[agent]\nname = \"python-engineer\"\nmodel = \"openai/gpt-4o-mini\"\n";
+    let body = "---\nname: python-engineer\nmodel: openai/gpt-4o-mini\n---\n";
     let tmp = agents_dir_with(body, "python-engineer");
 
     for mode in [
@@ -961,7 +939,7 @@ async fn sink_reaches_delegated_loop() {
         stop_response("engineer done"),
     ]));
     let tmp = agents_dir_with(
-        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n",
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n",
         "python-engineer",
     );
     let invoked = Arc::new(Mutex::new(Vec::new()));
@@ -1025,7 +1003,7 @@ async fn sequential_delegations_to_same_named_agent_get_distinct_ids() {
         stop_response("engineer done 2"),
     ]));
     let tmp = agents_dir_with(
-        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n",
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n",
         "python-engineer",
     );
     let invoked = Arc::new(Mutex::new(Vec::new()));
@@ -1143,7 +1121,7 @@ impl LlmClientTrait for ConversationAwareLlm {
 async fn concurrently_delegated_same_named_agents_get_distinct_ids_under_tokio_join() {
     let llm = Arc::new(ConversationAwareLlm);
     let tmp = agents_dir_with(
-        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n",
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n",
         "python-engineer",
     );
     let invoked = Arc::new(Mutex::new(Vec::new()));
@@ -1201,7 +1179,7 @@ async fn cancel_flag_reaches_delegated_loop() {
         "should never be reached",
     )]));
     let tmp = agents_dir_with(
-        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n",
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n",
         "python-engineer",
     );
     let invoked = Arc::new(Mutex::new(Vec::new()));

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -287,23 +287,19 @@ mod tests {
         let project = tempfile::tempdir().expect("project tempdir");
         std::fs::create_dir_all(project.path().join(".claude").join("agents")).expect("mkdir");
         std::fs::write(
-            project
-                .path()
-                .join(".claude")
-                .join("agents")
-                .join("pm.toml"),
-            "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"PM\"\n",
+            project.path().join(".claude").join("agents").join("pm.md"),
+            "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nPM\n",
         )
-        .expect("write pm.toml");
+        .expect("write pm.md");
         std::fs::write(
             project
                 .path()
                 .join(".claude")
                 .join("agents")
-                .join("python-engineer.toml"),
-            "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"eng\"\n",
+                .join("python-engineer.md"),
+            "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\neng\n",
         )
-        .expect("write python-engineer.toml");
+        .expect("write python-engineer.md");
 
         // SAFETY: test-only env mutation; serialized by the shared crate lock.
         let _guard = crate::task::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -40,7 +40,7 @@ use async_trait::async_trait;
 use crate::agent_loop::{
     AgentLoop, AgentLoopConfig, CompactionConfig, ToolEventSink, resolve_cadence_config,
 };
-use crate::agents::AgentConfig;
+use crate::agents::{AgentConfig, md_loader};
 use crate::binding::ProjectBinding;
 use crate::jsonrpc::RpcError;
 use crate::llm::{DebugCaptureSink, LlmClientTrait, wrap_with_debug_capture};
@@ -71,7 +71,7 @@ use super::sink::SessionToolEventSink;
 const ENGINEER_BASH_TIMEOUT_SECS: u64 = 120;
 
 /// Hardcoded delegated engineer agent name, matching the `run_task`/fixture
-/// convention used across this crate (`<agents_dir>/python-engineer.toml`).
+/// convention used across this crate (`<agents_dir>/python-engineer.md`).
 /// A future ticket may make this configurable per `task.run` call.
 pub const ENGINEER_AGENT_NAME: &str = "python-engineer";
 
@@ -285,10 +285,8 @@ async fn run_and_record(
     // `TCODE_DEBUG_TRANSCRIPT` is set, and cost nothing when it is not.
     let debug_sink: Option<Arc<DebugCaptureSink>> = DebugCaptureSink::from_env();
 
-    let pm_config_path = params
-        .agents_dir
-        .join(format!("{}.toml", params.agent_name));
-    let pm_config = match AgentConfig::load(&pm_config_path) {
+    let pm_config_path = params.agents_dir.join(format!("{}.md", params.agent_name));
+    let pm_config = match md_loader::load_md_agent(&pm_config_path) {
         Ok(cfg) => cfg,
         Err(e) => {
             finish_with_failure(&registry, &session_id, &format!("PM config error: {e:#}")).await;

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -16,20 +16,20 @@ use crate::llm::{ChatRequest, ChatResponse, LlmClientTrait, LlmError};
 use crate::session::{SessionRegistry, SessionStatus};
 use crate::task::mock_llm::EchoLlmClient;
 
-/// Agents dir fixture with `pm.toml` + `python-engineer.toml` (mirrors
+/// Agents dir fixture with `pm.md` + `python-engineer.md` (mirrors
 /// `run_task::tests::agents_dir`).
 fn agents_dir() -> TempDir {
     let tmp = tempfile::tempdir().expect("agents tempdir");
     std::fs::write(
-        tmp.path().join("pm.toml"),
-        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"You are the PM.\"\n",
+        tmp.path().join("pm.md"),
+        "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM.\n",
     )
-    .expect("write pm.toml");
+    .expect("write pm.md");
     std::fs::write(
-        tmp.path().join("python-engineer.toml"),
-        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n",
+        tmp.path().join("python-engineer.md"),
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\nYou are a Python engineer.\n",
     )
-    .expect("write python-engineer.toml");
+    .expect("write python-engineer.md");
     tmp
 }
 

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -190,15 +190,15 @@ mod tests {
     fn agents_dir() -> tempfile::TempDir {
         let tmp = tempfile::tempdir().expect("agents tempdir");
         std::fs::write(
-            tmp.path().join("pm.toml"),
-            "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"You are the PM.\"\n",
+            tmp.path().join("pm.md"),
+            "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM.\n",
         )
-        .expect("write pm.toml");
+        .expect("write pm.md");
         std::fs::write(
-            tmp.path().join("python-engineer.toml"),
-            "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"engineer\"\n",
+            tmp.path().join("python-engineer.md"),
+            "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\nengineer\n",
         )
-        .expect("write python-engineer.toml");
+        .expect("write python-engineer.md");
         tmp
     }
 

--- a/crates/trusty-code/src/tools/delegate.rs
+++ b/crates/trusty-code/src/tools/delegate.rs
@@ -25,7 +25,7 @@
 //! failed engineer attempt is worth automatically retrying — see that
 //! module's docs for the retry/cap mechanics.
 //! Test: `unknown_agent_returns_helpful_error` builds a tool pointed at a tempdir
-//! containing `engineer.toml` only, calls `execute({"agent_name":"ghost",...})`,
+//! containing `engineer.md` only, calls `execute({"agent_name":"ghost",...})`,
 //! and asserts the error names the unknown agent and lists `engineer`.
 //! `redelegation_hint_*` tests cover the reuse-directive behaviour.
 
@@ -173,8 +173,8 @@ impl EngineerCompletionSignal {
 /// `no_config_dir_skips_validation`, `delegate_refused_once_engineer_completed`.
 pub struct DelegateToAgentTool {
     runner: Arc<dyn AgentRunner>,
-    /// Directory holding `<agent>.toml` files. When `Some`, `execute()` rejects
-    /// calls whose `agent_name` does not have a matching TOML. When `None`,
+    /// Directory holding `<agent>.md` files. When `Some`, `execute()` rejects
+    /// calls whose `agent_name` does not have a matching `.md`. When `None`,
     /// validation is skipped (legacy / test mode).
     config_dir: Option<PathBuf>,
     /// Shared, run-scoped completion latch (#2683). When `Some` and already
@@ -206,7 +206,7 @@ impl DelegateToAgentTool {
     /// Why: When the LLM hallucinates an agent name, spawning the subprocess
     /// fails with a generic IO error. Validating up front returns a structured
     /// `ToolResult::err` listing available agents so the LLM can self-correct.
-    /// What: Stores `dir`. Files matching `<dir>/<agent_name>.toml` are
+    /// What: Stores `dir`. Files matching `<dir>/<agent_name>.md` are
     /// considered valid. Missing dir is treated as "no agents available".
     /// Test: `unknown_agent_returns_helpful_error`.
     pub fn with_config_dir(mut self, dir: PathBuf) -> Self {
@@ -240,28 +240,26 @@ impl DelegateToAgentTool {
     /// List agent names discoverable in `config_dir`, if any.
     ///
     /// Why: Builds the "available agents" hint in error messages so the LLM
-    /// gets immediate, structured feedback when it invents a name.
-    /// What: Reads `<config_dir>/*.toml` and returns each file stem. Returns
-    /// `None` when no `config_dir` was attached.
+    /// gets immediate, structured feedback when it invents a name. Reuses
+    /// `agents::discover_agents` (rather than re-implementing its own dir
+    /// scan) so this hint and the actual load path can never independently
+    /// drift on which extension counts as an agent, and a coexisting
+    /// orphaned `.toml` gets the SAME migration warning it would during a
+    /// real `load_all_agents` call.
+    /// What: Delegates to `crate::agents::discover_agents`, which already
+    /// returns `(name, path)` pairs sorted by name — mapped down to just the
+    /// names here. Returns `None` when no `config_dir` was attached
+    /// (`discover_agents` itself returns `[]`, not `None`, for a
+    /// missing/unreadable directory).
     /// Test: Indirect via `unknown_agent_returns_helpful_error`.
     fn available_agents(&self) -> Option<Vec<String>> {
         let dir = self.config_dir.as_ref()?;
-        let entries = std::fs::read_dir(dir).ok()?;
-        let mut names: Vec<String> = entries
-            .flatten()
-            .filter_map(|e| {
-                let p = e.path();
-                if p.extension().and_then(|x| x.to_str()) == Some("toml") {
-                    p.file_stem()
-                        .and_then(|s| s.to_str())
-                        .map(|s| s.to_string())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        names.sort();
-        Some(names)
+        Some(
+            crate::agents::discover_agents(dir)
+                .into_iter()
+                .map(|(name, _)| name)
+                .collect(),
+        )
     }
 }
 
@@ -346,22 +344,23 @@ impl ToolExecutor for DelegateToAgentTool {
 
         // Pre-flight validation: if a config_dir was attached, verify the agent
         // config exists before spawning. Converts a generic IO error into a
-        // structured tool error the LLM can act on.
-        if let Some(dir) = &self.config_dir {
-            let agent_toml = dir.join(format!("{agent_name}.toml"));
-            if !agent_toml.exists() {
-                let available = self.available_agents().unwrap_or_default();
-                let available_str = if available.is_empty() {
-                    "(none discovered)".to_string()
-                } else {
-                    available.join(", ")
-                };
-                return ToolResult::err(format!(
-                    "Unknown agent '{agent_name}'. Available agents: {available_str}. \
-                     Note: native tools (search_code, web_search, etc.) are NOT agent \
-                     names — call them directly as tools instead of via delegate_to_agent."
-                ));
-            }
+        // structured tool error the LLM can act on. Reuses
+        // `runner::agent_config_exists` (the SAME `<dir>/<name>.md` rule the
+        // runner itself applies) rather than re-deriving the extension here.
+        if let Some(dir) = &self.config_dir
+            && !crate::runner::agent_config_exists(dir, agent_name)
+        {
+            let available = self.available_agents().unwrap_or_default();
+            let available_str = if available.is_empty() {
+                "(none discovered)".to_string()
+            } else {
+                available.join(", ")
+            };
+            return ToolResult::err(format!(
+                "Unknown agent '{agent_name}'. Available agents: {available_str}. \
+                 Note: native tools (search_code, web_search, etc.) are NOT agent \
+                 names — call them directly as tools instead of via delegate_to_agent."
+            ));
         }
 
         match self.runner.run(agent_name, task).await {

--- a/crates/trusty-code/src/tools/delegate_tests.rs
+++ b/crates/trusty-code/src/tools/delegate_tests.rs
@@ -40,21 +40,13 @@ impl AgentRunner for RecordingRunner {
 ///
 /// Why: Guards against hallucinated agent names causing confusing IO errors.
 /// What: Calls `execute({"agent_name":"ghost",...})` with a tempdir
-/// containing only `engineer.toml`; expects error with "ghost" and "engineer".
+/// containing only `engineer.md`; expects error with "ghost" and "engineer".
 /// Test: This test.
 #[tokio::test]
 async fn unknown_agent_returns_helpful_error() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    std::fs::write(
-        tmp.path().join("engineer.toml"),
-        "[agent]\nname = \"engineer\"\n",
-    )
-    .expect("write");
-    std::fs::write(
-        tmp.path().join("qa-agent.toml"),
-        "[agent]\nname = \"qa-agent\"\n",
-    )
-    .expect("write");
+    std::fs::write(tmp.path().join("engineer.md"), "---\nname: engineer\n---\n").expect("write");
+    std::fs::write(tmp.path().join("qa-agent.md"), "---\nname: qa-agent\n---\n").expect("write");
 
     let runner = Arc::new(RecordingRunner {
         invoked: std::sync::Mutex::new(Vec::new()),
@@ -88,16 +80,12 @@ async fn unknown_agent_returns_helpful_error() {
 /// A valid agent name passes validation and reaches the runner.
 ///
 /// Why: Verify the happy-path dispatch contract.
-/// What: Register `engineer.toml`, dispatch with `agent_name="engineer"`.
+/// What: Register `engineer.md`, dispatch with `agent_name="engineer"`.
 /// Test: This test.
 #[tokio::test]
 async fn known_agent_reaches_runner() {
     let tmp = tempfile::tempdir().expect("tempdir");
-    std::fs::write(
-        tmp.path().join("engineer.toml"),
-        "[agent]\nname = \"engineer\"\n",
-    )
-    .expect("write");
+    std::fs::write(tmp.path().join("engineer.md"), "---\nname: engineer\n---\n").expect("write");
 
     let runner = Arc::new(RecordingRunner {
         invoked: std::sync::Mutex::new(Vec::new()),

--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -45,30 +45,32 @@ use tokio::time::timeout;
 /// test in seconds rather than hanging the suite.
 const WIRE_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Provision a throwaway project with `.claude/agents/{pm,python-engineer}.toml`.
+/// Provision a throwaway project with `.claude/agents/{pm,python-engineer}.md`.
 ///
 /// Why: shared by `tests/task_e2e.rs` (drives the daemon directly) and
 /// (#2060) `tests/cli_e2e.rs` (drives the `tcode` CLI, which spawns its own
 /// nested daemon) — both need the SAME minimal two-agent fixture for
 /// `TCODE_MOCK_LLM=echo`'s scripted PM -> engineer delegation to resolve.
+/// `.md` (not `.toml`) since #2897 Slice D retired the TOML agent loader —
+/// `agents::discover_agents` only globs `*.md`.
 pub fn project_with_agents() -> tempfile::TempDir {
     let tmp = tempfile::tempdir().expect("project tempdir");
     let agents = tmp.path().join(".claude").join("agents");
     std::fs::create_dir_all(&agents).expect("mkdir agents");
     std::fs::write(
-        agents.join("pm.toml"),
-        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"You are the PM. Delegate work to python-engineer.\"\n",
+        agents.join("pm.md"),
+        "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM. Delegate work to python-engineer.\n",
     )
-    .expect("write pm.toml");
+    .expect("write pm.md");
     std::fs::write(
-        agents.join("python-engineer.toml"),
-        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n",
+        agents.join("python-engineer.md"),
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\nYou are a Python engineer.\n",
     )
-    .expect("write python-engineer.toml");
+    .expect("write python-engineer.md");
     tmp
 }
 
-/// A fake `$HOME` containing `~/.claude/agents/{pm,python-engineer}.toml`.
+/// A fake `$HOME` containing `~/.claude/agents/{pm,python-engineer}.md`.
 ///
 /// Why: a PROJECTLESS daemon has no project root to resolve `.claude/agents`
 /// from, so `ProjectBinding::agents_dir` falls back to the USER-level
@@ -76,23 +78,24 @@ pub fn project_with_agents() -> tempfile::TempDir {
 /// projectless e2e resolve real agent configs hermetically — and exercises that
 /// user-level fallback itself, rather than depending on whatever happens to be
 /// in the developer's real home directory.
-/// What: same two agent configs `project_with_agents` writes, rooted at
-/// `<tmp>/.claude/agents` and intended to be passed as the child's `HOME`.
+/// What: same two agent configs `project_with_agents` writes (`.md`, #2897
+/// Slice D), rooted at `<tmp>/.claude/agents` and intended to be passed as
+/// the child's `HOME`.
 /// Test: used by `task_e2e::projectless_task_runs_end_to_end`.
 pub fn home_with_user_level_agents() -> tempfile::TempDir {
     let tmp = tempfile::tempdir().expect("home tempdir");
     let agents = tmp.path().join(".claude").join("agents");
     std::fs::create_dir_all(&agents).expect("mkdir user-level agents");
     std::fs::write(
-        agents.join("pm.toml"),
-        "[agent]\nname = \"pm\"\nmodel = \"openai/gpt-4o-mini\"\n[system_prompt]\ncontent = \"You are the PM. Delegate work to python-engineer.\"\n",
+        agents.join("pm.md"),
+        "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM. Delegate work to python-engineer.\n",
     )
-    .expect("write pm.toml");
+    .expect("write pm.md");
     std::fs::write(
-        agents.join("python-engineer.toml"),
-        "[agent]\nname = \"python-engineer\"\nmodel = \"deepseek/deepseek-chat\"\n[system_prompt]\ncontent = \"You are a Python engineer.\"\n",
+        agents.join("python-engineer.md"),
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\nYou are a Python engineer.\n",
     )
-    .expect("write python-engineer.toml");
+    .expect("write python-engineer.md");
     tmp
 }
 

--- a/crates/trusty-code/tests/task_e2e.rs
+++ b/crates/trusty-code/tests/task_e2e.rs
@@ -15,7 +15,7 @@
 //! — a real subprocess, a real JSON-RPC wire, a real in-process PM ->
 //! engineer delegation, just a scripted model underneath.
 //! What: [`task_run_streams_live_tool_events_to_completion`] provisions a
-//! throwaway project with `pm.toml` + `python-engineer.toml`, calls
+//! throwaway project with `pm.md` + `python-engineer.md`, calls
 //! `task.run`, `session.attach`es (the mock run may already have finished by
 //! the time this fires — the ring-buffer replay covers that race either
 //! way, mirroring `session_e2e.rs`'s own read-until-terminal pattern), and

--- a/scripts/migrate-tcode-agents-toml-to-md.py
+++ b/scripts/migrate-tcode-agents-toml-to-md.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""migrate-tcode-agents-toml-to-md.py — convert tcode agent configs from the
+retired TOML format to the Markdown+frontmatter format (#2897 Slice D).
+
+Why: trusty-code's TOML agent loader (`AgentConfig::from_toml_str` /
+`AgentConfig::load`) was retired in #2897 Slice D — `.claude/agents/*.toml`
+is no longer read at all. A project with pre-existing `.toml` agents gets a
+one-time WARN-level log naming this script (see
+`crates/trusty-code/src/agents/mod.rs`'s `discover_agents` doc comment) but
+the actual migration has to happen out-of-band, since the harness itself no
+longer understands the old format. This script does that conversion.
+
+What: reads one or more tcode agent `.toml` files and emits the equivalent
+`.md`+frontmatter document tcode's Markdown loader
+(`agents::md_loader::load_md_agent`) understands. Field mapping:
+
+    [agent]
+    name         -> frontmatter `name:`
+    role         -> frontmatter `role:`
+    model        -> frontmatter `model:`        (wins over [llm].model_override,
+                                                   matching AgentConfig::agent.model's
+                                                   higher precedence in resolve_model)
+    description  -> frontmatter `description:`
+
+    [llm]
+    max_tokens      -> frontmatter `max_tokens:`
+    model_override  -> frontmatter `model:` (ONLY if [agent].model is absent)
+    temperature     -> DROPPED (no consumer reads AgentConfig.llm.temperature
+                                 anywhere in trusty-code; see md_loader's own
+                                 docs for the same conclusion)
+
+    [system_prompt]
+    content         -> the Markdown body (after the closing `---` fence)
+    append_skills   -> frontmatter `skills:` (only emitted when non-empty —
+                                                the shared frontmatter grammar
+                                                has a `skills:` field even
+                                                though tcode itself has no
+                                                consumer for it yet; see
+                                                md_loader::project_to_agent_config's
+                                                doc comment)
+
+    [tools]
+    allowed         -> frontmatter `tools:` (direct list map; an explicit
+                                               empty list `tools: []` is
+                                               preserved as deny-all, not
+                                               dropped, since `Some([])` and
+                                               `None` are NOT the same thing)
+
+    [runner]        -> DROPPED entirely (dead config: nothing in trusty-code
+                                          ever reads AgentConfig.runner; the
+                                          in-process runner is the only
+                                          runtime backend)
+
+Usage:
+    # Convert a single file, writing <name>.md next to <name>.toml
+    python3 scripts/migrate-tcode-agents-toml-to-md.py .claude/agents/engineer.toml
+
+    # Convert every *.toml in a directory
+    python3 scripts/migrate-tcode-agents-toml-to-md.py .claude/agents/
+
+    # Write elsewhere / preview without writing
+    python3 scripts/migrate-tcode-agents-toml-to-md.py engineer.toml -o /tmp/engineer.md
+    python3 scripts/migrate-tcode-agents-toml-to-md.py engineer.toml --dry-run
+
+Requires Python 3.11+ (stdlib `tomllib`, no external dependencies).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+
+_LEADING_SPECIAL = set("-?:,[]{}#&*!|>'\"%@`")
+
+
+def _needs_quoting(value: str) -> bool:
+    """Whether `value` is unsafe to emit as a bare YAML scalar.
+
+    Why: agent names/models/descriptions are plain identifiers or slugs
+    (`python-engineer`, `openai/gpt-4o-mini`) that read far more naturally
+    unquoted, matching every hand-authored `.md` fixture in the repo — a
+    blanket "quote if it contains a hyphen" rule would needlessly quote the
+    common case. Only the actual YAML hazards force quoting.
+    What: true when `value` is empty, starts/ends with whitespace, starts
+    with a YAML indicator character, contains `: ` (a mapping-key
+    look-alike), contains a flow-collection character (`[`, `]`, `{`, `}`,
+    `,`), or contains a newline.
+    """
+    if not value:
+        return True
+    if value[0] in _LEADING_SPECIAL or value[0].isspace() or value[-1].isspace():
+        return True
+    if ": " in value or value.endswith(":"):
+        return True
+    if any(ch in value for ch in "[]{},\n"):
+        return True
+    return False
+
+
+def yaml_scalar(value: str) -> str:
+    """Render `value` as a safe YAML scalar for frontmatter.
+
+    Why: agent names/models/descriptions are free-form strings that may
+    contain YAML-significant characters; emitting them unquoted in that case
+    would silently corrupt the frontmatter.
+    What: double-quotes and escapes the value when [`_needs_quoting`] says
+    so; otherwise emits it bare for readability.
+    """
+    if _needs_quoting(value):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return value
+
+
+def yaml_list(items: list[str]) -> str:
+    """Render a flow-style YAML list, e.g. `[a, b, c]` or `[]`."""
+    return "[" + ", ".join(yaml_scalar(i) for i in items) + "]"
+
+
+def convert(toml_path: Path) -> str:
+    """Convert one TOML agent document's bytes into a `.md`+frontmatter string."""
+    with toml_path.open("rb") as f:
+        data = tomllib.load(f)
+
+    agent = data.get("agent", {})
+    llm = data.get("llm", {})
+    system_prompt = data.get("system_prompt", {})
+    tools = data.get("tools", {})
+    dropped: list[str] = []
+
+    if "runner" in data:
+        dropped.append("[runner] (dead config — no consumer reads AgentConfig.runner)")
+    if "temperature" in llm:
+        dropped.append(
+            "[llm].temperature (dead config — no consumer reads AgentConfig.llm.temperature)"
+        )
+
+    name = agent.get("name")
+    if not name:
+        raise ValueError(f"{toml_path}: missing required [agent].name")
+
+    frontmatter: list[tuple[str, str]] = [("name", yaml_scalar(name))]
+
+    role = agent.get("role")
+    if role:
+        frontmatter.append(("role", yaml_scalar(role)))
+
+    description = agent.get("description")
+    if description:
+        frontmatter.append(("description", yaml_scalar(description)))
+
+    # [agent].model wins over [llm].model_override — mirrors
+    # provider::routing::resolve_model's precedence (agent-level model beats
+    # llm.model_override), so the converted frontmatter's single `model:`
+    # field preserves whichever value actually drove the agent before.
+    model = agent.get("model") or llm.get("model_override")
+    if model:
+        frontmatter.append(("model", yaml_scalar(model)))
+
+    max_tokens = llm.get("max_tokens")
+    if max_tokens is not None:
+        frontmatter.append(("max_tokens", str(max_tokens)))
+
+    if "allowed" in tools:
+        frontmatter.append(("tools", yaml_list(tools["allowed"])))
+
+    skills = system_prompt.get("append_skills") or []
+    if skills:
+        frontmatter.append(("skills", yaml_list(skills)))
+
+    body = (system_prompt.get("content") or "").strip()
+
+    lines = ["---"]
+    lines.extend(f"{key}: {value}" for key, value in frontmatter)
+    lines.append("---")
+    lines.append("")
+    if body:
+        lines.append(body)
+        lines.append("")
+
+    if dropped:
+        print(f"{toml_path}: dropped (no equivalent in .md): {'; '.join(dropped)}", file=sys.stderr)
+
+    return "\n".join(lines)
+
+
+def discover_toml_files(target: Path) -> list[Path]:
+    if target.is_dir():
+        return sorted(target.glob("*.toml"))
+    return [target]
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert a tcode agent .toml config to .md+frontmatter (#2897 Slice D).",
+    )
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="a .toml agent file, or a directory to convert every *.toml file in",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="output .md path (single-file mode only; default: same name, .md extension)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the converted .md to stdout instead of writing a file",
+    )
+    args = parser.parse_args(argv)
+
+    if args.output and args.input.is_dir():
+        parser.error("-o/--output is only valid when converting a single file")
+
+    toml_files = discover_toml_files(args.input)
+    if not toml_files:
+        print(f"no .toml files found under {args.input}", file=sys.stderr)
+        return 1
+
+    exit_code = 0
+    for toml_path in toml_files:
+        try:
+            md_text = convert(toml_path)
+        except (tomllib.TOMLDecodeError, ValueError, OSError) as e:
+            print(f"{toml_path}: {e}", file=sys.stderr)
+            exit_code = 1
+            continue
+
+        if args.dry_run:
+            print(f"# --- {toml_path} -> .md ---")
+            print(md_text)
+            continue
+
+        out_path = args.output or toml_path.with_suffix(".md")
+        out_path.write_text(md_text, encoding="utf-8")
+        print(f"wrote {out_path}")
+
+    if exit_code == 0 and not args.dry_run:
+        print(
+            "Done. Review the .md file(s), then delete the source .toml file(s) — "
+            "trusty-code no longer reads them.",
+            file=sys.stderr,
+        )
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/migrate-tcode-agents-toml-to-md.py
+++ b/scripts/migrate-tcode-agents-toml-to-md.py
@@ -51,6 +51,38 @@ What: reads one or more tcode agent `.toml` files and emits the equivalent
                                           in-process runner is the only
                                           runtime backend)
 
+Frontmatter reader contract (why `yaml_scalar` never backslash-escapes):
+trusty-agents-common's frontmatter reader is NOT a full YAML parser. For
+every field this script emits (`name`, `role`, `description`, `model`, and
+each element of `tools:`/`skills:`), it only ever strips AT MOST ONE
+balanced leading/trailing quote-character pair
+(`agents::frontmatter::strip_one_quote_pair`, used by both `parse_kv_line`
+and `parse_list_value`) and does nothing else to the value. It does NOT
+backslash-unescape — that unescaping (`unescape_yaml_double_quoted`, in
+`agents/builder.rs`) is applied to exactly one field, `initial_prompt`,
+which this script never emits (tcode's `AgentConfig` has no
+`initial_prompt` concept). So `yaml_scalar` must emit a plain,
+un-escaped `"`..`"` wrap: since the reader always removes EXACTLY the
+first and last byte of a quoted value and nothing more, wrapping ANY
+string verbatim in one fresh quote pair round-trips correctly no matter
+what characters it contains — including embedded quotes, backslashes, or
+a value that itself starts/ends with a quote character. Backslash-escaping
+inner quotes (as a naive YAML emitter would) is WRONG here: the reader
+would leave the literal backslashes in the loaded value instead of
+resolving them.
+
+Verification (this script has no automated test harness, so this is a
+manually-reproducible check rather than a pinned regression test): a TOML
+fixture with `description = "\"Featured\""` (i.e. a decoded value that
+itself both starts AND ends with a literal `"`) was converted, then loaded
+through the REAL production parser
+(`trusty_agents_common::agents::metadata::agent_metadata_from_str`, the
+exact function `agents::md_loader::load_md_agent` calls) via a throwaway
+`cargo run` harness depending on `trusty-agents-common` by path. The
+loaded `description` was confirmed to equal the original `"Featured"`
+byte-for-byte, with no stray backslashes — re-run this check after editing
+`yaml_scalar`/`_needs_quoting`.
+
 Usage:
     # Convert a single file, writing <name>.md next to <name>.toml
     python3 scripts/migrate-tcode-agents-toml-to-md.py .claude/agents/engineer.toml
@@ -100,17 +132,27 @@ def _needs_quoting(value: str) -> bool:
 
 
 def yaml_scalar(value: str) -> str:
-    """Render `value` as a safe YAML scalar for frontmatter.
+    """Render `value` as a frontmatter scalar for a field the reader only
+    STRIPS a quote pair from, never unescapes (see the module docstring's
+    "Frontmatter reader contract" section — this covers every field this
+    script emits: `name`/`role`/`description`/`model`/list elements).
 
-    Why: agent names/models/descriptions are free-form strings that may
-    contain YAML-significant characters; emitting them unquoted in that case
-    would silently corrupt the frontmatter.
-    What: double-quotes and escapes the value when [`_needs_quoting`] says
-    so; otherwise emits it bare for readability.
+    Why: `agents::frontmatter::strip_one_quote_pair` removes exactly the
+    first and last byte of a quoted value with no further interpretation.
+    Backslash-escaping interior quotes/backslashes here (the naive YAML-
+    emitter move) would therefore be WRONG for this reader — those escapes
+    are never resolved back, so the loaded value would retain literal
+    backslashes. Wrapping the RAW value in one fresh, un-escaped quote pair
+    is the correct inverse of `strip_one_quote_pair` for ANY content
+    (including a value that itself starts/ends with a quote character),
+    because the strip always removes exactly the pair we just added and
+    returns everything between untouched.
+    What: double-quotes the value verbatim (no escaping) when
+    [`_needs_quoting`] says quoting is required; otherwise emits it bare for
+    readability.
     """
     if _needs_quoting(value):
-        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-        return f'"{escaped}"'
+        return f'"{value}"'
     return value
 
 


### PR DESCRIPTION
## ⚠️ BREAKING CHANGE

This PR **retires trusty-code's TOML agent loader**. After this merges,
`.claude/agents/*.toml` files are **no longer read at all**. Only
`.claude/agents/*.md` (Markdown+frontmatter, dark-launched in Slice B/#2897
and the primary format since Slice C) is loaded.

**The PM holds this PR — do not merge without explicit maintainer approval
of the breaking cutover.**

## What changed (Slice D of #2897, epic #2892)

- Deleted `AgentConfig::from_toml_str` / `AgentConfig::load` (pure TOML
  parsing) from `crates/trusty-code/src/agents/config.rs`. Kept
  `AgentConfig`/`AgentInfo`/`LlmParams`/`SystemPrompt`/`ToolsConfig`/
  `RunnerConfig`/`RunnerKind` — the shared, format-agnostic schema the `.md`
  loader (`agents::md_loader`) projects into.
- `agents::discover_agents` now globs `*.md` **only**. The `.toml`-wins-on-
  collision logic from the Slice B/C dark launch is gone (no more collisions
  possible).
- **Orphaned `.toml` handling (not silent):** when `discover_agents` finds a
  `*.toml` file, it emits **one aggregated `tracing::warn!`** naming every
  orphaned file and pointing at the converter script — the file is skipped
  (never parsed, never errors). Example:
  `trusty-code no longer loads TOML agents (#2897). Found <path>.toml —
  convert with scripts/migrate-tcode-agents-toml-to-md.py. See CHANGELOG.`
- `agents::load_all_agents` falls back to the embedded
  `engineer`/`qa-agent`/`code-reviewer` defaults when disk holds nothing but
  orphaned `.toml` (or nothing at all) — a project is never left with zero
  agents.
- All call sites that hardcoded `<agents_dir>/<name>.toml` now use
  `<name>.md` and dispatch through `md_loader::load_md_agent`:
  `runner::in_process::InProcessAgentRunner::load_agent`,
  `runner::agent_config_exists`, `run_task::execute_run_task`'s PM-config
  load, `run_task::resolve_agent_model_slug`, `task::executor`'s PM-config
  load. `tools::delegate::DelegateToAgentTool::available_agents` and its
  pre-flight existence check now reuse `agents::discover_agents` /
  `runner::agent_config_exists` instead of re-deriving the extension
  (consolidation — one source of truth for "is this an agent config").
- **Converter script:** `scripts/migrate-tcode-agents-toml-to-md.py`
  (executable, stdlib-only via `tomllib`, Python 3.11+). Reads a tcode agent
  `.toml` and emits the equivalent `.md`+frontmatter document:
  `[agent].name/role/model/description` → frontmatter, `[llm].max_tokens` →
  `max_tokens:`, `[llm].model_override` → `model:` (only when
  `[agent].model` is absent — mirrors `resolve_model`'s precedence),
  `[tools].allowed` → `tools:` (direct list map, preserves explicit
  `tools: []` deny-all), `[system_prompt].content` → the Markdown body,
  `[system_prompt].append_skills` → `skills:` (only when non-empty).
  `[runner]` and `[llm].temperature` are dropped (dead config — no consumer
  reads either field anywhere in trusty-code) with a stderr note naming what
  was dropped. Supports single-file, whole-directory, `--dry-run`, and
  `-o/--output`.
- Removed the `toml` dependency from `crates/trusty-code/Cargo.toml` — grep
  confirmed no other file in the crate uses `toml::` (it compiles back in
  transitively via `trusty-agents-common`'s own deps, but is no longer a
  direct dependency of trusty-code).
- Rewrote every `.toml`-fixture test to a parallel `.md` fixture (hand
  translated, not search/replace): `agents/mod.rs` (discover/load-all
  suite, plus new `discover_agents_ignores_toml` and
  `discover_agents_warns_on_orphaned_toml` — the latter asserts the actual
  captured WARN text via the crate's `test_support` capture harness),
  `agents/md_loader.rs` (`parallel_fixture_equivalence` → a `.md`-only
  `full_fidelity_md_fixture_projects_every_field`, since there's no more
  TOML side to compare against), `runner/tests.rs` (`agents_dir_with` + all
  ~18 call sites), `tools/delegate_tests.rs`, `task/executor_tests.rs`,
  `serve/mod.rs`, `task/protocol.rs`, `run_task/tests.rs` (`agents_dir` +
  both inline fixtures, plus two NEW tests —
  `resolve_agent_model_slug_falls_back_when_config_missing` /
  `resolve_agent_model_slug_honours_override` — that fixed a pre-existing
  dangling `Test:` doc pointer on `resolve_agent_model_slug` while I was
  already touching that function).
- Updated every doc comment that named the `.toml` path/extension across the
  crate (`config.rs`, `mod.rs`, `md_loader.rs`, `main.rs`, `binding/mod.rs`,
  `lib.rs`, `runner/error.rs`, `runner/in_process.rs`, `run_task/mod.rs`,
  `task/executor.rs`, `tools/delegate.rs`, `assets/mod.rs`).
- CHANGELOG: added a `### Changed` bullet under `[Unreleased]` prefixed
  `BREAKING —` (matching the crate's existing convention), describing the
  removal, the orphaned-`.toml` warning, and the converter path.

## Gates (raw output)

- `cargo build -p trusty-code --all-targets` — clean, exit 0.
- `cargo test -p trusty-code --lib -- --test-threads=1` — **1112 passed, 0
  failed, 4 ignored.** (Under the default parallel `--test-threads`, 1
  pre-existing, unrelated test occasionally flakes —
  `run_task::tests::no_changes_yields_no_changes_exit` /
  `exit_code_reflects_run_failure`, alternating — because several
  `run_task`/`task::executor` tests share the real repo working tree for
  `git diff`/background-indexing side effects under `ensure_project_indexed_in_background`;
  each such test passes individually and the whole suite is green at
  `--test-threads=1`. Confirmed pre-existing/unrelated to this change by
  reproducing before making any edits to these files were relevant.)
- `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean, exit 0.
- `cargo fmt --check -p trusty-code` — clean, exit 0 (after running
  `cargo fmt -p trusty-code` once to settle two long-line fixture strings).
- `bash scripts/check_line_cap.sh` — `line-cap: 9 allowlisted, 0
  violations — OK.`
- `bash scripts/check_test_pointers.sh` — **0 dangling pointers, 0 stale
  allowlist entries — OK.** (Fixing this required two doc-comment repoints —
  `AgentInfo`/`RunnerKind` in `config.rs` cited the two deleted TOML-parsing
  tests — and one `--update` prune of `.test-pointer-allowlist.tsv`: the two
  `resolve_agent_model_slug_*` tests added in this PR made their own
  pre-existing dangling allowlist entries stale, since the pointer they cite
  is real now.)

## Migration path (for maintainer review)

```
python3 scripts/migrate-tcode-agents-toml-to-md.py .claude/agents/engineer.toml
# review the generated engineer.md, then delete engineer.toml
```

or convert a whole directory at once:

```
python3 scripts/migrate-tcode-agents-toml-to-md.py .claude/agents/
```

Until migrated, `tcode` keeps working (falls back to embedded defaults if
disk holds only orphaned `.toml`) and logs a loud warning naming exactly
which files need conversion.

Closes #2897. Refs #2892.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
