### PR TITLE
feat(trusty-code): REST-pollable search/recall audit trail (closes #3072)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **REST-pollable search/recall audit trail (issue #3072).** New
+  `session.get_search_audit` RPC method and `GET /sessions/{id}/search-audit`
+  REST route return a session's retained, capped (200 records) history of
+  `search_code`/`recall_session` activity — the data source for DOC-39 §4.7's
+  Search tab (10d) and #3027's monitor card — mirroring the RPC+REST parity
+  pattern established by `session.get_agents` (#2962) and
+  `session.get_context_budget` (#3015).
 - **CI staleness guard for the embedded tm-agent copies (issue #2958 Slice
   E4).** `scripts/check_agent_assets.sh` + `.github/workflows/agent-assets.yml`
   diff `crates/trusty-code/src/assets/agents/*.md` against their source in

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -734,6 +734,57 @@ pub struct ContextBudgetSnapshot {
     pub compaction_rounds: usize,
 }
 
+/// One row in a session's RETAINED search/recall audit trail (issue #3072;
+/// backs `session.get_search_audit` / `GET /sessions/{id}/search-audit` —
+/// DOC-39 §4.7's Search tab (10d) and the #3027 8b monitor card).
+///
+/// Why: [`Event::SearchPerformed`]/[`Event::MemoryRecalled`] are emitted only
+/// on the SSE stream, so a client that attaches after either fired — or never
+/// opens an SSE connection at all, per DOC-39 §2.1's thin-REST-client
+/// constraint — has no way to see search/recall history. This is the
+/// per-record projection `SessionRegistry::push_search_audit`
+/// (`session::registry_search_audit`) appends to `SessionEntry::search_audit`
+/// from the SAME call `record_search_performed`/`record_memory_recalled`
+/// already makes to emit the live event, so the retained list and the SSE
+/// stream can never disagree about what happened. Retention is capped at
+/// `session::registry_search_audit::SEARCH_AUDIT_CAP` records, oldest
+/// dropped first — mirrors the ring buffer's own eviction policy, so a
+/// long-running session's memory use stays bounded.
+/// What: `#[serde(tag = "kind", rename_all = "snake_case")]` — `Search`
+/// mirrors [`Event::SearchPerformed`]'s `lane`/`query`/`hit_count`/
+/// `latency_ms` fields verbatim; per-hit path/score detail is deliberately
+/// NOT retained here (`hit_count` already answers "how many" — carrying
+/// every hit for up to `SEARCH_AUDIT_CAP` records would be unbounded per-hit
+/// growth this audit trail does not need). `Recall` mirrors
+/// [`Event::MemoryRecalled`]'s `query`, plus `result_count`/`injected_count`
+/// folded from `results` (the recalled TEXT itself is likewise not retained,
+/// same rationale). Both variants carry `agent`/`agent_id` (DOC-39 AC-13
+/// attribution) and `at` — the wall-clock time the record was appended,
+/// generated here because neither source event carries its own timestamp,
+/// giving DOC-39 AC-7.2's "age" column something to compute from.
+/// Test: `session::registry_search_audit::tests::*`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SearchAuditRecord {
+    Search {
+        agent: String,
+        agent_id: String,
+        lane: String,
+        query: String,
+        hit_count: Option<usize>,
+        latency_ms: u64,
+        at: DateTime<Utc>,
+    },
+    Recall {
+        agent: String,
+        agent_id: String,
+        query: String,
+        result_count: usize,
+        injected_count: usize,
+        at: DateTime<Utc>,
+    },
+}
+
 impl Event {
     /// Return the event's `session_id` if it has one. Used by the SSE
     /// handler to filter the broadcast stream to a single task subscription.

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -94,9 +94,9 @@ struct HttpState {
 /// (Slice 3) the write routes (`POST /sessions`,
 /// `POST /sessions/{id}/messages`, `POST /sessions/{id}/cancel`,
 /// `PUT`/`DELETE /sessions/{id}/goal`), (Slice 4) `POST /tasks`, (Slice 5)
-/// `GET /fs`, and (Slice 6) `GET /sessions/{id}/agents` — none of which
-/// collide with the paths registered directly on this router or with each
-/// other.
+/// `GET /fs`, (Slice 6) `GET /sessions/{id}/agents`, and (Slice 7, issue
+/// #3072) `GET /sessions/{id}/search-audit` — none of which collide with the
+/// paths registered directly on this router or with each other.
 /// Test: `http_rpc_ping_returns_pong`,
 /// `http_rpc_malformed_json_returns_parse_error`,
 /// `http_health_matches_jsonrpc_health_payload`,
@@ -106,7 +106,8 @@ struct HttpState {
 /// `http_rest_post_tasks_route_is_merged_in`,
 /// `http_rest_get_fs_route_is_merged_in`,
 /// `http_rest_get_session_agents_route_is_merged_in`,
-/// `http_rest_get_session_budget_route_is_merged_in`.
+/// `http_rest_get_session_budget_route_is_merged_in`,
+/// `http_rest_get_session_search_audit_route_is_merged_in`.
 pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) -> AxumRouter {
     let state = HttpState {
         router: router.clone(),
@@ -122,7 +123,8 @@ pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) ->
         .merge(rest::sessions_write::routes(router.clone()))
         .merge(rest::tasks::routes(router.clone()))
         .merge(rest::fs::routes(router.clone()))
-        .merge(rest::agents::routes(router));
+        .merge(rest::agents::routes(router.clone()))
+        .merge(rest::search_audit::routes(router));
     trusty_common::server::with_standard_middleware(app)
 }
 
@@ -617,6 +619,34 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert_eq!(v["status"], "never_recorded");
+    }
+
+    /// `GET /sessions/{id}/search-audit` (issue #3072, `rest::search_audit`'s
+    /// route group `build_axum_router` merges above) must be reachable on
+    /// the SAME router `GET /sessions/{id}/events` is — proving the merge
+    /// actually wires `rest::search_audit::routes` rather than silently
+    /// dropping it. Per-route error/status-code behaviour is already covered
+    /// by `rest::search_audit::tests`; this test only pins the merge itself.
+    #[tokio::test]
+    async fn http_rest_get_session_search_audit_route_is_merged_in() {
+        let (router, sessions) = router_and_sessions();
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        let app = build_axum_router(router, sessions);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/sessions/{}/search-audit", session.id))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["search_audit"].as_array().unwrap().len(), 0);
     }
 
     /// `GET /sessions/{id}/events` on an unknown session must 404 with a

--- a/crates/trusty-code/src/serve/rest/mod.rs
+++ b/crates/trusty-code/src/serve/rest/mod.rs
@@ -45,7 +45,9 @@
 //! `DELETE /sessions/{id}/goal`. Slice 4 ([`tasks`]) adds
 //! `POST /tasks` -> `task.run`. Slice 5 ([`fs`]) adds
 //! `GET /fs` -> `fs.list_dir`. Slice 6 ([`agents`]) adds
-//! `GET /sessions/{id}/agents` -> `session.get_agents`. Every slice reuses
+//! `GET /sessions/{id}/agents` -> `session.get_agents`. Slice 7
+//! ([`search_audit`]) adds `GET /sessions/{id}/search-audit` ->
+//! `session.get_search_audit` (issue #3072). Every slice reuses
 //! [`respond`]/[`throwaway_ctx`] rather than reimplementing the glue.
 //!
 //! Test: `tests::*` — a success round-trip, an error round-trip, and one
@@ -54,6 +56,7 @@
 
 pub mod agents;
 pub mod fs;
+pub mod search_audit;
 pub mod sessions;
 pub mod sessions_write;
 pub mod tasks;

--- a/crates/trusty-code/src/serve/rest/search_audit.rs
+++ b/crates/trusty-code/src/serve/rest/search_audit.rs
@@ -1,0 +1,142 @@
+//! `GET /sessions/{id}/search-audit` REST route over the
+//! `session.get_search_audit` JSON-RPC method (issue #3072).
+//!
+//! Why: DOC-39 §4.7 (Search tab, 10d) is the audit trail of agent
+//! search/recall operations — explicitly not an input box (AC-7.1) — and
+//! #3027's 8b monitor card needs the same settled history. Both need a
+//! REST-pollable snapshot rather than becoming SSE consumers of
+//! `GET /sessions/{id}/events` (DOC-39 §2.1). As with every route in this
+//! gateway, the handler stays thin — extract the path param, call
+//! `super::respond` — because the actual behaviour (the retained-list read,
+//! `-32007 session_not_found` mapping) already lives in
+//! `crate::session::registry_search_audit`/`protocol_search_audit`;
+//! duplicating it here would fork the two surfaces (see `super` module
+//! docs).
+//! What: [`routes`] builds a standalone `axum::Router<()>` (its own
+//! `SearchAuditState` carrying just the `Arc<Router>`, `with_state`-erased
+//! before return, mirroring `super::agents::AgentsState`) mapping
+//! `GET /sessions/{id}/search-audit` -> `session.get_search_audit`.
+//! `crate::serve::http::build_axum_router` merges this into the daemon's main
+//! router alongside `POST /rpc`, `GET /health`, `GET /sessions/{id}/events`,
+//! and the other REST resource groups. `/sessions/{id}/search-audit` does not
+//! collide with any path the other slices already registered under
+//! `/sessions/{id}`.
+//! Test: `tests::*`.
+
+use std::sync::Arc;
+
+use axum::Router as AxumRouter;
+use axum::extract::{Path, State};
+use axum::routing::get;
+use serde_json::json;
+
+use crate::jsonrpc::Router;
+
+use super::{RestResult, respond};
+
+/// Shared axum state for the route in this module: just the JSON-RPC
+/// router, mirroring `super::agents::AgentsState` — the handler goes through
+/// [`super::respond`] rather than touching `SessionRegistry` directly.
+#[derive(Clone)]
+struct SearchAuditState {
+    router: Arc<Router>,
+}
+
+/// Build the `GET /sessions/{id}/search-audit` route group.
+///
+/// Why: kept separate from `crate::serve::http::build_axum_router` so this
+/// resource group is unit-testable via `tower::util::ServiceExt::oneshot` on
+/// its own, exactly like every other `rest::*` group.
+/// What: one `GET` route, `SearchAuditState { router }`, `with_state`-erased
+/// to `axum::Router<()>` so the caller can `.merge()` it alongside the other
+/// resource groups into the daemon's main router.
+/// Test: `tests::get_search_audit_found_returns_200_with_empty_list`.
+pub fn routes(router: Arc<Router>) -> AxumRouter {
+    AxumRouter::new()
+        .route("/sessions/{id}/search-audit", get(get_search_audit))
+        .with_state(SearchAuditState { router })
+}
+
+/// `GET /sessions/{id}/search-audit` -> `session.get_search_audit`.
+///
+/// Why: lets an operator/UI inspect a session's search/recall history
+/// without becoming an SSE consumer of the live event stream.
+/// What: `404` for an unknown `id`; otherwise `{"search_audit": [...]}` —
+/// `[]` for a session with no search/recall activity yet.
+/// Test: `tests::get_search_audit_found_returns_200_with_empty_list`,
+/// `tests::get_search_audit_missing_returns_404_session_not_found`.
+async fn get_search_audit(
+    State(state): State<SearchAuditState>,
+    Path(id): Path<String>,
+) -> RestResult {
+    respond(
+        &state.router,
+        "session.get_search_audit",
+        json!({"session_id": id}),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::util::ServiceExt;
+
+    /// Build a router wired with every `session.*` method plus a fresh
+    /// `SessionRegistry`, then this module's route group over it — mirrors
+    /// `agents::tests::app_and_registry`.
+    fn app_and_registry() -> (AxumRouter, Arc<crate::session::SessionRegistry>) {
+        let sessions = Arc::new(crate::session::SessionRegistry::new());
+        let mut router = Router::new();
+        crate::session::protocol::register(&mut router, sessions.clone());
+        let app = routes(Arc::new(router));
+        (app, sessions)
+    }
+
+    async fn body_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn get(app: &AxumRouter, uri: &str) -> axum::response::Response {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    /// `GET /sessions/{id}/search-audit` on a real session with no
+    /// search/recall activity yet must return `200` with an empty
+    /// `search_audit` array, not an error.
+    #[tokio::test]
+    async fn get_search_audit_found_returns_200_with_empty_list() {
+        let (app, sessions) = app_and_registry();
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let resp = get(&app, &format!("/sessions/{}/search-audit", session.id)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["search_audit"].as_array().unwrap().len(), 0);
+    }
+
+    /// `GET /sessions/{id}/search-audit` on an unknown id must be a real
+    /// `404` with a `session_not_found` envelope.
+    #[tokio::test]
+    async fn get_search_audit_missing_returns_404_session_not_found() {
+        let (app, _sessions) = app_and_registry();
+
+        let resp = get(&app, "/sessions/does-not-exist/search-audit").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32007);
+    }
+}

--- a/crates/trusty-code/src/session/protocol.rs
+++ b/crates/trusty-code/src/session/protocol.rs
@@ -8,8 +8,8 @@
 //! `session.cancel`, (#2058) `session.get_transcript`, (#2350)
 //! `session.set_goal`/`session.clear_goal`/`session.get_goals`,
 //! (DOC-39 §5.6 Slice D) `session.get_readiness`, (DOC-39 §5.4)
-//! `session.get_agents`, and (issue #3015) `session.get_context_budget` onto
-//! a [`Router`], all
+//! `session.get_agents`, (issue #3015) `session.get_context_budget`, and
+//! (issue #3072) `session.get_search_audit` onto a [`Router`], all
 //! closed over the SAME `Arc<SessionRegistry>` so every method sees a
 //! consistent view. Each handler parses its typed `params`, forwards to the
 //! matching `SessionRegistry` method, and maps the result onto the JSON-RPC
@@ -174,6 +174,15 @@ pub fn register(router: &mut Router, registry: Arc<SessionRegistry>) {
         move |params: Value, ctx: ConnectionContext| {
             let r = r.clone();
             async move { protocol_budget::get_context_budget(&r, params, ctx).await }
+        },
+    );
+
+    let r = registry.clone();
+    router.register(
+        "session.get_search_audit",
+        move |params: Value, ctx: ConnectionContext| {
+            let r = r.clone();
+            async move { protocol_search_audit::get_search_audit(&r, params, ctx).await }
         },
     );
 }
@@ -429,6 +438,11 @@ mod protocol_agents;
 #[path = "protocol_budget.rs"]
 mod protocol_budget;
 
+/// `session.get_search_audit` (issue #3072), split into its own file for the
+/// same 500-SLOC-cap reason as `protocol_goals` above.
+#[path = "protocol_search_audit.rs"]
+mod protocol_search_audit;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -465,6 +479,10 @@ mod tests {
             ("session.get_agents", json!({"session_id": session.id})),
             (
                 "session.get_context_budget",
+                json!({"session_id": session.id}),
+            ),
+            (
+                "session.get_search_audit",
                 json!({"session_id": session.id}),
             ),
         ];

--- a/crates/trusty-code/src/session/protocol_search_audit.rs
+++ b/crates/trusty-code/src/session/protocol_search_audit.rs
@@ -1,0 +1,110 @@
+//! `session.get_search_audit` handler (issue #3072). Split out of
+//! `protocol.rs` purely to keep that production file under the crate's
+//! 500-SLOC cap — this is a child module of `protocol` (declared via
+//! `#[path = ...] mod protocol_search_audit;`), so it shares full access to
+//! `protocol`'s private `SessionIdParams`/`parse` helpers exactly as if this
+//! handler were still defined in that file.
+//!
+//! Why: DOC-39 §4.7 (Search tab, 10d) and #3027 (the 8b search/recall
+//! monitor card) both need a REST-pollable history of search/recall
+//! activity, but `Event::SearchPerformed`/`Event::MemoryRecalled` are
+//! emitted ONLY on the SSE stream — a late-attaching or SSE-avoiding client
+//! (DOC-39 §2.1) has no way to see them. This is the query half; see
+//! `session::registry_search_audit` module docs for the retained-list design
+//! and cap.
+//! What: [`get_search_audit`] forwards to
+//! `SessionRegistry::get_search_audit`, wrapping its result under a
+//! `"search_audit"` key — the same `{"<plural>": [...]}` shape
+//! `session.get_agents`/`session.get_goals` already use.
+//! Test: `tests::*` in this module.
+
+use super::*;
+
+/// `session.get_search_audit(session_id) -> { search_audit:
+/// [SearchAuditRecord] }` (issue #3072).
+///
+/// Why: the query counterpart to the search/recall telemetry every
+/// `search_code`/`recall_session` call already emits on the SSE stream — see
+/// module docs.
+/// What: `-32007 session_not_found` if `session_id` is unknown; otherwise
+/// `SessionRegistry::get_search_audit`'s retained list, oldest-first, under
+/// `"search_audit"`. An empty list (no search/recall activity recorded yet)
+/// is a success, not an error.
+/// Test: `tests::get_search_audit_wraps_records_under_search_audit_key`,
+/// `tests::get_search_audit_empty_session_returns_empty_array`,
+/// `tests::get_search_audit_unknown_session_maps_to_session_not_found`.
+pub(super) async fn get_search_audit(
+    registry: &SessionRegistry,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: SessionIdParams = parse(params, "session.get_search_audit")?;
+    Ok(json!({ "search_audit": registry.get_search_audit(&p.session_id)? }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    fn test_ctx() -> ConnectionContext {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    /// A session with a recorded search reports it under `"search_audit"`,
+    /// with the record's core fields populated.
+    #[tokio::test]
+    async fn get_search_audit_wraps_records_under_search_audit_key() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        registry
+            .record_search_performed(
+                &session.id,
+                "pm",
+                "pm-1",
+                &crate::tools::SearchTelemetry {
+                    lane: "grep".to_string(),
+                    query: "where is auth".to_string(),
+                    hit_count: Some(3),
+                    hits: vec![],
+                    latency_ms: 5,
+                },
+            )
+            .unwrap();
+
+        let result = get_search_audit(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        let records = result["search_audit"].as_array().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["kind"], "search");
+        assert_eq!(records[0]["query"], "where is auth");
+        assert_eq!(records[0]["hit_count"], 3);
+    }
+
+    /// A session with no search/recall activity yet returns an empty
+    /// `"search_audit"` array, not an error.
+    #[tokio::test]
+    async fn get_search_audit_empty_session_returns_empty_array() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let result = get_search_audit(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result["search_audit"].as_array().unwrap().len(), 0);
+    }
+
+    /// An unknown session must map to `-32007 session_not_found`.
+    #[tokio::test]
+    async fn get_search_audit_unknown_session_maps_to_session_not_found() {
+        let registry = SessionRegistry::new();
+        let err = get_search_audit(&registry, json!({"session_id": "nope"}), test_ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+}

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -40,7 +40,9 @@ use uuid::Uuid;
 
 use crate::agent_loop::Transcript;
 use crate::binding::ProjectBinding;
-use crate::events::{ContextBudgetSnapshot, Event, IndexReadinessSnapshot, SessionEventEnvelope};
+use crate::events::{
+    ContextBudgetSnapshot, Event, IndexReadinessSnapshot, SearchAuditRecord, SessionEventEnvelope,
+};
 use crate::jsonrpc::{NotifySender, RpcError};
 use crate::mode::HarnessMode;
 use crate::perf::TokenUsage;
@@ -138,6 +140,13 @@ struct SessionEntry {
     /// distinct-agent cardinality is small, so `record`'s linear find-or-insert
     /// scan is cheap.
     agents: Vec<AgentRosterState>,
+    /// (issue #3072) Retained search/recall audit trail, oldest-first — see
+    /// `session::registry_search_audit` module docs for the cap and eviction
+    /// policy. Appended by `SessionRegistry::push_search_audit`, called from
+    /// `record_search_performed`/`record_memory_recalled` (`registry_events`)
+    /// alongside the existing SSE emission; unlike `ring`, capacity here is
+    /// its own bound (`SEARCH_AUDIT_CAP`), independent of `ring_capacity`.
+    search_audit: VecDeque<SearchAuditRecord>,
 }
 
 /// One agent's live roster state inside a [`SessionEntry`] (DOC-39 §5.4) —
@@ -325,6 +334,7 @@ impl SessionRegistry {
                     readiness: None,
                     context_budget: None,
                     agents: Vec::new(),
+                    search_audit: VecDeque::new(),
                 },
             );
         }
@@ -1060,6 +1070,12 @@ mod goal_ops;
 /// own file for the same 500-SLOC-cap reason as `events` above.
 #[path = "registry_agents.rs"]
 mod agents;
+
+/// `session.get_search_audit`'s retained search/recall audit trail (issue
+/// #3072), split out into its own file for the same 500-SLOC-cap reason as
+/// `events` above.
+#[path = "registry_search_audit.rs"]
+mod search_audit;
 
 #[cfg(test)]
 #[path = "registry_tests.rs"]

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -397,7 +397,8 @@ impl SessionRegistry {
     /// What: same existence guard + ring-buffer/sequencing path as every
     /// other `record_*`, so a structured event replays on `session.attach`
     /// exactly like the generic ones.
-    /// Test: `registry_tests::record_search_performed_publishes_event`.
+    /// Test: `registry_tests::record_search_performed_publishes_event`,
+    /// `registry_search_audit::tests::get_search_audit_returns_records_after_recording`.
     pub fn record_search_performed(
         &self,
         id: &str,
@@ -406,6 +407,22 @@ impl SessionRegistry {
         telemetry: &SearchTelemetry,
     ) -> Result<(), RpcError> {
         self.ensure_exists(id)?;
+        // (issue #3072) Append to the retained audit trail BEFORE emitting
+        // the SSE event, mirroring `record_context_budget`'s cache-then-emit
+        // ordering — a client that queries `session.get_search_audit` right
+        // after observing this event on the stream is guaranteed to see it.
+        self.push_search_audit(
+            id,
+            crate::events::SearchAuditRecord::Search {
+                agent: agent.to_string(),
+                agent_id: agent_id.to_string(),
+                lane: telemetry.lane.clone(),
+                query: telemetry.query.clone(),
+                hit_count: telemetry.hit_count,
+                latency_ms: telemetry.latency_ms,
+                at: Utc::now(),
+            },
+        );
         self.record(
             id,
             Event::SearchPerformed {
@@ -428,7 +445,8 @@ impl SessionRegistry {
     /// Why: the `injected` flag is the UI's differentiating surface —
     /// injected memories vs ones recalled and held back.
     /// What: as [`Self::record_search_performed`].
-    /// Test: `registry_tests::record_memory_recalled_publishes_event`.
+    /// Test: `registry_tests::record_memory_recalled_publishes_event`,
+    /// `registry_search_audit::tests::get_search_audit_returns_records_after_recording`.
     pub fn record_memory_recalled(
         &self,
         id: &str,
@@ -437,6 +455,19 @@ impl SessionRegistry {
         telemetry: &RecallTelemetry,
     ) -> Result<(), RpcError> {
         self.ensure_exists(id)?;
+        // (issue #3072) Append to the retained audit trail BEFORE emitting
+        // the SSE event — see `record_search_performed`'s matching comment.
+        self.push_search_audit(
+            id,
+            crate::events::SearchAuditRecord::Recall {
+                agent: agent.to_string(),
+                agent_id: agent_id.to_string(),
+                query: telemetry.query.clone(),
+                result_count: telemetry.results.len(),
+                injected_count: telemetry.results.iter().filter(|r| r.injected).count(),
+                at: Utc::now(),
+            },
+        );
         self.record(
             id,
             Event::MemoryRecalled {

--- a/crates/trusty-code/src/session/registry_search_audit.rs
+++ b/crates/trusty-code/src/session/registry_search_audit.rs
@@ -1,0 +1,196 @@
+//! `session.get_search_audit`'s retained search/recall audit trail (issue
+//! #3072). Split out of `registry.rs` purely to keep that production file
+//! under the crate's 500-SLOC cap — this is a child module of `registry`
+//! (declared via `#[path = ...] mod search_audit;`), so it shares full
+//! access to `SessionRegistry`'s private `lock` helper exactly as if these
+//! methods were still defined in that file.
+//!
+//! Why: DOC-39 §4.7 (Search tab, 10d) and #3027 (the 8b search/recall
+//! monitor card) both need a REST-pollable history of `search_code`/
+//! `recall_session` activity, but `Event::SearchPerformed`/
+//! `Event::MemoryRecalled` (`crate::events`) are emitted ONLY on the SSE
+//! stream (`GET /sessions/{id}/events`) — a client that attaches late, or
+//! never opens an SSE connection at all (DOC-39 §2.1 forbids the GUI from
+//! becoming an ad hoc SSE consumer for this), cannot see them. This module
+//! is the daemon-owned, ALWAYS-RETAINED (bounded, not ring-evicted) list
+//! that closes that gap — the same shape `registry_agents.rs` used for
+//! #2962's `session.get_agents`, adapted for a growing history rather than a
+//! small per-agent roster.
+//!
+//! **Why a dedicated cap distinct from the ring buffer:** the ring buffer
+//! (`SessionEntry::ring`, `DEFAULT_RING_CAPACITY` = 1000) evicts EVERY event
+//! kind together, so a session dominated by tool-call chatter can age a
+//! search/recall record out of the ring long before `SEARCH_AUDIT_CAP`
+//! search/recall records have happened — exactly the silent-data-loss shape
+//! the #2962 code-critic HIGH flagged for `session.get_agents` (see
+//! `registry_agents.rs`'s module docs). Storing search/recall records in
+//! their OWN bounded list, independent of ring pressure from unrelated
+//! events, avoids that: a session's search/recall history survives exactly
+//! [`SEARCH_AUDIT_CAP`] records regardless of how much other traffic passes
+//! through the ring in between.
+//! What: [`push_search_audit`](SessionRegistry::push_search_audit) appends
+//! one [`SearchAuditRecord`] onto `SessionEntry::search_audit`, evicting the
+//! OLDEST record first once the list is at [`SEARCH_AUDIT_CAP`] — called
+//! from `record_search_performed`/`record_memory_recalled`
+//! (`registry_events.rs`) immediately before they call `self.record(...)` to
+//! emit the matching SSE event, mirroring `record_context_budget`'s
+//! cache-then-emit ordering. [`get_search_audit`](SessionRegistry::get_search_audit)
+//! returns the retained list verbatim, oldest-first — `[]` for a session
+//! with no search/recall activity yet (never an error), `-32007
+//! session_not_found` for an unknown session.
+//! Test: `tests::*` in this module (registry-level);
+//! `session::protocol_search_audit::tests::*` (RPC-level wiring).
+
+use super::*;
+
+/// Maximum number of [`SearchAuditRecord`]s retained per session — the
+/// OLDEST record is dropped once a session's `SEARCH_AUDIT_CAP`+1'th
+/// search/recall fires. Chosen generously above what a single interactive
+/// session realistically produces (DOC-39 §4.7's audit list is a debugging
+/// aid, not a permanent record — `session.get_transcript`/the durable memory
+/// palace are the sources of truth for long-term history) while still
+/// bounding per-session memory on a long-running or looping agent.
+pub(super) const SEARCH_AUDIT_CAP: usize = 200;
+
+impl SessionRegistry {
+    /// Append one [`SearchAuditRecord`] onto `id`'s retained search/recall
+    /// audit trail, evicting the oldest record first once at
+    /// [`SEARCH_AUDIT_CAP`] (issue #3072).
+    ///
+    /// Why: the write half of this module's gap-closing list — see the
+    /// module docs for why this is a DEDICATED cap rather than a fold over
+    /// the shared ring buffer.
+    /// What: a no-op if `id` is unknown, mirroring `SessionRegistry::record`'s
+    /// same "no hard error, caller already checked existence" contract —
+    /// every call site here is `record_search_performed`/
+    /// `record_memory_recalled`, both of which already call `ensure_exists`
+    /// before reaching this.
+    /// Test: `tests::push_search_audit_evicts_oldest_once_at_cap`.
+    pub(super) fn push_search_audit(&self, id: &str, record: SearchAuditRecord) {
+        let mut sessions = self.lock();
+        if let Some(entry) = sessions.get_mut(id) {
+            if entry.search_audit.len() >= SEARCH_AUDIT_CAP {
+                entry.search_audit.pop_front();
+            }
+            entry.search_audit.push_back(record);
+        }
+    }
+
+    /// `session.get_search_audit(session_id) -> { search_audit:
+    /// [SearchAuditRecord] }` (issue #3072).
+    ///
+    /// Why: the query surface DOC-39 §4.7's Search tab and #3027's monitor
+    /// card poll instead of buffering the SSE stream client-side — see
+    /// module docs.
+    /// What: `-32007 session_not_found` if `id` is unknown; otherwise the
+    /// retained `SearchAuditRecord` list, oldest-first, verbatim. A session
+    /// with no search/recall activity yet returns an empty list, not an
+    /// error — the same "empty means nothing yet" convention
+    /// `session.get_agents`/`session.get_goals` use.
+    /// Test: `tests::get_search_audit_empty_session_returns_empty_list`,
+    /// `tests::get_search_audit_returns_records_after_recording`,
+    /// `tests::get_search_audit_unknown_session_errors`.
+    pub fn get_search_audit(&self, id: &str) -> Result<Vec<SearchAuditRecord>, RpcError> {
+        let sessions = self.lock();
+        let entry = sessions
+            .get(id)
+            .ok_or_else(|| RpcError::session_not_found(id))?;
+        Ok(entry.search_audit.iter().cloned().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn search_record(query: &str) -> SearchAuditRecord {
+        SearchAuditRecord::Search {
+            agent: "pm".to_string(),
+            agent_id: "pm-1".to_string(),
+            lane: "grep".to_string(),
+            query: query.to_string(),
+            hit_count: Some(3),
+            latency_ms: 10,
+            at: Utc::now(),
+        }
+    }
+
+    /// A session with no search/recall activity yet returns an empty list,
+    /// not an error.
+    #[test]
+    fn get_search_audit_empty_session_returns_empty_list() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let records = registry.get_search_audit(&session.id).unwrap();
+
+        assert!(records.is_empty());
+    }
+
+    /// Records pushed via `push_search_audit` are returned, in push order.
+    #[test]
+    fn get_search_audit_returns_records_after_recording() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        registry.push_search_audit(&session.id, search_record("first"));
+        registry.push_search_audit(&session.id, search_record("second"));
+
+        let records = registry.get_search_audit(&session.id).unwrap();
+
+        assert_eq!(records.len(), 2);
+        assert!(matches!(&records[0], SearchAuditRecord::Search { query, .. } if query == "first"));
+        assert!(
+            matches!(&records[1], SearchAuditRecord::Search { query, .. } if query == "second")
+        );
+    }
+
+    /// Once a session is at `SEARCH_AUDIT_CAP` records, the next push evicts
+    /// the OLDEST record rather than growing unbounded — the retention
+    /// contract this module exists to enforce.
+    #[test]
+    fn push_search_audit_evicts_oldest_once_at_cap() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        for i in 0..SEARCH_AUDIT_CAP {
+            registry.push_search_audit(&session.id, search_record(&format!("q-{i}")));
+        }
+        // One more push past the cap.
+        registry.push_search_audit(&session.id, search_record("q-overflow"));
+
+        let records = registry.get_search_audit(&session.id).unwrap();
+
+        assert_eq!(records.len(), SEARCH_AUDIT_CAP);
+        // The very first record ("q-0") must have been evicted.
+        assert!(
+            !records
+                .iter()
+                .any(|r| matches!(r, SearchAuditRecord::Search { query, .. } if query == "q-0"))
+        );
+        // The overflow record must be present, as the newest (last) entry.
+        assert!(matches!(
+            records.last(),
+            Some(SearchAuditRecord::Search { query, .. }) if query == "q-overflow"
+        ));
+    }
+
+    /// An unknown session must map to `-32007 session_not_found`.
+    #[test]
+    fn get_search_audit_unknown_session_errors() {
+        let registry = SessionRegistry::new();
+        let err = registry.get_search_audit("nope").unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+
+    /// `push_search_audit` on an unknown session is a silent no-op, mirroring
+    /// `SessionRegistry::record`'s contract — it never panics or surfaces an
+    /// error to a caller that already validated existence.
+    #[test]
+    fn push_search_audit_unknown_session_is_noop() {
+        let registry = SessionRegistry::new();
+        // Must not panic.
+        registry.push_search_audit("nope", search_record("x"));
+    }
+}

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -499,6 +499,80 @@ async fn record_memory_recalled_publishes_event() {
     );
 }
 
+/// (issue #3072) `record_search_performed` must ALSO append onto the
+/// session's retained search/recall audit trail, not just publish the SSE
+/// event — this is the wiring `session.get_search_audit` depends on.
+#[tokio::test]
+async fn record_search_performed_appends_to_search_audit() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    registry
+        .record_search_performed(
+            &session.id,
+            "python-engineer",
+            "eng-1",
+            &search_telemetry("grep", Some(7)),
+        )
+        .unwrap();
+
+    let audit = registry.get_search_audit(&session.id).unwrap();
+    assert_eq!(audit.len(), 1);
+    assert!(matches!(
+        &audit[0],
+        crate::events::SearchAuditRecord::Search {
+            agent,
+            agent_id,
+            lane,
+            query,
+            hit_count,
+            latency_ms,
+            ..
+        } if agent == "python-engineer"
+            && agent_id == "eng-1"
+            && lane == "grep"
+            && query == "where is auth"
+            && *hit_count == Some(7)
+            && *latency_ms == 12
+    ));
+}
+
+/// (issue #3072) `record_memory_recalled` must ALSO append onto the
+/// session's retained search/recall audit trail, folding `results` into
+/// `result_count`/`injected_count`.
+#[tokio::test]
+async fn record_memory_recalled_appends_to_search_audit() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    registry
+        .record_memory_recalled(
+            &session.id,
+            "pm",
+            "pm-1",
+            &recall_telemetry(&[(0.9, true), (0.41, false)]),
+        )
+        .unwrap();
+
+    let audit = registry.get_search_audit(&session.id).unwrap();
+    assert_eq!(audit.len(), 1);
+    assert!(matches!(
+        &audit[0],
+        crate::events::SearchAuditRecord::Recall {
+            agent,
+            agent_id,
+            query,
+            result_count,
+            injected_count,
+            ..
+        } if agent == "pm"
+            && agent_id == "pm-1"
+            && query == "pkce"
+            && *result_count == 2
+            && *injected_count == 1
+    ));
+}
+
 /// `record_tool_started` must publish a `ToolStarted` event with a
 /// truncated `args_preview`.
 #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #3072. Unblocks #3027 (the DOC-39 §4.6 8b search/recall monitor card, which needed exactly this snapshot RPC+REST route instead of becoming an ad hoc SSE consumer).

DOC-39 §4.7 defines the Search tab (10d) as an audit trail of agent search
operations (not an input box). AC-7.2 requires every row to show lane badge,
query, hit count, latency, requesting agent, and age. `Event::SearchPerformed`
and `Event::MemoryRecalled` previously only existed on the SSE stream
(`GET /sessions/{id}/events`), with no REST snapshot and no persisted
per-session accumulation for late-attaching or SSE-avoiding clients.

This PR adds, mirroring the established RPC+REST parity pattern from
`session.get_agents` (#2962) and `session.get_context_budget` (#3015):

- `SessionEntry::search_audit: VecDeque<SearchAuditRecord>` — an
  always-retained, 200-record-capped audit list (oldest evicted first),
  appended by `SessionRegistry::push_search_audit` from the same
  `record_search_performed`/`record_memory_recalled` call sites that already
  emit the SSE event, so the retained list and stream can never disagree.
- `Event::SearchAuditRecord` (new type in `events.rs`) with `Search`/`Recall`
  variants carrying `agent`/`agent_id`/query/hit-count/latency plus an `at`
  timestamp (neither source event carried a timestamp before, needed for
  DOC-39 AC-7.2's "age" column).
- `session.get_search_audit` RPC method
  (`session/protocol_search_audit.rs`) returning `{"search_audit": [...]}`.
- `GET /sessions/{id}/search-audit` REST route
  (`serve/rest/search_audit.rs`), wired into `build_axum_router` alongside
  `rest::agents`/`rest::budget`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings`
- [x] `cargo test -p trusty-code` (1211 passed, 0 failed)
- [x] `bash scripts/check_line_cap.sh` (10 allowlisted, 0 violations)
- [x] Added `## [Unreleased]` entry to `crates/trusty-code/CHANGELOG.md`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
