### PR TITLE
fix: repair dangling Test: pointers + restore green main (closes #3256)

### DIFF
--- a/crates/trusty-agents/src/api/server/tests/cancel.rs
+++ b/crates/trusty-agents/src/api/server/tests/cancel.rs
@@ -11,7 +11,9 @@
 //! code uses.
 //! What: `cancel_running_task_marks_cancelled`, `cancel_unknown_id_404`,
 //! `cancel_already_done_409`, `clear_context_now_aborts_running_task`,
-//! `cancel_survives_fifo_eviction_pressure`.
+//! `cancel_survives_fifo_eviction_pressure`,
+//! `finalize_task_does_not_clobber_cancelled`,
+//! `register_handle_skips_already_terminal_task`.
 //! Test: This module IS the test.
 
 use std::sync::Arc;
@@ -24,7 +26,7 @@ use axum::http::{Method, Request, StatusCode};
 use tower::ServiceExt;
 
 use crate::api::server::routes::build_router;
-use crate::api::server::state::{AppState, MAX_RETAINED};
+use crate::api::server::state::{AppState, CancelOutcome, MAX_RETAINED};
 use crate::api::types::{PmResponse, PmStatus};
 
 fn router(state: AppState) -> Router {
@@ -204,5 +206,59 @@ async fn cancel_survives_fifo_eviction_pressure() {
     assert!(
         !completed.load(Ordering::SeqCst),
         "the surviving task's AbortHandle must still be live and effective"
+    );
+}
+
+/// Direct unit test of `AppState::finalize_task`'s cancellation guard
+/// (#3063 code review), isolated from `spawn_fake_running_task`'s
+/// abort-timing race: `cancel_running_task_marks_cancelled` above proves the
+/// end-to-end abort path stops the future before it ever calls
+/// `finalize_task`, so it never actually exercises the `already_cancelled`
+/// branch inside `finalize_task` itself. This test calls `finalize_task`
+/// directly, after the record is already `Cancelled`, to prove the guard
+/// itself — not just that abort prevents the call from happening at all.
+#[tokio::test]
+async fn finalize_task_does_not_clobber_cancelled() {
+    let state = AppState::default();
+    state
+        .upsert("task-4".to_string(), PmResponse::running("task-4"))
+        .await;
+    let outcome = state.try_cancel("task-4").await;
+    assert!(matches!(outcome, CancelOutcome::Cancelled));
+
+    // Simulate a late `finalize_task` call from a background future that
+    // raced the cancel and lost — it must not overwrite the cancelled
+    // record with its own (fabricated) success result.
+    let mut late = PmResponse::running("task-4");
+    late.status = PmStatus::Success;
+    state.finalize_task("task-4".to_string(), late).await;
+
+    let stored = state.get("task-4").await.unwrap();
+    assert_eq!(
+        stored.status,
+        PmStatus::Cancelled,
+        "finalize_task must not clobber an already-cancelled record"
+    );
+}
+
+/// Direct unit test of `AppState::register_handle`'s terminal-status guard
+/// (#3063 code review): registering a handle for a task whose stored
+/// response already reached a terminal status (a pathologically fast task
+/// completing before `register_handle` runs after `tokio::spawn`) must be a
+/// no-op, not silently orphan the handle in `handles` forever.
+#[tokio::test]
+async fn register_handle_skips_already_terminal_task() {
+    let state = AppState::default();
+    let mut done = PmResponse::running("task-5");
+    done.status = PmStatus::Success;
+    state.upsert("task-5".to_string(), done).await;
+
+    let join = tokio::spawn(async { tokio::time::sleep(Duration::from_secs(30)).await });
+    state.register_handle("task-5", join.abort_handle()).await;
+    join.abort();
+
+    assert!(
+        !state.inner.lock().await.handles.contains_key("task-5"),
+        "register_handle must skip storing a handle for an already-terminal task"
     );
 }

--- a/crates/trusty-agents/src/workflow/engine/executor/resume.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/resume.rs
@@ -12,7 +12,7 @@
 //! matches the checkpointed phase list), reconstructs context, and delegates
 //! to `run_phase_loop`. `ResumeOutcome` distinguishes "already finished,
 //! nothing to resume" from "picked back up and ran".
-//! Test: `checkpoint_resume_tests` in the engine `tests` submodule.
+//! Test: `checkpoint_resume` in the engine `tests` submodule.
 
 use std::path::PathBuf;
 

--- a/crates/trusty-code/src/session/connector.rs
+++ b/crates/trusty-code/src/session/connector.rs
@@ -176,7 +176,8 @@ impl WorkstreamConnector for TcodeConnector {
     /// `session.create`'s `agent` param. A `400` (empty task, or `project`
     /// naming no real directory — see `session::protocol::create`'s AC-16.2
     /// docs) maps to [`ConnectorError::InvalidRequest`].
-    /// Test: `connector_e2e::create_session_binds_project_and_appears_in_list`,
+    /// Test: `connector_e2e::create_session_full_lifecycle` (create -> list ->
+    /// status -> send_input via `ConnectorTestKit::assert_basic_lifecycle`),
     /// `connector_e2e::create_session_wrong_backend_params_is_invalid_request`.
     async fn create_session(&self, req: CreateSessionReq) -> Result<SessionInfo, ConnectorError> {
         let CreateSessionReq {
@@ -294,7 +295,8 @@ impl WorkstreamConnector for TcodeConnector {
     /// [`ConnectorError::NotFound`]). On success, wraps
     /// `result.{session_id,stream_url,events}` in
     /// [`AttachHandle::EventStream`].
-    /// Test: `connector_e2e::attach_returns_event_stream_for_known_session`,
+    /// Test: `connector_e2e::create_session_full_lifecycle` (covers `attach`'s
+    /// `EventStream` shape against a known session),
     /// `connector_e2e::attach_unknown_id_is_not_found`.
     async fn attach(&self, session_id: &str) -> Result<AttachHandle, ConnectorError> {
         let rpc_req = json!({

--- a/crates/trusty-mpm/src/connectors/tm.rs
+++ b/crates/trusty-mpm/src/connectors/tm.rs
@@ -142,7 +142,8 @@ impl WorkstreamConnector for TmConnector {
     /// fields; `agent` has no equivalent on tm's spawn request and is
     /// silently ignored (see [`CreateSessionReq`]'s docs on why that's
     /// intentional, not a data-loss bug).
-    /// Test: `tm_tests::create_session_spawns_and_appears_in_list`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (create -> list ->
+    /// status -> send_input via `ConnectorTestKit::assert_basic_lifecycle`),
     /// `tm_tests::create_session_wrong_backend_params_is_invalid_request`.
     async fn create_session(&self, req: CreateSessionReq) -> Result<SessionInfo, ConnectorError> {
         let CreateSessionReq {
@@ -198,7 +199,8 @@ impl WorkstreamConnector for TmConnector {
     /// Why: mirrors `daemon::managed_routes::list_managed_sessions`.
     /// What: unwraps the `{"sessions": [...]}` envelope and maps each
     /// `ManagedSessionSummary` onto a portable `SessionInfo`.
-    /// Test: `tm_tests::create_session_spawns_and_appears_in_list`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (covers `list_sessions`
+    /// returning the just-created session),
     /// `tm_tests::list_sessions_empty_fleet_returns_empty_vec`.
     async fn list_sessions(&self) -> Result<Vec<SessionInfo>, ConnectorError> {
         let url = format!("{}/api/v1/sessions/managed", self.daemon_url);
@@ -216,7 +218,8 @@ impl WorkstreamConnector for TmConnector {
     /// What: a 404 maps to [`ConnectorError::NotFound`] via
     /// [`map_error_response`]; otherwise the summary's `state` and
     /// `pending_decision` populate the [`SessionStatus`].
-    /// Test: `tm_tests::session_status_returns_state_for_known_session`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (covers `session_status`
+    /// for a known session),
     /// `tm_tests::session_status_unknown_id_is_not_found`.
     async fn session_status(&self, session_id: &str) -> Result<SessionStatus, ConnectorError> {
         let url = format!("{}/api/v1/sessions/managed/{session_id}", self.daemon_url);
@@ -268,7 +271,8 @@ impl WorkstreamConnector for TmConnector {
     /// What: wraps the daemon's `attach_cmd` string in
     /// [`AttachHandle::ShellCommand`]. A 404 (unknown session) maps to
     /// [`ConnectorError::NotFound`].
-    /// Test: `tm_tests::attach_returns_shell_command_for_known_session`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (covers `attach`'s
+    /// `ShellCommand` shape for a known session),
     /// `tm_tests::attach_unknown_id_is_not_found`.
     async fn attach(&self, session_id: &str) -> Result<AttachHandle, ConnectorError> {
         let url = format!(
@@ -313,7 +317,8 @@ impl WorkstreamConnector for TmConnector {
     /// `isError: true` into [`ConnectorError::Backend`] (`"no such
     /// session"`/circuit-breaker-open messages land here) and a malformed
     /// envelope into [`ConnectorError::Transport`].
-    /// Test: `tm_tests::delegate_records_a_delegation`,
+    /// Test: `tm_tests::create_session_full_lifecycle` (covers `delegate`
+    /// recording a delegation against a live session),
     /// `tm_tests::delegate_unknown_session_is_backend_error`.
     async fn delegate(
         &self,

--- a/crates/trusty-mpm/src/connectors/tm_tests.rs
+++ b/crates/trusty-mpm/src/connectors/tm_tests.rs
@@ -128,6 +128,17 @@ fn local_bare_repo() -> (TempDir, String) {
     (scratch, url)
 }
 
+/// `TmConnector::new` is a thin wrapper around `resolve_daemon_url(None)` —
+/// assert the delegation actually happens (both compute to the same value
+/// independently) rather than re-testing `resolve_daemon_url`'s own
+/// explicit-override/lock-file/default priority chain, which has its own
+/// dedicated coverage in `core::discovery`.
+#[test]
+fn new_resolves_default_daemon_url() {
+    let connector = TmConnector::new();
+    assert_eq!(connector.daemon_url, resolve_daemon_url(None));
+}
+
 /// `CreateSessionReq::backend` carrying `BackendParams::Tcode` must be
 /// rejected client-side, before any HTTP call — a caller bug, not a daemon
 /// round-trip.


### PR DESCRIPTION
## Summary

Main is red on `bash scripts/check_test_pointers.sh` (10 dangling `Test:` doc-comment pointers, introduced by #3194 WorkstreamConnector and #3196 task cancellation merging near-simultaneously). While this branch was in flight, `origin/main` picked up 4 more commits (through #3244), which introduced one additional dangling pointer (`checkpoint_resume_tests`, from #3244) and one `check_line_cap.sh` violation (`trusty-agents-ui/src-tauri/src/main.rs` at 518 SLOC, from the Stop/Retask merge #3259). This PR fixes all of it — both gates now pass clean on the rebased tree.

### Per-pointer resolution (cited → actual)

| File:line | Cited name | Resolution |
|---|---|---|
| `trusty-agents/src/api/server/state.rs:157` | `finalize_task_does_not_clobber_cancelled` | Citation was correct; test never existed. Added a real unit test in `tests/cancel.rs` calling `try_cancel` then `finalize_task` directly — the existing `cancel_running_task_marks_cancelled` test only proves abort happens before `finalize_task` runs, never exercises the guard itself. |
| `trusty-agents/src/api/server/state.rs:189` | `register_handle_skips_already_terminal_task` | Same — added a real unit test asserting `register_handle` is a no-op for an already-terminal task (checked via the crate-internal `state.inner` field, mirroring existing precedent elsewhere in the crate). |
| `trusty-code/src/session/connector.rs:179` | `create_session_binds_project_and_appears_in_list` | Corrected citation → `create_session_full_lifecycle` (the real end-to-end test in `connector_e2e.rs`, via `ConnectorTestKit::assert_basic_lifecycle`). |
| `trusty-code/src/session/connector.rs:297` | `attach_returns_event_stream_for_known_session` | Corrected citation → `create_session_full_lifecycle` (covers `attach`'s `EventStream` shape). |
| `trusty-mpm/src/connectors/tm.rs:55` | `new_resolves_default_daemon_url` | Citation was correct; test never existed. Added it in `tm_tests.rs`, asserting `TmConnector::new().daemon_url == resolve_daemon_url(None)`. |
| `trusty-mpm/src/connectors/tm.rs:145,201` | `create_session_spawns_and_appears_in_list` | Corrected citation → `create_session_full_lifecycle` (in `tm_tests.rs`). |
| `trusty-mpm/src/connectors/tm.rs:219` | `session_status_returns_state_for_known_session` | Corrected citation → `create_session_full_lifecycle`. |
| `trusty-mpm/src/connectors/tm.rs:271` | `attach_returns_shell_command_for_known_session` | Corrected citation → `create_session_full_lifecycle`. |
| `trusty-mpm/src/connectors/tm.rs:316` | `delegate_records_a_delegation` | Corrected citation → `create_session_full_lifecycle`. |
| `trusty-agents/src/workflow/engine/executor/resume.rs:15` | `checkpoint_resume_tests` | Typo (new, post-rebase) — real module is `checkpoint_resume`; corrected. |

### Line-cap fix

`trusty-agents/ui/src-tauri/src/main.rs` grew to 518 SLOC (over the 500 production cap) once its inline `#[cfg(test)] mod tests` block (from an earlier merge) pushed it over. Split that block out verbatim into a sibling `main_tests.rs` (the workspace's established `_tests.rs` exemption, 1500 cap), wired back in via `#[cfg(test)] #[path = "main_tests.rs"] mod tests;` — a pure move, no behavior change. `main.rs` is now well under cap.

## Test plan

- [x] `bash scripts/check_test_pointers.sh` — `test-pointers: 0 dangling pointers — OK.` (exit 0)
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 10 allowlisted, 0 violations — OK.` (exit 0)
- [x] `cargo check -p trusty-agents -p trusty-code -p trusty-mpm -p trusty-agents-ui` — clean
- [x] `cargo clippy -p trusty-agents -p trusty-code -p trusty-mpm -p trusty-agents-ui --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-agents --lib -- cancel::` — 7 passed (incl. the 2 new tests)
- [x] `cargo test -p trusty-mpm --lib connectors::` — 8 passed (incl. `new_resolves_default_daemon_url`)
- [x] `cargo test -p trusty-code --test connector_e2e -- --test-threads=1` — 7 passed
- [x] `cargo test -p trusty-agents-ui --bins` — 6 passed (post-split)
- [x] `cargo fmt --check` — clean

Closes #3256.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools