### PR TITLE
feat(trusty-agents): persistent plain-line CLI mode, defaults to assistant (Opus)

### DIFF
--- a/crates/trusty-agents/src/ctrl/mod.rs
+++ b/crates/trusty-agents/src/ctrl/mod.rs
@@ -44,7 +44,7 @@ pub use supervisor::{CtrlSupervisor, SupervisorOutcome};
 // (main.rs, REPL, tests). All implementations live in the submodules above.
 pub use config::SessionOverrides;
 pub use pm_task::{run_pm_task_with_history, run_pm_task_with_persona, run_pm_task_with_session};
-pub use repl::{run_ctrl, run_ctrl_headless};
+pub use repl::{run_ctrl, run_ctrl_headless, run_plain_cli};
 pub use socket_listener::{forward_to_controller, spawn_socket_listener};
 pub use state::ConversationTurn;
 pub use util::{PmMessageRecord, append_pm_message, detect_self_project};

--- a/crates/trusty-agents/src/ctrl/repl/mod.rs
+++ b/crates/trusty-agents/src/ctrl/repl/mod.rs
@@ -11,6 +11,7 @@
 //! Test: `cmd_*` tests cover slash-command dispatch; the larger setup paths
 //! are smoke-tested via tmux REPL harness.
 
+mod plain_cli;
 mod profile;
 
 use std::path::PathBuf;
@@ -31,6 +32,7 @@ use super::socket_listener::spawn_socket_listener;
 use super::state::{Ctrl, PmMsg};
 use super::util::{append_pm_message, detect_self_project};
 
+pub use plain_cli::run_plain_cli;
 use profile::load_or_create_user_profile;
 
 // INTENT: Print the CTRL command reference.

--- a/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
+++ b/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
@@ -1,0 +1,169 @@
+//! Persistent plain-line CLI mode (#3052) — split out of `repl/mod.rs` to
+//! keep that file under the 500-SLOC production cap.
+//!
+//! Why: `run_ctrl`'s own stdin loop (in `mod.rs`) dispatches free text
+//! through `ctrl_chat_turn` / `Ctrl::dispatch_task` — a DIFFERENT pipeline
+//! from what the ratatui TUI's submit path uses
+//! (`TrustyAgentsRepl::attempt_forward`, which routes through
+//! `run_pm_task_with_persona` / `run_pm_task_with_history` with `/model` +
+//! `/provider` session overrides applied). A tester driving `tagent` over
+//! SSH (Terminus/iPhone) needs the SAME agent/model routing the TUI gets,
+//! not a parallel implementation, and needs NO full-screen alt-screen TUI
+//! (which reflows badly on a narrow terminal and has a modal
+//! keystroke-swallow bug). This module reuses `TrustyAgentsRepl` directly —
+//! `try_handle_slash` for every slash command (`/help`, `/model`,
+//! `/provider`, `/switch`, `/clear`, `/quit`, …) and `attempt_forward` for
+//! free-text chat — exactly as `runtime::predispatch::handle_slash_passthrough`
+//! already does for the one-shot `trusty-agents /status`-style CLI
+//! passthrough. Bypassing `ReplBridge` (the TUI's event/picker layer) means
+//! `/model` and `/provider` with no argument print their list as plain text
+//! instead of opening a ratatui modal — the whole point of this mode.
+//! What: `run_plain_cli` — builds a `TrustyAgentsRepl`, optionally switches
+//! it into thin-client mode when a `--service` daemon is already running
+//! (mirrors the TUI startup path in `mode_dispatch`), prints a startup
+//! banner showing the resolved agent model/runner/credential, then loops
+//! reading one line at a time until `/exit`, `/quit`, `/disconnect`, or EOF
+//! (Ctrl-D).
+//! Test: `should_force_plain_cli_*` (mode-dispatch selector, in
+//! `runtime::cli_def`); `tests/plain_cli_repl.rs` (piped-stdin integration
+//! test driving the real compiled binary).
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use super::profile::load_or_create_user_profile;
+use crate::ctrl::state::ConversationTurn;
+
+/// Cap on retained conversation turns for the plain CLI loop.
+///
+/// Why: Mirrors `repl::dispatch::MAX_HISTORY_TURNS`, which is private to that
+/// module — this is an intentional small duplicate of the constant (not the
+/// dispatch logic) rather than widening that module's visibility for one use.
+const PLAIN_CLI_MAX_HISTORY_TURNS: usize = 20;
+
+/// Entry point for the persistent plain-line CLI mode. See module docs.
+pub async fn run_plain_cli() -> Result<()> {
+    let user_profile = load_or_create_user_profile().await?;
+    let mut repl = crate::repl::TrustyAgentsRepl::new(user_profile)?;
+
+    if crate::service::is_service_running(crate::service::DEFAULT_SERVICE_PORT).await {
+        let url = format!("http://localhost:{}", crate::service::DEFAULT_SERVICE_PORT);
+        let started = crate::service::read_pid_file()
+            .map(|s| {
+                format!(
+                    "pid {} port {} since {}",
+                    s.pid,
+                    s.port,
+                    s.started_at.to_rfc3339()
+                )
+            })
+            .unwrap_or_else(|| format!("port {}", crate::service::DEFAULT_SERVICE_PORT));
+        eprintln!("--- connected to running trusty-agents service ---");
+        eprintln!("    {started}");
+        eprintln!("    (use `/service stop` to shut it down)");
+        repl.set_service_client_mode(url);
+    }
+
+    println!(
+        "{} — plain CLI mode (no TUI)\ntype /help for commands, /quit or /exit to leave\n",
+        crate::build_info::version_string()
+    );
+    println!(
+        "resolved agent endpoint: model={} runner={:?} credential={}\n",
+        repl.resolve_active_model(),
+        repl.resolve_active_runner(),
+        resolved_credential_label(),
+    );
+
+    let mut stdin = BufReader::new(tokio::io::stdin());
+    let mut stdout = tokio::io::stdout();
+
+    loop {
+        stdout
+            .write_all(b"you> ")
+            .await
+            .context("failed to write prompt")?;
+        stdout.flush().await.context("failed to flush prompt")?;
+
+        let mut line = String::new();
+        let n = stdin
+            .read_line(&mut line)
+            .await
+            .context("failed to read stdin")?;
+        if n == 0 {
+            println!("Bye.");
+            break;
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match repl.try_handle_slash(trimmed).await {
+            Some(Ok((cont, output))) => {
+                if !output.is_empty() {
+                    print!("{output}");
+                    if !output.ends_with('\n') {
+                        println!();
+                    }
+                }
+                if !cont {
+                    break;
+                }
+            }
+            Some(Err(e)) => {
+                eprintln!("command error: {e:#}");
+            }
+            None => {
+                dispatch_free_text(&mut repl, trimmed).await;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Forward one free-text (non-slash) line through `attempt_forward` — the
+/// same LLM dispatch the ratatui TUI's submit path uses — print the
+/// response, and append the turn to `conversation_history` so multi-turn
+/// context keeps flowing exactly like the TUI.
+async fn dispatch_free_text(repl: &mut crate::repl::TrustyAgentsRepl, trimmed: &str) {
+    let start = std::time::Instant::now();
+    match repl.attempt_forward(trimmed).await {
+        Ok((response, _usage)) => {
+            let elapsed = start.elapsed();
+            println!("{response}");
+            if repl.conversation_history.len() >= PLAIN_CLI_MAX_HISTORY_TURNS {
+                repl.conversation_history.remove(0);
+            }
+            repl.conversation_history.push(ConversationTurn {
+                user: trimmed.to_string(),
+                assistant: response,
+            });
+            eprintln!("[TIMING] responded in {:.2}s", elapsed.as_secs_f64());
+        }
+        Err(e) => {
+            let elapsed = start.elapsed();
+            eprintln!("task error: {e:#}");
+            eprintln!("[TIMING] failed after {:.2}s", elapsed.as_secs_f64());
+        }
+    }
+}
+
+/// Which credential env var `run_plain_cli`'s startup banner resolved, so an
+/// SSH tester can see at a glance which auth path a message will use.
+/// Mirrors the precedence documented in `cli_def::check_credentials_and_warn`.
+fn resolved_credential_label() -> &'static str {
+    if std::env::var("CLAUDE_CODE_OAUTH_TOKEN").is_ok_and(|v| !v.is_empty()) {
+        "CLAUDE_CODE_OAUTH_TOKEN"
+    } else if std::env::var("ANTHROPIC_API_KEY").is_ok_and(|v| !v.is_empty()) {
+        "ANTHROPIC_API_KEY"
+    } else if std::env::var(trusty_common::env_vars::ENV_OPENROUTER_API_KEY)
+        .is_ok_and(|v| !v.is_empty())
+    {
+        "OPENROUTER_API_KEY"
+    } else {
+        "none configured"
+    }
+}

--- a/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
+++ b/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
@@ -18,12 +18,18 @@
 //! passthrough. Bypassing `ReplBridge` (the TUI's event/picker layer) means
 //! `/model` and `/provider` with no argument print their list as plain text
 //! instead of opening a ratatui modal — the whole point of this mode.
-//! What: `run_plain_cli` — builds a `TrustyAgentsRepl`, optionally switches
-//! it into thin-client mode when a `--service` daemon is already running
-//! (mirrors the TUI startup path in `mode_dispatch`), prints a startup
-//! banner showing the resolved agent model/runner/credential, then loops
-//! reading one line at a time until `/exit`, `/quit`, `/disconnect`, or EOF
-//! (Ctrl-D).
+//! What: `run_plain_cli` — builds a `TrustyAgentsRepl`, defaults its active
+//! conversational agent to `assistant` (Opus) by internally issuing
+//! `/switch assistant` — the same mechanism a user typing that command would
+//! trigger — so the owner's actual testing surface is answered by the
+//! assistant persona out of the box, not the `ctrl` coordinator (local
+//! ollama). `ctrl` remains fully reachable via `/switch ctrl`, and
+//! machine-coordination commands (`/connect`, `/status`, controller socket)
+//! are untouched. Optionally switches into thin-client mode when a
+//! `--service` daemon is already running (mirrors the TUI startup path in
+//! `mode_dispatch`), prints a startup banner showing the resolved agent
+//! name/model/runner/credential, then loops reading one line at a time
+//! until `/exit`, `/quit`, `/disconnect`, or EOF (Ctrl-D).
 //! Test: `should_force_plain_cli_*` (mode-dispatch selector, in
 //! `runtime::cli_def`); `tests/plain_cli_repl.rs` (piped-stdin integration
 //! test driving the real compiled binary).
@@ -32,7 +38,14 @@ use anyhow::{Context, Result};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 use super::profile::load_or_create_user_profile;
+use crate::agents::RunnerKind;
 use crate::ctrl::state::ConversationTurn;
+
+/// Persona the plain CLI defaults its conversational agent to at startup
+/// (owner decision, #3406 follow-up): the assistant (Opus) is what an SSH
+/// tester is actually exercising, not the `ctrl` machine-coordination
+/// persona (local ollama). `ctrl` stays one `/switch ctrl` away.
+const DEFAULT_PERSONA: &str = "assistant";
 
 /// Cap on retained conversation turns for the plain CLI loop.
 ///
@@ -45,6 +58,33 @@ const PLAIN_CLI_MAX_HISTORY_TURNS: usize = 20;
 pub async fn run_plain_cli() -> Result<()> {
     let user_profile = load_or_create_user_profile().await?;
     let mut repl = crate::repl::TrustyAgentsRepl::new(user_profile)?;
+
+    // Owner decision (#3406 follow-up): default the plain CLI's active
+    // conversational agent to `assistant` instead of the `ctrl` coordinator
+    // it inherits from `TrustyAgentsRepl::new`. Reuses the SAME dispatch a
+    // user typing `/switch assistant` would trigger — not a new mechanism —
+    // so behavior (persona resolution, display-name lookup, history reset)
+    // matches exactly. Missing/broken `assistant/agent.toml` degrades
+    // gracefully: the error is surfaced and the session stays on `ctrl`.
+    match repl
+        .try_handle_slash(&format!("/switch {DEFAULT_PERSONA}"))
+        .await
+    {
+        Some(Ok((_, output))) => {
+            if !output.is_empty() {
+                print!("{output}");
+                if !output.ends_with('\n') {
+                    println!();
+                }
+            }
+        }
+        Some(Err(e)) => {
+            eprintln!(
+                "warning: failed to default to the '{DEFAULT_PERSONA}' persona ({e:#}); staying on ctrl"
+            );
+        }
+        None => unreachable!("\"/switch ...\" always starts with '/'"),
+    }
 
     if crate::service::is_service_running(crate::service::DEFAULT_SERVICE_PORT).await {
         let url = format!("http://localhost:{}", crate::service::DEFAULT_SERVICE_PORT);
@@ -68,11 +108,13 @@ pub async fn run_plain_cli() -> Result<()> {
         "{} — plain CLI mode (no TUI)\ntype /help for commands, /quit or /exit to leave\n",
         crate::build_info::version_string()
     );
+    let (agent_name, model, runner) = resolve_endpoint_agent(&repl);
     println!(
-        "resolved agent endpoint: model={} runner={:?} credential={}\n",
-        repl.resolve_active_model(),
-        repl.resolve_active_runner(),
-        resolved_credential_label(),
+        "resolved agent endpoint: agent={} model={} runner={:?} credential={}\n",
+        agent_name,
+        model,
+        runner,
+        resolved_credential_label(runner),
     );
 
     let mut stdin = BufReader::new(tokio::io::stdin());
@@ -151,19 +193,56 @@ async fn dispatch_free_text(repl: &mut crate::repl::TrustyAgentsRepl, trimmed: &
     }
 }
 
-/// Which credential env var `run_plain_cli`'s startup banner resolved, so an
-/// SSH tester can see at a glance which auth path a message will use.
-/// Mirrors the precedence documented in `cli_def::check_credentials_and_warn`.
-fn resolved_credential_label() -> &'static str {
-    if std::env::var("CLAUDE_CODE_OAUTH_TOKEN").is_ok_and(|v| !v.is_empty()) {
-        "CLAUDE_CODE_OAUTH_TOKEN"
-    } else if std::env::var("ANTHROPIC_API_KEY").is_ok_and(|v| !v.is_empty()) {
-        "ANTHROPIC_API_KEY"
-    } else if std::env::var(trusty_common::env_vars::ENV_OPENROUTER_API_KEY)
-        .is_ok_and(|v| !v.is_empty())
-    {
-        "OPENROUTER_API_KEY"
-    } else {
-        "none configured"
+/// Resolve the agent name/model/runner the startup banner should display,
+/// reflecting whichever persona is ACTUALLY active after the default-persona
+/// switch above (or a later `/switch`/`/agent`).
+///
+/// Why: `TrustyAgentsRepl::resolve_active_model` / `resolve_active_runner`
+/// only ever consult `ctrl.toml` / `pm.toml` (see their doc comments in
+/// `repl/mod.rs`) — they predate per-persona chat and don't know about
+/// `active_persona`. Using them directly here would keep showing `ctrl`'s
+/// model/runner even after defaulting (or switching) to `assistant`. This
+/// resolves the SAME way `/agent`/`/switch` do — `AgentConfig::by_name_in`
+/// against the REPL's own `agents_dir` + the `$HOME` fallback — so the
+/// banner always matches what the next `attempt_forward` call will actually
+/// dispatch. Falls back to the ctrl-only resolvers if the lookup fails
+/// (e.g. a persona whose TOML was deleted after activation).
+/// What: Returns `(agent_name, model_id, runner_kind)`.
+fn resolve_endpoint_agent(repl: &crate::repl::TrustyAgentsRepl) -> (String, String, RunnerKind) {
+    let agent_name = repl
+        .active_persona
+        .clone()
+        .unwrap_or_else(|| "ctrl".to_string());
+
+    let mut dirs = vec![repl.agents_dir.clone()];
+    if let Some(home) = dirs::home_dir() {
+        let home_dir = home.join(".trusty-agents").join("agents");
+        if home_dir != repl.agents_dir {
+            dirs.push(home_dir);
+        }
     }
+
+    match crate::agents::AgentConfig::by_name_in(&dirs, &agent_name) {
+        Ok(cfg) => (agent_name, cfg.agent.model.clone(), cfg.agent.runner),
+        Err(_) => (
+            agent_name,
+            repl.resolve_active_model(),
+            repl.resolve_active_runner(),
+        ),
+    }
+}
+
+/// Which credential source `run_plain_cli`'s startup banner resolved, so an
+/// SSH tester can see at a glance which auth path a message will use.
+///
+/// Why (#3407): the previous implementation read `std::env::var(...)`
+/// directly, so a credential configured ONLY via the secure keystore
+/// (`tagent config keys set`, never exported to the shell) showed as "none
+/// configured" even though dispatch would resolve and use it fine. Routes
+/// through the same `pick_credentials` resolver the TUI's own startup
+/// banner uses (`repl/run.rs`), which checks env → `.env.local` → the store.
+fn resolved_credential_label(runner: RunnerKind) -> &'static str {
+    crate::llm::credentials::pick_credentials(Some(runner))
+        .map(|c| c.label())
+        .unwrap_or("none")
 }

--- a/crates/trusty-agents/src/runtime/cli_def.rs
+++ b/crates/trusty-agents/src/runtime/cli_def.rs
@@ -187,6 +187,15 @@ pub(super) struct Cli {
     #[arg(long)]
     pub(super) ctrl: bool,
 
+    /// #3052: Force the persistent plain-line REPL instead of the ratatui
+    /// full-screen TUI, even when stdin is a TTY. Intended for SSH / narrow
+    /// terminals (e.g. Terminus on iPhone) where the alt-screen TUI reflows
+    /// badly and modal pickers can swallow keystrokes. Equivalent to setting
+    /// `TAGENT_NO_TUI=1`. Bare `trusty-agents` (neither flag nor env set)
+    /// keeps launching the TUI unchanged.
+    #[arg(long)]
+    pub(super) plain: bool,
+
     /// Run the Telegram bot gateway (#264). Requires `TELEGRAM_BOT_TOKEN`.
     ///
     /// Headless/server mode: takes over the process and runs only the bot.
@@ -327,6 +336,26 @@ pub(super) fn check_credentials_and_warn() {
     eprintln!();
 }
 
+/// Decide whether an interactive TTY invocation should be forced into the
+/// persistent plain-line CLI mode (`ctrl::run_plain_cli`) instead of the
+/// ratatui full-screen TUI (#3052).
+///
+/// Why: The decision has two independent triggers — the `--plain` clap flag
+/// and the `TAGENT_NO_TUI=1` env var — and `dispatch_cli_mode` needs to check
+/// it before the existing `repl::is_tty()` branch so it wins regardless of
+/// terminal detection. Extracted as a pure function (rather than inlined at
+/// the call site) so the decision matrix is unit-testable without spinning up
+/// a real CLI/TTY/process.
+/// What: `true` when `plain_flag` is set OR `no_tui_env` is exactly `"1"`.
+/// Any other env value (unset, empty, `"0"`, `"true"`, …) is treated as
+/// not-set, matching the literal `TAGENT_NO_TUI=1` convention documented on
+/// the `--plain` flag and in the crate README.
+/// Test: `should_force_plain_cli_flag_alone`, `_env_alone`, `_neither`,
+/// `_env_zero_is_not_forced`.
+pub(super) fn should_force_plain_cli(plain_flag: bool, no_tui_env: Option<String>) -> bool {
+    plain_flag || no_tui_env.as_deref() == Some("1")
+}
+
 /// Concatenate non-flag positional args into a single task string.
 ///
 /// Why: When the user runs `trusty-agents "say hi"` (or `trusty-agents say hi`), we
@@ -343,4 +372,43 @@ pub(super) fn argv_as_task_text(args: &[String]) -> String {
         .cloned()
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_force_plain_cli;
+
+    #[test]
+    fn should_force_plain_cli_flag_alone() {
+        assert!(should_force_plain_cli(true, None));
+    }
+
+    #[test]
+    fn should_force_plain_cli_env_alone() {
+        assert!(should_force_plain_cli(false, Some("1".to_string())));
+    }
+
+    #[test]
+    fn should_force_plain_cli_neither() {
+        assert!(!should_force_plain_cli(false, None));
+    }
+
+    #[test]
+    fn should_force_plain_cli_env_zero_is_not_forced() {
+        assert!(!should_force_plain_cli(false, Some("0".to_string())));
+    }
+
+    #[test]
+    fn should_force_plain_cli_env_garbage_is_not_forced() {
+        assert!(!should_force_plain_cli(false, Some("true".to_string())));
+    }
+
+    #[test]
+    fn should_force_plain_cli_bare_no_flags_matches_default_dispatch() {
+        // Bare `trusty-agents` — neither the clap flag parsed nor the env var
+        // set — must NOT force plain mode, so the existing
+        // is_tty()-vs-piped-loop dispatch branch is unchanged (no regression
+        // for desktop TUI users).
+        assert!(!should_force_plain_cli(false, None));
+    }
 }

--- a/crates/trusty-agents/src/runtime/mode_dispatch.rs
+++ b/crates/trusty-agents/src/runtime/mode_dispatch.rs
@@ -393,6 +393,16 @@ pub(super) async fn dispatch_cli_mode(
         }
     }
 
+    // #3052: `--plain` / `TAGENT_NO_TUI=1` forces the persistent plain-line
+    // REPL (`ctrl::run_plain_cli`) instead of the ratatui full-screen TUI,
+    // even when stdin is a TTY — the SSH / narrow-terminal case. Checked
+    // BEFORE the `is_tty()` branch below so it wins regardless of terminal
+    // detection; bare `trusty-agents` (neither set) falls through unchanged
+    // to the existing TUI-vs-piped-loop dispatch.
+    if super::cli_def::should_force_plain_cli(cli.plain, std::env::var("TAGENT_NO_TUI").ok()) {
+        return ctrl::run_plain_cli().await;
+    }
+
     // Default interactive mode: use the rich reedline REPL when stdin is a
     // TTY; fall back to the legacy stdin loop in `run_ctrl` otherwise so
     // piped input keeps working unchanged.

--- a/crates/trusty-agents/tests/plain_cli_repl.rs
+++ b/crates/trusty-agents/tests/plain_cli_repl.rs
@@ -1,0 +1,157 @@
+//! Piped-stdin integration test for the persistent plain-line CLI mode
+//! (`--plain` / `TAGENT_NO_TUI=1`, #3052).
+//!
+//! Why: `--plain` exists so testers can drive `tagent` over SSH from a
+//! narrow terminal (Terminus/iPhone) without the ratatui full-screen TUI,
+//! which reflows badly and has a modal keystroke-swallow bug. The only way
+//! to prove the persistent line loop actually stays resident, dispatches
+//! slash commands, and exits cleanly is to drive the REAL compiled binary
+//! with piped stdin — an in-process unit test can't observe the stdin/stdout
+//! loop in `ctrl::run_plain_cli`. Mirrors the `CARGO_BIN_EXE_tagent` pattern
+//! already used by `tests/config_mount.rs`.
+//! What: Spawns `tagent --plain` (and separately with `TAGENT_NO_TUI=1` and
+//! no flag) with `TAGENT_NONINTERACTIVE=1` so the first-run profile
+//! interview is skipped deterministically, feeds `"/help\n/quit\n"` on
+//! stdin, and asserts the process printed the `you>` prompt + help text and
+//! exited 0 within a bounded wait. No free-text chat line is sent, so the
+//! test needs no LLM credential and never depends on network access —
+//! satisfying the "don't make CI depend on a key" requirement.
+//! Test: this file IS the test.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+/// Absolute path to the freshly built `tagent` binary (Cargo sets this for
+/// integration tests that share a package with a `[[bin]]` target).
+const BIN: &str = env!("CARGO_BIN_EXE_tagent");
+
+/// Bound on how long we'll wait for the child to exit. `/quit` after `/help`
+/// itself returns in well under a second, but `tagent`'s startup path spawns
+/// background MCP plugin handshakes and a tmux-backed session monitor shared
+/// with every other interactive mode (TUI included) — under a fully loaded
+/// `cargo test -p trusty-agents` run (thousands of unit tests plus several
+/// other subprocess-spawning integration tests competing for CPU) that
+/// startup can legitimately take tens of seconds. 120s leaves headroom for
+/// that contention while still failing (rather than hanging the suite
+/// forever) if a real regression makes the loop stop reading stdin or exit.
+const WAIT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Spawn `tagent` with `extra_args`/`extra_env`, write `stdin_input`, close
+/// stdin (EOF), and return `(exit_status, stdout, stderr)` once the process
+/// exits or the timeout elapses (whichever comes first — panics on timeout).
+///
+/// Runs with `current_dir` pinned to a fresh, isolated tempdir. Why: `tagent`
+/// unconditionally bumps a persistent `.trusty-agents/state/build.json`
+/// counter at startup (`runtime::startup::run_startup_init`), resolved via
+/// `ctrl::detect_self_project()`'s cwd walk-up. Without isolation, every
+/// spawned process in this file (and every OTHER integration test binary
+/// that also spawns the real binary, all running concurrently under `cargo
+/// test`) would race to rename the SAME `build.json.tmp` in the shared crate
+/// root, which is an unrelated pre-existing non-atomicity this test doesn't
+/// need to depend on. A cwd with no `.trusty-agents/agents/pm.toml` (and no
+/// such ancestor) makes `detect_self_project()` return `None`, so startup
+/// falls back to `std::env::current_dir()` — the private tempdir — for its
+/// state directory instead.
+fn run_piped(
+    extra_args: &[&str],
+    extra_env: &[(&str, &str)],
+    stdin_input: &str,
+) -> (bool, String, String) {
+    let isolated_cwd = tempfile::tempdir().expect("create isolated tempdir for tagent cwd");
+
+    let mut cmd = Command::new(BIN);
+    cmd.args(extra_args)
+        .current_dir(isolated_cwd.path())
+        // Deterministic: skip the interactive first-run profile interview,
+        // which would otherwise consume lines meant for the REPL loop.
+        .env("TAGENT_NONINTERACTIVE", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+
+    let mut child = cmd.spawn().expect("spawn tagent");
+    {
+        let mut stdin = child.stdin.take().expect("child stdin was piped");
+        stdin
+            .write_all(stdin_input.as_bytes())
+            .expect("write stdin");
+        // `stdin` drops here, closing the pipe (EOF) if the loop doesn't
+        // exit via `/quit` first.
+    }
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let out = child.wait_with_output();
+        let _ = tx.send(out);
+    });
+    let out = rx
+        .recv_timeout(WAIT_TIMEOUT)
+        .unwrap_or_else(|_| {
+            panic!("tagent did not exit within {WAIT_TIMEOUT:?} (hang regression?)")
+        })
+        .expect("wait_with_output failed");
+
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn plain_flag_stays_resident_and_exits_cleanly_on_quit() {
+    let (success, stdout, stderr) = run_piped(&["--plain"], &[], "/help\n/quit\n");
+    assert!(
+        success,
+        "tagent --plain should exit 0 on /quit; stderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("you> "),
+        "plain CLI should print the `you> ` prompt each turn; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("trusty-agents REPL — slash commands"),
+        "/help should print the shared slash-command reference; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("/model") && stdout.contains("/provider"),
+        "/help output should advertise /model and /provider; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("resolved agent endpoint"),
+        "startup banner should show the resolved agent endpoint; got:\n{stdout}"
+    );
+    // No ratatui alt-screen escape sequence should ever appear in plain mode.
+    assert!(
+        !stdout.contains("\x1b[?1049h"),
+        "plain CLI must never enter the alt-screen; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn no_tui_env_forces_plain_mode_without_the_flag() {
+    // Same behavior via TAGENT_NO_TUI=1 with no --plain flag — proves the
+    // env var alone is sufficient to bypass the TUI.
+    let (success, stdout, stderr) = run_piped(&[], &[("TAGENT_NO_TUI", "1")], "/quit\n");
+    assert!(
+        success,
+        "TAGENT_NO_TUI=1 tagent should exit 0 on /quit; stderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("you> "),
+        "TAGENT_NO_TUI=1 should route into the plain line loop; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn quit_command_stops_the_loop_immediately() {
+    // A single `/quit` (no `/help` first) should be enough to exit — proves
+    // the loop doesn't require a specific command sequence to terminate.
+    let (success, stdout, stderr) = run_piped(&["--plain"], &[], "/quit\n");
+    assert!(success, "a bare /quit should exit 0; stderr:\n{stderr}");
+    assert!(stdout.contains("you> "), "got:\n{stdout}");
+}

--- a/crates/trusty-agents/tests/plain_cli_repl.rs
+++ b/crates/trusty-agents/tests/plain_cli_repl.rs
@@ -19,6 +19,7 @@
 //! Test: this file IS the test.
 
 use std::io::Write;
+use std::path::Path;
 use std::process::{Command, Stdio};
 use std::time::Duration;
 
@@ -58,7 +59,21 @@ fn run_piped(
     extra_env: &[(&str, &str)],
     stdin_input: &str,
 ) -> (bool, String, String) {
+    run_piped_with_setup(extra_args, extra_env, stdin_input, |_| {})
+}
+
+/// Same as [`run_piped`], but calls `setup(tempdir_path)` after creating the
+/// isolated cwd and before spawning — lets a test seed fixture files (e.g. a
+/// minimal `assistant.toml`) into the isolated project without touching the
+/// real crate-root `.trusty-agents/`.
+fn run_piped_with_setup(
+    extra_args: &[&str],
+    extra_env: &[(&str, &str)],
+    stdin_input: &str,
+    setup: impl FnOnce(&Path),
+) -> (bool, String, String) {
     let isolated_cwd = tempfile::tempdir().expect("create isolated tempdir for tagent cwd");
+    setup(isolated_cwd.path());
 
     let mut cmd = Command::new(BIN);
     cmd.args(extra_args)
@@ -154,4 +169,82 @@ fn quit_command_stops_the_loop_immediately() {
     let (success, stdout, stderr) = run_piped(&["--plain"], &[], "/quit\n");
     assert!(success, "a bare /quit should exit 0; stderr:\n{stderr}");
     assert!(stdout.contains("you> "), "got:\n{stdout}");
+}
+
+/// Seed an isolated project's `.trusty-agents/agents/assistant.toml` with a
+/// minimal, deterministic fixture — a distinctive `model` id so the
+/// assertion doesn't depend on (or drift with) the real bundled
+/// `assistant/agent.toml`'s actual model.
+fn seed_fixture_assistant_agent(project_root: &Path) {
+    let agents_dir = project_root.join(".trusty-agents").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("create fixture agents dir");
+    std::fs::write(
+        agents_dir.join("assistant.toml"),
+        "[agent]\n\
+         name = \"assistant\"\n\
+         role = \"assistant\"\n\
+         model = \"test-vendor/test-opus-fixture\"\n\
+         description = \"fixture assistant persona for plain-CLI default test\"\n\
+         \n\
+         [llm]\n\
+         temperature = 0.7\n\
+         max_tokens = 4096\n\
+         \n\
+         [system_prompt]\n\
+         content = \"You are a fixture assistant persona used only by an automated test.\"\n",
+    )
+    .expect("write fixture assistant.toml");
+}
+
+#[test]
+fn plain_cli_defaults_active_agent_to_assistant_not_ctrl() {
+    // Owner decision (#3406 follow-up): the plain CLI's out-of-the-box
+    // conversational agent must be `assistant` (what testers actually
+    // exercise), not `ctrl` (the local-ollama machine-coordination
+    // persona) — even though `TrustyAgentsRepl::new` itself still
+    // constructs with `project_name = "ctrl"` / `active_persona = None`.
+    let (success, stdout, stderr) =
+        run_piped_with_setup(&["--plain"], &[], "/quit\n", seed_fixture_assistant_agent);
+    assert!(success, "should exit 0 on /quit; stderr:\n{stderr}");
+    assert!(
+        stdout.contains("Switched to: assistant"),
+        "startup should default-switch to the assistant persona; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(
+            "resolved agent endpoint: agent=assistant model=test-vendor/test-opus-fixture"
+        ),
+        "resolved agent endpoint banner should report agent=assistant with the assistant's \
+         actual model (not ctrl's); got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("agent=ctrl"),
+        "default agent must not be ctrl; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn switch_ctrl_still_reaches_the_ctrl_coordinator() {
+    // `ctrl` must remain fully reachable via `/switch ctrl` — defaulting to
+    // `assistant` changes the DEFAULT, not ctrl's availability. `/switch
+    // ctrl` doesn't need an agent-config lookup (it's special-cased to clear
+    // `active_persona` and reset `project_name` to "ctrl"), so no fixture
+    // seeding is needed here. `/connect` (TM-session coordination, not the
+    // controller-socket path) is exercised separately by the live manual
+    // transcript in the PR description — it doesn't need a real project
+    // fixture to prove the slash routes correctly here.
+    let (success, stdout, stderr) = run_piped(&["--plain"], &[], "/switch ctrl\n/connect\n/quit\n");
+    assert!(success, "should exit 0 on /quit; stderr:\n{stderr}");
+    assert!(
+        stdout.contains("Switched to: ctrl"),
+        "/switch ctrl should report switching back to ctrl; got:\n{stdout}"
+    );
+    // `/connect` with no args prints its usage line — proves the
+    // machine-coordination slash command is still routed/reachable (not
+    // shadowed or broken by the default-persona change), independent of
+    // whether a real project path is supplied.
+    assert!(
+        stdout.contains("usage: /connect"),
+        "/connect should still be reachable as a slash command; got:\n{stdout}"
+    );
 }


### PR DESCRIPTION
## Summary

- Adds `--plain` (clap) and `TAGENT_NO_TUI=1` (env) to force a persistent, readline-style plain-line REPL instead of the ratatui full-screen TUI — no alt-screen, no raw mode — even when stdin is a TTY. Intended for SSH / narrow terminals (e.g. Terminus on iPhone), where the full-screen TUI reflows badly and has a modal keystroke-swallow bug in its `/model`/`/provider` pickers.
- Free text and slash commands (`/help`, `/model`, `/provider`, `/switch`, `/clear`, `/quit`/`/exit`, …) route through `TrustyAgentsRepl::try_handle_slash` + `attempt_forward` — the exact same dispatch the TUI's submit path uses (`run_pm_task_with_persona` / `run_pm_task_with_history` with session overrides applied) — so agent/model routing is identical, not a parallel implementation. Bypassing `ReplBridge` (the TUI's picker layer) means `/model`/`/provider` with no argument print their list as plain text instead of opening a modal.
- **Owner decision**: `--plain`'s out-of-the-box conversational agent now defaults to `assistant` (Opus) instead of `ctrl` (the local-ollama machine-coordination persona) — the thing testers actually exercise. Implemented by issuing `/switch assistant` at startup (the exact mechanism a user typing that command triggers, not a new path). `ctrl` remains one `/switch ctrl` away, and machine-coordination commands (`/connect`, `/status`, controller socket) are untouched.
- Bare `tagent` (neither flag nor env set) is unregressed: the new check runs before the existing `is_tty()` TUI-vs-piped-loop dispatch and is a pure no-op when unset (see `should_force_plain_cli` unit tests). **The bare-TUI default was intentionally left unchanged** — see "Scope decision" below.
- Fixes code-critic MEDIUM #3407: the startup credential-banner label used to read raw `std::env::var(...)`, so a credential configured only via the secure keystore (`tagent config keys set`) showed as "none configured". Now resolves via `crate::llm::credentials::pick_credentials`, mirroring the TUI's own startup banner (`repl/run.rs`).
- Does not touch `repl/tui/*` at all — stays in `mode_dispatch.rs`, `cli_def.rs`, and `ctrl/repl/plain_cli.rs` (split out of `ctrl/repl/mod.rs` to respect the 500-SLOC production cap).

Closes #3405. Closes #3407. Part of epic #3052.

## Scope decision: CLI-only default, not CLI+TUI

The owner asked to flip the bare-TUI default to `assistant` too, IF it could be done cleanly without risking the `ctrl` coordination entrypoint. I scoped this to `--plain` only:

- `TrustyAgentsRepl::new()` (shared by both `--plain` and the TUI) hardcodes `project_name = "ctrl"` / `active_persona = None` at construction. Flipping the constructor's default would change both surfaces at once, which sounds appealing, but:
- The TUI's own startup banner/statusline (`repl/run.rs`, `banner.rs`, `statusline.rs`, `status_bar.rs`) computes the displayed model via `resolve_active_model()`/`resolve_active_runner()` **before** any persona switch, and those resolvers only ever consult `ctrl.toml`/`pm.toml` — they are not persona-aware. My `--plain` banner works around this with a small `resolve_endpoint_agent` helper (looks up the active persona via `AgentConfig::by_name_in`, same as `/agent`/`/switch`), but that same fix would need to be threaded through the TUI's ratatui rendering path to avoid a display bug (banner still shows "ctrl"/haiku even though dispatch is actually routing to "assistant"/opus) — real surgery in shared TUI-adjacent rendering files, not a small change, and I can't visually verify a ratatui alt-screen render in this sandbox (no real PTY).
- `--plain` is brand new (this PR), so changing its default is zero-risk to existing workflows. The bare TUI is an existing, widely-used entrypoint some workflows may rely on staying `ctrl`-first.

Recommend flipping the TUI default as a separate, deliberately-scoped follow-up (with real-terminal verification) once someone wants it.

## Live transcripts (real OpenRouter call, from `crates/trusty-agents/`)

Default persona is now assistant / Opus, credential resolves correctly (not "none configured", not claude-code):
```
$ printf 'hi\n/quit\n' | TAGENT_NONINTERACTIVE=1 ../../target/debug/tagent --plain
[trusty-agents] Switched to: assistant
trusty-agents v0.38.6 (f495dc6e) — plain CLI mode (no TUI)
type /help for commands, /quit or /exit to leave

resolved agent endpoint: agent=assistant model=claude-opus-4-6 runner=Subprocess credential=openrouter

you> Hey! What can I help you with?
[TIMING] responded in 2.08s
you> Bye.
```
Server log: `run_pm_task_with_persona: credentials resolved persona=assistant agent=assistant runner=Subprocess model=anthropic/claude-opus-4-6 creds="openrouter"`.

`/switch ctrl` still reaches ctrl / local ollama:
```
$ printf '/switch ctrl\nwhat model are you?\n/quit\n' | TAGENT_NONINTERACTIVE=1 ../../target/debug/tagent --plain
[trusty-agents] Switched to: assistant
you> [trusty-agents] Switched to: ctrl
you> [TIMING] responded in 3.86s
you> Bye.
```
Server log: `run_pm_task_with_persona: credentials resolved persona=ctrl agent=ctrl runner=Subprocess model=ollama/qwen3:30b creds="openrouter"`.

`/connect` (machine-coordination, TM-session path) still reachable:
```
$ printf '/connect\n/quit\n' | TAGENT_NONINTERACTIVE=1 ../../target/debug/tagent --plain
you> usage: /connect <path> <adapter> [name]
  adapters: claude-mpm, claude-code, codex, augment, gemini, trusty-agents, shell
you> Bye.
```

Bare `tagent` (no flag, piped stdin, no env) confirmed unregressed — still the legacy `run_ctrl` loop:
```
$ printf '/quit\n' | tagent
trusty-agents v0.38.6 (6834de3f) CTRL — machine-level coordination
CTRL> Shutting down...
```

## Gate evidence

- `cargo check -p trusty-agents` — clean.
- `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean.
- `cargo test -p trusty-agents` — 1968 lib tests + all integration tests pass (`plain_cli_repl.rs`: 5/5, including the new `plain_cli_defaults_active_agent_to_assistant_not_ctrl` and `switch_ctrl_still_reaches_the_ctrl_coordinator`).
- `cargo fmt -p trusty-agents --check` — clean.
- `bash scripts/check_line_cap.sh` — `line-cap: 7 allowlisted, 0 violations — OK.`
- `crates/trusty-search/ui-dist/` build churn discarded before each commit.
- Rebased cleanly onto `origin/main` (post #3404, the `/model`/`/provider` picker-swallow fix in `repl/tui/*`) — no conflicts, since this PR never touches `repl/tui/*`.

## Test plan

- [x] `should_force_plain_cli_*` unit tests cover the flag/env decision matrix.
- [x] `tests/plain_cli_repl.rs` piped-stdin integration tests (5): persistence + `/help` + no-alt-screen + clean exit; `TAGENT_NO_TUI=1` routing; bare `/quit`; **default active agent is `assistant` not `ctrl`** (seeded fixture agent so the assertion doesn't depend on the real bundled TOML's model drifting); **`/switch ctrl` still reaches ctrl and `/connect` is still reachable**.
- [x] Live manual transcripts above (assistant/opus default, `/switch ctrl` back to ollama, `/connect` usage, bare-`tagent` unregressed).