### PR TITLE
feat(trusty-review): git-range and stdin diff ingestion (--base/--head, --local-diff -)

### DIFF
--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- direct diff ingestion for `run`/`compare`: `--base <REF> [--head <REF>]` reviews an arbitrary local git ref range (`git diff -M <base>...<head>`, three-dot merge-base range, `head` defaults to `HEAD` — never the working tree) instead of fetching a GitHub PR; `--local-diff -` reads a unified diff piped in on stdin. Both new sources behave exactly like the existing `--local-diff <PATH>`: forced dry-run, never post to GitHub. `--base` and `--local-diff` are mutually exclusive (clap-enforced). Closes #2993.
+
 ### Fixed
 
 - narrowed confidence-banded reconciliation cap for Medium-driven REQUEST_CHANGES/D+ downgrades: when the model's own verdict is a clean APPROVE and the REQUEST_CHANGES floor rests SOLELY on one `Effort::Medium` finding in the marginal confidence band (`FLOOR_MIN_CONFIDENCE` 0.80 < c < the new `SOLO_MEDIUM_ESCALATION_CONFIDENCE` 0.90), the result is now capped at APPROVE* instead — a successor to the #1343 reconciliation cap #1876 removed, scoped narrowly so it does not reopen #1876's under-flagging regression (a ≥2-Medium floor, a solo Medium ≥0.90, any High-effort finding, or a confident conformance divergence all still escalate uncapped). Addresses the Rank-1 driver of the #1897 over-flagging shadow-eval (47% of clean PRs graded BLOCK/F under 0.6.3). Both new thresholds are env-overridable (`TRUSTY_REVIEW_SOLO_MEDIUM_ESCALATION_CONFIDENCE`, closes #1897)

--- a/crates/trusty-review/README.md
+++ b/crates/trusty-review/README.md
@@ -86,15 +86,30 @@ Homebrew provides:
 # Review a GitHub PR (Bedrock credentials required)
 trusty-review run owner repo 123
 
-# Review a local unified diff
+# Review a local unified diff file
 trusty-review run --local-diff /path/to/patch.diff
+
+# Review a diff piped in on stdin
+git diff origin/main...HEAD | trusty-review run --local-diff -
+
+# Review an arbitrary git ref range directly (no manual `git diff` step) —
+# runs `git diff -M <base>...<head>` in the current directory. `--head`
+# defaults to HEAD (the last commit, not the working tree).
+trusty-review run --base origin/main
+trusty-review run --base origin/main --head my-feature-branch
 
 # Override the reviewer model
 trusty-review run owner repo 123 --reviewer-model bedrock/us.anthropic.claude-haiku-4-5
 
 # Compare models
 trusty-review compare owner repo 123
+trusty-review compare --base origin/main --models bedrock/us.anthropic.claude-haiku-4-5,bedrock/us.anthropic.claude-sonnet-4-6
 ```
+
+> `--local-diff` (file or `-` for stdin) and `--base`/`--head` (git ref range)
+> are always dry-run — like every non-GitHub source, they can never post a
+> live PR comment (issue #2993). `--base` and `--local-diff` are mutually
+> exclusive.
 
 ## HTTP server
 

--- a/crates/trusty-review/src/commands/compare.rs
+++ b/crates/trusty-review/src/commands/compare.rs
@@ -304,7 +304,38 @@ pub fn truncate_str(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser as _;
     use trusty_review::models::{Effort, Finding, Verdict};
+
+    // ── CompareArgs clap wiring (#2993) ─────────────────────────────────
+
+    /// Guards the `conflicts_with = "base"` wiring on `local_diff`: a
+    /// field-id rename that silently drops the attribute would otherwise
+    /// only be caught by manual testing.
+    #[test]
+    fn compare_args_base_and_local_diff_conflict() {
+        let result =
+            CompareArgs::try_parse_from(["compare", "--base", "main", "--local-diff", "x.diff"]);
+        assert!(
+            result.is_err(),
+            "--base and --local-diff must be mutually exclusive"
+        );
+    }
+
+    /// Guards the `requires = "base"` wiring on `head`.
+    #[test]
+    fn compare_args_head_without_base_errors() {
+        let result = CompareArgs::try_parse_from(["compare", "--head", "feature"]);
+        assert!(result.is_err(), "--head requires --base");
+    }
+
+    #[test]
+    fn compare_args_base_and_head_parses() {
+        let args = CompareArgs::try_parse_from(["compare", "--base", "main", "--head", "feature"])
+            .expect("parse");
+        assert_eq!(args.base.as_deref(), Some("main"));
+        assert_eq!(args.head.as_deref(), Some("feature"));
+    }
 
     fn make_result(model: &str, verdict: Verdict, findings: usize, cost: f64) -> ReviewResult {
         let mut r = ReviewResult::new(

--- a/crates/trusty-review/src/commands/compare.rs
+++ b/crates/trusty-review/src/commands/compare.rs
@@ -7,7 +7,7 @@
 //! Test: CLI integration via `cargo run -p trusty-review -- compare --help`;
 //! table formatting covered by `print_compare_table_formats_correctly`.
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use tracing::warn;
 
 use trusty_review::{
@@ -21,6 +21,7 @@ use trusty_review::{
     pipeline::{CallerContext, DiffSource, ReviewInput, TriggerDecision, run_review},
 };
 
+use crate::commands::diff_source::{LocalDiffFlags, resolve_local_diff_source};
 use crate::commands::run::build_deps_async;
 
 // ─── compare args ────────────────────────────────────────────────────────────
@@ -33,15 +34,15 @@ use crate::commands::run::build_deps_async;
 /// Test: `cargo run -p trusty-review -- compare --help`.
 #[derive(Debug, clap::Parser)]
 pub struct CompareArgs {
-    /// GitHub organisation or user (required unless --local-diff is set).
+    /// GitHub organisation or user (required unless --local-diff/--base is set).
     #[arg(value_name = "OWNER")]
     pub owner: Option<String>,
 
-    /// GitHub repository name (required unless --local-diff is set).
+    /// GitHub repository name (required unless --local-diff/--base is set).
     #[arg(value_name = "REPO")]
     pub repo: Option<String>,
 
-    /// Pull request number (required unless --local-diff is set).
+    /// Pull request number (required unless --local-diff/--base is set).
     #[arg(value_name = "PR")]
     pub pr: Option<u64>,
 
@@ -50,8 +51,20 @@ pub struct CompareArgs {
     pub models: Option<Vec<String>>,
 
     /// Read a local unified diff file instead of fetching from GitHub.
-    #[arg(long, value_name = "PATH")]
+    /// Pass `-` to read the unified diff from stdin instead of a file.
+    #[arg(long, value_name = "PATH", conflicts_with = "base")]
     pub local_diff: Option<std::path::PathBuf>,
+
+    /// Diff the local git repository (current directory) from this ref instead
+    /// of fetching from GitHub — `git diff -M <base>...<head>` (three-dot
+    /// merge-base range). Mutually exclusive with --local-diff.
+    #[arg(long, value_name = "REF")]
+    pub base: Option<String>,
+
+    /// Head ref for --base; defaults to HEAD (the last commit, not the
+    /// working tree). Requires --base.
+    #[arg(long, value_name = "REF", requires = "base")]
+    pub head: Option<String>,
 
     /// Provider backend for bare model ids: `bedrock` (default) or `openrouter`.
     #[arg(long, value_name = "PROVIDER")]
@@ -101,11 +114,19 @@ pub async fn cmd_compare(mut config: ReviewConfig, args: CompareArgs) -> Result<
         .as_ref()
         .unwrap_or(&config.role_models.reviewer.provider);
 
+    // Resolved ONCE, outside the per-model loop: every model compares against
+    // the same diff. `materialize_stdin_if_needed` additionally guards against
+    // stdin only being readable once — see its doc comment (issue #2993).
+    let diff_source = resolve_diff_source_compare(&config, &args).await?;
+    // Keeps the tempfile alive for the whole loop when stdin was materialized;
+    // dropped (and deleted) when `cmd_compare` returns. `_stdin_tmp` itself is
+    // never read — it exists only to extend the tempfile's lifetime.
+    let (diff_source, _stdin_tmp) = materialize_stdin_if_needed(diff_source)?;
+
     for model in &models {
-        let diff_source = resolve_diff_source_compare(&config, &args).await?;
         let deps = build_deps_async(&config, model, default_provider).await?;
         let input = ReviewInput {
-            diff_source,
+            diff_source: diff_source.clone(),
             reviewer_model: model.clone(),
             write_log: false,
             print_result: false,
@@ -129,35 +150,43 @@ pub async fn cmd_compare(mut config: ReviewConfig, args: CompareArgs) -> Result<
     Ok(())
 }
 
-// ─── diff source helper ──────────────────────────────────────────────────────
+// ─── diff source helpers ──────────────────────────────────────────────────────
 
 /// Resolve the `DiffSource` for the `compare` subcommand.
 ///
-/// Why: compare and run share the same diff-source logic; compare reuses it
-/// per-model run.
-/// What: identical to `resolve_diff_source_run` but takes `CompareArgs`.
-/// Test: covered by compare flow.
+/// Why: compare and run share the same diff-source logic; compare resolves it
+/// once and reuses it across every model run (see `cmd_compare`).
+/// What: delegates local-mode selection (`LocalFile`/`Stdin`/`GitRange`) to
+/// the shared `resolve_local_diff_source` (issue #2993); falls back to
+/// resolving a GitHub PR source from the positional args + a resolved token.
+/// Test: local-mode selection is covered by `diff_source::tests`;
+/// `materialize_stdin_if_needed_passes_through_non_stdin` covers the stdin
+/// safety net this feeds into.
 async fn resolve_diff_source_compare(
     config: &ReviewConfig,
     args: &CompareArgs,
 ) -> Result<DiffSource> {
-    if let Some(ref path) = args.local_diff {
-        return Ok(DiffSource::LocalFile { path: path.clone() });
+    if let Some(source) = resolve_local_diff_source(LocalDiffFlags {
+        local_diff: args.local_diff.as_deref(),
+        base: args.base.as_deref(),
+        head: args.head.as_deref(),
+    })? {
+        return Ok(source);
     }
 
     let owner = args
         .owner
         .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("OWNER is required (or use --local-diff)"))?
+        .ok_or_else(|| anyhow::anyhow!("OWNER is required (or use --local-diff / --base)"))?
         .to_string();
     let repo = args
         .repo
         .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("REPO is required (or use --local-diff)"))?
+        .ok_or_else(|| anyhow::anyhow!("REPO is required (or use --local-diff / --base)"))?
         .to_string();
     let pr = args
         .pr
-        .ok_or_else(|| anyhow::anyhow!("PR number is required (or use --local-diff)"))?;
+        .ok_or_else(|| anyhow::anyhow!("PR number is required (or use --local-diff / --base)"))?;
 
     let client = GithubClient::new()
         .map_err(|e| anyhow::anyhow!("failed to build GitHub HTTP client: {e}"))?;
@@ -172,6 +201,45 @@ async fn resolve_diff_source_compare(
         pr,
         token,
     })
+}
+
+/// Materialize a `Stdin` diff source into a tempfile-backed `LocalFile`.
+///
+/// Why: `compare` runs the SAME diff through every model in a loop, and each
+/// iteration's `run_review` independently calls `load_diff`. Stdin can only be
+/// read to EOF once — a second read after EOF returns `Ok("")`, not an error —
+/// so without this, every model after the first would silently compare an
+/// EMPTY diff instead of failing loudly (issue #2993). Reading stdin once up
+/// front and handing every iteration a re-readable `LocalFile` (the same
+/// mechanism `--local-diff <PATH>` already uses) closes that gap.
+/// What: a no-op for every other `DiffSource` variant (returned unchanged,
+/// `None` guard); for `Stdin`, reads stdin to EOF, writes it to a `NamedTempFile`,
+/// and returns `(LocalFile, Some(guard))` — the caller must keep the guard
+/// alive for as long as the source is used; the file is deleted when it drops.
+/// Test: `materialize_stdin_if_needed_passes_through_non_stdin`,
+/// `materialize_stdin_if_needed_git_range_passes_through`. The `Stdin` branch
+/// itself needs a real piped stdin and is exercised manually
+/// (`git diff | trusty-review compare --local-diff - --models a,b`);
+/// `pipeline::diff::read_diff_from_reader` covers the underlying read loop
+/// with an in-memory `Cursor` instead of real stdin.
+fn materialize_stdin_if_needed(
+    source: DiffSource,
+) -> Result<(DiffSource, Option<tempfile::NamedTempFile>)> {
+    if !matches!(source, DiffSource::Stdin) {
+        return Ok((source, None));
+    }
+    use std::io::{Read as _, Write as _};
+    let mut buf = String::new();
+    std::io::stdin()
+        .lock()
+        .read_to_string(&mut buf)
+        .context("failed to read diff from stdin")?;
+    let mut tmp =
+        tempfile::NamedTempFile::new().context("failed to create tempfile for stdin diff")?;
+    tmp.write_all(buf.as_bytes())
+        .context("failed to write stdin diff to tempfile")?;
+    let path = tmp.path().to_path_buf();
+    Ok((DiffSource::LocalFile { path }, Some(tmp)))
 }
 
 // ─── table printer ────────────────────────────────────────────────────────────
@@ -318,5 +386,36 @@ mod tests {
         r.error = Some("timeout".to_string());
         let results = vec![("openai/gpt-5.4-nano-20260317".to_string(), r)];
         print_compare_table(&results);
+    }
+
+    // ── materialize_stdin_if_needed (#2993) ────────────────────────────
+
+    #[test]
+    fn materialize_stdin_if_needed_passes_through_non_stdin() {
+        let source = DiffSource::LocalFile {
+            path: std::path::PathBuf::from("/tmp/some.diff"),
+        };
+        let (result, tmp) =
+            materialize_stdin_if_needed(source).expect("non-stdin must never read stdin");
+        assert!(tmp.is_none(), "no tempfile should be created for LocalFile");
+        match result {
+            DiffSource::LocalFile { path } => {
+                assert_eq!(path, std::path::PathBuf::from("/tmp/some.diff"));
+            }
+            other => panic!("expected LocalFile to pass through unchanged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn materialize_stdin_if_needed_git_range_passes_through() {
+        let source = DiffSource::GitRange {
+            repo_root: std::path::PathBuf::from("/repo"),
+            base: "main".to_string(),
+            head: None,
+        };
+        let (result, tmp) =
+            materialize_stdin_if_needed(source).expect("git-range must never read stdin");
+        assert!(tmp.is_none());
+        assert!(matches!(result, DiffSource::GitRange { .. }));
     }
 }

--- a/crates/trusty-review/src/commands/diff_source.rs
+++ b/crates/trusty-review/src/commands/diff_source.rs
@@ -1,0 +1,166 @@
+//! Shared local-diff-mode resolution for the `run` and `compare` subcommands.
+//!
+//! Why: both subcommands accept three ways to pick a diff without touching
+//! GitHub — a local file (`--local-diff <PATH>`), stdin (`--local-diff -`),
+//! or an arbitrary git ref range (`--base <REF> [--head <REF>]`) — and both
+//! must apply the identical selection rule.  Centralising it here (issue
+//! #2993) avoids `resolve_diff_source_run` and `resolve_diff_source_compare`
+//! drifting apart on which flag wins or how the git range defaults `head`.
+//!
+//! What: [`LocalDiffFlags`] bundles the raw flag values; [`resolve_local_diff_source`]
+//! returns `Some(DiffSource)` for `LocalFile`/`Stdin`/`GitRange` when a local
+//! mode flag was set, or `None` so the caller falls through to GitHub-PR
+//! resolution.  `--base`/`--local-diff` mutual exclusion is enforced by clap
+//! (`conflicts_with`) on `RunArgs`/`CompareArgs`, not here.
+//!
+//! Test: `resolve_local_diff_source_*` below.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context as _, Result};
+
+use trusty_review::pipeline::DiffSource;
+
+/// The local-diff-mode CLI flag values shared by `RunArgs` and `CompareArgs`.
+///
+/// Why: bundles the three flags so `resolve_local_diff_source` has one
+/// signature usable from both subcommands' arg structs.
+/// What: borrowed views over the parsed clap fields — no ownership transfer.
+/// Test: constructed inline by every `resolve_local_diff_source_*` test.
+pub struct LocalDiffFlags<'a> {
+    /// `--local-diff <PATH>` value; `Some("-")` means stdin.
+    pub local_diff: Option<&'a Path>,
+    /// `--base <REF>` value (git-range mode).
+    pub base: Option<&'a str>,
+    /// `--head <REF>` value; `None` defaults to `HEAD` inside `DiffSource::GitRange`.
+    pub head: Option<&'a str>,
+}
+
+/// Resolve `flags` into a `DiffSource`, or `None` when neither local mode was set.
+///
+/// Why: single funnel so `run` and `compare` apply the identical local-vs-GitHub
+/// selection and the identical git-range defaulting (issue #2993).
+/// What: `--local-diff -` → `DiffSource::Stdin`; any other `--local-diff <PATH>`
+/// → `DiffSource::LocalFile`; `--base <REF>` (with clap enforcing it cannot
+/// coexist with `--local-diff`) → `DiffSource::GitRange` rooted at the current
+/// working directory, `head` passed through as-is (`None` → `HEAD` downstream).
+/// Neither flag set → `Ok(None)`, telling the caller to resolve a GitHub PR
+/// source instead.
+/// Test: `resolve_local_diff_source_prefers_local_file`,
+/// `resolve_local_diff_source_dash_is_stdin`,
+/// `resolve_local_diff_source_base_builds_git_range`,
+/// `resolve_local_diff_source_neither_flag_is_none`.
+pub fn resolve_local_diff_source(flags: LocalDiffFlags<'_>) -> Result<Option<DiffSource>> {
+    if let Some(path) = flags.local_diff {
+        if path.as_os_str() == "-" {
+            return Ok(Some(DiffSource::Stdin));
+        }
+        return Ok(Some(DiffSource::LocalFile {
+            path: path.to_path_buf(),
+        }));
+    }
+
+    if let Some(base) = flags.base {
+        let repo_root: PathBuf = std::env::current_dir()
+            .context("failed to determine current directory for --base git-range diff")?;
+        return Ok(Some(DiffSource::GitRange {
+            repo_root,
+            base: base.to_string(),
+            head: flags.head.map(str::to_string),
+        }));
+    }
+
+    Ok(None)
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_local_diff_source_prefers_local_file() {
+        let path = Path::new("/tmp/some.diff");
+        let source = resolve_local_diff_source(LocalDiffFlags {
+            local_diff: Some(path),
+            base: None,
+            head: None,
+        })
+        .expect("resolve")
+        .expect("Some(source)");
+        match source {
+            DiffSource::LocalFile { path: p } => assert_eq!(p, path),
+            other => panic!("expected LocalFile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_local_diff_source_dash_is_stdin() {
+        let source = resolve_local_diff_source(LocalDiffFlags {
+            local_diff: Some(Path::new("-")),
+            base: None,
+            head: None,
+        })
+        .expect("resolve")
+        .expect("Some(source)");
+        assert!(
+            matches!(source, DiffSource::Stdin),
+            "expected Stdin, got {source:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_local_diff_source_base_builds_git_range() {
+        let source = resolve_local_diff_source(LocalDiffFlags {
+            local_diff: None,
+            base: Some("origin/main"),
+            head: Some("feature-x"),
+        })
+        .expect("resolve")
+        .expect("Some(source)");
+        match source {
+            DiffSource::GitRange {
+                repo_root,
+                base,
+                head,
+            } => {
+                assert_eq!(base, "origin/main");
+                assert_eq!(head.as_deref(), Some("feature-x"));
+                assert!(
+                    repo_root.is_absolute(),
+                    "current_dir() must return an absolute path: {repo_root:?}"
+                );
+            }
+            other => panic!("expected GitRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_local_diff_source_base_without_head_leaves_head_none() {
+        let source = resolve_local_diff_source(LocalDiffFlags {
+            local_diff: None,
+            base: Some("main"),
+            head: None,
+        })
+        .expect("resolve")
+        .expect("Some(source)");
+        match source {
+            DiffSource::GitRange { head, .. } => {
+                assert!(head.is_none(), "no --head must pass through as None");
+            }
+            other => panic!("expected GitRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_local_diff_source_neither_flag_is_none() {
+        let result = resolve_local_diff_source(LocalDiffFlags {
+            local_diff: None,
+            base: None,
+            head: None,
+        })
+        .expect("resolve");
+        assert!(result.is_none(), "no local flags → caller resolves GitHub");
+    }
+}

--- a/crates/trusty-review/src/commands/mod.rs
+++ b/crates/trusty-review/src/commands/mod.rs
@@ -9,15 +9,18 @@
 //! behind `http-server`). Also re-exports the shared helpers `build_deps_async`,
 //! `resolve_diff_source_run`, `resolve_diff_source_compare`, and
 //! `print_compare_table`/`truncate_str` used by the compare printer.
-//! `cmd_calibrate` (calibration harness, #1422) is always present. `service`
-//! (the launchd wrapper, #2557) is gated behind `http-server` because it
-//! daemonizes `trusty-review serve`, which does not exist without that feature.
+//! `diff_source` holds the `--base`/`--head`/`--local-diff` resolution shared
+//! by `run` and `compare` (issue #2993). `cmd_calibrate` (calibration harness,
+//! #1422) is always present. `service` (the launchd wrapper, #2557) is gated
+//! behind `http-server` because it daemonizes `trusty-review serve`, which
+//! does not exist without that feature.
 //!
 //! Test: handlers are tested transitively via `runner::tests` (unit) and the
 //! CLI smoke-tests in this file's sibling modules.
 
 pub mod calibrate;
 pub mod compare;
+pub(crate) mod diff_source;
 pub mod port;
 pub mod run;
 #[cfg(feature = "http-server")]

--- a/crates/trusty-review/src/commands/run.rs
+++ b/crates/trusty-review/src/commands/run.rs
@@ -245,3 +245,51 @@ pub async fn build_deps_async(
         dedup: None,
     })
 }
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser as _;
+
+    /// Guards the `conflicts_with = "base"` wiring on `local_diff` (#2993):
+    /// a field-id rename that silently drops the attribute would otherwise
+    /// only be caught by manual testing.
+    #[test]
+    fn run_args_base_and_local_diff_conflict() {
+        let result = RunArgs::try_parse_from(["run", "--base", "main", "--local-diff", "x.diff"]);
+        assert!(
+            result.is_err(),
+            "--base and --local-diff must be mutually exclusive"
+        );
+    }
+
+    /// Guards the `requires = "base"` wiring on `head` (#2993).
+    #[test]
+    fn run_args_head_without_base_errors() {
+        let result = RunArgs::try_parse_from(["run", "--head", "feature"]);
+        assert!(result.is_err(), "--head requires --base");
+    }
+
+    #[test]
+    fn run_args_base_alone_parses() {
+        let args = RunArgs::try_parse_from(["run", "--base", "main"]).expect("parse");
+        assert_eq!(args.base.as_deref(), Some("main"));
+        assert!(args.head.is_none());
+    }
+
+    #[test]
+    fn run_args_base_and_head_parses() {
+        let args =
+            RunArgs::try_parse_from(["run", "--base", "main", "--head", "feature"]).expect("parse");
+        assert_eq!(args.base.as_deref(), Some("main"));
+        assert_eq!(args.head.as_deref(), Some("feature"));
+    }
+
+    #[test]
+    fn run_args_local_diff_dash_parses() {
+        let args = RunArgs::try_parse_from(["run", "--local-diff", "-"]).expect("parse");
+        assert_eq!(args.local_diff.as_deref(), Some(std::path::Path::new("-")));
+    }
+}

--- a/crates/trusty-review/src/commands/run.rs
+++ b/crates/trusty-review/src/commands/run.rs
@@ -28,25 +28,29 @@ use trusty_review::{
 };
 
 use crate::cli_verify;
+use crate::commands::diff_source::{LocalDiffFlags, resolve_local_diff_source};
 
 // ─── run args (re-used by compare) ─────────────────────────────────────────
 
 /// Arguments for the `run` subcommand.
 ///
 /// Why: groups all run-mode flags in one place for clarity and testability.
-/// What: owner/repo/pr identify the GitHub PR; --local-diff bypasses GitHub.
+/// What: owner/repo/pr identify the GitHub PR; --local-diff bypasses GitHub
+/// (`-` reads a unified diff from stdin); --base [--head] derives the diff
+/// from a local git ref range instead (issue #2993). --base and --local-diff
+/// are mutually exclusive (enforced by clap).
 /// Test: `cargo run -p trusty-review -- run --help`.
 #[derive(Debug, clap::Parser)]
 pub struct RunArgs {
-    /// GitHub organisation or user (required unless --local-diff is set).
+    /// GitHub organisation or user (required unless --local-diff/--base is set).
     #[arg(value_name = "OWNER")]
     pub owner: Option<String>,
 
-    /// GitHub repository name (required unless --local-diff is set).
+    /// GitHub repository name (required unless --local-diff/--base is set).
     #[arg(value_name = "REPO")]
     pub repo: Option<String>,
 
-    /// Pull request number (required unless --local-diff is set).
+    /// Pull request number (required unless --local-diff/--base is set).
     #[arg(value_name = "PR")]
     pub pr: Option<u64>,
 
@@ -62,8 +66,20 @@ pub struct RunArgs {
     pub provider: Option<String>,
 
     /// Read a local unified diff file instead of fetching from GitHub.
-    #[arg(long, value_name = "PATH")]
+    /// Pass `-` to read the unified diff from stdin instead of a file.
+    #[arg(long, value_name = "PATH", conflicts_with = "base")]
     pub local_diff: Option<std::path::PathBuf>,
+
+    /// Diff the local git repository (current directory) from this ref instead
+    /// of fetching from GitHub — `git diff -M <base>...<head>` (three-dot
+    /// merge-base range). Mutually exclusive with --local-diff.
+    #[arg(long, value_name = "REF")]
+    pub base: Option<String>,
+
+    /// Head ref for --base; defaults to HEAD (the last commit, not the
+    /// working tree). Requires --base.
+    #[arg(long, value_name = "REF", requires = "base")]
+    pub head: Option<String>,
 
     /// Write the review log file to the configured log directory.
     #[arg(long = "no-log", action = clap::ArgAction::SetFalse, default_value = "true")]
@@ -143,28 +159,35 @@ pub async fn cmd_run(config: ReviewConfig, args: RunArgs) -> Result<()> {
 
 /// Resolve the `DiffSource` for the `run` subcommand.
 ///
-/// Why: the diff source depends on whether `--local-diff` is set or the three
-/// positional args (owner/repo/pr) are provided.
-/// What: validates the args and builds the correct `DiffSource` variant.
-/// Test: positional args and --local-diff validated.
+/// Why: the diff source depends on whether `--local-diff`/`--base` is set or
+/// the three positional args (owner/repo/pr) are provided.
+/// What: delegates local-mode selection (`LocalFile`/`Stdin`/`GitRange`) to
+/// the shared `resolve_local_diff_source` (issue #2993); falls back to
+/// resolving a GitHub PR source from the positional args + a resolved token.
+/// Test: positional args and --local-diff/--base validated; local-mode
+/// selection itself is covered by `diff_source::tests`.
 pub async fn resolve_diff_source_run(config: &ReviewConfig, args: &RunArgs) -> Result<DiffSource> {
-    if let Some(ref path) = args.local_diff {
-        return Ok(DiffSource::LocalFile { path: path.clone() });
+    if let Some(source) = resolve_local_diff_source(LocalDiffFlags {
+        local_diff: args.local_diff.as_deref(),
+        base: args.base.as_deref(),
+        head: args.head.as_deref(),
+    })? {
+        return Ok(source);
     }
 
     let owner = args
         .owner
         .as_deref()
-        .context("OWNER is required (or use --local-diff)")?
+        .context("OWNER is required (or use --local-diff / --base)")?
         .to_string();
     let repo = args
         .repo
         .as_deref()
-        .context("REPO is required (or use --local-diff)")?
+        .context("REPO is required (or use --local-diff / --base)")?
         .to_string();
     let pr = args
         .pr
-        .context("PR number is required (or use --local-diff)")?;
+        .context("PR number is required (or use --local-diff / --base)")?;
 
     let client = GithubClient::new()
         .map_err(|e| anyhow::anyhow!("failed to build GitHub HTTP client: {e}"))?;

--- a/crates/trusty-review/src/main.rs
+++ b/crates/trusty-review/src/main.rs
@@ -68,13 +68,17 @@ enum Commands {
     /// when posting is enabled — set `PR_INTELLIGENCE_DRY_RUN=false` to allow it.
     ///
     /// Use --local-diff to review a local unified diff file without GitHub
-    /// (local-diff is always dry-run — it can never post).
+    /// (pass `-` to read the diff from stdin instead of a file), or --base
+    /// [--head] to review an arbitrary local git ref range (`git diff -M
+    /// <base>...<head>`; --head defaults to HEAD). All three local sources
+    /// are always dry-run — they can never post (#2993).
     Run(RunArgs),
 
     /// Compare the same PR across multiple models to evaluate speed/cost/quality.
     ///
     /// Runs the review pipeline once per model in the compare set (or --models
-    /// override) and prints a comparison table.  Always dry-run.
+    /// override) and prints a comparison table.  Always dry-run.  Accepts the
+    /// same --local-diff / --base [--head] local-diff flags as `run` (#2993).
     Compare(CompareArgs),
 
     /// Report the listening port of the running trusty-review daemon.

--- a/crates/trusty-review/src/pipeline/diff.rs
+++ b/crates/trusty-review/src/pipeline/diff.rs
@@ -132,12 +132,23 @@ pub async fn load_diff(source: &DiffSource) -> Result<String, GithubError> {
 /// Run `git diff -M <base>...<head>` in `repo_root` and return stdout.
 ///
 /// Why: extracted so the three-dot range formatting and error handling has one
-/// definition; also keeps `load_diff`'s match arms short.
+/// definition; also keeps `load_diff`'s match arms short. `--base`/`--head`
+/// are operator-controlled strings that reach this function verbatim — without
+/// a guard, a value like `--output=/tmp/poc` is parsed by git as an OPTION
+/// rather than a ref, letting an attacker who controls the CLI args write an
+/// arbitrary file (argument injection, found in review of #2993). `git diff`
+/// has no `--` end-of-options marker of its own (`--` after `diff` means "these
+/// are paths"), so the fix is git's dedicated `--end-of-options` pseudo-option
+/// (git >= 2.24, well below this workspace's toolchain floor): everything after
+/// it is treated as a positional revision/range argument, never re-parsed as a
+/// flag, even if it starts with `-`.
 /// What: shells out via `std::process::Command` (no `git2` dependency, mirroring
-/// the existing convention in `report/git_info.rs`); a non-zero exit or
-/// non-UTF-8 output is folded into `GithubError::Transport` with the captured
-/// stderr / decode error so the operator sees exactly what git rejected.
-/// Test: `git_range_diff_matches_git_output`, `git_range_diff_bad_repo_errors`.
+/// the existing convention in `report/git_info.rs`) as `git -C <repo_root> diff
+/// -M --end-of-options <base>...<head>`; a non-zero exit or non-UTF-8 output is
+/// folded into `GithubError::Transport` with the first line of stderr (git's
+/// actual error, not its ~70-line usage dump) / the decode error.
+/// Test: `git_range_diff_matches_git_output`, `git_range_diff_bad_repo_errors`,
+/// `git_range_diff_rejects_option_like_base_without_touching_filesystem`.
 fn run_git_range_diff(
     repo_root: &std::path::Path,
     base: &str,
@@ -149,17 +160,19 @@ fn run_git_range_diff(
         .arg(repo_root)
         .arg("diff")
         .arg("-M")
+        .arg("--end-of-options")
         .arg(&range)
         .output()
         .map_err(|e| GithubError::Transport(format!("failed to run `git diff {range}`: {e}")))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let first_line = stderr.trim().lines().next().unwrap_or_default();
         return Err(GithubError::Transport(format!(
             "`git diff {range}` in {} failed ({}): {}",
             repo_root.display(),
             output.status,
-            stderr.trim()
+            first_line
         )));
     }
 
@@ -685,6 +698,42 @@ index abc..def 100644
         };
         let result = load_diff(&source).await;
         assert!(result.is_err(), "a non-repo directory must error");
+    }
+
+    /// Regression test for the argument-injection vuln found in review of
+    /// #2993: `base`/`head` are operator-controlled strings that reach `git
+    /// diff` as a positional arg. Before the `--end-of-options` guard, a
+    /// value that LOOKS like a git option (e.g. `--output=<path>`) was parsed
+    /// as one, letting an attacker who controls the `--base`/`--head` CLI
+    /// flags make git write an arbitrary file. Asserts both that the call
+    /// errors AND that nothing was written under the injected output
+    /// directory (the strong claim — not just "it returned Err").
+    #[tokio::test]
+    async fn git_range_diff_rejects_option_like_base_without_touching_filesystem() {
+        let (dir, _base, head) = tiny_git_repo();
+        let poc_dir = tempfile::tempdir().expect("poc tempdir");
+        let hostile_base = format!("--output={}/PWNED", poc_dir.path().display());
+
+        let source = DiffSource::GitRange {
+            repo_root: dir.path().to_path_buf(),
+            base: hostile_base,
+            head: Some(head),
+        };
+
+        let result = load_diff(&source).await;
+        assert!(
+            result.is_err(),
+            "an option-like --base value must be rejected, not silently accepted"
+        );
+
+        let wrote_any_file = std::fs::read_dir(poc_dir.path())
+            .expect("read poc dir")
+            .next()
+            .is_some();
+        assert!(
+            !wrote_any_file,
+            "the --end-of-options guard must prevent git from writing the injected --output path"
+        );
     }
 
     // ── Stdin tests (#2993) ───────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/diff.rs
+++ b/crates/trusty-review/src/pipeline/diff.rs
@@ -147,7 +147,7 @@ pub async fn load_diff(source: &DiffSource) -> Result<String, GithubError> {
 /// -M --end-of-options <base>...<head>`; a non-zero exit or non-UTF-8 output is
 /// folded into `GithubError::Transport` with the first line of stderr (git's
 /// actual error, not its ~70-line usage dump) / the decode error.
-/// Test: `git_range_diff_matches_git_output`, `git_range_diff_bad_repo_errors`,
+/// Test: `git_range_diff_matches_git_output`, `git_range_diff_bad_repo_returns_error`,
 /// `git_range_diff_rejects_option_like_base_without_touching_filesystem`.
 fn run_git_range_diff(
     repo_root: &std::path::Path,

--- a/crates/trusty-review/src/pipeline/diff.rs
+++ b/crates/trusty-review/src/pipeline/diff.rs
@@ -4,12 +4,14 @@
 //! to avoid token budget overruns, and a small set of changed symbols to drive
 //! the code-search context retrieval step.
 //!
-//! What: exposes `DiffSource` (GitHub PR or local file path), `load_diff` to
-//! fetch / read the raw diff text, `truncate_diff` to apply the char cap, and
-//! `extract_identifiers` to pull changed function/type names from `+`/`-` lines.
+//! What: exposes `DiffSource` (GitHub PR, local file, git range, or stdin),
+//! `load_diff` to fetch / read the raw diff text, `truncate_diff` to apply the
+//! char cap, and `extract_identifiers` to pull changed function/type names from
+//! `+`/`-` lines.
 //!
 //! Test: `truncate_does_not_exceed_limit`, `extract_identifiers_finds_symbols`,
-//! `local_diff_reads_file`.
+//! `local_diff_reads_file`, `git_range_diff_matches_git_output`,
+//! `stdin_reader_reads_full_diff`.
 
 use tracing::{debug, warn};
 
@@ -22,11 +24,16 @@ use crate::{
 
 /// Where to obtain the unified diff.
 ///
-/// Why: the CLI supports both fetching from GitHub and reading a local file;
-/// the pipeline step must handle both without special-casing throughout.
-/// What: two variants — `Github` (fetches via API) and `LocalFile` (reads from
-/// disk; always dry-run and requires no GitHub credentials).
-/// Test: `local_diff_reads_file`.
+/// Why: the CLI supports fetching from GitHub, reading a local file, deriving
+/// a diff from an arbitrary git ref range, or reading a diff piped in on
+/// stdin; the pipeline step must handle all four without special-casing
+/// throughout.
+/// What: four variants — `Github` (fetches via API), `LocalFile` (reads from
+/// disk), `GitRange` (shells out to `git diff`), and `Stdin` (reads a piped
+/// diff). The last three are always dry-run and require no GitHub credentials
+/// (issue #2993).
+/// Test: `local_diff_reads_file`, `git_range_diff_matches_git_output`,
+/// `stdin_reader_reads_full_diff`.
 #[derive(Debug, Clone)]
 pub enum DiffSource {
     /// Fetch the diff from a live GitHub pull request.
@@ -45,6 +52,28 @@ pub enum DiffSource {
         /// Absolute path to the `.diff` or `.patch` file.
         path: std::path::PathBuf,
     },
+    /// Derive the diff from a git ref range in a local repository (dry-run
+    /// only; no GitHub needed).
+    ///
+    /// The diff is produced with `git diff -M <base>...<head>` — three-dot
+    /// (merge-base) range syntax, matching how GitHub renders a PR's "Files
+    /// changed" tab: only commits reachable from `head` but not from `base`
+    /// are shown, so commits landed on `base` after the branch point never
+    /// leak into the diff. `-M` enables rename detection so a pure rename
+    /// shows as a rename hunk rather than a full delete+add.
+    GitRange {
+        /// Repository root to run `git diff` in (`git -C <repo_root> diff …`).
+        repo_root: std::path::PathBuf,
+        /// Base ref (older side of the range).
+        base: String,
+        /// Head ref (newer side of the range). `None` defaults to `HEAD` —
+        /// the last committed state, not the (possibly dirty) working tree —
+        /// so a git-range review is reproducible from ref names alone and
+        /// never silently includes uncommitted local edits.
+        head: Option<String>,
+    },
+    /// Read a unified diff piped in on stdin (dry-run only; no GitHub needed).
+    Stdin,
 }
 
 // ─── Load ─────────────────────────────────────────────────────────────────────
@@ -54,9 +83,13 @@ pub enum DiffSource {
 /// Why: centralises the fetch / read logic so the rest of the pipeline just
 /// receives a `String` regardless of where the diff came from.
 /// What: for `Github`, calls `fetch_pr_diff`; for `LocalFile`, reads the file
-/// with `std::fs::read_to_string`.  Returns a `GithubError` if the GitHub API
-/// fails; wraps I/O errors in `GithubError::Transport` for `LocalFile`.
-/// Test: `local_diff_reads_file` writes a tmp file and calls this.
+/// with `std::fs::read_to_string`; for `GitRange`, shells out to `git diff`;
+/// for `Stdin`, reads to EOF from the process's stdin.  Returns a
+/// `GithubError` if the GitHub API fails; wraps I/O / subprocess failures in
+/// `GithubError::Transport` for the other three (same convention already used
+/// for `LocalFile`, so callers only ever match on one error type).
+/// Test: `local_diff_reads_file`, `git_range_diff_matches_git_output`,
+/// `stdin_reader_reads_full_diff`.
 pub async fn load_diff(source: &DiffSource) -> Result<String, GithubError> {
     match source {
         DiffSource::Github {
@@ -75,7 +108,80 @@ pub async fn load_diff(source: &DiffSource) -> Result<String, GithubError> {
                 GithubError::Transport(format!("read local diff {}: {e}", path.display()))
             })
         }
+        DiffSource::GitRange {
+            repo_root,
+            base,
+            head,
+        } => {
+            let head_ref = head.as_deref().unwrap_or("HEAD");
+            debug!(
+                repo_root = %repo_root.display(),
+                base,
+                head = head_ref,
+                "loading diff from git range"
+            );
+            run_git_range_diff(repo_root, base, head_ref)
+        }
+        DiffSource::Stdin => {
+            debug!("loading diff from stdin");
+            read_diff_from_reader(std::io::stdin().lock())
+        }
     }
+}
+
+/// Run `git diff -M <base>...<head>` in `repo_root` and return stdout.
+///
+/// Why: extracted so the three-dot range formatting and error handling has one
+/// definition; also keeps `load_diff`'s match arms short.
+/// What: shells out via `std::process::Command` (no `git2` dependency, mirroring
+/// the existing convention in `report/git_info.rs`); a non-zero exit or
+/// non-UTF-8 output is folded into `GithubError::Transport` with the captured
+/// stderr / decode error so the operator sees exactly what git rejected.
+/// Test: `git_range_diff_matches_git_output`, `git_range_diff_bad_repo_errors`.
+fn run_git_range_diff(
+    repo_root: &std::path::Path,
+    base: &str,
+    head: &str,
+) -> Result<String, GithubError> {
+    let range = format!("{base}...{head}");
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("diff")
+        .arg("-M")
+        .arg(&range)
+        .output()
+        .map_err(|e| GithubError::Transport(format!("failed to run `git diff {range}`: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(GithubError::Transport(format!(
+            "`git diff {range}` in {} failed ({}): {}",
+            repo_root.display(),
+            output.status,
+            stderr.trim()
+        )));
+    }
+
+    String::from_utf8(output.stdout).map_err(|e| {
+        GithubError::Transport(format!("`git diff {range}` produced non-UTF-8 output: {e}"))
+    })
+}
+
+/// Read a diff to completion from any `Read` implementation.
+///
+/// Why: extracted from the `Stdin` arm of `load_diff` so the read loop is
+/// directly unit-testable with an in-memory `Cursor` — real process stdin
+/// cannot be faked from within a single test binary.
+/// What: reads the reader to EOF into a `String`; a non-UTF-8 stream or I/O
+/// error is wrapped in `GithubError::Transport`.
+/// Test: `stdin_reader_reads_full_diff`, `stdin_reader_empty_input_is_ok`.
+fn read_diff_from_reader<R: std::io::Read>(mut reader: R) -> Result<String, GithubError> {
+    let mut buf = String::new();
+    reader
+        .read_to_string(&mut buf)
+        .map_err(|e| GithubError::Transport(format!("failed to read diff from stdin: {e}")))?;
+    Ok(buf)
 }
 
 // ─── Truncate ─────────────────────────────────────────────────────────────────
@@ -488,5 +594,111 @@ index abc..def 100644
             result.is_err(),
             "missing local diff file must return an error"
         );
+    }
+
+    // ── GitRange tests (#2993) ────────────────────────────────────────────
+
+    /// Build a tiny git repo in a tempdir with two commits, returning the dir
+    /// and the base/head SHAs (pinned by SHA rather than branch name, since
+    /// `git init`'s default branch name varies by git config).
+    fn tiny_git_repo() -> (tempfile::TempDir, String, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let run = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(dir.path())
+                .args(args)
+                .output()
+                .expect("run git");
+            assert!(
+                out.status.success(),
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+            String::from_utf8(out.stdout).expect("utf8 git output")
+        };
+
+        run(&["init", "-q"]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "Test"]);
+
+        std::fs::write(dir.path().join("a.rs"), "fn a() {}\n").expect("write a.rs");
+        run(&["add", "a.rs"]);
+        run(&["commit", "-q", "-m", "base"]);
+        let base = run(&["rev-parse", "HEAD"]).trim().to_string();
+
+        std::fs::write(dir.path().join("a.rs"), "fn a() {}\nfn b() {}\n").expect("write a.rs");
+        run(&["add", "a.rs"]);
+        run(&["commit", "-q", "-m", "head"]);
+        let head = run(&["rev-parse", "HEAD"]).trim().to_string();
+
+        (dir, base, head)
+    }
+
+    #[tokio::test]
+    async fn git_range_diff_matches_git_output() {
+        let (dir, base, head) = tiny_git_repo();
+        let source = DiffSource::GitRange {
+            repo_root: dir.path().to_path_buf(),
+            base: base.clone(),
+            head: Some(head.clone()),
+        };
+        let result = load_diff(&source).await.expect("git range diff");
+
+        // Recompute the expected diff independently (same flags `load_diff`
+        // is documented to use) to prove production code matches real git
+        // output rather than a hand-written fixture.
+        let expected = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .arg("diff")
+            .arg("-M")
+            .arg(format!("{base}...{head}"))
+            .output()
+            .expect("git diff");
+        assert_eq!(result, String::from_utf8(expected.stdout).expect("utf8"));
+        assert!(
+            result.contains("+fn b() {}"),
+            "diff should show the added line: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn git_range_diff_defaults_head_to_head_ref() {
+        let (dir, base, _head) = tiny_git_repo();
+        let source = DiffSource::GitRange {
+            repo_root: dir.path().to_path_buf(),
+            base,
+            head: None, // must default to HEAD, not fail or need worktree state
+        };
+        let result = load_diff(&source).await.expect("git range diff");
+        assert!(result.contains("+fn b() {}"));
+    }
+
+    #[tokio::test]
+    async fn git_range_diff_bad_repo_returns_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let source = DiffSource::GitRange {
+            repo_root: dir.path().to_path_buf(),
+            base: "main".to_string(),
+            head: Some("HEAD".to_string()),
+        };
+        let result = load_diff(&source).await;
+        assert!(result.is_err(), "a non-repo directory must error");
+    }
+
+    // ── Stdin tests (#2993) ───────────────────────────────────────────────
+
+    #[test]
+    fn stdin_reader_reads_full_diff() {
+        let diff = "--- a/foo.rs\n+++ b/foo.rs\n+fn bar() {}\n";
+        let result = read_diff_from_reader(std::io::Cursor::new(diff.as_bytes())).expect("read");
+        assert_eq!(result, diff);
+    }
+
+    #[test]
+    fn stdin_reader_empty_input_is_ok() {
+        let result = read_diff_from_reader(std::io::Cursor::new(&[][..])).expect("read");
+        assert_eq!(result, "");
     }
 }

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -159,6 +159,11 @@ pub async fn run_review(
     deps: ReviewDeps,
 ) -> ReviewResult {
     // ── Step 1: determine owner/repo/pr from diff source ──────────────────
+    // `LocalFile`, `GitRange`, and `Stdin` are all treated identically here:
+    // owner="local" is the sentinel `post::finalize_review` checks (via
+    // `is_github = owner != "local"`) to force `FinalizeAction::LogOnly` — so
+    // every non-GitHub source automatically inherits the "never post" / #2993
+    // dry-run guarantee without a separate posting check.
     let (owner, repo, pr_number, is_local) = match &input.diff_source {
         DiffSource::Github {
             owner, repo, pr, ..
@@ -167,6 +172,16 @@ pub async fn run_review(
             let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("local");
             ("local".to_string(), stem.to_string(), 0_u64, true)
         }
+        DiffSource::GitRange { base, head, .. } => {
+            let head_label = head.as_deref().unwrap_or("HEAD");
+            (
+                "local".to_string(),
+                format!("{base}...{head_label}"),
+                0_u64,
+                true,
+            )
+        }
+        DiffSource::Stdin => ("local".to_string(), "stdin".to_string(), 0_u64, true),
     };
 
     let pr_url = if !is_local {

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -299,6 +299,49 @@ fn local_diff_source(diff: &str) -> (DiffSource, tempfile::NamedTempFile) {
     (DiffSource::LocalFile { path }, tmp)
 }
 
+// ── Helper to build a two-commit git repo for GitRange tests (#2993) ───
+
+/// Build a tiny git repo in a tempdir with two commits, returning the dir and
+/// a `GitRange` source spanning them (base..head), so `run_review` can be
+/// driven end-to-end from a real `git diff` rather than a hand-written diff.
+fn git_range_source() -> (DiffSource, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let run = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir.path())
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).expect("utf8 git output")
+    };
+
+    run(&["init", "-q"]);
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "Test"]);
+    std::fs::write(dir.path().join("a.rs"), "fn a() {}\n").expect("write a.rs");
+    run(&["add", "a.rs"]);
+    run(&["commit", "-q", "-m", "base"]);
+    let base = run(&["rev-parse", "HEAD"]).trim().to_string();
+
+    std::fs::write(dir.path().join("a.rs"), "fn a() {}\nfn b() {}\n").expect("write a.rs");
+    run(&["add", "a.rs"]);
+    run(&["commit", "-q", "-m", "head"]);
+    let head = run(&["rev-parse", "HEAD"]).trim().to_string();
+
+    let source = DiffSource::GitRange {
+        repo_root: dir.path().to_path_buf(),
+        base,
+        head: Some(head),
+    };
+    (source, dir)
+}
+
 fn default_config() -> ReviewConfig {
     ReviewConfig::load(None)
 }
@@ -1176,6 +1219,65 @@ async fn run_review_local_diff_is_dry_run_and_not_posted() {
         "local-diff source must never post — always dry-run"
     );
     assert!(!result.posted, "local-diff must not be marked posted");
+}
+
+#[tokio::test]
+async fn run_review_git_range_is_dry_run_and_not_posted() {
+    // Same guarantee as `run_review_local_diff_is_dry_run_and_not_posted`,
+    // exercised end-to-end against a real two-commit git repo (#2993): even
+    // with the trigger forcing live and posting allowed, a GitRange source
+    // must never post.
+    let (source, _dir) = git_range_source();
+    let mut config = default_config();
+    config.dry_run = false; // service-live default
+    let input = ReviewInput {
+        diff_source: source,
+        reviewer_model: "openai/gpt-5.4-nano-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::ForceLive, // would post if GitHub-sourced
+        run_mode: RunMode::Serve,
+        allow_posting: true,
+        caller_context: CallerContext::default(),
+    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+
+    let result = run_review(&config, input, deps).await;
+    assert!(
+        result.dry_run,
+        "git-range source must never post — always dry-run"
+    );
+    assert!(!result.posted, "git-range must not be marked posted");
+}
+
+#[tokio::test]
+async fn run_review_stdin_is_dry_run_and_not_posted() {
+    // Same guarantee, for the `Stdin` source (#2993). `run_review` never
+    // reads real stdin in this test — `Stdin` loading is exercised via
+    // `read_diff_from_reader` unit tests in `diff.rs`; here we only need to
+    // confirm the source-selection dry-run/no-post wiring, so an empty stdin
+    // (nothing piped into `cargo test`) reading to "" is fine — the pipeline
+    // still runs through the fail-safe/gate path and must stay dry-run.
+    let mut config = default_config();
+    config.dry_run = false; // service-live default
+    let input = ReviewInput {
+        diff_source: DiffSource::Stdin,
+        reviewer_model: "openai/gpt-5.4-nano-20260317".to_string(),
+        write_log: false,
+        print_result: false,
+        trigger: TriggerDecision::ForceLive, // would post if GitHub-sourced
+        run_mode: RunMode::Serve,
+        allow_posting: true,
+        caller_context: CallerContext::default(),
+    };
+    let deps = ready_deps(Arc::new(FakeLlm::approves()), None);
+
+    let result = run_review(&config, input, deps).await;
+    assert!(
+        result.dry_run,
+        "stdin source must never post — always dry-run"
+    );
+    assert!(!result.posted, "stdin must not be marked posted");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Extends `DiffSource` (`crates/trusty-review/src/pipeline/diff.rs`) with `GitRange { repo_root, base, head }` (shells out to `git diff -M <base>...<head>`, three-dot merge-base semantics, `-M` rename detection) and `Stdin` (reads a unified diff from the process's stdin), exposed on `run`/`compare` as `--base <REF> [--head <REF>]` and `--local-diff -`.
- Both new sources are forced dry-run and can never post to GitHub — they reuse the same `owner="local"` sentinel `runner.rs`/`post.rs` already use for `LocalFile`, so no separate posting check was needed.
- `--base` and `--local-diff` are mutually exclusive (clap `conflicts_with`); `--head` requires `--base` and defaults to `HEAD` (not the working tree, for reproducibility from ref names alone).
- Diff-source resolution is de-duplicated between `run` and `compare` into a new `commands/diff_source.rs` module. `compare` now resolves the diff source once (not per-model) and materializes a `Stdin` source into a tempfile before its per-model loop, since stdin is only readable to EOF once — reading it again per model would otherwise silently review an empty diff for every model after the first.

## Design decisions

- **Three-dot (`base...head`), not two-dot**: matches how GitHub renders a PR's "Files changed" tab — only commits reachable from `head` but not `base` are shown, so commits landed on `base` after the branch point never leak into the diff.
- **`--head` defaults to `HEAD`, not the working tree**: keeps a git-range review reproducible from ref names alone and never silently includes uncommitted local edits.
- **Shell out to `git`, not `git2`**: mirrors the existing convention in `report/git_info.rs` — no new heavy vendored dependency.

## Test plan

- [x] `cargo test -p trusty-review` — 1415 lib + 48 bin + 13 integration tests pass, including new coverage: `pipeline::diff::tests::git_range_diff_matches_git_output` (diff text verified against an independently-invoked `git diff` on a real two-commit tempdir repo), `git_range_diff_defaults_head_to_head_ref`, `git_range_diff_bad_repo_returns_error`, `stdin_reader_reads_full_diff`/`stdin_reader_empty_input_is_ok`, `pipeline::runner::tests::run_review_git_range_is_dry_run_and_not_posted` / `run_review_stdin_is_dry_run_and_not_posted` (posting refused even with `ForceLive` + `allow_posting=true`), and `commands::diff_source::tests::*` / `commands::compare::tests::materialize_stdin_if_needed_*`.
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check -p trusty-review` — clean.
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations.
- [x] `bash scripts/check_sld.sh` — 0 errors, 0 warnings.
- [x] `cargo check -p trusty-analyze --features review` — dependent crate builds clean.
- [x] Manual end-to-end smoke test against a real tempdir git repo: `trusty-review run --base HEAD~1` and `git diff | trusty-review run --local-diff -` both load the diff correctly (`Stage A/B complete kept=1`) and print `(dry run — not posted to GitHub)`.

Closes #2993

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools