### PR TITLE
fix: repair 10 dangling doc-comment pointers (unblock main)

### DIFF
--- a/crates/trusty-agents/src/api/server/state.rs
+++ b/crates/trusty-agents/src/api/server/state.rs
@@ -154,7 +154,9 @@ impl AppState {
     /// What: Removes the task's stored `AbortHandle` (it's done either way)
     /// and, only if the current stored status isn't already `Cancelled`,
     /// performs the same insert/trim/persist `upsert` does.
-    /// Test: `finalize_task_does_not_clobber_cancelled`.
+    /// Test: `cancel_running_task_marks_cancelled` covers this directly —
+    /// its final assertions check that a late `finalize_task` call from an
+    /// aborted future does not clobber the already-cancelled record.
     pub(super) async fn finalize_task(&self, id: String, resp: PmResponse) {
         let snapshot = {
             let mut store = self.inner.lock().await;
@@ -186,7 +188,10 @@ impl AppState {
     /// acquire the lock.
     /// What: Inserts `handle` keyed by `id`, unless `id`'s stored response is
     /// already non-`Running`.
-    /// Test: `register_handle_skips_already_terminal_task`.
+    /// Test: exercised indirectly by every test in `tests::cancel` via
+    /// `spawn_fake_running_task` (the normal not-yet-terminal insert path);
+    /// the pathologically-fast-completion terminal-skip guard itself has no
+    /// dedicated regression test yet.
     pub(super) async fn register_handle(&self, id: &str, handle: AbortHandle) {
         let mut store = self.inner.lock().await;
         let terminal = matches!(

--- a/crates/trusty-agents/src/workflow/engine/executor/resume.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/resume.rs
@@ -12,7 +12,7 @@
 //! matches the checkpointed phase list), reconstructs context, and delegates
 //! to `run_phase_loop`. `ResumeOutcome` distinguishes "already finished,
 //! nothing to resume" from "picked back up and ran".
-//! Test: `checkpoint_resume_tests` in the engine `tests` submodule.
+//! Test: `checkpoint_resume` in the engine `tests` submodule.
 
 use std::path::PathBuf;
 

--- a/crates/trusty-code/src/session/connector.rs
+++ b/crates/trusty-code/src/session/connector.rs
@@ -176,7 +176,7 @@ impl WorkstreamConnector for TcodeConnector {
     /// `session.create`'s `agent` param. A `400` (empty task, or `project`
     /// naming no real directory — see `session::protocol::create`'s AC-16.2
     /// docs) maps to [`ConnectorError::InvalidRequest`].
-    /// Test: `connector_e2e::create_session_binds_project_and_appears_in_list`,
+    /// Test: `connector_e2e::create_session_full_lifecycle`,
     /// `connector_e2e::create_session_wrong_backend_params_is_invalid_request`.
     async fn create_session(&self, req: CreateSessionReq) -> Result<SessionInfo, ConnectorError> {
         let CreateSessionReq {
@@ -294,7 +294,8 @@ impl WorkstreamConnector for TcodeConnector {
     /// [`ConnectorError::NotFound`]). On success, wraps
     /// `result.{session_id,stream_url,events}` in
     /// [`AttachHandle::EventStream`].
-    /// Test: `connector_e2e::attach_returns_event_stream_for_known_session`,
+    /// Test: `connector_e2e::create_session_full_lifecycle` (asserts the
+    /// returned handle is an `EventStream` with the expected `stream_url`),
     /// `connector_e2e::attach_unknown_id_is_not_found`.
     async fn attach(&self, session_id: &str) -> Result<AttachHandle, ConnectorError> {
         let rpc_req = json!({

--- a/crates/trusty-mpm/src/connectors/tm.rs
+++ b/crates/trusty-mpm/src/connectors/tm.rs
@@ -52,7 +52,9 @@ impl TmConnector {
     /// Why: the common case — a caller (eventually the lead agent) that
     /// doesn't know or care which daemon address is in play.
     /// What: delegates to [`resolve_daemon_url`] with no explicit override.
-    /// Test: `tm_tests::new_resolves_default_daemon_url`.
+    /// Test: `default_returned_when_no_lock_and_no_explicit` (in
+    /// `core::discovery`) covers `resolve_daemon_url`'s no-override branch
+    /// this method delegates to; `new()` itself has no dedicated test.
     pub fn new() -> Self {
         Self::with_daemon_url(resolve_daemon_url(None))
     }
@@ -142,7 +144,7 @@ impl WorkstreamConnector for TmConnector {
     /// fields; `agent` has no equivalent on tm's spawn request and is
     /// silently ignored (see [`CreateSessionReq`]'s docs on why that's
     /// intentional, not a data-loss bug).
-    /// Test: `tm_tests::create_session_spawns_and_appears_in_list`,
+    /// Test: `tm_tests::create_session_full_lifecycle`,
     /// `tm_tests::create_session_wrong_backend_params_is_invalid_request`.
     async fn create_session(&self, req: CreateSessionReq) -> Result<SessionInfo, ConnectorError> {
         let CreateSessionReq {
@@ -198,7 +200,7 @@ impl WorkstreamConnector for TmConnector {
     /// Why: mirrors `daemon::managed_routes::list_managed_sessions`.
     /// What: unwraps the `{"sessions": [...]}` envelope and maps each
     /// `ManagedSessionSummary` onto a portable `SessionInfo`.
-    /// Test: `tm_tests::create_session_spawns_and_appears_in_list`,
+    /// Test: `tm_tests::create_session_full_lifecycle`,
     /// `tm_tests::list_sessions_empty_fleet_returns_empty_vec`.
     async fn list_sessions(&self) -> Result<Vec<SessionInfo>, ConnectorError> {
         let url = format!("{}/api/v1/sessions/managed", self.daemon_url);
@@ -216,7 +218,8 @@ impl WorkstreamConnector for TmConnector {
     /// What: a 404 maps to [`ConnectorError::NotFound`] via
     /// [`map_error_response`]; otherwise the summary's `state` and
     /// `pending_decision` populate the [`SessionStatus`].
-    /// Test: `tm_tests::session_status_returns_state_for_known_session`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (known-session path,
+    /// via `ConnectorTestKit::assert_basic_lifecycle`),
     /// `tm_tests::session_status_unknown_id_is_not_found`.
     async fn session_status(&self, session_id: &str) -> Result<SessionStatus, ConnectorError> {
         let url = format!("{}/api/v1/sessions/managed/{session_id}", self.daemon_url);
@@ -268,7 +271,8 @@ impl WorkstreamConnector for TmConnector {
     /// What: wraps the daemon's `attach_cmd` string in
     /// [`AttachHandle::ShellCommand`]. A 404 (unknown session) maps to
     /// [`ConnectorError::NotFound`].
-    /// Test: `tm_tests::attach_returns_shell_command_for_known_session`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (asserts the
+    /// returned handle is a `ShellCommand` containing `tmux attach`),
     /// `tm_tests::attach_unknown_id_is_not_found`.
     async fn attach(&self, session_id: &str) -> Result<AttachHandle, ConnectorError> {
         let url = format!(
@@ -313,7 +317,8 @@ impl WorkstreamConnector for TmConnector {
     /// `isError: true` into [`ConnectorError::Backend`] (`"no such
     /// session"`/circuit-breaker-open messages land here) and a malformed
     /// envelope into [`ConnectorError::Transport`].
-    /// Test: `tm_tests::delegate_records_a_delegation`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (asserts a
+    /// non-empty `delegate_id` against a live session),
     /// `tm_tests::delegate_unknown_session_is_backend_error`.
     async fn delegate(
         &self,


### PR DESCRIPTION
Closes #3256

## Summary

`scripts/check_test_pointers.sh` was failing on `origin/main`, blocking the "Test: doc-comment pointer lint" CI check on every open PR. Root cause per #3256: PRs #3194 and #3196 merged near-simultaneously, each green against its own pre-merge base, but the combined result on main left 10 `Test:` doc-comment pointers citing test names that don't actually exist.

While reproducing the lint locally I found an 11th, unrelated dangling pointer introduced by PR #3244 (`checkpoint_resume_tests` vs. the real module name `checkpoint_resume`) that was also failing the same gate — fixed in the same commit since it blocks the identical CI check.

## Fixes (11 total)

**`crates/trusty-agents/src/api/server/state.rs`**
- `finalize_task` doc: `Test: \`finalize_task_does_not_clobber_cancelled\`` (nonexistent) → cites the real `cancel_running_task_marks_cancelled` test, which directly asserts a late `finalize_task` call doesn't clobber a cancelled record.
- `register_handle` doc: `Test: \`register_handle_skips_already_terminal_task\`` (nonexistent) → reworded to prose (no fake identifier) noting the terminal-skip guard is exercised only indirectly today via `spawn_fake_running_task`, with no dedicated regression test.

**`crates/trusty-code/src/session/connector.rs`**
- `create_session` doc: `connector_e2e::create_session_binds_project_and_appears_in_list` (nonexistent) → `connector_e2e::create_session_full_lifecycle` (the real test that covers create/list/status/send/attach).
- `attach` doc: `connector_e2e::attach_returns_event_stream_for_known_session` (nonexistent) → same real `create_session_full_lifecycle` test (asserts the `EventStream` handle shape).

**`crates/trusty-mpm/src/connectors/tm.rs`**
- `TmConnector::new` doc: `tm_tests::new_resolves_default_daemon_url` (nonexistent) → points at `default_returned_when_no_lock_and_no_explicit` in `core::discovery` (covers the no-override branch `new()` delegates to), noting `new()` itself has no dedicated test.
- `create_session` doc (×2 pointers): `tm_tests::create_session_spawns_and_appears_in_list` (nonexistent) → `tm_tests::create_session_full_lifecycle`.
- `session_status` doc: `tm_tests::session_status_returns_state_for_known_session` (nonexistent) → `tm_tests::create_session_full_lifecycle`.
- `attach` doc: `tm_tests::attach_returns_shell_command_for_known_session` (nonexistent) → `tm_tests::create_session_full_lifecycle`.
- `delegate` doc: `tm_tests::delegate_records_a_delegation` (nonexistent) → `tm_tests::create_session_full_lifecycle`.

**`crates/trusty-agents/src/workflow/engine/executor/resume.rs`** (11th, unrelated to #3194/#3196, from #3244)
- Module doc: `Test: \`checkpoint_resume_tests\`` (nonexistent — real module is `checkpoint_resume`, no `_tests` suffix) → corrected to `checkpoint_resume`.

All fixes correct the pointer to name a real, verified-existing test/module — the linter itself is untouched.

## Verification

Raw `scripts/check_test_pointers.sh` output after the fix (full workspace scan):
```
test-pointers: 0 dangling pointers — OK.
```

`cargo check -p trusty-mpm -p trusty-code -p trusty-agents` — all three touched crates build clean.
`cargo fmt --check` — no formatting drift.

## Test plan
- [x] `bash scripts/check_test_pointers.sh` exits 0
- [x] `cargo check -p trusty-mpm -p trusty-code -p trusty-agents` passes
- [x] `cargo fmt --check` passes

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools