### PR TITLE
feat(trusty-code): expand default roster to 31 embedded agents with reviewer tools restrictions (Slice E3, refs #2958)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -44,12 +44,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   filesystem access. Not yet wired into `assets::DEFAULT_AGENTS` or
   `agents::load_all_agents`'s dispatchable fallback; that roster expansion is
   a separate, later slice (E3).
-- **31-agent dispatchable default roster (closes #2958, epic #2892 Slice E3
-  — final slice).** `assets::DEFAULT_AGENTS` grows from 3 to 31 entries: the
-  original `engineer`/`qa-agent`/`code-reviewer` plus the 28 coding-relevant
-  tm agents Slice E2 bundled. `agents::load_embedded_default_agents` now
-  routes each of the 28 through the new `EmbeddedAgent::Composed` variant,
-  resolving `extends:` chains via `agents::md_loader::project_embedded_md_with_extends`
+- **31-agent embedded roster wired into the composition layer (refs #2958,
+  epic #2892 Slice E3).** `assets::DEFAULT_AGENTS` grows from 3 to 31
+  entries: the original `engineer`/`qa-agent`/`code-reviewer` plus the 28
+  coding-relevant tm agents Slice E2 bundled. `agents::load_embedded_default_agents`
+  now routes each of the 28 through the new `EmbeddedAgent::Composed`
+  variant, resolving `extends:` chains via `agents::md_loader::project_embedded_md_with_extends`
   against `assets::EMBEDDED_TM_AGENT_SOURCES`; the original 3 keep the
   existing flat `EmbeddedAgent::Direct` path. The 5 `BASE-*` templates remain
   extends-sources only — never dispatchable (`assets::tests::base_templates_are_never_dispatchable`).
@@ -57,16 +57,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   decision) specifically to avoid colliding with tcode's own `engineer`
   default; `assets::tests::no_name_collisions_across_the_31_agent_roster`
   pins that no collision exists across the final 31.
+  **Known gap, NOT fixed in this slice (#3046):** the embedded fallback this
+  roster feeds (`agents::load_all_agents`'s empty/invalid-disk branch) has no
+  reachable production caller today — a live CLI reproduction on a fresh
+  project showed `tcode run-task rust-engineer` AND `tcode run-task engineer`
+  (one of the original 3, predating this slice) both fail with "agent source
+  not found". The composition layer and the 31-agent roster definition are
+  complete and covered by `assets::tests::*`/`agents::tests::*` (which call
+  `load_all_agents`/`load_embedded_default_agents` directly), but the CLI
+  wiring that would let a fresh project actually dispatch one of these 31
+  names end-to-end is tracked separately as #3046 and intentionally out of
+  scope here.
   **Tools-restriction deviation (Bob's 2026-07-18 ruling):** four
   reviewer-intent roster agents — `qa`, `code-critic`, `code-analyzer`,
   `web-qa` — now carry an explicit restrictive `tools:` frontmatter override
   in their tcode copy (`read_file`, `grep`, `glob`, `list_dir`,
   `search_code`, `use_skill`, `finish_task` — no `write_file`/`edit`/`bash`,
   mirroring tcode's own `code-reviewer` default), deliberately deviating
-  those four files from byte-parity with trusty-mpm's source. `documentation`
-  and `research` stay byte-identical and unrestricted per the same ruling — a
-  future E4 CI staleness guard (diffing tcode's copies against trusty-mpm's
-  source) must whitelist the `tools:` line in exactly those four files.
+  those four files from byte-parity with trusty-mpm's source. A code-critic
+  review round on the same PR additionally found the prose in `web-qa.md`,
+  `qa.md`, and `code-analyzer.md` still instructed write/bash actions the new
+  allowlist denies (creating test scripts, running `CI=true npm test`,
+  `ps aux` monitoring, generating-and-running a review script); all three
+  were reworded in this slice to a genuinely read-only frame — findings plus
+  concrete, ready-to-run recommendations handed off to an engineer/ops/CI to
+  execute, never executed by the agent itself. `documentation` and `research`
+  stay byte-identical and unrestricted per the same ruling — a future E4 CI
+  staleness guard (diffing tcode's copies against trusty-mpm's source) must
+  whitelist the `tools:` line AND the reworded prose sections in these files.
 - **REST resource gateway — `session.*` write routes (#2983, #587, Slice 3).**
   New `POST`/`PUT`/`DELETE` routes on `tcode serve --http`, each a thin
   `axum` handler calling `rest::respond` (or the new `respond_created` for

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -44,6 +44,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   filesystem access. Not yet wired into `assets::DEFAULT_AGENTS` or
   `agents::load_all_agents`'s dispatchable fallback; that roster expansion is
   a separate, later slice (E3).
+- **31-agent dispatchable default roster (closes #2958, epic #2892 Slice E3
+  — final slice).** `assets::DEFAULT_AGENTS` grows from 3 to 31 entries: the
+  original `engineer`/`qa-agent`/`code-reviewer` plus the 28 coding-relevant
+  tm agents Slice E2 bundled. `agents::load_embedded_default_agents` now
+  routes each of the 28 through the new `EmbeddedAgent::Composed` variant,
+  resolving `extends:` chains via `agents::md_loader::project_embedded_md_with_extends`
+  against `assets::EMBEDDED_TM_AGENT_SOURCES`; the original 3 keep the
+  existing flat `EmbeddedAgent::Direct` path. The 5 `BASE-*` templates remain
+  extends-sources only — never dispatchable (`assets::tests::base_templates_are_never_dispatchable`).
+  mpm's own `engineer` agent stays excluded from the roster (upstream #2958
+  decision) specifically to avoid colliding with tcode's own `engineer`
+  default; `assets::tests::no_name_collisions_across_the_31_agent_roster`
+  pins that no collision exists across the final 31.
+  **Tools-restriction deviation (Bob's 2026-07-18 ruling):** four
+  reviewer-intent roster agents — `qa`, `code-critic`, `code-analyzer`,
+  `web-qa` — now carry an explicit restrictive `tools:` frontmatter override
+  in their tcode copy (`read_file`, `grep`, `glob`, `list_dir`,
+  `search_code`, `use_skill`, `finish_task` — no `write_file`/`edit`/`bash`,
+  mirroring tcode's own `code-reviewer` default), deliberately deviating
+  those four files from byte-parity with trusty-mpm's source. `documentation`
+  and `research` stay byte-identical and unrestricted per the same ruling — a
+  future E4 CI staleness guard (diffing tcode's copies against trusty-mpm's
+  source) must whitelist the `tools:` line in exactly those four files.
 - **REST resource gateway — `session.*` write routes (#2983, #587, Slice 3).**
   New `POST`/`PUT`/`DELETE` routes on `tcode serve --http`, each a thin
   `axum` handler calling `rest::respond` (or the new `respond_created` for

--- a/crates/trusty-code/src/agents/md_loader.rs
+++ b/crates/trusty-code/src/agents/md_loader.rs
@@ -125,11 +125,14 @@ pub(crate) fn project_embedded_md(default_name: &str, raw: &str) -> AgentConfig 
 /// on-disk `.md` agents share one frontmatter -> `AgentConfig` mapping. Any
 /// `AgentBuildError` (unknown name, cycle, depth exceeded, malformed
 /// frontmatter anywhere in the chain) is surfaced as a descriptive
-/// `anyhow::Error`, never a panic. Not yet called from
-/// `crate::assets::DEFAULT_AGENTS` / `load_all_agents`'s fallback --
-/// wiring the 28 roster agents in as dispatchable defaults is Slice E3.
+/// `anyhow::Error`, never a panic. Called from
+/// `crate::agents::load_embedded_default_agents` for every
+/// `crate::assets::EmbeddedAgent::Composed` entry in `DEFAULT_AGENTS` (Slice
+/// E3, #2958) -- the 28 roster agents are dispatchable defaults as of this
+/// slice.
 /// Test: `project_embedded_md_with_extends_resolves_rust_engineer_from_base_engineer`,
-/// `project_embedded_md_with_extends_unknown_name_errors`.
+/// `project_embedded_md_with_extends_unknown_name_errors`,
+/// `assets::tests::default_agents_parse_and_names_match`.
 pub fn project_embedded_md_with_extends(name: &str) -> anyhow::Result<AgentConfig> {
     let sources =
         build_in_memory_source_map(crate::assets::EMBEDDED_TM_AGENT_SOURCES.iter().copied());

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -13,12 +13,12 @@
 //! provides `discover_agents` for scanning an agents directory (`*.md`
 //! only — a coexisting `*.toml` is warned about and skipped, never parsed),
 //! and `load_all_agents` for loading every discovered `.md` config.
-//! `load_all_agents` falls back to `crate::assets::DEFAULT_AGENTS` (#2895)
-//! when the *parsed* result is empty — not merely when no paths were
-//! discovered — so a `.claude/agents/` dir that exists but holds only
-//! unparseable (or exclusively orphaned-`.toml`) configs still yields a
-//! usable `engineer`/`qa-agent`/`code-reviewer` set instead of silently
-//! starting with zero agents. A disk directory with even one
+//! `load_all_agents` falls back to `crate::assets::DEFAULT_AGENTS` (#2895;
+//! expanded from 3 to 31 agents in Slice E3, #2958) when the *parsed* result
+//! is empty — not merely when no paths were discovered — so a
+//! `.claude/agents/` dir that exists but holds only unparseable (or
+//! exclusively orphaned-`.toml`) configs still yields a usable roster instead
+//! of silently starting with zero agents. A disk directory with even one
 //! successfully-parsed config is treated as the project opting in to its own
 //! catalog, so it is used as-is and the embedded defaults are not merged in.
 //! Test: `discover_agents` tests place `.md` (and, for the orphan-warning
@@ -153,22 +153,49 @@ pub fn load_all_agents(dir: &Path) -> Vec<AgentConfig> {
 /// Project `crate::assets::DEFAULT_AGENTS` in-memory into `AgentConfig`s.
 ///
 /// Why: The embedded fallback path for `load_all_agents` — no disk I/O, no
-/// materialization step (unlike trusty-mpm's install-time embed pattern); the
-/// bundled `.md` source is projected directly from the compiled-in
-/// `&'static str` (#2897 Slice C — previously native TOML, parsed via
-/// `AgentConfig::from_toml_str`; the format changed, the embedded-fallback
-/// behavior did not).
-/// What: Calls [`md_loader::project_embedded_md`] on every
-/// `EmbeddedAgent::md`. Unlike the retired TOML path this projection is
-/// infallible (`agent_metadata_from_str` degrades to an empty default on a
-/// malformed document rather than erroring — see its doc comment), so there
-/// is nothing to skip; every bundled default always yields a config.
+/// materialization step (unlike trusty-mpm's install-time embed pattern). As
+/// of Slice E3 (#2958) `DEFAULT_AGENTS` mixes two projection strategies:
+/// tcode's original 3 defaults are flat `.md` strings (#2897 Slice C —
+/// previously native TOML, parsed via `AgentConfig::from_toml_str`; the
+/// format changed, the embedded-fallback behavior did not), while the 28 tm
+/// roster agents inherit from `BASE-*` templates and must be composed
+/// in-memory first.
+/// What: For each `EmbeddedAgent::Direct { name, md }`, calls
+/// [`md_loader::project_embedded_md`] directly — infallible, same as before
+/// Slice E3 (`agent_metadata_from_str` degrades to an empty default on a
+/// malformed document rather than erroring). For each
+/// `EmbeddedAgent::Composed { name }`, calls
+/// [`md_loader::project_embedded_md_with_extends`], which IS fallible (an
+/// unresolvable `extends:` chain returns `Err`); a failure is logged at
+/// ERROR level and the agent is skipped rather than panicking — this should
+/// be unreachable in practice (every roster name is pinned against
+/// `EMBEDDED_TM_AGENT_SOURCES` by `assets::tests::default_agents_parse_and_names_match`),
+/// but a compiled-in asset table defect must degrade gracefully, not crash
+/// the harness, exactly like the disk-parsing path in [`load_all_agents`]
+/// does for a malformed on-disk config.
 /// Test: `load_all_agents_falls_back_to_embedded_when_disk_empty`,
-/// `assets::tests::default_agents_field_identical_to_retired_toml`.
+/// `assets::tests::default_agents_field_identical_to_retired_toml`,
+/// `assets::tests::default_agents_parse_and_names_match`.
 fn load_embedded_default_agents() -> Vec<AgentConfig> {
     crate::assets::DEFAULT_AGENTS
         .iter()
-        .map(|embedded| md_loader::project_embedded_md(embedded.name, embedded.md))
+        .filter_map(|embedded| match embedded {
+            crate::assets::EmbeddedAgent::Direct { name, md } => {
+                Some(md_loader::project_embedded_md(name, md))
+            }
+            crate::assets::EmbeddedAgent::Composed { name } => {
+                match md_loader::project_embedded_md_with_extends(name) {
+                    Ok(cfg) => Some(cfg),
+                    Err(e) => {
+                        tracing::error!(
+                            "embedded roster agent '{name}' failed to compose \
+                             (build-time asset defect, not a runtime condition): {e}"
+                        );
+                        None
+                    }
+                }
+            }
+        })
         .collect()
 }
 
@@ -202,6 +229,55 @@ pub fn locate_agents_dir(project_root: &Path) -> std::path::PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The 31-name default embedded roster, in `crate::assets::DEFAULT_AGENTS`'s
+    /// declared order (Slice E3, #2958) — shared by every fallback test in
+    /// this module so the expected list is written once, not duplicated
+    /// per-test with the risk of one copy drifting from another.
+    ///
+    /// Why: three separate fallback scenarios (empty dir, all-invalid dir,
+    /// only-orphaned-toml dir) all assert the identical 31-name outcome; a
+    /// single source avoids a silent typo in one copy passing review
+    /// unnoticed.
+    /// What: tcode's original 3 (`engineer`, `qa-agent`, `code-reviewer`)
+    /// followed by the 28 roster names, alphabetical, matching
+    /// `DEFAULT_AGENTS`'s literal declaration order.
+    /// Test: every `load_all_agents_falls_back_*` test below.
+    fn expected_default_agent_names() -> Vec<&'static str> {
+        vec![
+            "engineer",
+            "qa-agent",
+            "code-reviewer",
+            "api-qa",
+            "code-analyzer",
+            "code-critic",
+            "dart-engineer",
+            "data-engineer",
+            "documentation",
+            "golang-engineer",
+            "java-engineer",
+            "javascript-engineer",
+            "local-ops",
+            "nextjs-engineer",
+            "ops",
+            "phoenix-engineer",
+            "php-engineer",
+            "prompt-engineer",
+            "python-engineer",
+            "qa",
+            "react-engineer",
+            "refactoring-engineer",
+            "research",
+            "ruby-engineer",
+            "rust-engineer",
+            "security",
+            "svelte-engineer",
+            "tauri-engineer",
+            "typescript-engineer",
+            "web-qa",
+            "web-ui-engineer",
+        ]
+    }
 
     /// `discover_agents` finds `.md` files and returns sorted (name, path)
     /// pairs.
@@ -346,16 +422,17 @@ mod tests {
     /// both hit this branch, since `discover_agents` returns `[]` for both).
     ///
     /// Why: This is the whole point of #2895 — a fresh project must not
-    /// start with zero agents.
-    /// What: Load from a nonexistent dir; expect exactly the three bundled
-    /// defaults (`engineer`, `qa-agent`, `code-reviewer`), sorted by name
-    /// via `crate::assets::DEFAULT_AGENTS`'s declared order.
+    /// start with zero agents. As of Slice E3 (#2958) the bundled roster is
+    /// 31 agents, not 3.
+    /// What: Load from a nonexistent dir; expect exactly the 31-agent
+    /// embedded roster, in `crate::assets::DEFAULT_AGENTS`'s declared order —
+    /// the original 3 defaults intact, followed by the 28 roster agents.
     /// Test: this test.
     #[test]
     fn load_all_agents_falls_back_to_embedded_when_disk_empty() {
         let agents = load_all_agents(std::path::Path::new("/nonexistent/agents/dir"));
         let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
-        assert_eq!(names, vec!["engineer", "qa-agent", "code-reviewer"]);
+        assert_eq!(names, expected_default_agent_names());
     }
 
     /// A `.claude/agents/` dir that exists and holds `.md` files, but every
@@ -368,8 +445,8 @@ mod tests {
     /// alone would defeat the "never zero agents" goal for a directory that
     /// exists but is entirely malformed.
     /// What: One `broken.md` (an `extends:` cycle — a real `compose_agent`
-    /// failure) on disk, nothing else; `load_all_agents` returns the three
-    /// bundled defaults, not `[]`.
+    /// failure) on disk, nothing else; `load_all_agents` returns the
+    /// 31-agent bundled roster, not `[]`.
     /// Test: this test.
     #[test]
     fn load_all_agents_falls_back_to_embedded_when_disk_all_invalid() {
@@ -382,7 +459,7 @@ mod tests {
 
         let agents = load_all_agents(tmp.path());
         let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
-        assert_eq!(names, vec!["engineer", "qa-agent", "code-reviewer"]);
+        assert_eq!(names, expected_default_agent_names());
     }
 
     /// A directory holding ONLY orphaned `.toml` agents (no `.md` at all)
@@ -394,7 +471,7 @@ mod tests {
     /// fallback compose correctly: warning is a side effect, not a
     /// substitute for a real agent.
     /// What: one `legacy.toml` on disk, no `.md`; `load_all_agents` returns
-    /// the three bundled defaults.
+    /// the 31-agent bundled roster.
     /// Test: this test.
     #[test]
     fn load_all_agents_falls_back_when_disk_has_only_orphaned_toml() {
@@ -404,7 +481,7 @@ mod tests {
 
         let agents = load_all_agents(tmp.path());
         let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
-        assert_eq!(names, vec!["engineer", "qa-agent", "code-reviewer"]);
+        assert_eq!(names, expected_default_agent_names());
     }
 
     /// A disk directory with even one valid config is used as-is; the

--- a/crates/trusty-code/src/assets/agents/code-analyzer.md
+++ b/crates/trusty-code/src/assets/agents/code-analyzer.md
@@ -4,6 +4,7 @@ role: code-analyzer
 description: Code analysis specialist. Reviews code for correctness, quality, security, and architectural health using static analysis.
 model: sonnet
 extends: base-research
+tools: [read_file, grep, glob, list_dir, search_code, use_skill, finish_task]
 skills: [software-patterns, brainstorming, git-workflow, requesting-code-review, writing-plans, json-data-handling, root-cause-tracing, systematic-debugging, verification-before-completion, internal-comms, test-driven-development]
 ---
 

--- a/crates/trusty-code/src/assets/agents/code-analyzer.md
+++ b/crates/trusty-code/src/assets/agents/code-analyzer.md
@@ -95,14 +95,14 @@ For every public function, method, and class:
 
 ## Large-Volume Analysis
 
-For analysis spanning >10 files or >500 lines of diff, generate a script in `scripts/code-review/`:
+This agent has no `write_file` or `bash` access (see `tools:` above), so it never creates or runs a script itself. For analysis spanning >10 files or >500 lines of diff, recommend a script the engineer can save under `scripts/code-review/` and run, and include the full script content in your report rather than writing it to disk:
 
 ```python
-# scripts/code-review/review_<feature>.py
-# Run: python scripts/code-review/review_<feature>.py
+# Recommended: scripts/code-review/review_<feature>.py
+# Engineer runs: python scripts/code-review/review_<feature>.py
 ```
 
-Offer the scripted approach first for PR reviews touching >10 files, codebase-wide pattern searches, and refactoring candidate identification.
+Recommend the scripted approach first for PR reviews touching >10 files, codebase-wide pattern searches, and refactoring candidate identification.
 
 ## Standard Report Format
 

--- a/crates/trusty-code/src/assets/agents/code-critic.md
+++ b/crates/trusty-code/src/assets/agents/code-critic.md
@@ -4,6 +4,7 @@ role: qa
 description: Adversarial code review using a structured rubric. Outputs APPROVE/WARN/BLOCK verdict with line-level citations. Independent of implementer to avoid anchoring bias.
 model: sonnet
 extends: base-qa
+tools: [read_file, grep, glob, list_dir, search_code, use_skill, finish_task]
 skills: [code-review-standards, contract-driven-testing, code-production-process, software-patterns, systematic-debugging, verification-before-completion]
 ---
 

--- a/crates/trusty-code/src/assets/agents/qa.md
+++ b/crates/trusty-code/src/assets/agents/qa.md
@@ -12,13 +12,15 @@ skills: [brainstorming, git-workflow, requesting-code-review, writing-plans, jso
 
 You are an expert quality assurance engineer with deep expertise in testing methodologies, test automation, and quality validation processes.
 
+**Read-only mode**: this agent has no `write_file`, `edit`, or `bash` access (see `tools:` above) — it never writes a test file or runs a test suite itself. It designs test strategy and specifies concrete test cases/automation for an engineer to implement and run, and reviews test results/output that are handed to it (or that it can `read_file`/`grep` from disk).
+
 ## Core Responsibilities
 
-- Comprehensive test strategy development and execution
-- Test automation framework design and implementation
+- Comprehensive test strategy development, with concrete implementation specs for the engineer
+- Test automation framework design (implementation is the engineer's)
 - Quality metrics analysis and continuous improvement
 - Risk assessment and mitigation through systematic testing
-- Performance validation and load testing coordination
+- Performance validation planning and load-testing coordination
 
 ## Quality Assurance Methodology
 
@@ -26,9 +28,9 @@ You are an expert quality assurance engineer with deep expertise in testing meth
 
 2. **Design Test Strategy**: Select appropriate testing levels (unit, integration, system, acceptance); design test cases covering positive, negative, and boundary scenarios; establish quality gates and success criteria.
 
-3. **Implement Test Solutions**: Write maintainable, reliable automated test suites; implement effective test reporting; create robust test data management strategies.
+3. **Specify Test Solutions**: Specify maintainable, reliable automated test suites in enough detail for the engineer to implement directly; specify effective test reporting; propose robust test data management strategies.
 
-4. **Validate Quality**: Execute test plans and regression suites systematically; analyse results and quality metrics; identify and track defects to resolution.
+4. **Validate Quality**: Review test-plan and regression-suite results that are handed to you (or read from disk) systematically; analyse results and quality metrics; identify and track defects to resolution.
 
 5. **Monitor and Report**: Provide regular quality metrics and trend analysis; report test coverage gaps; communicate quality status to stakeholders clearly.
 
@@ -55,9 +57,9 @@ You are an expert quality assurance engineer with deep expertise in testing meth
 
 - Use grep patterns for test discovery instead of reading large files
 - Process test files sequentially; never in parallel
-- Check `package.json` test configuration before running JavaScript/TypeScript tests
-- Use `CI=true` or `--run`/`--ci` flags to prevent watch mode in JS test runners
-- Verify test process termination after execution to prevent memory leaks
+- Recommend the engineer/CI check `package.json` test configuration before running JavaScript/TypeScript tests
+- Recommend the engineer/CI use `CI=true` or `--run`/`--ci` flags to prevent watch mode in JS test runners
+- Recommend the engineer/CI verify test-process termination after execution to prevent memory leaks
 
 ## Communication
 

--- a/crates/trusty-code/src/assets/agents/qa.md
+++ b/crates/trusty-code/src/assets/agents/qa.md
@@ -4,6 +4,7 @@ role: qa
 description: Expert quality assurance engineer. Designs test strategies, implements automation, and validates software quality.
 model: sonnet
 extends: base-qa
+tools: [read_file, grep, glob, list_dir, search_code, use_skill, finish_task]
 skills: [brainstorming, git-workflow, requesting-code-review, writing-plans, json-data-handling, root-cause-tracing, systematic-debugging, verification-before-completion, internal-comms, condition-based-waiting, test-driven-development, test-quality-inspector, testing-anti-patterns, webapp-testing]
 ---
 

--- a/crates/trusty-code/src/assets/agents/web-qa.md
+++ b/crates/trusty-code/src/assets/agents/web-qa.md
@@ -10,14 +10,18 @@ skills: [brainstorming, git-workflow, requesting-code-review, writing-plans, jso
 
 # Web QA Agent
 
-Dual testing approach:
-1. **UAT Mode**: business intent verification, behavioral testing, documentation review, and user journey validation
-2. **Technical Testing**: progressive 6-phase approach (MCP Setup → API → Routes → Links2 → Safari → Playwright)
+**Read-only mode**: this agent has no `write_file`, `edit`, or `bash` access (see `tools:` above) — it never runs a browser, a shell command, or a test suite itself. Its output is findings plus a concrete, ready-to-run set of recommendations: draft scenarios, a technical checklist, and exact commands for an engineer, ops, or CI to execute. If test/console output is handed to it (pasted into the conversation, or present in a file it can `read_file`/`grep`), it reviews that output directly — it does not produce output of its own by running anything.
 
-## Browser Tool Priority
+Dual approach:
+1. **UAT Mode**: business intent verification, behavioral scenario drafting, documentation review, and user journey analysis
+2. **Technical Test Plan**: a progressive 6-phase review that produces a concrete, ready-to-execute checklist for whoever runs it
+
+## Recommended Browser Tooling (for the executor)
+
+This agent cannot invoke any of these itself — recommend the executor use, in priority order:
 
 ### 1. Native Claude Code Chrome (`/chrome`) — PREFERRED
-Built-in to Claude Code, no MCP server required. Uses your existing Chrome browser and logged-in sessions. Best for testing authenticated applications.
+Built-in to Claude Code, no MCP server required. Uses the executor's existing Chrome browser and logged-in sessions. Best for testing authenticated applications.
 
 **Enable**: `claude --chrome` or `/chrome` command in session
 
@@ -46,8 +50,8 @@ Proactively ask about:
 - Business priorities and critical paths
 - Success metrics and KPIs
 
-### 3. Behavioral Script Creation
-Create human-readable behavioral test scripts in `tests/uat/scripts/` using Gherkin-style format:
+### 3. Behavioral Scenario Drafting
+Draft human-readable behavioral test scenarios using Gherkin-style format, and include the draft in your findings for the engineer or PM to save under `tests/uat/scripts/` — you have no `write_file` access, so you hand off the draft rather than creating the file yourself:
 ```gherkin
 Feature: Checkout with Discount Code
   Scenario: Valid discount code application
@@ -57,61 +61,64 @@ Feature: Checkout with Discount Code
     And the new total should be $80
 ```
 
-### 4. User Journey Testing
-Test complete end-to-end user workflows:
+### 4. User Journey Analysis
+Identify complete end-to-end user workflows worth verifying:
 - Critical user paths: Registration → Browse → Add to Cart → Checkout → Confirmation
 - Business value flows: lead generation, conversion funnels
 - Cross-functional journeys: multi-channel experiences, email confirmations
 - Persona-based testing: different user types
 
 ### 5. Business Value Validation
-Explicitly verify:
+Explicitly assess:
 - **Goal Achievement**: does the feature achieve its stated business objective?
 - **User Value**: does it solve the user's problem effectively?
 - **ROI Indicators**: are success metrics trackable and measurable?
 
-## Technical Testing Protocol
+## Technical Test Plan
 
-### 6-Phase Progressive Testing
-1. **MCP Setup Phase**: verify browser tool availability
-2. **API Phase**: test backend endpoints directly (curl, fetch)
-3. **Routes Phase**: test server responses and server-side rendering
-4. **Links2 Phase**: text-browser validation (JavaScript-free view)
-5. **Safari Phase**: macOS WebKit validation with AppleScript
-6. **Playwright Phase**: full browser automation, cross-browser
+### 6-Phase Progressive Checklist
+Produce this checklist for the executor, with the exact command or tool for each applicable phase — you recommend and review results, you do not run these phases yourself:
+1. **MCP Setup Phase**: confirm which browser tool is available (see Recommended Browser Tooling above)
+2. **API Phase**: recommend direct backend-endpoint checks (`curl`/`fetch` commands)
+3. **Routes Phase**: recommend server-response and server-side-rendering checks
+4. **Links2 Phase**: recommend a text-browser pass (JavaScript-free view)
+5. **Safari Phase**: recommend macOS WebKit validation via AppleScript where applicable
+6. **Playwright Phase**: recommend full cross-browser automation coverage
 
 ### Console Monitoring
-- Monitor browser console during all UI testing phases
-- Correlate console errors with UI test failures
-- Track JavaScript exceptions and network failures
-- Check for security warnings (CSP, CORS, XSS)
+Instruct the executor to monitor the browser console during all UI testing phases, correlate console errors with UI test failures, track JavaScript exceptions and network failures, and check for security warnings (CSP, CORS, XSS). If console or log output is handed to you afterward, review it directly and fold the findings into your report.
 
-### Test Process Discipline
-- Always check `package.json` test script configuration before running tests
-- Use `CI=true` prefix for npm test to prevent watch mode activation
-- Verify test processes terminate completely after execution
-- Override watch mode with `--run` or `--ci` flags
+### Recommended Test-Execution Commands
+Hand these to the engineer or CI to run — never invoke them yourself:
 
 ```bash
-# Correct CI-safe test invocation
+# Recommended CI-safe test invocation
 CI=true npm test
 npx vitest run --coverage
-# Check for orphaned processes
+# Recommend checking for orphaned processes after the run
 ps aux | grep -E "(vitest|jest|node.*test)"
 ```
 
+Also recommend the executor:
+- Confirm `package.json` test script configuration before running
+- Use the `CI=true` prefix (or `--run`/`--ci` flags) to prevent watch-mode activation
+- Verify test processes terminate completely after execution
+
 ## Quality Standards
 
-- Test all critical user journeys, not just individual features
+When reviewing, ensure the test plan and any reported results:
+- Cover all critical user journeys, not just individual features
 - Validate business intent alongside technical correctness
-- Document when features work technically but miss business goals
+- Flag when a feature works technically but misses its business goal
+
+Recommend the executor also:
 - Include performance testing (Core Web Vitals)
 - Test accessibility with axe-core or similar
-- Screenshot on failure for visual evidence
+- Capture a screenshot on failure for visual evidence
 - Run visual regression baselines
-- Always monitor browser console during UI testing
+- Monitor the browser console throughout UI testing
 
 ## Integration Points
-- **With Engineer**: report bugs with reproduction steps
+- **With Engineer**: report bugs with reproduction steps; hand off drafted UAT scenarios and the technical test-plan checklist for execution
 - **With Security**: escalate authentication and authorization issues
 - **With Product**: communicate business value gaps

--- a/crates/trusty-code/src/assets/agents/web-qa.md
+++ b/crates/trusty-code/src/assets/agents/web-qa.md
@@ -4,6 +4,7 @@ role: qa
 description: Progressive 6-phase web testing with UAT mode for business intent verification, behavioral testing, and comprehensive acceptance validation alongside technical testing
 model: sonnet
 extends: base-qa
+tools: [read_file, grep, glob, list_dir, search_code, use_skill, finish_task]
 skills: [brainstorming, git-workflow, requesting-code-review, writing-plans, json-data-handling, root-cause-tracing, systematic-debugging, verification-before-completion, internal-comms, condition-based-waiting, test-driven-development, test-quality-inspector, testing-anti-patterns, webapp-testing, web-performance-optimization]
 ---
 

--- a/crates/trusty-code/src/assets/mod.rs
+++ b/crates/trusty-code/src/assets/mod.rs
@@ -49,6 +49,26 @@
 //! copies against trusty-mpm's source) MUST whitelist the `tools:` line in
 //! exactly these four files rather than flagging them as drift.
 //!
+//! ## Prose deviation follow-up (Slice E3 review round, #3041)
+//!
+//! Adding the `tools:` override alone left three of the four files
+//! internally contradictory: their prose still instructed write/bash actions
+//! the new allowlist denies (`web-qa.md`'s "Technical Testing Protocol" told
+//! the agent to create test scripts, run `CI=true npm test`, and shell out to
+//! `ps aux`; `qa.md`'s methodology told it to "Implement"/"Execute" test
+//! suites directly; `code-analyzer.md`'s "Large-Volume Analysis" told it to
+//! generate-and-run a Python script). A code-critic review of PR #3041 (WARN,
+//! two HIGH + one MEDIUM findings) caught this. `web-qa.md`, `qa.md`, and
+//! `code-analyzer.md` were reworded in the SAME PR to a genuinely read-only
+//! frame: findings plus concrete, ready-to-run recommendations (drafted
+//! scenarios, specified test cases, recommended commands) handed off to an
+//! engineer/ops/CI to execute, never executed by the agent itself.
+//! `code-critic.md` needed no prose change — its review-only body already had
+//! no execute-oriented instructions. This is an ADDITIONAL deviation from
+//! trusty-mpm byte-parity beyond the `tools:` line alone; the deferred E4
+//! staleness guard must whitelist the reworded prose sections in these three
+//! files too, not just the `tools:` line.
+//!
 //! Test: `assets::tests::*` — every embedded agent `.md` parses and projects
 //! to a field-identical `AgentConfig` vs. the retired TOML fixtures (the
 //! original 3), every roster name resolves through the extends composer with

--- a/crates/trusty-code/src/assets/mod.rs
+++ b/crates/trusty-code/src/assets/mod.rs
@@ -9,39 +9,108 @@
 //! disk-based `.claude/agents/` and `.claude/skills/` always take precedence
 //! when present (see `agents::load_all_agents` and
 //! `skills::discover_skill_metadata`'s embedded-fallback branches).
-//! What: [`EmbeddedAgent`]/[`DEFAULT_AGENTS`] — the three default agent
-//! configs (`engineer`, `qa-agent`, `code-reviewer`), authored as Markdown+
-//! frontmatter (`.md`) as of #2897 Slice C (previously native TOML; Slice D
-//! subsequently retired the TOML loader for USER `.claude/agents/*.toml`
-//! configs entirely — see `agents::mod`'s docs). The embedded fallback
-//! projects each `.md` string onto
-//! tcode's `AgentConfig` via `agents::md_loader::project_embedded_md`, which
-//! shares its frontmatter->`AgentConfig` mapping with the disk `.md` loader
+//! What: [`EmbeddedAgent`]/[`DEFAULT_AGENTS`] — the 31-agent dispatchable
+//! roster (Slice E3, #2958): tcode's own 3 defaults (`engineer`, `qa-agent`,
+//! `code-reviewer`, no `extends:` chain — projected via
+//! `agents::md_loader::project_embedded_md`) plus the 28 coding-relevant tm
+//! agents Bob selected in #2958 (`extends:`-chained through the 5 `BASE-*`
+//! templates — projected via
+//! `agents::md_loader::project_embedded_md_with_extends`, which resolves
+//! against [`EMBEDDED_TM_AGENT_SOURCES`]). Authored as Markdown+frontmatter
+//! (`.md`) as of #2897 Slice C (previously native TOML; Slice D subsequently
+//! retired the TOML loader for USER `.claude/agents/*.toml` configs entirely
+//! — see `agents::mod`'s docs). Both projection paths share one
+//! frontmatter->`AgentConfig` mapping with the disk `.md` loader
 //! (`agents::md_loader::load_md_agent`) — see that module's docs.
 //! [`EmbeddedSkill`]/[`DEFAULT_SKILLS`] — trusty-mpm's universal skill set
 //! (format-identical `SKILL.md` files), reused verbatim per Bob's reuse
 //! directive; the `tm-*` orchestration skills are excluded because they drive
 //! trusty-mpm MCP tools tcode does not have.
+//!
+//! ## Tools-restriction deviation (Slice E3, #2958, Bob's 2026-07-18 ruling)
+//!
+//! Four of the 28 roster agents — `qa`, `code-critic`, `code-analyzer`,
+//! `web-qa` — carry an explicit restrictive `tools:` override in their tcode
+//! copy (`assets/agents/{qa,code-critic,code-analyzer,web-qa}.md`) that is
+//! NOT present in the trusty-mpm source files they were copied from
+//! byte-for-byte in Slice E2. This is a deliberate, Bob-approved deviation
+//! from byte-parity, not drift: those four are reviewer-intent agents and get
+//! the same read-only tool allowlist tcode's own `code-reviewer` default uses
+//! (no `write_file`/`edit`/`bash`). `documentation` and `research` stay
+//! byte-identical and unrestricted per Bob's explicit ruling — they build
+//! docs and research reports, not verdicts. NOTE for the file itself: the
+//! shared frontmatter parser
+//! (`trusty_agents_common::agents::builder::split_frontmatter`) does NOT
+//! tolerate `#`-comment lines inside a frontmatter block (verified
+//! empirically — a bare `#`-prefixed line there is a hard `FrontmatterParse`
+//! error, not a tolerated comment), so no inline marker could be added to
+//! those four files without breaking the compose step; this doc comment is
+//! the marker of record. The deferred E4 CI staleness guard (diffing tcode's
+//! copies against trusty-mpm's source) MUST whitelist the `tools:` line in
+//! exactly these four files rather than flagging them as drift.
+//!
 //! Test: `assets::tests::*` — every embedded agent `.md` parses and projects
-//! to a field-identical `AgentConfig` vs. the retired TOML fixtures, every
-//! skill name is unique, and every skill's frontmatter `name:` matches its
-//! table key.
+//! to a field-identical `AgentConfig` vs. the retired TOML fixtures (the
+//! original 3), every roster name resolves through the extends composer with
+//! no BASE template dispatchable and no name collision, the four restricted
+//! agents' composed `AgentConfig` carries the read-only tool list, and
+//! `documentation`/`research` remain unrestricted. Every skill name is unique
+//! and every skill's frontmatter `name:` matches its table key.
 
-/// One embedded default agent: its dispatch name and raw `.md` source.
+/// One embedded default agent: either self-contained (tcode's own 3
+/// defaults, no `extends:` chain) or a roster agent whose `extends:` chain is
+/// resolved at load time against [`EMBEDDED_TM_AGENT_SOURCES`] (Slice E3,
+/// #2958).
 ///
-/// Why: `agents::mod`'s embedded-fallback needs both the name (for logging)
-/// and the raw `.md` document (to hand to
-/// `agents::md_loader::project_embedded_md`).
-/// What: `name` matches the frontmatter `name:` field inside `md`; `md` is
-/// the verbatim embedded file contents (frontmatter fence + prose body).
+/// Why: `agents::mod`'s embedded-fallback needs a single ordered table
+/// ([`DEFAULT_AGENTS`]) covering both projection strategies tcode's embedded
+/// agents need: tcode's own 3 defaults are flat `.md` strings with no
+/// inheritance (projected via `agents::md_loader::project_embedded_md`); the
+/// 28 tm roster agents inherit from `BASE-*` templates and must be composed
+/// in-memory (`agents::md_loader::project_embedded_md_with_extends`) before
+/// projection. One enum keeps both variants in the same ordered slice rather
+/// than two parallel tables that could silently drift out of sync in count
+/// or ordering.
+/// What: [`EmbeddedAgent::Direct`] carries the dispatch name and the raw
+/// `.md` source (frontmatter fence + prose body) verbatim. [`EmbeddedAgent::Composed`]
+/// carries only the dispatch name — its content is resolved from
+/// [`EMBEDDED_TM_AGENT_SOURCES`] at load time, since the whole point of the
+/// in-memory composer is that no second copy of the raw bytes is needed here.
+/// [`EmbeddedAgent::name`] reads the name back out of either variant.
 /// Test: `assets::tests::default_agents_parse_and_names_match`.
 #[derive(Debug, Clone, Copy)]
-pub struct EmbeddedAgent {
-    /// Dispatch key, matching the frontmatter `name:` inside `md`.
-    pub name: &'static str,
-    /// Raw `.md` source (frontmatter fence + prose body), projectable via
-    /// `agents::md_loader::project_embedded_md`.
-    pub md: &'static str,
+pub enum EmbeddedAgent {
+    /// A self-contained agent: raw `.md` source, no `extends:` chain.
+    Direct {
+        /// Dispatch key, matching the frontmatter `name:` inside `md`.
+        name: &'static str,
+        /// Raw `.md` source (frontmatter fence + prose body), projectable
+        /// via `agents::md_loader::project_embedded_md`.
+        md: &'static str,
+    },
+    /// A roster agent resolved via `agents::md_loader::project_embedded_md_with_extends`
+    /// against [`EMBEDDED_TM_AGENT_SOURCES`] at load time.
+    Composed {
+        /// Dispatch key, and the lookup key into `EMBEDDED_TM_AGENT_SOURCES`
+        /// (after that table's own case-folding).
+        name: &'static str,
+    },
+}
+
+impl EmbeddedAgent {
+    /// The dispatch key, regardless of variant.
+    ///
+    /// Why: callers (the embedded-fallback loader, tests) usually only need
+    /// the name and would otherwise have to `match` on the variant just to
+    /// read one shared field.
+    /// What: returns `name` from either `Direct` or `Composed`.
+    /// Test: `assets::tests::default_agents_parse_and_names_match`.
+    pub fn name(&self) -> &'static str {
+        match self {
+            EmbeddedAgent::Direct { name, .. } => name,
+            EmbeddedAgent::Composed { name } => name,
+        }
+    }
 }
 
 /// One embedded default skill: its catalog name and raw `SKILL.md` source.
@@ -64,7 +133,15 @@ const ENGINEER_MD: &str = include_str!("agents/engineer.md");
 const QA_AGENT_MD: &str = include_str!("agents/qa-agent.md");
 const CODE_REVIEWER_MD: &str = include_str!("agents/code-reviewer.md");
 
-/// The three default tcode agents, embedded at compile time.
+/// The 31-agent dispatchable default roster, embedded at compile time
+/// (Slice E3, #2958): tcode's original 3 defaults plus the 28
+/// coding-relevant tm roster agents. The 5 `BASE-*` extends templates in
+/// [`EMBEDDED_TM_AGENT_SOURCES`] are deliberately NOT entries here — they are
+/// extends-sources only, never dispatchable — and trusty-mpm's own
+/// `engineer` agent is excluded from the roster upstream (#2958's roster
+/// decision) precisely because it would collide with tcode's `engineer`
+/// below; `assets::tests::no_name_collisions_across_the_31_agent_roster`
+/// pins that no collision exists in the final table.
 ///
 /// Why: gives `agents::load_all_agents`'s embedded-fallback branch a fixed,
 /// ordered table to parse when the disk `.claude/agents/` directory is empty
@@ -72,26 +149,107 @@ const CODE_REVIEWER_MD: &str = include_str!("agents/code-reviewer.md");
 /// What: `engineer` (general implementation, full read/write tool set),
 /// `qa-agent` (verification — read/inspect/run only, no `write_file`/`edit`,
 /// hands bugs back to the engineer rather than fixing them), `code-reviewer`
-/// (adversarial, read-only review, no `bash`).
-/// Test: `assets::tests::default_agents_parse_and_names_match`.
+/// (adversarial, read-only review, no `bash`) — all three [`EmbeddedAgent::Direct`].
+/// Then the 28 [`EmbeddedAgent::Composed`] roster agents, alphabetical,
+/// matching [`EMBEDDED_TM_AGENT_SOURCES`]'s roster ordering. Four of them
+/// (`qa`, `code-critic`, `code-analyzer`, `web-qa`) carry a tcode-only
+/// restrictive `tools:` override in their `.md` source — see this module's
+/// "Tools-restriction deviation" doc section above.
+/// Test: `assets::tests::default_agents_parse_and_names_match`,
+/// `assets::tests::base_templates_are_never_dispatchable`,
+/// `assets::tests::no_name_collisions_across_the_31_agent_roster`,
+/// `assets::tests::restricted_reviewer_agents_carry_read_only_tools`,
+/// `assets::tests::documentation_and_research_remain_unrestricted`.
 pub const DEFAULT_AGENTS: &[EmbeddedAgent] = &[
-    EmbeddedAgent {
+    EmbeddedAgent::Direct {
         name: "engineer",
         md: ENGINEER_MD,
     },
-    EmbeddedAgent {
+    EmbeddedAgent::Direct {
         name: "qa-agent",
         md: QA_AGENT_MD,
     },
-    EmbeddedAgent {
+    EmbeddedAgent::Direct {
         name: "code-reviewer",
         md: CODE_REVIEWER_MD,
+    },
+    EmbeddedAgent::Composed { name: "api-qa" },
+    EmbeddedAgent::Composed {
+        name: "code-analyzer",
+    },
+    EmbeddedAgent::Composed {
+        name: "code-critic",
+    },
+    EmbeddedAgent::Composed {
+        name: "dart-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "data-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "documentation",
+    },
+    EmbeddedAgent::Composed {
+        name: "golang-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "java-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "javascript-engineer",
+    },
+    EmbeddedAgent::Composed { name: "local-ops" },
+    EmbeddedAgent::Composed {
+        name: "nextjs-engineer",
+    },
+    EmbeddedAgent::Composed { name: "ops" },
+    EmbeddedAgent::Composed {
+        name: "phoenix-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "php-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "prompt-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "python-engineer",
+    },
+    EmbeddedAgent::Composed { name: "qa" },
+    EmbeddedAgent::Composed {
+        name: "react-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "refactoring-engineer",
+    },
+    EmbeddedAgent::Composed { name: "research" },
+    EmbeddedAgent::Composed {
+        name: "ruby-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "rust-engineer",
+    },
+    EmbeddedAgent::Composed { name: "security" },
+    EmbeddedAgent::Composed {
+        name: "svelte-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "tauri-engineer",
+    },
+    EmbeddedAgent::Composed {
+        name: "typescript-engineer",
+    },
+    EmbeddedAgent::Composed { name: "web-qa" },
+    EmbeddedAgent::Composed {
+        name: "web-ui-engineer",
     },
 ];
 
 // -- Slice E2 (#2958): embedded tm agent catalog, for `md_loader`'s in-memory
-// extends-composer. NOT wired into `DEFAULT_AGENTS`/`load_all_agents`'s
-// fallback yet -- that expansion is Slice E3. --
+// extends-composer. Slice E3 wires the 28 roster names above into
+// `DEFAULT_AGENTS` as `EmbeddedAgent::Composed` entries; this table remains
+// their content source, resolved at load time via
+// `agents::md_loader::project_embedded_md_with_extends`. --
 
 const BASE_AGENT_MD: &str = include_str!("agents/BASE-AGENT.md");
 const BASE_ENGINEER_MD: &str = include_str!("agents/BASE-ENGINEER.md");
@@ -142,13 +300,17 @@ const WEB_UI_ENGINEER_MD: &str = include_str!("agents/web-ui-engineer.md");
 /// Why: `agents::md_loader::project_embedded_md_with_extends` needs a single
 /// batch source for `build_in_memory_source_map` instead of 33 individual
 /// `insert` calls; this table is that source. Kept separate from
-/// [`DEFAULT_AGENTS`] so Slice E3 (roster expansion into the dispatchable
-/// fallback) can build on this table without disturbing the existing
-/// 3-agent fallback this slice does not touch.
-/// What: 33 `(original_filename, raw_md_content)` pairs. None of these are
-/// dispatchable agents yet -- wiring them into `DEFAULT_AGENTS` /
-/// `load_all_agents`'s fallback is deferred to Slice E3.
+/// [`DEFAULT_AGENTS`] (rather than folded into it) because this table's key
+/// space includes the 5 `BASE-*` templates, which must remain resolvable as
+/// `extends:` targets while staying permanently non-dispatchable -- merging
+/// the two tables would require a third state ("resolvable but not listed")
+/// that the current `Direct`/`Composed` enum has no need to express.
+/// What: 33 `(original_filename, raw_md_content)` pairs: 5 `BASE-*` templates
+/// (never dispatchable) plus the 28 roster agents (dispatchable as of Slice
+/// E3 via [`DEFAULT_AGENTS`]'s `EmbeddedAgent::Composed` entries, which
+/// resolve against this table at load time).
 /// Test: `assets::tests::embedded_tm_agent_sources_has_33_entries_and_unique_keys`,
+/// `assets::tests::base_templates_are_never_dispatchable`,
 /// `md_loader::tests::project_embedded_md_with_extends_resolves_rust_engineer_from_base_engineer`.
 pub const EMBEDDED_TM_AGENT_SOURCES: &[(&str, &str)] = &[
     ("BASE-AGENT.md", BASE_AGENT_MD),

--- a/crates/trusty-code/src/assets/tests.rs
+++ b/crates/trusty-code/src/assets/tests.rs
@@ -11,22 +11,31 @@
 //! Test: this file — self-describing.
 
 use super::*;
-use crate::agents::md_loader::project_embedded_md;
+use crate::agents::md_loader::{project_embedded_md, project_embedded_md_with_extends};
 
-/// Every embedded agent `.md` parses, and its frontmatter `name:` matches the
-/// table key it is filed under.
+/// Every embedded agent `.md` parses (directly for the 3 originals, via the
+/// in-memory extends composer for the 28 roster agents), and its frontmatter
+/// `name:` matches the table key it is filed under.
 ///
 /// Why: A typo in either the `.md` frontmatter or the table entry would
 /// silently break `agents::load_all_agents`'s embedded-fallback at runtime
-/// instead of failing fast in CI.
+/// instead of failing fast in CI. This is also the acceptance test for Slice
+/// E3 (#2958): every one of the 31 entries must actually compose (a `Composed`
+/// variant that panics here rather than resolving would otherwise only be
+/// caught at runtime by `load_embedded_default_agents`'s log-and-skip path).
 /// Test: this test.
 #[test]
 fn default_agents_parse_and_names_match() {
-    assert_eq!(DEFAULT_AGENTS.len(), 3);
+    assert_eq!(DEFAULT_AGENTS.len(), 31, "3 originals + 28 roster agents");
     for agent in DEFAULT_AGENTS {
-        let cfg = project_embedded_md(agent.name, agent.md);
+        let cfg = match agent {
+            EmbeddedAgent::Direct { name, md } => project_embedded_md(name, md),
+            EmbeddedAgent::Composed { name } => project_embedded_md_with_extends(name)
+                .unwrap_or_else(|e| panic!("roster agent '{name}' failed to compose: {e}")),
+        };
         assert_eq!(
-            cfg.agent.name, agent.name,
+            cfg.agent.name,
+            agent.name(),
             "table key must match frontmatter name:"
         );
     }
@@ -129,20 +138,212 @@ fn default_agents_field_identical_to_retired_toml() {
 }
 
 /// The embedded fallback still fires when the disk `.claude/agents` dir is
-/// empty, and still yields exactly the three default agent names — proving
-/// the `.md` conversion did not break `load_all_agents`'s fallback wiring.
+/// empty, and yields the full 31-agent roster with the original 3 defaults
+/// intact as the first three entries — proving Slice E3's roster expansion
+/// did not disturb the original fallback wiring `.md` (#2897 Slice C)
+/// established.
 ///
 /// Why: #2897 Slice C's non-breaking claim rests on this: a fresh project
 /// with no `.claude/agents/` must still boot with `engineer`/`qa-agent`/
-/// `code-reviewer` available, exactly as it did when the defaults were TOML.
-/// What: calls `crate::agents::load_all_agents` on a nonexistent directory
-/// and asserts the three names come back.
+/// `code-reviewer` available, exactly as it did when the defaults were TOML
+/// — Slice E3 only ADDS the 28 roster agents after them, never replaces or
+/// reorders the original 3.
+/// What: calls `crate::agents::load_all_agents` on a nonexistent directory;
+/// asserts the returned names' first three entries are exactly
+/// `["engineer", "qa-agent", "code-reviewer"]` and the full 31-name list
+/// matches `crate::assets::DEFAULT_AGENTS`'s declared order with no
+/// duplicates.
 /// Test: this test.
 #[test]
-fn embedded_fallback_still_fires_and_yields_same_three_names() {
+fn embedded_fallback_still_fires_and_yields_31_agents_with_original_3_intact() {
     let agents = crate::agents::load_all_agents(std::path::Path::new("/nonexistent/agents/dir"));
     let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
-    assert_eq!(names, vec!["engineer", "qa-agent", "code-reviewer"]);
+
+    assert_eq!(names.len(), 31, "31-agent roster: 3 originals + 28 roster");
+    assert_eq!(
+        &names[..3],
+        &["engineer", "qa-agent", "code-reviewer"],
+        "the original 3 defaults must remain first and intact"
+    );
+
+    let expected: Vec<&str> = DEFAULT_AGENTS.iter().map(|a| a.name()).collect();
+    assert_eq!(
+        names, expected,
+        "fallback order must match DEFAULT_AGENTS's declared order exactly"
+    );
+
+    let mut deduped = names.clone();
+    deduped.sort_unstable();
+    deduped.dedup();
+    assert_eq!(deduped.len(), names.len(), "no duplicate agent names");
+}
+
+/// The 5 `BASE-*` extends templates are NEVER dispatchable — they must not
+/// appear anywhere in `DEFAULT_AGENTS` or the fallback roster it produces.
+///
+/// Why: #2958's roster decision is explicit that `BASE-AGENT`, `BASE-ENGINEER`,
+/// `BASE-OPS`, `BASE-QA`, and `BASE-RESEARCH` are extends-sources ONLY. A
+/// `BASE-*` entry leaking into the dispatchable roster would let a caller
+/// invoke a template fragment (no concrete role, designed to be composed
+/// into a leaf agent, not run standalone) as if it were a real agent.
+/// What: asserts none of the 31 `DEFAULT_AGENTS` names matches any of the 5
+/// base template names (case-insensitive, since the source table keys them
+/// `BASE-QA.md` while `extends:` references use `base-qa`).
+/// Test: this test.
+#[test]
+fn base_templates_are_never_dispatchable() {
+    const BASE_NAMES: &[&str] = &[
+        "base-agent",
+        "base-engineer",
+        "base-ops",
+        "base-qa",
+        "base-research",
+    ];
+    for agent in DEFAULT_AGENTS {
+        let lower = agent.name().to_ascii_lowercase();
+        assert!(
+            !BASE_NAMES.contains(&lower.as_str()),
+            "BASE template '{}' must never be dispatchable",
+            agent.name()
+        );
+    }
+}
+
+/// No two entries in the 31-agent `DEFAULT_AGENTS` roster share a dispatch
+/// name — in particular, trusty-mpm's own `engineer` agent (excluded from
+/// the roster upstream specifically because it collides with tcode's
+/// `engineer` default) does not sneak back in under any composed entry.
+///
+/// Why: the #2958 roster decision explicitly calls out `engineer` as
+/// EXCLUDEd from the 28-agent import "(name-collides with tcode's own
+/// default)" — this test is the regression pin for that exclusion, and a
+/// general guard against any future roster addition silently shadowing an
+/// existing dispatch name.
+/// What: collects all 31 names, dedupes, asserts the length is unchanged;
+/// separately asserts `"engineer"` appears exactly once.
+/// Test: this test.
+#[test]
+fn no_name_collisions_across_the_31_agent_roster() {
+    let names: Vec<&str> = DEFAULT_AGENTS.iter().map(|a| a.name()).collect();
+    assert_eq!(names.len(), 31);
+
+    let mut deduped = names.clone();
+    deduped.sort_unstable();
+    deduped.dedup();
+    assert_eq!(
+        deduped.len(),
+        names.len(),
+        "no name collisions across the 31-agent roster: {names:?}"
+    );
+
+    assert_eq!(
+        names.iter().filter(|&&n| n == "engineer").count(),
+        1,
+        "tcode's own 'engineer' must be the only 'engineer' entry -- mpm's \
+         'engineer' agent is excluded from the roster upstream precisely to \
+         avoid this collision"
+    );
+}
+
+/// The four reviewer-intent roster agents Bob designated for restrictive
+/// read-only tooling (2026-07-18, Slice E3, #2958) — `qa`, `code-critic`,
+/// `code-analyzer`, `web-qa` — compose to an `AgentConfig` carrying exactly
+/// the read-only tool allowlist, mirroring tcode's own `code-reviewer`
+/// default (no `write_file`/`edit`/`bash`).
+///
+/// Why: this is the acceptance test for the E3 tools-restriction decision —
+/// a frontmatter typo or a dropped `tools:` line would silently leave these
+/// "reviewer" agents with full read/write/bash access, defeating the whole
+/// point of the restriction.
+/// What: composes each of the four via `project_embedded_md_with_extends`
+/// (exercising the SAME path `load_embedded_default_agents` uses) and
+/// asserts `cfg.tools.allowed` equals the read-only list, with no
+/// `write_file`, `edit`, or `bash` entry.
+/// Test: this test.
+#[test]
+fn restricted_reviewer_agents_carry_read_only_tools() {
+    let expected_read_only: Vec<String> = vec![
+        "read_file".to_string(),
+        "grep".to_string(),
+        "glob".to_string(),
+        "list_dir".to_string(),
+        "search_code".to_string(),
+        "use_skill".to_string(),
+        "finish_task".to_string(),
+    ];
+
+    for name in ["qa", "code-critic", "code-analyzer", "web-qa"] {
+        let cfg = project_embedded_md_with_extends(name)
+            .unwrap_or_else(|e| panic!("failed to compose '{name}': {e}"));
+        let allowed = cfg.tools.and_then(|t| t.allowed);
+        assert_eq!(
+            allowed,
+            Some(expected_read_only.clone()),
+            "'{name}' must carry the restrictive read-only tools: override"
+        );
+        assert!(
+            !allowed
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|t| t == "write_file" || t == "edit" || t == "bash"),
+            "'{name}' must not carry any write/edit/bash-mutation tool"
+        );
+    }
+}
+
+/// `documentation` and `research` remain byte-identical to trusty-mpm's
+/// source and unrestricted (`tools: None` — all tools allowed), per Bob's
+/// explicit 2026-07-18 ruling that they build docs and research reports
+/// rather than issue verdicts.
+///
+/// Why: distinguishes "no override was accidentally added" from "an override
+/// was added but with the wrong value" — the previous test only pins the
+/// four restricted agents; this one pins that the two agents Bob explicitly
+/// exempted were NOT swept up by the same change.
+/// What: composes both via `project_embedded_md_with_extends` and asserts
+/// `cfg.tools.allowed` is `None`.
+/// Test: this test.
+#[test]
+fn documentation_and_research_remain_unrestricted() {
+    for name in ["documentation", "research"] {
+        let cfg = project_embedded_md_with_extends(name)
+            .unwrap_or_else(|e| panic!("failed to compose '{name}': {e}"));
+        assert_eq!(
+            cfg.tools.and_then(|t| t.allowed),
+            None,
+            "'{name}' must remain unrestricted (no tools: override)"
+        );
+    }
+}
+
+/// `crate::assets::DEFAULT_AGENTS`'s 28 `EmbeddedAgent::Composed` entries
+/// every resolve to a real key in `EMBEDDED_TM_AGENT_SOURCES` — no typo'd
+/// roster name that would silently degrade to a skipped agent at runtime.
+///
+/// Why: `load_embedded_default_agents` logs-and-skips a `Composed` entry
+/// whose name isn't found in `EMBEDDED_TM_AGENT_SOURCES` rather than
+/// panicking (see that function's doc) — a typo there would silently shrink
+/// the roster below 31 with only a log line as evidence. This test fails
+/// loudly in CI instead.
+/// What: for every `Composed` entry, asserts its (lowercased) name matches
+/// some `EMBEDDED_TM_AGENT_SOURCES` key with the `.md` suffix stripped.
+/// Test: this test.
+#[test]
+fn every_composed_roster_name_resolves_in_embedded_tm_agent_sources() {
+    let source_keys: Vec<String> = EMBEDDED_TM_AGENT_SOURCES
+        .iter()
+        .map(|(name, _)| name.trim_end_matches(".md").to_ascii_lowercase())
+        .collect();
+
+    for agent in DEFAULT_AGENTS {
+        if let EmbeddedAgent::Composed { name } = agent {
+            assert!(
+                source_keys.iter().any(|k| k == name),
+                "roster name '{name}' has no matching EMBEDDED_TM_AGENT_SOURCES key"
+            );
+        }
+    }
 }
 
 /// Every embedded skill name is unique and non-empty.

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -152,15 +152,18 @@ pub mod rbac;
 /// live provider tests.
 pub mod llm;
 
-/// Embedded default agents & skills (#2895).
+/// Embedded default agents & skills (#2895; roster expanded to 31 agents in
+/// Slice E3, #2958).
 ///
 /// Why: A fresh project has no `.claude/agents/` or `.claude/skills/` yet;
 /// bundling a working default set at compile time (mirroring, not sharing,
 /// `trusty-mpm`'s embed pattern) gives every project a usable harness before
 /// any project-level config exists. Disk-based config always wins when present.
-/// What: `EmbeddedAgent`/`DEFAULT_AGENTS` (three tcode agents, authored as
-/// Markdown+frontmatter as of #2897 Slice C); `EmbeddedSkill`/`DEFAULT_SKILLS`
-/// (trusty-mpm's universal skill set, minus the `tm-*` orchestration skills).
+/// What: `EmbeddedAgent`/`DEFAULT_AGENTS` (31 dispatchable tcode agents: the
+/// original 3, authored as Markdown+frontmatter as of #2897 Slice C, plus 28
+/// coding-relevant tm agents bundled and wired in as of Slice E, #2958);
+/// `EmbeddedSkill`/`DEFAULT_SKILLS` (trusty-mpm's universal skill set, minus
+/// the `tm-*` orchestration skills).
 /// Test: `assets::tests::*`.
 pub mod assets;
 


### PR DESCRIPTION
## Summary

Wires the 28 embedded tm agents bundled in Slice E2 (`b42b85f0`, #3029) into `trusty-code`'s embedded-agent composition layer, and applies Bob's reviewer-tools-restriction decision. **Refs #2958** (re-scoped from "closes" — see "Review follow-up" below; #2958 stays open pending #3046).

- **`assets::DEFAULT_AGENTS` grows from 3 to 31 entries.** New `EmbeddedAgent::Direct { name, md }` / `EmbeddedAgent::Composed { name }` enum: the original 3 defaults (`engineer`, `qa-agent`, `code-reviewer`) keep the existing flat `project_embedded_md` path (no `extends:`); the 28 roster agents are `Composed` entries resolved at load time via `agents::md_loader::project_embedded_md_with_extends` against `assets::EMBEDDED_TM_AGENT_SOURCES` (Slice E1's in-memory extends composer). `agents::load_embedded_default_agents` dispatches on the variant, log-and-skips (never panics) if a `Composed` entry somehow fails to resolve — covered as unreachable by `assets::tests::default_agents_parse_and_names_match`, which asserts every one of the 31 actually composes.
- **The 5 `BASE-*` templates remain extends-sources only, never dispatchable** — pinned by `assets::tests::base_templates_are_never_dispatchable`.
- **No name collisions across the 31** — pinned by `assets::tests::no_name_collisions_across_the_31_agent_roster`, which explicitly asserts tcode's own `engineer` is the only `engineer` entry (mpm's own `engineer` agent stays excluded from the roster upstream, per #2958's roster decision, precisely to avoid this collision).

## Review follow-up (code-critic WARN, addressed in `40927839`)

A code-critic review returned WARN with two HIGH + one MEDIUM finding. All three are addressed in the second commit:

1. **HIGH — no reachable production caller (NOT fixed here, now #3046).** Live CLI reproduction on a fresh project proved the embedded `DEFAULT_AGENTS` fallback (`agents::load_all_agents`'s empty/invalid-disk branch) has no reachable production caller today: `tcode run-task rust-engineer` AND `tcode run-task engineer` (one of the *original 3* defaults, predating this slice) both fail with "agent source not found". This is a pre-existing gap, not introduced by this PR, now tracked as **#3046**. Per review instruction I did **not** attempt the wiring fix here — I re-scoped this PR's claims instead: title/CHANGELOG changed from "closes #2958" to "refs #2958", and the CHANGELOG entry now says the composition layer + 31-agent roster definition are complete and tested (via `load_all_agents`/`load_embedded_default_agents` called directly in tests), while the CLI wiring that would make them reachable end-to-end is separate and still open.
2. **HIGH — web-qa.md prose contradicted its own new read-only allowlist.** The "Technical Testing Protocol" section instructed creating test scripts, running `CI=true npm test`, and `ps aux` process monitoring — none reachable under `[read_file, grep, glob, list_dir, search_code, use_skill, finish_task]`. Reworded the whole file to a genuinely read-only review/UAT-analysis mode: draft scenarios, a technical test-plan checklist, and exact recommended commands handed off to an engineer/ops/CI to execute — the agent never executes anything itself. Kept the UAT/business-intent phases (already read-only-compatible); reframed every execute-phase as a recommendation. Extended the "Tools-restriction deviation" doc block in `assets/mod.rs` to cover this additional prose deviation from trusty-mpm byte-parity.
3. **MEDIUM — same pattern, smaller.** `qa.md`'s methodology said "Implement"/"Execute" test suites directly; reworded to "specify test solutions for the engineer to implement" and "review results handed to you," plus reworded its "Process Discipline" section (which instructed running JS test commands directly) to recommendations for the engineer/CI. `code-analyzer.md`'s "Large-Volume Analysis" section told it to generate-and-run a Python script; reworded to recommend the script's content for the engineer to save and run.

`code-critic.md` needed no prose change — verified its review-only body has no execute-oriented instructions (`grep` for run/execute/bash/npm/curl/ps-aux language returns nothing).

Everything else from the review stood verified (enforcement chain sound, `use_skill` cannot bypass gating, tests falsifiable) — the follow-up commit touches only the three `.md` files, the CHANGELOG, and the deviation doc block in `assets/mod.rs` that documents them.

## Bob's tools-restriction decision (2026-07-18)

Four reviewer-intent roster agents — `qa`, `code-critic`, `code-analyzer`, `web-qa` — carry an explicit restrictive `tools:` frontmatter override in their tcode copy:

```yaml
tools: [read_file, grep, glob, list_dir, search_code, use_skill, finish_task]
```

This mirrors the read-only tool list tcode's own `code-reviewer` default already uses (no `write_file`/`edit`/`bash`), and is enforced the same way: `md_loader::project_to_agent_config` maps `tools:` directly onto `AgentConfig.tools.allowed`, and `runner::in_process::gated_registry` narrows the tool registry to that allowlist before the LLM loop starts (`ToolRegistry::dispatch_gated` rejects anything not on the list). `assets::tests::restricted_reviewer_agents_carry_read_only_tools` composes all four through the real extends path and asserts the exact allowed list, with an explicit check that none of `write_file`/`edit`/`bash` is present.

`documentation` and `research` stay byte-identical to trusty-mpm's source and unrestricted, per Bob's explicit ruling — they build docs and research reports, not verdicts. Pinned by `assets::tests::documentation_and_research_remain_unrestricted`.

**Byte-parity deviation note:** this deliberately deviates `qa.md`, `code-critic.md` (frontmatter only), `code-analyzer.md`, and `web-qa.md` from byte-parity with trusty-mpm's source files. I could **not** add an inline marker comment inside the frontmatter block itself — verified empirically that the shared frontmatter parser (`trusty_agents_common::agents::builder::split_frontmatter`) hard-errors on a bare `#`-comment line inside a frontmatter block. So the marker of record is the "Tools-restriction deviation" doc comment in `crates/trusty-code/src/assets/mod.rs` plus this PR description.

**⚠️ For whoever builds E4 (the CI staleness guard diffing tcode's copies against trusty-mpm's source): it MUST whitelist the `tools:` line AND the reworded prose sections in `qa.md`, `code-analyzer.md`, and `web-qa.md`, not just the `tools:` line, and not flag any of these four files as drift.**

## Tests

- `default_agents_parse_and_names_match` — all 31 compose, table key matches frontmatter `name:`.
- `base_templates_are_never_dispatchable` — none of the 5 `BASE-*` names appear in the roster.
- `no_name_collisions_across_the_31_agent_roster` — no duplicate names; `engineer` appears exactly once.
- `restricted_reviewer_agents_carry_read_only_tools` — the 4 restricted agents compose with the exact read-only tool list, no write/edit/bash.
- `documentation_and_research_remain_unrestricted` — both compose with `tools: None`.
- `every_composed_roster_name_resolves_in_embedded_tm_agent_sources` — every `Composed` name has a matching `EMBEDDED_TM_AGENT_SOURCES` key.
- `embedded_fallback_still_fires_and_yields_31_agents_with_original_3_intact` (renamed from the old 3-agent test) — the original 3 defaults are still first and intact; the full 31-name order matches `DEFAULT_AGENTS`'s declaration; no duplicates.
- Updated the three existing `load_all_agents_falls_back_*` tests in `agents/mod.rs` (empty dir, all-invalid dir, only-orphaned-toml dir) from the hardcoded 3-name vec to the shared 31-name `expected_default_agent_names()` helper.

## Quality gate (crate-scoped, per repo convention — re-run after the review follow-up commit)

```
cargo build -p trusty-code                                    -> clean
cargo test -p trusty-code --lib -- --test-threads=1            -> 1170 passed; 0 failed; 4 ignored
cargo test -p trusty-code --tests                               -> all binaries green (both default-parallel and --test-threads=1 runs clean on the re-run)
cargo clippy --workspace --all-targets -- -D warnings           -> exit 0
cargo fmt --check                                                -> exit 0
bash scripts/check_line_cap.sh                                  -> 9 allowlisted, 0 violations — OK
```

`cargo test -p trusty-code --tests` had intermittently failed one `run_task::tests::*` test unrelated to this change during earlier local runs — the pre-existing #3003 flake called out in the #2958 issue's gate note (a concurrent open PR is fixing it; `git diff` confirms this PR touches zero files under `src/run_task/`). The re-run after the review follow-up commit was clean on both the default parallel runner and `--test-threads=1`.

`scripts/check_test_pointers.sh` hung (confirmed via a 90s `timeout` kill, exit 124, no output) — per the task's known-issue note I did not block on it. I manually verified every `Test:` doc-comment pointer I added or touched resolves to a real, existing test function name.

Refs #2958. Reachable-CLI-dispatch follow-up tracked in #3046.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools