### PR TITLE
feat(trusty-code): workstream domain model + flat JSON store + boot reconciliation (closes #3293)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10964,6 +10964,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Workstream domain model + flat JSON storage + boot reconciliation
+  (issue #3293, DOC-48 §2/§3, Phase 1A foundation for epic #3292).** New
+  `workstreams` module: `Workstream`/`WorkstreamId`/`WorkstreamState` (state
+  is computed, never persisted — active iff its id equals the store's
+  `active_workstream_id` pointer) and `WorkstreamStore`, an atomic
+  temp+rename flat-JSON store at `~/.trusty-code/workstreams-{slug}-{hash}.json`
+  keyed off the daemon's `ProjectBinding`. `reconcile_on_boot` restores the
+  persisted active pointer on restart and is strictly non-destructive — no
+  workstream record is ever deleted, and a pointer whose target vanished is
+  simply cleared. Activation-lock RPC semantics, the RPC/REST surface, the
+  CLI, and SSE aggregation are follow-up tickets (#3294–#3297) building on
+  this foundation.
 - **Per-call project binding on `task.run` (issue #3178, DOC-39 §5.5 /
   AC-16.2).** `task.run` (and `POST /tasks`) now accept an optional `project`
   path, resolved through the exact same `ProjectBinding::resolve` helper

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -53,6 +53,10 @@ trusty-agents-common = { workspace = true }
 # Structured error types for library code (FsError, LlmError, etc.)
 thiserror = { workspace = true }
 
+# workstreams::path: deterministic SHA-256 project-root fingerprint for the
+# workstream store's filename (DOC-48 §3.1: "workstreams-{slug}-{hash}.json").
+sha2 = { workspace = true }
+
 # LLM client: HTTP + TLS for the OpenRouter chat-completions API
 reqwest = { workspace = true }
 

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -260,6 +260,21 @@ pub mod project_context;
 /// Test: `binding::tests::*`.
 pub mod binding;
 
+/// Workstream domain model + flat JSON persistence + boot reconciliation
+/// (DOC-48 Phase 1A, issue #3293).
+///
+/// Why: DOC-39 §4B's Workstream domain object had no daemon-owned identity —
+/// a restart silently discarded the in-memory `SessionRegistry`'s workstream
+/// grouping. This module gives it one: a serializable domain object plus a
+/// single flat, atomically-written JSON store per project.
+/// What: `WorkstreamId`, `WorkstreamState` (computed, never persisted),
+/// `Workstream` (the domain record); `WorkstreamStore` (load/save/create/get/
+/// list, the `set_active` persistence primitive, and boot reconciliation).
+/// Activation-lock RPC semantics, the RPC/REST/CLI surface, and SSE
+/// aggregation are out of scope here (#3294–#3297).
+/// Test: `cargo test -p trusty-code workstreams::`.
+pub mod workstreams;
+
 // ── Phase 4 orchestration layer (per #1028) ──
 
 /// Multi-turn agent loop driving an LLM through tool calls to completion.

--- a/crates/trusty-code/src/workstreams/mod.rs
+++ b/crates/trusty-code/src/workstreams/mod.rs
@@ -1,0 +1,48 @@
+//! Workstream domain model + flat JSON persistence + boot reconciliation
+//! (DOC-48 Phase 1A, issue #3293).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-WS-01~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-01~draft)
+//! - [`SPEC-WS-02~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-02~draft)
+//! - [`SPEC-WS-03~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-03~draft)
+//!
+//! Why: DOC-39 §4B introduced **Workstream** as a durable named grouping of
+//! sessions that must survive daemon restarts, but tcode's `SessionRegistry`
+//! is in-memory only — a restart silently loses the workstream list (DOC-48
+//! §1.1). This module is the foundation slice that fixes that: a serializable
+//! domain object plus a single flat JSON store per project, written with an
+//! atomic temp+rename so a crash mid-write never corrupts the file.
+//!
+//! **Disambiguation (DOC-48 §11):** [`trusty_agents_common::workstreams::Workstream`]
+//! is a *different* type — the cross-tool engineering-lead ledger entry
+//! (DOC-44). This module's [`Workstream`] is tcode's own native domain object.
+//! Code that touches both MUST use qualified imports
+//! (`trusty_agents_common::workstreams::Workstream` for the ledger,
+//! `trusty_code::workstreams::Workstream` for tcode-native state) — never a
+//! bare `use ...::Workstream` in a module that needs both.
+//!
+//! What: [`WorkstreamId`] (a UUID newtype), [`WorkstreamState`] (the computed
+//! `active | idle | closed` enum — never persisted, see §2.2/§3.2),
+//! [`Workstream`] (the domain record — see [`model`]); [`WorkstreamStore`]
+//! (the flat-JSON, atomic-write, fingerprint-reload store plus boot
+//! reconciliation — see [`store`]); path/filename derivation from the
+//! daemon's [`crate::binding::ProjectBinding`] (see [`path`]).
+//!
+//! **Scope note (Phase 1A, issue #3293):** this module implements ONLY the
+//! domain model and persistence layer. Activation-lock RPC semantics
+//! (`workstream.activate{force}` / `ActiveConflict`, #3294), the RPC/REST
+//! surface (#3295), the CLI (#3296), and the SSE aggregation route (#3297)
+//! are explicitly out of scope and land in follow-up tickets against this
+//! foundation.
+//!
+//! Test: `cargo test -p trusty-code workstreams::` exercises every submodule
+//! in place; see each submodule's own `Test:` line for specifics.
+
+pub mod model;
+mod path;
+pub mod store;
+
+pub use model::{Workstream, WorkstreamId, WorkstreamState};
+pub use path::{default_data_dir, store_path};
+pub use store::{ReconcileOutcome, StoreError, WorkstreamStore};

--- a/crates/trusty-code/src/workstreams/model.rs
+++ b/crates/trusty-code/src/workstreams/model.rs
@@ -184,7 +184,7 @@ impl Workstream {
     /// session liveness never gates this (§3.3: "it does NOT determine
     /// active/idle state").
     /// What: `Active` iff `active_workstream_id == Some(self.id)` (checked
-    /// FIRST, matching §3.3 step 3's literal ordering); otherwise `Closed` if
+    /// FIRST, matching §3.2's literal ordering); otherwise `Closed` if
     /// [`Self::is_closed`], else `Idle`.
     /// Test: `model_tests::state_is_active_iff_pointer_matches`,
     /// `model_tests::state_is_closed_when_metadata_flag_set`,

--- a/crates/trusty-code/src/workstreams/model.rs
+++ b/crates/trusty-code/src/workstreams/model.rs
@@ -1,0 +1,217 @@
+//! Workstream domain types (DOC-48 §2).
+//!
+//! Why: a workstream needs a canonical, serializable shape so it can survive
+//! daemon restarts (persisted to the flat JSON store, §3) and be returned
+//! over the future RPC/REST surface (#3295) without ambiguity. State is
+//! deliberately NOT a stored field — §2.2/§3.2 require it to be *computed*
+//! from the store's `active_workstream_id` pointer on every read, so an
+//! operator can never desync the persisted state from the pointer that
+//! actually governs it.
+//! What: [`WorkstreamId`] (a UUID newtype, mirrors
+//! `trusty_mpm::session_manager::ManagedSessionId`'s pattern), [`WorkstreamState`]
+//! (the computed `active | idle | closed` enum), and [`Workstream`] (the
+//! persisted record: id, name, session_ids, timestamps, metadata — §2.1).
+//! Test: `model_tests`.
+
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use uuid::Uuid;
+
+/// Opaque identifier for a workstream.
+///
+/// Why: a newtype over [`Uuid`] prevents accidental confusion with other
+/// UUID-typed identifiers (e.g. a session id) at the type level.
+/// What: wraps `uuid::Uuid`; implements `Display` and serde derive for
+/// transparent JSON serialization as a plain UUID string.
+/// Test: `model_tests::workstream_id_round_trip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct WorkstreamId(pub Uuid);
+
+impl WorkstreamId {
+    /// Generate a new random workstream id.
+    ///
+    /// Why: every new workstream needs a stable, globally unique identifier
+    /// assigned at creation time (§2.1: "Generated on creation").
+    /// What: wraps `Uuid::new_v4()`.
+    /// Test: used throughout `store_tests`.
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Return the inner UUID value.
+    pub fn as_uuid(&self) -> &Uuid {
+        &self.0
+    }
+}
+
+impl Default for WorkstreamId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for WorkstreamId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl From<Uuid> for WorkstreamId {
+    fn from(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+}
+
+/// Computed lifecycle state of a [`Workstream`] (DOC-48 §2.2).
+///
+/// Why: the operator never sets this directly — it is inferred fresh on
+/// every `get`/`list` from the store's `active_workstream_id` pointer
+/// (§3.2), so state can never drift out of sync with the pointer that
+/// actually governs which workstream is active.
+/// What: `Active` (its id equals the persisted active pointer, regardless of
+/// session liveness), `Idle` (default, not active, not closed), `Closed`
+/// (marked closed via the reserved `metadata["closed"]` flag — see
+/// [`Workstream::is_closed`]; the `workstream.close` RPC verb that sets this
+/// flag is #3294/#3295 scope, not this ticket's).
+/// Test: `model_tests::state_is_active_iff_pointer_matches`,
+/// `model_tests::state_is_closed_when_metadata_flag_set`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkstreamState {
+    Active,
+    Idle,
+    Closed,
+}
+
+impl fmt::Display for WorkstreamState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Self::Active => "active",
+            Self::Idle => "idle",
+            Self::Closed => "closed",
+        };
+        write!(f, "{s}")
+    }
+}
+
+/// The reserved `metadata` key marking a workstream as closed (§3.2: "a
+/// metadata flag; see future Phase C"). Reserved here so the eventual
+/// `workstream.close` verb (#3294/#3295) and this state-inference logic
+/// agree on the wire shape without either side inventing its own key.
+const CLOSED_METADATA_KEY: &str = "closed";
+
+/// A durable named grouping of sessions, scoped to a single daemon instance
+/// (DOC-48 §2.1).
+///
+/// Why: the domain object that finally gives a workstream daemon-owned
+/// identity (DOC-48 §1.1) — previously the in-memory `SessionRegistry` was
+/// the sole record and a restart discarded it.
+/// What: `id` is immutable; `name` and `metadata` are mutable; `session_ids`
+/// is append-only (never removed, per §2.1); `created_at` is immutable,
+/// `updated_at` reflects last activity. `state` is deliberately NOT a field —
+/// call [`Self::state`] with the store's active pointer to compute it.
+/// Test: `model_tests::workstream_serde_round_trip`,
+/// `model_tests::new_workstream_starts_idle_with_no_sessions`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Workstream {
+    /// Unique, immutable identifier assigned at creation.
+    pub id: WorkstreamId,
+    /// Human-readable name; mutable (future rename support, Phase C).
+    pub name: String,
+    /// Sessions bound to this workstream. Append-only — never remove an
+    /// entry (§2.1).
+    #[serde(default)]
+    pub session_ids: Vec<String>,
+    /// When the workstream was created (first `workstream.create` call).
+    pub created_at: DateTime<Utc>,
+    /// Last activity: state inferred, name changed, session attached,
+    /// activated/deactivated, or closed.
+    pub updated_at: DateTime<Utc>,
+    /// Reserved for future use (tags, description, the `closed` flag). Empty
+    /// by default; `#[serde(default)]` keeps pre-existing records without
+    /// this key deserializable.
+    #[serde(default)]
+    pub metadata: Map<String, Value>,
+}
+
+impl Workstream {
+    /// Create a new workstream with the given name, no bound sessions, and
+    /// empty metadata.
+    ///
+    /// Why: the one constructor every creation path (the future
+    /// `workstream.create` RPC, and this ticket's store/tests) funnels
+    /// through, so `id`/`created_at`/`updated_at` are never hand-assembled
+    /// inconsistently.
+    /// What: assigns a fresh [`WorkstreamId`], stamps `created_at` ==
+    /// `updated_at` == now, and starts with empty `session_ids`/`metadata`.
+    /// Test: `model_tests::new_workstream_starts_idle_with_no_sessions`.
+    pub fn new(name: impl Into<String>) -> Self {
+        let now = Utc::now();
+        Self {
+            id: WorkstreamId::new(),
+            name: name.into(),
+            session_ids: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            metadata: Map::new(),
+        }
+    }
+
+    /// Whether this workstream is marked closed via the reserved metadata
+    /// flag (§3.2).
+    ///
+    /// Why: closure itself (`workstream.close`, #3294/#3295) is out of this
+    /// ticket's scope, but the domain model must already agree on where that
+    /// future verb will record its effect, so state inference is correct
+    /// from day one rather than needing a schema migration later.
+    /// What: `true` iff `metadata["closed"]` is present and `== true`.
+    /// Test: `model_tests::state_is_closed_when_metadata_flag_set`.
+    pub fn is_closed(&self) -> bool {
+        self.metadata
+            .get(CLOSED_METADATA_KEY)
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+
+    /// Compute this workstream's state given the store's persisted active
+    /// pointer (DOC-48 §2.2/§3.2).
+    ///
+    /// Why: state must never be read from a stored field — the pointer is
+    /// the single source of truth for which workstream is active, and
+    /// session liveness never gates this (§3.3: "it does NOT determine
+    /// active/idle state").
+    /// What: `Active` iff `active_workstream_id == Some(self.id)` (checked
+    /// FIRST, matching §3.3 step 3's literal ordering); otherwise `Closed` if
+    /// [`Self::is_closed`], else `Idle`.
+    /// Test: `model_tests::state_is_active_iff_pointer_matches`,
+    /// `model_tests::state_is_closed_when_metadata_flag_set`,
+    /// `model_tests::state_defaults_to_idle`.
+    pub fn state(&self, active_workstream_id: Option<WorkstreamId>) -> WorkstreamState {
+        if active_workstream_id == Some(self.id) {
+            WorkstreamState::Active
+        } else if self.is_closed() {
+            WorkstreamState::Closed
+        } else {
+            WorkstreamState::Idle
+        }
+    }
+
+    /// Stamp `updated_at` to now.
+    ///
+    /// Why: every mutation the store performs on a record (rename, session
+    /// bind, activation change, close) must refresh liveness per §2.1's
+    /// `updated_at` semantics; centralising it here keeps every call site in
+    /// lock-step.
+    /// What: sets `updated_at = Utc::now()`.
+    /// Test: `model_tests::touch_updates_timestamp`.
+    pub fn touch(&mut self) {
+        self.updated_at = Utc::now();
+    }
+}
+
+#[cfg(test)]
+#[path = "model_tests.rs"]
+mod model_tests;

--- a/crates/trusty-code/src/workstreams/model_tests.rs
+++ b/crates/trusty-code/src/workstreams/model_tests.rs
@@ -77,7 +77,7 @@ fn state_is_closed_when_metadata_flag_set() {
 
 #[test]
 fn active_pointer_beats_closed_flag() {
-    // Why: §3.3 step 3 checks the active pointer FIRST — a workstream whose
+    // Why: §3.2 checks the active pointer FIRST — a workstream whose
     // id happens to still equal the persisted pointer reports Active even if
     // it was also marked closed (an inconsistent state a future
     // `workstream.close` verb must avoid producing, but the read-side

--- a/crates/trusty-code/src/workstreams/model_tests.rs
+++ b/crates/trusty-code/src/workstreams/model_tests.rs
@@ -1,0 +1,117 @@
+//! Tests for `workstreams::model` (DOC-48 §2, AC-1.1, AC-4.1, AC-4.2).
+
+use super::*;
+
+#[test]
+fn workstream_id_round_trip() {
+    let id = WorkstreamId::new();
+    let json = serde_json::to_string(&id).expect("serialize");
+    let back: WorkstreamId = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(id, back);
+    assert_eq!(id.as_uuid(), back.as_uuid());
+}
+
+#[test]
+fn new_workstream_starts_idle_with_no_sessions() {
+    let ws = Workstream::new("Token rotation hardening");
+    assert_eq!(ws.name, "Token rotation hardening");
+    assert!(ws.session_ids.is_empty());
+    assert!(ws.metadata.is_empty());
+    assert_eq!(ws.created_at, ws.updated_at);
+    // AC-4.1/AC-4.2: with no active pointer set anywhere, a fresh workstream
+    // is idle, never active or closed.
+    assert_eq!(ws.state(None), WorkstreamState::Idle);
+}
+
+#[test]
+fn workstream_serde_round_trip() {
+    let ws = Workstream::new("Auth refactoring");
+    let json = serde_json::to_string(&ws).expect("serialize");
+    let back: Workstream = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back.id, ws.id);
+    assert_eq!(back.name, ws.name);
+    assert_eq!(back.session_ids, ws.session_ids);
+    assert_eq!(back.created_at, ws.created_at);
+    assert_eq!(back.updated_at, ws.updated_at);
+}
+
+#[test]
+fn workstream_without_metadata_key_deserializes_empty() {
+    // Why: a record persisted before `metadata` existed (or a hand-authored
+    // fixture) must still deserialize with an empty map rather than failing.
+    let legacy = serde_json::json!({
+        "id": WorkstreamId::new(),
+        "name": "legacy",
+        "session_ids": [],
+        "created_at": Utc::now().to_rfc3339(),
+        "updated_at": Utc::now().to_rfc3339(),
+    });
+    let ws: Workstream = serde_json::from_value(legacy).expect("deserialize legacy");
+    assert!(ws.metadata.is_empty());
+    assert!(!ws.is_closed());
+}
+
+#[test]
+fn state_is_active_iff_pointer_matches() {
+    let ws = Workstream::new("A");
+    let other = WorkstreamId::new();
+
+    assert_eq!(ws.state(Some(ws.id)), WorkstreamState::Active);
+    assert_eq!(ws.state(Some(other)), WorkstreamState::Idle);
+    assert_eq!(ws.state(None), WorkstreamState::Idle);
+}
+
+#[test]
+fn state_defaults_to_idle() {
+    let ws = Workstream::new("B");
+    assert_eq!(ws.state(None), WorkstreamState::Idle);
+}
+
+#[test]
+fn state_is_closed_when_metadata_flag_set() {
+    let mut ws = Workstream::new("C");
+    ws.metadata.insert("closed".to_string(), Value::Bool(true));
+    assert!(ws.is_closed());
+    assert_eq!(ws.state(None), WorkstreamState::Closed);
+}
+
+#[test]
+fn active_pointer_beats_closed_flag() {
+    // Why: §3.3 step 3 checks the active pointer FIRST — a workstream whose
+    // id happens to still equal the persisted pointer reports Active even if
+    // it was also marked closed (an inconsistent state a future
+    // `workstream.close` verb must avoid producing, but the read-side
+    // inference must still resolve deterministically).
+    let mut ws = Workstream::new("D");
+    ws.metadata.insert("closed".to_string(), Value::Bool(true));
+    assert_eq!(ws.state(Some(ws.id)), WorkstreamState::Active);
+}
+
+#[test]
+fn closed_flag_false_is_not_closed() {
+    let mut ws = Workstream::new("E");
+    ws.metadata.insert("closed".to_string(), Value::Bool(false));
+    assert!(!ws.is_closed());
+    assert_eq!(ws.state(None), WorkstreamState::Idle);
+}
+
+#[test]
+fn touch_updates_timestamp() {
+    let mut ws = Workstream::new("F");
+    let before = ws.updated_at;
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    ws.touch();
+    assert!(ws.updated_at > before);
+    assert_eq!(ws.created_at, before, "created_at must never change");
+}
+
+#[test]
+fn state_display_matches_wire_string() {
+    assert_eq!(WorkstreamState::Active.to_string(), "active");
+    assert_eq!(WorkstreamState::Idle.to_string(), "idle");
+    assert_eq!(WorkstreamState::Closed.to_string(), "closed");
+    assert_eq!(
+        serde_json::to_value(WorkstreamState::Active).unwrap(),
+        serde_json::json!("active")
+    );
+}

--- a/crates/trusty-code/src/workstreams/path.rs
+++ b/crates/trusty-code/src/workstreams/path.rs
@@ -1,0 +1,139 @@
+//! Storage-path derivation for the workstream store (DOC-48 §3.1).
+//!
+//! Why: the spec pins the filename shape (`workstreams-{project_slug}-{hash}.json`)
+//! to the daemon's OWN [`ProjectBinding`] — never a caller-supplied label —
+//! so two daemons bound to the same project always agree on one file, and
+//! two different projects (even same-named checkouts) never collide.
+//! What: [`store_filename`] derives the filesystem-safe slug + a truncated
+//! SHA-256 fingerprint of the canonical root from a [`ProjectBinding`];
+//! [`store_path`] joins it under a data directory; [`default_data_dir`]
+//! resolves `~/.trusty-code` (mirrors trusty-mpm's `~/.trusty-mpm`
+//! precedent, `crates/trusty-mpm/src/core/paths.rs`).
+//! Test: `path_tests`.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::binding::ProjectBinding;
+
+/// Number of hex characters kept from the SHA-256 digest (§3.1: "truncated
+/// to 8 chars").
+const HASH_LEN: usize = 8;
+
+/// Fixed filename used when the daemon is projectless (`ProjectBinding::None`).
+///
+/// Why: DOC-48 §2.3/§3.1 only specify the filename shape for a BOUND
+/// project; a projectless daemon has no path to slug or hash. Rather than
+/// fabricate a fake root, this ticket resolves the ambiguity with one fixed,
+/// documented filename — a projectless daemon has at most one workstream
+/// store regardless of which directory `tcode serve` happened to start in.
+const PROJECTLESS_FILENAME: &str = "workstreams-projectless.json";
+
+/// Resolve `~/.trusty-code`, the trusty-code data directory.
+///
+/// Why: mirrors `trusty-mpm`'s `~/.trusty-mpm` precedent
+/// (`crates/trusty-mpm/src/core/paths.rs`) rather than inventing a new
+/// resolution convention.
+/// What: `dirs::home_dir()/.trusty-code`, falling back to a relative
+/// `.trusty-code` if the home directory cannot be resolved (never panics).
+/// Test: `path_tests::default_data_dir_is_dot_trusty_code`.
+pub fn default_data_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".trusty-code")
+}
+
+/// Turn an arbitrary string into a filesystem-safe, lowercase, hyphenated
+/// slug.
+///
+/// Why: a project's directory basename may contain characters unsafe for a
+/// filename component (spaces, underscores, mixed case); the slug must be
+/// stable and readable.
+/// What: keeps ASCII alphanumerics (lowercased), collapses any run of other
+/// characters into a single `-`, and trims leading/trailing `-`. An
+/// all-non-alphanumeric input slugs to `"project"` rather than an empty
+/// string.
+/// Test: `path_tests::slugify_*`.
+fn slugify(raw: &str) -> String {
+    let mut slug = String::with_capacity(raw.len());
+    let mut last_was_dash = false;
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            last_was_dash = false;
+        } else if !last_was_dash && !slug.is_empty() {
+            slug.push('-');
+            last_was_dash = true;
+        }
+    }
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+    if slug.is_empty() {
+        "project".to_string()
+    } else {
+        slug
+    }
+}
+
+/// Deterministic 8-hex-char fingerprint of a project root path.
+///
+/// Why: disambiguates multiple checkouts that share a directory basename
+/// (§3.1: "to handle multiple checkouts of the same project").
+/// What: SHA-256 of the path's platform string, truncated to
+/// [`HASH_LEN`] lowercase hex characters. Deterministic for a given path,
+/// unlike a per-process `RandomState`-seeded hasher.
+/// Test: `path_tests::project_hash_is_deterministic`,
+/// `path_tests::project_hash_differs_for_different_paths`.
+fn project_hash(root: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(root.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex.truncate(HASH_LEN);
+    hex
+}
+
+/// Derive the workstream store's filename from a daemon's project binding
+/// (DOC-48 §3.1).
+///
+/// Why: the ONE place the filename shape is assembled, so the store and any
+/// future inspection tooling can never disagree on it.
+/// What: for a bound project, `workstreams-{slug}-{hash}.json` where `slug`
+/// comes from the root's basename and `hash` fingerprints the full root
+/// path (§3.1). For [`ProjectBinding::None`], the fixed
+/// [`PROJECTLESS_FILENAME`] (see its docs for why).
+/// Test: `path_tests::store_filename_for_bound_project`,
+/// `path_tests::store_filename_for_projectless`.
+pub fn store_filename(binding: &ProjectBinding) -> String {
+    match binding.root() {
+        Some(root) => {
+            let basename = root
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| root.display().to_string());
+            let slug = slugify(&basename);
+            let hash = project_hash(root);
+            format!("workstreams-{slug}-{hash}.json")
+        }
+        None => PROJECTLESS_FILENAME.to_string(),
+    }
+}
+
+/// Join [`store_filename`] under a data directory to get the full store path.
+///
+/// Why: the single entry point `WorkstreamStore::load_for_binding` (and any
+/// future daemon boot code) calls to resolve where the store file lives.
+/// What: `data_dir.join(store_filename(binding))`.
+/// Test: `path_tests::store_path_joins_data_dir_and_filename`.
+pub fn store_path(data_dir: &Path, binding: &ProjectBinding) -> PathBuf {
+    data_dir.join(store_filename(binding))
+}
+
+#[cfg(test)]
+#[path = "path_tests.rs"]
+mod path_tests;

--- a/crates/trusty-code/src/workstreams/path_tests.rs
+++ b/crates/trusty-code/src/workstreams/path_tests.rs
@@ -59,14 +59,36 @@ fn store_filename_for_projectless() {
 
 #[test]
 fn store_filename_disambiguates_same_basename_different_roots() {
-    let dir_a = TempDir::new().expect("tempdir a");
-    let dir_b = TempDir::new().expect("tempdir b");
-    // Two distinct temp roots have distinct basenames already (random temp
-    // suffixes), which is enough to prove the hash component varies with the
-    // full root path rather than being a constant.
-    let binding_a = ProjectBinding::resolve(Some(dir_a.path().to_path_buf())).expect("resolve a");
-    let binding_b = ProjectBinding::resolve(Some(dir_b.path().to_path_buf())).expect("resolve b");
-    assert_ne!(store_filename(&binding_a), store_filename(&binding_b));
+    // Why: §3.1 — "a hash suffix disambiguates multiple checkouts of the
+    // same project" (e.g. two clones both named `acme-api`). This must
+    // construct an ACTUAL same-basename scenario: two directories that
+    // share the literal final path component under different temp roots, so
+    // the slug component is identical and only the hash can tell them apart.
+    let root_a = TempDir::new().expect("tempdir a");
+    let root_b = TempDir::new().expect("tempdir b");
+    let dir_a = root_a.path().join("acme-api");
+    let dir_b = root_b.path().join("acme-api");
+    std::fs::create_dir(&dir_a).expect("mkdir a");
+    std::fs::create_dir(&dir_b).expect("mkdir b");
+    assert_eq!(
+        dir_a.file_name(),
+        dir_b.file_name(),
+        "precondition: both roots must share the same basename"
+    );
+
+    let binding_a = ProjectBinding::resolve(Some(dir_a)).expect("resolve a");
+    let binding_b = ProjectBinding::resolve(Some(dir_b)).expect("resolve b");
+    let filename_a = store_filename(&binding_a);
+    let filename_b = store_filename(&binding_b);
+    assert_ne!(
+        filename_a, filename_b,
+        "same-basename projects at different roots must not collide on filename"
+    );
+    // Same-basename precondition means the slug component is identical; the
+    // difference must come from the hash, proving the hash actually varies
+    // with the full root path rather than being a constant.
+    assert!(filename_a.starts_with("workstreams-acme-api-"));
+    assert!(filename_b.starts_with("workstreams-acme-api-"));
 }
 
 #[test]

--- a/crates/trusty-code/src/workstreams/path_tests.rs
+++ b/crates/trusty-code/src/workstreams/path_tests.rs
@@ -1,0 +1,78 @@
+//! Tests for `workstreams::path` (DOC-48 §3.1, AC-1.2).
+
+use super::*;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+#[test]
+fn default_data_dir_is_dot_trusty_code() {
+    let dir = default_data_dir();
+    assert_eq!(dir.file_name().unwrap(), ".trusty-code");
+}
+
+#[test]
+fn slugify_lowercases_and_hyphenates() {
+    assert_eq!(slugify("Acme_API"), "acme-api");
+    assert_eq!(slugify("acme-api"), "acme-api");
+    assert_eq!(slugify("My Project 2"), "my-project-2");
+}
+
+#[test]
+fn slugify_trims_leading_and_trailing_separators() {
+    assert_eq!(slugify("--acme--"), "acme");
+    assert_eq!(slugify("___"), "project");
+    assert_eq!(slugify(""), "project");
+}
+
+#[test]
+fn project_hash_is_deterministic() {
+    let root = PathBuf::from("/path/to/acme-api");
+    assert_eq!(project_hash(&root), project_hash(&root));
+    assert_eq!(project_hash(&root).len(), HASH_LEN);
+}
+
+#[test]
+fn project_hash_differs_for_different_paths() {
+    let a = PathBuf::from("/path/to/acme-api");
+    let b = PathBuf::from("/other/path/to/acme-api");
+    assert_ne!(project_hash(&a), project_hash(&b));
+}
+
+#[test]
+fn store_filename_for_bound_project() {
+    let dir = TempDir::new().expect("tempdir");
+    let binding = ProjectBinding::resolve(Some(dir.path().to_path_buf())).expect("resolve");
+    let filename = store_filename(&binding);
+    assert!(filename.starts_with("workstreams-"));
+    assert!(filename.ends_with(".json"));
+    // Deterministic for the same binding.
+    assert_eq!(filename, store_filename(&binding));
+}
+
+#[test]
+fn store_filename_for_projectless() {
+    assert_eq!(
+        store_filename(&ProjectBinding::None),
+        "workstreams-projectless.json"
+    );
+}
+
+#[test]
+fn store_filename_disambiguates_same_basename_different_roots() {
+    let dir_a = TempDir::new().expect("tempdir a");
+    let dir_b = TempDir::new().expect("tempdir b");
+    // Two distinct temp roots have distinct basenames already (random temp
+    // suffixes), which is enough to prove the hash component varies with the
+    // full root path rather than being a constant.
+    let binding_a = ProjectBinding::resolve(Some(dir_a.path().to_path_buf())).expect("resolve a");
+    let binding_b = ProjectBinding::resolve(Some(dir_b.path().to_path_buf())).expect("resolve b");
+    assert_ne!(store_filename(&binding_a), store_filename(&binding_b));
+}
+
+#[test]
+fn store_path_joins_data_dir_and_filename() {
+    let data_dir = PathBuf::from("/tmp/trusty-code-data");
+    let binding = ProjectBinding::None;
+    let path = store_path(&data_dir, &binding);
+    assert_eq!(path, data_dir.join("workstreams-projectless.json"));
+}

--- a/crates/trusty-code/src/workstreams/store.rs
+++ b/crates/trusty-code/src/workstreams/store.rs
@@ -108,6 +108,26 @@ pub struct ReconcileOutcome {
 /// last-observed [`FileSig`] so a read can detect an external write (e.g. a
 /// second daemon process, or a test writing the file directly) and reload
 /// before answering.
+///
+/// **Concurrency model:** `create`/`set_active`/`reconcile_on_boot` are
+/// read-modify-write cycles (reload → mutate `self.data` → `save`) with NO
+/// cross-process lock — unlike
+/// [`trusty_agents_common::workstreams::WorkstreamLedger`], which at least
+/// serializes concurrent *threads within one process* behind an in-process
+/// `Mutex`, this store doesn't even do that; `&mut self` on every mutating
+/// method is the only serialization, so it is safe only for a single
+/// `WorkstreamStore` handle used from one task at a time. Two *processes*
+/// racing a read-modify-write on the same file can still lose an update: the
+/// last writer's atomic `rename` always leaves a whole, parseable file
+/// (never a torn one), but an interleaved writer can silently overwrite the
+/// other's change with a stale in-memory copy. This is inert today because
+/// DOC-48's architecture binds exactly one daemon process to one
+/// `ProjectBinding` (§2.3), and that daemon is the store's only writer; it
+/// becomes a real constraint only if a future caller opens a second
+/// `WorkstreamStore` over the same file from another process — such a
+/// caller must route writes through the owning daemon instead of writing
+/// directly, mirroring `WorkstreamLedger`'s documented callers-must-route-
+/// through-one-process caveat.
 /// Test: `store_tests::store_load_save_round_trip`,
 /// `store_tests::store_reload_picks_up_external_write`.
 #[derive(Debug)]
@@ -145,7 +165,7 @@ impl WorkstreamStore {
     /// Why: the entry point a daemon boot path (or a test standing in for
     /// one) calls — it never assembles the filename itself.
     /// What: `Self::load(store_path(data_dir, binding))`.
-    /// Test: `store_tests::load_for_binding_derives_filename`.
+    /// Test: `store_tests::store_load_for_binding_derives_filename`.
     pub async fn load_for_binding(
         data_dir: &Path,
         binding: &ProjectBinding,

--- a/crates/trusty-code/src/workstreams/store.rs
+++ b/crates/trusty-code/src/workstreams/store.rs
@@ -1,0 +1,349 @@
+//! On-disk JSON persistence + boot reconciliation for workstream records
+//! (DOC-48 §3).
+//!
+//! Why: the daemon must survive restarts without losing track of which
+//! workstreams it owns, or silently changing which one is active
+//! (§3.2: "A daemon restart never silently changes which workstream is
+//! active"). A single flat JSON file with an atomic temp+rename write gives
+//! crash-safe persistence without a database dependency — mirroring
+//! `trusty_mpm::session_manager::store::SessionStore`'s proven pattern
+//! (fingerprint-gated reload, atomic write, structured errors), adapted to
+//! this spec's flat-array-plus-pointer shape (§3.1) instead of a keyed map.
+//! What: [`StoreError`] (structured failure surface), [`ReconcileOutcome`]
+//! (what boot reconciliation did), and [`WorkstreamStore`] — load/save,
+//! create/get/list, the low-level `set_active` persistence primitive (NOT
+//! the future `workstream.activate` RPC verb — see its docs), and
+//! [`WorkstreamStore::reconcile_on_boot`] (§3.3: non-destructive, restores
+//! the active pointer or clears it if the target vanished).
+//! Test: `store_tests`.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::fs;
+use tracing::debug;
+
+use super::model::{Workstream, WorkstreamId};
+use super::path::store_path;
+use crate::binding::ProjectBinding;
+
+/// The `version` field stamped into every store file (§3.1).
+pub const STORE_VERSION: &str = "1.0";
+
+/// Errors that can arise from store I/O or serialization.
+///
+/// Why: callers (the daemon boot path, future RPC handlers) need structured
+/// errors they can pattern-match rather than opaque strings.
+/// What: one variant per failure mode.
+/// Test: `store_tests::load_returns_error_on_corrupt_file`,
+/// `store_tests::get_missing_id_returns_not_found`.
+#[derive(Debug, Error)]
+pub enum StoreError {
+    /// An I/O operation on the backing file failed.
+    #[error("workstream store I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    /// JSON serialization or deserialization failed.
+    #[error("workstream store serialization error: {0}")]
+    Serialize(String),
+    /// The requested workstream id was not found in the store.
+    #[error("workstream not found: {0}")]
+    NotFound(String),
+}
+
+/// The versioned, on-disk JSON shape (§3.1): `version`, `active_workstream_id`,
+/// and a flat `workstreams` array — NOT a file-per-record or a keyed map.
+#[derive(Debug, Serialize, Deserialize)]
+struct StoredData {
+    version: String,
+    #[serde(default)]
+    active_workstream_id: Option<WorkstreamId>,
+    #[serde(default)]
+    workstreams: Vec<Workstream>,
+}
+
+impl Default for StoredData {
+    fn default() -> Self {
+        Self {
+            version: STORE_VERSION.to_string(),
+            active_workstream_id: None,
+            workstreams: Vec::new(),
+        }
+    }
+}
+
+/// A cheap freshness fingerprint for the backing file (mirrors
+/// `SessionStore`'s `FileSig`: mtime alone is insufficient on filesystems
+/// with coarse mtime resolution, so pairing it with byte length catches a
+/// same-second write that changed the file size).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+struct FileSig {
+    mtime: Option<SystemTime>,
+    len: u64,
+}
+
+/// What a boot-time reconciliation pass (§3.3) observed and did.
+///
+/// Why: the daemon boot path needs to log/report what reconciliation found
+/// without re-deriving it from before/after store snapshots.
+/// What: how many workstream records were loaded, the active id restored (if
+/// any), and whether a stale pointer (referencing a now-nonexistent
+/// workstream) was cleared.
+/// Test: `store_tests::reconcile_restores_active_pointer`,
+/// `store_tests::reconcile_clears_active_when_target_missing`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ReconcileOutcome {
+    pub workstream_count: usize,
+    pub active_restored: Option<WorkstreamId>,
+    pub active_cleared: bool,
+}
+
+/// Async, file-backed store for [`Workstream`] records (DOC-48 §3).
+///
+/// Why: gives the daemon crash-safe persistence with restart-time
+/// reconciliation, matching the exact atomic-write + fingerprint-reload
+/// contract `SessionStore` already proved out for a sibling harness.
+/// What: holds the in-memory [`StoredData`], the backing file path, and the
+/// last-observed [`FileSig`] so a read can detect an external write (e.g. a
+/// second daemon process, or a test writing the file directly) and reload
+/// before answering.
+/// Test: `store_tests::store_load_save_round_trip`,
+/// `store_tests::store_reload_picks_up_external_write`.
+#[derive(Debug)]
+pub struct WorkstreamStore {
+    data: StoredData,
+    path: PathBuf,
+    last_sig: Option<FileSig>,
+}
+
+impl WorkstreamStore {
+    /// Load (or create) the store at an explicit file path.
+    ///
+    /// Why: the filename is derived from the daemon's `ProjectBinding`
+    /// (§3.1), not a fixed name under a directory — so this takes the full
+    /// resolved path rather than a directory, unlike `SessionStore::load`.
+    /// What: reads `path` if it exists; returns a fresh default store
+    /// (`version` stamped, empty `workstreams`, no active pointer) if the
+    /// file is absent. Propagates I/O and JSON errors — a CORRUPT file is
+    /// never silently treated as empty (see [`Self::read_file`]).
+    /// Test: `store_tests::store_load_save_round_trip`,
+    /// `store_tests::load_returns_error_on_corrupt_file`.
+    pub async fn load(path: impl Into<PathBuf>) -> Result<Self, StoreError> {
+        let path = path.into();
+        let (data, last_sig) = Self::read_file(&path).await?;
+        Ok(Self {
+            data,
+            path,
+            last_sig,
+        })
+    }
+
+    /// Load the store for a daemon's project binding, deriving the filename
+    /// per §3.1.
+    ///
+    /// Why: the entry point a daemon boot path (or a test standing in for
+    /// one) calls — it never assembles the filename itself.
+    /// What: `Self::load(store_path(data_dir, binding))`.
+    /// Test: `store_tests::load_for_binding_derives_filename`.
+    pub async fn load_for_binding(
+        data_dir: &Path,
+        binding: &ProjectBinding,
+    ) -> Result<Self, StoreError> {
+        Self::load(store_path(data_dir, binding)).await
+    }
+
+    async fn sig_of(path: &Path) -> Option<FileSig> {
+        let meta = fs::metadata(path).await.ok()?;
+        Some(FileSig {
+            mtime: meta.modified().ok(),
+            len: meta.len(),
+        })
+    }
+
+    /// Read and parse the backing file, returning the data and its signature.
+    ///
+    /// Why: a corrupt (malformed/truncated) file must surface as a loud
+    /// error, not silently reset to an empty store — that would look like
+    /// every workstream the user had was deleted (violates AC-6.1's
+    /// non-destructive spirit at the read layer too).
+    /// What: file absent -> `(default, None)`; file present and parseable ->
+    /// `(data, Some(sig))`; file present and unparseable -> propagates
+    /// `StoreError::Serialize`. The signature is captured AFTER the read
+    /// (closes the same TOCTOU window `SessionStore` documents).
+    /// Test: `store_tests::load_returns_error_on_corrupt_file`.
+    async fn read_file(path: &Path) -> Result<(StoredData, Option<FileSig>), StoreError> {
+        match fs::read_to_string(path).await {
+            Ok(raw) => {
+                let data = serde_json::from_str::<StoredData>(&raw)
+                    .map_err(|e| StoreError::Serialize(e.to_string()))?;
+                let sig = Self::sig_of(path).await.unwrap_or_default();
+                Ok((data, Some(sig)))
+            }
+            Err(_) => {
+                debug!(path = %path.display(), "no workstream store file found; starting fresh");
+                Ok((StoredData::default(), None))
+            }
+        }
+    }
+
+    /// Reload the in-memory state from disk if the backing file changed.
+    ///
+    /// Why: mirrors `SessionStore::reload_if_changed` — another process (or,
+    /// in tests, a second store handle) may have written the shared file
+    /// since this handle last touched it.
+    /// What: cheap no-op when the (mtime, len) fingerprint is unchanged;
+    /// otherwise re-reads and replaces the in-memory data + signature.
+    /// Test: `store_tests::store_reload_picks_up_external_write`,
+    /// `store_tests::store_reload_noop_when_unchanged`.
+    pub async fn reload_if_changed(&mut self) -> Result<(), StoreError> {
+        let current = Self::sig_of(&self.path).await;
+        let unchanged = matches!((current, self.last_sig), (Some(a), Some(b)) if a == b);
+        if unchanged {
+            return Ok(());
+        }
+        let (data, sig) = Self::read_file(&self.path).await?;
+        self.data = data;
+        self.last_sig = sig;
+        debug!(path = %self.path.display(), "workstream store reloaded after external change");
+        Ok(())
+    }
+
+    /// Persist the current in-memory state to disk atomically.
+    ///
+    /// Why: §3.1 requires "no partial writes even if the daemon crashes
+    /// mid-write" — a plain `fs::write` truncates then rewrites, exposing a
+    /// half-written file to a concurrent reader.
+    /// What: serializes to pretty JSON, writes a sibling `.json.tmp`, then
+    /// renames it over the real path (atomic swap on POSIX); records the
+    /// resulting fingerprint so a subsequent `reload_if_changed` treats this
+    /// write as "unchanged".
+    /// Test: exercised by every mutating test; `store_tests::store_load_save_round_trip`
+    /// verifies the round-trip.
+    pub async fn save(&mut self) -> Result<(), StoreError> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        let json = serde_json::to_string_pretty(&self.data)
+            .map_err(|e| StoreError::Serialize(e.to_string()))?;
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, json).await?;
+        fs::rename(&tmp, &self.path).await?;
+        self.last_sig = Self::sig_of(&self.path).await;
+        debug!(path = %self.path.display(), "workstream store saved");
+        Ok(())
+    }
+
+    /// Create a new workstream and persist it.
+    ///
+    /// Why: the one creation path this ticket owns (the `workstream.create`
+    /// RPC verb itself is #3295 scope; this is the persistence primitive it
+    /// will call).
+    /// What: reloads first (so a concurrent write is not clobbered),
+    /// appends a fresh [`Workstream::new`], saves, and returns its id.
+    /// Test: `store_tests::create_persists_and_is_gettable`.
+    pub async fn create(&mut self, name: impl Into<String>) -> Result<WorkstreamId, StoreError> {
+        self.reload_if_changed().await?;
+        let ws = Workstream::new(name);
+        let id = ws.id;
+        self.data.workstreams.push(ws);
+        self.save().await?;
+        Ok(id)
+    }
+
+    /// Look up a workstream by id, reloading first.
+    ///
+    /// Test: `store_tests::create_persists_and_is_gettable`,
+    /// `store_tests::get_missing_id_returns_not_found`.
+    pub async fn get(&mut self, id: WorkstreamId) -> Result<Workstream, StoreError> {
+        self.reload_if_changed().await?;
+        self.data
+            .workstreams
+            .iter()
+            .find(|w| w.id == id)
+            .cloned()
+            .ok_or_else(|| StoreError::NotFound(id.to_string()))
+    }
+
+    /// Return every stored workstream record, reloading first.
+    ///
+    /// Why: state is computed, not stored — callers pair each record with
+    /// [`Workstream::state`] and [`Self::active_workstream_id`] themselves.
+    /// Test: `store_tests::list_returns_all_records`.
+    pub async fn list(&mut self) -> Result<Vec<Workstream>, StoreError> {
+        self.reload_if_changed().await?;
+        Ok(self.data.workstreams.clone())
+    }
+
+    /// Return the persisted active-workstream pointer, reloading first.
+    ///
+    /// Test: `store_tests::set_active_persists_pointer`.
+    pub async fn active_workstream_id(&mut self) -> Result<Option<WorkstreamId>, StoreError> {
+        self.reload_if_changed().await?;
+        Ok(self.data.active_workstream_id)
+    }
+
+    /// Low-level persistence primitive: set (or clear) the active-workstream
+    /// pointer and persist.
+    ///
+    /// Why: this is NOT the future `workstream.activate{id, force}` RPC verb
+    /// (#3294) — that verb layers conflict detection (`ActiveConflict` when
+    /// another workstream is already active) and the prior-workstream
+    /// deactivation side effect on top. This method is the mechanical
+    /// "write the pointer" primitive that verb — and this ticket's own boot
+    /// reconciliation — build on.
+    /// What: validates that `Some(id)` refers to an existing record (a
+    /// dangling pointer must never be written deliberately — only
+    /// reconciliation clears an already-dangling one), then persists.
+    /// Test: `store_tests::set_active_persists_pointer`,
+    /// `store_tests::set_active_rejects_unknown_id`.
+    pub async fn set_active(&mut self, id: Option<WorkstreamId>) -> Result<(), StoreError> {
+        self.reload_if_changed().await?;
+        if let Some(id) = id
+            && !self.data.workstreams.iter().any(|w| w.id == id)
+        {
+            return Err(StoreError::NotFound(id.to_string()));
+        }
+        self.data.active_workstream_id = id;
+        self.save().await
+    }
+
+    /// Boot-time reconciliation (DOC-48 §3.3, AC-1.4, AC-6.1, AC-6.2).
+    ///
+    /// Why: a daemon restart must never silently change which workstream is
+    /// active (§3.2), and must never delete a workstream record (§3.3,
+    /// AC-6.1) — session liveness plays NO part in this (§3.3: "does NOT
+    /// determine active/idle state").
+    /// What: reloads from disk, then: if the persisted active pointer still
+    /// references an existing workstream, leaves it untouched (restored);
+    /// if it references a workstream that no longer exists, clears it to
+    /// `None` and persists that single change; if there was no pointer,
+    /// does nothing. Every workstream record is preserved either way — this
+    /// method never removes an entry from `workstreams`.
+    /// Test: `store_tests::reconcile_restores_active_pointer`,
+    /// `store_tests::reconcile_clears_active_when_target_missing`,
+    /// `store_tests::reconcile_is_noop_with_no_active_pointer`.
+    pub async fn reconcile_on_boot(&mut self) -> Result<ReconcileOutcome, StoreError> {
+        self.reload_if_changed().await?;
+        let mut outcome = ReconcileOutcome {
+            workstream_count: self.data.workstreams.len(),
+            ..Default::default()
+        };
+        match self.data.active_workstream_id {
+            Some(id) if self.data.workstreams.iter().any(|w| w.id == id) => {
+                outcome.active_restored = Some(id);
+            }
+            Some(_) => {
+                self.data.active_workstream_id = None;
+                outcome.active_cleared = true;
+                self.save().await?;
+            }
+            None => {}
+        }
+        Ok(outcome)
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod store_tests;

--- a/crates/trusty-code/src/workstreams/store_tests.rs
+++ b/crates/trusty-code/src/workstreams/store_tests.rs
@@ -1,0 +1,256 @@
+//! Tests for `workstreams::store` (DOC-48 §3, AC-1.2, AC-1.4, AC-6.1, AC-6.2).
+
+use super::*;
+use tempfile::TempDir;
+
+fn store_file(dir: &TempDir) -> PathBuf {
+    dir.path().join("workstreams-test.json")
+}
+
+#[tokio::test]
+async fn store_load_save_round_trip() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+
+    let mut store = WorkstreamStore::load(&path).await.expect("load empty");
+    assert!(store.list().await.expect("list").is_empty());
+
+    let id = store
+        .create("Token rotation hardening")
+        .await
+        .expect("create");
+
+    let mut store2 = WorkstreamStore::load(&path).await.expect("reload");
+    let ws = store2.get(id).await.expect("get after reload");
+    assert_eq!(ws.id, id);
+    assert_eq!(ws.name, "Token rotation hardening");
+}
+
+#[tokio::test]
+async fn store_load_for_binding_derives_filename() {
+    let dir = TempDir::new().expect("tempdir");
+    let binding = ProjectBinding::None;
+    let mut store = WorkstreamStore::load_for_binding(dir.path(), &binding)
+        .await
+        .expect("load_for_binding");
+    store.create("x").await.expect("create");
+    assert!(dir.path().join("workstreams-projectless.json").exists());
+}
+
+#[tokio::test]
+async fn create_persists_and_is_gettable() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+
+    let id = store.create("Auth refactoring").await.expect("create");
+    let ws = store.get(id).await.expect("get");
+    assert_eq!(ws.name, "Auth refactoring");
+    assert_eq!(store.list().await.expect("list").len(), 1);
+}
+
+#[tokio::test]
+async fn get_missing_id_returns_not_found() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let missing = WorkstreamId::new();
+    assert!(matches!(
+        store.get(missing).await,
+        Err(StoreError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn list_returns_all_records() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    store.create("A").await.expect("create A");
+    store.create("B").await.expect("create B");
+    let all = store.list().await.expect("list");
+    assert_eq!(all.len(), 2);
+}
+
+#[tokio::test]
+async fn set_active_persists_pointer() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("A").await.expect("create");
+
+    store.set_active(Some(id)).await.expect("set_active");
+    assert_eq!(
+        store.active_workstream_id().await.expect("active"),
+        Some(id)
+    );
+
+    store.set_active(None).await.expect("clear active");
+    assert_eq!(store.active_workstream_id().await.expect("active"), None);
+}
+
+#[tokio::test]
+async fn set_active_rejects_unknown_id() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let unknown = WorkstreamId::new();
+    assert!(matches!(
+        store.set_active(Some(unknown)).await,
+        Err(StoreError::NotFound(_))
+    ));
+}
+
+/// AC-1.4/AC-6.2: on daemon restart, the persisted active pointer is
+/// restored (its workstream still exists).
+#[tokio::test]
+async fn reconcile_restores_active_pointer() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+
+    let mut writer = WorkstreamStore::load(&path).await.expect("load writer");
+    let id = writer.create("A").await.expect("create");
+    writer.set_active(Some(id)).await.expect("activate");
+    drop(writer);
+
+    // A fresh store handle stands in for the daemon reloading after restart.
+    let mut restarted = WorkstreamStore::load(&path).await.expect("load restarted");
+    let outcome = restarted.reconcile_on_boot().await.expect("reconcile");
+    assert_eq!(outcome.workstream_count, 1);
+    assert_eq!(outcome.active_restored, Some(id));
+    assert!(!outcome.active_cleared);
+    assert_eq!(
+        restarted.active_workstream_id().await.expect("active"),
+        Some(id),
+        "restart must not silently change which workstream is active"
+    );
+}
+
+/// AC-6.1: reconciliation never deletes a workstream record, even the one
+/// referenced by a since-vanished active pointer.
+#[tokio::test]
+async fn reconcile_clears_active_when_target_missing() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+    let dangling_id = WorkstreamId::new();
+
+    // Simulate a store file whose active pointer refers to a workstream that
+    // is no longer present (e.g. hand-edited, or a future prune tool).
+    let raw = serde_json::json!({
+        "version": "1.0",
+        "active_workstream_id": dangling_id,
+        "workstreams": [],
+    });
+    tokio::fs::write(&path, serde_json::to_string_pretty(&raw).unwrap())
+        .await
+        .expect("seed raw file");
+
+    let mut store = WorkstreamStore::load(&path).await.expect("load");
+    assert_eq!(
+        store.active_workstream_id().await.expect("active"),
+        Some(dangling_id),
+        "precondition: dangling pointer is present before reconciliation"
+    );
+
+    let outcome = store.reconcile_on_boot().await.expect("reconcile");
+    assert!(outcome.active_cleared);
+    assert_eq!(outcome.active_restored, None);
+    assert_eq!(store.active_workstream_id().await.expect("active"), None);
+
+    // Persisted to disk, not just in-memory.
+    let mut reloaded = WorkstreamStore::load(&path).await.expect("reload");
+    assert_eq!(
+        reloaded.active_workstream_id().await.expect("active"),
+        None,
+        "cleared pointer must be persisted"
+    );
+}
+
+#[tokio::test]
+async fn reconcile_is_noop_with_no_active_pointer() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    store.create("A").await.expect("create");
+
+    let outcome = store.reconcile_on_boot().await.expect("reconcile");
+    assert_eq!(outcome.workstream_count, 1);
+    assert_eq!(outcome.active_restored, None);
+    assert!(!outcome.active_cleared);
+}
+
+/// AC-6.1: reconciliation is non-destructive even across multiple
+/// workstreams — every record must survive.
+#[tokio::test]
+async fn reconcile_preserves_every_workstream_record() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+    let mut store = WorkstreamStore::load(&path).await.expect("load");
+    let a = store.create("A").await.expect("create A");
+    let b = store.create("B").await.expect("create B");
+    store.set_active(Some(a)).await.expect("activate A");
+    drop(store);
+
+    let mut restarted = WorkstreamStore::load(&path).await.expect("reload");
+    restarted.reconcile_on_boot().await.expect("reconcile");
+    let all = restarted.list().await.expect("list");
+    assert_eq!(
+        all.len(),
+        2,
+        "no workstream may be deleted by reconciliation"
+    );
+    assert!(all.iter().any(|w| w.id == a));
+    assert!(all.iter().any(|w| w.id == b));
+}
+
+#[tokio::test]
+async fn load_returns_error_on_corrupt_file() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+    tokio::fs::write(&path, b"{ not valid json ]")
+        .await
+        .expect("write corrupt file");
+
+    let result = WorkstreamStore::load(&path).await;
+    assert!(
+        matches!(result, Err(StoreError::Serialize(_))),
+        "a corrupt file must surface a structured error, not silently reset to empty"
+    );
+}
+
+/// Why: another process (or a second store handle, standing in for one)
+/// writing the shared file must be picked up on the next read rather than
+/// served stale state forever (mirrors `SessionStore`'s
+/// `store_reload_picks_up_external_write`).
+#[tokio::test]
+async fn store_reload_picks_up_external_write() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+
+    // Store A seeds one workstream and reads it into memory.
+    let mut store_a = WorkstreamStore::load(&path).await.expect("load A");
+    let id_a = store_a.create("A").await.expect("create in A");
+    assert_eq!(store_a.list().await.expect("list A before").len(), 1);
+
+    // Store B (a different process's view) adds a second workstream and
+    // activates it.
+    let mut store_b = WorkstreamStore::load(&path).await.expect("load B");
+    let id_b = store_b.create("B").await.expect("create in B");
+    store_b.set_active(Some(id_b)).await.expect("activate B");
+
+    // Store A must now observe both records and B's activation, not its
+    // stale one-record view.
+    let all = store_a.list().await.expect("list A after");
+    assert_eq!(all.len(), 2, "A must reload B's externally-written record");
+    assert!(all.iter().any(|w| w.id == id_a));
+    assert!(all.iter().any(|w| w.id == id_b));
+    assert_eq!(
+        store_a.active_workstream_id().await.expect("active"),
+        Some(id_b)
+    );
+}
+
+#[tokio::test]
+async fn store_reload_noop_when_unchanged() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("A").await.expect("create");
+
+    store.reload_if_changed().await.expect("reload no-op");
+    let ws = store.get(id).await.expect("get");
+    assert_eq!(ws.id, id);
+}


### PR DESCRIPTION
## Summary

Foundation slice of epic #3292, implementing DOC-48 (`docs/specs/DOC-48-tcode-workstreams.md`) §2 (domain model) and §3 (persistence + boot reconciliation) for issue #3293.

- **`Workstream` / `WorkstreamId` / `WorkstreamState`** (`crates/trusty-code/src/workstreams/model.rs`, SPEC-WS-02~draft) — `id`, `name`, `session_ids` (append-only), `created_at`/`updated_at`, `metadata`. State is **computed, never persisted**: `Workstream::state(active_id)` returns `Active` iff `id == active_id` (checked first, per §3.3 step 3's literal ordering), else `Closed` if the reserved `metadata["closed"]` flag is set, else `Idle`.
- **`WorkstreamStore`** (`crates/trusty-code/src/workstreams/store.rs`, SPEC-WS-03~draft) — single flat JSON file (`version`, `active_workstream_id`, `workstreams[]`) written via atomic temp+rename, with mtime+len fingerprint-gated reload — mirrors `trusty_mpm::session_manager::store::SessionStore`'s proven pattern. `load`/`load_for_binding`/`create`/`get`/`list`/`active_workstream_id`/`set_active` (a persistence primitive, distinct from the future `workstream.activate{force}` RPC verb).
- **`reconcile_on_boot`** (§3.3, AC-1.4/AC-6.1/AC-6.2) — restores the persisted active pointer on restart; **never deletes a workstream record**; clears the pointer only if its referenced workstream has vanished.
- **`workstreams::path`** (§3.1) — derives `workstreams-{project_slug}-{hash}.json` from the daemon's `ProjectBinding` (SHA-256 fingerprint of the canonical root, truncated to 8 hex chars); a projectless daemon uses a fixed `workstreams-projectless.json` (documented resolved ambiguity — the spec doesn't define this case explicitly).

**Explicitly out of scope** (follow-up tickets against this foundation): activation-lock RPC semantics / `ActiveConflict` (#3294), RPC/REST surface (#3295), CLI (#3296), SSE aggregation route (#3297). Session binding (AC-1.3) is also deferred — it isn't in #3293's AC list.

## Spec anchors implemented

- SPEC-WS-01~draft (motivation, module-doc cross-ref)
- SPEC-WS-02~draft (domain model)
- SPEC-WS-03~draft (persistence + boot reconciliation)
- AC-1.1, AC-1.2, AC-1.4, AC-4.1, AC-4.2, AC-6.1, AC-6.2 (§7)

## Spec ambiguities resolved

1. **Projectless daemon store filename** — §3.1 only defines the filename shape for a bound project. Resolved with a fixed `workstreams-projectless.json` rather than fabricating a fake root/hash (documented in `path.rs`).
2. **Closed-state signal** — §3.2 says closure is "a metadata flag; see future Phase C" without naming it. Reserved `metadata["closed"] = true` as that flag now so `workstream.close` (#3294/#3295) has an agreed wire shape to write, with zero schema migration later.
3. **`set_active` persistence primitive** — the spec's `workstream.activate{id, force}` RPC verb (with `ActiveConflict`/force-switch semantics) is #3294 scope, but boot reconciliation needs *something* to set the pointer for the store to restore. Added a minimal, explicitly-scoped `WorkstreamStore::set_active` (no force flag, no conflict detection) that #3294's verb will build on top of — documented as distinct in both the method doc and this PR.

## Gate results (raw)

`cargo check -p trusty-code`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.84s
```

`cargo test -p trusty-code --lib workstreams::`:
```
test result: ok. 34 passed; 0 failed; 0 ignored; 0 measured; 1223 filtered out; finished in 0.02s
```

`cargo test -p trusty-code` (full suite, all pre-existing tests): 1252/1253 passing — the one flake (`run_task::tests::*`, different test each run) is a **pre-existing** parallel-execution race confirmed present on `origin/main` before this change (verified in a throwaway detached worktree), unrelated to this PR's files.

`cargo clippy -p trusty-code --all-targets -- -D warnings`:
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.40s
```
(zero warnings from this crate; the two `warning:` lines in raw output are pre-existing multi-bin-target manifest warnings from `trusty-mpm`/`trusty-installer`, unrelated.)

`cargo fmt --check`: clean.

`bash scripts/check_line_cap.sh`:
```
line-cap: 9 allowlisted, 0 violations — OK.
```

`bash scripts/check_test_pointers.sh`:
```
test-pointers: 0 dangling pointers — OK.
```

`bash scripts/check_sld.sh`:
```
sld-lint: scanned 38 spec doc(s) + 2581 code file(s); 0 error(s), 0 warning(s)
```

## Test plan

- [x] `cargo test -p trusty-code --lib workstreams::` — 34/34 passing (model serde round-trips, state inference incl. closed-flag edge cases, path slug/hash derivation, store round-trip, corrupt-file handling, fingerprint-gated cross-handle reload, boot reconciliation restoring/clearing the active pointer, non-destructive multi-workstream reconciliation)
- [x] All required gates green (see above)

Part of #3292

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)