### PR TITLE
docs(trusty-mpm): in-flight issue/PR progress updates as standard PM workflow

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -29,7 +29,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Documentation
 
-- in-flight issue/PR progress updates as standard PM workflow convention: bug diagnoses at triage time, progress comments at meaningful state changes, PR body freshness, and completion evidence (closes #3149) ([#TBD](https://github.com/bobmatnyc/trusty-tools/pull/TBD))
+- in-flight issue/PR progress updates as standard PM workflow convention: bug diagnoses at triage time, progress comments at meaningful state changes, PR body freshness, and completion evidence (closes #3149) ([#3151](https://github.com/bobmatnyc/trusty-tools/pull/3151))
 - long-wait protocol — disarm monitors on goal completion ([#2960](https://github.com/bobmatnyc/trusty-tools/pull/2960)) ([`e193414`](https://github.com/bobmatnyc/trusty-tools/commit/e1934140d38d6d9b847fef07676f29277683b220))
 
 ---

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -29,6 +29,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Documentation
 
+- in-flight issue/PR progress updates as standard PM workflow convention: bug diagnoses at triage time, progress comments at meaningful state changes, PR body freshness, and completion evidence (closes #3149) ([#TBD](https://github.com/bobmatnyc/trusty-tools/pull/TBD))
 - long-wait protocol — disarm monitors on goal completion ([#2960](https://github.com/bobmatnyc/trusty-tools/pull/2960)) ([`e193414`](https://github.com/bobmatnyc/trusty-tools/commit/e1934140d38d6d9b847fef07676f29277683b220))
 
 ---

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -73,14 +73,34 @@ session" --color 8250df`). This is multi-harness support — the assignee +
 When a ticket/issue reference is detected (an ID pattern, a URL, "work on
 issue #123"), the PM executes:
 
-1. **Work start** — delegate: transition to in-progress, comment "work
-   started."
-2. **Each phase** — delegate a progress comment with deliverables and
-   links to commits/PRs.
+1. **Work start** — delegate: transition to in-progress, comment with initial
+   findings (for bugs: root cause or hypothesis; for features: brief scope
+   summary) and any user workaround. Surfacing early findings to stakeholders
+   from the moment work begins is standard practice when tracking artifacts exist.
+
+2. **Each phase** — delegate a progress comment at meaningful state transitions
+   (diagnosis confirmed, fix pushed, review verdict received, blocked/waiting).
+   Not per-poll spam — only when work state materially changes. Include
+   deliverables and links to commits/PRs.
+
 3. **Work complete** — delegate: transition to done/closed, comprehensive
-   completion comment, link the PR.
+   completion comment with fix version/SHA and verification evidence (test
+   output, deployment status, etc.), link the merged PR.
+
 4. **Blockers** — delegate: transition to blocked, comment with blocker
-   detail and impact.
+   detail, impact, and unblock criteria.
+
+**In-flight updates are standard practice.** When tracking artifacts are in
+use, stakeholders follow issues from open through closure; visibility into
+in-progress work is as important as the final result. Projects without formal
+tracking workflows are not subject to this convention.
+
+**Attribution footer**: every issue/PR comment ends with:
+`🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools`
+
+**PR body freshness**: if scope or claims change mid-flight (e.g., a reviewer
+finding shifts what the diff covers), update the PR body immediately rather
+than leaving stale assertions.
 
 Every delegation in this chain includes the ticket/issue context so
 downstream agents (Engineer, QA) know the work is ticket-driven and can

--- a/crates/trusty-mpm/src/assets/sm_instructions/SM_WORKFLOW.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/SM_WORKFLOW.md
@@ -67,6 +67,29 @@ captured from session s-abc123"), or state the actual unverified status ("the
 session is still running the test suite; not yet verified"). If you have no
 evidence, the honest report is *not done* -- say so.
 
+## In-Flight Work Commentary (When Tracking Artifacts Exist)
+
+When the project's workflow includes GitHub issues, PRs, or another tracking
+system, work is visible to stakeholders from the moment it starts. Post
+meaningful progress updates on the tracking artifact at state transitions, not
+only at completion — this is part of the observation and delivery chain:
+
+**Progress comment triggers (meaningful transitions only — not per-poll spam):**
+- **Work starts**: brief root-cause hypothesis (for bugs) or diagnosis confirmed
+- **Fix in progress**: the fix shape (e.g., "hotfix release 0.34.1", "backport to v2.8") and any workaround
+- **State changes**: push verified, review feedback received, blocked/waiting details, PR ready
+- **Completion**: fix version/SHA, verification evidence, merged/released status
+
+**Attribution**: end all issue/PR comments with:
+`🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools`
+
+**PR body truthfulness**: if scope or claims change mid-flight (e.g., a finding
+shifts what the diff covers), update the PR body rather than leaving stale claims.
+
+This is standard practice when tracking artifacts exist; projects without formal
+tracking workflows are not subject to this convention. When present, visibility
+into in-progress state is as important as the final result.
+
 ## Triage & summarization
 
 Between requests, continuously summarize fleet state for the operator: one crisp

--- a/crates/trusty-mpm/src/assets/sm_instructions/SM_WORKFLOW.md
+++ b/crates/trusty-mpm/src/assets/sm_instructions/SM_WORKFLOW.md
@@ -67,28 +67,33 @@ captured from session s-abc123"), or state the actual unverified status ("the
 session is still running the test suite; not yet verified"). If you have no
 evidence, the honest report is *not done* -- say so.
 
-## In-Flight Work Commentary (When Tracking Artifacts Exist)
+## In-Flight Work Commentary (SM Delegation to Launched Sessions)
 
-When the project's workflow includes GitHub issues, PRs, or another tracking
-system, work is visible to stakeholders from the moment it starts. Post
-meaningful progress updates on the tracking artifact at state transitions, not
-only at completion — this is part of the observation and delivery chain:
+When a task references a tracking artifact (GitHub issue, PR, or other system),
+the SM recognizes this during **DECOMPOSE** and bakes the in-flight-commentary
+convention into the launched session's prompt via `sessions.launch(prompt=...)`.
+The SM does not post updates itself (that would violate its verb-surface boundary
+in SM_TOOLS); instead, the **session's own PM** is responsible for in-flight
+visibility.
 
-**Progress comment triggers (meaningful transitions only — not per-poll spam):**
-- **Work starts**: brief root-cause hypothesis (for bugs) or diagnosis confirmed
-- **Fix in progress**: the fix shape (e.g., "hotfix release 0.34.1", "backport to v2.8") and any workaround
-- **State changes**: push verified, review feedback received, blocked/waiting details, PR ready
-- **Completion**: fix version/SHA, verification evidence, merged/released status
+**SM's role:**
+1. Detect tracking artifact references in the task description during decompose
+2. Inject the in-flight-commentary convention into the session prompt (point to
+   `tm-ticketing.md` under "Ticket-Driven Development Protocol")
+3. Optionally remind via `sessions.send()` if monitoring a task — e.g., "This
+   issue is public; post a progress comment on the diagnosis when confirmed"
 
-**Attribution**: end all issue/PR comments with:
-`🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools`
+**Session PM's responsibility (delegated, not SM's direct action):**
+- Post progress comments at work start (root cause/scope), meaningful state
+  transitions (diagnosis, fix pushed, review feedback, blocked), and completion
+  (version/SHA, evidence)
+- Use attribution footer: `🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools`
+- Keep PR bodies truthful (update if scope changes mid-flight)
 
-**PR body truthfulness**: if scope or claims change mid-flight (e.g., a finding
-shifts what the diff covers), update the PR body rather than leaving stale claims.
-
-This is standard practice when tracking artifacts exist; projects without formal
-tracking workflows are not subject to this convention. When present, visibility
-into in-progress state is as important as the final result.
+This standard practice applies when tracking artifacts exist; projects without
+formal tracking workflows are exempt. When present, visibility into in-progress
+state is the session PM's responsibility, exercised via the same issue/PR tools
+the session would use for any other workflow operation.
 
 ## Triage & summarization
 


### PR DESCRIPTION
## Summary

Establishes in-flight progress commentary as a standard part of the trusty-mpm PM workflow when projects include tracking artifacts (GitHub issues, PRs, or similar systems). The convention is explicitly **opt-in/conditional**: applies only to projects with formal tracking workflows; projects without issue/PR tracking are not subject to this requirement.

Defines how visibility is achieved in the workflow:
- **SM role** (DECOMPOSE → LAUNCH): Detects tracking artifacts in task description; injects in-flight-commentary convention into session prompt; optionally reminds session via `sessions.send()` about public visibility
- **Session PM role** (the actual agent work): Posts progress updates at work start (root cause/scope), meaningful state transitions (diagnosis confirmed, fix pushed, review feedback, blocked), and completion (version/SHA, evidence)

Updates are not spam — only posted at materially meaningful state changes, respecting existing no-short-interval-updates discipline.

## Changes (corrected per code-critic feedback)

### SM_WORKFLOW.md
New section "In-Flight Work Commentary (SM Delegation to Launched Sessions)" clarifying the SM/session PM boundary:
- SM does NOT post updates directly (violates SM verb-surface boundary in SM_TOOLS.md/BASE_SM.md)
- SM injects convention into `sessions.launch(prompt=...)` during DECOMPOSE
- Session's PM is responsible for stakeholder-facing issue/PR comments
- Includes examples: SM can use `sessions.send()` reminders, points to `tm-ticketing.md` as authoritative reference
- Maintains conditional/opt-in and meaningful-transitions framing

### tm-ticketing.md
Expands "Ticket-Driven Development Protocol (TkDD)" section with:
- Detailed phase-by-phase guidance on work-start findings, in-phase progress comments, completion comments with evidence, and blocker details
- Emphasis that visibility into in-progress state is as important as final results (when artifacts are in use)
- Attribution footer and PR body freshness standards
- Conditional framing: standard practice when tracking artifacts are present

### CHANGELOG.md
Adds documentation entry under [Unreleased] → ### Documentation closing issue #3149; corrected PR link from TBD to #3151.

## Design Direction (Bob, 2026-07-19)

> "tm and tcode should share workflow models, though ticket/pr commenting are not mandatory if the user does not include them in their workflow."

This PR establishes the convention in trusty-mpm. Companion issue #3150 filed to align trusty-code's workflow understanding with this shared direction.

## Verification

- [x] `bash scripts/check_line_cap.sh` passes (no SLOC violations)
- [x] `bash scripts/check_sld.sh` passes (no spec-linked doc violations)
- [x] SM_WORKFLOW.md complies with SM verb-surface boundaries (sessions.*, goals.*, memory.* only)
- [x] Framework assets are semantically complete and internally consistent
- [x] Conditional/opt-in language is clear throughout
- [x] Attribution footer and PR body freshness standards documented
- [x] SM delegation flow clearly articulated: DECOMPOSE → inject convention → LAUNCH → session PM executes

Closes #3149
See also #3150 (trusty-code alignment)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools