### PR TITLE
feat(trusty-agents): enable gworkspace tool_registry endpoint by default

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- `gworkspace` `[[tool_registry.endpoints]]` in the bundled default config now
+  ships `enabled = true` (was `false`, "pending auth"). `rpc.discover` on the
+  `trusty-gworkspace-mcp` server is a pure static function that never touches
+  the token store, so eager discovery at harness startup always succeeds
+  regardless of auth state; unauthenticated tool calls fail with a clear
+  "run setup" operational error instead of a startup crash. Authenticate with
+  `trusty-gworkspace-mcp setup` to actually light up Gmail/Calendar/Drive
+  access for the Assistant (Phase 1 of the Assistant epic #3052, part of
+  [#3056](https://github.com/bobmatnyc/trusty-tools/issues/3056))
+
 ### Fixed
 
 - `tmux::orchestrator::TmuxOrchestrator::create_session` and `debugger::tmux::TmuxAdapter::create_session` now apply generous tmux scrollback (`history-limit=100000`) and mouse-wheel scrolling BEFORE `new-session`, via the new shared `trusty_common::tmux` layer — this crate previously ran its own independent tmux implementation with no scrollback handling at all, so every trusty-agents-hosted tmux session (including the debug REPL) was stuck at tmux's tiny 2000-line default even after trusty-mpm's #2398/#2399 fix landed (closes [#3004](https://github.com/bobmatnyc/trusty-tools/issues/3004), refs #2398, #2399)

--- a/crates/trusty-agents/assets/config/default-config.toml
+++ b/crates/trusty-agents/assets/config/default-config.toml
@@ -228,9 +228,22 @@ timeout_ms = 5000
 # `gworkspace-mcp` in #2644 to resolve a $PATH collision with the legacy pipx
 # Python package; from the trusty-common workspace, crate `trusty-gworkspace`)
 # exposes an OpenRPC 1.3.2 manifest via `rpc.discover` and advertises Google
-# OAuth scopes per tool through the `x-google-scopes` extension. Disabled by
-# default — flip `enabled = true` after authenticating
-# (`trusty-gworkspace-mcp setup`) on a machine with the binary on $PATH. See
+# OAuth scopes per tool through the `x-google-scopes` extension.
+#
+# Issue #3056: enabled by default (was `enabled = false`, "pending auth").
+# `rpc.discover`/`tools/list` on the gworkspace server are pure static
+# functions (crates/trusty-gworkspace/src/{openrpc,tools}.rs) that never
+# touch the token store, and `BaseClient::new()` succeeds with zero stored
+# credentials (`oauth: Option<OAuthManager>` is simply `None`/refresh-disabled
+# in that case) — so `ToolRegistryBuilder::build()`'s eager `discover()` at
+# harness startup always succeeds regardless of auth state, and per
+# `tool_registry/mod.rs::build()` a per-endpoint discovery failure only logs
+# a warning and skips that endpoint, never aborts startup. Individual tool
+# calls made before authenticating fail with a clear
+# "no default Google Workspace profile found — run setup" operational error
+# (crates/trusty-gworkspace/src/api/client.rs) rather than a crash. Run
+# `trusty-gworkspace-mcp setup` on a machine with the (renamed) binary on
+# $PATH to authorize a Google account — see
 # docs/trusty-agents/research/openrpc-trusty-contract.md.
 [[tool_registry.endpoints]]
 name = "gworkspace"
@@ -238,7 +251,7 @@ driver = "direct"
 description = "Google Workspace — Gmail, Calendar, Drive, Docs, Sheets, Tasks"
 command = "trusty-gworkspace-mcp"
 args = []
-enabled = false
+enabled = true
 scopes = [
     "google.gmail.*",
     "google.calendar.*",


### PR DESCRIPTION
## Summary

Part of #3056 (Phase 1 of the Assistant epic #3052) — make the Google
Workspace connector reachable for the Assistant.

- Flips `[[tool_registry.endpoints]]` `name = "gworkspace"` from
  `enabled = false` to `enabled = true` in
  `crates/trusty-agents/assets/config/default-config.toml` (the bundled
  default that `GlobalConfig::load_or_create` writes to
  `~/.trusty-agents/config.toml` on first run).
- Adds a `CHANGELOG.md` entry under `[Unreleased]` explaining the change
  and why it's safe.

## Why this is safe pre-auth

Investigated `crates/trusty-gworkspace` and the `tool_registry` harness code
before flipping the flag:

- `rpc.discover` / `tools/list` on the `trusty-gworkspace-mcp` server
  (`crates/trusty-gworkspace/src/openrpc.rs::discover_response`,
  `src/tools.rs::tool_list_response`) are pure static functions — they never
  touch the token store.
- `BaseClient::new()` (`crates/trusty-gworkspace/src/api/client.rs`)
  succeeds with zero stored credentials; `OAuthManager` is simply `None`
  (refresh disabled) in that case — construction never fails on missing auth.
- `ToolRegistryBuilder::build()` (`crates/trusty-agents/src/tools/registry/mod.rs`)
  runs eager `discover()` per endpoint at startup and, on a per-endpoint
  failure, only logs a warning and skips that endpoint — it never aborts
  harness startup (`Err(e) => tracing::warn!(...); continue` in `build()`).
- Individual tool calls made before authenticating fail with a clear
  operational error ("no default Google Workspace profile found — run
  setup") rather than a crash.

So enabling the endpoint pre-auth just means it contributes 0 working tool
*calls* until Bob authenticates — discovery still succeeds and the tools
register, matching how `izzie.toml` already gates its own prompt guidance on
`enabled = true`.

## What's still required (human action — cannot be automated)

This PR does **not** complete #3056 — the interactive Google OAuth `setup`
step must be run by Bob in a browser. See the PR discussion / issue for the
exact commands. Leaving #3056 open until that's done.

## Test plan

- [x] `cargo check -p trusty-agents` — clean build
- [x] `cargo test -p trusty-agents --lib mcp::config` — 17 passed
- [x] `cargo test -p trusty-agents --lib tools::registry` — 31 passed
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 10 allowlisted, 0 violations — OK.`

Part of #3056

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools