### PR TITLE
feat(trusty-agents): personality-editing panel + $HOME agents-dir dispatch fix

### DIFF
--- a/crates/trusty-agents/src/agents/loader.rs
+++ b/crates/trusty-agents/src/agents/loader.rs
@@ -98,7 +98,10 @@ impl AgentConfig {
     /// so the documented flow actually dispatches regardless of CWD. The
     /// `from_package` flag feeds [`Self::extends_shadow_fallback`], which must
     /// not let an unresolvable directory package silently shadow a complete flat
-    /// `<name>.toml`.
+    /// `<name>.toml` — and, since the package itself may have resolved from ANY
+    /// candidate directory (not just the primary one), the shadow rescue must
+    /// also search every candidate directory for the shadowing flat file rather
+    /// than assuming it lives in the same (primary) tier as the package.
     /// What: for each directory in [`agents_dir_candidates`], tries, in order:
     /// (1) the directory package (`<name>/agent.toml` + `persona.md`), (2) flat
     /// `<name>.toml`, (3) flat `<name>.md` via
@@ -149,30 +152,41 @@ impl AgentConfig {
     /// silent correctness/security hazard (a `[tools]`-less `izzie/agent.toml`
     /// shadowing a locked-down flat `izzie.toml`). Once the resolver works
     /// end-to-end the normal path resolves the package and this fires only on
-    /// genuine failures.
-    /// What: when the offending config came from a package AND a flat
-    /// `<name>.toml` exists alongside, logs a `warn` naming both paths and loads
-    /// the flat file (resolving its OWN `extends` if any, forcing `name` to bind
-    /// to the flat file rather than the shadowing package). Otherwise the
-    /// original resolution error is returned with context.
-    /// Test: `by_name_package_extends_shadow_falls_back_to_flat`.
+    /// genuine failures. #3198 code-critic fix: `by_name_unresolved_src` (and
+    /// its async twin) now resolve the offending package from ANY candidate
+    /// directory in [`agents_dir_candidates`] — e.g. the `$HOME` fallback tier
+    /// — not just the primary one. A single-tier `agents_dir()` lookup here
+    /// would therefore search the WRONG directory whenever the package came
+    /// from a non-primary tier, and hard-fail even though a valid flat
+    /// `<name>.toml` shadow exists right next to the package.
+    /// What: when the offending config came from a package, searches every
+    /// candidate directory (same order as [`agents_dir_candidates`]) for a flat
+    /// `<name>.toml`; on the first match, logs a `warn` naming both paths and
+    /// loads the flat file (resolving its OWN `extends` if any, forcing `name`
+    /// to bind to the flat file rather than the shadowing package). Otherwise
+    /// the original resolution error is returned with context.
+    /// Test: `by_name_package_extends_shadow_falls_back_to_flat`,
+    /// `extends_shadow_fallback_searches_home_tier_when_package_resolved_there`.
     fn extends_shadow_fallback(
         name: &str,
         from_package: bool,
         err: crate::agents::extends::AgentExtendsError,
     ) -> Result<Self> {
-        let dir = agents_dir();
-        let flat = dir.join(format!("{name}.toml"));
-        if from_package && flat.exists() {
-            tracing::warn!(
-                agent = %name,
-                package = %dir.join(name).display(),
-                flat = %flat.display(),
-                error = %err,
-                "directory-package `extends` failed to resolve; falling back to the \
-                 complete flat <name>.toml (refusing to serve the unresolved partial package)"
-            );
-            return Self::by_name_flat_toml(name, &flat);
+        if from_package {
+            for dir in agents_dir_candidates() {
+                let flat = dir.join(format!("{name}.toml"));
+                if flat.exists() {
+                    tracing::warn!(
+                        agent = %name,
+                        package = %dir.join(name).display(),
+                        flat = %flat.display(),
+                        error = %err,
+                        "directory-package `extends` failed to resolve; falling back to the \
+                         complete flat <name>.toml (refusing to serve the unresolved partial package)"
+                    );
+                    return Self::by_name_flat_toml(name, &flat);
+                }
+            }
         }
         Err(anyhow::Error::new(err))
             .with_context(|| format!("failed to resolve `extends` chain for agent '{name}'"))
@@ -540,7 +554,9 @@ fn agents_dir() -> PathBuf {
 /// when `HOME` is set and differs from the primary directory (avoids a
 /// redundant duplicate tier when they already coincide).
 /// Test: `by_name_finds_flat_md_in_home_tier_when_project_dir_misses`,
-/// `by_name_async_finds_flat_md_in_home_tier_when_project_dir_misses`
+/// `by_name_async_finds_flat_md_in_home_tier_when_project_dir_misses`,
+/// `same_name_project_local_shadows_home_tier` (+ async),
+/// `extends_shadow_fallback_searches_home_tier_when_package_resolved_there`
 /// (tests/loading.rs).
 fn agents_dir_candidates() -> Vec<PathBuf> {
     let primary = agents_dir();

--- a/crates/trusty-agents/src/agents/loader.rs
+++ b/crates/trusty-agents/src/agents/loader.rs
@@ -85,43 +85,57 @@ impl AgentConfig {
     /// per-name loader only tried `<name>/agent.toml` and `<name>.toml` — so a
     /// user's `~/.trusty-agents/agents/my-assistant.md` was visible in the
     /// registry roster but FILE-NOT-FOUND at dispatch (every runner loads via
-    /// `by_name`/`by_name_async`, not the informational registry). This adds the
-    /// missing flat-`.md` tier so the documented flow actually dispatches. The
+    /// `by_name`/`by_name_async`, not the informational registry). #3055 added
+    /// the missing flat-`.md` tier but ONLY under a single `agents_dir()` — which
+    /// has no `$HOME` awareness at all (unlike
+    /// [`agent_search_paths`](crate::agents::registry::agent_search_paths), which
+    /// DOES search `~/.trusty-agents/agents`). So a personalization overlay
+    /// dropped in `~/.trusty-agents/agents/` was STILL FILE-NOT-FOUND at dispatch
+    /// whenever `TAGENT_CONFIG_DIR` was unset and the process CWD wasn't the
+    /// project root (#3061). This tries every tier under EACH candidate
+    /// directory from [`agents_dir_candidates`] — primary (`TAGENT_CONFIG_DIR` /
+    /// project-local) first, `$HOME/.trusty-agents/agents` as a fallback tier —
+    /// so the documented flow actually dispatches regardless of CWD. The
     /// `from_package` flag feeds [`Self::extends_shadow_fallback`], which must
     /// not let an unresolvable directory package silently shadow a complete flat
     /// `<name>.toml`.
-    /// What: tries, in order under `agents_dir()`: (1) the directory package
-    /// (`<name>/agent.toml` + `persona.md`), (2) flat `<name>.toml`, (3) flat
-    /// `<name>.md` via [`parse_md_agent`](crate::agents::registry::parse_md_agent),
-    /// (4) the synchronous claude-mpm `.md` fallback (kept in lock-step with the
-    /// async loader's tiers so ancestor resolution is symmetric — see the
-    /// async/sync drift note in `by_name_async_unresolved`). Returns
-    /// `(config, came_from_package)`.
+    /// What: for each directory in [`agents_dir_candidates`], tries, in order:
+    /// (1) the directory package (`<name>/agent.toml` + `persona.md`), (2) flat
+    /// `<name>.toml`, (3) flat `<name>.md` via
+    /// [`parse_md_agent`](crate::agents::registry::parse_md_agent). Once every
+    /// candidate directory is exhausted, falls through to (4) the synchronous
+    /// claude-mpm `.md` fallback (kept in lock-step with the async loader's
+    /// tiers so ancestor resolution is symmetric — see the async/sync drift note
+    /// in `by_name_async_unresolved`). Returns `(config, came_from_package)`.
     /// Test: `by_name_flat_md_extends_dispatches`,
-    /// `by_name_package_extends_shadow_falls_back_to_flat` (tests.rs).
+    /// `by_name_package_extends_shadow_falls_back_to_flat`,
+    /// `by_name_finds_flat_md_in_home_tier_when_project_dir_misses` (tests.rs).
     fn by_name_unresolved_src(name: &str) -> Result<(Self, bool)> {
-        // #482: Prefer the directory-package format when present.
-        let dir = agents_dir();
-        if let Some(cfg) = load_agent_package(&dir, name)? {
-            return Ok((cfg, true));
-        }
-        let toml_path = dir.join(format!("{name}.toml"));
-        if toml_path.exists() {
-            return Ok((Self::load(&toml_path)?, false));
-        }
-        // #3055: flat `.md` personalization overlay — the primary user surface.
-        let md_path = dir.join(format!("{name}.md"));
-        if md_path.exists() {
-            let cfg = crate::agents::registry::parse_md_agent(&md_path)
-                .with_context(|| format!("failed to load agent md {}", md_path.display()))?;
-            return Ok((cfg, false));
+        let dirs = agents_dir_candidates();
+        for dir in &dirs {
+            // #482: Prefer the directory-package format when present.
+            if let Some(cfg) = load_agent_package(dir, name)? {
+                return Ok((cfg, true));
+            }
+            let toml_path = dir.join(format!("{name}.toml"));
+            if toml_path.exists() {
+                return Ok((Self::load(&toml_path)?, false));
+            }
+            // #3055: flat `.md` personalization overlay — the primary user surface.
+            let md_path = dir.join(format!("{name}.md"));
+            if md_path.exists() {
+                let cfg = crate::agents::registry::parse_md_agent(&md_path)
+                    .with_context(|| format!("failed to load agent md {}", md_path.display()))?;
+                return Ok((cfg, false));
+            }
         }
         // claude-mpm compatibility tier (sync), symmetric with the async loader.
         if let Some(cfg) = crate::agents::claude_mpm_loader::find_agent_sync(name) {
             return Ok((cfg, false));
         }
         // Preserve the historical missing-`<name>.toml` error shape when nothing
-        // resolved.
+        // resolved — report against the primary (highest-priority) directory.
+        let toml_path = dirs[0].join(format!("{name}.toml"));
         Ok((Self::load(&toml_path)?, false))
     }
 
@@ -248,8 +262,11 @@ impl AgentConfig {
         // loader uses sync `std::fs`; the reads are small config files, so
         // the blocking cost is negligible relative to the LLM dispatch that
         // follows.
-        let dir = agents_dir();
-        let (cfg, from_package) = Self::by_name_async_unresolved(name, &dir).await?;
+        // #3061: iterate every candidate directory (primary, then the
+        // `$HOME/.trusty-agents/agents` fallback tier) — mirrors the sync
+        // `by_name_unresolved_src` fix.
+        let dirs = agents_dir_candidates();
+        let (cfg, from_package) = Self::by_name_async_unresolved(name, &dirs).await?;
         // #3055: resolve `extends` at load time (DOC-41 §2.5). Base lookups use
         // the sync unresolved loader — which now carries the SAME tier set as
         // the async loader (package → flat toml → flat md → claude-mpm), so a
@@ -272,48 +289,58 @@ impl AgentConfig {
     /// Why: `by_name_async` needs the raw, still-`extends`-bearing child before
     /// it walks the chain.
     /// What: mirrors [`Self::by_name_unresolved_src`]'s tier ORDER exactly so
-    /// sync and async resolve the same agents: directory package → flat
-    /// `<name>.toml` → flat `<name>.md` (#3055 personalization overlay) →
-    /// claude-mpm `.md` fallback. Returns `(config, came_from_package)`.
+    /// sync and async resolve the same agents: for each candidate directory
+    /// (primary, then `$HOME/.trusty-agents/agents`, #3061) — directory package
+    /// → flat `<name>.toml` → flat `<name>.md` (#3055 personalization overlay)
+    /// — then, once all directories are exhausted, the claude-mpm `.md`
+    /// fallback. Returns `(config, came_from_package)`.
     /// Test: `by_name_async_loads_plan_agent`,
     /// `by_name_async_flat_md_extends_dispatches`.
-    async fn by_name_async_unresolved(name: &str, dir: &Path) -> Result<(Self, bool)> {
-        if let Some(cfg) = load_agent_package(dir, name)? {
-            return Ok((cfg, true));
-        }
-        let path = dir.join(format!("{name}.toml"));
-        match tokio::fs::read_to_string(&path).await {
-            Ok(raw) => Ok((Self::from_toml_str(&raw, &path)?, false)),
-            Err(e) => {
-                // #3055: flat `.md` personalization overlay tier, BEFORE the
-                // claude-mpm fallback — matching `by_name_unresolved_src`.
-                let md_path = dir.join(format!("{name}.md"));
-                if md_path.exists() {
-                    let cfg =
-                        crate::agents::registry::parse_md_agent(&md_path).with_context(|| {
-                            format!("failed to load agent md {}", md_path.display())
-                        })?;
-                    return Ok((cfg, false));
+    async fn by_name_async_unresolved(name: &str, dirs: &[PathBuf]) -> Result<(Self, bool)> {
+        for dir in dirs {
+            if let Some(cfg) = load_agent_package(dir, name)? {
+                return Ok((cfg, true));
+            }
+            let path = dir.join(format!("{name}.toml"));
+            match tokio::fs::read_to_string(&path).await {
+                Ok(raw) => return Ok((Self::from_toml_str(&raw, &path)?, false)),
+                Err(_e) => {
+                    // #3055: flat `.md` personalization overlay tier, BEFORE the
+                    // claude-mpm fallback — matching `by_name_unresolved_src`.
+                    let md_path = dir.join(format!("{name}.md"));
+                    if md_path.exists() {
+                        let cfg = crate::agents::registry::parse_md_agent(&md_path).with_context(
+                            || format!("failed to load agent md {}", md_path.display()),
+                        )?;
+                        return Ok((cfg, false));
+                    }
+                    // Neither tier matched in this directory; try the next
+                    // candidate directory before giving up.
                 }
-                // #128: Fallback to claude-mpm agent format (.md + YAML
-                // frontmatter) discovered under `.claude/agents/` (project)
-                // or `~/.claude/agents/` (user). Lets operators drop in
-                // claude-mpm agents without converting to TOML.
-                let project_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-                if let Some(agent) =
-                    crate::agents::claude_mpm_loader::find_agent(name, &project_dir).await
-                {
-                    tracing::info!(
-                        agent = %name,
-                        source = %agent.source_path.display(),
-                        "loaded claude-mpm agent (fallback from missing TOML)"
-                    );
-                    return Ok((agent.to_agent_config(), false));
-                }
-                Err(anyhow::Error::new(e))
-                    .with_context(|| format!("failed to read agent config {}", path.display()))
             }
         }
+        // #128: Fallback to claude-mpm agent format (.md + YAML
+        // frontmatter) discovered under `.claude/agents/` (project)
+        // or `~/.claude/agents/` (user). Lets operators drop in
+        // claude-mpm agents without converting to TOML.
+        let project_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        if let Some(agent) = crate::agents::claude_mpm_loader::find_agent(name, &project_dir).await
+        {
+            tracing::info!(
+                agent = %name,
+                source = %agent.source_path.display(),
+                "loaded claude-mpm agent (fallback from missing TOML)"
+            );
+            return Ok((agent.to_agent_config(), false));
+        }
+        // Preserve the historical missing-`<name>.toml` error shape when
+        // nothing resolved — report against the primary (highest-priority)
+        // directory by re-attempting the read to surface the real io error.
+        let path = dirs[0].join(format!("{name}.toml"));
+        let raw = tokio::fs::read_to_string(&path)
+            .await
+            .with_context(|| format!("failed to read agent config {}", path.display()))?;
+        Ok((Self::from_toml_str(&raw, &path)?, false))
     }
 
     /// Shared parsing + adapter-resolution path used by both `load` and
@@ -493,6 +520,38 @@ fn agents_dir() -> PathBuf {
             new_dir
         }
     }
+}
+
+/// Candidate agent directories in priority order for per-name dispatch
+/// (`by_name` / `by_name_async`).
+///
+/// Why: `agents_dir()` resolves to a SINGLE directory — `TAGENT_CONFIG_DIR`
+/// when set, else the CWD-relative project-local `.trusty-agents/agents` — with
+/// no `$HOME` awareness at all. The registry ROSTER
+/// ([`agent_search_paths`](crate::agents::registry::agent_search_paths)) DOES
+/// search `~/.trusty-agents/agents`, so a personalization overlay dropped
+/// there shows up in listings but was FILE-NOT-FOUND at dispatch (#3061) —
+/// every runner loads via `by_name`/`by_name_async`, never the informational
+/// registry. This adds `$HOME/.trusty-agents/agents` as an explicit fallback
+/// TIER (searched only after the primary directory misses), preserving the
+/// documented precedence: explicit `TAGENT_CONFIG_DIR` > project-local >
+/// `$HOME`.
+/// What: Returns `[agents_dir()]`, plus `$HOME/.trusty-agents/agents` appended
+/// when `HOME` is set and differs from the primary directory (avoids a
+/// redundant duplicate tier when they already coincide).
+/// Test: `by_name_finds_flat_md_in_home_tier_when_project_dir_misses`,
+/// `by_name_async_finds_flat_md_in_home_tier_when_project_dir_misses`
+/// (tests/loading.rs).
+fn agents_dir_candidates() -> Vec<PathBuf> {
+    let primary = agents_dir();
+    let mut dirs = vec![primary.clone()];
+    if let Some(home) = std::env::var_os("HOME") {
+        let home_dir = PathBuf::from(home).join(".trusty-agents/agents");
+        if home_dir != primary {
+            dirs.push(home_dir);
+        }
+    }
+    dirs
 }
 
 // Why: Helper kept available for ad-hoc tooling that needs the flat

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -731,14 +731,17 @@ allowed = ["locked_tool"]
 /// `~/.trusty-agents/agents`. So a personalization overlay dropped in
 /// `~/.trusty-agents/agents/` showed up in listings but was FILE-NOT-FOUND at
 /// dispatch. This proves `agents_dir_candidates()`'s `$HOME` fallback tier
-/// fixes it: the primary (project-local) directory here genuinely lacks the
-/// agent (unique per-process name), so resolution can only succeed by falling
-/// through to the `$HOME` tier.
+/// fixes it. #3198 code-critic: `TAGENT_CONFIG_DIR` is pinned to a dedicated,
+/// deliberately-empty tempdir (rather than left unset to fall back on the
+/// real project-local `.trusty-agents/agents/`) — deterministic primary-tier
+/// isolation, matching the sibling `TAGENT_CONFIG_DIR`-pinning tests in this
+/// file, and independent of `cargo test`'s CWD.
 #[test]
 fn by_name_finds_flat_md_in_home_tier_when_project_dir_misses() {
     let _guard = ENV_LOCK.blocking_lock();
-    let tmp = tempfile::tempdir().expect("temp dir");
-    let home_agents = tmp.path().join(".trusty-agents").join("agents");
+    let primary_tmp = tempfile::tempdir().expect("primary temp dir");
+    let home_tmp = tempfile::tempdir().expect("home temp dir");
+    let home_agents = home_tmp.path().join(".trusty-agents").join("agents");
     std::fs::create_dir_all(&home_agents).expect("mkdir home agents");
     let unique_name = format!("home-tier-agent-{}", std::process::id());
     std::fs::write(
@@ -751,13 +754,15 @@ fn by_name_finds_flat_md_in_home_tier_when_project_dir_misses() {
     let prev_home = std::env::var_os("HOME");
     // SAFETY: guarded by ENV_LOCK.
     unsafe {
-        // Force the project-local primary tier (which lacks this name).
-        std::env::remove_var("TAGENT_CONFIG_DIR");
-        std::env::set_var("HOME", tmp.path());
+        // Primary tier is a fresh, empty tempdir — deliberately isolated from
+        // the real project-local `.trusty-agents/agents/`.
+        std::env::set_var("TAGENT_CONFIG_DIR", primary_tmp.path());
+        std::env::set_var("HOME", home_tmp.path());
     }
     let result = AgentConfig::by_name(&unique_name);
     // SAFETY: guarded by ENV_LOCK.
     unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
         match &prev_home {
             Some(v) => std::env::set_var("HOME", v),
             None => std::env::remove_var("HOME"),
@@ -775,8 +780,9 @@ fn by_name_finds_flat_md_in_home_tier_when_project_dir_misses() {
 #[tokio::test]
 async fn by_name_async_finds_flat_md_in_home_tier_when_project_dir_misses() {
     let _guard = ENV_LOCK.lock().await;
-    let tmp = tempfile::tempdir().expect("temp dir");
-    let home_agents = tmp.path().join(".trusty-agents").join("agents");
+    let primary_tmp = tempfile::tempdir().expect("primary temp dir");
+    let home_tmp = tempfile::tempdir().expect("home temp dir");
+    let home_agents = home_tmp.path().join(".trusty-agents").join("agents");
     std::fs::create_dir_all(&home_agents).expect("mkdir home agents");
     let unique_name = format!("home-tier-agent-async-{}", std::process::id());
     std::fs::write(
@@ -789,12 +795,13 @@ async fn by_name_async_finds_flat_md_in_home_tier_when_project_dir_misses() {
     let prev_home = std::env::var_os("HOME");
     // SAFETY: guarded by ENV_LOCK across the await below.
     unsafe {
-        std::env::remove_var("TAGENT_CONFIG_DIR");
-        std::env::set_var("HOME", tmp.path());
+        std::env::set_var("TAGENT_CONFIG_DIR", primary_tmp.path());
+        std::env::set_var("HOME", home_tmp.path());
     }
     let result = AgentConfig::by_name_async(&unique_name).await;
     // SAFETY: guarded by ENV_LOCK.
     unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
         match &prev_home {
             Some(v) => std::env::set_var("HOME", v),
             None => std::env::remove_var("HOME"),
@@ -803,4 +810,163 @@ async fn by_name_async_finds_flat_md_in_home_tier_when_project_dir_misses() {
 
     let cfg = result.expect("by_name_async must find the overlay via the $HOME fallback tier");
     assert_eq!(cfg.system_prompt.content, "HOME TIER ASYNC PROSE");
+}
+
+/// #3198 code-critic MEDIUM fix: proves `agents_dir_candidates()` preserves
+/// the documented precedence (explicit `TAGENT_CONFIG_DIR`/project-local >
+/// `$HOME`) rather than e.g. merging fields or preferring `$HOME` — when the
+/// SAME agent name exists as a flat `.md` in BOTH the primary directory and
+/// the `$HOME` fallback tier, the primary tier's content must win.
+#[test]
+fn same_name_project_local_shadows_home_tier() {
+    let _guard = ENV_LOCK.blocking_lock();
+    let primary_tmp = tempfile::tempdir().expect("primary temp dir");
+    let home_tmp = tempfile::tempdir().expect("home temp dir");
+    let home_agents = home_tmp.path().join(".trusty-agents").join("agents");
+    std::fs::create_dir_all(&home_agents).expect("mkdir home agents");
+
+    let unique_name = format!("shadow-agent-{}", std::process::id());
+    std::fs::write(
+        primary_tmp.path().join(format!("{unique_name}.md")),
+        format!("---\nname: {unique_name}\nrole: agent\n---\nPRIMARY TIER PROSE"),
+    )
+    .expect("write primary overlay");
+    std::fs::write(
+        home_agents.join(format!("{unique_name}.md")),
+        format!("---\nname: {unique_name}\nrole: agent\n---\nHOME TIER PROSE"),
+    )
+    .expect("write home overlay");
+
+    clear_model_env(&unique_name);
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        std::env::set_var("TAGENT_CONFIG_DIR", primary_tmp.path());
+        std::env::set_var("HOME", home_tmp.path());
+    }
+    let result = AgentConfig::by_name(&unique_name);
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+        match &prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    let cfg = result.expect("by_name must resolve when both tiers have the name");
+    assert_eq!(cfg.system_prompt.content, "PRIMARY TIER PROSE");
+}
+
+/// Async counterpart of `same_name_project_local_shadows_home_tier`.
+#[tokio::test]
+async fn by_name_async_same_name_project_local_shadows_home_tier() {
+    let _guard = ENV_LOCK.lock().await;
+    let primary_tmp = tempfile::tempdir().expect("primary temp dir");
+    let home_tmp = tempfile::tempdir().expect("home temp dir");
+    let home_agents = home_tmp.path().join(".trusty-agents").join("agents");
+    std::fs::create_dir_all(&home_agents).expect("mkdir home agents");
+
+    let unique_name = format!("shadow-agent-async-{}", std::process::id());
+    std::fs::write(
+        primary_tmp.path().join(format!("{unique_name}.md")),
+        format!("---\nname: {unique_name}\nrole: agent\n---\nPRIMARY TIER ASYNC PROSE"),
+    )
+    .expect("write primary overlay");
+    std::fs::write(
+        home_agents.join(format!("{unique_name}.md")),
+        format!("---\nname: {unique_name}\nrole: agent\n---\nHOME TIER ASYNC PROSE"),
+    )
+    .expect("write home overlay");
+
+    clear_model_env(&unique_name);
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: guarded by ENV_LOCK across the await below.
+    unsafe {
+        std::env::set_var("TAGENT_CONFIG_DIR", primary_tmp.path());
+        std::env::set_var("HOME", home_tmp.path());
+    }
+    let result = AgentConfig::by_name_async(&unique_name).await;
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+        match &prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    let cfg = result.expect("by_name_async must resolve when both tiers have the name");
+    assert_eq!(cfg.system_prompt.content, "PRIMARY TIER ASYNC PROSE");
+}
+
+/// #3198 code-critic HIGH fix regression: when a directory-package agent
+/// resolves from the `$HOME` fallback tier (not the primary directory) and
+/// its `extends` fails to resolve, the flat `<name>.toml` shadow-rescue
+/// (`extends_shadow_fallback`) must search that SAME tier rather than only
+/// the (empty) primary directory. Before the fix this hard-failed even
+/// though a valid flat shadow sat right next to the package in `$HOME`.
+#[test]
+fn extends_shadow_fallback_searches_home_tier_when_package_resolved_there() {
+    let _guard = ENV_LOCK.blocking_lock();
+    let primary_tmp = tempfile::tempdir().expect("primary temp dir");
+    let home_tmp = tempfile::tempdir().expect("home temp dir");
+    let home_agents = home_tmp.path().join(".trusty-agents").join("agents");
+    std::fs::create_dir_all(&home_agents).expect("mkdir home agents");
+
+    let unique_name = format!("home-shadow-agent-{}", std::process::id());
+
+    // Package with an UNRESOLVABLE extends and NO [tools], living ONLY in
+    // the $HOME tier.
+    let pkg = home_agents.join(&unique_name);
+    std::fs::create_dir(&pkg).expect("mk pkg");
+    std::fs::write(
+        pkg.join("agent.toml"),
+        format!(
+            "\n[agent]\nname = \"{unique_name}\"\nrole = \"assistant\"\n\
+             model = \"anthropic/claude-sonnet-4-6\"\ndescription = \"partial package\"\n\
+             extends = \"ghost-base\"\n\n[llm]\ntemperature = 0.0\nmax_tokens = 1024\n"
+        ),
+    )
+    .expect("write pkg agent.toml");
+    std::fs::write(pkg.join("persona.md"), "PARTIAL PACKAGE").expect("write persona");
+
+    // Complete flat <name>.toml alongside it, in the SAME $HOME tier.
+    std::fs::write(
+        home_agents.join(format!("{unique_name}.toml")),
+        format!(
+            "\n[agent]\nname = \"{unique_name}\"\nrole = \"assistant\"\n\
+             model = \"anthropic/claude-sonnet-4-6\"\ndescription = \"complete flat\"\n\n\
+             [llm]\ntemperature = 0.0\nmax_tokens = 1024\n\n\
+             [system_prompt]\ncontent = \"HOME SHADOW FLAT\"\n\n\
+             [tools]\nallowed = [\"locked_tool\"]\n"
+        ),
+    )
+    .expect("write flat toml");
+
+    clear_model_env(&unique_name);
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        // Primary tier is a fresh, empty tempdir — the package/flat pair
+        // exists ONLY under the $HOME tier.
+        std::env::set_var("TAGENT_CONFIG_DIR", primary_tmp.path());
+        std::env::set_var("HOME", home_tmp.path());
+    }
+    let result = AgentConfig::by_name(&unique_name);
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+        match &prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    let cfg = result.expect("shadow fallback must search the $HOME tier, not just primary");
+    assert_eq!(cfg.system_prompt.content, "HOME SHADOW FLAT");
+    assert_eq!(
+        cfg.tools.allowed.as_deref(),
+        Some(&["locked_tool".to_string()][..])
+    );
 }

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -723,3 +723,84 @@ allowed = ["locked_tool"]
         Some(&["locked_tool".to_string()][..])
     );
 }
+
+/// #3061: `agents_dir()` resolves a SINGLE directory (`TAGENT_CONFIG_DIR` or
+/// the CWD-relative project-local `.trusty-agents/agents`) with no `$HOME`
+/// awareness at all — unlike the registry roster
+/// (`agent_search_paths`/`registry::mod.rs`), which DOES search
+/// `~/.trusty-agents/agents`. So a personalization overlay dropped in
+/// `~/.trusty-agents/agents/` showed up in listings but was FILE-NOT-FOUND at
+/// dispatch. This proves `agents_dir_candidates()`'s `$HOME` fallback tier
+/// fixes it: the primary (project-local) directory here genuinely lacks the
+/// agent (unique per-process name), so resolution can only succeed by falling
+/// through to the `$HOME` tier.
+#[test]
+fn by_name_finds_flat_md_in_home_tier_when_project_dir_misses() {
+    let _guard = ENV_LOCK.blocking_lock();
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let home_agents = tmp.path().join(".trusty-agents").join("agents");
+    std::fs::create_dir_all(&home_agents).expect("mkdir home agents");
+    let unique_name = format!("home-tier-agent-{}", std::process::id());
+    std::fs::write(
+        home_agents.join(format!("{unique_name}.md")),
+        format!("---\nname: {unique_name}\nrole: agent\n---\nHOME TIER PROSE"),
+    )
+    .expect("write home overlay");
+
+    clear_model_env(&unique_name);
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        // Force the project-local primary tier (which lacks this name).
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+        std::env::set_var("HOME", tmp.path());
+    }
+    let result = AgentConfig::by_name(&unique_name);
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        match &prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    let cfg = result.expect("by_name must find the overlay via the $HOME fallback tier");
+    assert_eq!(cfg.system_prompt.content, "HOME TIER PROSE");
+}
+
+/// Async counterpart of `by_name_finds_flat_md_in_home_tier_when_project_dir_misses`
+/// — proves `by_name_async`'s tier set is symmetric with the sync loader after
+/// the #3061 fix (both call `agents_dir_candidates()`, not a bare
+/// `agents_dir()`).
+#[tokio::test]
+async fn by_name_async_finds_flat_md_in_home_tier_when_project_dir_misses() {
+    let _guard = ENV_LOCK.lock().await;
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let home_agents = tmp.path().join(".trusty-agents").join("agents");
+    std::fs::create_dir_all(&home_agents).expect("mkdir home agents");
+    let unique_name = format!("home-tier-agent-async-{}", std::process::id());
+    std::fs::write(
+        home_agents.join(format!("{unique_name}.md")),
+        format!("---\nname: {unique_name}\nrole: agent\n---\nHOME TIER ASYNC PROSE"),
+    )
+    .expect("write home overlay");
+
+    clear_model_env(&unique_name);
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: guarded by ENV_LOCK across the await below.
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+        std::env::set_var("HOME", tmp.path());
+    }
+    let result = AgentConfig::by_name_async(&unique_name).await;
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        match &prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+
+    let cfg = result.expect("by_name_async must find the overlay via the $HOME fallback tier");
+    assert_eq!(cfg.system_prompt.content, "HOME TIER ASYNC PROSE");
+}

--- a/crates/trusty-agents/ui/src-tauri/src/main.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/main.rs
@@ -7,19 +7,26 @@
 //! (2) translate frontend `invoke(...)` calls into REST calls against that
 //! sidecar, and (3) emit `task-progress` / `task-complete` / `task-error`
 //! Tauri events so ChatView can stream a running task into its bubble.
-//! What: Four Tauri commands (`ensure_api_server`, `send_message`,
-//! `list_tasks`, `check_health`) plus a lightweight spawned-process registry
-//! to avoid double-starting the API server. As of #3059 the window runs in
-//! persistent/tray mode: closing the window only hides it (the sidecar stays
-//! alive so in-flight tasks keep running); a tray icon with Show/Quit lets
-//! the user bring the window back or fully quit. The sidecar is only reaped
-//! on a real quit (tray "Quit", Cmd+Q, or app-menu Quit — all surface as
-//! `RunEvent::ExitRequested`).
+//! What: Six Tauri commands (`ensure_api_server`, `send_message`,
+//! `list_tasks`, `check_health`, `read_personalization_overlay`,
+//! `write_personalization_overlay`) plus a lightweight spawned-process
+//! registry to avoid double-starting the API server. As of #3059 the window
+//! runs in persistent/tray mode: closing the window only hides it (the
+//! sidecar stays alive so in-flight tasks keep running); a tray icon with
+//! Show/Quit lets the user bring the window back or fully quit. The sidecar
+//! is only reaped on a real quit (tray "Quit", Cmd+Q, or app-menu Quit — all
+//! surface as `RunEvent::ExitRequested`). #3061 adds the
+//! `read_personalization_overlay` / `write_personalization_overlay` pair so
+//! the Personality panel can edit the user's `~/.trusty-agents/agents/*.md`
+//! overlay directly — both operate ONLY under that fixed `$HOME` directory,
+//! gated by a strict `[a-zA-Z0-9_-]+` slug check on `name` (no path
+//! separators, no `..` traversal).
 //! Test: `cargo check` in `ui/src-tauri/` passes; launching the app and
 //! sending a message produces a chat bubble that grows while polling the
 //! task id. Tray hide/show/quit behavior is smoke-tested manually (see PR
 //! description) — Tauri's window-manager event loop isn't unit-testable
-//! from this crate.
+//! from this crate. Personalization overlay commands are covered by
+//! `personalization_overlay_path_*` unit tests below.
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
@@ -364,6 +371,127 @@ async fn send_message(
     }
 }
 
+/// Result payload for `read_personalization_overlay`.
+///
+/// Why: The frontend needs to tell "file exists with this content" apart
+/// from "file does not exist yet" so it can offer a starter template instead
+/// of rendering a blank/broken editor. A plain `Result<String, String>` would
+/// conflate a genuine not-found with a real I/O error.
+/// What: `content: None` signals not-found (the UI should offer the starter
+/// template); `content: Some(text)` is the file's current contents. Real I/O
+/// errors (permission denied, etc.) still surface via the command's `Err`.
+/// Test: `personalization_overlay_path_rejects_traversal_and_separators`,
+/// manual: delete `~/.trusty-agents/agents/my-assistant.md`, open the panel,
+/// confirm the starter-template prompt renders.
+#[derive(Debug, Serialize)]
+struct PersonalizationOverlay {
+    content: Option<String>,
+    path: String,
+}
+
+/// Validate an agent-name slug used to derive a personalization overlay path.
+///
+/// Why: `read_personalization_overlay` / `write_personalization_overlay`
+/// build a filesystem path from a frontend-supplied `name`. Without a strict
+/// allowlist a name like `../../etc/passwd` or an absolute path could escape
+/// `~/.trusty-agents/agents/` entirely — the fs commands must operate ONLY
+/// inside that fixed directory. Rejecting anything but `[a-zA-Z0-9_-]+`
+/// rules out path separators (`/`, `\`), `.` (so no `..` traversal or hidden
+/// dotfiles), and empty names in one check, with no need to reason about
+/// platform-specific separator quirks.
+/// What: Returns `true` iff `name` is non-empty and every char is an ASCII
+/// alphanumeric, `_`, or `-`.
+/// Test: `agent_slug_accepts_simple_names`,
+/// `agent_slug_rejects_path_separators_and_traversal`.
+fn is_valid_agent_slug(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+/// Resolve the on-disk path for a personalization overlay, validating `name`.
+///
+/// Why: Centralizes both the slug check and the `$HOME`-anchored join so
+/// `read_personalization_overlay` and `write_personalization_overlay` can't
+/// drift (e.g. one command validating and the other forgetting to). Always
+/// resolves under the real `$HOME`, mirroring the backend's own
+/// `agents_dir_candidates()` `$HOME` fallback tier (trusty-agents#3061) — this
+/// is deliberately the ONLY tier the GUI writes to; it never touches
+/// `TAGENT_CONFIG_DIR` or a project-local `.trusty-agents/agents/`.
+/// What: Returns `Err` when `name` fails [`is_valid_agent_slug`] or `$HOME`
+/// is unset; otherwise `$HOME/.trusty-agents/agents/<name>.md`.
+/// Test: `personalization_overlay_path_rejects_traversal_and_separators`,
+/// `personalization_overlay_path_joins_home_dir`.
+fn personalization_overlay_path(name: &str) -> Result<std::path::PathBuf, String> {
+    if !is_valid_agent_slug(name) {
+        return Err(format!(
+            "invalid agent name '{name}': must match [a-zA-Z0-9_-]+ (no path separators or dots)"
+        ));
+    }
+    let home = std::env::var_os("HOME")
+        .ok_or_else(|| "cannot resolve personalization overlay: $HOME is not set".to_string())?;
+    Ok(std::path::PathBuf::from(home)
+        .join(".trusty-agents")
+        .join("agents")
+        .join(format!("{name}.md")))
+}
+
+/// Read a user's `~/.trusty-agents/agents/<name>.md` personalization overlay.
+///
+/// Why: The Personality panel needs the current overlay content (if any) to
+/// populate its editor on open, and a clear not-found signal (rather than an
+/// error) so the UI can offer a starter template for a first-time user.
+/// What: Resolves and validates the path via
+/// [`personalization_overlay_path`], then reads it. A missing file yields
+/// `Ok(PersonalizationOverlay { content: None, .. })`; any other I/O failure
+/// (permissions, etc.) is a genuine `Err`.
+/// Test: `personalization_overlay_path_rejects_traversal_and_separators`;
+/// manual: create/delete the target file and confirm both branches render
+/// correctly in the panel.
+#[tauri::command]
+fn read_personalization_overlay(name: String) -> Result<PersonalizationOverlay, String> {
+    let path = personalization_overlay_path(&name)?;
+    match std::fs::read_to_string(&path) {
+        Ok(content) => Ok(PersonalizationOverlay {
+            content: Some(content),
+            path: path.display().to_string(),
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(PersonalizationOverlay {
+            content: None,
+            path: path.display().to_string(),
+        }),
+        Err(e) => Err(format!(
+            "failed to read personalization overlay {}: {e}",
+            path.display()
+        )),
+    }
+}
+
+/// Write a user's `~/.trusty-agents/agents/<name>.md` personalization overlay.
+///
+/// Why: This is the Save action for the Personality panel — prose-only
+/// editing per #3061 (no structured schema). Creates the
+/// `~/.trusty-agents/agents/` directory on first write since a fresh install
+/// won't have it yet.
+/// What: Resolves and validates the path via
+/// [`personalization_overlay_path`], creates the parent directory if
+/// missing, then writes `content` verbatim (full overwrite, matching a plain
+/// text-editor Save).
+/// Test: `personalization_overlay_path_rejects_traversal_and_separators`;
+/// manual: edit + Save in the panel, confirm the file on disk matches and
+/// that `by_name`/`by_name_async` (trusty-agents#3061 loader fix) dispatch
+/// it.
+#[tauri::command]
+fn write_personalization_overlay(name: String, content: String) -> Result<(), String> {
+    let path = personalization_overlay_path(&name)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    }
+    std::fs::write(&path, content).map_err(|e| format!("failed to write {}: {e}", path.display()))
+}
+
 /// Reap the spawned `trusty-agents --api` sidecar, exactly once.
 ///
 /// Why: The tray "Quit" item and the real-quit `RunEvent::ExitRequested`
@@ -405,6 +533,8 @@ fn main() {
             send_message,
             list_tasks,
             check_health,
+            read_personalization_overlay,
+            write_personalization_overlay,
         ])
         .setup(|app| {
             // Tray icon + menu (#3059): lets the user bring the hidden main
@@ -520,4 +650,117 @@ fn tracing_subscriber_try_init() -> Result<(), String> {
     // No-op: we just inherit stderr from the Rust side, which is enough for
     // dev. Hook in `tracing-subscriber` here when we want filtering.
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Why: `personalization_overlay_path` reads the process-global `$HOME`
+    // env var; these are the only tests in this crate that mutate it, but
+    // `cargo test` still runs them concurrently on multiple threads within
+    // this binary unless serialized.
+    static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn agent_slug_accepts_simple_names() {
+        assert!(is_valid_agent_slug("my-assistant"));
+        assert!(is_valid_agent_slug("my_assistant2"));
+        assert!(is_valid_agent_slug("A"));
+    }
+
+    #[test]
+    fn agent_slug_rejects_path_separators_and_traversal() {
+        assert!(!is_valid_agent_slug(""));
+        assert!(!is_valid_agent_slug("../etc/passwd"));
+        assert!(!is_valid_agent_slug(".."));
+        assert!(!is_valid_agent_slug("foo/bar"));
+        assert!(!is_valid_agent_slug("foo\\bar"));
+        assert!(!is_valid_agent_slug("/etc/passwd"));
+        assert!(!is_valid_agent_slug("my-assistant.md"));
+        assert!(!is_valid_agent_slug("my assistant"));
+    }
+
+    #[test]
+    fn personalization_overlay_path_rejects_traversal_and_separators() {
+        let err = personalization_overlay_path("../../etc/passwd")
+            .expect_err("traversal must be rejected");
+        assert!(err.contains("invalid agent name"));
+    }
+
+    #[test]
+    fn personalization_overlay_path_joins_home_dir() {
+        let _guard = HOME_LOCK.lock().expect("lock poisoned");
+        let tmp = std::env::temp_dir().join(format!("t3061-home-{}", std::process::id()));
+        let prev = std::env::var_os("HOME");
+        // SAFETY: guarded by HOME_LOCK; restored before returning.
+        unsafe {
+            std::env::set_var("HOME", &tmp);
+        }
+        let path = personalization_overlay_path("my-assistant").expect("valid slug");
+        // SAFETY: guarded by HOME_LOCK.
+        unsafe {
+            match &prev {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        assert_eq!(
+            path,
+            tmp.join(".trusty-agents")
+                .join("agents")
+                .join("my-assistant.md")
+        );
+    }
+
+    #[test]
+    fn read_personalization_overlay_reports_not_found_without_error() {
+        let _guard = HOME_LOCK.lock().expect("lock poisoned");
+        let tmp = std::env::temp_dir().join(format!("t3061-home-nf-{}", std::process::id()));
+        let prev = std::env::var_os("HOME");
+        // SAFETY: guarded by HOME_LOCK; restored before returning.
+        unsafe {
+            std::env::set_var("HOME", &tmp);
+        }
+        let result = read_personalization_overlay("does-not-exist".to_string());
+        // SAFETY: guarded by HOME_LOCK.
+        unsafe {
+            match &prev {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        let overlay = result.expect("missing file is Ok(None), not Err");
+        assert!(overlay.content.is_none());
+    }
+
+    #[test]
+    fn write_then_read_personalization_overlay_round_trips() {
+        let _guard = HOME_LOCK.lock().expect("lock poisoned");
+        let tmp = std::env::temp_dir().join(format!("t3061-home-rw-{}", std::process::id()));
+        let prev = std::env::var_os("HOME");
+        // SAFETY: guarded by HOME_LOCK; restored before returning.
+        unsafe {
+            std::env::set_var("HOME", &tmp);
+        }
+        let write_result = write_personalization_overlay(
+            "my-assistant".to_string(),
+            "---\nname: my-assistant\n---\n\nBe helpful.\n".to_string(),
+        );
+        let read_result = read_personalization_overlay("my-assistant".to_string());
+        // SAFETY: guarded by HOME_LOCK.
+        unsafe {
+            match &prev {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+        write_result.expect("write should succeed, creating the dir");
+        let overlay = read_result.expect("read should succeed after write");
+        assert_eq!(
+            overlay.content.as_deref(),
+            Some("---\nname: my-assistant\n---\n\nBe helpful.\n")
+        );
+    }
 }

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -23,6 +23,34 @@
   // router for two views. (#341) 'personality' (#3061) shows the
   // personalization-overlay editor.
   let activeView: 'chat' | 'projects' | 'personality' = 'chat';
+  // Why (#3198 code-critic HIGH): the {#if}/{:else if} tab router below
+  // unmounts PersonalityPanel on navigation away from it, which would
+  // silently discard an unsaved edit buffer. Bound from PersonalityPanel's
+  // exported `unsavedChanges` prop so `switchView` can guard the transition
+  // BEFORE it happens (confirm() runs while the component is still mounted).
+  let personalityUnsaved = false;
+
+  /**
+   * Why: Centralizes tab navigation so the one place that can discard
+   * PersonalityPanel's unsaved buffer (by unmounting it) is also the one
+   * place that asks first. Simplest correct guard: a native `confirm()`
+   * when leaving 'personality' with unsaved changes.
+   * What: No-ops (asks for confirmation) when navigating AWAY from
+   * 'personality' while `personalityUnsaved` is true; otherwise switches
+   * `activeView` immediately.
+   * Test: Manual — type in the Personality editor without saving, click
+   * another tab, confirm a browser confirm() dialog blocks the switch;
+   * Cancel keeps the tab and the buffer; OK switches and discards.
+   */
+  function switchView(view: 'chat' | 'projects' | 'personality') {
+    if (activeView === 'personality' && view !== 'personality' && personalityUnsaved) {
+      const discard = confirm(
+        'You have unsaved changes in Personality. Discard them and switch tabs?',
+      );
+      if (!discard) return;
+    }
+    activeView = view;
+  }
   let tokenInput = '';
   let tokenError = '';
   let probingToken = false;
@@ -412,7 +440,7 @@
           class="rounded-md px-3 py-1 text-xs font-medium transition-colors {activeView === 'chat'
             ? 'bg-foundry-light-primary/20 dark:bg-foundry-primary/20 text-foundry-light-primary dark:text-foundry-primary'
             : 'text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10'}"
-          on:click={() => (activeView = 'chat')}
+          on:click={() => switchView('chat')}
         >
           Chat
         </button>
@@ -421,7 +449,7 @@
           class="rounded-md px-3 py-1 text-xs font-medium transition-colors {activeView === 'projects'
             ? 'bg-foundry-light-primary/20 dark:bg-foundry-primary/20 text-foundry-light-primary dark:text-foundry-primary'
             : 'text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10'}"
-          on:click={() => (activeView = 'projects')}
+          on:click={() => switchView('projects')}
         >
           Projects
         </button>
@@ -430,7 +458,7 @@
           class="rounded-md px-3 py-1 text-xs font-medium transition-colors {activeView === 'personality'
             ? 'bg-foundry-light-primary/20 dark:bg-foundry-primary/20 text-foundry-light-primary dark:text-foundry-primary'
             : 'text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10'}"
-          on:click={() => (activeView = 'personality')}
+          on:click={() => switchView('personality')}
         >
           Personality
         </button>
@@ -440,9 +468,9 @@
         <RecapPanel />
         <InputArea />
       {:else if activeView === 'projects'}
-        <ProjectsView on:navigate={(e) => (activeView = e.detail.view)} />
+        <ProjectsView on:navigate={(e) => switchView(e.detail.view)} />
       {:else}
-        <PersonalityPanel />
+        <PersonalityPanel bind:unsavedChanges={personalityUnsaved} />
       {/if}
     </main>
   {/if}

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -6,6 +6,7 @@
   import ProjectsView from './components/ProjectsView.svelte';
   import RecapPanel from './components/RecapPanel.svelte';
   import Header from './components/Header.svelte';
+  import PersonalityPanel from './components/PersonalityPanel.svelte';
   import { invoke, isDesktop, connectEventSource, emitWebEvent, type AppEvent } from './lib/transport';
   import { apiAuthRequired, getCurrentApiToken, setApiToken, addMessage } from './stores/app';
   import { setRecap, type Recap } from './stores/recap';
@@ -19,8 +20,9 @@
   let apiError = '';
   // Why: Top-level view selector. Chat is the default; Projects shows the
   // /api/projects panel. Kept as a simple tab toggle to avoid pulling in a
-  // router for two views. (#341)
-  let activeView: 'chat' | 'projects' = 'chat';
+  // router for two views. (#341) 'personality' (#3061) shows the
+  // personalization-overlay editor.
+  let activeView: 'chat' | 'projects' | 'personality' = 'chat';
   let tokenInput = '';
   let tokenError = '';
   let probingToken = false;
@@ -423,13 +425,24 @@
         >
           Projects
         </button>
+        <button
+          type="button"
+          class="rounded-md px-3 py-1 text-xs font-medium transition-colors {activeView === 'personality'
+            ? 'bg-foundry-light-primary/20 dark:bg-foundry-primary/20 text-foundry-light-primary dark:text-foundry-primary'
+            : 'text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10'}"
+          on:click={() => (activeView = 'personality')}
+        >
+          Personality
+        </button>
       </nav>
       {#if activeView === 'chat'}
         <ChatView />
         <RecapPanel />
         <InputArea />
-      {:else}
+      {:else if activeView === 'projects'}
         <ProjectsView on:navigate={(e) => (activeView = e.detail.view)} />
+      {:else}
+        <PersonalityPanel />
       {/if}
     </main>
   {/if}

--- a/crates/trusty-agents/ui/src/components/PersonalityPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/PersonalityPanel.svelte
@@ -1,0 +1,209 @@
+<script lang="ts">
+  /**
+   * Why: #3061 — users have no way to customize how their assistant talks to
+   * them short of hand-editing `~/.trusty-agents/agents/my-assistant.md` in a
+   * terminal. This panel is a minimal prose editor bound directly to that
+   * personalization overlay (DOC-41 §2.5.1's `extends:` mechanism) — NOT a
+   * structured personality schema, per the issue's scope. It is a thin
+   * wrapper around the `read_personalization_overlay` /
+   * `write_personalization_overlay` Tauri commands (ui/src-tauri/src/main.rs)
+   * added alongside this panel.
+   * What: On mount (desktop only), loads `my-assistant.md`'s current content
+   * via `invoke('read_personalization_overlay', ...)`. A not-found result
+   * pre-fills the textarea with a starter template (frontmatter +
+   * explanatory prose) instead of an error. Save writes the buffer back
+   * verbatim. Tracks unsaved changes by diffing the buffer against the last
+   * loaded/saved snapshot. In browser mode (no Tauri IPC — see
+   * `isDesktop()` in `lib/transport.ts`) renders a "desktop app only" empty
+   * state instead of a non-functional editor, since there is no REST
+   * equivalent for direct filesystem access.
+   * Test: Manual — in the Tauri app, open the Personality tab with no
+   * overlay file present, confirm the starter template + not-found notice
+   * render; type, confirm the unsaved-changes dot appears; Save, confirm it
+   * clears and the file exists on disk with matching content; reload the
+   * tab, confirm the saved content (not the template) loads. In `pnpm dev`
+   * (browser), confirm the "desktop app only" empty state renders instead.
+   */
+  import { onMount } from 'svelte';
+  import { User, Save, AlertCircle, FileText } from 'lucide-svelte';
+  import { invoke, isDesktop } from '../lib/transport';
+
+  // Why: Fixed target for v1 — the issue scopes this to a single overlay
+  // (`my-assistant.md`, extending the nameless "assistant" base agent) rather
+  // than a picker over every possible agent name. A multi-agent overlay
+  // picker is a natural follow-up, not required here.
+  const AGENT_NAME = 'my-assistant';
+
+  const STARTER_TEMPLATE = `---
+name: my-assistant
+extends: assistant
+display_name: My Assistant
+---
+
+Replace this paragraph with your own instructions: describe how you want
+your assistant to talk to you, what it should prioritize, and any personal
+context it should always remember. This text is appended after the base
+"assistant" agent's prompt, so write it in your own voice.
+`;
+
+  const desktop = isDesktop();
+
+  let loading = true;
+  let loadError = '';
+  let notFound = false;
+  let overlayPath = '';
+  let content = '';
+  let savedContent = '';
+  let saving = false;
+  let saveError = '';
+  let justSaved = false;
+  let justSavedTimer: ReturnType<typeof setTimeout> | null = null;
+
+  $: unsavedChanges = content !== savedContent;
+
+  interface OverlayResult {
+    content: string | null;
+    path: string;
+  }
+
+  async function load() {
+    loading = true;
+    loadError = '';
+    try {
+      const result = await invoke<OverlayResult>('read_personalization_overlay', {
+        name: AGENT_NAME,
+      });
+      overlayPath = result.path;
+      if (result.content === null) {
+        notFound = true;
+        content = STARTER_TEMPLATE;
+        // Why: an unsaved starter template should show the unsaved-changes
+        // indicator (nothing has been persisted yet), so savedContent stays
+        // empty rather than mirroring the template.
+        savedContent = '';
+      } else {
+        notFound = false;
+        content = result.content;
+        savedContent = result.content;
+      }
+    } catch (e) {
+      loadError = (e as Error).message ?? String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function save() {
+    saving = true;
+    saveError = '';
+    try {
+      await invoke('write_personalization_overlay', { name: AGENT_NAME, content });
+      savedContent = content;
+      notFound = false;
+      justSaved = true;
+      if (justSavedTimer) clearTimeout(justSavedTimer);
+      justSavedTimer = setTimeout(() => (justSaved = false), 2000);
+    } catch (e) {
+      saveError = (e as Error).message ?? String(e);
+    } finally {
+      saving = false;
+    }
+  }
+
+  onMount(() => {
+    if (desktop) load();
+    return () => {
+      if (justSavedTimer) clearTimeout(justSavedTimer);
+    };
+  });
+</script>
+
+<section class="flex h-full flex-1 flex-col overflow-hidden bg-foundry-light-bg dark:bg-foundry-bg">
+  <header
+    class="flex flex-wrap items-center justify-between gap-3 border-b border-foundry-light-border dark:border-foundry-border px-6 py-3"
+  >
+    <div class="flex items-center gap-2">
+      <User class="h-4 w-4 text-foundry-light-primary dark:text-foundry-primary" />
+      <h1 class="text-lg font-semibold text-foundry-light-text dark:text-foundry-text">Personality</h1>
+      {#if desktop && unsavedChanges}
+        <span
+          class="inline-flex items-center gap-1 border border-foundry-amber/40 bg-foundry-amber/10 px-2 py-0.5 text-xs text-foundry-amber"
+          title="Unsaved changes"
+        >
+          <span class="inline-block h-1.5 w-1.5 bg-foundry-amber" aria-hidden="true"></span>
+          Unsaved
+        </span>
+      {/if}
+    </div>
+    {#if desktop && !loading && !loadError}
+      <button
+        type="button"
+        on:click={save}
+        disabled={saving || !unsavedChanges}
+        class="inline-flex items-center gap-1 border border-foundry-light-primary dark:border-foundry-primary bg-foundry-light-primary dark:bg-foundry-primary px-3 py-1 text-xs font-medium text-white hover:bg-foundry-light-primary/80 dark:hover:bg-foundry-primary/80 disabled:cursor-not-allowed disabled:border-foundry-light-border dark:disabled:border-foundry-border disabled:bg-foundry-light-surface dark:disabled:bg-foundry-surface disabled:text-foundry-light-muted dark:disabled:text-foundry-text/40"
+      >
+        <Save class="h-3 w-3" />
+        {saving ? 'Saving…' : justSaved ? 'Saved' : 'Save'}
+      </button>
+    {/if}
+  </header>
+
+  <div class="flex-1 overflow-y-auto px-6 py-4">
+    {#if !desktop}
+      <!-- Tauri-only: no REST equivalent for direct filesystem access to
+           ~/.trusty-agents/agents/, so the browser build gets a clear empty
+           state rather than a broken editor. -->
+      <div
+        class="flex flex-col items-center justify-center gap-3 border border-dashed border-foundry-light-border dark:border-foundry-border px-6 py-12 text-center"
+      >
+        <FileText class="h-6 w-6 text-foundry-light-muted dark:text-foundry-text/40" />
+        <p class="text-sm font-medium text-foundry-light-text dark:text-foundry-text">Desktop app only</p>
+        <p class="max-w-sm text-xs text-foundry-light-muted dark:text-foundry-text/60">
+          Editing your personalization overlay reads and writes files under
+          <code class="font-mono">~/.trusty-agents/agents/</code> directly, which
+          is only available in the Trusty Assistant desktop app — not this
+          browser preview.
+        </p>
+      </div>
+    {:else if loading}
+      <p class="text-sm text-foundry-light-muted dark:text-foundry-text/60">Loading…</p>
+    {:else if loadError}
+      <div class="border border-red-500/40 bg-red-500/5 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+        {loadError}
+      </div>
+    {:else}
+      {#if notFound}
+        <div
+          class="mb-3 flex items-start gap-2 border border-foundry-light-primary/30 dark:border-foundry-primary/30 bg-foundry-light-primary/5 dark:bg-foundry-primary/5 px-4 py-3 text-xs text-foundry-light-text/80 dark:text-foundry-text/80"
+        >
+          <AlertCircle class="mt-0.5 h-3.5 w-3.5 shrink-0 text-foundry-light-primary dark:text-foundry-primary" />
+          <span>
+            No overlay found yet — a starter template is pre-filled below. Edit it and click
+            Save to create <code class="font-mono">{overlayPath || `~/.trusty-agents/agents/${AGENT_NAME}.md`}</code>.
+          </span>
+        </div>
+      {/if}
+      {#if saveError}
+        <div class="mb-3 border border-red-500/40 bg-red-500/5 px-4 py-2 text-xs text-red-600 dark:text-red-400">
+          {saveError}
+        </div>
+      {/if}
+      <!--
+        Prose-only editor (no structured schema, per #3061 scope). IBM Plex
+        Mono via font-mono gives the frontmatter block a config-file feel
+        while the free-prose body underneath stays readable.
+      -->
+      <textarea
+        bind:value={content}
+        spellcheck="false"
+        autocomplete="off"
+        class="h-full min-h-[24rem] w-full resize-none border border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface px-4 py-3 font-mono text-sm leading-relaxed text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
+        aria-label="Personalization overlay editor"
+      ></textarea>
+      <p class="mt-2 text-xs text-foundry-light-muted dark:text-foundry-text/50">
+        Edits apply to <code class="font-mono">{overlayPath || `~/.trusty-agents/agents/${AGENT_NAME}.md`}</code>.
+        Prose only — this is not a structured settings form.
+      </p>
+    {/if}
+  </div>
+</section>

--- a/crates/trusty-agents/ui/src/components/PersonalityPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/PersonalityPanel.svelte
@@ -59,6 +59,12 @@ context it should always remember. This text is appended after the base
   let justSaved = false;
   let justSavedTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Why (#3198 code-critic HIGH): exported (not just local) so App.svelte can
+  // `bind:unsavedChanges` and guard tab switches — the {#if}/{:else if} tab
+  // router unmounts this component on navigation, which would otherwise
+  // silently discard an unsaved buffer despite the "Unsaved" badge shown
+  // below.
+  export let unsavedChanges = false;
   $: unsavedChanges = content !== savedContent;
 
   interface OverlayResult {
@@ -96,9 +102,16 @@ context it should always remember. This text is appended after the base
   async function save() {
     saving = true;
     saveError = '';
+    // Why (#3198 code-critic MEDIUM): snapshot the buffer BEFORE the await.
+    // If the user keeps typing during the IPC round-trip, `content` can
+    // change while `write_personalization_overlay` is in flight; comparing
+    // against a snapshot (and marking only that snapshot saved) means
+    // keystrokes typed mid-save correctly stay flagged as unsaved instead of
+    // being silently treated as persisted.
+    const toSave = content;
     try {
-      await invoke('write_personalization_overlay', { name: AGENT_NAME, content });
-      savedContent = content;
+      await invoke('write_personalization_overlay', { name: AGENT_NAME, content: toSave });
+      savedContent = toSave;
       notFound = false;
       justSaved = true;
       if (justSavedTimer) clearTimeout(justSavedTimer);


### PR DESCRIPTION
## Summary

- Adds a **Personality** tab to the trusty-agents Tauri desktop app ("Trusty Assistant") — a minimal prose editor bound directly to the user's `~/.trusty-agents/agents/my-assistant.md` personalization overlay (the `extends:` mechanism from DOC-41 §2.5.1). No structured personality schema — prose editing only, per issue scope.
- Bundles a **required backend companion fix**: without it, anything a user saved through the panel would be invisible to real agent dispatch.

Closes #3061

## Why the backend fix is bundled (not a separate PR)

`AgentConfig::by_name` / `by_name_async` (`crates/trusty-agents/src/agents/loader.rs`) resolve agent configs via a single `agents_dir()` — either `$TAGENT_CONFIG_DIR` or a CWD-relative project-local `.trusty-agents/agents/`. It has **no `$HOME` awareness at all**. Meanwhile the registry roster (`agent_search_paths()`, `registry/mod.rs`) *does* search `~/.trusty-agents/agents/`, so an overlay dropped there showed up in listings but was **FILE-NOT-FOUND at actual dispatch** (every runner loads via `by_name`/`by_name_async`, never the informational registry).

Since this panel's entire purpose is writing to `~/.trusty-agents/agents/*.md`, shipping the panel without this fix would produce a file the running app can never load — the panel would be decorative. The fix adds `agents_dir_candidates()`, an ordered list of fallback directories (primary `TAGENT_CONFIG_DIR`/project-local first, then `$HOME/.trusty-agents/agents` as an explicit fallback tier), and both the sync and async per-name loaders now iterate every tier in every candidate directory before falling through to the claude-mpm compatibility loader. Precedence is preserved: explicit `TAGENT_CONFIG_DIR` > project-local > `$HOME`.

New regression tests: `by_name_finds_flat_md_in_home_tier_when_project_dir_misses` and its async counterpart (`crates/trusty-agents/src/agents/tests/loading.rs`) — both prove resolution succeeds via the `$HOME` tier when the primary (project-local) directory genuinely lacks the agent.

## New Tauri commands + security posture

`ui/src-tauri/src/main.rs` adds `read_personalization_overlay` / `write_personalization_overlay`:

- Both operate **only** on `$HOME/.trusty-agents/agents/<name>.md` — the path is built exclusively from the real `$HOME` env var plus a fixed subpath, never from a caller-supplied path.
- `<name>` is validated against a strict slug allowlist (`is_valid_agent_slug`): non-empty, every char in `[a-zA-Z0-9_-]`. This rejects path separators (`/`, `\`), `.`/`..` traversal, and absolute-path injection in one check — there is no way to escape the fixed directory.
- `read_personalization_overlay` distinguishes "file exists" from "not found yet" via `content: Option<String>` in its response (rather than conflating not-found with a real I/O error), so the frontend can offer a starter template instead of an error state.
- `write_personalization_overlay` creates `~/.trusty-agents/agents/` on first write (fresh installs won't have it yet) and does a full-overwrite write, matching a plain text editor's Save semantics.
- 6 new unit tests cover slug acceptance/rejection (including traversal attempts) and the read/write round trip against a faked `$HOME`.

## Frontend

- New `PersonalityPanel.svelte` (Foundry-styled: rectangular elements, no pills/gradients, `font-mono` textarea for the frontmatter feel) wired into `App.svelte` as a third tab (`chat` | `projects` | `personality`).
- Targets `my-assistant.md` by default. On open: loads current content, or — if not found — pre-fills a starter template (`extends: assistant`, i.e. the nameless base agent, plus a `display_name` placeholder and short explanatory prose). Save button, unsaved-changes indicator.
- **Tauri-only limitation**: this feature has no REST equivalent (direct filesystem access), so in browser/dev mode (`pnpm dev`, no Tauri IPC — detected via the existing `isDesktop()`/`isTauri` pattern in `lib/transport.ts`) the panel renders a clear "desktop app only" empty state instead of a broken editor.

## Test evidence

```
cargo test -p trusty-agents agents::tests::loading -- --nocapture
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 1796 filtered out

cargo test -p trusty-agents-ui
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo clippy -p trusty-agents -p trusty-agents-ui --all-targets -- -D warnings
(clean — no warnings on this PR's code)

cargo fmt --check
(clean)

bash scripts/check_line_cap.sh
line-cap: 10 allowlisted, 0 violations — OK.

cd crates/trusty-agents/ui && pnpm install && pnpm build
✓ built in 25.23s (pre-existing a11y warnings in ProjectsView.svelte, unrelated to this PR)
```

## Test plan

- [x] `cargo test -p trusty-agents agents::tests::loading` — 24/24 pass, including the two new `$HOME` fallback-tier regression tests
- [x] `cargo test -p trusty-agents-ui` — 6/6 pass (slug validation + read/write round trip)
- [x] `cargo clippy -p trusty-agents -p trusty-agents-ui --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean
- [x] `pnpm install && pnpm build` in `crates/trusty-agents/ui` — clean build
- [ ] Manual: launch the Tauri app, open Personality tab, confirm starter template + not-found notice, edit + Save, confirm the file lands at `~/.trusty-agents/agents/my-assistant.md` and dispatches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)