### PR TITLE
feat(trusty-code-gui): Phase-1 Search tab (refs DOC-39 10d)

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -122,3 +122,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Rust, per DOC-39 §2.1's thin-client rule. Minimal working shell only — the
   full DOC-39 screens land in later slices as the REST gateway (#2983) adds
   routes.
+
+### Added
+
+- Phase-1 Search tab (10d, DOC-39 §4.7): `SearchTab.svelte`, mounted in
+  `App.svelte` inside `.body` alongside `SessionMonitor`. Per §4.7/AC-7.1,
+  this screen is explicitly **not** a search box — it has no `<input>`
+  anywhere (pinned by `SearchTab.test.ts`) — and instead is meant to be the
+  audit trail of the searches agents performed, rendering AC-7.2's required
+  column headers (lane, query, hits, latency, agent, age) as static table
+  structure ready to receive rows once the REST gap below closes. Polls
+  `GET /sessions` only (identical `$effect`/`AbortController`/`setInterval`
+  shape to `StatusBar.svelte`/`SessionMonitor.svelte`) to distinguish
+  `connecting`/`daemon-unreachable`/`no-session` from an active session.
+  **Scope gap:** `Event::SearchPerformed`/`Event::MemoryRecalled`
+  (`crates/trusty-code/src/events.rs`) already carry every field AC-7.2
+  needs (`lane`/`query`/`hit_count`/`hits`/`latency_ms`/`agent`/`agent_id`),
+  but — the same underlying gap `SessionMonitor.svelte` already called out
+  for the 8b card's AC-6.3 (issue #3027) — both events are emitted ONLY on
+  the SSE stream (`GET /sessions/{id}/events`) with no REST snapshot/list
+  route and no persisted per-session accumulation in the registry. Per this
+  PR's architecture rule, the tab must be a thin REST client (never an SSE
+  consumer buffering an unbounded per-session event log client-side, and
+  never a direct `POST /rpc` caller bypassing the REST resource-gateway
+  pattern), so it ships the honest shell described above and renders a
+  labeled, non-hidden gap notice (same treatment as `StatusBar`'s `budget:
+  unavailable` span) instead of an empty table pretending to be complete.
+  Filed as issue #3072, proposing a new `GET /sessions/{id}/search-audit`
+  REST route backed by an always-retained `SessionEntry.search_audit` list
+  (mirroring the #2962 agents-map precedent), appended from the same
+  `SessionRegistry::record_search_performed`/`record_memory_recalled` path
+  that already emits the SSE event — a single fix that would close both
+  #3027 and #3072. `App.test.ts` gained a third assertion pinning that
+  `SearchTab` renders inside `.body`.

--- a/crates/trusty-code-gui/ui/src/App.svelte
+++ b/crates/trusty-code-gui/ui/src/App.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   // Why: Minimal scaffold shell (issue #2983, DOC-39) — proves the desktop
   // app connects to the tcode daemon and gives the next UI slice a layout to
-  // extend. Phase 1 adds the status bar (DOC-39 §6.2) and, in this slice,
-  // the 8b session monitor card (DOC-39 §4.6, refs #2983). `body`'s prior
+  // extend. Phase 1 adds the status bar (DOC-39 §6.2), the 8b session
+  // monitor card (DOC-39 §4.6, refs #2983), and, in this slice, the 10d
+  // Search tab (DOC-39 §4.7, refs #3072). `body`'s prior
   // `ActivityPlaceholder` explicitly said its purpose was "session list /
   // activity view... coming once GET /sessions lands" — that has now
   // landed and `SessionMonitor` covers "what's happening in the active
@@ -13,19 +14,22 @@
   // this placeholder was actually standing in for once GET /sessions is
   // live).
   // What: Renders a header, a `.body` region (the daemon HealthPanel smoke
-  // connection + the session monitor card), and `StatusBar` — the
-  // readiness+budget chrome — as a DIRECT SIBLING of `.body`, never nested
-  // inside it. DOC-39 §8.1 / AC-18.1 calls this out explicitly: nesting
-  // `.statusbar` inside `.body` has regressed the wireframe twice ("This bit
-  // us twice… assert it in a test") because it steals the body's row width.
-  // `App.test.ts` asserts the DOM invariant this markup encodes.
+  // connection + the session monitor card + the search audit tab), and
+  // `StatusBar` — the readiness+budget chrome — as a DIRECT SIBLING of
+  // `.body`, never nested inside it. DOC-39 §8.1 / AC-18.1 calls this out
+  // explicitly: nesting `.statusbar` inside `.body` has regressed the
+  // wireframe twice ("This bit us twice… assert it in a test") because it
+  // steals the body's row width. `App.test.ts` asserts the DOM invariant
+  // this markup encodes.
   // Test: Launch under Tauri or `pnpm dev` in a browser — both show the same
   // connected/disconnected state (DOC-39 §2.1 web/Tauri parity) plus the
-  // status bar's readiness indicator and the session monitor card.
-  // `App.test.ts::statusbar-is-sibling-of-body` pins the structural
-  // invariant; `App.test.ts::session-monitor-renders-inside-body` pins the
-  // monitor card's placement.
+  // status bar's readiness indicator, the session monitor card, and the
+  // search tab. `App.test.ts::statusbar-is-sibling-of-body` pins the
+  // structural invariant; `App.test.ts::session-monitor-renders-inside-body`
+  // and `App.test.ts::search-tab-renders-inside-body` pin the two cards'
+  // placement.
   import HealthPanel from './components/HealthPanel.svelte';
+  import SearchTab from './components/SearchTab.svelte';
   import SessionMonitor from './components/SessionMonitor.svelte';
   import StatusBar from './components/StatusBar.svelte';
 </script>
@@ -39,6 +43,7 @@
   <div class="body flex flex-1 flex-col gap-4 p-6">
     <HealthPanel />
     <SessionMonitor />
+    <SearchTab />
   </div>
 
   <StatusBar />

--- a/crates/trusty-code-gui/ui/src/App.test.ts
+++ b/crates/trusty-code-gui/ui/src/App.test.ts
@@ -2,14 +2,15 @@
 // that has "bit us twice in the wireframe" and explicitly asks for a
 // DOM/structural test (AC-18.1) — this is that test, pinned at the shell
 // level so a future refactor of `App.svelte` cannot silently reintroduce
-// the nesting. A second, lower-stakes assertion pins that `SessionMonitor`
-// (the 8b card, DOC-39 §4.6, refs #2983) mounts inside `.body` — a cheap
-// regression guard, not a new normative rule beyond what the spec already
+// the nesting. Two further, lower-stakes assertions pin that `SessionMonitor`
+// (the 8b card, DOC-39 §4.6, refs #2983) and `SearchTab` (the 10d Search
+// tab, DOC-39 §4.7, refs #3072) both mount inside `.body` — cheap
+// regression guards, not new normative rules beyond what the spec already
 // requires of `.statusbar`.
 // What: Mounts the real `App.svelte` (with `fetch` stubbed so the mount
 // doesn't make a real network call) and asserts `.statusbar` is a direct
 // child of `.app` and NOT a descendant of `.body`, and that the session
-// monitor card renders inside `.body`.
+// monitor card and the search tab both render inside `.body`.
 // Test: this file.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, unmount } from 'svelte';
@@ -59,5 +60,15 @@ describe('App shell structure (DOC-39 §8.1, AC-18.1)', () => {
 
     expect(body).not.toBeNull();
     expect(headings.some((h) => h.textContent === 'session monitor')).toBe(true);
+  });
+
+  it('SearchTab (10d Search tab, DOC-39 §4.7) renders inside .body', () => {
+    instance = mount(App, { target }) as unknown as Record<string, unknown>;
+
+    const body = target.querySelector('.body');
+    const headings = Array.from(body?.querySelectorAll('h2') ?? []);
+
+    expect(body).not.toBeNull();
+    expect(headings.some((h) => h.textContent === 'search')).toBe(true);
   });
 });

--- a/crates/trusty-code-gui/ui/src/components/SearchTab.svelte
+++ b/crates/trusty-code-gui/ui/src/components/SearchTab.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+  // Why: DOC-39 §4.7 (SPEC-TCUI, "'Search' is two different things") defines
+  // the **Search tab (10d)** as the audit trail of agent search operations —
+  // explicitly NOT a search box (AC-7.1: "no input field"). Literal find
+  // (⌘K) is a *different*, not-yet-built surface scoped to the Project page
+  // (AC-7.3/7.4), out of scope here.
+  //
+  // AC-7.2 requires every row to show lane badge, query, hit count, latency,
+  // **requesting agent**, and age. The underlying data exists —
+  // `Event::SearchPerformed`/`Event::MemoryRecalled`
+  // (`crates/trusty-code/src/events.rs`) already carry `lane`/`query`/
+  // `hit_count`/`hits`/`latency_ms`/`agent`/`agent_id` — but per this PR's
+  // architecture rule, this tab must be a thin REST client, never an SSE
+  // consumer buffering an unbounded per-session event log client-side, and
+  // never a direct `POST /rpc` caller (that would bypass the REST
+  // resource-gateway pattern `serve/rest/mod.rs` establishes). Both events
+  // are emitted ONLY on the SSE stream (`GET /sessions/{id}/events`) with no
+  // REST snapshot/list route and no persisted per-session accumulation
+  // anywhere in the registry — so there is no legal REST data source for
+  // AC-7.2's rows today. This is the SAME underlying gap `SessionMonitor.svelte`
+  // already calls out for the 8b inline monitor (issue #3027); the audit-list
+  // half (10d, this component) is tracked separately as issue #3072, which
+  // proposes the exact fix: a new `GET /sessions/{id}/search-audit` REST
+  // route backed by an always-retained `SessionEntry.search_audit` list
+  // (mirroring the #2962 agents-map precedent), appended from the same
+  // `SessionRegistry::record_search_performed`/`record_memory_recalled` path
+  // that already emits the SSE event.
+  //
+  // What: Ships the honest Phase-1 shell: the AC-7.1 explanatory banner (no
+  // input field — literally none is rendered, so AC-7.1 holds by
+  // construction), the AC-7.2 column headers (Lane / Query / Hits / Latency /
+  // Agent / Age) as static table structure, and a labeled, non-hidden gap
+  // notice in place of rows (same treatment as `StatusBar`'s `budget:
+  // unavailable` span and `SessionMonitor`'s AC-6.3 notice). Polls
+  // `GET /sessions` only (identical `$effect`/`AbortController`/
+  // `setInterval` shape to `StatusBar.svelte`/`SessionMonitor.svelte`) to
+  // distinguish `connecting`/`daemon-unreachable`/`no-session` from a real
+  // active session — once a session exists the gap notice explains why the
+  // table is empty (no data source) rather than implying zero searches ran.
+  //
+  // Test: `SearchTab.test.ts` covers the four phases and asserts no
+  // `<input>`/`<textarea>` renders (AC-7.1); `App.test.ts` pins that this
+  // component mounts inside `.body`.
+  import { apiBase } from '../lib/api-config';
+  import {
+    pickActiveSession,
+    type SessionListResponse,
+    type SessionSummary,
+  } from '../lib/session-status';
+
+  const POLL_MS = 5000; // matches StatusBar.svelte / SessionMonitor.svelte poll cadence
+
+  /** Tracks the REST-snapshot-route gap this tab cannot fill client-side. */
+  const SEARCH_AUDIT_GAP_ISSUE = 'https://github.com/bobmatnyc/trusty-tools/issues/3072';
+
+  type Phase = 'connecting' | 'daemon-unreachable' | 'no-session' | 'active';
+
+  let phase = $state<Phase>('connecting');
+  let session = $state<SessionSummary | null>(null);
+  let error = $state<string | null>(null);
+
+  async function refresh(signal: AbortSignal) {
+    let base: string;
+    try {
+      base = await apiBase();
+    } catch (e) {
+      if (!signal.aborted) {
+        phase = 'daemon-unreachable';
+        session = null;
+        error = e instanceof Error ? e.message : String(e);
+      }
+      return;
+    }
+    if (signal.aborted) return;
+
+    try {
+      const res = await fetch(`${base}/sessions`, { signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as SessionListResponse;
+      if (signal.aborted) return;
+
+      const active = pickActiveSession(body.sessions);
+      if (!active) {
+        phase = 'no-session';
+        session = null;
+        error = null;
+        return;
+      }
+      session = active;
+      phase = 'active';
+      error = null;
+    } catch (e) {
+      if (!signal.aborted) {
+        phase = 'daemon-unreachable';
+        session = null;
+        error = e instanceof Error ? e.message : String(e);
+      }
+    }
+  }
+
+  $effect(() => {
+    // One controller for the whole mounted lifetime — same shape as
+    // StatusBar.svelte/SessionMonitor.svelte: aborting once on teardown both
+    // cancels any in-flight request and flips every `signal.aborted` guard
+    // inside `refresh()`.
+    const controller = new AbortController();
+    void refresh(controller.signal);
+    const timer = setInterval(() => void refresh(controller.signal), POLL_MS);
+    return () => {
+      controller.abort();
+      clearInterval(timer);
+    };
+  });
+</script>
+
+<section class="mt-4 rounded-lg border border-trusty-border bg-trusty-surface/60 p-4">
+  <h2 class="text-sm font-semibold text-trusty-text">search</h2>
+  <p class="mt-1 text-xs text-trusty-text/50">
+    "Search" here isn't a box you type in — this tab is the audit trail of the searches
+    your agents performed.
+  </p>
+
+  {#if phase === 'connecting'}
+    <p class="mt-2 text-xs text-trusty-text/50">connecting&hellip;</p>
+  {:else if phase === 'daemon-unreachable'}
+    <p class="mt-2 flex items-center gap-1.5 text-xs text-status-error">
+      <span class="h-1.5 w-1.5 rounded-full bg-status-error"></span>
+      daemon unreachable{error ? ` — ${error}` : ''}
+    </p>
+  {:else if phase === 'no-session'}
+    <p class="mt-2 flex items-center gap-1.5 text-xs text-trusty-text/60">
+      <span class="h-1.5 w-1.5 rounded-full bg-status-neutral"></span>
+      no active session — nothing to audit yet
+    </p>
+  {:else if session}
+    <div class="mt-3 overflow-x-auto">
+      <table class="w-full text-left font-mono text-xs">
+        <thead>
+          <tr class="text-trusty-text/40">
+            <th class="pb-1 pr-3 font-normal">lane</th>
+            <th class="pb-1 pr-3 font-normal">query</th>
+            <th class="pb-1 pr-3 font-normal">hits</th>
+            <th class="pb-1 pr-3 font-normal">latency</th>
+            <th class="pb-1 pr-3 font-normal">agent</th>
+            <th class="pb-1 font-normal">age</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td colspan="6" class="pt-2 text-trusty-text/40">
+              no REST snapshot route yet — see the gap notice below
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p
+      class="mt-3 text-[11px] text-trusty-text/30"
+      title={`DOC-39 §4.7 AC-7.2's search/recall audit rows (lane, query, hit count, latency, requesting agent, age) are not renderable here — Event::SearchPerformed/Event::MemoryRecalled are SSE-only with no REST snapshot route and no persisted per-session history. Tracked at ${SEARCH_AUDIT_GAP_ISSUE}`}
+    >
+      search audit trail (AC-7.2): not yet implemented — see issue #3072
+    </p>
+  {/if}
+</section>

--- a/crates/trusty-code-gui/ui/src/components/SearchTab.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/SearchTab.test.ts
@@ -52,6 +52,21 @@ beforeEach(() => {
 });
 
 describe('SearchTab (DOC-39 §4.7, 10d)', () => {
+  it('renders the connecting state before the first poll resolves', async () => {
+    // A `fetch` that never resolves keeps `refresh()` parked on its first
+    // `await` forever, so `phase` never advances past its initial
+    // `'connecting'` value — review follow-up (code-critic on PR #3085): the
+    // doc comment claims all four phases are covered, but `connecting` had
+    // no assertion.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('connecting') ?? false);
+
+    expect(target.textContent).toContain('connecting');
+    expect(noInputRendered()).toBe(true);
+  });
+
   it('AC-7.1: renders no input field while daemon-unreachable', async () => {
     vi.stubGlobal(
       'fetch',

--- a/crates/trusty-code-gui/ui/src/components/SearchTab.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/SearchTab.test.ts
@@ -1,0 +1,132 @@
+// Why: DOC-39 §4.7 AC-7.1 requires the Search tab to have NO input field —
+// it is an audit trail, not a search box. This pins that invariant plus the
+// component's four phases (connecting/daemon-unreachable/no-session/active),
+// mirroring the phase-coverage style already established for
+// `SessionMonitor.test.ts`.
+// What: Mounts the real `SearchTab.svelte` with `fetch` stubbed for each
+// phase and asserts the rendered text/DOM matches, plus that no `<input>` or
+// `<textarea>` ever renders regardless of phase.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+import SearchTab from './SearchTab.svelte';
+
+const SESSION_ID = 'sess-search-tab';
+const CREATED_AT = new Date().toISOString();
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+function noInputRendered(): boolean {
+  return target.querySelector('input') === null && target.querySelector('textarea') === null;
+}
+
+/** jsdom's `textContent` preserves source whitespace/newlines verbatim (no
+ * CSS-driven collapse) — normalize before substring assertions so template
+ * line-wrapping doesn't break a test that only cares about the words. */
+function normalizedText(): string {
+  return (target.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+describe('SearchTab (DOC-39 §4.7, 10d)', () => {
+  it('AC-7.1: renders no input field while daemon-unreachable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }),
+    );
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('daemon unreachable') ?? false);
+
+    expect(target.textContent).toContain('daemon unreachable');
+    expect(noInputRendered()).toBe(true);
+  });
+
+  it('renders no-session state when the daemon has zero sessions', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/sessions')) {
+          return { ok: true, status: 200, json: async () => ({ sessions: [] }) } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('nothing to audit yet') ?? false);
+
+    expect(target.textContent).toContain('no active session');
+    expect(noInputRendered()).toBe(true);
+  });
+
+  it('AC-7.2: renders the column headers and the honest gap notice (issue #3072) for an active session', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/sessions')) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              sessions: [
+                { id: SESSION_ID, status: 'running', created_at: CREATED_AT, project: null },
+              ],
+            }),
+          } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('issue #3072') ?? false);
+
+    for (const column of ['lane', 'query', 'hits', 'latency', 'agent', 'age']) {
+      expect(target.textContent).toContain(column);
+    }
+    expect(target.textContent).toContain('not yet implemented');
+    expect(target.textContent).toContain('issue #3072');
+    // AC-7.1 must hold in every phase, including the active/gap-notice one.
+    expect(noInputRendered()).toBe(true);
+  });
+
+  it("AC-7.1: the explanatory banner is present and no input field ever renders", async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }),
+    );
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => normalizedText().includes("isn't a box you type in"));
+
+    expect(normalizedText()).toContain("isn't a box you type in");
+    expect(normalizedText()).toContain('audit trail of the searches your agents performed');
+    expect(noInputRendered()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Ships the DOC-39 §4.7 (10d) **Search tab**: `SearchTab.svelte`, mounted in `App.svelte` inside `.body` alongside `SessionMonitor`.
- AC-7.1 ("no input field") holds by construction — no `<input>`/`<textarea>` renders in any phase, pinned by `SearchTab.test.ts`.
- AC-7.2's required columns (lane, query, hits, latency, agent, age) render as static table headers; polls `GET /sessions` only (identical `$effect`/`AbortController`/`setInterval` shape to `StatusBar.svelte`/`SessionMonitor.svelte`) to distinguish `connecting`/`daemon-unreachable`/`no-session`/active-with-honest-gap-notice.
- `App.test.ts` gained a third assertion pinning that `SearchTab` mounts inside `.body` (alongside the existing `.statusbar`-is-a-sibling AC-18.1 invariant and the `SessionMonitor` placement check).
- CHANGELOG entry added under `[Unreleased] / Added`.

## Spec vs. shipped

| DOC-39 requirement | Status | Note |
|---|---|---|
| AC-7.1: no input field | ✅ Shipped | No `<input>`/`<textarea>` in any phase; DOM-asserted in `SearchTab.test.ts`. |
| AC-7.2: lane/query/hits/latency/agent/age columns | ⚠️ **Shell only** | Column headers render; **no rows** — see gap below. |
| AC-7.3: ⌘K find scoped to bound project | ❌ Not in scope | Literal find (⌘K) is a *different* surface (Project page, §4.7), not built here or anywhere yet. |
| AC-7.4: ⌘K find is a daemon query | ❌ Not in scope | Same as above — no ⌘K surface exists yet in this GUI. |
| DOC-39 §8.1 / AC-18.1 chrome nesting | ✅ Preserved | `SearchTab` is a `.body` child; `.statusbar` sibling invariant untouched. |

### The REST gap (the main finding)

`Event::SearchPerformed`/`Event::MemoryRecalled` (`crates/trusty-code/src/events.rs`) already carry every field AC-7.2 needs — `lane`/`query`/`hit_count`/`hits`/`latency_ms`/`agent`/`agent_id` — but **both are emitted only on the SSE stream** (`GET /sessions/{id}/events`), with **no REST snapshot/list route** and **no persisted per-session accumulation** anywhere in the registry. This is the exact same underlying gap `SessionMonitor.svelte` already called out for the 8b inline card's AC-6.3 (issue #3027).

Per this repo's architecture rule (thin REST client only — no SSE-consumer buffering an unbounded per-session event log client-side, and no direct `POST /rpc` calls bypassing the `serve/rest/mod.rs` gateway pattern), this PR does **not** invent a daemon endpoint. Instead it ships the honest shell above and files **issue #3072**, proposing:

- **New route:** `GET /sessions/{id}/search-audit` — a REST snapshot of every `SearchPerformed` (and optionally `MemoryRecalled`) event recorded for the session, each carrying `lane`/`query`/`hit_count`/`hits`/`latency_ms`/`agent`/`agent_id` plus a timestamp (needed for AC-7.2's "age" column — neither event variant carries one today; adding it is part of that ticket).
- **Backing storage:** extend `SessionEntry` (`crates/trusty-code/src/session/registry.rs`) with an always-retained `search_audit: Vec<SearchAuditEntry>` (mirroring the #2962 agents-map precedent — not a ring-buffer fold), appended from the same `SessionRegistry::record_search_performed`/`record_memory_recalled` path that already emits the SSE event, so the REST snapshot and the live stream stay in sync by construction.
- **New REST module:** `crates/trusty-code/src/serve/rest/search_audit.rs`, merged into `build_axum_router` the same way `rest::agents`/`rest::sessions` are today.

A single fix along these lines would close both #3027 (the 8b card) and #3072 (this tab).

## Files

- `crates/trusty-code-gui/ui/src/components/SearchTab.svelte` (new)
- `crates/trusty-code-gui/ui/src/components/SearchTab.test.ts` (new)
- `crates/trusty-code-gui/ui/src/App.svelte` (mount + doc comments)
- `crates/trusty-code-gui/ui/src/App.test.ts` (new placement assertion)
- `crates/trusty-code-gui/CHANGELOG.md` (Unreleased entry)

## Quality gate (raw tails)

`pnpm test` (vitest, jsdom):
```
 Test Files  6 passed (6)
      Tests  38 passed (38)
```

`pnpm build`: `✓ built in 2.54s`

`SKIP_UI_BUILD=1 cargo check -p trusty-code-gui`: `Finished `dev` profile [unoptimized + debuginfo] target(s) in 54.99s`

`SKIP_UI_BUILD=1 cargo test -p trusty-code-gui`: `test result: ok. 3 passed; 0 failed`

`cargo fmt --check`: clean (no diff)

`SKIP_UI_BUILD=1 cargo clippy -p trusty-code-gui --all-targets -- -D warnings`: `Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.52s` (zero warnings)

`bash scripts/check_line_cap.sh`: `line-cap: 10 allowlisted, 0 violations — OK.`

## Test plan

- [x] `pnpm test` — 38/38 passing including new `SearchTab.test.ts` (4 tests) and updated `App.test.ts` (3 tests)
- [x] `pnpm build` — production build succeeds
- [x] `cargo check -p trusty-code-gui` / `cargo test -p trusty-code-gui` / `cargo fmt --check` / `cargo clippy -p trusty-code-gui --all-targets -- -D warnings` — all clean
- [x] `bash scripts/check_line_cap.sh` — no new/grown oversized files

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools