### PR TITLE
feat(trusty-mpm): daemon startup version banner + stale-daemon doctor check

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -9,10 +9,10 @@
 # Regenerate with: scripts/check_line_cap.sh --update  (use --seed only to bootstrap).
 crates/trusty-console/src/server.rs	922
 crates/trusty-git-analytics/src/collect/collector.rs	766
-crates/trusty-mpm/src/daemon/api.rs	1271
+crates/trusty-mpm/src/daemon/api.rs	1272
 crates/trusty-mpm/src/daemon/api/control_routes.rs	543
-crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	1218
+crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	1217
 crates/trusty-mpm/src/daemon/mcp_backend.rs	564
 crates/trusty-mpm/src/runtime/claude_code.rs	1616
-crates/trusty-search/src/main.rs	666
+crates/trusty-search/src/main.rs	664
 crates/trusty-search/src/service/walker.rs	1167

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- daemon startup version banner (`v<CARGO_PKG_VERSION> pid <pid>`) plus a `tm doctor` stale-daemon check (`daemon_version`) that compares the freshly-installed `tm` binary's version against the running daemon's self-reported `/health` `version` field, warning when the daemon predates the installed binary and needs a restart (closes #2332)
 - pm_guard — 3-per-turn file-change budget, read-only-redirection fix, content-aware routing hints ([#2928](https://github.com/bobmatnyc/trusty-tools/pull/2928)) ([`95b69c8`](https://github.com/bobmatnyc/trusty-tools/commit/95b69c80e08e396de8da7fe606d329e8360835a3))
 - rust-build-performance bundled skill — dev-loop + dependency-graph build hygiene ([#2929](https://github.com/bobmatnyc/trusty-tools/pull/2929)) ([`c278874`](https://github.com/bobmatnyc/trusty-tools/commit/c278874db20e017323de27129f59647682de643f))
 

--- a/crates/trusty-mpm/src/bin/tm/commands/doctor_stale.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/doctor_stale.rs
@@ -1,0 +1,47 @@
+//! Client-side stale-daemon version check for `tm doctor` (issue #2332).
+//!
+//! Why: split out of `commands::misc` to keep that file under the 500-SLOC
+//! production cap (`misc.rs` was already near the ceiling before this
+//! addition). This check must live in the `tm` CLI binary — not the daemon's
+//! server-side `run_doctor` — because it needs THIS process's own
+//! `CARGO_PKG_VERSION`: `tm doctor` always executes as the just-installed
+//! binary, so its compiled-in version is the "installed" side of the
+//! comparison; the daemon can only ever report on itself.
+//! What: [`stale_daemon_check`] fetches the running daemon's `/health`
+//! version via [`trusty_mpm::client::DaemonClient::health_snapshot`] and
+//! folds it into a [`trusty_mpm::core::doctor::DoctorCheck`] via
+//! [`trusty_mpm::core::version_staleness::check_daemon_version_staleness`].
+//! Test: the pure comparison logic is covered by
+//! `core::version_staleness`'s own unit tests; the network fetch itself is
+//! exercised indirectly by the executor's live-daemon doctor test.
+
+use trusty_mpm::client::DaemonClient;
+use trusty_mpm::core::doctor::{CheckStatus, DoctorCheck};
+use trusty_mpm::core::version_staleness::{CHECK_NAME, check_daemon_version_staleness};
+
+/// Fetch the daemon's `/health` version and fold it into the #2332
+/// stale-daemon [`DoctorCheck`].
+///
+/// Why: separates the network fetch (untestable without a live daemon) from
+/// the pure comparison in [`trusty_mpm::core::version_staleness`], and keeps
+/// `commands::misc::doctor` itself free of the "daemon unreachable" branch.
+/// What: calls `daemon.health_snapshot()`; on success, compares its `version`
+/// against this process's own `env!("CARGO_PKG_VERSION")`. On a transport
+/// failure, returns `Warn` — the daemon is presumably unreachable, which the
+/// caller's own `report.checks` output already explains in detail; this just
+/// keeps the stale-daemon line from silently vanishing.
+/// Test: the comparison logic is covered by `core::version_staleness`'s unit
+/// tests; the network fetch itself is exercised indirectly by the executor's
+/// live-daemon doctor test.
+pub(crate) async fn stale_daemon_check(daemon: &DaemonClient) -> DoctorCheck {
+    match daemon.health_snapshot().await {
+        Ok(snapshot) => {
+            check_daemon_version_staleness(env!("CARGO_PKG_VERSION"), &snapshot.version)
+        }
+        Err(e) => DoctorCheck::new(
+            CHECK_NAME,
+            CheckStatus::Warn,
+            format!("could not fetch daemon version from /health: {e}"),
+        ),
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -117,19 +117,21 @@ pub(crate) async fn events(client: &reqwest::Client, url: &str) -> anyhow::Resul
 /// operator can confirm — or fix — a broken install at a glance.
 /// What: runs [`TrustyCommand::Doctor`] through the shared [`CommandExecutor`]
 /// (which calls `GET /api/v1/doctor`), then prints one status-tagged line per
-/// check plus an overall verdict. An unreachable daemon prints an error line.
-/// When `prune_stale_skills` is set (hidden `--prune-stale-skills` flag),
-/// also runs [`prune_stale_skills_locally`] as a manual troubleshooting
-/// escape hatch — normal operation cleans up pre-rename `mpm-*` skill
-/// directories automatically and silently via the one-time
-/// `core::stale_skills::run_stale_mpm_skills_migration_once` migration at
-/// `tm` startup (#1905), so this flag should rarely be needed.
+/// check plus the client-side #2332 stale-daemon check (see
+/// [`super::doctor_stale::stale_daemon_check`]) and an overall verdict that
+/// folds both. When `prune_stale_skills` is set (hidden
+/// `--prune-stale-skills` flag), also runs [`prune_stale_skills_locally`] as a
+/// manual troubleshooting escape hatch — normal operation cleans up
+/// pre-rename `mpm-*` skill directories automatically and silently via the
+/// one-time `core::stale_skills::run_stale_mpm_skills_migration_once`
+/// migration at `tm` startup (#1905), so this flag should rarely be needed.
 /// Test: `cli_parses_doctor` / `cli_parses_doctor_prune_stale_skills` cover
 /// parsing; the report path is covered by the executor's
 /// `execute_doctor_against_test_daemon` test; the prune path is covered by
-/// `core::stale_skills`'s own unit tests.
+/// `core::stale_skills`'s own unit tests; the stale-daemon comparison logic
+/// is covered by `core::version_staleness`'s own unit tests.
 pub(crate) async fn doctor(url: &str, prune_stale_skills: bool) -> anyhow::Result<()> {
-    use trusty_mpm::client::{CommandExecutor, CommandResult, TrustyCommand};
+    use trusty_mpm::client::{CommandExecutor, CommandResult, DaemonClient, TrustyCommand};
     use trusty_mpm::core::doctor::CheckStatus;
 
     let executor = CommandExecutor::new(url.to_string());
@@ -144,10 +146,27 @@ pub(crate) async fn doctor(url: &str, prune_stale_skills: bool) -> anyhow::Resul
                     check.message,
                 );
             }
+
+            // #2332: this check runs HERE (client-side) rather than inside the
+            // daemon's own `run_doctor` because it needs THIS process's own
+            // `CARGO_PKG_VERSION` — `tm doctor` always executes as the
+            // just-installed binary, so its compiled-in version is the
+            // "installed" side of the comparison. The daemon can only ever
+            // report on itself.
+            let daemon = DaemonClient::new(url.to_string());
+            let stale_check = super::doctor_stale::stale_daemon_check(&daemon).await;
+            println!(
+                "  {} {:<13} {}",
+                status_icon(stale_check.status),
+                stale_check.name,
+                stale_check.message,
+            );
+            let overall = report.overall.worst(stale_check.status);
+
             println!(
                 "\noverall: {} {}",
-                status_icon(report.overall),
-                match report.overall {
+                status_icon(overall),
+                match overall {
                     CheckStatus::Ok => "all checks passed",
                     CheckStatus::Warn => "passed with warnings",
                     CheckStatus::Fail => "one or more checks failed",

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod banner;
 pub(crate) mod compress;
 pub(crate) mod daemon;
 pub(crate) mod delete;
+pub(crate) mod doctor_stale;
 pub(crate) mod first_run;
 pub(crate) mod generate;
 pub(crate) mod guided;

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -731,21 +731,25 @@ fn managed_session_urls_use_managed_route_family() {
 #[test]
 fn health_snapshot_deserializes() {
     // The `/health` body deserializes into HealthSnapshot; the catalog flags
-    // default when absent so an older daemon returning only `status` still parses.
+    // and `version` (issue #2332) default when absent so an older daemon
+    // returning only `status` still parses.
     let full: HealthSnapshot = serde_json::from_value(serde_json::json!({
         "status": "ok",
         "catalog_stale": true,
         "catalog_unknown": false,
         "catalog_changes": ["agents/foo"],
+        "version": "0.42.0",
     }))
     .expect("full health body parses");
     assert_eq!(full.status, "ok");
     assert!(full.catalog_stale);
     assert!(!full.catalog_unknown);
+    assert_eq!(full.version, "0.42.0");
 
     let minimal: HealthSnapshot =
         serde_json::from_value(serde_json::json!({ "status": "ok" })).expect("minimal body parses");
     assert_eq!(minimal.status, "ok");
     assert!(!minimal.catalog_stale);
     assert!(!minimal.catalog_unknown);
+    assert_eq!(minimal.version, "", "older daemon omitting version → empty");
 }

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -777,8 +777,9 @@ pub struct FleetByProjectWireResponse {
 /// daemon's `HealthResponse` field names keeps the wire contract type-checked.
 /// What: `status` is the liveness word (`"ok"` while up); `catalog_stale` is true
 /// when deployed agents/skills drift from the synced catalog; `catalog_unknown`
-/// is true when the catalog has never been synced. All non-`status` fields
-/// default so an older daemon that returns only `status` still parses.
+/// is true when the catalog has never been synced; `version` is the running
+/// daemon's build version (issue #2332). All non-`status` fields default so an
+/// older daemon that returns only `status` still parses.
 /// Test: `health_snapshot_deserializes` in `tests.rs`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct HealthSnapshot {
@@ -790,4 +791,17 @@ pub struct HealthSnapshot {
     /// True when the catalog has never been synced (nothing to compare).
     #[serde(default)]
     pub catalog_unknown: bool,
+    /// The running daemon's build version (`CARGO_PKG_VERSION`), issue #2332.
+    ///
+    /// Why: `tm doctor`'s stale-daemon check needs to compare the daemon's
+    /// actual running build against the freshly-installed `tm` binary that is
+    /// executing `doctor` itself.
+    /// What: empty string when the daemon predates this field (an older
+    /// daemon's `/health` response omits `version` entirely, and
+    /// `#[serde(default)]` fills the gap) — the staleness check treats an
+    /// empty string as "unknown build, recommend a restart" rather than
+    /// failing to parse.
+    /// Test: `health_snapshot_deserializes`.
+    #[serde(default)]
+    pub version: String,
 }

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -89,6 +89,7 @@ pub mod standalone;
 pub mod tmux;
 pub mod trusty_tools_config;
 pub mod update_check;
+pub mod version_staleness;
 pub mod workspace_scan;
 pub mod worktree_naming;
 

--- a/crates/trusty-mpm/src/core/version_staleness.rs
+++ b/crates/trusty-mpm/src/core/version_staleness.rs
@@ -9,7 +9,17 @@
 //! just-installed binary (that is what running the command means), so
 //! comparing its own `CARGO_PKG_VERSION` against the version the daemon
 //! self-reports on `GET /health` (see [`crate::daemon::api::types::HealthResponse::version`])
-//! is a purely client-side, network-already-available check — no new RPC.
+//! is a purely client-side COMPARISON — the two values it folds together need
+//! no shared process or IPC to compare. It is NOT free of network cost,
+//! though: the caller, `stale_daemon_check` in the `tm` CLI binary's
+//! `commands::doctor_stale` module (a separate crate target from this
+//! library, so it cannot be an intra-doc link here), issues a SECOND
+//! `GET /health` round-trip after the primary `GET /api/v1/doctor` call
+//! already made by `tm doctor`, and the two requests are not atomic — the
+//! daemon can restart between them. That is handled by treating a transport
+//! failure on the second call as `Warn` rather than propagating an error (see
+//! `stale_daemon_check`'s own doc comment), not by this module, which only
+//! ever sees the two already-fetched strings.
 //! What: [`parse_version_triple`] extracts a `(major, minor, patch)` triple
 //! from a `CARGO_PKG_VERSION`-shaped string (mirrors the lightweight parser in
 //! [`crate::core::output_style::parse_claude_version`] rather than pulling in
@@ -190,5 +200,17 @@ mod tests {
         let check = check_daemon_version_staleness("0.42.0", "garbage");
         assert_eq!(check.status, CheckStatus::Warn);
         assert!(check.message.contains("could not compare"));
+    }
+
+    #[test]
+    fn staleness_ok_when_triples_match_but_raw_strings_differ() {
+        // Covers the `(Some(_), Some(_))` equal-triple arm specifically — a
+        // pre-release suffix difference (e.g. "0.42.0" vs "0.42.0-beta") must
+        // NOT hit the `daemon_reported == installed` exact-string
+        // short-circuit above it, since the raw strings differ; it must also
+        // NOT hit either `<`/`>` ordering arm, since the triples are equal.
+        let check = check_daemon_version_staleness("0.42.0", "0.42.0-beta");
+        assert_eq!(check.status, CheckStatus::Ok, "message: {}", check.message);
+        assert_eq!(check.name, CHECK_NAME);
     }
 }

--- a/crates/trusty-mpm/src/core/version_staleness.rs
+++ b/crates/trusty-mpm/src/core/version_staleness.rs
@@ -1,0 +1,194 @@
+//! Stale-daemon version comparison for `tm doctor` (issue #2332).
+//!
+//! Why: the #2332 incident traced a daemon that ran 46.8h on pre-migration
+//! code purely by hand-correlating tmux timestamps against
+//! `~/Library/Logs/trusty-mpm/stderr.log` restart banners — nothing anywhere
+//! in the stack told the operator the RUNNING daemon's build had drifted from
+//! the INSTALLED `tm` binary (the common `cargo install` restart-forgot
+//! failure, same family as #2214). `tm doctor` always executes as the
+//! just-installed binary (that is what running the command means), so
+//! comparing its own `CARGO_PKG_VERSION` against the version the daemon
+//! self-reports on `GET /health` (see [`crate::daemon::api::types::HealthResponse::version`])
+//! is a purely client-side, network-already-available check — no new RPC.
+//! What: [`parse_version_triple`] extracts a `(major, minor, patch)` triple
+//! from a `CARGO_PKG_VERSION`-shaped string (mirrors the lightweight parser in
+//! [`crate::core::output_style::parse_claude_version`] rather than pulling in
+//! the `semver` crate for a same-process comparison this simple).
+//! [`check_daemon_version_staleness`] folds `(installed, daemon_reported)`
+//! into a [`DoctorCheck`] the CLI prints alongside the server-side probes.
+//! Test: the `tests` module below covers match / older / newer / unparseable /
+//! empty-daemon-version branches.
+
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+
+/// Stable check name for [`check_daemon_version_staleness`]'s [`DoctorCheck`].
+pub const CHECK_NAME: &str = "daemon_version";
+
+/// Parse a `major.minor.patch[-suffix]` string into a comparable triple.
+///
+/// Why: `CARGO_PKG_VERSION` values are already clean semver (no `v` prefix,
+/// no extra whitespace), so this needs far less tolerance than
+/// [`crate::core::output_style::parse_claude_version`]'s CLI-output parser —
+/// but a pre-release suffix on patch (`"0.42.0-beta"`) must still parse the
+/// leading digits rather than failing outright.
+/// What: splits on `.`; requires three numeric components, taking only the
+/// leading digits of the patch segment. Returns `None` for anything that
+/// doesn't start with `major.minor.patch`.
+/// Test: `parse_version_triple_plain`, `parse_version_triple_prerelease_suffix`,
+/// `parse_version_triple_rejects_malformed`.
+pub fn parse_version_triple(raw: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = raw.split('.');
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let minor = parts.next()?.parse::<u64>().ok()?;
+    let patch_raw = parts.next()?;
+    let patch_digits: String = patch_raw
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
+    if patch_digits.is_empty() {
+        return None;
+    }
+    let patch = patch_digits.parse::<u64>().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Compare the installed binary's version against the running daemon's
+/// self-reported version and fold the result into a [`DoctorCheck`].
+///
+/// Why: the whole point of #2332 — surface drift BEFORE it costs another
+/// multi-hour forensics session, without ever hard-failing `tm doctor` over
+/// something a simple restart fixes.
+/// What: `daemon_reported == ""` (an older daemon predating
+/// [`crate::daemon::api::types::HealthResponse::version`], or a daemon that
+/// is simply unreachable and never got this far) → `Warn`, since that is
+/// itself evidence of exactly the staleness this check exists to catch.
+/// Equal strings → `Ok`. Different strings that both parse as
+/// `major.minor.patch` → `Warn` when the daemon is older, `Warn` (a distinct,
+/// less common message) when the daemon is newer than the installed binary
+/// (a downgrade — still worth flagging). Different strings where either side
+/// fails to parse → `Warn` with a "could not compare" message rather than
+/// guessing. Never `Fail` — a stale daemon still serves traffic; this is
+/// advisory, matching every other doctor probe's severity convention.
+/// Test: `staleness_ok_when_versions_match`, `staleness_warns_when_daemon_older`,
+/// `staleness_warns_when_daemon_newer`, `staleness_warns_when_daemon_version_empty`,
+/// `staleness_warns_when_unparseable`.
+pub fn check_daemon_version_staleness(installed: &str, daemon_reported: &str) -> DoctorCheck {
+    if daemon_reported.is_empty() {
+        return DoctorCheck::new(
+            CHECK_NAME,
+            CheckStatus::Warn,
+            format!(
+                "daemon did not report a version on /health — it likely predates this build \
+                 (installed binary is v{installed}); restart the daemon (`tm restart`)"
+            ),
+        );
+    }
+
+    if daemon_reported == installed {
+        return DoctorCheck::new(
+            CHECK_NAME,
+            CheckStatus::Ok,
+            format!("running daemon (v{daemon_reported}) matches the installed binary"),
+        );
+    }
+
+    match (
+        parse_version_triple(installed),
+        parse_version_triple(daemon_reported),
+    ) {
+        (Some(installed_triple), Some(daemon_triple)) if daemon_triple < installed_triple => {
+            DoctorCheck::new(
+                CHECK_NAME,
+                CheckStatus::Warn,
+                format!(
+                    "running daemon is older than installed binary — restart the daemon \
+                     (daemon: v{daemon_reported}, installed: v{installed}); run `tm restart`"
+                ),
+            )
+        }
+        (Some(installed_triple), Some(daemon_triple)) if daemon_triple > installed_triple => {
+            DoctorCheck::new(
+                CHECK_NAME,
+                CheckStatus::Warn,
+                format!(
+                    "running daemon (v{daemon_reported}) is NEWER than the installed binary \
+                     (v{installed}) — the installed binary may have been downgraded"
+                ),
+            )
+        }
+        // Equal triples with differing raw strings (e.g. a pre-release suffix
+        // difference) — not the drift this check targets.
+        (Some(_), Some(_)) => DoctorCheck::new(
+            CHECK_NAME,
+            CheckStatus::Ok,
+            format!("running daemon (v{daemon_reported}) matches the installed binary"),
+        ),
+        _ => DoctorCheck::new(
+            CHECK_NAME,
+            CheckStatus::Warn,
+            format!(
+                "could not compare daemon version `{daemon_reported}` against installed \
+                 binary version `{installed}` — restart the daemon if unsure (`tm restart`)"
+            ),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_version_triple_plain() {
+        assert_eq!(parse_version_triple("0.42.1"), Some((0, 42, 1)));
+        assert_eq!(parse_version_triple("12.0.7"), Some((12, 0, 7)));
+    }
+
+    #[test]
+    fn parse_version_triple_prerelease_suffix() {
+        assert_eq!(parse_version_triple("0.42.0-beta"), Some((0, 42, 0)));
+    }
+
+    #[test]
+    fn parse_version_triple_rejects_malformed() {
+        assert_eq!(parse_version_triple(""), None);
+        assert_eq!(parse_version_triple("0.42"), None);
+        assert_eq!(parse_version_triple("not-a-version"), None);
+    }
+
+    #[test]
+    fn staleness_ok_when_versions_match() {
+        let check = check_daemon_version_staleness("0.42.0", "0.42.0");
+        assert_eq!(check.status, CheckStatus::Ok, "message: {}", check.message);
+        assert_eq!(check.name, CHECK_NAME);
+    }
+
+    #[test]
+    fn staleness_warns_when_daemon_older() {
+        let check = check_daemon_version_staleness("0.42.0", "0.41.9");
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.message.contains("older than installed binary"));
+        assert!(check.message.contains("tm restart"));
+    }
+
+    #[test]
+    fn staleness_warns_when_daemon_newer() {
+        let check = check_daemon_version_staleness("0.41.9", "0.42.0");
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.message.contains("NEWER"));
+    }
+
+    #[test]
+    fn staleness_warns_when_daemon_version_empty() {
+        let check = check_daemon_version_staleness("0.42.0", "");
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.message.contains("did not report a version"));
+    }
+
+    #[test]
+    fn staleness_warns_when_unparseable() {
+        let check = check_daemon_version_staleness("0.42.0", "garbage");
+        assert_eq!(check.status, CheckStatus::Warn);
+        assert!(check.message.contains("could not compare"));
+    }
+}

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -395,13 +395,17 @@ pub fn router(state: Arc<DaemonState>) -> Router {
 /// (never `stale`, never an error) per the spec's "never block" rule. Also
 /// surfaces the #2486 `supervised` restart-race signal — a 200 response here
 /// does NOT by itself prove launchd owns this process; check `supervised` too.
+/// Also surfaces the #2332 `version` field so `tm doctor` can detect a
+/// stale, unrestarted daemon running older code than the installed binary.
 /// What: returns `status: "ok"` with `catalog_stale`/`catalog_unknown` flags, a
 /// small `catalog_changes` summary computed via
 /// [`crate::core::update_check::detect_for_framework`] anchored at the daemon's
-/// framework root, and `supervised` read from `state` (set once at daemon
-/// startup by `daemon_run::run_daemon`).
+/// framework root, `supervised` read from `state` (set once at daemon startup
+/// by `daemon_run::run_daemon`), and `version` (this process's
+/// `CARGO_PKG_VERSION`, a compile-time constant).
 /// Test: `health_reports_ok_status`, `health_reports_catalog_unknown_without_catalog`,
-/// `health_response_serializes_supervised_field`.
+/// `health_response_serializes_supervised_field`,
+/// `health_response_serializes_version_field`.
 #[utoipa::path(
     get,
     path = "/health",
@@ -419,6 +423,7 @@ pub async fn health(State(state): State<Arc<DaemonState>>) -> Json<HealthRespons
         catalog_unknown: report.unknown,
         catalog_changes: report.summary_lines(),
         supervised: state.supervised(),
+        version: env!("CARGO_PKG_VERSION").to_owned(),
     })
 }
 

--- a/crates/trusty-mpm/src/daemon/api/types.rs
+++ b/crates/trusty-mpm/src/daemon/api/types.rs
@@ -66,6 +66,25 @@ pub struct HealthResponse {
     /// `compute_supervised_*` in `commands::launchd_probe::tests`.
     #[serde(default = "default_supervised")]
     pub supervised: bool,
+    /// This running daemon process's build version (issue #2332).
+    ///
+    /// Why: the #2332 incident traced a 46.8h-stale daemon only by
+    /// correlating tmux timestamps against stderr log lines by hand — nothing
+    /// in `/health` or the startup banner identified WHICH build was actually
+    /// serving. Surfacing `CARGO_PKG_VERSION` here lets `tm doctor` (and any
+    /// operator) compare the running daemon against the installed `tm`
+    /// binary's own version and flag drift.
+    /// What: `env!("CARGO_PKG_VERSION")` of the daemon binary, set once at
+    /// `/health` handler time (it is a compile-time constant, so it never
+    /// changes across the process's lifetime). `#[serde(default)]` keeps an
+    /// older client parsing a newer daemon's response tolerant of the field,
+    /// and — the case that matters here — keeps a newer client parsing an
+    /// OLDER daemon's response (one built before this field existed)
+    /// tolerant too: it deserializes to `""`, which the staleness check
+    /// treats as "daemon predates version reporting — restart it".
+    /// Test: `health_response_serializes_version_field`.
+    #[serde(default)]
+    pub version: String,
 }
 
 /// Default for [`HealthResponse::supervised`] on deserialize — matches the

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -91,6 +91,24 @@ async fn health_response_serializes_supervised_field() {
 }
 
 #[tokio::test]
+async fn health_response_serializes_version_field() {
+    // Issue #2332: `/health` must carry this process's build version so a
+    // client can detect a stale daemon that predates the installed binary.
+    let state = DaemonState::shared();
+    let Json(body) = health(State(state)).await;
+    assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
+
+    let value = serde_json::to_value(&body).expect("HealthResponse must serialize");
+    assert_eq!(
+        value.get("version"),
+        Some(&serde_json::Value::String(
+            env!("CARGO_PKG_VERSION").to_owned()
+        )),
+        "wire shape must carry `version`: {value}"
+    );
+}
+
+#[tokio::test]
 async fn current_project_found_and_missing() {
     // `GET /projects/current` returns the project for a registered path
     // and `404` for an unregistered one.

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -150,7 +150,15 @@ pub async fn serve_http(
     }
 
     let app = api::router(Arc::clone(&state));
-    info!("daemon listening; press Ctrl-C to stop");
+    // Issue #2332: the startup banner carries the build version + PID so a
+    // `~/Library/Logs/trusty-mpm/stderr.log` timeline can be correlated
+    // against `cargo install` / restart events without guessing which
+    // binary a long-lived daemon is actually running.
+    info!(
+        "daemon listening (trusty-mpm v{} pid {}); press Ctrl-C to stop",
+        env!("CARGO_PKG_VERSION"),
+        std::process::id()
+    );
     // `into_make_service_with_connect_info` makes the peer `SocketAddr` available
     // to handlers via `ConnectInfo` — the loopback-only `POST /rpc` gate (#1221)
     // depends on it. Without connect-info the `ConnectInfo` extractor would 500.


### PR DESCRIPTION
## Summary

Closes #2332 — the incident where a trusty-mpm daemon ran 46.8h on
pre-migration code with no version/build identifier anywhere, forcing
forensics to hand-correlate tmux timestamps against stderr restart banners.

- **Startup banner**: `serve_http`'s "daemon listening" log line now carries
  `env!("CARGO_PKG_VERSION")` and the process PID
  (`crates/trusty-mpm/src/daemon/mod.rs`). No new build machinery (git SHA)
  was added — the workspace has no existing git-SHA embedding, and the issue
  explicitly allows version-only as a fallback.
- **`/health` version field**: `HealthResponse` (server) and `HealthSnapshot`
  (client) both gain an additive `version: String` field
  (`#[serde(default)]`, so older/newer daemons and clients stay wire-compatible
  in both directions) carrying the running daemon's `CARGO_PKG_VERSION`.
- **Stale-daemon `tm doctor` check**: a new `daemon_version` check, printed
  alongside the server-side `run_doctor` probes. It intentionally runs
  **client-side** (`commands/doctor_stale.rs`, called from
  `commands/misc.rs::doctor`) rather than inside the daemon's own
  `run_doctor` — `tm doctor` always executes as the just-installed binary, so
  its own `CARGO_PKG_VERSION` is the "installed" side of the comparison; the
  daemon can only ever report on itself. The pure comparison logic lives in
  `crates/trusty-mpm/src/core/version_staleness.rs` and warns
  `"running daemon is older than installed binary — restart the daemon"` when
  the daemon's self-reported version is behind, with corresponding messages
  for a newer/downgraded daemon, an unparseable version, or a daemon that
  predates this field entirely (empty `version`).
- Extracted `stale_daemon_check` into its own file
  (`commands/doctor_stale.rs`) to keep `commands/misc.rs` under the 500-SLOC
  production cap; the one unavoidable +1 SLOC to the already-oversized,
  allowlisted `daemon/api.rs` was frozen via `scripts/check_line_cap.sh
  --force-add` (the sanctioned escape hatch for a small, intentional bump).

## Test plan

- [x] `cargo check -p trusty-mpm`
- [x] `cargo test -p trusty-mpm` — 34/34 test binaries `ok`, 0 failed
      (includes 8 new pure-function tests in `core::version_staleness` and
      the new `health_response_serializes_version_field` /
      `health_snapshot_deserializes` coverage)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 9 allowlisted, 0 violations

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools