### PR TITLE
feat(trusty-agents-ui): model/provider selection in the Assistant GUI

### DIFF
--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -63,6 +63,42 @@ pub struct TaskRequest {
     /// from a task that prints `std::env::current_dir()`).
     #[serde(default)]
     pub project_path: Option<String>,
+    /// GUI model/provider picker (#3245, epic #3052): pins a specific model
+    /// id for this turn, mirroring the REPL's `/model <id>` slash command.
+    ///
+    /// Why: `GET /api/models` (#3243) gives the picker a live catalog of
+    /// models the user can choose from; without this field the choice had
+    /// nowhere to go and the request always fell back to the agent
+    /// config's default model. Naming matches the `/api/models` response
+    /// shape (`ModelProviderEntry.default_model`'s selected value) so the
+    /// GUI can round-trip a catalog entry straight into the request body.
+    /// What: When `Some`, threaded into `SessionOverrides::model` and
+    /// applied to `cfg.agent.model` before dispatch. `None` (the default —
+    /// omitted entirely by existing callers) preserves the pre-#3245
+    /// behavior byte-for-byte: the agent config's own model is used.
+    /// Test: `session_overrides_for_passes_through_model_and_provider`,
+    /// `session_overrides_for_defaults_to_none`.
+    #[serde(default)]
+    pub model_id: Option<String>,
+    /// GUI model/provider picker (#3245, epic #3052): pins a credential-
+    /// routing path for this turn, mirroring the REPL's `/provider <name>`
+    /// slash command.
+    ///
+    /// Why: Selecting a model from `GET /api/models` often implies a
+    /// specific provider (e.g. Bedrock vs. OpenRouter) rather than letting
+    /// the normal env-credential probe pick one. Only known values are
+    /// meaningful — see `resolve_overridden_credentials` for the accepted
+    /// set (`"claude-code"`, `"openrouter"`, `"bedrock"`, `"local"`); an
+    /// unrecognized value fails the turn with a clear error rather than
+    /// silently falling back, so a picker bug surfaces immediately instead
+    /// of routing through the wrong credential path.
+    /// What: When `Some`, threaded into `SessionOverrides::provider`.
+    /// `None` (the default) preserves the pre-#3245 behavior byte-for-byte:
+    /// the normal `pick_credentials()` env probe runs unchanged.
+    /// Test: `session_overrides_for_passes_through_model_and_provider`,
+    /// `session_overrides_for_defaults_to_none`.
+    #[serde(default)]
+    pub provider_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -164,6 +200,34 @@ fn resolve_agent_for_chat(req: &TaskRequest, is_ctrl_command: bool) -> Option<St
     }
 }
 
+/// Build the model/provider `SessionOverrides` for a Conversational/Research
+/// dispatch (#3245, epic #3052).
+///
+/// Why: `TaskRequest.model_id`/`provider_id` let the GUI's model picker pin
+/// a model or credential-routing path for a single turn, mirroring the
+/// REPL's `/model`/`/provider` slash commands (see `SessionOverrides`'s own
+/// doc comment in `ctrl::config`). Extracted as its own pure function —
+/// following the `agent_override`/`resolve_agent_for_chat` pattern above —
+/// so the wire-field-to-override mapping is unit-testable without the HTTP
+/// router or an LLM call.
+/// What: `model` = `req.model_id` verbatim (`None` → the agent config's
+/// own `cfg.agent.model` is used, exactly as before this field existed).
+/// `provider` = `req.provider_id` verbatim (`None` → the normal
+/// `pick_credentials()` env probe runs unchanged; `Some` is validated by
+/// `resolve_overridden_credentials`, which errors clearly on an
+/// unrecognized value). `user` is always `None` — the HTTP path carries no
+/// authenticated caller identity to forward (unlike the Slack/Telegram
+/// bridges).
+/// Test: `session_overrides_for_defaults_to_none`,
+/// `session_overrides_for_passes_through_model_and_provider`.
+fn session_overrides_for(req: &TaskRequest) -> crate::ctrl::SessionOverrides {
+    crate::ctrl::SessionOverrides {
+        model: req.model_id.clone(),
+        provider: req.provider_id.clone(),
+        user: None,
+    }
+}
+
 /// `POST /api/task` — kick off a workflow/agent/conversational run.
 ///
 /// Why: Single entry point the WebUI / CLI hit to submit work; the server
@@ -234,6 +298,10 @@ pub(super) async fn submit_task(
     // ListProjectsTool, SetActiveProjectTool, StopTaskTool). The roster's
     // agent override only applies to ordinary conversational/research turns.
     let agent_for_chat = resolve_agent_for_chat(&req, is_ctrl_command);
+    // #3245: GUI model/provider picker overrides for this turn. Computed
+    // once so both Conversational/Research dispatch paths below (persona
+    // and session) apply the same selection.
+    let overrides = session_overrides_for(&req);
 
     match intent {
         IntentClass::Conversational | IntentClass::Research => {
@@ -256,6 +324,7 @@ pub(super) async fn submit_task(
                 .map(std::path::PathBuf::from)
                 .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
             let agent_bg = agent_for_chat.clone();
+            let overrides_bg = overrides.clone();
             let intent_label = match intent {
                 IntentClass::Conversational => "conversational",
                 IntentClass::Research => "research",
@@ -270,14 +339,22 @@ pub(super) async fn submit_task(
                         &task_text,
                         &[],
                         Some(id_bg.clone()),
-                        crate::ctrl::SessionOverrides::default(),
+                        overrides_bg,
                     )
                     .await
                 } else {
-                    crate::ctrl::run_pm_task_with_session(
+                    // #3245: threading `overrides_bg` requires the
+                    // history-aware entry point — `run_pm_task_with_session`
+                    // hardcodes `SessionOverrides::default()` internally and
+                    // has no override parameter. This call is exactly what
+                    // `run_pm_task_with_session` does under the hood (empty
+                    // history, single turn) plus the model/provider pin.
+                    crate::ctrl::run_pm_task_with_history(
                         &project_path,
                         &task_text,
+                        &[],
                         Some(id_bg.clone()),
+                        overrides_bg,
                     )
                     .await
                 };
@@ -476,6 +553,8 @@ mod tests {
             task_file: None,
             agent: agent.map(str::to_string),
             project_path: None,
+            model_id: None,
+            provider_id: None,
         }
     }
 
@@ -534,5 +613,53 @@ mod tests {
             resolve_agent_for_chat(&base_request(Some("cto-assistant")), true),
             None
         );
+    }
+
+    /// #3245: omitting `model_id`/`provider_id` entirely (every pre-#3245
+    /// caller, and any GUI submission before the user touches the picker)
+    /// must produce a no-op `SessionOverrides`, so dispatch behaves exactly
+    /// as it did before this field existed — the agent config's own model
+    /// and the normal env-credential probe are used unchanged.
+    #[test]
+    fn session_overrides_for_defaults_to_none() {
+        let overrides = session_overrides_for(&base_request(None));
+        assert_eq!(overrides.model, None);
+        assert_eq!(overrides.provider, None);
+        assert!(overrides.user.is_none());
+    }
+
+    /// #3245: the GUI model/provider picker's selection threads through
+    /// verbatim — this is the field-mapping contract the frontend's
+    /// `POST /api/task` body relies on.
+    #[test]
+    fn session_overrides_for_passes_through_model_and_provider() {
+        let mut req = base_request(None);
+        req.model_id = Some("anthropic/claude-opus-4-6".to_string());
+        req.provider_id = Some("bedrock".to_string());
+        let overrides = session_overrides_for(&req);
+        assert_eq!(
+            overrides.model.as_deref(),
+            Some("anthropic/claude-opus-4-6")
+        );
+        assert_eq!(overrides.provider.as_deref(), Some("bedrock"));
+    }
+
+    /// `POST /api/task` must accept a body carrying `model_id`/`provider_id`
+    /// and a body omitting them entirely (serde `#[serde(default)]`) — the
+    /// omission case is what every existing caller (CLI, older GUI builds)
+    /// sends, and it must keep deserializing to `None` rather than erroring.
+    #[test]
+    fn task_request_deserializes_model_and_provider_fields() {
+        let with_fields: TaskRequest = serde_json::from_str(
+            r#"{"task":"hi","model_id":"claude-opus-4-6","provider_id":"openrouter"}"#,
+        )
+        .expect("should deserialize with model_id/provider_id present");
+        assert_eq!(with_fields.model_id.as_deref(), Some("claude-opus-4-6"));
+        assert_eq!(with_fields.provider_id.as_deref(), Some("openrouter"));
+
+        let without_fields: TaskRequest =
+            serde_json::from_str(r#"{"task":"hi"}"#).expect("should deserialize when omitted");
+        assert_eq!(without_fields.model_id, None);
+        assert_eq!(without_fields.provider_id, None);
     }
 }

--- a/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
@@ -77,9 +77,23 @@ struct SubmitResponse {
 /// is forwarded as the request body's `agent` field — the same field the
 /// `--direct <agent>` subprocess dispatch path already used — so the GUI's
 /// roster selection determines which persona answers.
+/// #3245 (model/provider picker, epic #3052): `model_id`/`provider_id`,
+/// when set, are forwarded verbatim as the request body's `model_id`/
+/// `provider_id` fields — the wire names `TaskRequest` (server-side)
+/// deserializes — so the GUI's model picker selection pins a model/
+/// credential-routing path for this turn. Tauri's `invoke()` maps
+/// camelCase JS arg names (`modelId`, `providerId`) to these snake_case
+/// Rust params automatically.
 /// Test: Run `trusty-agents --api` manually, call this command with `content=
 /// "echo hi"`, assert a sequence of progress events followed by
 /// `task-complete` and a non-empty narrative return value.
+// Why: Every parameter is a flat scalar Tauri maps 1:1 from the frontend's
+// `invoke()` args to this request body's JSON fields (mirrors the
+// `build_deployment_footer` allow in `trusty-agents/src/ctrl/pm_task/helpers.rs`
+// — bundling them into a struct just to satisfy the 7-argument heuristic
+// would obscure the `#[tauri::command]` call site without buying real
+// abstraction). Allow locally.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn send_message(
     app: AppHandle,
@@ -88,6 +102,8 @@ pub async fn send_message(
     project_path: Option<String>,
     workflow: Option<String>,
     agent: Option<String>,
+    model_id: Option<String>,
+    provider_id: Option<String>,
 ) -> Result<String, String> {
     let port = state.port.lock().await.unwrap_or(8765);
     let client = reqwest::Client::new();
@@ -103,6 +119,12 @@ pub async fn send_message(
     }
     if let Some(a) = agent.as_ref().filter(|s| !s.is_empty()) {
         body.insert("agent".into(), Value::String(a.clone()));
+    }
+    if let Some(m) = model_id.as_ref().filter(|s| !s.is_empty()) {
+        body.insert("model_id".into(), Value::String(m.clone()));
+    }
+    if let Some(p) = provider_id.as_ref().filter(|s| !s.is_empty()) {
+        body.insert("provider_id".into(), Value::String(p.clone()));
     }
 
     let submit_url = format!("{}/api/task", api_base(port));

--- a/crates/trusty-agents/ui/src/components/Header.svelte
+++ b/crates/trusty-agents/ui/src/components/Header.svelte
@@ -15,7 +15,8 @@
    * Personality — App.svelte owns `activeView`; this component only
    * dispatches `switch-view` so App.svelte's unsaved-Personality-buffer
    * guard in `switchView()` stays the single gate on navigation), the
-   * `AgentSwitcher` roster dropdown (#3223), a DESKTOP/WEB transport badge
+   * `AgentSwitcher` roster dropdown (#3223), the `ModelSwitcher` model/
+   * provider picker (#3245), a DESKTOP/WEB transport badge
    * (replaces the old floating pill), an API READY/CONNECTING status badge
    * driven by `apiReady`, and `ThemeToggle`.
    * Test: Mount `<Header activeView="chat" apiReady={true} />`, verify the
@@ -28,6 +29,7 @@
   import RobotIcon from '../lib/icons/RobotIcon.svelte';
   import ThemeToggle from './ThemeToggle.svelte';
   import AgentSwitcher from './AgentSwitcher.svelte';
+  import ModelSwitcher from './ModelSwitcher.svelte';
   import { isDesktop } from '../lib/transport';
 
   export let activeView: 'chat' | 'projects' | 'personality' = 'chat';
@@ -81,6 +83,7 @@
     </div>
 
     <AgentSwitcher />
+    <ModelSwitcher />
 
     <span
       class="rounded-md border px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-wide {desktop

--- a/crates/trusty-agents/ui/src/components/InputArea.svelte
+++ b/crates/trusty-agents/ui/src/components/InputArea.svelte
@@ -3,6 +3,7 @@
   import {
     activeAgentId,
     activeMessages,
+    activeModelEntry,
     activeProject,
     activeProjectId,
     activeTaskId,
@@ -16,6 +17,7 @@
   import { get } from 'svelte/store';
   import { cancelTask, invoke, listenEvent, type CancelTaskResult } from '../lib/transport';
   import { buildRetaskPayload, isPendingTaskId } from '../lib/retask';
+  import { resolveOverride } from '../lib/models';
 
   let input = '';
   let textareaEl: HTMLTextAreaElement;
@@ -185,6 +187,17 @@
       const selectedAgent = get(activeAgentId);
       if (selectedAgent) {
         invokeArgs.agent = selectedAgent;
+      }
+      // #3245: forward the model/provider picker's selection, when any.
+      // `resolveOverride` returns `{ modelId: null, providerId: null }` for
+      // both the "Default" row and a `null` store (nothing selected yet),
+      // so a session that never touches the picker omits both keys here —
+      // identical wire shape to every pre-#3245 submission.
+      const selectedModel = get(activeModelEntry);
+      if (selectedModel) {
+        const { modelId, providerId } = resolveOverride(selectedModel);
+        if (modelId) invokeArgs.modelId = modelId;
+        if (providerId) invokeArgs.providerId = providerId;
       }
       const result = await invoke<string>('send_message', invokeArgs);
       if (mySeq !== submissionSeq) return; // superseded by a retask

--- a/crates/trusty-agents/ui/src/components/ModelSwitcher.svelte
+++ b/crates/trusty-agents/ui/src/components/ModelSwitcher.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+  /**
+   * Why (#3245 — model/provider picker, epic #3052; depends on #3243's
+   * `GET /api/models` catalog): the Assistant MVP goal "choose which AI
+   * model/provider the Assistant uses" (e.g. switch between Claude, local
+   * Ollama, different Claude sizes) needs a visible picker, mirroring
+   * `AgentSwitcher.svelte`'s roster dropdown pattern exactly — same compact
+   * button + listbox shape, same store-on-select wiring, same graceful
+   * empty/loading/error handling (an unreachable `/api/models` leaves the
+   * picker showing only "Default" rather than crashing the input area).
+   * What: Renders the active picker entry's label as a rectangular button;
+   * clicking opens a list of every `buildPicker($modelCatalog)` row.
+   * Unselectable rows (no credential configured, or not yet wired for
+   * dispatch, or Ollama unreachable) render disabled with a reason. Selecting
+   * a row sets `activeModelEntry` (read by `InputArea.svelte` on next
+   * submit) and closes the list. Fetches `/api/models` on mount.
+   * Test: Manual — open the app, confirm "Default" renders by default;
+   * click it, confirm the list opens with every catalog provider + Ollama;
+   * click a credentialed row, confirm the button label updates and the next
+   * chat message's `POST /api/task` body carries `model_id`/`provider_id`.
+   */
+  import { onMount } from 'svelte';
+  import { ChevronDown, Cpu } from 'lucide-svelte';
+  import { activeModelEntry, fetchModelCatalog, modelCatalog } from '../stores/app';
+  import { DEFAULT_PICKER_ID, buildPicker, type PickerEntry } from '../lib/models';
+
+  let open = false;
+  let loadError = false;
+  let picker: PickerEntry[] = [];
+
+  $: picker = $modelCatalog ? buildPicker($modelCatalog) : [];
+  $: activeEntry = $activeModelEntry ?? picker[0] ?? null;
+
+  function toggle() {
+    open = !open;
+  }
+
+  function select(entry: PickerEntry) {
+    if (!entry.selectable) return;
+    activeModelEntry.set(entry.id === DEFAULT_PICKER_ID ? null : entry);
+    open = false;
+  }
+
+  function handleWindowClick(event: MouseEvent) {
+    if (!open) return;
+    const target = event.target as HTMLElement;
+    if (!target.closest('[data-model-switcher]')) {
+      open = false;
+    }
+  }
+
+  onMount(() => {
+    fetchModelCatalog().catch((e) => {
+      console.error('[ModelSwitcher] fetchModelCatalog failed:', e);
+      loadError = true;
+    });
+  });
+</script>
+
+<svelte:window on:click={handleWindowClick} />
+
+<div class="relative inline-block" data-model-switcher>
+  <button
+    type="button"
+    class="flex items-center gap-1.5 rounded-md border border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface px-2.5 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide text-foundry-light-text dark:text-foundry-text hover:border-foundry-light-primary dark:hover:border-foundry-primary"
+    on:click={toggle}
+    aria-haspopup="listbox"
+    aria-expanded={open}
+    title={loadError ? 'Model catalog unavailable — using default' : undefined}
+  >
+    <Cpu class="h-3.5 w-3.5 text-foundry-light-primary dark:text-foundry-primary" />
+    {activeEntry?.label ?? 'Default'}
+    <ChevronDown class="h-3 w-3 opacity-60" />
+  </button>
+
+  {#if open}
+    <ul
+      role="listbox"
+      class="absolute right-0 top-full z-30 mt-1 max-h-72 w-64 overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface py-1 shadow-lg"
+    >
+      {#if picker.length === 0}
+        <li class="px-3 py-1.5 text-xs text-foundry-light-muted dark:text-foundry-text/40">
+          {loadError ? 'Model catalog unavailable' : 'Loading…'}
+        </li>
+      {/if}
+      {#each picker as entry (entry.id)}
+        <li>
+          <button
+            type="button"
+            role="option"
+            aria-selected={entry.id === (activeEntry?.id ?? DEFAULT_PICKER_ID)}
+            disabled={!entry.selectable}
+            class="flex w-full flex-col items-start gap-0.5 px-3 py-1.5 text-left text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40 {entry.id ===
+            (activeEntry?.id ?? DEFAULT_PICKER_ID)
+              ? 'bg-foundry-light-primary/15 dark:bg-foundry-primary/15 text-foundry-light-primary dark:text-foundry-primary'
+              : 'text-foundry-light-text/80 dark:text-foundry-text/80 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10'}"
+            on:click={() => select(entry)}
+          >
+            <span class="font-medium">{entry.label}</span>
+            {#if !entry.selectable}
+              <span class="font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
+                unavailable
+              </span>
+            {/if}
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/crates/trusty-agents/ui/src/lib/models.test.ts
+++ b/crates/trusty-agents/ui/src/lib/models.test.ts
@@ -1,0 +1,135 @@
+// Unit tests for the pure model/provider picker helpers (#3245, epic #3052).
+// See `models.ts` for the Why/What of each function under test.
+
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_PICKER_ID,
+  buildPicker,
+  resolveOverride,
+  type ModelsCatalogResponse,
+} from './models';
+
+const CATALOG: ModelsCatalogResponse = {
+  providers: [
+    {
+      provider_id: 'openrouter',
+      default_model: 'anthropic/claude-sonnet-4-6',
+      context_window: 200000,
+      credential_configured: true,
+      reachable_today: true,
+    },
+    {
+      provider_id: 'anthropic',
+      default_model: 'claude-sonnet-4-6',
+      context_window: 200000,
+      credential_configured: true,
+      reachable_today: true,
+    },
+    {
+      provider_id: 'bedrock',
+      default_model: 'us.anthropic.claude-sonnet-4-6',
+      context_window: 200000,
+      credential_configured: true,
+      reachable_today: true,
+    },
+    {
+      provider_id: 'openai',
+      default_model: 'gpt-4o',
+      context_window: 128000,
+      credential_configured: false,
+      reachable_today: false,
+    },
+  ],
+  local: {
+    provider_id: 'ollama',
+    default_model: 'llama3.2',
+    available: true,
+    reachable_today: true,
+  },
+};
+
+describe('buildPicker', () => {
+  it('always includes the default entry first', () => {
+    const picker = buildPicker(CATALOG);
+    expect(picker[0].id).toBe(DEFAULT_PICKER_ID);
+    expect(picker[0].selectable).toBe(true);
+  });
+
+  it('marks uncredentialed providers unselectable', () => {
+    const picker = buildPicker(CATALOG);
+    const openai = picker.find((e) => e.id === 'openai');
+    expect(openai?.selectable).toBe(false);
+  });
+
+  it('marks credentialed + reachable providers selectable', () => {
+    const picker = buildPicker(CATALOG);
+    const openrouter = picker.find((e) => e.id === 'openrouter');
+    expect(openrouter?.selectable).toBe(true);
+    expect(openrouter?.modelId).toBe('anthropic/claude-sonnet-4-6');
+  });
+
+  it('appends the local entry with a normalized "local" provider id, not "ollama"', () => {
+    const picker = buildPicker(CATALOG);
+    const local = picker[picker.length - 1];
+    expect(local.id).toBe('local');
+    expect(local.providerId).toBe('local');
+    expect(local.modelId).toBe('llama3.2');
+    expect(local.selectable).toBe(true);
+  });
+
+  it('marks the local entry unselectable when Ollama is unavailable', () => {
+    const offline: ModelsCatalogResponse = {
+      ...CATALOG,
+      local: { ...CATALOG.local, available: false },
+    };
+    const picker = buildPicker(offline);
+    expect(picker[picker.length - 1].selectable).toBe(false);
+  });
+});
+
+describe('resolveOverride', () => {
+  it('omits both fields for the default entry', () => {
+    const picker = buildPicker(CATALOG);
+    const result = resolveOverride(picker[0]);
+    expect(result).toEqual({ modelId: null, providerId: null });
+  });
+
+  it('omits both fields for an unselectable entry', () => {
+    const picker = buildPicker(CATALOG);
+    const openai = picker.find((e) => e.id === 'openai')!;
+    const result = resolveOverride(openai);
+    expect(result).toEqual({ modelId: null, providerId: null });
+  });
+
+  it('passes through provider_id for openrouter and bedrock', () => {
+    const picker = buildPicker(CATALOG);
+    const openrouter = picker.find((e) => e.id === 'openrouter')!;
+    expect(resolveOverride(openrouter)).toEqual({
+      modelId: 'anthropic/claude-sonnet-4-6',
+      providerId: 'openrouter',
+    });
+    const bedrock = picker.find((e) => e.id === 'bedrock')!;
+    expect(resolveOverride(bedrock)).toEqual({
+      modelId: 'us.anthropic.claude-sonnet-4-6',
+      providerId: 'bedrock',
+    });
+  });
+
+  it('passes through provider_id "local" for the Ollama entry', () => {
+    const picker = buildPicker(CATALOG);
+    const local = picker[picker.length - 1];
+    expect(resolveOverride(local)).toEqual({
+      modelId: 'llama3.2',
+      providerId: 'local',
+    });
+  });
+
+  it('sends model_id only (omits provider_id) for a provider outside the accepted override set', () => {
+    const picker = buildPicker(CATALOG);
+    const anthropic = picker.find((e) => e.id === 'anthropic')!;
+    expect(resolveOverride(anthropic)).toEqual({
+      modelId: 'claude-sonnet-4-6',
+      providerId: null,
+    });
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/models.ts
+++ b/crates/trusty-agents/ui/src/lib/models.ts
@@ -1,0 +1,153 @@
+// Model/provider picker helpers (#3245, epic #3052).
+//
+// Why: `GET /api/models` (#3243) returns the live inference-provider catalog
+// (see `crates/trusty-agents/src/api/server/models.rs`); the picker needs to
+// turn that catalog into a flat, selectable list and turn a selected row
+// into the `model_id`/`provider_id` pair `POST /api/task` accepts. Both are
+// pure functions (no fetch/invoke) so they're unit-testable without a
+// running API server, mirroring `lib/roster.ts`'s split between pure
+// helpers here and data fetching in `stores/app.ts`.
+// What: `ModelProviderEntry`/`LocalModelEntry`/`ModelsCatalogResponse` types
+// (mirroring the Rust response shape verbatim), `PickerEntry`, `buildPicker`,
+// and `resolveOverride`.
+// Test: `models.test.ts`.
+
+/** One row in `GET /api/models`'s `providers` array. */
+export interface ModelProviderEntry {
+  provider_id: string;
+  default_model: string;
+  context_window: number;
+  credential_configured: boolean;
+  reachable_today: boolean;
+}
+
+/** The synthetic local-Ollama entry in `GET /api/models`'s `local` field. */
+export interface LocalModelEntry {
+  provider_id: string;
+  default_model: string;
+  available: boolean;
+  reachable_today: boolean;
+}
+
+/** Full `GET /api/models` response body. */
+export interface ModelsCatalogResponse {
+  providers: ModelProviderEntry[];
+  local: LocalModelEntry;
+}
+
+/**
+ * Why: The picker's "Default" row must always be selectable and must be
+ * distinguishable from every catalog id in `POST /api/task`'s `model_id`/
+ * `provider_id` fields, since selecting it is what makes InputArea OMIT both
+ * fields (see `resolveOverride`'s doc comment) and fall back to the current
+ * pre-#3245 behavior byte-for-byte.
+ */
+export const DEFAULT_PICKER_ID = '__default__';
+
+/** One row the `ModelSwitcher` dropdown renders. */
+export interface PickerEntry {
+  /** Stable id for the row — `DEFAULT_PICKER_ID` or a provider id. */
+  id: string;
+  label: string;
+  /** `false` disables the row (no credential, or not yet wired for dispatch). */
+  selectable: boolean;
+  modelId: string | null;
+  providerId: string | null;
+}
+
+/**
+ * Why: `resolve_overridden_credentials` (Rust, `ctrl/pm_task/helpers.rs`)
+ * only accepts `"claude-code" | "openrouter" | "bedrock" | "local"` as a
+ * `provider_id` override — sending any other registry provider id (e.g.
+ * `"anthropic"`, `"openai"`) would fail the turn with a clear "unknown
+ * provider override" error rather than silently falling back. The registry
+ * catalog legitimately lists more providers than that (extension providers
+ * like Fireworks/Together/AtlasCloud, plus Anthropic direct), so only a
+ * subset of catalog rows may safely carry BOTH fields.
+ * What: The provider ids for which it's safe to send `provider_id` alongside
+ * `model_id`. Every other catalog row still gets a picker entry (so the
+ * model choice itself is visible and can be pinned via `model_id` alone,
+ * letting normal env-credential resolution pick the transport) but
+ * `resolveOverride` omits `providerId` for it — see that function.
+ */
+const ACCEPTED_PROVIDER_OVERRIDES = new Set(['openrouter', 'bedrock']);
+
+/**
+ * Why: The switcher needs one flat list — a "Default" row plus one row per
+ * catalog provider plus the synthetic Ollama row — sorted the same way every
+ * render so the dropdown doesn't jitter.
+ * What: Prepends a `DEFAULT_PICKER_ID` row (always selectable), maps
+ * `providers` to rows (`selectable` = `credential_configured && reachable_today`),
+ * then appends the local/Ollama row (`selectable` = `local.available`) with
+ * `providerId` normalized to `"local"` — the value `resolve_overridden_credentials`
+ * actually accepts — rather than the catalog's own `"ollama"` id.
+ * Test: `buildPicker_always_includes_default_first`,
+ * `buildPicker_marks_uncredentialed_providers_unselectable`,
+ * `buildPicker_marks_unreachable_providers_unselectable`,
+ * `buildPicker_appends_local_entry_with_normalized_provider_id`.
+ */
+export function buildPicker(catalog: ModelsCatalogResponse): PickerEntry[] {
+  const defaultEntry: PickerEntry = {
+    id: DEFAULT_PICKER_ID,
+    label: 'Default',
+    selectable: true,
+    modelId: null,
+    providerId: null,
+  };
+
+  const providerEntries: PickerEntry[] = catalog.providers.map((p) => ({
+    id: p.provider_id,
+    label: `${p.provider_id} — ${p.default_model}`,
+    selectable: p.credential_configured && p.reachable_today,
+    modelId: p.default_model,
+    providerId: p.provider_id,
+  }));
+
+  const localEntry: PickerEntry = {
+    id: 'local',
+    label: `local — ${catalog.local.default_model}`,
+    selectable: catalog.local.available,
+    modelId: catalog.local.default_model,
+    providerId: 'local',
+  };
+
+  return [defaultEntry, ...providerEntries, localEntry];
+}
+
+/** The `model_id`/`provider_id` pair to send in `POST /api/task`. */
+export interface OverridePayload {
+  modelId: string | null;
+  providerId: string | null;
+}
+
+/**
+ * Why: `InputArea.svelte` must send exactly what the backend can act on —
+ * never a `provider_id` value `resolve_overridden_credentials` will reject.
+ * Centralizing the mapping here (rather than inline in the component) keeps
+ * it unit-testable and gives `ModelSwitcher`/`InputArea` one shared source of
+ * truth for "what does picking this row actually submit."
+ * What: `DEFAULT_PICKER_ID` and non-selectable entries resolve to
+ * `{ modelId: null, providerId: null }` (no override sent — the request
+ * omits both fields and behaves exactly as before #3245). Otherwise returns
+ * `entry.modelId` verbatim, and `entry.providerId` only when it's in
+ * `ACCEPTED_PROVIDER_OVERRIDES` or is the normalized `"local"` id — every
+ * other provider id (anthropic, openai, together, atlascloud, fireworks)
+ * still pins the model via `modelId` but omits `providerId`, letting the
+ * normal env-credential probe pick the transport.
+ * Test: `resolveOverride_default_entry_omits_both_fields`,
+ * `resolveOverride_unselectable_entry_omits_both_fields`,
+ * `resolveOverride_openrouter_and_bedrock_pass_through_provider_id`,
+ * `resolveOverride_local_passes_through_provider_id`,
+ * `resolveOverride_unaccepted_provider_sends_model_id_only`.
+ */
+export function resolveOverride(entry: PickerEntry): OverridePayload {
+  if (entry.id === DEFAULT_PICKER_ID || !entry.selectable) {
+    return { modelId: null, providerId: null };
+  }
+  const providerId =
+    entry.providerId &&
+    (entry.providerId === 'local' || ACCEPTED_PROVIDER_OVERRIDES.has(entry.providerId))
+      ? entry.providerId
+      : null;
+  return { modelId: entry.modelId, providerId };
+}

--- a/crates/trusty-agents/ui/src/lib/transport.ts
+++ b/crates/trusty-agents/ui/src/lib/transport.ts
@@ -100,6 +100,19 @@ async function fetchFallback(command: string, args?: Record<string, unknown>): P
       if (typeof agent === 'string' && agent.trim()) {
         body.agent = agent;
       }
+      // #3245: mirror the Tauri `send_message` command's `model_id`/
+      // `provider_id` forwarding (see `task_commands::send_message` on the
+      // Rust side) so the browser fallback path behaves identically —
+      // `InputArea.svelte` passes `modelId`/`providerId` only when the
+      // model picker has an active, selectable entry.
+      const modelId = args?.modelId;
+      if (typeof modelId === 'string' && modelId.trim()) {
+        body.model_id = modelId;
+      }
+      const providerId = args?.providerId;
+      if (typeof providerId === 'string' && providerId.trim()) {
+        body.provider_id = providerId;
+      }
       const submit = await fetch(`${base}/api/task`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...authHeaders() },

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -8,6 +8,7 @@ import {
   type OverlayAgent,
   type RosterEntry,
 } from '../lib/roster';
+import type { ModelsCatalogResponse, PickerEntry } from '../lib/models';
 
 /**
  * Why: The sidebar needs a single source of truth for the list of chat
@@ -181,6 +182,51 @@ export async function refreshOverlayAgents(): Promise<void> {
 
 export type { RosterEntry };
 export { BASE_AGENT_ID };
+
+/**
+ * Why (#3245 — model/provider picker, epic #3052; depends on #3243's
+ * `GET /api/models` catalog): mirrors `activeAgentId`'s "second, independent
+ * selection axis" pattern — which model/provider answers, alongside which
+ * project (`activeProjectId`) and which persona (`activeAgentId`). `null`
+ * is the default so a session that never touches the picker sends neither
+ * `model_id` nor `provider_id` in `POST /api/task`, preserving the
+ * pre-#3245 default (the agent config's own model, normal env-credential
+ * resolution) byte-for-byte.
+ * What: Holds the `PickerEntry` (see `lib/models.ts`) the user last
+ * selected in `ModelSwitcher.svelte`, or `null`. `InputArea.svelte` maps it
+ * through `resolveOverride()` into the submission payload.
+ * Test: `ModelSwitcher.svelte` sets this on row click; `InputArea.svelte`
+ * reads it into the submission payload (only when non-null and selectable).
+ */
+export const activeModelEntry = writable<PickerEntry | null>(null);
+
+/** `GET /api/models` catalog (#3243), populated on `ModelSwitcher` mount. */
+export const modelCatalog = writable<ModelsCatalogResponse | null>(null);
+
+/**
+ * Why: Same shape as `fetchAgentCatalog` — a plain REST fetch populating a
+ * store, callable from `ModelSwitcher`'s `onMount` and any manual refresh.
+ * What: Fetches `GET /api/models` and replaces `modelCatalog`. Throws on a
+ * non-2xx response or network failure; callers (mirroring `fetchAgentCatalog`
+ * call sites) catch around it so an unreachable API doesn't crash the input
+ * area — the picker just falls back to showing only "Default".
+ * Test: Mount the model switcher, observe a network call to `/api/models`
+ * and the store populated.
+ */
+export async function fetchModelCatalog(): Promise<void> {
+  const base = apiBase();
+  const headers: Record<string, string> = {};
+  const token = getCurrentApiToken();
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const r = await fetch(`${base}/api/models`, { headers });
+  if (!r.ok) {
+    throw new Error(`GET /api/models failed: ${r.status}`);
+  }
+  const data = (await r.json()) as ModelsCatalogResponse;
+  modelCatalog.set(data);
+}
+
+export type { ModelsCatalogResponse, PickerEntry };
 
 /**
  * Why: When `tagent --api --api-token …` runs, every `/api/*` call


### PR DESCRIPTION
## Summary

- Adds `model_id`/`provider_id: Option<String>` to `TaskRequest` (`crates/trusty-agents/src/api/server/handlers.rs`) and threads them into `SessionOverrides` for both Conversational/Research dispatch paths in `submit_task` (the default session path, previously hardcoded `SessionOverrides::default()`, now calls `run_pm_task_with_history` directly; the persona path now passes the built overrides instead of `SessionOverrides::default()`). Omitting both fields is byte-for-byte identical to pre-#3245 behavior — validated by `session_overrides_for_defaults_to_none`.
- Adds `ModelSwitcher.svelte` (mirrors the existing `AgentSwitcher.svelte` pattern), a `GET /api/models`-backed picker rendered in `Header.svelte` next to the agent roster switcher. Selecting a row sets a new `activeModelEntry` store; `InputArea.svelte` reads it via `resolveOverride()` and forwards `modelId`/`providerId` into the `send_message` Tauri command (both the desktop `invoke` path and the browser `fetchFallback` path in `transport.ts`).
- `crates/trusty-agents/ui/src/lib/models.ts` holds the pure catalog→picker mapping (`buildPicker`) and the picker→wire-payload mapping (`resolveOverride`), unit-tested in `models.test.ts`.

### Scope ambiguity resolved

`resolve_overridden_credentials` (pre-existing, `ctrl/pm_task/helpers.rs`) only accepts `provider` overrides of `"claude-code" | "openrouter" | "bedrock" | "local"` — an unrecognized value fails the turn with a clear error rather than silently falling back. The `/api/models` registry catalog (#3243) legitimately lists more providers than that (Anthropic direct, OpenAI, Together, AtlasCloud, Fireworks). `resolveOverride()` sends `provider_id` only for `openrouter`/`bedrock`/the normalized `local` (Ollama) entry; for every other catalog provider it still pins the model via `model_id` alone and omits `provider_id`, letting the normal env-credential probe pick the transport — rather than guaranteeing every catalog row 500s on submit. This is documented inline in `models.ts`.

The `Implementation` intent (prescriptive subprocess workflow, `task_runner.rs`) was left untouched — there is no `--model`/`--provider` CLI flag on the `trusty-agents` binary today, so threading a model override into that path would require new CLI plumbing outside `SessionOverrides`, which is out of scope for this issue's file evidence (`handlers.rs:33`, `ctrl/{session,config}.rs`).

## Test plan

- [x] `cargo check -p trusty-agents` — clean
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p trusty-agents-ui --all-targets -- -D warnings` — clean (added a documented `#[allow(clippy::too_many_arguments)]` on the Tauri `send_message` command, matching the existing `build_deployment_footer` precedent in this crate)
- [x] `cargo fmt -p trusty-agents --check` / `cargo fmt -p trusty-agents-ui --check` — clean
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 7 allowlisted, 0 violations — OK.`
- [x] `cargo test -p trusty-agents` — 1926 passed, 1 pre-existing flaky failure unrelated to this change (`workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts` — fails only under full-suite parallelism, passes in isolation and when scoped to its own module; no file under `workflow/` was touched by this PR)
- [x] `pnpm install && pnpm run test:unit` (in `crates/trusty-agents/ui`) — 38 passed (11 new, in `models.test.ts`)
- [x] `pnpm run build` — succeeds (pre-existing a11y warnings in untouched `ProjectsView.svelte`, not errors)
- [x] `pnpm run check` (svelte-check) — 1 pre-existing error in untouched `App.svelte` (`sseStatus` declared but never read, predates this PR — introduced in #3279), no new errors from this change

New tests: `session_overrides_for_defaults_to_none`, `session_overrides_for_passes_through_model_and_provider`, `task_request_deserializes_model_and_provider_fields` (Rust); `buildPicker_*` / `resolveOverride_*` (TS, `models.test.ts`).

Closes #3245