### PR TITLE
fix(trusty-console): apply write-origin guard router-wide + bind-aware self-origin allowlist

### DIFF
--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -7,7 +7,6 @@
 # and /* ... */ block comments (including multi-line spans). Trailing-comment lines count.
 # Ratchet: budgets may only DECREASE; when a file drops <= its applicable cap, remove it.
 # Regenerate with: scripts/check_line_cap.sh --update  (use --seed only to bootstrap).
-crates/trusty-console/src/server.rs	922
 crates/trusty-git-analytics/src/collect/collector.rs	766
 crates/trusty-mpm/src/core/gh_account.rs	537
 crates/trusty-mpm/src/daemon/api.rs	1273

--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -254,9 +254,9 @@ crates/trusty-common/src/update/mod.rs	check_throttled_uses_cache
 crates/trusty-console/src/bind.rs	test_port_from_addr
 crates/trusty-console/src/mcp_handle/mod.rs	call_tool_raw_absent_binary_returns_error
 crates/trusty-console/src/mcp_handle/mod.rs	mcp_handle_degraded_when_console_metrics_missing
-crates/trusty-console/src/server.rs	test_analyze_visualize_handler_absent_binary_returns_503
-crates/trusty-console/src/server.rs	test_analyze_visualize_handler_no_index_returns_400
-crates/trusty-console/src/server.rs	test_services_route_daemon_version_overlay
+crates/trusty-console/src/server/mod.rs	test_analyze_visualize_handler_absent_binary_returns_503
+crates/trusty-console/src/server/mod.rs	test_analyze_visualize_handler_no_index_returns_400
+crates/trusty-console/src/server/mod.rs	test_services_route_daemon_version_overlay
 crates/trusty-cto-db/src/lib.rs	open_readonly_rejects_writes
 crates/trusty-embedderd/src/lib.rs	try_parse_from
 crates/trusty-embedderd/src/stdio_server.rs	stdio_eof_terminates_cleanly

--- a/crates/trusty-console/CHANGELOG.md
+++ b/crates/trusty-console/CHANGELOG.md
@@ -10,6 +10,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Security (P1):** the write-origin (CSRF) guard is now applied
+  router-wide via `Router::layer` instead of a route-scoped `route_layer`, so
+  it also covers the reverse-proxied upstream daemon routes
+  (`/api/{service}/{*path}`, `/proxy/{daemon}/{*path}`) — previously a
+  cross-origin page could reach destructive daemon endpoints (index deletion,
+  daemon shutdown) through the proxy unguarded (closes #3268).
+- the same guard is now bind-aware: in Tailscale bind mode the console's own
+  resolved non-loopback bind address is trusted as an additional self-origin
+  (narrowly, not the whole CGNAT range), fixing 403s on the console's own
+  write UI when bound on a Tailscale address (closes #3269).
 - the cross-crate `default_port_does_not_collide_with_known_siblings`
   port-contract table now also tracks trusty-embedderd's `--http` mode
   default (7890) and trusty-review's corrected default (7891), closing the

--- a/crates/trusty-console/src/lib.rs
+++ b/crates/trusty-console/src/lib.rs
@@ -408,7 +408,13 @@ pub async fn run_serve(args: ServeArgs) -> Result<()> {
         }
     }
 
-    let router = server::build_router(state.clone());
+    // #3269: trust the console's own non-loopback bind address(es) (e.g. the
+    // Tailscale CGNAT address in `--tailscale` mode) as write-origin
+    // self-origins, so the console's own write UI served from that address is
+    // not 403'd by the same-origin guard. Loopback stays trusted unconditionally
+    // regardless of bind mode.
+    let self_origins = routes::origin_guard::SelfOrigins::from_bind_addrs(&addrs);
+    let router = server::build_router_with_self_origins(state.clone(), self_origins);
 
     // ── bind primary listener ───────────────────────────────────────────────
     let primary_addr = *addrs.first().context("bind address list is empty")?;

--- a/crates/trusty-console/src/routes/origin_guard.rs
+++ b/crates/trusty-console/src/routes/origin_guard.rs
@@ -1,31 +1,102 @@
-//! Same-origin guard for destructive console write routes (#1222 review #3).
+//! Same-origin guard for destructive console write routes (#1222 review #3,
+//! router-wide since #3268, bind-aware since #3269).
 //!
 //! Why: the console serves its HTTP API behind `CorsLayer::permissive()` (CORS is
 //! intentionally open so the SPA, tailnet clients, and tooling can read state).
-//! That is fine for the GET/read surface, but the session write routes
-//! (`POST /sessions`, `…/{id}/stop`, `…/{id}/resume`, `DELETE /{id}`,
-//! `…/supervisor/auto-resume`) are DESTRUCTIVE — a permissive CORS policy plus
+//! That is fine for the GET/read surface, but the state-changing write routes —
+//! including the session write routes (`POST /sessions`, `…/{id}/stop`,
+//! `…/{id}/resume`, `DELETE /{id}`, `…/supervisor/auto-resume`) AND the
+//! reverse-proxied upstream daemon routes (`/api/{service}/{*path}`,
+//! `/proxy/{daemon}/{*path}`) — are DESTRUCTIVE. A permissive CORS policy plus
 //! no auth means any web page the operator visits could fire a cross-origin
-//! `fetch` (a classic CSRF vector) and spawn/stop/decommission sessions. The
-//! console is a loopback/tailnet operator tool, so the proportionate, minimal
-//! defence (not full auth) is a same-origin check: a browser always sends an
-//! `Origin` header on cross-origin state-changing requests, so we reject a write
-//! whose `Origin` is present and is NOT a loopback host. Requests with no
-//! `Origin` (curl, the console's own server-side calls, native MCP clients) are
-//! allowed — they are not the CSRF threat model.
-//! What: [`guard_write_origin`] is an axum middleware: it inspects the `Origin`
-//! header; absent → pass through; present and loopback (`localhost`,
-//! `127.0.0.0/8`, `[::1]`) → pass through; present and non-loopback → `403`.
-//! [`origin_is_loopback`] is the pure host-classification helper it delegates to.
-//! Test: `origin_is_loopback_*` unit tests below classify hosts; the middleware
-//! itself is exercised end-to-end by `server.rs`'s
-//! `write_route_rejects_cross_origin` / `…_allows_loopback_origin` /
-//! `…_allows_missing_origin` integration tests.
+//! `fetch` (a classic CSRF vector) and spawn/stop/decommission sessions, or
+//! reach destructive daemon endpoints through the proxy (index deletion, daemon
+//! shutdown, etc — #3268). The console is a loopback/tailnet operator tool, so
+//! the proportionate, minimal defence (not full auth) is a same-origin check: a
+//! browser always sends an `Origin` header on cross-origin state-changing
+//! requests, so we reject a write whose `Origin` is present and is NOT one of
+//! the trusted self-origins. Requests with no `Origin` (curl, the console's own
+//! server-side calls, native MCP clients) are allowed — they are not the CSRF
+//! threat model.
+//!
+//! The guard is applied **router-wide** via `Router::layer` in
+//! `server::build_router` (not `route_layer`, which only covers routes
+//! registered before it in the same chain — the root cause of #3268: the
+//! reverse-proxy routes are declared after the `route_layer` call and were
+//! never guarded). A single router-wide `.layer()` covers every route,
+//! including routes added later, so the proxy surface is protected too.
+//!
+//! Trusted self-origins are not limited to loopback: when the console binds on
+//! a non-loopback address (e.g. Tailscale CGNAT `100.64.0.0/10`, #3269), the
+//! server's own actually-resolved bind addresses are passed in as an
+//! additional allowlist (see [`SelfOrigins`]) so the console's own write UI,
+//! served from that address, is not 403'd. This does NOT open the guard to
+//! arbitrary non-loopback origins — only the exact addresses the server itself
+//! is listening on.
+//!
+//! What: [`guard_write_origin`] is an axum middleware constructor: it captures
+//! a [`SelfOrigins`] allowlist and returns a middleware function that inspects
+//! the `Origin` header; absent → pass through; present and matching loopback OR
+//! a trusted self-origin → pass through; otherwise → `403`.
+//! [`origin_is_loopback`] classifies loopback hosts; [`origin_matches_self`]
+//! additionally checks the bind-derived allowlist.
+//! Test: `origin_is_loopback_*` / `origin_matches_self_*` unit tests below
+//! classify hosts; the middleware itself is exercised end-to-end by
+//! `server/tests.rs`'s `write_route_rejects_cross_origin` /
+//! `…_allows_loopback_origin` / `…_allows_missing_origin` /
+//! `proxy_route_rejects_cross_origin_write` /
+//! `proxy_route_allows_self_origin_write` integration tests.
 
-use axum::extract::Request;
+use std::collections::HashSet;
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use axum::extract::{Request, State};
 use axum::http::{StatusCode, header::ORIGIN};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
+
+/// The set of non-loopback addresses the console itself is bound to.
+///
+/// Why: #3269 — the origin guard must trust the console's own served origin
+/// even when it is not loopback (Tailscale bind mode), without opening the
+/// door to arbitrary remote origins. Wrapping the bind-derived addresses in a
+/// dedicated `Arc`-backed type keeps the allowlist cheap to clone into the
+/// middleware closure and keeps its provenance explicit (always derived from
+/// `bind::resolve_bind_addrs`, never user input).
+/// What: An `Arc<HashSet<SocketAddr>>` newtype with `Default` (empty — the
+/// loopback-only behaviour used by every existing test and by `Local` bind
+/// mode) and a `From<&[SocketAddr]>` / `FromIterator` constructor.
+/// Test: `origin_matches_self_*` below; `guard_write_origin` integration tests
+/// in `server/tests.rs`.
+#[derive(Debug, Clone, Default)]
+pub struct SelfOrigins(Arc<HashSet<SocketAddr>>);
+
+impl FromIterator<SocketAddr> for SelfOrigins {
+    fn from_iter<T: IntoIterator<Item = SocketAddr>>(iter: T) -> Self {
+        Self(Arc::new(iter.into_iter().collect()))
+    }
+}
+
+impl SelfOrigins {
+    /// Build a `SelfOrigins` allowlist from the server's resolved bind
+    /// addresses, keeping only non-loopback entries (loopback is always
+    /// trusted by [`origin_is_loopback`], so it need not be duplicated here).
+    ///
+    /// Why: `bind::resolve_bind_addrs` returns every address the server binds
+    /// (loopback plus, in Tailscale mode, the tailnet address); the guard only
+    /// needs the non-loopback ones as extra trust anchors.
+    /// What: Filters `addrs` to non-loopback `SocketAddr`s and collects them.
+    /// Test: `origin_matches_self_trusts_bind_derived_tailscale_addr` below.
+    pub fn from_bind_addrs(addrs: &[SocketAddr]) -> Self {
+        addrs
+            .iter()
+            .copied()
+            .filter(|a| !a.ip().is_loopback())
+            .collect()
+    }
+}
 
 /// Classify whether an `Origin` header value names a loopback host.
 ///
@@ -39,53 +110,103 @@ use axum::response::{IntoResponse, Response};
 /// `::1` IPv6 loopback. Anything else (including a missing host) is `false`.
 /// Test: `origin_is_loopback_*` below.
 pub fn origin_is_loopback(origin: &str) -> bool {
-    // Strip the scheme (`http://` / `https://`); if there is no `://` the value
-    // is malformed for an Origin and we treat it as non-loopback (reject).
-    let after_scheme = match origin.split_once("://") {
-        Some((_scheme, rest)) => rest,
-        None => return false,
-    };
-
-    // The authority ends at the first `/` (there should be none in an Origin,
-    // but be defensive), then we split host from port.
-    let authority = after_scheme.split('/').next().unwrap_or("");
-
-    let host = if let Some(rest) = authority.strip_prefix('[') {
-        // Bracketed IPv6 literal: `[::1]:7788` → `::1`.
-        match rest.split_once(']') {
-            Some((h, _port)) => h,
-            None => return false,
-        }
-    } else {
-        // host[:port] — drop the port if present.
-        authority.split(':').next().unwrap_or("")
-    };
-
-    host == "localhost" || host == "::1" || host.starts_with("127.")
+    match parse_origin_authority(origin) {
+        Some((host, _port)) => host == "localhost" || host == "::1" || host.starts_with("127."),
+        None => false,
+    }
 }
 
-/// axum middleware that rejects cross-origin requests to destructive routes.
+/// Check whether an `Origin` header value matches one of the console's own
+/// bind-derived, non-loopback addresses (#3269).
 ///
-/// Why: applied only to the session write routes so a malicious page cannot use
-/// the operator's authenticated-by-locality console to mutate the session fleet
-/// (CSRF). Read routes are unaffected — they leak no destructive capability.
-/// What: only acts on state-changing methods (`POST`/`PUT`/`PATCH`/`DELETE`) so
-/// it can be layered on a router that also serves safe `GET`/`HEAD` reads without
-/// blocking them. For a guarded method, if the request carries an `Origin` header
-/// that is present, valid UTF-8, and NOT loopback, responds `403 FORBIDDEN` with a
-/// short JSON body and does not call the inner handler. Absent / unreadable /
-/// loopback `Origin`, and all safe methods, pass through to `next`.
-/// Test: `server.rs` integration tests (`write_route_rejects_cross_origin`,
+/// Why: in Tailscale bind mode the console's legitimate write UI is served
+/// from a non-loopback address, so loopback-only matching (above) 403s the
+/// operator's own traffic. This function extends trust to exactly the
+/// addresses the server resolved for its own listeners — nothing broader.
+/// What: parses the `Origin` host/port, parses the host as an `IpAddr`
+/// (hostnames never match — the allowlist is IP-derived from
+/// `resolve_bind_addrs`), and returns `true` if `(ip, port)` is a member of
+/// `self_origins`.
+/// Test: `origin_matches_self_*` below.
+pub fn origin_matches_self(origin: &str, self_origins: &SelfOrigins) -> bool {
+    let Some((host, port)) = parse_origin_authority(origin) else {
+        return false;
+    };
+    let Ok(ip) = IpAddr::from_str(host) else {
+        return false;
+    };
+    let Some(port) = port.and_then(|p| p.parse::<u16>().ok()) else {
+        return false;
+    };
+    self_origins.0.contains(&SocketAddr::new(ip, port))
+}
+
+/// Extract `(host, port)` from a scheme-qualified `Origin` header value.
+///
+/// Why: shared parsing core for [`origin_is_loopback`] and
+/// [`origin_matches_self`] — keeps the (fiddly, IPv6-bracket-aware) authority
+/// parsing in exactly one place.
+/// What: strips the `scheme://` prefix, takes everything up to the first `/`
+/// as the authority, and splits it into host and optional port, unwrapping
+/// `[…]` IPv6 literals. Returns `None` for a value with no `://`.
+/// Test: exercised indirectly via `origin_is_loopback_*` and
+/// `origin_matches_self_*`.
+fn parse_origin_authority(origin: &str) -> Option<(&str, Option<&str>)> {
+    let after_scheme = origin.split_once("://").map(|(_, rest)| rest)?;
+    let authority = after_scheme.split('/').next().unwrap_or("");
+
+    if let Some(rest) = authority.strip_prefix('[') {
+        // Bracketed IPv6 literal: `[::1]:7788` → host `::1`, port `7788`.
+        let (host, remainder) = rest.split_once(']')?;
+        let port = remainder.strip_prefix(':');
+        Some((host, port))
+    } else {
+        // host[:port] — split at the last `:` so IPv6-without-brackets (which
+        // should not appear in a well-formed Origin) does not falsely match;
+        // a bare host has no `:` at all.
+        match authority.split_once(':') {
+            Some((h, p)) => Some((h, Some(p))),
+            None => Some((authority, None)),
+        }
+    }
+}
+
+/// axum middleware that rejects cross-origin requests to destructive routes,
+/// trusting loopback plus the bind-derived self-origins passed in as state.
+///
+/// Why: applied router-wide (#3268 — see module docs) so a malicious page
+/// cannot use the operator's authenticated-by-locality console to mutate the
+/// session fleet OR reach destructive daemon endpoints through the reverse
+/// proxy (CSRF). Read routes are unaffected — they leak no destructive
+/// capability. Taking `self_origins` via `State` (bound with
+/// `axum::middleware::from_fn_with_state` in `server::build_router`) lets
+/// Tailscale-bound deployments trust their own non-loopback origin without
+/// opening the guard to arbitrary remote origins (#3269).
+/// What: Only acts on state-changing methods (`POST`/`PUT`/`PATCH`/`DELETE`)
+/// so it can be layered on a router that also serves safe `GET`/`HEAD` reads
+/// without blocking them. For a guarded method, if the request carries an
+/// `Origin` header that is present, valid UTF-8, and neither loopback nor a
+/// member of `self_origins`, responds `403 FORBIDDEN` with a short JSON body
+/// and does not call the inner handler. Absent / unreadable Origin on a
+/// trusted host, and all safe methods, pass through to `next`.
+/// Test: `server/tests.rs` integration tests (`write_route_rejects_cross_origin`,
 /// `write_route_allows_loopback_origin`, `write_route_allows_missing_origin`,
-/// `read_route_allows_cross_origin`).
-pub async fn guard_write_origin(req: Request, next: Next) -> Response {
-    // Safe (non-state-changing) methods are never CSRF-relevant — pass through so
-    // this middleware can sit on a mixed read/write router.
+/// `proxy_route_rejects_cross_origin_write`,
+/// `proxy_route_allows_self_origin_write`).
+pub async fn guard_write_origin(
+    State(self_origins): State<SelfOrigins>,
+    req: Request,
+    next: Next,
+) -> Response {
+    // Safe (non-state-changing) methods are never CSRF-relevant — pass through
+    // so this middleware can sit on a mixed read/write router.
     if !req.method().is_safe()
         && let Some(origin) = req.headers().get(ORIGIN)
     {
         match origin.to_str() {
-            Ok(value) if !origin_is_loopback(value) => {
+            Ok(value)
+                if !origin_is_loopback(value) && !origin_matches_self(value, &self_origins) =>
+            {
                 tracing::warn!(
                     origin = %value,
                     "console write route rejected cross-origin request (same-origin guard)"
@@ -98,7 +219,7 @@ pub async fn guard_write_origin(req: Request, next: Next) -> Response {
                 )
                     .into_response();
             }
-            // Loopback origin → allowed.
+            // Loopback or trusted self-origin → allowed.
             Ok(_) => {}
             // Non-UTF-8 Origin is malformed; reject to be safe.
             Err(_) => {
@@ -155,5 +276,69 @@ mod tests {
         assert!(!origin_is_loopback("127.0.0.1:7788")); // no scheme
         assert!(!origin_is_loopback(""));
         assert!(!origin_is_loopback("garbage"));
+    }
+
+    /// Why: #3269 regression guard — a Tailscale bind's own resolved address
+    /// must be trusted as a self-origin so the write UI served from it works.
+    /// Test: this test.
+    #[test]
+    fn origin_matches_self_trusts_bind_derived_tailscale_addr() {
+        let addrs = [
+            SocketAddr::from(([127, 0, 0, 1], 7788)),
+            SocketAddr::from(([100, 64, 1, 2], 7788)),
+        ];
+        let self_origins = SelfOrigins::from_bind_addrs(&addrs);
+        assert!(origin_matches_self("http://100.64.1.2:7788", &self_origins));
+    }
+
+    /// Why: the allowlist must not blanket-trust the whole 100.64.0.0/10 CGNAT
+    /// range — only the exact address(es) the server itself resolved.
+    /// Test: this test.
+    #[test]
+    fn origin_matches_self_rejects_other_hosts_in_cgnat_range() {
+        let addrs = [SocketAddr::from(([100, 64, 1, 2], 7788))];
+        let self_origins = SelfOrigins::from_bind_addrs(&addrs);
+        assert!(!origin_matches_self(
+            "http://100.64.9.9:7788",
+            &self_origins
+        ));
+    }
+
+    /// Why: a matching host on the wrong port is not the server's own origin.
+    /// Test: this test.
+    #[test]
+    fn origin_matches_self_rejects_wrong_port() {
+        let addrs = [SocketAddr::from(([100, 64, 1, 2], 7788))];
+        let self_origins = SelfOrigins::from_bind_addrs(&addrs);
+        assert!(!origin_matches_self(
+            "http://100.64.1.2:9999",
+            &self_origins
+        ));
+    }
+
+    /// Why: an empty allowlist (the `Default` used by `Local` bind mode and
+    /// every existing test) must never match any non-loopback origin.
+    /// Test: this test.
+    #[test]
+    fn origin_matches_self_empty_allowlist_matches_nothing() {
+        let self_origins = SelfOrigins::default();
+        assert!(!origin_matches_self(
+            "http://100.64.1.2:7788",
+            &self_origins
+        ));
+        assert!(!origin_matches_self("http://127.0.0.1:7788", &self_origins));
+    }
+
+    /// Why: `from_bind_addrs` must drop loopback entries — they are already
+    /// covered by `origin_is_loopback` and should not be duplicated.
+    /// Test: this test.
+    #[test]
+    fn self_origins_from_bind_addrs_drops_loopback() {
+        let addrs = [
+            SocketAddr::from(([127, 0, 0, 1], 7788)),
+            SocketAddr::from(([100, 64, 1, 2], 7788)),
+        ];
+        let self_origins = SelfOrigins::from_bind_addrs(&addrs);
+        assert_eq!(self_origins.0.len(), 1);
     }
 }

--- a/crates/trusty-console/src/routes/origin_guard.rs
+++ b/crates/trusty-console/src/routes/origin_guard.rs
@@ -161,9 +161,14 @@ fn parse_origin_authority(origin: &str) -> Option<(&str, Option<&str>)> {
         let port = remainder.strip_prefix(':');
         Some((host, port))
     } else {
-        // host[:port] — split at the last `:` so IPv6-without-brackets (which
-        // should not appear in a well-formed Origin) does not falsely match;
-        // a bare host has no `:` at all.
+        // host[:port] — split at the FIRST `:` (`split_once`). For a
+        // well-formed, non-bracketed authority (IPv4 dotted-quad or hostname
+        // plus an optional `:port`) there is at most one `:`, so first and
+        // last coincide; a bare host has no `:` at all. A raw (unbracketed)
+        // IPv6 literal — which should never appear in a well-formed
+        // `Origin` — would produce a garbage `host` here, but that only
+        // degrades to a safe rejection in `origin_is_loopback` /
+        // `origin_matches_self`, never a false accept.
         match authority.split_once(':') {
             Some((h, p)) => Some((h, Some(p))),
             None => Some((authority, None)),

--- a/crates/trusty-console/src/server/mod.rs
+++ b/crates/trusty-console/src/server/mod.rs
@@ -280,14 +280,40 @@ impl AppState {
 
 // ─── router ──────────────────────────────────────────────────────────────────
 
-/// Build the axum `Router` with all routes wired.
+/// Build the axum `Router` with all routes wired, trusting only loopback as
+/// the write-origin self-origin.
 ///
 /// Why: Extracting the router into its own function allows both `main` and the
 /// test harness to share the same routing configuration without running a real
-/// TCP server.
+/// TCP server. This loopback-only entry point is what every existing test and
+/// `Local`/`Explicit` (non-Tailscale) bind mode use; Tailscale deployments use
+/// [`build_router_with_self_origins`] instead so their own bind address is
+/// also trusted (#3269).
 /// What: Returns a `Router<()>` with CORS, tracing middleware, and all routes.
 /// Test: Called from `tests::test_services_route_returns_json` below.
 pub fn build_router(state: AppState) -> Router {
+    build_router_with_self_origins(state, crate::routes::origin_guard::SelfOrigins::default())
+}
+
+/// Build the axum `Router` with all routes wired, additionally trusting the
+/// given bind-derived, non-loopback self-origins for the write-origin guard.
+///
+/// Why: #3269 — in Tailscale bind mode the console's own write UI is served
+/// from a non-loopback address; the guard must trust that exact address
+/// (derived from the server's actually-resolved bind addresses) without
+/// opening up to arbitrary remote origins. Splitting this out from
+/// `build_router` keeps every existing (loopback-only) call site and test
+/// unchanged.
+/// What: Identical router to `build_router`, except the write-origin guard
+/// (see below) is constructed with `self_origins` instead of the default
+/// empty set.
+/// Test: `server/tests.rs` tests `proxy_route_allows_self_origin_write` /
+/// `proxy_route_rejects_cross_origin_write`; `bind.rs`/`lib.rs` wire the real
+/// resolved addresses in `run_serve`.
+pub fn build_router_with_self_origins(
+    state: AppState,
+    self_origins: crate::routes::origin_guard::SelfOrigins,
+) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .route("/api/console/services", get(services_handler))
@@ -341,23 +367,12 @@ pub fn build_router(state: AppState) -> Router {
         )
         // #1220 Config tab: read/write the `~/.trusty-tools/trusty-mpm/config.yaml`
         // convention via the trusty-mpm `config_read` / `config_write` MCP tools.
-        // The POST is a state-changing write, so it sits inside the same
-        // origin-guarded block as the session write routes below.
+        // The POST is a state-changing write; the router-wide origin guard
+        // (see the `.layer()` call near the bottom of this router) covers it.
         .route(
             "/api/console/config/mpm",
             get(crate::routes::config::get_handler).post(crate::routes::config::post_handler),
         )
-        // Same-origin guard for the DESTRUCTIVE session write routes (#1222
-        // review #3). The console serves a permissive CORS policy (open reads),
-        // so without this guard any web page the operator visited could fire a
-        // cross-origin `fetch` and spawn/stop/decommission sessions (CSRF). The
-        // middleware is method-aware — it only blocks state-changing methods
-        // whose `Origin` header is present and non-loopback, so the GET reads on
-        // these same paths pass through untouched. `route_layer` applies it only
-        // to the seven session routes declared above, not the whole console.
-        .route_layer(axum::middleware::from_fn(
-            crate::routes::origin_guard::guard_write_origin,
-        ))
         // Analyze on-demand routes — call the analyze stdio MCP directly (no /proxy).
         .route(
             "/api/console/metrics/analyze/indexes",
@@ -385,6 +400,23 @@ pub fn build_router(state: AppState) -> Router {
         .route("/ui/", get(spa_index_handler))
         .route("/ui/{*path}", get(spa_asset_handler))
         .with_state(state)
+        // Same-origin guard for ALL destructive write routes, applied
+        // router-wide (#3268 fix). The console serves a permissive CORS
+        // policy (open reads), so without this guard any web page the
+        // operator visited could fire a cross-origin `fetch` and
+        // spawn/stop/decommission sessions, or — since this is a plain
+        // `.layer()`, not `route_layer` — reach destructive daemon endpoints
+        // through the reverse-proxy routes above (`/api/{service}/{*path}`,
+        // `/proxy/{daemon}/{*path}`), which a route-scoped `route_layer`
+        // placed earlier in the chain would miss entirely (the #3268 root
+        // cause). The middleware is method-aware — it only blocks
+        // state-changing methods whose `Origin` header is present and
+        // neither loopback nor a trusted self-origin, so GET reads (and the
+        // read-only daemon proxy traffic) pass through untouched.
+        .layer(axum::middleware::from_fn_with_state(
+            self_origins,
+            crate::routes::origin_guard::guard_write_origin,
+        ))
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
 }
@@ -814,738 +846,7 @@ fn serve_asset(path: &str) -> Response<Body> {
 
 // ─── tests ───────────────────────────────────────────────────────────────────
 
+// ─── tests ───────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::http::header::CONTENT_TYPE;
-    use axum::http::{Request, StatusCode};
-    use http_body_util::BodyExt;
-    use tower::ServiceExt;
-
-    use crate::connector::{ServiceInfo, ServiceStatus};
-
-    /// A stub connector for tests — always returns a fixed `ServiceInfo`.
-    struct StubConnector {
-        id: &'static str,
-        display_name: &'static str,
-        status: ServiceStatus,
-    }
-
-    impl ServiceConnector for StubConnector {
-        fn id(&self) -> &'static str {
-            self.id
-        }
-        fn display_name(&self) -> &'static str {
-            self.display_name
-        }
-        fn detect(&self) -> ServiceInfo {
-            ServiceInfo {
-                id: self.id.to_string(),
-                display_name: self.display_name.to_string(),
-                status: self.status.clone(),
-                version: None,
-                url: None,
-                hint: None,
-            }
-        }
-    }
-
-    fn make_test_state() -> AppState {
-        AppState::new(vec![
-            Box::new(StubConnector {
-                id: "trusty-search",
-                display_name: "Trusty Search",
-                status: ServiceStatus::Running,
-            }),
-            Box::new(StubConnector {
-                id: "trusty-memory",
-                display_name: "Trusty Memory",
-                status: ServiceStatus::Available,
-            }),
-            Box::new(StubConnector {
-                id: "trusty-analyze",
-                display_name: "Trusty Analyze",
-                status: ServiceStatus::Absent,
-            }),
-        ])
-    }
-
-    async fn get_bytes(resp: axum::http::Response<Body>) -> Vec<u8> {
-        resp.into_body()
-            .collect()
-            .await
-            .expect("collect body")
-            .to_bytes()
-            .to_vec()
-    }
-
-    /// Why: the services route must return a valid JSON array with one entry
-    /// per connector, each containing `id`, `display_name`, and `status`.
-    /// What: builds the router with stub connectors, issues GET
-    /// /api/console/services, parses the response.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_services_route_returns_json() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/api/console/services")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let bytes = get_bytes(resp).await;
-        let body: Vec<serde_json::Value> = serde_json::from_slice(&bytes).expect("parse json");
-        assert_eq!(body.len(), 3);
-
-        assert_eq!(body[0]["id"], "trusty-search");
-        assert_eq!(body[0]["status"], "running");
-        assert_eq!(body[0]["display_name"], "Trusty Search");
-
-        assert_eq!(body[1]["id"], "trusty-memory");
-        assert_eq!(body[1]["status"], "available");
-
-        assert_eq!(body[2]["id"], "trusty-analyze");
-        assert_eq!(body[2]["status"], "absent");
-    }
-
-    /// Why: health endpoint must return 200 with `status: ok`.
-    /// What: issues GET /health and checks the JSON body.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_health_route() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/health")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let bytes = get_bytes(resp).await;
-        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json");
-        assert_eq!(body["status"], "ok");
-        assert!(body["version"].is_string());
-    }
-
-    /// Why: the services route must serialise `Degraded` status and the
-    /// `hint` field correctly so the UI can render a distinct badge.
-    /// What: builds the router with a Degraded stub connector, issues GET
-    /// /api/console/services, asserts `status == "degraded"` and `hint` present.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_services_route_returns_degraded_with_hint() {
-        use crate::connector::ServiceInfo;
-        struct DegradedConnector;
-        impl ServiceConnector for DegradedConnector {
-            fn id(&self) -> &'static str {
-                "trusty-analyze"
-            }
-            fn display_name(&self) -> &'static str {
-                "Trusty Analyze"
-            }
-            fn detect(&self) -> ServiceInfo {
-                ServiceInfo {
-                    id: "trusty-analyze".to_string(),
-                    display_name: "Trusty Analyze".to_string(),
-                    status: ServiceStatus::Degraded,
-                    version: None,
-                    url: None,
-                    hint: Some("reachable but `console_metrics` tool not registered".to_string()),
-                }
-            }
-        }
-        let state = AppState::new(vec![Box::new(DegradedConnector)]);
-        let router = build_router(state);
-        let req = Request::builder()
-            .uri("/api/console/services")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::OK);
-        let bytes = get_bytes(resp).await;
-        let body: Vec<serde_json::Value> = serde_json::from_slice(&bytes).expect("parse json");
-        assert_eq!(body.len(), 1);
-        assert_eq!(body[0]["status"], "degraded");
-        assert!(
-            body[0].get("hint").is_some(),
-            "degraded service must include hint field"
-        );
-        assert!(
-            body[0]["hint"]
-                .as_str()
-                .unwrap_or("")
-                .contains("console_metrics"),
-            "hint must mention console_metrics"
-        );
-    }
-
-    /// Why: the root path must serve the embedded HTML (or placeholder).
-    /// What: issues GET / and asserts 200 + text/html content-type.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_spa_root_returns_html() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let ct = resp
-            .headers()
-            .get(CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("")
-            .to_string();
-        assert!(ct.contains("text/html"), "expected text/html, got: {ct}");
-    }
-
-    /// A connector whose `detect()` always panics — simulates a buggy plugin.
-    struct PanicConnector;
-
-    impl ServiceConnector for PanicConnector {
-        fn id(&self) -> &'static str {
-            "panic-svc"
-        }
-        fn display_name(&self) -> &'static str {
-            "Panic Service"
-        }
-        fn detect(&self) -> ServiceInfo {
-            panic!("intentional test panic from PanicConnector");
-        }
-    }
-
-    /// Why: a panicking connector must not silently return HTTP 200 with an
-    /// empty list — that is indistinguishable from "no services installed".
-    /// The handler must return HTTP 500 so the UI can display an error state.
-    /// What: builds the router with a PanicConnector, issues GET
-    /// /api/console/services, asserts the response status is 500.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_services_handler_returns_500_on_panic() {
-        let state = AppState::new(vec![Box::new(PanicConnector)]);
-        let router = build_router(state);
-
-        let req = Request::builder()
-            .uri("/api/console/services")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    }
-
-    /// Why: with an empty metrics cache the route must return 503 so the UI
-    /// can show a "not yet available" state rather than empty JSON.
-    /// What: issues GET /api/console/metrics/analyze on a fresh state,
-    /// asserts 503.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_metrics_analyze_route_cold_cache_returns_503() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .uri("/api/console/metrics/analyze")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-    }
-
-    /// Why: the `/api/{service}/*` proxy route for an unknown service key must
-    /// return 400 (not a 404 route-miss, since the route pattern matches but the
-    /// handler rejects the key).
-    /// What: issues GET /api/unknown/health on the new primary path, asserts 400.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_api_proxy_unknown_service_returns_400() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/api/unknown/health")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    }
-
-    /// Why: the `/api/{service}/*` route for a known service that is not running
-    /// must return 503 (cache cold) — proves the route reaches the proxy handler.
-    /// What: issues GET /api/search/health on a fresh state (no poll),
-    /// asserts 503 SERVICE_UNAVAILABLE.
-    /// Test: this test itself (#1849 Phase 2 primary path).
-    #[tokio::test]
-    async fn test_api_proxy_known_service_cold_cache_returns_503() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/api/search/health")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-    }
-
-    /// Why: `mpm` must be reachable via the new `/api/mpm/*` path and must NOT
-    /// return 400 (key absent from allowlist).
-    /// What: issues GET /api/mpm/health on a fresh state (no poll),
-    /// asserts 503 SERVICE_UNAVAILABLE (not 400 BAD_REQUEST).
-    /// Test: this test itself (#1849 Phase 2).
-    #[tokio::test]
-    async fn test_api_proxy_mpm_is_in_allowlist_cold_cache_returns_503() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/api/mpm/health")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(
-            resp.status(),
-            StatusCode::SERVICE_UNAVAILABLE,
-            "/api/mpm/health must return 503 (mpm in allowlist, cache cold), not 400"
-        );
-    }
-
-    /// Why: the deprecated `/proxy/{daemon}/*` alias must still route to the
-    /// proxy handler; removing it would break external callers mid-migration.
-    /// What: issues GET /proxy/search/health on the deprecated path, asserts 503
-    /// (cache cold, not 404 route-miss or 400 key-rejected).
-    /// Test: this test itself (backward-compat guard for #1849 Phase 2).
-    #[tokio::test]
-    async fn test_deprecated_proxy_alias_still_routes() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/proxy/search/health")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(
-            resp.status(),
-            StatusCode::SERVICE_UNAVAILABLE,
-            "/proxy/search/health must return 503 via deprecated alias, not 404"
-        );
-    }
-
-    /// Why: the deprecated `/proxy/*` alias must also reject unknown service keys
-    /// with 400, not a silent 404 — proves the handler still validates the key.
-    /// What: issues GET /proxy/unknown/health, asserts 400.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_deprecated_proxy_alias_unknown_key_returns_400() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/proxy/unknown/health")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    }
-
-    /// Why: #1849 Phase 1 adds `mpm` to the proxy allowlist. A request to
-    /// `/proxy/mpm/health` must NOT return 400 (unknown daemon) — it must return
-    /// 503 (cache not yet populated) which proves the key is now in the allowlist.
-    /// What: issues GET /proxy/mpm/health on a fresh state (no poll),
-    /// asserts 503 SERVICE_UNAVAILABLE (not 400 BAD_REQUEST).
-    /// Test: this test itself (regression guard for #1849 Phase 1).
-    #[tokio::test]
-    async fn test_proxy_mpm_is_in_allowlist_cold_cache_returns_503() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/proxy/mpm/health")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(
-            resp.status(),
-            StatusCode::SERVICE_UNAVAILABLE,
-            "/proxy/mpm/health must return 503 (mpm in allowlist, cache cold), not 400"
-        );
-    }
-
-    /// Why: the "console" service key is reserved for the console's own
-    /// /api/console/* namespace.  Issuing a request like /api/console/hijack
-    /// must never reach the reverse-proxy and be forwarded to an upstream; the
-    /// explicit guard in proxy_handler must return 400 before full_id is called.
-    /// What: issues GET /api/console/hijack on a fresh state, asserts 400.
-    /// Test: this test itself (#1849 Phase 2 console-key reservation guard).
-    #[tokio::test]
-    async fn test_api_proxy_console_key_returns_400() {
-        let router = build_router(make_test_state());
-
-        let req = Request::builder()
-            .uri("/api/console/hijack")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(
-            resp.status(),
-            StatusCode::BAD_REQUEST,
-            "/api/console/<unregistered-path> must return 400 from the console guard, not 404"
-        );
-    }
-
-    /// Why: with an empty memory metrics cache the route must return 503 so the
-    /// UI can show a "not yet available" state rather than empty JSON.
-    /// What: issues GET /api/console/metrics/memory on a fresh state, asserts 503.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_metrics_memory_route_cold_cache_returns_503() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .uri("/api/console/metrics/memory")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-    }
-
-    /// Why: with an empty search metrics cache the route must return 503 so the
-    /// UI can show a "not yet available" state rather than empty JSON.
-    /// What: issues GET /api/console/metrics/search on a fresh state, asserts 503.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_metrics_search_route_cold_cache_returns_503() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .uri("/api/console/metrics/search")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-    }
-
-    /// Why: with an empty review metrics cache the route must return 503 so the
-    /// UI can show a "not yet available" state rather than empty JSON.
-    /// What: issues GET /api/console/metrics/review on a fresh state, asserts 503.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_metrics_review_route_cold_cache_returns_503() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .uri("/api/console/metrics/review")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-    }
-
-    /// Why: with an empty mpm metrics cache the route must return 503 so the UI
-    /// can show a "not yet available" state rather than empty JSON (#1222).
-    /// What: issues GET /api/console/metrics/mpm on a fresh state, asserts 503.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_metrics_mpm_route_cold_cache_returns_503() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .uri("/api/console/metrics/mpm")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
-    }
-
-    /// Why: the analyze indexes route must return 503 (not 200 with empty data)
-    /// when the trusty-analyze binary is absent — the handle immediately marks
-    /// itself Absent and the route converts that to SERVICE_UNAVAILABLE.
-    /// What: issues GET /api/console/metrics/analyze/indexes on a fresh state
-    /// (where trusty-analyze is not on PATH in CI), asserts 503.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_analyze_indexes_absent_binary_returns_503() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .uri("/api/console/metrics/analyze/indexes")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        // Binary absent (or in backoff) → 503; if present and daemon is up → 200.
-        // In CI neither condition holds; the route must not return 500.
-        assert_ne!(
-            resp.status(),
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "indexes route must not 500 when binary absent"
-        );
-    }
-
-    /// Why: the analyze visualize route must return 400 when no `index` param
-    /// is provided — the endpoint needs it to query the daemon. A 200 with an
-    /// error field is indistinguishable from a success response to callers that
-    /// only check the status code.
-    /// What: issues GET /api/console/metrics/analyze/visualize (no ?index=),
-    /// asserts HTTP 400 and a JSON body containing `error`.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_analyze_visualize_handler_no_index_returns_json_error() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .uri("/api/console/metrics/analyze/visualize")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        // Missing index returns 400 BAD_REQUEST with a JSON error body.
-        assert_eq!(
-            resp.status(),
-            StatusCode::BAD_REQUEST,
-            "missing index param must return 400"
-        );
-        let bytes = get_bytes(resp).await;
-        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json");
-        assert!(
-            body.get("error").is_some(),
-            "expected error field, got: {body}"
-        );
-    }
-
-    /// Why: This is the key regression test for the UAT gap: the connector
-    /// `detect()` path reports `Running` or `Available` because it only does a
-    /// TCP/which probe and knows nothing about `tools/list`. When the actual
-    /// `McpServiceHandle` is in `Degraded` state (tools/list succeeded but
-    /// `console_metrics` absent), `GET /api/console/services` MUST override that
-    /// connector result to `degraded` with the remediation hint.
-    /// What: Builds state whose connector returns `Running` for trusty-search,
-    /// manually primes the trusty-search `McpServiceHandle` to `Degraded`, then
-    /// issues GET /api/console/services and asserts `status == "degraded"` with
-    /// a non-empty `hint`.  A connector that was `Absent` must NOT be overridden
-    /// (only reachable services can be Degraded by the tools/list probe).
-    /// This test intentionally does NOT use a hand-stubbed DegradedConnector —
-    /// it exercises the real `apply_handle_overrides` bridge from
-    /// `McpServiceHandle.state` → route response.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn test_services_route_handle_degraded_overlay() {
-        // Build state with:
-        //  - trusty-search connector returning Running (TCP probe passed)
-        //  - trusty-analyze connector returning Absent (binary not found)
-        let state = AppState::new(vec![
-            Box::new(StubConnector {
-                id: "trusty-search",
-                display_name: "Trusty Search",
-                status: ServiceStatus::Running,
-            }),
-            Box::new(StubConnector {
-                id: "trusty-analyze",
-                display_name: "Trusty Analyze",
-                status: ServiceStatus::Absent,
-            }),
-        ]);
-
-        // Prime the trusty-search handle to Degraded state (tools/list passed
-        // but console_metrics was absent).  This simulates the real-world
-        // situation on a machine where the daemon lacks console_metrics.
-        {
-            let handles = state.mcp_handles();
-            let search_handle = handles
-                .get("trusty-search")
-                .expect("search handle must exist");
-            search_handle.prime_degraded_for_test().await;
-        }
-
-        let router = build_router(state);
-        let req = Request::builder()
-            .uri("/api/console/services")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let bytes = get_bytes(resp).await;
-        let body: Vec<serde_json::Value> = serde_json::from_slice(&bytes).expect("parse json");
-        assert_eq!(body.len(), 2);
-
-        // trusty-search was Running via connector but Degraded via handle →
-        // must be overridden to degraded with a hint.
-        let search = body
-            .iter()
-            .find(|s| s["id"] == "trusty-search")
-            .expect("search entry");
-        assert_eq!(
-            search["status"], "degraded",
-            "Running service whose handle is Degraded must report degraded, got: {search}"
-        );
-        let hint = search["hint"].as_str().unwrap_or("");
-        assert!(
-            !hint.is_empty(),
-            "degraded service must include a non-empty hint"
-        );
-        assert!(
-            hint.contains("console_metrics"),
-            "hint must mention console_metrics, got: {hint}"
-        );
-
-        // trusty-analyze was Absent via connector — Absent must NOT be overridden
-        // even if the handle were somehow Degraded (process-down ≠ degraded).
-        let analyze = body
-            .iter()
-            .find(|s| s["id"] == "trusty-analyze")
-            .expect("analyze entry");
-        assert_eq!(
-            analyze["status"], "absent",
-            "Absent service must not be overridden to degraded"
-        );
-    }
-
-    /// Why: Regression test for issue #1170 — a stale daemon whose MCP process
-    /// is running but lacks the `list_analyze_indexes` tool must cause the
-    /// `/api/console/metrics/analyze/indexes` route to return HTTP 503 with a
-    /// clean JSON body containing `status: "degraded"` and an actionable `hint`,
-    /// NOT HTTP 502 with empty body. The capability-gate in `call_tool_checked`
-    /// must fire before any JSON-RPC call is made to the daemon.
-    /// What: Builds state with a `trusty-analyze` handle primed to `Connected`
-    /// but missing `list_analyze_indexes` in the cached tool set. Issues GET
-    /// /api/console/metrics/analyze/indexes and asserts:
-    ///   1. Status is 503 (SERVICE_UNAVAILABLE), not 502 (BAD_GATEWAY).
-    ///   2. JSON body has `status == "degraded"`.
-    ///   3. JSON body has a non-empty `hint` mentioning the missing tool.
-    /// Test: this test itself. Key regression for #1170.
-    #[tokio::test]
-    #[cfg(unix)]
-    async fn test_analyze_indexes_tool_unavailable_returns_degraded_hint() {
-        let state = make_test_state();
-
-        // Prime the analyze handle to Connected with list_analyze_indexes absent.
-        {
-            let analyze_handle = state.analyze_handle();
-            analyze_handle
-                .prime_connected_missing_tool_for_test("list_analyze_indexes")
-                .await;
-        }
-
-        let router = build_router(state);
-        let req = Request::builder()
-            .uri("/api/console/metrics/analyze/indexes")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-
-        // Must be 503, not 502 — the capability gate fires, not the JSON-RPC call.
-        assert_eq!(
-            resp.status(),
-            StatusCode::SERVICE_UNAVAILABLE,
-            "missing tool must return 503 SERVICE_UNAVAILABLE, not 502 BAD_GATEWAY"
-        );
-
-        let bytes = get_bytes(resp).await;
-        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json body");
-
-        assert_eq!(
-            body["status"], "degraded",
-            "response body must have status=degraded, got: {body}"
-        );
-
-        let hint = body["hint"].as_str().unwrap_or("");
-        assert!(
-            !hint.is_empty(),
-            "response body must include a non-empty hint, got: {body}"
-        );
-        assert!(
-            hint.contains("list_analyze_indexes"),
-            "hint must mention the missing tool name, got: {hint}"
-        );
-    }
-
-    // ── same-origin guard on destructive session write routes (#1222 review #3) ──
-
-    /// Why: a cross-origin browser `POST` to a destructive session route is the
-    /// CSRF threat the same-origin guard exists to block. With a non-loopback
-    /// `Origin` header present, the write route must return `403 FORBIDDEN` and
-    /// never reach the handler (which would otherwise return 503 absent-binary).
-    /// What: issues `POST /api/console/sessions` with `Origin: http://evil.example`
-    /// and asserts 403.
-    /// Test: this test itself (review finding #3 regression guard).
-    #[tokio::test]
-    async fn write_route_rejects_cross_origin() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .method("POST")
-            .uri("/api/console/sessions")
-            .header("origin", "http://evil.example.com")
-            .header("content-type", "application/json")
-            .body(Body::from(
-                serde_json::json!({"repo_url":"https://x/y","ref":"main","task":"t"}).to_string(),
-            ))
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_eq!(
-            resp.status(),
-            StatusCode::FORBIDDEN,
-            "cross-origin write must be rejected with 403"
-        );
-    }
-
-    /// Why: the legitimate operator surface (the SPA served from loopback) must
-    /// still be able to drive write routes — a loopback `Origin` must pass the
-    /// guard. With no trusty-mpm binary on PATH the handler then returns a 503,
-    /// so the guard is proven transparent by asserting the status is NOT 403.
-    /// What: issues `DELETE /api/console/sessions/abc` with a loopback Origin and
-    /// asserts the response is not 403 (guard passed; handler degraded to 503).
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn write_route_allows_loopback_origin() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .method("DELETE")
-            .uri("/api/console/sessions/abc")
-            .header("origin", "http://127.0.0.1:7788")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_ne!(
-            resp.status(),
-            StatusCode::FORBIDDEN,
-            "loopback-origin write must pass the same-origin guard"
-        );
-    }
-
-    /// Why: non-browser clients (curl, native tooling, the console's own
-    /// server-side calls) send no `Origin` header and are not the CSRF threat;
-    /// they must pass the guard. With no binary present the handler degrades to
-    /// 503, so we assert the status is NOT 403.
-    /// What: issues `POST /api/console/sessions/abc/stop` with no Origin header.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn write_route_allows_missing_origin() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .method("POST")
-            .uri("/api/console/sessions/abc/stop")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_ne!(
-            resp.status(),
-            StatusCode::FORBIDDEN,
-            "missing-Origin write must pass the same-origin guard"
-        );
-    }
-
-    /// Why: the guard must NOT block safe cross-origin reads — the CORS policy is
-    /// intentionally open for GETs so the SPA and tooling can read fleet state.
-    /// A cross-origin `GET` must pass the guard (and then degrade to 503 with no
-    /// binary), proving the middleware is method-aware.
-    /// What: issues `GET /api/console/sessions` with a remote Origin; asserts the
-    /// status is NOT 403.
-    /// Test: this test itself.
-    #[tokio::test]
-    async fn read_route_allows_cross_origin() {
-        let router = build_router(make_test_state());
-        let req = Request::builder()
-            .method("GET")
-            .uri("/api/console/sessions")
-            .header("origin", "http://evil.example.com")
-            .body(Body::empty())
-            .expect("request");
-        let resp = router.oneshot(req).await.expect("response");
-        assert_ne!(
-            resp.status(),
-            StatusCode::FORBIDDEN,
-            "cross-origin GET (read) must not be blocked by the write guard"
-        );
-    }
-}
+mod tests;

--- a/crates/trusty-console/src/server/tests.rs
+++ b/crates/trusty-console/src/server/tests.rs
@@ -1,0 +1,884 @@
+//! Integration tests for `server::build_router` / `build_router_with_self_origins`.
+//!
+//! Why: split out of `server/mod.rs` (was `server.rs`) to stay under the repo's
+//! 500-SLOC production-file cap after the #3268/#3269 same-origin-guard tests
+//! pushed the combined prod+test file over its grandfathered budget. This module
+//! is classified as a test file (basename `tests.rs`) under the 1500-SLOC
+//! test-file cap, so it has ample headroom.
+//! What: axum test-client integration tests exercising the router end-to-end
+//! (routes, proxy allowlist, and the write-origin guard) without a real TCP
+//! listener.
+//! Test: this module IS the test suite for `server/mod.rs`.
+
+use super::*;
+use axum::http::header::CONTENT_TYPE;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use crate::connector::{ServiceInfo, ServiceStatus};
+
+/// A stub connector for tests — always returns a fixed `ServiceInfo`.
+struct StubConnector {
+    id: &'static str,
+    display_name: &'static str,
+    status: ServiceStatus,
+}
+
+impl ServiceConnector for StubConnector {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+    fn display_name(&self) -> &'static str {
+        self.display_name
+    }
+    fn detect(&self) -> ServiceInfo {
+        ServiceInfo {
+            id: self.id.to_string(),
+            display_name: self.display_name.to_string(),
+            status: self.status.clone(),
+            version: None,
+            url: None,
+            hint: None,
+        }
+    }
+}
+
+fn make_test_state() -> AppState {
+    AppState::new(vec![
+        Box::new(StubConnector {
+            id: "trusty-search",
+            display_name: "Trusty Search",
+            status: ServiceStatus::Running,
+        }),
+        Box::new(StubConnector {
+            id: "trusty-memory",
+            display_name: "Trusty Memory",
+            status: ServiceStatus::Available,
+        }),
+        Box::new(StubConnector {
+            id: "trusty-analyze",
+            display_name: "Trusty Analyze",
+            status: ServiceStatus::Absent,
+        }),
+    ])
+}
+
+async fn get_bytes(resp: axum::http::Response<Body>) -> Vec<u8> {
+    resp.into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes()
+        .to_vec()
+}
+
+/// Why: the services route must return a valid JSON array with one entry
+/// per connector, each containing `id`, `display_name`, and `status`.
+/// What: builds the router with stub connectors, issues GET
+/// /api/console/services, parses the response.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_services_route_returns_json() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/api/console/services")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = get_bytes(resp).await;
+    let body: Vec<serde_json::Value> = serde_json::from_slice(&bytes).expect("parse json");
+    assert_eq!(body.len(), 3);
+
+    assert_eq!(body[0]["id"], "trusty-search");
+    assert_eq!(body[0]["status"], "running");
+    assert_eq!(body[0]["display_name"], "Trusty Search");
+
+    assert_eq!(body[1]["id"], "trusty-memory");
+    assert_eq!(body[1]["status"], "available");
+
+    assert_eq!(body[2]["id"], "trusty-analyze");
+    assert_eq!(body[2]["status"], "absent");
+}
+
+/// Why: health endpoint must return 200 with `status: ok`.
+/// What: issues GET /health and checks the JSON body.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_health_route() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = get_bytes(resp).await;
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json");
+    assert_eq!(body["status"], "ok");
+    assert!(body["version"].is_string());
+}
+
+/// Why: the services route must serialise `Degraded` status and the
+/// `hint` field correctly so the UI can render a distinct badge.
+/// What: builds the router with a Degraded stub connector, issues GET
+/// /api/console/services, asserts `status == "degraded"` and `hint` present.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_services_route_returns_degraded_with_hint() {
+    use crate::connector::ServiceInfo;
+    struct DegradedConnector;
+    impl ServiceConnector for DegradedConnector {
+        fn id(&self) -> &'static str {
+            "trusty-analyze"
+        }
+        fn display_name(&self) -> &'static str {
+            "Trusty Analyze"
+        }
+        fn detect(&self) -> ServiceInfo {
+            ServiceInfo {
+                id: "trusty-analyze".to_string(),
+                display_name: "Trusty Analyze".to_string(),
+                status: ServiceStatus::Degraded,
+                version: None,
+                url: None,
+                hint: Some("reachable but `console_metrics` tool not registered".to_string()),
+            }
+        }
+    }
+    let state = AppState::new(vec![Box::new(DegradedConnector)]);
+    let router = build_router(state);
+    let req = Request::builder()
+        .uri("/api/console/services")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = get_bytes(resp).await;
+    let body: Vec<serde_json::Value> = serde_json::from_slice(&bytes).expect("parse json");
+    assert_eq!(body.len(), 1);
+    assert_eq!(body[0]["status"], "degraded");
+    assert!(
+        body[0].get("hint").is_some(),
+        "degraded service must include hint field"
+    );
+    assert!(
+        body[0]["hint"]
+            .as_str()
+            .unwrap_or("")
+            .contains("console_metrics"),
+        "hint must mention console_metrics"
+    );
+}
+
+/// Why: the root path must serve the embedded HTML (or placeholder).
+/// What: issues GET / and asserts 200 + text/html content-type.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_spa_root_returns_html() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let ct = resp
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(ct.contains("text/html"), "expected text/html, got: {ct}");
+}
+
+/// A connector whose `detect()` always panics — simulates a buggy plugin.
+struct PanicConnector;
+
+impl ServiceConnector for PanicConnector {
+    fn id(&self) -> &'static str {
+        "panic-svc"
+    }
+    fn display_name(&self) -> &'static str {
+        "Panic Service"
+    }
+    fn detect(&self) -> ServiceInfo {
+        panic!("intentional test panic from PanicConnector");
+    }
+}
+
+/// Why: a panicking connector must not silently return HTTP 200 with an
+/// empty list — that is indistinguishable from "no services installed".
+/// The handler must return HTTP 500 so the UI can display an error state.
+/// What: builds the router with a PanicConnector, issues GET
+/// /api/console/services, asserts the response status is 500.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_services_handler_returns_500_on_panic() {
+    let state = AppState::new(vec![Box::new(PanicConnector)]);
+    let router = build_router(state);
+
+    let req = Request::builder()
+        .uri("/api/console/services")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+/// Why: with an empty metrics cache the route must return 503 so the UI
+/// can show a "not yet available" state rather than empty JSON.
+/// What: issues GET /api/console/metrics/analyze on a fresh state,
+/// asserts 503.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_metrics_analyze_route_cold_cache_returns_503() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .uri("/api/console/metrics/analyze")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Why: the `/api/{service}/*` proxy route for an unknown service key must
+/// return 400 (not a 404 route-miss, since the route pattern matches but the
+/// handler rejects the key).
+/// What: issues GET /api/unknown/health on the new primary path, asserts 400.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_api_proxy_unknown_service_returns_400() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/api/unknown/health")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Why: the `/api/{service}/*` route for a known service that is not running
+/// must return 503 (cache cold) — proves the route reaches the proxy handler.
+/// What: issues GET /api/search/health on a fresh state (no poll),
+/// asserts 503 SERVICE_UNAVAILABLE.
+/// Test: this test itself (#1849 Phase 2 primary path).
+#[tokio::test]
+async fn test_api_proxy_known_service_cold_cache_returns_503() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/api/search/health")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Why: `mpm` must be reachable via the new `/api/mpm/*` path and must NOT
+/// return 400 (key absent from allowlist).
+/// What: issues GET /api/mpm/health on a fresh state (no poll),
+/// asserts 503 SERVICE_UNAVAILABLE (not 400 BAD_REQUEST).
+/// Test: this test itself (#1849 Phase 2).
+#[tokio::test]
+async fn test_api_proxy_mpm_is_in_allowlist_cold_cache_returns_503() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/api/mpm/health")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "/api/mpm/health must return 503 (mpm in allowlist, cache cold), not 400"
+    );
+}
+
+/// Why: the deprecated `/proxy/{daemon}/*` alias must still route to the
+/// proxy handler; removing it would break external callers mid-migration.
+/// What: issues GET /proxy/search/health on the deprecated path, asserts 503
+/// (cache cold, not 404 route-miss or 400 key-rejected).
+/// Test: this test itself (backward-compat guard for #1849 Phase 2).
+#[tokio::test]
+async fn test_deprecated_proxy_alias_still_routes() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/proxy/search/health")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "/proxy/search/health must return 503 via deprecated alias, not 404"
+    );
+}
+
+/// Why: the deprecated `/proxy/*` alias must also reject unknown service keys
+/// with 400, not a silent 404 — proves the handler still validates the key.
+/// What: issues GET /proxy/unknown/health, asserts 400.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_deprecated_proxy_alias_unknown_key_returns_400() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/proxy/unknown/health")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// Why: #1849 Phase 1 adds `mpm` to the proxy allowlist. A request to
+/// `/proxy/mpm/health` must NOT return 400 (unknown daemon) — it must return
+/// 503 (cache not yet populated) which proves the key is now in the allowlist.
+/// What: issues GET /proxy/mpm/health on a fresh state (no poll),
+/// asserts 503 SERVICE_UNAVAILABLE (not 400 BAD_REQUEST).
+/// Test: this test itself (regression guard for #1849 Phase 1).
+#[tokio::test]
+async fn test_proxy_mpm_is_in_allowlist_cold_cache_returns_503() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/proxy/mpm/health")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "/proxy/mpm/health must return 503 (mpm in allowlist, cache cold), not 400"
+    );
+}
+
+/// Why: the "console" service key is reserved for the console's own
+/// /api/console/* namespace.  Issuing a request like /api/console/hijack
+/// must never reach the reverse-proxy and be forwarded to an upstream; the
+/// explicit guard in proxy_handler must return 400 before full_id is called.
+/// What: issues GET /api/console/hijack on a fresh state, asserts 400.
+/// Test: this test itself (#1849 Phase 2 console-key reservation guard).
+#[tokio::test]
+async fn test_api_proxy_console_key_returns_400() {
+    let router = build_router(make_test_state());
+
+    let req = Request::builder()
+        .uri("/api/console/hijack")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "/api/console/<unregistered-path> must return 400 from the console guard, not 404"
+    );
+}
+
+/// Why: with an empty memory metrics cache the route must return 503 so the
+/// UI can show a "not yet available" state rather than empty JSON.
+/// What: issues GET /api/console/metrics/memory on a fresh state, asserts 503.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_metrics_memory_route_cold_cache_returns_503() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .uri("/api/console/metrics/memory")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Why: with an empty search metrics cache the route must return 503 so the
+/// UI can show a "not yet available" state rather than empty JSON.
+/// What: issues GET /api/console/metrics/search on a fresh state, asserts 503.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_metrics_search_route_cold_cache_returns_503() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .uri("/api/console/metrics/search")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Why: with an empty review metrics cache the route must return 503 so the
+/// UI can show a "not yet available" state rather than empty JSON.
+/// What: issues GET /api/console/metrics/review on a fresh state, asserts 503.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_metrics_review_route_cold_cache_returns_503() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .uri("/api/console/metrics/review")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Why: with an empty mpm metrics cache the route must return 503 so the UI
+/// can show a "not yet available" state rather than empty JSON (#1222).
+/// What: issues GET /api/console/metrics/mpm on a fresh state, asserts 503.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_metrics_mpm_route_cold_cache_returns_503() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .uri("/api/console/metrics/mpm")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Why: the analyze indexes route must return 503 (not 200 with empty data)
+/// when the trusty-analyze binary is absent — the handle immediately marks
+/// itself Absent and the route converts that to SERVICE_UNAVAILABLE.
+/// What: issues GET /api/console/metrics/analyze/indexes on a fresh state
+/// (where trusty-analyze is not on PATH in CI), asserts 503.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_analyze_indexes_absent_binary_returns_503() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .uri("/api/console/metrics/analyze/indexes")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    // Binary absent (or in backoff) → 503; if present and daemon is up → 200.
+    // In CI neither condition holds; the route must not return 500.
+    assert_ne!(
+        resp.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "indexes route must not 500 when binary absent"
+    );
+}
+
+/// Why: the analyze visualize route must return 400 when no `index` param
+/// is provided — the endpoint needs it to query the daemon. A 200 with an
+/// error field is indistinguishable from a success response to callers that
+/// only check the status code.
+/// What: issues GET /api/console/metrics/analyze/visualize (no ?index=),
+/// asserts HTTP 400 and a JSON body containing `error`.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_analyze_visualize_handler_no_index_returns_json_error() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .uri("/api/console/metrics/analyze/visualize")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    // Missing index returns 400 BAD_REQUEST with a JSON error body.
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "missing index param must return 400"
+    );
+    let bytes = get_bytes(resp).await;
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json");
+    assert!(
+        body.get("error").is_some(),
+        "expected error field, got: {body}"
+    );
+}
+
+/// Why: This is the key regression test for the UAT gap: the connector
+/// `detect()` path reports `Running` or `Available` because it only does a
+/// TCP/which probe and knows nothing about `tools/list`. When the actual
+/// `McpServiceHandle` is in `Degraded` state (tools/list succeeded but
+/// `console_metrics` absent), `GET /api/console/services` MUST override that
+/// connector result to `degraded` with the remediation hint.
+/// What: Builds state whose connector returns `Running` for trusty-search,
+/// manually primes the trusty-search `McpServiceHandle` to `Degraded`, then
+/// issues GET /api/console/services and asserts `status == "degraded"` with
+/// a non-empty `hint`.  A connector that was `Absent` must NOT be overridden
+/// (only reachable services can be Degraded by the tools/list probe).
+/// This test intentionally does NOT use a hand-stubbed DegradedConnector —
+/// it exercises the real `apply_handle_overrides` bridge from
+/// `McpServiceHandle.state` → route response.
+/// Test: this test itself.
+#[tokio::test]
+async fn test_services_route_handle_degraded_overlay() {
+    // Build state with:
+    //  - trusty-search connector returning Running (TCP probe passed)
+    //  - trusty-analyze connector returning Absent (binary not found)
+    let state = AppState::new(vec![
+        Box::new(StubConnector {
+            id: "trusty-search",
+            display_name: "Trusty Search",
+            status: ServiceStatus::Running,
+        }),
+        Box::new(StubConnector {
+            id: "trusty-analyze",
+            display_name: "Trusty Analyze",
+            status: ServiceStatus::Absent,
+        }),
+    ]);
+
+    // Prime the trusty-search handle to Degraded state (tools/list passed
+    // but console_metrics was absent).  This simulates the real-world
+    // situation on a machine where the daemon lacks console_metrics.
+    {
+        let handles = state.mcp_handles();
+        let search_handle = handles
+            .get("trusty-search")
+            .expect("search handle must exist");
+        search_handle.prime_degraded_for_test().await;
+    }
+
+    let router = build_router(state);
+    let req = Request::builder()
+        .uri("/api/console/services")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = get_bytes(resp).await;
+    let body: Vec<serde_json::Value> = serde_json::from_slice(&bytes).expect("parse json");
+    assert_eq!(body.len(), 2);
+
+    // trusty-search was Running via connector but Degraded via handle →
+    // must be overridden to degraded with a hint.
+    let search = body
+        .iter()
+        .find(|s| s["id"] == "trusty-search")
+        .expect("search entry");
+    assert_eq!(
+        search["status"], "degraded",
+        "Running service whose handle is Degraded must report degraded, got: {search}"
+    );
+    let hint = search["hint"].as_str().unwrap_or("");
+    assert!(
+        !hint.is_empty(),
+        "degraded service must include a non-empty hint"
+    );
+    assert!(
+        hint.contains("console_metrics"),
+        "hint must mention console_metrics, got: {hint}"
+    );
+
+    // trusty-analyze was Absent via connector — Absent must NOT be overridden
+    // even if the handle were somehow Degraded (process-down ≠ degraded).
+    let analyze = body
+        .iter()
+        .find(|s| s["id"] == "trusty-analyze")
+        .expect("analyze entry");
+    assert_eq!(
+        analyze["status"], "absent",
+        "Absent service must not be overridden to degraded"
+    );
+}
+
+/// Why: Regression test for issue #1170 — a stale daemon whose MCP process
+/// is running but lacks the `list_analyze_indexes` tool must cause the
+/// `/api/console/metrics/analyze/indexes` route to return HTTP 503 with a
+/// clean JSON body containing `status: "degraded"` and an actionable `hint`,
+/// NOT HTTP 502 with empty body. The capability-gate in `call_tool_checked`
+/// must fire before any JSON-RPC call is made to the daemon.
+/// What: Builds state with a `trusty-analyze` handle primed to `Connected`
+/// but missing `list_analyze_indexes` in the cached tool set. Issues GET
+/// /api/console/metrics/analyze/indexes and asserts:
+///   1. Status is 503 (SERVICE_UNAVAILABLE), not 502 (BAD_GATEWAY).
+///   2. JSON body has `status == "degraded"`.
+///   3. JSON body has a non-empty `hint` mentioning the missing tool.
+/// Test: this test itself. Key regression for #1170.
+#[tokio::test]
+#[cfg(unix)]
+async fn test_analyze_indexes_tool_unavailable_returns_degraded_hint() {
+    let state = make_test_state();
+
+    // Prime the analyze handle to Connected with list_analyze_indexes absent.
+    {
+        let analyze_handle = state.analyze_handle();
+        analyze_handle
+            .prime_connected_missing_tool_for_test("list_analyze_indexes")
+            .await;
+    }
+
+    let router = build_router(state);
+    let req = Request::builder()
+        .uri("/api/console/metrics/analyze/indexes")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+
+    // Must be 503, not 502 — the capability gate fires, not the JSON-RPC call.
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "missing tool must return 503 SERVICE_UNAVAILABLE, not 502 BAD_GATEWAY"
+    );
+
+    let bytes = get_bytes(resp).await;
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json body");
+
+    assert_eq!(
+        body["status"], "degraded",
+        "response body must have status=degraded, got: {body}"
+    );
+
+    let hint = body["hint"].as_str().unwrap_or("");
+    assert!(
+        !hint.is_empty(),
+        "response body must include a non-empty hint, got: {body}"
+    );
+    assert!(
+        hint.contains("list_analyze_indexes"),
+        "hint must mention the missing tool name, got: {hint}"
+    );
+}
+
+// ── same-origin guard on destructive session write routes (#1222 review #3) ──
+
+/// Why: a cross-origin browser `POST` to a destructive session route is the
+/// CSRF threat the same-origin guard exists to block. With a non-loopback
+/// `Origin` header present, the write route must return `403 FORBIDDEN` and
+/// never reach the handler (which would otherwise return 503 absent-binary).
+/// What: issues `POST /api/console/sessions` with `Origin: http://evil.example`
+/// and asserts 403.
+/// Test: this test itself (review finding #3 regression guard).
+#[tokio::test]
+async fn write_route_rejects_cross_origin() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/console/sessions")
+        .header("origin", "http://evil.example.com")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({"repo_url":"https://x/y","ref":"main","task":"t"}).to_string(),
+        ))
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin write must be rejected with 403"
+    );
+}
+
+/// Why: the legitimate operator surface (the SPA served from loopback) must
+/// still be able to drive write routes — a loopback `Origin` must pass the
+/// guard. With no trusty-mpm binary on PATH the handler then returns a 503,
+/// so the guard is proven transparent by asserting the status is NOT 403.
+/// What: issues `DELETE /api/console/sessions/abc` with a loopback Origin and
+/// asserts the response is not 403 (guard passed; handler degraded to 503).
+/// Test: this test itself.
+#[tokio::test]
+async fn write_route_allows_loopback_origin() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .method("DELETE")
+        .uri("/api/console/sessions/abc")
+        .header("origin", "http://127.0.0.1:7788")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "loopback-origin write must pass the same-origin guard"
+    );
+}
+
+/// Why: non-browser clients (curl, native tooling, the console's own
+/// server-side calls) send no `Origin` header and are not the CSRF threat;
+/// they must pass the guard. With no binary present the handler degrades to
+/// 503, so we assert the status is NOT 403.
+/// What: issues `POST /api/console/sessions/abc/stop` with no Origin header.
+/// Test: this test itself.
+#[tokio::test]
+async fn write_route_allows_missing_origin() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/console/sessions/abc/stop")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "missing-Origin write must pass the same-origin guard"
+    );
+}
+
+/// Why: the guard must NOT block safe cross-origin reads — the CORS policy is
+/// intentionally open for GETs so the SPA and tooling can read fleet state.
+/// A cross-origin `GET` must pass the guard (and then degrade to 503 with no
+/// binary), proving the middleware is method-aware.
+/// What: issues `GET /api/console/sessions` with a remote Origin; asserts the
+/// status is NOT 403.
+/// Test: this test itself.
+#[tokio::test]
+async fn read_route_allows_cross_origin() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/console/sessions")
+        .header("origin", "http://evil.example.com")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin GET (read) must not be blocked by the write guard"
+    );
+}
+
+// ── router-wide guard coverage on the reverse-proxy routes (#3268) ────────
+
+/// Why: #3268 regression guard — the write-origin guard previously only
+/// covered the seven session routes registered before the old
+/// `route_layer` call, so a cross-origin `POST`/`DELETE` through the
+/// reverse proxy (e.g. `POST /api/search/admin/stop`, `DELETE
+/// /api/search/indexes/{id}`) reached the destructive daemon endpoint
+/// unguarded. Now that the guard is applied router-wide via `.layer()`,
+/// a cross-origin write to a proxied route must be rejected with `403`
+/// BEFORE `proxy_handler` ever attempts to reach an upstream daemon (no
+/// live daemon required for this test to pass).
+/// What: issues `POST /api/search/admin/stop` with a non-loopback,
+/// non-self `Origin` header and asserts `403 FORBIDDEN`.
+/// Test: this test itself.
+#[tokio::test]
+async fn proxy_route_rejects_cross_origin_write() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/search/admin/stop")
+        .header("origin", "http://evil.example.com")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin write through the reverse proxy must be rejected with 403"
+    );
+}
+
+/// Why: #3268 companion — the router-wide guard must still let a
+/// cross-origin, safe `GET` through the proxy pass (read traffic is not
+/// the CSRF threat model); this proves the router-wide `.layer()` stayed
+/// method-aware after replacing the route-scoped `route_layer`.
+/// What: issues `GET /api/search/status` with a remote Origin; asserts
+/// the response is NOT 403 (it degrades to 503/502 with no live daemon).
+/// Test: this test itself.
+#[tokio::test]
+async fn proxy_route_allows_cross_origin_read() {
+    let router = build_router(make_test_state());
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/search/status")
+        .header("origin", "http://evil.example.com")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin GET through the reverse proxy must not be blocked by the write guard"
+    );
+}
+
+// ── bind-aware self-origin allowlist (#3269) ───────────────────────────────
+
+/// Why: #3269 regression guard — the full Tailscale write flow. When the
+/// console is bound on a Tailscale (non-loopback) address, its own write
+/// UI served from that address must be able to drive BOTH the native
+/// session routes AND the reverse-proxied destructive routes; a request
+/// whose `Origin` is exactly the server's own resolved bind address must
+/// pass the guard rather than being 403'd as if it were a random
+/// non-loopback origin.
+/// What: builds the router via `build_router_with_self_origins` with a
+/// `SelfOrigins` allowlist containing `100.64.1.2:7788` (a Tailscale
+/// CGNAT address), then issues `POST /api/console/sessions` and `POST
+/// /api/search/admin/stop` with `Origin: http://100.64.1.2:7788`; asserts
+/// neither is 403 (both degrade to 503/502 with no live
+/// trusty-mpm/trusty-search binary — proving the guard, not the handler,
+/// is what would have blocked them).
+/// Test: this test itself.
+#[tokio::test]
+async fn proxy_route_allows_self_origin_write() {
+    let self_origins = crate::routes::origin_guard::SelfOrigins::from_bind_addrs(&[
+        "127.0.0.1:7788".parse().expect("addr"),
+        "100.64.1.2:7788".parse().expect("addr"),
+    ]);
+    let router = build_router_with_self_origins(make_test_state(), self_origins);
+
+    let session_req = Request::builder()
+        .method("POST")
+        .uri("/api/console/sessions")
+        .header("origin", "http://100.64.1.2:7788")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({"repo_url":"https://x/y","ref":"main","task":"t"}).to_string(),
+        ))
+        .expect("request");
+    let session_resp = router.clone().oneshot(session_req).await.expect("response");
+    assert_ne!(
+        session_resp.status(),
+        StatusCode::FORBIDDEN,
+        "self-origin (Tailscale bind addr) session write must pass the guard"
+    );
+
+    let proxy_req = Request::builder()
+        .method("POST")
+        .uri("/api/search/admin/stop")
+        .header("origin", "http://100.64.1.2:7788")
+        .body(Body::empty())
+        .expect("request");
+    let proxy_resp = router.oneshot(proxy_req).await.expect("response");
+    assert_ne!(
+        proxy_resp.status(),
+        StatusCode::FORBIDDEN,
+        "self-origin (Tailscale bind addr) proxied write must pass the guard"
+    );
+}
+
+/// Why: #3269 companion — the self-origin allowlist must stay narrowly
+/// scoped to the server's own resolved bind address(es), NOT the whole
+/// `100.64.0.0/10` CGNAT range (explicitly called out as the anti-goal in
+/// the issue). A different host in that range must still be rejected.
+/// What: builds the router trusting only `100.64.1.2:7788`, then issues a
+/// write with `Origin: http://100.64.9.9:7788` (a different tailnet host)
+/// and asserts `403`.
+/// Test: this test itself.
+#[tokio::test]
+async fn proxy_route_rejects_other_tailnet_host() {
+    let self_origins =
+        crate::routes::origin_guard::SelfOrigins::from_bind_addrs(&["100.64.1.2:7788"
+            .parse()
+            .expect("addr")]);
+    let router = build_router_with_self_origins(make_test_state(), self_origins);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/search/admin/stop")
+        .header("origin", "http://100.64.9.9:7788")
+        .body(Body::empty())
+        .expect("request");
+    let resp = router.oneshot(req).await.expect("response");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a non-self, non-loopback tailnet host must still be rejected — the allowlist must \
+         not blanket-trust the whole CGNAT range"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #3268
Closes #3269

Both issues share the same root cause location (`crates/trusty-console/src/routes/origin_guard.rs` + `crates/trusty-console/src/server.rs`) and are fixed together.

### #3268 — reverse-proxy routes bypassed the write-origin (CSRF) guard

`build_router` (now `crates/trusty-console/src/server/mod.rs`, split out of `server.rs` — see "File split" below) previously attached the guard with:

```rust
.route_layer(axum::middleware::from_fn(guard_write_origin))
```

`route_layer` only covers routes registered **before** it in the same builder chain. The reverse-proxy routes (`/api/{service}/{*path}`, `/proxy/{daemon}/{*path}`) are declared **after** that call, so they never passed through the guard — any cross-origin page could reach destructive daemon endpoints through the proxy (`POST /admin/stop`, `DELETE /api/search/indexes/{id}`, etc).

**Fix:** the guard is now attached as a plain `Router::layer(...)` after every `.route()` call (right before the `CorsLayer`/`TraceLayer`), so it wraps the entire router — proxy routes included. It stays method-aware (only `POST`/`PUT`/`PATCH`/`DELETE`), so GET reads (native and proxied) are unaffected.

### #3269 — Tailscale bind mode 403s the console's own write UI

`origin_is_loopback` only accepted `localhost` / `127.0.0.0/8` / `::1`. In `--tailscale` bind mode the console also listens on the detected tailnet (CGNAT `100.64.0.0/10`) address, so the SPA served from that address got 403'd on every write.

**Fix:** added `SelfOrigins`, an `Arc<HashSet<SocketAddr>>` allowlist built from the server's *actually resolved* bind addresses (`SelfOrigins::from_bind_addrs`, called from `run_serve` in `lib.rs` with the output of `bind::resolve_bind_addrs`, loopback entries filtered out since those are already covered by `origin_is_loopback`). The guard (`guard_write_origin`) now takes `State<SelfOrigins>` via `axum::middleware::from_fn_with_state` and allows an `Origin` when it is loopback **or** an exact `(ip, port)` match against this allowlist — never a blanket trust of the whole CGNAT range, and never a hostname (the allowlist is IP-derived only).

`build_router(state)` keeps its original signature and behavior (empty/loopback-only `SelfOrigins`, via `SelfOrigins::default()`) so all 20+ existing test call sites are untouched; a new `build_router_with_self_origins(state, self_origins)` is what `run_serve` now calls in production.

### File split (SLOC cap)

Adding the #3268/#3269 tests pushed the combined prod+test `server.rs` over its grandfathered 922-SLOC budget. Split it into `server/mod.rs` (production, well under the 500-SLOC cap) + `server/tests.rs` (test file, 1500-SLOC cap) — pure move, no logic change. Removed the now-stale `server.rs` entry from `.line-cap-allowlist.tsv`.

### Design ambiguity flagged

The self-origin match ignores scheme (http vs https) — same convention as the pre-existing `origin_is_loopback`, since the console currently only ever serves plain HTTP. If/when TLS termination is added in front of the console, this will need revisiting; flagging rather than guessing at scheme-handling that isn't exercised anywhere in the current codebase.

## Test plan

- [x] `origin_matches_self_trusts_bind_derived_tailscale_addr` / `origin_matches_self_rejects_other_hosts_in_cgnat_range` / `origin_matches_self_rejects_wrong_port` / `self_origins_from_bind_addrs_drops_loopback` (unit, `origin_guard.rs`)
- [x] `proxy_route_rejects_cross_origin_write` — #3268 regression guard: cross-origin `POST /api/search/admin/stop` → 403, before ever reaching `proxy_handler`
- [x] `proxy_route_allows_cross_origin_read` — proxy GETs stay unaffected
- [x] `proxy_route_allows_self_origin_write` — #3269 regression guard: full Tailscale write flow, both native session routes and proxied routes, from the bind-derived self-origin
- [x] `proxy_route_rejects_other_tailnet_host` — allowlist stays narrow, not the whole CGNAT range
- [x] All pre-existing `write_route_*` / `read_route_allows_cross_origin` tests still pass unchanged
- [x] `cargo check -p trusty-console` — clean
- [x] `cargo clippy -p trusty-console -- -D warnings` — clean
- [x] `cargo test -p trusty-console` — 154 passed, 0 failed, 1 ignored (pre-existing `#[ignore]`)
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — clean except one pre-existing, unrelated violation (`crates/trusty-agents/ui/src-tauri/src/main.rs`, already 821 lines on `origin/main`, untouched by this PR)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools