### PR TITLE
chore(release): trusty-common 0.23.4 + trusty-agents-common 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10810,7 +10810,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents-common"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents-common/CHANGELOG.md
+++ b/crates/trusty-agents-common/CHANGELOG.md
@@ -7,6 +7,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.2.3] — 2026-07-19
+
 ### Fixed
 
 - `events::tests::publish_round_trips_through_subscribe` (and sibling tests `bus_is_singleton`, `seq_is_monotonic`) now carry `#[serial_test::serial]` — these three tests share the process-global `HarnessEvent` broadcast bus, so a concurrent workspace test run could deliver an unrelated event or interleave `publish()` sequence numbers between them, causing an intermittent assertion failure (closes #2961; same pattern as the #2271 `bm25_client` fix).

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-agents-common"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.23.4] — 2026-07-19
+
 ### Added
 
 - new `banner` module — `TRUSTY_SPLASH_ART` (the compact block-robot "TRUSTY" wordmark art) and `shade_bucket` (glyph → amber/rust RGB triple), extracted from `tm`'s previously binary-local splash renderer so both `tm` and `trusty-agents`' REPL can render the identical trusty branding without drifting apart again (closes [#3326](https://github.com/bobmatnyc/trusty-tools/issues/3326)). Zero extra dependencies — pure `&str` + `match`.


### PR DESCRIPTION
## Summary

Unblocks the trusty-mpm 0.19.26/0.19.27 publish chain (`cargo publish -p trusty-mpm --dry-run` currently fails: it needs `trusty_common::server::SelfOrigins` and `trusty_agents_common::connectors`, which exist in local source but not yet on crates.io).

- **trusty-common 0.23.4**: the version field was already bumped in source as a side effect of #3345 (unrelated banner-module PR), so `SelfOrigins` (#3308) exists at 0.23.4 in-tree but has never been published. This PR only adds a proper `## [0.23.4]` CHANGELOG heading (was sitting under a long-accumulated `Unreleased` section).
- **trusty-agents-common 0.2.3**: real patch bump 0.2.2 -> 0.2.3 via `scripts/bump-version.sh trusty-agents-common patch`, adding the `connectors` module (#3194) to the published surface. Deduped the resulting stacked-Unreleased sections (known issue #2793) into one `## [0.2.3]` heading.

Patch bumps only — no API changes beyond what's already in source.

## Test plan
- [x] `cargo check -p trusty-agents-common -p trusty-common`
- [x] `cargo test -p trusty-agents-common -p trusty-common` — 309 + 175 passed, 0 failed
- [x] `cargo clippy -p trusty-agents-common -p trusty-common --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green
- [ ] Publish trusty-common 0.23.4 and trusty-agents-common 0.2.3 to crates.io after merge (tracked as a follow-up in this session)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools