### PR TITLE
feat(trusty-code-gui): status bar renders live context budget (refs #3015, DOC-39 §6.2)

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -84,6 +84,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   #3043):** the wire types match the shipped Rust field names
   (`working_context_pct`, `compaction_fired`) verbatim, not DOC-39 §5.6's
   stale `working_pct`/`fired` prose — the code is the source of truth.
+  **Known gap (issue #3050):** AC-5.9 requires a distinct "not applicable"
+  state for non-PM sessions (cadence is PM-only); `ContextBudgetQuery` has
+  no PM/cadence discriminant on the wire yet, so non-PM sessions render as
+  "no data yet" rather than "not applicable" until #3050 lands the
+  discriminant.
 - Phase-1 status bar: readiness + budget chrome per DOC-39 §6.2 (refs #2983).
   `StatusBar.svelte` polls `GET /sessions` then `GET /sessions/{id}/readiness`
   (REST Slice 2, squash 15156b42) every 5s via a Svelte 5 `$effect` whose

--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -64,6 +64,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Status bar renders the real context budget instead of the "unavailable"
+  placeholder described below (refs #3015, DOC-39 §4.5/§6.2).
+  `StatusBar.svelte` polls the now-shipped `GET /sessions/{id}/budget`
+  (PR #3042, squash `0bec593f`) in the same `refresh()` cycle, sharing the
+  existing `AbortController` and post-`await` `signal.aborted` guards, and
+  degrades a budget-route failure to a "no data yet" label rather than
+  dropping the whole status bar to `daemon-unreachable` — the same
+  partial-failure discipline already applied to the readiness fetch. Renders
+  `recorded` as `"NN% working"` (appending `", compacted"` when
+  `compaction_fired`, DOC-39 §4.5 AC-5.8) and `never_recorded` as a labeled
+  `"no data yet"` — never a fabricated `0%`. `within_budget === false` gets a
+  distinct red (`bg-status-error`/`text-status-error`) treatment per
+  AC-5.7's "red `--gap`" requirement. New `lib/context-budget.ts`
+  (`ContextBudgetQuery`/`ContextBudgetSnapshot` wire types plus
+  `classifyBudget`/`budgetLabel`/`budgetDotClass`/`budgetTitle`, covered by
+  `context-budget.test.ts`) holds the pure formatting/threshold logic,
+  mirroring the `lib/session-status.ts` split. **Naming note (issue
+  #3043):** the wire types match the shipped Rust field names
+  (`working_context_pct`, `compaction_fired`) verbatim, not DOC-39 §5.6's
+  stale `working_pct`/`fired` prose — the code is the source of truth.
 - Phase-1 status bar: readiness + budget chrome per DOC-39 §6.2 (refs #2983).
   `StatusBar.svelte` polls `GET /sessions` then `GET /sessions/{id}/readiness`
   (REST Slice 2, squash 15156b42) every 5s via a Svelte 5 `$effect` whose
@@ -78,12 +98,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   session to reflect. Mounted as `<StatusBar>` in `App.svelte`, structurally
   a **sibling of `.body`**, never nested inside it, per DOC-39 §8.1 /
   AC-18.1 — pinned by a new `App.test.ts` DOM-structure test (`pnpm test`,
-  vitest + jsdom, new devDependencies). **Data gap:** the budget half of the
-  status bar renders a labeled "unavailable" placeholder — `Event::ContextBudget`
-  is emitted on the SSE stream but never cached on the session the way
-  `IndexReadinessSnapshot` is, so there is no `session.get_context_budget`
-  RPC or `GET /sessions/{id}/budget` REST route to poll yet; tracked as a
-  REST-slice follow-up rather than adding a new daemon endpoint in this PR.
+  vitest + jsdom, new devDependencies). **Data gap (RESOLVED, see the Added
+  entry above this one):** at the time this PR shipped, the budget half of
+  the status bar rendered a labeled "unavailable" placeholder —
+  `Event::ContextBudget` was emitted on the SSE stream but never cached on
+  the session the way `IndexReadinessSnapshot` is, so there was no
+  `session.get_context_budget` RPC or `GET /sessions/{id}/budget` REST route
+  to poll; tracked as a REST-slice follow-up rather than adding a new daemon
+  endpoint in this PR. That follow-up (issue #3015) landed in PR #3042 and
+  the placeholder was swapped for live data in this same [Unreleased]
+  window.
 - Initial scaffold: Tauri 2 + Svelte 5 desktop shell for the `trusty-code`
   (tcode) daemon, mirroring `crates/trusty-mpm-gui`'s structure (refs #2983,
   `docs/specs/trusty-code-harness-ui.md`). A single `get_daemon_url` IPC

--- a/crates/trusty-code-gui/ui/src/components/StatusBar.svelte
+++ b/crates/trusty-code-gui/ui/src/components/StatusBar.svelte
@@ -1,41 +1,47 @@
 <script lang="ts">
   // Why: DOC-39 §6.2 Phase 1 UI — "the status bar (readiness + budget)".
-  // Readiness is pure wiring: `GET /sessions` + `GET /sessions/{id}/readiness`
-  // landed with REST Slice 2 (#2983, squash 15156b42) and this component is
-  // a thin `fetch()` client over them, identically to `HealthPanel.svelte`
-  // (no Tauri command, no client-side computation of daemon state).
+  // Both halves are pure wiring: `GET /sessions` + `GET /sessions/{id}/readiness`
+  // landed with REST Slice 2 (#2983, squash 15156b42), and `GET
+  // /sessions/{id}/budget` (issue #3015, PR #3042, squash 0bec593f) closed
+  // the budget data gap this component previously called out — this is a
+  // thin `fetch()` client over both, identically to `HealthPanel.svelte`
+  // (no Tauri command, no client-side computation of daemon state beyond
+  // the DOC-39 §4.5 AC-5.7 threshold classification in
+  // `lib/context-budget.ts`).
   //
-  // Budget is a DATA GAP, not a rendering gap: `Event::ContextBudget`
-  // (`crates/trusty-code/src/events.rs`) is emitted on the SSE stream but
-  // never cached on the session the way `IndexReadinessSnapshot` is
-  // (`SessionRegistry::record_context_budget` calls `self.record(...)` only —
-  // compare `record_index_readiness`, which also writes `entry.readiness`).
-  // There is today no `session.get_context_budget` RPC and therefore no
-  // `GET /sessions/{id}/budget` REST route to poll. Per the layer-priority
-  // rule this PR does NOT add one; the budget slot renders a labeled
-  // "unavailable" state instead of being silently omitted (DOC-39 AC-5.1:
-  // "an invisible budget is not a budget") and the gap is called out in the
-  // PR body as a REST-slice follow-up.
-  //
-  // What: Polls `GET /sessions` then `GET /sessions/{id}/readiness` for the
-  // session `pickActiveSession` selects, every `POLL_MS`, via a Svelte 5
-  // `$effect` that returns its own teardown — no `onMount`/`onDestroy`. The
-  // teardown clears the interval AND aborts one `AbortController` shared by
-  // every poll's `fetch()` calls; `refresh()` also re-checks `signal.aborted`
-  // after each `await` before writing `phase`/`session`/`readiness`/`error`,
-  // so an in-flight poll genuinely abandons its result on unmount (the
-  // network request is cancelled, not merely ignored) rather than racing a
-  // disposed effect scope. Renders one of four states: `daemon-unreachable`
-  // (the `/sessions` fetch itself failed), `no-session` (daemon reachable,
-  // zero sessions), `ready` (readiness + the budget placeholder), each as a
-  // `.statusbar` child — never hidden, per DOC-39 §4.4 AC-4.2's "locked, not
-  // hidden" chrome rule.
+  // What: Polls `GET /sessions` then `GET /sessions/{id}/readiness` and
+  // `GET /sessions/{id}/budget` for the session `pickActiveSession` selects,
+  // every `POLL_MS`, via a Svelte 5 `$effect` that returns its own teardown
+  // — no `onMount`/`onDestroy`. The teardown clears the interval AND aborts
+  // one `AbortController` shared by every poll's `fetch()` calls;
+  // `refresh()` also re-checks `signal.aborted` after each `await` before
+  // writing `phase`/`session`/`readiness`/`budget`/`error`, so an in-flight
+  // poll genuinely abandons its result on unmount (the network request is
+  // cancelled, not merely ignored) rather than racing a disposed effect
+  // scope. Renders one of four states: `daemon-unreachable` (the
+  // `/sessions` fetch itself failed), `no-session` (daemon reachable, zero
+  // sessions), `ready` (readiness + the budget slot — `recorded` renders the
+  // real working-context %, `never_recorded` renders a labeled "no data
+  // yet" rather than a fabricated `0%`), each as a `.statusbar` child —
+  // never hidden, per DOC-39 §4.4 AC-4.2's "locked, not hidden" chrome
+  // rule. A budget fetch failure (session reachable, budget route errors)
+  // degrades the budget slot to "no data yet" without dropping the whole
+  // status bar to `daemon-unreachable`, mirroring the existing readiness
+  // partial-failure handling below.
   //
   // Test: `session-status.test.ts` covers `pickActiveSession`;
-  // `App.test.ts` asserts the DOC-39 §8.1 AC-18.1 DOM invariant
-  // (`.statusbar` is a sibling of `.body`, not a descendant) that this
-  // component's root class participates in.
+  // `context-budget.test.ts` covers `classifyBudget`/`budgetLabel`/
+  // `budgetDotClass`/`budgetTitle`; `App.test.ts` asserts the DOC-39 §8.1
+  // AC-18.1 DOM invariant (`.statusbar` is a sibling of `.body`, not a
+  // descendant) that this component's root class participates in.
   import { apiBase } from '../lib/api-config';
+  import {
+    budgetDotClass,
+    budgetLabel,
+    budgetTitle,
+    classifyBudget,
+    type ContextBudgetQuery,
+  } from '../lib/context-budget';
   import {
     pickActiveSession,
     type ReadinessQuery,
@@ -50,6 +56,7 @@
   let phase = $state<Phase>('connecting');
   let session = $state<SessionSummary | null>(null);
   let readiness = $state<ReadinessQuery | null>(null);
+  let budget = $state<ContextBudgetQuery | null>(null);
   let error = $state<string | null>(null);
 
   async function refresh(signal: AbortSignal) {
@@ -76,6 +83,7 @@
         phase = 'daemon-unreachable';
         session = null;
         readiness = null;
+        budget = null;
         error = e instanceof Error ? e.message : String(e);
       }
       return;
@@ -87,6 +95,7 @@
       phase = 'no-session';
       session = null;
       readiness = null;
+      budget = null;
       error = null;
       return;
     }
@@ -108,6 +117,21 @@
         readiness = null;
         error = e instanceof Error ? e.message : String(e);
       }
+    }
+    if (signal.aborted) return;
+
+    try {
+      const res = await fetch(`${base}/sessions/${active.id}/budget`, { signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as ContextBudgetQuery;
+      if (signal.aborted) return;
+      budget = body;
+    } catch {
+      // Same partial-failure discipline as readiness above: the session is
+      // reachable, so a budget-route error degrades to "no data yet"
+      // (`budget = null`) rather than dropping the whole status bar to
+      // `daemon-unreachable`.
+      if (!signal.aborted) budget = null;
     }
   }
 
@@ -165,8 +189,12 @@
         <span class={`h-1.5 w-1.5 rounded-full ${readinessDotClass()}`}></span>
         readiness: {readinessLabel()}
       </span>
-      <span class="text-trusty-text/40" title="Budget: no poll-able REST route yet (Event::ContextBudget is SSE-only and not cached on the session) — tracked as a REST-slice follow-up">
-        budget: unavailable
+      <span
+        class={`flex items-center gap-1.5 ${classifyBudget(budget) === 'warn' ? 'text-status-error' : ''}`}
+        title={budgetTitle(budget)}
+      >
+        <span class={`h-1.5 w-1.5 rounded-full ${budgetDotClass(budget)}`}></span>
+        budget: {budgetLabel(budget)}
       </span>
     </div>
     {#if session}

--- a/crates/trusty-code-gui/ui/src/lib/context-budget.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/context-budget.test.ts
@@ -1,0 +1,108 @@
+// Why: `classifyBudget`/`budgetLabel`/`budgetDotClass`/`budgetTitle` are the
+// status bar's only client-side logic for the budget slot — a flipped
+// threshold or a fabricated "0%" for `never_recorded` would be silently
+// wrong with no error to surface it, so each case is pinned directly.
+// What: covers the three query shapes (`null`, `never_recorded`, `recorded`)
+// crossed with the `within_budget`/`compaction_fired` flags that change
+// output.
+// Test: this file.
+import { describe, expect, it } from 'vitest';
+import {
+  budgetDotClass,
+  budgetLabel,
+  budgetTitle,
+  classifyBudget,
+  type ContextBudgetQuery,
+} from './context-budget';
+
+function recorded(overrides: Partial<Extract<ContextBudgetQuery, { status: 'recorded' }>> = {}) {
+  return {
+    status: 'recorded' as const,
+    context_window_tokens: 200_000,
+    overhead_tokens: 50_000,
+    overhead_cap_tokens: 80_000,
+    working_context_pct: 75,
+    overhead_pct: 25,
+    within_budget: true,
+    compaction_fired: false,
+    compaction_rounds: 0,
+    ...overrides,
+  };
+}
+
+const neverRecorded: ContextBudgetQuery = { status: 'never_recorded' };
+
+describe('classifyBudget', () => {
+  it('treats null (not fetched yet) as no-data', () => {
+    expect(classifyBudget(null)).toBe('no-data');
+  });
+
+  it('treats never_recorded as no-data', () => {
+    expect(classifyBudget(neverRecorded)).toBe('no-data');
+  });
+
+  it('classifies within_budget=true as ok', () => {
+    expect(classifyBudget(recorded({ within_budget: true }))).toBe('ok');
+  });
+
+  it('classifies within_budget=false as warn', () => {
+    expect(classifyBudget(recorded({ within_budget: false }))).toBe('warn');
+  });
+});
+
+describe('budgetDotClass', () => {
+  it('maps ok to bg-status-ok', () => {
+    expect(budgetDotClass(recorded({ within_budget: true }))).toBe('bg-status-ok');
+  });
+
+  it('maps warn to bg-status-error (DOC-39 §4.5 AC-5.7 red gap token)', () => {
+    expect(budgetDotClass(recorded({ within_budget: false }))).toBe('bg-status-error');
+  });
+
+  it('maps no-data to bg-status-neutral', () => {
+    expect(budgetDotClass(neverRecorded)).toBe('bg-status-neutral');
+    expect(budgetDotClass(null)).toBe('bg-status-neutral');
+  });
+});
+
+describe('budgetLabel', () => {
+  it('renders "no data yet" for null, never a fake percentage', () => {
+    expect(budgetLabel(null)).toBe('no data yet');
+  });
+
+  it('renders "no data yet" for never_recorded', () => {
+    expect(budgetLabel(neverRecorded)).toBe('no data yet');
+  });
+
+  it('renders the working-context percentage for a recorded snapshot', () => {
+    expect(budgetLabel(recorded({ working_context_pct: 82, compaction_fired: false }))).toBe(
+      '82% working',
+    );
+  });
+
+  it('appends a compaction cue when compaction_fired (AC-5.8)', () => {
+    expect(budgetLabel(recorded({ working_context_pct: 58, compaction_fired: true }))).toBe(
+      '58% working, compacted',
+    );
+  });
+});
+
+describe('budgetTitle', () => {
+  it('explains the gap for null/never_recorded', () => {
+    expect(budgetTitle(null)).toMatch(/no context-budget measurement/i);
+    expect(budgetTitle(neverRecorded)).toMatch(/no context-budget measurement/i);
+  });
+
+  it('includes token counts for a recorded snapshot', () => {
+    const title = budgetTitle(
+      recorded({ context_window_tokens: 200_000, overhead_pct: 25, overhead_cap_tokens: 80_000 }),
+    );
+    expect(title).toContain('200000 tokens');
+    expect(title).toContain('25%');
+  });
+
+  it('includes the compaction round count when compaction_fired', () => {
+    const title = budgetTitle(recorded({ compaction_fired: true, compaction_rounds: 2 }));
+    expect(title).toContain('compacted 2x');
+  });
+});

--- a/crates/trusty-code-gui/ui/src/lib/context-budget.ts
+++ b/crates/trusty-code-gui/ui/src/lib/context-budget.ts
@@ -1,0 +1,124 @@
+// Why: `StatusBar.svelte` needs the wire shape for `GET /sessions/{id}/budget`
+// (issue #3015, PR #3042) plus the small formatting/threshold-classification
+// rules DOC-39 §4.5 attaches to it (AC-5.6 render the real ratio, AC-5.7 make
+// `within_budget == false` visually distinct, AC-5.8's compaction cue).
+// Extracted into its own module — rather than inlined in the component, the
+// way `readinessLabel`/`readinessDotClass` currently are — because it is
+// pure/testable logic independent of DOM/polling concerns, mirroring the
+// split `session-status.ts` already established for `pickActiveSession`.
+//
+// CRITICAL naming note (issue #3043): DOC-39 §5.6's prose uses
+// `working_pct`/`fired`, but the shipped Rust types
+// (`crate::events::ContextBudgetSnapshot`,
+// `crate::session::registry_events::ContextBudgetQuery`) use
+// `working_context_pct`/`compaction_fired`. This file mirrors the CODE
+// verbatim — the spec prose is stale, not the source of truth.
+//
+// What: `ContextBudgetSnapshot`/`ContextBudgetQuery` wire types, plus three
+// pure functions: `classifyBudget` (visual-state threshold classification),
+// `budgetLabel` (status-bar text), `budgetTitle` (hover detail). All three
+// accept `null` for "not fetched yet" and treat it identically to
+// `never_recorded` — the status bar has nothing honest to say about a budget
+// it hasn't queried, so the two states render the same "no data yet" cue
+// rather than a silently-different third label.
+// Test: `context-budget.test.ts`.
+
+/** Mirrors `crate::events::ContextBudgetSnapshot` field-for-field. */
+export interface ContextBudgetSnapshot {
+  context_window_tokens: number;
+  overhead_tokens: number;
+  overhead_cap_tokens: number;
+  working_context_pct: number;
+  overhead_pct: number;
+  within_budget: boolean;
+  compaction_fired: boolean;
+  compaction_rounds: number;
+}
+
+/** Mirrors `crate::session::registry_events::ContextBudgetQuery`
+ * (`#[serde(tag = "status", rename_all = "snake_case")]`). */
+export type ContextBudgetQuery =
+  | ({ status: 'recorded' } & ContextBudgetSnapshot)
+  | { status: 'never_recorded' };
+
+/** The status bar's visual treatment for the budget slot. `'warn'` is the
+ * DOC-39 §4.5 AC-5.7 floor breach (`within_budget === false`); `'no-data'`
+ * covers both `never_recorded` and "not fetched yet" (`null`) — genuinely
+ * indistinguishable states from the client's point of view, and both must
+ * render as an honest gap, never a fabricated ok/warn guess. */
+export type BudgetVisualState = 'ok' | 'warn' | 'no-data';
+
+/**
+ * Classify a budget query into its status-bar visual treatment.
+ *
+ * Why: DOC-39 §4.5 AC-5.7 requires `within_budget === false` to be visually
+ * distinguishable (red, the spec's `--gap` token) from the healthy case —
+ * this is the one threshold decision the status bar makes.
+ * What: `null` or `{status: 'never_recorded'}` -> `'no-data'`;
+ * `within_budget === false` -> `'warn'`; otherwise `'ok'`.
+ * Test: `context-budget.test.ts::classifyBudget`.
+ */
+export function classifyBudget(query: ContextBudgetQuery | null): BudgetVisualState {
+  if (!query || query.status === 'never_recorded') return 'no-data';
+  return query.within_budget ? 'ok' : 'warn';
+}
+
+/**
+ * Status-dot Tailwind class for a budget query, reusing the same
+ * `bg-status-*` token set `readinessDotClass` (`StatusBar.svelte`) already
+ * establishes — `'warn'` maps to `status-error` (red), matching DOC-39 §4.5
+ * AC-5.7's "red `--gap` per the token map" (this codebase has no separate
+ * `--gap` token; `status-error` is the red already in use for the
+ * daemon-unreachable state).
+ * Test: `context-budget.test.ts::budgetDotClass`.
+ */
+export function budgetDotClass(query: ContextBudgetQuery | null): string {
+  switch (classifyBudget(query)) {
+    case 'ok':
+      return 'bg-status-ok';
+    case 'warn':
+      return 'bg-status-error';
+    default:
+      return 'bg-status-neutral';
+  }
+}
+
+/**
+ * One-line status-bar label.
+ *
+ * Why: AC-5.6 the status bar must render the real working-context ratio,
+ * not an estimate; AC-5.8 a fired compaction must be observable — this is
+ * the lightweight status-bar cue for that (the fuller thread-level marker
+ * §4.7 describes is a separate, not-yet-built surface). `never_recorded`
+ * renders "no data yet", never a fake `0%` — DOC-39's own framing: "an
+ * invisible budget is not a budget", and a fabricated zero is worse than
+ * invisible because it looks like real data.
+ * What: `null`/`never_recorded` -> `"no data yet"`;
+ * `recorded` -> `"NN% working"`, `", compacted"` appended when
+ * `compaction_fired`.
+ * Test: `context-budget.test.ts::budgetLabel`.
+ */
+export function budgetLabel(query: ContextBudgetQuery | null): string {
+  if (!query || query.status === 'never_recorded') return 'no data yet';
+  const compactionNote = query.compaction_fired ? ', compacted' : '';
+  return `${query.working_context_pct}% working${compactionNote}`;
+}
+
+/**
+ * Hover-detail (`title` attribute) text for the budget slot — the
+ * per-token-count/overhead detail that doesn't fit the one-line label.
+ * Test: `context-budget.test.ts::budgetTitle`.
+ */
+export function budgetTitle(query: ContextBudgetQuery | null): string {
+  if (!query || query.status === 'never_recorded') {
+    return 'No context-budget measurement recorded yet for this session';
+  }
+  const roundsNote = query.compaction_fired
+    ? `, compacted ${query.compaction_rounds}x`
+    : '';
+  return (
+    `context window ${query.context_window_tokens} tokens — ` +
+    `overhead ${query.overhead_pct}% (cap from ${query.overhead_cap_tokens} tokens)` +
+    `${roundsNote}`
+  );
+}

--- a/crates/trusty-code-gui/ui/src/lib/context-budget.ts
+++ b/crates/trusty-code-gui/ui/src/lib/context-budget.ts
@@ -21,6 +21,12 @@
 // `never_recorded` — the status bar has nothing honest to say about a budget
 // it hasn't queried, so the two states render the same "no data yet" cue
 // rather than a silently-different third label.
+//
+// Known gap (issue #3050, see `classifyBudget`/`budgetLabel` docstrings):
+// DOC-39 §4.5 AC-5.9 requires a distinct "not applicable" state for non-PM
+// sessions (cadence is PM-only). `ContextBudgetQuery` carries no PM/cadence
+// discriminant on the wire today, so non-PM sessions render as "no data
+// yet" rather than "not applicable" until #3050 adds that discriminant.
 // Test: `context-budget.test.ts`.
 
 /** Mirrors `crate::events::ContextBudgetSnapshot` field-for-field. */
@@ -56,6 +62,15 @@ export type BudgetVisualState = 'ok' | 'warn' | 'no-data';
  * this is the one threshold decision the status bar makes.
  * What: `null` or `{status: 'never_recorded'}` -> `'no-data'`;
  * `within_budget === false` -> `'warn'`; otherwise `'ok'`.
+ *
+ * **Known gap (issue #3050):** AC-5.9 requires a distinct "not applicable"
+ * treatment for non-PM sessions (cadence is PM-only —
+ * `AgentLoopConfig.cadence` defaults `None`; only `task/executor.rs:327`
+ * sets `Some`), rather than implying an unmanaged context. `ContextBudgetQuery`
+ * carries no PM/cadence discriminant on the wire today, so this function
+ * cannot tell "non-PM session, will never record" from "PM session, hasn't
+ * completed a turn yet" — both collapse to `'no-data'` until #3050 adds the
+ * discriminant. Do not paper over this with client-side PM heuristics.
  * Test: `context-budget.test.ts::classifyBudget`.
  */
 export function classifyBudget(query: ContextBudgetQuery | null): BudgetVisualState {
@@ -96,6 +111,11 @@ export function budgetDotClass(query: ContextBudgetQuery | null): string {
  * What: `null`/`never_recorded` -> `"no data yet"`;
  * `recorded` -> `"NN% working"`, `", compacted"` appended when
  * `compaction_fired`.
+ *
+ * **Known gap (issue #3050):** AC-5.9's "not applicable" state for non-PM
+ * sessions requires a wire discriminant that doesn't exist yet — tracked
+ * #3050; until then non-PM sessions render as `"no data yet"`, same as a PM
+ * session that simply hasn't completed a turn.
  * Test: `context-budget.test.ts::budgetLabel`.
  */
 export function budgetLabel(query: ContextBudgetQuery | null): string {


### PR DESCRIPTION
## Summary

- Swaps the GUI status bar's `budget: unavailable` placeholder for real data from the just-merged budget API (PR #3042, squash `0bec593f`, closes #3015).
- `StatusBar.svelte` polls `GET /sessions/{id}/budget` in the same `refresh()` cycle as readiness, sharing the existing `AbortController` and post-`await` `signal.aborted` guards. A budget-route error degrades the budget slot to a labeled "no data yet" instead of dropping the whole status bar to `daemon-unreachable` — same partial-failure discipline already applied to readiness.
- Renders `recorded` as `"NN% working"` (appending `", compacted"` when `compaction_fired`, DOC-39 §4.5 AC-5.8) and `never_recorded` as a labeled `"no data yet"` — never a fabricated `0%`. `within_budget === false` gets a distinct red (`bg-status-error`/`text-status-error`) dot+text treatment per AC-5.7's "red `--gap`" requirement.
- New `crates/trusty-code-gui/ui/src/lib/context-budget.ts` holds the wire types (`ContextBudgetQuery`/`ContextBudgetSnapshot`) and pure `classifyBudget`/`budgetLabel`/`budgetDotClass`/`budgetTitle` helpers, mirroring the existing `lib/session-status.ts` split — component stays a thin renderer, logic is unit-tested independently.
- **Naming note (issue #3043):** the TS wire types mirror the shipped Rust field names verbatim (`working_context_pct`, `compaction_fired`), NOT DOC-39 §5.6's stale `working_pct`/`fired` prose — the code (`crates/trusty-code/src/events.rs::ContextBudgetSnapshot`, `crates/trusty-code/src/session/registry_events.rs::ContextBudgetQuery`) is the source of truth.
- **Known gap (issue #3050):** DOC-39 §4.5 AC-5.9 requires a distinct "not applicable" state for non-PM sessions (cadence is PM-only — `AgentLoopConfig.cadence` defaults `None`; only `task/executor.rs:327` sets `Some`), rather than implying an unmanaged context. `ContextBudgetQuery` has no PM/cadence discriminant on the wire today, so this PR cannot distinguish that case — non-PM sessions render as `"no data yet"` until #3050 lands the wire-side discriminant + a GUI branch. Disclosed in `classifyBudget`/`budgetLabel`'s docstrings, the module header, and the CHANGELOG entry; no client-side PM heuristic was added as a workaround (per review guidance, disclosure-only fix).
- `CHANGELOG.md` [Unreleased] gains a new `### Added` entry for this change, and the prior PR's "Data gap: unavailable placeholder" bullet is annotated `RESOLVED` with a pointer to this entry rather than left to silently contradict it.

## Test plan

- [x] `pnpm install && pnpm test` — 5 files, 33 tests passed (14 new in `context-budget.test.ts`)
- [x] `pnpm build` — vite build succeeds
- [x] `SKIP_UI_BUILD=1 cargo check -p trusty-code-gui` — clean
- [x] `SKIP_UI_BUILD=1 cargo test -p trusty-code-gui` — 3 passed
- [x] `cargo fmt --check` — clean
- [x] `SKIP_UI_BUILD=1 cargo clippy -p trusty-code-gui --all-targets -- -D warnings` — clean
- [x] `bash scripts/check_line_cap.sh` — 9 allowlisted, 0 violations

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools