### PR TITLE
fix(trusty-code): wire embedded agent roster into CLI dispatch paths (closes #3046, completes #2958)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- the embedded 31-agent `DEFAULT_AGENTS` roster (#2958) is now actually
+  reachable from every real CLI dispatch path, not just `agents::load_all_agents`'s
+  dir-wide scan. `runner::in_process::InProcessAgentRunner::load_agent`,
+  `run_task::execute_run_task`'s and `task::executor`'s PM-config loads,
+  `run_task::resolve_agent_model_slug`, and
+  `tools::delegate::DelegateToAgentTool`'s pre-flight check/hint previously
+  read `<agents_dir>/<name>.md` directly off disk with no embedded
+  fallback, so `tcode run-task engineer ...` and `tcode run-task
+  rust-engineer ...` both failed with "agent source not found" on a fresh
+  project with no `.claude/agents/`. All five now route through a single
+  new `agents::resolve_agent` helper (disk always wins when present, even
+  when it fails to parse — no silent fallback to a same-named embedded
+  agent) and `agents::available_agent_names` (disk ∪ embedded, for
+  "available agents" hints). This is the last gap in the #2958 arc; closes
+  #3046, completing #2958.
+
 ### Added
 
 - **Pollable context-budget snapshot — cache + `session.get_context_budget`

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -224,6 +224,148 @@ pub fn locate_agents_dir(project_root: &Path) -> std::path::PathBuf {
     claude_agents
 }
 
+/// Failure modes of [`resolve_agent`].
+///
+/// Why: `resolve_agent`'s callers need to distinguish "nothing named `name`
+/// exists anywhere" (a caller/LLM mistake — worth listing available agents
+/// for) from "a config for `name` exists but failed to load/compose" (a real
+/// bug in that specific file, on disk or embedded) — the same two shapes
+/// `RunnerError::UnknownAgent`/`ConfigLoad` already distinguish for the
+/// runner's own narrower `<dir>/<name>.md`-only lookup (#2897 Slice D).
+/// What: `NotFound` carries the searched `dir` and a precomputed
+/// `available` hint (disk ∪ embedded names, already joined for display —
+/// see [`available_agent_names`]). `Load` wraps the underlying
+/// `md_loader`/`compose` error, whether it came from an existing disk file
+/// or a compiled-in embedded asset.
+/// Test: `resolve_agent_unknown_name_lists_available_agents`,
+/// `resolve_agent_disk_parse_error_does_not_fall_back_to_embedded`.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveAgentError {
+    /// No config for `name` was found on disk or in the embedded roster.
+    #[error(
+        "unknown agent '{name}': no config found in {} and no embedded default \
+         named '{name}'. Available agents: {available}",
+        dir.display()
+    )]
+    NotFound {
+        /// The requested agent slug.
+        name: String,
+        /// The directory that was searched for `<name>.md`.
+        dir: PathBuf,
+        /// Disk ∪ embedded agent names, sorted/deduped and comma-joined.
+        available: String,
+    },
+    /// A config for `name` was found (on disk or embedded) but failed to
+    /// load, parse, or compose.
+    #[error("failed to load agent config for '{name}': {source}")]
+    Load {
+        /// The requested agent slug.
+        name: String,
+        /// The underlying load/parse/compose error.
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+/// Resolve a named agent's config, disk taking precedence over the embedded
+/// default roster (#3046 — the last gap in the #2958 embedded-roster arc).
+///
+/// Why: Slice E1-E3 (#2958) built a working embedded fallback for
+/// [`load_all_agents`] (the dir-wide scan), but five other production call
+/// sites — `runner::in_process::InProcessAgentRunner::load_agent`,
+/// `run_task::execute_run_task`'s and `task::executor`'s PM-config loads,
+/// `run_task::resolve_agent_model_slug`, and
+/// `tools::delegate::DelegateToAgentTool`'s pre-flight check — read
+/// `<dir>/<name>.md` directly by single-agent name, with no embedded
+/// consultation at all, so the 31-agent roster was unreachable from a real
+/// CLI run on a fresh project with no `.claude/agents/`. This is the ONE
+/// shared resolution helper all of them now route through, so the
+/// disk-wins/embedded-fallback precedence is written and tested exactly
+/// once.
+/// What: If `<dir>/<name>.md` EXISTS, loads it via [`md_loader::load_md_agent`]
+/// — a parse/compose error on an EXISTING disk file is returned as-is
+/// (`ResolveAgentError::Load`), NEVER silently falling through to an
+/// embedded copy of the same name: a project that deliberately overrode
+/// `name` gets its own broken override surfaced, not masked. If the disk
+/// file does not exist, looks `name` up in `crate::assets::DEFAULT_AGENTS`:
+/// a `Direct` entry projects via [`md_loader::project_embedded_md`]
+/// (infallible); a `Composed` entry projects via
+/// [`md_loader::project_embedded_md_with_extends`], and on `Err` (a
+/// build-time asset defect — see [`load_embedded_default_agents`]'s
+/// identical handling) logs `tracing::error!` and falls through to the
+/// not-found case below rather than propagating. If nothing matches
+/// anywhere, returns `ResolveAgentError::NotFound` with the disk ∪ embedded
+/// name list ([`available_agent_names`]) for a caller to surface.
+/// Test: `resolve_agent_disk_wins_over_embedded`,
+/// `resolve_agent_falls_back_to_embedded_when_disk_misses`,
+/// `resolve_agent_disk_parse_error_does_not_fall_back_to_embedded`,
+/// `resolve_agent_unknown_name_lists_available_agents`.
+pub fn resolve_agent(dir: &Path, name: &str) -> Result<AgentConfig, ResolveAgentError> {
+    let disk_path = dir.join(format!("{name}.md"));
+    if disk_path.exists() {
+        return md_loader::load_md_agent(&disk_path).map_err(|source| ResolveAgentError::Load {
+            name: name.to_string(),
+            source,
+        });
+    }
+
+    if let Some(embedded) = crate::assets::DEFAULT_AGENTS
+        .iter()
+        .find(|a| a.name() == name)
+    {
+        match embedded {
+            crate::assets::EmbeddedAgent::Direct { name: n, md } => {
+                return Ok(md_loader::project_embedded_md(n, md));
+            }
+            crate::assets::EmbeddedAgent::Composed { name: n } => {
+                match md_loader::project_embedded_md_with_extends(n) {
+                    Ok(cfg) => return Ok(cfg),
+                    Err(e) => {
+                        tracing::error!(
+                            "embedded roster agent '{n}' failed to compose \
+                             (build-time asset defect, not a runtime condition): {e}"
+                        );
+                        // Fall through to the not-found error below, mirroring
+                        // `load_embedded_default_agents`'s own handling.
+                    }
+                }
+            }
+        }
+    }
+
+    Err(ResolveAgentError::NotFound {
+        name: name.to_string(),
+        dir: dir.to_path_buf(),
+        available: available_agent_names(dir).join(", "),
+    })
+}
+
+/// List every agent name resolvable via [`resolve_agent`] for `dir`: disk ∪
+/// embedded, sorted and deduped.
+///
+/// Why: Both `resolve_agent`'s own not-found error and
+/// `tools::delegate::DelegateToAgentTool::available_agents` (the
+/// "Available agents: ..." hint an LLM sees after naming an unknown agent)
+/// need the same union — computing it in one place means the hint always
+/// names real dispatchable agents, on disk or embedded, never just one or
+/// the other.
+/// What: `discover_agents(dir)`'s names, plus every
+/// `crate::assets::DEFAULT_AGENTS` name not already present, sorted and
+/// deduped.
+/// Test: `available_agent_names_unions_disk_and_embedded`.
+pub fn available_agent_names(dir: &Path) -> Vec<String> {
+    let mut names: Vec<String> = discover_agents(dir).into_iter().map(|(n, _)| n).collect();
+    for embedded in crate::assets::DEFAULT_AGENTS {
+        let n = embedded.name().to_string();
+        if !names.contains(&n) {
+            names.push(n);
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -532,5 +674,133 @@ mod tests {
             tmp.path().join(".claude").join("agents"),
             "must prefer .claude/agents when both exist"
         );
+    }
+
+    /// `resolve_agent`: a disk override wins over an embedded agent of the
+    /// SAME name (#3046).
+    ///
+    /// Why: "project overrides always win" is the whole point of putting
+    /// disk-existence first in `resolve_agent`'s precedence.
+    /// What: `engineer` is BOTH on disk (with a distinguishing marker
+    /// description) and in the embedded roster; asserts the disk copy's
+    /// content came back, not the embedded one's.
+    /// Test: this test.
+    #[test]
+    fn resolve_agent_disk_wins_over_embedded() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("engineer.md"),
+            "---\nname: engineer\ndescription: DISK OVERRIDE MARKER\n---\n\nDisk body.\n",
+        )
+        .expect("write");
+
+        let cfg = resolve_agent(tmp.path(), "engineer").expect("resolve");
+        assert_eq!(
+            cfg.agent.description.as_deref(),
+            Some("DISK OVERRIDE MARKER")
+        );
+        assert_eq!(cfg.system_prompt.content, "Disk body.");
+    }
+
+    /// `resolve_agent`: a disk miss falls back to the embedded roster
+    /// (#3046).
+    ///
+    /// Why: this is the literal #3046 repro at the unit level — an empty
+    /// disk dir must still resolve a roster name like `rust-engineer`
+    /// (an `EmbeddedAgent::Composed` entry).
+    /// What: an empty/nonexistent agents dir; `resolve_agent(dir,
+    /// "rust-engineer")` must succeed and carry rust-engineer's known
+    /// composed content.
+    /// Test: this test.
+    #[test]
+    fn resolve_agent_falls_back_to_embedded_when_disk_misses() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cfg = resolve_agent(tmp.path(), "rust-engineer").expect("resolve embedded");
+        assert_eq!(cfg.agent.name, "rust-engineer");
+        assert!(
+            cfg.system_prompt.content.contains("toolchains-rust-core"),
+            "expected rust-engineer's composed body, got: {:?}",
+            cfg.system_prompt.content
+        );
+    }
+
+    /// `resolve_agent`: a parse/compose error on an EXISTING disk file must
+    /// error, never silently fall back to the embedded copy of the same
+    /// name (#3046).
+    ///
+    /// Why: masking a real on-disk config bug behind a silently-substituted
+    /// embedded default would hide the exact kind of typo/misconfiguration
+    /// this validation exists to surface.
+    /// What: a disk `rust-engineer.md` with a broken `extends:` chain (a
+    /// name that resolves to nothing); asserts `resolve_agent` errors with
+    /// `ResolveAgentError::Load`, not `Ok` with the embedded content.
+    /// Test: this test.
+    #[test]
+    fn resolve_agent_disk_parse_error_does_not_fall_back_to_embedded() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("rust-engineer.md"),
+            "---\nname: rust-engineer\nextends: does-not-exist\n---\n\nBroken.\n",
+        )
+        .expect("write");
+
+        let err = resolve_agent(tmp.path(), "rust-engineer")
+            .expect_err("a broken disk override must error, not fall back");
+        assert!(
+            matches!(err, ResolveAgentError::Load { .. }),
+            "expected Load, got: {err:?}"
+        );
+    }
+
+    /// `resolve_agent`: a name absent from disk AND the embedded roster
+    /// errors with a message listing available agents (#3046).
+    ///
+    /// Why: pins the `NotFound` shape callers rely on to build a helpful
+    /// "unknown agent, did you mean one of..." message.
+    /// What: an empty disk dir; `resolve_agent(dir, "totally-bogus")`
+    /// errors, and the error text names at least one real embedded agent
+    /// (`engineer`).
+    /// Test: this test.
+    #[test]
+    fn resolve_agent_unknown_name_lists_available_agents() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let err = resolve_agent(tmp.path(), "totally-bogus").expect_err("must error");
+        let msg = err.to_string();
+        assert!(msg.contains("totally-bogus"), "got: {msg}");
+        assert!(
+            msg.contains("engineer"),
+            "expected the available-agents hint to name a real embedded agent, got: {msg}"
+        );
+    }
+
+    /// `available_agent_names` unions disk and embedded names, sorted and
+    /// deduped (#3046).
+    ///
+    /// Why: shared by `resolve_agent`'s not-found hint and
+    /// `tools::delegate::DelegateToAgentTool::available_agents` — both need
+    /// the identical union, computed once.
+    /// What: one disk-only custom agent plus the embedded roster; asserts
+    /// both the disk name and a known embedded name are present, with no
+    /// duplicates.
+    /// Test: this test.
+    #[test]
+    fn available_agent_names_unions_disk_and_embedded() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("custom.md"),
+            "---\nname: custom\n---\n\nBody.\n",
+        )
+        .expect("write");
+
+        let names = available_agent_names(tmp.path());
+        assert!(names.contains(&"custom".to_string()), "got: {names:?}");
+        assert!(
+            names.contains(&"rust-engineer".to_string()),
+            "got: {names:?}"
+        );
+        let mut deduped = names.clone();
+        deduped.sort();
+        deduped.dedup();
+        assert_eq!(names, deduped, "must contain no duplicates");
     }
 }

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -29,7 +29,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::agent_loop::{AgentLoop, AgentLoopConfig, AgentLoopError, CompactionConfig};
-use crate::agents::{AgentConfig, md_loader};
+use crate::agents::AgentConfig;
 use crate::llm::{DebugCaptureSink, LlmClientTrait, wrap_with_debug_capture};
 use crate::mode::HarnessMode;
 use crate::project_context::load_project_context;
