### PR TITLE
docs(trusty-mpm): long-wait protocol — disarm monitors on goal completion

### DIFF
--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -276,6 +276,14 @@ sizing the wait to its real duration.
   expected wall-clock), run a ONE-SHOT diagnosis — `gh run view <run-id>` (or
   `gh pr checks <pr>` without `--watch`) — to see WHY it's stuck, then resume the
   blocking wait. Do not convert the overrun into faster polling.
+- **Disarm monitors on goal completion.** When your goal completes or becomes
+  moot — a CI run settles, a deployment finishes, a file appears, a condition
+  is satisfied — immediately cancel or disarm any monitors, scheduled wakeups,
+  background polls, or re-issue timers you armed. A stale monitor re-fires after
+  your goal is done, waking the agent again and surfacing as a spurious
+  "Agent finished" event to the user. Disarm first, then report. This applies
+  even if the monitor timeout is "distant" — do not rely on wall-clock limits
+  to clean up your own armed state.
 
 Do not end your turn while an unresolved wait is yours to watch — re-issue the
 blocking wait instead. A quiet foreground block is the goal; a poll-spam stream

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -278,12 +278,13 @@ sizing the wait to its real duration.
   blocking wait. Do not convert the overrun into faster polling.
 - **Disarm monitors on goal completion.** When your goal completes or becomes
   moot — a CI run settles, a deployment finishes, a file appears, a condition
-  is satisfied — immediately cancel or disarm any monitors, scheduled wakeups,
-  background polls, or re-issue timers you armed. A stale monitor re-fires after
-  your goal is done, waking the agent again and surfacing as a spurious
-  "Agent finished" event to the user. Disarm first, then report. This applies
-  even if the monitor timeout is "distant" — do not rely on wall-clock limits
-  to clean up your own armed state.
+  is satisfied — immediately cancel or disarm any `Monitor` tool call, `/loop`,
+  or `/schedule` routine you started (this cleans up legitimate recurring checks
+  — it does not re-authorize a background watcher to wake your own stopped turn).
+  A stale monitor re-fires after your goal is done, waking the agent again and
+  surfacing as a spurious "Agent finished" event to the user. Disarm first, then
+  report. This applies even if the monitor timeout is "distant" — do not rely on
+  wall-clock limits to clean up your own armed state.
 
 Do not end your turn while an unresolved wait is yours to watch — re-issue the
 blocking wait instead. A quiet foreground block is the goal; a poll-spam stream

--- a/crates/trusty-mpm/src/assets/agents/local-ops.md
+++ b/crates/trusty-mpm/src/assets/agents/local-ops.md
@@ -114,6 +114,9 @@ cargo build --release -p <crate>         # long build: run it, wait for exit
   (#2833). Prefer the blocking form (`--watch`, or the build itself); if you must
   sleep-poll, size the sleep to the real wall-clock (minutes) and print only when
   the observed state changes.
+- **When your wait goal completes** (build finishes, publish succeeds, CI goes
+  green), immediately disarm any monitors, polls, or re-issue timers you armed.
+  Stale monitors re-fire after your goal is done, spuriously waking the agent.
 
 ## GitHub Account Management
 

--- a/crates/trusty-mpm/src/assets/agents/version-control.md
+++ b/crates/trusty-mpm/src/assets/agents/version-control.md
@@ -63,7 +63,7 @@ gh pr checks <pr> --watch --fail-fast    # blocks until checks settle; run it an
   ever must sleep-poll, size the sleep to the CI wall-clock (minutes, not
   seconds) and only print when a check's state actually changes.
 - **When checks settle**, immediately disarm any monitors or re-issue timers you
-  armed — do not let stale checks re-fire after your goal is done.
+  armed — do not let stale monitors re-fire after your goal is done.
 
 ## Memory Management for Git Operations
 

--- a/crates/trusty-mpm/src/assets/agents/version-control.md
+++ b/crates/trusty-mpm/src/assets/agents/version-control.md
@@ -62,6 +62,8 @@ gh pr checks <pr> --watch --fail-fast    # blocks until checks settle; run it an
   wrong (#2833). `--watch` blocks silently and prints once; keep using it. If you
   ever must sleep-poll, size the sleep to the CI wall-clock (minutes, not
   seconds) and only print when a check's state actually changes.
+- **When checks settle**, immediately disarm any monitors or re-issue timers you
+  armed — do not let stale checks re-fire after your goal is done.
 
 ## Memory Management for Git Operations
 


### PR DESCRIPTION
## Summary

Add normative guidance to the long-wait protocol: when your goal completes or becomes moot, disarm any monitors, scheduled wakeups, or pending re-polls you armed. Stale monitors re-fire after the goal is done, causing spurious "Agent finished" events.

## Changes

- **BASE-AGENT.md**: Added "Disarm monitors on goal completion" bullet to the chunked-repoll pattern section, detailing the issue and the solution.
- **version-control.md**: Added one-line disarm guidance to the CI Waits section.
- **local-ops.md**: Added one-line disarm guidance to the Long Waits section.

All asset markdown files included via `include_str!` compile without error.

## Test plan

- [x] `cargo check -p trusty-mpm` passes
- [x] Files compile into binary assets

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools