### PR TITLE
feat(trusty-code): per-call project binding on task.run

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Per-call project binding on `task.run` (issue #3178, DOC-39 §5.5 /
+  AC-16.2).** `task.run` (and `POST /tasks`) now accept an optional `project`
+  path, resolved through the exact same `ProjectBinding::resolve` helper
+  `session.create` uses — an invalid path (missing, not a directory) maps to
+  `-32003 invalid_argument`/`400` identically on both surfaces. Omitting
+  `project` keeps today's process-boot-time binding unchanged (back-compat).
+  This converges the two project-binding entry points epic #3174 needs for
+  the project-first "pick a project and just start prompting" flow.
 - **REST-pollable search/recall audit trail (issue #3072).** New
   `session.get_search_audit` RPC method and `GET /sessions/{id}/search-audit`
   REST route return a session's retained, capped (200 records) history of

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -18,6 +18,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `project` keeps today's process-boot-time binding unchanged (back-compat).
   This converges the two project-binding entry points epic #3174 needs for
   the project-first "pick a project and just start prompting" flow.
+  **Follow-up (code-critic HIGH finding, PR #3189):** when `session_id`
+  reuses an existing session, `project` may only RESTATE that session's own
+  persisted binding root — a `project` naming a DIFFERENT root is rejected
+  with `-32003 invalid_argument`/`400` rather than silently executing the run
+  against a project `session.status`/`session.list` would never agree the
+  session is bound to (`SessionRegistry` has no binding-update path).
 - **REST-pollable search/recall audit trail (issue #3072).** New
   `session.get_search_audit` RPC method and `GET /sessions/{id}/search-audit`
   REST route return a session's retained, capped (200 records) history of

--- a/crates/trusty-code/src/serve/rest/tasks.rs
+++ b/crates/trusty-code/src/serve/rest/tasks.rs
@@ -323,4 +323,37 @@ mod tests {
         let v = body_json(resp).await;
         assert_eq!(v["error"]["code"], -32003);
     }
+
+    /// A `session_id` reusing an existing session, paired with a `project`
+    /// naming a DIFFERENT root than that session's own persisted binding,
+    /// must be rejected with `400`/`-32003 invalid_argument` (#3178,
+    /// code-critic HIGH finding, PR #3189) — the REST-level half of
+    /// `task::protocol::tests::task_run_session_id_with_mismatched_project_is_rejected`.
+    #[tokio::test]
+    async fn run_task_session_id_with_mismatched_project_returns_400() {
+        let (app, sessions, _boot_project) = app_and_registry();
+        let session_project = tempfile::tempdir().expect("session project tempdir");
+        let other_project = tempfile::tempdir().expect("other project tempdir");
+        let session_binding = ProjectBinding::resolve(Some(session_project.path().to_path_buf()))
+            .expect("tempdir must bind");
+        let existing = sessions.create("say hi".to_string(), None, session_binding);
+
+        let body = json!({
+            "task_description": "say hi",
+            "session_id": existing.id,
+            "project": other_project.path().to_string_lossy(),
+        })
+        .to_string();
+        let resp = post(&app, "/tasks", &body).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32003);
+        assert!(
+            v["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("does not match session"),
+            "error message must name the mismatch: {v}"
+        );
+    }
 }

--- a/crates/trusty-code/src/serve/rest/tasks.rs
+++ b/crates/trusty-code/src/serve/rest/tasks.rs
@@ -62,7 +62,11 @@ pub fn routes(router: Arc<Router>) -> AxumRouter {
 /// Request body for `POST /tasks`, shaped like `task::protocol`'s private
 /// `TaskRunRequestParams` — forwarded verbatim into the RPC `params` `Value`,
 /// so `task.run`'s own validation (empty `task_description`, unknown
-/// `session_id`, …) applies identically either way.
+/// `session_id`, invalid `project`, …) applies identically either way.
+/// `project` stays a `String` here (mirroring `sessions_write::CreateBody`'s
+/// identical choice) — it is forwarded verbatim into the RPC `params`
+/// `Value`, and `task.run`'s own `PathBuf` deserialization +
+/// `ProjectBinding::resolve` apply identically either way (#3178).
 #[derive(Deserialize)]
 struct RunTaskBody {
     task_description: String,
@@ -78,6 +82,8 @@ struct RunTaskBody {
     mode: Option<String>,
     #[serde(default)]
     deadline_secs: Option<u64>,
+    #[serde(default)]
+    project: Option<String>,
 }
 
 /// Like [`super::respond`] but reports `202 Accepted` on success instead of
@@ -115,14 +121,19 @@ async fn respond_accepted(
 /// session per `crate::task::protocol::task_run`'s docs.
 /// What: `202 Accepted` with `{session_id, status, mode, binding}` on
 /// success (see [`respond_accepted`] for the status-code rationale); `400`
-/// for an empty `task_description` (`-32003 invalid_argument`) or a
-/// syntactically malformed body (rejected by axum's `Json` extractor before
-/// this handler runs); `404` for an unknown `session_id` (`-32007
-/// session_not_found`).
+/// for an empty `task_description` or an invalid `project` (both `-32003
+/// invalid_argument`, #3178) or a syntactically malformed body (rejected by
+/// axum's `Json` extractor before this handler runs); `404` for an unknown
+/// `session_id` (`-32007 session_not_found`). `project` is forwarded
+/// verbatim to `task.run` — no independent resolution happens in this REST
+/// layer (see the module docs' "duplicating it here would fork the two
+/// surfaces" rationale).
 /// Test: `tests::run_task_returns_202_with_running_session`,
 /// `tests::run_task_empty_task_description_returns_400`,
 /// `tests::run_task_unknown_session_id_returns_404`,
-/// `tests::run_task_malformed_body_returns_400`.
+/// `tests::run_task_malformed_body_returns_400`,
+/// `tests::run_task_with_project_binds_a_real_directory`,
+/// `tests::run_task_invalid_project_returns_400`.
 async fn run_task(
     State(state): State<TasksState>,
     Json(body): Json<RunTaskBody>,
@@ -138,6 +149,7 @@ async fn run_task(
             "session_id": body.session_id,
             "mode": body.mode,
             "deadline_secs": body.deadline_secs,
+            "project": body.project,
         }),
     )
     .await
@@ -260,5 +272,55 @@ mod tests {
 
         let resp = post(&app, "/tasks", "{not valid json").await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// A `project` in the body must bind a real directory, overriding the
+    /// daemon's boot-time binding for this call, and the response must
+    /// reflect it (#3178) — the REST-level half of the `task.run` RPC
+    /// coverage in `task::protocol::tests::task_run_with_project_overrides_boot_binding`.
+    #[tokio::test]
+    async fn run_task_with_project_binds_a_real_directory() {
+        let _guard = crate::task::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+        unsafe {
+            std::env::set_var(
+                crate::task::mock_llm::MOCK_LLM_ENV,
+                crate::task::mock_llm::MOCK_LLM_ECHO,
+            );
+        }
+        let (app, _sessions, _boot_project) = app_and_registry();
+        let call_project = tempfile::tempdir().expect("call project tempdir");
+
+        let body = json!({
+            "task_description": "say hi",
+            "project": call_project.path().to_string_lossy(),
+        })
+        .to_string();
+        let resp = post(&app, "/tasks", &body).await;
+        unsafe {
+            std::env::remove_var(crate::task::mock_llm::MOCK_LLM_ENV);
+        }
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        let v = body_json(resp).await;
+        assert_eq!(
+            v["binding"]["state"], "directory",
+            "the per-call project must bind: {v}"
+        );
+    }
+
+    /// A `project` naming a nonexistent path must map to `400` (`-32003
+    /// invalid_argument`), matching `task.run`'s RPC-level error mapping.
+    #[tokio::test]
+    async fn run_task_invalid_project_returns_400() {
+        let (app, _sessions, _project) = app_and_registry();
+
+        let resp = post(
+            &app,
+            "/tasks",
+            r#"{"task_description": "say hi", "project": "/no/such/path/anywhere"}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32003);
     }
 }

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -103,6 +103,15 @@ struct TaskRunRequestParams {
     /// both surfaces — this is the keystone convergence the issue names:
     /// `task.run` and `session.create` can no longer disagree about what a
     /// project is or how one is resolved.
+    ///
+    /// **Invariant when paired with `session_id` (reusing an existing
+    /// session):** a session's persisted `Session.binding` is authoritative —
+    /// `SessionRegistry` has no binding-update path (it is set once, in
+    /// `SessionRegistry::create`). `project` may only RESTATE that same root;
+    /// naming a DIFFERENT root is rejected with `-32003 invalid_argument`
+    /// rather than silently executing the run against a project
+    /// `session.status`/`session.list` would never agree it is bound to. See
+    /// [`task_run`]'s docs.
     #[serde(default)]
     project: Option<PathBuf>,
 }
@@ -134,6 +143,17 @@ struct TaskRunRequestParams {
 /// LLM run" requirement. The response's own `mode`/`binding` fields are the
 /// SAME resolved values, surfaced immediately rather than requiring a
 /// follow-up `session.status` call.
+///
+/// **Invariant: a reused session's persisted binding is authoritative.** When
+/// `session_id` is supplied, `project` may only RESTATE that session's own
+/// `Session.binding` root (or be omitted); a `project` naming a DIFFERENT
+/// root is rejected as `-32003 invalid_argument` rather than silently
+/// executing the run against a project the session itself was never bound to
+/// (`SessionRegistry` has no binding-update path — `create` sets it once).
+/// Accepting the mismatch would let `session.status`/`session.list` report
+/// the ORIGINAL binding forever while the run actually executed against a
+/// different one — a silent audit/state divergence this validation exists to
+/// prevent (code-critic HIGH finding, PR #3189).
 /// Test: `task::protocol::tests::task_run_rejects_empty_task_description`,
 /// `task::protocol::tests::task_run_creates_session_when_none_given`,
 /// `task::protocol::tests::task_run_sessionful_reuses_existing_session`,
@@ -141,7 +161,9 @@ struct TaskRunRequestParams {
 /// `task::protocol::tests::task_run_resolves_and_reports_mode`,
 /// `task::protocol::tests::task_run_without_project_keeps_boot_binding`,
 /// `task::protocol::tests::task_run_with_project_overrides_boot_binding`,
-/// `task::protocol::tests::task_run_rejects_invalid_project`.
+/// `task::protocol::tests::task_run_rejects_invalid_project`,
+/// `task::protocol::tests::task_run_session_id_with_matching_project_succeeds`,
+/// `task::protocol::tests::task_run_session_id_with_mismatched_project_is_rejected`.
 async fn task_run(
     registry: Arc<SessionRegistry>,
     params: Value,
@@ -158,6 +180,7 @@ async fn task_run(
     // #3178: a per-call `project` overrides the boot-time binding for this
     // call only, resolved through the exact same helper `session.create` uses
     // — never a second, divergent implementation of "what is a project".
+    let project_given = p.project.is_some();
     let binding = match p.project {
         Some(project) => ProjectBinding::resolve(Some(project))
             .map_err(|e| RpcError::invalid_argument(format!("task.run: {e}")))?,
@@ -167,7 +190,25 @@ async fn task_run(
 
     let session_id = match &p.session_id {
         Some(id) => {
-            registry.status(id)?; // propagate session_not_found verbatim
+            let existing = registry.status(id)?; // propagate session_not_found verbatim
+            // HIGH finding (code-critic, PR #3189): a session's persisted
+            // binding is authoritative once created — reject a per-call
+            // `project` that would silently redirect the run to a DIFFERENT
+            // root than `session.status`/`session.list` will keep reporting.
+            if project_given && existing.binding.root() != binding.root() {
+                return Err(RpcError::invalid_argument(format!(
+                    "task.run: project `{}` does not match session `{id}`'s existing binding \
+                     `{}` — a session's persisted binding is authoritative; project may only \
+                     restate it, not change it",
+                    binding
+                        .label()
+                        .unwrap_or_else(|| "<projectless>".to_string()),
+                    existing
+                        .binding
+                        .label()
+                        .unwrap_or_else(|| "<projectless>".to_string()),
+                )));
+            }
             id.clone()
         }
         None => {
@@ -205,470 +246,5 @@ async fn task_run(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::jsonrpc::Request;
-    use tokio::sync::mpsc;
-
-    fn test_ctx() -> ConnectionContext {
-        let (tx, _rx) = mpsc::unbounded_channel();
-        ConnectionContext::new(tx)
-    }
-
-    fn agents_dir() -> tempfile::TempDir {
-        let tmp = tempfile::tempdir().expect("agents tempdir");
-        std::fs::write(
-            tmp.path().join("pm.md"),
-            "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM.\n",
-        )
-        .expect("write pm.md");
-        std::fs::write(
-            tmp.path().join("python-engineer.md"),
-            "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\nengineer\n",
-        )
-        .expect("write python-engineer.md");
-        tmp
-    }
-
-    /// `register` must wire `task.run` so the router recognises it.
-    #[tokio::test]
-    async fn register_wires_task_run() {
-        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
-        // SAFETY: test-only env mutation; serialized by `ENV_LOCK` above.
-        unsafe {
-            std::env::set_var(
-                super::super::mock_llm::MOCK_LLM_ENV,
-                super::super::mock_llm::MOCK_LLM_ECHO,
-            );
-        }
-        let registry = Arc::new(SessionRegistry::new());
-        let agents = agents_dir();
-        let project = tempfile::tempdir().expect("project tempdir");
-        let mut router = Router::new();
-        register(
-            &mut router,
-            registry,
-            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        );
-
-        let req = Request {
-            jsonrpc: Some("2.0".to_string()),
-            id: Some(json!(1)),
-            method: "task.run".to_string(),
-            params: Some(json!({"task_description": "say hi"})),
-        };
-        let resp = router.dispatch(req, &test_ctx()).await;
-        unsafe {
-            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
-        }
-        assert!(
-            resp.error.is_none(),
-            "task.run should succeed, got {:?}",
-            resp.error
-        );
-        assert_eq!(resp.result.unwrap()["status"], "running");
-    }
-
-    /// `task.run` must be callable with NO project bound at all (AC-16.1) —
-    /// the change that makes the shell's entry screen (7a) implementable. This
-    /// call was impossible before: `register` took a required `PathBuf`.
-    #[tokio::test]
-    async fn register_wires_task_run_projectless() {
-        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
-        // SAFETY: test-only env mutation; serialized by the lock above.
-        unsafe {
-            std::env::set_var(
-                super::super::mock_llm::MOCK_LLM_ENV,
-                super::super::mock_llm::MOCK_LLM_ECHO,
-            );
-        }
-        let registry = Arc::new(SessionRegistry::new());
-        let agents = agents_dir();
-        let mut router = Router::new();
-        register(
-            &mut router,
-            registry,
-            ProjectBinding::None,
-            agents.path().to_path_buf(),
-        );
-
-        let req = Request {
-            jsonrpc: Some("2.0".to_string()),
-            id: Some(json!(1)),
-            method: "task.run".to_string(),
-            params: Some(json!({"task_description": "just chat"})),
-        };
-        let resp = router.dispatch(req, &test_ctx()).await;
-        unsafe {
-            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
-        }
-        assert!(
-            resp.error.is_none(),
-            "projectless task.run must succeed, got {:?}",
-            resp.error
-        );
-        let result = resp.result.expect("a result");
-        assert_eq!(result["status"], "running");
-        assert_eq!(
-            result["binding"]["state"], "projectless",
-            "task.run must report the projectless binding back to the caller: {result}"
-        );
-    }
-
-    /// An empty `task_description` must map to `-32003 invalid_argument`.
-    #[tokio::test]
-    async fn task_run_rejects_empty_task_description() {
-        let registry = Arc::new(SessionRegistry::new());
-        let agents = agents_dir();
-        let project = tempfile::tempdir().expect("project tempdir");
-        let err = task_run(
-            registry,
-            json!({"task_description": "   "}),
-            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await
-        .unwrap_err();
-        assert_eq!(err.code, -32003);
-    }
-
-    /// Omitting `session_id` must mint a fresh session.
-    #[tokio::test]
-    async fn task_run_creates_session_when_none_given() {
-        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
-        unsafe {
-            std::env::set_var(
-                super::super::mock_llm::MOCK_LLM_ENV,
-                super::super::mock_llm::MOCK_LLM_ECHO,
-            );
-        }
-        let registry = Arc::new(SessionRegistry::new());
-        let agents = agents_dir();
-        let project = tempfile::tempdir().expect("project tempdir");
-
-        let result = task_run(
-            Arc::clone(&registry),
-            json!({"task_description": "say hi"}),
-            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await;
-        unsafe {
-            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
-        }
-        let value = result.expect("task.run should succeed");
-        let session_id = value["session_id"].as_str().expect("session_id string");
-        assert!(
-            registry.status(session_id).is_ok(),
-            "a new session must have been created"
-        );
-    }
-
-    /// `task.run` must resolve `HarnessMode` per §5.9's three-tier
-    /// precedence and report it BOTH in its own immediate response AND on
-    /// the session (queryable via `session.status`/`get_transcript`
-    /// afterward) — #2059.
-    ///
-    /// Why: this is the integration point proving the wiring
-    /// `crate::mode::resolve_mode`'s own unit tests cannot: that
-    /// `task::protocol::task_run` actually reads the `mode` request param,
-    /// the project's `.claude/settings.json`, and `TRUSTY_CODE_MODE`, in
-    /// that precedence, and persists the result via
-    /// `SessionRegistry::set_mode` before spawning the run.
-    /// What: covers default (nothing set), settings.json alone,
-    /// task-param-over-settings.json, and env-var-over-everything.
-    /// Test: this test.
-    #[tokio::test]
-    async fn task_run_resolves_and_reports_mode() {
-        let _mock_guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
-        let _mode_guard = crate::mode::MODE_ENV_LOCK.lock().await;
-        // SAFETY: test-only env mutation; serialized by both locks above.
-        unsafe {
-            std::env::set_var(
-                super::super::mock_llm::MOCK_LLM_ENV,
-                super::super::mock_llm::MOCK_LLM_ECHO,
-            );
-            std::env::remove_var(crate::mode::MODE_ENV_VAR);
-        }
-        let agents = agents_dir();
-
-        // 1. Nothing set anywhere -> default (daily-driver).
-        let project = tempfile::tempdir().expect("project tempdir");
-        let registry = Arc::new(SessionRegistry::new());
-        let value = task_run(
-            Arc::clone(&registry),
-            json!({"task_description": "say hi"}),
-            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await
-        .expect("task.run should succeed");
-        assert_eq!(value["mode"], "daily-driver");
-        let session_id = value["session_id"].as_str().unwrap().to_string();
-        assert_eq!(
-            registry.status(&session_id).unwrap().mode,
-            Some(crate::mode::HarnessMode::DailyDriver)
-        );
-
-        // 2. `.claude/settings.json` alone sets parity.
-        let project2 = tempfile::tempdir().expect("project tempdir");
-        std::fs::create_dir_all(project2.path().join(".claude")).expect("mkdir");
-        std::fs::write(
-            project2.path().join(".claude").join("settings.json"),
-            r#"{"code_harness": {"mode": "parity"}}"#,
-        )
-        .expect("write settings.json");
-        let registry2 = Arc::new(SessionRegistry::new());
-        let value2 = task_run(
-            Arc::clone(&registry2),
-            json!({"task_description": "say hi"}),
-            ProjectBinding::resolve(Some(project2.path().to_path_buf()))
-                .expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await
-        .expect("task.run should succeed");
-        assert_eq!(value2["mode"], "parity");
-
-        // 3. A `mode` request param overrides settings.json (still parity
-        //    from settings.json here, but requesting daily-driver must win).
-        let registry3 = Arc::new(SessionRegistry::new());
-        let value3 = task_run(
-            Arc::clone(&registry3),
-            json!({"task_description": "say hi", "mode": "daily-driver"}),
-            ProjectBinding::resolve(Some(project2.path().to_path_buf()))
-                .expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await
-        .expect("task.run should succeed");
-        assert_eq!(
-            value3["mode"], "daily-driver",
-            "task.run's mode param must override settings.json"
-        );
-
-        // 4. TRUSTY_CODE_MODE overrides EVERYTHING, including a task param.
-        unsafe {
-            std::env::set_var(crate::mode::MODE_ENV_VAR, "parity");
-        }
-        let registry4 = Arc::new(SessionRegistry::new());
-        let value4 = task_run(
-            Arc::clone(&registry4),
-            json!({"task_description": "say hi", "mode": "daily-driver"}),
-            ProjectBinding::resolve(Some(project2.path().to_path_buf()))
-                .expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await
-        .expect("task.run should succeed");
-        assert_eq!(
-            value4["mode"], "parity",
-            "TRUSTY_CODE_MODE must win over a task.run mode param"
-        );
-
-        unsafe {
-            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
-            std::env::remove_var(crate::mode::MODE_ENV_VAR);
-        }
-    }
-
-    /// A `session_id` that does not exist must propagate `session_not_found`.
-    #[tokio::test]
-    async fn task_run_unknown_session_id_errors() {
-        let registry = Arc::new(SessionRegistry::new());
-        let agents = agents_dir();
-        let project = tempfile::tempdir().expect("project tempdir");
-
-        let err = task_run(
-            registry,
-            json!({"task_description": "say hi", "session_id": "does-not-exist"}),
-            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await
-        .unwrap_err();
-        assert_eq!(err.code, -32007);
-    }
-
-    /// Omitting `project` must keep today's process-boot-time binding
-    /// unchanged (#3178 back-compat) — the daemon's `binding` param, not
-    /// `ProjectBinding::None`.
-    #[tokio::test]
-    async fn task_run_without_project_keeps_boot_binding() {
-        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
-        unsafe {
-            std::env::set_var(
-                super::super::mock_llm::MOCK_LLM_ENV,
-                super::super::mock_llm::MOCK_LLM_ECHO,
-            );
-        }
-        let registry = Arc::new(SessionRegistry::new());
-        let agents = agents_dir();
-        let boot_project = tempfile::tempdir().expect("project tempdir");
-        let boot_binding = ProjectBinding::resolve(Some(boot_project.path().to_path_buf()))
-            .expect("tempdir must bind");
-
-        let value = task_run(
-            registry,
-            json!({"task_description": "say hi"}),
-            boot_binding.clone(),
-            agents.path().to_path_buf(),
-        )
-        .await
-        .expect("task.run should succeed");
-        unsafe {
-            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
-        }
-        assert_eq!(value["binding"], boot_binding.to_json());
-    }
-
-    /// A per-call `project` must override the boot-time binding for this
-    /// call, resolved through the same `ProjectBinding::resolve` helper
-    /// `session.create` uses (#3178, DOC-39 §5.5/AC-16.2).
-    #[tokio::test]
-    async fn task_run_with_project_overrides_boot_binding() {
-        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
-        unsafe {
-            std::env::set_var(
-                super::super::mock_llm::MOCK_LLM_ENV,
-                super::super::mock_llm::MOCK_LLM_ECHO,
-            );
-        }
-        let registry = Arc::new(SessionRegistry::new());
-        let agents = agents_dir();
-        let call_project = tempfile::tempdir().expect("project tempdir");
-
-        let value = task_run(
-            registry,
-            json!({
-                "task_description": "say hi",
-                "project": call_project.path().to_string_lossy(),
-            }),
-            ProjectBinding::None,
-            agents.path().to_path_buf(),
-        )
-        .await
-        .expect("task.run should succeed");
-        unsafe {
-            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
-        }
-        assert_eq!(
-            value["binding"]["state"], "directory",
-            "the per-call project must bind, not stay projectless: {value}"
-        );
-    }
-
-    /// A `project` naming a nonexistent path must map to `-32003
-    /// invalid_argument`, matching `session.create`'s error mapping for the
-    /// same failure mode.
-    #[tokio::test]
-    async fn task_run_rejects_invalid_project() {
-        let registry = Arc::new(SessionRegistry::new());
-        let agents = agents_dir();
-
-        let err = task_run(
-            registry,
-            json!({"task_description": "say hi", "project": "/no/such/path/anywhere"}),
-            ProjectBinding::None,
-            agents.path().to_path_buf(),
-        )
-        .await
-        .unwrap_err();
-        assert_eq!(err.code, -32003);
-    }
-
-    /// A `session_id` for an existing session must reuse it, not mint a new
-    /// one.
-    #[tokio::test]
-    async fn task_run_sessionful_reuses_existing_session() {
-        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
-        unsafe {
-            std::env::set_var(
-                super::super::mock_llm::MOCK_LLM_ENV,
-                super::super::mock_llm::MOCK_LLM_ECHO,
-            );
-        }
-        let registry = Arc::new(SessionRegistry::new());
-        let existing = registry.create(
-            "say hi".to_string(),
-            None,
-            crate::binding::ProjectBinding::None,
-        );
-        let agents = agents_dir();
-        let project = tempfile::tempdir().expect("project tempdir");
-
-        let result = task_run(
-            Arc::clone(&registry),
-            json!({"task_description": "say hi", "session_id": existing.id}),
-            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await;
-        unsafe {
-            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
-        }
-        let value = result.expect("task.run should succeed");
-        assert_eq!(value["session_id"], existing.id);
-    }
-
-    /// A second `task.run` at the JSON-RPC entry point, issued AFTER the
-    /// first run against the same `session_id` has fully `Finished`, must be
-    /// ACCEPTED (#2344 resumption) rather than erroring — the acceptance
-    /// criterion "two sequential task.run calls on one session" exercised at
-    /// the actual RPC surface, not just `spawn_task_run` directly
-    /// (`task::executor::tests::spawn_task_run_second_call_after_finish_appends_to_cumulative_transcript`
-    /// covers the transcript-accumulation half; this test covers that
-    /// `task_run` itself — including its `registry.status(id)` existing-
-    /// session lookup — does not reject the resumed call).
-    #[tokio::test]
-    async fn task_run_second_call_after_finish_continues_the_session() {
-        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
-        unsafe {
-            std::env::set_var(
-                super::super::mock_llm::MOCK_LLM_ENV,
-                super::super::mock_llm::MOCK_LLM_ECHO,
-            );
-        }
-        let registry = Arc::new(SessionRegistry::new());
-        let agents = agents_dir();
-        let project = tempfile::tempdir().expect("project tempdir");
-
-        let first = task_run(
-            Arc::clone(&registry),
-            json!({"task_description": "say hi"}),
-            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await
-        .expect("first task.run should succeed");
-        let session_id = first["session_id"].as_str().unwrap().to_string();
-
-        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
-        loop {
-            let status = registry.status(&session_id).expect("session must exist");
-            if status.status.is_terminal() {
-                break;
-            }
-            assert!(
-                tokio::time::Instant::now() < deadline,
-                "first run did not reach a terminal state within 5s"
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
-        }
-
-        let second = task_run(
-            Arc::clone(&registry),
-            json!({"task_description": "say hi again", "session_id": session_id}),
-            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        )
-        .await;
-        unsafe {
-            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
-        }
-        let value = second.expect("a second task.run on a Finished session must be accepted");
-        assert_eq!(value["session_id"], session_id);
-        assert_eq!(value["status"], "running");
-    }
-}
+#[path = "protocol_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -94,34 +94,54 @@ struct TaskRunRequestParams {
     /// (`TCODE_RUN_DEADLINE_SECONDS`) and default (1800s) tiers.
     #[serde(default)]
     deadline_secs: Option<u64>,
+    /// #3178: per-call project override (DOC-39 §5.5, AC-16.2 convergence).
+    /// `None` preserves today's back-compat behaviour — the process-boot-time
+    /// `binding` `register` closed over. `Some(path)` is resolved through the
+    /// SAME [`ProjectBinding::resolve`] `session.create`'s `CreateParams.project`
+    /// uses (see `crate::session::protocol::create`'s docs), so a nonexistent
+    /// or non-directory path maps to `-32003 invalid_argument` identically on
+    /// both surfaces — this is the keystone convergence the issue names:
+    /// `task.run` and `session.create` can no longer disagree about what a
+    /// project is or how one is resolved.
+    #[serde(default)]
+    project: Option<PathBuf>,
 }
 
 /// `task.run(task_description, agent_name?, context?, model_override?,
-/// session_id?, mode?, deadline_secs?) -> { session_id, status, mode }`.
+/// session_id?, mode?, deadline_secs?, project?) -> { session_id, status, mode }`.
 ///
 /// Why: the single entry point that turns a request into a running
 /// background execution.
 /// What: validates `task_description` is non-empty
-/// (`-32003 invalid_argument`); resolves the target session — an existing
-/// one by `session_id` (propagating `session_not_found` if it doesn't
-/// exist) or a freshly `session.create`d one; resolves the effective
-/// `HarnessMode` via `crate::mode::resolve_mode` (#2059's three-tier
-/// precedence) and persists it onto the session (`SessionRegistry::set_mode`)
-/// so it is queryable afterward via `session.status`/`session.list`
-/// (`Session.mode`) and `session.get_transcript` (`TranscriptRecord.mode`);
-/// builds the shared LLM client (real or the #2056 offline mock, per
-/// `TCODE_MOCK_LLM`); and calls `spawn_task_run`, which reserves the
-/// execution slot synchronously (rejecting a second overlapping run) before
-/// handing off to the background task. Returns immediately — the caller
-/// `session.attach`es to observe progress, per the ticket's "must not block
-/// the request thread on the whole LLM run" requirement. The response's own
-/// `mode` field is the SAME resolved value, surfaced immediately rather than
-/// requiring a follow-up `session.status` call.
+/// (`-32003 invalid_argument`); resolves the EFFECTIVE binding for this call —
+/// `project: Some(path)` resolves via [`ProjectBinding::resolve`] (mapping a
+/// `BindingError` onto `-32003 invalid_argument`, exactly like
+/// `session.create`); `project: None` keeps the process-boot-time `binding`
+/// `register` closed over, so an existing caller that never sends `project`
+/// observes no change (#3178 back-compat). Then resolves the target session —
+/// an existing one by `session_id` (propagating `session_not_found` if it
+/// doesn't exist) or a freshly `session.create`d one bound to the effective
+/// binding; resolves the effective `HarnessMode` via `crate::mode::resolve_mode`
+/// (#2059's three-tier precedence, rooted at the effective binding) and
+/// persists it onto the session (`SessionRegistry::set_mode`) so it is
+/// queryable afterward via `session.status`/`session.list` (`Session.mode`)
+/// and `session.get_transcript` (`TranscriptRecord.mode`); builds the shared
+/// LLM client (real or the #2056 offline mock, per `TCODE_MOCK_LLM`); and
+/// calls `spawn_task_run`, which reserves the execution slot synchronously
+/// (rejecting a second overlapping run) before handing off to the background
+/// task. Returns immediately — the caller `session.attach`es to observe
+/// progress, per the ticket's "must not block the request thread on the whole
+/// LLM run" requirement. The response's own `mode`/`binding` fields are the
+/// SAME resolved values, surfaced immediately rather than requiring a
+/// follow-up `session.status` call.
 /// Test: `task::protocol::tests::task_run_rejects_empty_task_description`,
 /// `task::protocol::tests::task_run_creates_session_when_none_given`,
 /// `task::protocol::tests::task_run_sessionful_reuses_existing_session`,
 /// `task::protocol::tests::task_run_unknown_session_id_errors`,
-/// `task::protocol::tests::task_run_resolves_and_reports_mode`.
+/// `task::protocol::tests::task_run_resolves_and_reports_mode`,
+/// `task::protocol::tests::task_run_without_project_keeps_boot_binding`,
+/// `task::protocol::tests::task_run_with_project_overrides_boot_binding`,
+/// `task::protocol::tests::task_run_rejects_invalid_project`.
 async fn task_run(
     registry: Arc<SessionRegistry>,
     params: Value,
@@ -135,6 +155,14 @@ async fn task_run(
             "task_description must not be empty",
         ));
     }
+    // #3178: a per-call `project` overrides the boot-time binding for this
+    // call only, resolved through the exact same helper `session.create` uses
+    // — never a second, divergent implementation of "what is a project".
+    let binding = match p.project {
+        Some(project) => ProjectBinding::resolve(Some(project))
+            .map_err(|e| RpcError::invalid_argument(format!("task.run: {e}")))?,
+        None => binding,
+    };
     let agent_name = p.agent_name.unwrap_or_else(|| "pm".to_string());
 
     let session_id = match &p.session_id {
@@ -461,6 +489,93 @@ mod tests {
         .await
         .unwrap_err();
         assert_eq!(err.code, -32007);
+    }
+
+    /// Omitting `project` must keep today's process-boot-time binding
+    /// unchanged (#3178 back-compat) — the daemon's `binding` param, not
+    /// `ProjectBinding::None`.
+    #[tokio::test]
+    async fn task_run_without_project_keeps_boot_binding() {
+        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+        unsafe {
+            std::env::set_var(
+                super::super::mock_llm::MOCK_LLM_ENV,
+                super::super::mock_llm::MOCK_LLM_ECHO,
+            );
+        }
+        let registry = Arc::new(SessionRegistry::new());
+        let agents = agents_dir();
+        let boot_project = tempfile::tempdir().expect("project tempdir");
+        let boot_binding = ProjectBinding::resolve(Some(boot_project.path().to_path_buf()))
+            .expect("tempdir must bind");
+
+        let value = task_run(
+            registry,
+            json!({"task_description": "say hi"}),
+            boot_binding.clone(),
+            agents.path().to_path_buf(),
+        )
+        .await
+        .expect("task.run should succeed");
+        unsafe {
+            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+        }
+        assert_eq!(value["binding"], boot_binding.to_json());
+    }
+
+    /// A per-call `project` must override the boot-time binding for this
+    /// call, resolved through the same `ProjectBinding::resolve` helper
+    /// `session.create` uses (#3178, DOC-39 §5.5/AC-16.2).
+    #[tokio::test]
+    async fn task_run_with_project_overrides_boot_binding() {
+        let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+        unsafe {
+            std::env::set_var(
+                super::super::mock_llm::MOCK_LLM_ENV,
+                super::super::mock_llm::MOCK_LLM_ECHO,
+            );
+        }
+        let registry = Arc::new(SessionRegistry::new());
+        let agents = agents_dir();
+        let call_project = tempfile::tempdir().expect("project tempdir");
+
+        let value = task_run(
+            registry,
+            json!({
+                "task_description": "say hi",
+                "project": call_project.path().to_string_lossy(),
+            }),
+            ProjectBinding::None,
+            agents.path().to_path_buf(),
+        )
+        .await
+        .expect("task.run should succeed");
+        unsafe {
+            std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+        }
+        assert_eq!(
+            value["binding"]["state"], "directory",
+            "the per-call project must bind, not stay projectless: {value}"
+        );
+    }
+
+    /// A `project` naming a nonexistent path must map to `-32003
+    /// invalid_argument`, matching `session.create`'s error mapping for the
+    /// same failure mode.
+    #[tokio::test]
+    async fn task_run_rejects_invalid_project() {
+        let registry = Arc::new(SessionRegistry::new());
+        let agents = agents_dir();
+
+        let err = task_run(
+            registry,
+            json!({"task_description": "say hi", "project": "/no/such/path/anywhere"}),
+            ProjectBinding::None,
+            agents.path().to_path_buf(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, -32003);
     }
 
     /// A `session_id` for an existing session must reuse it, not mint a new

--- a/crates/trusty-code/src/task/protocol_tests.rs
+++ b/crates/trusty-code/src/task/protocol_tests.rs
@@ -1,0 +1,540 @@
+//! Tests for `task.run` (#2056, #3178's per-call project convergence). Split
+//! out of `protocol.rs` per the crate's `_tests.rs` sibling-file convention
+//! (see `executor_tests.rs` for precedent) to keep the production file under
+//! the 500-SLOC cap.
+
+use super::*;
+use crate::jsonrpc::Request;
+use tokio::sync::mpsc;
+
+fn test_ctx() -> ConnectionContext {
+    let (tx, _rx) = mpsc::unbounded_channel();
+    ConnectionContext::new(tx)
+}
+
+fn agents_dir() -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("agents tempdir");
+    std::fs::write(
+        tmp.path().join("pm.md"),
+        "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM.\n",
+    )
+    .expect("write pm.md");
+    std::fs::write(
+        tmp.path().join("python-engineer.md"),
+        "---\nname: python-engineer\nmodel: deepseek/deepseek-chat\n---\n\nengineer\n",
+    )
+    .expect("write python-engineer.md");
+    tmp
+}
+
+/// `register` must wire `task.run` so the router recognises it.
+#[tokio::test]
+async fn register_wires_task_run() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    // SAFETY: test-only env mutation; serialized by `ENV_LOCK` above.
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    let mut router = Router::new();
+    register(
+        &mut router,
+        registry,
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    );
+
+    let req = Request {
+        jsonrpc: Some("2.0".to_string()),
+        id: Some(json!(1)),
+        method: "task.run".to_string(),
+        params: Some(json!({"task_description": "say hi"})),
+    };
+    let resp = router.dispatch(req, &test_ctx()).await;
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    assert!(
+        resp.error.is_none(),
+        "task.run should succeed, got {:?}",
+        resp.error
+    );
+    assert_eq!(resp.result.unwrap()["status"], "running");
+}
+
+/// `task.run` must be callable with NO project bound at all (AC-16.1) —
+/// the change that makes the shell's entry screen (7a) implementable. This
+/// call was impossible before: `register` took a required `PathBuf`.
+#[tokio::test]
+async fn register_wires_task_run_projectless() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    // SAFETY: test-only env mutation; serialized by the lock above.
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let mut router = Router::new();
+    register(
+        &mut router,
+        registry,
+        ProjectBinding::None,
+        agents.path().to_path_buf(),
+    );
+
+    let req = Request {
+        jsonrpc: Some("2.0".to_string()),
+        id: Some(json!(1)),
+        method: "task.run".to_string(),
+        params: Some(json!({"task_description": "just chat"})),
+    };
+    let resp = router.dispatch(req, &test_ctx()).await;
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    assert!(
+        resp.error.is_none(),
+        "projectless task.run must succeed, got {:?}",
+        resp.error
+    );
+    let result = resp.result.expect("a result");
+    assert_eq!(result["status"], "running");
+    assert_eq!(
+        result["binding"]["state"], "projectless",
+        "task.run must report the projectless binding back to the caller: {result}"
+    );
+}
+
+/// An empty `task_description` must map to `-32003 invalid_argument`.
+#[tokio::test]
+async fn task_run_rejects_empty_task_description() {
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    let err = task_run(
+        registry,
+        json!({"task_description": "   "}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, -32003);
+}
+
+/// Omitting `session_id` must mint a fresh session.
+#[tokio::test]
+async fn task_run_creates_session_when_none_given() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let result = task_run(
+        Arc::clone(&registry),
+        json!({"task_description": "say hi"}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await;
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    let value = result.expect("task.run should succeed");
+    let session_id = value["session_id"].as_str().expect("session_id string");
+    assert!(
+        registry.status(session_id).is_ok(),
+        "a new session must have been created"
+    );
+}
+
+/// `task.run` must resolve `HarnessMode` per §5.9's three-tier
+/// precedence and report it BOTH in its own immediate response AND on
+/// the session (queryable via `session.status`/`get_transcript`
+/// afterward) — #2059.
+///
+/// Why: this is the integration point proving the wiring
+/// `crate::mode::resolve_mode`'s own unit tests cannot: that
+/// `task::protocol::task_run` actually reads the `mode` request param,
+/// the project's `.claude/settings.json`, and `TRUSTY_CODE_MODE`, in
+/// that precedence, and persists the result via
+/// `SessionRegistry::set_mode` before spawning the run.
+/// What: covers default (nothing set), settings.json alone,
+/// task-param-over-settings.json, and env-var-over-everything.
+/// Test: this test.
+#[tokio::test]
+async fn task_run_resolves_and_reports_mode() {
+    let _mock_guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    let _mode_guard = crate::mode::MODE_ENV_LOCK.lock().await;
+    // SAFETY: test-only env mutation; serialized by both locks above.
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+        std::env::remove_var(crate::mode::MODE_ENV_VAR);
+    }
+    let agents = agents_dir();
+
+    // 1. Nothing set anywhere -> default (daily-driver).
+    let project = tempfile::tempdir().expect("project tempdir");
+    let registry = Arc::new(SessionRegistry::new());
+    let value = task_run(
+        Arc::clone(&registry),
+        json!({"task_description": "say hi"}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await
+    .expect("task.run should succeed");
+    assert_eq!(value["mode"], "daily-driver");
+    let session_id = value["session_id"].as_str().unwrap().to_string();
+    assert_eq!(
+        registry.status(&session_id).unwrap().mode,
+        Some(crate::mode::HarnessMode::DailyDriver)
+    );
+
+    // 2. `.claude/settings.json` alone sets parity.
+    let project2 = tempfile::tempdir().expect("project tempdir");
+    std::fs::create_dir_all(project2.path().join(".claude")).expect("mkdir");
+    std::fs::write(
+        project2.path().join(".claude").join("settings.json"),
+        r#"{"code_harness": {"mode": "parity"}}"#,
+    )
+    .expect("write settings.json");
+    let registry2 = Arc::new(SessionRegistry::new());
+    let value2 = task_run(
+        Arc::clone(&registry2),
+        json!({"task_description": "say hi"}),
+        ProjectBinding::resolve(Some(project2.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await
+    .expect("task.run should succeed");
+    assert_eq!(value2["mode"], "parity");
+
+    // 3. A `mode` request param overrides settings.json (still parity
+    //    from settings.json here, but requesting daily-driver must win).
+    let registry3 = Arc::new(SessionRegistry::new());
+    let value3 = task_run(
+        Arc::clone(&registry3),
+        json!({"task_description": "say hi", "mode": "daily-driver"}),
+        ProjectBinding::resolve(Some(project2.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await
+    .expect("task.run should succeed");
+    assert_eq!(
+        value3["mode"], "daily-driver",
+        "task.run's mode param must override settings.json"
+    );
+
+    // 4. TRUSTY_CODE_MODE overrides EVERYTHING, including a task param.
+    unsafe {
+        std::env::set_var(crate::mode::MODE_ENV_VAR, "parity");
+    }
+    let registry4 = Arc::new(SessionRegistry::new());
+    let value4 = task_run(
+        Arc::clone(&registry4),
+        json!({"task_description": "say hi", "mode": "daily-driver"}),
+        ProjectBinding::resolve(Some(project2.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await
+    .expect("task.run should succeed");
+    assert_eq!(
+        value4["mode"], "parity",
+        "TRUSTY_CODE_MODE must win over a task.run mode param"
+    );
+
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+        std::env::remove_var(crate::mode::MODE_ENV_VAR);
+    }
+}
+
+/// A `session_id` that does not exist must propagate `session_not_found`.
+#[tokio::test]
+async fn task_run_unknown_session_id_errors() {
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let err = task_run(
+        registry,
+        json!({"task_description": "say hi", "session_id": "does-not-exist"}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, -32007);
+}
+
+/// Omitting `project` must keep today's process-boot-time binding
+/// unchanged (#3178 back-compat) — the daemon's `binding` param, not
+/// `ProjectBinding::None`.
+#[tokio::test]
+async fn task_run_without_project_keeps_boot_binding() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let boot_project = tempfile::tempdir().expect("project tempdir");
+    let boot_binding = ProjectBinding::resolve(Some(boot_project.path().to_path_buf()))
+        .expect("tempdir must bind");
+
+    let value = task_run(
+        registry,
+        json!({"task_description": "say hi"}),
+        boot_binding.clone(),
+        agents.path().to_path_buf(),
+    )
+    .await
+    .expect("task.run should succeed");
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    assert_eq!(value["binding"], boot_binding.to_json());
+}
+
+/// A per-call `project` must override the boot-time binding for this
+/// call, resolved through the same `ProjectBinding::resolve` helper
+/// `session.create` uses (#3178, DOC-39 §5.5/AC-16.2).
+#[tokio::test]
+async fn task_run_with_project_overrides_boot_binding() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let call_project = tempfile::tempdir().expect("project tempdir");
+
+    let value = task_run(
+        registry,
+        json!({
+            "task_description": "say hi",
+            "project": call_project.path().to_string_lossy(),
+        }),
+        ProjectBinding::None,
+        agents.path().to_path_buf(),
+    )
+    .await
+    .expect("task.run should succeed");
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    assert_eq!(
+        value["binding"]["state"], "directory",
+        "the per-call project must bind, not stay projectless: {value}"
+    );
+}
+
+/// A `project` naming a nonexistent path must map to `-32003
+/// invalid_argument`, matching `session.create`'s error mapping for the
+/// same failure mode.
+#[tokio::test]
+async fn task_run_rejects_invalid_project() {
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+
+    let err = task_run(
+        registry,
+        json!({"task_description": "say hi", "project": "/no/such/path/anywhere"}),
+        ProjectBinding::None,
+        agents.path().to_path_buf(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, -32003);
+}
+
+/// A `session_id` for an existing session must reuse it, not mint a new
+/// one.
+#[tokio::test]
+async fn task_run_sessionful_reuses_existing_session() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let existing = registry.create(
+        "say hi".to_string(),
+        None,
+        crate::binding::ProjectBinding::None,
+    );
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let result = task_run(
+        Arc::clone(&registry),
+        json!({"task_description": "say hi", "session_id": existing.id}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await;
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    let value = result.expect("task.run should succeed");
+    assert_eq!(value["session_id"], existing.id);
+}
+
+/// `session_id` + a `project` that RESTATES the reused session's own
+/// binding root must succeed (#3178, code-critic PR #3189 fix) — the
+/// invariant only forbids a DIFFERENT root, never the same one.
+#[tokio::test]
+async fn task_run_session_id_with_matching_project_succeeds() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    let session_binding =
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind");
+    let existing = registry.create("say hi".to_string(), None, session_binding);
+
+    let result = task_run(
+        Arc::clone(&registry),
+        json!({
+            "task_description": "say hi",
+            "session_id": existing.id,
+            "project": project.path().to_string_lossy(),
+        }),
+        ProjectBinding::None,
+        agents.path().to_path_buf(),
+    )
+    .await;
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    let value = result.expect("a project restating the session's own binding must succeed");
+    assert_eq!(value["session_id"], existing.id);
+    assert_eq!(value["binding"]["state"], "directory");
+}
+
+/// `session_id` + a `project` naming a DIFFERENT root than the reused
+/// session's own persisted binding must be rejected with `-32003
+/// invalid_argument` (#3178, code-critic HIGH finding, PR #3189) — never
+/// silently executed against a project `session.status`/`session.list`
+/// would never agree the session is bound to.
+#[tokio::test]
+async fn task_run_session_id_with_mismatched_project_is_rejected() {
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let session_project = tempfile::tempdir().expect("session project tempdir");
+    let other_project = tempfile::tempdir().expect("other project tempdir");
+    let session_binding = ProjectBinding::resolve(Some(session_project.path().to_path_buf()))
+        .expect("tempdir must bind");
+    let existing = registry.create("say hi".to_string(), None, session_binding);
+
+    let err = task_run(
+        registry,
+        json!({
+            "task_description": "say hi",
+            "session_id": existing.id,
+            "project": other_project.path().to_string_lossy(),
+        }),
+        ProjectBinding::None,
+        agents.path().to_path_buf(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, -32003);
+    assert!(
+        err.message.contains("does not match session"),
+        "error message must name the mismatch: {}",
+        err.message
+    );
+}
+
+/// A second `task.run` at the JSON-RPC entry point, issued AFTER the
+/// first run against the same `session_id` has fully `Finished`, must be
+/// ACCEPTED (#2344 resumption) rather than erroring — the acceptance
+/// criterion "two sequential task.run calls on one session" exercised at
+/// the actual RPC surface, not just `spawn_task_run` directly
+/// (`task::executor::tests::spawn_task_run_second_call_after_finish_appends_to_cumulative_transcript`
+/// covers the transcript-accumulation half; this test covers that
+/// `task_run` itself — including its `registry.status(id)` existing-
+/// session lookup — does not reject the resumed call).
+#[tokio::test]
+async fn task_run_second_call_after_finish_continues_the_session() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    let first = task_run(
+        Arc::clone(&registry),
+        json!({"task_description": "say hi"}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await
+    .expect("first task.run should succeed");
+    let session_id = first["session_id"].as_str().unwrap().to_string();
+
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(5);
+    loop {
+        let status = registry.status(&session_id).expect("session must exist");
+        if status.status.is_terminal() {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "first run did not reach a terminal state within 5s"
+        );
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    }
+
+    let second = task_run(
+        Arc::clone(&registry),
+        json!({"task_description": "say hi again", "session_id": session_id}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    )
+    .await;
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    let value = second.expect("a second task.run on a Finished session must be accepted");
+    assert_eq!(value["session_id"], session_id);
+    assert_eq!(value["status"], "running");
+}


### PR DESCRIPTION
## Summary

- Converges `session.create`'s and `task.run`'s project-binding entry points (DOC-39 §5.5, AC-16.2): `task.run`'s RPC params (and `POST /tasks`' JSON body) now accept an optional `project` path field.
- `project: Some(path)` resolves through the exact same `ProjectBinding::resolve` helper `session.create` already uses — no independent/duplicated resolution logic. A nonexistent path or non-directory maps to `-32003 invalid_argument` (`400` over REST), matching `session.create`'s error mapping.
- `project: None` (the field entirely absent) preserves today's process-boot-time binding unchanged — existing CLI/REST callers see no behavior change (back-compat).
- REST (`POST /tasks`) forwards `project` verbatim into the RPC `params`, exactly mirroring how `POST /sessions` already forwards its own `project` field to `session.create` — no independent REST-side serialization, per the RPC+REST parity precedent this crate already established (`session.get_agents`, `session.get_context_budget`, `session.get_search_audit`).

This is the keystone for epic #3174's project-first "pick a project and just start prompting" session flow.

Closes #3178

## Design notes

- `task::protocol::task_run` shadows its incoming boot-time `binding` parameter with the per-call resolved binding when `project` is present, so every downstream use (mode resolution, session creation, `TaskRunParams`, the response's own `binding` field) automatically uses the effective binding — no parallel code paths.
- When `session_id` is supplied to reuse an existing session, the effective binding still governs the run's `TaskRunParams`/mode resolution (matching pre-existing behavior for the boot-binding fallback case); this PR does not change how an existing session's own persisted `Session.binding` is read or mutated, which was out of scope for this issue.
- `RunTaskBody.project` is kept as `Option<String>` (not `PathBuf`) at the REST layer, mirroring `sessions_write::CreateBody`'s established convention — the RPC layer's own `PathBuf` deserialization + `ProjectBinding::resolve` do the actual work.

## Test plan

- [x] RPC-level: `task_run_without_project_keeps_boot_binding`, `task_run_with_project_overrides_boot_binding`, `task_run_rejects_invalid_project` (crates/trusty-code/src/task/protocol.rs)
- [x] REST-level: `run_task_with_project_binds_a_real_directory`, `run_task_invalid_project_returns_400` (crates/trusty-code/src/serve/rest/tasks.rs)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — zero warnings
- [x] `cargo test -p trusty-code` — `1216 passed; 0 failed; 4 ignored` (plus all other test binaries green)
- [x] `bash scripts/check_line_cap.sh` — `10 allowlisted, 0 violations — OK` (both touched files stay under the 500-SLOC production cap, not added to the allowlist)
- [x] CHANGELOG entry added under `[Unreleased]` for `trusty-code`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools