### PR TITLE
fix(trusty-mpm): make InstallPolicy real — honor Overwrite vs SeedOnce in install_to()

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **`InstallPolicy` was defined but never honored by the installer** ([#3381](https://github.com/bobmatnyc/trusty-tools/issues/3381)): `install_to()` applied the same "skip if present unless `--force`" rule to every bundled artifact regardless of its declared `InstallPolicy`, so upgrades silently skipped refreshing any framework-owned file a user had touched. The enum is restored to two variants — `Overwrite` (framework-owned; all ~178 current entries) always refreshes on `tm install`, no `--force` needed; `SeedOnce` (reserved for a genuinely user-owned artifact) writes once and is never clobbered by an upgrade. `--force` now means "reset a seed-once artifact back to the shipped default" rather than "overwrite anything that exists" — its CLI help text is updated accordingly. As a side effect, this also closes a related staleness hazard: on non-dev installs, `install_to()` populates the `~/.trusty-mpm/framework/skills` fallback that `check_skill_staleness` diffs against, so the old skip-on-upgrade behavior could leave that source stale and make the staleness check return a false `Ok`; `Overwrite` now keeps it current. (This change does **not** touch `tm doctor`'s `skill_staleness` check itself, which is unrelated — it diffs the skill source directory against the deploy-time manifest and never reads `bundle::ALL`.)
+
 ## [0.19.27] — 2026-07-19
 
 ### Fixed

--- a/crates/trusty-mpm/help.yaml
+++ b/crates/trusty-mpm/help.yaml
@@ -74,7 +74,7 @@ commands:
     description: Install the bundled framework artifacts to ~/.trusty-mpm/framework/
     flags:
       - name: force
-        description: Overwrite artifacts that already exist on disk
+        description: Reset user-owned (seed-once) artifacts back to the shipped default; framework-owned artifacts always refresh regardless
   hook:
     description: Handle a Claude Code lifecycle hook (PreToolUse/PostToolUse/Stop)
   daemon:

--- a/crates/trusty-mpm/src/assets/agents/mpm-agent-manager.md
+++ b/crates/trusty-mpm/src/assets/agents/mpm-agent-manager.md
@@ -37,12 +37,12 @@ cargo test -p trusty-mpm bundle -- --nocapture
 ```
 
 ### Deployment
-Agents deploy to `~/.trusty-mpm/framework/agents/` via `trusty-mpm install`. Each agent in `ALL` is written with `InstallPolicy::Overwrite` so framework upgrades replace prior versions.
+Agents deploy to `~/.trusty-mpm/framework/agents/` via `trusty-mpm install`. Each agent in `ALL` is written with `InstallPolicy::Overwrite` so framework upgrades replace prior versions. `InstallPolicy` is a real, honored choice, not boilerplate: `Overwrite` (every agent today) always refreshes on install; `SeedOnce` exists for a genuinely user-owned artifact and is written only once, never clobbered by an upgrade (`--force` resets it back to the shipped default).
 
 ### Adding a New Agent
 1. Create `crates/trusty-mpm/src/assets/agents/<name>.md` with 5-field frontmatter
 2. Add a `pub const` in `core/bundle.rs` with `include_str!`
-3. Add a `BundledArtifact` entry to `ALL` with `InstallPolicy::Overwrite`
+3. Add a `BundledArtifact` entry to `ALL` with `InstallPolicy::Overwrite` (agents are framework-owned, not user-editable)
 4. Update the count assertion in `bundle_tests.rs`
 5. Run `cargo test -p trusty-mpm bundle` — all tests must pass
 

--- a/crates/trusty-mpm/src/assets/agents/mpm-skills-manager.md
+++ b/crates/trusty-mpm/src/assets/agents/mpm-skills-manager.md
@@ -141,7 +141,7 @@ baseline new names should follow.
 
 1. Create `crates/trusty-mpm/src/assets/skills/<name>.md`
 2. Add a `pub const` in `core/bundle.rs` with `include_str!`
-3. Add a `BundledArtifact` entry to `ALL` with `InstallPolicy::Overwrite`
+3. Add a `BundledArtifact` entry to `ALL` with `InstallPolicy::Overwrite` — skills are framework-owned, so they must track upgrades; `InstallPolicy::SeedOnce` is reserved for a genuinely user-owned artifact that should be written once and never clobbered (`--force` resets it back to the shipped default)
 4. Update the count assertion in `bundle_tests.rs`
 5. Run `cargo test -p trusty-mpm bundle` — all tests must pass
 6. Commit with `feat(trusty-mpm): add <skill-name> skill — <reason>`

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -406,7 +406,10 @@ pub(crate) enum Command {
     /// filter). Requires `--reset-agents` (there is nothing "workspace" to
     /// reset without it).
     Install {
-        /// Overwrite artifacts that already exist on disk.
+        /// Reset user-owned (seed-once) artifacts back to the shipped
+        /// default. Framework-owned artifacts always refresh on install
+        /// regardless of this flag — `--force` only changes the outcome for
+        /// artifacts a user may have edited (issue #3381).
         #[arg(long)]
         force: bool,
         /// Force-recompose agent files from the current bundle (issue #2504).

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -4,10 +4,13 @@
 //! assembles the PM prompt, deploys agents and skills, and wires Claude Code
 //! hooks — and benefits from its own file so it stays reviewable.
 //! What: `install`, `install_claude_hooks` / `install_claude_hooks_at`,
-//! `mpm_hook_additions`, `install_to`, `deploy_report_lines`,
+//! `mpm_hook_additions`, `install_to`, `install_one`, `deploy_report_lines`,
 //! `reset_report_lines`, `skill_report_lines`, `remove_global_trusty_mpm_hooks`,
 //! `write_project_hooks_for_dir`.
-//! Test: `install_writes_all_artifacts`, `install_skips_existing_without_force`,
+//! Test: `install_writes_all_artifacts`,
+//! `overwrite_artifact_refreshes_modified_file_without_force`,
+//! `seed_once_artifact_is_not_clobbered_without_force`,
+//! `seed_once_artifact_force_resets_to_shipped_default`,
 //! `install_claude_hooks_at_writes_only_the_managed_config_dir`,
 //! `install_claude_hooks_at_is_idempotent`,
 //! `install_claude_hooks_at_never_touches_a_sibling_project_dir`,
@@ -472,14 +475,74 @@ pub(crate) fn skill_report_lines(
     lines
 }
 
+/// Write one bundled artifact to `dest` according to its declared
+/// [`InstallPolicy`](trusty_mpm::core::bundle::InstallPolicy), returning its
+/// report line.
+///
+/// Why: split out of [`install_to`] so the two policy branches are testable
+/// against a synthetic [`BundledArtifact`](trusty_mpm::core::bundle::BundledArtifact)
+/// fixture without adding a fake entry to the real
+/// [`ALL`](trusty_mpm::core::bundle::ALL) table (issue #3381 — no shipped
+/// artifact currently uses `SeedOnce`).
+/// What: [`Overwrite`](trusty_mpm::core::bundle::InstallPolicy::Overwrite)
+/// always writes the embedded contents, replacing any existing file — this is
+/// what makes `tm install` actually deliver refreshed framework assets on
+/// upgrade; `force` has no additional effect. `SeedOnce` writes only if
+/// `dest` is absent, preserving a user edit across upgrades; `force` is the
+/// escape hatch that resets it back to the shipped default. The report line
+/// distinguishes written / refreshed / preserved-user-file outcomes so
+/// `tm install` output stays honest about what it did and did not touch.
+/// Test: `overwrite_artifact_refreshes_modified_file_without_force`,
+/// `seed_once_artifact_is_not_clobbered_without_force`,
+/// `seed_once_artifact_force_resets_to_shipped_default`.
+pub(crate) fn install_one(
+    dest: &std::path::Path,
+    artifact: &trusty_mpm::core::bundle::BundledArtifact,
+    force: bool,
+) -> anyhow::Result<String> {
+    use trusty_mpm::core::bundle::InstallPolicy;
+
+    let exists = dest.exists();
+    match artifact.install {
+        InstallPolicy::Overwrite => {
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(dest, artifact.contents)?;
+            Ok(if exists {
+                format!("\u{2713} {} (refreshed)", artifact.rel_path)
+            } else {
+                format!("\u{2713} {}", artifact.rel_path)
+            })
+        }
+        InstallPolicy::SeedOnce => {
+            if exists && !force {
+                return Ok(format!(
+                    "- {} (exists, preserved \u{2014} user-owned)",
+                    artifact.rel_path
+                ));
+            }
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(dest, artifact.contents)?;
+            Ok(if exists {
+                format!("\u{2713} {} (reset to shipped default)", artifact.rel_path)
+            } else {
+                format!("\u{2713} {}", artifact.rel_path)
+            })
+        }
+    }
+}
+
 /// Write every bundled artifact under `paths`, returning a per-file report.
 ///
 /// Why: separating the filesystem work from argument parsing and stdout makes
 /// the installer unit-testable against a `tempfile::TempDir`.
-/// What: for each [`trusty_mpm::core::bundle::ALL`] artifact, creates parent
-/// directories and writes the file; an existing file is skipped unless `force`.
-/// Returns one human-readable status line per artifact.
-/// Test: `install_writes_all_artifacts`, `install_skips_existing_without_force`.
+/// What: for each [`trusty_mpm::core::bundle::ALL`] artifact, resolves its
+/// destination under `paths.framework` and delegates the policy-driven write
+/// to [`install_one`].
+/// Test: `install_writes_all_artifacts`.
 pub(crate) fn install_to(
     paths: &trusty_mpm::core::paths::FrameworkPaths,
     force: bool,
@@ -487,15 +550,7 @@ pub(crate) fn install_to(
     let mut report = Vec::new();
     for artifact in trusty_mpm::core::bundle::ALL {
         let dest = paths.framework.join(artifact.rel_path);
-        if dest.exists() && !force {
-            report.push(format!("- {} (exists, skipped)", artifact.rel_path));
-            continue;
-        }
-        if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(&dest, artifact.contents)?;
-        report.push(format!("\u{2713} {}", artifact.rel_path));
+        report.push(install_one(&dest, artifact, force)?);
     }
     Ok(report)
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -45,7 +45,10 @@
 /// deploys agents and skills, optionally resets the requested agent scope
 /// (user-level, then every intact session workspace when requested), then
 /// calls [`install_claude_hooks`].
-/// Test: `install_writes_all_artifacts`, `install_skips_existing_without_force`,
+/// Test: `install_writes_all_artifacts`,
+/// `overwrite_artifact_refreshes_modified_file_without_force`,
+/// `seed_once_artifact_is_not_clobbered_without_force`,
+/// `seed_once_artifact_force_resets_to_shipped_default`,
 /// `install_claude_hooks_is_idempotent`,
 /// `instruction_pipeline::install_system_prompt_to_writes_assembled`.
 pub(crate) async fn install(

--- a/crates/trusty-mpm/src/bin/tm/commands/install_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install_tests.rs
@@ -11,8 +11,11 @@
 //! sibling "project" directory that must never be touched.
 //! Test: this module IS the test suite for the hook-installation half of
 //! `commands::install`. The artifact-deploy half (`install_to`) is covered by
-//! `install_writes_all_artifacts` / `install_skips_existing_without_force` in
-//! `tests_behavior_a.rs`, unchanged by this issue.
+//! `install_writes_all_artifacts` in `tests_behavior_a.rs` and by
+//! `overwrite_artifact_refreshes_modified_file_without_force` /
+//! `seed_once_artifact_is_not_clobbered_without_force` /
+//! `seed_once_artifact_force_resets_to_shipped_default` in
+//! `install_policy_tests.rs`, unchanged by this issue.
 
 use super::*;
 

--- a/crates/trusty-mpm/src/bin/tm/install_policy_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/install_policy_tests.rs
@@ -1,0 +1,87 @@
+//! `InstallPolicy` behavior tests (issue #3381).
+//!
+//! Why: split out of `tests_behavior_a.rs` to stay under the 500-SLOC
+//! production-file cap — this basename ends in `_tests.rs` so it gets the
+//! 1500-SLOC test-file cap instead.
+//! What: pins the real two-way contract `install_to()`/`install_one()` now
+//! honor: `InstallPolicy::Overwrite` (framework-owned) always refreshes;
+//! `InstallPolicy::SeedOnce` (user-owned) writes once and is never clobbered
+//! without `--force`.
+//! Test: this file.
+
+use crate::commands::install::{install_one, install_to};
+
+#[test]
+fn overwrite_artifact_refreshes_modified_file_without_force() {
+    // A framework-owned (`InstallPolicy::Overwrite`) artifact must be
+    // refreshed on a PLAIN `tm install` — no `--force` needed — since that is
+    // what lets an upgrade actually deliver new framework assets.
+    // `optimizer.toml` is a real `ALL` entry and is `Overwrite`.
+    let dir = tempfile::tempdir().unwrap();
+    let paths = trusty_mpm::core::paths::FrameworkPaths::under(dir.path());
+    let optimizer = paths.optimizer_config();
+    std::fs::create_dir_all(&paths.hooks).unwrap();
+    std::fs::write(&optimizer, "custom").unwrap();
+
+    let report = install_to(&paths, false).unwrap();
+    assert!(
+        report
+            .iter()
+            .any(|l| l.contains("optimizer.toml") && l.contains("refreshed")),
+        "expected a refreshed line for optimizer.toml, got: {report:?}"
+    );
+    assert_ne!(
+        std::fs::read_to_string(&optimizer).unwrap(),
+        "custom",
+        "Overwrite artifact must replace a modified file even without --force"
+    );
+}
+
+#[test]
+fn seed_once_artifact_is_not_clobbered_without_force() {
+    // A user-owned (`InstallPolicy::SeedOnce`) artifact must NOT be touched
+    // by a plain `tm install` once it exists on disk. No shipped artifact
+    // currently uses `SeedOnce`, so this exercises the policy via a
+    // directly-constructed fixture rather than a fake bundled entry.
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("user-owned.md");
+    std::fs::write(&dest, "the user's own edits").unwrap();
+
+    let artifact = trusty_mpm::core::bundle::BundledArtifact {
+        rel_path: "user-owned.md",
+        contents: "shipped default content",
+        install: trusty_mpm::core::bundle::InstallPolicy::SeedOnce,
+    };
+
+    let line = install_one(&dest, &artifact, false).unwrap();
+    assert!(line.contains("preserved"), "unexpected report line: {line}");
+    assert_eq!(
+        std::fs::read_to_string(&dest).unwrap(),
+        "the user's own edits"
+    );
+}
+
+#[test]
+fn seed_once_artifact_force_resets_to_shipped_default() {
+    // `--force` is the escape hatch that lets a user reset a seed-once
+    // artifact back to the shipped default.
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("user-owned.md");
+    std::fs::write(&dest, "the user's own edits").unwrap();
+
+    let artifact = trusty_mpm::core::bundle::BundledArtifact {
+        rel_path: "user-owned.md",
+        contents: "shipped default content",
+        install: trusty_mpm::core::bundle::InstallPolicy::SeedOnce,
+    };
+
+    let line = install_one(&dest, &artifact, true).unwrap();
+    assert!(
+        line.contains("reset to shipped default"),
+        "unexpected report line: {line}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&dest).unwrap(),
+        "shipped default content"
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -47,6 +47,10 @@ mod tests;
 mod tests_behavior_a;
 
 #[cfg(test)]
+#[path = "install_policy_tests.rs"]
+mod install_policy_tests;
+
+#[cfg(test)]
 #[path = "tests_behavior_b_tests.rs"]
 mod tests_behavior_b;
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_a.rs
@@ -240,24 +240,10 @@ fn install_writes_all_artifacts() {
     }
 }
 
-#[test]
-fn install_skips_existing_without_force() {
-    // An existing artifact is left untouched without `--force` and the
-    // report says so; `--force` overwrites it.
-    let dir = tempfile::tempdir().unwrap();
-    let paths = trusty_mpm::core::paths::FrameworkPaths::under(dir.path());
-    let optimizer = paths.optimizer_config();
-    std::fs::create_dir_all(&paths.hooks).unwrap();
-    std::fs::write(&optimizer, "custom").unwrap();
-
-    let report = install_to(&paths, false).unwrap();
-    assert!(report.iter().any(|l| l.contains("skipped")));
-    assert_eq!(std::fs::read_to_string(&optimizer).unwrap(), "custom");
-
-    let forced = install_to(&paths, true).unwrap();
-    assert!(forced.iter().all(|l| !l.contains("skipped")));
-    assert_ne!(std::fs::read_to_string(&optimizer).unwrap(), "custom");
-}
+// `InstallPolicy::Overwrite`-vs-`SeedOnce` behavior tests (issue #3381) live in
+// `install_policy_tests.rs` — kept out of this file to stay under the 500-SLOC
+// production-file cap (this file's basename doesn't match the `_tests.rs`
+// test-cap pattern).
 
 #[test]
 #[ignore = "requires bundled framework artifacts (base-agent) — run locally after tm install"]

--- a/crates/trusty-mpm/src/core/bundle_all.rs
+++ b/crates/trusty-mpm/src/core/bundle_all.rs
@@ -37,8 +37,9 @@ pub struct BundledArtifact {
 /// again the moment any bundled artifact is meant to be user-owned.
 /// What: [`Overwrite`](InstallPolicy::Overwrite) always writes the embedded
 /// contents; [`SeedOnce`](InstallPolicy::SeedOnce) writes only when absent.
-/// Test: `framework_instructions_overwrites`, `seed_once_does_not_clobber`,
-/// `seed_once_force_resets_to_shipped_default`.
+/// Test: `framework_instructions_overwrites`,
+/// `seed_once_artifact_is_not_clobbered_without_force`,
+/// `seed_once_artifact_force_resets_to_shipped_default`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallPolicy {
     /// Always write the embedded contents, replacing any existing file.
@@ -79,7 +80,9 @@ const fn overwrite(rel_path: &'static str, contents: &'static str) -> BundledArt
 /// to exercise it) — `pub(super)` so `bundle_tests.rs` can build a fixture
 /// artifact with it instead.
 /// What: returns a [`BundledArtifact`] with `install: InstallPolicy::SeedOnce`.
-/// Test: `seed_once_does_not_clobber`, `seed_once_force_resets_to_shipped_default`.
+/// Test: `seed_once_constructor_builds_the_expected_artifact`,
+/// `seed_once_artifact_is_not_clobbered_without_force`,
+/// `seed_once_artifact_force_resets_to_shipped_default`.
 #[cfg_attr(not(test), allow(dead_code))]
 pub(super) const fn seed_once(rel_path: &'static str, contents: &'static str) -> BundledArtifact {
     BundledArtifact {

--- a/crates/trusty-mpm/src/core/bundle_all.rs
+++ b/crates/trusty-mpm/src/core/bundle_all.rs
@@ -27,30 +27,38 @@ pub struct BundledArtifact {
 
 /// How the installer writes a [`BundledArtifact`] when the target already exists.
 ///
-/// Why: every bundled artifact is currently framework-owned and must track
-/// upgrades. The former `SeedOnce` variant (used only by the now-removed
-/// `CLAUDE.md` stub artifact — issue #3374: that stub was never read back by
-/// any consumer) is gone; the enum is kept single-variant rather than
-/// collapsed so a future genuinely user-editable bundled artifact has a place
-/// to opt out of overwrite without redesigning the table.
+/// Why: framework-owned files (instructions, policy) must track upgrades, but
+/// user-editable stubs must not be clobbered — one enum makes the distinction
+/// explicit and data-driven. Issue #3374 removed the last user-owned artifact
+/// (the `CLAUDE.md` stub) and, with it, the `SeedOnce` variant; issue #3381
+/// restores it because `install_to()` had never actually branched on the
+/// enum at all — every entry used `Overwrite` so the single-variant enum was
+/// silently equivalent to no policy. The two-way distinction is required
+/// again the moment any bundled artifact is meant to be user-owned.
 /// What: [`Overwrite`](InstallPolicy::Overwrite) always writes the embedded
-/// contents.
-/// Test: `framework_instructions_overwrites`.
+/// contents; [`SeedOnce`](InstallPolicy::SeedOnce) writes only when absent.
+/// Test: `framework_instructions_overwrites`, `seed_once_does_not_clobber`,
+/// `seed_once_force_resets_to_shipped_default`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallPolicy {
     /// Always write the embedded contents, replacing any existing file.
     Overwrite,
+    /// Write the embedded contents only if the target file does not exist.
+    /// `tm install --force` is the escape hatch: it resets a user-owned file
+    /// back to the shipped default.
+    SeedOnce,
 }
 
 /// Build an [`InstallPolicy::Overwrite`] artifact entry.
 ///
-/// Why: every bundled artifact is framework-owned and must track upgrades.
-/// Spelling out the 5-line [`BundledArtifact`] struct literal for all ~164
-/// entries would blow the 500-SLOC production cap (issue #2903 alone adds 93
-/// skill-port entries); this shorthand collapses the common case to one line
-/// per entry so [`ALL`] stays a single, cap-compliant table instead of being
-/// split across files (which Rust cannot do for one array literal without
-/// unsafe const-array concatenation or forbidden global/lazy state).
+/// Why: nearly every bundled artifact is framework-owned and must track
+/// upgrades. Spelling out the 5-line [`BundledArtifact`] struct literal for
+/// all ~164 entries would blow the 500-SLOC production cap (issue #2903
+/// alone adds 93 skill-port entries); this shorthand collapses the common
+/// case to one line per entry so [`ALL`] stays a single, cap-compliant table
+/// instead of being split across files (which Rust cannot do for one array
+/// literal without unsafe const-array concatenation or forbidden
+/// global/lazy state).
 /// What: returns a [`BundledArtifact`] with `install: InstallPolicy::Overwrite`.
 /// Test: `bundle_table_is_complete` (exercises every entry `ALL` produces,
 /// including those built by this helper).
@@ -59,6 +67,25 @@ const fn overwrite(rel_path: &'static str, contents: &'static str) -> BundledArt
         rel_path,
         contents,
         install: InstallPolicy::Overwrite,
+    }
+}
+
+/// Build an [`InstallPolicy::SeedOnce`] artifact entry.
+///
+/// Why: mirrors [`overwrite`] for the user-owned case, so a genuinely
+/// user-editable bundled artifact reads as a one-line table entry rather than
+/// a hand-rolled struct literal. No entry in [`ALL`] currently uses it (issue
+/// #3381 restores the enum shape without shipping a fake bundled entry just
+/// to exercise it) — `pub(super)` so `bundle_tests.rs` can build a fixture
+/// artifact with it instead.
+/// What: returns a [`BundledArtifact`] with `install: InstallPolicy::SeedOnce`.
+/// Test: `seed_once_does_not_clobber`, `seed_once_force_resets_to_shipped_default`.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) const fn seed_once(rel_path: &'static str, contents: &'static str) -> BundledArtifact {
+    BundledArtifact {
+        rel_path,
+        contents,
+        install: InstallPolicy::SeedOnce,
     }
 }
 

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -322,6 +322,18 @@ fn framework_instructions_overwrites() {
 }
 
 #[test]
+fn seed_once_constructor_builds_the_expected_artifact() {
+    // Issue #3381: no shipped artifact currently uses `SeedOnce`, so the
+    // `seed_once()` constructor (the counterpart to `overwrite()`) is only
+    // exercised here rather than via a real `ALL` entry. Pins its shape so
+    // a future user-owned artifact can rely on it.
+    let artifact = all_inner::seed_once("instructions/CLAUDE.md", "stub contents");
+    assert_eq!(artifact.rel_path, "instructions/CLAUDE.md");
+    assert_eq!(artifact.contents, "stub contents");
+    assert_eq!(artifact.install, InstallPolicy::SeedOnce);
+}
+
+#[test]
 fn optimizer_toml_is_parseable() {
     // The shipped policy must be valid TOML or the installer would deploy
     // a file the daemon then fails to load.

--- a/docs/specs/trusty-mpm-self-awareness.md
+++ b/docs/specs/trusty-mpm-self-awareness.md
@@ -111,7 +111,9 @@ This spec defines four requirements (R1–R4) that close these four gaps.
   `crates/trusty-mpm/src/core/bundle_all.rs`'s `ALL` table with
   `rel_path: "docs/WHAT-IS-TRUSTY-MPM.md"` and `install: InstallPolicy::Overwrite` (the doc is
   framework-owned and must track upgrades, matching the policy already used for
-  `instructions/INSTRUCTIONS.md`).
+  `instructions/INSTRUCTIONS.md`). `InstallPolicy` also has a `SeedOnce` variant for
+  artifacts a user is meant to own and edit; it is not the right choice here since
+  this doc is not user-editable.
 - **Preconditions:** none — the doc has no dependency on project state.
 - **Postconditions:**
   - The file exists in the source tree at `crates/trusty-mpm/docs/WHAT-IS-TRUSTY-MPM.md` and is


### PR DESCRIPTION
## Summary

`InstallPolicy` was defined (in `crates/trusty-mpm/src/core/bundle_all.rs`) but
never read by `install_to()` (`crates/trusty-mpm/src/bin/tm/commands/install.rs`),
which applied a single uniform "skip if the destination exists unless `--force`"
rule to every bundled artifact regardless of its declared policy. Every one of
the ~178 current `ALL` entries is framework-owned, so this was silently
equivalent to no policy at all — an upgrade would skip refreshing a framework
file the moment a user had touched it.

Per the owner's decision on #3381: framework-owned bundled artifacts must
always refresh on upgrade, AND the system must keep supporting user-owned
artifacts seeded once and never clobbered. Both halves are required, so the
fix restores the two-variant enum (`Overwrite` / `SeedOnce`) that PR #3377
collapsed to one variant when it removed the last user-owned artifact (the
`CLAUDE.md` stub, issue #3374) — and, unlike before, actually wires
`install_to()` to branch on it.

## What changed

- **`InstallPolicy`** (`core/bundle_all.rs`): restored to two variants —
  - `Overwrite` — always writes the embedded contents, replacing any existing
    file. All ~178 current `ALL` entries keep this (they're all framework-owned).
  - `SeedOnce` — writes only if the destination does not exist; never
    clobbered by a plain upgrade.
  - Added a `seed_once()` `const fn` constructor mirroring the existing
    `overwrite()` helper. No shipped artifact uses it yet — added so a future
    genuinely user-owned artifact has somewhere to opt out of overwrite
    without redesigning the table.
- **`install_to()` / new `install_one()`** (`commands/install.rs`): the
  per-artifact write logic is now policy-driven:
  - `Overwrite` → always writes, report line says `(refreshed)` when it
    replaced an existing file.
  - `SeedOnce` → skipped (report line: `preserved — user-owned`) unless
    absent or `--force`; when forced over an existing file, the report line
    says `(reset to shipped default)`.
- **`--force` semantics changed**: it no longer means "overwrite anything
  that already exists" (that's now unconditional for `Overwrite` artifacts).
  It means "reset a `SeedOnce` (user-owned) artifact back to the shipped
  default." Updated the flag's help text in `cli/mod.rs` and the mirrored
  description in `help.yaml`.
- **Tests**: replaced `install_skips_existing_without_force` (which pinned the
  old, now-wrong, uniform-skip contract using the real `Overwrite` artifact
  `optimizer.toml`) with three behavior tests in a new
  `crates/trusty-mpm/src/bin/tm/install_policy_tests.rs`:
  - `overwrite_artifact_refreshes_modified_file_without_force` — a real
    `Overwrite` artifact (`optimizer.toml`) is refreshed over a
    user-modified file on a plain `tm install`.
  - `seed_once_artifact_is_not_clobbered_without_force` / 
    `seed_once_artifact_force_resets_to_shipped_default` — since no shipped
    artifact currently uses `SeedOnce`, these exercise the policy via a
    directly-constructed `BundledArtifact` fixture (not a fake `ALL` entry).
  - Also added `seed_once_constructor_builds_the_expected_artifact` in
    `bundle_tests.rs` to pin the new `seed_once()` helper's shape.
  - The new tests live in their own file (rather than growing
    `tests_behavior_a.rs`) so it stays under the repo's 500-SLOC
    production-file cap (`scripts/check_line_cap.sh`) — `tests_behavior_a.rs`
    doesn't match the `_tests.rs` naming pattern that earns the 1500-SLOC
    test-file cap.
- **Docs**: updated the three contributor-doc references that described
  `InstallPolicy::Overwrite` as boilerplate
  (`assets/agents/mpm-agent-manager.md`, `assets/agents/mpm-skills-manager.md`,
  `docs/specs/trusty-mpm-self-awareness.md`) to note the real two-way choice
  and when `SeedOnce` applies instead.
- **CHANGELOG.md**: added an `[Unreleased]` → `Fixed` bullet (no version
  headings touched).

## A note on `skill_staleness`

Issue #3381 speculated that this inertness causes `tm doctor`'s
`skill_staleness` finding. That's **not** the case — `check_skill_staleness`
(`core/skill_staleness.rs`) is an independent checksum diff between the skill
source directory and the deploy-time `SkillManifest`, and never touches
`bundle::ALL`. This PR does **not** fix `skill_staleness`.

There is a related, real hazard worth noting: on non-dev installs,
`skill_source_dir()` falls back to `~/.trusty-mpm/framework/skills`, which
`install_to()` populates. Under the old skip-on-upgrade behavior, that
fallback source could go stale on upgrade, which would make the staleness
check return a false `Ok` (comparing manifest checksums against an
already-stale source). Making `Overwrite` handling real closes that specific
side-effect — but this PR is not a fix for `skill_staleness` itself.

## Gate (raw output)

`cargo check -p trusty-mpm` — clean.

`cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean (exit 0;
only pre-existing, unrelated workspace warnings about MSRV/duplicate binary
targets/`tga` future-incompat, none introduced by this change).

`cargo fmt --all --check` — clean (exit 0).

`bash scripts/check_line_cap.sh` — `line-cap: 7 allowlisted, 0 violations — OK.`

`cargo test -p trusty-mpm` (full surface, no `--lib`) — clean, 0 failures
across every test binary, including:
```
test core::bundle::tests::framework_instructions_overwrites ... ok
test core::bundle::tests::seed_once_constructor_builds_the_expected_artifact ... ok
test result: ok. 3374 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 10.05s

test install_policy_tests::overwrite_artifact_refreshes_modified_file_without_force ... ok
test install_policy_tests::seed_once_artifact_is_not_clobbered_without_force ... ok
test install_policy_tests::seed_once_artifact_force_resets_to_shipped_default ... ok
test tests_behavior_a::install_writes_all_artifacts ... ok
test result: ok. 1106 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.44s
```
Every remaining integration-test binary in the crate also finished
`test result: ok. ... 0 failed`.

Closes #3381

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools