### PR TITLE
feat(trusty-agents): live MCP server discovery + tool registration (mcp.services discover mode + .mcp.json)

### DIFF
--- a/crates/trusty-agents/assets/config/default-config.toml
+++ b/crates/trusty-agents/assets/config/default-config.toml
@@ -5,6 +5,16 @@
 # Agent roles that receive MCP tool descriptions in their system prompt
 inject_for_roles = ["ctrl", "pm", "research", "observe"]
 
+# SECURITY (#3266): whether live MCP discovery is allowed to auto-spawn
+# servers declared in a project's `.mcp.json`. Defaults to false — a
+# project's `.mcp.json` is repo-controlled, untrusted content; cloning a
+# hostile repo must never cause trusty-agents to execute arbitrary binaries
+# on every persona turn. The supported opt-in path is a per-server
+# `[[mcp.services]]` entry with `discover = true` below, which is an
+# explicit, operator-curated allowlist and is unaffected by this flag. Only
+# set this to true if you trust every project you point trusty-agents at.
+trust_project_mcp_json = false
+
 # Service-tier MCPs agents can reference. Local native integrations
 # (kuzu-memory, mcp-vector-search) are handled by the harness directly and
 # do not appear here.

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -139,6 +139,30 @@ pub async fn run_pm_task_with_persona(
                 }
             }
 
+            // #3238: live-discover MCP servers (`[[mcp.services]] discover =
+            // true` and `.mcp.json`) and register whatever tools they
+            // actually advertise, on top of everything registered above.
+            // `existing_names` seeds the dedup set so a live-discovered tool
+            // never shadows a tool already registered from another source.
+            {
+                let existing_names: std::collections::HashSet<String> = registry
+                    .schemas()
+                    .iter()
+                    .filter_map(|s| {
+                        s.get("function")
+                            .and_then(|f| f.get("name"))
+                            .and_then(|n| n.as_str())
+                            .map(String::from)
+                    })
+                    .collect();
+                for tool in
+                    crate::tools::mcp_live::live_mcp_tool_executors(project_path, &existing_names)
+                        .await
+                {
+                    registry.register(tool);
+                }
+            }
+
             let all_names: Vec<String> = registry
                 .schemas()
                 .into_iter()

--- a/crates/trusty-agents/src/init/seed/mcp.rs
+++ b/crates/trusty-agents/src/init/seed/mcp.rs
@@ -6,13 +6,13 @@
 //! Test: `seed_mcp_connections_indexes_servers` in `init::tests`.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 use anyhow::Result;
 use chrono::Utc;
 
 use super::{file_mtime_secs, render_mcp_description};
 use crate::init::{MCP_SEED_SESSION_ID, ProjectInitializer};
+use crate::mcp::mcp_json::{discover_mcp_json_paths, parse_mcp_json_servers};
 use crate::memory::{Embedder, MemoryStore, Segment};
 
 impl ProjectInitializer {
@@ -35,17 +35,7 @@ impl ProjectInitializer {
         store: &dyn MemoryStore,
         embedder: &dyn Embedder,
     ) -> Result<usize> {
-        let mut sources: Vec<PathBuf> = Vec::new();
-        let project_mcp = self.project_dir.join(".mcp.json");
-        if project_mcp.exists() {
-            sources.push(project_mcp);
-        }
-        if let Some(home) = std::env::var_os("HOME") {
-            let user_mcp = PathBuf::from(home).join(".claude").join(".mcp.json");
-            if user_mcp.exists() {
-                sources.push(user_mcp);
-            }
-        }
+        let sources = discover_mcp_json_paths(&self.project_dir);
         if sources.is_empty() {
             tracing::debug!("seed_mcp_connections: no .mcp.json present, skipping");
             return Ok(0);
@@ -72,8 +62,8 @@ impl ProjectInitializer {
                     continue;
                 }
             };
-            let parsed: serde_json::Value = match serde_json::from_str(&raw) {
-                Ok(v) => v,
+            let servers = match parse_mcp_json_servers(&raw) {
+                Ok(s) => s,
                 Err(e) => {
                     tracing::warn!(
                         error = %e,
@@ -83,17 +73,13 @@ impl ProjectInitializer {
                     continue;
                 }
             };
-
-            let servers = match parsed.get("mcpServers").and_then(|v| v.as_object()) {
-                Some(s) => s,
-                None => {
-                    tracing::debug!(
-                        path = %source.display(),
-                        "seed_mcp_connections: no mcpServers key, skipping"
-                    );
-                    continue;
-                }
-            };
+            if servers.is_empty() {
+                tracing::debug!(
+                    path = %source.display(),
+                    "seed_mcp_connections: no mcpServers key, skipping"
+                );
+                continue;
+            }
 
             let rel = source
                 .strip_prefix(&self.project_dir)
@@ -101,7 +87,8 @@ impl ProjectInitializer {
                 .to_string_lossy()
                 .to_string();
 
-            for (server_name, def) in servers {
+            for server in &servers {
+                let server_name = &server.name;
                 let track_key = format!("{rel}#{server_name}");
                 if let Some(prev) = seeded.get(&track_key)
                     && *prev >= mtime_secs
@@ -110,33 +97,16 @@ impl ProjectInitializer {
                     continue;
                 }
 
-                let command = def
-                    .get("command")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let args: Vec<String> = def
-                    .get("args")
-                    .and_then(|v| v.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter_map(|x| x.as_str().map(|s| s.to_string()))
-                            .collect()
-                    })
-                    .unwrap_or_default();
-                let description = def
-                    .get("description")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-                let env_keys: Vec<String> = def
-                    .get("env")
-                    .and_then(|v| v.as_object())
-                    .map(|o| o.keys().cloned().collect())
-                    .unwrap_or_default();
+                let description = server.description.clone().unwrap_or_default();
+                let env_keys: Vec<String> = server.env.keys().cloned().collect();
 
-                let content =
-                    render_mcp_description(server_name, &command, &args, &description, &env_keys);
+                let content = render_mcp_description(
+                    server_name,
+                    &server.command,
+                    &server.args,
+                    &description,
+                    &env_keys,
+                );
 
                 let vec = match embedder.embed_single(&content) {
                     Ok(v) => v,
@@ -155,8 +125,8 @@ impl ProjectInitializer {
                     "tag": "configuration/mcp",
                     "session_id": MCP_SEED_SESSION_ID,
                     "server_name": server_name,
-                    "command": command,
-                    "args": args,
+                    "command": server.command,
+                    "args": server.args,
                     "env_keys": env_keys,
                     "path": rel.clone(),
                     "created_at": Utc::now().to_rfc3339(),

--- a/crates/trusty-agents/src/mcp/config/tests/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/mod.rs
@@ -187,6 +187,7 @@ async fn save_and_reload_roundtrip() {
         description: "A test service".to_string(),
         command: "test-cmd".to_string(),
         args: vec!["arg1".to_string()],
+        env: std::collections::HashMap::new(),
         url: None,
         transport: "stdio".to_string(),
         enabled: true,
@@ -194,6 +195,7 @@ async fn save_and_reload_roundtrip() {
             name: "test_tool".to_string(),
             description: "A test tool".to_string(),
         }],
+        discover: false,
     });
     cfg.save().await.expect("save should succeed");
     let reloaded = GlobalConfig::load().await;
@@ -218,10 +220,12 @@ async fn add_service_replaces_existing() {
         description: "first".to_string(),
         command: "a".to_string(),
         args: vec![],
+        env: std::collections::HashMap::new(),
         url: None,
         transport: "stdio".to_string(),
         enabled: true,
         tools: vec![],
+        discover: false,
     })
     .await
     .unwrap();
@@ -230,10 +234,12 @@ async fn add_service_replaces_existing() {
         description: "second".to_string(),
         command: "b".to_string(),
         args: vec![],
+        env: std::collections::HashMap::new(),
         url: None,
         transport: "stdio".to_string(),
         enabled: true,
         tools: vec![],
+        discover: false,
     })
     .await
     .unwrap();
@@ -255,10 +261,12 @@ async fn remove_service_returns_correct_bool() {
         description: "d".to_string(),
         command: "c".to_string(),
         args: vec![],
+        env: std::collections::HashMap::new(),
         url: None,
         transport: "stdio".to_string(),
         enabled: true,
         tools: vec![],
+        discover: false,
     })
     .await
     .unwrap();
@@ -280,10 +288,12 @@ async fn enable_disable_toggles_flag() {
         description: "d".to_string(),
         command: "c".to_string(),
         args: vec![],
+        env: std::collections::HashMap::new(),
         url: None,
         transport: "stdio".to_string(),
         enabled: false,
         tools: vec![],
+        discover: false,
     })
     .await
     .unwrap();

--- a/crates/trusty-agents/src/mcp/config/types.rs
+++ b/crates/trusty-agents/src/mcp/config/types.rs
@@ -134,6 +134,25 @@ pub struct McpSection {
     pub inject_for_roles: Vec<String>,
     #[serde(default)]
     pub services: Vec<McpService>,
+    /// Trust gate for auto-spawning servers discovered from a project's
+    /// `.mcp.json` (security-critical, see #3266 BLOCK remediation).
+    ///
+    /// Why: A `.mcp.json` file is project-controlled, not operator-curated —
+    /// cloning a hostile repo that ships a malicious `.mcp.json` would
+    /// otherwise cause trusty-agents to auto-spawn arbitrary binaries on
+    /// every persona turn with zero gating. Defaulting this to `false`
+    /// means live discovery only ever sources servers from the
+    /// operator-curated `[[mcp.services]]` allowlist (`discover = true`
+    /// entries) unless the operator explicitly opts a project in.
+    /// What: When `false` (the default), `mcp_live::spec::gather_specs`
+    /// skips `.mcp.json` entirely and only considers `[[mcp.services]]`
+    /// `discover = true` entries. When `true`, `.mcp.json` entries are
+    /// merged in as before (config-service entries still win on name
+    /// collision).
+    /// Test: `mcp_live::spec::tests::gather_specs_skips_mcp_json_when_untrusted`,
+    /// `gather_specs_includes_mcp_json_when_trusted`.
+    #[serde(default)]
+    pub trust_project_mcp_json: bool,
 }
 
 impl Default for McpSection {
@@ -141,6 +160,7 @@ impl Default for McpSection {
         Self {
             inject_for_roles: default_inject_roles(),
             services: Vec::new(),
+            trust_project_mcp_json: false,
         }
     }
 }

--- a/crates/trusty-agents/src/mcp/config/types.rs
+++ b/crates/trusty-agents/src/mcp/config/types.rs
@@ -7,6 +7,8 @@
 //! `McpTool`, plus the `serde` default helpers they share.
 //! Test: Defaults + round-trips exercised in `config::tests`.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 /// Default agent roles that receive MCP tool descriptions in their prompt.
@@ -152,6 +154,11 @@ pub struct McpService {
     pub command: String,
     #[serde(default)]
     pub args: Vec<String>,
+    /// Environment variables overlaid on the spawned server's process
+    /// environment (e.g. API keys). Empty by default — most services need
+    /// nothing beyond the inherited environment.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
     /// For HTTP-transport services, the endpoint URL. Stdio services leave
     /// this `None` and use `command` + `args` instead.
     #[serde(default)]
@@ -162,6 +169,13 @@ pub struct McpService {
     pub enabled: bool,
     #[serde(default)]
     pub tools: Vec<McpTool>,
+    /// When `true`, ignore `tools` (the static list above) entirely and
+    /// live-discover the server's tools via `tools/list` at registry-build
+    /// time instead (#3238). Requires `transport = "stdio"` and a non-empty
+    /// `command` — non-stdio or command-less services with `discover = true`
+    /// are skipped with a warning, same as the static path.
+    #[serde(default)]
+    pub discover: bool,
 }
 
 /// A single tool advertised by an MCP service.

--- a/crates/trusty-agents/src/mcp/mcp_json.rs
+++ b/crates/trusty-agents/src/mcp/mcp_json.rs
@@ -1,0 +1,253 @@
+//! Shared `.mcp.json` (`mcpServers` map) parsing (#3238).
+//!
+//! Why: `.mcp.json` — the standard Claude-Code-compatible file declaring
+//! stdio MCP servers — was previously parsed inline inside
+//! `init::seed::seed_mcp_connections` for memory-seeding only. The live
+//! runtime-registration path (`crate::tools::mcp_live`) needs the exact same
+//! parsing (server name, command, args, env, description) to turn each
+//! `mcpServers` entry into a spec it can spawn and `tools/list`. Extracting
+//! the parser here means both call sites share one implementation instead of
+//! two copies drifting apart.
+//! What: `McpJsonServer` is the parsed shape of one `mcpServers` entry.
+//! `discover_mcp_json_paths` locates the project-local and user-global
+//! `.mcp.json` files (project first, so a later `parse` loop can treat
+//! project entries as taking precedence over user-global ones with the same
+//! name). `parse_mcp_json_servers` parses one file's raw JSON content into a
+//! `Vec<McpJsonServer>`, sorted by name for deterministic iteration order.
+//! Test: `parse_mcp_json_servers_*`, `discover_mcp_json_paths_*` below.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// One parsed `mcpServers` entry from a `.mcp.json` file.
+///
+/// Why: Both `seed_mcp_connections` (memory indexing) and `mcp_live`
+/// (runtime tool registration) need the same fields; a shared struct means
+/// neither call site re-derives them from raw `serde_json::Value` by hand.
+/// What: Mirrors the Claude-Code-compatible `mcpServers.<name>` shape:
+/// `command`, `args`, `env` (full key/value — callers that only need key
+/// names, like the memory seeder, project `.keys()`), and an optional
+/// human-readable `description`.
+/// Test: `parse_mcp_json_servers_extracts_all_fields`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpJsonServer {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub description: Option<String>,
+}
+
+/// Locate `.mcp.json` files relevant to `project_dir`, project-local first.
+///
+/// Why: Project-local config should take precedence over the user's global
+/// `~/.claude/.mcp.json` when both declare a server with the same name;
+/// returning project-first lets callers implement "first occurrence wins"
+/// for that precedence without re-deriving the search order themselves.
+/// What: Returns `<project_dir>/.mcp.json` (if it exists) followed by
+/// `$HOME/.claude/.mcp.json` (if it exists). Neither existing yields an
+/// empty vec — callers should treat that as "no live-discovery servers from
+/// .mcp.json", not an error.
+/// Test: `discover_mcp_json_paths_prefers_project_then_home`.
+pub fn discover_mcp_json_paths(project_dir: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let project_mcp = project_dir.join(".mcp.json");
+    if project_mcp.exists() {
+        paths.push(project_mcp);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let user_mcp = PathBuf::from(home).join(".claude").join(".mcp.json");
+        if user_mcp.exists() {
+            paths.push(user_mcp);
+        }
+    }
+    paths
+}
+
+/// Parse a `.mcp.json` file's raw content into its `mcpServers` entries.
+///
+/// Why: Centralises the exact field extraction (`command`, `args`, `env`,
+/// `description`) that both `seed_mcp_connections` and `mcp_live` need,
+/// so the two call sites can never silently diverge on how a field is
+/// read.
+/// What: Returns `Err` only on malformed JSON. A file with no `mcpServers`
+/// key (or one that isn't an object) parses successfully to an empty vec —
+/// that's a normal "nothing to do here" case, not an error. Entries are
+/// sorted by name for deterministic iteration.
+/// Test: `parse_mcp_json_servers_extracts_all_fields`,
+/// `parse_mcp_json_servers_empty_without_mcp_servers_key`,
+/// `parse_mcp_json_servers_errors_on_malformed_json`.
+pub fn parse_mcp_json_servers(raw: &str) -> Result<Vec<McpJsonServer>> {
+    let parsed: serde_json::Value =
+        serde_json::from_str(raw).context("failed to parse .mcp.json content")?;
+
+    let Some(servers) = parsed.get("mcpServers").and_then(|v| v.as_object()) else {
+        return Ok(Vec::new());
+    };
+
+    let mut out: Vec<McpJsonServer> = servers
+        .iter()
+        .map(|(name, def)| {
+            let command = def
+                .get("command")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let args: Vec<String> = def
+                .get("args")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let env: HashMap<String, String> = def
+                .get("env")
+                .and_then(|v| v.as_object())
+                .map(|o| {
+                    o.iter()
+                        .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let description = def
+                .get("description")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            McpJsonServer {
+                name: name.clone(),
+                command,
+                args,
+                env,
+                description,
+            }
+        })
+        .collect();
+
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: Every field a live-discovery spec or a memory-seed description
+    /// needs must round-trip through the parser without loss.
+    /// What: Feed a two-server `.mcp.json` fixture; assert command/args/env/
+    /// description all extract correctly, and iteration order is
+    /// name-sorted.
+    /// Test: This test.
+    #[test]
+    fn parse_mcp_json_servers_extracts_all_fields() {
+        let raw = serde_json::json!({
+            "mcpServers": {
+                "vector-search": {
+                    "command": "uv",
+                    "args": ["run", "mcp-vector-search", "mcp"],
+                    "description": "Semantic code search"
+                },
+                "kuzu-memory": {
+                    "command": "kuzu-memory",
+                    "args": ["mcp"],
+                    "env": {"KUZU_MEMORY_DB": "/tmp/db"}
+                }
+            }
+        })
+        .to_string();
+
+        let servers = parse_mcp_json_servers(&raw).unwrap();
+        assert_eq!(servers.len(), 2);
+        // Sorted by name: kuzu-memory before vector-search.
+        assert_eq!(servers[0].name, "kuzu-memory");
+        assert_eq!(servers[0].command, "kuzu-memory");
+        assert_eq!(servers[0].args, vec!["mcp".to_string()]);
+        assert_eq!(
+            servers[0].env.get("KUZU_MEMORY_DB").map(String::as_str),
+            Some("/tmp/db")
+        );
+        assert_eq!(servers[0].description, None);
+
+        assert_eq!(servers[1].name, "vector-search");
+        assert_eq!(
+            servers[1].args,
+            vec![
+                "run".to_string(),
+                "mcp-vector-search".to_string(),
+                "mcp".to_string()
+            ]
+        );
+        assert_eq!(
+            servers[1].description.as_deref(),
+            Some("Semantic code search")
+        );
+    }
+
+    /// Why: A `.mcp.json`-shaped file without a `mcpServers` key (or an
+    /// unrelated JSON document) must not be treated as an error — it just
+    /// contributes zero servers.
+    /// What: Parse `{}` and assert an empty, non-error result.
+    /// Test: This test.
+    #[test]
+    fn parse_mcp_json_servers_empty_without_mcp_servers_key() {
+        let servers = parse_mcp_json_servers("{}").unwrap();
+        assert!(servers.is_empty());
+    }
+
+    /// Why: Malformed JSON must surface as an `Err` so callers can log and
+    /// skip that source file rather than silently losing servers.
+    /// What: Feed truncated JSON; assert `Err`.
+    /// Test: This test.
+    #[test]
+    fn parse_mcp_json_servers_errors_on_malformed_json() {
+        assert!(parse_mcp_json_servers("{ not json").is_err());
+    }
+
+    /// Why: Precedence semantics (project overrides user-global) depend on
+    /// project-local paths being returned before the home path.
+    /// What: Create both a project `.mcp.json` and a fake `$HOME/.claude/.mcp.json`
+    /// in a temp dir; assert the returned order is project-then-home, and
+    /// that a missing project file still returns the home path alone.
+    /// Test: This test.
+    #[test]
+    fn discover_mcp_json_paths_prefers_project_then_home() {
+        let _guard = crate::test_env::HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let project = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let claude_dir = home.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(claude_dir.join(".mcp.json"), "{}").unwrap();
+
+        // SAFETY: single-threaded test setup; no concurrent HOME readers
+        // within this test's lifetime.
+        let prev_home = std::env::var_os("HOME");
+        unsafe {
+            std::env::set_var("HOME", home.path());
+        }
+
+        // No project .mcp.json yet: only the home path comes back.
+        let paths_home_only = discover_mcp_json_paths(project.path());
+        assert_eq!(paths_home_only.len(), 1);
+        assert_eq!(paths_home_only[0], claude_dir.join(".mcp.json"));
+
+        // Add a project .mcp.json: it must come first.
+        std::fs::write(project.path().join(".mcp.json"), "{}").unwrap();
+        let paths_both = discover_mcp_json_paths(project.path());
+        assert_eq!(paths_both.len(), 2);
+        assert_eq!(paths_both[0], project.path().join(".mcp.json"));
+        assert_eq!(paths_both[1], claude_dir.join(".mcp.json"));
+
+        unsafe {
+            match prev_home {
+                Some(h) => std::env::set_var("HOME", h),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+}

--- a/crates/trusty-agents/src/mcp/mod.rs
+++ b/crates/trusty-agents/src/mcp/mod.rs
@@ -14,7 +14,10 @@
 //! Test: `mcp::config::tests::*` cover load/create/render.
 
 pub mod config;
+pub mod mcp_json;
 
 pub use config::GlobalConfig;
 #[allow(unused_imports)]
 pub use config::{LocalInferenceConfig, McpSection, McpService, McpTool};
+#[allow(unused_imports)]
+pub use mcp_json::{McpJsonServer, discover_mcp_json_paths, parse_mcp_json_servers};

--- a/crates/trusty-agents/src/runtime/subagent_mode.rs
+++ b/crates/trusty-agents/src/runtime/subagent_mode.rs
@@ -317,6 +317,32 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
         reg.register(Arc::new(tools::finish_task::FinishTaskTool::new()));
     }
 
+    // #3238: live-discover MCP servers (`[[mcp.services]] discover = true`
+    // and `.mcp.json`) and register whatever tools they advertise, using the
+    // same `tools::mcp_live::live_mcp_tool_executors` construction helper
+    // the persona-chat assembly point uses — kept as a step here (rather
+    // than folded into `build_registry_for_agent` itself) because that
+    // function is synchronous and called directly by ~10 existing
+    // `#[test]`s; doing async discovery at this async call site instead
+    // gives both assembly points the same discovered tool set without an
+    // invasive signature change.
+    {
+        let reg = registry.get_or_insert_with(ToolRegistry::new);
+        let existing_names: std::collections::HashSet<String> = reg
+            .schemas()
+            .iter()
+            .filter_map(|s| {
+                s.get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|n| n.as_str())
+                    .map(String::from)
+            })
+            .collect();
+        for tool in tools::mcp_live::live_mcp_tool_executors(&cwd, &existing_names).await {
+            reg.register(tool);
+        }
+    }
+
     let result = if let Some(reg) = registry {
         super::subagent_exec::run_subagent_with_tools(
             &client,

--- a/crates/trusty-agents/src/tools/mcp_live/cache.rs
+++ b/crates/trusty-agents/src/tools/mcp_live/cache.rs
@@ -1,0 +1,240 @@
+//! Discovery result cache + per-server timeout for live MCP tool discovery
+//! (#3266 BLOCK remediation, DoS fix for #3238's live-discovery path).
+//!
+//! Why: The original implementation re-ran spawn + `initialize` +
+//! `tools/list` for every configured server on EVERY persona turn, entirely
+//! sequentially, with no bound on any individual server's discovery time
+//! beyond the two chained 30s `CALL_TIMEOUT`s inside
+//! `StdioMcpClient::request` (`initialize` then `tools/list`). A single slow
+//! or hung server could cost up to ~60s, and N servers processed one at a
+//! time meant an N*60s worst case on every turn — a straightforward DoS
+//! against a persona's responsiveness from nothing more than a misbehaving
+//! MCP server. What: `discover_one` bounds a single server's discovery to
+//! `DISCOVERY_TIMEOUT` (well under the 60s worst case) via
+//! `tokio::time::timeout`, and consults/populates a process-wide
+//! `SERVER_CACHE` keyed by server name so a spec whose command/args/env are
+//! unchanged since the last successful discovery reuses the already-spawned
+//! `ServiceClient` and its `tools/list` result instead of respawning and
+//! re-listing. Callers (`super::build_executors_from_specs`) run
+//! `discover_one` concurrently across all specs via `futures::future::join_all`,
+//! so the whole batch's worst case is bounded by `DISCOVERY_TIMEOUT`
+//! regardless of server count, not `DISCOVERY_TIMEOUT * N`.
+//! Test: `discover_one_reuses_cached_client_across_calls`,
+//! `discover_one_returns_none_on_timeout`.
+
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+use super::spec::McpServerSpec;
+use crate::tools::mcp_service_tools::ServiceClient;
+
+/// Per-server discovery deadline (spawn + `initialize` + `tools/list`
+/// combined). Well under the ~60s worst case two chained 30s `CALL_TIMEOUT`s
+/// could otherwise cost, and — because discovery now runs concurrently
+/// across servers — this is also the effective ceiling for the whole batch.
+pub(super) const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// How long a successful discovery result stays valid before the next
+/// persona turn re-runs `tools/list` against the (already-spawned) server to
+/// pick up any change in the server's advertised tools.
+const CACHE_TTL: Duration = Duration::from_secs(120);
+
+/// A cached, already-spawned server plus its last-discovered tool list.
+struct CachedServer {
+    /// Fingerprint of the spec that produced this entry (command + args +
+    /// sorted env). A spec whose fingerprint changes (config edit, `.mcp.json`
+    /// edit) invalidates the cache for that server name.
+    fingerprint: String,
+    client: Arc<ServiceClient>,
+    tools: Vec<trusty_common::stdio_mcp_client::McpTool>,
+    cached_at: Instant,
+}
+
+/// Process-wide cache, keyed by server name. `LazyLock` gives lazy,
+/// synchronization-free initialization; the `Mutex` guards concurrent
+/// persona turns (and, within a turn, concurrent `discover_one` calls from
+/// `join_all`) from racing on inserts.
+static SERVER_CACHE: LazyLock<Mutex<HashMap<String, CachedServer>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Build a stable fingerprint for a spec's spawn-relevant fields.
+///
+/// Why: The cache must invalidate itself when an operator edits a server's
+/// command/args/env, not just serve stale spawn parameters forever.
+/// What: `command`, `args` (order-sensitive — args order matters to the
+/// spawned process), and `env` (sorted by key so map iteration order never
+/// causes spurious cache misses) joined into one string.
+fn fingerprint(spec: &McpServerSpec) -> String {
+    let mut env_pairs: Vec<(&String, &String)> = spec.env.iter().collect();
+    env_pairs.sort_by(|a, b| a.0.cmp(b.0));
+    format!("{}|{:?}|{:?}", spec.command, spec.args, env_pairs)
+}
+
+/// Discover one server's tools: a cache hit reuses the already-spawned
+/// `ServiceClient` and prior `tools/list` result; a cache miss (or stale/
+/// changed spec) spawns fresh, bounded by `DISCOVERY_TIMEOUT`.
+///
+/// Why: The single per-spec unit of work `build_executors_from_specs` fans
+/// out concurrently — see module docs for the DoS rationale.
+/// What: Returns `None` (warn-and-skip, never panics/aborts the batch) on
+/// spawn/handshake/list failure OR on exceeding `DISCOVERY_TIMEOUT`.
+/// Test: `discover_one_reuses_cached_client_across_calls`,
+/// `discover_one_returns_none_on_timeout`.
+pub(super) async fn discover_one(
+    spec: &McpServerSpec,
+) -> Option<(
+    Arc<ServiceClient>,
+    Vec<trusty_common::stdio_mcp_client::McpTool>,
+)> {
+    let fp = fingerprint(spec);
+
+    {
+        let cache = SERVER_CACHE.lock().await;
+        if let Some(entry) = cache.get(&spec.name)
+            && entry.fingerprint == fp
+            && entry.cached_at.elapsed() < CACHE_TTL
+        {
+            return Some((entry.client.clone(), entry.tools.clone()));
+        }
+    }
+
+    let client = Arc::new(ServiceClient::with_parts(
+        spec.name.clone(),
+        spec.command.clone(),
+        spec.args.clone(),
+        spec.env.clone(),
+    ));
+    let tools = match tokio::time::timeout(DISCOVERY_TIMEOUT, client.list_tools()).await {
+        Ok(Ok(t)) => t,
+        Ok(Err(e)) => {
+            tracing::warn!(
+                server = %spec.name,
+                source = ?spec.source,
+                error = %e,
+                "mcp_live: discovery failed (spawn/initialize/tools-list); skipping server"
+            );
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(
+                server = %spec.name,
+                source = ?spec.source,
+                timeout_secs = DISCOVERY_TIMEOUT.as_secs(),
+                "mcp_live: discovery exceeded per-server deadline; skipping server"
+            );
+            return None;
+        }
+    };
+
+    let mut cache = SERVER_CACHE.lock().await;
+    cache.insert(
+        spec.name.clone(),
+        CachedServer {
+            fingerprint: fp,
+            client: client.clone(),
+            tools: tools.clone(),
+            cached_at: Instant::now(),
+        },
+    );
+
+    Some((client, tools))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tools::mcp_live::spec::SpecSource;
+    use std::collections::HashMap as StdHashMap;
+
+    fn fake_spec_with_marker(name: &str, marker_path: &std::path::Path) -> McpServerSpec {
+        let script = format!(
+            r#"echo spawned >> {marker}
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{{"jsonrpc":"2.0","id":1,"result":{{"protocolVersion":"2024-11-05","serverInfo":{{"name":"fake","version":"0.1.0"}}}}}}\n'
+      ;;
+    *'"method":"tools/list"'*)
+      printf '{{"jsonrpc":"2.0","id":2,"result":{{"tools":[]}}}}\n'
+      ;;
+  esac
+done"#,
+            marker = marker_path.display()
+        );
+        McpServerSpec {
+            name: name.to_string(),
+            command: "sh".to_string(),
+            args: vec!["-c".to_string(), script],
+            env: StdHashMap::new(),
+            source: SpecSource::ConfigService,
+        }
+    }
+
+    /// Why: The whole point of the cache (#3266 DoS fix) — a second call
+    /// with an unchanged spec must reuse the already-spawned client rather
+    /// than spawning a fresh subprocess, which is what made discovery
+    /// expensive to run on every persona turn.
+    /// What: Discover the same fake server twice; assert both calls return
+    /// the identical `Arc<ServiceClient>` pointer, AND that the underlying
+    /// shell script's spawn-marker file has exactly one line (proving only
+    /// one subprocess was ever started).
+    /// Test: This test.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn discover_one_reuses_cached_client_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let marker = dir.path().join("marker.txt");
+        let spec = fake_spec_with_marker("cache-test-server-reuse", &marker);
+
+        let first = discover_one(&spec).await.expect("first discovery");
+        let second = discover_one(&spec).await.expect("second discovery");
+
+        assert!(
+            Arc::ptr_eq(&first.0, &second.0),
+            "second call must reuse the cached client instead of spawning a new one"
+        );
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let contents = std::fs::read_to_string(&marker).unwrap_or_default();
+        assert_eq!(
+            contents.lines().count(),
+            1,
+            "expected exactly one subprocess spawn, marker file contained: {contents:?}"
+        );
+    }
+
+    /// Why: A server whose handshake never responds must not be allowed to
+    /// block discovery indefinitely (or for the full chained-60s worst
+    /// case) — `DISCOVERY_TIMEOUT` must actually fire.
+    /// What: Point a spec at `sleep 3600` (never speaks the MCP protocol);
+    /// assert `discover_one` returns `None` well before the OS would kill
+    /// the process on its own. Uses a shortened effective wait by relying on
+    /// `DISCOVERY_TIMEOUT`'s real value — this test's own timeout wrapper
+    /// only guards against the assertion itself hanging in CI.
+    /// Test: This test.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn discover_one_returns_none_on_timeout() {
+        let spec = McpServerSpec {
+            name: "cache-test-server-hang".to_string(),
+            command: "sleep".to_string(),
+            args: vec!["3600".to_string()],
+            env: StdHashMap::new(),
+            source: SpecSource::ConfigService,
+        };
+
+        let result = tokio::time::timeout(DISCOVERY_TIMEOUT + Duration::from_secs(10), async {
+            discover_one(&spec).await
+        })
+        .await
+        .expect("discover_one must respect DISCOVERY_TIMEOUT, not hang indefinitely");
+
+        assert!(
+            result.is_none(),
+            "a server that never speaks MCP must be skipped, not treated as discovered"
+        );
+    }
+}

--- a/crates/trusty-agents/src/tools/mcp_live/executor.rs
+++ b/crates/trusty-agents/src/tools/mcp_live/executor.rs
@@ -7,8 +7,8 @@
 //! built by passing the MCP server's `inputSchema` straight through (no
 //! synthetic open-object schema — the server told us the real shape),
 //! and a shared `ServiceClient` handle for `tools/call` dispatch.
-//! Test: `execute_dispatches_through_shared_client`,
-//! `execute_surfaces_call_errors`, `build_tool_schema_passes_through_input_schema`.
+//! Test: `execute_surfaces_spawn_failure_as_recoverable_error`,
+//! `build_tool_schema_passes_through_input_schema`.
 
 use std::sync::Arc;
 
@@ -17,6 +17,16 @@ use serde_json::{Value, json};
 
 use crate::tools::mcp_service_tools::{ServiceClient, format_mcp_call_result};
 use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Upper bound on a passed-through `inputSchema`'s serialized size, in
+/// bytes. A malicious or buggy MCP server could otherwise advertise an
+/// arbitrarily large `inputSchema` (deeply nested, huge enum lists, etc.)
+/// that gets cloned into every `LiveMcpTool`'s schema and re-serialized on
+/// every `registry.schemas()` call — unbounded memory/CPU per discovered
+/// tool. 64 KiB comfortably covers legitimate real-world schemas (the
+/// largest observed in this codebase's fixtures is a few hundred bytes)
+/// while bounding the worst case.
+const MAX_INPUT_SCHEMA_BYTES: usize = 64 * 1024;
 
 /// Build the OpenAI-shape function-calling schema for one discovered MCP
 /// tool, prefixing the description with `[<server_name>]` (matching the
@@ -28,17 +38,36 @@ use crate::tools::traits::{ToolExecutor, ToolResult};
 /// `inputSchema` from `tools/list` — passing it through gives the LLM
 /// accurate argument shapes instead of an unconstrained object.
 /// What: Wraps `tool.input_schema` as `function.parameters`, falling back to
-/// an empty object schema only if the server didn't advertise one.
+/// an empty object schema if the server didn't advertise one OR if the
+/// advertised schema exceeds `MAX_INPUT_SCHEMA_BYTES` (#3266 memory-bound
+/// fix) — an oversized schema is treated the same as a missing one rather
+/// than rejecting the whole tool, so the tool still registers (with a less
+/// precise, open-object parameter shape) instead of vanishing.
 /// Test: `build_tool_schema_passes_through_input_schema`,
-/// `build_tool_schema_falls_back_when_input_schema_absent`.
+/// `build_tool_schema_falls_back_when_input_schema_absent`,
+/// `build_tool_schema_falls_back_when_input_schema_exceeds_size_cap`.
 pub(super) fn build_tool_schema(
     server_name: &str,
     tool: &trusty_common::stdio_mcp_client::McpTool,
 ) -> Value {
-    let params = if tool.input_schema.is_object() {
-        tool.input_schema.clone()
+    let fallback = || json!({"type": "object", "properties": {}});
+    let params = if !tool.input_schema.is_object() {
+        fallback()
     } else {
-        json!({"type": "object", "properties": {}})
+        match serde_json::to_vec(&tool.input_schema) {
+            Ok(bytes) if bytes.len() <= MAX_INPUT_SCHEMA_BYTES => tool.input_schema.clone(),
+            Ok(bytes) => {
+                tracing::warn!(
+                    server = %server_name,
+                    tool = %tool.name,
+                    schema_bytes = bytes.len(),
+                    cap_bytes = MAX_INPUT_SCHEMA_BYTES,
+                    "mcp_live: inputSchema exceeds size cap; falling back to an open-object schema"
+                );
+                fallback()
+            }
+            Err(_) => fallback(),
+        }
     };
     json!({
         "type": "function",
@@ -59,8 +88,7 @@ pub(super) fn build_tool_schema(
 /// What: `execute()` forwards to `client.get_or_spawn()` then `tools/call`,
 /// formatting results with the same `format_mcp_call_result` the static path
 /// uses (shared, not duplicated).
-/// Test: `execute_dispatches_through_shared_client`,
-/// `execute_surfaces_call_errors`.
+/// Test: `execute_surfaces_spawn_failure_as_recoverable_error`.
 pub(super) struct LiveMcpTool {
     pub(super) name: String,
     pub(super) schema: Value,
@@ -168,6 +196,36 @@ mod tests {
         assert_eq!(
             schema["function"]["parameters"],
             json!({"type": "object", "properties": {}})
+        );
+    }
+
+    /// Why: SECURITY/DoS (#3266) — a malicious or buggy MCP server could
+    /// advertise an oversized `inputSchema` (e.g. a huge enum or deeply
+    /// nested object). Without a cap, that gets cloned into the schema of
+    /// every registered `LiveMcpTool` and re-serialized on every registry
+    /// listing, an unbounded per-tool memory/CPU cost.
+    /// What: Build an `inputSchema` whose serialized size exceeds
+    /// `MAX_INPUT_SCHEMA_BYTES`; assert the resulting `function.parameters`
+    /// falls back to the empty-object schema (tool still registers, just
+    /// with a less precise parameter shape) rather than passing the huge
+    /// schema through.
+    /// Test: This test.
+    #[test]
+    fn build_tool_schema_falls_back_when_input_schema_exceeds_size_cap() {
+        let huge_enum: Vec<String> = (0..20_000).map(|i| format!("value-{i}")).collect();
+        let tool = WireMcpTool {
+            name: "oversized".to_string(),
+            description: Some("Has a huge inputSchema".to_string()),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"choice": {"type": "string", "enum": huge_enum}}
+            }),
+        };
+        let schema = build_tool_schema("fake-server", &tool);
+        assert_eq!(
+            schema["function"]["parameters"],
+            json!({"type": "object", "properties": {}}),
+            "oversized inputSchema must fall back, not pass through"
         );
     }
 

--- a/crates/trusty-agents/src/tools/mcp_live/executor.rs
+++ b/crates/trusty-agents/src/tools/mcp_live/executor.rs
@@ -1,0 +1,199 @@
+//! `ToolExecutor` wrapper for one live-discovered MCP tool (#3238).
+//!
+//! Why: A discovered `tools/list` entry needs to become a `dyn ToolExecutor`
+//! so it can sit in the same `ToolRegistry` as every in-process and
+//! static-config MCP tool, dispatched identically by the LLM loop.
+//! What: `LiveMcpTool` holds the tool's real name, an OpenAI-shape schema
+//! built by passing the MCP server's `inputSchema` straight through (no
+//! synthetic open-object schema — the server told us the real shape),
+//! and a shared `ServiceClient` handle for `tools/call` dispatch.
+//! Test: `execute_dispatches_through_shared_client`,
+//! `execute_surfaces_call_errors`, `build_tool_schema_passes_through_input_schema`.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::mcp_service_tools::{ServiceClient, format_mcp_call_result};
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Build the OpenAI-shape function-calling schema for one discovered MCP
+/// tool, prefixing the description with `[<server_name>]` (matching the
+/// convention the static `mcp_service_tools` path already uses) so the LLM
+/// can tell which server a tool belongs to.
+///
+/// Why: Unlike the static config path (which has no schema to pass through
+/// and falls back to an open object), live discovery gets the server's real
+/// `inputSchema` from `tools/list` — passing it through gives the LLM
+/// accurate argument shapes instead of an unconstrained object.
+/// What: Wraps `tool.input_schema` as `function.parameters`, falling back to
+/// an empty object schema only if the server didn't advertise one.
+/// Test: `build_tool_schema_passes_through_input_schema`,
+/// `build_tool_schema_falls_back_when_input_schema_absent`.
+pub(super) fn build_tool_schema(
+    server_name: &str,
+    tool: &trusty_common::stdio_mcp_client::McpTool,
+) -> Value {
+    let params = if tool.input_schema.is_object() {
+        tool.input_schema.clone()
+    } else {
+        json!({"type": "object", "properties": {}})
+    };
+    json!({
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": format!("[{}] {}", server_name, tool.description.clone().unwrap_or_default()),
+            "parameters": params
+        }
+    })
+}
+
+/// `ToolExecutor` for one tool advertised by a live-discovered MCP server.
+///
+/// Why: Same dispatch shape as `mcp_service_tools::McpServiceTool`, but the
+/// schema comes from real discovery instead of static config, and the
+/// backing `ServiceClient` was constructed by `mcp_live::spec` rather than
+/// from an `McpService`.
+/// What: `execute()` forwards to `client.get_or_spawn()` then `tools/call`,
+/// formatting results with the same `format_mcp_call_result` the static path
+/// uses (shared, not duplicated).
+/// Test: `execute_dispatches_through_shared_client`,
+/// `execute_surfaces_call_errors`.
+pub(super) struct LiveMcpTool {
+    pub(super) name: String,
+    pub(super) schema: Value,
+    pub(super) client: Arc<ServiceClient>,
+}
+
+#[async_trait]
+impl ToolExecutor for LiveMcpTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn schema(&self) -> Value {
+        self.schema.clone()
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let client = match self.client.get_or_spawn().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!(
+                    tool = %self.name,
+                    service = %self.client.name(),
+                    error = %e,
+                    "mcp_live: server unavailable; tool call returning error"
+                );
+                return ToolResult::err(format!(
+                    "MCP service '{}' is not running: {}. The tool '{}' is currently unavailable.",
+                    self.client.name(),
+                    e,
+                    self.name
+                ));
+            }
+        };
+
+        let mut guard = client.lock().await;
+        match guard.call_tool(&self.name, args).await {
+            Ok(value) => ToolResult::ok(format_mcp_call_result(&value)),
+            Err(e) => {
+                tracing::warn!(
+                    tool = %self.name,
+                    service = %self.client.name(),
+                    error = %e,
+                    "mcp_live: tool call failed"
+                );
+                ToolResult::err(format!("MCP tool '{}' failed: {}", self.name, e))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use trusty_common::stdio_mcp_client::McpTool as WireMcpTool;
+
+    /// Why: The server's real `inputSchema` must pass through unmodified so
+    /// the LLM sees accurate argument shapes.
+    /// What: Build a schema for a tool with a non-trivial inputSchema;
+    /// assert `function.parameters` equals it exactly, and the description
+    /// is prefixed with `[server_name]`.
+    /// Test: This test.
+    #[test]
+    fn build_tool_schema_passes_through_input_schema() {
+        let tool = WireMcpTool {
+            name: "echo".to_string(),
+            description: Some("Echoes input".to_string()),
+            input_schema: json!({
+                "type": "object",
+                "properties": {"msg": {"type": "string"}},
+                "required": ["msg"]
+            }),
+        };
+        let schema = build_tool_schema("fake-server", &tool);
+        assert_eq!(schema["type"], "function");
+        assert_eq!(schema["function"]["name"], "echo");
+        assert_eq!(
+            schema["function"]["description"],
+            "[fake-server] Echoes input"
+        );
+        assert_eq!(
+            schema["function"]["parameters"],
+            json!({
+                "type": "object",
+                "properties": {"msg": {"type": "string"}},
+                "required": ["msg"]
+            })
+        );
+    }
+
+    /// Why: Some servers omit `inputSchema`; the executor must still produce
+    /// a valid (empty-object) schema rather than propagating `null`.
+    /// What: Tool with `input_schema: Value::Null`; assert the fallback
+    /// empty-object schema is used.
+    /// Test: This test.
+    #[test]
+    fn build_tool_schema_falls_back_when_input_schema_absent() {
+        let tool = WireMcpTool {
+            name: "bare".to_string(),
+            description: None,
+            input_schema: Value::Null,
+        };
+        let schema = build_tool_schema("fake-server", &tool);
+        assert_eq!(
+            schema["function"]["parameters"],
+            json!({"type": "object", "properties": {}})
+        );
+    }
+
+    /// Why: `execute()` must return a recoverable error (not panic) when the
+    /// backing server can't be spawned.
+    /// What: `ServiceClient` pointed at a nonexistent binary; assert
+    /// `execute` returns an error result mentioning the tool/service.
+    /// Test: This test.
+    #[tokio::test]
+    async fn execute_surfaces_spawn_failure_as_recoverable_error() {
+        let client = Arc::new(ServiceClient::with_parts(
+            "ghost-server".to_string(),
+            "/nonexistent/mcp/binary/xyzzy-live-test".to_string(),
+            vec![],
+            HashMap::new(),
+        ));
+        let tool = LiveMcpTool {
+            name: "ghost_tool".to_string(),
+            schema: json!({"type": "function", "function": {"name": "ghost_tool"}}),
+            client,
+        };
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_error());
+        assert!(!result.is_fatal());
+        assert!(
+            result.content().contains("ghost_tool") || result.content().contains("ghost-server")
+        );
+    }
+}

--- a/crates/trusty-agents/src/tools/mcp_live/mod.rs
+++ b/crates/trusty-agents/src/tools/mcp_live/mod.rs
@@ -24,8 +24,11 @@
 //! adding the async live-discovery step at the call site instead of inside
 //! it avoids a disruptive signature change while still giving both assembly
 //! points the same discovered tool set). Specs are gathered by
-//! `spec::gather_specs` (config `discover = true` services + `.mcp.json`,
-//! config wins on name collision); each surviving spec is spawned via a
+//! `spec::gather_specs` (config `discover = true` services always; a
+//! project's `.mcp.json` ONLY when the operator has opted in via
+//! `mcp.trust_project_mcp_json = true`, since `.mcp.json` is untrusted
+//! repo-controlled content — see #3266 and `spec::gather_specs` docs; config
+//! wins on name collision); each surviving spec is spawned via a
 //! `mcp_service_tools::ServiceClient` (same lazy-spawn-and-cache shape the
 //! static path uses — one subprocess per server, reused across calls) and
 //! `tools/list` is called eagerly at registry-build time (discovery
@@ -48,6 +51,7 @@
 //! integration tests below (discovery, execute round-trip, duplicate
 //! policy, spawn-failure skip).
 
+mod cache;
 mod executor;
 mod spec;
 
@@ -56,10 +60,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use executor::{LiveMcpTool, build_tool_schema};
+use futures::future::join_all;
 pub use spec::{McpServerSpec, SpecSource, gather_specs};
 
 use crate::mcp::config::GlobalConfig;
-use crate::tools::mcp_service_tools::ServiceClient;
 use crate::tools::traits::ToolExecutor;
 
 /// Build live-discovered `ToolExecutor`s for every eligible MCP server.
@@ -83,6 +87,20 @@ pub async fn live_mcp_tool_executors(
 
 /// Pure(ish) helper split out so tests can feed synthetic specs without
 /// touching `~/.trusty-agents/config.toml` or a real project directory.
+///
+/// Why: #3266 DoS remediation — this used to discover each spec
+/// sequentially with no cap on a single server's discovery time, so N
+/// servers could cost up to N*60s on every persona turn. Discovery is now
+/// fanned out concurrently via `join_all`, with each server's spawn +
+/// `initialize` + `tools/list` individually bounded by
+/// `cache::DISCOVERY_TIMEOUT` and served from `cache::SERVER_CACHE` across
+/// turns when the spec is unchanged — see `cache` module docs.
+/// What: Runs `cache::discover_one` concurrently for every spec, then
+/// processes results in the original spec order (so duplicate-name
+/// first-wins semantics stay deterministic even though discovery itself is
+/// concurrent).
+/// Test: `discovery_registers_advertised_tools_as_executors` and friends
+/// below; cache/timeout behavior is covered by `cache::tests`.
 async fn build_executors_from_specs(
     specs: Vec<McpServerSpec>,
     existing_names: &HashSet<String>,
@@ -90,24 +108,11 @@ async fn build_executors_from_specs(
     let mut executors: Vec<Arc<dyn ToolExecutor>> = Vec::new();
     let mut seen: HashSet<String> = existing_names.clone();
 
-    for spec in specs {
-        let client = Arc::new(ServiceClient::with_parts(
-            spec.name.clone(),
-            spec.command.clone(),
-            spec.args.clone(),
-            spec.env.clone(),
-        ));
-        let tools = match client.list_tools().await {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::warn!(
-                    server = %spec.name,
-                    source = ?spec.source,
-                    error = %e,
-                    "mcp_live: discovery failed (spawn/initialize/tools-list); skipping server"
-                );
-                continue;
-            }
+    let discoveries = join_all(specs.iter().map(cache::discover_one)).await;
+
+    for (spec, discovered) in specs.iter().zip(discoveries) {
+        let Some((client, tools)) = discovered else {
+            continue;
         };
 
         let mut registered_for_server = 0usize;

--- a/crates/trusty-agents/src/tools/mcp_live/mod.rs
+++ b/crates/trusty-agents/src/tools/mcp_live/mod.rs
@@ -1,0 +1,293 @@
+//! Live runtime MCP-server discovery + tool registration (#3238, part of
+//! epic #3052).
+//!
+//! Why: Before this module, agents could only call MCP tools that were
+//! either hand-registered in-process or listed statically under
+//! `[[mcp.services.tools]]` in `~/.trusty-agents/config.toml` — a drift-prone
+//! pattern where the config had to be kept in sync by hand with whatever the
+//! server actually advertised. `.mcp.json` (the standard Claude-Code file
+//! declaring stdio MCP servers) was read only for memory-seeding, never for
+//! runtime tool registration. This module closes that gap: given a server
+//! spec (name, command, args, env), it spawns the server, runs the MCP
+//! `initialize` + `tools/list` handshake, and wraps every advertised tool as
+//! a `ToolExecutor` with a passthrough schema — so an agent becomes
+//! connectable to *any* configured MCP server, not just the ones someone
+//! remembered to hand-list.
+//!
+//! What: `live_mcp_tool_executors(project_dir, existing_names)` is the
+//! single construction helper both assembly points call:
+//! `ctrl::pm_task::dispatch::persona::run_pm_task_with_persona` (persona
+//! chat) and `runtime::subagent_mode` (sub-agent tool-registry
+//! construction, called right after the existing sync
+//! `tool_registry::build_registry_for_agent` — that function stays
+//! synchronous on purpose since ~10 existing `#[test]`s call it directly;
+//! adding the async live-discovery step at the call site instead of inside
+//! it avoids a disruptive signature change while still giving both assembly
+//! points the same discovered tool set). Specs are gathered by
+//! `spec::gather_specs` (config `discover = true` services + `.mcp.json`,
+//! config wins on name collision); each surviving spec is spawned via a
+//! `mcp_service_tools::ServiceClient` (same lazy-spawn-and-cache shape the
+//! static path uses — one subprocess per server, reused across calls) and
+//! `tools/list` is called eagerly at registry-build time (discovery
+//! inherently needs the process up, unlike static-config tools which need no
+//! spawn until first call). A server that fails to spawn/handshake/list is
+//! warned-and-skipped — startup never aborts for one bad server. Duplicate
+//! tool names (against tools the caller already registered, or across two
+//! live-discovered servers) are skipped-with-warning, keeping the earlier
+//! registration — matching the existing `mcp_service_tools` dedup policy
+//! rather than introducing a second (prefixing) convention.
+//!
+//! Gating: registering a tool here does not grant access to it. Both
+//! assembly points still filter the resulting registry through the agent's
+//! `[tools].allow` glob (e.g. `"tm_*"` to opt into a discovered server whose
+//! tools are named `tm_*`) and RBAC tier before anything reaches the LLM's
+//! tool list — this module only makes the tool *exist* in the registry.
+//!
+//! Test: `spec::tests::*` (gathering/precedence), `executor::tests::*`
+//! (schema passthrough, spawn-failure recovery), and the fake-MCP-server
+//! integration tests below (discovery, execute round-trip, duplicate
+//! policy, spawn-failure skip).
+
+mod executor;
+mod spec;
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::Arc;
+
+use executor::{LiveMcpTool, build_tool_schema};
+pub use spec::{McpServerSpec, SpecSource, gather_specs};
+
+use crate::mcp::config::GlobalConfig;
+use crate::tools::mcp_service_tools::ServiceClient;
+use crate::tools::traits::ToolExecutor;
+
+/// Build live-discovered `ToolExecutor`s for every eligible MCP server.
+///
+/// Why: The single entry point both assembly points call — see module docs.
+/// What: Loads `GlobalConfig`, gathers specs (`spec::gather_specs`), then for
+/// each spec spawns + `tools/list`s via a fresh `ServiceClient`, wrapping
+/// every advertised tool as a `LiveMcpTool`. `existing_names` seeds the
+/// dedup set so tools the caller already registered (from any other source)
+/// are never shadowed.
+/// Test: `discovery_registers_advertised_tools_as_executors` (integration,
+/// below).
+pub async fn live_mcp_tool_executors(
+    project_dir: &Path,
+    existing_names: &HashSet<String>,
+) -> Vec<Arc<dyn ToolExecutor>> {
+    let config = GlobalConfig::load().await;
+    let specs = gather_specs(&config, project_dir).await;
+    build_executors_from_specs(specs, existing_names).await
+}
+
+/// Pure(ish) helper split out so tests can feed synthetic specs without
+/// touching `~/.trusty-agents/config.toml` or a real project directory.
+async fn build_executors_from_specs(
+    specs: Vec<McpServerSpec>,
+    existing_names: &HashSet<String>,
+) -> Vec<Arc<dyn ToolExecutor>> {
+    let mut executors: Vec<Arc<dyn ToolExecutor>> = Vec::new();
+    let mut seen: HashSet<String> = existing_names.clone();
+
+    for spec in specs {
+        let client = Arc::new(ServiceClient::with_parts(
+            spec.name.clone(),
+            spec.command.clone(),
+            spec.args.clone(),
+            spec.env.clone(),
+        ));
+        let tools = match client.list_tools().await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(
+                    server = %spec.name,
+                    source = ?spec.source,
+                    error = %e,
+                    "mcp_live: discovery failed (spawn/initialize/tools-list); skipping server"
+                );
+                continue;
+            }
+        };
+
+        let mut registered_for_server = 0usize;
+        for tool in tools {
+            if seen.contains(&tool.name) {
+                tracing::warn!(
+                    tool = %tool.name,
+                    server = %spec.name,
+                    "mcp_live: duplicate tool name; keeping earlier registration"
+                );
+                continue;
+            }
+            seen.insert(tool.name.clone());
+            let schema = build_tool_schema(&spec.name, &tool);
+            executors.push(Arc::new(LiveMcpTool {
+                name: tool.name,
+                schema,
+                client: client.clone(),
+            }) as Arc<dyn ToolExecutor>);
+            registered_for_server += 1;
+        }
+        tracing::info!(
+            server = %spec.name,
+            count = registered_for_server,
+            "mcp_live: registered live-discovered tools"
+        );
+    }
+
+    executors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// A minimal fake MCP server: a POSIX shell one-liner that matches on
+    /// substrings of each JSON-RPC request line and prints a canned
+    /// response. Mirrors the same technique
+    /// `trusty_common::stdio_mcp_client`'s own tests use (see
+    /// `read_line_skips_non_json_prefix_lines`) — no external binary or
+    /// process-spawning test harness needed. Ids are hardcoded to the
+    /// sequence a single fresh `StdioMcpClient` actually allocates:
+    /// `initialize`=1, `tools/list`=2, `tools/call`=3 (the `initialize`d
+    /// notification carries no id and gets no response).
+    fn fake_mcp_server_script(tool_name: &str, tool_desc: &str, call_result_text: &str) -> String {
+        format!(
+            r#"while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '{{"jsonrpc":"2.0","id":1,"result":{{"protocolVersion":"2024-11-05","serverInfo":{{"name":"fake","version":"0.1.0"}}}}}}\n'
+      ;;
+    *'"method":"tools/list"'*)
+      printf '{{"jsonrpc":"2.0","id":2,"result":{{"tools":[{{"name":"{tool_name}","description":"{tool_desc}","inputSchema":{{"type":"object","properties":{{}}}}}}]}}}}\n'
+      ;;
+    *'"method":"tools/call"'*)
+      printf '{{"jsonrpc":"2.0","id":3,"result":{{"content":[{{"type":"text","text":"{call_result_text}"}}]}}}}\n'
+      ;;
+  esac
+done"#
+        )
+    }
+
+    fn fake_spec(
+        name: &str,
+        tool_name: &str,
+        tool_desc: &str,
+        call_result_text: &str,
+    ) -> McpServerSpec {
+        McpServerSpec {
+            name: name.to_string(),
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                fake_mcp_server_script(tool_name, tool_desc, call_result_text),
+            ],
+            env: HashMap::new(),
+            source: SpecSource::ConfigService,
+        }
+    }
+
+    /// Why: The core promise of #3238 — a live server's advertised tools
+    /// must show up as real `ToolExecutor`s with the right name/schema,
+    /// without any static config listing them.
+    /// What: One fake server advertising `fake_echo`; assert exactly one
+    /// executor comes back named `fake_echo` with a function-shape schema.
+    /// Test: This test.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn discovery_registers_advertised_tools_as_executors() {
+        let specs = vec![fake_spec("fake-server", "fake_echo", "Echoes input", "ok")];
+        let execs = build_executors_from_specs(specs, &HashSet::new()).await;
+        assert_eq!(execs.len(), 1);
+        assert_eq!(execs[0].name(), "fake_echo");
+        let schema = execs[0].schema();
+        assert_eq!(schema["type"], "function");
+        assert_eq!(schema["function"]["name"], "fake_echo");
+    }
+
+    /// Why: A discovered tool must actually dispatch `tools/call` through
+    /// to the server and surface the text content — not just exist in the
+    /// registry.
+    /// What: Build the one executor from `discovery_registers_...`, call
+    /// `execute`, assert the round-tripped content matches the fake
+    /// server's canned `tools/call` response.
+    /// Test: This test.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn execute_round_trips_a_tools_call() {
+        let specs = vec![fake_spec(
+            "fake-server",
+            "fake_echo",
+            "Echoes input",
+            "hello from fake server",
+        )];
+        let execs = build_executors_from_specs(specs, &HashSet::new()).await;
+        assert_eq!(execs.len(), 1);
+        let result = execs[0].execute(serde_json::json!({})).await;
+        assert!(!result.is_error(), "unexpected error: {}", result.content());
+        assert_eq!(result.content(), "hello from fake server");
+    }
+
+    /// Why: One bad server (missing binary) must never take down discovery
+    /// for the rest — this is the "warn-and-skip, never abort" contract
+    /// #3238 requires.
+    /// What: Two specs: one pointing at a nonexistent binary, one a working
+    /// fake server. Assert the working server's tool still registers and
+    /// the total count is exactly one (the failed server contributes zero,
+    /// not an error/panic).
+    /// Test: This test.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn server_spawn_failure_warns_and_skips_that_server_only() {
+        let broken = McpServerSpec {
+            name: "broken-server".to_string(),
+            command: "/nonexistent/mcp/binary/xyzzy-live-mod-test".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            source: SpecSource::ConfigService,
+        };
+        let working = fake_spec("working-server", "works_fine", "desc", "ok");
+        let execs = build_executors_from_specs(vec![broken, working], &HashSet::new()).await;
+        assert_eq!(execs.len(), 1);
+        assert_eq!(execs[0].name(), "works_fine");
+    }
+
+    /// Why: Two servers advertising the same tool name must not both
+    /// register — that would panic the `debug_assert!` in
+    /// `ToolRegistry::register` once these executors are handed off. The
+    /// documented policy is skip-with-warning, keeping the earlier
+    /// registration (matches `mcp_service_tools`'s static-path policy).
+    /// What: Two fake servers both advertising `dup_tool`; assert exactly
+    /// one executor comes back, from the first server processed.
+    /// Test: This test.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn duplicate_tool_names_across_servers_keep_first() {
+        let first = fake_spec("server-a", "dup_tool", "from a", "a-result");
+        let second = fake_spec("server-b", "dup_tool", "from b", "b-result");
+        let execs = build_executors_from_specs(vec![first, second], &HashSet::new()).await;
+        assert_eq!(execs.len(), 1);
+        let result = execs[0].execute(serde_json::json!({})).await;
+        assert_eq!(result.content(), "a-result");
+    }
+
+    /// Why: A tool already registered by another source (static
+    /// `mcp_service_tools`, git tools, ticketing, …) must not be shadowed by
+    /// a live-discovered tool of the same name — `existing_names` is the
+    /// seam that lets callers seed the dedup set from their own registry.
+    /// What: Seed `existing_names` with the fake server's tool name; assert
+    /// zero executors come back even though the server is healthy and
+    /// advertises that tool.
+    /// Test: This test.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn existing_names_prevent_shadowing_already_registered_tools() {
+        let specs = vec![fake_spec("fake-server", "already_registered", "d", "r")];
+        let mut existing = HashSet::new();
+        existing.insert("already_registered".to_string());
+        let execs = build_executors_from_specs(specs, &existing).await;
+        assert!(execs.is_empty());
+    }
+}

--- a/crates/trusty-agents/src/tools/mcp_live/spec.rs
+++ b/crates/trusty-agents/src/tools/mcp_live/spec.rs
@@ -45,14 +45,24 @@ pub struct McpServerSpec {
 /// both wire through "the same construction helper").
 /// What: Walks `global.mcp.services` for `enabled && discover` entries
 /// (stdio transport, non-empty command only — same graceful-skip rules as
-/// the static path in `mcp_service_tools`), then walks `.mcp.json` files
-/// found via `discover_mcp_json_paths(project_dir)` (project file before
-/// `~/.claude/.mcp.json`). A `.mcp.json` entry whose name collides with an
-/// already-collected config-service name is skipped (config wins);
-/// otherwise first-file-wins for `.mcp.json`-vs-`.mcp.json` collisions.
+/// the static path in `mcp_service_tools`). `.mcp.json` files (found via
+/// `discover_mcp_json_paths(project_dir)`, project file before
+/// `~/.claude/.mcp.json`) are walked ONLY when
+/// `global.mcp.trust_project_mcp_json` is `true` — a project's `.mcp.json`
+/// is untrusted, repo-controlled content, and auto-spawning whatever it
+/// declares is a remote-code-execution vector for anyone who clones a
+/// hostile repo (#3266 security remediation). The default-false gate means
+/// the only opt-in path for a `.mcp.json`-declared server is an explicit,
+/// operator-curated `[[mcp.services]]` entry with `discover = true` — those
+/// are unaffected by this gate since they never touch `.mcp.json`. A
+/// `.mcp.json` entry whose name collides with an already-collected
+/// config-service name is skipped (config wins); otherwise first-file-wins
+/// for `.mcp.json`-vs-`.mcp.json` collisions.
 /// Test: `gather_specs_includes_discover_services`,
 /// `gather_specs_config_service_wins_over_mcp_json_by_name`,
-/// `gather_specs_skips_non_stdio_and_empty_command`.
+/// `gather_specs_skips_non_stdio_and_empty_command`,
+/// `gather_specs_skips_mcp_json_when_untrusted`,
+/// `gather_specs_includes_mcp_json_when_trusted`.
 pub async fn gather_specs(global: &GlobalConfig, project_dir: &Path) -> Vec<McpServerSpec> {
     let mut specs: Vec<McpServerSpec> = Vec::new();
     let mut seen_names: HashSet<String> = HashSet::new();
@@ -84,6 +94,13 @@ pub async fn gather_specs(global: &GlobalConfig, project_dir: &Path) -> Vec<McpS
             env: svc.env.clone(),
             source: SpecSource::ConfigService,
         });
+    }
+
+    if !global.mcp.trust_project_mcp_json {
+        tracing::debug!(
+            "mcp_live: mcp.trust_project_mcp_json is false (default); skipping .mcp.json auto-spawn entirely"
+        );
+        return specs;
     }
 
     for path in discover_mcp_json_paths(project_dir) {
@@ -214,7 +231,9 @@ mod tests {
 
     /// Why: #3238's documented precedence — a `[[mcp.services]]
     /// discover=true` entry must win over a `.mcp.json` entry of the same
-    /// name, since the config is the operator-curated source.
+    /// name, since the config is the operator-curated source. This test
+    /// explicitly opts into `trust_project_mcp_json = true` since `.mcp.json`
+    /// entries are gated off by default (#3266 security remediation).
     /// What: Config declares `shared` (discover=true); project `.mcp.json`
     /// also declares `shared` with a different command. Assert exactly one
     /// spec named `shared`, sourced from config, with the config's command.
@@ -237,6 +256,7 @@ mod tests {
 
         let mut global = GlobalConfig::default();
         global.mcp.services = vec![discover_service("shared", "from-config")];
+        global.mcp.trust_project_mcp_json = true;
 
         let specs = gather_specs(&global, project.path()).await;
         assert_eq!(specs.len(), 2);
@@ -246,5 +266,72 @@ mod tests {
         let json_only = specs.iter().find(|s| s.name == "json-only").unwrap();
         assert_eq!(json_only.command, "json-only-bin");
         assert_eq!(json_only.source, SpecSource::McpJson);
+    }
+
+    /// Why: SECURITY (#3266) — `GlobalConfig::default()` must leave
+    /// `trust_project_mcp_json` at `false`, and `gather_specs` must not
+    /// auto-spawn anything from `.mcp.json` in that state. This is the
+    /// default-deny proof: a hostile repo's `.mcp.json` must never cause a
+    /// spawn without an explicit operator opt-in.
+    /// What: Project declares a `.mcp.json` server with no corresponding
+    /// `[[mcp.services]]` entry, default config (untrusted). Assert zero
+    /// specs come back even though the file parses fine and the command is
+    /// non-empty.
+    /// Test: This test.
+    #[tokio::test]
+    async fn gather_specs_skips_mcp_json_when_untrusted() {
+        let project = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            project.path().join(".mcp.json"),
+            serde_json::json!({
+                "mcpServers": {
+                    "hostile": {"command": "rm", "args": ["-rf", "/"]}
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        let global = GlobalConfig::default();
+        assert!(!global.mcp.trust_project_mcp_json, "default must be false");
+
+        let specs = gather_specs(&global, project.path()).await;
+        assert!(
+            specs.is_empty(),
+            "untrusted .mcp.json must not auto-spawn: {specs:?}"
+        );
+    }
+
+    /// Why: The trust gate must be a real opt-in, not a permanently-closed
+    /// door — an operator who explicitly sets
+    /// `trust_project_mcp_json = true` still gets the pre-#3266 merge
+    /// behavior.
+    /// What: Same untrusted-repo fixture as the previous test, but
+    /// `trust_project_mcp_json = true`; assert the `.mcp.json` entry now
+    /// comes back.
+    /// Test: This test.
+    #[tokio::test]
+    async fn gather_specs_includes_mcp_json_when_trusted() {
+        let project = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            project.path().join(".mcp.json"),
+            serde_json::json!({
+                "mcpServers": {
+                    "trusted-entry": {"command": "trusted-bin", "args": []}
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        let mut global = GlobalConfig::default();
+        global.mcp.trust_project_mcp_json = true;
+
+        let specs = gather_specs(&global, project.path()).await;
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].name, "trusted-entry");
+        assert_eq!(specs[0].source, SpecSource::McpJson);
     }
 }

--- a/crates/trusty-agents/src/tools/mcp_live/spec.rs
+++ b/crates/trusty-agents/src/tools/mcp_live/spec.rs
@@ -1,0 +1,250 @@
+//! Live-discovery MCP server specs: gathering + config/`.mcp.json` precedence
+//! (#3238).
+//!
+//! Why: Live discovery needs a uniform "enough to spawn" shape regardless of
+//! whether the server came from `[[mcp.services]]` (`discover = true`) or a
+//! `.mcp.json` `mcpServers` entry — the two sources have different on-disk
+//! schemas but the same runtime needs (command, args, env).
+//! What: `McpServerSpec` is that uniform shape; `gather_specs` merges both
+//! sources with the documented precedence: a `[[mcp.services]]` entry with
+//! `discover = true` wins over a `.mcp.json` entry of the same name (config
+//! is operator-curated and presumed more trustworthy/intentional than an
+//! auto-discovered `.mcp.json`, which may be shared across tools like Claude
+//! Code that don't know about trusty-agents' service registry).
+//! Test: `gather_specs_*` below.
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use crate::mcp::config::GlobalConfig;
+use crate::mcp::mcp_json::{discover_mcp_json_paths, parse_mcp_json_servers};
+
+/// Where a live-discovery spec came from. Carried only for tracing/debug
+/// messages — dispatch behavior is identical regardless of source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpecSource {
+    ConfigService,
+    McpJson,
+}
+
+/// A live-discovery-eligible MCP server: enough to spawn + `tools/list`.
+#[derive(Debug, Clone)]
+pub struct McpServerSpec {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub source: SpecSource,
+}
+
+/// Gather every live-discovery-eligible server spec.
+///
+/// Why: Both `crate::ctrl::pm_task::dispatch::persona` and
+/// `crate::runtime::subagent_mode` need the identical merged spec list so
+/// the two assembly points' tool sets match (per #3238's requirement that
+/// both wire through "the same construction helper").
+/// What: Walks `global.mcp.services` for `enabled && discover` entries
+/// (stdio transport, non-empty command only — same graceful-skip rules as
+/// the static path in `mcp_service_tools`), then walks `.mcp.json` files
+/// found via `discover_mcp_json_paths(project_dir)` (project file before
+/// `~/.claude/.mcp.json`). A `.mcp.json` entry whose name collides with an
+/// already-collected config-service name is skipped (config wins);
+/// otherwise first-file-wins for `.mcp.json`-vs-`.mcp.json` collisions.
+/// Test: `gather_specs_includes_discover_services`,
+/// `gather_specs_config_service_wins_over_mcp_json_by_name`,
+/// `gather_specs_skips_non_stdio_and_empty_command`.
+pub async fn gather_specs(global: &GlobalConfig, project_dir: &Path) -> Vec<McpServerSpec> {
+    let mut specs: Vec<McpServerSpec> = Vec::new();
+    let mut seen_names: HashSet<String> = HashSet::new();
+
+    for svc in &global.mcp.services {
+        if !svc.enabled || !svc.discover {
+            continue;
+        }
+        if svc.transport != "stdio" {
+            tracing::debug!(
+                service = %svc.name,
+                transport = %svc.transport,
+                "mcp_live: skipping non-stdio discover=true service (only stdio transport supported)"
+            );
+            continue;
+        }
+        if svc.command.is_empty() {
+            tracing::debug!(
+                service = %svc.name,
+                "mcp_live: skipping discover=true service with empty command"
+            );
+            continue;
+        }
+        seen_names.insert(svc.name.clone());
+        specs.push(McpServerSpec {
+            name: svc.name.clone(),
+            command: svc.command.clone(),
+            args: svc.args.clone(),
+            env: svc.env.clone(),
+            source: SpecSource::ConfigService,
+        });
+    }
+
+    for path in discover_mcp_json_paths(project_dir) {
+        let raw = match tokio::fs::read_to_string(&path).await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(path = %path.display(), error = %e, "mcp_live: .mcp.json unreadable, skipping");
+                continue;
+            }
+        };
+        let servers = match parse_mcp_json_servers(&raw) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "mcp_live: .mcp.json parse failed, skipping");
+                continue;
+            }
+        };
+        for s in servers {
+            if seen_names.contains(&s.name) {
+                tracing::debug!(
+                    server = %s.name,
+                    path = %path.display(),
+                    "mcp_live: .mcp.json entry shadowed by a [[mcp.services]] discover=true entry of the same name, skipping"
+                );
+                continue;
+            }
+            if s.command.is_empty() {
+                tracing::debug!(server = %s.name, path = %path.display(), "mcp_live: .mcp.json entry has empty command, skipping");
+                continue;
+            }
+            seen_names.insert(s.name.clone());
+            specs.push(McpServerSpec {
+                name: s.name,
+                command: s.command,
+                args: s.args,
+                env: s.env,
+                source: SpecSource::McpJson,
+            });
+        }
+    }
+
+    specs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::config::{McpService, McpTool};
+
+    fn discover_service(name: &str, command: &str) -> McpService {
+        McpService {
+            name: name.to_string(),
+            description: format!("{name} service"),
+            command: command.to_string(),
+            args: vec!["mcp".to_string()],
+            env: HashMap::new(),
+            url: None,
+            transport: "stdio".to_string(),
+            enabled: true,
+            tools: vec![McpTool {
+                name: "ignored_static_tool".to_string(),
+                description: "should not surface — discover=true ignores this".to_string(),
+            }],
+            discover: true,
+        }
+    }
+
+    /// Why: A `discover = true` config service must appear as a
+    /// `ConfigService`-sourced spec even when the project has no `.mcp.json`
+    /// at all.
+    /// What: One discover=true service, empty project dir; assert one spec
+    /// comes back with matching name/command/source.
+    /// Test: This test.
+    #[tokio::test]
+    async fn gather_specs_includes_discover_services() {
+        let project = tempfile::tempdir().unwrap();
+        let mut global = GlobalConfig::default();
+        global.mcp.services = vec![discover_service("alpha", "alpha-bin")];
+
+        let specs = gather_specs(&global, project.path()).await;
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].name, "alpha");
+        assert_eq!(specs[0].command, "alpha-bin");
+        assert_eq!(specs[0].source, SpecSource::ConfigService);
+    }
+
+    /// Why: Non-discover services (the default) and disabled services must
+    /// contribute nothing — they're handled by the pre-existing static path
+    /// in `mcp_service_tools`, not by live discovery.
+    /// What: One non-discover service + one disabled discover service;
+    /// assert zero specs.
+    /// Test: This test.
+    #[tokio::test]
+    async fn gather_specs_excludes_non_discover_and_disabled() {
+        let project = tempfile::tempdir().unwrap();
+        let mut normal = discover_service("beta", "beta-bin");
+        normal.discover = false;
+        let mut disabled = discover_service("gamma", "gamma-bin");
+        disabled.enabled = false;
+
+        let mut global = GlobalConfig::default();
+        global.mcp.services = vec![normal, disabled];
+
+        let specs = gather_specs(&global, project.path()).await;
+        assert!(specs.is_empty());
+    }
+
+    /// Why: Non-stdio transports and empty commands aren't spawnable; the
+    /// live path must skip them exactly like the static path does, rather
+    /// than crash trying to spawn `""`.
+    /// What: One http-transport discover service, one empty-command
+    /// discover service; assert zero specs.
+    /// Test: This test.
+    #[tokio::test]
+    async fn gather_specs_skips_non_stdio_and_empty_command() {
+        let mut http_svc = discover_service("http-svc", "");
+        http_svc.transport = "http".to_string();
+        http_svc.command = "irrelevant".to_string();
+        let empty_cmd_svc = discover_service("empty-cmd", "");
+
+        let project = tempfile::tempdir().unwrap();
+        let mut global = GlobalConfig::default();
+        global.mcp.services = vec![http_svc, empty_cmd_svc];
+
+        let specs = gather_specs(&global, project.path()).await;
+        assert!(specs.is_empty());
+    }
+
+    /// Why: #3238's documented precedence — a `[[mcp.services]]
+    /// discover=true` entry must win over a `.mcp.json` entry of the same
+    /// name, since the config is the operator-curated source.
+    /// What: Config declares `shared` (discover=true); project `.mcp.json`
+    /// also declares `shared` with a different command. Assert exactly one
+    /// spec named `shared`, sourced from config, with the config's command.
+    /// Test: This test.
+    #[tokio::test]
+    async fn gather_specs_config_service_wins_over_mcp_json_by_name() {
+        let project = tempfile::tempdir().unwrap();
+        tokio::fs::write(
+            project.path().join(".mcp.json"),
+            serde_json::json!({
+                "mcpServers": {
+                    "shared": {"command": "from-mcp-json", "args": []},
+                    "json-only": {"command": "json-only-bin", "args": []}
+                }
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        let mut global = GlobalConfig::default();
+        global.mcp.services = vec![discover_service("shared", "from-config")];
+
+        let specs = gather_specs(&global, project.path()).await;
+        assert_eq!(specs.len(), 2);
+        let shared = specs.iter().find(|s| s.name == "shared").unwrap();
+        assert_eq!(shared.command, "from-config");
+        assert_eq!(shared.source, SpecSource::ConfigService);
+        let json_only = specs.iter().find(|s| s.name == "json-only").unwrap();
+        assert_eq!(json_only.command, "json-only-bin");
+        assert_eq!(json_only.source, SpecSource::McpJson);
+    }
+}

--- a/crates/trusty-agents/src/tools/mcp_live/spec.rs
+++ b/crates/trusty-agents/src/tools/mcp_live/spec.rs
@@ -147,6 +147,12 @@ pub async fn gather_specs(global: &GlobalConfig, project_dir: &Path) -> Vec<McpS
 
 #[cfg(test)]
 mod tests {
+    // Why: `gather_specs_does_not_spawn_mcp_add_discover_bypass` holds
+    // `HOME_LOCK` (a `std::sync::Mutex`) across async I/O to serialize
+    // global $HOME mutation against other tests — same rationale as
+    // `tools::mcp_tools::tests` (see `crate::test_env` docs).
+    #![allow(clippy::await_holding_lock)]
+
     use super::*;
     use crate::mcp::config::{McpService, McpTool};
 
@@ -333,5 +339,62 @@ mod tests {
         assert_eq!(specs.len(), 1);
         assert_eq!(specs[0].name, "trusted-entry");
         assert_eq!(specs[0].source, SpecSource::McpJson);
+    }
+
+    /// Why: SECURITY (#3266 follow-up) — closes the same bypass class the
+    /// `.mcp.json` trust-gate tests above cover, but for the `mcp_add` LLM
+    /// tool path: `dispatch_mcp_tool("mcp_add", ...)` (`tools/mcp_tools`)
+    /// forces `discover = false` on any LLM-originated call regardless of
+    /// what the caller requested, specifically so a config-service entry
+    /// that arrived via that path can never reach `gather_specs`' unguarded
+    /// `enabled && discover && stdio` auto-spawn loop. This test proves the
+    /// end-to-end path: an `mcp_add` call requesting `discover: true` with
+    /// an attacker-chosen command is persisted, reloaded from disk, and
+    /// still produces zero specs.
+    /// What: Set `HOME` to an isolated tempdir, dispatch `mcp_add` with
+    /// `discover: true` and `command: "evil-binary"`, reload
+    /// `GlobalConfig::load()`, then call `gather_specs`; assert the
+    /// resulting spec list contains no entry for that service.
+    /// Test: This test.
+    #[tokio::test]
+    async fn gather_specs_does_not_spawn_mcp_add_discover_bypass() {
+        use crate::test_env::HOME_LOCK;
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HOME", home.path());
+        }
+
+        let out = crate::tools::mcp_tools::dispatch_mcp_tool(
+            "mcp_add",
+            &serde_json::json!({
+                "name": "attacker-service",
+                "description": "attacker-controlled",
+                "transport": "stdio",
+                "command": "evil-binary",
+                "discover": true
+            }),
+        )
+        .await;
+        assert!(out.contains("Added"), "got: {out}");
+
+        let reloaded = GlobalConfig::load().await;
+        let persisted = reloaded
+            .mcp
+            .services
+            .iter()
+            .find(|s| s.name == "attacker-service")
+            .expect("attacker-service present");
+        assert!(
+            !persisted.discover,
+            "mcp_add must have forced discover=false on persist"
+        );
+
+        let project = tempfile::tempdir().unwrap();
+        let specs = gather_specs(&reloaded, project.path()).await;
+        assert!(
+            !specs.iter().any(|s| s.name == "attacker-service"),
+            "mcp_add-originated discover:true must never be auto-spawned by gather_specs: {specs:?}"
+        );
     }
 }

--- a/crates/trusty-agents/src/tools/mcp_service_tools.rs
+++ b/crates/trusty-agents/src/tools/mcp_service_tools.rs
@@ -35,7 +35,11 @@ use crate::tools::traits::{ToolExecutor, ToolResult};
 
 /// Lazily-spawned MCP client for a single service. Multiple `McpServiceTool`
 /// instances belonging to the same service share one `ServiceClient` so we
-/// open exactly one subprocess per server.
+/// open exactly one subprocess per server. Shared (as `pub(crate)`) with
+/// `crate::tools::mcp_live`, which spawns the same kind of client for
+/// *live-discovered* services (#3238) — the caching/spawn shape is
+/// >80% identical between the static and live-discovery paths, so this is
+/// the single consolidated implementation rather than two near-duplicates.
 ///
 /// Why: Spawning a new MCP child per tool call would be wasteful and would
 /// break stateful servers. A `OnceCell<Mutex<StdioMcpClient>>` keyed off the
@@ -43,41 +47,84 @@ use crate::tools::traits::{ToolExecutor, ToolResult};
 /// reuse thereafter" semantics safely across tokio tasks.
 /// What: `get_or_spawn()` returns the cached client (running handshake on
 /// first call); subsequent calls return the same handle. The inner mutex
-/// serialises JSON-RPC requests, which `StdioMcpClient` requires.
-/// Test: Indirectly via `McpServiceTool::execute` — see integration tests.
-struct ServiceClient {
+/// serialises JSON-RPC requests, which `StdioMcpClient` requires. `env` is
+/// overlaid on the spawned process's environment (empty for services that
+/// don't need credentials).
+/// Test: Indirectly via `McpServiceTool::execute` — see integration tests;
+/// `crate::tools::mcp_live` tests exercise the `list_tools()` path.
+pub(crate) struct ServiceClient {
     name: String,
     command: String,
     args: Vec<String>,
+    env: HashMap<String, String>,
     cell: OnceCell<Arc<Mutex<StdioMcpClient>>>,
 }
 
 impl ServiceClient {
     fn new(service: &McpService) -> Self {
+        Self::with_parts(
+            service.name.clone(),
+            service.command.clone(),
+            service.args.clone(),
+            service.env.clone(),
+        )
+    }
+
+    /// Construct from primitive parts rather than a full `McpService` — used
+    /// by `mcp_live`, whose server specs may originate from `.mcp.json`
+    /// (no `McpService` involved).
+    pub(crate) fn with_parts(
+        name: String,
+        command: String,
+        args: Vec<String>,
+        env: HashMap<String, String>,
+    ) -> Self {
         Self {
-            name: service.name.clone(),
-            command: service.command.clone(),
-            args: service.args.clone(),
+            name,
+            command,
+            args,
+            env,
             cell: OnceCell::new(),
         }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
     }
 
     /// Spawn the MCP server subprocess (if not already) and return the shared
     /// client. Returns `Err` if the binary isn't on PATH, the handshake
     /// fails, or any I/O error occurs — callers convert this to a
-    /// `ToolResult::Error` for the LLM.
-    async fn get_or_spawn(&self) -> anyhow::Result<Arc<Mutex<StdioMcpClient>>> {
+    /// `ToolResult::Error` for the LLM (or, for `mcp_live` discovery, a
+    /// warn-and-skip for that server).
+    pub(crate) async fn get_or_spawn(&self) -> anyhow::Result<Arc<Mutex<StdioMcpClient>>> {
         self.cell
             .get_or_try_init(|| async {
                 let arg_refs: Vec<&str> = self.args.iter().map(String::as_str).collect();
-                let mut client =
-                    StdioMcpClient::spawn(&self.command, &arg_refs, "trusty-agents").await?;
+                let mut client = StdioMcpClient::spawn_with_env(
+                    &self.command,
+                    &arg_refs,
+                    "trusty-agents",
+                    &self.env,
+                )
+                .await?;
                 client.initialize().await?;
                 tracing::debug!(service = %self.name, "MCP service client spawned");
                 Ok::<_, anyhow::Error>(Arc::new(Mutex::new(client)))
             })
             .await
             .cloned()
+    }
+
+    /// Spawn (if needed) and return the tools the server advertises via
+    /// `tools/list`. Used only by the live-discovery path (`mcp_live`) —
+    /// the static path in this module gets its tool list from config.
+    pub(crate) async fn list_tools(
+        &self,
+    ) -> anyhow::Result<Vec<trusty_common::stdio_mcp_client::McpTool>> {
+        let client = self.get_or_spawn().await?;
+        let mut guard = client.lock().await;
+        guard.list_tools().await
     }
 }
 
@@ -149,10 +196,12 @@ impl ToolExecutor for McpServiceTool {
 /// Why: MCP returns `{ "content": [{ "type": "text", "text": "..." }, ...] }`.
 /// The LLM consumes our `ToolResult` as a string, so we concatenate the text
 /// frames. Non-text content (resource refs, images) falls back to JSON.
+/// Shared (as `pub(crate)`) with `crate::tools::mcp_live`, which formats
+/// `tools/call` results identically for live-discovered tools.
 /// What: If `content` is an array, joins its `text` fields with newlines;
 /// otherwise returns the full JSON serialization.
 /// Test: `format_mcp_call_result_*` unit tests.
-fn format_mcp_call_result(value: &Value) -> String {
+pub(crate) fn format_mcp_call_result(value: &Value) -> String {
     if let Some(items) = value.get("content").and_then(|v| v.as_array()) {
         let mut parts: Vec<String> = Vec::with_capacity(items.len());
         for item in items {
@@ -206,6 +255,13 @@ fn build_executors_from_services(services: &[McpService]) -> Vec<Arc<dyn ToolExe
 
     for svc in services {
         if !svc.enabled {
+            continue;
+        }
+        if svc.discover {
+            tracing::debug!(
+                service = %svc.name,
+                "MCP service has discover=true; skipping static tool list (crate::tools::mcp_live handles this service via live tools/list discovery)"
+            );
             continue;
         }
         if svc.tools.is_empty() {
@@ -286,6 +342,7 @@ mod tests {
             description: format!("{name} service"),
             command: format!("{name}-bin"),
             args: vec!["mcp".to_string()],
+            env: HashMap::new(),
             url: None,
             transport: "stdio".to_string(),
             enabled,
@@ -296,6 +353,7 @@ mod tests {
                     description: format!("{t} description"),
                 })
                 .collect(),
+            discover: false,
         }
     }
 
@@ -360,6 +418,21 @@ mod tests {
         let mut s = svc("http-svc", true, &["http_op"]);
         s.transport = "http".to_string();
         s.url = Some("https://example.com".to_string());
+        assert!(build_executors_from_services(&[s]).is_empty());
+    }
+
+    /// Why: #3238 — a service with `discover = true` opts entirely into the
+    /// live-discovery path (`crate::tools::mcp_live`); the static path here
+    /// must not ALSO register its `tools` list, or the same tool name would
+    /// be double-registered (triggering the debug-assert duplicate panic in
+    /// `ToolRegistry::register`).
+    /// What: Service has a non-empty static `tools` list AND `discover =
+    /// true`; assert the static builder contributes zero executors for it.
+    /// Test: This test.
+    #[test]
+    fn discover_services_skip_static_tool_list() {
+        let mut s = svc("discover-svc", true, &["static_tool"]);
+        s.discover = true;
         assert!(build_executors_from_services(&[s]).is_empty());
     }
 
@@ -440,6 +513,7 @@ mod tests {
             description: "missing".to_string(),
             command: "/nonexistent/mcp/binary/xyzzy-tool-test".to_string(),
             args: vec![],
+            env: HashMap::new(),
             url: None,
             transport: "stdio".to_string(),
             enabled: true,
@@ -447,6 +521,7 @@ mod tests {
                 name: "ghost_tool".to_string(),
                 description: "won't run".to_string(),
             }],
+            discover: false,
         }];
         let execs = build_executors_from_services(&services);
         assert_eq!(execs.len(), 1);

--- a/crates/trusty-agents/src/tools/mcp_tools/dispatch.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/dispatch.rs
@@ -113,15 +113,22 @@ fn parse_service_from_args(args: &Value) -> Result<McpService> {
         .get("discover")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let env: std::collections::HashMap<String, String> = args
-        .get("env")
-        .and_then(Value::as_object)
-        .map(|o| {
-            o.iter()
-                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
-                .collect()
-        })
-        .unwrap_or_default();
+    // SECURITY (#3266): `env` is intentionally NOT read from `args` here.
+    // `mcp_add` is dispatched from LLM-originated tool calls (the persona's
+    // model decides the arguments); `env` is not declared in this tool's
+    // schema (`mcp_tool_definitions` in `schema.rs`), so any `env` object an
+    // LLM call includes is undeclared input. Silently honoring it would let
+    // a prompt-injected or hallucinated tool call inject arbitrary
+    // environment variables (credentials, `LD_PRELOAD`-style hijacks, proxy
+    // overrides) into a spawned MCP server's process environment. Services
+    // that genuinely need env vars are configured by a human editing
+    // `~/.trusty-agents/config.toml` directly, not via this LLM-facing tool.
+    let env: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    if args.get("env").is_some() {
+        tracing::warn!(
+            "mcp_add: rejected undeclared 'env' field from LLM-originated tool call; service added with no env vars"
+        );
+    }
     let tools = args
         .get("tools")
         .and_then(Value::as_array)

--- a/crates/trusty-agents/src/tools/mcp_tools/dispatch.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/dispatch.rs
@@ -109,10 +109,25 @@ fn parse_service_from_args(args: &Value) -> Result<McpService> {
         .unwrap_or_default();
     let url = args.get("url").and_then(Value::as_str).map(str::to_string);
     let enabled = args.get("enabled").and_then(Value::as_bool).unwrap_or(true);
-    let discover = args
-        .get("discover")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
+    // SECURITY (#3266 follow-up): `discover` is a declared `mcp_add` schema
+    // field, but it is intentionally forced to `false` here regardless of
+    // what an LLM-originated tool call requests. `gather_specs`
+    // (`tools/mcp_live/spec.rs`) auto-spawns ANY `enabled && discover &&
+    // stdio` service with no trust gate of its own — the `.mcp.json` trust
+    // gate only covers the `.mcp.json` ingestion path. Without this strip, a
+    // prompt-injected or hallucinated `mcp_add` call could set
+    // `discover: true` with an attacker-chosen `command`, `add_service`
+    // would persist it, and the very next persona turn's `gather_specs` call
+    // would auto-spawn that binary — a full trust-gate bypass. Live
+    // discovery remains available, but only via a human hand-editing
+    // `~/.trusty-agents/config.toml` directly, same as the documented `env`
+    // path above.
+    let discover = false;
+    if args.get("discover").and_then(Value::as_bool) == Some(true) {
+        tracing::warn!(
+            "mcp_add: rejected 'discover: true' from LLM-originated tool call; service added with discover=false"
+        );
+    }
     // SECURITY (#3266): `env` is intentionally NOT read from `args` here.
     // `mcp_add` is dispatched from LLM-originated tool calls (the persona's
     // model decides the arguments); `env` is not declared in this tool's

--- a/crates/trusty-agents/src/tools/mcp_tools/dispatch.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/dispatch.rs
@@ -109,6 +109,19 @@ fn parse_service_from_args(args: &Value) -> Result<McpService> {
         .unwrap_or_default();
     let url = args.get("url").and_then(Value::as_str).map(str::to_string);
     let enabled = args.get("enabled").and_then(Value::as_bool).unwrap_or(true);
+    let discover = args
+        .get("discover")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let env: std::collections::HashMap<String, String> = args
+        .get("env")
+        .and_then(Value::as_object)
+        .map(|o| {
+            o.iter()
+                .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                .collect()
+        })
+        .unwrap_or_default();
     let tools = args
         .get("tools")
         .and_then(Value::as_array)
@@ -131,9 +144,11 @@ fn parse_service_from_args(args: &Value) -> Result<McpService> {
         description,
         command,
         args: args_vec,
+        env,
         url,
         transport,
         enabled,
         tools,
+        discover,
     })
 }

--- a/crates/trusty-agents/src/tools/mcp_tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/mod.rs
@@ -271,4 +271,49 @@ mod tests {
             epsilon.env
         );
     }
+
+    /// Why: SECURITY (#3266 follow-up) — `discover` IS a declared `mcp_add`
+    /// schema field (unlike `env`), but honoring `discover: true` from an
+    /// LLM-originated call is a trust-gate bypass: `gather_specs`
+    /// (`tools/mcp_live/spec.rs`) auto-spawns any `enabled && discover &&
+    /// stdio` `[[mcp.services]]` entry with no trust gate of its own. A
+    /// prompt-injected `mcp_add` call setting `discover: true` +
+    /// attacker-chosen `command` must not result in a service that the next
+    /// persona turn auto-spawns.
+    /// What: Call `mcp_add` with `discover: true` and an attacker-chosen
+    /// command; assert the persisted service has `discover == false`
+    /// regardless (the code additionally emits a `tracing::warn!` on this
+    /// path, mirroring the undeclared-`env` strip above).
+    /// Test: This test.
+    #[tokio::test]
+    async fn dispatch_mcp_add_strips_discover_true() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = tempdir();
+        unsafe {
+            std::env::set_var("HOME", &home);
+        }
+
+        let args = json!({
+            "name": "zeta",
+            "description": "zeta service",
+            "transport": "stdio",
+            "command": "evil-binary",
+            "discover": true
+        });
+        let out = dispatch_mcp_tool("mcp_add", &args).await;
+        assert!(out.contains("Added"), "got: {out}");
+
+        let reloaded = GlobalConfig::load().await;
+        let zeta = reloaded
+            .mcp
+            .services
+            .iter()
+            .find(|s| s.name == "zeta")
+            .expect("zeta service present");
+        assert!(
+            !zeta.discover,
+            "discover must be forced to false for LLM-originated mcp_add calls, got: {}",
+            zeta.discover
+        );
+    }
 }

--- a/crates/trusty-agents/src/tools/mcp_tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/mod.rs
@@ -228,4 +228,47 @@ mod tests {
         let out = dispatch_mcp_tool("mcp_bogus", &json!({})).await;
         assert!(out.contains("Unknown"));
     }
+
+    /// Why: SECURITY (#3266) — `env` is not a declared `mcp_add` schema
+    /// field (see `schema.rs`), so an LLM-originated tool call that includes
+    /// one anyway must never reach the persisted `McpService`. Silently
+    /// honoring it would let a prompt-injected/hallucinated tool call plant
+    /// arbitrary environment variables into a spawned MCP server's process.
+    /// What: Call `mcp_add` with an `env` object containing a poisoned var;
+    /// assert the persisted service's `env` map is empty regardless.
+    /// Test: This test.
+    #[tokio::test]
+    async fn dispatch_mcp_add_strips_undeclared_env_field() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let home = tempdir();
+        unsafe {
+            std::env::set_var("HOME", &home);
+        }
+
+        let args = json!({
+            "name": "epsilon",
+            "description": "epsilon service",
+            "transport": "stdio",
+            "command": "epsilon-cmd",
+            "env": {
+                "LD_PRELOAD": "/tmp/evil.so",
+                "OPENROUTER_API_KEY": "stolen"
+            }
+        });
+        let out = dispatch_mcp_tool("mcp_add", &args).await;
+        assert!(out.contains("Added"), "got: {out}");
+
+        let reloaded = GlobalConfig::load().await;
+        let epsilon = reloaded
+            .mcp
+            .services
+            .iter()
+            .find(|s| s.name == "epsilon")
+            .expect("epsilon service present");
+        assert!(
+            epsilon.env.is_empty(),
+            "env must be stripped from LLM-originated mcp_add calls, got: {:?}",
+            epsilon.env
+        );
+    }
 }

--- a/crates/trusty-agents/src/tools/mcp_tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/mod.rs
@@ -72,10 +72,12 @@ mod tests {
             description: "alpha service".to_string(),
             command: "a".to_string(),
             args: vec![],
+            env: std::collections::HashMap::new(),
             url: None,
             transport: "stdio".to_string(),
             enabled: true,
             tools: vec![],
+            discover: false,
         })
         .await
         .unwrap();

--- a/crates/trusty-agents/src/tools/mcp_tools/schema.rs
+++ b/crates/trusty-agents/src/tools/mcp_tools/schema.rs
@@ -49,6 +49,7 @@ pub fn mcp_tool_definitions() -> Vec<ChatCompletionTool> {
                     },
                     "url": {"type": "string", "description": "For http: service endpoint URL"},
                     "enabled": {"type": "boolean", "description": "Whether to enable immediately (default: true)"},
+                    "discover": {"type": "boolean", "description": "When true, ignore 'tools' and live-discover this service's tools via tools/list at registry-build time instead (stdio only, default: false)"},
                     "tools": {
                         "type": "array",
                         "description": "Optional list of tools this service provides",

--- a/crates/trusty-agents/src/tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mod.rs
@@ -20,6 +20,7 @@ pub mod finish_task;
 pub mod format_translator;
 pub mod fs_reader;
 pub mod git_tools;
+pub mod mcp_live;
 pub mod mcp_service_tools;
 pub mod mcp_tools;
 pub mod memory;

--- a/crates/trusty-common/src/stdio_mcp_client/client.rs
+++ b/crates/trusty-common/src/stdio_mcp_client/client.rs
@@ -38,7 +38,8 @@ impl StdioMcpClient {
     /// library name here would mislead MCP server logs and any server-side
     /// logic keyed on that field.
     /// What: Returns an unconnected client with the handshake NOT yet sent.
-    /// Call `initialize` next to complete the MCP handshake.
+    /// Call `initialize` next to complete the MCP handshake. Thin wrapper
+    /// over `spawn_with_env` with an empty environment overlay.
     /// Test: Indirectly via `#[ignore]`d e2e test; unit-test failure is
     /// covered by `spawn_missing_binary_errors` in `mod.rs`. The
     /// `initialize_envelope_is_well_formed` test verifies the supplied name
@@ -48,8 +49,32 @@ impl StdioMcpClient {
         args: &[&str],
         client_name: impl Into<String>,
     ) -> Result<Self> {
+        Self::spawn_with_env(binary, args, client_name, &std::collections::HashMap::new()).await
+    }
+
+    /// Spawn `binary` with `args` and an additional set of environment
+    /// variables overlaid on the inherited process environment.
+    ///
+    /// Why: Many MCP servers (e.g. those declared in a `.mcp.json`
+    /// `mcpServers` entry, or a `[[mcp.services]]` config block) need
+    /// credentials or config passed via env vars (`API_KEY`, `DB_URL`, …)
+    /// that must not be baked into `args` (they'd leak into process listings
+    /// and logs). `spawn` delegates here with an empty map so existing call
+    /// sites are unaffected.
+    /// What: Identical to `spawn` except `envs` is applied via
+    /// `Command::envs` before spawning, overlaying (not replacing) the
+    /// inherited environment.
+    /// Test: `spawn_with_env_makes_variable_visible_to_child` (unix-only,
+    /// spawns `sh -c 'echo $FOO'` and asserts the child observed the value).
+    pub async fn spawn_with_env(
+        binary: &str,
+        args: &[&str],
+        client_name: impl Into<String>,
+        envs: &std::collections::HashMap<String, String>,
+    ) -> Result<Self> {
         let mut child = Command::new(binary)
             .args(args)
+            .envs(envs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(plugin_stderr_stdio(binary))

--- a/crates/trusty-common/src/stdio_mcp_client/mod.rs
+++ b/crates/trusty-common/src/stdio_mcp_client/mod.rs
@@ -356,6 +356,33 @@ mod tests {
         assert!(r.is_err());
     }
 
+    /// Why: `spawn_with_env` exists so MCP servers that need credentials
+    /// (`API_KEY`, `DB_URL`, …) declared in `.mcp.json` or `[[mcp.services]]`
+    /// receive them without baking secrets into `args`. Verify the child
+    /// process actually observes the overlaid variable.
+    /// What: Spawns `sh -c 'echo $FOO_TEST_VAR'` with `FOO_TEST_VAR` set via
+    /// `spawn_with_env`, reads the raw line the shell printed to stdout, and
+    /// asserts it matches the value supplied (not empty / not inherited).
+    /// Test: This test.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn spawn_with_env_makes_variable_visible_to_child() {
+        let mut envs = std::collections::HashMap::new();
+        envs.insert("FOO_TEST_VAR".to_string(), "bar-value-123".to_string());
+        let mut client = StdioMcpClient::spawn_with_env(
+            "sh",
+            &["-c", "echo \"$FOO_TEST_VAR\""],
+            "test-client",
+            &envs,
+        )
+        .await
+        .unwrap();
+        let mut line = String::new();
+        use tokio::io::AsyncBufReadExt;
+        client.stdout.read_line(&mut line).await.unwrap();
+        assert_eq!(line.trim(), "bar-value-123");
+    }
+
     /// Why: Issue #421 — if the MCP child dies between calls, writing to its
     /// stdin blocks for the full 30s timeout. `is_alive()` must report false
     /// so callers can respawn before writing.


### PR DESCRIPTION
## Summary

Generic runtime MCP-server registration path for `trusty-agents` (MVP epic #3052 keystone). Agents become connectable to **any** configured MCP server — not just the ones someone remembered to hand-list statically — by live-spawning the server, running `tools/list`, and registering every advertised tool as a `ToolExecutor`.

Closes #3238

## Architecture

**New module: `crates/trusty-agents/src/tools/mcp_live/`** (all files under the 500-SLOC cap):
- `spec.rs` — `McpServerSpec` (name/command/args/env/source) + `gather_specs()`, which merges two sources: `[[mcp.services]]` entries with the new `discover = true` flag, and `.mcp.json` `mcpServers` entries. Config wins on a name collision.
- `executor.rs` — `LiveMcpTool: ToolExecutor`, wrapping one discovered tool. Schema is a **passthrough** of the server's real `inputSchema` (not a synthetic open object like the static path uses), so the LLM sees accurate argument shapes.
- `mod.rs` — `live_mcp_tool_executors(project_dir, existing_names)`, the single construction helper both assembly points call.

**Spawn/caching model:** reuses (and extends) the existing `ServiceClient` lazy-`OnceCell<Mutex<StdioMcpClient>>`-per-server pattern from `mcp_service_tools.rs` — one subprocess per server, cached across calls — rather than duplicating it. `tools/list` runs *eagerly* at registry-build time (discovery inherently needs the process up), while `tools/call` still only happens on demand. `ServiceClient` gained an `env` field and a `list_tools()` passthrough shared by both the static and live paths.

**Env support (new):** `StdioMcpClient::spawn` had no way to pass environment variables to the child process, which many real MCP servers need (API keys, DB URLs). Added `StdioMcpClient::spawn_with_env` in `trusty-common` (`spawn` now delegates to it with an empty map — zero behavior change for existing callers). Covered by a new unix test spawning `sh -c 'echo $VAR'`.

**Shared `.mcp.json` parser:** extracted the inline parsing that used to live only in `init::seed::seed_mcp_connections` (memory-seeding) into `crates/trusty-agents/src/mcp/mcp_json.rs` (`McpJsonServer`, `discover_mcp_json_paths`, `parse_mcp_json_servers`). Both the memory-seeder and the new live-discovery path now share one implementation instead of two that could drift.

## Config surface

- `McpService` (`[[mcp.services]]`) gains two new fields, both backward-compatible via `#[serde(default)]`:
  - `discover: bool` (default `false`) — when `true`, ignore the static `tools` list entirely and live-discover instead. The existing static builder (`mcp_service_tools::build_executors_from_services`) now skips any service with `discover = true`, so a tool can never be double-registered from both paths.
  - `env: HashMap<String, String>` (default empty) — overlaid on the spawned process's environment.
- `.mcp.json` `mcpServers` entries are loaded automatically as discover-mode specs at registry-build time (project `.mcp.json` first, then `~/.claude/.mcp.json`).
- **Precedence:** a `[[mcp.services]] discover = true` entry wins over a `.mcp.json` entry of the same name (operator-curated config over auto-discovered file).
- `mcp_add` (the LLM-facing tool) gained a `discover` schema property + parsing in `dispatch.rs` (not `env`, deliberately — avoids encouraging secrets in chat).

## Collision + failure policy

- **Duplicate tool names:** skip-with-warning, keep the earlier registration — matches the existing `mcp_service_tools` static-path convention rather than introducing a second (prefixing) one. Dedup is seeded from the caller's already-registered tool names (`existing_names`), so a live-discovered tool can never shadow a tool from any other source either.
- **Discovery failure** (spawn/handshake/`tools/list` failure) for one server: `tracing::warn!` and skip that server only — never aborts registry construction, matching the `ToolRegistryBuilder` precedent.

## Wiring (both assembly points, same helper)

- `ctrl::pm_task::dispatch::persona::run_pm_task_with_persona` — added inline, after the existing static tool registration, before allow-glob filtering.
- `runtime::subagent_mode` (sub-agent registry construction) — added right after the existing (synchronous) `tool_registry::build_registry_for_agent` call. That function stays synchronous deliberately: ~10 existing `#[test]`s call it directly, and folding async discovery into it would force every one of them to become `#[tokio::test]` for no benefit. Doing the async step at the (already async) call site gives both assembly points the same discovered tool set without touching that function's signature.

## Gating (unchanged)

Registering a live-discovered tool does not grant access — both assembly points still run the result through the agent's `[tools].allow` glob and RBAC tier filtering exactly as before. A glob like `"tm_*"` is how an agent opts into a discovered server's tools.

## Test evidence

```
$ cargo test -p trusty-agents mcp_live
running 12 tests
test tools::mcp_live::executor::tests::build_tool_schema_falls_back_when_input_schema_absent ... ok
test tools::mcp_live::executor::tests::build_tool_schema_passes_through_input_schema ... ok
test tools::mcp_live::executor::tests::execute_surfaces_spawn_failure_as_recoverable_error ... ok
test tools::mcp_live::spec::tests::gather_specs_includes_discover_services ... ok
test tools::mcp_live::spec::tests::gather_specs_excludes_non_discover_and_disabled ... ok
test tools::mcp_live::spec::tests::gather_specs_skips_non_stdio_and_empty_command ... ok
test tools::mcp_live::spec::tests::gather_specs_config_service_wins_over_mcp_json_by_name ... ok
test tools::mcp_live::tests::execute_round_trips_a_tools_call ... ok
test tools::mcp_live::tests::server_spawn_failure_warns_and_skips_that_server_only ... ok
test tools::mcp_live::tests::existing_names_prevent_shadowing_already_registered_tools ... ok
test tools::mcp_live::tests::discovery_registers_advertised_tools_as_executors ... ok
test tools::mcp_live::tests::duplicate_tool_names_across_servers_keep_first ... ok
test result: ok. 12 passed; 0 failed

$ cargo test -p trusty-agents tools::
test result: ok. 305 passed; 0 failed

$ cargo test -p trusty-agents mcp:: / mcp_tools / init::tests::mcp_tests / runtime::tool_registry
all green (21 + 7 + 4 + 10 passed)

$ cargo test -p trusty-common --lib --features stdio-mcp-client
test result: ok. 181 passed; 0 failed  (incl. new spawn_with_env_makes_variable_visible_to_child)

$ cargo clippy -p trusty-agents --all-targets -- -D warnings   → clean
$ cargo clippy -p trusty-common --all-targets --features stdio-mcp-client -- -D warnings → clean
$ cargo fmt --check   → clean
$ bash scripts/check_line_cap.sh   → line-cap: 10 allowlisted, 0 violations — OK.
$ cargo check --workspace (SKIP_UI_BUILD=1) → clean except trusty-mpm-gui / trusty-code-gui,
    which fail on a missing pre-built ui/dist (pnpm build prerequisite) — pre-existing,
    unrelated to this change, outside the "AVOID TOUCHING" ui/** scope for trusty-agents.
```

Fake-MCP-server tests use the same technique `trusty_common::stdio_mcp_client`'s own tests already use: a `sh -c` one-liner matching JSON-RPC method substrings and printing canned responses — no external binary or new test harness needed.

## Test plan

- [x] `discovery_registers_advertised_tools_as_executors` — live server's `tools/list` output becomes real `ToolExecutor`s
- [x] `execute_round_trips_a_tools_call` — `tools/call` dispatches through and returns the server's content
- [x] `server_spawn_failure_warns_and_skips_that_server_only` — one bad server doesn't take down discovery
- [x] `duplicate_tool_names_across_servers_keep_first` — collision policy
- [x] `existing_names_prevent_shadowing_already_registered_tools` — dedup against the caller's registry
- [x] `gather_specs_config_service_wins_over_mcp_json_by_name` — precedence
- [x] `discover_services_skip_static_tool_list` — `discover=true` ignores the static `tools` list

Not merging per instructions — opening for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)