### PR TITLE
docs: correct launchd plist label in install-and-run-tm.md

### DIFF
--- a/docs/getting-started/install-and-run-tm.md
+++ b/docs/getting-started/install-and-run-tm.md
@@ -219,16 +219,16 @@ Use the graceful restart convention (SIGTERM, not SIGKILL):
 
 ```bash
 # On macOS
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty-search.plist
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty-memory.plist
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty-mpm.plist
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.memory.plist
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.mpm.plist
 
 # Reinstall or run: cargo install --path … --locked
 
 # Restart
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty-search.plist
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty-memory.plist
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty-mpm.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.memory.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.mpm.plist
 ```
 
 On Linux, use `systemctl`:
@@ -247,10 +247,10 @@ rm ~/.local/bin/trusty-mpm ~/.local/bin/trusty-memory ~/.local/bin/trusty-search
 
 On macOS, also remove the launchd plists:
 ```bash
-rm ~/Library/LaunchAgents/com.trusty-*.plist
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty-search.plist 2>/dev/null || true
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty-memory.plist 2>/dev/null || true
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty-mpm.plist 2>/dev/null || true
+rm ~/Library/LaunchAgents/com.trusty.*.plist
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist 2>/dev/null || true
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.memory.plist 2>/dev/null || true
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.mpm.plist 2>/dev/null || true
 ```
 
 ### Q: Installation failed. What do I do?


### PR DESCRIPTION
## Summary

Fixes documentation bug #2965: wrong launchd plist label family in `docs/getting-started/install-and-run-tm.md`.

The document referenced plist names with dashes (`com.trusty-search.plist`, `com.trusty-memory.plist`, `com.trusty-mpm.plist`) that don't exist on the system. The correct launchd labels use dots instead:

| Wrong | Correct |
|---|---|
| `com.trusty-search.plist` | `com.trusty.trusty-search.plist` |
| `com.trusty-memory.plist` | `com.trusty.memory.plist` |
| `com.trusty-mpm.plist` | `com.trusty.mpm.plist` |

All occurrences in the restart and uninstall sections have been corrected, and the glob pattern in the uninstall section was updated from `com.trusty-*.plist` to `com.trusty.*.plist` to match the actual daemon files.

## Verification

- [x] `bash scripts/check_sld.sh` passes (0 errors, 0 warnings)
- [x] `bash scripts/check_line_cap.sh` passes (SLOC limits OK)
- [x] No other files have this wrong label family (docs-only fix)

Closes #2965