### PR TITLE
fix(trusty-agents-common): serialize event-bus tests to eliminate broadcast race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10818,6 +10818,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/trusty-agents-common/CHANGELOG.md
+++ b/crates/trusty-agents-common/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- `events::tests::publish_round_trips_through_subscribe` (and sibling tests `bus_is_singleton`, `seq_is_monotonic`) now carry `#[serial_test::serial]` — these three tests share the process-global `HarnessEvent` broadcast bus, so a concurrent workspace test run could deliver an unrelated event or interleave `publish()` sequence numbers between them, causing an intermittent assertion failure (closes #2961; same pattern as the #2271 `bm25_client` fix).
+
 ### Added
 
 - new public `agents::builder_in_memory` module (`InMemorySources`, `build_in_memory_source_map`, `compose_agent_in_memory`): an in-memory counterpart to `agents::builder::compose_agent` that resolves `extends:` inheritance chains (including through BASE-* templates) against an embedded `name -> markdown` asset map instead of a filesystem `source_dir` (refs #2958, epic #2892 Slice E1 — the foundation for trusty-code embedding a curated tm agent roster as `include_str!` assets). Internally, `agents::builder::resolve` was generalised over a new `pub(crate)` `SourceLookup` trait so both the fs and in-memory paths share one chain-walk/cycle-detection/depth-limit implementation instead of forking it; the fs `compose_agent` API and its behavior are unchanged (verified by a byte-equivalence test comparing fs vs. in-memory composition of identical content). Additive only.

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -35,3 +35,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 # session_registry tests use tempfile for isolated state-dir creation.
 tempfile = { workspace = true }
+# events::tests use serial_test to serialise tests that share the
+# process-global broadcast bus (issue #2961; precedent: #2271 bm25_client).
+serial_test = { workspace = true }

--- a/crates/trusty-agents-common/src/events/mod.rs
+++ b/crates/trusty-agents-common/src/events/mod.rs
@@ -169,7 +169,14 @@ mod tests {
 
     // ---- bus + seq ----
 
+    /// Why: `bus()` returns a process-global singleton broadcast channel, so
+    /// any other test sending on it concurrently can deliver an unrelated
+    /// event to this test's receiver before the expected `Ping` arrives.
+    /// `#[serial]` serialises this against the other global-bus tests in this
+    /// module (issue #2961), matching the #2271 `bm25_client` precedent.
+    /// Test: this test itself.
     #[test]
+    #[serial_test::serial]
     fn bus_is_singleton() {
         let a = bus();
         let b = bus();
@@ -179,7 +186,15 @@ mod tests {
         assert!(matches!(got.payload, HarnessPayload::Ping));
     }
 
+    /// Why: `subscribe()`/`publish()` operate on the same process-global
+    /// broadcast bus as `bus_is_singleton` and `seq_is_monotonic`. Without
+    /// serialisation, a concurrent `publish()` from a sibling test can land on
+    /// this test's receiver ahead of (or instead of) the expected event,
+    /// causing the `got.seq == seq` assertion to intermittently fail under
+    /// parallel workspace test runs (issue #2961).
+    /// Test: this test itself.
     #[tokio::test]
+    #[serial_test::serial]
     async fn publish_round_trips_through_subscribe() {
         let mut rx = subscribe();
         let seq = publish(
@@ -202,7 +217,14 @@ mod tests {
         }
     }
 
+    /// Why: `publish()` increments a process-global sequence counter shared
+    /// with the other global-bus tests in this module. `#[serial]` keeps this
+    /// test's three consecutive `publish()` calls from interleaving with a
+    /// sibling test's `publish()` calls (issue #2961) — the monotonic-order
+    /// assertion only holds for this test's own sequence values.
+    /// Test: this test itself.
     #[test]
+    #[serial_test::serial]
     fn seq_is_monotonic() {
         let s1 = publish(HarnessSource::Agents, None, HarnessPayload::Ping);
         let s2 = publish(HarnessSource::Agents, None, HarnessPayload::Ping);


### PR DESCRIPTION
## Summary
- `events::tests::publish_round_trips_through_subscribe`, `bus_is_singleton`, and `seq_is_monotonic` all exercise the process-global `HarnessEvent` broadcast bus in `crates/trusty-agents-common/src/events/mod.rs`. Run in parallel with other workspace tests, a sibling test's `publish()`/`subscribe()` call could interleave and deliver an unrelated event or unexpected `seq` value, causing an intermittent assertion failure.
- Apply `#[serial_test::serial]` to all three global-bus tests (fixing the class, not just the reported instance) — same pattern as the #2271 `bm25_client` fix.
- Add `serial_test` as a dev-dependency for `trusty-agents-common` via the workspace table (`serial_test = { workspace = true }`); already declared in root `[workspace.dependencies]`.
- `CHANGELOG.md` `[Unreleased]` entry added.

Closes #2961.

## Test plan
- [x] `cargo test -p trusty-agents-common` — 270 passed, 0 failed
- [x] `cargo test -p trusty-agents-common events::` run 5x consecutively — 22 passed each run, 0 failed, 0 flakes
- [x] `cargo clippy -p trusty-agents-common --all-targets -- -D warnings` — clean

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools