### PR TITLE
chore(release): trusty-mpm 0.19.27 + trusty-search 0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11207,7 +11207,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.19.26"
+version = "0.19.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11327,7 +11327,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -61,7 +61,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.19.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.34.0" }
+trusty-search = { path = "../trusty-search", version = "0.35.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,28 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.19.27] — 2026-07-19
+
 ### Fixed
 
-- **Framework-guaranteed conventions delivered only via user-editable channels** ([#3374](https://github.com/bobmatnyc/trusty-tools/issues/3374)): the commit/PR attribution footer, the proportional-documentation policy, and the ticket-attribution-at-change-site convention are now stated in the non-overridable `BASE_PM.md` floor — the one channel `resolve_pm_prompt` appends unconditionally in every override branch. Previously the proportional-documentation and ticket-attribution conventions lived only in the bundled `documentation-style` skill (user-editable; the deployer skips re-syncing a locally modified skill) and were guaranteed nowhere; the attribution footer was duplicated across three non-floor locations including a dead, never-consumed `assets/instructions/CLAUDE.md` stub. That dead asset (and its `CLAUDE_STUB` constant, `bundle_all.rs` `SeedOnce` registration, and `paths.rs` `claude_stub()` accessor) has been removed. `assets/skills/documentation-style.md` and the seeded project `CLAUDE.md` stub now point back to `BASE_PM.md` as the source of truth. A new CI guard (`scripts/check_instruction_floor.sh` + `.github/workflows/instruction-floor-guard.yml`) mechanically enforces that the floor keeps carrying these conventions and that the dead asset never reappears.
+- **Framework-guaranteed conventions delivered only via user-editable channels** ([#3374](https://github.com/bobmatnyc/trusty-tools/issues/3374)): the commit/PR attribution footer, the proportional-documentation policy, and the ticket-attribution-at-change-site convention are now stated in the non-overridable `BASE_PM.md` floor — the one channel `resolve_pm_prompt` appends unconditionally in every override branch. Previously the proportional-documentation and ticket-attribution conventions lived only in the bundled `documentation-style` skill (user-editable; the deployer skips re-syncing a locally modified skill) and were guaranteed nowhere; the attribution footer was duplicated across three non-floor locations including a dead, never-consumed `assets/instructions/CLAUDE.md` stub. That dead asset (and its `CLAUDE_STUB` constant, `bundle_all.rs` `SeedOnce` registration, and `paths.rs` `claude_stub()` accessor) has been removed. `assets/skills/documentation-style.md` and the seeded project `CLAUDE.md` stub now point back to `BASE_PM.md` as the source of truth. A new CI guard (`scripts/check_instruction_floor.sh` + `.github/workflows/instruction-floor-guard.yml`) mechanically enforces that the floor keeps carrying these conventions and that the dead asset never reappears. ([#3377](https://github.com/bobmatnyc/trusty-tools/pull/3377))
 
 ### Changed
 
-- `tm doctor`'s `skill_staleness` check now escalates to `Fail` (instead of `Warn`) when a **conventions-bearing** bundled skill has drifted from its bundled source — `documentation-style`, `tm-pr-workflow`, or `tm-git-file-tracking`, the small allowlist of skills whose text is the sole carrier of a framework-guaranteed rule (e.g. the commit/PR attribution footer). Ordinary skill drift stays `Warn` as before; the escalated message names the drifted skill(s) and points at `tm install` to restore the bundled version. This hardens the exact silent-drift path behind the PR #2825 attribution bypass (issue [#2825](https://github.com/bobmatnyc/trusty-tools/issues/2825)) without blocking session start — the escalation is a doctor signal only.
-- `tm`'s launch/connect splash art now sources from the shared `trusty_common::banner::TRUSTY_SPLASH_ART` / `shade_bucket` instead of a locally embedded `image.txt` + `shade_bucket` copy, so it can never silently drift from `trusty-agents`' REPL splash again (issue [#3326](https://github.com/bobmatnyc/trusty-tools/issues/3326)). Byte-identical art and rendering — `tm`'s own banner is unchanged; all 41 existing banner unit tests pass unmodified.
-
-### Security
-
-- **Daemon write guard extended from single-handler to router-wide**
-  ([#3304](https://github.com/bobmatnyc/trusty-tools/issues/3304), PR [#3317](https://github.com/bobmatnyc/trusty-tools/pull/3317)): previously
-  only `coordinator_chat` (`POST /api/v1/sessions/chat`) was origin-checked;
-  every other destructive route (`POST /sessions` spawn, `DELETE /sessions/{id}`,
-  `POST /api/v1/control/sessions/{id}/stop`, managed-session mutation,
-  `/claude-config/apply`, `/pair/*`) was exposed to cross-origin CSRF. The shared
-  `trusty_common` same-origin guard is now layered router-wide at the serve site
-  (`daemon::api::origin_guard::guard_router`), method-gated and fail-open on a
-  missing `Origin`. The `coordinator_chat` handler keeps its own finer-grained
-  origin check and `/rpc` keeps its loopback `ConnectInfo` gate (belt and
-  braces).
+- `tm doctor`'s `skill_staleness` check now escalates to `Fail` (instead of `Warn`) when a **conventions-bearing** bundled skill has drifted from its bundled source — `documentation-style`, `tm-pr-workflow`, or `tm-git-file-tracking`, the small allowlist of skills whose text is the sole carrier of a framework-guaranteed rule (e.g. the commit/PR attribution footer). Ordinary skill drift stays `Warn` as before; the escalated message names the drifted skill(s) and points at `tm install` to restore the bundled version. This hardens the exact silent-drift path behind the PR #2825 attribution bypass (issue [#2825](https://github.com/bobmatnyc/trusty-tools/issues/2825)) without blocking session start — the escalation is a doctor signal only. ([#3376](https://github.com/bobmatnyc/trusty-tools/pull/3376))
+- `tm`'s launch/connect splash art now sources from the shared `trusty_common::banner::TRUSTY_SPLASH_ART` / `shade_bucket` instead of a locally embedded `image.txt` + `shade_bucket` copy, so it can never silently drift from `trusty-agents`' REPL splash again (issue [#3326](https://github.com/bobmatnyc/trusty-tools/issues/3326)). Byte-identical art and rendering — `tm`'s own banner is unchanged; all 41 existing banner unit tests pass unmodified. ([#3345](https://github.com/bobmatnyc/trusty-tools/pull/3345))
 
 ### Removed
 
@@ -47,43 +35,84 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `commands/daemon_run.rs`; the router-wide write guard (#3304) now always
   trusts only the loopback default (there is no longer a second bind address
   to additionally trust). The daemon lock file no longer carries the optional
-  `tailscale_addr` field (`daemon::lock::write_lock` dropped that parameter).
+  `tailscale_addr` field (`daemon::lock::write_lock` dropped that parameter). ([#3342](https://github.com/bobmatnyc/trusty-tools/pull/3342))
+
+## [0.19.26] — 2026-07-19
+
+### Security
+
+- **Daemon write guard extended from single-handler to router-wide**
+  ([#3304](https://github.com/bobmatnyc/trusty-tools/issues/3304), PR [#3317](https://github.com/bobmatnyc/trusty-tools/pull/3317)): previously
+  only `coordinator_chat` (`POST /api/v1/sessions/chat`) was origin-checked;
+  every other destructive route (`POST /sessions` spawn, `DELETE /sessions/{id}`,
+  `POST /api/v1/control/sessions/{id}/stop`, managed-session mutation,
+  `/claude-config/apply`, `/pair/*`) was exposed to cross-origin CSRF. The shared
+  `trusty_common` same-origin guard is now layered router-wide at the serve site
+  (`daemon::api::origin_guard::guard_router`), method-gated and fail-open on a
+  missing `Origin`. The `coordinator_chat` handler keeps its own finer-grained
+  origin check and `/rpc` keeps its loopback `ConnectInfo` gate (belt and
+  braces).
 
 ### Added
 
 - WorkstreamConnector trait + tm/tcode backends (twin Phase 1, DOC-44) ([#3194](https://github.com/bobmatnyc/trusty-tools/pull/3194)) ([`6890b62`](https://github.com/bobmatnyc/trusty-tools/commit/6890b624f0e772827e6f1e50f2d885f36276c3db))
 - `tm sessions rename <id-or-name> <new-name>` (and in-session `tm sessions rename <new-name>` via `$TM_MANAGED_SESSION_ID`) renames a managed session, updating the record's `tmux_name` and the live tmux session, with collision + invalid-name guards ([#3302](https://github.com/bobmatnyc/trusty-tools/pull/3302))
 - `tm sessions delete` now marks a session `--deleted--` (a new persisted `Deleted` state shown in the master list) instead of silently dropping the record; `tm sessions prune --state deleted` compacts the tombstones ([#3302](https://github.com/bobmatnyc/trusty-tools/pull/3302))
-- per-project gh account pinning via GH_TOKEN spawn-env injection (closes #3025) ([#3040](https://github.com/bobmatnyc/trusty-tools/pull/3040)) ([`53d0a54`](https://github.com/bobmatnyc/trusty-tools/commit/53d0a5433c9e42b2c49f11f943de8cfc2c7f4696))
-- bridge custom remote+local MCP servers into fleet sessions at project/user scope ([#3033](https://github.com/bobmatnyc/trusty-tools/pull/3033)) ([`07cb73f`](https://github.com/bobmatnyc/trusty-tools/commit/07cb73f6bc236f753bb8e920ebab20b5cd9658c5))
-- per-session asset staleness + tm sessions sync-assets ([#2980](https://github.com/bobmatnyc/trusty-tools/pull/2980)) ([`c8d137a`](https://github.com/bobmatnyc/trusty-tools/commit/c8d137a632275e85709e745176a39253e62d6e3b))
-- daemon startup version banner + stale-daemon doctor check ([#2968](https://github.com/bobmatnyc/trusty-tools/pull/2968)) ([`abbcc45`](https://github.com/bobmatnyc/trusty-tools/commit/abbcc45c646cf821e8a9ed0828e66b11fc9b0a94))
+- `tm ls` / the session picker no longer report running/attached sessions as `(stopped)`: the list handler now reconciles each session's displayed state against live tmux (`active`/`attached` when the tmux session exists, `stopped` only when it is truly gone) so the offered action (connect vs restart) matches reality ([#3302](https://github.com/bobmatnyc/trusty-tools/pull/3302))
 
 ### Fixed
 
 - disclaim the tmux-pane `claude` off the shared tmux server (via an `internal-spawn-disclaimed` launch shim) so TCC attributes its data-access prompts to Claude Code itself, not tmux; adds a `tcc_taint` doctor check surfacing the disclaim state (refs #2997) ([#3314](https://github.com/bobmatnyc/trusty-tools/pull/3314)) ([`7849296`](https://github.com/bobmatnyc/trusty-tools/commit/7849296bb1e26d4ba8a594289c0316b8c6700e83))
 - disclaim TCC responsibility on the TUI health screen's `[S]`-key `cargo run` spawn — the last undisclaimed spawn site in the TUI/session-launch call graph from the #2997 sweep; two remaining sites elsewhere in the crate tracked as #2997 part 6 (closes #3126) ([#3261](https://github.com/bobmatnyc/trusty-tools/pull/3261)) ([`6dc1ef7`](https://github.com/bobmatnyc/trusty-tools/commit/6dc1ef753a2f5655d262850e981ea58797bd35ee))
-- `tm ls` / the session picker no longer report running/attached sessions as `(stopped)`: the list handler now reconciles each session's displayed state against live tmux (`active`/`attached` when the tmux session exists, `stopped` only when it is truly gone) so the offered action (connect vs restart) matches reality
-- disclaim TCC responsibility on session-launch spawns so Claude Code isn't attributed to trusty-mpm (closes #2997) ([#3037](https://github.com/bobmatnyc/trusty-tools/pull/3037)) ([`d481a0c`](https://github.com/bobmatnyc/trusty-tools/commit/d481a0cd7e264b20109e1c92122ba972db828222))
-- teach user-scope MCP registration via tm mcp add in tm-cli-operations (closes #3020) ([#3021](https://github.com/bobmatnyc/trusty-tools/pull/3021)) ([`f6223aa`](https://github.com/bobmatnyc/trusty-tools/commit/f6223aacc1c030055440cea93c5ae52c1c4d231f))
-- write_project_hooks uses write_json_atomic for torn-write parity (closes #2972) ([#3018](https://github.com/bobmatnyc/trusty-tools/pull/3018)) ([`32e805d`](https://github.com/bobmatnyc/trusty-tools/commit/32e805d609e15bbcc02ab4212f606e0e34b20293))
-- tm doctor output_style content-drift + orphan detection ([#2976](https://github.com/bobmatnyc/trusty-tools/pull/2976)) ([`05a4a05`](https://github.com/bobmatnyc/trusty-tools/commit/05a4a059b1cd4d00f052e5a504141b8f2b621b84))
-- explicit --url errors on unreachable daemon instead of silent fallback ([#2971](https://github.com/bobmatnyc/trusty-tools/pull/2971)) ([`c228ad9`](https://github.com/bobmatnyc/trusty-tools/commit/c228ad9a31093f79c27866d7ae15f0cb253e710f))
-- entry-level hook matching for mixed groups + lifecycle triad in project-tier settings ([#2969](https://github.com/bobmatnyc/trusty-tools/pull/2969)) ([`de11649`](https://github.com/bobmatnyc/trusty-tools/commit/de11649700a79028771092cc22ea6343e4a8da84))
 - repair 10 dangling doc-comment pointers (unblock main) ([#3282](https://github.com/bobmatnyc/trusty-tools/pull/3282)) ([`f906005`](https://github.com/bobmatnyc/trusty-tools/commit/f906005cf9972fcdd150865219042096b03b8950))
 
 ### Changed
 
 - extract gh_account enforcement into `gh_account_enforce.rs` and split `claude_code.rs` command-builder tests into sibling `claude_code_tests.rs`, bringing both production files back under the 500-SLOC cap (closes #3070) ([#3281](https://github.com/bobmatnyc/trusty-tools/pull/3281)) ([`83d3ed3`](https://github.com/bobmatnyc/trusty-tools/commit/83d3ed3e2aef4d528af67a0b123f5d985f660072))
 - tm-adr skill v2.0.0 — formalize ADRs as first-class documentation artifact (opt-in → mandatory) ([#3172](https://github.com/bobmatnyc/trusty-tools/pull/3172))
-- single shared tmux library; route trusty-mpm + trusty-agents through it ([#3017](https://github.com/bobmatnyc/trusty-tools/pull/3017)) ([`383b9f4`](https://github.com/bobmatnyc/trusty-tools/commit/383b9f475e781ef6049900f1630875e8ebf68264))
 
 ### Documentation
 
 - proportional documentation policy — lighter touch for self-evident code ([#3271](https://github.com/bobmatnyc/trusty-tools/pull/3271)) ([`5bc8aba`](https://github.com/bobmatnyc/trusty-tools/commit/5bc8abab497b1993a72d731d361316c086cabc73))
 - DOC-46 — formalize ADRs as first-class artifact with consistency-vetting protocol ([#3172](https://github.com/bobmatnyc/trusty-tools/pull/3172)) ([`b775ede`](https://github.com/bobmatnyc/trusty-tools/commit/b775edebcd2a1ee7a11396ebc392d69b8ab9defc))
 - in-flight issue/PR progress updates as standard PM workflow convention: bug diagnoses at triage time, progress comments at meaningful state changes, PR body freshness, and completion evidence (closes #3149) ([#3151](https://github.com/bobmatnyc/trusty-tools/pull/3151))
+
+## [0.19.25] — 2026-07-18
+
+### Added
+
+- daemon startup version banner + stale-daemon doctor check ([#2968](https://github.com/bobmatnyc/trusty-tools/pull/2968)) ([`abbcc45`](https://github.com/bobmatnyc/trusty-tools/commit/abbcc45c646cf821e8a9ed0828e66b11fc9b0a94))
+- per-session asset staleness + tm sessions sync-assets ([#2980](https://github.com/bobmatnyc/trusty-tools/pull/2980)) ([`c8d137a`](https://github.com/bobmatnyc/trusty-tools/commit/c8d137a632275e85709e745176a39253e62d6e3b))
+- bridge custom remote+local MCP servers into fleet sessions at project/user scope ([#3033](https://github.com/bobmatnyc/trusty-tools/pull/3033)) ([`07cb73f`](https://github.com/bobmatnyc/trusty-tools/commit/07cb73f6bc236f753bb8e920ebab20b5cd9658c5))
+- per-project gh account pinning via GH_TOKEN spawn-env injection (closes #3025) ([#3040](https://github.com/bobmatnyc/trusty-tools/pull/3040)) ([`53d0a54`](https://github.com/bobmatnyc/trusty-tools/commit/53d0a5433c9e42b2c49f11f943de8cfc2c7f4696))
+
+### Fixed
+
+- entry-level hook matching for mixed groups + lifecycle triad in project-tier settings ([#2969](https://github.com/bobmatnyc/trusty-tools/pull/2969)) ([`de11649`](https://github.com/bobmatnyc/trusty-tools/commit/de11649700a79028771092cc22ea6343e4a8da84))
+- explicit --url errors on unreachable daemon instead of silent fallback ([#2971](https://github.com/bobmatnyc/trusty-tools/pull/2971)) ([`c228ad9`](https://github.com/bobmatnyc/trusty-tools/commit/c228ad9a31093f79c27866d7ae15f0cb253e710f))
+- tm doctor output_style content-drift + orphan detection ([#2976](https://github.com/bobmatnyc/trusty-tools/pull/2976)) ([`05a4a05`](https://github.com/bobmatnyc/trusty-tools/commit/05a4a059b1cd4d00f052e5a504141b8f2b621b84))
+- write_project_hooks uses write_json_atomic for torn-write parity (closes #2972) ([#3018](https://github.com/bobmatnyc/trusty-tools/pull/3018)) ([`32e805d`](https://github.com/bobmatnyc/trusty-tools/commit/32e805d609e15bbcc02ab4212f606e0e34b20293))
+- teach user-scope MCP registration via tm mcp add in tm-cli-operations (closes #3020) ([#3021](https://github.com/bobmatnyc/trusty-tools/pull/3021)) ([`f6223aa`](https://github.com/bobmatnyc/trusty-tools/commit/f6223aacc1c030055440cea93c5ae52c1c4d231f))
+- disclaim TCC responsibility on session-launch spawns so Claude Code isn't attributed to trusty-mpm (closes #2997) ([#3037](https://github.com/bobmatnyc/trusty-tools/pull/3037)) ([`d481a0c`](https://github.com/bobmatnyc/trusty-tools/commit/d481a0cd7e264b20109e1c92122ba972db828222))
+
+### Changed
+
+- single shared tmux library; route trusty-mpm + trusty-agents through it ([#3017](https://github.com/bobmatnyc/trusty-tools/pull/3017)) ([`383b9f4`](https://github.com/bobmatnyc/trusty-tools/commit/383b9f475e781ef6049900f1630875e8ebf68264))
+
+### Documentation
+
 - long-wait protocol — disarm monitors on goal completion ([#2960](https://github.com/bobmatnyc/trusty-tools/pull/2960)) ([`e193414`](https://github.com/bobmatnyc/trusty-tools/commit/e1934140d38d6d9b847fef07676f29277683b220))
+
+## [0.19.24] — 2026-07-17
+
+### Added
+
+- pm_guard — 3-per-turn file-change budget, read-only-redirection fix, content-aware routing hints (closes #2918, refs #2745) ([#2928](https://github.com/bobmatnyc/trusty-tools/pull/2928)) ([`95b69c8`](https://github.com/bobmatnyc/trusty-tools/commit/95b69c80e08e396de8da7fe606d329e8360835a3))
+- rust-build-performance bundled skill — dev-loop + dependency-graph build hygiene, declared for the rust-engineer and tauri-engineer agents ([#2929](https://github.com/bobmatnyc/trusty-tools/pull/2929)) ([`c278874`](https://github.com/bobmatnyc/trusty-tools/commit/c278874db20e017323de27129f59647682de643f))
+
+### Fixed
+
+- tm hooks live only in the tm-owned settings path — stop `tm install` from discovering and mutating every `.claude/settings.json`/`settings.local.json` under `$HOME`, adds `tm hooks clean` + a doctor check ([#2945](https://github.com/bobmatnyc/trusty-tools/pull/2945)) ([`3940d7f`](https://github.com/bobmatnyc/trusty-tools/commit/3940d7f90d25fd57ef02ea47bb09a20cca06d34e))
 
 ---
 ## [0.19.23] — 2026-07-17

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.19.26"
+version = "0.19.27"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.35.0] — 2026-07-19
+
 ### Security
 
 - **Document-extraction DoS advisories fixed** ([#3367](https://github.com/bobmatnyc/trusty-tools/issues/3367)):
@@ -35,6 +37,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (previously unhandled references were silently dropped from extracted
   text). Covered by
   `docx::tests::test_paragraphs_from_document_xml_unescapes_entities`.
+  ([#3373](https://github.com/bobmatnyc/trusty-tools/pull/3373))
 - **Router-wide same-origin (CSRF) write guard** ([#3304](https://github.com/bobmatnyc/trusty-tools/issues/3304)):
   destructive write routes (`POST /admin/stop`, `POST /indexes`,
   `DELETE /indexes/{id}`, `POST /upgrade`, reindex) are now guarded against
@@ -43,7 +46,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   SSE streams unaffected) and fail-open on a missing `Origin` (the console
   reverse proxy, `curl`, and the MCP stdio bridge keep working); the daemon's
   own resolved bind address is trusted so a non-loopback bind still serves its
-  UI.
+  UI. ([#3317](https://github.com/bobmatnyc/trusty-tools/pull/3317))
+
+## [0.34.1] — 2026-07-18
 
 ### Added
 
@@ -51,7 +56,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- restore crates.io installability against trusty-common 0.23.3 — wedge_reset_secs field now set in all SupervisorConfig initializers (closes #3131)
+- restore crates.io installability against trusty-common 0.23.3 — wedge_reset_secs field now set in all SupervisorConfig initializers (closes #3131) ([#3148](https://github.com/bobmatnyc/trusty-tools/pull/3148))
 - EmbedderSupervisor shutdown reachable + no respawn on intentional shutdown ([#3023](https://github.com/bobmatnyc/trusty-tools/pull/3023)) ([`dd5f212`](https://github.com/bobmatnyc/trusty-tools/commit/dd5f212900abff69573121e826028e941188b79a))
 - warm-boot honors skip_kg — no graph load/rebuild for skipped indexes ([#2988](https://github.com/bobmatnyc/trusty-tools/pull/2988)) ([`cdf998e`](https://github.com/bobmatnyc/trusty-tools/commit/cdf998eadf92a42e924e770ce45b8f616d172448))
 - migrate off archived serde_yml/libyml to serde_yaml 0.9 ([#2992](https://github.com/bobmatnyc/trusty-tools/pull/2992)) ([`6a67317`](https://github.com/bobmatnyc/trusty-tools/commit/6a673178d8e9db98b901ad43872f003bc81d0f40))

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.34.1"
+version = "0.35.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Cuts the release carrying three merges landed on `main` but not yet in installed binaries:

- #3377 — non-overridable instruction floor + `check_instruction_floor.sh` CI guard
- #3376 — `tm doctor` escalates severity when conventions-bearing skills drift
- #3373 — document-extraction DoS input cap + quick-xml `GeneralRef` fix (trusty-search)

**Rebased 2026-07-20** onto green `origin/main` (`6834de3f`, PR #3395 "fix red main"). The
original commit predated that fix and duplicated it (`crates/trusty-agents/tests/
inference_shared_adapter_e2e.rs`); the duplicate was dropped during the rebase —
that file is now byte-identical to `main`, untouched by this PR. The only
`trusty-agents` change remaining is the `Cargo.toml` path-dependency version
requirement bump (see below), which is not redundant.

## Version drift check (issue #3366)

Independently re-verified against the live crates.io API (not just trusted from
the prior pass):

| Crate | Local | crates.io (`max_version`) | Action |
|---|---|---|---|
| trusty-mpm | 0.19.26 | 0.19.26 | bump -> 0.19.27 (this PR) |
| trusty-search | 0.34.1 | 0.34.1 | bump -> 0.35.0 (this PR) |
| trusty-common | 0.23.4 | 0.23.4 | in sync per version, **but see note below** |
| trusty-agents-common | 0.2.3 | 0.2.3 | in sync, no bump |
| trusty-progress | 0.1.1 | 0.1.1 | in sync, no bump |
| trusty-embedderd | 0.3.8 | 0.3.8 | in sync, no bump |

Only `trusty-mpm` and `trusty-search` source actually changed in a way this
release needs to carry; no other workspace crate needed a version bump to
satisfy this release's own dependency graph.

**Note (out of scope, flagging only):** `crates/trusty-common/src/catchup/mod.rs`
picked up a real behavioral fix after the `trusty-common-v0.23.4` tag
(`3563924e`, closes #1772 — canonical palace-id derivation). Its `Cargo.toml`
version is still `0.23.4`, unbumped, so that fix is not yet reflected in any
published `trusty-common` release. This does **not** block or change this PR:
neither `trusty-mpm` nor `trusty-search`'s caret requirement on `trusty-common`
needs a newer version to resolve (`^0.23` is already satisfied by the published
`0.23.4`), so dry-run/publish for this release is unaffected either way. Raising
it here only so it isn't lost — recommend a follow-up `trusty-common` patch
release, tracked separately from this PR's stated scope.

**Caret-drift catch:** `crates/trusty-agents/Cargo.toml` path-pins
`trusty-search = { version = "0.34.0" }`. Bumping trusty-search to 0.35.0 would
have broken that pin (`^0.34.0` doesn't cover `0.35.0`), so it's bumped in
lockstep here.

## Versions bumped

- `trusty-mpm`: 0.19.26 -> 0.19.27
- `trusty-search`: 0.34.1 -> 0.35.0 (minor, not patch — the range also carries a `feat`: #3317's router-wide CSRF write guard)
- `trusty-agents`'s `trusty-search` path-dependency requirement: 0.34.0 -> 0.35.0 (no crate version bump; not a published crate)

## CHANGELOG

- `trusty-mpm/CHANGELOG.md`: reconstructed missing `## [0.19.24]` / `## [0.19.25]` / `## [0.19.26]` headings — this content had been accumulating under a single dangling `## [Unreleased]` block across three prior releases. Rebuilt from `git log <tag>..<tag> -- crates/trusty-mpm/` cross-checked against each PR's `mergedAt` timestamp. Added the `## [0.19.27]` entry for this release. No dangling `[Unreleased]` content remains (the heading itself stays, empty, per Keep a Changelog convention).
- `trusty-search/CHANGELOG.md`: same dangling-`Unreleased` problem, one level deep — split into a retroactive `## [0.34.1]` heading (that content was already live on crates.io, just never got its own heading) and the new `## [0.35.0]` heading for this release.

PR #3397 (InstallPolicy Overwrite/SeedOnce) was checked at rebase time and is
still **OPEN, unmerged** — proceeding without it per the release brief; it is
not included in the 0.19.27 CHANGELOG entry.

## Quality gate (raw output, re-run post-rebase at workspace scope)

```
$ cargo fmt --all --check
(clean — no diff; only pre-existing "unstable feature" clippy.toml warnings)

$ cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.70s
(zero warnings/errors — only pre-existing duplicate-bin-target and future-incompat notices)

$ cargo check --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.93s
(clean)

$ CI= cargo test --workspace --no-fail-fast --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
170 test binaries executed. 1 failure:
  workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts (trusty-agents)
  -> re-ran in isolation: PASSES (test result: ok. 1 passed; 0 failed).
  This is the pre-existing, unrelated env-var-race flake filed as #3398
  (neither trusty-mpm nor trusty-search; trusty-agents is not published by
  this release). Every other test binary in the workspace: 0 failed.

$ CI= cargo test -p trusty-review
test result: ok. 3 passed; 0 failed (+ 3 passed, 0 failed in report_investigate.rs; 0 doc-tests)
```

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (excluding GUI crates, matching CI)
- [x] `cargo check --workspace` (excluding GUI crates, matching CI)
- [x] `cargo test --workspace --no-fail-fast` (excluding GUI crates, matching CI) — one pre-existing unrelated flake (#3398), verified passing in isolation
- [x] `cargo test -p trusty-review` (separate CI step)
- [ ] CI green on this PR
- [ ] Merge, then publish `trusty-mpm` 0.19.27 and `trusty-search` 0.35.0 to crates.io in dependency order

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
