### PR TITLE
chore: architecture-review tranche 0 — CLAUDE.md re-track guard + scheduled cargo audit

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -1,0 +1,65 @@
+# Scheduled cargo-audit dependency vulnerability scan (architecture-review tranche 0).
+#
+# WHY this workflow exists:
+#   SECURITY.md claimed `cargo audit` ran in CI on every commit, but no such
+#   job existed — the claim was aspirational, not real. This workflow makes
+#   it real: a weekly visibility-only scan of Cargo.lock against the RustSec
+#   advisory database.
+#
+# WHAT it does:
+#   1. Checks out the repo.
+#   2. Installs cargo-audit (`cargo install cargo-audit --locked`), matching
+#      this repo's "single-path workflow" convention of plain `cargo install`
+#      over pulling in a third-party audit action.
+#   3. Runs `cargo audit`, which fails the job (non-zero exit) if any
+#      advisory matches a dependency in Cargo.lock.
+#
+# TRIGGERS:
+#   - schedule: weekly, Monday 03:00 UTC. Weekly is appropriate because
+#     advisory data changes at the pace of new RustSec publications, not
+#     per-commit — unlike e2e-docker.yml's nightly install-path check.
+#   - workflow_dispatch: manual trigger from the Actions UI, e.g. to
+#     re-check immediately after fixing a flagged advisory.
+#   NOT triggered on push/pull_request — this job never gates a PR merge.
+#     It is intentionally non-blocking: `cargo audit` is allowed to fail
+#     normally (no continue-on-error) so a red scheduled run is visible,
+#     but because it isn't wired to push/pull_request it can't block anyone
+#     from merging.
+#
+# KNOWN OPEN ADVISORIES (as of this PR — expect the first scheduled runs to
+# be RED until these are resolved; that is intentional, not a workflow bug):
+#   - #2433: serde_yml/libyml are unsound and unmaintained with no fix
+#     upstream (GHSA-gfxp-f68g-8x78, high) — requires migrating off
+#     serde_yml/libyml entirely, not a version bump.
+#   - #2434: legacy rustls 0.21 / rustls-webpki 0.101.7 pulled in via
+#     aws-smithy default features (GHSA-82j2-j2ch-gfr8, high) — DoS via
+#     panic on malformed CRL BIT STRING; requires dropping the legacy
+#     rustls-webpki from aws-smithy's default feature set.
+#   - #2437: nltk 3.9.4 path traversal, transitive via pipecat-ai in
+#     python/trusty-voice/uv.lock (GHSA-p4gq-832x-fm9v, high) — no patched
+#     version exists upstream yet.
+name: Cargo audit (scheduled)
+
+on:
+  schedule:
+    # Weekly, Monday 03:00 UTC — advisories don't change per-commit.
+    - cron: '0 3 * * 1'
+  workflow_dispatch: {}
+
+concurrency:
+  group: cargo-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cargo-audit:
+    name: cargo audit (dependency vulnerability scan)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        run: cargo audit

--- a/.github/workflows/claude-md-guard.yml
+++ b/.github/workflows/claude-md-guard.yml
@@ -1,0 +1,33 @@
+# Root CLAUDE.md re-track guard for the trusty-tools workspace (issue #2299).
+#
+# Enforces that the repo-root CLAUDE.md stays untracked mechanically:
+#   - issue #2299 moved it to .trusty-mpm/INSTRUCTIONS.md to avoid duplicate
+#     context loading (~11k tokens/session) in Claude Code;
+#   - #2647 was a regression where it got re-tracked at the repo root;
+#   - this workflow fails the build if that ever happens again.
+#
+# Pure git-index check — no Rust toolchain or build needed, so this is fast
+# and runs as its own lightweight job (matches line-cap.yml's shape).
+name: CLAUDE.md guard
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs for the same ref to save CI minutes (matches line-cap.yml).
+concurrency:
+  group: claude-md-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude-md-guard:
+    name: Root CLAUDE.md must stay untracked
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Guard against re-tracking root CLAUDE.md (#2299)
+        run: bash scripts/check_claude_md_not_tracked.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,13 +49,21 @@ We take security seriously. If you discover a security vulnerability, **do not o
 
 ## Dependency Security
 
-The project uses `cargo audit` to scan for known vulnerabilities in dependencies:
+`cargo audit` scans dependencies for known vulnerabilities against the RustSec
+advisory database. It runs automatically on a **weekly schedule** via
+[`.github/workflows/cargo-audit.yml`](.github/workflows/cargo-audit.yml)
+(Monday 03:00 UTC, plus manual `workflow_dispatch`). This scan is
+visibility-only — it is not wired to `push`/`pull_request`, so it never
+blocks a PR merge; a failing scheduled run means an advisory needs triage,
+not that CI is broken.
+
+You can also run it locally at any time:
 
 ```bash
 cargo audit
 ```
 
-This is run in CI on every commit. Dependencies are kept up-to-date as part of regular maintenance.
+Dependencies are kept up-to-date as part of regular maintenance.
 
 ## Secure Coding Practices
 

--- a/scripts/check_claude_md_not_tracked.sh
+++ b/scripts/check_claude_md_not_tracked.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# check_claude_md_not_tracked.sh — root CLAUDE.md re-track guard (issue #2299).
+#
+# Why: issue #2299 moved the root CLAUDE.md to .trusty-mpm/INSTRUCTIONS.md
+#   because a tracked root CLAUDE.md causes duplicate context loading
+#   (~11k tokens/session) — Claude Code auto-loads both the tracked file
+#   AND the project's own instruction injection. #2647 was a regression of
+#   this fix: CLAUDE.md got re-tracked at the repo root and the duplicate
+#   loading came back. Advice without a gate loses — this script turns
+#   "don't re-track it" into a mechanical CI check.
+#
+# What: checks only the repo-root `CLAUDE.md` path (nested `crates/*/CLAUDE.md`
+#   files are fine and out of scope). If `git ls-files --error-unmatch CLAUDE.md`
+#   succeeds (exit 0, meaning the file IS tracked by git), this guard FAILS
+#   (exit 1) with a message pointing back at #2299 and
+#   .trusty-mpm/INSTRUCTIONS.md. If `git ls-files` reports the path as
+#   untracked (non-zero exit), this guard PASSES (exit 0).
+#
+# Must be run from the repo root so the pathspec resolves unambiguously to
+# the root-level file, not any nested CLAUDE.md.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if git ls-files --error-unmatch CLAUDE.md >/dev/null 2>&1; then
+  echo "FAIL: root CLAUDE.md is tracked by git."
+  echo
+  echo "  Issue #2299 moved the root CLAUDE.md to .trusty-mpm/INSTRUCTIONS.md"
+  echo "  specifically to avoid duplicate context loading (~11k tokens/session)"
+  echo "  when Claude Code auto-loads both the tracked file and the project's"
+  echo "  own instruction injection. #2647 was a prior regression of this."
+  echo
+  echo "  Fix: git rm --cached CLAUDE.md and put any new project-instruction"
+  echo "  content in .trusty-mpm/INSTRUCTIONS.md instead. Nested"
+  echo "  crates/*/CLAUDE.md files are unaffected — this guard only checks"
+  echo "  the repo root."
+  exit 1
+fi
+
+echo "PASS: root CLAUDE.md is not tracked (see #2299)."
+exit 0


### PR DESCRIPTION
## Summary

Architecture-review tranche 0 — two small, pre-approved mechanical fixes.

### Item 1: Root CLAUDE.md re-track guard (#2299)

Issue #2299 (closed) moved the root `CLAUDE.md` to `.trusty-mpm/INSTRUCTIONS.md`
because a tracked root `CLAUDE.md` causes duplicate context loading
(~11k tokens/session) — Claude Code auto-loads both the tracked file and the
project's own instruction injection. #2647 was a regression of this fix.

- `scripts/check_claude_md_not_tracked.sh` — fails if `CLAUDE.md` is tracked
  at the repo root (nested `crates/*/CLAUDE.md` are unaffected).
- `.github/workflows/claude-md-guard.yml` — runs the check on push/PR to
  main, mirroring `line-cap.yml`'s shape (no Rust toolchain needed).

### Item 2: Scheduled `cargo audit` + `SECURITY.md` correction

`SECURITY.md` claimed `cargo audit` already ran in CI on every commit — it
did not; the claim was aspirational. This PR makes it real:

- `.github/workflows/cargo-audit.yml` — weekly scheduled scan (Monday 03:00
  UTC) + `workflow_dispatch`, **not** wired to `push`/`pull_request` so it is
  visibility-only and never blocks a PR merge. No `continue-on-error` — a
  red run is the point.
- `SECURITY.md` — corrected to describe the actual weekly/manual cadence,
  kept the local `cargo audit` usage snippet.

Three High-severity advisories are currently open and unfixed upstream, so
the **first scheduled runs of this workflow are expected to be red** — noted
in the workflow's header comment:

- #2433 — `serde_yml`/`libyml` unsound + unmaintained, no fix upstream
  (GHSA-gfxp-f68g-8x78, high)
- #2434 — legacy `rustls 0.21`/`rustls-webpki 0.101.7` via `aws-smithy`
  default features (GHSA-82j2-j2ch-gfr8, high)
- #2437 — `nltk` path traversal, transitive via `pipecat-ai` in
  `python/trusty-voice/uv.lock` (GHSA-p4gq-832x-fm9v, high)

### Item 3 (out of scope, confirmed already fixed)

The root `Cargo.toml` `serde_yaml` comment was already corrected in commit
`ca862583` (2026-07-18) — verified via `git blame`. No change needed; not
touched in this PR.

## Test plan

- [x] `bash scripts/check_claude_md_not_tracked.sh` passes on current HEAD
      (CLAUDE.md untracked)
- [x] Demonstrated failure mode: `git add -f CLAUDE.md` (temp test file) →
      script correctly exits 1 → `git reset CLAUDE.md` + removed temp file,
      worktree clean, script passes again
- [x] `shellcheck scripts/check_claude_md_not_tracked.sh` — clean
- [x] `bash scripts/check_line_cap.sh` — still passes (no oversized files)
- [x] No Rust code changes — workflow/script/markdown only

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools