### PR TITLE
fix(trusty-memory): validate consolidation model at startup, fail loud once instead of per-cycle retry

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -16,6 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- semantic-consolidation dream job: validate the configured model against the resolved provider (Ollama vs OpenRouter) before building the inference backend; a misconfigured model (e.g. the OpenRouter-style default resolved against a local Ollama server) now logs one loud, actionable error and disables the phase for that palace's `Dreamer` lifetime instead of retrying every dream cycle ([#2593](https://github.com/bobmatnyc/trusty-tools/issues/2593))
 - harden mid-task incremental index-file updates against transient send failures ([#2796](https://github.com/bobmatnyc/trusty-tools/pull/2796)) ([`1f8b569`](https://github.com/bobmatnyc/trusty-tools/commit/1f8b56924db6534d6b67811c39d8862dc53cc606))
 - bump lru and jsonwebtoken to patched versions ([#2782](https://github.com/bobmatnyc/trusty-tools/pull/2782)) ([`298df87`](https://github.com/bobmatnyc/trusty-tools/commit/298df87e6a5b5e96874ea2866509303df14712bc))
 

--- a/crates/trusty-common/src/memory_core/dream/cycle.rs
+++ b/crates/trusty-common/src/memory_core/dream/cycle.rs
@@ -19,7 +19,7 @@ use crate::memory_core::semantic_consolidation::{
     SemanticConsolidator, inference_available, validate_ollama_model,
 };
 use crate::memory_core::store::vector::VectorStore;
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -332,7 +332,7 @@ pub struct RoomConsolidationStats {
 /// (`Err` path), and the production daemon.
 fn build_consolidator_from_config(
     config: &DreamConfig,
-) -> std::result::Result<Option<Arc<SemanticConsolidator>>, String> {
+) -> Result<Option<Arc<SemanticConsolidator>>> {
     if !config.semantic.enabled {
         return Ok(None);
     }
@@ -568,11 +568,11 @@ pub(super) async fn semantic_consolidation_pass(
                     );
                     return (0, 0, 0);
                 }
-                Err(msg) => {
+                Err(e) => {
                     tracing::error!(
                         palace = %handle.id,
                         model = %config.semantic.model,
-                        "semantic consolidation disabled for this palace: {msg}"
+                        "semantic consolidation disabled for this palace: {e:#}"
                     );
                     disabled.store(true, Ordering::Relaxed);
                     return (0, 0, 0);
@@ -666,16 +666,16 @@ pub async fn consolidate_scoped(
                 );
                 return Ok(RoomConsolidationStats::default());
             }
-            Err(msg) => {
+            Err(e) => {
                 // On-demand call (not a recurring background job): surface
                 // the misconfiguration to the caller immediately rather than
                 // silently no-op'ing or retrying (issue #2593).
                 tracing::error!(
                     palace = %handle.id,
                     model = %config.semantic.model,
-                    "dream_consolidate_room: semantic consolidation misconfigured: {msg}"
+                    "dream_consolidate_room: semantic consolidation misconfigured: {e:#}"
                 );
-                return Err(anyhow!(msg));
+                return Err(e);
             }
         },
     };

--- a/crates/trusty-common/src/memory_core/dream/cycle.rs
+++ b/crates/trusty-common/src/memory_core/dream/cycle.rs
@@ -16,7 +16,7 @@ use crate::memory_core::decay::DecayConfig;
 use crate::memory_core::palace::{Drawer, RoomType};
 use crate::memory_core::retrieval::{PalaceHandle, shared_embedder};
 use crate::memory_core::semantic_consolidation::{
-    SemanticConsolidator, inference_available, validate_ollama_model,
+    SemanticConsolidator, inference_available, resolve_openrouter_api_key, validate_ollama_model,
 };
 use crate::memory_core::store::vector::VectorStore;
 use anyhow::Result;
@@ -336,11 +336,7 @@ fn build_consolidator_from_config(
     if !config.semantic.enabled {
         return Ok(None);
     }
-    let api_key = if !config.openrouter_api_key.is_empty() {
-        config.openrouter_api_key.clone()
-    } else {
-        std::env::var(crate::env_vars::ENV_OPENROUTER_API_KEY).unwrap_or_default()
-    };
+    let api_key = resolve_openrouter_api_key(&config.openrouter_api_key);
     if !inference_available(&api_key, config.local_model_enabled) {
         return Ok(None);
     }

--- a/crates/trusty-common/src/memory_core/dream/cycle.rs
+++ b/crates/trusty-common/src/memory_core/dream/cycle.rs
@@ -15,11 +15,14 @@ use super::helpers::{
 use crate::memory_core::decay::DecayConfig;
 use crate::memory_core::palace::{Drawer, RoomType};
 use crate::memory_core::retrieval::{PalaceHandle, shared_embedder};
-use crate::memory_core::semantic_consolidation::{SemanticConsolidator, inference_available};
+use crate::memory_core::semantic_consolidation::{
+    SemanticConsolidator, inference_available, validate_ollama_model,
+};
 use crate::memory_core::store::vector::VectorStore;
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -309,20 +312,29 @@ pub struct RoomConsolidationStats {
 }
 
 /// Build the production semantic consolidator from config, gating on inference
-/// availability.
+/// availability and validating the model against the resolved provider.
 ///
 /// Why: both the idle dream pass and the on-demand room consolidation need the
 /// identical "is inference configured? then build a backend" logic; sharing it
-/// keeps the gate in one place.
-/// What: returns `None` when `config.semantic` is disabled or no inference
-/// backend is available; otherwise builds an `OllamaInference` (when a local
-/// model is enabled and no key is set) or `OpenRouterInference` and wraps it in
-/// a `SemanticConsolidator`.
-/// Test: exercised via `dream_cycle_semantic_consolidation_no_inference` (None
-/// path) and the production daemon.
-fn build_consolidator_from_config(config: &DreamConfig) -> Option<Arc<SemanticConsolidator>> {
+/// keeps the gate in one place. It is also the single place that validates the
+/// configured model against the resolved provider (issue #2593), so a
+/// misconfigured Ollama model id is caught before the first of many doomed
+/// network calls rather than retried every cycle.
+/// What: returns `Ok(None)` when `config.semantic` is disabled or no inference
+/// backend is available (a legitimate, silent no-op); returns `Err` with an
+/// actionable message when the resolved backend is Ollama and
+/// `config.semantic.model` cannot resolve there (see `validate_ollama_model`);
+/// otherwise builds an `OllamaInference` (when a local model is enabled and no
+/// key is set) or `OpenRouterInference` and wraps it in a
+/// `SemanticConsolidator`.
+/// Test: exercised via `dream_cycle_semantic_consolidation_no_inference`
+/// (`Ok(None)` path), `dream_cycle_semantic_consolidation_invalid_model_disables_once`
+/// (`Err` path), and the production daemon.
+fn build_consolidator_from_config(
+    config: &DreamConfig,
+) -> std::result::Result<Option<Arc<SemanticConsolidator>>, String> {
     if !config.semantic.enabled {
-        return None;
+        return Ok(None);
     }
     let api_key = if !config.openrouter_api_key.is_empty() {
         config.openrouter_api_key.clone()
@@ -330,11 +342,12 @@ fn build_consolidator_from_config(config: &DreamConfig) -> Option<Arc<SemanticCo
         std::env::var(crate::env_vars::ENV_OPENROUTER_API_KEY).unwrap_or_default()
     };
     if !inference_available(&api_key, config.local_model_enabled) {
-        return None;
+        return Ok(None);
     }
     use crate::memory_core::semantic_consolidation::{OllamaInference, OpenRouterInference};
     let backend: Arc<dyn crate::memory_core::semantic_consolidation::Inference> =
         if config.local_model_enabled && api_key.is_empty() {
+            validate_ollama_model(&config.semantic.model)?;
             Arc::new(OllamaInference::new(
                 "http://localhost:11434",
                 &config.semantic.model,
@@ -342,10 +355,10 @@ fn build_consolidator_from_config(config: &DreamConfig) -> Option<Arc<SemanticCo
         } else {
             Arc::new(OpenRouterInference::new(api_key, &config.semantic.model))
         };
-    Some(Arc::new(SemanticConsolidator::new(
+    Ok(Some(Arc::new(SemanticConsolidator::new(
         backend,
         config.semantic.clone(),
-    )))
+    ))))
 }
 
 /// Apply a consolidation result: add canonical drawers + record KG provenance.
@@ -509,14 +522,21 @@ async fn apply_alias_and_flag_passes(
 /// injected via `Dreamer::with_consolidator`), runs consolidation on all
 /// current non-Task drawers, writes each canonical drawer via `handle.remember`,
 /// and records the `superseded_by` KG triple so the original drawers are
-/// traceable. Additive-only — originals are preserved.
+/// traceable. Additive-only — originals are preserved. When
+/// `build_consolidator_from_config` reports a misconfigured model/provider
+/// combination (issue #2593), logs ONE loud `error!` naming the model, the
+/// provider, and the config knob to fix, sets `disabled`, and returns
+/// `(0, 0, 0)`; every subsequent call with the same `disabled` flag short-
+/// circuits before rebuilding or retrying, instead of failing every cycle.
 /// Returns `(canonical_count, llm_calls, cache_hits)`.
 /// Test: `dream_cycle_semantic_consolidation_with_mock` (injected
-/// consolidator); `dream_cycle_semantic_consolidation_no_inference`.
+/// consolidator); `dream_cycle_semantic_consolidation_no_inference`;
+/// `dream_cycle_semantic_consolidation_invalid_model_disables_once`.
 pub(super) async fn semantic_consolidation_pass(
     handle: &Arc<PalaceHandle>,
     config: &DreamConfig,
     injected: Option<Arc<SemanticConsolidator>>,
+    disabled: &AtomicBool,
 ) -> (usize, usize, usize) {
     // The idle cycle honours the `semantic.enabled` switch even when a
     // consolidator is injected (tests rely on this): disabling the phase in
@@ -532,16 +552,33 @@ pub(super) async fn semantic_consolidation_pass(
     // Use the injected consolidator (test path) or build one from config.
     let consolidator: Arc<SemanticConsolidator> = match injected {
         Some(c) => c,
-        None => match build_consolidator_from_config(config) {
-            Some(c) => c,
-            None => {
-                tracing::debug!(
-                    palace = %handle.id,
-                    "skipping semantic consolidation: disabled or inference unavailable"
-                );
+        None => {
+            if disabled.load(Ordering::Relaxed) {
+                // Already failed loud once for this palace's Dreamer
+                // lifetime; skip without rebuilding or retrying the
+                // known-bad config every cycle (issue #2593).
                 return (0, 0, 0);
             }
-        },
+            match build_consolidator_from_config(config) {
+                Ok(Some(c)) => c,
+                Ok(None) => {
+                    tracing::debug!(
+                        palace = %handle.id,
+                        "skipping semantic consolidation: disabled or inference unavailable"
+                    );
+                    return (0, 0, 0);
+                }
+                Err(msg) => {
+                    tracing::error!(
+                        palace = %handle.id,
+                        model = %config.semantic.model,
+                        "semantic consolidation disabled for this palace: {msg}"
+                    );
+                    disabled.store(true, Ordering::Relaxed);
+                    return (0, 0, 0);
+                }
+            }
+        }
     };
 
     // spec-001: exclude protected Task drawers from consolidation entirely so
@@ -590,11 +627,15 @@ pub(super) async fn semantic_consolidation_pass(
 /// the guard a cutoff of `now` would make every drawer (even ones created this
 /// instant) eligible and evict the entire room.
 /// `injected` lets tests supply a `MockInference`-backed consolidator; in
-/// production it is `None` and the consolidator is built from `config`.
+/// production it is `None` and the consolidator is built from `config`. This
+/// is an on-demand, user-triggered call (not the recurring background dream
+/// loop), so a misconfigured model/provider combination (issue #2593) is
+/// surfaced as `Err` to the caller immediately rather than silently no-op'd.
 /// Test: `consolidate_scoped_filters_by_room`,
 /// `consolidate_scoped_skips_task_drawers`,
 /// `consolidate_scoped_no_inference_is_noop`,
-/// `consolidate_scoped_non_positive_age_is_noop` in `dream::tests`.
+/// `consolidate_scoped_non_positive_age_is_noop`,
+/// `consolidate_scoped_invalid_model_returns_err` in `dream::tests`.
 pub async fn consolidate_scoped(
     handle: &Arc<PalaceHandle>,
     config: &DreamConfig,
@@ -617,13 +658,24 @@ pub async fn consolidate_scoped(
     let consolidator: Arc<SemanticConsolidator> = match injected {
         Some(c) => c,
         None => match build_consolidator_from_config(config) {
-            Some(c) => c,
-            None => {
+            Ok(Some(c)) => c,
+            Ok(None) => {
                 tracing::debug!(
                     palace = %handle.id,
                     "dream_consolidate_room: inference unavailable; no-op"
                 );
                 return Ok(RoomConsolidationStats::default());
+            }
+            Err(msg) => {
+                // On-demand call (not a recurring background job): surface
+                // the misconfiguration to the caller immediately rather than
+                // silently no-op'ing or retrying (issue #2593).
+                tracing::error!(
+                    palace = %handle.id,
+                    model = %config.semantic.model,
+                    "dream_consolidate_room: semantic consolidation misconfigured: {msg}"
+                );
+                return Err(anyhow!(msg));
             }
         },
     };

--- a/crates/trusty-common/src/memory_core/dream/dreamer.rs
+++ b/crates/trusty-common/src/memory_core/dream/dreamer.rs
@@ -22,7 +22,7 @@ use crate::memory_core::retrieval::PalaceHandle;
 use crate::memory_core::semantic_consolidation::SemanticConsolidator;
 use anyhow::{Context, Result};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
 use super::helpers::now_secs;
@@ -43,6 +43,13 @@ pub struct Dreamer {
     /// When `None`, `semantic_consolidation_pass` builds the consolidator from
     /// `config` at runtime.
     pub(super) consolidator: Option<Arc<SemanticConsolidator>>,
+    /// Set once the semantic-consolidation phase hits an unresolvable
+    /// model/provider combination (issue #2593). Once `true`,
+    /// `semantic_consolidation_pass` skips the phase entirely on every
+    /// subsequent cycle instead of rebuilding and retrying a known-bad
+    /// config forever. Only cleared by constructing a fresh `Dreamer` (i.e.
+    /// a config reload), matching "disabled until the config is fixed".
+    pub(super) semantic_consolidation_disabled: AtomicBool,
 }
 
 impl Dreamer {
@@ -58,6 +65,7 @@ impl Dreamer {
             config,
             last_activity: Arc::new(AtomicU64::new(now_secs())),
             consolidator: None,
+            semantic_consolidation_disabled: AtomicBool::new(false),
         }
     }
 
@@ -76,6 +84,7 @@ impl Dreamer {
             config,
             last_activity: Arc::new(AtomicU64::new(now_secs())),
             consolidator: Some(consolidator),
+            semantic_consolidation_disabled: AtomicBool::new(false),
         }
     }
 
@@ -88,6 +97,18 @@ impl Dreamer {
     pub fn is_idle(&self) -> bool {
         let last = self.last_activity.load(Ordering::Relaxed);
         now_secs().saturating_sub(last) >= self.config.idle_secs
+    }
+
+    /// Whether the semantic-consolidation phase is disabled due to a
+    /// misconfigured model/provider combination detected during a prior
+    /// cycle (issue #2593).
+    ///
+    /// Why: surfaces the "fail loud once, don't retry" state for callers
+    /// (tests, admin dashboards) without exposing the raw atomic field.
+    /// What: relaxed load of `semantic_consolidation_disabled`.
+    /// Test: `dream_cycle_semantic_consolidation_invalid_model_disables_once`.
+    pub fn is_semantic_consolidation_disabled(&self) -> bool {
+        self.semantic_consolidation_disabled.load(Ordering::Relaxed)
     }
 
     /// Spawn the background dream loop.
@@ -245,7 +266,13 @@ impl Dreamer {
 
         // ── Phase: Semantic consolidation (optional, inference-gated) ──────────
         let (semantically_consolidated, semantic_llm_calls, semantic_cache_hits) =
-            semantic_consolidation_pass(handle, &self.config, self.consolidator.clone()).await;
+            semantic_consolidation_pass(
+                handle,
+                &self.config,
+                self.consolidator.clone(),
+                &self.semantic_consolidation_disabled,
+            )
+            .await;
 
         // Persist the trimmed L1 snapshot so a restart sees the consolidated state.
         if let Err(e) = handle.flush() {

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -809,6 +809,109 @@ async fn dream_cycle_semantic_consolidation_no_inference() {
     );
 }
 
+/// Why (issue #2593): the exact production failure — default config
+/// (`local_model_enabled = true`, no OpenRouter key, `semantic.model =
+/// "anthropic/claude-haiku-4-5"`) — must be caught once and disable the
+/// phase for this `Dreamer`'s lifetime instead of retrying every cycle.
+/// What: Runs `dream_cycle` twice with no injected consolidator and
+/// `DreamConfig::default()`. Asserts both cycles report zero semantic work,
+/// `Dreamer::is_semantic_consolidation_disabled()` is `true` after the first
+/// cycle, and it stays `true` (no reset) after the second — proving the
+/// second cycle short-circuited before rebuilding/retrying the backend.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_cycle_semantic_consolidation_invalid_model_disables_once() {
+    let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
+
+    let handle = open_test_handle("dream-semantic-invalid-model").await;
+    handle
+        .remember(
+            "some memory that should not be semantically consolidated".into(),
+            RoomType::General,
+            vec![],
+            0.5,
+        )
+        .await
+        .unwrap();
+
+    let dreamer = Dreamer::new(DreamConfig::default());
+    assert!(!dreamer.is_semantic_consolidation_disabled());
+
+    let stats1 = dreamer.dream_cycle(&handle).await.unwrap();
+    assert_eq!(
+        stats1.semantically_consolidated, 0,
+        "misconfigured model must not produce any consolidation output"
+    );
+    assert_eq!(stats1.semantic_llm_calls, 0);
+    assert!(
+        dreamer.is_semantic_consolidation_disabled(),
+        "invalid model/provider combination must disable the phase after one cycle"
+    );
+
+    let stats2 = dreamer.dream_cycle(&handle).await.unwrap();
+    assert_eq!(
+        stats2.semantically_consolidated, 0,
+        "second cycle must remain a no-op (no retry of the known-bad config)"
+    );
+    assert_eq!(stats2.semantic_llm_calls, 0);
+    assert!(
+        dreamer.is_semantic_consolidation_disabled(),
+        "disabled state must persist across cycles"
+    );
+
+    // Palace must be intact — no partial writes from the doomed build attempt.
+    assert_eq!(
+        handle.drawers.read().len(),
+        1,
+        "drawer must survive untouched"
+    );
+}
+
+/// Why (issue #2593): a correctly-configured local model (a bare Ollama tag,
+/// no OpenRouter/cloud vendor prefix) must pass validation and NOT trip the
+/// disable flag — only the specific cloud-vendor-prefix mismatch should.
+/// What: Sets `semantic.model = "llama3.1"` with the local-model path
+/// enabled. The actual HTTP call still fails in this sandboxed test
+/// environment (no live Ollama server), which `SemanticConsolidator`
+/// already handles gracefully (counts the call, returns no actions) — the
+/// assertion here is specifically that `is_semantic_consolidation_disabled()`
+/// stays `false`, proving the model passed validation and normal operation
+/// (build + attempt) proceeded unchanged.
+/// Test: This test itself.
+#[tokio::test]
+async fn dream_cycle_semantic_consolidation_valid_local_model_not_disabled() {
+    let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
+
+    let handle = open_test_handle("dream-semantic-valid-local-model").await;
+    handle
+        .remember(
+            "some memory that should not be semantically consolidated".into(),
+            RoomType::General,
+            vec![],
+            0.5,
+        )
+        .await
+        .unwrap();
+
+    let dreamer = Dreamer::new(DreamConfig {
+        semantic: crate::memory_core::semantic_consolidation::SemanticConsolidationConfig {
+            enabled: true,
+            model: "llama3.1".to_string(),
+            ..Default::default()
+        },
+        local_model_enabled: true,
+        openrouter_api_key: String::new(),
+        ..DreamConfig::default()
+    });
+
+    let _stats = dreamer.dream_cycle(&handle).await.unwrap();
+
+    assert!(
+        !dreamer.is_semantic_consolidation_disabled(),
+        "a valid local model id must pass validation and not disable the phase"
+    );
+}
+
 /// Why: When `semantic.enabled = false`, the phase must be skipped even
 /// if an inference backend is configured, so operators can opt out cheaply.
 /// What: Supply a consolidator but set enabled=false; assert the consolidator's
@@ -1436,8 +1539,13 @@ async fn consolidate_scoped_skips_task_drawers() {
 }
 
 /// Why: when no inference backend is configured the tool must no-op cleanly.
-/// What: with the OpenRouter env key removed, default config, and no injected
-/// consolidator, `consolidate_scoped` returns zero counts without error.
+/// What: with the OpenRouter env key removed, the local-model path explicitly
+/// disabled, and no injected consolidator, `consolidate_scoped` returns zero
+/// counts without error. `local_model_enabled: false` is set explicitly here
+/// (issue #2593): `DreamConfig::default()` alone is no longer "no inference"
+/// — its default model/provider combination is exactly the misconfiguration
+/// this issue fixes, so it now returns `Err` (see
+/// `consolidate_scoped_invalid_model_returns_err`) instead of a silent no-op.
 /// Test: this function.
 #[tokio::test]
 async fn consolidate_scoped_no_inference_is_noop() {
@@ -1447,10 +1555,44 @@ async fn consolidate_scoped_no_inference_is_noop() {
         .remember("some aged fact".into(), RoomType::Backend, vec![], 0.5)
         .await
         .unwrap();
-    let stats = consolidate_scoped(&handle, &DreamConfig::default(), None, 7, None)
+    let cfg = DreamConfig {
+        local_model_enabled: false,
+        ..DreamConfig::default()
+    };
+    let stats = consolidate_scoped(&handle, &cfg, None, 7, None)
         .await
         .unwrap();
     assert_eq!(stats, RoomConsolidationStats::default());
+}
+
+/// Why (issue #2593): the on-demand `dream_consolidate_room` tool must
+/// surface a misconfigured model/provider combination to the caller as an
+/// error rather than silently no-op'ing (it's a single user-triggered call,
+/// not a recurring background job, so there is nothing to "disable").
+/// What: `DreamConfig::default()` — local-model path enabled, no OpenRouter
+/// key, default OpenRouter-style model id — is exactly the #2593
+/// misconfiguration. Asserts `consolidate_scoped` returns `Err` naming both
+/// the model and Ollama.
+#[tokio::test]
+async fn consolidate_scoped_invalid_model_returns_err() {
+    let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
+    let handle = open_test_handle("scoped-invalid-model").await;
+    handle
+        .remember("some aged fact".into(), RoomType::Backend, vec![], 0.5)
+        .await
+        .unwrap();
+    let err = consolidate_scoped(&handle, &DreamConfig::default(), None, 7, None)
+        .await
+        .unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("anthropic/"),
+        "error should name the model: {msg}"
+    );
+    assert!(
+        msg.contains("Ollama"),
+        "error should name the provider: {msg}"
+    );
 }
 
 /// Why: `max_age_days <= 0` is a guard value meaning "consolidate nothing".

--- a/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
+++ b/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
@@ -155,10 +155,11 @@ mod tests {
     #[test]
     fn validate_ollama_model_rejects_cloud_prefix() {
         let err = validate_ollama_model("anthropic/claude-haiku-4-5").unwrap_err();
-        assert!(err.contains("anthropic/"), "message should name the model");
-        assert!(err.contains("Ollama"), "message should name the provider");
+        let msg = err.to_string();
+        assert!(msg.contains("anthropic/"), "message should name the model");
+        assert!(msg.contains("Ollama"), "message should name the provider");
         assert!(
-            err.contains("semantic.model") || err.contains("openrouter_api_key"),
+            msg.contains("semantic.model") || msg.contains("openrouter_api_key"),
             "message should name a config knob to fix it"
         );
     }
@@ -170,6 +171,28 @@ mod tests {
         assert!(validate_ollama_model("llama3.1").is_ok());
         assert!(validate_ollama_model("llama3.1:8b").is_ok());
         assert!(validate_ollama_model("qwen2.5:7b-instruct").is_ok());
+    }
+
+    /// Why (code review on #2977): several `CLOUD_VENDOR_PREFIXES` entries
+    /// (`qwen/`, `mistralai/`, `nvidia/`, `meta-llama/`, `deepseek/`) are also
+    /// real, pullable Ollama registry namespaces. A locally-pulled model
+    /// referenced with its explicit `:tag` must NOT be rejected — otherwise
+    /// the validator itself would produce the false-positive failure mode
+    /// this issue is fixing.
+    #[test]
+    fn validate_ollama_model_accepts_tagged_vendor_namespaced_pull() {
+        assert!(validate_ollama_model("qwen/qwen2.5:7b-instruct").is_ok());
+        assert!(validate_ollama_model("mistralai/mistral-nemo:12b").is_ok());
+        assert!(validate_ollama_model("meta-llama/llama-3.1:8b").is_ok());
+    }
+
+    /// Why: dropping the `:tag` suffix removes the only signal that
+    /// distinguishes a deliberate local pull from a copy-pasted OpenRouter
+    /// id, so the untagged form of a vendor-namespaced id must still be
+    /// rejected.
+    #[test]
+    fn validate_ollama_model_rejects_untagged_vendor_namespaced_pull() {
+        assert!(validate_ollama_model("qwen/qwen2.5-7b-instruct").is_err());
     }
 
     /// Why: two different batches must have different keys so the cache

--- a/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
+++ b/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
@@ -21,7 +21,7 @@ pub use consolidator::SemanticConsolidator;
 pub use inference::{Inference, MockInference, OllamaInference, OpenRouterInference};
 pub use types::{
     CanonicalDrawer, ConsolidationAction, ConsolidationResult, SemanticConsolidationConfig,
-    inference_available, parse_consolidation_actions,
+    inference_available, parse_consolidation_actions, validate_ollama_model,
 };
 
 #[cfg(test)]
@@ -147,6 +147,29 @@ mod tests {
         let k1 = types::batch_cache_key(&batch);
         let k2 = types::batch_cache_key(&batch);
         assert_eq!(k1, k2);
+    }
+
+    /// Why (issue #2593): the exact failure — the Anthropic-style default
+    /// model resolved against a local Ollama backend — must be rejected with
+    /// an actionable message, not silently attempted and retried forever.
+    #[test]
+    fn validate_ollama_model_rejects_cloud_prefix() {
+        let err = validate_ollama_model("anthropic/claude-haiku-4-5").unwrap_err();
+        assert!(err.contains("anthropic/"), "message should name the model");
+        assert!(err.contains("Ollama"), "message should name the provider");
+        assert!(
+            err.contains("semantic.model") || err.contains("openrouter_api_key"),
+            "message should name a config knob to fix it"
+        );
+    }
+
+    /// Why: a real local model id (no vendor prefix) must pass validation so
+    /// a correctly-configured local-model deployment keeps working.
+    #[test]
+    fn validate_ollama_model_accepts_local_tag() {
+        assert!(validate_ollama_model("llama3.1").is_ok());
+        assert!(validate_ollama_model("llama3.1:8b").is_ok());
+        assert!(validate_ollama_model("qwen2.5:7b-instruct").is_ok());
     }
 
     /// Why: two different batches must have different keys so the cache

--- a/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
+++ b/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
@@ -21,7 +21,8 @@ pub use consolidator::SemanticConsolidator;
 pub use inference::{Inference, MockInference, OllamaInference, OpenRouterInference};
 pub use types::{
     CanonicalDrawer, ConsolidationAction, ConsolidationResult, SemanticConsolidationConfig,
-    inference_available, parse_consolidation_actions, validate_ollama_model,
+    inference_available, parse_consolidation_actions, resolve_openrouter_api_key,
+    validate_ollama_model,
 };
 
 #[cfg(test)]
@@ -109,6 +110,58 @@ mod tests {
     #[test]
     fn inference_available_true_with_local_model() {
         assert!(inference_available("", true));
+    }
+
+    /// Why: a non-empty configured value must always win over the
+    /// environment, regardless of what `OPENROUTER_API_KEY` holds — no env
+    /// mutation needed for this half of the contract.
+    #[test]
+    fn resolve_openrouter_api_key_prefers_configured_value() {
+        assert_eq!(resolve_openrouter_api_key("sk-configured"), "sk-configured");
+    }
+
+    /// Why (code review follow-up on #2977): `build_consolidator_from_config`
+    /// resolves an empty configured key against `OPENROUTER_API_KEY` in the
+    /// process environment before picking a backend; `resolve_openrouter_api_key`
+    /// must do the same so every caller (including
+    /// `trusty-memory::dream_config_from_user_config`) agrees on the
+    /// resolved key. `#[serial]` + a local `EnvVarGuard` avoid racing other
+    /// tests that read/write the same real env var.
+    #[test]
+    #[serial_test::serial]
+    fn resolve_openrouter_api_key_falls_back_to_env() {
+        let _guard = EnvVarGuard::set("OPENROUTER_API_KEY", "sk-from-env");
+        assert_eq!(resolve_openrouter_api_key(""), "sk-from-env");
+    }
+
+    // ─── RAII env-var guard for tests (mirrors
+    // trusty_common::memory_core::dream::tests::EnvVarGuard) ───────────────
+    //
+    // Safety: test-only; `#[serial_test::serial]` on every caller serialises
+    // access to the real process environment across test threads.
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            // Safety: test-only; caller is `#[serial]`.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // Safety: test-only; caller is `#[serial]`.
+            match &self.previous {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
     }
 
     /// Why: `parse_consolidation_actions` must extract actions from raw JSON.

--- a/crates/trusty-common/src/memory_core/semantic_consolidation/types.rs
+++ b/crates/trusty-common/src/memory_core/semantic_consolidation/types.rs
@@ -154,13 +154,15 @@ pub fn inference_available(openrouter_api_key: &str, local_model_enabled: bool) 
 /// Vendor prefixes used by OpenRouter's `vendor/model` naming convention
 /// (e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-4o-mini`).
 ///
-/// Why: Ollama's own model catalog does not use these prefixes — local tags
-/// are bare names like `llama3.1` or `llama3.1:8b`. A configured model that
-/// starts with one of these was written for OpenRouter and will 404 forever
-/// against a local Ollama server (issue #2593). This is a curated allowlist
-/// of the exact failure mode observed, not an exhaustive OpenRouter vendor
-/// catalog — good enough to catch the unambiguous mismatch without false-
-/// positiving on legitimate local tags.
+/// Why: most of these prefixes are ambiguous on their own — Ollama's own
+/// registry does host several vendor-namespaced pulls (`qwen/…`,
+/// `mistralai/…`, `nvidia/…`, `meta-llama/…`, `deepseek/…`), so a bare prefix
+/// match alone would false-positive on a legitimately-configured local model.
+/// `validate_ollama_model` additionally requires the id to carry no explicit
+/// `:tag` suffix before rejecting it — see that function's doc for the full
+/// rule. This is a curated allowlist of the exact failure mode observed
+/// (issue #2593: the OpenRouter-style default `anthropic/claude-haiku-4-5`
+/// resolved against Ollama), not an exhaustive OpenRouter vendor catalog.
 /// What: consulted only by `validate_ollama_model`.
 /// Test: `validate_ollama_model_rejects_cloud_prefix`.
 const CLOUD_VENDOR_PREFIXES: &[&str] = &[
@@ -188,31 +190,45 @@ const CLOUD_VENDOR_PREFIXES: &[&str] = &[
 /// log noise and redb write-lock churn on the retried batches. Catching the
 /// mismatch once at consolidator-build time lets the caller fail loud and
 /// disable the phase instead of retrying blindly.
-/// What: returns `Err` with an actionable message (names the model, the
-/// resolved provider, and the config knob to fix) when `model` starts with a
-/// known OpenRouter/cloud-vendor prefix; `Ok(())` otherwise. Does NOT verify
-/// the model is actually pulled in Ollama (that requires a network call this
-/// function deliberately avoids) — it only catches the specific, unambiguous
-/// "this is not a local-model id" case.
+/// What: returns `Err` (an actionable message naming the model, the resolved
+/// provider, and the config knob to fix) only when `model` BOTH starts with a
+/// known OpenRouter/cloud-vendor prefix AND carries no `:tag` suffix. Several
+/// of those prefixes (`qwen/`, `mistralai/`, `nvidia/`, `meta-llama/`,
+/// `deepseek/`) are also real, pullable Ollama namespaces, and a real local
+/// pull is near-always referenced with an explicit tag
+/// (`vendor/model:tag`) — so the presence of a `:tag` suffix is treated as
+/// evidence the operator deliberately configured that vendor-namespaced
+/// model locally, and bypasses the check. `Ok(())` in every other case. Does
+/// NOT verify the model is actually pulled in Ollama (that requires a
+/// network call this function deliberately avoids) — it only catches the
+/// specific, unambiguous "this is not a local-model id" case.
 /// Test: `validate_ollama_model_rejects_cloud_prefix`,
-/// `validate_ollama_model_accepts_local_tag`.
-pub fn validate_ollama_model(model: &str) -> std::result::Result<(), String> {
-    match CLOUD_VENDOR_PREFIXES
+/// `validate_ollama_model_accepts_local_tag`,
+/// `validate_ollama_model_accepts_tagged_vendor_namespaced_pull`.
+pub fn validate_ollama_model(model: &str) -> Result<()> {
+    let Some(prefix) = CLOUD_VENDOR_PREFIXES
         .iter()
         .find(|p| model.starts_with(**p))
-    {
-        Some(prefix) => Err(format!(
-            "semantic consolidation model '{model}' has the OpenRouter/cloud vendor prefix \
-             '{prefix}' but resolves to the local Ollama backend (local_model_enabled=true, no \
-             OpenRouter API key configured) — Ollama cannot serve this model id and every call \
-             would fail. Fix: set `DreamConfig.semantic.model` to a locally-pulled Ollama tag \
-             (e.g. \"llama3.1\"), or configure an OpenRouter API key \
-             (`DreamConfig.openrouter_api_key` / OPENROUTER_API_KEY env var) to route this model \
-             through OpenRouter instead. Semantic consolidation is disabled until the config is \
-             fixed."
-        )),
-        None => Ok(()),
+    else {
+        return Ok(());
+    };
+    if model.contains(':') {
+        // Carries an explicit tag (e.g. "qwen/qwen2.5:7b-instruct") — treat
+        // as a deliberately-configured local pull, not a copy-pasted
+        // OpenRouter id.
+        return Ok(());
     }
+    anyhow::bail!(
+        "semantic consolidation model '{model}' has the OpenRouter/cloud vendor prefix \
+         '{prefix}' but resolves to the local Ollama backend (local_model_enabled=true, no \
+         OpenRouter API key configured) — Ollama cannot serve this model id and every call \
+         would fail. Fix: set `DreamConfig.semantic.model` to a locally-pulled Ollama tag \
+         (e.g. \"llama3.1\"; if you really did pull \"{model}\" locally, add its explicit \
+         `:tag` suffix — e.g. \"{model}:latest\" — to bypass this check), or configure an \
+         OpenRouter API key (`DreamConfig.openrouter_api_key` / OPENROUTER_API_KEY env var) to \
+         route this model through OpenRouter instead. Semantic consolidation is disabled until \
+         the config is fixed."
+    );
 }
 
 // ─── Internal prompt/response helpers ───────────────────────────────────────

--- a/crates/trusty-common/src/memory_core/semantic_consolidation/types.rs
+++ b/crates/trusty-common/src/memory_core/semantic_consolidation/types.rs
@@ -149,6 +149,72 @@ pub fn inference_available(openrouter_api_key: &str, local_model_enabled: bool) 
     !env_key.trim().is_empty()
 }
 
+// ─── Model / provider compatibility validation (issue #2593) ──────────────
+
+/// Vendor prefixes used by OpenRouter's `vendor/model` naming convention
+/// (e.g. `anthropic/claude-haiku-4-5`, `openai/gpt-4o-mini`).
+///
+/// Why: Ollama's own model catalog does not use these prefixes — local tags
+/// are bare names like `llama3.1` or `llama3.1:8b`. A configured model that
+/// starts with one of these was written for OpenRouter and will 404 forever
+/// against a local Ollama server (issue #2593). This is a curated allowlist
+/// of the exact failure mode observed, not an exhaustive OpenRouter vendor
+/// catalog — good enough to catch the unambiguous mismatch without false-
+/// positiving on legitimate local tags.
+/// What: consulted only by `validate_ollama_model`.
+/// Test: `validate_ollama_model_rejects_cloud_prefix`.
+const CLOUD_VENDOR_PREFIXES: &[&str] = &[
+    "anthropic/",
+    "openai/",
+    "google/",
+    "x-ai/",
+    "mistralai/",
+    "meta-llama/",
+    "cohere/",
+    "perplexity/",
+    "deepseek/",
+    "qwen/",
+    "nvidia/",
+];
+
+/// Reject a consolidation model id that cannot possibly resolve against a
+/// local Ollama server.
+///
+/// Why (issue #2593): the default `semantic.model` is the OpenRouter-style id
+/// `anthropic/claude-haiku-4-5`. When a deployment enables the local-model
+/// path (`local_model_enabled = true`, no OpenRouter key) without overriding
+/// `semantic.model`, every consolidation call 404s against Ollama and the
+/// dream cycle retried the failure every cycle forever, producing recurring
+/// log noise and redb write-lock churn on the retried batches. Catching the
+/// mismatch once at consolidator-build time lets the caller fail loud and
+/// disable the phase instead of retrying blindly.
+/// What: returns `Err` with an actionable message (names the model, the
+/// resolved provider, and the config knob to fix) when `model` starts with a
+/// known OpenRouter/cloud-vendor prefix; `Ok(())` otherwise. Does NOT verify
+/// the model is actually pulled in Ollama (that requires a network call this
+/// function deliberately avoids) — it only catches the specific, unambiguous
+/// "this is not a local-model id" case.
+/// Test: `validate_ollama_model_rejects_cloud_prefix`,
+/// `validate_ollama_model_accepts_local_tag`.
+pub fn validate_ollama_model(model: &str) -> std::result::Result<(), String> {
+    match CLOUD_VENDOR_PREFIXES
+        .iter()
+        .find(|p| model.starts_with(**p))
+    {
+        Some(prefix) => Err(format!(
+            "semantic consolidation model '{model}' has the OpenRouter/cloud vendor prefix \
+             '{prefix}' but resolves to the local Ollama backend (local_model_enabled=true, no \
+             OpenRouter API key configured) — Ollama cannot serve this model id and every call \
+             would fail. Fix: set `DreamConfig.semantic.model` to a locally-pulled Ollama tag \
+             (e.g. \"llama3.1\"), or configure an OpenRouter API key \
+             (`DreamConfig.openrouter_api_key` / OPENROUTER_API_KEY env var) to route this model \
+             through OpenRouter instead. Semantic consolidation is disabled until the config is \
+             fixed."
+        )),
+        None => Ok(()),
+    }
+}
+
 // ─── Internal prompt/response helpers ───────────────────────────────────────
 
 /// Internal: build the user-turn content for a consolidation prompt.

--- a/crates/trusty-common/src/memory_core/semantic_consolidation/types.rs
+++ b/crates/trusty-common/src/memory_core/semantic_consolidation/types.rs
@@ -123,6 +123,38 @@ pub struct CanonicalDrawer {
     pub canonical_for: Vec<Uuid>,
 }
 
+// ─── Effective OpenRouter API key resolution ───────────────────────────────
+
+/// Resolve the effective OpenRouter API key: the explicitly configured value
+/// if non-empty, otherwise the `OPENROUTER_API_KEY` environment variable.
+///
+/// Why: multiple call sites need to agree on whether an OpenRouter key is
+/// configured so they pick the SAME inference backend (Ollama vs OpenRouter)
+/// for the SAME model id — `build_consolidator_from_config` (this crate)
+/// resolves the key with this env-var fallback before branching;
+/// `dream_config_from_user_config` (trusty-memory) picks which model string
+/// to forward based on which backend will resolve. Before this function
+/// existed those two call sites computed "is a key configured" independently
+/// and diverged whenever `OPENROUTER_API_KEY` was set in the daemon's process
+/// environment but absent from `~/.trusty-memory/config.toml`: the helper
+/// picked the local-model id (config.toml has no key), the consolidator built
+/// the OpenRouter backend (the env var supplied one), and every consolidation
+/// call silently failed sending an Ollama-style tag to OpenRouter — a
+/// regression report on the #2593 fix itself.
+/// What: returns `configured` verbatim when non-empty; otherwise reads
+/// `OPENROUTER_API_KEY` from the process environment (empty string when
+/// unset). No trimming — matches the pre-existing resolution semantics of
+/// `build_consolidator_from_config` exactly, so callers stay bit-for-bit
+/// consistent with it.
+/// Test: `resolve_openrouter_api_key_prefers_configured_value`,
+/// `resolve_openrouter_api_key_falls_back_to_env`.
+pub fn resolve_openrouter_api_key(configured: &str) -> String {
+    if !configured.is_empty() {
+        return configured.to_string();
+    }
+    std::env::var(crate::env_vars::ENV_OPENROUTER_API_KEY).unwrap_or_default()
+}
+
 // ─── Gate: is inference available? ─────────────────────────────────────────
 
 /// Check whether at least one inference backend is configured and potentially

--- a/crates/trusty-memory/src/dream_scheduler.rs
+++ b/crates/trusty-memory/src/dream_scheduler.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use tokio::sync::watch;
 use tracing::info;
-use trusty_common::memory_core::dream::{DreamConfig, Dreamer};
+use trusty_common::memory_core::dream::Dreamer;
 use trusty_common::memory_core::PalaceRegistry;
 
 /// Environment variable that disables autonomous dream scheduling when set to
@@ -46,11 +46,18 @@ pub const DREAM_DISABLED_ENV: &str = "TRUSTY_DREAM_DISABLED";
 ///
 /// What:
 /// 1. Checks `TRUSTY_DREAM_DISABLED`; returns immediately (no loops) when set.
-/// 2. Iterates every `PalaceId` currently registered in `registry`.
-/// 3. For each palace: resolves the `Arc<PalaceHandle>` via `registry.get()`,
-///    constructs a fresh `Dreamer` with `DreamConfig::default()`, and spawns
-///    a background loop via `Dreamer::start_with_shutdown(handle, rx.clone())`.
-/// 4. Spawns a bridge task that awaits `shutdown_rx` (a `watch::Receiver<bool>`
+/// 2. Loads the daemon's user config ONCE via `crate::service::load_user_config`
+///    and derives a shared `DreamConfig` template via
+///    `crate::service::dream_config_from_user_config` (issue #2593) — every
+///    loop previously used `DreamConfig::default()` outright, so the idle
+///    background job never saw the user's OpenRouter key, local-model flag,
+///    or local-model id at all, regardless of what `~/.trusty-memory/config.toml`
+///    said.
+/// 3. Iterates every `PalaceId` currently registered in `registry`.
+/// 4. For each palace: resolves the `Arc<PalaceHandle>` via `registry.get()`,
+///    constructs a fresh `Dreamer` from a clone of the shared template, and
+///    spawns a background loop via `Dreamer::start_with_shutdown(handle, rx.clone())`.
+/// 5. Spawns a bridge task that awaits `shutdown_rx` (a `watch::Receiver<bool>`
 ///    driven by the daemon's SIGTERM / SIGINT signal) and broadcasts the stop
 ///    signal to all dream loops.
 ///
@@ -74,11 +81,18 @@ pub fn spawn_dream_scheduler(
         return 0;
     }
 
+    // Loaded once for the whole scheduler (not per palace): all palaces on
+    // this daemon share the same `~/.trusty-memory/config.toml`, and the
+    // loader falls back to `LoadedUserConfig::default()` when the file is
+    // absent, so this never blocks scheduling on a missing config.
+    let user_cfg = crate::service::load_user_config().unwrap_or_default();
+    let config_template = crate::service::dream_config_from_user_config(&user_cfg);
+
     let palace_ids = registry.list();
     let mut spawned: usize = 0;
 
     for palace_id in palace_ids {
-        let config = DreamConfig::default();
+        let config = config_template.clone();
         let idle_secs = config.idle_secs;
         let dreamer = Arc::new(Dreamer::new(config));
         // Unpin (idle-to-disk): the loop takes the registry + id and resolves

--- a/crates/trusty-memory/src/service/helpers.rs
+++ b/crates/trusty-memory/src/service/helpers.rs
@@ -1,26 +1,23 @@
-//! Free helper functions + user-config loading for the trusty-memory service
-//! layer.
+//! Free helper functions for the trusty-memory service layer.
 //!
 //! Why: thin no-IO transforms (preview/snippet/recall-entry JSON), palace-stat
-//! aggregation, palace-info enrichment, gaps-cache refresh, and user-config
-//! loading are shared by the HTTP handlers, the chat dispatcher, and the
-//! `MemoryService` core (split out of the former monolithic `service.rs`,
-//! issue #607).
-//! What: the free helpers + `LoadedUserConfig`/`load_user_config` +
-//! `service_result_to_anyhow`, moved verbatim. The service-layer unit tests
-//! live here too (1500-SLOC test cap applies).
+//! aggregation, palace-info enrichment, and gaps-cache refresh are shared by
+//! the HTTP handlers, the chat dispatcher, and the `MemoryService` core (split
+//! out of the former monolithic `service.rs`, issue #607). User-config
+//! loading + `DreamConfig` derivation live in the sibling `user_config`
+//! module (split out of this file, issue #2593 follow-up, to stay under the
+//! 500-SLOC cap).
+//! What: the free helpers + `service_result_to_anyhow`, moved verbatim. The
+//! service-layer unit tests live here too (1500-SLOC test cap applies).
 //! Test: `drawer_*`, `recall_entry_*`, and `list_drawers_*` in `service::tests`.
 
 use crate::AppState;
 use anyhow::{anyhow, Context, Result};
-use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::sync::Arc;
-use trusty_common::memory_core::dream::DreamConfig;
 use trusty_common::memory_core::palace::{Palace, PalaceId};
 use trusty_common::memory_core::retrieval::RecallResult;
-use trusty_common::memory_core::semantic_consolidation::SemanticConsolidationConfig;
 use trusty_common::memory_core::PalaceHandle;
 use uuid::Uuid;
 
@@ -305,148 +302,12 @@ pub async fn enrich_gap_exploration(
 }
 
 // ---------------------------------------------------------------------------
-// User config — moved from `web.rs` so chat and HTTP both load it cheaply.
+// User config loading + DreamConfig derivation moved to `service::user_config`
+// (split out, issue #2593 follow-up, to keep this file under the 500-SLOC
+// cap): `LoadedUserConfig`, `load_user_config`, `dream_config_from_user_config`.
+// `service::mod` re-exports them directly from there now — see that module's
+// doc header. Nothing in this file references them anymore.
 // ---------------------------------------------------------------------------
-
-/// Minimal mirror of the user-config schema.
-#[derive(Deserialize, Default, Clone)]
-struct UserConfigMin {
-    #[serde(default)]
-    openrouter: OpenRouterMin,
-    #[serde(default)]
-    local_model: LocalModelMin,
-}
-
-#[derive(Deserialize, Default, Clone)]
-struct OpenRouterMin {
-    #[serde(default)]
-    api_key: String,
-    #[serde(default)]
-    model: String,
-}
-
-#[derive(Deserialize, Clone)]
-struct LocalModelMin {
-    #[serde(default = "default_local_enabled")]
-    enabled: bool,
-    #[serde(default = "default_local_base_url")]
-    base_url: String,
-    #[serde(default = "default_local_model")]
-    model: String,
-}
-
-fn default_local_enabled() -> bool {
-    true
-}
-fn default_local_base_url() -> String {
-    "http://localhost:11434".to_string()
-}
-fn default_local_model() -> String {
-    "llama3.2".to_string()
-}
-
-impl Default for LocalModelMin {
-    fn default() -> Self {
-        Self {
-            enabled: default_local_enabled(),
-            base_url: default_local_base_url(),
-            model: default_local_model(),
-        }
-    }
-}
-
-/// Loaded user config (mirrors the public `LoadedUserConfig` from `web.rs`).
-#[derive(Clone)]
-pub struct LoadedUserConfig {
-    pub openrouter_api_key: String,
-    pub openrouter_model: String,
-    pub local_model: trusty_common::LocalModelConfig,
-}
-
-impl Default for LoadedUserConfig {
-    fn default() -> Self {
-        Self {
-            openrouter_api_key: String::new(),
-            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
-            local_model: trusty_common::LocalModelConfig::default(),
-        }
-    }
-}
-
-/// Read the user's `~/.trusty-memory/config.toml`, falling back to defaults.
-///
-/// Why: shared between HTTP config endpoint, chat tool dispatch, and
-/// provider auto-detection.
-/// What: returns `Some(LoadedUserConfig)` even when the file is missing
-/// (so callers see defaults consistently); `None` only when the home
-/// directory itself can't be resolved.
-/// Test: indirectly via `config_endpoint_returns_payload`.
-pub fn load_user_config() -> Option<LoadedUserConfig> {
-    let home = dirs::home_dir()?;
-    let path = home.join(".trusty-memory").join("config.toml");
-    if !path.exists() {
-        return Some(LoadedUserConfig::default());
-    }
-    let raw = std::fs::read_to_string(&path).ok()?;
-    let parsed: UserConfigMin = toml::from_str(&raw).unwrap_or_default();
-    let model = if parsed.openrouter.model.is_empty() {
-        "anthropic/claude-3-5-sonnet".to_string()
-    } else {
-        parsed.openrouter.model
-    };
-    Some(LoadedUserConfig {
-        openrouter_api_key: parsed.openrouter.api_key,
-        openrouter_model: model,
-        local_model: trusty_common::LocalModelConfig {
-            enabled: parsed.local_model.enabled,
-            base_url: parsed.local_model.base_url,
-            model: parsed.local_model.model,
-        },
-    })
-}
-
-/// Derive a `DreamConfig` seed from the user's loaded config (OpenRouter key,
-/// local-model flag, and local-model id).
-///
-/// Why (issue #2593): the idle dream scheduler and the on-demand
-/// `dream_consolidate_room`/`palace_dream` tools both need to translate
-/// `LoadedUserConfig` into `DreamConfig` identically, or the two paths
-/// silently diverge — the idle scheduler previously used
-/// `DreamConfig::default()` outright (ignoring the user's config.toml
-/// entirely), and the on-demand path forwarded the OpenRouter key and the
-/// local-model flag but dropped `local_model.model`, leaving
-/// `semantic.model` on the OpenRouter-style default even when consolidation
-/// resolved to a local Ollama backend — the exact misconfiguration
-/// `validate_ollama_model` now rejects. Centralising the derivation also
-/// pins the "which model string goes with which backend" decision: it
-/// mirrors `build_consolidator_from_config`'s own branch
-/// (`local_model_enabled && api_key.is_empty()` => Ollama) so the model
-/// forwarded here always matches the backend the dream cycle will actually
-/// select.
-/// What: sets `openrouter_api_key`, `local_model_enabled`, and
-/// `semantic.model` (the local-model id when the local path resolves, the
-/// OpenRouter model id otherwise); every other `DreamConfig` field keeps its
-/// default.
-/// Test: `dream_config_from_user_config_prefers_local_model_when_resolved`,
-/// `dream_config_from_user_config_prefers_openrouter_model_with_key`.
-pub fn dream_config_from_user_config(cfg: &LoadedUserConfig) -> DreamConfig {
-    let resolves_local = cfg.local_model.enabled && cfg.openrouter_api_key.is_empty();
-    let model = if resolves_local {
-        cfg.local_model.model.clone()
-    } else {
-        cfg.openrouter_model.clone()
-    };
-
-    DreamConfig {
-        openrouter_api_key: cfg.openrouter_api_key.clone(),
-        local_model_enabled: cfg.local_model.enabled,
-        semantic: SemanticConsolidationConfig {
-            model,
-            ..SemanticConsolidationConfig::default()
-        },
-        ..DreamConfig::default()
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Convenience helpers for callers that want `anyhow::Result<Value>` shape.
@@ -479,57 +340,6 @@ mod tests {
         // Leak the TempDir guard so the directory survives the test body.
         std::mem::forget(tmp);
         AppState::new(root)
-    }
-
-    /// Why (issue #2593): the exact production gap — the idle scheduler and
-    /// the on-demand tool both need `local_model.model` to reach
-    /// `DreamConfig.semantic.model` when the local Ollama path is what will
-    /// actually resolve (local model enabled, no OpenRouter key).
-    /// What: builds a `LoadedUserConfig` with a configured local model id and
-    /// no OpenRouter key; asserts the derived `DreamConfig.semantic.model`
-    /// equals the configured local model, not the OpenRouter-style default.
-    #[test]
-    fn dream_config_from_user_config_prefers_local_model_when_resolved() {
-        let cfg = LoadedUserConfig {
-            openrouter_api_key: String::new(),
-            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
-            local_model: trusty_common::LocalModelConfig {
-                enabled: true,
-                base_url: "http://localhost:11434".to_string(),
-                model: "llama3.2".to_string(),
-            },
-        };
-
-        let dream_cfg = dream_config_from_user_config(&cfg);
-
-        assert_eq!(dream_cfg.semantic.model, "llama3.2");
-        assert!(dream_cfg.local_model_enabled);
-        assert!(dream_cfg.openrouter_api_key.is_empty());
-    }
-
-    /// Why: when an OpenRouter key is configured, consolidation resolves to
-    /// the OpenRouter backend regardless of `local_model.enabled` (mirrors
-    /// `build_consolidator_from_config`'s branch), so the OpenRouter model
-    /// id must be forwarded instead of the local-model id.
-    /// What: builds a `LoadedUserConfig` with both a local model AND an
-    /// OpenRouter key configured; asserts the derived `semantic.model` is
-    /// the OpenRouter model, not the local one.
-    #[test]
-    fn dream_config_from_user_config_prefers_openrouter_model_with_key() {
-        let cfg = LoadedUserConfig {
-            openrouter_api_key: "sk-test-key".to_string(),
-            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
-            local_model: trusty_common::LocalModelConfig {
-                enabled: true,
-                base_url: "http://localhost:11434".to_string(),
-                model: "llama3.2".to_string(),
-            },
-        };
-
-        let dream_cfg = dream_config_from_user_config(&cfg);
-
-        assert_eq!(dream_cfg.semantic.model, "anthropic/claude-3-5-sonnet");
-        assert_eq!(dream_cfg.openrouter_api_key, "sk-test-key");
     }
 
     /// Issue #184 — `sort=created_desc` paginates newest-first and the

--- a/crates/trusty-memory/src/service/helpers.rs
+++ b/crates/trusty-memory/src/service/helpers.rs
@@ -17,8 +17,10 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::sync::Arc;
+use trusty_common::memory_core::dream::DreamConfig;
 use trusty_common::memory_core::palace::{Palace, PalaceId};
 use trusty_common::memory_core::retrieval::RecallResult;
+use trusty_common::memory_core::semantic_consolidation::SemanticConsolidationConfig;
 use trusty_common::memory_core::PalaceHandle;
 use uuid::Uuid;
 
@@ -403,6 +405,49 @@ pub fn load_user_config() -> Option<LoadedUserConfig> {
     })
 }
 
+/// Derive a `DreamConfig` seed from the user's loaded config (OpenRouter key,
+/// local-model flag, and local-model id).
+///
+/// Why (issue #2593): the idle dream scheduler and the on-demand
+/// `dream_consolidate_room`/`palace_dream` tools both need to translate
+/// `LoadedUserConfig` into `DreamConfig` identically, or the two paths
+/// silently diverge — the idle scheduler previously used
+/// `DreamConfig::default()` outright (ignoring the user's config.toml
+/// entirely), and the on-demand path forwarded the OpenRouter key and the
+/// local-model flag but dropped `local_model.model`, leaving
+/// `semantic.model` on the OpenRouter-style default even when consolidation
+/// resolved to a local Ollama backend — the exact misconfiguration
+/// `validate_ollama_model` now rejects. Centralising the derivation also
+/// pins the "which model string goes with which backend" decision: it
+/// mirrors `build_consolidator_from_config`'s own branch
+/// (`local_model_enabled && api_key.is_empty()` => Ollama) so the model
+/// forwarded here always matches the backend the dream cycle will actually
+/// select.
+/// What: sets `openrouter_api_key`, `local_model_enabled`, and
+/// `semantic.model` (the local-model id when the local path resolves, the
+/// OpenRouter model id otherwise); every other `DreamConfig` field keeps its
+/// default.
+/// Test: `dream_config_from_user_config_prefers_local_model_when_resolved`,
+/// `dream_config_from_user_config_prefers_openrouter_model_with_key`.
+pub fn dream_config_from_user_config(cfg: &LoadedUserConfig) -> DreamConfig {
+    let resolves_local = cfg.local_model.enabled && cfg.openrouter_api_key.is_empty();
+    let model = if resolves_local {
+        cfg.local_model.model.clone()
+    } else {
+        cfg.openrouter_model.clone()
+    };
+
+    DreamConfig {
+        openrouter_api_key: cfg.openrouter_api_key.clone(),
+        local_model_enabled: cfg.local_model.enabled,
+        semantic: SemanticConsolidationConfig {
+            model,
+            ..SemanticConsolidationConfig::default()
+        },
+        ..DreamConfig::default()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Convenience helpers for callers that want `anyhow::Result<Value>` shape.
 // ---------------------------------------------------------------------------
@@ -434,6 +479,57 @@ mod tests {
         // Leak the TempDir guard so the directory survives the test body.
         std::mem::forget(tmp);
         AppState::new(root)
+    }
+
+    /// Why (issue #2593): the exact production gap — the idle scheduler and
+    /// the on-demand tool both need `local_model.model` to reach
+    /// `DreamConfig.semantic.model` when the local Ollama path is what will
+    /// actually resolve (local model enabled, no OpenRouter key).
+    /// What: builds a `LoadedUserConfig` with a configured local model id and
+    /// no OpenRouter key; asserts the derived `DreamConfig.semantic.model`
+    /// equals the configured local model, not the OpenRouter-style default.
+    #[test]
+    fn dream_config_from_user_config_prefers_local_model_when_resolved() {
+        let cfg = LoadedUserConfig {
+            openrouter_api_key: String::new(),
+            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
+            local_model: trusty_common::LocalModelConfig {
+                enabled: true,
+                base_url: "http://localhost:11434".to_string(),
+                model: "llama3.2".to_string(),
+            },
+        };
+
+        let dream_cfg = dream_config_from_user_config(&cfg);
+
+        assert_eq!(dream_cfg.semantic.model, "llama3.2");
+        assert!(dream_cfg.local_model_enabled);
+        assert!(dream_cfg.openrouter_api_key.is_empty());
+    }
+
+    /// Why: when an OpenRouter key is configured, consolidation resolves to
+    /// the OpenRouter backend regardless of `local_model.enabled` (mirrors
+    /// `build_consolidator_from_config`'s branch), so the OpenRouter model
+    /// id must be forwarded instead of the local-model id.
+    /// What: builds a `LoadedUserConfig` with both a local model AND an
+    /// OpenRouter key configured; asserts the derived `semantic.model` is
+    /// the OpenRouter model, not the local one.
+    #[test]
+    fn dream_config_from_user_config_prefers_openrouter_model_with_key() {
+        let cfg = LoadedUserConfig {
+            openrouter_api_key: "sk-test-key".to_string(),
+            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
+            local_model: trusty_common::LocalModelConfig {
+                enabled: true,
+                base_url: "http://localhost:11434".to_string(),
+                model: "llama3.2".to_string(),
+            },
+        };
+
+        let dream_cfg = dream_config_from_user_config(&cfg);
+
+        assert_eq!(dream_cfg.semantic.model, "anthropic/claude-3-5-sonnet");
+        assert_eq!(dream_cfg.openrouter_api_key, "sk-test-key");
     }
 
     /// Issue #184 — `sort=created_desc` paginates newest-first and the

--- a/crates/trusty-memory/src/service/mod.rs
+++ b/crates/trusty-memory/src/service/mod.rs
@@ -25,9 +25,9 @@ pub mod types;
 // monolithic module.
 pub use core::MemoryService;
 pub use helpers::{
-    drawer_content_preview, drawer_snippet, enrich_gap_exploration, load_user_config,
-    palace_info_from, recall_entry_json, refresh_gaps_cache, service_result_to_anyhow,
-    LoadedUserConfig, DRAWER_PREVIEW_MAX_CHARS, DRAWER_SNIPPET_MAX_CHARS,
+    drawer_content_preview, drawer_snippet, dream_config_from_user_config, enrich_gap_exploration,
+    load_user_config, palace_info_from, recall_entry_json, refresh_gaps_cache,
+    service_result_to_anyhow, LoadedUserConfig, DRAWER_PREVIEW_MAX_CHARS, DRAWER_SNIPPET_MAX_CHARS,
 };
 pub use types::{
     CreateDrawerBody, CreatePalaceBody, DreamStatusPayload, KgAssertBody, KgGraphPayload,

--- a/crates/trusty-memory/src/service/mod.rs
+++ b/crates/trusty-memory/src/service/mod.rs
@@ -19,17 +19,22 @@ pub mod core;
 pub mod core_kg;
 pub mod helpers;
 pub mod types;
+pub mod user_config;
 
 // Re-export the full public surface so external call sites
 // (`crate::service::X`) keep resolving exactly as they did against the former
-// monolithic module.
+// monolithic module. `load_user_config`, `dream_config_from_user_config`, and
+// `LoadedUserConfig` moved from `helpers` to `user_config` (issue #2593
+// follow-up, to keep `helpers.rs` under the 500-SLOC cap); re-exported from
+// their new home here so `crate::service::X` call sites are unaffected.
 pub use core::MemoryService;
 pub use helpers::{
-    drawer_content_preview, drawer_snippet, dream_config_from_user_config, enrich_gap_exploration,
-    load_user_config, palace_info_from, recall_entry_json, refresh_gaps_cache,
-    service_result_to_anyhow, LoadedUserConfig, DRAWER_PREVIEW_MAX_CHARS, DRAWER_SNIPPET_MAX_CHARS,
+    drawer_content_preview, drawer_snippet, enrich_gap_exploration, palace_info_from,
+    recall_entry_json, refresh_gaps_cache, service_result_to_anyhow, DRAWER_PREVIEW_MAX_CHARS,
+    DRAWER_SNIPPET_MAX_CHARS,
 };
 pub use types::{
     CreateDrawerBody, CreatePalaceBody, DreamStatusPayload, KgAssertBody, KgGraphPayload,
     ListDrawersQuery, PalaceInfo, ServiceError, ServiceResult, StatusPayload,
 };
+pub use user_config::{dream_config_from_user_config, load_user_config, LoadedUserConfig};

--- a/crates/trusty-memory/src/service/user_config.rs
+++ b/crates/trusty-memory/src/service/user_config.rs
@@ -1,0 +1,316 @@
+//! User config (`~/.trusty-memory/config.toml`) loading + `DreamConfig`
+//! derivation.
+//!
+//! Why: split out of `helpers.rs` (issue #2593 follow-up, code review on
+//! #2977) to keep that file under the 500-SLOC production cap after the
+//! `dream_config_from_user_config` addition pushed it over. This is also a
+//! cohesive unit on its own: "read config.toml" and "translate it into the
+//! shapes downstream consumers need" belong together, separate from the
+//! unrelated preview/snippet/palace-info transforms that fill the rest of
+//! `helpers.rs`.
+//! What: `UserConfigMin`/`OpenRouterMin`/`LocalModelMin` (the minimal TOML
+//! mirror), `LoadedUserConfig` (the public, normalised shape), `load_user_config`
+//! (file → `LoadedUserConfig`), and `dream_config_from_user_config`
+//! (`LoadedUserConfig` → `DreamConfig`, used by both the idle dream scheduler
+//! and the on-demand `dream_consolidate_room`/`palace_dream` tools). Re-exported
+//! from `service::mod` unchanged so `crate::service::{load_user_config,
+//! dream_config_from_user_config, LoadedUserConfig}` keeps resolving exactly as
+//! before this split — no public API change.
+//! Test: `dream_config_from_user_config_prefers_local_model_when_resolved`,
+//! `dream_config_from_user_config_prefers_openrouter_model_with_key`,
+//! `dream_config_from_user_config_prefers_openrouter_model_with_env_key`.
+
+use serde::Deserialize;
+use trusty_common::memory_core::dream::DreamConfig;
+use trusty_common::memory_core::semantic_consolidation::SemanticConsolidationConfig;
+
+/// Minimal mirror of the user-config schema.
+#[derive(Deserialize, Default, Clone)]
+struct UserConfigMin {
+    #[serde(default)]
+    openrouter: OpenRouterMin,
+    #[serde(default)]
+    local_model: LocalModelMin,
+}
+
+#[derive(Deserialize, Default, Clone)]
+struct OpenRouterMin {
+    #[serde(default)]
+    api_key: String,
+    #[serde(default)]
+    model: String,
+}
+
+#[derive(Deserialize, Clone)]
+struct LocalModelMin {
+    #[serde(default = "default_local_enabled")]
+    enabled: bool,
+    #[serde(default = "default_local_base_url")]
+    base_url: String,
+    #[serde(default = "default_local_model")]
+    model: String,
+}
+
+fn default_local_enabled() -> bool {
+    true
+}
+fn default_local_base_url() -> String {
+    "http://localhost:11434".to_string()
+}
+fn default_local_model() -> String {
+    "llama3.2".to_string()
+}
+
+impl Default for LocalModelMin {
+    fn default() -> Self {
+        Self {
+            enabled: default_local_enabled(),
+            base_url: default_local_base_url(),
+            model: default_local_model(),
+        }
+    }
+}
+
+/// Loaded user config (mirrors the public `LoadedUserConfig` from `web.rs`).
+#[derive(Clone)]
+pub struct LoadedUserConfig {
+    pub openrouter_api_key: String,
+    pub openrouter_model: String,
+    pub local_model: trusty_common::LocalModelConfig,
+}
+
+impl Default for LoadedUserConfig {
+    fn default() -> Self {
+        Self {
+            openrouter_api_key: String::new(),
+            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
+            local_model: trusty_common::LocalModelConfig::default(),
+        }
+    }
+}
+
+/// Read the user's `~/.trusty-memory/config.toml`, falling back to defaults.
+///
+/// Why: shared between HTTP config endpoint, chat tool dispatch, and
+/// provider auto-detection.
+/// What: returns `Some(LoadedUserConfig)` even when the file is missing
+/// (so callers see defaults consistently); `None` only when the home
+/// directory itself can't be resolved.
+/// Test: indirectly via `config_endpoint_returns_payload`.
+pub fn load_user_config() -> Option<LoadedUserConfig> {
+    let home = dirs::home_dir()?;
+    let path = home.join(".trusty-memory").join("config.toml");
+    if !path.exists() {
+        return Some(LoadedUserConfig::default());
+    }
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let parsed: UserConfigMin = toml::from_str(&raw).unwrap_or_default();
+    let model = if parsed.openrouter.model.is_empty() {
+        "anthropic/claude-3-5-sonnet".to_string()
+    } else {
+        parsed.openrouter.model
+    };
+    Some(LoadedUserConfig {
+        openrouter_api_key: parsed.openrouter.api_key,
+        openrouter_model: model,
+        local_model: trusty_common::LocalModelConfig {
+            enabled: parsed.local_model.enabled,
+            base_url: parsed.local_model.base_url,
+            model: parsed.local_model.model,
+        },
+    })
+}
+
+/// Derive a `DreamConfig` seed from the user's loaded config (OpenRouter key,
+/// local-model flag, and local-model id).
+///
+/// Why (issue #2593): the idle dream scheduler and the on-demand
+/// `dream_consolidate_room`/`palace_dream` tools both need to translate
+/// `LoadedUserConfig` into `DreamConfig` identically, or the two paths
+/// silently diverge — the idle scheduler previously used
+/// `DreamConfig::default()` outright (ignoring the user's config.toml
+/// entirely), and the on-demand path forwarded the OpenRouter key and the
+/// local-model flag but dropped `local_model.model`, leaving
+/// `semantic.model` on the OpenRouter-style default even when consolidation
+/// resolved to a local Ollama backend — the exact misconfiguration
+/// `validate_ollama_model` now rejects. Centralising the derivation also
+/// pins the "which model string goes with which backend" decision: it
+/// mirrors `build_consolidator_from_config`'s own branch
+/// (`local_model_enabled && api_key.is_empty()` => Ollama) so the model
+/// forwarded here always matches the backend the dream cycle will actually
+/// select. The key-presence half of that branch is resolved via the SAME
+/// `trusty_common::memory_core::semantic_consolidation::resolve_openrouter_api_key`
+/// that `build_consolidator_from_config` itself calls — an earlier version
+/// of this function checked only `cfg.openrouter_api_key` (config.toml),
+/// which diverged from `build_consolidator_from_config`'s env-var-fallback
+/// resolution whenever `OPENROUTER_API_KEY` was set in the daemon's process
+/// environment but absent from config.toml: this function picked the
+/// local-model id while the consolidator built the OpenRouter backend,
+/// silently sending an Ollama tag to OpenRouter every cycle.
+/// What: sets `openrouter_api_key`, `local_model_enabled`, and
+/// `semantic.model` (the local-model id when the local path resolves, the
+/// OpenRouter model id otherwise); every other `DreamConfig` field keeps its
+/// default.
+/// Test: `dream_config_from_user_config_prefers_local_model_when_resolved`,
+/// `dream_config_from_user_config_prefers_openrouter_model_with_key`,
+/// `dream_config_from_user_config_prefers_openrouter_model_with_env_key`.
+pub fn dream_config_from_user_config(cfg: &LoadedUserConfig) -> DreamConfig {
+    let resolved_api_key =
+        trusty_common::memory_core::semantic_consolidation::resolve_openrouter_api_key(
+            &cfg.openrouter_api_key,
+        );
+    let resolves_local = cfg.local_model.enabled && resolved_api_key.is_empty();
+    let model = if resolves_local {
+        cfg.local_model.model.clone()
+    } else {
+        cfg.openrouter_model.clone()
+    };
+
+    DreamConfig {
+        openrouter_api_key: cfg.openrouter_api_key.clone(),
+        local_model_enabled: cfg.local_model.enabled,
+        semantic: SemanticConsolidationConfig {
+            model,
+            ..SemanticConsolidationConfig::default()
+        },
+        ..DreamConfig::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why (issue #2593): the exact production gap — the idle scheduler and
+    /// the on-demand tool both need `local_model.model` to reach
+    /// `DreamConfig.semantic.model` when the local Ollama path is what will
+    /// actually resolve (local model enabled, no OpenRouter key ANYWHERE —
+    /// neither config.toml nor the real process environment; without the
+    /// `EnvVarGuard::remove` this test is order-dependent on whatever the
+    /// ambient shell happens to export, since `dream_config_from_user_config`
+    /// now resolves the env-var fallback too — code review follow-up on
+    /// #2977). `#[serial]` avoids racing other tests that read/write the
+    /// same real env var.
+    /// What: builds a `LoadedUserConfig` with a configured local model id and
+    /// no OpenRouter key; asserts the derived `DreamConfig.semantic.model`
+    /// equals the configured local model, not the OpenRouter-style default.
+    #[test]
+    #[serial_test::serial]
+    fn dream_config_from_user_config_prefers_local_model_when_resolved() {
+        let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
+        let cfg = LoadedUserConfig {
+            openrouter_api_key: String::new(),
+            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
+            local_model: trusty_common::LocalModelConfig {
+                enabled: true,
+                base_url: "http://localhost:11434".to_string(),
+                model: "llama3.2".to_string(),
+            },
+        };
+
+        let dream_cfg = dream_config_from_user_config(&cfg);
+
+        assert_eq!(dream_cfg.semantic.model, "llama3.2");
+        assert!(dream_cfg.local_model_enabled);
+        assert!(dream_cfg.openrouter_api_key.is_empty());
+    }
+
+    /// Why: when an OpenRouter key is configured, consolidation resolves to
+    /// the OpenRouter backend regardless of `local_model.enabled` (mirrors
+    /// `build_consolidator_from_config`'s branch), so the OpenRouter model
+    /// id must be forwarded instead of the local-model id.
+    /// What: builds a `LoadedUserConfig` with both a local model AND an
+    /// OpenRouter key configured; asserts the derived `semantic.model` is
+    /// the OpenRouter model, not the local one.
+    #[test]
+    fn dream_config_from_user_config_prefers_openrouter_model_with_key() {
+        let cfg = LoadedUserConfig {
+            openrouter_api_key: "sk-test-key".to_string(),
+            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
+            local_model: trusty_common::LocalModelConfig {
+                enabled: true,
+                base_url: "http://localhost:11434".to_string(),
+                model: "llama3.2".to_string(),
+            },
+        };
+
+        let dream_cfg = dream_config_from_user_config(&cfg);
+
+        assert_eq!(dream_cfg.semantic.model, "anthropic/claude-3-5-sonnet");
+        assert_eq!(dream_cfg.openrouter_api_key, "sk-test-key");
+    }
+
+    /// Why (code review follow-up on #2977): `config.toml` may have no
+    /// OpenRouter key while the daemon's process environment carries
+    /// `OPENROUTER_API_KEY` — `build_consolidator_from_config` (trusty-common)
+    /// resolves that env-var fallback before choosing a backend, so this
+    /// helper must resolve it identically or it picks the local-model id
+    /// while the consolidator builds the OpenRouter backend, silently
+    /// sending an Ollama tag to OpenRouter every cycle. `#[serial]` +
+    /// `EnvVarGuard` (mirroring the pattern in
+    /// `trusty_common::memory_core::dream::tests`) avoid racing other tests
+    /// that read/write the same real env var.
+    /// What: empty `openrouter_api_key` in config, `OPENROUTER_API_KEY` set
+    /// in the real environment; asserts the OpenRouter model is chosen, not
+    /// the local one.
+    #[test]
+    #[serial_test::serial]
+    fn dream_config_from_user_config_prefers_openrouter_model_with_env_key() {
+        let _guard = EnvVarGuard::set("OPENROUTER_API_KEY", "sk-from-env");
+
+        let cfg = LoadedUserConfig {
+            openrouter_api_key: String::new(),
+            openrouter_model: "anthropic/claude-3-5-sonnet".to_string(),
+            local_model: trusty_common::LocalModelConfig {
+                enabled: true,
+                base_url: "http://localhost:11434".to_string(),
+                model: "llama3.2".to_string(),
+            },
+        };
+
+        let dream_cfg = dream_config_from_user_config(&cfg);
+
+        assert_eq!(
+            dream_cfg.semantic.model, "anthropic/claude-3-5-sonnet",
+            "an env-supplied OpenRouter key must resolve the OpenRouter \
+             model, not the local one, even though config.toml has no key"
+        );
+    }
+
+    // ─── RAII env-var guard for tests (mirrors
+    // trusty_common::memory_core::dream::tests::EnvVarGuard) ───────────────
+    //
+    // Safety: test-only; `#[serial_test::serial]` on every caller serialises
+    // access to the real process environment across test threads.
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            // Safety: test-only; caller is `#[serial]`.
+            unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            // Safety: test-only; caller is `#[serial]`.
+            unsafe { std::env::remove_var(key) };
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // Safety: test-only; caller is `#[serial]`.
+            match &self.previous {
+                Some(v) => unsafe { std::env::set_var(self.key, v) },
+                None => unsafe { std::env::remove_var(self.key) },
+            }
+        }
+    }
+}

--- a/crates/trusty-memory/src/tools/dream_ops.rs
+++ b/crates/trusty-memory/src/tools/dream_ops.rs
@@ -6,7 +6,8 @@
 //! actually shrinks. This handler exposes that scoped, synchronous pipeline.
 //! What: `handle_dream_consolidate_room` resolves the palace, parses the
 //! optional room + age window, builds a `DreamConfig` from the daemon's user
-//! config (OpenRouter key / local-model setting), and delegates to
+//! config (OpenRouter key, local-model flag, and local-model id — issue
+//! #2593) via `dream_config_from_user_config`, and delegates to
 //! `dream::consolidate_scoped`. Task drawers are skipped inside that helper.
 //! `handle_palace_dream` is an alias for `handle_dream_consolidate_room` with
 //! the same parameters, exposed as `palace_dream` in the MCP tool surface.
@@ -16,7 +17,7 @@
 use crate::AppState;
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
-use trusty_common::memory_core::dream::{consolidate_scoped, detect_fading, DreamConfig};
+use trusty_common::memory_core::dream::{consolidate_scoped, detect_fading};
 
 use super::helpers::{open_palace_handle, parse_room, resolve_palace};
 
@@ -29,10 +30,11 @@ const DEFAULT_MAX_AGE_DAYS: i64 = 7;
 /// control instead of waiting for the idle dreamer; returns the work done so
 /// the caller can log progress.
 /// What: parses `room` (null/omitted = all rooms) and `max_age_days`
-/// (default 7), builds a `DreamConfig` seeded with the daemon's OpenRouter key
-/// and local-model flag, opens the palace, and runs `consolidate_scoped`. When
-/// no inference backend is configured the helper is a graceful no-op (zero
-/// counts). Also computes the palace-wide fading-memories resurface list (issue
+/// (default 7), builds a `DreamConfig` seeded from the daemon's user config
+/// (OpenRouter key, local-model flag, local-model id — issue #2593), opens
+/// the palace, and runs `consolidate_scoped`. When no inference backend is
+/// configured the helper is a graceful no-op (zero counts). Also computes
+/// the palace-wide fading-memories resurface list (issue
 /// #2352) — high-value memories that have decayed below the resurface threshold,
 /// surfaced (never auto-boosted) so the caller can touch or `memory_forget`
 /// them. Returns
@@ -55,8 +57,13 @@ pub(crate) async fn handle_dream_consolidate_room(state: &AppState, args: Value)
     let handle = open_palace_handle(state, &palace)?;
 
     // Seed the consolidation config from the daemon's user config so the
-    // inference backend (OpenRouter key / local model) matches the idle dream
-    // cycle. Everything else uses the dream defaults (semantic enabled).
+    // inference backend (OpenRouter key / local model / local model id)
+    // matches the idle dream cycle. Everything else uses the dream defaults
+    // (semantic enabled). `dream_config_from_user_config` (issue #2593) also
+    // forwards `local_model.model` into `semantic.model` — previously only
+    // the key and the enabled flag were forwarded, leaving `semantic.model`
+    // on the OpenRouter-style default even when the local Ollama backend was
+    // what actually resolved.
     //
     // Use `crate::service::load_user_config` (the axum-free home of the loader,
     // issue #226) rather than the `crate::web::` re-export: this `tools` module
@@ -64,11 +71,7 @@ pub(crate) async fn handle_dream_consolidate_room(state: &AppState, args: Value)
     // "axum-server")]`-gated, so the re-export vanishes when a dependent builds
     // trusty-memory without that feature — which broke the build (E0433).
     let cfg = crate::service::load_user_config().unwrap_or_default();
-    let dream_cfg = DreamConfig {
-        openrouter_api_key: cfg.openrouter_api_key,
-        local_model_enabled: cfg.local_model.enabled,
-        ..DreamConfig::default()
-    };
+    let dream_cfg = crate::service::dream_config_from_user_config(&cfg);
 
     let stats = consolidate_scoped(&handle, &dream_cfg, room, max_age_days, None).await?;
 


### PR DESCRIPTION
## Summary

- `crates/trusty-common/src/memory_core/semantic_consolidation/types.rs`: adds `validate_ollama_model`, rejecting an OpenRouter/cloud-vendor-prefixed model id (e.g. the default `anthropic/claude-haiku-4-5`) when the resolved backend is a local Ollama server — Ollama can never serve that id and every call would 404.
- `crates/trusty-common/src/memory_core/dream/cycle.rs`: `build_consolidator_from_config` now validates the model before constructing an `OllamaInference` backend and returns `Result<Option<Arc<SemanticConsolidator>>, String>`. The idle-loop path (`semantic_consolidation_pass`) logs ONE loud `error!` naming the model, the provider, and the config knob to fix, then sets a disabled flag so subsequent cycles skip the phase entirely instead of rebuilding/retrying every cycle. The on-demand path (`consolidate_scoped`, backing the `dream_consolidate_room` MCP tool) surfaces the misconfiguration as an `Err` to the caller immediately (it's a single user-triggered call, not a recurring background job — nothing to "disable").
- `crates/trusty-common/src/memory_core/dream/dreamer.rs`: `Dreamer` gains a `semantic_consolidation_disabled: AtomicBool` field (persists for the `Dreamer`'s — i.e. that palace's — process lifetime, cleared only by a fresh `Dreamer`/config reload) and a public `is_semantic_consolidation_disabled()` accessor.

Scope is deliberately limited to validation + fail-loud, per the issue's own list of options — the `trusty_common::inference` migration (epic #2400) is explicitly out of scope here.

Fixes #2593.

## Test plan

- [x] `cargo check -p trusty-memory` — clean
- [x] `cargo test -p trusty-common --features memory-core` — 539 passed, 0 failed (adds 5 new tests: `validate_ollama_model_rejects_cloud_prefix`, `validate_ollama_model_accepts_local_tag`, `dream_cycle_semantic_consolidation_invalid_model_disables_once`, `dream_cycle_semantic_consolidation_valid_local_model_not_disabled`, `consolidate_scoped_invalid_model_returns_err`; also fixes `consolidate_scoped_no_inference_is_noop`, which previously relied on `DreamConfig::default()` being a `local_model_enabled=true` no-op — that default is exactly the #2593 misconfiguration and now correctly errors, so the test now sets `local_model_enabled: false` to test genuine "no inference configured")
- [x] `cargo test -p trusty-memory` — all suites pass, 0 failed
- [x] `cargo clippy -p trusty-memory --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p trusty-common --all-targets --features memory-core -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools