### PR TITLE
chore: architecture-review tranche 0 — sever cto-assistant edge + trusty-memory/trusty-search dep audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10832,7 +10832,6 @@ name = "trusty-agents-local"
 version = "0.1.3"
 dependencies = [
  "anyhow",
- "cto-assistant",
  "tokio",
  "trusty-agents",
 ]

--- a/crates/trusty-agents-local/CHANGELOG.md
+++ b/crates/trusty-agents-local/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+## [Unreleased]
+
+### Changed
+
+- **BREAKING (behavioral):** `trusty-agents-local` no longer depends on `cto-assistant` and no longer calls `trusty_agents::install_plugins(...)` at startup. The binary is now a thin pass-through to `trusty_agents::run()`. Running `trusty-agents-local` no longer exposes the CTO-assistant persona or its CTO DB tools. This severs the `trusty-agents-local -> cto-assistant` Cargo dependency edge as part of architecture-review tranche 0 (item 4), ahead of cto-assistant's planned migration directly into `trusty-agents`.

--- a/crates/trusty-agents-local/Cargo.toml
+++ b/crates/trusty-agents-local/Cargo.toml
@@ -3,11 +3,10 @@ name = "trusty-agents-local"
 version = "0.1.3"
 edition = "2024"
 publish = false
-description = "Private launcher: trusty-agents + local agents (cto-assistant, etc.)"
+description = "Private launcher: thin pass-through to trusty-agents::run()"
 license.workspace = true
 
 [dependencies]
 trusty-agents = { path = "../trusty-agents", version = "0.38.6" }
-cto-assistant = { path = "../cto-assistant", version = "0.1.3" }
 tokio = { workspace = true, features = ["full"] }
 anyhow = { workspace = true }

--- a/crates/trusty-agents-local/src/main.rs
+++ b/crates/trusty-agents-local/src/main.rs
@@ -1,23 +1,18 @@
-//! Why: `trusty-agents` cannot depend on private (publish=false) agent
-//!      crates. This private binary wires local agents into the trusty-agents
-//!      plugin registry before starting the server, giving a full-featured
-//!      local build without polluting the published crate.
-//! What: Installs the cto-assistant plugin, then delegates to trusty_agents::run().
-//! Test: `cargo run -p trusty-agents-local` starts the agent server with CTO tools.
+//! Why: architecture-review tranche 0 (item 4) severs the
+//!      `trusty-agents-local -> cto-assistant` Cargo edge. The cto-assistant
+//!      cluster (`trusty-agents-common`, `tc-services`, `trusty-cto-db`) is
+//!      planned to migrate directly into `trusty-agents` rather than stay a
+//!      plugin wired in from this launcher, so reworking the plugin-install
+//!      call here would be throwaway effort. Until that migration lands,
+//!      this binary carries no CTO plugin wiring.
+//! What: Thin pass-through launcher — delegates straight to
+//!       `trusty_agents::run()` with no local plugin installation.
+//! Test: `cargo run -p trusty-agents-local` starts the agent server with no
+//!       CTO tools exposed (behavioral change — see PR notes).
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Why: `install_plugins` writes into a process-wide OnceLock; calling it
-    //      twice (e.g. from a re-entrant test) returns the rejected plugin
-    //      list. We surface that as an error rather than silently dropping
-    //      the plugins so misconfiguration is loud.
-    // What: Registers the cto-assistant persona before `run()` so the ctrl
-    //       loop sees its `AgentPlugin` when it builds tool surfaces.
-    // Test: Indirectly covered by running `trusty-agents-local` and confirming
-    //       the cto-assistant persona exposes its CTO DB tools.
-    trusty_agents::install_plugins(vec![cto_assistant::agent_plugin()])
-        .map_err(|_| anyhow!("install_plugins called more than once"))?;
     trusty_agents::run().await
 }

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -129,10 +129,14 @@ lru = "0.16"
 # other through it.
 #
 # Why: The `trusty-agents` crate must NOT depend on `publish = false`
-#      agent crates (e.g. `cto-assistant`). Private launchers like
-#      `trusty-agents-local` depend on both `trusty-agents` and the agent crate, and
-#      wire them at startup via `trusty_agents::install_plugins(...)` before
-#      calling `trusty_agents::run()`.
+#      agent crates (e.g. `cto-assistant`). A private launcher can depend on
+#      both `trusty-agents` and such an agent crate, wiring them at startup
+#      via `trusty_agents::install_plugins(...)` before calling
+#      `trusty_agents::run()`. As of architecture-review tranche 0 (item 4),
+#      `trusty-agents-local` no longer does this for `cto-assistant` — that
+#      Cargo edge was cut deliberately, ahead of cto-assistant's planned
+#      migration directly into `trusty-agents`. This `install_plugins`
+#      mechanism remains available for any future private launcher.
 trusty-agents-common = { path = "../trusty-agents-common", version = "0.2.0" }
 
 # [patch.crates-io] moved to workspace root Cargo.toml (Cargo requires


### PR DESCRIPTION
## Architecture review tranche 0

Two small, pre-approved dependency-graph cleanup items for the trusty-tools Cargo workspace.

### Item 4 — Sever `trusty-agents-local -> cto-assistant` Cargo dependency

`crates/trusty-agents-local/src/main.rs` was a 24-line private (`publish = false`) launcher whose entire job was to install the `cto-assistant` plugin into `trusty-agents`'s process-wide plugin registry before calling `trusty_agents::run()`.

**Change:**
- Removed the `cto-assistant` path dependency from `crates/trusty-agents-local/Cargo.toml`.
- Removed the `cto_assistant::agent_plugin()` / `trusty_agents::install_plugins(...)` call from `main.rs`. The binary is now a pure pass-through to `trusty_agents::run()`.
- Updated the file's Why/What/Test doc comments and the crate description to reflect the new reality, noting the future plan: cto-assistant's functionality is expected to migrate directly into `trusty-agents` rather than stay a plugin wired in from this launcher — which is why the edge was cut now instead of reworked.
- Added `crates/trusty-agents-local/CHANGELOG.md` (didn't previously exist) documenting the change under `[Unreleased]`.
- Lightly updated the adjacent `trusty-agents-common` dependency comment in `crates/trusty-agents/Cargo.toml` (still describes the general private-launcher plugin pattern, but no longer claims `trusty-agents-local` specifically does this for `cto-assistant`).

**🔴 BEHAVIORAL CHANGE — flagged explicitly:** Running `trusty-agents-local` no longer exposes the CTO-assistant persona or its CTO DB tools. This is intentional per Bob's explicit prior decision ("the cto cluster later migrates into trusty-agents; this edge goes regardless") — not a bug, not reversible via config. Anyone currently relying on `trusty-agents-local` for CTO-assistant tooling will lose that until the CTO cluster migration lands in `trusty-agents` itself.

**Scope check:** confirmed via `grep -rn cto-assistant --include=Cargo.toml crates/` that `trusty-agents-local` is the *only* dependent of `cto-assistant` in the workspace. `crates/cto-assistant` itself is untouched.

### Item 5 — trusty-agents' direct Cargo deps on trusty-memory / trusty-search

**Outcome: documented no-op — dependency kept, no code change.**

Investigated whether `crates/trusty-agents/src/rpc/mod.rs`'s in-process usage of `trusty_memory::MemoryMcpService` and `trusty_search::SearchMcpService` could be trivially replaced with the same subprocess-MCP-over-stdio pattern that `crates/trusty-agents/src/plugins/trusty_search.rs` already uses for its own local `StdioMcpClient`.

Findings:
- `rpc/mod.rs::build_unified_discovery()` is a **synchronous** function that instantiates `MemoryMcpService` / `SearchMcpService`, collects them as `&dyn ServiceDescriptor`, and feeds them to `OpenRpcBuilder::from_services` to build one merged OpenRPC document. It's called directly from the `POST /rpc` axum handler (`rpc_handler`, wired in `api/server/routes.rs`) on every request — no async I/O, no subprocess.
- The module's own tests (`merged_doc_has_all_tools`, `every_method_has_x_service_annotation`) assert exact/minimum merged tool counts (≥26 = 11 memory + 15 search) and that every method carries an `x-service` annotation — i.e. the merge is relied on to be deterministic and synchronous at call time.
- Replacing this with a spawned-subprocess + MCP-stdio-handshake pattern would be a real architectural change (async, requires the `trusty-search`/`trusty-memory` binaries to be installed and spawnable at runtime, turns a cheap trait-based merge into a process-spawn-per-discovery or a persistent-subprocess-pool problem) — not a trivial substitution.
- This matches the existing justification already in `crates/trusty-agents/Cargo.toml` (the issue #226 comment), which explains `trusty-memory` is already minimized (`default-features = false`, dropping the `axum-server` feature) specifically because it's used in-process for this exact `rpc.discover` merge. That comment is prior art for this exact judgment call.

Per the original task instructions ("If you find a REAL lib-level usage that can't be trivially replaced, leave that dep, note it in the PR"), the `trusty-memory` / `trusty-search` deps on `trusty-agents` are left in place.

## Gates

```
cargo check -p trusty-agents-local   → Finished, clean
cargo check -p trusty-agents         → Finished, clean
cargo clippy -p trusty-agents-local -p trusty-agents -- -D warnings → Finished, 0 warnings
cargo fmt --check                    → exit 0 (only nightly-feature-unavailable notices, no diff)
cargo test -p trusty-agents-local    → 0 tests (expected — 24-line pass-through binary, no test target)
cargo test -p trusty-agents          → 1900 passed, 1 failed, 8 ignored
bash scripts/check_line_cap.sh       → line-cap: 9 allowlisted, 0 violations — OK
```

The one `trusty-agents` test failure (`workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts`) is a **pre-existing, unrelated flake**: it fails only under full-suite parallel execution and passes both standalone (`cargo test -p trusty-agents --lib workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts`) and scoped to its own module (`checkpoint_resume`, 6/6 passing). Confirmed it also fails identically with our diff stashed out (i.e. on top of plain `origin/main`), so it's unrelated to items 4 or 5. Not touched by this PR's diff (checkpoint/executor code is untouched).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools