### PR TITLE
feat(trusty-code): workstream CRUD RPC/REST surface (closes #3295)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -22,12 +22,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `workstream.deactivate{id}` clears the pointer only when `id` is the
   currently-active workstream — otherwise an idempotent no-op, per spec.
   REST twins: `POST /workstreams/{id}/activate` and
-  `POST /workstreams/{id}/deactivate`. `tcode serve`'s router now loads and
+  `POST /workstreams/{id}/deactivate`.
+- **Workstream CRUD RPC/REST surface (issue #3295, DOC-48 §5, Phase 1A for
+  epic #3292).** New JSON-RPC methods `workstream.create{name?}`,
+  `workstream.get{id}`, `workstream.list{include_closed?}`,
+  `workstream.close{id}`, sharing the SAME `SharedWorkstreamStore` handle
+  #3294's activation methods use. `workstream.list` returns
+  `{active_workstream_id, workstreams: [...]}`, each record paired with its
+  computed `state` (`active`/`idle`/`closed`); `include_closed` defaults to
+  `false`. `workstream.close` marks the record closed and, per §4.4,
+  auto-deactivates it if it was the active workstream — the store gains a
+  `WorkstreamStore::close` primitive for this. REST wrappers
+  (`POST`/`GET /workstreams`, `GET /workstreams/{id}`,
+  `POST /workstreams/{id}/close`) mirror the existing `rest::sessions`/
+  `rest::tasks` pattern; paths are intentionally unprefixed (not DOC-48
+  §5.2's literal `/api/v1/workstreams`) to match every other REST resource
+  group this crate ships. `tcode serve`'s router now loads and
   boot-reconciles a project-scoped `WorkstreamStore` (`build_router` is now
   `async`/fallible) and shares it across every `workstream.*` handler behind
   a `tokio::sync::Mutex`. `WorkstreamActivationChanged` SSE emission and the
-  remaining `workstream.create`/`get`/`list`/`close` surface are deferred to
-  #3297/#3295.
+  CLI (#3296) remain follow-up tickets.
 - **Workstream domain model + flat JSON storage + boot reconciliation
   (issue #3293, DOC-48 §2/§3, Phase 1A foundation for epic #3292).** New
   `workstreams` module: `Workstream`/`WorkstreamId`/`WorkstreamState` (state

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -94,11 +94,13 @@ struct HttpState {
 /// (Slice 3) the write routes (`POST /sessions`,
 /// `POST /sessions/{id}/messages`, `POST /sessions/{id}/cancel`,
 /// `PUT`/`DELETE /sessions/{id}/goal`), (Slice 4) `POST /tasks`, (Slice 5)
-/// `GET /fs`, (Slice 6) `GET /sessions/{id}/agents`, (Slice 7, issue
-/// #3072) `GET /sessions/{id}/search-audit`, and (DOC-48 §5.2, issue #3294)
-/// `POST /workstreams/{id}/activate`/`.../deactivate` — none of which
-/// collide with the paths registered directly on this router or with each
-/// other.
+/// `GET /fs`, (Slice 6) `GET /sessions/{id}/agents`, (Slice 7, issue #3072)
+/// `GET /sessions/{id}/search-audit`, and the full `workstream.*` REST
+/// surface: `POST /workstreams`, `GET /workstreams/{id}`, `GET /workstreams`,
+/// `POST /workstreams/{id}/close` (issue #3295) plus
+/// `POST /workstreams/{id}/activate`/`.../deactivate` (DOC-48 §5.2, issue
+/// #3294) — none of which collide with the paths registered directly on
+/// this router or with each other.
 /// Test: `http_rpc_ping_returns_pong`,
 /// `http_rpc_malformed_json_returns_parse_error`,
 /// `http_health_matches_jsonrpc_health_payload`,
@@ -109,7 +111,8 @@ struct HttpState {
 /// `http_rest_get_fs_route_is_merged_in`,
 /// `http_rest_get_session_agents_route_is_merged_in`,
 /// `http_rest_get_session_budget_route_is_merged_in`,
-/// `http_rest_get_session_search_audit_route_is_merged_in`.
+/// `http_rest_get_session_search_audit_route_is_merged_in`,
+/// `http_rest_get_workstreams_route_is_merged_in`.
 pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) -> AxumRouter {
     let state = HttpState {
         router: router.clone(),
@@ -650,6 +653,45 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert_eq!(v["search_audit"].as_array().unwrap().len(), 0);
+    }
+
+    /// `GET /workstreams` (issue #3295, `rest::workstreams`'s route group
+    /// `build_axum_router` merges above) must be reachable on the SAME
+    /// router `GET /sessions/{id}/events` is — proving the merge actually
+    /// wires `rest::workstreams::routes` rather than silently dropping it.
+    /// Per-route error/status-code behaviour is already covered by
+    /// `rest::workstreams::tests`; this test only pins the merge itself.
+    #[tokio::test]
+    async fn http_rest_get_workstreams_route_is_merged_in() {
+        let sessions = Arc::new(SessionRegistry::new());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store =
+            crate::workstreams::WorkstreamStore::load(dir.path().join("workstreams-test.json"))
+                .await
+                .expect("load");
+        let mut router = Router::new();
+        crate::serve::methods::register(&mut router);
+        crate::session::protocol::register(&mut router, sessions.clone());
+        crate::workstreams::protocol::register(
+            &mut router,
+            Arc::new(tokio::sync::Mutex::new(store)),
+        );
+        let app = build_axum_router(Arc::new(router), sessions);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/workstreams")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert!(v["workstreams"].is_array());
     }
 
     /// `GET /sessions/{id}/events` on an unknown session must 404 with a

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -93,7 +93,7 @@ pub const DEFAULT_HTTP_PORT: u16 = 7881;
 /// `crate::fs_browse::protocol::register`, and
 /// `crate::task::protocol::register` on them, and returns both.
 ///
-/// (DOC-48, issue #3294) also loads this project's
+/// (DOC-48, issues #3294/#3295) also loads this project's
 /// [`crate::workstreams::WorkstreamStore`] (`~/.trusty-code/workstreams-....json`,
 /// derived from `binding` per DOC-48 §3.1), runs its boot reconciliation
 /// (§3.3 — restores the persisted active pointer, or clears it if the
@@ -102,13 +102,14 @@ pub const DEFAULT_HTTP_PORT: u16 = 7881;
 /// its file I/O is `async` — mirrors `SessionRegistry`'s `Arc`-shared-state
 /// convention, see `crate::workstreams::activation::SharedWorkstreamStore`'s
 /// docs for why `tokio`'s `Mutex` specifically), and registers
-/// `crate::workstreams::protocol::register` (`workstream.activate`/
-/// `workstream.deactivate`) alongside every other method group. This is why
-/// `build_router` is now `async` and fallible — the prior synchronous,
-/// infallible signature had no way to load persisted state before the router
-/// starts answering requests, and a corrupt store file must fail daemon
-/// startup loudly rather than silently discard the user's workstreams (see
-/// `WorkstreamStore::load`'s docs).
+/// `crate::workstreams::protocol::register` — all six `workstream.*` methods
+/// (`create`/`get`/`list`/`close` from #3295, `activate`/`deactivate` from
+/// #3294) sharing this one store handle — alongside every other method
+/// group. This is why `build_router` is now `async` and fallible — the
+/// prior synchronous, infallible signature had no way to load persisted
+/// state before the router starts answering requests, and a corrupt store
+/// file must fail daemon startup loudly rather than silently discard the
+/// user's workstreams (see `WorkstreamStore::load`'s docs).
 ///
 /// `binding` is the daemon's project binding. Its `None` (projectless) state is
 /// what makes the shell's entry screen implementable: previously `build_router`
@@ -120,7 +121,8 @@ pub const DEFAULT_HTTP_PORT: u16 = 7881;
 /// Test: `run_stdio_router_recognises_proof_of_life_methods`,
 /// `build_router_wires_session_methods`, `build_router_wires_task_run`,
 /// `build_router_is_projectless_without_a_project`,
-/// `build_router_wires_fs_list_dir`, `build_router_wires_workstream_methods`.
+/// `build_router_wires_fs_list_dir`, `build_router_wires_workstream_methods`,
+/// `build_router_reconciles_dangling_active_pointer_on_boot`.
 pub async fn build_router(binding: ProjectBinding) -> Result<(Router, Arc<SessionRegistry>)> {
     build_router_at(binding, &crate::workstreams::default_data_dir()).await
 }
@@ -215,7 +217,7 @@ pub async fn run_http(binding: ProjectBinding, port: u16) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+    use serde_json::{Value, json};
     use trusty_common::mcp::Request;
 
     fn test_ctx() -> crate::jsonrpc::ConnectionContext {
@@ -461,5 +463,60 @@ mod tests {
         let (_router2, _sessions2) = build_router_at(binding, data_dir.path())
             .await
             .expect("a second build_router_at over the same data_dir must succeed");
+    }
+
+    /// Boot reconciliation (DOC-48 §3.3, AC-1.4/AC-6.1/AC-6.2) must run
+    /// through the REAL daemon assembly path, not just
+    /// `WorkstreamStore::reconcile_on_boot` called directly (already covered
+    /// by `workstreams::store::store_tests::reconcile_clears_active_when_target_missing`).
+    /// A store file seeded on disk with a DANGLING `active_workstream_id`
+    /// (pointing at a workstream absent from `workstreams[]` — e.g. deleted
+    /// out from under the pointer, or hand-edited) must have that pointer
+    /// cleared by `build_router_at`'s `reconcile_on_boot()` call BEFORE the
+    /// router ever answers a request; `workstream.list` reporting
+    /// `active_workstream_id: null` is the end-to-end proof.
+    #[tokio::test]
+    async fn build_router_reconciles_dangling_active_pointer_on_boot() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let data_dir = tempfile::tempdir().expect("data tempdir");
+        let binding =
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind");
+
+        let store_path = crate::workstreams::store_path(data_dir.path(), &binding);
+        let dangling_id = crate::workstreams::WorkstreamId::new();
+        let raw = json!({
+            "version": "1.0",
+            "active_workstream_id": dangling_id,
+            "workstreams": [],
+        });
+        tokio::fs::create_dir_all(data_dir.path())
+            .await
+            .expect("mkdir data_dir");
+        tokio::fs::write(&store_path, serde_json::to_string_pretty(&raw).unwrap())
+            .await
+            .expect("seed raw store file with a dangling active_workstream_id");
+
+        let (router, _sessions) = build_router_at(binding, data_dir.path())
+            .await
+            .expect("build_router_at must reconcile the dangling pointer, not fail");
+
+        let req = Request {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(json!(1)),
+            method: "workstream.list".to_string(),
+            params: Some(json!({})),
+        };
+        let resp = router.dispatch(req, &test_ctx()).await;
+        assert!(
+            resp.error.is_none(),
+            "workstream.list must succeed, got {:?}",
+            resp.error
+        );
+        assert_eq!(
+            resp.result.unwrap()["active_workstream_id"],
+            Value::Null,
+            "boot reconciliation through build_router_at must clear a dangling \
+             active_workstream_id before the router answers requests"
+        );
     }
 }

--- a/crates/trusty-code/src/serve/rest/mod.rs
+++ b/crates/trusty-code/src/serve/rest/mod.rs
@@ -47,11 +47,14 @@
 //! `GET /fs` -> `fs.list_dir`. Slice 6 ([`agents`]) adds
 //! `GET /sessions/{id}/agents` -> `session.get_agents`. Slice 7
 //! ([`search_audit`]) adds `GET /sessions/{id}/search-audit` ->
-//! `session.get_search_audit` (issue #3072). [`workstreams`] (DOC-48 §5.2,
-//! issue #3294) adds `POST /workstreams/{id}/activate` ->
-//! `workstream.activate` and `POST /workstreams/{id}/deactivate` ->
-//! `workstream.deactivate`. Every slice reuses [`respond`]/[`throwaway_ctx`]
-//! rather than reimplementing the glue.
+//! `session.get_search_audit` (issue #3072). [`workstreams`] adds the full
+//! `workstream.*` surface: `POST /workstreams`, `GET /workstreams/{id}`,
+//! `GET /workstreams`, `POST /workstreams/{id}/close` (issue #3295, epic
+//! #3292) and `POST /workstreams/{id}/activate`,
+//! `POST /workstreams/{id}/deactivate` (DOC-48 §5.2/§6, issue #3294) — see
+//! its module docs for why the paths are unprefixed rather than DOC-48
+//! §5.2's literal `/api/v1/workstreams`. Every slice reuses
+//! [`respond`]/[`throwaway_ctx`] rather than reimplementing the glue.
 //!
 //! Test: `tests::*` — a success round-trip, an error round-trip, and one
 //! assertion per `rpc_error_to_status` mapping. See `sessions::tests` for

--- a/crates/trusty-code/src/serve/rest/workstreams.rs
+++ b/crates/trusty-code/src/serve/rest/workstreams.rs
@@ -1,32 +1,36 @@
-//! `POST /workstreams/{id}/activate` and `POST /workstreams/{id}/deactivate`
-//! REST routes over the `workstream.activate`/`workstream.deactivate`
-//! JSON-RPC methods (DOC-48 §5.2/§6, issue #3294).
+//! `GET`/`POST /workstreams*` REST routes over the full `workstream.*`
+//! JSON-RPC surface (issues #3294, #3295, epic #3292).
 //!
 //! # Spec References
 //!
 //! - [`SPEC-WS-05~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-05~draft)
 //!
-//! Why: mirrors every other REST resource group in this module
-//! (`super::sessions`/`super::sessions_write`/`super::tasks`) — a thin axum
-//! handler calling [`super::respond`] against the ALREADY-implemented
-//! `workstream.*` JSON-RPC handler (`crate::workstreams::protocol`), so the
-//! REST and JSON-RPC surfaces can never fork (see `super` module docs).
+//! Why: mirrors every other resource group in this gateway (`super::sessions`,
+//! `super::tasks`, …) — a REST-only client gets the same `workstream.*`
+//! surface `POST /rpc` exposes, without duplicating
+//! `crate::workstreams::protocol`'s business logic as bespoke axum handlers
+//! (see `super` module docs' "forking the two surfaces" rationale). This is
+//! where BOTH concurrent tickets against that RPC surface land their REST
+//! twins: #3295's CRUD/inspection routes (`create`/`get`/`list`/`close`) and
+//! #3294's activation-lock routes (`activate`/`deactivate`).
 //!
-//! **Path convention note:** DOC-48 §5.2 specifies `/api/v1/workstreams/...`
-//! paths, but every REST resource this crate has actually shipped so far
-//! (`/sessions`, `/tasks`, `/fs`, …) is unprefixed — there is no `/api/v1`
-//! mount anywhere in `crate::serve::http::build_axum_router`. This resolves
-//! the ambiguity by following the established code convention (unprefixed
-//! `/workstreams/...`) rather than the spec's literal path text, exactly as
-//! every prior REST slice has; a future ticket that wants to introduce an
-//! `/api/v1` prefix would need to re-mount every existing resource, not just
-//! this one.
+//! **Path prefix deviation from DOC-48 §5.2 (documented, deliberate):** the
+//! spec's table writes `/api/v1/workstreams`, but every REST resource group
+//! this crate has shipped since #2983 (`/sessions`, `/tasks`, `/fs`, …) is
+//! UNPREFIXED — there is no `/api/v1` anywhere in `crate::serve::rest`. today.
+//! Introducing a prefix for exactly one resource group would make the API
+//! surface internally inconsistent (a client would need to special-case
+//! which resource lives under which prefix) for no behavioural gain; this
+//! ticket follows the shipped convention instead of the spec's literal path,
+//! matching every curl example in §12 except for the prefix itself.
 //!
-//! **Scope note (issue #3294):** only `activate`/`deactivate` land here —
-//! `POST /workstreams` (create), `GET /workstreams`, `GET /workstreams/{id}`,
-//! and `POST /workstreams/{id}/close` are issue #3295's REST surface.
-//!
-//! What: [`routes`] builds a standalone `axum::Router<()>` mapping:
+//! What: [`routes`] builds a standalone `axum::Router<()>` (its own
+//! `WorkstreamsState` carrying just the `Arc<Router>`, `with_state`-erased
+//! before return, mirroring `super::sessions::SessionsState`) mapping:
+//!   - `POST /workstreams` -> `workstream.create` (`201 Created`)
+//!   - `GET /workstreams/{id}` -> `workstream.get`
+//!   - `GET /workstreams?include_closed=..` -> `workstream.list`
+//!   - `POST /workstreams/{id}/close` -> `workstream.close`
 //!   - `POST /workstreams/{id}/activate` -> `workstream.activate{id, force?}`
 //!     (JSON body `{"force": bool}`, defaulting `force` to `false` when the
 //!     body omits it or is `{}`)
@@ -34,43 +38,72 @@
 //!     (no body, mirroring `super::sessions_write`'s `POST
 //!     /sessions/{id}/cancel`)
 //!
-//! `crate::serve::http::build_axum_router` merges this in alongside every
-//! other REST slice; none of its paths collide.
+//! `crate::serve::http::build_axum_router` merges this into the daemon's main
+//! router alongside `POST /rpc`, `GET /health`, and the other REST resource
+//! groups — none of those paths collide with the ones here.
 //! Test: `tests::*`.
 
 use std::sync::Arc;
 
 use axum::Json;
 use axum::Router as AxumRouter;
-use axum::extract::{Path, State};
-use axum::routing::post;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::routing::{get, post};
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{Value, json};
+use trusty_common::mcp::Response;
 
 use crate::jsonrpc::Router;
 
 use super::{RestResult, respond};
 
-/// Shared axum state for this route group: just the JSON-RPC router,
-/// mirroring every other REST slice's `*State` struct.
+/// Shared axum state for every route in this module: just the JSON-RPC
+/// router, mirroring `super::sessions::SessionsState` — every handler here
+/// goes through [`super::respond`]/[`respond_created`] rather than touching
+/// `WorkstreamStore` directly.
 #[derive(Clone)]
 struct WorkstreamsState {
     router: Arc<Router>,
 }
 
-/// Build the `POST /workstreams/{id}/activate|deactivate` route group.
+/// Build the `GET`/`POST /workstreams*` route group.
 ///
 /// Why: kept separate from `crate::serve::http::build_axum_router` so this
-/// resource group is unit-testable via `tower::util::ServiceExt::oneshot`
-/// on its own, exactly like every other REST slice.
-/// What: two `POST` routes (see module docs), sharing one
-/// `WorkstreamsState { router }`, `with_state`-erased to `axum::Router<()>`.
-/// Test: `tests::activate_returns_200_with_active_id`.
+/// resource group is unit-testable via `tower::util::ServiceExt::oneshot` on
+/// its own, exactly like every other `rest::*` group.
+/// What: six routes (see module docs), all sharing one
+/// `WorkstreamsState { router }`, `with_state`-erased to `axum::Router<()>`
+/// so the caller can `.merge()` it alongside the other resource groups.
+/// Test: `tests::create_workstream_returns_201_with_id`,
+/// `tests::activate_returns_200_with_active_id`.
 pub fn routes(router: Arc<Router>) -> AxumRouter {
     AxumRouter::new()
+        .route(
+            "/workstreams",
+            get(list_workstreams).post(create_workstream),
+        )
+        .route("/workstreams/{id}", get(get_workstream))
+        .route("/workstreams/{id}/close", post(close_workstream))
         .route("/workstreams/{id}/activate", post(activate))
         .route("/workstreams/{id}/deactivate", post(deactivate))
         .with_state(WorkstreamsState { router })
+}
+
+/// Request body for `POST /workstreams`, shaped like
+/// `workstreams::protocol`'s private `CreateParams`.
+#[derive(Deserialize, Default)]
+struct CreateBody {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// Query params for `GET /workstreams`, shaped like
+/// `workstreams::protocol`'s private `ListParams`.
+#[derive(Deserialize, Default)]
+struct ListQuery {
+    #[serde(default)]
+    include_closed: bool,
 }
 
 /// Request body for `POST /workstreams/{id}/activate` — `id` comes from the
@@ -80,6 +113,90 @@ pub fn routes(router: Arc<Router>) -> AxumRouter {
 struct ActivateBody {
     #[serde(default)]
     force: bool,
+}
+
+/// Like [`super::respond`] but reports `201 Created` on success — the one
+/// route in this module that mints a brand-new resource (mirrors
+/// `sessions_write::respond_created`, `tasks::respond_accepted`).
+async fn respond_created(
+    router: &Router,
+    method: &str,
+    params: Value,
+) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Response>)> {
+    respond(router, method, params)
+        .await
+        .map(|Json(v)| (StatusCode::CREATED, Json(v)))
+}
+
+/// `POST /workstreams` -> `workstream.create`.
+///
+/// Why: the REST entry point for minting a new workstream in the daemon's
+/// project — no `project_id` in the body, matching the RPC twin (§2.3: the
+/// daemon's own `ProjectBinding` is implicit).
+/// What: `201 Created` with `{"id": ..}` on success. An empty JSON body
+/// (`{}`) is valid — `name` defaults to empty (§5.1); a syntactically
+/// malformed or missing body is rejected by axum's `Json` extractor before
+/// this handler runs, matching every other `POST` route in this gateway
+/// (`sessions_write::create_session`, `tasks::run_task`).
+/// Test: `tests::create_workstream_returns_201_with_id`,
+/// `tests::create_workstream_empty_body_defaults_name`.
+async fn create_workstream(
+    State(state): State<WorkstreamsState>,
+    Json(body): Json<CreateBody>,
+) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Response>)> {
+    respond_created(
+        &state.router,
+        "workstream.create",
+        json!({ "name": body.name }),
+    )
+    .await
+}
+
+/// `GET /workstreams/{id}` -> `workstream.get`.
+///
+/// Why: point lookup for one workstream's current (inferred) state.
+/// What: `404` with a `not_found` envelope for an unknown `id`; otherwise the
+/// `Workstream` JSON (id, name, computed `state`, `session_ids`, timestamps).
+/// Test: `tests::get_workstream_found_returns_200`,
+/// `tests::get_workstream_missing_returns_404`.
+async fn get_workstream(
+    State(state): State<WorkstreamsState>,
+    Path(id): Path<String>,
+) -> RestResult {
+    respond(&state.router, "workstream.get", json!({"id": id})).await
+}
+
+/// `GET /workstreams?include_closed=..` -> `workstream.list`.
+///
+/// Why: enumerates every workstream in the daemon's project for a switcher
+/// UI/CLI, without a `get` per id.
+/// What: `200` with `{"active_workstream_id", "workstreams": [...]}`;
+/// `include_closed` defaults to `false` (§4.4).
+/// Test: `tests::list_workstreams_returns_active_id_and_records`.
+async fn list_workstreams(
+    State(state): State<WorkstreamsState>,
+    Query(q): Query<ListQuery>,
+) -> RestResult {
+    respond(
+        &state.router,
+        "workstream.list",
+        json!({"include_closed": q.include_closed}),
+    )
+    .await
+}
+
+/// `POST /workstreams/{id}/close` -> `workstream.close`.
+///
+/// Why: the REST entry point for irreversibly closing a workstream (§4.4);
+/// no body needed, `id` from the path is the whole request.
+/// What: `200` with `{}` on success; `404` for an unknown `id`.
+/// Test: `tests::close_workstream_returns_200_empty_object`,
+/// `tests::close_workstream_missing_returns_404`.
+async fn close_workstream(
+    State(state): State<WorkstreamsState>,
+    Path(id): Path<String>,
+) -> RestResult {
+    respond(&state.router, "workstream.close", json!({"id": id})).await
 }
 
 /// `POST /workstreams/{id}/activate` -> `workstream.activate`.
@@ -125,15 +242,34 @@ async fn deactivate(State(state): State<WorkstreamsState>, Path(id): Path<String
 mod tests {
     use super::*;
     use axum::body::{Body, to_bytes};
-    use axum::http::{Request, StatusCode};
-    use serde_json::Value;
+    use axum::http::Request;
     use tower::util::ServiceExt;
 
     /// Build the route group over a fresh, tempdir-backed workstream store
-    /// with one workstream already created — mirrors
-    /// `crate::workstreams::protocol_tests`' own helper, but exercised
-    /// through the REST layer rather than calling the handler functions
-    /// directly.
+    /// with no workstreams yet — used by the `create`/`get`/`list`/`close`
+    /// tests, which each create whatever records they need via `POST
+    /// /workstreams`.
+    async fn app() -> AxumRouter {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store =
+            crate::workstreams::WorkstreamStore::load(dir.path().join("workstreams-test.json"))
+                .await
+                .expect("load");
+        std::mem::forget(dir);
+        let mut router = Router::new();
+        crate::workstreams::protocol::register(
+            &mut router,
+            std::sync::Arc::new(tokio::sync::Mutex::new(store)),
+        );
+        routes(Arc::new(router))
+    }
+
+    /// Like [`app`] but pre-seeds one workstream directly through the store
+    /// (bypassing the REST layer) and returns its id — used by the
+    /// `activate`/`deactivate` tests, which need an existing workstream to
+    /// act on. Also returns the backing `TempDir` so a test can reload the
+    /// same file directly (e.g. to seed a SECOND workstream for a conflict
+    /// scenario).
     async fn app_and_id() -> (AxumRouter, String, tempfile::TempDir) {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("workstreams-test.json");
@@ -154,7 +290,7 @@ mod tests {
         serde_json::from_slice(&bytes).unwrap()
     }
 
-    async fn post(app: &AxumRouter, uri: &str, body: Value) -> axum::response::Response {
+    async fn post(app: &AxumRouter, uri: &str, body: &str) -> axum::response::Response {
         app.clone()
             .oneshot(
                 Request::builder()
@@ -168,13 +304,134 @@ mod tests {
             .unwrap()
     }
 
+    async fn get(app: &AxumRouter, uri: &str) -> axum::response::Response {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_workstream_returns_201_with_id() {
+        let app = app().await;
+        let resp = post(&app, "/workstreams", r#"{"name": "Token rotation"}"#).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let v = body_json(resp).await;
+        assert!(v["id"].is_string());
+    }
+
+    #[tokio::test]
+    async fn create_workstream_empty_body_defaults_name() {
+        let app = app().await;
+        let resp = post(&app, "/workstreams", "{}").await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let id = body_json(resp).await["id"].as_str().unwrap().to_string();
+
+        let get_resp = get(&app, &format!("/workstreams/{id}")).await;
+        let v = body_json(get_resp).await;
+        assert_eq!(v["name"], "");
+    }
+
+    #[tokio::test]
+    async fn get_workstream_found_returns_200() {
+        let app = app().await;
+        let created = body_json(post(&app, "/workstreams", r#"{"name": "A"}"#).await).await;
+        let id = created["id"].as_str().unwrap();
+
+        let resp = get(&app, &format!("/workstreams/{id}")).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["name"], "A");
+        assert_eq!(v["state"], "idle");
+    }
+
+    #[tokio::test]
+    async fn get_workstream_missing_returns_404() {
+        let app = app().await;
+        let resp = get(&app, "/workstreams/00000000-0000-0000-0000-000000000000").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32002);
+    }
+
+    #[tokio::test]
+    async fn list_workstreams_returns_active_id_and_records() {
+        let app = app().await;
+        post(&app, "/workstreams", r#"{"name": "A"}"#).await;
+        post(&app, "/workstreams", r#"{"name": "B"}"#).await;
+
+        let resp = get(&app, "/workstreams").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["active_workstream_id"], Value::Null);
+        assert_eq!(v["workstreams"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn close_workstream_returns_200_empty_object() {
+        let app = app().await;
+        let created = body_json(post(&app, "/workstreams", r#"{"name": "A"}"#).await).await;
+        let id = created["id"].as_str().unwrap();
+
+        let resp = post(&app, &format!("/workstreams/{id}/close"), "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(body_json(resp).await, json!({}));
+
+        let get_resp = get(&app, &format!("/workstreams/{id}")).await;
+        assert_eq!(body_json(get_resp).await["state"], "closed");
+    }
+
+    #[tokio::test]
+    async fn close_workstream_missing_returns_404() {
+        let app = app().await;
+        let resp = post(
+            &app,
+            "/workstreams/00000000-0000-0000-0000-000000000000/close",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32002);
+    }
+
+    /// `GET /workstreams?include_closed=..` must round-trip the query param
+    /// through to `workstream.list` (proving the merge/extraction wiring,
+    /// not just the RPC layer `protocol_tests` already cover).
+    #[tokio::test]
+    async fn list_include_closed_query_param_includes_closed_workstream() {
+        let app = app().await;
+        let created = body_json(post(&app, "/workstreams", r#"{"name": "A"}"#).await).await;
+        let id = created["id"].as_str().unwrap();
+        post(&app, &format!("/workstreams/{id}/close"), "").await;
+
+        let default_resp = get(&app, "/workstreams").await;
+        assert!(
+            body_json(default_resp).await["workstreams"]
+                .as_array()
+                .unwrap()
+                .is_empty(),
+            "closed workstream must be excluded by default"
+        );
+
+        let included_resp = get(&app, "/workstreams?include_closed=true").await;
+        let v = body_json(included_resp).await;
+        assert_eq!(v["workstreams"].as_array().unwrap().len(), 1);
+    }
+
     /// Activating with no prior active workstream must return `200` with
     /// the new `active_id` and a null `prior_id`.
     #[tokio::test]
     async fn activate_returns_200_with_active_id() {
         let (app, id, _dir) = app_and_id().await;
 
-        let resp = post(&app, &format!("/workstreams/{id}/activate"), json!({})).await;
+        let resp = post(&app, &format!("/workstreams/{id}/activate"), "{}").await;
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert_eq!(v["active_id"], json!(id));
@@ -192,12 +449,12 @@ mod tests {
                 .expect("reload store");
         let other = store.create("other").await.expect("create other");
 
-        post(&app, &format!("/workstreams/{id}/activate"), json!({})).await;
+        post(&app, &format!("/workstreams/{id}/activate"), "{}").await;
 
         let resp = post(
             &app,
             &format!("/workstreams/{other}/activate"),
-            json!({"force": false}),
+            r#"{"force": false}"#,
         )
         .await;
         assert_eq!(resp.status(), StatusCode::CONFLICT);
@@ -214,7 +471,7 @@ mod tests {
         let resp = post(
             &app,
             &format!("/workstreams/{}/activate", uuid::Uuid::new_v4()),
-            json!({}),
+            "{}",
         )
         .await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -226,7 +483,7 @@ mod tests {
     #[tokio::test]
     async fn deactivate_returns_200_empty_object() {
         let (app, id, _dir) = app_and_id().await;
-        post(&app, &format!("/workstreams/{id}/activate"), json!({})).await;
+        post(&app, &format!("/workstreams/{id}/activate"), "{}").await;
 
         let resp = app
             .clone()

--- a/crates/trusty-code/src/workstreams/mod.rs
+++ b/crates/trusty-code/src/workstreams/mod.rs
@@ -32,16 +32,18 @@
 //! daemon's [`crate::binding::ProjectBinding`] (see [`path`]); (issue #3294)
 //! [`activation`] — the activation-lock exclusivity layer above the store
 //! (`ActiveConflict`/force-switch semantics `WorkstreamStore::set_active`
-//! deliberately left out) — and [`protocol`], the `workstream.activate`/
-//! `workstream.deactivate` JSON-RPC handlers built on it.
+//! deliberately left out) — and [`protocol`], the full `workstream.*`
+//! JSON-RPC surface (`create`/`get`/`list`/`close` from #3295 plus
+//! `activate`/`deactivate` from #3294, built on [`activation`]).
 //!
 //! **Scope note (Phase 1A):** #3293 built ONLY the domain model and
 //! persistence layer (this module's `model`/`path`/`store` submodules);
-//! #3294 (this ticket) adds the activation-lock RPC semantics
-//! (`activation`/`protocol`, above). The remaining `workstream.*` RPC/REST
-//! surface (`create`/`get`/`list`/`close`, #3295), the CLI (#3296), and the
-//! SSE aggregation route (#3297) land in their own follow-up tickets against
-//! this foundation.
+//! #3294 added the activation-lock RPC semantics (`activation`, plus
+//! `activate`/`deactivate` in [`protocol`]); #3295 (this ticket) added the
+//! rest of `protocol`'s surface (`create`/`get`/`list`/`close`) and the REST
+//! wrappers (`crate::serve::rest::workstreams`). The CLI (#3296) and the SSE
+//! aggregation route (#3297) remain out of scope and land in their own
+//! follow-up tickets against this foundation.
 //!
 //! Test: `cargo test -p trusty-code workstreams::` exercises every submodule
 //! in place; see each submodule's own `Test:` line for specifics.

--- a/crates/trusty-code/src/workstreams/model.rs
+++ b/crates/trusty-code/src/workstreams/model.rs
@@ -210,6 +210,24 @@ impl Workstream {
     pub fn touch(&mut self) {
         self.updated_at = Utc::now();
     }
+
+    /// Mark this workstream closed via the reserved metadata flag (DOC-48
+    /// §4.4, [`SPEC-WS-04~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-04~draft)).
+    ///
+    /// Why: `workstream.close` (#3295) is the sole call site that flips a
+    /// workstream irreversible-closed; centralising the mutation here keeps
+    /// the reserved `metadata["closed"]` key private to this module rather
+    /// than leaking its literal string to the store/RPC layers. Idempotent —
+    /// closing an already-closed workstream re-sets the same flag and simply
+    /// refreshes `updated_at`, since the spec never requires re-close to
+    /// error.
+    /// What: sets `metadata["closed"] = true`, then calls [`Self::touch`].
+    /// Test: `model_tests::mark_closed_sets_flag_and_touches`.
+    pub fn mark_closed(&mut self) {
+        self.metadata
+            .insert(CLOSED_METADATA_KEY.to_string(), Value::Bool(true));
+        self.touch();
+    }
 }
 
 #[cfg(test)]

--- a/crates/trusty-code/src/workstreams/model_tests.rs
+++ b/crates/trusty-code/src/workstreams/model_tests.rs
@@ -106,6 +106,19 @@ fn touch_updates_timestamp() {
 }
 
 #[test]
+fn mark_closed_sets_flag_and_touches() {
+    let mut ws = Workstream::new("G");
+    let before = ws.updated_at;
+    std::thread::sleep(std::time::Duration::from_millis(2));
+
+    ws.mark_closed();
+
+    assert!(ws.is_closed());
+    assert_eq!(ws.state(None), WorkstreamState::Closed);
+    assert!(ws.updated_at > before);
+}
+
+#[test]
 fn state_display_matches_wire_string() {
     assert_eq!(WorkstreamState::Active.to_string(), "active");
     assert_eq!(WorkstreamState::Idle.to_string(), "idle");

--- a/crates/trusty-code/src/workstreams/protocol.rs
+++ b/crates/trusty-code/src/workstreams/protocol.rs
@@ -1,54 +1,99 @@
-//! `workstream.activate` / `workstream.deactivate` JSON-RPC method handlers
-//! (DOC-48 §5.1/§6, issue #3294).
+//! `workstream.*` JSON-RPC method handlers (issues #3294, #3295, epic #3292).
 //!
 //! # Spec References
 //!
 //! - [`SPEC-WS-05~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-05~draft)
 //! - [`SPEC-WS-06~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-06~draft)
+//! - [`SPEC-WS-07~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-07~draft)
 //!
 //! Why: mirrors `crate::session::protocol`'s role for `session.*` — the RPC
 //! surface the daemon exposes over `POST /rpc` (and, via
-//! `crate::serve::rest::workstreams`, the REST twin), thin handlers that
-//! parse `params` and delegate to [`super::activation`]'s business logic, so
-//! the activation-lock rules live in exactly one place regardless of which
-//! transport a caller uses.
+//! `crate::serve::rest::workstreams`, the REST twin). #3293 (merged) built
+//! the domain model and the flat-JSON [`super::store::WorkstreamStore`], but
+//! left it unreachable from any transport. This file is where BOTH
+//! concurrent follow-up tickets against that foundation land: #3294's
+//! activation-lock exclusivity model (`activate`/`deactivate`, built on
+//! [`super::activation`]) and #3295's CRUD/inspection surface
+//! (`create`/`get`/`list`/`close`, built directly on the store) — six thin
+//! handlers, one shared [`SharedWorkstreamStore`], one `register` call.
 //!
-//! **Scope note (issue #3294):** this file registers ONLY `activate` and
-//! `deactivate` — `workstream.create`/`get`/`list`/`close` are issue #3295's
-//! surface (a sibling ticket landing concurrently; see that ticket for the
-//! rest of `workstream.*`). Both tickets' `register` functions are additive
-//! (`Router::register` on a distinct method name each), so whichever merges
-//! first, the other rebases cleanly onto the same `router.register(...)`
-//! call in `crate::serve::build_router` rather than colliding.
+//! **Scope note:** `activate`/`deactivate`'s business logic (conflict
+//! detection, force-switch) lives entirely in [`super::activation`] — this
+//! file only parses `params` and maps [`ActivationError`] onto the JSON-RPC
+//! taxonomy. `create`/`get`/`list`/`close` have no activation-lock rules to
+//! apply, so they call [`super::store::WorkstreamStore`] directly. The CLI
+//! (#3296) and the SSE aggregation route (#3297) remain out of scope.
 //!
-//! What: [`register`] wires both methods onto a [`Router`], sharing one
-//! [`SharedWorkstreamStore`](super::activation::SharedWorkstreamStore).
-//! [`activate`] maps [`ActivationError::NotFound`] to `-32002 not_found`,
-//! [`ActivationError::ActiveConflict`] to the new `-32008 active_conflict`
-//! (`RpcError::active_conflict`, carrying `active_id`), and
-//! [`ActivationError::Store`] to `-32603 internal_error`. [`deactivate`]
-//! never fails on a valid UUID — see [`super::activation::deactivate`]'s
-//! idempotent-no-op contract.
+//! What: [`register`] wires `workstream.create`, `workstream.get`,
+//! `workstream.list`, `workstream.close`, `workstream.activate`,
+//! `workstream.deactivate` onto a [`crate::jsonrpc::Router`], all sharing one
+//! [`SharedWorkstreamStore`]. Every verb that takes a wire `id` parses it via
+//! [`parse_id`] (a manual `Uuid::parse_str` + `-32602 Invalid params` on
+//! failure) rather than deserializing straight into a [`WorkstreamId`] —
+//! chosen as the ONE id-parsing style for this file since #3294 landed it
+//! first. [`WorkstreamView`] is the wire-shape adapter `get`/`list` share:
+//! the domain [`Workstream`] has no `state` FIELD (§2.2 — it is computed,
+//! never stored), so every read path builds this view by pairing a record
+//! with the store's current `active_workstream_id` pointer via
+//! [`Workstream::state`], exactly once, right before serializing.
 //! Test: `protocol_tests`.
 
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 use uuid::Uuid;
 
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 
 use super::activation::{self, ActivationError, SharedWorkstreamStore};
-use super::model::WorkstreamId;
+use super::model::{Workstream, WorkstreamId, WorkstreamState};
+use super::store::StoreError;
 
-/// Register `workstream.activate`/`workstream.deactivate` onto `router`, both
-/// sharing `store`.
+/// Register every `workstream.*` method onto `router`, all sharing `store`.
 ///
-/// Why: the one place that lists this ticket's slice of the `workstream.*`
-/// surface — mirrors `crate::session::protocol::register`'s role.
+/// Why: the one place that lists the full `workstream.*` surface — mirrors
+/// `crate::session::protocol::register`'s role for `session.*`.
 /// What: clones `store` once per method (cheap — `Arc`) into a small adapter
 /// closure that forwards to the corresponding free function below.
-/// Test: `protocol_tests::register_wires_activate_and_deactivate`.
+/// Test: `protocol_tests::register_wires_activate_and_deactivate`,
+/// `protocol_tests::register_wires_create_get_list_close`.
 pub fn register(router: &mut Router, store: SharedWorkstreamStore) {
+    let s = store.clone();
+    router.register(
+        "workstream.create",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { create(&s, params, ctx).await }
+        },
+    );
+
+    let s = store.clone();
+    router.register(
+        "workstream.get",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { get(&s, params, ctx).await }
+        },
+    );
+
+    let s = store.clone();
+    router.register(
+        "workstream.list",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { list(&s, params, ctx).await }
+        },
+    );
+
+    let s = store.clone();
+    router.register(
+        "workstream.close",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { close(&s, params, ctx).await }
+        },
+    );
+
     let s = store.clone();
     router.register(
         "workstream.activate",
@@ -68,6 +113,92 @@ pub fn register(router: &mut Router, store: SharedWorkstreamStore) {
     );
 }
 
+/// The wire shape for a workstream record — the domain [`Workstream`] plus
+/// its computed [`WorkstreamState`] (§2.2: never a stored field), assembled
+/// fresh for every response.
+#[derive(Debug, serde::Serialize)]
+struct WorkstreamView {
+    id: WorkstreamId,
+    name: String,
+    state: WorkstreamState,
+    session_ids: Vec<String>,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    metadata: serde_json::Map<String, Value>,
+}
+
+impl WorkstreamView {
+    /// Pair a stored record with the pointer that governs its state.
+    fn new(ws: Workstream, active_workstream_id: Option<WorkstreamId>) -> Self {
+        let state = ws.state(active_workstream_id);
+        Self {
+            id: ws.id,
+            name: ws.name,
+            state,
+            session_ids: ws.session_ids,
+            created_at: ws.created_at,
+            updated_at: ws.updated_at,
+            metadata: ws.metadata,
+        }
+    }
+}
+
+/// Deserialise `params` into `T`, mapping a failure onto `-32602 Invalid
+/// params` with the method name for context (mirrors
+/// `crate::session::protocol::parse`).
+fn parse<T: DeserializeOwned>(params: Value, method: &str) -> Result<T, RpcError> {
+    serde_json::from_value(params).map_err(|e| RpcError::invalid_params(format!("{method}: {e}")))
+}
+
+/// Parse a wire `id` string into a [`WorkstreamId`], mapping a malformed
+/// UUID onto `-32602 Invalid params` rather than a panic (issue #3294's
+/// id-parsing style, applied uniformly to every verb in this file — see
+/// module docs).
+fn parse_id(raw: &str, method: &str) -> Result<WorkstreamId, RpcError> {
+    Uuid::parse_str(raw)
+        .map(WorkstreamId::from)
+        .map_err(|e| RpcError::invalid_params(format!("{method}: invalid workstream id: {e}")))
+}
+
+/// Map a [`StoreError`] onto the JSON-RPC error taxonomy (vision spec §13.2)
+/// for the `create`/`get`/`list`/`close` verbs (the `activate`/`deactivate`
+/// verbs instead map [`ActivationError`], which wraps `StoreError` alongside
+/// its own `NotFound`/`ActiveConflict` variants).
+///
+/// Why: the one place `NotFound` becomes the spec's general `-32002
+/// not_found` (workstreams have no session-specific error code) and every
+/// other variant (I/O, serialization) becomes `-32603 internal` — a
+/// caller-triggerable "id doesn't exist" must never be indistinguishable
+/// from a daemon-side storage fault.
+/// Test: `protocol_tests::get_unknown_id_maps_to_not_found`.
+fn map_store_err(err: StoreError) -> RpcError {
+    match err {
+        StoreError::NotFound(id) => RpcError::not_found(format!("workstream not found: {id}")),
+        StoreError::Io(_) | StoreError::Serialize(_) => RpcError::internal(err.to_string()),
+    }
+}
+
+/// `params` shape for `workstream.create`.
+#[derive(Deserialize)]
+struct CreateParams {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// `params` shape shared by every verb that only needs a workstream id
+/// (`get`, `close`, `deactivate`).
+#[derive(Deserialize)]
+struct WorkstreamIdParams {
+    id: String,
+}
+
+/// `params` shape for `workstream.list`.
+#[derive(Deserialize, Default)]
+struct ListParams {
+    #[serde(default)]
+    include_closed: bool,
+}
+
 /// `params` shape for `workstream.activate` (DOC-48 §5.1).
 #[derive(Deserialize)]
 struct ActivateParams {
@@ -76,18 +207,112 @@ struct ActivateParams {
     force: bool,
 }
 
-/// `params` shape shared by `workstream.deactivate` (a bare workstream id).
-#[derive(Deserialize)]
-struct WorkstreamIdParams {
-    id: String,
+/// `workstream.create{name?} -> {id: UUID}` (DOC-48 §5.1, AC-2.1).
+///
+/// Why: mints a brand-new daemon-owned workstream. No `project_id`
+/// parameter — the daemon's own `ProjectBinding` is implicit (§2.3): the
+/// store this handler shares is already scoped to it via the file the daemon
+/// booted with.
+/// What: `name` defaults to an empty string when omitted (§5.1: "Name is
+/// initially empty"). Returns `{"id": <new id>}`.
+/// Test: `protocol_tests::create_returns_new_id`,
+/// `protocol_tests::create_without_name_defaults_to_empty`.
+async fn create(
+    store: &SharedWorkstreamStore,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: CreateParams = parse(params, "workstream.create")?;
+    let mut store = store.lock().await;
+    let id = store
+        .create(p.name.unwrap_or_default())
+        .await
+        .map_err(map_store_err)?;
+    Ok(json!({ "id": id }))
 }
 
-/// Parse a wire `id` string into a [`WorkstreamId`], mapping a malformed
-/// UUID onto `-32602 Invalid params` rather than a panic.
-fn parse_id(raw: &str, method: &str) -> Result<WorkstreamId, RpcError> {
-    Uuid::parse_str(raw)
-        .map(WorkstreamId::from)
-        .map_err(|e| RpcError::invalid_params(format!("{method}: invalid workstream id: {e}")))
+/// `workstream.get{id} -> Workstream` (DOC-48 §5.1, AC-2.1).
+///
+/// Why: point lookup for one workstream's current (inferred) state.
+/// What: `-32002 not_found` if `id` is unknown; otherwise the full
+/// [`WorkstreamView`] — id, name, computed `state`, `session_ids`,
+/// timestamps, `metadata`.
+/// Test: `protocol_tests::get_returns_workstream_with_state`,
+/// `protocol_tests::get_unknown_id_maps_to_not_found`.
+async fn get(
+    store: &SharedWorkstreamStore,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: WorkstreamIdParams = parse(params, "workstream.get")?;
+    let id = parse_id(&p.id, "workstream.get")?;
+    let mut store = store.lock().await;
+    let ws = store.get(id).await.map_err(map_store_err)?;
+    let active_id = store.active_workstream_id().await.map_err(map_store_err)?;
+    Ok(json!(WorkstreamView::new(ws, active_id)))
+}
+
+/// `workstream.list{include_closed?} -> {active_workstream_id, workstreams: [Workstream]}`
+/// (DOC-48 §5.1, AC-2.1, AC-2.3).
+///
+/// Why: enumerates every workstream in the daemon's project, so a client can
+/// build a switcher without a `get` per id.
+/// What: default `include_closed = false` filters out records whose
+/// [`Workstream::is_closed`] flag is set (§4.4: "optionally listable ...
+/// for audit/historical query"); `true` includes them. Every returned record
+/// is paired with the SAME `active_workstream_id` snapshot (read once, not
+/// per record) so the response is internally consistent even if a concurrent
+/// writer changes the pointer mid-list. `active_workstream_id` is always
+/// present at the top level (`null` if none active, AC-2.3).
+/// Test: `protocol_tests::list_returns_active_workstream_id_and_records`,
+/// `protocol_tests::list_default_excludes_closed`,
+/// `protocol_tests::list_include_closed_true_includes_closed`.
+async fn list(
+    store: &SharedWorkstreamStore,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: ListParams = if params.is_null() {
+        ListParams::default()
+    } else {
+        parse(params, "workstream.list")?
+    };
+    let mut store = store.lock().await;
+    let all = store.list().await.map_err(map_store_err)?;
+    let active_id = store.active_workstream_id().await.map_err(map_store_err)?;
+    let views: Vec<WorkstreamView> = all
+        .into_iter()
+        .filter(|ws| p.include_closed || !ws.is_closed())
+        .map(|ws| WorkstreamView::new(ws, active_id))
+        .collect();
+    Ok(json!({
+        "active_workstream_id": active_id,
+        "workstreams": views,
+    }))
+}
+
+/// `workstream.close{id} -> {}` (DOC-48 §4.4/§5.1, AC-2.1).
+///
+/// Why: irreversibly closes a workstream — rejects future session bindings
+/// (enforced at the session-binding call site, #3298 scope, not here) and,
+/// per §4.4, auto-deactivates it if it is currently the active one.
+/// What: `-32002 not_found` if `id` is unknown; otherwise `{}` (matching the
+/// spec's §5.1 signature exactly — not the updated record, since a client
+/// that needs the post-close view already has `workstream.get`). Idempotent:
+/// closing an already-closed workstream succeeds again (see
+/// [`super::model::Workstream::mark_closed`]'s docs).
+/// Test: `protocol_tests::close_succeeds_and_clears_active_pointer`,
+/// `protocol_tests::close_unknown_id_maps_to_not_found`.
+async fn close(
+    store: &SharedWorkstreamStore,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: WorkstreamIdParams = parse(params, "workstream.close")?;
+    let id = parse_id(&p.id, "workstream.close")?;
+    let mut store = store.lock().await;
+    store.close(id).await.map_err(map_store_err)?;
+    Ok(json!({}))
 }
 
 /// `workstream.activate(id, force?) -> {active_id, prior_id?}` (DOC-48
@@ -95,7 +320,10 @@ fn parse_id(raw: &str, method: &str) -> Result<WorkstreamId, RpcError> {
 ///
 /// Why: the RPC entry point for the activation-lock exclusivity model.
 /// What: parses `params`, delegates to [`activation::activate`], and maps
-/// its typed error onto the JSON-RPC error taxonomy — see the module docs.
+/// its typed error onto the JSON-RPC error taxonomy — [`ActivationError::NotFound`]
+/// to `-32002 not_found`, [`ActivationError::ActiveConflict`] to `-32008
+/// active_conflict` (`RpcError::active_conflict`, carrying `active_id`), and
+/// [`ActivationError::Store`] to `-32603 internal_error`.
 /// Test: `protocol_tests::activate_succeeds_with_no_prior_active`,
 /// `protocol_tests::activate_without_force_maps_to_active_conflict`,
 /// `protocol_tests::activate_with_force_switches`,
@@ -106,8 +334,7 @@ async fn activate(
     params: Value,
     _ctx: ConnectionContext,
 ) -> Result<Value, RpcError> {
-    let p: ActivateParams = serde_json::from_value(params)
-        .map_err(|e| RpcError::invalid_params(format!("workstream.activate: {e}")))?;
+    let p: ActivateParams = parse(params, "workstream.activate")?;
     let id = parse_id(&p.id, "workstream.activate")?;
 
     match activation::activate(store, id, p.force).await {
@@ -138,8 +365,7 @@ async fn deactivate(
     params: Value,
     _ctx: ConnectionContext,
 ) -> Result<Value, RpcError> {
-    let p: WorkstreamIdParams = serde_json::from_value(params)
-        .map_err(|e| RpcError::invalid_params(format!("workstream.deactivate: {e}")))?;
+    let p: WorkstreamIdParams = parse(params, "workstream.deactivate")?;
     let id = parse_id(&p.id, "workstream.deactivate")?;
 
     activation::deactivate(store, id)

--- a/crates/trusty-code/src/workstreams/protocol_tests.rs
+++ b/crates/trusty-code/src/workstreams/protocol_tests.rs
@@ -1,5 +1,4 @@
-//! Tests for `workstream.activate`/`workstream.deactivate` RPC handlers
-//! (DOC-48 §5.1/§6, issue #3294).
+//! Tests for `workstream.*` RPC handlers (DOC-48 §5.1/§6, issues #3294/#3295).
 
 use super::*;
 use serde_json::json;
@@ -24,7 +23,10 @@ async fn shared_store() -> (SharedWorkstreamStore, TempDir) {
     (std::sync::Arc::new(tokio::sync::Mutex::new(store)), dir)
 }
 
-async fn create(store: &SharedWorkstreamStore, name: &str) -> WorkstreamId {
+/// Seed a workstream directly via the store (bypassing the
+/// `workstream.create` RPC handler, which some tests below exercise
+/// directly under its own name — named distinctly so the two never collide).
+async fn seed_workstream(store: &SharedWorkstreamStore, name: &str) -> WorkstreamId {
     store.lock().await.create(name).await.expect("create")
 }
 
@@ -37,12 +39,13 @@ fn req(method: &str, params: serde_json::Value) -> Request {
     }
 }
 
-/// Both methods must be reachable through a `Router` built by `register`
-/// (proves the wiring, not just the free functions).
+/// `workstream.activate`/`workstream.deactivate` must be reachable through a
+/// `Router` built by `register` (proves the wiring, not just the free
+/// functions).
 #[tokio::test]
 async fn register_wires_activate_and_deactivate() {
     let (store, _dir) = shared_store().await;
-    let id = create(&store, "t").await;
+    let id = seed_workstream(&store, "t").await;
     let mut router = Router::new();
     register(&mut router, store);
 
@@ -71,18 +74,44 @@ async fn register_wires_activate_and_deactivate() {
     );
 }
 
+/// `workstream.create`/`get`/`list`/`close` must be reachable through a
+/// `Router` built by `register` (proves the wiring, not just the free
+/// functions) — the #3295 counterpart to
+/// `register_wires_activate_and_deactivate` above.
+#[tokio::test]
+async fn register_wires_create_get_list_close() {
+    let (store, _dir) = shared_store().await;
+    let mut router = Router::new();
+    register(&mut router, store);
+
+    let resp = router
+        .dispatch(req("workstream.create", json!({"name": "A"})), &test_ctx())
+        .await;
+    assert!(resp.error.is_none(), "create failed: {:?}", resp.error);
+    let id = resp.result.unwrap()["id"].clone();
+
+    for (method, params) in [
+        ("workstream.get", json!({"id": id})),
+        ("workstream.list", json!({})),
+        ("workstream.close", json!({"id": id})),
+    ] {
+        let resp = router.dispatch(req(method, params), &test_ctx()).await;
+        assert!(resp.error.is_none(), "{method} failed: {:?}", resp.error);
+    }
+}
+
 /// Activating with no prior active workstream must return `active_id` and a
 /// null `prior_id`.
 #[tokio::test]
 async fn activate_succeeds_with_no_prior_active() {
     let (store, _dir) = shared_store().await;
-    let id = create(&store, "t").await;
+    let id = seed_workstream(&store, "t").await;
 
     let result = activate(&store, json!({"id": id.to_string()}), test_ctx())
         .await
         .expect("activate must succeed");
     assert_eq!(result["active_id"], json!(id));
-    assert_eq!(result["prior_id"], serde_json::Value::Null);
+    assert_eq!(result["prior_id"], Value::Null);
 }
 
 /// Re-activating the already-active workstream (force omitted, defaults to
@@ -90,7 +119,7 @@ async fn activate_succeeds_with_no_prior_active() {
 #[tokio::test]
 async fn activate_already_active_is_idempotent() {
     let (store, _dir) = shared_store().await;
-    let id = create(&store, "t").await;
+    let id = seed_workstream(&store, "t").await;
     activate(&store, json!({"id": id.to_string()}), test_ctx())
         .await
         .expect("first activate");
@@ -99,7 +128,7 @@ async fn activate_already_active_is_idempotent() {
         .await
         .expect("re-activate must succeed");
     assert_eq!(result["active_id"], json!(id));
-    assert_eq!(result["prior_id"], serde_json::Value::Null);
+    assert_eq!(result["prior_id"], Value::Null);
 }
 
 /// Activating a different workstream without `force` while one is active
@@ -107,8 +136,8 @@ async fn activate_already_active_is_idempotent() {
 #[tokio::test]
 async fn activate_without_force_maps_to_active_conflict() {
     let (store, _dir) = shared_store().await;
-    let a = create(&store, "a").await;
-    let b = create(&store, "b").await;
+    let a = seed_workstream(&store, "a").await;
+    let b = seed_workstream(&store, "b").await;
     activate(&store, json!({"id": a.to_string()}), test_ctx())
         .await
         .expect("activate a");
@@ -124,8 +153,8 @@ async fn activate_without_force_maps_to_active_conflict() {
 #[tokio::test]
 async fn activate_with_force_switches() {
     let (store, _dir) = shared_store().await;
-    let a = create(&store, "a").await;
-    let b = create(&store, "b").await;
+    let a = seed_workstream(&store, "a").await;
+    let b = seed_workstream(&store, "b").await;
     activate(&store, json!({"id": a.to_string()}), test_ctx())
         .await
         .expect("activate a");
@@ -171,7 +200,7 @@ async fn activate_malformed_id_maps_to_invalid_params() {
 #[tokio::test]
 async fn deactivate_active_clears_pointer() {
     let (store, _dir) = shared_store().await;
-    let id = create(&store, "t").await;
+    let id = seed_workstream(&store, "t").await;
     activate(&store, json!({"id": id.to_string()}), test_ctx())
         .await
         .expect("activate");
@@ -191,8 +220,8 @@ async fn deactivate_active_clears_pointer() {
 #[tokio::test]
 async fn deactivate_idle_is_idempotent_noop() {
     let (store, _dir) = shared_store().await;
-    let a = create(&store, "a").await;
-    let b = create(&store, "b").await;
+    let a = seed_workstream(&store, "a").await;
+    let b = seed_workstream(&store, "b").await;
     activate(&store, json!({"id": a.to_string()}), test_ctx())
         .await
         .expect("activate a");
@@ -218,7 +247,7 @@ async fn activation_persists_across_store_reload_through_rpc() {
         .await
         .expect("load fresh store");
     let shared: SharedWorkstreamStore = std::sync::Arc::new(tokio::sync::Mutex::new(store));
-    let id = create(&shared, "t").await;
+    let id = seed_workstream(&shared, "t").await;
     activate(&shared, json!({"id": id.to_string()}), test_ctx())
         .await
         .expect("activate");
@@ -229,4 +258,172 @@ async fn activation_persists_across_store_reload_through_rpc() {
         Some(id),
         "active pointer must persist across a fresh load"
     );
+}
+
+#[tokio::test]
+async fn create_returns_new_id() {
+    let (store, _dir) = shared_store().await;
+    let result = create(&store, json!({"name": "Token rotation"}), test_ctx())
+        .await
+        .expect("create");
+    assert!(result["id"].is_string());
+}
+
+#[tokio::test]
+async fn create_without_name_defaults_to_empty() {
+    let (store, _dir) = shared_store().await;
+    let result = create(&store, json!({}), test_ctx()).await.expect("create");
+    let id = result["id"].clone();
+    let ws = get(&store, json!({"id": id}), test_ctx())
+        .await
+        .expect("get");
+    assert_eq!(ws["name"], "");
+}
+
+#[tokio::test]
+async fn get_returns_workstream_with_state() {
+    let (store, _dir) = shared_store().await;
+    let created = create(&store, json!({"name": "A"}), test_ctx())
+        .await
+        .expect("create");
+    let id = created["id"].clone();
+
+    let ws = get(&store, json!({"id": id}), test_ctx())
+        .await
+        .expect("get");
+    assert_eq!(ws["name"], "A");
+    assert_eq!(ws["state"], "idle");
+    assert!(ws["session_ids"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn get_unknown_id_maps_to_not_found() {
+    let (store, _dir) = shared_store().await;
+    let err = get(
+        &store,
+        json!({"id": WorkstreamId::new().to_string()}),
+        test_ctx(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, -32002);
+}
+
+#[tokio::test]
+async fn get_invalid_params_maps_to_invalid_params() {
+    let (store, _dir) = shared_store().await;
+    let err = get(&store, json!({"id": "not-a-uuid"}), test_ctx())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, trusty_common::mcp::error_codes::INVALID_PARAMS);
+}
+
+#[tokio::test]
+async fn list_returns_active_workstream_id_and_records() {
+    let (store, _dir) = shared_store().await;
+    let a = create(&store, json!({"name": "A"}), test_ctx())
+        .await
+        .expect("create A")["id"]
+        .clone();
+    create(&store, json!({"name": "B"}), test_ctx())
+        .await
+        .expect("create B");
+
+    let a_id: WorkstreamId = serde_json::from_value(a.clone()).unwrap();
+    store
+        .lock()
+        .await
+        .set_active(Some(a_id))
+        .await
+        .expect("activate A");
+
+    let result = list(&store, json!({}), test_ctx()).await.expect("list");
+    assert_eq!(result["active_workstream_id"], a);
+    let workstreams = result["workstreams"].as_array().unwrap();
+    assert_eq!(workstreams.len(), 2);
+    let a_view = workstreams.iter().find(|w| w["id"] == a).unwrap();
+    assert_eq!(a_view["state"], "active");
+}
+
+#[tokio::test]
+async fn list_missing_params_defaults_to_include_closed_false() {
+    let (store, _dir) = shared_store().await;
+    let result = list(&store, Value::Null, test_ctx()).await.expect("list");
+    assert!(result["workstreams"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn list_default_excludes_closed() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, json!({"name": "A"}), test_ctx())
+        .await
+        .expect("create")["id"]
+        .clone();
+    close(&store, json!({"id": id}), test_ctx())
+        .await
+        .expect("close");
+
+    let result = list(&store, json!({}), test_ctx()).await.expect("list");
+    assert!(
+        result["workstreams"].as_array().unwrap().is_empty(),
+        "closed workstream must be excluded by default"
+    );
+}
+
+#[tokio::test]
+async fn list_include_closed_true_includes_closed() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, json!({"name": "A"}), test_ctx())
+        .await
+        .expect("create")["id"]
+        .clone();
+    close(&store, json!({"id": id}), test_ctx())
+        .await
+        .expect("close");
+
+    let result = list(&store, json!({"include_closed": true}), test_ctx())
+        .await
+        .expect("list");
+    let workstreams = result["workstreams"].as_array().unwrap();
+    assert_eq!(workstreams.len(), 1);
+    assert_eq!(workstreams[0]["state"], "closed");
+}
+
+#[tokio::test]
+async fn close_succeeds_and_clears_active_pointer() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, json!({"name": "A"}), test_ctx())
+        .await
+        .expect("create")["id"]
+        .clone();
+    let ws_id: WorkstreamId = serde_json::from_value(id.clone()).unwrap();
+    store
+        .lock()
+        .await
+        .set_active(Some(ws_id))
+        .await
+        .expect("activate");
+
+    let result = close(&store, json!({"id": id}), test_ctx())
+        .await
+        .expect("close");
+    assert_eq!(result, json!({}));
+
+    let list_result = list(&store, json!({"include_closed": true}), test_ctx())
+        .await
+        .expect("list");
+    assert_eq!(list_result["active_workstream_id"], Value::Null);
+}
+
+#[tokio::test]
+async fn close_unknown_id_maps_to_not_found() {
+    let (store, _dir) = shared_store().await;
+    let err = close(
+        &store,
+        json!({"id": WorkstreamId::new().to_string()}),
+        test_ctx(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, -32002);
 }

--- a/crates/trusty-code/src/workstreams/store.rs
+++ b/crates/trusty-code/src/workstreams/store.rs
@@ -328,6 +328,47 @@ impl WorkstreamStore {
         self.save().await
     }
 
+    /// Irreversibly close a workstream, auto-deactivating it if it is the
+    /// active one (DOC-48 §4.4, [`SPEC-WS-04~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-04~draft)).
+    ///
+    /// Why: the persistence primitive `workstream.close` (#3295) calls. §4.4
+    /// is explicit that "if the closed workstream is the active one, it is
+    /// automatically deactivated (sets `active_workstream_id` to `null`)" —
+    /// closing must never leave a dangling active pointer referencing a
+    /// closed workstream, which would otherwise let a closed workstream keep
+    /// reporting `Active` state forever (model precedence: the pointer beats
+    /// the closed flag, see [`Workstream::state`]'s docs).
+    /// What: reloads first, marks the record closed via
+    /// [`Workstream::mark_closed`] (idempotent — closing twice is not an
+    /// error), clears `active_workstream_id` if it pointed at `id`, persists,
+    /// and returns the updated record. `NotFound` if `id` does not exist.
+    /// Test: `store_tests::close_marks_closed_and_persists`,
+    /// `store_tests::close_active_workstream_clears_active_pointer`,
+    /// `store_tests::close_missing_id_returns_not_found`,
+    /// `store_tests::close_is_idempotent`.
+    pub async fn close(&mut self, id: WorkstreamId) -> Result<Workstream, StoreError> {
+        self.reload_if_changed().await?;
+        {
+            let ws = self
+                .data
+                .workstreams
+                .iter_mut()
+                .find(|w| w.id == id)
+                .ok_or_else(|| StoreError::NotFound(id.to_string()))?;
+            ws.mark_closed();
+        }
+        if self.data.active_workstream_id == Some(id) {
+            self.data.active_workstream_id = None;
+        }
+        self.save().await?;
+        self.data
+            .workstreams
+            .iter()
+            .find(|w| w.id == id)
+            .cloned()
+            .ok_or_else(|| StoreError::NotFound(id.to_string()))
+    }
+
     /// Boot-time reconciliation (DOC-48 §3.3, AC-1.4, AC-6.1, AC-6.2).
     ///
     /// Why: a daemon restart must never silently change which workstream is

--- a/crates/trusty-code/src/workstreams/store_tests.rs
+++ b/crates/trusty-code/src/workstreams/store_tests.rs
@@ -244,6 +244,73 @@ async fn store_reload_picks_up_external_write() {
     );
 }
 
+/// §4.4: closing a non-active workstream just flips the metadata flag and
+/// persists it — the active pointer (if any, pointing elsewhere) is
+/// untouched.
+#[tokio::test]
+async fn close_marks_closed_and_persists() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+    let mut store = WorkstreamStore::load(&path).await.expect("load");
+    let a = store.create("A").await.expect("create A");
+    let b = store.create("B").await.expect("create B");
+    store.set_active(Some(a)).await.expect("activate A");
+
+    let closed = store.close(b).await.expect("close B");
+    assert!(closed.is_closed());
+    assert_eq!(
+        store.active_workstream_id().await.expect("active"),
+        Some(a),
+        "closing a non-active workstream must not touch the active pointer"
+    );
+
+    let mut reloaded = WorkstreamStore::load(&path).await.expect("reload");
+    let ws = reloaded.get(b).await.expect("get after reload");
+    assert!(ws.is_closed(), "closed flag must be persisted");
+}
+
+/// §4.4: closing the ACTIVE workstream must auto-deactivate it (clear
+/// `active_workstream_id` to `null`).
+#[tokio::test]
+async fn close_active_workstream_clears_active_pointer() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("A").await.expect("create");
+    store.set_active(Some(id)).await.expect("activate");
+
+    store.close(id).await.expect("close active workstream");
+
+    assert_eq!(
+        store.active_workstream_id().await.expect("active"),
+        None,
+        "closing the active workstream must clear the active pointer"
+    );
+}
+
+#[tokio::test]
+async fn close_missing_id_returns_not_found() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let missing = WorkstreamId::new();
+    assert!(matches!(
+        store.close(missing).await,
+        Err(StoreError::NotFound(_))
+    ));
+}
+
+/// Closing an already-closed workstream is not an error (§4.4 does not
+/// require re-close to fail).
+#[tokio::test]
+async fn close_is_idempotent() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("A").await.expect("create");
+
+    store.close(id).await.expect("first close");
+    let second = store.close(id).await.expect("second close must not error");
+    assert!(second.is_closed());
+}
+
 #[tokio::test]
 async fn store_reload_noop_when_unchanged() {
     let dir = TempDir::new().expect("tempdir");


### PR DESCRIPTION
## Summary

Implements DOC-48 §5's Phase 1A workstream RPC/REST surface (epic #3292),
building on the merged domain model + persistence foundation (#3293,
`c42797a5`):

- **JSON-RPC verbs** (`crates/trusty-code/src/workstreams/protocol.rs`):
  `workstream.create{name?} -> {id}`, `workstream.get{id} -> Workstream`,
  `workstream.list{include_closed?} -> {active_workstream_id, workstreams[]}`,
  `workstream.close{id} -> {}`. All share one
  `Arc<tokio::sync::Mutex<WorkstreamStore>>` (async-shared-state convention,
  matching `crate::llm::client`'s `Mutex<HashMap<..>>`, not `SessionRegistry`'s
  synchronous `std::sync::Mutex`).
- **REST wrappers** (`crates/trusty-code/src/serve/rest/workstreams.rs`):
  `POST /workstreams`, `GET /workstreams/{id}`, `GET /workstreams`,
  `POST /workstreams/{id}/close` — thin handlers over the same RPC dispatch
  seam every other `rest::*` group uses (`super::respond`), mirroring
  `rest/sessions.rs`/`rest/tasks.rs`.
- **Router wiring** (`crates/trusty-code/src/serve/mod.rs`): `build_router`
  is now `async`/fallible — it loads (or creates) the daemon's
  `WorkstreamStore` via `WorkstreamStore::load_for_binding` and registers
  `workstreams::protocol::register` alongside `session.*`/`task.*`/`fs.*`.
  Added a `build_router_in(binding, data_dir)` internal seam so the test
  suite points the store at a tempdir instead of `~/.trusty-code`.
- **Store addition** (`crates/trusty-code/src/workstreams/store.rs`):
  `WorkstreamStore::close` — the persistence primitive `workstream.close`
  calls, marking the record closed via a new `Workstream::mark_closed()` and
  auto-deactivating it if it was the active workstream (DOC-48 §4.4).

## Spec anchors

- SPEC-WS-05~draft (RPC/REST surface), SPEC-WS-07~draft (AC-2.1–2.3),
  SPEC-WS-04~draft §4.4 (close-the-active-workstream auto-deactivation rule).

## Ambiguities resolved

1. **REST path prefix.** DOC-48 §5.2 and the issue body write
   `/api/v1/workstreams`, but every REST resource group shipped since #2983
   (`/sessions`, `/tasks`, `/fs`, `/sessions/{id}/agents`, …) is unprefixed —
   there is no `/api/v1` anywhere in `crate::serve::rest`. Introducing a
   prefix for exactly one resource group would make the surface internally
   inconsistent, so this PR follows the shipped convention (documented in
   `rest/workstreams.rs`'s module docs).
2. **`workstream.close` on the active workstream.** §4.4 is explicit: "if the
   closed workstream is the active one, it is automatically deactivated
   (sets `active_workstream_id` to `null`)" — implemented exactly as
   specified (`WorkstreamStore::close`), not rejected.
3. **Re-closing an already-closed workstream.** Not addressed explicitly by
   the spec; made idempotent (second `close` succeeds, re-touches
   `updated_at`) rather than erroring, matching this crate's existing
   idempotent-mutation conventions (e.g. `session.detach`,
   `protocol_goals::clear_goal`).

## Out of scope (per issue)

`workstream.activate`/`deactivate` + `ActiveConflict` (#3294, concurrent
sibling branch `feat-3294-activation-lock`), CLI (#3296), SSE (#3297),
session binding (#3298).

## Coordination note

#3294 touches the same `build_router` registration block and router-state
wiring. This PR's diff there is a single contiguous addition (the
`workstreams` `Arc<Mutex<..>>` + one `register` call). If #3294 merges
first, this branch will rebase onto `origin/main` and reuse its store-in-
state wiring rather than duplicating it.

## Gates (raw tails)

```
$ cargo check -p trusty-code
Finished `dev` profile [unoptimized + debuginfo] target(s) in 10.33s

$ cargo test -p trusty-code --lib workstreams::
test result: ok. 59 passed; 0 failed; 0 ignored; 0 measured; 1225 filtered out

$ cargo test -p trusty-code --lib
test result: FAILED. 1279 passed; 1 failed; 4 ignored
  (run_task::tests::exit_code_reflects_run_failure — pre-existing,
  unrelated to this PR: touches real trusty-memory network I/O, passes
  in isolation `cargo test -p trusty-code --lib run_task::tests::exit_code_reflects_run_failure`,
  fails only under full-suite parallel execution. Not caused by this
  change — this PR never touches `run_task`.)

$ cargo clippy -p trusty-code --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.21s   (clean)

$ cargo fmt --check
(clean — only nightly-feature warnings, no diff)

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 38 spec doc(s) + 2593 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_test_pointers.sh
test-pointers: 1 dangling pointer(s) — FAILED
  (crates/trusty-agents/src/agents/loader.rs:35 — pre-existing, unrelated
  crate this PR never touches; not introduced by this change.)
```

## Test plan

- [x] `workstream.create`/`get`/`list`/`close` round-trip at the RPC layer
- [x] `list` `include_closed` filtering (default false / explicit true)
- [x] `close` on the active workstream clears `active_workstream_id` (§4.4)
- [x] `close` on a non-active workstream leaves the active pointer untouched
- [x] `close` is idempotent; unknown id -> `-32002 not_found`
- [x] REST smoke tests for all four routes (create 201, get 200/404, list
      200 with query param, close 200/404)
- [x] `build_router` wires every `workstream.*` method
- [x] `WorkstreamStore::close` unit tests (store layer)

Part of #3292

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)