### PR TITLE
fix(scripts): bump-version.sh regenerates Cargo.lock after version bump

### DIFF
--- a/.trusty-mpm/INSTRUCTIONS.md
+++ b/.trusty-mpm/INSTRUCTIONS.md
@@ -280,10 +280,14 @@ versions by version number.
 1. Bump the crate version in `crates/<name>/Cargo.toml`.
    - Shortcut: `scripts/bump-version.sh <crate-dir> <major|minor|patch>` reads the
      current version, computes the next semver, edits the package version in
-     place, stages the unreleased `CHANGELOG.md` section (via
-     `scripts/generate-changelog.sh`), and **prints** the exact `git tag` /
-     `git push` commands for you to run. It never tags or pushes — the human
-     stays in the loop per the manual-tag convention. It honours the
+     place, syncs the root `Cargo.lock` (`cargo update -p <package-name>
+     --precise <next-version>`, resolving `<package-name>` from the crate's
+     `[package] name` field so it works even when that differs from the
+     crates/ directory name, e.g. `tga`) so the release PR is `--locked`-clean
+     on the first CI run (issue #3199), stages the unreleased `CHANGELOG.md`
+     section (via `scripts/generate-changelog.sh`), and **prints** the exact
+     `git tag` / `git push` commands for you to run. It never tags or pushes —
+     the human stays in the loop per the manual-tag convention. It honours the
      `trusty-git-analytics` tag-prefix gotcha automatically (tags are
      `trusty-git-analytics-v*`, not `tga-v*`).
 2. Update any dependent crates that pin that version.

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -18,12 +18,19 @@ e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
 2. Update any dependent crates that pin that version.
 
 > **Convenience helper:** `scripts/bump-version.sh <crate-dir> <major|minor|patch>`
-> automates step 1 and the changelog staging. It reads the current package
-> `version` from `crates/<crate-dir>/Cargo.toml`, computes the next semver,
-> rewrites the package version line in place (dependency `version =` pins are
-> left untouched), calls `scripts/generate-changelog.sh <crate-dir> <tag-prefix>`
-> to prepend the unreleased `CHANGELOG.md` section, then **prints — but does not
-> run —** the `git tag <prefix>-v<version>` and `git push origin <prefix>-v<version>`
+> automates step 1, the Cargo.lock sync, and the changelog staging. It reads
+> the current package `version` from `crates/<crate-dir>/Cargo.toml`, computes
+> the next semver, rewrites the package version line in place (dependency
+> `version =` pins are left untouched), runs
+> `cargo update -p <package-name> --precise <next-version>` so the root
+> `Cargo.lock` entry for that package matches the bumped manifest (resolving
+> `<package-name>` from the crate's `[package] name` field, which can differ
+> from the crates/ directory name — see the `tga` note below; this closes
+> issue #3199, where every release PR previously failed CI's `--locked` build
+> until a human pushed a manual lock-sync follow-up commit), calls
+> `scripts/generate-changelog.sh <crate-dir> <tag-prefix>` to prepend the
+> unreleased `CHANGELOG.md` section, then **prints — but does not run —** the
+> `git tag <prefix>-v<version>` and `git push origin <prefix>-v<version>`
 > commands. This preserves the manual-tag convention (the human reviews and
 > tags). The tag prefix defaults to the crate-dir name, with the one documented
 > exception baked in: `trusty-git-analytics` (package name `tga`) releases under

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -11,11 +11,15 @@
 # What: Given a crate directory under crates/ and a bump level
 # (major|minor|patch), reads the package `version = "X.Y.Z"` from
 # crates/<crate-dir>/Cargo.toml, computes the next semver, edits that line in
-# place, then calls scripts/generate-changelog.sh <crate-dir> <tag-prefix> to
-# prepend the unreleased CHANGELOG section. For every current crate the tag
-# prefix equals the crate-dir name (tag_prefix_for() is the single, easy-to-
-# extend place that derives it). Finally it prints — but does NOT execute — the
-# `git tag` and `git push` commands.
+# place, runs `cargo update -p <package-name> --precise <next>` so
+# Cargo.lock's entry for that package matches the bumped manifest (issue
+# #3199 — every release PR previously failed CI's `--locked` build until a
+# human pushed a manual lock-sync follow-up commit), then calls
+# scripts/generate-changelog.sh <crate-dir> <tag-prefix> to prepend the
+# unreleased CHANGELOG section. For every current crate the tag prefix equals
+# the crate-dir name (tag_prefix_for() is the single, easy-to-extend place
+# that derives it). Finally it prints — but does NOT execute — the `git tag`
+# and `git push` commands.
 #
 # Test: `bash -n scripts/bump-version.sh` for syntax and `shellcheck
 # scripts/bump-version.sh` for lint. Functionally, the pure version-bump logic
@@ -53,8 +57,9 @@ usage() {
   echo "  <major|minor|patch>    semver component to increment" >&2
   echo "" >&2
   echo "Reads the package version from crates/<crate-dir>/Cargo.toml, bumps it," >&2
-  echo "stages the unreleased CHANGELOG section, and PRINTS the tag/push commands" >&2
-  echo "for you to run (it never tags or pushes itself)." >&2
+  echo "syncs Cargo.lock (cargo update -p <package> --precise <next>), stages the" >&2
+  echo "unreleased CHANGELOG section, and PRINTS the tag/push commands for you to" >&2
+  echo "run (it never tags or pushes itself)." >&2
   exit 2
 }
 
@@ -73,6 +78,26 @@ read_package_version() {
     return 1
   fi
   echo "${version}"
+}
+
+# Why: `cargo update -p <name>` needs the crate's cargo PACKAGE name, which can
+# differ from its crates/ directory name (e.g. crates/trusty-git-analytics has
+# package name "tga" — see tag_prefix_for() above). By Cargo convention the
+# [package] table is always the first table in a manifest, so the FIRST
+# `name = "..."` line is the package name — the same first-occurrence anchor
+# read_package_version() relies on for the version line just below it.
+# What: prints the crate's cargo package name from crates/<crate-dir>/Cargo.toml,
+# or fails.
+read_package_name() {
+  local manifest="$1"
+  local name
+  name="$(grep -m1 -E '^name[[:space:]]*=[[:space:]]*"[^"]+"' "${manifest}" \
+    | sed -E 's/^name[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+  if [[ -z "${name}" ]]; then
+    echo "ERROR: could not find a package name (name = \"...\") in ${manifest}" >&2
+    return 1
+  fi
+  echo "${name}"
 }
 
 # Why: centralise the semver arithmetic so it is unit-testable in isolation.
@@ -199,6 +224,34 @@ main() {
   fi
   echo "Bumped crates/${crate_dir}/Cargo.toml: ${current} -> ${next} (${level})" >&2
 
+  # Sync Cargo.lock to the bumped manifest (issue #3199): CI's --locked builds
+  # reject a Cargo.lock whose entry for this package still pins the OLD
+  # version, and until this step existed a human had to notice the failure and
+  # push a manual `cargo update -p <crate> --precise <version>` follow-up
+  # commit on every release PR. Resolve the cargo PACKAGE name (not the
+  # crates/ directory name — they differ for trusty-git-analytics/"tga") and
+  # run the equivalent update here so the release PR is --locked-clean on the
+  # first push.
+  local pkg_name
+  pkg_name="$(read_package_name "${manifest}")"
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "ERROR: cargo not found on PATH — cannot sync Cargo.lock for package" >&2
+    echo "       '${pkg_name}' (crates/${crate_dir}). crates/${crate_dir}/Cargo.toml" >&2
+    echo "       has ALREADY been bumped to ${next}; install/enable cargo, then run" >&2
+    echo "       this from ${WORKSPACE_ROOT} before committing:" >&2
+    echo "         cargo update -p ${pkg_name} --precise ${next}" >&2
+    echo "       Skipping this will fail CI's --locked build." >&2
+    exit 1
+  fi
+  echo "Syncing Cargo.lock: cargo update -p ${pkg_name} --precise ${next} ..." >&2
+  if ! (cd "${WORKSPACE_ROOT}" && cargo update -p "${pkg_name}" --precise "${next}"); then
+    echo "ERROR: cargo update -p ${pkg_name} --precise ${next} failed. Note:" >&2
+    echo "       crates/${crate_dir}/Cargo.toml has ALREADY been bumped to ${next} —" >&2
+    echo "       resolve the Cargo.lock issue manually before committing, or run" >&2
+    echo "       \`git checkout crates/${crate_dir}/Cargo.toml\` to start over." >&2
+    exit 1
+  fi
+
   # Stage the unreleased CHANGELOG section for this crate's tag series.
   echo "Staging unreleased CHANGELOG section via generate-changelog.sh ..." >&2
   "${changelog_script}" "${crate_dir}" "${prefix}"
@@ -228,7 +281,7 @@ main() {
   echo "" >&2
   echo "Next steps (review, then run these yourself):" >&2
   echo "" >&2
-  echo "  git add crates/${crate_dir}/Cargo.toml crates/${crate_dir}/CHANGELOG.md  # add Cargo.lock too if cargo regenerated it" >&2
+  echo "  git add crates/${crate_dir}/Cargo.toml crates/${crate_dir}/CHANGELOG.md Cargo.lock" >&2
   echo "  git commit -m \"chore(release): ${crate_dir} ${next}\"" >&2
   echo "  git tag ${tag}" >&2
   echo "  git push origin ${tag}" >&2


### PR DESCRIPTION
## Summary
- `scripts/bump-version.sh` bumped a crate's `Cargo.toml` version but never touched `Cargo.lock`, so every release PR it produced failed CI's `--locked` build until a human pushed a manual `cargo update -p <crate> --precise <version>` follow-up commit. This cost #3084, #3109, and #3148 an extra CI round-trip each this week.
- Adds a `read_package_name()` helper (the cargo package name can differ from the `crates/` directory name — e.g. `trusty-git-analytics` → `tga`) and runs `cargo update -p <package-name> --precise <next>` from the workspace root right after the version-field edit is verified, with a clear failure message if `cargo` is unavailable or the update fails.
- Preserves the script's existing contract: still only prints (never runs) the `git tag`/`git push` commands.
- Updates `docs/reference/release-workflow.md` and `.trusty-mpm/INSTRUCTIONS.md` to describe the new Cargo.lock sync step.

Closes #3199

## Test plan
- [x] `bash -n scripts/bump-version.sh` — syntax OK
- [x] `shellcheck scripts/bump-version.sh` — exit 0, zero warnings
- [x] Live dry-run: `bash scripts/bump-version.sh trusty-common patch` — confirmed `Cargo.toml` bumped `0.23.3 -> 0.23.4` AND `Cargo.lock`'s `trusty-common` entry updated to `version = "0.23.4"` in the same run (previously this required a manual follow-up commit)
- [x] Test mutation discarded via `git checkout -- Cargo.lock crates/trusty-common/CHANGELOG.md crates/trusty-common/Cargo.toml` inside the dedicated worktree — no residual changes beyond the intentional script/doc edits

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools