### PR TITLE
fix(scripts): correct launchd plist names in signed-install restart hints

### DIFF
--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -693,7 +693,7 @@ To fix:
    filesystem access as your user account, without the launchd TCC restriction.
    ```bash
    # Stop the launchd agent first, then start manually:
-   launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.search.plist
+   launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist
    trusty-search start --foreground
    ```
    Note: indexes restored when running manually will NOT be available when the

--- a/scripts/install-trusty-mpm-signed.sh
+++ b/scripts/install-trusty-mpm-signed.sh
@@ -288,6 +288,39 @@ run_sign() {
 # Post-install guidance
 # ---------------------------------------------------------------------------
 
+# Why: the printed restart hint must name the plist launchd actually has
+# installed, not a guessed name derived from the codesign `--identifier`
+# (`com.trusty.trusty-mpm`, a DIFFERENT namespace). The real daemon launchd
+# label is `com.trusty.mpm` (crates/trusty-mpm/src/bin/tm/commands/
+# guided_autostart.rs, MAIN_DAEMON_PLIST_LABEL) — a stale hardcoded
+# `com.trusty.trusty-mpm.plist` here sent every reader into two failing
+# `launchctl` calls (#2827).
+# What: prefers the canonical `com.trusty.mpm.plist` when it exists on disk;
+# otherwise globs LaunchAgents for any other `com.trusty.*mpm*.plist`
+# (excluding the supervisor/GUI plists, which are distinct services) so the
+# hint still finds a drifted label, and falls back to the canonical name if
+# nothing is installed yet.
+# Test: `bash -n` syntax check; manually verified against a real
+# ~/Library/LaunchAgents/com.trusty.mpm.plist during #2827 triage.
+resolve_mpm_plist() {
+    local agents_dir="$HOME/Library/LaunchAgents"
+    local canonical="$agents_dir/com.trusty.mpm.plist"
+    if [[ -f "$canonical" ]]; then
+        printf '%s' "$canonical"
+        return 0
+    fi
+    local candidate
+    for candidate in "$agents_dir"/com.trusty.*mpm*.plist; do
+        [[ -f "$candidate" ]] || continue
+        case "$candidate" in
+            *supervisor*|*gui*) continue ;;
+        esac
+        printf '%s' "$candidate"
+        return 0
+    done
+    printf '%s' "$canonical"
+}
+
 print_next_steps() {
     section "Done — next steps"
     # shellcheck disable=SC2016  # literal "$HOME" is intended narration, not expansion
@@ -299,10 +332,12 @@ print_next_steps() {
     printf 'approval persist across every future cargo install.\n\n'
     printf 'RESTART the tm daemon gracefully to pick up the newly signed binaries\n'
     printf '(SIGTERM drains in-flight requests; do NOT use kickstart -k / SIGKILL):\n'
+    local plist_path
+    plist_path="$(resolve_mpm_plist)"
+    # shellcheck disable=SC2016  # literal "$(id -u)" is narration for the reader to run, not expansion here
+    printf '  launchctl bootout   gui/$(id -u) %s\n' "$plist_path"
     # shellcheck disable=SC2016
-    printf '  launchctl bootout   gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-mpm.plist\n'
-    # shellcheck disable=SC2016
-    printf '  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-mpm.plist\n'
+    printf '  launchctl bootstrap gui/$(id -u) %s\n' "$plist_path"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/install-trusty-search-signed.sh
+++ b/scripts/install-trusty-search-signed.sh
@@ -176,6 +176,38 @@ run_sign() {
 }
 
 # ---------------------------------------------------------------------------
+# Post-install guidance
+# ---------------------------------------------------------------------------
+
+# Why: the printed restart hint must name the plist launchd actually has
+# installed. The real daemon launchd label is `com.trusty.trusty-search`
+# (crates/trusty-search/src/commands/service.rs, LAUNCHD_LABEL) — this script
+# already printed the correct name, but the sibling README and the Makefile's
+# `deploy` target had drifted to two OTHER names (`com.trusty.search` and
+# `com.bobmatnyc.trusty-search` respectively), the same class of bug as #2827.
+# What: prefers the canonical `com.trusty.trusty-search.plist` when it exists
+# on disk; otherwise globs LaunchAgents for any other `com.trusty.*search*
+# .plist` / `com.bobmatnyc.*search*.plist` so the hint still finds a drifted
+# label, and falls back to the canonical name if nothing is installed yet.
+# Test: `bash -n` syntax check; manually verified against a real
+# ~/Library/LaunchAgents/com.trusty.trusty-search.plist during #2834 triage.
+resolve_search_plist() {
+    local agents_dir="$HOME/Library/LaunchAgents"
+    local canonical="$agents_dir/com.trusty.trusty-search.plist"
+    if [[ -f "$canonical" ]]; then
+        printf '%s' "$canonical"
+        return 0
+    fi
+    local candidate
+    for candidate in "$agents_dir"/com.trusty.*search*.plist "$agents_dir"/com.bobmatnyc.*search*.plist; do
+        [[ -f "$candidate" ]] || continue
+        printf '%s' "$candidate"
+        return 0
+    done
+    printf '%s' "$canonical"
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -194,10 +226,12 @@ main() {
     if [[ "$TRUSTY_CODESIGN_DRY_RUN" != "1" ]]; then
         section "Done — next steps"
         printf '\nRESTART the daemon to pick up the newly signed binary:\n'
+        local plist_path
+        plist_path="$(resolve_search_plist)"
+        # shellcheck disable=SC2016  # literal "$(id -u)" is narration for the reader to run, not expansion here
+        printf '  launchctl bootout  gui/$(id -u) %s\n' "$plist_path"
         # shellcheck disable=SC2016
-        printf '  launchctl bootout  gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist\n'
-        # shellcheck disable=SC2016
-        printf '  launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist\n'
+        printf '  launchctl bootstrap gui/$(id -u) %s\n' "$plist_path"
         printf '\nVerify the daemon loaded all indexes:\n'
         printf '  trusty-search status\n'
         printf '\nOPTIONAL — notarize for distribution to OTHER machines:\n'


### PR DESCRIPTION
## Summary

Three different scripts/docs printed three DIFFERENT launchd plist names for the same two daemons — none of which matched what the daemon actually installs — sending anyone who ran the printed restart commands into failing `launchctl` calls (`Input/output error: 5`).

**Ground truth, verified against source (not the issue reports, which were themselves stale/wrong in one case):**
- trusty-mpm daemon launchd label: `com.trusty.mpm` (`crates/trusty-mpm/src/bin/tm/commands/guided_autostart.rs:38`, `MAIN_DAEMON_PLIST_LABEL`, with a unit test asserting `com.trusty.mpm.plist`).
- trusty-search daemon launchd label: `com.trusty.trusty-search` (`crates/trusty-search/src/commands/service.rs:34`, `LAUNCHD_LABEL` — unchanged since the initial monorepo commit).

## What was wrong, per file

- `scripts/install-trusty-mpm-signed.sh` (#2827): restart hint printed `com.trusty.trusty-mpm.plist` — confusing the codesign `--identifier` (`com.trusty.trusty-mpm`, a *different* namespace) with the actual launchd label (`com.trusty.mpm`). Fixed to the real label.
- `scripts/install-trusty-search-signed.sh` (#2834 defect 2): restart hint already correctly said `com.trusty.trusty-search.plist` — no fix needed here beyond adding detection (see below).
- `crates/trusty-search/README.md:696`: said `com.trusty.search.plist` (stale/wrong — never matched the real label). Fixed to `com.trusty.trusty-search.plist`.
- `crates/trusty-search/Makefile:98-102`: uses a THIRD label, `com.bobmatnyc.trusty-search`, calling it "canonical" and treating `com.trusty.trusty-search` as "legacy" for its local `make deploy` target. Git history shows this has been present since the initial monorepo import with no later reconciliation — it looks like a personal-dev-environment convention that predates (or never synced with) the code's actual `LAUNCHD_LABEL`. Per the task brief I left this alone (changing it would alter local deploy behavior, not just a printed string) — flagging it here as a known discrepancy worth its own ticket if `make deploy`'s behavior needs to match the binary's actual self-registered label.

## Robustness (per #2827's own suggestion)

Both signed-install scripts now detect the actually-installed plist under `~/Library/LaunchAgents/` (`resolve_mpm_plist` / `resolve_search_plist`) instead of only ever printing a hardcoded name: they prefer the canonical file if present, fall back to globbing for a drifted label (excluding the supervisor/GUI plists, which are separate services), and fall back to the canonical name if nothing is installed yet. This means a future label rename can't silently reintroduce this class of bug in the printed hint. No shared lib file exists for these scripts, so the small function is duplicated per the task brief's guidance.

## #2834 note

#2834's OTHER half (silent no-op `tctl sign` stub causing ad-hoc-signed binaries to pass as "Done") was already fixed on `main` before this PR — not touched here, per the task brief.

## Test plan

- [x] `bash -n scripts/install-trusty-mpm-signed.sh` — syntax OK
- [x] `bash -n scripts/install-trusty-search-signed.sh` — syntax OK
- [x] `shellcheck scripts/install-trusty-mpm-signed.sh` — exit 0, no findings
- [x] `shellcheck scripts/install-trusty-search-signed.sh` — exit 0, no findings
- [x] Manually exercised `resolve_mpm_plist` / `resolve_search_plist` against a fake `$HOME/Library/LaunchAgents` covering: nothing installed (falls back to canonical), canonical installed (uses it), only a drifted label installed (finds it), only the supervisor plist installed (correctly skips it and falls back to canonical)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

Closes #2827
Closes #2834
