### PR TITLE
feat(trusty-code): REST gateway Slice 3 — session write routes (refs #2983)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -25,6 +25,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **REST resource gateway — `session.*` write routes (#2983, #587, Slice 3).**
+  New `POST`/`PUT`/`DELETE` routes on `tcode serve --http`, each a thin
+  `axum` handler calling `rest::respond` (or the new `respond_created` for
+  the one route that returns a non-`200` success status) against its
+  `session.*` JSON-RPC twin — zero duplicated business logic:
+  - `POST /sessions` -> `session.create` (`201 Created` — the only route in
+    this slice that mints a brand-new resource; every other route below
+    acts on an existing one and keeps `200` on success)
+  - `POST /sessions/{id}/messages` -> `session.send`
+  - `POST /sessions/{id}/cancel` -> `session.cancel`
+  - `PUT /sessions/{id}/goal` -> `session.set_goal`
+  - `DELETE /sessions/{id}/goal` -> `session.clear_goal`
+
+  An unknown `id` returns a real HTTP `404` with a `session_not_found`
+  JSON-RPC error envelope; a malformed JSON body never reaches a handler at
+  all — axum's `Json` extractor rejects it (`400`/`422`) before any
+  `session.*` method runs. New `crate::serve::rest::sessions_write` module
+  (tests split into a sibling `sessions_write_tests.rs`, mirroring
+  `session::registry`'s `registry_tests.rs` convention, purely for the
+  500-SLOC production cap), merged into
+  `crate::serve::http::build_axum_router` alongside `POST /rpc`,
+  `GET /health`, `GET /sessions/{id}/events`, and Slice 2's read routes.
 - **REST resource gateway — `session.*` read routes (#2983, #587, Slice 2).**
   New `GET` routes on `tcode serve --http`, each a thin `axum` handler calling
   `rest::respond` (new: wraps `rest::call` + `rpc_error_to_status` into the

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -77,8 +77,8 @@ struct HttpState {
 }
 
 /// Build the pure axum router (no listener bound) exposing `POST /rpc`,
-/// `GET /health`, `GET /sessions/{id}/events`, and (#2983 Slice 2) the
-/// `GET /sessions*` REST resource group.
+/// `GET /health`, `GET /sessions/{id}/events`, and (#2983 Slice 2 + Slice 3)
+/// the full `/sessions*` REST resource group.
 ///
 /// Why: kept separate from [`run_http`] so unit tests exercise routing and
 /// dispatch via `tower::util::ServiceExt::oneshot` without opening a real
@@ -89,8 +89,11 @@ struct HttpState {
 /// returns [`health_payload`]; `GET /sessions/{id}/events` streams that
 /// session's ring-buffer replay then live events as SSE; `crate::serve::rest`
 /// merges in the `session.*` REST read routes (`GET /sessions`,
-/// `GET /sessions/{id}`, `.../transcript`, `.../readiness`, `.../goals`) —
-/// none of which collide with the paths registered directly on this router.
+/// `GET /sessions/{id}`, `.../transcript`, `.../readiness`, `.../goals`) and
+/// (Slice 3) the write routes (`POST /sessions`,
+/// `POST /sessions/{id}/messages`, `POST /sessions/{id}/cancel`,
+/// `PUT`/`DELETE /sessions/{id}/goal`) — none of which collide with the
+/// paths registered directly on this router.
 /// Test: `http_rpc_ping_returns_pong`,
 /// `http_rpc_malformed_json_returns_parse_error`,
 /// `http_health_matches_jsonrpc_health_payload`,
@@ -106,7 +109,9 @@ pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) ->
         .route("/health", get(health_handler))
         .route("/sessions/{id}/events", get(session_events_sse))
         .with_state(state);
-    let app = core.merge(rest::sessions::routes(router));
+    let app = core
+        .merge(rest::sessions::routes(router.clone()))
+        .merge(rest::sessions_write::routes(router));
     trusty_common::server::with_standard_middleware(app)
 }
 

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -98,7 +98,8 @@ struct HttpState {
 /// `http_rpc_malformed_json_returns_parse_error`,
 /// `http_health_matches_jsonrpc_health_payload`,
 /// `http_session_events_sse_streams_replay_then_live_event`,
-/// `http_rest_sessions_route_is_merged_in`.
+/// `http_rest_sessions_route_is_merged_in`,
+/// `http_rest_post_sessions_route_is_merged_in`.
 pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) -> AxumRouter {
     let state = HttpState {
         router: router.clone(),
@@ -376,6 +377,82 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert!(v["sessions"].is_array());
+    }
+
+    /// `POST /sessions` (the #2983 Slice 3 REST write route group, merged in
+    /// by `build_axum_router` via `rest::sessions_write::routes`) must be
+    /// reachable on the SAME router `GET /sessions` is (the previous test) —
+    /// proving axum's `.merge()` doesn't silently drop one side when two
+    /// sub-routers register the SAME literal path under different HTTP
+    /// methods. `GET`+`POST` both claim `/sessions`; `PUT`+`DELETE` both
+    /// claim `/sessions/{id}/goal` — this test pins both same-literal-path
+    /// pairs in one pass, driving the created session's id through a real
+    /// `PUT` then `DELETE` on `/goal` and asserting a clean `200` round trip
+    /// (seeding a `pm_transcript` first via the registry so `set_goal`/
+    /// `clear_goal`'s "has a transcript" precondition passes — otherwise a
+    /// merge bug that silently 404'd the route would be indistinguishable
+    /// from a legitimate `400 invalid_argument`). Per-route error/malformed-
+    /// body behaviour is already covered by `rest::sessions_write::tests`;
+    /// this test only pins the merge itself.
+    #[tokio::test]
+    async fn http_rest_post_sessions_route_is_merged_in() {
+        let (router, sessions) = router_and_sessions();
+        let sessions_for_seeding = sessions.clone();
+        let app = build_axum_router(router, sessions);
+
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"task": "do it"}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_resp.status(), StatusCode::CREATED);
+        let created = body_json(create_resp).await;
+        assert_eq!(created["status"], "running");
+        assert_eq!(created["task"], "do it");
+        let session_id = created["id"].as_str().unwrap().to_string();
+
+        let transcript = sessions_for_seeding
+            .begin_pm_transcript(&session_id, "you are the pm", "first task")
+            .unwrap();
+        sessions_for_seeding.store_pm_transcript(&session_id, transcript);
+
+        let put_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/sessions/{session_id}/goal"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({"slot": 1, "text": "ship it"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(put_resp.status(), StatusCode::OK);
+        assert_eq!(body_json(put_resp).await, json!({}));
+
+        let delete_resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/sessions/{session_id}/goal"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({"slot": 1}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(delete_resp.status(), StatusCode::OK);
+        assert_eq!(body_json(delete_resp).await, json!({}));
     }
 
     /// `GET /sessions/{id}/events` on an unknown session must 404 with a

--- a/crates/trusty-code/src/serve/rest/mod.rs
+++ b/crates/trusty-code/src/serve/rest/mod.rs
@@ -39,15 +39,19 @@
 //! `GET /sessions/{id}`, `GET /sessions/{id}/transcript`,
 //! `GET /sessions/{id}/readiness`, `GET /sessions/{id}/goals`, each a thin
 //! handler calling [`respond`] against its `session.*` JSON-RPC twin.
-//! Further resource groups (`task.*`, `POST /sessions`, …) land in S3-S6,
-//! each its own sibling module reusing [`respond`]/[`throwaway_ctx`] rather
-//! than reimplementing the glue.
+//! Slice 3 ([`sessions_write`]) adds the `session.*` WRITE routes:
+//! `POST /sessions`, `POST /sessions/{id}/messages`,
+//! `POST /sessions/{id}/cancel`, `PUT /sessions/{id}/goal`,
+//! `DELETE /sessions/{id}/goal`. Further resource groups (`task.*`, …) land
+//! in S4-S6, each its own sibling module reusing
+//! [`respond`]/[`throwaway_ctx`] rather than reimplementing the glue.
 //!
 //! Test: `tests::*` — a success round-trip, an error round-trip, and one
 //! assertion per `rpc_error_to_status` mapping. See `sessions::tests` for
 //! the Slice 2 route-level coverage.
 
 pub mod sessions;
+pub mod sessions_write;
 
 use axum::Json;
 use axum::http::StatusCode;

--- a/crates/trusty-code/src/serve/rest/sessions_write.rs
+++ b/crates/trusty-code/src/serve/rest/sessions_write.rs
@@ -1,0 +1,263 @@
+//! `POST`/`PUT`/`DELETE /sessions*` REST routes over the `session.*`
+//! JSON-RPC methods (#2983 Slice 3 — write routes).
+//!
+//! Why: Slice 2 (`super::sessions`) covered the five read-only `GET`
+//! routes; a REST client also needs to mint sessions, drive them, and
+//! manage their goal slots without dropping to raw JSON-RPC. Every handler
+//! below stays as thin as Slice 2's — extract path/body, build the
+//! JSON-RPC `params`, call `super::respond` (or [`respond_created`] for the
+//! one route that needs a non-200 success status) — because the actual
+//! behaviour (session lookup, validation, `-32007 session_not_found`
+//! mapping, …) already lives in `crate::session::protocol`'s handlers;
+//! duplicating it here as bespoke axum logic would fork the two surfaces
+//! (see `super` module docs).
+//! What: [`routes`] builds a standalone `axum::Router<()>` (its own
+//! `SessionsWriteState` carrying just the `Arc<Router>`, `with_state`-erased
+//! before return, mirroring `super::sessions::SessionsState`) mapping:
+//!   - `POST /sessions` -> `session.create` (`201 Created` — this route
+//!     mints a brand-new resource, so it follows the standard REST
+//!     creation convention rather than Slice 1-2's uniform `200`/mapped-4xx;
+//!     every other route below acts on an EXISTING resource, so it keeps
+//!     `200` on success like every Slice 2 route)
+//!   - `POST /sessions/{id}/messages` -> `session.send`
+//!   - `POST /sessions/{id}/cancel` -> `session.cancel`
+//!   - `PUT /sessions/{id}/goal` -> `session.set_goal`
+//!   - `DELETE /sessions/{id}/goal` -> `session.clear_goal`
+//!
+//! Request bodies deserialize into private structs shaped identically to
+//! the RPC layer's own `params` structs (`crate::session::protocol`'s
+//! `CreateParams`/`SendParams`, `protocol_goals`'s
+//! `SetGoalParams`/`ClearGoalParams`) minus whatever the URL path already
+//! supplies (`session_id`) — a malformed body never reaches a handler at
+//! all; axum's `Json<T>` extractor rejects it before the handler runs
+//! (`400`/`422`, see module docs on [`super`]), so no handler here
+//! hand-rolls body validation.
+//! `crate::serve::http::build_axum_router` merges this into the daemon's
+//! main router alongside `POST /rpc`, `GET /health`,
+//! `GET /sessions/{id}/events`, and `super::sessions`'s read routes — none
+//! of those paths collide with the ones here (`PUT`/`DELETE
+//! /sessions/{id}/goal` share a path with different methods, which axum
+//! routes independently).
+//! Test: `tests::*` (`sessions_write_tests.rs`, split out purely for the
+//! 500-SLOC cap — see `crate::session::registry`'s identical
+//! `#[path = "registry_tests.rs"]` split for the established convention).
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::Router as AxumRouter;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{post, put};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use trusty_common::mcp::Response;
+
+use crate::jsonrpc::Router;
+
+use super::{RestResult, respond};
+
+/// Shared axum state for every route in this module: just the JSON-RPC
+/// router, mirroring `super::sessions::SessionsState` — every handler here
+/// goes through [`super::respond`]/[`respond_created`] rather than touching
+/// `SessionRegistry` directly.
+#[derive(Clone)]
+struct SessionsWriteState {
+    router: Arc<Router>,
+}
+
+/// Build the `POST`/`PUT`/`DELETE /sessions*` write route group.
+///
+/// Why: kept separate from `crate::serve::http::build_axum_router` so this
+/// resource group is unit-testable via `tower::util::ServiceExt::oneshot`
+/// on its own, exactly like `super::sessions::routes`.
+/// What: five write routes (see module docs), all sharing one
+/// `SessionsWriteState { router }`, `with_state`-erased to
+/// `axum::Router<()>` so the caller can `.merge()` it alongside
+/// `super::sessions::routes` into the daemon's main router.
+/// Test: `tests::create_session_returns_201_with_running_session`.
+pub fn routes(router: Arc<Router>) -> AxumRouter {
+    AxumRouter::new()
+        .route("/sessions", post(create_session))
+        .route("/sessions/{id}/messages", post(send_message))
+        .route("/sessions/{id}/cancel", post(cancel_session))
+        .route("/sessions/{id}/goal", put(set_goal).delete(clear_goal))
+        .with_state(SessionsWriteState { router })
+}
+
+/// Request body for `POST /sessions`, shaped like `session::protocol`'s
+/// private `CreateParams` (`project` stays a `String` here — it is
+/// forwarded verbatim into the RPC `params` `Value`, and `session.create`'s
+/// own `PathBuf` deserialization applies identically either way).
+#[derive(Deserialize)]
+struct CreateBody {
+    task: String,
+    #[serde(default)]
+    agent: Option<String>,
+    #[serde(default)]
+    project: Option<String>,
+}
+
+/// Request body for `POST /sessions/{id}/messages` — `session_id` comes
+/// from the path, so only `input` remains.
+#[derive(Deserialize)]
+struct SendMessageBody {
+    input: String,
+}
+
+/// Request body for `PUT /sessions/{id}/goal` — `session_id` comes from the
+/// path, so only `slot`/`text` remain (mirrors `protocol_goals`'s private
+/// `SetGoalParams`).
+#[derive(Deserialize)]
+struct SetGoalBody {
+    slot: usize,
+    text: String,
+}
+
+/// Request body for `DELETE /sessions/{id}/goal` — `session_id` comes from
+/// the path, so only `slot` remains (mirrors `protocol_goals`'s private
+/// `ClearGoalParams`). `DELETE` carrying a JSON body is unusual but valid
+/// HTTP; it keeps this route's shape symmetric with `PUT`'s rather than
+/// introducing a query-string convention nowhere else in this crate uses.
+#[derive(Deserialize)]
+struct ClearGoalBody {
+    slot: usize,
+}
+
+/// Like [`super::respond`] but reports `201 Created` on success instead of
+/// the implicit `200` `Json<Value>` carries — the one route in this module
+/// that creates a brand-new resource rather than acting on an existing one.
+///
+/// Why: every other handler in this crate returns [`RestResult`], whose
+/// `Ok` arm is a bare `Json<Value>` (200 via axum's blanket `IntoResponse`);
+/// `POST /sessions` needs a different status on the SAME success path
+/// without duplicating [`respond`]'s error-mapping logic.
+/// What: delegates to [`respond`], then rewraps a successful `Json<Value>`
+/// as `(StatusCode::CREATED, Json<Value>)`; the error arm is untouched —
+/// `rpc_error_to_status` already returns the correct 4xx/5xx.
+/// Test: `tests::create_session_returns_201_with_running_session`.
+async fn respond_created(
+    router: &Router,
+    method: &str,
+    params: Value,
+) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Response>)> {
+    respond(router, method, params)
+        .await
+        .map(|Json(v)| (StatusCode::CREATED, Json(v)))
+}
+
+/// `POST /sessions` -> `session.create`.
+///
+/// Why: the write half of the resource `GET /sessions` (Slice 2) already
+/// enumerates — the only way a REST-only client can bring a session into
+/// existence at all.
+/// What: `201 Created` with the new `Session` JSON on success; `400` if
+/// `task` is empty or `project` names no real directory (`-32003
+/// invalid_argument`, see `session::protocol::create`'s docs on the AC-16.2
+/// project-path reconciliation).
+/// Test: `tests::create_session_returns_201_with_running_session`,
+/// `tests::create_session_empty_task_returns_400`,
+/// `tests::create_session_malformed_body_returns_400`.
+async fn create_session(
+    State(state): State<SessionsWriteState>,
+    Json(body): Json<CreateBody>,
+) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Response>)> {
+    respond_created(
+        &state.router,
+        "session.create",
+        json!({"task": body.task, "agent": body.agent, "project": body.project}),
+    )
+    .await
+}
+
+/// `POST /sessions/{id}/messages` -> `session.send`.
+///
+/// Why: the client -> daemon input path as a REST resource — a "message"
+/// added to the session's input stream.
+/// What: `200` with `{"acknowledged": true}` on success; `404` for an
+/// unknown `id` (`-32007 session_not_found`).
+/// Test: `tests::send_message_returns_200_acknowledged`,
+/// `tests::send_message_missing_session_returns_404`,
+/// `tests::send_message_malformed_body_returns_400`.
+async fn send_message(
+    State(state): State<SessionsWriteState>,
+    Path(id): Path<String>,
+    Json(body): Json<SendMessageBody>,
+) -> RestResult {
+    respond(
+        &state.router,
+        "session.send",
+        json!({"session_id": id, "input": body.input}),
+    )
+    .await
+}
+
+/// `POST /sessions/{id}/cancel` -> `session.cancel`.
+///
+/// Why: explicit REST termination signal, mirroring the JSON-RPC method's
+/// cooperative-vs-immediate cancel semantics (see
+/// `session::protocol::cancel`'s docs) — this route never needs a body,
+/// `session_id` from the path is the whole request.
+/// What: `200` with the (possibly still-`running`, cooperative-cancel-
+/// pending) `Session` snapshot on success; `404` for an unknown `id`.
+/// Test: `tests::cancel_session_returns_200_with_session_json`,
+/// `tests::cancel_session_missing_session_returns_404`,
+/// `tests::cancel_session_is_idempotent`.
+async fn cancel_session(
+    State(state): State<SessionsWriteState>,
+    Path(id): Path<String>,
+) -> RestResult {
+    respond(&state.router, "session.cancel", json!({"session_id": id})).await
+}
+
+/// `PUT /sessions/{id}/goal` -> `session.set_goal`.
+///
+/// Why: the operator-facing REST entry point onto a session's 5 fixed goal
+/// slots (see `protocol_goals` module docs) — `PUT` because it is a full
+/// replace-by-slot, idempotent write.
+/// What: `200` with `{}` on success; `404` for an unknown `id`; `400` if
+/// the session has no transcript yet or `slot` is out of range (`-32003
+/// invalid_argument`, see `protocol_goals::set_goal`'s docs).
+/// Test: `tests::set_goal_returns_200_empty_object`,
+/// `tests::set_goal_missing_session_returns_404`,
+/// `tests::set_goal_malformed_body_returns_400`.
+async fn set_goal(
+    State(state): State<SessionsWriteState>,
+    Path(id): Path<String>,
+    Json(body): Json<SetGoalBody>,
+) -> RestResult {
+    respond(
+        &state.router,
+        "session.set_goal",
+        json!({"session_id": id, "slot": body.slot, "text": body.text}),
+    )
+    .await
+}
+
+/// `DELETE /sessions/{id}/goal` -> `session.clear_goal`.
+///
+/// Why: the operator-facing REST counterpart to `PUT` above.
+/// What: `200` with `{}` on success — clearing an already-empty slot is
+/// idempotent success, matching `protocol_goals::clear_goal`'s convention,
+/// so this route never needs its own idempotency special-case; `404` for an
+/// unknown `id`; `400` for an out-of-range `slot` (`-32003
+/// invalid_argument`).
+/// Test: `tests::clear_goal_returns_200_empty_object`,
+/// `tests::clear_goal_missing_session_returns_404`,
+/// `tests::clear_goal_malformed_body_returns_400`.
+async fn clear_goal(
+    State(state): State<SessionsWriteState>,
+    Path(id): Path<String>,
+    Json(body): Json<ClearGoalBody>,
+) -> RestResult {
+    respond(
+        &state.router,
+        "session.clear_goal",
+        json!({"session_id": id, "slot": body.slot}),
+    )
+    .await
+}
+
+#[cfg(test)]
+#[path = "sessions_write_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/serve/rest/sessions_write_tests.rs
+++ b/crates/trusty-code/src/serve/rest/sessions_write_tests.rs
@@ -1,0 +1,350 @@
+//! Route-level tests for `sessions_write.rs` (#2983 Slice 3), split into its
+//! own file purely to keep `sessions_write.rs` under the crate's 500-SLOC
+//! production cap — see that file's trailing `#[path = ...]` doc for the
+//! established convention (`crate::session::registry`'s identical
+//! `registry_tests.rs` split).
+//!
+//! Why: proves each write route end-to-end against a REAL
+//! `session::protocol::register` router (never RPC-layer mocks), exactly
+//! like `sessions.rs`'s own `tests` module — a route only passes if the
+//! whole stack (axum extraction -> `rest::respond` -> `Router::dispatch` ->
+//! the real `session.*` handler) agrees.
+//! What: one success case, one domain-error case (404 `session_not_found`
+//! for the four id-bearing routes; 400 `invalid_argument` for `POST
+//! /sessions`, which has no id to be missing), and one malformed-body case
+//! per route — except `POST /sessions/{id}/cancel`, which takes no request
+//! body at all (see `cancel_session`'s docs), so its third case is an
+//! idempotency check instead.
+//! Test: this IS the test module.
+
+use axum::Router as AxumRouter;
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::Value;
+use std::sync::Arc;
+use tower::util::ServiceExt;
+
+use super::routes;
+use crate::jsonrpc::Router;
+use crate::session::SessionRegistry;
+
+/// Build a router wired with every `session.*` method plus a fresh
+/// `SessionRegistry`, then this module's write route group over it —
+/// mirrors `sessions::tests::app_and_registry`.
+fn app_and_registry() -> (AxumRouter, Arc<SessionRegistry>) {
+    let sessions = Arc::new(SessionRegistry::new());
+    let mut router = Router::new();
+    crate::session::protocol::register(&mut router, sessions.clone());
+    let app = routes(Arc::new(router));
+    (app, sessions)
+}
+
+/// Seed `id`'s `pm_transcript` the same way a real `task.run` would, so
+/// `set_goal`/`clear_goal` get past the "no transcript yet" guard — mirrors
+/// `protocol_goals::tests::seed_pm_transcript`.
+fn seed_pm_transcript(sessions: &SessionRegistry, id: &str) {
+    let transcript = sessions
+        .begin_pm_transcript(id, "you are the pm", "first task")
+        .unwrap();
+    sessions.store_pm_transcript(id, transcript);
+}
+
+async fn body_json(response: axum::response::Response) -> Value {
+    let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+async fn send(
+    app: &AxumRouter,
+    method: &str,
+    uri: &str,
+    body: Option<&str>,
+) -> axum::response::Response {
+    let mut builder = Request::builder().method(method).uri(uri);
+    if body.is_some() {
+        builder = builder.header("content-type", "application/json");
+    }
+    let body = match body {
+        Some(b) => Body::from(b.to_string()),
+        None => Body::empty(),
+    };
+    app.clone()
+        .oneshot(builder.body(body).unwrap())
+        .await
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------
+// POST /sessions -> session.create
+// ---------------------------------------------------------------------
+
+/// A well-formed `POST /sessions` must return `201 Created` with a running
+/// `Session` JSON.
+#[tokio::test]
+async fn create_session_returns_201_with_running_session() {
+    let (app, _sessions) = app_and_registry();
+
+    let resp = send(&app, "POST", "/sessions", Some(r#"{"task": "do it"}"#)).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let v = body_json(resp).await;
+    assert_eq!(v["status"], "running");
+    assert_eq!(v["task"], "do it");
+}
+
+/// An empty `task` must map to `400` (`-32003 invalid_argument`) — the
+/// `POST /sessions` stand-in for the other routes' "missing session" 404
+/// case, since a create request has no `session_id` to be missing.
+#[tokio::test]
+async fn create_session_empty_task_returns_400() {
+    let (app, _sessions) = app_and_registry();
+
+    let resp = send(&app, "POST", "/sessions", Some(r#"{"task": "   "}"#)).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], -32003);
+}
+
+/// Syntactically invalid JSON must never reach the handler — axum's `Json`
+/// extractor rejects it with a client error before `session.create` runs.
+#[tokio::test]
+async fn create_session_malformed_body_returns_400() {
+    let (app, _sessions) = app_and_registry();
+
+    let resp = send(&app, "POST", "/sessions", Some("{not valid json")).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------
+// POST /sessions/{id}/messages -> session.send
+// ---------------------------------------------------------------------
+
+/// A message sent to a real session must return `200` with
+/// `{"acknowledged": true}`.
+#[tokio::test]
+async fn send_message_returns_200_acknowledged() {
+    let (app, sessions) = app_and_registry();
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let resp = send(
+        &app,
+        "POST",
+        &format!("/sessions/{}/messages", session.id),
+        Some(r#"{"input": "hi"}"#),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["acknowledged"], true);
+}
+
+/// Sending a message to an unknown session must be a real `404` with a
+/// `session_not_found` envelope.
+#[tokio::test]
+async fn send_message_missing_session_returns_404() {
+    let (app, _sessions) = app_and_registry();
+
+    let resp = send(
+        &app,
+        "POST",
+        "/sessions/does-not-exist/messages",
+        Some(r#"{"input": "hi"}"#),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], -32007);
+}
+
+/// A body missing the required `input` field must be rejected by the `Json`
+/// extractor before `session.send` runs.
+#[tokio::test]
+async fn send_message_malformed_body_returns_400() {
+    let (app, sessions) = app_and_registry();
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let resp = send(
+        &app,
+        "POST",
+        &format!("/sessions/{}/messages", session.id),
+        Some(r#"{}"#),
+    )
+    .await;
+    assert!(resp.status().is_client_error());
+}
+
+// ---------------------------------------------------------------------
+// POST /sessions/{id}/cancel -> session.cancel
+// ---------------------------------------------------------------------
+
+/// Cancelling a real, non-executing session must return `200` with the
+/// terminal `Session` snapshot.
+#[tokio::test]
+async fn cancel_session_returns_200_with_session_json() {
+    let (app, sessions) = app_and_registry();
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let resp = send(
+        &app,
+        "POST",
+        &format!("/sessions/{}/cancel", session.id),
+        None,
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["status"], "cancelled");
+}
+
+/// Cancelling an unknown session must be a real `404`.
+#[tokio::test]
+async fn cancel_session_missing_session_returns_404() {
+    let (app, _sessions) = app_and_registry();
+
+    let resp = send(&app, "POST", "/sessions/does-not-exist/cancel", None).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], -32007);
+}
+
+/// Cancelling twice must be idempotent success both times, matching
+/// `session::protocol::cancel`'s documented semantics — this route's
+/// substitute for the "malformed body" case, since it takes no body.
+#[tokio::test]
+async fn cancel_session_is_idempotent() {
+    let (app, sessions) = app_and_registry();
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let first = send(
+        &app,
+        "POST",
+        &format!("/sessions/{}/cancel", session.id),
+        None,
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK);
+
+    let second = send(
+        &app,
+        "POST",
+        &format!("/sessions/{}/cancel", session.id),
+        None,
+    )
+    .await;
+    assert_eq!(second.status(), StatusCode::OK);
+}
+
+// ---------------------------------------------------------------------
+// PUT /sessions/{id}/goal -> session.set_goal
+// ---------------------------------------------------------------------
+
+/// Setting a goal slot on a session with a seeded transcript must return
+/// `200` with `{}`.
+#[tokio::test]
+async fn set_goal_returns_200_empty_object() {
+    let (app, sessions) = app_and_registry();
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    seed_pm_transcript(&sessions, &session.id);
+
+    let resp = send(
+        &app,
+        "PUT",
+        &format!("/sessions/{}/goal", session.id),
+        Some(r#"{"slot": 2, "text": "ship it"}"#),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v, serde_json::json!({}));
+}
+
+/// Setting a goal on an unknown session must be a real `404`.
+#[tokio::test]
+async fn set_goal_missing_session_returns_404() {
+    let (app, _sessions) = app_and_registry();
+
+    let resp = send(
+        &app,
+        "PUT",
+        "/sessions/does-not-exist/goal",
+        Some(r#"{"slot": 1, "text": "x"}"#),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], -32007);
+}
+
+/// A body missing the required `text` field must be rejected by the `Json`
+/// extractor before `session.set_goal` runs.
+#[tokio::test]
+async fn set_goal_malformed_body_returns_400() {
+    let (app, sessions) = app_and_registry();
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let resp = send(
+        &app,
+        "PUT",
+        &format!("/sessions/{}/goal", session.id),
+        Some(r#"{"slot": 1}"#),
+    )
+    .await;
+    assert!(resp.status().is_client_error());
+}
+
+// ---------------------------------------------------------------------
+// DELETE /sessions/{id}/goal -> session.clear_goal
+// ---------------------------------------------------------------------
+
+/// Clearing a previously-set goal slot must return `200` with `{}`.
+#[tokio::test]
+async fn clear_goal_returns_200_empty_object() {
+    let (app, sessions) = app_and_registry();
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    seed_pm_transcript(&sessions, &session.id);
+    sessions.set_goal(&session.id, 3, "temp").unwrap();
+
+    let resp = send(
+        &app,
+        "DELETE",
+        &format!("/sessions/{}/goal", session.id),
+        Some(r#"{"slot": 3}"#),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v, serde_json::json!({}));
+}
+
+/// Clearing a goal on an unknown session must be a real `404`.
+#[tokio::test]
+async fn clear_goal_missing_session_returns_404() {
+    let (app, _sessions) = app_and_registry();
+
+    let resp = send(
+        &app,
+        "DELETE",
+        "/sessions/does-not-exist/goal",
+        Some(r#"{"slot": 1}"#),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], -32007);
+}
+
+/// A body missing the required `slot` field must be rejected by the `Json`
+/// extractor before `session.clear_goal` runs.
+#[tokio::test]
+async fn clear_goal_malformed_body_returns_400() {
+    let (app, sessions) = app_and_registry();
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let resp = send(
+        &app,
+        "DELETE",
+        &format!("/sessions/{}/goal", session.id),
+        Some(r#"{}"#),
+    )
+    .await;
+    assert!(resp.status().is_client_error());
+}


### PR DESCRIPTION
## Summary

REST gateway Slice 3 (#2983): adds the `session.*` **write** routes on top of Slice 1's `rest::call`/`rpc_error_to_status` bridge and Slice 2's read routes. Every handler is a thin wrapper — extract path/body, build JSON-RPC `params`, call `rest::respond` (or the new `respond_created` for the one non-200 success case) — so a REST route and its JSON-RPC method twin always run the exact same handler (zero duplicated business logic).

## Route table

| HTTP | Path | RPC method | Success | Error(s) | Rationale |
|---|---|---|---|---|---|
| `POST` | `/sessions` | `session.create` | `201 Created` | `400` (`-32003 invalid_argument` — empty `task` or `project` names no real directory) | The only route in this slice that mints a brand-new resource — standard REST creation convention, unlike every other route below which acts on an existing resource and keeps `200`. |
| `POST` | `/sessions/{id}/messages` | `session.send` | `200 OK` (`{"acknowledged": true}`) | `404` (`-32007 session_not_found`) | Acknowledges synchronously with no new addressable resource/id returned — `200` fits better than `201`/`202`. |
| `POST` | `/sessions/{id}/cancel` | `session.cancel` | `200 OK` (`Session` snapshot) | `404` | Action on an existing resource, not a creation; mirrors `session.cancel`'s cooperative-vs-immediate semantics (may still read `status: "running"` if cancellation is cooperative-pending). |
| `PUT` | `/sessions/{id}/goal` | `session.set_goal` | `200 OK` (`{}`) | `404`; `400` (no transcript yet / out-of-range `slot`) | Idempotent replace-by-slot — canonical `PUT` semantics. |
| `DELETE` | `/sessions/{id}/goal` | `session.clear_goal` | `200 OK` (`{}`) | `404`; `400` (out-of-range `slot`) | Kept `200`+`{}` rather than `204` to stay on the same `RestResult` shape every other handler in this crate returns — `204` would need a distinct body-less return type for one route's sake. Idempotent (clearing an empty slot succeeds), matching `protocol_goals::clear_goal`'s own convention. |

Malformed JSON bodies never reach a handler — axum's `Json<T>` extractor rejects them (`400` syntax error / `422` data error) before any `session.*` method runs; no handler here hand-rolls body validation.

## Files added/changed

- `/Users/masa/trusty-mpm-projects/bobmatnyc/trusty-tools/.base/.claude/worktrees/tcode-rest-s3/crates/trusty-code/src/serve/rest/sessions_write.rs` (new) — the 5 write handlers, request-body structs, `respond_created` helper.
- `/Users/masa/trusty-mpm-projects/bobmatnyc/trusty-tools/.base/.claude/worktrees/tcode-rest-s3/crates/trusty-code/src/serve/rest/sessions_write_tests.rs` (new) — route-level tests, split out purely for the 500-SLOC production cap (mirrors `session::registry`'s `registry_tests.rs` `#[path = ...]` convention).
- `/Users/masa/trusty-mpm-projects/bobmatnyc/trusty-tools/.base/.claude/worktrees/tcode-rest-s3/crates/trusty-code/src/serve/rest/mod.rs` — declares `pub mod sessions_write;`, updated module doc to describe Slice 3.
- `/Users/masa/trusty-mpm-projects/bobmatnyc/trusty-tools/.base/.claude/worktrees/tcode-rest-s3/crates/trusty-code/src/serve/http.rs` — `build_axum_router` now merges `rest::sessions_write::routes(...)` alongside Slice 2's read routes.
- `/Users/masa/trusty-mpm-projects/bobmatnyc/trusty-tools/.base/.claude/worktrees/tcode-rest-s3/crates/trusty-code/CHANGELOG.md` — `[Unreleased] > Added` entry for Slice 3.

## Test coverage

15 new tests in `sessions_write_tests.rs`, all driving the real `session::protocol::register` router via `tower::ServiceExt::oneshot` (no RPC-layer mocks) — 3 per route:
- `POST /sessions`: success (201), empty-task 400 (stand-in for "missing session" since create has no id), malformed-body 400.
- `POST /sessions/{id}/messages`: success (200 acknowledged), missing-session 404, malformed-body 400.
- `POST /sessions/{id}/cancel`: success (200), missing-session 404, idempotent-double-cancel (stand-in for "malformed body" — this route takes no request body at all).
- `PUT /sessions/{id}/goal`: success (200 `{}`), missing-session 404, malformed-body 400.
- `DELETE /sessions/{id}/goal`: success (200 `{}`), missing-session 404, malformed-body 400.

Manually verified (per task instructions, in place of `scripts/check_test_pointers.sh`, which is known to hang) that every `Test:` doc-comment pointer in `sessions_write.rs` names a real test function in `sessions_write_tests.rs` that actually passed.

## Gate evidence (raw tails)

### `cargo build -p trusty-code`
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 44.02s
```

### `cargo test -p trusty-code --lib -- --test-threads=1`
```
test serve::rest::sessions_write::tests::cancel_session_is_idempotent ... ok
test serve::rest::sessions_write::tests::cancel_session_missing_session_returns_404 ... ok
test serve::rest::sessions_write::tests::cancel_session_returns_200_with_session_json ... ok
test serve::rest::sessions_write::tests::clear_goal_malformed_body_returns_400 ... ok
test serve::rest::sessions_write::tests::clear_goal_missing_session_returns_404 ... ok
test serve::rest::sessions_write::tests::clear_goal_returns_200_empty_object ... ok
test serve::rest::sessions_write::tests::create_session_empty_task_returns_400 ... ok
test serve::rest::sessions_write::tests::create_session_malformed_body_returns_400 ... ok
test serve::rest::sessions_write::tests::create_session_returns_201_with_running_session ... ok
test serve::rest::sessions_write::tests::send_message_malformed_body_returns_400 ... ok
test serve::rest::sessions_write::tests::send_message_missing_session_returns_404 ... ok
test serve::rest::sessions_write::tests::send_message_returns_200_acknowledged ... ok
test serve::rest::sessions_write::tests::set_goal_malformed_body_returns_400 ... ok
test serve::rest::sessions_write::tests::set_goal_missing_session_returns_404 ... ok
test serve::rest::sessions_write::tests::set_goal_returns_200_empty_object ... ok
...
test result: ok. 1161 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 9.71s
```

**Flake workaround note:** on one earlier full-suite run (parallel threads), `run_task::tests::exit_code_reflects_run_failure` and `run_task::tests::repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap` failed with `could not reach trusty-memory at http://127.0.0.1:19999` — the documented port-19999 contention flake (issue #3003, not in scope here). Re-ran each in isolation and both passed:
```
test run_task::tests::exit_code_reflects_run_failure ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1164 filtered out; finished in 0.06s

test run_task::tests::repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1164 filtered out; finished in 0.04s
```
The subsequent full `--test-threads=1` run (pasted above) passed clean with 0 failures — no flake hit that time.

### `cargo test -p trusty-code --tests`
```
     Running tests/task_e2e.rs (target/debug/deps/task_e2e-4b8ed2ee5bfacc2a)

running 6 tests
test task_run_rejects_a_second_overlapping_run ... ok
test non_git_project_binds_as_directory_not_projectless ... ok
test projectless_task_runs_end_to_end ... ok
test task_run_then_get_transcript_exposes_turns_usage_and_cost ... ok
test task_run_streams_live_tool_events_to_completion ... ok
test git_project_binds_as_git_repo ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.60s
```
(all other integration test binaries in this run — `m1_cutline_e2e`, `readiness_e2e`, `recall_content_e2e`, `search_hits_e2e`, `session_e2e`, plus the doctest-style adapter tests — also passed 0 failed; full output captured during the run.)

### `cargo clippy --workspace --all-targets -- -D warnings`
```
    Checking trusty-agents-local v0.1.3 (.../crates/trusty-agents-local)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 42s
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```
(exit code 0; the only warnings printed are pre-existing, unrelated to this change — `tga`'s MSRV-vs-clippy.toml mismatch and a future-incompat notice for a transitive dependency.)

### `cargo fmt --check`
First run found one line that needed rewrapping in the new test file; ran `cargo fmt -p trusty-code` to fix it, then re-ran `--check` clean (empty diff, exit 0).

### `bash scripts/check_line_cap.sh`
```
line-cap: 9 allowlisted, 0 violations — OK.
```
(`sessions_write.rs`: 263 SLOC, production cap 500; `sessions_write_tests.rs`: 350 SLOC, test-file cap 1500 — both well clear, no allowlist entry needed.)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
