### PR TITLE
docs(design): land Foundry Svelte edition as design-system-svelte reference

### DIFF
--- a/docs/design/UI/README.md
+++ b/docs/design/UI/README.md
@@ -45,3 +45,74 @@ Drop both CSS files into each crate's `ui/src/lib/styles/` directory:
 
 - #3153 — Reconcile Foundry with DOC-39 visual-system spec
 - #3133 — Design system request (resolved)
+
+---
+
+## Foundry — Svelte Edition (reference)
+
+**[design-system-svelte/](design-system-svelte/)** is a runnable Svelte 5 (runes) + Vite
+port of the same Foundry v2 tokens, landed verbatim from the 2026-07-19 design drop. It
+is committed as **reference material**, not as an importable package — see rationale
+below.
+
+### What it is
+
+- `design-system-svelte/src/styles/tokens.css` and `foundry.css` are **byte-identical**
+  to `design-system/tokens.css` / `design-system/foundry.css` — confirms the Svelte
+  edition is a straight port of the same v2 tokens/visuals, not a new palette.
+- `design-system-svelte/src/lib/` — reusable primitives built on those raw `foundry.css`
+  classes: `Button`, `Badge`, `Modal`, `Toast`, `StatCard`, `Sidebar`, `Topbar`,
+  `AppShell`, `RobotMark` (idle/receiving/working states, square/round/visor eyes).
+- `design-system-svelte/src/screens/` — 14 full-page reference screens across
+  search (Dashboard, Search+chat, Indexes, Health, Dialogs gallery), console
+  (Command deck), memory (Palaces), agents (Chat, Projects, Auth gate, Task failure,
+  Recap), and **code** (`CodeGui.svelte`, `CodeTui.svelte` — direct mockups for
+  `trusty-code-gui`). Screens are fixed 1440×900 review frames with static mock data,
+  by the drop's own README — not drop-in production components.
+- Svelte 5 runes throughout (`$state`, `$props`, `{@render children?.()}`); no
+  Svelte 4 idioms found.
+- No licensing/provenance markers beyond the drop's own README; treated as
+  Bob-authored internal design material like the rest of `docs/design/UI/`.
+
+### Why reference, not `crates/trusty-code-gui/ui/src` source
+
+`crates/trusty-code-gui/ui` already has its own, tested Foundry integration
+(issue #3153): Tailwind utility classes (`bg-trusty-surface`, `text-status-ok/60`,
+etc.) backed by `rgb(var(--color-*) / <alpha-value>)` CSS custom properties in
+`src/app.css`, wired through `tailwind.config.js`. The Svelte-edition components use a
+**different** mechanism — plain `foundry.css` classes (`.btn`, `.card`, `.badge`) and
+raw `--trusty-*` vars consumed directly in inline styles/class bindings. Importing
+`foundry.css` wholesale into the app's style entry point would stand up a second,
+overlapping styling system (duplicate `html`/`body` resets, `.btn`/`.card` class names)
+rather than a drop-in addition — that's a restyle, not an additive change, so it's out
+of scope for this PR. Landing the drop as a runnable, browsable reference
+(`npm install && npm run dev` inside `design-system-svelte/`) preserves its full value
+— including the `CodeGui`/`CodeTui` screens as a north star for trusty-code-gui's own
+layout — without destabilizing the shipped Tailwind-token integration.
+
+### Adoption plan (follow-up work, not this PR)
+
+Component-by-component adoption into `crates/trusty-code-gui/ui` means re-expressing
+each `design-system-svelte/src/lib/` primitive against the app's existing
+`trusty-*`/`status-*` Tailwind tokens (same visual values, different class mechanism),
+not copying the files as-is. Roughly sized, smallest/lowest-risk first:
+
+1. **RobotMark** (S) — self-contained, inline-styled, zero foundry.css class
+   dependency beyond animation keyframes; easiest first port and gives the app its
+   brand mark.
+2. **Badge / Button** (S) — small, high-reuse primitives; mechanical class-to-Tailwind
+   translation (`.btn-primary` → `bg-trusty-primary text-trusty-text-inverse …`).
+3. **StatCard / Toast** (M) — a few more states/variants to cover, still self-contained.
+4. **Modal** (M) — needs the app's existing focus-trap/overlay conventions reconciled
+   with the drop's markup.
+5. **Sidebar / Topbar / AppShell** (L) — chrome components; trusty-code-gui already has
+   its own shell (`AppHeader.svelte`, `WorkstreamRail.svelte`, `ServiceNav.svelte`), so
+   this is a design-reconciliation task, not a straight port — do last, informed by
+   whatever the smaller ports teach about the token mapping.
+6. **Screens** — reference only; use `CodeGui.svelte`/`CodeTui.svelte` as a layout
+   guide when reworking trusty-code-gui's own tabs, not as source to import.
+
+### Related Issues
+
+- #3153 — Reconcile Foundry with DOC-39 visual-system spec (established the Tailwind
+  token bridge this drop's components don't yet use)

--- a/docs/design/UI/design-system-svelte/README.md
+++ b/docs/design/UI/design-system-svelte/README.md
@@ -1,0 +1,34 @@
+# Foundry — Trusty Tools screens in Svelte
+
+Svelte 5 (runes) + Vite build of the Foundry design system screens.
+
+## Run
+
+```sh
+npm install
+npm run dev
+```
+
+Open the printed URL. A left rail switches between all 14 screens.
+
+## Layout
+
+- `src/styles/tokens.css` — Foundry design tokens (light + `.dark` / `[data-theme='dark']` NIGHT SHIFT).
+- `src/styles/foundry.css` — global component classes (`.btn`, `.badge`, `.card`, `.table`, `.toast`, `.modal`, robot animations…). Same class names as the Trusty Suite UIs.
+- `src/lib/` — shared components:
+  - `RobotMark.svelte` — the robot mark (size, body/face colors, `eyes: square|round|visor`, `state: idle|receiving|working`).
+  - `Badge.svelte`, `Button.svelte`, `Toast.svelte`, `Modal.svelte`, `StatCard.svelte`.
+  - `Sidebar.svelte`, `Topbar.svelte`, `AppShell.svelte` — the sidebar-app chrome (Search, Memory).
+- `src/screens/` — one folder per product:
+  - `search/` — Dashboard, Search (+chat), Indexes (bulk ops, modal, toasts), Health, Dialogs gallery. Mock data in `data.js`.
+  - `console/` — Command deck service grid.
+  - `memory/` — Palaces tree.
+  - `agents/` — Chat, Projects, Auth gate, Task failure, Recap (all dark). Shared `AgentsHeader.svelte`.
+  - `code/` — trusty-code GUI (flagship) and TUI.
+
+## Conventions
+
+- Dark screens wrap their root in `class="dark"` — the tokens flip; component classes need no changes.
+- Screens are fixed 1440×900 frames for review; drop the fixed size on `.screen` for a real app.
+- Styling: foundry.css classes first, scoped screen-specific CSS second, everything on tokens (`var(--trusty-*)`). No hard-coded colors except the robot-mark faceplates and ANSI TUI palette.
+- All data is static mock data inline (or in `data.js`), ready to be swapped for API calls.

--- a/docs/design/UI/design-system-svelte/index.html
+++ b/docs/design/UI/design-system-svelte/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Foundry — Trusty Tools</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/docs/design/UI/design-system-svelte/package.json
+++ b/docs/design/UI/design-system-svelte/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "foundry-svelte",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "svelte": "^5.0.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/docs/design/UI/design-system-svelte/src/App.svelte
+++ b/docs/design/UI/design-system-svelte/src/App.svelte
@@ -1,0 +1,70 @@
+<script>
+  import Dashboard from './screens/search/Dashboard.svelte';
+  import Search from './screens/search/Search.svelte';
+  import Indexes from './screens/search/Indexes.svelte';
+  import Health from './screens/search/Health.svelte';
+  import Dialogs from './screens/search/Dialogs.svelte';
+  import Console from './screens/console/Console.svelte';
+  import Palaces from './screens/memory/Palaces.svelte';
+  import AgentsChat from './screens/agents/AgentsChat.svelte';
+  import AgentsProjects from './screens/agents/AgentsProjects.svelte';
+  import AgentsAuth from './screens/agents/AgentsAuth.svelte';
+  import AgentsFailure from './screens/agents/AgentsFailure.svelte';
+  import AgentsRecap from './screens/agents/AgentsRecap.svelte';
+  import CodeGui from './screens/code/CodeGui.svelte';
+  import CodeTui from './screens/code/CodeTui.svelte';
+
+  const groups = [
+    { label: 'SEARCH', screens: [
+      { id: 'dashboard', label: 'Dashboard', comp: Dashboard },
+      { id: 'search', label: 'Search', comp: Search },
+      { id: 'indexes', label: 'Indexes', comp: Indexes },
+      { id: 'health', label: 'Health', comp: Health },
+      { id: 'dialogs', label: 'Dialogs', comp: Dialogs }
+    ]},
+    { label: 'CONSOLE', screens: [{ id: 'console', label: 'Command deck', comp: Console }] },
+    { label: 'MEMORY', screens: [{ id: 'palaces', label: 'Palaces', comp: Palaces }] },
+    { label: 'AGENTS', screens: [
+      { id: 'agents-chat', label: 'Chat', comp: AgentsChat },
+      { id: 'agents-projects', label: 'Projects', comp: AgentsProjects },
+      { id: 'agents-auth', label: 'Auth gate', comp: AgentsAuth },
+      { id: 'agents-failure', label: 'Task failure', comp: AgentsFailure },
+      { id: 'agents-recap', label: 'Recap', comp: AgentsRecap }
+    ]},
+    { label: 'CODE', screens: [
+      { id: 'code-gui', label: 'GUI', comp: CodeGui },
+      { id: 'code-tui', label: 'TUI', comp: CodeTui }
+    ]}
+  ];
+  let current = $state(groups[0].screens[0]);
+</script>
+
+<div class="app">
+  <nav>
+    <div class="brand">FOUNDRY <span>· TRUSTY TOOLS</span></div>
+    {#each groups as g}
+      <span class="g-label">{g.label}</span>
+      {#each g.screens as s}
+        <button class:on={current.id === s.id} onclick={() => (current = s)}>{s.label}</button>
+      {/each}
+    {/each}
+  </nav>
+  <main>
+    {#key current.id}
+      {@const Screen = current.comp}
+      <Screen />
+    {/key}
+  </main>
+</div>
+
+<style>
+  .app { display: flex; min-height: 100vh; background: #211b17; }
+  nav { width: 190px; flex: none; padding: 20px 14px; display: flex; flex-direction: column; gap: 3px; position: sticky; top: 0; align-self: flex-start; height: 100vh; box-sizing: border-box; overflow: auto; }
+  .brand { font: 700 14px var(--trusty-display); color: #f5efe7; letter-spacing: 0.04em; margin-bottom: 14px; }
+  .brand span { font: 500 9px var(--trusty-mono); color: #a58a6b; display: block; letter-spacing: 0.12em; margin-top: 2px; }
+  .g-label { font: 600 9px var(--trusty-mono); letter-spacing: 0.16em; color: #a58a6b; margin: 12px 0 4px; }
+  nav button { text-align: left; padding: 7px 10px; border: none; border-left: 3px solid transparent; border-radius: 4px; background: none; color: #cbb69c; font: 500 12.5px var(--trusty-font); cursor: pointer; }
+  nav button:hover { background: rgba(217, 119, 66, 0.09); }
+  nav button.on { background: #46311f; color: #e9b98a; font-weight: 600; border-left-color: #d97742; }
+  main { flex: 1; padding: 32px; overflow: auto; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/lib/AppShell.svelte
+++ b/docs/design/UI/design-system-svelte/src/lib/AppShell.svelte
@@ -1,0 +1,26 @@
+<script>
+  // Full-screen shell: dark sidebar + topbar + content pane. 1440x900 frame.
+  import Sidebar from './Sidebar.svelte';
+  import Topbar from './Topbar.svelte';
+  let { sidebar, crumb, status, topbarActions, children } = $props();
+</script>
+
+<div class="shell">
+  <Sidebar {...sidebar} />
+  <div class="main">
+    <Topbar {crumb} {status} actions={topbarActions} />
+    <div class="content">
+      {@render children?.()}
+    </div>
+  </div>
+</div>
+
+<style>
+  .shell {
+    width: 1440px; height: 900px; display: flex;
+    background: var(--trusty-content-bg); overflow: hidden;
+    font-size: 14px; color: var(--trusty-text-primary); position: relative;
+  }
+  .main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+  .content { padding: 28px 32px; flex: 1; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/lib/Badge.svelte
+++ b/docs/design/UI/design-system-svelte/src/lib/Badge.svelte
@@ -1,0 +1,14 @@
+<script>
+  // tone: '' | 'success' | 'warning' | 'danger' | 'info' | 'muted'
+  let { tone = '', dot = false, spinner = false, children } = $props();
+</script>
+
+<span class="badge inline {tone ? 'badge-' + tone : ''}">
+  {#if spinner}<span class="spinner"></span>{:else if dot}<span class="dot"></span>{/if}
+  {@render children?.()}
+</span>
+
+<style>
+  .inline { display: inline-flex; align-items: center; gap: 6px; }
+  .dot { width: 7px; height: 7px; border-radius: 50%; background: currentColor; flex: none; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/lib/Button.svelte
+++ b/docs/design/UI/design-system-svelte/src/lib/Button.svelte
@@ -1,0 +1,8 @@
+<script>
+  // variant: '' | 'primary' | 'danger' | 'ghost'; size: '' | 'sm'
+  let { variant = '', size = '', disabled = false, onclick, children } = $props();
+</script>
+
+<button class="btn {variant ? 'btn-' + variant : ''} {size ? 'btn-' + size : ''}" {disabled} {onclick}>
+  {@render children?.()}
+</button>

--- a/docs/design/UI/design-system-svelte/src/lib/Modal.svelte
+++ b/docs/design/UI/design-system-svelte/src/lib/Modal.svelte
@@ -1,0 +1,32 @@
+<script>
+  // Set backdrop={false} to render the sheet inline (spec/dialog galleries).
+  let { title, titleMeta = '', danger = false, backdrop = true, onclose, children, footer } = $props();
+</script>
+
+{#snippet sheet()}
+  <div class="modal">
+    <div class="modal-header" class:danger>
+      <div class="titles">
+        <span class="modal-title" class:danger-text={danger}>{title}</span>
+        {#if titleMeta}<span class="meta">{titleMeta}</span>{/if}
+      </div>
+      <button class="x" onclick={onclose}>✕</button>
+    </div>
+    <div class="modal-body">{@render children?.()}</div>
+    {#if footer}<div class="modal-footer">{@render footer()}</div>{/if}
+  </div>
+{/snippet}
+
+{#if backdrop}
+  <div class="modal-backdrop">{@render sheet()}</div>
+{:else}
+  {@render sheet()}
+{/if}
+
+<style>
+  .titles { display: flex; align-items: baseline; gap: 10px; }
+  .meta { font: 600 11px var(--trusty-mono); color: var(--trusty-accent); }
+  .modal-header.danger { background: var(--trusty-danger-soft); }
+  .danger-text { color: #8a2013; }
+  .x { background: none; border: none; color: var(--trusty-text-muted); font-size: 15px; padding: 0; line-height: 1; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/lib/RobotMark.svelte
+++ b/docs/design/UI/design-system-svelte/src/lib/RobotMark.svelte
@@ -1,0 +1,38 @@
+<script>
+  // Foundry robot mark. eyes: 'square' | 'round' | 'visor'.
+  // state: 'idle' | 'receiving' | 'working' | 'none' (maps to foundry.css robot-* animations)
+  let {
+    size = 40,
+    body = 'var(--trusty-accent)',
+    face = '#f5efe7',
+    eyes = 'square',
+    antenna = true,
+    antennaColor = '#e9b98a',
+    state = 'none'
+  } = $props();
+  const u = $derived(size / 40);
+</script>
+
+<div
+  class="robot"
+  class:robot-idle={state === 'idle'}
+  class:robot-working={state === 'working'}
+  class:robot-receiving={state === 'receiving'}
+  style="width:{size}px;height:{size}px;background:{body};border-radius:{6 * u}px;"
+>
+  {#if antenna}
+    <span class="stem" style="top:{-6 * u}px;width:{Math.max(2, 2 * u)}px;height:{7 * u}px;background:{antennaColor};"></span>
+    <span class="tip robot-antenna-tip" style="top:{-10 * u}px;width:{5 * u}px;height:{5 * u}px;background:{antennaColor};"></span>
+    {#if state === 'receiving'}<span class="robot-ring"></span><span class="robot-ring"></span>{/if}
+  {/if}
+  <span class="robot-eye" style="left:{9 * u}px;top:{eyes === 'visor' ? 15 * u : 13 * u}px;width:{7 * u}px;height:{(eyes === 'visor' ? 3 : 7) * u}px;background:{face};border-radius:{eyes === 'round' ? '50%' : '0'};"></span>
+  <span class="robot-eye" style="right:{9 * u}px;top:{eyes === 'visor' ? 15 * u : 13 * u}px;width:{7 * u}px;height:{(eyes === 'visor' ? 3 : 7) * u}px;background:{face};border-radius:{eyes === 'round' ? '50%' : '0'};"></span>
+  <span class="mouth" style="left:{12 * u}px;right:{12 * u}px;bottom:{9 * u}px;height:{3 * u}px;background:{face};"></span>
+</div>
+
+<style>
+  .robot { position: relative; flex: none; }
+  .robot > span { position: absolute; display: block; }
+  .stem, .tip { left: 50%; transform: translateX(-50%); }
+  .tip { border-radius: 50%; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/lib/Sidebar.svelte
+++ b/docs/design/UI/design-system-svelte/src/lib/Sidebar.svelte
@@ -1,0 +1,45 @@
+<script>
+  import RobotMark from './RobotMark.svelte';
+  let {
+    title,
+    unit,
+    items = [],            // [{ icon, label, active }]
+    accent = 'var(--trusty-accent)',
+    mark = {}              // extra RobotMark props
+  } = $props();
+</script>
+
+<aside style="border-right-color:{accent};">
+  <div class="brand">
+    <RobotMark size={40} state="idle" {...mark} />
+    <div>
+      <div class="title">{title}</div>
+      <div class="unit">{unit}</div>
+    </div>
+  </div>
+  <nav>
+    {#each items as it}
+      <div class="item" class:active={it.active}>
+        <span class="icon">{it.icon}</span><span>{it.label}</span>
+      </div>
+    {/each}
+  </nav>
+  <div class="foot">TRUSTY WORKS ⚙ EST. 2026</div>
+</aside>
+
+<style>
+  aside {
+    width: var(--trusty-sidebar-width); flex: none;
+    background: var(--trusty-sidebar-bg); color: var(--trusty-sidebar-text);
+    display: flex; flex-direction: column; border-right: 3px solid;
+  }
+  .brand { padding: 20px 18px; display: flex; align-items: center; gap: 12px; border-bottom: 1px solid var(--trusty-sidebar-border); }
+  .title { font: 700 15px var(--trusty-display); color: #f5efe7; letter-spacing: 0.04em; }
+  .unit { font: 500 10px var(--trusty-mono); color: var(--trusty-sidebar-muted); letter-spacing: 0.12em; }
+  nav { padding: 14px 10px; flex: 1; display: flex; flex-direction: column; gap: 3px; }
+  .item { display: flex; align-items: center; gap: 11px; padding: 10px 13px; border-radius: 4px; border-left: 3px solid transparent; font-weight: 500; cursor: pointer; }
+  .item:hover:not(.active) { background: var(--trusty-surface-hover); }
+  .item.active { background: var(--trusty-sidebar-active); color: var(--trusty-sidebar-accent); font-weight: 600; border-left-color: #d97742; }
+  .icon { width: 15px; text-align: center; }
+  .foot { padding: 14px 18px; border-top: 1px solid var(--trusty-sidebar-border); font: 500 10px var(--trusty-mono); color: var(--trusty-sidebar-muted); letter-spacing: 0.12em; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/lib/StatCard.svelte
+++ b/docs/design/UI/design-system-svelte/src/lib/StatCard.svelte
@@ -1,0 +1,14 @@
+<script>
+  let { label, value, meta = '', accent = false, children } = $props();
+</script>
+
+<div class="stat">
+  <div class="stat-label">{label}</div>
+  {#if value}<div class="stat-value" class:accent>{value}</div>{/if}
+  {@render children?.()}
+  {#if meta}<div class="stat-meta">{meta}</div>{/if}
+</div>
+
+<style>
+  .accent { color: var(--trusty-accent); }
+</style>

--- a/docs/design/UI/design-system-svelte/src/lib/Toast.svelte
+++ b/docs/design/UI/design-system-svelte/src/lib/Toast.svelte
@@ -1,0 +1,17 @@
+<script>
+  // tone: '' | 'success' | 'danger'
+  let { tone = '', title, ondismiss, children } = $props();
+</script>
+
+<div class="toast {tone ? 'toast-' + tone : ''}">
+  <div class="body-wrap">
+    <div class="toast-title">{title}</div>
+    <div class="toast-body">{@render children?.()}</div>
+  </div>
+  <button class="x" onclick={ondismiss}>✕</button>
+</div>
+
+<style>
+  .body-wrap { flex: 1; }
+  .x { background: none; border: none; color: var(--trusty-sidebar-muted); font-size: 14px; line-height: 1; padding: 0; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/lib/Topbar.svelte
+++ b/docs/design/UI/design-system-svelte/src/lib/Topbar.svelte
@@ -1,0 +1,24 @@
+<script>
+  import Badge from './Badge.svelte';
+  let { crumb, status = 'ONLINE v0.4.2', actions } = $props();
+</script>
+
+<header>
+  <span class="crumb">// {crumb}</span>
+  <div class="right">
+    {@render actions?.()}
+    <Badge tone="success" dot>{status}</Badge>
+  </div>
+</header>
+
+<style>
+  header {
+    height: var(--trusty-topbar-height); flex: none;
+    background: var(--trusty-surface-raised);
+    border-bottom: 2px solid var(--trusty-border);
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 32px;
+  }
+  .crumb { font: 600 13px var(--trusty-mono); letter-spacing: 0.1em; color: var(--trusty-text-secondary); }
+  .right { display: flex; align-items: center; gap: 10px; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/main.js
+++ b/docs/design/UI/design-system-svelte/src/main.js
@@ -1,0 +1,6 @@
+import { mount } from 'svelte';
+import './styles/tokens.css';
+import './styles/foundry.css';
+import App from './App.svelte';
+
+export default mount(App, { target: document.getElementById('app') });

--- a/docs/design/UI/design-system-svelte/src/screens/agents/AgentsAuth.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/agents/AgentsAuth.svelte
@@ -1,0 +1,53 @@
+<script>
+  import RobotMark from '../../lib/RobotMark.svelte';
+  import Button from '../../lib/Button.svelte';
+
+  let token = $state('sk-ant-api03-••••••••••••');
+  let endpoint = $state('http://localhost:8790');
+</script>
+
+<div class="dark screen">
+  <span class="corner">TRUSTY WORKS ⚙ EST. 2026</span>
+  <div class="card gate">
+    <div class="ident">
+      <RobotMark size={64} body="#d97742" face="#201612" state="receiving" />
+      <div class="titles">
+        <div class="name">TRUSTY AGENTS</div>
+        <div class="sub">UNIT-04 REQUESTS CREDENTIALS</div>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="form-label lit" for="token">ANTHROPIC API TOKEN</label>
+      <input id="token" class="input" type="password" bind:value={token}>
+      <div class="hint">Stored locally in the OS keychain. Never leaves this machine except to api.anthropic.com.</div>
+    </div>
+    <div class="form-group last">
+      <label class="form-label lit" for="endpoint">MPM ENDPOINT</label>
+      <input id="endpoint" class="input" bind:value={endpoint}>
+      <div class="reach"><span class="dot"></span>DAEMON REACHABLE · trusty-mpm v0.5.0</div>
+    </div>
+    <Button variant="primary">CONNECT →</Button>
+    <div class="links">
+      <a href="#help">Where do I get a token?</a>
+      <a href="#skip" class="dim">Skip — offline mode</a>
+    </div>
+  </div>
+</div>
+
+<style>
+  .screen { width: 1440px; height: 900px; display: flex; align-items: center; justify-content: center; background: var(--trusty-content-bg); overflow: hidden; font-size: 14px; color: var(--trusty-text-primary); position: relative; }
+  .corner { position: absolute; top: 20px; left: 24px; font: 500 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-border-strong); }
+  .gate { width: 480px; padding: 40px 44px; border-radius: var(--trusty-radius-lg); }
+  .ident { display: flex; flex-direction: column; align-items: center; gap: 14px; margin-bottom: 28px; }
+  .titles { text-align: center; }
+  .name { font: 700 22px var(--trusty-display); letter-spacing: 0.03em; }
+  .sub { font: 500 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-text-muted); margin-top: 4px; }
+  .lit { color: var(--trusty-sidebar-accent); }
+  .hint { font-size: 11.5px; color: var(--trusty-text-muted); line-height: 1.5; margin-top: 6px; }
+  .last { margin-bottom: 22px; }
+  .reach { display: flex; align-items: center; gap: 7px; font: 600 10px var(--trusty-mono); color: var(--trusty-success); margin-top: 8px; }
+  .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--trusty-success); }
+  .gate :global(.btn-primary) { width: 100%; justify-content: center; padding: 12px 0; font-size: 13px; letter-spacing: 0.08em; }
+  .links { margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--trusty-border); display: flex; justify-content: space-between; font: 500 11px var(--trusty-mono); }
+  .links .dim { color: var(--trusty-text-muted); }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/agents/AgentsChat.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/agents/AgentsChat.svelte
@@ -1,0 +1,163 @@
+<script>
+  import AgentsHeader from './AgentsHeader.svelte';
+  import Button from '../../lib/Button.svelte';
+  import RobotMark from '../../lib/RobotMark.svelte';
+
+  const history = [
+    { title: 'Fix flaky reindex e2e test', status: 'IMPLEMENTING', tone: '#d9a83a', spinner: true, when: '2m ago', active: true },
+    { title: 'Add disk-usage column to Indexes', status: '✓ COMPLETE', tone: '#8fbf6a', when: '1h ago' },
+    { title: 'Migrate tokens.css to Foundry', status: '✓ COMPLETE', tone: '#8fbf6a', when: '3h ago' },
+    { title: 'Bump usearch to 2.16', status: '✕ FAILED', tone: '#e06a52', when: 'yesterday' }
+  ];
+  const phases = [
+    { name: 'RESEARCH', state: 'done', note: 'root cause isolated' },
+    { name: 'PLAN', state: 'done', note: 'approved by PM' },
+    { name: 'IMPLEMENT', state: 'running', note: 'engineer agent editing tests/reindex_e2e.rs' },
+    { name: 'VERIFY', state: 'queued', note: 'queued' }
+  ];
+  const agents = [
+    { name: 'engineer', dot: '#d9a83a', note: 'editing 1 file' },
+    { name: 'researcher', dot: '#8fbf6a', note: 'idle' },
+    { name: 'qa', dot: '#a58a6b', note: 'waiting' }
+  ];
+</script>
+
+<div class="dark screen">
+  <AgentsHeader tab="CHAT" />
+  <div class="body">
+    <aside class="left">
+      <div class="new"><Button variant="primary">+ NEW TASK</Button></div>
+      <div class="section-label">TASK HISTORY</div>
+      <div class="list">
+        {#each history as h}
+          <div class="task" class:active={h.active}>
+            <div class="t-title" class:dim={!h.active}>{h.title}</div>
+            <div class="t-meta">
+              <span class="t-status" style="color:{h.tone}">
+                {#if h.spinner}<span class="spinner"></span>{/if}{h.status}
+              </span>
+              <span class="t-when">{h.when}</span>
+            </div>
+          </div>
+        {/each}
+      </div>
+      <div class="foot">PM LOOP · RESEARCH→PLAN→IMPLEMENT→VERIFY</div>
+    </aside>
+
+    <div class="center">
+      <div class="thread">
+        <div class="msg user"><div class="bubble">Fix the flaky reindex e2e test — it times out on CI about once in five runs.</div></div>
+        <div class="msg bot">
+          <RobotMark size={30} body="#2b1c12" face="#e9b98a" antenna={false} state="working" />
+          <div class="stack">
+            <div class="bubble">
+              Research complete. The timeout is in <code class="ref">tests/reindex_e2e.rs</code> — the SSE
+              stream assertion races the daemon's batch flush. Plan: replace the fixed 5s sleep with an
+              event-driven wait on the <code class="ref">complete</code> event, bounded at 30s.
+            </div>
+            <div class="workflow">
+              <div class="wf-head"><span>WORKFLOW · TASK #482</span><span class="phase-n">PHASE 3/4</span></div>
+              <div class="wf-body">
+                {#each phases as p}
+                  <div class="wf-row">
+                    <span class="wf-ic">
+                      {#if p.state === 'done'}<span class="ok">✓</span>
+                      {:else if p.state === 'running'}<span class="spinner run"></span>
+                      {:else}<span class="idle">○</span>{/if}
+                    </span>
+                    <span class="wf-name" class:lit={p.state === 'running'} class:mute={p.state === 'queued'}>{p.name}</span>
+                    <span class="wf-note">{p.note}</span>
+                  </div>
+                {/each}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="composer">
+        <textarea class="textarea" rows="2" placeholder="Describe a task for the PM… (Enter to send)"></textarea>
+        <Button variant="primary">SEND</Button>
+      </div>
+    </div>
+
+    <aside class="right">
+      <div class="r-head">SESSION RECAP</div>
+      <div class="r-body">
+        <div>
+          <div class="r-label">AGENTS ACTIVE</div>
+          {#each agents as a}
+            <div class="agent"><span class="dot" style="background:{a.dot}"></span><span class="a-name">{a.name}</span><span class="a-note">{a.note}</span></div>
+          {/each}
+        </div>
+        <div>
+          <div class="r-label">FILES TOUCHED</div>
+          <div class="files">tests/reindex_e2e.rs<br>src/index/stream.rs</div>
+        </div>
+        <div>
+          <div class="r-label">TOKENS</div>
+          <div class="tok-row"><span>42.1k / 200k</span><span class="pct">21%</span></div>
+          <div class="bar wide"><span class="bar-fill" style="width:21%"></span></div>
+        </div>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<style>
+  .screen { width: 1440px; height: 900px; display: flex; flex-direction: column; background: var(--trusty-content-bg); overflow: hidden; font-size: 14px; color: var(--trusty-text-primary); }
+  .body { flex: 1; display: flex; min-height: 0; }
+  aside.left { width: 280px; flex: none; background: var(--trusty-sidebar-bg); border-right: 1px solid var(--trusty-sidebar-border); display: flex; flex-direction: column; }
+  .new { padding: 16px 16px 10px; }
+  .new :global(.btn) { width: 100%; justify-content: center; }
+  .section-label { padding: 8px 16px; font: 600 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-text-muted); }
+  .list { flex: 1; overflow: hidden; padding: 0 10px; display: flex; flex-direction: column; gap: 3px; }
+  .task { padding: 10px 12px; border-radius: 4px; border-left: 3px solid transparent; }
+  .task.active { background: var(--trusty-surface-raised); border-left-color: var(--trusty-accent); }
+  .t-title { font-size: 13px; font-weight: 600; margin-bottom: 3px; }
+  .t-title.dim { font-weight: 500; color: var(--trusty-text-secondary); }
+  .t-meta { display: flex; gap: 8px; align-items: center; }
+  .t-status { display: inline-flex; align-items: center; gap: 5px; font: 600 9px var(--trusty-mono); }
+  .t-status .spinner { width: 8px; height: 8px; }
+  .t-when { font: 500 10px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .foot { padding: 14px 16px; border-top: 1px solid var(--trusty-sidebar-border); font: 500 10px var(--trusty-mono); color: var(--trusty-text-muted); letter-spacing: 0.12em; }
+  .center { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+  .thread { flex: 1; padding: 24px 32px; display: flex; flex-direction: column; gap: 16px; overflow: hidden; }
+  .msg { display: flex; }
+  .msg.user { justify-content: flex-end; }
+  .msg.bot { justify-content: flex-start; gap: 12px; }
+  .msg.bot :global(.robot) { margin-top: 2px; border: 1.5px solid var(--trusty-border-strong); box-sizing: border-box; }
+  .bubble { max-width: 64%; padding: 12px 16px; border-radius: 8px; line-height: 1.6; font-size: 13.5px; }
+  .user .bubble { border-bottom-right-radius: 2px; background: #b7410e; color: #fff; }
+  .bot .bubble, .bot .stack { max-width: 72%; }
+  .bot .stack .bubble { max-width: none; }
+  .stack { display: flex; flex-direction: column; gap: 10px; }
+  .bot .bubble { border-bottom-left-radius: 2px; background: var(--trusty-card-bg); border: 1px solid var(--trusty-border); }
+  .ref { font: 500 12px var(--trusty-mono); color: var(--trusty-sidebar-accent); }
+  .workflow { background: var(--trusty-card-bg); border: 1px solid var(--trusty-border); border-radius: var(--trusty-radius); overflow: hidden; }
+  .wf-head { padding: 9px 14px; background: var(--trusty-surface-raised); font: 600 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-sidebar-accent); display: flex; justify-content: space-between; }
+  .phase-n { color: var(--trusty-warning); }
+  .wf-body { padding: 12px 14px; display: flex; flex-direction: column; gap: 9px; }
+  .wf-row { display: flex; align-items: center; gap: 10px; }
+  .wf-ic { width: 16px; }
+  .ok { font: 600 10px var(--trusty-mono); color: var(--trusty-success); }
+  .idle { font: 600 10px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .spinner.run { width: 9px; height: 9px; color: var(--trusty-warning); }
+  .wf-name { font: 500 12px var(--trusty-mono); color: var(--trusty-text-secondary); }
+  .wf-name.lit { color: var(--trusty-text-primary); }
+  .wf-name.mute { color: var(--trusty-text-muted); }
+  .wf-note { font: 400 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .composer { flex: none; padding: 16px 32px 20px; border-top: 1px solid var(--trusty-sidebar-border); display: flex; gap: 10px; align-items: flex-end; }
+  .composer .textarea { min-height: 0; font-size: 13.5px; }
+  aside.right { width: 300px; flex: none; background: var(--trusty-sidebar-bg); border-left: 1px solid var(--trusty-sidebar-border); display: flex; flex-direction: column; }
+  .r-head { padding: 14px 18px; border-bottom: 1px solid var(--trusty-sidebar-border); font: 600 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-text-muted); }
+  .r-body { padding: 16px 18px; display: flex; flex-direction: column; gap: 14px; font-size: 12.5px; color: var(--trusty-text-secondary); line-height: 1.55; }
+  .r-label { font: 600 10px var(--trusty-mono); letter-spacing: 0.12em; color: var(--trusty-sidebar-accent); margin-bottom: 5px; }
+  .agent { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
+  .dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+  .a-name { font: 500 11px var(--trusty-mono); }
+  .a-note { font: 400 10px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .files { font: 400 11px var(--trusty-mono); line-height: 1.8; }
+  .tok-row { display: flex; justify-content: space-between; margin-bottom: 5px; font: 400 11px var(--trusty-mono); }
+  .pct { color: var(--trusty-text-muted); }
+  .bar.wide { width: 100%; height: 7px; border: none; background: var(--trusty-surface-raised); border-radius: 2px; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/agents/AgentsFailure.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/agents/AgentsFailure.svelte
@@ -1,0 +1,77 @@
+<script>
+  import AgentsHeader from './AgentsHeader.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  import Button from '../../lib/Button.svelte';
+  import RobotMark from '../../lib/RobotMark.svelte';
+</script>
+
+<div class="dark screen">
+  <AgentsHeader subtitle="TASK #479 · BUMP USEARCH TO 2.16" showTabs={false}>
+    {#snippet right()}
+      <Badge tone="danger" dot>VERIFY FAILED</Badge>
+    {/snippet}
+  </AgentsHeader>
+
+  <div class="body">
+    <div class="thread">
+      <div class="msg user"><div class="bubble">Bump usearch to 2.16 and make sure all index tests still pass.</div></div>
+      <div class="msg bot">
+        <RobotMark size={30} body="#2b1c12" face="#e06a52" eyes="visor" antenna={false} />
+        <div class="stack">
+          <div class="bubble">
+            Implementation finished, but the VERIFY gate caught two regressions. The 2.16 API changed
+            <code class="ref">Index::add</code> to take owned vectors — two call sites still pass references.
+          </div>
+          <div class="fail">
+            <div class="fail-head"><span>✕ VERIFY FAILED · cargo test</span><span>2 FAILURES / 148 TESTS</span></div>
+            <div class="fail-log">
+              <div class="f">FAILED  index::tests::add_batch_borrowed</div>
+              <div class="d">error[E0308]: mismatched types — expected Vec&lt;f32&gt;, found &amp;Vec&lt;f32&gt;</div>
+              <div class="d">src/index/hnsw.rs:214</div>
+              <div class="f gap">FAILED  index::tests::reindex_preserves_ids</div>
+              <div class="d">src/index/reindex.rs:88 — same mismatch</div>
+            </div>
+            <div class="fail-acts">
+              <Button variant="primary" size="sm">RETRY — FIX CALL SITES</Button>
+              <Button size="sm">OPEN DIFF</Button>
+              <Button variant="danger" size="sm">ROLL BACK BRANCH</Button>
+            </div>
+          </div>
+          <div class="pm-note">
+            PM recommendation: retry. The fix is mechanical — pass owned clones at both call sites.
+            Estimated 1 phase, no plan change needed.
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="composer">
+      <textarea class="textarea" rows="2" placeholder="Reply to the PM… (Enter to send)"></textarea>
+      <Button variant="primary">SEND</Button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .screen { width: 1440px; height: 900px; display: flex; flex-direction: column; background: var(--trusty-content-bg); overflow: hidden; font-size: 14px; color: var(--trusty-text-primary); }
+  .body { flex: 1; display: flex; flex-direction: column; min-height: 0; max-width: 960px; width: 100%; margin: 0 auto; }
+  .thread { flex: 1; padding: 28px 32px; display: flex; flex-direction: column; gap: 16px; overflow: hidden; }
+  .msg { display: flex; }
+  .msg.user { justify-content: flex-end; }
+  .msg.bot { justify-content: flex-start; gap: 12px; }
+  .msg.bot :global(.robot) { margin-top: 2px; border: 1.5px solid var(--trusty-border-strong); box-sizing: border-box; }
+  .bubble { max-width: 64%; padding: 12px 16px; border-radius: 8px; line-height: 1.6; font-size: 13.5px; }
+  .user .bubble { border-bottom-right-radius: 2px; background: #b7410e; color: #fff; }
+  .stack { max-width: 76%; display: flex; flex-direction: column; gap: 10px; }
+  .stack .bubble { max-width: none; border-bottom-left-radius: 2px; background: var(--trusty-card-bg); border: 1px solid var(--trusty-border); }
+  .ref { font: 500 12px var(--trusty-mono); color: var(--trusty-sidebar-accent); }
+  .fail { background: var(--trusty-card-bg); border: 1.5px solid #7a3428; border-radius: var(--trusty-radius); overflow: hidden; }
+  .fail-head { padding: 9px 14px; background: var(--trusty-danger-soft); font: 600 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-danger); display: flex; justify-content: space-between; }
+  .fail-log { padding: 12px 14px; font: 400 11.5px var(--trusty-mono); color: var(--trusty-text-secondary); line-height: 1.8; background: var(--trusty-sidebar-bg); }
+  .f { color: var(--trusty-danger); }
+  .f.gap { margin-top: 6px; }
+  .d { color: var(--trusty-text-muted); padding-left: 16px; }
+  .fail-acts { padding: 10px 14px; border-top: 1px solid var(--trusty-border); display: flex; gap: 8px; }
+  .pm-note { padding: 10px 14px; border-radius: var(--trusty-radius); background: var(--trusty-warning-soft); border: 1px solid #6b5320; font-size: 12.5px; color: var(--trusty-warning); line-height: 1.55; }
+  .composer { flex: none; padding: 16px 32px 20px; border-top: 1px solid var(--trusty-sidebar-border); display: flex; gap: 10px; align-items: flex-end; }
+  .composer .textarea { min-height: 0; font-size: 13.5px; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/agents/AgentsHeader.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/agents/AgentsHeader.svelte
@@ -1,0 +1,37 @@
+<script>
+  // Shared header for all trusty-agents (dark) screens.
+  import RobotMark from '../../lib/RobotMark.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  let { subtitle = 'UNIT-04 · MPM ORCHESTRATION', tab = 'CHAT', showTabs = true, right } = $props();
+</script>
+
+<header>
+  <div class="left">
+    <RobotMark size={30} body="#d97742" face="#201612" state="working" />
+    <span class="brand">TRUSTY AGENTS</span>
+    <span class="sub">{subtitle}</span>
+  </div>
+  <div class="right">
+    {#if showTabs}
+      <div class="tabs">
+        <span class:on={tab === 'CHAT'}>CHAT</span>
+        <span class:on={tab === 'PROJECTS'}>PROJECTS</span>
+      </div>
+    {/if}
+    <span class="chip">DESKTOP</span>
+    <Badge tone="success" dot>API READY</Badge>
+    {@render right?.()}
+  </div>
+</header>
+
+<style>
+  header { height: 52px; flex: none; background: var(--trusty-sidebar-bg); border-bottom: 1px solid var(--trusty-sidebar-border); display: flex; align-items: center; justify-content: space-between; padding: 0 20px; }
+  .left, .right { display: flex; align-items: center; gap: 12px; }
+  .right { gap: 10px; }
+  .brand { font: 700 15px var(--trusty-display); letter-spacing: 0.04em; }
+  .sub { font: 500 10px var(--trusty-mono); letter-spacing: 0.12em; color: var(--trusty-text-muted); }
+  .tabs { display: flex; gap: 2px; }
+  .tabs span { padding: 5px 14px; font: 600 11px var(--trusty-mono); color: var(--trusty-text-muted); border-radius: 4px; }
+  .tabs .on { color: var(--trusty-accent); background: var(--trusty-accent-soft); }
+  .chip { padding: 2px 8px; border-radius: 4px; font: 600 10px var(--trusty-mono); background: var(--trusty-accent-soft); color: var(--trusty-sidebar-accent); border: 1px solid var(--trusty-border-strong); }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/agents/AgentsProjects.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/agents/AgentsProjects.svelte
@@ -1,0 +1,124 @@
+<script>
+  import AgentsHeader from './AgentsHeader.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  import Button from '../../lib/Button.svelte';
+
+  const projects = [
+    {
+      name: 'trusty-search', top: '#d97742', status: { tone: 'warning', spinner: true, label: '1 RUNNING' },
+      meta: '~/code/trusty-search · rust\nmain · clean · 8 tasks done',
+      tasks: [
+        { dot: '#d9a83a', text: 'Fix flaky reindex e2e test', tag: 'IMPL', tagColor: '#d9a83a' },
+        { dot: '#8fbf6a', text: 'Add disk-usage column', tag: 'DONE', tagColor: '#8fbf6a' }
+      ],
+      cta: { variant: 'primary', label: 'OPEN CHAT →' }
+    },
+    {
+      name: 'trusty-memory', top: '#8a5a2b', status: { tone: 'success', dot: true, label: 'IDLE' },
+      meta: '~/code/trusty-memory · rust\nmain · clean · 3 tasks done',
+      tasks: [
+        { dot: '#8fbf6a', text: 'Dream-phase compaction pass', tag: 'DONE', tagColor: '#8fbf6a' },
+        { dot: '#8fbf6a', text: 'Palace export to JSONL', tag: 'DONE', tagColor: '#8fbf6a' }
+      ],
+      cta: { variant: '', label: 'OPEN CHAT →' }
+    },
+    {
+      name: 'trusty-code', top: '#6e5843', status: { tone: 'danger', dot: true, label: '1 FAILED' },
+      meta: '~/code/trusty-code · rust\nfeat/verify-gate · 2 dirty files',
+      tasks: [
+        { dot: '#e06a52', text: 'Bump usearch to 2.16', tag: 'FAILED', tagColor: '#e06a52' },
+        { dot: '#a58a6b', text: 'Session resume from TUI', tag: 'QUEUED', tagColor: '#a58a6b' }
+      ],
+      cta: { variant: 'danger', label: 'REVIEW FAILURE →' }
+    }
+  ];
+  const activity = [
+    { t: '14:02', kind: 'IMPLEMENT', color: '#d9a83a', text: 'engineer editing tests/reindex_e2e.rs', proj: 'trusty-search' },
+    { t: '13:58', kind: 'PLAN ✓', color: '#8fbf6a', text: 'PM approved plan for task #482', proj: 'trusty-search' },
+    { t: '13:41', kind: 'VERIFY ✕', color: '#e06a52', text: 'cargo test failed — 2 regressions in usearch bump', proj: 'trusty-code' },
+    { t: '12:10', kind: 'COMPLETE', color: '#8fbf6a', text: 'Dream-phase compaction pass merged', proj: 'trusty-memory' }
+  ];
+</script>
+
+<div class="dark screen">
+  <AgentsHeader tab="PROJECTS" />
+  <div class="content">
+    <div class="head">
+      <h1 class="page-title">PROJECTS</h1>
+      <div class="tools">
+        <input class="input" placeholder="filter projects…">
+        <Button variant="primary">+ LINK REPO</Button>
+      </div>
+    </div>
+    <div class="subhead">3 LINKED REPOS · 12 TASKS THIS WEEK · PM LOOP ENABLED ON ALL</div>
+
+    <div class="grid">
+      {#each projects as p}
+        <div class="card proj" style="border-top:3px solid {p.top};">
+          <div class="p-head">
+            <span class="p-name">{p.name}</span>
+            <Badge tone={p.status.tone} dot={p.status.dot} spinner={p.status.spinner}>{p.status.label}</Badge>
+          </div>
+          <div class="p-meta">{p.meta}</div>
+          <div class="p-tasks">
+            {#each p.tasks as t}
+              <div class="p-task">
+                <span class="dot" style="background:{t.dot}"></span>
+                <span class="truncate">{t.text}</span>
+                <span class="tag-mini" style="color:{t.tagColor}">{t.tag}</span>
+              </div>
+            {/each}
+          </div>
+          <div class="p-act"><Button variant={p.cta.variant} size="sm">{p.cta.label}</Button></div>
+        </div>
+      {/each}
+    </div>
+
+    <div class="log card-dark">
+      <div class="log-head">
+        <span>RECENT ACTIVITY · ALL PROJECTS</span>
+        <a href="#log">FULL LOG →</a>
+      </div>
+      <div class="log-rows">
+        {#each activity as a}
+          <div class="log-row">
+            <span class="t">{a.t}</span>
+            <span class="kind" style="color:{a.color}">{a.kind}</span>
+            <span class="text">{a.text}</span>
+            <span class="proj">{a.proj}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .screen { width: 1440px; height: 900px; display: flex; flex-direction: column; background: var(--trusty-content-bg); overflow: hidden; font-size: 14px; color: var(--trusty-text-primary); }
+  .content { flex: 1; padding: 32px 40px; overflow: hidden; min-height: 0; }
+  .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 8px; }
+  h1 { font-size: 26px; margin: 0; }
+  .tools { display: flex; gap: 10px; align-items: center; }
+  .tools .input { width: 240px; padding: 8px 14px; font-size: 12px; }
+  .subhead { font: 500 11px var(--trusty-mono); color: var(--trusty-text-muted); margin-bottom: 22px; }
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-bottom: 24px; }
+  .proj { padding: 20px; }
+  .p-head { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 10px; }
+  .p-name { font: 700 16px var(--trusty-display); }
+  .p-meta { font: 400 11px var(--trusty-mono); color: var(--trusty-text-muted); line-height: 1.9; margin-bottom: 14px; white-space: pre-line; }
+  .p-tasks { display: flex; flex-direction: column; gap: 7px; padding-top: 12px; border-top: 1px solid var(--trusty-border); font-size: 12.5px; color: var(--trusty-text-secondary); }
+  .p-task { display: flex; gap: 8px; align-items: center; }
+  .p-task .truncate { flex: 1; }
+  .dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+  .tag-mini { font: 500 10px var(--trusty-mono); }
+  .p-act { margin-top: 16px; }
+  .card-dark { background: var(--trusty-sidebar-bg); border: 1px solid var(--trusty-sidebar-border); border-radius: var(--trusty-radius); overflow: hidden; }
+  .log-head { padding: 10px 18px; border-bottom: 1px solid var(--trusty-sidebar-border); display: flex; justify-content: space-between; align-items: center; font: 600 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-text-muted); }
+  .log-head a { font: 600 10px var(--trusty-mono); letter-spacing: 0.08em; }
+  .log-rows { padding: 6px 0; font: 400 12px var(--trusty-mono); }
+  .log-row { display: flex; gap: 16px; padding: 8px 18px; color: var(--trusty-text-secondary); }
+  .t { color: var(--trusty-text-muted); flex: 0 0 60px; }
+  .kind { flex: 0 0 110px; }
+  .text { flex: 1; }
+  .proj { color: var(--trusty-text-muted); }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/agents/AgentsRecap.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/agents/AgentsRecap.svelte
@@ -1,0 +1,162 @@
+<script>
+  import Button from '../../lib/Button.svelte';
+
+  const phases = [
+    { name: 'RESEARCH', state: 'done', time: '13:44 → 13:51 · 7m · researcher', note: 'Reproduced the timeout locally (1 in 6 runs). Isolated race between SSE stream assertion and daemon batch flush.' },
+    { name: 'PLAN', state: 'done', time: '13:51 → 13:58 · 7m · PM + user', note: 'Replace fixed 5s sleep with event-driven wait on the complete event, 30s bound. Approved without changes.' },
+    { name: 'IMPLEMENT', state: 'running', time: '13:58 → now · 12m · engineer', note: 'Editing tests/reindex_e2e.rs — event-wait helper added, replacing sleep at 3 call sites (2 of 3 done).' },
+    { name: 'VERIFY', state: 'queued', time: 'queued · qa', note: 'Will run the e2e suite 20× to confirm flake is gone.' }
+  ];
+  const files = [
+    { op: 'M', opColor: '#d9a83a', path: 'tests/reindex_e2e.rs', add: '+41', del: '−18' },
+    { op: 'A', opColor: '#8fbf6a', path: 'tests/support/event_wait.rs', add: '+66', del: '−0' },
+    { op: 'M', opColor: '#d9a83a', path: 'src/index/stream.rs', add: '+3', del: '−1' }
+  ];
+  const agents = [
+    { name: 'engineer', dot: '#d9a83a', note: 'editing · 12m active · 28.4k tokens' },
+    { name: 'researcher', dot: '#8fbf6a', note: 'done · 7m active · 9.8k tokens' },
+    { name: 'qa', dot: '#a58a6b', note: 'waiting on IMPLEMENT' }
+  ];
+</script>
+
+<div class="dark screen">
+  <header>
+    <div class="left">
+      <span class="back">← BACK TO CHAT</span>
+      <span class="brand">SESSION RECAP</span>
+      <span class="sub">TASK #482 · FIX FLAKY REINDEX E2E TEST</span>
+    </div>
+    <div class="acts">
+      <Button size="sm">EXPORT MARKDOWN</Button>
+      <Button variant="primary" size="sm">SAVE TO MEMORY</Button>
+    </div>
+  </header>
+
+  <div class="body">
+    <div class="main">
+      <section>
+        <div class="s-label">PHASE TIMELINE</div>
+        <div class="card timeline">
+          {#each phases as p, i}
+            <div class="ph">
+              <div class="rail">
+                <span class="node {p.state}">
+                  {#if p.state === 'done'}✓{:else if p.state === 'running'}<span class="spinner"></span>{:else}○{/if}
+                </span>
+                {#if i < phases.length - 1}<span class="line"></span>{/if}
+              </div>
+              <div class="ph-body" class:pad={i < phases.length - 1}>
+                <div class="ph-head">
+                  <span class="ph-name" class:mute={p.state === 'queued'}>{p.name}</span>
+                  <span class="ph-time" class:warn={p.state === 'running'}>{p.time}</span>
+                </div>
+                <div class="ph-note" class:mute={p.state === 'queued'}>{p.note}</div>
+              </div>
+            </div>
+          {/each}
+        </div>
+      </section>
+      <section>
+        <div class="s-label">FILES TOUCHED</div>
+        <div class="files card-dark">
+          {#each files as f}
+            <div class="file">
+              <span class="op" style="color:{f.opColor}">{f.op}</span>
+              <span class="path">{f.path}</span>
+              <span class="add">{f.add}</span>
+              <span class="del">{f.del}</span>
+            </div>
+          {/each}
+        </div>
+      </section>
+    </div>
+
+    <aside>
+      <section>
+        <div class="s-label">AGENTS</div>
+        <div class="agents">
+          {#each agents as a}
+            <div class="agent card">
+              <span class="dot" style="background:{a.dot}"></span>
+              <div>
+                <div class="a-name">{a.name}</div>
+                <div class="a-note">{a.note}</div>
+              </div>
+            </div>
+          {/each}
+        </div>
+      </section>
+      <section>
+        <div class="s-label">BUDGET</div>
+        <div class="budget">
+          <div>
+            <div class="b-row"><span>TOKENS</span><span class="dim">42.1k / 200k · 21%</span></div>
+            <div class="track"><span style="width:21%; background:var(--trusty-accent);"></span></div>
+          </div>
+          <div>
+            <div class="b-row"><span>WALL CLOCK</span><span class="dim">26m / 60m cap</span></div>
+            <div class="track"><span style="width:43%; background:var(--trusty-warning);"></span></div>
+          </div>
+          <div class="b-row"><span>EST. COST</span><span class="dim">$0.84</span></div>
+        </div>
+      </section>
+      <section>
+        <div class="s-label">MEMORY WRITES</div>
+        <div class="mem card">
+          2 drawers queued for palace <code class="ref">trusty-search/testing</code>: flake root cause;
+          event-wait helper pattern.
+        </div>
+      </section>
+    </aside>
+  </div>
+</div>
+
+<style>
+  .screen { width: 1440px; height: 900px; display: flex; flex-direction: column; background: var(--trusty-content-bg); overflow: hidden; font-size: 14px; color: var(--trusty-text-primary); }
+  header { height: 52px; flex: none; background: var(--trusty-sidebar-bg); border-bottom: 1px solid var(--trusty-sidebar-border); display: flex; align-items: center; justify-content: space-between; padding: 0 20px; }
+  .left { display: flex; align-items: center; gap: 12px; }
+  .back { font: 600 12px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .brand { font: 700 15px var(--trusty-display); letter-spacing: 0.04em; }
+  .sub { font: 500 10px var(--trusty-mono); letter-spacing: 0.12em; color: var(--trusty-text-muted); }
+  .acts { display: flex; gap: 8px; }
+  .body { flex: 1; display: flex; min-height: 0; }
+  .main { flex: 1; padding: 28px 32px; display: flex; flex-direction: column; gap: 20px; overflow: hidden; min-width: 0; }
+  .s-label { font: 600 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-sidebar-accent); margin-bottom: 10px; }
+  .timeline { padding: 18px 20px; }
+  .ph { display: flex; gap: 14px; }
+  .rail { display: flex; flex-direction: column; align-items: center; }
+  .node { width: 22px; height: 22px; border-radius: 50%; font: 600 11px var(--trusty-mono); display: flex; align-items: center; justify-content: center; }
+  .node.done { background: var(--trusty-success-soft); border: 1.5px solid var(--trusty-success); color: var(--trusty-success); }
+  .node.running { background: var(--trusty-warning-soft); border: 1.5px solid var(--trusty-warning); color: var(--trusty-warning); }
+  .node.running .spinner { width: 8px; height: 8px; }
+  .node.queued { border: 1.5px solid var(--trusty-border-strong); color: var(--trusty-text-muted); }
+  .line { width: 2px; flex: 1; background: var(--trusty-border); min-height: 26px; }
+  .ph-body.pad { padding-bottom: 16px; }
+  .ph-head { display: flex; gap: 10px; align-items: baseline; }
+  .ph-name { font: 600 12px var(--trusty-mono); }
+  .ph-name.mute { color: var(--trusty-text-muted); }
+  .ph-time { font: 400 10px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .ph-time.warn { color: var(--trusty-warning); }
+  .ph-note { font-size: 12.5px; color: var(--trusty-text-secondary); line-height: 1.55; margin-top: 4px; }
+  .ph-note.mute { color: var(--trusty-text-muted); }
+  .card-dark { background: var(--trusty-sidebar-bg); border: 1px solid var(--trusty-sidebar-border); border-radius: var(--trusty-radius); font: 400 12px var(--trusty-mono); }
+  .file { display: flex; gap: 14px; padding: 9px 16px; color: var(--trusty-text-secondary); border-bottom: 1px solid var(--trusty-sidebar-border); }
+  .file:last-child { border-bottom: none; }
+  .op { width: 14px; }
+  .path { flex: 1; }
+  .add { color: var(--trusty-success); }
+  .del { color: var(--trusty-danger); }
+  aside { width: 340px; flex: none; background: var(--trusty-sidebar-bg); border-left: 1px solid var(--trusty-sidebar-border); padding: 28px 24px; display: flex; flex-direction: column; gap: 22px; overflow: hidden; }
+  .agents { display: flex; flex-direction: column; gap: 10px; }
+  .agent { display: flex; align-items: center; gap: 10px; padding: 10px 12px; }
+  .dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+  .a-name { font: 600 12px var(--trusty-mono); }
+  .a-note { font: 400 10px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .budget { display: flex; flex-direction: column; gap: 12px; }
+  .b-row { display: flex; justify-content: space-between; margin-bottom: 5px; font: 400 11px var(--trusty-mono); }
+  .dim { color: var(--trusty-text-muted); }
+  .track { height: 7px; background: var(--trusty-surface-raised); border-radius: 2px; overflow: hidden; }
+  .track span { display: block; height: 100%; }
+  .mem { font-size: 12px; color: var(--trusty-text-secondary); line-height: 1.6; padding: 10px 12px; }
+  .ref { font: 500 11px var(--trusty-mono); color: var(--trusty-sidebar-accent); }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/code/CodeGui.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/code/CodeGui.svelte
@@ -1,0 +1,167 @@
+<script>
+  import AgentsHeader from '../agents/AgentsHeader.svelte';
+  import RobotMark from '../../lib/RobotMark.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  import Button from '../../lib/Button.svelte';
+
+  const sessions = [
+    { title: '#482 Fix flaky reindex e2e', status: 'IMPLEMENT', tone: '#d9a83a', spinner: true, when: '1m 12s', active: true },
+    { title: '#481 Disk-usage column', status: '✓ MERGED', tone: '#8fbf6a', when: '1h ago' },
+    { title: '#479 Bump usearch 2.16', status: '✕ FAILED', tone: '#e06a52', when: 'yesterday' }
+  ];
+  const output = [
+    { t: '09:14:03', kind: 'TOOL', kindColor: '#e9b98a', text: 'read tests/reindex_e2e.rs' },
+    { t: '09:14:11', kind: 'TOOL', kindColor: '#e9b98a', text: 'edit tests/reindex_e2e.rs' },
+    { t: '09:14:19', kind: 'TOOL', kindColor: '#e9b98a', text: 'cargo test reindex_e2e' },
+    { t: '', kind: '', text: '3 passed · 0 failed · 4.2s', ok: true },
+    { t: '09:14:31', kind: 'INFO', kindColor: '#8fbf6a', text: 'engineer → qa handoff' },
+    { t: '09:14:31', kind: 'PM', kindColor: '#d97742', text: 'ready for VERIFY', cursor: true }
+  ];
+</script>
+
+<div class="dark screen">
+  <header>
+    <div class="left">
+      <RobotMark size={30} body="#d97742" face="#201612" state="working" />
+      <span class="brand">TRUSTY CODE</span>
+      <span class="sub">CODING HARNESS · trusty-tools · feat/foundry-ds</span>
+    </div>
+    <div class="right">
+      <span class="chip warn">IMPLEMENT 3/4</span>
+      <Badge tone="success" dot>SERVE :8790</Badge>
+    </div>
+  </header>
+
+  <div class="body">
+    <aside>
+      <div class="new"><Button variant="primary">+ NEW TASK</Button></div>
+      <div class="s-label">SESSIONS</div>
+      <div class="list">
+        {#each sessions as s}
+          <div class="sess" class:active={s.active}>
+            <div class="s-title" class:dim={!s.active}>{s.title}</div>
+            <div class="s-meta">
+              <span class="s-status" style="color:{s.tone}">
+                {#if s.spinner}<span class="spinner"></span>{/if}{s.status}
+              </span>
+              <span class="s-when">{s.when}</span>
+            </div>
+          </div>
+        {/each}
+      </div>
+      <div class="foot">AGENTS <span class="amber">engineer●</span> qa○<br>TOKENS <span class="lit">42.1k/200k</span></div>
+    </aside>
+
+    <div class="main">
+      <div class="phasebar-wrap">
+        <div class="phasebar">
+          <div class="seg"><span class="ok">✓</span><span class="pname">RESEARCH</span><span class="conn done"></span></div>
+          <div class="seg"><span class="ok">✓</span><span class="pname">PLAN</span><span class="conn done"></span></div>
+          <div class="seg"><span class="spinner amber-sp"></span><span class="pname lit">IMPLEMENT</span><span class="conn"></span></div>
+          <div class="seg end"><span class="mute">○</span><span class="pname mute">VERIFY</span></div>
+        </div>
+      </div>
+
+      <div class="panes">
+        <div class="pane diff">
+          <div class="pane-head">
+            <span class="file">tests/reindex_e2e.rs</span>
+            <span class="stats"><i class="add">+3</i> <i class="del">−2</i> · 1 of 2 files</span>
+          </div>
+          <div class="code">
+            <div class="hunk">@@ -88,7 +88,8 @@ async fn reindex_completes()</div>
+            <div class="ctx">    daemon.trigger_reindex("fixture").await?;</div>
+            <div class="rm">-   tokio::time::sleep(Duration::from_secs(5)).await;</div>
+            <div class="rm">-   assert!(stream.saw("complete"));</div>
+            <div class="ad">+   // Event-driven wait, bounded — no more fixed-sleep race (#482).</div>
+            <div class="ad">+   wait_for_event(&amp;mut stream, "complete", TIMEOUT_30S).await?;</div>
+            <div class="ad">+   assert_eq!(stream.last_event(), "complete");</div>
+            <div class="ctx">    daemon.shutdown().await;</div>
+          </div>
+        </div>
+        <div class="pane">
+          <div class="pane-head label">SESSION OUTPUT</div>
+          <div class="log">
+            {#each output as o}
+              <div class:indent={o.ok} class:okline={o.ok}>
+                {#if o.t}<span class="t" class:pm={o.kind === 'PM'}>{o.t}</span> <span style="color:{o.kindColor}">{o.kind}</span> {/if}{o.text}{#if o.cursor}<span class="cursor"></span>{/if}
+              </div>
+            {/each}
+          </div>
+        </div>
+      </div>
+
+      <div class="gate">
+        <span class="gate-label">VERIFY GATE</span>
+        <span class="gate-text">Tests pass locally. Approve to run the full verify phase (CI matrix + lint) and open the PR.</span>
+        <Button size="sm">REQUEST CHANGES</Button>
+        <Button variant="primary" size="sm">APPROVE &amp; VERIFY</Button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .screen { width: 1440px; height: 900px; display: flex; flex-direction: column; background: var(--trusty-content-bg); overflow: hidden; font-size: 14px; color: var(--trusty-text-primary); }
+  header { height: 52px; flex: none; background: var(--trusty-sidebar-bg); border-bottom: 1px solid var(--trusty-sidebar-border); display: flex; align-items: center; justify-content: space-between; padding: 0 20px; }
+  .left, .right { display: flex; align-items: center; gap: 12px; }
+  .right { gap: 10px; }
+  .brand { font: 700 15px var(--trusty-display); letter-spacing: 0.04em; }
+  .sub { font: 500 10px var(--trusty-mono); letter-spacing: 0.12em; color: var(--trusty-text-muted); }
+  .chip.warn { padding: 2px 8px; border-radius: 4px; font: 600 10px var(--trusty-mono); background: var(--trusty-warning-soft); color: var(--trusty-warning); border: 1px solid var(--trusty-border-strong); }
+  .body { flex: 1; display: flex; min-height: 0; }
+  aside { width: 264px; flex: none; background: var(--trusty-sidebar-bg); border-right: 1px solid var(--trusty-sidebar-border); display: flex; flex-direction: column; }
+  .new { padding: 14px 14px 10px; }
+  .new :global(.btn) { width: 100%; justify-content: center; }
+  .s-label { padding: 6px 14px; font: 600 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-text-muted); }
+  .list { flex: 1; padding: 0 8px; display: flex; flex-direction: column; gap: 3px; }
+  .sess { padding: 10px 12px; border-radius: 4px; border-left: 3px solid transparent; }
+  .sess.active { background: var(--trusty-surface-raised); border-left-color: var(--trusty-accent); }
+  .s-title { font-size: 13px; font-weight: 600; margin-bottom: 3px; }
+  .s-title.dim { font-weight: 500; color: var(--trusty-text-secondary); }
+  .s-meta { display: flex; gap: 8px; }
+  .s-status { display: inline-flex; align-items: center; gap: 5px; font: 600 9px var(--trusty-mono); }
+  .s-status .spinner { width: 8px; height: 8px; }
+  .s-when { font: 500 10px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .foot { padding: 12px 14px; border-top: 1px solid var(--trusty-sidebar-border); font: 500 10px var(--trusty-mono); color: var(--trusty-text-muted); line-height: 1.9; }
+  .amber { color: #d9a83a; }
+  .lit { color: var(--trusty-sidebar-accent); }
+  .main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+  .phasebar-wrap { flex: none; padding: 16px 24px 0; }
+  .phasebar { display: flex; align-items: center; background: var(--trusty-sidebar-bg); border: 1px solid var(--trusty-sidebar-border); border-radius: 5px; padding: 12px 18px; }
+  .seg { display: flex; align-items: center; gap: 9px; flex: 1; }
+  .seg.end { flex: none; }
+  .ok { font: 600 11px var(--trusty-mono); color: var(--trusty-success); }
+  .mute { font: 600 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .pname { font: 600 11px var(--trusty-mono); color: var(--trusty-text-secondary); }
+  .pname.lit { color: var(--trusty-text-primary); }
+  .pname.mute { color: var(--trusty-text-muted); }
+  .conn { flex: 1; height: 2px; background: var(--trusty-surface-raised); margin: 0 6px; }
+  .conn.done { background: var(--trusty-success); }
+  .amber-sp { width: 10px; height: 10px; color: var(--trusty-warning); }
+  .panes { flex: 1; display: flex; gap: 16px; padding: 16px 24px; min-height: 0; }
+  .pane { flex: 1; background: var(--trusty-sidebar-bg); border: 1px solid var(--trusty-sidebar-border); border-radius: 5px; overflow: hidden; display: flex; flex-direction: column; min-width: 0; }
+  .pane.diff { flex: 1.3; }
+  .pane-head { padding: 10px 16px; border-bottom: 1px solid var(--trusty-sidebar-border); display: flex; justify-content: space-between; align-items: center; }
+  .pane-head.label { font: 600 10px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-text-muted); }
+  .file { font: 600 11px var(--trusty-mono); color: var(--trusty-sidebar-accent); }
+  .stats { font: 500 10px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .stats i { font-style: normal; }
+  .add { color: var(--trusty-success); }
+  .del { color: var(--trusty-danger); }
+  .code { flex: 1; padding: 12px 16px; font: 400 12px var(--trusty-mono); line-height: 1.85; overflow: hidden; }
+  .hunk { color: var(--trusty-text-muted); }
+  .ctx { color: var(--trusty-text-secondary); }
+  .rm { background: var(--trusty-danger-soft); color: var(--trusty-danger); }
+  .ad { background: var(--trusty-success-soft); color: var(--trusty-success); }
+  .log { flex: 1; padding: 12px 16px; font: 400 11.5px var(--trusty-mono); line-height: 1.95; overflow: hidden; color: var(--trusty-text-secondary); }
+  .t { color: var(--trusty-text-muted); }
+  .t.pm { color: var(--trusty-accent); }
+  .indent { padding-left: 70px; }
+  .okline { color: var(--trusty-success); }
+  .cursor { display: inline-block; width: 7px; height: 13px; background: var(--trusty-accent); vertical-align: text-bottom; margin-left: 4px; animation: tc-blink 1s step-end infinite; }
+  @keyframes tc-blink { 50% { opacity: 0; } }
+  .gate { flex: none; margin: 0 24px 20px; background: var(--trusty-surface-raised); border: 1px solid var(--trusty-border-strong); border-radius: 5px; padding: 12px 18px; display: flex; align-items: center; gap: 14px; }
+  .gate-label { font: 600 11px var(--trusty-mono); letter-spacing: 0.12em; color: var(--trusty-sidebar-accent); }
+  .gate-text { font-size: 13px; color: var(--trusty-text-secondary); flex: 1; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/code/CodeTui.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/code/CodeTui.svelte
@@ -1,0 +1,66 @@
+<script>
+  // Faithful HTML rendering of the tcode terminal UI (Foundry ANSI palette).
+</script>
+
+<div class="tui">
+  <pre class="mark">  ┌─[◠]─┐
+  │ ■ ■ │  TCODE v0.6.0 — CODING HARNESS
+  │ ───── │  project: trusty-tools · branch: feat/foundry-ds
+  └──────┘</pre>
+  <div class="rule"></div>
+  <div class="cols">
+    <div class="panel side">
+      <div class="p-label">TASK #482 · WORKFLOW</div>
+      <div><span class="green">✓ RESEARCH</span> <span class="mute">· 42s · root cause isolated</span></div>
+      <div><span class="green">✓ PLAN</span> <span class="mute">· 18s · approved</span></div>
+      <div><span class="amber">▶ IMPLEMENT</span> <span class="fg">· running 1m 12s</span></div>
+      <div class="mute nest">└ engineer → tests/reindex_e2e.rs</div>
+      <div class="mute">○ VERIFY · queued</div>
+      <div class="side-foot">AGENTS: <span class="amber">engineer●</span> researcher○ qa○<br>TOKENS: <span class="peach">42.1k/200k</span> ▮▮▮▯▯▯▯▯▯▯</div>
+    </div>
+    <div class="panel out">
+      <div class="p-label">SESSION OUTPUT</div>
+      <div><span class="mute">09:14:02</span> <span class="green">INFO</span> pm: phase transition PLAN → IMPLEMENT</div>
+      <div><span class="mute">09:14:03</span> <span class="peach">TOOL</span> engineer: read tests/reindex_e2e.rs (214 lines)</div>
+      <div><span class="mute">09:14:11</span> <span class="peach">TOOL</span> engineer: edit tests/reindex_e2e.rs</div>
+      <div class="rm ind">- tokio::time::sleep(Duration::from_secs(5)).await;</div>
+      <div class="green ind">+ wait_for_event(&amp;mut stream, "complete", TIMEOUT_30S).await?;</div>
+      <div><span class="mute">09:14:19</span> <span class="peach">TOOL</span> engineer: cargo test -p trusty-search reindex_e2e</div>
+      <div class="mute ind">running 3 tests… <span class="green">ok ok ok</span> (4.2s)</div>
+      <div><span class="mute">09:14:31</span> <span class="green">INFO</span> engineer: implementation complete, handing to qa</div>
+      <div><span class="rust">09:14:31</span> <span class="rust">PM</span> awaiting VERIFY phase<span class="cursor"></span></div>
+    </div>
+  </div>
+  <div class="rule"></div>
+  <div class="statusbar">
+    <span class="mode">IMPLEMENT</span>
+    <span><span class="peach">^P</span> phases</span><span><span class="peach">^A</span> agents</span><span><span class="peach">^L</span> logs</span><span><span class="peach">^C</span> abort</span>
+    <span class="push">tcode serve · :8790 · MCP ok</span>
+  </div>
+</div>
+
+<style>
+  .tui { width: 1440px; height: 900px; display: flex; flex-direction: column; background: #171009; overflow: hidden; font: 400 13px var(--trusty-mono); color: #e6d8c8; padding: 20px 24px; box-sizing: border-box; line-height: 1.75; }
+  .mark { color: #d97742; white-space: pre; line-height: 1.3; font-weight: 600; margin: 0; font-family: inherit; }
+  .rule { height: 1px; background: #382513; margin: 14px 0; flex: none; }
+  .cols { flex: 1; display: flex; gap: 20px; min-height: 0; }
+  .panel { border: 1px solid #382513; border-radius: 3px; padding: 12px 16px; display: flex; flex-direction: column; gap: 2px; }
+  .side { width: 340px; flex: none; }
+  .out { flex: 1; overflow: hidden; min-width: 0; }
+  .p-label { color: #a58a6b; font-size: 11px; letter-spacing: 0.14em; margin-bottom: 8px; }
+  .green { color: #8fbf6a; }
+  .amber { color: #d9a83a; }
+  .mute { color: #a58a6b; }
+  .fg { color: #e6d8c8; }
+  .peach { color: #e9b98a; }
+  .rust { color: #d97742; }
+  .rm { color: #8a6a4c; }
+  .nest { padding-left: 14px; }
+  .ind { padding-left: 72px; }
+  .side-foot { margin-top: auto; padding-top: 10px; border-top: 1px solid #382513; color: #a58a6b; font-size: 11px; }
+  .cursor { display: inline-block; width: 8px; height: 14px; background: #d97742; vertical-align: text-bottom; margin-left: 4px; animation: tui-blink 1s step-end infinite; }
+  @keyframes tui-blink { 50% { opacity: 0; } }
+  .statusbar { display: flex; gap: 14px; color: #a58a6b; font-size: 12px; flex: none; }
+  .mode { color: #171009; background: #d97742; padding: 0 8px; font-weight: 600; }
+  .push { margin-left: auto; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/console/Console.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/console/Console.svelte
@@ -1,0 +1,98 @@
+<script>
+  import RobotMark from '../../lib/RobotMark.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  import Button from '../../lib/Button.svelte';
+
+  const services = [
+    { name: 'Trusty Search', id: 'trusty-search', ver: 'VER 0.4.2 · PORT :7878', tone: 'success', status: 'RUNNING', mark: { body: '#b7410e', eyes: 'square' }, primary: true },
+    { name: 'Trusty Memory', id: 'trusty-memory', ver: 'VER 0.3.8 · PORT :7882', tone: 'success', status: 'RUNNING', mark: { body: '#8a5a2b', eyes: 'round' }, primary: true },
+    { name: 'Trusty Analyze', id: 'trusty-analyze', ver: 'VER 0.2.1 · PORT :7879', tone: 'warning', status: 'DEGRADED', mark: { body: '#6e5843', eyes: 'visor' }, note: 'Reachable, but console_metrics tool is missing.', noteWarn: true, primary: true },
+    { name: 'Trusty Review', id: 'trusty-review', ver: 'VER 0.1.4', tone: 'warning', status: 'AVAILABLE', mark: { body: '#a3672e', eyes: 'square' }, note: 'Binary found but daemon is not running.' },
+    { name: 'Trusty MPM', id: 'trusty-mpm', ver: 'VER 0.5.0 · 3 SESSIONS', tone: 'success', status: 'RUNNING', mark: { body: '#8a5a2b', eyes: 'square' }, primary: true }
+  ];
+  const tabs = ['OVERVIEW', 'SEARCH', 'MEMORY', 'ANALYZE', 'REVIEW', 'SESSIONS', 'CONFIG'];
+</script>
+
+<div class="screen">
+  <div class="wrap">
+    <div class="masthead">
+      <div class="ident">
+        <RobotMark size={46} body="#2b1c12" face="#e9b98a" antennaColor="#b7410e" state="idle" />
+        <div>
+          <div class="name">TRUSTY CONSOLE</div>
+          <div class="sub">COMMAND DECK · UNIFIED SERVICE DASHBOARD</div>
+        </div>
+      </div>
+      <div class="right">
+        <div class="theme-toggle">
+          <span class="on">DAY</span><span>NIGHT</span><span>AUTO</span>
+        </div>
+        <Badge tone="success" dot>6 SERVICES</Badge>
+      </div>
+    </div>
+
+    <div class="tabs">
+      {#each tabs as t, i}
+        <span class="tab" class:active={i === 0}>{t}</span>
+      {/each}
+    </div>
+
+    <div class="grid">
+      {#each services as s}
+        <div class="card svc">
+          <div class="head">
+            <div class="ident-sm">
+              <RobotMark size={28} antenna={false} {...s.mark} />
+              <span class="svc-name">{s.name}</span>
+            </div>
+            <Badge tone={s.tone} dot>{s.status}</Badge>
+          </div>
+          <div class="meta">ID {s.id}<br>{s.ver}</div>
+          {#if s.note}<div class="note" class:warn={s.noteWarn}>{s.note}</div>{/if}
+          <div class="act"><Button variant={s.primary ? 'primary' : ''} size="sm">VIEW DETAILS →</Button></div>
+        </div>
+      {/each}
+      <div class="card svc absent">
+        <div class="head">
+          <div class="ident-sm">
+            <RobotMark size={28} antenna={false} body="var(--trusty-surface-raised)" face="#a58a6b" eyes="visor" />
+            <span class="svc-name dim">Trusty Code</span>
+          </div>
+          <Badge tone="muted">ABSENT</Badge>
+        </div>
+        <div class="meta">ID trusty-code</div>
+        <div class="act">
+          <button class="btn btn-sm installing"><span class="spinner"></span>INSTALLING… 64%</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .screen { width: 1440px; height: 900px; background: var(--trusty-content-bg); overflow: hidden; font-size: 14px; color: var(--trusty-text-primary); }
+  .wrap { max-width: 1160px; margin: 0 auto; padding: 36px 32px; }
+  .masthead { display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px; }
+  .ident { display: flex; align-items: center; gap: 16px; }
+  .name { font: 700 24px var(--trusty-display); letter-spacing: 0.02em; line-height: 1.1; }
+  .sub { font: 500 11px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-text-muted); }
+  .right { display: flex; align-items: center; gap: 10px; }
+  .theme-toggle { display: flex; border: 1.5px solid var(--trusty-border-strong); border-radius: 4px; overflow: hidden; }
+  .theme-toggle span { padding: 5px 12px; font: 600 11px var(--trusty-mono); background: var(--trusty-card-bg); color: var(--trusty-text-secondary); }
+  .theme-toggle .on { background: var(--trusty-accent); color: #fff; }
+  .tabs { display: flex; gap: 2px; border-bottom: 2px solid var(--trusty-border); margin-bottom: 24px; }
+  .tab { padding: 10px 18px; font: 600 12px var(--trusty-mono); letter-spacing: 0.06em; color: var(--trusty-text-muted); }
+  .tab.active { color: var(--trusty-accent); border-bottom: 3px solid var(--trusty-accent); margin-bottom: -2px; }
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  .svc { padding: 20px; }
+  .svc.absent { background: var(--trusty-content-bg); border-style: dashed; }
+  .head { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 12px; }
+  .ident-sm { display: flex; align-items: center; gap: 10px; }
+  .svc-name { font: 700 15px var(--trusty-display); }
+  .svc-name.dim { color: var(--trusty-text-secondary); }
+  .meta { font: 400 11px var(--trusty-mono); color: var(--trusty-text-muted); line-height: 1.9; }
+  .note { margin-top: 8px; font-size: 12px; color: var(--trusty-text-secondary); }
+  .note.warn { color: #7a5a10; }
+  .act { margin-top: 14px; }
+  .installing { display: inline-flex; align-items: center; gap: 8px; background: var(--trusty-surface-raised); border-color: var(--trusty-border); color: var(--trusty-text-secondary); }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/memory/Palaces.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/memory/Palaces.svelte
@@ -1,0 +1,77 @@
+<script>
+  import AppShell from '../../lib/AppShell.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  import Button from '../../lib/Button.svelte';
+  import { memoryNav } from '../search/data.js';
+
+  let palaces = $state([
+    {
+      name: 'trusty-tools', drawers: 142, active: 'active 2m ago', open: true,
+      items: [
+        { kind: 'MESSAGE', tone: 'info', text: 'Reindex schedule agreed with trusty-search: nightly at 02:00, skip if…', when: 'unread' },
+        { kind: 'DECISION', tone: 'muted', text: 'Chose usearch over hnswlib for the vector index — better mmap story…', when: 'Jul 12' },
+        { kind: 'SNIPPET', tone: 'muted', text: 'RRF fusion constant k=60 tuned against the eval set; see evals/rrf_sweep…', when: 'Jul 09' }
+      ]
+    },
+    { name: 'memory-palace', drawers: 96, active: 'active 1h ago', open: false, items: [] },
+    { name: 'gitflow-rs', drawers: 61, active: 'active yesterday', open: false, items: [] },
+    { name: 'docs-site', drawers: 38, active: 'active Jul 14', open: false, items: [] }
+  ]);
+</script>
+
+<AppShell sidebar={memoryNav('Palaces')} crumb="PALACES" status="ONLINE v0.3.8">
+  <div class="head">
+    <h1 class="page-title">PALACES</h1>
+    <span class="count">88 PALACES · 4,312 DRAWERS</span>
+  </div>
+  <div class="filters">
+    <input class="input grow" placeholder="filter by name or project…">
+    <select class="select auto"><option>SORT: ACTIVITY</option><option>NAME</option><option>DRAWERS</option><option>CREATED</option></select>
+    <select class="select auto"><option>ALL COLLECTIONS</option><option>trusty-*</option></select>
+    <Button size="sm">GROUP BY PROJECT</Button>
+  </div>
+  <div class="card tree">
+    {#each palaces as p}
+      <button class="node" class:open={p.open} onclick={() => (p.open = !p.open)}>
+        <span class="caret">{p.open ? '▾' : '▸'}</span>
+        <span class="pname">{p.name}</span>
+        <Badge tone="muted">{p.drawers} DRAWERS</Badge>
+        <span class="when">{p.active}</span>
+        <a href="#graph" onclick={(e) => e.stopPropagation()}>GRAPH →</a>
+      </button>
+      {#if p.open && p.items.length}
+        <div class="drawers">
+          {#each p.items as d}
+            <div class="drawer">
+              <Badge tone={d.tone}>{d.kind}</Badge>
+              <span class="text">{d.text}</span>
+              <span class="dwhen">{d.when}</span>
+            </div>
+          {/each}
+        </div>
+      {/if}
+    {/each}
+  </div>
+</AppShell>
+
+<style>
+  .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 20px; }
+  h1 { font-size: 28px; margin: 0; }
+  .count { font: 500 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .filters { display: flex; gap: 8px; margin-bottom: 16px; }
+  .grow { flex: 1; width: auto; }
+  .auto { width: auto; padding: 8px 12px; font-size: 12px; }
+  .tree { overflow: hidden; }
+  .node { display: flex; align-items: center; gap: 12px; width: 100%; text-align: left; padding: 13px 20px; border: none; border-bottom: 1px solid var(--trusty-surface-hover); background: none; font: inherit; color: inherit; cursor: pointer; }
+  .node:hover { background: var(--trusty-surface-hover); }
+  .node.open { background: var(--trusty-primary-soft); }
+  .caret { font: 600 12px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .open .caret { color: var(--trusty-accent); }
+  .pname { font-weight: 600; flex: 1; }
+  .when { font: 400 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .node a { font: 600 11px var(--trusty-mono); }
+  .drawers { padding: 6px 20px 14px 46px; display: flex; flex-direction: column; gap: 8px; border-bottom: 1px solid var(--trusty-surface-hover); }
+  .drawer { display: flex; gap: 10px; align-items: center; }
+  .text { font-size: 12.5px; color: var(--trusty-text-secondary); flex: 1; }
+  .dwhen { font: 400 10px var(--trusty-mono); color: var(--trusty-text-muted); }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/search/Dashboard.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/search/Dashboard.svelte
@@ -1,0 +1,74 @@
+<script>
+  import AppShell from '../../lib/AppShell.svelte';
+  import StatCard from '../../lib/StatCard.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  import Button from '../../lib/Button.svelte';
+  import Toast from '../../lib/Toast.svelte';
+  import { searchNav, indexes } from './data.js';
+
+  let toastVisible = $state(true);
+  const statusBadge = { ready: ['success', 'READY'], error: ['danger', 'ERROR'] };
+</script>
+
+{#snippet actions()}
+  <Button variant="danger" size="sm">STOP</Button>
+  <Button size="sm">RESTART</Button>
+{/snippet}
+
+<AppShell sidebar={searchNav('Dashboard')} crumb="DASHBOARD" topbarActions={actions}>
+  <h1 class="page-title">DASHBOARD</h1>
+  <div class="stat-grid four">
+    <StatCard label="INDEXES" value="4" meta="registered" />
+    <StatCard label="DOCUMENTS" value="128,441" meta="indexed chunks" accent />
+    <StatCard label="UPTIME" value="3d 04h" meta="daemon" />
+    <StatCard label="VERSION">
+      <div class="ver">0.4.2</div>
+      <div class="mt-3"><Badge tone="success">HEALTHY</Badge></div>
+    </StatCard>
+  </div>
+  <div class="card">
+    <div class="card-header flex-between">
+      <span>RECENT INDEXES</span>
+      <Button variant="primary" size="sm">MANAGE ALL</Button>
+    </div>
+    <table class="table">
+      <thead>
+        <tr><th>Name</th><th>Documents</th><th>Root path</th><th>Status</th></tr>
+      </thead>
+      <tbody>
+        {#each indexes as ix}
+          <tr>
+            <td class="name">{ix.name}</td>
+            <td class="text-mono">{ix.docs}</td>
+            <td class="path">{ix.path}</td>
+            <td>
+              {#if ix.status === 'working'}
+                <Badge tone="warning" spinner>{ix.progress}</Badge>
+              {:else}
+                <Badge tone={statusBadge[ix.status][0]}>{statusBadge[ix.status][1]}</Badge>
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  {#if toastVisible}
+    <div class="toast-stack">
+      <Toast tone="success" title="REINDEX COMPLETE" ondismiss={() => (toastVisible = false)}>
+        memory-palace — 31,870 chunks in 2m 14s.
+      </Toast>
+    </div>
+  {/if}
+</AppShell>
+
+<style>
+  h1 { font-size: 28px; margin: 0 0 24px; }
+  .four { grid-template-columns: repeat(4, 1fr); }
+  .ver { font: 600 20px var(--trusty-mono); margin-top: 6px; }
+  .card-header :global(.btn) { text-transform: uppercase; }
+  .name { font-weight: 600; }
+  .path { font: 400 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .toast-stack { position: absolute; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/search/Dialogs.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/search/Dialogs.svelte
@@ -1,0 +1,105 @@
+<script>
+  // Gallery of the four standard dialogs, rendered inline (no backdrop).
+  import Modal from '../../lib/Modal.svelte';
+  import Button from '../../lib/Button.svelte';
+</script>
+
+<div class="board">
+  <Modal title="STOP THE DAEMON?" backdrop={false}>
+    <p>UNIT-01 will power down. Active searches are interrupted and MCP clients lose their connection.</p>
+    <div class="cmd">restart: trusty-search stop &amp;&amp; trusty-search start</div>
+    {#snippet footer()}
+      <Button>CANCEL</Button>
+      <Button variant="primary">STOP DAEMON</Button>
+    {/snippet}
+  </Modal>
+
+  <Modal title="REGISTER A NEW INDEX" backdrop={false}>
+    <div class="form-group">
+      <label class="form-label" for="ix-id">INDEX ID</label>
+      <input id="ix-id" class="input" value="docs-site">
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="ix-path">ROOT PATH</label>
+      <input id="ix-path" class="input focus" value="/Users/mo/code/docs-site">
+      <div class="hint">Absolute path. Indexing starts immediately after registration.</div>
+    </div>
+    <label class="check"><input type="checkbox" checked> Boost results from the current git branch</label>
+    {#snippet footer()}
+      <Button>CANCEL</Button>
+      <Button variant="primary">CREATE &amp; INDEX</Button>
+    {/snippet}
+  </Modal>
+
+  <Modal title="INDEX SETTINGS" titleMeta="trusty-tools" backdrop={false}>
+    <div class="form-group">
+      <span class="form-label">IGNORE GLOBS</span>
+      <div class="globs">
+        <span class="tag">target/** <i>✕</i></span>
+        <span class="tag">node_modules/** <i>✕</i></span>
+        <span class="tag">*.lock <i>✕</i></span>
+        <span class="add">add glob…</span>
+      </div>
+    </div>
+    <div class="pair">
+      <div class="form-group">
+        <label class="form-label" for="chunk">MAX CHUNK SIZE</label>
+        <input id="chunk" class="input" value="1024">
+      </div>
+      <div class="form-group">
+        <label class="form-label" for="model">EMBEDDING MODEL</label>
+        <select id="model" class="select"><option>bge-small-en-v1.5</option></select>
+      </div>
+    </div>
+    <label class="check"><input type="checkbox" checked> Knowledge-graph expansion (caller/callee chains)</label>
+    <label class="check"><input type="checkbox"> Watch filesystem and reindex changed files</label>
+    {#snippet footer()}
+      <div class="spread">
+        <Button variant="ghost">RESET TO DEFAULTS</Button>
+        <div class="pairbtn">
+          <Button>CANCEL</Button>
+          <Button variant="primary">SAVE SETTINGS</Button>
+        </div>
+      </div>
+    {/snippet}
+  </Modal>
+
+  <Modal title="REINDEX FAILED" danger backdrop={false}>
+    <p><code class="ref">gitflow-rs</code> could not be reindexed — the registered root path no longer exists on disk.</p>
+    <div class="log">
+      <span class="t">2026-07-18T09:14:02Z</span> <span class="err">ERROR</span> indexer: walk failed<br>
+      <span class="t">  path:</span> /Users/mo/code/gitflow-rs<br>
+      <span class="t">  cause:</span> No such file or directory (os error 2)
+    </div>
+    {#snippet footer()}
+      <div class="spread">
+        <Button variant="ghost">OPEN LOGS</Button>
+        <div class="pairbtn">
+          <Button variant="danger">REMOVE INDEX</Button>
+          <Button variant="primary">EDIT ROOT PATH</Button>
+        </div>
+      </div>
+    {/snippet}
+  </Modal>
+</div>
+
+<style>
+  .board { width: 1440px; background: var(--trusty-surface-raised); padding: 48px; box-sizing: border-box; display: grid; grid-template-columns: 1fr 1fr; gap: 40px; align-items: start; font-size: 14px; color: var(--trusty-text-primary); }
+  .board :global(.modal) { box-shadow: var(--trusty-shadow-lg); }
+  p { margin: 0 0 10px; font-size: 13.5px; line-height: 1.6; color: var(--trusty-text-secondary); }
+  .cmd { padding: 10px 14px; background: var(--trusty-content-bg); border: 1px solid var(--trusty-surface-raised); border-radius: 4px; font: 400 12px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .hint { font-size: 12px; color: var(--trusty-text-muted); margin-top: 6px; }
+  .focus { border-color: var(--trusty-accent); box-shadow: 0 0 0 3px var(--trusty-accent-soft); }
+  .check { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--trusty-text-secondary); margin-bottom: 10px; }
+  .check input { width: 15px; height: 15px; }
+  .globs { display: flex; flex-wrap: wrap; gap: 6px; padding: 8px 10px; border: 1.5px solid var(--trusty-border-strong); border-radius: 4px; background: var(--trusty-card-bg); }
+  .tag i { font-style: normal; color: var(--trusty-sidebar-muted); }
+  .add { font: 400 12px var(--trusty-mono); color: var(--trusty-sidebar-muted); padding: 2px 4px; }
+  .pair { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .spread { display: flex; justify-content: space-between; align-items: center; width: 100%; }
+  .pairbtn { display: flex; gap: 8px; }
+  .ref { font: 600 12px var(--trusty-mono); color: var(--trusty-accent); }
+  .log { padding: 12px 14px; background: #2b1c12; border-radius: 4px; font: 400 11.5px var(--trusty-mono); color: #e6d8c8; line-height: 1.7; }
+  .log .t { color: #a58a6b; }
+  .log .err { color: #f0a898; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/search/Health.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/search/Health.svelte
@@ -1,0 +1,149 @@
+<script>
+  import AppShell from '../../lib/AppShell.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  import Button from '../../lib/Button.svelte';
+  import { searchNav } from './data.js';
+
+  const engines = [
+    { label: 'BM25 ENGINE', value: '2.1ms', meta: 'p50 query latency · 24h', tone: 'success', status: 'OK', bars: [35, 50, 40, 65, 45, 55, 38, 48] },
+    { label: 'VECTOR INDEX', value: '6.8ms', meta: 'p50 ANN lookup · 24h', tone: 'success', status: 'OK', bars: [55, 60, 48, 70, 62, 52, 58, 60] },
+    { label: 'KNOWLEDGE GRAPH', value: '41ms', meta: 'expansion, cache cold', tone: 'warning', status: 'DEGRADED', warn: true, bars: [30, 35, 32, 45, 68, 85, 92, 100] },
+    { label: 'EMBEDDER', value: '312/s', meta: 'chunks embedded', tone: 'success', status: 'OK', bars: [60, 72, 66, 80, 74, 70, 76, 72] }
+  ];
+  const sidecars = [
+    { name: 'trusty-analyze', port: ':7879', tone: 'success', status: 'CONNECTED' },
+    { name: 'trusty-embedderd', port: ':7881', tone: 'success', status: 'CONNECTED' },
+    { name: 'trusty-bm25-daemon', port: ':7880', tone: 'danger', status: 'UNREACHABLE' },
+    { name: 'trusty-memory', port: ':7882', tone: 'muted', status: 'NOT INSTALLED' }
+  ];
+  const events = [
+    { t: '09:14', dot: '#5c9a3d', text: 'Reindex complete — memory-palace' },
+    { t: '09:02', dot: '#c2331f', text: 'bm25-daemon connection lost' },
+    { t: '08:47', dot: '#b07d10', text: 'KG cache evicted (memory pressure)' },
+    { t: '06:00', dot: '#5c9a3d', text: 'Daemon started · tier 3 auto-selected' }
+  ];
+  const qpm = [30, 42, 38, 55, 70, 100, 84, 62, 48, 52, 44, 36];
+</script>
+
+{#snippet actions()}
+  <Button variant="danger" size="sm">STOP</Button>
+  <Button size="sm">RESTART</Button>
+{/snippet}
+
+<AppShell sidebar={searchNav('Health')} crumb="HEALTH" topbarActions={actions}>
+  <div class="head">
+    <h1 class="page-title">HEALTH</h1>
+    <span class="refresh">LAST CHECK 09:14:32 · AUTO-REFRESH 10S</span>
+  </div>
+
+  <div class="grid four">
+    {#each engines as e}
+      <div class="stat">
+        <div class="row">
+          <span class="stat-label label">{e.label}</span>
+          <Badge tone={e.tone}>{e.status}</Badge>
+        </div>
+        <div class="val" class:warn={e.warn}>{e.value}</div>
+        <div class="spark">
+          {#each e.bars as h, i}
+            <span style="height:{h}%; background:{i === e.bars.length - 1 ? (e.warn ? '#b07d10' : 'var(--trusty-accent)') : 'var(--trusty-border)'};"></span>
+          {/each}
+        </div>
+        <div class="stat-meta">{e.meta}</div>
+      </div>
+    {/each}
+  </div>
+
+  <div class="grid two">
+    <div class="card">
+      <div class="card-header">MEMORY TIER</div>
+      <div class="card-body">
+        <div class="tier-row">
+          <span class="tier">TIER 3 — 32 GB MACHINE</span>
+          <span class="budget">11.2 GB / 14 GB BUDGET</span>
+        </div>
+        <div class="segbar">
+          <span style="width:46%; background:#b7410e;"></span>
+          <span style="width:21%; background:#d97742;"></span>
+          <span style="width:13%; background:#e9b98a;"></span>
+          <span class="rest"></span>
+        </div>
+        <div class="legend">
+          <span><i style="background:#b7410e"></i>HNSW 6.4 GB</span>
+          <span><i style="background:#d97742"></i>BM25 2.9 GB</span>
+          <span><i style="background:#e9b98a"></i>CACHE 1.9 GB</span>
+        </div>
+        <div class="qpm">
+          <div class="qpm-head"><span class="stat-label">QUERIES / MIN · LAST HOUR</span><span class="peak">PEAK 240</span></div>
+          <div class="qpm-bars">
+            {#each qpm as h}
+              <span style="height:{h}%; background:{h === 100 ? '#b7410e' : h >= 55 ? '#d97742' : '#e9b98a'};"></span>
+            {/each}
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-header">SIDECARS</div>
+      <table class="table">
+        <tbody>
+          {#each sidecars as s}
+            <tr>
+              <td class="name">{s.name}</td>
+              <td class="port">{s.port}</td>
+              <td class="right"><Badge tone={s.tone}>{s.status}</Badge></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+      <div class="events">
+        <div class="stat-label">RECENT EVENTS</div>
+        {#each events as ev}
+          <div class="ev">
+            <span class="dot" style="background:{ev.dot}"></span>
+            <span class="time">{ev.t}</span>
+            <span class="text">{ev.text}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+  </div>
+</AppShell>
+
+<style>
+  .head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 24px; }
+  h1 { font-size: 28px; margin: 0; }
+  .refresh { font: 500 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .grid { display: grid; gap: 16px; }
+  .four { grid-template-columns: repeat(4, 1fr); margin-bottom: 20px; }
+  .two { grid-template-columns: 1.2fr 1fr; }
+  .row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
+  .label { margin-bottom: 0; }
+  .val { font: 700 24px var(--trusty-display); }
+  .val.warn { color: var(--trusty-warning); }
+  .spark { display: flex; align-items: flex-end; gap: 2px; height: 22px; margin-top: 10px; }
+  .spark span { width: 6px; display: block; }
+  .tier-row { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 10px; }
+  .tier { font: 600 13px var(--trusty-mono); }
+  .budget { font: 500 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .segbar { display: flex; height: 14px; border: 1px solid var(--trusty-border); border-radius: 2px; overflow: hidden; }
+  .segbar span { display: block; }
+  .segbar .rest { flex: 1; background: var(--trusty-surface-raised); }
+  .legend { display: flex; gap: 20px; margin-top: 14px; }
+  .legend span { display: flex; align-items: center; gap: 7px; font: 500 11px var(--trusty-mono); color: var(--trusty-text-secondary); }
+  .legend i { width: 9px; height: 9px; display: block; }
+  .qpm { margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--trusty-surface-raised); }
+  .qpm-head { display: flex; justify-content: space-between; margin-bottom: 8px; }
+  .peak { font: 600 11px var(--trusty-mono); color: var(--trusty-accent); }
+  .qpm-bars { display: flex; align-items: flex-end; gap: 3px; height: 48px; }
+  .qpm-bars span { flex: 1; display: block; }
+  .name { font-weight: 600; }
+  .port { font: 400 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .right { text-align: right; }
+  .events { padding: 16px 20px; border-top: 1px solid var(--trusty-surface-raised); }
+  .events .stat-label { margin-bottom: 12px; }
+  .ev { display: flex; gap: 10px; align-items: center; margin-bottom: 10px; }
+  .dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+  .time { font: 500 11px var(--trusty-mono); color: var(--trusty-text-muted); flex: 0 0 52px; }
+  .text { font-size: 12.5px; color: var(--trusty-text-secondary); }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/search/Indexes.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/search/Indexes.svelte
@@ -1,0 +1,123 @@
+<script>
+  import AppShell from '../../lib/AppShell.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  import Button from '../../lib/Button.svelte';
+  import Modal from '../../lib/Modal.svelte';
+  import Toast from '../../lib/Toast.svelte';
+  import { searchNav, indexes } from './data.js';
+
+  let rows = $state(indexes.map((ix) => ({ ...ix })));
+  let showDelete = $state(true);
+  const selected = $derived(rows.filter((r) => r.selected));
+</script>
+
+{#snippet actions()}
+  <Button variant="danger" size="sm">STOP</Button>
+  <Button size="sm">RESTART</Button>
+{/snippet}
+
+<AppShell sidebar={searchNav('Indexes')} crumb="INDEXES" topbarActions={actions}>
+  <h1 class="page-title">INDEXES</h1>
+
+  <div class="card register">
+    <div class="card-header">REGISTER A NEW INDEX</div>
+    <div class="reg-row">
+      <input class="input" placeholder="index-id (e.g. my-project)">
+      <input class="input" placeholder="/absolute/root/path">
+      <Button disabled>CREATE</Button>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header flex-between">
+      <span>REGISTERED INDEXES</span>
+      <Button size="sm">REFRESH</Button>
+    </div>
+    {#if selected.length}
+      <div class="bulkbar">
+        <span class="count">{selected.length} SELECTED</span>
+        <Button size="sm">REINDEX SELECTED</Button>
+        <Button variant="primary" size="sm" onclick={() => (showDelete = true)}>DELETE SELECTED</Button>
+        <Button variant="ghost" size="sm" onclick={() => rows.forEach((r) => (r.selected = false))}>CLEAR</Button>
+      </div>
+    {/if}
+    <table class="table">
+      <thead>
+        <tr>
+          <th class="check"><input type="checkbox"></th>
+          <th>Name</th><th>Docs</th><th>Disk</th><th>Last indexed</th><th>Root path</th><th>Status</th>
+          <th class="right">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each rows as row}
+          <tr class:selected-row={row.selected}>
+            <td class="check"><input type="checkbox" bind:checked={row.selected}></td>
+            <td class="name">{row.name}</td>
+            <td class="text-mono">{row.docs}</td>
+            <td class="mono-sm">{row.disk}</td>
+            <td class="dim">{row.last}</td>
+            <td class="path">{row.path}</td>
+            <td>
+              {#if row.status === 'working'}
+                <Badge tone="warning" spinner>{row.progress}</Badge>
+              {:else if row.status === 'error'}
+                <Badge tone="danger">ERROR</Badge>
+              {:else}
+                <Badge tone="success">READY</Badge>
+              {/if}
+            </td>
+            <td class="right acts">
+              <Button size="sm">⚙ SETTINGS</Button>
+              {#if row.status === 'working'}
+                <Button size="sm" disabled>WORKING…</Button>
+              {:else}
+                <Button size="sm">REINDEX</Button>
+              {/if}
+              <Button variant="danger" size="sm">DELETE</Button>
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  </div>
+
+  {#if showDelete}
+    <Modal title="DELETE 2 INDEXES?" onclose={() => (showDelete = false)}>
+      <p>
+        <code class="ref">trusty-tools</code> and <code class="ref">memory-palace</code>
+        will be removed from the registry.
+      </p>
+      <p class="dim-p">On-disk data is preserved. You can re-register the same paths later.</p>
+      {#snippet footer()}
+        <Button onclick={() => (showDelete = false)}>CANCEL</Button>
+        <Button variant="primary">CONFIRM DELETE</Button>
+      {/snippet}
+    </Modal>
+  {/if}
+
+  <div class="toast-stack">
+    <Toast title="REINDEX STARTED">memory-palace — queued 31,870 chunks.</Toast>
+    <Toast tone="danger" title="REINDEX FAILED">gitflow-rs — root path not found. <a href="#log">View log</a></Toast>
+  </div>
+</AppShell>
+
+<style>
+  h1 { font-size: 28px; margin: 0 0 24px; }
+  .register { margin-bottom: 16px; }
+  .reg-row { padding: 20px; display: grid; grid-template-columns: 1fr 2fr auto; gap: 8px; }
+  .bulkbar { display: flex; align-items: center; gap: 8px; padding: 9px 20px; background: var(--trusty-accent-soft); border-bottom: 1.5px solid var(--trusty-border); }
+  .count { font: 600 12px var(--trusty-mono); color: var(--trusty-accent-hover); margin-right: 6px; }
+  .check { width: 38px; padding-right: 0; }
+  .check input { width: 15px; height: 15px; }
+  .right { text-align: right; }
+  .name { font-weight: 600; }
+  .mono-sm { font: 400 11px var(--trusty-mono); }
+  .dim { font-size: 11px; color: var(--trusty-text-muted); }
+  .path { font: 400 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .acts { white-space: nowrap; }
+  .acts :global(.btn + .btn) { margin-left: 4px; }
+  .ref { font: 600 12px var(--trusty-mono); color: var(--trusty-accent); }
+  p { margin: 0 0 10px; font-size: 13.5px; line-height: 1.6; color: var(--trusty-text-secondary); }
+  .dim-p { margin: 0; color: var(--trusty-text-muted); }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/search/Search.svelte
+++ b/docs/design/UI/design-system-svelte/src/screens/search/Search.svelte
@@ -1,0 +1,122 @@
+<script>
+  import AppShell from '../../lib/AppShell.svelte';
+  import Badge from '../../lib/Badge.svelte';
+  import Button from '../../lib/Button.svelte';
+  import RobotMark from '../../lib/RobotMark.svelte';
+  import { searchNav } from './data.js';
+
+  let query = $state('fn authenticate');
+  let limit = $state('10');
+  const results = [
+    {
+      file: 'src/auth/service.rs', symbol: 'authenticate', index: 'TRUSTY-TOOLS', lines: 'L42–88', score: '0.913',
+      code: 'pub async fn authenticate(&self, token: &str) -> Result<Session> {\n    let claims = self.verify_jwt(token)?;\n    self.sessions.get_or_create(claims.sub).await\n}'
+    },
+    {
+      file: 'src/auth/middleware.rs', symbol: null, index: 'TRUSTY-TOOLS', lines: 'L12–31', score: '0.847',
+      code: 'let session = state.auth.authenticate(bearer.token()).await\n    .map_err(|_| StatusCode::UNAUTHORIZED)?;'
+    }
+  ];
+</script>
+
+{#snippet actions()}
+  <Button variant="danger" size="sm">STOP</Button>
+  <Button size="sm">RESTART</Button>
+{/snippet}
+
+<AppShell sidebar={searchNav('Search')} crumb="SEARCH" topbarActions={actions}>
+  <h1 class="page-title">SEARCH</h1>
+  <div class="card query-card">
+    <div class="row">
+      <input class="input" bind:value={query}>
+      <input class="input limit" bind:value={limit}>
+      <Button variant="primary">SEARCH</Button>
+    </div>
+    <div class="meta">
+      <span class="hint">Searches 4 indexes</span>
+      <span class="ms">· 8ms</span>
+      <Badge tone="info">DEFINITION</Badge>
+    </div>
+  </div>
+
+  <div class="results">
+    {#each results as r}
+      <div class="card result">
+        <div class="head">
+          <div class="ids">
+            <span class="file">{r.file}</span>
+            {#if r.symbol}<Badge tone="muted">{r.symbol}</Badge>{/if}
+            <Badge tone="info">{r.index}</Badge>
+            <span class="lines">{r.lines}</span>
+          </div>
+          <div class="score"><span class="score-label">SCORE</span><span class="score-val">{r.score}</span></div>
+        </div>
+        <pre>{r.code}</pre>
+      </div>
+    {/each}
+  </div>
+
+  <div class="chat">
+    <div class="chat-head">
+      <h2>CHAT</h2>
+      <div class="index-pick">
+        <span class="form-label inline-label">INDEX</span>
+        <select class="select"><option>trusty-tools</option></select>
+      </div>
+      <Button size="sm">CLEAR</Button>
+    </div>
+    <div class="thread">
+      <div class="msg user"><div class="bubble">Where is the session store created?</div></div>
+      <div class="msg bot">
+        <RobotMark size={26} body="#2b1c12" face="#e9b98a" antenna={false} />
+        <div class="bubble">
+          The session store is created in <code class="ref">src/auth/service.rs</code> inside
+          <code class="ref">AuthService::new</code>, backed by the SQLite pool.
+          <div class="sources">▸ 2 SOURCES</div>
+        </div>
+      </div>
+    </div>
+    <div class="composer">
+      <textarea class="textarea" rows="2" placeholder="Ask a question… (Enter to send, Shift+Enter for newline)"></textarea>
+      <Button variant="primary">SEND</Button>
+    </div>
+  </div>
+</AppShell>
+
+<style>
+  h1 { font-size: 28px; margin: 0 0 24px; }
+  .query-card { padding: 20px; margin-bottom: 16px; }
+  .row { display: flex; gap: 8px; align-items: stretch; }
+  .limit { width: 72px; flex: none; text-align: center; }
+  .meta { display: flex; gap: 12px; align-items: center; margin-top: 12px; }
+  .hint { color: var(--trusty-text-muted); font-size: 13px; }
+  .ms { font: 500 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .results { display: flex; flex-direction: column; gap: 12px; margin-bottom: 20px; }
+  .result { padding: 16px 20px; }
+  .head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; gap: 12px; }
+  .ids { display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }
+  .file { font: 600 13px var(--trusty-mono); color: var(--trusty-accent); }
+  .lines { font: 400 11px var(--trusty-mono); color: var(--trusty-text-muted); }
+  .score { display: flex; align-items: baseline; gap: 6px; flex: none; }
+  .score-label { font: 600 9px var(--trusty-mono); letter-spacing: 0.14em; color: var(--trusty-text-muted); }
+  .score-val { font: 600 14px var(--trusty-mono); color: var(--trusty-accent); }
+  pre { margin: 0; padding: 12px 14px; background: var(--trusty-content-bg); border: 1px solid var(--trusty-surface-raised); border-radius: 4px; white-space: pre-wrap; word-break: break-word; font: 400 12px var(--trusty-mono); color: var(--trusty-text-secondary); line-height: 1.55; }
+  .chat { border-top: 2px solid var(--trusty-border); padding-top: 20px; display: flex; flex-direction: column; gap: 12px; flex: 1; min-height: 0; }
+  .chat-head { display: flex; align-items: center; gap: 16px; }
+  .chat-head h2 { font: 700 16px var(--trusty-display); margin: 0; letter-spacing: 0.04em; }
+  .index-pick { display: flex; align-items: center; gap: 10px; flex: 1; }
+  .inline-label { margin: 0; }
+  .index-pick .select { min-width: 170px; width: auto; padding: 5px 12px; font-size: 12px; }
+  .thread { background: var(--trusty-surface-raised); border: 1.5px solid var(--trusty-border); border-radius: var(--trusty-radius); padding: 14px 16px; display: flex; flex-direction: column; gap: 12px; flex: 1; min-height: 120px; }
+  .msg { display: flex; }
+  .msg.user { justify-content: flex-end; }
+  .msg.bot { justify-content: flex-start; gap: 10px; }
+  .msg.bot :global(.robot) { margin-top: 2px; }
+  .bubble { max-width: 72%; padding: 11px 15px; border-radius: 8px; line-height: 1.55; font-size: 13px; }
+  .user .bubble { border-bottom-right-radius: 2px; background: var(--trusty-accent); color: #fff; }
+  .bot .bubble { border-bottom-left-radius: 2px; background: var(--trusty-card-bg); border: 1.5px solid var(--trusty-border); }
+  .ref { font: 500 12px var(--trusty-mono); color: var(--trusty-accent); }
+  .sources { margin-top: 8px; padding-top: 8px; border-top: 1px solid var(--trusty-surface-raised); font: 600 10px var(--trusty-mono); letter-spacing: 0.1em; color: var(--trusty-text-muted); }
+  .composer { display: flex; gap: 8px; align-items: flex-end; }
+  .composer .textarea { min-height: 0; font-size: 13px; }
+</style>

--- a/docs/design/UI/design-system-svelte/src/screens/search/data.js
+++ b/docs/design/UI/design-system-svelte/src/screens/search/data.js
@@ -1,0 +1,36 @@
+// Shared mock data for the Trusty Search screens.
+export const searchNav = (active) => ({
+  title: 'TRUSTY SEARCH',
+  unit: 'UNIT-01 · CODE SEARCH',
+  accent: '#b7410e',
+  mark: { body: '#b7410e', eyes: 'square' },
+  items: [
+    { icon: '◇', label: 'Dashboard' },
+    { icon: '⌕', label: 'Search' },
+    { icon: '▣', label: 'Indexes' },
+    { icon: '♥', label: 'Health' },
+    { icon: '☰', label: 'Logs' },
+    { icon: '⚙', label: 'Config' }
+  ].map((it) => ({ ...it, active: it.label === active }))
+});
+
+export const indexes = [
+  { name: 'trusty-tools', docs: '48,213', disk: '412.6 MB', last: 'Jul 18, 09:14', path: '/Users/mo/code/trusty-tools', status: 'ready', selected: true },
+  { name: 'memory-palace', docs: '31,870', disk: '268.1 MB', last: 'Jul 17, 18:40', path: '/Users/mo/code/memory-palace', status: 'working', progress: '1,204 / 31,870', selected: true },
+  { name: 'gitflow-rs', docs: '27,904', disk: '231.9 MB', last: 'Jul 12, 14:03', path: '/Users/mo/code/gitflow-rs', status: 'error', selected: false },
+  { name: 'docs-site', docs: '20,454', disk: '166.3 MB', last: 'Jul 16, 11:52', path: '/Users/mo/code/docs-site', status: 'ready', selected: false }
+];
+
+export const memoryNav = (active) => ({
+  title: 'TRUSTY MEMORY',
+  unit: 'UNIT-02 · MEMORY PALACE',
+  accent: '#8a5a2b',
+  mark: { body: '#8a5a2b', eyes: 'round' },
+  items: [
+    { icon: '▦', label: 'Palaces' },
+    { icon: '◈', label: 'Graph' },
+    { icon: '☾', label: 'Dream' },
+    { icon: '♥', label: 'Health' },
+    { icon: '☰', label: 'Logs' }
+  ].map((it) => ({ ...it, active: it.label === active }))
+});

--- a/docs/design/UI/design-system-svelte/src/styles/foundry.css
+++ b/docs/design/UI/design-system-svelte/src/styles/foundry.css
@@ -1,0 +1,289 @@
+/*
+ * Foundry component styles — drop-in replacement for the Trusty Suite
+ * global.css. Same class names as the existing Svelte UIs, restyled to the
+ * Foundry system. Requires tokens.css. v1.
+ */
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  margin: 0; padding: 0; height: 100%;
+  font-family: var(--trusty-font);
+  font-size: 14px;
+  color: var(--trusty-text-primary);
+  background: var(--trusty-content-bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+#app { min-height: 100vh; }
+
+a { color: var(--trusty-accent); text-decoration: none; }
+a:hover { text-decoration: underline; color: var(--trusty-accent-hover); }
+
+button { font-family: var(--trusty-mono); font-size: inherit; cursor: pointer; }
+
+code, pre { font-family: var(--trusty-mono); font-size: 0.85em; }
+
+/* Display headings */
+.page-title, .display {
+  font-family: var(--trusty-display);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+/* Buttons — every tier has a distinct background */
+.btn {
+  display: inline-flex; align-items: center; gap: var(--trusty-space-2);
+  padding: 8px 16px;
+  border: 1.5px solid var(--trusty-border-strong);
+  border-radius: var(--trusty-radius-sm);
+  background: var(--trusty-card-bg);
+  color: var(--trusty-text-secondary);
+  font: 600 12px var(--trusty-mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition: all 0.15s ease;
+}
+.btn:hover { border-color: var(--trusty-accent); color: var(--trusty-accent); }
+.btn:disabled {
+  background: var(--trusty-surface-raised);
+  border-color: var(--trusty-border);
+  color: var(--trusty-sidebar-muted);
+  cursor: not-allowed;
+}
+.btn-primary {
+  background: var(--trusty-accent);
+  border-color: var(--trusty-accent-hover);
+  color: var(--trusty-text-inverse);
+}
+.btn-primary:hover { background: var(--trusty-accent-hover); color: var(--trusty-text-inverse); }
+.btn-danger {
+  background: var(--trusty-accent-soft);
+  border-color: var(--trusty-accent);
+  color: var(--trusty-accent-hover);
+}
+.btn-danger:hover { background: var(--trusty-accent); color: var(--trusty-text-inverse); }
+.btn-ghost { background: transparent; border-color: transparent; color: var(--trusty-text-muted); }
+.btn-ghost:hover:not(:disabled) { background: var(--trusty-surface-hover); color: var(--trusty-text-primary); }
+.btn-sm { padding: 5px 12px; font-size: 11px; }
+
+/* Inputs — machine values in mono */
+.input, .select, .textarea {
+  width: 100%; padding: 9px 14px;
+  border: 1.5px solid var(--trusty-border-strong);
+  border-radius: var(--trusty-radius-sm);
+  background: var(--trusty-card-bg);
+  color: var(--trusty-text-primary);
+  font-family: var(--trusty-mono); font-size: 13px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.input:focus, .select:focus, .textarea:focus {
+  outline: none;
+  border-color: var(--trusty-accent);
+  box-shadow: 0 0 0 3px var(--trusty-accent-soft);
+}
+.textarea { resize: vertical; min-height: 80px; font-family: var(--trusty-font); }
+
+input[type='checkbox'], .checkbox { accent-color: var(--trusty-accent); }
+
+/* Cards — flat, clean 1.5px line borders */
+.card {
+  background: var(--trusty-card-bg);
+  border: 1.5px solid var(--trusty-border);
+  border-radius: var(--trusty-radius);
+}
+.card-header {
+  padding: 14px var(--trusty-space-5);
+  border-bottom: 1.5px solid var(--trusty-border);
+  background: var(--trusty-surface-raised);
+  font-family: var(--trusty-display);
+  font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
+}
+.card-body { padding: var(--trusty-space-5); }
+
+/* Tables — mono stamped headers, no zebra */
+.table { width: 100%; border-collapse: collapse; font-size: var(--trusty-fs-sm); }
+.table th, .table td {
+  text-align: left; padding: 11px 16px;
+  border-bottom: 1px solid var(--trusty-surface-raised);
+}
+.table th {
+  font: 600 10px var(--trusty-mono);
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--trusty-text-muted);
+  border-bottom: 1px solid var(--trusty-border);
+  background: transparent;
+}
+.table tbody tr:hover { background: var(--trusty-surface-hover); }
+.selected-row { background: var(--trusty-primary-soft); }
+
+/* Badges — rectangular stamps, never pills */
+.badge {
+  display: inline-block; padding: 2px 8px;
+  border-radius: var(--trusty-radius-sm);
+  font: 600 10px var(--trusty-mono);
+  letter-spacing: 0.04em; text-transform: uppercase;
+  background: var(--trusty-accent-soft); color: var(--trusty-accent-hover);
+}
+.badge-success { background: var(--trusty-success-soft); color: var(--trusty-success); }
+.badge-warning { background: var(--trusty-warning-soft); color: #7a5a10; }
+.badge-danger { background: var(--trusty-danger-soft); color: #8a2013; }
+.badge-info { background: var(--trusty-info-soft); color: var(--trusty-info); }
+.badge-muted { background: var(--trusty-surface-raised); color: var(--trusty-text-secondary); }
+
+/* Stat cards */
+.stat-grid {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--trusty-space-4); margin-bottom: var(--trusty-space-5);
+}
+.stat {
+  background: var(--trusty-card-bg);
+  border: 1.5px solid var(--trusty-border);
+  border-radius: var(--trusty-radius);
+  padding: 20px;
+}
+.stat-label {
+  font: 600 10px var(--trusty-mono);
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--trusty-text-muted);
+  margin-bottom: var(--trusty-space-2);
+}
+.stat-value {
+  font-family: var(--trusty-display);
+  font-size: var(--trusty-fs-2xl); font-weight: 700;
+  color: var(--trusty-text-primary);
+}
+.stat-meta { font-size: var(--trusty-fs-xs); color: var(--trusty-text-muted); margin-top: var(--trusty-space-1); }
+
+/* Modal — floats, so it gets the shadow */
+.modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(43, 28, 18, 0.55);
+  display: flex; align-items: center; justify-content: center; z-index: 100;
+}
+.modal {
+  background: var(--trusty-card-bg);
+  border: 1.5px solid var(--trusty-border);
+  border-radius: var(--trusty-radius);
+  box-shadow: var(--trusty-shadow-lg);
+  width: 100%; max-width: 520px; max-height: 90vh; overflow: auto;
+}
+.modal-header {
+  padding: 14px var(--trusty-space-5);
+  border-bottom: 1.5px solid var(--trusty-border);
+  background: var(--trusty-surface-raised);
+  display: flex; align-items: center; justify-content: space-between;
+}
+.modal-title {
+  font-family: var(--trusty-display);
+  font-size: 15px; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+.modal-body { padding: var(--trusty-space-5); }
+.modal-footer {
+  padding: 14px var(--trusty-space-5);
+  border-top: 1.5px solid var(--trusty-surface-raised);
+  display: flex; justify-content: flex-end; gap: var(--trusty-space-2);
+}
+
+/* Toasts — dark chassis, bottom-right stack, 3px status edge */
+.toast-stack {
+  position: fixed; right: 24px; bottom: 24px;
+  display: flex; flex-direction: column; gap: 10px;
+  width: 340px; z-index: 200;
+}
+.toast {
+  background: var(--trusty-sidebar-bg);
+  border-left: 3px solid var(--trusty-accent);
+  border-radius: var(--trusty-radius-sm);
+  padding: 12px 16px;
+  color: var(--trusty-sidebar-text);
+  display: flex; gap: 12px; align-items: flex-start;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+}
+.toast-title {
+  font: 600 11px var(--trusty-mono);
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--trusty-sidebar-accent);
+  margin-bottom: 3px;
+}
+.toast-body { font-size: 12.5px; line-height: 1.5; }
+.toast-success { border-left-color: #5c9a3d; }
+.toast-success .toast-title { color: #a8c878; }
+.toast-danger { border-left-color: var(--trusty-danger); }
+.toast-danger .toast-title { color: #f0a898; }
+
+/* Form */
+.form-group { margin-bottom: var(--trusty-space-4); }
+.form-label {
+  display: block; margin-bottom: var(--trusty-space-2);
+  font: 600 10px var(--trusty-mono);
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--trusty-text-muted);
+}
+
+/* Progress bar */
+.bar {
+  display: inline-block; vertical-align: middle;
+  width: 80px; height: 7px;
+  border: 1px solid var(--trusty-border);
+  background: var(--trusty-surface-raised);
+  overflow: hidden; position: relative;
+}
+.bar-fill { display: block; height: 100%; background: var(--trusty-accent); }
+
+/* Spinner */
+.spinner {
+  width: 10px; height: 10px;
+  border: 2px solid currentColor; border-right-color: transparent;
+  border-radius: 50%; display: inline-block;
+  animation: trusty-spin 0.7s linear infinite;
+}
+@keyframes trusty-spin { to { transform: rotate(360deg); } }
+
+/* Utility (unchanged names) */
+.flex { display: flex; }
+.flex-between { display: flex; justify-content: space-between; align-items: center; }
+.flex-gap-2 { display: flex; gap: var(--trusty-space-2); }
+.flex-gap-3 { display: flex; gap: var(--trusty-space-3); }
+.text-muted { color: var(--trusty-text-muted); }
+.text-mono { font-family: var(--trusty-mono); }
+.text-sm { font-size: var(--trusty-fs-sm); }
+.text-xs { font-size: var(--trusty-fs-xs); }
+.mb-2 { margin-bottom: var(--trusty-space-2); }
+.mb-3 { margin-bottom: var(--trusty-space-3); }
+.mb-4 { margin-bottom: var(--trusty-space-4); }
+.mb-5 { margin-bottom: var(--trusty-space-5); }
+.mt-3 { margin-top: var(--trusty-space-3); }
+.mt-4 { margin-top: var(--trusty-space-4); }
+.empty { text-align: center; padding: var(--trusty-space-6); color: var(--trusty-text-muted); }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.tag {
+  display: inline-block; padding: 2px 8px; margin-right: 4px;
+  border-radius: var(--trusty-radius-sm);
+  background: var(--trusty-surface-raised);
+  color: var(--trusty-text-secondary);
+  font: 500 11px var(--trusty-mono);
+}
+
+/* Robot activity animation — event-driven mark states.
+ * Markup: .robot > .robot-eye (x2), .robot-antenna-tip; add .robot-ring spans for receiving.
+ * States: .robot-idle (slow blink) / .robot-receiving (antenna pings, throttle to <=2/s)
+ * / .robot-working (double-blink + tilt). */
+@keyframes foundry-blink { 0%, 94%, 100% { transform: scaleY(1); } 96%, 98% { transform: scaleY(0.12); } }
+@keyframes foundry-blink-busy { 0%, 86%, 100% { transform: scaleY(1); } 88%, 90% { transform: scaleY(0.12); } 92% { transform: scaleY(1); } 94%, 96% { transform: scaleY(0.12); } }
+@keyframes foundry-ping { 0% { transform: translateX(-50%) scale(0.3); opacity: 0.9; } 100% { transform: translateX(-50%) scale(2.6); opacity: 0; } }
+@keyframes foundry-tilt { 0%, 100% { transform: rotate(0); } 40% { transform: rotate(-4deg); } 60% { transform: rotate(4deg); } }
+.robot-idle .robot-eye { animation: foundry-blink 4s infinite; transform-origin: center; }
+.robot-working .robot-eye { animation: foundry-blink-busy 2.2s infinite; transform-origin: center; }
+.robot-working { animation: foundry-tilt 2.8s ease-in-out infinite; }
+.robot-receiving .robot-ring {
+  position: absolute; left: 50%; top: -16px; width: 8px; height: 8px;
+  border-radius: 50%; border: 2px solid var(--trusty-accent);
+  animation: foundry-ping 1.4s ease-out infinite;
+}
+.robot-receiving .robot-ring:nth-child(2) { animation-delay: 0.7s; border-color: var(--trusty-sidebar-accent); }
+@media (prefers-reduced-motion: reduce) {
+  .robot-idle .robot-eye, .robot-working .robot-eye, .robot-working { animation: none; }
+  .robot-receiving .robot-ring { animation: none; opacity: 0.4; transform: translateX(-50%) scale(1.6); }
+}

--- a/docs/design/UI/design-system-svelte/src/styles/tokens.css
+++ b/docs/design/UI/design-system-svelte/src/styles/tokens.css
@@ -1,0 +1,124 @@
+/*
+ * Trusty Suite design tokens — "FOUNDRY" theme.
+ * Robot-themed, rust-colored. Drop-in replacement for
+ * crates/*/ui/src/lib/styles/tokens.css (same variable names).
+ * Fonts: Chakra Petch (display), IBM Plex Sans (body), IBM Plex Mono (code/labels).
+ * Load: https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap
+ */
+:root {
+  /* Sidebar (dark oxide chassis) */
+  --trusty-sidebar-bg: #2b1c12;
+  --trusty-sidebar-text: #e6d8c8;
+  --trusty-sidebar-muted: #a58a6b;
+  --trusty-sidebar-accent: #e9b98a;
+  --trusty-sidebar-active: #46311f;
+  --trusty-sidebar-border: #46311f;
+
+  /* Content (warm paper) */
+  --trusty-content-bg: #f5efe7;
+  --trusty-card-bg: #fffdf9;
+  --trusty-border: #d8c9b4;
+  --trusty-border-strong: #c4b096;
+  --trusty-surface-raised: #efe6d8;
+  --trusty-surface-hover: rgba(183, 65, 14, 0.06);
+
+  /* Text */
+  --trusty-text-primary: #2b1c12;
+  --trusty-text-secondary: #6e5843;
+  --trusty-text-muted: #8a7460;
+  --trusty-text-inverse: #ffffff;
+
+  /* Accents (rust core) */
+  --trusty-accent: #b7410e;
+  --trusty-accent-hover: #8a2f0b;
+  --trusty-accent-soft: #f3d9cb;
+  --trusty-primary: #b7410e;
+  --trusty-primary-soft: rgba(183, 65, 14, 0.07);
+  --trusty-success: #3f6f2a;
+  --trusty-success-soft: #dcedd2;
+  --trusty-warning: #b07d10;
+  --trusty-warning-soft: #f5e7c4;
+  --trusty-danger: #c2331f;
+  --trusty-danger-soft: #f6d7d0;
+  --trusty-info: #3d6b8a;
+  --trusty-info-soft: #dde9f0;
+
+  /* Typography */
+  --trusty-font: 'IBM Plex Sans', system-ui, -apple-system, sans-serif;
+  --trusty-display: 'Chakra Petch', 'IBM Plex Sans', sans-serif;
+  --trusty-mono: 'IBM Plex Mono', ui-monospace, Menlo, monospace;
+  --trusty-fs-xs: 0.75rem;
+  --trusty-fs-sm: 0.875rem;
+  --trusty-fs-md: 1rem;
+  --trusty-fs-lg: 1.125rem;
+  --trusty-fs-xl: 1.5rem;
+  --trusty-fs-2xl: 2rem;
+
+  /* Surface — flat, clean line borders (no offset shadows) */
+  --trusty-radius-sm: 3px;
+  --trusty-radius: 5px;
+  --trusty-radius-lg: 8px;
+  --trusty-shadow-sm: none;
+  --trusty-shadow: 0 1px 2px rgba(43, 28, 18, 0.06);
+  --trusty-shadow-lg: 0 14px 32px rgba(43, 28, 18, 0.28);
+
+  /* Layout */
+  --trusty-sidebar-width: 240px;
+  --trusty-topbar-height: 56px;
+  --trusty-space-1: 4px;
+  --trusty-space-2: 8px;
+  --trusty-space-3: 12px;
+  --trusty-space-4: 16px;
+  --trusty-space-5: 24px;
+  --trusty-space-6: 32px;
+}
+</content>
+
+
+/*
+ * Dark theme — "NIGHT SHIFT". Activate with <html data-theme="dark"> or the
+ * .dark class. Same rust hue family; surfaces flip to oxide chassis, the
+ * accent brightens one step (#D97742) to hold contrast on dark paper.
+ */
+[data-theme='dark'], .dark {
+  /* Sidebar (deepest chassis) */
+  --trusty-sidebar-bg: #171009;
+  --trusty-sidebar-text: #e6d8c8;
+  --trusty-sidebar-muted: #a58a6b;
+  --trusty-sidebar-accent: #e9b98a;
+  --trusty-sidebar-active: #382513;
+  --trusty-sidebar-border: #382513;
+
+  /* Content (dark oxide) */
+  --trusty-content-bg: #201612;
+  --trusty-card-bg: #2b1c12;
+  --trusty-border: #46311f;
+  --trusty-border-strong: #5c4126;
+  --trusty-surface-raised: #382513;
+  --trusty-surface-hover: rgba(217, 119, 66, 0.09);
+
+  /* Text */
+  --trusty-text-primary: #f0e7d8;
+  --trusty-text-secondary: #cbb69c;
+  --trusty-text-muted: #a58a6b;
+  --trusty-text-inverse: #201612;
+
+  /* Accents — rust brightens one step on dark */
+  --trusty-accent: #d97742;
+  --trusty-accent-hover: #e8905c;
+  --trusty-accent-soft: rgba(217, 119, 66, 0.16);
+  --trusty-primary: #d97742;
+  --trusty-primary-soft: rgba(217, 119, 66, 0.10);
+  --trusty-success: #8fbf6a;
+  --trusty-success-soft: rgba(143, 191, 106, 0.14);
+  --trusty-warning: #d9a83a;
+  --trusty-warning-soft: rgba(217, 168, 58, 0.14);
+  --trusty-danger: #e06a52;
+  --trusty-danger-soft: rgba(224, 106, 82, 0.14);
+  --trusty-info: #7ba7c4;
+  --trusty-info-soft: rgba(123, 167, 196, 0.14);
+
+  /* Surface */
+  --trusty-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --trusty-shadow-lg: 0 14px 32px rgba(0, 0, 0, 0.55);
+}

--- a/docs/design/UI/design-system-svelte/vite.config.js
+++ b/docs/design/UI/design-system-svelte/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()]
+});


### PR DESCRIPTION
## Summary

Bob delivered a new zip — `docs/design/UI/Trusty Tools robot design system = svelts.zip` — containing a Svelte 5 (runes) + Vite port of the Foundry v2 design system. This PR lands it as tracked, runnable reference material.

### Inventory

- 14 full-page review screens across search (Dashboard, Search+chat, Indexes, Health, Dialogs gallery), console (Command deck), memory (Palaces), agents (Chat, Projects, Auth gate, Task failure, Recap), and code (`CodeGui.svelte`, `CodeTui.svelte` — direct mockups for trusty-code-gui).
- 9 reusable `src/lib/` primitives: `Button`, `Badge`, `Modal`, `Toast`, `StatCard`, `Sidebar`, `Topbar`, `AppShell`, `RobotMark` (idle/receiving/working states, square/round/visor eyes).
- Svelte 5 runes throughout (`$state`, `$props`, `{@render children?.()}`) — no Svelte 4 idioms.
- `src/styles/tokens.css` and `foundry.css` are **byte-identical** to the already-committed `docs/design/UI/design-system/{tokens,foundry}.css` — confirms this is a straight Svelte port of the same v2 tokens/visuals, not a new design pass.
- No licensing/provenance markers beyond the drop's own README; treated as Bob-authored internal design material, same as the rest of `docs/design/UI/`.

### Landing rationale

Landed under `docs/design/UI/design-system-svelte/` as **committed reference**, not as importable source under `crates/trusty-code-gui/ui/src`.

`crates/trusty-code-gui/ui` already ships its own tested Foundry integration (issue #3153): Tailwind utility classes (`bg-trusty-surface`, `text-status-ok/60`, …) backed by `rgb(var(--color-*) / <alpha-value>)` CSS custom properties in `src/app.css`. This drop's Svelte components use a **different** mechanism — raw `foundry.css` classes (`.btn`, `.card`, `.badge`) and `--trusty-*` vars consumed directly. Importing `foundry.css` wholesale into the app's style entry point would stand up a second, overlapping styling system (duplicate `html`/`body` resets, colliding `.btn`/`.card` class names) rather than a clean additive change.

Landing it as a runnable, browsable reference (`npm install && npm run dev` inside `design-system-svelte/`) preserves its full value — including the `CodeGui`/`CodeTui` screens as a layout north-star for trusty-code-gui — without destabilizing the shipped Tailwind-token integration.

### Non-goal

**No restyling of any existing screen or component in this PR.** `crates/trusty-code-gui/ui` is untouched — no changes to `app.css`, `tailwind.config.js`, or any existing component. This lands reference material and documentation only.

### Adoption plan (follow-up, sized)

1. **RobotMark** (S) — self-contained, inline-styled; easiest first port, gives the app its brand mark.
2. **Badge / Button** (S) — small, high-reuse; mechanical class-to-Tailwind translation.
3. **StatCard / Toast** (M) — a few more states/variants, still self-contained.
4. **Modal** (M) — needs the app's existing focus-trap/overlay conventions reconciled with the drop's markup.
5. **Sidebar / Topbar / AppShell** (L) — trusty-code-gui already has its own shell (`AppHeader.svelte`, `WorkstreamRail.svelte`, `ServiceNav.svelte`); design-reconciliation task, do last.
6. **Screens** — reference only; use `CodeGui.svelte`/`CodeTui.svelte` as a layout guide, not as import source.

### Gate results (raw)

```
$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 38 spec doc(s) + 2612 code file(s); 0 error(s), 0 warning(s)

$ pnpm test   (crates/trusty-code-gui/ui, untouched baseline)
 Test Files  14 passed (14)
      Tests  155 passed (155)

$ pnpm build  (crates/trusty-code-gui/ui, untouched baseline)
✓ 136 modules transformed.
✓ built in 713ms
```

None of the three repo-wide gate scripts scan `.svelte`/`.css`/`.js` files (line-cap and test-pointers are `.rs`-only; sld-lint only applies its full checks to `docs/specs/**` frontmatter-bearing specs), so the new tree needed no allowlist entries. The `trusty-code-gui/ui` package itself is untouched by this PR — its test/build run above is the pre-existing baseline, confirmed green.

## Test plan

- [x] `bash scripts/check_line_cap.sh` — OK
- [x] `bash scripts/check_test_pointers.sh` — OK
- [x] `bash scripts/check_sld.sh` — OK
- [x] `pnpm test` in `crates/trusty-code-gui/ui` — 155/155 passing (baseline, unmodified)
- [x] `pnpm build` in `crates/trusty-code-gui/ui` — clean (baseline, unmodified)
- [x] No `.zip` files committed; Bob's originals in `docs/design/UI/` left untouched
- [ ] DO NOT MERGE — awaiting review

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools