### PR TITLE
docs: reconcile Eve-style agent framework spec header to DOC-41

### DIFF
--- a/docs/specs/trusty-agents-eve-style-agents-spec.md
+++ b/docs/specs/trusty-agents-eve-style-agents-spec.md
@@ -1,10 +1,10 @@
-# DOC-37 — Eve-Style Agent Framework for trusty-agents
+# DOC-41 — Eve-Style Agent Framework for trusty-agents
 
 **Status:** Draft
 **Subsystem:** trusty-agents — agent definition / runtime / tool-calling / memory
 **Owner:** Engineering (trusty-agents)
 **Last-updated:** 2026-07-16
-**Spec ID:** `SPEC-AGENTFW-01~draft` … `SPEC-AGENTFW-06~draft` (DOC-37)
+**Spec ID:** `SPEC-AGENTFW-01~draft` … `SPEC-AGENTFW-06~draft` (DOC-41)
 **Builds on:** the existing `.toml` and `.md`+YAML-frontmatter agent-definition
 loaders (`crates/trusty-agents/src/agents/registry/mod.rs`,
 `crates/trusty-agents/src/agents/registry/md_agent.rs`,


### PR DESCRIPTION
## Summary
- `docs/specs/README.md` (the doc catalog) already resolved the DOC-37/DOC-41 collision, cataloging the Eve-style agent framework spec (`trusty-agents-eve-style-agents-spec.md`) as **DOC-41**, with `trusty-search-managed-repo-awareness.md` retaining the legitimate DOC-37 slot.
- The spec file's own header (`# DOC-37 — ...`) and Spec ID line (`... (DOC-37)`) were never updated to match that resolution, leaving a live on-disk header collision between two files both claiming DOC-37.
- This PR is a 2-line reconciliation: updates the header and Spec ID line to DOC-41 to match the canonical catalog entry. No renumbering of any other doc.

## Test plan
- [x] `git show origin/main:docs/specs/README.md` confirmed DOC-41 is the catalog's canonical assignment for this spec, and DOC-37 is solely claimed by `trusty-search-managed-repo-awareness.md`.
- [x] `git grep -n "DOC-37"` / `"DOC-41"` across `docs/` on `origin/main` confirmed the collision was header-only (catalog was already correct).
- [x] Docs-only change; no build/test required.

Closes #3067

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools