### PR TITLE
feat(trusty-code-gui): create-session flow — folder picker + task form (refs DOC-39 7a)

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -10,6 +10,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Create-session flow: the 7a folder picker plus the minimal task-input form
+  needed to start a session from the desktop shell (refs DOC-39 §4.2.1,
+  §6.2 item 6). Previously the GUI was observe-and-cancel only — there was no
+  way to mint a session from the UI at all. `CreateSessionForm.svelte` is a
+  pure `fetch()` client over two already-shipped daemon routes: `GET /fs`
+  (`fs.list_dir`) for the picker and `POST /sessions` (`session.create`) to
+  submit. **No Tauri command and no native dialog plugin were added** — DOC-39
+  §2.1 C-4 explicitly bars a Tauri-native fs/dialog as a functional path (it
+  would give the Tauri build a capability the web build lacks, which C-3
+  forbids), and the daemon-served `GET /fs` route already covers the picker
+  identically in both shells. Picker interaction mirrors 7a's own shape:
+  browsing a directory lists its children as the selectable candidates (a
+  `▸`-style `open` button descends, a `use` button binds without navigating);
+  every selectable entry was already confirmed to exist and be a directory by
+  the listing call itself, so no separate path-validation round-trip is
+  needed before enabling submit. Leaving the selection cleared submits
+  projectless (`project` omitted from the body), per AC-2.1's "workstream
+  creatable with no project bound" requirement. New `lib/create-session.ts`
+  holds the pure logic (`buildCreateBody`, `canSubmitCreate`, `bindingLabel`,
+  `describeFsError`), covered by `create-session.test.ts`; the component's
+  disabled/enabled submit states, the no-double-submit guard, and picker
+  navigation are covered by `CreateSessionForm.test.ts`. Mounted in
+  `App.svelte` inside `.body`, between `HealthPanel` and `SessionMonitor`;
+  `App.test.ts` gained a new assertion pinning that it renders inside
+  `.body`. **Scope gap (documented, not worked around):**
+  `GET /sessions/{id}/agents` (`session.get_agents`) requires an existing
+  session — there is no pre-session agent-roster route — so this form omits
+  `agent` from the `POST /sessions` body entirely and lets the daemon apply
+  its own default, rather than inventing a roster endpoint DOC-39 §2.1 C-2
+  would call a UI-side workaround.
 - Phase-1 session monitor card: an active-session summary — status, task,
   elapsed time, a recent transcript tail, and a cancel action — per DOC-39
   §4.6 (the 8b UI surface, refs #2983). `SessionMonitor.svelte` polls

--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -8,6 +8,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Create-session flow response-shape hardening (PR #3103 review findings):
+  `GET /fs` 200 bodies and `POST /sessions` 201 bodies are now validated at
+  runtime (`lib/create-session.ts::isDirListing` / `extractSessionId`)
+  instead of bare `as` type assertions. Previously a 200 listing missing
+  `entries` threw a `TypeError` out of the `listing.entries.filter(...)`
+  derived — and since `CreateSessionForm` is mounted unconditionally, that
+  crashed the entire shell; a 201 missing `id` threw the same way from the
+  template's `.slice(0, 8)`. Now a shape-invalid listing degrades to the
+  existing picker error line ("malformed response from daemon") and a 201
+  without a usable id shows a generic "session created" message (the status
+  code, not the body, is authoritative that the session exists). Regression
+  tests for both live in `CreateSessionForm.test.ts`; guard unit tests in
+  `create-session.test.ts`.
+
 ### Added
 
 - Create-session flow: the 7a folder picker plus the minimal task-input form

--- a/crates/trusty-code-gui/ui/src/App.svelte
+++ b/crates/trusty-code-gui/ui/src/App.svelte
@@ -2,8 +2,11 @@
   // Why: Minimal scaffold shell (issue #2983, DOC-39) — proves the desktop
   // app connects to the tcode daemon and gives the next UI slice a layout to
   // extend. Phase 1 adds the status bar (DOC-39 §6.2), the 8b session
-  // monitor card (DOC-39 §4.6, refs #2983), and, in this slice, the 10d
-  // Search tab (DOC-39 §4.7, refs #3072). `body`'s prior
+  // monitor card (DOC-39 §4.6, refs #2983), the 10d Search tab (DOC-39
+  // §4.7, refs #3072), and `CreateSessionForm` — the 7a folder picker +
+  // task-input flow (DOC-39 §4.2.1, §6.2 item 6) — closing the gap that
+  // made the GUI observe-and-cancel only: there was previously no way to
+  // start a session from the desktop shell at all. `body`'s prior
   // `ActivityPlaceholder` explicitly said its purpose was "session list /
   // activity view... coming once GET /sessions lands" — that has now
   // landed and `SessionMonitor` covers "what's happening in the active
@@ -14,20 +17,22 @@
   // this placeholder was actually standing in for once GET /sessions is
   // live).
   // What: Renders a header, a `.body` region (the daemon HealthPanel smoke
-  // connection + the session monitor card + the search audit tab), and
-  // `StatusBar` — the readiness+budget chrome — as a DIRECT SIBLING of
-  // `.body`, never nested inside it. DOC-39 §8.1 / AC-18.1 calls this out
-  // explicitly: nesting `.statusbar` inside `.body` has regressed the
-  // wireframe twice ("This bit us twice… assert it in a test") because it
-  // steals the body's row width. `App.test.ts` asserts the DOM invariant
-  // this markup encodes.
+  // connection, the create-session form, the session monitor card — new
+  // session before monitor since it's the entry action and the monitor
+  // reflects the result — then the search audit tab), and `StatusBar` — the
+  // readiness+budget chrome — as a DIRECT SIBLING of `.body`, never nested
+  // inside it. DOC-39 §8.1 / AC-18.1 calls this out explicitly: nesting
+  // `.statusbar` inside `.body` has regressed the wireframe twice ("This bit
+  // us twice… assert it in a test") because it steals the body's row width.
+  // `App.test.ts` asserts the DOM invariant this markup encodes.
   // Test: Launch under Tauri or `pnpm dev` in a browser — both show the same
   // connected/disconnected state (DOC-39 §2.1 web/Tauri parity) plus the
-  // status bar's readiness indicator, the session monitor card, and the
-  // search tab. `App.test.ts::statusbar-is-sibling-of-body` pins the
-  // structural invariant; `App.test.ts::session-monitor-renders-inside-body`
-  // and `App.test.ts::search-tab-renders-inside-body` pin the two cards'
-  // placement.
+  // status bar's readiness indicator, the create-session form, the session
+  // monitor card, and the search tab. `App.test.ts::statusbar-is-sibling-of-body`
+  // pins the structural invariant; `App.test.ts` also pins each card's
+  // inside-`.body` placement (create-session form, session monitor, search
+  // tab).
+  import CreateSessionForm from './components/CreateSessionForm.svelte';
   import HealthPanel from './components/HealthPanel.svelte';
   import SearchTab from './components/SearchTab.svelte';
   import SessionMonitor from './components/SessionMonitor.svelte';
@@ -42,6 +47,7 @@
 
   <div class="body flex flex-1 flex-col gap-4 p-6">
     <HealthPanel />
+    <CreateSessionForm />
     <SessionMonitor />
     <SearchTab />
   </div>

--- a/crates/trusty-code-gui/ui/src/App.test.ts
+++ b/crates/trusty-code-gui/ui/src/App.test.ts
@@ -3,14 +3,16 @@
 // DOM/structural test (AC-18.1) — this is that test, pinned at the shell
 // level so a future refactor of `App.svelte` cannot silently reintroduce
 // the nesting. Two further, lower-stakes assertions pin that `SessionMonitor`
-// (the 8b card, DOC-39 §4.6, refs #2983) and `SearchTab` (the 10d Search
-// tab, DOC-39 §4.7, refs #3072) both mount inside `.body` — cheap
+// (the 8b card, DOC-39 §4.6, refs #2983), `SearchTab` (the 10d Search tab,
+// DOC-39 §4.7, refs #3072), and `CreateSessionForm` (the 7a picker + task
+// form, refs DOC-39 §4.2.1/§6.2 item 6) all mount inside `.body` — cheap
 // regression guards, not new normative rules beyond what the spec already
 // requires of `.statusbar`.
 // What: Mounts the real `App.svelte` (with `fetch` stubbed so the mount
 // doesn't make a real network call) and asserts `.statusbar` is a direct
 // child of `.app` and NOT a descendant of `.body`, and that the session
-// monitor card and the search tab both render inside `.body`.
+// monitor card, the search tab, and the create-session form all render
+// inside `.body`.
 // Test: this file.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, unmount } from 'svelte';
@@ -70,5 +72,15 @@ describe('App shell structure (DOC-39 §8.1, AC-18.1)', () => {
 
     expect(body).not.toBeNull();
     expect(headings.some((h) => h.textContent === 'search')).toBe(true);
+  });
+
+  it('CreateSessionForm (7a picker + task form, DOC-39 §4.2.1) renders inside .body', () => {
+    instance = mount(App, { target }) as unknown as Record<string, unknown>;
+
+    const body = target.querySelector('.body');
+    const headings = Array.from(body?.querySelectorAll('h2') ?? []);
+
+    expect(body).not.toBeNull();
+    expect(headings.some((h) => h.textContent === 'new session')).toBe(true);
   });
 });

--- a/crates/trusty-code-gui/ui/src/components/CreateSessionForm.svelte
+++ b/crates/trusty-code-gui/ui/src/components/CreateSessionForm.svelte
@@ -1,0 +1,294 @@
+<script lang="ts">
+  // Why: DOC-39's biggest gap called out for this slice — the GUI could only
+  // observe and cancel a session, never create one. This is the create-
+  // session flow: the 7a folder picker (§4.2.1) plus the minimal task-input
+  // form needed to call `POST /sessions` (`session.create`, REST Slice 3,
+  // `crate::serve::rest::sessions_write`). Two daemon routes cover the whole
+  // slice — no Tauri command, no native dialog (barred by §2.1 C-4, see
+  // `lib/create-session.ts`'s module doc), identical behavior in web and
+  // Tauri per C-3.
+  //
+  // **Picker interaction model.** Mirrors 7a's own shape: browsing a
+  // directory lists its CHILDREN as the selectable candidates (each row a
+  // future project root), not the directory itself — the breadcrumb is where
+  // you are, the rows are what you can bind. A row's directory arrow
+  // (`▸ open`) descends into it to browse further; its `use` button binds it
+  // as `selectedProject` without navigating. Only entries `GET /fs` already
+  // returned are selectable, so by construction every `selectedProject` has
+  // already passed the exists+is-dir check this task's brief asks for — no
+  // second validation round-trip is needed at submit time (`is_git_repo`
+  // comes along for free, feeding DOC-39 §4.2's binding-state label).
+  // Leaving the selection cleared (or clicking `clear`) submits projectless
+  // (`project` omitted from the body) — AC-2.1 mandates this MUST be
+  // supported, not treated as an error state.
+  //
+  // What: Two independent `$effect`s, same `AbortController`-per-lifetime
+  // shape `SessionMonitor.svelte`/`StatusBar.svelte` already establish: one
+  // re-fetches `GET /fs?path=..` whenever `browsePath` changes (aborting the
+  // previous in-flight listing fetch — a fast double-click through several
+  // directories must not let a stale response win the race), the other only
+  // aborts `submitController` on unmount (`POST /sessions` is user-triggered,
+  // not polled, so it needs no interval). The prior listing stays on screen
+  // while a new one loads (`listingPhase === 'loading'` renders a small
+  // inline cue rather than blanking the rows) to avoid picker flicker while
+  // navigating. Submit is gated by `canSubmitCreate` (non-empty task, not
+  // already in flight — `lib/create-session.ts`), and the button's `disabled`
+  // binding is the only double-submit guard needed since there is no
+  // separate confirm step for creation (unlike `SessionMonitor`'s cancel).
+  // A successful `201` clears `task`/`selectedProject` and shows the new
+  // session's id; the session itself becomes visible through the existing
+  // `GET /sessions` pollers (`StatusBar`/`SessionMonitor`'s `pickActiveSession`)
+  // on their next tick — this component does not need its own poll.
+  // Test: `create-session.test.ts` covers the pure gating/body-construction
+  // logic; `CreateSessionForm.test.ts` covers the form's disabled/enabled
+  // submit states, the no-double-submit guard, and picker navigation.
+  import { apiBase } from '../lib/api-config';
+  import {
+    bindingLabel,
+    buildCreateBody,
+    canSubmitCreate,
+    describeFsError,
+    type DirEntryInfo,
+    type DirListing,
+    type ProjectSelection,
+    type SubmitPhase,
+  } from '../lib/create-session';
+
+  type ListingPhase = 'loading' | 'error' | 'ready';
+
+  let browsePath = $state<string | null>(null);
+  let listing = $state<DirListing | null>(null);
+  let listingPhase = $state<ListingPhase>('loading');
+  let listingError = $state<string | null>(null);
+
+  let selectedProject = $state<ProjectSelection | null>(null);
+  let task = $state('');
+
+  let submitPhase = $state<SubmitPhase>('idle');
+  let submitError = $state<string | null>(null);
+  let createdSessionId = $state<string | null>(null);
+
+  let submitController: AbortController | null = null;
+
+  async function loadListing(path: string | null, signal: AbortSignal) {
+    listingPhase = 'loading';
+    let base: string;
+    try {
+      base = await apiBase();
+    } catch (e) {
+      if (!signal.aborted) {
+        listingPhase = 'error';
+        listingError = e instanceof Error ? e.message : String(e);
+      }
+      return;
+    }
+    if (signal.aborted) return;
+
+    const qs = path ? `?path=${encodeURIComponent(path)}` : '';
+    try {
+      const res = await fetch(`${base}/fs${qs}`, { signal });
+      if (!res.ok) {
+        if (!signal.aborted) {
+          listingPhase = 'error';
+          listingError = describeFsError(res.status);
+        }
+        return;
+      }
+      const body = (await res.json()) as DirListing;
+      if (signal.aborted) return;
+      listing = body;
+      listingPhase = 'ready';
+      listingError = null;
+    } catch (e) {
+      if (!signal.aborted) {
+        listingPhase = 'error';
+        listingError = e instanceof Error ? e.message : String(e);
+      }
+    }
+  }
+
+  function openEntry(entry: DirEntryInfo) {
+    if (!entry.is_dir) return;
+    browsePath = entry.path;
+  }
+
+  function goUp() {
+    if (listing?.parent) browsePath = listing.parent;
+  }
+
+  function selectEntry(entry: DirEntryInfo) {
+    selectedProject = { path: entry.path, displayPath: entry.name, isGitRepo: entry.is_git_repo };
+  }
+
+  function clearSelection() {
+    selectedProject = null;
+  }
+
+  async function submit() {
+    if (!canSubmitCreate(task, submitPhase)) return;
+    submitPhase = 'submitting';
+    submitError = null;
+    createdSessionId = null;
+
+    const controller = new AbortController();
+    submitController = controller;
+    try {
+      const base = await apiBase();
+      if (controller.signal.aborted) return;
+
+      const body = buildCreateBody(task, selectedProject);
+      const res = await fetch(`${base}/sessions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
+
+      if (res.status !== 201) {
+        const errBody = (await res.json().catch(() => null)) as {
+          error?: { message?: string };
+        } | null;
+        submitError = errBody?.error?.message ?? `HTTP ${res.status}`;
+        return;
+      }
+
+      const created = (await res.json()) as { id: string };
+      if (controller.signal.aborted) return;
+      createdSessionId = created.id;
+      task = '';
+      selectedProject = null;
+    } catch (e) {
+      if (!controller.signal.aborted) {
+        submitError = e instanceof Error ? e.message : String(e);
+      }
+    } finally {
+      if (!controller.signal.aborted) submitPhase = 'idle';
+      if (submitController === controller) submitController = null;
+    }
+  }
+
+  $effect(() => {
+    const path = browsePath;
+    const controller = new AbortController();
+    void loadListing(path, controller.signal);
+    return () => controller.abort();
+  });
+
+  $effect(() => {
+    // Unmount-only teardown for the submit request — creation is
+    // user-triggered, not polled, so this effect has no reactive deps.
+    return () => {
+      submitController?.abort();
+    };
+  });
+
+  let dirEntries = $derived(listing?.entries.filter((e) => e.is_dir) ?? []);
+</script>
+
+<section class="mt-4 rounded-lg border border-trusty-border bg-trusty-surface/60 p-4">
+  <h2 class="text-sm font-semibold text-trusty-text">new session</h2>
+
+  <div class="mt-3">
+    <p class="text-xs text-trusty-text/60">project folder</p>
+
+    {#if listingPhase === 'error' && !listing}
+      <p class="mt-1 text-xs text-status-error">
+        daemon unreachable{listingError ? ` — ${listingError}` : ''}
+      </p>
+    {:else if listing}
+      <div class="mt-1 flex items-center gap-2 text-xs text-trusty-text/70">
+        <button
+          type="button"
+          disabled={!listing.parent}
+          onclick={goUp}
+          class="rounded border border-trusty-border px-1.5 py-0.5 disabled:cursor-not-allowed disabled:opacity-30"
+        >
+          ↑ up
+        </button>
+        <span class="truncate font-mono" title={listing.path}>{listing.display_path}</span>
+        {#if listingPhase === 'loading'}
+          <span class="text-trusty-text/30">loading…</span>
+        {/if}
+      </div>
+
+      <ul class="mt-2 max-h-40 space-y-1 overflow-y-auto text-xs">
+        {#each dirEntries as entry (entry.path)}
+          <li class="flex items-center justify-between gap-2 rounded px-1.5 py-1 hover:bg-trusty-border/10">
+            <button
+              type="button"
+              class="flex flex-1 items-center gap-1.5 truncate text-left"
+              onclick={() => openEntry(entry)}
+            >
+              <span class="truncate">{entry.name}</span>
+              <span
+                class={`rounded px-1 text-[10px] ${
+                  entry.is_git_repo ? 'bg-status-ok/15 text-status-ok' : 'text-trusty-text/30'
+                }`}
+              >
+                {entry.is_git_repo ? 'git' : '—'}
+              </span>
+            </button>
+            <button
+              type="button"
+              class="shrink-0 rounded border border-trusty-border px-1.5 py-0.5 text-trusty-text/70 hover:bg-trusty-border/20"
+              onclick={() => selectEntry(entry)}
+            >
+              use
+            </button>
+          </li>
+        {/each}
+        {#if dirEntries.length === 0}
+          <li class="text-trusty-text/40">no subdirectories</li>
+        {/if}
+      </ul>
+    {:else}
+      <p class="mt-1 text-xs text-trusty-text/50">loading…</p>
+    {/if}
+
+    <p class="mt-2 text-xs text-trusty-text/70">
+      selected: <span class="font-mono">{bindingLabel(selectedProject)}</span>
+      {#if selectedProject}
+        <button type="button" class="ml-2 text-trusty-text/40 underline" onclick={clearSelection}>
+          clear
+        </button>
+      {/if}
+    </p>
+  </div>
+
+  <div class="mt-3">
+    <label class="text-xs text-trusty-text/60" for="new-session-task">task</label>
+    <textarea
+      id="new-session-task"
+      bind:value={task}
+      rows="3"
+      placeholder="Describe what this session should do…"
+      class="mt-1 w-full rounded border border-trusty-border bg-trusty-surface/40 p-2 text-xs text-trusty-text"
+    ></textarea>
+  </div>
+
+  <p
+    class="mt-2 text-[11px] text-trusty-text/30"
+    title="session.get_agents (GET /sessions/{'{'}id{'}'}/agents) requires an existing session — there is no pre-session roster route, so this form omits `agent` and the daemon applies its own default (DOC-39 §5.4)."
+  >
+    agent: daemon default — no pre-session roster endpoint exists yet
+  </p>
+
+  {#if submitError}
+    <p class="mt-2 text-xs text-status-error">{submitError}</p>
+  {/if}
+  {#if createdSessionId}
+    <p class="mt-2 text-xs text-status-ok">session created — {createdSessionId.slice(0, 8)}</p>
+  {/if}
+
+  <div class="mt-3">
+    <button
+      type="button"
+      disabled={!canSubmitCreate(task, submitPhase)}
+      onclick={submit}
+      class="rounded border border-trusty-border px-3 py-1.5 text-xs font-medium text-trusty-text hover:bg-trusty-border/20 disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      {submitPhase === 'submitting' ? 'creating…' : 'create session'}
+    </button>
+  </div>
+</section>

--- a/crates/trusty-code-gui/ui/src/components/CreateSessionForm.svelte
+++ b/crates/trusty-code-gui/ui/src/components/CreateSessionForm.svelte
@@ -36,7 +36,13 @@
   // binding is the only double-submit guard needed since there is no
   // separate confirm step for creation (unlike `SessionMonitor`'s cancel).
   // A successful `201` clears `task`/`selectedProject` and shows the new
-  // session's id; the session itself becomes visible through the existing
+  // session's id when the body carries one (a generic "session created"
+  // otherwise — the 201 status, not the body, is authoritative). Both
+  // response bodies pass runtime shape guards (`isDirListing` /
+  // `extractSessionId`) before touching reactive state, so a shape-invalid
+  // 200/201 degrades to an inline message instead of throwing out of this
+  // unconditionally-mounted component and crashing the shell.
+  // The session itself becomes visible through the existing
   // `GET /sessions` pollers (`StatusBar`/`SessionMonitor`'s `pickActiveSession`)
   // on their next tick — this component does not need its own poll.
   // Test: `create-session.test.ts` covers the pure gating/body-construction
@@ -48,6 +54,8 @@
     buildCreateBody,
     canSubmitCreate,
     describeFsError,
+    extractSessionId,
+    isDirListing,
     type DirEntryInfo,
     type DirListing,
     type ProjectSelection,
@@ -66,7 +74,7 @@
 
   let submitPhase = $state<SubmitPhase>('idle');
   let submitError = $state<string | null>(null);
-  let createdSessionId = $state<string | null>(null);
+  let successMessage = $state<string | null>(null);
 
   let submitController: AbortController | null = null;
 
@@ -94,8 +102,17 @@
         }
         return;
       }
-      const body = (await res.json()) as DirListing;
+      const body: unknown = await res.json();
       if (signal.aborted) return;
+      if (!isDirListing(body)) {
+        // A 200 with a shape-invalid body (schema drift, proxy, future
+        // daemon) must degrade to the error line, not reach the
+        // `listing.entries` $derived and throw — this component is mounted
+        // unconditionally, so an uncaught throw here takes down the shell.
+        listingPhase = 'error';
+        listingError = 'malformed response from daemon';
+        return;
+      }
       listing = body;
       listingPhase = 'ready';
       listingError = null;
@@ -128,7 +145,7 @@
     if (!canSubmitCreate(task, submitPhase)) return;
     submitPhase = 'submitting';
     submitError = null;
-    createdSessionId = null;
+    successMessage = null;
 
     const controller = new AbortController();
     submitController = controller;
@@ -153,9 +170,13 @@
         return;
       }
 
-      const created = (await res.json()) as { id: string };
+      // The 201 status is authoritative — the session exists even if the
+      // body is missing/malformed (same guard rationale as `isDirListing`),
+      // so a bad body degrades the message to a generic one, never an error.
+      const created: unknown = await res.json().catch(() => null);
       if (controller.signal.aborted) return;
-      createdSessionId = created.id;
+      const id = extractSessionId(created);
+      successMessage = id ? `session created — ${id.slice(0, 8)}` : 'session created';
       task = '';
       selectedProject = null;
     } catch (e) {
@@ -277,8 +298,8 @@
   {#if submitError}
     <p class="mt-2 text-xs text-status-error">{submitError}</p>
   {/if}
-  {#if createdSessionId}
-    <p class="mt-2 text-xs text-status-ok">session created — {createdSessionId.slice(0, 8)}</p>
+  {#if successMessage}
+    <p class="mt-2 text-xs text-status-ok">{successMessage}</p>
   {/if}
 
   <div class="mt-3">

--- a/crates/trusty-code-gui/ui/src/components/CreateSessionForm.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/CreateSessionForm.test.ts
@@ -193,6 +193,59 @@ describe('CreateSessionForm submit gating', () => {
     expect(submitButton().disabled).toBe(false); // re-enabled after failure
   });
 
+  it('degrades to the error UI when GET /fs returns 200 with a shape-invalid body (PR #3103 HIGH finding)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          // 200 but no `entries` array — schema drift / interposed proxy.
+          return { ok: true, status: 200, json: async () => ({ ok: true }) } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('malformed response') ?? false);
+
+    // The shell survives: the form renders its own error line instead of the
+    // `listing.entries` $derived throwing out of the component tree.
+    expect(target.textContent).toContain('malformed response');
+    expect(submitButton().disabled).toBe(true); // no task entered yet
+  });
+
+  it('shows a generic success message when a 201 body lacks a valid id (PR #3103 MEDIUM finding)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          return { ok: true, status: 200, json: async () => HOME_LISTING } as Response;
+        }
+        if (url.endsWith('/sessions') && init?.method === 'POST') {
+          // 201 (session WAS created) but the body carries no `id`.
+          return { ok: true, status: 201, json: async () => ({ status: 'running' }) } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    taskField().value = 'ship the feature';
+    taskField().dispatchEvent(new Event('input', { bubbles: true }));
+    await waitFor(() => !submitButton().disabled);
+
+    submitButton().click();
+    await waitFor(() => target.textContent?.includes('session created') ?? false);
+
+    expect(target.textContent).toContain('session created');
+    expect(target.textContent).not.toContain('session created —'); // no id prefix
+    expect(taskField().value).toBe(''); // 201 is authoritative — form still clears
+  });
+
   it('renders daemon-unreachable when the initial GET /fs fails', async () => {
     vi.stubGlobal(
       'fetch',

--- a/crates/trusty-code-gui/ui/src/components/CreateSessionForm.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/CreateSessionForm.test.ts
@@ -1,0 +1,210 @@
+// Why: `CreateSessionForm.svelte` is this slice's main deliverable — the
+// create-session flow that closes the "observe-and-cancel only" gap. Its
+// pure logic is covered by `lib/create-session.test.ts`; this file covers
+// what only mounting the real component can: the submit button's
+// disabled/enabled states, the no-double-submit guard under a real in-flight
+// `fetch`, and that picking a listed folder updates the "selected:" line
+// before submit.
+// What: Mounts the real component with `fetch` stubbed to answer
+// `GET /fs` and `POST /sessions`. Mirrors `SessionMonitor.test.ts`'s
+// stub-fetch-by-URL-suffix mounting pattern.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+import CreateSessionForm from './CreateSessionForm.svelte';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+function submitButton(): HTMLButtonElement {
+  const button = Array.from(target.querySelectorAll('button')).find(
+    (b) => b.textContent === 'create session' || b.textContent === 'creating…',
+  );
+  if (!button) throw new Error('submit button not found');
+  return button as HTMLButtonElement;
+}
+
+function taskField(): HTMLTextAreaElement {
+  return target.querySelector('#new-session-task') as HTMLTextAreaElement;
+}
+
+const HOME_LISTING = {
+  path: '/home/bob',
+  display_path: '~',
+  parent: '/home',
+  entries: [
+    { name: 'acme-api', path: '/home/bob/acme-api', is_dir: true, is_git_repo: true },
+    { name: 'scratch', path: '/home/bob/scratch', is_dir: true, is_git_repo: false },
+  ],
+};
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('CreateSessionForm submit gating', () => {
+  it('disables submit when the task is empty, enables it once text is entered', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          return { ok: true, status: 200, json: async () => HOME_LISTING } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    expect(submitButton().disabled).toBe(true);
+
+    taskField().value = 'fix the login bug';
+    taskField().dispatchEvent(new Event('input', { bubbles: true }));
+    await waitFor(() => !submitButton().disabled);
+
+    expect(submitButton().disabled).toBe(false);
+  });
+
+  it('picking a listed folder updates the selected-project line', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          return { ok: true, status: 200, json: async () => HOME_LISTING } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    expect(target.textContent).toContain('projectless');
+
+    const useButtons = Array.from(target.querySelectorAll('button')).filter(
+      (b) => b.textContent === 'use',
+    );
+    expect(useButtons.length).toBe(2);
+    (useButtons[0] as HTMLButtonElement).click();
+
+    await waitFor(() => target.textContent?.includes('git repo — acme-api') ?? false);
+    expect(target.textContent).toContain('git repo — acme-api');
+  });
+
+  it('disables submit while a create request is in flight (no double submit)', async () => {
+    let resolveCreate: ((value: Response) => void) | null = null;
+    const createPromise = new Promise<Response>((resolve) => {
+      resolveCreate = resolve;
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          return { ok: true, status: 200, json: async () => HOME_LISTING } as Response;
+        }
+        if (url.endsWith('/sessions') && init?.method === 'POST') {
+          return createPromise;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    taskField().value = 'ship the feature';
+    taskField().dispatchEvent(new Event('input', { bubbles: true }));
+    await waitFor(() => !submitButton().disabled);
+
+    submitButton().click();
+    await waitFor(() => submitButton().disabled && submitButton().textContent === 'creating…');
+
+    // A second click while in flight must be a no-op — the button is
+    // disabled, so the component's own `submit()` guard is never reached a
+    // second time.
+    submitButton().click();
+    expect(submitButton().disabled).toBe(true);
+
+    resolveCreate!({
+      ok: true,
+      status: 201,
+      json: async () => ({ id: 'sess-abc12345', status: 'running' }),
+    } as Response);
+
+    await waitFor(() => target.textContent?.includes('session created') ?? false);
+    expect(submitButton().disabled).toBe(true); // task cleared on success
+    expect(taskField().value).toBe('');
+  });
+
+  it('surfaces a 400 validation error from the daemon without clearing the form', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          return { ok: true, status: 200, json: async () => HOME_LISTING } as Response;
+        }
+        if (url.endsWith('/sessions') && init?.method === 'POST') {
+          return {
+            ok: false,
+            status: 400,
+            json: async () => ({ error: { code: -32003, message: 'task must not be empty' } }),
+          } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    taskField().value = 'ship the feature';
+    taskField().dispatchEvent(new Event('input', { bubbles: true }));
+    await waitFor(() => !submitButton().disabled);
+
+    submitButton().click();
+    await waitFor(() => target.textContent?.includes('task must not be empty') ?? false);
+
+    expect(taskField().value).toBe('ship the feature'); // not cleared on error
+    expect(submitButton().disabled).toBe(false); // re-enabled after failure
+  });
+
+  it('renders daemon-unreachable when the initial GET /fs fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('daemon unreachable') ?? false);
+
+    expect(target.textContent).toContain('daemon unreachable');
+    expect(submitButton().disabled).toBe(true); // no task entered yet
+  });
+});

--- a/crates/trusty-code-gui/ui/src/lib/create-session.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/create-session.test.ts
@@ -1,0 +1,91 @@
+// Why: `lib/create-session.ts` carries every piece of pure gating/body-
+// construction logic `CreateSessionForm.svelte` depends on for correctness
+// (what the daemon receives, when the submit button may be clicked) —
+// covering it here means those invariants are checked without mounting
+// Svelte or touching `fetch`, mirroring the split `session-status.test.ts`/
+// `context-budget.test.ts` already establish for their own modules.
+// What: One `describe` block per exported function.
+// Test: this file.
+import { describe, expect, it } from 'vitest';
+import {
+  bindingLabel,
+  buildCreateBody,
+  canSubmitCreate,
+  describeFsError,
+  type ProjectSelection,
+} from './create-session';
+
+const GIT_PROJECT: ProjectSelection = {
+  path: '/Users/bob/code/acme-api',
+  displayPath: 'acme-api',
+  isGitRepo: true,
+};
+
+const NON_GIT_PROJECT: ProjectSelection = {
+  path: '/Users/bob/code/scratch',
+  displayPath: 'scratch',
+  isGitRepo: false,
+};
+
+describe('buildCreateBody', () => {
+  it('trims the task and omits project when projectless (AC-2.1)', () => {
+    expect(buildCreateBody('  fix the bug  ', null)).toEqual({ task: 'fix the bug' });
+  });
+
+  it('includes project.path when a project is selected', () => {
+    expect(buildCreateBody('add a feature', GIT_PROJECT)).toEqual({
+      task: 'add a feature',
+      project: '/Users/bob/code/acme-api',
+    });
+  });
+
+  it('includes a non-git project path identically to a git one (AC-2.6)', () => {
+    expect(buildCreateBody('index this', NON_GIT_PROJECT)).toEqual({
+      task: 'index this',
+      project: '/Users/bob/code/scratch',
+    });
+  });
+
+  it('never sends the agent field (no pre-session roster route, see module doc)', () => {
+    const body = buildCreateBody('t', GIT_PROJECT);
+    expect('agent' in body).toBe(false);
+  });
+});
+
+describe('canSubmitCreate', () => {
+  it('is false for an empty task', () => {
+    expect(canSubmitCreate('', 'idle')).toBe(false);
+  });
+
+  it('is false for a whitespace-only task', () => {
+    expect(canSubmitCreate('   ', 'idle')).toBe(false);
+  });
+
+  it('is true for a non-empty task while idle', () => {
+    expect(canSubmitCreate('do the thing', 'idle')).toBe(true);
+  });
+
+  it('is false while submitting, even with a valid task (no double submit)', () => {
+    expect(canSubmitCreate('do the thing', 'submitting')).toBe(false);
+  });
+});
+
+describe('bindingLabel', () => {
+  it('labels a null selection as projectless', () => {
+    expect(bindingLabel(null)).toBe('projectless — chat/planning only');
+  });
+
+  it('labels a git-repo selection distinctly from a plain directory', () => {
+    expect(bindingLabel(GIT_PROJECT)).toBe('git repo — acme-api');
+    expect(bindingLabel(NON_GIT_PROJECT)).toBe('directory — scratch');
+  });
+});
+
+describe('describeFsError', () => {
+  it('maps the four rpc_error_to_status-mapped GET /fs statuses distinctly', () => {
+    expect(describeFsError(404)).toBe('path not found');
+    expect(describeFsError(400)).toBe('not a directory');
+    expect(describeFsError(403)).toBe('permission denied');
+    expect(describeFsError(500)).toBe('error (HTTP 500)');
+  });
+});

--- a/crates/trusty-code-gui/ui/src/lib/create-session.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/create-session.test.ts
@@ -12,6 +12,8 @@ import {
   buildCreateBody,
   canSubmitCreate,
   describeFsError,
+  extractSessionId,
+  isDirListing,
   type ProjectSelection,
 } from './create-session';
 
@@ -87,5 +89,60 @@ describe('describeFsError', () => {
     expect(describeFsError(400)).toBe('not a directory');
     expect(describeFsError(403)).toBe('permission denied');
     expect(describeFsError(500)).toBe('error (HTTP 500)');
+  });
+});
+
+describe('isDirListing', () => {
+  const VALID = {
+    path: '/home/bob',
+    display_path: '~',
+    parent: '/home',
+    entries: [{ name: 'code', path: '/home/bob/code', is_dir: true, is_git_repo: false }],
+  };
+
+  it('accepts a well-formed listing, including a null parent and empty entries', () => {
+    expect(isDirListing(VALID)).toBe(true);
+    expect(isDirListing({ ...VALID, parent: null, entries: [] })).toBe(true);
+  });
+
+  it('rejects non-object bodies (null, string, array)', () => {
+    expect(isDirListing(null)).toBe(false);
+    expect(isDirListing('ok')).toBe(false);
+    expect(isDirListing([VALID])).toBe(false);
+  });
+
+  it('rejects a 200 body missing entries or with non-array entries (PR #3103 HIGH finding)', () => {
+    const { entries: _entries, ...noEntries } = VALID;
+    expect(isDirListing(noEntries)).toBe(false);
+    expect(isDirListing({ ...VALID, entries: 'oops' })).toBe(false);
+  });
+
+  it('rejects a listing whose entries have drifted shapes', () => {
+    expect(isDirListing({ ...VALID, entries: [{ name: 'x' }] })).toBe(false);
+    expect(
+      isDirListing({
+        ...VALID,
+        entries: [{ name: 'x', path: '/x', is_dir: 'yes', is_git_repo: false }],
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects drifted top-level fields the UI dereferences', () => {
+    expect(isDirListing({ ...VALID, display_path: 7 })).toBe(false);
+    expect(isDirListing({ ...VALID, parent: 42 })).toBe(false);
+  });
+});
+
+describe('extractSessionId', () => {
+  it('returns the id when it is a non-empty string', () => {
+    expect(extractSessionId({ id: 'sess-abc12345', status: 'running' })).toBe('sess-abc12345');
+  });
+
+  it('returns null for missing, empty, or non-string ids and non-object bodies', () => {
+    expect(extractSessionId({})).toBeNull();
+    expect(extractSessionId({ id: '' })).toBeNull();
+    expect(extractSessionId({ id: 42 })).toBeNull();
+    expect(extractSessionId(null)).toBeNull();
+    expect(extractSessionId('sess-abc')).toBeNull();
   });
 });

--- a/crates/trusty-code-gui/ui/src/lib/create-session.ts
+++ b/crates/trusty-code-gui/ui/src/lib/create-session.ts
@@ -1,0 +1,159 @@
+// Why: `CreateSessionForm.svelte` (DOC-39 §4.2.1 the 7a folder picker,
+// §6.2 item 6 `project.list_dir`/`fs.list_dir`, plus the minimal
+// session-creation form this slice adds — the GUI was observe-and-cancel
+// only before this) needs typed wire shapes for `GET /fs` (mirrors
+// `crate::fs_browse::{DirListing, DirEntryInfo}`) and a handful of pure,
+// testable helpers: gating whether the create button may be clicked,
+// building the `POST /sessions` body, and describing an `RpcError`-mapped
+// HTTP status from `GET /fs` in one line. Extracted from the component for
+// the same reason `session-status.ts`/`context-budget.ts` were: pure
+// logic independent of DOM/network concerns is unit-testable without
+// mounting anything.
+//
+// **Picker mechanism note (DOC-39 §2.1 C-4).** The spec is explicit that a
+// Tauri-native `fs`/dialog plugin is barred as a functional path — it would
+// place filesystem capability in the UI layer and make the web build
+// missing a capability the Tauri build has, which C-3 forbids. `GET /fs`
+// (`crate::serve::rest::fs`, backed by `fs.list_dir`) is the daemon-served
+// alternative DOC-39 §5.8/§4.2.1 calls for, already shipped on `origin/main`
+// — this module and its component are a pure `fetch()` client over it, no
+// Tauri command involved, identical in both shells (§2.1 C-3).
+//
+// **Agent-selection gap (task item 2, explicitly noted rather than
+// invented).** `GET /sessions/{id}/agents` (`session.get_agents`) requires
+// an existing `session_id` — there is no pre-session roster route. This
+// form therefore omits `agent` from the `POST /sessions` body entirely,
+// letting the daemon apply its own default (`session::protocol::create`
+// treats an absent `agent` as `None`, matching `CreateBody`'s
+// `#[serde(default)]`). Adding a roster endpoint that does not exist would
+// violate DOC-39 §2.1 C-2 ("a UI need with no API is an unbuilt feature, not
+// a UI problem") — so this is recorded as a gap, not worked around.
+//
+// What: [`DirListing`]/[`DirEntryInfo`] mirror the daemon's wire shape
+// field-for-field. [`ProjectSelection`] is the form's own selected-project
+// state (always built from an already-listed, already-`is_dir`-confirmed
+// entry — see the component's docs on why that makes a separate
+// "validate this path" round-trip unnecessary: the listing call itself IS
+// the exists+is-dir check DOC-39's task brief asks for). [`buildCreateBody`]
+// mirrors `crate::serve::rest::sessions_write::CreateBody` minus `agent`;
+// [`canSubmitCreate`] is the single gate the submit button's `disabled`
+// binds to (non-empty task, not already in flight); [`bindingLabel`] is the
+// small "projectless / directory / git repo" status line DOC-39 §4.2's
+// three-state model implies; [`describeFsError`] turns a `GET /fs` HTTP
+// status into the one-line message `rpc_error_to_status`'s four-way mapping
+// (404/400/403/else) already promises the client.
+// Test: `create-session.test.ts`.
+
+/** Mirrors `crate::fs_browse::DirEntryInfo` field-for-field. */
+export interface DirEntryInfo {
+  name: string;
+  path: string;
+  is_dir: boolean;
+  is_git_repo: boolean;
+}
+
+/** Mirrors `crate::fs_browse::DirListing` field-for-field — the
+ * `GET /fs?path=..` response body. */
+export interface DirListing {
+  path: string;
+  display_path: string;
+  parent: string | null;
+  entries: DirEntryInfo[];
+}
+
+/**
+ * The form's selected-project state: always constructed from one
+ * `DirEntryInfo` the daemon already returned in a successful listing, so
+ * `isGitRepo` is exactly DOC-39 §4.2.1's binding discriminant and `path` is
+ * already known to exist and be a directory — no separate validation call
+ * is needed at submit time.
+ */
+export interface ProjectSelection {
+  path: string;
+  displayPath: string;
+  isGitRepo: boolean;
+}
+
+/** Request body for `POST /sessions`, mirroring
+ * `crate::serve::rest::sessions_write::CreateBody` minus `agent` (see the
+ * module doc's gap note — this form never sends `agent`). */
+export interface CreateSessionBody {
+  task: string;
+  project?: string;
+}
+
+/** Whether the create-session submit control may be enabled. */
+export type SubmitPhase = 'idle' | 'submitting';
+
+/**
+ * Build the `POST /sessions` request body from form state.
+ *
+ * Why: the single place task text is trimmed and an optional project path
+ * is attached — kept out of the component so it's testable without
+ * mounting Svelte.
+ * What: `task` is trimmed (never sent with leading/trailing whitespace);
+ * `project` is included only when `project` is non-null (a `null` selection
+ * means projectless, AC-2.1 — the field is omitted entirely rather than
+ * sent as `null`, matching `CreateBody`'s `#[serde(default)]` Option
+ * handling on the Rust side).
+ * Test: `create-session.test.ts::buildCreateBody`.
+ */
+export function buildCreateBody(task: string, project: ProjectSelection | null): CreateSessionBody {
+  const body: CreateSessionBody = { task: task.trim() };
+  if (project) body.project = project.path;
+  return body;
+}
+
+/**
+ * Whether the create-session button may be clicked right now.
+ *
+ * Why: the one gate `CreateSessionForm.svelte`'s submit button binds
+ * `disabled` to — a non-empty (post-trim) task, and not already mid-flight
+ * (double-submit guard, since `POST /sessions` mints a brand-new resource on
+ * every call).
+ * What: `task.trim().length > 0 && phase === 'idle'`.
+ * Test: `create-session.test.ts::canSubmitCreate`.
+ */
+export function canSubmitCreate(task: string, phase: SubmitPhase): boolean {
+  return task.trim().length > 0 && phase === 'idle';
+}
+
+/**
+ * One-line description of the current project selection, for the form's
+ * "selected: …" status line.
+ *
+ * Why: DOC-39 §4.2's three-state binding model (`Projectless` /
+ * `Bound · non-git` / `Bound · git repo`) is exactly what the operator needs
+ * confirmed before they hit submit.
+ * What: `null` -> `"projectless — chat/planning only"`; otherwise
+ * `"git repo — <displayPath>"` or `"directory — <displayPath>"`.
+ * Test: `create-session.test.ts::bindingLabel`.
+ */
+export function bindingLabel(project: ProjectSelection | null): string {
+  if (!project) return 'projectless — chat/planning only';
+  return project.isGitRepo ? `git repo — ${project.displayPath}` : `directory — ${project.displayPath}`;
+}
+
+/**
+ * One-line description of a `GET /fs` failure, keyed on HTTP status.
+ *
+ * Why: `crate::serve::rest::rpc_error_to_status` maps `fs.list_dir`'s four
+ * caller-actionable causes onto four distinct statuses (404/400/403/else) —
+ * the client should not re-derive that from a raw status code inline in the
+ * component, and should never substring-match a message to tell them apart.
+ * What: `404` -> `"path not found"`; `400` -> `"not a directory"`; `403` ->
+ * `"permission denied"`; anything else -> `"error (HTTP <status>)"`.
+ * Test: `create-session.test.ts::describeFsError`.
+ */
+export function describeFsError(status: number): string {
+  switch (status) {
+    case 404:
+      return 'path not found';
+    case 400:
+      return 'not a directory';
+    case 403:
+      return 'permission denied';
+    default:
+      return `error (HTTP ${status})`;
+  }
+}

--- a/crates/trusty-code-gui/ui/src/lib/create-session.ts
+++ b/crates/trusty-code-gui/ui/src/lib/create-session.ts
@@ -157,3 +157,54 @@ export function describeFsError(status: number): string {
       return `error (HTTP ${status})`;
   }
 }
+
+/**
+ * Runtime shape guard for a `GET /fs` 200 response body.
+ *
+ * Why: PR #3103 review finding (HIGH) — a bare `as DirListing` assertion let
+ * a 200 response missing `entries` (schema drift, an interposed proxy, a
+ * future daemon) flow into `listing.entries.filter(...)` and throw, and since
+ * `CreateSessionForm` is mounted unconditionally in `App.svelte` that
+ * TypeError took down the whole shell. A 200 status is a promise from THIS
+ * daemon version's handler, not from whatever actually answered the socket —
+ * the shape must be verified before it becomes reactive state.
+ * What: structural check of every field the UI dereferences: `path` and
+ * `display_path` are strings, `parent` is a string or null, `entries` is an
+ * array whose members each carry string `name`/`path` and boolean
+ * `is_dir`/`is_git_repo`.
+ * Test: `create-session.test.ts::isDirListing`.
+ */
+export function isDirListing(body: unknown): body is DirListing {
+  if (typeof body !== 'object' || body === null) return false;
+  const b = body as Record<string, unknown>;
+  if (typeof b.path !== 'string' || typeof b.display_path !== 'string') return false;
+  if (b.parent !== null && typeof b.parent !== 'string') return false;
+  if (!Array.isArray(b.entries)) return false;
+  return b.entries.every((e: unknown) => {
+    if (typeof e !== 'object' || e === null) return false;
+    const entry = e as Record<string, unknown>;
+    return (
+      typeof entry.name === 'string' &&
+      typeof entry.path === 'string' &&
+      typeof entry.is_dir === 'boolean' &&
+      typeof entry.is_git_repo === 'boolean'
+    );
+  });
+}
+
+/**
+ * Extract the created session id from a `POST /sessions` 201 body, if any.
+ *
+ * Why: PR #3103 review finding (MEDIUM, same root pattern as [`isDirListing`])
+ * — `(await res.json()) as { id: string }` followed by `.slice(0, 8)` in the
+ * template throws when a 201 body is missing or malformed. The 201 status is
+ * authoritative that the session WAS created; the id is only cosmetic, so its
+ * absence must degrade the success message, never crash the form.
+ * What: returns `body.id` when it is a non-empty string, else `null`.
+ * Test: `create-session.test.ts::extractSessionId`.
+ */
+export function extractSessionId(body: unknown): string | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const id = (body as Record<string, unknown>).id;
+  return typeof id === 'string' && id.length > 0 ? id : null;
+}


### PR DESCRIPTION
## Summary

- Adds the create-session flow to `trusty-code-gui`: the DOC-39 7a folder
  picker plus the minimal task-input form needed to start a session from
  the desktop shell. This closes the single biggest gap blocking user
  testing — the GUI was previously observe-and-cancel only, with no way to
  mint a session from the UI at all.
- `CreateSessionForm.svelte` is a pure `fetch()` client over two daemon
  routes already shipped on `origin/main`: `GET /fs` (`fs.list_dir`) for
  the picker, `POST /sessions` (`session.create`) to submit. **No Tauri
  command and no native dialog plugin** — DOC-39 §2.1 C-4 explicitly bars
  a Tauri-native fs/dialog as a functional path (it would give the Tauri
  build a capability the web build lacks, violating C-3's no-divergence
  rule), and the daemon-served `GET /fs` route already covers the picker
  identically in both shells.
- Picker interaction mirrors 7a's own shape: browsing a directory lists
  its children as the selectable candidates (`open` descends, `use` binds
  without navigating). Every selectable entry was already confirmed by the
  listing call to exist and be a directory, so no separate path-validation
  round-trip is needed before enabling submit. Leaving the selection
  cleared submits projectless (`project` omitted from the body), per
  AC-2.1's "workstream creatable with no project bound" requirement.
- New `lib/create-session.ts` holds the pure gating/body-construction logic
  (`buildCreateBody`, `canSubmitCreate`, `bindingLabel`, `describeFsError`);
  `create-session.test.ts` (11 tests) covers it in isolation.
  `CreateSessionForm.test.ts` (5 tests) covers the form's disabled/enabled
  submit states, the no-double-submit guard under a real in-flight fetch,
  picker navigation/selection, and daemon-unreachable/400-error rendering.
- `App.svelte` mounts the form inside `.body`, between `HealthPanel` and
  `SessionMonitor`; `App.test.ts` gained a matching structural assertion.

**Documented gap (not worked around):** `GET /sessions/{id}/agents`
(`session.get_agents`) requires an existing `session_id` — there is no
pre-session agent-roster route. This form therefore omits `agent` from the
`POST /sessions` body entirely and lets the daemon apply its own default,
rather than inventing a roster endpoint (DOC-39 §2.1 C-2: "a UI need with
no API is an unbuilt feature, not a UI problem").

**Scope:** GUI-only. No changes under `crates/trusty-code` — a
concurrent PR is adding a search-audit route there and this PR does not
touch that crate at all.

## Test plan

- [x] `pnpm install && pnpm test` — 50/50 tests pass (7 files)
- [x] `pnpm build` — clean Vite production build
- [x] `SKIP_UI_BUILD=1 cargo check -p trusty-code-gui` — clean (no Rust
      source changes were needed for this feature)
- [x] `SKIP_UI_BUILD=1 cargo test -p trusty-code-gui` — 3/3 existing Rust
      tests still pass, untouched
- [x] `cargo fmt --check` — clean
- [x] `SKIP_UI_BUILD=1 cargo clippy -p trusty-code-gui --all-targets -- -D warnings` — clean
- [x] `bash scripts/check_line_cap.sh` — 0 violations

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools