### PR TITLE
feat(trusty-code-gui): wire Search tab to real search/recall audit data (closes #3027)

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -56,6 +56,42 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `agent` from the `POST /sessions` body entirely and lets the daemon apply
   its own default, rather than inventing a roster endpoint DOC-39 §2.1 C-2
   would call a UI-side workaround.
+- Search tab (10d, DOC-39 §4.7) now renders real search/recall audit rows
+  instead of the honest "not yet implemented" shell PR #3085 shipped
+  (closes #3027; refs #3072, PR #3107). `SearchTab.svelte` polls
+  `GET /sessions/{id}/search-audit` for the active session in the same
+  `refresh()` cycle that already polls `GET /sessions`, using the identical
+  `$effect`/`AbortController`/`setInterval` shape as `StatusBar.svelte` /
+  `SessionMonitor.svelte`, plus an independent 1s local age-redisplay tick
+  (no network call), mirroring `SessionMonitor.svelte`'s elapsed-time tick.
+  New `lib/search-audit.ts` holds the wire types (`SearchAuditRecord`,
+  mirroring `crate::events::SearchAuditRecord`'s `search`/`recall` tagged
+  variants), a runtime shape guard (`isSearchAuditResponse`, following the
+  `create-session.ts::isDirListing` house pattern — a `200` status is a
+  promise from this daemon version's handler, not from whatever actually
+  answered the socket, so the body's shape is verified before it becomes
+  reactive state, never a bare `as` assertion), and three pure per-record
+  formatters (`auditLaneLabel`/`auditHitsLabel`/`auditLatencyLabel`) that
+  normalize `Search` and `Recall` records onto AC-7.2's shared six columns
+  without fabricating fields neither variant carries (`Recall` has no
+  `lane`/`latency_ms` on the wire; it renders `'recall'` and an em dash
+  respectively, and combines `result_count`/`injected_count` into one
+  "N (M injected)" hits label). A malformed response body degrades to a
+  labeled "audit unavailable" row rather than throwing; a `404` on the
+  audit fetch (session vanished mid-poll, same partial-fetch case
+  `SessionMonitor.svelte` already handles for its own chained requests) is
+  treated as `no-session`. `search-audit.test.ts` covers the shape guard's
+  valid/malformed cases and the formatters; `SearchTab.test.ts` gained
+  fetch-URL assertions plus populated/empty/malformed/404/500 audit-state
+  coverage on top of the existing four connection-phase tests. **Scope
+  note:** this closes the REST-consumption half of the search/recall gap
+  #3027 and #3072 shared; `SessionMonitor.svelte`'s own AC-6.3 "settled
+  inline card" half has not been wired to this same route yet — tracked
+  separately as issue #3108 (that component's gap notice/comment now points
+  there instead of the now-closed #3027). Deliberately did not build a
+  shared GUI session poller here (issue #3092 tracks that refactor
+  opportunity across `StatusBar`/`SessionMonitor`/`SearchTab`) — this card's
+  polling stays local, matching the existing per-component pattern.
 - Phase-1 session monitor card: an active-session summary — status, task,
   elapsed time, a recent transcript tail, and a cancel action — per DOC-39
   §4.6 (the 8b UI surface, refs #2983). `SessionMonitor.svelte` polls

--- a/crates/trusty-code-gui/ui/src/components/SearchTab.svelte
+++ b/crates/trusty-code-gui/ui/src/components/SearchTab.svelte
@@ -6,58 +6,66 @@
   // (AC-7.3/7.4), out of scope here.
   //
   // AC-7.2 requires every row to show lane badge, query, hit count, latency,
-  // **requesting agent**, and age. The underlying data exists —
-  // `Event::SearchPerformed`/`Event::MemoryRecalled`
-  // (`crates/trusty-code/src/events.rs`) already carry `lane`/`query`/
-  // `hit_count`/`hits`/`latency_ms`/`agent`/`agent_id` — but per this PR's
-  // architecture rule, this tab must be a thin REST client, never an SSE
-  // consumer buffering an unbounded per-session event log client-side, and
-  // never a direct `POST /rpc` caller (that would bypass the REST
-  // resource-gateway pattern `serve/rest/mod.rs` establishes). Both events
-  // are emitted ONLY on the SSE stream (`GET /sessions/{id}/events`) with no
-  // REST snapshot/list route and no persisted per-session accumulation
-  // anywhere in the registry — so there is no legal REST data source for
-  // AC-7.2's rows today. This is the SAME underlying gap `SessionMonitor.svelte`
-  // already calls out for the 8b inline monitor (issue #3027); the audit-list
-  // half (10d, this component) is tracked separately as issue #3072, which
-  // proposes the exact fix: a new `GET /sessions/{id}/search-audit` REST
-  // route backed by an always-retained `SessionEntry.search_audit` list
-  // (mirroring the #2962 agents-map precedent), appended from the same
-  // `SessionRegistry::record_search_performed`/`record_memory_recalled` path
-  // that already emits the SSE event.
+  // **requesting agent**, and age. PR #3085 shipped this tab as an honest
+  // shell — the column headers with a labeled gap notice in place of rows —
+  // because `Event::SearchPerformed`/`Event::MemoryRecalled` were SSE-only
+  // with no REST snapshot route (issue #3072). That route now exists
+  // (`GET /sessions/{id}/search-audit`, PR #3107) backed by an
+  // always-retained, 200-record-capped `SessionEntry.search_audit` list, so
+  // this slice replaces the gap notice with real rows polled the same way
+  // `StatusBar.svelte`/`SessionMonitor.svelte` poll their own REST routes —
+  // still a thin REST client, never an SSE consumer.
   //
-  // What: Ships the honest Phase-1 shell: the AC-7.1 explanatory banner (no
-  // input field — literally none is rendered, so AC-7.1 holds by
-  // construction), the AC-7.2 column headers (Lane / Query / Hits / Latency /
-  // Agent / Age) as static table structure, and a labeled, non-hidden gap
-  // notice in place of rows (same treatment as `StatusBar`'s `budget:
-  // unavailable` span and `SessionMonitor`'s AC-6.3 notice). Polls
-  // `GET /sessions` only (identical `$effect`/`AbortController`/
-  // `setInterval` shape to `StatusBar.svelte`/`SessionMonitor.svelte`) to
-  // distinguish `connecting`/`daemon-unreachable`/`no-session` from a real
-  // active session — once a session exists the gap notice explains why the
-  // table is empty (no data source) rather than implying zero searches ran.
+  // What: Polls `GET /sessions` to pick the active session
+  // (`pickActiveSession`), then `GET /sessions/{id}/search-audit` for that
+  // session, every `POLL_MS` — identical `$effect`/`AbortController`/
+  // `setInterval` shape to the sibling components. A `404` on the audit
+  // fetch (session vanished between the two calls in the same `refresh()`)
+  // is treated as `no-session`, same as `SessionMonitor.svelte`'s handling
+  // of its own chained fetches. A non-200 or malformed body degrades to an
+  // `audit unavailable` row rather than throwing — the fetched body's shape
+  // is verified with `isSearchAuditResponse`
+  // (`lib/search-audit.ts`, mirroring `create-session.ts::isDirListing`)
+  // before it becomes reactive state; no bare `as` assertion on
+  // network-derived data. Rows render in the order the daemon returns them
+  // (oldest first, newest last — the API doc's own ordering), so the most
+  // recent search lands where the eye naturally finishes reading, same
+  // convention as `transcript.ts::selectTranscriptTail`. `Recall` rows have
+  // no `lane`/`latency_ms` on the wire; `auditLaneLabel`/`auditLatencyLabel`
+  // (`lib/search-audit.ts`) normalize both variants onto the shared six
+  // columns without fabricating fields neither carries. A second, local
+  // `now` tick (no network call) redisplays each row's age every second via
+  // `transcript.ts::formatElapsed`, same pattern as `SessionMonitor.svelte`.
   //
-  // Test: `SearchTab.test.ts` covers the four phases and asserts no
-  // `<input>`/`<textarea>` renders (AC-7.1); `App.test.ts` pins that this
-  // component mounts inside `.body`.
+  // Test: `SearchTab.test.ts` covers the four connection phases, the
+  // populated/empty/malformed audit states, and asserts no `<input>`/
+  // `<textarea>` ever renders (AC-7.1).
   import { apiBase } from '../lib/api-config';
+  import {
+    auditHitsLabel,
+    auditLaneLabel,
+    auditLatencyLabel,
+    isSearchAuditResponse,
+    type SearchAuditRecord,
+  } from '../lib/search-audit';
   import {
     pickActiveSession,
     type SessionListResponse,
     type SessionSummary,
   } from '../lib/session-status';
+  import { formatElapsed } from '../lib/transcript';
 
   const POLL_MS = 5000; // matches StatusBar.svelte / SessionMonitor.svelte poll cadence
-
-  /** Tracks the REST-snapshot-route gap this tab cannot fill client-side. */
-  const SEARCH_AUDIT_GAP_ISSUE = 'https://github.com/bobmatnyc/trusty-tools/issues/3072';
+  const TICK_MS = 1000; // local age-redisplay tick only — no network call
 
   type Phase = 'connecting' | 'daemon-unreachable' | 'no-session' | 'active';
 
   let phase = $state<Phase>('connecting');
   let session = $state<SessionSummary | null>(null);
   let error = $state<string | null>(null);
+  let auditRows = $state<SearchAuditRecord[]>([]);
+  let auditError = $state<string | null>(null);
+  let now = $state(Date.now());
 
   async function refresh(signal: AbortSignal) {
     let base: string;
@@ -73,27 +81,62 @@
     }
     if (signal.aborted) return;
 
+    let sessions: SessionSummary[];
     try {
       const res = await fetch(`${base}/sessions`, { signal });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const body = (await res.json()) as SessionListResponse;
-      if (signal.aborted) return;
-
-      const active = pickActiveSession(body.sessions);
-      if (!active) {
-        phase = 'no-session';
-        session = null;
-        error = null;
-        return;
-      }
-      session = active;
-      phase = 'active';
-      error = null;
+      sessions = body.sessions;
     } catch (e) {
       if (!signal.aborted) {
         phase = 'daemon-unreachable';
         session = null;
         error = e instanceof Error ? e.message : String(e);
+      }
+      return;
+    }
+    if (signal.aborted) return;
+
+    const active = pickActiveSession(sessions);
+    if (!active) {
+      phase = 'no-session';
+      session = null;
+      auditRows = [];
+      auditError = null;
+      error = null;
+      return;
+    }
+    session = active;
+    phase = 'active';
+    error = null;
+
+    try {
+      const res = await fetch(`${base}/sessions/${active.id}/search-audit`, { signal });
+      if (res.status === 404) {
+        // Reachable daemon, just-listed session vanished mid-poll — same
+        // partial-case handling as SessionMonitor.svelte's chained fetches.
+        if (!signal.aborted) {
+          phase = 'no-session';
+          session = null;
+          auditRows = [];
+          auditError = null;
+        }
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body: unknown = await res.json();
+      if (signal.aborted) return;
+      if (!isSearchAuditResponse(body)) {
+        auditRows = [];
+        auditError = 'malformed response from daemon';
+        return;
+      }
+      auditRows = body.search_audit;
+      auditError = null;
+    } catch (e) {
+      if (!signal.aborted) {
+        auditRows = [];
+        auditError = e instanceof Error ? e.message : String(e);
       }
     }
   }
@@ -110,6 +153,17 @@
       controller.abort();
       clearInterval(timer);
     };
+  });
+
+  $effect(() => {
+    // Independent of the network poll: a pure local redisplay tick so each
+    // row's "age" column advances smoothly without waiting on POLL_MS. No
+    // fetch, no AbortController needed — clearing the interval is the whole
+    // teardown (mirrors SessionMonitor.svelte's elapsed-time tick).
+    const timer = setInterval(() => {
+      now = Date.now();
+    }, TICK_MS);
+    return () => clearInterval(timer);
   });
 </script>
 
@@ -146,20 +200,30 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td colspan="6" class="pt-2 text-trusty-text/40">
-              no REST snapshot route yet — see the gap notice below
-            </td>
-          </tr>
+          {#if auditError}
+            <tr>
+              <td colspan="6" class="pt-2 text-status-error">
+                audit unavailable — {auditError}
+              </td>
+            </tr>
+          {:else if auditRows.length === 0}
+            <tr>
+              <td colspan="6" class="pt-2 text-trusty-text/40">no searches recorded yet</td>
+            </tr>
+          {:else}
+            {#each auditRows as record, i (`${record.at}-${record.agent_id}-${i}`)}
+              <tr class="text-trusty-text/80">
+                <td class="py-0.5 pr-3">{auditLaneLabel(record)}</td>
+                <td class="py-0.5 pr-3 truncate" title={record.query}>{record.query}</td>
+                <td class="py-0.5 pr-3">{auditHitsLabel(record)}</td>
+                <td class="py-0.5 pr-3">{auditLatencyLabel(record)}</td>
+                <td class="py-0.5 pr-3">{record.agent}</td>
+                <td class="py-0.5">{formatElapsed(record.at, now)}</td>
+              </tr>
+            {/each}
+          {/if}
         </tbody>
       </table>
     </div>
-
-    <p
-      class="mt-3 text-[11px] text-trusty-text/30"
-      title={`DOC-39 §4.7 AC-7.2's search/recall audit rows (lane, query, hit count, latency, requesting agent, age) are not renderable here — Event::SearchPerformed/Event::MemoryRecalled are SSE-only with no REST snapshot route and no persisted per-session history. Tracked at ${SEARCH_AUDIT_GAP_ISSUE}`}
-    >
-      search audit trail (AC-7.2): not yet implemented — see issue #3072
-    </p>
   {/if}
 </section>

--- a/crates/trusty-code-gui/ui/src/components/SearchTab.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/SearchTab.test.ts
@@ -1,11 +1,14 @@
 // Why: DOC-39 §4.7 AC-7.1 requires the Search tab to have NO input field —
 // it is an audit trail, not a search box. This pins that invariant plus the
-// component's four phases (connecting/daemon-unreachable/no-session/active),
-// mirroring the phase-coverage style already established for
-// `SessionMonitor.test.ts`.
+// component's four connection phases (connecting/daemon-unreachable/
+// no-session/active), and now that `GET /sessions/{id}/search-audit`
+// (issue #3072, PR #3107) is wired in, the audit-row states: populated,
+// empty, and malformed-body degradation (the runtime shape guard from
+// `lib/search-audit.ts` must stop a schema-drifted response before it
+// crashes the tab).
 // What: Mounts the real `SearchTab.svelte` with `fetch` stubbed for each
-// phase and asserts the rendered text/DOM matches, plus that no `<input>` or
-// `<textarea>` ever renders regardless of phase.
+// phase, asserting the rendered DOM/text and the exact URLs fetched, plus
+// that no `<input>` or `<textarea>` ever renders regardless of phase.
 // Test: this file.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, unmount } from 'svelte';
@@ -37,6 +40,17 @@ function normalizedText(): string {
   return (target.textContent ?? '').replace(/\s+/g, ' ').trim();
 }
 
+/** A `GET /sessions` stub returning exactly one running session. */
+function sessionsResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      sessions: [{ id: SESSION_ID, status: 'running', created_at: CREATED_AT, project: null }],
+    }),
+  } as Response;
+}
+
 afterEach(() => {
   if (instance) {
     unmount(instance);
@@ -53,11 +67,6 @@ beforeEach(() => {
 
 describe('SearchTab (DOC-39 §4.7, 10d)', () => {
   it('renders the connecting state before the first poll resolves', async () => {
-    // A `fetch` that never resolves keeps `refresh()` parked on its first
-    // `await` forever, so `phase` never advances past its initial
-    // `'connecting'` value — review follow-up (code-critic on PR #3085): the
-    // doc comment claims all four phases are covered, but `connecting` had
-    // no assertion.
     vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
     instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
 
@@ -81,16 +90,133 @@ describe('SearchTab (DOC-39 §4.7, 10d)', () => {
   });
 
   it('renders no-session state when the daemon has zero sessions', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (input: RequestInfo | URL) => {
-        const url = String(input);
-        if (url.endsWith('/sessions')) {
-          return { ok: true, status: 200, json: async () => ({ sessions: [] }) } as Response;
-        }
-        throw new Error(`unexpected fetch: ${url}`);
-      }),
-    );
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/sessions')) {
+        return { ok: true, status: 200, json: async () => ({ sessions: [] }) } as Response;
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('nothing to audit yet') ?? false);
+
+    expect(target.textContent).toContain('no active session');
+    expect(noInputRendered()).toBe(true);
+    // No search-audit fetch should ever be attempted with no active session.
+    expect(fetchMock.mock.calls.some(([u]) => String(u).includes('search-audit'))).toBe(false);
+  });
+
+  it('AC-7.2: fetches search-audit for the active session and renders real rows', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/sessions')) return sessionsResponse();
+      if (url.endsWith(`/sessions/${SESSION_ID}/search-audit`)) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            search_audit: [
+              {
+                kind: 'search',
+                agent: 'engineer',
+                agent_id: 'ag-1',
+                lane: 'semantic',
+                query: 'parse config',
+                hit_count: 7,
+                latency_ms: 42,
+                at: new Date().toISOString(),
+              },
+              {
+                kind: 'recall',
+                agent: 'pm',
+                agent_id: 'ag-2',
+                query: 'prior decisions',
+                result_count: 5,
+                injected_count: 3,
+                at: new Date().toISOString(),
+              },
+            ],
+          }),
+        } as Response;
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('parse config') ?? false);
+
+    for (const column of ['lane', 'query', 'hits', 'latency', 'agent', 'age']) {
+      expect(target.textContent).toContain(column);
+    }
+    // Search row: real lane, hit count, latency.
+    expect(target.textContent).toContain('semantic');
+    expect(target.textContent).toContain('parse config');
+    expect(target.textContent).toContain('7');
+    expect(target.textContent).toContain('42ms');
+    expect(target.textContent).toContain('engineer');
+    // Recall row: normalized 'recall' lane label, no latency, combined counts.
+    expect(target.textContent).toContain('recall');
+    expect(target.textContent).toContain('prior decisions');
+    expect(target.textContent).toContain('5 (3 injected)');
+    expect(target.textContent).toContain('pm');
+
+    expect(
+      fetchMock.mock.calls.some(([u]) => String(u).endsWith(`/sessions/${SESSION_ID}/search-audit`)),
+    ).toBe(true);
+    expect(noInputRendered()).toBe(true);
+  });
+
+  it('renders the empty-list state honestly when a session has no search activity yet', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/sessions')) return sessionsResponse();
+      if (url.endsWith(`/sessions/${SESSION_ID}/search-audit`)) {
+        return { ok: true, status: 200, json: async () => ({ search_audit: [] }) } as Response;
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('no searches recorded yet') ?? false);
+
+    expect(target.textContent).toContain('no searches recorded yet');
+    expect(noInputRendered()).toBe(true);
+  });
+
+  it('degrades to an error row instead of throwing when the audit body is malformed', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/sessions')) return sessionsResponse();
+      if (url.endsWith(`/sessions/${SESSION_ID}/search-audit`)) {
+        // Missing `search_audit` entirely — schema drift / interposed proxy.
+        return { ok: true, status: 200, json: async () => ({ unexpected: true }) } as Response;
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('audit unavailable') ?? false);
+
+    expect(target.textContent).toContain('audit unavailable');
+    expect(target.textContent).toContain('malformed response');
+    expect(noInputRendered()).toBe(true);
+  });
+
+  it('treats a 404 on search-audit as the session having vanished mid-poll', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/sessions')) return sessionsResponse();
+      if (url.endsWith(`/sessions/${SESSION_ID}/search-audit`)) {
+        return { ok: false, status: 404, json: async () => ({}) } as Response;
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
     instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
 
     await waitFor(() => target.textContent?.includes('nothing to audit yet') ?? false);
@@ -99,35 +225,22 @@ describe('SearchTab (DOC-39 §4.7, 10d)', () => {
     expect(noInputRendered()).toBe(true);
   });
 
-  it('AC-7.2: renders the column headers and the honest gap notice (issue #3072) for an active session', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (input: RequestInfo | URL) => {
-        const url = String(input);
-        if (url.endsWith('/sessions')) {
-          return {
-            ok: true,
-            status: 200,
-            json: async () => ({
-              sessions: [
-                { id: SESSION_ID, status: 'running', created_at: CREATED_AT, project: null },
-              ],
-            }),
-          } as Response;
-        }
-        throw new Error(`unexpected fetch: ${url}`);
-      }),
-    );
+  it('treats a non-200/non-404 audit status as a recoverable partial error, not a crash', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/sessions')) return sessionsResponse();
+      if (url.endsWith(`/sessions/${SESSION_ID}/search-audit`)) {
+        return { ok: false, status: 500, json: async () => ({}) } as Response;
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
     instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
 
-    await waitFor(() => target.textContent?.includes('issue #3072') ?? false);
+    await waitFor(() => target.textContent?.includes('audit unavailable') ?? false);
 
-    for (const column of ['lane', 'query', 'hits', 'latency', 'agent', 'age']) {
-      expect(target.textContent).toContain(column);
-    }
-    expect(target.textContent).toContain('not yet implemented');
-    expect(target.textContent).toContain('issue #3072');
-    // AC-7.1 must hold in every phase, including the active/gap-notice one.
+    expect(target.textContent).toContain('audit unavailable');
+    expect(target.textContent).toContain('HTTP 500');
     expect(noInputRendered()).toBe(true);
   });
 

--- a/crates/trusty-code-gui/ui/src/components/SessionMonitor.svelte
+++ b/crates/trusty-code-gui/ui/src/components/SessionMonitor.svelte
@@ -21,9 +21,16 @@
   // but it does NOT fulfil AC-6.3's literal "live search/recall monitor
   // settling into an inline card" requirement. That gap is rendered as a
   // labeled, non-hidden notice below (mirroring exactly how
-  // `StatusBar.svelte` labels its missing-budget-RPC gap) and tracked in
-  // issue #3027 (DOC-39 §4.6 AC-6.3: SearchPerformed/MemoryRecalled are
-  // SSE-only with no REST snapshot route).
+  // `StatusBar.svelte` labels its missing-budget-RPC gap).
+  //
+  // UPDATE (issue #3027 closed, tracked onward as #3108): the underlying
+  // REST gap this comment originally described — `SearchPerformed`/
+  // `MemoryRecalled` being SSE-only with no snapshot route — is now closed
+  // (`GET /sessions/{id}/search-audit`, issue #3072, PR #3107). The sibling
+  // `SearchTab.svelte` (10d) consumes it for its full audit trail (AC-7.2).
+  // This component's own settled-card half of AC-6.3 has NOT been wired to
+  // that route yet — that remaining, purely client-side gap is tracked as
+  // issue #3108 rather than #3027 (now closed for the Search tab reason).
   //
   // What: Polls `GET /sessions` then `GET /sessions/{id}` +
   // `GET /sessions/{id}/transcript` for the session `pickActiveSession`
@@ -60,7 +67,7 @@
   const TICK_MS = 1000; // local redisplay tick only — no network call
 
   /** Tracks the future AC-6.3 gap (see the Why block above). */
-  const SEARCH_RECALL_GAP_ISSUE = 'https://github.com/bobmatnyc/trusty-tools/issues/3027';
+  const SEARCH_RECALL_GAP_ISSUE = 'https://github.com/bobmatnyc/trusty-tools/issues/3108';
 
   type Phase = 'connecting' | 'daemon-unreachable' | 'no-session' | 'ready';
   type CancelPhase = 'idle' | 'confirming' | 'cancelling';
@@ -327,9 +334,9 @@
 
     <p
       class="mt-3 text-[11px] text-trusty-text/30"
-      title={`DOC-39 §4.6 AC-6.3's live search/memory-recall monitor (lane/query/hit_count/latency, docked-rail → inline settle) is not implemented here — Event::SearchPerformed/Event::MemoryRecalled are SSE-only with no REST snapshot route. Tracked at ${SEARCH_RECALL_GAP_ISSUE}`}
+      title={`DOC-39 §4.6 AC-6.3's live search/memory-recall monitor (lane/query/hit_count/latency, docked-rail → inline settle) is not implemented here — GET /sessions/{id}/search-audit now exists (issue #3072) but this card has not been wired to it yet. Tracked at ${SEARCH_RECALL_GAP_ISSUE}`}
     >
-      search/recall monitor (AC-6.3): not yet implemented — see issue #3027
+      search/recall monitor (AC-6.3): not yet implemented — see issue #3108
     </p>
   {/if}
 </section>

--- a/crates/trusty-code-gui/ui/src/lib/search-audit.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/search-audit.test.ts
@@ -1,0 +1,135 @@
+// Why: `isSearchAuditResponse` is the runtime shape guard `SearchTab.svelte`
+// relies on to never trust a malformed `GET /sessions/{id}/search-audit`
+// body — a gap here means a schema-drifted daemon response silently crashes
+// the tab instead of degrading. The three label formatters are the only
+// other client-side logic in `search-audit.ts` and each has a branch per
+// `SearchAuditRecord` variant that must be pinned directly.
+// What: covers valid `search`/`recall` records, every malformed-shape
+// rejection `isSearchAuditResponse` must catch, and the label formatters'
+// per-variant/`null`-field output.
+// Test: this file.
+import { describe, expect, it } from 'vitest';
+import {
+  auditHitsLabel,
+  auditLaneLabel,
+  auditLatencyLabel,
+  isSearchAuditResponse,
+  type SearchAuditRecallRecord,
+  type SearchAuditSearchRecord,
+} from './search-audit';
+
+const searchRecord: SearchAuditSearchRecord = {
+  kind: 'search',
+  agent: 'engineer',
+  agent_id: 'ag-1',
+  lane: 'semantic',
+  query: 'parse config',
+  hit_count: 7,
+  latency_ms: 42,
+  at: '2026-07-18T00:00:00Z',
+};
+
+const recallRecord: SearchAuditRecallRecord = {
+  kind: 'recall',
+  agent: 'pm',
+  agent_id: 'ag-2',
+  query: 'prior decisions',
+  result_count: 5,
+  injected_count: 3,
+  at: '2026-07-18T00:00:01Z',
+};
+
+describe('isSearchAuditResponse', () => {
+  it('accepts a response with valid search and recall records', () => {
+    expect(isSearchAuditResponse({ search_audit: [searchRecord, recallRecord] })).toBe(true);
+  });
+
+  it('accepts an empty search_audit array (no activity yet)', () => {
+    expect(isSearchAuditResponse({ search_audit: [] })).toBe(true);
+  });
+
+  it('accepts a search record with hit_count: null', () => {
+    expect(
+      isSearchAuditResponse({ search_audit: [{ ...searchRecord, hit_count: null }] }),
+    ).toBe(true);
+  });
+
+  it('rejects non-object bodies', () => {
+    expect(isSearchAuditResponse(null)).toBe(false);
+    expect(isSearchAuditResponse('ok')).toBe(false);
+    expect(isSearchAuditResponse([searchRecord])).toBe(false);
+  });
+
+  it('rejects a body missing search_audit', () => {
+    expect(isSearchAuditResponse({})).toBe(false);
+  });
+
+  it('rejects a body whose search_audit is not an array', () => {
+    expect(isSearchAuditResponse({ search_audit: 'oops' })).toBe(false);
+  });
+
+  it('rejects a record with an unknown kind', () => {
+    expect(
+      isSearchAuditResponse({ search_audit: [{ ...searchRecord, kind: 'other' }] }),
+    ).toBe(false);
+  });
+
+  it('rejects a record missing a common field (agent)', () => {
+    const { agent: _agent, ...rest } = searchRecord;
+    expect(isSearchAuditResponse({ search_audit: [rest] })).toBe(false);
+  });
+
+  it('rejects a search record with a non-string lane', () => {
+    expect(
+      isSearchAuditResponse({ search_audit: [{ ...searchRecord, lane: 42 }] }),
+    ).toBe(false);
+  });
+
+  it('rejects a search record with a non-numeric latency_ms', () => {
+    expect(
+      isSearchAuditResponse({ search_audit: [{ ...searchRecord, latency_ms: '42' }] }),
+    ).toBe(false);
+  });
+
+  it('rejects a recall record with a non-numeric result_count', () => {
+    expect(
+      isSearchAuditResponse({
+        search_audit: [{ ...recallRecord, result_count: 'five' }],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('auditLaneLabel', () => {
+  it("renders the real lane for a search record", () => {
+    expect(auditLaneLabel(searchRecord)).toBe('semantic');
+  });
+
+  it("renders 'recall' for a recall record (no lane on the wire)", () => {
+    expect(auditLaneLabel(recallRecord)).toBe('recall');
+  });
+});
+
+describe('auditHitsLabel', () => {
+  it('renders the hit count for a search record', () => {
+    expect(auditHitsLabel(searchRecord)).toBe('7');
+  });
+
+  it('renders an em dash for a null hit_count, never a fabricated 0', () => {
+    expect(auditHitsLabel({ ...searchRecord, hit_count: null })).toBe('—');
+  });
+
+  it('renders result_count with injected_count for a recall record', () => {
+    expect(auditHitsLabel(recallRecord)).toBe('5 (3 injected)');
+  });
+});
+
+describe('auditLatencyLabel', () => {
+  it('renders milliseconds for a search record', () => {
+    expect(auditLatencyLabel(searchRecord)).toBe('42ms');
+  });
+
+  it('renders an em dash for a recall record (no latency on the wire)', () => {
+    expect(auditLatencyLabel(recallRecord)).toBe('—');
+  });
+});

--- a/crates/trusty-code-gui/ui/src/lib/search-audit.ts
+++ b/crates/trusty-code-gui/ui/src/lib/search-audit.ts
@@ -1,0 +1,162 @@
+// Why: `SearchTab.svelte` (DOC-39 §4.7, 10d) needs the wire shape for
+// `GET /sessions/{id}/search-audit` (issue #3072, PR #3107) — the tagged
+// `SearchAuditRecord` enum `crate::events::SearchAuditRecord` defines
+// (`#[serde(tag = "kind", rename_all = "snake_case")]`), plus the small
+// per-kind formatting rules AC-7.2 needs (lane badge, hit count, latency).
+// Extracted into its own module rather than inlined in the component, the
+// same split already established by `session-status.ts`/`context-budget.ts`
+// — pure/testable logic independent of DOM/polling concerns.
+//
+// CRITICAL house rule (this session's critic reviews on PR #3103): no bare
+// `as` assertion on a network-derived body. A `200` status is a promise from
+// THIS daemon version's handler, not from whatever actually answered the
+// socket — the shape must be verified before it becomes reactive state.
+// `isSearchAuditResponse` is the runtime shape guard, mirroring
+// `create-session.ts::isDirListing`'s per-field structural check.
+//
+// What: `SearchAuditRecord` (discriminated union on `kind`), the
+// `{search_audit: [...]}` response envelope, `isSearchAuditResponse` (the
+// shape guard `SearchTab.svelte` calls before trusting a fetched body), and
+// three pure per-record formatters (`auditLaneLabel`/`auditHitsLabel`/
+// `auditLatencyLabel`) — `Recall` records carry no `lane`/`latency_ms` (they
+// are not a lane search), so these normalize both variants onto AC-7.2's six
+// shared columns without fabricating fields neither the wire type nor the
+// daemon has. Reuses `transcript.ts::formatElapsed` for the "age" column
+// rather than re-deriving duration formatting.
+// Test: `search-audit.test.ts`.
+
+/** One `SearchAuditRecord::Search` row — mirrors `crate::events::SearchAuditRecord::Search`. */
+export interface SearchAuditSearchRecord {
+  kind: 'search';
+  agent: string;
+  agent_id: string;
+  lane: string;
+  query: string;
+  hit_count: number | null;
+  latency_ms: number;
+  at: string;
+}
+
+/** One `SearchAuditRecord::Recall` row — mirrors `crate::events::SearchAuditRecord::Recall`. */
+export interface SearchAuditRecallRecord {
+  kind: 'recall';
+  agent: string;
+  agent_id: string;
+  query: string;
+  result_count: number;
+  injected_count: number;
+  at: string;
+}
+
+/** Mirrors `crate::events::SearchAuditRecord` in full. */
+export type SearchAuditRecord = SearchAuditSearchRecord | SearchAuditRecallRecord;
+
+/** `GET /sessions/{id}/search-audit` 200 response envelope. */
+export interface SearchAuditResponse {
+  search_audit: SearchAuditRecord[];
+}
+
+/**
+ * Structural check for one `SearchAuditRecord` — used only through
+ * {@link isSearchAuditResponse}, never called directly by the component.
+ *
+ * Why: same root pattern as `create-session.ts::isDirListing` — a record
+ * whose `kind` doesn't match either known variant, or whose fields don't
+ * match that variant's expected types, must not silently pass through as a
+ * usable row (`record.lane.toUpperCase()`-style dereferences later would
+ * throw on `undefined`).
+ * What: every field common to both variants (`agent`/`agent_id`/`query`/
+ * `at`, all strings) is checked first; `kind === 'search'` additionally
+ * requires `lane: string`, `hit_count: number | null`, `latency_ms: number`;
+ * `kind === 'recall'` additionally requires `result_count`/`injected_count:
+ * number`. Any other `kind` value fails.
+ * Test: `search-audit.test.ts::isSearchAuditRecord-via-response`.
+ */
+function isValidRecord(value: unknown): value is SearchAuditRecord {
+  if (typeof value !== 'object' || value === null) return false;
+  const r = value as Record<string, unknown>;
+  if (
+    typeof r.agent !== 'string' ||
+    typeof r.agent_id !== 'string' ||
+    typeof r.query !== 'string' ||
+    typeof r.at !== 'string'
+  ) {
+    return false;
+  }
+  if (r.kind === 'search') {
+    return (
+      typeof r.lane === 'string' &&
+      (r.hit_count === null || typeof r.hit_count === 'number') &&
+      typeof r.latency_ms === 'number'
+    );
+  }
+  if (r.kind === 'recall') {
+    return typeof r.result_count === 'number' && typeof r.injected_count === 'number';
+  }
+  return false;
+}
+
+/**
+ * Runtime shape guard for a `GET /sessions/{id}/search-audit` 200 response
+ * body.
+ *
+ * Why: PR #3103 review finding (HIGH, `isDirListing`) established the house
+ * rule — a bare `as SearchAuditResponse` assertion lets a malformed body
+ * (schema drift, an interposed proxy) flow straight into reactive state and
+ * throw once the template dereferences a missing field. `SearchTab.svelte`
+ * must degrade to an error state instead, never throw from its `$effect`.
+ * What: `body.search_audit` must be an array whose every element passes
+ * {@link isValidRecord}. Malformed input (not an object, missing/non-array
+ * `search_audit`, or any element failing its per-kind check) returns
+ * `false`.
+ * Test: `search-audit.test.ts::isSearchAuditResponse`.
+ */
+export function isSearchAuditResponse(body: unknown): body is SearchAuditResponse {
+  if (typeof body !== 'object' || body === null) return false;
+  const b = body as Record<string, unknown>;
+  return Array.isArray(b.search_audit) && b.search_audit.every(isValidRecord);
+}
+
+/**
+ * AC-7.2's "lane" column value for one record.
+ *
+ * Why: only `Search` records carry a real lane (`lexical`/`semantic`/
+ * `graph`); a `Recall` record is not a lane search at all, so fabricating
+ * one would misrepresent the operation. `'recall'` is an honest label for
+ * the row's actual kind, not a guessed lane.
+ * Test: `search-audit.test.ts::auditLaneLabel`.
+ */
+export function auditLaneLabel(record: SearchAuditRecord): string {
+  return record.kind === 'search' ? record.lane : 'recall';
+}
+
+/**
+ * AC-7.2's "hits" column value for one record.
+ *
+ * Why: `Search.hit_count` is `Option<usize>` on the wire (a lane that
+ * doesn't report a count, e.g. a graph traversal) — `null` renders as an
+ * honest em dash, never a fabricated `0`. `Recall` has no `hit_count` at
+ * all; its `result_count`/`injected_count` pair is the closest equivalent,
+ * rendered together so "how many came back" and "how many were actually
+ * injected into context" are both visible rather than picking one and
+ * silently dropping the other.
+ * Test: `search-audit.test.ts::auditHitsLabel`.
+ */
+export function auditHitsLabel(record: SearchAuditRecord): string {
+  if (record.kind === 'search') {
+    return record.hit_count === null ? '—' : String(record.hit_count);
+  }
+  return `${record.result_count} (${record.injected_count} injected)`;
+}
+
+/**
+ * AC-7.2's "latency" column value for one record.
+ *
+ * Why: only `Search` carries `latency_ms`; a `Recall` record has no timing
+ * field on the wire at all, so this renders an honest em dash rather than a
+ * fabricated `0ms`.
+ * Test: `search-audit.test.ts::auditLatencyLabel`.
+ */
+export function auditLatencyLabel(record: SearchAuditRecord): string {
+  return record.kind === 'search' ? `${record.latency_ms}ms` : '—';
+}


### PR DESCRIPTION
## Summary

- Consumes the now-shipped `GET /sessions/{id}/search-audit` REST route
  (issue #3072, PR #3107) in `SearchTab.svelte` (DOC-39 §4.7, 10d — the
  audit trail of agent search/recall operations, AC-7.2), replacing the
  honest "not yet implemented" shell PR #3085 shipped with real rows.
- Polls `GET /sessions/{id}/search-audit` for the active session inside the
  same `refresh()` cycle that already polls `GET /sessions`, using the
  identical `$effect`/`AbortController`/`setInterval` shape as
  `StatusBar.svelte`/`SessionMonitor.svelte`, plus an independent 1s local
  age-redisplay tick (no network call).
- New `lib/search-audit.ts`: wire types mirroring
  `crate::events::SearchAuditRecord`'s tagged `search`/`recall` variants, a
  **runtime shape guard** (`isSearchAuditResponse`) following the house
  pattern this session's critic reviews established on PR #3103
  (`create-session.ts::isDirListing`) — no bare `as` assertion on
  network-derived data; a malformed body degrades to a labeled "audit
  unavailable" row instead of throwing from the `$effect` — plus three pure
  per-record formatters (`auditLaneLabel`/`auditHitsLabel`/
  `auditLatencyLabel`) that normalize both variants onto AC-7.2's shared six
  columns without fabricating fields neither variant carries (`Recall` has
  no `lane`/`latency_ms` on the wire).
- A `404` on the audit fetch (session vanished mid-poll) is treated as
  `no-session`, matching `SessionMonitor.svelte`'s existing chained-fetch
  handling for the same partial-failure case.
- CHANGELOG entry under `[Unreleased]` for `trusty-code-gui`.

Closes #3027

## Scope note / issue-tracking honesty

Issue #3027 as literally filed describes `SessionMonitor.svelte`'s (8b)
"docked-rail → inline settle" card, not the Search tab. Per the CHANGELOG
precedent from when the Search-tab shell landed (PR #3085) — "a single fix
[the REST route]... would close both #3027 and #3072" — and per this task's
explicit scope, this PR closes #3027 via the Search tab (10d) wiring, since
#3072 (the REST route itself) is already closed by PR #3107.

`SessionMonitor.svelte`'s own AC-6.3 gap notice/doc comment previously
pointed at #3027; since this PR closes that issue for the Search-tab reason
and `SessionMonitor` has NOT been wired to the new route, I filed a
follow-up — **issue #3108** — for that remaining, purely client-side gap,
and updated `SessionMonitor.svelte`'s comment/notice to point there instead
of the now-closed #3027, so no code ships referencing a closed issue as if
the gap it describes were still open under that number.

Did not build a shared GUI session poller here — issue #3092 tracks that
refactor opportunity across `StatusBar`/`SessionMonitor`/`SearchTab`; this
card's polling stays local, matching the existing per-component pattern.

## Files

- `crates/trusty-code-gui/ui/src/lib/search-audit.ts` (new)
- `crates/trusty-code-gui/ui/src/lib/search-audit.test.ts` (new)
- `crates/trusty-code-gui/ui/src/components/SearchTab.svelte`
- `crates/trusty-code-gui/ui/src/components/SearchTab.test.ts`
- `crates/trusty-code-gui/ui/src/components/SessionMonitor.svelte` (gap-notice reference update only, no behavior change)
- `crates/trusty-code-gui/CHANGELOG.md`

## Quality gate (raw tails)

`pnpm test` (vitest, jsdom):
```
 Test Files  7 passed (7)
      Tests  61 passed (61)
```

`pnpm build`:
```
✓ 121 modules transformed.
✓ built in 527ms
```

`cargo fmt --check`: clean (exit 0, no diff)

`SKIP_UI_BUILD=1 cargo check -p trusty-code-gui`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 24.39s
```

`SKIP_UI_BUILD=1 cargo clippy -p trusty-code-gui --all-targets -- -D warnings`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.25s
```
(zero warnings)

`bash scripts/check_line_cap.sh`:
```
line-cap: 10 allowlisted, 0 violations — OK.
```

## Test plan

- [x] `pnpm test` — 61/61 passing, including new `search-audit.test.ts` (18
      tests: shape-guard valid/malformed cases, per-record formatters) and
      rewritten `SearchTab.test.ts` (9 tests: 4 connection phases + populated
      rows with real fetch-URL assertions + empty-list + malformed-body
      degradation + 404-mid-poll + non-200 partial error + AC-7.1 banner)
- [x] `pnpm build` — production build succeeds
- [x] `cargo fmt --check` / `cargo check -p trusty-code-gui` /
      `cargo clippy -p trusty-code-gui --all-targets -- -D warnings` — all clean
- [x] `bash scripts/check_line_cap.sh` — no new/grown oversized files

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools