### PR TITLE
feat(trusty-code): REST gateway bridge (rest::call + rpc_error_to_status), no routes yet

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **REST resource gateway bridge, no routes yet (#2983, #587, Slice 1).** New
+  `crate::serve::rest` module: `rest::call(router, method, params, ctx)` drives
+  a synthetic JSON-RPC `Request` through the existing `Router::dispatch` seam
+  and unwraps the `Response` envelope into `Result<Value, RpcError>`, and
+  `rest::rpc_error_to_status(&RpcError) -> StatusCode` maps `RpcError` codes
+  onto real HTTP statuses (`not_found`/`session_not_found` -> 404,
+  `permission_denied` -> 403, `invalid_argument`/`invalid_params` -> 400,
+  `internal` -> 500, anything unmapped -> 500). This reuses trusty-memory's
+  "Pattern C" (one shared handler, many transports) so a future REST route and
+  its JSON-RPC method twin always run the exact same handler — zero business-
+  logic duplication. `serve::mod` now declares `mod rest;` but wires no axum
+  routes; concrete resource routes land in S2-S6.
+
 - **Embedded default agents converted from TOML to `.md`+frontmatter (#2897,
   epic #2892, Slice C).** The three bundled default agents
   (`engineer`/`qa-agent`/`code-reviewer`, #2895) are now authored as

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -35,6 +35,7 @@
 
 pub mod http;
 pub mod methods;
+pub mod rest;
 pub mod transport;
 
 use std::sync::Arc;

--- a/crates/trusty-code/src/serve/rest/mod.rs
+++ b/crates/trusty-code/src/serve/rest/mod.rs
@@ -53,9 +53,13 @@ use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 /// `id` is `Some(_)` (see `Router::dispatch`'s notification rule) — calls
 /// `router.dispatch(req, ctx)`, and unwraps the `Response` envelope: `Ok`
 /// when `result` is set, `Err` reconstructing the `RpcError` from
-/// `Response::error` otherwise. Panics only if `dispatch` ever returns a
-/// `Response` with neither `result` nor `error` set, which would be a bug in
-/// `Router::dispatch` itself, not a condition a caller can trigger.
+/// `Response::error` otherwise. If `dispatch` ever returned a `Response`
+/// with neither `result` nor `error` set — a `Router::dispatch` bug, not a
+/// caller-triggerable condition, and provably unreachable through this
+/// bridge since `call` always sets a non-`None` `id`, so `dispatch` never
+/// returns `Response::suppressed()` — this falls back to `Ok(Value::Null)`
+/// rather than panicking (no `unwrap`/`expect` in library code). That would
+/// surface as a silently-wrong 200 response, not a panic.
 /// Test: `call_success_returns_handler_result`, `call_error_returns_rpc_error`.
 pub async fn call(
     router: &Router,

--- a/crates/trusty-code/src/serve/rest/mod.rs
+++ b/crates/trusty-code/src/serve/rest/mod.rs
@@ -1,0 +1,234 @@
+//! REST resource gateway over the JSON-RPC method registry (#2983, #587,
+//! Slice 1: bridge only — no routes).
+//!
+//! Why: the vision spec (#587) wants `tcode serve --http` to expose a
+//! conventional REST resource vocabulary (`GET /projects`, `POST
+//! /sessions`, …) alongside the existing JSON-RPC `POST /rpc` endpoint, but
+//! every one of those resources is already backed by a registered JSON-RPC
+//! method (`session.create`, `task.run`, …). Re-implementing the same
+//! business logic a second time as bespoke axum handlers would fork the two
+//! surfaces the moment either one changed — exactly the drift `trusty-code`'s
+//! `Router` was built to prevent between the STDIO and HTTP JSON-RPC
+//! transports (see `crate::jsonrpc` module docs). This module is
+//! `trusty-memory`'s "Pattern C" (`crates/trusty-memory/src/web/rpc.rs`:
+//! one shared dispatch seam, many transports) applied one layer further:
+//! a REST route handler will call [`call`] instead of building its own
+//! `Request`, so a REST resource and its JSON-RPC method twin always run
+//! the exact same handler.
+//!
+//! What: [`call`] synthesizes a JSON-RPC [`Request`] from a `method` +
+//! `params` pair and drives it through [`Router::dispatch`], unwrapping the
+//! `Response` envelope back into a plain `Result<Value, RpcError>` — the
+//! shape a REST handler wants (`?` onto an HTTP error), rather than the
+//! always-200 envelope `POST /rpc` returns. [`rpc_error_to_status`] maps an
+//! `RpcError` onto the real HTTP status a REST response should carry,
+//! deliberately diverging from `POST /rpc`'s "always 200, error in the
+//! envelope" convention — matching how `GET /sessions/{id}/events`
+//! (`crate::serve::http::session_events_sse`) already returns a real `404`
+//! for `session_not_found` rather than a 200-wrapped error.
+//!
+//! This slice wires no axum routes — [`crate::serve::mod`] only declares
+//! `mod rest;` so the bridge compiles and is unit-testable on its own.
+//! Concrete resource routes (`GET /projects`, `POST /sessions`, …) land in
+//! S2-S6, each calling [`call`] + [`rpc_error_to_status`] instead of talking
+//! to the `Router` directly.
+//!
+//! Test: `tests::*` — a success round-trip, an error round-trip, and one
+//! assertion per `rpc_error_to_status` mapping.
+
+use serde_json::Value;
+use trusty_common::mcp::{Request, error_codes};
+
+use crate::jsonrpc::{ConnectionContext, Router, RpcError};
+
+/// Call a registered JSON-RPC method from a REST handler, in-process.
+///
+/// Why: the single seam every future REST resource handler goes through, so
+/// a REST route and its JSON-RPC method twin are provably the same code
+/// path — never two handwritten implementations of the same business logic
+/// (see module docs).
+/// What: synthesizes a `Request { jsonrpc: "2.0", id: Some(0), method,
+/// params }` — the `id` is a fixed synthetic value because a REST caller
+/// never observes it; `dispatch` never suppresses a response as long as
+/// `id` is `Some(_)` (see `Router::dispatch`'s notification rule) — calls
+/// `router.dispatch(req, ctx)`, and unwraps the `Response` envelope: `Ok`
+/// when `result` is set, `Err` reconstructing the `RpcError` from
+/// `Response::error` otherwise. Panics only if `dispatch` ever returns a
+/// `Response` with neither `result` nor `error` set, which would be a bug in
+/// `Router::dispatch` itself, not a condition a caller can trigger.
+/// Test: `call_success_returns_handler_result`, `call_error_returns_rpc_error`.
+pub async fn call(
+    router: &Router,
+    method: &str,
+    params: Value,
+    ctx: &ConnectionContext,
+) -> Result<Value, RpcError> {
+    let req = Request {
+        jsonrpc: Some("2.0".to_string()),
+        id: Some(Value::from(0)),
+        method: method.to_string(),
+        params: Some(params),
+    };
+    let resp = router.dispatch(req, ctx).await;
+    if let Some(err) = resp.error {
+        let mut rpc_err = RpcError::new(err.code, err.message);
+        rpc_err.data = err.data;
+        return Err(rpc_err);
+    }
+    Ok(resp.result.unwrap_or(Value::Null))
+}
+
+/// Map an [`RpcError`] onto the HTTP status a REST response should carry.
+///
+/// Why: `POST /rpc` always returns HTTP 200 with the JSON-RPC error carried
+/// in the envelope — appropriate for a JSON-RPC transport, but REST callers
+/// (and REST tooling: curl, browsers, API gateways) expect the status line
+/// itself to say "not found" / "forbidden" / etc. This mirrors the mapping
+/// `crate::serve::http::session_events_sse` already applies by hand for
+/// `session_not_found` -> 404, generalised to every domain error code
+/// `crate::jsonrpc::error::RpcError` currently defines (vision spec §13.2).
+/// What: matches on the numeric JSON-RPC error code: `-32002 not_found` ->
+/// 404, `-32001 permission_denied` -> 403, `-32003 invalid_argument` and
+/// `-32602 Invalid params` -> 400, `-32007 session_not_found` -> 404,
+/// `-32603 Internal error` -> 500. Any other/future code (including
+/// `-32601`/`-32600`, which a REST handler should never see because it
+/// calls `call` with a hardcoded, known-good method name) falls back to 500
+/// — an unmapped domain error is a bug to fix by adding a mapping, not a
+/// client-facing 4xx.
+/// Test: `status_mapping_*` — one case per mapped code, plus the unknown ->
+/// 500 fallback.
+pub fn rpc_error_to_status(err: &RpcError) -> axum::http::StatusCode {
+    use axum::http::StatusCode;
+
+    match err.code {
+        -32002 => StatusCode::NOT_FOUND,   // not_found
+        -32007 => StatusCode::NOT_FOUND,   // session_not_found
+        -32001 => StatusCode::FORBIDDEN,   // permission_denied
+        -32003 => StatusCode::BAD_REQUEST, // invalid_argument
+        c if c == error_codes::INVALID_PARAMS => StatusCode::BAD_REQUEST,
+        c if c == error_codes::INTERNAL_ERROR => StatusCode::INTERNAL_SERVER_ERROR,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::sync::mpsc;
+
+    fn test_ctx() -> ConnectionContext {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    fn echo_router() -> Router {
+        let mut router = Router::new();
+        router.register(
+            "echo",
+            |params: Value, _ctx: ConnectionContext| async move { Ok(params) },
+        );
+        router.register(
+            "boom.not_found",
+            |_params: Value, _ctx: ConnectionContext| async move {
+                Err(RpcError::not_found("thing not found: x"))
+            },
+        );
+        router
+    }
+
+    /// `call` on a registered method must return `Ok` with the handler's
+    /// result, unwrapped from the `Response` envelope.
+    #[tokio::test]
+    async fn call_success_returns_handler_result() {
+        let router = echo_router();
+        let result = call(&router, "echo", json!({"a": 1}), &test_ctx())
+            .await
+            .expect("echo must succeed");
+        assert_eq!(result, json!({"a": 1}));
+    }
+
+    /// `call` on a handler that returns an `RpcError` must surface that
+    /// exact error (code + message + data) as `Err`, not swallow it into
+    /// the `Ok` branch.
+    #[tokio::test]
+    async fn call_error_returns_rpc_error() {
+        let router = echo_router();
+        let err = call(&router, "boom.not_found", Value::Null, &test_ctx())
+            .await
+            .expect_err("boom.not_found must fail");
+        assert_eq!(err.code, -32002);
+        assert!(err.message.contains("thing not found"));
+        assert_eq!(err.data, Some(json!({"error_type": "not_found"})));
+    }
+
+    /// `call` on an unknown method must surface `-32601 Method not found`
+    /// like any other `Router::dispatch` caller — `call` does not swallow
+    /// or re-map dispatcher-level errors, only handler-level ones.
+    #[tokio::test]
+    async fn call_unknown_method_returns_method_not_found() {
+        let router = echo_router();
+        let err = call(&router, "does.not.exist", Value::Null, &test_ctx())
+            .await
+            .expect_err("unknown method must fail");
+        assert_eq!(err.code, error_codes::METHOD_NOT_FOUND);
+    }
+
+    /// Every currently-mapped `RpcError` code must resolve to its documented
+    /// HTTP status.
+    #[test]
+    fn status_mapping_not_found_is_404() {
+        assert_eq!(
+            rpc_error_to_status(&RpcError::not_found("x")),
+            axum::http::StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn status_mapping_session_not_found_is_404() {
+        assert_eq!(
+            rpc_error_to_status(&RpcError::session_not_found("s-1")),
+            axum::http::StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn status_mapping_permission_denied_is_403() {
+        assert_eq!(
+            rpc_error_to_status(&RpcError::permission_denied("x")),
+            axum::http::StatusCode::FORBIDDEN
+        );
+    }
+
+    #[test]
+    fn status_mapping_invalid_argument_is_400() {
+        assert_eq!(
+            rpc_error_to_status(&RpcError::invalid_argument("x")),
+            axum::http::StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test]
+    fn status_mapping_invalid_params_is_400() {
+        assert_eq!(
+            rpc_error_to_status(&RpcError::invalid_params("x")),
+            axum::http::StatusCode::BAD_REQUEST
+        );
+    }
+
+    #[test]
+    fn status_mapping_internal_error_is_500() {
+        assert_eq!(
+            rpc_error_to_status(&RpcError::internal("x")),
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[test]
+    fn status_mapping_unknown_code_falls_back_to_500() {
+        assert_eq!(
+            rpc_error_to_status(&RpcError::new(-1, "custom")),
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Slice 1 of the trusty-code (tcode) REST resource gateway (#2983, vision spec #587): the in-process bridge that lets a future REST handler call the existing JSON-RPC method registry, plus the `RpcError` -> HTTP-status mapper. **No routes are wired in this slice** — this is the mergeable, independently-testable foundation that S2-S6 (concrete `GET /projects`, `POST /sessions`, …) build on.

- New module `crates/trusty-code/src/serve/rest/mod.rs`:
  - `pub async fn call(router: &Router, method: &str, params: Value, ctx: &ConnectionContext) -> Result<Value, RpcError>` — synthesizes a JSON-RPC `Request { jsonrpc: "2.0", id: Some(0), method, params }`, calls `router.dispatch(req, ctx)`, and unwraps the `Response` envelope into `Ok(result)` / `Err(rpc_error)`.
  - `pub fn rpc_error_to_status(err: &RpcError) -> axum::http::StatusCode` — maps `RpcError` codes onto real HTTP statuses (`not_found`/`session_not_found` -> 404, `permission_denied` -> 403, `invalid_argument`/`invalid_params` -> 400, `internal` -> 500, anything unmapped -> 500).
- `crates/trusty-code/src/serve/mod.rs` now declares `mod rest;` — no axum routes wired yet.
- No visibility widening was needed: `Request`/`Response`/`RpcError`/`Router`/`ConnectionContext`/`error_codes` were already `pub` and reachable from `serve::rest` within the same crate.

This reuses trusty-memory's "Pattern C" (`crates/trusty-memory/src/web/rpc.rs`: one shared dispatch seam, many transports) so a future REST route and its JSON-RPC method twin will always run the exact same handler — zero business-logic duplication, matching how `GET /sessions/{id}/events` (`crate::serve::http::session_events_sse`) already returns a real 404 for `session_not_found` rather than a 200-wrapped envelope.

## RpcError -> HTTP status mapping

| RpcError code | domain | HTTP status |
|---|---|---|
| `-32002` | `not_found` | 404 |
| `-32007` | `session_not_found` | 404 |
| `-32001` | `permission_denied` | 403 |
| `-32003` | `invalid_argument` | 400 |
| `-32602` | `Invalid params` (`error_codes::INVALID_PARAMS`) | 400 |
| `-32603` | `Internal error` (`error_codes::INTERNAL_ERROR`) | 500 |
| anything else | (unmapped/future) | 500 |

## Test plan

- [x] `cargo build -p trusty-code --all-targets` — clean
- [x] `cargo test -p trusty-code --lib` — 1122 passed, 0 failed, 4 ignored (10 new in `serve::rest::tests`)
- [x] `cargo test -p trusty-code --tests` — all integration suites pass
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling pointers

Refs #2983, refs #587.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools