### PR TITLE
feat(trusty-agents-ui): structured workflow store + phase card + session-recap rail + phase stamps

### DIFF
--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import Sidebar from './components/Sidebar.svelte';
   import ChatView from './components/ChatView.svelte';
   import InputArea from './components/InputArea.svelte';
@@ -13,7 +14,7 @@
   // Why (#3217): parallel structured-data sink — see stores/workflow.ts doc
   // comment for the full rationale. Additive to the flattened webBus path
   // below, never a replacement.
-  import { handleWorkflowEvent, applyTaskResult } from './stores/workflow';
+  import { handleWorkflowEvent, applyTaskResult, resetWorkflow, workflowState } from './stores/workflow';
   // Why: Importing the theme store has the side-effect of running applyTheme()
   // for the persisted theme, ensuring the `dark` class on <html> tracks the
   // user's preference for the lifetime of the app (the inline <head> script
@@ -204,6 +205,39 @@
    * "Recent tasks" updates without a page refresh and ChatView shows live
    * progress text.
    */
+  /**
+   * Why (#3257 code-critic HIGH): `workflowState.resetWorkflow()` previously
+   * only fired on the SSE `session_started` event — but Tauri desktop mode
+   * never opens the SSE stream (`startEventStream()` below no-ops when
+   * `isDesktop()`; "Tauri has its own listen() bridge already"), so
+   * `handleWorkflowEvent` never runs there. Without this, a new desktop task
+   * would keep showing the PREVIOUS task's phase checklist / agents / files
+   * until the new task's own `task-complete` finally overwrote them —
+   * actively misleading mid-run. `task-progress` is emitted in BOTH modes
+   * (browser fallback's own polling loop and the Tauri `send_message`
+   * command) and its very first firing for a task always carries that
+   * task's id, so it's the earliest per-task signal available without
+   * touching `InputArea.svelte` or `src-tauri/**`.
+   * What: Resets + adopts a new task id the moment it's first seen. No-op
+   * when the id matches what's already tracked (the common case — most
+   * `task-progress` ticks repeat the same id) so this never clobbers
+   * in-flight browser/SSE phase data for the task already running; in
+   * browser mode `session_started` still performs its own reset as before
+   * (this only changes behavior for desktop, where it was previously a
+   * no-op because nothing ever called `resetWorkflow()`).
+   * Test: Manual — start a desktop task, let it reach IMPLEMENT, submit a
+   * second task before the first's `task-complete` arrives, confirm the
+   * phase card clears instead of showing the first task's stale phases.
+   */
+  function maybeAdoptNewTask(taskId: string | null | undefined) {
+    if (!taskId) return;
+    const current = get(workflowState);
+    if (current.taskId !== taskId) {
+      resetWorkflow();
+      workflowState.update((s) => ({ ...s, taskId, status: 'running' }));
+    }
+  }
+
   function bridgeEventToWebBus(ev: AppEvent) {
     // #3217: feed the structured workflow store first — additive, never
     // short-circuits the flattened-text switch below.
@@ -377,9 +411,18 @@
     listenEvent('task-complete', applyTaskResult).then((fn) => {
       unlistenWorkflowComplete = fn;
     });
+    // #3257 code-critic HIGH: the earliest per-task signal available in
+    // both transport modes — see `maybeAdoptNewTask` doc comment above.
+    let unlistenWorkflowProgress: (() => void) | null = null;
+    listenEvent<{ task_id?: string }>('task-progress', (p) => {
+      maybeAdoptNewTask(p?.task_id);
+    }).then((fn) => {
+      unlistenWorkflowProgress = fn;
+    });
     return () => {
       window.removeEventListener('beforeunload', onUnload);
       unlistenWorkflowComplete?.();
+      unlistenWorkflowProgress?.();
       stopEventStream();
     };
   });

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -7,9 +7,13 @@
   import RecapPanel from './components/RecapPanel.svelte';
   import Header from './components/Header.svelte';
   import PersonalityPanel from './components/PersonalityPanel.svelte';
-  import { invoke, isDesktop, connectEventSource, emitWebEvent, type AppEvent } from './lib/transport';
+  import { invoke, isDesktop, connectEventSource, listenEvent, emitWebEvent, type AppEvent } from './lib/transport';
   import { apiAuthRequired, getCurrentApiToken, setApiToken, addMessage } from './stores/app';
   import { setRecap, type Recap } from './stores/recap';
+  // Why (#3217): parallel structured-data sink — see stores/workflow.ts doc
+  // comment for the full rationale. Additive to the flattened webBus path
+  // below, never a replacement.
+  import { handleWorkflowEvent, applyTaskResult } from './stores/workflow';
   // Why: Importing the theme store has the side-effect of running applyTheme()
   // for the persisted theme, ensuring the `dark` class on <html> tracks the
   // user's preference for the lifetime of the app (the inline <head> script
@@ -201,6 +205,9 @@
    * progress text.
    */
   function bridgeEventToWebBus(ev: AppEvent) {
+    // #3217: feed the structured workflow store first — additive, never
+    // short-circuits the flattened-text switch below.
+    handleWorkflowEvent(ev);
     switch (ev.type) {
       case 'session_started':
         emitWebEvent('task-progress', {
@@ -360,8 +367,19 @@
     bootstrap();
     const onUnload = () => stopEventStream();
     window.addEventListener('beforeunload', onUnload);
+    // #3217: `task-complete`'s payload is the full `PmResponse` in Tauri
+    // desktop mode (phases_completed/files_modified/metadata included) and
+    // a narrower {id,status,narrative} shape from the browser fallback;
+    // `applyTaskResult` merges whichever fields are present. This is the
+    // only source of per-phase elapsed/cost/note and the files/tokens
+    // sections in either transport mode.
+    let unlistenWorkflowComplete: (() => void) | null = null;
+    listenEvent('task-complete', applyTaskResult).then((fn) => {
+      unlistenWorkflowComplete = fn;
+    });
     return () => {
       window.removeEventListener('beforeunload', onUnload);
+      unlistenWorkflowComplete?.();
       stopEventStream();
     };
   });
@@ -464,9 +482,17 @@
         </button>
       </nav>
       {#if activeView === 'chat'}
-        <ChatView />
-        <RecapPanel />
-        <InputArea />
+        <!-- #3219: RecapPanel is now a persistent right rail (own scroll,
+             AGENTS ACTIVE / FILES TOUCHED / TOKENS + folded recap summary),
+             so it sits beside the chat+input column rather than stacked
+             between them. -->
+        <div class="flex flex-1 min-h-0">
+          <div class="flex flex-1 flex-col min-w-0">
+            <ChatView />
+            <InputArea />
+          </div>
+          <RecapPanel />
+        </div>
       {:else if activeView === 'projects'}
         <ProjectsView on:navigate={(e) => switchView(e.detail.view)} />
       {:else}

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -9,6 +9,8 @@
   } from '../stores/app';
   import { listenEvent, type UnlistenFn } from '../lib/transport';
   import ActionIcon from '../lib/icons/ActionIcon.svelte';
+  import WorkflowPhaseCard from './WorkflowPhaseCard.svelte';
+  import { workflowState } from '../stores/workflow';
 
   let scrollEl: HTMLDivElement | undefined;
   let unlistenProgress: UnlistenFn | null = null;
@@ -168,6 +170,16 @@
         </div>
       {/if}
     {/each}
+
+    {#if $workflowState.phases.length > 0}
+      <!-- #3218: inline RESEARCH/PLAN/IMPLEMENT/VERIFY checklist for the
+           active task, fed live by the structured workflow store. -->
+      <div class="flex justify-start ml-4">
+        <div class="max-w-[85%] w-full">
+          <WorkflowPhaseCard />
+        </div>
+      </div>
+    {/if}
 
     {#if $isRunning}
       <div class="flex items-center justify-start gap-2 text-xs text-foundry-teal">

--- a/crates/trusty-agents/ui/src/components/RecapPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/RecapPanel.svelte
@@ -1,89 +1,161 @@
 <script lang="ts">
   /**
-   * Why: #371 — When the backend emits a `recap_generated` SSE event, the
-   * latest recap for the active session should surface as a slim, collapsible
-   * banner between the chat scrollback and the input area. This keeps the
-   * step-by-step results visible without forcing the user to scroll up.
-   * What: Subscribes to the recap store and renders a teal-tinted panel for
-   * the active session's most recent recap, with a clickable header that
-   * collapses/expands the result table.
-   * Test: Dispatch a `recap_generated` SSE event for the active project, see
-   * the panel appear with the summary; click the header to collapse the
-   * table; switch projects and verify the panel hides when no recap exists.
+   * Why: #3219 — the mockup's SESSION RECAP rail (docs/design/gui/Foundry
+   * Ecosystem.dc.html:220-238) is a persistent 300px right `<aside>` with
+   * three always-visible sections (AGENTS ACTIVE, FILES TOUCHED, TOKENS),
+   * not a horizontal band that only appears after a `recap_generated`
+   * event. The old horizontal-band behavior (#371) is preserved as a
+   * fourth, conditional section fed by the same `recaps` store, so the
+   * prose summary + step/result table users already rely on don't
+   * disappear — they just move into the rail.
+   * What: A right-hand `<aside>` (own vertical scroll) reading the new
+   * `workflowState` store (#3217) for agents/files/tokens, and the
+   * existing `recaps` store for the summary/table fold. Collapses below
+   * the `xl` breakpoint (see the responsive note in the issue) since at
+   * narrower widths there isn't room for sidebar + chat + a 300px rail.
+   * Test: Dispatch SSE `agent_spawned`/`agent_message`/`phase_*` events and
+   * a `recap_generated` event for the active project; observe AGENTS
+   * ACTIVE/FILES TOUCHED/TOKENS populate live and the recap fold appear
+   * with its summary; click the recap header to collapse/expand the table.
    */
   import { recaps } from '../stores/recap';
   import { activeProjectId } from '../stores/app';
+  import { workflowState, type AgentActivityStatus } from '../stores/workflow';
 
   let collapsed = false;
 
   $: currentRecap = $recaps.get($activeProjectId) ?? null;
+  $: agents = $workflowState.agents;
+  $: filesTouched = $workflowState.filesTouched;
+  $: tokens = $workflowState.tokens;
 
   function toggleCollapse() {
     collapsed = !collapsed;
   }
+
+  function dotClass(status: AgentActivityStatus): string {
+    if (status === 'working') return 'bg-foundry-light-primary dark:bg-foundry-primary';
+    if (status === 'failed') return 'bg-red-500 dark:bg-red-400';
+    return 'bg-foundry-light-muted dark:bg-foundry-text/40';
+  }
+
+  function fmtTokenCount(n: number): string {
+    return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`;
+  }
+
+  function fmtCost(c: number): string {
+    return c < 0.01 ? `$${c.toFixed(4)}` : `$${c.toFixed(2)}`;
+  }
 </script>
 
-{#if currentRecap}
-  <div class="border-t border-foundry-teal/20 bg-foundry-teal/5 dark:bg-foundry-teal/10 text-xs font-mono">
-    <button
-      type="button"
-      class="w-full flex items-center gap-2 px-3 py-1.5 text-foundry-teal hover:bg-foundry-teal/10 transition-colors"
-      on:click={toggleCollapse}
-      aria-expanded={!collapsed}
-    >
-      <span class="text-foundry-teal" aria-hidden="true">※</span>
-      <span class="font-semibold">recap</span>
-      <span
-        class="text-foundry-light-text/60 dark:text-foundry-text/60 truncate flex-1 text-left"
-      >
-        · {currentRecap.summary}
-      </span>
-      <span class="text-foundry-light-muted dark:text-foundry-text/40" aria-hidden="true">
-        {collapsed ? '▲' : '▼'}
-      </span>
-    </button>
+<aside
+  class="hidden xl:flex w-[300px] flex-shrink-0 flex-col border-l border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface overflow-y-auto"
+>
+  <div
+    class="px-4 py-3 border-b border-foundry-light-border dark:border-foundry-border font-mono text-[10px] font-semibold uppercase tracking-widest text-foundry-light-muted dark:text-foundry-text/60"
+  >
+    Session Recap
+  </div>
 
-    {#if !collapsed && currentRecap.table_rows.length > 0}
-      <div class="px-3 pb-2">
-        <table class="w-full border-collapse">
-          <thead>
-            <tr class="text-foundry-teal/70 border-b border-foundry-teal/20">
-              <th class="text-left py-1 pr-4 w-32 font-normal">Step</th>
-              <th class="text-left py-1 font-normal">Result</th>
-            </tr>
-          </thead>
-          <tbody>
-            {#each currentRecap.table_rows as [step, result], i (i)}
-              <tr
-                class="border-b border-foundry-teal/10 last:border-0"
-                class:bg-white={false}
-                class:bg-foundry-teal={i % 2 === 0}
-              >
-                <td class="py-0.5 pr-4 text-foundry-teal/80 whitespace-nowrap align-top">
-                  {step}
-                </td>
-                <td class="py-0.5 text-foundry-light-text/80 dark:text-foundry-text/70 break-words">
-                  {result}
-                </td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
-      </div>
+  <div class="flex flex-col gap-5 px-4 py-4 text-xs font-mono">
+    <!-- AGENTS ACTIVE -->
+    <section>
+      <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-foundry-light-primary dark:text-[#e9b98a]">
+        Agents Active
+      </h3>
+      {#if agents.length === 0}
+        <p class="text-foundry-light-muted dark:text-foundry-text/40">No agents active.</p>
+      {:else}
+        <ul class="flex flex-col gap-2">
+          {#each agents as a (a.agent)}
+            <li class="flex items-center gap-2 min-w-0">
+              <span class="h-1.5 w-1.5 flex-shrink-0 rounded-full {dotClass(a.status)}" aria-hidden="true"></span>
+              <span class="font-medium text-foundry-light-text dark:text-foundry-text">{a.agent}</span>
+              <span class="truncate text-foundry-light-muted dark:text-foundry-text/50">{a.lastActivity ?? a.status}</span>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <!-- FILES TOUCHED -->
+    <section>
+      <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-foundry-light-primary dark:text-[#e9b98a]">
+        Files Touched
+      </h3>
+      {#if filesTouched.length === 0}
+        <p class="text-foundry-light-muted dark:text-foundry-text/40">No files touched yet.</p>
+      {:else}
+        <ul class="flex flex-col gap-1 text-foundry-light-text/80 dark:text-foundry-text/80">
+          {#each filesTouched as f (f)}
+            <li class="truncate" title={f}>{f}</li>
+          {/each}
+        </ul>
+      {/if}
+    </section>
+
+    <!-- TOKENS -->
+    <section>
+      <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-foundry-light-primary dark:text-[#e9b98a]">
+        Tokens
+      </h3>
+      {#if tokens}
+        <div class="flex items-center justify-between text-foundry-light-text dark:text-foundry-text">
+          <span>{fmtTokenCount(tokens.tokensIn)} in / {fmtTokenCount(tokens.tokensOut)} out</span>
+          <span class="text-foundry-light-muted dark:text-foundry-text/60">{fmtCost(tokens.costUsd)}</span>
+        </div>
+        {#if tokens.model}
+          <div class="mt-1 truncate text-foundry-light-muted dark:text-foundry-text/50">{tokens.model}</div>
+        {/if}
+        <!-- Why (#3219 scope note): the mockup shows a "42.1k / 200k · 21%"
+             progress bar, but no context-window max is available from the
+             server today and per-model constants aren't reliably knowable
+             client-side — inventing one would show a fabricated limit.
+             Deliberately showing absolute numbers + cost only; see PR body. -->
+      {:else}
+        <p class="text-foundry-light-muted dark:text-foundry-text/40">No token data yet.</p>
+      {/if}
+    </section>
+
+    <!-- Folded recap summary/table (#371) -->
+    {#if currentRecap}
+      <section class="border-t border-foundry-light-border dark:border-foundry-border pt-4">
+        <button
+          type="button"
+          class="w-full flex items-center gap-2 text-left text-foundry-teal"
+          on:click={toggleCollapse}
+          aria-expanded={!collapsed}
+        >
+          <span aria-hidden="true">※</span>
+          <span class="text-[10px] font-semibold uppercase tracking-widest">Recap</span>
+          <span class="ml-auto text-foundry-light-muted dark:text-foundry-text/40" aria-hidden="true">
+            {collapsed ? '▲' : '▼'}
+          </span>
+        </button>
+        <p class="mt-1.5 text-foundry-light-text/70 dark:text-foundry-text/70">{currentRecap.summary}</p>
+
+        {#if !collapsed && currentRecap.table_rows.length > 0}
+          <table class="mt-2 w-full border-collapse">
+            <tbody>
+              {#each currentRecap.table_rows as [step, result], i (i)}
+                <tr class="border-b border-foundry-teal/10 last:border-0 recap-row align-top">
+                  <td class="py-1 pr-3 text-foundry-teal/80 whitespace-nowrap">{step}</td>
+                  <td class="py-1 text-foundry-light-text/80 dark:text-foundry-text/70 break-words">{result}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+      </section>
     {/if}
   </div>
-{/if}
+</aside>
 
 <style>
-  /* Why: Tailwind class-toggle for striping was clumsy with arbitrary teal
-     opacity; a tiny scoped rule using nth-child gives clean alternating rows
-     without an extra class plumbing layer.
-     Test: Inspect rendered table — even rows have a faint teal tint, odd rows
-     are fully transparent over the panel background. */
-  tbody tr:nth-child(even) {
+  /* Why: Alternate-row striping for the folded recap table; nth-child avoids
+     plumbing extra Tailwind classes per row.
+     Test: Inspect the recap fold's table — even rows have a faint teal tint. */
+  tbody tr.recap-row:nth-child(even) {
     background-color: rgb(20 184 166 / 0.04);
-  }
-  tbody tr {
-    background-color: transparent;
   }
 </style>

--- a/crates/trusty-agents/ui/src/components/RecapPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/RecapPanel.svelte
@@ -21,8 +21,10 @@
   import { recaps } from '../stores/recap';
   import { activeProjectId } from '../stores/app';
   import { workflowState, type AgentActivityStatus } from '../stores/workflow';
+  import { isDesktop } from '../lib/transport';
 
   let collapsed = false;
+  const desktop = isDesktop();
 
   $: currentRecap = $recaps.get($activeProjectId) ?? null;
   $: agents = $workflowState.agents;
@@ -60,11 +62,25 @@
   <div class="flex flex-col gap-5 px-4 py-4 text-xs font-mono">
     <!-- AGENTS ACTIVE -->
     <section>
-      <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-foundry-light-primary dark:text-[#e9b98a]">
+      <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-foundry-light-primary dark:text-foundry-sidebar-accent">
         Agents Active
       </h3>
       {#if agents.length === 0}
-        <p class="text-foundry-light-muted dark:text-foundry-text/40">No agents active.</p>
+        {#if desktop}
+          <!-- Why (#3257 code-critic HIGH / #3258): desktop mode never
+               receives agent_spawned/agent_message/agent_done/agent_failed
+               SSE events (App.svelte's SSE bridge is browser-only), and
+               today's terminal PmResponse carries no per-agent summary
+               either — see PmResponseLike.agents_active doc comment in
+               stores/workflow.ts. `agents.length === 0` in desktop mode is
+               therefore NOT "no agents ran"; it's "we have no way to know."
+               Saying "No agents active." would be actively misleading. -->
+          <p class="text-foundry-light-muted dark:text-foundry-text/40">
+            Live agent status unavailable in desktop mode (see #3258).
+          </p>
+        {:else}
+          <p class="text-foundry-light-muted dark:text-foundry-text/40">No agents active.</p>
+        {/if}
       {:else}
         <ul class="flex flex-col gap-2">
           {#each agents as a (a.agent)}
@@ -80,7 +96,7 @@
 
     <!-- FILES TOUCHED -->
     <section>
-      <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-foundry-light-primary dark:text-[#e9b98a]">
+      <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-foundry-light-primary dark:text-foundry-sidebar-accent">
         Files Touched
       </h3>
       {#if filesTouched.length === 0}
@@ -96,7 +112,7 @@
 
     <!-- TOKENS -->
     <section>
-      <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-foundry-light-primary dark:text-[#e9b98a]">
+      <h3 class="mb-2 text-[10px] font-semibold uppercase tracking-widest text-foundry-light-primary dark:text-foundry-sidebar-accent">
         Tokens
       </h3>
       {#if tokens}

--- a/crates/trusty-agents/ui/src/components/TaskHistory.svelte
+++ b/crates/trusty-agents/ui/src/components/TaskHistory.svelte
@@ -3,6 +3,7 @@
   import { taskHistory } from '../stores/app';
   import type { TaskHistoryEntry } from '../stores/app';
   import { invoke, listenEvent, type UnlistenFn } from '../lib/transport';
+  import type { PmResponseLike } from '../stores/workflow';
 
   let unlistenComplete: UnlistenFn | null = null;
   let unlistenError: UnlistenFn | null = null;
@@ -17,12 +18,11 @@
    * interface) keeps this a self-contained, additive read of data that was
    * already on the wire, with no risk to other TaskHistoryEntry consumers.
    * What: Same shape as `TaskHistoryEntry` plus the optional raw
-   * `phases_completed` list (name/status only — elapsed/cost aren't needed
-   * for a stamp label).
+   * `phases_completed` list, reusing `PmResponseLike`'s field (#3217's
+   * `stores/workflow.ts`) instead of a second, drifting inline duplicate of
+   * that shape — `phaseStamp` below only reads `.name`/`.status` off it.
    */
-  interface TaskHistoryEntryWithPhases extends TaskHistoryEntry {
-    phases_completed?: Array<{ name: string; status: string }>;
-  }
+  type TaskHistoryEntryWithPhases = TaskHistoryEntry & Pick<PmResponseLike, 'phases_completed'>;
 
   /**
    * Why: The mockup's task-history stamps read as present-continuous verbs

--- a/crates/trusty-agents/ui/src/components/TaskHistory.svelte
+++ b/crates/trusty-agents/ui/src/components/TaskHistory.svelte
@@ -9,6 +9,59 @@
   let errorMessage = '';
 
   /**
+   * Why (#3221): `GET /api/tasks` (wired via `invoke('list_tasks')`) returns
+   * the server's full `PmResponse` array — it carries `phases_completed`
+   * even though the frontend's `TaskHistoryEntry` interface (stores/app.ts)
+   * only declares the narrower fields TaskHistory has historically rendered.
+   * Declaring the extra field locally (rather than widening the shared
+   * interface) keeps this a self-contained, additive read of data that was
+   * already on the wire, with no risk to other TaskHistoryEntry consumers.
+   * What: Same shape as `TaskHistoryEntry` plus the optional raw
+   * `phases_completed` list (name/status only — elapsed/cost aren't needed
+   * for a stamp label).
+   */
+  interface TaskHistoryEntryWithPhases extends TaskHistoryEntry {
+    phases_completed?: Array<{ name: string; status: string }>;
+  }
+
+  /**
+   * Why: The mockup's task-history stamps read as present-continuous verbs
+   * ("IMPLEMENTING") rather than the bare phase noun ("IMPLEMENT"). A small
+   * static map covers the known workflow phase vocabulary; anything outside
+   * it degrades gracefully to "<NAME>…" rather than guessing an inflection.
+   */
+  const CONTINUOUS_LABEL: Record<string, string> = {
+    research: 'RESEARCHING',
+    plan: 'PLANNING',
+    implement: 'IMPLEMENTING',
+    verify: 'VERIFYING',
+    qa: 'TESTING',
+    docs: 'DOCUMENTING',
+  };
+
+  /**
+   * Why: Extends the coarse running/completed/failed pill with the
+   * current/last phase name when the entry carries `phases_completed`,
+   * matching the mockup's "IMPLEMENTING"/"✓ COMPLETE"/"✕ FAILED" stamps.
+   * What: Terminal statuses keep the existing ✓/✕ labels (phase data adds
+   * no information once the task is done); a running task with phase data
+   * shows the last phase's continuous-form label instead of the generic
+   * "running" word. Returns `null` when there's no phase data so the
+   * caller falls back to the existing coarse pill unchanged.
+   * Test: Manual — see PR description; covered visually via `pnpm dev`
+   * against a running server with an in-flight prescriptive-workflow task.
+   */
+  function phaseStamp(entry: TaskHistoryEntry): string | null {
+    const phases = (entry as TaskHistoryEntryWithPhases).phases_completed;
+    if (!phases || phases.length === 0) return null;
+    if (entry.status === 'completed' || entry.status === 'success') return '✓ COMPLETE';
+    if (entry.status === 'failed' || entry.status === 'error') return '✕ FAILED';
+    if (entry.status !== 'running') return null;
+    const last = phases[phases.length - 1];
+    return CONTINUOUS_LABEL[last.name] ?? `${last.name.toUpperCase()}…`;
+  }
+
+  /**
    * Why: Gives the user an at-a-glance view of recent workflow runs so they
    * can see whether prior bake-off tasks succeeded and what they cost.
    * What: Fetches list_tasks on demand; caps the display at 10 entries.
@@ -16,7 +69,7 @@
   async function refresh() {
     try {
       const raw = await invoke<unknown>('list_tasks');
-      const arr = Array.isArray(raw) ? (raw as TaskHistoryEntry[]) : [];
+      const arr = Array.isArray(raw) ? (raw as TaskHistoryEntryWithPhases[]) : [];
       taskHistory.set(arr.slice(0, 10));
       errorMessage = '';
     } catch (e) {
@@ -80,7 +133,7 @@
                 : entry.status === 'failed' || entry.status === 'error'
                   ? 'bg-red-500/20 text-red-600 dark:text-red-400'
                   : 'bg-foundry-light-border dark:bg-foundry-surface text-foundry-light-muted dark:text-foundry-text/70'}"
-          >{entry.status}</span>
+          >{phaseStamp(entry) ?? entry.status}</span>
           {#if typeof entry.score === 'number' && typeof entry.score_max === 'number'}
             <span class="font-mono">{entry.score}/{entry.score_max}</span>
           {/if}

--- a/crates/trusty-agents/ui/src/components/WorkflowPhaseCard.svelte
+++ b/crates/trusty-agents/ui/src/components/WorkflowPhaseCard.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  /**
+   * Why: #3218 — the Foundry mockup's signature interaction is an inline
+   * RESEARCH/PLAN/IMPLEMENT/VERIFY checklist card rendered in the chat
+   * stream, not just a "Running…" spinner. `workflowState.phases` (#3217)
+   * has carried this data since the SSE `phase_started`/`phase_done`
+   * events started feeding it — this component just renders it.
+   * What: A rectangular, mono-labelled checklist card: one row per phase
+   * with a ✓ (done) / spinner (running) / ○ (pending or failed shows ✕)
+   * marker, the phase name, and its note (elapsed/cost once the terminal
+   * `PmResponse` backfills them via `applyTaskResult`, blank until then).
+   * Test: Manual — drive a `--workflow prescriptive` task against a running
+   * `tagent --api` server in browser/SSE mode; observe rows tick from ○ to
+   * spinner to ✓ as `phase_started`/`phase_done` events arrive.
+   */
+  import { Loader2 } from 'lucide-svelte';
+  import { workflowState } from '../stores/workflow';
+
+  $: phases = $workflowState.phases;
+  $: doneCount = phases.filter((p) => p.status === 'done').length;
+
+  function fmtElapsed(secs?: number): string {
+    if (typeof secs !== 'number') return '';
+    return secs < 60 ? `${Math.round(secs)}s` : `${Math.floor(secs / 60)}m ${Math.round(secs % 60)}s`;
+  }
+
+  function phaseNote(note: string | undefined, elapsedSecs: number | undefined, costUsd: number | undefined): string {
+    const parts: string[] = [];
+    const e = fmtElapsed(elapsedSecs);
+    if (e) parts.push(e);
+    if (typeof costUsd === 'number') parts.push(`$${costUsd.toFixed(costUsd < 0.01 ? 4 : 2)}`);
+    if (note) parts.push(note);
+    return parts.join(' · ');
+  }
+</script>
+
+{#if phases.length > 0}
+  <div class="rounded-md border border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface overflow-hidden font-mono text-xs">
+    <div class="flex items-center justify-between px-3.5 py-2 bg-foundry-light-border/40 dark:bg-foundry-border/40 text-foundry-light-text dark:text-[#e9b98a] font-semibold uppercase tracking-wide">
+      <span>Workflow</span>
+      <span class="text-foundry-amber">Phase {Math.min(doneCount + 1, phases.length)}/{phases.length}</span>
+    </div>
+    <div class="flex flex-col gap-2 px-3.5 py-3">
+      {#each phases as phase (phase.name)}
+        <div class="flex items-center gap-2.5">
+          <span class="w-4 flex-shrink-0 text-center">
+            {#if phase.status === 'done'}
+              <span class="text-foundry-teal font-semibold" aria-hidden="true">&#10003;</span>
+            {:else if phase.status === 'running'}
+              <Loader2 class="h-3 w-3 animate-spin text-foundry-amber inline-block" aria-hidden="true" />
+            {:else if phase.status === 'failed'}
+              <span class="text-red-500 dark:text-red-400 font-semibold" aria-hidden="true">&#10007;</span>
+            {:else}
+              <span class="text-foundry-light-muted dark:text-foundry-text/40" aria-hidden="true">&#9675;</span>
+            {/if}
+            <span class="sr-only">{phase.status}</span>
+          </span>
+          <span
+            class="font-medium uppercase tracking-wide {phase.status === 'running'
+              ? 'text-foundry-light-text dark:text-foundry-text'
+              : 'text-foundry-light-muted dark:text-foundry-text/60'}"
+          >{phase.name}</span>
+          <span class="text-foundry-light-muted dark:text-foundry-text/50 truncate">
+            {phaseNote(phase.note, phase.elapsedSecs, phase.costUsd) || (phase.status === 'pending' ? 'queued' : '')}
+          </span>
+        </div>
+      {/each}
+    </div>
+  </div>
+{/if}

--- a/crates/trusty-agents/ui/src/components/WorkflowPhaseCard.svelte
+++ b/crates/trusty-agents/ui/src/components/WorkflowPhaseCard.svelte
@@ -36,7 +36,7 @@
 
 {#if phases.length > 0}
   <div class="rounded-md border border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface overflow-hidden font-mono text-xs">
-    <div class="flex items-center justify-between px-3.5 py-2 bg-foundry-light-border/40 dark:bg-foundry-border/40 text-foundry-light-text dark:text-[#e9b98a] font-semibold uppercase tracking-wide">
+    <div class="flex items-center justify-between px-3.5 py-2 bg-foundry-light-border/40 dark:bg-foundry-border/40 text-foundry-light-text dark:text-foundry-sidebar-accent font-semibold uppercase tracking-wide">
       <span>Workflow</span>
       <span class="text-foundry-amber">Phase {Math.min(doneCount + 1, phases.length)}/{phases.length}</span>
     </div>

--- a/crates/trusty-agents/ui/src/stores/workflow.ts
+++ b/crates/trusty-agents/ui/src/stores/workflow.ts
@@ -1,0 +1,276 @@
+import { writable } from 'svelte/store';
+import type { AppEvent } from '../lib/transport';
+
+/**
+ * Why: #3217 — `bridgeEventToWebBus` (App.svelte) flattens every structured
+ * SSE event (`phase_started`/`phase_done`/`agent_*`) and every completed
+ * task's `PmResponse` (`phases_completed`/`files_modified`/`metadata`) into
+ * plain-text webBus messages before any component can see the shape. That
+ * loses the data ChatView's phase checklist (#3218), RecapPanel's session
+ * rail (#3219), and TaskHistory's phase stamps (#3221) all need. This store
+ * is a parallel, additive sink: it preserves the structured shape so those
+ * three components can render it directly, while the existing flattened
+ * webBus path keeps working unchanged for the plain-text chat log.
+ * What: A single `workflowState` writable tracking the *active* task's
+ * phase checklist, per-agent activity, touched files, and token/cost
+ * totals, fed by two independent sources:
+ *   1. `handleWorkflowEvent(ev)` — live, low-fidelity updates from the raw
+ *      `AppEvent` stream (browser/SSE mode only; phase/agent events carry
+ *      name+status but not elapsed/cost/note).
+ *   2. `applyTaskResult(resp)` — a full-fidelity backfill from a
+ *      `PmResponse`-shaped payload (available in Tauri desktop mode via the
+ *      `task-complete` event, which carries the entire server response).
+ * Test: Manual — `crates/trusty-agents/ui` has no unit test harness wired
+ * up yet (see README); verified by driving `pnpm dev` against a running
+ * `tagent --api` server and observing the phase card / recap rail update
+ * live. See PR description for the SSE-event -> store-field mapping table.
+ */
+
+export type WorkflowPhaseStatus = 'pending' | 'running' | 'done' | 'failed';
+
+export interface WorkflowPhase {
+  name: string;
+  status: WorkflowPhaseStatus;
+  /** Only known once the terminal `PmResponse` arrives (see `applyTaskResult`). */
+  elapsedSecs?: number;
+  costUsd?: number;
+  note?: string;
+}
+
+/** Why #3219: three states is the full vocabulary the recap rail's dot needs. */
+export type AgentActivityStatus = 'working' | 'idle' | 'failed';
+
+export interface AgentActivity {
+  agent: string;
+  status: AgentActivityStatus;
+  lastActivity?: string;
+  updatedAt: number;
+}
+
+export interface WorkflowTokens {
+  tokensIn: number;
+  tokensOut: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  costUsd: number;
+  model?: string;
+}
+
+export type WorkflowRunStatus = 'idle' | 'running' | 'done' | 'failed' | 'cancelled';
+
+export interface WorkflowState {
+  taskId: string | null;
+  status: WorkflowRunStatus;
+  phases: WorkflowPhase[];
+  agents: AgentActivity[];
+  filesTouched: string[];
+  tokens: WorkflowTokens | null;
+}
+
+function initialState(): WorkflowState {
+  return {
+    taskId: null,
+    status: 'idle',
+    phases: [],
+    agents: [],
+    filesTouched: [],
+    tokens: null,
+  };
+}
+
+export const workflowState = writable<WorkflowState>(initialState());
+
+/**
+ * Why: A new task (or `/api/clear-context`, which reloads the page and thus
+ * re-initializes this module anyway) must not show the previous task's
+ * checklist/agents/files. Exported separately from `handleWorkflowEvent` so
+ * it stays a one-line, obviously-correct reset call site.
+ * What: Replaces `workflowState` with a fresh `initialState()`.
+ * Test: Call `resetWorkflow()` after populating state, assert `phases`,
+ * `agents`, `filesTouched` are empty and `tokens` is null.
+ */
+export function resetWorkflow(): void {
+  workflowState.set(initialState());
+}
+
+function upsertPhase(name: string, status: WorkflowPhaseStatus): void {
+  workflowState.update((s) => {
+    const idx = s.phases.findIndex((p) => p.name === name);
+    if (idx === -1) {
+      return { ...s, phases: [...s.phases, { name, status }] };
+    }
+    const phases = s.phases.slice();
+    phases[idx] = { ...phases[idx], status };
+    return { ...s, phases };
+  });
+}
+
+function upsertAgent(
+  agent: string | undefined,
+  status: AgentActivityStatus,
+  lastActivity?: string,
+): void {
+  if (!agent) return;
+  workflowState.update((s) => {
+    const idx = s.agents.findIndex((a) => a.agent === agent);
+    const entry: AgentActivity = { agent, status, lastActivity, updatedAt: Date.now() };
+    if (idx === -1) {
+      return { ...s, agents: [...s.agents, entry] };
+    }
+    const agents = s.agents.slice();
+    agents[idx] = entry;
+    return { ...s, agents };
+  });
+}
+
+/**
+ * SSE event -> store field mapping (browser/SSE mode; see PR description for
+ * the full table):
+ *   session_started  -> reset(), taskId, status='running'
+ *   session_done      -> status='done'|'failed'|'cancelled' (from ev.status)
+ *   session_cancelled -> status='cancelled'
+ *   phase_started     -> upsert phases[name].status='running'
+ *   phase_done        -> upsert phases[name].status='done'|'failed'
+ *   agent_spawned     -> upsert agents[agent] = working, "starting…"
+ *   agent_message     -> upsert agents[agent] = working, ev.text
+ *   agent_done        -> upsert agents[agent] = idle, "done (<status>)"
+ *   agent_failed      -> upsert agents[agent] = failed, ev.error
+ *
+ * Why: Called unconditionally from `bridgeEventToWebBus` (App.svelte) for
+ * every incoming `AppEvent`, alongside (not instead of) the existing
+ * flattened-text switch — this function never emits webBus messages itself.
+ * What: Mutates `workflowState` in place per the mapping above. Unknown
+ * event types are ignored (no default branch needed since files_modified /
+ * metadata / phase elapsed+cost+note are not carried on the wire by these
+ * events — see `applyTaskResult` for the full-fidelity backfill).
+ * Test: Manual — see module doc comment.
+ */
+export function handleWorkflowEvent(ev: AppEvent): void {
+  switch (ev.type) {
+    case 'session_started':
+      resetWorkflow();
+      workflowState.update((s) => ({ ...s, taskId: ev.session_id ?? null, status: 'running' }));
+      break;
+    case 'session_done': {
+      const wireStatus = (ev.status as string) ?? 'success';
+      const status: WorkflowRunStatus =
+        wireStatus === 'cancelled' ? 'cancelled' : wireStatus === 'success' || wireStatus === 'partial' ? 'done' : 'failed';
+      workflowState.update((s) => ({ ...s, status }));
+      break;
+    }
+    case 'session_cancelled':
+      workflowState.update((s) => ({ ...s, status: 'cancelled' }));
+      break;
+    case 'phase_started':
+      if (ev.phase) upsertPhase(ev.phase, 'running');
+      break;
+    case 'phase_done':
+      if (ev.phase) upsertPhase(ev.phase, ev.status === 'failed' ? 'failed' : 'done');
+      break;
+    case 'agent_spawned':
+      upsertAgent(ev.agent, 'working', 'starting…');
+      break;
+    case 'agent_message':
+      upsertAgent(ev.agent, 'working', ev.text);
+      break;
+    case 'agent_done':
+      upsertAgent(ev.agent, ev.status === 'failed' ? 'failed' : 'idle', `done (${ev.status ?? 'ok'})`);
+      break;
+    case 'agent_failed':
+      upsertAgent(ev.agent, 'failed', ev.error);
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Why: The only place the full `phases_completed` (with `elapsed_secs` /
+ * `cost_usd` / `note`), `files_modified`, and `metadata` (token/cost
+ * totals) are available on the wire is the terminal `PmResponse` itself —
+ * the `task-complete` event. In Tauri desktop mode that event's payload IS
+ * the full `PmResponse` (see `ui/src-tauri/src/main.rs::send_message`); in
+ * the browser fallback it's a narrower `{id,narrative,status}` shape, so
+ * this function defensively no-ops on whichever fields are absent rather
+ * than assuming a fixed shape.
+ * What: Merges any present fields from a `PmResponse`-shaped payload into
+ * `workflowState`. Phase list is replaced wholesale (it's the authoritative
+ * final list, not an incremental patch); files/tokens likewise replace.
+ * Test: Manual — see module doc comment.
+ */
+export interface PmResponseLike {
+  id?: string;
+  status?: string;
+  files_modified?: string[];
+  phases_completed?: Array<{
+    name: string;
+    status: string;
+    elapsed_secs?: number;
+    cost_usd?: number;
+    note?: string | null;
+  }>;
+  metadata?: {
+    total_tokens_in?: number;
+    total_tokens_out?: number;
+    cache_read_tokens?: number;
+    cache_creation_tokens?: number;
+    total_cost_usd?: number;
+    model?: string | null;
+  };
+}
+
+export function applyTaskResult(resp: unknown): void {
+  if (!resp || typeof resp !== 'object') return;
+  const r = resp as PmResponseLike;
+
+  workflowState.update((s) => {
+    const next: WorkflowState = { ...s };
+
+    if (r.id) next.taskId = r.id;
+
+    if (r.status) {
+      next.status =
+        r.status === 'cancelled'
+          ? 'cancelled'
+          : r.status === 'success' || r.status === 'partial'
+            ? 'done'
+            : r.status === 'running'
+              ? 'running'
+              : 'failed';
+    }
+
+    if (Array.isArray(r.phases_completed) && r.phases_completed.length > 0) {
+      next.phases = r.phases_completed.map((p) => ({
+        name: p.name,
+        status:
+          p.status === 'done'
+            ? 'done'
+            : p.status === 'failed'
+              ? 'failed'
+              : p.status === 'running'
+                ? 'running'
+                : 'pending',
+        elapsedSecs: p.elapsed_secs,
+        costUsd: p.cost_usd,
+        note: p.note ?? undefined,
+      }));
+    }
+
+    if (Array.isArray(r.files_modified)) {
+      next.filesTouched = r.files_modified;
+    }
+
+    if (r.metadata) {
+      next.tokens = {
+        tokensIn: r.metadata.total_tokens_in ?? 0,
+        tokensOut: r.metadata.total_tokens_out ?? 0,
+        cacheReadTokens: r.metadata.cache_read_tokens ?? 0,
+        cacheCreationTokens: r.metadata.cache_creation_tokens ?? 0,
+        costUsd: r.metadata.total_cost_usd ?? 0,
+        model: r.metadata.model ?? undefined,
+      };
+    }
+
+    return next;
+  });
+}

--- a/crates/trusty-agents/ui/src/stores/workflow.ts
+++ b/crates/trusty-agents/ui/src/stores/workflow.ts
@@ -1,4 +1,4 @@
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 import type { AppEvent } from '../lib/transport';
 
 /**
@@ -143,14 +143,37 @@ function upsertAgent(
  * event types are ignored (no default branch needed since files_modified /
  * metadata / phase elapsed+cost+note are not carried on the wire by these
  * events — see `applyTaskResult` for the full-fidelity backfill).
+ *
+ * #3257 code-critic MEDIUM: events are filtered to the session this store is
+ * currently tracking before the switch runs. The broadcast SSE stream is
+ * process-wide (`events::bus()`), not per-subscriber-filtered by session
+ * unless the client opted into `?session_id=`, so a stale event from a
+ * previous/foreign task racing in after a reset (or arriving out of order)
+ * must not mutate the active task's checklist. `session_started` always
+ * resets+adopts regardless of the current id (it's the definitive "new task"
+ * signal). When `workflowState.taskId` is still `null` (bootstrap — no
+ * `session_started` seen yet, e.g. a `phase_started` arriving first) the
+ * event's session is adopted rather than discarded, so the store isn't stuck
+ * waiting for an event type that may never come.
  * Test: Manual — see module doc comment.
  */
 export function handleWorkflowEvent(ev: AppEvent): void {
+  if (ev.type === 'session_started') {
+    resetWorkflow();
+    workflowState.update((s) => ({ ...s, taskId: ev.session_id ?? null, status: 'running' }));
+    return;
+  }
+
+  if (ev.session_id) {
+    const current = get(workflowState);
+    if (current.taskId === null) {
+      workflowState.update((s) => (s.taskId === null ? { ...s, taskId: ev.session_id ?? null } : s));
+    } else if (ev.session_id !== current.taskId) {
+      return; // stale/foreign session — ignore
+    }
+  }
+
   switch (ev.type) {
-    case 'session_started':
-      resetWorkflow();
-      workflowState.update((s) => ({ ...s, taskId: ev.session_id ?? null, status: 'running' }));
-      break;
     case 'session_done': {
       const wireStatus = (ev.status as string) ?? 'success';
       const status: WorkflowRunStatus =
@@ -217,6 +240,21 @@ export interface PmResponseLike {
     total_cost_usd?: number;
     model?: string | null;
   };
+  /**
+   * Why (#3257 code-critic HIGH / #3258): today's `PmResponse` (see
+   * `crates/trusty-agents/src/api/types.rs`) carries no per-agent summary —
+   * `AgentSpawned`/`AgentMessage`/`AgentDone`/`AgentFailed` only exist as
+   * live SSE events (`events.rs`), which Tauri desktop mode never receives
+   * (`App.svelte`'s SSE bridge is browser-only). So in desktop mode
+   * `workflowState.agents` stays empty for the entire task, not just until
+   * completion — `RecapPanel` renders an explicit "unavailable in desktop
+   * mode" state rather than a misleading "No agents active." in that case
+   * (see #3258, tracked as a follow-up to forward live agent events through
+   * the Tauri bridge). This field does not exist on the wire yet; it's
+   * declared here so that if/when the backend adds one, `applyTaskResult`
+   * picks it up with zero changes to this store or its consumers.
+   */
+  agents_active?: Array<{ agent: string; status: string; last_activity?: string | null }>;
 }
 
 export function applyTaskResult(resp: unknown): void {
@@ -258,6 +296,17 @@ export function applyTaskResult(resp: unknown): void {
 
     if (Array.isArray(r.files_modified)) {
       next.filesTouched = r.files_modified;
+    }
+
+    // See `PmResponseLike.agents_active` doc comment — no-op today (the
+    // field doesn't exist on the wire), forward-compatible if it's added.
+    if (Array.isArray(r.agents_active) && r.agents_active.length > 0) {
+      next.agents = r.agents_active.map((a) => ({
+        agent: a.agent,
+        status: a.status === 'working' ? 'working' : a.status === 'failed' ? 'failed' : 'idle',
+        lastActivity: a.last_activity ?? undefined,
+        updatedAt: Date.now(),
+      }));
     }
 
     if (r.metadata) {

--- a/crates/trusty-agents/ui/tailwind.config.js
+++ b/crates/trusty-agents/ui/tailwind.config.js
@@ -28,6 +28,10 @@ export default {
           primary: '#d97742',
           teal: '#7ba7c4',
           amber: '#d9a83a',
+          // --trusty-sidebar-accent (docs/design/gui/tokens.css) — the warm
+          // tan/gold used for section labels in dark-themed sidebars/rails
+          // (e.g. RecapPanel's AGENTS ACTIVE/FILES TOUCHED/TOKENS headers).
+          'sidebar-accent': '#e9b98a',
           // Light theme values (used via `dark:` prefix inversion, same
           // pattern the app already used pre-rebrand).
           'light-bg': '#f5efe7',


### PR DESCRIPTION
## Summary

GUI structured-data wave for the Trusty Assistant Tauri app (epic #3052). Implements #3217, #3218, #3219, #3221 as one PR since #3218/#3219/#3221 all depend on #3217's store.

- **#3217** — new `crates/trusty-agents/ui/src/stores/workflow.ts`: a parallel typed store (`workflowState`) that preserves the structured shape of SSE events and terminal `PmResponse` data, additive to the existing flattened-text webBus path (never replaces it).
- **#3218** — new `WorkflowPhaseCard.svelte`, rendered inline in `ChatView` when the active task has phases: a RESEARCH/PLAN/IMPLEMENT/VERIFY checklist with ✓ / spinner / ○ (✕ on failure) markers and per-phase elapsed/cost/note.
- **#3219** — `RecapPanel.svelte` restructured from a horizontal band into a persistent 300px right `<aside>` (own scroll) with AGENTS ACTIVE / FILES TOUCHED / TOKENS sections, folding the existing recap summary/table (#371) in as a fourth section.
- **#3221** — `TaskHistory.svelte` entries now show the current/last phase name (e.g. "IMPLEMENTING") as the status stamp when phase data is present, falling back to the existing coarse running/completed/failed pill otherwise.

## Store shape (`workflowState`)

```ts
interface WorkflowState {
  taskId: string | null;
  status: 'idle' | 'running' | 'done' | 'failed' | 'cancelled';
  phases: { name; status: 'pending'|'running'|'done'|'failed'; elapsedSecs?; costUsd?; note? }[];
  agents: { agent; status: 'working'|'idle'|'failed'; lastActivity?; updatedAt }[];
  filesTouched: string[];
  tokens: { tokensIn; tokensOut; cacheReadTokens; cacheCreationTokens; costUsd; model? } | null;
}
```

Two independent feeds, both additive:

| Source | Function | Fidelity |
|---|---|---|
| `bridgeEventToWebBus` (App.svelte, browser/SSE mode) | `handleWorkflowEvent(ev: AppEvent)` | live, low-fidelity — phase/agent name+status only, no elapsed/cost/note on the wire |
| `task-complete` listener (App.svelte `onMount`, both modes) | `applyTaskResult(resp)` | full-fidelity backfill from the terminal `PmResponse` — Tauri desktop emits the *full* response on this event; browser fallback emits a narrower `{id,status,narrative}` shape, so the function defensively merges whichever fields are present |

### SSE event → store field mapping

| Event | Store effect |
|---|---|
| `session_started` | `resetWorkflow()`, `taskId = ev.session_id`, `status = 'running'` |
| `session_done` | `status` from `ev.status` (`success`/`partial`→`done`, `cancelled`→`cancelled`, else `failed`) |
| `session_cancelled` | `status = 'cancelled'` |
| `phase_started` | upsert `phases[name].status = 'running'` |
| `phase_done` | upsert `phases[name].status = 'done'`\|`'failed'` |
| `agent_spawned` | upsert `agents[agent] = { status: 'working', lastActivity: 'starting…' }` |
| `agent_message` | upsert `agents[agent] = { status: 'working', lastActivity: ev.text }` |
| `agent_done` | upsert `agents[agent] = { status: 'idle'\|'failed', lastActivity: 'done (<status>)' }` |
| `agent_failed` | upsert `agents[agent] = { status: 'failed', lastActivity: ev.error }` |
| terminal `PmResponse` (`task-complete`) | `phases` replaced wholesale from `phases_completed` (adds `elapsedSecs`/`costUsd`/`note`), `filesTouched` from `files_modified`, `tokens` from `metadata`, `agents` from `agents_active` (forward-compat hook, no-op today — see below) |
| `task-progress` (App.svelte, both transport modes) | not fed into `handleWorkflowEvent`/`applyTaskResult` directly — used only to detect "a new task started" (see code-critic remediation, HIGH #2) |

All non-`session_started` events additionally pass a session-id filter (see code-critic remediation, MEDIUM #3) before reaching the mapping above.

## Code-critic remediation (WARN → this push)

The first push got a WARN verdict: 2 HIGH + 2 MEDIUM required, 1 LOW optional. Root cause for both HIGHs: `bridgeEventToWebBus` (and thus `handleWorkflowEvent`) only runs in browser/SSE mode — Tauri desktop mode never calls it, so anything gated on it silently no-ops in the primary shipping surface. All five addressed in this push:

1. **HIGH — AGENTS ACTIVE dead in desktop mode.** `applyTaskResult` never wrote `next.agents` (no per-agent field exists on `PmResponse` today). Added a forward-compatible `PmResponseLike.agents_active` hook (currently always absent → no-op) and changed `RecapPanel`'s empty state to branch on `isDesktop()`: browser mode still shows "No agents active." (a true empty state); desktop mode shows "Live agent status unavailable in desktop mode (see #3258)." instead of the misleading phrase. Filed **#3258** to track live-forwarding.
2. **HIGH — stale phase card across tasks in desktop mode.** `resetWorkflow()` previously only fired on SSE `session_started`, which desktop never sees, so a second desktop task kept showing the first task's checklist until its own `task-complete` finally overwrote it. Fixed in `App.svelte` (not `InputArea.svelte`, not `src-tauri/**`): a new `task-progress` listener — that event fires in both transport modes — calls `maybeAdoptNewTask(taskId)`, which resets + adopts the moment a task id different from the currently-tracked one is first observed. No-ops when the id matches (the common case), so browser-mode behavior via `session_started` is unchanged.
3. **MEDIUM — no session/task-id filtering in `handleWorkflowEvent`.** The SSE broadcast bus is process-wide, not scoped per subscriber, so a stale event from a previous/foreign session could still land after a reset. Added a filter: events whose `session_id` doesn't match `workflowState.taskId` are ignored; when `taskId` is still `null` (bootstrap — no `session_started` observed yet) the event's session is adopted instead of discarded.
4. **MEDIUM — `dark:text-[#e9b98a]` arbitrary values.** All four occurrences (three in `RecapPanel.svelte`, one in `WorkflowPhaseCard.svelte`) replaced with `dark:text-foundry-sidebar-accent`, backed by a new `'sidebar-accent': '#e9b98a'` entry in `tailwind.config.js`'s `foundry` color scale, matching `--trusty-sidebar-accent` in `docs/design/gui/tokens.css`.
5. **LOW — duplicated phase-shape type.** `TaskHistory.svelte`'s local `TaskHistoryEntryWithPhases` now composes `Pick<PmResponseLike, 'phases_completed'>` from `stores/workflow.ts` instead of redeclaring the shape inline.

## Mockup fidelity notes + deliberate deviations

- Phase checklist marker set (✓/spinner/○/✕), rectangular card, mono uppercase labels, per-phase note line — matches `docs/design/gui/Foundry Ecosystem.dc.html:203-211`.
- Recap rail: 300px `<aside>`, three sections in mockup order (AGENTS ACTIVE / FILES TOUCHED / TOKENS) — matches `:220-238`. Existing recap summary/table (#371) folded in as a 4th section rather than dropped.
- **Deviation — no tokens percent bar.** The mockup shows `"42.1k / 200k · 21%"` with a progress bar. No context-window max is exposed by the server today, and per-model constants aren't reliably knowable client-side; inventing a limit would show a fabricated number. Shows absolute in/out token counts + cost only (see `RecapPanel.svelte` comment at the TOKENS section).
- **Deviation — no live per-phase elapsed/cost while running.** `PhaseStarted`/`PhaseDone` SSE events (`crates/trusty-agents/src/events.rs`) only carry `name`+`status`, not `elapsed_secs`/`cost_usd`/`note` — those only exist in the terminal `PmResponse`. The card shows the phase note/timing once available (end of run in SSE/browser mode; live via Tauri's full `task-complete` payload in a limited sense — see below).
- **Known gap — no live phase/agent granularity in Tauri desktop mode; AGENTS ACTIVE never populates there today.** `bridgeEventToWebBus`'s SSE stream is browser-only (`App.svelte`: `if (eventSource || isDesktop()) return;` — Tauri "has its own listen() bridge already"). That Tauri bridge (`ui/src-tauri/src/main.rs::send_message`) only emits coarse `task-progress`/`task-complete`/`task-error`, not per-phase/per-agent events, and today's terminal `PmResponse` (`crates/trusty-agents/src/api/types.rs`) carries **no per-agent summary field at all** — so in the desktop shell the phase card populates once, at task completion, from `phases_completed`, but the AGENTS ACTIVE section **never populates**, not even at completion (there is nothing on the wire to populate it from). Filed as **#3258** to forward `events::bus()` phase/agent events through the Rust Tauri backend (touches `src-tauri/**` — out of this PR's file ownership; a parallel agent may own that surface). Until #3258 lands, `RecapPanel` shows an explicit "Live agent status unavailable in desktop mode (see #3258)." message in desktop mode instead of the misleading "No agents active." — see the code-critic remediation section below. `stores/workflow.ts` also declares a forward-compatible (currently unused) `PmResponseLike.agents_active` field so that if/when the backend adds per-agent data to `PmResponse`, `applyTaskResult` picks it up with zero further store changes.
- TaskHistory phase stamps use a small continuous-form label map (`research→RESEARCHING`, `implement→IMPLEMENTING`, etc.) with a `${NAME}…` fallback for anything outside the known vocabulary, rather than attempting general English inflection.
- Responsive: recap rail is `hidden xl:flex` (simple breakpoint hide, per the issue's "hidden-below-width is fine" note) rather than a stacking layout — narrow windows show sidebar + chat only, matching current mobile/narrow behavior.

## Visual sanity (verified)

- `pnpm build` succeeds; inspected the emitted bundle for syntax errors — none.
- Manually traced the reactive wiring end-to-end by reading each store subscription (`$workflowState.phases`, `$workflowState.agents`, `.filesTouched`, `.tokens`) against the new `RecapPanel`/`WorkflowPhaseCard`/`TaskHistory` templates to confirm they read from live derived values, not stale snapshots.
- Confirmed `RecapPanel` is now a sibling `<aside>` next to the chat+input column (not stacked inside it) by re-reading the restructured `App.svelte` `{#if activeView === 'chat'}` block.
- No local Tauri/browser dev server was launched to click through this interactively (out of scope for a synchronous single-pass PR); flagging that a follow-up manual QA pass against a running `tagent --api` server is recommended before merge.

## File ownership

Touched only: `App.svelte`, `ChatView.svelte`, `RecapPanel.svelte`, `TaskHistory.svelte`, new `WorkflowPhaseCard.svelte`, new `stores/workflow.ts`. Did not touch `InputArea.svelte`, `Sidebar.svelte`, `stores/app.ts`, or any `src-tauri/**`/Rust backend code (per the parallel-agent split for Stop/Retask + NEW TASK work).

## Test plan

- [x] `pnpm install && pnpm build` — passes (see gate output below)
- [x] `pnpm check` — 1 pre-existing error (`sseStatus` unused var in `App.svelte`, confirmed present on `origin/main` before this branch's changes, not introduced here)
- [x] `cargo check -p trusty-agents-ui` — passes (`Finished` dev profile)
- [x] `cargo fmt --check` — clean, no Rust files touched
- [ ] Manual click-through against a live `tagent --api` server (recommended before merge, not run in this pass)

## Quality gate output (raw, re-run after code-critic remediation — commit `caf1ed57`)

```
$ pnpm build
✓ 1678 modules transformed.
dist/index.html                   3.75 kB │ gzip:  1.34 kB
dist/assets/index-DBJSRkL_.css   24.84 kB │ gzip:  5.29 kB
dist/assets/core-BEOw45JP.js      0.20 kB │ gzip:  0.15 kB
dist/assets/event-lmqrH_TB.js     1.15 kB │ gzip:  0.61 kB
dist/assets/index-IuASD0Se.js   149.43 kB │ gzip: 45.56 kB
✓ built in 33.58s

$ pnpm check
1637 FILES 1 ERRORS 2 WARNINGS 2 FILES_WITH_PROBLEMS
ERROR "src/App.svelte" 73:7 "'sseStatus' is declared but its value is never read." (pre-existing on main; line shifted from 72→73 by this PR's own added import lines, not a new issue)
WARNING "src/components/ProjectsView.svelte" 731:5 a11y (pre-existing, unrelated file)
WARNING "src/components/ProjectsView.svelte" 739:7 a11y (pre-existing, unrelated file)

$ cargo check -p trusty-agents-ui
    Checking trusty-agents-ui v0.16.1 (.../crates/trusty-agents/ui/src-tauri)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.63s

$ cargo fmt --check
(no diff — exit 0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
