### PR TITLE
feat(trusty-code): REST gateway Slice 2 — session read routes (refs #2983)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -25,6 +25,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **REST resource gateway — `session.*` read routes (#2983, #587, Slice 2).**
+  New `GET` routes on `tcode serve --http`, each a thin `axum` handler calling
+  `rest::respond` (new: wraps `rest::call` + `rpc_error_to_status` into the
+  `Result<Json<Value>, (StatusCode, Json<Response>)>` shape every REST handler
+  returns) against its `session.*` JSON-RPC twin — zero duplicated business
+  logic:
+  - `GET /sessions` -> `session.list`
+  - `GET /sessions/{id}` -> `session.status`
+  - `GET /sessions/{id}/transcript` -> `session.get_transcript`
+  - `GET /sessions/{id}/readiness` -> `session.get_readiness`
+  - `GET /sessions/{id}/goals` -> `session.get_goals`
+
+  An unknown `id` returns a real HTTP `404` with a `session_not_found`
+  JSON-RPC error envelope (never a 200-wrapped error), matching the existing
+  `GET /sessions/{id}/events` convention. New `crate::serve::rest::sessions`
+  module, merged into `crate::serve::http::build_axum_router` alongside
+  `POST /rpc`/`GET /health`/`GET /sessions/{id}/events`.
 - **REST resource gateway bridge, no routes yet (#2983, #587, Slice 1).** New
   `crate::serve::rest` module: `rest::call(router, method, params, ctx)` drives
   a synthetic JSON-RPC `Request` through the existing `Router::dispatch` seam

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -60,6 +60,7 @@ use trusty_common::mcp::Response;
 
 use crate::jsonrpc::{ConnectionContext, Router};
 use crate::serve::methods::health_payload;
+use crate::serve::rest;
 use crate::session::SessionRegistry;
 
 /// Shared axum state: the JSON-RPC router (for `POST /rpc`) and the session
@@ -76,7 +77,8 @@ struct HttpState {
 }
 
 /// Build the pure axum router (no listener bound) exposing `POST /rpc`,
-/// `GET /health`, and `GET /sessions/{id}/events`.
+/// `GET /health`, `GET /sessions/{id}/events`, and (#2983 Slice 2) the
+/// `GET /sessions*` REST resource group.
 ///
 /// Why: kept separate from [`run_http`] so unit tests exercise routing and
 /// dispatch via `tower::util::ServiceExt::oneshot` without opening a real
@@ -85,18 +87,26 @@ struct HttpState {
 /// What: `POST /rpc` dispatches the request body through
 /// `Router::dispatch_json` (shared with the STDIO transport); `GET /health`
 /// returns [`health_payload`]; `GET /sessions/{id}/events` streams that
-/// session's ring-buffer replay then live events as SSE.
+/// session's ring-buffer replay then live events as SSE; `crate::serve::rest`
+/// merges in the `session.*` REST read routes (`GET /sessions`,
+/// `GET /sessions/{id}`, `.../transcript`, `.../readiness`, `.../goals`) —
+/// none of which collide with the paths registered directly on this router.
 /// Test: `http_rpc_ping_returns_pong`,
 /// `http_rpc_malformed_json_returns_parse_error`,
 /// `http_health_matches_jsonrpc_health_payload`,
-/// `http_session_events_sse_streams_replay_then_live_event`.
+/// `http_session_events_sse_streams_replay_then_live_event`,
+/// `http_rest_sessions_route_is_merged_in`.
 pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) -> AxumRouter {
-    let state = HttpState { router, sessions };
-    let app = AxumRouter::new()
+    let state = HttpState {
+        router: router.clone(),
+        sessions,
+    };
+    let core = AxumRouter::new()
         .route("/rpc", post(rpc_handler))
         .route("/health", get(health_handler))
         .route("/sessions/{id}/events", get(session_events_sse))
         .with_state(state);
+    let app = core.merge(rest::sessions::routes(router));
     trusty_common::server::with_standard_middleware(app)
 }
 
@@ -334,6 +344,33 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert_eq!(v, health_payload());
+    }
+
+    /// `GET /sessions` (the #2983 Slice 2 REST route group, merged in by
+    /// `build_axum_router`) must be reachable on the SAME router `POST /rpc`
+    /// and `GET /sessions/{id}/events` are — proving the merge in
+    /// `build_axum_router` actually wires `rest::sessions::routes` rather
+    /// than silently dropping it. Route-level behaviour (found/missing/
+    /// transcript/readiness/goals) is covered by `rest::sessions::tests`.
+    #[tokio::test]
+    async fn http_rest_sessions_route_is_merged_in() {
+        let (router, sessions) = router_and_sessions();
+        let app = build_axum_router(router, sessions);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/sessions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert!(v["sessions"].is_array());
     }
 
     /// `GET /sessions/{id}/events` on an unknown session must 404 with a

--- a/crates/trusty-code/src/serve/rest/mod.rs
+++ b/crates/trusty-code/src/serve/rest/mod.rs
@@ -1,5 +1,5 @@
 //! REST resource gateway over the JSON-RPC method registry (#2983, #587,
-//! Slice 1: bridge only — no routes).
+//! Slice 1 bridge + Slice 2 `session.*` read routes).
 //!
 //! Why: the vision spec (#587) wants `tcode serve --http` to expose a
 //! conventional REST resource vocabulary (`GET /projects`, `POST
@@ -25,19 +25,34 @@
 //! deliberately diverging from `POST /rpc`'s "always 200, error in the
 //! envelope" convention — matching how `GET /sessions/{id}/events`
 //! (`crate::serve::http::session_events_sse`) already returns a real `404`
-//! for `session_not_found` rather than a 200-wrapped error.
+//! for `session_not_found` rather than a 200-wrapped error. [`respond`] is
+//! the one place that glues those two together into the `Result<Json<Value>,
+//! (StatusCode, Json<Response>)>` shape every axum REST handler returns, so
+//! a route handler is never more than "extract params, call `respond`".
+//! [`throwaway_ctx`] builds the per-request [`ConnectionContext`] every REST
+//! handler needs to call [`call`] with — identical in spirit to
+//! `crate::serve::http::rpc_handler`'s own throwaway context, since a REST
+//! call is exactly as one-shot as a `POST /rpc` call.
 //!
-//! This slice wires no axum routes — [`crate::serve::mod`] only declares
-//! `mod rest;` so the bridge compiles and is unit-testable on its own.
-//! Concrete resource routes (`GET /projects`, `POST /sessions`, …) land in
-//! S2-S6, each calling [`call`] + [`rpc_error_to_status`] instead of talking
-//! to the `Router` directly.
+//! Slice 1 wired no axum routes — only this bridge. Slice 2
+//! ([`sessions`]) adds the first concrete resource group: `GET /sessions`,
+//! `GET /sessions/{id}`, `GET /sessions/{id}/transcript`,
+//! `GET /sessions/{id}/readiness`, `GET /sessions/{id}/goals`, each a thin
+//! handler calling [`respond`] against its `session.*` JSON-RPC twin.
+//! Further resource groups (`task.*`, `POST /sessions`, …) land in S3-S6,
+//! each its own sibling module reusing [`respond`]/[`throwaway_ctx`] rather
+//! than reimplementing the glue.
 //!
 //! Test: `tests::*` — a success round-trip, an error round-trip, and one
-//! assertion per `rpc_error_to_status` mapping.
+//! assertion per `rpc_error_to_status` mapping. See `sessions::tests` for
+//! the Slice 2 route-level coverage.
 
+pub mod sessions;
+
+use axum::Json;
+use axum::http::StatusCode;
 use serde_json::Value;
-use trusty_common::mcp::{Request, error_codes};
+use trusty_common::mcp::{Request, Response, error_codes};
 
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 
@@ -113,6 +128,59 @@ pub fn rpc_error_to_status(err: &RpcError) -> axum::http::StatusCode {
         c if c == error_codes::INTERNAL_ERROR => StatusCode::INTERNAL_SERVER_ERROR,
         _ => StatusCode::INTERNAL_SERVER_ERROR,
     }
+}
+
+/// Build a throwaway [`ConnectionContext`] for a single REST call.
+///
+/// Why: every REST handler calls [`call`], which requires a
+/// `&ConnectionContext`, but a REST request is exactly as one-shot as an
+/// HTTP `POST /rpc` call — there is no live connection for a handler like
+/// `session.attach` to push notifications back to (that path is the
+/// dedicated SSE route, `crate::serve::http::session_events_sse`). Mirrors
+/// `crate::serve::http::rpc_handler`'s identical throwaway-channel
+/// construction so the two transports build a `ConnectionContext` the same
+/// way.
+/// What: a fresh `mpsc::unbounded_channel()`, receiver immediately dropped —
+/// any handler that queues a notification onto `notify` simply stops on its
+/// next send once this function returns.
+/// Test: exercised indirectly by every `sessions::tests::*` route test (a
+/// route only responds at all if its `ConnectionContext` is constructible).
+pub(crate) fn throwaway_ctx() -> ConnectionContext {
+    let (notify_tx, _notify_rx) = tokio::sync::mpsc::unbounded_channel();
+    ConnectionContext::new(notify_tx)
+}
+
+/// A REST handler's return type: the JSON-RPC result as a `Json` body on
+/// success, or a real HTTP status plus a JSON-RPC error envelope on failure.
+///
+/// Why: `(StatusCode, Json<Response>)` already implements axum's
+/// `IntoResponse` for the error arm, so every route handler can just return
+/// this type from [`respond`] without a bespoke error type.
+pub(crate) type RestResult = Result<Json<Value>, (StatusCode, Json<Response>)>;
+
+/// Call `method` through [`call`] and convert the result into a
+/// [`RestResult`] — the single glue point every Slice 2+ REST handler goes
+/// through.
+///
+/// Why: keeps route handlers themselves down to "extract path/query params,
+/// build `params`, call `respond`" with zero business logic and zero
+/// repeated error-mapping boilerplate (see module docs).
+/// What: `Ok(value)` becomes `Ok(Json(value))`; `Err(rpc_err)` becomes
+/// `Err((rpc_error_to_status(&rpc_err), Json(Response::err(None,
+/// rpc_err.code, rpc_err.message))))` — `data` is intentionally dropped from
+/// the REST envelope, matching `crate::serve::http::session_events_sse`'s
+/// existing `session_not_found` -> 404 mapping (the `id` is always `None`
+/// because a REST error response has no JSON-RPC request id to echo).
+/// Test: `sessions::tests::get_session_found_returns_200_with_session_json`,
+/// `sessions::tests::get_session_missing_returns_404_session_not_found`.
+pub(crate) async fn respond(router: &Router, method: &str, params: Value) -> RestResult {
+    call(router, method, params, &throwaway_ctx())
+        .await
+        .map(Json)
+        .map_err(|err| {
+            let status = rpc_error_to_status(&err);
+            (status, Json(Response::err(None, err.code, err.message)))
+        })
 }
 
 #[cfg(test)]

--- a/crates/trusty-code/src/serve/rest/sessions.rs
+++ b/crates/trusty-code/src/serve/rest/sessions.rs
@@ -1,0 +1,302 @@
+//! `GET /sessions*` REST routes over the `session.*` JSON-RPC methods
+//! (#2983 Slice 2 — read-only routes only, no writes).
+//!
+//! Why: Slice 1 (`super`) built the `rest::call`/`rpc_error_to_status`
+//! bridge but wired no axum routes. This is the first concrete resource
+//! group: session state is the thing every other `tcode` client (CLI, TUI,
+//! future browser UI) polls most, so it lands first. Every handler below is
+//! deliberately thin — parse the path param, build the JSON-RPC `params`,
+//! call `super::respond` — because the actual behaviour (session lookup,
+//! `-32007 session_not_found` mapping, …) already lives in
+//! `crate::session::protocol`'s handlers; duplicating it here as bespoke
+//! axum logic would fork the two surfaces (see `super` module docs).
+//! What: [`routes`] builds a standalone `axum::Router<()>` (its own
+//! `SessionsState` carrying just the `Arc<Router>`, `with_state`-erased
+//! before return) mapping:
+//!   - `GET /sessions` -> `session.list`
+//!   - `GET /sessions/{id}` -> `session.status`
+//!   - `GET /sessions/{id}/transcript` -> `session.get_transcript`
+//!   - `GET /sessions/{id}/readiness` -> `session.get_readiness`
+//!   - `GET /sessions/{id}/goals` -> `session.get_goals`
+//!
+//! `crate::serve::http::build_axum_router` merges this into the daemon's
+//! main router alongside `POST /rpc`, `GET /health`, and
+//! `GET /sessions/{id}/events` (SSE) — none of those paths collide with the
+//! ones here.
+//! Test: `tests::*`.
+
+use std::sync::Arc;
+
+use axum::Router as AxumRouter;
+use axum::extract::{Path, State};
+use axum::routing::get;
+use serde_json::json;
+
+use crate::jsonrpc::Router;
+
+use super::{RestResult, respond};
+
+/// Shared axum state for every route in this module: just the JSON-RPC
+/// router — every handler here is read-only and goes through
+/// [`super::respond`] rather than touching `SessionRegistry` directly.
+#[derive(Clone)]
+struct SessionsState {
+    router: Arc<Router>,
+}
+
+/// Build the `GET /sessions*` route group.
+///
+/// Why: kept separate from `crate::serve::http::build_axum_router` so this
+/// resource group is unit-testable via `tower::util::ServiceExt::oneshot`
+/// on its own, exactly like `crate::serve::http`'s own routes.
+/// What: five `GET` routes (see module docs), all sharing one
+/// `SessionsState { router }`, `with_state`-erased to `axum::Router<()>` so
+/// the caller can `.merge()` it into a router with a different state type.
+/// Test: `tests::list_sessions_returns_sessions_array`.
+pub fn routes(router: Arc<Router>) -> AxumRouter {
+    AxumRouter::new()
+        .route("/sessions", get(list_sessions))
+        .route("/sessions/{id}", get(get_session))
+        .route("/sessions/{id}/transcript", get(get_transcript))
+        .route("/sessions/{id}/readiness", get(get_readiness))
+        .route("/sessions/{id}/goals", get(get_goals))
+        .with_state(SessionsState { router })
+}
+
+/// `GET /sessions` -> `session.list`.
+///
+/// Why: enumerates every session the daemon currently owns.
+/// What: no params; forwards straight to `session.list`, returning its
+/// `{"sessions": [...]}` result verbatim.
+/// Test: `tests::list_sessions_returns_sessions_array`.
+async fn list_sessions(State(state): State<SessionsState>) -> RestResult {
+    respond(&state.router, "session.list", json!({})).await
+}
+
+/// `GET /sessions/{id}` -> `session.status`.
+///
+/// Why: point lookup for one session's current state.
+/// What: `404` with a JSON-RPC `session_not_found` envelope for an unknown
+/// `id`; otherwise the `Session` JSON.
+/// Test: `tests::get_session_found_returns_200_with_session_json`,
+/// `tests::get_session_missing_returns_404_session_not_found`.
+async fn get_session(State(state): State<SessionsState>, Path(id): Path<String>) -> RestResult {
+    respond(&state.router, "session.status", json!({"session_id": id})).await
+}
+
+/// `GET /sessions/{id}/transcript` -> `session.get_transcript`.
+///
+/// Why: read-only access to a session's persisted run record (turns,
+/// aggregate usage, cost).
+/// What: `404` for an unknown `id`; otherwise the `TranscriptRecord` JSON —
+/// a never-run session returns an empty `turns` array, not an error (see
+/// `session::protocol::get_transcript`'s docs).
+/// Test: `tests::get_transcript_found_returns_200_with_empty_turns`,
+/// `tests::get_transcript_missing_returns_404_session_not_found`.
+async fn get_transcript(State(state): State<SessionsState>, Path(id): Path<String>) -> RestResult {
+    respond(
+        &state.router,
+        "session.get_transcript",
+        json!({"session_id": id}),
+    )
+    .await
+}
+
+/// `GET /sessions/{id}/readiness` -> `session.get_readiness`.
+///
+/// Why: lets a late-attaching client query the one-time index-readiness
+/// probe it may have missed on the SSE stream.
+/// What: `404` for an unknown `id`; otherwise the `ReadinessQuery` JSON
+/// (`{"status":"probed",...}` or `{"status":"never_probed"}`).
+/// Test: `tests::get_readiness_found_returns_200_never_probed`,
+/// `tests::get_readiness_missing_returns_404_session_not_found`.
+async fn get_readiness(State(state): State<SessionsState>, Path(id): Path<String>) -> RestResult {
+    respond(
+        &state.router,
+        "session.get_readiness",
+        json!({"session_id": id}),
+    )
+    .await
+}
+
+/// `GET /sessions/{id}/goals` -> `session.get_goals`.
+///
+/// Why: lets an operator/UI inspect the current 5-slot goal state without
+/// pulling the larger transcript payload.
+/// What: `404` for an unknown `id`; otherwise `{"goals": [...]}` — `[]` for
+/// a session with no transcript yet.
+/// Test: `tests::get_goals_found_returns_200_with_empty_goals`,
+/// `tests::get_goals_missing_returns_404_session_not_found`.
+async fn get_goals(State(state): State<SessionsState>, Path(id): Path<String>) -> RestResult {
+    respond(
+        &state.router,
+        "session.get_goals",
+        json!({"session_id": id}),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::util::ServiceExt;
+
+    /// Build a router wired with every `session.*` method plus a fresh
+    /// `SessionRegistry`, then the REST route group over it — mirrors
+    /// `crate::serve::http::tests::router_and_sessions` but only needs the
+    /// registry to seed sessions directly (these routes never touch it).
+    fn app_and_registry() -> (AxumRouter, Arc<crate::session::SessionRegistry>) {
+        let sessions = Arc::new(crate::session::SessionRegistry::new());
+        let mut router = Router::new();
+        crate::session::protocol::register(&mut router, sessions.clone());
+        let app = routes(Arc::new(router));
+        (app, sessions)
+    }
+
+    async fn body_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn get(app: &AxumRouter, uri: &str) -> axum::response::Response {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    /// `GET /sessions` must return `{"sessions": [...]}` with every session
+    /// currently owned by the registry.
+    #[tokio::test]
+    async fn list_sessions_returns_sessions_array() {
+        let (app, sessions) = app_and_registry();
+        sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let resp = get(&app, "/sessions").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["sessions"].as_array().unwrap().len(), 1);
+    }
+
+    /// `GET /sessions/{id}` on a real session must return HTTP 200 with the
+    /// `Session` JSON, `id` included.
+    #[tokio::test]
+    async fn get_session_found_returns_200_with_session_json() {
+        let (app, sessions) = app_and_registry();
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let resp = get(&app, &format!("/sessions/{}", session.id)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["id"], session.id);
+    }
+
+    /// `GET /sessions/{id}` on an unknown id must be a real HTTP 404 with a
+    /// JSON-RPC `session_not_found` envelope, not a 200-wrapped error.
+    #[tokio::test]
+    async fn get_session_missing_returns_404_session_not_found() {
+        let (app, _sessions) = app_and_registry();
+
+        let resp = get(&app, "/sessions/does-not-exist").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32007);
+    }
+
+    /// A percent-encoded, never-created id must decode through axum's path
+    /// extractor and still reach the JSON-RPC layer as a `session_not_found`
+    /// 404 — proving the REST id param is never treated as "invalid" at the
+    /// routing layer, only at the domain (session lookup) layer, exactly
+    /// like the JSON-RPC surface itself has no separate id-format
+    /// validation.
+    #[tokio::test]
+    async fn get_session_percent_encoded_missing_id_returns_404() {
+        let (app, _sessions) = app_and_registry();
+
+        let resp = get(&app, "/sessions/not%20a%20real%20id").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32007);
+    }
+
+    /// `GET /sessions/{id}/transcript` on a never-run session must return
+    /// HTTP 200 with an empty `turns` array, not an error.
+    #[tokio::test]
+    async fn get_transcript_found_returns_200_with_empty_turns() {
+        let (app, sessions) = app_and_registry();
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let resp = get(&app, &format!("/sessions/{}/transcript", session.id)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["turns"].as_array().unwrap().len(), 0);
+    }
+
+    /// `GET /sessions/{id}/transcript` on an unknown id must 404.
+    #[tokio::test]
+    async fn get_transcript_missing_returns_404_session_not_found() {
+        let (app, _sessions) = app_and_registry();
+
+        let resp = get(&app, "/sessions/does-not-exist/transcript").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32007);
+    }
+
+    /// `GET /sessions/{id}/readiness` on a never-probed session must return
+    /// HTTP 200 with `status: "never_probed"`, not an error.
+    #[tokio::test]
+    async fn get_readiness_found_returns_200_never_probed() {
+        let (app, sessions) = app_and_registry();
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let resp = get(&app, &format!("/sessions/{}/readiness", session.id)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["status"], "never_probed");
+    }
+
+    /// `GET /sessions/{id}/readiness` on an unknown id must 404.
+    #[tokio::test]
+    async fn get_readiness_missing_returns_404_session_not_found() {
+        let (app, _sessions) = app_and_registry();
+
+        let resp = get(&app, "/sessions/does-not-exist/readiness").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32007);
+    }
+
+    /// `GET /sessions/{id}/goals` on a never-run session must return HTTP
+    /// 200 with an empty `goals` array, not an error.
+    #[tokio::test]
+    async fn get_goals_found_returns_200_with_empty_goals() {
+        let (app, sessions) = app_and_registry();
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let resp = get(&app, &format!("/sessions/{}/goals", session.id)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["goals"].as_array().unwrap().len(), 0);
+    }
+
+    /// `GET /sessions/{id}/goals` on an unknown id must 404.
+    #[tokio::test]
+    async fn get_goals_missing_returns_404_session_not_found() {
+        let (app, _sessions) = app_and_registry();
+
+        let resp = get(&app, "/sessions/does-not-exist/goals").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32007);
+    }
+}


### PR DESCRIPTION
## Summary

Slice 2 of the `tcode` REST gateway (#2983): the first concrete resource
group, built on Slice 1's `rest::call`/`rpc_error_to_status` bridge (#2986,
merged `7c375a46`). Adds five read-only `session.*` routes on
`tcode serve --http`, each a thin `axum` handler that parses its path param,
builds the JSON-RPC `params`, and calls the new `rest::respond` glue
(`rest::call` + `rpc_error_to_status`, returning a real HTTP status — never
a 200-wrapped error) against its `session.*` JSON-RPC twin. No business
logic lives in the handlers; the existing `session::protocol` handlers stay
the single source of truth.

## Route -> RPC mapping

| REST route | JSON-RPC method |
|---|---|
| `GET /sessions` | `session.list` |
| `GET /sessions/{id}` | `session.status` |
| `GET /sessions/{id}/transcript` | `session.get_transcript` |
| `GET /sessions/{id}/readiness` | `session.get_readiness` |
| `GET /sessions/{id}/goals` | `session.get_goals` |

An unknown `id` returns a real HTTP `404` with a `session_not_found`
JSON-RPC error envelope, matching the existing
`GET /sessions/{id}/events` (SSE) convention rather than `POST /rpc`'s
always-200 envelope.

## Files added/changed

- `crates/trusty-code/src/serve/rest/sessions.rs` (new) — the five route
  handlers + `routes()` builder + `tests::*` (10 tests).
- `crates/trusty-code/src/serve/rest/mod.rs` — adds `pub mod sessions;`,
  `throwaway_ctx()`, `RestResult`, and `respond()` (shared glue reused by
  future S3-S6 resource groups).
- `crates/trusty-code/src/serve/http.rs` — `build_axum_router` now merges
  `rest::sessions::routes(router)` alongside `POST /rpc`/`GET /health`/
  `GET /sessions/{id}/events`; new `http_rest_sessions_route_is_merged_in`
  test proves the merge is wired.
- `crates/trusty-code/CHANGELOG.md` — `[Unreleased]/### Added` entry.

## Test plan

- [x] `cargo build -p trusty-code`
- [x] `cargo test -p trusty-code --tests` (single-threaded: 1146/1146 lib +
      2/2 session_e2e + 6/6 task_e2e pass; the parallel run shows 2
      pre-existing, unrelated `run_task::tests::*` flakes caused by fixed-port
      contention on a mock daemon at `127.0.0.1:19999` — confirmed
      pre-existing by reproducing in isolation and under `--test-threads=1`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling pointers
- [x] `bash scripts/check_line_cap.sh` — 0 violations

### Evidence (raw tails)

```
$ cargo build -p trusty-code
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.38s

$ cargo test -p trusty-code --lib -- --test-threads=1
test result: ok. 1146 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 9.09s

$ cargo test -p trusty-code --lib serve::rest
test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 1130 filtered out; finished in 0.00s

$ cargo clippy --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.35s

$ cargo fmt --check
(exit 0, no diff)

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_line_cap.sh
line-cap: 9 allowlisted, 0 violations — OK.
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools