### PR TITLE
fix: stop REPL TUI swallowing keystrokes during chat output

### DIFF
--- a/crates/trusty-agents/src/repl/tui/keys.rs
+++ b/crates/trusty-agents/src/repl/tui/keys.rs
@@ -15,17 +15,18 @@ pub(crate) fn handle_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
     // arrow keys navigate the choices, Enter commits the selection into the
     // input buffer (or clears for free-type on the "Other…" row), Esc
     // dismisses. Other keys fall through so the user can keep typing — and
-    // (#3325) dismiss a *stale LLM-offered list* first, since `app.choices`
-    // otherwise stays populated indefinitely (it's set once per assistant
-    // turn by `push_assistant` -> `detect_choices`, not per-keystroke) and
-    // would keep intercepting the *next* Enter as "confirm choice" instead
-    // of "submit the line I just typed", silently discarding the whole
-    // typed message. This only applies to the untagged (`choices_context ==
-    // None`) LLM list: live slash-command completions (also untagged, but
-    // rebuilt from `input_buf` on every keystroke by
-    // `update_slash_completions` below) and the tagged `/switch` picker
-    // (`choices_context == Some("switch")`, intentionally left open while
-    // typing) are both exempt.
+    // (#3325) dismiss a *stale picker* first, since `app.choices` otherwise
+    // stays populated indefinitely (it's set once per assistant turn by
+    // `push_assistant` -> `detect_choices`, or once by `/switch`, not
+    // per-keystroke) and would keep intercepting the *next* Enter as
+    // "confirm choice" (or, for `/switch`, silently dispatch a persona
+    // switch) instead of "submit the line I just typed", swallowing the
+    // whole typed message. This applies to BOTH the untagged
+    // (`choices_context == None`) LLM list AND the tagged `/switch` picker
+    // (`choices_context == Some("switch")`) — the only exemption is live
+    // slash-command completions, which are also untagged but rebuilt from
+    // `input_buf` on every keystroke by `update_slash_completions` below,
+    // so they must survive typing rather than being dismissed by it.
     if !app.choices.is_empty() {
         match key.code {
             KeyCode::Up => {
@@ -80,15 +81,20 @@ pub(crate) fn handle_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
             }
             _ => {
                 // Any other key means the user is editing/typing instead of
-                // navigating the picker. Dismiss a stale LLM-offered list
-                // (untagged + not slash-shaped) so the normal input-editing
-                // match below runs unobstructed and a subsequent Enter
-                // submits the line (#3325). Leave live slash completions
-                // and the tagged `/switch` picker alone — see the comment
-                // above `is_live_slash_completion`.
-                if app.choices_context.is_none() && !is_live_slash_completion(app) {
+                // navigating the picker. Dismiss a stale picker — the
+                // untagged LLM-offered list OR the tagged `/switch` list —
+                // so the normal input-editing match below runs unobstructed
+                // and a subsequent Enter submits the line instead of
+                // confirming a choice (#3325) or firing an unintended
+                // persona switch (#3325 follow-up). Leave live slash
+                // completions alone: `is_live_slash_completion` only ever
+                // matches the untagged, all-`/`-prefixed shape
+                // `update_slash_completions` produces, so it never
+                // shadows the tagged `/switch` picker.
+                if !is_live_slash_completion(app) {
                     app.choices.clear();
                     app.choice_cursor = 0;
+                    app.choices_context = None;
                 }
             }
         }

--- a/crates/trusty-agents/src/repl/tui/keys.rs
+++ b/crates/trusty-agents/src/repl/tui/keys.rs
@@ -14,7 +14,18 @@ pub(crate) fn handle_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
     // Inline choice picker: when the LLM offered a list and we surfaced it,
     // arrow keys navigate the choices, Enter commits the selection into the
     // input buffer (or clears for free-type on the "Other…" row), Esc
-    // dismisses. Other keys fall through so the user can keep typing.
+    // dismisses. Other keys fall through so the user can keep typing — and
+    // (#3325) dismiss a *stale LLM-offered list* first, since `app.choices`
+    // otherwise stays populated indefinitely (it's set once per assistant
+    // turn by `push_assistant` -> `detect_choices`, not per-keystroke) and
+    // would keep intercepting the *next* Enter as "confirm choice" instead
+    // of "submit the line I just typed", silently discarding the whole
+    // typed message. This only applies to the untagged (`choices_context ==
+    // None`) LLM list: live slash-command completions (also untagged, but
+    // rebuilt from `input_buf` on every keystroke by
+    // `update_slash_completions` below) and the tagged `/switch` picker
+    // (`choices_context == Some("switch")`, intentionally left open while
+    // typing) are both exempt.
     if !app.choices.is_empty() {
         match key.code {
             KeyCode::Up => {
@@ -67,7 +78,19 @@ pub(crate) fn handle_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
                 app.choices_context = None;
                 return None;
             }
-            _ => { /* fall through to normal input editing */ }
+            _ => {
+                // Any other key means the user is editing/typing instead of
+                // navigating the picker. Dismiss a stale LLM-offered list
+                // (untagged + not slash-shaped) so the normal input-editing
+                // match below runs unobstructed and a subsequent Enter
+                // submits the line (#3325). Leave live slash completions
+                // and the tagged `/switch` picker alone — see the comment
+                // above `is_live_slash_completion`.
+                if app.choices_context.is_none() && !is_live_slash_completion(app) {
+                    app.choices.clear();
+                    app.choice_cursor = 0;
+                }
+            }
         }
     }
     // Ctrl combos.

--- a/crates/trusty-agents/src/repl/tui/pickers.rs
+++ b/crates/trusty-agents/src/repl/tui/pickers.rs
@@ -86,29 +86,36 @@ pub(crate) fn strip_numbered_marker(line: &str) -> Option<&str> {
 }
 
 /// Whether `app.choices` currently holds a *live* slash-command completion
-/// list, as opposed to an untagged LLM-offered choice list.
+/// list, as opposed to a stale LLM-offered or `/switch` choice list.
 ///
-/// Why (#3325): `app.choices` (untagged, i.e. `choices_context == None`) is
-/// populated by two different producers with very different lifecycles —
-/// `detect_choices` sets it ONCE per assistant turn and then leaves it
-/// alone, while `update_slash_completions` rebuilds it from `input_buf` on
-/// EVERY keystroke. `handle_key`'s choices branch used to let both kinds
-/// fall through untouched on a non-navigation key, which meant a stale
-/// LLM-offered list from a *previous* turn would still be sitting in
+/// Why (#3325): `app.choices` is populated by three different producers with
+/// very different lifecycles — `detect_choices` sets it ONCE per assistant
+/// turn (untagged, `choices_context == None`) and then leaves it alone,
+/// `bridge.rs`'s `/switch` handler sets it ONCE per invocation (tagged,
+/// `choices_context == Some("switch")`), while `update_slash_completions`
+/// rebuilds the untagged list from `input_buf` on EVERY keystroke.
+/// `handle_key`'s choices branch used to let all three kinds fall through
+/// untouched on a non-navigation key, which meant a stale LLM-offered *or*
+/// `/switch` list from a *previous* action would still be sitting in
 /// `app.choices` the next time the user typed a new message — so the
-/// following Enter got swallowed as "confirm choice" instead of "submit
-/// this line". This predicate lets the caller dismiss only the stale kind:
-/// slash completions never go stale (they're rebuilt immediately after),
-/// so they're exempt. The tagged `/switch` picker
-/// (`choices_context == Some("switch")`) is a separate, deliberately
-/// persistent overlay and is never routed through this predicate — see the
-/// `choices_context.is_none()` guard at the call site in `keys.rs`.
+/// following Enter got swallowed as "confirm choice" (or silently fired an
+/// unintended `/switch <persona>`) instead of "submit this line". This
+/// predicate lets the caller dismiss only the stale kinds: slash
+/// completions never go stale (they're rebuilt immediately after), so
+/// they're exempt regardless of how many other producers exist.
 /// What: True only when there is no picker `context` tag AND every current
 /// entry is a `/`-prefixed command name (the shape `update_slash_completions`
-/// always produces).
+/// always produces). Depends on the invariant that no other producer's
+/// items are ALL `/`-prefixed — in particular, `push_assistant` always
+/// appends a non-`/`-prefixed `"Other (type your own)"` sentinel to every
+/// `detect_choices` result (see `app.rs`), so an untagged LLM list can never
+/// be misclassified as a live slash completion. `is_live_slash_completion_sentinel_pins_non_slash_shape`
+/// pins that invariant.
 /// Test: `repl_app_choices_dismissed_on_typing_over_llm_list`,
 /// `repl_app_slash_completion_choices_survive_typing`,
-/// `slash_completions_does_not_stomp_context_picker`.
+/// `repl_app_switch_picker_dismissed_on_typing_over_it`,
+/// `slash_completions_does_not_stomp_context_picker`,
+/// `is_live_slash_completion_sentinel_pins_non_slash_shape`.
 pub(crate) fn is_live_slash_completion(app: &ReplApp) -> bool {
     !app.choices.is_empty()
         && app.choices_context.is_none()

--- a/crates/trusty-agents/src/repl/tui/pickers.rs
+++ b/crates/trusty-agents/src/repl/tui/pickers.rs
@@ -85,6 +85,36 @@ pub(crate) fn strip_numbered_marker(line: &str) -> Option<&str> {
     Some(&line[after_punct + n.len_utf8()..])
 }
 
+/// Whether `app.choices` currently holds a *live* slash-command completion
+/// list, as opposed to an untagged LLM-offered choice list.
+///
+/// Why (#3325): `app.choices` (untagged, i.e. `choices_context == None`) is
+/// populated by two different producers with very different lifecycles —
+/// `detect_choices` sets it ONCE per assistant turn and then leaves it
+/// alone, while `update_slash_completions` rebuilds it from `input_buf` on
+/// EVERY keystroke. `handle_key`'s choices branch used to let both kinds
+/// fall through untouched on a non-navigation key, which meant a stale
+/// LLM-offered list from a *previous* turn would still be sitting in
+/// `app.choices` the next time the user typed a new message — so the
+/// following Enter got swallowed as "confirm choice" instead of "submit
+/// this line". This predicate lets the caller dismiss only the stale kind:
+/// slash completions never go stale (they're rebuilt immediately after),
+/// so they're exempt. The tagged `/switch` picker
+/// (`choices_context == Some("switch")`) is a separate, deliberately
+/// persistent overlay and is never routed through this predicate — see the
+/// `choices_context.is_none()` guard at the call site in `keys.rs`.
+/// What: True only when there is no picker `context` tag AND every current
+/// entry is a `/`-prefixed command name (the shape `update_slash_completions`
+/// always produces).
+/// Test: `repl_app_choices_dismissed_on_typing_over_llm_list`,
+/// `repl_app_slash_completion_choices_survive_typing`,
+/// `slash_completions_does_not_stomp_context_picker`.
+pub(crate) fn is_live_slash_completion(app: &ReplApp) -> bool {
+    !app.choices.is_empty()
+        && app.choices_context.is_none()
+        && app.choices.iter().all(|c| c.starts_with('/'))
+}
+
 /// Render the inline multiple-choice picker (just below the input row).
 ///
 /// Why: A non-modal picker right beneath the input keeps the user's eyes near

--- a/crates/trusty-agents/src/repl/tui/tests_input.rs
+++ b/crates/trusty-agents/src/repl/tui/tests_input.rs
@@ -514,6 +514,104 @@ fn repl_app_choices_dismissed_on_typing_over_llm_list() {
     );
 }
 
+/// Why (#3325 follow-up, HIGH from code-critic review of PR #3344): The
+/// original fix only dismissed the *untagged* (`choices_context == None`)
+/// LLM-offered list on typing, gated by `app.choices_context.is_none()`.
+/// That left the tagged `/switch` picker (`choices_context ==
+/// Some("switch")`) exempt, so it stayed open while the user typed an
+/// unrelated message right over it. Typed characters still landed in
+/// `input_buf` (the `KeyCode::Char` arm is unconditional), but the
+/// following Enter never reached `take_input` — it hit the `choices`
+/// branch's `Some("switch")` case instead, cleared the input-less
+/// `pending_submit = "/switch <highlighted-persona>"`, and fired an
+/// unintended persona switch while silently discarding the fully-typed
+/// message. Same bug class as #3325, just a second producer.
+/// What: Open the `/switch` picker (`choices_context = Some("switch")`,
+/// mirroring `bridge.rs`'s handler), type a full unrelated message
+/// char-by-char, then press Enter. Assert the typed message is returned
+/// as the submitted line (i.e. it reached `take_input`, not the picker's
+/// `Some("switch")` dispatch path) and `pending_submit` was never set to
+/// a `/switch ...` command — no persona-switch side effect fired.
+/// Test: `repl_app_switch_picker_dismissed_on_typing_over_it` (this test).
+#[test]
+fn repl_app_switch_picker_dismissed_on_typing_over_it() {
+    let mut a = ReplApp::new("ctrl".into(), "u".into());
+    // Mirrors bridge.rs's `/switch` handler: SetChoices { items, context:
+    // Some("switch") } with no arg after `/switch`.
+    a.choices = vec![
+        "ctrl".to_string(),
+        "Izzie".to_string(),
+        "CTO Assistant".to_string(),
+    ];
+    a.choice_cursor = 0;
+    a.choices_context = Some("switch".to_string());
+
+    for ch in "please just answer my question".chars() {
+        let r = handle_key(&mut a, KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        assert_eq!(r, None, "no key mid-message should submit");
+    }
+    assert!(
+        a.choices.is_empty(),
+        "typing over the /switch picker must dismiss it"
+    );
+    assert!(
+        a.choices_context.is_none(),
+        "the switch context tag must be cleared along with the choices"
+    );
+
+    let submitted = handle_key(&mut a, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert_eq!(
+        submitted.as_deref(),
+        Some("please just answer my question"),
+        "Enter must submit the freshly typed line via take_input, not \
+         confirm a stale /switch selection"
+    );
+    assert_eq!(
+        a.pending_submit, None,
+        "no synthetic '/switch <persona>' dispatch must fire — the user \
+         never selected a persona, they typed over the picker"
+    );
+}
+
+/// Why (MEDIUM from code-critic review of PR #3344): `is_live_slash_completion`
+/// distinguishes an untagged LLM-offered list from a live slash-completion
+/// list purely by content shape (`all(|c| c.starts_with('/'))`) — that's
+/// only safe because `push_assistant` always appends a non-`/`-prefixed
+/// `"Other (type your own)"` sentinel to every `detect_choices` result
+/// (see `app.rs`), so a real LLM list can never accidentally look like an
+/// all-`/` slash-completion list. Nothing pinned that invariant; a future
+/// change to the sentinel text (e.g. dropping it, or prefixing it with
+/// `/`) would silently break the #3325 dismiss-on-type fix for every
+/// LLM-offered list. This test pins it directly.
+/// What: Drive `detect_choices` + `push_assistant`'s exact list-building
+/// path via a numbered-list assistant response, then assert the resulting
+/// `app.choices` is non-empty, contains at least one non-`/`-prefixed
+/// entry (the sentinel), and `is_live_slash_completion` correctly reports
+/// `false` for it.
+/// Test: `is_live_slash_completion_sentinel_pins_non_slash_shape` (this test).
+#[test]
+fn is_live_slash_completion_sentinel_pins_non_slash_shape() {
+    let mut a = ReplApp::new("ctrl".into(), "u".into());
+    a.push_assistant("Pick one:\n1. Apple\n2. Banana\n3. Orange", false);
+
+    assert!(
+        !a.choices.is_empty(),
+        "push_assistant should have detected the numbered list"
+    );
+    assert!(
+        a.choices.iter().any(|c| !c.starts_with('/')),
+        "detect_choices results must retain a non-slash sentinel \
+         ('Other (type your own)') so they never look like a live slash \
+         completion, got {:?}",
+        a.choices
+    );
+    assert!(
+        !is_live_slash_completion(&a),
+        "an LLM-offered list carrying the 'Other (type your own)' \
+         sentinel must never be classified as a live slash completion"
+    );
+}
+
 /// Why: Slash-command autocomplete also lives in `app.choices`, but unlike
 /// an LLM-offered list it is rebuilt from `input_buf` on every keystroke
 /// (`update_slash_completions`), so it must NOT be force-dismissed by the
@@ -552,17 +650,22 @@ impl ReplHandler for NoopReplHandler {
     }
 }
 
-/// Why (#3325): The reported bug is a *race*, not just stale state —
-/// keystrokes get dropped/swallowed specifically when they arrive
-/// concurrently with model output landing mid-message. A test that only
-/// drives `handle_key` directly (as the two tests above do) never
-/// exercises the actual async entry point the event loop uses per-event
-/// (`process_event` in `events.rs`), so it can't catch a regression in
-/// that interleaving — e.g. a future change that drops keys queued while
-/// `process_event` holds the app lock to apply an `LlmResponse`. This
-/// test drives `process_event` directly (the same function
+/// Why (#3325): The confirmed root cause is stale picker state, not a
+/// channel-level race — `run.rs`'s `event_loop` drains `ReplEvent`s off an
+/// unbounded mpsc channel strictly in send order, so no keystroke is ever
+/// dropped at the channel/`select!` layer. But the *symptom* is only
+/// user-visible when an `LlmResponse` (which can populate `app.choices`
+/// via `push_assistant` -> `detect_choices`) is interleaved with the
+/// user's next round of keystrokes — a test that only drives `handle_key`
+/// directly (as the two tests above do) never exercises the actual async
+/// entry point the event loop uses per-event (`process_event` in
+/// `events.rs`), so it can't catch a regression in that ordered
+/// interleaving — e.g. a future change that mishandles keys processed
+/// while `process_event` holds the app lock to apply an `LlmResponse`.
+/// This test drives `process_event` directly (the same function
 /// `run_tui`'s `event_loop` calls for every `ReplEvent`), interleaving
-/// `Key` events with an `LlmResponse` event mid-message.
+/// `Key` events with an `LlmResponse` event mid-message, awaited in
+/// sequence exactly as the real event loop would deliver them.
 /// What: Types "abc" via `process_event(ReplEvent::Key(..))`, then
 /// processes an `LlmResponse` carrying a numbered list — populating
 /// `app.choices` exactly like a real assistant turn arriving while the

--- a/crates/trusty-agents/src/repl/tui/tests_input.rs
+++ b/crates/trusty-agents/src/repl/tui/tests_input.rs
@@ -461,3 +461,193 @@ fn ctrl_e_noop_when_python_block_but_no_shell_block() {
     assert_eq!(a.input_buf, "");
     assert_eq!(a.cursor_pos, 0);
 }
+
+// ---------------------------------------------------------------------
+// #3325: REPL swallows a fully-typed message when a stale LLM-offered
+// choice list is still showing from the previous turn. Root cause:
+// `handle_key`'s inline-choice branch intercepted every Enter as "confirm
+// picker selection" while `app.choices` was non-empty, and `app.choices`
+// is only populated once per assistant turn (`push_assistant` ->
+// `detect_choices`) — it never clears itself just because the user typed
+// something new. The fix dismisses non-live pickers the moment the user
+// presses any key other than Up/Down/Enter/Esc.
+// ---------------------------------------------------------------------
+
+/// Why: This is the exact user-visible symptom from #3325 — type a brand
+/// new message after a numbered/bulleted assistant response and press
+/// Enter, and the whole line used to vanish (replaced by the first stale
+/// choice) instead of submitting.
+/// What: Seed `app.choices` the way `push_assistant` would after a
+/// numbered-list response, type a fresh message character-by-character
+/// (mirroring real keystroke delivery), then press Enter. Assert the
+/// typed message is returned as the submitted line and the picker state
+/// is cleared — not swallowed and replaced by "Apple".
+/// Test: `repl_app_choices_dismissed_on_typing_over_llm_list` (this test).
+#[test]
+fn repl_app_choices_dismissed_on_typing_over_llm_list() {
+    let mut a = ReplApp::new("ctrl".into(), "u".into());
+    // Simulate the picker state left behind by a numbered-list assistant
+    // response (mirrors what `push_assistant` -> `detect_choices` sets).
+    a.choices = vec![
+        "Apple".to_string(),
+        "Banana".to_string(),
+        "Orange".to_string(),
+        "Other (type your own)".to_string(),
+    ];
+    a.choice_cursor = 0;
+    a.choices_context = None;
+
+    for ch in "totally different followup message".chars() {
+        let r = handle_key(&mut a, KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        assert_eq!(r, None, "no key mid-message should submit");
+    }
+    // The stale picker must be gone the moment typing started.
+    assert!(
+        a.choices.is_empty(),
+        "typing over a stale LLM choice list must dismiss it"
+    );
+    let submitted = handle_key(&mut a, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert_eq!(
+        submitted.as_deref(),
+        Some("totally different followup message"),
+        "Enter must submit the freshly typed line, not a stale picker choice"
+    );
+}
+
+/// Why: Slash-command autocomplete also lives in `app.choices`, but unlike
+/// an LLM-offered list it is rebuilt from `input_buf` on every keystroke
+/// (`update_slash_completions`), so it must NOT be force-dismissed by the
+/// same-key fall-through path — that would make the completion list flicker
+/// away on every character instead of narrowing normally.
+/// What: Type `/mo` char-by-char; after each character, `app.choices`
+/// should still contain the live `/model` completion (never spuriously
+/// emptied by the choices dismissal added for #3325).
+/// Test: `repl_app_slash_completion_choices_survive_typing` (this test).
+#[test]
+fn repl_app_slash_completion_choices_survive_typing() {
+    let mut a = ReplApp::new("ctrl".into(), "u".into());
+    for ch in "/mo".chars() {
+        handle_key(&mut a, KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+    }
+    assert_eq!(a.input_buf, "/mo");
+    assert!(
+        a.choices.iter().any(|c| c == "/model"),
+        "live slash completions must survive typing, got {:?}",
+        a.choices
+    );
+    assert!(a.choices_context.is_none());
+}
+
+/// No-op `ReplHandler` for driving `process_event` in tests without a real
+/// LLM backend. `handle_input` is never actually invoked by the assertions
+/// below (Enter's spawned dispatch task is fire-and-forget and the test
+/// checks state that `process_event` sets synchronously before spawning),
+/// but the trait bound requires a concrete impl.
+struct NoopReplHandler;
+
+#[async_trait::async_trait]
+impl ReplHandler for NoopReplHandler {
+    async fn handle_input(&self, _line: String, _tx: UnboundedSender<ReplEvent>) -> Result<bool> {
+        Ok(true)
+    }
+}
+
+/// Why (#3325): The reported bug is a *race*, not just stale state —
+/// keystrokes get dropped/swallowed specifically when they arrive
+/// concurrently with model output landing mid-message. A test that only
+/// drives `handle_key` directly (as the two tests above do) never
+/// exercises the actual async entry point the event loop uses per-event
+/// (`process_event` in `events.rs`), so it can't catch a regression in
+/// that interleaving — e.g. a future change that drops keys queued while
+/// `process_event` holds the app lock to apply an `LlmResponse`. This
+/// test drives `process_event` directly (the same function
+/// `run_tui`'s `event_loop` calls for every `ReplEvent`), interleaving
+/// `Key` events with an `LlmResponse` event mid-message.
+/// What: Types "abc" via `process_event(ReplEvent::Key(..))`, then
+/// processes an `LlmResponse` carrying a numbered list — populating
+/// `app.choices` exactly like a real assistant turn arriving while the
+/// user keeps typing — then types "def" the rest of the message, then
+/// Enter. Asserts every character survived (`input_buf`/submitted line is
+/// exactly "abcdef", nothing dropped) and the concurrently-arrived
+/// picker didn't swallow the final Enter.
+/// Test: `repl_process_event_keys_survive_concurrent_llm_response` (this
+/// test).
+#[tokio::test]
+async fn repl_process_event_keys_survive_concurrent_llm_response() {
+    let app = Arc::new(Mutex::new(ReplApp::new("ctrl".into(), "u".into())));
+    let current_task: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>> = Arc::new(Mutex::new(None));
+    let (tx, _rx) = mpsc::unbounded_channel::<ReplEvent>();
+    let handler = Arc::new(NoopReplHandler);
+
+    async fn send_key(
+        app: &Arc<Mutex<ReplApp>>,
+        current_task: &Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+        tx: &UnboundedSender<ReplEvent>,
+        handler: &Arc<NoopReplHandler>,
+        code: KeyCode,
+    ) {
+        process_event(
+            ReplEvent::Key(KeyEvent::new(code, KeyModifiers::NONE)),
+            app,
+            current_task,
+            tx,
+            handler,
+        )
+        .await;
+    }
+
+    for ch in "abc".chars() {
+        send_key(&app, &current_task, &tx, &handler, KeyCode::Char(ch)).await;
+    }
+
+    // Model output for the prior turn lands mid-keystroke — mirrors
+    // `push_assistant`/`detect_choices` populating `app.choices` while the
+    // user is still typing their next message.
+    process_event(
+        ReplEvent::LlmResponse {
+            text: "Pick one:\n1. Apple\n2. Banana\n3. Orange".to_string(),
+            is_error: false,
+        },
+        &app,
+        &current_task,
+        &tx,
+        &handler,
+    )
+    .await;
+
+    for ch in "def".chars() {
+        send_key(&app, &current_task, &tx, &handler, KeyCode::Char(ch)).await;
+    }
+
+    {
+        let a = app.lock().await;
+        assert_eq!(
+            a.input_buf, "abcdef",
+            "keystrokes must survive an LlmResponse landing mid-message"
+        );
+        // The stale picker is dismissed the moment the user resumes typing
+        // (the first "d" keystroke after the LlmResponse) rather than
+        // lingering until Enter — see the `is_live_slash_completion` guard
+        // in `keys.rs`. Confirmed empty here as a sanity check on that
+        // dismiss-on-type behavior before asserting the Enter path below.
+        assert!(
+            a.choices.is_empty(),
+            "the stale picker should already be dismissed by the 'd' \
+             keystroke that followed the LlmResponse"
+        );
+    }
+
+    send_key(&app, &current_task, &tx, &handler, KeyCode::Enter).await;
+
+    let a = app.lock().await;
+    assert!(
+        a.choices.is_empty(),
+        "Enter after typing over a stale picker must dismiss it"
+    );
+    assert_eq!(
+        a.chat.last().map(|l| l.text.as_str()),
+        Some("abcdef"),
+        "the freshly typed line must be submitted verbatim, not swallowed by \
+         the concurrently-arrived choice list"
+    );
+}

--- a/crates/trusty-agents/src/repl/tui/tests_render.rs
+++ b/crates/trusty-agents/src/repl/tui/tests_render.rs
@@ -259,12 +259,20 @@ fn slash_completions_clears_on_backspace_past_slash() {
     assert!(a.choices.is_empty(), "removing `/` must clear picker");
 }
 
-/// Why: Inline-picker context (e.g. `/switch` persona list) must NOT be
-/// stomped by the slash-completion helper — those choices have their
-/// own lifecycle and Enter-action.
-/// What: Set `choices_context = Some("switch")` with persona names;
-/// type a `/` char (which would normally trigger slash autocomplete);
-/// assert choices and context survive untouched.
+/// Why (#3325 follow-up): `update_slash_completions` must never REPLACE a
+/// context picker's choices with unrelated slash-command matches — but as
+/// of the #3325 fix, `handle_key`'s own dismiss-on-type guard now clears a
+/// stale `/switch` picker the moment the user types over it (see
+/// `repl_app_switch_picker_dismissed_on_typing_over_it` in
+/// `tests_input.rs` for the full user-visible regression this protects
+/// against: a typed message getting silently replaced by a persona
+/// switch). So after typing 'x', the `/switch` list must be gone
+/// entirely — cleared by the dismiss guard, not stomped-then-repopulated
+/// by the slash-completion helper — and the character must land in
+/// `input_buf` like ordinary typing.
+/// What: Set `choices_context = Some("switch")` with persona names; type a
+/// `/`-unrelated char; assert the picker and its context tag are both
+/// cleared and the character was inserted normally.
 /// Test: Self-contained.
 #[test]
 fn slash_completions_does_not_stomp_context_picker() {
@@ -277,8 +285,13 @@ fn slash_completions_does_not_stomp_context_picker() {
         &mut a,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
-    assert_eq!(a.choices, vec!["ctrl".to_string(), "Izzie".to_string()]);
-    assert_eq!(a.choices_context.as_deref(), Some("switch"));
+    assert!(
+        a.choices.is_empty(),
+        "typing over the /switch picker must dismiss it, not leave it \
+         showing (#3325 follow-up)"
+    );
+    assert!(a.choices_context.is_none());
+    assert_eq!(a.input_buf, "x", "the typed char must land in the editor");
 }
 
 /// Why: When the picker is open, ALL keys must be intercepted — typing a


### PR DESCRIPTION
## Summary

- Root cause: `app.choices` (the inline LLM-offered choice/picker list) is populated once per assistant turn by `push_assistant` → `detect_choices`, but never cleared just because the user starts typing a new message. `handle_key`'s inline-choice branch intercepted every `Enter` while `app.choices` was non-empty as "confirm picker selection" — so a fully-typed follow-up message got silently discarded (replaced by the stale choice, or simply not submitted) instead of being sent. This is the "REPL TUI swallows keystrokes during chat" symptom from #3325: it manifests specifically when a numbered/bulleted assistant response (which sets `app.choices`) arrives and the user then types straight through it.
- Fix: `crates/trusty-agents/src/repl/tui/keys.rs` — on any key press other than Up/Down/Enter/Esc while `app.choices` is non-empty, dismiss the picker immediately *unless* it's a live, per-keystroke-rebuilt slash-command completion list (`update_slash_completions`) or the tagged `/switch` picker (`choices_context == Some("switch")`, intentionally persistent). `crates/trusty-agents/src/repl/tui/pickers.rs` adds the `is_live_slash_completion` predicate used to distinguish the two `app.choices` producers, since both are untagged (`choices_context == None`) but have very different lifecycles.
- Added a concurrency regression test that drives the actual async `process_event` entry point (the same one `run_tui`'s event loop calls per `ReplEvent`), interleaving `Key` events with an `LlmResponse` event mid-message, and asserts no keystroke is dropped and the final `Enter` still submits the freshly typed line rather than being swallowed by the picker that arrived concurrently.

## Test plan

- [x] `cargo check -p trusty-agents`
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings`
- [x] `cargo test -p trusty-agents` — 1911 passed, 0 failed, 8 ignored (full workspace run; one unrelated checkpoint-resume test is pre-existing order/parallelism flake, confirmed passing in isolation both before and after this change)
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 7 allowlisted, 0 violations — OK.`

Closes #3325

🤖 Generated with [Claude Code](https://claude.com/claude-code)