### PR TITLE
fix(trusty-agents): make plain-text retry opt-in for tool-mandatory agents

### DIFF
--- a/crates/trusty-agents/src/agents/in_process_runner.rs
+++ b/crates/trusty-agents/src/agents/in_process_runner.rs
@@ -396,6 +396,7 @@ impl InProcessAgentRunner {
             cfg.llm.enable_prompt_caching,
             tool_choice,
             cfg.llm.use_finish_task,
+            cfg.llm.strict_tool_discipline(),
             cfg.llm.use_anthropic_direct,
             &cfg.llm.stop_sequences,
         )

--- a/crates/trusty-agents/src/agents/params.rs
+++ b/crates/trusty-agents/src/agents/params.rs
@@ -358,6 +358,28 @@ pub struct LlmParams {
     pub thinking_enabled: Option<bool>,
 }
 
+impl LlmParams {
+    /// Whether this agent's `chat_with_tools_gated` calls should apply the
+    /// #33 plain-text tool-discipline retry (#3371).
+    ///
+    /// Why: The retry (see `should_retry_plain_text_turn`) is only correct
+    /// for agents that do their work entirely through tools and treat a
+    /// plain-text mid-task response as confusion — signaled by either
+    /// `use_finish_task = true` (the agent relies on an explicit terminal
+    /// tool call rather than "the model stopped calling tools") or
+    /// `tool_choice = "any"` (the agent forces a tool call every turn).
+    /// Conversational/orchestrator agents (`pm`, `assistant`, personas)
+    /// leave both at their defaults (`false` / `"auto"`) and a first-turn
+    /// plain-text answer is the CORRECT behavior for them, not confusion.
+    /// What: `use_finish_task || tool_choice == ToolChoice::Any`.
+    /// Test: `strict_tool_discipline_true_when_use_finish_task`,
+    /// `strict_tool_discipline_true_when_tool_choice_any`,
+    /// `strict_tool_discipline_false_by_default`.
+    pub fn strict_tool_discipline(&self) -> bool {
+        self.use_finish_task || self.tool_choice == ToolChoice::Any
+    }
+}
+
 /// How to drive the `tool_choice` API field.
 ///
 /// Why: Translates a user-friendly TOML keyword into the provider-agnostic

--- a/crates/trusty-agents/src/agents/tests/params.rs
+++ b/crates/trusty-agents/src/agents/tests/params.rs
@@ -214,6 +214,72 @@ content = "base"
     assert!(cfg.llm.use_finish_task);
 }
 
+// #3371: `strict_tool_discipline()` derives the #33 plain-text-retry opt-in
+// from the two signals that already distinguish tool-mandatory agents from
+// conversational/orchestrator ones.
+
+#[test]
+fn strict_tool_discipline_false_by_default() {
+    let toml_str = r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert!(!cfg.llm.strict_tool_discipline());
+}
+
+#[test]
+fn strict_tool_discipline_true_when_use_finish_task() {
+    let toml_str = r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+use_finish_task = true
+
+[system_prompt]
+content = "base"
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert!(cfg.llm.strict_tool_discipline());
+}
+
+#[test]
+fn strict_tool_discipline_true_when_tool_choice_any() {
+    let toml_str = r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+tool_choice = "any"
+
+[system_prompt]
+content = "base"
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert!(cfg.llm.strict_tool_discipline());
+}
+
 #[test]
 fn llm_params_use_anthropic_direct_defaults_false() {
     let toml_str = r#"

--- a/crates/trusty-agents/src/ctrl/ctrl_turn/dispatch.rs
+++ b/crates/trusty-agents/src/ctrl/ctrl_turn/dispatch.rs
@@ -198,6 +198,7 @@ pub(crate) async fn run_ctrl_turn_via_rest(
         false,
         None,
         false,
+        routed_cfg.llm.strict_tool_discipline(),
         effective_use_direct,
         &routed_cfg.llm.stop_sequences,
     )
@@ -226,6 +227,7 @@ pub(crate) async fn run_ctrl_turn_via_rest(
                 false,
                 None,
                 false,
+                routed_cfg.llm.strict_tool_discipline(),
                 routed_cfg.llm.use_anthropic_direct,
                 &routed_cfg.llm.stop_sequences,
             )

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -262,6 +262,7 @@ pub async fn run_pm_task_with_history(
             false,
             None,
             false,
+            pm_cfg.llm.strict_tool_discipline(),
             effective_use_direct,
             &pm_cfg.llm.stop_sequences,
         )
@@ -289,6 +290,7 @@ pub async fn run_pm_task_with_history(
                     false,
                     None,
                     false,
+                    pm_cfg.llm.strict_tool_discipline(),
                     pm_cfg.llm.use_anthropic_direct,
                     &pm_cfg.llm.stop_sequences,
                 )
@@ -385,6 +387,7 @@ pub async fn run_pm_task_with_history(
         false,
         None,
         false,
+        pm_cfg.llm.strict_tool_discipline(),
         pm_cfg.llm.use_anthropic_direct,
         &pm_cfg.llm.stop_sequences,
     )

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -368,6 +368,7 @@ pub async fn run_pm_task_with_persona(
         false,
         None,
         false,
+        persona_cfg.llm.strict_tool_discipline(),
         persona_cfg.llm.use_anthropic_direct,
         &persona_cfg.llm.stop_sequences,
     )

--- a/crates/trusty-agents/src/llm/helpers/mod.rs
+++ b/crates/trusty-agents/src/llm/helpers/mod.rs
@@ -250,7 +250,20 @@ pub(super) fn extract_finish_task_summary(
 /// Why: #33 — this logic lives inline in `chat_with_tools_gated` but is
 /// cleanly testable as a pure function: we want the first plain-text turn
 /// to trigger a retry and the second (or final-turn) plain-text to be
-/// accepted gracefully.
+/// accepted gracefully. #3371 — that behavior is correct ONLY for
+/// tool-mandatory agents (`use_finish_task = true` and/or
+/// `tool_choice = "any"`, e.g. `plan-agent`/`research-agent`). Conversational
+/// / orchestrator agents (`pm`, `assistant`, personas — default
+/// `tool_choice = "auto"`, `use_finish_task = false`) correctly return plain
+/// text on turn 1 (greeting, direct answer, post-delegation synthesis); the
+/// old unconditional heuristic retried on essentially every one of their
+/// turns, paying a real extra API round trip 16/16 times in production
+/// measurement. `strict_tool_discipline` opts a caller into the old
+/// behavior; it defaults to `false` everywhere else. Separately, #3371 Bug A:
+/// a caller that offered zero tools (`tools_offered = false`) can never
+/// satisfy the discipline the retry is enforcing — dispatching a retry in
+/// that case only guarantees a wasted round trip, so it's gated off
+/// regardless of `strict_tool_discipline`.
 /// What: Returns `true` if the caller should retry (inject error + continue),
 /// `false` if it should accept the plain-text content as the final answer.
 /// Test: See `tool_discipline_decision_*` tests below.
@@ -258,8 +271,13 @@ pub fn should_retry_plain_text_turn(
     consecutive_no_tool_turns: u32,
     turn: u32,
     max_turns: u32,
+    strict_tool_discipline: bool,
+    tools_offered: bool,
 ) -> bool {
-    consecutive_no_tool_turns == 0 && turn < max_turns.saturating_sub(1)
+    strict_tool_discipline
+        && tools_offered
+        && consecutive_no_tool_turns == 0
+        && turn < max_turns.saturating_sub(1)
 }
 
 /// Pull a `(system_prompt, first_user_message)` pair out of a typed

--- a/crates/trusty-agents/src/llm/helpers/tests.rs
+++ b/crates/trusty-agents/src/llm/helpers/tests.rs
@@ -129,27 +129,43 @@ fn empty_stop_sequences_leave_no_stop_key_in_raw_body() {
 
 #[test]
 fn tool_discipline_decision_first_plain_text_retries() {
-    // turn 0 of 12, 0 prior no-tool turns -> retry
-    assert!(should_retry_plain_text_turn(0, 0, 12));
+    // turn 0 of 12, 0 prior no-tool turns, strict + tools offered -> retry
+    assert!(should_retry_plain_text_turn(0, 0, 12, true, true));
 }
 
 #[test]
 fn tool_discipline_decision_second_plain_text_accepts() {
     // We've already retried once (counter == 1). Do NOT retry again.
-    assert!(!should_retry_plain_text_turn(1, 1, 12));
+    assert!(!should_retry_plain_text_turn(1, 1, 12, true, true));
 }
 
 #[test]
 fn tool_discipline_decision_final_turn_accepts_even_first_time() {
     // Don't inject a retry on the very last turn — the loop would break
     // anyway; just accept whatever the model produced.
-    assert!(!should_retry_plain_text_turn(0, 11, 12));
+    assert!(!should_retry_plain_text_turn(0, 11, 12, true, true));
 }
 
 #[test]
 fn tool_discipline_decision_saturates_on_zero_max_turns() {
     // Edge case: max_turns = 0 should never retry (underflow-safe).
-    assert!(!should_retry_plain_text_turn(0, 0, 0));
+    assert!(!should_retry_plain_text_turn(0, 0, 0, true, true));
+}
+
+// #3371: non-strict (conversational/orchestrator) agents never retry on a
+// plain-text turn, even on turn 0 with tools offered — this is the primary
+// regression fix (pm/assistant/personas were retrying on ~16/16 turns).
+#[test]
+fn tool_discipline_non_strict_never_retries() {
+    assert!(!should_retry_plain_text_turn(0, 0, 12, false, true));
+}
+
+// #3371 Bug A: even a strict-discipline caller must not retry when zero
+// tools were offered to the model — the retry demands a tool call that the
+// model can never satisfy, guaranteeing a wasted round trip.
+#[test]
+fn tool_discipline_strict_but_no_tools_offered_never_retries() {
+    assert!(!should_retry_plain_text_turn(0, 0, 12, true, false));
 }
 
 /// Pure-logic simulation of the tool-discipline state machine mimicking
@@ -167,7 +183,7 @@ fn simulate_turns(events: &[&str], max_turns: u32) -> (u32, u32, Option<String>)
         }
         match *ev {
             "text" => {
-                if should_retry_plain_text_turn(counter, turn, max_turns) {
+                if should_retry_plain_text_turn(counter, turn, max_turns, true, true) {
                     counter += 1;
                     retries += 1;
                     continue;

--- a/crates/trusty-agents/src/llm/tool_loop/mod.rs
+++ b/crates/trusty-agents/src/llm/tool_loop/mod.rs
@@ -82,6 +82,7 @@ pub async fn chat_with_tools(
         None,
         false,
         false,
+        false,
         &[],
     )
     .await
@@ -104,6 +105,13 @@ pub async fn chat_with_tools(
 /// `max_turns`.
 /// Test: See `tests::parallel_tool_dispatch_does_not_cancel_peers` (mocks two
 /// tools; asserts both ran and one erroring did not cancel the other).
+///
+/// `strict_tool_discipline` (#3371): gates the #33 plain-text retry (see
+/// `should_retry_plain_text_turn`). Callers for tool-mandatory agents
+/// (`use_finish_task = true` and/or `tool_choice = "any"`) should pass
+/// `true`; conversational/orchestrator callers (default `tool_choice =
+/// "auto"`, `use_finish_task = false`) should pass `false` so a correct
+/// first-turn plain-text answer isn't retried.
 //
 // Why (signature): This is the workhorse function-call loop and every
 // parameter is independently load-bearing (model routing, sampling, gating
@@ -123,6 +131,7 @@ pub async fn chat_with_tools_gated(
     enable_prompt_caching: bool,
     tool_choice: Option<serde_json::Value>,
     use_finish_task: bool,
+    strict_tool_discipline: bool,
     use_anthropic_direct: bool,
     stop_sequences: &[String],
 ) -> Result<(String, TokenUsage)> {
@@ -209,10 +218,14 @@ pub async fn chat_with_tools_gated(
         needs_raw,
         endpoint: &endpoint,
     };
-    // #33: Count consecutive turns in which the model returned plain text
-    // instead of a tool call. Reset to 0 whenever a tool call is emitted.
-    // We allow ONE plain-text-mid-task turn (injecting a reminder to use a
-    // tool), then accept the second plain-text response as the final answer.
+    // #33/#3371: Count consecutive turns in which the model returned plain
+    // text instead of a tool call. Reset to 0 whenever a tool call is
+    // emitted. When `strict_tool_discipline` is set (tool-mandatory agents
+    // only — see the doc comment above), we allow ONE plain-text-mid-task
+    // turn (injecting a reminder to use a tool), then accept the second
+    // plain-text response as the final answer. Non-strict callers accept the
+    // first plain-text turn immediately; the counter still tracks state for
+    // consistency but never gates a retry.
     let mut consecutive_no_tool_turns: u32 = 0;
 
     // #69: Apply a default 50% context-window budget trim before each turn.
@@ -319,7 +332,13 @@ pub async fn chat_with_tools_gated(
             // an error reminding the agent to use a tool and retry. On the
             // SECOND, give up and accept the text as the final answer so we
             // degrade gracefully rather than loop forever.
-            if should_retry_plain_text_turn(consecutive_no_tool_turns, turn, max_turns) {
+            if should_retry_plain_text_turn(
+                consecutive_no_tool_turns,
+                turn,
+                max_turns,
+                strict_tool_discipline,
+                !openai_tools.is_empty(),
+            ) {
                 consecutive_no_tool_turns += 1;
                 let reminder: ChatCompletionRequestMessage =
                     ChatCompletionRequestUserMessageArgs::default()

--- a/crates/trusty-agents/src/runtime/subagent_exec.rs
+++ b/crates/trusty-agents/src/runtime/subagent_exec.rs
@@ -127,6 +127,7 @@ pub(super) async fn run_subagent_single_shot(
             cfg.llm.enable_prompt_caching,
             resolve_tool_choice(cfg.llm.tool_choice, &*cfg.adapter),
             cfg.llm.use_finish_task,
+            cfg.llm.strict_tool_discipline(),
             cfg.llm.use_anthropic_direct,
             &cfg.llm.stop_sequences,
         )
@@ -220,6 +221,7 @@ pub(super) async fn run_subagent_with_tools(
         cfg.llm.enable_prompt_caching,
         resolve_tool_choice(cfg.llm.tool_choice, &*cfg.adapter),
         cfg.llm.use_finish_task,
+        cfg.llm.strict_tool_discipline(),
         cfg.llm.use_anthropic_direct,
         &cfg.llm.stop_sequences,
     )


### PR DESCRIPTION
## Summary

- `should_retry_plain_text_turn` (`crates/trusty-agents/src/llm/helpers/mod.rs`) fired the #33 tool-call-discipline retry on ANY plain-text turn. That's correct only for tool-mandatory agents (`use_finish_task = true` and/or `tool_choice = "any"` — e.g. `plan-agent`, `gpt5-codex-engineer`), but wrong for conversational/orchestrator agents (`pm`, `assistant`, personas), whose correct first-turn behavior IS plain text (greeting, direct answer, post-delegation synthesis). Measured **16/16 (100%)** of live `pm`/`assistant`/persona turns were spuriously retried, each paying a real extra API round trip.
- Added `strict_tool_discipline: bool` to `chat_with_tools_gated` and `should_retry_plain_text_turn`, derived by a new `LlmParams::strict_tool_discipline()` = `use_finish_task || tool_choice == ToolChoice::Any`. Threaded through all 9 call sites. Default is effectively `false` for `pm`/`assistant`/personas/`ctrl` (none of their TOMLs set either field); tool-mandatory agents that route through this loop (e.g. `gpt5-codex-engineer`, which has no `runner` override and no `use_finish_task=true`) keep today's behavior exactly.
- **Bug A fix**: the conversational fast path in `run_pm_task_with_history` (`ctrl/pm_task/dispatch/history.rs:252,279`) passes `Arc::new(ToolRegistry::new())` — zero tools — into `chat_with_tools_gated`. With no tools offered, `tool_calls` can never be non-empty, so the old code retried on literally every turn. Gated the retry on `!openai_tools.is_empty()` in `tool_loop/mod.rs`, in addition to `strict_tool_discipline`, so a caller offering zero tools can never trigger a doomed retry — defensive for this and any future zero-tool caller.
- Left Finding B (RBAC/`allowed_tools` filtering gap in `ToolRegistry::openai_tools()`) untouched — separate ticket per the diagnosis.

## Derivation signal

`LlmParams::strict_tool_discipline() = use_finish_task || tool_choice == ToolChoice::Any`. `use_finish_task` is the primary signal (the agent relies on an explicit terminal tool call rather than "stopped calling tools" as its completion signal); `tool_choice = "any"` is OR'd in as belt-and-braces for an agent that forces a tool call every turn without necessarily setting `use_finish_task`. Verified against every agent TOML in `.trusty-agents/agents/`: `plan-agent` (any+finish_task), `research-agent`/`ticketing-agent`/`docs-agent`/`local-ops-agent`/`gpt5-codex-engineer` (auto+finish_task) all resolve `true`; `pm`/`assistant`/`personal-assistant`/`izzie`/`cto-assistant`/`ctrl` (all unset → auto/false) resolve `false`. Note `code-agent`/`research-agent`/etc. mostly route via `runner = "claude-code"` (a separate CLI-subprocess path that never touches this loop); the loop-relevant tool-mandatory agent actually exercised live below is `gpt5-codex-engineer` (default `Subprocess` runner, `use_finish_task = true`).

## Tests

- `tool_discipline_non_strict_never_retries` — non-strict caller never retries, even turn 0 with tools offered (the primary regression fix).
- `tool_discipline_strict_but_no_tools_offered_never_retries` — Bug A: strict caller with zero tools offered never retries.
- `strict_tool_discipline_false_by_default`, `strict_tool_discipline_true_when_use_finish_task`, `strict_tool_discipline_true_when_tool_choice_any` — pin the derivation.
- Existing `tool_discipline_decision_*` / `tool_discipline_*` tests updated to pass `(strict=true, tools_offered=true)`, preserving the exact original #33 behavior for tool-mandatory agents (no regression).

## Gate (raw output)

```
$ cargo check -p trusty-agents
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 14s

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 55.73s
(zero warnings from this change; only pre-existing unrelated multi-bin-target warnings)

$ cargo test -p trusty-agents
test result: ok. 1941 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out
(one checkpoint test flaked once under full parallelism on an unrelated
workflow-engine checkpoint path, unrelated to this change; passed both in
isolation and on a clean full re-run)

$ cargo fmt -p trusty-agents --check
(clean, no output)

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.
```

## Live verification (before/after retry rate)

Rebuilt `tagent` and drove real turns against OpenRouter (`RUST_LOG`/`TAGENT_LOG=debug`), same shape as the original diagnosis:

- `ctrl` persona (local `ollama/qwen3:30b`, conversational): "Hi!" → 1 dispatch, no retry.
- `pm` persona (`claude-opus-4-6` via OpenRouter): "What's 2+2?", "list your skills", "search the codebase for the TokenUsage struct..." → 3/3 single dispatch, no retry (the last one actually triggered tool-shaped model output and still completed in one call).
- `personal-assistant`/Izzie (`claude-sonnet-4-6` via OpenRouter): conversational + tool-shaped turn → 2/2 single dispatch, no retry.
- **Result: 0/7 (0%) retries**, down from the diagnosed **16/16 (100%)**. `grep -c "injecting retry error" ~/.trusty-agents/logs/repl.log` = 0 across the whole session.
- Regression check — `gpt5-codex-engineer` (`use_finish_task=true`, tool-mandatory, default `Subprocess` runner) via `tagent --direct gpt5-codex-engineer --task "Just say hello, don't write any files or call any tools."`:
  ```
  DEBUG chat_with_tools: sending request turn=0 model="openai/gpt-5.1-codex"
   WARN agent produced plain-text mid-task; injecting retry error turn=0
  DEBUG chat_with_tools: sending request turn=1 model="openai/gpt-5.1-codex"
   INFO sub-agent complete agent=gpt5-codex-engineer
  ```
  Confirms the discipline retry still fires correctly for tool-mandatory agents — no regression to #33's intent.

## Test plan

- [x] `cargo check -p trusty-agents`
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings`
- [x] `cargo test -p trusty-agents`
- [x] `cargo fmt -p trusty-agents --check`
- [x] `bash scripts/check_line_cap.sh`
- [x] Live verification against real OpenRouter API calls (pm, personal-assistant, ctrl — 0/7 retries)
- [x] Live regression check on a tool-mandatory agent (gpt5-codex-engineer — retry still fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)