### PR TITLE
feat(ci): agent-asset staleness guard — byte-parity + pinned-deviation checks (Slice E4, refs #2958)

### DIFF
--- a/.github/workflows/agent-assets.yml
+++ b/.github/workflows/agent-assets.yml
@@ -1,0 +1,50 @@
+# Agent-asset staleness guard for the trusty-tools workspace (issue #2958 Slice E4).
+#
+# Enforces that trusty-code's embedded tm-agent copies
+# (crates/trusty-code/src/assets/agents/*.md) never silently drift from their
+# trusty-mpm source (crates/trusty-mpm/src/assets/agents/*.md):
+#   - 29 files must stay byte-identical to their trusty-mpm source;
+#   - 4 known-deviated files (qa.md, code-critic.md, code-analyzer.md,
+#     web-qa.md — a Bob-approved tools: restriction + reworded prose) are
+#     pinned by trusty-mpm SOURCE hash instead, so an upstream edit behind
+#     one of them fails the gate for deliberate reconciliation instead of
+#     drifting unnoticed.
+#
+# Pure file/hash comparison — no Rust toolchain or build needed, so this runs
+# as its own lightweight job (matches line-cap.yml's structure/style). Scoped
+# to PRs touching either assets directory or the guard itself.
+name: Agent assets
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/trusty-code/src/assets/agents/**"
+      - "crates/trusty-mpm/src/assets/agents/**"
+      - "scripts/check_agent_assets.sh"
+      - "scripts/agent-asset-pins.tsv"
+      - ".github/workflows/agent-assets.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/trusty-code/src/assets/agents/**"
+      - "crates/trusty-mpm/src/assets/agents/**"
+      - "scripts/check_agent_assets.sh"
+      - "scripts/agent-asset-pins.tsv"
+      - ".github/workflows/agent-assets.yml"
+
+# Cancel superseded runs for the same ref to save CI minutes (matches ci.yml).
+concurrency:
+  group: agent-assets-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  agent-assets:
+    name: tcode embedded agent-asset staleness check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Enforce agent-asset parity + pinned-deviation checks
+        run: bash scripts/check_agent_assets.sh

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **CI staleness guard for the embedded tm-agent copies (issue #2958 Slice
+  E4).** `scripts/check_agent_assets.sh` + `.github/workflows/agent-assets.yml`
+  diff `crates/trusty-code/src/assets/agents/*.md` against their source in
+  `crates/trusty-mpm/src/assets/agents/`: the 29 byte-parity files must stay
+  byte-identical to trusty-mpm's source, and the 4 Slice-E3 deliberate
+  deviations (`qa.md`, `code-critic.md`, `code-analyzer.md`, `web-qa.md` —
+  `tools:` restriction + reworded read-only prose) are pinned by trusty-mpm
+  SOURCE hash in `scripts/agent-asset-pins.tsv` instead of byte-compared, so
+  an upstream edit behind one of them fails the gate for deliberate
+  reconciliation rather than silently drifting. `--update`/`--force-add`
+  re-pin after an intentional reconciliation, mirroring
+  `scripts/check_line_cap.sh`'s ratchet ethos (refuses to add a new deviation
+  silently).
+
 ### Fixed
 
 - the embedded 31-agent `DEFAULT_AGENTS` roster (#2958) is now actually

--- a/crates/trusty-code/src/assets/mod.rs
+++ b/crates/trusty-code/src/assets/mod.rs
@@ -69,6 +69,15 @@
 //! staleness guard must whitelist the reworded prose sections in these three
 //! files too, not just the `tools:` line.
 //!
+//! ## E4 staleness guard (issue #2958, `scripts/check_agent_assets.sh`)
+//!
+//! CI enforcement of everything above: byte-compares the 29 non-deviated
+//! embedded copies against their trusty-mpm source, and pins the 4 deviated
+//! files' upstream SOURCE hash (`scripts/agent-asset-pins.tsv`) so an
+//! upstream edit behind one of them fails the gate for deliberate
+//! reconciliation rather than drifting unnoticed. See that script's header
+//! for the full design and `.github/workflows/agent-assets.yml` for the gate.
+//!
 //! Test: `assets::tests::*` — every embedded agent `.md` parses and projects
 //! to a field-identical `AgentConfig` vs. the retired TOML fixtures (the
 //! original 3), every roster name resolves through the extends composer with

--- a/scripts/agent-asset-pins.tsv
+++ b/scripts/agent-asset-pins.tsv
@@ -1,0 +1,25 @@
+# agent-asset-pins.tsv — pinned trusty-mpm source hashes for deliberately
+# deviated tcode agent copies (issue #2958 Slice E4).
+#
+# Format: <mpm-source-relative-path><TAB><sha256-of-mpm-source-file>
+#
+# These 4 files are the KNOWN INTENTIONAL DEVIATIONS from byte-parity
+# documented in crates/trusty-code/src/assets/mod.rs ("Tools-restriction
+# deviation" / "Prose deviation follow-up" doc blocks, Slice E3, PR #3041):
+# the tcode copy carries an added `tools:` frontmatter line plus (for three
+# of the four) reworded read-only prose, so it can never be byte-identical
+# to the trusty-mpm source it was derived from.
+#
+# check_agent_assets.sh does NOT byte-compare these 4 tcode copies against
+# their mpm source (that would always fail by design). Instead it hashes the
+# CURRENT mpm SOURCE file and compares against the pin recorded here. If the
+# mpm source hash no longer matches, upstream changed behind a deliberately
+# deviated copy — the guard fails so a human reconciles the tcode copy on
+# purpose, rather than silently drifting.
+#
+# Regenerate a pin (only after manually reconciling the tcode copy with the
+# new upstream content) with: scripts/check_agent_assets.sh --update
+crates/trusty-mpm/src/assets/agents/code-analyzer.md	de345cc4775625d0c1953bd8cf06f8701d068ebac138c69dd4cb15cc163b02bc
+crates/trusty-mpm/src/assets/agents/code-critic.md	e68065861132e1684392e15fc3a718ffae3e0b398aecdb36460e7ca16a153d63
+crates/trusty-mpm/src/assets/agents/qa.md	1878ecb3773296fb5e2d659b1d28a044608511bad2cf7c294870bd67aa1fc353
+crates/trusty-mpm/src/assets/agents/web-qa.md	50f913c1291d3f5b118413abc35c3d6bcf125ca06fa06b3351315781b5b60b97

--- a/scripts/check_agent_assets.sh
+++ b/scripts/check_agent_assets.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+#
+# check_agent_assets.sh — tcode embedded agent-asset staleness guard (issue #2958 Slice E4).
+#
+# Why: Slice E2/E3 embedded 33 of trusty-mpm's agent `.md` files (5 BASE-*
+#   templates + 28 coding-relevant roster agents) into trusty-code as
+#   `include_str!` assets under crates/trusty-code/src/assets/agents/, copied
+#   byte-for-byte from crates/trusty-mpm/src/assets/agents/ at the time of the
+#   copy. Nothing mechanically stops trusty-mpm's source files from drifting
+#   away from the tcode copies afterward — an upstream prompt tweak, a typo
+#   fix, a new tool restriction — landing in trusty-mpm/src/assets/agents/
+#   with zero signal that trusty-code's embedded copy is now stale. This gate
+#   closes that gap.
+#
+# KNOWN INTENTIONAL DEVIATIONS (Slice E3, PR #3041, Bob's 2026-07-18 ruling):
+#   four files — qa.md, code-critic.md, code-analyzer.md, web-qa.md — carry a
+#   deliberate `tools:` frontmatter restriction in their tcode copy (plus, for
+#   three of the four, reworded read-only prose) that is NOT present in the
+#   trusty-mpm source. Byte-parity is the wrong test for these four. See the
+#   "Tools-restriction deviation" / "Prose deviation follow-up" doc blocks in
+#   crates/trusty-code/src/assets/mod.rs for the full rationale.
+#
+# What: two check strategies, chosen per file:
+#   1. PARITY (29 files: 5 BASE-* + 24 roster agents) — the tcode copy must be
+#      byte-identical to its trusty-mpm source (same basename). A mismatch
+#      means the tcode copy silently drifted (edited without updating the
+#      copy) OR trusty-mpm's source moved on without the copy following —
+#      either way, FAIL and name the exact two paths to diff.
+#   2. PINNED DEVIATION (4 files, $DEVIATED_FILES below) — never byte-compared
+#      (they are supposed to differ). Instead this script hashes the CURRENT
+#      trusty-mpm SOURCE file and compares it against the sha256 recorded in
+#      scripts/agent-asset-pins.tsv. If upstream's source hash no longer
+#      matches the pin, upstream changed behind a deliberately-deviated copy —
+#      FAIL so a human reconciles the tcode copy on purpose (re-apply the
+#      tools: restriction / read-only prose rewrite against the new upstream
+#      content) rather than the deviation silently going stale.
+#   Three tcode-only files (engineer.md, qa-agent.md, code-reviewer.md — tcode's
+#   pre-existing defaults, never sourced from trusty-mpm; tcode's own
+#   `engineer.md` deliberately does NOT track trusty-mpm's `engineer.md`,
+#   which is excluded from the roster specifically to avoid the name
+#   collision) are skipped entirely.
+#   Any other tcode `.md` file not in the parity set, the deviated set, or the
+#   tcode-only exclude list is flagged as "new roster file unaccounted" — add
+#   it to TCODE_ONLY (if genuinely tcode's own) or verify its trusty-mpm
+#   source path.
+#
+#   NOTE ON SCOPE: this only walks the tcode-side files that are tracked in
+#   git (`git ls-files`), so it cannot detect a *wholesale deletion* of an
+#   embedded copy that Rust's `include_str!` didn't already catch at compile
+#   time (a missing embedded asset fails the trusty-code build). The 4 pinned
+#   deviated files are the exception — their presence is checked explicitly
+#   (see below) since Rust's compile error alone wouldn't explain *why* they
+#   went missing.
+#
+#   --update       recompute the pinned sha256 for every file already listed
+#                  in scripts/agent-asset-pins.tsv, after you've deliberately
+#                  reconciled the tcode copy with new upstream content. Only
+#                  refreshes existing pins; refuses to add a new deviated
+#                  file to the pin set.
+#   --force-add    like --update but also permits adding a pin for a basename
+#                  in $DEVIATED_FILES that has no row in the pins file yet
+#                  (i.e. you just declared a NEW deliberate deviation). Escape
+#                  hatch; use sparingly and update the mod.rs doc block too.
+#
+# Usage:
+#   bash scripts/check_agent_assets.sh              # check (CI mode)
+#   bash scripts/check_agent_assets.sh --update      # re-pin after reconciling
+#   bash scripts/check_agent_assets.sh --force-add   # re-pin + allow new deviations
+#
+# Test: exercised manually per Slice E4's task brief — a clean tree passes; a
+#   byte-mutated parity copy fails as "COPY DRIFTED"; a mutated pinned mpm
+#   source fails as "UPSTREAM CHANGED"; both revert cleanly. No unit-test
+#   harness (pure file/hash comparison against tracked git content, mirrors
+#   scripts/check_line_cap.sh and scripts/check_capabilities.sh conventions).
+#
+# Portability: bash 3.2 (macOS) and bash 5 (Linux CI). POSIX tools only
+# (`git`, `awk`, `cmp`, `shasum`/`sha256sum`). No associative arrays.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+TCODE_DIR="crates/trusty-code/src/assets/agents"
+MPM_DIR="crates/trusty-mpm/src/assets/agents"
+PINS="scripts/agent-asset-pins.tsv"
+
+# tcode's own pre-existing defaults — never sourced from trusty-mpm.
+TCODE_ONLY="engineer.md qa-agent.md code-reviewer.md"
+
+# The 4 files with a Bob-approved deliberate deviation from byte-parity
+# (Slice E3, PR #3041). Pinned by trusty-mpm SOURCE hash, not byte-compared.
+DEVIATED_FILES="code-analyzer.md code-critic.md qa.md web-qa.md"
+
+# ---------------------------------------------------------------------------
+# Mode parsing
+# ---------------------------------------------------------------------------
+MODE="check"
+ALLOW_NEW=0
+for arg in "$@"; do
+  case "$arg" in
+    --update)    MODE="update" ;;
+    --force-add) MODE="update"; ALLOW_NEW=1 ;;
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "check_agent_assets: unknown argument: $arg" >&2
+      echo "usage: check_agent_assets.sh [--update | --force-add]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+sha256_of() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    sha256sum "$1" | awk '{print $1}'
+  fi
+}
+
+is_in() {
+  local needle="$1"; shift
+  local x
+  for x in "$@"; do
+    [ "$x" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+# get_pinned_hash <mpm-source-path> — prints the recorded sha256, or nothing.
+get_pinned_hash() {
+  local path="$1"
+  awk -F'\t' -v p="$path" '$0 !~ /^#/ && $1 == p { print $2 }' "$PINS" 2>/dev/null
+}
+
+# DEVIATED_FILES/TCODE_ONLY are fixed, glob-free basename lists declared
+# above — safe to word-split into arrays.
+# shellcheck disable=SC2206
+DEVIATED_ARR=($DEVIATED_FILES)
+# shellcheck disable=SC2206
+TCODE_ONLY_ARR=($TCODE_ONLY)
+
+# ===========================================================================
+# UPDATE MODE  (--update / --force-add)
+# ===========================================================================
+if [ "$MODE" = "update" ]; then
+  NEWPINS="$(mktemp "${TMPDIR:-/tmp}/agentpins.new.XXXXXX")"
+  trap 'rm -f "$NEWPINS"' EXIT
+
+  {
+    echo "# agent-asset-pins.tsv — pinned trusty-mpm source hashes for deliberately"
+    echo "# deviated tcode agent copies (issue #2958 Slice E4)."
+    echo "#"
+    echo "# Format: <mpm-source-relative-path><TAB><sha256-of-mpm-source-file>"
+    echo "#"
+    echo "# These 4 files are the KNOWN INTENTIONAL DEVIATIONS from byte-parity"
+    echo "# documented in crates/trusty-code/src/assets/mod.rs (\"Tools-restriction"
+    echo "# deviation\" / \"Prose deviation follow-up\" doc blocks, Slice E3, PR #3041):"
+    echo "# the tcode copy carries an added \`tools:\` frontmatter line plus (for three"
+    echo "# of the four) reworded read-only prose, so it can never be byte-identical"
+    echo "# to the trusty-mpm source it was derived from."
+    echo "#"
+    echo "# check_agent_assets.sh does NOT byte-compare these 4 tcode copies against"
+    echo "# their mpm source (that would always fail by design). Instead it hashes the"
+    echo "# CURRENT mpm SOURCE file and compares against the pin recorded here. If the"
+    echo "# mpm source hash no longer matches, upstream changed behind a deliberately"
+    echo "# deviated copy — the guard fails so a human reconciles the tcode copy on"
+    echo "# purpose, rather than silently drifting."
+    echo "#"
+    echo "# Regenerate a pin (only after manually reconciling the tcode copy with the"
+    echo "# new upstream content) with: scripts/check_agent_assets.sh --update"
+  } > "$NEWPINS"
+
+  err=0
+  for base in "${DEVIATED_ARR[@]}"; do
+    mpm_path="$MPM_DIR/$base"
+    if [ ! -f "$mpm_path" ]; then
+      echo "REFUSE: $mpm_path does not exist — cannot pin a missing source file." >&2
+      err=1
+      continue
+    fi
+    existing="$(get_pinned_hash "$mpm_path")"
+    if [ -z "$existing" ] && [ "$ALLOW_NEW" -ne 1 ]; then
+      echo "REFUSE: $mpm_path has no existing pin in $PINS (new deviation)." >&2
+      echo "        Pass --force-add to add it deliberately, and update the" >&2
+      echo "        'Tools-restriction deviation' doc block in" >&2
+      echo "        crates/trusty-code/src/assets/mod.rs to document it." >&2
+      err=1
+      continue
+    fi
+    new_hash="$(sha256_of "$mpm_path")"
+    printf '%s\t%s\n' "$mpm_path" "$new_hash" >> "$NEWPINS"
+  done
+
+  if [ "$err" -ne 0 ]; then
+    echo "check_agent_assets --update aborted: unresolved issues above." >&2
+    exit 1
+  fi
+
+  mv "$NEWPINS" "$PINS"
+  trap - EXIT
+  echo "check_agent_assets: wrote $PINS with ${#DEVIATED_ARR[@]} pinned deviation(s)."
+  exit 0
+fi
+
+# ===========================================================================
+# CHECK MODE
+# ===========================================================================
+FAIL=0
+
+if [ ! -f "$PINS" ]; then
+  echo "FAIL: pins file $PINS is missing." >&2
+  exit 1
+fi
+
+# --- 1. Pinned deviated files: must exist in tcode dir, and their mpm SOURCE
+#        hash must still match the pin. Never byte-compared against tcode. ---
+for base in "${DEVIATED_ARR[@]}"; do
+  tcode_path="$TCODE_DIR/$base"
+  mpm_path="$MPM_DIR/$base"
+
+  if [ ! -f "$tcode_path" ]; then
+    echo "FAIL: MISSING COPY — $tcode_path is a declared deviated file (see" >&2
+    echo "      DEVIATED_FILES in scripts/check_agent_assets.sh) but does not exist." >&2
+    FAIL=1
+    continue
+  fi
+  if [ ! -f "$mpm_path" ]; then
+    echo "FAIL: MISSING SOURCE — $mpm_path (source for the deviated copy $tcode_path)" >&2
+    echo "      no longer exists. If trusty-mpm genuinely removed this agent," >&2
+    echo "      retire the tcode copy and drop it from DEVIATED_FILES + $PINS." >&2
+    FAIL=1
+    continue
+  fi
+
+  pinned="$(get_pinned_hash "$mpm_path")"
+  if [ -z "$pinned" ]; then
+    echo "FAIL: UNPINNED DEVIATION — $mpm_path has no entry in $PINS." >&2
+    echo "      Run: scripts/check_agent_assets.sh --force-add" >&2
+    FAIL=1
+    continue
+  fi
+
+  current="$(sha256_of "$mpm_path")"
+  if [ "$current" != "$pinned" ]; then
+    echo "FAIL: UPSTREAM CHANGED BEHIND A DEVIATED COPY — $mpm_path no longer" >&2
+    echo "      matches its pin in $PINS (pinned=$pinned current=$current)." >&2
+    echo "      Reconcile $tcode_path with the new upstream content on purpose" >&2
+    echo "      (it deliberately deviates: tools: restriction + reworded prose)," >&2
+    echo "      then run: scripts/check_agent_assets.sh --update" >&2
+    FAIL=1
+  fi
+done
+
+# --- 2. Parity files: every tracked tcode .md not in TCODE_ONLY or
+#        DEVIATED_FILES must byte-match its trusty-mpm source. ---
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  base="${f##*/}"
+
+  if is_in "$base" "${TCODE_ONLY_ARR[@]}"; then
+    continue
+  fi
+  if is_in "$base" "${DEVIATED_ARR[@]}"; then
+    continue
+  fi
+
+  mpm_path="$MPM_DIR/$base"
+  if [ ! -f "$mpm_path" ]; then
+    echo "FAIL: NEW ROSTER FILE UNACCOUNTED — $f has no trusty-mpm source at" >&2
+    echo "      $mpm_path and is not declared tcode-only (TCODE_ONLY in" >&2
+    echo "      scripts/check_agent_assets.sh). Either add it to TCODE_ONLY (if it" >&2
+    echo "      is genuinely tcode's own, not copied from trusty-mpm) or restore" >&2
+    echo "      the trusty-mpm source path." >&2
+    FAIL=1
+    continue
+  fi
+
+  if ! cmp -s "$f" "$mpm_path"; then
+    echo "FAIL: COPY DRIFTED — $f no longer byte-matches $mpm_path." >&2
+    echo "      Either restore byte-parity (unintentional edit), or if this is a" >&2
+    echo "      deliberate new deviation: add '$base' to DEVIATED_FILES in" >&2
+    echo "      scripts/check_agent_assets.sh, pin it with --force-add, and" >&2
+    echo "      document it in the 'Tools-restriction deviation' doc block in" >&2
+    echo "      crates/trusty-code/src/assets/mod.rs." >&2
+    FAIL=1
+  fi
+done < <(git ls-files "$TCODE_DIR/*.md")
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "agent-assets: FAILED — see FAIL lines above." >&2
+  exit 1
+fi
+
+echo "agent-assets: 29 byte-parity file(s) match, ${#DEVIATED_ARR[@]} pinned deviation(s) match upstream — OK."
+exit 0


### PR DESCRIPTION
## Summary

Final slice of #2958 (E4, deferred from the E3 PR #3041 note). Adds a CI
staleness guard so trusty-mpm's source agent `.md` files
(`crates/trusty-mpm/src/assets/agents/`) can never silently drift away from
trusty-code's embedded copies (`crates/trusty-code/src/assets/agents/`,
merged in E2/E3) without a gate catching it.

## Design

`scripts/check_agent_assets.sh` classifies every embedded tcode agent `.md`
file into one of three buckets:

1. **29 byte-parity files** (5 `BASE-*` templates + 24 roster agents) —
   byte-compared against their trusty-mpm source. Any diff fails as `COPY
   DRIFTED`.
2. **4 pinned-deviation files** (`qa.md`, `code-critic.md`,
   `code-analyzer.md`, `web-qa.md`) — the Slice E3 / PR #3041 Bob-approved
   deliberate deviation (an added `tools:` frontmatter restriction, plus
   reworded read-only prose in three of the four). These are never
   byte-compared — instead the script hashes the **current trusty-mpm
   source** and compares it to a pinned sha256 in
   `scripts/agent-asset-pins.tsv`. If upstream's source hash no longer
   matches the pin, the gate fails as `UPSTREAM CHANGED BEHIND A DEVIATED
   COPY`, forcing a human to reconcile the tcode copy on purpose instead of
   it silently going stale.
3. **3 tcode-only files** (`engineer.md`, `qa-agent.md`, `code-reviewer.md`)
   — tcode's own pre-existing defaults, never sourced from trusty-mpm, are
   excluded entirely (tcode's `engineer.md` deliberately does not track
   trusty-mpm's `engineer.md`, which is excluded from the roster specifically
   to avoid the name collision — see #2958).

Any other tcode `.md` file that doesn't fall into one of the three buckets
fails as `NEW ROSTER FILE UNACCOUNTED`.

`--update` re-pins the 4 deviated files' hashes after a deliberate
reconciliation; it refuses to add a pin for a newly-declared deviation
without `--force-add`, mirroring `scripts/check_line_cap.sh`'s ratchet ethos.

`.github/workflows/agent-assets.yml` runs the guard on pushes/PRs touching
either assets directory, the script, or the pins file — mirrors
`line-cap.yml`'s lightweight (no Rust toolchain) structure.

## Failure-mode verification (all demonstrated locally, then reverted)

- **COPY DRIFTED** — appended a line to the tcode copy of `rust-engineer.md`
  (a parity file) → guard failed naming both paths; reverted, guard passed.
- **UPSTREAM CHANGED BEHIND A DEVIATED COPY** — appended a line to
  trusty-mpm's `qa.md` source (a pinned file) → guard failed with pinned vs.
  current hash; reverted, guard passed.
- **MISSING COPY** — removed the tcode copy of a pinned deviated file
  (`web-qa.md`) → guard failed; restored, guard passed.
- **NEW ROSTER FILE UNACCOUNTED** — added and `git add`ed a new tcode agent
  file with no trusty-mpm source (`mystery-agent.md`) → guard failed;
  removed, guard passed.

## Gate (crate-scoped, per repo convention)

```
bash scripts/check_agent_assets.sh   -> 29 byte-parity file(s) match, 4 pinned deviation(s) match upstream — OK.
shellcheck scripts/check_agent_assets.sh -> exit 0 (fixed two SC2206 word-splitting warnings)
cargo build -p trusty-code           -> Finished, clean (docs-only Rust change: a doc-comment pointer)
cargo fmt --check                    -> clean, no diff
bash scripts/check_line_cap.sh       -> 10 allowlisted, 0 violations — OK
```

## Files

- `scripts/check_agent_assets.sh` (new) — the guard
- `scripts/agent-asset-pins.tsv` (new) — pinned trusty-mpm source hashes for the 4 deviated files
- `.github/workflows/agent-assets.yml` (new) — CI wiring
- `crates/trusty-code/src/assets/mod.rs` — one-line pointer to the guard added to the existing deviation doc block
- `crates/trusty-code/CHANGELOG.md` — `[Unreleased] / ### Added` entry

Refs #2958.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools