### PR TITLE
feat(trusty-code-gui): GUI workstream switcher in header (closes #3300)

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -8,6 +8,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **GUI workstream switcher in the header (closes #3300, DOC-48 §8 Phase C,
+  DOC-39 §2/§8).** New `WorkstreamSwitcher.svelte` fills the reserved header
+  slot `AppHeader.svelte`/PR #3301 left as a disabled placeholder: a trigger
+  button showing the active workstream's name + state dot, opening a
+  dropdown that lists every workstream with an active indicator. Clicking a
+  non-active row activates it (`POST /workstreams/{id}/activate`,
+  `force: false`); a `409` (DOC-48 §6.1 `ActiveConflict` — another client
+  activated concurrently) surfaces an inline banner with a Refresh action
+  rather than silently retrying with `force: true`. Each row has inline
+  rename (text input, no `window.prompt()`) and close (two-step confirm, no
+  `window.confirm()` — mirrors `SessionMonitor.svelte`'s cancel action) —
+  close and rename call the new `workstream.close`/`workstream.rename`
+  REST routes. Polls `GET /workstreams` every 5s (same
+  `$effect`/`AbortController` shape as `StatusBar.svelte`) as the
+  authoritative source, plus an `EventSource` subscription to
+  `/workstreams/{active_id}/events` for a low-latency nudge on
+  `workstream_activation_changed`/`workstream_state_inferred` frames — a
+  latency optimization only; there is no daemon-wide "any workstream
+  changed" push channel today (a documented API gap, DOC-39 §2.1 C-2), so
+  polling never becomes secondary. New `lib/workstreams.ts` (wire types +
+  `fetchWorkstreams`/`activateWorkstream`/`closeWorkstream`/
+  `renameWorkstream` + pure helpers), unit tested in `workstreams.test.ts`;
+  component covered in `WorkstreamSwitcher.test.ts`. `AppHeader.svelte`
+  itself is otherwise unchanged — only the reserved slot's content was
+  filled in.
+
 ### Changed
 
 - Shell rebuild to the DOC-39 §8 Foundry skeleton (closes #3153). `App.svelte`

--- a/crates/trusty-code-gui/ui/src/components/AppHeader.svelte
+++ b/crates/trusty-code-gui/ui/src/components/AppHeader.svelte
@@ -2,28 +2,25 @@
   // Why: DOC-39 §2's "two nested scopes" framing (issue #3153 shell rebuild)
   // — the header is the OUTER "app context" scope: branding + the
   // workstream switcher, always present, rendering an empty or hydrated
-  // state (§4.4 AC-4.1). Phase 1 has no workstream registry yet (§6.3/7B —
-  // "single synthetic current session entry, no registry"), so the
-  // workstream box is a READ-ONLY label rather than a real switcher.
-  //
-  // DOC-48 reservation (PR #3284, tcode workstreams spec): a NEW spec
-  // reserves a workstream-switcher control slot in this exact header
-  // position per DOC-39 §2/§8. This component must not preclude that slot —
-  // it renders a disabled placeholder control next to the read-only label
-  // rather than omitting the affordance outright, so DOC-48's follow-up
-  // only needs to enable it, not carve out header space from scratch.
+  // state (§4.4 AC-4.1). Phase 1 shipped a READ-ONLY label + disabled `▾`
+  // placeholder here because "Phase 1 has no workstream registry yet"; DOC-48
+  // (epic #3292) built that registry, and its Phase C — issue #3300 — is the
+  // real switcher now mounted in the exact slot the placeholder reserved:
+  // `WorkstreamSwitcher.svelte` (state display, activation, close, rename;
+  // see its own module docs for the full design).
   //
   // Tokens/cost on the right is a compact GLOBAL readout (distinct from
   // `StatusBar.svelte`'s per-session TOKENS/COST segments) — both are stub
   // text today since live cost tracking is issue #3254, not yet shipped.
   //
-  // What: A `.hdr` flex row: brand mark + name on the left, the read-only
-  // workstream box + reserved switcher slot in the middle, tokens/cost stub
-  // + a disabled settings control on the right.
+  // What: A `.hdr` flex row: brand mark + name on the left, `WorkstreamSwitcher`
+  // in the middle, tokens/cost stub + a disabled settings control on the
+  // right.
   // Test: `App.test.ts` pins `.hdr` renders inside `.app` as the shell's
-  // first child (structural smoke coverage) — no dedicated
-  // `AppHeader.test.ts` exists yet since every value here is static Phase 1
-  // stub content, nothing pure/branchy to unit-test independently.
+  // first child (structural smoke coverage); `WorkstreamSwitcher.test.ts`
+  // covers the switcher itself — this component has no branchy logic of its
+  // own to test independently.
+  import WorkstreamSwitcher from './WorkstreamSwitcher.svelte';
 </script>
 
 <header
@@ -37,21 +34,7 @@
   </div>
 
   <div class="flex min-w-0 flex-1 items-center justify-center gap-1.5">
-    <span
-      class="truncate rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2.5 py-1 font-mono text-[11px] uppercase tracking-wide text-trusty-text-secondary"
-      title="Workstream switcher lands with DOC-48 (PR #3284) — Phase 1 shows the current workstream as a read-only label."
-    >
-      workstream: current session
-    </span>
-    <button
-      type="button"
-      disabled
-      aria-label="switch workstream"
-      title="Workstream switcher — reserved slot, DOC-48 (PR #3284), not yet built"
-      class="rounded-sm border-1.5 border-trusty-border bg-trusty-card px-1.5 py-1 font-mono text-[10px] text-trusty-text-muted disabled:cursor-not-allowed disabled:opacity-50"
-    >
-      ▾
-    </button>
+    <WorkstreamSwitcher />
   </div>
 
   <div class="flex items-center gap-3">

--- a/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.svelte
+++ b/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.svelte
@@ -25,6 +25,12 @@
   // push channel today (a real API gap: DOC-39 §2.1 C-2 — per-workstream SSE
   // requires already knowing which workstream to subscribe to), so polling
   // stays the AUTHORITATIVE source and SSE is purely a latency optimization.
+  // Every `refresh()` call is guarded by a monotonic sequence number
+  // (`requestSeq`, code-critic PR #3356 review MEDIUM 1) — the poll interval
+  // and an SSE-triggered refresh share one `AbortController`, so neither
+  // aborts the other, and a slow earlier call resolving AFTER a fresher
+  // later one must not clobber it; only the call that is still the MOST
+  // RECENTLY STARTED one by the time it resolves is allowed to commit.
   //
   // Renders a trigger button (state dot + name, `▾`) that opens a dropdown
   // panel listing every workstream with an active indicator. Clicking a
@@ -35,11 +41,18 @@
   // never silent, and DOC-48's own wording for this issue's scope is
   // "surface it, offer refresh"). Rename swaps a row into an inline
   // text-input edit (no `window.prompt()` — see `SessionMonitor.svelte`'s
-  // identical rationale). Close requires the same two-step in-row confirm
-  // `SessionMonitor.svelte`'s cancel action already establishes (no
-  // `window.confirm()`).
+  // identical rationale); allowed on a closed row too, matching the
+  // backend's `rename_closed_workstream_succeeds` contract (§4.4: closure
+  // only rejects new session bindings, never label edits). Close requires
+  // the same two-step in-row confirm `SessionMonitor.svelte`'s cancel action
+  // already establishes (no `window.confirm()`). `resetRowState()` clears
+  // every armed rename/close/conflict control at EVERY open-state
+  // transition (code-critic PR #3356 review, HIGH) — both `toggleOpen()`
+  // directions, the backdrop-dismiss button, and a successful activation —
+  // so an armed control can never survive a dismiss-and-reopen cycle.
   //
-  // Test: `WorkstreamSwitcher.test.ts` covers every phase/interaction;
+  // Test: `WorkstreamSwitcher.test.ts` covers every phase/interaction, the
+  // backdrop-dismiss row-state reset, and the out-of-order refresh guard;
   // `lib/workstreams.test.ts` covers the network/pure-logic layer this
   // component calls into; `App.test.ts` pins that `AppHeader` (and by
   // extension this component) mounts inside `.hdr`.
@@ -76,32 +89,48 @@
 
   let pollController: AbortController | null = null;
 
+  // Monotonic guard against out-of-order `refresh()` resolution (code-critic
+  // PR #3356 review, MEDIUM 1): the poll interval and the SSE-triggered
+  // refresh share one `AbortController`/signal, so neither call aborts the
+  // other — a slow earlier fetch (e.g. an interval tick) can resolve AFTER a
+  // later, fresher one (e.g. an SSE-triggered refresh right after a mutation)
+  // and clobber it with stale data. Every `refresh()` call stamps its own
+  // sequence number and only commits `list`/`phase`/`error` if it is still
+  // the MOST RECENTLY STARTED call by the time it resolves — an in-flight
+  // call that a newer one has since superseded silently drops its result
+  // instead of overwriting fresher state (the newer call already committed,
+  // or will).
+  let requestSeq = 0;
+
   function msg(e: unknown): string {
     return e instanceof Error ? e.message : String(e);
   }
 
   async function refresh(signal: AbortSignal) {
+    const seq = ++requestSeq;
+    const stale = () => signal.aborted || seq !== requestSeq;
+
     let base: string;
     try {
       base = await apiBase();
     } catch (e) {
-      if (!signal.aborted) {
+      if (!stale()) {
         phase = 'daemon-unreachable';
         list = null;
         error = msg(e);
       }
       return;
     }
-    if (signal.aborted) return;
+    if (stale()) return;
 
     try {
       const body = await fetchWorkstreams(base, signal);
-      if (signal.aborted) return;
+      if (stale()) return;
       list = body;
       phase = 'ready';
       error = null;
     } catch (e) {
-      if (!signal.aborted) {
+      if (!stale()) {
         phase = 'daemon-unreachable';
         list = null;
         error = msg(e);
@@ -177,13 +206,30 @@
     return 'bg-status-neutral';
   }
 
+  // Clears every armed per-row destructive/edit control (code-critic PR
+  // #3356 review, HIGH): rename-in-progress, close-confirm-armed, and any
+  // conflict banner. Called at EVERY open-state transition (both directions
+  // of `toggleOpen()`, the backdrop-dismiss button, and the post-activation
+  // success path in `onActivateClick`) — not just "closing via the trigger"
+  // — so a row armed via `closeConfirmId`/`renameId` can never survive a
+  // dismiss-and-reopen cycle (repro: open -> arm close on row B ->
+  // backdrop-dismiss -> reopen used to still show row B pre-armed).
+  function resetRowState() {
+    renameId = null;
+    renameDraft = '';
+    closeConfirmId = null;
+    conflictMessage = null;
+  }
+
   function toggleOpen() {
     if (phase !== 'ready' || !list || list.workstreams.length === 0) return;
     open = !open;
-    if (!open) {
-      renameId = null;
-      closeConfirmId = null;
-    }
+    resetRowState();
+  }
+
+  function closePanel() {
+    open = false;
+    resetRowState();
   }
 
   async function onActivateClick(w: Workstream) {
@@ -193,7 +239,7 @@
     try {
       const base = await apiBase();
       await activateWorkstream(base, w.id);
-      open = false;
+      closePanel();
       if (pollController) await refresh(pollController.signal);
     } catch (e) {
       if (e instanceof ActiveConflictError) {
@@ -274,7 +320,7 @@
       type="button"
       class="fixed inset-0 z-10 cursor-default"
       aria-label="close workstream switcher"
-      onclick={() => (open = false)}
+      onclick={closePanel}
     ></button>
 
     <div
@@ -354,7 +400,6 @@
                 type="button"
                 class="shrink-0 px-1 font-mono text-[11px] text-trusty-text-muted hover:text-trusty-primary disabled:cursor-not-allowed disabled:opacity-50"
                 aria-label={`rename ${workstreamLabel(w)}`}
-                disabled={w.state === 'closed'}
                 onclick={() => startRename(w)}
               >
                 ✎

--- a/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.svelte
+++ b/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.svelte
@@ -1,0 +1,379 @@
+<script lang="ts">
+  // Why: DOC-39 §2/§8 reserved this exact header slot (issue #3153 shell
+  // rebuild, PR #3301) — `AppHeader.svelte` shipped a read-only label plus a
+  // disabled `▾` placeholder because "Phase 1 has no workstream registry
+  // yet". DOC-48 (epic #3292) built that registry (domain model,
+  // persistence, activation-lock exclusivity — `crates/trusty-code/src/
+  // workstreams/`) and its Phase C explicitly scopes this component: state
+  // display, list view with an active indicator, activation (switch), close
+  // (confirm first), and rename — DOC-48 §8 "GUI workstream switcher"
+  // (issue #3300). This is that component filling the reserved slot;
+  // `AppHeader.svelte` itself is otherwise untouched.
+  //
+  // What: Polls `GET /workstreams` every `POLL_MS` (the same
+  // `$effect`/`AbortController`/`setInterval` shape `StatusBar.svelte`/
+  // `SessionMonitor.svelte` already establish — one controller for the
+  // whole mounted lifetime, `signal.aborted` re-checked after every
+  // `await`). A second `$effect` opens an `EventSource` on
+  // `/workstreams/{active_id}/events` whenever the polled
+  // `active_workstream_id` changes (DOC-48 §5.3) and calls `refresh()`
+  // immediately on any `workstream_activation_changed`/
+  // `workstream_state_inferred` frame (`lib/workstreams.ts::isActivationSignal`)
+  // for a low-latency update between poll ticks; it no-ops (falls back to
+  // the `POLL_MS` cadence alone) when `EventSource` is unavailable or no
+  // workstream is active — there is no daemon-wide "any workstream changed"
+  // push channel today (a real API gap: DOC-39 §2.1 C-2 — per-workstream SSE
+  // requires already knowing which workstream to subscribe to), so polling
+  // stays the AUTHORITATIVE source and SSE is purely a latency optimization.
+  //
+  // Renders a trigger button (state dot + name, `▾`) that opens a dropdown
+  // panel listing every workstream with an active indicator. Clicking a
+  // non-active row activates it (`workstream.activate{force: false}`,
+  // DOC-48 §6.1); a `409` (`ActiveConflictError` — someone else activated
+  // concurrently) shows an inline conflict banner with a Refresh action
+  // rather than silently retrying with `force: true` (an explicit switch is
+  // never silent, and DOC-48's own wording for this issue's scope is
+  // "surface it, offer refresh"). Rename swaps a row into an inline
+  // text-input edit (no `window.prompt()` — see `SessionMonitor.svelte`'s
+  // identical rationale). Close requires the same two-step in-row confirm
+  // `SessionMonitor.svelte`'s cancel action already establishes (no
+  // `window.confirm()`).
+  //
+  // Test: `WorkstreamSwitcher.test.ts` covers every phase/interaction;
+  // `lib/workstreams.test.ts` covers the network/pure-logic layer this
+  // component calls into; `App.test.ts` pins that `AppHeader` (and by
+  // extension this component) mounts inside `.hdr`.
+  import { apiBase } from '../lib/api-config';
+  import {
+    ActiveConflictError,
+    activateWorkstream,
+    closeWorkstream,
+    fetchWorkstreams,
+    isActivationSignal,
+    renameWorkstream,
+    workstreamLabel,
+    workstreamStateDotClass,
+    type Workstream,
+    type WorkstreamEventEnvelope,
+    type WorkstreamListResponse,
+  } from '../lib/workstreams';
+
+  const POLL_MS = 5000; // matches StatusBar.svelte's poll cadence
+
+  type Phase = 'connecting' | 'daemon-unreachable' | 'ready';
+
+  let phase = $state<Phase>('connecting');
+  let list = $state<WorkstreamListResponse | null>(null);
+  let error = $state<string | null>(null);
+  let open = $state(false);
+  let busyId = $state<string | null>(null);
+  let conflictMessage = $state<string | null>(null);
+  let renameId = $state<string | null>(null);
+  let renameDraft = $state('');
+  let renameBusy = $state(false);
+  let closeConfirmId = $state<string | null>(null);
+  let closeBusy = $state(false);
+
+  let pollController: AbortController | null = null;
+
+  function msg(e: unknown): string {
+    return e instanceof Error ? e.message : String(e);
+  }
+
+  async function refresh(signal: AbortSignal) {
+    let base: string;
+    try {
+      base = await apiBase();
+    } catch (e) {
+      if (!signal.aborted) {
+        phase = 'daemon-unreachable';
+        list = null;
+        error = msg(e);
+      }
+      return;
+    }
+    if (signal.aborted) return;
+
+    try {
+      const body = await fetchWorkstreams(base, signal);
+      if (signal.aborted) return;
+      list = body;
+      phase = 'ready';
+      error = null;
+    } catch (e) {
+      if (!signal.aborted) {
+        phase = 'daemon-unreachable';
+        list = null;
+        error = msg(e);
+      }
+    }
+  }
+
+  $effect(() => {
+    const controller = new AbortController();
+    pollController = controller;
+    void refresh(controller.signal);
+    const timer = setInterval(() => void refresh(controller.signal), POLL_MS);
+    return () => {
+      controller.abort();
+      if (pollController === controller) pollController = null;
+      clearInterval(timer);
+    };
+  });
+
+  // Re-subscribes only when the ACTIVE id itself changes (Svelte 5 tracks
+  // the primitive value read below, not every `list` refresh) — see the Why
+  // block above for why this is a latency optimization over polling, not
+  // the authoritative source.
+  $effect(() => {
+    const activeId = list?.active_workstream_id ?? null;
+    if (!activeId || typeof EventSource === 'undefined') return;
+
+    let source: EventSource | null = null;
+    let cancelled = false;
+
+    void (async () => {
+      let base: string;
+      try {
+        base = await apiBase();
+      } catch {
+        return;
+      }
+      if (cancelled) return;
+      source = new EventSource(`${base}/workstreams/${activeId}/events`);
+      source.onmessage = (e: MessageEvent<string>) => {
+        try {
+          const envelope = JSON.parse(e.data) as WorkstreamEventEnvelope;
+          if (isActivationSignal(envelope) && pollController) {
+            void refresh(pollController.signal);
+          }
+        } catch {
+          // Ignore a malformed SSE frame — the next poll tick self-heals.
+        }
+      };
+    })();
+
+    return () => {
+      cancelled = true;
+      source?.close();
+    };
+  });
+
+  let activeWorkstream = $derived(
+    list?.workstreams.find((w) => w.id === list?.active_workstream_id) ?? null,
+  );
+
+  function triggerLabel(): string {
+    if (phase === 'connecting') return 'connecting…';
+    if (phase === 'daemon-unreachable') return 'daemon unreachable';
+    if (!list || list.workstreams.length === 0) return 'no workstreams yet';
+    if (activeWorkstream) return workstreamLabel(activeWorkstream);
+    return 'no active workstream';
+  }
+
+  function triggerDotClass(): string {
+    if (phase !== 'ready') return 'bg-status-error';
+    if (activeWorkstream) return workstreamStateDotClass(activeWorkstream.state);
+    return 'bg-status-neutral';
+  }
+
+  function toggleOpen() {
+    if (phase !== 'ready' || !list || list.workstreams.length === 0) return;
+    open = !open;
+    if (!open) {
+      renameId = null;
+      closeConfirmId = null;
+    }
+  }
+
+  async function onActivateClick(w: Workstream) {
+    if (w.state === 'active' || w.state === 'closed' || busyId) return;
+    busyId = w.id;
+    conflictMessage = null;
+    try {
+      const base = await apiBase();
+      await activateWorkstream(base, w.id);
+      open = false;
+      if (pollController) await refresh(pollController.signal);
+    } catch (e) {
+      if (e instanceof ActiveConflictError) {
+        conflictMessage = 'another workstream was just activated — refresh to see the current one';
+      } else {
+        error = msg(e);
+      }
+    } finally {
+      busyId = null;
+    }
+  }
+
+  async function onRefreshConflict() {
+    conflictMessage = null;
+    if (pollController) await refresh(pollController.signal);
+  }
+
+  function startRename(w: Workstream) {
+    renameId = w.id;
+    renameDraft = w.name;
+    closeConfirmId = null;
+  }
+
+  function cancelRename() {
+    renameId = null;
+    renameDraft = '';
+  }
+
+  async function saveRename() {
+    if (!renameId || renameBusy) return;
+    const id = renameId;
+    renameBusy = true;
+    try {
+      const base = await apiBase();
+      await renameWorkstream(base, id, renameDraft.trim());
+      renameId = null;
+      if (pollController) await refresh(pollController.signal);
+    } catch (e) {
+      error = msg(e);
+    } finally {
+      renameBusy = false;
+    }
+  }
+
+  async function doClose(id: string) {
+    if (closeBusy) return;
+    closeBusy = true;
+    try {
+      const base = await apiBase();
+      await closeWorkstream(base, id);
+      closeConfirmId = null;
+      if (pollController) await refresh(pollController.signal);
+    } catch (e) {
+      error = msg(e);
+    } finally {
+      closeBusy = false;
+    }
+  }
+</script>
+
+<div class="wsswitch relative">
+  <button
+    type="button"
+    class="wsswitch-trigger flex items-center gap-1.5 truncate rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2.5 py-1 font-mono text-[11px] uppercase tracking-wide text-trusty-text-secondary disabled:cursor-not-allowed disabled:opacity-50"
+    disabled={phase !== 'ready' || !list || list.workstreams.length === 0}
+    aria-label="switch workstream"
+    aria-expanded={open}
+    title={error ?? 'switch workstream'}
+    onclick={toggleOpen}
+  >
+    <span class={`h-1.5 w-1.5 shrink-0 rounded-full ${triggerDotClass()}`}></span>
+    <span class="truncate">workstream: {triggerLabel()}</span>
+    <span class="text-trusty-text-muted">▾</span>
+  </button>
+
+  {#if open}
+    <button
+      type="button"
+      class="fixed inset-0 z-10 cursor-default"
+      aria-label="close workstream switcher"
+      onclick={() => (open = false)}
+    ></button>
+
+    <div
+      class="wsswitch-panel absolute left-1/2 top-full z-20 mt-1.5 w-72 -translate-x-1/2 rounded-sm border-1.5 border-trusty-border bg-trusty-raised p-1.5 shadow-lg"
+    >
+      {#if conflictMessage}
+        <div class="mb-1.5 flex items-center justify-between gap-2 rounded-sm bg-status-error/10 px-2 py-1.5 text-[11px] text-status-error">
+          <span>{conflictMessage}</span>
+          <button
+            type="button"
+            class="shrink-0 rounded-sm border-1.5 border-status-error px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide"
+            onclick={onRefreshConflict}
+          >
+            refresh
+          </button>
+        </div>
+      {/if}
+
+      {#each list?.workstreams ?? [] as w (w.id)}
+        <div class="wsswitch-row flex items-center gap-1 rounded-sm px-1.5 py-1.5 hover:bg-trusty-card">
+          {#if renameId === w.id}
+            <input
+              class="min-w-0 flex-1 rounded-sm border-1.5 border-trusty-primary bg-trusty-card px-1.5 py-0.5 font-mono text-[11px] text-trusty-text"
+              bind:value={renameDraft}
+              aria-label={`rename ${workstreamLabel(w)}`}
+            />
+            <button
+              type="button"
+              class="shrink-0 font-mono text-[10px] uppercase tracking-wide text-trusty-primary"
+              disabled={renameBusy}
+              onclick={saveRename}
+            >
+              save
+            </button>
+            <button
+              type="button"
+              class="shrink-0 font-mono text-[10px] uppercase tracking-wide text-trusty-text-muted"
+              disabled={renameBusy}
+              onclick={cancelRename}
+            >
+              cancel
+            </button>
+          {:else}
+            <button
+              type="button"
+              class="flex min-w-0 flex-1 items-center gap-1.5 truncate text-left font-mono text-[11px] text-trusty-text disabled:cursor-not-allowed disabled:opacity-60"
+              disabled={w.state === 'active' || w.state === 'closed' || busyId === w.id}
+              title={w.id}
+              onclick={() => onActivateClick(w)}
+            >
+              <span class={`h-1.5 w-1.5 shrink-0 rounded-full ${workstreamStateDotClass(w.state)}`}></span>
+              <span class="truncate">{workstreamLabel(w)}</span>
+              {#if w.state === 'active'}
+                <span class="shrink-0 text-trusty-primary">active</span>
+              {/if}
+            </button>
+
+            {#if closeConfirmId === w.id}
+              <button
+                type="button"
+                class="shrink-0 font-mono text-[10px] uppercase tracking-wide text-status-error"
+                disabled={closeBusy}
+                onclick={() => doClose(w.id)}
+              >
+                confirm
+              </button>
+              <button
+                type="button"
+                class="shrink-0 font-mono text-[10px] uppercase tracking-wide text-trusty-text-muted"
+                disabled={closeBusy}
+                onclick={() => (closeConfirmId = null)}
+              >
+                never mind
+              </button>
+            {:else}
+              <button
+                type="button"
+                class="shrink-0 px-1 font-mono text-[11px] text-trusty-text-muted hover:text-trusty-primary disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={`rename ${workstreamLabel(w)}`}
+                disabled={w.state === 'closed'}
+                onclick={() => startRename(w)}
+              >
+                ✎
+              </button>
+              <button
+                type="button"
+                class="shrink-0 px-1 font-mono text-[11px] text-trusty-text-muted hover:text-status-error disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={`close ${workstreamLabel(w)}`}
+                disabled={w.state === 'closed'}
+                onclick={() => (closeConfirmId = w.id)}
+              >
+                ×
+              </button>
+            {/if}
+          {/if}
+        </div>
+      {:else}
+        <p class="px-1.5 py-2 text-[11px] text-trusty-text-muted">no workstreams yet</p>
+      {/each}
+    </div>
+  {/if}
+</div>

--- a/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.test.ts
@@ -278,3 +278,125 @@ describe('WorkstreamSwitcher close', () => {
     expect(target.querySelector('.wsswitch-panel')?.textContent).toContain('Token rotation');
   });
 });
+
+// code-critic PR #3356 review, HIGH: `renameId`/`closeConfirmId` were only
+// cleared in `toggleOpen()`'s "closing" branch, so dismissing via the
+// backdrop (a DIFFERENT code path) — or a successful activation — left them
+// armed, and reopening never reset them. Repro: open -> arm close on row B
+// -> backdrop-dismiss -> reopen -> row B must show its normal icons again,
+// not a pre-armed "confirm / never mind".
+describe('WorkstreamSwitcher backdrop-dismiss resets armed row state (code-critic HIGH)', () => {
+  it('clears an armed close-confirm on backdrop-dismiss, so reopening shows normal icons', async () => {
+    const { fetchMock } = fakeDaemon(
+      [ws('ws-1', 'Token rotation', 'idle'), ws('ws-2', 'Schema migration', 'idle')],
+      'ws-1',
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(WorkstreamSwitcher, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => trigger().textContent?.includes('Token rotation') ?? false);
+
+    trigger().click();
+    flushSync();
+    const armCloseButton = Array.from(target.querySelectorAll('button')).find(
+      (b) => b.getAttribute('aria-label') === 'close Schema migration',
+    ) as HTMLButtonElement;
+    armCloseButton.click();
+    flushSync();
+    expect(target.textContent).toContain('never mind');
+
+    // Dismiss via the BACKDROP, not the trigger — the code path the HIGH
+    // finding says was missing the reset.
+    const backdrop = target.querySelector(
+      '[aria-label="close workstream switcher"]',
+    ) as HTMLButtonElement;
+    backdrop.click();
+    flushSync();
+    expect(target.querySelector('.wsswitch-panel')).toBeNull();
+
+    trigger().click();
+    flushSync();
+    const panel = target.querySelector('.wsswitch-panel') as HTMLElement;
+    expect(panel.textContent).not.toContain('never mind');
+    const closeButtonAfterReopen = Array.from(panel.querySelectorAll('button')).find(
+      (b) => b.getAttribute('aria-label') === 'close Schema migration',
+    );
+    expect(closeButtonAfterReopen).toBeTruthy();
+  });
+});
+
+// code-critic PR #3356 review, MEDIUM 1: the poll interval and an
+// SSE-triggered refresh share one `AbortController`, so neither aborts the
+// other — a slow EARLIER call can resolve AFTER a fresher LATER one and
+// overwrite it. This pins the monotonic-sequence guard: an interval tick
+// that resolves after a subsequent tick must not clobber the subsequent
+// tick's already-committed state.
+describe('WorkstreamSwitcher out-of-order refresh guard (code-critic MEDIUM 1)', () => {
+  function deferredResponse(): {
+    promise: Promise<Response>;
+    resolve: (r: Response) => void;
+  } {
+    let resolve!: (r: Response) => void;
+    const promise = new Promise<Response>((res) => {
+      resolve = res;
+    });
+    return { promise, resolve };
+  }
+
+  it('a slow, earlier poll response must not overwrite a fresher, later one', async () => {
+    vi.useFakeTimers();
+    try {
+      const stale = deferredResponse();
+      const fresh = deferredResponse();
+      let call = 0;
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (!url.endsWith('/workstreams')) throw new Error(`unexpected fetch: ${url}`);
+        call += 1;
+        return call === 1 ? stale.promise : fresh.promise;
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      instance = mount(WorkstreamSwitcher, { target }) as unknown as Record<string, unknown>;
+
+      // Flush the initial mount `$effect`: issues the FIRST request, which
+      // stays pending (not yet resolved).
+      await vi.advanceTimersByTimeAsync(0);
+      expect(call).toBe(1);
+      expect(trigger().textContent).toContain('connecting');
+
+      // Advance past POLL_MS (5000ms) to fire the interval's SECOND request
+      // while the first is still in flight.
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(call).toBe(2);
+
+      // The SECOND (later-started) request resolves FIRST, with fresh data.
+      fresh.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          active_workstream_id: 'ws-2',
+          workstreams: [ws('ws-2', 'Fresh workstream', 'active')],
+        }),
+      } as Response);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(trigger().textContent).toContain('Fresh workstream');
+
+      // The FIRST (earlier-started) request finally resolves, late, with
+      // stale data — it must NOT clobber the fresher state already shown.
+      stale.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          active_workstream_id: 'ws-1',
+          workstreams: [ws('ws-1', 'Stale workstream', 'active')],
+        }),
+      } as Response);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(trigger().textContent).toContain('Fresh workstream');
+      expect(trigger().textContent).not.toContain('Stale workstream');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.test.ts
@@ -1,0 +1,280 @@
+// Why: `WorkstreamSwitcher.svelte` is the Phase C GUI switcher (DOC-48 §8,
+// issue #3300) filling the header slot `AppHeader.svelte`/PR #3301 reserved.
+// This covers every phase and interaction the component's own module docs
+// describe: state display, the dropdown list with an active indicator,
+// activation (including the `409` conflict banner), rename, and close —
+// mirroring `SessionMonitor.test.ts`'s "mount the real component, stub
+// fetch, `waitFor` the settled DOM" approach, since this component shares
+// its polling shape.
+// What: A small in-memory fake daemon (`fakeDaemon`) backs a stubbed global
+// `fetch`, so activate/rename/close calls actually mutate what the next
+// `GET /workstreams` poll returns — real state transitions, not just "was
+// the right URL called".
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import WorkstreamSwitcher from './WorkstreamSwitcher.svelte';
+import type { Workstream } from '../lib/workstreams';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+function ws(id: string, name: string, state: Workstream['state']): Workstream {
+  return {
+    id,
+    name,
+    state,
+    session_ids: [],
+    created_at: '2026-07-19T14:00:00Z',
+    updated_at: '2026-07-19T14:00:00Z',
+    metadata: {},
+  };
+}
+
+/** A minimal in-memory fake of the `/workstreams*` REST surface. */
+function fakeDaemon(initial: Workstream[], activeId: string | null = null) {
+  const records = new Map(initial.map((w) => [w.id, { ...w }]));
+  let active = activeId;
+  let conflictOnNextActivate = false;
+
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? 'GET';
+
+    if (url.endsWith('/workstreams') && method === 'GET') {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          active_workstream_id: active,
+          // `fetchWorkstreams` never sends `include_closed` -> the real
+          // server's `workstream.list` default (`false`) applies, so a
+          // closed record must drop out of this response, matching
+          // `crate::workstreams::protocol::list`'s filter.
+          workstreams: Array.from(records.values())
+            .map((r) => ({
+              ...r,
+              state: r.id === active ? 'active' : r.state === 'closed' ? 'closed' : 'idle',
+            }))
+            .filter((r) => r.state !== 'closed'),
+        }),
+      } as Response;
+    }
+
+    const activateMatch = url.match(/\/workstreams\/([^/]+)\/activate$/);
+    if (activateMatch && method === 'POST') {
+      if (conflictOnNextActivate) {
+        conflictOnNextActivate = false;
+        return { ok: false, status: 409, json: async () => ({}) } as Response;
+      }
+      active = activateMatch[1];
+      return { ok: true, status: 200, json: async () => ({ active_id: active, prior_id: null }) } as Response;
+    }
+
+    const closeMatch = url.match(/\/workstreams\/([^/]+)\/close$/);
+    if (closeMatch && method === 'POST') {
+      const record = records.get(closeMatch[1]);
+      if (record) record.state = 'closed';
+      if (active === closeMatch[1]) active = null;
+      return { ok: true, status: 200, json: async () => ({}) } as Response;
+    }
+
+    const renameMatch = url.match(/\/workstreams\/([^/]+)\/rename$/);
+    if (renameMatch && method === 'POST') {
+      const record = records.get(renameMatch[1]);
+      const body = JSON.parse(String(init?.body ?? '{}')) as { name: string };
+      if (record) record.name = body.name;
+      return { ok: true, status: 200, json: async () => record } as Response;
+    }
+
+    throw new Error(`unexpected fetch: ${method} ${url}`);
+  });
+
+  return {
+    fetchMock,
+    forceConflictOnNextActivate: () => {
+      conflictOnNextActivate = true;
+    },
+  };
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+  vi.unstubAllGlobals();
+});
+
+function trigger(): HTMLButtonElement {
+  return target.querySelector('.wsswitch-trigger') as HTMLButtonElement;
+}
+
+describe('WorkstreamSwitcher phases', () => {
+  it('renders "daemon unreachable" when the daemon cannot be reached', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    instance = mount(WorkstreamSwitcher, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => trigger().textContent?.includes('daemon unreachable') ?? false);
+    expect(trigger().disabled).toBe(true);
+  });
+
+  it('renders "no workstreams yet" and a disabled trigger when the daemon has none', async () => {
+    const { fetchMock } = fakeDaemon([]);
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(WorkstreamSwitcher, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => trigger().textContent?.includes('no workstreams yet') ?? false);
+    expect(trigger().disabled).toBe(true);
+  });
+
+  it('shows the active workstream\'s name in the trigger', async () => {
+    const { fetchMock } = fakeDaemon(
+      [ws('ws-1', 'Token rotation', 'idle'), ws('ws-2', 'Schema migration', 'idle')],
+      'ws-1',
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(WorkstreamSwitcher, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => trigger().textContent?.includes('Token rotation') ?? false);
+    expect(trigger().disabled).toBe(false);
+  });
+});
+
+describe('WorkstreamSwitcher dropdown + activation', () => {
+  it('lists every workstream with an active indicator and activates a clicked row', async () => {
+    const { fetchMock } = fakeDaemon(
+      [ws('ws-1', 'Token rotation', 'idle'), ws('ws-2', 'Schema migration', 'idle')],
+      'ws-1',
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(WorkstreamSwitcher, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => trigger().textContent?.includes('Token rotation') ?? false);
+
+    trigger().click();
+    flushSync();
+
+    const panel = target.querySelector('.wsswitch-panel') as HTMLElement;
+    expect(panel).toBeTruthy();
+    expect(panel.textContent).toContain('Token rotation');
+    expect(panel.textContent).toContain('Schema migration');
+    expect(panel.textContent).toContain('active');
+
+    const rows = Array.from(panel.querySelectorAll('.wsswitch-row'));
+    const schemaRow = rows.find((r) => r.textContent?.includes('Schema migration'));
+    const activateButton = schemaRow?.querySelector('button') as HTMLButtonElement;
+    activateButton.click();
+
+    await waitFor(() => trigger().textContent?.includes('Schema migration') ?? false);
+  });
+
+  it('shows a conflict banner with a Refresh action on a 409, without auto-forcing', async () => {
+    const daemon = fakeDaemon(
+      [ws('ws-1', 'Token rotation', 'idle'), ws('ws-2', 'Schema migration', 'idle')],
+      'ws-1',
+    );
+    daemon.forceConflictOnNextActivate();
+    vi.stubGlobal('fetch', daemon.fetchMock);
+    instance = mount(WorkstreamSwitcher, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => trigger().textContent?.includes('Token rotation') ?? false);
+
+    trigger().click();
+    flushSync();
+    const panel = target.querySelector('.wsswitch-panel') as HTMLElement;
+    const rows = Array.from(panel.querySelectorAll('.wsswitch-row'));
+    const schemaRow = rows.find((r) => r.textContent?.includes('Schema migration'));
+    (schemaRow?.querySelector('button') as HTMLButtonElement).click();
+
+    await waitFor(() => target.textContent?.includes('refresh to see the current one') ?? false);
+    // Still shows the original active workstream — no silent force-switch.
+    expect(trigger().textContent).toContain('Token rotation');
+
+    const refreshButton = Array.from(target.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'refresh',
+    ) as HTMLButtonElement;
+    refreshButton.click();
+    await waitFor(() => !target.textContent?.includes('refresh to see the current one'));
+  });
+});
+
+describe('WorkstreamSwitcher rename', () => {
+  it('renames a workstream via the inline edit control', async () => {
+    const { fetchMock } = fakeDaemon([ws('ws-1', 'Token rotation', 'idle')], 'ws-1');
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(WorkstreamSwitcher, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => trigger().textContent?.includes('Token rotation') ?? false);
+
+    trigger().click();
+    flushSync();
+    const renameButton = Array.from(target.querySelectorAll('button')).find(
+      (b) => b.getAttribute('aria-label') === 'rename Token rotation',
+    ) as HTMLButtonElement;
+    renameButton.click();
+    flushSync();
+
+    const input = target.querySelector('.wsswitch-panel input') as HTMLInputElement;
+    expect(input).toBeTruthy();
+    input.value = 'Token rotation v2';
+    input.dispatchEvent(new Event('input'));
+    flushSync();
+
+    const saveButton = Array.from(target.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'save',
+    ) as HTMLButtonElement;
+    saveButton.click();
+
+    await waitFor(() => trigger().textContent?.includes('Token rotation v2') ?? false);
+  });
+});
+
+describe('WorkstreamSwitcher close', () => {
+  it('requires a two-step confirm before closing (no window.confirm)', async () => {
+    const { fetchMock } = fakeDaemon(
+      [ws('ws-1', 'Token rotation', 'idle'), ws('ws-2', 'Schema migration', 'idle')],
+      'ws-1',
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(WorkstreamSwitcher, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => trigger().textContent?.includes('Token rotation') ?? false);
+
+    trigger().click();
+    flushSync();
+    const closeButton = Array.from(target.querySelectorAll('button')).find(
+      (b) => b.getAttribute('aria-label') === 'close Schema migration',
+    ) as HTMLButtonElement;
+    closeButton.click();
+    flushSync();
+
+    expect(target.textContent).toContain('confirm');
+    expect(target.textContent).toContain('never mind');
+
+    const confirmButton = Array.from(target.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'confirm',
+    ) as HTMLButtonElement;
+    confirmButton.click();
+
+    // The panel stays open across the post-close `refresh()` — a closed
+    // workstream drops out of the next `GET /workstreams` response (server
+    // default `include_closed=false`), so its row must disappear from the
+    // still-open panel without the operator re-toggling anything.
+    await waitFor(
+      () => !(target.querySelector('.wsswitch-panel') as HTMLElement)?.textContent?.includes('Schema migration'),
+    );
+    expect(target.querySelector('.wsswitch-panel')?.textContent).toContain('Token rotation');
+  });
+});

--- a/crates/trusty-code-gui/ui/src/lib/workstreams.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/workstreams.test.ts
@@ -1,0 +1,170 @@
+// Why: `lib/workstreams.ts` carries every network call and pure
+// formatting/decision rule `WorkstreamSwitcher.svelte` depends on —
+// covering it here means those wire-shape and error-mapping invariants
+// (`409` -> `ActiveConflictError`, no auto-force-retry) are checked without
+// mounting Svelte, mirroring `create-session.test.ts`'s split.
+// What: One `describe` block per exported function; network calls are
+// exercised against a stubbed global `fetch` (`vi.stubGlobal`), matching
+// `App.test.ts`'s existing stubbing convention for this crate.
+// Test: this file.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  ActiveConflictError,
+  activateWorkstream,
+  closeWorkstream,
+  fetchWorkstreams,
+  isActivationSignal,
+  renameWorkstream,
+  workstreamLabel,
+  workstreamStateDotClass,
+  type Workstream,
+  type WorkstreamListResponse,
+} from './workstreams';
+
+const BASE = 'http://127.0.0.1:7881';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function ws(overrides: Partial<Workstream> = {}): Workstream {
+  return {
+    id: 'ws-1',
+    name: 'Token rotation hardening',
+    state: 'idle',
+    session_ids: [],
+    created_at: '2026-07-19T14:32:00Z',
+    updated_at: '2026-07-19T14:32:00Z',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('fetchWorkstreams', () => {
+  it('GETs /workstreams and returns the parsed envelope', async () => {
+    const body: WorkstreamListResponse = { active_workstream_id: 'ws-1', workstreams: [ws()] };
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => body });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchWorkstreams(BASE);
+    expect(result).toEqual(body);
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE}/workstreams`, { signal: undefined });
+  });
+
+  it('throws on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    await expect(fetchWorkstreams(BASE)).rejects.toThrow('HTTP 503');
+  });
+});
+
+describe('activateWorkstream', () => {
+  it('POSTs {force: false} to /workstreams/{id}/activate', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await activateWorkstream(BASE, 'ws-1');
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE}/workstreams/ws-1/activate`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ force: false }),
+      }),
+    );
+  });
+
+  it('throws ActiveConflictError on 409 (DOC-48 §6.1), never auto-retries with force', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 409 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(activateWorkstream(BASE, 'ws-1')).rejects.toBeInstanceOf(ActiveConflictError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws a plain error on any other non-ok status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    await expect(activateWorkstream(BASE, 'missing')).rejects.toThrow('HTTP 404');
+  });
+});
+
+describe('closeWorkstream', () => {
+  it('POSTs to /workstreams/{id}/close with no body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await closeWorkstream(BASE, 'ws-1');
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE}/workstreams/ws-1/close`, { method: 'POST' });
+  });
+
+  it('throws on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    await expect(closeWorkstream(BASE, 'missing')).rejects.toThrow('HTTP 404');
+  });
+});
+
+describe('renameWorkstream', () => {
+  it('POSTs {name} and returns the updated record', async () => {
+    const updated = ws({ name: 'renamed' });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => updated });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await renameWorkstream(BASE, 'ws-1', 'renamed');
+    expect(result).toEqual(updated);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE}/workstreams/ws-1/rename`,
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ name: 'renamed' }) }),
+    );
+  });
+
+  it('throws on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+    await expect(renameWorkstream(BASE, 'missing', 'x')).rejects.toThrow('HTTP 404');
+  });
+});
+
+describe('workstreamLabel', () => {
+  it('returns the name when non-blank', () => {
+    expect(workstreamLabel(ws({ name: 'Token rotation' }))).toBe('Token rotation');
+  });
+
+  it('falls back to a placeholder for an empty or whitespace-only name', () => {
+    expect(workstreamLabel(ws({ name: '' }))).toBe('(untitled workstream)');
+    expect(workstreamLabel(ws({ name: '   ' }))).toBe('(untitled workstream)');
+  });
+});
+
+describe('workstreamStateDotClass', () => {
+  it('maps each state to a distinct status-dot class', () => {
+    expect(workstreamStateDotClass('active')).toBe('bg-status-ok');
+    expect(workstreamStateDotClass('idle')).toBe('bg-status-warn');
+    expect(workstreamStateDotClass('closed')).toBe('bg-status-neutral');
+  });
+});
+
+describe('isActivationSignal', () => {
+  it('is true for workstream_activation_changed and workstream_state_inferred', () => {
+    expect(
+      isActivationSignal({
+        session_id: '',
+        event_type: 'workstream_activation_changed',
+        payload: { type: 'workstream_activation_changed', new_active_id: 'ws-2', prior_id: 'ws-1' },
+      }),
+    ).toBe(true);
+    expect(
+      isActivationSignal({
+        session_id: '',
+        event_type: 'workstream_state_inferred',
+        payload: { type: 'workstream_state_inferred', workstream_id: 'ws-1', state: 'closed' },
+      }),
+    ).toBe(true);
+  });
+
+  it('is false for any other event type (e.g. a session-scoped event)', () => {
+    expect(
+      isActivationSignal({
+        session_id: 'sess-1',
+        event_type: 'session_activity_update',
+        payload: { type: 'session_activity_update' },
+      }),
+    ).toBe(false);
+  });
+});

--- a/crates/trusty-code-gui/ui/src/lib/workstreams.ts
+++ b/crates/trusty-code-gui/ui/src/lib/workstreams.ts
@@ -1,0 +1,200 @@
+// Why: DOC-39 §2/§8 reserve a workstream-switcher control slot in
+// `AppHeader.svelte` (issue #3153 shell rebuild, PR #3301) that Phase 1
+// left as a disabled placeholder because "Phase 1 has no workstream
+// registry yet". DOC-48 (issue #3292) built that registry — domain model,
+// persistence, activation-lock exclusivity, and the `workstream.*`
+// RPC/REST surface (`crates/trusty-code/src/workstreams/`,
+// `crate::serve::rest::workstreams`) — and explicitly deferred "GUI
+// workstream switcher" to Phase C (DOC-48 §8), this issue (#3300). This
+// module is the wire-shape + transport layer `WorkstreamSwitcher.svelte`
+// is built on, split out the same way `session-status.ts`/
+// `context-budget.ts` split transport/pure-logic from their components.
+//
+// What: `Workstream`/`WorkstreamListResponse` mirror
+// `crate::workstreams::protocol::WorkstreamView` and `workstream.list`'s
+// response shape field-for-field. `fetchWorkstreams`/`activateWorkstream`/
+// `closeWorkstream`/`renameWorkstream` are thin `fetch()` wrappers over the
+// unprefixed `/workstreams*` REST routes (`crate::serve::rest::workstreams`,
+// DOC-48 §5.2) — no local caching, no derived state (DOC-39 §2.1 C-1). Every
+// other `lib/*.ts` module in this crate (`session-status.ts`,
+// `context-budget.ts`, `search-audit.ts`) leaves `fetch()` calls inline in
+// the component and only extracts pure parsing/formatting logic; this
+// module goes one step further and extracts the calls themselves, because
+// the switcher is the first component with FOUR distinct network
+// operations (list/activate/close/rename) plus an SSE subscription —
+// worth making each one independently testable (`workstreams.test.ts`)
+// rather than mockable only by mounting the full component.
+//
+// `ActiveConflictError` surfaces the `409` `workstream.activate` returns
+// when a DIFFERENT workstream is already active (DOC-48 §6.1). Its wire
+// body's `error.data.active_id` is NOT available here: `respond()`
+// (`crate::serve::rest::mod::respond`) deliberately drops `data` from every
+// REST error envelope, a pre-existing, documented choice this ticket does
+// not change (widening it would affect every REST error path, not just
+// this one route) — so the conflict UI can say "someone else activated a
+// workstream", never name which one by id/name. `activateWorkstream` does
+// NOT auto-retry with `force: true`; DOC-48 §6.1 calls activation "an
+// EXPLICIT switch, never silent" and this issue's scope says "surface it,
+// offer refresh" — never a silent force override.
+//
+// Test: `workstreams.test.ts`.
+
+/** Mirrors `crate::workstreams::model::WorkstreamState` (`#[serde(rename_all
+ * = "snake_case")]`). */
+export type WorkstreamState = 'active' | 'idle' | 'closed';
+
+/** Mirrors `crate::workstreams::protocol::WorkstreamView` field-for-field —
+ * the shape `workstream.get`/`workstream.list`/`workstream.rename` all
+ * return for one record. */
+export interface Workstream {
+  id: string;
+  name: string;
+  state: WorkstreamState;
+  session_ids: string[];
+  created_at: string;
+  updated_at: string;
+  metadata: Record<string, unknown>;
+}
+
+/** `GET /workstreams` response envelope (DOC-48 §5.1 `workstream.list`). */
+export interface WorkstreamListResponse {
+  active_workstream_id: string | null;
+  workstreams: Workstream[];
+}
+
+/**
+ * Thrown by [`activateWorkstream`] on a real HTTP `409` — DOC-48 §6.1's
+ * activation-lock exclusivity model: a DIFFERENT workstream is already
+ * active and this call did not pass `force: true`.
+ * Test: `workstreams.test.ts::activateWorkstream throws ActiveConflictError on 409`.
+ */
+export class ActiveConflictError extends Error {
+  constructor() {
+    super('another workstream is already active');
+    this.name = 'ActiveConflictError';
+  }
+}
+
+/**
+ * `GET /workstreams` (default `include_closed=false`, matching the
+ * server-side default DOC-48 §5.1 documents — a closed workstream is not a
+ * switch target).
+ * Test: `workstreams.test.ts::fetchWorkstreams`.
+ */
+export async function fetchWorkstreams(
+  base: string,
+  signal?: AbortSignal,
+): Promise<WorkstreamListResponse> {
+  const res = await fetch(`${base}/workstreams`, { signal });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as WorkstreamListResponse;
+}
+
+/**
+ * `POST /workstreams/{id}/activate` with `force: false` — always an
+ * explicit, non-forcing switch (see module docs for why this never
+ * auto-retries with `force: true`).
+ * Test: `workstreams.test.ts::activateWorkstream`.
+ */
+export async function activateWorkstream(base: string, id: string): Promise<void> {
+  const res = await fetch(`${base}/workstreams/${id}/activate`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ force: false }),
+  });
+  if (res.status === 409) throw new ActiveConflictError();
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}
+
+/**
+ * `POST /workstreams/{id}/close` — irreversible (DOC-48 §4.4); the caller
+ * is responsible for the two-step confirm UI, not this function.
+ * Test: `workstreams.test.ts::closeWorkstream`.
+ */
+export async function closeWorkstream(base: string, id: string): Promise<void> {
+  const res = await fetch(`${base}/workstreams/${id}/close`, { method: 'POST' });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+}
+
+/**
+ * `POST /workstreams/{id}/rename` -> the updated [`Workstream`] (issue
+ * #3300, Phase C — the one verb DOC-48 §5.1 shipped alongside its first
+ * caller rather than in Phase 1A).
+ * Test: `workstreams.test.ts::renameWorkstream`.
+ */
+export async function renameWorkstream(
+  base: string,
+  id: string,
+  name: string,
+): Promise<Workstream> {
+  const res = await fetch(`${base}/workstreams/${id}/rename`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return (await res.json()) as Workstream;
+}
+
+/**
+ * Display label for a workstream whose `name` is empty — `workstream.create`
+ * defaults `name` to `""` when the caller omits it (DOC-48 §5.1), and an
+ * empty button/row label is not a usable affordance.
+ * What: the record's `name` if non-blank (after trimming whitespace),
+ * otherwise `"(untitled workstream)"`.
+ * Test: `workstreams.test.ts::workstreamLabel`.
+ */
+export function workstreamLabel(ws: Pick<Workstream, 'name'>): string {
+  const trimmed = ws.name.trim();
+  return trimmed.length > 0 ? trimmed : '(untitled workstream)';
+}
+
+/**
+ * Status-dot Tailwind class for a workstream's [`WorkstreamState`] — reuses
+ * the same `bg-status-*` token set `StatusBar.svelte`/`SessionMonitor.svelte`
+ * already establish (`ok` = green settled, `warn` = amber in-progress,
+ * `neutral` = closed/inactive).
+ * Test: `workstreams.test.ts::workstreamStateDotClass`.
+ */
+export function workstreamStateDotClass(state: WorkstreamState): string {
+  switch (state) {
+    case 'active':
+      return 'bg-status-ok';
+    case 'idle':
+      return 'bg-status-warn';
+    case 'closed':
+    default:
+      return 'bg-status-neutral';
+  }
+}
+
+/**
+ * The wire envelope one `GET /workstreams/{id}/events` SSE frame carries
+ * (mirrors `crate::workstreams::sse::WorkstreamEventEnvelope` field-for-
+ * field). `payload` is left as a loosely-typed record — this module only
+ * needs `payload.type` to decide whether to trigger a re-fetch (see
+ * `isActivationSignal`), not the full `crate::events::Event` union.
+ */
+export interface WorkstreamEventEnvelope {
+  session_id: string;
+  event_type: string;
+  payload: { type: string; [key: string]: unknown };
+}
+
+/**
+ * Whether a decoded SSE envelope is one the switcher must react to by
+ * re-fetching `GET /workstreams` — `workstream_activation_changed` (the
+ * daemon-wide active pointer moved) or `workstream_state_inferred` (this
+ * workstream's own computed state changed, e.g. it was closed by another
+ * client).
+ * Why: extracted as a pure predicate so the SSE `onmessage` handler in
+ * `WorkstreamSwitcher.svelte` has nothing to unit-test around — the
+ * component only calls `refresh()` when this returns `true`.
+ * Test: `workstreams.test.ts::isActivationSignal`.
+ */
+export function isActivationSignal(envelope: WorkstreamEventEnvelope): boolean {
+  return (
+    envelope.payload.type === 'workstream_activation_changed' ||
+    envelope.payload.type === 'workstream_state_inferred'
+  );
+}

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`workstream.rename` RPC + REST verb (issue #3300, DOC-48 §5.1, Phase C).**
+  `workstream.rename{id, name} -> Workstream` overwrites a workstream's name
+  and refreshes `updated_at`; `-32002 not_found` for an unknown `id`. REST
+  twin: `POST /workstreams/{id}/rename` (JSON body `{"name": string}`),
+  mapped `404` for the same case. Renaming a closed workstream is allowed —
+  closure only rejects new session bindings (§4.4), not label edits. DOC-48
+  §5.1 marked this verb "future, Phase C" when Phase 1A shipped; this is
+  that phase's first caller, the GUI workstream switcher.
 - **`tcode workstream` / `tcode ws` CLI family (issue #3296, DOC-48 §5.4,
   epic #3292).** `list [--include-closed]` (tmux-`list-sessions`-style
   table: id prefix, state, session count, humanized age, name — `*` marks

--- a/crates/trusty-code/src/serve/rest/workstreams.rs
+++ b/crates/trusty-code/src/serve/rest/workstreams.rs
@@ -37,6 +37,10 @@
 //!   - `POST /workstreams/{id}/deactivate` -> `workstream.deactivate{id}`
 //!     (no body, mirroring `super::sessions_write`'s `POST
 //!     /sessions/{id}/cancel`)
+//!   - `POST /workstreams/{id}/rename` -> `workstream.rename{id, name}`
+//!     (JSON body `{"name": string}`, issue #3300, Phase C — DOC-48 §5.1
+//!     marked this verb "future, Phase C" when Phase 1A shipped; this is
+//!     that phase)
 //!
 //! `crate::serve::http::build_axum_router` merges this into the daemon's main
 //! router alongside `POST /rpc`, `GET /health`, and the other REST resource
@@ -87,6 +91,7 @@ pub fn routes(router: Arc<Router>) -> AxumRouter {
         .route("/workstreams/{id}/close", post(close_workstream))
         .route("/workstreams/{id}/activate", post(activate))
         .route("/workstreams/{id}/deactivate", post(deactivate))
+        .route("/workstreams/{id}/rename", post(rename))
         .with_state(WorkstreamsState { router })
 }
 
@@ -113,6 +118,13 @@ struct ListQuery {
 struct ActivateBody {
     #[serde(default)]
     force: bool,
+}
+
+/// Request body for `POST /workstreams/{id}/rename` — `id` comes from the
+/// path, so only `name` remains.
+#[derive(Deserialize)]
+struct RenameBody {
+    name: String,
 }
 
 /// Like [`super::respond`] but reports `201 Created` on success — the one
@@ -236,6 +248,27 @@ async fn activate(
 /// Test: `tests::deactivate_returns_200_empty_object`.
 async fn deactivate(State(state): State<WorkstreamsState>, Path(id): Path<String>) -> RestResult {
     respond(&state.router, "workstream.deactivate", json!({"id": id})).await
+}
+
+/// `POST /workstreams/{id}/rename` -> `workstream.rename`.
+///
+/// Why: the REST entry point for the GUI switcher's rename action (issue
+/// #3300, Phase C).
+/// What: `200` with the updated `Workstream` JSON on success; `404` for an
+/// unknown `id`.
+/// Test: `tests::rename_returns_200_with_updated_name`,
+/// `tests::rename_missing_returns_404`.
+async fn rename(
+    State(state): State<WorkstreamsState>,
+    Path(id): Path<String>,
+    Json(body): Json<RenameBody>,
+) -> RestResult {
+    respond(
+        &state.router,
+        "workstream.rename",
+        json!({"id": id, "name": body.name}),
+    )
+    .await
 }
 
 #[cfg(test)]
@@ -499,5 +532,37 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert_eq!(v, json!({}));
+    }
+
+    /// Renaming must return `200` with the updated `name` (issue #3300).
+    #[tokio::test]
+    async fn rename_returns_200_with_updated_name() {
+        let (app, id, _dir) = app_and_id().await;
+
+        let resp = post(
+            &app,
+            &format!("/workstreams/{id}/rename"),
+            r#"{"name": "renamed"}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert_eq!(v["name"], "renamed");
+    }
+
+    /// Renaming an unknown id must return a real HTTP `404`.
+    #[tokio::test]
+    async fn rename_missing_returns_404() {
+        let app = app().await;
+
+        let resp = post(
+            &app,
+            "/workstreams/00000000-0000-0000-0000-000000000000/rename",
+            r#"{"name": "renamed"}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let v = body_json(resp).await;
+        assert_eq!(v["error"]["code"], -32002);
     }
 }

--- a/crates/trusty-code/src/workstreams/protocol.rs
+++ b/crates/trusty-code/src/workstreams/protocol.rs
@@ -26,8 +26,9 @@
 //!
 //! What: [`register`] wires `workstream.create`, `workstream.get`,
 //! `workstream.list`, `workstream.close`, `workstream.activate`,
-//! `workstream.deactivate` onto a [`crate::jsonrpc::Router`], all sharing one
-//! [`SharedWorkstreamStore`]. Every verb that takes a wire `id` parses it via
+//! `workstream.deactivate`, `workstream.rename` (Phase C, issue #3300) onto
+//! a [`crate::jsonrpc::Router`], all sharing one [`SharedWorkstreamStore`].
+//! Every verb that takes a wire `id` parses it via
 //! [`parse_id`] (a manual `Uuid::parse_str` + `-32602 Invalid params` on
 //! failure) rather than deserializing straight into a [`WorkstreamId`] —
 //! chosen as the ONE id-parsing style for this file since #3294 landed it
@@ -103,12 +104,21 @@ pub fn register(router: &mut Router, store: SharedWorkstreamStore) {
         },
     );
 
-    let s = store;
+    let s = store.clone();
     router.register(
         "workstream.deactivate",
         move |params: Value, ctx: ConnectionContext| {
             let s = s.clone();
             async move { deactivate(&s, params, ctx).await }
+        },
+    );
+
+    let s = store;
+    router.register(
+        "workstream.rename",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { rename(&s, params, ctx).await }
         },
     );
 }
@@ -205,6 +215,13 @@ struct ActivateParams {
     id: String,
     #[serde(default)]
     force: bool,
+}
+
+/// `params` shape for `workstream.rename` (DOC-48 §5.1, Phase C).
+#[derive(Deserialize)]
+struct RenameParams {
+    id: String,
+    name: String,
 }
 
 /// `workstream.create{name?} -> {id: UUID}` (DOC-48 §5.1, AC-2.1).
@@ -385,6 +402,33 @@ async fn deactivate(
             other => RpcError::internal(format!("unexpected activation error: {other}")),
         })?;
     Ok(json!({}))
+}
+
+/// `workstream.rename{id, name} -> Workstream` (DOC-48 §5.1, Phase C, issue
+/// #3300).
+///
+/// Why: the RPC entry point for the GUI switcher's rename action — the one
+/// verb DOC-48 §5.1 marked "future, Phase C" when Phase 1A shipped; this
+/// issue is that phase.
+/// What: `-32002 not_found` if `id` is unknown; otherwise the updated
+/// [`WorkstreamView`] (matching `get`'s response shape, since a client that
+/// just renamed a record typically wants the fresh view without a second
+/// round-trip). An empty `name` is accepted — matching `workstream.create`'s
+/// own "name defaults to empty" tolerance rather than inventing a new
+/// validation rule this spec never states.
+/// Test: `protocol_tests::rename_succeeds_and_returns_updated_view`,
+/// `protocol_tests::rename_unknown_id_maps_to_not_found`.
+async fn rename(
+    store: &SharedWorkstreamStore,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: RenameParams = parse(params, "workstream.rename")?;
+    let id = parse_id(&p.id, "workstream.rename")?;
+    let mut store = store.lock().await;
+    let ws = store.rename(id, p.name).await.map_err(map_store_err)?;
+    let active_id = store.active_workstream_id().await.map_err(map_store_err)?;
+    Ok(json!(WorkstreamView::new(ws, active_id)))
 }
 
 #[cfg(test)]

--- a/crates/trusty-code/src/workstreams/protocol_tests.rs
+++ b/crates/trusty-code/src/workstreams/protocol_tests.rs
@@ -91,8 +91,9 @@ async fn register_wires_create_get_list_close() {
     let id = resp.result.unwrap()["id"].clone();
 
     for (method, params) in [
-        ("workstream.get", json!({"id": id})),
+        ("workstream.get", json!({"id": id.clone()})),
         ("workstream.list", json!({})),
+        ("workstream.rename", json!({"id": id.clone(), "name": "B"})),
         ("workstream.close", json!({"id": id})),
     ] {
         let resp = router.dispatch(req(method, params), &test_ctx()).await;
@@ -468,4 +469,43 @@ async fn close_unknown_id_maps_to_not_found() {
     .await
     .unwrap_err();
     assert_eq!(err.code, -32002);
+}
+
+/// `workstream.rename` (issue #3300, Phase C) must overwrite `name` and
+/// return the updated view.
+#[tokio::test]
+async fn rename_succeeds_and_returns_updated_view() {
+    let (store, _dir) = shared_store().await;
+    let id = create(&store, json!({"name": "A"}), test_ctx())
+        .await
+        .expect("create")["id"]
+        .clone();
+
+    let renamed = rename(&store, json!({"id": id, "name": "B"}), test_ctx())
+        .await
+        .expect("rename");
+    assert_eq!(renamed["name"], "B");
+    assert_eq!(renamed["state"], "idle");
+}
+
+#[tokio::test]
+async fn rename_unknown_id_maps_to_not_found() {
+    let (store, _dir) = shared_store().await;
+    let err = rename(
+        &store,
+        json!({"id": WorkstreamId::new().to_string(), "name": "B"}),
+        test_ctx(),
+    )
+    .await
+    .unwrap_err();
+    assert_eq!(err.code, -32002);
+}
+
+#[tokio::test]
+async fn rename_invalid_params_maps_to_invalid_params() {
+    let (store, _dir) = shared_store().await;
+    let err = rename(&store, json!({"id": "not-a-uuid", "name": "B"}), test_ctx())
+        .await
+        .unwrap_err();
+    assert_eq!(err.code, trusty_common::mcp::error_codes::INVALID_PARAMS);
 }

--- a/crates/trusty-code/src/workstreams/store.rs
+++ b/crates/trusty-code/src/workstreams/store.rs
@@ -369,6 +369,46 @@ impl WorkstreamStore {
             .ok_or_else(|| StoreError::NotFound(id.to_string()))
     }
 
+    /// Rename a workstream (DOC-48 §5.1 `workstream.rename`, Phase C —
+    /// issue #3300).
+    ///
+    /// Why: the persistence primitive `workstream.rename` calls. The domain
+    /// model has always documented `name` as mutable ("future rename
+    /// support, Phase C" — [`Workstream`]'s own doc comment); this is that
+    /// support landing. Renaming a closed workstream is allowed — closure
+    /// only rejects new session bindings (§4.4), it says nothing about the
+    /// label, and forbidding it would leave a typo permanently unfixable.
+    /// What: reloads first, overwrites `name` and calls
+    /// [`Workstream::touch`] to refresh `updated_at`, persists, and returns
+    /// the updated record. `NotFound` if `id` does not exist.
+    /// Test: `store_tests::rename_updates_name_and_persists`,
+    /// `store_tests::rename_missing_id_returns_not_found`,
+    /// `store_tests::rename_closed_workstream_succeeds`.
+    pub async fn rename(
+        &mut self,
+        id: WorkstreamId,
+        name: impl Into<String>,
+    ) -> Result<Workstream, StoreError> {
+        self.reload_if_changed().await?;
+        {
+            let ws = self
+                .data
+                .workstreams
+                .iter_mut()
+                .find(|w| w.id == id)
+                .ok_or_else(|| StoreError::NotFound(id.to_string()))?;
+            ws.name = name.into();
+            ws.touch();
+        }
+        self.save().await?;
+        self.data
+            .workstreams
+            .iter()
+            .find(|w| w.id == id)
+            .cloned()
+            .ok_or_else(|| StoreError::NotFound(id.to_string()))
+    }
+
     /// Boot-time reconciliation (DOC-48 §3.3, AC-1.4, AC-6.1, AC-6.2).
     ///
     /// Why: a daemon restart must never silently change which workstream is

--- a/crates/trusty-code/src/workstreams/store_tests.rs
+++ b/crates/trusty-code/src/workstreams/store_tests.rs
@@ -311,6 +311,54 @@ async fn close_is_idempotent() {
     assert!(second.is_closed());
 }
 
+/// Renaming must overwrite `name`, refresh `updated_at`, and persist across
+/// a reload.
+#[tokio::test]
+async fn rename_updates_name_and_persists() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = store_file(&dir);
+    let mut store = WorkstreamStore::load(&path).await.expect("load");
+    let id = store.create("original").await.expect("create");
+    let before = store.get(id).await.expect("get before rename");
+
+    let renamed = store.rename(id, "renamed").await.expect("rename");
+    assert_eq!(renamed.name, "renamed");
+    assert!(renamed.updated_at >= before.updated_at);
+
+    let mut reloaded = WorkstreamStore::load(&path).await.expect("reload");
+    let ws = reloaded.get(id).await.expect("get after reload");
+    assert_eq!(ws.name, "renamed", "rename must be persisted");
+}
+
+/// Renaming an unknown id must return `NotFound`.
+#[tokio::test]
+async fn rename_missing_id_returns_not_found() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let missing = WorkstreamId::new();
+    assert!(matches!(
+        store.rename(missing, "new name").await,
+        Err(StoreError::NotFound(_))
+    ));
+}
+
+/// A closed workstream is still renamable — closure only rejects new
+/// session bindings (§4.4), not label edits.
+#[tokio::test]
+async fn rename_closed_workstream_succeeds() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = WorkstreamStore::load(store_file(&dir)).await.expect("load");
+    let id = store.create("original").await.expect("create");
+    store.close(id).await.expect("close");
+
+    let renamed = store
+        .rename(id, "renamed after close")
+        .await
+        .expect("rename closed");
+    assert_eq!(renamed.name, "renamed after close");
+    assert!(renamed.is_closed(), "rename must not clear the closed flag");
+}
+
 #[tokio::test]
 async fn store_reload_noop_when_unchanged() {
     let dir = TempDir::new().expect("tempdir");

--- a/docs/specs/DOC-48-tcode-workstreams.md
+++ b/docs/specs/DOC-48-tcode-workstreams.md
@@ -274,7 +274,7 @@ The daemon adds the following JSON-RPC methods (to `crates/trusty-code/src/serve
 | `workstream.activate` | `{id: UUID, force?: bool} → {active_id: UUID, prior_id?: UUID}` | Activate this workstream (make it the active workstream). Default `force = false`. If another workstream is active, return `ActiveConflict{active_id}` (fail) unless `force: true`. When `force: true`, deactivates the prior workstream. Returns the new active ID and the prior ID (if any). This is an **explicit switch**, never silent (DOC-40 principle). |
 | `workstream.deactivate` | `{id: UUID} → {}` | Deactivate the active workstream. Only the active workstream may be deactivated; deactivating an `idle` workstream is idempotent. Sets `active_workstream_id` to `null`. |
 | `workstream.close` | `{id: UUID} → {}` | Irreversibly close a workstream. Rejects new session bindings; existing sessions remain valid. If the closed workstream is the active one, it is automatically deactivated. |
-| `workstream.rename` | `{id: UUID, name: String} → Workstream` | Rename a workstream (future, Phase C). Out of scope for Phase 1A. |
+| `workstream.rename` | `{id: UUID, name: String} → Workstream` | Rename a workstream. Shipped with the Phase C GUI switcher (issue #3300); out of scope for Phase 1A. |
 
 ### 5.2 REST endpoints (wrappers around JSON-RPC)
 
@@ -287,6 +287,7 @@ Per #2983 Slice 4, REST alternatives are provided alongside JSON-RPC for one-sho
 | `GET` | `/workstreams?include_closed=…` | → `workstream.list{…}` |
 | `POST` | `/workstreams/{id}/activate` | → `workstream.activate{id, force?}` |
 | `POST` | `/workstreams/{id}/deactivate` | → `workstream.deactivate{id}` |
+| `POST` | `/workstreams/{id}/rename` | → `workstream.rename{id, name}` (issue #3300, Phase C) |
 | `POST` | `/workstreams/{id}/close` | → `workstream.close{id}` |
 
 All endpoints return JSON. Errors are HTTP 4xx/5xx with a JSON error body (matching existing tcode error conventions).
@@ -497,11 +498,14 @@ This preserves DOC-40's "never silently multiplex" principle at the activation l
 - Session-creation UI wiring to bind to workstream (§4.1)
 - Ambient default-target logic: new work targets the active workstream (§4.2)
 
-### Phase C (future, blocked on #3153) — GUI workstream switcher
+### Phase C (issue #3300) — GUI workstream switcher
 
-- Visual workstream switcher in the header (DOC-39 §2, principle 3)
-- State display, rename, close actions
-- Activation UI (switch between workstreams)
+- [x] Visual workstream switcher in the header (DOC-39 §2, principle 3)
+- [x] State display, rename, close actions
+- [x] Activation UI (switch between workstreams), including the
+      `ActiveConflict` (409) surfacing + refresh affordance
+- [x] `workstream.rename` RPC/REST verb (previously deferred, now shipped
+      alongside its first caller)
 
 ---
 
@@ -657,7 +661,7 @@ curl -X POST http://localhost:7881/rpc \
 **Rev 2 contract:**
 - [ ] Workstream storage: single flat `workstreams-{project_slug}-{hash}.json` file (atomic temp+rename), with `version`, `active_workstream_id`, and `workstreams[]` array.
 - [ ] Boot reconciliation: loads all records, restores `active_workstream_id`, clears no stale data (persistence is deterministic, no TTL-based expiry).
-- [ ] RPC methods implemented: `workstream.create`, `workstream.get`, `workstream.list`, `workstream.activate`, `workstream.deactivate`, `workstream.close` (NO attach/detach/heartbeat).
+- [ ] RPC methods implemented: `workstream.create`, `workstream.get`, `workstream.list`, `workstream.activate`, `workstream.deactivate`, `workstream.close`, `workstream.rename` (Phase C, issue #3300; NO attach/detach/heartbeat).
 - [ ] REST endpoints wrap the RPC methods (POST /workstreams, GET /workstreams/{id}, POST /workstreams/{id}/activate, etc.).
 - [ ] **NEW route**: `GET /workstreams/{id}/events` — workstream-level SSE endpoint that fan-outs over bound session_ids with event tagging `{session_id, event_type, payload}`.
 - [ ] CLI commands: `tcode workstream list/get/create/activate/deactivate/close` (NO attach/detach; ws short alias works).

--- a/docs/specs/DOC-48-tcode-workstreams.md
+++ b/docs/specs/DOC-48-tcode-workstreams.md
@@ -274,7 +274,7 @@ The daemon adds the following JSON-RPC methods (to `crates/trusty-code/src/serve
 | `workstream.activate` | `{id: UUID, force?: bool} → {active_id: UUID, prior_id?: UUID}` | Activate this workstream (make it the active workstream). Default `force = false`. If another workstream is active, return `ActiveConflict{active_id}` (fail) unless `force: true`. When `force: true`, deactivates the prior workstream. Returns the new active ID and the prior ID (if any). This is an **explicit switch**, never silent (DOC-40 principle). |
 | `workstream.deactivate` | `{id: UUID} → {}` | Deactivate the active workstream. Only the active workstream may be deactivated; deactivating an `idle` workstream is idempotent. Sets `active_workstream_id` to `null`. |
 | `workstream.close` | `{id: UUID} → {}` | Irreversibly close a workstream. Rejects new session bindings; existing sessions remain valid. If the closed workstream is the active one, it is automatically deactivated. |
-| `workstream.rename` | `{id: UUID, name: String} → Workstream` | Rename a workstream. Shipped with the Phase C GUI switcher (issue #3300); out of scope for Phase 1A. |
+| `workstream.rename` | `{id: UUID, name: String} → Workstream` | Rename a workstream. Shipped in Phase C (issue #3300) — was deferred from Phase 1A. |
 
 ### 5.2 REST endpoints (wrappers around JSON-RPC)
 


### PR DESCRIPTION
## Summary

Implements issue #3300 (DOC-48 §8 SPEC-WS-08 Phase C, DOC-39 §2/§8 header
slot): the GUI workstream switcher in the tcode GUI header, filling the slot
`AppHeader.svelte` (PR #3301, issue #3153 shell rebuild) reserved as a
disabled placeholder.

**Scope delivered (the issue's six bullets):**
1. **State display** — the header trigger shows the active workstream's name
   + a state-colored dot.
2. **List view** — a dropdown panel lists every workstream with an active
   indicator.
3. **Activation** — clicking a non-active row calls
   `POST /workstreams/{id}/activate {force: false}`. A `409`
   (`ActiveConflict` — DOC-48 §6.1, someone else activated concurrently) is
   surfaced as an inline banner with a **Refresh** action; it never
   auto-retries with `force: true` (an explicit switch is never silent, per
   §6.1, and the issue's own wording is "surface it, offer refresh").
4. **Close** — a two-step in-row confirm (no `window.confirm()`, matching
   `SessionMonitor.svelte`'s existing cancel-action convention).
5. **Rename** — an inline text-input edit (no `window.prompt()`).
6. Live updates — polls `GET /workstreams` every 5s as the authoritative
   source (same shape as `StatusBar.svelte`), plus an `EventSource`
   subscription to `/workstreams/{active_id}/events` for a low-latency nudge
   on `workstream_activation_changed`/`workstream_state_inferred` frames.

## Design decisions / judgment calls

- **`workstream.rename` didn't exist yet.** DOC-48 §5.1 documented the verb
  but explicitly marked it "future, Phase C. Out of scope for Phase 1A" —
  this issue *is* that phase, so the first commit adds
  `WorkstreamStore::rename` + the `workstream.rename` RPC handler +
  `POST /workstreams/{id}/rename` REST route (with tests), then DOC-48 is
  updated to reflect it shipping. Renaming a closed workstream is allowed —
  closure only rejects new session bindings (§4.4), not label edits.
- **No daemon-wide activation-change push channel.** The only SSE route is
  per-workstream (`GET /workstreams/{id}/events`), which requires already
  knowing which workstream to subscribe to — there's no "any workstream's
  activation changed" global stream. The switcher therefore treats **polling
  as authoritative** and SSE as a pure latency optimization (subscribes to
  the currently-active workstream's stream once one exists; falls back to
  the 5s poll cadence otherwise, including when `EventSource` is
  unavailable). Documented as a real API gap (DOC-39 §2.1 C-2) in the code,
  not silently worked around.
- **The `409` conflict body carries no `active_id`.** `respond()`
  (`crate::serve::rest::mod::respond`) deliberately drops `data` from every
  REST error envelope (pre-existing, documented choice). Rather than widen
  that shared helper for one route, the conflict banner shows a generic
  message + Refresh instead of naming the conflicting workstream — a
  scoped, minimal choice; happy to revisit if you'd rather widen `respond()`.
- **No "create workstream" affordance in the switcher.** Nothing in the GUI
  creates workstreams yet (session→workstream binding is explicit Phase 1B,
  out of scope here) — the switcher is a pure observer/controller over
  server-side state (created via CLI or another client), consistent with
  DOC-48's multi-client design. Matches the issue's six scope bullets, which
  don't include creation.
- **Rename/close via `fetch()` wrappers in `lib/workstreams.ts`** rather than
  inlined in the component (every other `lib/*.ts` module in this crate
  inlines `fetch()` in the component and only extracts pure logic) — this
  switcher is the first component with four distinct network operations,
  worth making independently testable.

## Files changed

Backend (`trusty-code`):
- `crates/trusty-code/src/workstreams/store.rs` (+40) — `rename()`
- `crates/trusty-code/src/workstreams/store_tests.rs` (+48)
- `crates/trusty-code/src/workstreams/protocol.rs` (+50) — `workstream.rename` RPC
- `crates/trusty-code/src/workstreams/protocol_tests.rs` (+42)
- `crates/trusty-code/src/serve/rest/workstreams.rs` (+65) — `POST /workstreams/{id}/rename`
- `docs/specs/DOC-48-tcode-workstreams.md` (+16/-4)
- `crates/trusty-code/CHANGELOG.md`

Frontend (`trusty-code-gui`):
- `crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.svelte` (new, 379 lines)
- `crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.test.ts` (new, 280 lines, 7 tests)
- `crates/trusty-code-gui/ui/src/lib/workstreams.ts` (new, 200 lines)
- `crates/trusty-code-gui/ui/src/lib/workstreams.test.ts` (new, 170 lines, 14 tests)
- `crates/trusty-code-gui/ui/src/components/AppHeader.svelte` (-45/+23, slot filled)
- `crates/trusty-code-gui/CHANGELOG.md`

## Gate results (raw output)

```
$ cargo fmt --check -p trusty-code && cargo fmt --check -p trusty-code-gui
(clean, no diff)

$ cargo clippy -p trusty-code --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.36s
(0 warnings from this crate; 2 pre-existing, unrelated duplicate-bin-target
warnings from trusty-installer/trusty-mpm)

$ cargo clippy -p trusty-code-gui --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.19s
(clean)

$ cargo test -p trusty-code --lib          (default parallel)
test result: ok. 1334 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out

$ cargo test -p trusty-code --lib -- --test-threads=1
test result: ok. 1334 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
(one run hit a PRE-EXISTING flake unrelated to this change,
run_task::tests::exit_code_reflects_run_failure — reproduced in isolation
across 3 reruns, 2/3 passed, 1/3 failed with identical assertion; confirmed
this ticket touches none of run_task/executor/ScriptedLlm)

$ cargo test -p trusty-code-gui
test result: ok. 3 passed; 0 failed (Rust side: commands.rs, state.rs)

$ pnpm test   (crates/trusty-code-gui/ui)
Test Files  14 passed (14)
     Tests  153 passed (153)

$ pnpm build  (crates/trusty-code-gui/ui)
✓ 136 modules transformed
✓ built in 513ms

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 38 spec doc(s) + 2608 code file(s); 0 error(s), 0 warning(s)
```

Note on issue #3318 (tauri `beforeBuildCommand` cwd bug): not hit — this PR
only ran `pnpm build`/`vitest`/`cargo test`, not a full `cargo tauri build`.

Closes #3300

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)