### PR TITLE
ci(trusty-agents-ui): bring nested Tauri app into workspace build + CI (#3053)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,27 @@
 # CI workflow for the trusty-tools Cargo workspace.
 #
 # Jobs:
-#   fmt    – cargo fmt --all --check (stable)
-#   clippy – cargo clippy --workspace --all-targets -D warnings (stable, SKIP_UI_BUILD=1)
-#   test   – cargo test --workspace (stable, SKIP_UI_BUILD=1, full clone for git tests)
-#   msrv   – cargo check --workspace (toolchain 1.91, SKIP_UI_BUILD=1)
+#   fmt      – cargo fmt --all --check (stable)
+#   clippy   – cargo clippy --workspace --all-targets -D warnings (stable, SKIP_UI_BUILD=1)
+#   test     – cargo test --workspace (stable, SKIP_UI_BUILD=1, full clone for git tests)
+#   msrv     – cargo check --workspace (toolchain 1.91, SKIP_UI_BUILD=1)
+#   agents-ui – cargo clippy -p trusty-agents-ui (stable, WebKit2GTK-enabled runner)
 #
-# trusty-mpm-gui and trusty-code-gui are excluded from all jobs: both are
-# Tauri desktop GUIs (publish = false) that require WebKit2GTK on Linux
-# (~100 MB apt chain). Neither is a deployable service, and neither can be
-# meaningfully validated in a headless CI runner. Exclude both via
-# --exclude trusty-mpm-gui --exclude trusty-code-gui on every cargo invocation.
+# trusty-mpm-gui, trusty-code-gui, and trusty-agents-ui are excluded from the
+# headless workspace jobs (clippy/test/msrv): all three are Tauri desktop apps
+# (publish = false) that require WebKit2GTK on Linux (~100 MB apt chain) which
+# the headless runners do not install. Exclude them via
+# --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
+# on every workspace-wide cargo invocation.
+#
+# UNLIKE the two other GUIs, trusty-agents-ui gets a DEDICATED `agents-ui` job
+# (#3053) that installs the WebKit2GTK toolchain and runs
+# `cargo clippy -p trusty-agents-ui --all-targets -- -D warnings`, so the crate
+# is genuinely build- and lint-verified in CI rather than merely excluded. That
+# job stubs a minimal `crates/trusty-agents/ui/dist/index.html` (gitignored)
+# because `tauri::generate_context!()` requires the `frontendDist` path to
+# exist at compile time; a placeholder is sufficient to compile- and
+# lint-verify the Rust side without pulling node/pnpm into CI.
 #
 # SKIP_UI_BUILD=1 is set globally: the four crates with build.rs Svelte
 # pipelines (trusty-search, trusty-memory, trusty-analyze, trusty-agents) skip
@@ -88,7 +99,7 @@ jobs:
 
   # --------------------------------------------------------------------------
   # clippy: deny warnings across the whole workspace (stable, all targets)
-  # trusty-mpm-gui and trusty-code-gui excluded: Tauri desktop GUIs, need WebKit2GTK on Linux.
+  # trusty-mpm-gui, trusty-code-gui, trusty-agents-ui excluded: Tauri desktop apps, need WebKit2GTK on Linux.
   # --------------------------------------------------------------------------
   clippy:
     name: Clippy
@@ -132,13 +143,13 @@ jobs:
           key: clippy
 
       - name: cargo clippy --workspace --all-targets -- -D warnings
-        run: cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui -- -D warnings
+        run: cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings
 
   # --------------------------------------------------------------------------
   # test: run all unit + integration tests (stable, no --include-ignored).
   # ONNX-backed tests are #[ignore]-tagged; they are intentionally skipped here
   # because they require model downloads and a running embedderd daemon.
-  # trusty-mpm-gui, trusty-code-gui excluded: see clippy note above.
+  # trusty-mpm-gui, trusty-code-gui, trusty-agents-ui excluded: see clippy note above.
   # fetch-depth: 0 (full clone) required for trusty-agents git tests that inspect
   # local branch refs and search commit history.
   #
@@ -419,7 +430,7 @@ jobs:
         # We set CI="" here to shadow the global CI=true injected by the runner.
         env:
           CI: ""
-        run: cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui
+        run: cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
 
       # Explicit per-crate step so trusty-review failures are individually
       # attributed in the GitHub Actions UI (closes #950).
@@ -432,7 +443,7 @@ jobs:
   # msrv: verify the workspace compiles on the effective MSRV.
   # cargo check is used (not test) to keep this job fast: the MSRV guarantee
   # is that the code *compiles* on the minimum toolchain, not that tests pass.
-  # trusty-mpm-gui, trusty-code-gui excluded: see clippy note above.
+  # trusty-mpm-gui, trusty-code-gui, trusty-agents-ui excluded: see clippy note above.
   #
   # Toolchain is 1.91, matching [workspace.package].rust-version = "1.91" in the
   # root Cargo.toml. The current Cargo.lock pulls aws-sdk-*/aws-smithy-* at
@@ -478,7 +489,69 @@ jobs:
           key: msrv-1-91
 
       - name: cargo check --workspace
-        run: cargo check --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui
+        run: cargo check --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
+
+  # --------------------------------------------------------------------------
+  # agents-ui: build- and lint-verify the trusty-agents Tauri desktop app
+  # (crates/trusty-agents/ui/src-tauri, package `trusty-agents-ui`). Issue #3053.
+  #
+  # This crate is a Tauri 2 app and is EXCLUDED from the headless workspace
+  # jobs above (clippy/test/msrv) because Tauri links WebKit2GTK on Linux,
+  # which those runners do not install. This dedicated job installs the
+  # WebKit2GTK toolchain so the crate is genuinely compiled and clippy-linted
+  # in CI (unlike trusty-mpm-gui / trusty-code-gui, which are only excluded).
+  #
+  # `tauri::generate_context!()` embeds the config's `frontendDist` ("../dist",
+  # i.e. crates/trusty-agents/ui/dist) at compile time and hard-errors if that
+  # path is absent. `dist/` is a gitignored build artefact (produced by
+  # `pnpm build`), so we stub a minimal placeholder index.html before clippy.
+  # That is sufficient to compile- and lint-verify the Rust side without
+  # pulling node/pnpm into CI; the real UI bundle is only needed for `tauri
+  # build` packaging, which this build/lint gate does not perform.
+  # --------------------------------------------------------------------------
+  agents-ui:
+    name: trusty-agents-ui clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install stable toolchain with clippy
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      # Tauri 2 Linux system dependencies (WebKit2GTK 4.1 + GTK stack). These
+      # mirror the Tauri project's documented Linux prerequisites and are the
+      # same reason the headless workspace jobs exclude this crate.
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            pkg-config \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: agents-ui
+
+      # Stub the frontendDist so tauri::generate_context!() can embed it.
+      - name: Stub frontend dist for generate_context!
+        run: |
+          mkdir -p crates/trusty-agents/ui/dist
+          printf '<!doctype html><html><head><meta charset="utf-8"><title>open-mpm</title></head><body></body></html>\n' \
+            > crates/trusty-agents/ui/dist/index.html
+
+      - name: cargo clippy -p trusty-agents-ui --all-targets -- -D warnings
+        run: cargo clippy -p trusty-agents-ui --all-targets -- -D warnings
 
   # --------------------------------------------------------------------------
   # search-daemon-smoke: build the trusty-search release binary and verify

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6524,6 +6524,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -8080,6 +8081,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9608,6 +9633,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e126abc9e84e35cdfd01596140a73a1850cdb0df0a23acf0185776c30b469a6e"
+dependencies = [
+ "anyhow",
+ "glob",
+ "plist",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tauri-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10802,6 +10885,21 @@ dependencies = [
  "cto-assistant",
  "tokio",
  "trusty-agents",
+]
+
+[[package]]
+name = "trusty-agents-ui"
+version = "0.16.1"
+dependencies = [
+ "anyhow",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-dialog",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,18 @@
 [workspace]
 # Glob picks up every crate directory under `crates/`. Add a new crate by
 # dropping its directory in `crates/` with its own Cargo.toml.
-members = ["crates/*"]
+#
+# The explicit `crates/trusty-agents/ui/src-tauri` entry (#3053) is the
+# trusty-agents Tauri desktop app. It lives NESTED inside the trusty-agents
+# member's directory rather than as a top-level `crates/*` dir, so the glob
+# above does not match it — it must be listed by full path. It used to declare
+# its own standalone `[workspace]` table (self-excluding from all
+# workspace-wide build/clippy/test); that has been removed so the crate is now
+# workspace-verified. It is deliberately NOT in `default-members` below (same
+# as the two other Tauri GUIs — bare builds skip it) and is excluded from the
+# headless CI jobs (WebKit2GTK-dependent); a dedicated `agents-ui` CI job
+# build- and lint-verifies it.
+members = ["crates/*", "crates/trusty-agents/ui/src-tauri"]
 resolver = "2"
 # Exclude paths inside copied projects that contain stray manifests we don't
 # want Cargo to treat as workspace members. trusty-agents bundles a `weather_alerter`

--- a/crates/trusty-agents/ui/src-tauri/Cargo.toml
+++ b/crates/trusty-agents/ui/src-tauri/Cargo.toml
@@ -25,8 +25,16 @@ tracing = "0.1"
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]
 
-# Mark this crate as its own (empty) workspace so the parent workspace at
-# /Users/masa/Projects/trusty-tools/crates/trusty-agents/Cargo.toml doesn't try to claim it. The Tauri
-# crate intentionally lives outside the main workspace because its tauri/wry
-# deps don't share the parent's edition / target dir layout. (#364)
-[workspace]
+# NOTE (#3053): This crate is now a first-class member of the root
+# trusty-tools workspace (declared explicitly in the root Cargo.toml
+# `[workspace.members]` list because the `crates/*` glob only matches
+# top-level crate directories, not this nested `ui/src-tauri` path). It no
+# longer declares its own empty `[workspace]` table. The original #364
+# rationale ("tauri/wry deps don't share the parent's edition/target-dir
+# layout") is now moot: the workspace already hosts two other Tauri GUIs
+# (trusty-mpm-gui, trusty-code-gui) that pin the same `tauri = "2"` and share
+# the workspace target dir without issue. Keeping this crate in the workspace
+# gives it shared dependency resolution and lets a dedicated CI job build- and
+# lint-verify it (see .github/workflows/ci.yml `agents-ui` job). Like the
+# other two Tauri GUIs it is intentionally NOT in the root `default-members`
+# list, so a bare `cargo build` (no --workspace / -p) still skips it.


### PR DESCRIPTION
## Summary

Phase 0 of the trusty-agents Assistant M1 epic (#3052). Brings the trusty-agents Tauri desktop app (`crates/trusty-agents/ui/src-tauri`, package `trusty-agents-ui`) into the workspace so it is build- and lint-verified in CI.

### Problem

The crate declared its own empty `[workspace]` table (per the now-stale #364 rationale), self-excluding it from every workspace-wide `cargo build`/`clippy`/`test`. Its CI coverage was unconfirmed.

### Investigation

- The nested `ui/src-tauri` path is **not** matched by the root `crates/*` members glob (that glob only matches top-level dirs), so the crate was fully isolated — its own `[workspace]` table made it a standalone workspace root.
- The #364 reason ("tauri/wry can't share the parent's edition/target-dir layout") is **stale**: the workspace already hosts two Tauri GUIs — `trusty-mpm-gui` and `trusty-code-gui` — that pin the same `tauri = "2"` and share the workspace target dir without issue. So workspace membership is safe and consistent.
- `tauri::generate_context!()` embeds the config's `frontendDist` (`../dist`) at compile time and hard-errors if it's absent. `dist/` is a gitignored `vite build` artefact, so a compile/lint gate needs a stub `index.html` (a placeholder is sufficient to compile- and lint-verify the Rust side — no node/pnpm needed).

### Decision: workspace member + dedicated CI job

Chose the issue's **preferred** option (workspace member) plus a dedicated CI job for real verification:

- **Removed** the standalone `[workspace]` table from the crate's `Cargo.toml`.
- **Added** `crates/trusty-agents/ui/src-tauri` as an explicit member in the root `Cargo.toml` (glob can't reach the nested path). Kept **out** of `default-members`, so a bare `cargo build` still skips it — matching the two other Tauri GUIs.
- **Excluded** `trusty-agents-ui` from the headless clippy/test/msrv jobs (those runners don't install WebKit2GTK), matching the two other GUIs.
- **Added** a dedicated `agents-ui` CI job that installs the WebKit2GTK toolchain, stubs `crates/trusty-agents/ui/dist/index.html`, and runs `cargo clippy -p trusty-agents-ui --all-targets -- -D warnings`. Unlike the other two GUIs (excluded-only), this crate is now genuinely build- and lint-verified in CI.

`Cargo.lock` gains only the new member's unique deps (`tauri-plugin-dialog`, `tauri-plugin-fs`, `rfd`); no version churn. No source/feature changes — build/CI wiring only (no `open-mpm` rebrand — that's #3060; no CHANGELOG needed per the CI-only exemption).

### Verification (raw output)

`cargo clippy -p trusty-agents-ui --all-targets -- -D warnings` → **exit 0**:
```
    Checking trusty-agents-ui v0.16.1 (…/crates/trusty-agents/ui/src-tauri)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s
```
(the two `multiple build targets` warnings are pre-existing workspace-manifest notes for trusty-installer/trusty-mpm, not from this crate)

`cargo check --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` → **exit 0** (workspace build intact).

`cargo fmt --check` → **exit 0**. `bash scripts/check_line_cap.sh` → `line-cap: 9 allowlisted, 0 violations — OK.`

Closes #3053

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools