### PR TITLE
fix(trusty-code-gui): restore stable macOS signing config (match #2957 pattern)

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -8,6 +8,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored the macOS Developer-ID signing config that was intentionally
+  omitted at scaffold time, mirroring the `trusty-mpm-gui` pattern (#2951 /
+  PR #2957): `tauri.conf.json` now pins `bundle.macOS.signingIdentity` to
+  `Developer ID Application: Bob Matsuoka (4JH68XUHC5)` so `cargo tauri build`
+  produces a stable-identity `.app` bundle instead of a fresh ad-hoc identity
+  per rebuild. `productName`/window title (`"Trusty Code"`) and the bundle
+  identifier (`com.trusty.trusty-code.gui`) were already stable from the
+  original scaffold and are unchanged. Documented the cert-less
+  `APPLE_SIGNING_IDENTITY=- cargo tauri build` escape hatch in the README and
+  `docs/reference/common-pitfalls.md`. `trusty-code-gui` was already excluded
+  from the workspace's `default-members` at scaffold time (#2983), so no
+  change was needed there. `trusty-code`/`tcode` has no `SIGNABLE_BINARIES`
+  entry or `tctl sign`-style fallback install script of its own yet, so no
+  equivalent install-script wiring was added for `trusty-code-gui` (the Tauri
+  config is the only signing path today).
+
 ### Added
 
 - Initial scaffold: Tauri 2 + Svelte 5 desktop shell for the `trusty-code`

--- a/crates/trusty-code-gui/README.md
+++ b/crates/trusty-code-gui/README.md
@@ -50,6 +50,31 @@ cargo check -p trusty-code-gui
 cd crates/trusty-code-gui/ui && pnpm install && pnpm dev
 ```
 
+### Release Build
+
+```bash
+cd crates/trusty-code-gui
+cargo tauri build
+```
+
+**macOS signing (mirrors the `trusty-mpm-gui` #2951 pattern; restored here
+after being intentionally omitted at scaffold time):** `tauri.conf.json` pins
+`bundle.macOS.signingIdentity` to Bob's Developer ID
+cert (`Developer ID Application: Bob Matsuoka (4JH68XUHC5)`) — the same
+identity `trusty-mpm-gui` uses — so the `.app` bundle gets a stable TCC
+identity instead of a fresh ad-hoc one per rebuild. On a machine without that
+exact certificate in the login keychain, `cargo tauri build` will fail to
+sign — override it with the `APPLE_SIGNING_IDENTITY` environment variable,
+which Tauri's bundler honors in place of the config value:
+
+```bash
+# Local ad-hoc build (no Developer ID cert required):
+APPLE_SIGNING_IDENTITY=- cargo tauri build
+
+# Or sign with a different Developer ID cert you do have:
+APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)" cargo tauri build
+```
+
 `trusty-code-gui` is excluded from the workspace's `default-members` and from
 CI (`--exclude trusty-code-gui`), matching `trusty-mpm-gui`: it needs the
 pnpm/Svelte UI toolchain (and, for `cargo tauri build`, a platform WebView

--- a/crates/trusty-code-gui/tauri.conf.json
+++ b/crates/trusty-code-gui/tauri.conf.json
@@ -21,5 +21,10 @@
     "security": {
       "csp": null
     }
+  },
+  "bundle": {
+    "macOS": {
+      "signingIdentity": "Developer ID Application: Bob Matsuoka (4JH68XUHC5)"
+    }
   }
 }

--- a/docs/reference/common-pitfalls.md
+++ b/docs/reference/common-pitfalls.md
@@ -97,3 +97,18 @@ honors it in place of the config value (confirmed against the Tauri v2
 `-` pseudo-identity), or set it to a Developer ID string you do have. `cargo
 build -p trusty-mpm-gui` / `cargo check -p trusty-mpm-gui` (no bundling) are
 unaffected — this only matters for `cargo tauri build`/`tauri build`.
+
+🟡 **`trusty-code-gui` mirrors the `trusty-mpm-gui` signing pattern above** —
+same stable Developer ID identity (`Developer ID Application: Bob Matsuoka
+(4JH68XUHC5)`) pinned in `crates/trusty-code-gui/tauri.conf.json`'s
+`bundle.macOS.signingIdentity`, same `APPLE_SIGNING_IDENTITY` env-var
+override for machines without that cert, and it is likewise excluded from
+`default-members` (a bare `cargo build`/`test`/`check` skips it; use
+`cargo build -p trusty-code-gui` or `--workspace`). `trusty-code-gui` is a
+second, independent Tauri crate (`crates/trusty-code-gui`, for the
+`trusty-code`/tcode daemon) — it does not join `trusty-mpm-gui`'s
+`SIGNABLE_BINARIES` set, and as of this writing `trusty-code`/`tcode` has no
+`tctl sign`-style fallback install path of its own for either the CLI or the
+GUI binary (no `install-trusty-code-signed.sh` script or `CODE_SET` exists);
+the Tauri `bundle.macOS.signingIdentity` config is the only signing path for
+`trusty-code-gui` today.


### PR DESCRIPTION
## Summary

- `trusty-code-gui` (Tauri 2 + Svelte 5 GUI for the `trusty-code`/tcode daemon, merged in PR #2987) had its macOS Developer-ID signing block intentionally removed at scaffold time. This restores it, mirroring the `trusty-mpm-gui` pattern established in PR #2957 (issue #2951).
- `crates/trusty-code-gui/tauri.conf.json`: added `bundle.macOS.signingIdentity = "Developer ID Application: Bob Matsuoka (4JH68XUHC5)"` — the exact identity string `trusty-mpm-gui` uses, so both desktop shells share one designated requirement / Team ID.
- `productName` (`"Trusty Code"`) and the bundle identifier (`com.trusty.trusty-code.gui`) were **already** stable from the original scaffold — no change needed there (unlike `trusty-mpm-gui`, which had to be renamed off the bare `"trusty-mpm"` productName in #2957).
- Documented the cert-less `APPLE_SIGNING_IDENTITY=- cargo tauri build` escape hatch in `crates/trusty-code-gui/README.md` (new "Release Build" section, mirroring `trusty-mpm-gui`'s README) and in `docs/reference/common-pitfalls.md`.
- `CHANGELOG.md` entry added under `[Unreleased]`.

## What was and wasn't wired

- **`default-members`**: already excludes `trusty-code-gui` — this was done at scaffold time in #2983 alongside the `trusty-mpm-gui` exclusion from #2951/#2957. No change needed.
- **`SIGNABLE_BINARIES` / `install-trusty-mpm-signed.sh`**: **not** wired. `trusty-mpm-gui` was added to the existing `MPM_SET` in `crates/trusty-installer/src/commands/macos_signing/mod.rs` because `trusty-mpm`/`tm` already had a signable set and fallback install script (`scripts/install-trusty-mpm-signed.sh`) to join. `trusty-code`/`tcode` has **no** `SIGNABLE_BINARIES` entry, no signable set, and no `install-trusty-code-signed.sh`-equivalent script of its own yet — there is nothing for `trusty-code-gui` to join without inventing new install infrastructure that wasn't requested. Noted explicitly in the CHANGELOG and `docs/reference/common-pitfalls.md` rather than invented. The Tauri `bundle.macOS.signingIdentity` config (this PR) is the only signing path for `trusty-code-gui` today, same as it was for `trusty-mpm-gui` before #2951's fallback-script follow-up.

## Test plan

- [x] `SKIP_UI_BUILD=1 cargo check -p trusty-code-gui` — clean
- [x] `SKIP_UI_BUILD=1 cargo clippy -p trusty-code-gui --all-targets -- -D warnings` — clean (only pre-existing, unrelated `trusty-installer`/`trusty-mpm` multi-target-name warnings from other crates)
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 9 allowlisted, 0 violations — OK.`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools