### PR TITLE
fix(trusty-common): single canonical palace-id derivation so catch-up and memory daemon agree

### DIFF
--- a/crates/trusty-code/src/session/memory_sink.rs
+++ b/crates/trusty-code/src/session/memory_sink.rs
@@ -347,11 +347,20 @@ async fn write_turn(base_url: &str, palace: &str, turn: &QueuedTurn) {
 /// `derive_palace_id_for` convention exactly, so a session's turns land in
 /// the SAME palace `catchup::pm_catchup_context` reads its digest from — the
 /// PM's own catch-up section and the turn recorder's writes must agree on
-/// "which palace is this project."
+/// "which palace is this project." Both this function and
+/// `trusty_common::catchup::derive_palace_id_for` previously carried their
+/// OWN copy of a 4th, unslugified `file_name()` fallback for when
+/// `derive_palace_id` returned `None`; since each copy re-derived the
+/// fallback from its own local `project_dir` handle, the two could in
+/// principle diverge (and could leak a storage-unsafe, unslugified token as
+/// a palace id) — see issue #1772. Both call sites now share the exact same
+/// terminal behavior — a fixed, non-derived placeholder — so `derive_palace_id`
+/// remains the single source of truth for every real precedence level.
 /// What: probes `git config --get remote.origin.url` from `project_dir`,
 /// then calls `trusty_common::derive_palace_id` (explicit override env ->
-/// git owner/repo slug -> parent/dir slug), falling back to the directory's
-/// basename (or `"unknown-project"`) when all three yield `None`.
+/// git owner/repo slug -> parent/dir slug), falling back to the fixed
+/// literal `"unknown-project"` (never a directory-derived value) when all
+/// three yield `None`.
 /// Test: `memory_sink::tests::derive_palace_id_for_project_falls_back_to_dirname`.
 pub fn derive_palace_id_for_project(project_dir: &Path) -> String {
     let remote = std::process::Command::new("git")
@@ -366,13 +375,7 @@ pub fn derive_palace_id_for_project(project_dir: &Path) -> String {
 
     let override_val = trusty_common::palace_override_from_env();
     trusty_common::derive_palace_id(project_dir, remote.as_deref(), override_val.as_deref())
-        .unwrap_or_else(|| {
-            project_dir
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("unknown-project")
-                .to_string()
-        })
+        .unwrap_or_else(|| "unknown-project".to_string())
 }
 
 #[cfg(test)]

--- a/crates/trusty-code/src/session/memory_sink_tests.rs
+++ b/crates/trusty-code/src/session/memory_sink_tests.rs
@@ -370,3 +370,36 @@ fn derive_palace_id_for_project_falls_back_to_dirname() {
         "derivation must be deterministic for the same path"
     );
 }
+
+/// No git remote, no override -> agrees with the shared `derive_palace_id`
+/// core (issue #1772).
+///
+/// Why: this function used to carry its own copy of the divergent 4th
+/// fallback that `trusty_common::catchup::derive_palace_id_for` also carried
+/// (a raw, unslugified `file_name()` basename), which could disagree with
+/// `derive_palace_id` on the same inputs. Both call sites now delegate
+/// entirely to `trusty_common::derive_palace_id` and only fall back to a
+/// fixed, non-derived placeholder, so for a plain (non-git) temp dir with no
+/// `TRUSTY_MEMORY_PALACE` override, this function's result must equal calling
+/// `trusty_common::derive_palace_id(project_dir, None, None)` directly.
+/// What: clears the env override for the duration of the test (no other test
+/// in this crate mutates `TRUSTY_MEMORY_PALACE`, so no `#[serial]` guard is
+/// needed), then asserts the two calls agree.
+/// Test: itself.
+#[test]
+fn derive_palace_id_for_project_agrees_with_derive_palace_id_no_remote_no_env() {
+    // SAFETY: no other test in this crate mutates TRUSTY_MEMORY_PALACE.
+    unsafe {
+        std::env::remove_var(trusty_common::PALACE_OVERRIDE_ENV);
+    }
+    let tmp = TempDir::new().expect("tempdir");
+
+    let project_value = derive_palace_id_for_project(tmp.path());
+    let core_value = trusty_common::derive_palace_id(tmp.path(), None, None)
+        .expect("a real temp dir always has a usable parent/dir slug");
+
+    assert_eq!(
+        project_value, core_value,
+        "turn-recorder derivation must agree with the shared derive_palace_id core"
+    );
+}

--- a/crates/trusty-common/src/catchup/mod.rs
+++ b/crates/trusty-common/src/catchup/mod.rs
@@ -76,11 +76,28 @@ impl Default for CatchupOptions {
 /// Derive the palace_id for a project directory (fail-open).
 ///
 /// Why: the catch-up state is keyed by palace_id; deriving it from the project
-/// directory keeps it consistent with the session-launch palace pinning.
+/// directory keeps it consistent with the session-launch palace pinning AND
+/// with the memory daemon's own `cwd_palace_slug_at`
+/// (`trusty-memory::messaging::operations`), which resolves the identical
+/// three-level precedence through the same `crate::derive_palace_id` core.
+/// Previously this function re-implemented its own 4th fallback — the RAW,
+/// unslugified `file_name()` basename — whenever `derive_palace_id` returned
+/// `None` (e.g. a leaf directory name that slugifies to empty). That
+/// caller-local fallback could both (a) diverge from the daemon, which has no
+/// such fallback and errors instead, and (b) leak a storage-unsafe,
+/// unslugified token as a palace id (see issue #1772). `derive_palace_id` is
+/// now the single source of truth for every precedence level, so this
+/// function no longer re-derives anything from `project_dir` on failure — it
+/// falls back to a fixed literal, never a directory-derived value — meaning
+/// it can never disagree with the daemon on a real project.
 /// What: probes git remote origin from the project dir, then calls
-/// `crate::derive_palace_id`. Returns a fallback slug from the dir
-/// basename when derivation yields None (no git remote, no override).
-/// Test: covered indirectly by `generate_catchup_context_renders_all_sections`.
+/// `crate::derive_palace_id`. Falls back to the fixed literal
+/// `"unknown-project"` only when derivation yields `None` for every
+/// precedence level.
+/// Test: `derive_palace_id_for_agrees_with_daemon_path_no_remote_no_env`,
+/// `derive_palace_id_for_env_override_unchanged`,
+/// `derive_palace_id_for_git_remote_unchanged`; also covered indirectly by
+/// `generate_catchup_context_renders_all_sections`.
 fn derive_palace_id_for(project_dir: &Path) -> String {
     let remote = std::process::Command::new("git")
         .arg("-C")
@@ -93,15 +110,8 @@ fn derive_palace_id_for(project_dir: &Path) -> String {
         .filter(|s| !s.is_empty());
 
     let override_val = crate::palace_override_from_env();
-    crate::derive_palace_id(project_dir, remote.as_deref(), override_val.as_deref()).unwrap_or_else(
-        || {
-            project_dir
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("unknown-project")
-                .to_string()
-        },
-    )
+    crate::derive_palace_id(project_dir, remote.as_deref(), override_val.as_deref())
+        .unwrap_or_else(|| "unknown-project".to_string())
 }
 
 /// Probe the HEAD git SHA of a repo (for watermark advancement).
@@ -438,5 +448,104 @@ mod tests {
             !ctx.is_empty(),
             "blocking wrapper should return non-empty context"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // derive_palace_id_for — agreement with the shared derivation core (#1772)
+    // -----------------------------------------------------------------------
+
+    /// Why: issue #1772 — before this fix, `derive_palace_id_for` (the
+    /// catch-up path) re-implemented its own divergent 4th fallback (a raw,
+    /// unslugified `file_name()` basename) whenever `derive_palace_id`
+    /// returned `None`, which could disagree with the memory daemon's
+    /// `cwd_palace_slug_at` (trusty-memory) — the only other caller that
+    /// reaches the "no override, no git remote" branch. Both now call
+    /// `crate::derive_palace_id` with identical inputs and no caller-local
+    /// re-derivation, so for a project with no git remote and no
+    /// `TRUSTY_MEMORY_PALACE` override, the catch-up-path value MUST equal
+    /// the value `derive_palace_id` itself produces for the exact same
+    /// inputs — the same call the daemon path makes at its own step 3.
+    /// What: a plain (non-git) temp directory has no remote to probe, and the
+    /// env override is left unset, so `derive_palace_id_for` falls straight
+    /// through to `derive_palace_id(project_dir, None, None)`. Asserts the
+    /// two calls agree byte-for-byte.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn derive_palace_id_for_agrees_with_daemon_path_no_remote_no_env() {
+        // SAFETY: #[serial] serialises this against the other TRUSTY_MEMORY_PALACE
+        // mutating test in this module; ensure a clean slate first.
+        unsafe {
+            std::env::remove_var(crate::PALACE_OVERRIDE_ENV);
+        }
+        let tmp = TempDir::new().unwrap();
+
+        let catchup_value = derive_palace_id_for(tmp.path());
+
+        // The "daemon path": trusty-memory's `cwd_palace_slug_at` step 3 calls
+        // `crate::derive_palace_id(project_root, git_remote, None)` directly.
+        // A plain temp dir has no git remote, mirroring that exact call.
+        let daemon_value = crate::derive_palace_id(tmp.path(), None, None)
+            .expect("a real temp dir always has a usable parent/dir slug");
+
+        assert_eq!(
+            catchup_value, daemon_value,
+            "catch-up and daemon derivations must agree with no remote and no env override"
+        );
+    }
+
+    /// Why: regression guard — the `TRUSTY_MEMORY_PALACE` override must still
+    /// win unconditionally (precedence level 1), unaffected by removing the
+    /// divergent fallback.
+    /// What: sets the env override, asserts `derive_palace_id_for` returns the
+    /// slugified override value regardless of the (non-git) directory.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn derive_palace_id_for_env_override_unchanged() {
+        let tmp = TempDir::new().unwrap();
+        // SAFETY: #[serial] serialises env access against the other
+        // TRUSTY_MEMORY_PALACE-mutating test in this module.
+        unsafe {
+            std::env::set_var(crate::PALACE_OVERRIDE_ENV, "My Override");
+        }
+        let got = derive_palace_id_for(tmp.path());
+        unsafe {
+            std::env::remove_var(crate::PALACE_OVERRIDE_ENV);
+        }
+        assert_eq!(got, "my-override");
+    }
+
+    /// Why: regression guard — a valid git remote must still win over the
+    /// parent/dir fallback (precedence level 2), unaffected by removing the
+    /// divergent fallback. Uses the real `bobmatnyc/trusty-tools` shape so the
+    /// expected slug matches this repo's own palace id.
+    /// What: inits a temp git repo, adds an `origin` remote, asserts
+    /// `derive_palace_id_for` returns the owner-repo slug.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn derive_palace_id_for_git_remote_unchanged() {
+        // SAFETY: #[serial] serialises env access against the other
+        // TRUSTY_MEMORY_PALACE-mutating tests in this module.
+        unsafe {
+            std::env::remove_var(crate::PALACE_OVERRIDE_ENV);
+        }
+        let tmp = TempDir::new().unwrap();
+        init_git_repo(&tmp);
+        Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args([
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:bobmatnyc/trusty-tools.git",
+            ])
+            .output()
+            .unwrap();
+
+        let got = derive_palace_id_for(tmp.path());
+        assert_eq!(got, "bobmatnyc-trusty-tools");
     }
 }


### PR DESCRIPTION
## Summary

Closes #1772.

`trusty_common::catchup::derive_palace_id_for` — the DOC-28 catch-up flow's
palace-id derivation — carried its own divergent 4th fallback on top of the
shared `derive_palace_id` core: a RAW, unslugified `file_name()` basename
used whenever `derive_palace_id` returned `None` (no `TRUSTY_MEMORY_PALACE`
override, no parseable git remote/parent-dir). The memory daemon's
`cwd_palace_slug_at` (`trusty-memory::messaging::operations`) has no such
fallback and errors instead, so the two derivations could in principle
diverge, and the unslugified basename could leak a storage-unsafe token as a
palace id (a literal directory name is not guaranteed to be a safe
filesystem/socket segment).

A third copy of the identical pattern existed in `trusty-code`'s
`derive_palace_id_for_project` (`crates/trusty-code/src/session/memory_sink.rs`),
whose own doc comment says it "mirrors `trusty_common::catchup`'s ...
`derive_palace_id_for` convention exactly" — so fixing only one copy would
have made them disagree with *each other*.

### Fix

Both `derive_palace_id_for` (trusty-common's catchup module) and
`derive_palace_id_for_project` (trusty-code's turn recorder) now delegate
entirely to `trusty_common::derive_palace_id` and fall back only to a fixed,
non-derived placeholder literal (`"unknown-project"`) when every precedence
level yields `None` — never re-deriving anything from the directory locally.
`derive_palace_id` remains the single source of truth for every real
precedence level (env override > git owner/repo slug > parent/dir slug), so
catch-up, the turn recorder, and the memory daemon can no longer diverge on a
real project. Common-case behavior (env override set, or a valid git remote)
is unchanged — those tests already existed and still pass, plus new
regression tests confirm they still hold with the divergent fallback removed.

## Call sites touched

- `crates/trusty-common/src/catchup/mod.rs` — `derive_palace_id_for` (the
  catch-up path from the issue).
- `crates/trusty-code/src/session/memory_sink.rs` — `derive_palace_id_for_project`
  (turn-recorder path; explicitly documented as mirroring the catch-up
  convention, so it had the identical bug).
- No change needed in `crates/trusty-memory/src/messaging/operations.rs`
  (`cwd_palace_slug_at`, the daemon path) — it already called
  `derive_palace_id` directly with no local fallback; it is now the pattern
  the other two call sites match.

## Tests

- `catchup::tests::derive_palace_id_for_agrees_with_daemon_path_no_remote_no_env`
  — proves the catch-up-path derivation and a direct `derive_palace_id` call
  (the same call the daemon's `cwd_palace_slug_at` step 3 makes) return the
  identical value for a plain, non-git temp dir with no env override.
- `session::memory_sink::tests::derive_palace_id_for_project_agrees_with_derive_palace_id_no_remote_no_env`
  — the same agreement proof for the trusty-code copy.
- `catchup::tests::derive_palace_id_for_env_override_unchanged` /
  `derive_palace_id_for_git_remote_unchanged` — regression guards proving the
  env-override and valid-git-remote precedence levels are unaffected.

## Test plan

- [x] `cargo test -p trusty-common --features catchup` — 7/7 catchup tests
      pass (includes the 3 new tests above).
- [x] `cargo test -p trusty-common` — 175 passed, 0 failed.
- [x] `cargo test -p trusty-code` — pre-existing, unrelated flaky failures in
      `run_task::tests::{exit_code_reflects_run_failure,no_changes_yields_no_changes_exit}`
      confirmed present on `origin/main` too (ambient local `trusty-memory`/
      `trusty-search` daemons on this machine leak into those sandboxed temp
      dirs); the new/touched palace-id tests all pass.
- [x] `cargo test -p trusty-memory -- palace` — all pass.
- [x] `cargo clippy -p trusty-common --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations.
- [x] `cargo check` (workspace) — clean.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools