### PR TITLE
feat(trusty-code): workstream SSE event aggregation route + activation events (closes #3297)

### DIFF
--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -665,6 +665,81 @@ pub enum Event {
         compaction_rounds: usize,
     },
 
+    // -- Workstream lifecycle (DOC-48 §5.3/§6.3, issue #3297) --
+    /// The daemon-wide active workstream changed: `workstream.activate`
+    /// switched to a different workstream (or activated one from no prior
+    /// active workstream), or `workstream.deactivate` cleared the pointer
+    /// with no successor (`crate::workstreams::activation::{activate,
+    /// deactivate}` are the sole emitters — see their docs).
+    ///
+    /// Why: DOC-48 AC-3.3 requires every client observing a workstream to
+    /// learn when the active workstream changes, including a workstream that
+    /// was active learning it just got DEACTIVATED (so it can stop treating
+    /// itself as the ambient default target, §4.2) — not just clients of the
+    /// newly-active one. `crate::events::Event` was, until now, exhaustively
+    /// session-scoped (every variant but `Ping` carries a `session_id`); this
+    /// is a genuinely DAEMON-scoped signal with no owning session, so it
+    /// reuses the SAME global broadcast bus (the one mechanism already wired
+    /// to every live SSE subscriber) rather than standing up a second,
+    /// parallel channel purely to carry one event type — the aggregation
+    /// route (`crate::workstreams::sse::aggregate_live`) already subscribes
+    /// to this bus for its per-session fan-out, so no extra subscription is
+    /// needed to also observe this variant.
+    /// What: `new_active_id` is `Some(id)` for both a fresh activation (no
+    /// prior active workstream) and a force-switch; `None` exactly when
+    /// `workstream.deactivate` cleared the pointer with no successor — this
+    /// widens DOC-48 §5.3's literal `{new_active_id: UUID, prior_id?}` table
+    /// (which only anticipates a switch always landing on a new active
+    /// workstream) to also cover deactivation, a case the table's shape
+    /// otherwise cannot express. `prior_id` is the workstream that was active
+    /// immediately before this change, `None` when there wasn't one. Emitted
+    /// only when the persisted active pointer ACTUALLY changed — not on an
+    /// idempotent re-activation of the already-active workstream, nor on a
+    /// deactivate of a non-active workstream (both are true no-ops).
+    /// Not session-scoped: `Event::session_id()` returns `None` for this
+    /// variant, same as `Event::Ping`.
+    /// Test: `workstreams::activation_tests::activate_with_no_prior_active_publishes_activation_changed`,
+    /// `workstreams::activation_tests::activate_with_force_publishes_activation_changed_with_prior`,
+    /// `workstreams::activation_tests::activate_already_active_does_not_publish`,
+    /// `workstreams::activation_tests::deactivate_active_publishes_activation_changed`,
+    /// `workstreams::activation_tests::deactivate_non_active_does_not_publish`.
+    WorkstreamActivationChanged {
+        new_active_id: Option<String>,
+        prior_id: Option<String>,
+    },
+
+    /// A workstream's computed state (DOC-48 §2.2: `active | idle | closed`)
+    /// actually transitioned — fired by `workstream.activate`/`deactivate`
+    /// (`crate::workstreams::activation`) and `workstream.close`
+    /// (`crate::workstreams::protocol::close`) whenever they change it.
+    ///
+    /// Why: DOC-48 §5.3's event table lists this alongside
+    /// `WorkstreamActivationChanged` as part of the minimal Phase 1A set — a
+    /// client observing one workstream via `GET /workstreams/{id}/events`
+    /// needs to learn its OWN state changed (e.g. it was closed) even when no
+    /// bound session emitted anything, the same gap `WorkstreamActivationChanged`
+    /// fills for the daemon-wide active pointer.
+    /// What: `workstream_id` names which workstream transitioned; `state` is
+    /// its NEW state as a lowercase string (`"active"` | `"idle"` |
+    /// `"closed"`) — deliberately a plain string rather than
+    /// `crate::workstreams::WorkstreamState` so this module stays
+    /// domain-decoupled, matching `Event::IndexReadiness`/
+    /// `SessionStatusChanged`'s existing "state as a plain string"
+    /// convention. `reason` is a short human-readable cause (e.g.
+    /// `"activated"`, `"activated (force-switch)"`, `"deactivated"`,
+    /// `"closed"`).
+    /// Not session-scoped — grouped with `WorkstreamActivationChanged` and
+    /// `Ping` in `session_id()`.
+    /// Test: `workstreams::activation_tests::activate_with_no_prior_active_publishes_state_inferred`,
+    /// `workstreams::activation_tests::activate_with_force_publishes_state_inferred_for_both`,
+    /// `workstreams::activation_tests::deactivate_active_publishes_state_inferred_idle`,
+    /// `workstreams::protocol_tests::close_publishes_state_inferred`.
+    WorkstreamStateInferred {
+        workstream_id: String,
+        state: String,
+        reason: String,
+    },
+
     // -- Keepalive --
     Ping,
 }
@@ -828,7 +903,9 @@ impl Event {
             | Event::RecapGenerated { session_id, .. }
             | Event::IndexReadiness { session_id, .. }
             | Event::ContextBudget { session_id, .. } => Some(session_id),
-            Event::Ping => None,
+            Event::WorkstreamActivationChanged { .. }
+            | Event::WorkstreamStateInferred { .. }
+            | Event::Ping => None,
         }
     }
 
@@ -879,6 +956,8 @@ impl Event {
             Event::RecapGenerated { .. } => "recap_generated",
             Event::IndexReadiness { .. } => "index_readiness",
             Event::ContextBudget { .. } => "context_budget",
+            Event::WorkstreamActivationChanged { .. } => "workstream_activation_changed",
+            Event::WorkstreamStateInferred { .. } => "workstream_state_inferred",
             Event::Ping => "ping",
         }
     }

--- a/crates/trusty-code/src/events_tests.rs
+++ b/crates/trusty-code/src/events_tests.rs
@@ -40,6 +40,30 @@ fn session_id_returns_correct_field() {
     assert_eq!(Event::Ping.session_id(), None);
 }
 
+/// (issue #3297) `WorkstreamActivationChanged` is daemon-scoped, not
+/// session-scoped — mirrors `Event::Ping`'s `None`.
+#[test]
+fn workstream_activation_changed_is_not_session_scoped() {
+    let ev = Event::WorkstreamActivationChanged {
+        new_active_id: Some("ws-2".into()),
+        prior_id: Some("ws-1".into()),
+    };
+    assert_eq!(ev.session_id(), None);
+    assert_eq!(ev.kind(), "workstream_activation_changed");
+}
+
+/// (issue #3297) `WorkstreamStateInferred` is likewise daemon-scoped.
+#[test]
+fn workstream_state_inferred_is_not_session_scoped() {
+    let ev = Event::WorkstreamStateInferred {
+        workstream_id: "ws-1".into(),
+        state: "closed".into(),
+        reason: "closed".into(),
+    };
+    assert_eq!(ev.session_id(), None);
+    assert_eq!(ev.kind(), "workstream_state_inferred");
+}
+
 #[test]
 fn bus_is_singleton() {
     let a = bus();
@@ -189,6 +213,15 @@ fn kind_matches_serde_tag_for_every_variant() {
             within_budget: true,
             compaction_fired: false,
             compaction_rounds: 0,
+        },
+        Event::WorkstreamActivationChanged {
+            new_active_id: Some("ws-2".into()),
+            prior_id: Some("ws-1".into()),
+        },
+        Event::WorkstreamStateInferred {
+            workstream_id: "ws-1".into(),
+            state: "idle".into(),
+            reason: "deactivated".into(),
         },
         Event::Ping,
     ];

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -62,6 +62,7 @@ use crate::jsonrpc::{ConnectionContext, Router};
 use crate::serve::methods::health_payload;
 use crate::serve::rest;
 use crate::session::SessionRegistry;
+use crate::workstreams::SharedWorkstreamStore;
 
 /// Shared axum state: the JSON-RPC router (for `POST /rpc`) and the session
 /// registry (for the SSE route, which reads it directly rather than going
@@ -99,8 +100,10 @@ struct HttpState {
 /// surface: `POST /workstreams`, `GET /workstreams/{id}`, `GET /workstreams`,
 /// `POST /workstreams/{id}/close` (issue #3295) plus
 /// `POST /workstreams/{id}/activate`/`.../deactivate` (DOC-48 §5.2, issue
-/// #3294) — none of which collide with the paths registered directly on
-/// this router or with each other.
+/// #3294) — plus (issue #3297) `GET /workstreams/{id}/events` (the
+/// workstream-level SSE aggregation route, `crate::workstreams::sse::routes`)
+/// — none of which collide with the paths registered directly on this
+/// router or with each other.
 /// Test: `http_rpc_ping_returns_pong`,
 /// `http_rpc_malformed_json_returns_parse_error`,
 /// `http_health_matches_jsonrpc_health_payload`,
@@ -112,8 +115,13 @@ struct HttpState {
 /// `http_rest_get_session_agents_route_is_merged_in`,
 /// `http_rest_get_session_budget_route_is_merged_in`,
 /// `http_rest_get_session_search_audit_route_is_merged_in`,
-/// `http_rest_get_workstreams_route_is_merged_in`.
-pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) -> AxumRouter {
+/// `http_rest_get_workstreams_route_is_merged_in` (also pins the
+/// `GET /workstreams/{id}/events` merge).
+pub fn build_axum_router(
+    router: Arc<Router>,
+    sessions: Arc<SessionRegistry>,
+    workstreams: SharedWorkstreamStore,
+) -> AxumRouter {
     let state = HttpState {
         router: router.clone(),
         sessions,
@@ -130,7 +138,8 @@ pub fn build_axum_router(router: Arc<Router>, sessions: Arc<SessionRegistry>) ->
         .merge(rest::fs::routes(router.clone()))
         .merge(rest::agents::routes(router.clone()))
         .merge(rest::search_audit::routes(router.clone()))
-        .merge(rest::workstreams::routes(router));
+        .merge(rest::workstreams::routes(router))
+        .merge(crate::workstreams::sse::routes(workstreams));
     trusty_common::server::with_standard_middleware(app)
 }
 
@@ -254,7 +263,12 @@ fn sse_event_for(envelope: &crate::events::SessionEventEnvelope) -> SseEvent {
 /// Test: not directly unit-tested (would require a real socket + a real
 /// signal); [`build_axum_router`]'s tests cover the routing/dispatch logic
 /// this serves.
-pub async fn run_http(router: Router, sessions: Arc<SessionRegistry>, port: u16) -> Result<()> {
+pub async fn run_http(
+    router: Router,
+    sessions: Arc<SessionRegistry>,
+    workstreams: SharedWorkstreamStore,
+    port: u16,
+) -> Result<()> {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = TcpListener::bind(addr)
         .await
@@ -265,7 +279,7 @@ pub async fn run_http(router: Router, sessions: Arc<SessionRegistry>, port: u16)
     info!("tcode serve --http: listening on http://{bound}");
     eprintln!("tcode serve --http: listening on http://{bound}");
 
-    let app = build_axum_router(Arc::new(router), sessions);
+    let app = build_axum_router(Arc::new(router), sessions, workstreams);
     axum::serve(listener, app)
         .with_graceful_shutdown(trusty_common::shutdown_signal())
         .await
@@ -276,501 +290,5 @@ pub async fn run_http(router: Router, sessions: Arc<SessionRegistry>, port: u16)
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use axum::body::{Body, to_bytes};
-    use axum::http::{Request, StatusCode};
-    use serde_json::{Value, json};
-    use tower::util::ServiceExt;
-    use trusty_common::mcp::error_codes;
-
-    fn router_and_sessions() -> (Arc<Router>, Arc<SessionRegistry>) {
-        let sessions = Arc::new(SessionRegistry::new());
-        let mut router = Router::new();
-        crate::serve::methods::register(&mut router);
-        crate::session::protocol::register(&mut router, sessions.clone());
-        (Arc::new(router), sessions)
-    }
-
-    async fn body_json(response: axum::response::Response) -> Value {
-        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
-        serde_json::from_slice(&bytes).unwrap()
-    }
-
-    /// `POST /rpc` with a `ping` request must return HTTP 200 and the same
-    /// `{"pong": true}` result the STDIO transport returns.
-    #[tokio::test]
-    async fn http_rpc_ping_returns_pong() {
-        let (router, sessions) = router_and_sessions();
-        let app = build_axum_router(router, sessions);
-        let req_body = json!({"jsonrpc": "2.0", "id": 1, "method": "ping"}).to_string();
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/rpc")
-                    .header("content-type", "application/json")
-                    .body(Body::from(req_body))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert_eq!(v["result"], json!({"pong": true}));
-        assert_eq!(v["id"], 1);
-    }
-
-    /// `POST /rpc` with a malformed body must still return HTTP 200 with a
-    /// JSON-RPC `-32700 Parse error` envelope, not a bare HTTP 400.
-    #[tokio::test]
-    async fn http_rpc_malformed_json_returns_parse_error() {
-        let (router, sessions) = router_and_sessions();
-        let app = build_axum_router(router, sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/rpc")
-                    .header("content-type", "application/json")
-                    .body(Body::from("not json at all"))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert_eq!(v["error"]["code"], error_codes::PARSE_ERROR);
-    }
-
-    /// `GET /health` must return the exact payload `health_payload()`
-    /// (and thus the `health` JSON-RPC method) returns.
-    #[tokio::test]
-    async fn http_health_matches_jsonrpc_health_payload() {
-        let (router, sessions) = router_and_sessions();
-        let app = build_axum_router(router, sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("GET")
-                    .uri("/health")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert_eq!(v, health_payload());
-    }
-
-    /// `GET /sessions` (the #2983 Slice 2 REST route group, merged in by
-    /// `build_axum_router`) must be reachable on the SAME router `POST /rpc`
-    /// and `GET /sessions/{id}/events` are — proving the merge in
-    /// `build_axum_router` actually wires `rest::sessions::routes` rather
-    /// than silently dropping it. Route-level behaviour (found/missing/
-    /// transcript/readiness/goals) is covered by `rest::sessions::tests`.
-    #[tokio::test]
-    async fn http_rest_sessions_route_is_merged_in() {
-        let (router, sessions) = router_and_sessions();
-        let app = build_axum_router(router, sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("GET")
-                    .uri("/sessions")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert!(v["sessions"].is_array());
-    }
-
-    /// `POST /sessions` (the #2983 Slice 3 REST write route group, merged in
-    /// by `build_axum_router` via `rest::sessions_write::routes`) must be
-    /// reachable on the SAME router `GET /sessions` is (the previous test) —
-    /// proving axum's `.merge()` doesn't silently drop one side when two
-    /// sub-routers register the SAME literal path under different HTTP
-    /// methods. `GET`+`POST` both claim `/sessions`; `PUT`+`DELETE` both
-    /// claim `/sessions/{id}/goal` — this test pins both same-literal-path
-    /// pairs in one pass, driving the created session's id through a real
-    /// `PUT` then `DELETE` on `/goal` and asserting a clean `200` round trip
-    /// (seeding a `pm_transcript` first via the registry so `set_goal`/
-    /// `clear_goal`'s "has a transcript" precondition passes — otherwise a
-    /// merge bug that silently 404'd the route would be indistinguishable
-    /// from a legitimate `400 invalid_argument`). Per-route error/malformed-
-    /// body behaviour is already covered by `rest::sessions_write::tests`;
-    /// this test only pins the merge itself.
-    #[tokio::test]
-    async fn http_rest_post_sessions_route_is_merged_in() {
-        let (router, sessions) = router_and_sessions();
-        let sessions_for_seeding = sessions.clone();
-        let app = build_axum_router(router, sessions);
-
-        let create_resp = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/sessions")
-                    .header("content-type", "application/json")
-                    .body(Body::from(json!({"task": "do it"}).to_string()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(create_resp.status(), StatusCode::CREATED);
-        let created = body_json(create_resp).await;
-        assert_eq!(created["status"], "running");
-        assert_eq!(created["task"], "do it");
-        let session_id = created["id"].as_str().unwrap().to_string();
-
-        let transcript = sessions_for_seeding
-            .begin_pm_transcript(&session_id, "you are the pm", "first task")
-            .unwrap();
-        sessions_for_seeding.store_pm_transcript(&session_id, transcript);
-
-        let put_resp = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .method("PUT")
-                    .uri(format!("/sessions/{session_id}/goal"))
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        json!({"slot": 1, "text": "ship it"}).to_string(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(put_resp.status(), StatusCode::OK);
-        assert_eq!(body_json(put_resp).await, json!({}));
-
-        let delete_resp = app
-            .oneshot(
-                Request::builder()
-                    .method("DELETE")
-                    .uri(format!("/sessions/{session_id}/goal"))
-                    .header("content-type", "application/json")
-                    .body(Body::from(json!({"slot": 1}).to_string()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(delete_resp.status(), StatusCode::OK);
-        assert_eq!(body_json(delete_resp).await, json!({}));
-    }
-
-    /// `POST /tasks` (the #2983 Slice 4 REST route group, merged in by
-    /// `build_axum_router` via `rest::tasks::routes`) must be reachable on
-    /// the SAME router `POST /sessions` is — proving the merge actually
-    /// wires `rest::tasks::routes` rather than silently dropping it.
-    /// Per-route error/status-code behaviour is already covered by
-    /// `rest::tasks::tests`; this test only pins the merge itself.
-    #[tokio::test]
-    async fn http_rest_post_tasks_route_is_merged_in() {
-        let _guard = crate::task::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
-        // SAFETY: test-only env mutation; serialized by `MOCK_LLM_ENV_LOCK`.
-        unsafe {
-            std::env::set_var(
-                crate::task::mock_llm::MOCK_LLM_ENV,
-                crate::task::mock_llm::MOCK_LLM_ECHO,
-            );
-        }
-        // `router_and_sessions()` does not register `task.run` (it is not
-        // needed by any other test in this file) — build a router that also
-        // has it wired, mirroring `task::protocol::tests::agents_dir`.
-        let sessions = Arc::new(SessionRegistry::new());
-        let agents = tempfile::tempdir().expect("agents tempdir");
-        std::fs::write(
-            agents.path().join("pm.md"),
-            "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM.\n",
-        )
-        .expect("write pm.md");
-        let project = tempfile::tempdir().expect("project tempdir");
-        let mut router = Router::new();
-        crate::serve::methods::register(&mut router);
-        crate::session::protocol::register(&mut router, sessions.clone());
-        crate::task::protocol::register(
-            &mut router,
-            sessions.clone(),
-            crate::binding::ProjectBinding::resolve(Some(project.path().to_path_buf()))
-                .expect("tempdir must bind"),
-            agents.path().to_path_buf(),
-        );
-        let app = build_axum_router(Arc::new(router), sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri("/tasks")
-                    .header("content-type", "application/json")
-                    .body(Body::from(
-                        json!({"task_description": "say hi"}).to_string(),
-                    ))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        unsafe {
-            std::env::remove_var(crate::task::mock_llm::MOCK_LLM_ENV);
-        }
-
-        assert_eq!(resp.status(), StatusCode::ACCEPTED);
-        let v = body_json(resp).await;
-        assert_eq!(v["status"], "running");
-    }
-
-    /// `GET /fs` (the #2983 Slice 5 REST route group, merged in by
-    /// `build_axum_router` via `rest::fs::routes`) must be reachable on the
-    /// SAME router `POST /rpc` is — proving the merge actually wires
-    /// `rest::fs::routes` rather than silently dropping it. Per-route
-    /// error/status-code behaviour is already covered by `rest::fs::tests`;
-    /// this test only pins the merge itself.
-    #[tokio::test]
-    async fn http_rest_get_fs_route_is_merged_in() {
-        // `router_and_sessions()` does not register `fs.list_dir` (it is not
-        // needed by any other test in this file) — build a router that also
-        // has it wired.
-        let sessions = Arc::new(SessionRegistry::new());
-        let mut router = Router::new();
-        crate::serve::methods::register(&mut router);
-        crate::session::protocol::register(&mut router, sessions.clone());
-        crate::fs_browse::protocol::register(&mut router);
-        let app = build_axum_router(Arc::new(router), sessions);
-        let tmp = tempfile::tempdir().expect("tempdir");
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("GET")
-                    .uri(format!("/fs?path={}", tmp.path().display()))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert!(v["entries"].is_array());
-    }
-
-    /// `GET /sessions/{id}/agents` (the #2983 Slice 6 REST route group,
-    /// merged in by `build_axum_router` via `rest::agents::routes`) must be
-    /// reachable on the SAME router `GET /sessions/{id}/events` is —
-    /// proving the merge actually wires `rest::agents::routes` rather than
-    /// silently dropping it. Per-route error/status-code behaviour is
-    /// already covered by `rest::agents::tests`; this test only pins the
-    /// merge itself.
-    #[tokio::test]
-    async fn http_rest_get_session_agents_route_is_merged_in() {
-        let (router, sessions) = router_and_sessions();
-        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-        let app = build_axum_router(router, sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("GET")
-                    .uri(format!("/sessions/{}/agents", session.id))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert!(v["agents"].is_array());
-    }
-
-    /// `GET /sessions/{id}/budget` (issue #3015, part of the `rest::sessions`
-    /// route group `build_axum_router` already merges via
-    /// `rest::sessions::routes`) must be reachable on the SAME router
-    /// `GET /sessions/{id}/events` is — proving the merge actually wires the
-    /// route rather than silently dropping it. Per-route error/status-code
-    /// behaviour is already covered by `rest::sessions::tests`; this test
-    /// only pins the merge itself.
-    #[tokio::test]
-    async fn http_rest_get_session_budget_route_is_merged_in() {
-        let (router, sessions) = router_and_sessions();
-        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-        let app = build_axum_router(router, sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("GET")
-                    .uri(format!("/sessions/{}/budget", session.id))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert_eq!(v["status"], "never_recorded");
-    }
-
-    /// `GET /sessions/{id}/search-audit` (issue #3072, `rest::search_audit`'s
-    /// route group `build_axum_router` merges above) must be reachable on
-    /// the SAME router `GET /sessions/{id}/events` is — proving the merge
-    /// actually wires `rest::search_audit::routes` rather than silently
-    /// dropping it. Per-route error/status-code behaviour is already covered
-    /// by `rest::search_audit::tests`; this test only pins the merge itself.
-    #[tokio::test]
-    async fn http_rest_get_session_search_audit_route_is_merged_in() {
-        let (router, sessions) = router_and_sessions();
-        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-        let app = build_axum_router(router, sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("GET")
-                    .uri(format!("/sessions/{}/search-audit", session.id))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert_eq!(v["search_audit"].as_array().unwrap().len(), 0);
-    }
-
-    /// `GET /workstreams` (issue #3295, `rest::workstreams`'s route group
-    /// `build_axum_router` merges above) must be reachable on the SAME
-    /// router `GET /sessions/{id}/events` is — proving the merge actually
-    /// wires `rest::workstreams::routes` rather than silently dropping it.
-    /// Per-route error/status-code behaviour is already covered by
-    /// `rest::workstreams::tests`; this test only pins the merge itself.
-    #[tokio::test]
-    async fn http_rest_get_workstreams_route_is_merged_in() {
-        let sessions = Arc::new(SessionRegistry::new());
-        let dir = tempfile::tempdir().expect("tempdir");
-        let store =
-            crate::workstreams::WorkstreamStore::load(dir.path().join("workstreams-test.json"))
-                .await
-                .expect("load");
-        let mut router = Router::new();
-        crate::serve::methods::register(&mut router);
-        crate::session::protocol::register(&mut router, sessions.clone());
-        crate::workstreams::protocol::register(
-            &mut router,
-            Arc::new(tokio::sync::Mutex::new(store)),
-        );
-        let app = build_axum_router(Arc::new(router), sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("GET")
-                    .uri("/workstreams")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::OK);
-        let v = body_json(resp).await;
-        assert!(v["workstreams"].is_array());
-    }
-
-    /// `GET /sessions/{id}/events` on an unknown session must 404 with a
-    /// JSON-RPC `session_not_found` envelope.
-    #[tokio::test]
-    async fn http_session_events_sse_unknown_session_returns_404() {
-        let (router, sessions) = router_and_sessions();
-        let app = build_axum_router(router, sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("GET")
-                    .uri("/sessions/does-not-exist/events")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-        let v = body_json(resp).await;
-        assert_eq!(v["error"]["code"], -32007);
-    }
-
-    /// `GET /sessions/{id}/events` on a real session must stream the
-    /// ring-buffer replay as SSE `data:` frames.
-    ///
-    /// Why: the response body never terminates (the live half subscribes to
-    /// the bus forever), so this reads a bounded prefix of the body as a
-    /// `Stream` (rather than `axum::body::to_bytes`, which would hang or
-    /// error waiting for a completion that never comes) until the expected
-    /// content shows up or a timeout fires.
-    #[tokio::test]
-    async fn http_session_events_sse_streams_replay() {
-        let (router, sessions) = router_and_sessions();
-        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-        let app = build_axum_router(router, sessions);
-
-        let resp = app
-            .oneshot(
-                Request::builder()
-                    .method("GET")
-                    .uri(format!("/sessions/{}/events", session.id))
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-
-        let mut stream = resp.into_body().into_data_stream();
-        let mut collected = Vec::new();
-        let read_replay = tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            while !String::from_utf8_lossy(&collected).contains("session_status_changed") {
-                match stream.next().await {
-                    Some(Ok(chunk)) => collected.extend_from_slice(&chunk),
-                    _ => break,
-                }
-            }
-        })
-        .await;
-
-        assert!(
-            read_replay.is_ok(),
-            "timed out waiting for the SSE replay burst"
-        );
-        let text = String::from_utf8(collected).unwrap();
-        assert!(text.contains("session_started"), "body so far: {text}");
-        assert!(
-            text.contains("session_status_changed"),
-            "body so far: {text}"
-        );
-        // #2055: the SSE frames must carry the full envelope, not a bare
-        // event — `seq` and the top-level `kind` field must both appear.
-        assert!(text.contains("\"seq\":1"), "body so far: {text}");
-        assert!(
-            text.contains("\"kind\":\"session_started\""),
-            "body so far: {text}"
-        );
-    }
-}
+#[path = "http_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/serve/http_tests.rs
+++ b/crates/trusty-code/src/serve/http_tests.rs
@@ -1,0 +1,539 @@
+//! Tests for `serve::http`'s axum router assembly (`build_axum_router`) and
+//! its routes (`POST /rpc`, `GET /health`, `GET /sessions/{id}/events`).
+//!
+//! Why: split out of `http.rs` per the crate's `_tests.rs` sibling-file
+//! convention (see `events_tests`/`workstreams::model_tests` for precedent)
+//! so the router's test surface — which grew with issue #3297's new
+//! `SharedWorkstreamStore` parameter and its `GET /workstreams/{id}/events`
+//! merge — doesn't push the production file past its 500-SLOC cap; test
+//! files carry the 1500-SLOC cap.
+//! What: `POST /rpc` ping/malformed-JSON, `GET /health`, every REST resource
+//! group's merge-in smoke test, and the `GET /sessions/{id}/events` SSE
+//! replay/live/404 behaviour.
+//! Test: this module is itself the test surface.
+
+use super::*;
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::util::ServiceExt;
+use trusty_common::mcp::error_codes;
+
+async fn router_and_sessions() -> (Arc<Router>, Arc<SessionRegistry>, SharedWorkstreamStore) {
+    let sessions = Arc::new(SessionRegistry::new());
+    let mut router = Router::new();
+    crate::serve::methods::register(&mut router);
+    crate::session::protocol::register(&mut router, sessions.clone());
+    (Arc::new(router), sessions, test_workstreams_store().await)
+}
+
+/// A fresh, tempdir-backed `SharedWorkstreamStore` with no workstreams
+/// yet — every test in this file that doesn't specifically exercise
+/// `workstream.*` just needs SOMETHING to pass to `build_axum_router`
+/// (issue #3297 added the store as a required parameter so
+/// `GET /workstreams/{id}/events` can be merged in).
+async fn test_workstreams_store() -> SharedWorkstreamStore {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("workstreams-test.json");
+    let store = crate::workstreams::WorkstreamStore::load(path)
+        .await
+        .expect("load");
+    std::mem::forget(dir);
+    Arc::new(tokio::sync::Mutex::new(store))
+}
+
+async fn body_json(response: axum::response::Response) -> Value {
+    let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// `POST /rpc` with a `ping` request must return HTTP 200 and the same
+/// `{"pong": true}` result the STDIO transport returns.
+#[tokio::test]
+async fn http_rpc_ping_returns_pong() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let app = build_axum_router(router, sessions, workstreams);
+    let req_body = json!({"jsonrpc": "2.0", "id": 1, "method": "ping"}).to_string();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/rpc")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["result"], json!({"pong": true}));
+    assert_eq!(v["id"], 1);
+}
+
+/// `POST /rpc` with a malformed body must still return HTTP 200 with a
+/// JSON-RPC `-32700 Parse error` envelope, not a bare HTTP 400.
+#[tokio::test]
+async fn http_rpc_malformed_json_returns_parse_error() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let app = build_axum_router(router, sessions, workstreams);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/rpc")
+                .header("content-type", "application/json")
+                .body(Body::from("not json at all"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], error_codes::PARSE_ERROR);
+}
+
+/// `GET /health` must return the exact payload `health_payload()`
+/// (and thus the `health` JSON-RPC method) returns.
+#[tokio::test]
+async fn http_health_matches_jsonrpc_health_payload() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let app = build_axum_router(router, sessions, workstreams);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v, health_payload());
+}
+
+/// `GET /sessions` (the #2983 Slice 2 REST route group, merged in by
+/// `build_axum_router`) must be reachable on the SAME router `POST /rpc`
+/// and `GET /sessions/{id}/events` are — proving the merge in
+/// `build_axum_router` actually wires `rest::sessions::routes` rather
+/// than silently dropping it. Route-level behaviour (found/missing/
+/// transcript/readiness/goals) is covered by `rest::sessions::tests`.
+#[tokio::test]
+async fn http_rest_sessions_route_is_merged_in() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let app = build_axum_router(router, sessions, workstreams);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert!(v["sessions"].is_array());
+}
+
+/// `POST /sessions` (the #2983 Slice 3 REST write route group, merged in
+/// by `build_axum_router` via `rest::sessions_write::routes`) must be
+/// reachable on the SAME router `GET /sessions` is (the previous test) —
+/// proving axum's `.merge()` doesn't silently drop one side when two
+/// sub-routers register the SAME literal path under different HTTP
+/// methods. `GET`+`POST` both claim `/sessions`; `PUT`+`DELETE` both
+/// claim `/sessions/{id}/goal` — this test pins both same-literal-path
+/// pairs in one pass, driving the created session's id through a real
+/// `PUT` then `DELETE` on `/goal` and asserting a clean `200` round trip
+/// (seeding a `pm_transcript` first via the registry so `set_goal`/
+/// `clear_goal`'s "has a transcript" precondition passes — otherwise a
+/// merge bug that silently 404'd the route would be indistinguishable
+/// from a legitimate `400 invalid_argument`). Per-route error/malformed-
+/// body behaviour is already covered by `rest::sessions_write::tests`;
+/// this test only pins the merge itself.
+#[tokio::test]
+async fn http_rest_post_sessions_route_is_merged_in() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let sessions_for_seeding = sessions.clone();
+    let app = build_axum_router(router, sessions, workstreams);
+
+    let create_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions")
+                .header("content-type", "application/json")
+                .body(Body::from(json!({"task": "do it"}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_resp.status(), StatusCode::CREATED);
+    let created = body_json(create_resp).await;
+    assert_eq!(created["status"], "running");
+    assert_eq!(created["task"], "do it");
+    let session_id = created["id"].as_str().unwrap().to_string();
+
+    let transcript = sessions_for_seeding
+        .begin_pm_transcript(&session_id, "you are the pm", "first task")
+        .unwrap();
+    sessions_for_seeding.store_pm_transcript(&session_id, transcript);
+
+    let put_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/sessions/{session_id}/goal"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"slot": 1, "text": "ship it"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(put_resp.status(), StatusCode::OK);
+    assert_eq!(body_json(put_resp).await, json!({}));
+
+    let delete_resp = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/sessions/{session_id}/goal"))
+                .header("content-type", "application/json")
+                .body(Body::from(json!({"slot": 1}).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete_resp.status(), StatusCode::OK);
+    assert_eq!(body_json(delete_resp).await, json!({}));
+}
+
+/// `POST /tasks` (the #2983 Slice 4 REST route group, merged in by
+/// `build_axum_router` via `rest::tasks::routes`) must be reachable on
+/// the SAME router `POST /sessions` is — proving the merge actually
+/// wires `rest::tasks::routes` rather than silently dropping it.
+/// Per-route error/status-code behaviour is already covered by
+/// `rest::tasks::tests`; this test only pins the merge itself.
+#[tokio::test]
+async fn http_rest_post_tasks_route_is_merged_in() {
+    let _guard = crate::task::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    // SAFETY: test-only env mutation; serialized by `MOCK_LLM_ENV_LOCK`.
+    unsafe {
+        std::env::set_var(
+            crate::task::mock_llm::MOCK_LLM_ENV,
+            crate::task::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    // `router_and_sessions()` does not register `task.run` (it is not
+    // needed by any other test in this file) — build a router that also
+    // has it wired, mirroring `task::protocol::tests::agents_dir`.
+    let sessions = Arc::new(SessionRegistry::new());
+    let agents = tempfile::tempdir().expect("agents tempdir");
+    std::fs::write(
+        agents.path().join("pm.md"),
+        "---\nname: pm\nmodel: openai/gpt-4o-mini\n---\n\nYou are the PM.\n",
+    )
+    .expect("write pm.md");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let mut router = Router::new();
+    crate::serve::methods::register(&mut router);
+    crate::session::protocol::register(&mut router, sessions.clone());
+    crate::task::protocol::register(
+        &mut router,
+        sessions.clone(),
+        crate::binding::ProjectBinding::resolve(Some(project.path().to_path_buf()))
+            .expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+    );
+    let app = build_axum_router(Arc::new(router), sessions, test_workstreams_store().await);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/tasks")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({"task_description": "say hi"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    unsafe {
+        std::env::remove_var(crate::task::mock_llm::MOCK_LLM_ENV);
+    }
+
+    assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    let v = body_json(resp).await;
+    assert_eq!(v["status"], "running");
+}
+
+/// `GET /fs` (the #2983 Slice 5 REST route group, merged in by
+/// `build_axum_router` via `rest::fs::routes`) must be reachable on the
+/// SAME router `POST /rpc` is — proving the merge actually wires
+/// `rest::fs::routes` rather than silently dropping it. Per-route
+/// error/status-code behaviour is already covered by `rest::fs::tests`;
+/// this test only pins the merge itself.
+#[tokio::test]
+async fn http_rest_get_fs_route_is_merged_in() {
+    // `router_and_sessions()` does not register `fs.list_dir` (it is not
+    // needed by any other test in this file) — build a router that also
+    // has it wired.
+    let sessions = Arc::new(SessionRegistry::new());
+    let mut router = Router::new();
+    crate::serve::methods::register(&mut router);
+    crate::session::protocol::register(&mut router, sessions.clone());
+    crate::fs_browse::protocol::register(&mut router);
+    let app = build_axum_router(Arc::new(router), sessions, test_workstreams_store().await);
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/fs?path={}", tmp.path().display()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert!(v["entries"].is_array());
+}
+
+/// `GET /sessions/{id}/agents` (the #2983 Slice 6 REST route group,
+/// merged in by `build_axum_router` via `rest::agents::routes`) must be
+/// reachable on the SAME router `GET /sessions/{id}/events` is —
+/// proving the merge actually wires `rest::agents::routes` rather than
+/// silently dropping it. Per-route error/status-code behaviour is
+/// already covered by `rest::agents::tests`; this test only pins the
+/// merge itself.
+#[tokio::test]
+async fn http_rest_get_session_agents_route_is_merged_in() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let app = build_axum_router(router, sessions, workstreams);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/sessions/{}/agents", session.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert!(v["agents"].is_array());
+}
+
+/// `GET /sessions/{id}/budget` (issue #3015, part of the `rest::sessions`
+/// route group `build_axum_router` already merges via
+/// `rest::sessions::routes`) must be reachable on the SAME router
+/// `GET /sessions/{id}/events` is — proving the merge actually wires the
+/// route rather than silently dropping it. Per-route error/status-code
+/// behaviour is already covered by `rest::sessions::tests`; this test
+/// only pins the merge itself.
+#[tokio::test]
+async fn http_rest_get_session_budget_route_is_merged_in() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let app = build_axum_router(router, sessions, workstreams);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/sessions/{}/budget", session.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["status"], "never_recorded");
+}
+
+/// `GET /sessions/{id}/search-audit` (issue #3072, `rest::search_audit`'s
+/// route group `build_axum_router` merges above) must be reachable on
+/// the SAME router `GET /sessions/{id}/events` is — proving the merge
+/// actually wires `rest::search_audit::routes` rather than silently
+/// dropping it. Per-route error/status-code behaviour is already covered
+/// by `rest::search_audit::tests`; this test only pins the merge itself.
+#[tokio::test]
+async fn http_rest_get_session_search_audit_route_is_merged_in() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let app = build_axum_router(router, sessions, workstreams);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/sessions/{}/search-audit", session.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["search_audit"].as_array().unwrap().len(), 0);
+}
+
+/// `GET /workstreams` (issue #3295, `rest::workstreams`'s route group
+/// `build_axum_router` merges above) must be reachable on the SAME
+/// router `GET /sessions/{id}/events` is — proving the merge actually
+/// wires `rest::workstreams::routes` rather than silently dropping it.
+/// Also hits `GET /workstreams/{id}/events` (issue #3297,
+/// `crate::workstreams::sse::routes`, merged in the SAME call) on the
+/// SAME router — proving that merge too, without a second whole test
+/// function. Per-route behaviour for both groups is already covered by
+/// `rest::workstreams::tests`/`crate::workstreams::sse::sse_tests`; this
+/// test only pins the merges themselves.
+#[tokio::test]
+async fn http_rest_get_workstreams_route_is_merged_in() {
+    let sessions = Arc::new(SessionRegistry::new());
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = crate::workstreams::WorkstreamStore::load(dir.path().join("workstreams-test.json"))
+        .await
+        .expect("load");
+    let workstreams = Arc::new(tokio::sync::Mutex::new(store));
+    let mut router = Router::new();
+    crate::serve::methods::register(&mut router);
+    crate::session::protocol::register(&mut router, sessions.clone());
+    crate::workstreams::protocol::register(&mut router, workstreams.clone());
+    let id = workstreams.lock().await.create("t").await.expect("create");
+    let app = build_axum_router(Arc::new(router), sessions, workstreams);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/workstreams")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert!(v["workstreams"].is_array());
+
+    let events_resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/workstreams/{id}/events"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(events_resp.status(), StatusCode::OK);
+}
+
+/// `GET /sessions/{id}/events` on an unknown session must 404 with a
+/// JSON-RPC `session_not_found` envelope.
+#[tokio::test]
+async fn http_session_events_sse_unknown_session_returns_404() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let app = build_axum_router(router, sessions, workstreams);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/sessions/does-not-exist/events")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let v = body_json(resp).await;
+    assert_eq!(v["error"]["code"], -32007);
+}
+
+/// `GET /sessions/{id}/events` on a real session must stream the
+/// ring-buffer replay as SSE `data:` frames.
+///
+/// Why: the response body never terminates (the live half subscribes to
+/// the bus forever), so this reads a bounded prefix of the body as a
+/// `Stream` (rather than `axum::body::to_bytes`, which would hang or
+/// error waiting for a completion that never comes) until the expected
+/// content shows up or a timeout fires.
+#[tokio::test]
+async fn http_session_events_sse_streams_replay() {
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let app = build_axum_router(router, sessions, workstreams);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/sessions/{}/events", session.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let mut stream = resp.into_body().into_data_stream();
+    let mut collected = Vec::new();
+    let read_replay = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while !String::from_utf8_lossy(&collected).contains("session_status_changed") {
+            match stream.next().await {
+                Some(Ok(chunk)) => collected.extend_from_slice(&chunk),
+                _ => break,
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        read_replay.is_ok(),
+        "timed out waiting for the SSE replay burst"
+    );
+    let text = String::from_utf8(collected).unwrap();
+    assert!(text.contains("session_started"), "body so far: {text}");
+    assert!(
+        text.contains("session_status_changed"),
+        "body so far: {text}"
+    );
+    // #2055: the SSE frames must carry the full envelope, not a bare
+    // event — `seq` and the top-level `kind` field must both appear.
+    assert!(text.contains("\"seq\":1"), "body so far: {text}");
+    assert!(
+        text.contains("\"kind\":\"session_started\""),
+        "body so far: {text}"
+    );
+}

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -48,7 +48,7 @@ use tracing::info;
 use crate::binding::ProjectBinding;
 use crate::jsonrpc::Router;
 use crate::session::SessionRegistry;
-use crate::workstreams::WorkstreamStore;
+use crate::workstreams::{SharedWorkstreamStore, WorkstreamStore};
 
 /// How long a graceful stop waits for in-flight `task.run` executions to
 /// observe cancellation and unwind before the process exits anyway.
@@ -118,12 +118,21 @@ pub const DEFAULT_HTTP_PORT: u16 = 7881;
 /// resolves via `ProjectBinding::agents_dir`, which falls back to the
 /// user-level `~/.claude/agents` when projectless rather than to the process
 /// CWD (which would silently bind a directory nobody chose).
+/// (issue #3297) Also returns the [`SharedWorkstreamStore`] itself (not just
+/// the `Router` it registered `workstream.*` against) — `run_http` needs the
+/// SAME handle to hand to `crate::serve::http::run_http`, which merges
+/// `crate::workstreams::sse::routes` (the `GET /workstreams/{id}/events`
+/// aggregation route) alongside the JSON-RPC-backed REST surface. This is
+/// why the return type grew a third element rather than staying a 2-tuple.
+///
 /// Test: `run_stdio_router_recognises_proof_of_life_methods`,
 /// `build_router_wires_session_methods`, `build_router_wires_task_run`,
 /// `build_router_is_projectless_without_a_project`,
 /// `build_router_wires_fs_list_dir`, `build_router_wires_workstream_methods`,
 /// `build_router_reconciles_dangling_active_pointer_on_boot`.
-pub async fn build_router(binding: ProjectBinding) -> Result<(Router, Arc<SessionRegistry>)> {
+pub async fn build_router(
+    binding: ProjectBinding,
+) -> Result<(Router, Arc<SessionRegistry>, SharedWorkstreamStore)> {
     build_router_at(binding, &crate::workstreams::default_data_dir()).await
 }
 
@@ -142,7 +151,7 @@ pub async fn build_router(binding: ProjectBinding) -> Result<(Router, Arc<Sessio
 async fn build_router_at(
     binding: ProjectBinding,
     data_dir: &std::path::Path,
-) -> Result<(Router, Arc<SessionRegistry>)> {
+) -> Result<(Router, Arc<SessionRegistry>, SharedWorkstreamStore)> {
     let sessions = Arc::new(SessionRegistry::new());
     let agents_dir = binding.agents_dir();
 
@@ -160,8 +169,8 @@ async fn build_router_at(
     crate::session::protocol::register(&mut router, sessions.clone());
     crate::fs_browse::protocol::register(&mut router);
     crate::task::protocol::register(&mut router, sessions.clone(), binding, agents_dir);
-    crate::workstreams::protocol::register(&mut router, workstreams);
-    Ok((router, sessions))
+    crate::workstreams::protocol::register(&mut router, workstreams.clone());
+    Ok((router, sessions, workstreams))
 }
 
 /// Run `tcode serve --stdio` to completion.
@@ -182,7 +191,7 @@ pub async fn run_stdio(binding: ProjectBinding) -> Result<()> {
         project = binding.label().unwrap_or_else(|| "<projectless>".into()),
         "tcode serve --stdio: starting"
     );
-    let (router, sessions) = build_router(binding).await?;
+    let (router, sessions, _workstreams) = build_router(binding).await?;
     transport::run_stdio_loop(router).await?;
     sessions.shutdown_executions(SHUTDOWN_GRACE).await;
     info!("tcode serve --stdio: stopped");
@@ -207,8 +216,8 @@ pub async fn run_http(binding: ProjectBinding, port: u16) -> Result<()> {
         port,
         "tcode serve --http: starting"
     );
-    let (router, sessions) = build_router(binding).await?;
-    http::run_http(router, sessions.clone(), port).await?;
+    let (router, sessions, workstreams) = build_router(binding).await?;
+    http::run_http(router, sessions.clone(), workstreams, port).await?;
     sessions.shutdown_executions(SHUTDOWN_GRACE).await;
     info!("tcode serve --http: stopped");
     Ok(())
@@ -230,7 +239,7 @@ mod tests {
     async fn run_stdio_router_recognises_proof_of_life_methods() {
         let project = tempfile::tempdir().expect("project tempdir");
         let data_dir = tempfile::tempdir().expect("data tempdir");
-        let (router, _sessions) = build_router_at(
+        let (router, _sessions, _workstreams) = build_router_at(
             ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             data_dir.path(),
         )
@@ -258,7 +267,7 @@ mod tests {
     async fn build_router_wires_session_methods() {
         let project = tempfile::tempdir().expect("project tempdir");
         let data_dir = tempfile::tempdir().expect("data tempdir");
-        let (router, sessions) = build_router_at(
+        let (router, sessions, _workstreams) = build_router_at(
             ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             data_dir.path(),
         )
@@ -288,7 +297,7 @@ mod tests {
     async fn build_router_wires_fs_list_dir() {
         let project = tempfile::tempdir().expect("project tempdir");
         let data_dir = tempfile::tempdir().expect("data tempdir");
-        let (router, _sessions) = build_router_at(
+        let (router, _sessions, _workstreams) = build_router_at(
             ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             data_dir.path(),
         )
@@ -325,9 +334,10 @@ mod tests {
     #[tokio::test]
     async fn build_router_is_projectless_without_a_project() {
         let data_dir = tempfile::tempdir().expect("data tempdir");
-        let (router, _sessions) = build_router_at(ProjectBinding::None, data_dir.path())
-            .await
-            .expect("build_router_at");
+        let (router, _sessions, _workstreams) =
+            build_router_at(ProjectBinding::None, data_dir.path())
+                .await
+                .expect("build_router_at");
         for method in ["task.run", "session.create", "session.list"] {
             let req = Request {
                 jsonrpc: Some("2.0".to_string()),
@@ -377,7 +387,7 @@ mod tests {
             );
         }
         let data_dir = tempfile::tempdir().expect("data tempdir");
-        let (router, sessions) = build_router_at(
+        let (router, sessions, _workstreams) = build_router_at(
             ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             data_dir.path(),
         )
@@ -418,7 +428,7 @@ mod tests {
         let binding =
             ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind");
 
-        let (router, _sessions) = build_router_at(binding.clone(), data_dir.path())
+        let (router, _sessions, _workstreams) = build_router_at(binding.clone(), data_dir.path())
             .await
             .expect("build_router_at");
 
@@ -460,7 +470,7 @@ mod tests {
         // rather than starting from a brand-new empty one — proven here by
         // reconciliation completing without error on the same file the
         // first instance created.
-        let (_router2, _sessions2) = build_router_at(binding, data_dir.path())
+        let (_router2, _sessions2, _workstreams2) = build_router_at(binding, data_dir.path())
             .await
             .expect("a second build_router_at over the same data_dir must succeed");
     }
@@ -496,7 +506,7 @@ mod tests {
             .await
             .expect("seed raw store file with a dangling active_workstream_id");
 
-        let (router, _sessions) = build_router_at(binding, data_dir.path())
+        let (router, _sessions, _workstreams) = build_router_at(binding, data_dir.path())
             .await
             .expect("build_router_at must reconcile the dangling pointer, not fail");
 

--- a/crates/trusty-code/src/workstreams/activation.rs
+++ b/crates/trusty-code/src/workstreams/activation.rs
@@ -39,15 +39,77 @@
 //!     from "never existed" without an extra lookup the spec does not ask
 //!     for).
 //!
+//! (issue #3297) [`activate`]/[`deactivate`] are also the sole publishers of
+//! [`crate::events::Event::WorkstreamActivationChanged`] (DOC-48 §5.3/§6.3,
+//! AC-3.3) — emitted exactly when the persisted active pointer actually
+//! changes (a fresh activation, a force-switch, or a real deactivation),
+//! never on the idempotent no-op branches. Centralising the emission here
+//! (rather than at each RPC/REST call site) means every current AND future
+//! caller of these two functions gets the notification for free — see
+//! [`crate::events::Event::WorkstreamActivationChanged`]'s own docs for why
+//! this reuses the existing global event bus instead of a second channel.
+//! They also publish [`crate::events::Event::WorkstreamStateInferred`] for
+//! every workstream whose computed state actually transitions alongside the
+//! pointer change (the newly-active workstream on every real activation, plus
+//! the prior one on a force-switch); [`super::protocol::close`] publishes the
+//! same event's `"closed"` state via [`publish_state_inferred`] (`pub(super)`
+//! for exactly that one cross-file call).
+//!
 //! Test: `activation_tests`.
 
 use std::sync::Arc;
 
+use chrono::Utc;
 use thiserror::Error;
 use tokio::sync::Mutex;
 
+use crate::events::{Event, SessionEventEnvelope};
+
 use super::model::WorkstreamId;
 use super::store::{StoreError, WorkstreamStore};
+
+/// Publish `Event::WorkstreamActivationChanged` on the global event bus.
+///
+/// Why: the one place [`activate`]/[`deactivate`] construct this event, so
+/// both always build the same envelope shape.
+/// What: `seq` is always `0` — this event is not part of any per-session
+/// ring buffer (there is no owning session to sequence it against), unlike
+/// every other envelope this daemon publishes. `session_id` is the empty
+/// string for the same reason (see the event's own docs).
+fn publish_activation_changed(new_active_id: Option<WorkstreamId>, prior_id: Option<WorkstreamId>) {
+    let event = Event::WorkstreamActivationChanged {
+        new_active_id: new_active_id.map(|id| id.to_string()),
+        prior_id: prior_id.map(|id| id.to_string()),
+    };
+    crate::events::publish(SessionEventEnvelope::new(
+        String::new(),
+        0,
+        Utc::now(),
+        event,
+    ));
+}
+
+/// Publish `Event::WorkstreamStateInferred` on the global event bus.
+///
+/// Why: shared by [`activate`]/[`deactivate`] (this file) and
+/// `super::protocol::close` (the one place outside this module that
+/// transitions a workstream's state) — see the module docs for why `close`
+/// reaches into this helper rather than duplicating the envelope shape.
+/// What: mirrors [`publish_activation_changed`]'s `seq`/`session_id`
+/// convention (both are meaningless for a daemon-scoped event).
+pub(super) fn publish_state_inferred(workstream_id: WorkstreamId, state: &str, reason: &str) {
+    let event = Event::WorkstreamStateInferred {
+        workstream_id: workstream_id.to_string(),
+        state: state.to_string(),
+        reason: reason.to_string(),
+    };
+    crate::events::publish(SessionEventEnvelope::new(
+        String::new(),
+        0,
+        Utc::now(),
+        event,
+    ));
+}
 
 /// Shared, lock-wrapped handle to a project's workstream store.
 ///
@@ -119,7 +181,9 @@ pub struct ActivateOutcome {
 /// `activation_tests::activate_already_active_is_idempotent`,
 /// `activation_tests::activate_without_force_returns_active_conflict`,
 /// `activation_tests::activate_with_force_switches_and_reports_prior`,
-/// `activation_tests::activate_unknown_id_returns_not_found`.
+/// `activation_tests::activate_unknown_id_returns_not_found`,
+/// `activation_tests::activate_with_no_prior_active_publishes_state_inferred`,
+/// `activation_tests::activate_with_force_publishes_state_inferred_for_both`.
 pub async fn activate(
     store: &SharedWorkstreamStore,
     id: WorkstreamId,
@@ -140,6 +204,9 @@ pub async fn activate(
         Some(active) if !force => Err(ActivationError::ActiveConflict(active)),
         Some(active) => {
             store.set_active(Some(id)).await?;
+            publish_activation_changed(Some(id), Some(active));
+            publish_state_inferred(id, "active", "activated (force-switch)");
+            publish_state_inferred(active, "idle", "deactivated (force-switch)");
             Ok(ActivateOutcome {
                 active_id: id,
                 prior_id: Some(active),
@@ -147,6 +214,8 @@ pub async fn activate(
         }
         None => {
             store.set_active(Some(id)).await?;
+            publish_activation_changed(Some(id), None);
+            publish_state_inferred(id, "active", "activated");
             Ok(ActivateOutcome {
                 active_id: id,
                 prior_id: None,
@@ -165,7 +234,8 @@ pub async fn activate(
 /// is idempotent by design (§4.3), so this never looks the id up in
 /// `workstreams[]` at all.
 /// Test: `activation_tests::deactivate_active_clears_pointer`,
-/// `activation_tests::deactivate_non_active_is_idempotent_noop`.
+/// `activation_tests::deactivate_non_active_is_idempotent_noop`,
+/// `activation_tests::deactivate_active_publishes_state_inferred_idle`.
 pub async fn deactivate(
     store: &SharedWorkstreamStore,
     id: WorkstreamId,
@@ -173,6 +243,8 @@ pub async fn deactivate(
     let mut store = store.lock().await;
     if store.active_workstream_id().await? == Some(id) {
         store.set_active(None).await?;
+        publish_activation_changed(None, Some(id));
+        publish_state_inferred(id, "idle", "deactivated");
         Ok(Some(id))
     } else {
         Ok(None)

--- a/crates/trusty-code/src/workstreams/activation_tests.rs
+++ b/crates/trusty-code/src/workstreams/activation_tests.rs
@@ -1,8 +1,30 @@
 //! Tests for `activation::activate`/`activation::deactivate` (DOC-48 §6,
-//! issue #3294).
+//! issue #3294; the `Event::WorkstreamActivationChanged` publication tests
+//! are issue #3297).
+
+use std::time::Duration;
 
 use super::*;
 use tempfile::tempdir;
+
+/// Read the next event off `rx`, failing the test if none arrives within 2s.
+async fn recv_event(rx: &mut tokio::sync::broadcast::Receiver<SessionEventEnvelope>) -> Event {
+    tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out waiting for a published event")
+        .expect("event bus channel closed")
+        .event
+}
+
+/// Assert NO event arrives on `rx` within a short window — used to prove the
+/// idempotent no-op branches of `activate`/`deactivate` do not publish.
+async fn assert_no_event(rx: &mut tokio::sync::broadcast::Receiver<SessionEventEnvelope>) {
+    let result = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await;
+    assert!(
+        result.is_err(),
+        "expected no event to be published, but got one"
+    );
+}
 
 /// Build a fresh [`SharedWorkstreamStore`] backed by a tempfile path (never
 /// created ahead of time — `WorkstreamStore::load` treats a missing file as
@@ -168,4 +190,192 @@ async fn activate_persists_across_store_reload() {
         Some(id),
         "active pointer must persist across a fresh load"
     );
+}
+
+/// (issue #3297, DOC-48 AC-3.3) Activating with no prior active workstream
+/// must publish `WorkstreamActivationChanged{new_active_id: Some(id),
+/// prior_id: None}`.
+#[tokio::test]
+async fn activate_with_no_prior_active_publishes_activation_changed() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, "a").await;
+    let mut rx = crate::events::subscribe();
+
+    activate(&store, id, false).await.expect("activate");
+
+    match recv_event(&mut rx).await {
+        Event::WorkstreamActivationChanged {
+            new_active_id,
+            prior_id,
+        } => {
+            assert_eq!(new_active_id, Some(id.to_string()));
+            assert_eq!(prior_id, None);
+        }
+        other => panic!("expected WorkstreamActivationChanged, got {other:?}"),
+    }
+}
+
+/// A force-switch must publish `WorkstreamActivationChanged` naming BOTH the
+/// new active id and the prior one.
+#[tokio::test]
+async fn activate_with_force_publishes_activation_changed_with_prior() {
+    let (store, _dir) = shared_store().await;
+    let a = create(&store, "a").await;
+    let b = create(&store, "b").await;
+    activate(&store, a, false).await.expect("activate a");
+
+    let mut rx = crate::events::subscribe();
+    activate(&store, b, true).await.expect("force switch");
+
+    match recv_event(&mut rx).await {
+        Event::WorkstreamActivationChanged {
+            new_active_id,
+            prior_id,
+        } => {
+            assert_eq!(new_active_id, Some(b.to_string()));
+            assert_eq!(prior_id, Some(a.to_string()));
+        }
+        other => panic!("expected WorkstreamActivationChanged, got {other:?}"),
+    }
+}
+
+/// Re-activating the already-active workstream is a true no-op (§6.1) — it
+/// must NOT publish an activation-changed event.
+#[tokio::test]
+async fn activate_already_active_does_not_publish() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, "a").await;
+    activate(&store, id, false).await.expect("first activate");
+
+    let mut rx = crate::events::subscribe();
+    activate(&store, id, false)
+        .await
+        .expect("idempotent re-activate");
+
+    assert_no_event(&mut rx).await;
+}
+
+/// Deactivating the active workstream must publish `WorkstreamActivationChanged{new_active_id: None, prior_id: Some(id)}`.
+#[tokio::test]
+async fn deactivate_active_publishes_activation_changed() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, "a").await;
+    activate(&store, id, false).await.expect("activate");
+
+    let mut rx = crate::events::subscribe();
+    deactivate(&store, id).await.expect("deactivate");
+
+    match recv_event(&mut rx).await {
+        Event::WorkstreamActivationChanged {
+            new_active_id,
+            prior_id,
+        } => {
+            assert_eq!(new_active_id, None);
+            assert_eq!(prior_id, Some(id.to_string()));
+        }
+        other => panic!("expected WorkstreamActivationChanged, got {other:?}"),
+    }
+}
+
+/// Deactivating a non-active (idle or unknown) workstream is a no-op (§4.3)
+/// — it must NOT publish an activation-changed event.
+#[tokio::test]
+async fn deactivate_non_active_does_not_publish() {
+    let (store, _dir) = shared_store().await;
+    let a = create(&store, "a").await;
+    let b = create(&store, "b").await;
+    activate(&store, a, false).await.expect("activate a");
+
+    let mut rx = crate::events::subscribe();
+    deactivate(&store, b).await.expect("deactivate idle b");
+
+    assert_no_event(&mut rx).await;
+}
+
+/// (issue #3297) A fresh activation must ALSO publish
+/// `WorkstreamStateInferred{workstream_id: id, state: "active"}` right after
+/// `WorkstreamActivationChanged`.
+#[tokio::test]
+async fn activate_with_no_prior_active_publishes_state_inferred() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, "a").await;
+    let mut rx = crate::events::subscribe();
+
+    activate(&store, id, false).await.expect("activate");
+
+    let _ = recv_event(&mut rx).await; // WorkstreamActivationChanged, covered above
+    match recv_event(&mut rx).await {
+        Event::WorkstreamStateInferred {
+            workstream_id,
+            state,
+            ..
+        } => {
+            assert_eq!(workstream_id, id.to_string());
+            assert_eq!(state, "active");
+        }
+        other => panic!("expected WorkstreamStateInferred, got {other:?}"),
+    }
+}
+
+/// A force-switch must publish `WorkstreamStateInferred` for BOTH the
+/// newly-active workstream (`"active"`) and the prior one (`"idle"`).
+#[tokio::test]
+async fn activate_with_force_publishes_state_inferred_for_both() {
+    let (store, _dir) = shared_store().await;
+    let a = create(&store, "a").await;
+    let b = create(&store, "b").await;
+    activate(&store, a, false).await.expect("activate a");
+
+    let mut rx = crate::events::subscribe();
+    activate(&store, b, true).await.expect("force switch");
+
+    let _ = recv_event(&mut rx).await; // WorkstreamActivationChanged
+    match recv_event(&mut rx).await {
+        Event::WorkstreamStateInferred {
+            workstream_id,
+            state,
+            ..
+        } => {
+            assert_eq!(workstream_id, b.to_string());
+            assert_eq!(state, "active");
+        }
+        other => panic!("expected WorkstreamStateInferred for b, got {other:?}"),
+    }
+    match recv_event(&mut rx).await {
+        Event::WorkstreamStateInferred {
+            workstream_id,
+            state,
+            ..
+        } => {
+            assert_eq!(workstream_id, a.to_string());
+            assert_eq!(state, "idle");
+        }
+        other => panic!("expected WorkstreamStateInferred for a, got {other:?}"),
+    }
+}
+
+/// Deactivating the active workstream must ALSO publish
+/// `WorkstreamStateInferred{state: "idle"}` right after
+/// `WorkstreamActivationChanged`.
+#[tokio::test]
+async fn deactivate_active_publishes_state_inferred_idle() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, "a").await;
+    activate(&store, id, false).await.expect("activate");
+
+    let mut rx = crate::events::subscribe();
+    deactivate(&store, id).await.expect("deactivate");
+
+    let _ = recv_event(&mut rx).await; // WorkstreamActivationChanged
+    match recv_event(&mut rx).await {
+        Event::WorkstreamStateInferred {
+            workstream_id,
+            state,
+            ..
+        } => {
+            assert_eq!(workstream_id, id.to_string());
+            assert_eq!(state, "idle");
+        }
+        other => panic!("expected WorkstreamStateInferred, got {other:?}"),
+    }
 }

--- a/crates/trusty-code/src/workstreams/activation_tests.rs
+++ b/crates/trusty-code/src/workstreams/activation_tests.rs
@@ -1,28 +1,114 @@
 //! Tests for `activation::activate`/`activation::deactivate` (DOC-48 §6,
-//! issue #3294; the `Event::WorkstreamActivationChanged` publication tests
-//! are issue #3297).
+//! issue #3294; the `Event::WorkstreamActivationChanged`/
+//! `WorkstreamStateInferred` publication tests are issue #3297).
 
 use std::time::Duration;
 
 use super::*;
 use tempfile::tempdir;
 
-/// Read the next event off `rx`, failing the test if none arrives within 2s.
-async fn recv_event(rx: &mut tokio::sync::broadcast::Receiver<SessionEventEnvelope>) -> Event {
-    tokio::time::timeout(Duration::from_secs(2), rx.recv())
-        .await
-        .expect("timed out waiting for a published event")
-        .expect("event bus channel closed")
-        .event
+/// Read from the process-global event bus until a `WorkstreamActivationChanged`
+/// naming `id` (as either `new_active_id` or `prior_id`) arrives, ignoring
+/// anything else.
+///
+/// Why: `crate::events::bus()` is a single process-wide singleton shared by
+/// every test in this binary — `cargo test` runs tests concurrently by
+/// default, so a raw `rx.recv().await` can observe another test's unrelated
+/// envelope interleaved on the same subscription (confirmed by PR #3343 CI:
+/// a foreign workstream's `WorkstreamActivationChanged` leaked into this
+/// file's tests under parallel execution). Unlike
+/// `session::registry_tests::next_event_for` (which filters on the
+/// envelope's OWN `session_id` field), these events are daemon-scoped — the
+/// envelope's `session_id` is always the empty string (see
+/// `Event::WorkstreamActivationChanged`'s docs) — so the filter reads into
+/// the EVENT's own id fields instead. Bounded by a 2s timeout so a genuine
+/// bug (event never published) still fails fast instead of hanging.
+async fn next_activation_changed_for(
+    rx: &mut tokio::sync::broadcast::Receiver<SessionEventEnvelope>,
+    id: WorkstreamId,
+) -> (Option<String>, Option<String>) {
+    let id = id.to_string();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let envelope = rx.recv().await.expect("event bus channel closed");
+            if let Event::WorkstreamActivationChanged {
+                new_active_id,
+                prior_id,
+            } = envelope.event
+                && (new_active_id.as_deref() == Some(id.as_str())
+                    || prior_id.as_deref() == Some(id.as_str()))
+            {
+                return (new_active_id, prior_id);
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for WorkstreamActivationChanged naming this workstream")
 }
 
-/// Assert NO event arrives on `rx` within a short window — used to prove the
-/// idempotent no-op branches of `activate`/`deactivate` do not publish.
-async fn assert_no_event(rx: &mut tokio::sync::broadcast::Receiver<SessionEventEnvelope>) {
-    let result = tokio::time::timeout(Duration::from_millis(200), rx.recv()).await;
+/// Read from the process-global event bus until a `WorkstreamStateInferred`
+/// naming `id` arrives, ignoring anything else — see
+/// [`next_activation_changed_for`]'s docs for the shared-bus-interleaving
+/// rationale.
+async fn next_state_inferred_for(
+    rx: &mut tokio::sync::broadcast::Receiver<SessionEventEnvelope>,
+    id: WorkstreamId,
+) -> (String, String) {
+    let id = id.to_string();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let envelope = rx.recv().await.expect("event bus channel closed");
+            if let Event::WorkstreamStateInferred {
+                workstream_id,
+                state,
+                reason,
+            } = envelope.event
+                && workstream_id == id
+            {
+                return (state, reason);
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for WorkstreamStateInferred naming this workstream")
+}
+
+/// Assert that NO `WorkstreamActivationChanged`/`WorkstreamStateInferred`
+/// naming `id` arrives within a short window — used to prove the idempotent
+/// no-op branches of `activate`/`deactivate` do not publish. Drains (and
+/// discards) any unrelated envelope from another concurrently-running test
+/// rather than treating one as evidence of publication (see
+/// [`next_activation_changed_for`]'s docs).
+async fn assert_no_event_for(
+    rx: &mut tokio::sync::broadcast::Receiver<SessionEventEnvelope>,
+    id: WorkstreamId,
+) {
+    let id = id.to_string();
+    let result = tokio::time::timeout(Duration::from_millis(300), async {
+        loop {
+            let envelope = rx.recv().await.expect("event bus channel closed");
+            let matches = match &envelope.event {
+                Event::WorkstreamActivationChanged {
+                    new_active_id,
+                    prior_id,
+                } => {
+                    new_active_id.as_deref() == Some(id.as_str())
+                        || prior_id.as_deref() == Some(id.as_str())
+                }
+                Event::WorkstreamStateInferred { workstream_id, .. } => workstream_id == &id,
+                _ => false,
+            };
+            if matches {
+                return;
+            }
+            // Unrelated envelope from another concurrently-running test —
+            // ignore and keep draining until the timeout below fires.
+        }
+    })
+    .await;
     assert!(
         result.is_err(),
-        "expected no event to be published, but got one"
+        "expected no event naming workstream {id}, but got one"
     );
 }
 
@@ -203,16 +289,9 @@ async fn activate_with_no_prior_active_publishes_activation_changed() {
 
     activate(&store, id, false).await.expect("activate");
 
-    match recv_event(&mut rx).await {
-        Event::WorkstreamActivationChanged {
-            new_active_id,
-            prior_id,
-        } => {
-            assert_eq!(new_active_id, Some(id.to_string()));
-            assert_eq!(prior_id, None);
-        }
-        other => panic!("expected WorkstreamActivationChanged, got {other:?}"),
-    }
+    let (new_active_id, prior_id) = next_activation_changed_for(&mut rx, id).await;
+    assert_eq!(new_active_id, Some(id.to_string()));
+    assert_eq!(prior_id, None);
 }
 
 /// A force-switch must publish `WorkstreamActivationChanged` naming BOTH the
@@ -227,16 +306,9 @@ async fn activate_with_force_publishes_activation_changed_with_prior() {
     let mut rx = crate::events::subscribe();
     activate(&store, b, true).await.expect("force switch");
 
-    match recv_event(&mut rx).await {
-        Event::WorkstreamActivationChanged {
-            new_active_id,
-            prior_id,
-        } => {
-            assert_eq!(new_active_id, Some(b.to_string()));
-            assert_eq!(prior_id, Some(a.to_string()));
-        }
-        other => panic!("expected WorkstreamActivationChanged, got {other:?}"),
-    }
+    let (new_active_id, prior_id) = next_activation_changed_for(&mut rx, b).await;
+    assert_eq!(new_active_id, Some(b.to_string()));
+    assert_eq!(prior_id, Some(a.to_string()));
 }
 
 /// Re-activating the already-active workstream is a true no-op (§6.1) — it
@@ -252,7 +324,7 @@ async fn activate_already_active_does_not_publish() {
         .await
         .expect("idempotent re-activate");
 
-    assert_no_event(&mut rx).await;
+    assert_no_event_for(&mut rx, id).await;
 }
 
 /// Deactivating the active workstream must publish `WorkstreamActivationChanged{new_active_id: None, prior_id: Some(id)}`.
@@ -265,16 +337,9 @@ async fn deactivate_active_publishes_activation_changed() {
     let mut rx = crate::events::subscribe();
     deactivate(&store, id).await.expect("deactivate");
 
-    match recv_event(&mut rx).await {
-        Event::WorkstreamActivationChanged {
-            new_active_id,
-            prior_id,
-        } => {
-            assert_eq!(new_active_id, None);
-            assert_eq!(prior_id, Some(id.to_string()));
-        }
-        other => panic!("expected WorkstreamActivationChanged, got {other:?}"),
-    }
+    let (new_active_id, prior_id) = next_activation_changed_for(&mut rx, id).await;
+    assert_eq!(new_active_id, None);
+    assert_eq!(prior_id, Some(id.to_string()));
 }
 
 /// Deactivating a non-active (idle or unknown) workstream is a no-op (§4.3)
@@ -289,12 +354,11 @@ async fn deactivate_non_active_does_not_publish() {
     let mut rx = crate::events::subscribe();
     deactivate(&store, b).await.expect("deactivate idle b");
 
-    assert_no_event(&mut rx).await;
+    assert_no_event_for(&mut rx, b).await;
 }
 
 /// (issue #3297) A fresh activation must ALSO publish
-/// `WorkstreamStateInferred{workstream_id: id, state: "active"}` right after
-/// `WorkstreamActivationChanged`.
+/// `WorkstreamStateInferred{workstream_id: id, state: "active"}`.
 #[tokio::test]
 async fn activate_with_no_prior_active_publishes_state_inferred() {
     let (store, _dir) = shared_store().await;
@@ -303,18 +367,8 @@ async fn activate_with_no_prior_active_publishes_state_inferred() {
 
     activate(&store, id, false).await.expect("activate");
 
-    let _ = recv_event(&mut rx).await; // WorkstreamActivationChanged, covered above
-    match recv_event(&mut rx).await {
-        Event::WorkstreamStateInferred {
-            workstream_id,
-            state,
-            ..
-        } => {
-            assert_eq!(workstream_id, id.to_string());
-            assert_eq!(state, "active");
-        }
-        other => panic!("expected WorkstreamStateInferred, got {other:?}"),
-    }
+    let (state, _reason) = next_state_inferred_for(&mut rx, id).await;
+    assert_eq!(state, "active");
 }
 
 /// A force-switch must publish `WorkstreamStateInferred` for BOTH the
@@ -329,34 +383,14 @@ async fn activate_with_force_publishes_state_inferred_for_both() {
     let mut rx = crate::events::subscribe();
     activate(&store, b, true).await.expect("force switch");
 
-    let _ = recv_event(&mut rx).await; // WorkstreamActivationChanged
-    match recv_event(&mut rx).await {
-        Event::WorkstreamStateInferred {
-            workstream_id,
-            state,
-            ..
-        } => {
-            assert_eq!(workstream_id, b.to_string());
-            assert_eq!(state, "active");
-        }
-        other => panic!("expected WorkstreamStateInferred for b, got {other:?}"),
-    }
-    match recv_event(&mut rx).await {
-        Event::WorkstreamStateInferred {
-            workstream_id,
-            state,
-            ..
-        } => {
-            assert_eq!(workstream_id, a.to_string());
-            assert_eq!(state, "idle");
-        }
-        other => panic!("expected WorkstreamStateInferred for a, got {other:?}"),
-    }
+    let (b_state, _) = next_state_inferred_for(&mut rx, b).await;
+    assert_eq!(b_state, "active");
+    let (a_state, _) = next_state_inferred_for(&mut rx, a).await;
+    assert_eq!(a_state, "idle");
 }
 
 /// Deactivating the active workstream must ALSO publish
-/// `WorkstreamStateInferred{state: "idle"}` right after
-/// `WorkstreamActivationChanged`.
+/// `WorkstreamStateInferred{state: "idle"}`.
 #[tokio::test]
 async fn deactivate_active_publishes_state_inferred_idle() {
     let (store, _dir) = shared_store().await;
@@ -366,16 +400,6 @@ async fn deactivate_active_publishes_state_inferred_idle() {
     let mut rx = crate::events::subscribe();
     deactivate(&store, id).await.expect("deactivate");
 
-    let _ = recv_event(&mut rx).await; // WorkstreamActivationChanged
-    match recv_event(&mut rx).await {
-        Event::WorkstreamStateInferred {
-            workstream_id,
-            state,
-            ..
-        } => {
-            assert_eq!(workstream_id, id.to_string());
-            assert_eq!(state, "idle");
-        }
-        other => panic!("expected WorkstreamStateInferred, got {other:?}"),
-    }
+    let (state, _reason) = next_state_inferred_for(&mut rx, id).await;
+    assert_eq!(state, "idle");
 }

--- a/crates/trusty-code/src/workstreams/mod.rs
+++ b/crates/trusty-code/src/workstreams/mod.rs
@@ -8,6 +8,7 @@
 //! - [`SPEC-WS-03~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-03~draft)
 //! - [`SPEC-WS-05~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-05~draft)
 //! - [`SPEC-WS-06~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-06~draft)
+//! - [`SPEC-WS-07~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-07~draft) AC-7
 //!
 //! Why: DOC-39 §4B introduced **Workstream** as a durable named grouping of
 //! sessions that must survive daemon restarts, but tcode's `SessionRegistry`
@@ -32,18 +33,25 @@
 //! daemon's [`crate::binding::ProjectBinding`] (see [`path`]); (issue #3294)
 //! [`activation`] — the activation-lock exclusivity layer above the store
 //! (`ActiveConflict`/force-switch semantics `WorkstreamStore::set_active`
-//! deliberately left out) — and [`protocol`], the full `workstream.*`
+//! deliberately left out) — [`protocol`], the full `workstream.*`
 //! JSON-RPC surface (`create`/`get`/`list`/`close` from #3295 plus
-//! `activate`/`deactivate` from #3294, built on [`activation`]).
+//! `activate`/`deactivate` from #3294, built on [`activation`]); and (issue
+//! #3297) [`sse`] — the `GET /workstreams/{id}/events` fan-out aggregation
+//! route, built directly on [`store::WorkstreamStore`] (bypassing the
+//! JSON-RPC router, mirroring `crate::serve::http::session_events_sse`'s
+//! per-session precedent).
 //!
 //! **Scope note (Phase 1A):** #3293 built ONLY the domain model and
 //! persistence layer (this module's `model`/`path`/`store` submodules);
 //! #3294 added the activation-lock RPC semantics (`activation`, plus
-//! `activate`/`deactivate` in [`protocol`]); #3295 (this ticket) added the
-//! rest of `protocol`'s surface (`create`/`get`/`list`/`close`) and the REST
-//! wrappers (`crate::serve::rest::workstreams`). The CLI (#3296) and the SSE
-//! aggregation route (#3297) remain out of scope and land in their own
-//! follow-up tickets against this foundation.
+//! `activate`/`deactivate` in [`protocol`]); #3295 added the rest of
+//! `protocol`'s surface (`create`/`get`/`list`/`close`) and the REST wrappers
+//! (`crate::serve::rest::workstreams`); #3297 (this ticket) adds [`sse`] —
+//! the `GET /workstreams/{id}/events` aggregation route — plus
+//! `activation`'s new role as the sole publisher of
+//! `crate::events::Event::WorkstreamActivationChanged`. The CLI (#3296) and
+//! the `trusty-agents-common` extraction of [`sse`]'s aggregation layer
+//! (Phase 1B, #3299) remain out of scope.
 //!
 //! Test: `cargo test -p trusty-code workstreams::` exercises every submodule
 //! in place; see each submodule's own `Test:` line for specifics.
@@ -52,9 +60,11 @@ pub mod activation;
 pub mod model;
 mod path;
 pub mod protocol;
+pub mod sse;
 pub mod store;
 
 pub use activation::{ActivateOutcome, ActivationError, SharedWorkstreamStore};
 pub use model::{Workstream, WorkstreamId, WorkstreamState};
 pub use path::{default_data_dir, store_path};
+pub use sse::WorkstreamEventEnvelope;
 pub use store::{ReconcileOutcome, StoreError, WorkstreamStore};

--- a/crates/trusty-code/src/workstreams/protocol.rs
+++ b/crates/trusty-code/src/workstreams/protocol.rs
@@ -45,7 +45,7 @@ use uuid::Uuid;
 
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 
-use super::activation::{self, ActivationError, SharedWorkstreamStore};
+use super::activation::{self, ActivationError, SharedWorkstreamStore, publish_state_inferred};
 use super::model::{Workstream, WorkstreamId, WorkstreamState};
 use super::store::StoreError;
 
@@ -300,9 +300,14 @@ async fn list(
 /// spec's §5.1 signature exactly — not the updated record, since a client
 /// that needs the post-close view already has `workstream.get`). Idempotent:
 /// closing an already-closed workstream succeeds again (see
-/// [`super::model::Workstream::mark_closed`]'s docs).
+/// [`super::model::Workstream::mark_closed`]'s docs). (Issue #3297)
+/// Unconditionally publishes `Event::WorkstreamStateInferred{state: "closed"}`
+/// via [`publish_state_inferred`] — even a repeat close re-asserts the same
+/// state to any freshly-subscribed `GET /workstreams/{id}/events` observer,
+/// and re-publishing an unchanged state is harmless.
 /// Test: `protocol_tests::close_succeeds_and_clears_active_pointer`,
-/// `protocol_tests::close_unknown_id_maps_to_not_found`.
+/// `protocol_tests::close_unknown_id_maps_to_not_found`,
+/// `protocol_tests::close_publishes_state_inferred`.
 async fn close(
     store: &SharedWorkstreamStore,
     params: Value,
@@ -312,6 +317,7 @@ async fn close(
     let id = parse_id(&p.id, "workstream.close")?;
     let mut store = store.lock().await;
     store.close(id).await.map_err(map_store_err)?;
+    publish_state_inferred(id, "closed", "closed");
     Ok(json!({}))
 }
 

--- a/crates/trusty-code/src/workstreams/protocol_tests.rs
+++ b/crates/trusty-code/src/workstreams/protocol_tests.rs
@@ -415,6 +415,39 @@ async fn close_succeeds_and_clears_active_pointer() {
     assert_eq!(list_result["active_workstream_id"], Value::Null);
 }
 
+/// (issue #3297) `workstream.close` must publish
+/// `Event::WorkstreamStateInferred{state: "closed"}`.
+#[tokio::test]
+async fn close_publishes_state_inferred() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, json!({"name": "A"}), test_ctx())
+        .await
+        .expect("create")["id"]
+        .clone();
+    let ws_id: WorkstreamId = serde_json::from_value(id.clone()).unwrap();
+
+    let mut rx = crate::events::subscribe();
+    close(&store, json!({"id": id}), test_ctx())
+        .await
+        .expect("close");
+
+    let envelope = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out waiting for the state-inferred event")
+        .expect("event bus channel closed");
+    match envelope.event {
+        crate::events::Event::WorkstreamStateInferred {
+            workstream_id,
+            state,
+            ..
+        } => {
+            assert_eq!(workstream_id, ws_id.to_string());
+            assert_eq!(state, "closed");
+        }
+        other => panic!("expected WorkstreamStateInferred, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn close_unknown_id_maps_to_not_found() {
     let (store, _dir) = shared_store().await;

--- a/crates/trusty-code/src/workstreams/protocol_tests.rs
+++ b/crates/trusty-code/src/workstreams/protocol_tests.rs
@@ -431,21 +431,30 @@ async fn close_publishes_state_inferred() {
         .await
         .expect("close");
 
-    let envelope = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
-        .await
-        .expect("timed out waiting for the state-inferred event")
-        .expect("event bus channel closed");
-    match envelope.event {
-        crate::events::Event::WorkstreamStateInferred {
-            workstream_id,
-            state,
-            ..
-        } => {
-            assert_eq!(workstream_id, ws_id.to_string());
-            assert_eq!(state, "closed");
+    // `crate::events::bus()` is a process-wide singleton shared by every
+    // concurrently-running test (issue #3297 CI: `cargo test` runs tests in
+    // parallel by default, so a raw `rx.recv().await` can observe another
+    // test's unrelated envelope first) — loop past anything that doesn't
+    // name THIS test's own workstream id, mirroring
+    // `workstreams::activation_tests::next_state_inferred_for`.
+    let target = ws_id.to_string();
+    let (state, _reason) = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let envelope = rx.recv().await.expect("event bus channel closed");
+            if let crate::events::Event::WorkstreamStateInferred {
+                workstream_id,
+                state,
+                reason,
+            } = envelope.event
+                && workstream_id == target
+            {
+                return (state, reason);
+            }
         }
-        other => panic!("expected WorkstreamStateInferred, got {other:?}"),
-    }
+    })
+    .await
+    .expect("timed out waiting for WorkstreamStateInferred naming this workstream");
+    assert_eq!(state, "closed");
 }
 
 #[tokio::test]

--- a/crates/trusty-code/src/workstreams/sse.rs
+++ b/crates/trusty-code/src/workstreams/sse.rs
@@ -1,0 +1,255 @@
+//! Workstream-level SSE event aggregation route (DOC-48 §5.3, §5.3.1; issue
+//! #3297, epic #3292).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-WS-05~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-05~draft) §5.3, §5.3.1
+//! - [`SPEC-WS-07~draft`](docs/specs/DOC-48-tcode-workstreams.md#SPEC-WS-07~draft) AC-7
+//!
+//! Why: `GET /sessions/{id}/events` (`crate::serve::http::session_events_sse`)
+//! is a direct lookup against ONE session's ring buffer + live filter. A
+//! workstream is a GROUP of sessions (§2.1), so observing "this workstream"
+//! is not a lookup at all — it is a fan-out: subscribe once to the daemon's
+//! existing session-scoped event bus (`crate::events::subscribe`, already
+//! shared by every per-session SSE connection) and forward only the events
+//! whose `session_id` is currently bound to this workstream, tagged with the
+//! generic `{session_id, event_type, payload}` envelope AC-7.2 requires.
+//! "Currently bound" is re-checked against the store on every event (not a
+//! snapshot taken at subscribe time) so a session added to the workstream
+//! after the client connected is picked up without a reconnect (§5.3 point
+//! 4) — cheap in practice because `WorkstreamStore::get` only re-parses the
+//! backing file when its (mtime, len) fingerprint actually changed.
+//!
+//! **AC-7 harness-agnostic seam:** [`aggregate_live`] takes a
+//! [`WorkstreamId`] and a [`SharedWorkstreamStore`] and returns a stream of
+//! [`WorkstreamEventEnvelope`] — it never names `crate::session::Session` or
+//! any tcode-specific session type, only session ids as plain `String`s (the
+//! same abstraction AC-7.1 asks for). Phase 1A ships this as a tcode-private
+//! module, per §5.3.1's explicit allowance; **Phase 1B (issue #3299) must
+//! extract this function (plus [`WorkstreamEventEnvelope`] and a formal
+//! session-id-abstraction trait) to `trusty-agents-common`** so
+//! `trusty-agents` background sessions can reuse the same fan-out for epic
+//! #3052 — this module is that extraction's landing zone.
+//!
+//! What: [`WorkstreamEventEnvelope`] (the AC-7.2 wire shape),
+//! [`aggregate_live`] (the fan-out stream, no ring-buffer replay in Phase
+//! 1A — see its own docs), and [`routes`] (the single `GET
+//! /workstreams/{id}/events` axum route, merged into
+//! `crate::serve::http::build_axum_router` alongside `rest::workstreams`).
+//! Unknown workstream id -> `404`; malformed (non-UUID) id -> `400`; a
+//! CLOSED workstream is still observable (`200`, not `404`) because its
+//! existing bound sessions "remain valid and may accumulate turns" after
+//! closure (§4.4) — closing only stops NEW session bindings, not event
+//! delivery for the ones it already has. A workstream with zero bound
+//! sessions returns `200` with a stream that simply never emits (until a
+//! future session is added or the workstream's activation state changes) —
+//! it does not error or close early.
+//! Test: `sse_tests`.
+
+use std::convert::Infallible;
+
+use axum::extract::{Path, State};
+use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
+use axum::routing::get;
+use axum::{Json, Router as AxumRouter};
+use futures_util::{Stream, StreamExt};
+use serde::Serialize;
+use tokio_stream::wrappers::BroadcastStream;
+use trusty_common::mcp::Response;
+use uuid::Uuid;
+
+use crate::events::Event;
+use crate::jsonrpc::RpcError;
+
+use super::activation::SharedWorkstreamStore;
+use super::model::WorkstreamId;
+use super::store::StoreError;
+
+/// The harness-agnostic wire envelope AC-7.2 requires: `{session_id,
+/// event_type, payload}` — deliberately distinct from
+/// `crate::events::SessionEventEnvelope` (which carries `seq`/`at`/`kind`/
+/// `event`, tuned for one session's ring-buffer replay), since this shape is
+/// the one destined for extraction to `trusty-agents-common` (see module
+/// docs) and must not carry tcode-specific ring-buffer bookkeeping.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorkstreamEventEnvelope {
+    /// The session this event belongs to; empty string for a daemon-scoped
+    /// event with no owning session (currently only
+    /// `Event::WorkstreamActivationChanged` — see its own docs).
+    pub session_id: String,
+    /// Mirrors `Event::kind()` — the same stable string the per-session SSE
+    /// envelope's `kind` field carries, named `event_type` here to match
+    /// AC-7.2's literal wire shape.
+    pub event_type: String,
+    pub payload: Event,
+}
+
+impl WorkstreamEventEnvelope {
+    fn from_session_event(envelope: &crate::events::SessionEventEnvelope) -> Self {
+        Self {
+            session_id: envelope.session_id.clone(),
+            event_type: envelope.kind.clone(),
+            payload: envelope.event.clone(),
+        }
+    }
+
+    fn daemon_scoped(event: Event) -> Self {
+        Self {
+            session_id: String::new(),
+            event_type: event.kind().to_string(),
+            payload: event,
+        }
+    }
+}
+
+/// Build the live aggregation stream for one workstream (no ring-buffer
+/// replay — see module docs).
+///
+/// Why: the single seam [`routes`]' handler drives; kept as a free function
+/// (not inlined into the handler) so a unit test can exercise the fan-out
+/// logic directly against a `SharedWorkstreamStore`, without going through
+/// axum at all.
+/// What: subscribes ONCE to `crate::events::subscribe()`, the SAME
+/// daemon-global bus every per-session SSE connection already reads. For
+/// each envelope that arrives: a `WorkstreamActivationChanged` event is
+/// forwarded iff it names `workstream_id` as its `new_active_id` OR
+/// `prior_id` (a workstream observer must learn when IT stops being active,
+/// not only when a session it owns emits, §6.3); a `WorkstreamStateInferred`
+/// event is forwarded iff its `workstream_id` names THIS workstream (an
+/// observer must learn its own state changed — e.g. it was closed — even
+/// with zero bound sessions); any other event is forwarded iff
+/// `workstream_id`'s CURRENT `session_ids` (re-fetched from `store` on every
+/// event, not a stale snapshot) contains the envelope's `session_id`. A store
+/// lookup failure (the workstream vanished from under an open connection —
+/// not possible via any current mutation path, since `workstream.close`
+/// never removes a record) is treated as "no match" rather than closing the
+/// stream, matching this route's "stay open" bias for a zero-session
+/// workstream.
+/// Test: `sse_tests::fan_out_tags_events_from_bound_sessions_only`,
+/// `sse_tests::activation_changed_event_is_forwarded_regardless_of_session_binding`,
+/// `sse_tests::state_inferred_event_is_forwarded_for_this_workstream_only`,
+/// `sse_tests::empty_workstream_stream_yields_nothing`.
+pub fn aggregate_live(
+    workstream_id: WorkstreamId,
+    store: SharedWorkstreamStore,
+) -> impl Stream<Item = WorkstreamEventEnvelope> {
+    let target = workstream_id.to_string();
+    BroadcastStream::new(crate::events::subscribe()).filter_map(move |item| {
+        let store = store.clone();
+        let target = target.clone();
+        async move {
+            let envelope = item.ok()?;
+            match &envelope.event {
+                Event::WorkstreamActivationChanged {
+                    new_active_id,
+                    prior_id,
+                } => {
+                    let relevant = new_active_id.as_deref() == Some(target.as_str())
+                        || prior_id.as_deref() == Some(target.as_str());
+                    return relevant
+                        .then(|| WorkstreamEventEnvelope::daemon_scoped(envelope.event.clone()));
+                }
+                Event::WorkstreamStateInferred { workstream_id, .. } => {
+                    let relevant = workstream_id.as_str() == target.as_str();
+                    return relevant
+                        .then(|| WorkstreamEventEnvelope::daemon_scoped(envelope.event.clone()));
+                }
+                _ => {}
+            }
+            let bound = store
+                .lock()
+                .await
+                .get(workstream_id)
+                .await
+                .map(|ws| ws.session_ids.contains(&envelope.session_id))
+                .unwrap_or(false);
+            bound.then(|| WorkstreamEventEnvelope::from_session_event(&envelope))
+        }
+    })
+}
+
+/// Serialise one [`WorkstreamEventEnvelope`] as an SSE `data:` frame — mirrors
+/// `crate::serve::http::sse_event_for`'s (practically infallible) fallback
+/// convention.
+fn sse_event_for(envelope: &WorkstreamEventEnvelope) -> SseEvent {
+    SseEvent::default()
+        .json_data(envelope)
+        .unwrap_or_else(|_| SseEvent::default().data("{}"))
+}
+
+/// Map a [`StoreError`] onto the JSON-RPC error taxonomy (mirrors
+/// `crate::workstreams::protocol::map_store_err`, kept separate since that
+/// function is private to `protocol`).
+fn map_store_err(err: StoreError) -> RpcError {
+    match err {
+        StoreError::NotFound(id) => RpcError::not_found(format!("workstream not found: {id}")),
+        StoreError::Io(_) | StoreError::Serialize(_) => RpcError::internal(err.to_string()),
+    }
+}
+
+/// Shared axum state for this route: just the workstream store.
+#[derive(Clone)]
+struct WorkstreamSseState {
+    store: SharedWorkstreamStore,
+}
+
+/// `GET /workstreams/{id}/events` — SSE aggregation over a workstream's
+/// bound sessions.
+///
+/// Why: see module docs for the full fan-out design.
+/// What: `400` (`-32602 invalid_params`) if `id` is not a valid UUID; `404`
+/// (`-32002 not_found`) if it names no existing workstream (a CLOSED
+/// workstream is NOT a 404 — see module docs); otherwise `200` with an SSE
+/// stream from [`aggregate_live`], kept alive with axum's default
+/// keep-alive comments (matching `session_events_sse`'s convention).
+/// Test: `sse_tests::unknown_id_returns_404`,
+/// `sse_tests::malformed_id_returns_400`.
+async fn workstream_events_sse(
+    State(state): State<WorkstreamSseState>,
+    Path(id): Path<String>,
+) -> Result<
+    Sse<impl Stream<Item = Result<SseEvent, Infallible>>>,
+    (axum::http::StatusCode, Json<Response>),
+> {
+    let ws_id = Uuid::parse_str(&id).map(WorkstreamId::from).map_err(|e| {
+        let err = RpcError::invalid_params(format!("invalid workstream id: {e}"));
+        (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(Response::err(None, err.code, err.message)),
+        )
+    })?;
+
+    {
+        let mut store = state.store.lock().await;
+        store.get(ws_id).await.map_err(map_store_err).map_err(|e| {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                Json(Response::err(None, e.code, e.message)),
+            )
+        })?;
+    }
+
+    let stream = aggregate_live(ws_id, state.store.clone()).map(|env| Ok(sse_event_for(&env)));
+    Ok(Sse::new(stream).keep_alive(KeepAlive::default()))
+}
+
+/// Build the `GET /workstreams/{id}/events` route group.
+///
+/// Why: kept separate from `crate::serve::http::build_axum_router` so this
+/// route is unit-testable via `tower::util::ServiceExt::oneshot` on its own,
+/// exactly like every `rest::*` group — `crate::serve::rest::workstreams`
+/// merges the CRUD/activation REST surface, this merges the observation
+/// surface, both sharing the SAME `SharedWorkstreamStore` handle the daemon
+/// boot path constructs.
+/// What: one route, `with_state`-erased to `axum::Router<()>` so the caller
+/// can `.merge()` it.
+/// Test: `sse_tests::*`.
+pub fn routes(store: SharedWorkstreamStore) -> AxumRouter {
+    AxumRouter::new()
+        .route("/workstreams/{id}/events", get(workstream_events_sse))
+        .with_state(WorkstreamSseState { store })
+}
+
+#[cfg(test)]
+#[path = "sse_tests.rs"]
+mod sse_tests;

--- a/crates/trusty-code/src/workstreams/sse_tests.rs
+++ b/crates/trusty-code/src/workstreams/sse_tests.rs
@@ -9,17 +9,34 @@ use axum::http::{Request, StatusCode};
 use serde_json::Value;
 use tokio::sync::Mutex;
 use tower::util::ServiceExt;
+use uuid::Uuid;
 
 use super::*;
 use crate::events::{Event, SessionEventEnvelope};
 use crate::workstreams::WorkstreamStore;
+
+/// Mint a session id unique to this test invocation.
+///
+/// Why: `crate::events::bus()` is a process-wide singleton shared by every
+/// concurrently-running test (issue #3297 CI: `cargo test` runs tests in
+/// parallel by default). A literal id like `"s1"` collides with any OTHER
+/// test in this file using the same literal for its own, differently-bound
+/// workstream — confirmed by CI: two concurrently-running tests both using
+/// `"s1"` caused one test's fan-out to forward the OTHER's event, since
+/// membership is checked by string equality alone. A fresh UUID suffix per
+/// test makes cross-test collision practically impossible, mirroring how
+/// `session::registry_tests`' real `SessionRegistry::create` calls get
+/// unique ids for free.
+fn unique_session_id(label: &str) -> String {
+    format!("{label}-{}", Uuid::new_v4())
+}
 
 /// Build a `SharedWorkstreamStore` seeded with one workstream directly on
 /// disk (bypassing the store's public API, which has no session-binding
 /// method yet — session binding is issue #3298's scope, not this ticket's;
 /// see `workstreams::model::Workstream::session_ids`'s field docs).
 async fn seeded_store(
-    session_ids: Vec<&str>,
+    session_ids: Vec<String>,
 ) -> (SharedWorkstreamStore, WorkstreamId, tempfile::TempDir) {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("workstreams-test.json");
@@ -63,28 +80,35 @@ fn session_started(session_id: &str) -> SessionEventEnvelope {
 /// third, unbound session.
 #[tokio::test]
 async fn fan_out_tags_events_from_bound_sessions_only() {
-    let (store, id, _dir) = seeded_store(vec!["s1", "s2"]).await;
+    let s1 = unique_session_id("s1");
+    let s2 = unique_session_id("s2");
+    let s3 = unique_session_id("s3"); // deliberately NOT added to session_ids below
+    let (store, id, _dir) = seeded_store(vec![s1.clone(), s2.clone()]).await;
     let mut stream = std::pin::pin!(aggregate_live(id, store));
 
-    crate::events::publish(session_started("s1"));
-    crate::events::publish(session_started("s2"));
-    crate::events::publish(session_started("s3")); // not bound — must be filtered out
+    crate::events::publish(session_started(&s1));
+    crate::events::publish(session_started(&s2));
+    crate::events::publish(session_started(&s3)); // not bound — must be filtered out
 
     let first = tokio::time::timeout(Duration::from_secs(2), stream.next())
         .await
         .expect("timed out")
         .expect("stream ended early");
-    assert_eq!(first.session_id, "s1");
+    assert_eq!(first.session_id, s1);
     assert_eq!(first.event_type, "session_started");
 
     let second = tokio::time::timeout(Duration::from_secs(2), stream.next())
         .await
         .expect("timed out")
         .expect("stream ended early");
-    assert_eq!(second.session_id, "s2");
+    assert_eq!(second.session_id, s2);
 
     // s3's event must never arrive — confirmed by a bounded wait timing out.
-    let third = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+    // Any OTHER concurrently-running test's unrelated event is filtered out
+    // upstream by `aggregate_live`'s own `session_ids.contains` check (this
+    // workstream only binds s1/s2), so a stray foreign envelope cannot
+    // masquerade as "the third event" here.
+    let third = tokio::time::timeout(Duration::from_millis(300), stream.next()).await;
     assert!(
         third.is_err(),
         "an event from an unbound session must not be forwarded"
@@ -110,6 +134,10 @@ async fn activation_changed_event_is_forwarded_regardless_of_session_binding() {
         event,
     ));
 
+    // `id` is a fresh UUID minted by `seeded_store` for this test alone, so
+    // filtering the stream for the first matching envelope is robust to any
+    // OTHER concurrently-running test's own `WorkstreamActivationChanged` —
+    // `aggregate_live` already only forwards events naming THIS `id`.
     let forwarded = tokio::time::timeout(Duration::from_secs(2), stream.next())
         .await
         .expect("timed out waiting for the activation-changed event")
@@ -177,16 +205,18 @@ async fn empty_workstream_stream_yields_nothing() {
     let (store, id, _dir) = seeded_store(vec![]).await;
     let mut stream = std::pin::pin!(aggregate_live(id, store));
 
-    crate::events::publish(session_started("unrelated"));
+    crate::events::publish(session_started(&unique_session_id("unrelated")));
 
-    let outcome = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+    let outcome = tokio::time::timeout(Duration::from_millis(300), stream.next()).await;
     assert!(
         outcome.is_err(),
         "an empty workstream must not forward any session's events"
     );
 }
 
-async fn app_with_store(session_ids: Vec<&str>) -> (axum::Router, WorkstreamId, tempfile::TempDir) {
+async fn app_with_store(
+    session_ids: Vec<String>,
+) -> (axum::Router, WorkstreamId, tempfile::TempDir) {
     let (store, id, dir) = seeded_store(session_ids).await;
     (routes(store), id, dir)
 }
@@ -238,7 +268,8 @@ async fn malformed_id_returns_400() {
 /// stream a live event tagged for one of them as an SSE `data:` frame.
 #[tokio::test]
 async fn route_streams_live_tagged_event_for_bound_session() {
-    let (app, id, _dir) = app_with_store(vec!["s1"]).await;
+    let s1 = unique_session_id("s1");
+    let (app, id, _dir) = app_with_store(vec![s1.clone()]).await;
 
     let resp = app
         .oneshot(
@@ -256,12 +287,13 @@ async fn route_streams_live_tagged_event_for_bound_session() {
     // subscribe()` synchronously while building the response (before
     // `.oneshot()`'s future resolves), so the subscription is already live
     // by the time this `.await` above returns — no race to guard against.
-    crate::events::publish(session_started("s1"));
+    crate::events::publish(session_started(&s1));
 
+    let want = format!("\"session_id\":\"{s1}\"");
     let mut stream = resp.into_body().into_data_stream();
     let mut collected = Vec::new();
     let read = tokio::time::timeout(Duration::from_secs(5), async {
-        while !String::from_utf8_lossy(&collected).contains("session_started") {
+        while !String::from_utf8_lossy(&collected).contains(&want) {
             match stream.next().await {
                 Some(Ok(chunk)) => collected.extend_from_slice(&chunk),
                 _ => break,
@@ -272,10 +304,7 @@ async fn route_streams_live_tagged_event_for_bound_session() {
 
     assert!(read.is_ok(), "timed out waiting for the tagged SSE frame");
     let text = String::from_utf8(collected).unwrap();
-    assert!(
-        text.contains("\"session_id\":\"s1\""),
-        "body so far: {text}"
-    );
+    assert!(text.contains(&want), "body so far: {text}");
     assert!(
         text.contains("\"event_type\":\"session_started\""),
         "body so far: {text}"

--- a/crates/trusty-code/src/workstreams/sse_tests.rs
+++ b/crates/trusty-code/src/workstreams/sse_tests.rs
@@ -1,0 +1,283 @@
+//! Tests for `sse::aggregate_live`/`sse::routes` (DOC-48 §5.3, §5.3.1; issue
+//! #3297).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::Value;
+use tokio::sync::Mutex;
+use tower::util::ServiceExt;
+
+use super::*;
+use crate::events::{Event, SessionEventEnvelope};
+use crate::workstreams::WorkstreamStore;
+
+/// Build a `SharedWorkstreamStore` seeded with one workstream directly on
+/// disk (bypassing the store's public API, which has no session-binding
+/// method yet — session binding is issue #3298's scope, not this ticket's;
+/// see `workstreams::model::Workstream::session_ids`'s field docs).
+async fn seeded_store(
+    session_ids: Vec<&str>,
+) -> (SharedWorkstreamStore, WorkstreamId, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("workstreams-test.json");
+    let id = WorkstreamId::new();
+    let now = chrono::Utc::now();
+    let raw = serde_json::json!({
+        "version": "1.0",
+        "active_workstream_id": Value::Null,
+        "workstreams": [{
+            "id": id,
+            "name": "t",
+            "session_ids": session_ids,
+            "created_at": now,
+            "updated_at": now,
+            "metadata": {},
+        }],
+    });
+    tokio::fs::write(&path, serde_json::to_string_pretty(&raw).unwrap())
+        .await
+        .expect("seed raw store file");
+    let store = WorkstreamStore::load(&path)
+        .await
+        .expect("load seeded store");
+    (Arc::new(Mutex::new(store)), id, dir)
+}
+
+fn session_started(session_id: &str) -> SessionEventEnvelope {
+    SessionEventEnvelope::new(
+        session_id.to_string(),
+        1,
+        chrono::Utc::now(),
+        Event::SessionStarted {
+            session_id: session_id.to_string(),
+            project: "p".to_string(),
+        },
+    )
+}
+
+/// The fan-out must forward events from BOTH bound sessions, tagged with
+/// their own `session_id`/`event_type`, and must NOT forward an event from a
+/// third, unbound session.
+#[tokio::test]
+async fn fan_out_tags_events_from_bound_sessions_only() {
+    let (store, id, _dir) = seeded_store(vec!["s1", "s2"]).await;
+    let mut stream = std::pin::pin!(aggregate_live(id, store));
+
+    crate::events::publish(session_started("s1"));
+    crate::events::publish(session_started("s2"));
+    crate::events::publish(session_started("s3")); // not bound — must be filtered out
+
+    let first = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out")
+        .expect("stream ended early");
+    assert_eq!(first.session_id, "s1");
+    assert_eq!(first.event_type, "session_started");
+
+    let second = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out")
+        .expect("stream ended early");
+    assert_eq!(second.session_id, "s2");
+
+    // s3's event must never arrive — confirmed by a bounded wait timing out.
+    let third = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+    assert!(
+        third.is_err(),
+        "an event from an unbound session must not be forwarded"
+    );
+}
+
+/// A `WorkstreamActivationChanged` naming this workstream (as either the new
+/// active id or the prior one) must be forwarded even though it carries no
+/// bound session id at all.
+#[tokio::test]
+async fn activation_changed_event_is_forwarded_regardless_of_session_binding() {
+    let (store, id, _dir) = seeded_store(vec![]).await;
+    let mut stream = std::pin::pin!(aggregate_live(id, store));
+
+    let event = Event::WorkstreamActivationChanged {
+        new_active_id: Some(id.to_string()),
+        prior_id: None,
+    };
+    crate::events::publish(SessionEventEnvelope::new(
+        String::new(),
+        0,
+        chrono::Utc::now(),
+        event,
+    ));
+
+    let forwarded = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for the activation-changed event")
+        .expect("stream ended early");
+    assert_eq!(forwarded.event_type, "workstream_activation_changed");
+    match forwarded.payload {
+        Event::WorkstreamActivationChanged { new_active_id, .. } => {
+            assert_eq!(new_active_id, Some(id.to_string()));
+        }
+        other => panic!("expected WorkstreamActivationChanged, got {other:?}"),
+    }
+}
+
+/// A `WorkstreamStateInferred` naming THIS workstream must be forwarded even
+/// with zero bound sessions; one naming a DIFFERENT workstream must not.
+#[tokio::test]
+async fn state_inferred_event_is_forwarded_for_this_workstream_only() {
+    let (store, id, _dir) = seeded_store(vec![]).await;
+    let mut stream = std::pin::pin!(aggregate_live(id, store));
+
+    let other = WorkstreamId::new();
+    crate::events::publish(SessionEventEnvelope::new(
+        String::new(),
+        0,
+        chrono::Utc::now(),
+        Event::WorkstreamStateInferred {
+            workstream_id: other.to_string(),
+            state: "closed".to_string(),
+            reason: "closed".to_string(),
+        },
+    ));
+    crate::events::publish(SessionEventEnvelope::new(
+        String::new(),
+        0,
+        chrono::Utc::now(),
+        Event::WorkstreamStateInferred {
+            workstream_id: id.to_string(),
+            state: "idle".to_string(),
+            reason: "deactivated".to_string(),
+        },
+    ));
+
+    let forwarded = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for the state-inferred event")
+        .expect("stream ended early");
+    match forwarded.payload {
+        Event::WorkstreamStateInferred {
+            workstream_id,
+            state,
+            ..
+        } => {
+            assert_eq!(workstream_id, id.to_string());
+            assert_eq!(state, "idle");
+        }
+        other => panic!("expected WorkstreamStateInferred, got {other:?}"),
+    }
+}
+
+/// A zero-session workstream's stream must stay open (never close, never
+/// error) with no events flowing — it is not an empty/closed stream, just a
+/// quiet one until a session is bound or its activation state changes.
+#[tokio::test]
+async fn empty_workstream_stream_yields_nothing() {
+    let (store, id, _dir) = seeded_store(vec![]).await;
+    let mut stream = std::pin::pin!(aggregate_live(id, store));
+
+    crate::events::publish(session_started("unrelated"));
+
+    let outcome = tokio::time::timeout(Duration::from_millis(200), stream.next()).await;
+    assert!(
+        outcome.is_err(),
+        "an empty workstream must not forward any session's events"
+    );
+}
+
+async fn app_with_store(session_ids: Vec<&str>) -> (axum::Router, WorkstreamId, tempfile::TempDir) {
+    let (store, id, dir) = seeded_store(session_ids).await;
+    (routes(store), id, dir)
+}
+
+/// `GET /workstreams/{unknown-id}/events` must return a real HTTP `404` with
+/// a `-32002 not_found` envelope.
+#[tokio::test]
+async fn unknown_id_returns_404() {
+    let (app, _id, _dir) = app_with_store(vec![]).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/workstreams/{}/events", WorkstreamId::new()))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let bytes = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["error"]["code"], -32002);
+}
+
+/// A malformed (non-UUID) workstream id must return `400`, not `404` or a
+/// panic.
+#[tokio::test]
+async fn malformed_id_returns_400() {
+    let (app, _id, _dir) = app_with_store(vec![]).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/workstreams/not-a-uuid/events")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// `GET /workstreams/{id}/events` on a workstream with bound sessions must
+/// stream a live event tagged for one of them as an SSE `data:` frame.
+#[tokio::test]
+async fn route_streams_live_tagged_event_for_bound_session() {
+    let (app, id, _dir) = app_with_store(vec!["s1"]).await;
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/workstreams/{id}/events"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // Safe to publish only now: `aggregate_live` calls `crate::events::
+    // subscribe()` synchronously while building the response (before
+    // `.oneshot()`'s future resolves), so the subscription is already live
+    // by the time this `.await` above returns — no race to guard against.
+    crate::events::publish(session_started("s1"));
+
+    let mut stream = resp.into_body().into_data_stream();
+    let mut collected = Vec::new();
+    let read = tokio::time::timeout(Duration::from_secs(5), async {
+        while !String::from_utf8_lossy(&collected).contains("session_started") {
+            match stream.next().await {
+                Some(Ok(chunk)) => collected.extend_from_slice(&chunk),
+                _ => break,
+            }
+        }
+    })
+    .await;
+
+    assert!(read.is_ok(), "timed out waiting for the tagged SSE frame");
+    let text = String::from_utf8(collected).unwrap();
+    assert!(
+        text.contains("\"session_id\":\"s1\""),
+        "body so far: {text}"
+    );
+    assert!(
+        text.contains("\"event_type\":\"session_started\""),
+        "body so far: {text}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the workstream-level SSE event aggregation route from DOC-48 §5.3/§5.3.1 (epic #3292, Phase 1A).

- **`GET /workstreams/{id}/events`** — a new axum sub-router (`crate::workstreams::sse`), merged into `build_axum_router` alongside `rest::workstreams`. Fans out over the workstream's bound `session_ids` by subscribing ONCE to the existing daemon-global session-scoped bus (`crate::events::subscribe`) and re-checking current membership per event (dynamic fan-out — a session added to a workstream after connect is picked up without reconnecting, once #3298 lands binding). Emits the AC-7.2 `{session_id, event_type, payload}` envelope.
  - Unknown workstream id → `404` (`-32002 not_found`); malformed (non-UUID) id → `400`.
  - A CLOSED workstream is still observable (`200`, not `404`) — its existing bound sessions "remain valid and may accumulate turns" after closure (§4.4).
  - Zero-session workstream → `200` with a stream that stays open and simply never emits (until a session is bound or its state changes).
- **`WorkstreamActivationChanged`** and **`WorkstreamStateInferred`** — two new `crate::events::Event` variants (daemon-scoped, not session-scoped — `session_id()` returns `None`, grouped with `Ping`). Published by `workstreams::activation::{activate, deactivate}` (only on branches that ACTUALLY change the persisted pointer/state — never on idempotent no-ops) and by `workstream.close`. `SessionAdded`/`SessionActivityUpdate` (DOC-48's other two Phase-1A event names) are deferred — both describe session-BINDING activity, and `session.create(workstream_id)` binding is #3298 scope; there is no producer for either yet.
- **AC-7 harness-agnostic seam**: `aggregate_live`/`WorkstreamEventEnvelope` operate only on `WorkstreamId`/`String` session ids and a generic envelope shape, never referencing `crate::session::Session`. A module-level doc note marks this as the landing zone for extraction to `trusty-agents-common` in Phase 1B (#3299).

## Design decision: daemon-level event carrying

`crate::events::Event` was, until now, exhaustively session-scoped. Rather than standing up a second, parallel broadcast channel purely to carry two event kinds with no owning session, both new variants reuse the SAME global bus every per-session SSE connection already subscribes to — the aggregation route (which must already subscribe to that bus for its per-session fan-out) picks them up for free with no second subscription. Documented in both events' own doc comments and in `workstreams::activation`'s module docs (DOC-48 §5.3/§6.3, AC-3.3, issue #3294's deferral).

## Spec anchors

- SPEC-WS-05~draft §5.3, §5.3.1 (aggregation route, harness-agnostic transport)
- SPEC-WS-06~draft §6.3 (explicit-switch / activation-changed notification)
- SPEC-WS-07~draft AC-7 (harness-agnostic multi-client attach transport), AC-3.3/AC-3.4

## Gates (all green)

- `cargo check -p trusty-code`
- `cargo test -p trusty-code --lib -- --test-threads=1` — 1326 passed, 0 failed, 4 ignored
- `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — OK (0 violations; split `serve/http.rs`'s test module into a sibling `http_tests.rs` per the crate's `_tests.rs` convention to stay under the 500-SLOC production cap)
- `bash scripts/check_test_pointers.sh` — OK
- `bash scripts/check_sld.sh` — OK

## Ambiguities resolved

- **Closed-workstream SSE access**: §5.3 doesn't state a rule explicitly; judged consistent with §4.4 ("existing sessions remain valid") — closed workstreams remain observable.
- **`WorkstreamActivationChanged` on deactivate**: the spec's literal `{new_active_id: UUID, prior_id?}` shape assumes a switch always lands on a new active workstream. Widened `new_active_id` to `Option<String>` to also cover `workstream.deactivate` clearing the pointer with no successor (AC-3.3 says "when the active workstream changes", which includes this case).
- **Emission scope**: publish exactly when the persisted pointer/state actually changes — never on idempotent re-activation/no-op deactivation branches.

Part of #3292.

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)