### PR TITLE
feat(trusty-agents,trusty-console): loopback-only API bind + origin guard + console agents proxy (closes #3329, #3331)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Security
+
+- **Loopback-only doctrine (#3329):** the HTTP API server (`--api`/`--serve`)
+  now binds `127.0.0.1` by default instead of `0.0.0.0`. A non-loopback bind is
+  an explicit opt-in via the new `--bind <addr>` flag, and the server **refuses
+  to start** on a non-loopback interface unless an API token is set
+  (`--api-token` / `TAGENT_API_TOKEN`) — the error points operators at the
+  trusty-console proxy (`/api/agents/*`) as the intended remote path. The API
+  can spawn arbitrary subprocesses, so an unauthenticated LAN-reachable bind was
+  a real exposure. Additionally adopts the shared same-origin write guard
+  (`trusty_common::server::with_guarded_middleware`, mirroring #3317) router-wide
+  so cross-origin browser writes (CSRF) to `POST /api/task`, the `/api/tm/*`,
+  `/api/ctrl/*`, and `POST /rpc` surfaces are rejected with 403; GET reads, the
+  `/api/events` SSE stream, and same-origin/loopback writes are unaffected. The
+  agents-ui webview keeps working: in Tauri desktop mode writes travel over
+  Tauri IPC (never HTTP), and in browser mode the SPA is served same-origin
+  loopback. Replaces the crate-local CORS/compression/trace stack with the
+  shared standard middleware so trusty-agents no longer drifts from the sibling
+  trusty-* daemons.
+
+### Added
+
+- The API server now writes the standard `http_addr` discovery file on bind
+  (and removes it on graceful shutdown), so the trusty-console reverse proxy can
+  resolve the agents surface at `/api/agents/*` (#3331).
+
 ### Fixed
 
 - Committed `ui/pnpm-lock.yaml` (architecture-review tranche 0): the file was gitignored with a comment claiming the repo-wide detect-secrets pre-commit hook flags npm integrity hashes, but the root `.pre-commit-config.yaml` already excludes `.*pnpm-lock\.yaml` (only the crate-scoped `crates/trusty-agents/.pre-commit-config.yaml`, which governs Python tooling and is unrelated to the JS UI, was missing that exclusion) and no CI workflow runs detect-secrets at all. Every other Tauri UI in the workspace (`trusty-mpm-gui`, `trusty-search`, `trusty-memory`, `trusty-analyze`, `trusty-code-gui`, `trusty-console`) already commits its own subdir-scoped `pnpm-lock.yaml`; `trusty-agents/ui` was the only outlier. Removed the stale `.gitignore` entry and regenerated the lockfile with `pnpm install --lockfile-only`.

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -42,7 +42,11 @@ trusty-code = { workspace = true }
 # (absorbed from the former `trusty-symgraph` crate in #5 phase 2c).
 # The `memory-core` feature pulls in the Memory Palace storage engine
 # (absorbed from the former `trusty-memory-core` crate in #5 phase 2d).
-trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli"] }
+# `axum-server` (#3329): the shared same-origin write guard + standard axum
+#      middleware stack (`trusty_common::server::with_guarded_middleware`,
+#      `SelfOrigins`) the API server adopts router-wide for the loopback-only
+#      doctrine (mirrors trusty-console/#3317).
+trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli", "axum-server"] }
 # Why (issue #226): trusty-agents only links `trusty_memory::MemoryMcpService` for
 #      in-process `rpc.discover` merging; it does not need the axum HTTP/SSE
 #      surface (it owns its own axum stack for the orchestrator's UI). Setting

--- a/crates/trusty-agents/src/api/server/auth.rs
+++ b/crates/trusty-agents/src/api/server/auth.rs
@@ -17,19 +17,25 @@ use axum::{
 };
 use serde::Serialize;
 
-/// Server configuration. (#181)
+/// Server configuration. (#181, #3329)
 ///
 /// Why: Bearer-token auth must be configurable per-launch so users can run
 /// the server unauthenticated for local-only dev or token-protected when
 /// exposing the bound port over a LAN. Keeping this as a struct (instead of
 /// extra bare args to `serve`) gives us a clean place to grow more knobs
 /// (TLS, allowed origins, …) without breaking callers.
-/// What: `port` is the TCP port to bind on `0.0.0.0`. `token`, when `Some`,
-/// makes every `/api/*` route (except `GET /api/health`) require an
+/// What: `bind` is the interface to listen on (#3329: defaults to loopback
+/// `127.0.0.1`; a non-loopback bind is an explicit opt-in that REQUIRES a
+/// token — see `serve_with_config`). `port` is the TCP port. `token`, when
+/// `Some`, makes every `/api/*` route (except the public probes) require an
 /// `Authorization: Bearer <token>` header that exactly matches `token`.
-/// Test: `auth_middleware_rejects_missing_token`, `auth_middleware_allows_health`.
+/// Test: `auth_middleware_rejects_missing_token`, `auth_middleware_allows_health`,
+/// and the loopback-doctrine tests in `super::tests::guard`.
 #[derive(Clone, Debug)]
 pub struct ApiConfig {
+    /// Interface to bind. Defaults to loopback (`127.0.0.1`) per the
+    /// loopback-only doctrine (#3329); non-loopback is opt-in via `--bind`.
+    pub bind: std::net::IpAddr,
     pub port: u16,
     pub token: Option<String>,
 }
@@ -38,12 +44,17 @@ impl ApiConfig {
     /// Convenience constructor mirroring the previous bare-port API.
     ///
     /// Why: Lets unauthenticated callers (tests, `serve`) construct a config
-    /// without naming the `token` field.
-    /// What: Builds `ApiConfig { port, token: None }`.
+    /// without naming every field. Binds loopback — the only interface on
+    /// which an unauthenticated server is permitted to start (#3329).
+    /// What: Builds `ApiConfig { bind: 127.0.0.1, port, token: None }`.
     /// Test: Used by `serve` and `super::tests`.
     #[allow(dead_code)]
     pub fn unauthenticated(port: u16) -> Self {
-        Self { port, token: None }
+        Self {
+            bind: std::net::Ipv4Addr::LOCALHOST.into(),
+            port,
+            token: None,
+        }
     }
 }
 

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -1,23 +1,25 @@
-//! Router assembly + server bootstrap (#151, #181).
+//! Router assembly + server bootstrap (#151, #181, #3329).
 //!
-//! Why: One place to wire every route to its handler, attach CORS /
-//! compression / tracing / optional bearer-auth layers, and bind the listener.
-//! Keeping route registration separate from the handlers themselves makes the
-//! API surface auditable at a glance.
-//! What: `build_router*` construct the axum `Router`; `serve*` bind
-//! `0.0.0.0:<port>`, print startup URLs, and run until killed.
-//! Test: `super::tests` build routers via `build_router` / `build_router_with_config`.
+//! Why: One place to wire every route to its handler, attach the shared
+//! same-origin write guard + standard middleware stack, the optional
+//! bearer-auth layer, and bind the listener. Keeping route registration
+//! separate from the handlers themselves makes the API surface auditable at a
+//! glance.
+//! What: `build_router*` construct the axum `Router` (router-wide guard applied
+//! AFTER all route registration, #3329); `serve*` default to a loopback bind
+//! (`127.0.0.1:<port>`), refuse an unauthenticated non-loopback bind, write the
+//! `http_addr` discovery file so the console proxy can reach this surface, print
+//! startup URLs, and run until killed.
+//! Test: `super::tests` build routers via `build_router` / `build_router_with_config`;
+//! `super::tests::guard` covers the router-wide write guard and the
+//! non-loopback-without-token startup refusal.
 
 use anyhow::Result;
 use axum::{
-    Json, Router,
-    http::{Method, header},
-    middleware,
+    Json, Router, middleware,
     routing::{get, post},
 };
-use tower_http::compression::CompressionLayer;
-use tower_http::cors::{Any, CorsLayer};
-use tower_http::trace::TraceLayer;
+use trusty_common::server::{SelfOrigins, with_guarded_middleware};
 
 use super::agent_patch::patch_agent_route;
 use super::auth::{ApiClientConfig, ApiConfig, AuthState, auth_middleware};
@@ -42,22 +44,15 @@ use super::ui::{serve_asset, serve_index};
 
 /// Build the axum router.
 ///
-/// Why: A permissive CORS layer lets the dual-mode UI (`pnpm dev` browser
-/// build) talk to the API directly without a Vite proxy when desired, and
-/// also unblocks `curl`/Postman from any origin during local development.
-/// In production-style deploys the server is fronted by a same-origin
-/// reverse proxy (or the Tauri webview) so the wide-open policy is
-/// acceptable for our local-dev threat model. Tighten if/when we expose the
-/// API publicly.
-/// What: Builds the route table with a permissive `CorsLayer` and no auth.
-/// Test: `curl -i -H 'Origin: http://localhost:5173' http://localhost:7654/api/health`
-/// returns `access-control-allow-origin: *`.
+/// Why: Kept `pub` for unit tests and future callers that want an
+/// unauthenticated, loopback-only router without going through `ApiConfig`.
+/// What: Delegates to `build_router_with_config` (no token, loopback-only
+/// self-origins).
+/// Test: `super::tests` build routers via this entry point.
 //
-// Used by unit tests (see `test_router` below) and kept `pub` for future
-// callers that want an unauthenticated router without going through
-// `ApiConfig`. Note: `#[allow(dead_code)]` is required because this is a
-// `bin` crate — `pub` only suppresses dead-code warnings for library crates
-// exposing items as public API, not for binaries with no external consumers.
+// Note: `#[allow(dead_code)]` is required because this is a `bin` crate —
+// `pub` only suppresses dead-code warnings for library crates exposing items
+// as public API, not for binaries with no external consumers.
 #[allow(dead_code)]
 pub fn build_router(state: AppState) -> Router {
     build_router_with_config(state, None)
@@ -65,41 +60,45 @@ pub fn build_router(state: AppState) -> Router {
 
 /// Build the axum router, optionally with bearer-token auth. (#181)
 ///
-/// Why: Splitting this from `build_router` keeps the call-sites that don't
-/// care about auth (most tests) ergonomic while letting `serve()` thread an
-/// `ApiConfig` through. The auth layer is only attached when `token` is
-/// `Some` so the unauthenticated path remains identical to before.
-/// What: Builds the same routes as `build_router`, adds `/api/config` for UI
-/// bootstrap, and conditionally wraps `/api/*` with `auth_middleware`.
-/// Test: `auth_middleware_*` tests cover both with-token and without-token
-/// branches via `oneshot` requests.
+/// Why: The default entry point for tests and same-machine dev — trusts only
+/// loopback for the router-wide write guard. `serve_with_config` uses
+/// [`build_router_with_origins`] with the resolved (possibly non-loopback)
+/// bind address.
+/// What: Delegates to [`build_router_with_origins`] with a default
+/// (loopback-only) `SelfOrigins`.
+/// Test: `auth_middleware_*` and `super::tests::guard` cover both branches.
 pub fn build_router_with_config(state: AppState, token: Option<String>) -> Router {
-    // CORS: keep `allow_origin(Any)` because the server is reachable over
-    // Tailscale / LAN from the operator's other devices and from the Tauri
-    // webview, and we don't know those origins ahead of time. We tighten the
-    // method/header allowlists to the minimum the API actually uses so a
-    // hostile LAN page can't smuggle exotic headers. Bearer-token auth (when
-    // configured) remains the real gate on `POST /api/task` — CORS is
-    // defence-in-depth, not the lock.
-    //
-    // #3063: DELETE was missing from this list even though `/api/ctrl/sessions/:id`,
-    // `/api/tm/sessions/:name`, and `/api/tm/sessions/:name/favorite` already
-    // route DELETE — a pre-existing gap that silently blocked browser access
-    // to all of them (curl/oneshot tests never hit it since CORS preflight is
-    // browser-enforced). Adding the new `DELETE /api/task/:id` cancellation
-    // route in the same PR made fixing it the smallest correct move.
-    // #3246: PATCH added for `/api/agents/:name`.
-    let cors = CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods([
-            Method::GET,
-            Method::POST,
-            Method::DELETE,
-            Method::PATCH,
-            Method::OPTIONS,
-        ])
-        .allow_headers([header::AUTHORIZATION, header::CONTENT_TYPE]);
+    build_router_with_origins(state, token, SelfOrigins::default())
+}
 
+/// Build the axum router with bearer-token auth AND the router-wide
+/// same-origin write guard bound to `self_origins`. (#181, #3329)
+///
+/// Why: The trusty-agents API exposes DESTRUCTIVE write routes (`POST
+/// /api/task` spawns arbitrary subprocesses, `DELETE /api/task/{id}` and the
+/// `/api/tm/*`, `/api/ctrl/*`, `POST /rpc` surfaces mutate live sessions)
+/// behind permissive CORS. Without a same-origin guard, any page the operator
+/// visits could drive those endpoints cross-origin (CSRF). This adopts the
+/// shared guard (`trusty_common::server::with_guarded_middleware`,
+/// mirroring #3317) router-wide so every route — including any merged in
+/// later — is covered (the #3268 lesson). The guard is method-gated
+/// (POST/PUT/PATCH/DELETE only), so `GET` reads and the `/api/events` SSE
+/// stream pass through untouched, and it fails open on a missing `Origin`
+/// header so server-side callers (the console reverse proxy, `curl`, the Tauri
+/// IPC path) keep working. `self_origins` additionally trusts the daemon's own
+/// resolved non-loopback bind address so a token-guarded remote bind still
+/// serves its own write UI (#3269).
+/// What: Registers the same routes as before, conditionally wraps `/api/*`
+/// with `auth_middleware` when a token is set (innermost), then applies
+/// `with_guarded_middleware` (guard + standard CORS/trace/gzip stack)
+/// router-wide.
+/// Test: `super::tests::guard` — cross-origin write → 403; loopback (browser
+/// same-origin) write → allowed; GET reads unaffected.
+pub fn build_router_with_origins(
+    state: AppState,
+    token: Option<String>,
+    self_origins: SelfOrigins,
+) -> Router {
     let auth_required = token.is_some();
     let config_route = get(move || async move { Json(ApiClientConfig { auth_required }) });
 
@@ -190,17 +189,20 @@ pub fn build_router_with_config(state: AppState, token: Option<String>) -> Route
         router = router.layer(middleware::from_fn_with_state(auth_state, auth_middleware));
     }
 
-    router
-        .layer(cors)
-        .layer(CompressionLayer::new())
-        .layer(TraceLayer::new_for_http())
+    // #3329: router-wide same-origin write guard + the shared standard
+    // middleware stack (permissive CORS, tracing, gzip), applied AFTER all
+    // route registration so every destructive route is covered (#3268 lesson).
+    // Replaces the crate-local CORS/compression/trace layers so trusty-agents
+    // no longer drifts from the sibling trusty-* daemons' middleware.
+    with_guarded_middleware(router, self_origins)
 }
 
-/// Serve the HTTP API and embedded web UI on `0.0.0.0:<port>` until killed.
+/// Serve the HTTP API and embedded web UI on `127.0.0.1:<port>` until killed.
 ///
 /// Why: Single-binary deployment — one process handles both API requests and
 /// serves the web frontend so users don't need a separate static-file server.
-/// What: Delegates to `serve_with_config` with an unauthenticated config.
+/// What: Delegates to `serve_with_config` with an unauthenticated,
+/// loopback-only config (#3329).
 /// Test: `cargo run -- --serve --port 7654 &` followed by
 /// `curl -s http://localhost:7654/ | grep -c 'app'` should return > 0.
 //
@@ -214,19 +216,37 @@ pub async fn serve(port: u16) -> Result<()> {
     serve_with_config(ApiConfig::unauthenticated(port)).await
 }
 
-/// Serve the HTTP API and embedded web UI, honoring `ApiConfig`. (#181)
+/// Serve the HTTP API and embedded web UI, honoring `ApiConfig`. (#181, #3329)
 ///
-/// Why: Bound on `0.0.0.0`, the server is reachable from any host on the
-/// LAN. We surface the LAN IP at startup so the operator can copy/paste the
-/// URL to other devices, and we loudly warn if no auth token is configured
-/// because the API can spawn arbitrary subprocesses.
-/// What: Resolves the LAN IP via the standard "connect a UDP socket to
-/// 8.8.8.8 and ask the kernel for the local addr" trick (no packet is
-/// actually sent — UDP is connectionless), prints localhost + LAN URLs,
-/// optionally warns on missing token, then serves until killed.
-/// Test: Manual — run `--api --port 7654` with and without `--api-token`
-/// and confirm the warning + LAN URL print as documented.
+/// Why: Loopback-only doctrine (#3329) — the API can spawn arbitrary
+/// subprocesses and mutate live sessions, so it binds `127.0.0.1` by default
+/// and REFUSES to start on a non-loopback interface without a token. For
+/// remote access the intended path is the trusty-console reverse proxy
+/// (`/api/agents/*`), not exposing this port directly. We also write the
+/// standard `http_addr` discovery file after bind so the console proxy can
+/// resolve this surface, and remove it on shutdown.
+/// What: Rejects a non-loopback `cfg.bind` when `cfg.token` is `None` with an
+/// actionable error; binds `cfg.bind:cfg.port`; builds the router trusting the
+/// resolved bind address as a self-origin for the write guard; writes/removes
+/// the `http_addr` discovery file; prints startup URLs (LAN URL only for a
+/// non-loopback bind); serves until killed.
+/// Test: `super::tests::guard::non_loopback_without_token_refuses_start`;
+/// manual — run `--api --port 7654` and confirm the discovery file appears.
 pub async fn serve_with_config(cfg: ApiConfig) -> Result<()> {
+    // #3329: loopback-only doctrine. An unauthenticated non-loopback bind would
+    // expose an arbitrary-subprocess-spawning API to the whole LAN — refuse it
+    // with an actionable error rather than binding silently.
+    if !cfg.bind.is_loopback() && cfg.token.is_none() {
+        anyhow::bail!(
+            "refusing to start the trusty-agents API on non-loopback bind {bind} without an API \
+             token: this API can spawn arbitrary subprocesses. Set --api-token <TOKEN> (or the \
+             TAGENT_API_TOKEN env var), or bind loopback (omit --bind for the 127.0.0.1 default). \
+             For remote access, front this surface with the trusty-console proxy (reachable as \
+             /api/agents/*) instead of exposing this port directly.",
+            bind = cfg.bind
+        );
+    }
+
     // #364: Don't block server startup on docs indexing. For projects with
     // many docs files, `DocsIndex::build` can take 5–15s, which pushes us
     // past the Tauri sidecar's 20s health-check budget and the user sees
@@ -267,24 +287,56 @@ pub async fn serve_with_config(cfg: ApiConfig) -> Result<()> {
     });
     // #212: Load persisted task snapshot so restarts don't lose history.
     let state = AppState::with_persistence(None).await;
-    let app = build_router_with_config(state, cfg.token.clone());
-    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], cfg.port));
+    let addr = std::net::SocketAddr::from((cfg.bind, cfg.port));
     tracing::info!(%addr, "trusty-agents api server listening");
     let listener = tokio::net::TcpListener::bind(addr).await?;
+
+    // Resolve the actual bound address (port may have been requested as 0) and
+    // trust it as a self-origin for the router-wide write guard so a
+    // token-guarded non-loopback bind still serves its own write UI (#3269);
+    // loopback binds are always trusted by the guard, so `from_bind_addrs`
+    // drops them.
+    let resolved = listener.local_addr().unwrap_or(addr);
+    let self_origins = SelfOrigins::from_bind_addrs(&[resolved]);
+    let app = build_router_with_origins(state, cfg.token.clone(), self_origins);
+
+    // #3331: publish the bound address via the standard `http_addr` discovery
+    // file so the trusty-console reverse proxy (and the connector poller) can
+    // resolve `/api/agents/*` to this daemon — the same mechanism the sibling
+    // daemons use. Best-effort: a missing $HOME / read-only fs is non-fatal.
+    if let Err(e) = trusty_common::write_daemon_addr("trusty-agents", &resolved.to_string()) {
+        tracing::warn!(?e, "could not write trusty-agents http_addr discovery file");
+    }
 
     let port = cfg.port;
     println!("[trusty-agents] API:    http://localhost:{port}/api");
     println!("[trusty-agents] Web UI: http://localhost:{port}/");
-    if let Some(lan_ip) = detect_lan_ip() {
+    // Only advertise a LAN URL when the operator explicitly opted into a
+    // non-loopback bind; the loopback default is not reachable off-host.
+    if !cfg.bind.is_loopback()
+        && let Some(lan_ip) = detect_lan_ip()
+    {
         println!("[trusty-agents] Web UI (LAN): http://{lan_ip}:{port}/");
     }
     if cfg.token.is_none() {
-        eprintln!("\u{26A0}  No API token set — server is unauthenticated");
+        eprintln!("\u{26A0}  No API token set — server is unauthenticated (loopback-only)");
     } else {
         eprintln!("[trusty-agents] API token authentication: enabled");
     }
 
-    axum::serve(listener, app).await?;
+    let serve_result = axum::serve(listener, app)
+        .with_graceful_shutdown(trusty_common::shutdown_signal())
+        .await;
+
+    // Remove the discovery file so stale clients fail fast instead of proxying
+    // to a dead port.
+    if let Err(e) = trusty_common::remove_daemon_addr("trusty-agents") {
+        tracing::warn!(
+            ?e,
+            "could not remove trusty-agents http_addr discovery file"
+        );
+    }
+    serve_result?;
     Ok(())
 }
 

--- a/crates/trusty-agents/src/api/server/tests/guard.rs
+++ b/crates/trusty-agents/src/api/server/tests/guard.rs
@@ -1,0 +1,155 @@
+//! Loopback-only doctrine tests (#3329): the router-wide same-origin write
+//! guard and the non-loopback-without-token startup refusal.
+//!
+//! Why: `POST /api/task` (and the `/api/tm/*`, `/api/ctrl/*`, `POST /rpc`
+//! surfaces) can spawn subprocesses and mutate live sessions. The shared
+//! `trusty_common::server::with_guarded_middleware` guard (adopted router-wide
+//! in `routes::build_router_with_origins`) must reject cross-origin writes
+//! (CSRF) while leaving GET reads, SSE, and the legitimate agents-ui webview
+//! path working. The webview-origin finding: in Tauri desktop mode every
+//! backend WRITE travels over Tauri IPC (`@tauri-apps/api/core#invoke`), never
+//! HTTP, so the guard never sees it; the only HTTP the desktop webview makes is
+//! the `GET /api/events` SSE stream (a safe method the guard ignores). In
+//! browser mode the SPA is served same-origin from `tagent --api`, so its
+//! `POST /api/task` carries a loopback `Origin`. Both paths are admitted below;
+//! a cross-origin `Origin` is rejected.
+//! What: exercises the guard via `oneshot` on `build_router` (loopback-only
+//! self-origins, the production test default) and asserts `serve_with_config`
+//! refuses an unauthenticated non-loopback bind.
+//! Test: this module IS the test.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use tower::ServiceExt;
+
+use crate::api::server::ApiConfig;
+use crate::api::server::routes::{build_router, serve_with_config};
+use crate::api::server::state::AppState;
+
+/// POST `/api/tm/sessions` carrying `origin`, returning the response status.
+///
+/// Why: `/api/tm/sessions` is a guarded write route that returns a clean 503
+/// (no TmManager in a default `AppState`) once the guard admits it — so a 403
+/// unambiguously came from the guard and a 503 unambiguously means the guard
+/// let the request through to the handler.
+/// What: builds a default (loopback-only) router and oneshots one POST.
+/// Test: used by every guard case below.
+async fn post_tm_sessions_with_origin(origin: Option<&str>) -> StatusCode {
+    let app = build_router(AppState::default());
+    let mut builder = Request::builder()
+        .method(Method::POST)
+        .uri("/api/tm/sessions")
+        .header(header::CONTENT_TYPE, "application/json");
+    if let Some(o) = origin {
+        builder = builder.header(header::ORIGIN, o);
+    }
+    let req = builder
+        .body(Body::from(r#"{"project_path":"/tmp"}"#))
+        .unwrap();
+    app.oneshot(req).await.unwrap().status()
+}
+
+/// Why: a genuinely cross-origin browser page firing `POST /api/tm/sessions`
+/// (CSRF) must be rejected with 403 by the router-wide guard.
+/// Test: this test.
+#[tokio::test]
+async fn cross_origin_write_rejected_403() {
+    let status = post_tm_sessions_with_origin(Some("http://evil.example.com")).await;
+    assert_eq!(
+        status,
+        StatusCode::FORBIDDEN,
+        "cross-origin write must be 403'd by the same-origin guard"
+    );
+}
+
+/// Why: the browser-mode agents-ui is served same-origin from `tagent --api`,
+/// so its writes carry a loopback `Origin` and MUST be admitted (the guard
+/// passes them to the handler, which returns 503 without a TmManager).
+/// Test: this test.
+#[tokio::test]
+async fn loopback_write_allowed() {
+    let status = post_tm_sessions_with_origin(Some("http://localhost:8765")).await;
+    assert_ne!(
+        status,
+        StatusCode::FORBIDDEN,
+        "loopback (browser same-origin) write must NOT be blocked by the guard"
+    );
+    assert_eq!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "admitted write should reach the handler (503 without a TmManager)"
+    );
+}
+
+/// Why: server-side callers (the console reverse proxy, curl, the Tauri IPC
+/// path) send no `Origin` header; the guard fails open on a missing Origin so
+/// those keep working.
+/// Test: this test.
+#[tokio::test]
+async fn missing_origin_write_allowed() {
+    let status = post_tm_sessions_with_origin(None).await;
+    assert_ne!(status, StatusCode::FORBIDDEN);
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// Why: the real Origin a Tauri (macOS) webview presents on any HTTP request is
+/// `tauri://localhost`, which the shared guard classifies as loopback (host ==
+/// "localhost"). Documenting it here proves the desktop webview is admitted
+/// even on the (IPC-only in practice) write path, not just for its SSE GET.
+/// Test: this test.
+#[tokio::test]
+async fn tauri_localhost_origin_allowed() {
+    let status = post_tm_sessions_with_origin(Some("tauri://localhost")).await;
+    assert_ne!(
+        status,
+        StatusCode::FORBIDDEN,
+        "the Tauri webview origin (tauri://localhost) must be admitted as loopback"
+    );
+}
+
+/// Why: the guard is method-gated — GET reads leak no destructive capability
+/// and must pass through untouched even from a cross-origin page.
+/// Test: this test.
+#[tokio::test]
+async fn cross_origin_get_read_unaffected() {
+    let app = build_router(AppState::default());
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/health")
+        .header(header::ORIGIN, "http://evil.example.com")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a safe GET must never be blocked by the write guard"
+    );
+}
+
+/// Why: loopback-only doctrine (#3329) — an unauthenticated non-loopback bind
+/// exposes an arbitrary-subprocess-spawning API to the LAN and MUST be refused
+/// at startup with an actionable error, before any listener is bound.
+/// What: `serve_with_config` bails at the top of the function (before the docs
+/// spawn / bind), so this asserts the refusal without opening a socket.
+/// Test: this test.
+#[tokio::test]
+async fn non_loopback_without_token_refuses_start() {
+    let cfg = ApiConfig {
+        bind: std::net::Ipv4Addr::UNSPECIFIED.into(), // 0.0.0.0
+        port: 0,
+        token: None,
+    };
+    let err = serve_with_config(cfg)
+        .await
+        .expect_err("non-loopback bind without a token must refuse to start");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("non-loopback") && msg.contains("token"),
+        "refusal must be actionable (mention non-loopback + token), got: {msg}"
+    );
+    assert!(
+        msg.contains("/api/agents/*"),
+        "refusal should point at the console proxy as the intended remote path, got: {msg}"
+    );
+}

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -9,6 +9,7 @@
 mod agent_patch;
 mod cancel;
 mod ctrl_sessions;
+mod guard;
 mod listing;
 mod models;
 

--- a/crates/trusty-agents/src/runtime/cli_def.rs
+++ b/crates/trusty-agents/src/runtime/cli_def.rs
@@ -166,6 +166,14 @@ pub(super) struct Cli {
     #[arg(long)]
     pub(super) port: Option<u16>,
 
+    /// Interface to bind the API server on (#3329). Defaults to loopback
+    /// (`127.0.0.1`). A non-loopback bind (e.g. `0.0.0.0`) is an explicit
+    /// opt-in and REQUIRES `--api-token`; the server refuses to start
+    /// unauthenticated on a non-loopback interface. Prefer the trusty-console
+    /// proxy (`/api/agents/*`) for remote access over binding this directly.
+    #[arg(long)]
+    pub(super) bind: Option<std::net::IpAddr>,
+
     /// Bearer token required for `POST /api/task` (overrides
     /// `TAGENT_API_TOKEN`).
     #[arg(long = "api-token")]

--- a/crates/trusty-agents/src/runtime/mode_dispatch.rs
+++ b/crates/trusty-agents/src/runtime/mode_dispatch.rs
@@ -213,7 +213,13 @@ pub(super) async fn dispatch_cli_mode(
             .clone()
             .or_else(|| crate::env_compat::env_var("TAGENT_API_TOKEN", "OPEN_MPM_API_TOKEN").ok())
             .filter(|s| !s.is_empty());
+        // #3329: default to loopback; `--bind` is the explicit non-loopback
+        // opt-in (which serve_with_config gates on a token being present).
+        let bind = cli
+            .bind
+            .unwrap_or_else(|| std::net::Ipv4Addr::LOCALHOST.into());
         return crate::api::server::serve_with_config(crate::api::server::ApiConfig {
+            bind,
             port,
             token,
         })

--- a/crates/trusty-agents/src/runtime/startup.rs
+++ b/crates/trusty-agents/src/runtime/startup.rs
@@ -272,7 +272,27 @@ pub(super) async fn run_startup_init(_args: &[String]) -> Result<bool> {
                     crate::env_compat::env_var("TAGENT_API_TOKEN", "OPEN_MPM_API_TOKEN").ok()
                 })
                 .filter(|s| !s.is_empty());
-            api::server::serve_with_config(api::server::ApiConfig { port, token }).await?;
+            // #3329: `--bind <addr>` / `--bind=<addr>`; default loopback. A
+            // non-loopback bind without a token is refused inside
+            // serve_with_config (loopback-only doctrine).
+            let mut bind: std::net::IpAddr = std::net::Ipv4Addr::LOCALHOST.into();
+            let mut iter = raw_args.iter();
+            while let Some(a) = iter.next() {
+                if a == "--bind"
+                    && let Some(v) = iter.next()
+                    && let Ok(ip) = v.parse::<std::net::IpAddr>()
+                {
+                    bind = ip;
+                    break;
+                }
+                if let Some(rest) = a.strip_prefix("--bind=")
+                    && let Ok(ip) = rest.parse::<std::net::IpAddr>()
+                {
+                    bind = ip;
+                    break;
+                }
+            }
+            api::server::serve_with_config(api::server::ApiConfig { bind, port, token }).await?;
             return Ok(false);
         }
     }

--- a/crates/trusty-console/CHANGELOG.md
+++ b/crates/trusty-console/CHANGELOG.md
@@ -8,6 +8,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **trusty-agents proxy route (#3331):** `agents` is now in the reverse-proxy
+  allowlist, so the trusty-agents API surface is reachable via `/api/agents/*`.
+  Under the loopback-only doctrine (#3328) the agents daemon binds `127.0.0.1`
+  by default, making this console proxy the intended remote path to it. A new
+  `AgentsConnector` resolves the daemon's live base URL from the standard
+  `http_addr` discovery file — the same mechanism the other proxied siblings use
+  (`resolve_data_dir("trusty-agents")/http_addr`, gated on the `tagent` binary).
+  `all_connectors()` now returns six connectors.
+
 ### Changed
 
 - **Security (internal):** the write-origin (CSRF) guard implementation moved

--- a/crates/trusty-console/src/detect/agents.rs
+++ b/crates/trusty-console/src/detect/agents.rs
@@ -1,0 +1,201 @@
+//! `ServiceConnector` implementation for `trusty-agents` (#3331).
+//!
+//! Why: the loopback-only doctrine (#3328) makes the trusty-console reverse
+//! proxy the intended remote path to the trusty-agents API (which now binds
+//! `127.0.0.1` by default, #3329). For the `/api/agents/*` proxy route to
+//! resolve an upstream URL, the connector must surface the daemon's live base
+//! URL — exactly as the trusty-mpm connector does.
+//! What: `AgentsConnector` implements `ServiceConnector::detect()` using the
+//! standard `trusty-common` `http_addr` discovery file written by the daemon
+//! after bind (`serve_with_config` calls `write_daemon_addr("trusty-agents")`).
+//! Path: binary check (`tagent`) → `resolve_data_dir("trusty-agents")/http_addr`
+//! → TCP probe → `Running`/`Available`/`Absent`. The daemon writes no TOML
+//! lock file, so there is no lock-file fallback (unlike the mpm connector).
+//! Test: `agents_connector_absent_binary`, `agents_connector_no_addr_file`,
+//! `agents_connector_surfaces_url_via_http_addr` below.
+
+use crate::connector::{ServiceConnector, ServiceInfo, ServiceStatus};
+
+use super::helpers::{binary_on_path, detect_service};
+
+/// ServiceConnector for `trusty-agents`.
+///
+/// Why: surfaces the running trusty-agents API daemon in the console Overview
+/// and enables the `/api/agents/*` reverse-proxy route by providing the
+/// daemon's live base URL via the standard `http_addr` discovery file (#3331).
+/// What: implements `detect()` using the standard `trusty-common` data-dir
+/// discovery path (`resolve_data_dir("trusty-agents")/http_addr`) written by
+/// the daemon on bind. The primary (`tagent`) binary is the presence gate.
+/// Test: unit tests below; run with `cargo test -p trusty-console`.
+pub struct AgentsConnector {
+    _priv: (),
+}
+
+impl AgentsConnector {
+    /// Create a new `AgentsConnector`.
+    ///
+    /// Why: production callers use `new()`; there is no home override because
+    /// detection reads the OS data dir via `resolve_data_dir` (overridable in
+    /// tests through `TRUSTY_DATA_DIR_OVERRIDE`).
+    /// What: stores no state.
+    /// Test: created in `all_connectors()` and in unit tests.
+    pub fn new() -> Self {
+        Self { _priv: () }
+    }
+}
+
+impl Default for AgentsConnector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ServiceConnector for AgentsConnector {
+    fn id(&self) -> &'static str {
+        "trusty-agents"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Trusty Agents"
+    }
+
+    /// Detect trusty-agents status, surfacing the daemon URL when reachable.
+    ///
+    /// Why: the `/api/agents/*` proxy handler resolves the daemon base URL from
+    /// this connector's `ServiceInfo.url`, so `detect()` must surface a URL when
+    /// the daemon is reachable via the standard `http_addr` discovery file.
+    /// What: binary check (`tagent`) →
+    /// `resolve_data_dir("trusty-agents")/http_addr` → TCP probe → `Running`
+    /// with `url: Some(base_url)`; binary present but no reachable addr file →
+    /// `Available`; binary absent → `Absent`. Delegates to the shared
+    /// `detect_service()` helper (addr-file read, TCP probe, version fetch).
+    /// Test: `agents_connector_surfaces_url_via_http_addr` (primary path),
+    /// `agents_connector_no_addr_file`, `agents_connector_absent_binary`.
+    fn detect(&self) -> ServiceInfo {
+        // `resolve_data_dir` is infallible in practice; if the data directory
+        // cannot be resolved, report status purely on binary presence.
+        if let Ok(dir) = trusty_common::resolve_data_dir("trusty-agents") {
+            return detect_service(
+                self.id(),
+                self.display_name(),
+                "tagent",
+                dir.join("http_addr"),
+            );
+        }
+
+        ServiceInfo {
+            id: self.id().to_string(),
+            display_name: self.display_name().to_string(),
+            status: if binary_on_path("tagent") {
+                ServiceStatus::Available
+            } else {
+                ServiceStatus::Absent
+            },
+            version: None,
+            url: None,
+            hint: None,
+        }
+    }
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::super::ENV_LOCK;
+    use super::*;
+    use std::fs;
+    use std::net::TcpListener;
+    use tempfile::TempDir;
+    use trusty_common::DATA_DIR_OVERRIDE_ENV;
+
+    /// Why: with no binary on PATH the connector must report Absent regardless
+    /// of any stale discovery file.
+    /// Test: this test.
+    #[test]
+    fn agents_connector_absent_binary() {
+        // Only meaningful when the binary is genuinely not installed (CI).
+        if which::which("tagent").is_ok() {
+            return;
+        }
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let data_tmp = TempDir::new().expect("data-tempdir");
+        unsafe {
+            std::env::set_var(DATA_DIR_OVERRIDE_ENV, data_tmp.path());
+        }
+        let info = AgentsConnector::new().detect();
+        unsafe {
+            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
+        }
+        assert_eq!(info.status, ServiceStatus::Absent);
+        assert_eq!(info.id, "trusty-agents");
+        assert_eq!(info.display_name, "Trusty Agents");
+    }
+
+    /// Why: no http_addr file with the binary present must yield Available (not
+    /// Running); binary absent yields Absent.
+    /// Test: this test.
+    #[test]
+    fn agents_connector_no_addr_file() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let data_tmp = TempDir::new().expect("data-tempdir");
+        unsafe {
+            std::env::set_var(DATA_DIR_OVERRIDE_ENV, data_tmp.path());
+        }
+        let info = AgentsConnector::new().detect();
+        unsafe {
+            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
+        }
+        assert!(info.url.is_none());
+        if which::which("tagent").is_ok() {
+            assert_eq!(info.status, ServiceStatus::Available);
+        } else {
+            assert_eq!(info.status, ServiceStatus::Absent);
+        }
+    }
+
+    /// Why: the primary path (#3331) must surface `url: Some(base_url)` when the
+    /// http_addr file exists and the port is reachable — this is what the proxy
+    /// handler reads to forward `/api/agents/*` requests.
+    /// What: writes a valid addr to the standard http_addr file under a temp
+    /// TRUSTY_DATA_DIR_OVERRIDE, binds a real listening port so tcp_probe passes,
+    /// calls detect(), and asserts the url and Running status.
+    /// Test: this test (key regression guard for #3331).
+    #[test]
+    fn agents_connector_surfaces_url_via_http_addr() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let data_tmp = TempDir::new().expect("data-tempdir");
+        unsafe {
+            std::env::set_var(DATA_DIR_OVERRIDE_ENV, data_tmp.path());
+        }
+        // Write the http_addr file with a listening port so tcp_probe passes.
+        let agents_dir = data_tmp.path().join("trusty-agents");
+        fs::create_dir_all(&agents_dir).expect("mkdir");
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind free port");
+        let addr = listener.local_addr().expect("local_addr").to_string();
+        fs::write(agents_dir.join("http_addr"), &addr).expect("write addr");
+
+        let info = AgentsConnector::new().detect();
+
+        // Drop listener after detect() so the port is open during the probe.
+        drop(listener);
+        unsafe {
+            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
+        }
+
+        if which::which("tagent").is_ok() {
+            assert_eq!(
+                info.status,
+                ServiceStatus::Running,
+                "http_addr present + port open must yield Running, got: {info:?}"
+            );
+            assert_eq!(
+                info.url,
+                Some(format!("http://{addr}")),
+                "Running status must include daemon base URL for proxy routing"
+            );
+        } else {
+            assert_eq!(info.status, ServiceStatus::Absent);
+        }
+    }
+}

--- a/crates/trusty-console/src/detect/mod.rs
+++ b/crates/trusty-console/src/detect/mod.rs
@@ -17,6 +17,7 @@
 //! `with_home` constructor so they never touch the real user's files. Run with
 //! `cargo test -p trusty-console`.
 
+mod agents;
 mod analyze;
 mod helpers;
 mod memory;
@@ -24,6 +25,7 @@ mod mpm;
 mod review;
 mod search;
 
+pub use agents::AgentsConnector;
 pub use analyze::AnalyzeConnector;
 pub use memory::MemoryConnector;
 pub use mpm::MpmConnector;
@@ -32,16 +34,31 @@ pub use search::SearchConnector;
 
 use crate::connector::ServiceConnector;
 
+/// Process-wide lock serialising every test that mutates the global
+/// `TRUSTY_DATA_DIR_OVERRIDE` env var.
+///
+/// Why: both the mpm and agents connector tests point `resolve_data_dir` at a
+/// tempdir via that ONE process-global env var. Per-module locks do NOT
+/// serialise across modules, so two such tests in different modules could
+/// clobber each other's override and race (#3331 regression: the agents tests
+/// racing the mpm lock-file test). A single shared lock in the common parent
+/// module serialises them all.
+/// What: a `std::sync::Mutex<()>` locked by every env-mutating connector test.
+/// Test: used by `agents::tests` and `mpm::tests`; not itself a test.
+#[cfg(test)]
+pub(super) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Return all connectors in display order.
 ///
 /// Why: Centralises the connector list so the server and any future CLI
 /// command iterate the same set. Issue #1163 lifts the prior #1069 exclusion
 /// of trusty-review: the Review dashboard tab is now fully implemented with a
 /// `console_metrics` MCP tool, so the service is included in the Overview.
-/// What: Returns a `Vec<Box<dyn ServiceConnector>>` with five connectors:
+/// What: Returns a `Vec<Box<dyn ServiceConnector>>` with six connectors:
 /// search, memory, analyze, review, mpm (#1222 adds trusty-mpm for the Sessions
-/// tab).
-/// Test: `test_all_connectors_returns_five` below.
+/// tab), agents (#3331 adds trusty-agents so `/api/agents/*` resolves an
+/// upstream under the loopback-only doctrine).
+/// Test: `test_all_connectors_returns_six` below.
 pub fn all_connectors() -> Vec<Box<dyn ServiceConnector>> {
     vec![
         Box::new(SearchConnector::new()),
@@ -49,6 +66,7 @@ pub fn all_connectors() -> Vec<Box<dyn ServiceConnector>> {
         Box::new(AnalyzeConnector::new()),
         Box::new(ReviewConnector::new()),
         Box::new(MpmConnector::new()),
+        Box::new(AgentsConnector::new()),
     ]
 }
 
@@ -58,18 +76,20 @@ pub fn all_connectors() -> Vec<Box<dyn ServiceConnector>> {
 mod tests {
     use super::*;
 
-    /// Why: the registry must return exactly five connectors in order (search,
-    /// memory, analyze, review, mpm — #1222 adds trusty-mpm for the Sessions tab).
+    /// Why: the registry must return exactly six connectors in order (search,
+    /// memory, analyze, review, mpm — #1222; agents — #3331 for the
+    /// `/api/agents/*` proxy under the loopback-only doctrine).
     /// What: calls all_connectors() and checks IDs.
     /// Test: this test itself.
     #[test]
-    fn test_all_connectors_returns_five() {
+    fn test_all_connectors_returns_six() {
         let cs = all_connectors();
-        assert_eq!(cs.len(), 5);
+        assert_eq!(cs.len(), 6);
         assert_eq!(cs[0].id(), "trusty-search");
         assert_eq!(cs[1].id(), "trusty-memory");
         assert_eq!(cs[2].id(), "trusty-analyze");
         assert_eq!(cs[3].id(), "trusty-review");
         assert_eq!(cs[4].id(), "trusty-mpm");
+        assert_eq!(cs[5].id(), "trusty-agents");
     }
 }

--- a/crates/trusty-console/src/detect/mpm.rs
+++ b/crates/trusty-console/src/detect/mpm.rs
@@ -205,16 +205,11 @@ mod tests {
     use std::fs;
     use std::net::TcpListener;
     use tempfile::TempDir;
+    // #3331: use the shared `detect::ENV_LOCK` so these env-mutating tests
+    // serialise against the sibling agents-connector tests, which also point
+    // `resolve_data_dir` at a tempdir via the same process-global env var.
+    use super::super::ENV_LOCK;
     use trusty_common::DATA_DIR_OVERRIDE_ENV;
-
-    /// Mutex serialising tests that mutate `TRUSTY_DATA_DIR_OVERRIDE`.
-    ///
-    /// Why: concurrent tests that set the same env var race with each other
-    /// and with trusty-common's own test suite when run in the same binary.
-    /// Sharing one lock prevents spurious env-var clobber failures.
-    /// What: a `std::sync::Mutex<()>` locked by every env-mutating test.
-    /// Test: used by the tests in this module; not itself a test.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// Why: the TCP probe needs a bare host:port; the parser must strip the TOML
     /// quoting and the `http://` scheme.

--- a/crates/trusty-console/src/proxy/routes.rs
+++ b/crates/trusty-console/src/proxy/routes.rs
@@ -59,6 +59,12 @@ fn full_id(service_key: &str) -> Option<&'static str> {
         // forward requests to the live trusty-mpm HTTP daemon via its base URL
         // resolved from the standard http_addr discovery file.
         "mpm" => Some("trusty-mpm"),
+        // #3331: agents added so the trusty-agents API surface is reachable via
+        // `/api/agents/*`. Under the loopback-only doctrine (#3328) the agents
+        // daemon binds 127.0.0.1 by default, so this console proxy is the
+        // intended remote path to it — resolved from the same `http_addr`
+        // discovery file the other entries use (see `detect::AgentsConnector`).
+        "agents" => Some("trusty-agents"),
         _ => None,
     }
 }
@@ -531,6 +537,8 @@ mod tests {
         assert_eq!(full_id("review"), Some("trusty-review"));
         // #1849 Phase 1: mpm must be in the allowlist.
         assert_eq!(full_id("mpm"), Some("trusty-mpm"));
+        // #3331: agents must be in the allowlist so `/api/agents/*` proxies.
+        assert_eq!(full_id("agents"), Some("trusty-agents"));
         assert_eq!(full_id("unknown"), None);
     }
 

--- a/crates/trusty-console/src/service.rs
+++ b/crates/trusty-console/src/service.rs
@@ -297,6 +297,13 @@ mod tests {
                 7890,
                 "trusty-embedderd/src/lib.rs::Args::http_addr (--http default_value, manual/dev-run only)",
             ),
+            (
+                // #3331: trusty-agents joined the proxied-sibling set; its API
+                // server default port must not collide with the console's.
+                "trusty-agents",
+                8080,
+                "trusty-agents/src/runtime/mode_dispatch.rs (--port default 8080)",
+            ),
         ];
         for (binary, port, source) in known_siblings {
             assert_ne!(


### PR DESCRIPTION
## Loopback-only doctrine tranche (part of #3328)

Bob-approved doctrine: **the trusty-console proxy is the only non-loopback HTTP surface.** This PR retires the trusty-agents API server's unconditional `0.0.0.0` bind and makes the agents surface reachable through the console at `/api/agents/*`.

Closes #3329
Closes #3331

## trusty-agents (#3329)

- **Default bind `127.0.0.1`** (was unconditional `0.0.0.0`). Non-loopback is an explicit opt-in via the new `--bind <addr>` flag, wired into **both** dispatch paths (the clap parse in `mode_dispatch.rs` and the early argv-scan sidecar path in `startup.rs`).
- **`serve_with_config` refuses to start** on a non-loopback bind without an API token (`--api-token` / `TAGENT_API_TOKEN`), bailing *before* any listener binds with an actionable error that names the console proxy (`/api/agents/*`) as the intended remote path.
- **Adopts the shared same-origin write guard** `trusty_common::server::with_guarded_middleware` (mirroring #3317) **router-wide, after all route registration** (the #3268 lesson). Method-gated: `POST/PUT/PATCH/DELETE` writes to `/api/task`, `/api/tm/*`, `/api/ctrl/*`, `POST /rpc` get CSRF-guarded; `GET` reads and the `/api/events` SSE stream are untouched. `SelfOrigins::from_bind_addrs` trusts the resolved bind addr so a token-guarded non-loopback bind still serves its own UI (#3269). Enables the `axum-server` feature on the agents→trusty-common dep. Replaces the crate-local CORS/compression/trace stack with the shared standard middleware (permissive CORS is now a superset — the guard is the real write lock).
- **Writes the standard `http_addr` discovery file** on bind / removes on graceful shutdown so the console proxy can resolve this surface.
- **Internal per-project search daemon** (`search/service/mod.rs:312`) already binds `127.0.0.1:0` — confirmed loopback-only, no change (its guard adoption is a separate issue, as scoped).

## trusty-console (#3331)

- Add `agents` to the reverse-proxy allowlist (`full_id()` → `trusty-agents`).
- New `AgentsConnector` resolves the daemon URL from the `http_addr` discovery file (`resolve_data_dir("trusty-agents")`, gated on the `tagent` binary), mirroring the mpm connector's primary path; registered in `all_connectors()` (now six).
- Hoisted a shared `detect::ENV_LOCK` so the agents + mpm env-mutating tests serialise on the process-global `TRUSTY_DATA_DIR_OVERRIDE` (fixes a cross-module race the new tests would otherwise introduce).

## agents-ui webview-origin finding

**The guard does not break the webview**, in either mode:

- **Tauri desktop mode:** every backend *write* (`send_message`, `cancel_task`, `list_tasks`, `check_health`) routes through Tauri IPC (`@tauri-apps/api/core#invoke` in `ui/src/lib/transport.ts`), **never HTTP** — so the guard never sees it. The *only* HTTP the desktop webview makes is the `GET /api/events` SSE stream (`connectEventSource`, always `EventSource`), a safe method the guard ignores. Even if a desktop write ever went over HTTP, the WKWebView Origin `tauri://localhost` is classified loopback by the shared guard (host == `localhost`).
- **Browser (`pnpm dev`) mode:** the SPA is served same-origin from `tagent --api` (`apiBase()` returns `''` → same-origin), so `POST /api/task` carries a loopback `Origin` and is admitted.

Tests assert cross-origin → 403, loopback / missing-Origin / `tauri://localhost` → allowed, `GET` read pass-through, and the non-loopback-without-token startup refusal.

## Key wiring points (file:line)

- `crates/trusty-agents/src/api/server/auth.rs:32` — `ApiConfig.bind` field (default loopback)
- `crates/trusty-agents/src/api/server/routes.rs` — `build_router_with_origins` (guard adoption) + `serve_with_config` (refusal, bind, `http_addr` write/remove)
- `crates/trusty-agents/src/runtime/cli_def.rs` — `--bind` flag
- `crates/trusty-agents/src/runtime/mode_dispatch.rs` / `startup.rs` — bind parsing in both dispatch paths
- `crates/trusty-console/src/proxy/routes.rs:53` — `full_id()` adds `agents`
- `crates/trusty-console/src/detect/agents.rs` — `AgentsConnector`
- `crates/trusty-console/src/detect/mod.rs` — registration + shared `ENV_LOCK`

## Gates (raw tails)

- `cargo test -p trusty-console` → **149 passed; 0 failed; 1 ignored**
- `cargo test -p trusty-agents` → **1913 passed; 1 failed** — the one failure (`workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts`) is a pre-existing flake unrelated to this change; it **passes in isolation** on rerun. The 6 new `api::server::tests::guard::*` tests all pass.
- `cargo fmt --check` → clean (exit 0)
- `bash scripts/check_line_cap.sh` → `7 allowlisted, 0 violations — OK`
- `bash scripts/check_capabilities.sh` → `up to date (6 generated files)`
- `cargo clippy --all-targets` was permission-blocked locally; deferred to CI.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools