### PR TITLE
feat(trusty-code): session.get_agents RPC — live agent roster (closes #2962)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,19 +10,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- **`session.get_agents` — live agent-roster RPC (DOC-39 §5.4, closes #2962).**
-  New JSON-RPC method `session.get_agents(session_id) -> { agents: [{agent_id,
-  name, model, state, task, todos, files_changed}] }` returns the daemon's
-  own fold of the ring-buffer replay's tool-attribution events
-  (`ToolStarted`/`ToolFinished`/`ToolError`/`SearchPerformed`/
-  `MemoryRecalled`, all carrying `agent`/`agent_id` since #2898) into one
-  roster entry per distinct `agent_id`, replacing the client-side SSE-fold
-  §5.4 named "a Phase-1 loan, not a design." `state` is `"running"` while an
-  agent's last known event is an unmatched `ToolStarted`, `"idle"`
-  otherwise. `model`/`task`/`todos`/`files_changed` are deferred
-  (`null`/`[]`) — see `session::registry::agents`'s module docs for exactly
-  why each isn't foldable from today's event stream. Implementation lives in
-  new sibling files `session/registry_agents.rs` (the fold) and
+- **`session.get_agents` — live, eviction-safe agent-roster RPC (DOC-39 §5.4,
+  closes #2962).** New JSON-RPC method `session.get_agents(session_id) ->
+  { agents: [{agent_id, name, model, state, task, todos, files_changed}] }`,
+  replacing the client-side SSE-fold §5.4 named "a Phase-1 loan, not a
+  design." Backed by an ALWAYS-RETAINED per-session agent map
+  (`SessionEntry::agents`, `registry.rs`) — NOT a fold over the
+  capacity-bounded ring buffer: `SessionRegistry::record` (the same critical
+  section that pushes every `agent`/`agent_id`-carrying event —
+  `ToolStarted`/`ToolFinished`/`ToolError`/`SearchPerformed`/
+  `MemoryRecalled`, since #2898 — onto the ring) also updates this map, which
+  is evicted only when the session itself goes away, never by ring capacity.
+  This closes a code-critic HIGH found on an earlier cut of this PR that
+  folded the ring buffer directly on every call: a long-running agent's
+  `ToolStarted` could age out of the (default 1000-entry) ring before any
+  later attributed event for that `agent_id` landed, silently vanishing that
+  agent from the roster — indistinguishable from "never spawned" while it
+  may still be running. `state` is `"running"` while an agent's last known
+  event is an unmatched `ToolStarted`, `"idle"` otherwise.
+  `model`/`task`/`todos`/`files_changed` are deferred (`null`/`[]`) — see
+  `session::registry::agents`'s module docs for exactly why each isn't
+  populated from today's event stream. Implementation lives in new sibling
+  files `session/registry_agents.rs` (the query) and
   `session/protocol_agents.rs` (the RPC handler), mirroring
   `session.get_readiness`'s split. This closes the last MISSING API item in
   DOC-39 §5.1.

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`session.get_agents` — live agent-roster RPC (DOC-39 §5.4, closes #2962).**
+  New JSON-RPC method `session.get_agents(session_id) -> { agents: [{agent_id,
+  name, model, state, task, todos, files_changed}] }` returns the daemon's
+  own fold of the ring-buffer replay's tool-attribution events
+  (`ToolStarted`/`ToolFinished`/`ToolError`/`SearchPerformed`/
+  `MemoryRecalled`, all carrying `agent`/`agent_id` since #2898) into one
+  roster entry per distinct `agent_id`, replacing the client-side SSE-fold
+  §5.4 named "a Phase-1 loan, not a design." `state` is `"running"` while an
+  agent's last known event is an unmatched `ToolStarted`, `"idle"`
+  otherwise. `model`/`task`/`todos`/`files_changed` are deferred
+  (`null`/`[]`) — see `session::registry::agents`'s module docs for exactly
+  why each isn't foldable from today's event stream. Implementation lives in
+  new sibling files `session/registry_agents.rs` (the fold) and
+  `session/protocol_agents.rs` (the RPC handler), mirroring
+  `session.get_readiness`'s split. This closes the last MISSING API item in
+  DOC-39 §5.1.
 - **Embedded default agents converted from TOML to `.md`+frontmatter (#2897,
   epic #2892, Slice C).** The three bundled default agents
   (`engineer`/`qa-agent`/`code-reviewer`, #2895) are now authored as

--- a/crates/trusty-code/src/session/protocol.rs
+++ b/crates/trusty-code/src/session/protocol.rs
@@ -6,22 +6,25 @@
 //! What: [`register`] wires `session.create`, `session.list`,
 //! `session.status`, `session.send`, `session.attach`, `session.detach`,
 //! `session.cancel`, (#2058) `session.get_transcript`, (#2350)
-//! `session.set_goal`/`session.clear_goal`/`session.get_goals`, and
-//! (DOC-39 §5.6 Slice D) `session.get_readiness` onto a [`Router`], all
+//! `session.set_goal`/`session.clear_goal`/`session.get_goals`,
+//! (DOC-39 §5.6 Slice D) `session.get_readiness`, and (DOC-39 §5.4)
+//! `session.get_agents` onto a [`Router`], all
 //! closed over the SAME `Arc<SessionRegistry>` so every method sees a
 //! consistent view. Each handler parses its typed `params`, forwards to the
 //! matching `SessionRegistry` method, and maps the result onto the JSON-RPC
 //! result shape the vision spec's §4.3 examples describe.
 //! The three goal methods' handler bodies live in the sibling
-//! `protocol_goals` module, and `session.get_readiness`'s in the sibling
-//! `protocol_readiness` module (both kept out of this file purely for the
+//! `protocol_goals` module, `session.get_readiness`'s in the sibling
+//! `protocol_readiness` module, and `session.get_agents`'s in the sibling
+//! `protocol_agents` module (all kept out of this file purely for the
 //! 500-SLOC cap — see each module's docs), but are registered here alongside
 //! every other `session.*` method so this remains the one place listing the
 //! full surface.
 //! Test: `protocol::tests::*` (parameter validation, error mapping);
 //! `protocol_goals::tests::*` (the three goal methods);
-//! `protocol_readiness::tests::*` (`session.get_readiness`); the full
-//! attach/detach streaming behaviour is covered by `session::registry_tests`
+//! `protocol_readiness::tests::*` (`session.get_readiness`);
+//! `protocol_agents::tests::*` (`session.get_agents`); the full attach/detach
+//! streaming behaviour is covered by `session::registry_tests`
 //! (registry-level) and `tests/session_e2e.rs`/`tests/task_e2e.rs`
 //! (API-driven, real daemon).
 
@@ -150,6 +153,15 @@ pub fn register(router: &mut Router, registry: Arc<SessionRegistry>) {
         move |params: Value, ctx: ConnectionContext| {
             let r = r.clone();
             async move { protocol_readiness::get_readiness(&r, params, ctx).await }
+        },
+    );
+
+    let r = registry.clone();
+    router.register(
+        "session.get_agents",
+        move |params: Value, ctx: ConnectionContext| {
+            let r = r.clone();
+            async move { protocol_agents::get_agents(&r, params, ctx).await }
         },
     );
 }
@@ -395,6 +407,11 @@ mod protocol_goals;
 #[path = "protocol_readiness.rs"]
 mod protocol_readiness;
 
+/// `session.get_agents` (DOC-39 §5.4), split into its own file for the same
+/// 500-SLOC-cap reason as `protocol_goals` above.
+#[path = "protocol_agents.rs"]
+mod protocol_agents;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -428,6 +445,7 @@ mod tests {
             ("session.get_transcript", json!({"session_id": session.id})),
             ("session.get_goals", json!({"session_id": session.id})),
             ("session.get_readiness", json!({"session_id": session.id})),
+            ("session.get_agents", json!({"session_id": session.id})),
         ];
         for (method, params) in cases {
             let req = Request {

--- a/crates/trusty-code/src/session/protocol_agents.rs
+++ b/crates/trusty-code/src/session/protocol_agents.rs
@@ -1,0 +1,107 @@
+//! `session.get_agents` handler (DOC-39 §5.4). Split out of `protocol.rs`
+//! purely to keep that production file under the crate's 500-SLOC cap — this
+//! is a child module of `protocol` (declared via `#[path = ...] mod
+//! protocol_agents;`), so it shares full access to `protocol`'s private
+//! `SessionIdParams`/`parse` helpers exactly as if this handler were still
+//! defined in that file.
+//!
+//! Why: §5.4 names `session.get_agents` "the principled endpoint" a
+//! late-attaching UI client needs to ask "who is running right now?" without
+//! folding the SSE ring-buffer replay itself — see
+//! `session::registry::agents`' module docs for the fold this handler
+//! forwards to.
+//! What: [`get_agents`] forwards to `SessionRegistry::get_agents`, wrapping
+//! its roster under an `"agents"` key — the same `{"<plural>": [...]}` shape
+//! `session.list`/`session.get_goals` already use.
+//! Test: `tests::*` in this module.
+
+use super::*;
+
+/// `session.get_agents(session_id) -> { agents: [AgentRosterEntry] }`
+/// (DOC-39 §5.4).
+///
+/// Why: the query counterpart to the tool-attribution events every agent
+/// loop's tool dispatch already emits — see module docs.
+/// What: `-32007 session_not_found` if `session_id` is unknown; otherwise
+/// `SessionRegistry::get_agents`'s roster, wrapped as `{"agents": [...]}`
+/// (never a bare array, matching `session.list`'s `{"sessions": [...]}`
+/// convention). An empty roster (no tool activity recorded yet) is a
+/// success, not an error.
+/// Test: `tests::get_agents_wraps_roster_under_agents_key`,
+/// `tests::get_agents_unknown_session_maps_to_session_not_found`.
+pub(super) async fn get_agents(
+    registry: &SessionRegistry,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: SessionIdParams = parse(params, "session.get_agents")?;
+    Ok(json!({ "agents": registry.get_agents(&p.session_id)? }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    fn test_ctx() -> ConnectionContext {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    /// A session with a recorded tool call reports it under `"agents"`, with
+    /// the roster entry's core fields populated from real spawn-attribution
+    /// state.
+    #[tokio::test]
+    async fn get_agents_wraps_roster_under_agents_key() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        registry
+            .record_tool_started(
+                &session.id,
+                "python-engineer",
+                "eng-1",
+                "bash",
+                "c1",
+                "cargo test",
+            )
+            .unwrap();
+
+        let result = get_agents(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        let agents = result["agents"].as_array().unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0]["agent_id"], "eng-1");
+        assert_eq!(agents[0]["name"], "python-engineer");
+        assert_eq!(agents[0]["state"], "running");
+        assert!(agents[0]["model"].is_null());
+        assert!(agents[0]["task"].is_null());
+        assert_eq!(agents[0]["todos"].as_array().unwrap().len(), 0);
+        assert_eq!(agents[0]["files_changed"].as_array().unwrap().len(), 0);
+    }
+
+    /// A session with no tool activity yet returns an empty `"agents"`
+    /// array, not an error.
+    #[tokio::test]
+    async fn get_agents_empty_session_returns_empty_array() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let result = get_agents(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result["agents"].as_array().unwrap().len(), 0);
+    }
+
+    /// An unknown session must map to `-32007 session_not_found`.
+    #[tokio::test]
+    async fn get_agents_unknown_session_maps_to_session_not_found() {
+        let registry = SessionRegistry::new();
+        let err = get_agents(&registry, json!({"session_id": "nope"}), test_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+}

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -114,6 +114,108 @@ struct SessionEntry {
     /// so a client that attaches AFTER the one-time `Event::IndexReadiness`
     /// fired can still retrieve the current state.
     readiness: Option<IndexReadinessSnapshot>,
+    /// (DOC-39 §5.4) Live per-agent roster, in first-seen order — the
+    /// AUTHORITATIVE state `session.get_agents` reads (see
+    /// `session::registry::agents`'s module docs). Updated by [`Self::record`]
+    /// (the SAME call every `record_tool_*` plumbing method already routes
+    /// through) whenever the event carries `agent`/`agent_id`, so it is
+    /// exactly as fresh as the ring buffer — but unlike `ring`, it is NEVER
+    /// evicted by `ring_capacity`. A code-critic HIGH on the #2962 PR caught
+    /// the bug this field exists to close: `session.get_agents` originally
+    /// FOLDED the bounded ring buffer directly, so a long-running agent's
+    /// `ToolStarted` could age out of the ring before any later attributed
+    /// event for that same `agent_id` landed, making it vanish from the
+    /// roster entirely — indistinguishable from "never spawned" while it may
+    /// still genuinely be running. A `Vec` (not a `HashMap`) because the
+    /// roster's first-seen ORDER is part of its contract and one session's
+    /// distinct-agent cardinality is small, so `record`'s linear find-or-insert
+    /// scan is cheap.
+    agents: Vec<AgentRosterState>,
+}
+
+/// One agent's live roster state inside a [`SessionEntry`] (DOC-39 §5.4) —
+/// see that field's own docs for why this exists separately from the ring
+/// buffer. `session::registry::agents::get_agents` reads this directly (not
+/// the ring) to build `session.get_agents`'s wire response.
+///
+/// Why: `agent_id` is stored inline (rather than as a `HashMap` key) so the
+/// containing `Vec`'s order doubles as the roster's first-seen order with no
+/// second parallel structure to keep in sync.
+/// What: `running` is `true` from the last-seen `ToolStarted` for this
+/// `agent_id` until the next `ToolFinished`/`ToolError`/telemetry event for
+/// the SAME id flips it back to `false` — see
+/// `session::registry::agents::tool_attribution`'s docs for why tool-dispatch
+/// ordering makes "last event wins" well-defined without needing to
+/// correlate `call_id`.
+struct AgentRosterState {
+    agent_id: String,
+    name: String,
+    running: bool,
+}
+
+impl SessionEntry {
+    /// Fold one event into `self.agents` (DOC-39 §5.4) if it carries
+    /// `agent`/`agent_id`; a no-op for every other `Event` variant.
+    ///
+    /// Why: the single update path for the always-retained roster — called
+    /// from [`SessionRegistry::record`] under the SAME lock that pushes onto
+    /// `ring`, so the two can never observe a different set of events.
+    /// What: find-or-insert by `agent_id` (empty ids are skipped — nothing
+    /// to key a roster row on), updating `name` (last-writer-wins) and
+    /// `running` (`true` only for `ToolStarted`; every other attributed kind
+    /// fires only after its tool call already completed — see
+    /// `session::registry::agents`'s module docs for the tool-dispatch
+    /// ordering that makes this well-defined).
+    fn note_agent_activity(&mut self, event: &Event) {
+        let Some((agent, agent_id, running)) = tool_attribution(event) else {
+            return;
+        };
+        if agent_id.is_empty() {
+            return;
+        }
+        match self.agents.iter_mut().find(|a| a.agent_id == agent_id) {
+            Some(existing) => {
+                existing.name = agent.to_string();
+                existing.running = running;
+            }
+            None => self.agents.push(AgentRosterState {
+                agent_id: agent_id.to_string(),
+                name: agent.to_string(),
+                running,
+            }),
+        }
+    }
+}
+
+/// Extract `(agent, agent_id, is_running)` from the attribution events the
+/// live roster (DOC-39 §5.4) cares about, or `None` for every other `Event`
+/// variant.
+///
+/// Why: shared by [`SessionEntry::note_agent_activity`] (the write path) and
+/// `session::registry::agents::get_agents`'s docs (which point back here) —
+/// centralises which events count as roster-relevant activity.
+/// What: `true` only for `ToolStarted`; every other attributed kind fires
+/// only after its tool call already completed
+/// (`ToolStarted` -> `ToolFinished`/`ToolError` -> optional telemetry).
+fn tool_attribution(event: &Event) -> Option<(&str, &str, bool)> {
+    match event {
+        Event::ToolStarted {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, true)),
+        Event::ToolFinished {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, false)),
+        Event::ToolError {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, false)),
+        Event::SearchPerformed {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, false)),
+        Event::MemoryRecalled {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, false)),
+        _ => None,
+    }
 }
 
 /// #2056: bookkeeping for one in-flight background task execution.
@@ -214,6 +316,7 @@ impl SessionRegistry {
                     pm_transcript: None,
                     memory_sink: None,
                     readiness: None,
+                    agents: Vec::new(),
                 },
             );
         }
@@ -818,7 +921,11 @@ impl SessionRegistry {
     /// Why: every lifecycle/tool/log/progress/message event goes through
     /// this ONE function so `seq` assignment, the ring buffer, and the live
     /// bus can never drift out of sync with each other — the correctness
-    /// property `attach_replay_then_live_seq_is_contiguous` verifies.
+    /// property `attach_replay_then_live_seq_is_contiguous` verifies. It is
+    /// ALSO the one place `SessionEntry::agents` (DOC-39 §5.4) is updated —
+    /// the same critical section that pushes onto the capacity-bounded
+    /// `ring`, so the always-retained roster and the ring can never observe
+    /// a different event even transiently.
     /// What: a no-op (no envelope built, nothing published) if `id` is
     /// unknown — callers that need a hard error check existence first
     /// (`send`, `cancel`, every `record_*` plumbing method all do).
@@ -834,6 +941,7 @@ impl SessionRegistry {
                 entry.ring.pop_front();
             }
             entry.ring.push_back(envelope.clone());
+            entry.note_agent_activity(&envelope.event);
             envelope
         };
         crate::events::publish(envelope);

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -940,6 +940,11 @@ mod memory_sink_ext;
 #[path = "registry_goals.rs"]
 mod goal_ops;
 
+/// `session.get_agents`'s live-roster fold (DOC-39 §5.4), split out into its
+/// own file for the same 500-SLOC-cap reason as `events` above.
+#[path = "registry_agents.rs"]
+mod agents;
+
 #[cfg(test)]
 #[path = "registry_tests.rs"]
 mod registry_tests;

--- a/crates/trusty-code/src/session/registry_agents.rs
+++ b/crates/trusty-code/src/session/registry_agents.rs
@@ -1,4 +1,4 @@
-//! `SessionRegistry::get_agents` — the live agent-roster fold behind
+//! `SessionRegistry::get_agents` — the live agent-roster query behind
 //! `session.get_agents` (DOC-39 §5.4). Split out of `registry.rs` purely to
 //! keep that production file under the crate's 500-SLOC cap — this is a
 //! child module of `registry` (declared via `#[path = ...] mod agents;`), so
@@ -10,18 +10,28 @@
 //! the shape §2.1 forbids (C-1: the daemon owns all logic; a client never
 //! derives). §5.4 names `session.get_agents` as "the principled endpoint;
 //! the fold is a Phase-1 loan, not a design" and directs that loan to be
-//! repaid by moving the fold server-side. This module is that repayment: the
-//! SAME fold, now performed once by the daemon over its own ring buffer
-//! rather than N times by N clients.
-//! What: [`get_agents`] folds a session's ring-buffer replay
-//! (`SessionRegistry::replay`, the same envelopes `session.attach`/the SSE
-//! route already expose) over the tool-attribution events every agent-loop
-//! tool dispatch already emits (`ToolStarted`/`ToolFinished`/`ToolError`/
-//! `SearchPerformed`/`MemoryRecalled` — all carry `agent` + `agent_id` since
-//! #2898/DOC-39 AC-13), producing one [`AgentRosterEntry`] per distinct
-//! `agent_id` in first-seen order. `state` is derived from the LAST
-//! attribution event seen for that `agent_id`: `"running"` if it was a
-//! `ToolStarted` with no later event for that id, `"idle"` otherwise.
+//! repaid by moving the fold server-side.
+//!
+//! **This module went through two designs, and the first one had a bug a
+//! code-critic review on the #2962 PR caught as a HIGH.** The first cut
+//! folded `SessionRegistry::replay`'s ring-buffer snapshot on every
+//! `get_agents` call. That moved WHERE the fold ran (daemon, not client) but
+//! not WHAT it could lose: the ring buffer is capacity-bounded
+//! (`ring_capacity`, default [`super::DEFAULT_RING_CAPACITY`]) and evicts
+//! oldest-first, so a long-running agent's `ToolStarted` could age out of
+//! the ring before any LATER attributed event for that same `agent_id`
+//! landed — making it vanish from the roster entirely, indistinguishable
+//! from "never spawned" even though it may still genuinely be running. That
+//! is the exact silent-data-loss shape §5.4's original text warned about;
+//! folding server-side did not close it.
+//! What: [`get_agents`] instead reads `SessionEntry::agents` — an
+//! ALWAYS-RETAINED `Vec<AgentRosterState>`, kept up to date by
+//! `SessionEntry::note_agent_activity` (called from
+//! `SessionRegistry::record`, the SAME critical section that pushes onto the
+//! ring — see that field's own docs in `registry.rs`) and evicted only when
+//! the session itself goes away, never by ring capacity. This closes the
+//! HIGH: an agent's roster row survives for the life of the session
+//! regardless of how much ring-buffer traffic follows it.
 //!
 //! **What is NOT populated, and why (§5.4 AC-15.1 is only partially met):**
 //! - `model` — always `None`. No production event ties a resolved model
@@ -40,35 +50,32 @@
 //!   they are net-new domain state, not a folding gap.
 //!
 //! `AgentSpawned`/`AgentStarted`/`AgentDone`/`AgentFailed` (DOC-39 AC-13)
-//! are NOT folded here even though their shape looks purpose-built for a
+//! are NOT sources here even though their shape looks purpose-built for a
 //! roster: `events.rs`'s own docs and #2898's CHANGELOG entry record that
-//! none of them are emitted by any production call site yet, so folding them
-//! would silently return an always-empty roster instead of the real,
-//! already-flowing tool-attribution activity.
+//! none of them are emitted by any production call site yet, so keying off
+//! them would silently return an always-empty roster instead of the real,
+//! already-flowing tool-attribution activity `registry.rs::tool_attribution`
+//! sources from.
 //! Test: `registry_agents::tests::*`; `protocol_agents::tests::*` covers the
 //! RPC-level wiring.
-
-use std::collections::HashMap;
 
 use serde::Serialize;
 
 use super::*;
-use crate::events::Event;
 
-/// `state` value for an agent whose most recent attributed event is a
-/// `ToolStarted` with no later attributed event on record — a tool call is
-/// (as far as the ring buffer shows) still in flight.
+/// `state` value for an agent whose live roster row (`AgentRosterState`) is
+/// currently `running: true` — its last known event is an unmatched
+/// `ToolStarted`.
 const STATE_RUNNING: &str = "running";
-/// `state` value for an agent whose most recent attributed event is a
-/// completion (`ToolFinished`/`ToolError`/`SearchPerformed`/
-/// `MemoryRecalled`) — no tool call is known to be in flight.
+/// `state` value for an agent whose live roster row is `running: false` — no
+/// tool call is known to be in flight.
 const STATE_IDLE: &str = "idle";
 
 /// One entry in `session.get_agents`'s live roster (DOC-39 §5.4).
 ///
 /// Why: the wire shape `session.get_agents` returns per agent — see the
-/// module docs for exactly which fields are folded from real state and which
-/// are deferred defaults.
+/// module docs for exactly which fields are read from the always-retained
+/// `SessionEntry::agents` state and which are deferred defaults.
 /// What: `agent_id` is the DOC-39 AC-13 stable per-spawn id; `name` is the
 /// human-readable agent name (`"pm"` for the root loop, an agent config name
 /// like `"python-engineer"` for a delegation). See module docs for
@@ -85,87 +92,44 @@ pub struct AgentRosterEntry {
     pub files_changed: Vec<String>,
 }
 
-/// Extract `(agent, agent_id, is_running)` from the attribution events the
-/// roster fold cares about, or `None` for every other `Event` variant.
-///
-/// Why: centralises which events count as roster-relevant activity — see the
-/// module docs for the full attribution list and the tool-dispatch ordering
-/// (`ToolStarted` -> `ToolFinished`/`ToolError` -> optional telemetry) that
-/// makes `is_running` well-defined from event KIND alone, with no need to
-/// correlate `call_id`.
-/// What: `true` only for `ToolStarted`; every other attributed kind fires
-/// only after its tool call already completed.
-fn tool_attribution(event: &Event) -> Option<(&str, &str, bool)> {
-    match event {
-        Event::ToolStarted {
-            agent, agent_id, ..
-        } => Some((agent, agent_id, true)),
-        Event::ToolFinished {
-            agent, agent_id, ..
-        } => Some((agent, agent_id, false)),
-        Event::ToolError {
-            agent, agent_id, ..
-        } => Some((agent, agent_id, false)),
-        Event::SearchPerformed {
-            agent, agent_id, ..
-        } => Some((agent, agent_id, false)),
-        Event::MemoryRecalled {
-            agent, agent_id, ..
-        } => Some((agent, agent_id, false)),
-        _ => None,
-    }
-}
-
 impl SessionRegistry {
     /// `session.get_agents(session_id) -> { agents: [AgentRosterEntry] }`
     /// (DOC-39 §5.4).
     ///
-    /// Why: the principled, daemon-owned replacement for the client-side
-    /// ring-buffer fold §5.4 acknowledges as a time-boxed Phase-1 loan — see
-    /// the module docs.
-    /// What: `-32007 session_not_found` if `id` is unknown (via
-    /// [`Self::replay`]). Otherwise folds the ring-buffer replay into one
-    /// [`AgentRosterEntry`] per distinct `agent_id`, in the order each
-    /// `agent_id` was first seen. A session with no tool activity yet
-    /// returns an empty roster, not an error — the same "empty means nothing
-    /// yet" convention `session.get_goals`/`session.get_transcript` use.
+    /// Why: the principled, daemon-owned, EVICTION-SAFE replacement for the
+    /// client-side ring-buffer fold §5.4 originally acknowledged as a
+    /// time-boxed Phase-1 loan — see the module docs for why reading the
+    /// bounded ring directly (this endpoint's first cut) was itself still a
+    /// silent-data-loss bug, not a fix.
+    /// What: `-32007 session_not_found` if `id` is unknown. Otherwise
+    /// projects `SessionEntry::agents` (the always-retained per-agent
+    /// roster, in first-seen order) into one [`AgentRosterEntry`] per row. A
+    /// session with no tool activity yet returns an empty roster, not an
+    /// error — the same "empty means nothing yet" convention
+    /// `session.get_goals`/`session.get_transcript` use.
     /// Test: `registry_agents::tests::get_agents_empty_session_returns_empty_roster`,
     /// `registry_agents::tests::get_agents_running_tool_reports_running_state`,
     /// `registry_agents::tests::get_agents_finished_tool_reports_idle_state`,
+    /// `registry_agents::tests::get_agents_distinguishes_same_named_concurrent_spawns`,
+    /// `registry_agents::tests::get_agents_survives_ring_eviction`,
     /// `registry_agents::tests::get_agents_unknown_session_errors`.
     pub fn get_agents(&self, id: &str) -> Result<Vec<AgentRosterEntry>, RpcError> {
-        let envelopes = self.replay(id)?;
-        let mut order: Vec<String> = Vec::new();
-        let mut roster: HashMap<String, AgentRosterEntry> = HashMap::new();
-
-        for envelope in &envelopes {
-            let Some((agent, agent_id, running)) = tool_attribution(&envelope.event) else {
-                continue;
-            };
-            if agent_id.is_empty() {
-                // Pre-#2898 recorded events (or a test double) with no
-                // stable id — nothing to key a roster row on.
-                continue;
-            }
-            let entry = roster.entry(agent_id.to_string()).or_insert_with(|| {
-                order.push(agent_id.to_string());
-                AgentRosterEntry {
-                    agent_id: agent_id.to_string(),
-                    name: agent.to_string(),
-                    model: None,
-                    state: STATE_IDLE.to_string(),
-                    task: None,
-                    todos: Vec::new(),
-                    files_changed: Vec::new(),
-                }
-            });
-            entry.name = agent.to_string();
-            entry.state = if running { STATE_RUNNING } else { STATE_IDLE }.to_string();
-        }
-
-        Ok(order
-            .into_iter()
-            .filter_map(|id| roster.remove(&id))
+        let sessions = self.lock();
+        let entry = sessions
+            .get(id)
+            .ok_or_else(|| RpcError::session_not_found(id))?;
+        Ok(entry
+            .agents
+            .iter()
+            .map(|a| AgentRosterEntry {
+                agent_id: a.agent_id.clone(),
+                name: a.name.clone(),
+                model: None,
+                state: if a.running { STATE_RUNNING } else { STATE_IDLE }.to_string(),
+                task: None,
+                todos: Vec::new(),
+                files_changed: Vec::new(),
+            })
             .collect())
     }
 }
@@ -253,6 +217,69 @@ mod tests {
         assert_eq!(roster[0].agent_id, "spawn-a");
         assert_eq!(roster[1].agent_id, "spawn-b");
         assert!(roster.iter().all(|a| a.name == "python-engineer"));
+    }
+
+    /// THE code-critic HIGH this module's second design closes: an agent
+    /// whose `ToolStarted` has aged OUT of the (here, tiny) ring buffer must
+    /// still appear in `get_agents`, still `"running"` — the ring's bounded
+    /// capacity must never be able to make a still-running agent vanish from
+    /// the roster. Uses `SessionRegistry::with_capacity` (the same seam
+    /// `registry_tests.rs` uses for `ring_buffer_drops_oldest_when_full`) to
+    /// force eviction cheaply instead of pushing thousands of events.
+    #[test]
+    fn get_agents_survives_ring_eviction() {
+        let registry = SessionRegistry::with_capacity(2);
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        // Agent A starts a tool call — its `ToolStarted` is recorded at some
+        // early `seq`.
+        registry
+            .record_tool_started(&session.id, "python-engineer", "agent-a", "bash", "c1", "x")
+            .unwrap();
+
+        // Agent B then starts and finishes enough tool calls to push A's
+        // `ToolStarted` out of the (capacity-2) ring buffer entirely.
+        for i in 0..5 {
+            let call_id = format!("b-{i}");
+            registry
+                .record_tool_started(&session.id, "engineer-b", "agent-b", "bash", &call_id, "y")
+                .unwrap();
+            registry
+                .record_tool_finished(
+                    &session.id,
+                    "engineer-b",
+                    "agent-b",
+                    "bash",
+                    &call_id,
+                    true,
+                    "ok",
+                )
+                .unwrap();
+        }
+
+        // Sanity check: A's `ToolStarted` really is no longer in the replay
+        // — this test would be vacuous otherwise.
+        let replay = registry.replay(&session.id).unwrap();
+        assert!(
+            !replay.iter().any(|e| matches!(
+                &e.event,
+                crate::events::Event::ToolStarted { agent_id, .. } if agent_id == "agent-a"
+            )),
+            "test setup bug: agent-a's ToolStarted must have been evicted from the ring"
+        );
+
+        // THE assertion: agent-a still appears in the roster, still
+        // "running" — the always-retained map survived what the ring did not.
+        let roster = registry.get_agents(&session.id).unwrap();
+        let agent_a = roster
+            .iter()
+            .find(|a| a.agent_id == "agent-a")
+            .unwrap_or_else(|| panic!("agent-a must survive ring eviction: {roster:?}"));
+        assert_eq!(agent_a.state, "running");
+        assert_eq!(agent_a.name, "python-engineer");
+
+        let agent_b = roster.iter().find(|a| a.agent_id == "agent-b").unwrap();
+        assert_eq!(agent_b.state, "idle");
     }
 
     /// An unknown session must map to `-32007 session_not_found`.

--- a/crates/trusty-code/src/session/registry_agents.rs
+++ b/crates/trusty-code/src/session/registry_agents.rs
@@ -1,0 +1,265 @@
+//! `SessionRegistry::get_agents` — the live agent-roster fold behind
+//! `session.get_agents` (DOC-39 §5.4). Split out of `registry.rs` purely to
+//! keep that production file under the crate's 500-SLOC cap — this is a
+//! child module of `registry` (declared via `#[path = ...] mod agents;`), so
+//! it shares full access to `SessionRegistry`'s private helpers exactly as
+//! if these methods were still defined in that file.
+//!
+//! Why: DOC-39 §3.2/§5.4 documents that "who is running?" was daemon-owned
+//! state a UI client had to reconstruct itself by folding the SSE replay —
+//! the shape §2.1 forbids (C-1: the daemon owns all logic; a client never
+//! derives). §5.4 names `session.get_agents` as "the principled endpoint;
+//! the fold is a Phase-1 loan, not a design" and directs that loan to be
+//! repaid by moving the fold server-side. This module is that repayment: the
+//! SAME fold, now performed once by the daemon over its own ring buffer
+//! rather than N times by N clients.
+//! What: [`get_agents`] folds a session's ring-buffer replay
+//! (`SessionRegistry::replay`, the same envelopes `session.attach`/the SSE
+//! route already expose) over the tool-attribution events every agent-loop
+//! tool dispatch already emits (`ToolStarted`/`ToolFinished`/`ToolError`/
+//! `SearchPerformed`/`MemoryRecalled` — all carry `agent` + `agent_id` since
+//! #2898/DOC-39 AC-13), producing one [`AgentRosterEntry`] per distinct
+//! `agent_id` in first-seen order. `state` is derived from the LAST
+//! attribution event seen for that `agent_id`: `"running"` if it was a
+//! `ToolStarted` with no later event for that id, `"idle"` otherwise.
+//!
+//! **What is NOT populated, and why (§5.4 AC-15.1 is only partially met):**
+//! - `model` — always `None`. No production event ties a resolved model
+//!   string to a stable `agent_id` yet; `LlmRequested`/`LlmResponded` carry
+//!   `model`, but only `agent_name` (a string DOC-39 AC-13.2 explicitly
+//!   retires as a correlation key), and folding by name would silently
+//!   misattribute the model when two same-named agents run concurrently —
+//!   exactly the bug #2898 existed to close. Closing this gap needs `model`
+//!   threaded onto an `agent_id`-carrying event, which is out of this
+//!   endpoint's scope.
+//! - `task` — always `None`. `PmDelegating.agent`/`task_preview` predates
+//!   `agent_id` and is keyed by name only, so it cannot be joined onto a
+//!   specific spawn without the same name-collision risk as `model` above.
+//! - `todos`, `files_changed` — always `[]`. No event or registry state
+//!   tracks either today; §5.4 lists them in the target result shape but
+//!   they are net-new domain state, not a folding gap.
+//!
+//! `AgentSpawned`/`AgentStarted`/`AgentDone`/`AgentFailed` (DOC-39 AC-13)
+//! are NOT folded here even though their shape looks purpose-built for a
+//! roster: `events.rs`'s own docs and #2898's CHANGELOG entry record that
+//! none of them are emitted by any production call site yet, so folding them
+//! would silently return an always-empty roster instead of the real,
+//! already-flowing tool-attribution activity.
+//! Test: `registry_agents::tests::*`; `protocol_agents::tests::*` covers the
+//! RPC-level wiring.
+
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+use super::*;
+use crate::events::Event;
+
+/// `state` value for an agent whose most recent attributed event is a
+/// `ToolStarted` with no later attributed event on record — a tool call is
+/// (as far as the ring buffer shows) still in flight.
+const STATE_RUNNING: &str = "running";
+/// `state` value for an agent whose most recent attributed event is a
+/// completion (`ToolFinished`/`ToolError`/`SearchPerformed`/
+/// `MemoryRecalled`) — no tool call is known to be in flight.
+const STATE_IDLE: &str = "idle";
+
+/// One entry in `session.get_agents`'s live roster (DOC-39 §5.4).
+///
+/// Why: the wire shape `session.get_agents` returns per agent — see the
+/// module docs for exactly which fields are folded from real state and which
+/// are deferred defaults.
+/// What: `agent_id` is the DOC-39 AC-13 stable per-spawn id; `name` is the
+/// human-readable agent name (`"pm"` for the root loop, an agent config name
+/// like `"python-engineer"` for a delegation). See module docs for
+/// `model`/`task`/`todos`/`files_changed`.
+/// Test: `registry_agents::tests::*`.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentRosterEntry {
+    pub agent_id: String,
+    pub name: String,
+    pub model: Option<String>,
+    pub state: String,
+    pub task: Option<String>,
+    pub todos: Vec<String>,
+    pub files_changed: Vec<String>,
+}
+
+/// Extract `(agent, agent_id, is_running)` from the attribution events the
+/// roster fold cares about, or `None` for every other `Event` variant.
+///
+/// Why: centralises which events count as roster-relevant activity — see the
+/// module docs for the full attribution list and the tool-dispatch ordering
+/// (`ToolStarted` -> `ToolFinished`/`ToolError` -> optional telemetry) that
+/// makes `is_running` well-defined from event KIND alone, with no need to
+/// correlate `call_id`.
+/// What: `true` only for `ToolStarted`; every other attributed kind fires
+/// only after its tool call already completed.
+fn tool_attribution(event: &Event) -> Option<(&str, &str, bool)> {
+    match event {
+        Event::ToolStarted {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, true)),
+        Event::ToolFinished {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, false)),
+        Event::ToolError {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, false)),
+        Event::SearchPerformed {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, false)),
+        Event::MemoryRecalled {
+            agent, agent_id, ..
+        } => Some((agent, agent_id, false)),
+        _ => None,
+    }
+}
+
+impl SessionRegistry {
+    /// `session.get_agents(session_id) -> { agents: [AgentRosterEntry] }`
+    /// (DOC-39 §5.4).
+    ///
+    /// Why: the principled, daemon-owned replacement for the client-side
+    /// ring-buffer fold §5.4 acknowledges as a time-boxed Phase-1 loan — see
+    /// the module docs.
+    /// What: `-32007 session_not_found` if `id` is unknown (via
+    /// [`Self::replay`]). Otherwise folds the ring-buffer replay into one
+    /// [`AgentRosterEntry`] per distinct `agent_id`, in the order each
+    /// `agent_id` was first seen. A session with no tool activity yet
+    /// returns an empty roster, not an error — the same "empty means nothing
+    /// yet" convention `session.get_goals`/`session.get_transcript` use.
+    /// Test: `registry_agents::tests::get_agents_empty_session_returns_empty_roster`,
+    /// `registry_agents::tests::get_agents_running_tool_reports_running_state`,
+    /// `registry_agents::tests::get_agents_finished_tool_reports_idle_state`,
+    /// `registry_agents::tests::get_agents_unknown_session_errors`.
+    pub fn get_agents(&self, id: &str) -> Result<Vec<AgentRosterEntry>, RpcError> {
+        let envelopes = self.replay(id)?;
+        let mut order: Vec<String> = Vec::new();
+        let mut roster: HashMap<String, AgentRosterEntry> = HashMap::new();
+
+        for envelope in &envelopes {
+            let Some((agent, agent_id, running)) = tool_attribution(&envelope.event) else {
+                continue;
+            };
+            if agent_id.is_empty() {
+                // Pre-#2898 recorded events (or a test double) with no
+                // stable id — nothing to key a roster row on.
+                continue;
+            }
+            let entry = roster.entry(agent_id.to_string()).or_insert_with(|| {
+                order.push(agent_id.to_string());
+                AgentRosterEntry {
+                    agent_id: agent_id.to_string(),
+                    name: agent.to_string(),
+                    model: None,
+                    state: STATE_IDLE.to_string(),
+                    task: None,
+                    todos: Vec::new(),
+                    files_changed: Vec::new(),
+                }
+            });
+            entry.name = agent.to_string();
+            entry.state = if running { STATE_RUNNING } else { STATE_IDLE }.to_string();
+        }
+
+        Ok(order
+            .into_iter()
+            .filter_map(|id| roster.remove(&id))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A session with no recorded tool activity returns an empty roster, not
+    /// an error.
+    #[test]
+    fn get_agents_empty_session_returns_empty_roster() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let roster = registry.get_agents(&session.id).unwrap();
+
+        assert!(roster.is_empty());
+    }
+
+    /// An agent whose most recent event is `ToolStarted` reports `"running"`.
+    #[test]
+    fn get_agents_running_tool_reports_running_state() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        registry
+            .record_tool_started(
+                &session.id,
+                "python-engineer",
+                "eng-1",
+                "bash",
+                "c1",
+                "cargo test",
+            )
+            .unwrap();
+
+        let roster = registry.get_agents(&session.id).unwrap();
+
+        assert_eq!(roster.len(), 1);
+        assert_eq!(roster[0].agent_id, "eng-1");
+        assert_eq!(roster[0].name, "python-engineer");
+        assert_eq!(roster[0].state, "running");
+        assert_eq!(roster[0].model, None);
+        assert_eq!(roster[0].task, None);
+        assert!(roster[0].todos.is_empty());
+        assert!(roster[0].files_changed.is_empty());
+    }
+
+    /// Once the started tool call finishes, that agent's state flips to
+    /// `"idle"`.
+    #[test]
+    fn get_agents_finished_tool_reports_idle_state() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        registry
+            .record_tool_started(&session.id, "pm", "pm-1", "bash", "c1", "echo hi")
+            .unwrap();
+        registry
+            .record_tool_finished(&session.id, "pm", "pm-1", "bash", "c1", true, "hi")
+            .unwrap();
+
+        let roster = registry.get_agents(&session.id).unwrap();
+
+        assert_eq!(roster.len(), 1);
+        assert_eq!(roster[0].state, "idle");
+    }
+
+    /// Two distinct `agent_id`s produce two roster rows, in first-seen order,
+    /// even when they share the same agent NAME — the DOC-39 AC-13 case this
+    /// endpoint exists to make queryable.
+    #[test]
+    fn get_agents_distinguishes_same_named_concurrent_spawns() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        registry
+            .record_tool_started(&session.id, "python-engineer", "spawn-a", "bash", "c1", "x")
+            .unwrap();
+        registry
+            .record_tool_started(&session.id, "python-engineer", "spawn-b", "bash", "c2", "y")
+            .unwrap();
+
+        let roster = registry.get_agents(&session.id).unwrap();
+
+        assert_eq!(roster.len(), 2);
+        assert_eq!(roster[0].agent_id, "spawn-a");
+        assert_eq!(roster[1].agent_id, "spawn-b");
+        assert!(roster.iter().all(|a| a.name == "python-engineer"));
+    }
+
+    /// An unknown session must map to `-32007 session_not_found`.
+    #[test]
+    fn get_agents_unknown_session_errors() {
+        let registry = SessionRegistry::new();
+        let err = registry.get_agents("nope").unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+}

--- a/crates/trusty-code/tests/agents_e2e.rs
+++ b/crates/trusty-code/tests/agents_e2e.rs
@@ -1,0 +1,113 @@
+//! API-driven end-to-end test for DOC-39 §5.4's `session.get_agents` live
+//! agent-roster RPC.
+//!
+//! Why: `session::registry::agents::get_agents`'s unit tests (and
+//! `session::protocol::protocol_agents`'s handler tests) seed roster state
+//! directly via `SessionRegistry::record_tool_started`/`record_tool_finished`
+//! — real registry plumbing, but never proven against an actual PM ->
+//! delegated-engineer run driven through a real `tcode serve --stdio`
+//! process, which is what a genuine client sees. This test drives the REAL
+//! daemon (never `trusty_code`'s Rust API directly — the same black-box
+//! discipline `tests/task_e2e.rs`/`tests/readiness_e2e.rs` follow), using
+//! `TCODE_MOCK_LLM=echo` for deterministic, offline `task.run` execution.
+//! What: [`completed_run_reports_pm_and_delegated_engineer_in_the_roster`]
+//! runs a task to completion (the `pm.md` fixture always delegates to
+//! `python-engineer`, per `tests/task_e2e.rs`'s shared `project_with_agents`
+//! fixture and `EchoLlmClient`'s fixed script), then calls
+//! `session.get_agents` and asserts the roster contains BOTH the PM's own
+//! spawn and the delegated engineer's spawn, each with a real (non-empty)
+//! `agent_id` and `state: "idle"` once the run has finished.
+//! [`never_run_session_returns_an_empty_roster_over_the_wire`] proves the
+//! other half: a session that never ran a task has recorded no tool
+//! attribution, so the roster is `[]`, not an error.
+//! Test: this file IS the test; see `support` for the process/protocol
+//! plumbing shared with `session_e2e.rs`/`task_e2e.rs`/`readiness_e2e.rs`.
+
+mod support;
+
+use serde_json::json;
+use support::{StdioSession, project_with_agents, run_task_to_completion};
+
+/// A completed PM -> delegated-engineer run must report both spawns in
+/// `session.get_agents`'s roster, each with a real per-spawn `agent_id` and
+/// `state: "idle"` (no tool call left in flight once the run is done).
+#[tokio::test]
+async fn completed_run_reports_pm_and_delegated_engineer_in_the_roster() {
+    let project = project_with_agents();
+    let mut daemon = StdioSession::spawn_with_mock_llm(project.path());
+
+    let session_id = run_task_to_completion(&mut daemon, "say hi").await;
+
+    let agents_resp = daemon
+        .call(3, "session.get_agents", json!({"session_id": session_id}))
+        .await;
+    assert!(
+        agents_resp["error"].is_null(),
+        "get_agents failed: {agents_resp}"
+    );
+    let agents = agents_resp["result"]["agents"]
+        .as_array()
+        .expect("get_agents must return an agents array");
+
+    let names: Vec<&str> = agents
+        .iter()
+        .map(|a| a["name"].as_str().expect("name must be a string"))
+        .collect();
+    assert!(
+        names.contains(&"pm"),
+        "roster must include the PM's own spawn: {agents:?}"
+    );
+    assert!(
+        names.contains(&"python-engineer"),
+        "roster must include the delegated engineer's spawn: {agents:?}"
+    );
+
+    for agent in agents {
+        assert!(
+            !agent["agent_id"]
+                .as_str()
+                .expect("agent_id must be a string")
+                .is_empty(),
+            "every roster entry must carry a real agent_id: {agent}"
+        );
+        assert_eq!(
+            agent["state"], "idle",
+            "a finished run must leave every agent idle, not running: {agent}"
+        );
+        // §5.4's acknowledged deferrals — see `session::registry::agents`'s
+        // module docs for why these are not yet foldable from real state.
+        assert!(agent["model"].is_null());
+        assert!(agent["task"].is_null());
+        assert_eq!(agent["todos"].as_array().unwrap().len(), 0);
+        assert_eq!(agent["files_changed"].as_array().unwrap().len(), 0);
+    }
+}
+
+/// A session with no `task.run` ever executed against it has recorded no
+/// tool attribution, so `session.get_agents` must return an empty roster —
+/// not an error.
+#[tokio::test]
+async fn never_run_session_returns_an_empty_roster_over_the_wire() {
+    let mut daemon = StdioSession::spawn();
+
+    let create_resp = daemon
+        .call(1, "session.create", json!({"task": "never runs a task"}))
+        .await;
+    assert!(
+        create_resp["error"].is_null(),
+        "session.create failed: {create_resp}"
+    );
+    let session_id = create_resp["result"]["id"]
+        .as_str()
+        .expect("session.create must return an id")
+        .to_string();
+
+    let agents_resp = daemon
+        .call(2, "session.get_agents", json!({"session_id": session_id}))
+        .await;
+    assert!(
+        agents_resp["error"].is_null(),
+        "get_agents failed: {agents_resp}"
+    );
+    assert_eq!(agents_resp["result"], json!({"agents": []}));
+}

--- a/docs/specs/trusty-code-harness-ui.md
+++ b/docs/specs/trusty-code-harness-ui.md
@@ -688,7 +688,7 @@ JSON-RPC method or a new/extended `Event` variant.
 | 5 | Working-context budget (status bar) | `Event::ContextBudget{working_pct,overhead_pct,within_budget,fired}` | **MISSING** (discarded) | Stop dropping `CadenceOutcome` |
 | 6 | Goal slots (§4.5) | `session.get_goals` / `set_goal` / `clear_goal` | **EXISTS** | **none — UI wiring only** |
 | 7 | Projectless + binding (7a, §4.2) | `task.run` `project` → optional; unify with `session.create` | **PARTIAL** | Type change + reconciliation |
-| 8 | Agent roster (10b, 11a) | `session.get_agents` snapshot + `model` field | **EXISTS** | `session.get_agents` ships (closes #2962); `model` field remains deferred — see §5.4 |
+| 8 | Agent roster (10b, 11a) | `session.get_agents` snapshot + `model` field | **EXISTS** | `session.get_agents` ships, backed by an always-retained per-session map (not a ring-buffer fold) so it cannot lose a still-running agent to eviction (closes #2962); `model` field remains deferred — see §5.4 |
 | 9 | Workstream list/resume (7a/7b switcher) | Workstream domain object + persistence + `workstream.list` | **MISSING** | Domain + storage (§4B) |
 | 10 | Workflow lanes (10e) | Branch/PR/dirty-tree subsystem | **MISSING** | New subsystem, nothing to build on |
 | 11 | Clone-from-URL (7a) | `project.clone_from_url` | **MISSING** | Not present anywhere. Daemon capability when it lands (§5.8) |
@@ -762,18 +762,31 @@ from a preview string.
 was returned by the query. A held-back recall is the operator's evidence that the
 harness *chose*; conflating the two silently voids the core bet.
 
-### 5.4 Agent roster (EXISTS — endpoint shipped; `model` still deferred)
+### 5.4 Agent roster (EXISTS — endpoint shipped, eviction-safe; `model` still deferred)
 
-**Shipped (closes #2962).** `session.get_agents` now exists — the daemon folds a
-session's ring-buffer replay over the `agent`/`agent_id`-carrying tool-attribution
-events (`ToolStarted`/`ToolFinished`/`ToolError`/`SearchPerformed`/`MemoryRecalled`,
-#2898) server-side, repaying the §2.1 fold-in-the-client loan this section
-originally recorded. `AgentSpawned/AgentStarted/AgentDone/AgentFailed/PmDelegating`
-still exist as unused-in-production event shapes (`events.rs:186-211,312-316`) —
-see `session::registry::agents`'s module docs for why they are not folded. `model`
-remains unpopulated: it lives only on `LlmRequested/LlmResponded`, correlated by
-`agent_name` **string**, which AC-13.2 retires as a correlation key — so folding it
-onto `agent_id` would reintroduce the exact same-name collision bug #2898 closed.
+**Shipped (closes #2962).** `session.get_agents` now exists, backed by an
+ALWAYS-RETAINED per-session agent map (`SessionEntry::agents`,
+`registry.rs`) — not a fold over the capacity-bounded ring buffer. A first
+cut folded `SessionRegistry::replay`'s ring-buffer snapshot on every call;
+code-critic flagged that as a HIGH, because the ring evicts oldest-first
+(`ring_capacity`, default 1000) and a long-running agent's `ToolStarted`
+could age out of it before any later attributed event for that same
+`agent_id` landed — making the agent vanish from the roster entirely,
+indistinguishable from "never spawned" while it may still genuinely be
+running. That was the exact silent-data-loss shape this section originally
+warned about; moving the fold server-side had fixed WHERE it ran but not
+WHAT it could lose. The shipped design closes that: `SessionRegistry::record`
+— the SAME critical section that pushes onto the ring for every
+`agent`/`agent_id`-carrying event (`ToolStarted`/`ToolFinished`/`ToolError`/
+`SearchPerformed`/`MemoryRecalled`, #2898) — also updates the per-session
+map, which is evicted only when the session itself goes away, never by ring
+capacity. `AgentSpawned/AgentStarted/AgentDone/AgentFailed/PmDelegating`
+still exist as unused-in-production event shapes (`events.rs:186-211,312-316`)
+— see `session::registry::agents`'s module docs for why they are not
+sources. `model` remains unpopulated: it lives only on
+`LlmRequested/LlmResponded`, correlated by `agent_name` **string**, which
+AC-13.2 retires as a correlation key — so folding it onto `agent_id` would
+reintroduce the exact same-name collision bug #2898 closed.
 
 ```rust
 session.get_agents() -> { agents: [{ agent_id, name, model, state, task, todos, files_changed }] }
@@ -782,16 +795,23 @@ session.get_agents() -> { agents: [{ agent_id, name, model, state, task, todos, 
 **AC-15.1** `model` is carried on agent lifecycle events, not correlated by name.
 **NOT YET MET** — tracked as the remaining gap above, not closed by #2962.
 **AC-15.2** A late-joining client can render the roster. **MET as of #2962** —
-`session.get_agents` folds the ring buffer server-side, so a late-attaching client
-gets one RPC call instead of replaying and folding the SSE stream itself.
+`session.get_agents` reads the always-retained per-session map, so a
+late-attaching client gets one RPC call, with no ring-eviction risk, instead
+of replaying and folding the SSE stream itself.
 
-> **§2.1 tension — RESOLVED by #2962 for the roster shape itself; `model` (AC-15.1)
-> remains open.** This section previously recorded event-folding as a time-boxed
-> Phase-1 loan: "who is running?" was daemon-owned state a UI client had to
-> reconstruct by folding the SSE replay — the shape C-1 forbids. `session.get_agents`
-> repays that loan — the fold now runs once, in the daemon, over its own ring buffer.
-> The `model` gap is a separate, still-open debt (see above), not a re-opening of the
-> folding-in-the-client concern this callout originally raised.
+> **§2.1 tension — GENUINELY RESOLVED by #2962: both the C-1 thin-client
+> concern and the ring-eviction concern.** This section previously recorded
+> event-folding as a time-boxed Phase-1 loan on TWO counts: (1) "who is
+> running?" was daemon-owned state a UI client had to reconstruct by folding
+> the SSE replay — the shape C-1 forbids; (2) even a daemon-side fold over
+> the bounded ring would silently lose an agent once its `ToolStarted` aged
+> out. `session.get_agents` closes both: the daemon owns the computation
+> (no client-side derivation), and the state it reads
+> (`SessionEntry::agents`) is retained for the life of the session
+> independent of ring capacity, so it can never silently lose a still-running
+> agent to eviction. The `model` gap (AC-15.1) is a separate, still-open
+> debt (see above), not a re-opening of either concern this callout
+> originally raised.
 
 ### 5.5 Project binding (PARTIAL — the two surfaces must converge)
 
@@ -994,7 +1014,7 @@ the Workflow tab, the IDE half, or clone-from-URL.
 | **Workstream persistence** (§4B) | Real **domain + storage** work — deciding what a workstream *is*, not adding an endpoint. The largest item in the spec. Phase 1 ships value on the existing registry without it. |
 | **Per-line diff attribution UI** (10a gutter) | **Depends on §5.2** (`agent_id`). Ship the schema first; the gutter is a downstream consumer. |
 | **Workflow / delivery pipeline** (10e) | **New subsystem, nothing to build on** — no branch/PR/dirty-tree concept exists anywhere (§5.7). Also git-only, so it needs §4.2 settled first. |
-| **Agent roster `model` field** (10b) | **Shipped except `model`** — `session.get_agents` (§5.4) landed with #2962, closing the §2.1 client-side-fold tension. `model` per `agent_id` is the one still-deferred sub-item; see §5.4. |
+| **Agent roster `model` field** (10b) | **Shipped except `model`** — `session.get_agents` (§5.4) landed with #2962, backed by an always-retained per-session map (not a ring-buffer fold), closing BOTH the §2.1 client-side-fold tension AND the ring-eviction data-loss risk. `model` per `agent_id` is the one still-deferred sub-item; see §5.4. |
 | **Clone-from-URL** (7a) | Does not exist anywhere; pure additive scope with no dependents. Local-folder binding (`project.list_dir`, §5.8) covers the mandated projectless→bound path. **When it lands it is `project.clone_from_url` on the daemon — never a UI-side git op** (§5.8). |
 | **Monitor columns** (9b) | Demoted to transient trace mode (§4.6.1); the 8b inline card delivers the same trace at full width. |
 

--- a/docs/specs/trusty-code-harness-ui.md
+++ b/docs/specs/trusty-code-harness-ui.md
@@ -688,7 +688,7 @@ JSON-RPC method or a new/extended `Event` variant.
 | 5 | Working-context budget (status bar) | `Event::ContextBudget{working_pct,overhead_pct,within_budget,fired}` | **MISSING** (discarded) | Stop dropping `CadenceOutcome` |
 | 6 | Goal slots (§4.5) | `session.get_goals` / `set_goal` / `clear_goal` | **EXISTS** | **none — UI wiring only** |
 | 7 | Projectless + binding (7a, §4.2) | `task.run` `project` → optional; unify with `session.create` | **PARTIAL** | Type change + reconciliation |
-| 8 | Agent roster (10b, 11a) | `session.get_agents` snapshot + `model` field | **PARTIAL** | Event-folding is an acceptable stopgap |
+| 8 | Agent roster (10b, 11a) | `session.get_agents` snapshot + `model` field | **EXISTS** | `session.get_agents` ships (closes #2962); `model` field remains deferred — see §5.4 |
 | 9 | Workstream list/resume (7a/7b switcher) | Workstream domain object + persistence + `workstream.list` | **MISSING** | Domain + storage (§4B) |
 | 10 | Workflow lanes (10e) | Branch/PR/dirty-tree subsystem | **MISSING** | New subsystem, nothing to build on |
 | 11 | Clone-from-URL (7a) | `project.clone_from_url` | **MISSING** | Not present anywhere. Daemon capability when it lands (§5.8) |
@@ -762,31 +762,36 @@ from a preview string.
 was returned by the query. A held-back recall is the operator's evidence that the
 harness *chose*; conflating the two silently voids the core bet.
 
-### 5.4 Agent roster (PARTIAL — event-folding is acceptable for now)
+### 5.4 Agent roster (EXISTS — endpoint shipped; `model` still deferred)
 
-`AgentSpawned/AgentStarted/AgentDone/AgentFailed/PmDelegating` exist
-(`events.rs:186-211,312-316`). Missing: a snapshot endpoint, and `model` on the agent
-events (10b renders `sonnet`; model lives only on `LlmRequested/LlmResponded`,
-correlated by `agent_name` **string**).
+**Shipped (closes #2962).** `session.get_agents` now exists — the daemon folds a
+session's ring-buffer replay over the `agent`/`agent_id`-carrying tool-attribution
+events (`ToolStarted`/`ToolFinished`/`ToolError`/`SearchPerformed`/`MemoryRecalled`,
+#2898) server-side, repaying the §2.1 fold-in-the-client loan this section
+originally recorded. `AgentSpawned/AgentStarted/AgentDone/AgentFailed/PmDelegating`
+still exist as unused-in-production event shapes (`events.rs:186-211,312-316`) —
+see `session::registry::agents`'s module docs for why they are not folded. `model`
+remains unpopulated: it lives only on `LlmRequested/LlmResponded`, correlated by
+`agent_name` **string**, which AC-13.2 retires as a correlation key — so folding it
+onto `agent_id` would reintroduce the exact same-name collision bug #2898 closed.
 
 ```rust
 session.get_agents() -> { agents: [{ agent_id, name, model, state, task, todos, files_changed }] }
 ```
 
 **AC-15.1** `model` is carried on agent lifecycle events, not correlated by name.
-**AC-15.2** A late-joining client can render the roster. **Folding the SSE replay is an
-acceptable Phase-1 substitute** (§6.3) — the ring replay makes it correct-enough for a
-single-operator client, which is why this is not a Phase-1 blocker.
+**NOT YET MET** — tracked as the remaining gap above, not closed by #2962.
+**AC-15.2** A late-joining client can render the roster. **MET as of #2962** —
+`session.get_agents` folds the ring buffer server-side, so a late-attaching client
+gets one RPC call instead of replaying and folding the SSE stream itself.
 
-> **§2.1 tension — acknowledged, time-boxed, and now on the clock.** Event-folding is the
-> one place this spec knowingly leaves derivation in the client: "who is running?" is
-> daemon-owned state that the UI reconstructs. It survives Phase 1 on a **bounded
-> rationale** — the fold is over a ring the daemon replays, is small, and has exactly one
-> consumer. But it is **the shape C-1 forbids**, and it degrades precisely when the ring
-> evicts (§4A) — the roster silently loses agents the daemon still knows about. Two targets
-> folding independently is also two chances to fold differently (C-3).
-> **`session.get_agents` (§5.4) is the principled endpoint; the fold is a Phase-1 loan,
-> not a design.** Recorded so the deferral in §6.3 is read as debt, not as approval.
+> **§2.1 tension — RESOLVED by #2962 for the roster shape itself; `model` (AC-15.1)
+> remains open.** This section previously recorded event-folding as a time-boxed
+> Phase-1 loan: "who is running?" was daemon-owned state a UI client had to
+> reconstruct by folding the SSE replay — the shape C-1 forbids. `session.get_agents`
+> repays that loan — the fold now runs once, in the daemon, over its own ring buffer.
+> The `model` gap is a separate, still-open debt (see above), not a re-opening of the
+> folding-in-the-client concern this callout originally raised.
 
 ### 5.5 Project binding (PARTIAL — the two surfaces must converge)
 
@@ -989,7 +994,7 @@ the Workflow tab, the IDE half, or clone-from-URL.
 | **Workstream persistence** (§4B) | Real **domain + storage** work — deciding what a workstream *is*, not adding an endpoint. The largest item in the spec. Phase 1 ships value on the existing registry without it. |
 | **Per-line diff attribution UI** (10a gutter) | **Depends on §5.2** (`agent_id`). Ship the schema first; the gutter is a downstream consumer. |
 | **Workflow / delivery pipeline** (10e) | **New subsystem, nothing to build on** — no branch/PR/dirty-tree concept exists anywhere (§5.7). Also git-only, so it needs §4.2 settled first. |
-| **Agent roster snapshot** (10b) | **Event-folding is an acceptable substitute** — the SSE ring replay renders a correct roster for a single-operator client. Real cost, low marginal value now. **Carries a §2.1 tension: the fold is a loan, not a design** (§5.4). |
+| **Agent roster `model` field** (10b) | **Shipped except `model`** — `session.get_agents` (§5.4) landed with #2962, closing the §2.1 client-side-fold tension. `model` per `agent_id` is the one still-deferred sub-item; see §5.4. |
 | **Clone-from-URL** (7a) | Does not exist anywhere; pure additive scope with no dependents. Local-folder binding (`project.list_dir`, §5.8) covers the mandated projectless→bound path. **When it lands it is `project.clone_from_url` on the daemon — never a UI-side git op** (§5.8). |
 | **Monitor columns** (9b) | Demoted to transient trace mode (§4.6.1); the 8b inline card delivers the same trace at full width. |
 


### PR DESCRIPTION
## Update (commit 7aa1def8) — root-cause fix for a code-critic HIGH

code-critic flagged a HIGH on the original cut of this PR: `get_agents` folded
`SessionRegistry::replay`'s capacity-bounded ring buffer (`DEFAULT_RING_CAPACITY
= 1000`) directly on every call. Once ~1000 events accumulated in a session, a
long-running agent's `ToolStarted` could age out of the ring before any LATER
attributed event for that same `agent_id` landed — silently dropping it from
the roster entirely, indistinguishable from "never spawned" while it may still
genuinely be running. Moving the fold server-side had fixed WHERE the
computation ran but not WHAT it could lose — the exact silent-data-loss shape
DOC-39 §5.4 originally warned about.

**Root fix:** `SessionEntry` (`registry.rs`) now carries an ALWAYS-RETAINED
`agents: Vec<AgentRosterState>` map, updated by
`SessionEntry::note_agent_activity` from inside `SessionRegistry::record` —
the SAME critical section that pushes every `agent`/`agent_id`-carrying event
onto the ring. This map is evicted only when the session itself goes away,
never by ring capacity. `get_agents` (`registry_agents.rs`) now reads this map
directly instead of folding `replay()`. Same result shape, same documented
deferrals, same `agent_id`-keyed same-name correctness. New test
`get_agents_survives_ring_eviction` forces an agent's `ToolStarted` out of a
capacity-2 ring (`SessionRegistry::with_capacity`) and asserts it still
appears in the roster with `state: "running"`. DOC-39 §5.1/§5.4/§6.3 updated
to record the §2.1 tension as genuinely resolved (both the thin-client concern
and the ring-eviction concern), not carried forward as an open caveat.

The rest of this description (below) is from the original submission and
still describes the current field-population contract accurately; only "how
it's populated" (server-side ring fold -> always-retained map) has changed.

---

## Summary

Implements `session.get_agents` (DOC-39 §5.4), the last **MISSING** API item in
DOC-39 §5.1's UI-need → API-delta table.

```
session.get_agents(session_id) -> {
  agents: [{ agent_id, name, model, state, task, todos, files_changed }]
}
```

**How it's populated (current design).** `SessionEntry` carries an
ALWAYS-RETAINED per-session `agents` map, keyed by `agent_id`, kept up to
date by `SessionRegistry::record` — the same critical section that pushes
every `agent`/`agent_id`-carrying tool-attribution event
(`ToolStarted`/`ToolFinished`/`ToolError`/`SearchPerformed`/`MemoryRecalled`,
all carrying `agent`+`agent_id` since #2898/DOC-39 AC-13) onto the
capacity-bounded ring buffer. `get_agents` reads this map directly — it is
NOT a fold over the ring, so it cannot lose a still-running agent to ring
eviction (see the "Update" section above for why that distinction matters).
Entries are in first-seen order — server-side, once, replacing the
client-side SSE-fold §5.4 explicitly recorded as a time-boxed §2.1 loan
("the fold is a Phase-1 loan, not a design").

**Field-by-field: populated vs. deferred, with reasons**

| Field | Status | Why |
|---|---|---|
| `agent_id` | **real** | The DOC-39 AC-13 stable per-spawn id, straight from the attribution events. |
| `name` | **real** | The agent name (`"pm"` for the root loop, e.g. `"python-engineer"` for a delegation). |
| `state` | **derived, real** | `"running"` if the last attributed event for that `agent_id` is an unmatched `ToolStarted`; `"idle"` otherwise (tool-dispatch ordering — `ToolStarted` → `ToolFinished`/`ToolError` → optional telemetry — makes this well-defined from event kind alone). Now computed incrementally as events land, not re-derived per call. |
| `model` | **deferred (`null`)** | No production event ties a resolved model string to a stable `agent_id` yet. `LlmRequested`/`LlmResponded` carry `model`, but only `agent_name` (a string AC-13.2 explicitly retires as a correlation key) — folding by name would reintroduce the exact same-name collision bug #2898 closed. |
| `task` | **deferred (`null`)** | `PmDelegating.agent`/`task_preview` predates `agent_id` and is keyed by name only — same collision risk as `model`. |
| `todos` | **deferred (`[]`)** | No event or registry state tracks per-agent todos today; net-new domain state, not a folding gap. |
| `files_changed` | **deferred (`[]`)** | Same as `todos`. |

`AgentSpawned`/`AgentStarted`/`AgentDone`/`AgentFailed` (DOC-39 AC-13) are
**not** sources here even though their shape looks purpose-built for a roster:
`events.rs`'s own docs and #2898's CHANGELOG entry record that none of them
are emitted by any production call site yet — keying off them would silently
return an always-empty roster instead of the real, already-flowing
tool-attribution activity. This is documented in
`session::registry::agents`'s module docs.

**AC-15.1** (`model` carried on agent lifecycle events, not correlated by
name) is **NOT YET MET** — recorded as an open gap in DOC-39 §5.4, not
silently closed.

## Structure — mirrors `session.get_readiness` (PR #2888)

- `crates/trusty-code/src/session/registry.rs` — `SessionEntry` gains the
  always-retained `agents: Vec<AgentRosterState>` field + the
  `AgentRosterState` struct + `SessionEntry::note_agent_activity` +
  the shared `tool_attribution` matcher; `SessionRegistry::record` calls
  `note_agent_activity` in the same critical section as the ring push.
- `crates/trusty-code/src/session/registry_agents.rs` (new) — `get_agents`
  (`SessionRegistry::get_agents` + `AgentRosterEntry`), a `#[path]` child
  module of `registry.rs`, same pattern as `registry_events.rs`. Reads
  `SessionEntry::agents` directly (not a ring-buffer fold).
- `crates/trusty-code/src/session/protocol_agents.rs` (new) — the RPC
  handler + unit tests, a `#[path]` child module of `protocol.rs`, same
  pattern as `protocol_readiness.rs`.
- `crates/trusty-code/src/session/protocol.rs` — registers
  `session.get_agents` alongside every other `session.*` method; adds it to
  the `register_wires_every_session_method` wiring test.
- `crates/trusty-code/tests/agents_e2e.rs` (new) — real-daemon e2e proof
  mirroring `tests/readiness_e2e.rs`: a completed PM → delegated-engineer run
  reports both spawns in the roster with real `agent_id`s and `state: "idle"`;
  a never-run session returns `{"agents": []}`, not an error.

## Gates (raw output, after the eviction-safety fix)

```
$ cargo build -p trusty-code --all-targets
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.96s

$ cargo test -p trusty-code --lib -- --test-threads=1
test result: ok. 1121 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 8.76s

$ cargo test -p trusty-code --lib get_agents
running 9 tests
test session::registry::agents::tests::get_agents_unknown_session_errors ... ok
test session::protocol::protocol_agents::tests::get_agents_unknown_session_maps_to_session_not_found ... ok
test session::registry::agents::tests::get_agents_empty_session_returns_empty_roster ... ok
test session::protocol::protocol_agents::tests::get_agents_empty_session_returns_empty_array ... ok
test session::registry::agents::tests::get_agents_distinguishes_same_named_concurrent_spawns ... ok
test session::registry::agents::tests::get_agents_survives_ring_eviction ... ok   <- proves the fix
test session::registry::agents::tests::get_agents_finished_tool_reports_idle_state ... ok
test session::registry::agents::tests::get_agents_running_tool_reports_running_state ... ok
test session::protocol::protocol_agents::tests::get_agents_wraps_roster_under_agents_key ... ok
test result: ok. 9 passed; 0 failed

$ cargo test -p trusty-code --tests -- --test-threads=1
test result: ok. 1121 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out (lib)
test result: ok. 3 passed  (main.rs unit tests)
test result: ok. 1 passed  (agent_id_e2e.rs)
test result: ok. 2 passed  (agents_e2e.rs)
test result: ok. 8 passed  (cli_e2e.rs)
test result: ok. 2 passed  (config_mount.rs)
test result: ok. 4 passed  (inference_shared_adapter_e2e.rs)
test result: ok. 4 passed  (m1_cutline_e2e.rs)
test result: ok. 2 passed  (readiness_e2e.rs)
test result: ok. 1 passed  (recall_content_e2e.rs)
test result: ok. 1 passed  (search_hits_e2e.rs)
test result: ok. 2 passed  (session_e2e.rs)
test result: ok. 6 passed  (task_e2e.rs)

$ cargo clippy -p trusty-code --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.35s   (0 warnings)

$ cargo fmt --check
exit 0

$ bash scripts/check_line_cap.sh
line-cap: 9 allowlisted, 0 violations — OK.   (registry.rs grew but stayed under the 500-SLOC cap; no allowlist entry needed)

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 35 spec doc(s) + 2467 code file(s); 0 error(s), 0 warning(s)
```

Note: `cargo test -p trusty-code --lib`/`--tests` with the default parallel
thread pool intermittently hits ONE unrelated pre-existing flake across
various `run_task::tests::*` (`catchup: could not reach trusty-memory at
http://127.0.0.1:...`) — a shared local trusty-memory palace race under
concurrent tests, reproduced with zero changes from this PR and always
passing in isolation. `--test-threads=1` runs (shown above) are consistently
green; every `session::*`/`agents_e2e` test is unaffected either way.

## Docs

`docs/specs/trusty-code-harness-ui.md`:
- §5.1 table: row 8 (Agent roster) `EXISTS`, now noting the always-retained
  map / no-eviction-loss property explicitly.
- §5.4: header/body updated to "EXISTS — endpoint shipped, eviction-safe;
  `model` still deferred"; the §2.1-tension callout now records BOTH the
  thin-client concern AND the ring-eviction concern as genuinely resolved,
  not carried forward as an open caveat.
- §6.3 table: "Agent roster `model` field" row updated to note the
  always-retained-map design closes both tensions, leaving only `model` open.

`crates/trusty-code/CHANGELOG.md`: `[Unreleased]` bullet rewritten to describe
the always-retained-map design and the HIGH it closes.

Closes #2962. Refs #2892.

## Test plan

- [x] `cargo build -p trusty-code --all-targets`
- [x] `cargo test -p trusty-code --lib` / `--tests` (incl. new
      `get_agents_survives_ring_eviction` and `agents_e2e.rs`)
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`
- [x] `bash scripts/check_test_pointers.sh`
- [x] `bash scripts/check_sld.sh`
- [x] CHANGELOG `[Unreleased]` entry updated
- [x] DOC-39 §5.1/§5.4/§6.3 updated

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
