### PR TITLE
fix(trusty-installer): add --dry-run and non-TTY confirmation guard to tctl install

### DIFF
--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -12,6 +12,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `trusty-mpm-gui` joined the `trusty-mpm` signable set in `SIGNABLE_BINARIES` (`com.trusty.trusty-mpm.gui`), so `tctl sign trusty-mpm` and the automatic `tctl install` post-install hook also sign the GUI binary (if present under the install dir) with the stable Developer ID identity — fallback coverage for a bare `cargo install --path crates/trusty-mpm-gui`, alongside the GUI's own `bundle.macOS.signingIdentity` fix (closes #2951).
 - `tctl sign --verbose` (via the existing global `-v`/`--verbose` flag): prints the raw `security find-identity` probe output and which identity was selected, to help diagnose "no identity found" failures (closes #2939).
+- `tctl install --dry-run` previews the blast radius (members, binaries, planned launchd service actions) and exits 0 without installing anything — identical behaviour in TTY, non-TTY, and `--json` contexts (closes #2112).
+
+### Changed
+
+- **BREAKING for automation:** `tctl install` now REFUSES to run (exit 3) when stdin is not a TTY and neither `--yes` nor `--dry-run` was passed, instead of silently proceeding with a real install. Previously the blast-radius confirmation prompt was skipped entirely in non-TTY contexts (piped/scripted/agent-driven invocations), so an exploratory `tctl install` could reactivate real launchd services with no confirmation (#2112). Scripts and CI that relied on the old silent-proceed path must add `--yes`.
 
 ### Fixed
 

--- a/crates/trusty-installer/src/cli.rs
+++ b/crates/trusty-installer/src/cli.rs
@@ -217,6 +217,10 @@ pub enum Commands {
         /// Preview what would be installed (members, binaries, planned service
         /// actions) without installing anything (#2112). Exits 0. Safe to run
         /// in any context — TTY, non-TTY, or `--json` — and never prompts.
+        /// Always bypasses the interactive component picker for determinism:
+        /// with no members named, previews the FULL stable set (not a
+        /// TTY-driven subset) — same as omitting `--dry-run` in a non-TTY
+        /// context.
         #[arg(long)]
         dry_run: bool,
     },

--- a/crates/trusty-installer/src/cli.rs
+++ b/crates/trusty-installer/src/cli.rs
@@ -213,6 +213,12 @@ pub enum Commands {
         /// bootstrap (#2556). Also settable via `TCTL_NO_SERVICE_BOOTSTRAP`.
         #[arg(long)]
         no_service: bool,
+
+        /// Preview what would be installed (members, binaries, planned service
+        /// actions) without installing anything (#2112). Exits 0. Safe to run
+        /// in any context — TTY, non-TTY, or `--json` — and never prompts.
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Upgrade the stack (or named members) to the BOM-pinned versions, then restart. (DOC-9)

--- a/crates/trusty-installer/src/cli_tests.rs
+++ b/crates/trusty-installer/src/cli_tests.rs
@@ -236,6 +236,18 @@ fn parse_install_no_service() {
     }
 }
 
+/// Parse `trusty-installer install --dry-run` (#2112 preview flag).
+#[test]
+fn parse_install_dry_run() {
+    let cli = Cli::try_parse_from(["trusty-installer", "install", "--dry-run"])
+        .expect("install --dry-run parses");
+    if let Commands::Install { dry_run, .. } = &cli.command {
+        assert!(*dry_run, "--dry-run must set the flag");
+    } else {
+        panic!("expected Install");
+    }
+}
+
 /// Parse `trusty-installer ensure`.
 #[test]
 fn parse_ensure() {

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -17,14 +17,24 @@
 //! `trusty-progress`. Honours `--yes` (non-interactive) and `--json` (machine
 //! output). Returns a process exit code: 0 all installed, 2 one or more failed.
 //!
-//! Test: `tests` covers the JSON envelope shaping (`build_report`) and the
-//! unknown-member handling; the network / `cargo install` path is side-effecting
-//! and validated manually.
+//! `--dry-run` (#2112) previews the same blast-radius summary the confirmation
+//! prompt shows — members, binaries, and planned service actions — and exits 0
+//! without installing anything; it behaves identically in TTY, non-TTY, and
+//! `--json` contexts. When `--dry-run` is not passed and confirmation cannot be
+//! obtained (non-TTY, no `--yes`), `run` refuses to install (see
+//! [`super::install_gate::decide_install_gate`]) rather than silently
+//! proceeding — the exact gap #2112 reported.
+//!
+//! Test: `tests` covers the JSON envelope shaping (`build_report`), the
+//! unknown-member handling, and the dry-run report shaping; the network /
+//! `cargo install` path and the confirmation gate's TTY plumbing are
+//! side-effecting / covered by `super::install_gate::tests`.
 
 use serde::Serialize;
 use trusty_progress::{Component, ComponentTracker};
 
 use super::dependency_graph::describe_added;
+use super::install_gate::{decide_install_gate, GateInputs, InstallGate};
 use super::progress_ui::{narrator, prompt_yes_no};
 use super::runtime::block_on;
 use super::service_bootstrap::{
@@ -133,31 +143,137 @@ impl InstallReport {
     }
 }
 
+/// One member's planned (not-yet-applied) install action for `--dry-run`.
+///
+/// Why: `--dry-run` (#2112) must show the operator the exact blast radius —
+/// what `tctl install` would do — without doing it; a typed row keeps that
+/// preview consistent with the real [`InstallOutcome`] shape it stands in for.
+/// What: `member` / `binary` mirror [`StableMember`]; `service_bootstrap` is
+/// `true` when a launchd `service install` would be attempted for this member
+/// (service bootstrap enabled AND the member is [`ManageStrategy::Launchd`]).
+/// Test: `tests::dry_run_report_shape`.
+#[derive(Clone, Debug, Serialize)]
+pub struct DryRunMember {
+    /// Crate name that would be installed.
+    pub member: String,
+    /// Binary name that would land on PATH.
+    pub binary: String,
+    /// Whether a post-install launchd service bootstrap would be attempted.
+    pub service_bootstrap: bool,
+}
+
+/// The `--dry-run` preview report (#2112).
+///
+/// Why: Mirrors [`InstallReport`]'s shape (`command`, per-member rows) so
+/// `--json` consumers get a familiar, stable envelope, with `dry_run: true`
+/// as the discriminator instead of an `all_ok` verdict (nothing was applied).
+/// What: `members` lists every member that WOULD be installed, in install
+/// order; `service_bootstrap_enabled` is the resolved `--no-service` /
+/// `TCTL_NO_SERVICE_BOOTSTRAP` state applied to the preview.
+/// Test: `tests::dry_run_report_shape`.
+#[derive(Clone, Debug, Serialize)]
+pub struct DryRunReport {
+    /// Fixed command tag for JSON consumers.
+    pub command: &'static str,
+    /// Always `true` — discriminates this envelope from [`InstallReport`].
+    pub dry_run: bool,
+    /// Members that would be installed, in install order.
+    pub members: Vec<DryRunMember>,
+    /// Whether the post-install service bootstrap step is enabled.
+    pub service_bootstrap_enabled: bool,
+}
+
+/// Build the `--dry-run` preview report from the resolved member set.
+///
+/// Why: Extracted so the report's shaping is unit-testable without stdout.
+/// What: Maps each [`StableMember`] to a [`DryRunMember`], computing
+/// `service_bootstrap` the same way `install_all` decides whether to bootstrap
+/// (`service_enabled && m.manage == ManageStrategy::Launchd`).
+/// Test: `tests::dry_run_report_shape`.
+fn build_dry_run_report(selected: &[StableMember], service_enabled: bool) -> DryRunReport {
+    let members = selected
+        .iter()
+        .map(|m| DryRunMember {
+            member: m.crate_name.clone(),
+            binary: m.binary.clone(),
+            service_bootstrap: service_enabled && m.manage == ManageStrategy::Launchd,
+        })
+        .collect();
+    DryRunReport {
+        command: "install",
+        dry_run: true,
+        members,
+        service_bootstrap_enabled: service_enabled,
+    }
+}
+
+/// Print the `--dry-run` preview and return the process exit code (always 0).
+///
+/// Why: A dry run never fails on its own account — it only reports what WOULD
+/// happen; a resolution error (unknown member) is caught earlier in `run`.
+/// What: `--json` emits [`DryRunReport`] via `render_json`; otherwise prints a
+/// human blast-radius summary matching the wording the confirmation prompt
+/// used, one line per member noting whether it would bootstrap a service.
+/// Test: Side-effect-only (stdout); the data it prints is covered by
+/// `tests::dry_run_report_shape`.
+fn print_dry_run(selected: &[StableMember], service_enabled: bool, json: bool) -> i32 {
+    let report = build_dry_run_report(selected, service_enabled);
+    if json {
+        if render_json(&report).is_err() {
+            eprintln!("tctl install: failed to write JSON output");
+            return 1;
+        }
+        return 0;
+    }
+    let names: Vec<&str> = report.members.iter().map(|m| m.member.as_str()).collect();
+    eprintln!(
+        "tctl install: DRY RUN — would install {} tool(s): {}",
+        report.members.len(),
+        names.join(", ")
+    );
+    for m in &report.members {
+        let svc = if m.service_bootstrap {
+            "would bootstrap launchd service"
+        } else {
+            "no service bootstrap"
+        };
+        eprintln!("tctl install:   {} -> {} ({svc})", m.member, m.binary);
+    }
+    eprintln!("tctl install: dry run complete — no changes made.");
+    0
+}
+
 /// Handle `tctl install [<members>…]`.
 ///
 /// Why: Phase-1 entry point for the system install flow (#1316 priority 1).
 ///
 /// What: Resolves `members` against the stable set (empty = all). When no
-/// members are given AND stdin is a TTY AND `--json` is not set, presents the
-/// Phase-4 interactive component picker so the operator can choose a subset
-/// without needing to know crate names. On a TTY without `--yes`, confirms the
-/// blast radius before installing. Installs each member in topological order,
-/// rendering progress rows; emits either the human component table + summary or
-/// the `--json` [`InstallReport`]. Returns the process exit code.
+/// members are given AND stdin is a TTY AND `--json` is not set AND not
+/// `--dry-run`, presents the Phase-4 interactive component picker so the
+/// operator can choose a subset without needing to know crate names.
+/// `--dry-run` (#2112) then prints the blast-radius preview and returns 0
+/// without installing. Otherwise, the pre-install confirmation gate
+/// ([`super::install_gate::decide_install_gate`]) either proceeds (`--yes`),
+/// prompts (TTY available), or REFUSES to install (non-TTY, no `--yes` — the
+/// #2112 default-safe fix: previously this silently proceeded). Installs each
+/// member in topological order, rendering progress rows; emits either the
+/// human component table + summary or the `--json` [`InstallReport`]. Returns
+/// the process exit code.
 ///
 /// `no_service` (the `--no-service` flag) — together with the [`NO_SERVICE_ENV`]
 /// environment opt-out — suppresses the Phase-7b launchd service bootstrap
 /// (#2556) so operators who manage launchd themselves, or CI, install binaries
 /// only.
 ///
-/// Test: `tests::run_unknown_member_is_error`; the install path itself is
+/// Test: `tests::run_unknown_member_is_error`, `tests::run_dry_run_exits_zero`,
+/// `tests::run_non_tty_no_yes_refuses`; the install path itself is
 /// side-effecting (`cargo install`) and validated manually.
-pub fn run(members: &[String], yes: bool, json: bool, no_service: bool) -> i32 {
+pub fn run(members: &[String], yes: bool, json: bool, no_service: bool, dry_run: bool) -> i32 {
     // Phase 4: interactive component picker.
-    // Only activates when: no explicit members, stdin is a TTY, and not --json.
-    // When members are passed, or in --json / non-TTY mode, behaviour is unchanged.
+    // Only activates when: no explicit members, stdin is a TTY, not --json,
+    // and not --dry-run (a preview must behave identically regardless of TTY).
     let members_override: Vec<String>;
-    let members = if members.is_empty() && !json && super::progress_ui::is_tty() {
+    let members = if members.is_empty() && !json && !dry_run && super::progress_ui::is_tty() {
         let all = super::stable_set::stable_set();
         match super::picker::prompt_picker(&all) {
             Ok(chosen) => {
@@ -208,6 +324,19 @@ pub fn run(members: &[String], yes: bool, json: bool, no_service: bool) -> i32 {
         }
     }
 
+    // #2556: whether to bootstrap each daemon member's launchd plist after it
+    // installs. Disabled by the `--no-service` flag or the env opt-out.
+    // Resolved early (pure, no side effects) so the dry-run preview below can
+    // report the same planned service actions the real install would take.
+    let service_enabled = bootstrap_enabled(no_service, std::env::var_os(NO_SERVICE_ENV).is_some());
+
+    // #2112: `--dry-run` previews the blast radius and exits — before any
+    // prerequisite detection, prompting, or install side effect. Behaves
+    // identically in TTY, non-TTY, and `--json` contexts.
+    if dry_run {
+        return print_dry_run(&selected, service_enabled, json);
+    }
+
     // Phase 6: detect and optionally install external prerequisites.
     // Prints ✓ lines for found tools and offers interactive install for missing ones.
     {
@@ -241,19 +370,40 @@ pub fn run(members: &[String], yes: bool, json: bool, no_service: bool) -> i32 {
         }
     }
 
-    // Confirm the blast radius unless --yes or non-interactive (#1316 default-safe).
-    if !yes && super::progress_ui::is_tty() && !json {
-        let names: Vec<&str> = selected.iter().map(|m| m.crate_name.as_str()).collect();
-        let q = format!("Install {} tool(s): {}? ", selected.len(), names.join(", "));
-        if !prompt_yes_no(&q) {
-            eprintln!("tctl install: aborted (no confirmation).");
+    // Confirm the blast radius (#1316 default-safe, hardened by #2112): probe
+    // the TTY exactly once and route through the pure gate so the decision is
+    // auditable and cannot silently proceed when consent is unobtainable.
+    let tty = super::progress_ui::is_tty();
+    match decide_install_gate(GateInputs { yes, is_tty: tty }) {
+        InstallGate::Proceed => {}
+        InstallGate::Refuse => {
+            let msg = "refusing to install without confirmation in a non-interactive \
+                       context; pass --yes to proceed non-interactively, or --dry-run \
+                       to preview what would be installed.";
+            if json {
+                if render_json(&serde_json::json!({"command": "install", "error": msg})).is_err() {
+                    eprintln!("tctl install: failed to write JSON output");
+                    return 1;
+                }
+            } else {
+                eprintln!("tctl install: {msg}");
+            }
             return 3;
         }
+        InstallGate::NeedsPrompt => {
+            // `--json` mode never prompts (a human y/n prompt has no place in a
+            // machine-readable stream); preserves the pre-#2112 behaviour for
+            // the TTY + --json combination, which is unaffected by this fix.
+            if !json {
+                let names: Vec<&str> = selected.iter().map(|m| m.crate_name.as_str()).collect();
+                let q = format!("Install {} tool(s): {}? ", selected.len(), names.join(", "));
+                if !prompt_yes_no(&q) {
+                    eprintln!("tctl install: aborted (no confirmation).");
+                    return 3;
+                }
+            }
+        }
     }
-
-    // #2556: whether to bootstrap each daemon member's launchd plist after it
-    // installs. Disabled by the `--no-service` flag or the env opt-out.
-    let service_enabled = bootstrap_enabled(no_service, std::env::var_os(NO_SERVICE_ENV).is_some());
 
     let report = block_on(install_all(&selected, json, service_enabled));
     if json {
@@ -632,7 +782,82 @@ mod tests {
     /// Test: This is the test.
     #[test]
     fn run_unknown_member_is_error() {
-        let code = run(&["not-a-real-tool".to_owned()], true, true, false);
+        let code = run(&["not-a-real-tool".to_owned()], true, true, false, false);
         assert_eq!(code, 3);
+    }
+
+    /// Why: #2112 — `--dry-run` must preview and exit 0 WITHOUT installing,
+    /// regardless of `--yes`. A `--json` invocation keeps the test hermetic
+    /// (no interactive picker, no TTY-dependent branch).
+    /// What: Calls `run` with `dry_run: true`, `yes: false`; asserts exit 0.
+    /// Test: This is the test.
+    #[test]
+    fn run_dry_run_exits_zero() {
+        let code = run(&["tga".to_owned()], false, true, false, true);
+        assert_eq!(code, 0);
+    }
+
+    /// Why: #2112's exact regression — a non-interactive `run()` invocation
+    /// (no `--yes`, no `--dry-run`) must REFUSE rather than silently install.
+    /// The test harness's stdin is not a TTY (matches every CI / piped /
+    /// agent-driven invocation #2112 was reported from), so this exercises the
+    /// real `run()` path end-to-end, not just the pure `install_gate` gate.
+    /// `--json` keeps output machine-parseable; "tga" is the cheapest real
+    /// member (non-daemon, single "git" prereq check, no network).
+    /// What: Calls `run` with a real member, `yes: false`, `dry_run: false`;
+    /// asserts exit code 3 (refuse).
+    /// Test: This is the test.
+    #[test]
+    fn run_non_tty_no_yes_refuses() {
+        let code = run(&["tga".to_owned()], false, true, false, false);
+        assert_eq!(code, 3);
+    }
+
+    /// Why: The `--dry-run` JSON envelope is a public contract; pin its shape
+    /// and the `service_bootstrap` derivation (enabled AND launchd-managed).
+    /// What: Builds a report over a launchd daemon + a non-daemon with service
+    /// bootstrap enabled; asserts per-member `service_bootstrap` values.
+    /// Test: This is the test.
+    #[test]
+    fn dry_run_report_shape() {
+        let members = vec![
+            stable_member_for_test("trusty-search", "trusty-search", ManageStrategy::Launchd),
+            stable_member_for_test("tga", "tga", ManageStrategy::None),
+        ];
+        let report = build_dry_run_report(&members, true);
+        assert_eq!(report.command, "install");
+        assert!(report.dry_run);
+        assert!(report.service_bootstrap_enabled);
+        assert_eq!(report.members.len(), 2);
+        assert!(
+            report.members[0].service_bootstrap,
+            "launchd member should plan a service bootstrap"
+        );
+        assert!(
+            !report.members[1].service_bootstrap,
+            "non-daemon member must not plan a service bootstrap"
+        );
+
+        let disabled = build_dry_run_report(&members, false);
+        assert!(
+            !disabled.members[0].service_bootstrap,
+            "disabled service bootstrap must suppress every member"
+        );
+    }
+
+    /// Test-only `StableMember` builder — its fields are public for reads but
+    /// `stable_set` only constructs instances via its own invariant-deriving
+    /// constructor; this builds one directly for the dry-run shaping test.
+    fn stable_member_for_test(
+        crate_name: &str,
+        binary: &str,
+        manage: ManageStrategy,
+    ) -> StableMember {
+        StableMember {
+            crate_name: crate_name.to_owned(),
+            binary: binary.to_owned(),
+            daemon: manage == ManageStrategy::Launchd,
+            manage,
+        }
     }
 }

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -20,10 +20,12 @@
 //! `--dry-run` (#2112) previews the same blast-radius summary the confirmation
 //! prompt shows — members, binaries, and planned service actions — and exits 0
 //! without installing anything; it behaves identically in TTY, non-TTY, and
-//! `--json` contexts. When `--dry-run` is not passed and confirmation cannot be
-//! obtained (non-TTY, no `--yes`), `run` refuses to install (see
-//! [`super::install_gate::decide_install_gate`]) rather than silently
-//! proceeding — the exact gap #2112 reported.
+//! `--json` contexts. It always bypasses the interactive component picker for
+//! determinism — a no-members `--dry-run` previews the FULL stable set, never
+//! a TTY-driven subset (see `run`'s doc). When `--dry-run` is not passed and
+//! confirmation cannot be obtained (non-TTY, no `--yes`), `run` refuses to
+//! install (see [`super::install_gate::decide_install_gate`]) rather than
+//! silently proceeding — the exact gap #2112 reported.
 //!
 //! Test: `tests` covers the JSON envelope shaping (`build_report`), the
 //! unknown-member handling, and the dry-run report shaping; the network /
@@ -183,12 +185,28 @@ pub struct DryRunReport {
     pub service_bootstrap_enabled: bool,
 }
 
+/// Whether an install (real or previewed) would attempt a launchd service
+/// bootstrap for `m`.
+///
+/// Why: The `--dry-run` preview (`build_dry_run_report`) and the real install
+/// loop (`install_all`) must never drift on this decision — a preview that
+/// disagrees with reality is worse than no preview at all. A single shared
+/// predicate is the only way to guarantee that.
+/// What: `true` when the post-install service-bootstrap step is enabled AND
+/// `m` is a [`ManageStrategy::Launchd`]-managed member.
+/// Test: `tests::dry_run_report_shape` (via `build_dry_run_report`);
+/// `install_all`'s use is exercised indirectly by the (side-effecting) install
+/// path.
+fn plans_service_bootstrap(m: &StableMember, service_enabled: bool) -> bool {
+    service_enabled && m.manage == ManageStrategy::Launchd
+}
+
 /// Build the `--dry-run` preview report from the resolved member set.
 ///
 /// Why: Extracted so the report's shaping is unit-testable without stdout.
 /// What: Maps each [`StableMember`] to a [`DryRunMember`], computing
-/// `service_bootstrap` the same way `install_all` decides whether to bootstrap
-/// (`service_enabled && m.manage == ManageStrategy::Launchd`).
+/// `service_bootstrap` via the shared [`plans_service_bootstrap`] predicate so
+/// the preview can never drift from what `install_all` actually does.
 /// Test: `tests::dry_run_report_shape`.
 fn build_dry_run_report(selected: &[StableMember], service_enabled: bool) -> DryRunReport {
     let members = selected
@@ -196,7 +214,7 @@ fn build_dry_run_report(selected: &[StableMember], service_enabled: bool) -> Dry
         .map(|m| DryRunMember {
             member: m.crate_name.clone(),
             binary: m.binary.clone(),
-            service_bootstrap: service_enabled && m.manage == ManageStrategy::Launchd,
+            service_bootstrap: plans_service_bootstrap(m, service_enabled),
         })
         .collect();
     DryRunReport {
@@ -207,13 +225,15 @@ fn build_dry_run_report(selected: &[StableMember], service_enabled: bool) -> Dry
     }
 }
 
-/// Print the `--dry-run` preview and return the process exit code (always 0).
+/// Print the `--dry-run` preview and return the process exit code.
 ///
 /// Why: A dry run never fails on its own account — it only reports what WOULD
 /// happen; a resolution error (unknown member) is caught earlier in `run`.
 /// What: `--json` emits [`DryRunReport`] via `render_json`; otherwise prints a
 /// human blast-radius summary matching the wording the confirmation prompt
 /// used, one line per member noting whether it would bootstrap a service.
+/// Returns `0` unless the `--json` write itself fails, in which case `1`
+/// (mirrors the real install path's failed-JSON-write handling below).
 /// Test: Side-effect-only (stdout); the data it prints is covered by
 /// `tests::dry_run_report_shape`.
 fn print_dry_run(selected: &[StableMember], service_enabled: bool, json: bool) -> i32 {
@@ -251,8 +271,11 @@ fn print_dry_run(selected: &[StableMember], service_enabled: bool, json: bool) -
 /// members are given AND stdin is a TTY AND `--json` is not set AND not
 /// `--dry-run`, presents the Phase-4 interactive component picker so the
 /// operator can choose a subset without needing to know crate names.
-/// `--dry-run` (#2112) then prints the blast-radius preview and returns 0
-/// without installing. Otherwise, the pre-install confirmation gate
+/// `--dry-run` (#2112) ALWAYS skips the picker — even on a TTY with no
+/// members named — so a no-members preview deterministically covers the FULL
+/// stable set rather than a TTY-driven subset; it then prints the
+/// blast-radius preview and returns 0 without installing. Otherwise, the
+/// pre-install confirmation gate
 /// ([`super::install_gate::decide_install_gate`]) either proceeds (`--yes`),
 /// prompts (TTY available), or REFUSES to install (non-TTY, no `--yes` — the
 /// #2112 default-safe fix: previously this silently proceeded). Installs each
@@ -266,8 +289,11 @@ fn print_dry_run(selected: &[StableMember], service_enabled: bool, json: bool) -
 /// only.
 ///
 /// Test: `tests::run_unknown_member_is_error`, `tests::run_dry_run_exits_zero`,
-/// `tests::run_non_tty_no_yes_refuses`; the install path itself is
-/// side-effecting (`cargo install`) and validated manually.
+/// `tests::dry_run_full_set_when_no_members_named`. The non-TTY refusal gate
+/// itself is TTY-independent and exhaustively covered by
+/// `super::install_gate::tests` (see that module's doc for why a `run()`-level
+/// refusal test is unsound — it would block forever on a real terminal). The
+/// install path is side-effecting (`cargo install`) and validated manually.
 pub fn run(members: &[String], yes: bool, json: bool, no_service: bool, dry_run: bool) -> i32 {
     // Phase 4: interactive component picker.
     // Only activates when: no explicit members, stdin is a TTY, not --json,
@@ -497,22 +523,21 @@ async fn install_all(
                 // folds into `service_ok` / `all_ok` / the exit code (#2566
                 // review — `--json` previously reported `all_ok: true` even
                 // when every daemon's service bootstrap had failed).
-                let (service_ok, service_detail) =
-                    if service_enabled && m.manage == ManageStrategy::Launchd {
-                        let action = bootstrap_member_service(&m.binary);
-                        let note = action.note(&m.binary);
-                        match &action {
-                            BootstrapAction::Failed(_) => {
-                                let _ = narr.error(&note);
-                            }
-                            BootstrapAction::Skipped(_) | BootstrapAction::Installed => {
-                                let _ = narr.info(&note);
-                            }
+                let (service_ok, service_detail) = if plans_service_bootstrap(m, service_enabled) {
+                    let action = bootstrap_member_service(&m.binary);
+                    let note = action.note(&m.binary);
+                    match &action {
+                        BootstrapAction::Failed(_) => {
+                            let _ = narr.error(&note);
                         }
-                        (!matches!(action, BootstrapAction::Failed(_)), note)
-                    } else {
-                        InstallOutcome::service_not_attempted()
-                    };
+                        BootstrapAction::Skipped(_) | BootstrapAction::Installed => {
+                            let _ = narr.info(&note);
+                        }
+                    }
+                    (!matches!(action, BootstrapAction::Failed(_)), note)
+                } else {
+                    InstallOutcome::service_not_attempted()
+                };
                 outcomes.push(InstallOutcome {
                     member: m.crate_name.clone(),
                     ok: true,
@@ -797,21 +822,17 @@ mod tests {
         assert_eq!(code, 0);
     }
 
-    /// Why: #2112's exact regression — a non-interactive `run()` invocation
-    /// (no `--yes`, no `--dry-run`) must REFUSE rather than silently install.
-    /// The test harness's stdin is not a TTY (matches every CI / piped /
-    /// agent-driven invocation #2112 was reported from), so this exercises the
-    /// real `run()` path end-to-end, not just the pure `install_gate` gate.
-    /// `--json` keeps output machine-parseable; "tga" is the cheapest real
-    /// member (non-daemon, single "git" prereq check, no network).
-    /// What: Calls `run` with a real member, `yes: false`, `dry_run: false`;
-    /// asserts exit code 3 (refuse).
-    /// Test: This is the test.
-    #[test]
-    fn run_non_tty_no_yes_refuses() {
-        let code = run(&["tga".to_owned()], false, true, false, false);
-        assert_eq!(code, 3);
-    }
+    // #2112 review (HIGH): a `run_non_tty_no_yes_refuses` test previously
+    // called the real `run()` relying on the test harness's ambient stdin not
+    // being a TTY. That is unsound: on a developer's interactive terminal
+    // `is_tty()` returns true → `InstallGate::NeedsPrompt` → `prompt_yes_no`
+    // blocks forever on `stdin().read_line()`, hanging the test suite. The
+    // #2112 regression this was meant to guard — non-TTY + no `--yes` must
+    // REFUSE — is already exhaustively covered, TTY-independent, by
+    // `super::install_gate::tests::decide_non_tty_refuses` (mirrors the
+    // established `upgrade.rs`/`update_engine.rs` split: `resolve_and_apply`
+    // is side-effecting and validated manually, `decide_apply` is the unit-
+    // tested pure gate). No `run()`-level replacement is added here.
 
     /// Why: The `--dry-run` JSON envelope is a public contract; pin its shape
     /// and the `service_bootstrap` derivation (enabled AND launchd-managed).
@@ -842,6 +863,36 @@ mod tests {
         assert!(
             !disabled.members[0].service_bootstrap,
             "disabled service bootstrap must suppress every member"
+        );
+    }
+
+    /// Why: #2112 review (MEDIUM) — `--dry-run` always bypasses the
+    /// interactive picker (`run`'s picker gate requires `!dry_run`), so a
+    /// no-members `--dry-run` must preview the FULL stable set, not whatever
+    /// subset a TTY-driven picker might otherwise offer. `run()`'s exit code
+    /// can't be inspected for the resolved set without capturing stdout, so
+    /// this pins the composition `run()` itself uses:
+    /// `select_members_transitive(&[])` (what an empty `members` slice
+    /// resolves to) fed into `build_dry_run_report`.
+    /// What: Resolving `&[]` yields every [`stable_set`] member, in order,
+    /// and the dry-run report carries them all.
+    /// Test: This is the test.
+    #[test]
+    fn dry_run_full_set_when_no_members_named() {
+        let resolved = select_members_transitive(&[]);
+        let all = super::super::stable_set::stable_set();
+        assert_eq!(
+            resolved.members.len(),
+            all.len(),
+            "empty members must resolve to the full stable set"
+        );
+
+        let report = build_dry_run_report(&resolved.members, true);
+        let names: Vec<&str> = report.members.iter().map(|m| m.member.as_str()).collect();
+        let expected: Vec<&str> = all.iter().map(|m| m.crate_name.as_str()).collect();
+        assert_eq!(
+            names, expected,
+            "dry-run preview must list every stable-set member, in order, when none are named"
         );
     }
 

--- a/crates/trusty-installer/src/commands/install_gate.rs
+++ b/crates/trusty-installer/src/commands/install_gate.rs
@@ -1,0 +1,134 @@
+//! Pre-install confirmation gate — the #2112 default-safe posture for `tctl install`.
+//!
+//! Why: #2112 — during the 2026-07-06 deploy, `tctl install trusty-mpm` was run
+//! from a non-interactive (non-TTY) context expecting it to no-op/abort without
+//! an explicit `--yes`. Instead it silently proceeded and reactivated a dormant
+//! launchd service. The pre-existing confirmation prompt was gated on
+//! `is_tty()`, so any piped, scripted, or agent-driven invocation skipped
+//! confirmation entirely and installed for real. This mirrors the #1316 safety
+//! property already enforced for `tctl upgrade` via
+//! [`super::update_engine::decide_apply`]: encoding the decision as one pure,
+//! exhaustively-testable function makes the gate auditable independent of any
+//! terminal or process side effect.
+//!
+//! What: [`decide_install_gate`] takes whether `--yes` was passed and whether
+//! stdin/stdout is a TTY, and returns an [`InstallGate`] verdict: `Proceed`
+//! (yes was given — install without prompting), `NeedsPrompt` (a TTY is
+//! available — the caller shows the interactive blast-radius prompt), or
+//! `Refuse` (non-TTY and no `--yes` — cannot obtain consent, so `tctl install`
+//! must hard-fail rather than silently install). `--dry-run` short-circuits
+//! before this gate is ever consulted (see `install::run`) since a preview
+//! never needs consent.
+//!
+//! Test: `tests::decide_yes_proceeds`, `tests::decide_tty_needs_prompt`,
+//! `tests::decide_non_tty_refuses`.
+
+/// Inputs to the pure pre-install confirmation gate.
+///
+/// Why: A single-argument-struct keeps [`decide_install_gate`] trivial to call
+/// and exhaustively test across the 2×2 decision matrix.
+/// What: `yes` — the global `--yes`/`-y` flag; `is_tty` — whether stdin is an
+/// interactive terminal we could prompt on.
+/// Test: `tests::decide_*` construct these inline.
+#[derive(Clone, Copy, Debug)]
+pub struct GateInputs {
+    /// The `--yes` flag (explicit non-interactive consent).
+    pub yes: bool,
+    /// Whether stdin is an interactive terminal we can prompt on.
+    pub is_tty: bool,
+}
+
+/// The verdict of the pre-install confirmation gate.
+///
+/// Why: Separates the *decision* from prompting/printing so `install::run` can
+/// be tested without a real terminal.
+/// What: `Proceed` — install without prompting (explicit `--yes`); `NeedsPrompt`
+/// — a TTY is available, show the interactive blast-radius confirmation;
+/// `Refuse` — no TTY and no `--yes`; consent cannot be obtained, so the install
+/// must hard-fail (#2112's core fix) rather than silently proceed.
+/// Test: `tests::decide_*`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InstallGate {
+    /// Explicit consent already given — install without prompting.
+    Proceed,
+    /// A TTY is available — the caller must show the interactive prompt.
+    NeedsPrompt,
+    /// No TTY and no `--yes` — refuse to install (cannot obtain consent).
+    Refuse,
+}
+
+/// The pure pre-install confirmation gate (#2112 default-safe posture).
+///
+/// Why: THE safety property #2112 asks for: `tctl install` must never mutate
+/// the system (real binaries, launchd services) without either explicit
+/// consent (`--yes`) or an interactive confirmation the operator can actually
+/// see and answer (a TTY). Encoding the rule as one pure function makes it
+/// auditable and exhaustively testable, decoupled from the terminal.
+///
+/// What:
+/// 1. `--yes` → [`InstallGate::Proceed`] (explicit non-interactive consent).
+/// 2. Not `--yes`, on a TTY → [`InstallGate::NeedsPrompt`] (caller prompts).
+/// 3. Not `--yes`, not a TTY → [`InstallGate::Refuse`] (consent impossible;
+///    the caller must hard-fail with a message pointing at `--yes`/`--dry-run`
+///    rather than silently installing — this is the exact gap #2112 reported).
+///
+/// Test: `tests::decide_yes_proceeds`, `tests::decide_tty_needs_prompt`,
+/// `tests::decide_non_tty_refuses`.
+pub fn decide_install_gate(inputs: GateInputs) -> InstallGate {
+    if inputs.yes {
+        InstallGate::Proceed
+    } else if inputs.is_tty {
+        InstallGate::NeedsPrompt
+    } else {
+        InstallGate::Refuse
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: `--yes` must always short-circuit to `Proceed`, TTY or not — it is
+    /// the documented automation escape hatch (DOC-5 §3.3 / §4.3).
+    /// What: Both TTY states with `yes: true` yield `Proceed`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_yes_proceeds() {
+        for is_tty in [true, false] {
+            assert_eq!(
+                decide_install_gate(GateInputs { yes: true, is_tty }),
+                InstallGate::Proceed
+            );
+        }
+    }
+
+    /// Why: On a TTY without `--yes`, the operator can see and answer a
+    /// prompt — the gate must hand control back to the caller, not refuse.
+    /// What: `yes: false, is_tty: true` yields `NeedsPrompt`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_tty_needs_prompt() {
+        assert_eq!(
+            decide_install_gate(GateInputs {
+                yes: false,
+                is_tty: true
+            }),
+            InstallGate::NeedsPrompt
+        );
+    }
+
+    /// Why: THIS is the #2112 regression case — a piped/scripted/agent-driven
+    /// invocation (non-TTY) with no `--yes` must never silently install.
+    /// What: `yes: false, is_tty: false` yields `Refuse`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_non_tty_refuses() {
+        assert_eq!(
+            decide_install_gate(GateInputs {
+                yes: false,
+                is_tty: false
+            }),
+            InstallGate::Refuse
+        );
+    }
+}

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod dependency_graph;
 pub mod doctor;
 pub mod ensure;
 pub mod install;
+pub mod install_gate;
 pub mod lifecycle;
 pub mod macos_signing;
 pub mod passthrough;

--- a/crates/trusty-installer/src/main.rs
+++ b/crates/trusty-installer/src/main.rs
@@ -126,8 +126,9 @@ fn dispatch(cli: Cli) {
         Commands::Install {
             members,
             no_service,
+            dry_run,
         } => {
-            std::process::exit(install::run(&members, yes, json, no_service));
+            std::process::exit(install::run(&members, yes, json, no_service, dry_run));
         }
 
         Commands::Ensure { wait } => {


### PR DESCRIPTION
## Summary

`tctl install` (crates/trusty-installer, binary `tctl`/`trusty-installer`) had a blast-radius confirmation prompt gated on `!yes && is_tty() && !json` (`crates/trusty-installer/src/commands/install.rs:245-251` pre-fix). Any piped, scripted, or agent-driven invocation — i.e. every non-TTY context — skipped confirmation entirely and proceeded straight to a real install. During the 2026-07-06 deploy, an operator ran `tctl install trusty-mpm` from a non-interactive context expecting it to no-op/abort without an explicit `--yes`; instead it silently reactivated a dormant `com.trusty.mpm.supervisor` launchd service, which had to be manually booted back out.

Fixes #2112.

## What changed

- **`--dry-run` (new flag, `crates/trusty-installer/src/cli.rs`):** previews the exact blast radius — members, binaries, and planned launchd service actions — and exits 0 without installing anything. Behaves identically in TTY, non-TTY, and `--json` contexts. It **always** bypasses the interactive component picker for determinism — a no-members `tctl install --dry-run` previews the **full stable set**, not a TTY-driven subset (a plain `tctl install` with no members on a TTY would let you pick a subset via the picker; `--dry-run` intentionally does not, so the preview is reproducible regardless of terminal). `--json` emits a structured `DryRunReport` (`command`, `dry_run: true`, per-member `service_bootstrap` flags) consistent with the existing `InstallReport` JSON conventions.
- **Non-TTY safety default (the core fix):** the confirmation decision is now a pure, exhaustively-tested gate (`crates/trusty-installer/src/commands/install_gate.rs::decide_install_gate`, mirroring the existing `update_engine::decide_apply` pattern used by `tctl upgrade`):
  - `--yes` → proceed without prompting (unchanged).
  - TTY, no `--yes` → interactive confirmation prompt (unchanged).
  - **Non-TTY, no `--yes`, no `--dry-run` → REFUSE (exit 3) with a clear message pointing at `--yes` or `--dry-run`.** This is the new behavior that closes the gap — previously this case fell through to a real install with zero confirmation.
- Refactored the inline confirmation logic into the pure gate function so it's unit-testable without faking a TTY.
- Extracted `plans_service_bootstrap(m, service_enabled)` as a single predicate shared by the `--dry-run` preview and the real install loop, so the preview can never drift from what an actual install would do to launchd.

## Review follow-ups (code-critic pass)

- Dropped an initially-added `run_non_tty_no_yes_refuses` test that called the real `run()` and relied on the test harness's ambient stdin not being a TTY — on a developer's interactive terminal that would have blocked forever on `prompt_yes_no`'s stdin read. The regression it targeted is already covered, TTY-independent, by `install_gate::tests::decide_non_tty_refuses` (same split `upgrade.rs`/`update_engine.rs` already use: side-effecting command vs. unit-tested pure gate).
- Documented (CLI help text + this PR body) that `--dry-run` always previews the full resolved set when no members are named, since it bypasses the picker.
- Reworded `print_dry_run`'s doc: returns `0` unless the `--json` write itself fails (`1`), not unconditionally `0`.

## Breaking change (call out for automation)

🔴 **Any script, CI job, or agent that invoked `tctl install` in a non-TTY context without `--yes` and relied on it silently proceeding will now get exit code 3 instead of a real install.** This is intentional per #2112's original ask ("require an explicit `--yes`/confirmation prompt... or a `--dry-run`"). The fix: add `--yes` to automation call sites, or `--dry-run` first to preview.

## Test plan

- [x] `cargo check -p trusty-installer`
- [x] `cargo test -p trusty-installer` — 381 passed, 0 failed, 3 ignored (live-network tests, unaffected)
  - `install_gate::tests::{decide_yes_proceeds, decide_tty_needs_prompt, decide_non_tty_refuses}`
  - `install::tests::{run_dry_run_exits_zero, dry_run_report_shape, dry_run_full_set_when_no_members_named}`
  - `cli::tests::parse_install_dry_run`
- [x] `cargo clippy -p trusty-installer --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — OK (0 violations)
- [x] `CHANGELOG.md` updated under `[Unreleased]` (Added + Changed/breaking note)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