@@ -247,11 +247,17 @@ pub async fn execute_run_task(params: RunTaskParams, llm: Arc<dyn LlmClientTrait
     let debug_sink: Option<Arc<DebugCaptureSink>> = DebugCaptureSink::from_env();
 
     // Load the PM config; a missing/invalid config is a configuration error.
-    let pm_config =
-        match md_loader::load_md_agent(&params.agents_dir.join(format!("{}.md", params.agent))) {
-            Ok(cfg) => cfg,
-            Err(e) => return config_error_report(&params, &transcript, &format!("{e:#}")),
-        };
+    // (#3046) Routes through the shared disk-then-embedded resolver so a
+    // top-level agent name that is only in the embedded roster (e.g.
+    // `engineer`, `rust-engineer`) resolves here too, not just via
+    // `load_all_agents`'s dir-wide scan. Note the embedded roster has no
+    // `pm` entry, so `run-task pm ...` still requires a disk `pm.md` — only
+    // `run-task engineer` / `run-task rust-engineer` etc. exercise the new
+    // fallback.
+    let pm_config = match crate::agents::resolve_agent(&params.agents_dir, &params.agent) {
+        Ok(cfg) => cfg,
+        Err(e) => return config_error_report(&params, &transcript, &format!("{e}")),
+    };
 
     // Load project context (#1033) — absent file is fine.
     let project_context = load_project_context(&params.project);
@@ -623,13 +629,15 @@ fn apply_engineer_model_override(
 /// pricing step. Shared with the daemon path (`task::executor`'s own
 /// `resolve_engineer_model`, which now delegates here) so the two paths
 /// can never independently drift on how per-role pricing resolves a model.
-/// What: loads `<agents_dir>/<agent_name>.md` (#2897 Slice D); on any load
-/// failure (missing/invalid file) falls back to the literal string
-/// `"unknown"` — `crate::perf::cost_usd` degrades gracefully
-/// (Sonnet-equivalent pricing) for an unrecognised model rather than
-/// erroring, so a missing agent config degrades pricing accuracy, not the
-/// whole run. When `model_override` is `Some`, it wins over the config's own
-/// model (mirrors `RunContext`'s override precedence).
+/// What: (#3046) resolves `<agents_dir>/<agent_name>.md` via the shared
+/// disk-then-embedded [`crate::agents::resolve_agent`]; on any resolution
+/// failure (missing everywhere, or an invalid disk/embedded file) falls
+/// back to the literal string `"unknown"` — `crate::perf::cost_usd`
+/// degrades gracefully (Sonnet-equivalent pricing) for an unrecognised
+/// model rather than erroring, so a missing agent config degrades pricing
+/// accuracy, not the whole run. When `model_override` is `Some`, it wins
+/// over the config's own model (mirrors `RunContext`'s override
+/// precedence).
 /// Test: `run_task::tests::resolve_agent_model_slug_falls_back_when_config_missing`,
 /// `run_task::tests::resolve_agent_model_slug_honours_override`.
 pub fn resolve_agent_model_slug(
@@ -637,8 +645,7 @@ pub fn resolve_agent_model_slug(
     agent_name: &str,
     model_override: Option<&str>,
 ) -> String {
-    let path = agents_dir.join(format!("{agent_name}.md"));
-    let Ok(config) = md_loader::load_md_agent(&path) else {
+    let Ok(config) = crate::agents::resolve_agent(agents_dir, agent_name) else {
         return "unknown".to_string();
     };
     match model_override {

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -27,7 +27,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::agent_loop::{AgentLoop, AgentLoopConfig, ToolEventSink};
-use crate::agents::{AgentConfig, md_loader};
+use crate::agents::AgentConfig;
 use crate::llm::LlmClientTrait;
 use crate::mode::HarnessMode;
 use crate::prompt::assemble_system_prompt_for_mode;
@@ -292,29 +292,37 @@ impl InProcessAgentRunner {
         self
     }
 
-    /// Load the agent config for `agent_name` from the config directory.
+    /// Load the agent config for `agent_name` from the config directory,
+    /// falling back to the embedded default roster when no disk config
+    /// exists (#3046).
     ///
     /// Why: Each delegation targets a named agent; its model, prompt, and
-    /// `tools.allowed` come from `<config_dir>/<agent_name>.md` (#2897 Slice D
-    /// — `.toml` is no longer a loadable source). Distinguishing "no such
-    /// file" (`UnknownAgent`) from "file present but unparseable"
-    /// (`ConfigLoad`) gives the caller actionable errors.
-    /// What: Builds the path, returns `UnknownAgent` if it does not exist, else
-    /// loads it via [`md_loader::load_md_agent`] (mapping a parse/compose
-    /// failure to `ConfigLoad`).
+    /// `tools.allowed` come from `<config_dir>/<agent_name>.md` (#2897 Slice
+    /// D — `.toml` is no longer a loadable source) when present, or from
+    /// `crate::assets::DEFAULT_AGENTS` when it is not — every delegated
+    /// sub-agent run goes through this method, so it is the load-bearing
+    /// site for making the 31-agent embedded roster actually dispatchable
+    /// from a real run (the gap #3046 closes). Distinguishing "no such
+    /// config anywhere" (`UnknownAgent`) from "a config exists but is
+    /// unparseable" (`ConfigLoad`) gives the caller actionable errors; this
+    /// method's own typed-error contract is preserved unchanged by mapping
+    /// [`crate::agents::resolve_agent`]'s shared `ResolveAgentError` onto
+    /// these SAME two `RunnerError` variants.
+    /// What: Delegates the disk-then-embedded precedence entirely to
+    /// [`crate::agents::resolve_agent`], then maps
+    /// `ResolveAgentError::NotFound` -> `RunnerError::UnknownAgent` and
+    /// `ResolveAgentError::Load` -> `RunnerError::ConfigLoad`.
     /// Test: `runner::tests::unknown_agent_errors`,
-    /// `runner::tests::delegate_runs_engineer_loop`.
+    /// `runner::tests::delegate_runs_engineer_loop`,
+    /// `runner::tests::embedded_restricted_agent_dispatch_preserves_tools_allowed`.
     fn load_agent(&self, agent_name: &str) -> Result<AgentConfig, RunnerError> {
-        let path = self.config_dir.join(format!("{agent_name}.md"));
-        if !path.exists() {
-            return Err(RunnerError::UnknownAgent {
-                name: agent_name.to_string(),
-                dir: self.config_dir.clone(),
-            });
-        }
-        md_loader::load_md_agent(&path).map_err(|source| RunnerError::ConfigLoad {
-            name: agent_name.to_string(),
-            source,
+        crate::agents::resolve_agent(&self.config_dir, agent_name).map_err(|e| match e {
+            crate::agents::ResolveAgentError::NotFound { name, dir, .. } => {
+                RunnerError::UnknownAgent { name, dir }
+            }
+            crate::agents::ResolveAgentError::Load { name, source } => {
+                RunnerError::ConfigLoad { name, source }
+            }
         })
     }
 
@@ -488,14 +496,24 @@ impl AgentRunner for InProcessAgentRunner {
     }
 }
 
-/// Convenience: discover whether an agent config exists for `name` under `dir`.
+/// Convenience: discover whether an agent config exists for `name` under
+/// `dir`, on disk OR in the embedded default roster (#3046).
 ///
-/// Why: Callers (e.g. the orchestrator wiring the delegate tool) sometimes need
-/// to pre-check an agent name without constructing a runner; exposing the same
-/// path rule the runner uses keeps the two in lockstep.
-/// What: Returns `true` iff `<dir>/<name>.md` exists (#2897 Slice D — `.toml`
-/// is no longer a loadable source).
-/// Test: `runner::tests::agent_config_exists_detects_present_and_absent`.
+/// Why: Callers (e.g. `tools::delegate::DelegateToAgentTool::execute`'s
+/// pre-flight gate) sometimes need to pre-check an agent name without
+/// constructing a runner; exposing the same disk-then-embedded rule
+/// [`crate::agents::resolve_agent`] uses keeps the two in lockstep — a
+/// pre-flight check that only saw disk would reject a real embedded roster
+/// name (e.g. `rust-engineer`) before the runner ever got a chance to
+/// resolve it.
+/// What: Returns `true` iff `<dir>/<name>.md` exists (#2897 Slice D —
+/// `.toml` is no longer a loadable source) OR `name` matches an entry in
+/// `crate::assets::DEFAULT_AGENTS`.
+/// Test: `runner::tests::agent_config_exists_detects_present_and_absent`,
+/// `runner::tests::agent_config_exists_detects_embedded_default`.
 pub fn agent_config_exists(dir: &Path, name: &str) -> bool {
     dir.join(format!("{name}.md")).exists()
+        || crate::assets::DEFAULT_AGENTS
+            .iter()
+            .any(|a| a.name() == name)
 }

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -310,6 +310,70 @@ fn agent_config_exists_detects_present_and_absent() {
     assert!(!super::agent_config_exists(tmp.path(), "ghost"));
 }
 
+/// `agent_config_exists` also recognises an embedded default roster name
+/// with no disk config at all (#3046).
+///
+/// Why: `tools::delegate::DelegateToAgentTool::execute`'s pre-flight gate
+/// calls this function directly; before #3046 it only ever consulted disk,
+/// so a valid embedded roster name (e.g. `rust-engineer`) on a fresh
+/// project with no `.claude/agents/` was rejected before the runner ever
+/// got a chance to resolve it via the embedded fallback.
+/// What: An empty/nonexistent agents dir; asserts `true` for a known
+/// embedded roster name and `false` for a genuinely unknown one.
+/// Test: this test.
+#[test]
+fn agent_config_exists_detects_embedded_default() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(super::agent_config_exists(tmp.path(), "rust-engineer"));
+    assert!(!super::agent_config_exists(tmp.path(), "totally-bogus"));
+}
+
+/// Dispatching to an embedded, tools-restricted roster agent (`qa` — one of
+/// the four Slice E3 restricted agents) with NO disk config at all still
+/// enforces its `tools.allowed` — the embedded-fallback path in `load_agent`
+/// (#3046) feeds `run_pipeline`'s `gate_registry` exactly like a disk-loaded
+/// config does.
+///
+/// Why: Slice E3's own tests (`assets::tests::restricted_reviewer_agents_carry_read_only_tools`)
+/// already prove the COMPOSED `AgentConfig` carries the restricted
+/// allowlist; this proves the DISPATCH path — the thing #3046 actually
+/// wires up — narrows the registry for a name that was NEVER on disk,
+/// mirroring `tools_allowed_is_enforced`'s existing pattern but pointed at
+/// an empty agents dir so `load_agent` must take the embedded branch.
+/// What: An empty agents dir (no `qa.md`). Factory builds both an allowed
+/// tool (`read_file`, in `qa`'s restricted allowlist) and a denied one
+/// (`bash`, NOT in it). Script the model to call `bash`, then stop. Assert
+/// the denied tool never ran.
+/// Test: this test.
+#[tokio::test]
+async fn embedded_restricted_agent_dispatch_preserves_tools_allowed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let llm = Arc::new(ScriptedLlm::from_json(&[
+        tool_call_response("c1", "bash"),
+        stop_response("concluded"),
+    ]));
+    let invoked = Arc::new(Mutex::new(Vec::new()));
+    let factory = Arc::new(recording_factory(
+        vec!["read_file", "bash"],
+        Arc::clone(&invoked),
+    ));
+    let runner = InProcessAgentRunner::new(llm.clone(), factory, tmp.path().to_path_buf());
+
+    let out = runner
+        .run("qa", "try the denied tool")
+        .await
+        .expect("loop completes (denied tool surfaces a recoverable error)");
+
+    assert_eq!(out.content, "concluded");
+    let ran = invoked.lock().expect("invoked");
+    assert!(
+        !ran.contains(&"bash".to_string()),
+        "the embedded 'qa' agent's restricted allowlist must gate out 'bash' \
+         even though it was never loaded from disk, ran: {ran:?}"
+    );
+}
+
 /// Stubbed-PM: `delegate_to_agent(python-engineer)` runs the engineer's own loop
 /// on its own slug and returns an `AgentOutput` to the PM.
 ///

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -40,7 +40,7 @@ use async_trait::async_trait;
 use crate::agent_loop::{
     AgentLoop, AgentLoopConfig, CompactionConfig, ToolEventSink, resolve_cadence_config,
 };
-use crate::agents::{AgentConfig, md_loader};
+use crate::agents::AgentConfig;
 use crate::binding::ProjectBinding;
 use crate::jsonrpc::RpcError;
 use crate::llm::{DebugCaptureSink, LlmClientTrait, wrap_with_debug_capture};
@@ -285,11 +285,15 @@ async fn run_and_record(
     // `TCODE_DEBUG_TRANSCRIPT` is set, and cost nothing when it is not.
     let debug_sink: Option<Arc<DebugCaptureSink>> = DebugCaptureSink::from_env();
 
-    let pm_config_path = params.agents_dir.join(format!("{}.md", params.agent_name));
-    let pm_config = match md_loader::load_md_agent(&pm_config_path) {
+    // (#3046) Routes through the shared disk-then-embedded resolver —
+    // mirrors `run_task::execute_run_task`'s own PM-config load — so a
+    // top-level agent name that only exists in the embedded roster (e.g.
+    // `engineer`, `rust-engineer`) resolves here too, on the daemon-driven
+    // session path.
+    let pm_config = match crate::agents::resolve_agent(&params.agents_dir, &params.agent_name) {
         Ok(cfg) => cfg,
         Err(e) => {
-            finish_with_failure(&registry, &session_id, &format!("PM config error: {e:#}")).await;
+            finish_with_failure(&registry, &session_id, &format!("PM config error: {e}")).await;
             return;
         }
     };

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -92,10 +92,24 @@ async fn spawn_task_run_unknown_session_errors() {
 // (`aggregate_usage_per_role_prices_each_role_separately`). This module only
 // tests THIS daemon path's own wrapper (`resolve_engineer_model`, below).
 
-/// `resolve_engineer_model` must fall back to `"unknown"` (never panic) when
-/// the engineer config is missing.
+/// `resolve_engineer_model` resolves via the embedded default roster
+/// (#3046) — never panics, and no longer degrades to the literal
+/// `"unknown"` — when the on-disk engineer config is missing, because
+/// `ENGINEER_AGENT_NAME` (`"python-engineer"`) is one of the 31 embedded
+/// roster names.
+///
+/// Why: before #3046, `resolve_agent_model_slug` read
+/// `<agents_dir>/python-engineer.md` directly with no embedded fallback, so
+/// a fresh project with no `.claude/agents/` priced every engineer turn
+/// under the degraded `"unknown"` slug even though the run itself (once
+/// #3046's other fixes land) now actually dispatches a real embedded
+/// `python-engineer` config. This pins the corrected behaviour: pricing and
+/// dispatch now agree.
+/// What: empty agents dir, no `python-engineer.md`; asserts the resolved
+/// slug is neither empty nor the literal `"unknown"` fallback string.
+/// Test: this test.
 #[test]
-fn resolve_engineer_model_falls_back_when_config_missing() {
+fn resolve_engineer_model_falls_back_to_embedded_when_disk_config_missing() {
     let empty_agents = tempfile::tempdir().expect("empty agents tempdir");
     let p = TaskRunParams {
         session_id: "s".to_string(),
@@ -109,7 +123,12 @@ fn resolve_engineer_model_falls_back_when_config_missing() {
         deadline_secs: None,
     };
     let model = resolve_engineer_model(&p);
-    assert_eq!(model, "unknown");
+    assert_ne!(
+        model, "unknown",
+        "python-engineer is embedded (#3046); a missing disk config must resolve \
+         via the embedded fallback, not degrade to unknown"
+    );
+    assert!(!model.is_empty());
 }
 
 /// `daily_driver_skills_catalog` returns `None` under `HarnessMode::Parity`,

--- a/crates/trusty-code/src/tools/delegate.rs
+++ b/crates/trusty-code/src/tools/delegate.rs
@@ -237,29 +237,25 @@ impl DelegateToAgentTool {
         self
     }
 
-    /// List agent names discoverable in `config_dir`, if any.
+    /// List agent names discoverable in `config_dir`, disk ∪ embedded
+    /// (#3046), if any.
     ///
     /// Why: Builds the "available agents" hint in error messages so the LLM
     /// gets immediate, structured feedback when it invents a name. Reuses
-    /// `agents::discover_agents` (rather than re-implementing its own dir
-    /// scan) so this hint and the actual load path can never independently
-    /// drift on which extension counts as an agent, and a coexisting
-    /// orphaned `.toml` gets the SAME migration warning it would during a
-    /// real `load_all_agents` call.
-    /// What: Delegates to `crate::agents::discover_agents`, which already
-    /// returns `(name, path)` pairs sorted by name — mapped down to just the
-    /// names here. Returns `None` when no `config_dir` was attached
-    /// (`discover_agents` itself returns `[]`, not `None`, for a
-    /// missing/unreadable directory).
+    /// `agents::available_agent_names` (rather than re-implementing its own
+    /// dir scan) so this hint, the actual load path
+    /// (`crate::agents::resolve_agent`), and the pre-flight gate
+    /// (`crate::runner::agent_config_exists`) can never independently drift
+    /// on which agents are real — before #3046 this hint only ever named
+    /// disk agents, so on a fresh project with no `.claude/agents/` it named
+    /// NONE even though the 31-agent embedded roster was dispatchable.
+    /// What: Delegates to `crate::agents::available_agent_names`, which
+    /// already returns disk ∪ embedded names, sorted and deduped. Returns
+    /// `None` when no `config_dir` was attached.
     /// Test: Indirect via `unknown_agent_returns_helpful_error`.
     fn available_agents(&self) -> Option<Vec<String>> {
         let dir = self.config_dir.as_ref()?;
-        Some(
-            crate::agents::discover_agents(dir)
-                .into_iter()
-                .map(|(name, _)| name)
-                .collect(),
-        )
+        Some(crate::agents::available_agent_names(dir))
     }
 }
 

--- a/crates/trusty-code/tests/agent_fallback_e2e.rs
+++ b/crates/trusty-code/tests/agent_fallback_e2e.rs
@@ -1,0 +1,247 @@
+//! E2E repro for issue #3046: the embedded 31-agent `DEFAULT_AGENTS` roster
+//! (Slice E1-E3, #2958) has a working in-memory composer, but before this
+//! fix FIVE production call sites (`runner::in_process::load_agent`,
+//! `run_task::execute_run_task`'s and `task::executor`'s PM-config loads,
+//! `run_task::resolve_agent_model_slug`, and
+//! `tools::delegate::DelegateToAgentTool`'s pre-flight/hint) read
+//! `<agents_dir>/<name>.md` directly off disk with no embedded fallback at
+//! all — so `tcode run-task engineer ...` (an ORIGINAL default, predating
+//! #2958) and `tcode run-task rust-engineer ...` (a Slice E3 roster agent)
+//! both failed with "agent source not found" on a fresh project with no
+//! `.claude/agents/`. `crate::agents::resolve_agent` (#3046) is the shared
+//! fix; this file is the literal real-binary repro the issue names as the
+//! acceptance bar.
+//!
+//! Why: every offline unit test in `agents::tests`/`runner::tests` proves
+//! the fix at the library level, but only spawning the REAL `tcode` binary
+//! (as a subprocess, exactly like `tests/cli_e2e.rs`) proves the fix is
+//! actually WIRED into the CLI dispatch paths a user drives.
+//! What: (a)/(b) point `tcode run-task <agent> ... --project <bare-tmp>
+//! --json` (`TCODE_MOCK_LLM=echo`) at a tempdir with NO `.claude/agents/`
+//! directory at all (unlike `support::project_with_agents`, which writes
+//! `.claude/agents/{pm,python-engineer}.md` — the opposite of what #3046
+//! needs to prove) and assert the run reaches `status: "finished"`. (c)
+//! proves disk-override-wins by driving the daemon protocol directly
+//! (`support::StdioSession`, mirroring `tests/task_e2e.rs`) so the run's
+//! transcript (not exposed by the outer CLI's `--json`, which only prints
+//! the terminal `Session` snapshot) can be inspected: a disk
+//! `rust-engineer.md` with a distinguishing `model:` must drive the
+//! top-level loop even though its delegated `python-engineer` sub-agent
+//! resolves purely via the embedded fallback in the SAME run.
+//! Test: this file IS the test.
+
+mod support;
+
+use std::process::Command;
+
+use serde_json::json;
+
+/// A bare project tempdir with NO `.claude/agents/` directory — the exact
+/// fresh-project shape #3046 requires, deliberately NOT
+/// `support::project_with_agents()` (which writes `.claude/agents/*.md` and
+/// would defeat the point of this repro).
+fn bare_project() -> tempfile::TempDir {
+    tempfile::tempdir().expect("project tempdir")
+}
+
+/// (a) Direct repro: `tcode run-task engineer ...` on a fresh project with
+/// no `.claude/agents/` must dispatch successfully via
+/// `EmbeddedAgent::Direct`.
+///
+/// Why: `engineer` is one of tcode's three ORIGINAL defaults (predating
+/// #2958) and exercises `run_task::execute_run_task`'s PM-config load (the
+/// #run_task-mod-mod-fix) directly. `EchoLlmClient`'s fixed script then
+/// self-delegates to `python-engineer` — also not on disk, also embedded
+/// (`EmbeddedAgent::Composed`) — so this single run additionally exercises
+/// `runner::in_process::load_agent` and
+/// `tools::delegate::DelegateToAgentTool`'s pre-flight gate.
+/// What: spawns the real `tcode` binary with `TCODE_MOCK_LLM=echo`; asserts
+/// exit 0 and `status: "finished"` in the `--json` output.
+/// Test: this test.
+#[test]
+fn run_task_engineer_direct_embedded_agent_dispatches_successfully() {
+    let project = bare_project();
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "run-task",
+            "engineer",
+            "say hi",
+            "--project",
+            &project.path().display().to_string(),
+            "--json",
+        ])
+        .env("TCODE_MOCK_LLM", "echo")
+        .output()
+        .expect("spawn tcode run-task engineer");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "tcode run-task engineer must exit 0 on a fresh project with no \
+         .claude/agents/ (#3046), got {:?}\nstdout: {stdout}\nstderr: {stderr}",
+        output.status.code()
+    );
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be valid JSON: {e}: {stdout}"));
+    assert_eq!(parsed["status"], "finished");
+}
+
+/// (b) Composed repro: `tcode run-task rust-engineer ...` on a fresh
+/// project with no `.claude/agents/` must dispatch successfully via
+/// `EmbeddedAgent::Composed` (`rust-engineer` extends `base-engineer`
+/// extends `base-agent`).
+///
+/// Why: proves the in-memory extends-composition path also works from the
+/// TOP-LEVEL (PM-config) entry point, not just the delegated-sub-agent path
+/// `runner::tests::embedded_restricted_agent_dispatch_preserves_tools_allowed`
+/// already covers.
+/// What: same shape as (a), agent name `rust-engineer`.
+/// Test: this test.
+#[test]
+fn run_task_rust_engineer_composed_embedded_agent_dispatches_successfully() {
+    let project = bare_project();
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "run-task",
+            "rust-engineer",
+            "say hi",
+            "--project",
+            &project.path().display().to_string(),
+            "--json",
+        ])
+        .env("TCODE_MOCK_LLM", "echo")
+        .output()
+        .expect("spawn tcode run-task rust-engineer");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "tcode run-task rust-engineer must exit 0 on a fresh project with no \
+         .claude/agents/ (#3046), got {:?}\nstdout: {stdout}\nstderr: {stderr}",
+        output.status.code()
+    );
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("stdout must be valid JSON: {e}: {stdout}"));
+    assert_eq!(parsed["status"], "finished");
+}
+
+/// (c) Project-override e2e: a disk `rust-engineer.md` must drive the
+/// top-level loop instead of the embedded default, even in the SAME run
+/// where the delegated `python-engineer` sub-agent resolves purely via the
+/// embedded fallback (proving override and fallback coexist correctly).
+///
+/// Why: the outer `tcode run-task ... --json` CLI surface only ever prints
+/// the terminal `Session` snapshot (`session.status`'s wire shape), which
+/// carries no transcript field — so proving WHICH config drove the loop
+/// requires inspecting `session.get_transcript`, which requires driving the
+/// daemon protocol directly on the SAME session (a second `tcode`
+/// invocation would spawn a fresh, empty-registry daemon — M1 sessions are
+/// in-memory, non-persistent). This mirrors `tests/task_e2e.rs`'s own
+/// `support::StdioSession`-based pattern instead of `tests/cli_e2e.rs`'s
+/// outer-binary-only pattern.
+/// What: writes ONLY `.claude/agents/rust-engineer.md` (no `python-engineer.md`)
+/// in a bare tempdir, with a distinguishing `model: marker/disk-override-wins`.
+/// Drives `task.run(agent_name: "rust-engineer")` -> `session.attach` ->
+/// polls for `session_done` -> `session.get_transcript`, then asserts the
+/// `"pm"`-role turn's `model` is the disk marker, not the embedded
+/// rust-engineer's real model slug.
+/// Test: this test.
+#[tokio::test]
+async fn disk_override_wins_over_embedded_for_top_level_dispatch() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let agents = project.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents).expect("mkdir agents");
+    std::fs::write(
+        agents.join("rust-engineer.md"),
+        "---\nname: rust-engineer\nmodel: marker/disk-override-wins\n---\n\n\
+         Disk override body — no extends: needed, it just has to parse.\n",
+    )
+    .expect("write rust-engineer.md override");
+    // Deliberately no python-engineer.md on disk: the delegated sub-agent
+    // must resolve via the embedded fallback in this SAME run.
+
+    let mut daemon = support::StdioSession::spawn_with_mock_llm(project.path());
+
+    let run_resp = daemon
+        .call(
+            1,
+            "task.run",
+            json!({"task_description": "say hi", "agent_name": "rust-engineer"}),
+        )
+        .await;
+    assert!(run_resp["error"].is_null(), "task.run failed: {run_resp}");
+    let session_id = run_resp["result"]["session_id"]
+        .as_str()
+        .expect("task.run must return a session_id")
+        .to_string();
+
+    let attach_resp = daemon
+        .call(2, "session.attach", json!({"session_id": session_id}))
+        .await;
+    assert!(
+        attach_resp["error"].is_null(),
+        "attach failed: {attach_resp}"
+    );
+    let mut kinds: Vec<String> = attach_resp["result"]["events"]
+        .as_array()
+        .expect("attach must return a replay events array")
+        .iter()
+        .map(|e| {
+            e["kind"]
+                .as_str()
+                .expect("kind must be a string")
+                .to_string()
+        })
+        .collect();
+
+    let mut iterations = 0;
+    while !kinds.iter().any(|k| k == "session_done") {
+        iterations += 1;
+        assert!(
+            iterations < 20,
+            "gave up waiting for session_done after {iterations} read rounds; \
+             kinds so far: {kinds:?}"
+        );
+        let lines = daemon.read_lines(20).await;
+        assert!(
+            !lines.is_empty(),
+            "timed out waiting for more events; kinds so far: {kinds:?}"
+        );
+        for line in &lines {
+            if let Some(envelope) = support::find_session_event(line, &session_id) {
+                kinds.push(
+                    envelope["kind"]
+                        .as_str()
+                        .expect("kind must be a string")
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    let transcript_resp = daemon
+        .call(
+            3,
+            "session.get_transcript",
+            json!({"session_id": session_id}),
+        )
+        .await;
+    assert!(
+        transcript_resp["error"].is_null(),
+        "get_transcript failed: {transcript_resp}"
+    );
+    let turns = transcript_resp["result"]["turns"]
+        .as_array()
+        .expect("turns must be an array");
+    let pm_turn = turns
+        .iter()
+        .find(|t| t["role"] == "pm")
+        .unwrap_or_else(|| panic!("expected a pm-role turn in the transcript: {turns:?}"));
+    assert_eq!(
+        pm_turn["model"], "marker/disk-override-wins",
+        "the disk rust-engineer.md override must drive the top-level loop, \
+         not the embedded default's own model"
+    );
+}


### PR DESCRIPTION
## Summary

- The embedded 31-agent `DEFAULT_AGENTS` roster (#2958) had a working composer for `agents::load_all_agents`'s dir-wide scan, but five other production call sites read `<agents_dir>/<name>.md` directly off disk with no embedded fallback at all — `InProcessAgentRunner::load_agent`, `run_task::execute_run_task`'s and `task::executor`'s PM-config loads, `run_task::resolve_agent_model_slug`, and `tools::delegate::DelegateToAgentTool`'s pre-flight check/hint. `tcode run-task engineer ...` and `tcode run-task rust-engineer ...` both failed with "agent source not found" on a fresh project with no `.claude/agents/` (live-reproduced during code-critic review of #3041).
- Adds one shared resolution helper, `agents::resolve_agent(dir, name) -> Result<AgentConfig, ResolveAgentError>` (`crates/trusty-code/src/agents/mod.rs`) — disk always wins when present, even on a parse error (never silently falls back to a same-named embedded agent, so a broken project override surfaces its own bug rather than being masked) — plus `agents::available_agent_names(dir) -> Vec<String>` (disk ∪ embedded, sorted/deduped) for "available agents" hints.
- Routes all six call sites through it: `runner::in_process::InProcessAgentRunner::load_agent` and `agent_config_exists`, `run_task::execute_run_task`'s PM-config load and `resolve_agent_model_slug`, `task::executor`'s PM-config load, and `tools::delegate::DelegateToAgentTool::available_agents`.

## Test plan

- [x] `cargo build -p trusty-code`
- [x] `cargo test -p trusty-code --lib` — 1198 passed, 0 failed (includes new unit tests on `resolve_agent`/`available_agent_names`, and a runner-level test proving the four tools-restricted embedded agents — `qa`/`code-critic`/`code-analyzer`/`web-qa` — still get gated correctly when dispatched purely via the embedded fallback)
- [x] `cargo test -p trusty-code --tests` — all binaries pass, including the new `tests/agent_fallback_e2e.rs`, which spawns the real `tcode` binary and reproduces both failing cases named in #3046 (`run-task engineer`, `run-task rust-engineer`, both on a fresh project with no `.claude/agents/`) plus a disk-override-wins case proving a project's own `rust-engineer.md` still beats the embedded default
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (pre-existing unrelated `tga` warnings only)
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean, no new allowlist entries
- [x] `CHANGELOG.md` updated under `## [Unreleased]` / `### Fixed`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools