### PR TITLE
fix(trusty-code-gui): tolerate partially-valid search-audit payloads (closes #3111)

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -23,6 +23,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   code, not the body, is authoritative that the session exists). Regression
   tests for both live in `CreateSessionForm.test.ts`; guard unit tests in
   `create-session.test.ts`.
+- Search-audit shape guard no longer rejects an entire
+  `GET /sessions/{id}/search-audit` response over a single bad record (issue
+  #3111 MEDIUM, PR #3110 critic review). `lib/search-audit.ts`'s
+  `isSearchAuditResponse` (a `body is SearchAuditResponse` all-or-nothing
+  predicate) is replaced by `parseSearchAuditResponse`, which filters
+  `search_audit` to the subset passing the existing per-record shape check
+  and reports how many entries were dropped (`omittedCount`) — a malformed
+  row, or a future third `SearchAuditRecord` variant this client build
+  doesn't recognize yet, no longer hides every known-good row behind an
+  "audit unavailable" wall. Only a genuine top-level shape failure (body not
+  an object, or `search_audit` not even an array) still returns `null` and
+  renders that error state. `SearchTab.svelte` now renders the trustworthy
+  rows plus a visible "N rows omitted (unrecognized record shape)" notice
+  when `omittedCount > 0`, rather than silently dropping or wholesale
+  rejecting them. Also added a fake-timer-driven regression test (issue
+  #3111 LOW) proving the tab recovers real rows on the next poll after a
+  transient `HTTP 500` from the audit route.
 
 ### Added
 

--- a/crates/trusty-code-gui/ui/src/components/SearchTab.svelte
+++ b/crates/trusty-code-gui/ui/src/components/SearchTab.svelte
@@ -22,30 +22,36 @@
   // `setInterval` shape to the sibling components. A `404` on the audit
   // fetch (session vanished between the two calls in the same `refresh()`)
   // is treated as `no-session`, same as `SessionMonitor.svelte`'s handling
-  // of its own chained fetches. A non-200 or malformed body degrades to an
-  // `audit unavailable` row rather than throwing — the fetched body's shape
-  // is verified with `isSearchAuditResponse`
+  // of its own chained fetches. A non-200 or top-level-malformed body
+  // degrades to an `audit unavailable` row rather than throwing — the
+  // fetched body's shape is verified with `parseSearchAuditResponse`
   // (`lib/search-audit.ts`, mirroring `create-session.ts::isDirListing`)
   // before it becomes reactive state; no bare `as` assertion on
-  // network-derived data. Rows render in the order the daemon returns them
-  // (oldest first, newest last — the API doc's own ordering), so the most
-  // recent search lands where the eye naturally finishes reading, same
-  // convention as `transcript.ts::selectTranscriptTail`. `Recall` rows have
-  // no `lane`/`latency_ms` on the wire; `auditLaneLabel`/`auditLatencyLabel`
-  // (`lib/search-audit.ts`) normalize both variants onto the shared six
-  // columns without fabricating fields neither carries. A second, local
-  // `now` tick (no network call) redisplays each row's age every second via
-  // `transcript.ts::formatElapsed`, same pattern as `SessionMonitor.svelte`.
+  // network-derived data. A single malformed RECORD (or a future
+  // `SearchAuditRecord` variant this build doesn't recognize) does NOT take
+  // down the whole table (issue #3111 MEDIUM) — `parseSearchAuditResponse`
+  // filters to the trustworthy subset and reports how many rows it dropped,
+  // rendered as a visible "N rows omitted" notice alongside the known-good
+  // rows rather than silently or wholesale. Rows render in the order the
+  // daemon returns them (oldest first, newest last — the API doc's own
+  // ordering), so the most recent search lands where the eye naturally
+  // finishes reading, same convention as `transcript.ts::selectTranscriptTail`.
+  // `Recall` rows have no `lane`/`latency_ms` on the wire;
+  // `auditLaneLabel`/`auditLatencyLabel` (`lib/search-audit.ts`) normalize
+  // both variants onto the shared six columns without fabricating fields
+  // neither carries. A second, local `now` tick (no network call) redisplays
+  // each row's age every second via `transcript.ts::formatElapsed`, same
+  // pattern as `SessionMonitor.svelte`.
   //
   // Test: `SearchTab.test.ts` covers the four connection phases, the
-  // populated/empty/malformed audit states, and asserts no `<input>`/
-  // `<textarea>` ever renders (AC-7.1).
+  // populated/empty/partially-valid/malformed audit states, a poll-recovery
+  // sequence, and asserts no `<input>`/`<textarea>` ever renders (AC-7.1).
   import { apiBase } from '../lib/api-config';
   import {
     auditHitsLabel,
     auditLaneLabel,
     auditLatencyLabel,
-    isSearchAuditResponse,
+    parseSearchAuditResponse,
     type SearchAuditRecord,
   } from '../lib/search-audit';
   import {
@@ -64,6 +70,7 @@
   let session = $state<SessionSummary | null>(null);
   let error = $state<string | null>(null);
   let auditRows = $state<SearchAuditRecord[]>([]);
+  let auditOmittedCount = $state(0);
   let auditError = $state<string | null>(null);
   let now = $state(Date.now());
 
@@ -102,6 +109,7 @@
       phase = 'no-session';
       session = null;
       auditRows = [];
+      auditOmittedCount = 0;
       auditError = null;
       error = null;
       return;
@@ -119,6 +127,7 @@
           phase = 'no-session';
           session = null;
           auditRows = [];
+          auditOmittedCount = 0;
           auditError = null;
         }
         return;
@@ -126,16 +135,25 @@
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const body: unknown = await res.json();
       if (signal.aborted) return;
-      if (!isSearchAuditResponse(body)) {
+      const parsed = parseSearchAuditResponse(body);
+      if (!parsed) {
+        // Top-level shape failure only (not an object, or `search_audit`
+        // isn't even an array) — nothing here can be trusted or filtered.
         auditRows = [];
+        auditOmittedCount = 0;
         auditError = 'malformed response from daemon';
         return;
       }
-      auditRows = body.search_audit;
+      // A record-level failure (or an unrecognized future `kind`) never
+      // takes down the whole table (issue #3111) — render whatever subset
+      // IS trustworthy plus an honest omitted-count, not "audit unavailable".
+      auditRows = parsed.records;
+      auditOmittedCount = parsed.omittedCount;
       auditError = null;
     } catch (e) {
       if (!signal.aborted) {
         auditRows = [];
+        auditOmittedCount = 0;
         auditError = e instanceof Error ? e.message : String(e);
       }
     }
@@ -206,7 +224,7 @@
                 audit unavailable — {auditError}
               </td>
             </tr>
-          {:else if auditRows.length === 0}
+          {:else if auditRows.length === 0 && auditOmittedCount === 0}
             <tr>
               <td colspan="6" class="pt-2 text-trusty-text/40">no searches recorded yet</td>
             </tr>
@@ -221,6 +239,18 @@
                 <td class="py-0.5">{formatElapsed(record.at, now)}</td>
               </tr>
             {/each}
+            {#if auditOmittedCount > 0}
+              <tr>
+                <td
+                  colspan="6"
+                  class="pt-2 text-trusty-text/40"
+                  title="One or more search-audit records from the daemon didn't match a known shape (malformed or an unrecognized future kind) and were left out rather than crashing the tab."
+                >
+                  {auditOmittedCount}
+                  {auditOmittedCount === 1 ? 'row' : 'rows'} omitted (unrecognized record shape)
+                </td>
+              </tr>
+            {/if}
           {/if}
         </tbody>
       </table>

--- a/crates/trusty-code-gui/ui/src/components/SearchTab.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/SearchTab.test.ts
@@ -169,6 +169,69 @@ describe('SearchTab (DOC-39 §4.7, 10d)', () => {
     expect(noInputRendered()).toBe(true);
   });
 
+  it('issue #3111: renders the valid subset plus an omitted-rows indicator for a partially-valid payload', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/sessions')) return sessionsResponse();
+      if (url.endsWith(`/sessions/${SESSION_ID}/search-audit`)) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            search_audit: [
+              {
+                kind: 'search',
+                agent: 'engineer',
+                agent_id: 'ag-1',
+                lane: 'semantic',
+                query: 'parse config',
+                hit_count: 7,
+                latency_ms: 42,
+                at: new Date().toISOString(),
+              },
+              // Malformed: lane must be a string. Must not take the whole
+              // response down with it (issue #3111 MEDIUM).
+              {
+                kind: 'search',
+                agent: 'engineer',
+                agent_id: 'ag-4',
+                lane: 42,
+                query: 'bad row',
+                hit_count: 1,
+                latency_ms: 10,
+                at: new Date().toISOString(),
+              },
+              // Unrecognized future kind — tolerated as omitted, not fatal.
+              {
+                kind: 'graph_traverse',
+                agent: 'engineer',
+                agent_id: 'ag-5',
+                query: 'call graph',
+                at: new Date().toISOString(),
+              },
+            ],
+          }),
+        } as Response;
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => normalizedText().includes('rows omitted'));
+
+    // The one valid row still renders.
+    expect(target.textContent).toContain('parse config');
+    // Two rows dropped (the bad `lane` and the unrecognized `kind`). jsdom's
+    // `textContent` preserves the template's source whitespace/line-wrapping
+    // verbatim (see `normalizedText()`'s own doc comment), so this asserts
+    // against the whitespace-collapsed text, not a raw substring.
+    expect(normalizedText()).toContain('2 rows omitted');
+    // Never the all-or-nothing "audit unavailable" for a partially-valid payload.
+    expect(target.textContent).not.toContain('audit unavailable');
+    expect(noInputRendered()).toBe(true);
+  });
+
   it('renders the empty-list state honestly when a session has no search activity yet', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -242,6 +305,58 @@ describe('SearchTab (DOC-39 §4.7, 10d)', () => {
     expect(target.textContent).toContain('audit unavailable');
     expect(target.textContent).toContain('HTTP 500');
     expect(noInputRendered()).toBe(true);
+  });
+
+  it('issue #3111 LOW: recovers on the next poll once the daemon stops returning 500 for search-audit', async () => {
+    vi.useFakeTimers();
+    try {
+      let auditCalls = 0;
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/sessions')) return sessionsResponse();
+        if (url.endsWith(`/sessions/${SESSION_ID}/search-audit`)) {
+          auditCalls += 1;
+          if (auditCalls === 1) {
+            return { ok: false, status: 500, json: async () => ({}) } as Response;
+          }
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              search_audit: [
+                {
+                  kind: 'search',
+                  agent: 'engineer',
+                  agent_id: 'ag-1',
+                  lane: 'semantic',
+                  query: 'recovered query',
+                  hit_count: 3,
+                  latency_ms: 15,
+                  at: new Date().toISOString(),
+                },
+              ],
+            }),
+          } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      instance = mount(SearchTab, { target }) as unknown as Record<string, unknown>;
+
+      // Flush the initial poll (poll #1: HTTP 500 -> "audit unavailable").
+      await vi.advanceTimersByTimeAsync(0);
+      expect(target.textContent).toContain('audit unavailable');
+      expect(auditCalls).toBe(1);
+
+      // Advance past POLL_MS (5000ms, matching StatusBar.svelte/SessionMonitor.svelte)
+      // to trigger poll #2, which now succeeds.
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(auditCalls).toBe(2);
+      expect(target.textContent).toContain('recovered query');
+      expect(target.textContent).not.toContain('audit unavailable');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("AC-7.1: the explanatory banner is present and no input field ever renders", async () => {

--- a/crates/trusty-code-gui/ui/src/lib/search-audit.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/search-audit.test.ts
@@ -1,19 +1,25 @@
-// Why: `isSearchAuditResponse` is the runtime shape guard `SearchTab.svelte`
-// relies on to never trust a malformed `GET /sessions/{id}/search-audit`
-// body — a gap here means a schema-drifted daemon response silently crashes
-// the tab instead of degrading. The three label formatters are the only
-// other client-side logic in `search-audit.ts` and each has a branch per
+// Why: `parseSearchAuditResponse` is the runtime shape guard/subset-filter
+// `SearchTab.svelte` relies on to never trust a malformed
+// `GET /sessions/{id}/search-audit` body — a gap here means a schema-drifted
+// daemon response either silently crashes the tab or (the issue #3111 MEDIUM
+// this file's coverage was extended for) drops every known-good row just
+// because one record was bad. The three label formatters are the only other
+// client-side logic in `search-audit.ts` and each has a branch per
 // `SearchAuditRecord` variant that must be pinned directly.
-// What: covers valid `search`/`recall` records, every malformed-shape
-// rejection `isSearchAuditResponse` must catch, and the label formatters'
-// per-variant/`null`-field output.
+// What: covers valid `search`/`recall` records, the top-level shape
+// failures `parseSearchAuditResponse` must still reject wholesale (not an
+// object, missing/non-array `search_audit`), and the per-record filtering
+// behavior: all-valid, some-invalid (subset + omitted count), all-invalid
+// (empty subset, non-zero count, still not `null`), and an unrecognized
+// future `kind` tolerated as one more omitted row rather than a fatal
+// rejection. Plus the label formatters' per-variant/`null`-field output.
 // Test: this file.
 import { describe, expect, it } from 'vitest';
 import {
   auditHitsLabel,
   auditLaneLabel,
   auditLatencyLabel,
-  isSearchAuditResponse,
+  parseSearchAuditResponse,
   type SearchAuditRecallRecord,
   type SearchAuditSearchRecord,
 } from './search-audit';
@@ -39,64 +45,86 @@ const recallRecord: SearchAuditRecallRecord = {
   at: '2026-07-18T00:00:01Z',
 };
 
-describe('isSearchAuditResponse', () => {
-  it('accepts a response with valid search and recall records', () => {
-    expect(isSearchAuditResponse({ search_audit: [searchRecord, recallRecord] })).toBe(true);
+describe('parseSearchAuditResponse', () => {
+  it('accepts a response with valid search and recall records (all-valid)', () => {
+    const parsed = parseSearchAuditResponse({ search_audit: [searchRecord, recallRecord] });
+    expect(parsed).toEqual({ records: [searchRecord, recallRecord], omittedCount: 0 });
   });
 
-  it('accepts an empty search_audit array (no activity yet)', () => {
-    expect(isSearchAuditResponse({ search_audit: [] })).toBe(true);
+  it('accepts an empty search_audit array (no activity yet), not a shape failure', () => {
+    expect(parseSearchAuditResponse({ search_audit: [] })).toEqual({
+      records: [],
+      omittedCount: 0,
+    });
   });
 
   it('accepts a search record with hit_count: null', () => {
-    expect(
-      isSearchAuditResponse({ search_audit: [{ ...searchRecord, hit_count: null }] }),
-    ).toBe(true);
+    const record = { ...searchRecord, hit_count: null };
+    expect(parseSearchAuditResponse({ search_audit: [record] })).toEqual({
+      records: [record],
+      omittedCount: 0,
+    });
   });
 
-  it('rejects non-object bodies', () => {
-    expect(isSearchAuditResponse(null)).toBe(false);
-    expect(isSearchAuditResponse('ok')).toBe(false);
-    expect(isSearchAuditResponse([searchRecord])).toBe(false);
+  it('returns null for non-object bodies (top-level shape failure)', () => {
+    expect(parseSearchAuditResponse(null)).toBeNull();
+    expect(parseSearchAuditResponse('ok')).toBeNull();
+    expect(parseSearchAuditResponse([searchRecord])).toBeNull();
   });
 
-  it('rejects a body missing search_audit', () => {
-    expect(isSearchAuditResponse({})).toBe(false);
+  it('returns null for a body missing search_audit (top-level shape failure)', () => {
+    expect(parseSearchAuditResponse({})).toBeNull();
   });
 
-  it('rejects a body whose search_audit is not an array', () => {
-    expect(isSearchAuditResponse({ search_audit: 'oops' })).toBe(false);
+  it('returns null for a body whose search_audit is not an array (top-level shape failure)', () => {
+    expect(parseSearchAuditResponse({ search_audit: 'oops' })).toBeNull();
   });
 
-  it('rejects a record with an unknown kind', () => {
-    expect(
-      isSearchAuditResponse({ search_audit: [{ ...searchRecord, kind: 'other' }] }),
-    ).toBe(false);
+  it('some-invalid: filters to the valid subset and reports the omitted count, never rejecting the whole response', () => {
+    const malformed = { ...searchRecord, lane: 42 }; // lane must be a string
+    const parsed = parseSearchAuditResponse({
+      search_audit: [searchRecord, malformed, recallRecord],
+    });
+    expect(parsed).toEqual({ records: [searchRecord, recallRecord], omittedCount: 1 });
   });
 
-  it('rejects a record missing a common field (agent)', () => {
+  it('all-invalid: returns an empty subset with a non-zero omitted count, still not null', () => {
+    const parsed = parseSearchAuditResponse({
+      search_audit: [
+        { ...searchRecord, latency_ms: 'not-a-number' },
+        { ...recallRecord, result_count: 'five' },
+      ],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed).toEqual({ records: [], omittedCount: 2 });
+  });
+
+  it('tolerates an unrecognized future kind as one omitted row, not a fatal rejection', () => {
+    const futureRecord = {
+      kind: 'graph_traverse',
+      agent: 'engineer',
+      agent_id: 'ag-3',
+      query: 'call graph',
+      at: '2026-07-18T00:00:02Z',
+    };
+    const parsed = parseSearchAuditResponse({
+      search_audit: [searchRecord, futureRecord],
+    });
+    expect(parsed).toEqual({ records: [searchRecord], omittedCount: 1 });
+  });
+
+  it('rejects a record missing a common field (agent) as one omitted row', () => {
     const { agent: _agent, ...rest } = searchRecord;
-    expect(isSearchAuditResponse({ search_audit: [rest] })).toBe(false);
+    const parsed = parseSearchAuditResponse({ search_audit: [rest, recallRecord] });
+    expect(parsed).toEqual({ records: [recallRecord], omittedCount: 1 });
   });
 
-  it('rejects a search record with a non-string lane', () => {
-    expect(
-      isSearchAuditResponse({ search_audit: [{ ...searchRecord, lane: 42 }] }),
-    ).toBe(false);
-  });
-
-  it('rejects a search record with a non-numeric latency_ms', () => {
-    expect(
-      isSearchAuditResponse({ search_audit: [{ ...searchRecord, latency_ms: '42' }] }),
-    ).toBe(false);
-  });
-
-  it('rejects a recall record with a non-numeric result_count', () => {
-    expect(
-      isSearchAuditResponse({
-        search_audit: [{ ...recallRecord, result_count: 'five' }],
-      }),
-    ).toBe(false);
+  it('preserves original ordering when filtering out invalid entries', () => {
+    const malformed = { ...recallRecord, injected_count: 'oops' };
+    const parsed = parseSearchAuditResponse({
+      search_audit: [searchRecord, malformed, recallRecord],
+    });
+    expect(parsed?.records.map((r) => r.agent_id)).toEqual(['ag-1', 'ag-2']);
   });
 });
 

--- a/crates/trusty-code-gui/ui/src/lib/search-audit.ts
+++ b/crates/trusty-code-gui/ui/src/lib/search-audit.ts
@@ -11,18 +11,32 @@
 // `as` assertion on a network-derived body. A `200` status is a promise from
 // THIS daemon version's handler, not from whatever actually answered the
 // socket — the shape must be verified before it becomes reactive state.
-// `isSearchAuditResponse` is the runtime shape guard, mirroring
+// `parseSearchAuditResponse` is the runtime shape guard, mirroring
 // `create-session.ts::isDirListing`'s per-field structural check.
 //
+// PARTIAL-VALIDITY note (issue #3111 MEDIUM, PR #3110 critic review): the
+// first cut of this guard (`isSearchAuditResponse`, a `body is
+// SearchAuditResponse` predicate) rejected the ENTIRE array when even one
+// record failed its per-kind check — a single malformed row, or a future
+// third `SearchAuditRecord` variant the client doesn't know about yet, took
+// down every known-good row with it. `parseSearchAuditResponse` replaces it:
+// only a TOP-LEVEL shape failure (body not an object, or `search_audit` not
+// an array — cases where there is no array to even iterate) returns `null`;
+// a record-level failure is filtered out of the returned subset and counted
+// in `omittedCount` instead, so `SearchTab.svelte` can render every row it
+// CAN trust plus an honest "N rows omitted" indicator, rather than an
+// all-or-nothing "audit unavailable".
+//
 // What: `SearchAuditRecord` (discriminated union on `kind`), the
-// `{search_audit: [...]}` response envelope, `isSearchAuditResponse` (the
-// shape guard `SearchTab.svelte` calls before trusting a fetched body), and
-// three pure per-record formatters (`auditLaneLabel`/`auditHitsLabel`/
-// `auditLatencyLabel`) — `Recall` records carry no `lane`/`latency_ms` (they
-// are not a lane search), so these normalize both variants onto AC-7.2's six
-// shared columns without fabricating fields neither the wire type nor the
-// daemon has. Reuses `transcript.ts::formatElapsed` for the "age" column
-// rather than re-deriving duration formatting.
+// `{search_audit: [...]}` response envelope, `parseSearchAuditResponse` (the
+// shape guard/subset-filter `SearchTab.svelte` calls before trusting a
+// fetched body), and three pure per-record formatters (`auditLaneLabel`/
+// `auditHitsLabel`/`auditLatencyLabel`) — `Recall` records carry no
+// `lane`/`latency_ms` (they are not a lane search), so these normalize both
+// variants onto AC-7.2's six shared columns without fabricating fields
+// neither the wire type nor the daemon has. Reuses
+// `transcript.ts::formatElapsed` for the "age" column rather than
+// re-deriving duration formatting.
 // Test: `search-audit.test.ts`.
 
 /** One `SearchAuditRecord::Search` row — mirrors `crate::events::SearchAuditRecord::Search`. */
@@ -58,7 +72,7 @@ export interface SearchAuditResponse {
 
 /**
  * Structural check for one `SearchAuditRecord` — used only through
- * {@link isSearchAuditResponse}, never called directly by the component.
+ * {@link parseSearchAuditResponse}, never called directly by the component.
  *
  * Why: same root pattern as `create-session.ts::isDirListing` — a record
  * whose `kind` doesn't match either known variant, or whose fields don't
@@ -69,8 +83,12 @@ export interface SearchAuditResponse {
  * `at`, all strings) is checked first; `kind === 'search'` additionally
  * requires `lane: string`, `hit_count: number | null`, `latency_ms: number`;
  * `kind === 'recall'` additionally requires `result_count`/`injected_count:
- * number`. Any other `kind` value fails.
- * Test: `search-audit.test.ts::isSearchAuditRecord-via-response`.
+ * number`. Any other `kind` value fails — including a hypothetical future
+ * third variant this client build doesn't know about yet, which is exactly
+ * the case {@link parseSearchAuditResponse} tolerates as "omit this one
+ * row", not "reject the whole response".
+ * Test: `search-audit.test.ts` (exercised indirectly through
+ * `parseSearchAuditResponse`).
  */
 function isValidRecord(value: unknown): value is SearchAuditRecord {
   if (typeof value !== 'object' || value === null) return false;
@@ -96,25 +114,56 @@ function isValidRecord(value: unknown): value is SearchAuditRecord {
   return false;
 }
 
+/** {@link parseSearchAuditResponse}'s result for a structurally-valid
+ * top-level body: the trustworthy subset of records, plus how many were
+ * dropped for failing {@link isValidRecord}. `omittedCount === 0` is the
+ * common case (every record valid); a positive count means `SearchTab.svelte`
+ * should render `records` plus a visible "N rows omitted" indicator, never
+ * silently drop them with no trace. */
+export interface ParsedSearchAudit {
+  records: SearchAuditRecord[];
+  omittedCount: number;
+}
+
 /**
- * Runtime shape guard for a `GET /sessions/{id}/search-audit` 200 response
- * body.
+ * Runtime shape guard AND subset-filter for a `GET /sessions/{id}/search-audit`
+ * 200 response body.
  *
  * Why: PR #3103 review finding (HIGH, `isDirListing`) established the house
  * rule — a bare `as SearchAuditResponse` assertion lets a malformed body
  * (schema drift, an interposed proxy) flow straight into reactive state and
- * throw once the template dereferences a missing field. `SearchTab.svelte`
- * must degrade to an error state instead, never throw from its `$effect`.
- * What: `body.search_audit` must be an array whose every element passes
- * {@link isValidRecord}. Malformed input (not an object, missing/non-array
- * `search_audit`, or any element failing its per-kind check) returns
- * `false`.
- * Test: `search-audit.test.ts::isSearchAuditResponse`.
+ * throw once the template dereferences a missing field. The first version of
+ * this guard (`isSearchAuditResponse`, issue #3111 MEDIUM) over-corrected:
+ * it rejected the ENTIRE array when even one record failed validation,
+ * hiding every known-good row behind an all-or-nothing "audit unavailable"
+ * just because one row (or a future third `SearchAuditRecord` variant) was
+ * unrecognized. A single bad row is not evidence the WHOLE response is
+ * untrustworthy — only a broken top-level shape (not an object, or
+ * `search_audit` isn't even an array to iterate) is.
+ * What: returns `null` only for a top-level shape failure (not an object, or
+ * `search_audit` missing/non-array — nothing to filter). Otherwise returns
+ * `{records, omittedCount}`: `records` is `search_audit` filtered to entries
+ * passing {@link isValidRecord} (in original order — filtering never
+ * reorders), `omittedCount` is how many entries were dropped. An empty
+ * `search_audit` array is valid input and returns `{records: [], omittedCount: 0}`,
+ * not `null` — there is a real, empty list, not a shape failure.
+ * Test: `search-audit.test.ts::parseSearchAuditResponse`.
  */
-export function isSearchAuditResponse(body: unknown): body is SearchAuditResponse {
-  if (typeof body !== 'object' || body === null) return false;
+export function parseSearchAuditResponse(body: unknown): ParsedSearchAudit | null {
+  if (typeof body !== 'object' || body === null) return null;
   const b = body as Record<string, unknown>;
-  return Array.isArray(b.search_audit) && b.search_audit.every(isValidRecord);
+  if (!Array.isArray(b.search_audit)) return null;
+
+  const records: SearchAuditRecord[] = [];
+  let omittedCount = 0;
+  for (const item of b.search_audit) {
+    if (isValidRecord(item)) {
+      records.push(item);
+    } else {
+      omittedCount++;
+    }
+  }
+  return { records, omittedCount };
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses the non-blocking findings from the code-critic APPROVE on PR #3110
(issue #3111):

1. **MEDIUM — all-or-nothing shape guard.** `lib/search-audit.ts`'s
   `isSearchAuditResponse` (a `body is SearchAuditResponse` predicate)
   rejected the ENTIRE `search_audit` array when even one record failed
   validation — a single malformed row, or a future third
   `SearchAuditRecord` variant this client build doesn't recognize yet, took
   every known-good row down with it into an "audit unavailable" wall.
   Replaced with `parseSearchAuditResponse`, which returns `null` only for a
   genuine **top-level** shape failure (body not an object, or
   `search_audit` not even an array), and otherwise returns
   `{records, omittedCount}` — `search_audit` filtered to the subset passing
   the existing per-record structural check, plus how many entries were
   dropped. `SearchTab.svelte` now renders the trustworthy rows plus a
   visible "N rows omitted (unrecognized record shape)" notice when
   `omittedCount > 0`, rather than the previous wholesale rejection.
2. **LOW — recovery-path test gap.** Added a fake-timer-driven
   `SearchTab.test.ts` case: `HTTP 500` on poll 1 (asserts "audit
   unavailable"), then `vi.advanceTimersByTimeAsync(5000)` (`POLL_MS`)
   triggers poll 2, which returns real rows — asserts the error row is gone
   and the recovered query renders, proving `auditError` clears and
   `auditRows` repopulate once the daemon recovers.
3. **LOW — duplicate `### Added` CHANGELOG heading.** Already fixed as part
   of PR #3110's `origin/main` rebase (two consecutive `### Added` blocks
   under the same `## [Unreleased]` were merged into one) — no additional
   change needed here.

Closes #3111

## Test coverage added

- `search-audit.test.ts`: all-valid, some-invalid (subset + omitted count),
  all-invalid (empty subset, non-zero count, still not `null` — a shape
  failure and an all-invalid-but-structurally-real array are different
  things), an unrecognized future `kind` tolerated as one omitted row rather
  than fatal, and ordering preservation when filtering.
- `SearchTab.test.ts`: a partially-valid-payload DOM test (one valid row
  renders alongside a "2 rows omitted" indicator, never "audit
  unavailable"), plus the fake-timer recovery test described above.

## Files

- `crates/trusty-code-gui/ui/src/lib/search-audit.ts`
- `crates/trusty-code-gui/ui/src/lib/search-audit.test.ts`
- `crates/trusty-code-gui/ui/src/components/SearchTab.svelte`
- `crates/trusty-code-gui/ui/src/components/SearchTab.test.ts`
- `crates/trusty-code-gui/CHANGELOG.md`

## Quality gate (raw tails)

`pnpm test` (vitest, jsdom):
```
 Test Files  9 passed (9)
      Tests  89 passed (89)
```

`pnpm build`:
```
✓ 123 modules transformed.
✓ built in 679ms
```

`cargo fmt --check`: clean (exit 0, no diff)

`SKIP_UI_BUILD=1 cargo check -p trusty-code-gui`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.36s
```

`SKIP_UI_BUILD=1 cargo clippy -p trusty-code-gui --all-targets -- -D warnings`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.93s
```
(zero warnings)

`bash scripts/check_line_cap.sh`:
```
line-cap: 10 allowlisted, 0 violations — OK.
```

## Test plan

- [x] `pnpm test` — 89/89 passing
- [x] `pnpm build` — production build succeeds
- [x] `cargo fmt --check` / `cargo check -p trusty-code-gui` /
      `cargo clippy -p trusty-code-gui --all-targets -- -D warnings` — all clean
- [x] `bash scripts/check_line_cap.sh` — no new/grown oversized files

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools