### PR TITLE
ci: SLOC counter hardening + resilient fastembed pre-seed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,22 @@ jobs:
       #       cargo test never needs HuggingFace network access — this step
       #       is a best-effort latency/flake optimisation, not a correctness
       #       dependency, and must not be allowed to fail the job.
+      #
+      #       PR #2981 code-critic fix: fail-soft MUST NOT invoke seed_models
+      #       directly as an `if`/`while` condition. Bash disables `errexit`
+      #       for the entire compound command being tested as a conditional,
+      #       and — per the bash manual — "this behavior applies even when
+      #       the failing command is ... contained within a shell function
+      #       called by a command in the list", so a `set -e` re-declared
+      #       INSIDE the function does not help: a mid-download curl failure
+      #       is silently swallowed, execution falls through to the final
+      #       `du -sh ... || true` (always exit 0), the function reports
+      #       success, the ::warning:: never fires, and a PARTIAL/corrupt
+      #       cache dir gets persisted by actions/cache's post-step and
+      #       served as a false "hit" on every run until the cache key
+      #       rotates. Empirically reproduced during review. Fix: invoke
+      #       seed_models as a plain statement in a subshell (never as a
+      #       conditional's test) and capture its exit status via $?.
       - name: Pre-seed fastembed models (cache miss only)
         if: steps.fastembed-cache.outputs.cache-hit != 'true'
         env:
@@ -313,11 +329,12 @@ jobs:
 
           # The substantive pre-seed logic runs strict (its own set -e) inside
           # this function so any failure anywhere inside it — a 403, a
-          # transient network error, anything — is caught by the `if
-          # seed_models; then … else …` below rather than propagating past
-          # this step (issue #2554 fail-soft requirement). Bash functions
-          # share the enclosing shell's variables/other functions, so
-          # CURL_AUTH and curl_retry are visible here without re-declaration.
+          # transient network error, anything — aborts the function
+          # immediately instead of silently continuing. Bash functions share
+          # the enclosing shell's variables/other functions, so CURL_AUTH and
+          # curl_retry are visible here without re-declaration. See the
+          # PR #2981 code-critic note above the step name for why this MUST
+          # be invoked in a subshell below, never as an `if`/`while` test.
           seed_models() {
             set -euo pipefail
 
@@ -375,10 +392,23 @@ jobs:
             du -sh "${CACHE_DIR}" || true
           }
 
-          if seed_models; then
-            :
-          else
-            echo "::warning::fastembed model pre-seed failed (HuggingFace rate-limit/403 or network issue) — continuing WITHOUT a pre-seeded cache. This is non-fatal: cargo test --workspace never needs the real model (non-ignored tests use a MockEmbedder via seed_shared_embedder_with_mock(), issue #850; the tests that need the real model are #[ignore]-gated and are not run in this job). See issue #2554 for details."
+          # Invoke as a plain statement in a subshell — NOT as an `if`/`while`
+          # test — so seed_models' own `set -e` is actually honored (see the
+          # PR #2981 code-critic note above). `set +e` around the call stops
+          # THIS failure from tripping the outer script's own errexit; it is
+          # restored immediately after the status is captured.
+          set +e
+          ( seed_models )
+          rc=$?
+          set -e
+
+          if [ "${rc}" -ne 0 ]; then
+            # Do not let actions/cache persist a partial/corrupt download
+            # tree under this run's key: an absent cache is a safe "miss"
+            # next run; a partial one would look like a permanent false
+            # "hit" until the key rotates (issue #2554/#2981).
+            rm -rf "${CACHE_DIR}"
+            echo "::warning::fastembed model pre-seed failed (rc=${rc}; HuggingFace rate-limit/403 or network issue) — continuing WITHOUT a pre-seeded cache. This is non-fatal: cargo test --workspace never needs the real model (non-ignored tests use a MockEmbedder via seed_shared_embedder_with_mock(), issue #850; the tests that need the real model are #[ignore]-gated and are not run in this job). See issue #2554 for details."
           fi
 
       - name: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,20 +249,57 @@ jobs:
       # Primary model: Xenova/all-MiniLM-L6-v2 at the pinned snapshot.
       # The refs/main pointer, tokenizer files, and the quantized ONNX are
       # all needed for fastembed initialisation.
+      #
+      # Resilience (issue #2554): two changes after PR #2548's run 29291600721
+      # hit a hard HTTP 403 from HuggingFace's CDN and killed the whole Test
+      # job before any Rust tests ran:
+      #   (a) Authenticated requests when an optional HF_TOKEN repo/org
+      #       secret is configured — authenticated callers generally get a
+      #       materially higher HF rate limit than anonymous ones.
+      #       ${{ secrets.HF_TOKEN }} evaluates to an empty string (never an
+      #       error) when the secret is unset, so forks/PRs without access
+      #       to repo secrets fall back to the previous anonymous behavior.
+      #   (b) The whole step is now fail-SOFT: any failure (rate limit,
+      #       network blip, etc.) prints a ::warning:: annotation and lets
+      #       the job continue instead of hard-failing. This is safe because
+      #       the only tests that require the real downloaded model are
+      #       #[ignore]-gated (crates/trusty-common/src/embedder/mod.rs
+      #       fastembed_returns_correct_dim / fastembed_cache_hit_is_idempotent,
+      #       crates/trusty-search/tests/migration_e2e.rs, crates/trusty-search/
+      #       tests/embedder_supervisor_e2e.rs, crates/trusty-embedderd/tests/
+      #       bit_identical.rs) and are never run by the plain `cargo test
+      #       --workspace` step below. Every non-ignored test that touches
+      #       the shared embedder pre-seeds a MockEmbedder instead via
+      #       seed_shared_embedder_with_mock() (issue #850,
+      #       crates/trusty-common/src/memory_core/retrieval/embedder.rs), so
+      #       cargo test never needs HuggingFace network access — this step
+      #       is a best-effort latency/flake optimisation, not a correctness
+      #       dependency, and must not be allowed to fail the job.
       - name: Pre-seed fastembed models (cache miss only)
         if: steps.fastembed-cache.outputs.cache-hit != 'true'
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           set -euo pipefail
 
           CACHE_DIR="${FASTEMBED_CACHE_DIR}"
           mkdir -p "${CACHE_DIR}"
 
+          # ── Auth header (issue #2554) ───────────────────────────────────
+          # Authenticated HF requests get a materially higher rate limit
+          # than anonymous ones. Built once; empty when HF_TOKEN is unset so
+          # unauthenticated requests behave exactly as before.
+          CURL_AUTH=()
+          if [ -n "${HF_TOKEN:-}" ]; then
+            CURL_AUTH=(-H "Authorization: Bearer ${HF_TOKEN}")
+          fi
+
           # ── Retry helper ──────────────────────────────────────────────────
           # curl_retry <url> <dest>
           # 5 attempts, starting with 5 s back-off, doubling each time.
           curl_retry() {
             local url="$1" dest="$2" attempt=1 max=5 wait=5
-            until curl -fsSL --retry 0 -o "${dest}" "${url}"; do
+            until curl -fsSL --retry 0 "${CURL_AUTH[@]}" -o "${dest}" "${url}"; do
               if [ "${attempt}" -ge "${max}" ]; then
                 echo "ERROR: download failed after ${max} attempts: ${url}" >&2
                 return 1
@@ -274,58 +311,75 @@ jobs:
             done
           }
 
-          # ── Xenova/all-MiniLM-L6-v2 (AllMiniLML6V2Q — primary model) ────
-          # hf-hub resolves the model at the revision pinned in refs/main.
-          # We download the refs/main pointer first, then the exact snapshot.
-          HF_BASE="https://huggingface.co"
-          XENOVA_REPO="Xenova/all-MiniLM-L6-v2"
-          XENOVA_DIR="${CACHE_DIR}/models--Xenova--all-MiniLM-L6-v2"
+          # The substantive pre-seed logic runs strict (its own set -e) inside
+          # this function so any failure anywhere inside it — a 403, a
+          # transient network error, anything — is caught by the `if
+          # seed_models; then … else …` below rather than propagating past
+          # this step (issue #2554 fail-soft requirement). Bash functions
+          # share the enclosing shell's variables/other functions, so
+          # CURL_AUTH and curl_retry are visible here without re-declaration.
+          seed_models() {
+            set -euo pipefail
 
-          mkdir -p "${XENOVA_DIR}/refs" "${XENOVA_DIR}/blobs"
+            # ── Xenova/all-MiniLM-L6-v2 (AllMiniLML6V2Q — primary model) ──
+            # hf-hub resolves the model at the revision pinned in refs/main.
+            # We download the refs/main pointer first, then the exact snapshot.
+            HF_BASE="https://huggingface.co"
+            XENOVA_REPO="Xenova/all-MiniLM-L6-v2"
+            XENOVA_DIR="${CACHE_DIR}/models--Xenova--all-MiniLM-L6-v2"
 
-          # Resolve current HEAD commit for the model repo.
-          echo "Resolving Xenova/all-MiniLM-L6-v2 HEAD revision …"
-          XENOVA_REV=$(curl -fsSL \
-            "${HF_BASE}/${XENOVA_REPO}/resolve/main/onnx/model_quantized.onnx" \
-            -o /dev/null -w '%{url_effective}' | grep -oP '(?<=/resolve/)[^/]+' || true)
+            mkdir -p "${XENOVA_DIR}/refs" "${XENOVA_DIR}/blobs"
 
-          # Fallback: query the HF API for the main branch commit hash.
-          if [ -z "${XENOVA_REV}" ] || [ "${XENOVA_REV}" = "main" ]; then
-            XENOVA_REV=$(curl -fsSL \
-              "https://huggingface.co/api/models/${XENOVA_REPO}?full=false" \
-              | grep -oP '"sha":"[^"]{40}"' | head -1 | grep -oP '[0-9a-f]{40}' || true)
-          fi
+            # Resolve current HEAD commit for the model repo.
+            echo "Resolving Xenova/all-MiniLM-L6-v2 HEAD revision …"
+            XENOVA_REV=$(curl -fsSL "${CURL_AUTH[@]}" \
+              "${HF_BASE}/${XENOVA_REPO}/resolve/main/onnx/model_quantized.onnx" \
+              -o /dev/null -w '%{url_effective}' | grep -oP '(?<=/resolve/)[^/]+' || true)
 
-          # If we still have no revision, use the well-known pinned hash from
-          # the developer's local cache (matches fastembed 5.13.4).
-          XENOVA_REV="${XENOVA_REV:-751bff37182d3f1213fa05d7196b954e230abad9}"
-          echo "Using Xenova/all-MiniLM-L6-v2 revision: ${XENOVA_REV}"
-
-          echo "${XENOVA_REV}" > "${XENOVA_DIR}/refs/main"
-          SNAP_DIR="${XENOVA_DIR}/snapshots/${XENOVA_REV}"
-          mkdir -p "${SNAP_DIR}/onnx"
-
-          # Download required files for AllMiniLML6V2Q initialisation.
-          for FILE in tokenizer.json tokenizer_config.json special_tokens_map.json config.json; do
-            DEST="${SNAP_DIR}/${FILE}"
-            if [ ! -f "${DEST}" ]; then
-              echo "Downloading ${XENOVA_REPO}/${FILE} …"
-              curl_retry \
-                "${HF_BASE}/${XENOVA_REPO}/resolve/${XENOVA_REV}/${FILE}" \
-                "${DEST}"
+            # Fallback: query the HF API for the main branch commit hash.
+            if [ -z "${XENOVA_REV}" ] || [ "${XENOVA_REV}" = "main" ]; then
+              XENOVA_REV=$(curl -fsSL "${CURL_AUTH[@]}" \
+                "https://huggingface.co/api/models/${XENOVA_REPO}?full=false" \
+                | grep -oP '"sha":"[^"]{40}"' | head -1 | grep -oP '[0-9a-f]{40}' || true)
             fi
-          done
 
-          ONNX_DEST="${SNAP_DIR}/onnx/model_quantized.onnx"
-          if [ ! -f "${ONNX_DEST}" ]; then
-            echo "Downloading ${XENOVA_REPO}/onnx/model_quantized.onnx (~22 MB) …"
-            curl_retry \
-              "${HF_BASE}/${XENOVA_REPO}/resolve/${XENOVA_REV}/onnx/model_quantized.onnx" \
-              "${ONNX_DEST}"
+            # If we still have no revision, use the well-known pinned hash from
+            # the developer's local cache (matches fastembed 5.13.4).
+            XENOVA_REV="${XENOVA_REV:-751bff37182d3f1213fa05d7196b954e230abad9}"
+            echo "Using Xenova/all-MiniLM-L6-v2 revision: ${XENOVA_REV}"
+
+            echo "${XENOVA_REV}" > "${XENOVA_DIR}/refs/main"
+            SNAP_DIR="${XENOVA_DIR}/snapshots/${XENOVA_REV}"
+            mkdir -p "${SNAP_DIR}/onnx"
+
+            # Download required files for AllMiniLML6V2Q initialisation.
+            for FILE in tokenizer.json tokenizer_config.json special_tokens_map.json config.json; do
+              DEST="${SNAP_DIR}/${FILE}"
+              if [ ! -f "${DEST}" ]; then
+                echo "Downloading ${XENOVA_REPO}/${FILE} …"
+                curl_retry \
+                  "${HF_BASE}/${XENOVA_REPO}/resolve/${XENOVA_REV}/${FILE}" \
+                  "${DEST}"
+              fi
+            done
+
+            ONNX_DEST="${SNAP_DIR}/onnx/model_quantized.onnx"
+            if [ ! -f "${ONNX_DEST}" ]; then
+              echo "Downloading ${XENOVA_REPO}/onnx/model_quantized.onnx (~22 MB) …"
+              curl_retry \
+                "${HF_BASE}/${XENOVA_REPO}/resolve/${XENOVA_REV}/onnx/model_quantized.onnx" \
+                "${ONNX_DEST}"
+            fi
+
+            echo "fastembed model pre-seed complete."
+            du -sh "${CACHE_DIR}" || true
+          }
+
+          if seed_models; then
+            :
+          else
+            echo "::warning::fastembed model pre-seed failed (HuggingFace rate-limit/403 or network issue) — continuing WITHOUT a pre-seeded cache. This is non-fatal: cargo test --workspace never needs the real model (non-ignored tests use a MockEmbedder via seed_shared_embedder_with_mock(), issue #850; the tests that need the real model are #[ignore]-gated and are not run in this job). See issue #2554 for details."
           fi
-
-          echo "fastembed model pre-seed complete."
-          du -sh "${CACHE_DIR}" || true
 
       - name: cargo test --workspace
         # Unset CI so trusty-common's update::check_throttled runs the

--- a/.github/workflows/line-cap.yml
+++ b/.github/workflows/line-cap.yml
@@ -28,5 +28,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Gate on the SLOC counter's own regression fixtures (issue #2563) so a
+      # future edit to scripts/lib/sloc_awk.sh that reintroduces a counting
+      # bug (e.g. the nested-block-comment overcount fixed here, or the
+      # #2489/#2509 doc-comment-prose swallow) fails CI instead of silently
+      # rotting. Runs before the real gate since a broken counter makes the
+      # real gate's result unreliable.
+      - name: SLOC counter selftest (regression fixtures)
+        run: bash scripts/check_line_cap_selftest.sh
+
       - name: Enforce 500-line file cap (ratcheted allowlist)
         run: bash scripts/check_line_cap.sh

--- a/scripts/check_line_cap.sh
+++ b/scripts/check_line_cap.sh
@@ -56,6 +56,15 @@
 #   will NEVER falsely fail a legitimate file. Pathological cases (e.g. a raw
 #   string containing /*) can be noted as exceptions in a code comment.
 #
+#   SWALLOW-TO-EOF RISK (issue #2563 item 2, intentional, not a bug): an
+#   unmatched /* inside a string/char literal — one with no real */ anywhere
+#   later in the file — is indistinguishable from a genuinely unterminated
+#   block comment, so it swallows every subsequent line to EOF as "inside a
+#   comment". This can undercount a large tail of a file, not just one line.
+#   It is still safe under the never-overcount invariant above (the gate can
+#   only pass files it should fail, never fail files it should pass) and is
+#   pinned as a fixture in scripts/test-data/sloc-string-literal-slash-star.rs.
+#
 # Test: exercised in the PR that introduced SLOC counting (clean tree exits 0;
 #   a production file with 600 SLOC fails; 600 SLOC in a test path passes;
 #   1600 SLOC in a test path fails). The logic is pure SLOC counting against

--- a/scripts/check_line_cap_selftest.sh
+++ b/scripts/check_line_cap_selftest.sh
@@ -3,13 +3,25 @@
 # check_line_cap_selftest.sh — regression fixtures for the SLOC counter
 # shared by scripts/check_line_cap.sh (issues #2489 / #2509).
 #
-# Why: the SLOC awk heuristic in scripts/lib/sloc_awk.sh has one specific,
-#   previously-broken failure mode: a `/*` appearing inside `//`/`///`/`//!`
-#   line-comment PROSE (e.g. a doc comment mentioning a path glob like
-#   `/api/v1/sessions/*`) was mistaken for a block-comment opener, which
-#   silently swallowed the rest of the file as an "unterminated" block
-#   comment. There is no bats/shell-test convention elsewhere in scripts/, so
-#   this is a minimal, dependency-free self-test runnable directly with bash.
+# Why: the SLOC awk heuristic in scripts/lib/sloc_awk.sh has had two specific,
+#   previously-broken failure modes, both pinned here as regressions:
+#     - issue #2489/#2509: a `/*` appearing inside `//`/`///`/`//!`
+#       line-comment PROSE (e.g. a doc comment mentioning a path glob like
+#       `/api/v1/sessions/*`) was mistaken for a block-comment opener, which
+#       silently swallowed the rest of the file as an "unterminated" block
+#       comment.
+#     - issue #2563: a boolean `in_block` flag (rather than a nesting-depth
+#       counter) mis-tracked genuine NESTED `/* ... */` block comments — a
+#       `*/` that only closed an inner nested comment was mistaken for
+#       closing the outer one, causing an OVERCOUNT (comment prose counted
+#       as code), which violates the documented never-overcount invariant.
+#   There is also one INTENTIONAL leniency case pinned as a fixture (not a
+#   bug — see scripts/lib/sloc_awk.sh's header comment): a `/*` inside a
+#   string literal with no matching `*/` swallows the rest of the file to
+#   EOF, which UNDERCOUNTS real code lines. This is accepted because the
+#   counter is designed to never overcount, only (rarely) undercount.
+#   There is no bats/shell-test convention elsewhere in scripts/, so this is
+#   a minimal, dependency-free self-test runnable directly with bash.
 #
 # What: runs the shared $SLOC_AWK program (scripts/lib/sloc_awk.sh) against
 #   each fixture in scripts/test-data/ and asserts the exact expected SLOC
@@ -35,12 +47,27 @@ FIXTURE_DIR="$SCRIPT_DIR/test-data"
 #                              glob) must NOT swallow the rest of the file.
 # - sloc-real-block-comment.rs: genuine /* ... */ block comments (including
 #                              multi-line spans) must still be fully excluded.
+# - sloc-nested-block-comment.rs: regression fixture for #2563 — a genuine
+#                              NESTED /* /* */ */ block comment (6 comment
+#                              lines) must be fully excluded; only the trailing
+#                              real code line counts. Pre-fix this overcounted
+#                              (the inner `*/` was mistaken for the outer
+#                              closer, exposing comment prose as "code").
 # - sloc-trailing-comment.rs:  code followed by a trailing `//` comment must
 #                              still count the code portion of the line.
+# - sloc-string-literal-slash-star.rs: INTENTIONAL leniency case (#2563 item
+#                              2, not a bug) — an unmatched `/*` inside a
+#                              string literal swallows the rest of the file to
+#                              EOF, undercounting 2 genuine code lines. Pinned
+#                              here so this known trade-off cannot silently
+#                              change (e.g. into an overcount) without a
+#                              deliberate selftest update.
 CASES="sloc-normal.rs	7
 sloc-pathglob-doc.rs	6
 sloc-real-block-comment.rs	2
-sloc-trailing-comment.rs	4"
+sloc-nested-block-comment.rs	1
+sloc-trailing-comment.rs	4
+sloc-string-literal-slash-star.rs	2"
 
 fail=0
 while IFS="$(printf '\t')" read -r fixture expected; do

--- a/scripts/lib/sloc_awk.sh
+++ b/scripts/lib/sloc_awk.sh
@@ -8,83 +8,109 @@
 # What: defines the `SLOC_AWK` shell variable — an awk program that counts
 #   SLOC (source lines of code) in a single file, excluding blank lines,
 #   `//`/`///`/`//!` line comments, and `/* ... */` block comments (including
-#   multi-line spans). A line with code followed by a trailing `//` comment
-#   still counts.
+#   multi-line spans AND nested block comments — Rust supports nesting them,
+#   e.g. `/* outer /* inner */ still outer */`). A line with code followed by
+#   a trailing `//` comment still counts.
 #
-# Algorithm (issue #2489/#2509 fix): unlike a naive scanner that looks for the
-#   next `/*` unconditionally, this walks the line left-to-right and, at each
-#   step, asks "which comment marker comes first: `//` or `/*`?"
-#     - If `//` comes first (or `/*` is absent), the rest of the line is a
-#       line comment: truncate there and stop. This is the critical fix — a
-#       `/*` appearing later in a `///`/`//!` doc-comment's PROSE (e.g. a path
-#       glob like `/api/v1/sessions/*`) is never reached, because the line
-#       comment truncation happens first and removes it along with the rest
-#       of the line.
-#     - If `/*` comes first, scan for its matching `*/` as before (handling
-#       multiple same-line block comments), then loop again on what remains
-#       so a `//` appearing AFTER a same-line block comment is still honored.
-#   This preserves the pre-existing behavior for real, code-context block
-#   comments (`/* ... */` spanning one or many lines) while fixing the false
-#   trap when `/*` only ever appeared inside comment prose.
+# Algorithm (issue #2489/#2509 fix, extended by issue #2563 for nesting): the
+#   awk program walks each line left-to-right with a single cursor `pos` and a
+#   block-comment NESTING DEPTH counter `depth` (carried across lines):
+#     - While `depth > 0` (we are inside one or more nested block comments),
+#       scan forward from `pos` for whichever of `/*` or `*/` occurs first.
+#       A `*/` decrements `depth`; a `/*` increments it (issue #2563 — a plain
+#       boolean `in_block` flag cannot tell a nested `/*` from a coincidental
+#       one deeper inside prose, so a `*/` that only closes an INNER nested
+#       comment was previously mistaken for closing the outer one, causing
+#       genuine comment prose after it to be miscounted as code, i.e. an
+#       OVERCOUNT — a violation of the documented never-overcount invariant).
+#       If neither marker is found, the rest of the line is consumed by the
+#       open comment and contributes nothing to this line's code text.
+#     - While `depth == 0`, scan forward from `pos` for whichever of `//` or
+#       `/*` occurs first:
+#         - `//` first (or `/*` absent): the remainder of the line is a line
+#           comment; keep only the text before it and stop scanning this
+#           line. This is the issue #2489/#2509 fix — a `/*` appearing later
+#           in `///`/`//!` doc-comment PROSE (e.g. a path glob like
+#           `/api/v1/sessions/*`) is never reached, because the line-comment
+#           truncation happens first and removes it along with the rest of
+#           the line.
+#         - `/*` first: keep the text before it as code, set `depth = 1`, and
+#           continue the walk (now in the `depth > 0` branch above) so any
+#           further nesting or a same-line close is still handled correctly.
+#   Whatever code text survives the walk (i.e. was never inside a comment) is
+#   whitespace-stripped; the line counts as 1 SLOC iff any characters remain.
+#   This preserves the pre-existing behavior for non-nested block comments and
+#   trailing `//` comments while fixing the nested-comment overcount.
 #
-# Intentional leniency (unchanged from the original heuristic): `//` or `/*`
-#   inside a string/char literal or raw string can still suppress real code
-#   on that line (undercounts). The counter is designed to err TOWARD
-#   LENIENCY — it may undercount, but it will never over-count. See
-#   scripts/check_line_cap.sh's header comment for the full leniency note.
+# Intentional leniency (unchanged from the original heuristic, issue #2563
+#   item 2): this awk program has no notion of string/char literals or raw
+#   strings, so a `//` or `/*` INSIDE a string literal is still treated as a
+#   real comment marker. An unmatched `/*` inside a string literal (i.e. one
+#   with no `*/` anywhere later in the string or file) sets `depth = 1` and,
+#   because no real `*/` ever appears to close it, SWALLOWS EVERY SUBSEQUENT
+#   LINE TO EOF as if it were still inside that block comment — the same
+#   failure class as #2489/#2509 via a different trigger. This is a known,
+#   accepted trade-off: the counter is designed to err TOWARD LENIENCY (it may
+#   UNDERCOUNT real code, e.g. missing genuine code lines after such a string),
+#   but per the invariant above it will NEVER overcount. See
+#   scripts/test-data/sloc-string-literal-slash-star.rs for a pinned fixture
+#   of this exact swallow-to-EOF behavior, and scripts/check_line_cap.sh's
+#   header comment for the full leniency note.
 #
 # Test: scripts/check_line_cap_selftest.sh exercises this against fixtures in
 #   scripts/test-data/ (normal file, `/*` inside doc-comment prose, real block
-#   comments, trailing `//` after code).
+#   comments, nested block comments, trailing `//` after code, `/*` inside a
+#   string literal).
 SLOC_AWK='
-BEGIN { in_block = 0; sloc = 0 }
+BEGIN { depth = 0; sloc = 0 }
 {
   line = $0
-  if (in_block) {
-    # Inside a block comment: look for the closing */
-    pos = index(line, "*/")
-    if (pos > 0) {
-      in_block = 0
-      line = substr(line, pos + 2)
+  n = length(line)
+  pos = 1
+  out = ""
+  while (pos <= n) {
+    if (depth > 0) {
+      # Inside one or more nested block comments: find whichever of /* or */
+      # occurs first from the current cursor and adjust nesting depth.
+      rest = substr(line, pos)
+      o = index(rest, "/*")
+      c = index(rest, "*/")
+      if (c > 0 && (o == 0 || c < o)) {
+        depth--
+        pos = pos + (c - 1) + 2
+      } else if (o > 0) {
+        depth++
+        pos = pos + (o - 1) + 2
+      } else {
+        # Neither marker found: the rest of the line stays inside the
+        # comment and contributes no code text.
+        pos = n + 1
+      }
     } else {
-      # Entire line is inside block comment
-      next
+      # Not inside a block comment: find whichever of // or /* occurs first.
+      rest = substr(line, pos)
+      lc = index(rest, "//")
+      bc = index(rest, "/*")
+      if (lc > 0 && (bc == 0 || lc < bc)) {
+        # Line comment starts first (or is the only marker present): keep
+        # the code before it and stop scanning this line.
+        out = out substr(line, pos, lc - 1)
+        pos = n + 1
+      } else if (bc > 0) {
+        # Block comment starts first: keep the code before it, open one
+        # level of nesting, and keep walking from just past the "/*".
+        out = out substr(line, pos, bc - 1)
+        depth = 1
+        pos = pos + (bc - 1) + 2
+      } else {
+        # No comment markers left on this line: the remainder is all code.
+        out = out substr(line, pos)
+        pos = n + 1
+      }
     }
   }
-  # Walk the line, resolving whichever comment marker (// or /*) occurs
-  # first at each step. A // that occurs before any /* on the remaining
-  # line ALWAYS wins and truncates the line immediately — this is what
-  # stops a /* inside line-comment prose from being mistaken for a block
-  # opener (issue #2489/#2509).
-  while (1) {
-    lc = index(line, "//")
-    bc = index(line, "/*")
-    if (lc == 0 && bc == 0) break
-    if (lc > 0 && (bc == 0 || lc < bc)) {
-      # Line comment starts first (or is the only marker present): the
-      # remainder of the line is comment prose. Truncate and stop scanning.
-      line = substr(line, 1, lc - 1)
-      break
-    }
-    # Block comment starts first. Search for its closer only in the portion
-    # after the opener, so a stray */ earlier in the line cannot be
-    # mistaken for the closer of this opener.
-    after_open = substr(line, bc + 2)
-    rel_close = index(after_open, "*/")
-    if (rel_close > 0) {
-      blk_close = bc + 1 + rel_close   # +1 for the two chars of /*
-      line = substr(line, 1, bc - 1) substr(line, blk_close + 2)
-      # Loop again: there may be more // or /* markers in what remains.
-    } else {
-      # /* opened but no */ on this line — remainder is a block comment.
-      line = substr(line, 1, bc - 1)
-      in_block = 1
-      break
-    }
-  }
-  # Count the line if anything non-whitespace remains
-  gsub(/[[:space:]]/, "", line)
-  if (length(line) > 0) sloc++
+  gsub(/[[:space:]]/, "", out)
+  if (length(out) > 0) sloc++
 }
 END { print sloc }
 '

--- a/scripts/test-data/sloc-nested-block-comment.rs
+++ b/scripts/test-data/sloc-nested-block-comment.rs
@@ -1,0 +1,7 @@
+/*
+  outer comment start
+  /*
+    nested inner comment
+  */
+*/
+fn real_code() {}

--- a/scripts/test-data/sloc-string-literal-slash-star.rs
+++ b/scripts/test-data/sloc-string-literal-slash-star.rs
@@ -1,0 +1,4 @@
+fn broken() {
+    let s = "contains /* not a real comment";
+    let x = 1;
+}


### PR DESCRIPTION
## Summary

Two small CI/tooling fixes, batched into one PR per the delegated task:

### #2563 — SLOC counter hardening + selftest wired into CI

Three follow-ups from PR #2561 review (all MEDIUM, none blocking):

1. **Nested block-comment overcount (real correctness bug).** `scripts/lib/sloc_awk.sh` used a boolean `in_block` flag instead of a nesting-depth counter. A genuine nested `/* /* */ */` block comment (which Rust supports) had its inner `*/` mistaken for the outer closer, exposing trailing comment prose as "code" — an overcount that violated the counter's documented never-overcount invariant. Fixed by replacing the boolean with a proper `depth` counter that only exits block-comment mode once every opened nesting level has closed. Verified pre-fix: the 6-line nested-comment fixture (`sloc-nested-block-comment.rs`) reported **2** SLOC against the old boolean algorithm instead of the correct 1 (the stray closing `*/` of the outer comment was miscounted as a code line); post-fix it correctly reports 1.
2. **String-literal `/*` swallow-to-EOF (intentional leniency, documented not fixed).** Per the issue's stated preference, this was documented rather than fixed — string-aware tokenization would be a much larger, riskier change for a heuristic whose entire contract is "err toward leniency, never overcount" (an undercount already satisfies that contract). Strengthened the doc caveats in both `scripts/lib/sloc_awk.sh` and `scripts/check_line_cap.sh`, and pinned the exact behavior with a new fixture (`sloc-string-literal-slash-star.rs`, expected 2 SLOC — undercounting 2 real code lines swallowed after the unmatched `/*`) so this trade-off can't silently regress into an overcount.
3. **Selftest wired into CI.** `scripts/check_line_cap_selftest.sh` now runs as its own step in `.github/workflows/line-cap.yml`, ahead of the real gate, so a future edit to the SLOC counter that reintroduces a counting bug fails CI instead of rotting silently.

### #2554 — resilient fastembed pre-seed

The Test job's "Pre-seed fastembed models (cache miss only)" step did unauthenticated `curl` to huggingface.co and hard-failed the entire job (killing every Rust test suite) after 5 retries on an HTTP 403 (observed on PR #2548, run `29291600721`, 2026-07-13 — two consecutive failures, pure CI infra issue, no code regression).

1. **Optional `HF_TOKEN`-authenticated requests.** Added `env: HF_TOKEN: ${{ secrets.HF_TOKEN }}` (standard guarded pattern — empty string, never an error, when unset) and an `Authorization: Bearer` header built once and passed to every curl call in the step. Forks/PRs without access to repo secrets are unaffected (fall back to anonymous requests, identical to before).
2. **Fail-soft.** The pre-seed logic runs inside a `seed_models()` function with its own `set -euo pipefail`. It is invoked as a plain statement in a subshell — `set +e; ( seed_models ); rc=$?; set -e` — never as an `if`/`while` test. On failure, the step removes the (now-partial) `FASTEMBED_CACHE_DIR` and prints a `::warning::` annotation with the captured exit code, then continues instead of hard-failing.

   **Code-critic caught a HIGH-severity bug in the first version of this fix** (`if seed_models; then … else … fi`): bash disables `errexit` for the entire compound command being tested as a conditional, and — per the bash manual — this applies even to a `set -e` re-declared *inside* a function called from that condition. A mid-download curl failure was silently swallowed, execution fell through to the function's final `du -sh ... || true` (always exit 0), the function reported success, the `::warning::` never fired, and a **partial/corrupt** cache directory would have been persisted by `actions/cache`'s post-step and served as a false "hit" on every subsequent run until the cache key rotated. I reproduced this empirically with a minimal repro before and after the fix (see below), then re-verified end-to-end by pointing a fake `curl` at a guaranteed failure for the entire pre-seed body: the warning fired with the correct `rc`, the step exited 0, and the cache directory was removed.

   I verified the fail-soft change is safe rather than just trusting the issue's stated assumption — checked what the Test job's `cargo test --workspace --exclude trusty-mpm-gui` actually runs:
   - Every test that constructs a real `FastEmbedder` and needs the actual ONNX model is `#[ignore]`-gated: `fastembed_returns_correct_dim` / `fastembed_cache_hit_is_idempotent` (`crates/trusty-common/src/embedder/mod.rs`), all of `crates/trusty-search/tests/embedder_supervisor_e2e.rs` and `migration_e2e.rs`, and `crates/trusty-embedderd/tests/bit_identical.rs`. None of these run in the normal CI pass.
   - The `ci.yml` comment claiming "~31 trusty-memory tests" needed the model turned out to describe a **historical** problem, already fixed by issue #850: every non-ignored test that touches the shared embedder calls `seed_shared_embedder_with_mock()` (`crates/trusty-common/src/memory_core/retrieval/embedder.rs`) to pre-populate the process-wide `SHARED_EMBEDDER` cell with a `MockEmbedder` before any real embedder call — no network access required.

   So `cargo test --workspace` never needed HuggingFace access to begin with; the pre-seed step is purely a latency/flake optimisation. Fail-hard was never warranted, and fail-soft (now actually functional) is safe to ship.

## Files changed
- `scripts/lib/sloc_awk.sh` — boolean → depth-counter block-comment tracking; strengthened leniency doc caveats
- `scripts/check_line_cap.sh` — strengthened swallow-to-EOF doc caveat
- `scripts/check_line_cap_selftest.sh` — added nested-comment and string-literal-swallow fixture cases
- `scripts/test-data/sloc-nested-block-comment.rs` (new fixture)
- `scripts/test-data/sloc-string-literal-slash-star.rs` (new fixture)
- `.github/workflows/line-cap.yml` — wired selftest in as a step ahead of the real gate
- `.github/workflows/ci.yml` — HF_TOKEN auth + fail-soft pre-seed (subshell + explicit `rc` capture, per code-critic HIGH fix)

Closes #2563
Closes #2554

## Test plan
- [x] `bash scripts/check_line_cap_selftest.sh` — all 6 cases pass (including 2 new)
- [x] `bash scripts/check_line_cap.sh` — 9 allowlisted, 0 violations, exit 0
- [x] `bash -n` on every edited script — clean
- [x] `actionlint .github/workflows/ci.yml .github/workflows/line-cap.yml` — clean
- [x] `shellcheck -s bash` on the extracted fastembed pre-seed run block — clean (pre-existing SC1091 info-level only)
- [x] CI itself (fmt/clippy/test/msrv/line-cap/doc-comment lint/SLD lint/tm-capabilities/search-daemon-smoke) — all green on this PR
- [x] code-critic HIGH fix: minimal repro of the `set -e`-inside-`if`-condition bash gotcha, before/after; then full synthetic-failure re-verification of the actual pre-seed script body (forced every `curl` call to fail) on bash 5.3 (matching the Ubuntu runner) — `::warning::` fires with correct `rc`, step exits 0, cache dir removed

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
