### PR TITLE
fix(trusty-mpm-gui): stable Developer ID signing identity + distinct product name for TCC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,53 @@ resolver = "2"
 # want Cargo to treat as workspace members. trusty-agents bundles a `weather_alerter`
 # scratch dir; trusty-mpm-gui's `src-tauri` is included via its parent crate.
 exclude = []
+# `default-members` — the crates a BARE `cargo build`/`test`/`check` (no
+# `--workspace`, no `-p`, run from this root) actually targets. Everything
+# except `trusty-mpm-gui` (#2951).
+#
+# Why: CI already runs the workspace-wide gates with
+# `--workspace --exclude trusty-mpm-gui` (`.github/workflows/ci.yml`) because
+# the GUI needs the pnpm/Svelte UI toolchain — a bare `cargo build`/`test`/
+# `check` had no equivalent exclusion, so every agent worktree (which routinely
+# runs the bare form per this repo's own documented workflow) silently
+# rebuilt the GUI too. Seven stray ad-hoc-signed `trusty-mpm-gui` debug
+# binaries were found across worktrees this way (forensics in #2951) — each a
+# brand-new identity to macOS TCC, and each a wasted UI-toolchain-dependent
+# build for anyone not actually touching the GUI. `--workspace` and `-p
+# trusty-mpm-gui` are UNAFFECTED by `default-members` and keep working exactly
+# as before (`cargo build --workspace`, `cargo test -p trusty-mpm-gui`, etc.),
+# so this only changes what the bare, no-flag form does — it does not remove
+# `trusty-mpm-gui` from the workspace.
+#
+# Maintenance note: Cargo has no "members minus one" glob for
+# `default-members`, so this list must be updated by hand when a new crate
+# lands under `crates/` (it is already a member via the `members` glob above
+# either way — only the bare-command default is affected, so forgetting to add
+# a new crate here is a mildly stale default, not a build break).
+default-members = [
+    "crates/cto-assistant",
+    "crates/tc-services",
+    "crates/trusty-agents",
+    "crates/trusty-agents-common",
+    "crates/trusty-agents-local",
+    "crates/trusty-analyze",
+    "crates/trusty-bm25-daemon",
+    "crates/trusty-channels",
+    "crates/trusty-code",
+    "crates/trusty-common",
+    "crates/trusty-console",
+    "crates/trusty-cto-db",
+    "crates/trusty-embedderd",
+    "crates/trusty-git-analytics",
+    "crates/trusty-gworkspace",
+    "crates/trusty-installer",
+    "crates/trusty-memory",
+    "crates/trusty-mpm",
+    "crates/trusty-progress",
+    "crates/trusty-review",
+    "crates/trusty-search",
+    "crates/trusty-sld-lint",
+]
 
 [workspace.package]
 edition = "2024"

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- `trusty-mpm-gui` joined the `trusty-mpm` signable set in `SIGNABLE_BINARIES` (`com.trusty.trusty-mpm.gui`), so `tctl sign trusty-mpm` and the automatic `tctl install` post-install hook also sign the GUI binary (if present under the install dir) with the stable Developer ID identity — fallback coverage for a bare `cargo install --path crates/trusty-mpm-gui`, alongside the GUI's own `bundle.macOS.signingIdentity` fix (closes #2951).
+
 ## [0.4.2] — 2026-07-17
 
 Ships the real Developer-ID signed-install path — the working `tctl sign`

--- a/crates/trusty-installer/src/commands/macos_signing.rs
+++ b/crates/trusty-installer/src/commands/macos_signing.rs
@@ -38,6 +38,15 @@
 //!   Runtime is verified. TCC grant stability depends on `--identifier` + Team
 //!   ID, not on `--options runtime`, so this split does not reintroduce the
 //!   identifier drift above.
+//! - #2951: `trusty-mpm-gui` (the Tauri desktop shell) joined [`MPM_SET`] as a
+//!   third binary. It presented its own App-Data TCC prompt textually
+//!   identical to `trusty-mpm`'s (`productName: "trusty-mpm"` in
+//!   `tauri.conf.json`) and, because ad-hoc debug builds happen in every
+//!   worktree, churned a fresh random identity per rebuild — the same class of
+//!   bug this module already fixed for `trusty-mpm`/`tm`. The primary fix is
+//!   Tauri's own `bundle.macOS.signingIdentity` (so `cargo tauri build`
+//!   produces a Developer-ID-signed `.app` directly); this table entry covers
+//!   the fallback case of a bare `cargo install --path crates/trusty-mpm-gui`.
 //!
 //! What: [`binaries_for_set`] and [`codesign_identifier`] are both derived from
 //! the single [`SIGNABLE_BINARIES`] table (binary, set, identifier) so set
@@ -101,6 +110,20 @@ const SIGNABLE_BINARIES: &[(&str, &str, &str)] = &[
     // (#2721). Ordered after `trusty-mpm` so `binaries_for_set(MPM_SET).first()`
     // — the binary whose path the guidance/prompt names — stays `trusty-mpm`.
     ("tm", MPM_SET, "com.trusty.tm"),
+    // `trusty-mpm-gui` (#2951): the Tauri desktop shell. It is a separate
+    // binary/crate from `trusty-mpm`/`tm` and is normally not present under
+    // `install_dir` unless someone runs `cargo install --path
+    // crates/trusty-mpm-gui`, so `post_install_signed_set`'s existing
+    // "skip if the path doesn't exist" behavior makes this entry a no-op for
+    // everyone who never installs the GUI that way. Sharing `MPM_SET` (rather
+    // than a new set) means `tctl sign trusty-mpm` / the automatic
+    // `tctl install` post-install hook picks it up for free with no new set
+    // name to thread through `SignSetError`'s messages. Identifier matches the
+    // `bundle.macOS.signingIdentity`-driven identifier in
+    // `crates/trusty-mpm-gui/tauri.conf.json` so both signing paths (Tauri's
+    // own bundler and this fallback for a bare `cargo install`ed binary) agree
+    // on one designated requirement.
+    ("trusty-mpm-gui", MPM_SET, "com.trusty.trusty-mpm.gui"),
 ];
 
 /// Resolve the binaries that make up a named Developer-ID-signable set.
@@ -674,8 +697,9 @@ mod tests {
     /// `trusty-mpm` set MUST include `tm` (#2721) — omitting it left the primary
     /// `tm` binary ad-hoc and the App-Data TCC prompt kept recurring. Order
     /// matters: `trusty-mpm` first so it stays the guidance/prompt "primary".
+    /// `trusty-mpm-gui` (#2951) joined the set after `tm` for the same reason.
     /// What: Asserts `trusty-search` covers search+embedderd, `trusty-mpm` covers
-    /// both `trusty-mpm` and `tm` in that order.
+    /// `trusty-mpm`, `tm`, and `trusty-mpm-gui` in that order.
     /// Test: This is the test.
     #[test]
     fn binaries_for_set_covers_search_and_mpm() {
@@ -683,7 +707,10 @@ mod tests {
             binaries_for_set(SEARCH_SET),
             vec!["trusty-search", "trusty-embedderd"]
         );
-        assert_eq!(binaries_for_set(MPM_SET), vec!["trusty-mpm", "tm"]);
+        assert_eq!(
+            binaries_for_set(MPM_SET),
+            vec!["trusty-mpm", "tm", "trusty-mpm-gui"]
+        );
     }
 
     /// Why: An unrecognised set name must not silently sign nothing without
@@ -700,8 +727,9 @@ mod tests {
     /// `com.trusty.trusty-<binary>` scheme used by `plist_label.rs` and the
     /// release-workflow docs (the pre-#2558 short-form identifiers were the
     /// drift this module fixes).
-    /// What: Asserts all four target binaries map to the expected IDs, including
-    /// the `tm` binary (`com.trusty.tm`, #2721) that shares the trusty-mpm set.
+    /// What: Asserts all five target binaries map to the expected IDs,
+    /// including the `tm` binary (`com.trusty.tm`, #2721) and `trusty-mpm-gui`
+    /// (`com.trusty.trusty-mpm.gui`, #2951) that share the trusty-mpm set.
     /// Test: This is the test.
     #[test]
     fn identifier_map_covers_all_signable_binaries() {
@@ -715,6 +743,10 @@ mod tests {
         );
         assert_eq!(codesign_identifier("trusty-mpm"), "com.trusty.trusty-mpm");
         assert_eq!(codesign_identifier("tm"), "com.trusty.tm");
+        assert_eq!(
+            codesign_identifier("trusty-mpm-gui"),
+            "com.trusty.trusty-mpm.gui"
+        );
     }
 
     /// Why: PR #2657 review MEDIUM — with set membership and identifier now

--- a/crates/trusty-mpm-gui/CHANGELOG.md
+++ b/crates/trusty-mpm-gui/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog — trusty-mpm-gui
+
+All notable changes to trusty-mpm-gui are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+
+## [Unreleased]
+
+### Fixed
+
+- Stopped the recurring macOS "'trusty-mpm' would like to access data from other apps" TCC prompt caused by the GUI (closes #2951): renamed `productName`/window title from the bare `"trusty-mpm"` to `"Trusty MPM Dashboard"` so any future prompt is visibly the GUI, not the CLI/daemon; changed the bundle identifier from `com.trusty-mpm.gui` to `com.trusty.trusty-mpm.gui` and wired `bundle.macOS.signingIdentity` in `tauri.conf.json` so `cargo tauri build` produces a Developer-ID-signed `.app` with a stable designated requirement instead of a fresh ad-hoc identity per rebuild.

--- a/crates/trusty-mpm-gui/CHANGELOG.md
+++ b/crates/trusty-mpm-gui/CHANGELOG.md
@@ -11,3 +11,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Stopped the recurring macOS "'trusty-mpm' would like to access data from other apps" TCC prompt caused by the GUI (closes #2951): renamed `productName`/window title from the bare `"trusty-mpm"` to `"Trusty MPM Dashboard"` so any future prompt is visibly the GUI, not the CLI/daemon; changed the bundle identifier from `com.trusty-mpm.gui` to `com.trusty.trusty-mpm.gui` and wired `bundle.macOS.signingIdentity` in `tauri.conf.json` so `cargo tauri build` produces a Developer-ID-signed `.app` with a stable designated requirement instead of a fresh ad-hoc identity per rebuild.
+
+### Documentation
+
+- Documented the cert-less build escape hatch for `cargo tauri build` (#2957 review follow-up): `bundle.macOS.signingIdentity` in `tauri.conf.json` is hardcoded to Bob's Developer ID cert, so building the bundle on any other machine requires either that exact certificate in the keychain or an `APPLE_SIGNING_IDENTITY` environment variable override (`APPLE_SIGNING_IDENTITY=-` for a local ad-hoc build, or a different Developer ID string) — Tauri's bundler honors the env var in place of the config value. See the README's "Release Build" section and `docs/reference/common-pitfalls.md`.

--- a/crates/trusty-mpm-gui/README.md
+++ b/crates/trusty-mpm-gui/README.md
@@ -70,6 +70,22 @@ Builds optimized binaries for the current platform:
 - Linux: AppImage or deb package
 - Windows: `.msi` installer
 
+**macOS signing (#2951):** `tauri.conf.json` pins `bundle.macOS.signingIdentity`
+to Bob's Developer ID cert (`Developer ID Application: Bob Matsuoka
+(4JH68XUHC5)`) so the `.app` bundle gets a stable TCC identity instead of a
+fresh ad-hoc one per rebuild. On a machine without that exact certificate in
+the login keychain, `cargo tauri build` will fail to sign — override it with
+the `APPLE_SIGNING_IDENTITY` environment variable, which Tauri's bundler
+honors in place of the config value:
+
+```bash
+# Local ad-hoc build (no Developer ID cert required):
+APPLE_SIGNING_IDENTITY=- cargo tauri build
+
+# Or sign with a different Developer ID cert you do have:
+APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)" cargo tauri build
+```
+
 ## Configuration
 
 ### Daemon Connection

--- a/crates/trusty-mpm-gui/tauri.conf.json
+++ b/crates/trusty-mpm-gui/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "trusty-mpm",
+  "productName": "Trusty MPM Dashboard",
   "version": "0.1.0",
-  "identifier": "com.trusty-mpm.gui",
+  "identifier": "com.trusty.trusty-mpm.gui",
   "build": {
     "frontendDist": "ui/dist",
     "devUrl": "http://localhost:5173",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "trusty-mpm",
+        "title": "Trusty MPM Dashboard",
         "width": 1280,
         "height": 800,
         "resizable": true
@@ -20,6 +20,11 @@
     ],
     "security": {
       "csp": null
+    }
+  },
+  "bundle": {
+    "macOS": {
+      "signingIdentity": "Developer ID Application: Bob Matsuoka (4JH68XUHC5)"
     }
   }
 }

--- a/docs/reference/common-pitfalls.md
+++ b/docs/reference/common-pitfalls.md
@@ -72,3 +72,12 @@ compiles locally but fails on CI. Prefer stable channel toolchains.
 🟢 **Edition mismatch** — `trusty-mpm`, `trusty-mpm-gui`, `trusty-agents`, `trusty-agents-common`, and `trusty-agents-local` use edition 2024;
 all other crates use edition 2021. Let-chains (`if let … && let …`) only
 work in edition 2024. Do not copy let-chain patterns into edition-2021 crates.
+
+🟢 **`trusty-mpm-gui` is excluded from bare `cargo build`/`test`/`check`**
+(#2951) — the root `Cargo.toml`'s `default-members` list omits it, matching
+CI's existing `--workspace --exclude trusty-mpm-gui` for the same commands.
+Use `cargo build -p trusty-mpm-gui` (or `--workspace`, which always builds
+everything regardless of `default-members`) when you actually need it. This
+also stops every agent worktree from silently producing a fresh ad-hoc-signed
+GUI debug binary — and its own macOS "would like to access data from other
+apps" TCC prompt — on every bare `cargo build`.

--- a/docs/reference/common-pitfalls.md
+++ b/docs/reference/common-pitfalls.md
@@ -81,3 +81,19 @@ everything regardless of `default-members`) when you actually need it. This
 also stops every agent worktree from silently producing a fresh ad-hoc-signed
 GUI debug binary — and its own macOS "would like to access data from other
 apps" TCC prompt — on every bare `cargo build`.
+
+🟡 **`cargo tauri build` for `trusty-mpm-gui` needs Bob's Developer ID cert,
+or an env-var override** — `crates/trusty-mpm-gui/tauri.conf.json` pins
+`bundle.macOS.signingIdentity` to `"Developer ID Application: Bob Matsuoka
+(4JH68XUHC5)"` (#2951, stable TCC identity instead of a fresh ad-hoc one per
+rebuild — see the entry above). On a machine without that exact certificate
+in the login keychain, Tauri's bundler hard-fails the signing step. Override
+it with the `APPLE_SIGNING_IDENTITY` environment variable — Tauri's bundler
+honors it in place of the config value (confirmed against the Tauri v2
+[environment variables reference](https://v2.tauri.app/reference/environment-variables/):
+"`APPLE_SIGNING_IDENTITY` — The identity used to code sign. Overwrites
+`tauri.conf.json > bundle > macOS > signingIdentity`."):
+`APPLE_SIGNING_IDENTITY=- cargo tauri build` for a local ad-hoc build (the
+`-` pseudo-identity), or set it to a Developer ID string you do have. `cargo
+build -p trusty-mpm-gui` / `cargo check -p trusty-mpm-gui` (no bundling) are
+unaffected — this only matters for `cargo tauri build`/`tauri build`.

--- a/scripts/install-trusty-mpm-signed.sh
+++ b/scripts/install-trusty-mpm-signed.sh
@@ -30,6 +30,17 @@
 # installs and can, if desired, be reduced to a delegation to
 # `tctl sign trusty-mpm` now that the table is complete.
 #
+# GUI NOTE (#2951): `trusty-mpm-gui` (`com.trusty.trusty-mpm.gui`) also joined
+# the `SIGNABLE_BINARIES` table's `trusty-mpm` set. This script's Step 1 only
+# `cargo install`s `crates/trusty-mpm` (the CLI/daemon), so the GUI binary is
+# NOT built here — the GUI's primary fix is its own `bundle.macOS.
+# signingIdentity` in `crates/trusty-mpm-gui/tauri.conf.json`, applied whenever
+# `cargo tauri build` runs. Step 2b below is a best-effort fallback: IF
+# `~/.cargo/bin/trusty-mpm-gui` already exists (e.g. from a separate `cargo
+# install --path crates/trusty-mpm-gui`), sign it with the same stable
+# identifier too; otherwise it is skipped gracefully, matching
+# `post_install_signed_set`'s "skip if the path doesn't exist" behavior.
+#
 # Hardened Runtime: `--options runtime --timestamp` is applied to both binaries.
 # Unlike trusty-search/trusty-embedderd (which load an ONNX runtime dylib and so
 # gate Hardened Runtime carefully — see #2663 / the tctl `use_hardened_runtime`
@@ -71,11 +82,15 @@ set -euo pipefail
 CARGO_BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
 readonly MPM_BIN="$CARGO_BIN_DIR/trusty-mpm"
 readonly TM_BIN="$CARGO_BIN_DIR/tm"
+# Optional: only present if the operator separately ran
+# `cargo install --path crates/trusty-mpm-gui` (#2951 — see GUI NOTE above).
+readonly GUI_BIN="$CARGO_BIN_DIR/trusty-mpm-gui"
 
 # Fixed codesign identifiers — MUST match the canonical scheme (macos_signing.rs)
 # so the designated requirement stays stable across every reinstall.
 readonly MPM_IDENTIFIER="com.trusty.trusty-mpm"
 readonly TM_IDENTIFIER="com.trusty.tm"
+readonly GUI_IDENTIFIER="com.trusty.trusty-mpm.gui"
 
 # Sign identity: auto-detected from the keychain if not overridden.
 TRUSTY_SIGN_IDENTITY="${TRUSTY_SIGN_IDENTITY:-}"
@@ -252,6 +267,20 @@ run_sign() {
         error "The two binaries now have different identities (trusty-mpm has the new stable DR; tm is unchanged)."
         error "Re-run this script to retry — signing trusty-mpm again is idempotent (--force overwrites the existing signature)."
         return 1
+    fi
+
+    # trusty-mpm-gui (#2951): best-effort, gracefully skipped when absent — see
+    # the GUI NOTE above. This script never builds it, so a missing binary here
+    # is the expected common case, not an error. Checked directly (not via
+    # sign_binary's own not-found check, which is an error path for the
+    # required MPM_BIN/TM_BIN) so a missing GUI binary stays a skip, not a
+    # failure.
+    if [[ -f "$GUI_BIN" ]]; then
+        if ! sign_binary "$GUI_BIN" "$GUI_IDENTIFIER" "$identity" || ! verify_binary "$GUI_BIN"; then
+            warn "trusty-mpm-gui signing failed; trusty-mpm and tm are still correctly signed."
+        fi
+    else
+        info "trusty-mpm-gui not found at $GUI_BIN — skipping (only built via a separate 'cargo install --path crates/trusty-mpm-gui')."
     fi
 }
 


### PR DESCRIPTION
## Summary

Fixes #2951 — `trusty-mpm-gui` was the unaddressed vector behind the recurring macOS "'trusty-mpm' would like to access data from other apps" TCC prompt. The #2721 fix (PRs #2723/#2736) only covered the CLI (`trusty-mpm`/`tm`); the GUI presented as the bare `productName: "trusty-mpm"` and got a fresh ad-hoc signing identity on every rebuild (7 stray debug builds found across worktrees, each with a random `trusty_mpm_gui-<hash>` identifier and `TeamIdentifier=not set`).

### Part 1 — Disambiguate the name
`crates/trusty-mpm-gui/tauri.conf.json`: `productName` and window `title` changed from the bare `"trusty-mpm"` to `"Trusty MPM Dashboard"`, so any future prompt is visibly the GUI, not the daemon. I checked for other bare-name surfaces (Info.plist template, hardcoded window titles in `src/`) and found none — Tauri generates `Info.plist` from this config at build time; there's no static template checked in. I deliberately left the in-app `Header.svelte` "trusty-mpm" wordmark alone — that's app UI content, not a TCC-facing identity surface, and changing it is a product-branding decision outside this bug's scope.

### Part 2 — Stable signing identity
- `tauri.conf.json`: `identifier` renamed `com.trusty-mpm.gui` → `com.trusty.trusty-mpm.gui` (matches the `com.trusty.trusty-<name>` scheme already used for `trusty-search`/`trusty-mpm`/`tm`), plus `bundle.macOS.signingIdentity = "Developer ID Application: Bob Matsuoka (4JH68XUHC5)"` so `cargo tauri build` produces a Developer-ID-signed `.app` directly.
  - **Identifier-rename decision**: the old identifier was already churning per ad-hoc rebuild, so there was no existing stable TCC grant keyed to it worth preserving — a one-time rename is a clean break with no migration cost, unlike the #2657 CLI-identifier-migration case which had to warn about breaking a real, stable, existing grant.
- `crates/trusty-installer/src/commands/macos_signing.rs`: added `trusty-mpm-gui` to `SIGNABLE_BINARIES`, joining `MPM_SET` (identifier `com.trusty.trusty-mpm.gui`) rather than a new set — so `tctl sign trusty-mpm` and the automatic `tctl install` post-install hook cover it for free, no new set name to thread through `SignSetError`. It's a no-op for anyone who never separately does `cargo install --path crates/trusty-mpm-gui` (existing "skip if the path doesn't exist" behavior in `post_install_signed_set`).
- `scripts/install-trusty-mpm-signed.sh`: added a best-effort Step 2b that signs `~/.cargo/bin/trusty-mpm-gui` with the same stable identifier if present, gracefully skipped (info-logged, not an error) when absent — the script's Step 1 only `cargo install`s `crates/trusty-mpm`, so the GUI is not built there.

Both signing paths agree on one designated requirement: Tauri's own bundler (primary, for real `.app` distribution) and this fallback table entry (for a raw `cargo install`ed binary).

### Part 3 — Stop the churn at the source
Added `default-members` to the root `Cargo.toml`, excluding `trusty-mpm-gui`, so a **bare** `cargo build`/`test`/`check` (no `--workspace`, no `-p`) no longer builds it — this is exactly what was producing the 7 stray ad-hoc-signed debug binaries across agent worktrees.

I verified this is safe before implementing:
- Every `cargo` invocation in `.github/workflows/ci.yml` uses either `--workspace` (which **ignores** `default-members` entirely and always builds everything) or `-p <crate>` — never the bare form. CI already explicitly runs `--workspace --exclude trusty-mpm-gui` for the clippy/test/check jobs, so this change actually makes local bare-command behavior *more* consistent with CI, not less.
- `Makefile`'s `check` target uses `cargo test --workspace` — unaffected.
- `.github/workflows/release.yml` always scopes with `-p ${{ matrix.cargo_pkg }}` — unaffected.
- `cargo build -p trusty-mpm-gui` / `cargo tauri build` continue to work exactly as before for anyone actually working on the GUI.

Tradeoff, documented in a `Cargo.toml` comment and in `docs/reference/common-pitfalls.md`: Cargo's `default-members` has no "all members minus one" glob, so the list is a hand-maintained enumeration of the other 22 crates. Forgetting to add a newly-created crate here is a mildly stale default (bare `cargo build` won't include it until someone notices), not a build break — `--workspace`/`-p` are unaffected either way.

## Test plan

- [x] `cargo check -p trusty-mpm-gui` — clean
- [x] `SKIP_UI_BUILD=1 cargo build -p trusty-mpm-gui` — clean; confirmed the resulting `target/debug/trusty-mpm-gui` is still ad-hoc/linker-signed with a random identifier when built via bare `cargo build` (not through `cargo tauri build`), which is exactly why the `SIGNABLE_BINARIES`/script fallback in Part 2 exists
- [x] `cargo clippy -p trusty-mpm-gui -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 9 allowlisted, 0 violations — OK.`
- [x] `cargo test -p trusty-installer` — 374 passed, 0 failed (including the two `macos_signing` tests updated for the new table entry)
- [x] `bash -n` + `shellcheck` on `scripts/install-trusty-mpm-signed.sh` — clean
- [x] Manually dry-ran the script with a fake `$CARGO_HOME` both with and without a `trusty-mpm-gui` binary present — confirmed the skip-when-absent and sign-when-present branches both behave correctly
- [x] `cargo metadata` confirms `workspace_default_members` now lists 22 crates, correctly excluding `trusty-mpm-gui`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools