### PR TITLE
feat(trusty-agents): add shared-inference seam with OpenRouter parity (flag-off)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -29,6 +29,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Shared-inference seam, Step 1+2 (#2410):** `llm::inference_bridge` is a
+  pure, field-by-field conversion between `async-openai`'s wire types
+  (`ChatCompletionRequestMessage`, `ChatCompletionTool`,
+  `ChatCompletionMessageToolCall`) and `trusty_common::inference`'s shared
+  request/response model, and `llm::inference_client::InferenceClient` is an
+  OpenRouter transport built on it (mirrors `trusty-code`'s
+  `OpenAiCompatClient`). Wired into `tool_loop::turn::dispatch_turn`'s plain
+  OpenRouter branch behind `TAGENT_INFERENCE_SHARED=1` — **inert by default**:
+  with the flag unset (or any value other than `"1"`), every existing call
+  path is byte-for-byte unchanged, including the cache_control/tool_choice-
+  forcing raw path, native-Anthropic-direct, ollama, and Bedrock, none of
+  which this flag ever touches. Anthropic-direct migration and Fireworks
+  routing are explicitly out of scope for this step (later epic steps).
 - The API server now writes the standard `http_addr` discovery file on bind
   (and removes it on graceful shutdown), so the trusty-console reverse proxy can
   resolve the agents surface at `/api/agents/*` (#3331).

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -46,7 +46,14 @@ trusty-code = { workspace = true }
 #      middleware stack (`trusty_common::server::with_guarded_middleware`,
 #      `SelfOrigins`) the API server adopts router-wide for the loopback-only
 #      doctrine (mirrors trusty-console/#3317).
-trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli", "axum-server"] }
+# `inference-client` (#2410, epic #2400): the shared OpenAI-compatible
+#      adapter layer (`Configurator`, `InferenceAdapter`, the `ChatRequest`/
+#      `ChatResponse` wire types, `test_support::MockInferenceServer` when
+#      paired with `axum-server`) that `llm::inference_bridge` /
+#      `llm::inference_client` build on. Already implied transitively by
+#      `config-cli`, but declared explicitly so that relationship is never a
+#      silent, breakable assumption.
+trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli", "axum-server", "inference-client"] }
 # Why (issue #226): trusty-agents only links `trusty_memory::MemoryMcpService` for
 #      in-process `rpc.discover` merging; it does not need the axum HTTP/SSE
 #      surface (it owns its own axum stack for the orchestrator's UI). Setting

--- a/crates/trusty-agents/src/llm/inference_bridge/mod.rs
+++ b/crates/trusty-agents/src/llm/inference_bridge/mod.rs
@@ -171,32 +171,88 @@ fn system_content_text(content: &ChatCompletionRequestSystemMessageContent) -> S
 
 /// Concatenate a user-message content value to plain text, dropping any
 /// non-text parts (image/audio — see compromise #2 in the module doc).
+///
+/// Why: unreachable today (verified: no `ImageUrl`/`InputAudio` content-part
+/// call site exists in this crate as of #2410) but silent on a future
+/// vision-capable call site would degrade a prompt with zero signal. A
+/// `tracing::warn!` — not an error, since dropping is still the documented,
+/// intended behaviour for now — makes that degradation loud instead.
+/// What: keeps `Text` parts, drops `ImageUrl`/`InputAudio` parts after
+/// logging how many of each were dropped.
+/// Test: `multi_part_user_content_collapses_to_concatenated_text`.
 fn user_content_text(content: &ChatCompletionRequestUserMessageContent) -> String {
     match content {
         ChatCompletionRequestUserMessageContent::Text(s) => s.clone(),
-        ChatCompletionRequestUserMessageContent::Array(parts) => parts
-            .iter()
-            .filter_map(|p| match p {
-                ChatCompletionRequestUserMessageContentPart::Text(t) => Some(t.text.as_str()),
-                ChatCompletionRequestUserMessageContentPart::ImageUrl(_)
-                | ChatCompletionRequestUserMessageContentPart::InputAudio(_) => None,
-            })
-            .collect::<String>(),
+        ChatCompletionRequestUserMessageContent::Array(parts) => {
+            let (mut images, mut audio) = (0u32, 0u32);
+            let text = parts
+                .iter()
+                .filter_map(|p| match p {
+                    ChatCompletionRequestUserMessageContentPart::Text(t) => Some(t.text.as_str()),
+                    ChatCompletionRequestUserMessageContentPart::ImageUrl(_) => {
+                        images += 1;
+                        None
+                    }
+                    ChatCompletionRequestUserMessageContentPart::InputAudio(_) => {
+                        audio += 1;
+                        None
+                    }
+                })
+                .collect::<String>();
+            if images > 0 || audio > 0 {
+                tracing::warn!(
+                    images_dropped = images,
+                    audio_parts_dropped = audio,
+                    "inference_bridge: dropped non-text content part(s) — the shared \
+                     inference seam's ChatMessage.content is text-only (see \
+                     inference_bridge module doc, compromise #2)"
+                );
+            }
+            text
+        }
     }
 }
 
 /// Concatenate an assistant-message content value to plain text, dropping any
 /// refusal parts.
+///
+/// Why: same silent-degradation risk as [`user_content_text`] — a refusal
+/// part carries the model's stated refusal reason, which is currently
+/// discarded rather than surfaced as `content`.
+/// What: keeps `Text` parts, drops `Refusal` parts after logging how many
+/// were dropped.
+/// Test: exercised via `assistant_message_with_tool_calls_maps_fields`
+/// (single-string content path); the `Array`/refusal branch has no
+/// constructible call site in this crate today (same verification as
+/// compromise #2), so it is defended by this warn rather than a dedicated
+/// unit test.
 fn assistant_content_text(content: &ChatCompletionRequestAssistantMessageContent) -> String {
     match content {
         ChatCompletionRequestAssistantMessageContent::Text(s) => s.clone(),
-        ChatCompletionRequestAssistantMessageContent::Array(parts) => parts
-            .iter()
-            .filter_map(|p| match p {
-                ChatCompletionRequestAssistantMessageContentPart::Text(t) => Some(t.text.as_str()),
-                ChatCompletionRequestAssistantMessageContentPart::Refusal(_) => None,
-            })
-            .collect::<String>(),
+        ChatCompletionRequestAssistantMessageContent::Array(parts) => {
+            let mut refusals = 0u32;
+            let text = parts
+                .iter()
+                .filter_map(|p| match p {
+                    ChatCompletionRequestAssistantMessageContentPart::Text(t) => {
+                        Some(t.text.as_str())
+                    }
+                    ChatCompletionRequestAssistantMessageContentPart::Refusal(_) => {
+                        refusals += 1;
+                        None
+                    }
+                })
+                .collect::<String>();
+            if refusals > 0 {
+                tracing::warn!(
+                    refusal_parts_dropped = refusals,
+                    "inference_bridge: dropped assistant refusal content part(s) — the \
+                     shared inference seam's ChatMessage.content is text-only (see \
+                     inference_bridge module doc, compromise #2)"
+                );
+            }
+            text
+        }
     }
 }
 

--- a/crates/trusty-agents/src/llm/inference_bridge/mod.rs
+++ b/crates/trusty-agents/src/llm/inference_bridge/mod.rs
@@ -1,0 +1,317 @@
+//! Bridge between trusty-agents' `async-openai` wire types and the shared
+//! `trusty_common::inference` request/response model (#2410, epic #2400,
+//! Step 1 — conversion only, not wired into dispatch yet).
+//!
+//! Why: trusty-agents' tool-calling loop is built directly on
+//! `async_openai::types::ChatCompletionRequestMessage` (and friends) rather
+//! than a crate-owned wire type the way `trusty-code` is (see
+//! `trusty-code/src/llm/{message,request,response}.rs`). Rather than ripple a
+//! new message type through every call site (`ToolRegistry`, the tool loop,
+//! the recorder, `perf::TokenUsage`), the shared adapter is bridged at
+//! exactly one seam: this module. It mirrors `trusty-code`'s
+//! `llm::convert` (`crates/trusty-code/src/llm/convert.rs`) — field-by-field,
+//! never a `to_value`/`from_value` round trip — but the source types differ
+//! structurally, which surfaces two compromises documented below.
+//!
+//! What: [`to_shared_messages`]/[`to_shared_tools`] convert the outbound
+//! `async-openai` request pieces to `trusty_common::inference` types;
+//! [`from_shared_response`] converts a shared response back into the
+//! `(content, tool_calls, usage)` tuple `tool_loop::turn::dispatch_turn`
+//! returns; [`to_shared_tool_choice`] maps `agents::ToolChoice` onto the
+//! shared [`tci::ToolChoice`] policy (`Auto→Auto`, `Any→Required`,
+//! `None→None`) for a future step that routes the tool_choice-forcing raw
+//! path through this seam.
+//!
+//! Known compromises (read before depending on this seam in a later step):
+//!
+//! 1. **`cache_control` cannot flow through the REQUEST side of this bridge.**
+//!    `async_openai::types::ChatCompletionRequestMessage` and `FunctionObject`
+//!    carry no `cache_control` field at all — unlike `trusty-code`'s
+//!    hand-rolled `ChatMessage`/`FunctionDefinition`, which mirror the shared
+//!    types field-for-field including that marker. trusty-agents' own
+//!    prompt-cache mechanism (`crate::llm::http::build_raw_request` +
+//!    `ModelAdapter::inject_cache_control`) instead mutates a raw
+//!    `serde_json::Value` *after* the typed messages are serialised, entirely
+//!    downstream of this bridge. Every `to_shared_message` conversion below
+//!    therefore always sets `cache_control: None`. This is safe for Step 2
+//!    because `tool_loop::turn::dispatch_turn` only ever routes through this
+//!    bridge on the plain typed branch (`needs_raw == false`), which never
+//!    carries cache_control today either. A future step that wants
+//!    cache-control-bearing traffic on the shared seam will need a different
+//!    design (e.g. constructing `tci::ChatMessage` directly rather than
+//!    bridging from `ChatCompletionRequestMessage`). The shared wire type's
+//!    own cache_control→content-block serialisation is still exercised here
+//!    (see `shared_chat_message_cache_control_still_serialises_as_block` in
+//!    `tests.rs`) to prove the seam is ready to receive it once a producer
+//!    sets it.
+//! 2. **Multi-part message content (images/audio) collapses to text-only.**
+//!    `async-openai`'s `ChatCompletionRequest*MessageContent` allows an
+//!    `Array` of content parts (text/image/audio); the shared
+//!    `tci::ChatMessage.content` is `Option<String>`. Non-text parts are
+//!    dropped. trusty-agents never constructs multi-part content today
+//!    (verified: no `ImageUrl`/`InputAudio` content-part call site exists in
+//!    this crate as of #2410) — every message is built via a builder's
+//!    `.content(<string>)`, which always produces the `Text` variant — so
+//!    this path is currently untriggered, but it is a real, if narrow, loss
+//!    of fidelity for a hypothetical future vision-capable agent.
+//!
+//! Test: `inference_bridge::tests::*`.
+
+#[cfg(test)]
+mod tests;
+
+use async_openai::types::{
+    ChatCompletionMessageToolCall, ChatCompletionRequestAssistantMessageContent,
+    ChatCompletionRequestAssistantMessageContentPart, ChatCompletionRequestDeveloperMessageContent,
+    ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageContent,
+    ChatCompletionRequestSystemMessageContentPart, ChatCompletionRequestToolMessageContent,
+    ChatCompletionRequestToolMessageContentPart, ChatCompletionRequestUserMessageContent,
+    ChatCompletionRequestUserMessageContentPart, ChatCompletionTool, ChatCompletionToolType,
+    FunctionCall,
+};
+use trusty_common::inference as tci;
+
+use crate::agents::ToolChoice as AgentToolChoice;
+use crate::perf::TokenUsage;
+
+/// Convert the outbound `async-openai` message history to the shared wire
+/// message type.
+///
+/// Why: this is the request-side half of the seam every dispatch path funnels
+/// through.
+/// What: maps each `ChatCompletionRequestMessage` variant element-wise (never
+/// a serde round trip); see the module doc for the two documented
+/// compromises.
+/// Test: `system_message_maps_role_and_text`, `user_message_maps_role_and_text`,
+/// `assistant_message_with_tool_calls_maps_fields`, `tool_message_maps_fields`,
+/// `multi_part_user_content_collapses_to_concatenated_text`.
+pub fn to_shared_messages(messages: &[ChatCompletionRequestMessage]) -> Vec<tci::ChatMessage> {
+    messages.iter().map(to_shared_message).collect()
+}
+
+fn to_shared_message(msg: &ChatCompletionRequestMessage) -> tci::ChatMessage {
+    match msg {
+        ChatCompletionRequestMessage::Developer(m) => tci::ChatMessage {
+            role: "system".to_string(),
+            content: Some(developer_content_text(&m.content)),
+            tool_calls: None,
+            tool_call_id: None,
+            name: m.name.clone(),
+            cache_control: None,
+        },
+        ChatCompletionRequestMessage::System(m) => tci::ChatMessage {
+            role: "system".to_string(),
+            content: Some(system_content_text(&m.content)),
+            tool_calls: None,
+            tool_call_id: None,
+            name: m.name.clone(),
+            cache_control: None,
+        },
+        ChatCompletionRequestMessage::User(m) => tci::ChatMessage {
+            role: "user".to_string(),
+            content: Some(user_content_text(&m.content)),
+            tool_calls: None,
+            tool_call_id: None,
+            name: m.name.clone(),
+            cache_control: None,
+        },
+        ChatCompletionRequestMessage::Assistant(m) => tci::ChatMessage {
+            role: "assistant".to_string(),
+            content: m.content.as_ref().map(assistant_content_text),
+            tool_calls: m
+                .tool_calls
+                .as_ref()
+                .map(|calls| calls.iter().map(to_shared_tool_call).collect()),
+            tool_call_id: None,
+            name: m.name.clone(),
+            cache_control: None,
+        },
+        ChatCompletionRequestMessage::Tool(m) => tci::ChatMessage {
+            role: "tool".to_string(),
+            content: Some(tool_content_text(&m.content)),
+            tool_calls: None,
+            tool_call_id: Some(m.tool_call_id.clone()),
+            name: None,
+            cache_control: None,
+        },
+        // Deprecated legacy variant; trusty-agents never constructs it, but the
+        // match must stay exhaustive against upstream's enum.
+        ChatCompletionRequestMessage::Function(m) => tci::ChatMessage {
+            role: "function".to_string(),
+            content: m.content.clone(),
+            tool_calls: None,
+            tool_call_id: None,
+            name: Some(m.name.clone()),
+            cache_control: None,
+        },
+    }
+}
+
+/// Concatenate a developer-message content value to plain text (see
+/// compromise #2 in the module doc for the `Array` case).
+fn developer_content_text(content: &ChatCompletionRequestDeveloperMessageContent) -> String {
+    match content {
+        ChatCompletionRequestDeveloperMessageContent::Text(s) => s.clone(),
+        ChatCompletionRequestDeveloperMessageContent::Array(parts) => {
+            parts.iter().map(|p| p.text.as_str()).collect::<String>()
+        }
+    }
+}
+
+/// Concatenate a system-message content value to plain text.
+fn system_content_text(content: &ChatCompletionRequestSystemMessageContent) -> String {
+    match content {
+        ChatCompletionRequestSystemMessageContent::Text(s) => s.clone(),
+        ChatCompletionRequestSystemMessageContent::Array(parts) => parts
+            .iter()
+            .map(|ChatCompletionRequestSystemMessageContentPart::Text(t)| t.text.as_str())
+            .collect::<String>(),
+    }
+}
+
+/// Concatenate a user-message content value to plain text, dropping any
+/// non-text parts (image/audio — see compromise #2 in the module doc).
+fn user_content_text(content: &ChatCompletionRequestUserMessageContent) -> String {
+    match content {
+        ChatCompletionRequestUserMessageContent::Text(s) => s.clone(),
+        ChatCompletionRequestUserMessageContent::Array(parts) => parts
+            .iter()
+            .filter_map(|p| match p {
+                ChatCompletionRequestUserMessageContentPart::Text(t) => Some(t.text.as_str()),
+                ChatCompletionRequestUserMessageContentPart::ImageUrl(_)
+                | ChatCompletionRequestUserMessageContentPart::InputAudio(_) => None,
+            })
+            .collect::<String>(),
+    }
+}
+
+/// Concatenate an assistant-message content value to plain text, dropping any
+/// refusal parts.
+fn assistant_content_text(content: &ChatCompletionRequestAssistantMessageContent) -> String {
+    match content {
+        ChatCompletionRequestAssistantMessageContent::Text(s) => s.clone(),
+        ChatCompletionRequestAssistantMessageContent::Array(parts) => parts
+            .iter()
+            .filter_map(|p| match p {
+                ChatCompletionRequestAssistantMessageContentPart::Text(t) => Some(t.text.as_str()),
+                ChatCompletionRequestAssistantMessageContentPart::Refusal(_) => None,
+            })
+            .collect::<String>(),
+    }
+}
+
+/// Concatenate a tool-result content value to plain text.
+fn tool_content_text(content: &ChatCompletionRequestToolMessageContent) -> String {
+    match content {
+        ChatCompletionRequestToolMessageContent::Text(s) => s.clone(),
+        ChatCompletionRequestToolMessageContent::Array(parts) => parts
+            .iter()
+            .map(|ChatCompletionRequestToolMessageContentPart::Text(t)| t.text.as_str())
+            .collect::<String>(),
+    }
+}
+
+/// Map an `async-openai` tool call (assistant-emitted, echoed in history) to
+/// the shared wire shape.
+fn to_shared_tool_call(call: &ChatCompletionMessageToolCall) -> tci::ToolCall {
+    tci::ToolCall {
+        id: call.id.clone(),
+        kind: "function".to_string(),
+        function: tci::FunctionCall {
+            name: call.function.name.clone(),
+            arguments: call.function.arguments.clone(),
+        },
+    }
+}
+
+/// Convert `ToolRegistry::openai_tools()`'s output to the shared tool-schema
+/// type.
+///
+/// Why: `ToolRegistry` builds tool definitions as `async_openai::ChatCompletionTool`
+/// (see `crates/trusty-agents/src/tools/mod.rs:226`); the shared adapter needs
+/// `tci::ToolDefinition`.
+/// What: element-wise conversion; `cache_control` is always `None` because
+/// `async_openai::types::FunctionObject` has no such field (module doc
+/// compromise #1 — the same gap, on the tool-schema side).
+/// Test: `to_shared_tools_maps_function_definition`.
+pub fn to_shared_tools(tools: &[ChatCompletionTool]) -> Vec<tci::ToolDefinition> {
+    tools
+        .iter()
+        .map(|t| {
+            tci::ToolDefinition::function(tci::FunctionDefinition {
+                name: t.function.name.clone(),
+                description: t.function.description.clone(),
+                parameters: t.function.parameters.clone(),
+                cache_control: None,
+            })
+        })
+        .collect()
+}
+
+/// Map `agents::ToolChoice` (the TOML-configured policy) onto the shared
+/// neutral [`tci::ToolChoice`].
+///
+/// Why: `crates/trusty-agents/src/agents/params.rs`'s `ToolChoice` is a
+/// 3-variant TOML-friendly enum (`Auto`/`Any`/`None`); the shared adapter
+/// speaks the 4-variant `tci::ToolChoice` (adding `Function(name)`, which
+/// `agents::ToolChoice` cannot express and no trusty-agents call site needs
+/// today).
+/// What: `Auto → Auto`, `Any → Required` (force some tool call), `None → None`.
+/// Test: `to_shared_tool_choice_maps_every_agent_variant`.
+pub fn to_shared_tool_choice(choice: AgentToolChoice) -> tci::ToolChoice {
+    match choice {
+        AgentToolChoice::Auto => tci::ToolChoice::Auto,
+        AgentToolChoice::Any => tci::ToolChoice::Required,
+        AgentToolChoice::None => tci::ToolChoice::None,
+    }
+}
+
+/// Convert a shared [`tci::ChatResponse`] into the `(content, tool_calls,
+/// usage)` tuple `tool_loop::turn::dispatch_turn` returns for every routing
+/// branch.
+///
+/// Why: every downstream consumer (the tool loop, `record_dispatch_usage`,
+/// the XML-tool-call promotion fallback) speaks this tuple shape regardless
+/// of which branch produced it; bridging back to it here means the shared
+/// branch is a drop-in for the legacy typed branch.
+/// What: `first_text()` for content, `first_tool_calls()` mapped element-wise
+/// for tool calls, and `usage()` mapped into `TokenUsage` (the four token
+/// buckets `record_dispatch_usage` reads; the shared `Usage.cost_usd` has no
+/// `TokenUsage` field to carry it into — cost is computed downstream from
+/// `TokenUsage` + model via `crate::perf::cost_usd`, unaffected by this seam).
+/// Test: `from_shared_response_maps_content_tool_calls_and_usage`,
+/// `from_shared_response_handles_no_tool_calls`.
+pub fn from_shared_response(
+    resp: tci::ChatResponse,
+) -> (
+    Option<String>,
+    Vec<ChatCompletionMessageToolCall>,
+    TokenUsage,
+) {
+    let content = resp.first_text();
+    let tool_calls = resp
+        .first_tool_calls()
+        .iter()
+        .map(from_shared_tool_call)
+        .collect();
+    let u = resp.usage();
+    let usage = TokenUsage::new(
+        u.prompt_tokens,
+        u.completion_tokens,
+        u.cache_read_tokens,
+        u.cache_creation_tokens,
+    );
+    (content, tool_calls, usage)
+}
+
+/// Map a shared [`tci::ToolCall`] back to the `async-openai` wire shape.
+fn from_shared_tool_call(call: &tci::ToolCall) -> ChatCompletionMessageToolCall {
+    ChatCompletionMessageToolCall {
+        id: call.id.clone(),
+        r#type: ChatCompletionToolType::Function,
+        function: FunctionCall {
+            name: call.function.name.clone(),
+            arguments: call.function.arguments.clone(),
+        },
+    }
+}

--- a/crates/trusty-agents/src/llm/inference_bridge/tests.rs
+++ b/crates/trusty-agents/src/llm/inference_bridge/tests.rs
@@ -1,0 +1,285 @@
+//! Unit tests for the `inference_bridge` conversion seam.
+//!
+//! Why: kept in its own file so `mod.rs` stays under the 500-SLOC production
+//! cap while every conversion path (and the two documented compromises) gets
+//! explicit coverage.
+//! What: message round-trips per role, tool-call/tool-definition mapping,
+//! `ToolChoice` mapping, response mapping, and the multi-part-content /
+//! cache-control compromise probes called out in the module doc.
+//! Test: this IS the test module.
+
+use super::*;
+use async_openai::types::{
+    ChatCompletionRequestAssistantMessageArgs, ChatCompletionRequestSystemMessageArgs,
+    ChatCompletionRequestToolMessageArgs, ChatCompletionRequestUserMessage,
+    ChatCompletionRequestUserMessageArgs, ChatCompletionToolArgs, FunctionObjectArgs, ImageUrl,
+};
+
+fn sys(text: &str) -> ChatCompletionRequestMessage {
+    ChatCompletionRequestSystemMessageArgs::default()
+        .content(text)
+        .build()
+        .unwrap()
+        .into()
+}
+
+fn user(text: &str) -> ChatCompletionRequestMessage {
+    ChatCompletionRequestUserMessageArgs::default()
+        .content(text)
+        .build()
+        .unwrap()
+        .into()
+}
+
+fn tool_msg(call_id: &str, content: &str) -> ChatCompletionRequestMessage {
+    ChatCompletionRequestToolMessageArgs::default()
+        .tool_call_id(call_id)
+        .content(content)
+        .build()
+        .unwrap()
+        .into()
+}
+
+fn make_tool(name: &str, params: serde_json::Value) -> ChatCompletionTool {
+    let func = FunctionObjectArgs::default()
+        .name(name)
+        .description("a tool")
+        .parameters(params)
+        .build()
+        .unwrap();
+    ChatCompletionToolArgs::default()
+        .function(func)
+        .build()
+        .unwrap()
+}
+
+/// Why: role + text + `name` must survive the system-message conversion.
+/// Test: itself.
+#[test]
+fn system_message_maps_role_and_text() {
+    let shared = to_shared_message(&sys("you are helpful"));
+    assert_eq!(shared.role, "system");
+    assert_eq!(shared.content.as_deref(), Some("you are helpful"));
+    assert!(shared.cache_control.is_none());
+}
+
+/// Why: the user-message path is the most common turn; role/content/name must
+/// carry through unchanged.
+/// Test: itself.
+#[test]
+fn user_message_maps_role_and_text() {
+    let shared = to_shared_message(&user("hello there"));
+    assert_eq!(shared.role, "user");
+    assert_eq!(shared.content.as_deref(), Some("hello there"));
+}
+
+/// Why: assistant turns with tool calls must carry the calls AND leave
+/// `content` as whatever async-openai reports (`None` for tool-only turns).
+/// Test: itself.
+#[test]
+fn assistant_message_with_tool_calls_maps_fields() {
+    let call = ChatCompletionMessageToolCall {
+        id: "call_1".into(),
+        r#type: ChatCompletionToolType::Function,
+        function: FunctionCall {
+            name: "get_weather".into(),
+            arguments: r#"{"loc":"SEA"}"#.into(),
+        },
+    };
+    let msg: ChatCompletionRequestMessage = ChatCompletionRequestAssistantMessageArgs::default()
+        .tool_calls(vec![call])
+        .build()
+        .unwrap()
+        .into();
+    let shared = to_shared_message(&msg);
+    assert_eq!(shared.role, "assistant");
+    assert!(shared.content.is_none());
+    let calls = shared.tool_calls.expect("tool_calls present");
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].id, "call_1");
+    assert_eq!(calls[0].kind, "function");
+    assert_eq!(calls[0].function.name, "get_weather");
+    assert_eq!(calls[0].function.arguments, r#"{"loc":"SEA"}"#);
+}
+
+/// Why: tool-result messages must carry `tool_call_id` — the field the next
+/// turn's pairing depends on.
+/// Test: itself.
+#[test]
+fn tool_message_maps_fields() {
+    let shared = to_shared_message(&tool_msg("call_abc", r#"{"t":72}"#));
+    assert_eq!(shared.role, "tool");
+    assert_eq!(shared.tool_call_id.as_deref(), Some("call_abc"));
+    assert_eq!(shared.content.as_deref(), Some(r#"{"t":72}"#));
+}
+
+/// Documents compromise #2 (module doc): a multi-part user content array
+/// collapses to the concatenation of its text parts, and non-text parts
+/// (image/audio) are dropped rather than erroring.
+///
+/// Why: `async-openai`'s content model technically allows this shape even
+/// though trusty-agents never constructs it (verified — see module doc); the
+/// bridge must degrade predictably rather than panic if it ever does.
+/// Test: itself.
+#[test]
+fn multi_part_user_content_collapses_to_concatenated_text() {
+    use async_openai::types::{
+        ChatCompletionRequestMessageContentPartImage, ChatCompletionRequestMessageContentPartText,
+        ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
+    };
+    let msg = ChatCompletionRequestUserMessage {
+        content: ChatCompletionRequestUserMessageContent::Array(vec![
+            ChatCompletionRequestUserMessageContentPart::Text(
+                ChatCompletionRequestMessageContentPartText {
+                    text: "look at this: ".into(),
+                },
+            ),
+            ChatCompletionRequestUserMessageContentPart::ImageUrl(
+                ChatCompletionRequestMessageContentPartImage {
+                    image_url: ImageUrl {
+                        url: "https://example.test/x.png".into(),
+                        detail: None,
+                    },
+                },
+            ),
+            ChatCompletionRequestUserMessageContentPart::Text(
+                ChatCompletionRequestMessageContentPartText {
+                    text: "what is it?".into(),
+                },
+            ),
+        ]),
+        name: None,
+    };
+    let shared = to_shared_message(&ChatCompletionRequestMessage::User(msg));
+    assert_eq!(
+        shared.content.as_deref(),
+        Some("look at this: what is it?"),
+        "text parts concatenate; the image part is dropped, not errored"
+    );
+}
+
+/// The shared wire type's own cache_control→content-block serialisation is
+/// intact and ready to receive a marker from a future producer, even though
+/// THIS bridge can never set one (module doc compromise #1 — async-openai's
+/// `ChatCompletionRequestMessage` has no `cache_control` field to read from).
+///
+/// Why: proves the seam itself is not broken, only that this particular
+/// source type cannot feed it — the distinction the PR report calls out.
+/// Test: itself.
+#[test]
+fn shared_chat_message_cache_control_still_serialises_as_block() {
+    let mut m = tci::ChatMessage::system("prefix");
+    assert!(m.cache_control.is_none(), "bridge never sets this field");
+    m.cache_control = Some(tci::CacheControl::ephemeral());
+    let v = serde_json::to_value(&m).expect("serialise");
+    assert_eq!(
+        v["content"],
+        serde_json::json!([{
+            "type": "text",
+            "text": "prefix",
+            "cache_control": {"type": "ephemeral"}
+        }])
+    );
+}
+
+/// Why: `ToolRegistry::openai_tools()`'s output must map onto the shared
+/// tool-schema type without dropping name/description/parameters.
+/// Test: itself.
+#[test]
+fn to_shared_tools_maps_function_definition() {
+    let tools = vec![make_tool(
+        "search",
+        serde_json::json!({"type": "object", "properties": {}}),
+    )];
+    let shared = to_shared_tools(&tools);
+    assert_eq!(shared.len(), 1);
+    assert_eq!(shared[0].function.name, "search");
+    assert_eq!(shared[0].function.description.as_deref(), Some("a tool"));
+    assert_eq!(
+        shared[0].function.parameters,
+        Some(serde_json::json!({"type": "object", "properties": {}}))
+    );
+    assert!(
+        shared[0].function.cache_control.is_none(),
+        "FunctionObject has no cache_control field to carry"
+    );
+}
+
+/// Why: every `agents::ToolChoice` variant must map onto its documented
+/// `tci::ToolChoice` counterpart.
+/// Test: itself.
+#[test]
+fn to_shared_tool_choice_maps_every_agent_variant() {
+    assert_eq!(
+        to_shared_tool_choice(AgentToolChoice::Auto),
+        tci::ToolChoice::Auto
+    );
+    assert_eq!(
+        to_shared_tool_choice(AgentToolChoice::Any),
+        tci::ToolChoice::Required
+    );
+    assert_eq!(
+        to_shared_tool_choice(AgentToolChoice::None),
+        tci::ToolChoice::None
+    );
+}
+
+/// The shared `tci::ToolChoice::Function` variant (unreachable from
+/// `agents::ToolChoice`, which has no such variant) still maps to the correct
+/// OpenAI-dialect wire shape via the shared crate's own mapper — proving the
+/// full 4-variant seam works even though trusty-agents can only drive 3 of
+/// them today.
+/// Test: itself.
+#[test]
+fn shared_tool_choice_function_variant_maps_via_openai_tool_choice() {
+    let v = tci::openai_tool_choice(tci::ToolChoice::Function("get_weather".into()));
+    assert_eq!(
+        v,
+        serde_json::json!({"type": "function", "function": {"name": "get_weather"}})
+    );
+}
+
+/// Why: content, tool calls, and usage must all flow through
+/// `from_shared_response` into the tuple the tool loop expects.
+/// Test: itself.
+#[test]
+fn from_shared_response_maps_content_tool_calls_and_usage() {
+    let fixture = r#"{
+      "id": "gen-1",
+      "choices": [{"message": {"role": "assistant", "content": null,
+          "tool_calls": [{"id": "c1", "type": "function",
+              "function": {"name": "bash", "arguments": "{}"}}]},
+          "finish_reason": "tool_calls"}],
+      "usage": {"prompt_tokens": 12, "completion_tokens": 3,
+                "prompt_tokens_details": {"cached_tokens": 4, "cache_write_tokens": 1}}
+    }"#;
+    let shared: tci::ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+    let (content, tool_calls, usage) = from_shared_response(shared);
+    assert!(content.is_none());
+    assert_eq!(tool_calls.len(), 1);
+    assert_eq!(tool_calls[0].id, "c1");
+    assert_eq!(tool_calls[0].function.name, "bash");
+    assert_eq!(usage.prompt_tokens, 12);
+    assert_eq!(usage.completion_tokens, 3);
+    assert_eq!(usage.cache_read_tokens, 4);
+    assert_eq!(usage.cache_creation_tokens, 1);
+}
+
+/// Why: a plain-text response (no tool calls) must round-trip cleanly too —
+/// the common "final answer" turn.
+/// Test: itself.
+#[test]
+fn from_shared_response_handles_no_tool_calls() {
+    let fixture = r#"{
+      "id": "gen-2",
+      "choices": [{"message": {"role": "assistant", "content": "all done"},
+                   "finish_reason": "stop"}],
+      "usage": {"prompt_tokens": 5, "completion_tokens": 2}
+    }"#;
+    let shared: tci::ChatResponse = serde_json::from_str(fixture).expect("deserialise");
+    let (content, tool_calls, usage) = from_shared_response(shared);
+    assert_eq!(content.as_deref(), Some("all done"));
+    assert!(tool_calls.is_empty());
+    assert_eq!(usage.prompt_tokens, 5);
+    assert_eq!(usage.completion_tokens, 2);
+}

--- a/crates/trusty-agents/src/llm/inference_client/mod.rs
+++ b/crates/trusty-agents/src/llm/inference_client/mod.rs
@@ -1,0 +1,231 @@
+//! Shared-inference client for trusty-agents' OpenRouter traffic (#2410,
+//! epic #2400, Step 2 — flag-gated, default OFF).
+//!
+//! Why: Step 1 (`crate::llm::inference_bridge`) built the pure conversion
+//! seam; this module is the thin consumer that turns it into a real HTTP
+//! transport, mirroring `trusty-code`'s `OpenAiCompatClient`
+//! (`crates/trusty-code/src/llm/client.rs`) so the two crates share the
+//! same shape of adoption. Construction never touches credentials — the
+//! #2245 deferred-failure contract — so a caller can build an
+//! [`InferenceClient`] unconditionally and only pay the "is a key
+//! configured" cost inside [`InferenceClient::chat`].
+//!
+//! What: [`InferenceClient`] owns a `Configurator` (populated via
+//! `register_default_factories`, `crates/trusty-common/src/inference/providers/mod.rs:45`),
+//! a credential `KeyStore`, and a `ProviderId`-keyed adapter cache
+//! (`Arc<dyn InferenceAdapter>`) so the underlying `reqwest` connection pool
+//! is reused across turns rather than rebuilt per call.
+//!
+//! 🔴 Step 1+2 scope is OpenRouter ONLY. [`InferenceClient::adapter`] always
+//! resolves against the FIXED routing slug [`OPENROUTER_ROUTING_SLUG`] —
+//! **never** the caller's real model slug. This is deliberate, not an
+//! oversight: `register_default_factories` also registers the Anthropic
+//! **direct** factory, and `trusty_common::inference::provider_for` resolves
+//! an `"anthropic/…"`-prefixed slug to `ProviderId::Anthropic` whenever an
+//! `ANTHROPIC_API_KEY` happens to be configured (a very common local-dev
+//! setup per this crate's own `llm::credentials` priority order). If this
+//! client ever resolved on the real (already-OpenRouter-qualified, per
+//! `llm::credentials::qualify_openrouter_model`) model slug instead of the
+//! fixed routing slug, an anthropic-prefixed model would silently defect
+//! from OpenRouter onto the Anthropic-direct adapter — exactly the migration
+//! the owner explicitly ruled out of scope for #2410 (see the epic's SCOPE
+//! BOUNDARIES: `llm::anthropic_native` is untouched). The fixed routing slug
+//! makes that misroute structurally impossible: `provider_for` resolves
+//! `"openrouter/route"`'s prefix to `ProviderId::OpenRouter` in BOTH
+//! resolution stages, regardless of which other credentials are configured
+//! (see `openrouter_route_never_resolves_to_anthropic_even_when_anthropic_key_present`
+//! in `tests.rs`). Per-slug provider routing (Fireworks) is epic Step 3, a
+//! later PR — it will need a different resolution strategy than this one.
+//!
+//! [`shared_inference_enabled`] is the single source of truth for the
+//! `TAGENT_INFERENCE_SHARED` env flag `tool_loop::turn::dispatch_turn` gates
+//! on; default OFF, so the legacy `async-openai` typed path is unchanged
+//! unless a caller opts in.
+//!
+//! Test: `inference_client::tests::*`; the offline black-box wire-shape proof
+//! lives in `crates/trusty-agents/tests/inference_shared_adapter_e2e.rs`.
+
+#[cfg(test)]
+mod tests;
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use tokio::sync::Mutex;
+use trusty_common::inference::{
+    ChatRequest, ChatResponse, Configurator, InferenceAdapter, InferenceError, ResolvedProvider,
+    credentials::{KeyStore, default_store},
+    providers::openrouter,
+    registry::ProviderId,
+};
+
+/// Env var overriding the OpenRouter base URL. Reuses the SAME variable the
+/// legacy path already honours (`llm::adapter::openrouter_endpoint`,
+/// `llm::helpers::create_client`) so a single override affects both paths
+/// identically — the byte-parity property the offline e2e test relies on.
+/// Defaults to [`openrouter::OPENROUTER_BASE_URL`] when unset.
+const OPENROUTER_BASE_URL_ENV: &str = "OPENROUTER_BASE_URL";
+
+/// Env var gating the shared-inference OpenRouter path. Default OFF — unset
+/// or any value other than `"1"` keeps the legacy `async-openai` typed path.
+pub const SHARED_INFERENCE_ENV: &str = "TAGENT_INFERENCE_SHARED";
+
+/// Fixed routing slug forcing `provider_for` to resolve `ProviderId::OpenRouter`
+/// regardless of the caller's real model slug. See the module doc for why
+/// this must never be the request's own model.
+const OPENROUTER_ROUTING_SLUG: &str = "openrouter/route";
+
+/// Whether the shared-inference seam is enabled for this process.
+///
+/// Why: single source of truth so `dispatch_turn` and any future call site
+/// agree on the flag name and the exact value that turns it on.
+/// What: `true` iff `TAGENT_INFERENCE_SHARED` is exactly `"1"`.
+/// Test: `shared_inference_enabled_reads_flag`.
+pub fn shared_inference_enabled() -> bool {
+    std::env::var(SHARED_INFERENCE_ENV).is_ok_and(|v| v == "1")
+}
+
+/// OpenRouter transport backed by the shared `trusty_common::inference`
+/// adapter layer.
+///
+/// Why: one place that owns "build the OpenRouter adapter once, cache it,
+/// reuse its connection pool" so `dispatch_turn`'s shared branch stays a
+/// one-line call.
+/// What: holds the `Configurator` (factory registry), the `KeyStore`, and a
+/// lazily-populated adapter cache keyed by `ProviderId` (mirroring
+/// `trusty-code`'s cache shape even though Step 1+2 only ever populates the
+/// `OpenRouter` entry).
+/// Test: `tests::*`.
+pub struct InferenceClient {
+    configurator: Configurator,
+    store: Box<dyn KeyStore>,
+    adapters: Mutex<HashMap<ProviderId, Arc<dyn InferenceAdapter>>>,
+}
+
+impl std::fmt::Debug for InferenceClient {
+    /// Redacting `Debug`: the `KeyStore` and built adapters hold credential
+    /// material, so this prints only the opaque type name.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InferenceClient").finish_non_exhaustive()
+    }
+}
+
+impl InferenceClient {
+    /// Construct with the process-default secure store and the real
+    /// (production-URL) provider factories.
+    ///
+    /// Why: the production entry point `dispatch_turn`'s shared branch calls.
+    /// What: `register_default_factories` into a fresh `Configurator`, paired
+    /// with `default_store()`. Never touches credentials — construction
+    /// cannot fail on a missing key.
+    /// Test: `constructs_without_touching_credentials`.
+    pub fn new() -> Self {
+        Self::with_store(default_store())
+    }
+
+    /// Construct with an explicit `KeyStore`, using the real
+    /// `register_default_factories` with the OpenRouter entry's base URL
+    /// re-pointed at the `OPENROUTER_BASE_URL` override when set.
+    ///
+    /// Why: lets a caller inject a hermetic store (e.g. `MemoryKeyStore`)
+    /// while still exercising the real provider factories, AND — by honouring
+    /// the same env override the legacy `async-openai` client already reads —
+    /// lets the offline e2e test point BOTH the legacy and shared paths at one
+    /// mock server with a single env var, without mutating the production
+    /// `openrouter::factory` registration itself.
+    /// What: registers every default factory, then `Configurator::register`
+    /// replaces just the `OpenRouter` entry with a closure using
+    /// [`openrouter::build`] against the resolved base URL (env override or
+    /// [`openrouter::OPENROUTER_BASE_URL`]).
+    /// Test: `missing_openrouter_key_errors_at_chat_time`.
+    pub fn with_store(store: Box<dyn KeyStore>) -> Self {
+        let mut configurator = Configurator::new();
+        trusty_common::inference::register_default_factories(&mut configurator);
+        let base_url = std::env::var(OPENROUTER_BASE_URL_ENV)
+            .unwrap_or_else(|_| openrouter::OPENROUTER_BASE_URL.to_string());
+        configurator.register(
+            ProviderId::OpenRouter,
+            Box::new(move |resolved: &ResolvedProvider| openrouter::build(resolved, &base_url)),
+        );
+        Self::with_configurator(configurator, store)
+    }
+
+    /// Construct with a caller-supplied `Configurator` AND `KeyStore`.
+    ///
+    /// Why: the offline e2e test substitutes a `Configurator` whose
+    /// `OpenRouter` factory points at a loopback mock instead of the real
+    /// `https://openrouter.ai/api/v1`, without mutating process env or
+    /// touching the production registry.
+    /// What: stores both and starts with an empty adapter cache.
+    /// Test: `crates/trusty-agents/tests/inference_shared_adapter_e2e.rs`.
+    pub fn with_configurator(configurator: Configurator, store: Box<dyn KeyStore>) -> Self {
+        Self {
+            configurator,
+            store,
+            adapters: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Get (or lazily build + cache) the OpenRouter adapter.
+    ///
+    /// Why: building an adapter constructs a `reqwest::Client`; doing that
+    /// once and reusing it preserves connection pooling across a run's many
+    /// turns, mirroring `trusty-code`'s `OpenAiCompatClient::adapter_for`.
+    /// What: resolves + builds against the FIXED [`OPENROUTER_ROUTING_SLUG`]
+    /// (see module doc) on a cache miss; a build failure is returned, not
+    /// cached, so a later turn can retry once the credential is fixed.
+    /// Test: `adapter_is_cached_across_calls`,
+    /// `openrouter_route_never_resolves_to_anthropic_even_when_anthropic_key_present`.
+    async fn adapter(&self) -> Result<Arc<dyn InferenceAdapter>, InferenceError> {
+        {
+            let cache = self.adapters.lock().await;
+            if let Some(adapter) = cache.get(&ProviderId::OpenRouter) {
+                return Ok(adapter.clone());
+            }
+        }
+        let built: Arc<dyn InferenceAdapter> = Arc::from(
+            self.configurator
+                .build(OPENROUTER_ROUTING_SLUG, self.store.as_ref())?,
+        );
+        let mut cache = self.adapters.lock().await;
+        Ok(cache.entry(ProviderId::OpenRouter).or_insert(built).clone())
+    }
+
+    /// Issue one chat call through the shared OpenRouter adapter.
+    ///
+    /// Why: the single method `dispatch_turn`'s shared branch calls; all
+    /// adapter selection/caching/credential resolution lives behind it.
+    /// What: gets the cached (or freshly-built) OpenRouter adapter and
+    /// forwards `req` to it verbatim — the caller has already applied
+    /// `llm::credentials::qualify_openrouter_model` and the
+    /// `inference_bridge` conversions.
+    /// Test: `crates/trusty-agents/tests/inference_shared_adapter_e2e.rs`.
+    pub async fn chat(&self, req: &ChatRequest) -> Result<ChatResponse, InferenceError> {
+        let adapter = self.adapter().await?;
+        adapter.chat(req).await
+    }
+}
+
+impl Default for InferenceClient {
+    /// Delegates to [`InferenceClient::new`].
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Process-wide shared client, mirroring `http::http_client()`'s
+/// once-per-process reuse pattern (MIN-2 / #98) so the shared branch's
+/// `reqwest` connection pool is reused across every turn of every agent in
+/// this process, not rebuilt per call.
+static SHARED_CLIENT: OnceLock<InferenceClient> = OnceLock::new();
+
+/// Hand out the process-wide [`InferenceClient`], initializing on first call.
+///
+/// Why: `tool_loop::turn::dispatch_turn` calls this once per turn when the
+/// flag is on; a fresh client per call would rebuild the `reqwest::Client`
+/// (and its connection pool) every turn, defeating keep-alive.
+/// What: returns a `'static` reference to the lazily-built default client.
+/// Test: `shared_client_returns_same_instance`.
+pub fn shared_client() -> &'static InferenceClient {
+    SHARED_CLIENT.get_or_init(InferenceClient::new)
+}

--- a/crates/trusty-agents/src/llm/inference_client/tests.rs
+++ b/crates/trusty-agents/src/llm/inference_client/tests.rs
@@ -1,0 +1,223 @@
+//! Unit tests for `InferenceClient` and `shared_inference_enabled`.
+//!
+//! Why: kept in its own file so `mod.rs` stays under the 500-SLOC production
+//! cap. Covers the flag reader, the #2245 deferred-credential contract, adapter
+//! caching, and — the highest-value regression here — that the fixed
+//! `OPENROUTER_ROUTING_SLUG` can never resolve to the Anthropic-direct
+//! adapter no matter what other credentials happen to be configured.
+//! Test: this IS the test module.
+
+use super::*;
+use serial_test::serial;
+use trusty_common::inference::ChatMessage;
+use trusty_common::inference::credentials::MemoryKeyStore;
+use trusty_common::inference::test_support::MockInferenceServer;
+
+/// Why: `dispatch_turn` and any future call site must agree on the exact
+/// value that turns the seam on; only `"1"` counts, everything else (unset,
+/// `"true"`, `"0"`) must keep the legacy path.
+/// Test: itself.
+#[test]
+#[serial]
+fn shared_inference_enabled_reads_flag() {
+    let _g = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    unsafe {
+        std::env::remove_var(SHARED_INFERENCE_ENV);
+    }
+    assert!(!shared_inference_enabled(), "unset must be OFF");
+    unsafe {
+        std::env::set_var(SHARED_INFERENCE_ENV, "true");
+    }
+    assert!(!shared_inference_enabled(), "\"true\" must NOT enable it");
+    unsafe {
+        std::env::set_var(SHARED_INFERENCE_ENV, "1");
+    }
+    assert!(shared_inference_enabled(), "\"1\" must enable it");
+    unsafe {
+        std::env::remove_var(SHARED_INFERENCE_ENV);
+    }
+}
+
+/// Why: the #2245 deferred-failure contract — building an `InferenceClient`
+/// must never touch credentials, so it can never fail at construction time.
+/// What: constructs against an empty `MemoryKeyStore` (no factories even
+/// registered) and asserts the constructor itself is infallible (it returns
+/// `Self`, not a `Result`).
+/// Test: itself.
+#[test]
+fn constructs_without_touching_credentials() {
+    let _client =
+        InferenceClient::with_configurator(Configurator::new(), Box::new(MemoryKeyStore::new()));
+    // No panic / no Result to unwrap — construction is infallible by type.
+}
+
+/// Why: with no OpenRouter credential resolvable anywhere, `chat()` must fail
+/// with `MissingCredential` — never a panic or a silent empty response — and
+/// only at call time, not at construction.
+/// What: skips (does not fail) when the ambient environment happens to carry
+/// a real `OPENROUTER_API_KEY`, mirroring `trusty-code`'s identical guard.
+/// Test: itself.
+#[tokio::test]
+async fn missing_openrouter_key_errors_at_chat_time() {
+    if std::env::var("OPENROUTER_API_KEY").is_ok_and(|v| !v.is_empty()) {
+        return; // real key present locally — don't assert MissingCredential
+    }
+    let mut configurator = Configurator::new();
+    trusty_common::inference::register_default_factories(&mut configurator);
+    let client = InferenceClient::with_configurator(configurator, Box::new(MemoryKeyStore::new()));
+    let req = ChatRequest::new(
+        "unused", // Step 1+2 always routes on the fixed slug, never this value.
+        vec![ChatMessage::user("hi")],
+    );
+    let err = client
+        .chat(&req)
+        .await
+        .expect_err("must fail without a key");
+    assert!(
+        matches!(
+            err,
+            InferenceError::MissingCredential {
+                provider: ProviderId::OpenRouter
+            }
+        ),
+        "expected MissingCredential{{OpenRouter}}, got: {err:?}"
+    );
+}
+
+/// Why: adapter construction builds a `reqwest::Client`; a second `chat()`
+/// call must reuse the SAME adapter (pointer-identical) rather than rebuild
+/// it, preserving connection pooling across turns.
+/// What: seeds a store with a fake OpenRouter key (adapter construction never
+/// makes a network call, so this succeeds without a live server), calls
+/// `adapter()` twice, and asserts `Arc::ptr_eq`.
+/// Test: itself.
+#[tokio::test]
+async fn adapter_is_cached_across_calls() {
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-fake").expect("seed store"); // pragma: allowlist secret
+    let mut configurator = Configurator::new();
+    trusty_common::inference::register_default_factories(&mut configurator);
+    let client = InferenceClient::with_configurator(configurator, Box::new(store));
+
+    let first = client.adapter().await.expect("first build");
+    let second = client.adapter().await.expect("cached build");
+    assert!(
+        Arc::ptr_eq(&first, &second),
+        "second call must reuse the cached adapter"
+    );
+}
+
+/// Why: `InferenceClient::with_store` must honour the SAME `OPENROUTER_BASE_URL`
+/// override the legacy `async-openai` client reads
+/// (`llm::helpers::create_client`, `llm::adapter::openrouter_endpoint`) — the
+/// property the offline e2e test's byte-parity claim depends on.
+/// What: points `OPENROUTER_BASE_URL` at a loopback `MockInferenceServer`,
+/// builds a client via `with_store` (the production constructor path, not
+/// `with_configurator`), sends one request, and asserts the mock actually
+/// received it — proving the override reached the registered OpenRouter
+/// factory, not just a test-only bypass.
+/// Test: itself.
+#[tokio::test]
+#[serial]
+async fn with_store_honours_openrouter_base_url_override() {
+    // NOTE: no `ENV_LOCK` guard here — it is a `std::sync::Mutex` and this
+    // test holds env-var state across `.await` points, which clippy's
+    // `await_holding_lock` correctly forbids for a sync mutex. `#[serial]`
+    // (unnamed group) alone is sufficient: it serializes against every other
+    // unnamed `#[serial]` test in this binary, and no other test in this file
+    // touches `OPENROUTER_BASE_URL`.
+    let server = MockInferenceServer::spawn(
+        200,
+        serde_json::json!({
+            "id": "gen-mock",
+            "choices": [{"message": {"role": "assistant", "content": "pong-mock", "tool_calls": []},
+                         "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 1}
+        }),
+    )
+    .await
+    .expect("spawn mock");
+    unsafe {
+        std::env::set_var(OPENROUTER_BASE_URL_ENV, server.url());
+    }
+
+    let store = MemoryKeyStore::new();
+    store.set("openrouter", "sk-or-fake").expect("seed store"); // pragma: allowlist secret
+    let client = InferenceClient::with_store(Box::new(store));
+    let req = ChatRequest::new("openai/gpt-4o-mini", vec![ChatMessage::user("hi")]);
+    let resp = client
+        .chat(&req)
+        .await
+        .expect("chat via overridden base url");
+    assert_eq!(resp.first_text().as_deref(), Some("pong-mock"));
+    assert!(
+        server.last_request().is_some(),
+        "the mock must have received the request"
+    );
+
+    unsafe {
+        std::env::remove_var(OPENROUTER_BASE_URL_ENV);
+    }
+}
+
+/// Why: `shared_client()` must hand out the SAME process-wide instance on
+/// every call so its adapter cache (and the underlying `reqwest` connection
+/// pool) is actually shared across turns, mirroring `http_client_returns_same_instance`
+/// in `llm::http::tests`.
+/// Test: itself.
+#[test]
+fn shared_client_returns_same_instance() {
+    let a = shared_client();
+    let b = shared_client();
+    assert!(std::ptr::eq(a, b));
+}
+
+/// The regression this module's design exists to prevent: the fixed
+/// [`OPENROUTER_ROUTING_SLUG`] must resolve to `ProviderId::OpenRouter` — and
+/// ONLY ever fail with `MissingCredential{OpenRouter}` otherwise — even when
+/// an `anthropic` credential IS present in the store (simulating a developer
+/// with `ANTHROPIC_API_KEY` set, the common case `llm::credentials::pick_credentials`
+/// prefers). If this ever resolved to `ProviderId::Anthropic` instead, traffic
+/// this client is meant to send to OpenRouter would silently defect onto the
+/// out-of-scope Anthropic-direct path.
+///
+/// Why: this is the single highest-value correctness test in this module —
+/// see the module doc's 🔴 scope-boundary note.
+/// What: seeds an `anthropic` key in the store (no `openrouter` key in the
+/// store), builds against the real registered factories, and asserts the
+/// outcome is EITHER `adapter.name() == "openrouter"` (when the ambient
+/// process env — e.g. a real `OPENROUTER_API_KEY` in `.env.local` on a dev
+/// machine — resolves OpenRouter's own credential) OR
+/// `MissingCredential{OpenRouter}` (when it does not). Neither branch may
+/// ever name Anthropic — that's the property under test, checked
+/// unconditionally so this test is meaningful in every environment rather
+/// than skipping like the sibling credential tests.
+/// Test: itself.
+#[tokio::test]
+async fn openrouter_route_never_resolves_to_anthropic_even_when_anthropic_key_present() {
+    let store = MemoryKeyStore::new();
+    store.set("anthropic", "sk-ant-fake").expect("seed store"); // pragma: allowlist secret
+    let mut configurator = Configurator::new();
+    trusty_common::inference::register_default_factories(&mut configurator);
+    let client = InferenceClient::with_configurator(configurator, Box::new(store));
+
+    // `.expect`/`.expect_err` would require `Arc<dyn InferenceAdapter>: Debug`,
+    // which it is not (trait object for a non-Debug trait) — match manually.
+    match client.adapter().await {
+        Ok(adapter) => assert_eq!(
+            adapter.name(),
+            "openrouter",
+            "must never silently build the Anthropic-direct adapter"
+        ),
+        Err(InferenceError::MissingCredential { provider }) => assert_eq!(
+            provider,
+            ProviderId::OpenRouter,
+            "must name OpenRouter, never silently resolve to Anthropic"
+        ),
+        Err(other) => {
+            panic!("expected Ok(openrouter) or MissingCredential{{OpenRouter}}, got: {other:?}")
+        }
+    }
+}

--- a/crates/trusty-agents/src/llm/mod.rs
+++ b/crates/trusty-agents/src/llm/mod.rs
@@ -8,7 +8,11 @@
 //! What: Declares the provider adapters, the Anthropic-native / Bedrock
 //! backends, the HTTP/event/compression/helper submodules, and the chat entry
 //! points (single-shot in `single_turn`, multi-turn in `tool_loop`), then
-//! re-exports them under their historical `llm::` paths.
+//! re-exports them under their historical `llm::` paths. `inference_bridge`
+//! and `inference_client` (#2410, epic #2400) are the shared-inference seam:
+//! a pure `async-openai` ↔ `trusty_common::inference` type bridge plus the
+//! OpenRouter transport built on it, wired into `tool_loop::turn::dispatch_turn`
+//! behind the default-OFF `TAGENT_INFERENCE_SHARED` flag.
 //! Test: Each submodule carries its own unit tests; the dispatch loop's
 //! parallel-tool behavior is covered by `tool_loop::tests`.
 
@@ -20,6 +24,8 @@ pub mod credentials;
 mod events;
 mod helpers;
 mod http;
+pub mod inference_bridge;
+pub mod inference_client;
 mod single_turn;
 pub mod thinking_classifier;
 mod tool_loop;

--- a/crates/trusty-agents/src/llm/tool_loop/turn.rs
+++ b/crates/trusty-agents/src/llm/tool_loop/turn.rs
@@ -25,6 +25,8 @@ use crate::llm::http::{
     build_raw_request, create_chat_completion_lenient, send_anthropic_native_completion,
     send_raw_completion,
 };
+use crate::llm::inference_bridge;
+use crate::llm::inference_client::{shared_client, shared_inference_enabled};
 use crate::perf::TokenUsage;
 
 /// Routing flags resolved once per `chat_with_tools_gated` call and reused for
@@ -131,6 +133,28 @@ pub(super) async fn dispatch_turn(
         return send_raw_completion(&raw, adapter).await;
     }
 
+    // #2410 (epic #2400) Step 2: this is trusty-agents' plain OpenRouter
+    // happy path — no caching, no explicit tool_choice, not native-Anthropic,
+    // not ollama/bedrock (all already handled/returned above). Route it
+    // through the shared `trusty_common::inference` adapter instead of the
+    // typed `async-openai` client ONLY when the caller has opted in via
+    // `TAGENT_INFERENCE_SHARED=1`. Default OFF — every other branch in this
+    // function (raw/native-Anthropic/ollama) is untouched by the flag and
+    // always uses the legacy path, so cache_control/tool_choice-forcing
+    // traffic and Anthropic-direct/Bedrock routing behave exactly as before
+    // regardless of this flag's value.
+    if shared_inference_enabled() {
+        return dispatch_turn_shared(
+            model,
+            messages,
+            openai_tools,
+            temperature,
+            max_tokens,
+            stop_sequences,
+        )
+        .await;
+    }
+
     let mut builder = CreateChatCompletionRequestArgs::default();
     builder
         .model(model)
@@ -181,4 +205,61 @@ pub(super) async fn dispatch_turn(
         message.tool_calls.unwrap_or_default(),
         usage,
     ))
+}
+
+/// Route this turn through the shared `trusty_common::inference` OpenRouter
+/// adapter (#2410, epic #2400, Step 2) instead of the typed `async-openai`
+/// client.
+///
+/// Why: `dispatch_turn`'s typed-async-openai branch calls this when
+/// `TAGENT_INFERENCE_SHARED=1`; keeping it as a separate function (rather
+/// than inlining) keeps both this file and `inference_client`/`inference_bridge`
+/// independently testable and under the 500-SLOC cap.
+/// What: applies `llm::credentials::qualify_openrouter_model` to `model` (this
+/// client always routes to OpenRouter — see `inference_client`'s module doc
+/// for why the model resolution itself is NOT used to pick a provider —
+/// so the same bare-`claude-*` → `anthropic/claude-*` normalization the
+/// legacy client's upstream callers apply is re-applied here, defensively and
+/// idempotently: `qualify_openrouter_model` is a documented no-op on an
+/// already-prefixed id), bridges `messages`/`openai_tools`/`stop_sequences`
+/// via `inference_bridge`, sends through the process-wide `shared_client()`,
+/// and bridges the response back into the same `(content, tool_calls, usage)`
+/// tuple every other branch returns.
+/// Test: `crates/trusty-agents/tests/inference_shared_adapter_e2e.rs`
+/// (offline, black-box wire-shape proof against a loopback mock).
+async fn dispatch_turn_shared(
+    model: &str,
+    messages: &[ChatCompletionRequestMessage],
+    openai_tools: &[ChatCompletionTool],
+    temperature: f32,
+    max_tokens: u32,
+    stop_sequences: &[String],
+) -> Result<(
+    Option<String>,
+    Vec<ChatCompletionMessageToolCall>,
+    TokenUsage,
+)> {
+    let wire_model = crate::llm::credentials::qualify_openrouter_model(
+        &crate::llm::credentials::LlmCredentials::OpenRouter,
+        model,
+    );
+
+    let mut req = trusty_common::inference::ChatRequest::new(
+        wire_model,
+        inference_bridge::to_shared_messages(messages),
+    );
+    req.temperature = Some(temperature);
+    req.max_tokens = Some(max_tokens);
+    if !openai_tools.is_empty() {
+        req.tools = Some(inference_bridge::to_shared_tools(openai_tools));
+    }
+    if !stop_sequences.is_empty() {
+        req.stop = Some(stop_sequences.to_vec());
+    }
+
+    let resp = shared_client()
+        .chat(&req)
+        .await
+        .context("chat_with_tools: shared-inference OpenRouter request failed")?;
+    Ok(inference_bridge::from_shared_response(resp))
 }

--- a/crates/trusty-agents/tests/inference_shared_adapter_e2e.rs
+++ b/crates/trusty-agents/tests/inference_shared_adapter_e2e.rs
@@ -17,15 +17,26 @@
 //! evidence Step 2's wiring works end-to-end, not just at the unit level.
 //!
 //! `OPENROUTER_BASE_URL` and `TAGENT_INFERENCE_SHARED` are process-global env
-//! vars this file mutates; this is the only test function in this binary
-//! (each file under `tests/` is its own process) so there is no cross-test
-//! race, and `InferenceClient`'s process-wide `shared_client()` `OnceLock` is
-//! guaranteed to see the override on its first (and only) initialisation.
+//! vars both tests in this file mutate; both are `#[serial]` (unnamed group)
+//! so they never interleave within this binary (each file under `tests/` is
+//! its own process, so there is no cross-FILE race either), and
+//! `InferenceClient`'s process-wide `shared_client()` `OnceLock` is
+//! guaranteed to see whichever override was active at its first
+//! initialisation.
 //!
-//! What: one test — routes a bare `claude-*` model through
-//! `chat_with_tools_gated` with the flag on, and asserts the parsed response
-//! AND the captured wire request (path, `Bearer` auth, qualified model id,
-//! detailed-usage directive).
+//! What: two tests —
+//! 1. `bare_claude_model_routes_through_shared_adapter_when_flag_enabled`:
+//!    routes a bare `claude-*` model through `chat_with_tools_gated` with the
+//!    flag on, and asserts the parsed response AND the captured wire request
+//!    (path, `Bearer` auth, qualified model id, detailed-usage directive).
+//! 2. `caching_active_keeps_raw_path_even_with_flag_enabled`: the regression
+//!    the plan calls the highest-value test in the epic — proves
+//!    `enable_prompt_caching`'s `caching_active` term still forces
+//!    `needs_raw` (`llm/tool_loop/mod.rs`'s `let needs_raw = caching_active ||
+//!    …`) even when `TAGENT_INFERENCE_SHARED=1`, so a caching turn is NEVER
+//!    silently routed through the shared adapter. See that test's own doc for
+//!    why the wire signal is the OpenRouter-only `usage:{include:true}`
+//!    directive's ABSENCE, not `cache_control`'s presence.
 //! Test: this file (`cargo test -p trusty-agents --test inference_shared_adapter_e2e`).
 
 use std::sync::Arc;
@@ -37,6 +48,7 @@ use async_openai::types::{
     ChatCompletionRequestUserMessageArgs,
 };
 use serde_json::json;
+use serial_test::serial;
 
 use trusty_agents::llm::adapter::adapter_for_model;
 use trusty_agents::llm::chat_with_tools_gated;
@@ -71,6 +83,7 @@ fn canned_response() -> serde_json::Value {
 /// captured wire request.
 /// Test: this test.
 #[tokio::test]
+#[serial]
 async fn bare_claude_model_routes_through_shared_adapter_when_flag_enabled() {
     let server = MockInferenceServer::spawn(200, canned_response())
         .await
@@ -147,6 +160,123 @@ async fn bare_claude_model_routes_through_shared_adapter_when_flag_enabled() {
         body["usage"],
         json!({"include": true}),
         "shared OpenRouter adapter must inject the detailed-usage directive"
+    );
+
+    unsafe {
+        std::env::remove_var(SHARED_INFERENCE_ENV);
+        std::env::remove_var("OPENROUTER_BASE_URL");
+        std::env::remove_var("OPENROUTER_API_KEY");
+    }
+}
+
+/// Regression: a prompt-caching turn must keep taking the RAW dispatch path
+/// — never the shared adapter — even with `TAGENT_INFERENCE_SHARED=1` set.
+///
+/// Why: `dispatch_turn`'s shared branch is reachable only when
+/// `!routing.needs_raw` (`llm/tool_loop/mod.rs`: `let needs_raw =
+/// caching_active || tool_choice.is_some() || route_native_anthropic ||
+/// is_ollama;`). That's a plain boolean OR with no test pinning any one of
+/// its terms — if a future refactor dropped or reordered `caching_active`,
+/// prompt-caching traffic would silently start flowing through the shared
+/// adapter with zero test failure and a real dollar cost (a dropped cache
+/// discount). This test drives EXACTLY that term: `enable_prompt_caching =
+/// true` on an Anthropic-family model with `use_anthropic_direct = false`
+/// (so `route_native_anthropic` is false and does NOT independently force
+/// `needs_raw` — only `caching_active` does here), which must resolve
+/// `caching_active = true` and therefore `needs_raw = true`, sending the
+/// turn down `send_raw_completion` instead of `dispatch_turn_shared`.
+///
+/// The observable wire signal is the ABSENCE of the OpenRouter-only
+/// `usage:{include:true}` directive — NOT `cache_control`'s presence.
+/// `dispatch_turn`'s raw branch only calls `adapter.inject_cache_control`
+/// when `routing.route_native_anthropic` is true (see the `if
+/// routing.route_native_anthropic { adapter.inject_cache_control(..) }` guard
+/// inside the `needs_raw` block in `turn.rs`) — and `route_native_anthropic`
+/// is deliberately false in this test so it isolates `caching_active` as the
+/// sole thing forcing `needs_raw`. That's a pre-existing trusty-agents
+/// behaviour (OpenRouter-routed, non-native-Anthropic caching has never
+/// injected `cache_control` — the comment at that call site says injecting it
+/// for OpenRouter breaks the OpenAI-format body OpenRouter expects) predating
+/// and unrelated to #2410; this test does not change or depend on fixing it.
+/// What `usage:{include:true}` DOES prove: only `inference_client`'s shared
+/// `OpenAiCompatAdapter` ever injects that directive (`prepare_body`, driven
+/// by the OpenRouter capability registry) — the raw path (`build_raw_request`)
+/// and the legacy typed path (`CreateChatCompletionRequestArgs`) never set a
+/// `usage` key at all. So `usage`'s absence is direct, wire-level proof this
+/// request did NOT go through `dispatch_turn_shared` — the property that
+/// would break with zero signal if `caching_active` fell out of the
+/// `needs_raw` OR.
+/// What: spawn a mock, point `OPENROUTER_BASE_URL` at it, enable the shared
+/// flag, drive `chat_with_tools_gated` with `enable_prompt_caching = true`
+/// and `use_anthropic_direct = false` on a `claude-*` model, then assert the
+/// captured wire request has NO `usage` key.
+/// Test: this test.
+#[tokio::test]
+#[serial]
+async fn caching_active_keeps_raw_path_even_with_flag_enabled() {
+    let server = MockInferenceServer::spawn(200, canned_response())
+        .await
+        .expect("spawn mock");
+
+    // SAFETY: guarded by `#[serial]` against the sibling test in this file;
+    // this is the only other test in this binary that touches these vars.
+    unsafe {
+        std::env::set_var("OPENROUTER_BASE_URL", server.url());
+        std::env::set_var("OPENROUTER_API_KEY", "sk-or-mock"); // pragma: allowlist secret
+        std::env::set_var(SHARED_INFERENCE_ENV, "1");
+    }
+
+    let messages: Vec<ChatCompletionRequestMessage> = vec![
+        ChatCompletionRequestSystemMessageArgs::default()
+            .content("You are a concise assistant.")
+            .build()
+            .unwrap()
+            .into(),
+        ChatCompletionRequestUserMessageArgs::default()
+            .content("Reply with exactly the word: pong")
+            .build()
+            .unwrap()
+            .into(),
+    ];
+
+    let legacy_client = Client::with_config(OpenAIConfig::new());
+    let model = "claude-sonnet-4-6"; // Anthropic-family -> caching_active eligible
+    let adapter = adapter_for_model(model);
+    let registry = Arc::new(ToolRegistry::new());
+
+    let (content, _usage) = chat_with_tools_gated(
+        &legacy_client,
+        model,
+        &*adapter,
+        messages,
+        registry,
+        None,  // allowed_tools
+        0.0,   // temperature
+        16,    // max_tokens
+        1,     // max_turns
+        true,  // enable_prompt_caching — the term under test
+        None,  // tool_choice
+        false, // use_finish_task
+        false, // use_anthropic_direct — keeps route_native_anthropic false
+        &[],   // stop_sequences
+    )
+    .await
+    .expect("chat_with_tools_gated via raw path");
+
+    assert_eq!(content, "pong-mock");
+
+    let captured = server.last_request().expect("one request captured");
+    assert_eq!(
+        captured.path, "/chat/completions",
+        "the raw path posts to the same OpenAI-compatible endpoint as the shared/legacy paths"
+    );
+    let body = captured.body.expect("json body");
+    assert!(
+        body.get("usage").is_none(),
+        "a caching-active turn must take the raw path, which never sets `usage` — \
+         its presence would mean the shared adapter (the only thing that injects \
+         `usage:{{include:true}}`) handled this call instead, i.e. `caching_active` \
+         stopped forcing `needs_raw`. Body: {body}"
     );
 
     unsafe {

--- a/crates/trusty-agents/tests/inference_shared_adapter_e2e.rs
+++ b/crates/trusty-agents/tests/inference_shared_adapter_e2e.rs
@@ -1,0 +1,157 @@
+//! Black-box e2e: prove trusty-agents' OpenRouter traffic flows through the
+//! shared `trusty_common::inference` adapter when `TAGENT_INFERENCE_SHARED=1`
+//! (#2410, epic #2400, Step 1+2).
+//!
+//! Why: #2410's core claim is that, behind a default-OFF flag, trusty-agents'
+//! plain OpenRouter dispatch path (`llm::tool_loop::turn::dispatch_turn`'s
+//! typed branch) can be routed through the shared adapter with byte-identical
+//! wire behaviour to the legacy `async-openai` client — including the
+//! `usage:{include:true}` detailed-usage directive OpenRouter only returns
+//! when asked, and the `qualify_openrouter_model` bare-`claude-*` → `anthropic/
+//! claude-*` normalisation. This drives the crate's REAL public entry point
+//! (`trusty_agents::llm::chat_with_tools_gated`, the same function every agent
+//! run calls) over a REAL loopback socket served by the shared
+//! `test_support::MockInferenceServer`, then asserts on the exact wire request
+//! the shared adapter emitted. That request shape is producible ONLY by the
+//! shared adapter having actually been invoked — so a green run is direct
+//! evidence Step 2's wiring works end-to-end, not just at the unit level.
+//!
+//! `OPENROUTER_BASE_URL` and `TAGENT_INFERENCE_SHARED` are process-global env
+//! vars this file mutates; this is the only test function in this binary
+//! (each file under `tests/` is its own process) so there is no cross-test
+//! race, and `InferenceClient`'s process-wide `shared_client()` `OnceLock` is
+//! guaranteed to see the override on its first (and only) initialisation.
+//!
+//! What: one test — routes a bare `claude-*` model through
+//! `chat_with_tools_gated` with the flag on, and asserts the parsed response
+//! AND the captured wire request (path, `Bearer` auth, qualified model id,
+//! detailed-usage directive).
+//! Test: this file (`cargo test -p trusty-agents --test inference_shared_adapter_e2e`).
+
+use std::sync::Arc;
+
+use async_openai::Client;
+use async_openai::config::OpenAIConfig;
+use async_openai::types::{
+    ChatCompletionRequestMessage, ChatCompletionRequestSystemMessageArgs,
+    ChatCompletionRequestUserMessageArgs,
+};
+use serde_json::json;
+
+use trusty_agents::llm::adapter::adapter_for_model;
+use trusty_agents::llm::chat_with_tools_gated;
+use trusty_agents::llm::inference_client::SHARED_INFERENCE_ENV;
+use trusty_agents::tools::ToolRegistry;
+use trusty_common::inference::test_support::MockInferenceServer;
+
+/// A canned OpenAI-compatible chat/completions response the mock serves.
+fn canned_response() -> serde_json::Value {
+    json!({
+        "id": "gen-mock",
+        "model": "anthropic/claude-sonnet-4-6",
+        "choices": [{
+            "message": {"role": "assistant", "content": "pong-mock", "tool_calls": []},
+            "finish_reason": "stop"
+        }],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 2, "total_tokens": 7}
+    })
+}
+
+/// A bare-`claude-*` model (unqualified) routed with `TAGENT_INFERENCE_SHARED=1`
+/// flows through the shared OpenRouter adapter: the qualifier prefixes the
+/// model, the shared adapter injects the detailed-usage directive, and the
+/// response comes back through the same `(content, tool_calls, usage)` shape
+/// the legacy path produces.
+///
+/// Why: proves Step 2's wiring end-to-end through the crate's real public
+/// entry point, not a synthetic call into `inference_client` directly.
+/// What: point `OPENROUTER_BASE_URL` at the mock, set the flag, drive
+/// `chat_with_tools_gated` for one turn (no tools, so the model's plain-text
+/// reply ends the loop immediately), then assert the parsed content AND the
+/// captured wire request.
+/// Test: this test.
+#[tokio::test]
+async fn bare_claude_model_routes_through_shared_adapter_when_flag_enabled() {
+    let server = MockInferenceServer::spawn(200, canned_response())
+        .await
+        .expect("spawn mock");
+
+    // SAFETY: this file is the only test in this binary (integration test
+    // files each get their own process), so there is no cross-test race on
+    // these process-global env vars.
+    unsafe {
+        std::env::set_var("OPENROUTER_BASE_URL", server.url());
+        std::env::set_var("OPENROUTER_API_KEY", "sk-or-mock"); // pragma: allowlist secret
+        std::env::set_var(SHARED_INFERENCE_ENV, "1");
+    }
+
+    let messages: Vec<ChatCompletionRequestMessage> = vec![
+        ChatCompletionRequestSystemMessageArgs::default()
+            .content("You are a concise assistant.")
+            .build()
+            .unwrap()
+            .into(),
+        ChatCompletionRequestUserMessageArgs::default()
+            .content("Reply with exactly the word: pong")
+            .build()
+            .unwrap()
+            .into(),
+    ];
+
+    // The legacy client is never touched on the shared path (see
+    // `dispatch_turn`'s flag gate), so an unconfigured placeholder is fine.
+    let legacy_client = Client::with_config(OpenAIConfig::new());
+    let model = "claude-sonnet-4-6"; // bare — must be qualified to anthropic/claude-sonnet-4-6
+    let adapter = adapter_for_model(model);
+    let registry = Arc::new(ToolRegistry::new());
+
+    let (content, _usage) = chat_with_tools_gated(
+        &legacy_client,
+        model,
+        &*adapter,
+        messages,
+        registry,
+        None,  // allowed_tools
+        0.0,   // temperature
+        16,    // max_tokens
+        1,     // max_turns
+        false, // enable_prompt_caching
+        None,  // tool_choice
+        false, // use_finish_task
+        false, // use_anthropic_direct
+        &[],   // stop_sequences
+    )
+    .await
+    .expect("chat_with_tools_gated via shared adapter");
+
+    assert_eq!(content, "pong-mock");
+
+    // The shared adapter's outbound wire request — this shape is producible
+    // ONLY by the shared adapter having actually handled the call.
+    let captured = server.last_request().expect("one request captured");
+    assert_eq!(captured.method, "POST");
+    assert_eq!(captured.path, "/chat/completions");
+    assert!(
+        captured
+            .header("authorization")
+            .is_some_and(|v| v.starts_with("Bearer ")),
+        "shared adapter must send a Bearer auth header"
+    );
+    let body = captured.body.expect("json body");
+    assert_eq!(
+        body["model"], "anthropic/claude-sonnet-4-6",
+        "qualify_openrouter_model must prefix the bare claude-* id"
+    );
+    assert_eq!(body["messages"][0]["role"], "system");
+    assert_eq!(
+        body["usage"],
+        json!({"include": true}),
+        "shared OpenRouter adapter must inject the detailed-usage directive"
+    );
+
+    unsafe {
+        std::env::remove_var(SHARED_INFERENCE_ENV);
+        std::env::remove_var("OPENROUTER_BASE_URL");
+        std::env::remove_var("OPENROUTER_API_KEY");
+    }
+}


### PR DESCRIPTION
## Summary

Step 1 + Step 2 of epic #2410 (structured inference layer for trusty-agents, per owner directive: route via OpenRouter/fireworks.ai etc., **not** the Claude Code CLI). Anthropic-direct, Bedrock, and Fireworks routing are explicitly out of scope for this PR — see SCOPE BOUNDARIES below.

- **Step 1 — `crates/trusty-agents/src/llm/inference_bridge/`**: pure, field-by-field conversion between `async_openai` wire types (`ChatCompletionRequestMessage`, `ChatCompletionTool`, `ChatCompletionMessageToolCall`) and `trusty_common::inference` (`ChatMessage`, `ToolDefinition`, `ChatResponse`), plus `agents::ToolChoice → tci::ToolChoice` (`Auto→Auto`, `Any→Required`, `None→None`). No wiring into dispatch.
- **Step 2 — `crates/trusty-agents/src/llm/inference_client/`**: `InferenceClient` wraps a `Configurator` (`register_default_factories`) + `KeyStore` + a `ProviderId`-keyed adapter cache (mirrors `trusty-code`'s `OpenAiCompatClient`). Wired into `tool_loop::turn::dispatch_turn`'s plain OpenRouter branch behind `TAGENT_INFERENCE_SHARED=1` (default OFF).

## Key design decision: fixed routing slug

`InferenceClient::adapter()` always resolves against the **fixed** slug `"openrouter/route"`, never the caller's real model. `register_default_factories` also registers the Anthropic-direct factory, and `provider_for("anthropic/…", store)` resolves to `ProviderId::Anthropic` whenever `ANTHROPIC_API_KEY` is configured — a very common local-dev setup per this crate's own `llm::credentials` priority order (`AnthropicDirect` is preferred over `OpenRouter`). Without the fixed slug, an anthropic-prefixed model would silently defect from OpenRouter onto the out-of-scope Anthropic-direct adapter. Regression test: `openrouter_route_never_resolves_to_anthropic_even_when_anthropic_key_present`.

## Two documented bridge compromises (read `inference_bridge/mod.rs`'s module doc)

1. **`cache_control` cannot flow through the request side of the bridge.** `async_openai::types::ChatCompletionRequestMessage`/`FunctionObject` carry no `cache_control` field at all (unlike `trusty-code`'s hand-rolled types). trusty-agents' prompt-cache mechanism (`http::build_raw_request` + `ModelAdapter::inject_cache_control`) mutates raw JSON *downstream* of this bridge. Safe for this PR because the flag only gates the plain typed branch (`needs_raw == false`), which never carries cache_control today either — the raw/native-Anthropic path is completely untouched by the flag. A future step routing cache-bearing traffic through the shared seam needs a different design.
2. **Multi-part message content (images/audio) collapses to text-only.** Verified trusty-agents never constructs multi-part content today (no `ImageUrl`/`InputAudio` call sites), so this is untriggered but real if a vision agent is added later.

Both are covered by dedicated tests and called out explicitly so Step 3 doesn't build on a false assumption.

## Byte-parity e2e proof

`crates/trusty-agents/tests/inference_shared_adapter_e2e.rs` drives the crate's real public entry point (`chat_with_tools_gated`) with `TAGENT_INFERENCE_SHARED=1` against a loopback `MockInferenceServer`, using a bare `claude-sonnet-4-6` model, and asserts the captured wire request: `POST /chat/completions`, `Bearer` auth, `qualify_openrouter_model` applied (`anthropic/claude-sonnet-4-6`), and the OpenRouter `usage:{include:true}` directive present.

## Gate evidence (raw)

```
$ cargo check -p trusty-agents
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.40s

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.75s

$ cargo fmt -p trusty-agents --check
(exit 0, no diff)

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ cargo test -p trusty-agents --lib -- --test-threads=4
test result: ok. 1954 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out; finished in 20.38s

$ cargo test -p trusty-agents --test '*'
tests/api_e2e.rs        ... ok. 4 passed; 0 failed; 3 ignored
tests/cli_project.rs    ... ok. 2 passed; 0 failed
tests/config_mount.rs   ... ok. 2 passed; 0 failed
tests/inference_shared_adapter_e2e.rs ... ok. 1 passed; 0 failed
```

**Known pre-existing flake (unrelated to this PR):** `workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts` intermittently fails ONLY under full default parallelism (`cargo test -p trusty-agents` with no `--test-threads` override), with a *different* assertion line failing each run — a parallel-execution race. It passes reliably in isolation and under `--test-threads=4`. This file (`workflow/engine/executor/tests/checkpoint_resume.rs`, from PR #3244) is untouched by this PR and imports nothing from `llm::`/`inference_bridge`/`inference_client`. Confirmed pre-existing on this branch before any consideration of these changes.

## Test plan

- [x] `cargo check -p trusty-agents`
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings`
- [x] `cargo test -p trusty-agents` (flag OFF by default — every pre-existing test still passes)
- [x] `cargo fmt -p trusty-agents --check`
- [x] `bash scripts/check_line_cap.sh`
- [x] New byte-parity e2e test (`inference_shared_adapter_e2e.rs`) — offline, deterministic, no live API key required
- [x] Unit tests for both documented compromises (cache_control seam readiness, multi-part content degradation)
- [x] Regression test proving the fixed routing slug can never resolve to the Anthropic-direct adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)