### PR TITLE
feat(trusty-code): tcode workstream CLI family (closes #3296)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`tcode workstream` / `tcode ws` CLI family (issue #3296, DOC-48 §5.4,
+  epic #3292).** `list [--include-closed]` (tmux-`list-sessions`-style
+  table: id prefix, state, session count, humanized age, name — `*` marks
+  the active row), `get <id>` (raw JSON), `create [--name NAME]`,
+  `activate <id> [--force]`, `deactivate` (no-arg; resolves and clears
+  whichever workstream is active, or reports a clean no-op), and
+  `close <id>`, all thin JSON-RPC clients over the daemon's `workstream.*`
+  surface (#3294/#3295). `ws` is a clap alias for the whole family.
+  `activate` without `--force` while a different workstream is active
+  surfaces the `-32008 active_conflict` error as a clear message naming the
+  active workstream and suggesting `--force`, instead of the raw RPC error
+  text. ID arguments require the full UUID — the RPC layer has no
+  prefix-matching support, so none is built client-side. Auto-streaming
+  from the newly-active workstream on `activate` is deferred until the
+  workstream-level SSE aggregation route (issue #3297) lands.
 - **Workstream activation lock: `workstream.activate`/`workstream.deactivate`
   RPC + REST, `ActiveConflict` (issue #3294, DOC-48 §5/§6, epic #3292).**
   Daemon-enforced singleton active-workstream invariant on top of #3293's

--- a/crates/trusty-code/src/cli/mod.rs
+++ b/crates/trusty-code/src/cli/mod.rs
@@ -14,7 +14,9 @@
 //! re-spawn itself as `tcode serve --stdio`), [`session::list`]/
 //! [`session::status`], [`run_task::run`] (create + `task.run` + attach +
 //! stream — the M1 cut-line "replay via thin CLI" verb), [`attach::run`],
-//! [`cancel::run`], [`transcript::run`].
+//! [`cancel::run`], [`transcript::run`], and (#3296)
+//! [`workstream::list`]/[`workstream::get`]/[`workstream::create`]/
+//! [`workstream::activate`]/[`workstream::deactivate`]/[`workstream::close`].
 //! Test: each submodule's own doc comments note its coverage; the full
 //! spawn+wire behaviour is covered end-to-end by `tests/cli_e2e.rs` against
 //! the real `tcode` binary — these handlers are too thin to usefully unit
@@ -27,3 +29,4 @@ pub mod run_task;
 pub mod session;
 pub mod tcode_exe;
 pub mod transcript;
+pub mod workstream;

--- a/crates/trusty-code/src/cli/workstream.rs
+++ b/crates/trusty-code/src/cli/workstream.rs
@@ -1,0 +1,277 @@
+//! `tcode workstream <action>` / `tcode ws <action>` (#3296, epic #3292).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-WS-05~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-05~draft)
+//! - [`SPEC-WS-06~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-06~draft)
+//!
+//! Why: the CLI-layer half of DOC-48 §5.4's `tcode workstream` family —
+//! `create`/`get`/`list`/`activate`/`deactivate`/`close`, all thin JSON-RPC
+//! clients over an ephemeral `tcode serve --stdio` child, matching every
+//! other handler in this directory (`cli::session`/`attach`/`cancel`/
+//! `transcript`). Unlike sessions, workstreams are DAEMON-PERSISTED (flat
+//! JSON per project, `crate::workstreams::path`) — so, unlike
+//! `cli::session::list`'s "only sees sessions from THIS invocation's daemon"
+//! caveat, two SEPARATE `tcode workstream` invocations against the same
+//! `--project` see the SAME workstreams, because the store file survives
+//! between ephemeral daemon spawns.
+//!
+//! **`deactivate` takes no id (DOC-48 §5.4's CLI surface), but the RPC verb
+//! it wraps does** (`workstream.deactivate{id}`, `crate::workstreams::protocol`)
+//! — only the active workstream may ever be deactivated (§4.3), so this
+//! handler resolves the id itself via one `workstream.list` call before
+//! deactivating (see [`deactivate`]'s own docs).
+//!
+//! **`activate` does NOT start streaming events** (DOC-48 §5.4 says a CLI
+//! client should auto-stream from the newly-active workstream): the
+//! workstream-level SSE aggregation route (`GET /workstreams/{id}/events`,
+//! issue #3297) is explicitly out of this ticket's scope per
+//! `crate::workstreams::protocol`'s own module docs ("The CLI (#3296) and the
+//! SSE aggregation route (#3297) remain out of scope") and isn't reachable
+//! over the stdio JSON-RPC transport this CLI uses regardless (SSE is
+//! HTTP-only). [`activate`] performs the activation call and reports the
+//! outcome; wiring auto-attach is deferred until #3297 lands a route this
+//! handler can actually call.
+//!
+//! **ID arguments require the full UUID.** DOC-48's RPC layer has no
+//! prefix-matching support (`crate::workstreams::protocol::parse_id` is a
+//! plain `Uuid::parse_str`), so building client-side "list, then match an
+//! unambiguous prefix" resolution here would race against concurrent
+//! creates/closes for a purely cosmetic convenience. Left as a documented
+//! future nicety — [`crate::cli_client::render::render_workstream_table`]'s
+//! displayed id prefix is DISPLAY ONLY.
+//! What: [`list`] (table view), [`get`] (raw JSON view), [`create`],
+//! [`activate`] (special-cases `-32008 active_conflict` into a human message
+//! naming the active workstream and suggesting `--force`, via
+//! [`explain_activation_error`]), [`deactivate`], [`close`].
+//! Test: `tests::explain_activation_error_names_the_active_workstream_and_suggests_force`,
+//! `tests::explain_activation_error_passes_through_other_errors`; the full
+//! spawn+wire behaviour is covered by `tests/cli_e2e.rs`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde_json::json;
+
+use trusty_code::cli_client::render::{WorkstreamRow, render_workstream_table};
+use trusty_code::cli_client::{RpcClientError, StdioRpcClient};
+
+use super::tcode_exe;
+
+/// `tcode workstream list [--include-closed] [--project P]`.
+///
+/// Why/What: see module docs. Renders
+/// [`render_workstream_table`] over the daemon's `workstream.list`
+/// response.
+pub async fn list(project: &Path, include_closed: bool) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+    let result = client
+        .call("workstream.list", json!({"include_closed": include_closed}))
+        .await;
+    client.shutdown(Duration::from_secs(5)).await?;
+    let result = result?;
+
+    let rows: Vec<WorkstreamRow> = serde_json::from_value(
+        result
+            .get("workstreams")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+    )
+    .map_err(|e| anyhow::anyhow!("tcode workstream list: malformed daemon response: {e}"))?;
+    println!("{}", render_workstream_table(&rows));
+    Ok(())
+}
+
+/// `tcode workstream get <ID> [--project P]`.
+///
+/// Why/What: DOC-48 §5.4 specifies JSON output for `get` (unlike `list`'s
+/// table); prints the daemon's raw `workstream.get` result pretty-printed
+/// rather than re-shaping it, so every field the daemon returns is visible.
+pub async fn get(project: &Path, id: &str) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+    let result = client.call("workstream.get", json!({"id": id})).await;
+    client.shutdown(Duration::from_secs(5)).await?;
+    let result = result?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&result)
+            .map_err(|e| anyhow::anyhow!("tcode workstream get: failed to render JSON: {e}"))?
+    );
+    Ok(())
+}
+
+/// `tcode workstream create [--name NAME] [--project P]`.
+///
+/// Why/What: `name` is optional (DOC-48 §5.1: "Name is initially empty");
+/// prints the newly-minted id so a script or the next command in a shell
+/// session can capture it.
+pub async fn create(project: &Path, name: Option<String>) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+    let result = client
+        .call("workstream.create", json!({"name": name}))
+        .await;
+    client.shutdown(Duration::from_secs(5)).await?;
+    let result = result?;
+    let id = result.get("id").and_then(|v| v.as_str()).unwrap_or("?");
+    println!("created workstream {id}");
+    Ok(())
+}
+
+/// `tcode workstream activate <ID> [--force] [--project P]`.
+///
+/// Why/What: see module docs re: deferred auto-streaming. A plain success
+/// reports the new active id (and the prior one, if this was a force
+/// switch); an `ActiveConflict` (`-32008`) is translated by
+/// [`explain_activation_error`] into a message naming the currently-active
+/// workstream and suggesting `--force`, rather than surfacing the daemon's
+/// generic `RpcClientError::Rpc` `Display` text.
+pub async fn activate(project: &Path, id: &str, force: bool) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+    let result = client
+        .call("workstream.activate", json!({"id": id, "force": force}))
+        .await;
+    client.shutdown(Duration::from_secs(5)).await?;
+
+    let value = result.map_err(|e| explain_activation_error(e, id))?;
+    match value.get("prior_id").and_then(|v| v.as_str()) {
+        Some(prior_id) => println!("activated workstream {id} (switched from {prior_id})"),
+        None => println!("activated workstream {id}"),
+    }
+    Ok(())
+}
+
+/// `tcode workstream deactivate [--project P]`.
+///
+/// Why/What: see module docs — DOC-48 §5.4 gives this subcommand no `id`
+/// argument, but `workstream.deactivate` requires one. Resolves it via one
+/// `workstream.list` call reading `active_workstream_id`; if none is active,
+/// this is a documented no-op (printed, not an error), matching
+/// `crate::workstreams::activation::deactivate`'s own idempotent stance.
+pub async fn deactivate(project: &Path) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+
+    let list_result = client.call("workstream.list", json!({})).await;
+    let list_result = match list_result {
+        Ok(v) => v,
+        Err(e) => {
+            client.shutdown(Duration::from_secs(5)).await?;
+            return Err(e.into());
+        }
+    };
+    let active_id = list_result
+        .get("active_workstream_id")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let Some(active_id) = active_id else {
+        client.shutdown(Duration::from_secs(5)).await?;
+        println!("no workstream is active");
+        return Ok(());
+    };
+
+    let result = client
+        .call("workstream.deactivate", json!({"id": active_id}))
+        .await;
+    client.shutdown(Duration::from_secs(5)).await?;
+    result?;
+    println!("deactivated workstream {active_id}");
+    Ok(())
+}
+
+/// `tcode workstream close <ID> [--project P]`.
+///
+/// Why/What: irreversible (DOC-48 §4.4); prints a plain confirmation.
+pub async fn close(project: &Path, id: &str) -> Result<()> {
+    let exe = tcode_exe::resolve()?;
+    let mut client = StdioRpcClient::spawn(&exe, project)?;
+    let result = client.call("workstream.close", json!({"id": id})).await;
+    client.shutdown(Duration::from_secs(5)).await?;
+    result?;
+    println!("closed workstream {id}");
+    Ok(())
+}
+
+/// Turn an `RpcClientError` from `workstream.activate` into a clear message,
+/// special-casing `-32008 active_conflict` (DOC-48 §5.2/§6.1,
+/// `RpcError::active_conflict`'s `{"error_type": "active_conflict",
+/// "active_id": ...}` data shape) to name the currently-active workstream
+/// and suggest `--force`.
+///
+/// Why: the raw `RpcClientError::Rpc` `Display` ("daemon returned an error
+/// (-32008): another workstream is active: <id>") already contains the
+/// active id, but doesn't tell the operator what to DO about it — this is
+/// the one place that turns the wire error into an actionable instruction.
+/// What: pattern-matches `code == -32008`, pulling `active_id` out of the
+/// error's `data` payload; any other error passes through unchanged (`.into()`).
+/// Test: `tests::explain_activation_error_names_the_active_workstream_and_suggests_force`,
+/// `tests::explain_activation_error_passes_through_other_errors`.
+fn explain_activation_error(err: RpcClientError, target_id: &str) -> anyhow::Error {
+    if let RpcClientError::Rpc {
+        code: -32008,
+        ref data,
+        ..
+    } = err
+    {
+        let active_id = data
+            .as_ref()
+            .and_then(|d| d.get("active_id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("<unknown>");
+        return anyhow::anyhow!(
+            "workstream {active_id} is already active; pass --force to switch to {target_id}"
+        );
+    }
+    err.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explain_activation_error_names_the_active_workstream_and_suggests_force() {
+        let err = RpcClientError::Rpc {
+            code: -32008,
+            message: "another workstream is active: a1b2c3d4-e5f6-4748-9a0b-1c2d3e4f5a6b"
+                .to_string(),
+            data: Some(json!({
+                "error_type": "active_conflict",
+                "active_id": "a1b2c3d4-e5f6-4748-9a0b-1c2d3e4f5a6b",
+            })),
+        };
+        let message =
+            explain_activation_error(err, "b2c3d4e5-f6a1-4748-9a0b-1c2d3e4f5a6b").to_string();
+        assert!(
+            message.contains("a1b2c3d4-e5f6-4748-9a0b-1c2d3e4f5a6b"),
+            "must name the currently-active workstream: {message}"
+        );
+        assert!(
+            message.contains("--force"),
+            "must suggest --force: {message}"
+        );
+        assert!(
+            message.contains("b2c3d4e5-f6a1-4748-9a0b-1c2d3e4f5a6b"),
+            "must name the target workstream: {message}"
+        );
+    }
+
+    #[test]
+    fn explain_activation_error_passes_through_other_errors() {
+        let err = RpcClientError::Rpc {
+            code: -32002,
+            message: "workstream not found: nonexistent".to_string(),
+            data: None,
+        };
+        let message = explain_activation_error(err, "nonexistent").to_string();
+        assert!(
+            message.contains("workstream not found"),
+            "a non-active_conflict error must pass through unchanged: {message}"
+        );
+    }
+}

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -10,15 +10,18 @@
 //! What: [`render_session_table`] (a fixed-width table for `session list`),
 //! [`render_event_line`] (one line per streamed [`SessionEventEnvelope`],
 //! used by `attach`/`run-task`), [`render_transcript_human`] (a readable
-//! turn-by-turn view for `transcript`), and [`exit_code_for_status`] (maps a
-//! terminal `SessionStatus` onto the SAME `run_task::ExitCode` values the
-//! legacy in-process `run-task` path already used, so scripts checking `$?`
-//! see a consistent contract regardless of which path produced the run).
+//! turn-by-turn view for `transcript`), [`render_workstream_table`] (a
+//! tmux-`list-sessions`-style table for `tcode workstream list`, #3296), and
+//! [`exit_code_for_status`] (maps a terminal `SessionStatus` onto the SAME
+//! `run_task::ExitCode` values the legacy in-process `run-task` path already
+//! used, so scripts checking `$?` see a consistent contract regardless of
+//! which path produced the run).
 //! Test: `render::tests::*`.
 
 use crate::events::{Event, SessionEventEnvelope};
 use crate::run_task::ExitCode;
 use crate::session::{Session, SessionStatus, TranscriptRecord};
+use crate::workstreams::{WorkstreamId, WorkstreamState};
 
 /// Render a fixed-width table of sessions for `tcode session list`.
 ///
@@ -165,6 +168,109 @@ pub fn render_transcript_human(record: &TranscriptRecord) -> String {
     ));
     out.pop();
     out
+}
+
+/// One row of `workstream.list`'s wire response, as needed to render
+/// [`render_workstream_table`] (#3296, DOC-48 §5.4).
+///
+/// Why: the daemon's `workstream.list` response nests each record as
+/// `crate::workstreams::protocol::WorkstreamView` — private to that module,
+/// and carrying fields (`metadata`, `created_at`) the table never displays.
+/// This is the CLI's own minimal read-only projection of that wire shape;
+/// serde's default "ignore unknown fields" behavior means it deserializes
+/// straight out of the same JSON without the protocol module needing to
+/// expose anything new.
+/// What: `id`/`state` reuse the library's own [`WorkstreamId`]/
+/// [`WorkstreamState`] types (both already `pub` from `crate::workstreams`)
+/// so the table can never disagree with the domain model on what "active"
+/// means; `session_ids` is only read for its length (live session count).
+/// Test: `tests::render_workstream_table_marks_the_active_row`.
+#[derive(Debug, serde::Deserialize)]
+pub struct WorkstreamRow {
+    pub id: WorkstreamId,
+    #[serde(default)]
+    pub name: String,
+    pub state: WorkstreamState,
+    #[serde(default)]
+    pub session_ids: Vec<String>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Render a tmux-`list-sessions`-style table of workstreams for
+/// `tcode workstream list` (DOC-48 §5.4, AC-5.1, issue #3296).
+///
+/// Why: rhymes with `tm`'s session-listing conventions (fixed-width columns,
+/// a leading marker for "the one that's current") WITHOUT importing from
+/// `trusty-mpm` — this crate has no dependency on it, so the shape is
+/// reinvented small and pure here. The leading `*` marker mirrors tmux's own
+/// `list-sessions` attached-session convention, which DOC-48 §5.3 already
+/// cites as the mental model for workstream observation ("tmux-attach-like
+/// behavior").
+/// What: one header line + one row per workstream: a leading `*` on the
+/// active workstream (blank otherwise), an 8-hex-char id prefix (DISPLAY
+/// ONLY — `tcode workstream get`/`activate`/`close` still require the full
+/// id; see `crate::cli::workstream`'s module docs in the `tcode` binary for
+/// why prefix resolution isn't implemented client-side), the computed
+/// state, the live session count, a humanized `updated_at` age, and the
+/// name (`(untitled)` when empty, DOC-48 §5.1: "Name is initially empty").
+/// An empty list renders one explanatory line instead of a bare header.
+/// Test: `tests::render_workstream_table_marks_the_active_row`,
+/// `tests::render_workstream_table_handles_empty_list`.
+pub fn render_workstream_table(rows: &[WorkstreamRow]) -> String {
+    if rows.is_empty() {
+        return "(no workstreams)".to_string();
+    }
+    let mut out = String::from("  ID        STATE   SESSIONS  UPDATED   NAME\n");
+    for r in rows {
+        let marker = if r.state == WorkstreamState::Active {
+            '*'
+        } else {
+            ' '
+        };
+        let id_prefix: String = r.id.to_string().chars().take(8).collect();
+        let name = if r.name.is_empty() {
+            "(untitled)"
+        } else {
+            &r.name
+        };
+        out.push_str(&format!(
+            "{marker} {:<9} {:<7} {:<9} {:<9} {}\n",
+            id_prefix,
+            r.state.to_string(),
+            r.session_ids.len(),
+            humanize_age(r.updated_at),
+            truncate(name, 40),
+        ));
+    }
+    out.pop(); // drop the trailing newline; callers add their own via println!
+    out
+}
+
+/// Render a compact "time ago" string for a past UTC timestamp.
+///
+/// Why: `updated_at`'s raw ISO-8601 timestamp is hard to scan at a glance;
+/// an operator wants "how stale is this workstream" in one short token.
+/// What: buckets the age into `just now` (<60s), `<N>m ago` (<1h), `<N>h ago`
+/// (<24h), `<N>d ago` (<30d), or `<N>w ago` beyond that. Never panics on a
+/// future timestamp (clock skew) — `signed_duration_since` is clamped to a
+/// minimum of zero seconds.
+/// Test: `tests::humanize_age_buckets_common_durations`.
+fn humanize_age(at: chrono::DateTime<chrono::Utc>) -> String {
+    let secs = chrono::Utc::now()
+        .signed_duration_since(at)
+        .num_seconds()
+        .max(0);
+    if secs < 60 {
+        "just now".to_string()
+    } else if secs < 3_600 {
+        format!("{}m ago", secs / 60)
+    } else if secs < 86_400 {
+        format!("{}h ago", secs / 3_600)
+    } else if secs < 30 * 86_400 {
+        format!("{}d ago", secs / 86_400)
+    } else {
+        format!("{}w ago", secs / (7 * 86_400))
+    }
 }
 
 /// Map a terminal `SessionStatus` onto the CLI process exit code.
@@ -352,6 +458,81 @@ mod tests {
         let out = render_transcript_human(&record);
         assert!(out.contains("s-1"));
         assert!(out.contains("has not run"));
+    }
+
+    #[test]
+    fn render_workstream_table_marks_the_active_row() {
+        use uuid::Uuid;
+
+        let active_id =
+            WorkstreamId(Uuid::parse_str("a1b2c3d4-e5f6-4748-9a0b-1c2d3e4f5a6b").unwrap());
+        let idle_id =
+            WorkstreamId(Uuid::parse_str("b2c3d4e5-f6a1-4748-9a0b-1c2d3e4f5a6b").unwrap());
+        let rows = vec![
+            WorkstreamRow {
+                id: active_id,
+                name: "Token rotation hardening".to_string(),
+                state: WorkstreamState::Active,
+                session_ids: vec!["s-1".to_string(), "s-2".to_string()],
+                updated_at: Utc::now(),
+            },
+            WorkstreamRow {
+                id: idle_id,
+                name: String::new(),
+                state: WorkstreamState::Idle,
+                session_ids: vec![],
+                updated_at: Utc::now() - chrono::Duration::hours(2),
+            },
+        ];
+        let table = render_workstream_table(&rows);
+        assert!(
+            table.contains('*'),
+            "active row must carry the marker: {table}"
+        );
+        assert!(
+            table.contains("a1b2c3d4"),
+            "expected the 8-char id prefix: {table}"
+        );
+        assert!(table.contains("active"));
+        assert!(table.contains("Token rotation hardening"));
+        assert!(
+            table.contains("(untitled)"),
+            "an empty name must render a placeholder: {table}"
+        );
+        assert!(
+            table.contains("2h ago"),
+            "expected a humanized age: {table}"
+        );
+        assert!(
+            table.contains('2'),
+            "active row's session count must be 2: {table}"
+        );
+    }
+
+    #[test]
+    fn render_workstream_table_handles_empty_list() {
+        assert_eq!(render_workstream_table(&[]), "(no workstreams)");
+    }
+
+    #[test]
+    fn humanize_age_buckets_common_durations() {
+        assert_eq!(humanize_age(Utc::now()), "just now");
+        assert_eq!(
+            humanize_age(Utc::now() - chrono::Duration::minutes(5)),
+            "5m ago"
+        );
+        assert_eq!(
+            humanize_age(Utc::now() - chrono::Duration::hours(3)),
+            "3h ago"
+        );
+        assert_eq!(
+            humanize_age(Utc::now() - chrono::Duration::days(2)),
+            "2d ago"
+        );
+        assert_eq!(
+            humanize_age(Utc::now() - chrono::Duration::days(45)),
+            "6w ago"
+        );
     }
 
     #[test]

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -15,7 +15,9 @@
 //!
 //! What: thin clap CLI. `serve` (#2053) delegates to
 //! `trusty_code::serve::{run_stdio, run_http}` for its two transports.
-//! `run-workflow` remains a stub.
+//! `run-workflow` remains a stub. `workstream` (`ws` alias, #3296, DOC-48
+//! §5.4) is the same thin-client shape over `workstream.*` — see
+//! [`WorkstreamCommand`] and `crate::cli::workstream`.
 //!
 //! Test: `cargo run -p trusty-code -- --version` must exit 0 and print the
 //! crate version. The thin-client subcommands are covered end-to-end by
@@ -228,6 +230,93 @@ enum Command {
     /// `config keys set/list/test/unset` surface shared by every trusty-*
     /// binary (epic #2400 Wave 1, #2405).
     Config(trusty_common::inference::config::ConfigCommand),
+
+    /// Manage workstreams — durable named groupings of sessions bound to the
+    /// daemon's project (#3296, DOC-48 §5.4). `tcode ws` is a short alias
+    /// for this whole family (DOC-48 AC-5.3).
+    #[command(alias = "ws")]
+    Workstream {
+        #[command(subcommand)]
+        action: WorkstreamCommand,
+    },
+}
+
+/// `tcode workstream <action>` / `tcode ws <action>` subcommands (#3296,
+/// DOC-48 §5.4).
+///
+/// Every variant carries its own `--project` (defaulting to `.`), matching
+/// [`SessionCommand`]/[`Command::Attach`]/[`Command::Cancel`]/
+/// [`Command::Transcript`]'s existing per-leaf convention rather than
+/// hoisting it onto the parent [`Command::Workstream`] variant (clap
+/// subcommand args aren't inherited from an enclosing variant without a
+/// shared flattened struct, which would be a bigger change than this
+/// ticket's scope).
+#[derive(Subcommand)]
+enum WorkstreamCommand {
+    /// List workstreams in the daemon's project (tm-ls-style table; DOC-48
+    /// AC-5.1).
+    List {
+        /// Include closed workstreams (default: false, DOC-48 §4.4).
+        #[arg(long)]
+        include_closed: bool,
+
+        /// Path to the project root the daemon should be rooted at.
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
+
+    /// Show one workstream's full record as JSON.
+    Get {
+        /// The workstream id — a FULL UUID only (prefix-matching is a
+        /// documented future nicety; see `crate::cli::workstream`'s module
+        /// docs for why it isn't implemented client-side today).
+        id: String,
+
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
+
+    /// Create a new workstream.
+    Create {
+        /// Human-readable name (defaults to empty/untitled if omitted).
+        #[arg(long)]
+        name: Option<String>,
+
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
+
+    /// Activate a workstream, making it the daemon's one active workstream
+    /// (DOC-48 §6.1, AC-5.2).
+    Activate {
+        /// The workstream id to activate (full UUID only).
+        id: String,
+
+        /// Force-switch even if a DIFFERENT workstream is currently active
+        /// (deactivates the prior one; DOC-48 §6.1). Without this flag,
+        /// activating while another workstream is active fails with a clear
+        /// message naming the active workstream.
+        #[arg(long)]
+        force: bool,
+
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
+
+    /// Deactivate the currently active workstream, if any (no-op otherwise).
+    Deactivate {
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
+
+    /// Irreversibly close a workstream (DOC-48 §4.4).
+    Close {
+        /// The workstream id to close (full UUID only).
+        id: String,
+
+        #[arg(long, short, value_name = "PATH", default_value = ".")]
+        project: PathBuf,
+    },
 }
 
 /// `tcode session <action>` subcommands (#2060).
@@ -364,6 +453,48 @@ async fn main() -> Result<()> {
         }
 
         Command::Config(cmd) => cmd.run().await,
+
+        Command::Workstream { action } => match action {
+            WorkstreamCommand::List {
+                include_closed,
+                project,
+            } => {
+                let project = canonicalize_project_or_exit(&project, "workstream list");
+                run_thin_client(
+                    cli::workstream::list(&project, include_closed),
+                    "workstream list",
+                )
+                .await
+            }
+            WorkstreamCommand::Get { id, project } => {
+                let project = canonicalize_project_or_exit(&project, "workstream get");
+                run_thin_client(cli::workstream::get(&project, &id), "workstream get").await
+            }
+            WorkstreamCommand::Create { name, project } => {
+                let project = canonicalize_project_or_exit(&project, "workstream create");
+                run_thin_client(cli::workstream::create(&project, name), "workstream create").await
+            }
+            WorkstreamCommand::Activate { id, force, project } => {
+                let project = canonicalize_project_or_exit(&project, "workstream activate");
+                run_thin_client(
+                    cli::workstream::activate(&project, &id, force),
+                    "workstream activate",
+                )
+                .await
+            }
+            WorkstreamCommand::Deactivate { project } => {
+                let project = canonicalize_project_or_exit(&project, "workstream deactivate");
+                run_thin_client(
+                    cli::workstream::deactivate(&project),
+                    "workstream deactivate",
+                )
+                .await
+            }
+            WorkstreamCommand::Close { id, project } => {
+                let project = canonicalize_project_or_exit(&project, "workstream close");
+                run_thin_client(cli::workstream::close(&project, &id), "workstream close").await
+            }
+        },
     }
 }
 

--- a/crates/trusty-code/tests/cli_e2e.rs
+++ b/crates/trusty-code/tests/cli_e2e.rs
@@ -34,7 +34,21 @@
 //! inspection test (attach to a session a DIFFERENT process created) isn't
 //! possible yet: M1 sessions are in-memory, one per ephemeral spawned
 //! daemon, and this ticket's required path is spawn-stdio, not a shared
-//! long-lived daemon.
+//! daemon.
+//!
+//! `workstream_list_on_fresh_project_reports_no_workstreams` through
+//! `workstream_close_hides_from_default_list_but_include_closed_shows_it`
+//! (#3296, DOC-48 §5.4) prove the `tcode workstream`/`tcode ws` family end
+//! to end. UNLIKE sessions, workstreams are persisted to a flat file keyed
+//! on `--project` (`crate::workstreams::path`), so — unlike every
+//! session/attach/cancel/transcript case above — these tests spawn the CLI
+//! TWICE against the same `--project` and prove the SECOND invocation's
+//! ephemeral daemon sees what the FIRST one persisted (create, then a
+//! separate list; close, then a separate list). Each test pins `HOME` to
+//! its own tempdir (`crate::workstreams::path::default_data_dir` resolves
+//! `~/.trusty-code`) so the store file never touches the real developer's
+//! home directory — the same sandboxing `support::home_with_user_level_agents`
+//! already uses for agent resolution.
 //!
 //! Test: this file IS the test; see `support` for the shared
 //! `project_with_agents` fixture.
@@ -336,5 +350,236 @@ fn version_flag_reports_build_provenance() {
     assert!(
         stdout.trim() != format!("tcode {}", env!("CARGO_PKG_VERSION")),
         "--version regressed to a bare semver with no provenance: {stdout}"
+    );
+}
+
+/// `tcode workstream create --name <NAME> --project <project_arg>`, run
+/// against `home`, returning the newly-minted id parsed out of its
+/// `created workstream <id>` confirmation line.
+///
+/// Why: every workstream e2e test below needs at least one persisted
+/// workstream to act on; factored out so each test's setup is one line
+/// instead of a repeated Command/parse block.
+fn create_workstream(home: &std::path::Path, project_arg: &str, name: &str) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "workstream",
+            "create",
+            "--name",
+            name,
+            "--project",
+            project_arg,
+        ])
+        .env("HOME", home)
+        .output()
+        .expect("spawn tcode workstream create");
+    assert!(
+        output.status.success(),
+        "workstream create must exit 0: {output:?}"
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .strip_prefix("created workstream ")
+        .expect("expected the `created workstream <id>` confirmation shape")
+        .to_string()
+}
+
+/// `tcode workstream list` on a project with no prior workstreams must
+/// report none and exit 0 (DOC-48 AC-5.1).
+#[test]
+fn workstream_list_on_fresh_project_reports_no_workstreams() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "workstream",
+            "list",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode workstream list");
+
+    assert!(output.status.success(), "must exit 0: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("no workstreams"),
+        "expected an empty-list message: {stdout}"
+    );
+}
+
+/// `tcode workstream create` persists to a flat file keyed on `--project`
+/// (DOC-48 §3.1) — a SEPARATE `tcode ws list` invocation against the SAME
+/// project must see what a prior, already-exited invocation created. This
+/// also proves the `ws` alias (DOC-48 AC-5.3).
+#[test]
+fn workstream_create_persists_and_ws_alias_lists_it() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let project_arg = project.path().display().to_string();
+
+    create_workstream(home.path(), &project_arg, "Token rotation hardening");
+
+    let list_output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args(["ws", "list", "--project", &project_arg])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode ws list");
+    assert!(
+        list_output.status.success(),
+        "ws list must exit 0: {list_output:?}"
+    );
+    let list_stdout = String::from_utf8_lossy(&list_output.stdout);
+    assert!(
+        list_stdout.contains("Token rotation hardening"),
+        "a SEPARATE invocation against the same --project must see the persisted workstream: {list_stdout}"
+    );
+    assert!(
+        list_stdout.contains("idle"),
+        "a freshly-created workstream must show idle: {list_stdout}"
+    );
+}
+
+/// `tcode workstream get <unknown-uuid>` must surface `not_found` cleanly
+/// and exit nonzero.
+#[test]
+fn workstream_get_unknown_id_errors_cleanly() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "workstream",
+            "get",
+            "00000000-0000-0000-0000-000000000000",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode workstream get");
+
+    assert!(!output.status.success(), "must exit nonzero on not_found");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found") || stderr.contains("-32002"),
+        "expected a clear not_found error on stderr: {stderr}"
+    );
+}
+
+/// `tcode workstream activate` without `--force` while a DIFFERENT
+/// workstream is active must name the active workstream and suggest
+/// `--force`, exiting nonzero (DOC-48 §5.2/§6.1's `ActiveConflict`
+/// scenario, the ONE piece of business logic this CLI ticket's scope
+/// explicitly calls out).
+#[test]
+fn workstream_activate_conflict_names_active_and_suggests_force() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let project_arg = project.path().display().to_string();
+
+    let id_a = create_workstream(home.path(), &project_arg, "A");
+    let id_b = create_workstream(home.path(), &project_arg, "B");
+
+    let activate_a = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args(["workstream", "activate", &id_a, "--project", &project_arg])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode workstream activate a");
+    assert!(
+        activate_a.status.success(),
+        "activating a with no prior active must succeed: {activate_a:?}"
+    );
+
+    let activate_b = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args(["workstream", "activate", &id_b, "--project", &project_arg])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode workstream activate b");
+    assert!(
+        !activate_b.status.success(),
+        "activating b without --force while a is active must fail"
+    );
+    let stderr = String::from_utf8_lossy(&activate_b.stderr);
+    assert!(
+        stderr.contains(&id_a),
+        "must name the currently-active workstream: {stderr}"
+    );
+    assert!(stderr.contains("--force"), "must suggest --force: {stderr}");
+}
+
+/// `tcode workstream deactivate` with no active workstream is a documented
+/// no-op (DOC-48 §4.3) — must print a clear message and exit 0, never an
+/// error.
+#[test]
+fn workstream_deactivate_with_none_active_is_a_clean_noop() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "workstream",
+            "deactivate",
+            "--project",
+            &project.path().display().to_string(),
+        ])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode workstream deactivate");
+
+    assert!(output.status.success(), "must exit 0: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("no workstream is active"),
+        "expected a clear no-op message: {stdout}"
+    );
+}
+
+/// `tcode workstream close` then `tcode workstream list` (default) must hide
+/// the closed workstream; `--include-closed` must still show it (DOC-48
+/// §4.4).
+#[test]
+fn workstream_close_hides_from_default_list_but_include_closed_shows_it() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let project_arg = project.path().display().to_string();
+
+    let id = create_workstream(home.path(), &project_arg, "Old spike");
+
+    let close_output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args(["workstream", "close", &id, "--project", &project_arg])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode workstream close");
+    assert!(
+        close_output.status.success(),
+        "close must exit 0: {close_output:?}"
+    );
+
+    let default_list = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args(["workstream", "list", "--project", &project_arg])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode workstream list");
+    let default_stdout = String::from_utf8_lossy(&default_list.stdout);
+    assert!(
+        !default_stdout.contains("Old spike"),
+        "closed workstream must be hidden from the default list: {default_stdout}"
+    );
+
+    let include_closed_list = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args([
+            "workstream",
+            "list",
+            "--include-closed",
+            "--project",
+            &project_arg,
+        ])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn tcode workstream list --include-closed");
+    let include_closed_stdout = String::from_utf8_lossy(&include_closed_list.stdout);
+    assert!(
+        include_closed_stdout.contains("Old spike") && include_closed_stdout.contains("closed"),
+        "include-closed list must show the closed workstream: {include_closed_stdout}"
     );
 }


### PR DESCRIPTION
## Summary

Adds the `tcode workstream` / `tcode ws` CLI family (DOC-48 §5.4, epic #3292) as thin JSON-RPC clients over the already-merged `workstream.*` daemon surface (#3294 activation-lock, #3295 CRUD) — no orchestration logic lives client-side, matching the existing `session`/`attach`/`cancel`/`transcript` pattern in `crates/trusty-code/src/cli/`.

- `tcode workstream list [--include-closed]` — tmux-`list-sessions`-style table (id prefix, state, live session count, humanized age, name); `*` marks the active row. `tcode workstream get <id>` — raw JSON.
- `tcode workstream create [--name NAME]`
- `tcode workstream activate <id> [--force]` — an `ActiveConflict` (`-32008`) without `--force` is translated into a clear message naming the currently-active workstream and suggesting `--force`, instead of the daemon's raw RPC error text.
- `tcode workstream deactivate` (no id — resolves and clears whichever workstream is active; a clean no-op message if none is)
- `tcode workstream close <id>`
- `tcode ws` is a clap alias for the whole family (DOC-48 AC-5.3).

Unlike sessions (in-memory, per ephemeral daemon spawn), workstreams are persisted to a flat file keyed on `--project`, so two separate CLI invocations against the same project see each other's state — proven by the e2e tests spawning the CLI twice per scenario.

## Spec anchors

- DOC-48 §5.4 (`SPEC-WS-05~draft`) — CLI surface definition
- DOC-48 §6.1 (`SPEC-WS-06~draft`) — activation-lock exclusivity / `ActiveConflict`
- AC-5.1/5.2/5.3 — `docs/specs/DOC-48-tcode-workstreams.md`

Part of #3292.

## Ambiguities resolved

- **`deactivate` has no `--id` in the CLI surface, but `workstream.deactivate` requires one at the RPC layer.** Resolved by having the handler call `workstream.list` first to read `active_workstream_id`, then deactivate that id (a one-shot list-then-act, not a prefix-matching feature) — documented in `cli::workstream`'s module docs.
- **DOC-48 §5.4 says `tcode ws activate` should auto-start streaming events from the new active workstream.** The workstream-level SSE aggregation route (`GET /workstreams/{id}/events`, issue #3297) is explicitly out of THIS ticket's scope per `crate::workstreams::protocol`'s own module docs, and isn't reachable over the stdio JSON-RPC transport the CLI uses regardless (SSE is HTTP-only). `activate` performs the RPC call and reports the outcome; auto-streaming is deferred until #3297 lands a route this handler can call.
- **ID prefix-matching**: not implemented — the RPC layer's `parse_id` is a plain `Uuid::parse_str` with no prefix support, so a client-side "list, then match a prefix" resolver would just race concurrent creates/closes for a cosmetic convenience. `tcode workstream get/activate/close` all require the full UUID; only the rendered `list` table shows a display-only 8-char prefix. Documented as a future nicety.

## Gates (raw tails)

```
$ cargo check -p trusty-code
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.02s

$ cargo test -p trusty-code --lib -- --test-threads=1
test result: ok. 1308 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 8.97s

$ cargo test -p trusty-code --bins
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

$ cargo test -p trusty-code --test cli_e2e
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.38s

$ cargo clippy -p trusty-code --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.99s   (zero warnings)

$ cargo fmt --check -p trusty-code
(clean, exit 0)

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 38 spec doc(s) + 2597 code file(s); 0 error(s), 0 warning(s)
```

Note: `cargo test -p trusty-code` (default parallel threads) intermittently fails ONE unrelated `run_task::tests::*` test (a different one each run) due to a real local `trusty-memory` daemon on `127.0.0.1:7070` interfering with parallel test execution — pre-existing/environmental, reproduced on a clean `git stash` of this branch's diff, and passes 100% clean single-threaded (see tail above). No file this PR touches is anywhere near `run_task`.

## Sample output

```
$ tcode workstream create --name "Token rotation hardening" --project .
created workstream 7c8166b1-1c67-4d54-b97d-3630c7723eb1
$ tcode workstream create --name "Auth refactoring" --project .
created workstream 1306ed13-1552-4fc5-8b6f-3751c9c94939
$ tcode ws activate 7c8166b1-1c67-4d54-b97d-3630c7723eb1 --project .
activated workstream 7c8166b1-1c67-4d54-b97d-3630c7723eb1
$ tcode ws list --project .
  ID        STATE   SESSIONS  UPDATED   NAME
* 7c8166b1  active  0         just now  Token rotation hardening
  1306ed13  idle    0         just now  Auth refactoring
$ tcode ws activate 1306ed13-1552-4fc5-8b6f-3751c9c94939 --project .
workstream 7c8166b1-1c67-4d54-b97d-3630c7723eb1 is already active; pass --force to switch to 1306ed13-1552-4fc5-8b6f-3751c9c94939
$ tcode ws activate 1306ed13-1552-4fc5-8b6f-3751c9c94939 --force --project .
activated workstream 1306ed13-1552-4fc5-8b6f-3751c9c94939 (switched from 7c8166b1-1c67-4d54-b97d-3630c7723eb1)
$ tcode ws get 7c8166b1-1c67-4d54-b97d-3630c7723eb1 --project .
{
  "created_at": "2026-07-19T16:49:40.155359Z",
  "id": "7c8166b1-1c67-4d54-b97d-3630c7723eb1",
  "metadata": {},
  "name": "Token rotation hardening",
  "session_ids": [],
  "state": "idle",
  "updated_at": "2026-07-19T16:49:40.155359Z"
}
```

## Test plan

- [x] `cargo test -p trusty-code --lib` (single-threaded) — 1308 passed
- [x] `cargo test -p trusty-code --bins` — 5 passed (incl. 2 new `explain_activation_error` unit tests)
- [x] `cargo test -p trusty-code --test cli_e2e` — 14 passed (8 pre-existing + 6 new workstream e2e tests: empty list, create+ws-alias-list persistence, get-unknown-errors, activate-conflict message, deactivate-noop, close+include-closed)
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-code` — clean
- [x] `scripts/check_line_cap.sh` / `check_test_pointers.sh` / `check_sld.sh` — clean
- [x] Manual smoke test of the full list/create/activate/conflict/force/get/deactivate/close flow (see sample output above)

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)