### PR TITLE
feat(trusty-code): session↔workstream binding + ambient targeting (closes #3298)

### DIFF
--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -322,6 +322,7 @@ mod tests {
             status,
             created_at: Utc::now(),
             mode: None,
+            workstream_id: None,
         }
     }
 

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -665,6 +665,76 @@ pub enum Event {
         compaction_rounds: usize,
     },
 
+    // -- Session<->workstream binding (DOC-48 §4/§5.3, issue #3298) --
+    /// A session was just bound to a workstream — either the ambient default
+    /// target (§4.2: `session.create`/`task.run` called with no explicit
+    /// `workstream_id` while a workstream is active) or an explicit
+    /// `workstream_id` param (§4.1). `session::protocol::create` and
+    /// `task::protocol::task_run` are the sole emitters, each exactly once
+    /// per newly-minted session that resolves a binding — a session's
+    /// binding is immutable thereafter (§4.1), so this can never fire twice
+    /// for the same `session_id`.
+    ///
+    /// Why: DOC-48 §5.3's event table lists `SessionAdded` as part of the
+    /// minimal Phase 1A/1B set so a client observing
+    /// `GET /workstreams/{id}/events` learns a new session joined the
+    /// workstream. Session-scoped (unlike `WorkstreamActivationChanged`/
+    /// `WorkstreamStateInferred` above) — published via
+    /// `SessionRegistry::record`, so it flows through the SAME per-session
+    /// ring buffer and live bus every other session event does. This is
+    /// exactly why `crate::workstreams::sse::aggregate_live`'s dynamic
+    /// per-event membership re-check (module docs) needs no change to pick
+    /// it up: by the time this event is recorded, the binding write into
+    /// [`crate::workstreams::store::WorkstreamStore`] has already completed,
+    /// so the session is already a member of `workstream_id`'s `session_ids`
+    /// when the aggregation route re-checks membership for this event.
+    /// What: `workstream_id` and `session_id` are both carried (unlike
+    /// §5.3's literal `{session_id, binding_time}` table, widened per this
+    /// ticket's scope note so a client subscribed to one workstream's
+    /// aggregate stream — which tags every forwarded event with its source
+    /// `session_id` already — can also learn WHICH workstream without a
+    /// second round trip); `binding_time` is the UTC instant the binding was
+    /// persisted.
+    /// Test: `session::protocol::workstream_binding_tests::create_binds_ambient_active_workstream`,
+    /// `session::protocol::workstream_binding_tests::create_binds_explicit_workstream_overriding_ambient`,
+    /// `task::protocol::tests::task_run_binds_ambient_active_workstream_and_publishes_session_added`.
+    SessionAdded {
+        session_id: String,
+        workstream_id: String,
+        binding_time: DateTime<Utc>,
+    },
+
+    /// A bound session's activity signal changed — currently fired whenever
+    /// `SessionRegistry::set_run_outcome` records a completed run's turns
+    /// (the natural "a turn just happened" hook; #2056's `task::executor`
+    /// calls it once per finished execution).
+    ///
+    /// Why: DOC-48 §5.3's event table lists this alongside `SessionAdded` so
+    /// a workstream observer can track which of its bound sessions are
+    /// live/recently-active without polling `session.status` per id. Emitted
+    /// unconditionally (workstream-bound or not — `SessionRegistry` has no
+    /// cheap way to know at this call site, and a client observing a
+    /// PROJECTLESS session's own `GET /sessions/{id}/events` stream benefits
+    /// from it identically); the workstream-level aggregation route only
+    /// ever forwards it for sessions that ARE bound (dynamic membership
+    /// check, same as `SessionAdded` above), so an unbound session's copy is
+    /// simply never surfaced there.
+    /// What: `last_turn_at` is the UTC instant this update was recorded;
+    /// `has_running_task` mirrors `SessionRegistry::is_executing` at that
+    /// same instant (`true` while `set_run_outcome`'s caller — `run_task`'s
+    /// executor — still holds the execution slot when this fires; #2056's
+    /// call order means this is realistically always `false` in practice
+    /// today, since the executor clears its execution slot only AFTER
+    /// `set_run_outcome` returns — carried anyway so a future caller with a
+    /// genuinely mid-run activity signal has a field to set it on without a
+    /// schema change).
+    /// Test: `session::registry_tests::set_run_outcome_publishes_activity_update`.
+    SessionActivityUpdate {
+        session_id: String,
+        last_turn_at: DateTime<Utc>,
+        has_running_task: bool,
+    },
+
     // -- Workstream lifecycle (DOC-48 §5.3/§6.3, issue #3297) --
     /// The daemon-wide active workstream changed: `workstream.activate`
     /// switched to a different workstream (or activated one from no prior
@@ -902,7 +972,9 @@ impl Event {
             | Event::ReportGenerated { session_id, .. }
             | Event::RecapGenerated { session_id, .. }
             | Event::IndexReadiness { session_id, .. }
-            | Event::ContextBudget { session_id, .. } => Some(session_id),
+            | Event::ContextBudget { session_id, .. }
+            | Event::SessionAdded { session_id, .. }
+            | Event::SessionActivityUpdate { session_id, .. } => Some(session_id),
             Event::WorkstreamActivationChanged { .. }
             | Event::WorkstreamStateInferred { .. }
             | Event::Ping => None,
@@ -956,6 +1028,8 @@ impl Event {
             Event::RecapGenerated { .. } => "recap_generated",
             Event::IndexReadiness { .. } => "index_readiness",
             Event::ContextBudget { .. } => "context_budget",
+            Event::SessionAdded { .. } => "session_added",
+            Event::SessionActivityUpdate { .. } => "session_activity_update",
             Event::WorkstreamActivationChanged { .. } => "workstream_activation_changed",
             Event::WorkstreamStateInferred { .. } => "workstream_state_inferred",
             Event::Ping => "ping",

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -712,13 +712,15 @@ pub enum Event {
     /// Why: DOC-48 §5.3's event table lists this alongside `SessionAdded` so
     /// a workstream observer can track which of its bound sessions are
     /// live/recently-active without polling `session.status` per id. Emitted
-    /// unconditionally (workstream-bound or not — `SessionRegistry` has no
-    /// cheap way to know at this call site, and a client observing a
-    /// PROJECTLESS session's own `GET /sessions/{id}/events` stream benefits
-    /// from it identically); the workstream-level aggregation route only
-    /// ever forwards it for sessions that ARE bound (dynamic membership
-    /// check, same as `SessionAdded` above), so an unbound session's copy is
-    /// simply never surfaced there.
+    /// ONLY for workstream-BOUND sessions (`Session.workstream_id` set):
+    /// this is a workstream-taxonomy event (§5.3 defines it in that set),
+    /// an unbound session has no workstream observer to serve — and the M1
+    /// cutline e2e contract (`tests/m1_cutline_e2e.rs`) freezes the exact
+    /// event-kind sequence a plain, workstream-less session emits, so
+    /// firing this unconditionally would (and, in PR #3354's first cut,
+    /// did) break that frozen baseline for every existing client on both
+    /// transports. See `SessionRegistry::set_run_outcome`'s docs for the
+    /// gate.
     /// What: `last_turn_at` is the UTC instant this update was recorded;
     /// `has_running_task` mirrors `SessionRegistry::is_executing` at that
     /// same instant (`true` while `set_run_outcome`'s caller — `run_task`'s
@@ -728,7 +730,8 @@ pub enum Event {
     /// `set_run_outcome` returns — carried anyway so a future caller with a
     /// genuinely mid-run activity signal has a field to set it on without a
     /// schema change).
-    /// Test: `session::registry_tests::set_run_outcome_publishes_activity_update`.
+    /// Test: `session::registry_tests::set_run_outcome_publishes_activity_update_when_workstream_bound`,
+    /// `session::registry_tests::set_run_outcome_stays_silent_for_unbound_session`.
     SessionActivityUpdate {
         session_id: String,
         last_turn_at: DateTime<Utc>,

--- a/crates/trusty-code/src/events_tests.rs
+++ b/crates/trusty-code/src/events_tests.rs
@@ -40,6 +40,27 @@ fn session_id_returns_correct_field() {
     assert_eq!(Event::Ping.session_id(), None);
 }
 
+/// (issue #3298) `SessionAdded`/`SessionActivityUpdate` ARE session-scoped —
+/// unlike the daemon-scoped workstream events below.
+#[test]
+fn session_added_and_activity_update_are_session_scoped() {
+    let added = Event::SessionAdded {
+        session_id: "s-1".into(),
+        workstream_id: "ws-1".into(),
+        binding_time: Utc::now(),
+    };
+    assert_eq!(added.session_id(), Some("s-1"));
+    assert_eq!(added.kind(), "session_added");
+
+    let activity = Event::SessionActivityUpdate {
+        session_id: "s-1".into(),
+        last_turn_at: Utc::now(),
+        has_running_task: false,
+    };
+    assert_eq!(activity.session_id(), Some("s-1"));
+    assert_eq!(activity.kind(), "session_activity_update");
+}
+
 /// (issue #3297) `WorkstreamActivationChanged` is daemon-scoped, not
 /// session-scoped — mirrors `Event::Ping`'s `None`.
 #[test]
@@ -213,6 +234,16 @@ fn kind_matches_serde_tag_for_every_variant() {
             within_budget: true,
             compaction_fired: false,
             compaction_rounds: 0,
+        },
+        Event::SessionAdded {
+            session_id: "s".into(),
+            workstream_id: "ws-1".into(),
+            binding_time: Utc::now(),
+        },
+        Event::SessionActivityUpdate {
+            session_id: "s".into(),
+            last_turn_at: Utc::now(),
+            has_running_task: false,
         },
         Event::WorkstreamActivationChanged {
             new_active_id: Some("ws-2".into()),

--- a/crates/trusty-code/src/serve/http_tests.rs
+++ b/crates/trusty-code/src/serve/http_tests.rs
@@ -21,10 +21,11 @@ use trusty_common::mcp::error_codes;
 
 async fn router_and_sessions() -> (Arc<Router>, Arc<SessionRegistry>, SharedWorkstreamStore) {
     let sessions = Arc::new(SessionRegistry::new());
+    let workstreams = test_workstreams_store().await;
     let mut router = Router::new();
     crate::serve::methods::register(&mut router);
-    crate::session::protocol::register(&mut router, sessions.clone());
-    (Arc::new(router), sessions, test_workstreams_store().await)
+    crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
+    (Arc::new(router), sessions, workstreams)
 }
 
 /// A fresh, tempdir-backed `SharedWorkstreamStore` with no workstreams
@@ -250,17 +251,19 @@ async fn http_rest_post_tasks_route_is_merged_in() {
     )
     .expect("write pm.md");
     let project = tempfile::tempdir().expect("project tempdir");
+    let workstreams = test_workstreams_store().await;
     let mut router = Router::new();
     crate::serve::methods::register(&mut router);
-    crate::session::protocol::register(&mut router, sessions.clone());
+    crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
     crate::task::protocol::register(
         &mut router,
         sessions.clone(),
         crate::binding::ProjectBinding::resolve(Some(project.path().to_path_buf()))
             .expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        workstreams.clone(),
     );
-    let app = build_axum_router(Arc::new(router), sessions, test_workstreams_store().await);
+    let app = build_axum_router(Arc::new(router), sessions, workstreams);
 
     let resp = app
         .oneshot(
@@ -298,7 +301,11 @@ async fn http_rest_get_fs_route_is_merged_in() {
     let sessions = Arc::new(SessionRegistry::new());
     let mut router = Router::new();
     crate::serve::methods::register(&mut router);
-    crate::session::protocol::register(&mut router, sessions.clone());
+    crate::session::protocol::register(
+        &mut router,
+        sessions.clone(),
+        test_workstreams_store().await,
+    );
     crate::fs_browse::protocol::register(&mut router);
     let app = build_axum_router(Arc::new(router), sessions, test_workstreams_store().await);
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -425,7 +432,7 @@ async fn http_rest_get_workstreams_route_is_merged_in() {
     let workstreams = Arc::new(tokio::sync::Mutex::new(store));
     let mut router = Router::new();
     crate::serve::methods::register(&mut router);
-    crate::session::protocol::register(&mut router, sessions.clone());
+    crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
     crate::workstreams::protocol::register(&mut router, workstreams.clone());
     let id = workstreams.lock().await.create("t").await.expect("create");
     let app = build_axum_router(Arc::new(router), sessions, workstreams);

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -166,9 +166,15 @@ async fn build_router_at(
 
     let mut router = Router::new();
     methods::register(&mut router);
-    crate::session::protocol::register(&mut router, sessions.clone());
+    crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
     crate::fs_browse::protocol::register(&mut router);
-    crate::task::protocol::register(&mut router, sessions.clone(), binding, agents_dir);
+    crate::task::protocol::register(
+        &mut router,
+        sessions.clone(),
+        binding,
+        agents_dir,
+        workstreams.clone(),
+    );
     crate::workstreams::protocol::register(&mut router, workstreams.clone());
     Ok((router, sessions, workstreams))
 }

--- a/crates/trusty-code/src/serve/rest/agents.rs
+++ b/crates/trusty-code/src/serve/rest/agents.rs
@@ -94,10 +94,14 @@ mod tests {
     /// Build a router wired with every `session.*` method plus a fresh
     /// `SessionRegistry`, then this module's route group over it — mirrors
     /// `sessions::tests::app_and_registry`.
-    fn app_and_registry() -> (AxumRouter, Arc<crate::session::SessionRegistry>) {
+    async fn app_and_registry() -> (AxumRouter, Arc<crate::session::SessionRegistry>) {
         let sessions = Arc::new(crate::session::SessionRegistry::new());
         let mut router = Router::new();
-        crate::session::protocol::register(&mut router, sessions.clone());
+        crate::session::protocol::register(
+            &mut router,
+            sessions.clone(),
+            crate::workstreams::test_shared_store().await,
+        );
         let app = routes(Arc::new(router));
         (app, sessions)
     }
@@ -124,7 +128,7 @@ mod tests {
     /// yet must return `200` with an empty `agents` array, not an error.
     #[tokio::test]
     async fn get_agents_found_returns_200_with_empty_roster() {
-        let (app, sessions) = app_and_registry();
+        let (app, sessions) = app_and_registry().await;
         let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let resp = get(&app, &format!("/sessions/{}/agents", session.id)).await;
@@ -137,7 +141,7 @@ mod tests {
     /// a `session_not_found` envelope.
     #[tokio::test]
     async fn get_agents_missing_returns_404_session_not_found() {
-        let (app, _sessions) = app_and_registry();
+        let (app, _sessions) = app_and_registry().await;
 
         let resp = get(&app, "/sessions/does-not-exist/agents").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/crates/trusty-code/src/serve/rest/search_audit.rs
+++ b/crates/trusty-code/src/serve/rest/search_audit.rs
@@ -88,10 +88,14 @@ mod tests {
     /// Build a router wired with every `session.*` method plus a fresh
     /// `SessionRegistry`, then this module's route group over it — mirrors
     /// `agents::tests::app_and_registry`.
-    fn app_and_registry() -> (AxumRouter, Arc<crate::session::SessionRegistry>) {
+    async fn app_and_registry() -> (AxumRouter, Arc<crate::session::SessionRegistry>) {
         let sessions = Arc::new(crate::session::SessionRegistry::new());
         let mut router = Router::new();
-        crate::session::protocol::register(&mut router, sessions.clone());
+        crate::session::protocol::register(
+            &mut router,
+            sessions.clone(),
+            crate::workstreams::test_shared_store().await,
+        );
         let app = routes(Arc::new(router));
         (app, sessions)
     }
@@ -119,7 +123,7 @@ mod tests {
     /// `search_audit` array, not an error.
     #[tokio::test]
     async fn get_search_audit_found_returns_200_with_empty_list() {
-        let (app, sessions) = app_and_registry();
+        let (app, sessions) = app_and_registry().await;
         let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let resp = get(&app, &format!("/sessions/{}/search-audit", session.id)).await;
@@ -132,7 +136,7 @@ mod tests {
     /// `404` with a `session_not_found` envelope.
     #[tokio::test]
     async fn get_search_audit_missing_returns_404_session_not_found() {
-        let (app, _sessions) = app_and_registry();
+        let (app, _sessions) = app_and_registry().await;
 
         let resp = get(&app, "/sessions/does-not-exist/search-audit").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/crates/trusty-code/src/serve/rest/sessions.rs
+++ b/crates/trusty-code/src/serve/rest/sessions.rs
@@ -173,10 +173,14 @@ mod tests {
     /// `SessionRegistry`, then the REST route group over it — mirrors
     /// `crate::serve::http::tests::router_and_sessions` but only needs the
     /// registry to seed sessions directly (these routes never touch it).
-    fn app_and_registry() -> (AxumRouter, Arc<crate::session::SessionRegistry>) {
+    async fn app_and_registry() -> (AxumRouter, Arc<crate::session::SessionRegistry>) {
         let sessions = Arc::new(crate::session::SessionRegistry::new());
         let mut router = Router::new();
-        crate::session::protocol::register(&mut router, sessions.clone());
+        crate::session::protocol::register(
+            &mut router,
+            sessions.clone(),
+            crate::workstreams::test_shared_store().await,
+        );
         let app = routes(Arc::new(router));
         (app, sessions)
     }
@@ -203,7 +207,7 @@ mod tests {
     /// currently owned by the registry.
     #[tokio::test]
     async fn list_sessions_returns_sessions_array() {
-        let (app, sessions) = app_and_registry();
+        let (app, sessions) = app_and_registry().await;
         sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let resp = get(&app, "/sessions").await;
@@ -216,7 +220,7 @@ mod tests {
     /// `Session` JSON, `id` included.
     #[tokio::test]
     async fn get_session_found_returns_200_with_session_json() {
-        let (app, sessions) = app_and_registry();
+        let (app, sessions) = app_and_registry().await;
         let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let resp = get(&app, &format!("/sessions/{}", session.id)).await;
@@ -229,7 +233,7 @@ mod tests {
     /// JSON-RPC `session_not_found` envelope, not a 200-wrapped error.
     #[tokio::test]
     async fn get_session_missing_returns_404_session_not_found() {
-        let (app, _sessions) = app_and_registry();
+        let (app, _sessions) = app_and_registry().await;
 
         let resp = get(&app, "/sessions/does-not-exist").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -245,7 +249,7 @@ mod tests {
     /// validation.
     #[tokio::test]
     async fn get_session_percent_encoded_missing_id_returns_404() {
-        let (app, _sessions) = app_and_registry();
+        let (app, _sessions) = app_and_registry().await;
 
         let resp = get(&app, "/sessions/not%20a%20real%20id").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -257,7 +261,7 @@ mod tests {
     /// HTTP 200 with an empty `turns` array, not an error.
     #[tokio::test]
     async fn get_transcript_found_returns_200_with_empty_turns() {
-        let (app, sessions) = app_and_registry();
+        let (app, sessions) = app_and_registry().await;
         let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let resp = get(&app, &format!("/sessions/{}/transcript", session.id)).await;
@@ -269,7 +273,7 @@ mod tests {
     /// `GET /sessions/{id}/transcript` on an unknown id must 404.
     #[tokio::test]
     async fn get_transcript_missing_returns_404_session_not_found() {
-        let (app, _sessions) = app_and_registry();
+        let (app, _sessions) = app_and_registry().await;
 
         let resp = get(&app, "/sessions/does-not-exist/transcript").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -281,7 +285,7 @@ mod tests {
     /// HTTP 200 with `status: "never_probed"`, not an error.
     #[tokio::test]
     async fn get_readiness_found_returns_200_never_probed() {
-        let (app, sessions) = app_and_registry();
+        let (app, sessions) = app_and_registry().await;
         let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let resp = get(&app, &format!("/sessions/{}/readiness", session.id)).await;
@@ -293,7 +297,7 @@ mod tests {
     /// `GET /sessions/{id}/readiness` on an unknown id must 404.
     #[tokio::test]
     async fn get_readiness_missing_returns_404_session_not_found() {
-        let (app, _sessions) = app_and_registry();
+        let (app, _sessions) = app_and_registry().await;
 
         let resp = get(&app, "/sessions/does-not-exist/readiness").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -305,7 +309,7 @@ mod tests {
     /// 200 with an empty `goals` array, not an error.
     #[tokio::test]
     async fn get_goals_found_returns_200_with_empty_goals() {
-        let (app, sessions) = app_and_registry();
+        let (app, sessions) = app_and_registry().await;
         let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let resp = get(&app, &format!("/sessions/{}/goals", session.id)).await;
@@ -317,7 +321,7 @@ mod tests {
     /// `GET /sessions/{id}/goals` on an unknown id must 404.
     #[tokio::test]
     async fn get_goals_missing_returns_404_session_not_found() {
-        let (app, _sessions) = app_and_registry();
+        let (app, _sessions) = app_and_registry().await;
 
         let resp = get(&app, "/sessions/does-not-exist/goals").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -329,7 +333,7 @@ mod tests {
     /// return HTTP 200 with `status: "never_recorded"`, not an error.
     #[tokio::test]
     async fn get_context_budget_found_returns_200_never_recorded() {
-        let (app, sessions) = app_and_registry();
+        let (app, sessions) = app_and_registry().await;
         let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
         let resp = get(&app, &format!("/sessions/{}/budget", session.id)).await;
@@ -341,7 +345,7 @@ mod tests {
     /// `GET /sessions/{id}/budget` on an unknown id must 404.
     #[tokio::test]
     async fn get_context_budget_missing_returns_404_session_not_found() {
-        let (app, _sessions) = app_and_registry();
+        let (app, _sessions) = app_and_registry().await;
 
         let resp = get(&app, "/sessions/does-not-exist/budget").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);

--- a/crates/trusty-code/src/serve/rest/sessions_write.rs
+++ b/crates/trusty-code/src/serve/rest/sessions_write.rs
@@ -96,6 +96,11 @@ struct CreateBody {
     agent: Option<String>,
     #[serde(default)]
     project: Option<String>,
+    /// (Issue #3298) Forwarded verbatim to `session.create`'s own
+    /// `workstream_id` param — see `session::protocol::create`'s docs for
+    /// the explicit-vs-ambient resolution rules.
+    #[serde(default)]
+    workstream_id: Option<String>,
 }
 
 /// Request body for `POST /sessions/{id}/messages` — `session_id` comes
@@ -165,7 +170,12 @@ async fn create_session(
     respond_created(
         &state.router,
         "session.create",
-        json!({"task": body.task, "agent": body.agent, "project": body.project}),
+        json!({
+            "task": body.task,
+            "agent": body.agent,
+            "project": body.project,
+            "workstream_id": body.workstream_id,
+        }),
     )
     .await
 }

--- a/crates/trusty-code/src/serve/rest/sessions_write_tests.rs
+++ b/crates/trusty-code/src/serve/rest/sessions_write_tests.rs
@@ -31,10 +31,14 @@ use crate::session::SessionRegistry;
 /// Build a router wired with every `session.*` method plus a fresh
 /// `SessionRegistry`, then this module's write route group over it —
 /// mirrors `sessions::tests::app_and_registry`.
-fn app_and_registry() -> (AxumRouter, Arc<SessionRegistry>) {
+async fn app_and_registry() -> (AxumRouter, Arc<SessionRegistry>) {
     let sessions = Arc::new(SessionRegistry::new());
     let mut router = Router::new();
-    crate::session::protocol::register(&mut router, sessions.clone());
+    crate::session::protocol::register(
+        &mut router,
+        sessions.clone(),
+        crate::workstreams::test_shared_store().await,
+    );
     let app = routes(Arc::new(router));
     (app, sessions)
 }
@@ -82,7 +86,7 @@ async fn send(
 /// `Session` JSON.
 #[tokio::test]
 async fn create_session_returns_201_with_running_session() {
-    let (app, _sessions) = app_and_registry();
+    let (app, _sessions) = app_and_registry().await;
 
     let resp = send(&app, "POST", "/sessions", Some(r#"{"task": "do it"}"#)).await;
     assert_eq!(resp.status(), StatusCode::CREATED);
@@ -96,7 +100,7 @@ async fn create_session_returns_201_with_running_session() {
 /// case, since a create request has no `session_id` to be missing.
 #[tokio::test]
 async fn create_session_empty_task_returns_400() {
-    let (app, _sessions) = app_and_registry();
+    let (app, _sessions) = app_and_registry().await;
 
     let resp = send(&app, "POST", "/sessions", Some(r#"{"task": "   "}"#)).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -108,7 +112,7 @@ async fn create_session_empty_task_returns_400() {
 /// extractor rejects it with a client error before `session.create` runs.
 #[tokio::test]
 async fn create_session_malformed_body_returns_400() {
-    let (app, _sessions) = app_and_registry();
+    let (app, _sessions) = app_and_registry().await;
 
     let resp = send(&app, "POST", "/sessions", Some("{not valid json")).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -122,7 +126,7 @@ async fn create_session_malformed_body_returns_400() {
 /// `{"acknowledged": true}`.
 #[tokio::test]
 async fn send_message_returns_200_acknowledged() {
-    let (app, sessions) = app_and_registry();
+    let (app, sessions) = app_and_registry().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let resp = send(
@@ -141,7 +145,7 @@ async fn send_message_returns_200_acknowledged() {
 /// `session_not_found` envelope.
 #[tokio::test]
 async fn send_message_missing_session_returns_404() {
-    let (app, _sessions) = app_and_registry();
+    let (app, _sessions) = app_and_registry().await;
 
     let resp = send(
         &app,
@@ -159,7 +163,7 @@ async fn send_message_missing_session_returns_404() {
 /// extractor before `session.send` runs.
 #[tokio::test]
 async fn send_message_malformed_body_returns_400() {
-    let (app, sessions) = app_and_registry();
+    let (app, sessions) = app_and_registry().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let resp = send(
@@ -180,7 +184,7 @@ async fn send_message_malformed_body_returns_400() {
 /// terminal `Session` snapshot.
 #[tokio::test]
 async fn cancel_session_returns_200_with_session_json() {
-    let (app, sessions) = app_and_registry();
+    let (app, sessions) = app_and_registry().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let resp = send(
@@ -198,7 +202,7 @@ async fn cancel_session_returns_200_with_session_json() {
 /// Cancelling an unknown session must be a real `404`.
 #[tokio::test]
 async fn cancel_session_missing_session_returns_404() {
-    let (app, _sessions) = app_and_registry();
+    let (app, _sessions) = app_and_registry().await;
 
     let resp = send(&app, "POST", "/sessions/does-not-exist/cancel", None).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -211,7 +215,7 @@ async fn cancel_session_missing_session_returns_404() {
 /// substitute for the "malformed body" case, since it takes no body.
 #[tokio::test]
 async fn cancel_session_is_idempotent() {
-    let (app, sessions) = app_and_registry();
+    let (app, sessions) = app_and_registry().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let first = send(
@@ -241,7 +245,7 @@ async fn cancel_session_is_idempotent() {
 /// `200` with `{}`.
 #[tokio::test]
 async fn set_goal_returns_200_empty_object() {
-    let (app, sessions) = app_and_registry();
+    let (app, sessions) = app_and_registry().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     seed_pm_transcript(&sessions, &session.id);
 
@@ -260,7 +264,7 @@ async fn set_goal_returns_200_empty_object() {
 /// Setting a goal on an unknown session must be a real `404`.
 #[tokio::test]
 async fn set_goal_missing_session_returns_404() {
-    let (app, _sessions) = app_and_registry();
+    let (app, _sessions) = app_and_registry().await;
 
     let resp = send(
         &app,
@@ -278,7 +282,7 @@ async fn set_goal_missing_session_returns_404() {
 /// extractor before `session.set_goal` runs.
 #[tokio::test]
 async fn set_goal_malformed_body_returns_400() {
-    let (app, sessions) = app_and_registry();
+    let (app, sessions) = app_and_registry().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let resp = send(
@@ -298,7 +302,7 @@ async fn set_goal_malformed_body_returns_400() {
 /// Clearing a previously-set goal slot must return `200` with `{}`.
 #[tokio::test]
 async fn clear_goal_returns_200_empty_object() {
-    let (app, sessions) = app_and_registry();
+    let (app, sessions) = app_and_registry().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
     seed_pm_transcript(&sessions, &session.id);
     sessions.set_goal(&session.id, 3, "temp").unwrap();
@@ -318,7 +322,7 @@ async fn clear_goal_returns_200_empty_object() {
 /// Clearing a goal on an unknown session must be a real `404`.
 #[tokio::test]
 async fn clear_goal_missing_session_returns_404() {
-    let (app, _sessions) = app_and_registry();
+    let (app, _sessions) = app_and_registry().await;
 
     let resp = send(
         &app,
@@ -336,7 +340,7 @@ async fn clear_goal_missing_session_returns_404() {
 /// extractor before `session.clear_goal` runs.
 #[tokio::test]
 async fn clear_goal_malformed_body_returns_400() {
-    let (app, sessions) = app_and_registry();
+    let (app, sessions) = app_and_registry().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
     let resp = send(

--- a/crates/trusty-code/src/serve/rest/tasks.rs
+++ b/crates/trusty-code/src/serve/rest/tasks.rs
@@ -84,6 +84,11 @@ struct RunTaskBody {
     deadline_secs: Option<u64>,
     #[serde(default)]
     project: Option<String>,
+    /// (Issue #3298) Forwarded verbatim to `task.run`'s own `workstream_id`
+    /// param — see `task::protocol`'s docs for the mint-vs-reuse resolution
+    /// rules.
+    #[serde(default)]
+    workstream_id: Option<String>,
 }
 
 /// Like [`super::respond`] but reports `202 Accepted` on success instead of
@@ -150,6 +155,7 @@ async fn run_task(
             "mode": body.mode,
             "deadline_secs": body.deadline_secs,
             "project": body.project,
+            "workstream_id": body.workstream_id,
         }),
     )
     .await
@@ -169,7 +175,7 @@ mod tests {
     /// Build a router wired with a real `task.run` (mock LLM, so no real
     /// subprocess/network call happens), then this module's route group over
     /// it — mirrors `sessions::tests::app_and_registry`.
-    fn app_and_registry() -> (AxumRouter, StdArc<SessionRegistry>, tempfile::TempDir) {
+    async fn app_and_registry() -> (AxumRouter, StdArc<SessionRegistry>, tempfile::TempDir) {
         let sessions = StdArc::new(SessionRegistry::new());
         let agents = tempfile::tempdir().expect("agents tempdir");
         std::fs::write(
@@ -178,13 +184,15 @@ mod tests {
         )
         .expect("write pm.md");
         let project = tempfile::tempdir().expect("project tempdir");
+        let workstreams = crate::workstreams::test_shared_store().await;
         let mut router = Router::new();
-        crate::session::protocol::register(&mut router, sessions.clone());
+        crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
         crate::task::protocol::register(
             &mut router,
             sessions.clone(),
             ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
             agents.path().to_path_buf(),
+            workstreams,
         );
         let app = routes(StdArc::new(router));
         (app, sessions, project)
@@ -221,7 +229,7 @@ mod tests {
                 crate::task::mock_llm::MOCK_LLM_ECHO,
             );
         }
-        let (app, _sessions, _project) = app_and_registry();
+        let (app, _sessions, _project) = app_and_registry().await;
 
         let resp = post(&app, "/tasks", r#"{"task_description": "say hi"}"#).await;
         unsafe {
@@ -236,7 +244,7 @@ mod tests {
     /// invalid_argument`).
     #[tokio::test]
     async fn run_task_empty_task_description_returns_400() {
-        let (app, _sessions, _project) = app_and_registry();
+        let (app, _sessions, _project) = app_and_registry().await;
 
         let resp = post(&app, "/tasks", r#"{"task_description": "   "}"#).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -249,7 +257,7 @@ mod tests {
     /// above.
     #[tokio::test]
     async fn run_task_unknown_session_id_returns_404() {
-        let (app, _sessions, _project) = app_and_registry();
+        let (app, _sessions, _project) = app_and_registry().await;
 
         let resp = post(
             &app,
@@ -268,7 +276,7 @@ mod tests {
     /// identical case for `POST /sessions`.
     #[tokio::test]
     async fn run_task_malformed_body_returns_400() {
-        let (app, _sessions, _project) = app_and_registry();
+        let (app, _sessions, _project) = app_and_registry().await;
 
         let resp = post(&app, "/tasks", "{not valid json").await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -287,7 +295,7 @@ mod tests {
                 crate::task::mock_llm::MOCK_LLM_ECHO,
             );
         }
-        let (app, _sessions, _boot_project) = app_and_registry();
+        let (app, _sessions, _boot_project) = app_and_registry().await;
         let call_project = tempfile::tempdir().expect("call project tempdir");
 
         let body = json!({
@@ -311,7 +319,7 @@ mod tests {
     /// invalid_argument`), matching `task.run`'s RPC-level error mapping.
     #[tokio::test]
     async fn run_task_invalid_project_returns_400() {
-        let (app, _sessions, _project) = app_and_registry();
+        let (app, _sessions, _project) = app_and_registry().await;
 
         let resp = post(
             &app,
@@ -331,7 +339,7 @@ mod tests {
     /// `task::protocol::tests::task_run_session_id_with_mismatched_project_is_rejected`.
     #[tokio::test]
     async fn run_task_session_id_with_mismatched_project_returns_400() {
-        let (app, sessions, _boot_project) = app_and_registry();
+        let (app, sessions, _boot_project) = app_and_registry().await;
         let session_project = tempfile::tempdir().expect("session project tempdir");
         let other_project = tempfile::tempdir().expect("other project tempdir");
         let session_binding = ProjectBinding::resolve(Some(session_project.path().to_path_buf()))

--- a/crates/trusty-code/src/session/model.rs
+++ b/crates/trusty-code/src/session/model.rs
@@ -123,6 +123,19 @@ pub struct Session {
     /// older persisted/serialized `Session` without the field still reads back.
     #[serde(default)]
     pub binding: crate::binding::ProjectBinding,
+    /// (Issue #3298, DOC-48 §4.1) The workstream this session is bound to, if
+    /// any. `None` means projectless/unbound — a fully valid state (DOC-39
+    /// §4.2), not a missing one. Set exactly once, at creation
+    /// (`session::protocol::create` / `task::protocol::task_run` resolve
+    /// either an explicit `workstream_id` param or §4.2's ambient
+    /// active-workstream default before calling
+    /// `SessionRegistry::bind_workstream`); there is no setter that changes
+    /// it afterward, mirroring `binding`'s own immutability convention — see
+    /// `SessionRegistry::bind_workstream`'s docs for the enforcement point.
+    /// `#[serde(default)]` keeps an older persisted/serialized `Session`
+    /// (predating this field) reading back as unbound.
+    #[serde(default)]
+    pub workstream_id: Option<crate::workstreams::model::WorkstreamId>,
 }
 
 #[cfg(test)]
@@ -200,6 +213,7 @@ mod tests {
             status: SessionStatus::Running,
             created_at: Utc::now(),
             mode: Some(crate::mode::HarnessMode::DailyDriver),
+            workstream_id: None,
         };
         let value = serde_json::to_value(&session).unwrap();
         assert_eq!(value["id"], "s-1");
@@ -232,6 +246,7 @@ mod binding_model_tests {
             status: SessionStatus::Running,
             created_at: Utc::now(),
             mode: None,
+            workstream_id: None,
         };
         let value = serde_json::to_value(&session).expect("serialize");
         assert_eq!(value["binding"]["state"], "projectless");
@@ -251,5 +266,32 @@ mod binding_model_tests {
             crate::binding::ProjectBinding::None,
             "a missing binding field must default to projectless"
         );
+        assert_eq!(
+            back.workstream_id, None,
+            "a missing workstream_id field must default to unbound"
+        );
+    }
+
+    /// (Issue #3298) A `Session` bound to a workstream must round-trip that
+    /// binding through JSON.
+    #[test]
+    fn workstream_bound_session_round_trips() {
+        let ws_id = crate::workstreams::model::WorkstreamId::new();
+        let session = Session {
+            id: "s-1".to_string(),
+            task: "t".to_string(),
+            agent: None,
+            project: None,
+            binding: crate::binding::ProjectBinding::None,
+            status: SessionStatus::Running,
+            created_at: Utc::now(),
+            mode: None,
+            workstream_id: Some(ws_id),
+        };
+        let value = serde_json::to_value(&session).expect("serialize");
+        assert_eq!(value["workstream_id"], ws_id.to_string());
+
+        let back: Session = serde_json::from_value(value).expect("deserialize");
+        assert_eq!(back.workstream_id, Some(ws_id));
     }
 }

--- a/crates/trusty-code/src/session/protocol.rs
+++ b/crates/trusty-code/src/session/protocol.rs
@@ -40,6 +40,7 @@ use serde_json::{Value, json};
 
 use crate::binding::ProjectBinding;
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
+use crate::workstreams::SharedWorkstreamStore;
 
 use super::registry::SessionRegistry;
 
@@ -50,13 +51,24 @@ use super::registry::SessionRegistry;
 /// What: clones `registry` once per method (cheap — `Arc`) into a small
 /// adapter closure that forwards to the corresponding free function below.
 /// Test: `protocol::tests::register_wires_every_session_method`.
-pub fn register(router: &mut Router, registry: Arc<SessionRegistry>) {
+///
+/// (Issue #3298) `workstreams` is the daemon's shared workstream store —
+/// `session.create` resolves and persists the session's binding (explicit
+/// `workstream_id` param, or DOC-48 §4.2's ambient active-workstream
+/// default) through it before returning.
+pub fn register(
+    router: &mut Router,
+    registry: Arc<SessionRegistry>,
+    workstreams: SharedWorkstreamStore,
+) {
     let r = registry.clone();
+    let ws = workstreams.clone();
     router.register(
         "session.create",
         move |params: Value, ctx: ConnectionContext| {
             let r = r.clone();
-            async move { create(&r, params, ctx).await }
+            let ws = ws.clone();
+            async move { create(&r, &ws, params, ctx).await }
         },
     );
 
@@ -205,6 +217,12 @@ struct CreateParams {
     agent: Option<String>,
     #[serde(default)]
     project: Option<PathBuf>,
+    /// (Issue #3298, DOC-48 §4.1) Explicit workstream to bind this NEW
+    /// session to. `None` falls back to §4.2's ambient active-workstream
+    /// default (or stays projectless if nothing is active) — see
+    /// [`create`]'s docs.
+    #[serde(default)]
+    workstream_id: Option<String>,
 }
 
 /// `params` shape for `session.send`.
@@ -248,8 +266,25 @@ fn parse<T: DeserializeOwned>(params: Value, method: &str) -> Result<T, RpcError
 /// `protocol::tests::create_without_project_is_projectless`,
 /// `protocol::tests::create_binds_a_real_directory`,
 /// `protocol::tests::create_rejects_a_label_that_is_not_a_directory`.
+///
+/// **(Issue #3298, DOC-48 §4.1/§4.2) Workstream binding.** Resolves the
+/// EFFECTIVE workstream target via
+/// `crate::workstreams::protocol::resolve_and_bind_session` — an explicit
+/// `workstream_id` param wins; otherwise the daemon's active workstream is
+/// the ambient default (§4.2); if neither applies the session stays
+/// projectless (valid). Resolution/binding happens AFTER the session is
+/// minted (the store needs the fresh id to bind), but BEFORE the response is
+/// returned, so a caller never observes an unbound `Session` that is about
+/// to be bound moments later. A malformed/unknown/closed `workstream_id`
+/// fails the whole call — see that function's docs for the exact error
+/// mapping.
+/// Test: `binding_tests::create_binds_ambient_active_workstream`,
+/// `binding_tests::create_binds_explicit_workstream_overriding_ambient`,
+/// `binding_tests::create_stays_projectless_without_explicit_or_active`,
+/// `binding_tests::create_rejects_closed_explicit_workstream`.
 async fn create(
     registry: &SessionRegistry,
+    workstreams: &SharedWorkstreamStore,
     params: Value,
     _ctx: ConnectionContext,
 ) -> Result<Value, RpcError> {
@@ -260,7 +295,14 @@ async fn create(
     let binding = ProjectBinding::resolve(p.project)
         .map_err(|e| RpcError::invalid_argument(format!("session.create: {e}")))?;
     let session = registry.create(p.task, p.agent, binding);
-    Ok(json!(session))
+    protocol_workstream::bind_and_snapshot(
+        registry,
+        workstreams,
+        &session.id,
+        p.workstream_id.as_deref(),
+        "session.create",
+    )
+    .await
 }
 
 /// `session.list() -> [Session]` (vision spec Axiom 4).
@@ -423,6 +465,12 @@ async fn get_transcript(
 #[path = "protocol_goals.rs"]
 mod protocol_goals;
 
+/// `session.create`'s workstream-binding step (DOC-48 §4.1/§4.2, issue
+/// #3298), split out for the same 500-SLOC-cap reason as `protocol_goals`
+/// above.
+#[path = "protocol_workstream.rs"]
+mod protocol_workstream;
+
 /// `session.get_readiness` (DOC-39 §5.6 Slice D), split into its own file for
 /// the same 500-SLOC-cap reason as `protocol_goals` above.
 #[path = "protocol_readiness.rs"]
@@ -443,300 +491,26 @@ mod protocol_budget;
 #[path = "protocol_search_audit.rs"]
 mod protocol_search_audit;
 
+/// `protocol::tests` (parameter validation, error mapping), split into its
+/// own file for the same reason `sessions_write_tests.rs`/`registry_tests.rs`
+/// are split — a `_tests.rs`-suffixed sibling file falls under the crate's
+/// 1500-SLOC test cap rather than counting against this production file's
+/// 500-SLOC budget.
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tokio::sync::mpsc;
-    use trusty_common::mcp::Request;
+#[path = "protocol_tests.rs"]
+mod tests;
 
-    fn test_ctx() -> ConnectionContext {
-        let (tx, _rx) = mpsc::unbounded_channel();
-        ConnectionContext::new(tx)
-    }
-
-    /// Every `session.*` method must be reachable through a `Router` built
-    /// by `register` (proves the wiring, not just the free functions).
-    #[tokio::test]
-    async fn register_wires_every_session_method() {
-        let registry = Arc::new(SessionRegistry::new());
-        let mut router = Router::new();
-        register(&mut router, registry.clone());
-
-        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-
-        let cases: &[(&str, Value)] = &[
-            ("session.list", json!({})),
-            ("session.status", json!({"session_id": session.id})),
-            (
-                "session.send",
-                json!({"session_id": session.id, "input": "hi"}),
-            ),
-            ("session.attach", json!({"session_id": session.id})),
-            ("session.detach", json!({"session_id": session.id})),
-            ("session.get_transcript", json!({"session_id": session.id})),
-            ("session.get_goals", json!({"session_id": session.id})),
-            ("session.get_readiness", json!({"session_id": session.id})),
-            ("session.get_agents", json!({"session_id": session.id})),
-            (
-                "session.get_context_budget",
-                json!({"session_id": session.id}),
-            ),
-            (
-                "session.get_search_audit",
-                json!({"session_id": session.id}),
-            ),
-        ];
-        for (method, params) in cases {
-            let req = Request {
-                jsonrpc: Some("2.0".to_string()),
-                id: Some(json!(1)),
-                method: method.to_string(),
-                params: Some(params.clone()),
-            };
-            let resp = router.dispatch(req, &test_ctx()).await;
-            assert!(
-                resp.error.is_none(),
-                "{method} should succeed, got {:?}",
-                resp.error
-            );
-        }
-
-        // `session.cancel` last since it terminates the session.
-        let req = Request {
-            jsonrpc: Some("2.0".to_string()),
-            id: Some(json!(1)),
-            method: "session.cancel".to_string(),
-            params: Some(json!({"session_id": session.id})),
-        };
-        let resp = router.dispatch(req, &test_ctx()).await;
-        assert!(
-            resp.error.is_none(),
-            "session.cancel should succeed, got {:?}",
-            resp.error
-        );
-    }
-
-    /// `session.set_goal`/`session.clear_goal` must be reachable through the
-    /// `Router` (proving the wiring) even though a freshly-created session
-    /// with no `task.run` yet has no transcript to write into — the
-    /// documented #2350 "no transcript yet" error IS the proof the request
-    /// was routed to the real handler rather than `-32601 method not found`.
-    #[tokio::test]
-    async fn register_wires_set_goal_and_clear_goal() {
-        let registry = Arc::new(SessionRegistry::new());
-        let mut router = Router::new();
-        register(&mut router, registry.clone());
-        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-
-        for method in ["session.set_goal", "session.clear_goal"] {
-            let req = Request {
-                jsonrpc: Some("2.0".to_string()),
-                id: Some(json!(1)),
-                method: method.to_string(),
-                params: Some(json!({"session_id": session.id, "slot": 1, "text": "x"})),
-            };
-            let resp = router.dispatch(req, &test_ctx()).await;
-            let error = resp
-                .error
-                .unwrap_or_else(|| panic!("{method} must error (no transcript yet)"));
-            assert_eq!(error.code, -32003, "{method} wrong error code");
-        }
-    }
-
-    /// An empty `task` must map to `-32003 invalid_argument`, not silently
-    /// create a blank session.
-    #[tokio::test]
-    async fn create_rejects_empty_task() {
-        let registry = SessionRegistry::new();
-        let err = create(&registry, json!({"task": "   "}), test_ctx())
-            .await
-            .unwrap_err();
-        assert_eq!(err.code, -32003);
-    }
-
-    /// A well-formed `session.create` call must return a running session.
-    #[tokio::test]
-    async fn create_returns_running_session() {
-        let registry = SessionRegistry::new();
-        let result = create(&registry, json!({"task": "do it"}), test_ctx())
-            .await
-            .unwrap();
-        assert_eq!(result["status"], "running");
-        assert_eq!(result["task"], "do it");
-    }
-
-    /// `session.list` must wrap its result under a `"sessions"` key.
-    #[tokio::test]
-    async fn list_returns_sessions_key() {
-        let registry = SessionRegistry::new();
-        registry.create("a".to_string(), None, crate::binding::ProjectBinding::None);
-        let result = list(&registry, Value::Null, test_ctx()).await.unwrap();
-        assert_eq!(result["sessions"].as_array().unwrap().len(), 1);
-    }
-
-    /// `session.status` on an unknown id must map to `session_not_found`.
-    #[tokio::test]
-    async fn status_unknown_session_maps_to_session_not_found() {
-        let registry = SessionRegistry::new();
-        let err = status(&registry, json!({"session_id": "nope"}), test_ctx())
-            .await
-            .unwrap_err();
-        assert_eq!(err.code, -32007);
-    }
-
-    /// `session.get_transcript` on an unknown id must map to
-    /// `session_not_found` (#2058).
-    #[tokio::test]
-    async fn get_transcript_unknown_session_maps_to_session_not_found() {
-        let registry = SessionRegistry::new();
-        let err = get_transcript(&registry, json!({"session_id": "nope"}), test_ctx())
-            .await
-            .unwrap_err();
-        assert_eq!(err.code, -32007);
-    }
-
-    /// `session.get_transcript` on a session that has never run a task
-    /// returns an empty transcript, not an error (#2058).
-    #[tokio::test]
-    async fn get_transcript_on_never_run_session_is_empty() {
-        let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-        let result = get_transcript(&registry, json!({"session_id": session.id}), test_ctx())
-            .await
-            .unwrap();
-        assert_eq!(result["session_id"], session.id);
-        assert_eq!(result["turns"].as_array().unwrap().len(), 0);
-        assert_eq!(result["cost_usd"], Value::Null);
-    }
-
-    /// `session.send` on an unknown id must map to `session_not_found`.
-    #[tokio::test]
-    async fn send_unknown_session_maps_to_session_not_found() {
-        let registry = SessionRegistry::new();
-        let err = send(
-            &registry,
-            json!({"session_id": "nope", "input": "hi"}),
-            test_ctx(),
-        )
-        .await
-        .unwrap_err();
-        assert_eq!(err.code, -32007);
-    }
-
-    /// `session.attach` on an unknown id must map to `session_not_found`.
-    #[tokio::test]
-    async fn attach_unknown_session_maps_to_session_not_found() {
-        let registry = SessionRegistry::new();
-        let err = attach(&registry, json!({"session_id": "nope"}), test_ctx())
-            .await
-            .unwrap_err();
-        assert_eq!(err.code, -32007);
-    }
-
-    /// `session.detach` on an unknown id must map to `session_not_found`.
-    #[tokio::test]
-    async fn detach_unknown_session_maps_to_session_not_found() {
-        let registry = SessionRegistry::new();
-        let err = detach(&registry, json!({"session_id": "nope"}), test_ctx())
-            .await
-            .unwrap_err();
-        assert_eq!(err.code, -32007);
-    }
-
-    /// `session.cancel` on an unknown id must map to `session_not_found`.
-    #[tokio::test]
-    async fn cancel_unknown_session_maps_to_session_not_found() {
-        let registry = SessionRegistry::new();
-        let err = cancel(&registry, json!({"session_id": "nope"}), test_ctx())
-            .await
-            .unwrap_err();
-        assert_eq!(err.code, -32007);
-    }
-
-    /// `session.cancel` on a session with an in-flight execution must request
-    /// cooperative cancellation (set the flag) rather than immediately
-    /// transitioning to `cancelled` — the executor lands that transition once
-    /// it actually observes the flag.
-    #[tokio::test]
-    async fn cancel_executing_session_requests_cooperative_cancel() {
-        let registry = SessionRegistry::new();
-        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-        let flag = registry.begin_execution(&session.id).unwrap();
-
-        let result = cancel(&registry, json!({"session_id": &session.id}), test_ctx())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            result["status"], "running",
-            "status must NOT be transitioned immediately for an executing session"
-        );
-        assert!(
-            flag.load(std::sync::atomic::Ordering::Relaxed),
-            "the shared cancel flag must have been set"
-        );
-    }
-}
-
+/// `protocol::binding_tests` (project-binding validation, AC-2.1/AC-16.2),
+/// split out for the same reason as `tests` above.
 #[cfg(test)]
-mod binding_tests {
-    use super::*;
-    use tokio::sync::mpsc;
+#[path = "protocol_binding_tests.rs"]
+mod binding_tests;
 
-    fn ctx() -> ConnectionContext {
-        let (tx, _rx) = mpsc::unbounded_channel();
-        ConnectionContext::new(tx)
-    }
-
-    /// Omitting `project` is VALID and means projectless — a supported state,
-    /// never an error (AC-2.1). This is the entry state screen 7a renders.
-    #[tokio::test]
-    async fn create_without_project_is_projectless() {
-        let registry = SessionRegistry::new();
-        let value = create(&registry, json!({"task": "just chat"}), ctx())
-            .await
-            .expect("omitting project must be valid");
-
-        assert_eq!(value["binding"]["state"], "projectless");
-        assert!(value["binding"]["root"].is_null());
-        assert!(
-            value["project"].is_null(),
-            "projectless must derive no label"
-        );
-    }
-
-    /// A real directory binds, and the derived label matches the binding — the
-    /// reconciliation in one assertion (AC-16.2).
-    #[tokio::test]
-    async fn create_binds_a_real_directory() {
-        let registry = SessionRegistry::new();
-        let dir = tempfile::tempdir().expect("tempdir");
-        let value = create(
-            &registry,
-            json!({"task": "t", "project": dir.path().to_string_lossy()}),
-            ctx(),
-        )
-        .await
-        .expect("a real directory must bind");
-
-        // A non-git tempdir binds as `directory` — NOT projectless (#2728).
-        assert_eq!(value["binding"]["state"], "directory");
-        assert_eq!(
-            value["project"], value["binding"]["root"],
-            "the label must be derived from the binding root, not independent of it"
-        );
-    }
-
-    /// The old free-form label is now rejected: `"my-app"` names no directory,
-    /// so it can bind nothing and index nothing. Erroring is the point — see
-    /// `create`'s docs. This is the deliberate breaking change.
-    #[tokio::test]
-    async fn create_rejects_a_label_that_is_not_a_directory() {
-        let registry = SessionRegistry::new();
-        let err = create(&registry, json!({"task": "t", "project": "my-app"}), ctx())
-            .await
-            .expect_err("a decorative label must no longer be silently accepted");
-
-        assert_eq!(err.code, -32003, "expected invalid_argument, got {err:?}");
-    }
-}
+/// `session.create`'s workstream-binding tests (issue #3298), split into its
+/// own file for the same reason `sessions_write_tests.rs`/`registry_tests.rs`
+/// are split — a `_tests.rs`-suffixed sibling file falls under the crate's
+/// 1500-SLOC test cap rather than counting against this production file's
+/// 500-SLOC budget.
+#[cfg(test)]
+#[path = "protocol_workstream_binding_tests.rs"]
+mod workstream_binding_tests;

--- a/crates/trusty-code/src/session/protocol.rs
+++ b/crates/trusty-code/src/session/protocol.rs
@@ -267,21 +267,24 @@ fn parse<T: DeserializeOwned>(params: Value, method: &str) -> Result<T, RpcError
 /// `protocol::tests::create_binds_a_real_directory`,
 /// `protocol::tests::create_rejects_a_label_that_is_not_a_directory`.
 ///
-/// **(Issue #3298, DOC-48 §4.1/§4.2) Workstream binding.** Resolves the
-/// EFFECTIVE workstream target via
-/// `crate::workstreams::protocol::resolve_and_bind_session` — an explicit
+/// **(Issue #3298, DOC-48 §4.1/§4.2) Workstream binding.** Resolves and
+/// VALIDATES the EFFECTIVE workstream target via
+/// `crate::workstreams::protocol::resolve_validate_bind` — an explicit
 /// `workstream_id` param wins; otherwise the daemon's active workstream is
 /// the ambient default (§4.2); if neither applies the session stays
-/// projectless (valid). Resolution/binding happens AFTER the session is
-/// minted (the store needs the fresh id to bind), but BEFORE the response is
-/// returned, so a caller never observes an unbound `Session` that is about
-/// to be bound moments later. A malformed/unknown/closed `workstream_id`
-/// fails the whole call — see that function's docs for the exact error
-/// mapping.
-/// Test: `binding_tests::create_binds_ambient_active_workstream`,
-/// `binding_tests::create_binds_explicit_workstream_overriding_ambient`,
-/// `binding_tests::create_stays_projectless_without_explicit_or_active`,
-/// `binding_tests::create_rejects_closed_explicit_workstream`.
+/// projectless (valid). **Validation happens BEFORE the session is minted**
+/// (PR #3354 code-critic HIGH 1): `SessionRegistry` has no delete/rollback,
+/// so a malformed/unknown/closed `workstream_id` must reject the call while
+/// nothing has been created yet — otherwise every rejected bind would
+/// strand an orphaned, caller-invisible session in the registry for the
+/// daemon lifetime. The mint runs as a closure inside that helper, under
+/// the SAME store lock as validation and the subsequent bind, keeping the
+/// whole sequence TOCTOU-free (see the helper's docs).
+/// Test: `workstream_binding_tests::create_binds_ambient_active_workstream`,
+/// `workstream_binding_tests::create_binds_explicit_workstream_overriding_ambient`,
+/// `workstream_binding_tests::create_stays_projectless_without_explicit_or_active`,
+/// `workstream_binding_tests::create_rejects_closed_explicit_workstream`,
+/// `workstream_binding_tests::create_rejected_bind_leaves_no_phantom_session`.
 async fn create(
     registry: &SessionRegistry,
     workstreams: &SharedWorkstreamStore,
@@ -294,13 +297,12 @@ async fn create(
     }
     let binding = ProjectBinding::resolve(p.project)
         .map_err(|e| RpcError::invalid_argument(format!("session.create: {e}")))?;
-    let session = registry.create(p.task, p.agent, binding);
-    protocol_workstream::bind_and_snapshot(
+    protocol_workstream::mint_bound_session(
         registry,
         workstreams,
-        &session.id,
         p.workstream_id.as_deref(),
         "session.create",
+        || registry.create(p.task, p.agent, binding).id,
     )
     .await
 }

--- a/crates/trusty-code/src/session/protocol_binding_tests.rs
+++ b/crates/trusty-code/src/session/protocol_binding_tests.rs
@@ -1,0 +1,73 @@
+//! Project-binding tests for `session::protocol::create` (AC-2.1,
+//! AC-16.2). Split out of `protocol.rs` per the crate's `_tests.rs`
+//! sibling-file convention so this production file stays under its
+//! 500-SLOC cap.
+
+use super::*;
+use tokio::sync::mpsc;
+
+fn ctx() -> ConnectionContext {
+    let (tx, _rx) = mpsc::unbounded_channel();
+    ConnectionContext::new(tx)
+}
+
+/// Omitting `project` is VALID and means projectless — a supported state,
+/// never an error (AC-2.1). This is the entry state screen 7a renders.
+#[tokio::test]
+async fn create_without_project_is_projectless() {
+    let registry = SessionRegistry::new();
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let value = create(&registry, &workstreams, json!({"task": "just chat"}), ctx())
+        .await
+        .expect("omitting project must be valid");
+
+    assert_eq!(value["binding"]["state"], "projectless");
+    assert!(value["binding"]["root"].is_null());
+    assert!(
+        value["project"].is_null(),
+        "projectless must derive no label"
+    );
+}
+
+/// A real directory binds, and the derived label matches the binding — the
+/// reconciliation in one assertion (AC-16.2).
+#[tokio::test]
+async fn create_binds_a_real_directory() {
+    let registry = SessionRegistry::new();
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let dir = tempfile::tempdir().expect("tempdir");
+    let value = create(
+        &registry,
+        &workstreams,
+        json!({"task": "t", "project": dir.path().to_string_lossy()}),
+        ctx(),
+    )
+    .await
+    .expect("a real directory must bind");
+
+    // A non-git tempdir binds as `directory` — NOT projectless (#2728).
+    assert_eq!(value["binding"]["state"], "directory");
+    assert_eq!(
+        value["project"], value["binding"]["root"],
+        "the label must be derived from the binding root, not independent of it"
+    );
+}
+
+/// The old free-form label is now rejected: `"my-app"` names no directory,
+/// so it can bind nothing and index nothing. Erroring is the point — see
+/// `create`'s docs. This is the deliberate breaking change.
+#[tokio::test]
+async fn create_rejects_a_label_that_is_not_a_directory() {
+    let registry = SessionRegistry::new();
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let err = create(
+        &registry,
+        &workstreams,
+        json!({"task": "t", "project": "my-app"}),
+        ctx(),
+    )
+    .await
+    .expect_err("a decorative label must no longer be silently accepted");
+
+    assert_eq!(err.code, -32003, "expected invalid_argument, got {err:?}");
+}

--- a/crates/trusty-code/src/session/protocol_tests.rs
+++ b/crates/trusty-code/src/session/protocol_tests.rs
@@ -1,0 +1,251 @@
+//! Tests for `session::protocol` (parameter validation, error mapping). Split
+//! out of `protocol.rs` per the crate's `_tests.rs` sibling-file convention
+//! (see `registry_tests`/`sessions_write_tests` for precedent) so this
+//! production file stays under its 500-SLOC cap.
+
+use super::*;
+use tokio::sync::mpsc;
+use trusty_common::mcp::Request;
+
+fn test_ctx() -> ConnectionContext {
+    let (tx, _rx) = mpsc::unbounded_channel();
+    ConnectionContext::new(tx)
+}
+
+/// Every `session.*` method must be reachable through a `Router` built
+/// by `register` (proves the wiring, not just the free functions).
+#[tokio::test]
+async fn register_wires_every_session_method() {
+    let registry = Arc::new(SessionRegistry::new());
+    let mut router = Router::new();
+    register(
+        &mut router,
+        registry.clone(),
+        crate::workstreams::test_shared_store().await,
+    );
+
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let cases: &[(&str, Value)] = &[
+        ("session.list", json!({})),
+        ("session.status", json!({"session_id": session.id})),
+        (
+            "session.send",
+            json!({"session_id": session.id, "input": "hi"}),
+        ),
+        ("session.attach", json!({"session_id": session.id})),
+        ("session.detach", json!({"session_id": session.id})),
+        ("session.get_transcript", json!({"session_id": session.id})),
+        ("session.get_goals", json!({"session_id": session.id})),
+        ("session.get_readiness", json!({"session_id": session.id})),
+        ("session.get_agents", json!({"session_id": session.id})),
+        (
+            "session.get_context_budget",
+            json!({"session_id": session.id}),
+        ),
+        (
+            "session.get_search_audit",
+            json!({"session_id": session.id}),
+        ),
+    ];
+    for (method, params) in cases {
+        let req = Request {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(json!(1)),
+            method: method.to_string(),
+            params: Some(params.clone()),
+        };
+        let resp = router.dispatch(req, &test_ctx()).await;
+        assert!(
+            resp.error.is_none(),
+            "{method} should succeed, got {:?}",
+            resp.error
+        );
+    }
+
+    // `session.cancel` last since it terminates the session.
+    let req = Request {
+        jsonrpc: Some("2.0".to_string()),
+        id: Some(json!(1)),
+        method: "session.cancel".to_string(),
+        params: Some(json!({"session_id": session.id})),
+    };
+    let resp = router.dispatch(req, &test_ctx()).await;
+    assert!(
+        resp.error.is_none(),
+        "session.cancel should succeed, got {:?}",
+        resp.error
+    );
+}
+
+/// `session.set_goal`/`session.clear_goal` must be reachable through the
+/// `Router` (proving the wiring) even though a freshly-created session
+/// with no `task.run` yet has no transcript to write into — the
+/// documented #2350 "no transcript yet" error IS the proof the request
+/// was routed to the real handler rather than `-32601 method not found`.
+#[tokio::test]
+async fn register_wires_set_goal_and_clear_goal() {
+    let registry = Arc::new(SessionRegistry::new());
+    let mut router = Router::new();
+    register(
+        &mut router,
+        registry.clone(),
+        crate::workstreams::test_shared_store().await,
+    );
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    for method in ["session.set_goal", "session.clear_goal"] {
+        let req = Request {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(json!(1)),
+            method: method.to_string(),
+            params: Some(json!({"session_id": session.id, "slot": 1, "text": "x"})),
+        };
+        let resp = router.dispatch(req, &test_ctx()).await;
+        let error = resp
+            .error
+            .unwrap_or_else(|| panic!("{method} must error (no transcript yet)"));
+        assert_eq!(error.code, -32003, "{method} wrong error code");
+    }
+}
+
+/// An empty `task` must map to `-32003 invalid_argument`, not silently
+/// create a blank session.
+#[tokio::test]
+async fn create_rejects_empty_task() {
+    let registry = SessionRegistry::new();
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let err = create(&registry, &workstreams, json!({"task": "   "}), test_ctx())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, -32003);
+}
+
+/// A well-formed `session.create` call must return a running session.
+#[tokio::test]
+async fn create_returns_running_session() {
+    let registry = SessionRegistry::new();
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let result = create(
+        &registry,
+        &workstreams,
+        json!({"task": "do it"}),
+        test_ctx(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result["status"], "running");
+    assert_eq!(result["task"], "do it");
+}
+
+/// `session.list` must wrap its result under a `"sessions"` key.
+#[tokio::test]
+async fn list_returns_sessions_key() {
+    let registry = SessionRegistry::new();
+    registry.create("a".to_string(), None, crate::binding::ProjectBinding::None);
+    let result = list(&registry, Value::Null, test_ctx()).await.unwrap();
+    assert_eq!(result["sessions"].as_array().unwrap().len(), 1);
+}
+
+/// `session.status` on an unknown id must map to `session_not_found`.
+#[tokio::test]
+async fn status_unknown_session_maps_to_session_not_found() {
+    let registry = SessionRegistry::new();
+    let err = status(&registry, json!({"session_id": "nope"}), test_ctx())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, -32007);
+}
+
+/// `session.get_transcript` on an unknown id must map to
+/// `session_not_found` (#2058).
+#[tokio::test]
+async fn get_transcript_unknown_session_maps_to_session_not_found() {
+    let registry = SessionRegistry::new();
+    let err = get_transcript(&registry, json!({"session_id": "nope"}), test_ctx())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, -32007);
+}
+
+/// `session.get_transcript` on a session that has never run a task
+/// returns an empty transcript, not an error (#2058).
+#[tokio::test]
+async fn get_transcript_on_never_run_session_is_empty() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let result = get_transcript(&registry, json!({"session_id": session.id}), test_ctx())
+        .await
+        .unwrap();
+    assert_eq!(result["session_id"], session.id);
+    assert_eq!(result["turns"].as_array().unwrap().len(), 0);
+    assert_eq!(result["cost_usd"], Value::Null);
+}
+
+/// `session.send` on an unknown id must map to `session_not_found`.
+#[tokio::test]
+async fn send_unknown_session_maps_to_session_not_found() {
+    let registry = SessionRegistry::new();
+    let err = send(
+        &registry,
+        json!({"session_id": "nope", "input": "hi"}),
+        test_ctx(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, -32007);
+}
+
+/// `session.attach` on an unknown id must map to `session_not_found`.
+#[tokio::test]
+async fn attach_unknown_session_maps_to_session_not_found() {
+    let registry = SessionRegistry::new();
+    let err = attach(&registry, json!({"session_id": "nope"}), test_ctx())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, -32007);
+}
+
+/// `session.detach` on an unknown id must map to `session_not_found`.
+#[tokio::test]
+async fn detach_unknown_session_maps_to_session_not_found() {
+    let registry = SessionRegistry::new();
+    let err = detach(&registry, json!({"session_id": "nope"}), test_ctx())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, -32007);
+}
+
+/// `session.cancel` on an unknown id must map to `session_not_found`.
+#[tokio::test]
+async fn cancel_unknown_session_maps_to_session_not_found() {
+    let registry = SessionRegistry::new();
+    let err = cancel(&registry, json!({"session_id": "nope"}), test_ctx())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, -32007);
+}
+
+/// `session.cancel` on a session with an in-flight execution must request
+/// cooperative cancellation (set the flag) rather than immediately
+/// transitioning to `cancelled` — the executor lands that transition once
+/// it actually observes the flag.
+#[tokio::test]
+async fn cancel_executing_session_requests_cooperative_cancel() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let flag = registry.begin_execution(&session.id).unwrap();
+
+    let result = cancel(&registry, json!({"session_id": &session.id}), test_ctx())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result["status"], "running",
+        "status must NOT be transitioned immediately for an executing session"
+    );
+    assert!(
+        flag.load(std::sync::atomic::Ordering::Relaxed),
+        "the shared cancel flag must have been set"
+    );
+}

--- a/crates/trusty-code/src/session/protocol_workstream.rs
+++ b/crates/trusty-code/src/session/protocol_workstream.rs
@@ -1,0 +1,49 @@
+//! `session.create`'s workstream-binding step (DOC-48 §4.1/§4.2, issue
+//! #3298), split out of `protocol.rs` purely to keep that production file
+//! under the crate's 500-SLOC cap — a child module of `protocol` (declared
+//! via `#[path = ...] mod protocol_workstream;`), so it shares full access
+//! to `protocol`'s private items exactly as if this function were still
+//! defined there.
+//!
+//! Why: `create`'s own body would otherwise inline the
+//! resolve-then-bind-then-snapshot sequence; factoring it into one function
+//! keeps `create` itself short and makes the sequence a single named unit
+//! `task::protocol::task_run`'s mint path could, in principle, share too
+//! (it does not today only because its own resolve/bind call sites differ
+//! slightly around the reuse-vs-mint branch — see that module's docs).
+//!
+//! What: [`bind_and_snapshot`] resolves the effective workstream target via
+//! `crate::workstreams::protocol::resolve_and_bind_session`, stamps it onto
+//! the registry via `SessionRegistry::bind_workstream` when one was
+//! resolved, and returns the POST-bind `Session` snapshot as `Value` — so a
+//! caller's response always reflects the binding it just made, never a
+//! stale pre-bind snapshot.
+
+use serde_json::{Value, json};
+
+use crate::jsonrpc::RpcError;
+use crate::workstreams::SharedWorkstreamStore;
+
+use super::SessionRegistry;
+
+/// Resolve + persist `session_id`'s workstream binding, then return its
+/// current snapshot.
+pub(super) async fn bind_and_snapshot(
+    registry: &SessionRegistry,
+    workstreams: &SharedWorkstreamStore,
+    session_id: &str,
+    workstream_id: Option<&str>,
+    method: &str,
+) -> Result<Value, RpcError> {
+    let target = crate::workstreams::protocol::resolve_and_bind_session(
+        workstreams,
+        workstream_id,
+        session_id,
+        method,
+    )
+    .await?;
+    if let Some(ws_id) = target {
+        registry.bind_workstream(session_id, ws_id)?;
+    }
+    Ok(json!(registry.status(session_id)?))
+}

--- a/crates/trusty-code/src/session/protocol_workstream.rs
+++ b/crates/trusty-code/src/session/protocol_workstream.rs
@@ -1,23 +1,32 @@
-//! `session.create`'s workstream-binding step (DOC-48 §4.1/§4.2, issue
-//! #3298), split out of `protocol.rs` purely to keep that production file
-//! under the crate's 500-SLOC cap — a child module of `protocol` (declared
-//! via `#[path = ...] mod protocol_workstream;`), so it shares full access
-//! to `protocol`'s private items exactly as if this function were still
+//! `session.create`'s validate-then-mint-then-bind step (DOC-48 §4.1/§4.2,
+//! issue #3298; atomicity fix per PR #3354 code-critic HIGH finding 1),
+//! split out of `protocol.rs` purely to keep that production file under the
+//! crate's 500-SLOC cap — a child module of `protocol` (declared via
+//! `#[path = ...] mod protocol_workstream;`), so it shares full access to
+//! `protocol`'s private items exactly as if this function were still
 //! defined there.
 //!
-//! Why: `create`'s own body would otherwise inline the
-//! resolve-then-bind-then-snapshot sequence; factoring it into one function
-//! keeps `create` itself short and makes the sequence a single named unit
-//! `task::protocol::task_run`'s mint path could, in principle, share too
-//! (it does not today only because its own resolve/bind call sites differ
-//! slightly around the reuse-vs-mint branch — see that module's docs).
+//! Why: `SessionRegistry` has no delete/rollback, so `create` must NOT mint
+//! a session until the workstream target (if any) has been fully validated
+//! — the first cut minted first and could then fail the bind, stranding an
+//! orphaned, caller-invisible session in the registry on every rejected
+//! bind (code-critic HIGH 1, PR #3354). This helper drives
+//! `crate::workstreams::protocol::resolve_validate_bind`, which validates
+//! every caller-triggerable failure mode (malformed/unknown/closed
+//! `workstream_id`) BEFORE invoking the mint closure, all under one store
+//! lock (TOCTOU-free — see that function's docs).
 //!
-//! What: [`bind_and_snapshot`] resolves the effective workstream target via
-//! `crate::workstreams::protocol::resolve_and_bind_session`, stamps it onto
-//! the registry via `SessionRegistry::bind_workstream` when one was
-//! resolved, and returns the POST-bind `Session` snapshot as `Value` — so a
-//! caller's response always reflects the binding it just made, never a
-//! stale pre-bind snapshot.
+//! What: [`mint_bound_session`] resolves+validates the effective workstream
+//! target, mints the session via the caller's closure only once validation
+//! passes, persists the bind, stamps it onto the registry via
+//! `SessionRegistry::bind_workstream` (publishing `Event::SessionAdded`),
+//! and returns the POST-bind `Session` snapshot as `Value` — so the
+//! response always reflects the binding it just made, never a stale
+//! pre-bind snapshot.
+//!
+//! Test: `super::workstream_binding_tests::*`, in particular
+//! `create_rejected_bind_leaves_no_phantom_session` (the regression the
+//! critic required).
 
 use serde_json::{Value, json};
 
@@ -26,24 +35,27 @@ use crate::workstreams::SharedWorkstreamStore;
 
 use super::SessionRegistry;
 
-/// Resolve + persist `session_id`'s workstream binding, then return its
-/// current snapshot.
-pub(super) async fn bind_and_snapshot(
+/// Validate the workstream target, mint the session (only after validation
+/// passes), persist + stamp its binding, and return its snapshot.
+pub(super) async fn mint_bound_session<F>(
     registry: &SessionRegistry,
     workstreams: &SharedWorkstreamStore,
-    session_id: &str,
     workstream_id: Option<&str>,
     method: &str,
-) -> Result<Value, RpcError> {
-    let target = crate::workstreams::protocol::resolve_and_bind_session(
+    mint: F,
+) -> Result<Value, RpcError>
+where
+    F: FnOnce() -> String,
+{
+    let (session_id, target) = crate::workstreams::protocol::resolve_validate_bind(
         workstreams,
         workstream_id,
-        session_id,
         method,
+        mint,
     )
     .await?;
     if let Some(ws_id) = target {
-        registry.bind_workstream(session_id, ws_id)?;
+        registry.bind_workstream(&session_id, ws_id)?;
     }
-    Ok(json!(registry.status(session_id)?))
+    Ok(json!(registry.status(&session_id)?))
 }

--- a/crates/trusty-code/src/session/protocol_workstream_binding_tests.rs
+++ b/crates/trusty-code/src/session/protocol_workstream_binding_tests.rs
@@ -1,0 +1,111 @@
+//! `session.create`'s workstream-binding tests (DOC-48 §4.1/§4.2, issue
+//! #3298). Split out of `protocol.rs` per the crate's `_tests.rs`
+//! sibling-file convention (see `registry_tests`/`sessions_write_tests` for
+//! precedent) so this production file stays under its 500-SLOC cap.
+
+use super::*;
+use tokio::sync::mpsc;
+
+fn ctx() -> ConnectionContext {
+    let (tx, _rx) = mpsc::unbounded_channel();
+    ConnectionContext::new(tx)
+}
+
+/// Seed a workstream and activate it, returning the shared store and the
+/// workstream's id.
+async fn store_with_active_workstream() -> (
+    crate::workstreams::SharedWorkstreamStore,
+    crate::workstreams::WorkstreamId,
+) {
+    let store = crate::workstreams::test_shared_store().await;
+    let id = store.lock().await.create("active").await.expect("create");
+    crate::workstreams::activation::activate(&store, id, false)
+        .await
+        .expect("activate");
+    (store, id)
+}
+
+/// A `session.create` call with no explicit `workstream_id`, while a
+/// workstream is active, must bind to the ACTIVE workstream (DOC-48 §4.2's
+/// ambient default target).
+#[tokio::test]
+async fn create_binds_ambient_active_workstream() {
+    let registry = SessionRegistry::new();
+    let (workstreams, active_id) = store_with_active_workstream().await;
+
+    let value = create(&registry, &workstreams, json!({"task": "t"}), ctx())
+        .await
+        .expect("create must succeed");
+
+    assert_eq!(value["workstream_id"], active_id.to_string());
+    let ws = workstreams.lock().await.get(active_id).await.expect("get");
+    assert_eq!(
+        ws.session_ids,
+        vec![value["id"].as_str().unwrap().to_string()]
+    );
+}
+
+/// An explicit `workstream_id` param must win over the ambient active
+/// workstream (DOC-48 §4.1).
+#[tokio::test]
+async fn create_binds_explicit_workstream_overriding_ambient() {
+    let registry = SessionRegistry::new();
+    let (workstreams, _active_id) = store_with_active_workstream().await;
+    let explicit_id = workstreams
+        .lock()
+        .await
+        .create("explicit")
+        .await
+        .expect("create");
+
+    let value = create(
+        &registry,
+        &workstreams,
+        json!({"task": "t", "workstream_id": explicit_id.to_string()}),
+        ctx(),
+    )
+    .await
+    .expect("create must succeed");
+
+    assert_eq!(value["workstream_id"], explicit_id.to_string());
+}
+
+/// With no explicit param and nothing active, a session must stay
+/// projectless — a fully valid state, never an error (DOC-48 §4.2).
+#[tokio::test]
+async fn create_stays_projectless_without_explicit_or_active() {
+    let registry = SessionRegistry::new();
+    let workstreams = crate::workstreams::test_shared_store().await;
+
+    let value = create(&registry, &workstreams, json!({"task": "t"}), ctx())
+        .await
+        .expect("create must succeed");
+
+    assert!(value["workstream_id"].is_null());
+}
+
+/// An explicit `workstream_id` naming a CLOSED workstream must reject the
+/// whole `session.create` call (DOC-48 §4.1: "new sessions may not bind to
+/// it").
+#[tokio::test]
+async fn create_rejects_closed_explicit_workstream() {
+    let registry = SessionRegistry::new();
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let id = workstreams
+        .lock()
+        .await
+        .create("closed")
+        .await
+        .expect("create");
+    workstreams.lock().await.close(id).await.expect("close");
+
+    let err = create(
+        &registry,
+        &workstreams,
+        json!({"task": "t", "workstream_id": id.to_string()}),
+        ctx(),
+    )
+    .await
+    .expect_err("closed workstream must reject the bind");
+    assert_eq!(err.code, -32003);
+}

--- a/crates/trusty-code/src/session/protocol_workstream_binding_tests.rs
+++ b/crates/trusty-code/src/session/protocol_workstream_binding_tests.rs
@@ -109,3 +109,52 @@ async fn create_rejects_closed_explicit_workstream() {
     .expect_err("closed workstream must reject the bind");
     assert_eq!(err.code, -32003);
 }
+
+/// (PR #3354 code-critic HIGH 1 regression) A rejected bind must leave the
+/// `SessionRegistry` UNCHANGED — no phantom, caller-invisible session may
+/// survive the error — for ALL THREE caller-triggerable failure modes:
+/// closed workstream, unknown workstream, malformed id.
+#[tokio::test]
+async fn create_rejected_bind_leaves_no_phantom_session() {
+    let registry = SessionRegistry::new();
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let closed = workstreams
+        .lock()
+        .await
+        .create("closed")
+        .await
+        .expect("create");
+    workstreams.lock().await.close(closed).await.expect("close");
+
+    let cases: &[(&str, String, i32)] = &[
+        ("closed workstream", closed.to_string(), -32003),
+        (
+            "unknown workstream",
+            crate::workstreams::WorkstreamId::new().to_string(),
+            -32002,
+        ),
+        ("malformed id", "not-a-uuid".to_string(), -32602),
+    ];
+    for (label, ws_id, expected_code) in cases {
+        let before = registry.list().len();
+        let err = create(
+            &registry,
+            &workstreams,
+            json!({"task": "t", "workstream_id": ws_id}),
+            ctx(),
+        )
+        .await
+        .expect_err("bind must be rejected");
+        assert_eq!(err.code, *expected_code, "{label}: wrong error code");
+        assert_eq!(
+            registry.list().len(),
+            before,
+            "{label}: a rejected bind must not leave a phantom session"
+        );
+    }
+    assert_eq!(
+        registry.list().len(),
+        0,
+        "no session may exist after three rejected creates"
+    );
+}

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -750,10 +750,19 @@ impl SessionRegistry {
     /// (Issue #3298) Also records+publishes `Event::SessionActivityUpdate` —
     /// the natural "a turn just happened" hook DOC-48 §5.3's event table asks
     /// for, so a workstream observer can see which bound sessions are
-    /// recently active without polling. Published unconditionally (whether
-    /// or not `id` is workstream-bound — see the event's own docs); a no-op
-    /// alongside the rest of this method if `id` is already gone.
-    /// Test: `registry_tests::set_run_outcome_publishes_activity_update`.
+    /// recently active without polling. Published ONLY when `id` is
+    /// workstream-bound (`Session.workstream_id.is_some()`): the event
+    /// exists for workstream observers (§5.3 lists it in the WORKSTREAM
+    /// event set), an unbound session has no such observer, and — decisive
+    /// — the M1 cutline e2e contract (`tests/m1_cutline_e2e.rs`) freezes the
+    /// exact event-kind sequence a plain, workstream-less session emits;
+    /// firing this unconditionally inserted a new kind into that baseline
+    /// and broke both transports' frozen sequences (CI failure on PR #3354).
+    /// A no-op alongside the rest of this method if `id` is already gone.
+    /// Test: `registry_tests::set_run_outcome_publishes_activity_update_when_workstream_bound`,
+    /// `registry_tests::set_run_outcome_stays_silent_for_unbound_session`;
+    /// the frozen unbound-session baseline itself in
+    /// `m1_cutline_e2e::m1_cutline_full_scenario_over_stdio`/`_http`.
     pub fn set_run_outcome(
         &self,
         id: &str,
@@ -761,7 +770,7 @@ impl SessionRegistry {
         usage: TokenUsage,
         cost_usd: Option<f64>,
     ) {
-        let has_running_task = {
+        let activity = {
             let mut sessions = self.lock();
             let Some(entry) = sessions.get_mut(id) else {
                 return;
@@ -773,9 +782,10 @@ impl SessionRegistry {
                 (Some(a), None) | (None, Some(a)) => Some(a),
                 (None, None) => None,
             };
-            entry.execution.is_some()
+            let bound = entry.session.workstream_id.is_some();
+            bound.then_some(entry.execution.is_some())
         };
-        self.publish_activity_update(id, has_running_task);
+        self.publish_activity_update(id, activity);
     }
 
     /// Retrieve this session's persistent PM conversation `Transcript`,

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -315,6 +315,7 @@ impl SessionRegistry {
             status: SessionStatus::Created,
             created_at: Utc::now(),
             mode: None,
+            workstream_id: None,
         };
         {
             let mut sessions = self.lock();
@@ -745,6 +746,14 @@ impl SessionRegistry {
     /// sum, either `Some` alone passes through, `None`+`None` stays `None`).
     /// Test: `registry_tests::set_run_outcome_stores_transcript_and_usage`,
     /// `registry_tests::set_run_outcome_accumulates_across_two_calls`.
+    ///
+    /// (Issue #3298) Also records+publishes `Event::SessionActivityUpdate` —
+    /// the natural "a turn just happened" hook DOC-48 §5.3's event table asks
+    /// for, so a workstream observer can see which bound sessions are
+    /// recently active without polling. Published unconditionally (whether
+    /// or not `id` is workstream-bound — see the event's own docs); a no-op
+    /// alongside the rest of this method if `id` is already gone.
+    /// Test: `registry_tests::set_run_outcome_publishes_activity_update`.
     pub fn set_run_outcome(
         &self,
         id: &str,
@@ -752,8 +761,11 @@ impl SessionRegistry {
         usage: TokenUsage,
         cost_usd: Option<f64>,
     ) {
-        let mut sessions = self.lock();
-        if let Some(entry) = sessions.get_mut(id) {
+        let has_running_task = {
+            let mut sessions = self.lock();
+            let Some(entry) = sessions.get_mut(id) else {
+                return;
+            };
             entry.transcript.extend(transcript);
             entry.usage.add(&usage);
             entry.cost_usd = match (entry.cost_usd, cost_usd) {
@@ -761,7 +773,9 @@ impl SessionRegistry {
                 (Some(a), None) | (None, Some(a)) => Some(a),
                 (None, None) => None,
             };
-        }
+            entry.execution.is_some()
+        };
+        self.publish_activity_update(id, has_running_task);
     }
 
     /// Retrieve this session's persistent PM conversation `Transcript`,
@@ -1070,6 +1084,11 @@ mod goal_ops;
 /// own file for the same 500-SLOC-cap reason as `events` above.
 #[path = "registry_agents.rs"]
 mod agents;
+
+/// `SessionRegistry::bind_workstream` (DOC-48 §4.1, issue #3298), split out
+/// into its own file for the same 500-SLOC-cap reason as `events` above.
+#[path = "registry_workstream.rs"]
+mod workstream_binding;
 
 /// `session.get_search_audit`'s retained search/recall audit trail (issue
 /// #3072), split out into its own file for the same 500-SLOC-cap reason as

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -1030,6 +1030,29 @@ async fn set_run_outcome_stores_transcript_and_usage() {
     registry.set_run_outcome("nope", turns, crate::perf::TokenUsage::default(), None);
 }
 
+/// (Issue #3298) `set_run_outcome` must record+publish
+/// `Event::SessionActivityUpdate` on the session's own ring buffer/live bus.
+#[tokio::test]
+async fn set_run_outcome_publishes_activity_update() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    registry.set_run_outcome(
+        &session.id,
+        vec![],
+        crate::perf::TokenUsage::default(),
+        None,
+    );
+
+    let events = registry.replay(&session.id).unwrap();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(&e.event, Event::SessionActivityUpdate { has_running_task, .. } if !has_running_task)),
+        "expected a SessionActivityUpdate event: {events:?}"
+    );
+}
+
 /// `set_run_outcome` must ACCUMULATE across two calls (#2344): the second
 /// run's turns are appended (not replacing the first run's), and usage/cost
 /// are added onto the running total — `session.get_transcript` must reflect

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -1031,11 +1031,16 @@ async fn set_run_outcome_stores_transcript_and_usage() {
 }
 
 /// (Issue #3298) `set_run_outcome` must record+publish
-/// `Event::SessionActivityUpdate` on the session's own ring buffer/live bus.
+/// `Event::SessionActivityUpdate` on the session's own ring buffer/live bus
+/// — but ONLY when the session is workstream-bound (see the gate rationale
+/// on `set_run_outcome`'s docs and the sibling test below).
 #[tokio::test]
-async fn set_run_outcome_publishes_activity_update() {
+async fn set_run_outcome_publishes_activity_update_when_workstream_bound() {
     let registry = SessionRegistry::new();
     let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    registry
+        .bind_workstream(&session.id, crate::workstreams::WorkstreamId::new())
+        .expect("bind");
 
     registry.set_run_outcome(
         &session.id,
@@ -1050,6 +1055,32 @@ async fn set_run_outcome_publishes_activity_update() {
             .iter()
             .any(|e| matches!(&e.event, Event::SessionActivityUpdate { has_running_task, .. } if !has_running_task)),
         "expected a SessionActivityUpdate event: {events:?}"
+    );
+}
+
+/// (PR #3354 CI regression) An UNBOUND session's `set_run_outcome` must
+/// publish NO `SessionActivityUpdate` — the M1 cutline e2e contract
+/// (`tests/m1_cutline_e2e.rs`) freezes the exact event-kind sequence a
+/// plain, workstream-less session emits, and this event is not in that
+/// baseline; unconditional emission broke it on both transports.
+#[tokio::test]
+async fn set_run_outcome_stays_silent_for_unbound_session() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    registry.set_run_outcome(
+        &session.id,
+        vec![],
+        crate::perf::TokenUsage::default(),
+        None,
+    );
+
+    let events = registry.replay(&session.id).unwrap();
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(&e.event, Event::SessionActivityUpdate { .. })),
+        "an unbound session must emit no SessionActivityUpdate (frozen M1 baseline): {events:?}"
     );
 }
 

--- a/crates/trusty-code/src/session/registry_workstream.rs
+++ b/crates/trusty-code/src/session/registry_workstream.rs
@@ -1,0 +1,122 @@
+//! `SessionRegistry::bind_workstream` (DOC-48 §4.1/§5.3, issue #3298). Split
+//! out of `registry.rs` for the same 500-SLOC-cap reason as
+//! `registry_events.rs`/`registry_goals.rs` — this is a child module of
+//! `registry` (declared via `#[path = ...] mod workstream_binding;`), so it
+//! shares full access to `SessionRegistry`'s private `lock`/`record` helpers
+//! and `SessionEntry`'s fields exactly as if this method were still defined
+//! in that file.
+//!
+//! Why: `session::protocol::create` and `task::protocol::task_run` both need
+//! to stamp a freshly-minted session's immutable workstream binding once
+//! they've resolved it (either an explicit `workstream_id` param, §4.1, or
+//! §4.2's ambient active-workstream default) and PERSISTED it into
+//! [`crate::workstreams::store::WorkstreamStore`] (via
+//! `WorkstreamStore::bind_session`) — this is the registry-side half that
+//! also makes the binding observable on the `Session` snapshot
+//! (`session.status`/`session.list`) and publishes the DOC-48 §5.3
+//! `SessionAdded` event.
+//!
+//! Test: `registry_tests::bind_workstream_sets_field_and_publishes_session_added`,
+//! `registry_tests::bind_workstream_unknown_session_errors`.
+
+use super::*;
+
+impl SessionRegistry {
+    /// Stamp a freshly-minted session's immutable workstream binding, and
+    /// publish `Event::SessionAdded`.
+    ///
+    /// Why: `session::protocol::create` and `task::protocol::task_run` are
+    /// the ONLY callers, each calling this at most once — immediately after
+    /// `Self::create` mints the session's id and the caller has separately
+    /// persisted the binding into the workstream store — so there is no
+    /// setter that changes `Session.workstream_id` a second time; this
+    /// method itself does not enforce that (it would silently overwrite),
+    /// the immutability guarantee comes from the call sites never invoking
+    /// it twice for the same session (a REUSED session on `task.run` never
+    /// calls this again — see `task::protocol::task_run`'s docs on the
+    /// mismatch rejection it performs instead).
+    /// What: `Err(session_not_found)` if `id` is unknown; otherwise sets
+    /// `entry.session.workstream_id = Some(workstream_id)` and records+
+    /// publishes `Event::SessionAdded { session_id, workstream_id,
+    /// binding_time }` through the normal per-session ring buffer/live bus
+    /// (`Self::record`) — see that event's own docs for why this is what
+    /// lets `crate::workstreams::sse::aggregate_live`'s dynamic membership
+    /// re-check pick it up with no changes.
+    pub fn bind_workstream(
+        &self,
+        id: &str,
+        workstream_id: crate::workstreams::model::WorkstreamId,
+    ) -> Result<(), RpcError> {
+        {
+            let mut sessions = self.lock();
+            let entry = sessions
+                .get_mut(id)
+                .ok_or_else(|| RpcError::session_not_found(id))?;
+            entry.session.workstream_id = Some(workstream_id);
+        }
+        self.record(
+            id,
+            Event::SessionAdded {
+                session_id: id.to_string(),
+                workstream_id: workstream_id.to_string(),
+                binding_time: Utc::now(),
+            },
+        );
+        Ok(())
+    }
+
+    /// Record+publish `Event::SessionActivityUpdate` for `id`.
+    ///
+    /// Why: `Self::set_run_outcome`'s sole activity-signal hook (module
+    /// docs) — split out here purely so that method's own diff stays small
+    /// enough for `registry.rs`'s 500-SLOC cap; behaviourally this is still
+    /// just `Self::record` with the event's shape.
+    /// What: `last_turn_at` is stamped `Utc::now()` at call time;
+    /// `has_running_task` is passed in by the caller (which already holds
+    /// the lock needed to read `entry.execution.is_some()`, so this helper
+    /// does not re-lock).
+    pub(super) fn publish_activity_update(&self, id: &str, has_running_task: bool) {
+        self.record(
+            id,
+            Event::SessionActivityUpdate {
+                session_id: id.to_string(),
+                last_turn_at: Utc::now(),
+                has_running_task,
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `bind_workstream` must set the field and publish `SessionAdded` on
+    /// the session's own ring buffer/live bus.
+    #[tokio::test]
+    async fn bind_workstream_sets_field_and_publishes_session_added() {
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, ProjectBinding::None);
+        let ws_id = crate::workstreams::model::WorkstreamId::new();
+
+        registry.bind_workstream(&session.id, ws_id).expect("bind");
+
+        let status = registry.status(&session.id).expect("status");
+        assert_eq!(status.workstream_id, Some(ws_id));
+
+        let events = registry.replay(&session.id).expect("replay");
+        assert!(events.iter().any(|e| matches!(
+            &e.event,
+            Event::SessionAdded { workstream_id, .. } if *workstream_id == ws_id.to_string()
+        )));
+    }
+
+    /// An unknown session id must map to `session_not_found`.
+    #[tokio::test]
+    async fn bind_workstream_unknown_session_errors() {
+        let registry = SessionRegistry::new();
+        let ws_id = crate::workstreams::model::WorkstreamId::new();
+        let err = registry.bind_workstream("nope", ws_id).unwrap_err();
+        assert_eq!(err.code, -32007);
+    }
+}

--- a/crates/trusty-code/src/session/registry_workstream.rs
+++ b/crates/trusty-code/src/session/registry_workstream.rs
@@ -65,17 +65,25 @@ impl SessionRegistry {
         Ok(())
     }
 
-    /// Record+publish `Event::SessionActivityUpdate` for `id`.
+    /// Record+publish `Event::SessionActivityUpdate` for `id` — a no-op for
+    /// an UNBOUND session.
     ///
     /// Why: `Self::set_run_outcome`'s sole activity-signal hook (module
     /// docs) — split out here purely so that method's own diff stays small
     /// enough for `registry.rs`'s 500-SLOC cap; behaviourally this is still
     /// just `Self::record` with the event's shape.
-    /// What: `last_turn_at` is stamped `Utc::now()` at call time;
-    /// `has_running_task` is passed in by the caller (which already holds
-    /// the lock needed to read `entry.execution.is_some()`, so this helper
-    /// does not re-lock).
-    pub(super) fn publish_activity_update(&self, id: &str, has_running_task: bool) {
+    /// What: `activity` is `None` when the session is not workstream-bound
+    /// — publish NOTHING, keeping an unbound session's event stream
+    /// byte-identical to the pre-#3298 baseline the M1 cutline e2e contract
+    /// freezes (see `set_run_outcome`'s docs for the full rationale) — and
+    /// `Some(has_running_task)` when it is. `last_turn_at` is stamped
+    /// `Utc::now()` at call time; the caller computes `activity` while
+    /// already holding the lock (reading `Session.workstream_id` and
+    /// `entry.execution`), so this helper does not re-lock.
+    pub(super) fn publish_activity_update(&self, id: &str, activity: Option<bool>) {
+        let Some(has_running_task) = activity else {
+            return;
+        };
         self.record(
             id,
             Event::SessionActivityUpdate {

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -32,6 +32,7 @@ use serde_json::{Value, json};
 use crate::binding::ProjectBinding;
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 use crate::session::SessionRegistry;
+use crate::workstreams::SharedWorkstreamStore;
 
 use super::executor::{TaskRunParams, spawn_task_run};
 use super::mock_llm::build_llm_client;
@@ -48,17 +49,25 @@ use super::mock_llm::build_llm_client;
 /// [`ProjectBinding`], whose `None` variant is that state.
 /// Test: `task::protocol::tests::register_wires_task_run`,
 /// `task::protocol::tests::register_wires_task_run_projectless`.
+/// (Issue #3298) `workstreams` is the daemon's shared workstream store —
+/// `task.run` resolves and persists a freshly-minted session's binding
+/// (explicit `workstream_id` param, or DOC-48 §4.2's ambient
+/// active-workstream default) through it, or enforces §4.1's immutability
+/// rule against an EXISTING session's persisted binding — see
+/// [`task_run`]'s docs.
 pub fn register(
     router: &mut Router,
     registry: Arc<SessionRegistry>,
     binding: ProjectBinding,
     agents_dir: PathBuf,
+    workstreams: SharedWorkstreamStore,
 ) {
     router.register("task.run", move |params: Value, _ctx: ConnectionContext| {
         let registry = Arc::clone(&registry);
         let binding = binding.clone();
         let agents_dir = agents_dir.clone();
-        async move { task_run(registry, params, binding, agents_dir).await }
+        let workstreams = workstreams.clone();
+        async move { task_run(registry, params, binding, agents_dir, workstreams).await }
     });
 }
 
@@ -114,13 +123,39 @@ struct TaskRunRequestParams {
     /// [`task_run`]'s docs.
     #[serde(default)]
     project: Option<PathBuf>,
+    /// (Issue #3298, DOC-48 §4.1/§4.2) Explicit workstream to bind a
+    /// FRESHLY-MINTED session to (`session_id` absent), or to RESTATE an
+    /// existing reused session's own persisted binding — see
+    /// [`task_run`]'s docs on the immutability check this triggers on the
+    /// `session_id`-present path. `None` on the mint path falls back to
+    /// §4.2's ambient active-workstream default; `None` on the reuse path
+    /// never re-applies ambient targeting (a session's binding, once set, is
+    /// immutable — see `crate::workstreams::protocol::check_workstream_immutable`'s
+    /// docs).
+    #[serde(default)]
+    workstream_id: Option<String>,
 }
 
 /// `task.run(task_description, agent_name?, context?, model_override?,
-/// session_id?, mode?, deadline_secs?, project?) -> { session_id, status, mode }`.
+/// session_id?, mode?, deadline_secs?, project?, workstream_id?) -> {
+/// session_id, status, mode }`.
 ///
 /// Why: the single entry point that turns a request into a running
 /// background execution.
+///
+/// **(Issue #3298, DOC-48 §4.1/§4.2) Workstream binding**, mirroring the
+/// `project`/binding reconciliation immediately below: on the mint path
+/// (`session_id` absent), resolves the EFFECTIVE workstream target —
+/// `workstream_id` explicit param wins, else the daemon's active workstream
+/// is the ambient default (§4.2), else the session stays projectless — and
+/// persists it via `crate::workstreams::protocol::resolve_and_bind_session`
+/// before this session is used further. On the reuse path (`session_id`
+/// present), the session's own persisted `workstream_id` is authoritative;
+/// `crate::workstreams::protocol::check_workstream_immutable` rejects a
+/// `workstream_id` param that would silently redirect a session
+/// `session.status`/`session.list` already reports as bound to a different
+/// (or no) workstream — same rule, same rationale as the `project` mismatch
+/// guard.
 /// What: validates `task_description` is non-empty
 /// (`-32003 invalid_argument`); resolves the EFFECTIVE binding for this call —
 /// `project: Some(path)` resolves via [`ProjectBinding::resolve`] (mapping a
@@ -169,6 +204,7 @@ async fn task_run(
     params: Value,
     binding: ProjectBinding,
     agents_dir: PathBuf,
+    workstreams: SharedWorkstreamStore,
 ) -> Result<Value, RpcError> {
     let p: TaskRunRequestParams = serde_json::from_value(params)
         .map_err(|e| RpcError::invalid_params(format!("task.run: {e}")))?;
@@ -209,6 +245,17 @@ async fn task_run(
                         .unwrap_or_else(|| "<projectless>".to_string()),
                 )));
             }
+            // (Issue #3298, DOC-48 §4.1 AC-1.3) A REUSED session's own
+            // persisted `workstream_id` is likewise authoritative — the
+            // exact same rule as the `project` check just above, applied to
+            // the sibling binding. `None` here never rejects: ambient
+            // default-targeting (§4.2) applies only at a session's FIRST
+            // binding, never re-applied on reuse.
+            crate::workstreams::protocol::check_workstream_immutable(
+                existing.workstream_id,
+                p.workstream_id.as_deref(),
+                "task.run",
+            )?;
             id.clone()
         }
         None => {
@@ -217,6 +264,16 @@ async fn task_run(
                 Some(agent_name.clone()),
                 binding.clone(),
             );
+            if let Some(ws_id) = crate::workstreams::protocol::resolve_and_bind_session(
+                &workstreams,
+                p.workstream_id.as_deref(),
+                &session.id,
+                "task.run",
+            )
+            .await?
+            {
+                registry.bind_workstream(&session.id, ws_id)?;
+            }
             session.id
         }
     };

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -148,7 +148,9 @@ struct TaskRunRequestParams {
 /// (`session_id` absent), resolves the EFFECTIVE workstream target —
 /// `workstream_id` explicit param wins, else the daemon's active workstream
 /// is the ambient default (§4.2), else the session stays projectless — and
-/// persists it via `crate::workstreams::protocol::resolve_and_bind_session`
+/// persists it via `crate::workstreams::protocol::resolve_validate_bind`
+/// (validated BEFORE the session is minted — see that helper's docs on the
+/// PR #3354 phantom-session fix)
 /// before this session is used further. On the reuse path (`session_id`
 /// present), the session's own persisted `workstream_id` is authoritative;
 /// `crate::workstreams::protocol::check_workstream_immutable` rejects a
@@ -259,22 +261,32 @@ async fn task_run(
             id.clone()
         }
         None => {
-            let session = registry.create(
-                p.task_description.clone(),
-                Some(agent_name.clone()),
-                binding.clone(),
-            );
-            if let Some(ws_id) = crate::workstreams::protocol::resolve_and_bind_session(
+            // (PR #3354 code-critic HIGH 2) Validate the workstream target
+            // BEFORE minting: `SessionRegistry` has no delete/rollback, so
+            // a rejected bind (malformed/unknown/closed `workstream_id`)
+            // must fire while no session exists yet — the mint runs as a
+            // closure inside `resolve_validate_bind`, only after validation
+            // passes, under the same store lock (TOCTOU-free; see that
+            // helper's docs).
+            let (session_id, target) = crate::workstreams::protocol::resolve_validate_bind(
                 &workstreams,
                 p.workstream_id.as_deref(),
-                &session.id,
                 "task.run",
+                || {
+                    registry
+                        .create(
+                            p.task_description.clone(),
+                            Some(agent_name.clone()),
+                            binding.clone(),
+                        )
+                        .id
+                },
             )
-            .await?
-            {
-                registry.bind_workstream(&session.id, ws_id)?;
+            .await?;
+            if let Some(ws_id) = target {
+                registry.bind_workstream(&session_id, ws_id)?;
             }
-            session.id
+            session_id
         }
     };
 

--- a/crates/trusty-code/src/task/protocol_tests.rs
+++ b/crates/trusty-code/src/task/protocol_tests.rs
@@ -684,3 +684,57 @@ async fn task_run_mismatched_workstream_on_reuse_is_rejected() {
     assert_eq!(err.code, -32003);
     assert_ne!(bound_id, other_id);
 }
+
+/// (PR #3354 code-critic HIGH 2 regression) A rejected bind on `task.run`'s
+/// mint path must leave the `SessionRegistry` UNCHANGED — no phantom,
+/// caller-invisible session may survive the error — for ALL THREE
+/// caller-triggerable failure modes: closed workstream, unknown workstream,
+/// malformed id. No mock-LLM env is needed: the rejection fires before
+/// `build_llm_client` is ever reached.
+#[tokio::test]
+async fn task_run_rejected_bind_leaves_no_phantom_session() {
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let closed = workstreams
+        .lock()
+        .await
+        .create("closed")
+        .await
+        .expect("create");
+    workstreams.lock().await.close(closed).await.expect("close");
+
+    let cases: &[(&str, String, i32)] = &[
+        ("closed workstream", closed.to_string(), -32003),
+        (
+            "unknown workstream",
+            crate::workstreams::WorkstreamId::new().to_string(),
+            -32002,
+        ),
+        ("malformed id", "not-a-uuid".to_string(), -32602),
+    ];
+    for (label, ws_id, expected_code) in cases {
+        let before = registry.list().len();
+        let err = task_run(
+            Arc::clone(&registry),
+            json!({"task_description": "say hi", "workstream_id": ws_id}),
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+            agents.path().to_path_buf(),
+            workstreams.clone(),
+        )
+        .await
+        .expect_err("bind must be rejected");
+        assert_eq!(err.code, *expected_code, "{label}: wrong error code");
+        assert_eq!(
+            registry.list().len(),
+            before,
+            "{label}: a rejected bind must not leave a phantom session"
+        );
+    }
+    assert_eq!(
+        registry.list().len(),
+        0,
+        "no session may exist after three rejected task.run calls"
+    );
+}

--- a/crates/trusty-code/src/task/protocol_tests.rs
+++ b/crates/trusty-code/src/task/protocol_tests.rs
@@ -47,6 +47,7 @@ async fn register_wires_task_run() {
         registry,
         ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     );
 
     let req = Request {
@@ -88,6 +89,7 @@ async fn register_wires_task_run_projectless() {
         registry,
         ProjectBinding::None,
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     );
 
     let req = Request {
@@ -124,6 +126,7 @@ async fn task_run_rejects_empty_task_description() {
         json!({"task_description": "   "}),
         ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .unwrap_err();
@@ -149,6 +152,7 @@ async fn task_run_creates_session_when_none_given() {
         json!({"task_description": "say hi"}),
         ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await;
     unsafe {
@@ -198,6 +202,7 @@ async fn task_run_resolves_and_reports_mode() {
         json!({"task_description": "say hi"}),
         ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .expect("task.run should succeed");
@@ -222,6 +227,7 @@ async fn task_run_resolves_and_reports_mode() {
         json!({"task_description": "say hi"}),
         ProjectBinding::resolve(Some(project2.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .expect("task.run should succeed");
@@ -235,6 +241,7 @@ async fn task_run_resolves_and_reports_mode() {
         json!({"task_description": "say hi", "mode": "daily-driver"}),
         ProjectBinding::resolve(Some(project2.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .expect("task.run should succeed");
@@ -253,6 +260,7 @@ async fn task_run_resolves_and_reports_mode() {
         json!({"task_description": "say hi", "mode": "daily-driver"}),
         ProjectBinding::resolve(Some(project2.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .expect("task.run should succeed");
@@ -279,6 +287,7 @@ async fn task_run_unknown_session_id_errors() {
         json!({"task_description": "say hi", "session_id": "does-not-exist"}),
         ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .unwrap_err();
@@ -308,6 +317,7 @@ async fn task_run_without_project_keeps_boot_binding() {
         json!({"task_description": "say hi"}),
         boot_binding.clone(),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .expect("task.run should succeed");
@@ -341,6 +351,7 @@ async fn task_run_with_project_overrides_boot_binding() {
         }),
         ProjectBinding::None,
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .expect("task.run should succeed");
@@ -366,6 +377,7 @@ async fn task_run_rejects_invalid_project() {
         json!({"task_description": "say hi", "project": "/no/such/path/anywhere"}),
         ProjectBinding::None,
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .unwrap_err();
@@ -397,6 +409,7 @@ async fn task_run_sessionful_reuses_existing_session() {
         json!({"task_description": "say hi", "session_id": existing.id}),
         ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await;
     unsafe {
@@ -434,6 +447,7 @@ async fn task_run_session_id_with_matching_project_succeeds() {
         }),
         ProjectBinding::None,
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await;
     unsafe {
@@ -468,6 +482,7 @@ async fn task_run_session_id_with_mismatched_project_is_rejected() {
         }),
         ProjectBinding::None,
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .unwrap_err();
@@ -506,6 +521,7 @@ async fn task_run_second_call_after_finish_continues_the_session() {
         json!({"task_description": "say hi"}),
         ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await
     .expect("first task.run should succeed");
@@ -529,6 +545,7 @@ async fn task_run_second_call_after_finish_continues_the_session() {
         json!({"task_description": "say hi again", "session_id": session_id}),
         ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
         agents.path().to_path_buf(),
+        crate::workstreams::test_shared_store().await,
     )
     .await;
     unsafe {
@@ -537,4 +554,133 @@ async fn task_run_second_call_after_finish_continues_the_session() {
     let value = second.expect("a second task.run on a Finished session must be accepted");
     assert_eq!(value["session_id"], session_id);
     assert_eq!(value["status"], "running");
+}
+
+// -- Workstream binding (DOC-48 §4.1/§4.2, issue #3298) --
+
+/// Seed a workstream and activate it on `workstreams`, returning its id.
+async fn seed_active_workstream(
+    workstreams: &crate::workstreams::SharedWorkstreamStore,
+) -> crate::workstreams::WorkstreamId {
+    let id = workstreams
+        .lock()
+        .await
+        .create("active")
+        .await
+        .expect("create");
+    crate::workstreams::activation::activate(workstreams, id, false)
+        .await
+        .expect("activate");
+    id
+}
+
+/// `task.run` minting a NEW session with no explicit `workstream_id`, while
+/// a workstream is active, must bind to the ACTIVE workstream (§4.2) and
+/// publish `Event::SessionAdded`.
+#[tokio::test]
+async fn task_run_binds_ambient_active_workstream_and_publishes_session_added() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let active_id = seed_active_workstream(&workstreams).await;
+
+    let mut rx = crate::events::subscribe();
+    let value = task_run(
+        Arc::clone(&registry),
+        json!({"task_description": "say hi"}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+        workstreams.clone(),
+    )
+    .await;
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    let value = value.expect("task.run should succeed");
+    let session_id = value["session_id"].as_str().unwrap().to_string();
+
+    let status = registry.status(&session_id).expect("status");
+    assert_eq!(status.workstream_id, Some(active_id));
+
+    let found = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            let envelope = rx.recv().await.expect("event bus channel closed");
+            if let crate::events::Event::SessionAdded {
+                session_id: sid,
+                workstream_id,
+                ..
+            } = envelope.event
+                && sid == session_id
+            {
+                return workstream_id;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for SessionAdded");
+    assert_eq!(found, active_id.to_string());
+}
+
+/// `task.run` reusing an EXISTING session that is already bound to a
+/// workstream, with a `workstream_id` param naming a DIFFERENT workstream,
+/// must be rejected (§4.1 AC-1.3 immutability) — mirroring the sibling
+/// `project` mismatch guard.
+#[tokio::test]
+async fn task_run_mismatched_workstream_on_reuse_is_rejected() {
+    let _guard = super::super::mock_llm::MOCK_LLM_ENV_LOCK.lock().await;
+    unsafe {
+        std::env::set_var(
+            super::super::mock_llm::MOCK_LLM_ENV,
+            super::super::mock_llm::MOCK_LLM_ECHO,
+        );
+    }
+    let registry = Arc::new(SessionRegistry::new());
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+    let workstreams = crate::workstreams::test_shared_store().await;
+    let bound_id = seed_active_workstream(&workstreams).await;
+
+    let first = task_run(
+        Arc::clone(&registry),
+        json!({"task_description": "say hi"}),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+        workstreams.clone(),
+    )
+    .await
+    .expect("first task.run should succeed");
+    let session_id = first["session_id"].as_str().unwrap().to_string();
+
+    let other_id = workstreams
+        .lock()
+        .await
+        .create("other")
+        .await
+        .expect("create");
+    let err = task_run(
+        Arc::clone(&registry),
+        json!({
+            "task_description": "say hi again",
+            "session_id": session_id,
+            "workstream_id": other_id.to_string(),
+        }),
+        ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+        agents.path().to_path_buf(),
+        workstreams.clone(),
+    )
+    .await;
+    unsafe {
+        std::env::remove_var(super::super::mock_llm::MOCK_LLM_ENV);
+    }
+    let err = err.expect_err("a mismatched workstream_id on reuse must be rejected");
+    assert_eq!(err.code, -32003);
+    assert_ne!(bound_id, other_id);
 }

--- a/crates/trusty-code/src/workstreams/mod.rs
+++ b/crates/trusty-code/src/workstreams/mod.rs
@@ -67,4 +67,29 @@ pub use activation::{ActivateOutcome, ActivationError, SharedWorkstreamStore};
 pub use model::{Workstream, WorkstreamId, WorkstreamState};
 pub use path::{default_data_dir, store_path};
 pub use sse::WorkstreamEventEnvelope;
-pub use store::{ReconcileOutcome, StoreError, WorkstreamStore};
+pub use store::{BindError, ReconcileOutcome, StoreError, WorkstreamStore};
+
+/// Test-only helper: a fresh, in-memory-backed [`SharedWorkstreamStore`]
+/// rooted at a throwaway tempdir (issue #3298).
+///
+/// Why: `session::protocol::register`/`task::protocol::register` both now
+/// require a `SharedWorkstreamStore` — every test call site across the
+/// crate that wires either `register` but does not itself care about
+/// workstream binding needs a cheap, disposable store rather than resolving
+/// the real `~/.trusty-code` directory. One helper here (rather than each
+/// call site re-deriving its own) keeps that boilerplate in exactly one
+/// place.
+/// What: loads a fresh [`WorkstreamStore`] at a tempdir path and wraps it in
+/// the same `Arc<tokio::sync::Mutex<_>>` shape production code uses. The
+/// `TempDir` guard is intentionally dropped here — `WorkstreamStore::save`
+/// re-creates its parent directory on every write (see that method's docs),
+/// so a test that never asserts on persisted file contents (the common case)
+/// is unaffected by the directory's removal.
+#[cfg(test)]
+pub(crate) async fn test_shared_store() -> SharedWorkstreamStore {
+    let dir = tempfile::tempdir().expect("tempdir for test workstream store");
+    let store = WorkstreamStore::load(dir.path().join("workstreams-test.json"))
+        .await
+        .expect("load fresh workstream store");
+    std::sync::Arc::new(tokio::sync::Mutex::new(store))
+}

--- a/crates/trusty-code/src/workstreams/protocol.rs
+++ b/crates/trusty-code/src/workstreams/protocol.rs
@@ -153,8 +153,10 @@ impl WorkstreamView {
     }
 }
 
-/// Resolve the EFFECTIVE workstream target for a freshly-minted session and
-/// persist the binding (DOC-48 §4.1/§4.2, issue #3298).
+/// Resolve + VALIDATE the EFFECTIVE workstream target, then mint a session
+/// and persist its binding — all under one store lock (DOC-48 §4.1/§4.2,
+/// issue #3298; validate-before-mint ordering per PR #3354 code-critic
+/// HIGH findings 1 & 2).
 ///
 /// Why: `session::protocol::create` and `task::protocol::task_run` (minting
 /// a NEW session) both need this exact resolution — an explicit
@@ -165,51 +167,86 @@ impl WorkstreamView {
 /// is the same "one place, both callers" precedent
 /// `crate::binding::ProjectBinding::resolve` already set for project
 /// binding.
-/// What: `explicit` is the caller's raw wire `workstream_id` string, if any.
-/// `Ok(None)` — no explicit param and no active workstream. `Ok(Some(id))` —
-/// after `WorkstreamStore::bind_session` has persisted the append.
+///
+/// **Why the `mint` closure (atomicity):** `SessionRegistry` has no
+/// delete/rollback — a session, once minted, exists for the daemon
+/// lifetime. The first cut of this function took an ALREADY-minted
+/// `session_id` and could then fail (closed/unknown/malformed target),
+/// leaving an orphaned, caller-invisible session in the registry on every
+/// rejected bind — a retry-amplified memory-growth vector (code-critic
+/// HIGH, PR #3354). Now every caller-triggerable failure mode (malformed
+/// id, unknown id, closed workstream) is validated BEFORE `mint()` runs, so
+/// a rejected bind mints nothing. Holding the ONE store lock across
+/// resolve -> validate -> mint -> bind keeps the sequence TOCTOU-free: no
+/// concurrent `workstream.close`/`deactivate` can invalidate the target
+/// between its validation and the bind.
+/// What: `explicit` is the caller's raw wire `workstream_id` string, if
+/// any; `mint` mints the session (infallible — `SessionRegistry::create`
+/// never fails) and returns its id, called EXACTLY ONCE, and only after
+/// validation passes. Returns `(session_id, bound_workstream)` —
+/// `(id, None)` when no explicit param was given and no workstream is
+/// active (projectless mint); `(id, Some(ws))` after
+/// `WorkstreamStore::bind_session` persisted the append.
 /// `Err(-32602 invalid_params)` — `explicit` is not a valid UUID.
 /// `Err(-32002 not_found)` — `explicit` names no workstream.
 /// `Err(-32003 invalid_argument)` — the target (explicit OR ambient) is
-/// closed (§4.1: "new sessions may not bind to it"). `StoreError::AlreadyBound`
-/// maps to `-32603 internal` — unreachable in practice, since `session_id`
-/// here is always a just-minted, globally-unique id that cannot already
-/// appear in any workstream's `session_ids`.
-/// Test: `protocol_tests::resolve_and_bind_session_explicit_wins_over_active`,
-/// `protocol_tests::resolve_and_bind_session_falls_back_to_active`,
-/// `protocol_tests::resolve_and_bind_session_none_when_nothing_active`,
-/// `protocol_tests::resolve_and_bind_session_rejects_closed_explicit_target`,
-/// `protocol_tests::resolve_and_bind_session_rejects_unknown_explicit_id`.
-pub async fn resolve_and_bind_session(
+/// closed (§4.1: "new sessions may not bind to it"). All three fire before
+/// `mint`. The residual post-mint failure surface is `bind_session`'s
+/// save-to-disk I/O error (`-32603 internal`) — a daemon-side storage
+/// fault, not caller-triggerable; `BindError::NotFound`/`Closed`/
+/// `AlreadyBound` are unreachable post-validation under the held lock and
+/// map to `-32603 internal` defensively.
+/// Test: `protocol_tests::resolve_validate_bind_explicit_wins_over_active`,
+/// `protocol_tests::resolve_validate_bind_falls_back_to_active`,
+/// `protocol_tests::resolve_validate_bind_none_when_nothing_active`,
+/// `protocol_tests::resolve_validate_bind_rejects_closed_target_without_minting`,
+/// `protocol_tests::resolve_validate_bind_rejects_unknown_id_without_minting`,
+/// `protocol_tests::resolve_validate_bind_rejects_malformed_id_without_minting`;
+/// the end-to-end no-phantom-session regression at both RPC surfaces in
+/// `session::protocol::workstream_binding_tests::create_rejected_bind_leaves_no_phantom_session`
+/// and `task::protocol::tests::task_run_rejected_bind_leaves_no_phantom_session`.
+pub async fn resolve_validate_bind<F>(
     store: &SharedWorkstreamStore,
     explicit: Option<&str>,
-    session_id: &str,
     method: &str,
-) -> Result<Option<WorkstreamId>, RpcError> {
+    mint: F,
+) -> Result<(String, Option<WorkstreamId>), RpcError>
+where
+    F: FnOnce() -> String,
+{
     let mut store = store.lock().await;
     let target = match explicit {
         Some(raw) => Some(parse_id(raw, method)?),
         None => store.active_workstream_id().await.map_err(map_store_err)?,
     };
-    let Some(id) = target else {
-        return Ok(None);
-    };
-    store
-        .bind_session(id, session_id)
-        .await
-        .map_err(|e| match e {
-            super::store::BindError::NotFound(id) => {
-                RpcError::not_found(format!("workstream not found: {id}"))
-            }
-            super::store::BindError::Closed(id) => RpcError::invalid_argument(format!(
+    // Validate the target BEFORE minting — every caller-triggerable
+    // rejection must happen while nothing has been created yet.
+    if let Some(id) = target {
+        let ws = store.get(id).await.map_err(map_store_err)?;
+        if ws.is_closed() {
+            return Err(RpcError::invalid_argument(format!(
                 "workstream {id} is closed; new sessions may not bind to it"
-            )),
-            super::store::BindError::AlreadyBound(sid) => RpcError::internal(format!(
-                "unexpected: freshly-minted session `{sid}` already bound to a workstream"
-            )),
-            super::store::BindError::Store(e) => map_store_err(e),
-        })?;
-    Ok(Some(id))
+            )));
+        }
+    }
+    let session_id = mint();
+    if let Some(id) = target {
+        store
+            .bind_session(id, &session_id)
+            .await
+            .map_err(|e| match e {
+                // Post-validation, under the same lock, only a storage I/O
+                // fault can land here; the caller-shaped variants are
+                // defensively mapped to internal rather than silently
+                // reusing their pre-mint codes (which would misreport an
+                // impossible state as a caller error).
+                super::store::BindError::Store(e) => map_store_err(e),
+                other => RpcError::internal(format!(
+                    "unexpected post-validation bind failure for session `{session_id}`: {other}"
+                )),
+            })?;
+    }
+    Ok((session_id, target))
 }
 
 /// Enforce DOC-48 §4.1's binding immutability on a REUSED session (AC-1.3,

--- a/crates/trusty-code/src/workstreams/protocol.rs
+++ b/crates/trusty-code/src/workstreams/protocol.rs
@@ -153,6 +153,107 @@ impl WorkstreamView {
     }
 }
 
+/// Resolve the EFFECTIVE workstream target for a freshly-minted session and
+/// persist the binding (DOC-48 §4.1/§4.2, issue #3298).
+///
+/// Why: `session::protocol::create` and `task::protocol::task_run` (minting
+/// a NEW session) both need this exact resolution — an explicit
+/// `workstream_id` param (§4.1) takes precedence; otherwise the daemon's
+/// currently active workstream is the ambient default target (§4.2); if
+/// neither applies, the session stays projectless (valid, never an error).
+/// Centralising it here (rather than duplicating in both `protocol` modules)
+/// is the same "one place, both callers" precedent
+/// `crate::binding::ProjectBinding::resolve` already set for project
+/// binding.
+/// What: `explicit` is the caller's raw wire `workstream_id` string, if any.
+/// `Ok(None)` — no explicit param and no active workstream. `Ok(Some(id))` —
+/// after `WorkstreamStore::bind_session` has persisted the append.
+/// `Err(-32602 invalid_params)` — `explicit` is not a valid UUID.
+/// `Err(-32002 not_found)` — `explicit` names no workstream.
+/// `Err(-32003 invalid_argument)` — the target (explicit OR ambient) is
+/// closed (§4.1: "new sessions may not bind to it"). `StoreError::AlreadyBound`
+/// maps to `-32603 internal` — unreachable in practice, since `session_id`
+/// here is always a just-minted, globally-unique id that cannot already
+/// appear in any workstream's `session_ids`.
+/// Test: `protocol_tests::resolve_and_bind_session_explicit_wins_over_active`,
+/// `protocol_tests::resolve_and_bind_session_falls_back_to_active`,
+/// `protocol_tests::resolve_and_bind_session_none_when_nothing_active`,
+/// `protocol_tests::resolve_and_bind_session_rejects_closed_explicit_target`,
+/// `protocol_tests::resolve_and_bind_session_rejects_unknown_explicit_id`.
+pub async fn resolve_and_bind_session(
+    store: &SharedWorkstreamStore,
+    explicit: Option<&str>,
+    session_id: &str,
+    method: &str,
+) -> Result<Option<WorkstreamId>, RpcError> {
+    let mut store = store.lock().await;
+    let target = match explicit {
+        Some(raw) => Some(parse_id(raw, method)?),
+        None => store.active_workstream_id().await.map_err(map_store_err)?,
+    };
+    let Some(id) = target else {
+        return Ok(None);
+    };
+    store
+        .bind_session(id, session_id)
+        .await
+        .map_err(|e| match e {
+            super::store::BindError::NotFound(id) => {
+                RpcError::not_found(format!("workstream not found: {id}"))
+            }
+            super::store::BindError::Closed(id) => RpcError::invalid_argument(format!(
+                "workstream {id} is closed; new sessions may not bind to it"
+            )),
+            super::store::BindError::AlreadyBound(sid) => RpcError::internal(format!(
+                "unexpected: freshly-minted session `{sid}` already bound to a workstream"
+            )),
+            super::store::BindError::Store(e) => map_store_err(e),
+        })?;
+    Ok(Some(id))
+}
+
+/// Enforce DOC-48 §4.1's binding immutability on a REUSED session (AC-1.3,
+/// issue #3298): "if a session with an existing workstream binding receives
+/// a task with a different workstream, the task is rejected."
+///
+/// Why: `task::protocol::task_run`'s `session_id` ("sessionful") path is the
+/// one call site that can present a session already carrying a persisted
+/// `workstream_id` alongside a fresh, possibly-conflicting `workstream_id`
+/// param — mirrors the existing `project` mismatch guard right next to it
+/// (`task::protocol::task_run`'s own docs) at the exact same layer.
+/// What: `explicit: None` never rejects — ambient default-targeting (§4.2)
+/// applies only to a session's FIRST binding at creation, never re-applied
+/// on reuse. `explicit: Some(raw)` — parses `raw`; `Ok(())` if it restates
+/// `existing` exactly (including `existing: None` restated by... it cannot
+/// restate `None`, so any `Some` explicit id against an unbound session is
+/// ALSO a mismatch, per the same authoritative-binding rule
+/// `task::protocol::task_run`'s `project` check already applies); otherwise
+/// `Err(-32003 invalid_argument)` naming both ids.
+/// Test: `protocol_tests::check_workstream_immutable_allows_none`,
+/// `protocol_tests::check_workstream_immutable_allows_restating_same_id`,
+/// `protocol_tests::check_workstream_immutable_rejects_mismatch`,
+/// `protocol_tests::check_workstream_immutable_rejects_binding_an_unbound_session`.
+pub fn check_workstream_immutable(
+    existing: Option<WorkstreamId>,
+    explicit: Option<&str>,
+    method: &str,
+) -> Result<(), RpcError> {
+    let Some(raw) = explicit else {
+        return Ok(());
+    };
+    let requested = parse_id(raw, method)?;
+    if existing == Some(requested) {
+        return Ok(());
+    }
+    Err(RpcError::invalid_argument(format!(
+        "{method}: workstream `{requested}` does not match this session's existing binding \
+         `{}` — a session's workstream binding is immutable once set (DOC-48 §4.1)",
+        existing
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "<unbound>".to_string()),
+    )))
+}
+
 /// Deserialise `params` into `T`, mapping a failure onto `-32602 Invalid
 /// params` with the method name for context (mirrors
 /// `crate::session::protocol::parse`).

--- a/crates/trusty-code/src/workstreams/protocol_tests.rs
+++ b/crates/trusty-code/src/workstreams/protocol_tests.rs
@@ -509,3 +509,102 @@ async fn rename_invalid_params_maps_to_invalid_params() {
         .unwrap_err();
     assert_eq!(err.code, trusty_common::mcp::error_codes::INVALID_PARAMS);
 }
+
+// -- resolve_and_bind_session / check_workstream_immutable (issue #3298) --
+
+#[tokio::test]
+async fn resolve_and_bind_session_explicit_wins_over_active() {
+    let (store, _dir) = shared_store().await;
+    let active = seed_workstream(&store, "active").await;
+    let explicit = seed_workstream(&store, "explicit").await;
+    activation::activate(&store, active, false)
+        .await
+        .expect("activate");
+
+    let bound = resolve_and_bind_session(&store, Some(&explicit.to_string()), "s-1", "test")
+        .await
+        .expect("resolve");
+    assert_eq!(bound, Some(explicit));
+    let ws = store.lock().await.get(explicit).await.expect("get");
+    assert_eq!(ws.session_ids, vec!["s-1".to_string()]);
+}
+
+#[tokio::test]
+async fn resolve_and_bind_session_falls_back_to_active() {
+    let (store, _dir) = shared_store().await;
+    let active = seed_workstream(&store, "active").await;
+    activation::activate(&store, active, false)
+        .await
+        .expect("activate");
+
+    let bound = resolve_and_bind_session(&store, None, "s-1", "test")
+        .await
+        .expect("resolve");
+    assert_eq!(bound, Some(active));
+}
+
+#[tokio::test]
+async fn resolve_and_bind_session_none_when_nothing_active() {
+    let (store, _dir) = shared_store().await;
+    let bound = resolve_and_bind_session(&store, None, "s-1", "test")
+        .await
+        .expect("resolve");
+    assert_eq!(
+        bound, None,
+        "no explicit param and nothing active must stay projectless"
+    );
+}
+
+#[tokio::test]
+async fn resolve_and_bind_session_rejects_closed_explicit_target() {
+    let (store, _dir) = shared_store().await;
+    let id = seed_workstream(&store, "closed").await;
+    store.lock().await.close(id).await.expect("close");
+
+    let err = resolve_and_bind_session(&store, Some(&id.to_string()), "s-1", "test")
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, -32003);
+}
+
+#[tokio::test]
+async fn resolve_and_bind_session_rejects_unknown_explicit_id() {
+    let (store, _dir) = shared_store().await;
+    let err = resolve_and_bind_session(
+        &store,
+        Some(&WorkstreamId::new().to_string()),
+        "s-1",
+        "test",
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, -32002);
+}
+
+#[test]
+fn check_workstream_immutable_allows_none() {
+    let existing = Some(WorkstreamId::new());
+    assert!(check_workstream_immutable(existing, None, "test").is_ok());
+}
+
+#[test]
+fn check_workstream_immutable_allows_restating_same_id() {
+    let id = WorkstreamId::new();
+    assert!(check_workstream_immutable(Some(id), Some(&id.to_string()), "test").is_ok());
+}
+
+#[test]
+fn check_workstream_immutable_rejects_mismatch() {
+    let existing = WorkstreamId::new();
+    let requested = WorkstreamId::new();
+    let err = check_workstream_immutable(Some(existing), Some(&requested.to_string()), "test")
+        .unwrap_err();
+    assert_eq!(err.code, -32003);
+}
+
+#[test]
+fn check_workstream_immutable_rejects_binding_an_unbound_session() {
+    let requested = WorkstreamId::new();
+    let err = check_workstream_immutable(None, Some(&requested.to_string()), "test").unwrap_err();
+    assert_eq!(err.code, -32003);
+}

--- a/crates/trusty-code/src/workstreams/protocol_tests.rs
+++ b/crates/trusty-code/src/workstreams/protocol_tests.rs
@@ -510,10 +510,32 @@ async fn rename_invalid_params_maps_to_invalid_params() {
     assert_eq!(err.code, trusty_common::mcp::error_codes::INVALID_PARAMS);
 }
 
-// -- resolve_and_bind_session / check_workstream_immutable (issue #3298) --
+// -- resolve_validate_bind / check_workstream_immutable (issue #3298;
+//    validate-before-mint atomicity per PR #3354 code-critic HIGH 1 & 2) --
+
+/// A mint closure that returns a fixed id and records whether it ran — the
+/// critic's required property is precisely "the mint must NOT run on any
+/// rejected bind".
+fn tracked_mint(
+    id: &str,
+) -> (
+    impl FnOnce() -> String,
+    std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    let minted = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let flag = minted.clone();
+    let id = id.to_string();
+    (
+        move || {
+            flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            id
+        },
+        minted,
+    )
+}
 
 #[tokio::test]
-async fn resolve_and_bind_session_explicit_wins_over_active() {
+async fn resolve_validate_bind_explicit_wins_over_active() {
     let (store, _dir) = shared_store().await;
     let active = seed_workstream(&store, "active").await;
     let explicit = seed_workstream(&store, "explicit").await;
@@ -521,34 +543,39 @@ async fn resolve_and_bind_session_explicit_wins_over_active() {
         .await
         .expect("activate");
 
-    let bound = resolve_and_bind_session(&store, Some(&explicit.to_string()), "s-1", "test")
+    let (session_id, bound) =
+        resolve_validate_bind(&store, Some(&explicit.to_string()), "test", || {
+            "s-1".to_string()
+        })
         .await
         .expect("resolve");
+    assert_eq!(session_id, "s-1");
     assert_eq!(bound, Some(explicit));
     let ws = store.lock().await.get(explicit).await.expect("get");
     assert_eq!(ws.session_ids, vec!["s-1".to_string()]);
 }
 
 #[tokio::test]
-async fn resolve_and_bind_session_falls_back_to_active() {
+async fn resolve_validate_bind_falls_back_to_active() {
     let (store, _dir) = shared_store().await;
     let active = seed_workstream(&store, "active").await;
     activation::activate(&store, active, false)
         .await
         .expect("activate");
 
-    let bound = resolve_and_bind_session(&store, None, "s-1", "test")
+    let (_, bound) = resolve_validate_bind(&store, None, "test", || "s-1".to_string())
         .await
         .expect("resolve");
     assert_eq!(bound, Some(active));
 }
 
 #[tokio::test]
-async fn resolve_and_bind_session_none_when_nothing_active() {
+async fn resolve_validate_bind_none_when_nothing_active() {
     let (store, _dir) = shared_store().await;
-    let bound = resolve_and_bind_session(&store, None, "s-1", "test")
+    let (session_id, bound) = resolve_validate_bind(&store, None, "test", || "s-1".to_string())
         .await
         .expect("resolve");
+    assert_eq!(session_id, "s-1", "the projectless path must still mint");
     assert_eq!(
         bound, None,
         "no explicit param and nothing active must stay projectless"
@@ -556,29 +583,82 @@ async fn resolve_and_bind_session_none_when_nothing_active() {
 }
 
 #[tokio::test]
-async fn resolve_and_bind_session_rejects_closed_explicit_target() {
+async fn resolve_validate_bind_rejects_closed_target_without_minting() {
     let (store, _dir) = shared_store().await;
     let id = seed_workstream(&store, "closed").await;
     store.lock().await.close(id).await.expect("close");
+    let (mint, minted) = tracked_mint("s-1");
 
-    let err = resolve_and_bind_session(&store, Some(&id.to_string()), "s-1", "test")
+    let err = resolve_validate_bind(&store, Some(&id.to_string()), "test", mint)
         .await
         .unwrap_err();
     assert_eq!(err.code, -32003);
+    assert!(
+        !minted.load(std::sync::atomic::Ordering::SeqCst),
+        "a rejected bind must never mint a session (PR #3354 HIGH)"
+    );
 }
 
 #[tokio::test]
-async fn resolve_and_bind_session_rejects_unknown_explicit_id() {
+async fn resolve_validate_bind_rejects_unknown_id_without_minting() {
     let (store, _dir) = shared_store().await;
-    let err = resolve_and_bind_session(
-        &store,
-        Some(&WorkstreamId::new().to_string()),
-        "s-1",
-        "test",
-    )
-    .await
-    .unwrap_err();
+    let (mint, minted) = tracked_mint("s-1");
+
+    let err = resolve_validate_bind(&store, Some(&WorkstreamId::new().to_string()), "test", mint)
+        .await
+        .unwrap_err();
     assert_eq!(err.code, -32002);
+    assert!(
+        !minted.load(std::sync::atomic::Ordering::SeqCst),
+        "a rejected bind must never mint a session (PR #3354 HIGH)"
+    );
+}
+
+#[tokio::test]
+async fn resolve_validate_bind_rejects_malformed_id_without_minting() {
+    let (store, _dir) = shared_store().await;
+    let (mint, minted) = tracked_mint("s-1");
+
+    let err = resolve_validate_bind(&store, Some("not-a-uuid"), "test", mint)
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, -32602);
+    assert!(
+        !minted.load(std::sync::atomic::Ordering::SeqCst),
+        "a rejected bind must never mint a session (PR #3354 HIGH)"
+    );
+}
+
+/// A rejected AMBIENT target (the active workstream was closed out from
+/// under the pointer) must likewise reject without minting — the ambient
+/// path validates identically to the explicit one.
+#[tokio::test]
+async fn resolve_validate_bind_rejects_closed_ambient_target_without_minting() {
+    let (store, _dir) = shared_store().await;
+    let active = seed_workstream(&store, "active").await;
+    activation::activate(&store, active, false)
+        .await
+        .expect("activate");
+    // `close` clears the active pointer, so force the dangling-pointer shape
+    // directly at the store level: close, then restore the pointer as a
+    // simulated concurrent-writer artifact.
+    store.lock().await.close(active).await.expect("close");
+    store
+        .lock()
+        .await
+        .set_active(Some(active))
+        .await
+        .expect("restore pointer");
+    let (mint, minted) = tracked_mint("s-1");
+
+    let err = resolve_validate_bind(&store, None, "test", mint)
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, -32003);
+    assert!(
+        !minted.load(std::sync::atomic::Ordering::SeqCst),
+        "a rejected ambient bind must never mint a session"
+    );
 }
 
 #[test]

--- a/crates/trusty-code/src/workstreams/store.rs
+++ b/crates/trusty-code/src/workstreams/store.rs
@@ -438,32 +438,6 @@ impl WorkstreamStore {
             .ok_or_else(|| StoreError::NotFound(id.to_string()))
     }
 
-    /// Find which workstream (if any) `session_id` is already bound to.
-    ///
-    /// Why: the read-side counterpart [`Self::bind_session`] needs to enforce
-    /// "a session appears in at most one workstream" (DOC-48 §2), and the
-    /// session-creation call sites (`session::protocol::create`,
-    /// `task::protocol::task_run`) need the same lookup for the immutability
-    /// check on a REUSED session (AC-1.3: a differing `workstream_id` on a
-    /// later call is rejected).
-    /// What: reloads first, then a linear scan of every record's
-    /// `session_ids` — the store has no reverse index; this is fine at the
-    /// scale a single project's workstream count implies (§2.3).
-    /// Test: `store_tests::find_binding_returns_owning_workstream`,
-    /// `store_tests::find_binding_returns_none_for_unbound_session`.
-    pub async fn find_binding(
-        &mut self,
-        session_id: &str,
-    ) -> Result<Option<WorkstreamId>, StoreError> {
-        self.reload_if_changed().await?;
-        Ok(self
-            .data
-            .workstreams
-            .iter()
-            .find(|w| w.session_ids.iter().any(|s| s == session_id))
-            .map(|w| w.id))
-    }
-
     /// Bind `session_id` to `workstream_id`, persisting the append (DOC-48
     /// §4.1, issue #3298).
     ///

--- a/crates/trusty-code/src/workstreams/store.rs
+++ b/crates/trusty-code/src/workstreams/store.rs
@@ -52,6 +52,35 @@ pub enum StoreError {
     NotFound(String),
 }
 
+/// Typed failure surface for [`WorkstreamStore::bind_session`] (issue
+/// #3298).
+///
+/// Why: a SEPARATE enum from [`StoreError`] rather than two new variants on
+/// it — `StoreError` already has non-exhaustive `match`es at existing call
+/// sites outside this ticket's file ownership (`workstreams::sse`'s own
+/// `map_store_err`, owned by the concurrent sibling ticket #3299), which
+/// widening `StoreError` would silently break. `BindError::Store` wraps
+/// every other [`StoreError`] variant unchanged.
+/// What: [`Self::NotFound`] — the target workstream does not exist.
+/// [`Self::Closed`] — DOC-48 §4.1/§4.4: "If a workstream is closed, new
+/// sessions may not bind to it". [`Self::AlreadyBound`] — DOC-48 §2: a
+/// session appears in at most one workstream's `session_ids`; this session
+/// id is already bound to a DIFFERENT workstream.
+/// Test: `store_tests::bind_session_rejects_unknown_workstream`,
+/// `store_tests::bind_session_rejects_closed_workstream`,
+/// `store_tests::bind_session_rejects_double_binding_to_different_workstream`.
+#[derive(Debug, Error)]
+pub enum BindError {
+    #[error("workstream not found: {0}")]
+    NotFound(String),
+    #[error("workstream is closed: {0}")]
+    Closed(String),
+    #[error("session already bound to another workstream: {0}")]
+    AlreadyBound(String),
+    #[error(transparent)]
+    Store(#[from] StoreError),
+}
+
 /// The versioned, on-disk JSON shape (§3.1): `version`, `active_workstream_id`,
 /// and a flat `workstreams` array — NOT a file-per-record or a keyed map.
 #[derive(Debug, Serialize, Deserialize)]
@@ -407,6 +436,88 @@ impl WorkstreamStore {
             .find(|w| w.id == id)
             .cloned()
             .ok_or_else(|| StoreError::NotFound(id.to_string()))
+    }
+
+    /// Find which workstream (if any) `session_id` is already bound to.
+    ///
+    /// Why: the read-side counterpart [`Self::bind_session`] needs to enforce
+    /// "a session appears in at most one workstream" (DOC-48 §2), and the
+    /// session-creation call sites (`session::protocol::create`,
+    /// `task::protocol::task_run`) need the same lookup for the immutability
+    /// check on a REUSED session (AC-1.3: a differing `workstream_id` on a
+    /// later call is rejected).
+    /// What: reloads first, then a linear scan of every record's
+    /// `session_ids` — the store has no reverse index; this is fine at the
+    /// scale a single project's workstream count implies (§2.3).
+    /// Test: `store_tests::find_binding_returns_owning_workstream`,
+    /// `store_tests::find_binding_returns_none_for_unbound_session`.
+    pub async fn find_binding(
+        &mut self,
+        session_id: &str,
+    ) -> Result<Option<WorkstreamId>, StoreError> {
+        self.reload_if_changed().await?;
+        Ok(self
+            .data
+            .workstreams
+            .iter()
+            .find(|w| w.session_ids.iter().any(|s| s == session_id))
+            .map(|w| w.id))
+    }
+
+    /// Bind `session_id` to `workstream_id`, persisting the append (DOC-48
+    /// §4.1, issue #3298).
+    ///
+    /// Why: the persistence primitive `session::protocol::create` and
+    /// `task::protocol::task_run` call once they have resolved the EFFECTIVE
+    /// target workstream (either the caller's explicit `workstream_id` or
+    /// §4.2's ambient active-workstream default) for a freshly minted
+    /// session — mirrors [`Self::set_active`]'s role as the low-level
+    /// "write it and persist" primitive beneath the higher-level resolution
+    /// logic those call sites own.
+    /// What: reloads first. Idempotent no-op success if `session_id` is
+    /// already bound to `workstream_id` itself (a caller resolving the SAME
+    /// binding twice — e.g. a retried request — must not error). Otherwise:
+    /// `AlreadyBound` if `session_id` is bound to a DIFFERENT workstream
+    /// (§2's at-most-one-workstream invariant); `NotFound` if `workstream_id`
+    /// names no record; `Closed` if the target workstream is closed (§4.1/
+    /// §4.4). On success, appends `session_id` to the target's `session_ids`
+    /// (append-only, §2.1), touches it, and persists.
+    /// Test: `store_tests::bind_session_appends_and_persists`,
+    /// `store_tests::bind_session_is_idempotent_for_same_workstream`,
+    /// `store_tests::bind_session_rejects_double_binding_to_different_workstream`,
+    /// `store_tests::bind_session_rejects_unknown_workstream`,
+    /// `store_tests::bind_session_rejects_closed_workstream`.
+    pub async fn bind_session(
+        &mut self,
+        workstream_id: WorkstreamId,
+        session_id: &str,
+    ) -> Result<(), BindError> {
+        self.reload_if_changed().await?;
+        if let Some(existing) = self
+            .data
+            .workstreams
+            .iter()
+            .find(|w| w.session_ids.iter().any(|s| s == session_id))
+        {
+            return if existing.id == workstream_id {
+                Ok(())
+            } else {
+                Err(BindError::AlreadyBound(session_id.to_string()))
+            };
+        }
+        let ws = self
+            .data
+            .workstreams
+            .iter_mut()
+            .find(|w| w.id == workstream_id)
+            .ok_or_else(|| BindError::NotFound(workstream_id.to_string()))?;
+        if ws.is_closed() {
+            return Err(BindError::Closed(workstream_id.to_string()));
+        }
+        ws.session_ids.push(session_id.to_string());
+        ws.touch();
+        self.save().await?;
+        Ok(())
     }
 
     /// Boot-time reconciliation (DOC-48 §3.3, AC-1.4, AC-6.1, AC-6.2).

--- a/crates/trusty-code/src/workstreams/store_tests.rs
+++ b/crates/trusty-code/src/workstreams/store_tests.rs
@@ -369,3 +369,100 @@ async fn store_reload_noop_when_unchanged() {
     let ws = store.get(id).await.expect("get");
     assert_eq!(ws.id, id);
 }
+
+// -- Session binding (DOC-48 §4.1/§2, issue #3298) --
+
+#[tokio::test]
+async fn bind_session_appends_and_persists() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("A").await.expect("create");
+
+    store.bind_session(id, "s-1").await.expect("bind");
+    let ws = store.get(id).await.expect("get");
+    assert_eq!(ws.session_ids, vec!["s-1".to_string()]);
+
+    // Persisted, not just in-memory.
+    let mut reloaded = WorkstreamStore::load(store_file(&dir))
+        .await
+        .expect("reload");
+    let ws = reloaded.get(id).await.expect("get after reload");
+    assert_eq!(ws.session_ids, vec!["s-1".to_string()]);
+}
+
+#[tokio::test]
+async fn bind_session_is_idempotent_for_same_workstream() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("A").await.expect("create");
+
+    store.bind_session(id, "s-1").await.expect("first bind");
+    store
+        .bind_session(id, "s-1")
+        .await
+        .expect("re-binding to the SAME workstream must not error");
+    let ws = store.get(id).await.expect("get");
+    assert_eq!(
+        ws.session_ids,
+        vec!["s-1".to_string()],
+        "must not double-append on the idempotent path"
+    );
+}
+
+#[tokio::test]
+async fn bind_session_rejects_double_binding_to_different_workstream() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let a = store.create("A").await.expect("create a");
+    let b = store.create("B").await.expect("create b");
+
+    store.bind_session(a, "s-1").await.expect("bind to a");
+    assert!(matches!(
+        store.bind_session(b, "s-1").await,
+        Err(BindError::AlreadyBound(id)) if id == "s-1"
+    ));
+}
+
+#[tokio::test]
+async fn bind_session_rejects_unknown_workstream() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let missing = WorkstreamId::new();
+
+    assert!(matches!(
+        store.bind_session(missing, "s-1").await,
+        Err(BindError::NotFound(_))
+    ));
+}
+
+#[tokio::test]
+async fn bind_session_rejects_closed_workstream() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("A").await.expect("create");
+    store.close(id).await.expect("close");
+
+    assert!(matches!(
+        store.bind_session(id, "s-1").await,
+        Err(BindError::Closed(_))
+    ));
+}
+
+#[tokio::test]
+async fn find_binding_returns_owning_workstream() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("A").await.expect("create");
+    store.bind_session(id, "s-1").await.expect("bind");
+
+    assert_eq!(store.find_binding("s-1").await.expect("find"), Some(id));
+}
+
+#[tokio::test]
+async fn find_binding_returns_none_for_unbound_session() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    store.create("A").await.expect("create");
+
+    assert_eq!(store.find_binding("s-nope").await.expect("find"), None);
+}

--- a/crates/trusty-code/src/workstreams/store_tests.rs
+++ b/crates/trusty-code/src/workstreams/store_tests.rs
@@ -359,6 +359,47 @@ async fn rename_closed_workstream_succeeds() {
     assert!(renamed.is_closed(), "rename must not clear the closed flag");
 }
 
+/// (#3298 x #3300 intersection) Renaming a workstream with BOUND sessions —
+/// including the active one — must disturb neither its `session_ids` nor
+/// the active pointer: rename touches only `name`/`updated_at`, and this
+/// pins that orthogonality now that both features exist. Also proves a
+/// session can still bind AFTER a rename (the record's identity is its id,
+/// not its label).
+#[tokio::test]
+async fn rename_preserves_session_bindings_and_active_pointer() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("original").await.expect("create");
+    store.set_active(Some(id)).await.expect("activate");
+    store.bind_session(id, "s-1").await.expect("bind s-1");
+    store.bind_session(id, "s-2").await.expect("bind s-2");
+
+    let renamed = store.rename(id, "renamed").await.expect("rename");
+    assert_eq!(renamed.name, "renamed");
+    assert_eq!(
+        renamed.session_ids,
+        vec!["s-1".to_string(), "s-2".to_string()],
+        "rename must not disturb existing session bindings"
+    );
+    assert_eq!(
+        store.active_workstream_id().await.expect("active"),
+        Some(id),
+        "rename must not disturb the active pointer"
+    );
+
+    // Binding still works after the rename, and persists across reload.
+    store.bind_session(id, "s-3").await.expect("bind s-3");
+    let mut reloaded = WorkstreamStore::load(store_file(&dir))
+        .await
+        .expect("reload");
+    let ws = reloaded.get(id).await.expect("get after reload");
+    assert_eq!(ws.name, "renamed");
+    assert_eq!(
+        ws.session_ids,
+        vec!["s-1".to_string(), "s-2".to_string(), "s-3".to_string()]
+    );
+}
+
 #[tokio::test]
 async fn store_reload_noop_when_unchanged() {
     let dir = TempDir::new().expect("tempdir");

--- a/crates/trusty-code/src/workstreams/store_tests.rs
+++ b/crates/trusty-code/src/workstreams/store_tests.rs
@@ -447,22 +447,3 @@ async fn bind_session_rejects_closed_workstream() {
         Err(BindError::Closed(_))
     ));
 }
-
-#[tokio::test]
-async fn find_binding_returns_owning_workstream() {
-    let dir = TempDir::new().expect("tempdir");
-    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
-    let id = store.create("A").await.expect("create");
-    store.bind_session(id, "s-1").await.expect("bind");
-
-    assert_eq!(store.find_binding("s-1").await.expect("find"), Some(id));
-}
-
-#[tokio::test]
-async fn find_binding_returns_none_for_unbound_session() {
-    let dir = TempDir::new().expect("tempdir");
-    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
-    store.create("A").await.expect("create");
-
-    assert_eq!(store.find_binding("s-nope").await.expect("find"), None);
-}


### PR DESCRIPTION
## Scope

Implements DOC-48 §4.1 (session binding at creation) and §4.2 (ambient active-workstream default targeting) for `session.create` and `task.run`, per issue #3298 (Phase 1B, epic #3292).

- **Binding write path**: `session.create`/`task.run` (mint path) resolve the effective workstream target — explicit `workstream_id` param wins (§4.1), else the daemon's active workstream is the ambient default (§4.2), else the session stays projectless (valid, never an error) — and persist the bind via `WorkstreamStore::bind_session`.
- **No double-binding** (§2): `WorkstreamStore::bind_session` rejects a session id already bound to a *different* workstream (`BindError::AlreadyBound`); idempotent if restating the same one.
- **Closed-workstream rejection** (§4.1/§4.4): binding to a closed workstream fails with `-32003 invalid_argument`.
- **Immutability** (§4.1, AC-1.3): `task.run` reusing an existing `session_id` with a `workstream_id` param that doesn't restate the session's own persisted binding is rejected — mirrors the existing `project` mismatch guard exactly (`crate::workstreams::protocol::check_workstream_immutable`).
- **New events** (§5.3): `Event::SessionAdded` (published via `SessionRegistry::bind_workstream`, carries both `session_id` and `workstream_id` — widened from the spec table's literal `{session_id, binding_time}` shape per the ticket's scope note) and `Event::SessionActivityUpdate` (published from `SessionRegistry::set_run_outcome`, the natural "a turn happened" hook). Both are session-scoped, so they flow through the existing per-session ring buffer/live bus with **zero changes needed** in `workstreams::sse::aggregate_live`'s dynamic per-event membership re-check (verified — that file was not touched, per the sibling #3299 ownership boundary).
- **REST/RPC param plumbing**: `workstream_id` added to `session.create`/`task.run` JSON-RPC params and their REST wrappers (`POST /sessions`, `POST /tasks`).

## Spec anchors

- SPEC-WS-04.1 (session binding rules), SPEC-WS-04.2 (ambient default target) — docs/specs/DOC-48-tcode-workstreams.md §4.1/§4.2
- SPEC-WS-02 (§2: at-most-one-workstream-per-session invariant)
- SPEC-WS-05.3 (event table: `SessionAdded`, `SessionActivityUpdate`)
- AC-1.3 (immutability rejection on mismatched reuse)

## Ambiguities resolved (with citations)

1. **Where a session's binding lives**: added `Session.workstream_id: Option<WorkstreamId>` (§2.1/§4.1 — set once at creation, immutable thereafter, mirroring `Session.binding`'s existing convention).
2. **`SessionAdded` payload shape**: widened beyond the spec table's literal `{session_id, binding_time}` to also carry `workstream_id`, per the task's explicit scope note ("SessionAdded should carry both workstream id and session id").
3. **`StoreError` vs a new `BindError`**: introduced a *separate* `BindError` enum for `WorkstreamStore::bind_session` rather than adding variants to `StoreError` — widening `StoreError` would have broken `workstreams::sse::map_store_err`'s exhaustive match, which is owned by the concurrent sibling ticket #3299 and out of this PR's file-ownership scope.
4. **Immutability on an unbound session**: an explicit `workstream_id` on `task.run` reuse of a session that was created *unbound* (`workstream_id: None`) is also rejected as a mismatch (not treated as a free late-bind) — consistent with the existing `project` binding's "authoritative once created" precedent (`task_run`'s docs, PR #3189 code-critic finding).

## Gates (raw tails)

`cargo check -p trusty-code`: clean.

`cargo clippy -p trusty-code --all-targets -- -D warnings`: clean.

`cargo fmt -p trusty-code --check`: clean.

`bash scripts/check_line_cap.sh`: `line-cap: 7 allowlisted, 0 violations — OK.`

`bash scripts/check_test_pointers.sh`: `test-pointers: 0 dangling pointers — OK.`

`bash scripts/check_sld.sh`: `sld-lint: scanned 38 spec doc(s) + 2605 code file(s); 0 error(s), 0 warning(s)`

`cargo test -p trusty-code --lib` (default parallel), excluding the pre-existing `run_task::` module (untouched by this PR — network-dependent on a local `trusty-memory` daemon at `127.0.0.1:7070` not reachable in this sandbox; confirmed flaky in isolation on `origin/main` too, unrelated to session/workstream code):
```
test result: ok. 1295 passed; 0 failed; 4 ignored; 0 measured; 58 filtered out
```

`cargo test -p trusty-code --lib -- --test-threads=1 --skip run_task::` (race guard):
```
test result: ok. 1295 passed; 0 failed; 4 ignored; 0 measured; 58 filtered out
```

Test count: 58 new/updated tests across `workstreams::store`, `workstreams::protocol`, `session::protocol` (workstream binding), `session::registry`, `task::protocol`, and `events`.

## File ownership note

Per the concurrent sibling ticket #3299 (attach/fan-out transport extraction to `trusty-agents-common`), `workstreams/sse.rs` and `crates/trusty-agents-common/**` were **not touched** — verified `SessionAdded`/`SessionActivityUpdate` reach the workstream SSE aggregation route with zero changes there, since both are ordinary per-session events published through `SessionRegistry::record`.

Part of #3292.

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)