### PR TITLE
feat(trusty-agents): phase-checkpoint RunState journal + tagent resume

### DIFF
--- a/crates/trusty-agents/src/events.rs
+++ b/crates/trusty-agents/src/events.rs
@@ -165,6 +165,21 @@ pub enum Event {
         persona: String,
     },
 
+    // -- Checkpoint durability (#3062, SPEC-AGENTFW-02 §3.4) --
+    /// Emitted once at the start of `tagent resume <run-id>`, before any
+    /// phase from the resume point re-executes.
+    ///
+    /// Why: Lets the UI / stderr stream distinguish "a fresh run started"
+    /// from "an existing run picked back up mid-pipeline" without parsing
+    /// the checkpoint journal itself.
+    /// What: `resumed_at_phase` is the name of the first phase that will
+    /// re-execute (the phase immediately after the last `PhaseComplete`, or
+    /// the in-flight phase for `Failed`/`Retrying`/`PhaseRunning`).
+    RunResumed {
+        session_id: String,
+        resumed_at_phase: String,
+    },
+
     // -- LLM call lifecycle (#199) --
     /// Emitted just before any LLM chat-completion HTTP call leaves the
     /// process. Pairs with `LlmResponded` so consumers can compute latency
@@ -259,6 +274,7 @@ impl Event {
             | Event::PhaseDone { session_id, .. }
             | Event::PhaseSkipped { session_id, .. }
             | Event::PersonaDetected { session_id, .. }
+            | Event::RunResumed { session_id, .. }
             | Event::LlmRequested { session_id, .. }
             | Event::LlmResponded { session_id, .. }
             | Event::AgentStarted { session_id, .. }

--- a/crates/trusty-agents/src/repl/event_display.rs
+++ b/crates/trusty-agents/src/repl/event_display.rs
@@ -76,6 +76,14 @@ pub fn format_event(event: &Event) -> Option<String> {
         Event::PersonaDetected { persona, .. } => {
             Some(dim.paint(format!("  ◆ persona: {persona}")).to_string())
         }
+        // #3062: surface a resumed checkpointed run distinctly from a fresh
+        // start so the REPL stream reads "picked back up", not "started over".
+        Event::RunResumed {
+            resumed_at_phase, ..
+        } => Some(
+            teal.paint(format!("  ↻ resumed at phase: {resumed_at_phase}"))
+                .to_string(),
+        ),
         Event::Ping => None,
         // #199: LLM lifecycle + agent fine-grained events emit on the bus but
         // are suppressed from the REPL stream by default to reduce noise.

--- a/crates/trusty-agents/src/runtime/subcommands.rs
+++ b/crates/trusty-agents/src/runtime/subcommands.rs
@@ -100,6 +100,8 @@ pub(super) async fn dispatch_subcommands(args: &[String]) -> Result<bool> {
         "dash",
         // #2405: universal inference-provider credential CLI (`config keys …`).
         "config",
+        // #3062: resume a checkpointed workflow run (`resume <run-id>`).
+        "resume",
     ];
     if args.len() > 1 {
         let candidate = &args[1];
@@ -186,6 +188,13 @@ pub(super) async fn dispatch_subcommands(args: &[String]) -> Result<bool> {
     // #449: `trusty-agents eval run --suite <path>` — run a behavior eval suite.
     if args.len() > 1 && args[1] == "eval" {
         registry_cmds::run_eval_subcommand(&args[2..]).await?;
+        return Ok(false);
+    }
+
+    // #3062: `trusty-agents resume [--list] [--json] <run-id>` — continue a
+    // checkpointed workflow run from its first incomplete phase.
+    if args.len() > 1 && args[1] == "resume" {
+        super::workflow_mode::run_resume_subcommand(&args[2..]).await?;
         return Ok(false);
     }
 

--- a/crates/trusty-agents/src/runtime/workflow_mode/mod.rs
+++ b/crates/trusty-agents/src/runtime/workflow_mode/mod.rs
@@ -107,14 +107,19 @@ use workflow::WorkflowEngine;
 
 // Module layout (see #366 split): the `run_workflow` orchestration body lives
 // here; the self-contained helpers (runner selection, init-context build,
-// modified-file scan, build-counter read) live in `helpers.rs`.
+// modified-file scan, build-counter read) live in `helpers.rs`. `resume.rs`
+// (#3062) is the `tagent resume <run-id>` CLI surface — a sibling entry
+// point sharing the same helpers rather than a mode of `run_workflow`.
 mod helpers;
+mod resume;
 
 use helpers::{
     build_init_context, build_runner_for_workflow, check_workflow_project_dirs,
     collect_modified_files, load_skill_registry, load_tag_skill_registry, load_user_memory_suffix,
     read_current_build_number, refresh_global_skills_cache, resolve_out_dir,
 };
+
+pub(super) use resume::run_resume_subcommand;
 
 // Re-export the task-text readers so sibling runtime modules can keep calling
 // `workflow_mode::read_task_text` / `read_task_text_with_inline`.

--- a/crates/trusty-agents/src/runtime/workflow_mode/resume.rs
+++ b/crates/trusty-agents/src/runtime/workflow_mode/resume.rs
@@ -1,0 +1,139 @@
+// Pre-existing clippy warnings across this large binary crate — see
+// `workflow_mode/mod.rs`'s header block for the full rationale list.
+#![allow(dead_code)]
+#![allow(clippy::too_many_arguments)]
+
+//! `tagent resume <run-id>` CLI surface (#3062, SPEC-AGENTFW-02 §3.4).
+//!
+//! Why: A checkpointed run needs the same agent-runner/skills/memory wiring
+//! a fresh `--workflow` invocation gets — the resumed phases dispatch real
+//! agents, not mocks. This mirrors `run_workflow`'s engine construction
+//! (minus task/out_dir/code_dir, which come from the checkpoint itself) and
+//! calls `WorkflowEngine::resume_with_perf_and_dirs` instead of
+//! `run_with_perf_and_dirs`.
+//! What: `run_resume_subcommand` parses `tagent resume [--list] [--json]
+//! <run-id>` and either lists resumable run ids (from
+//! `checkpoint::list_resumable_runs`) or resumes the given one, printing the
+//! narrative (or a `PmResponse` JSON envelope with `--json`, matching
+//! `run_workflow`'s `--json` contract).
+//! Test: Manual — a killed multi-phase workflow leaves a checkpoint;
+//! `tagent resume <id>` continues without re-dispatching completed phases.
+//! Engine-level resume logic is unit/integration-tested in
+//! `workflow::engine::executor::tests::checkpoint_resume_tests`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::workflow::engine::checkpoint;
+use crate::workflow::{ResumeOutcome, WorkflowEngine};
+use crate::{api, subprocess, tools};
+
+use super::helpers::{
+    build_runner_for_workflow, load_skill_registry, load_tag_skill_registry,
+    load_user_memory_suffix, read_current_build_number,
+};
+
+/// Handle `tagent resume [--list] [--json] <run-id>`.
+///
+/// Why: Single entry point so `subcommands::dispatch_subcommands` only needs
+/// one call for the `resume` subcommand, matching the `postmortem`/`agents`/
+/// `skills` pre-clap dispatch pattern already used for other subcommands
+/// that own their own tiny argv grammar.
+/// What: `--list` (or no positional arg at all) prints resumable run ids and
+/// returns. Otherwise builds a `WorkflowEngine` wired the same way
+/// `run_workflow` is, then resumes the named run and prints its result.
+/// Test: See module doc.
+pub(crate) async fn run_resume_subcommand(args: &[String]) -> Result<()> {
+    let json_output = args.iter().any(|a| a == "--json");
+    let list_only = args.iter().any(|a| a == "--list");
+    let project_dir = crate::usage::project_dir();
+
+    let run_id = args.iter().find(|a| !a.starts_with('-')).cloned();
+
+    if list_only || run_id.is_none() {
+        let ids = checkpoint::list_resumable_runs(&project_dir);
+        if ids.is_empty() {
+            println!(
+                "No resumable runs found under {}/.trusty-agents/state/runs/",
+                project_dir.display()
+            );
+        } else {
+            println!("Resumable runs:");
+            for id in &ids {
+                println!("  {id}");
+            }
+            println!();
+            println!("Resume one with: tagent resume <run-id>");
+        }
+        return Ok(());
+    }
+    let run_id = run_id.expect("checked above");
+
+    // Peek the checkpoint once up front so the runner + subprocess env can be
+    // wired with the checkpoint's workflow name / out_dir / code_dir before
+    // constructing the engine — mirrors `run_workflow`'s wiring, just sourced
+    // from the journal instead of CLI flags. `resume_with_perf_and_dirs`
+    // below loads the checkpoint again internally; a cheap re-read, not worth
+    // threading the already-loaded record through the engine API.
+    let record = checkpoint::load_checkpoint(&project_dir, &run_id)?;
+
+    let build_num = read_current_build_number().await.unwrap_or(0);
+    let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let agents_config_dir = project_root.join(".trusty-agents").join("agents");
+    let subprocess_runner: Arc<dyn tools::AgentRunner> = Arc::new(
+        subprocess::SubprocessAgentRunner::new()
+            .with_config_dir(Some(agents_config_dir))
+            .with_out_dir(Some(record.out_dir.clone()))
+            .with_code_dir(Some(record.code_dir.clone()))
+            .with_project_dir(Some(record.code_dir.clone())),
+    );
+    let runner = build_runner_for_workflow(&record.workflow, subprocess_runner.clone()).await?;
+
+    let perf_dir: PathBuf = project_root.join("docs").join("performance");
+    let skill_registry = load_skill_registry(&project_root).await;
+    let tag_skill_registry = load_tag_skill_registry();
+    let user_memory_suffix = load_user_memory_suffix().await;
+
+    let engine = WorkflowEngine::new(runner, PathBuf::from(".trusty-agents/workflows"))
+        .with_build(build_num)
+        .with_perf_dir(Some(perf_dir))
+        .with_skill_registry(Some(skill_registry))
+        .with_tag_skill_registry(Some(tag_skill_registry))
+        .with_user_memory(user_memory_suffix)
+        .with_progress(Some(Arc::new(crate::progress::ProgressReporter::new())));
+
+    match engine.resume_with_perf_and_dirs(&run_id).await? {
+        ResumeOutcome::AlreadyDone { run_id } => {
+            println!("Run {run_id} already completed — nothing to resume.");
+        }
+        ResumeOutcome::Resumed {
+            ctx,
+            perf: perf_record,
+            resumed_at_phase,
+        } => {
+            eprintln!("Resumed run {run_id} at phase '{resumed_at_phase}'.");
+            let narrative = ctx
+                .phase_outputs
+                .get("observe")
+                .cloned()
+                .or_else(|| ctx.phase_outputs.values().last().cloned())
+                .unwrap_or_default();
+            if json_output {
+                let response = api::builder::build_from_workflow(
+                    &ctx,
+                    Some(&perf_record),
+                    narrative,
+                    Some(&record.workflow),
+                    Vec::new(),
+                );
+                println!("{}", serde_json::to_string_pretty(&response)?);
+            } else if !narrative.is_empty() {
+                println!("{narrative}");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/trusty-agents/src/workflow/engine/checkpoint.rs
+++ b/crates/trusty-agents/src/workflow/engine/checkpoint.rs
@@ -20,8 +20,10 @@
 //! corrupt-file handling, list/delete behavior).
 
 use std::collections::BTreeMap;
+use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 
+use fs4::FileExt;
 use serde::{Deserialize, Serialize};
 
 use crate::context::GoalBlock;
@@ -41,7 +43,13 @@ use crate::workflow::error::WorkflowError;
 /// What: Bump this constant whenever `CheckpointRecord`'s shape changes in a
 /// way that isn't safely `serde(default)`-compatible.
 /// Test: `schema_version_mismatch_is_rejected`.
-pub const CHECKPOINT_SCHEMA_VERSION: u32 = 1;
+///
+/// v2 (code-critic finding, PR #3244): added `phase_summaries` — v1 journals
+/// (which lack it) now fail closed via the schema-version check below rather
+/// than silently deserializing with an empty summary map, which would have
+/// replayed FULL phase content into every downstream `context_template` on
+/// resume (see `CheckpointRecord::phase_summaries` doc).
+pub const CHECKPOINT_SCHEMA_VERSION: u32 = 2;
 
 fn current_schema_version() -> u32 {
     CHECKPOINT_SCHEMA_VERSION
@@ -55,11 +63,24 @@ fn current_schema_version() -> u32 {
 /// `phase_outputs` alone.
 /// What: `Pending` before phase 0 starts; `PhaseRunning{i}` while phase `i`'s
 /// agent call is in flight; `PhaseComplete{i}` once phase `i`'s output has
-/// been recorded into the context; `Retrying{i,attempt}` for the existing
-/// one-shot QA-triggered code-phase retry; `Failed{i}` when phase `i`'s
-/// dispatch returned an error; `Done` once the whole run finished
-/// successfully. `Failed` and `Done` are terminal for the journal — `Done`
-/// causes the journal directory to be deleted (see `delete_run_dir`).
+/// been recorded into the context; `Failed{i}` when phase `i`'s dispatch
+/// returned an error; `Done` once the whole run finished successfully.
+/// `Failed` and `Done` are terminal for the journal — `Done` causes the
+/// journal directory to be deleted (see `delete_run_dir`).
+///
+/// `Retrying{i,attempt}` is a DISTINCT-BUT-EQUIVALENT sibling of
+/// `PhaseRunning{i}` (code-critic finding, PR #3244 — kept as its own
+/// variant rather than folded into `PhaseRunning`, for observability: an
+/// operator inspecting the journal can tell "phase i is running for the
+/// first time" from "phase i is running as the existing Fix 2 one-shot
+/// QA-triggered code-phase retry" without cross-referencing
+/// `qa_retry_count`). It always carries the SAME `phase_index` the current
+/// loop iteration is on when `handle_qa_envelope` flips `qa_retry_count`
+/// 0->1 — today that is always the `qa` phase's own index, since this
+/// engine's loop has no phase-index jump-back (see `phase_loop.rs`).
+/// `tagent resume` treats `Retrying` IDENTICALLY to `PhaseRunning` /
+/// `Failed`: resume AT `phase_index`, re-dispatching that phase from
+/// scratch — there is no separate "replay the retry feedback" resume path.
 /// Test: `run_state_round_trips_through_json`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -77,15 +98,24 @@ pub enum RunState {
 /// Why: Everything a resumed run needs to reconstruct `WorkflowContext` and
 /// continue from the first incomplete phase, without re-running (and
 /// re-billing) any already-completed phase.
-/// What: `phase_outputs` holds the full content of every completed phase,
-/// keyed by phase name (mirrors `WorkflowContext::phase_outputs`, not the
-/// summary map — resuming re-derives summaries as `content.clone()`, a
-/// documented simplification versus the original run's extracted summary).
-/// `phase_names` is a diagnostic snapshot of `def.phases[..].name` taken at
-/// `Pending`; `tagent resume` always reloads the workflow definition fresh
-/// and validates it against this snapshot rather than trusting it directly
+/// What: `phase_outputs` holds the FULL content of every completed phase,
+/// keyed by phase name (mirrors `WorkflowContext::phase_outputs`).
+/// `phase_summaries` holds the EXTRACTED summary for the same phases
+/// (mirrors `WorkflowContext::phase_summaries` — code-critic finding, PR
+/// #3244 v2). This split matters: `WorkflowContext::render_template`
+/// (`context.rs`) injects `phase_summaries`, not `phase_outputs`, into every
+/// downstream `{{phase_name}}` template substitution — that's the entire
+/// point of extracting a ~500-word digest instead of forwarding 30k raw
+/// chars. A resumed run that only had `phase_outputs` to replay from would
+/// have to fall back to `content.clone()` as the "summary", silently
+/// re-inflating every downstream prompt for exactly the long-running,
+/// content-heavy workflows checkpointing exists to protect. `phase_names` is
+/// a diagnostic snapshot of `def.phases[..].name` taken at `Pending`;
+/// `tagent resume` always reloads the workflow definition fresh and
+/// validates it against this snapshot rather than trusting it directly
 /// (§3.4).
-/// Test: `checkpoint_record_round_trips_through_json`.
+/// Test: `checkpoint_record_round_trips_through_json`,
+/// `checkpoint_resume_tests::resume_replays_summary_not_full_content_into_downstream_prompts`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CheckpointRecord {
     #[serde(default = "current_schema_version")]
@@ -100,6 +130,14 @@ pub struct CheckpointRecord {
     /// `run_with_perf_and_dirs` receives before `detect_persona` strips them.
     pub task: String,
     pub phase_outputs: BTreeMap<String, String>,
+    /// Extracted per-phase summary — see the struct-level doc for why this
+    /// must be persisted (and replayed) separately from `phase_outputs`.
+    /// `#[serde(default)]` so a v1 journal still deserializes (as empty);
+    /// the `schema_version` check in `load_checkpoint` is what actually
+    /// rejects it, with a clear "incompatible schema" message rather than a
+    /// raw serde error.
+    #[serde(default)]
+    pub phase_summaries: BTreeMap<String, String>,
     pub goal_block: Option<GoalBlock>,
     pub qa_retry_count: u32,
     pub qa_failure_feedback: Option<String>,
@@ -190,13 +228,55 @@ pub fn load_checkpoint(
     Ok(record)
 }
 
+/// Flip an existing checkpoint's `state` to `RunState::Done` and write it
+/// back, best-effort. A no-op (not an error) when no checkpoint exists yet.
+///
+/// Why (code-critic finding, PR #3244 HIGH): `finalize_run` previously went
+/// straight to `delete_run_dir` on success WITHOUT ever writing
+/// `RunState::Done` to disk. If `remove_dir_all` then failed (e.g. a
+/// transient permission/lock issue), the journal was left at
+/// `PhaseComplete{last}` — indistinguishable from "the last phase finished
+/// but the run is still in flight". A subsequent `tagent resume` would
+/// happily re-enter `run_phase_loop` at `resume_index = last + 1` (an empty
+/// slice, since every phase is already complete) and re-run `finalize_run`
+/// a SECOND time: duplicate perf flush, duplicate auto-push, duplicate
+/// `on_workflow_success` ticket comment/close. Calling this function BEFORE
+/// `delete_run_dir` means a failed deletion still leaves an accurate `Done`
+/// record on disk, so a subsequent resume's `RunState::Done` check
+/// short-circuits to `ResumeOutcome::AlreadyDone` and fires nothing.
+/// What: Loads the checkpoint (if `load_checkpoint` errors — missing,
+/// corrupt, or schema-mismatched — this is a silent no-op; there is nothing
+/// safe to "flip", and the workflow already succeeded so we must not fail
+/// the run over journal bookkeeping), sets `state = Done` and refreshes
+/// `updated_at`, then re-writes via the same `atomic_write`-backed `write`.
+/// Write failures are logged at WARN and non-fatal, matching every other
+/// finalize-tail side effect.
+/// Test: `mark_done_before_delete_transitions_existing_checkpoint`,
+/// `mark_done_before_delete_is_noop_when_absent`.
+pub fn mark_done_before_delete(project_dir: &Path, run_id: &str) {
+    let Ok(mut record) = load_checkpoint(project_dir, run_id) else {
+        return;
+    };
+    record.state = RunState::Done;
+    record.updated_at = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    if let Err(e) = record.write(project_dir) {
+        tracing::warn!(
+            run_id = %run_id,
+            error = %e,
+            "failed to write Done checkpoint before deletion (non-fatal)"
+        );
+    }
+}
+
 /// Best-effort removal of `.trusty-agents/state/runs/<run_id>/` on successful
 /// (`RunState::Done`) completion (SPEC-AGENTFW-02 §3.3 "Deletion").
 ///
 /// Why: A completed run's journal has no further durability value — keeping
 /// it around forever would leak disk over many runs. A `Failed` checkpoint is
 /// intentionally NOT deleted by this function (it's the resumable artifact);
-/// callers only invoke this once the run reaches `Done`.
+/// callers only invoke this once the run reaches `Done`. Callers MUST call
+/// `mark_done_before_delete` first (see its doc) so a failed deletion still
+/// leaves an accurate terminal record.
 /// What: `remove_dir_all`, logged at WARN on failure and otherwise silently
 /// non-fatal — matching the existing pattern used throughout `finalize.rs`
 /// for ticket-manager/auto-push hooks. Never panics, never propagates an
@@ -240,6 +320,73 @@ pub fn list_resumable_runs(project_dir: &Path) -> Vec<String> {
         .collect();
     ids.sort();
     ids
+}
+
+/// Holds the exclusive advisory lock on `<run_dir>/resume.lock` for the
+/// duration of one `tagent resume` call (code-critic finding, PR #3244).
+///
+/// Why: Two `tagent resume <run-id>` invocations racing on the same run
+/// would both read the checkpoint, both start dispatching from the same
+/// phase index, and both write phase-boundary checkpoints — corrupting the
+/// journal's phase ordering and double-running agent calls. Unlike
+/// `atomic_write`'s per-call lock (held only for the duration of one file
+/// write), a resume needs the lock held for the ENTIRE resumed run.
+/// What: Wraps the locked `File` handle; `Drop` releases the lock
+/// (best-effort — `unlock` failures are logged, never panic) so the lock is
+/// always released when the guard goes out of scope, including on an early
+/// `?` return from `resume_with_perf_and_dirs`.
+/// Test: `resume_lock_blocks_concurrent_acquisition`,
+/// `resume_lock_released_on_drop`.
+#[derive(Debug)]
+pub struct ResumeLockGuard {
+    file: File,
+    run_id: String,
+}
+
+impl Drop for ResumeLockGuard {
+    fn drop(&mut self) {
+        if let Err(e) = FileExt::unlock(&self.file) {
+            tracing::warn!(
+                run_id = %self.run_id,
+                error = %e,
+                "failed to release resume lock (non-fatal; OS releases it on process exit)"
+            );
+        }
+    }
+}
+
+/// Acquire the exclusive `resume.lock` for `run_id`, failing closed
+/// immediately (non-blocking) if another process already holds it.
+///
+/// Why: A `tagent resume` that can't get the lock should tell the operator
+/// clearly ("already being resumed") rather than hang indefinitely or,
+/// worse, silently proceed and corrupt the journal.
+/// What: Opens (creating if absent) `<run_dir>/resume.lock` and calls
+/// `FileExt::try_lock` (the same `fs4` primitive `state_writer::atomic_write`
+/// uses, non-blocking here since we want fail-closed, not fail-slow).
+/// Returns `WorkflowError::ResumeAlreadyInProgress` when the lock is held by
+/// someone else. The lock is released when the returned guard is dropped.
+/// Test: `resume_lock_blocks_concurrent_acquisition`.
+pub fn acquire_resume_lock(
+    project_dir: &Path,
+    run_id: &str,
+) -> Result<ResumeLockGuard, WorkflowError> {
+    let dir = run_dir(project_dir, run_id);
+    std::fs::create_dir_all(&dir)?;
+    let lock_path = dir.join("resume.lock");
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(&lock_path)?;
+    FileExt::try_lock(&file).map_err(|_| WorkflowError::ResumeAlreadyInProgress {
+        run_id: run_id.to_string(),
+        lock_path: lock_path.display().to_string(),
+    })?;
+    Ok(ResumeLockGuard {
+        file,
+        run_id: run_id.to_string(),
+    })
 }
 
 #[cfg(test)]

--- a/crates/trusty-agents/src/workflow/engine/checkpoint.rs
+++ b/crates/trusty-agents/src/workflow/engine/checkpoint.rs
@@ -1,0 +1,246 @@
+//! Phase-checkpoint durability journal for the workflow engine (#3062,
+//! SPEC-AGENTFW-02 / `docs/specs/trusty-agents-eve-style-agents-spec.md` §3).
+//!
+//! Why: Before this module, the engine held zero on-disk state during an
+//! in-flight run — `perf.flush` only wrote once, at the very end. A process
+//! crash mid-run lost the entire `WorkflowContext`, and there was no way to
+//! continue a multi-phase run without starting over (and re-billing every
+//! already-completed phase's LLM calls). §3.2/§3.3 of the spec define a
+//! phase-level `RunState` machine and a `CheckpointRecord` journal written at
+//! every phase boundary via the existing `state_writer::atomic_write`
+//! primitive (reused verbatim, per the issue) so a resumed run can pick up
+//! from the last completed phase.
+//! What: `RunState` — the phase-boundary state machine; `CheckpointRecord` —
+//! the on-disk journal shape (one file per run id at
+//! `.trusty-agents/state/runs/<run_id>/checkpoint.json`); `write`, load,
+//! delete, and list helpers, all going through `atomic_write` for writes and
+//! plain reads for loads (matching the existing `.trusty-agents/state/`
+//! convention documented in `build_info.rs`/`mistake_log.rs`).
+//! Test: `checkpoint_tests` (round-trip serde, schema-version rejection,
+//! corrupt-file handling, list/delete behavior).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::context::GoalBlock;
+use crate::state_writer::atomic_write;
+use crate::workflow::error::WorkflowError;
+
+/// Current on-disk schema version for `CheckpointRecord`.
+///
+/// Why: SPEC-AGENTFW-02 §3.3's `CheckpointRecord` example does not include an
+/// explicit version field, but issue #3062 explicitly requires "if the
+/// journal is from an incompatible/older schema, fail with a clear message
+/// (version the journal format)". This is an additive deviation from the
+/// spec's literal struct, documented in the PR description: a `schema_version`
+/// field lets a future incompatible change to this struct fail closed
+/// (`WorkflowError::CheckpointSchemaMismatch`) instead of silently
+/// misinterpreting an old journal via serde defaults.
+/// What: Bump this constant whenever `CheckpointRecord`'s shape changes in a
+/// way that isn't safely `serde(default)`-compatible.
+/// Test: `schema_version_mismatch_is_rejected`.
+pub const CHECKPOINT_SCHEMA_VERSION: u32 = 1;
+
+fn current_schema_version() -> u32 {
+    CHECKPOINT_SCHEMA_VERSION
+}
+
+/// Phase-boundary run state machine (SPEC-AGENTFW-02 §3.2, reproduced
+/// verbatim).
+///
+/// Why: A single tagged enum makes every valid mid-run state explicit and
+/// exhaustively matchable, rather than inferring progress from partial
+/// `phase_outputs` alone.
+/// What: `Pending` before phase 0 starts; `PhaseRunning{i}` while phase `i`'s
+/// agent call is in flight; `PhaseComplete{i}` once phase `i`'s output has
+/// been recorded into the context; `Retrying{i,attempt}` for the existing
+/// one-shot QA-triggered code-phase retry; `Failed{i}` when phase `i`'s
+/// dispatch returned an error; `Done` once the whole run finished
+/// successfully. `Failed` and `Done` are terminal for the journal — `Done`
+/// causes the journal directory to be deleted (see `delete_run_dir`).
+/// Test: `run_state_round_trips_through_json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunState {
+    Pending,
+    PhaseRunning { phase_index: usize },
+    PhaseComplete { phase_index: usize },
+    Retrying { phase_index: usize, attempt: u32 },
+    Failed { phase_index: usize },
+    Done,
+}
+
+/// On-disk checkpoint journal for one workflow run (SPEC-AGENTFW-02 §3.3).
+///
+/// Why: Everything a resumed run needs to reconstruct `WorkflowContext` and
+/// continue from the first incomplete phase, without re-running (and
+/// re-billing) any already-completed phase.
+/// What: `phase_outputs` holds the full content of every completed phase,
+/// keyed by phase name (mirrors `WorkflowContext::phase_outputs`, not the
+/// summary map — resuming re-derives summaries as `content.clone()`, a
+/// documented simplification versus the original run's extracted summary).
+/// `phase_names` is a diagnostic snapshot of `def.phases[..].name` taken at
+/// `Pending`; `tagent resume` always reloads the workflow definition fresh
+/// and validates it against this snapshot rather than trusting it directly
+/// (§3.4).
+/// Test: `checkpoint_record_round_trips_through_json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckpointRecord {
+    #[serde(default = "current_schema_version")]
+    pub schema_version: u32,
+    pub run_id: String,
+    pub workflow: String,
+    pub state: RunState,
+    pub phase_names: Vec<String>,
+    pub out_dir: PathBuf,
+    pub code_dir: PathBuf,
+    /// Original (uncleaned) task text — persona tags intact, matching what
+    /// `run_with_perf_and_dirs` receives before `detect_persona` strips them.
+    pub task: String,
+    pub phase_outputs: BTreeMap<String, String>,
+    pub goal_block: Option<GoalBlock>,
+    pub qa_retry_count: u32,
+    pub qa_failure_feedback: Option<String>,
+    pub started_at: String,
+    pub updated_at: String,
+}
+
+/// `.trusty-agents/state/runs/<run_id>/` under `project_dir` — the directory
+/// holding one run's `checkpoint.json` (and reserved for future per-run
+/// artifacts).
+///
+/// Why: Matches the existing `.trusty-agents/state/` runtime-state root
+/// convention (`build.json`, `sessions.json`, `mistakes/<sid>.jsonl`, …)
+/// documented in `build_info.rs` / `mistake_log.rs`, scoped one level deeper
+/// per run id so multiple in-flight runs never collide.
+/// What: Pure path join, no I/O.
+/// Test: `run_dir_and_checkpoint_path_join_correctly`.
+pub fn run_dir(project_dir: &Path, run_id: &str) -> PathBuf {
+    project_dir
+        .join(".trusty-agents")
+        .join("state")
+        .join("runs")
+        .join(run_id)
+}
+
+/// `<run_dir>/checkpoint.json` — the single journal file for a run.
+pub fn checkpoint_path(project_dir: &Path, run_id: &str) -> PathBuf {
+    run_dir(project_dir, run_id).join("checkpoint.json")
+}
+
+impl CheckpointRecord {
+    /// Persist this record to `.trusty-agents/state/runs/<run_id>/checkpoint.json`
+    /// under `project_dir`, atomically.
+    ///
+    /// Why: The write path REUSES `state_writer::atomic_write` verbatim (per
+    /// the issue) — lock + tmp + rename — so a crash mid-write never leaves a
+    /// half-written journal for a subsequent `tagent resume` to trip over.
+    /// What: Serializes via `serde_json::to_vec_pretty` and calls
+    /// `atomic_write`. Failures are returned to the caller, which (per the
+    /// engine's existing "log and continue" convention for non-critical
+    /// persistence side effects — perf flush, ticket hooks) logs a warning
+    /// and does NOT fail the workflow run itself; see `phase_loop.rs`.
+    /// Test: `write_then_load_round_trips`.
+    pub fn write(&self, project_dir: &Path) -> Result<(), WorkflowError> {
+        let path = checkpoint_path(project_dir, &self.run_id);
+        let bytes = serde_json::to_vec_pretty(self)?;
+        atomic_write(&path, &bytes).map_err(|e| {
+            WorkflowError::ConfigInvalid(format!(
+                "failed to write checkpoint {}: {e:#}",
+                path.display()
+            ))
+        })
+    }
+}
+
+/// Load and validate the checkpoint for `run_id` under `project_dir`.
+///
+/// Why: `tagent resume` must fail closed — never silently start a fresh run
+/// under an existing `run_id` — on either a missing file or a corrupt/
+/// schema-mismatched one (SPEC-AGENTFW-02 §3.5 failure matrix).
+/// What: Missing file -> `WorkflowError::CheckpointNotFound` listing the run
+/// ids that DO have a checkpoint (`list_resumable_runs`). Unparseable JSON ->
+/// `WorkflowError::CheckpointCorrupt`. Parseable but a different
+/// `schema_version` -> `WorkflowError::CheckpointSchemaMismatch`.
+/// Test: `load_checkpoint_missing_lists_available_runs`,
+/// `load_checkpoint_rejects_corrupt_json`, `schema_version_mismatch_is_rejected`.
+pub fn load_checkpoint(
+    project_dir: &Path,
+    run_id: &str,
+) -> Result<CheckpointRecord, WorkflowError> {
+    let path = checkpoint_path(project_dir, run_id);
+    let bytes = std::fs::read(&path).map_err(|_| WorkflowError::CheckpointNotFound {
+        run_id: run_id.to_string(),
+        available: list_resumable_runs(project_dir),
+    })?;
+    let record: CheckpointRecord =
+        serde_json::from_slice(&bytes).map_err(|e| WorkflowError::CheckpointCorrupt {
+            path: path.display().to_string(),
+            source: anyhow::Error::new(e),
+        })?;
+    if record.schema_version != CHECKPOINT_SCHEMA_VERSION {
+        return Err(WorkflowError::CheckpointSchemaMismatch {
+            path: path.display().to_string(),
+            found: record.schema_version,
+            expected: CHECKPOINT_SCHEMA_VERSION,
+        });
+    }
+    Ok(record)
+}
+
+/// Best-effort removal of `.trusty-agents/state/runs/<run_id>/` on successful
+/// (`RunState::Done`) completion (SPEC-AGENTFW-02 §3.3 "Deletion").
+///
+/// Why: A completed run's journal has no further durability value — keeping
+/// it around forever would leak disk over many runs. A `Failed` checkpoint is
+/// intentionally NOT deleted by this function (it's the resumable artifact);
+/// callers only invoke this once the run reaches `Done`.
+/// What: `remove_dir_all`, logged at WARN on failure and otherwise silently
+/// non-fatal — matching the existing pattern used throughout `finalize.rs`
+/// for ticket-manager/auto-push hooks. Never panics, never propagates an
+/// error.
+/// Test: `delete_run_dir_removes_directory`,
+/// `delete_run_dir_is_noop_when_absent`.
+pub fn delete_run_dir(project_dir: &Path, run_id: &str) {
+    let dir = run_dir(project_dir, run_id);
+    if dir.exists()
+        && let Err(e) = std::fs::remove_dir_all(&dir)
+    {
+        tracing::warn!(
+            path = %dir.display(),
+            error = %e,
+            "failed to remove completed run's checkpoint dir (non-fatal)"
+        );
+    }
+}
+
+/// List run ids under `.trusty-agents/state/runs/` that currently have a
+/// `checkpoint.json` — i.e. runs `tagent resume <id>` can act on.
+///
+/// Why: Both the "missing checkpoint" error message and `tagent resume
+/// --list` need the same enumeration; centralizing it keeps them consistent.
+/// What: Reads the `runs/` directory (empty `Vec` if it doesn't exist yet —
+/// never an error), keeps only entries containing a `checkpoint.json`, and
+/// returns the directory names (run ids) sorted for stable output.
+/// Test: `list_resumable_runs_finds_only_dirs_with_checkpoint`.
+pub fn list_resumable_runs(project_dir: &Path) -> Vec<String> {
+    let runs_root = project_dir
+        .join(".trusty-agents")
+        .join("state")
+        .join("runs");
+    let Ok(entries) = std::fs::read_dir(&runs_root) else {
+        return Vec::new();
+    };
+    let mut ids: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().join("checkpoint.json").exists())
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect();
+    ids.sort();
+    ids
+}
+
+#[cfg(test)]
+mod checkpoint_tests;

--- a/crates/trusty-agents/src/workflow/engine/checkpoint/checkpoint_tests.rs
+++ b/crates/trusty-agents/src/workflow/engine/checkpoint/checkpoint_tests.rs
@@ -1,0 +1,208 @@
+//! Unit tests for the checkpoint journal (#3062).
+//!
+//! Why: The journal is the entire durability contract — serde round-trips,
+//! schema-version rejection, and corrupt/missing-file handling must be locked
+//! down so a future refactor can't silently break crash recovery.
+//! What: Exercises `RunState`/`CheckpointRecord` JSON round-trips, `write` +
+//! `load_checkpoint` end-to-end via `atomic_write`, the three fail-closed
+//! paths (missing, corrupt, schema mismatch), and `list_resumable_runs` /
+//! `delete_run_dir`.
+//! Test: This file IS the test suite for `checkpoint.rs`.
+
+use std::collections::BTreeMap;
+
+use tempfile::TempDir;
+
+use super::*;
+
+fn sample_record(run_id: &str) -> CheckpointRecord {
+    let mut phase_outputs = BTreeMap::new();
+    phase_outputs.insert("research".to_string(), "research output".to_string());
+    CheckpointRecord {
+        schema_version: CHECKPOINT_SCHEMA_VERSION,
+        run_id: run_id.to_string(),
+        workflow: "prescriptive".to_string(),
+        state: RunState::PhaseComplete { phase_index: 0 },
+        phase_names: vec!["research".to_string(), "plan".to_string()],
+        out_dir: "/tmp/out".into(),
+        code_dir: "/tmp/code".into(),
+        task: "[hacker] do the thing".to_string(),
+        phase_outputs,
+        goal_block: None,
+        qa_retry_count: 0,
+        qa_failure_feedback: None,
+        started_at: "2026-07-19T00:00:00Z".to_string(),
+        updated_at: "2026-07-19T00:01:00Z".to_string(),
+    }
+}
+
+/// `RunState` round-trips through JSON for every variant, including the
+/// struct-carrying ones — this is the wire format `tagent resume` depends on.
+#[test]
+fn run_state_round_trips_through_json() {
+    let states = [
+        RunState::Pending,
+        RunState::PhaseRunning { phase_index: 2 },
+        RunState::PhaseComplete { phase_index: 2 },
+        RunState::Retrying {
+            phase_index: 2,
+            attempt: 1,
+        },
+        RunState::Failed { phase_index: 2 },
+        RunState::Done,
+    ];
+    for state in states {
+        let json = serde_json::to_string(&state).unwrap();
+        let back: RunState = serde_json::from_str(&json).unwrap();
+        assert_eq!(state, back, "round-trip mismatch for {json}");
+    }
+}
+
+/// A full `CheckpointRecord` (including a populated `phase_outputs` map)
+/// round-trips byte-for-byte-equivalent through JSON.
+#[test]
+fn checkpoint_record_round_trips_through_json() {
+    let record = sample_record("run-abc");
+    let json = serde_json::to_string_pretty(&record).unwrap();
+    let back: CheckpointRecord = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.run_id, "run-abc");
+    assert_eq!(back.workflow, "prescriptive");
+    assert_eq!(back.state, RunState::PhaseComplete { phase_index: 0 });
+    assert_eq!(
+        back.phase_outputs.get("research"),
+        Some(&"research output".to_string())
+    );
+    assert_eq!(back.schema_version, CHECKPOINT_SCHEMA_VERSION);
+}
+
+/// `run_dir` / `checkpoint_path` join `project_dir` / `.trusty-agents/state/
+/// runs/<run_id>/checkpoint.json` exactly — this is the on-disk location
+/// SPEC-AGENTFW-02 §3.3 mandates.
+#[test]
+fn run_dir_and_checkpoint_path_join_correctly() {
+    let project = std::path::Path::new("/proj");
+    let dir = run_dir(project, "run-1");
+    assert_eq!(
+        dir,
+        std::path::PathBuf::from("/proj/.trusty-agents/state/runs/run-1")
+    );
+    let path = checkpoint_path(project, "run-1");
+    assert_eq!(
+        path,
+        std::path::PathBuf::from("/proj/.trusty-agents/state/runs/run-1/checkpoint.json")
+    );
+}
+
+/// `write` followed by `load_checkpoint` returns an equivalent record — the
+/// core write-then-resume contract, going through the real `atomic_write`
+/// primitive (lock + tmp + rename), not a mock.
+#[test]
+fn write_then_load_round_trips() {
+    let tmp = TempDir::new().unwrap();
+    let record = sample_record("run-xyz");
+    record.write(tmp.path()).unwrap();
+
+    let loaded = load_checkpoint(tmp.path(), "run-xyz").unwrap();
+    assert_eq!(loaded.run_id, "run-xyz");
+    assert_eq!(loaded.state, record.state);
+    assert_eq!(loaded.phase_outputs, record.phase_outputs);
+}
+
+/// Loading a run id with no checkpoint on disk fails closed with
+/// `CheckpointNotFound`, listing the run ids that DO resolve.
+#[test]
+fn load_checkpoint_missing_lists_available_runs() {
+    let tmp = TempDir::new().unwrap();
+    sample_record("run-present").write(tmp.path()).unwrap();
+
+    let err = load_checkpoint(tmp.path(), "run-absent").unwrap_err();
+    match err {
+        WorkflowError::CheckpointNotFound { run_id, available } => {
+            assert_eq!(run_id, "run-absent");
+            assert_eq!(available, vec!["run-present".to_string()]);
+        }
+        other => panic!("expected CheckpointNotFound, got {other:?}"),
+    }
+}
+
+/// A hand-truncated / non-JSON checkpoint file fails closed with
+/// `CheckpointCorrupt`, never a panic and never a silent fresh-run fallback.
+#[test]
+fn load_checkpoint_rejects_corrupt_json() {
+    let tmp = TempDir::new().unwrap();
+    let dir = run_dir(tmp.path(), "run-bad");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("checkpoint.json"), b"{ not valid json").unwrap();
+
+    let err = load_checkpoint(tmp.path(), "run-bad").unwrap_err();
+    assert!(
+        matches!(err, WorkflowError::CheckpointCorrupt { .. }),
+        "expected CheckpointCorrupt, got {err:?}"
+    );
+}
+
+/// A checkpoint whose `schema_version` doesn't match the running binary's
+/// `CHECKPOINT_SCHEMA_VERSION` fails closed with `CheckpointSchemaMismatch`
+/// rather than silently reinterpreting an incompatible journal.
+#[test]
+fn schema_version_mismatch_is_rejected() {
+    let tmp = TempDir::new().unwrap();
+    let mut record = sample_record("run-old");
+    record.schema_version = CHECKPOINT_SCHEMA_VERSION + 99;
+    record.write(tmp.path()).unwrap();
+
+    let err = load_checkpoint(tmp.path(), "run-old").unwrap_err();
+    match err {
+        WorkflowError::CheckpointSchemaMismatch {
+            found, expected, ..
+        } => {
+            assert_eq!(found, CHECKPOINT_SCHEMA_VERSION + 99);
+            assert_eq!(expected, CHECKPOINT_SCHEMA_VERSION);
+        }
+        other => panic!("expected CheckpointSchemaMismatch, got {other:?}"),
+    }
+}
+
+/// `delete_run_dir` removes the whole `runs/<run_id>/` directory (matching
+/// §3.3 "Deletion": a `Done` run leaves nothing behind).
+#[test]
+fn delete_run_dir_removes_directory() {
+    let tmp = TempDir::new().unwrap();
+    sample_record("run-done").write(tmp.path()).unwrap();
+    assert!(checkpoint_path(tmp.path(), "run-done").exists());
+
+    delete_run_dir(tmp.path(), "run-done");
+    assert!(!run_dir(tmp.path(), "run-done").exists());
+}
+
+/// Deleting a run dir that was never created (or already removed) is a
+/// silent no-op — never panics, never errors the caller.
+#[test]
+fn delete_run_dir_is_noop_when_absent() {
+    let tmp = TempDir::new().unwrap();
+    delete_run_dir(tmp.path(), "never-existed");
+    // Reaching here without panicking is the assertion.
+}
+
+/// `list_resumable_runs` only returns run ids that actually have a
+/// `checkpoint.json` — a stray empty directory under `runs/` doesn't count.
+#[test]
+fn list_resumable_runs_finds_only_dirs_with_checkpoint() {
+    let tmp = TempDir::new().unwrap();
+    sample_record("run-a").write(tmp.path()).unwrap();
+    sample_record("run-b").write(tmp.path()).unwrap();
+    // A directory with no checkpoint.json inside — must be excluded.
+    std::fs::create_dir_all(run_dir(tmp.path(), "run-empty")).unwrap();
+
+    let ids = list_resumable_runs(tmp.path());
+    assert_eq!(ids, vec!["run-a".to_string(), "run-b".to_string()]);
+}
+
+/// An empty (or nonexistent) `runs/` directory yields an empty list, not an
+/// error — a fresh project with no checkpoints ever written is the common
+/// case, not an edge case.
+#[test]
+fn list_resumable_runs_empty_when_no_runs_dir() {
+    let tmp = TempDir::new().unwrap();
+    assert!(list_resumable_runs(tmp.path()).is_empty());
+}

--- a/crates/trusty-agents/src/workflow/engine/checkpoint/checkpoint_tests.rs
+++ b/crates/trusty-agents/src/workflow/engine/checkpoint/checkpoint_tests.rs
@@ -18,6 +18,8 @@ use super::*;
 fn sample_record(run_id: &str) -> CheckpointRecord {
     let mut phase_outputs = BTreeMap::new();
     phase_outputs.insert("research".to_string(), "research output".to_string());
+    let mut phase_summaries = BTreeMap::new();
+    phase_summaries.insert("research".to_string(), "research summary".to_string());
     CheckpointRecord {
         schema_version: CHECKPOINT_SCHEMA_VERSION,
         run_id: run_id.to_string(),
@@ -28,6 +30,7 @@ fn sample_record(run_id: &str) -> CheckpointRecord {
         code_dir: "/tmp/code".into(),
         task: "[hacker] do the thing".to_string(),
         phase_outputs,
+        phase_summaries,
         goal_block: None,
         qa_retry_count: 0,
         qa_failure_feedback: None,
@@ -72,7 +75,57 @@ fn checkpoint_record_round_trips_through_json() {
         back.phase_outputs.get("research"),
         Some(&"research output".to_string())
     );
+    // Code-critic finding (PR #3244): phase_summaries must round-trip
+    // separately from phase_outputs — this is what resume replays into
+    // downstream `{{phase_name}}` template substitutions.
+    assert_eq!(
+        back.phase_summaries.get("research"),
+        Some(&"research summary".to_string())
+    );
     assert_eq!(back.schema_version, CHECKPOINT_SCHEMA_VERSION);
+}
+
+/// Code-critic finding (PR #3244): a v1 journal (schema_version 1, written
+/// before `phase_summaries` existed) must fail closed with a CLEAR
+/// "incompatible schema" message via `CheckpointSchemaMismatch` — not
+/// silently deserialize with an empty `phase_summaries` map and let a
+/// resumed run replay full raw content into downstream prompts.
+#[test]
+fn v1_journal_without_phase_summaries_fails_closed_via_schema_mismatch() {
+    let tmp = TempDir::new().unwrap();
+    // Hand-write a v1-shaped journal: schema_version 1, no phase_summaries
+    // key at all (simulating what PR #3244's original implementation wrote
+    // before this fix).
+    let v1_json = r#"{
+        "schema_version": 1,
+        "run_id": "run-v1",
+        "workflow": "prescriptive",
+        "state": {"phase_complete": {"phase_index": 0}},
+        "phase_names": ["research", "plan"],
+        "out_dir": "/tmp/out",
+        "code_dir": "/tmp/code",
+        "task": "do the thing",
+        "phase_outputs": {"research": "research output"},
+        "goal_block": null,
+        "qa_retry_count": 0,
+        "qa_failure_feedback": null,
+        "started_at": "2026-07-19T00:00:00Z",
+        "updated_at": "2026-07-19T00:01:00Z"
+    }"#;
+    let dir = run_dir(tmp.path(), "run-v1");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("checkpoint.json"), v1_json).unwrap();
+
+    let err = load_checkpoint(tmp.path(), "run-v1").unwrap_err();
+    match err {
+        WorkflowError::CheckpointSchemaMismatch {
+            found, expected, ..
+        } => {
+            assert_eq!(found, 1);
+            assert_eq!(expected, CHECKPOINT_SCHEMA_VERSION);
+        }
+        other => panic!("expected CheckpointSchemaMismatch, got {other:?}"),
+    }
 }
 
 /// `run_dir` / `checkpoint_path` join `project_dir` / `.trusty-agents/state/
@@ -205,4 +258,78 @@ fn list_resumable_runs_finds_only_dirs_with_checkpoint() {
 fn list_resumable_runs_empty_when_no_runs_dir() {
     let tmp = TempDir::new().unwrap();
     assert!(list_resumable_runs(tmp.path()).is_empty());
+}
+
+/// Code-critic finding (PR #3244 MEDIUM): `finalize_run`'s pre-delete step —
+/// an existing `PhaseComplete` checkpoint is flipped to `Done` in place,
+/// with `updated_at` refreshed, and everything else preserved.
+#[test]
+fn mark_done_before_delete_transitions_existing_checkpoint() {
+    let tmp = TempDir::new().unwrap();
+    let record = sample_record("run-finishing");
+    record.write(tmp.path()).unwrap();
+
+    mark_done_before_delete(tmp.path(), "run-finishing");
+
+    let loaded = load_checkpoint(tmp.path(), "run-finishing").unwrap();
+    assert_eq!(loaded.state, RunState::Done);
+    // Everything else survives the transition untouched.
+    assert_eq!(loaded.run_id, "run-finishing");
+    assert_eq!(loaded.phase_outputs, record.phase_outputs);
+    assert_eq!(loaded.phase_summaries, record.phase_summaries);
+}
+
+/// `mark_done_before_delete` on a run id with no checkpoint at all is a
+/// silent no-op — the workflow already succeeded, and there is nothing safe
+/// to "flip"; this must never fail the run over journal bookkeeping.
+#[test]
+fn mark_done_before_delete_is_noop_when_absent() {
+    let tmp = TempDir::new().unwrap();
+    mark_done_before_delete(tmp.path(), "never-existed");
+    // Reaching here without panicking is the assertion; nothing was created.
+    assert!(!checkpoint_path(tmp.path(), "never-existed").exists());
+}
+
+/// Code-critic finding (PR #3244 MEDIUM): `acquire_resume_lock` fails closed
+/// immediately (non-blocking) when another holder already has the lock for
+/// the same run id — two concurrent `tagent resume` calls on the same run
+/// must never both proceed.
+#[test]
+fn resume_lock_blocks_concurrent_acquisition() {
+    let tmp = TempDir::new().unwrap();
+    let _first =
+        acquire_resume_lock(tmp.path(), "run-locked").expect("first acquisition must succeed");
+
+    let second = acquire_resume_lock(tmp.path(), "run-locked");
+    assert!(
+        matches!(second, Err(WorkflowError::ResumeAlreadyInProgress { .. })),
+        "expected ResumeAlreadyInProgress while the first guard is held, got {second:?}"
+    );
+}
+
+/// Dropping the lock guard releases the OS-level advisory lock, so a
+/// subsequent acquisition (e.g. a retried resume after the first one
+/// finished) succeeds.
+#[test]
+fn resume_lock_released_on_drop() {
+    let tmp = TempDir::new().unwrap();
+    {
+        let _guard = acquire_resume_lock(tmp.path(), "run-reacquire").expect("first acquisition");
+        // Guard drops at the end of this block.
+    }
+    let reacquired = acquire_resume_lock(tmp.path(), "run-reacquire");
+    assert!(
+        reacquired.is_ok(),
+        "expected re-acquisition to succeed after the first guard dropped: {reacquired:?}"
+    );
+}
+
+/// Two DIFFERENT run ids never contend for the same lock — the lock is
+/// scoped to `<run_dir>/resume.lock`, per run id.
+#[test]
+fn resume_lock_is_scoped_per_run_id() {
+    let tmp = TempDir::new().unwrap();
+    let _a = acquire_resume_lock(tmp.path(), "run-a").expect("run-a lock");
+    let b = acquire_resume_lock(tmp.path(), "run-b");
+    assert!(b.is_ok(), "distinct run ids must not contend: {b:?}");
 }

--- a/crates/trusty-agents/src/workflow/engine/executor/finalize.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/finalize.rs
@@ -20,6 +20,7 @@ use tracing::info;
 use crate::workflow::autopush;
 use crate::workflow::config::WorkflowDef;
 use crate::workflow::context::WorkflowContext;
+use crate::workflow::engine::checkpoint;
 use crate::workflow::error::WorkflowError;
 
 use super::WorkflowEngine;
@@ -44,6 +45,9 @@ pub(super) struct FinalizeState {
     pub total_cost_usd: f64,
     pub files_generated: usize,
     pub qa_summary: String,
+    /// #3062: run id used to locate `.trusty-agents/state/runs/<run_id>/` for
+    /// checkpoint deletion on full success (`RunState::Done`).
+    pub run_id: String,
 }
 
 impl WorkflowEngine {
@@ -73,6 +77,7 @@ impl WorkflowEngine {
             total_cost_usd,
             files_generated,
             qa_summary,
+            run_id,
         } = state;
 
         // Only write the workflow report when all phases succeeded — a partial
@@ -180,6 +185,12 @@ impl WorkflowEngine {
         if let Some(err) = first_error {
             return Err(err);
         }
+
+        // #3062 (SPEC-AGENTFW-02 §3.3 "Deletion"): a full-success run reaches
+        // `RunState::Done` here — its checkpoint journal has no further
+        // durability value, so remove `.trusty-agents/state/runs/<run_id>/`
+        // entirely. Best-effort/non-fatal, matching every other finalize hook.
+        checkpoint::delete_run_dir(&crate::usage::project_dir(), &run_id);
 
         Ok((ctx, perf_record))
     }

--- a/crates/trusty-agents/src/workflow/engine/executor/finalize.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/finalize.rs
@@ -187,10 +187,19 @@ impl WorkflowEngine {
         }
 
         // #3062 (SPEC-AGENTFW-02 §3.3 "Deletion"): a full-success run reaches
-        // `RunState::Done` here — its checkpoint journal has no further
-        // durability value, so remove `.trusty-agents/state/runs/<run_id>/`
-        // entirely. Best-effort/non-fatal, matching every other finalize hook.
-        checkpoint::delete_run_dir(&crate::usage::project_dir(), &run_id);
+        // `RunState::Done` here. Code-critic finding (PR #3244 HIGH): write
+        // the `Done` transition to disk BEFORE attempting deletion — if
+        // `delete_run_dir` then fails (e.g. a transient permission/lock
+        // issue), the journal is left at `Done`, not a stale
+        // `PhaseComplete{last}` that a subsequent `tagent resume` would
+        // misinterpret as "still in flight" and re-run `finalize_run` a
+        // second time (duplicate perf flush / auto-push / ticket hooks). See
+        // `checkpoint::mark_done_before_delete` for the full rationale.
+        // Both calls are best-effort/non-fatal, matching every other
+        // finalize hook.
+        let project_dir = crate::usage::project_dir();
+        checkpoint::mark_done_before_delete(&project_dir, &run_id);
+        checkpoint::delete_run_dir(&project_dir, &run_id);
 
         Ok((ctx, perf_record))
     }

--- a/crates/trusty-agents/src/workflow/engine/executor/mod.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/mod.rs
@@ -32,13 +32,17 @@ use super::skills::skill_summary_for;
 
 mod dispatch;
 mod finalize;
+mod phase_loop;
 mod post_phase;
 mod prompt;
+mod resume;
 mod run;
 mod setup;
 
 #[cfg(test)]
 mod tests;
+
+pub use resume::ResumeOutcome;
 
 /// Workflow execution engine.
 pub struct WorkflowEngine {

--- a/crates/trusty-agents/src/workflow/engine/executor/phase_loop.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/phase_loop.rs
@@ -112,6 +112,13 @@ fn write_checkpoint(
         code_dir: meta.code_dir.clone(),
         task: meta.task.clone(),
         phase_outputs: ctx.phase_outputs.clone().into_iter().collect(),
+        // Code-critic finding (PR #3244): persist the SUMMARY map alongside
+        // the full-content map. `render_template` injects `phase_summaries`
+        // into downstream `{{phase_name}}` substitutions, not
+        // `phase_outputs` — replaying only `phase_outputs` on resume would
+        // silently blow up every downstream prompt with raw, un-digested
+        // phase content.
+        phase_summaries: ctx.phase_summaries.clone().into_iter().collect(),
         goal_block: ctx.goal_block.clone(),
         qa_retry_count,
         qa_failure_feedback: qa_failure_feedback.clone(),

--- a/crates/trusty-agents/src/workflow/engine/executor/phase_loop.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/phase_loop.rs
@@ -1,0 +1,586 @@
+//! Shared phase-loop driver used by both a fresh run and `tagent resume`
+//! (#3062, SPEC-AGENTFW-02 §3).
+//!
+//! Why: A resumed run must execute the exact same phase-dispatch logic as a
+//! fresh run — prompt assembly, wave/parallel/persistent dispatch, QA
+//! gating, file extraction — starting partway through `def.phases` instead
+//! of at index 0, with `WorkflowContext` pre-seeded from a checkpoint instead
+//! of empty. Extracting the loop body out of `run.rs` (which built it inline
+//! for the fresh-run case only) lets `run` and `resume` share one
+//! implementation instead of drifting apart. This also owns the phase-
+//! boundary checkpoint writes: `PhaseRunning{i}` on entering a non-skipped
+//! phase, `PhaseComplete{i}` once that phase's output has been recorded AND
+//! any produced files extracted (deliberately later than SPEC-AGENTFW-02
+//! §3.3's literal "immediately after `ctx.record_phase`" — see the doc on
+//! `run_phase_loop` for why), `Retrying{i,1}` on the one-shot QA retry
+//! signal, and `Failed{i}` on a phase dispatch error.
+//! What: `PhaseLoopSeed` bundles the run-scoped state that differs between a
+//! fresh run (all zeroed, `start_index: 0`) and a resume (loaded from the
+//! checkpoint, `start_index` past the last completed phase).
+//! `WorkflowEngine::run_phase_loop` is the (former) body of
+//! `run_with_perf_and_dirs`'s `'phase_loop`, now parameterized over the
+//! start index and seed state, ending in the same `finalize_run` call.
+//! Test: Exercised end-to-end via the engine `tests` submodule (fresh-run
+//! path, unchanged behavior) and `checkpoint_resume_tests` (resume path,
+//! phases before `start_index` are not re-dispatched).
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use tracing::info;
+
+use crate::agents::AgentConfig;
+use crate::context::TurnRecord;
+use crate::ipc::extract_summary;
+use crate::perf::PerfCollector;
+use crate::workflow::config::{Assignments, WorkflowDef};
+use crate::workflow::context::WorkflowContext;
+use crate::workflow::engine::checkpoint::{self, CheckpointRecord, RunState};
+use crate::workflow::error::WorkflowError;
+
+use super::super::helpers::relocate_plan_outputs_from_project_root;
+use super::super::state::emit_progress_event;
+use super::super::step_dispatch::discover_project_dir;
+use super::DiscoveredSkill;
+use super::WorkflowEngine;
+use super::finalize::FinalizeState;
+
+/// Run-scoped state that differs between a fresh run (start_index 0,
+/// zeroed/defaulted) and a resume (loaded from a `CheckpointRecord`).
+///
+/// Why: Bundling these into one struct keeps `run_phase_loop`'s signature
+/// readable and makes the fresh-vs-resume seeding differences explicit at
+/// each call site instead of scattered across a dozen positional args.
+/// What: Plain owned fields, consumed once at the top of `run_phase_loop`.
+/// Test: Covered indirectly — both call sites (`run.rs`, `resume.rs`)
+/// construct one and are exercised by the engine test suites.
+pub(super) struct PhaseLoopSeed {
+    /// Index into `def.phases` to start iterating from (0 for a fresh run).
+    pub start_index: usize,
+    /// Run id used for both telemetry (`TAGENT_RUN_ID`) and the checkpoint
+    /// journal's `run_id` field.
+    pub run_id: String,
+    /// Original (uncleaned) task text — persisted into the checkpoint
+    /// verbatim so a later resume sees the same persona tag.
+    pub raw_task: String,
+    /// ISO8601 run start time — a fresh run stamps `now()`; a resume reuses
+    /// the checkpoint's original `started_at` so the journal reflects true
+    /// run age, not just the resume's restart time.
+    pub started_at: String,
+    pub workflow_started: Instant,
+    pub qa_retry_count: u32,
+    pub qa_failure_feedback: Option<String>,
+    pub total_cost_usd: f64,
+    pub files_generated: usize,
+    pub qa_summary: String,
+    pub code_phase_used_claude_code: bool,
+}
+
+/// Fixed (per-run) fields needed to build a `CheckpointRecord` at each
+/// phase boundary — split out of `PhaseLoopSeed` because these don't change
+/// across the loop's iterations, unlike `qa_retry_count`/`qa_failure_feedback`.
+struct CheckpointMeta {
+    run_id: String,
+    workflow: String,
+    out_dir: PathBuf,
+    code_dir: PathBuf,
+    task: String,
+    phase_names: Vec<String>,
+    started_at: String,
+}
+
+/// Build and persist one checkpoint write. Failures are logged and
+/// non-fatal (matching the engine's existing "log and continue" convention
+/// for non-critical persistence side effects — perf flush, ticket hooks):
+/// a checkpoint write failure must not abort an otherwise-succeeding
+/// workflow run, it just degrades that run's crash-resumability.
+fn write_checkpoint(
+    project_dir: &std::path::Path,
+    meta: &CheckpointMeta,
+    state: RunState,
+    ctx: &WorkflowContext,
+    qa_retry_count: u32,
+    qa_failure_feedback: &Option<String>,
+) {
+    let record = CheckpointRecord {
+        schema_version: checkpoint::CHECKPOINT_SCHEMA_VERSION,
+        run_id: meta.run_id.clone(),
+        workflow: meta.workflow.clone(),
+        state,
+        phase_names: meta.phase_names.clone(),
+        out_dir: meta.out_dir.clone(),
+        code_dir: meta.code_dir.clone(),
+        task: meta.task.clone(),
+        phase_outputs: ctx.phase_outputs.clone().into_iter().collect(),
+        goal_block: ctx.goal_block.clone(),
+        qa_retry_count,
+        qa_failure_feedback: qa_failure_feedback.clone(),
+        started_at: meta.started_at.clone(),
+        updated_at: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
+    };
+    if let Err(e) = record.write(project_dir) {
+        tracing::warn!(
+            run_id = %meta.run_id,
+            state = ?record.state,
+            error = %e,
+            "failed to write phase checkpoint (non-fatal; resume durability degraded for this phase)"
+        );
+    }
+}
+
+impl WorkflowEngine {
+    /// Iterate `def.phases` from `seed.start_index` onward, dispatching each
+    /// non-skipped phase and persisting a checkpoint at every phase
+    /// boundary, then hand off to `finalize_run`.
+    ///
+    /// Why: This is the single shared driver for both a fresh run
+    /// (`start_index: 0`, empty `ctx`) and `tagent resume` (`start_index`
+    /// past the last completed phase, `ctx` pre-seeded from the checkpoint's
+    /// `phase_outputs`). Sharing one implementation means resume can never
+    /// silently diverge from fresh-run dispatch behavior.
+    /// What: Mirrors the pre-#3062 `run_with_perf_and_dirs` loop body
+    /// exactly for dispatch/QA/extraction logic, adding checkpoint writes at
+    /// three points: `PhaseRunning{i}` right after the skip-check (matching
+    /// SPEC-AGENTFW-02 §3.2's "entering the first non-skipped phase"),
+    /// `Retrying{i,1}` immediately after `handle_qa_envelope` flips
+    /// `qa_retry_count` 0->1, and `PhaseComplete{i}` / `Failed{i}` at the
+    /// true end of the iteration. `PhaseComplete{i}` is written AFTER
+    /// `extract_phase_files` completes — deliberately later than the spec's
+    /// literal "immediately after `ctx.record_phase`" — because a phase's
+    /// generated files are extracted to disk only after `record_phase`;
+    /// writing the checkpoint before extraction would let a crash between
+    /// the two leave a `PhaseComplete{i}` journal entry whose files were
+    /// never written, so a resume would skip re-dispatching phase `i` (its
+    /// checkpoint says done) while `code_dir`/`out_dir` is silently missing
+    /// its output. Ending the checkpoint boundary after extraction closes
+    /// that gap.
+    /// Test: `checkpoint_resume_tests::resume_skips_completed_phases_and_reuses_their_output`.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn run_phase_loop(
+        &self,
+        def: &WorkflowDef,
+        mut ctx: WorkflowContext,
+        mut perf: PerfCollector,
+        out_dir: Option<PathBuf>,
+        code_dir: Option<PathBuf>,
+        persona: &str,
+        discovered_skills: &[DiscoveredSkill],
+        seed: PhaseLoopSeed,
+    ) -> Result<(WorkflowContext, crate::perf::PerfRecord), WorkflowError> {
+        let PhaseLoopSeed {
+            start_index,
+            run_id,
+            raw_task,
+            started_at,
+            workflow_started,
+            mut qa_retry_count,
+            mut qa_failure_feedback,
+            mut total_cost_usd,
+            mut files_generated,
+            mut qa_summary,
+            mut code_phase_used_claude_code,
+        } = seed;
+
+        let mut failed_phase: Option<String> = None;
+        let mut first_error: Option<WorkflowError> = None;
+
+        let cp_project_dir = crate::usage::project_dir();
+        let cp_meta = CheckpointMeta {
+            run_id: run_id.clone(),
+            workflow: def.name.clone(),
+            out_dir: out_dir.clone().unwrap_or_default(),
+            code_dir: code_dir
+                .clone()
+                .or_else(|| out_dir.clone())
+                .unwrap_or_default(),
+            task: raw_task,
+            phase_names: def.phases.iter().map(|p| p.name.clone()).collect(),
+            started_at,
+        };
+
+        'phase_loop: for (phase_index, phase) in def.phases.iter().enumerate().skip(start_index) {
+            // #82/#196/#209: Skip `skip: true` and persona-opt-out phases,
+            // recording a sentinel output. See `setup::phase_should_skip`.
+            if self.phase_should_skip(phase, persona, &mut ctx) {
+                continue;
+            }
+            info!(phase = %phase.name, agent = %phase.agent, "running phase");
+            // #3062: Pending -> PhaseRunning{i} / PhaseComplete{i-1} -> PhaseRunning{i}.
+            write_checkpoint(
+                &cp_project_dir,
+                &cp_meta,
+                RunState::PhaseRunning { phase_index },
+                &ctx,
+                qa_retry_count,
+                &qa_failure_feedback,
+            );
+
+            // Per-phase AST-native override (#347/#348 follow-up). The override
+            // lives in a process-wide AtomicBool, so we save the prior value,
+            // apply the phase's preference, and let `_ast_guard` restore it
+            // when the phase completes (Drop runs on every continue/break/error).
+            struct AstNativeGuard {
+                prev: bool,
+                applied: bool,
+            }
+            impl Drop for AstNativeGuard {
+                fn drop(&mut self) {
+                    if self.applied {
+                        crate::ast::set_ast_native_override(self.prev);
+                    }
+                }
+            }
+            let _ast_guard = {
+                let prev = crate::ast::is_ast_native_overridden();
+                let applied = if let Some(phase_ast) = phase.ast_native {
+                    crate::ast::set_ast_native_override(phase_ast);
+                    true
+                } else {
+                    false
+                };
+                AstNativeGuard { prev, applied }
+            };
+
+            // #149: Stream phase-start to stderr + machine progress event.
+            if let Some(rep) = &self.progress {
+                rep.phase_start(&phase.name);
+            }
+            emit_progress_event(&phase.name, "running", 0.0, 0.0, None);
+
+            // #140/#222: Refresh the discovered project_dir inside `code_dir`
+            // (where source files actually land) before rendering templates
+            // that reference {{project_dir}}.
+            if let Some(dir) = code_dir.as_deref() {
+                ctx.project_dir = discover_project_dir(dir);
+                if let Some(p) = &ctx.project_dir
+                    && p.as_path() != dir
+                {
+                    info!(
+                        project_dir = %p.display(),
+                        code_dir = %dir.display(),
+                        "discovered project subdirectory for {{{{project_dir}}}}"
+                    );
+                }
+            }
+
+            // Assemble the full per-phase prompt (template render + every
+            // context-injection layer). See `prompt::assemble_phase_prompt`.
+            let rendered = self
+                .assemble_phase_prompt(
+                    phase,
+                    &ctx,
+                    &out_dir,
+                    &code_dir,
+                    discovered_skills,
+                    code_phase_used_claude_code,
+                    &mut qa_failure_feedback,
+                    &mut perf,
+                )
+                .await;
+
+            let phase_started = Instant::now();
+
+            // #107: `phase.model` is threaded through `RunContext` below.
+            if let Some(m) = &phase.model {
+                tracing::debug!(phase = %phase.name, model = %m, "phase model");
+            }
+
+            // #51: Check the agent's TOML for `persistent_session`.
+            let persistent = AgentConfig::by_name(&phase.agent)
+                .map(|c| c.agent.persistent_session)
+                .unwrap_or(false);
+
+            // #88: Wave-loop execution path. When this is the "code" phase AND
+            // the plan-agent has written `assignments.json` into `out_dir`,
+            // run one code-agent per file in topological wave order.
+            let wave_assignments = if phase.name == "code" {
+                match out_dir.as_deref() {
+                    Some(dir) => {
+                        let loaded = Assignments::load(dir);
+                        if loaded.is_some() {
+                            tracing::info!(
+                                phase = %phase.name,
+                                out_dir = %dir.display(),
+                                "code phase: taking WAVE LOOP path (assignments.json present)"
+                            );
+                        } else {
+                            tracing::info!(
+                                phase = %phase.name,
+                                out_dir = %dir.display(),
+                                "code phase: taking LEGACY monolithic path (assignments.json absent or unparseable)"
+                            );
+                        }
+                        loaded
+                    }
+                    None => {
+                        tracing::debug!(
+                            phase = %phase.name,
+                            "code phase: no out_dir configured; wave loop cannot run"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            // Per-phase AST-native override (#349 follow-up to #348). Save the
+            // current global override, apply the phase's override (if any) for
+            // the duration of the dispatch, then restore in BOTH Ok and Err
+            // paths so subsequent phases see the correct inherited value.
+            let prior_ast_native = crate::ast::is_ast_native_overridden();
+            if let Some(phase_ast) = phase.ast_native {
+                crate::ast::set_ast_native_override(phase_ast);
+            }
+
+            let output_result = self
+                .dispatch_phase(
+                    phase,
+                    &rendered,
+                    &out_dir,
+                    &code_dir,
+                    wave_assignments,
+                    persistent,
+                )
+                .await;
+
+            // Restore the global AST-native override now that this phase's
+            // dispatch is complete (regardless of Ok/Err).
+            crate::ast::set_ast_native_override(prior_ast_native);
+
+            let output = match output_result {
+                Ok(o) => o,
+                Err(e) => {
+                    // Record perf + ticket + progress for the failed phase, then
+                    // capture the error and break. See `post_phase::record_phase_failure`.
+                    failed_phase = Some(phase.name.clone());
+                    first_error = Some(
+                        self.record_phase_failure(phase, e, phase_started, &mut perf)
+                            .await,
+                    );
+                    // #3062: PhaseRunning{i} -> Failed{i}.
+                    write_checkpoint(
+                        &cp_project_dir,
+                        &cp_meta,
+                        RunState::Failed { phase_index },
+                        &ctx,
+                        qa_retry_count,
+                        &qa_failure_feedback,
+                    );
+                    break 'phase_loop;
+                }
+            };
+
+            // #27: Prefer the agent-supplied summary; else extract one ourselves.
+            let summary = output
+                .summary
+                .clone()
+                .or_else(|| Some(extract_summary(&output.content)));
+            let content_len = output.content.len();
+            let summary_len = summary.as_ref().map(|s| s.len()).unwrap_or(0);
+
+            // #47: Record perf BEFORE we move `output.content` into the ctx.
+            let duration_ms = phase_started.elapsed().as_millis() as u64;
+            let phase_model = phase
+                .model
+                .clone()
+                .or_else(|| {
+                    AgentConfig::by_name(&phase.agent)
+                        .ok()
+                        .map(|c| c.agent.model)
+                })
+                .unwrap_or_else(|| "unknown".to_string());
+            perf.record_phase(&phase.name, duration_ms, &phase_model, &output.usage);
+
+            // #84: Compute this phase's cost for the ticket comment and
+            // accumulate into the workflow total.
+            let phase_cost = crate::perf::cost_usd(
+                &phase_model,
+                output.usage.prompt_tokens,
+                output.usage.completion_tokens,
+                output.usage.cache_read_tokens,
+                output.usage.cache_creation_tokens,
+            );
+            total_cost_usd += phase_cost;
+
+            // #149: Stream phase-done to stderr + machine progress event. For
+            // QA, surface the first content line as a note (e.g. "35/35 passed").
+            let phase_note: Option<String> = if phase.name == "qa" {
+                output
+                    .content
+                    .lines()
+                    .find(|l| !l.trim().is_empty())
+                    .map(|l| l.chars().take(60).collect::<String>())
+            } else {
+                None
+            };
+            let elapsed = std::time::Duration::from_millis(duration_ms);
+            if let Some(rep) = &self.progress {
+                rep.phase_done(
+                    &phase.name,
+                    elapsed,
+                    phase_cost as f32,
+                    phase_note.as_deref(),
+                );
+            }
+            emit_progress_event(
+                &phase.name,
+                "done",
+                elapsed.as_secs_f32(),
+                phase_cost as f32,
+                phase_note.as_deref(),
+            );
+
+            // #84: Post per-phase ticket comment. Non-fatal on failure.
+            if let Some(tm_cell) = &self.ticket_manager {
+                let tm = tm_cell.lock().await;
+                if let Err(e) = tm
+                    .on_phase_complete(
+                        &phase.name,
+                        &phase_model,
+                        duration_ms,
+                        output.usage.prompt_tokens,
+                        output.usage.completion_tokens,
+                        phase_cost,
+                        "✅ success",
+                    )
+                    .await
+                {
+                    tracing::warn!(error = %e, phase = %phase.name,
+                        "ticket manager: on_phase_complete failed");
+                }
+            }
+
+            // #84 + Fix 2 (claude-mpm parity): QA summary + structured envelope
+            // handling (test counts + one-shot retry gating). See
+            // `post_phase::handle_qa_envelope`.
+            let qa_retry_before = qa_retry_count;
+            self.handle_qa_envelope(
+                phase,
+                &output.content,
+                &mut perf,
+                &mut qa_summary,
+                &mut failed_phase,
+                &mut qa_retry_count,
+                &mut qa_failure_feedback,
+            );
+            if qa_retry_before == 0 && qa_retry_count == 1 {
+                // #3062: PhaseRunning{i} -> Retrying{i,1} (SPEC-AGENTFW-02 §3.2's
+                // "existing Fix 2 one-shot code-phase retry", signaled from
+                // whichever phase index `handle_qa_envelope` is currently
+                // processing — today always the `qa` phase itself, since this
+                // engine's loop has no phase-index jump-back).
+                write_checkpoint(
+                    &cp_project_dir,
+                    &cp_meta,
+                    RunState::Retrying {
+                        phase_index,
+                        attempt: qa_retry_count,
+                    },
+                    &ctx,
+                    qa_retry_count,
+                    &qa_failure_feedback,
+                );
+            }
+
+            // #70: Fire-and-forget record this turn for background indexing.
+            if let Some(idx) = &self.indexer {
+                idx.record(TurnRecord {
+                    session_id: run_id.clone(),
+                    agent: phase.agent.clone(),
+                    turn_number: ctx.phase_outputs.len() as u32,
+                    timestamp: chrono::Utc::now(),
+                    prompt_text: rendered.clone(),
+                    response_text: output.content.clone(),
+                    prompt_tokens: output.usage.prompt_tokens,
+                    completion_tokens: output.usage.completion_tokens,
+                });
+            }
+
+            ctx.record_phase(&phase.name, output.content, summary);
+
+            // #68: After the plan phase, try to extract the goal block so
+            // downstream phases can inject it into their prompts.
+            if ctx.goal_block.is_none()
+                && let Some(content) = ctx.phase_outputs.get(&phase.name)
+                && let Some(g) = crate::context::goals::parse_goal_block_from_text(content)
+            {
+                tracing::info!(
+                    phase = %phase.name,
+                    primary = %g.primary,
+                    secondary_count = g.secondary.len(),
+                    "parsed goal block from phase output"
+                );
+                ctx.goal_block = Some(g);
+            }
+            info!(
+                phase = %phase.name,
+                content_chars = content_len,
+                summary_chars = summary_len,
+                duration_ms,
+                prompt_tokens = output.usage.prompt_tokens,
+                completion_tokens = output.usage.completion_tokens,
+                cache_read = output.usage.cache_read_tokens,
+                cache_creation = output.usage.cache_creation_tokens,
+                "phase complete"
+            );
+
+            // #160: After the plan phase, check for a misrouted
+            // assignments.json at the project root and relocate it.
+            if phase.name == "plan"
+                && let Some(dir) = out_dir.as_deref()
+                && let Err(e) = relocate_plan_outputs_from_project_root(dir).await
+            {
+                tracing::warn!(
+                    error = %e,
+                    "post-plan relocation check failed; continuing"
+                );
+            }
+
+            // #123/#222: After the code phase for a claude-code runner,
+            // reconcile file locations into `code_dir`. Returns whether this was
+            // a claude-code code phase so the QA prompt can be hinted later.
+            if self.reconcile_code_phase(phase, &out_dir, &code_dir).await {
+                code_phase_used_claude_code = true;
+            }
+
+            // #64/#222: Extract `## File: <path>` sections from this phase's
+            // output BEFORE the next phase runs (code -> code_dir, else out_dir).
+            files_generated += self
+                .extract_phase_files(phase, &ctx, &out_dir, &code_dir)
+                .await?;
+
+            // #3062: PhaseRunning{i} -> PhaseComplete{i}, written after file
+            // extraction — see the doc comment above for why this is later
+            // than the spec's literal "immediately after ctx.record_phase".
+            write_checkpoint(
+                &cp_project_dir,
+                &cp_meta,
+                RunState::PhaseComplete { phase_index },
+                &ctx,
+                qa_retry_count,
+                &qa_failure_feedback,
+            );
+        }
+
+        // Hand off all accumulated run state to the finalization tail (report
+        // write, perf flush, auto-push, ticket hooks, progress, error return,
+        // and — #3062 — checkpoint deletion on full success).
+        self.finalize_run(
+            def,
+            FinalizeState {
+                ctx,
+                perf,
+                out_dir,
+                first_error,
+                failed_phase,
+                workflow_started,
+                total_cost_usd,
+                files_generated,
+                qa_summary,
+                run_id,
+            },
+        )
+        .await
+    }
+}

--- a/crates/trusty-agents/src/workflow/engine/executor/resume.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/resume.rs
@@ -1,0 +1,216 @@
+//! `tagent resume <run-id>` engine entry point (#3062, SPEC-AGENTFW-02 §3.4).
+//!
+//! Why: A crashed/killed run leaves a `checkpoint.json` behind (written by
+//! `phase_loop::run_phase_loop`). This module reconstructs a
+//! `WorkflowContext` from that journal — reusing every already-completed
+//! phase's output verbatim, never re-dispatching it — and continues the
+//! SAME shared phase loop a fresh run uses, starting at the first incomplete
+//! phase.
+//! What: `WorkflowEngine::resume_with_perf_and_dirs` loads + validates the
+//! checkpoint (fails closed per §3.5's failure matrix: missing/corrupt/
+//! schema-mismatched journal, or a workflow definition that no longer
+//! matches the checkpointed phase list), reconstructs context, and delegates
+//! to `run_phase_loop`. `ResumeOutcome` distinguishes "already finished,
+//! nothing to resume" from "picked back up and ran".
+//! Test: `checkpoint_resume_tests` in the engine `tests` submodule.
+
+use std::path::PathBuf;
+
+use crate::perf::PerfCollector;
+use crate::workflow::config::WorkflowDef;
+use crate::workflow::context::WorkflowContext;
+use crate::workflow::engine::checkpoint::{self, RunState};
+use crate::workflow::error::WorkflowError;
+
+use super::WorkflowEngine;
+use super::phase_loop::PhaseLoopSeed;
+use super::setup::detect_persona;
+
+/// Outcome of `tagent resume <run-id>` (SPEC-AGENTFW-02 §3.4 requirement:
+/// "If the run finished, say so.").
+///
+/// Why: A checkpoint directory should never contain a `Done` record in
+/// practice (`finalize_run` deletes it on success) but a resume MUST still
+/// handle finding one gracefully — e.g. a prior checkpoint-delete failure —
+/// rather than re-running a completed workflow.
+/// What: `AlreadyDone` carries the run id back for the CLI's message;
+/// `Resumed` carries the same `(WorkflowContext, PerfRecord)` shape `run()`
+/// returns, plus the phase name resume actually restarted at (for the CLI's
+/// "resumed at phase '…'" line).
+/// Test: `resume_reports_already_done_for_done_checkpoint`.
+#[derive(Debug)]
+pub enum ResumeOutcome {
+    AlreadyDone {
+        run_id: String,
+    },
+    /// Boxed: `WorkflowContext` + `PerfRecord` together dwarf the
+    /// `AlreadyDone` variant, which would otherwise force every
+    /// `ResumeOutcome` (including the common already-done case) to reserve
+    /// stack space for the larger variant.
+    Resumed {
+        ctx: Box<WorkflowContext>,
+        perf: Box<crate::perf::PerfRecord>,
+        resumed_at_phase: String,
+    },
+}
+
+impl WorkflowEngine {
+    /// Resume a checkpointed run: reconstruct `WorkflowContext` from the
+    /// journal and continue `run_phase_loop` from the first incomplete
+    /// phase.
+    ///
+    /// Why: Single entry point so `tagent resume <run-id>` only needs one
+    /// call, mirroring how `run_with_perf_and_dirs` is the single entry
+    /// point for a fresh run.
+    /// What: Loads the checkpoint (fail-closed on missing/corrupt/schema
+    /// mismatch — see `checkpoint::load_checkpoint`), reloads the workflow
+    /// definition fresh and validates its phase list still matches the
+    /// checkpoint's snapshot (fail-closed on drift —
+    /// `WorkflowError::ResumeDefinitionChanged`), replays every
+    /// already-`PhaseComplete` phase's output into a fresh `WorkflowContext`
+    /// without re-dispatching it, re-validates `out_dir`/`code_dir` exactly
+    /// as a fresh run does, and hands off to the shared `run_phase_loop`
+    /// starting at the first incomplete phase index.
+    /// Test: `checkpoint_resume_tests::resume_skips_completed_phases_and_reuses_their_output`,
+    /// `checkpoint_resume_tests::resume_fails_closed_on_definition_change`.
+    pub async fn resume_with_perf_and_dirs(
+        &self,
+        run_id: &str,
+    ) -> Result<ResumeOutcome, WorkflowError> {
+        let project_dir = crate::usage::project_dir();
+        let record = checkpoint::load_checkpoint(&project_dir, run_id)?;
+
+        if matches!(record.state, RunState::Done) {
+            return Ok(ResumeOutcome::AlreadyDone {
+                run_id: run_id.to_string(),
+            });
+        }
+
+        // §3.4: reload the workflow definition FRESH — never trust the
+        // checkpoint's `phase_names` snapshot directly, only validate against it.
+        let path = if record.workflow.ends_with(".json") || record.workflow.contains('/') {
+            PathBuf::from(&record.workflow)
+        } else {
+            self.config_dir.join(format!("{}.json", record.workflow))
+        };
+        if !path.exists() {
+            return Err(WorkflowError::WorkflowNotFound {
+                path: path.display().to_string(),
+            });
+        }
+        let def =
+            WorkflowDef::load(&path).map_err(|e| WorkflowError::ConfigInvalid(format!("{e:#}")))?;
+
+        let current_phase_names: Vec<String> = def.phases.iter().map(|p| p.name.clone()).collect();
+        if current_phase_names != record.phase_names {
+            return Err(WorkflowError::ResumeDefinitionChanged {
+                run_id: run_id.to_string(),
+                workflow: record.workflow.clone(),
+                checkpoint_phases: record.phase_names.clone(),
+                current_phases: current_phase_names,
+            });
+        }
+
+        // §3.4: resume immediately AFTER phase_index for PhaseComplete, or AT
+        // phase_index for Failed/Retrying/PhaseRunning (re-run from scratch —
+        // no sub-phase resume).
+        let resume_index = match record.state {
+            RunState::Pending => 0,
+            RunState::PhaseRunning { phase_index }
+            | RunState::Failed { phase_index }
+            | RunState::Retrying { phase_index, .. } => phase_index,
+            RunState::PhaseComplete { phase_index } => phase_index + 1,
+            RunState::Done => unreachable!("handled above"),
+        };
+        let resumed_at_phase = def
+            .phases
+            .get(resume_index)
+            .map(|p| p.name.clone())
+            .unwrap_or_else(|| "(finalize)".to_string());
+
+        crate::events::emit(crate::events::Event::RunResumed {
+            session_id: run_id.to_string(),
+            resumed_at_phase: resumed_at_phase.clone(),
+        });
+        tracing::info!(
+            run_id = %run_id,
+            workflow = %record.workflow,
+            resumed_at_phase = %resumed_at_phase,
+            resume_index,
+            "resuming checkpointed workflow run"
+        );
+
+        // Persona detection runs on the ORIGINAL raw task text, exactly as a
+        // fresh run's `detect_persona(&task)` call does.
+        let (persona, cleaned_task) = detect_persona(&record.task);
+
+        let mut ctx = WorkflowContext::builder(cleaned_task)
+            .with_out_dir(Some(record.out_dir.clone()))
+            .build();
+        ctx.goal_block = record.goal_block.clone();
+        // Replay every already-complete phase's output verbatim — NOT
+        // re-dispatched. `record_phase(name, content, None)` defaults the
+        // summary to the content; the original run's extracted summary isn't
+        // preserved in the journal (documented simplification, see
+        // `checkpoint::CheckpointRecord` doc comment).
+        for phase_def in &def.phases[..resume_index.min(def.phases.len())] {
+            if let Some(content) = record.phase_outputs.get(&phase_def.name) {
+                ctx.record_phase(&phase_def.name, content.clone(), None);
+            }
+        }
+
+        // §3.5 failure matrix: re-validate/re-canonicalize out_dir/code_dir
+        // exactly as a fresh run does. A missing out_dir is recreated; a
+        // missing code_dir with partial generated files is a known MVP
+        // limitation, not solved here.
+        let (out_dir, code_dir) = self
+            .resolve_dirs(Some(record.out_dir.clone()), Some(record.code_dir.clone()))
+            .await?;
+
+        let discovered_skills = self.discover_skills_for_task(&ctx.task, 8);
+        let mut perf = PerfCollector::new(self.build, &def.name, &record.task);
+        for skill in &discovered_skills {
+            perf.record_skill_considered(&skill.name);
+        }
+        self.maybe_pre_index_ast(&def, &code_dir);
+
+        // Deviations from a fresh run, documented in the PR body: the
+        // ticket-manager `on_workflow_start` hook does not re-fire (the
+        // tracking issue already exists), `workflow_started` restarts the
+        // wall clock for the resumed portion only, and per-phase cost/file
+        // counters start at zero (perf for the pre-crash portion was never
+        // flushed anyway, since `perf.flush` only runs once at the end).
+        let seed = PhaseLoopSeed {
+            start_index: resume_index,
+            run_id: run_id.to_string(),
+            raw_task: record.task.clone(),
+            started_at: record.started_at.clone(),
+            workflow_started: std::time::Instant::now(),
+            qa_retry_count: record.qa_retry_count,
+            qa_failure_feedback: record.qa_failure_feedback.clone(),
+            total_cost_usd: 0.0,
+            files_generated: 0,
+            qa_summary: "n/a".to_string(),
+            code_phase_used_claude_code: false,
+        };
+
+        let (ctx, perf_record) = self
+            .run_phase_loop(
+                &def,
+                ctx,
+                perf,
+                out_dir,
+                code_dir,
+                persona,
+                &discovered_skills,
+                seed,
+            )
+            .await?;
+
+        Ok(ResumeOutcome::Resumed {
+            ctx: Box::new(ctx),
+            perf: Box::new(perf_record),
+            resumed_at_phase,
+        })
+    }
+}

--- a/crates/trusty-agents/src/workflow/engine/executor/resume.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/resume.rs
@@ -78,6 +78,14 @@ impl WorkflowEngine {
         run_id: &str,
     ) -> Result<ResumeOutcome, WorkflowError> {
         let project_dir = crate::usage::project_dir();
+
+        // Code-critic finding (PR #3244): hold an exclusive advisory lock for
+        // the ENTIRE resume, not just the checkpoint writes inside it — two
+        // concurrent `tagent resume` calls for the same run_id must not both
+        // dispatch phases. Fails closed immediately (non-blocking) rather
+        // than queuing. Held until this function returns (drop releases it).
+        let _resume_lock = checkpoint::acquire_resume_lock(&project_dir, run_id)?;
+
         let record = checkpoint::load_checkpoint(&project_dir, run_id)?;
 
         if matches!(record.state, RunState::Done) {
@@ -149,13 +157,18 @@ impl WorkflowEngine {
             .build();
         ctx.goal_block = record.goal_block.clone();
         // Replay every already-complete phase's output verbatim — NOT
-        // re-dispatched. `record_phase(name, content, None)` defaults the
-        // summary to the content; the original run's extracted summary isn't
-        // preserved in the journal (documented simplification, see
-        // `checkpoint::CheckpointRecord` doc comment).
+        // re-dispatched. Code-critic finding (PR #3244): pass the PERSISTED
+        // SUMMARY (not `None`) so `ctx.phase_summaries` — the map
+        // `render_template` actually injects into downstream
+        // `{{phase_name}}` substitutions — carries the original ~500-word
+        // digest, not the full raw content. Falling back to `None` (which
+        // defaults the summary to the full content) would silently re-inflate
+        // every downstream prompt for exactly the long-running,
+        // content-heavy workflows checkpointing exists to protect.
         for phase_def in &def.phases[..resume_index.min(def.phases.len())] {
             if let Some(content) = record.phase_outputs.get(&phase_def.name) {
-                ctx.record_phase(&phase_def.name, content.clone(), None);
+                let summary = record.phase_summaries.get(&phase_def.name).cloned();
+                ctx.record_phase(&phase_def.name, content.clone(), summary);
             }
         }
 

--- a/crates/trusty-agents/src/workflow/engine/executor/run.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/run.rs
@@ -127,9 +127,17 @@ impl WorkflowEngine {
         // #3062: `TAGENT_RUN_ID`/`OPEN_MPM_RUN_ID` is the existing run-id
         // convention (already threaded through `emit_progress_event` and
         // `HistoryIndexer`) — reused verbatim as the checkpoint journal's
-        // `run_id`, no new ID scheme.
+        // `run_id`, no new ID scheme. `startup::run_startup_init` always sets
+        // this env var before `run()` dispatches to a workflow, so this
+        // fallback only fires for library callers that construct/run a
+        // `WorkflowEngine` directly without going through the CLI startup
+        // path (e.g. tests, embedders). Code-critic finding (PR #3244
+        // MEDIUM): a fixed `"unknown"` fallback would collide every such
+        // caller onto the same `runs/unknown/` checkpoint directory, so
+        // generate a fresh id instead — same `uuid::Uuid::new_v4()` pattern
+        // `startup.rs:327` uses for the primary env-var generation path.
         let run_id = crate::env_compat::env_var("TAGENT_RUN_ID", "OPEN_MPM_RUN_ID")
-            .unwrap_or_else(|_| "unknown".to_string());
+            .unwrap_or_else(|_| uuid::Uuid::new_v4().to_string());
         let started_at = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
 
         let seed = PhaseLoopSeed {

--- a/crates/trusty-agents/src/workflow/engine/executor/run.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/run.rs
@@ -1,12 +1,16 @@
-//! The workflow engine's phase-loop driver (`run_with_perf_and_dirs`).
+//! The workflow engine's fresh-run entry point (`run_with_perf_and_dirs`).
 //!
 //! Why: This is the deterministic Research -> Plan -> Code -> QA -> Observe
-//! driver. It resolves output/code dirs, detects the persona, iterates phases
-//! (skipping, prompt assembly, dispatch, perf, QA gating, file extraction), and
-//! hands off to `finalize_run`. Split from the builder surface (#359) to keep
-//! each file under the 500-line cap.
-//! What: `WorkflowEngine::run_with_perf_and_dirs` — the single end-to-end entry
-//! point all the public `run*` wrappers funnel into.
+//! driver's fresh-start path: resolve the workflow definition, fire the
+//! ticket-manager start hook, build the initial (empty) `WorkflowContext` +
+//! `PerfCollector`, detect persona, then delegate to the shared
+//! `phase_loop::run_phase_loop` — the SAME driver `tagent resume` uses via
+//! `resume::resume_with_perf_and_dirs` — with `start_index: 0`. The loop
+//! body itself (dispatch, QA gating, file extraction, checkpoint writes)
+//! moved to `phase_loop` in #3062 specifically so resume never diverges from
+//! fresh-run dispatch behavior.
+//! What: `WorkflowEngine::run_with_perf_and_dirs` — the single end-to-end
+//! entry point all the public `run*` wrappers funnel into.
 //! Test: Covered end-to-end by the engine `tests` submodule and
 //! `main::run_workflow`.
 
@@ -15,20 +19,13 @@ use std::time::Instant;
 
 use tracing::info;
 
-use crate::agents::AgentConfig;
-use crate::context::TurnRecord;
-use crate::ipc::extract_summary;
 use crate::perf::PerfCollector;
-use crate::workflow::config::{Assignments, WorkflowDef};
+use crate::workflow::config::WorkflowDef;
 use crate::workflow::context::WorkflowContext;
 use crate::workflow::error::WorkflowError;
 
-use super::super::helpers::relocate_plan_outputs_from_project_root;
-use super::super::state::emit_progress_event;
-use super::super::step_dispatch::discover_project_dir;
-use super::DiscoveredSkill;
 use super::WorkflowEngine;
-use super::finalize::FinalizeState;
+use super::phase_loop::PhaseLoopSeed;
 use super::setup::detect_persona;
 
 impl WorkflowEngine {
@@ -100,14 +97,6 @@ impl WorkflowEngine {
         // clock + aggregated TokenUsage + resolved agent model get pushed
         // into the collector and flushed to disk at the end.
         let mut perf = PerfCollector::new(self.build, &def.name, &task);
-        // #84: Accumulate cost + files count so the success hook has a
-        // single-line summary without re-reading the flushed perf JSON.
-        let mut total_cost_usd: f64 = 0.0;
-        let mut files_generated: usize = 0;
-        let mut qa_summary: String = "n/a".to_string();
-        // #123: Track whether the code phase ran under a `claude-code` runner
-        // so we can prepend a path-search hint to the QA agent's prompt.
-        let mut code_phase_used_claude_code: bool = false;
 
         // #126/#153/#222: Pre-create + canonicalize out_dir and code_dir (the
         // latter falling back to out_dir). See `setup::resolve_dirs`.
@@ -117,26 +106,15 @@ impl WorkflowEngine {
         // it's cleaned and handed to the context. See `setup::detect_persona`.
         let (persona, cleaned_task) = detect_persona(&task);
 
-        let mut ctx = WorkflowContext::builder(cleaned_task)
+        let ctx = WorkflowContext::builder(cleaned_task)
             .with_out_dir(out_dir.clone())
             .build();
-
-        // #56: Track the first failing phase name and the error so we can
-        // flush a partial perf record before propagating.
-        let mut failed_phase: Option<String> = None;
-        let mut first_error: Option<WorkflowError> = None;
-
-        // Fix 2 (claude-mpm parity): QA gating state. `qa_failure_feedback`
-        // carries the `[QA FEEDBACK] …` block to prepend to the next
-        // code-phase render; `qa_retry_count` bounds retries at exactly one.
-        let mut qa_failure_feedback: Option<String> = None;
-        let mut qa_retry_count: u32 = 0;
 
         // #173: Run pre-plan skill discovery once for the whole workflow so
         // every skill the engine considered is recorded in the perf record
         // (`skills_considered`) regardless of which phase eventually consumed
         // them.
-        let discovered_skills: Vec<DiscoveredSkill> = self.discover_skills_for_task(&ctx.task, 8);
+        let discovered_skills = self.discover_skills_for_task(&ctx.task, 8);
         for skill in &discovered_skills {
             perf.record_skill_considered(&skill.name);
         }
@@ -146,339 +124,37 @@ impl WorkflowEngine {
         // `setup::maybe_pre_index_ast`.
         self.maybe_pre_index_ast(&def, &code_dir);
 
-        'phase_loop: for phase in &def.phases {
-            // #82/#196/#209: Skip `skip: true` and persona-opt-out phases,
-            // recording a sentinel output. See `setup::phase_should_skip`.
-            if self.phase_should_skip(phase, persona, &mut ctx) {
-                continue;
-            }
-            info!(phase = %phase.name, agent = %phase.agent, "running phase");
+        // #3062: `TAGENT_RUN_ID`/`OPEN_MPM_RUN_ID` is the existing run-id
+        // convention (already threaded through `emit_progress_event` and
+        // `HistoryIndexer`) — reused verbatim as the checkpoint journal's
+        // `run_id`, no new ID scheme.
+        let run_id = crate::env_compat::env_var("TAGENT_RUN_ID", "OPEN_MPM_RUN_ID")
+            .unwrap_or_else(|_| "unknown".to_string());
+        let started_at = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
 
-            // Per-phase AST-native override (#347/#348 follow-up). The override
-            // lives in a process-wide AtomicBool, so we save the prior value,
-            // apply the phase's preference, and let `_ast_guard` restore it
-            // when the phase completes (Drop runs on every continue/break/error).
-            struct AstNativeGuard {
-                prev: bool,
-                applied: bool,
-            }
-            impl Drop for AstNativeGuard {
-                fn drop(&mut self) {
-                    if self.applied {
-                        crate::ast::set_ast_native_override(self.prev);
-                    }
-                }
-            }
-            let _ast_guard = {
-                let prev = crate::ast::is_ast_native_overridden();
-                let applied = if let Some(phase_ast) = phase.ast_native {
-                    crate::ast::set_ast_native_override(phase_ast);
-                    true
-                } else {
-                    false
-                };
-                AstNativeGuard { prev, applied }
-            };
+        let seed = PhaseLoopSeed {
+            start_index: 0,
+            run_id,
+            raw_task: task,
+            started_at,
+            workflow_started,
+            qa_retry_count: 0,
+            qa_failure_feedback: None,
+            total_cost_usd: 0.0,
+            files_generated: 0,
+            qa_summary: "n/a".to_string(),
+            code_phase_used_claude_code: false,
+        };
 
-            // #149: Stream phase-start to stderr + machine progress event.
-            if let Some(rep) = &self.progress {
-                rep.phase_start(&phase.name);
-            }
-            emit_progress_event(&phase.name, "running", 0.0, 0.0, None);
-
-            // #140/#222: Refresh the discovered project_dir inside `code_dir`
-            // (where source files actually land) before rendering templates
-            // that reference {{project_dir}}.
-            if let Some(dir) = code_dir.as_deref() {
-                ctx.project_dir = discover_project_dir(dir);
-                if let Some(p) = &ctx.project_dir
-                    && p.as_path() != dir
-                {
-                    info!(
-                        project_dir = %p.display(),
-                        code_dir = %dir.display(),
-                        "discovered project subdirectory for {{{{project_dir}}}}"
-                    );
-                }
-            }
-
-            // Assemble the full per-phase prompt (template render + every
-            // context-injection layer). See `prompt::assemble_phase_prompt`.
-            let rendered = self
-                .assemble_phase_prompt(
-                    phase,
-                    &ctx,
-                    &out_dir,
-                    &code_dir,
-                    &discovered_skills,
-                    code_phase_used_claude_code,
-                    &mut qa_failure_feedback,
-                    &mut perf,
-                )
-                .await;
-
-            let phase_started = Instant::now();
-
-            // #107: `phase.model` is threaded through `RunContext` below.
-            if let Some(m) = &phase.model {
-                tracing::debug!(phase = %phase.name, model = %m, "phase model");
-            }
-
-            // #51: Check the agent's TOML for `persistent_session`.
-            let persistent = AgentConfig::by_name(&phase.agent)
-                .map(|c| c.agent.persistent_session)
-                .unwrap_or(false);
-
-            // #88: Wave-loop execution path. When this is the "code" phase AND
-            // the plan-agent has written `assignments.json` into `out_dir`,
-            // run one code-agent per file in topological wave order.
-            let wave_assignments = if phase.name == "code" {
-                match out_dir.as_deref() {
-                    Some(dir) => {
-                        let loaded = Assignments::load(dir);
-                        if loaded.is_some() {
-                            tracing::info!(
-                                phase = %phase.name,
-                                out_dir = %dir.display(),
-                                "code phase: taking WAVE LOOP path (assignments.json present)"
-                            );
-                        } else {
-                            tracing::info!(
-                                phase = %phase.name,
-                                out_dir = %dir.display(),
-                                "code phase: taking LEGACY monolithic path (assignments.json absent or unparseable)"
-                            );
-                        }
-                        loaded
-                    }
-                    None => {
-                        tracing::debug!(
-                            phase = %phase.name,
-                            "code phase: no out_dir configured; wave loop cannot run"
-                        );
-                        None
-                    }
-                }
-            } else {
-                None
-            };
-
-            // Per-phase AST-native override (#349 follow-up to #348). Save the
-            // current global override, apply the phase's override (if any) for
-            // the duration of the dispatch, then restore in BOTH Ok and Err
-            // paths so subsequent phases see the correct inherited value.
-            let prior_ast_native = crate::ast::is_ast_native_overridden();
-            if let Some(phase_ast) = phase.ast_native {
-                crate::ast::set_ast_native_override(phase_ast);
-            }
-
-            let output_result = self
-                .dispatch_phase(
-                    phase,
-                    &rendered,
-                    &out_dir,
-                    &code_dir,
-                    wave_assignments,
-                    persistent,
-                )
-                .await;
-
-            // Restore the global AST-native override now that this phase's
-            // dispatch is complete (regardless of Ok/Err).
-            crate::ast::set_ast_native_override(prior_ast_native);
-
-            let output = match output_result {
-                Ok(o) => o,
-                Err(e) => {
-                    // Record perf + ticket + progress for the failed phase, then
-                    // capture the error and break. See `post_phase::record_phase_failure`.
-                    failed_phase = Some(phase.name.clone());
-                    first_error = Some(
-                        self.record_phase_failure(phase, e, phase_started, &mut perf)
-                            .await,
-                    );
-                    break 'phase_loop;
-                }
-            };
-
-            // #27: Prefer the agent-supplied summary; else extract one ourselves.
-            let summary = output
-                .summary
-                .clone()
-                .or_else(|| Some(extract_summary(&output.content)));
-            let content_len = output.content.len();
-            let summary_len = summary.as_ref().map(|s| s.len()).unwrap_or(0);
-
-            // #47: Record perf BEFORE we move `output.content` into the ctx.
-            let duration_ms = phase_started.elapsed().as_millis() as u64;
-            let phase_model = phase
-                .model
-                .clone()
-                .or_else(|| {
-                    AgentConfig::by_name(&phase.agent)
-                        .ok()
-                        .map(|c| c.agent.model)
-                })
-                .unwrap_or_else(|| "unknown".to_string());
-            perf.record_phase(&phase.name, duration_ms, &phase_model, &output.usage);
-
-            // #84: Compute this phase's cost for the ticket comment and
-            // accumulate into the workflow total.
-            let phase_cost = crate::perf::cost_usd(
-                &phase_model,
-                output.usage.prompt_tokens,
-                output.usage.completion_tokens,
-                output.usage.cache_read_tokens,
-                output.usage.cache_creation_tokens,
-            );
-            total_cost_usd += phase_cost;
-
-            // #149: Stream phase-done to stderr + machine progress event. For
-            // QA, surface the first content line as a note (e.g. "35/35 passed").
-            let phase_note: Option<String> = if phase.name == "qa" {
-                output
-                    .content
-                    .lines()
-                    .find(|l| !l.trim().is_empty())
-                    .map(|l| l.chars().take(60).collect::<String>())
-            } else {
-                None
-            };
-            let elapsed = std::time::Duration::from_millis(duration_ms);
-            if let Some(rep) = &self.progress {
-                rep.phase_done(
-                    &phase.name,
-                    elapsed,
-                    phase_cost as f32,
-                    phase_note.as_deref(),
-                );
-            }
-            emit_progress_event(
-                &phase.name,
-                "done",
-                elapsed.as_secs_f32(),
-                phase_cost as f32,
-                phase_note.as_deref(),
-            );
-
-            // #84: Post per-phase ticket comment. Non-fatal on failure.
-            if let Some(tm_cell) = &self.ticket_manager {
-                let tm = tm_cell.lock().await;
-                if let Err(e) = tm
-                    .on_phase_complete(
-                        &phase.name,
-                        &phase_model,
-                        duration_ms,
-                        output.usage.prompt_tokens,
-                        output.usage.completion_tokens,
-                        phase_cost,
-                        "✅ success",
-                    )
-                    .await
-                {
-                    tracing::warn!(error = %e, phase = %phase.name,
-                        "ticket manager: on_phase_complete failed");
-                }
-            }
-
-            // #84 + Fix 2 (claude-mpm parity): QA summary + structured envelope
-            // handling (test counts + one-shot retry gating). See
-            // `post_phase::handle_qa_envelope`.
-            self.handle_qa_envelope(
-                phase,
-                &output.content,
-                &mut perf,
-                &mut qa_summary,
-                &mut failed_phase,
-                &mut qa_retry_count,
-                &mut qa_failure_feedback,
-            );
-
-            // #70: Fire-and-forget record this turn for background indexing.
-            if let Some(idx) = &self.indexer {
-                let run_id = crate::env_compat::env_var("TAGENT_RUN_ID", "OPEN_MPM_RUN_ID")
-                    .unwrap_or_else(|_| "unknown".to_string());
-                idx.record(TurnRecord {
-                    session_id: run_id,
-                    agent: phase.agent.clone(),
-                    turn_number: ctx.phase_outputs.len() as u32,
-                    timestamp: chrono::Utc::now(),
-                    prompt_text: rendered.clone(),
-                    response_text: output.content.clone(),
-                    prompt_tokens: output.usage.prompt_tokens,
-                    completion_tokens: output.usage.completion_tokens,
-                });
-            }
-
-            ctx.record_phase(&phase.name, output.content, summary);
-
-            // #68: After the plan phase, try to extract the goal block so
-            // downstream phases can inject it into their prompts.
-            if ctx.goal_block.is_none()
-                && let Some(content) = ctx.phase_outputs.get(&phase.name)
-                && let Some(g) = crate::context::goals::parse_goal_block_from_text(content)
-            {
-                tracing::info!(
-                    phase = %phase.name,
-                    primary = %g.primary,
-                    secondary_count = g.secondary.len(),
-                    "parsed goal block from phase output"
-                );
-                ctx.goal_block = Some(g);
-            }
-            info!(
-                phase = %phase.name,
-                content_chars = content_len,
-                summary_chars = summary_len,
-                duration_ms,
-                prompt_tokens = output.usage.prompt_tokens,
-                completion_tokens = output.usage.completion_tokens,
-                cache_read = output.usage.cache_read_tokens,
-                cache_creation = output.usage.cache_creation_tokens,
-                "phase complete"
-            );
-
-            // #160: After the plan phase, check for a misrouted
-            // assignments.json at the project root and relocate it.
-            if phase.name == "plan"
-                && let Some(dir) = out_dir.as_deref()
-                && let Err(e) = relocate_plan_outputs_from_project_root(dir).await
-            {
-                tracing::warn!(
-                    error = %e,
-                    "post-plan relocation check failed; continuing"
-                );
-            }
-
-            // #123/#222: After the code phase for a claude-code runner,
-            // reconcile file locations into `code_dir`. Returns whether this was
-            // a claude-code code phase so the QA prompt can be hinted later.
-            if self.reconcile_code_phase(phase, &out_dir, &code_dir).await {
-                code_phase_used_claude_code = true;
-            }
-
-            // #64/#222: Extract `## File: <path>` sections from this phase's
-            // output BEFORE the next phase runs (code -> code_dir, else out_dir).
-            files_generated += self
-                .extract_phase_files(phase, &ctx, &out_dir, &code_dir)
-                .await?;
-        }
-
-        // Hand off all accumulated run state to the finalization tail (report
-        // write, perf flush, auto-push, ticket hooks, progress, error return).
-        self.finalize_run(
+        self.run_phase_loop(
             &def,
-            FinalizeState {
-                ctx,
-                perf,
-                out_dir,
-                first_error,
-                failed_phase,
-                workflow_started,
-                total_cost_usd,
-                files_generated,
-                qa_summary,
-            },
+            ctx,
+            perf,
+            out_dir,
+            code_dir,
+            persona,
+            &discovered_skills,
+            seed,
         )
         .await
     }

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/checkpoint_resume.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/checkpoint_resume.rs
@@ -1,0 +1,354 @@
+//! Integration tests for phase-checkpoint durability + `tagent resume`
+//! (#3062, SPEC-AGENTFW-02 §3).
+//!
+//! Why: Unit tests in `checkpoint_tests.rs` cover the journal's serde/I-O
+//! contract in isolation. These tests drive the REAL `WorkflowEngine` phase
+//! loop end-to-end through a simulated crash (a mock agent that fails on its
+//! first call, standing in for "the process was killed mid-phase" without
+//! literally `SIGKILL`ing the test process) and assert that resuming does
+//! not re-dispatch any already-completed phase, and that the run completes.
+//! What: `FlakyOnceMock` counts calls per agent name and fails the first
+//! call to one designated agent. `resume_skips_completed_phases_and_reuses_their_output`
+//! is the primary conformance test (SPEC-AGENTFW-02 §3.6: "re-runs phase 1
+//! ... and does not re-invoke the phase-0 agent"). The remaining tests cover
+//! the §3.5 failure-matrix fail-closed paths.
+//! Test: This file IS the test suite.
+
+use std::collections::HashMap;
+
+use super::*;
+
+use crate::workflow::ResumeOutcome;
+use crate::workflow::engine::checkpoint::{self, CheckpointRecord, RunState};
+use crate::workflow::error::WorkflowError;
+
+/// Mock runner that counts calls per agent name and fails ONLY the first
+/// call to `fail_once_agent` — every other call (including retries of that
+/// same agent) succeeds. Stands in for "the process crashed mid-phase and a
+/// resume re-dispatches that phase" without an actual process kill.
+struct FlakyOnceMock {
+    call_counts: Arc<Mutex<HashMap<String, u32>>>,
+    fail_once_agent: String,
+}
+
+#[async_trait]
+impl AgentRunner for FlakyOnceMock {
+    async fn run(&self, agent_name: &str, _task: &str) -> Result<AgentOutput> {
+        let call_number = {
+            let mut counts = self.call_counts.lock().unwrap();
+            let entry = counts.entry(agent_name.to_string()).or_insert(0);
+            *entry += 1;
+            *entry
+        };
+        if agent_name == self.fail_once_agent && call_number == 1 {
+            anyhow::bail!("simulated crash: {agent_name} failed on its first invocation");
+        }
+        Ok(AgentOutput {
+            content: format!("{agent_name} output (call #{call_number})"),
+            summary: Some(format!("{agent_name} summary")),
+            usage: TokenUsage::default(),
+        })
+    }
+}
+
+/// RAII guard that sets a process env var for the duration of a test and
+/// restores its previous value (or removes it) on drop — including on
+/// panic/early-return. Every test in this file is `#[serial]` (env vars are
+/// process-global) matching the existing convention in `env_compat.rs` /
+/// `llm/credentials.rs`.
+struct EnvVarGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: serialized against every other `#[serial]` env-mutating
+        // test in this crate (see `env_compat.rs` for the established
+        // pattern this mirrors).
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+/// Write the shared 3-phase test workflow (`phase-a` -> `phase-b` ->
+/// `phase-c`) used by every test in this file.
+fn write_three_phase_workflow(workflows_dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    std::fs::create_dir_all(workflows_dir).unwrap();
+    let path = workflows_dir.join(format!("{name}.json"));
+    let json = format!(
+        r#"{{
+            "name": "{name}",
+            "description": "checkpoint/resume integration test",
+            "phases": [
+                {{"name": "phase-a", "agent": "agent-a", "context_template": "{{{{task}}}}"}},
+                {{"name": "phase-b", "agent": "agent-b", "context_template": "{{{{task}}}} / {{{{phase-a}}}}"}},
+                {{"name": "phase-c", "agent": "agent-c", "context_template": "{{{{task}}}} / {{{{phase-b}}}}"}}
+            ]
+        }}"#
+    );
+    std::fs::write(&path, json).unwrap();
+    path
+}
+
+/// The primary conformance test (SPEC-AGENTFW-02 §3.6): a 3-phase workflow's
+/// middle phase (`phase-b`) fails on its first dispatch — simulating a crash
+/// after `phase-a` completed. The run returns `Err` and leaves a `Failed{1}`
+/// checkpoint. `tagent resume` (via `resume_with_perf_and_dirs`) then
+/// completes the run: `phase-a`'s agent is called exactly once (never
+/// re-dispatched), `phase-b`'s agent is called twice (the failed attempt +
+/// the successful retry), `phase-c` runs once, and the final context
+/// contains all three phase outputs. The checkpoint directory is deleted
+/// once the resumed run reaches `Done`.
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_skips_completed_phases_and_reuses_their_output() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _project_guard = EnvVarGuard::set("TAGENT_PROJECT_DIR", &tmp.path().to_string_lossy());
+    let run_id = format!("test-run-{}", uuid::Uuid::new_v4());
+    let _run_id_guard = EnvVarGuard::set("TAGENT_RUN_ID", &run_id);
+
+    let workflows_dir = tmp.path().join("workflows");
+    write_three_phase_workflow(&workflows_dir, "checkpoint-resume-test");
+    let out_dir = tmp.path().join("out");
+
+    let call_counts: Arc<Mutex<HashMap<String, u32>>> = Arc::new(Mutex::new(HashMap::new()));
+    let mock = Arc::new(FlakyOnceMock {
+        call_counts: call_counts.clone(),
+        fail_once_agent: "agent-b".to_string(),
+    });
+    let engine = WorkflowEngine::new(mock, workflows_dir.clone());
+
+    // --- "crash" run: phase-a succeeds, phase-b fails, phase-c never runs.
+    let first_result = engine
+        .run(
+            "checkpoint-resume-test",
+            "do the thing".into(),
+            Some(out_dir.clone()),
+        )
+        .await;
+    assert!(
+        first_result.is_err(),
+        "expected the simulated phase-b crash to propagate as Err"
+    );
+    {
+        let counts = call_counts.lock().unwrap();
+        assert_eq!(counts.get("agent-a").copied(), Some(1));
+        assert_eq!(counts.get("agent-b").copied(), Some(1));
+        assert_eq!(counts.get("agent-c"), None, "phase-c must not run yet");
+    }
+
+    // Checkpoint must reflect phase-a complete, phase-b failed (index 1).
+    let project_dir = crate::usage::project_dir();
+    let record = checkpoint::load_checkpoint(&project_dir, &run_id)
+        .expect("a checkpoint must exist after the simulated crash");
+    assert_eq!(record.state, RunState::Failed { phase_index: 1 });
+    assert!(record.phase_outputs.contains_key("phase-a"));
+    assert!(!record.phase_outputs.contains_key("phase-b"));
+
+    // --- resume: phase-a must NOT be re-dispatched; phase-b retries and
+    // succeeds; phase-c runs for the first time; the run completes.
+    let outcome = engine
+        .resume_with_perf_and_dirs(&run_id)
+        .await
+        .expect("resume should succeed");
+    let (ctx, resumed_at_phase) = match outcome {
+        ResumeOutcome::Resumed {
+            ctx,
+            resumed_at_phase,
+            ..
+        } => (ctx, resumed_at_phase),
+        ResumeOutcome::AlreadyDone { .. } => panic!("expected Resumed, got AlreadyDone"),
+    };
+    assert_eq!(resumed_at_phase, "phase-b");
+
+    {
+        let counts = call_counts.lock().unwrap();
+        assert_eq!(
+            counts.get("agent-a").copied(),
+            Some(1),
+            "phase-a must NOT be re-executed on resume"
+        );
+        assert_eq!(
+            counts.get("agent-b").copied(),
+            Some(2),
+            "phase-b's failed attempt + successful retry"
+        );
+        assert_eq!(counts.get("agent-c").copied(), Some(1));
+    }
+
+    assert!(ctx.phase_outputs.contains_key("phase-a"));
+    assert!(ctx.phase_outputs.contains_key("phase-b"));
+    assert!(ctx.phase_outputs.contains_key("phase-c"));
+
+    // A successfully-completed (Done) run deletes its checkpoint directory.
+    assert!(
+        checkpoint::load_checkpoint(&project_dir, &run_id).is_err(),
+        "checkpoint must be deleted after the resumed run completes"
+    );
+}
+
+/// §3.5 failure matrix: if the workflow JSON's phase list changed since the
+/// checkpoint was written, resume MUST fail closed with
+/// `ResumeDefinitionChanged` rather than silently running a different
+/// pipeline than the one that was checkpointed.
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_fails_closed_on_definition_change() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _project_guard = EnvVarGuard::set("TAGENT_PROJECT_DIR", &tmp.path().to_string_lossy());
+    let run_id = format!("test-run-{}", uuid::Uuid::new_v4());
+
+    let workflows_dir = tmp.path().join("workflows");
+    write_three_phase_workflow(&workflows_dir, "definition-changed-test");
+    let out_dir = tmp.path().join("out");
+    std::fs::create_dir_all(&out_dir).unwrap();
+
+    // Hand-write a checkpoint claiming phase-a is complete.
+    let mut phase_outputs = std::collections::BTreeMap::new();
+    phase_outputs.insert("phase-a".to_string(), "a output".to_string());
+    let record = CheckpointRecord {
+        schema_version: checkpoint::CHECKPOINT_SCHEMA_VERSION,
+        run_id: run_id.clone(),
+        workflow: "definition-changed-test".to_string(),
+        state: RunState::PhaseComplete { phase_index: 0 },
+        phase_names: vec![
+            "phase-a".to_string(),
+            "phase-b".to_string(),
+            "phase-c".to_string(),
+        ],
+        out_dir: out_dir.clone(),
+        code_dir: out_dir.clone(),
+        task: "do the thing".to_string(),
+        phase_outputs,
+        goal_block: None,
+        qa_retry_count: 0,
+        qa_failure_feedback: None,
+        started_at: "2026-07-19T00:00:00Z".to_string(),
+        updated_at: "2026-07-19T00:00:01Z".to_string(),
+    };
+    record.write(tmp.path()).unwrap();
+
+    // Now mutate the on-disk workflow JSON to remove a phase — the
+    // definition on disk no longer matches what was checkpointed.
+    let path = workflows_dir.join("definition-changed-test.json");
+    std::fs::write(
+        &path,
+        r#"{
+            "name": "definition-changed-test",
+            "phases": [
+                {"name": "phase-a", "agent": "agent-a", "context_template": "{{task}}"}
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let call_counts: Arc<Mutex<HashMap<String, u32>>> = Arc::new(Mutex::new(HashMap::new()));
+    let mock = Arc::new(FlakyOnceMock {
+        call_counts,
+        fail_once_agent: String::new(),
+    });
+    let engine = WorkflowEngine::new(mock, workflows_dir.clone());
+
+    let err = engine
+        .resume_with_perf_and_dirs(&run_id)
+        .await
+        .expect_err("resume must fail closed when the phase list changed");
+    assert!(
+        matches!(err, WorkflowError::ResumeDefinitionChanged { .. }),
+        "expected ResumeDefinitionChanged, got {err:?}"
+    );
+}
+
+/// §3.4 requirement: "If the run finished, say so." A checkpoint whose state
+/// is (unexpectedly) `Done` must report `AlreadyDone` instead of attempting
+/// to re-run anything.
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_reports_already_done_for_done_checkpoint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _project_guard = EnvVarGuard::set("TAGENT_PROJECT_DIR", &tmp.path().to_string_lossy());
+    let run_id = format!("test-run-{}", uuid::Uuid::new_v4());
+
+    let workflows_dir = tmp.path().join("workflows");
+    write_three_phase_workflow(&workflows_dir, "already-done-test");
+    let out_dir = tmp.path().join("out");
+    std::fs::create_dir_all(&out_dir).unwrap();
+
+    let record = CheckpointRecord {
+        schema_version: checkpoint::CHECKPOINT_SCHEMA_VERSION,
+        run_id: run_id.clone(),
+        workflow: "already-done-test".to_string(),
+        state: RunState::Done,
+        phase_names: vec![
+            "phase-a".to_string(),
+            "phase-b".to_string(),
+            "phase-c".to_string(),
+        ],
+        out_dir: out_dir.clone(),
+        code_dir: out_dir.clone(),
+        task: "do the thing".to_string(),
+        phase_outputs: std::collections::BTreeMap::new(),
+        goal_block: None,
+        qa_retry_count: 0,
+        qa_failure_feedback: None,
+        started_at: "2026-07-19T00:00:00Z".to_string(),
+        updated_at: "2026-07-19T00:00:01Z".to_string(),
+    };
+    record.write(tmp.path()).unwrap();
+
+    let call_counts: Arc<Mutex<HashMap<String, u32>>> = Arc::new(Mutex::new(HashMap::new()));
+    let mock = Arc::new(FlakyOnceMock {
+        call_counts,
+        fail_once_agent: String::new(),
+    });
+    let engine = WorkflowEngine::new(mock, workflows_dir.clone());
+
+    let outcome = engine
+        .resume_with_perf_and_dirs(&run_id)
+        .await
+        .expect("resume of a Done checkpoint must not error");
+    assert!(matches!(outcome, ResumeOutcome::AlreadyDone { .. }));
+}
+
+/// §3.5 failure matrix: resuming a run id with no checkpoint on disk fails
+/// closed with `CheckpointNotFound`, not a panic.
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_missing_checkpoint_returns_clear_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _project_guard = EnvVarGuard::set("TAGENT_PROJECT_DIR", &tmp.path().to_string_lossy());
+
+    let workflows_dir = tmp.path().join("workflows");
+    write_three_phase_workflow(&workflows_dir, "missing-checkpoint-test");
+
+    let call_counts: Arc<Mutex<HashMap<String, u32>>> = Arc::new(Mutex::new(HashMap::new()));
+    let mock = Arc::new(FlakyOnceMock {
+        call_counts,
+        fail_once_agent: String::new(),
+    });
+    let engine = WorkflowEngine::new(mock, workflows_dir.clone());
+
+    let err = engine
+        .resume_with_perf_and_dirs("never-existed")
+        .await
+        .expect_err("resuming an unknown run id must fail closed");
+    assert!(
+        matches!(err, WorkflowError::CheckpointNotFound { .. }),
+        "expected CheckpointNotFound, got {err:?}"
+    );
+}

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/checkpoint_resume.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/checkpoint_resume.rs
@@ -6,12 +6,19 @@
 //! loop end-to-end through a simulated crash (a mock agent that fails on its
 //! first call, standing in for "the process was killed mid-phase" without
 //! literally `SIGKILL`ing the test process) and assert that resuming does
-//! not re-dispatch any already-completed phase, and that the run completes.
-//! What: `FlakyOnceMock` counts calls per agent name and fails the first
-//! call to one designated agent. `resume_skips_completed_phases_and_reuses_their_output`
+//! not re-dispatch any already-completed phase, that resume replays the
+//! extracted SUMMARY (not full content) into downstream prompts, that
+//! concurrent resumes of the same run fail closed, and that the run
+//! completes.
+//! What: `FlakyOnceMock` counts calls per agent name, fails the first call
+//! to one designated agent, records every rendered prompt it receives per
+//! agent, and can be configured to return a custom (content, summary) pair
+//! for a given agent. `resume_skips_completed_phases_and_reuses_their_output`
 //! is the primary conformance test (SPEC-AGENTFW-02 §3.6: "re-runs phase 1
 //! ... and does not re-invoke the phase-0 agent"). The remaining tests cover
-//! the §3.5 failure-matrix fail-closed paths.
+//! the §3.5 failure-matrix fail-closed paths plus the two code-critic
+//! findings from PR #3244 (summary/content conflation, concurrent-resume
+//! mutual exclusion).
 //! Test: This file IS the test suite.
 
 use std::collections::HashMap;
@@ -22,18 +29,64 @@ use crate::workflow::ResumeOutcome;
 use crate::workflow::engine::checkpoint::{self, CheckpointRecord, RunState};
 use crate::workflow::error::WorkflowError;
 
-/// Mock runner that counts calls per agent name and fails ONLY the first
-/// call to `fail_once_agent` — every other call (including retries of that
-/// same agent) succeeds. Stands in for "the process crashed mid-phase and a
-/// resume re-dispatches that phase" without an actual process kill.
+/// Mock runner that counts calls per agent name, fails ONLY the first call
+/// to `fail_once_agent` (every other call — including retries of that same
+/// agent — succeeds), records every task/prompt text it receives per agent
+/// (in call order, successful calls only), and returns a per-agent custom
+/// `(content, summary)` pair when configured via `with_custom_output`
+/// (otherwise a generic stub). Stands in for "the process crashed mid-phase
+/// and a resume re-dispatches that phase" without an actual process kill.
 struct FlakyOnceMock {
-    call_counts: Arc<Mutex<HashMap<String, u32>>>,
+    call_counts: Mutex<HashMap<String, u32>>,
     fail_once_agent: String,
+    captured_tasks: Mutex<HashMap<String, Vec<String>>>,
+    custom_outputs: Mutex<HashMap<String, (String, Option<String>)>>,
+}
+
+impl FlakyOnceMock {
+    fn new(fail_once_agent: &str) -> Self {
+        Self {
+            call_counts: Mutex::new(HashMap::new()),
+            fail_once_agent: fail_once_agent.to_string(),
+            captured_tasks: Mutex::new(HashMap::new()),
+            custom_outputs: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Configure `agent_name` to return `content`/`summary` instead of the
+    /// generic stub, on every (non-failing) call.
+    fn with_custom_output(self, agent_name: &str, content: &str, summary: Option<&str>) -> Self {
+        self.custom_outputs.lock().unwrap().insert(
+            agent_name.to_string(),
+            (content.to_string(), summary.map(str::to_string)),
+        );
+        self
+    }
+
+    fn call_count(&self, agent_name: &str) -> u32 {
+        self.call_counts
+            .lock()
+            .unwrap()
+            .get(agent_name)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// The task/prompt text captured for `agent_name`'s `call_index`'th
+    /// (0-based) successful call.
+    fn captured_task(&self, agent_name: &str, call_index: usize) -> Option<String> {
+        self.captured_tasks
+            .lock()
+            .unwrap()
+            .get(agent_name)
+            .and_then(|v| v.get(call_index))
+            .cloned()
+    }
 }
 
 #[async_trait]
 impl AgentRunner for FlakyOnceMock {
-    async fn run(&self, agent_name: &str, _task: &str) -> Result<AgentOutput> {
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
         let call_number = {
             let mut counts = self.call_counts.lock().unwrap();
             let entry = counts.entry(agent_name.to_string()).or_insert(0);
@@ -42,6 +95,20 @@ impl AgentRunner for FlakyOnceMock {
         };
         if agent_name == self.fail_once_agent && call_number == 1 {
             anyhow::bail!("simulated crash: {agent_name} failed on its first invocation");
+        }
+        self.captured_tasks
+            .lock()
+            .unwrap()
+            .entry(agent_name.to_string())
+            .or_default()
+            .push(task.to_string());
+
+        if let Some((content, summary)) = self.custom_outputs.lock().unwrap().get(agent_name) {
+            return Ok(AgentOutput {
+                content: content.clone(),
+                summary: summary.clone(),
+                usage: TokenUsage::default(),
+            });
         }
         Ok(AgentOutput {
             content: format!("{agent_name} output (call #{call_number})"),
@@ -105,6 +172,41 @@ fn write_three_phase_workflow(workflows_dir: &std::path::Path, name: &str) -> st
     path
 }
 
+/// A minimal hand-built `CheckpointRecord`, matching what `phase_loop.rs`
+/// would actually write for a partially-complete run — used by tests that
+/// need to inject a specific journal state without driving the engine
+/// through a real crash.
+#[allow(clippy::too_many_arguments)]
+fn hand_written_record(
+    run_id: &str,
+    workflow: &str,
+    state: RunState,
+    phase_names: &[&str],
+    out_dir: &std::path::Path,
+    phase_outputs: &[(&str, &str)],
+) -> CheckpointRecord {
+    CheckpointRecord {
+        schema_version: checkpoint::CHECKPOINT_SCHEMA_VERSION,
+        run_id: run_id.to_string(),
+        workflow: workflow.to_string(),
+        state,
+        phase_names: phase_names.iter().map(|s| s.to_string()).collect(),
+        out_dir: out_dir.to_path_buf(),
+        code_dir: out_dir.to_path_buf(),
+        task: "do the thing".to_string(),
+        phase_outputs: phase_outputs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect(),
+        phase_summaries: std::collections::BTreeMap::new(),
+        goal_block: None,
+        qa_retry_count: 0,
+        qa_failure_feedback: None,
+        started_at: "2026-07-19T00:00:00Z".to_string(),
+        updated_at: "2026-07-19T00:00:01Z".to_string(),
+    }
+}
+
 /// The primary conformance test (SPEC-AGENTFW-02 §3.6): a 3-phase workflow's
 /// middle phase (`phase-b`) fails on its first dispatch — simulating a crash
 /// after `phase-a` completed. The run returns `Err` and leaves a `Failed{1}`
@@ -126,12 +228,8 @@ async fn resume_skips_completed_phases_and_reuses_their_output() {
     write_three_phase_workflow(&workflows_dir, "checkpoint-resume-test");
     let out_dir = tmp.path().join("out");
 
-    let call_counts: Arc<Mutex<HashMap<String, u32>>> = Arc::new(Mutex::new(HashMap::new()));
-    let mock = Arc::new(FlakyOnceMock {
-        call_counts: call_counts.clone(),
-        fail_once_agent: "agent-b".to_string(),
-    });
-    let engine = WorkflowEngine::new(mock, workflows_dir.clone());
+    let mock = Arc::new(FlakyOnceMock::new("agent-b"));
+    let engine = WorkflowEngine::new(mock.clone(), workflows_dir.clone());
 
     // --- "crash" run: phase-a succeeds, phase-b fails, phase-c never runs.
     let first_result = engine
@@ -145,12 +243,9 @@ async fn resume_skips_completed_phases_and_reuses_their_output() {
         first_result.is_err(),
         "expected the simulated phase-b crash to propagate as Err"
     );
-    {
-        let counts = call_counts.lock().unwrap();
-        assert_eq!(counts.get("agent-a").copied(), Some(1));
-        assert_eq!(counts.get("agent-b").copied(), Some(1));
-        assert_eq!(counts.get("agent-c"), None, "phase-c must not run yet");
-    }
+    assert_eq!(mock.call_count("agent-a"), 1);
+    assert_eq!(mock.call_count("agent-b"), 1);
+    assert_eq!(mock.call_count("agent-c"), 0, "phase-c must not run yet");
 
     // Checkpoint must reflect phase-a complete, phase-b failed (index 1).
     let project_dir = crate::usage::project_dir();
@@ -176,20 +271,17 @@ async fn resume_skips_completed_phases_and_reuses_their_output() {
     };
     assert_eq!(resumed_at_phase, "phase-b");
 
-    {
-        let counts = call_counts.lock().unwrap();
-        assert_eq!(
-            counts.get("agent-a").copied(),
-            Some(1),
-            "phase-a must NOT be re-executed on resume"
-        );
-        assert_eq!(
-            counts.get("agent-b").copied(),
-            Some(2),
-            "phase-b's failed attempt + successful retry"
-        );
-        assert_eq!(counts.get("agent-c").copied(), Some(1));
-    }
+    assert_eq!(
+        mock.call_count("agent-a"),
+        1,
+        "phase-a must NOT be re-executed on resume"
+    );
+    assert_eq!(
+        mock.call_count("agent-b"),
+        2,
+        "phase-b's failed attempt + successful retry"
+    );
+    assert_eq!(mock.call_count("agent-c"), 1);
 
     assert!(ctx.phase_outputs.contains_key("phase-a"));
     assert!(ctx.phase_outputs.contains_key("phase-b"));
@@ -200,6 +292,129 @@ async fn resume_skips_completed_phases_and_reuses_their_output() {
         checkpoint::load_checkpoint(&project_dir, &run_id).is_err(),
         "checkpoint must be deleted after the resumed run completes"
     );
+}
+
+/// CRITICAL code-critic finding (PR #3244): a resumed downstream phase's
+/// rendered prompt must contain the persisted SUMMARY of an already-complete
+/// phase, never its full raw content. `phase-a` is configured to return a
+/// large body (a few KB, far bigger than a real summary) plus a short,
+/// distinctive summary; after the simulated crash + resume, we inspect the
+/// EXACT rendered task `phase-b` received on its (post-resume) successful
+/// call and assert it contains the summary marker but not the full-content
+/// marker.
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_replays_summary_not_full_content_into_downstream_prompts() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _project_guard = EnvVarGuard::set("TAGENT_PROJECT_DIR", &tmp.path().to_string_lossy());
+    let run_id = format!("test-run-{}", uuid::Uuid::new_v4());
+    let _run_id_guard = EnvVarGuard::set("TAGENT_RUN_ID", &run_id);
+
+    let workflows_dir = tmp.path().join("workflows");
+    write_three_phase_workflow(&workflows_dir, "summary-replay-test");
+    let out_dir = tmp.path().join("out");
+
+    // A large body (2KB+) that must NEVER reach phase-b's rendered prompt
+    // after resume — only the short summary should.
+    let full_content = format!("FULL_CONTENT_MARKER_{}", "x".repeat(2000));
+    let short_summary = "CONCISE_SUMMARY_MARKER";
+
+    let mock = Arc::new(FlakyOnceMock::new("agent-b").with_custom_output(
+        "agent-a",
+        &full_content,
+        Some(short_summary),
+    ));
+    let engine = WorkflowEngine::new(mock.clone(), workflows_dir.clone());
+
+    let first_result = engine
+        .run(
+            "summary-replay-test",
+            "do the thing".into(),
+            Some(out_dir.clone()),
+        )
+        .await;
+    assert!(first_result.is_err(), "expected simulated phase-b crash");
+
+    // Sanity: the checkpoint itself carries the SHORT summary separately
+    // from the full content for phase-a.
+    let project_dir = crate::usage::project_dir();
+    let record = checkpoint::load_checkpoint(&project_dir, &run_id).unwrap();
+    assert_eq!(
+        record.phase_summaries.get("phase-a").map(String::as_str),
+        Some(short_summary),
+    );
+    assert_eq!(
+        record.phase_outputs.get("phase-a").map(String::as_str),
+        Some(full_content.as_str()),
+    );
+
+    engine
+        .resume_with_perf_and_dirs(&run_id)
+        .await
+        .expect("resume should succeed");
+
+    // The ACTUAL rendered task phase-b received after resume (its one and
+    // only successful call) must contain the summary and must NOT contain
+    // the full raw content.
+    let phase_b_task = mock
+        .captured_task("agent-b", 0)
+        .expect("agent-b must have been dispatched exactly once after resume");
+    assert!(
+        phase_b_task.contains(short_summary),
+        "resumed phase-b prompt must contain phase-a's SUMMARY: {phase_b_task}"
+    );
+    assert!(
+        !phase_b_task.contains(&full_content),
+        "resumed phase-b prompt must NOT contain phase-a's full raw content"
+    );
+}
+
+/// HIGH code-critic finding (PR #3244): a second `tagent resume` for the
+/// SAME run id while the first is still in flight must fail closed with
+/// `ResumeAlreadyInProgress`, not race it. We simulate "already in flight"
+/// by acquiring the resume lock directly (as the first resume would) and
+/// keeping the guard alive while attempting a second `resume_with_perf_and_dirs`
+/// call for the same run id.
+#[tokio::test]
+#[serial_test::serial]
+async fn resume_fails_closed_when_already_in_progress() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _project_guard = EnvVarGuard::set("TAGENT_PROJECT_DIR", &tmp.path().to_string_lossy());
+    let run_id = format!("test-run-{}", uuid::Uuid::new_v4());
+
+    let workflows_dir = tmp.path().join("workflows");
+    write_three_phase_workflow(&workflows_dir, "concurrent-resume-test");
+    let out_dir = tmp.path().join("out");
+    std::fs::create_dir_all(&out_dir).unwrap();
+
+    let record = hand_written_record(
+        &run_id,
+        "concurrent-resume-test",
+        RunState::PhaseComplete { phase_index: 0 },
+        &["phase-a", "phase-b", "phase-c"],
+        &out_dir,
+        &[("phase-a", "a output")],
+    );
+    let project_dir = crate::usage::project_dir();
+    record.write(&project_dir).unwrap();
+
+    // Hold the lock as if a first `tagent resume` were already in flight.
+    let _held = checkpoint::acquire_resume_lock(&project_dir, &run_id)
+        .expect("simulated in-flight resume must acquire the lock");
+
+    let mock = Arc::new(FlakyOnceMock::new(""));
+    let engine = WorkflowEngine::new(mock.clone(), workflows_dir.clone());
+
+    let err = engine
+        .resume_with_perf_and_dirs(&run_id)
+        .await
+        .expect_err("a second concurrent resume must fail closed");
+    assert!(
+        matches!(err, WorkflowError::ResumeAlreadyInProgress { .. }),
+        "expected ResumeAlreadyInProgress, got {err:?}"
+    );
+    // Nothing was dispatched — the lock check happens before any phase runs.
+    assert_eq!(mock.call_count("agent-a"), 0);
 }
 
 /// §3.5 failure matrix: if the workflow JSON's phase list changed since the
@@ -219,28 +434,14 @@ async fn resume_fails_closed_on_definition_change() {
     std::fs::create_dir_all(&out_dir).unwrap();
 
     // Hand-write a checkpoint claiming phase-a is complete.
-    let mut phase_outputs = std::collections::BTreeMap::new();
-    phase_outputs.insert("phase-a".to_string(), "a output".to_string());
-    let record = CheckpointRecord {
-        schema_version: checkpoint::CHECKPOINT_SCHEMA_VERSION,
-        run_id: run_id.clone(),
-        workflow: "definition-changed-test".to_string(),
-        state: RunState::PhaseComplete { phase_index: 0 },
-        phase_names: vec![
-            "phase-a".to_string(),
-            "phase-b".to_string(),
-            "phase-c".to_string(),
-        ],
-        out_dir: out_dir.clone(),
-        code_dir: out_dir.clone(),
-        task: "do the thing".to_string(),
-        phase_outputs,
-        goal_block: None,
-        qa_retry_count: 0,
-        qa_failure_feedback: None,
-        started_at: "2026-07-19T00:00:00Z".to_string(),
-        updated_at: "2026-07-19T00:00:01Z".to_string(),
-    };
+    let record = hand_written_record(
+        &run_id,
+        "definition-changed-test",
+        RunState::PhaseComplete { phase_index: 0 },
+        &["phase-a", "phase-b", "phase-c"],
+        &out_dir,
+        &[("phase-a", "a output")],
+    );
     record.write(tmp.path()).unwrap();
 
     // Now mutate the on-disk workflow JSON to remove a phase — the
@@ -257,11 +458,7 @@ async fn resume_fails_closed_on_definition_change() {
     )
     .unwrap();
 
-    let call_counts: Arc<Mutex<HashMap<String, u32>>> = Arc::new(Mutex::new(HashMap::new()));
-    let mock = Arc::new(FlakyOnceMock {
-        call_counts,
-        fail_once_agent: String::new(),
-    });
+    let mock = Arc::new(FlakyOnceMock::new(""));
     let engine = WorkflowEngine::new(mock, workflows_dir.clone());
 
     let err = engine
@@ -276,7 +473,10 @@ async fn resume_fails_closed_on_definition_change() {
 
 /// §3.4 requirement: "If the run finished, say so." A checkpoint whose state
 /// is (unexpectedly) `Done` must report `AlreadyDone` instead of attempting
-/// to re-run anything.
+/// to re-run anything — and, per the HIGH code-critic finding on PR #3244,
+/// this is also the "no duplicate hooks fire" proof: `resume_with_perf_and_dirs`
+/// returns as soon as it observes `Done`, before touching the ticket
+/// manager, perf collector, or dispatching a single phase.
 #[tokio::test]
 #[serial_test::serial]
 async fn resume_reports_already_done_for_done_checkpoint() {
@@ -289,40 +489,28 @@ async fn resume_reports_already_done_for_done_checkpoint() {
     let out_dir = tmp.path().join("out");
     std::fs::create_dir_all(&out_dir).unwrap();
 
-    let record = CheckpointRecord {
-        schema_version: checkpoint::CHECKPOINT_SCHEMA_VERSION,
-        run_id: run_id.clone(),
-        workflow: "already-done-test".to_string(),
-        state: RunState::Done,
-        phase_names: vec![
-            "phase-a".to_string(),
-            "phase-b".to_string(),
-            "phase-c".to_string(),
-        ],
-        out_dir: out_dir.clone(),
-        code_dir: out_dir.clone(),
-        task: "do the thing".to_string(),
-        phase_outputs: std::collections::BTreeMap::new(),
-        goal_block: None,
-        qa_retry_count: 0,
-        qa_failure_feedback: None,
-        started_at: "2026-07-19T00:00:00Z".to_string(),
-        updated_at: "2026-07-19T00:00:01Z".to_string(),
-    };
+    let record = hand_written_record(
+        &run_id,
+        "already-done-test",
+        RunState::Done,
+        &["phase-a", "phase-b", "phase-c"],
+        &out_dir,
+        &[],
+    );
     record.write(tmp.path()).unwrap();
 
-    let call_counts: Arc<Mutex<HashMap<String, u32>>> = Arc::new(Mutex::new(HashMap::new()));
-    let mock = Arc::new(FlakyOnceMock {
-        call_counts,
-        fail_once_agent: String::new(),
-    });
-    let engine = WorkflowEngine::new(mock, workflows_dir.clone());
+    let mock = Arc::new(FlakyOnceMock::new(""));
+    let engine = WorkflowEngine::new(mock.clone(), workflows_dir.clone());
 
     let outcome = engine
         .resume_with_perf_and_dirs(&run_id)
         .await
         .expect("resume of a Done checkpoint must not error");
     assert!(matches!(outcome, ResumeOutcome::AlreadyDone { .. }));
+    // No phase was dispatched — proves no hooks/side effects fired.
+    assert_eq!(mock.call_count("agent-a"), 0);
+    assert_eq!(mock.call_count("agent-b"), 0);
+    assert_eq!(mock.call_count("agent-c"), 0);
 }
 
 /// §3.5 failure matrix: resuming a run id with no checkpoint on disk fails
@@ -336,11 +524,7 @@ async fn resume_missing_checkpoint_returns_clear_error() {
     let workflows_dir = tmp.path().join("workflows");
     write_three_phase_workflow(&workflows_dir, "missing-checkpoint-test");
 
-    let call_counts: Arc<Mutex<HashMap<String, u32>>> = Arc::new(Mutex::new(HashMap::new()));
-    let mock = Arc::new(FlakyOnceMock {
-        call_counts,
-        fail_once_agent: String::new(),
-    });
+    let mock = Arc::new(FlakyOnceMock::new(""));
     let engine = WorkflowEngine::new(mock, workflows_dir.clone());
 
     let err = engine

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/mod.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/mod.rs
@@ -26,6 +26,7 @@ pub use crate::workflow::config::Assignments;
 pub(crate) use crate::workflow::engine::helpers::reconcile_code_outputs_against;
 pub(crate) use crate::workflow::engine::step_dispatch::discover_project_dir;
 
+mod checkpoint_resume;
 mod phase_order;
 mod relocate;
 mod retry;

--- a/crates/trusty-agents/src/workflow/engine/mod.rs
+++ b/crates/trusty-agents/src/workflow/engine/mod.rs
@@ -8,6 +8,7 @@
 //! Test: Behavior is covered by each sub-module's own `#[cfg(test)]` block and
 //! the integration tests in `executor`.
 
+pub mod checkpoint;
 mod executor;
 mod helpers;
 mod qa;
@@ -16,4 +17,4 @@ mod skills;
 mod state;
 mod step_dispatch;
 
-pub use executor::{DiscoveredSkill, WorkflowEngine};
+pub use executor::{DiscoveredSkill, ResumeOutcome, WorkflowEngine};

--- a/crates/trusty-agents/src/workflow/error.rs
+++ b/crates/trusty-agents/src/workflow/error.rs
@@ -44,4 +44,52 @@ pub enum WorkflowError {
         agent: String,
         consecutive_turns: u32,
     },
+
+    /// #3062 (SPEC-AGENTFW-02 §3.5): `tagent resume <run-id>` was asked for a
+    /// run id with no `checkpoint.json` on disk.
+    #[error(
+        "no checkpoint found for run '{run_id}'; resumable runs: {}",
+        if available.is_empty() { "(none)".to_string() } else { available.join(", ") }
+    )]
+    CheckpointNotFound {
+        run_id: String,
+        available: Vec<String>,
+    },
+
+    /// #3062 (SPEC-AGENTFW-02 §3.5): the checkpoint file exists but is not
+    /// parseable JSON (or does not match `CheckpointRecord`'s shape). Fails
+    /// closed rather than silently starting a fresh run under the same id.
+    #[error("checkpoint at {path} is corrupt: {source}")]
+    CheckpointCorrupt {
+        path: String,
+        #[source]
+        source: anyhow::Error,
+    },
+
+    /// #3062: the checkpoint parses but was written by an incompatible
+    /// journal schema version. See `checkpoint::CHECKPOINT_SCHEMA_VERSION`.
+    #[error(
+        "checkpoint at {path} has schema_version {found}, expected {expected}; \
+         it was written by an incompatible version of trusty-agents"
+    )]
+    CheckpointSchemaMismatch {
+        path: String,
+        found: u32,
+        expected: u32,
+    },
+
+    /// #3062 (SPEC-AGENTFW-02 §3.4): the on-disk workflow JSON's phase list no
+    /// longer matches the checkpoint's `phase_names` snapshot. Resume MUST
+    /// fail closed rather than run a different pipeline than the one that was
+    /// checkpointed.
+    #[error(
+        "workflow '{workflow}' definition changed since checkpoint '{run_id}' was written: \
+         phase list no longer matches (checkpoint: {checkpoint_phases:?}, current: {current_phases:?})"
+    )]
+    ResumeDefinitionChanged {
+        run_id: String,
+        workflow: String,
+        checkpoint_phases: Vec<String>,
+        current_phases: Vec<String>,
+    },
 }

--- a/crates/trusty-agents/src/workflow/error.rs
+++ b/crates/trusty-agents/src/workflow/error.rs
@@ -92,4 +92,16 @@ pub enum WorkflowError {
         checkpoint_phases: Vec<String>,
         current_phases: Vec<String>,
     },
+
+    /// #3062 (code-critic finding, PR #3244): a second `tagent resume` for
+    /// the same `run_id` tried to start while an earlier resume already
+    /// holds the exclusive `resume.lock` for that run's checkpoint
+    /// directory. Fails closed immediately (non-blocking `try_lock`) rather
+    /// than queuing — two concurrent resumes of the same run would race on
+    /// dispatching phases and corrupt the checkpoint's phase ordering.
+    #[error(
+        "run '{run_id}' is already being resumed by another process (lock held at {lock_path}); \
+         wait for it to finish or investigate a stale lock if no resume is actually running"
+    )]
+    ResumeAlreadyInProgress { run_id: String, lock_path: String },
 }

--- a/crates/trusty-agents/src/workflow/mod.rs
+++ b/crates/trusty-agents/src/workflow/mod.rs
@@ -24,7 +24,7 @@ pub use config::{
 };
 #[allow(unused_imports)]
 pub use context::{WorkflowContext, WorkflowContextBuilder};
-pub use engine::WorkflowEngine;
+pub use engine::{ResumeOutcome, WorkflowEngine};
 #[allow(unused_imports)]
 pub use error::WorkflowError;
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary

Implements #3062 (MVP-critical, owner decision 2026-07-19): phase-checkpoint durability for the `trusty-agents` workflow engine, per Eve §3 / SPEC-AGENTFW-02 (`docs/specs/trusty-agents-eve-style-agents-spec.md`).

Before this change the workflow engine held **zero on-disk state** during an in-flight run — `perf.flush` only wrote once, at the very end. A crash lost the whole run and every already-completed phase's LLM calls had to be re-billed on retry. This PR adds a phase-level `RunState`/`CheckpointRecord` journal written at every phase boundary, plus `tagent resume <run-id>` to continue a checkpointed run from the first incomplete phase.

## Journal schema + location

- `crates/trusty-agents/src/workflow/engine/checkpoint.rs` (NEW): `RunState` (`Pending` / `PhaseRunning{i}` / `PhaseComplete{i}` / `Retrying{i,attempt}` / `Failed{i}` / `Done`) and `CheckpointRecord` (run id, workflow name, state, phase name snapshot, out_dir/code_dir, original task text, `phase_outputs`, goal block, QA retry state, timestamps) — reproduced verbatim from spec §3.2/§3.3.
- Location: `.trusty-agents/state/runs/<run_id>/checkpoint.json` (project-relative, matching the existing `.trusty-agents/state/` runtime-state root used by `build.json`/`mistakes/*.jsonl`/etc.).
- **Every write goes through `crate::state_writer::atomic_write` verbatim** (lock + tmp + rename), per the issue — no new I/O primitive introduced.
- On full success (`RunState::Done`), `finalize_run` removes `.trusty-agents/state/runs/<run_id>/` entirely (best-effort, non-fatal). A `Failed` checkpoint is intentionally left on disk as the resumable artifact.

## Resume semantics

`tagent resume [--list] [--json] <run-id>`:

- `--list` (or no run-id) prints resumable run ids under `.trusty-agents/state/runs/`.
- Loads the checkpoint (fails closed on missing/corrupt/schema-mismatched journal — `WorkflowError::CheckpointNotFound` / `CheckpointCorrupt` / `CheckpointSchemaMismatch`).
- Reloads the workflow JSON **fresh** (never trusts the checkpoint's `phase_names` snapshot directly) and validates it still matches — fails closed with `WorkflowError::ResumeDefinitionChanged` on drift.
- Resumes immediately **after** the last `PhaseComplete` phase, or **at** the phase index for `Failed`/`Retrying`/`PhaseRunning` (re-runs that phase from scratch — no sub-phase resume).
- Every already-`PhaseComplete` phase's output is reused verbatim from the journal — **never re-dispatched**.
- If the checkpoint's state is (unexpectedly — see below) `Done`, reports `ResumeOutcome::AlreadyDone` instead of re-running anything.
- Fires a new `Event::RunResumed { session_id, resumed_at_phase }` once at resume start.

The phase-loop body (dispatch, QA gating, file extraction) moved out of `run.rs` into a new shared `phase_loop::run_phase_loop`, used by **both** a fresh run (`start_index: 0`) and resume (`start_index` past the last completed phase) — so resume can never silently diverge from fresh-run dispatch behavior.

## What Eve §3 prescribed vs what I chose where it was silent

- **Schema versioning** (spec's `CheckpointRecord` example has no version field, but issue #3062 explicitly requires "version the journal format"): added `schema_version: u32` (additive), checked on load — a mismatch fails closed with `CheckpointSchemaMismatch` rather than silently misinterpreting an old journal.
- **`PhaseComplete{i}` write timing**: spec says "immediately after `ctx.record_phase`". I write it **after** `extract_phase_files` completes instead. Rationale: files are extracted to disk only *after* `record_phase`; writing the checkpoint before extraction would let a crash between the two leave a `PhaseComplete{i}` journal entry whose generated files were never written — a resume would then skip re-dispatching phase `i` (checkpoint says done) while `code_dir`/`out_dir` is silently missing its output. Moving the checkpoint boundary to the true end of the iteration closes that gap.
- **Journal cleanup**: spec's own §3.3 already specifies delete-on-`Done`; I implemented exactly that (no alternative considered — pruning-by-policy would need a background sweep for zero added benefit at MVP scope, since a `Failed` checkpoint is small and operator-visible via `tagent resume --list`).
- **Resumed-run bookkeeping deviations** (documented in code comments in `resume.rs`): the ticket-manager `on_workflow_start` hook does not re-fire on resume (the tracking issue already exists); `workflow_started` restarts the wall clock for the resumed portion only; per-phase cost/file counters start at zero for the resumed portion (the pre-crash portion's perf was never flushed anyway, since `perf.flush` only runs once at the very end — unaffected by this change).
- **Resumed phase-output summaries**: the journal's `phase_outputs` stores full content only (matching the spec's literal `BTreeMap<String,String>`), not the original run's extracted summary — on resume, `record_phase(name, content, None)` defaults the summary to the content. Documented simplification.

## Test evidence

`cargo test -p trusty-agents --lib`:
```
test result: ok. 1825 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out; finished in 10.14s
```

New tests (15 total):
- `workflow::engine::checkpoint::checkpoint_tests` (11 unit tests): serde round-trip for `RunState`/`CheckpointRecord`, `write`/`load_checkpoint` round-trip through the real `atomic_write`, missing/corrupt/schema-mismatch fail-closed paths, `list_resumable_runs`/`delete_run_dir`.
- `workflow::engine::executor::tests::checkpoint_resume` (4 integration tests) — drives the real `WorkflowEngine` phase loop through a simulated crash (a mock agent that fails its first call, standing in for "process killed mid-phase" without literally SIGKILLing the test process):
  - `resume_skips_completed_phases_and_reuses_their_output` — the primary conformance test: 3-phase workflow, phase-b fails first attempt (phase-a already complete), run returns `Err` with a `Failed{1}` checkpoint on disk; resume completes the run and asserts phase-a's agent was called **exactly once** (never re-dispatched), phase-b's agent twice (failed attempt + successful retry), phase-c once, and the checkpoint directory is deleted after the resumed run reaches `Done`.
  - `resume_fails_closed_on_definition_change`, `resume_reports_already_done_for_done_checkpoint`, `resume_missing_checkpoint_returns_clear_error`.

```
cargo clippy -p trusty-agents --all-targets -- -D warnings   # clean
cargo fmt --check                                             # clean
bash scripts/check_line_cap.sh                                # line-cap: 10 allowlisted, 0 violations — OK.
```

Also verified downstream consumer `cargo check -p trusty-agents-local --all-targets` (pulls in `cto-assistant`) compiles clean.

## Files changed

- NEW: `crates/trusty-agents/src/workflow/engine/checkpoint.rs` + `checkpoint/checkpoint_tests.rs`
- NEW: `crates/trusty-agents/src/workflow/engine/executor/phase_loop.rs` (shared phase-loop driver, moved out of `run.rs`)
- NEW: `crates/trusty-agents/src/workflow/engine/executor/resume.rs` (`WorkflowEngine::resume_with_perf_and_dirs`, `ResumeOutcome`)
- NEW: `crates/trusty-agents/src/workflow/engine/executor/tests/checkpoint_resume.rs`
- NEW: `crates/trusty-agents/src/runtime/workflow_mode/resume.rs` (`tagent resume` CLI)
- MODIFIED: `crates/trusty-agents/src/workflow/engine/executor/run.rs` (now a thin fresh-run wrapper around `phase_loop`), `finalize.rs` (checkpoint deletion on `Done`), `mod.rs` (module wiring)
- MODIFIED: `crates/trusty-agents/src/workflow/error.rs` (new `WorkflowError` variants), `mod.rs`, `engine/mod.rs` (re-export `ResumeOutcome`)
- MODIFIED: `crates/trusty-agents/src/events.rs` (`Event::RunResumed`), `repl/event_display.rs` (REPL rendering)
- MODIFIED: `crates/trusty-agents/src/runtime/subcommands.rs`, `runtime/workflow_mode/mod.rs` (CLI dispatch wiring)

## Test plan

- [x] `cargo check -p trusty-agents --all-targets`
- [x] `cargo test -p trusty-agents --lib` (1825 passed)
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check_line_cap.sh`
- [x] `cargo check -p trusty-agents-local --all-targets` (downstream consumer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)