### PR TITLE
fix(trusty-code-gui): Enter-to-submit, system light/dark theming, picker adjacency

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -10,6 +10,62 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- GUI smoke-test UX feedback (Bob, 2026-07-18): three fixes to
+  `CreateSessionForm.svelte`/`HealthPanel.svelte` and the global theme.
+  - **#3132 Enter-to-submit.** The task `<textarea>` had no keyboard submit
+    path — click was the only way in. `docs/specs/trusty-code-harness-ui.md`
+    specifies no submit-key convention, so this follows the universal
+    textarea pattern: `Enter` (without `Shift`, not mid-IME-composition)
+    calls `preventDefault()` and submits; `Shift+Enter` is left untouched,
+    falling through to the textarea's own newline-insertion default. The
+    existing `canSubmitCreate` no-double-submit guard is unchanged — the new
+    `handleTaskKeydown` handler defers to the same `submit()` the button
+    already called, adding no separate gate. Covered by three new
+    `CreateSessionForm.test.ts` cases: Enter submits (and a rapid second
+    Enter while the first is in flight produces no second `POST`),
+    Shift+Enter never calls `preventDefault()` or submits, and a non-Enter
+    key is a no-op.
+  - **#3133 light + dark themes following system appearance.** Every
+    `trusty-*`/`status-*` Tailwind color token (`tailwind.config.js`) now
+    resolves to `rgb(var(--color-*) / <alpha-value>)` instead of a
+    hardcoded hex literal; the actual light (default) and
+    `@media (prefers-color-scheme: dark)` (override) values live in
+    `src/app.css`. No manual toggle — theming purely follows the OS
+    setting, live, including inside the Tauri webview (WebKit re-evaluates
+    the media query on the native "Appearance changed" notification with no
+    reload needed). The previous `darkMode: 'class'` config was dead
+    weight — nothing in this codebase ever added a `.dark` class to
+    `<html>`, so its `html:not(.dark)` override in `app.css` silently won
+    every render regardless of the OS setting. The CSS-variable values are
+    space-separated RGB triples (`"15 23 42"`, not `"#0f172a"`) — required
+    by the `rgb(var(...) / <alpha-value>)` format, the only way Tailwind
+    can still generate the `bg-status-ok/15`/`text-trusty-text/60`-style
+    opacity modifiers used throughout every component; a bare `var(--x)`
+    reference (this PR's first cut) compiles the base utility fine but
+    silently produces NO rule at all for any opacity-modified one. The
+    theming audit also caught one real hardcoded color outside the token
+    system: `HealthPanel.svelte`'s JSON payload `<pre>` block used the
+    Tailwind built-in near-black shade (which never changes with
+    `prefers-color-scheme`) instead of a themed token — swapped for the
+    `trusty-border` token at reduced opacity. New `lib/theme.test.ts`
+    covers the token format, both themes' CSS-variable values (and that
+    dark genuinely differs from light), a real `postcss`/`tailwindcss`
+    compile check proving opacity-modified utilities produce a rule (the
+    actual regression a bare `var()` causes), and a component-hygiene scan
+    for `<style>` blocks, hardcoded inline-style colors, and raw
+    (non-themed) Tailwind palette utilities.
+  - **#3134 picker placement.** The directory listing's `use` button sat at
+    the row's far right (`flex-1` on the name button + `justify-between` on
+    the row stretched the name button to fill the available width), leaving
+    a wide, disorienting gap between a short directory name and the control
+    that binds it. The name button is now width-bounded
+    (`min-w-0 max-w-[65%]`, `truncate` still applies) rather than
+    flex-stretched, so with `justify-between` removed the row's default
+    left-packed flex layout puts `use` immediately after the name. Covered
+    by a new `CreateSessionForm.test.ts` structural assertion: the `use`
+    button must be the name button's next DOM sibling, and neither the name
+    button nor the row may carry the `flex-1`/`justify-between` classes that
+    caused the separation.
 - Create-session flow response-shape hardening (PR #3103 review findings):
   `GET /fs` 200 bodies and `POST /sessions` 201 bodies are now validated at
   runtime (`lib/create-session.ts::isDirListing` / `extractSessionId`)

--- a/crates/trusty-code-gui/ui/src/app.css
+++ b/crates/trusty-code-gui/ui/src/app.css
@@ -2,9 +2,56 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Base, dark-first styling — mirrors crates/trusty-mpm-gui/ui/src/app.css. */
+/* Why: issue #3133 — light + dark themes that follow the OS appearance
+ * live, with no manual toggle. Every themed color the components use
+ * (via `tailwind.config.js`'s `trusty-*`/`status-*` tokens) reads one of
+ * these custom properties, so this is the SINGLE place either theme's
+ * actual values live.
+ * What: each `--color-*` value is a SPACE-SEPARATED RGB triple (`"R G B"`,
+ * not `"#rrggbb"`) — required by `tailwind.config.js`'s
+ * `rgb(var(--color-*) / <alpha-value>)` format, the only way Tailwind can
+ * still generate opacity-modified utilities (`bg-status-ok/15`,
+ * `text-trusty-text/60`, used throughout every component) for a
+ * CSS-variable-backed color. `:root` sets the light theme as the default
+ * (`color-scheme: light dark` tells the UA both are supported, with no
+ * assumption about which is "native"); `@media (prefers-color-scheme:
+ * dark)` overrides every variable for dark. This is *system-following
+ * only* — there is no persisted preference and no manual light/dark switch
+ * (explicitly out of scope for issue #3133); the values simply track the
+ * OS setting live, including inside the Tauri webview: WebKit re-evaluates
+ * `prefers-color-scheme` on the native "Appearance changed" notification
+ * without a reload, the same mechanism a browser tab uses.
+ * Test: `lib/theme.test.ts` pins that both blocks exist, that the dark
+ * override actually differs from the light default (real theming, not a
+ * no-op), and that an opacity-modified utility class actually compiles a
+ * rule in the built CSS (regression guard — a bare `var()` value passes
+ * silently with zero opacity rules generated, which is exactly the bug this
+ * RGB-triple format fixes). Manual verification: toggle System Settings >
+ * Appearance while `pnpm tauri dev` is running and confirm the window
+ * recolors. */
 :root {
-  color-scheme: dark;
+  color-scheme: light dark;
+
+  --color-primary: 79 70 229; /* indigo-600 (#4f46e5) */
+  --color-surface: 255 255 255; /* white */
+  --color-border: 226 232 240; /* slate-200 */
+  --color-text: 15 23 42; /* slate-900 */
+  --color-status-ok: 22 163 74; /* green-600 — darker for contrast on a light surface */
+  --color-status-error: 220 38 38; /* red-600 */
+  --color-status-warn: 217 119 6; /* amber-600 */
+  --color-status-neutral: 100 116 139; /* slate-500 */
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-surface: 15 23 42; /* slate-900 */
+    --color-border: 51 65 85; /* slate-700 */
+    --color-text: 241 245 249; /* slate-100 */
+    --color-status-ok: 34 197 94; /* green-500 — brighter for contrast on a dark surface */
+    --color-status-error: 239 68 68; /* red-500 */
+    --color-status-warn: 245 158 11; /* amber-500 */
+    --color-status-neutral: 100 116 139; /* unchanged — already mid-contrast both ways */
+  }
 }
 
 html,
@@ -15,10 +62,6 @@ body {
 
 body {
   @apply bg-trusty-surface text-trusty-text font-sans antialiased;
-}
-
-html:not(.dark) body {
-  @apply bg-trusty-surface-light text-trusty-text-light;
 }
 
 #app {

--- a/crates/trusty-code-gui/ui/src/components/CreateSessionForm.svelte
+++ b/crates/trusty-code-gui/ui/src/components/CreateSessionForm.svelte
@@ -20,7 +20,11 @@
   // comes along for free, feeding DOC-39 §4.2's binding-state label).
   // Leaving the selection cleared (or clicking `clear`) submits projectless
   // (`project` omitted from the body) — AC-2.1 mandates this MUST be
-  // supported, not treated as an error state.
+  // supported, not treated as an error state. The row's `use` button sits
+  // directly adjacent to the directory name (issue #3134, Bob's smoke-test
+  // feedback: the prior `flex-1`/`justify-between` layout stretched the
+  // name button to fill the row and stranded `use` at the far right, wide
+  // gap included) — see the row markup's inline comment.
   //
   // What: Two independent `$effect`s, same `AbortController`-per-lifetime
   // shape `SessionMonitor.svelte`/`StatusBar.svelte` already establish: one
@@ -45,9 +49,17 @@
   // The session itself becomes visible through the existing
   // `GET /sessions` pollers (`StatusBar`/`SessionMonitor`'s `pickActiveSession`)
   // on their next tick — this component does not need its own poll.
+  // Enter-to-submit (issue #3132, Bob's smoke-test feedback: the form had
+  // no keyboard submit path — click was the only way in) is handled by
+  // `handleTaskKeydown` on the task `<textarea>`: plain `Enter` submits,
+  // `Shift+Enter` inserts a newline (the textarea's own default behavior,
+  // untouched) — see that function's own doc comment for the full
+  // rationale and why no separate double-submit guard was needed.
+  //
   // Test: `create-session.test.ts` covers the pure gating/body-construction
   // logic; `CreateSessionForm.test.ts` covers the form's disabled/enabled
-  // submit states, the no-double-submit guard, and picker navigation.
+  // submit states, the no-double-submit guard (click AND rapid Enter),
+  // Enter-vs-Shift+Enter keyboard behavior, and picker navigation.
   import { apiBase } from '../lib/api-config';
   import {
     bindingLabel,
@@ -139,6 +151,35 @@
 
   function clearSelection() {
     selectedProject = null;
+  }
+
+  /**
+   * Task-field `keydown` handler — issue #3132.
+   *
+   * Why: the form had no keyboard submit path at all — clicking "create
+   * session" was the only way in, which Bob's smoke test flagged as wrong
+   * UX (`docs/specs/trusty-code-harness-ui.md` has no submit-key
+   * convention to defer to, so this follows the universal textarea
+   * pattern: Enter submits, Shift+Enter inserts a newline). A plain
+   * `<textarea>`'s native behavior is to insert a newline on every Enter
+   * (never auto-submit, unlike a single-line `<input>` in a `<form>`), so
+   * Shift+Enter needs no handling at all here — only the plain-Enter case
+   * needs to be intercepted and redirected to `submit()`.
+   * What: `Enter` without `Shift` (and not mid-IME-composition) calls
+   * `preventDefault()` — so no newline is inserted — then defers to the
+   * existing `submit()`, which already re-checks `canSubmitCreate` at its
+   * top; this handler adds no separate guard, so the no-double-submit
+   * semantics are identical to the button's `disabled` binding. `Shift+Enter`
+   * (or any other key) falls through untouched, letting the textarea's
+   * default newline-insertion behavior apply.
+   * Test: `CreateSessionForm.test.ts` — Enter submits, Shift+Enter does not
+   * (and is never prevented), and a second rapid Enter while the first
+   * submit is in flight produces no second `POST`.
+   */
+  function handleTaskKeydown(e: KeyboardEvent) {
+    if (e.key !== 'Enter' || e.shiftKey || e.isComposing) return;
+    e.preventDefault();
+    void submit();
   }
 
   async function submit() {
@@ -235,10 +276,23 @@
 
       <ul class="mt-2 max-h-40 space-y-1 overflow-y-auto text-xs">
         {#each dirEntries as entry (entry.path)}
-          <li class="flex items-center justify-between gap-2 rounded px-1.5 py-1 hover:bg-trusty-border/10">
+          <!-- issue #3134: the "use" (picker) button sits DIRECTLY adjacent
+               to the directory name it acts on. The prior markup put
+               `flex-1` on the name button and `justify-between` on the
+               row, which stretched the name button to fill the row and
+               shoved "use" to the row's far right — for a short name that
+               left a wide, disorienting gap between the name and the
+               control that binds it. `min-w-0 max-w-[65%]` still bounds
+               the name button's width so `truncate` keeps working on long
+               names, but without `flex-1`/`justify-between` the row's
+               default `flex items-center` packs both buttons together at
+               the left, so "use" always immediately follows the name
+               (any leftover row width is simply unused space at the end,
+               not a gap in the middle). -->
+          <li class="flex items-center gap-2 rounded px-1.5 py-1 hover:bg-trusty-border/10">
             <button
               type="button"
-              class="flex flex-1 items-center gap-1.5 truncate text-left"
+              class="flex min-w-0 max-w-[65%] items-center gap-1.5 truncate text-left"
               onclick={() => openEntry(entry)}
             >
               <span class="truncate">{entry.name}</span>
@@ -282,8 +336,9 @@
     <textarea
       id="new-session-task"
       bind:value={task}
+      onkeydown={handleTaskKeydown}
       rows="3"
-      placeholder="Describe what this session should do…"
+      placeholder="Describe what this session should do… (Enter to submit, Shift+Enter for a new line)"
       class="mt-1 w-full rounded border border-trusty-border bg-trusty-surface/40 p-2 text-xs text-trusty-text"
     ></textarea>
   </div>

--- a/crates/trusty-code-gui/ui/src/components/CreateSessionForm.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/CreateSessionForm.test.ts
@@ -246,6 +246,160 @@ describe('CreateSessionForm submit gating', () => {
     expect(taskField().value).toBe(''); // 201 is authoritative — form still clears
   });
 
+  it('issue #3132: Enter (no Shift) submits the task field, and a rapid second Enter while in flight causes no second POST', async () => {
+    let postCount = 0;
+    let resolveCreate: ((value: Response) => void) | null = null;
+    const createPromise = new Promise<Response>((resolve) => {
+      resolveCreate = resolve;
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          return { ok: true, status: 200, json: async () => HOME_LISTING } as Response;
+        }
+        if (url.endsWith('/sessions') && init?.method === 'POST') {
+          postCount += 1;
+          return createPromise;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    taskField().value = 'ship the feature';
+    taskField().dispatchEvent(new Event('input', { bubbles: true }));
+    await waitFor(() => !submitButton().disabled);
+
+    const firstEnter = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    taskField().dispatchEvent(firstEnter);
+
+    // Intercepted to submit rather than insert a newline.
+    expect(firstEnter.defaultPrevented).toBe(true);
+    await waitFor(() => postCount === 1 && submitButton().disabled);
+
+    // A rapid second Enter while the first submit is still in flight must
+    // be a no-op — `submit()`'s own `canSubmitCreate` guard (submitPhase
+    // already 'submitting') rejects it before a second fetch is ever made,
+    // same guard the button's `disabled` binding relies on.
+    const secondEnter = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    taskField().dispatchEvent(secondEnter);
+    expect(postCount).toBe(1);
+
+    resolveCreate!({
+      ok: true,
+      status: 201,
+      json: async () => ({ id: 'sess-abc12345', status: 'running' }),
+    } as Response);
+
+    await waitFor(() => target.textContent?.includes('session created') ?? false);
+    expect(postCount).toBe(1);
+  });
+
+  it('issue #3132: Shift+Enter does not submit, letting the textarea insert a newline', async () => {
+    let postCount = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          return { ok: true, status: 200, json: async () => HOME_LISTING } as Response;
+        }
+        if (url.endsWith('/sessions') && init?.method === 'POST') {
+          postCount += 1;
+          return { ok: true, status: 201, json: async () => ({ id: 'sess-abc' }) } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    taskField().value = 'line one';
+    taskField().dispatchEvent(new Event('input', { bubbles: true }));
+    await waitFor(() => !submitButton().disabled);
+
+    const shiftEnter = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    taskField().dispatchEvent(shiftEnter);
+
+    // Never prevented — the textarea's default newline-insertion behavior
+    // must be left alone for Shift+Enter.
+    expect(shiftEnter.defaultPrevented).toBe(false);
+    expect(postCount).toBe(0);
+    expect(submitButton().disabled).toBe(false); // form untouched, still submittable by other means
+  });
+
+  it('issue #3132: a non-Enter key never triggers submit or preventDefault', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          return { ok: true, status: 200, json: async () => HOME_LISTING } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    const aKey = new KeyboardEvent('keydown', { key: 'a', bubbles: true, cancelable: true });
+    taskField().dispatchEvent(aKey);
+    expect(aKey.defaultPrevented).toBe(false);
+  });
+
+  it('issue #3134: the picker "use" button is immediately adjacent to the directory-name button, not pushed to the far right', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/fs')) {
+          return { ok: true, status: 200, json: async () => HOME_LISTING } as Response;
+        }
+        throw new Error(`unexpected fetch: ${url}`);
+      }),
+    );
+
+    instance = mount(CreateSessionForm, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    const nameButton = Array.from(target.querySelectorAll('li button')).find((b) =>
+      b.textContent?.includes('acme-api'),
+    ) as HTMLButtonElement;
+    expect(nameButton).toBeTruthy();
+
+    // Structural adjacency: the "use" button must be the name button's very
+    // next element sibling within the row, with nothing spacing them apart.
+    const nextSibling = nameButton.nextElementSibling as HTMLButtonElement | null;
+    expect(nextSibling?.textContent?.trim()).toBe('use');
+
+    // The layout classes that caused the far-right separation (stretching
+    // the name button to fill the row, then justifying the row's content
+    // apart) must be gone — regression guard for issue #3134.
+    expect(nameButton.className).not.toMatch(/\bflex-1\b/);
+    const row = nameButton.closest('li');
+    expect(row?.className).not.toMatch(/justify-between/);
+  });
+
   it('renders daemon-unreachable when the initial GET /fs fails', async () => {
     vi.stubGlobal(
       'fetch',

--- a/crates/trusty-code-gui/ui/src/components/HealthPanel.svelte
+++ b/crates/trusty-code-gui/ui/src/components/HealthPanel.svelte
@@ -9,6 +9,13 @@
   // What: On mount (and every `pollMs`), fetches `${base}/health` and renders
   // connected/disconnected plus the raw JSON payload
   // (`{server, version, status}` — see `crates/trusty-code/src/serve/methods.rs`).
+  // The payload's `<pre>` block uses the themed `trusty-border` token at
+  // 20% opacity rather than the raw, non-themed Tailwind near-black it
+  // previously hardcoded at 30% opacity (issue #3133 theming audit) — that
+  // built-in shade never changes with `prefers-color-scheme`, so on a
+  // light theme the code block would have stayed a dark box regardless of
+  // the surrounding page; the themed border token tints appropriately in
+  // both schemes.
   // Test: With `tcode serve --http` running, the panel shows "Connected" and
   // the payload; with it stopped, "Disconnected" and the error message.
   import { onDestroy, onMount } from 'svelte';
@@ -68,7 +75,7 @@
   <p class="mt-1 text-xs text-trusty-text/60">{base}</p>
 
   {#if connected}
-    <pre class="mt-3 overflow-x-auto rounded bg-black/30 p-2 text-xs text-trusty-text">{JSON.stringify(
+    <pre class="mt-3 overflow-x-auto rounded bg-trusty-border/20 p-2 text-xs text-trusty-text">{JSON.stringify(
         payload,
         null,
         2,

--- a/crates/trusty-code-gui/ui/src/lib/theme.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/theme.test.ts
@@ -1,0 +1,199 @@
+// Why: issue #3133 — light + dark themes following `prefers-color-scheme`,
+// with no manual toggle. The actual theming lives in two places:
+// `tailwind.config.js` (maps `trusty-*`/`status-*` utility classes onto CSS
+// custom properties) and `src/app.css` (defines the light-default `:root`
+// values and the `@media (prefers-color-scheme: dark)` override). A
+// regression here — a token reverting to a hardcoded hex literal, or the
+// dark block silently matching the light one — would be invisible in a
+// normal component test (there's no DOM assertion that exercises a media
+// query), so this file asserts the actual config/CSS content directly.
+// What: `tailwindConfig` colors must all be `rgb(var(--color-*) / <alpha-value>)`
+// references — NOT a bare `var(--color-*)`, which silently compiles zero
+// opacity-modifier rules (a regression this file specifically pins, since
+// every component relies on `bg-status-ok/15`-style modifiers). `app.css`
+// must define both a `:root` block and a `prefers-color-scheme: dark`
+// override for every variable Tailwind references, with the dark values
+// genuinely differing from light for the primary surface/text/border
+// tokens. Also scans every component `.svelte` file for a `<style>` block
+// or an inline `style="..."` carrying a hardcoded color literal, and for
+// any raw (non-themed) Tailwind palette utility — this codebase has none
+// today (all theming flows through the `trusty-*`/`status-*` tokens), and
+// this guards that staying true.
+// Test: this file. Manual verification: toggle System Settings > Appearance
+// while `pnpm tauri dev` is running and confirm the window recolors live.
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postcss from 'postcss';
+import tailwindcss from 'tailwindcss';
+import { describe, expect, it } from 'vitest';
+import tailwindConfig from '../../tailwind.config.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const uiRoot = resolve(__dirname, '../..');
+const appCss = readFileSync(resolve(uiRoot, 'src/app.css'), 'utf-8');
+
+function colorTokens(): Record<string, string> {
+  return tailwindConfig.theme.extend.colors as Record<string, string>;
+}
+
+function block(css: string, pattern: RegExp): string {
+  const match = css.match(pattern);
+  if (!match) throw new Error(`pattern not found: ${pattern}`);
+  return match[1];
+}
+
+describe('theme tokens (tailwind.config.js) — issue #3133', () => {
+  it('every trusty-*/status-* color uses the rgb(var(--color-*) / <alpha-value>) format, never a hardcoded literal or a bare var()', () => {
+    // The bare `var(--color-*)` form (no `rgb(... / <alpha-value>)`
+    // wrapper) is a real regression this test would have caught: it
+    // compiles fine for the base utility (`bg-status-ok`) but silently
+    // produces NO rule at all for any opacity-modified one
+    // (`bg-status-ok/15`) — Tailwind can't manipulate an opaque `var()`
+    // value's alpha channel at build time.
+    const colors = colorTokens();
+    expect(Object.keys(colors).length).toBeGreaterThan(0);
+    for (const [name, value] of Object.entries(colors)) {
+      expect(
+        value,
+        `color token "${name}" should be rgb(var(--color-*) / <alpha-value>)`,
+      ).toMatch(/^rgb\(var\(--color-[a-z-]+\) \/ <alpha-value>\)$/);
+    }
+  });
+
+  it('does not force a class-based dark mode strategy (no manual toggle exists to key off)', () => {
+    expect(tailwindConfig.darkMode).toBeUndefined();
+  });
+
+  it('compiles opacity-modified utilities to a real rule, not a silently-missing one — the actual regression a bare var() causes', async () => {
+    // Runs the REAL tailwind.config.js through postcss/tailwindcss against
+    // a tiny virtual template, exactly like the production build does.
+    // This is the one test that would have caught the original bug: with
+    // `colors: { 'status-ok': 'var(--color-status-ok)' }`, this compiles to
+    // zero bytes of output for `bg-status-ok/15` — no error, no warning,
+    // just a missing rule — because Tailwind cannot inject an alpha value
+    // into an opaque `var()`. `pnpm build`'s raw CSS output showed exactly
+    // that silent gap during this issue's investigation.
+    const result = await postcss([
+      tailwindcss({
+        ...tailwindConfig,
+        content: [
+          { raw: '<div class="bg-status-ok/15 text-trusty-text/60"></div>', extension: 'html' },
+        ],
+      }),
+    ]).process('@tailwind utilities;', { from: undefined });
+
+    // Un-minified postcss output formatting (whitespace, leading zero on
+    // the alpha value) is incidental — assert the substance: each selector
+    // exists and its declaration references the variable with a non-zero
+    // alpha fraction, not an empty/missing rule.
+    expect(result.css).toMatch(/\.bg-status-ok\\\/15\s*{[^}]*rgb\(var\(--color-status-ok\) \/ 0?\.15\)/);
+    expect(result.css).toMatch(/\.text-trusty-text\\\/60\s*{[^}]*rgb\(var\(--color-text\) \/ 0?\.6\)/);
+  });
+});
+
+describe('theme values (src/app.css) — issue #3133', () => {
+  it('sets color-scheme: light dark so native controls also follow the system', () => {
+    expect(appCss).toMatch(/color-scheme:\s*light dark/);
+  });
+
+  it('defines a :root light-default value for every CSS variable Tailwind references', () => {
+    const rootBlock = block(appCss, /:root\s*{([^}]*)}/);
+    for (const value of Object.values(colorTokens())) {
+      const varName = value.match(/--([a-z-]+)/)![1];
+      expect(rootBlock, `:root should define --${varName}`).toMatch(
+        new RegExp(`--${varName}\\s*:`),
+      );
+    }
+  });
+
+  it('defines a prefers-color-scheme: dark override for every color that actually differs by theme', () => {
+    // `--color-primary` is intentionally the same brand color in both
+    // themes (never overridden — it simply cascades from `:root`), so this
+    // checks the surface/border/text/status set that genuinely needs a
+    // dark-specific value, not every Tailwind-referenced variable.
+    const darkBlock = block(
+      appCss,
+      /@media\s*\(prefers-color-scheme:\s*dark\)\s*{\s*:root\s*{([^}]*)}/,
+    );
+    const mustDiffer = [
+      'color-surface',
+      'color-border',
+      'color-text',
+      'color-status-ok',
+      'color-status-error',
+      'color-status-warn',
+    ];
+    for (const varName of mustDiffer) {
+      expect(darkBlock, `dark override should define --${varName}`).toMatch(
+        new RegExp(`--${varName}\\s*:`),
+      );
+    }
+  });
+
+  it('the dark override genuinely differs from the light default for surface/text/border (real theming, not a no-op)', () => {
+    const rootBlock = block(appCss, /:root\s*{([^}]*)}/);
+    const darkBlock = block(
+      appCss,
+      /@media\s*\(prefers-color-scheme:\s*dark\)\s*{\s*:root\s*{([^}]*)}/,
+    );
+    const valueOf = (css: string, varName: string): string | undefined =>
+      css.match(new RegExp(`--${varName}\\s*:\\s*([^;]+);`))?.[1]?.trim();
+
+    for (const varName of ['color-surface', 'color-text', 'color-border']) {
+      const light = valueOf(rootBlock, varName);
+      const dark = valueOf(darkBlock, varName);
+      expect(light, `--${varName} missing from :root`).toBeTruthy();
+      expect(dark, `--${varName} missing from the dark override`).toBeTruthy();
+      expect(dark, `--${varName} should differ between light and dark`).not.toBe(light);
+    }
+  });
+});
+
+describe('component theming hygiene — issue #3133', () => {
+  const svelteFiles: { name: string; content: string }[] = [
+    { name: 'App.svelte', content: readFileSync(resolve(uiRoot, 'src/App.svelte'), 'utf-8') },
+    ...readdirSync(resolve(uiRoot, 'src/components'))
+      .filter((f) => f.endsWith('.svelte'))
+      .map((f) => ({
+        name: f,
+        content: readFileSync(resolve(uiRoot, 'src/components', f), 'utf-8'),
+      })),
+  ];
+
+  it('no component defines its own <style> block (all theming flows through Tailwind tokens)', () => {
+    expect(svelteFiles.length).toBeGreaterThan(0);
+    for (const { name, content } of svelteFiles) {
+      expect(content, `${name} should not define a <style> block`).not.toMatch(/<style[\s>]/);
+    }
+  });
+
+  it('no component uses an inline style="" attribute carrying a hardcoded color literal', () => {
+    for (const { name, content } of svelteFiles) {
+      const styleAttrs = content.match(/style="[^"]*"/g) ?? [];
+      for (const attr of styleAttrs) {
+        expect(attr, `${name} has a hardcoded color in an inline style`).not.toMatch(
+          /#[0-9a-fA-F]{3,8}\b|rgba?\(/,
+        );
+      }
+    }
+  });
+
+  it('no component uses a raw (non-themed) Tailwind palette color utility — every color routes through a trusty-*/status-* token', () => {
+    // Caught a real instance during the #3133 audit: HealthPanel.svelte's
+    // code-block background was `bg-black/30` — Tailwind's built-in
+    // `black`, which never changes with `prefers-color-scheme`, unlike the
+    // `trusty-*`/`status-*` tokens this file's other tests pin to
+    // `var(--color-*)`. Fixed to `bg-trusty-border/20`; this test guards
+    // against the same class of regression reappearing anywhere else.
+    const HARDCODED_PALETTE =
+      /\b(?:bg|text|border|ring|from|via|to|fill|stroke)-(?:black|white|slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)(?:-[0-9]+)?\b/;
+    for (const { name, content } of svelteFiles) {
+      const match = content.match(HARDCODED_PALETTE);
+      expect(
+        match,
+        `${name} uses a raw Tailwind palette color (${match?.[0]}) instead of a trusty-*/status-* theme token`,
+      ).toBeNull();
+    }
+  });
+});

--- a/crates/trusty-code-gui/ui/tailwind.config.js
+++ b/crates/trusty-code-gui/ui/tailwind.config.js
@@ -1,21 +1,46 @@
 /** @type {import('tailwindcss').Config} */
+// Why: issue #3133 — the GUI needs light + dark themes that follow the OS
+// appearance (`prefers-color-scheme`), not a manual toggle. Every
+// `trusty-*`/`status-*` color token used across the components
+// (App/StatusBar/HealthPanel/SessionMonitor/SearchTab/CreateSessionForm)
+// now resolves to a CSS custom property instead of a hardcoded hex
+// literal — the actual light/dark VALUES live in `src/app.css`'s `:root`
+// block (light default) and its `@media (prefers-color-scheme: dark)`
+// override.
+//
+// CRITICAL format note: each color is `rgb(var(--color-*) / <alpha-value>)`,
+// NOT a bare `var(--color-*)`. This is Tailwind's documented CSS-variable
+// pattern (https://tailwindcss.com/docs/customizing-colors#using-css-variables)
+// — a bare `var()` reference cannot have its opacity manipulated at build
+// time, so `bg-status-ok/15`/`text-trusty-text/60`-style modifiers (used
+// throughout every component for hover states, dimmed text, and badges)
+// silently generate NO rule at all with a plain `var()` value. The `/*
+// alpha-value */` placeholder only works when the referenced custom
+// property holds space-separated RGB channel numbers (`"15 23 42"`, not
+// `"#0f172a"`) — see `app.css`'s custom-property declarations.
+// What: `darkMode` is intentionally OMITTED — no component ever used a
+// `dark:` variant (there is no manual toggle to key off), and the previous
+// `darkMode: 'class'` config was dead weight: nothing in this codebase ever
+// added a `.dark` class to `<html>`, so the old `html:not(.dark)` override
+// in `app.css` silently won every render regardless of OS appearance. Theme
+// switching is handled entirely by the CSS custom properties + media query
+// in `app.css`.
+// Test: `lib/theme.test.ts` pins the `rgb(var(--color-*) / <alpha-value>)`
+// format and that opacity-modified utilities actually compile (regression
+// guard for the silent-no-rule failure mode above).
 export default {
-  darkMode: 'class',
   content: ['./index.html', './src/**/*.{svelte,js,ts}'],
   theme: {
     extend: {
       colors: {
-        'trusty-primary': '#4f46e5', // indigo-600
-        'trusty-surface': '#0f172a', // slate-900 (dark)
-        'trusty-surface-light': '#ffffff', // white (light)
-        'trusty-border': '#334155', // slate-700 (dark)
-        'trusty-border-light': '#e2e8f0', // slate-200 (light)
-        'trusty-text': '#f1f5f9', // slate-100 (dark)
-        'trusty-text-light': '#0f172a', // slate-900 (light)
-        'status-ok': '#22c55e', // green-500
-        'status-error': '#ef4444', // red-500
-        'status-warn': '#f59e0b', // amber-500 — DOC-39 §8: amber = inferred/warming
-        'status-neutral': '#64748b', // slate-500 — no-session / never-probed
+        'trusty-primary': 'rgb(var(--color-primary) / <alpha-value>)',
+        'trusty-surface': 'rgb(var(--color-surface) / <alpha-value>)',
+        'trusty-border': 'rgb(var(--color-border) / <alpha-value>)',
+        'trusty-text': 'rgb(var(--color-text) / <alpha-value>)',
+        'status-ok': 'rgb(var(--color-status-ok) / <alpha-value>)',
+        'status-error': 'rgb(var(--color-status-error) / <alpha-value>)',
+        'status-warn': 'rgb(var(--color-status-warn) / <alpha-value>)', // DOC-39 §8: amber = inferred/warming
+        'status-neutral': 'rgb(var(--color-status-neutral) / <alpha-value>)', // no-session / never-probed
       },
     },
   },


### PR DESCRIPTION
## Summary

Three GUI smoke-test UX fixes from Bob's direct feedback (2026-07-18), all
touching `CreateSessionForm.svelte`/`HealthPanel.svelte`/theme config, so
shipped together per the delegated scope.

### #3132 — Enter-to-submit

The create-session task `<textarea>` had no keyboard submit path — click was
the only way in. `docs/specs/trusty-code-harness-ui.md` specifies no
submit-key convention, so this follows the universal textarea pattern via a
new `handleTaskKeydown` handler: `Enter` (no `Shift`, not mid-IME-composition)
calls `preventDefault()` and the existing `submit()` — which already
re-checks `canSubmitCreate` at its top, so no separate double-submit guard
was needed. `Shift+Enter` is left completely untouched, falling through to
the textarea's own default newline insertion.

### #3133 — light + dark themes following system appearance

Every `trusty-*`/`status-*` Tailwind color token (`tailwind.config.js`) now
resolves to `rgb(var(--color-*) / <alpha-value>)` instead of a hardcoded hex
literal. The actual values live in `src/app.css`'s `:root` (light default)
and `@media (prefers-color-scheme: dark)` (override) — no manual toggle,
purely system-following, and live inside the Tauri webview (WebKit
re-evaluates the media query on the native "Appearance changed" notification
with no reload).

**Format note worth flagging in review:** the CSS custom properties are
space-separated RGB triples (`"15 23 42"`, not `"#0f172a"`) — this is
required by the `rgb(var(...) / <alpha-value>)` format, the only way
Tailwind can still generate the `bg-status-ok/15`/`text-trusty-text/60`-style
opacity modifiers used throughout every component. My first cut used a bare
`var(--color-*)` reference, which compiled the base utility fine but
silently produced **zero** opacity-modifier rules — no error, no warning,
just missing CSS. A real `postcss`/`tailwindcss` compile check in the new
`lib/theme.test.ts` catches this class of regression directly (it would have
failed against my first cut).

Also removed the dead `darkMode: 'class'` config — nothing in this codebase
ever added a `.dark` class to `<html>`, so the old `html:not(.dark)`
override in `app.css` silently won every render regardless of the actual OS
appearance setting.

The theming audit across App/StatusBar/HealthPanel/SessionMonitor/SearchTab/
CreateSessionForm caught one real hardcoded color outside the token system:
`HealthPanel.svelte`'s JSON payload `<pre>` block used Tailwind's built-in
near-black shade (which never changes with `prefers-color-scheme`) instead
of a themed token — swapped for `trusty-border` at reduced opacity.

### #3134 — picker placement

The directory listing's `use` button sat at the row's far right — `flex-1`
on the name button plus `justify-between` on the row stretched the name
button to fill the available width, leaving a wide, disorienting gap
between a short directory name and the control that binds it. The name
button is now width-bounded (`min-w-0 max-w-[65%]`, `truncate` still
applies) instead of flex-stretched; with `justify-between` removed, the
row's default left-packed flex layout puts `use` immediately adjacent to
the name.

Closes #3132
Closes #3133
Closes #3134

## Test coverage

- `CreateSessionForm.test.ts`: Enter submits (real `KeyboardEvent`,
  `defaultPrevented` asserted), a rapid second Enter while the first submit
  is in flight causes no second `POST`, Shift+Enter never prevents default
  or submits, a non-Enter key is a no-op, and a structural DOM-adjacency
  assertion for the picker `use` button (next-sibling of the name button,
  neither carrying the `flex-1`/`justify-between` classes that caused the
  separation).
- `lib/theme.test.ts` (new): the `rgb(var(...) / <alpha-value>)` token
  format, both themes' CSS-variable values (and that dark genuinely differs
  from light for surface/text/border), a real `postcss`/`tailwindcss`
  compile check proving opacity-modified utilities produce an actual rule,
  and a component-hygiene scan across every `.svelte` file for `<style>`
  blocks, hardcoded inline-style colors, and raw (non-themed) Tailwind
  palette utilities.

## Files

- `crates/trusty-code-gui/ui/tailwind.config.js`
- `crates/trusty-code-gui/ui/src/app.css`
- `crates/trusty-code-gui/ui/src/components/CreateSessionForm.svelte`
- `crates/trusty-code-gui/ui/src/components/CreateSessionForm.test.ts`
- `crates/trusty-code-gui/ui/src/components/HealthPanel.svelte`
- `crates/trusty-code-gui/ui/src/lib/theme.test.ts` (new)
- `crates/trusty-code-gui/CHANGELOG.md`

## Quality gate (raw tails)

`pnpm test` (vitest, jsdom):
```
 Test Files  10 passed (10)
      Tests  103 passed (103)
```

`pnpm build`:
```
✓ 123 modules transformed.
✓ built in 821ms
```

`cargo fmt --check`: clean (exit 0, no diff)

`SKIP_UI_BUILD=1 cargo check -p trusty-code-gui`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 23.21s
```

`SKIP_UI_BUILD=1 cargo clippy -p trusty-code-gui --all-targets -- -D warnings`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.31s
```
(zero warnings)

`bash scripts/check_line_cap.sh`:
```
line-cap: 10 allowlisted, 0 violations — OK.
```

## Manual verification still recommended

`prefers-color-scheme` live-switching inside the actual Tauri webview
(toggling System Settings > Appearance while `pnpm tauri dev` is running)
is inherently not exercisable from `vitest`/jsdom — the automated coverage
proves the CSS/config is correct and that opacity utilities compile; the
live OS-toggle behavior itself needs a manual pass in a running Tauri
window.

## Test plan

- [x] `pnpm test` — 103/103 passing
- [x] `pnpm build` — production build succeeds
- [x] `cargo fmt --check` / `cargo check -p trusty-code-gui` /
      `cargo clippy -p trusty-code-gui --all-targets -- -D warnings` — all clean
- [x] `bash scripts/check_line_cap.sh` — no new/grown oversized files
- [ ] Manual: toggle macOS Appearance while `pnpm tauri dev` is running and
      confirm the window recolors live

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools