### PR TITLE
feat(trusty-code): pollable context-budget snapshot — cache + RPC + REST route (closes #3015)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Pollable context-budget snapshot — cache + `session.get_context_budget`
+  RPC + `GET /sessions/{id}/budget` REST route (#3015).** Closes the gap
+  behind PR #3014's GUI status bar rendering "budget: unavailable":
+  `record_context_budget` now caches a `ContextBudgetSnapshot`
+  (`crate::events`) on the session entry, mirroring how `record_index_readiness`
+  caches `IndexReadinessSnapshot`, so a client that attaches or reconnects
+  after a turn's `Event::ContextBudget` already fired can still retrieve it.
+  New `session.get_context_budget` JSON-RPC method (`session::protocol_budget`)
+  returns a tagged `ContextBudgetQuery` — `{"status":"recorded", ...}` or
+  `{"status":"never_recorded"}`, never a bare `null` — and a thin
+  `GET /sessions/{id}/budget` REST route in `serve::rest::sessions` forwards
+  to it, following the exact `session.get_readiness`/`GET .../readiness`
+  precedent.
+
 - **REST resource gateway — `task.run`/`fs.list_dir`/`session.get_agents`
   routes (#2983, #587, Slices 4-6).** Three more thin `axum` route groups on
   `tcode serve --http`, each calling `rest::respond` (or the new

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -702,6 +702,38 @@ pub struct IndexReadinessSnapshot {
     pub summary: String,
 }
 
+/// A cached snapshot of the `Event::ContextBudget` payload (issue #3015 —
+/// `session.get_context_budget` query RPC; surfaced by PR #3014's GUI status
+/// bar, which renders "budget: unavailable" waiting for exactly this API).
+///
+/// Why: `Event::ContextBudget` above is a per-turn STREAM value, not a
+/// queryable one — a client that attaches (or reconnects) between turns has
+/// no way to ask "what is the working-context budget right now"; it can only
+/// ever see events that arrive while it happens to be subscribed. This is
+/// the field-for-field twin of `Event::ContextBudget`'s payload (deliberately
+/// excluding `session_id`, contextual to the cache slot it lives in) so
+/// `SessionRegistry` can cache the last-recorded measurement per session and
+/// `session.get_context_budget` can hand it back verbatim to a
+/// late-attaching client — mirrors [`IndexReadinessSnapshot`] exactly.
+/// What: every field name and type matches the corresponding field on
+/// `Event::ContextBudget` exactly. `SessionRegistry::record_context_budget`
+/// builds one of these first and derives the `Event::ContextBudget` it
+/// publishes from it, so the two can never disagree. All-`Copy` (unlike
+/// `IndexReadinessSnapshot`) since every field is a primitive.
+/// Test: `session::registry_tests::record_context_budget_caches_snapshot_for_late_query`,
+/// `session::protocol_budget::tests::get_context_budget_returns_recorded_snapshot_after_recording`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ContextBudgetSnapshot {
+    pub context_window_tokens: usize,
+    pub overhead_tokens: usize,
+    pub overhead_cap_tokens: usize,
+    pub working_context_pct: u8,
+    pub overhead_pct: u8,
+    pub within_budget: bool,
+    pub compaction_fired: bool,
+    pub compaction_rounds: usize,
+}
+
 impl Event {
     /// Return the event's `session_id` if it has one. Used by the SSE
     /// handler to filter the broadcast stream to a single task subscription.

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -89,7 +89,8 @@ struct HttpState {
 /// returns [`health_payload`]; `GET /sessions/{id}/events` streams that
 /// session's ring-buffer replay then live events as SSE; `crate::serve::rest`
 /// merges in the `session.*` REST read routes (`GET /sessions`,
-/// `GET /sessions/{id}`, `.../transcript`, `.../readiness`, `.../goals`),
+/// `GET /sessions/{id}`, `.../transcript`, `.../readiness`, `.../goals`,
+/// (issue #3015) `.../budget`),
 /// (Slice 3) the write routes (`POST /sessions`,
 /// `POST /sessions/{id}/messages`, `POST /sessions/{id}/cancel`,
 /// `PUT`/`DELETE /sessions/{id}/goal`), (Slice 4) `POST /tasks`, (Slice 5)
@@ -104,7 +105,8 @@ struct HttpState {
 /// `http_rest_post_sessions_route_is_merged_in`,
 /// `http_rest_post_tasks_route_is_merged_in`,
 /// `http_rest_get_fs_route_is_merged_in`,
-/// `http_rest_get_session_agents_route_is_merged_in`.
+/// `http_rest_get_session_agents_route_is_merged_in`,
+/// `http_rest_get_session_budget_route_is_merged_in`.
 pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) -> AxumRouter {
     let state = HttpState {
         router: router.clone(),
@@ -586,6 +588,35 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert!(v["agents"].is_array());
+    }
+
+    /// `GET /sessions/{id}/budget` (issue #3015, part of the `rest::sessions`
+    /// route group `build_axum_router` already merges via
+    /// `rest::sessions::routes`) must be reachable on the SAME router
+    /// `GET /sessions/{id}/events` is — proving the merge actually wires the
+    /// route rather than silently dropping it. Per-route error/status-code
+    /// behaviour is already covered by `rest::sessions::tests`; this test
+    /// only pins the merge itself.
+    #[tokio::test]
+    async fn http_rest_get_session_budget_route_is_merged_in() {
+        let (router, sessions) = router_and_sessions();
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        let app = build_axum_router(router, sessions);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/sessions/{}/budget", session.id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["status"], "never_recorded");
     }
 
     /// `GET /sessions/{id}/events` on an unknown session must 404 with a

--- a/crates/trusty-code/src/serve/rest/sessions.rs
+++ b/crates/trusty-code/src/serve/rest/sessions.rs
@@ -18,6 +18,9 @@
 //!   - `GET /sessions/{id}/transcript` -> `session.get_transcript`
 //!   - `GET /sessions/{id}/readiness` -> `session.get_readiness`
 //!   - `GET /sessions/{id}/goals` -> `session.get_goals`
+//!   - `GET /sessions/{id}/budget` -> `session.get_context_budget` (issue
+//!     #3015 — the API PR #3014's GUI status bar polls instead of leaving
+//!     "budget: unavailable" permanently)
 //!
 //! `crate::serve::http::build_axum_router` merges this into the daemon's
 //! main router alongside `POST /rpc`, `GET /health`, and
@@ -60,6 +63,7 @@ pub fn routes(router: Arc<Router>) -> AxumRouter {
         .route("/sessions/{id}/transcript", get(get_transcript))
         .route("/sessions/{id}/readiness", get(get_readiness))
         .route("/sessions/{id}/goals", get(get_goals))
+        .route("/sessions/{id}/budget", get(get_context_budget))
         .with_state(SessionsState { router })
 }
 
@@ -131,6 +135,27 @@ async fn get_goals(State(state): State<SessionsState>, Path(id): Path<String>) -
     respond(
         &state.router,
         "session.get_goals",
+        json!({"session_id": id}),
+    )
+    .await
+}
+
+/// `GET /sessions/{id}/budget` -> `session.get_context_budget` (issue #3015).
+///
+/// Why: lets a late-attaching/reconnecting client (PR #3014's GUI status
+/// bar) query the working-context budget it may have missed on the SSE
+/// stream, instead of rendering "budget: unavailable" forever.
+/// What: `404` for an unknown `id`; otherwise the `ContextBudgetQuery` JSON
+/// (`{"status":"recorded",...}` or `{"status":"never_recorded"}`).
+/// Test: `tests::get_context_budget_found_returns_200_never_recorded`,
+/// `tests::get_context_budget_missing_returns_404_session_not_found`.
+async fn get_context_budget(
+    State(state): State<SessionsState>,
+    Path(id): Path<String>,
+) -> RestResult {
+    respond(
+        &state.router,
+        "session.get_context_budget",
         json!({"session_id": id}),
     )
     .await
@@ -295,6 +320,30 @@ mod tests {
         let (app, _sessions) = app_and_registry();
 
         let resp = get(&app, "/sessions/does-not-exist/goals").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32007);
+    }
+
+    /// `GET /sessions/{id}/budget` on a session with no recorded turn must
+    /// return HTTP 200 with `status: "never_recorded"`, not an error.
+    #[tokio::test]
+    async fn get_context_budget_found_returns_200_never_recorded() {
+        let (app, sessions) = app_and_registry();
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let resp = get(&app, &format!("/sessions/{}/budget", session.id)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["status"], "never_recorded");
+    }
+
+    /// `GET /sessions/{id}/budget` on an unknown id must 404.
+    #[tokio::test]
+    async fn get_context_budget_missing_returns_404_session_not_found() {
+        let (app, _sessions) = app_and_registry();
+
+        let resp = get(&app, "/sessions/does-not-exist/budget").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
         let v = body_json(resp).await;
         assert_eq!(v["error"]["code"], -32007);

--- a/crates/trusty-code/src/session/protocol.rs
+++ b/crates/trusty-code/src/session/protocol.rs
@@ -7,24 +7,27 @@
 //! `session.status`, `session.send`, `session.attach`, `session.detach`,
 //! `session.cancel`, (#2058) `session.get_transcript`, (#2350)
 //! `session.set_goal`/`session.clear_goal`/`session.get_goals`,
-//! (DOC-39 §5.6 Slice D) `session.get_readiness`, and (DOC-39 §5.4)
-//! `session.get_agents` onto a [`Router`], all
+//! (DOC-39 §5.6 Slice D) `session.get_readiness`, (DOC-39 §5.4)
+//! `session.get_agents`, and (issue #3015) `session.get_context_budget` onto
+//! a [`Router`], all
 //! closed over the SAME `Arc<SessionRegistry>` so every method sees a
 //! consistent view. Each handler parses its typed `params`, forwards to the
 //! matching `SessionRegistry` method, and maps the result onto the JSON-RPC
 //! result shape the vision spec's §4.3 examples describe.
 //! The three goal methods' handler bodies live in the sibling
 //! `protocol_goals` module, `session.get_readiness`'s in the sibling
-//! `protocol_readiness` module, and `session.get_agents`'s in the sibling
-//! `protocol_agents` module (all kept out of this file purely for the
-//! 500-SLOC cap — see each module's docs), but are registered here alongside
-//! every other `session.*` method so this remains the one place listing the
-//! full surface.
+//! `protocol_readiness` module, `session.get_agents`'s in the sibling
+//! `protocol_agents` module, and `session.get_context_budget`'s in the
+//! sibling `protocol_budget` module (all kept out of this file purely for
+//! the 500-SLOC cap — see each module's docs), but are registered here
+//! alongside every other `session.*` method so this remains the one place
+//! listing the full surface.
 //! Test: `protocol::tests::*` (parameter validation, error mapping);
 //! `protocol_goals::tests::*` (the three goal methods);
 //! `protocol_readiness::tests::*` (`session.get_readiness`);
-//! `protocol_agents::tests::*` (`session.get_agents`); the full attach/detach
-//! streaming behaviour is covered by `session::registry_tests`
+//! `protocol_agents::tests::*` (`session.get_agents`);
+//! `protocol_budget::tests::*` (`session.get_context_budget`); the full
+//! attach/detach streaming behaviour is covered by `session::registry_tests`
 //! (registry-level) and `tests/session_e2e.rs`/`tests/task_e2e.rs`
 //! (API-driven, real daemon).
 
@@ -162,6 +165,15 @@ pub fn register(router: &mut Router, registry: Arc<SessionRegistry>) {
         move |params: Value, ctx: ConnectionContext| {
             let r = r.clone();
             async move { protocol_agents::get_agents(&r, params, ctx).await }
+        },
+    );
+
+    let r = registry.clone();
+    router.register(
+        "session.get_context_budget",
+        move |params: Value, ctx: ConnectionContext| {
+            let r = r.clone();
+            async move { protocol_budget::get_context_budget(&r, params, ctx).await }
         },
     );
 }
@@ -412,6 +424,11 @@ mod protocol_readiness;
 #[path = "protocol_agents.rs"]
 mod protocol_agents;
 
+/// `session.get_context_budget` (issue #3015), split into its own file for
+/// the same 500-SLOC-cap reason as `protocol_goals` above.
+#[path = "protocol_budget.rs"]
+mod protocol_budget;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -446,6 +463,10 @@ mod tests {
             ("session.get_goals", json!({"session_id": session.id})),
             ("session.get_readiness", json!({"session_id": session.id})),
             ("session.get_agents", json!({"session_id": session.id})),
+            (
+                "session.get_context_budget",
+                json!({"session_id": session.id}),
+            ),
         ];
         for (method, params) in cases {
             let req = Request {

--- a/crates/trusty-code/src/session/protocol_budget.rs
+++ b/crates/trusty-code/src/session/protocol_budget.rs
@@ -1,0 +1,112 @@
+//! `session.get_context_budget` handler (issue #3015). Split out of
+//! `protocol.rs` purely to keep that production file under the crate's
+//! 500-SLOC cap — this is a child module of `protocol` (declared via
+//! `#[path = ...] mod protocol_budget;`), so it shares full access to
+//! `protocol`'s private `SessionIdParams`/`parse` helpers exactly as if this
+//! handler were still defined in that file.
+//!
+//! Why: `Event::ContextBudget` (`crate::events`) is a per-turn STREAM value
+//! (epic #2343 "Infinite Sessions") — a UI status bar that attaches after a
+//! turn already ran, or reconnects mid-session, has no way to ask "what is
+//! the working-context budget right now"; it can only ever see events that
+//! arrive while it happens to be attached. This is the query half PR #3014's
+//! GUI status bar needs (it currently renders "budget: unavailable" waiting
+//! for exactly this API): a client asks once, instead of hoping it was
+//! subscribed at the right moment. Mirrors `protocol_readiness` exactly.
+//! What: [`get_context_budget`] forwards to
+//! `SessionRegistry::get_context_budget`, returning its `ContextBudgetQuery`
+//! (`{"status":"recorded", ...snapshot fields}` or
+//! `{"status":"never_recorded"}`) verbatim as the JSON-RPC result.
+//! Test: `tests::*` in this module.
+
+use super::*;
+
+/// `session.get_context_budget(session_id) -> ContextBudgetQuery` (issue
+/// #3015).
+///
+/// Why: the query counterpart to the per-turn `Event::ContextBudget` stream
+/// — see module docs.
+/// What: `-32007 session_not_found` if `session_id` is unknown; otherwise
+/// `SessionRegistry::get_context_budget`'s `ContextBudgetQuery` verbatim —
+/// either the cached snapshot (`status: "recorded"`) or the typed "nothing
+/// recorded yet" result (`status: "never_recorded"`), never a bare `null`.
+/// Test: `tests::get_context_budget_returns_recorded_snapshot_after_recording`,
+/// `tests::get_context_budget_never_recorded_session_returns_never_recorded`,
+/// `tests::get_context_budget_unknown_session_maps_to_session_not_found`.
+pub(super) async fn get_context_budget(
+    registry: &SessionRegistry,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: SessionIdParams = parse(params, "session.get_context_budget")?;
+    Ok(json!(registry.get_context_budget(&p.session_id)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    fn test_ctx() -> ConnectionContext {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    fn measurement() -> crate::agent_loop::ContextBudgetSnapshot {
+        crate::agent_loop::ContextBudgetSnapshot {
+            context_window: 200_000,
+            overhead_tokens: 50_000,
+            overhead_cap_tokens: 80_000,
+            working_context_pct: 75,
+            overhead_pct: 25,
+            within_budget: true,
+            fired: false,
+            rounds: 1,
+        }
+    }
+
+    /// A session with no recorded measurement returns the typed
+    /// `never_recorded` result, not an error or a bare `null`.
+    #[tokio::test]
+    async fn get_context_budget_never_recorded_session_returns_never_recorded() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let result = get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "never_recorded");
+    }
+
+    /// Once a measurement has been recorded, `session.get_context_budget`
+    /// returns it with `status: "recorded"` and the snapshot fields
+    /// alongside.
+    #[tokio::test]
+    async fn get_context_budget_returns_recorded_snapshot_after_recording() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        registry
+            .record_context_budget(&session.id, &measurement())
+            .unwrap();
+
+        let result = get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "recorded");
+        assert_eq!(result["working_context_pct"], 75);
+        assert_eq!(result["within_budget"], true);
+        assert_eq!(result["context_window_tokens"], 200_000);
+    }
+
+    /// An unknown session must map to `-32007 session_not_found`.
+    #[tokio::test]
+    async fn get_context_budget_unknown_session_maps_to_session_not_found() {
+        let registry = SessionRegistry::new();
+        let err = get_context_budget(&registry, json!({"session_id": "nope"}), test_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+}

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -40,7 +40,7 @@ use uuid::Uuid;
 
 use crate::agent_loop::Transcript;
 use crate::binding::ProjectBinding;
-use crate::events::{Event, IndexReadinessSnapshot, SessionEventEnvelope};
+use crate::events::{ContextBudgetSnapshot, Event, IndexReadinessSnapshot, SessionEventEnvelope};
 use crate::jsonrpc::{NotifySender, RpcError};
 use crate::mode::HarnessMode;
 use crate::perf::TokenUsage;
@@ -114,6 +114,13 @@ struct SessionEntry {
     /// so a client that attaches AFTER the one-time `Event::IndexReadiness`
     /// fired can still retrieve the current state.
     readiness: Option<IndexReadinessSnapshot>,
+    /// (issue #3015) The most recently recorded [`ContextBudgetSnapshot`] for
+    /// this session — last-writer-wins, mirrors `readiness` above but for
+    /// `record_context_budget`'s per-turn measurement. `None` until the
+    /// session's first `Event::ContextBudget` fires (PM-only; a delegated
+    /// sub-agent loop never emits one), so `session.get_context_budget` can
+    /// distinguish "never recorded" from an all-zero snapshot.
+    context_budget: Option<ContextBudgetSnapshot>,
     /// (DOC-39 §5.4) Live per-agent roster, in first-seen order — the
     /// AUTHORITATIVE state `session.get_agents` reads (see
     /// `session::registry::agents`'s module docs). Updated by [`Self::record`]
@@ -316,6 +323,7 @@ impl SessionRegistry {
                     pm_transcript: None,
                     memory_sink: None,
                     readiness: None,
+                    context_budget: None,
                     agents: Vec::new(),
                 },
             );

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -24,8 +24,7 @@ use serde::Serialize;
 use super::*;
 use crate::tools::telemetry::{RecallTelemetry, SearchTelemetry};
 
-use crate::agent_loop::ContextBudgetSnapshot;
-use crate::events::IndexReadinessSnapshot;
+use crate::events::{ContextBudgetSnapshot, IndexReadinessSnapshot};
 
 /// `Event::IndexReadiness.state` when the semantic lane is queryable — an
 /// empty search result IS evidence of absence.
@@ -62,6 +61,28 @@ pub enum ReadinessQuery {
     Probed(IndexReadinessSnapshot),
     /// No `record_index_readiness` call has ever landed for this session.
     NeverProbed,
+}
+
+/// `session.get_context_budget`'s response payload (issue #3015).
+///
+/// Why: a session's working-context budget is a single cached value, not a
+/// collection — the same "typed nothing-yet, never a bare `null`" rationale
+/// as [`ReadinessQuery`] applies verbatim: a consumer must be able to tell
+/// "no turn has completed yet" from "a turn completed and every field
+/// happens to be zero" without a discriminant.
+/// What: `#[serde(tag = "status", rename_all = "snake_case")]` so the wire
+/// shape is `{"status":"recorded", ...snapshot fields}` for a session with a
+/// cached measurement, or `{"status":"never_recorded"}` for one with none.
+/// Test: `registry_tests::record_context_budget_caches_snapshot_for_late_query`,
+/// `protocol_budget::tests::get_context_budget_never_recorded_session_returns_never_recorded`.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ContextBudgetQuery {
+    /// A turn has completed for this session; wraps the last-recorded
+    /// snapshot.
+    Recorded(ContextBudgetSnapshot),
+    /// No `record_context_budget` call has ever landed for this session.
+    NeverRecorded,
 }
 
 impl SessionRegistry {
@@ -177,39 +198,95 @@ impl SessionRegistry {
             .unwrap_or(ReadinessQuery::NeverProbed))
     }
 
-    /// Record one turn's working-context budget measurement (epic #2343).
+    /// Record one turn's working-context budget measurement (epic #2343;
+    /// caches the snapshot for late queries as of issue #3015).
     ///
     /// Why: the Infinite Sessions guarantee (working context >= 60%, session
     /// overhead <= 40%) is enforced every single turn and was visible to
     /// nothing — `CadenceOutcome` was computed and dropped. This is the
     /// emission plumbing that lets `task::SessionToolEventSink` forward the
-    /// measurement to a `session.attach`ed UI's budget indicator.
-    /// What: maps a [`ContextBudgetSnapshot`] field-for-field onto
-    /// `Event::ContextBudget`; every value is already computed by the caller,
-    /// so this adds no arithmetic of its own. Errors with `session_not_found`
-    /// if `id` is unknown.
-    /// Test: `registry_tests::record_context_budget_publishes_event`.
+    /// measurement to a `session.attach`ed UI's budget indicator. (issue
+    /// #3015) Also caches the resulting [`ContextBudgetSnapshot`] on the
+    /// session (last-writer-wins), mirroring [`Self::record_index_readiness`],
+    /// so a client that attaches or reconnects AFTER a turn's event already
+    /// fired can still retrieve it via [`Self::get_context_budget`]/
+    /// `session.get_context_budget` — the API PR #3014's GUI status bar
+    /// polls instead of leaving "budget: unavailable" permanently.
+    /// What: maps the caller's `agent_loop::ContextBudgetSnapshot` field-for-
+    /// field onto a cached [`ContextBudgetSnapshot`] first, then derives
+    /// `Event::ContextBudget` from that cached value so the two can never
+    /// disagree; every value is already computed by the caller, so this adds
+    /// no arithmetic of its own. Errors with `session_not_found` if `id` is
+    /// unknown.
+    /// Test: `registry_tests::record_context_budget_publishes_event`,
+    /// `registry_tests::record_context_budget_caches_snapshot_for_late_query`.
     pub fn record_context_budget(
         &self,
         id: &str,
-        snapshot: &ContextBudgetSnapshot,
+        measurement: &crate::agent_loop::ContextBudgetSnapshot,
     ) -> Result<(), RpcError> {
         self.ensure_exists(id)?;
+        let snapshot = ContextBudgetSnapshot {
+            context_window_tokens: measurement.context_window,
+            overhead_tokens: measurement.overhead_tokens,
+            overhead_cap_tokens: measurement.overhead_cap_tokens,
+            working_context_pct: measurement.working_context_pct,
+            overhead_pct: measurement.overhead_pct,
+            within_budget: measurement.within_budget,
+            compaction_fired: measurement.fired,
+            compaction_rounds: measurement.rounds,
+        };
+        {
+            let mut sessions = self.lock();
+            if let Some(entry) = sessions.get_mut(id) {
+                entry.context_budget = Some(snapshot);
+            }
+        }
         self.record(
             id,
             Event::ContextBudget {
                 session_id: id.to_string(),
-                context_window_tokens: snapshot.context_window,
+                context_window_tokens: snapshot.context_window_tokens,
                 overhead_tokens: snapshot.overhead_tokens,
                 overhead_cap_tokens: snapshot.overhead_cap_tokens,
                 working_context_pct: snapshot.working_context_pct,
                 overhead_pct: snapshot.overhead_pct,
                 within_budget: snapshot.within_budget,
-                compaction_fired: snapshot.fired,
-                compaction_rounds: snapshot.rounds,
+                compaction_fired: snapshot.compaction_fired,
+                compaction_rounds: snapshot.compaction_rounds,
             },
         );
         Ok(())
+    }
+
+    /// `session.get_context_budget`: return the last-recorded working-context
+    /// budget measurement for a session, for clients that attach after the
+    /// per-turn `Event::ContextBudget` already fired (issue #3015).
+    ///
+    /// Why: [`Self::record_context_budget`] emits its event once per PM turn
+    /// boundary — a client that attaches (or reconnects) between turns has no
+    /// query surface to ask "what is the budget right now", only a stream it
+    /// may have missed. This is that query surface, the exact counterpart to
+    /// [`Self::get_readiness`].
+    /// What: `Err(session_not_found)` if `id` is unknown. Otherwise
+    /// [`ContextBudgetQuery::Recorded`] wrapping the cached
+    /// [`ContextBudgetSnapshot`] if a turn has ever completed for this
+    /// session, or [`ContextBudgetQuery::NeverRecorded`] — a distinct,
+    /// clearly-typed state, never a bare `null` — if no
+    /// `record_context_budget` call has happened yet (e.g. a session queried
+    /// before its first PM turn completes, or a delegated sub-agent session,
+    /// which never emits cadence budget events at all).
+    /// Test: `registry_tests::record_context_budget_caches_snapshot_for_late_query`,
+    /// `protocol_budget::tests::get_context_budget_never_recorded_session_returns_never_recorded`,
+    /// `registry_tests::get_context_budget_unknown_session_errors`.
+    pub fn get_context_budget(&self, id: &str) -> Result<ContextBudgetQuery, RpcError> {
+        self.ensure_exists(id)?;
+        Ok(self
+            .lock()
+            .get(id)
+            .and_then(|e| e.context_budget)
+            .map(ContextBudgetQuery::Recorded)
+            .unwrap_or(ContextBudgetQuery::NeverRecorded))
     }
 
     /// Record a tool invocation starting (#2055 emission plumbing for

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -1666,3 +1666,72 @@ async fn record_context_budget_publishes_event() {
             && compaction_rounds == 2
     ));
 }
+
+/// `record_context_budget` must cache the resulting [`events::ContextBudgetSnapshot`]
+/// on the session entry (issue #3015), so a LATER `get_context_budget` call —
+/// without ever re-subscribing to the event stream — retrieves the exact
+/// same state. Mirrors `record_index_readiness_caches_snapshot_for_late_query`.
+///
+/// Why: this is the registry-level half of the late-attaching-client
+/// guarantee: `Event::ContextBudget` fires once per turn and is easy to
+/// miss, so the cache `record_context_budget` writes (not the event itself)
+/// is what `get_context_budget` reads back.
+/// What: records a measurement, then calls `get_context_budget` and asserts
+/// it returns `ContextBudgetQuery::Recorded` with fields matching what was
+/// just recorded.
+/// Test: this test.
+#[tokio::test]
+async fn record_context_budget_caches_snapshot_for_late_query() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let snapshot = crate::agent_loop::ContextBudgetSnapshot {
+        context_window: 200_000,
+        overhead_tokens: 50_000,
+        overhead_cap_tokens: 80_000,
+        working_context_pct: 75,
+        overhead_pct: 25,
+        within_budget: true,
+        fired: true,
+        rounds: 2,
+    };
+    registry
+        .record_context_budget(&session.id, &snapshot)
+        .unwrap();
+
+    let queried = registry.get_context_budget(&session.id).unwrap();
+    match queried {
+        events::ContextBudgetQuery::Recorded(cached) => {
+            assert_eq!(cached.context_window_tokens, 200_000);
+            assert_eq!(cached.working_context_pct, 75);
+            assert!(cached.within_budget);
+            assert!(cached.compaction_fired);
+            assert_eq!(cached.compaction_rounds, 2);
+        }
+        events::ContextBudgetQuery::NeverRecorded => {
+            panic!("expected a cached snapshot after record_context_budget, got NeverRecorded")
+        }
+    }
+}
+
+/// `get_context_budget` on a session with no recorded measurement must
+/// return the typed `NeverRecorded` variant, not an error or a bare `null`.
+/// Test: this test.
+#[tokio::test]
+async fn get_context_budget_never_recorded_returns_never_recorded() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let queried = registry.get_context_budget(&session.id).unwrap();
+    assert!(matches!(queried, events::ContextBudgetQuery::NeverRecorded));
+}
+
+/// `get_context_budget` against an unknown session must error, not panic —
+/// mirrors every other registry method's `session_not_found` convention.
+/// Test: this test.
+#[tokio::test]
+async fn get_context_budget_unknown_session_errors() {
+    let registry = SessionRegistry::new();
+    let err = registry.get_context_budget("nope").unwrap_err();
+    assert_eq!(err.code, -32007);
+}


### PR DESCRIPTION
## Summary

- Caches a `ContextBudgetSnapshot` (`crate::events`) on the session entry inside `record_context_budget`, mirroring how `record_index_readiness` caches `IndexReadinessSnapshot` — a late-attaching/reconnecting client can now retrieve the last-recorded working-context budget instead of only ever seeing the per-turn `Event::ContextBudget` stream.
- Adds `session.get_context_budget` JSON-RPC method (`session::protocol_budget`, following `protocol_readiness`'s exact registration/param/response conventions), returning a tagged `ContextBudgetQuery` — `{"status":"recorded", ...snapshot fields}` or `{"status":"never_recorded"}` — never a bare `null`, so a caller can distinguish "no turn has completed yet" from a session that doesn't exist.
- Adds `GET /sessions/{id}/budget` REST route in `serve::rest::sessions`, a thin `respond`/`RestResult` wrapper over the new RPC, plus a `http_rest_get_session_budget_route_is_merged_in` pin test in `serve::http` proving `build_axum_router` actually wires it.
- Closes the gap behind PR #3014's GUI status bar, which currently renders "budget: unavailable" waiting for exactly this API. The GUI swap itself is an explicit follow-up, not part of this PR.

Refs #2983 (REST gateway, merged). Closes #3015.

## Test plan

- [x] `cargo build -p trusty-code`
- [x] `cargo test -p trusty-code --lib -- --test-threads=1` — 1186 passed, 0 failed
- [x] `cargo test -p trusty-code --tests` — 1186 lib + all integration suites passed (session_e2e, task_e2e, readiness_e2e, agents_e2e, m1_cutline_e2e, etc.)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `9 allowlisted, 0 violations — OK`
- [x] New tests cover: cached-snapshot-for-late-query at the registry level, never-recorded/recorded/unknown-session at the RPC layer, found/never-recorded/missing at the REST layer, and the merged-router pin test

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools