### PR TITLE
fix(trusty-mpm): disclaim TCC responsibility on health_start cargo spawn

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -16,7 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- disclaim TCC responsibility on the TUI health screen's `[S]`-key `cargo run` spawn — the last undisclaimed spawn site from the #2997 sweep (closes #3126)
+- disclaim TCC responsibility on the TUI health screen's `[S]`-key `cargo run` spawn — the last undisclaimed spawn site in the TUI/session-launch call graph from the #2997 sweep; two remaining sites elsewhere in the crate tracked as #2997 part 6 (closes #3126)
 - disclaim TCC responsibility on session-launch spawns so Claude Code isn't attributed to trusty-mpm (closes #2997) ([#3037](https://github.com/bobmatnyc/trusty-tools/pull/3037)) ([`d481a0c`](https://github.com/bobmatnyc/trusty-tools/commit/d481a0cd7e264b20109e1c92122ba972db828222))
 - teach user-scope MCP registration via tm mcp add in tm-cli-operations (closes #3020) ([#3021](https://github.com/bobmatnyc/trusty-tools/pull/3021)) ([`f6223aa`](https://github.com/bobmatnyc/trusty-tools/commit/f6223aacc1c030055440cea93c5ae52c1c4d231f))
 - write_project_hooks uses write_json_atomic for torn-write parity (closes #2972) ([#3018](https://github.com/bobmatnyc/trusty-tools/pull/3018)) ([`32e805d`](https://github.com/bobmatnyc/trusty-tools/commit/32e805d609e15bbcc02ab4212f606e0e34b20293))

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -16,6 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- disclaim TCC responsibility on the TUI health screen's `[S]`-key `cargo run` spawn — the last undisclaimed spawn site from the #2997 sweep (closes #3126)
 - disclaim TCC responsibility on session-launch spawns so Claude Code isn't attributed to trusty-mpm (closes #2997) ([#3037](https://github.com/bobmatnyc/trusty-tools/pull/3037)) ([`d481a0c`](https://github.com/bobmatnyc/trusty-tools/commit/d481a0cd7e264b20109e1c92122ba972db828222))
 - teach user-scope MCP registration via tm mcp add in tm-cli-operations (closes #3020) ([#3021](https://github.com/bobmatnyc/trusty-tools/pull/3021)) ([`f6223aa`](https://github.com/bobmatnyc/trusty-tools/commit/f6223aacc1c030055440cea93c5ae52c1c4d231f))
 - write_project_hooks uses write_json_atomic for torn-write parity (closes #2972) ([#3018](https://github.com/bobmatnyc/trusty-tools/pull/3018)) ([`32e805d`](https://github.com/bobmatnyc/trusty-tools/commit/32e805d609e15bbcc02ab4212f606e0e34b20293))

--- a/crates/trusty-mpm/src/core/spawn_disclaim/macos/mod.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/macos/mod.rs
@@ -1,8 +1,8 @@
 //! macOS-only spawn primitives shared by [`super::disclaimed_output`] (the
 //! capture-to-completion shape, [`capture`]), [`super::disclaimed_status`]
-//! (the inherited-stdio shape, [`status`]), and
-//! [`super::disclaimed_piped_spawn`] (the long-lived async piped shape,
-//! [`piped`]).
+//! and [`super::disclaimed_spawn_detached`] (the inherited-stdio shapes,
+//! [`status`]), and [`super::disclaimed_piped_spawn`] (the long-lived async
+//! piped shape, [`piped`]).
 //!
 //! Why: all three spawn shapes need the SAME low-level building blocks —
 //! resolving the private disclaim SPI, reaping a pid, and (for two of the
@@ -26,7 +26,7 @@ mod status;
 
 pub(crate) use capture::spawn_capture_disclaimed;
 pub(crate) use piped::spawn_piped_disclaimed;
-pub(crate) use status::spawn_status_inherit_disclaimed;
+pub(crate) use status::{spawn_detached_disclaimed, spawn_status_inherit_disclaimed};
 
 use std::io;
 use std::os::unix::process::ExitStatusExt;

--- a/crates/trusty-mpm/src/core/spawn_disclaim/macos/status.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/macos/status.rs
@@ -1,5 +1,7 @@
 //! Inherited-stdio disclaimed spawn — the macOS implementation behind
-//! [`super::super::disclaimed_status`] (issue #2997, `tm run`/`tm login`).
+//! [`super::super::disclaimed_status`] (issue #2997, `tm run`/`tm login`) AND
+//! [`super::super::disclaimed_spawn_detached`] (issue #3126, the TUI health
+//! screen's detached `cargo run` spawn).
 //!
 //! Why: `standalone::run::build_launch_command`/`build_login_command` (the
 //! `tm run <alias>`/`tm login` interactive drivers) spawn `claude` directly
@@ -7,20 +9,28 @@
 //! the tmux-hosted disclaim in [`super::capture`]/
 //! [`crate::core::tmux::run_tmux_with_bin`] entirely — so this session-launch
 //! path still reproduced the #2819/#2721 TCC mis-attribution storm.
-//! What: [`spawn_status_inherit_disclaimed`] reconstructs argv from
-//! `cmd.get_program()`/`cmd.get_args()`, chdirs to `cmd.get_current_dir()`
-//! when set (via [`super::posix_spawn_file_actions_addchdir_np`]), and
-//! rebuilds envp as the current process environment with `cmd.get_envs()`'s
-//! overrides/removals layered on top — matching what `Command` itself would
-//! hand the child. No stdin/stdout/stderr file actions are added, so the
-//! child inherits the caller's fds directly (`Stdio::inherit()` semantics —
-//! this fn assumes `cmd` was built that way; it does not read back `cmd`'s
-//! stdio config, since `std::process::Command` exposes no accessor for it).
-//! Sets the disclaim attribute when the private SPI resolves (via
-//! [`super::resolve_disclaim_fn`]), spawns via `posix_spawnp`, and reaps the
-//! child via [`super::wait_for`].
-//! Test: `disclaimed_status_*` in `super::super`'s test module (this module
-//! has no tests of its own — see that module's doc for why).
+//! `tui::event_loop::health_start` spawns a detached `cargo run` child with
+//! the same inherited-stdio shape but never waits on it, so it needs the
+//! identical argv/envp/cwd/disclaim setup minus the final reap.
+//! What: [`spawn_pid_inherit_disclaimed`] does the shared setup — reconstructs
+//! argv from `cmd.get_program()`/`cmd.get_args()`, chdirs to
+//! `cmd.get_current_dir()` when set (via
+//! [`super::posix_spawn_file_actions_addchdir_np`]), rebuilds envp as the
+//! current process environment with `cmd.get_envs()`'s overrides/removals
+//! layered on top (matching what `Command` itself would hand the child), sets
+//! the disclaim attribute when the private SPI resolves (via
+//! [`super::resolve_disclaim_fn`]), and spawns via `posix_spawnp`. No
+//! stdin/stdout/stderr file actions are added, so the child inherits the
+//! caller's fds directly (`Stdio::inherit()` semantics — this fn assumes
+//! `cmd` was built that way; it does not read back `cmd`'s stdio config,
+//! since `std::process::Command` exposes no accessor for it).
+//! [`spawn_status_inherit_disclaimed`] reaps the pid via [`super::wait_for`]
+//! before returning; [`spawn_detached_disclaimed`] discards the pid instead,
+//! leaving the child un-reaped exactly like the un-awaited
+//! `std::process::Child` it replaces.
+//! Test: `disclaimed_status_*` and `disclaimed_spawn_detached_*` in
+//! `super::super`'s test module (this module has no tests of its own — see
+//! that module's doc for why).
 
 use std::collections::HashMap;
 use std::ffi::{CString, OsString};
@@ -30,13 +40,18 @@ use std::process::{Command, ExitStatus};
 
 use super::{posix_spawn_file_actions_addchdir_np, resolve_disclaim_fn, wait_for};
 
-/// Spawn `cmd` with stdio inherited (fds 0/1/2 left untouched) and TCC
-/// responsibility disclaimed.
+/// Build argv/envp/cwd from `cmd`, disclaim TCC responsibility when the SPI
+/// resolves, and `posix_spawnp` with stdio left untouched (fds 0/1/2 pass
+/// through — `Stdio::inherit()` semantics). Returns the child's pid WITHOUT
+/// waiting on it — callers decide whether to reap immediately
+/// ([`spawn_status_inherit_disclaimed`]) or leave it detached
+/// ([`spawn_detached_disclaimed`]).
 ///
-/// Why: see the module docs.
-/// What: see the module docs.
-/// Test: `super::super::tests::disclaimed_status_*`.
-pub(crate) fn spawn_status_inherit_disclaimed(cmd: &mut Command) -> io::Result<ExitStatus> {
+/// Why/What: see the module docs.
+/// Test: exercised transitively by both public wrappers' callers
+/// (`super::super::tests::disclaimed_status_*` and
+/// `disclaimed_spawn_detached_*`).
+fn spawn_pid_inherit_disclaimed(cmd: &Command) -> io::Result<libc::pid_t> {
     let prog_c = CString::new(cmd.get_program().as_bytes())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "program contains NUL"))?;
 
@@ -147,5 +162,35 @@ pub(crate) fn spawn_status_inherit_disclaimed(cmd: &mut Command) -> io::Result<E
         }
     };
 
+    Ok(pid)
+}
+
+/// Spawn `cmd` with stdio inherited (fds 0/1/2 left untouched), TCC
+/// responsibility disclaimed, and reap it before returning.
+///
+/// Why: see the module docs.
+/// What: see the module docs.
+/// Test: `super::super::tests::disclaimed_status_*`.
+pub(crate) fn spawn_status_inherit_disclaimed(cmd: &mut Command) -> io::Result<ExitStatus> {
+    let pid = spawn_pid_inherit_disclaimed(cmd)?;
     wait_for(pid)
+}
+
+/// Spawn `cmd` with stdio inherited and TCC responsibility disclaimed,
+/// WITHOUT waiting for the child to exit (fire-and-forget) — the macOS
+/// implementation behind [`super::super::disclaimed_spawn_detached`].
+///
+/// Why: issue #3126 — the TUI health screen's `[S]` key spawns a detached
+/// `cargo run` child it never waits on, so it needs the disclaim setup
+/// without the blocking [`wait_for`] that [`spawn_status_inherit_disclaimed`]
+/// performs.
+/// What: identical setup to [`spawn_status_inherit_disclaimed`] (argv/envp/
+/// cwd/disclaim via [`spawn_pid_inherit_disclaimed`]) but discards the pid
+/// after a successful `posix_spawnp` instead of reaping it — matching the
+/// un-awaited `std::process::Child` this replaces, whose caller already
+/// dropped it without calling `wait()`.
+/// Test: `super::super::tests::disclaimed_spawn_detached_*`.
+pub(crate) fn spawn_detached_disclaimed(cmd: &mut Command) -> io::Result<()> {
+    spawn_pid_inherit_disclaimed(cmd)?;
+    Ok(())
 }

--- a/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
@@ -154,8 +154,11 @@ pub fn disclaimed_status(
 /// launches a detached `cargo run -p trusty-search -- start` / `cargo run -p
 /// trusty-memory` child and never waits on it, so it fit none of the other
 /// three disclaim shapes (capture-to-completion, wait-for-status, or
-/// long-lived piped) — the last undisclaimed `Command::new(..).spawn()` call
-/// site in the crate (issue #2997 part 5, #3126).
+/// long-lived piped) — the last undisclaimed spawn site in the TUI/
+/// session-launch call graph (issue #2997 part 5, #3126). Two undisclaimed
+/// spawn sites remain elsewhere in the crate (`provisioner::clone_progress`,
+/// `formatters::info_box::probes::run_git_log`); tracked as #2997 part 6,
+/// issue #3267.
 /// What: on macOS, builds a `Command` for `program`/`args` with stdio left at
 /// the default (inherited from the caller, matching the pre-existing
 /// `.spawn()` call this replaces) and spawns it via `posix_spawnp` with the

--- a/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/mod.rs
@@ -46,7 +46,11 @@
 //! inherited-stdio path (`standalone::run::build_launch_command` /
 //! `build_login_command`), AND the daemon's default actor-managed session
 //! backend ([`crate::control::backend::stream_json::StreamJsonBackend`]) —
-//! every known `claude`-spawning call site in the crate now disclaims.
+//! every known `claude`-spawning call site in the crate now disclaims. As of
+//! #3126 [`disclaimed_spawn_detached`] adds the TUI health screen's `[S]` key
+//! (`tui::event_loop::health_start`, a detached `cargo run` child never
+//! waited on) — the last undisclaimed spawn site found by the #2997 part 5
+//! sweep.
 //! Test: `disclaimed_output_captures_stdout`,
 //! `disclaimed_output_captures_stderr_and_nonzero_exit`,
 //! `disclaimed_output_saturates_stdout_and_stderr_without_deadlock`,
@@ -58,7 +62,11 @@
 //! in this module's `tests`); `spawn_piped_disclaimed_writes_and_reads_via_cat`
 //! and its siblings in `macos::piped` (piped path, macOS-only);
 //! `disclaimed_piped_spawn_native_path_round_trips` (piped path, any OS —
-//! exercises the exact code path Linux always takes).
+//! exercises the exact code path Linux always takes);
+//! `disclaimed_spawn_detached_returns_ok_for_true`,
+//! `disclaimed_spawn_detached_reports_spawn_error_for_missing_binary`,
+//! `disclaimed_spawn_detached_disable_env_forces_plain_path` (macOS-only,
+//! this module's `tests`).
 
 /// Environment variable that, when set to any value, forces
 /// [`disclaimed_output`]/[`disclaimed_status`]/[`disclaimed_piped_spawn`]
@@ -134,6 +142,46 @@ pub fn disclaimed_status(
         }
     }
     cmd.status()
+}
+
+/// Spawn `program` with `args` detached from the current process — a
+/// fire-and-forget spawn, matching `Command::spawn()`'s semantics of
+/// returning immediately without waiting for the child — and, on macOS,
+/// disclaim TCC responsibility exactly like [`disclaimed_output`]/
+/// [`disclaimed_status`].
+///
+/// Why: the TUI health screen's `[S]` key (`tui::event_loop::health_start`)
+/// launches a detached `cargo run -p trusty-search -- start` / `cargo run -p
+/// trusty-memory` child and never waits on it, so it fit none of the other
+/// three disclaim shapes (capture-to-completion, wait-for-status, or
+/// long-lived piped) — the last undisclaimed `Command::new(..).spawn()` call
+/// site in the crate (issue #2997 part 5, #3126).
+/// What: on macOS, builds a `Command` for `program`/`args` with stdio left at
+/// the default (inherited from the caller, matching the pre-existing
+/// `.spawn()` call this replaces) and spawns it via `posix_spawnp` with the
+/// disclaim attribute set, discarding the pid without waiting on it — the
+/// child is reaped later either by an unrelated `waitpid` or, once `tm`
+/// itself exits, by init/launchd, exactly as the un-awaited
+/// `std::process::Child` this replaces already behaved (its caller dropped
+/// the `Child` without calling `wait()`). On non-macOS, or with
+/// [`DISABLE_ENV`] set, delegates straight to `Command::spawn()` and drops
+/// the `Child` the same way.
+/// Test: `disclaimed_spawn_detached_returns_ok_for_true`,
+/// `disclaimed_spawn_detached_reports_spawn_error_for_missing_binary`,
+/// `disclaimed_spawn_detached_disable_env_forces_plain_path`.
+pub fn disclaimed_spawn_detached(program: &str, args: &[&str]) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        if std::env::var_os(DISABLE_ENV).is_none() {
+            let mut cmd = std::process::Command::new(program);
+            cmd.args(args);
+            return macos::spawn_detached_disclaimed(&mut cmd);
+        }
+    }
+    std::process::Command::new(program)
+        .args(args)
+        .spawn()
+        .map(|_| ())
 }
 
 /// Trait-object alias for a spawned child's writable stdin, uniform across
