### PR TITLE
fix(trusty-code): eliminate fixed-port contention in run_task tests (closes #3003)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- `catchup::tests::*` no longer mutates the process-global `TRUSTY_MEMORY_URL`
+  env var to point at a fixed, unreachable `127.0.0.1:19999` — under
+  `cargo test`'s default parallelism, that unguarded `unsafe { set_var(..) }`
+  (with no matching cleanup) leaked into every other test in the same lib
+  binary that resolves a trusty-memory URL via `pm_catchup_context`
+  (e.g. `run_task::tests::repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap`),
+  producing false-red gates on unrelated PRs. `pm_catchup_context` is now
+  split into a thin env-resolving wrapper and a testable
+  `pm_catchup_context_with_memory_url(project_dir, memory_url)` that takes the
+  target URL as a parameter, so tests thread in a guaranteed-unreachable
+  address directly with no shared mutable global, no lock, and no cleanup
+  required (closes #3003).
 - the unified-diff applier (`tools/fs/edit_format/diff.rs`) no longer errors
   on a `git diff`-style `\ No newline at end of file` footer marker inside a
   hunk body — the marker is metadata, not content, so it no longer fails the

--- a/crates/trusty-code/src/catchup.rs
+++ b/crates/trusty-code/src/catchup.rs
@@ -40,13 +40,41 @@ use trusty_common::catchup::{CatchupOptions, run_catchup};
 /// What: resolves `memory_url` via
 /// [`trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable`] (env override
 /// `TRUSTY_MEMORY_URL` first, else the daemon's discovered bound address,
-/// else a fail-fast placeholder — issue #2030), builds `CatchupOptions` with
-/// sane limits, calls `run_catchup` with `advance_watermark = false`, and
-/// returns `Some(digest)` when the result is non-whitespace, else `None`.
+/// else a fail-fast placeholder — issue #2030), then delegates to
+/// [`pm_catchup_context_with_memory_url`].
 /// Test: `catchup::tests::pm_catchup_context_does_not_panic_on_empty_repo`.
 pub async fn pm_catchup_context(project_dir: &Path) -> Option<String> {
     let memory_url = trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable();
+    pm_catchup_context_with_memory_url(project_dir, memory_url).await
+}
 
+/// Same as [`pm_catchup_context`], but with the trusty-memory base URL passed
+/// in explicitly rather than resolved from the process-wide `TRUSTY_MEMORY_URL`
+/// env var (issue #3003).
+///
+/// Why: [`pm_catchup_context`]'s tests need a guaranteed-unreachable dial
+/// target so the fail-open path is exercised deterministically. The previous
+/// approach mutated the process-global `TRUSTY_MEMORY_URL` env var via
+/// `unsafe { std::env::set_var(..) }` with no cleanup and no cross-test lock —
+/// `cargo test`'s default parallelism runs every test in this crate's lib
+/// binary as threads of ONE process, so that leaked env value was observable
+/// by any concurrently-running test whose code path also calls
+/// [`trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable`]
+/// (e.g. `run_task::tests::*`, via `execute_run_task` -> `pm_catchup_context`),
+/// producing false-red flakes unrelated to the leaking test itself. Threading
+/// `memory_url` through as a parameter — the same pattern
+/// [`crate::session::memory_sink::TurnMemorySink::with_capacity`] already uses
+/// for the identical reason — removes the shared mutable global entirely, so
+/// tests need no lock and no cleanup.
+/// What: builds `CatchupOptions` with `memory_url` and sane limits, calls
+/// `run_catchup` with `advance_watermark = false`, and returns `Some(digest)`
+/// when the result is non-whitespace, else `None`.
+/// Test: `catchup::tests::pm_catchup_context_does_not_panic_on_empty_repo`,
+/// `catchup::tests::pm_catchup_context_does_not_panic_on_non_git_dir`.
+async fn pm_catchup_context_with_memory_url(
+    project_dir: &Path,
+    memory_url: String,
+) -> Option<String> {
     let opts = CatchupOptions {
         project_dir: project_dir.to_path_buf(),
         memory_url,
@@ -102,12 +130,26 @@ mod tests {
             .output();
     }
 
+    /// A guaranteed-never-listening loopback address (port 1 is a reserved,
+    /// unassigned TCP port) so a connection attempt fails fast rather than
+    /// hanging or timing out — the same convention
+    /// `trusty_common::mcp::memory_rpc`'s own `UNREACHABLE_PLACEHOLDER` uses.
+    ///
+    /// Why (#3003): passed directly to
+    /// [`pm_catchup_context_with_memory_url`] instead of mutating the
+    /// process-global `TRUSTY_MEMORY_URL` env var, so this test needs no lock
+    /// and cannot leak state into concurrently-running tests (e.g.
+    /// `run_task::tests::*`, which also resolves a trusty-memory URL via
+    /// `pm_catchup_context` inside `execute_run_task`).
+    const UNREACHABLE_MEMORY_URL: &str = "http://127.0.0.1:1";
+
     /// Verifies that `pm_catchup_context` does not panic and returns either
     /// `Some` or `None` consistently when the memory daemon is unreachable.
     ///
     /// Why: tests can never assume a live trusty-memory daemon; this test
     /// points at an unreachable port so the palace section degrades gracefully.
-    /// What: creates a temp dir with a git repo, calls `pm_catchup_context`,
+    /// What: creates a temp dir with a git repo, calls
+    /// `pm_catchup_context_with_memory_url` with [`UNREACHABLE_MEMORY_URL`],
     /// asserts no panic and that the returned value is well-formed.
     /// Test: this test.
     #[tokio::test]
@@ -115,16 +157,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         init_git_repo(&tmp);
 
-        // Point memory_url at an unreachable port so palace fetch fails-open.
-        // SAFETY: single-threaded test; no concurrent env reads.
-        unsafe {
-            std::env::set_var(
-                trusty_common::mcp::memory_rpc::TRUSTY_MEMORY_URL_ENV,
-                "http://127.0.0.1:19999",
-            )
-        };
-
-        let result = pm_catchup_context(tmp.path()).await;
+        let result =
+            pm_catchup_context_with_memory_url(tmp.path(), UNREACHABLE_MEMORY_URL.to_string())
+                .await;
 
         // Result is either Some(non-empty) or None — never panics.
         match &result {
@@ -162,23 +197,17 @@ mod tests {
     ///
     /// Why: operators may invoke `tcode run-task` outside a git repo; the PM
     /// prompt must still be assembled without aborting.
-    /// What: calls `pm_catchup_context` on a plain temp dir (no git init) and
+    /// What: calls `pm_catchup_context_with_memory_url` with
+    /// [`UNREACHABLE_MEMORY_URL`] on a plain temp dir (no git init) and
     /// asserts that the function returns without panicking.
     /// Test: this test.
     #[tokio::test]
     async fn pm_catchup_context_does_not_panic_on_non_git_dir() {
         let tmp = TempDir::new().unwrap();
 
-        // Point memory_url at an unreachable port.
-        // SAFETY: single-threaded test; no concurrent env reads.
-        unsafe {
-            std::env::set_var(
-                trusty_common::mcp::memory_rpc::TRUSTY_MEMORY_URL_ENV,
-                "http://127.0.0.1:19999",
-            )
-        };
-
         // Must not panic — fall through to None or Some(whitespace-only) path.
-        let _result = pm_catchup_context(tmp.path()).await;
+        let _result =
+            pm_catchup_context_with_memory_url(tmp.path(), UNREACHABLE_MEMORY_URL.to_string())
+                .await;
     }
 }


### PR DESCRIPTION
## Summary

- `catchup::tests::pm_catchup_context_does_not_panic_on_{empty_repo,non_git_dir}` mutated the **process-global** `TRUSTY_MEMORY_URL` env var to point at a fixed, unreachable `127.0.0.1:19999`, via an unguarded `unsafe { std::env::set_var(..) }` with **no cleanup and no cross-test lock**.
- Under `cargo test`'s default parallelism, every test in `trusty-code`'s lib binary runs as a thread of **one process**, so the leaked value was observable by any concurrently-running test that also resolves a trusty-memory URL via `pm_catchup_context` — most notably `run_task::tests::repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap`, which `execute_run_task` calls internally. This produced false-red gates on unrelated PRs (reported at least 5x on 2026-07-18 across independent worktrees).
- Reproduced locally: running `cargo test -p trusty-code --lib` repeatedly at default parallelism reliably failed with `catchup: could not reach trusty-memory at http://127.0.0.1:19999` bleeding into the redelegation-cap test's assertion.

## Fix

Split `pm_catchup_context` into a thin env-resolving wrapper and a new, testable `pm_catchup_context_with_memory_url(project_dir, memory_url)` that takes the trusty-memory base URL as a parameter — the same pattern `session::memory_sink::TurnMemorySink::with_capacity` already uses for the identical reason (its own doc comment calls out avoiding "mutating the process-global `TRUSTY_MEMORY_URL` env var (unsafe across parallel tests)").

Both tests now call `pm_catchup_context_with_memory_url` directly with a guaranteed-unreachable `http://127.0.0.1:1` (matching `trusty_common::mcp::memory_rpc`'s own `UNREACHABLE_PLACEHOLDER` convention). No env var mutation, no lock, no cleanup required — the root cause (a shared mutable global) is removed rather than serialized around.

Production call sites (`task::executor.rs`, `run_task/mod.rs`) are unaffected — `pm_catchup_context(project_dir)`'s public signature and behavior are unchanged.

## Test plan

- [x] `cargo build -p trusty-code`
- [x] `cargo test -p trusty-code --lib` — **3 consecutive runs**, default parallelism (no `--test-threads=1`), all green: `1162 passed; 0 failed` each run
- [x] `cargo test -p trusty-code --tests` — all green (lib + every integration test binary)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (`9 allowlisted, 0 violations`)

**Note on local verification isolation:** this dev machine has several already-running `trusty-memory`/`trusty-search` daemons (real discovery files under `~/Library/Application Support/...`) left over from unrelated concurrent sessions. Those get discovered by `run_task`'s own (unrelated, production) fire-and-forget background indexing and occasionally interfere with other `run_task` tests (e.g. `no_changes_yields_no_changes_exit` seeing an unexpected `.trusty-search/index.redb` diff) — confirmed unrelated to #3003 (no hardcoded port involved, pure real-daemon discovery) and **will not occur in CI**, which has no such daemon running. The proof runs above set `TRUSTY_DATA_DIR_OVERRIDE=/tmp/tcode-test-data-override` to point discovery at an empty directory, neutralizing this personal-machine-only variable so the actual #3003 fix could be verified cleanly; this does not disable parallelism or touch `--test-threads`.

Closes #3003.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools