### PR TITLE
fix(trusty-agents): thread strict_tool_discipline into shared-inference e2e test (fix red main)

### DIFF
--- a/crates/trusty-agents/tests/inference_shared_adapter_e2e.rs
+++ b/crates/trusty-agents/tests/inference_shared_adapter_e2e.rs
@@ -131,6 +131,10 @@ async fn bare_claude_model_routes_through_shared_adapter_when_flag_enabled() {
         false, // enable_prompt_caching
         None,  // tool_choice
         false, // use_finish_task
+        false, // strict_tool_discipline (#3371): use_finish_task=false and
+        // tool_choice=None (Auto), so LlmParams::strict_tool_discipline()'s
+        // `use_finish_task || tool_choice == Any` is false — mirrors every
+        // production call site's derivation for this same param combo.
         false, // use_anthropic_direct
         &[],   // stop_sequences
     )
@@ -257,6 +261,10 @@ async fn caching_active_keeps_raw_path_even_with_flag_enabled() {
         true,  // enable_prompt_caching — the term under test
         None,  // tool_choice
         false, // use_finish_task
+        false, // strict_tool_discipline (#3371): use_finish_task=false and
+        // tool_choice=None (Auto), so LlmParams::strict_tool_discipline()'s
+        // `use_finish_task || tool_choice == Any` is false — mirrors every
+        // production call site's derivation for this same param combo.
         false, // use_anthropic_direct — keeps route_native_anthropic false
         &[],   // stop_sequences
     )


### PR DESCRIPTION
## Summary

`main` (HEAD `d818ec39`) is red: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo check --workspace --all-targets` fail with `E0061: this function takes 15 arguments but 14 arguments were supplied`.

**Root cause — merge collision between two PRs:**

- **#3383** (`47ab01d3`, inference seam) added `crates/trusty-agents/tests/inference_shared_adapter_e2e.rs`, a new e2e test file with two calls to the crate's public entry point `trusty_agents::llm::chat_with_tools_gated`, written against the then-current **14-arg** signature.
- **#3389** (`d818ec39`, retry-discipline fix) added a new 15th parameter, `strict_tool_discipline: bool`, to `chat_with_tools_gated` (`crates/trusty-agents/src/llm/tool_loop/mod.rs:121`), and updated every call site **it could see** — but #3389 merged while behind #3383, so its branch/CI never saw #3383's new test file. Each PR was green alone; the combination doesn't compile.

Note: `cargo check -p trusty-agents` (lib/bin only) is misleadingly green — the broken call sites are only reachable via `--all-targets` (a `tests/` integration file), which is what CI's clippy actually runs.

## Before / after

Both call sites in `crates/trusty-agents/tests/inference_shared_adapter_e2e.rs` (lines 121 and 247) were missing argument #14 (`strict_tool_discipline`). Fixed by inserting `false` immediately after `use_finish_task` at both sites:

```rust
        false, // enable_prompt_caching
        None,  // tool_choice
        false, // use_finish_task
        false, // strict_tool_discipline (#3371): use_finish_task=false and
        // tool_choice=None (Auto), so LlmParams::strict_tool_discipline()'s
        // `use_finish_task || tool_choice == Any` is false — mirrors every
        // production call site's derivation for this same param combo.
        false, // use_anthropic_direct
        &[],   // stop_sequences
```

## Why `false` is correct here (not just compile-satisfying)

`LlmParams::strict_tool_discipline()` (`crates/trusty-agents/src/agents/params.rs:378`) is the single source of truth every production call site uses to derive this value:

```rust
pub fn strict_tool_discipline(&self) -> bool {
    self.use_finish_task || self.tool_choice == ToolChoice::Any
}
```

Both e2e tests pass `use_finish_task = false` and `tool_choice = None` (i.e. `Auto`) into `chat_with_tools_gated`. Plugging those exact values into the production derivation formula gives `false || false = false` — the value every real caller with this identical param combination would compute. This is not a hardcoded "make it compile" value; it is the value the documented rule at `llm/tool_loop/mod.rs:109` prescribes for conversational/non-tool-mandatory callers, which is exactly what these tests simulate (they assert on the shared-inference wire request shape, not on tool-discipline retry behavior, so this term is inert for their actual assertions — but it is still semantically the correct value).

## Test plan

- [x] `cargo check -p trusty-agents` — clean
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean, zero warnings
- [x] `cargo build -p trusty-agents` — compiles
- [x] `cargo test -p trusty-agents -- --test-threads=4` — **1959 passed; 0 failed; 8 ignored** (unit) + all integration test files pass, including both fixed tests: `bare_claude_model_routes_through_shared_adapter_when_flag_enabled` and `caching_active_keeps_raw_path_even_with_flag_enabled`
- [x] `cargo check --workspace --all-targets` — no `E0061` anywhere in the workspace (remaining failures are pre-existing, unrelated Tauri `frontendDist` missing-build-artifact errors in `trusty-mpm-gui` / `trusty-code-gui`, not caused by this change — need `pnpm build` or `SKIP_UI_BUILD=1`)
- [x] `bash scripts/check_line_cap.sh` — `line-cap: 7 allowlisted, 0 violations — OK.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)