### PR TITLE
fix(trusty-agents): stop /model & /provider picker swallowing typed keystrokes

### DIFF
--- a/crates/trusty-agents/src/repl/tui/keys.rs
+++ b/crates/trusty-agents/src/repl/tui/keys.rs
@@ -53,10 +53,28 @@ fn should_navigate_picker(app: &ReplApp) -> bool {
 
 /// Handle one key press. Returns `Some(line)` if the user submitted.
 pub(crate) fn handle_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
-    // Picker modal: when an overlay is open, capture all keys here so
-    // arrow / Enter / Esc don't leak through to the input editor.
+    // Picker modal (`/model`, `/provider`): while an overlay is open, Up /
+    // Down / Enter / Esc drive `handle_picker_key` exclusively so navigation
+    // doesn't leak into the input editor underneath. Any OTHER key (#3403 —
+    // sibling of #3325/#3346, which fixed the same swallow class for
+    // `app.choices`) used to hit `handle_picker_key`'s `_ => {}` catch-all
+    // and vanish with zero effect: the user would type a few characters
+    // while `/model` was open, see nothing happen, and have no idea their
+    // keystrokes were being eaten. Type-to-dismiss: a non-navigation key
+    // closes the picker and falls through to the normal input path below,
+    // so a printable character lands in `input_buf` exactly like it would
+    // with no picker open. Mirrors the #3325 resolution for `app.choices`.
     if app.picker.is_some() {
-        return handle_picker_key(app, key);
+        match key.code {
+            KeyCode::Up | KeyCode::Down | KeyCode::Enter | KeyCode::Esc => {
+                return handle_picker_key(app, key);
+            }
+            _ => {
+                app.picker = None;
+                // Fall through — the rest of `handle_key` treats this as a
+                // normal keystroke (char insert, backspace, cursor move, …).
+            }
+        }
     }
     // Inline choice picker: when the LLM offered a list and we surfaced it,
     // arrow keys navigate the choices, Enter commits the selection into the
@@ -285,7 +303,11 @@ pub(crate) fn handle_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
     }
 }
 
-/// Handle a key while a picker overlay is open.
+/// Handle a key while a picker overlay is open, for the navigation keys
+/// `handle_key` routes here (Up/Down/Enter/Esc). Every other key is
+/// intercepted one level up in `handle_key`, which dismisses the picker and
+/// falls through to normal input editing instead of calling this function
+/// (#3403) — so this function only ever sees the four keys it understands.
 ///
 /// Why: Centralizes the modal-state key routing so `handle_key`'s normal path
 /// can stay focused on the input editor. Up/Down navigate (with wrap-around),
@@ -295,7 +317,7 @@ pub(crate) fn handle_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
 /// never produce a submitted line directly; the event loop synthesizes a
 /// `Submit("/model …")` after observing `pending_picker_selection`.
 /// Test: `repl_app_picker_navigation_wraps`, `repl_app_picker_enter_sets_pending_selection`,
-/// `repl_app_picker_esc_dismisses`.
+/// `repl_app_picker_esc_dismisses`, `repl_app_picker_printable_key_dismisses_and_inserts`.
 pub(crate) fn handle_picker_key(app: &mut ReplApp, key: KeyEvent) -> Option<String> {
     let picker = app.picker.as_mut().expect("picker present");
     match key.code {

--- a/crates/trusty-agents/src/repl/tui/tests_render.rs
+++ b/crates/trusty-agents/src/repl/tui/tests_render.rs
@@ -83,6 +83,108 @@ fn repl_app_picker_esc_dismisses() {
     assert!(a.pending_picker_selection.is_none());
 }
 
+/// Why (#3403): `handle_picker_key` only understands Up/Down/Enter/Esc; every
+/// other key used to hit its `_ => {}` catch-all and vanish with zero effect
+/// — the `/model`/`/provider` sibling of the #3325 `app.choices` swallow bug.
+/// This test drives the picker through `handle_key` (the real dispatch entry
+/// point, not `handle_picker_key` directly) so it exercises the dismiss-and-
+/// fall-through routing added in `handle_key`. Against the pre-fix code
+/// (`handle_key` unconditionally returning `handle_picker_key(app, key)`
+/// whenever `app.picker.is_some()`), this fails: the picker stays `Some` and
+/// `input_buf` stays empty.
+/// What: Open a `/model` picker, send a printable `Char('x')` via
+/// `handle_key`, assert the picker is dismissed AND `'x'` landed in
+/// `input_buf` — the keystroke was neither swallowed nor discarded.
+/// Test: `repl_app_picker_printable_key_dismisses_and_inserts` (this test).
+#[test]
+fn repl_app_picker_printable_key_dismisses_and_inserts() {
+    let mut a = ReplApp::new("ctrl".into(), "u".into());
+    a.picker = Some(PickerState {
+        items: vec!["anthropic/claude-haiku-4-5".into()],
+        selected: 0,
+        title: "Select Model".into(),
+        kind: PickerKind::Model,
+    });
+    let submitted = handle_key(
+        &mut a,
+        KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
+    );
+    assert!(
+        submitted.is_none(),
+        "a single char must not submit the line"
+    );
+    assert!(
+        a.picker.is_none(),
+        "a printable key must dismiss the picker, not leave it capturing input"
+    );
+    assert_eq!(
+        a.input_buf, "x",
+        "the keystroke that dismissed the picker must land in input_buf, not vanish"
+    );
+}
+
+/// Why (#3403): Backspace is another non-nav key the old `_ => {}` catch-all
+/// swallowed. Confirms the dismiss-and-fall-through path also covers editing
+/// keys, not just `Char`.
+/// What: Open a picker with pre-populated `input_buf`, send Backspace,
+/// assert the picker is dismissed and the last character was removed (i.e.
+/// Backspace reached the normal input editor instead of being eaten).
+/// Test: `repl_app_picker_backspace_dismisses_and_edits` (this test).
+#[test]
+fn repl_app_picker_backspace_dismisses_and_edits() {
+    let mut a = ReplApp::new("ctrl".into(), "u".into());
+    a.set_input("hi".into());
+    a.picker = Some(PickerState {
+        items: vec!["anthropic/claude-haiku-4-5".into()],
+        selected: 0,
+        title: "Select Model".into(),
+        kind: PickerKind::Model,
+    });
+    handle_key(
+        &mut a,
+        KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE),
+    );
+    assert!(a.picker.is_none(), "Backspace must dismiss the picker");
+    assert_eq!(
+        a.input_buf, "h",
+        "Backspace must reach the input editor, not be swallowed"
+    );
+}
+
+/// Why (#3403 regression guard): Up/Down/Enter/Esc must keep navigating the
+/// `/model`/`/provider` picker exactly as before through `handle_key` (not
+/// just `handle_picker_key` directly, which the pre-existing tests already
+/// cover) — the fix must not regress the working navigation path while
+/// closing the printable-key swallow hole.
+/// What: Drive a 2-item picker through `handle_key` with Down then Enter,
+/// assert the pending selection is set and the picker is closed.
+/// Test: `repl_app_picker_nav_keys_still_work_via_handle_key` (this test).
+#[test]
+fn repl_app_picker_nav_keys_still_work_via_handle_key() {
+    let mut a = ReplApp::new("ctrl".into(), "u".into());
+    a.picker = Some(PickerState {
+        items: vec![
+            "anthropic/claude-haiku-4-5".into(),
+            "anthropic/claude-sonnet-4-6".into(),
+        ],
+        selected: 0,
+        title: "Select Model".into(),
+        kind: PickerKind::Model,
+    });
+    handle_key(&mut a, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+    assert_eq!(
+        a.picker.as_ref().unwrap().selected,
+        1,
+        "Down must still navigate the picker via handle_key"
+    );
+    handle_key(&mut a, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert!(a.picker.is_none());
+    assert_eq!(
+        a.pending_picker_selection,
+        Some((PickerKind::Model, "anthropic/claude-sonnet-4-6".into()))
+    );
+}
+
 /// Why bug fix (#switch-popup): `/switch` (no arg) populates the inline
 /// flat-list picker with `choices_context = Some("switch")`. Pressing
 /// Enter on a selection must NOT insert the persona name into the input
@@ -294,13 +396,18 @@ fn slash_completions_does_not_stomp_context_picker() {
     assert_eq!(a.input_buf, "x", "the typed char must land in the editor");
 }
 
-/// Why: When the picker is open, ALL keys must be intercepted — typing a
-/// regular character must NOT leak through to the input editor.
-/// What: With picker open, sending KeyCode::Char('x') leaves input_buf
-/// empty. With picker closed, the same key inserts into the buffer.
+/// Why (#3403 — supersedes the original "modal swallows all keys" pin):
+/// This test used to assert the picker modal swallowed every non-nav key
+/// with zero effect, which is exactly the bug reported live and tracked as
+/// #3403 (the `app.picker` sibling of #3325's `app.choices` swallow). The
+/// modal now only intercepts Up/Down/Enter/Esc; a printable char dismisses
+/// it and lands in the input editor, same as when no picker is open.
+/// What: With picker open, sending `KeyCode::Char('x')` dismisses the picker
+/// AND inserts `'x'` into `input_buf`. With picker closed, the same key
+/// still inserts into the buffer (unchanged baseline).
 /// Test: Two parallel cases.
 #[test]
-fn handle_key_modal_gates_input_editor() {
+fn handle_key_modal_dismisses_and_inserts_on_char() {
     let mut a = ReplApp::new("ctrl".into(), "u".into());
     a.picker = Some(PickerState {
         items: vec!["x".into()],
@@ -313,10 +420,15 @@ fn handle_key_modal_gates_input_editor() {
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),
     );
     assert_eq!(r, None);
-    assert!(a.input_buf.is_empty(), "modal must swallow chars");
+    assert!(a.picker.is_none(), "a printable key must dismiss the modal");
+    assert_eq!(
+        a.input_buf, "x",
+        "the keystroke that dismissed the modal must land in input_buf"
+    );
 
-    // Close picker → same key inserts.
-    a.picker = None;
+    // Picker already closed → same key still inserts (baseline unchanged).
+    a.input_buf.clear();
+    a.cursor_pos = 0;
     handle_key(
         &mut a,
         KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE),

--- a/crates/trusty-agents/src/repl/tui/types.rs
+++ b/crates/trusty-agents/src/repl/tui/types.rs
@@ -139,9 +139,11 @@ pub struct ReplApp {
     pub session_start: std::time::Instant,
     /// Active picker overlay (model/provider). `None` when no picker is open.
     ///
-    /// Why: When `Some`, `handle_key` routes ALL key events to the picker
+    /// Why: When `Some`, `handle_key` routes Up/Down/Enter/Esc to the picker
     /// modal handler so navigation/dismiss don't accidentally edit the input
-    /// buffer underneath.
+    /// buffer underneath. Any other key dismisses the picker and falls
+    /// through to normal input editing (#3403) rather than being silently
+    /// swallowed.
     /// What: Carries items, selection index, title, and kind.
     /// Test: `repl_app_picker_*`.
     pub picker: Option<PickerState>,


### PR DESCRIPTION
## Summary

- Fixes #3403 — the `app.picker` modal (opened by `/model` and `/provider`) silently swallowed any keystroke that wasn't Up/Down/Enter/Esc. `handle_key` routed **every** key to `handle_picker_key` whenever `app.picker.is_some()`, and `handle_picker_key`'s `_ => {}` catch-all discarded printable chars, Backspace, Tab, etc. with zero feedback.
- This is the `app.picker` sibling of the #3325 (PR #3344) / #3346 (PR #3350) `app.choices` swallow bug — those fixes only ever touched the OTHER overlay state (the LLM-list / `/switch` picker). `app.picker` was never touched.
- Reported live over SSH: user opens `/model` or `/provider`, starts typing, keystrokes vanish.

## UX chosen: type-to-dismiss

Mirrors the #3325 resolution. `handle_key` now only routes `Up`/`Down`/`Enter`/`Esc` into `handle_picker_key`. Any other key:
1. Dismisses the picker (`app.picker = None`)
2. Falls through to the normal input-editing path in the rest of `handle_key`

So a printable character lands in `input_buf` exactly as if no picker were open — never silently discarded. Backspace, Left/Right, Ctrl combos, etc. all fall through the same way.

I considered type-to-filter (narrowing the list as you type) but rejected it for this PR: it changes the picker's interaction model non-trivially (would need a query buffer, re-filtering, cursor-reset semantics) for a bug whose non-negotiable requirement is simply "no silent vanish." Type-to-dismiss is the minimal, consistent-with-precedent fix; a filter UX can be a separate follow-up if wanted.

The picker's footer hint (`↑↓ navigate  Enter select  Esc cancel`, `crates/trusty-agents/src/repl/tui/pickers.rs:244-248`) already existed and needed no change — it correctly describes the now-accurate nav-key-only capture surface.

## Change

`crates/trusty-agents/src/repl/tui/keys.rs` — `handle_key`'s picker-modal gate:

```rust
if app.picker.is_some() {
    match key.code {
        KeyCode::Up | KeyCode::Down | KeyCode::Enter | KeyCode::Esc => {
            return handle_picker_key(app, key);
        }
        _ => {
            app.picker = None;
            // Fall through to normal input handling below.
        }
    }
}
```

Plus updated doc comments in `keys.rs` and `types.rs` (`ReplApp::picker`) reflecting the narrowed capture surface.

## Tests

New, in `crates/trusty-agents/src/repl/tui/tests_render.rs`:
- `repl_app_picker_printable_key_dismisses_and_inserts` — printable char via `handle_key` dismisses the picker and lands in `input_buf`. Fails against pre-fix code (picker stays `Some`, buffer stays empty).
- `repl_app_picker_backspace_dismisses_and_edits` — same coverage for Backspace.
- `repl_app_picker_nav_keys_still_work_via_handle_key` — Down + Enter through `handle_key` still navigate/confirm correctly (regression guard for the existing `handle_picker_key`-level tests).

Updated: `handle_key_modal_gates_input_editor` → renamed `handle_key_modal_dismisses_and_inserts_on_char` — this test previously *pinned the bug* (asserted `input_buf` stayed empty after typing over an open picker). Rewritten to assert the corrected behavior.

Pre-existing tests `repl_app_picker_navigation_wraps`, `repl_app_picker_enter_sets_pending_selection`, `repl_app_picker_esc_dismisses` (call `handle_picker_key` directly) are untouched and still pass — nav/confirm/cancel semantics are unchanged.

## Gate evidence (raw)

```
$ cargo check -p trusty-agents
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 46.94s

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 13s
(zero clippy warnings/errors; only unrelated pre-existing manifest warnings about
 duplicate bin targets in trusty-mpm/trusty-installer)

$ cargo test -p trusty-agents
test result: FAILED. 1961 passed; 1 failed; 8 ignored; 0 measured; 0 filtered out
failures:
    workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts
```
That single failure is a **pre-existing, unrelated flake** — a parallel-execution
race in `workflow::engine::executor::tests::checkpoint_resume` (unrelated module,
not touched by this PR). Confirmed by running it in isolation / single-threaded:
```
$ cargo test -p trusty-agents --lib -- --test-threads=1 workflow::engine::executor::tests::checkpoint_resume
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 1964 filtered out
```
All `repl::tui::*` tests, including the 4 new/updated picker tests, pass every run:
```
$ cargo test -p trusty-agents repl::tui::tests_render
test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 1945 filtered out
```

```
$ cargo fmt -p trusty-agents --check
(exit 0, no diff)

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.
```

## Test plan

- [x] `cargo check -p trusty-agents`
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings`
- [x] `cargo test -p trusty-agents` (all passing except the pre-existing unrelated flake noted above)
- [x] `cargo fmt -p trusty-agents --check`
- [x] `bash scripts/check_line_cap.sh`

Closes #3403

🤖 Generated with [Claude Code](https://claude.com/claude-code)