### PR TITLE
Route Assistant + personas off the claude-code runner; set Opus/Sonnet testing defaults

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
@@ -14,8 +14,12 @@
 [agent]
 name = "assistant"
 role = "assistant"
-runner = "claude-code"
-model = "claude-sonnet-4-6"
+# #3358: no `runner` — falls back to the default (Subprocess), routing off
+# the claude-code CLI onto the direct-API credential path (AnthropicDirect
+# when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
+# in `src/llm/credentials.rs`. This is the base "Assistant" agent
+# (BASE_AGENT_ID in ui/src/lib/roster.ts) — testing default is Opus.
+model = "claude-opus-4-6"
 description = "General-purpose productivity assistant (base template; personalize via `extends`)"
 # Intentionally NO display_name / prompt_label: the base is nameless. A persona
 # identity (name + prompt label) is contributed by the personalization overlay.

--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant.toml
@@ -1,7 +1,12 @@
 [agent]
 name = "cto-assistant"
 role = "assistant"
-runner = "claude-code"
+# #3358: no `runner` — falls back to the default (Subprocess), routing off
+# the claude-code CLI onto the direct-API credential path (AnthropicDirect
+# when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
+# in `src/llm/credentials.rs`. NOTE: this flat file is shadowed by the
+# directory package at `cto-assistant/agent.toml` (loader prefers packages,
+# #482) and is not resolved by name today — kept in sync for hygiene.
 model = "claude-sonnet-4-6"
 description = "CTO Assistant — private assistant for Robert Matsuoka (CTO, Duetto)"
 display_name = "CTO Assistant"

--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
@@ -1,7 +1,10 @@
 [agent]
 name = "cto-assistant"
 role = "assistant"
-runner = "claude-code"
+# #3358: no `runner` — falls back to the default (Subprocess), routing off
+# the claude-code CLI onto the direct-API credential path (AnthropicDirect
+# when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
+# in `src/llm/credentials.rs`.
 model = "claude-sonnet-4-6"
 description = "CTO Assistant — private assistant for Robert Matsuoka (CTO, Duetto)"
 display_name = "CTO Assistant"

--- a/crates/trusty-agents/.trusty-agents/agents/izzie.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie.toml
@@ -12,7 +12,13 @@
 [agent]
 name = "izzie"
 role = "assistant"
-runner = "claude-code"
+# #3358: no `runner` — falls back to the default (Subprocess), routing off
+# the claude-code CLI onto the direct-API credential path (AnthropicDirect
+# when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
+# in `src/llm/credentials.rs`. NOTE: this flat file is shadowed by the
+# directory package at `izzie/agent.toml` (loader prefers packages, #482)
+# but is also the `extends_shadow_fallback_in` safety net if the package's
+# `extends = "assistant"` chain ever fails to resolve — kept in sync.
 model = "claude-sonnet-4-6"
 description = "Izzie — personal assistant"
 display_name = "Izzie"

--- a/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
@@ -25,7 +25,10 @@ extends = "assistant"
 [agent]
 name = "izzie"
 role = "assistant"
-runner = "claude-code"
+# #3358: no `runner` — falls back to the default (Subprocess), routing off
+# the claude-code CLI onto the direct-API credential path (AnthropicDirect
+# when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
+# in `src/llm/credentials.rs`.
 model = "claude-sonnet-4-6"
 description = "Izzie — personal assistant (personalization overlay over `assistant`)"
 # Persona identity supplied by the overlay (the base is nameless).

--- a/crates/trusty-agents/.trusty-agents/agents/personal-assistant.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/personal-assistant.toml
@@ -1,8 +1,13 @@
 [agent]
 name = "personal-assistant"
 role = "assistant"
-runner = "claude-code"
-model = "claude-haiku-4-5"
+# #3358: no `runner` — falls back to the default (Subprocess), routing off
+# the claude-code CLI onto the direct-API credential path (AnthropicDirect
+# when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
+# in `src/llm/credentials.rs`. Model bumped Haiku -> Sonnet per the
+# personas-first testing default (Opus for the base Assistant, Sonnet for
+# every other persona).
+model = "claude-sonnet-4-6"
 description = "Izzie — personal assistant for Masa"
 display_name = "Izzie"
 prompt_label = "izzie"

--- a/crates/trusty-agents/.trusty-agents/agents/pm.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/pm.toml
@@ -1,7 +1,10 @@
 [agent]
 name = "pm"
 role = "orchestrator"
-runner = "claude-code"
+# #3358: no `runner` — falls back to the default (Subprocess), routing off
+# the claude-code CLI onto the direct-API credential path (AnthropicDirect
+# when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
+# in `src/llm/credentials.rs`.
 model = "claude-sonnet-4-6"
 description = "PM orchestrator — receives user requests, delegates to sub-agents"
 

--- a/crates/trusty-agents/.trusty-agents/agents/pm.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/pm.toml
@@ -4,8 +4,13 @@ role = "orchestrator"
 # #3358: no `runner` — falls back to the default (Subprocess), routing off
 # the claude-code CLI onto the direct-API credential path (AnthropicDirect
 # when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
-# in `src/llm/credentials.rs`.
-model = "claude-sonnet-4-6"
+# in `src/llm/credentials.rs`. Model is Opus, matching `assistant/agent.toml`
+# — `pm` is the GUI's DEFAULT no-roster-selection chat backend
+# (`resolve_agent_config` in `src/ctrl/config.rs` prefers project
+# `pm.toml`), so a user who just opens the GUI and types must also get the
+# Opus testing default, not just an explicit `assistant` roster pick
+# (owner decision on code-critic WARN, PR #3360).
+model = "claude-opus-4-6"
 description = "PM orchestrator — receives user requests, delegates to sub-agents"
 
 [llm]

--- a/crates/trusty-agents/CLAUDE.md
+++ b/crates/trusty-agents/CLAUDE.md
@@ -184,7 +184,12 @@ Credential priority (highest → lowest, applied per-agent at dispatch time — 
 1. **`CLAUDE_CODE_OAUTH_TOKEN`** — primary local-dev credential. When this is set
    AND the agent's TOML declares `runner = "claude-code"`, the harness routes the
    call through the `claude` CLI subprocess (`ClaudeCodeAgentRunner`). This is
-   the default for `pm`, `engineer`, `qa-agent`, `ticketing-agent`, `ctrl`, etc.
+   the default for specialist/task agents (`engineer`, `qa-agent`,
+   `ticketing-agent`, etc.). As of #3358, the Assistant + persona agents
+   (`assistant`, `pm`, `cto-assistant`, `izzie`, `personal-assistant`) no
+   longer declare `runner = "claude-code"` — they fall back to `Subprocess`
+   and route via `AnthropicDirect`/`OpenRouter` instead (see path 2/3 below).
+   `ctrl` never used the claude-code runner — it runs a local Ollama model.
 2. **`ANTHROPIC_API_KEY`** — when set AND the agent TOML has
    `[llm] use_anthropic_direct = true`, the harness POSTs directly to
    `api.anthropic.com` with `x-api-key`. Lower latency than OpenRouter; requires

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -1040,3 +1040,89 @@ fn extends_shadow_fallback_searches_home_tier_when_package_resolved_there() {
         Some(&["locked_tool".to_string()][..])
     );
 }
+
+// --- #3358: Assistant + persona agents off the claude-code runner --------
+//
+// Why: The Assistant MVP (epic #3052) staged its move off the claude-code
+// CLI runner to the conversational Assistant/PM/persona agents first,
+// leaving specialist/task agents (`engineer`, `qa-agent`, …, and especially
+// `claude-code-engineer` — deliberately claude-code) untouched. These tests
+// pin the resulting `runner`/`model` shape on the bundled configs so a
+// future edit can't silently reintroduce `runner = "claude-code"` on this
+// agent set, and so the Opus-for-the-base-Assistant /
+// Sonnet-for-every-other-persona testing default stays correct.
+// What: `bundled_persona_agents_do_not_use_claude_code_runner` loads each
+// in-scope agent by name (resolving through `AgentConfig::by_name`, which
+// prefers a directory package over a same-named flat file — #482) and
+// asserts `runner != ClaudeCode` and the expected model. A second test
+// loads the two flat files that are shadowed by a directory package
+// (`cto-assistant.toml`, `izzie.toml`) directly by path, since `by_name`
+// would never reach them while the package is present — the flat `izzie`
+// file additionally serves as the `extends` shadow-fallback safety net
+// (see `AgentConfig::extends_shadow_fallback_in`), so it must stay
+// consistent even though it isn't the primary load path today.
+// Test: This module IS the test surface.
+
+#[test]
+fn bundled_persona_agents_do_not_use_claude_code_runner() {
+    use crate::agents::RunnerKind;
+
+    let _guard = ENV_LOCK.blocking_lock();
+    // (agent name, expected model) — Opus for the base Assistant, Sonnet for
+    // every other in-scope persona (owner directive, #3358).
+    let cases = [
+        ("assistant", "claude-opus-4-6"),
+        ("pm", "claude-sonnet-4-6"),
+        ("personal-assistant", "claude-sonnet-4-6"),
+        ("cto-assistant", "claude-sonnet-4-6"),
+        ("izzie", "claude-sonnet-4-6"),
+    ];
+    for (name, expected_model) in cases {
+        clear_model_env(name);
+        // SAFETY: guarded by ENV_LOCK.
+        unsafe {
+            std::env::set_var("TAGENT_CONFIG_DIR", bundled_agents_dir());
+        }
+        let cfg = AgentConfig::by_name(name);
+        // SAFETY: guarded by ENV_LOCK.
+        unsafe {
+            std::env::remove_var("TAGENT_CONFIG_DIR");
+        }
+        let cfg = cfg.unwrap_or_else(|e| panic!("bundled agent '{name}' must load: {e}"));
+
+        assert_ne!(
+            cfg.agent.runner,
+            RunnerKind::ClaudeCode,
+            "bundled agent '{name}' must not declare runner = \"claude-code\" (#3358)"
+        );
+        assert_eq!(
+            cfg.agent.model, expected_model,
+            "bundled agent '{name}' model mismatch"
+        );
+    }
+}
+
+#[test]
+fn bundled_persona_shadowed_flat_duplicates_do_not_use_claude_code_runner() {
+    use crate::agents::RunnerKind;
+
+    // `cto-assistant.toml` and `izzie.toml` are shadowed by their same-named
+    // directory package (`cto-assistant/agent.toml`, `izzie/agent.toml`) and
+    // are never reached via `by_name` while the package is present — load
+    // them directly by path so this hygiene guard actually exercises them.
+    for name in ["cto-assistant", "izzie"] {
+        let path = bundled_agents_dir().join(format!("{name}.toml"));
+        let cfg = AgentConfig::load(&path)
+            .unwrap_or_else(|e| panic!("shadowed flat agent '{name}.toml' must still parse: {e}"));
+
+        assert_ne!(
+            cfg.agent.runner,
+            RunnerKind::ClaudeCode,
+            "shadowed flat agent '{name}.toml' must not declare runner = \"claude-code\" (#3358)"
+        );
+        assert_eq!(
+            cfg.agent.model, "claude-sonnet-4-6",
+            "shadowed flat agent '{name}.toml' model mismatch"
+        );
+    }
+}

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -1068,11 +1068,16 @@ fn bundled_persona_agents_do_not_use_claude_code_runner() {
     use crate::agents::RunnerKind;
 
     let _guard = ENV_LOCK.blocking_lock();
-    // (agent name, expected model) — Opus for the base Assistant, Sonnet for
-    // every other in-scope persona (owner directive, #3358).
+    // (agent name, expected model) — Opus for the base Assistant AND `pm`
+    // (the GUI's DEFAULT no-roster-selection chat backend — see
+    // `resolve_agent_config` in `src/ctrl/config.rs`, which prefers project
+    // `pm.toml` over `ctrl.toml`), Sonnet for every other in-scope persona
+    // (owner directive, #3358; `pm` bumped to Opus per the owner's ruling on
+    // the code-critic WARN on PR #3360 — the default chat must also get the
+    // Opus testing default, not just an explicit `assistant` roster pick).
     let cases = [
         ("assistant", "claude-opus-4-6"),
-        ("pm", "claude-sonnet-4-6"),
+        ("pm", "claude-opus-4-6"),
         ("personal-assistant", "claude-sonnet-4-6"),
         ("cto-assistant", "claude-sonnet-4-6"),
         ("izzie", "claude-sonnet-4-6"),
@@ -1125,4 +1130,116 @@ fn bundled_persona_shadowed_flat_duplicates_do_not_use_claude_code_runner() {
             "shadowed flat agent '{name}.toml' model mismatch"
         );
     }
+}
+
+/// #3358 code-critic MEDIUM: the two tests above assert over a hardcoded
+/// name list, so a brand-new persona added later with `runner =
+/// "claude-code"` would silently evade both guards. This test instead
+/// walks every physical TOML file under `bundled_agents_dir()` — every
+/// flat `<name>.toml` AND every directory package's `agent.toml`,
+/// independently, not deduplicated by `by_name` — and asserts that any
+/// agent NOT on the explicit `claude-code`-eligible allow-list (the
+/// specialist/task agents, which stay out of scope for #3358, plus
+/// `claude-code-engineer` which is deliberately claude-code) does not
+/// declare `runner = "claude-code"`. A future addition — a new persona
+/// TOML, or a new directory package — is caught automatically without
+/// needing a matching new assertion here.
+/// Test: This module IS the test surface.
+#[test]
+fn all_bundled_agent_tomls_outside_the_specialist_allowlist_avoid_claude_code_runner() {
+    use crate::agents::RunnerKind;
+    use std::collections::HashSet;
+
+    // Loading each package goes through `resolve_model`, which reads
+    // process-global `TAGENT_MODEL_*` / `TAGENT_DEFAULT_MODEL` env vars —
+    // guard against concurrent mutation by the env-mutating tests in this
+    // file, same as every other test here (this test doesn't itself mutate
+    // env, but reads must still be serialized against writers).
+    let _guard = ENV_LOCK.blocking_lock();
+
+    // Specialist/task agents (staged OUT of scope for #3358) plus
+    // `claude-code-engineer` (deliberately claude-code, never migrate).
+    // Every other bundled agent TOML must not declare
+    // `runner = "claude-code"`.
+    let claude_code_eligible: HashSet<&str> = [
+        "analysis-agent",
+        "bedrock-engineer",
+        "claude-code-engineer",
+        "code-agent",
+        "docs-agent",
+        "engineer",
+        "gpt-engineer",
+        "gpt5-codex-engineer",
+        "local-ops-agent",
+        "observe-agent",
+        "plan-agent",
+        "postmortem-agent",
+        "python-engineer",
+        "qa-agent",
+        "research-agent",
+        "ticketing-agent",
+    ]
+    .into_iter()
+    .collect();
+
+    let dir = bundled_agents_dir();
+    let mut checked = 0usize;
+    for entry in std::fs::read_dir(&dir).expect("read bundled agents dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        let file_type = entry.file_type().expect("file type");
+
+        // Directory-package agent: `<name>/agent.toml` + `persona.md`.
+        // `AgentConfig::load` can't parse a package's `agent.toml` in
+        // isolation (its system-prompt content lives in the sibling
+        // `persona.md`, merged only by the private `load_agent_package`
+        // helper) — go through the public `by_name_in`, scoped to just
+        // this one directory so it can't wander into $HOME, which resolves
+        // packages correctly (#482). Non-agent directories under
+        // `.trusty-agents/agents/` (there are none today, but be
+        // defensive) are skipped by requiring `agent.toml` to exist.
+        let (cfg, display_path) = if file_type.is_dir() {
+            let candidate = path.join("agent.toml");
+            if !candidate.is_file() {
+                continue;
+            }
+            let dir_name = entry
+                .file_name()
+                .to_str()
+                .expect("bundled agent dir name is valid UTF-8")
+                .to_string();
+            let cfg = AgentConfig::by_name_in(std::slice::from_ref(&dir), &dir_name)
+                .unwrap_or_else(|e| {
+                    panic!("bundled package {} must load: {e}", candidate.display())
+                });
+            (cfg, candidate)
+        } else if path.extension().is_some_and(|ext| ext == "toml") {
+            let cfg = AgentConfig::load(&path)
+                .unwrap_or_else(|e| panic!("bundled TOML {} must parse: {e}", path.display()));
+            (cfg, path.clone())
+        } else {
+            continue;
+        };
+        checked += 1;
+
+        if claude_code_eligible.contains(cfg.agent.name.as_str()) {
+            continue;
+        }
+        assert_ne!(
+            cfg.agent.runner,
+            RunnerKind::ClaudeCode,
+            "bundled agent '{}' ({}) declares runner = \"claude-code\" but is not on the \
+             claude-code-eligible allow-list in this test — either it's a new specialist \
+             that needs adding to the allow-list, or it's a persona that must be migrated \
+             per #3358",
+            cfg.agent.name,
+            display_path.display()
+        );
+    }
+    assert!(
+        checked >= 20,
+        "expected to scan at least 20 bundled agent TOMLs under {}, only found {checked} — \
+         bundled_agents_dir() may be resolving the wrong path",
+        dir.display()
+    );
 }


### PR DESCRIPTION
## Summary

Owner directive: "we shouldn't be using claude code cli for agents; we have a structured inference access model we should be using that supports openrouter, fireworks.ai, etc." and "for testing, default to opus for assistant, sonnet for others."

Staged scope: **Assistant + personas first** — specialist/task agents (`engineer.toml`, `qa-agent.toml`, `research-agent.toml`, `claude-code-engineer.toml`, etc.) are explicitly **out of scope** here; the full `trusty_common::inference` dispatch migration (needed to actually reach Fireworks/Together/AtlasCloud beyond OpenRouter/AnthropicDirect) is tracked separately as **issue #2410**, also out of scope for this PR.

### Classified agent list

**IN scope (edited):**
| Agent | File(s) | Model before → after |
|---|---|---|
| `assistant` (**the Assistant** — `BASE_AGENT_ID` in `ui/src/lib/roster.ts`, explicit roster pick) | `assistant/agent.toml` | `claude-sonnet-4-6` → **`claude-opus-4-6`** |
| `pm` (PM orchestrator — **DEFAULT** no-roster-selection chat backend when connected) | `pm.toml` | `claude-sonnet-4-6` → **`claude-opus-4-6`** |
| `personal-assistant` (Izzie, flat-only) | `personal-assistant.toml` | `claude-haiku-4-5` → **`claude-sonnet-4-6`** |
| `cto-assistant` | `cto-assistant.toml` + `cto-assistant/agent.toml` (package shadows flat, #482) | `claude-sonnet-4-6` (unchanged) |
| `izzie` | `izzie.toml` + `izzie/agent.toml` (package shadows flat; flat also serves as the `extends` fallback) | `claude-sonnet-4-6` (unchanged) |

All 7 files above: removed `runner = "claude-code"`, letting `RunnerKind` fall back to its default (`Subprocess`). Per `pick_credentials()` in `src/llm/credentials.rs` this routes to `AnthropicDirect` (when `ANTHROPIC_API_KEY` is set) then `OpenRouter`, instead of requiring the local `claude` CLI.

**Deliberately untouched:** `ctrl.toml` / `ctrl/agent.toml` — already runs a local Ollama model (`ollama/qwen3:30b`) by design and never declared `runner = "claude-code"` in the first place.

**Evidence for "the Assistant":** `ui/src/lib/roster.ts` — `BASE_AGENT_ID = 'assistant'`, described as "the base, nameless 'assistant' agent... is always a member of the roster... so 'chat with the assistant' works out of the box."

**Update (owner ruling on code-critic WARN):** the critic confirmed the GUI's DEFAULT chat (no roster selection, `activeAgentId = null`) routes `run_pm_task_with_session` → `resolve_agent_config` → `pm.toml`, not `assistant/agent.toml` — a user who just opens the GUI and types would never get Opus if `pm.toml` stayed Sonnet, since the Opus assignment on `assistant/agent.toml` only applies after an explicit roster pick. **Owner decision: the default chat should also be Opus.** `pm.toml` is now `claude-opus-4-6` too. Final state: **both** the default-chat backend (`pm`) and the explicit `assistant` persona run Opus for testing; `personal-assistant`, `cto-assistant`, and `izzie` stay Sonnet.

### Live-turn verification (the crux)

Built `cargo build --release -p trusty-agents` and ran real turns via `tagent --direct <agent> --task "..."` from `crates/trusty-agents/` (bundled config dir). No `ANTHROPIC_API_KEY` was configured in this environment (`tagent config keys list` → `anthropic: not configured`), so the turns routed through `OpenRouter` (`OPENROUTER_API_KEY` present) rather than `AnthropicDirect` — but **not** through claude-code either way, which is what this change is about.

```
resolved agent endpoint agent=assistant model=anthropic/claude-opus-4-6 endpoint=openrouter.ai auth=openrouter
... agent produced plain-text mid-task; injecting retry error turn=0
... sub-agent complete agent=assistant
```
A run against the `assistant` agent asking it to call `list_skills` actually invoked the tool and got a real skill-count result back before producing its final summary — confirming the tool loop (not just a bare completion) works end-to-end without the claude-code runner.

**Re-verified after the `pm.toml` Opus bump — the DEFAULT-chat path:**
```
resolved agent endpoint agent=pm model=anthropic/claude-opus-4-6 endpoint=openrouter.ai auth=openrouter
... agent produced plain-text mid-task; injecting retry error turn=1
... sub-agent complete agent=pm
```
Final response: `"I have **33 domain skills** loaded and available."` — confirms `pm` (the GUI's default no-selection chat backend) now resolves Opus, routes via `auth=openrouter` (not claude-code), and the tool loop (`list_skills` call → real result → summary) works end-to-end.

**Gap:** `AnthropicDirect` specifically was not exercised live (no `ANTHROPIC_API_KEY` in this sandbox) — only confirmed at the config/unit-test level (`runner` no longer gates to `ClaudeCode`, so `pick_credentials()` would resolve `AnthropicDirect` first if the key were present). A human with `ANTHROPIC_API_KEY` set can re-run the same `--direct pm --task "..."` command to confirm `auth=anthropic-direct` in the logs.

## Test plan
- [x] `cargo check -p trusty-agents` — clean
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-agents` — 1936 passed, 0 failed, 8 ignored (pre-existing, require live API keys). One unrelated test (`workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts`) is flaky under full-suite parallel execution — passes reliably in isolation and on repeat full-suite runs; unrelated to agent config/credentials.
- [x] `cargo fmt -p trusty-agents --check` — clean
- [x] `bash scripts/check_line_cap.sh` — 7 allowlisted, 0 violations
- [x] Regression tests: `bundled_persona_agents_do_not_use_claude_code_runner`, `bundled_persona_shadowed_flat_duplicates_do_not_use_claude_code_runner` (pin runner + model on all 7 files), and `all_bundled_agent_tomls_outside_the_specialist_allowlist_avoid_claude_code_runner` (directory-scan guard added per code-critic MEDIUM — walks every bundled agent TOML against an explicit specialist/`claude-code-engineer` allow-list so a future persona addition can't silently reintroduce `runner = "claude-code"` without a matching hardcoded test case)
- [x] Live-turn verification via `tagent --direct` for both `assistant` and `pm` (see above)

## Follow-ups filed
- #2410 — full `trusty_common::inference` dispatch migration (Fireworks/Together/AtlasCloud), deliberately out of scope here
- #3362 — housekeeping: delete/update legacy `crates/trusty-search/.open-mpm/agents/pm.toml` (still declares `runner = "claude-code"`, but confirmed NOT on the live dispatch path — `resolve_agent_config` hardcodes `.trusty-agents/agents/pm.toml` with no `.open-mpm` fallback)

Closes #3358

🤖 Generated with [Claude Code](https://claude.com/claude-code)
