### PR TITLE
fix: misc bug sweep — gworkspace bin collision, review port contract, diff footer, use_skill registry

### DIFF
--- a/crates/trusty-agents/assets/config/default-config.toml
+++ b/crates/trusty-agents/assets/config/default-config.toml
@@ -10,19 +10,21 @@ inject_for_roles = ["ctrl", "pm", "research", "observe"]
 # do not appear here.
 
 # gworkspace-mcp — the NATIVE in-workspace stdio MCP server built from crate
-# `trusty-gworkspace` (bin `gworkspace-mcp`, src/bin/gworkspace-mcp.rs). Per
-# ADR-0014 (native Rust MCP, PR #2624) this repoints off the retired external
-# Python upstream: the native binary is a pure stdio server that takes NO
-# subcommand, so `args = []` (the old external upstream required `["mcp"]`).
+# `trusty-gworkspace` (bin `trusty-gworkspace-mcp`,
+# src/bin/trusty-gworkspace-mcp.rs). Per ADR-0014 (native Rust MCP, PR #2624)
+# this repoints off the retired external Python upstream: the native binary is
+# a pure stdio server that takes NO subcommand, so `args = []` (the old
+# external upstream required `["mcp"]`).
 #
-# ⚠️ NAME COLLISION: the native cargo-installed `gworkspace-mcp` and the legacy
-# pipx Python package share the same binary name on $PATH, so which one launches
-# depends on PATH order. `args = []` targets the native contract, but full
-# disambiguation needs a binary rename (follow-up) or removing the pipx package.
+# Issue #2644: the native binary was renamed from `gworkspace-mcp` to
+# `trusty-gworkspace-mcp` to disambiguate it from the legacy pipx-installed
+# Python package, which previously shared the same name on $PATH. The service
+# `name` below stays `gworkspace-mcp` (registry identifier only); `command`
+# now targets the renamed binary.
 [[mcp.services]]
 name = "gworkspace-mcp"
 description = "Google Workspace (native trusty-gworkspace) — Gmail, Calendar, Drive, Docs, Sheets, Tasks"
-command = "gworkspace-mcp"
+command = "trusty-gworkspace-mcp"
 args = []
 transport = "stdio"
 enabled = true
@@ -222,17 +224,19 @@ eager_discovery = true
 timeout_ms = 5000
 
 # gworkspace — Google Workspace (Gmail, Calendar, Drive, Docs, Sheets, Tasks)
-# via JSON-RPC 2.0 stdio. The `gworkspace-mcp` binary (from the trusty-common
-# workspace, crate `trusty-gworkspace`) exposes an OpenRPC 1.3.2 manifest via
-# `rpc.discover` and advertises Google OAuth scopes per tool through the
-# `x-google-scopes` extension. Disabled by default — flip `enabled = true`
-# after authenticating (`gworkspace-mcp auth login`) on a machine with the
-# binary on $PATH. See docs/trusty-agents/research/openrpc-trusty-contract.md.
+# via JSON-RPC 2.0 stdio. The `trusty-gworkspace-mcp` binary (renamed from
+# `gworkspace-mcp` in #2644 to resolve a $PATH collision with the legacy pipx
+# Python package; from the trusty-common workspace, crate `trusty-gworkspace`)
+# exposes an OpenRPC 1.3.2 manifest via `rpc.discover` and advertises Google
+# OAuth scopes per tool through the `x-google-scopes` extension. Disabled by
+# default — flip `enabled = true` after authenticating
+# (`trusty-gworkspace-mcp setup`) on a machine with the binary on $PATH. See
+# docs/trusty-agents/research/openrpc-trusty-contract.md.
 [[tool_registry.endpoints]]
 name = "gworkspace"
 driver = "direct"
 description = "Google Workspace — Gmail, Calendar, Drive, Docs, Sheets, Tasks"
-command = "gworkspace-mcp"
+command = "trusty-gworkspace-mcp"
 args = []
 enabled = false
 scopes = [

--- a/crates/trusty-agents/src/tools/mcp_tools/schema.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/schema.rs
@@ -41,7 +41,7 @@ pub fn mcp_tool_definitions() -> Vec<ChatCompletionTool> {
                     "name": {"type": "string", "description": "Unique service identifier"},
                     "description": {"type": "string", "description": "Human-readable description"},
                     "transport": {"type": "string", "enum": ["stdio", "http"], "description": "Transport type"},
-                    "command": {"type": "string", "description": "For stdio: command to run (e.g. 'gworkspace-mcp')"},
+                    "command": {"type": "string", "description": "For stdio: command to run (e.g. 'trusty-gworkspace-mcp')"},
                     "args": {
                         "type": "array",
                         "items": {"type": "string"},

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -18,6 +18,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   of always copying the original file's, which silently corrupted the
   trailing byte on either direction of a no-trailing-newline state change
   (closes #2150).
+- the delegated engineer's tool registry (`task::executor::ProjectToolFactory`)
+  now registers `use_skill` when a skills catalog resolved, matching what its
+  system prompt advertises via `with_skills_catalog` — previously the tool
+  call failed with "no tool registered" (closes #2152).
 
 ### Added
 

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- the unified-diff applier (`tools/fs/edit_format/diff.rs`) no longer errors
+  on a `git diff`-style `\ No newline at end of file` footer marker inside a
+  hunk body — the marker is metadata, not content, so it no longer fails the
+  whole apply. Its *position* (after a `-`, `+`, or ` ` line) is also tracked
+  so the applier picks the OUTPUT's trailing-newline state correctly instead
+  of always copying the original file's, which silently corrupted the
+  trailing byte on either direction of a no-trailing-newline state change
+  (closes #2150).
+
 ### Added
 
 - **Embedded default agents converted from TOML to `.md`+frontmatter (#2897,

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -316,6 +316,9 @@ async fn run_and_record(
         EngineerPromptContext {
             project_context: project_context.clone(),
             skills_catalog: skills_catalog.as_ref().map(|(catalog, _)| catalog.clone()),
+            skill_resolver: skills_catalog
+                .as_ref()
+                .map(|(_, resolver)| Arc::clone(resolver)),
         },
         Arc::clone(&transcript),
         Arc::clone(&sink),
@@ -534,9 +537,10 @@ async fn run_and_record(
 ///
 /// `skills_catalog` (#2069) is the same rendered metadata catalog the PM's own
 /// prompt gets, threaded through so the delegated engineer's DailyDriver
-/// prompt also sees it. Wiring the `use_skill` *tool* into the engineer's own
-/// per-delegation registry (`ProjectToolFactory::build`) is deferred — see
-/// this crate's #2069 delivery notes. #2207: resolves the SAME wall-clock
+/// prompt also sees it. #2152/#2942: the `use_skill` *tool* is now also wired
+/// into the engineer's own per-delegation registry (`ProjectToolFactory::build`)
+/// against the SAME resolver instance the PM's own `use_skill` tool and catalog
+/// were built from — see [`EngineerPromptContext::skill_resolver`]. #2207: resolves the SAME wall-clock
 /// budget applied to the delegating PM's own loop via
 /// `crate::provider::resolve_deadline_secs(params.deadline_secs)` — called
 /// again here (rather than threaded in as an extra argument) purely to keep
@@ -563,6 +567,7 @@ fn build_engineer_runner(
     let EngineerPromptContext {
         project_context,
         skills_catalog,
+        skill_resolver,
     } = prompt;
     let engineer_llm: Arc<dyn LlmClientTrait> = Arc::new(RecordingLlmClient::new(
         llm,
@@ -573,6 +578,7 @@ fn build_engineer_runner(
     let factory: Arc<dyn RegistryFactory> = Arc::new(ProjectToolFactory {
         project: work_root.to_path_buf(),
         mode: params.mode,
+        skill_resolver,
     });
 
     let mut runner = InProcessAgentRunner::new(engineer_llm, factory, params.agents_dir.clone())
@@ -589,14 +595,21 @@ fn build_engineer_runner(
     apply_engineer_model_override(Arc::new(runner), params)
 }
 
-/// The two prompt-context strings the delegated engineer's system prompt is
-/// assembled from.
+/// The prompt-context strings (plus the skill resolver the `use_skill` tool
+/// needs) the delegated engineer's system prompt and registry are assembled
+/// from.
 ///
-/// Why: both are `Option<String>`, are always produced and consumed together,
-/// and are positionally adjacent — bundling them removes a real
+/// Why: `project_context`/`skills_catalog` are always produced and consumed
+/// together and are positionally adjacent — bundling them removes a real
 /// easy-to-transpose-the-arguments hazard and keeps
 /// [`build_engineer_runner`]'s arity under clippy's `too_many_arguments` gate
 /// now that `work_root` must also be threaded through for projectless runs.
+/// #2152: `skill_resolver` joined the bundle so `ProjectToolFactory::build`
+/// can register `use_skill` against the SAME resolver instance backing
+/// `skills_catalog` and the PM's own `use_skill` tool, rather than the
+/// engineer's registry omitting the tool its prompt explicitly advertises
+/// (closes the gap PR #2942 fixed in the legacy `run_task/mod.rs` path but
+/// left open here).
 /// What: `project_context` is the project's `CLAUDE.md` (`None` when absent —
 /// always the case projectless, since the scratch root has none);
 /// `skills_catalog` is the rendered skill-metadata catalog from either the
@@ -605,11 +618,16 @@ fn build_engineer_runner(
 /// (`skills::discover_skill_metadata`'s embedded-fallback, #2895). `None`
 /// only in `HarnessMode::Parity` (which never discovers skills at all, disk
 /// or embedded); in `DailyDriver` the embedded fallback means this is
-/// effectively always `Some`.
-/// Test: exercised via `task::executor::tests::*`'s engineer-runner paths.
+/// effectively always `Some`. `skill_resolver` is `Some` under the exact same
+/// condition as `skills_catalog` (both come from the same
+/// `daily_driver_skills_catalog` call at the sole construction site).
+/// Test: exercised via `task::executor::tests::*`'s engineer-runner paths;
+/// `engineer_registry_includes_use_skill_when_catalog_present` pins the
+/// registry-side contract.
 struct EngineerPromptContext {
     project_context: Option<String>,
     skills_catalog: Option<String>,
+    skill_resolver: Option<Arc<dyn SkillResolver>>,
 }
 
 /// Discover the (cheap, metadata-only) skill catalog under `work_root` and
@@ -658,6 +676,13 @@ struct ProjectToolFactory {
     /// does not carry this field — its `EditTool` stays on the pre-#2073
     /// plain per-model order, unchanged.
     mode: HarnessMode,
+    /// #2152: the SAME `Arc<dyn SkillResolver>` the PM's own `use_skill` tool
+    /// and the rendered skills catalog were built from (threaded through
+    /// [`EngineerPromptContext::skill_resolver`]). `None` under the same
+    /// condition `skills_catalog` is `None` (`HarnessMode::Parity`, which
+    /// never discovers skills). Mirrors `run_task::ProjectToolFactory`'s
+    /// `skill_resolver` field, which PR #2942 wired up on the legacy path.
+    skill_resolver: Option<Arc<dyn SkillResolver>>,
 }
 
 #[async_trait]
@@ -695,6 +720,13 @@ impl RegistryFactory for ProjectToolFactory {
             Duration::from_secs(ENGINEER_BASH_TIMEOUT_SECS),
         )));
         reg.register(Arc::new(FinishTaskTool::new()));
+        // #2152: mirrors the PM's own conditional `use_skill` registration —
+        // only when a skill catalog actually resolved for this delegation, so
+        // the engineer's prompt (which advertises `use_skill` whenever
+        // `with_skills_catalog` was applied) and its registry stay in sync.
+        if let Some(resolver) = &self.skill_resolver {
+            reg.register(Arc::new(UseSkillTool::new(Arc::clone(resolver))));
+        }
         Arc::new(reg)
     }
 }

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -250,6 +250,7 @@ async fn project_tool_factory_threads_parity_mode_into_edit_tool() {
     let factory = ProjectToolFactory {
         project: project.path().to_path_buf(),
         mode: crate::mode::HarnessMode::Parity,
+        skill_resolver: None,
     };
     let agent = crate::agents::AgentConfig::default();
     let ctx = crate::tools::RunContext {
@@ -275,6 +276,78 @@ async fn project_tool_factory_threads_parity_mode_into_edit_tool() {
     assert!(result.content().contains("unified_diff"));
     let updated = std::fs::read_to_string(project.path().join("f.py")).expect("read");
     assert_eq!(updated, "line1\nline2-diffed\n");
+}
+
+/// #2152: `ProjectToolFactory::build` registers `use_skill` when a skill
+/// resolver was threaded in — the gap PR #2942 fixed on the legacy
+/// `run_task/mod.rs` path but left open on this daemon path (`task::executor`),
+/// where the engineer's prompt (`with_skills_catalog`) advertised `use_skill`
+/// while its registry omitted the tool, so a following call errored with
+/// "no tool registered".
+///
+/// Why: the positive case (`Some(resolver)` registers the tool) and the
+/// negative case (`None` must NOT register it) are both asserted directly
+/// against `ProjectToolFactory::build`'s resulting `ToolRegistry`, mirroring
+/// `run_task::tests::use_skill_absent_from_engineer_when_no_skills`'s direct
+/// (non-end-to-end) style — the embedded-default-skill-catalog fallback
+/// (#2895) makes `skill_resolver` virtually always `Some` on any real project
+/// directory, so exercising the `None` branch end-to-end would be impractical.
+/// What: builds one `ProjectToolFactory` with a resolver present and one with
+/// `skill_resolver: None`, calls `.build()` on each, and asserts
+/// `registry.contains("use_skill")` accordingly.
+/// Test: this test.
+#[tokio::test]
+async fn engineer_registry_includes_use_skill_when_catalog_present() {
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    let skills_dir = project.path().join(".claude").join("skills").join("demo");
+    std::fs::create_dir_all(&skills_dir).expect("mkdir skill dir");
+    std::fs::write(
+        skills_dir.join("SKILL.md"),
+        "---\nname: demo\ndescription: Demo skill\n---\nfull body\n",
+    )
+    .expect("write SKILL.md");
+
+    let mut p = params(&agents, &project, "s");
+    p.mode = crate::mode::HarnessMode::DailyDriver;
+    let (_, resolver) =
+        daily_driver_skills_catalog(&p, p.binding.root().expect("bound")).expect("catalog present");
+
+    let with_resolver = ProjectToolFactory {
+        project: project.path().to_path_buf(),
+        mode: crate::mode::HarnessMode::DailyDriver,
+        skill_resolver: Some(resolver),
+    };
+    let registry = with_resolver
+        .build(
+            &crate::agents::AgentConfig::default(),
+            &RunContext::default(),
+        )
+        .await;
+    assert!(
+        registry.contains("use_skill"),
+        "engineer registry must advertise use_skill when skill_resolver is Some"
+    );
+
+    let without_resolver = ProjectToolFactory {
+        project: project.path().to_path_buf(),
+        mode: crate::mode::HarnessMode::DailyDriver,
+        skill_resolver: None,
+    };
+    let registry = without_resolver
+        .build(
+            &crate::agents::AgentConfig::default(),
+            &RunContext::default(),
+        )
+        .await;
+    assert!(
+        !registry.contains("use_skill"),
+        "engineer registry must NOT advertise use_skill when skill_resolver is None"
+    );
+    assert!(
+        registry.contains("finish_task"),
+        "sanity check: registry should still contain other always-present tools"
+    );
 }
 
 // ── #2207/#2206: daemon-path deadline wiring + distinct status + telemetry ─────

--- a/crates/trusty-code/src/tools/fs/edit_format/diff.rs
+++ b/crates/trusty-code/src/tools/fs/edit_format/diff.rs
@@ -22,12 +22,28 @@ use crate::tools::fs::FsError;
 ///
 /// Why: Central entry point used by `edit_format::apply_payload`.
 /// What: Parses hunks from `diff_text`, applies each in order against
-/// `content`'s lines, and returns the full patched text (preserving whether
-/// the original had a trailing newline). Returns `FsError::DiffHunkHeader` if
-/// no valid hunk header is found, or `FsError::DiffContextMismatch` if a
-/// context/removal line does not match the file at the expected position.
+/// `content`'s lines, and returns the full patched text. Returns
+/// `FsError::DiffHunkHeader` if no valid hunk header is found, or
+/// `FsError::DiffContextMismatch` if a context/removal line does not match
+/// the file at the expected position.
+///
+/// Trailing-newline semantics (#2150, hardened after a #2975 code-critic
+/// HIGH finding): the default is to preserve whether the ORIGINAL `content`
+/// ended with `\n`. That default is overridden ONLY when the LAST hunk
+/// actually reaches end-of-file (no untouched original lines remain after
+/// it) AND that hunk carries a `\ No newline at end of file` footer marker —
+/// see [`Hunk`]'s docs for how the marker's position (after a `-`/old-side,
+/// `+`/new-side, or ` `/both-sides line) is tracked. A marker attached to the
+/// new/both side means the OUTPUT has no trailing newline; a marker attached
+/// ONLY to the old side means the diff is REMOVING a no-trailing-newline
+/// state, so the output DOES get a trailing newline, regardless of what the
+/// original file had. No marker at all in the tail-reaching hunk leaves the
+/// default (original file's own state) untouched.
 /// Test: `tests::apply_single_hunk`, `tests::apply_multiple_hunks`,
-/// `tests::apply_context_mismatch_errors`, `tests::apply_no_hunks_errors`.
+/// `tests::apply_context_mismatch_errors`, `tests::apply_no_hunks_errors`,
+/// `tests::apply_footer_marker_after_removal_only_forces_trailing_newline`,
+/// `tests::apply_footer_marker_after_addition_removes_trailing_newline`,
+/// `tests::apply_footer_marker_on_both_sides_keeps_no_trailing_newline`.
 pub(crate) fn apply_unified_diff(
     content: &str,
     diff_text: &str,
@@ -45,7 +61,12 @@ pub(crate) fn apply_unified_diff(
     let mut out: Vec<String> = Vec::with_capacity(orig_lines.len());
     let mut cursor = 0usize; // 0-based index into orig_lines already emitted/consumed
 
-    for hunk in &hunks {
+    // Set only when the LAST hunk reaches end-of-file and carries an
+    // explicit `\ No newline at end of file` hint; see the doc above.
+    let mut trailing_newline_override: Option<bool> = None;
+    let last_hunk_idx = hunks.len() - 1;
+
+    for (idx, hunk) in hunks.iter().enumerate() {
         let start = hunk.old_start.saturating_sub(1); // 0-based
         if start < cursor || start > orig_lines.len() {
             return Err(FsError::DiffContextMismatch {
@@ -74,11 +95,23 @@ pub(crate) fn apply_unified_diff(
                 }
             }
         }
+
+        if idx == last_hunk_idx && cursor == orig_lines.len() {
+            trailing_newline_override = match (hunk.new_tail_no_newline, hunk.old_tail_no_newline) {
+                // New/both side explicitly marked: output has no trailing \n.
+                (true, _) => Some(false),
+                // Only the old side was marked: the diff REMOVES the
+                // no-trailing-newline state, so output DOES get one.
+                (false, true) => Some(true),
+                // No marker at all: leave the original file's own state.
+                (false, false) => None,
+            };
+        }
     }
     out.extend(orig_lines[cursor..].iter().map(|s| s.to_string()));
 
     let mut result = out.join("\n");
-    if had_trailing_newline {
+    if trailing_newline_override.unwrap_or(had_trailing_newline) {
         result.push('\n');
     }
     Ok(result)
@@ -115,10 +148,29 @@ enum HunkLine {
 }
 
 /// A single parsed `@@ -old_start,old_len +new_start,new_len @@` hunk.
+///
+/// Why (#2150, hardened after a #2975 code-critic HIGH finding): a `git
+/// diff`-style `\ No newline at end of file` footer marker's POSITION
+/// carries meaning, not just its presence. It always immediately follows one
+/// hunk-body line, and which line tells you which file(s) it describes:
+/// after a `-` (`Removal`) line, the OLD file's last line there has no
+/// trailing newline; after a `+` (`Addition`) line, the NEW file's last line
+/// there has no trailing newline; after a ` ` (`Context`) line — common to
+/// both files — BOTH lack one. `old_tail_no_newline` / `new_tail_no_newline`
+/// record which side(s) any footer marker(s) in this hunk were attached to,
+/// so [`apply_unified_diff`] can decide the OUTPUT's trailing-newline state
+/// correctly instead of blindly copying the original file's.
+/// What: `old_tail_no_newline` is `true` when a footer followed a `Removal`
+/// or `Context` line in this hunk; `new_tail_no_newline` is `true` when one
+/// followed an `Addition` or `Context` line. Both can be `true` at once (two
+/// separate markers, one per side, both lacking a trailing newline with
+/// different content).
 #[derive(Debug, Clone, PartialEq)]
 struct Hunk {
     old_start: usize,
     lines: Vec<HunkLine>,
+    old_tail_no_newline: bool,
+    new_tail_no_newline: bool,
 }
 
 /// Parse every hunk out of a unified-diff text, skipping file-header lines.
@@ -135,6 +187,8 @@ fn parse_hunks(diff_text: &str) -> Result<Vec<Hunk>, FsError> {
             current = Some(Hunk {
                 old_start,
                 lines: Vec::new(),
+                old_tail_no_newline: false,
+                new_tail_no_newline: false,
             });
             continue;
         }
@@ -168,6 +222,29 @@ fn parse_hunks(diff_text: &str) -> Result<Vec<Hunk>, FsError> {
             b'+' => hunk
                 .lines
                 .push(HunkLine::Addition(raw_line[1..].to_string())),
+            // #2150: `git diff`-style output emits a footer marker line —
+            // `\ No newline at end of file` — directly after the last
+            // context/removal/addition line of a hunk when that line lacked a
+            // trailing newline in the source. It is metadata about the
+            // preceding line, not a hunk-body line itself, so it carries no
+            // content to apply — but WHICH line it followed matters (see
+            // `Hunk`'s docs), so record that before moving on.
+            b'\\' => {
+                match hunk.lines.last() {
+                    Some(HunkLine::Context(_)) => {
+                        hunk.old_tail_no_newline = true;
+                        hunk.new_tail_no_newline = true;
+                    }
+                    Some(HunkLine::Removal(_)) => hunk.old_tail_no_newline = true,
+                    Some(HunkLine::Addition(_)) => hunk.new_tail_no_newline = true,
+                    // A footer marker with no preceding line in this hunk is
+                    // malformed input we can't attribute to a side; ignore it
+                    // rather than erroring — the marker carries no content of
+                    // its own to apply either way.
+                    None => {}
+                }
+                continue;
+            }
             _ => {
                 return Err(FsError::DiffHunkHeader {
                     reason: format!("unrecognised hunk line prefix: {raw_line:?}"),
@@ -275,5 +352,40 @@ mod tests {
         let diff = "--- a/f.py\n+++ b/f.py\n@@ -1,1 +1,1 @@\n-a\n+A\n";
         let updated = apply_unified_diff(content, diff, Path::new("f.py")).expect("must apply");
         assert_eq!(updated, "A\nb\n");
+    }
+
+    /// #2150/#2975: a footer marker attached ONLY to the removed (old-side)
+    /// line means the diff is REMOVING a no-trailing-newline state — the
+    /// output must gain a trailing newline even though the original file
+    /// lacked one. (Regression case: pre-fix this incorrectly copied the
+    /// original file's own missing-trailing-newline state into the output.)
+    #[test]
+    fn apply_footer_marker_after_removal_only_forces_trailing_newline() {
+        let content = "a\nb"; // no trailing newline
+        let diff = "@@ -1,2 +1,2 @@\n a\n-b\n\\ No newline at end of file\n+B\n";
+        let updated = apply_unified_diff(content, diff, Path::new("f.py")).expect("must apply");
+        assert_eq!(updated, "a\nB\n");
+    }
+
+    /// #2150/#2975: a footer marker attached to the added (new-side) line
+    /// means the diff INTRODUCES a no-trailing-newline state — the output
+    /// must lack a trailing newline even though the original file had one.
+    #[test]
+    fn apply_footer_marker_after_addition_removes_trailing_newline() {
+        let content = "a\nb\n"; // has a trailing newline
+        let diff = "@@ -1,2 +1,2 @@\n a\n-b\n+B\n\\ No newline at end of file\n";
+        let updated = apply_unified_diff(content, diff, Path::new("f.py")).expect("must apply");
+        assert_eq!(updated, "a\nB");
+    }
+
+    /// #2150/#2975: footer markers on BOTH sides (old line lacked a trailing
+    /// newline, and so does its new-side replacement) leave the
+    /// no-trailing-newline state unchanged across the edit.
+    #[test]
+    fn apply_footer_marker_on_both_sides_keeps_no_trailing_newline() {
+        let content = "a\nb"; // no trailing newline
+        let diff = "@@ -1,2 +1,2 @@\n a\n-b\n\\ No newline at end of file\n+B\n\\ No newline at end of file\n";
+        let updated = apply_unified_diff(content, diff, Path::new("f.py")).expect("must apply");
+        assert_eq!(updated, "a\nB");
     }
 }

--- a/crates/trusty-console/CHANGELOG.md
+++ b/crates/trusty-console/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- the cross-crate `default_port_does_not_collide_with_known_siblings`
+  port-contract table now also tracks trusty-embedderd's `--http` mode
+  default (7890) and trusty-review's corrected default (7891), closing the
+  gap that let trusty-review's 7890 collide with trusty-embedderd silently
+  (closes #2573).
+
 ## [0.4.0] — 2026-07-09
 
 ### Changed

--- a/crates/trusty-console/src/service.rs
+++ b/crates/trusty-console/src/service.rs
@@ -249,14 +249,17 @@ mod tests {
         assert_eq!(serve_args(), vec!["serve".to_string()]);
     }
 
-    /// Cross-crate port-uniqueness contract (#2566 review finding).
+    /// Cross-crate port-uniqueness contract (#2566, extended by #2573).
     ///
     /// Why: trusty-review's original `DEFAULT_PORT` (7880) silently collided
     /// with trusty-mpm's live `DEFAULT_DAEMON_ADDR`, crash-looping a launchd
     /// agent on install. This mirrors that fix's guard for the console's own
     /// default (`crate::DEFAULT_PORT`), pointer-commented to each sibling's
     /// real source constant, so a future edit here that reintroduces a
-    /// collision fails this test instead of shipping a crash-loop.
+    /// collision fails this test instead of shipping a crash-loop. #2573
+    /// extended this table to also cover trusty-embedderd's `--http` mode
+    /// default, which the original table omitted because it is a manual/
+    /// dev-run listener rather than a `tctl`-managed daemon.
     /// What: asserts `crate::DEFAULT_PORT` is absent from the known-sibling
     /// ports list.
     /// Test: this is the test.
@@ -281,13 +284,18 @@ mod tests {
             ),
             (
                 "trusty-review",
-                7890,
+                7891,
                 "trusty-review/src/service/mod.rs::DEFAULT_PORT",
             ),
             (
                 "trusty-mpm",
                 7880,
                 "trusty-mpm/src/core/discovery.rs::DEFAULT_DAEMON_ADDR",
+            ),
+            (
+                "trusty-embedderd",
+                7890,
+                "trusty-embedderd/src/lib.rs::Args::http_addr (--http default_value, manual/dev-run only)",
             ),
         ];
         for (binary, port, source) in known_siblings {

--- a/crates/trusty-gworkspace/CHANGELOG.md
+++ b/crates/trusty-gworkspace/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** the native binary is renamed from `gworkspace-mcp` to
+  `trusty-gworkspace-mcp` (`crates/trusty-gworkspace/Cargo.toml` `[[bin]]`),
+  closing #2644. The cargo-installed native binary and the legacy
+  pipx-installed Python `gworkspace-mcp` package previously shared one name on
+  `$PATH`, so which implementation actually launched depended on install
+  order. Migration: update any `.mcp.json` / `~/.claude.json` server entry's
+  `"command"` from `"gworkspace-mcp"` to `"trusty-gworkspace-mcp"`, then
+  re-run `cargo install --path crates/trusty-gworkspace`. Token/config file
+  paths (`~/.gworkspace-mcp/…`) and the default profile name are unchanged —
+  existing accounts keep working without re-authenticating.
+
 ### Fixed
 
 - MCP server self-refresh in tm-managed sessions — `OAuthManager::from_env()`

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -10,8 +10,8 @@ license.workspace = true
 crate-type = ["rlib"]
 
 [[bin]]
-name = "gworkspace-mcp"
-path = "src/bin/gworkspace-mcp.rs"
+name = "trusty-gworkspace-mcp"
+path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
 trusty-common = { path = "../trusty-common", version = "0.23.0", features = ["mcp"] }

--- a/crates/trusty-gworkspace/README.md
+++ b/crates/trusty-gworkspace/README.md
@@ -5,10 +5,22 @@ Python [`gworkspace-mcp`](https://pypi.org/project/gworkspace-mcp/) project.
 
 Exposes 43 [Model Context Protocol](https://modelcontextprotocol.io/) tools
 across Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, and Accounts.
-Authentication is fully native: the `gworkspace-mcp` binary runs the OAuth
-consent flow itself and reads/writes `~/.gworkspace-mcp/tokens.json` — no
-external CLI is required. The token file is wire-compatible with the original
-Python `gworkspace-mcp`, so an existing token file is picked up unchanged.
+Authentication is fully native: the `trusty-gworkspace-mcp` binary runs the
+OAuth consent flow itself and reads/writes `~/.gworkspace-mcp/tokens.json` —
+no external CLI is required. The token file is wire-compatible with the
+original Python `gworkspace-mcp`, so an existing token file is picked up
+unchanged.
+
+> **Breaking change (issue #2644):** the native binary was renamed from
+> `gworkspace-mcp` to `trusty-gworkspace-mcp`. Previously the cargo-installed
+> native binary and the legacy pipx-installed Python package both claimed the
+> `gworkspace-mcp` name on `$PATH`, so which implementation actually launched
+> depended on install order. Migration: update any `.mcp.json` /
+> `~/.claude.json` entry's `"command"` field from `"gworkspace-mcp"` to
+> `"trusty-gworkspace-mcp"`, then re-run `cargo install --path
+> crates/trusty-gworkspace` (or `cargo install trusty-gworkspace`) to get the
+> new binary name on `$PATH`. Token/config file paths (`~/.gworkspace-mcp/…`)
+> are unchanged — existing accounts keep working without re-authenticating.
 
 ## Installation
 
@@ -16,9 +28,9 @@ Python `gworkspace-mcp`, so an existing token file is picked up unchanged.
 cargo install --path crates/trusty-gworkspace
 ```
 
-This installs the `gworkspace-mcp` binary into `~/.cargo/bin`. The same binary
-is both the MCP stdio server (run with no subcommand) and the onboarding CLI
-(`setup` / `doctor` / `accounts`).
+This installs the `trusty-gworkspace-mcp` binary into `~/.cargo/bin`. The same
+binary is both the MCP stdio server (run with no subcommand) and the
+onboarding CLI (`setup` / `doctor` / `accounts`).
 
 ## Authentication
 
@@ -50,8 +62,8 @@ precedence over the file.
 ### 2. Authorize an account
 
 ```sh
-gworkspace-mcp setup                       # authorize the default profile
-gworkspace-mcp setup --profile work        # authorize a named profile
+trusty-gworkspace-mcp setup                       # authorize the default profile
+trusty-gworkspace-mcp setup --profile work        # authorize a named profile
 ```
 
 `setup` opens your browser to Google's consent screen, captures the redirect on
@@ -71,7 +83,7 @@ it is never changed.
 {
   "mcpServers": {
     "gworkspace": {
-      "command": "gworkspace-mcp"
+      "command": "trusty-gworkspace-mcp"
     }
   }
 }
@@ -88,14 +100,14 @@ fail with an actionable message naming the exact fix, e.g.:
 
 ```
 Google refresh token for profile 'work' is expired or revoked — re-authenticate
-with: gworkspace-mcp setup --profile work (400 Bad Request invalid_grant: …)
+with: trusty-gworkspace-mcp setup --profile work (400 Bad Request invalid_grant: …)
 ```
 
 You can run the fix without leaving the session:
 
 ```sh
-! gworkspace-mcp setup --profile work        # interactive browser consent
-! gworkspace-mcp setup --profile work --print-url   # headless: prints the URL
+! trusty-gworkspace-mcp setup --profile work        # interactive browser consent
+! trusty-gworkspace-mcp setup --profile work --print-url   # headless: prints the URL
 ```
 
 `--print-url` (alias `--no-browser`) skips the browser launch and prints the
@@ -110,10 +122,10 @@ spawned for you.
 profile's refresh token, classifying it OK / DEAD / UNKNOWN:
 
 ```sh
-gworkspace-mcp doctor
+trusty-gworkspace-mcp doctor
 ```
 
-For any DEAD profile it prints the exact `gworkspace-mcp setup --profile <name>`
+For any DEAD profile it prints the exact `trusty-gworkspace-mcp setup --profile <name>`
 command to fix it. The probe is read-only (it never rewrites `tokens.json`),
 bounded by a short per-profile timeout, and degrades to UNKNOWN when Google is
 unreachable rather than failing the whole diagnostic.
@@ -121,9 +133,9 @@ unreachable rather than failing the whole diagnostic.
 ## Managing accounts
 
 ```sh
-gworkspace-mcp accounts list                 # show profiles + which is default
-gworkspace-mcp accounts default work         # switch the default profile
-gworkspace-mcp accounts remove work          # forget a local token (no revoke)
+trusty-gworkspace-mcp accounts list                 # show profiles + which is default
+trusty-gworkspace-mcp accounts default work         # switch the default profile
+trusty-gworkspace-mcp accounts remove work          # forget a local token (no revoke)
 ```
 
 ## Configuration

--- a/crates/trusty-gworkspace/src/api/auth/oauth/errors.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/errors.rs
@@ -189,7 +189,7 @@ pub(crate) fn is_invalid_grant(body: &str) -> bool {
 /// transient/server error is never misattributed to a dead token.
 /// What: For `invalid_grant`, returns
 /// `Google refresh token for profile '<name>' is expired or revoked —
-/// re-authenticate with: gworkspace-mcp setup --profile <name> (<sanitized>)`;
+/// re-authenticate with: trusty-gworkspace-mcp setup --profile <name> (<sanitized>)`;
 /// otherwise returns `token refresh failed: <sanitized>`.
 /// Test: `refresh_failure_message_names_profile_and_setup_command`,
 /// `refresh_failure_message_non_invalid_grant_has_no_hint`.
@@ -202,7 +202,7 @@ pub(crate) fn refresh_failure_message(
     if is_invalid_grant(body) {
         format!(
             "Google refresh token for profile '{profile}' is expired or revoked — \
-             re-authenticate with: gworkspace-mcp setup --profile {profile} ({sanitized})"
+             re-authenticate with: trusty-gworkspace-mcp setup --profile {profile} ({sanitized})"
         )
     } else {
         format!("token refresh failed: {sanitized}")
@@ -386,7 +386,7 @@ mod tests {
             "message must name the profile: {msg}"
         );
         assert!(
-            msg.contains("gworkspace-mcp setup --profile work"),
+            msg.contains("trusty-gworkspace-mcp setup --profile work"),
             "message must name the exact re-auth command: {msg}"
         );
         assert!(

--- a/crates/trusty-gworkspace/src/bin/trusty-gworkspace-mcp.rs
+++ b/crates/trusty-gworkspace/src/bin/trusty-gworkspace-mcp.rs
@@ -1,9 +1,14 @@
-//! `gworkspace-mcp` binary — stdio MCP server + OAuth onboarding CLI.
+//! `trusty-gworkspace-mcp` binary — stdio MCP server + OAuth onboarding CLI.
 //!
 //! Why: MCP hosts (Claude Code and friends) launch this process with NO
 //! arguments and talk JSON-RPC over stdin/stdout, so that path must stay the
 //! default. Issue #2631 adds `setup` / `doctor` / `accounts` subcommands for
 //! native onboarding without breaking the argument-less server invocation.
+//! Issue #2644 renamed the binary from `gworkspace-mcp` to
+//! `trusty-gworkspace-mcp` to eliminate a `$PATH` collision with the legacy
+//! pipx-installed Python `gworkspace-mcp` package — the two implementations
+//! previously shared one name on `$PATH`, so which binary launched depended
+//! on install order.
 //! What: Parses args with clap; a present subcommand dispatches to the CLI
 //! (and exits), while no subcommand runs the stdio MCP server exactly as
 //! before.

--- a/crates/trusty-gworkspace/src/cli/accounts.rs
+++ b/crates/trusty-gworkspace/src/cli/accounts.rs
@@ -22,7 +22,7 @@ use crate::api::auth::TokenStorage;
 pub fn list(storage: &TokenStorage) -> Result<()> {
     let rows = storage.list_accounts()?;
     if rows.is_empty() {
-        println!("No accounts found. Run `gworkspace-mcp setup` to authorize one.");
+        println!("No accounts found. Run `trusty-gworkspace-mcp setup` to authorize one.");
         return Ok(());
     }
     println!("{:<24} {:<32} DEFAULT", "PROFILE", "EMAIL");

--- a/crates/trusty-gworkspace/src/cli/doctor.rs
+++ b/crates/trusty-gworkspace/src/cli/doctor.rs
@@ -3,7 +3,7 @@
 //! Why: OAuth onboarding fails in a handful of predictable ways (missing
 //! client creds, no tokens, an expired/revoked refresh token). A one-shot
 //! diagnostic tells the user exactly what to fix — and, crucially, for a dead
-//! refresh token it names the exact `gworkspace-mcp setup --profile <name>`
+//! refresh token it names the exact `trusty-gworkspace-mcp setup --profile <name>`
 //! command to run — before they hit a cryptic API error mid-session.
 //! What: Checks client-credential resolution and tokens.json state (read-only),
 //! then, when credentials are available, live-probes each stored profile's
@@ -52,7 +52,7 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(6);
 
 /// Run the doctor check and print a report to stdout.
 ///
-/// Why: Human-facing entry point for `gworkspace-mcp doctor`.
+/// Why: Human-facing entry point for `trusty-gworkspace-mcp doctor`.
 /// What: Prints the static credential/storage checks, then — when client
 /// credentials resolve — live-probes each stored profile and prints its health.
 /// Always returns `Ok` (the report *is* the result); never mutates tokens.json.
@@ -165,7 +165,7 @@ async fn probe_profile(
 /// summary hint when something is wrong.
 /// Test: `report_lines_flags_missing_creds`, `report_lines_all_green`.
 pub fn report_lines(creds_ok: bool, account_count: usize, has_default: bool) -> Vec<String> {
-    let mut lines = vec!["gworkspace-mcp doctor".to_string(), String::new()];
+    let mut lines = vec!["trusty-gworkspace-mcp doctor".to_string(), String::new()];
 
     lines.push(format!("[{}] OAuth client credentials", mark(creds_ok)));
     if !creds_ok {
@@ -181,7 +181,7 @@ pub fn report_lines(creds_ok: bool, account_count: usize, has_default: bool) -> 
         mark(account_count > 0)
     ));
     if account_count == 0 {
-        lines.push("      Run `gworkspace-mcp setup` to authorize an account.".to_string());
+        lines.push("      Run `trusty-gworkspace-mcp setup` to authorize an account.".to_string());
     }
 
     lines.push(format!(
@@ -205,7 +205,7 @@ pub fn report_lines(creds_ok: bool, account_count: usize, has_default: bool) -> 
 /// real network call or a test — and a `Dead` profile must always print the
 /// exact re-auth command so the fix is copy-pasteable.
 /// What: `Live` → one OK line (email + access-token lifetime); `Dead` → a
-/// failure line plus the `gworkspace-mcp setup --profile <name>` command;
+/// failure line plus the `trusty-gworkspace-mcp setup --profile <name>` command;
 /// `Unknown` → one graceful "could not determine" line (never fatal).
 /// Test: `health_lines_ok_shows_email`, `health_lines_dead_names_setup_command`,
 /// `health_lines_unknown_is_graceful`.
@@ -221,7 +221,7 @@ pub fn health_lines(profile: &str, email: Option<&str>, result: &ProbeResult) ->
         }
         ProbeResult::Dead => vec![
             format!("[!] {profile}: DEAD — refresh token for {who} is expired or revoked"),
-            format!("      re-authenticate with: gworkspace-mcp setup --profile {profile}"),
+            format!("      re-authenticate with: trusty-gworkspace-mcp setup --profile {profile}"),
         ],
         ProbeResult::Unknown => vec![format!(
             "[?] {profile}: UNKNOWN — could not reach Google to verify ({who}); check your connection"
@@ -244,7 +244,7 @@ mod tests {
         let joined = lines.join("\n");
         assert!(joined.contains("[!] OAuth client credentials"));
         assert!(joined.contains("GOOGLE_OAUTH_CLIENT_ID"));
-        assert!(joined.contains("Run `gworkspace-mcp setup`"));
+        assert!(joined.contains("Run `trusty-gworkspace-mcp setup`"));
         assert!(joined.contains("need attention"));
     }
 
@@ -294,7 +294,7 @@ mod tests {
         assert!(joined.contains("DEAD"), "dead marker: {joined}");
         assert!(joined.contains("expired or revoked"), "cause: {joined}");
         assert!(
-            joined.contains("gworkspace-mcp setup --profile work"),
+            joined.contains("trusty-gworkspace-mcp setup --profile work"),
             "must name the exact re-auth command for the dead profile: {joined}"
         );
     }

--- a/crates/trusty-gworkspace/src/cli/mod.rs
+++ b/crates/trusty-gworkspace/src/cli/mod.rs
@@ -1,4 +1,4 @@
-//! Command-line interface for the `gworkspace-mcp` binary.
+//! Command-line interface for the `trusty-gworkspace-mcp` binary.
 //!
 //! Why: The binary was stdio-only (no arg parsing) and relied on the Python
 //! CLI for onboarding. Issue #2631 adds native `setup` / `doctor` / `accounts`
@@ -20,7 +20,7 @@ use clap::{Parser, Subcommand};
 use crate::api::auth::TokenStorage;
 use crate::api::auth::oauth::{DefaultMode, flow, run_consent};
 
-/// `gworkspace-mcp` — Google Workspace MCP server + onboarding CLI.
+/// `trusty-gworkspace-mcp` — Google Workspace MCP server + onboarding CLI.
 ///
 /// Why: One binary serves two roles — the MCP stdio server (no subcommand)
 /// and the interactive management CLI (subcommands).
@@ -28,7 +28,7 @@ use crate::api::auth::oauth::{DefaultMode, flow, run_consent};
 /// Test: `no_subcommand_parses`.
 #[derive(Debug, Parser)]
 #[command(
-    name = "gworkspace-mcp",
+    name = "trusty-gworkspace-mcp",
     about = "Google Workspace MCP server (run with no subcommand) + OAuth onboarding CLI",
     long_about = None,
     version

--- a/crates/trusty-gworkspace/src/lib.rs
+++ b/crates/trusty-gworkspace/src/lib.rs
@@ -5,7 +5,7 @@
 //! Docs/Sheets/Slides/Tasks access through Model Context Protocol.
 //! What: Two logical layers — a pure Google Workspace API client under
 //! `api::` (auth, token storage, service modules) and an MCP server in
-//! `server` + `bin/gworkspace-mcp.rs` that dispatches JSON-RPC tool calls.
+//! `server` + `bin/trusty-gworkspace-mcp.rs` that dispatches JSON-RPC tool calls.
 //! Test: `cargo test -p trusty-gworkspace` runs the auth-model deserialise
 //! tests and the tools-list shape test.
 

--- a/crates/trusty-gworkspace/src/server.rs
+++ b/crates/trusty-gworkspace/src/server.rs
@@ -1,4 +1,4 @@
-//! MCP JSON-RPC dispatch + stdio loop for `gworkspace-mcp`.
+//! MCP JSON-RPC dispatch + stdio loop for `trusty-gworkspace-mcp`.
 //!
 //! Why: Every trusty-* MCP server uses the same shape — `initialize`,
 //! `tools/list`, `tools/call`, with notifications suppressed. Centralising
@@ -239,7 +239,7 @@ pub async fn handle_message(state: AppState, req: Value) -> Value {
 
 /// Run the stdio MCP loop wired to this server.
 ///
-/// Why: Single entry point for `bin/gworkspace-mcp.rs`.
+/// Why: Single entry point for `bin/trusty-gworkspace-mcp.rs`.
 /// What: Forwards every parsed `Request` to `handle_message` and wraps the
 /// JSON result back into a `Response`.
 /// Test: Manual — driven from Claude Code.

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -22,6 +22,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `has_developer_id_cert()` no longer passes a garbage identity string (SHA1 fingerprint + quotes still attached) to `codesign --sign` — it now extracts the quoted common name between the first and last `"` on the matching `security find-identity` line, matching `scripts/install-trusty-mpm-signed.sh`'s working `detect_identity()`. Previously `codesign` failed with "no identity found" even though the certificate was valid and listed by `security find-identity` (closes #2937, closes #2939).
 
+### Fixed
+
+- `tctl start`'s launchd skip message now says "already loaded" instead of "already running" — `is_loaded()` only confirms launchd registration via `launchctl print`, not process health, so a crash-looping agent (`KeepAlive::Always` restarting on every throttle interval) previously reported a misleading "already running" (closes #2573).
+
 ## [0.4.2] — 2026-07-17
 
 Ships the real Developer-ID signed-install path — the working `tctl sign`

--- a/crates/trusty-installer/src/commands/lifecycle.rs
+++ b/crates/trusty-installer/src/commands/lifecycle.rs
@@ -321,8 +321,16 @@ fn launchd_control(verb: Verb, binary: &str) -> anyhow::Result<String> {
                     // this same daemon seconds earlier. Skip the bounce when the
                     // agent is already loaded; this is a cheap `launchctl print`
                     // check (mirrors the daemons' own `service status`).
+                    //
+                    // #2573 (LOW): `is_loaded()` only confirms launchd
+                    // REGISTRATION via `launchctl print` — it says nothing about
+                    // whether the process is actually healthy, so a crash-looping
+                    // agent (`KeepAlive::Always` restarting it every throttle
+                    // interval) still reports "loaded" here. The message says
+                    // "already loaded", not "already running", so it doesn't
+                    // imply a health guarantee it can't back up.
                     if cfg.is_loaded() {
-                        return Ok(format!("{} already running (skipped restart)", cfg.label));
+                        return Ok(format!("{} already loaded (skipped restart)", cfg.label));
                     }
                     cfg.bootstrap()?;
                     Ok(format!("bootstrapped {}", cfg.label))

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -10,6 +10,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - narrowed confidence-banded reconciliation cap for Medium-driven REQUEST_CHANGES/D+ downgrades: when the model's own verdict is a clean APPROVE and the REQUEST_CHANGES floor rests SOLELY on one `Effort::Medium` finding in the marginal confidence band (`FLOOR_MIN_CONFIDENCE` 0.80 < c < the new `SOLO_MEDIUM_ESCALATION_CONFIDENCE` 0.90), the result is now capped at APPROVE* instead — a successor to the #1343 reconciliation cap #1876 removed, scoped narrowly so it does not reopen #1876's under-flagging regression (a ≥2-Medium floor, a solo Medium ≥0.90, any High-effort finding, or a confident conformance divergence all still escalate uncapped). Addresses the Rank-1 driver of the #1897 over-flagging shadow-eval (47% of clean PRs graded BLOCK/F under 0.6.3). Both new thresholds are env-overridable (`TRUSTY_REVIEW_SOLO_MEDIUM_ESCALATION_CONFIDENCE`, closes #1897)
+- **BREAKING:** `DEFAULT_PORT` moved from 7890 to 7891 — 7890 collided with
+  trusty-embedderd's `--http` mode default. The cross-crate
+  known-siblings port-contract test now also tracks trusty-embedderd,
+  closing the gap that let the collision through (closes #2573).
+  Anyone with tooling, scripts, or a launchd/systemd unit hard-coded to
+  `trusty-review`'s old default (7890, e.g. `curl http://127.0.0.1:7890/health`)
+  must either pass `--port 7890` explicitly to `trusty-review serve` to keep
+  the old behavior, or update that tooling to the new default (7891).
 
 ## [0.9.2] — 2026-07-17
 

--- a/crates/trusty-review/src/commands/serve.rs
+++ b/crates/trusty-review/src/commands/serve.rs
@@ -37,16 +37,17 @@ use crate::cli_verify;
 ///
 /// Why: collects the port, bind address, and mode flags so the server can be
 /// configured purely from CLI flags without requiring env-var wrangling.
-/// What: `--port` sets the listen port (default 7890); `--stdio` activates the
+/// What: `--port` sets the listen port (default 7891); `--stdio` activates the
 /// MCP JSON-RPC stdio loop instead of binding TCP.
 /// Test: `cargo run -p trusty-review --features http-server -- serve --help`.
 #[derive(Debug, clap::Parser)]
 pub struct ServeArgs {
     /// HTTP listen port.
-    /// Default: 7890 — distinct from every known sibling default: trusty-memory
+    /// Default: 7891 — distinct from every known sibling default: trusty-memory
     /// :7070, trusty-search :7878, trusty-analyze :7879, trusty-console :7788,
-    /// AND trusty-mpm (`tm`) :7880 (the collision a live host reproduced —
-    /// #2566 review; see `service::DEFAULT_PORT`'s doc for the incident).
+    /// trusty-mpm (`tm`) :7880 (the collision a live host reproduced — #2566
+    /// review), AND trusty-embedderd's `--http` mode :7890 (#2573 — see
+    /// `service::DEFAULT_PORT`'s doc for both incidents).
     /// Ignored when --stdio is set.
     #[arg(long, default_value_t = DEFAULT_PORT, value_name = "PORT")]
     pub port: u16,

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -82,9 +82,9 @@ enum Commands {
     /// Reads the `http_addr` discovery file written at daemon bind time and
     /// prints the address in one of three machine-readable formats:
     ///
-    ///   trusty-review port          → bare port:  7890
-    ///   trusty-review port --addr   → host:port:  127.0.0.1:7890
-    ///   trusty-review port --json   → JSON:       {"addr":"127.0.0.1","port":7890}
+    ///   trusty-review port          → bare port:  7891
+    ///   trusty-review port --addr   → host:port:  127.0.0.1:7891
+    ///   trusty-review port --json   → JSON:       {"addr":"127.0.0.1","port":7891}
     ///
     /// Exits non-zero when no daemon discovery file is found so shell
     /// substitution (`$(trusty-review port)`) fails safely.
@@ -98,7 +98,7 @@ enum Commands {
         json: bool,
     },
 
-    /// Start the long-lived HTTP webhook server (port 7890 by default).
+    /// Start the long-lived HTTP webhook server (port 7891 by default).
     ///
     /// Exposes:
     ///   GET  /health                  — liveness + dep status

--- a/crates/trusty-review/src/service/mod.rs
+++ b/crates/trusty-review/src/service/mod.rs
@@ -44,14 +44,22 @@ use crate::service::webhook::handle_github_webhook;
 /// `tm` daemon binds `127.0.0.1:7880` on every managed machine, so a launchd
 /// agent that runs `trusty-review serve` with no explicit `--port` collided
 /// with it and crash-looped (`KeepAlive::Always`, 10s throttle) on install.
-/// 7890 is verified free against the full known set: 7070 = trusty-memory,
+/// The follow-up default (7890) was itself found (#2573) to collide with
+/// `trusty-embedderd`'s `--http` mode default (`127.0.0.1:7890`,
+/// `crates/trusty-embedderd/src/lib.rs`) — not reachable via any
+/// `tctl`-managed automation, since the embedder auto-spawn always uses
+/// `--stdio`/UDS, so it was a manual dev-run footgun only, but still a real
+/// collision for anyone running `trusty-embedderd --http` and
+/// `trusty-review serve` on the same host with no explicit `--port`/`--http`.
+/// 7891 is verified free against the full known set: 7070 = trusty-memory,
 /// 7878 = trusty-search, 7879 = trusty-analyze, 7788 = trusty-console,
-/// 7880 = trusty-mpm (`tm`).
-/// What: 7890 (superseding the REV-803 spec's original 7880).
+/// 7880 = trusty-mpm (`tm`), 7890 = trusty-embedderd (`--http` mode).
+/// What: 7891 (superseding the #2566 fix's 7890, itself superseding the
+/// REV-803 spec's original 7880).
 /// Test: `serve_help_shows_default_port` checks the CLI default;
 /// `default_port_does_not_collide_with_known_siblings` pins uniqueness
-/// against the full known-port table.
-pub const DEFAULT_PORT: u16 = 7890;
+/// against the full known-port table, which now includes trusty-embedderd.
+pub const DEFAULT_PORT: u16 = 7891;
 
 /// Resolve the dotfile discovery path `~/.trusty-review/http_addr`.
 ///
@@ -259,16 +267,23 @@ mod tests {
         assert_eq!(content, "127.0.0.1:7880");
     }
 
-    /// Cross-crate port-uniqueness contract (#2566 review finding).
+    /// Cross-crate port-uniqueness contract (#2566, extended by #2573).
     ///
     /// Why: the original `DEFAULT_PORT` value (7880) silently collided with
     /// trusty-mpm's `DEFAULT_DAEMON_ADDR` (`core/discovery.rs`), which is bound
     /// on every managed machine — a launchd agent running `trusty-review serve`
-    /// crash-looped against the live `tm` daemon on install. This table encodes
-    /// every sibling daemon's known default port (pointer-commented to its real
-    /// source constant, mirroring `trusty-installer`'s `plist_label.rs` override
-    /// table) so a future edit to `DEFAULT_PORT` that reintroduces a collision
-    /// fails this test instead of shipping a crash-loop.
+    /// crash-looped against the live `tm` daemon on install. The follow-up
+    /// default (7890) then collided with `trusty-embedderd`'s `--http` mode
+    /// default (#2573) — that gap existed because this table only tracked
+    /// `tctl`-managed daemons and omitted trusty-embedderd, whose HTTP listener
+    /// is a manual/dev-only opt-in (auto-spawn always uses `--stdio`/UDS), not
+    /// a "full known set" as originally claimed. This table now encodes every
+    /// sibling process's known default port — both `tctl`-managed daemons AND
+    /// manually-run HTTP listeners like trusty-embedderd — pointer-commented to
+    /// its real source constant (mirroring `trusty-installer`'s
+    /// `plist_label.rs` override table), so a future edit to `DEFAULT_PORT`
+    /// that reintroduces a collision fails this test instead of shipping a
+    /// crash-loop or a silent bind failure.
     /// What: asserts `DEFAULT_PORT` is absent from the known-sibling-ports list.
     /// Test: this is the test.
     #[test]
@@ -299,6 +314,11 @@ mod tests {
                 "trusty-mpm",
                 7880,
                 "trusty-mpm/src/core/discovery.rs::DEFAULT_DAEMON_ADDR",
+            ),
+            (
+                "trusty-embedderd",
+                7890,
+                "trusty-embedderd/src/lib.rs::Args::http_addr (--http default_value, manual/dev-run only)",
             ),
         ];
         for (binary, port, source) in known_siblings {


### PR DESCRIPTION
## Summary

Four small, independent bug fixes bundled into one sweep PR, one commit per issue.

### #2644 — gworkspace-mcp $PATH collision (BREAKING, migration required)

The native cargo-installed binary and the legacy pipx-installed Python `gworkspace-mcp` package shared one name on `$PATH`, so which implementation actually launched depended on install order.

**Fix:** renamed the native `[[bin]]` target from `gworkspace-mcp` to `trusty-gworkspace-mcp` (`crates/trusty-gworkspace/Cargo.toml`; `src/bin/gworkspace-mcp.rs` → `src/bin/trusty-gworkspace-mcp.rs`). Updated the CLI program name, doctor/accounts/oauth-error messages, README, and CHANGELOG. `trusty-agents`' `default-config.toml` `command` fields for the two native gworkspace MCP entries now target the renamed binary; the registry `name` identifier is left as `gworkspace-mcp` (an internal label, not a `$PATH` lookup).

**⚠️ Breaking change / migration:** token/config paths (`~/.gworkspace-mcp/…`) and the default profile name are UNCHANGED — existing accounts keep working without re-authenticating. But any `.mcp.json` / `~/.claude.json` entry's `"command"` field must be updated from `"gworkspace-mcp"` to `"trusty-gworkspace-mcp"`, then re-run `cargo install --path crates/trusty-gworkspace`.

**Follow-up (code-critic LOW):** `crates/trusty-agents/src/tools/mcp_tools/schema.rs`'s `mcp_add` tool schema still used `'gworkspace-mcp'` as its example `command` value — surfaced live to LLM agents, so a stale example would have told agents to point new registrations at the now-ambiguous old name. Updated to `'trusty-gworkspace-mcp'`.

### #2573 — trusty-review port collision with trusty-embedderd (BREAKING for hard-coded tooling)

`trusty-review`'s `DEFAULT_PORT` (7890, from the #2566 fix) collided with `trusty-embedderd`'s `--http` mode default (`127.0.0.1:7890`) — a manual dev-run footgun (not reachable via `tctl` automation, since embedder auto-spawn always uses `--stdio`/UDS).

**Fix:** moved `trusty-review`'s `DEFAULT_PORT` to 7891; extended the cross-crate `known_siblings` port-contract tables in both `trusty-review` and `trusty-console` to also track `trusty-embedderd`'s `--http` default, closing the gap that let the collision through (the table previously only tracked `tctl`-managed daemons). Also fixed the LOW item from the same review: `tctl start`'s `is_loaded()` skip message said "already running" for a job that may be crash-looping (`launchctl print` reports registration, not health) — reworded to "already loaded".

**⚠️ Breaking change:** anyone with tooling, scripts, or a launchd/systemd unit hard-coded to `trusty-review`'s old default (7890 — e.g. `curl http://127.0.0.1:7890/health`) must either pass `--port 7890` explicitly to `trusty-review serve` to keep the old behavior, or update that tooling to the new default (7891).

### #2150 — unified-diff applier chokes on `\ No newline at end of file`

`parse_hunks` (`crates/trusty-code/src/tools/fs/edit_format/diff.rs`) hard-errored on any hunk-body line whose first byte wasn't space/-/+, including the standard git diff footer marker `\ No newline at end of file`.

**Fix:** skip `\`-prefixed footer lines instead of erroring — but the marker's *position* also carries meaning (which side of the diff it followed), not just its presence. A footer attached to the new/both side means the output has no trailing newline; a footer attached ONLY to the old side means the diff *removes* a no-trailing-newline state, so the output *gains* a trailing newline regardless of what the original file had. Added `apply_footer_marker_after_removal_only_forces_trailing_newline`, `apply_footer_marker_after_addition_removes_trailing_newline`, and `apply_footer_marker_on_both_sides_keeps_no_trailing_newline` covering both state-change directions plus the unchanged case.

**Follow-up (code-critic HIGH):** an initial version of this fix skipped the marker at parse time but decided the output's trailing-newline state solely from the ORIGINAL file's trailing byte, silently producing the wrong final byte on a state-change hunk — a regression from the pre-fix fail-closed behavior (hard error, no corruption). Fixed as described above before this PR opened for review.

### #2152 — delegated engineer prompt advertises `use_skill` but the tool isn't registered

PR #2942 fixed this gap in the legacy `run_task/mod.rs::ProjectToolFactory` path; the *current* delegation path's `task::executor::ProjectToolFactory::build` still omitted `UseSkillTool` while the engineer's prompt advertised it via `with_skills_catalog`, so a `use_skill` call from the engineer errored with "no tool registered".

**Fix:** threaded the same `Arc<dyn SkillResolver>` through `EngineerPromptContext`/`ProjectToolFactory`, mirroring `run_task`'s fix. Added `engineer_registry_includes_use_skill_when_catalog_present`.

## Test plan

- [x] `cargo check` (workspace) — clean
- [x] `cargo test -p trusty-gworkspace -p trusty-review -p trusty-code -p trusty-agents` — clean, all pass. (An earlier pass surfaced two `run_task::tests` failures — `exit_code_reflects_run_failure`, `no_changes_yields_no_changes_exit` — confirmed to be a PRE-EXISTING environmental flake by reproducing them identically against pristine `origin/main` in an isolated verification worktree: a locally-running `trusty-search` daemon writes `.trusty-search/index.redb` into test tempdirs, unrelated to any file this PR touches (`run_task/mod.rs`/`run_task/tests.rs` are untouched) and order/timing-dependent — a subsequent full run was clean.)
- [x] `cargo clippy -p trusty-gworkspace -p trusty-review -p trusty-code -p trusty-agents --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (9 allowlisted, 0 violations)

Closes #2644
Closes #2573
Closes #2150
Closes #2152

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
