### PR TITLE
feat(trusty-agents): wire trusty-mpm MCP tools into agent config; prune stale gworkspace service list

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
@@ -44,6 +44,13 @@ allow = [
   "granola_*",
   # web search
   "web_search",
+  # trusty-mpm (#3203) — read-only subset only, per the base's read-only
+  # posture (see the `scopes` note below); session_send/agent_delegate are
+  # left to cto-assistant's broader, write-capable allowlist.
+  "session_list",
+  "session_status",
+  "project_list",
+  "console_metrics",
   # gworkspace — Gmail
   "compose_email",
   "download_gmail_attachment",

--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
@@ -59,6 +59,16 @@ allow = [
     "get_gmail_message_content",
     "modify_gmail_messages",
     "create_draft",
+    # trusty-mpm (#3203) — full curated set; cto-assistant already has a
+    # broader write-capable posture (create_ticket, modify_gmail_messages,
+    # create_task, ...), so session_send (drive a pane) and agent_delegate
+    # (tracking/gating only) are included alongside the read-only tools.
+    "session_list",
+    "session_status",
+    "session_send",
+    "project_list",
+    "agent_delegate",
+    "console_metrics",
 ]
 
 [system_prompt]

--- a/crates/trusty-agents/assets/config/default-config.toml
+++ b/crates/trusty-agents/assets/config/default-config.toml
@@ -9,101 +9,88 @@ inject_for_roles = ["ctrl", "pm", "research", "observe"]
 # (kuzu-memory, mcp-vector-search) are handled by the harness directly and
 # do not appear here.
 
-# gworkspace-mcp — the NATIVE in-workspace stdio MCP server built from crate
-# `trusty-gworkspace` (bin `trusty-gworkspace-mcp`,
-# src/bin/trusty-gworkspace-mcp.rs). Per ADR-0014 (native Rust MCP, PR #2624)
-# this repoints off the retired external Python upstream: the native binary is
-# a pure stdio server that takes NO subcommand, so `args = []` (the old
-# external upstream required `["mcp"]`).
+# gworkspace-mcp — REMOVED (#3204). This used to be a static `[[mcp.services]]`
+# stdio entry (command = "trusty-gworkspace-mcp") carrying a hand-written tool
+# list (`gmail_search`, `calendar_list`, `docs_read`, `sheets_read`,
+# `tasks_list`, ...) that had drifted from the real binary's tool surface —
+# the actual `trusty-gworkspace-mcp` tools are named `compose_email`,
+# `search_gmail_messages`, `manage_calendars`, `get_document`, etc. (see the
+# `assistant`/`cto-assistant` agent.toml `[tools].allow` lists, and
+# `crates/trusty-gworkspace/src/tools.rs`). That mismatch was not cosmetic:
+# `mcp_service_tool_executors()` (crates/trusty-agents/src/tools/
+# mcp_service_tools.rs) spawns the service's `command` and calls
+# `tools/call` using EXACTLY the names listed under `[[mcp.services.tools]]`,
+# so every one of those stale names would have failed against the live server
+# with a "method not found"-style error.
 #
-# Issue #2644: the native binary was renamed from `gworkspace-mcp` to
-# `trusty-gworkspace-mcp` to disambiguate it from the legacy pipx-installed
-# Python package, which previously shared the same name on $PATH. The service
-# `name` below stays `gworkspace-mcp` (registry identifier only); `command`
-# now targets the renamed binary.
+# The LIVE, self-discovering path for gworkspace is the OpenRPC
+# `[[tool_registry.endpoints]]` entry named "gworkspace" below (search this
+# file for `name = "gworkspace"`), which calls `rpc.discover` against the
+# running `trusty-gworkspace-mcp` binary and always reflects its real tool
+# surface — no static list to drift. Do not re-add a `[[mcp.services]]`
+# block for gworkspace; extend the OpenRPC endpoint's `scopes` instead.
+#
+# slack-user-proxy retired per ADR-0014 (native Rust MCP, PR #2624): it was a
+# disabled external (Python) stdio stub with no native in-workspace successor,
+# so it is dropped rather than repointed.
+
+# trusty-mpm — the native session-orchestration + project-registry MCP server
+# (crate `trusty-mpm`, bin `trusty-mpm`). `serve --stdio` is a thin bridge:
+# it ensures the trusty-mpm daemon is running, then forwards JSON-RPC framing
+# to the daemon's loopback `POST /rpc` (crates/trusty-mpm/src/mcp/mod.rs,
+# crates/trusty-mpm/src/daemon/mcp_backend.rs). The repo-root `.mcp.json`
+# already wires this exact command for Claude Code itself (`.mcp.json:9-15`);
+# this block gives trusty-agents personas the identical MCP surface.
+#
+# Issue #3203: curated, safe subset of the full 31-tool catalog
+# (crates/trusty-mpm/src/mcp/tools/{core,session,console,project,proxy}.rs —
+# see `TOOL_CATALOG` in `tools/mod.rs` for the authoritative name list).
+# INCLUDED — read-only or clearly non-destructive: `session_list`,
+# `session_status`, `session_send` (drives an existing pane; does not
+# create/destroy sessions), `project_list`, `agent_delegate` (tracking/gating
+# only — its own description states it "does not spawn" anything), and
+# `console_metrics`. EXCLUDED: `session_new` / `session_stop` /
+# `session_resume` / `session_decommission*` / `session_delete` /
+# `session_prune` (real tmux-session lifecycle mutation — too consequential
+# for a static default allowlist), `config_read` / `config_write` /
+# `auto_resume_set` / `project_register` (mutate on-disk daemon config or the
+# project registry), `memory_protect` / `hook_event` / `circuit_breaker_status`
+# (internal daemon-instrumentation/ops surface, not agent-facing), the
+# bug-reporting trio `list_recent_errors` / `preview_bug_report` /
+# `report_bug` (`report_bug` files public GitHub issues and needs an
+# explicit human-gated flow, not a default tool), and the `session_proxy_*`
+# quartet (channel-proxy focus state — out of scope for this MVP wiring).
 [[mcp.services]]
-name = "gworkspace-mcp"
-description = "Google Workspace (native trusty-gworkspace) — Gmail, Calendar, Drive, Docs, Sheets, Tasks"
-command = "trusty-gworkspace-mcp"
-args = []
+name = "trusty-mpm"
+description = "trusty-mpm session orchestration + project registry (native MCP)"
+command = "trusty-mpm"
+args = ["serve", "--stdio"]
 transport = "stdio"
 enabled = true
 
 [[mcp.services.tools]]
-name = "gmail_search"
-description = "Search Gmail messages by query"
+name = "session_list"
+description = "List all Claude Code sessions the trusty-mpm daemon is managing, with status, working directory, and active delegation count."
 
 [[mcp.services.tools]]
-name = "gmail_send"
-description = "Send an email via Gmail"
+name = "session_status"
+description = "Get detailed status for one session: uptime, token usage, current agent, memory pressure, and last activity."
 
 [[mcp.services.tools]]
-name = "gmail_read"
-description = "Read a Gmail message by ID"
+name = "session_send"
+description = "Send a line of text into a managed session's tmux pane (followed by Enter), e.g. to answer a prompt or drive the harness."
 
 [[mcp.services.tools]]
-name = "gmail_list"
-description = "List Gmail messages with optional filters"
+name = "project_list"
+description = "List all projects registered in the project registry."
 
 [[mcp.services.tools]]
-name = "calendar_list"
-description = "List Google Calendar events"
+name = "agent_delegate"
+description = "Record and gate a delegation to a named agent: applies the circuit-breaker and depth limits. Tracking/gating only — does not spawn the agent."
 
 [[mcp.services.tools]]
-name = "calendar_create"
-description = "Create a Google Calendar event"
-
-[[mcp.services.tools]]
-name = "calendar_update"
-description = "Update an existing calendar event"
-
-[[mcp.services.tools]]
-name = "drive_search"
-description = "Search Google Drive files"
-
-[[mcp.services.tools]]
-name = "drive_read"
-description = "Read a Google Drive file"
-
-[[mcp.services.tools]]
-name = "drive_create"
-description = "Create a file in Google Drive"
-
-[[mcp.services.tools]]
-name = "docs_read"
-description = "Read a Google Doc"
-
-[[mcp.services.tools]]
-name = "docs_create"
-description = "Create a new Google Doc"
-
-[[mcp.services.tools]]
-name = "docs_update"
-description = "Update content in a Google Doc"
-
-[[mcp.services.tools]]
-name = "sheets_read"
-description = "Read data from Google Sheets"
-
-[[mcp.services.tools]]
-name = "sheets_update"
-description = "Write data to Google Sheets"
-
-[[mcp.services.tools]]
-name = "tasks_list"
-description = "List Google Tasks"
-
-[[mcp.services.tools]]
-name = "tasks_create"
-description = "Create a Google Task"
-
-[[mcp.services.tools]]
-name = "tasks_complete"
-description = "Mark a Google Task as complete"
-
-# slack-user-proxy retired per ADR-0014 (native Rust MCP, PR #2624): it was a
-# disabled external (Python) stdio stub with no native in-workspace successor,
-# so it is dropped rather than repointed.
+name = "console_metrics"
+description = "Return the standard trusty-console metrics report for trusty-mpm: health status plus the managed-session fleet snapshot."
 
 # Granola — meeting notes, transcripts, and action items (#256).
 # Enabled by default; harmless when the binary is absent (the harness

--- a/crates/trusty-agents/assets/config/default-config.toml
+++ b/crates/trusty-agents/assets/config/default-config.toml
@@ -78,19 +78,19 @@ description = "Get detailed status for one session: uptime, token usage, current
 
 [[mcp.services.tools]]
 name = "session_send"
-description = "Send a line of text into a managed session's tmux pane (followed by Enter), e.g. to answer a prompt or drive the harness."
+description = "Send a line of text into a managed session's tmux pane (followed by Enter), e.g. to answer a prompt or drive the harness. Returns a confirmation with the target tmux session name."
 
 [[mcp.services.tools]]
 name = "project_list"
-description = "List all projects registered in the project registry."
+description = "List all projects registered in the project registry. Returns a JSON array of project objects, each with `name`, `repo_url`, `default_branch`, and optional `stack_hint`, `tags`, `description`, and `gh_user` (the project's preferred GitHub account login, #2081)."
 
 [[mcp.services.tools]]
 name = "agent_delegate"
-description = "Record and gate a delegation to a named agent: applies the circuit-breaker and depth limits. Tracking/gating only — does not spawn the agent."
+description = "Record and gate a delegation to a named agent: applies the circuit-breaker and depth limits and adds the delegation to the session's dashboard tree. This is a TRACKING/GATING companion, NOT an execution path — it does not spawn the agent. Execution happens via the native Agent/Task tool using the deployed agent name (from ~/.claude/agents/), e.g. Agent(subagent_type=\"rust-engineer\")."
 
 [[mcp.services.tools]]
 name = "console_metrics"
-description = "Return the standard trusty-console metrics report for trusty-mpm: health status plus the managed-session fleet snapshot."
+description = "Return the standard trusty-console metrics report for trusty-mpm: service id, display name, version, coarse health status, and a `metrics` payload carrying the managed-session fleet snapshot (counts by lifecycle state) and the supervisor auto-resume control state. Polled uniformly by trusty-console for the dashboard."
 
 # Granola — meeting notes, transcripts, and action items (#256).
 # Enabled by default; harmless when the binary is absent (the harness

--- a/crates/trusty-agents/src/mcp/config/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/mod.rs
@@ -8,7 +8,7 @@
 //! What: `GlobalConfig` is the on-disk schema (formerly `McpConfig`; renamed
 //! in #245 to reflect that it composes multiple subsystems — MCP registry +
 //! GitHub identities — rather than only MCP). `load_or_create()` creates the
-//! file with default content (native gworkspace-mcp enabled) when missing.
+//! file with default content (native trusty-mpm enabled, #3203) when missing.
 //! The registry only lists *remote/service-tier*
 //! MCPs that agents should know about — local native integrations
 //! (kuzu-memory, mcp-vector-search) are wired into the harness directly and
@@ -176,7 +176,7 @@ impl GlobalConfig {
     /// changes made via the `mcp_*` tools. When the file is missing the
     /// prompt-build path must not fail — and previously it returned an empty
     /// registry (`Self::default()`), which silently dropped the documented
-    /// native gworkspace-mcp defaults from in-memory state. We
+    /// native trusty-mpm defaults from in-memory state. We
     /// now parse `DEFAULT_CONFIG_TOML` so the in-memory defaults match what
     /// `load_or_create` would write to disk. Parse failure (a programmer
     /// error in the literal) falls back to `Self::default()` rather than

--- a/crates/trusty-agents/src/mcp/config/tests/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/mod.rs
@@ -44,23 +44,31 @@ async fn load_or_create_writes_default_when_absent() {
         "config file should exist after load_or_create"
     );
 
-    // Defaults after ADR-0014 (#256, native-MCP retire): gworkspace-mcp
-    // (enabled, native), granola-notes (enabled), duetto-memory (disabled).
-    // slack-user-proxy was retired as a dead external stub.
+    // Defaults after ADR-0014 (#256, native-MCP retire) + #3203/#3204:
+    // trusty-mpm (enabled, native), granola-notes (enabled), duetto-memory
+    // (disabled). slack-user-proxy was retired as a dead external stub;
+    // gworkspace-mcp was removed (#3204) — its static tool list had drifted
+    // from the real binary and is superseded by the OpenRPC "gworkspace"
+    // tool_registry.endpoints entry.
     assert_eq!(cfg.mcp.services.len(), 3);
-    let gw = cfg
+    let tm = cfg
         .mcp
         .services
         .iter()
-        .find(|s| s.name == "gworkspace-mcp")
-        .expect("gworkspace-mcp present in defaults");
-    assert!(gw.enabled);
+        .find(|s| s.name == "trusty-mpm")
+        .expect("trusty-mpm present in defaults (#3203)");
+    assert!(tm.enabled);
     assert!(
         !cfg.mcp
             .services
             .iter()
             .any(|s| s.name == "slack-user-proxy"),
         "slack-user-proxy retired per ADR-0014"
+    );
+    assert!(
+        !cfg.mcp.services.iter().any(|s| s.name == "gworkspace-mcp"),
+        "gworkspace-mcp mcp.services entry removed (#3204); live path is the \
+         OpenRPC tool_registry.endpoints \"gworkspace\" entry"
     );
     let granola = cfg
         .mcp
@@ -137,7 +145,7 @@ enabled = true
 #[tokio::test]
 async fn load_returns_documented_defaults_when_absent() {
     // (#244, #245) load() must not create the file (unlike load_or_create),
-    // but must return the documented defaults (native gworkspace-mcp,
+    // but must return the documented defaults (native trusty-mpm,
     // granola-notes, duetto-memory) so prompt-build paths see the same registry
     // that `load_or_create` would write.
     let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -148,10 +156,12 @@ async fn load_returns_documented_defaults_when_absent() {
     let cfg = GlobalConfig::load().await;
     let path = home.join(".trusty-agents").join("config.toml");
     assert!(!path.exists(), "load() must not create the config file");
-    // #245/#256 + ADR-0014: defaults mirror DEFAULT_CONFIG_TOML — 3 services
-    // (gworkspace-mcp, granola-notes, duetto-memory) after slack-user-proxy retire.
+    // #245/#256 + ADR-0014 + #3203/#3204: defaults mirror DEFAULT_CONFIG_TOML —
+    // 3 services (trusty-mpm, granola-notes, duetto-memory) after
+    // slack-user-proxy retire and gworkspace-mcp removal.
     assert_eq!(cfg.mcp.services.len(), 3);
-    assert!(cfg.mcp.services.iter().any(|s| s.name == "gworkspace-mcp"));
+    assert!(cfg.mcp.services.iter().any(|s| s.name == "trusty-mpm"));
+    assert!(!cfg.mcp.services.iter().any(|s| s.name == "gworkspace-mcp"));
     assert!(
         !cfg.mcp
             .services

--- a/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
@@ -316,4 +316,33 @@ fn trusty_mpm_service_tool_names_match_expected_curated_list() {
          list; update EXPECTED_TRUSTY_MPM_TOOLS here AND cross-check against \
          crates/trusty-mpm/src/mcp/tools/mod.rs::TOOL_CATALOG"
     );
+
+    // Safety-relevant substring check: `mcp_service_tool_executors()` feeds
+    // this description to the LLM VERBATIM as the tool's function
+    // description (crates/trusty-agents/src/tools/mcp_service_tools.rs), so
+    // it is behavior-relevant, not decorative. `agent_delegate`'s verbatim
+    // source description (crates/trusty-mpm/src/mcp/tools/core.rs) carries a
+    // load-bearing correction: it clarifies the tool is TRACKING/GATING only
+    // and does NOT execute the agent — without it, the LLM could believe
+    // calling `agent_delegate` is sufficient to run the agent and skip the
+    // native Agent/Task tool call entirely. Guard against a future paraphrase
+    // silently dropping that guidance.
+    let agent_delegate_desc = svc
+        .tools
+        .iter()
+        .find(|t| t.name == "agent_delegate")
+        .expect("agent_delegate tool present")
+        .description
+        .as_str();
+    assert!(
+        agent_delegate_desc.contains("does not spawn"),
+        "agent_delegate description must retain 'does not spawn' \
+         (mcp_service_tool_executors() feeds this text to the LLM verbatim): {agent_delegate_desc}"
+    );
+    assert!(
+        agent_delegate_desc.contains("Agent/Task tool"),
+        "agent_delegate description must retain the pointer to the native \
+         Agent/Task tool (mcp_service_tool_executors() feeds this text to \
+         the LLM verbatim): {agent_delegate_desc}"
+    );
 }

--- a/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
@@ -234,25 +234,32 @@ fn default_config_includes_local_inference_section() {
 #[test]
 fn default_config_is_valid_toml() {
     let cfg = GlobalConfig::from_toml_str(DEFAULT_CONFIG_TOML).expect("default parses");
-    // ADR-0014: 3 services after slack-user-proxy retire.
+    // ADR-0014 + #3203/#3204: 3 services after slack-user-proxy retire and
+    // the gworkspace-mcp → trusty-mpm swap (gworkspace-mcp's static tool list
+    // had drifted from the real binary; trusty-mpm's is fresh, see #3203).
     assert_eq!(cfg.mcp.services.len(), 3);
-    let gw = cfg
+    let tm = cfg
         .mcp
         .services
         .iter()
-        .find(|s| s.name == "gworkspace-mcp")
-        .expect("gworkspace-mcp present");
-    assert!(gw.enabled);
-    // Native gworkspace-mcp takes no subcommand (external upstream used ["mcp"]).
-    assert!(gw.args.is_empty(), "native gworkspace-mcp takes no args");
-    assert!(gw.tools.iter().any(|t| t.name == "gmail_search"));
-    assert!(gw.tools.iter().any(|t| t.name == "calendar_list"));
+        .find(|s| s.name == "trusty-mpm")
+        .expect("trusty-mpm present");
+    assert!(tm.enabled);
+    assert_eq!(tm.command, "trusty-mpm");
+    assert_eq!(tm.args, vec!["serve".to_string(), "--stdio".to_string()]);
+    assert!(tm.tools.iter().any(|t| t.name == "session_list"));
+    assert!(tm.tools.iter().any(|t| t.name == "agent_delegate"));
     assert!(
         !cfg.mcp
             .services
             .iter()
             .any(|s| s.name == "slack-user-proxy"),
         "slack-user-proxy retired per ADR-0014"
+    );
+    assert!(
+        !cfg.mcp.services.iter().any(|s| s.name == "gworkspace-mcp"),
+        "gworkspace-mcp mcp.services entry removed (#3204); live path is the \
+         OpenRPC tool_registry.endpoints \"gworkspace\" entry"
     );
     // Native local integrations stay out of the registry.
     assert!(!cfg.mcp.services.iter().any(|s| s.name == "kuzu-memory"));
@@ -261,5 +268,52 @@ fn default_config_is_valid_toml() {
             .services
             .iter()
             .any(|s| s.name == "mcp-vector-search")
+    );
+}
+
+/// Drift guard (#3203): freeze the curated `trusty-mpm` static tool list as a
+/// checked-in expected set so a silent typo, addition, or removal in
+/// `default-config.toml` fails CI.
+///
+/// Why: the ideal guard would assert directly against
+/// `trusty_mpm::mcp::tools::TOOL_CATALOG`, but `trusty-agents` does not
+/// currently depend on `trusty-mpm` (and `trusty-mpm` does not depend on
+/// `trusty-agents` either — no cycle risk); adding it as a dev-dependency
+/// purely for this one assertion would pull `trusty-mpm`'s full
+/// daemon/tui/telegram/slack dependency graph into every `cargo test -p
+/// trusty-agents` run, which is disproportionate for an Effort:S ticket. This
+/// checked-in-list approach is the cheaper option named in #3203 — it still
+/// catches accidental drift in this file, just not a rename inside
+/// `trusty-mpm` itself (a human cross-checks that case against
+/// `crates/trusty-mpm/src/mcp/tools/mod.rs::TOOL_CATALOG` when touching
+/// either side).
+/// What: parses `DEFAULT_CONFIG_TOML`, finds the `trusty-mpm` service, and
+/// asserts its tool names equal `EXPECTED_TRUSTY_MPM_TOOLS` verbatim
+/// (order-sensitive, matching the file).
+/// Test: this test.
+#[test]
+fn trusty_mpm_service_tool_names_match_expected_curated_list() {
+    const EXPECTED_TRUSTY_MPM_TOOLS: [&str; 6] = [
+        "session_list",
+        "session_status",
+        "session_send",
+        "project_list",
+        "agent_delegate",
+        "console_metrics",
+    ];
+    let cfg = GlobalConfig::from_toml_str(DEFAULT_CONFIG_TOML).expect("default parses");
+    let svc = cfg
+        .mcp
+        .services
+        .iter()
+        .find(|s| s.name == "trusty-mpm")
+        .expect("trusty-mpm service present in defaults (#3203)");
+    let names: Vec<&str> = svc.tools.iter().map(|t| t.name.as_str()).collect();
+    assert_eq!(
+        names,
+        EXPECTED_TRUSTY_MPM_TOOLS.to_vec(),
+        "trusty-mpm mcp.services.tools drifted from the checked-in expected \
+         list; update EXPECTED_TRUSTY_MPM_TOOLS here AND cross-check against \
+         crates/trusty-mpm/src/mcp/tools/mod.rs::TOOL_CATALOG"
     );
 }

--- a/crates/trusty-agents/src/tools/mcp_tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/mod.rs
@@ -108,7 +108,7 @@ mod tests {
         assert!(out.contains("beta"));
 
         // Verify it persists by reloading. Note: #245 — load() now returns
-        // documented defaults (native gworkspace-mcp, granola-notes,
+        // documented defaults (native trusty-mpm, granola-notes,
         // duetto-memory) when the file doesn't exist, so mcp_add against a
         // missing file persists those defaults plus the new "beta" service.
         let reloaded = GlobalConfig::load().await;


### PR DESCRIPTION
## Summary

MVP work under epic #3052 (trusty-agents Assistant). Two related changes to `crates/trusty-agents/assets/config/default-config.toml` and the agents that consume it:

**T1 — wire trusty-mpm as an agent MCP tool (Closes #3203).** Adds a `[[mcp.services]]` entry (`name = "trusty-mpm"`, `command = "trusty-mpm"`, `args = ["serve", "--stdio"]`, `transport = "stdio"`) mirroring the exact command the repo-root `.mcp.json` already uses for Claude Code itself (`.mcp.json:9-15`). `trusty-mpm serve --stdio` is a thin bridge that ensures the daemon is up and forwards JSON-RPC to the daemon's loopback `POST /rpc`.

**T2 — prune the stale gworkspace `[[mcp.services]]` tool list (Closes #3204).** Removed the old `gworkspace-mcp` static service entry entirely. Its tool names (`gmail_search`, `calendar_list`, `docs_read`, `sheets_read`, `tasks_list`, ...) had drifted from the real `trusty-gworkspace-mcp` binary's actual tool surface (`compose_email`, `search_gmail_messages`, `manage_calendars`, `get_document`, ...). This wasn't just cosmetic drift: `mcp_service_tool_executors()` (`crates/trusty-agents/src/tools/mcp_service_tools.rs`) spawns the service's `command` and calls `tools/call` using exactly the names listed under `[[mcp.services.tools]]`, so every one of those stale names would fail against the live server with a "method not found"-style error. The live, self-discovering path is the already-enabled OpenRPC `[[tool_registry.endpoints]]` entry named `"gworkspace"` further down the same file, which calls `rpc.discover` against the running binary and always reflects its real tool surface — no static list to drift. Left a comment pointing future editors at that endpoint instead of re-adding a static `mcp.services` block for gworkspace.

## Tool subset chosen (T1) and rationale

Curated 6 of the 31 tools in `crates/trusty-mpm/src/mcp/tools/{core,session,console,project,proxy}.rs` (`TOOL_CATALOG`):

- `session_list`, `session_status` — read-only session introspection
- `session_send` — drives an *existing* session's pane; does not create/destroy sessions
- `project_list` — read-only project-registry listing
- `agent_delegate` — tracking/gating only; its own description states it "does not spawn" anything
- `console_metrics` — read-only fleet/health snapshot

**Excluded** (documented inline in the TOML): `session_new`/`stop`/`resume`/`decommission*`/`delete`/`prune` (real tmux-session lifecycle mutation — too consequential for a static default allowlist), `config_read`/`config_write`/`auto_resume_set`/`project_register` (mutate on-disk daemon config or the project registry), `memory_protect`/`hook_event`/`circuit_breaker_status` (internal daemon-instrumentation/ops surface), the bug-reporting trio `list_recent_errors`/`preview_bug_report`/`report_bug` (`report_bug` files public GitHub issues — needs an explicit human-gated flow), and the `session_proxy_*` quartet (channel-proxy focus state — out of scope for this MVP).

**Per-agent allowlists:**
- `assistant/agent.toml` (base, read-only Google-Workspace posture per `scopes = [..., "google.read"]`) gets the read-only subset only: `session_list`, `session_status`, `project_list`, `console_metrics`.
- `cto-assistant/agent.toml` (already has a broader write-capable posture — `create_ticket`, `modify_gmail_messages`, `create_task`, ...) gets the full curated set of 6, including `session_send` and `agent_delegate`.
- Note: a stale, pre-#482 flat duplicate `agents/cto-assistant.toml` also exists alongside the canonical `agents/cto-assistant/agent.toml` (dir-package form). Confirmed via the loader (`crates/trusty-agents/src/agents/loader.rs:99-105`, "#482: Prefer the directory-package format when present") that the dir form always wins for dispatch and the flat file is dead code for that path — left untouched as out-of-scope pre-existing cleanup, not touched by this PR.

## Drift-guard approach (item 4)

Added `trusty_mpm_service_tool_names_match_expected_curated_list` in `crates/trusty-agents/src/mcp/config/tests/render_tests.rs`: parses `DEFAULT_CONFIG_TOML` and asserts the `trusty-mpm` service's tool names equal a checked-in `EXPECTED_TRUSTY_MPM_TOOLS` list verbatim.

Did **not** wire a direct dependency on `trusty_mpm::mcp::tools::TOOL_CATALOG` (the stronger guard): confirmed there's no cycle risk (`trusty-mpm` depends on `trusty-agents-common`, not `trusty-agents`; `trusty-agents` currently depends on neither `trusty-mpm` nor `trusty-agents-common`... it does depend on `trusty-agents-common`, but not `trusty-mpm`), but adding `trusty-mpm` as a dev-dependency purely for one assertion would pull its full daemon/tui/telegram/slack dependency graph into every `cargo test -p trusty-agents` run — disproportionate for an Effort:S ticket. Documented the tradeoff inline; a human touching either side is expected to cross-check the two lists by hand.

## Smoke test

`trusty-mpm` (v0.19.25) is on `$PATH` in this environment. Ran a manual `initialize` + `tools/list` round-trip against `trusty-mpm serve --stdio`:

```
$ echo '<initialize>\n<tools/list>' | trusty-mpm serve --stdio
{"jsonrpc":"2.0","id":1,"result":{"capabilities":{"tools":{}},"protocolVersion":"2024-11-05","serverInfo":{"name":"trusty-mpm","version":"0.19.25"}}}
{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"session_list",...},{"name":"session_status",...},{"name":"agent_delegate",...},...,{"name":"session_send",...},...,{"name":"console_metrics",...},...,{"name":"project_list",...},...]}}
```

Confirmed all 31 catalog tools present, including all 6 chosen for the curated subset with descriptions matching what's now in `default-config.toml`.

## Test plan

- [x] `cargo check` (workspace) — clean
- [x] `cargo test -p trusty-agents mcp::config` — 18/18 passed (including the new drift-guard test)
- [x] `cargo test -p trusty-agents` (full suite) — 1811 passed, 0 failed, 8 ignored (API-key-gated, expected)
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — OK (10 allowlisted, 0 violations)
- [x] Manual `trusty-mpm serve --stdio` `tools/list` round-trip — confirmed live

🤖 Generated with [Claude Code](https://claude.com/claude-code)