### PR TITLE
feat(trusty-code): workstream SSE event aggregation route (closes #3297)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Workstream SSE event aggregation route (issue #3297, DOC-48 §5.3/§5.3.1,
+  epic #3292).** New `GET /workstreams/{id}/events` endpoint: fans out over a
+  workstream's bound `session_ids`, replaying then live-streaming each
+  session's events tagged with the generic `{session_id, event_type,
+  payload}` envelope, merged with a new daemon-global workstream-level bus
+  carrying `WorkstreamActivationChanged`/`WorkstreamStateInferred` — both now
+  published by `workstream.activate`/`.../deactivate`/`.../close`. 404s for an
+  unknown workstream; a zero-session workstream keeps the stream open,
+  emitting workstream-level events only. The fan-out/merge layer
+  (`workstreams::events::{SessionEventSource, aggregate}`) is designed
+  against an abstract session-id trait (AC-7.1) so it can be lifted into
+  `trusty-agents-common` (#3299) without rework. `SessionAdded`/
+  `SessionActivityUpdate` and dynamic (post-subscribe) membership changes are
+  deferred to #3298 (session binding), documented in the module.
 - **Workstream activation lock: `workstream.activate`/`workstream.deactivate`
   RPC + REST, `ActiveConflict` (issue #3294, DOC-48 §5/§6, epic #3292).**
   Daemon-enforced singleton active-workstream invariant on top of #3293's

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -95,12 +95,14 @@ struct HttpState {
 /// `POST /sessions/{id}/messages`, `POST /sessions/{id}/cancel`,
 /// `PUT`/`DELETE /sessions/{id}/goal`), (Slice 4) `POST /tasks`, (Slice 5)
 /// `GET /fs`, (Slice 6) `GET /sessions/{id}/agents`, (Slice 7, issue #3072)
-/// `GET /sessions/{id}/search-audit`, and the full `workstream.*` REST
+/// `GET /sessions/{id}/search-audit`, the full `workstream.*` REST
 /// surface: `POST /workstreams`, `GET /workstreams/{id}`, `GET /workstreams`,
 /// `POST /workstreams/{id}/close` (issue #3295) plus
 /// `POST /workstreams/{id}/activate`/`.../deactivate` (DOC-48 §5.2, issue
-/// #3294) — none of which collide with the paths registered directly on
-/// this router or with each other.
+/// #3294), and (issue #3297) `GET /workstreams/{id}/events` (the
+/// workstream-level SSE aggregation route, `rest::workstream_events`) — none
+/// of which collide with the paths registered directly on this router or
+/// with each other.
 /// Test: `http_rpc_ping_returns_pong`,
 /// `http_rpc_malformed_json_returns_parse_error`,
 /// `http_health_matches_jsonrpc_health_payload`,
@@ -112,11 +114,12 @@ struct HttpState {
 /// `http_rest_get_session_agents_route_is_merged_in`,
 /// `http_rest_get_session_budget_route_is_merged_in`,
 /// `http_rest_get_session_search_audit_route_is_merged_in`,
-/// `http_rest_get_workstreams_route_is_merged_in`.
+/// `http_rest_get_workstreams_route_is_merged_in`,
+/// `http_rest_get_workstream_events_route_is_merged_in`.
 pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) -> AxumRouter {
     let state = HttpState {
         router: router.clone(),
-        sessions,
+        sessions: sessions.clone(),
     };
     let core = AxumRouter::new()
         .route("/rpc", post(rpc_handler))
@@ -130,7 +133,8 @@ pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) ->
         .merge(rest::fs::routes(router.clone()))
         .merge(rest::agents::routes(router.clone()))
         .merge(rest::search_audit::routes(router.clone()))
-        .merge(rest::workstreams::routes(router));
+        .merge(rest::workstreams::routes(router.clone()))
+        .merge(rest::workstream_events::routes(router, sessions));
     trusty_common::server::with_standard_middleware(app)
 }
 
@@ -655,6 +659,24 @@ mod tests {
         assert_eq!(v["search_audit"].as_array().unwrap().len(), 0);
     }
 
+    /// Build a router with only `workstream.*` registered, plus a fresh
+    /// `SessionRegistry` — shared by the two merge-only tests below (issues
+    /// #3295/#3297), since neither needs `methods`/`session` wired.
+    async fn workstream_router_and_sessions() -> (Arc<Router>, Arc<SessionRegistry>) {
+        let sessions = Arc::new(SessionRegistry::new());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store =
+            crate::workstreams::WorkstreamStore::load(dir.path().join("workstreams-test.json"))
+                .await
+                .expect("load");
+        let mut router = Router::new();
+        crate::workstreams::protocol::register(
+            &mut router,
+            Arc::new(tokio::sync::Mutex::new(store)),
+        );
+        (Arc::new(router), sessions)
+    }
+
     /// `GET /workstreams` (issue #3295, `rest::workstreams`'s route group
     /// `build_axum_router` merges above) must be reachable on the SAME
     /// router `GET /sessions/{id}/events` is — proving the merge actually
@@ -663,20 +685,8 @@ mod tests {
     /// `rest::workstreams::tests`; this test only pins the merge itself.
     #[tokio::test]
     async fn http_rest_get_workstreams_route_is_merged_in() {
-        let sessions = Arc::new(SessionRegistry::new());
-        let dir = tempfile::tempdir().expect("tempdir");
-        let store =
-            crate::workstreams::WorkstreamStore::load(dir.path().join("workstreams-test.json"))
-                .await
-                .expect("load");
-        let mut router = Router::new();
-        crate::serve::methods::register(&mut router);
-        crate::session::protocol::register(&mut router, sessions.clone());
-        crate::workstreams::protocol::register(
-            &mut router,
-            Arc::new(tokio::sync::Mutex::new(store)),
-        );
-        let app = build_axum_router(Arc::new(router), sessions);
+        let (router, sessions) = workstream_router_and_sessions().await;
+        let app = build_axum_router(router, sessions);
 
         let resp = app
             .oneshot(
@@ -692,6 +702,34 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert!(v["workstreams"].is_array());
+    }
+
+    /// `GET /workstreams/{id}/events` (issue #3297, `rest::workstream_events`'s
+    /// route group `build_axum_router` merges above) must be reachable on the
+    /// SAME router `GET /sessions/{id}/events` is — proving the merge wires
+    /// `rest::workstream_events::routes` rather than silently dropping it (a
+    /// JSON-RPC error BODY, not axum's bare no-route 404, is the proof of
+    /// dispatch). Fan-out/tagging/200 behaviour is covered by
+    /// `rest::workstream_events::tests`; this test only pins the merge.
+    #[tokio::test]
+    async fn http_rest_get_workstream_events_route_is_merged_in() {
+        let (router, sessions) = workstream_router_and_sessions().await;
+        let app = build_axum_router(router, sessions);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/workstreams/00000000-0000-0000-0000-000000000000/events")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32002);
     }
 
     /// `GET /sessions/{id}/events` on an unknown session must 404 with a

--- a/crates/trusty-code/src/serve/rest/mod.rs
+++ b/crates/trusty-code/src/serve/rest/mod.rs
@@ -53,7 +53,10 @@
 //! #3292) and `POST /workstreams/{id}/activate`,
 //! `POST /workstreams/{id}/deactivate` (DOC-48 §5.2/§6, issue #3294) — see
 //! its module docs for why the paths are unprefixed rather than DOC-48
-//! §5.2's literal `/api/v1/workstreams`. Every slice reuses
+//! §5.2's literal `/api/v1/workstreams`. [`workstream_events`] (issue #3297)
+//! adds the one SSE route, `GET /workstreams/{id}/events` — the only route in
+//! this gateway that isn't a plain [`respond`] wrapper, since it composes
+//! `crate::workstreams::events::aggregate` instead. Every other slice reuses
 //! [`respond`]/[`throwaway_ctx`] rather than reimplementing the glue.
 //!
 //! Test: `tests::*` — a success round-trip, an error round-trip, and one
@@ -66,6 +69,7 @@ pub mod search_audit;
 pub mod sessions;
 pub mod sessions_write;
 pub mod tasks;
+pub mod workstream_events;
 pub mod workstreams;
 
 use axum::Json;

--- a/crates/trusty-code/src/serve/rest/workstream_events.rs
+++ b/crates/trusty-code/src/serve/rest/workstream_events.rs
@@ -1,0 +1,314 @@
+//! `GET /workstreams/{id}/events` — workstream-level SSE aggregation route
+//! (DOC-48 §5.3, issue #3297, epic #3292).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-WS-05~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-05~draft) §5.3
+//! - [`SPEC-WS-07~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-07~draft) AC-7
+//!
+//! Why: `crate::serve::http::session_events_sse` is the per-session SSE
+//! primitive (replay + live, session-scoped per AC-7.3); this route composes
+//! it into a single per-WORKSTREAM stream by fanning out over the
+//! workstream's bound `session_ids` (§5.3 steps 1-3) via
+//! `crate::workstreams::events::aggregate`, merged with the daemon-global
+//! workstream-level bus (`WorkstreamActivationChanged`/
+//! `WorkstreamStateInferred`). Kept in its own file (mirroring every other
+//! `rest::*` resource group) rather than inline in `crate::serve::http` —
+//! that file is already near this crate's 500-SLOC production-file cap.
+//! Looks the workstream up via [`super::call`] against the already-registered
+//! `workstream.get` RPC method (not `WorkstreamStore` directly) so a REST-only
+//! client and this SSE route can never disagree about what "the workstream's
+//! current session_ids" means, and so this route needs no new plumbing to
+//! reach the store beyond the `Arc<Router>` every other `rest::*` group
+//! already receives.
+//!
+//! What: [`routes`] builds a standalone `axum::Router<()>` (its own
+//! `WorkstreamEventsState { router, sessions }`, `with_state`-erased) mapping
+//! `GET /workstreams/{id}/events` to [`workstream_events_sse`]. 404 (mapped
+//! from `workstream.get`'s `-32002 not_found`) if the workstream doesn't
+//! exist; otherwise an SSE stream that never terminates on its own (client
+//! disconnect is "detach", exactly like `session_events_sse`) — including for
+//! a workstream with an EMPTY `session_ids` (§5.3: "stream stays open,
+//! workstream-level events only", proven by
+//! `tests::zero_session_workstream_stream_stays_open`).
+//!
+//! `crate::serve::http::build_axum_router` merges this in alongside every
+//! other REST resource group.
+//! Test: `tests::*`.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
+use axum::routing::get;
+use axum::{Json, Router as AxumRouter};
+use futures_util::{Stream, StreamExt};
+use serde_json::json;
+use trusty_common::mcp::Response;
+
+use crate::jsonrpc::Router;
+use crate::session::SessionRegistry;
+use crate::workstreams::events::{
+    RegistrySessionEventSource, WorkstreamEventEnvelope, aggregate, subscribe_workstream_bus,
+};
+
+use super::{call, rpc_error_to_status, throwaway_ctx};
+
+/// Shared axum state: the JSON-RPC router (to resolve the workstream via
+/// `workstream.get`) and the session registry (the concrete
+/// [`RegistrySessionEventSource`] this route's fan-out reads from).
+#[derive(Clone)]
+struct WorkstreamEventsState {
+    router: Arc<Router>,
+    sessions: Arc<SessionRegistry>,
+}
+
+/// Build the `GET /workstreams/{id}/events` route group.
+///
+/// Why: kept separate from `crate::serve::rest::workstreams` (the CRUD/
+/// activation REST group) since this route needs `Arc<SessionRegistry>` in
+/// its state alongside the router, unlike every other `workstream.*` REST
+/// handler (which only ever calls through [`super::respond`]).
+/// Test: `tests::*`.
+pub fn routes(router: Arc<Router>, sessions: Arc<SessionRegistry>) -> AxumRouter {
+    AxumRouter::new()
+        .route("/workstreams/{id}/events", get(workstream_events_sse))
+        .with_state(WorkstreamEventsState { router, sessions })
+}
+
+/// `GET /workstreams/{id}/events` handler (DOC-48 §5.3).
+///
+/// Why: see module docs for the fan-out architecture.
+/// What: 404 with a JSON-RPC error envelope if `id` names no workstream
+/// (`workstream.get` -> `-32002 not_found`, mapped via
+/// [`rpc_error_to_status`]). Otherwise reads the workstream's current
+/// `session_ids` from that SAME `workstream.get` response (a snapshot at
+/// subscribe time — see `crate::workstreams::events` module docs for why
+/// membership is static-at-subscribe-time in this ticket), builds one
+/// [`RegistrySessionEventSource`]-backed stream per bound session plus the
+/// workstream-level bus stream, and merges them via
+/// `crate::workstreams::events::aggregate` into one SSE response.
+/// Test: `tests::events_route_streams_replay_from_bound_session`,
+/// `tests::events_route_unknown_workstream_returns_404`,
+/// `tests::zero_session_workstream_stream_stays_open`.
+async fn workstream_events_sse(
+    State(state): State<WorkstreamEventsState>,
+    Path(workstream_id): Path<String>,
+) -> Result<Sse<impl Stream<Item = Result<SseEvent, Infallible>>>, (StatusCode, Json<Response>)> {
+    let ws = call(
+        &state.router,
+        "workstream.get",
+        json!({"id": workstream_id}),
+        &throwaway_ctx(),
+    )
+    .await
+    .map_err(|e| {
+        let status = rpc_error_to_status(&e);
+        (status, Json(Response::err(None, e.code, e.message)))
+    })?;
+
+    let session_ids: Vec<String> = ws["session_ids"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let source = RegistrySessionEventSource::new(state.sessions.clone());
+    let merged = aggregate(&source, &session_ids, subscribe_workstream_bus());
+
+    Ok(
+        Sse::new(merged.map(|envelope| Ok(sse_event_for(&envelope))))
+            .keep_alive(KeepAlive::default()),
+    )
+}
+
+/// Serialise one [`WorkstreamEventEnvelope`] as an SSE `data:` frame —
+/// mirrors `crate::serve::http::sse_event_for`'s fallback-on-serialize-error
+/// convention.
+fn sse_event_for(envelope: &WorkstreamEventEnvelope) -> SseEvent {
+    SseEvent::default()
+        .json_data(envelope)
+        .unwrap_or_else(|_| SseEvent::default().data("{}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::util::ServiceExt;
+
+    fn build(sessions: Arc<SessionRegistry>, workstreams_router: Router) -> AxumRouter {
+        routes(Arc::new(workstreams_router), sessions)
+    }
+
+    async fn router_with_workstream() -> (AxumRouter, String, Arc<SessionRegistry>) {
+        let sessions = Arc::new(SessionRegistry::new());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store =
+            crate::workstreams::WorkstreamStore::load(dir.path().join("workstreams-test.json"))
+                .await
+                .expect("load");
+        std::mem::forget(dir);
+        let mut router = Router::new();
+        crate::workstreams::protocol::register(
+            &mut router,
+            Arc::new(tokio::sync::Mutex::new(store)),
+        );
+        let id = call(
+            &router,
+            "workstream.create",
+            json!({"name": "t"}),
+            &throwaway_ctx(),
+        )
+        .await
+        .expect("create")["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let app = build(sessions.clone(), router);
+        (app, id, sessions)
+    }
+
+    /// A workstream with no bound sessions must still return `200` and keep
+    /// the stream open, per DOC-48 §5.3 — proven by reading a bounded prefix
+    /// (a `keep-alive` comment ping) rather than the whole (never-ending)
+    /// body.
+    #[tokio::test]
+    async fn zero_session_workstream_stream_stays_open() {
+        let (app, id, _sessions) = router_with_workstream().await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/workstreams/{id}/events"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        // Publish a workstream-level event and confirm it reaches this
+        // response body — proves the stream is genuinely live, not merely
+        // "200 then immediately closed".
+        let marker = crate::workstreams::WorkstreamId::new();
+        crate::workstreams::events::publish_activation_changed(marker, None);
+
+        let mut stream = resp.into_body().into_data_stream();
+        let mut collected = Vec::new();
+        let read = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !String::from_utf8_lossy(&collected).contains(&marker.to_string()) {
+                match stream.next().await {
+                    Some(Ok(chunk)) => collected.extend_from_slice(&chunk),
+                    _ => break,
+                }
+            }
+        })
+        .await;
+        assert!(read.is_ok(), "timed out waiting for the marker event");
+    }
+
+    /// An unknown workstream id must 404 with the `workstream.get` mapped
+    /// error, not a 200-wrapped envelope.
+    #[tokio::test]
+    async fn events_route_unknown_workstream_returns_404() {
+        let (app, _id, _sessions) = router_with_workstream().await;
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/workstreams/00000000-0000-0000-0000-000000000000/events")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// A workstream with a bound session must fan out that session's replay,
+    /// tagged with its `session_id`, into the merged SSE stream.
+    ///
+    /// Why: `session.create(workstream_id)` binding (#3298) does not exist
+    /// yet — see `crate::workstreams::events` module docs — so this test
+    /// seeds `Workstream::session_ids` directly (a `pub` field on the real
+    /// domain type) via a hand-written store file, mirroring
+    /// `crate::serve::mod::tests::build_router_reconciles_dangling_active_pointer_on_boot`'s
+    /// established "seed the raw store file, then load it for real"
+    /// pattern. This proves the ROUTE'S fan-out over real `session_ids`
+    /// end-to-end; `crate::workstreams::events::events_tests` already proves
+    /// `aggregate`/`RegistrySessionEventSource` in isolation.
+    #[tokio::test]
+    async fn events_route_streams_replay_from_bound_session() {
+        let sessions = Arc::new(SessionRegistry::new());
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let mut ws = crate::workstreams::Workstream::new("bound");
+        ws.session_ids.push(session.id.clone());
+        let ws_id = ws.id;
+        let raw = json!({
+            "version": "1.0",
+            "active_workstream_id": serde_json::Value::Null,
+            "workstreams": [ws],
+        });
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store_path = dir.path().join("workstreams-test.json");
+        tokio::fs::write(&store_path, serde_json::to_string_pretty(&raw).unwrap())
+            .await
+            .expect("seed raw store file with a bound session");
+
+        let store = crate::workstreams::WorkstreamStore::load(store_path)
+            .await
+            .expect("load seeded store");
+        let mut router = Router::new();
+        crate::workstreams::protocol::register(
+            &mut router,
+            Arc::new(tokio::sync::Mutex::new(store)),
+        );
+        let app = build(sessions, router);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/workstreams/{ws_id}/events"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let mut stream = resp.into_body().into_data_stream();
+        let mut collected = Vec::new();
+        let want = format!("\"session_id\":\"{}\"", session.id);
+        let read = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            while !String::from_utf8_lossy(&collected).contains(&want) {
+                match stream.next().await {
+                    Some(Ok(chunk)) => collected.extend_from_slice(&chunk),
+                    _ => break,
+                }
+            }
+        })
+        .await;
+        let text = String::from_utf8_lossy(&collected).to_string();
+        assert!(
+            read.is_ok(),
+            "timed out waiting for the bound session's tagged event; body so far: {text}"
+        );
+        assert!(
+            text.contains("\"event_type\":\"session_started\""),
+            "{text}"
+        );
+    }
+}

--- a/crates/trusty-code/src/workstreams/activation.rs
+++ b/crates/trusty-code/src/workstreams/activation.rs
@@ -39,6 +39,20 @@
 //!     from "never existed" without an extra lookup the spec does not ask
 //!     for).
 //!
+//! (Issue #3297) Every branch that ACTUALLY flips the persisted active
+//! pointer also publishes onto [`super::events`]'s workstream-level bus —
+//! never the idempotent re-activation branch, since nothing transitioned
+//! there (AC-3.3 says clients learn when the active workstream CHANGES, and
+//! re-activating yourself is not a change): `WorkstreamActivationChanged`
+//! (`{new_active_id, prior_id}`, DOC-48 §5.3's table — `prior_id` only
+//! `Some` on a force-switch) and `WorkstreamStateInferred` once per
+//! workstream whose computed state actually transitioned (the newly-active
+//! id always, plus the prior id on a force-switch, since it moves `Active`
+//! -> `Idle`). [`deactivate`] publishes only `WorkstreamStateInferred` (no
+//! `WorkstreamActivationChanged` — the spec's `new_active_id` field is a
+//! required `UUID`, not optional, so the event models "switched to a
+//! specific new workstream", not "nothing is active now").
+//!
 //! Test: `activation_tests`.
 
 use std::sync::Arc;
@@ -46,7 +60,8 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::Mutex;
 
-use super::model::WorkstreamId;
+use super::events::{publish_activation_changed, publish_state_inferred};
+use super::model::{WorkstreamId, WorkstreamState};
 use super::store::{StoreError, WorkstreamStore};
 
 /// Shared, lock-wrapped handle to a project's workstream store.
@@ -115,11 +130,17 @@ pub struct ActivateOutcome {
 /// `force: false` -> `ActivationError::ActiveConflict`; a DIFFERENT
 /// workstream active and `force: true` -> persist the switch, `prior_id:
 /// Some(previous)`.
+/// (Issue #3297) publishes `WorkstreamActivationChanged` + one
+/// `WorkstreamStateInferred` per transitioned workstream on every branch
+/// EXCEPT the idempotent re-activation — see module docs.
 /// Test: `activation_tests::activate_with_no_prior_active_succeeds`,
 /// `activation_tests::activate_already_active_is_idempotent`,
 /// `activation_tests::activate_without_force_returns_active_conflict`,
 /// `activation_tests::activate_with_force_switches_and_reports_prior`,
-/// `activation_tests::activate_unknown_id_returns_not_found`.
+/// `activation_tests::activate_unknown_id_returns_not_found`,
+/// `activation_tests::activate_publishes_activation_changed_and_state_inferred`,
+/// `activation_tests::activate_idempotent_does_not_publish`,
+/// `activation_tests::activate_force_switch_publishes_state_inferred_for_both`.
 pub async fn activate(
     store: &SharedWorkstreamStore,
     id: WorkstreamId,
@@ -140,6 +161,9 @@ pub async fn activate(
         Some(active) if !force => Err(ActivationError::ActiveConflict(active)),
         Some(active) => {
             store.set_active(Some(id)).await?;
+            publish_activation_changed(id, Some(active));
+            publish_state_inferred(id, WorkstreamState::Active, "activated (force-switch)");
+            publish_state_inferred(active, WorkstreamState::Idle, "deactivated (force-switch)");
             Ok(ActivateOutcome {
                 active_id: id,
                 prior_id: Some(active),
@@ -147,6 +171,8 @@ pub async fn activate(
         }
         None => {
             store.set_active(Some(id)).await?;
+            publish_activation_changed(id, None);
+            publish_state_inferred(id, WorkstreamState::Active, "activated");
             Ok(ActivateOutcome {
                 active_id: id,
                 prior_id: None,
@@ -163,9 +189,12 @@ pub async fn activate(
 /// when `id` is the CURRENTLY active workstream; otherwise a no-op success
 /// returning `None` — deactivating an idle, closed, or even nonexistent id
 /// is idempotent by design (§4.3), so this never looks the id up in
-/// `workstreams[]` at all.
+/// `workstreams[]` at all. (Issue #3297) publishes `WorkstreamStateInferred`
+/// only on the actual-deactivation branch — see module docs for why no
+/// `WorkstreamActivationChanged` fires here.
 /// Test: `activation_tests::deactivate_active_clears_pointer`,
-/// `activation_tests::deactivate_non_active_is_idempotent_noop`.
+/// `activation_tests::deactivate_non_active_is_idempotent_noop`,
+/// `activation_tests::deactivate_publishes_state_inferred`.
 pub async fn deactivate(
     store: &SharedWorkstreamStore,
     id: WorkstreamId,
@@ -173,6 +202,7 @@ pub async fn deactivate(
     let mut store = store.lock().await;
     if store.active_workstream_id().await? == Some(id) {
         store.set_active(None).await?;
+        publish_state_inferred(id, WorkstreamState::Idle, "deactivated");
         Ok(Some(id))
     } else {
         Ok(None)

--- a/crates/trusty-code/src/workstreams/activation_tests.rs
+++ b/crates/trusty-code/src/workstreams/activation_tests.rs
@@ -1,8 +1,38 @@
 //! Tests for `activation::activate`/`activation::deactivate` (DOC-48 §6,
-//! issue #3294).
+//! issue #3294; #3297's activation-changed/state-inferred publication).
 
-use super::*;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use serde_json::json;
 use tempfile::tempdir;
+
+use super::super::events::{EventStream, WorkstreamEventEnvelope, subscribe_workstream_bus};
+use super::*;
+
+/// Read `stream` until an envelope satisfying `matches` arrives, or `None`
+/// if none does within `timeout` — used both to assert a specific event WAS
+/// published (expect `Some`) and that one was NOT (expect `None`), since
+/// `WORKSTREAM_BUS` is process-global and other tests publish concurrently
+/// (mirrors `crate::events_tests`' established tolerance for that sharing;
+/// filtering on a real `WorkstreamId` generated fresh per test keeps this
+/// deterministic against cross-test noise).
+async fn recv_matching(
+    stream: &mut EventStream,
+    timeout: Duration,
+    matches: impl Fn(&WorkstreamEventEnvelope) -> bool,
+) -> Option<WorkstreamEventEnvelope> {
+    tokio::time::timeout(timeout, async {
+        loop {
+            let env = stream.next().await.expect("bus must not close");
+            if matches(&env) {
+                return env;
+            }
+        }
+    })
+    .await
+    .ok()
+}
 
 /// Build a fresh [`SharedWorkstreamStore`] backed by a tempfile path (never
 /// created ahead of time — `WorkstreamStore::load` treats a missing file as
@@ -168,4 +198,101 @@ async fn activate_persists_across_store_reload() {
         Some(id),
         "active pointer must persist across a fresh load"
     );
+}
+
+/// A fresh activation (no prior active workstream) must publish both
+/// `WorkstreamActivationChanged{new_active_id: id, prior_id: null}` and
+/// `WorkstreamStateInferred{workstream_id: id, state: active}` (issue #3297).
+#[tokio::test]
+async fn activate_publishes_activation_changed_and_state_inferred() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, "a").await;
+    let mut stream = subscribe_workstream_bus();
+
+    activate(&store, id, false).await.expect("activate");
+
+    let changed = recv_matching(&mut stream, Duration::from_secs(2), |e| {
+        e.event_type == "workstream_activation_changed" && e.payload["new_active_id"] == json!(id)
+    })
+    .await
+    .expect("expected WorkstreamActivationChanged");
+    assert_eq!(changed.payload["prior_id"], serde_json::Value::Null);
+
+    let inferred = recv_matching(&mut stream, Duration::from_secs(2), |e| {
+        e.event_type == "workstream_state_inferred" && e.payload["workstream_id"] == json!(id)
+    })
+    .await
+    .expect("expected WorkstreamStateInferred");
+    assert_eq!(inferred.payload["state"], json!("active"));
+}
+
+/// Re-activating the ALREADY-active workstream must publish NOTHING onto the
+/// workstream bus — it is not a state transition (AC-3.3: clients learn when
+/// the active workstream CHANGES).
+#[tokio::test]
+async fn activate_idempotent_does_not_publish() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, "a").await;
+    activate(&store, id, false).await.expect("first activate");
+
+    // Subscribe only AFTER the first (real) activation, so its own events
+    // are never seen here — only the second, idempotent call is observed.
+    let mut stream = subscribe_workstream_bus();
+    activate(&store, id, false)
+        .await
+        .expect("idempotent re-activate");
+
+    let spurious = recv_matching(&mut stream, Duration::from_millis(300), |e| {
+        e.payload.get("workstream_id") == Some(&json!(id))
+            || e.payload.get("new_active_id") == Some(&json!(id))
+    })
+    .await;
+    assert!(
+        spurious.is_none(),
+        "idempotent re-activation must not publish an event referencing {id}, got {spurious:?}"
+    );
+}
+
+/// A `force: true` switch must publish `WorkstreamStateInferred` for BOTH
+/// the newly-active workstream (`active`) and the prior one (`idle`), plus
+/// `WorkstreamActivationChanged` carrying both ids.
+#[tokio::test]
+async fn activate_force_switch_publishes_state_inferred_for_both() {
+    let (store, _dir) = shared_store().await;
+    let a = create(&store, "a").await;
+    let b = create(&store, "b").await;
+    activate(&store, a, false).await.expect("activate a");
+
+    let mut stream = subscribe_workstream_bus();
+    activate(&store, b, true).await.expect("force switch");
+
+    let a_idle = recv_matching(&mut stream, Duration::from_secs(2), |e| {
+        e.event_type == "workstream_state_inferred"
+            && e.payload["workstream_id"] == json!(a)
+            && e.payload["state"] == json!("idle")
+    })
+    .await;
+    assert!(a_idle.is_some(), "expected prior workstream to go idle");
+}
+
+/// Deactivating the active workstream must publish `WorkstreamStateInferred`
+/// (`state: idle`, `reason: "deactivated"`) but NOT
+/// `WorkstreamActivationChanged` (the spec's `new_active_id` field is a
+/// required `UUID` — there is no "new active workstream" when deactivating).
+#[tokio::test]
+async fn deactivate_publishes_state_inferred() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, "a").await;
+    activate(&store, id, false).await.expect("activate");
+
+    let mut stream = subscribe_workstream_bus();
+    deactivate(&store, id).await.expect("deactivate");
+
+    let inferred = recv_matching(&mut stream, Duration::from_secs(2), |e| {
+        e.event_type == "workstream_state_inferred" && e.payload["workstream_id"] == json!(id)
+    })
+    .await
+    .expect("expected WorkstreamStateInferred");
+    assert_eq!(inferred.payload["state"], json!("idle"));
+    assert_eq!(inferred.payload["reason"], json!("deactivated"));
 }

--- a/crates/trusty-code/src/workstreams/events.rs
+++ b/crates/trusty-code/src/workstreams/events.rs
@@ -1,0 +1,298 @@
+//! Workstream-level SSE event aggregation (DOC-48 §5.3/§5.3.1, issue #3297).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-WS-05~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-05~draft) §5.3
+//! - [`SPEC-WS-07~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-07~draft) AC-7
+//!
+//! Why: `GET /workstreams/{id}/events` (`crate::serve::rest::workstream_events`)
+//! must present a workstream as ONE logical SSE stream even though the daemon
+//! only tracks events per-session (`crate::events`, session-keyed per
+//! AC-7.3). §5.3 requires fanning out over the workstream's bound
+//! `session_ids`, tagging each event `{session_id, event_type, payload}`, and
+//! merging in workstream-level events (`WorkstreamActivationChanged`,
+//! `WorkstreamStateInferred`) that have no single owning session. AC-7.1
+//! additionally requires this fan-out layer to be designed against a
+//! session-id ABSTRACTION rather than `crate::session::SessionRegistry`
+//! directly, so it can be lifted into `trusty-agents-common` (#3299) for
+//! `trusty-agents` background sessions (epic #3052) without rework — this
+//! module is that seam: [`SessionEventSource`] is the trait a tcode-native
+//! adapter ([`RegistrySessionEventSource`]) implements today, and a future
+//! tagents-native adapter will implement identically once extracted.
+//!
+//! What: [`WorkstreamEventEnvelope`] (the generic `{session_id, event_type,
+//! payload}` wire shape, AC-7.2), [`SessionEventSource`] (the harness-agnostic
+//! per-session stream seam, AC-7.1) plus its tcode-native impl
+//! [`RegistrySessionEventSource`], [`aggregate`] (the merge function
+//! `crate::serve::rest::workstream_events` calls — one stream per bound
+//! session plus the workstream-level bus, `futures_util::stream::select_all`),
+//! and the workstream-level event bus
+//! ([`publish_activation_changed`]/[`publish_state_inferred`]/
+//! [`subscribe_workstream_bus`]) that [`super::activation`] and
+//! [`super::protocol`] publish onto when the activation-lock or close verbs
+//! fire a state transition.
+//!
+//! **Dynamic membership (§5.3 step 4, resolved ambiguity):** this ticket
+//! implements STATIC-at-subscribe-time fan-out — [`aggregate`] snapshots
+//! `session_ids` once, at the moment `GET /workstreams/{id}/events` is called,
+//! and does not notice a session bound to the workstream afterward. Session
+//! BINDING itself (`session.create(workstream_id)`) is #3298 scope and does
+//! not exist yet — `Workstream::session_ids` never grows today (see
+//! `super::model` — nothing currently calls `WorkstreamStore` to append an
+//! id), so there is no live membership-change event to react to yet. When
+//! #3298 lands session binding, it should also publish onto
+//! [`subscribe_workstream_bus`] (an event this module's aggregator already
+//! merges in) so a follow-up can make membership changes dynamic without
+//! touching this file's merge logic again — noted here as the deliberate
+//! seam for that follow-up.
+//!
+//! **`SessionAdded`/`SessionActivityUpdate` deferred:** DOC-48 §13's event
+//! list also names these two, but both describe session-BINDING activity
+//! (`{session_id, binding_time}` / activity/heartbeat on a bound session) —
+//! there is no producer for either today because #3298 (session binding) has
+//! not landed, exactly like the dynamic-membership note above. Wiring them in
+//! now would mean inventing call sites this crate does not yet have (no code
+//! path ever adds to `session_ids`). [`WorkstreamEventEnvelope`]'s shape
+//! already accommodates them without a wire-format change once #3298 lands.
+//!
+//! Test: `events_tests`.
+
+use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
+
+use futures_util::stream::{self, Stream, StreamExt};
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+
+use super::model::{WorkstreamId, WorkstreamState};
+use crate::session::SessionRegistry;
+
+/// A boxed, owned, `'static` event stream — the common currency every piece
+/// of this module passes around (per-session streams, the workstream-level
+/// bus, and the final merged stream all share this one type).
+pub type EventStream = Pin<Box<dyn Stream<Item = WorkstreamEventEnvelope> + Send>>;
+
+/// The generic wire envelope `GET /workstreams/{id}/events` emits (DOC-48
+/// §5.3 step 3, AC-7.2): `{session_id, event_type, payload}`.
+///
+/// Why: AC-7.2 requires a harness-agnostic envelope shape, not tcode's
+/// session-scoped [`crate::events::SessionEventEnvelope`] (which always
+/// carries a `session_id` and a closed-set `Event` enum) — a
+/// workstream-level event like `WorkstreamActivationChanged` has no single
+/// owning session, so `session_id` must be optional here.
+/// What: `session_id` is `Some(id)` for an event fanned out from one of the
+/// workstream's bound sessions, `None` for a workstream-level event.
+/// `event_type` is the event's stable snake_case tag (mirrors
+/// `crate::events::Event::kind`'s convention). `payload` is the
+/// event-specific JSON body.
+/// Test: `events_tests::session_envelope_carries_session_id`,
+/// `events_tests::workstream_level_envelope_has_no_session_id`.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkstreamEventEnvelope {
+    pub session_id: Option<String>,
+    pub event_type: String,
+    pub payload: Value,
+}
+
+impl WorkstreamEventEnvelope {
+    /// Build an envelope for an event fanned out from a specific bound
+    /// session.
+    fn for_session(
+        session_id: impl Into<String>,
+        event_type: impl Into<String>,
+        payload: Value,
+    ) -> Self {
+        Self {
+            session_id: Some(session_id.into()),
+            event_type: event_type.into(),
+            payload,
+        }
+    }
+
+    /// Build an envelope for a workstream-level event with no owning
+    /// session (`WorkstreamActivationChanged`, `WorkstreamStateInferred`).
+    fn workstream_level(event_type: impl Into<String>, payload: Value) -> Self {
+        Self {
+            session_id: None,
+            event_type: event_type.into(),
+            payload,
+        }
+    }
+}
+
+/// AC-7.1's harness-agnostic seam: the aggregation layer's only dependency
+/// on "how does a session emit events", abstracted behind a generic
+/// `session_id: &str` rather than `crate::session::SessionRegistry`.
+///
+/// Why: this is the exact interface boundary DOC-48 §5.3.1 requires be
+/// extractable to `trusty-agents-common` (#3299) — [`aggregate`] (and the
+/// SSE route that calls it) never touch `SessionRegistry` directly, only
+/// this trait, so lifting the aggregation layer into a shared crate is a
+/// matter of moving [`aggregate`]/[`WorkstreamEventEnvelope`]/this trait
+/// verbatim and leaving [`RegistrySessionEventSource`] behind as tcode's
+/// local adapter (a future `trusty-agents`-native adapter implements the
+/// same trait over its own session/event types).
+/// What: [`Self::subscribe`] returns this session's live event stream
+/// already tagged as [`WorkstreamEventEnvelope`]s, or `None` if `session_id`
+/// names no session the source knows about (a dangling/removed binding —
+/// the aggregator skips it rather than failing the whole request, since one
+/// stale bound session must never take down observation of the rest).
+/// Test: `events_tests::aggregate_merges_per_session_and_workstream_streams`.
+pub trait SessionEventSource: Send + Sync {
+    fn subscribe(&self, session_id: &str) -> Option<EventStream>;
+}
+
+/// The tcode-native [`SessionEventSource`] impl, wrapping the daemon's real
+/// [`SessionRegistry`] + global event bus (`crate::events`).
+///
+/// Why: the one place this module touches tcode-specific types — every
+/// other item here (the trait, the envelope, [`aggregate`]) is generic.
+/// What: [`Self::subscribe`] replays a session's ring buffer
+/// ([`SessionRegistry::replay`]) then chains its live events, filtered from
+/// the shared global bus by `session_id` — the exact same replay-then-live
+/// composition `crate::serve::http::session_events_sse` already uses for the
+/// per-session route, reused here rather than reimplemented.
+/// Test: `events_tests::registry_source_replays_then_streams_live_events`,
+/// `events_tests::registry_source_unknown_session_returns_none`.
+pub struct RegistrySessionEventSource {
+    sessions: Arc<SessionRegistry>,
+}
+
+impl RegistrySessionEventSource {
+    pub fn new(sessions: Arc<SessionRegistry>) -> Self {
+        Self { sessions }
+    }
+}
+
+impl SessionEventSource for RegistrySessionEventSource {
+    fn subscribe(&self, session_id: &str) -> Option<EventStream> {
+        let replay = self.sessions.replay(session_id).ok()?;
+        let replay_stream = stream::iter(replay.into_iter().map(session_envelope_to_workstream));
+
+        let filter_id = session_id.to_string();
+        let live_stream =
+            BroadcastStream::new(crate::events::subscribe()).filter_map(move |item| {
+                let filter_id = filter_id.clone();
+                async move {
+                    match item {
+                        Ok(envelope) if envelope.session_id == filter_id => {
+                            Some(session_envelope_to_workstream(envelope))
+                        }
+                        _ => None,
+                    }
+                }
+            });
+
+        Some(Box::pin(replay_stream.chain(live_stream)))
+    }
+}
+
+/// Adapt one `crate::events::SessionEventEnvelope` into the generic
+/// [`WorkstreamEventEnvelope`] shape (`event_type` == `Event::kind()`,
+/// `payload` == the serialized `Event`).
+fn session_envelope_to_workstream(
+    envelope: crate::events::SessionEventEnvelope,
+) -> WorkstreamEventEnvelope {
+    let payload = serde_json::to_value(&envelope.event).unwrap_or(Value::Null);
+    WorkstreamEventEnvelope::for_session(envelope.session_id, envelope.kind, payload)
+}
+
+/// Merge each bound session's event stream (via `source`) with the
+/// workstream-level stream into one [`EventStream`] (DOC-48 §5.3 steps 1-3;
+/// AC-7.1's aggregation layer).
+///
+/// Why: the single function `crate::serve::rest::workstream_events` calls —
+/// keeping the merge logic here (rather than inline in the axum handler)
+/// is what makes it independently unit-testable against a fake
+/// [`SessionEventSource`] and, per the module docs, independently liftable
+/// into `trusty-agents-common`.
+/// What: `session_ids` is snapshotted by the caller ONCE (static-at-subscribe
+/// -time membership, see module docs) — an unknown/dangling id is silently
+/// skipped (`SessionEventSource::subscribe` returning `None`), never fatal to
+/// the whole aggregation. An empty `session_ids` still returns a live stream
+/// containing just `workstream_events` — matching DOC-48 §5.3's "zero-session
+/// workstream: stream stays open, workstream-level events only" requirement.
+/// Test: `events_tests::aggregate_merges_per_session_and_workstream_streams`,
+/// `events_tests::aggregate_with_no_sessions_still_streams_workstream_events`,
+/// `events_tests::aggregate_skips_unknown_session_ids`.
+pub fn aggregate(
+    source: &dyn SessionEventSource,
+    session_ids: &[String],
+    workstream_events: EventStream,
+) -> EventStream {
+    let mut streams: Vec<EventStream> = session_ids
+        .iter()
+        .filter_map(|id| source.subscribe(id))
+        .collect();
+    streams.push(workstream_events);
+    Box::pin(stream::select_all(streams))
+}
+
+/// Capacity of the workstream-level event bus. Far lower volume than
+/// `crate::events`'s per-session bus (`CHANNEL_CAPACITY` 1024) — activation
+/// changes and state transitions are rare, daemon-wide occurrences, not a
+/// per-turn stream.
+const WORKSTREAM_BUS_CAPACITY: usize = 256;
+
+/// Process-global bus for workstream-LEVEL events (`WorkstreamActivationChanged`,
+/// `WorkstreamStateInferred`) — deliberately separate from `crate::events`'s
+/// per-session bus, since these events have no owning `session_id` (AC-3.3:
+/// "ALL connected clients receive `WorkstreamActivationChanged`", not just
+/// those observing the affected workstream(s) — so no per-workstream
+/// filtering is applied on publish; every subscriber of every
+/// `/workstreams/{id}/events` stream receives every event on this bus).
+static WORKSTREAM_BUS: OnceLock<broadcast::Sender<WorkstreamEventEnvelope>> = OnceLock::new();
+
+fn workstream_bus() -> broadcast::Sender<WorkstreamEventEnvelope> {
+    WORKSTREAM_BUS
+        .get_or_init(|| broadcast::channel(WORKSTREAM_BUS_CAPACITY).0)
+        .clone()
+}
+
+/// Subscribe to the workstream-level event bus as an [`EventStream`], ready
+/// to hand to [`aggregate`].
+///
+/// Test: `events_tests::workstream_bus_round_trips_through_subscribe`.
+pub fn subscribe_workstream_bus() -> EventStream {
+    Box::pin(
+        BroadcastStream::new(workstream_bus().subscribe())
+            .filter_map(|item| async move { item.ok() }),
+    )
+}
+
+/// Publish `WorkstreamActivationChanged` (DOC-48 §5.3, AC-3.3) — called by
+/// [`super::activation::activate`]/[`super::activation::deactivate`] whenever
+/// the daemon-wide active pointer actually changes.
+///
+/// Why: the single production call site for this event kind, so its wire
+/// shape (`{new_active_id, prior_id}`) can never drift between call sites.
+/// Test: `events_tests::publish_activation_changed_reaches_subscriber`.
+pub fn publish_activation_changed(new_active_id: WorkstreamId, prior_id: Option<WorkstreamId>) {
+    let envelope = WorkstreamEventEnvelope::workstream_level(
+        "workstream_activation_changed",
+        json!({ "new_active_id": new_active_id, "prior_id": prior_id }),
+    );
+    let _ = workstream_bus().send(envelope);
+}
+
+/// Publish `WorkstreamStateInferred` (DOC-48 §5.3) — called whenever a
+/// workstream's computed state actually transitions (activated, deactivated,
+/// or closed).
+///
+/// Why: mirrors [`publish_activation_changed`] — one call site per event
+/// kind, so the wire shape (`{workstream_id, state, reason}`) stays
+/// consistent.
+/// Test: `events_tests::publish_state_inferred_reaches_subscriber`.
+pub fn publish_state_inferred(workstream_id: WorkstreamId, state: WorkstreamState, reason: &str) {
+    let envelope = WorkstreamEventEnvelope::workstream_level(
+        "workstream_state_inferred",
+        json!({ "workstream_id": workstream_id, "state": state, "reason": reason }),
+    );
+    let _ = workstream_bus().send(envelope);
+}
+
+#[cfg(test)]
+#[path = "events_tests.rs"]
+mod events_tests;

--- a/crates/trusty-code/src/workstreams/events_tests.rs
+++ b/crates/trusty-code/src/workstreams/events_tests.rs
@@ -1,0 +1,213 @@
+//! Unit tests for `workstreams::events` (issue #3297).
+//!
+//! Why: split out per the crate's `_tests.rs` sibling-file convention (see
+//! `events_tests` at crate root for the session-event-taxonomy precedent) so
+//! the aggregation layer's test surface can grow without pushing the
+//! production file past its 500-SLOC cap.
+//! What: covers the envelope constructors, [`super::aggregate`] against a
+//! fake [`super::SessionEventSource`] (proving the merge logic never touches
+//! `SessionRegistry`), [`super::RegistrySessionEventSource`] against a real
+//! `SessionRegistry`, and the workstream-level bus round trip. The bus tests
+//! loop-until-match (bounded by a timeout) rather than trusting the first
+//! `recv()`, since `WORKSTREAM_BUS` is process-global and other tests in this
+//! binary may publish concurrently — mirrors `crate::events_tests`'
+//! established tolerance for that same global-bus sharing.
+//! Test: this module is itself the test surface.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use serde_json::json;
+
+use super::*;
+use crate::session::SessionRegistry;
+
+/// A fake [`SessionEventSource`] backed by an in-memory map — proves
+/// [`aggregate`] depends only on the trait, never on `SessionRegistry`.
+struct FakeSource {
+    data: HashMap<String, Vec<WorkstreamEventEnvelope>>,
+}
+
+impl SessionEventSource for FakeSource {
+    fn subscribe(&self, session_id: &str) -> Option<EventStream> {
+        let events = self.data.get(session_id)?.clone();
+        Some(Box::pin(stream::iter(events)))
+    }
+}
+
+#[test]
+fn session_envelope_carries_session_id() {
+    let env = WorkstreamEventEnvelope::for_session("s-1", "tool_started", json!({"a": 1}));
+    assert_eq!(env.session_id, Some("s-1".to_string()));
+    assert_eq!(env.event_type, "tool_started");
+    assert_eq!(env.payload, json!({"a": 1}));
+}
+
+#[test]
+fn workstream_level_envelope_has_no_session_id() {
+    let env = WorkstreamEventEnvelope::workstream_level("workstream_activation_changed", json!({}));
+    assert_eq!(env.session_id, None);
+    assert_eq!(env.event_type, "workstream_activation_changed");
+}
+
+#[tokio::test]
+async fn aggregate_merges_per_session_and_workstream_streams() {
+    let mut data = HashMap::new();
+    data.insert(
+        "s-1".to_string(),
+        vec![WorkstreamEventEnvelope::for_session(
+            "s-1",
+            "tool_started",
+            json!({"tool": "grep"}),
+        )],
+    );
+    let source = FakeSource { data };
+    let session_ids = vec!["s-1".to_string()];
+    let workstream_events: EventStream = Box::pin(stream::iter(vec![
+        WorkstreamEventEnvelope::workstream_level("workstream_state_inferred", json!({})),
+    ]));
+
+    let merged: Vec<_> = aggregate(&source, &session_ids, workstream_events)
+        .collect()
+        .await;
+
+    assert_eq!(merged.len(), 2);
+    assert!(merged.iter().any(|e| e.event_type == "tool_started"));
+    assert!(
+        merged
+            .iter()
+            .any(|e| e.event_type == "workstream_state_inferred")
+    );
+}
+
+#[tokio::test]
+async fn aggregate_with_no_sessions_still_streams_workstream_events() {
+    let source = FakeSource {
+        data: HashMap::new(),
+    };
+    let workstream_events: EventStream = Box::pin(stream::iter(vec![
+        WorkstreamEventEnvelope::workstream_level("workstream_activation_changed", json!({})),
+    ]));
+
+    let merged: Vec<_> = aggregate(&source, &[], workstream_events).collect().await;
+
+    assert_eq!(merged.len(), 1);
+    assert_eq!(merged[0].event_type, "workstream_activation_changed");
+    assert_eq!(merged[0].session_id, None);
+}
+
+#[tokio::test]
+async fn aggregate_skips_unknown_session_ids() {
+    let source = FakeSource {
+        data: HashMap::new(),
+    };
+    let session_ids = vec!["ghost".to_string()];
+    let workstream_events: EventStream = Box::pin(stream::iter(vec![
+        WorkstreamEventEnvelope::workstream_level("workstream_state_inferred", json!({})),
+    ]));
+
+    // Must not panic on the unknown id; the workstream-level stream alone
+    // still comes through.
+    let merged: Vec<_> = aggregate(&source, &session_ids, workstream_events)
+        .collect()
+        .await;
+    assert_eq!(merged.len(), 1);
+}
+
+#[tokio::test]
+async fn registry_source_replays_then_streams_live_events() {
+    let sessions = std::sync::Arc::new(SessionRegistry::new());
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let source = RegistrySessionEventSource::new(sessions);
+
+    let stream = source
+        .subscribe(&session.id)
+        .expect("known session must yield a stream");
+    // `session.create` publishes exactly `SessionStarted` +
+    // `SessionStatusChanged` into the ring buffer (mirrors
+    // `crate::serve::http::tests::http_session_events_sse_streams_replay`) —
+    // `take(2)` is satisfied entirely by the replay half, so this never
+    // touches the live (global-bus) half and cannot race other tests.
+    let replayed: Vec<_> = stream.take(2).collect().await;
+    assert_eq!(replayed.len(), 2);
+    assert_eq!(replayed[0].session_id.as_deref(), Some(session.id.as_str()));
+    assert!(replayed.iter().any(|e| e.event_type == "session_started"));
+    assert!(
+        replayed
+            .iter()
+            .any(|e| e.event_type == "session_status_changed")
+    );
+}
+
+#[tokio::test]
+async fn registry_source_unknown_session_returns_none() {
+    let sessions = std::sync::Arc::new(SessionRegistry::new());
+    let source = RegistrySessionEventSource::new(sessions);
+    assert!(source.subscribe("does-not-exist").is_none());
+}
+
+#[tokio::test]
+async fn workstream_bus_round_trips_through_subscribe() {
+    let mut stream = subscribe_workstream_bus();
+    let marker = WorkstreamId::new();
+    publish_activation_changed(marker, None);
+
+    let found = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let env = stream.next().await.expect("bus must not close");
+            if env.payload["new_active_id"] == json!(marker) {
+                return env;
+            }
+        }
+    })
+    .await
+    .expect("expected our publish to arrive within the timeout");
+
+    assert_eq!(found.event_type, "workstream_activation_changed");
+    assert_eq!(found.session_id, None);
+}
+
+#[tokio::test]
+async fn publish_activation_changed_reaches_subscriber() {
+    let mut stream = subscribe_workstream_bus();
+    let new_id = WorkstreamId::new();
+    let prior_id = WorkstreamId::new();
+    publish_activation_changed(new_id, Some(prior_id));
+
+    let found = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let env = stream.next().await.expect("bus must not close");
+            if env.payload["new_active_id"] == json!(new_id) {
+                return env;
+            }
+        }
+    })
+    .await
+    .expect("expected our publish to arrive within the timeout");
+
+    assert_eq!(found.payload["prior_id"], json!(prior_id));
+}
+
+#[tokio::test]
+async fn publish_state_inferred_reaches_subscriber() {
+    let mut stream = subscribe_workstream_bus();
+    let id = WorkstreamId::new();
+    let marker_reason = format!("test-reason-{id}");
+    publish_state_inferred(id, WorkstreamState::Idle, &marker_reason);
+
+    let found = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let env = stream.next().await.expect("bus must not close");
+            if env.payload["reason"] == json!(marker_reason) {
+                return env;
+            }
+        }
+    })
+    .await
+    .expect("expected our publish to arrive within the timeout");
+
+    assert_eq!(found.event_type, "workstream_state_inferred");
+    assert_eq!(found.payload["state"], json!("idle"));
+    assert_eq!(found.payload["workstream_id"], json!(id));
+}

--- a/crates/trusty-code/src/workstreams/mod.rs
+++ b/crates/trusty-code/src/workstreams/mod.rs
@@ -39,22 +39,30 @@
 //! **Scope note (Phase 1A):** #3293 built ONLY the domain model and
 //! persistence layer (this module's `model`/`path`/`store` submodules);
 //! #3294 added the activation-lock RPC semantics (`activation`, plus
-//! `activate`/`deactivate` in [`protocol`]); #3295 (this ticket) added the
-//! rest of `protocol`'s surface (`create`/`get`/`list`/`close`) and the REST
-//! wrappers (`crate::serve::rest::workstreams`). The CLI (#3296) and the SSE
-//! aggregation route (#3297) remain out of scope and land in their own
-//! follow-up tickets against this foundation.
+//! `activate`/`deactivate` in [`protocol`]); #3295 added the rest of
+//! `protocol`'s surface (`create`/`get`/`list`/`close`) and the REST wrappers
+//! (`crate::serve::rest::workstreams`); #3297 (this ticket) adds
+//! [`events`] — the harness-agnostic SSE aggregation layer
+//! (`crate::serve::rest::workstream_events`) — and wires
+//! `WorkstreamActivationChanged`/`WorkstreamStateInferred` publication into
+//! [`activation`] and [`protocol::close`]. The CLI (#3296) remains out of
+//! scope.
 //!
 //! Test: `cargo test -p trusty-code workstreams::` exercises every submodule
 //! in place; see each submodule's own `Test:` line for specifics.
 
 pub mod activation;
+pub mod events;
 pub mod model;
 mod path;
 pub mod protocol;
 pub mod store;
 
 pub use activation::{ActivateOutcome, ActivationError, SharedWorkstreamStore};
+pub use events::{
+    EventStream, RegistrySessionEventSource, SessionEventSource, WorkstreamEventEnvelope,
+    aggregate, publish_activation_changed, publish_state_inferred, subscribe_workstream_bus,
+};
 pub use model::{Workstream, WorkstreamId, WorkstreamState};
 pub use path::{default_data_dir, store_path};
 pub use store::{ReconcileOutcome, StoreError, WorkstreamStore};

--- a/crates/trusty-code/src/workstreams/protocol.rs
+++ b/crates/trusty-code/src/workstreams/protocol.rs
@@ -46,6 +46,7 @@ use uuid::Uuid;
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 
 use super::activation::{self, ActivationError, SharedWorkstreamStore};
+use super::events::publish_state_inferred;
 use super::model::{Workstream, WorkstreamId, WorkstreamState};
 use super::store::StoreError;
 
@@ -300,9 +301,15 @@ async fn list(
 /// spec's §5.1 signature exactly — not the updated record, since a client
 /// that needs the post-close view already has `workstream.get`). Idempotent:
 /// closing an already-closed workstream succeeds again (see
-/// [`super::model::Workstream::mark_closed`]'s docs).
+/// [`super::model::Workstream::mark_closed`]'s docs). (Issue #3297) publishes
+/// `WorkstreamStateInferred{state: closed}` unconditionally — even a repeat
+/// close re-asserts the same state to any freshly-subscribed observer, and
+/// re-publishing an unchanged state is harmless (no `WorkstreamActivationChanged`
+/// pairing here, since closing the active workstream deactivates it via the
+/// store, not via [`super::activation`]).
 /// Test: `protocol_tests::close_succeeds_and_clears_active_pointer`,
-/// `protocol_tests::close_unknown_id_maps_to_not_found`.
+/// `protocol_tests::close_unknown_id_maps_to_not_found`,
+/// `protocol_tests::close_publishes_state_inferred`.
 async fn close(
     store: &SharedWorkstreamStore,
     params: Value,
@@ -312,6 +319,7 @@ async fn close(
     let id = parse_id(&p.id, "workstream.close")?;
     let mut store = store.lock().await;
     store.close(id).await.map_err(map_store_err)?;
+    publish_state_inferred(id, WorkstreamState::Closed, "closed");
     Ok(json!({}))
 }
 

--- a/crates/trusty-code/src/workstreams/protocol_tests.rs
+++ b/crates/trusty-code/src/workstreams/protocol_tests.rs
@@ -427,3 +427,33 @@ async fn close_unknown_id_maps_to_not_found() {
     .unwrap_err();
     assert_eq!(err.code, -32002);
 }
+
+/// `workstream.close` must publish `WorkstreamStateInferred{state: closed}`
+/// onto the workstream-level bus (issue #3297).
+#[tokio::test]
+async fn close_publishes_state_inferred() {
+    use futures_util::StreamExt;
+
+    let (store, _dir) = shared_store().await;
+    let id = seed_workstream(&store, "a").await;
+    let mut stream = crate::workstreams::events::subscribe_workstream_bus();
+
+    close(&store, json!({"id": id.to_string()}), test_ctx())
+        .await
+        .expect("close");
+
+    let found = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let env = stream.next().await.expect("bus must not close");
+            if env.event_type == "workstream_state_inferred"
+                && env.payload["workstream_id"] == json!(id)
+            {
+                return env;
+            }
+        }
+    })
+    .await
+    .expect("expected WorkstreamStateInferred within timeout");
+
+    assert_eq!(found.payload["state"], json!("closed"));
+}


### PR DESCRIPTION
## Summary

- Implements `GET /workstreams/{id}/events` — a workstream-level SSE aggregation route that fans out over the workstream's bound `session_ids` (replay + live per session, via the existing per-session `crate::events` bus), tagged with the generic `{session_id, event_type, payload}` envelope, merged with a new daemon-global workstream-level bus carrying `WorkstreamActivationChanged`/`WorkstreamStateInferred`.
- Wires `WorkstreamActivationChanged`/`WorkstreamStateInferred` publication into `workstream.activate`/`workstream.deactivate` (`workstreams::activation`) and `workstream.close` (`workstreams::protocol`) — deferred from #3321 per that ticket's note.
- Designs the fan-out/merge layer (`workstreams::events::{SessionEventSource, aggregate}`) against an abstract session-id trait (AC-7.1) so it can be lifted into `trusty-agents-common` (#3299) with minimal surgery.
- Zero-session workstream: stream stays open, workstream-level events only (§5.3). Unknown workstream: 404.
- Documents two deliberately-deferred items with spec cites: (1) dynamic (post-subscribe) membership changes — static-at-subscribe-time snapshot for now, since #3298 (session binding) hasn't landed and `session_ids` never grows yet; (2) `SessionAdded`/`SessionActivityUpdate` — no producer exists until #3298 lands session binding.

## Spec anchors

- DOC-48 §5.3 (workstream event aggregation architecture)
- DOC-48 §5.3.1 / AC-7 (harness-agnostic shared multi-client attach transport)
- DOC-48 §13 implementation checklist (SSE route + event list)

## Trait/interface shape for the shared-transport extraction (#3299)

```rust
pub trait SessionEventSource: Send + Sync {
    fn subscribe(&self, session_id: &str) -> Option<EventStream>;
}

pub fn aggregate(
    source: &dyn SessionEventSource,
    session_ids: &[String],
    workstream_events: EventStream,
) -> EventStream;
```

`RegistrySessionEventSource` is the tcode-native impl (wraps `SessionRegistry` + `crate::events`); `aggregate`/`WorkstreamEventEnvelope`/the trait are the pieces that move to `trusty-agents-common` verbatim, per the module docs in `crates/trusty-code/src/workstreams/events.rs`.

## Gates (raw tails)

```
cargo check -p trusty-code           -> Finished, clean
cargo test -p trusty-code --lib -- --test-threads=1
  -> test result: ok. 1324 passed; 0 failed; 4 ignored
cargo clippy -p trusty-code --all-targets -- -D warnings -> Finished, clean
cargo fmt --check -p trusty-code     -> clean
bash scripts/check_line_cap.sh       -> line-cap: 7 allowlisted, 0 violations — OK.
bash scripts/check_test_pointers.sh  -> test-pointers: 0 dangling pointers — OK.
bash scripts/check_sld.sh            -> sld-lint: scanned 38 spec doc(s) + 2598 code file(s); 0 error(s), 0 warning(s)
```

Note: `cargo test -p trusty-code --lib` with default parallel test threads intermittently fails one of the unrelated `run_task::tests::*` (process-spawning tests) — reproduced identically on unmodified `origin/main`, confirmed pre-existing/out of scope for this ticket. `--test-threads=1` is fully green.

## Test plan

- [x] `cargo test -p trusty-code --lib workstreams::` (96 tests) — aggregation unit tests, activation/close event-publication tests, existing CRUD/activation coverage
- [x] `cargo test -p trusty-code --lib serve::rest::workstream_events` — real axum SSE round-trip: zero-session stays open, unknown workstream 404s, bound-session replay is tagged and fanned out
- [x] `cargo test -p trusty-code --lib serve::http` — route-merge wiring proof
- [x] Full crate suite green under `--test-threads=1`

Part of #3292

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)