@@ -533,6 +581,37 @@ mod tests {
         // the pid (the SAFETY comment in start_kill establishes this is the
         // only code path that could touch a reused pid).
         assert!(spawned.handle.start_kill().is_ok());
+    }
+
+    // --- disclaimed_spawn_detached (issue #3126: TUI health-screen `[S]` cargo spawn) ---
+
+    #[test]
+    #[serial_test::serial]
+    fn disclaimed_spawn_detached_returns_ok_for_true() {
+        // `/usr/bin/true` exits immediately; a detached spawn must report
+        // `Ok(())` without blocking on the child's exit.
+        assert!(disclaimed_spawn_detached("/usr/bin/true", &[]).is_ok());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disclaimed_spawn_detached_reports_spawn_error_for_missing_binary() {
+        let err = disclaimed_spawn_detached("/nonexistent/definitely-not-a-real-binary-3126", &[])
+            .expect_err("spawning a missing binary must error, not hang or panic");
+        assert!(matches!(
+            err.kind(),
+            std::io::ErrorKind::NotFound | std::io::ErrorKind::Other
+        ));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn disclaimed_spawn_detached_disable_env_forces_plain_path() {
+        // SAFETY: single-threaded test setup around the env toggle.
+        unsafe { std::env::set_var(DISABLE_ENV, "1") };
+        let result = disclaimed_spawn_detached("/usr/bin/true", &[]);
+        unsafe { std::env::remove_var(DISABLE_ENV) };
+        assert!(result.is_ok());
     }
 }
 

--- a/crates/trusty-mpm/src/tui/event_loop.rs
+++ b/crates/trusty-mpm/src/tui/event_loop.rs
@@ -304,7 +304,8 @@ pub(super) async fn refresh_health_data(screen: &mut health::HealthScreen) {
 /// spawn routes through [`crate::core::spawn_disclaim::disclaimed_spawn_detached`]
 /// (issue #3126) so macOS TCC does not attribute the child `cargo build`'s
 /// file access back to the signed `trusty-mpm` daemon — this was the last
-/// undisclaimed `Command::new(..).spawn()` call site in the crate.
+/// undisclaimed spawn site in the TUI/session-launch call graph (two sites
+/// remain elsewhere in the crate, tracked as #2997 part 6, issue #3267).
 /// What: spawns the appropriate `cargo run` child detached from the TUI and
 /// records the outcome in `chat.last_action`. A spawn failure is recorded
 /// rather than panicking.

--- a/crates/trusty-mpm/src/tui/event_loop.rs
+++ b/crates/trusty-mpm/src/tui/event_loop.rs
@@ -300,12 +300,17 @@ pub(super) async fn refresh_health_data(screen: &mut health::HealthScreen) {
 /// Spawn the focused daemon's start command as a detached child process.
 ///
 /// Why: the `[S]` key starts a stopped daemon; the ticket specifies launching
-/// `cargo run -p trusty-search -- start` / `cargo run -p trusty-memory`.
+/// `cargo run -p trusty-search -- start` / `cargo run -p trusty-memory`. The
+/// spawn routes through [`crate::core::spawn_disclaim::disclaimed_spawn_detached`]
+/// (issue #3126) so macOS TCC does not attribute the child `cargo build`'s
+/// file access back to the signed `trusty-mpm` daemon — this was the last
+/// undisclaimed `Command::new(..).spawn()` call site in the crate.
 /// What: spawns the appropriate `cargo run` child detached from the TUI and
 /// records the outcome in `chat.last_action`. A spawn failure is recorded
 /// rather than panicking.
 /// Test: `health_start` is side-effecting (spawns a process); the action-string
-/// recording is exercised manually.
+/// recording is exercised manually. The disclaim itself is covered by
+/// `disclaimed_spawn_detached_*` in `crate::core::spawn_disclaim`.
 pub(super) fn health_start(chat: &mut DashboardState, hp: &HealthScreen) {
     let (label, args): (&str, &[&str]) = match hp.focus {
         Daemon::Search => (
@@ -314,8 +319,8 @@ pub(super) fn health_start(chat: &mut DashboardState, hp: &HealthScreen) {
         ),
         Daemon::Memory => ("trusty-memory", &["run", "-p", "trusty-memory"]),
     };
-    match std::process::Command::new("cargo").args(args).spawn() {
-        Ok(_) => {
+    match crate::core::spawn_disclaim::disclaimed_spawn_detached("cargo", args) {
+        Ok(()) => {
             tracing::info!("health screen: spawned {label}");
             chat.last_action = Some(format!("starting {label}…"));
         }


### PR DESCRIPTION
## Summary

Routes the TUI health screen's `[S]`-key `cargo run` spawn (`tui::event_loop::health_start`) through the existing `spawn_disclaim` helper so macOS TCC does not attribute the child `cargo build`'s file access back to the signed `trusty-mpm` daemon. This was the last undisclaimed spawn site in the TUI/session-launch call graph (see #2721 / #2957 / #3037 for the prior #2997 parts). Two undisclaimed spawn sites remain elsewhere in the crate (`provisioner::clone_progress::clone_with_progress`, `formatters::info_box::probes::run_git_log`) — tracked as follow-up #3267 (#2997 part 6).

- Adds `disclaimed_spawn_detached(program, args)` to `crates/trusty-mpm/src/core/spawn_disclaim/mod.rs`, matching the existing `disclaimed_output`/`disclaimed_status` shape (including the `TM_DISABLE_SPAWN_DISCLAIM` escape hatch), for the fire-and-forget spawn case that `health_start` needs (spawn detached, never wait on the child).
- Refactors the macOS `status.rs` implementation to share a common `spawn_pid_inherit_disclaimed` helper between `spawn_status_inherit_disclaimed` (waits) and the new `spawn_detached_disclaimed` (does not wait) — same argv/envp/cwd reconstruction and disclaim-SPI setup, no logic duplicated.
- `health_start` now calls `crate::core::spawn_disclaim::disclaimed_spawn_detached("cargo", args)` instead of `std::process::Command::new("cargo").args(args).spawn()`.
- Adds `disclaimed_spawn_detached_returns_ok_for_true`, `disclaimed_spawn_detached_reports_spawn_error_for_missing_binary`, and `disclaimed_spawn_detached_disable_env_forces_plain_path` tests.
- CHANGELOG entry under `[Unreleased] / Fixed`.

Closes #3126

## Test plan

- [x] `cargo check -p trusty-mpm`
- [x] `cargo test -p trusty-mpm` — 1097 passed, 0 failed (full suite, run twice; an initial run surfaced one unrelated flaky test in `commands::statusline::branch` that passes in isolation and on rerun — a pre-existing parallel-execution race unrelated to this change)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 10 allowlisted, 0 violations — OK.`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools