### PR TITLE
fix(trusty-agents-ui): split src-tauri main.rs under the 500-SLOC cap

### DIFF
--- a/crates/trusty-agents/src/api/server/state.rs
+++ b/crates/trusty-agents/src/api/server/state.rs
@@ -154,7 +154,9 @@ impl AppState {
     /// What: Removes the task's stored `AbortHandle` (it's done either way)
     /// and, only if the current stored status isn't already `Cancelled`,
     /// performs the same insert/trim/persist `upsert` does.
-    /// Test: `finalize_task_does_not_clobber_cancelled`.
+    /// Test: `cancel_running_task_marks_cancelled` covers this directly —
+    /// its final assertions check that a late `finalize_task` call from an
+    /// aborted future does not clobber the already-cancelled record.
     pub(super) async fn finalize_task(&self, id: String, resp: PmResponse) {
         let snapshot = {
             let mut store = self.inner.lock().await;
@@ -186,7 +188,10 @@ impl AppState {
     /// acquire the lock.
     /// What: Inserts `handle` keyed by `id`, unless `id`'s stored response is
     /// already non-`Running`.
-    /// Test: `register_handle_skips_already_terminal_task`.
+    /// Test: exercised indirectly by every test in `tests::cancel` via
+    /// `spawn_fake_running_task` (the normal not-yet-terminal insert path);
+    /// the pathologically-fast-completion terminal-skip guard itself has no
+    /// dedicated regression test yet.
     pub(super) async fn register_handle(&self, id: &str, handle: AbortHandle) {
         let mut store = self.inner.lock().await;
         let terminal = matches!(

--- a/crates/trusty-agents/src/workflow/engine/executor/resume.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/resume.rs
@@ -12,7 +12,7 @@
 //! matches the checkpointed phase list), reconstructs context, and delegates
 //! to `run_phase_loop`. `ResumeOutcome` distinguishes "already finished,
 //! nothing to resume" from "picked back up and ran".
-//! Test: `checkpoint_resume_tests` in the engine `tests` submodule.
+//! Test: `checkpoint_resume` in the engine `tests` submodule.
 
 use std::path::PathBuf;
 

--- a/crates/trusty-agents/ui/src-tauri/src/main.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/main.rs
@@ -16,8 +16,10 @@
 //! Show/Quit lets the user bring the window back or fully quit. The sidecar
 //! is only reaped on a real quit (tray "Quit", Cmd+Q, or app-menu Quit — all
 //! surface as `RunEvent::ExitRequested`). #3061 adds the
-//! `read_personalization_overlay` / `write_personalization_overlay` pair so
-//! the Personality panel can edit the user's `~/.trusty-agents/agents/*.md`
+//! `read_personalization_overlay` / `write_personalization_overlay` pair
+//! (implementation lives in [`personalization`], split out in #3270 to keep
+//! this file under the workspace's 500-SLOC production-file cap) so the
+//! Personality panel can edit the user's `~/.trusty-agents/agents/*.md`
 //! overlay directly — both operate ONLY under that fixed `$HOME` directory,
 //! gated by a strict `[a-zA-Z0-9_-]+` slug check on `name` (no path
 //! separators, no `..` traversal). #3063 adds `cancel_task`, proxying
@@ -29,13 +31,16 @@
 //! sending a message produces a chat bubble that grows while polling the
 //! task id. Tray hide/show/quit behavior is smoke-tested manually (see PR
 //! description) — Tauri's window-manager event loop isn't unit-testable
-//! from this crate. Personalization overlay commands are covered by
-//! `personalization_overlay_path_*` unit tests below.
+//! from this crate. Personalization overlay commands are covered by unit
+//! tests in [`personalization`].
 
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod personalization;
+
 use std::sync::Arc;
 
+use personalization::{read_personalization_overlay, write_personalization_overlay};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::menu::{Menu, MenuItem};
@@ -425,127 +430,6 @@ async fn cancel_task(state: State<'_, SharedApi>, task_id: String) -> Result<Val
     Ok(Value::Object(obj))
 }
 
-/// Result payload for `read_personalization_overlay`.
-///
-/// Why: The frontend needs to tell "file exists with this content" apart
-/// from "file does not exist yet" so it can offer a starter template instead
-/// of rendering a blank/broken editor. A plain `Result<String, String>` would
-/// conflate a genuine not-found with a real I/O error.
-/// What: `content: None` signals not-found (the UI should offer the starter
-/// template); `content: Some(text)` is the file's current contents. Real I/O
-/// errors (permission denied, etc.) still surface via the command's `Err`.
-/// Test: `personalization_overlay_path_rejects_traversal_and_separators`,
-/// manual: delete `~/.trusty-agents/agents/my-assistant.md`, open the panel,
-/// confirm the starter-template prompt renders.
-#[derive(Debug, Serialize)]
-struct PersonalizationOverlay {
-    content: Option<String>,
-    path: String,
-}
-
-/// Validate an agent-name slug used to derive a personalization overlay path.
-///
-/// Why: `read_personalization_overlay` / `write_personalization_overlay`
-/// build a filesystem path from a frontend-supplied `name`. Without a strict
-/// allowlist a name like `../../etc/passwd` or an absolute path could escape
-/// `~/.trusty-agents/agents/` entirely — the fs commands must operate ONLY
-/// inside that fixed directory. Rejecting anything but `[a-zA-Z0-9_-]+`
-/// rules out path separators (`/`, `\`), `.` (so no `..` traversal or hidden
-/// dotfiles), and empty names in one check, with no need to reason about
-/// platform-specific separator quirks.
-/// What: Returns `true` iff `name` is non-empty and every char is an ASCII
-/// alphanumeric, `_`, or `-`.
-/// Test: `agent_slug_accepts_simple_names`,
-/// `agent_slug_rejects_path_separators_and_traversal`.
-fn is_valid_agent_slug(name: &str) -> bool {
-    !name.is_empty()
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-}
-
-/// Resolve the on-disk path for a personalization overlay, validating `name`.
-///
-/// Why: Centralizes both the slug check and the `$HOME`-anchored join so
-/// `read_personalization_overlay` and `write_personalization_overlay` can't
-/// drift (e.g. one command validating and the other forgetting to). Always
-/// resolves under the real `$HOME`, mirroring the backend's own
-/// `agents_dir_candidates()` `$HOME` fallback tier (trusty-agents#3061) — this
-/// is deliberately the ONLY tier the GUI writes to; it never touches
-/// `TAGENT_CONFIG_DIR` or a project-local `.trusty-agents/agents/`.
-/// What: Returns `Err` when `name` fails [`is_valid_agent_slug`] or `$HOME`
-/// is unset; otherwise `$HOME/.trusty-agents/agents/<name>.md`.
-/// Test: `personalization_overlay_path_rejects_traversal_and_separators`,
-/// `personalization_overlay_path_joins_home_dir`.
-fn personalization_overlay_path(name: &str) -> Result<std::path::PathBuf, String> {
-    if !is_valid_agent_slug(name) {
-        return Err(format!(
-            "invalid agent name '{name}': must match [a-zA-Z0-9_-]+ (no path separators or dots)"
-        ));
-    }
-    let home = std::env::var_os("HOME")
-        .ok_or_else(|| "cannot resolve personalization overlay: $HOME is not set".to_string())?;
-    Ok(std::path::PathBuf::from(home)
-        .join(".trusty-agents")
-        .join("agents")
-        .join(format!("{name}.md")))
-}
-
-/// Read a user's `~/.trusty-agents/agents/<name>.md` personalization overlay.
-///
-/// Why: The Personality panel needs the current overlay content (if any) to
-/// populate its editor on open, and a clear not-found signal (rather than an
-/// error) so the UI can offer a starter template for a first-time user.
-/// What: Resolves and validates the path via
-/// [`personalization_overlay_path`], then reads it. A missing file yields
-/// `Ok(PersonalizationOverlay { content: None, .. })`; any other I/O failure
-/// (permissions, etc.) is a genuine `Err`.
-/// Test: `personalization_overlay_path_rejects_traversal_and_separators`;
-/// manual: create/delete the target file and confirm both branches render
-/// correctly in the panel.
-#[tauri::command]
-fn read_personalization_overlay(name: String) -> Result<PersonalizationOverlay, String> {
-    let path = personalization_overlay_path(&name)?;
-    match std::fs::read_to_string(&path) {
-        Ok(content) => Ok(PersonalizationOverlay {
-            content: Some(content),
-            path: path.display().to_string(),
-        }),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(PersonalizationOverlay {
-            content: None,
-            path: path.display().to_string(),
-        }),
-        Err(e) => Err(format!(
-            "failed to read personalization overlay {}: {e}",
-            path.display()
-        )),
-    }
-}
-
-/// Write a user's `~/.trusty-agents/agents/<name>.md` personalization overlay.
-///
-/// Why: This is the Save action for the Personality panel — prose-only
-/// editing per #3061 (no structured schema). Creates the
-/// `~/.trusty-agents/agents/` directory on first write since a fresh install
-/// won't have it yet.
-/// What: Resolves and validates the path via
-/// [`personalization_overlay_path`], creates the parent directory if
-/// missing, then writes `content` verbatim (full overwrite, matching a plain
-/// text-editor Save).
-/// Test: `personalization_overlay_path_rejects_traversal_and_separators`;
-/// manual: edit + Save in the panel, confirm the file on disk matches and
-/// that `by_name`/`by_name_async` (trusty-agents#3061 loader fix) dispatch
-/// it.
-#[tauri::command]
-fn write_personalization_overlay(name: String, content: String) -> Result<(), String> {
-    let path = personalization_overlay_path(&name)?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
-    }
-    std::fs::write(&path, content).map_err(|e| format!("failed to write {}: {e}", path.display()))
-}
-
 /// Reap the spawned `trusty-agents --api` sidecar, exactly once.
 ///
 /// Why: The tray "Quit" item and the real-quit `RunEvent::ExitRequested`
@@ -705,117 +589,4 @@ fn tracing_subscriber_try_init() -> Result<(), String> {
     // No-op: we just inherit stderr from the Rust side, which is enough for
     // dev. Hook in `tracing-subscriber` here when we want filtering.
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Why: `personalization_overlay_path` reads the process-global `$HOME`
-    // env var; these are the only tests in this crate that mutate it, but
-    // `cargo test` still runs them concurrently on multiple threads within
-    // this binary unless serialized.
-    static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    #[test]
-    fn agent_slug_accepts_simple_names() {
-        assert!(is_valid_agent_slug("my-assistant"));
-        assert!(is_valid_agent_slug("my_assistant2"));
-        assert!(is_valid_agent_slug("A"));
-    }
-
-    #[test]
-    fn agent_slug_rejects_path_separators_and_traversal() {
-        assert!(!is_valid_agent_slug(""));
-        assert!(!is_valid_agent_slug("../etc/passwd"));
-        assert!(!is_valid_agent_slug(".."));
-        assert!(!is_valid_agent_slug("foo/bar"));
-        assert!(!is_valid_agent_slug("foo\\bar"));
-        assert!(!is_valid_agent_slug("/etc/passwd"));
-        assert!(!is_valid_agent_slug("my-assistant.md"));
-        assert!(!is_valid_agent_slug("my assistant"));
-    }
-
-    #[test]
-    fn personalization_overlay_path_rejects_traversal_and_separators() {
-        let err = personalization_overlay_path("../../etc/passwd")
-            .expect_err("traversal must be rejected");
-        assert!(err.contains("invalid agent name"));
-    }
-
-    #[test]
-    fn personalization_overlay_path_joins_home_dir() {
-        let _guard = HOME_LOCK.lock().expect("lock poisoned");
-        let tmp = std::env::temp_dir().join(format!("t3061-home-{}", std::process::id()));
-        let prev = std::env::var_os("HOME");
-        // SAFETY: guarded by HOME_LOCK; restored before returning.
-        unsafe {
-            std::env::set_var("HOME", &tmp);
-        }
-        let path = personalization_overlay_path("my-assistant").expect("valid slug");
-        // SAFETY: guarded by HOME_LOCK.
-        unsafe {
-            match &prev {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-        assert_eq!(
-            path,
-            tmp.join(".trusty-agents")
-                .join("agents")
-                .join("my-assistant.md")
-        );
-    }
-
-    #[test]
-    fn read_personalization_overlay_reports_not_found_without_error() {
-        let _guard = HOME_LOCK.lock().expect("lock poisoned");
-        let tmp = std::env::temp_dir().join(format!("t3061-home-nf-{}", std::process::id()));
-        let prev = std::env::var_os("HOME");
-        // SAFETY: guarded by HOME_LOCK; restored before returning.
-        unsafe {
-            std::env::set_var("HOME", &tmp);
-        }
-        let result = read_personalization_overlay("does-not-exist".to_string());
-        // SAFETY: guarded by HOME_LOCK.
-        unsafe {
-            match &prev {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-        let overlay = result.expect("missing file is Ok(None), not Err");
-        assert!(overlay.content.is_none());
-    }
-
-    #[test]
-    fn write_then_read_personalization_overlay_round_trips() {
-        let _guard = HOME_LOCK.lock().expect("lock poisoned");
-        let tmp = std::env::temp_dir().join(format!("t3061-home-rw-{}", std::process::id()));
-        let prev = std::env::var_os("HOME");
-        // SAFETY: guarded by HOME_LOCK; restored before returning.
-        unsafe {
-            std::env::set_var("HOME", &tmp);
-        }
-        let write_result = write_personalization_overlay(
-            "my-assistant".to_string(),
-            "---\nname: my-assistant\n---\n\nBe helpful.\n".to_string(),
-        );
-        let read_result = read_personalization_overlay("my-assistant".to_string());
-        // SAFETY: guarded by HOME_LOCK.
-        unsafe {
-            match &prev {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
-        let _ = std::fs::remove_dir_all(&tmp);
-        write_result.expect("write should succeed, creating the dir");
-        let overlay = read_result.expect("read should succeed after write");
-        assert_eq!(
-            overlay.content.as_deref(),
-            Some("---\nname: my-assistant\n---\n\nBe helpful.\n")
-        );
-    }
 }

--- a/crates/trusty-agents/ui/src-tauri/src/personalization.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/personalization.rs
@@ -1,0 +1,247 @@
+//! Personalization overlay commands (`~/.trusty-agents/agents/<name>.md`).
+//!
+//! Why: Extracted from `main.rs` (#3270) purely to keep that file under the
+//! workspace's 500-SLOC production-file cap; this is a pure code-motion split
+//! with no behavior change. The Personality panel needs to read and write a
+//! user's prose-only agent overlay file without the frontend ever supplying a
+//! raw filesystem path — `name` is validated to a strict slug before any I/O.
+//! What: `PersonalizationOverlay` (the read result shape),
+//! `is_valid_agent_slug` / `personalization_overlay_path` (shared validation +
+//! path resolution), and the `read_personalization_overlay` /
+//! `write_personalization_overlay` Tauri commands themselves.
+//! Test: unit tests below cover slug validation, path resolution/traversal
+//! rejection, and the read/write round trip.
+
+/// Result payload for `read_personalization_overlay`.
+///
+/// Why: The frontend needs to tell "file exists with this content" apart
+/// from "file does not exist yet" so it can offer a starter template instead
+/// of rendering a blank/broken editor. A plain `Result<String, String>` would
+/// conflate a genuine not-found with a real I/O error.
+/// What: `content: None` signals not-found (the UI should offer the starter
+/// template); `content: Some(text)` is the file's current contents. Real I/O
+/// errors (permission denied, etc.) still surface via the command's `Err`.
+/// Test: `personalization_overlay_path_rejects_traversal_and_separators`,
+/// manual: delete `~/.trusty-agents/agents/my-assistant.md`, open the panel,
+/// confirm the starter-template prompt renders.
+#[derive(Debug, serde::Serialize)]
+pub struct PersonalizationOverlay {
+    content: Option<String>,
+    path: String,
+}
+
+/// Validate an agent-name slug used to derive a personalization overlay path.
+///
+/// Why: `read_personalization_overlay` / `write_personalization_overlay`
+/// build a filesystem path from a frontend-supplied `name`. Without a strict
+/// allowlist a name like `../../etc/passwd` or an absolute path could escape
+/// `~/.trusty-agents/agents/` entirely — the fs commands must operate ONLY
+/// inside that fixed directory. Rejecting anything but `[a-zA-Z0-9_-]+`
+/// rules out path separators (`/`, `\`), `.` (so no `..` traversal or hidden
+/// dotfiles), and empty names in one check, with no need to reason about
+/// platform-specific separator quirks.
+/// What: Returns `true` iff `name` is non-empty and every char is an ASCII
+/// alphanumeric, `_`, or `-`.
+/// Test: `agent_slug_accepts_simple_names`,
+/// `agent_slug_rejects_path_separators_and_traversal`.
+fn is_valid_agent_slug(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+/// Resolve the on-disk path for a personalization overlay, validating `name`.
+///
+/// Why: Centralizes both the slug check and the `$HOME`-anchored join so
+/// `read_personalization_overlay` and `write_personalization_overlay` can't
+/// drift (e.g. one command validating and the other forgetting to). Always
+/// resolves under the real `$HOME`, mirroring the backend's own
+/// `agents_dir_candidates()` `$HOME` fallback tier (trusty-agents#3061) — this
+/// is deliberately the ONLY tier the GUI writes to; it never touches
+/// `TAGENT_CONFIG_DIR` or a project-local `.trusty-agents/agents/`.
+/// What: Returns `Err` when `name` fails [`is_valid_agent_slug`] or `$HOME`
+/// is unset; otherwise `$HOME/.trusty-agents/agents/<name>.md`.
+/// Test: `personalization_overlay_path_rejects_traversal_and_separators`,
+/// `personalization_overlay_path_joins_home_dir`.
+fn personalization_overlay_path(name: &str) -> Result<std::path::PathBuf, String> {
+    if !is_valid_agent_slug(name) {
+        return Err(format!(
+            "invalid agent name '{name}': must match [a-zA-Z0-9_-]+ (no path separators or dots)"
+        ));
+    }
+    let home = std::env::var_os("HOME")
+        .ok_or_else(|| "cannot resolve personalization overlay: $HOME is not set".to_string())?;
+    Ok(std::path::PathBuf::from(home)
+        .join(".trusty-agents")
+        .join("agents")
+        .join(format!("{name}.md")))
+}
+
+/// Read a user's `~/.trusty-agents/agents/<name>.md` personalization overlay.
+///
+/// Why: The Personality panel needs the current overlay content (if any) to
+/// populate its editor on open, and a clear not-found signal (rather than an
+/// error) so the UI can offer a starter template for a first-time user.
+/// What: Resolves and validates the path via
+/// [`personalization_overlay_path`], then reads it. A missing file yields
+/// `Ok(PersonalizationOverlay { content: None, .. })`; any other I/O failure
+/// (permissions, etc.) is a genuine `Err`.
+/// Test: `personalization_overlay_path_rejects_traversal_and_separators`;
+/// manual: create/delete the target file and confirm both branches render
+/// correctly in the panel.
+#[tauri::command]
+pub fn read_personalization_overlay(name: String) -> Result<PersonalizationOverlay, String> {
+    let path = personalization_overlay_path(&name)?;
+    match std::fs::read_to_string(&path) {
+        Ok(content) => Ok(PersonalizationOverlay {
+            content: Some(content),
+            path: path.display().to_string(),
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(PersonalizationOverlay {
+            content: None,
+            path: path.display().to_string(),
+        }),
+        Err(e) => Err(format!(
+            "failed to read personalization overlay {}: {e}",
+            path.display()
+        )),
+    }
+}
+
+/// Write a user's `~/.trusty-agents/agents/<name>.md` personalization overlay.
+///
+/// Why: This is the Save action for the Personality panel — prose-only
+/// editing per #3061 (no structured schema). Creates the
+/// `~/.trusty-agents/agents/` directory on first write since a fresh install
+/// won't have it yet.
+/// What: Resolves and validates the path via
+/// [`personalization_overlay_path`], creates the parent directory if
+/// missing, then writes `content` verbatim (full overwrite, matching a plain
+/// text-editor Save).
+/// Test: `personalization_overlay_path_rejects_traversal_and_separators`;
+/// manual: edit + Save in the panel, confirm the file on disk matches and
+/// that `by_name`/`by_name_async` (trusty-agents#3061 loader fix) dispatch
+/// it.
+#[tauri::command]
+pub fn write_personalization_overlay(name: String, content: String) -> Result<(), String> {
+    let path = personalization_overlay_path(&name)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create {}: {e}", parent.display()))?;
+    }
+    std::fs::write(&path, content).map_err(|e| format!("failed to write {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Why: `personalization_overlay_path` reads the process-global `$HOME`
+    // env var; these are the only tests in this crate that mutate it, but
+    // `cargo test` still runs them concurrently on multiple threads within
+    // this binary unless serialized.
+    static HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn agent_slug_accepts_simple_names() {
+        assert!(is_valid_agent_slug("my-assistant"));
+        assert!(is_valid_agent_slug("my_assistant2"));
+        assert!(is_valid_agent_slug("A"));
+    }
+
+    #[test]
+    fn agent_slug_rejects_path_separators_and_traversal() {
+        assert!(!is_valid_agent_slug(""));
+        assert!(!is_valid_agent_slug("../etc/passwd"));
+        assert!(!is_valid_agent_slug(".."));
+        assert!(!is_valid_agent_slug("foo/bar"));
+        assert!(!is_valid_agent_slug("foo\\bar"));
+        assert!(!is_valid_agent_slug("/etc/passwd"));
+        assert!(!is_valid_agent_slug("my-assistant.md"));
+        assert!(!is_valid_agent_slug("my assistant"));
+    }
+
+    #[test]
+    fn personalization_overlay_path_rejects_traversal_and_separators() {
+        let err = personalization_overlay_path("../../etc/passwd")
+            .expect_err("traversal must be rejected");
+        assert!(err.contains("invalid agent name"));
+    }
+
+    #[test]
+    fn personalization_overlay_path_joins_home_dir() {
+        let _guard = HOME_LOCK.lock().expect("lock poisoned");
+        let tmp = std::env::temp_dir().join(format!("t3061-home-{}", std::process::id()));
+        let prev = std::env::var_os("HOME");
+        // SAFETY: guarded by HOME_LOCK; restored before returning.
+        unsafe {
+            std::env::set_var("HOME", &tmp);
+        }
+        let path = personalization_overlay_path("my-assistant").expect("valid slug");
+        // SAFETY: guarded by HOME_LOCK.
+        unsafe {
+            match &prev {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        assert_eq!(
+            path,
+            tmp.join(".trusty-agents")
+                .join("agents")
+                .join("my-assistant.md")
+        );
+    }
+
+    #[test]
+    fn read_personalization_overlay_reports_not_found_without_error() {
+        let _guard = HOME_LOCK.lock().expect("lock poisoned");
+        let tmp = std::env::temp_dir().join(format!("t3061-home-nf-{}", std::process::id()));
+        let prev = std::env::var_os("HOME");
+        // SAFETY: guarded by HOME_LOCK; restored before returning.
+        unsafe {
+            std::env::set_var("HOME", &tmp);
+        }
+        let result = read_personalization_overlay("does-not-exist".to_string());
+        // SAFETY: guarded by HOME_LOCK.
+        unsafe {
+            match &prev {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        let overlay = result.expect("missing file is Ok(None), not Err");
+        assert!(overlay.content.is_none());
+    }
+
+    #[test]
+    fn write_then_read_personalization_overlay_round_trips() {
+        let _guard = HOME_LOCK.lock().expect("lock poisoned");
+        let tmp = std::env::temp_dir().join(format!("t3061-home-rw-{}", std::process::id()));
+        let prev = std::env::var_os("HOME");
+        // SAFETY: guarded by HOME_LOCK; restored before returning.
+        unsafe {
+            std::env::set_var("HOME", &tmp);
+        }
+        let write_result = write_personalization_overlay(
+            "my-assistant".to_string(),
+            "---\nname: my-assistant\n---\n\nBe helpful.\n".to_string(),
+        );
+        let read_result = read_personalization_overlay("my-assistant".to_string());
+        // SAFETY: guarded by HOME_LOCK.
+        unsafe {
+            match &prev {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+        write_result.expect("write should succeed, creating the dir");
+        let overlay = read_result.expect("read should succeed after write");
+        assert_eq!(
+            overlay.content.as_deref(),
+            Some("---\nname: my-assistant\n---\n\nBe helpful.\n")
+        );
+    }
+}

--- a/crates/trusty-code/src/session/connector.rs
+++ b/crates/trusty-code/src/session/connector.rs
@@ -176,7 +176,7 @@ impl WorkstreamConnector for TcodeConnector {
     /// `session.create`'s `agent` param. A `400` (empty task, or `project`
     /// naming no real directory — see `session::protocol::create`'s AC-16.2
     /// docs) maps to [`ConnectorError::InvalidRequest`].
-    /// Test: `connector_e2e::create_session_binds_project_and_appears_in_list`,
+    /// Test: `connector_e2e::create_session_full_lifecycle`,
     /// `connector_e2e::create_session_wrong_backend_params_is_invalid_request`.
     async fn create_session(&self, req: CreateSessionReq) -> Result<SessionInfo, ConnectorError> {
         let CreateSessionReq {
@@ -294,7 +294,8 @@ impl WorkstreamConnector for TcodeConnector {
     /// [`ConnectorError::NotFound`]). On success, wraps
     /// `result.{session_id,stream_url,events}` in
     /// [`AttachHandle::EventStream`].
-    /// Test: `connector_e2e::attach_returns_event_stream_for_known_session`,
+    /// Test: `connector_e2e::create_session_full_lifecycle` (asserts the
+    /// returned handle is an `EventStream` with the expected `stream_url`),
     /// `connector_e2e::attach_unknown_id_is_not_found`.
     async fn attach(&self, session_id: &str) -> Result<AttachHandle, ConnectorError> {
         let rpc_req = json!({

--- a/crates/trusty-mpm/src/connectors/tm.rs
+++ b/crates/trusty-mpm/src/connectors/tm.rs
@@ -52,7 +52,9 @@ impl TmConnector {
     /// Why: the common case — a caller (eventually the lead agent) that
     /// doesn't know or care which daemon address is in play.
     /// What: delegates to [`resolve_daemon_url`] with no explicit override.
-    /// Test: `tm_tests::new_resolves_default_daemon_url`.
+    /// Test: `default_returned_when_no_lock_and_no_explicit` (in
+    /// `core::discovery`) covers `resolve_daemon_url`'s no-override branch
+    /// this method delegates to; `new()` itself has no dedicated test.
     pub fn new() -> Self {
         Self::with_daemon_url(resolve_daemon_url(None))
     }
@@ -142,7 +144,7 @@ impl WorkstreamConnector for TmConnector {
     /// fields; `agent` has no equivalent on tm's spawn request and is
     /// silently ignored (see [`CreateSessionReq`]'s docs on why that's
     /// intentional, not a data-loss bug).
-    /// Test: `tm_tests::create_session_spawns_and_appears_in_list`,
+    /// Test: `tm_tests::create_session_full_lifecycle`,
     /// `tm_tests::create_session_wrong_backend_params_is_invalid_request`.
     async fn create_session(&self, req: CreateSessionReq) -> Result<SessionInfo, ConnectorError> {
         let CreateSessionReq {
@@ -198,7 +200,7 @@ impl WorkstreamConnector for TmConnector {
     /// Why: mirrors `daemon::managed_routes::list_managed_sessions`.
     /// What: unwraps the `{"sessions": [...]}` envelope and maps each
     /// `ManagedSessionSummary` onto a portable `SessionInfo`.
-    /// Test: `tm_tests::create_session_spawns_and_appears_in_list`,
+    /// Test: `tm_tests::create_session_full_lifecycle`,
     /// `tm_tests::list_sessions_empty_fleet_returns_empty_vec`.
     async fn list_sessions(&self) -> Result<Vec<SessionInfo>, ConnectorError> {
         let url = format!("{}/api/v1/sessions/managed", self.daemon_url);
@@ -216,7 +218,8 @@ impl WorkstreamConnector for TmConnector {
     /// What: a 404 maps to [`ConnectorError::NotFound`] via
     /// [`map_error_response`]; otherwise the summary's `state` and
     /// `pending_decision` populate the [`SessionStatus`].
-    /// Test: `tm_tests::session_status_returns_state_for_known_session`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (known-session path,
+    /// via `ConnectorTestKit::assert_basic_lifecycle`),
     /// `tm_tests::session_status_unknown_id_is_not_found`.
     async fn session_status(&self, session_id: &str) -> Result<SessionStatus, ConnectorError> {
         let url = format!("{}/api/v1/sessions/managed/{session_id}", self.daemon_url);
@@ -268,7 +271,8 @@ impl WorkstreamConnector for TmConnector {
     /// What: wraps the daemon's `attach_cmd` string in
     /// [`AttachHandle::ShellCommand`]. A 404 (unknown session) maps to
     /// [`ConnectorError::NotFound`].
-    /// Test: `tm_tests::attach_returns_shell_command_for_known_session`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (asserts the
+    /// returned handle is a `ShellCommand` containing `tmux attach`),
     /// `tm_tests::attach_unknown_id_is_not_found`.
     async fn attach(&self, session_id: &str) -> Result<AttachHandle, ConnectorError> {
         let url = format!(
@@ -313,7 +317,8 @@ impl WorkstreamConnector for TmConnector {
     /// `isError: true` into [`ConnectorError::Backend`] (`"no such
     /// session"`/circuit-breaker-open messages land here) and a malformed
     /// envelope into [`ConnectorError::Transport`].
-    /// Test: `tm_tests::delegate_records_a_delegation`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (asserts a
+    /// non-empty `delegate_id` against a live session),
     /// `tm_tests::delegate_unknown_session_is_backend_error`.
     async fn delegate(
         &self,


### PR DESCRIPTION
## Summary

- P0: origin/main's line-cap gate (`scripts/check_line_cap.sh`) was RED because `crates/trusty-agents/ui/src-tauri/src/main.rs` had grown to 518 SLOC (unallowlisted, cap 500), blocking every open PR's CI.
- Pure code motion: extracted the personalization-overlay commands (`PersonalizationOverlay`, `is_valid_agent_slug`, `personalization_overlay_path`, `read_personalization_overlay`, `write_personalization_overlay`, and their unit tests) into a new `crates/trusty-agents/ui/src-tauri/src/personalization.rs` module, wired via `mod personalization;` + `use personalization::{read_personalization_overlay, write_personalization_overlay};` and the existing `tauri::generate_handler!` registration list.
- Zero behavioral change — same commands, same validation, same tests, just relocated.
- `main.rs`: 518 → 374 SLOC. `personalization.rs`: 0 → 146 SLOC. Both well under the 500-SLOC production cap.
- **Also fixes a second red gate found on `origin/main`**: 11 dangling `Test:` doc-comment pointer citations (`scripts/check_test_pointers.sh`) across `trusty-agents`, `trusty-code`, and `trusty-mpm` — doc-comment-only, zero code changes. Cherry-picked from PR #3282 (branch `fix-3256-doccomment`, commit `ed719b67`) to break the circular red-check deadlock: #3272 was red on the pointer lint, #3282 was red on line-cap, and neither could merge fully green alone.

Closes #3270
Closes #3273
Closes #3256

## Test plan

- [x] `bash scripts/check_line_cap.sh` → `line-cap: 10 allowlisted, 0 violations — OK.` (exit 0)
- [x] `bash scripts/check_test_pointers.sh` → `test-pointers: 0 dangling pointers — OK.` (exit 0)
- [x] `SKIP_UI_BUILD=1 cargo check -p trusty-agents-ui` → clean
- [x] `cargo check -p trusty-agents -p trusty-code -p trusty-mpm` → clean
- [x] `cargo fmt --check -p trusty-agents-ui` → clean
- [x] `cargo fmt --check` (workspace) → clean
- [x] `SKIP_UI_BUILD=1 cargo clippy -p trusty-agents-ui --all-targets -- -D warnings` → clean
- [x] `SKIP_UI_BUILD=1 cargo test -p trusty-agents-ui` → 6 passed, 0 failed

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
