### PR TITLE
feat(daemons): apply router-wide same-origin write guard to search/memory/analyze + tm daemon (#3304 tranche 1, PR B)

### DIFF
--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -7,6 +7,18 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [Unreleased]
+
+### Security
+
+- **Router-wide same-origin (CSRF) write guard** ([#3304](https://github.com/bobmatnyc/trusty-tools/issues/3304)):
+  destructive write routes (`POST /indexes/{id}/scip`, `POST /review`,
+  `POST /analyze/deep`, `POST /facts`, `DELETE /facts/{id}`, the GitHub webhook)
+  are now guarded against cross-origin browser requests via the shared
+  `trusty_common::server::with_guarded_middleware`. Method-gated (GET reads and
+  `/sse` unaffected) and fail-open on a missing `Origin` (the console proxy,
+  `curl`, and GitHub's server-side webhook POST keep working).
+
 ## [0.7.3] — 2026-07-09
 
 ### Changed

--- a/crates/trusty-analyze/src/service/routes.rs
+++ b/crates/trusty-analyze/src/service/routes.rs
@@ -46,6 +46,30 @@ use super::ui;
 /// the returned router; the middleware composition is smoke-tested
 /// transitively (any layering regression breaks the suite).
 pub fn build_router(state: AnalyzerAppState) -> Router {
+    // #3304: loopback-only default. `serve` calls
+    // `build_router_with_self_origins` with the resolved bind address; every
+    // test keeps this entry point.
+    build_router_with_self_origins(state, trusty_common::server::SelfOrigins::default())
+}
+
+/// Build the router, additionally trusting the given bind-derived, non-loopback
+/// self-origins for the router-wide same-origin write guard (#3304).
+///
+/// Why: the analyzer exposes destructive write routes (`POST /indexes/{id}/scip`,
+/// `POST /review`, `POST /analyze/deep`, `POST /facts`, `DELETE /facts/{id}`,
+/// GitHub webhook) behind the permissive-CORS shared stack; without a
+/// same-origin guard a page the operator visits could drive them cross-origin
+/// (CSRF). This is the guarded entry point; `build_router` delegates here with a
+/// loopback-only allowlist so existing callers/tests are unchanged. `serve`
+/// passes its resolved bind address so a non-loopback bind trusts itself (#3269).
+/// What: identical router to `build_router`, except the final middleware is
+/// `with_guarded_middleware` (guard + standard stack).
+/// Test: `service::tests_review` guard tests (cross-origin `POST /review` →
+/// 403; loopback/missing-Origin → allowed; GET read unaffected).
+pub fn build_router_with_self_origins(
+    state: AnalyzerAppState,
+    self_origins: trusty_common::server::SelfOrigins,
+) -> Router {
     let router = Router::new()
         .route("/", get(|| async { Redirect::permanent("/ui/") }))
         .route("/health", get(health))
@@ -98,7 +122,9 @@ pub fn build_router(state: AnalyzerAppState) -> Router {
         .route("/ui/", get(ui::ui_index_handler))
         .route("/ui/{*path}", get(ui::ui_asset_handler))
         .with_state(Arc::new(state));
-    trusty_common::server::with_standard_middleware(router)
+    // #3304: router-wide same-origin write guard, applied AFTER all route
+    // registration so every destructive route is covered.
+    trusty_common::server::with_guarded_middleware(router, self_origins)
 }
 
 /// Bind to `start_port` (or auto-pick a free port walking forward) and run
@@ -119,7 +145,10 @@ pub async fn serve(state: AnalyzerAppState, start_port: u16) -> Result<()> {
     let actual = listener.local_addr()?;
     trusty_common::write_daemon_addr("trusty-analyze", &actual.to_string())?;
     tracing::info!("trusty-analyze listening on http://{actual}");
-    let app = build_router(state);
+    // #3304: trust the resolved bind address as a self-origin (non-loopback
+    // binds only; `from_bind_addrs` drops loopback) for the write guard.
+    let self_origins = trusty_common::server::SelfOrigins::from_bind_addrs(&[actual]);
+    let app = build_router_with_self_origins(state, self_origins);
     // Why (issue #534): without `with_graceful_shutdown`, SIGTERM from
     // `launchctl bootout` kills the process before any cleanup code in the
     // caller (PID file removal, supervisor shutdown) can run, and in-flight

--- a/crates/trusty-analyze/src/service/tests.rs
+++ b/crates/trusty-analyze/src/service/tests.rs
@@ -75,6 +75,104 @@ async fn health_response_includes_version() {
     assert!(!body["version"].as_str().unwrap().is_empty());
 }
 
+/// Why (#3304): `POST /facts` is a destructive write; a malicious cross-origin
+/// page must be rejected with `403` by the router-wide same-origin guard before
+/// the handler runs (CSRF defence).
+/// Test: this test.
+#[tokio::test]
+async fn write_route_rejects_cross_origin() {
+    let (state, _tmp) = make_state();
+    let app = build_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/facts")
+                .header("origin", "http://evil.example.com")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin POST /facts must be rejected by the write guard"
+    );
+}
+
+/// Why (#3304): the analyzer's own loopback-served UI and server-side callers
+/// (the console proxy / `curl` / the GitHub webhook, which send NO `Origin`)
+/// must keep driving writes — loopback and missing-Origin writes must NOT 403.
+/// Test: this test.
+#[tokio::test]
+async fn write_route_allows_loopback_and_missing_origin() {
+    let (state, _tmp) = make_state();
+    let app = build_router(state);
+    // Loopback origin → allowed.
+    let loopback = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/facts")
+                .header("origin", "http://127.0.0.1:7799")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        loopback.status(),
+        StatusCode::FORBIDDEN,
+        "loopback-origin POST /facts must pass the guard"
+    );
+    // No Origin (server-side caller) → allowed.
+    let missing = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/facts")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        missing.status(),
+        StatusCode::FORBIDDEN,
+        "missing-Origin POST /facts (server-side caller) must pass the guard"
+    );
+}
+
+/// Why (#3304): the guard is method-gated — a cross-origin GET read leaks no
+/// destructive capability and must NOT be blocked.
+/// Test: this test.
+#[tokio::test]
+async fn read_route_allows_cross_origin() {
+    let (state, _tmp) = make_state();
+    let app = build_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/health")
+                .header("origin", "http://evil.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin GET /health must not be blocked by the write guard"
+    );
+}
+
 #[tokio::test]
 async fn sse_subscriber_receives_emitted_event() {
     // Why: confirms the broadcast wiring is correct end-to-end —

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -14,6 +14,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **Router-wide same-origin (CSRF) write guard** ([#3304](https://github.com/bobmatnyc/trusty-tools/issues/3304)):
+  destructive write routes — `DELETE /api/v1/palaces/{id}` (palace deletion),
+  `DELETE …/drawers/{drawer_id}` (drawer deletion), `POST /api/v1/admin/stop`,
+  `POST /rpc` (the full JSON-RPC tool surface), `POST /api/v1/dream/run`, KG
+  asserts/deletes — are now guarded against cross-origin browser requests via
+  the shared `trusty_common::server::with_guarded_middleware`. Method-gated (GET
+  reads and `/sse` unaffected) and fail-open on a missing `Origin` (the console
+  proxy, the `serve --stdio` bridge, and `curl` keep working).
+
 ### Fixed
 
 - idle-to-disk palace eviction + unpin dream scheduler + configurable max-open ([#2276](https://github.com/bobmatnyc/trusty-tools/pull/2276)) ([`0e8e504`](https://github.com/bobmatnyc/trusty-tools/commit/0e8e50440cea09a8f5eedf2c7bba9613f96cd8a8))

--- a/crates/trusty-memory/src/http_server.rs
+++ b/crates/trusty-memory/src/http_server.rs
@@ -192,8 +192,6 @@ pub(crate) fn dotfile_http_addr_path() -> Option<PathBuf> {
 /// manual: `curl http://127.0.0.1:<port>/health` returns `ok` with `addr`.
 #[cfg(feature = "axum-server")]
 pub async fn run_http_on(state: AppState, listener: tokio::net::TcpListener) -> Result<()> {
-    use axum::routing::get;
-
     // Issue #35: recompute the `data_root` disk footprint every 10 s on a
     // background task so `GET /health` reports `disk_bytes` without doing a
     // recursive directory walk on the request path.
@@ -269,16 +267,15 @@ pub async fn run_http_on(state: AppState, listener: tokio::net::TcpListener) -> 
 
     // #3304: trust the resolved bind address as a self-origin (non-loopback
     // binds only; `from_bind_addrs` drops loopback) for the router-wide write
-    // guard, so a non-loopback bind still serves its own write UI. `/sse` is a
-    // GET (safe method) so it is unaffected by the guard whether or not it sits
-    // outside the guarded layer.
+    // guard, so a non-loopback bind still serves its own write UI. The `/sse`
+    // route is now registered INSIDE `router_with_self_origins` (before the
+    // guard/middleware layer) rather than chained on here — see #3304 review:
+    // routes added after `.layer()` get no middleware per axum's contract.
     let self_origins = match local {
         Some(a) => trusty_common::server::SelfOrigins::from_bind_addrs(&[a]),
         None => trusty_common::server::SelfOrigins::default(),
     };
-    let app = crate::web::router_with_self_origins(self_origins)
-        .route("/sse", get(sse_handler))
-        .with_state(state);
+    let app = crate::web::router_with_self_origins(self_origins).with_state(state);
 
     // Why (issue #534): bare axum::serve exits only on an internal error; SIGTERM
     // (launchctl bootout) would kill the process before the cleanup below had a

--- a/crates/trusty-memory/src/http_server.rs
+++ b/crates/trusty-memory/src/http_server.rs
@@ -267,7 +267,16 @@ pub async fn run_http_on(state: AppState, listener: tokio::net::TcpListener) -> 
     // the router below.
     let bm25_supervisor = state.bm25_supervisor.clone();
 
-    let app = crate::web::router()
+    // #3304: trust the resolved bind address as a self-origin (non-loopback
+    // binds only; `from_bind_addrs` drops loopback) for the router-wide write
+    // guard, so a non-loopback bind still serves its own write UI. `/sse` is a
+    // GET (safe method) so it is unaffected by the guard whether or not it sits
+    // outside the guarded layer.
+    let self_origins = match local {
+        Some(a) => trusty_common::server::SelfOrigins::from_bind_addrs(&[a]),
+        None => trusty_common::server::SelfOrigins::default(),
+    };
+    let app = crate::web::router_with_self_origins(self_origins)
         .route("/sse", get(sse_handler))
         .with_state(state);
 

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -178,7 +178,7 @@ pub use http_server::{run_http, run_http_dynamic, run_http_on};
 // (`lib_tests`, `web::tests`), so gate the re-export on `cfg(test)` to avoid an
 // unused-import warning in the normal (non-test) build.
 #[cfg(all(test, feature = "axum-server"))]
-pub(crate) use http_server::{dotfile_http_addr_path, sse_handler, write_http_addr_file};
+pub(crate) use http_server::{dotfile_http_addr_path, write_http_addr_file};
 
 /// Maximum bytes retained in the trigger-prompt excerpt embedded on a
 /// `HookFired` event.

--- a/crates/trusty-memory/src/web/mod.rs
+++ b/crates/trusty-memory/src/web/mod.rs
@@ -210,6 +210,13 @@ pub fn router_with_self_origins(
         // tool surface without learning the REST routes. The REST
         // routes above remain for backwards compatibility.
         .route("/rpc", post(rpc::rpc_handler))
+        // #3304: `/sse` (a GET event stream) is registered HERE, inside the
+        // router, so it sits UNDER the guard/standard-middleware layer applied
+        // below — not chained on by `run_http_on` AFTER the layer (where axum's
+        // `layer` contract would leave it middleware-less). It is a safe GET so
+        // the guard never blocks it; placing it here keeps "router-wide after
+        // all registration" literally true and avoids the layering footgun.
+        .route("/sse", get(crate::http_server::sse_handler))
         .fallback(static_assets::static_handler);
 
     // #3304: router-wide same-origin write guard, applied AFTER all route

--- a/crates/trusty-memory/src/web/mod.rs
+++ b/crates/trusty-memory/src/web/mod.rs
@@ -56,9 +56,36 @@ pub(crate) const HEALTH_PROBE_PALACE: &str = "__health_probe__";
 /// Build the public router with API routes + SPA asset fallback.
 ///
 /// Why: `run_http` calls this so the same router shape is used in tests.
-/// What: All API routes under `/api/v1`, fallback to the SPA shell.
+/// What: All API routes under `/api/v1`, fallback to the SPA shell. Trusts only
+/// loopback for the write guard (the `run_http_on` startup path uses
+/// [`router_with_self_origins`] with the resolved bind address).
 /// Test: `serves_index_html_fallback` and `status_endpoint_returns_payload`.
 pub fn router() -> Router<AppState> {
+    // #3304: loopback-only default. Every test keeps this entry point; the
+    // daemon startup passes its resolved bind address (see `http_server`).
+    router_with_self_origins(trusty_common::server::SelfOrigins::default())
+}
+
+/// Build the public router, additionally trusting the given bind-derived,
+/// non-loopback self-origins for the router-wide same-origin write guard (#3304).
+///
+/// Why: trusty-memory exposes DESTRUCTIVE write routes behind the permissive-CORS
+/// shared stack — `DELETE /api/v1/palaces/{id}` (palace deletion),
+/// `DELETE …/drawers/{drawer_id}` (drawer deletion), `POST /api/v1/admin/stop`,
+/// `POST /rpc` (the full JSON-RPC tool surface — every mutating MCP tool),
+/// `POST /api/v1/dream/run`, KG asserts/deletes. Without a same-origin guard any
+/// page the operator visits could drive them cross-origin (CSRF). This is the
+/// guarded entry point; `router` delegates here loopback-only so existing tests
+/// are unchanged. `run_http_on` passes the resolved bind address so a
+/// non-loopback bind trusts itself (#3269).
+/// What: identical router to `router`, except the final middleware is
+/// `with_guarded_middleware` (guard + standard stack) instead of
+/// `with_standard_middleware`.
+/// Test: `web::tests` guard tests (cross-origin `DELETE /api/v1/palaces/{id}` and
+/// `POST /rpc` → 403; loopback/missing-Origin → allowed; GET read unaffected).
+pub fn router_with_self_origins(
+    self_origins: trusty_common::server::SelfOrigins,
+) -> Router<AppState> {
     // axum 0.8 path syntax uses `{param}` instead of `:param`. The shared
     // `trusty_common::server::with_standard_middleware` layer brings in CORS,
     // tracing, and gzip (with SSE excluded) so we don't drift from sibling
@@ -185,7 +212,10 @@ pub fn router() -> Router<AppState> {
         .route("/rpc", post(rpc::rpc_handler))
         .fallback(static_assets::static_handler);
 
-    trusty_common::server::with_standard_middleware(router)
+    // #3304: router-wide same-origin write guard, applied AFTER all route
+    // registration so every destructive route (palace/drawer deletion, admin
+    // stop, the `/rpc` tool surface) is covered.
+    trusty_common::server::with_guarded_middleware(router, self_origins)
 }
 
 #[cfg(test)]

--- a/crates/trusty-memory/src/web/tests/dream_sse_tests.rs
+++ b/crates/trusty-memory/src/web/tests/dream_sse_tests.rs
@@ -58,11 +58,12 @@ async fn sse_broadcast_emits_palace_created() {
 /// Test: `cargo test -p trusty-memory-mcp sse_endpoint_emits_connected_frame`.
 #[tokio::test]
 async fn sse_endpoint_emits_connected_frame() {
-    use axum::routing::get;
+    // #3304: `/sse` is now registered inside `router()` (before the guard
+    // layer), so the test no longer adds it — doing so would panic on a
+    // duplicate route. This also exercises the real wired shape: `/sse` under
+    // the standard middleware + write guard (it is a safe GET, so unblocked).
     let state = test_state();
-    let app = router()
-        .route("/sse", get(crate::sse_handler))
-        .with_state(state);
+    let app = router().with_state(state);
     let resp = app
         .oneshot(Request::builder().uri("/sse").body(Body::empty()).unwrap())
         .await

--- a/crates/trusty-memory/src/web/tests/mod.rs
+++ b/crates/trusty-memory/src/web/tests/mod.rs
@@ -48,6 +48,7 @@ mod chat_tests;
 mod dream_sse_tests;
 mod health_tests;
 mod kg_tests;
+mod origin_guard_tests;
 mod palace_crud_tests;
 mod palace_tests;
 mod prompt_tests;

--- a/crates/trusty-memory/src/web/tests/origin_guard_tests.rs
+++ b/crates/trusty-memory/src/web/tests/origin_guard_tests.rs
@@ -1,0 +1,118 @@
+//! Regression tests for the router-wide same-origin write guard (#3304).
+//!
+//! Why: trusty-memory exposes DESTRUCTIVE write routes behind the
+//! permissive-CORS shared middleware stack — `POST /rpc` (the full JSON-RPC
+//! tool surface), `DELETE /api/v1/palaces/{id}` (palace deletion),
+//! `POST /api/v1/admin/stop`, KG asserts/deletes. Before #3304 these had NO
+//! write-origin guard, so any page the operator visited could drive them
+//! cross-origin (CSRF). The daemon now composes the shared
+//! `trusty_common::server::with_guarded_middleware` router-wide.
+//! What: builds the router via `router()` (loopback-only default) and drives it
+//! with `oneshot` HTTP requests against `POST /rpc` (write) and
+//! `/api/v1/status` (read).
+//! Test: this module.
+
+use super::super::router;
+use super::test_state;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::util::ServiceExt;
+
+/// Why: the CSRF threat — a malicious cross-origin page POSTing to the JSON-RPC
+/// tool surface (which can delete palaces/drawers, run dreams, mutate the KG).
+/// The router-wide guard MUST reject it with `403` before the handler runs.
+/// Test: this test.
+#[tokio::test]
+async fn rpc_rejects_cross_origin_write() {
+    let app = router().with_state(test_state());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/rpc")
+                .header("origin", "http://evil.example.com")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin POST /rpc must be rejected by the write guard"
+    );
+}
+
+/// Why: server-side callers — the console reverse proxy, the `serve --stdio`
+/// bridge fallback, `curl` — send NO `Origin`; and the daemon's own loopback UI
+/// sends a loopback `Origin`. Both must keep driving `/rpc` (fail-open contract).
+/// Test: this test.
+#[tokio::test]
+async fn rpc_allows_loopback_and_missing_origin() {
+    let body = || Body::from(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#);
+    // Loopback origin → allowed (handler processes; never 403).
+    let app = router().with_state(test_state());
+    let loopback = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/rpc")
+                .header("origin", "http://127.0.0.1:7070")
+                .header("content-type", "application/json")
+                .body(body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        loopback.status(),
+        StatusCode::FORBIDDEN,
+        "loopback-origin POST /rpc must pass the guard"
+    );
+    // No Origin (server-side caller / stdio bridge) → allowed.
+    let app = router().with_state(test_state());
+    let missing = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/rpc")
+                .header("content-type", "application/json")
+                .body(body())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        missing.status(),
+        StatusCode::FORBIDDEN,
+        "missing-Origin POST /rpc (server-side caller) must pass the guard"
+    );
+}
+
+/// Why: the guard is method-gated — a cross-origin GET read leaks no
+/// destructive capability and must NOT be blocked (dashboards read cross-origin
+/// under the permissive CORS policy).
+/// Test: this test.
+#[tokio::test]
+async fn read_route_allows_cross_origin() {
+    let app = router().with_state(test_state());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/status")
+                .header("origin", "http://evil.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin GET /api/v1/status must not be blocked by the write guard"
+    );
+}

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Security
+
+- **Daemon write guard extended from single-handler to router-wide**
+  ([#3304](https://github.com/bobmatnyc/trusty-tools/issues/3304)): previously
+  only `coordinator_chat` (`POST /api/v1/sessions/chat`) was origin-checked;
+  every other destructive route (`POST /sessions` spawn, `DELETE /sessions/{id}`,
+  `POST /api/v1/control/sessions/{id}/stop`, managed-session mutation,
+  `/claude-config/apply`, `/pair/*`) was exposed to cross-origin CSRF. The shared
+  `trusty_common` same-origin guard is now layered router-wide at the serve site
+  (`daemon::api::origin_guard::guard_router`), method-gated and fail-open on a
+  missing `Origin`. The `coordinator_chat` handler keeps its own finer-grained
+  origin check and `/rpc` keeps its loopback `ConnectInfo` gate (belt and
+  braces); the secondary Tailscale listener trusts its own bind address.
+
 ### Added
 
 - `tm sessions rename <id-or-name> <new-name>` (and in-session `tm sessions rename <new-name>` via `$TM_MANAGED_SESSION_ID`) renames a managed session, updating the record's `tmux_name` and the live tmux session, with collision + invalid-name guards

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -187,6 +187,11 @@ trusty-common = { workspace = true, features = [
     # (`search_index::register_project_index` → `trusty_common::search_index`).
     # Promoted out of trusty-mpm so trusty-code can reuse the ONE implementation.
     "search-index",
+    # #3304: the shared router-wide same-origin write guard
+    # (`trusty_common::server::guard_write_origin` / `SelfOrigins`) applied to the
+    # daemon router in `daemon/api.rs`. Already enabled as a dev-dependency below;
+    # promoted to the main dep so the guard compiles into the production daemon.
+    "axum-server",
 ] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # `console-metrics` enables `trusty_common::console_metrics` (used unconditionally by

--- a/crates/trusty-mpm/src/daemon/api/origin_guard.rs
+++ b/crates/trusty-mpm/src/daemon/api/origin_guard.rs
@@ -19,8 +19,38 @@
 //! Test: `origin_guard_tests` covers no-Origin → allowed, loopback/same-origin →
 //! allowed, and cross-origin → rejected.
 
+use axum::Router;
 use axum::http::HeaderMap;
 use axum::http::header::{HOST, ORIGIN};
+
+/// Apply the shared router-wide same-origin write guard to the daemon router
+/// (#3304).
+///
+/// Why: before #3304 only the `coordinator_chat` handler was origin-checked (via
+/// [`origin_allowed`], above); every OTHER destructive route (`POST /sessions`,
+/// `DELETE /sessions/{id}`, `POST /api/v1/control/sessions/{id}/stop`,
+/// managed-session mutation, `/claude-config/apply`, `/pair/*`) was exposed to
+/// cross-origin CSRF. Layering the shared `trusty_common` guard router-wide (a
+/// plain `.layer()` AFTER `with_state`, applied at the serve site in
+/// `daemon::mod` so it wraps every route incl. merged sub-routers — the #3268
+/// lesson) covers them all. `coordinator_chat` KEEPS its own finer-grained
+/// [`origin_allowed`] check and `/rpc` KEEPS its loopback `ConnectInfo` gate —
+/// belt and braces. Only the guard is layered (NOT `with_standard_middleware`)
+/// so the daemon's existing no-CORS posture is unchanged.
+/// What: wraps `router` with `guard_write_origin` carrying `self_origins`. The
+/// primary (loopback) listener passes `SelfOrigins::default()`; the secondary
+/// Tailscale listener passes its resolved bind address so its `/web` surface can
+/// POST to itself (#3269). Method-gated + fail-open-on-missing-Origin, so GET
+/// reads, SSE streams, the `serve --stdio` bridge, `curl`, and the TUI/Telegram
+/// adapters are unaffected.
+/// Test: `origin_guard_router_tests` (cross-origin `POST /sessions` → 403;
+/// loopback/missing-Origin → allowed; GET read unaffected).
+pub fn guard_router(router: Router, self_origins: trusty_common::server::SelfOrigins) -> Router {
+    router.layer(axum::middleware::from_fn_with_state(
+        self_origins,
+        trusty_common::server::guard_write_origin,
+    ))
+}
 
 /// Decide whether a request to the action-capable chat endpoint is allowed by the
 /// CSRF/origin guard.
@@ -239,3 +269,6 @@ mod origin_guard_tests {
         )));
     }
 }
+
+#[cfg(test)]
+mod origin_guard_router_tests;

--- a/crates/trusty-mpm/src/daemon/api/origin_guard/origin_guard_router_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api/origin_guard/origin_guard_router_tests.rs
@@ -1,0 +1,118 @@
+//! Regression tests for the router-wide same-origin write guard (#3304).
+//!
+//! Why: before #3304 the daemon guarded exactly ONE handler (`coordinator_chat`)
+//! via `origin_allowed`; every OTHER destructive route (`POST /sessions` spawn,
+//! `DELETE /sessions/{id}`, control-session stop, managed-session mutation,
+//! `/claude-config/apply`, `/pair/*`) was exposed to cross-origin CSRF. The
+//! daemon now layers the shared `trusty_common` guard router-wide via
+//! [`super::guard_router`] at the serve site. These tests prove a formerly
+//! unguarded write route (`POST /sessions`) is now covered, while reads and
+//! server-side/loopback callers are unaffected.
+//! What: builds `guard_router(router(state), SelfOrigins::default())` (the
+//! loopback-only primary-listener configuration) and drives it with `oneshot`.
+//! Test: this module.
+
+use super::guard_router;
+use crate::daemon::api::router;
+use crate::daemon::state::DaemonState;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+use trusty_common::server::SelfOrigins;
+
+/// Build the guarded daemon router exactly as the primary (loopback) listener
+/// does in `daemon::mod` — the router-wide guard trusting only loopback.
+fn guarded() -> axum::Router {
+    guard_router(router(DaemonState::shared()), SelfOrigins::default())
+}
+
+/// Why: the CSRF threat — a cross-origin page POSTing to `POST /sessions` (spawn
+/// a managed session), a route that had NO guard before #3304. The router-wide
+/// guard MUST reject it with `403` before the handler runs.
+/// Test: this test.
+#[tokio::test]
+async fn session_spawn_rejects_cross_origin_write() {
+    let resp = guarded()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions")
+                .header("origin", "http://evil.example.com")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin POST /sessions must be rejected by the router-wide write guard"
+    );
+}
+
+/// Why: the daemon's own loopback UI and server-side callers (the `serve
+/// --stdio` bridge, `curl`, the TUI/Telegram adapters — which send NO `Origin`)
+/// must keep driving writes; loopback and missing-Origin writes must NOT 403.
+/// Test: this test.
+#[tokio::test]
+async fn session_spawn_allows_loopback_and_missing_origin() {
+    // Loopback origin → allowed (handler runs; never 403).
+    let loopback = guarded()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions")
+                .header("origin", "http://127.0.0.1:4317")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        loopback.status(),
+        StatusCode::FORBIDDEN,
+        "loopback-origin POST /sessions must pass the guard"
+    );
+    // No Origin (server-side caller) → allowed.
+    let missing = guarded()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        missing.status(),
+        StatusCode::FORBIDDEN,
+        "missing-Origin POST /sessions (server-side caller) must pass the guard"
+    );
+}
+
+/// Why: the guard is method-gated — a cross-origin GET read leaks no destructive
+/// capability and must NOT be blocked.
+/// Test: this test.
+#[tokio::test]
+async fn read_route_allows_cross_origin() {
+    let resp = guarded()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/health")
+                .header("origin", "http://evil.example.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin GET /health must not be blocked by the write guard"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -149,7 +149,12 @@ pub async fn serve_http(
         info!("inproject-hygiene disabled via TRUSTY_MPM_INPROJECT_HYGIENE");
     }
 
-    let app = api::router(Arc::clone(&state));
+    // #3304: the primary listener is loopback; guard router-wide trusting only
+    // loopback. The secondary (Tailscale) listener trusts its own bind addr.
+    let app = api::origin_guard::guard_router(
+        api::router(Arc::clone(&state)),
+        trusty_common::server::SelfOrigins::default(),
+    );
     // Issue #2332: the startup banner carries the build version + PID so a
     // `~/Library/Logs/trusty-mpm/stderr.log` timeline can be correlated
     // against `cargo install` / restart events without guessing which
@@ -282,7 +287,17 @@ async fn reap_all_live_sessions(state: Arc<DaemonState>) {
 /// Test: covered indirectly — the primary listener path is exercised by the
 /// e2e suite and the secondary path reuses the same `api::router`.
 pub fn spawn_secondary_listener(state: Arc<DaemonState>, listener: tokio::net::TcpListener) {
-    let app = api::router(state);
+    // #3304: the secondary listener is the non-loopback (e.g. Tailscale) bind.
+    // Trust its own resolved address as a self-origin so the browser `/web`
+    // surface served from that address can POST to itself through the
+    // router-wide write guard, while genuinely cross-origin pages are still
+    // rejected (#3269). `from_bind_addrs` drops loopback, so a loopback
+    // secondary bind degrades to the loopback-only default.
+    let self_origins = match listener.local_addr() {
+        Ok(addr) => trusty_common::server::SelfOrigins::from_bind_addrs(&[addr]),
+        Err(_) => trusty_common::server::SelfOrigins::default(),
+    };
+    let app = api::origin_guard::guard_router(api::router(state), self_origins);
     tokio::spawn(async move {
         // Match the primary listener: expose ConnectInfo so the loopback-only
         // `POST /rpc` gate (#1221) works on this listener too. The Tailscale

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Security
+
+- **Router-wide same-origin (CSRF) write guard** ([#3304](https://github.com/bobmatnyc/trusty-tools/issues/3304)):
+  destructive write routes (`POST /admin/stop`, `POST /indexes`,
+  `DELETE /indexes/{id}`, `POST /upgrade`, reindex) are now guarded against
+  cross-origin browser requests via the shared
+  `trusty_common::server::with_guarded_middleware`. Method-gated (GET reads and
+  SSE streams unaffected) and fail-open on a missing `Origin` (the console
+  reverse proxy, `curl`, and the MCP stdio bridge keep working); the daemon's
+  own resolved bind address is trusted so a non-loopback bind still serves its
+  UI.
+
 ### Added
 
 - skip_vector flag + runtime component toggle with catch-up (#2984 Phase 1) ([#3024](https://github.com/bobmatnyc/trusty-tools/pull/3024)) ([`0fe2b81`](https://github.com/bobmatnyc/trusty-tools/commit/0fe2b8160eb62e8ee265d0970555e67fec537a72))

--- a/crates/trusty-search/src/service/daemon.rs
+++ b/crates/trusty-search/src/service/daemon.rs
@@ -28,7 +28,7 @@
 //! same path errors), (c) auto-port selection when the requested port is
 //! taken.
 
-use crate::service::server::{build_router, SearchAppState};
+use crate::service::server::{build_router_with_self_origins, SearchAppState};
 use fs4::FileExt;
 use std::{
     fs::{File, OpenOptions},
@@ -465,7 +465,12 @@ pub async fn run_daemon(state: SearchAppState, requested_port: u16) -> Result<()
     let flush_state = state.clone();
     // Issue #829: subscribe before moving state into build_router.
     let mut shutdown_rx = state.shutdown_tx.subscribe();
-    let router = build_router(state);
+    // #3304: trust the daemon's own resolved bind address as a self-origin so a
+    // non-loopback (Tailscale) bind still passes the router-wide write guard;
+    // `from_bind_addrs` drops loopback (already trusted), so a plain loopback
+    // bind yields the empty default.
+    let self_origins = trusty_common::server::SelfOrigins::from_bind_addrs(&[addr]);
+    let router = build_router_with_self_origins(state, self_origins);
 
     tracing::info!("daemon listening on {addr} (lock {})", lock_path.display());
 

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -42,6 +42,8 @@ mod tests_2336;
 #[cfg(test)]
 mod tests_2984;
 #[cfg(test)]
+mod tests_3304;
+#[cfg(test)]
 mod tests_829;
 #[cfg(test)]
 mod tests_chunks;
@@ -141,6 +143,32 @@ use self::health::upgrade_handler;
 ///
 /// Test: each handler test builds the router via this function using `oneshot`.
 pub fn build_router(state: SearchAppState) -> Router {
+    // #3304: loopback-only default. The daemon startup path
+    // (`service::daemon`) calls `build_router_with_self_origins` with the
+    // actually-resolved bind address so a non-loopback (Tailscale) bind still
+    // trusts its own served origin; every existing test keeps this entry point.
+    build_router_with_self_origins(state, trusty_common::server::SelfOrigins::default())
+}
+
+/// Build the router, additionally trusting the given bind-derived, non-loopback
+/// self-origins for the router-wide same-origin write guard (#3304).
+///
+/// Why: the daemon serves destructive write routes (`POST /admin/stop`,
+/// `DELETE /indexes/{id}`, `POST /indexes`, `POST /upgrade`, reindex) behind the
+/// permissive-CORS shared stack; without a same-origin guard any page the
+/// operator visits could drive them cross-origin (CSRF). This is the guarded
+/// entry point; `build_router` delegates here with an empty (loopback-only)
+/// allowlist so existing callers/tests are unchanged. The daemon startup path
+/// passes its resolved bind address so a non-loopback bind trusts itself (#3269).
+/// What: identical router to `build_router`, except the final middleware is
+/// `with_guarded_middleware` (guard + standard stack) instead of
+/// `with_standard_middleware`.
+/// Test: `admin_stop_rejects_cross_origin_write` / `_allows_loopback_write` /
+/// `_allows_missing_origin` / `read_route_allows_cross_origin` in `tests_2984`.
+pub fn build_router_with_self_origins(
+    state: SearchAppState,
+    self_origins: trusty_common::server::SelfOrigins,
+) -> Router {
     use crate::service::query_timeout::{apply_query_timeout, QueryTimeoutConfig};
     use crate::service::ui::{
         chat_handler, list_chat_providers, ui_asset_handler, ui_index_handler,
@@ -254,5 +282,7 @@ pub fn build_router(state: SearchAppState) -> Router {
         crate::service::metrics::request_metrics_middleware,
     ));
 
-    trusty_common::server::with_standard_middleware(router)
+    // #3304: router-wide same-origin write guard, applied AFTER all route
+    // registration so every destructive route (incl. any merged in) is covered.
+    trusty_common::server::with_guarded_middleware(router, self_origins)
 }

--- a/crates/trusty-search/src/service/server/tests_3304.rs
+++ b/crates/trusty-search/src/service/server/tests_3304.rs
@@ -1,0 +1,123 @@
+//! Regression tests for the router-wide same-origin write guard (#3304).
+//!
+//! Why: trusty-search exposes destructive write routes (`POST /admin/stop` —
+//! daemon shutdown, `POST /indexes`, `DELETE /indexes/{id}`, `POST /upgrade`,
+//! reindex) behind the permissive-CORS shared middleware stack. Before #3304
+//! these had NO write-origin guard, so any page the operator visited could
+//! drive them cross-origin (CSRF). The daemon now composes the shared
+//! `trusty_common::server::with_guarded_middleware` router-wide. These tests
+//! mirror trusty-console's guard suite: a cross-origin write is `403`, a
+//! loopback / missing-Origin write is allowed, and reads are unaffected.
+//! What: builds the full router via `build_router` (loopback-only default) and
+//! drives it with `oneshot` HTTP requests against `/admin/stop` (write) and
+//! `/health` (read).
+//! Test: this module. Run with `cargo test -p trusty-search tests_3304`.
+
+use super::build_router;
+use crate::core::registry::IndexRegistry;
+use crate::service::server::SearchAppState;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+/// Build the full daemon router over a fresh, empty registry (loopback-only
+/// self-origins — the `build_router` default). No embedder is installed: the
+/// guard runs in front of the handlers, and `/admin/stop` / `/health` need no
+/// embedding, so this is sufficient to exercise the middleware.
+fn guarded_router() -> axum::Router {
+    build_router(SearchAppState::new(IndexRegistry::new()))
+}
+
+/// Why: the CSRF threat — a malicious cross-origin page POSTing to the
+/// daemon-shutdown endpoint. Its `Origin` is neither loopback nor a self-origin,
+/// so the router-wide guard MUST reject it with `403` before the handler runs.
+/// Test: this test.
+#[tokio::test]
+async fn admin_stop_rejects_cross_origin_write() {
+    let resp = guarded_router()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/stop")
+                .header("origin", "http://evil.example.com")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin POST /admin/stop must be rejected by the write guard"
+    );
+}
+
+/// Why: the daemon's own loopback-served UI must keep driving destructive
+/// routes — a loopback `Origin` is trusted and must NOT be 403'd.
+/// Test: this test.
+#[tokio::test]
+async fn admin_stop_allows_loopback_write() {
+    let resp = guarded_router()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/stop")
+                .header("origin", "http://127.0.0.1:7654")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "loopback-origin POST /admin/stop must pass the guard"
+    );
+}
+
+/// Why: server-side callers — the console reverse proxy, `curl`, the MCP stdio
+/// bridge — send NO `Origin` header; the guard MUST let them through or every
+/// existing caller breaks. This is the fail-open-on-missing-Origin contract.
+/// Test: this test.
+#[tokio::test]
+async fn admin_stop_allows_missing_origin() {
+    let resp = guarded_router()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/admin/stop")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "missing-Origin POST /admin/stop (server-side caller) must pass the guard"
+    );
+}
+
+/// Why: the guard is method-gated — cross-origin GET reads leak no destructive
+/// capability and must NOT be blocked (the daemon SPA and monitoring probes
+/// read cross-origin under the permissive CORS policy).
+/// Test: this test.
+#[tokio::test]
+async fn read_route_allows_cross_origin() {
+    let resp = guarded_router()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/health")
+                .header("origin", "http://evil.example.com")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cross-origin GET /health must not be blocked by the write guard"
+    );
+}


### PR DESCRIPTION
## Architecture review — Tranche 1 (PR B of 2)

Applies the shared write-origin (CSRF) guard from **PR A (#3308)** router-wide
to the sibling daemons, which the security review found exposing destructive
HTTP endpoints behind permissive CORS with NO origin guard, and extends the tm
daemon's single-handler guard to router-wide.

**Stacked on #3308** — base branch is `feat-shared-origin-guard`. Review/merge
PR A first; this PR's diff is only the daemon wiring + tests.

Closes #3304. Lineage: #3268 (`route_layer` mid-chain bug) → #3269 (bind-aware
self-origins) → #3280 (console guard) → #3308 (shared primitive).

### Per-daemon wiring (file:line)

- **trusty-search** — `service/server/mod.rs:143` `build_router` now delegates to
  new `build_router_with_self_origins` (`:154`) which ends with
  `with_guarded_middleware` (was `with_standard_middleware`); wired from
  `service/daemon.rs:468` with `SelfOrigins::from_bind_addrs(&[addr])`.
- **trusty-memory** — `web/mod.rs:63` `router()` delegates to
  `router_with_self_origins` (`:86`) ending in `with_guarded_middleware`; wired
  from `http_server.rs:270` with the resolved bind addr.
- **trusty-analyze** — `service/routes.rs:48` `build_router` delegates to
  `build_router_with_self_origins` ending in `with_guarded_middleware`; wired
  from `serve` (`routes.rs:~122`) with the resolved bind addr.
- **trusty-mpm** — new `daemon::api::origin_guard::guard_router` (layers the
  shared guard) applied at the serve site: primary listener
  `daemon/mod.rs:152` (loopback default), secondary Tailscale listener
  `daemon/mod.rs:spawn_secondary_listener` (its own bind addr). `api.rs::router`
  is UNCHANGED — it is at its frozen 1273-SLOC allowlist budget, so the helper
  lives in the origin_guard module rather than growing api.rs. Enables
  `trusty-common/axum-server` on the main dep (was dev-only).

### Deliberate design choices

- **mpm uses only the guard layer, NOT `with_standard_middleware`** — the tm
  daemon has no CORS layer today; adding one would be an unrelated behaviour
  change. The guard is layered standalone (additive).
- **Belt and braces on mpm**: `coordinator_chat` keeps its own finer-grained
  `origin_allowed` (Host-match) check; `/rpc` keeps its loopback `ConnectInfo`
  gate. Both are orthogonal to and complemented by the router-wide guard.

### What was deliberately NOT guarded (with reason)

- **GET reads / SSE / WS-upgrade routes** (`/status/stream`, `reindex/stream`,
  `/sse`, `/sessions/{id}/events`, `/events`): method-gated — the guard only
  acts on POST/PUT/PATCH/DELETE, so these are untouched by design.
- **Missing-Origin writes** (console reverse proxy, `serve --stdio` bridge,
  `curl`, GitHub webhook, Telegram/TUI adapters): fail-open by the documented
  threat model — a browser always sends `Origin` on a cross-origin write, so
  absent `Origin` is a trusted server-side caller. Tests assert this.
- **MCP stdio paths**: untouched (no HTTP).

### Verification (raw tails)

- `cargo test -p trusty-mpm --lib daemon::` → `809 passed; 0 failed; 1 ignored`
  (incl. 3 new `origin_guard_router_tests`).
- `cargo test -p trusty-memory` → all pass (incl. 3 new `origin_guard_tests`).
- `cargo test -p trusty-analyze` → all pass (incl. 3 new guard tests).
- `cargo test -p trusty-search` → 1150 passed incl. 4 new `tests_3304`; the ONE
  failure — `colocated_storage::tests::gitignore_entry_added_idempotently` — is a
  PRE-EXISTING environment flake unrelated to this diff: `colocated_storage.rs`
  is untouched, and the test walks up from a system-`$TMPDIR` tempdir and is
  hijacked by a stray ancestor `/var/folders/.../T/.gitignore` (mtime 10:46,
  before any test run here). It fails identically on the untouched base.
- `cargo clippy -p trusty-search -p trusty-memory -p trusty-analyze -p trusty-mpm --all-targets -- -D warnings` → clean.
- `cargo fmt --check` → clean. `bash scripts/check_line_cap.sh` → OK.

Do NOT merge — critic-gated.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools


---

## Critic-round follow-up (MEDIUM fix + rebase)

**Fixed the `/sse` layering footgun (memory):** `run_http_on` chained
`.route("/sse", …)` onto the router AFTER `router_with_self_origins` had already
applied `with_guarded_middleware`, so per axum's `Router::layer` contract `/sse`
received no middleware (guard, CORS, trace, compression). Moved the `/sse`
registration INSIDE `router_with_self_origins` before the guard call (mirroring
trusty-analyze's correct placement). `/sse` is a safe GET so the guard never
blocks it; compression still skips `text/event-stream`. Updated
`dream_sse_tests::sse_endpoint_emits_connected_frame` (it manually re-added
`/sse`, which now duplicates the router's route) to use the real wired shape,
and dropped the now-unused test-only `sse_handler` re-export.

**Rebased onto the fixed PR A** (which carries the CRITICAL `origin_is_loopback`
IP-parse fix, `Closes #3319`). No conflicts.

### Re-verification (raw tails, this round)

- `cargo test -p trusty-memory` → EXIT 0, all pass incl. the 3 guard tests and
  the corrected `/sse` test; no warnings.
- `cargo test -p trusty-analyze` → EXIT 0 (incl. 3 guard tests).
- `cargo test -p trusty-mpm --lib daemon::` → `809 passed; 0 failed; 1 ignored`
  (incl. 3 `origin_guard_router_tests`).
- `cargo test -p trusty-search` (isolated `TMPDIR`) → EXIT 0, ~1438 passed incl.
  4 `tests_3304`. NB: the pre-existing `gitignore_entry_added_idempotently`
  flake reported last round was confirmed to be stray-`$TMPDIR`-`.gitignore`
  pollution — it passes clean under an isolated TMPDIR, proving it is unrelated
  to this diff.
- `cargo clippy -p trusty-common --features axum-server -p trusty-search -p trusty-memory -p trusty-analyze -p trusty-mpm -p trusty-console --all-targets -- -D warnings` → EXIT 0.
- `cargo fmt --check` → clean. `bash scripts/check_line_cap.sh` → OK.
