### PR TITLE
feat(trusty-search): server-side path/repo search scoping, applied pre-truncation (closes #3401)

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- `BM25Index::score_query_all_with_filter` — same ranking as `score_query_all`,
+  but evaluates a caller-supplied `Fn(&str) -> bool` predicate on each
+  candidate `doc_id` BEFORE the internal `top_k` truncation, not after
+  (trusty-search issue #3401: a scope filter applied only on the already-
+  truncated result set can silently drop a genuinely matching, lexically
+  relevant document). Purely additive — `score_query_all`'s signature and
+  behaviour are unchanged, so existing callers (`trusty-bm25-daemon`) are
+  unaffected.
+
 ## [0.23.4] — 2026-07-19
 
 ### Added

--- a/crates/trusty-common/src/bm25.rs
+++ b/crates/trusty-common/src/bm25.rs
@@ -391,6 +391,48 @@ impl BM25Index {
     /// This is the production search entry point. Cost is `O(sum(df_i))`
     /// over query terms — independent of total corpus size.
     pub fn score_query_all(&self, query: &str, top_k: usize) -> Vec<(String, f32)> {
+        self.score_query_all_filtered(query, top_k, None)
+    }
+
+    /// Same as [`Self::score_query_all`], but `filter` is evaluated on each
+    /// candidate `doc_id` BEFORE the `top_k` truncation (issue #3401 —
+    /// trusty-tools).
+    ///
+    /// Why: a caller-supplied scope filter (e.g. a repo/path prefix) must not
+    /// lose recall to `top_k` — a document that genuinely matches the scope
+    /// AND has real lexical overlap with the query can rank outside the
+    /// unscoped top `top_k` and still need to surface once scoped. Applying
+    /// `filter` naively AFTER this function returns cannot recover such a
+    /// document, because it was already discarded by the internal
+    /// `truncate(top_k)`. Evaluating it in the same pass, before truncation,
+    /// fixes that — `filter` only has to reject candidates, so the touched-set
+    /// cost model (`O(sum(df_i))` over query terms) is unchanged.
+    /// What: identical BM25 scoring pass as `score_query_all`; the one
+    /// difference is a `filter(|(id, _)| filter(id))` step inserted between
+    /// resolving `doc_id`s and truncating.
+    /// Test: `trusty-search::core::indexer::tests::path_filter_search::
+    /// test_path_prefix_filter_recovers_bm25_match_beyond_want` exercises this
+    /// through the full search pipeline with a target chunk that DOES share
+    /// query tokens and is one of more than `want` matching documents.
+    pub fn score_query_all_with_filter(
+        &self,
+        query: &str,
+        top_k: usize,
+        filter: &dyn Fn(&str) -> bool,
+    ) -> Vec<(String, f32)> {
+        self.score_query_all_filtered(query, top_k, Some(filter))
+    }
+
+    /// Shared scoring pass behind [`Self::score_query_all`] and
+    /// [`Self::score_query_all_with_filter`]. `filter`, when present, is
+    /// applied before the `top_k` truncation — see the doc comment on
+    /// `score_query_all_with_filter` for why that ordering matters.
+    fn score_query_all_filtered(
+        &self,
+        query: &str,
+        top_k: usize,
+        filter: Option<&dyn Fn(&str) -> bool>,
+    ) -> Vec<(String, f32)> {
         if self.live_docs == 0 || top_k == 0 {
             return Vec::new();
         }
@@ -430,6 +472,9 @@ impl BM25Index {
                     .and_then(|o| o.clone())
                     .map(|id| (id, score))
             })
+            // Issue #3401: scope filter applied BEFORE truncation — see
+            // `score_query_all_with_filter`'s doc comment.
+            .filter(|(id, _)| filter.is_none_or(|f| f(id.as_str())))
             .collect();
         scored.sort_by(|a, b| {
             b.1.partial_cmp(&a.1)
@@ -601,6 +646,44 @@ mod tests {
         let unique = ids.len();
         ids.dedup();
         assert_eq!(unique, ids.len());
+    }
+
+    /// Pins the pre-truncation guarantee `score_query_all_with_filter` exists
+    /// for (issue #3401, trusty-tools): the filter must be evaluated BEFORE
+    /// `top_k` truncation, not after, so a document that genuinely matches
+    /// the filter — and has real lexical overlap with the query — is never
+    /// lost just because it ranks outside the UNFILTERED top `top_k`.
+    #[test]
+    fn score_query_all_with_filter_recovers_match_beyond_top_k() {
+        let mut idx = BM25Index::new();
+        // 5 filler docs with higher term frequency (all outrank the target).
+        for i in 0..5 {
+            idx.upsert_document(&format!("filler{i}"), "rust rust rust async");
+        }
+        // The target: real overlap, but lower term frequency, so it ranks
+        // last among the 6 matching documents.
+        idx.upsert_document("target", "rust async");
+
+        // Precondition: unfiltered top_k=3 never returns "target" — it
+        // genuinely ranks below the cutoff.
+        let unfiltered = idx.score_query_all("rust async", 3);
+        assert_eq!(unfiltered.len(), 3);
+        assert!(
+            unfiltered.iter().all(|(id, _)| id != "target"),
+            "precondition failed: target must rank below top_k=3 unfiltered; \
+             got {unfiltered:?}"
+        );
+
+        // A naive "filter after the call" can't recover it — it was already
+        // discarded by the internal `truncate(3)`. The filter-aware entry
+        // point must, because it evaluates the filter BEFORE truncation.
+        let filtered = idx.score_query_all_with_filter("rust async", 3, &|id: &str| id == "target");
+        assert_eq!(
+            filtered.len(),
+            1,
+            "the filter admits only \"target\" — it must be the one result: {filtered:?}"
+        );
+        assert_eq!(filtered[0].0, "target");
     }
 
     #[test]

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -25,24 +25,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   for network-mounted and build/serve-split deployments, with a worked example —
   see `README.md` and `CLAUDE.md`'s endpoint catalogue.
 - Server-side `path_prefix` / `repos` search scoping, applied during candidate
-  selection BEFORE `top_k` truncation in every retrieval lane (closes #3401).
-  Lets consumers scope a query to a repo/path subtree within the single
-  unified index instead of building a separate physical index per repo.
-  **Recall guarantee:** the vector/HNSW lane ships the fully recall-safe
-  design directly (no over-fetch approximation) — the filter predicate is
-  pushed INTO the HNSW graph traversal itself via
-  `usearch::Index::filtered_search` (already available in the pinned usearch
-  2.25), so a chunk matching the filter is found regardless of how it ranks
-  by raw, unscoped similarity. BM25/lexical and KG-expansion hits are
-  filtered on the candidate id (which always encodes the file path) before
-  fusion/truncation, for the same guarantee. Surfaced on `SearchQuery`
-  (HTTP `/indexes/:id/search`, the fan-out `POST /search`'s
-  `GlobalSearchRequest`) and the MCP `search` / `search_lexical` /
+  selection BEFORE `top_k` truncation in every retrieval lane — vector/HNSW,
+  BM25/lexical, grep-fallback, and KG expansion (closes #3401). Lets
+  consumers scope a query to a repo/path subtree within the single unified
+  index instead of building a separate physical index per repo.
+  **Recall guarantee:** the vector/HNSW lane pushes the filter predicate
+  directly INTO HNSW graph traversal via `usearch::Index::filtered_search`
+  (already available in the pinned usearch 2.25) — no over-fetch
+  approximation, though a highly selective filter does mean real added
+  traversal latency, since the search visits more of the graph to find
+  `top_k` passing candidates. BM25 gets a new `Bm25Index::
+  score_query_all_with_filter` (trusty-common, additive — existing callers
+  are unaffected) that evaluates the filter before its internal `top_k`
+  truncate, not after; grep-fallback evaluates it before its early-exit
+  cutoff. `path_prefix` matches at a path-segment boundary (so `"foo"`
+  cannot also match a sibling `"foobar"` directory) and is normalized
+  against the index's `root_path`, so a caller can pass either the
+  root-relative or the absolute form (`CodeChunk::file` in results is always
+  absolute). Surfaced on `SearchQuery` (HTTP `/indexes/:id/search`) and the
+  fan-out `POST /search`'s `GlobalSearchRequest` — both now reject unknown
+  fields (`deny_unknown_fields`), and the MCP `search` / `search_lexical` /
   `search_semantic` / `search_kg` / `search_all` tool schemas. Composes with
   `exclude_archived` and the branch fields (`branch`/`branch_files`/`branch_boost`).
-  `SearchQuery` now also rejects unknown fields (`deny_unknown_fields`) — a
-  silently-ignored misspelled filter field would otherwise return too much
-  data, the exact correctness trap that motivated this issue.
 
 ## [0.35.0] — 2026-07-19
 

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -24,6 +24,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   / `remove_file` MCP equivalents) as the supported incremental-indexing path
   for network-mounted and build/serve-split deployments, with a worked example —
   see `README.md` and `CLAUDE.md`'s endpoint catalogue.
+- Server-side `path_prefix` / `repos` search scoping, applied during candidate
+  selection BEFORE `top_k` truncation in every retrieval lane (closes #3401).
+  Lets consumers scope a query to a repo/path subtree within the single
+  unified index instead of building a separate physical index per repo.
+  **Recall guarantee:** the vector/HNSW lane ships the fully recall-safe
+  design directly (no over-fetch approximation) — the filter predicate is
+  pushed INTO the HNSW graph traversal itself via
+  `usearch::Index::filtered_search` (already available in the pinned usearch
+  2.25), so a chunk matching the filter is found regardless of how it ranks
+  by raw, unscoped similarity. BM25/lexical and KG-expansion hits are
+  filtered on the candidate id (which always encodes the file path) before
+  fusion/truncation, for the same guarantee. Surfaced on `SearchQuery`
+  (HTTP `/indexes/:id/search`, the fan-out `POST /search`'s
+  `GlobalSearchRequest`) and the MCP `search` / `search_lexical` /
+  `search_semantic` / `search_kg` / `search_all` tool schemas. Composes with
+  `exclude_archived` and the branch fields (`branch`/`branch_files`/`branch_boost`).
+  `SearchQuery` now also rejects unknown fields (`deny_unknown_fields`) — a
+  silently-ignored misspelled filter field would otherwise return too much
+  data, the exact correctness trap that motivated this issue.
 
 ## [0.35.0] — 2026-07-19
 

--- a/crates/trusty-search/src/core/indexer/search/lanes.rs
+++ b/crates/trusty-search/src/core/indexer/search/lanes.rs
@@ -172,18 +172,33 @@ impl CodeIndexer {
     /// silently degrading recall.
     /// What: rehydrates an idle-evicted or race-evicted BM25 corpus (issue
     /// #2162 / #2846), then acquires the BM25 read lock and runs
-    /// `score_query_all`. Retries up to [`REHYDRATE_RACE_RETRIES`] times only
-    /// when the race is detected; a genuinely empty BM25 index returns `Ok(vec![])`
-    /// on the first pass with no retry.
+    /// `score_query_all` (or, when `filter` is set, `score_query_all_with_filter`
+    /// — issue #3401: the path/repo scope predicate MUST be evaluated by BM25
+    /// itself before its internal `top_k` truncation, not applied by the
+    /// caller afterward, or a genuinely in-scope, lexically-matching document
+    /// ranked outside the unscoped top `want` would already be gone by the
+    /// time this function returns). Retries up to [`REHYDRATE_RACE_RETRIES`]
+    /// times only when the race is detected; a genuinely empty BM25 index
+    /// returns `Ok(vec![])` on the first pass with no retry.
     /// Test: BM25 results are covered by every search integration test;
     /// `bm25_search_survives_reclaim_race_between_ensure_and_read` in
-    /// `indexer::tests_idle_evict` pins the race-detection retry itself.
-    pub(super) async fn bm25_search(&self, query: &str, want: usize) -> Result<Vec<(String, f32)>> {
+    /// `indexer::tests_idle_evict` pins the race-detection retry itself;
+    /// `test_path_prefix_filter_recovers_bm25_match_beyond_want` in
+    /// `indexer::tests::path_filter_search` pins the pre-truncation filter.
+    pub(super) async fn bm25_search(
+        &self,
+        query: &str,
+        want: usize,
+        filter: Option<&(dyn Fn(&str) -> bool + Send + Sync)>,
+    ) -> Result<Vec<(String, f32)>> {
         for _ in 0..REHYDRATE_RACE_RETRIES {
             self.ensure_bm25_entities_loaded().await;
             let bm25 = self.bm25.read().await;
             if !bm25.is_empty() {
-                return Ok(bm25.score_query_all(query, want));
+                return Ok(match filter {
+                    Some(f) => bm25.score_query_all_with_filter(query, want, f),
+                    None => bm25.score_query_all(query, want),
+                });
             }
             if !self.bm25_entities_evicted.load(Ordering::Relaxed) {
                 return Ok(Vec::new());
@@ -222,6 +237,13 @@ impl CodeIndexer {
     /// Retries up to [`REHYDRATE_RACE_RETRIES`] times only when the race is
     /// detected (mirrors `bm25_search`'s flag-under-guard check); a
     /// genuinely-empty map returns immediately.
+    ///
+    /// Issue #3401: when `filter` is set, a chunk must ALSO pass it to count
+    /// toward the `out.len() >= want` early-exit. Counting an out-of-scope
+    /// match toward that cap would cut the scan short and silently drop
+    /// later in-scope matches — the same truncate-before-filter bug class as
+    /// `bm25_search`, just expressed as an early `break` instead of a
+    /// `Vec::truncate`.
     /// Test: `test_grep_fallback_returns_substring_hits` in `indexer::tests`;
     /// `grep_fallback_survives_reclaim_race_between_ensure_and_read` in
     /// `indexer::tests_idle_evict` pins the race-detection retry.
@@ -230,6 +252,7 @@ impl CodeIndexer {
         &self,
         query: &str,
         want: usize,
+        filter: Option<&(dyn Fn(&str) -> bool + Send + Sync)>,
     ) -> Vec<(String, f32)> {
         if query.is_empty() || want == 0 {
             return Vec::new();
@@ -247,11 +270,17 @@ impl CodeIndexer {
             }
             let mut out: Vec<(String, f32)> = Vec::new();
             for raw in chunks.values() {
-                if re.is_match(&raw.content) {
-                    out.push((raw.id.clone(), super::GREP_FALLBACK_SCORE));
-                    if out.len() >= want {
-                        break;
+                if !re.is_match(&raw.content) {
+                    continue;
+                }
+                if let Some(f) = filter {
+                    if !f(&raw.id) {
+                        continue;
                     }
+                }
+                out.push((raw.id.clone(), super::GREP_FALLBACK_SCORE));
+                if out.len() >= want {
+                    break;
                 }
             }
             return out;
@@ -296,15 +325,24 @@ impl CodeIndexer {
     /// itself via `VectorStore::search_filtered` (usearch's
     /// `Index::filtered_search`, which evaluates the predicate during graph
     /// exploration and keeps expanding until `want` matching candidates are
-    /// found or the graph is exhausted) — no recall loss, and no latency
-    /// tradeoff to calibrate.
+    /// found or the graph is exhausted) — no recall loss. This is NOT free:
+    /// a highly selective filter forces the traversal to visit far more of
+    /// the graph than an unfiltered `top_k` search would (verified against
+    /// vendored usearch 2.25.2's `filtered_search` C++ implementation,
+    /// `index.hpp`, which only stops on `top_limit` predicate-passing
+    /// candidates or frontier exhaustion) — real added latency under a very
+    /// narrow scope, traded deliberately for correctness.
     /// What: delegates to plain `store.search` when no filter is active
-    /// (identical behaviour/cost to today); otherwise builds a predicate
-    /// over the chunk id (see `path_filter` module docs for why testing the
-    /// id is safe here) and calls `store.search_filtered`.
-    /// Test: `test_vector_search_scoped_recovers_filtered_match_below_top_k`
-    /// in `indexer::tests`; `UsearchStore` predicate-pushdown itself is
-    /// covered by `store::tests::test_filtered_search_finds_match_ranked_below_top_k`.
+    /// (identical behaviour/cost to today); otherwise resolves the
+    /// root-relative `path_prefix` (`path_filter::normalized_path_prefix` —
+    /// callers may pass either a root-relative or an absolute-under-root
+    /// prefix, since `CodeChunk::file` in results is always absolute) and
+    /// calls `store.search_filtered` with a predicate over the chunk id (see
+    /// `path_filter` module docs for why testing the id is safe here).
+    /// Test: `test_path_prefix_filter_survives_top_k_truncation` in
+    /// `indexer::tests::path_filter_search`; `UsearchStore` predicate-pushdown
+    /// itself is covered by
+    /// `store::tests::test_filtered_search_finds_match_ranked_below_top_k`.
     pub(crate) async fn vector_search_scoped(
         &self,
         embedding: &[f32],
@@ -318,8 +356,9 @@ impl CodeIndexer {
             let hits = store.search(embedding, want).await?;
             return Ok(hits.into_iter().map(|h| (h.chunk_id, h.score)).collect());
         }
+        let normalized_prefix = path_filter::normalized_path_prefix(query, &self.root_path);
         let hits = store
-            .search_filtered(embedding, want, query.path_prefix.as_deref(), &query.repos)
+            .search_filtered(embedding, want, normalized_prefix.as_deref(), &query.repos)
             .await?;
         Ok(hits.into_iter().map(|h| (h.chunk_id, h.score)).collect())
     }

--- a/crates/trusty-search/src/core/indexer/search/lanes.rs
+++ b/crates/trusty-search/src/core/indexer/search/lanes.rs
@@ -17,7 +17,8 @@ use anyhow::{Context, Result};
 use crate::core::classifier::QueryIntent;
 use crate::core::entity::EdgeKind;
 
-use super::super::{hash_query, CodeIndexer};
+use super::super::{hash_query, CodeIndexer, SearchQuery};
+use super::path_filter;
 
 /// Bound on the ensure-then-read retry loop in [`CodeIndexer::bm25_search`] /
 /// [`CodeIndexer::grep_fallback_search`] (issue #2846 review).
@@ -281,6 +282,45 @@ impl CodeIndexer {
             return Ok(Vec::new());
         };
         let hits = store.search(embedding, want).await?;
+        Ok(hits.into_iter().map(|h| (h.chunk_id, h.score)).collect())
+    }
+
+    /// Path/repo-scoped HNSW lane (issue #3401).
+    ///
+    /// Why: a naive over-fetch-then-filter cannot guarantee recall for an
+    /// approximate-nearest-neighbour index — a chunk that genuinely matches
+    /// the path/repo filter can rank arbitrarily far outside the raw-cosine-
+    /// similarity `want` window HNSW would otherwise explore, and no amount
+    /// of `want` inflation removes that risk in general. Instead, when a
+    /// filter is active, this pushes the predicate INTO the HNSW traversal
+    /// itself via `VectorStore::search_filtered` (usearch's
+    /// `Index::filtered_search`, which evaluates the predicate during graph
+    /// exploration and keeps expanding until `want` matching candidates are
+    /// found or the graph is exhausted) — no recall loss, and no latency
+    /// tradeoff to calibrate.
+    /// What: delegates to plain `store.search` when no filter is active
+    /// (identical behaviour/cost to today); otherwise builds a predicate
+    /// over the chunk id (see `path_filter` module docs for why testing the
+    /// id is safe here) and calls `store.search_filtered`.
+    /// Test: `test_vector_search_scoped_recovers_filtered_match_below_top_k`
+    /// in `indexer::tests`; `UsearchStore` predicate-pushdown itself is
+    /// covered by `store::tests::test_filtered_search_finds_match_ranked_below_top_k`.
+    pub(crate) async fn vector_search_scoped(
+        &self,
+        embedding: &[f32],
+        want: usize,
+        query: &SearchQuery,
+    ) -> Result<Vec<(String, f32)>> {
+        let Some(store) = &self.store else {
+            return Ok(Vec::new());
+        };
+        if !path_filter::is_active(query) {
+            let hits = store.search(embedding, want).await?;
+            return Ok(hits.into_iter().map(|h| (h.chunk_id, h.score)).collect());
+        }
+        let hits = store
+            .search_filtered(embedding, want, query.path_prefix.as_deref(), &query.repos)
+            .await?;
         Ok(hits.into_iter().map(|h| (h.chunk_id, h.score)).collect())
     }
 

--- a/crates/trusty-search/src/core/indexer/search/lanes_tests.rs
+++ b/crates/trusty-search/src/core/indexer/search/lanes_tests.rs
@@ -83,7 +83,8 @@ async fn bm25_search_survives_reclaim_race_between_ensure_and_read() {
     let write_guard = idx.bm25.write().await;
 
     let idx_bg = Arc::clone(&idx);
-    let search_task = tokio::spawn(async move { idx_bg.bm25_search("authenticate", 5).await });
+    let search_task =
+        tokio::spawn(async move { idx_bg.bm25_search("authenticate", 5, None).await });
 
     let_background_task_reach_its_read_lock().await;
 
@@ -131,7 +132,7 @@ async fn grep_fallback_survives_reclaim_race_between_ensure_and_read() {
     let idx_bg = Arc::clone(&idx);
     let search_task = tokio::spawn(async move {
         idx_bg
-            .grep_fallback_search("authenticate_user_via_token", 5)
+            .grep_fallback_search("authenticate_user_via_token", 5, None)
             .await
     });
 

--- a/crates/trusty-search/src/core/indexer/search/mod.rs
+++ b/crates/trusty-search/src/core/indexer/search/mod.rs
@@ -211,8 +211,12 @@ impl CodeIndexer {
         // absolute (issue #402) — normalize once so a caller-supplied
         // absolute prefix (the form callers actually see) still matches.
         let normalized_prefix = path_filter::normalized_path_prefix(query, &self.root_path);
+        // BM25/grep candidates are chunk ids, not bare file paths — use
+        // `matches_id` (accepts the chunk-id suffix grammar), never
+        // `matches_file` (see `path_filter` module docs for why the two are
+        // not interchangeable).
         let path_pred =
-            |id: &str| path_filter::matches(id, normalized_prefix.as_deref(), &query.repos);
+            |id: &str| path_filter::matches_id(id, normalized_prefix.as_deref(), &query.repos);
         let filter: Option<&(dyn Fn(&str) -> bool + Send + Sync)> = if path_filter::is_active(query)
         {
             Some(&path_pred)
@@ -442,14 +446,21 @@ impl CodeIndexer {
         // kept — the existing materialize step would have skipped it anyway.
         // `path_prefix` is normalized against `root_path` here too (code
         // review HIGH finding) so this authoritative check applies the exact
-        // same scope as the per-lane admission predicates above.
+        // same scope as the per-lane admission predicates above. This
+        // candidate is `raw.file` — a bare file path, not a chunk id — so it
+        // MUST go through `matches_file`, never `matches_id` (see
+        // `path_filter` module docs: the two are not interchangeable).
         let candidates: Vec<(String, f32)> = if path_filter::is_active(query) {
             let normalized_prefix = path_filter::normalized_path_prefix(query, &self.root_path);
             candidates
                 .into_iter()
                 .filter(|(id, _)| {
                     chunks.get(id).is_some_and(|raw| {
-                        path_filter::matches(&raw.file, normalized_prefix.as_deref(), &query.repos)
+                        path_filter::matches_file(
+                            &raw.file,
+                            normalized_prefix.as_deref(),
+                            &query.repos,
+                        )
                     })
                 })
                 .collect()

--- a/crates/trusty-search/src/core/indexer/search/mod.rs
+++ b/crates/trusty-search/src/core/indexer/search/mod.rs
@@ -196,46 +196,51 @@ impl CodeIndexer {
 
         // 2) Run lanes (HNSW + BM25), then inject entity-exact-match.
         let want = query.top_k.saturating_mul(HNSW_OVERSAMPLE).max(query.top_k);
-        let bm25_fut = self.bm25_search(&query.text, want);
-        // Issue #3401: when a path/repo filter is active, the vector lane
-        // pushes the predicate into the HNSW traversal itself (see
-        // `vector_search_scoped` / `VectorStore::search_filtered`) rather
-        // than fetching raw-similarity top candidates and filtering after —
-        // the latter would silently lose recall for a chunk that only ranks
-        // highly once scoped to the filtered repo/path.
+        // Issue #3401: a single path/repo predicate, threaded into every lane
+        // BEFORE that lane's own internal truncation/early-exit — not applied
+        // as a `.retain()` afterward. `bm25_search` evaluates it inside
+        // `Bm25Index::score_query_all_with_filter` ahead of its
+        // `truncate(want)`; `grep_fallback_search` evaluates it ahead of its
+        // `out.len() >= want` early-break; the vector lane pushes it into HNSW
+        // traversal itself (`vector_search_scoped`). Filtering any of these
+        // AFTER the lane returns cannot recover a genuinely in-scope,
+        // otherwise-well-ranked candidate that the lane's own internal cutoff
+        // already discarded in favour of `want` out-of-scope hits.
+        // Issue #3401 code review HIGH finding: `path_prefix` is stored/
+        // compared root-relative, but `CodeChunk::file` in results is always
+        // absolute (issue #402) — normalize once so a caller-supplied
+        // absolute prefix (the form callers actually see) still matches.
+        let normalized_prefix = path_filter::normalized_path_prefix(query, &self.root_path);
+        let path_pred =
+            |id: &str| path_filter::matches(id, normalized_prefix.as_deref(), &query.repos);
+        let filter: Option<&(dyn Fn(&str) -> bool + Send + Sync)> = if path_filter::is_active(query)
+        {
+            Some(&path_pred)
+        } else {
+            None
+        };
+        let bm25_fut = self.bm25_search(&query.text, want, filter);
         let hnsw_results = match &embedding {
             Some(v) => self.vector_search_scoped(v, want, query).await?,
             None => Vec::new(),
         };
         let mut bm25_results = bm25_fut.await?;
-        // Issue #3401: retain in-scope BM25 hits BEFORE RRF fuse / MMR rerank
-        // (both of which truncate their working set to `want`). Without this,
-        // a query whose lexical lane returns `want` non-matching hits (a
-        // heavily-matched but out-of-scope filler, say) would crowd the
-        // correctly-found (predicate-pushed) vector-lane candidate out of the
-        // `want`-bounded fusion/MMR stages before `apply_score_adjustments`'s
-        // authoritative retain ever runs. Checking the id string (rather than
-        // fetching each candidate's `RawChunk`) is safe here — see the
-        // `path_filter` module docs for why a chunk id always begins with its
-        // literal file path.
-        if path_filter::is_active(query) {
-            bm25_results.retain(|(id, _)| path_filter::matches(id, query));
-        }
         self.inject_entity_exact_match(&intent, &query.text, beta, &mut bm25_results)
             .await;
+        // The entity-exact-match injection above resolves its hit via a
+        // direct name lookup (`entity_exact_match`), not through BM25's own
+        // filtered scoring path, so it can't have honoured `filter` itself —
+        // a cheap retain (at most one extra element) closes that gap.
         if path_filter::is_active(query) {
-            bm25_results.retain(|(id, _)| path_filter::matches(id, query));
+            bm25_results.retain(|(id, _)| path_pred(id));
         }
 
         // 2a) Issue #75: for Definition intent, run grep as a third RRF lane.
-        let mut grep_lane: Vec<(String, f32)> = if matches!(intent, QueryIntent::Definition) {
-            self.grep_fallback_search(&query.text, want).await
+        let grep_lane: Vec<(String, f32)> = if matches!(intent, QueryIntent::Definition) {
+            self.grep_fallback_search(&query.text, want, filter).await
         } else {
             Vec::new()
         };
-        if path_filter::is_active(query) {
-            grep_lane.retain(|(id, _)| path_filter::matches(id, query));
-        }
 
         // 3) RRF fuse, then MMR diversity pass.
         let fused_raw = rrf_fuse(&hnsw_results, &bm25_results, alpha, beta, RRF_K, want);
@@ -244,11 +249,7 @@ impl CodeIndexer {
         // 3a) Issue #75: empty-result fallback — scan chunk corpus for literal
         // substring match.
         let fused_raw = if fused_raw.is_empty() {
-            let mut fallback = self.grep_fallback_search(&query.text, want).await;
-            if path_filter::is_active(query) {
-                fallback.retain(|(id, _)| path_filter::matches(id, query));
-            }
-            fallback
+            self.grep_fallback_search(&query.text, want, filter).await
         } else {
             fused_raw
         };
@@ -439,13 +440,17 @@ impl CodeIndexer {
         // `materialize_search_results`). A candidate whose chunk failed to
         // resolve (race with a concurrent removal) is dropped rather than
         // kept — the existing materialize step would have skipped it anyway.
+        // `path_prefix` is normalized against `root_path` here too (code
+        // review HIGH finding) so this authoritative check applies the exact
+        // same scope as the per-lane admission predicates above.
         let candidates: Vec<(String, f32)> = if path_filter::is_active(query) {
+            let normalized_prefix = path_filter::normalized_path_prefix(query, &self.root_path);
             candidates
                 .into_iter()
                 .filter(|(id, _)| {
-                    chunks
-                        .get(id)
-                        .is_some_and(|raw| path_filter::matches(&raw.file, query))
+                    chunks.get(id).is_some_and(|raw| {
+                        path_filter::matches(&raw.file, normalized_prefix.as_deref(), &query.repos)
+                    })
                 })
                 .collect()
         } else {

--- a/crates/trusty-search/src/core/indexer/search/mod.rs
+++ b/crates/trusty-search/src/core/indexer/search/mod.rs
@@ -14,6 +14,7 @@
 pub(crate) mod kg;
 pub(crate) mod lanes;
 pub(crate) mod materialize;
+pub(crate) mod path_filter;
 
 #[cfg(test)]
 #[path = "lanes_tests.rs"]
@@ -196,20 +197,45 @@ impl CodeIndexer {
         // 2) Run lanes (HNSW + BM25), then inject entity-exact-match.
         let want = query.top_k.saturating_mul(HNSW_OVERSAMPLE).max(query.top_k);
         let bm25_fut = self.bm25_search(&query.text, want);
+        // Issue #3401: when a path/repo filter is active, the vector lane
+        // pushes the predicate into the HNSW traversal itself (see
+        // `vector_search_scoped` / `VectorStore::search_filtered`) rather
+        // than fetching raw-similarity top candidates and filtering after —
+        // the latter would silently lose recall for a chunk that only ranks
+        // highly once scoped to the filtered repo/path.
         let hnsw_results = match &embedding {
-            Some(v) => self.vector_search(v, want).await?,
+            Some(v) => self.vector_search_scoped(v, want, query).await?,
             None => Vec::new(),
         };
         let mut bm25_results = bm25_fut.await?;
+        // Issue #3401: retain in-scope BM25 hits BEFORE RRF fuse / MMR rerank
+        // (both of which truncate their working set to `want`). Without this,
+        // a query whose lexical lane returns `want` non-matching hits (a
+        // heavily-matched but out-of-scope filler, say) would crowd the
+        // correctly-found (predicate-pushed) vector-lane candidate out of the
+        // `want`-bounded fusion/MMR stages before `apply_score_adjustments`'s
+        // authoritative retain ever runs. Checking the id string (rather than
+        // fetching each candidate's `RawChunk`) is safe here — see the
+        // `path_filter` module docs for why a chunk id always begins with its
+        // literal file path.
+        if path_filter::is_active(query) {
+            bm25_results.retain(|(id, _)| path_filter::matches(id, query));
+        }
         self.inject_entity_exact_match(&intent, &query.text, beta, &mut bm25_results)
             .await;
+        if path_filter::is_active(query) {
+            bm25_results.retain(|(id, _)| path_filter::matches(id, query));
+        }
 
         // 2a) Issue #75: for Definition intent, run grep as a third RRF lane.
-        let grep_lane: Vec<(String, f32)> = if matches!(intent, QueryIntent::Definition) {
+        let mut grep_lane: Vec<(String, f32)> = if matches!(intent, QueryIntent::Definition) {
             self.grep_fallback_search(&query.text, want).await
         } else {
             Vec::new()
         };
+        if path_filter::is_active(query) {
+            grep_lane.retain(|(id, _)| path_filter::matches(id, query));
+        }
 
         // 3) RRF fuse, then MMR diversity pass.
         let fused_raw = rrf_fuse(&hnsw_results, &bm25_results, alpha, beta, RRF_K, want);
@@ -218,7 +244,11 @@ impl CodeIndexer {
         // 3a) Issue #75: empty-result fallback — scan chunk corpus for literal
         // substring match.
         let fused_raw = if fused_raw.is_empty() {
-            self.grep_fallback_search(&query.text, want).await
+            let mut fallback = self.grep_fallback_search(&query.text, want).await;
+            if path_filter::is_active(query) {
+                fallback.retain(|(id, _)| path_filter::matches(id, query));
+            }
+            fallback
         } else {
             fused_raw
         };
@@ -256,7 +286,7 @@ impl CodeIndexer {
             .apply_score_adjustments(
                 all,
                 &intent,
-                &query.text,
+                query,
                 branch_set.as_ref(),
                 branch_boost,
                 effective_mode,
@@ -364,20 +394,33 @@ impl CodeIndexer {
     /// (2) Issue #72: the mode-aware `doc_score_penalty` matrix must fire
     /// BEFORE `take(top_k)` so prose chunks can't crowd source matches out of
     /// the result list. (3) Issues #117/#122: struct/function definition boost.
+    /// (4) Issue #3401: the path/repo filter is hard-applied here too — this
+    /// is the single choke point every lane's candidates (BM25, HNSW, grep,
+    /// KG-expanded) flow through before `materialize_search_results`'s
+    /// `take(query.top_k)`, so filtering here (against the authoritative
+    /// `RawChunk::file`, already fetched below for the other adjustments)
+    /// guarantees no non-matching chunk can occupy a `top_k` slot — and,
+    /// since it runs before that truncation, no matching chunk can be lost
+    /// to it either. This complements (does not replace) the vector lane's
+    /// own predicate-pushed retrieval (`vector_search_scoped`): that step is
+    /// what lets a path-scoped match reach this point at all when it would
+    /// otherwise rank outside the raw-similarity oversample window.
     /// What: adjusts every candidate's score in a single pass and re-sorts
     /// before truncation.
     /// Test: `test_definition_demotes_markdown_below_source`,
     /// `test_kg_results_survive_top_k_truncation`,
-    /// `test_struct_definition_boost_surfaces_struct_over_usage`.
+    /// `test_struct_definition_boost_surfaces_struct_over_usage`,
+    /// `test_path_prefix_filter_survives_top_k_truncation` (issue #3401).
     async fn apply_score_adjustments(
         &self,
         candidates: Vec<(String, f32)>,
         intent: &QueryIntent,
-        query_text: &str,
+        query: &SearchQuery,
         branch_files: Option<&HashSet<String>>,
         branch_boost: f32,
         effective_mode: super::SearchMode,
     ) -> Vec<(String, f32)> {
+        let query_text = query.text.as_str();
         let demote_docs = matches!(intent, QueryIntent::Definition);
         // Issue #117: for Definition-intent queries, boost chunks that are the
         // declaration of a type whose `function_name` matches a literal query
@@ -389,6 +432,26 @@ impl CodeIndexer {
         };
         let candidate_ids: Vec<String> = candidates.iter().map(|(id, _)| id.clone()).collect();
         let chunks = self.fetch_chunks_for_ids(&candidate_ids).await;
+
+        // Issue #3401: hard path/repo filter against the real file path,
+        // applied strictly before the sort/return below (and therefore
+        // strictly before the final `top_k` truncation in
+        // `materialize_search_results`). A candidate whose chunk failed to
+        // resolve (race with a concurrent removal) is dropped rather than
+        // kept — the existing materialize step would have skipped it anyway.
+        let candidates: Vec<(String, f32)> = if path_filter::is_active(query) {
+            candidates
+                .into_iter()
+                .filter(|(id, _)| {
+                    chunks
+                        .get(id)
+                        .is_some_and(|raw| path_filter::matches(&raw.file, query))
+                })
+                .collect()
+        } else {
+            candidates
+        };
+
         let mut adjusted: Vec<(String, f32)> = candidates
             .into_iter()
             .map(|(id, score)| {

--- a/crates/trusty-search/src/core/indexer/search/path_filter.rs
+++ b/crates/trusty-search/src/core/indexer/search/path_filter.rs
@@ -2,26 +2,31 @@
 //!
 //! Why: consumers of the single unified `main` index (~315k chunks) need to
 //! scope results to a repo/path subtree without losing recall to `top_k`
-//! truncation. This module is the single shared predicate used at both
-//! admission points:
+//! truncation. This module is the shared predicate used at every admission
+//! point:
 //!
 //!   1. The vector lane's predicate-pushed HNSW traversal
 //!      (`lanes::vector_search_scoped`), which only has the chunk id string
 //!      to test cheaply during graph exploration.
-//!   2. The authoritative, pre-truncation retain in
+//!   2. The BM25/grep lanes' pre-truncation filter (`search()`'s
+//!      `path_pred`), also keyed on the chunk id.
+//!   3. The authoritative, pre-truncation retain in
 //!      `CodeIndexer::apply_score_adjustments`, which has the real
 //!      `RawChunk::file`.
 //!
-//! Every chunk id is built as `"{file}:{start}:{end}"` or
-//! `"{file}::{type}::{name}::{start}"` (see `chunker::walk::make_chunk_id`) —
-//! i.e. a chunk id always begins with its literal file path. That, plus the
-//! path-segment-boundary check in `core::store::path_match`, makes `matches`
-//! correct for `path_prefix` whether given a chunk id or a file path
-//! directly, and safe — over-inclusive at worst, never under-inclusive —
-//! for `repos`. Site (1) only decides which candidates the vector lane
-//! *admits*; site (2), which re-checks against the real file path, is what
-//! the caller-visible result set is actually filtered by, so any
-//! theoretical over-inclusion at (1) can never leak through.
+//! **Two functions, not one** (code review finding, issue #3401): a chunk id
+//! is built as `"{file}:{start}:{end}"` or `"{file}::{type}::{name}::{start}"`
+//! (see `chunker::walk::make_chunk_id`) — i.e. it begins with the literal
+//! file path, but is NOT itself a file path; it carries a suffix that starts
+//! with `:`. A single boundary check that accepted any `:` as a valid
+//! "end of prefix" byte (to make exact-file chunk-id scoping work) would
+//! ALSO accept a colon that's just a legal POSIX filename/directory
+//! character in a REAL path, e.g. `path_prefix: "vendor/foo"` matching a
+//! genuine `vendor/foo:evil/secret.rs` — the sibling-prefix leak this module
+//! exists to close, reopened through a different byte. So sites 1–2 (chunk
+//! id candidates) use [`matches_id`]; site 3 (bare file path) uses
+//! [`matches_file`]. Never use one where the other belongs — see each
+//! function's doc for what distinguishes them.
 //!
 //! **Root-relative normalization (code review HIGH finding, issue #3401):**
 //! `RawChunk::file` / chunk ids are stored root-relative, but `CodeChunk::file`
@@ -31,19 +36,23 @@
 //! `file` would otherwise silently get zero rows. `normalized_path_prefix`
 //! strips `root_path` from an absolute caller-supplied prefix so both forms
 //! work; every production call site MUST go through it rather than reading
-//! `query.path_prefix` directly (see `matches`, which takes the already-
-//! normalized prefix, not the raw query, to make that unavoidable).
+//! `query.path_prefix` directly (see `matches_id` / `matches_file`, which
+//! take the already-normalized prefix, not the raw query, to make that
+//! unavoidable).
 //!
 //! What: `is_active` (fast short-circuit for the overwhelmingly common
 //! unfiltered case), `normalized_path_prefix` (root-relative normalization),
-//! and `matches` (AND-composed `path_prefix` + `repos` check over already-
-//! normalized data).
+//! `matches_id` and `matches_file` (AND-composed `path_prefix` + `repos`
+//! checks over already-normalized data, for a chunk id and a bare file path
+//! respectively).
 //! Test: `test_path_prefix_matches_and_rejects`,
 //! `test_repos_matches_path_segment`, `test_inactive_filter_matches_everything`,
 //! `test_path_prefix_and_repos_compose_with_and`,
 //! `test_normalizes_absolute_prefix_under_root`,
 //! `test_leaves_relative_prefix_untouched`,
-//! `test_leaves_foreign_absolute_prefix_untouched` in this module.
+//! `test_leaves_foreign_absolute_prefix_untouched` in this module;
+//! `core::store::path_match`'s own tests pin the boundary/colon-leak
+//! behaviour directly.
 
 use std::path::Path;
 
@@ -76,18 +85,38 @@ pub(crate) fn normalized_path_prefix(query: &SearchQuery, root_path: &Path) -> O
     })
 }
 
-/// Test whether `candidate` (a chunk id OR a file path — see module docs)
-/// satisfies the filter described by `path_prefix` (already normalized via
-/// [`normalized_path_prefix`] — this function does NOT do that itself) and
-/// `repos`.
+/// Test whether `candidate` — a CHUNK ID — satisfies the filter described by
+/// `path_prefix` (already normalized via [`normalized_path_prefix`] — this
+/// function does NOT do that itself) and `repos`.
+///
+/// Two functions, not one (code review finding, issue #3401): a chunk id and
+/// a bare file path are different candidate shapes — a chunk id carries a
+/// `:start:end` (or `::type::name::start`) suffix after the file path, and
+/// treating that suffix's leading `:` as a generic "boundary byte" would
+/// also (wrongly) accept a REAL path segment that happens to contain a
+/// colon, e.g. `vendor/foo:evil/secret.rs` against `path_prefix:
+/// "vendor/foo"`. Use `matches_id` only where the candidate is genuinely a
+/// chunk id (BM25/grep/HNSW admission predicates); use [`matches_file`]
+/// wherever it's a bare file path.
 ///
 /// `path_prefix` and `repos` compose with AND: when both are set, a
 /// candidate must satisfy both to match. An inactive filter (`path_prefix:
 /// None`, `repos: []`) always matches — this function is still safe to call
-/// unconditionally. Delegates to `core::store::path_match` — the single
-/// source of truth shared with `VectorStore::search_filtered`'s predicate.
-pub(crate) fn matches(candidate: &str, path_prefix: Option<&str>, repos: &[String]) -> bool {
-    crate::core::store::path_match::matches(candidate, path_prefix, repos)
+/// unconditionally. Delegates to `core::store::path_match::matches_chunk_id`
+/// — the single source of truth shared with `VectorStore::search_filtered`'s
+/// predicate.
+pub(crate) fn matches_id(candidate: &str, path_prefix: Option<&str>, repos: &[String]) -> bool {
+    crate::core::store::path_match::matches_chunk_id(candidate, path_prefix, repos)
+}
+
+/// Test whether `candidate` — a bare file path (`RawChunk::file` /
+/// `CodeChunk::file`) — satisfies the filter. Same composition rules as
+/// [`matches_id`]; see that function's doc for why this is a SEPARATE
+/// function rather than one shared check. Delegates to
+/// `core::store::path_match::matches_file` — the authoritative retain in
+/// `CodeIndexer::apply_score_adjustments` is the canonical caller.
+pub(crate) fn matches_file(candidate: &str, path_prefix: Option<&str>, repos: &[String]) -> bool {
+    crate::core::store::path_match::matches_file(candidate, path_prefix, repos)
 }
 
 #[cfg(test)]
@@ -106,7 +135,7 @@ mod tests {
     fn test_inactive_filter_matches_everything() {
         let q = query_with(None, &[]);
         assert!(!is_active(&q));
-        assert!(matches(
+        assert!(matches_id(
             "/any/path/at/all.rs",
             q.path_prefix.as_deref(),
             &q.repos
@@ -117,12 +146,12 @@ mod tests {
     fn test_path_prefix_matches_and_rejects() {
         let q = query_with(Some("/repos/foo/src"), &[]);
         assert!(is_active(&q));
-        assert!(matches(
+        assert!(matches_id(
             "/repos/foo/src/lib.rs:1:5",
             q.path_prefix.as_deref(),
             &q.repos
         ));
-        assert!(!matches(
+        assert!(!matches_id(
             "/repos/bar/src/lib.rs:1:5",
             q.path_prefix.as_deref(),
             &q.repos
@@ -132,17 +161,17 @@ mod tests {
     #[test]
     fn test_repos_matches_path_segment() {
         let q = query_with(None, &["foo"]);
-        assert!(matches(
+        assert!(matches_id(
             "/home/user/repos/foo/src/lib.rs:1:5",
             q.path_prefix.as_deref(),
             &q.repos
         ));
-        assert!(matches(
+        assert!(matches_id(
             "foo/src/lib.rs:1:5",
             q.path_prefix.as_deref(),
             &q.repos
         ));
-        assert!(!matches(
+        assert!(!matches_id(
             "/home/user/repos/foobar/src/lib.rs:1:5",
             q.path_prefix.as_deref(),
             &q.repos
@@ -152,13 +181,13 @@ mod tests {
     #[test]
     fn test_path_prefix_and_repos_compose_with_and() {
         let q = query_with(Some("/repos/foo/src"), &["foo"]);
-        assert!(matches(
+        assert!(matches_id(
             "/repos/foo/src/lib.rs:1:5",
             q.path_prefix.as_deref(),
             &q.repos
         ));
         // Matches `repos` but not `path_prefix`.
-        assert!(!matches(
+        assert!(!matches_id(
             "/repos/foo/tests/lib.rs:1:5",
             q.path_prefix.as_deref(),
             &q.repos
@@ -173,7 +202,7 @@ mod tests {
         assert_eq!(normalized.as_deref(), Some("vendor/acme"));
         // And the normalized form actually matches the root-relative
         // `RawChunk::file` / chunk id stored form.
-        assert!(matches(
+        assert!(matches_id(
             "vendor/acme/src/lib.rs:1:5",
             normalized.as_deref(),
             &[]

--- a/crates/trusty-search/src/core/indexer/search/path_filter.rs
+++ b/crates/trusty-search/src/core/indexer/search/path_filter.rs
@@ -14,22 +14,38 @@
 //!
 //! Every chunk id is built as `"{file}:{start}:{end}"` or
 //! `"{file}::{type}::{name}::{start}"` (see `chunker::walk::make_chunk_id`) —
-//! i.e. a chunk id always begins with its literal file path. That makes
-//! `matches` exact for `path_prefix` whether given a chunk id or a file path
-//! directly (`id.starts_with(prefix) == file.starts_with(prefix)` whenever
-//! `prefix` is no longer than `file`), and safe — over-inclusive at worst,
-//! never under-inclusive — for `repos`. Site (1) only decides which
-//! candidates the vector lane *admits*; site (2), which re-checks against
-//! the real file path, is what the caller-visible result set is actually
-//! filtered by, so any theoretical over-inclusion at (1) can never leak
-//! through.
+//! i.e. a chunk id always begins with its literal file path. That, plus the
+//! path-segment-boundary check in `core::store::path_match`, makes `matches`
+//! correct for `path_prefix` whether given a chunk id or a file path
+//! directly, and safe — over-inclusive at worst, never under-inclusive —
+//! for `repos`. Site (1) only decides which candidates the vector lane
+//! *admits*; site (2), which re-checks against the real file path, is what
+//! the caller-visible result set is actually filtered by, so any
+//! theoretical over-inclusion at (1) can never leak through.
+//!
+//! **Root-relative normalization (code review HIGH finding, issue #3401):**
+//! `RawChunk::file` / chunk ids are stored root-relative, but `CodeChunk::file`
+//! in RESULTS is always resolved to an absolute host path (issue #402) — the
+//! same absolute form the issue's own reporter observed in `file` fields. A
+//! caller who copies a `path_prefix` straight out of a previous result's
+//! `file` would otherwise silently get zero rows. `normalized_path_prefix`
+//! strips `root_path` from an absolute caller-supplied prefix so both forms
+//! work; every production call site MUST go through it rather than reading
+//! `query.path_prefix` directly (see `matches`, which takes the already-
+//! normalized prefix, not the raw query, to make that unavoidable).
 //!
 //! What: `is_active` (fast short-circuit for the overwhelmingly common
-//! unfiltered case) and `matches` (AND-composed `path_prefix` + `repos`
-//! check).
+//! unfiltered case), `normalized_path_prefix` (root-relative normalization),
+//! and `matches` (AND-composed `path_prefix` + `repos` check over already-
+//! normalized data).
 //! Test: `test_path_prefix_matches_and_rejects`,
 //! `test_repos_matches_path_segment`, `test_inactive_filter_matches_everything`,
-//! `test_path_prefix_and_repos_compose_with_and` in `indexer::tests`.
+//! `test_path_prefix_and_repos_compose_with_and`,
+//! `test_normalizes_absolute_prefix_under_root`,
+//! `test_leaves_relative_prefix_untouched`,
+//! `test_leaves_foreign_absolute_prefix_untouched` in this module.
+
+use std::path::Path;
 
 use super::super::SearchQuery;
 
@@ -40,18 +56,38 @@ pub(crate) fn is_active(query: &SearchQuery) -> bool {
     query.path_prefix.is_some() || !query.repos.is_empty()
 }
 
+/// Normalize `query.path_prefix` against `root_path` (issue #3401 — see
+/// module docs). When the prefix is absolute and falls under `root_path`,
+/// strips `root_path` (and any leading `/`) so it matches the root-relative
+/// form chunks are actually stored/compared in. A prefix that is already
+/// relative, or is absolute but outside this index's root entirely, passes
+/// through unchanged — the latter simply won't match anything, which is
+/// correct (the caller named a path outside this index).
+pub(crate) fn normalized_path_prefix(query: &SearchQuery, root_path: &Path) -> Option<String> {
+    query.path_prefix.as_deref().map(|prefix| {
+        if !prefix.starts_with('/') {
+            return prefix.to_string();
+        }
+        let root = root_path.to_string_lossy();
+        match prefix.strip_prefix(root.as_ref()) {
+            Some(rest) => rest.trim_start_matches('/').to_string(),
+            None => prefix.to_string(),
+        }
+    })
+}
+
 /// Test whether `candidate` (a chunk id OR a file path — see module docs)
-/// satisfies the query's path/repo filter.
+/// satisfies the filter described by `path_prefix` (already normalized via
+/// [`normalized_path_prefix`] — this function does NOT do that itself) and
+/// `repos`.
 ///
 /// `path_prefix` and `repos` compose with AND: when both are set, a
-/// candidate must satisfy both to match. An inactive filter (`is_active`
-/// false) always matches — this function is still safe to call
+/// candidate must satisfy both to match. An inactive filter (`path_prefix:
+/// None`, `repos: []`) always matches — this function is still safe to call
 /// unconditionally. Delegates to `core::store::path_match` — the single
-/// source of truth shared with `VectorStore::search_filtered`'s predicate,
-/// which takes the same `path_prefix` / `repos` shape as plain data (see
-/// that module's docs for why it can't take a `SearchQuery` directly).
-pub(crate) fn matches(candidate: &str, query: &SearchQuery) -> bool {
-    crate::core::store::path_match::matches(candidate, query.path_prefix.as_deref(), &query.repos)
+/// source of truth shared with `VectorStore::search_filtered`'s predicate.
+pub(crate) fn matches(candidate: &str, path_prefix: Option<&str>, repos: &[String]) -> bool {
+    crate::core::store::path_match::matches(candidate, path_prefix, repos)
 }
 
 #[cfg(test)]
@@ -70,30 +106,100 @@ mod tests {
     fn test_inactive_filter_matches_everything() {
         let q = query_with(None, &[]);
         assert!(!is_active(&q));
-        assert!(matches("/any/path/at/all.rs", &q));
+        assert!(matches(
+            "/any/path/at/all.rs",
+            q.path_prefix.as_deref(),
+            &q.repos
+        ));
     }
 
     #[test]
     fn test_path_prefix_matches_and_rejects() {
         let q = query_with(Some("/repos/foo/src"), &[]);
         assert!(is_active(&q));
-        assert!(matches("/repos/foo/src/lib.rs:1:5", &q));
-        assert!(!matches("/repos/bar/src/lib.rs:1:5", &q));
+        assert!(matches(
+            "/repos/foo/src/lib.rs:1:5",
+            q.path_prefix.as_deref(),
+            &q.repos
+        ));
+        assert!(!matches(
+            "/repos/bar/src/lib.rs:1:5",
+            q.path_prefix.as_deref(),
+            &q.repos
+        ));
     }
 
     #[test]
     fn test_repos_matches_path_segment() {
         let q = query_with(None, &["foo"]);
-        assert!(matches("/home/user/repos/foo/src/lib.rs:1:5", &q));
-        assert!(matches("foo/src/lib.rs:1:5", &q));
-        assert!(!matches("/home/user/repos/foobar/src/lib.rs:1:5", &q));
+        assert!(matches(
+            "/home/user/repos/foo/src/lib.rs:1:5",
+            q.path_prefix.as_deref(),
+            &q.repos
+        ));
+        assert!(matches(
+            "foo/src/lib.rs:1:5",
+            q.path_prefix.as_deref(),
+            &q.repos
+        ));
+        assert!(!matches(
+            "/home/user/repos/foobar/src/lib.rs:1:5",
+            q.path_prefix.as_deref(),
+            &q.repos
+        ));
     }
 
     #[test]
     fn test_path_prefix_and_repos_compose_with_and() {
         let q = query_with(Some("/repos/foo/src"), &["foo"]);
-        assert!(matches("/repos/foo/src/lib.rs:1:5", &q));
+        assert!(matches(
+            "/repos/foo/src/lib.rs:1:5",
+            q.path_prefix.as_deref(),
+            &q.repos
+        ));
         // Matches `repos` but not `path_prefix`.
-        assert!(!matches("/repos/foo/tests/lib.rs:1:5", &q));
+        assert!(!matches(
+            "/repos/foo/tests/lib.rs:1:5",
+            q.path_prefix.as_deref(),
+            &q.repos
+        ));
+    }
+
+    #[test]
+    fn test_normalizes_absolute_prefix_under_root() {
+        let root = Path::new("/tmp/test-root");
+        let q = query_with(Some("/tmp/test-root/vendor/acme"), &[]);
+        let normalized = normalized_path_prefix(&q, root);
+        assert_eq!(normalized.as_deref(), Some("vendor/acme"));
+        // And the normalized form actually matches the root-relative
+        // `RawChunk::file` / chunk id stored form.
+        assert!(matches(
+            "vendor/acme/src/lib.rs:1:5",
+            normalized.as_deref(),
+            &[]
+        ));
+    }
+
+    #[test]
+    fn test_leaves_relative_prefix_untouched() {
+        let root = Path::new("/tmp/test-root");
+        let q = query_with(Some("vendor/acme"), &[]);
+        assert_eq!(
+            normalized_path_prefix(&q, root).as_deref(),
+            Some("vendor/acme")
+        );
+    }
+
+    #[test]
+    fn test_leaves_foreign_absolute_prefix_untouched() {
+        // An absolute path that isn't under this index's root: left as-is,
+        // which simply won't match anything under `root_path` — correct,
+        // since the caller named a path outside this index.
+        let root = Path::new("/tmp/test-root");
+        let q = query_with(Some("/somewhere/else/vendor"), &[]);
+        assert_eq!(
+            normalized_path_prefix(&q, root).as_deref(),
+            Some("/somewhere/else/vendor")
+        );
     }
 }

--- a/crates/trusty-search/src/core/indexer/search/path_filter.rs
+++ b/crates/trusty-search/src/core/indexer/search/path_filter.rs
@@ -1,0 +1,99 @@
+//! Path/repo scoping predicate for search results (issue #3401).
+//!
+//! Why: consumers of the single unified `main` index (~315k chunks) need to
+//! scope results to a repo/path subtree without losing recall to `top_k`
+//! truncation. This module is the single shared predicate used at both
+//! admission points:
+//!
+//!   1. The vector lane's predicate-pushed HNSW traversal
+//!      (`lanes::vector_search_scoped`), which only has the chunk id string
+//!      to test cheaply during graph exploration.
+//!   2. The authoritative, pre-truncation retain in
+//!      `CodeIndexer::apply_score_adjustments`, which has the real
+//!      `RawChunk::file`.
+//!
+//! Every chunk id is built as `"{file}:{start}:{end}"` or
+//! `"{file}::{type}::{name}::{start}"` (see `chunker::walk::make_chunk_id`) —
+//! i.e. a chunk id always begins with its literal file path. That makes
+//! `matches` exact for `path_prefix` whether given a chunk id or a file path
+//! directly (`id.starts_with(prefix) == file.starts_with(prefix)` whenever
+//! `prefix` is no longer than `file`), and safe — over-inclusive at worst,
+//! never under-inclusive — for `repos`. Site (1) only decides which
+//! candidates the vector lane *admits*; site (2), which re-checks against
+//! the real file path, is what the caller-visible result set is actually
+//! filtered by, so any theoretical over-inclusion at (1) can never leak
+//! through.
+//!
+//! What: `is_active` (fast short-circuit for the overwhelmingly common
+//! unfiltered case) and `matches` (AND-composed `path_prefix` + `repos`
+//! check).
+//! Test: `test_path_prefix_matches_and_rejects`,
+//! `test_repos_matches_path_segment`, `test_inactive_filter_matches_everything`,
+//! `test_path_prefix_and_repos_compose_with_and` in `indexer::tests`.
+
+use super::super::SearchQuery;
+
+/// `true` when the query carries an active path/repo filter. Callers use
+/// this to skip filtering work entirely on the (overwhelmingly common)
+/// unfiltered path.
+pub(crate) fn is_active(query: &SearchQuery) -> bool {
+    query.path_prefix.is_some() || !query.repos.is_empty()
+}
+
+/// Test whether `candidate` (a chunk id OR a file path — see module docs)
+/// satisfies the query's path/repo filter.
+///
+/// `path_prefix` and `repos` compose with AND: when both are set, a
+/// candidate must satisfy both to match. An inactive filter (`is_active`
+/// false) always matches — this function is still safe to call
+/// unconditionally. Delegates to `core::store::path_match` — the single
+/// source of truth shared with `VectorStore::search_filtered`'s predicate,
+/// which takes the same `path_prefix` / `repos` shape as plain data (see
+/// that module's docs for why it can't take a `SearchQuery` directly).
+pub(crate) fn matches(candidate: &str, query: &SearchQuery) -> bool {
+    crate::core::store::path_match::matches(candidate, query.path_prefix.as_deref(), &query.repos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn query_with(path_prefix: Option<&str>, repos: &[&str]) -> SearchQuery {
+        SearchQuery {
+            path_prefix: path_prefix.map(str::to_string),
+            repos: repos.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_inactive_filter_matches_everything() {
+        let q = query_with(None, &[]);
+        assert!(!is_active(&q));
+        assert!(matches("/any/path/at/all.rs", &q));
+    }
+
+    #[test]
+    fn test_path_prefix_matches_and_rejects() {
+        let q = query_with(Some("/repos/foo/src"), &[]);
+        assert!(is_active(&q));
+        assert!(matches("/repos/foo/src/lib.rs:1:5", &q));
+        assert!(!matches("/repos/bar/src/lib.rs:1:5", &q));
+    }
+
+    #[test]
+    fn test_repos_matches_path_segment() {
+        let q = query_with(None, &["foo"]);
+        assert!(matches("/home/user/repos/foo/src/lib.rs:1:5", &q));
+        assert!(matches("foo/src/lib.rs:1:5", &q));
+        assert!(!matches("/home/user/repos/foobar/src/lib.rs:1:5", &q));
+    }
+
+    #[test]
+    fn test_path_prefix_and_repos_compose_with_and() {
+        let q = query_with(Some("/repos/foo/src"), &["foo"]);
+        assert!(matches("/repos/foo/src/lib.rs:1:5", &q));
+        // Matches `repos` but not `path_prefix`.
+        assert!(!matches("/repos/foo/tests/lib.rs:1:5", &q));
+    }
+}

--- a/crates/trusty-search/src/core/indexer/tests/branch_and_corpus.rs
+++ b/crates/trusty-search/src/core/indexer/tests/branch_and_corpus.rs
@@ -26,6 +26,8 @@ fn make_branch_query(text: &str, files: Vec<String>, boost: f32) -> SearchQuery 
         exclude_archived: false,
         stage: None,
         refine_query: None,
+        path_prefix: None,
+        repos: Vec::new(),
     }
 }
 
@@ -192,6 +194,8 @@ async fn test_no_boost_when_branch_files_absent() {
         exclude_archived: false,
         stage: None,
         refine_query: None,
+        path_prefix: None,
+        repos: Vec::new(),
     };
     let results = idx.search(&q).await.unwrap();
     assert!(!results.is_empty());

--- a/crates/trusty-search/src/core/indexer/tests/branch_and_corpus.rs
+++ b/crates/trusty-search/src/core/indexer/tests/branch_and_corpus.rs
@@ -1009,7 +1009,9 @@ async fn test_grep_fallback_returns_substring_hits() {
     idx.add_chunk(raw("b", "src/b.rs", "fn beta() {}"))
         .await
         .unwrap();
-    let hits = idx.grep_fallback_search("alpha_qwerty_unique", 5).await;
+    let hits = idx
+        .grep_fallback_search("alpha_qwerty_unique", 5, None)
+        .await;
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].0, "a");
     // The score must be tiny — well below any real BM25 / vector hit.
@@ -1030,7 +1032,7 @@ async fn test_grep_fallback_treats_query_as_literal() {
         .unwrap();
     // `.` is a regex metachar. With `regex::escape` it should only match the
     // literal "a.b.c" in chunk `a` — not the wildcard-style "aXbYc" in `b`.
-    let hits = idx.grep_fallback_search("a.b.c", 5).await;
+    let hits = idx.grep_fallback_search("a.b.c", 5, None).await;
     let ids: Vec<&str> = hits.iter().map(|(id, _)| id.as_str()).collect();
     assert!(ids.contains(&"a"), "literal match in a missing: {ids:?}");
     assert!(

--- a/crates/trusty-search/src/core/indexer/tests/mod.rs
+++ b/crates/trusty-search/src/core/indexer/tests/mod.rs
@@ -99,5 +99,6 @@ fn make_indexer_with_corpus(redb_path: &std::path::Path) -> CodeIndexer {
 
 mod branch_and_corpus;
 mod eviction_kg_paths;
+mod path_filter_search;
 mod persistence_and_search;
 mod ranking_and_modes;

--- a/crates/trusty-search/src/core/indexer/tests/path_filter_search.rs
+++ b/crates/trusty-search/src/core/indexer/tests/path_filter_search.rs
@@ -18,8 +18,12 @@
 //! unrelated short id (as several OTHER tests in this suite use for
 //! brevity) would not exercise that code path realistically.
 //! What: `test_path_prefix_filter_survives_top_k_truncation` (the core
-//! proof), `test_repos_filter_matches_path_segment`, and two composition
-//! tests with `exclude_archived` and the branch-boost fields.
+//! vector-lane proof), `test_path_prefix_filter_recovers_bm25_match_beyond_want`
+//! (the equivalent proof for the BM25 lane — code review CRITICAL 1),
+//! `test_repos_filter_matches_path_segment`, `test_path_prefix_rejects_sibling_directory`
+//! (code review CRITICAL 3), `test_path_prefix_accepts_absolute_form_from_a_prior_result`
+//! (code review HIGH finding), and two composition tests with
+//! `exclude_archived` and the branch-boost fields.
 //! Test: this module.
 
 use super::*;
@@ -108,6 +112,88 @@ async fn test_path_prefix_filter_survives_top_k_truncation() {
         scoped.iter().all(|c| c.file.starts_with(&vendor_prefix)),
         "no filler chunk (outside vendor/) may leak through the filter: {:?}",
         scoped.iter().map(|c| &c.file).collect::<Vec<_>>()
+    );
+}
+
+/// Code review CRITICAL 1 regression test (issue #3401).
+///
+/// Why: `test_path_prefix_filter_survives_top_k_truncation` deliberately
+/// gives its target chunk ZERO BM25 token overlap with the query, to isolate
+/// the vector lane — but that means it CANNOT catch a bug where the BM25
+/// lane itself truncates before the filter runs. `Bm25Index::score_query_all`
+/// internally does `scored.truncate(top_k)` (here `top_k` = `want`); a filter
+/// applied only after `bm25_search` returns can never recover a document
+/// already dropped by that internal truncate. This test isolates the BM25
+/// lane (`stage: Lexical` disables the vector lane; no chunk here contains
+/// the literal query string, so the literal-substring grep-fallback lane
+/// can't rescue the result either — see the content note below) and gives
+/// the target chunk REAL lexical overlap with the query, as one of MORE
+/// than `want` matching documents.
+/// What: 15 filler chunks repeat every query token twice (higher BM25 term
+/// frequency, so they all outrank the target); the target repeats each
+/// token once. All chunk content reorders the tokens relative to the query
+/// text so the literal query string never appears as a substring anywhere —
+/// neutralizing the grep-fallback lane (relevant if `juniper_falcon_metric`
+/// were classified as `Definition` intent, which pulls grep in as a third
+/// RRF lane) regardless of intent classification, so this test isolates
+/// BM25 cleanly no matter how the query classifies.
+/// Test: this test.
+#[tokio::test]
+async fn test_path_prefix_filter_recovers_bm25_match_beyond_want() {
+    let idx = make_indexer();
+    for i in 0..15 {
+        let file = format!("src/filler{i}.rs");
+        idx.add_chunk(raw(
+            &file,
+            &file,
+            "current wizard plasma nectar current wizard plasma nectar",
+        ))
+        .await
+        .unwrap();
+    }
+    let target_file = "vendor/acme/target.rs";
+    idx.add_chunk(raw(
+        target_file,
+        target_file,
+        "current wizard plasma nectar",
+    ))
+    .await
+    .unwrap();
+
+    let base_query = SearchQuery {
+        text: "wizard nectar plasma current".to_string(),
+        top_k: 3,
+        expand_graph: false,
+        compact: false,
+        stage: Some(SearchStage::Lexical),
+        ..Default::default()
+    };
+
+    // Precondition: unfiltered, BM25 alone (vector lane disabled via
+    // `stage: Lexical`) must not return the target — it genuinely ranks
+    // below `want` (top_k * HNSW_OVERSAMPLE = 12) among 16 matching
+    // documents, not just below the final `top_k`.
+    let baseline = idx.search(&base_query).await.unwrap();
+    assert!(
+        baseline.iter().all(|c| c.id != target_file),
+        "precondition failed: target must rank below want=12 on BM25 alone; \
+         got {:?}",
+        baseline.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+
+    let scoped = idx
+        .search(&SearchQuery {
+            path_prefix: Some("vendor/".to_string()),
+            ..base_query
+        })
+        .await
+        .unwrap();
+    assert!(
+        scoped.iter().any(|c| c.id == target_file),
+        "path_prefix filter must recover a BM25 match that ranks below \
+         BM25's own internal `want` truncation, not just below the final \
+         top_k; got {:?}",
+        scoped.iter().map(|c| &c.id).collect::<Vec<_>>()
     );
 }
 
@@ -313,4 +399,112 @@ async fn test_search_query_rejects_unknown_field() {
     let q: SearchQuery =
         serde_json::from_value(correct).expect("correctly-spelled field must deserialize");
     assert_eq!(q.path_prefix.as_deref(), Some("src/"));
+}
+
+/// Code review CRITICAL 3 regression test (issue #3401), exercised through
+/// the full search pipeline rather than the `path_match` unit tests alone —
+/// `path_prefix: "vendor/foo"` must not also match the sibling directory
+/// `vendor/foobar/...`, which a bare `starts_with` would silently allow.
+#[tokio::test]
+async fn test_path_prefix_rejects_sibling_directory() {
+    let idx = make_indexer();
+    let in_scope = "vendor/foo/src/lib.rs";
+    let sibling = "vendor/foobar/src/secret.rs";
+    idx.add_chunk(raw(in_scope, in_scope, "fn oscar_delta_marker() {}"))
+        .await
+        .unwrap();
+    idx.add_chunk(raw(sibling, sibling, "fn oscar_delta_marker() {}"))
+        .await
+        .unwrap();
+
+    let results = idx
+        .search(&SearchQuery {
+            text: "oscar_delta_marker".to_string(),
+            top_k: 10,
+            expand_graph: false,
+            compact: false,
+            path_prefix: Some("vendor/foo".to_string()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        results.iter().any(|c| c.id == in_scope),
+        "the true subtree entry must be returned; got {:?}",
+        results.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+    assert!(
+        results.iter().all(|c| c.id != sibling),
+        "path_prefix: \"vendor/foo\" must NOT match the sibling directory \
+         \"vendor/foobar/...\"; got {:?}",
+        results.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+}
+
+/// Code review HIGH finding regression test (issue #3401): a caller who
+/// builds `path_prefix` from the absolute `file` they saw in a PRIOR search
+/// result (the natural thing to do, since `CodeChunk::file` is always
+/// resolved to an absolute host path) must get the same results as a caller
+/// who already knew to pass the root-relative form.
+#[tokio::test]
+async fn test_path_prefix_accepts_absolute_form_from_a_prior_result() {
+    let idx = make_indexer();
+    let in_scope = "vendor/acme/lib.rs";
+    let out_of_scope = "vendor/other/lib.rs";
+    idx.add_chunk(raw(in_scope, in_scope, "fn quebec_hotel_signal() {}"))
+        .await
+        .unwrap();
+    idx.add_chunk(raw(
+        out_of_scope,
+        out_of_scope,
+        "fn quebec_hotel_signal() {}",
+    ))
+    .await
+    .unwrap();
+
+    let base_query = SearchQuery {
+        text: "quebec_hotel_signal".to_string(),
+        top_k: 10,
+        expand_graph: false,
+        compact: false,
+        ..Default::default()
+    };
+
+    // Discover the absolute `file` form a real caller would see.
+    let unscoped = idx.search(&base_query).await.unwrap();
+    let seen_absolute_file = unscoped
+        .iter()
+        .find(|c| c.id == in_scope)
+        .expect("in-scope chunk present in the unscoped baseline")
+        .file
+        .clone();
+    assert!(
+        std::path::Path::new(&seen_absolute_file).is_absolute(),
+        "precondition: CodeChunk::file must be absolute (issue #402); got {seen_absolute_file}"
+    );
+
+    // A caller scoping by the exact absolute directory containing that file.
+    let absolute_prefix = std::path::Path::new(&seen_absolute_file)
+        .parent()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    let scoped = idx
+        .search(&SearchQuery {
+            path_prefix: Some(absolute_prefix),
+            ..base_query
+        })
+        .await
+        .unwrap();
+    assert!(
+        scoped.iter().any(|c| c.id == in_scope),
+        "an absolute path_prefix under root_path must be normalized and \
+         still match; got {:?}",
+        scoped.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+    assert!(
+        scoped.iter().all(|c| c.id != out_of_scope),
+        "the absolute-form prefix must still exclude the other directory"
+    );
 }

--- a/crates/trusty-search/src/core/indexer/tests/path_filter_search.rs
+++ b/crates/trusty-search/src/core/indexer/tests/path_filter_search.rs
@@ -1,0 +1,316 @@
+//! Path/repo filter tests for issue #3401.
+//!
+//! Why: the whole point of #3401 is that a `path_prefix` / `repos` filter
+//! must be applied during candidate selection — BEFORE `top_k`
+//! truncation — in every retrieval lane, so a chunk that genuinely matches
+//! the scoped repo/path is never lost just because it ranks poorly against
+//! the *unscoped* query. A test that only proves "filtering happens" would
+//! pass even for a naive post-hoc filter (`results.retain(...)` after
+//! `search()` returns); the tests here specifically construct a candidate
+//! that ranks below the global `top_k` cutoff and assert it is STILL
+//! returned once the query is scoped to its repo/path — that is the
+//! regression a post-filter implementation could not pass.
+//!
+//! Every chunk id here is set equal to its file path (as production's
+//! `chunker::walk::make_chunk_id` guarantees a chunk id always begins with
+//! its literal file path) — the vector lane's HNSW admission predicate
+//! (`vector_search_scoped`) tests the chunk id, so a fixture with an
+//! unrelated short id (as several OTHER tests in this suite use for
+//! brevity) would not exercise that code path realistically.
+//! What: `test_path_prefix_filter_survives_top_k_truncation` (the core
+//! proof), `test_repos_filter_matches_path_segment`, and two composition
+//! tests with `exclude_archived` and the branch-boost fields.
+//! Test: this module.
+
+use super::*;
+
+/// The core proof for issue #3401.
+///
+/// Why: constructs a query where the target chunk (`vendor/acme/target.rs`)
+/// shares no BM25 tokens with the query text at all (so it can only be
+/// found via the vector lane) and is embedded to a much lower cosine
+/// similarity than 20 filler chunks under a different path. With
+/// `top_k = 3` (`HNSW_OVERSAMPLE = 4` ⇒ an unfiltered internal candidate
+/// pool of only ~12), the target is unreachable by raw similarity alone —
+/// it ranks dead last among 21 chunks. Scoping the query to
+/// `path_prefix: "vendor/"` must still return it: `vector_search_scoped`
+/// pushes the predicate into HNSW traversal (`VectorStore::search_filtered`)
+/// rather than filtering an already-truncated candidate set.
+/// What: (1) asserts the unfiltered baseline never returns the target
+/// (precondition — proves it really does rank below the cutoff); (2)
+/// asserts the `path_prefix`-scoped query returns it.
+/// Test: this test.
+#[tokio::test]
+async fn test_path_prefix_filter_survives_top_k_truncation() {
+    let idx = make_indexer();
+
+    // 20 filler chunks: identical content, heavy token overlap with the
+    // query, so every one of them outranks the target on both BM25 and
+    // vector similarity. More fillers than HNSW_OVERSAMPLE * top_k (4*3=12)
+    // so the target is unreachable within the internal oversample window,
+    // not just beyond the final top_k.
+    for i in 0..20 {
+        let file = format!("src/filler{i}.rs");
+        idx.add_chunk(raw(
+            &file,
+            &file,
+            "zephyr_wombat_flux_token handler zephyr_wombat_flux_token",
+        ))
+        .await
+        .unwrap();
+    }
+    // The target: zero shared BM25 tokens with the query (findable only via
+    // the vector lane), under a distinct path prefix.
+    let target_file = "vendor/acme/target.rs";
+    idx.add_chunk(raw(
+        target_file,
+        target_file,
+        "completely unrelated prose about something else entirely",
+    ))
+    .await
+    .unwrap();
+
+    let base_query = SearchQuery {
+        text: "zephyr_wombat_flux_token".to_string(),
+        top_k: 3,
+        expand_graph: false,
+        compact: false,
+        ..Default::default()
+    };
+
+    // Precondition: unfiltered, the target must NOT be in the results — it
+    // genuinely ranks outside the top_k window, not merely outside some
+    // arbitrary post-hoc filter.
+    let baseline = idx.search(&base_query).await.unwrap();
+    assert!(
+        baseline.iter().all(|c| c.id != target_file),
+        "precondition failed: target must rank below top_k=3 unfiltered; got {:?}",
+        baseline.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+
+    // Scoped: path_prefix must recover the target despite its last-place
+    // global rank. This is the property a post-hoc filter cannot satisfy.
+    let scoped = idx
+        .search(&SearchQuery {
+            path_prefix: Some("vendor/".to_string()),
+            ..base_query.clone()
+        })
+        .await
+        .unwrap();
+    assert!(
+        scoped.iter().any(|c| c.id == target_file),
+        "path_prefix filter must recover a match ranked below the global \
+         top_k cutoff; got {:?}",
+        scoped.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+    let vendor_prefix = abs("vendor");
+    assert!(
+        scoped.iter().all(|c| c.file.starts_with(&vendor_prefix)),
+        "no filler chunk (outside vendor/) may leak through the filter: {:?}",
+        scoped.iter().map(|c| &c.file).collect::<Vec<_>>()
+    );
+}
+
+/// `repos` filter: same pre-truncation guarantee, keyed on a path segment
+/// rather than a prefix.
+#[tokio::test]
+async fn test_repos_filter_matches_path_segment() {
+    let idx = make_indexer();
+    for i in 0..20 {
+        let file = format!("repos/main-monorepo/src/filler{i}.rs");
+        idx.add_chunk(raw(
+            &file,
+            &file,
+            "kilo_bravo_ranger_signal handler kilo_bravo_ranger_signal",
+        ))
+        .await
+        .unwrap();
+    }
+    let target_file = "repos/other-service/src/target.rs";
+    idx.add_chunk(raw(
+        target_file,
+        target_file,
+        "completely unrelated prose about something else entirely",
+    ))
+    .await
+    .unwrap();
+
+    let base_query = SearchQuery {
+        text: "kilo_bravo_ranger_signal".to_string(),
+        top_k: 3,
+        expand_graph: false,
+        compact: false,
+        ..Default::default()
+    };
+    let baseline = idx.search(&base_query).await.unwrap();
+    assert!(
+        baseline.iter().all(|c| c.id != target_file),
+        "precondition failed: target must rank below top_k=3 unfiltered"
+    );
+
+    let scoped = idx
+        .search(&SearchQuery {
+            repos: vec!["other-service".to_string()],
+            ..base_query
+        })
+        .await
+        .unwrap();
+    assert!(
+        scoped.iter().any(|c| c.id == target_file),
+        "repos filter must recover a match ranked below the global top_k \
+         cutoff; got {:?}",
+        scoped.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+}
+
+/// Composition: `path_prefix` + `exclude_archived` — both must apply
+/// (independent hard filters), neither silently disables the other.
+#[tokio::test]
+async fn test_path_prefix_composes_with_exclude_archived() {
+    let idx = make_indexer();
+    let live = "vendor/acme/live.rs";
+    let archived = "vendor/acme/_archive/old.rs";
+    let other_repo = "vendor/other/live.rs";
+    idx.add_chunk(raw(live, live, "fn ranger_kilo_delta_signal_live() {}"))
+        .await
+        .unwrap();
+    idx.add_chunk(raw(
+        archived,
+        archived,
+        "fn ranger_kilo_delta_signal_old() {}",
+    ))
+    .await
+    .unwrap();
+    idx.add_chunk(raw(
+        other_repo,
+        other_repo,
+        "fn ranger_kilo_delta_signal_other() {}",
+    ))
+    .await
+    .unwrap();
+
+    let results = idx
+        .search(&SearchQuery {
+            text: "ranger_kilo_delta_signal".to_string(),
+            top_k: 10,
+            expand_graph: false,
+            compact: false,
+            path_prefix: Some("vendor/acme/".to_string()),
+            exclude_archived: true,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        results.iter().any(|c| c.id == live),
+        "the live, in-scope chunk must be returned; got {:?}",
+        results.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+    assert!(
+        results.iter().all(|c| c.id != archived),
+        "exclude_archived must still drop archived chunks inside the scoped path"
+    );
+    assert!(
+        results.iter().all(|c| c.id != other_repo),
+        "path_prefix must still exclude chunks outside the scoped path"
+    );
+}
+
+/// Composition: `path_prefix` + branch boost — the filter and the boost are
+/// independent passes; a chunk can be both in-scope and branch-boosted.
+#[tokio::test]
+async fn test_path_prefix_composes_with_branch_boost() {
+    let idx = make_indexer();
+    let on_branch = "vendor/acme/on_branch.rs";
+    let off_branch = "vendor/acme/off_branch.rs";
+    let other_repo_on_branch = "vendor/other/on_branch.rs";
+    idx.add_chunk(raw(
+        on_branch,
+        on_branch,
+        "fn tango_uniform_signal_alpha() {}",
+    ))
+    .await
+    .unwrap();
+    idx.add_chunk(raw(
+        off_branch,
+        off_branch,
+        "fn tango_uniform_signal_alpha() {}",
+    ))
+    .await
+    .unwrap();
+    idx.add_chunk(raw(
+        other_repo_on_branch,
+        other_repo_on_branch,
+        "fn tango_uniform_signal_alpha() {}",
+    ))
+    .await
+    .unwrap();
+
+    let results = idx
+        .search(&SearchQuery {
+            text: "tango_uniform_signal_alpha".to_string(),
+            top_k: 10,
+            expand_graph: false,
+            compact: false,
+            path_prefix: Some("vendor/acme/".to_string()),
+            branch_files: Some(vec![on_branch.to_string()]),
+            branch_boost: 3.0,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    // Path filter: only vendor/acme/* chunks are present.
+    assert!(
+        results.iter().all(|c| c.id != other_repo_on_branch),
+        "path_prefix must exclude the other repo's chunk even though it's \
+         also on-branch; got {:?}",
+        results.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        results.len(),
+        2,
+        "both in-scope chunks must be present: {:?}",
+        results.iter().map(|c| &c.id).collect::<Vec<_>>()
+    );
+    // Branch boost still applies within the scoped set: on_branch outranks
+    // off_branch despite identical content.
+    let on_branch_pos = results.iter().position(|c| c.id == on_branch).unwrap();
+    let off_branch_pos = results.iter().position(|c| c.id == off_branch).unwrap();
+    assert!(
+        on_branch_pos < off_branch_pos,
+        "branch-boosted chunk must outrank the identical off-branch chunk \
+         within the path-scoped result set"
+    );
+    assert!(results[on_branch_pos].on_branch);
+    assert!(!results[off_branch_pos].on_branch);
+}
+
+/// `SearchQuery` must reject an unknown field rather than silently ignoring
+/// it (issue #3401) — a silently-dropped filter field returns too much data,
+/// which is the exact correctness trap the issue's reporter demonstrated
+/// (21 candidate field names all returned HTTP 200 with an identical result
+/// set before this fix).
+#[tokio::test]
+async fn test_search_query_rejects_unknown_field() {
+    let with_typo = serde_json::json!({
+        "text": "foo",
+        "path_prefx": "src/", // typo: missing the trailing 'i'
+    });
+    let err = serde_json::from_value::<SearchQuery>(with_typo)
+        .expect_err("a misspelled filter field must be rejected, not silently ignored");
+    assert!(
+        err.to_string().contains("path_prefx"),
+        "error should name the offending field: {err}"
+    );
+
+    // Sanity: the correctly-spelled field still deserializes fine.
+    let correct = serde_json::json!({
+        "text": "foo",
+        "path_prefix": "src/",
+    });
+    let q: SearchQuery =
+        serde_json::from_value(correct).expect("correctly-spelled field must deserialize");
+    assert_eq!(q.path_prefix.as_deref(), Some("src/"));
+}

--- a/crates/trusty-search/src/core/indexer/types.rs
+++ b/crates/trusty-search/src/core/indexer/types.rs
@@ -160,15 +160,25 @@ pub struct SearchQuery {
     pub refine_query: Option<String>,
 
     /// Restrict results to chunks whose file path starts with this prefix
-    /// (issue #3401). Applied during candidate selection — BEFORE `top_k`
-    /// truncation — in every retrieval lane (BM25, HNSW/vector, KG expansion),
-    /// never as a post-hoc filter over an already-truncated result set. See
-    /// `CodeIndexer::apply_score_adjustments` (the single choke point every
-    /// lane's candidates flow through pre-truncation) and
-    /// `lanes::vector_search_scoped` (predicate-pushed HNSW traversal, so a
-    /// path-scoped match ranked far outside the raw-similarity oversample
-    /// window is still found). Composes with `repos` via AND, and
-    /// independently with `exclude_archived` / the branch fields.
+    /// (issue #3401), matched at a path-segment boundary — `"foo"` does NOT
+    /// also match a sibling `"foobar"` directory. Accepts either the
+    /// root-relative form chunks are stored in, or the absolute form
+    /// `CodeChunk::file` returns in results (normalized internally against
+    /// the index's `root_path`), so a prefix copied from a prior result
+    /// works without the caller having to know which form to use.
+    ///
+    /// Applied during candidate selection — BEFORE `top_k` truncation — in
+    /// every retrieval lane: BM25 (`Bm25Index::score_query_all_with_filter`,
+    /// evaluated ahead of its own internal truncate, not after),
+    /// grep-fallback (evaluated ahead of its early-exit cutoff), HNSW/vector
+    /// (`lanes::vector_search_scoped`, predicate-pushed into HNSW traversal
+    /// itself so a path-scoped match ranked far outside the raw-similarity
+    /// oversample window is still found), and KG expansion — never as a
+    /// post-hoc filter over an already-truncated result set. See
+    /// `CodeIndexer::apply_score_adjustments` for the authoritative,
+    /// pre-truncation choke point every lane's candidates flow through.
+    /// Composes with `repos` via AND, and independently with
+    /// `exclude_archived` / the branch fields.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub path_prefix: Option<String>,
 

--- a/crates/trusty-search/src/core/indexer/types.rs
+++ b/crates/trusty-search/src/core/indexer/types.rs
@@ -116,7 +116,16 @@ pub enum SearchStage {
 }
 
 /// Query parameters for hybrid search.
+///
+/// `deny_unknown_fields` (issue #3401): a misspelled or unimplemented filter
+/// field (e.g. `path_prefx`) must be rejected, not silently dropped — for a
+/// *filter*, "unknown field ignored" means "returns too much data," which is
+/// a correctness trap, not a harmless typo. The reporter of #3401 proved the
+/// prior absence of path filtering by observing 21 candidate field names all
+/// return HTTP 200 with an identical result set; `deny_unknown_fields` turns
+/// that failure mode into an explicit 4xx.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SearchQuery {
     pub text: String,
     #[serde(default = "default_top_k")]
@@ -149,6 +158,26 @@ pub struct SearchQuery {
     /// Optional refining query for `search_kg` (issue #147).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refine_query: Option<String>,
+
+    /// Restrict results to chunks whose file path starts with this prefix
+    /// (issue #3401). Applied during candidate selection — BEFORE `top_k`
+    /// truncation — in every retrieval lane (BM25, HNSW/vector, KG expansion),
+    /// never as a post-hoc filter over an already-truncated result set. See
+    /// `CodeIndexer::apply_score_adjustments` (the single choke point every
+    /// lane's candidates flow through pre-truncation) and
+    /// `lanes::vector_search_scoped` (predicate-pushed HNSW traversal, so a
+    /// path-scoped match ranked far outside the raw-similarity oversample
+    /// window is still found). Composes with `repos` via AND, and
+    /// independently with `exclude_archived` / the branch fields.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path_prefix: Option<String>,
+
+    /// Restrict results to chunks whose file path names one of these repos as
+    /// a path segment (matches a leading `"{repo}/"` or an embedded
+    /// `"/{repo}/"`) — issue #3401. Same pre-truncation guarantee as
+    /// `path_prefix`; composes with it via AND.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repos: Vec<String>,
 }
 
 impl SearchQuery {
@@ -178,6 +207,8 @@ impl Default for SearchQuery {
             exclude_archived: false,
             stage: None,
             refine_query: None,
+            path_prefix: None,
+            repos: Vec::new(),
         }
     }
 }

--- a/crates/trusty-search/src/core/store/mod.rs
+++ b/crates/trusty-search/src/core/store/mod.rs
@@ -7,6 +7,7 @@
 //! (the primary concrete impl).
 //! Test: see `tests` submodule for async unit tests.
 
+pub(crate) mod path_match;
 #[cfg(test)]
 mod tests;
 mod types;

--- a/crates/trusty-search/src/core/store/path_match.rs
+++ b/crates/trusty-search/src/core/store/path_match.rs
@@ -1,27 +1,71 @@
-//! Shared path/repo predicate for `VectorStore::search_filtered` (issue #3401).
+//! Shared path/repo predicates for `VectorStore::search_filtered` (issue #3401).
 //!
-//! Why: both [`super::types::VectorStore`]'s default over-fetch fallback and
-//! [`super::usearch_impl`]'s predicate-pushed `UsearchStore` override need
-//! the exact same "does this chunk id/file path satisfy the filter?" check.
-//! Living here (rather than in `core::indexer::search::path_filter`, which
-//! wraps this for its `SearchQuery`-shaped call site) keeps `core::store`
-//! free of any dependency on the indexer module — it takes the filter as
-//! plain `Option<&str>` / `&[String]` data instead of a `SearchQuery`.
-//! What: `matches` — AND-composed `path_prefix` + `repos` check, identical
-//! semantics to `core::indexer::search::path_filter::matches`.
-//! Test: `test_prefix_and_repos_compose_with_and`,
-//! `test_empty_filter_matches_everything` below;
-//! `core::indexer::search::path_filter`'s tests cover the `SearchQuery`-facing
-//! wrapper.
+//! Why: [`super::types::VectorStore`]'s default over-fetch fallback,
+//! [`super::usearch_impl`]'s predicate-pushed `UsearchStore` override, and
+//! `core::indexer::search::path_filter` (which wraps these for its
+//! `SearchQuery`-shaped call site) all need "does this candidate satisfy the
+//! filter?" checks. Living here (rather than in the indexer module) keeps
+//! `core::store` free of any dependency on the indexer — it takes the
+//! filter as plain `Option<&str>` / `&[String]` data instead of a
+//! `SearchQuery`.
+//!
+//! **Two functions, not one** (code review finding, issue #3401): a chunk id
+//! (`"{file}:{start}:{end}"` or `"{file}::{type}::{name}::{start}"`, see
+//! `chunker::walk::make_chunk_id`) and a bare file path (`RawChunk::file` /
+//! `CodeChunk::file`) are different candidate SHAPES. `:` is both the
+//! chunk-id start/end separator AND a legal POSIX filename/directory
+//! character (ISO-8601 timestamp dirs, versioned artifact names) — a single
+//! shared boundary rule that accepts `:` unconditionally to satisfy chunk-id
+//! matching would then also let `path_prefix: "vendor/foo"` match a real
+//! directory named `vendor/foo:evil/`, which is exactly the sibling-prefix
+//! leak this module exists to close. So: [`matches_file`] (boundary is only
+//! end-of-string or `/` — used wherever the candidate is a bare file path)
+//! and [`matches_chunk_id`] (also accepts the literal chunk-id suffix
+//! grammar — used wherever the candidate is a chunk id).
+//!
+//! What: `matches_file` and `matches_chunk_id` each AND-compose `path_prefix`
+//! with `repos`; `is_chunk_id_suffix` validates the suffix shape
+//! `make_chunk_id` actually emits, rather than accepting any `:`.
+//!
+//! Test: `test_file_prefix_rejects_sibling_directory`,
+//! `test_chunk_id_prefix_rejects_colon_in_real_path_segment`,
+//! `test_exact_file_prefix_matches_its_own_chunk_ids`, and others below.
 
-/// Test whether `candidate` (a chunk id or file path — both begin with the
-/// literal file path, see `chunker::walk::make_chunk_id`) satisfies
-/// `path_prefix` (if set) AND every name in `repos` matching as a path
-/// segment (if non-empty). An empty filter (`path_prefix: None`,
-/// `repos: []`) always matches.
-pub(crate) fn matches(candidate: &str, path_prefix: Option<&str>, repos: &[String]) -> bool {
+/// Test whether `candidate` — a bare file path (`RawChunk::file` /
+/// `CodeChunk::file`) — satisfies `path_prefix` (if set) AND every name in
+/// `repos` matching as a path segment (if non-empty). An empty filter
+/// (`path_prefix: None`, `repos: []`) always matches.
+///
+/// Use this at any site whose candidate is a real file path, never a chunk
+/// id — the authoritative retain in `apply_score_adjustments` is the
+/// canonical caller.
+pub(crate) fn matches_file(candidate: &str, path_prefix: Option<&str>, repos: &[String]) -> bool {
+    matches_with(candidate, path_prefix, repos, file_prefix_boundary_ok)
+}
+
+/// Test whether `candidate` — a chunk id — satisfies `path_prefix` (if set)
+/// AND `repos` (if non-empty). Same composition as [`matches_file`], but the
+/// prefix boundary check also accepts a landing right at the start of the
+/// chunk-id suffix `make_chunk_id` appends after the file path.
+///
+/// Use this at any site whose candidate is a chunk id (BM25/grep/HNSW
+/// admission predicates), never a bare file path.
+pub(crate) fn matches_chunk_id(
+    candidate: &str,
+    path_prefix: Option<&str>,
+    repos: &[String],
+) -> bool {
+    matches_with(candidate, path_prefix, repos, chunk_id_prefix_boundary_ok)
+}
+
+fn matches_with(
+    candidate: &str,
+    path_prefix: Option<&str>,
+    repos: &[String],
+    prefix_boundary_ok: impl Fn(&str, &str) -> bool,
+) -> bool {
     if let Some(prefix) = path_prefix {
-        if !prefix.is_empty() && !prefix_matches_at_boundary(candidate, prefix) {
+        if !prefix.is_empty() && !prefix_boundary_ok(candidate, prefix) {
             return false;
         }
     }
@@ -39,35 +83,64 @@ pub(crate) fn matches(candidate: &str, path_prefix: Option<&str>, repos: &[Strin
     true
 }
 
-/// `true` when `candidate` starts with `prefix` at a genuine path-segment
-/// boundary — code review finding on issue #3401: a bare
-/// `candidate.starts_with(prefix)` lets `path_prefix: "/repos/foo"` also
-/// match `/repos/foobar/secret.rs`, silently leaking a sibling repo/dir into
-/// the "scoped" result set.
-///
-/// A boundary holds when `prefix` already ends in `/` (the caller opted in
-/// explicitly), `candidate` is exactly `prefix` (scoping to one exact file —
-/// no trailing content to bound), the byte immediately after `prefix` in
-/// `candidate` is `/` (the natural "next path segment" case, e.g.
-/// `prefix = "/repos/foo"`, `candidate = "/repos/foo/src/lib.rs"`), or that
-/// byte is `:` — `candidate` may be a chunk id rather than a bare file path
-/// (`"{file}:{start}:{end}"` / `"{file}::{type}::{name}::{start}"`, see
-/// `chunker::walk::make_chunk_id`), and `prefix` naming that file exactly
-/// (no trailing separator) must still match its own chunks. Falls through
-/// to `false` for anything else, including the `foo`/`foobar` collision and
-/// a prefix that lands mid-segment for any other reason (e.g.
-/// `candidate = "/repos/foo_backup/x.rs"` against `prefix = "/repos/foo"`).
-fn prefix_matches_at_boundary(candidate: &str, prefix: &str) -> bool {
+/// Boundary rule for a bare file path: `prefix` must be the whole of
+/// `candidate`, or `candidate` must continue with `/` right after it (or
+/// `prefix` was already `/`-terminated by the caller). No other byte is
+/// ever a valid boundary — in particular NOT `:`, which is a legal POSIX
+/// path character, so accepting it here would let `path_prefix: "vendor/foo"`
+/// match a real directory `vendor/foo:evil/...`.
+fn file_prefix_boundary_ok(candidate: &str, prefix: &str) -> bool {
     if !candidate.starts_with(prefix) {
         return false;
     }
     if prefix.ends_with('/') {
         return true;
     }
-    matches!(
-        candidate.as_bytes().get(prefix.len()),
-        None | Some(b'/') | Some(b':')
-    )
+    matches!(candidate.as_bytes().get(prefix.len()), None | Some(b'/'))
+}
+
+/// Boundary rule for a chunk id: everything [`file_prefix_boundary_ok`]
+/// accepts, PLUS landing exactly at the start of a genuine chunk-id suffix
+/// (validated against the shape `chunker::walk::make_chunk_id` actually
+/// emits — not "any `:`", which is what let a real `vendor/foo:evil/...`
+/// directory leak through in the prior version of this check).
+fn chunk_id_prefix_boundary_ok(candidate: &str, prefix: &str) -> bool {
+    if file_prefix_boundary_ok(candidate, prefix) {
+        return true;
+    }
+    if !candidate.starts_with(prefix) {
+        return false;
+    }
+    is_chunk_id_suffix(&candidate[prefix.len()..])
+}
+
+/// `true` when `suffix` (everything in a chunk id after a matched file-path
+/// prefix) is a syntactically valid chunk-id suffix — i.e. `suffix` starts
+/// with the literal grammar `make_chunk_id` emits, not merely a colon.
+///
+/// `make_chunk_id` emits exactly two shapes after `file`:
+///
+///   - `:{start_line}:{end_line}` — a SINGLE `:` immediately followed by an
+///     ASCII digit (line numbers are `usize`, so always `\d+`).
+///   - `::{chunk_type}::{name}::{start_line}` — a DOUBLE `::`.
+///
+/// Requiring a digit after a single `:` (rather than accepting any byte) is
+/// what distinguishes the real suffix `:10:20` from a real path segment
+/// that merely starts with a colon, e.g. `:evil/secret.rs` (`e` is not a
+/// digit → rejected) or `:bar.rs` (`b` is not a digit → rejected).
+fn is_chunk_id_suffix(suffix: &str) -> bool {
+    let bytes = suffix.as_bytes();
+    let Some(&first) = bytes.first() else {
+        return false; // no suffix at all — file_prefix_boundary_ok already covers this case
+    };
+    if first != b':' {
+        return false;
+    }
+    match bytes.get(1) {
+        Some(b':') => true,            // "::type::name::start" shape
+        Some(b) => b.is_ascii_digit(), // "start:end" shape
+        None => false,                 // bare trailing ":" — not a real suffix
+    }
 }
 
 #[cfg(test)]
@@ -76,23 +149,24 @@ mod tests {
 
     #[test]
     fn test_empty_filter_matches_everything() {
-        assert!(matches("/any/path.rs:1:2", None, &[]));
+        assert!(matches_file("/any/path.rs", None, &[]));
+        assert!(matches_chunk_id("/any/path.rs:1:2", None, &[]));
     }
 
     #[test]
     fn test_prefix_and_repos_compose_with_and() {
         let repos = vec!["foo".to_string()];
-        assert!(matches(
+        assert!(matches_chunk_id(
             "/repos/foo/src/lib.rs:1:2",
             Some("/repos/foo"),
             &repos
         ));
-        assert!(!matches(
+        assert!(!matches_chunk_id(
             "/repos/bar/src/lib.rs:1:2",
             Some("/repos/foo"),
             &repos
         ));
-        assert!(!matches(
+        assert!(!matches_chunk_id(
             "/repos/foo/tests/lib.rs:1:2",
             Some("/repos/foo/src"),
             &repos
@@ -101,49 +175,106 @@ mod tests {
 
     /// Code review finding (issue #3401): `path_prefix: "/repos/foo"` must
     /// NOT match a sibling directory that merely shares the prefix as a
-    /// string, e.g. `/repos/foobar/...`.
+    /// string, e.g. `/repos/foobar/...`. Pinned against BOTH functions.
     #[test]
-    fn test_prefix_does_not_match_sibling_directory() {
-        assert!(!matches(
-            "/repos/foobar/secret.rs:1:2",
+    fn test_file_prefix_rejects_sibling_directory() {
+        assert!(!matches_file(
+            "/repos/foobar/secret.rs",
             Some("/repos/foo"),
             &[]
         ));
-        // The true subtree entry (boundary at '/') still matches.
-        assert!(matches(
-            "/repos/foo/src/lib.rs:1:2",
+        assert!(matches_file(
+            "/repos/foo/src/lib.rs",
             Some("/repos/foo"),
             &[]
         ));
-        // A prefix the caller already terminated with '/' behaves the same
-        // (explicit opt-in boundary).
-        assert!(matches(
-            "/repos/foo/src/lib.rs:1:2",
+        assert!(matches_file(
+            "/repos/foo/src/lib.rs",
             Some("/repos/foo/"),
             &[]
         ));
-        assert!(!matches(
-            "/repos/foobar/secret.rs:1:2",
+        assert!(!matches_file(
+            "/repos/foobar/secret.rs",
             Some("/repos/foo/"),
             &[]
         ));
-        // Exact-file scoping: candidate equals prefix exactly.
-        assert!(matches("/repos/foo", Some("/repos/foo"), &[]));
+        assert!(matches_file("/repos/foo", Some("/repos/foo"), &[]));
     }
 
-    /// A `path_prefix` naming one exact file (no trailing separator) must
-    /// still match that file's own chunk ids, which carry a `:start:end` (or
-    /// `::type::name::start`) suffix rather than ending at the file path —
-    /// this is why the boundary check also accepts `:` as a valid next byte.
+    #[test]
+    fn test_chunk_id_prefix_rejects_sibling_directory() {
+        assert!(!matches_chunk_id(
+            "/repos/foobar/secret.rs:1:2",
+            Some("/repos/foo"),
+            &[]
+        ));
+        assert!(matches_chunk_id(
+            "/repos/foo/src/lib.rs:1:2",
+            Some("/repos/foo"),
+            &[]
+        ));
+    }
+
+    /// The exact regression the second code-review pass caught: the OLD
+    /// single-function boundary check accepted any `:` as a valid boundary
+    /// byte, so `path_prefix: "vendor/foo"` matched the real directory
+    /// `vendor/foo:evil/secret.rs` — a colon is a legal POSIX path
+    /// character, not just the chunk-id separator. `matches_file` must
+    /// reject this (candidate here is a bare file path, so the `:` boundary
+    /// allowance never applies at all), and `matches_chunk_id` must ALSO
+    /// reject it even though `:` is allowed there in principle, because the
+    /// byte after `:` is `e` (not a digit, not a second `:`) — it doesn't
+    /// match the real chunk-id suffix grammar.
+    #[test]
+    fn test_chunk_id_prefix_rejects_colon_in_real_path_segment() {
+        assert!(!matches_file(
+            "vendor/foo:evil/secret.rs",
+            Some("vendor/foo"),
+            &[]
+        ));
+        assert!(!matches_chunk_id(
+            "vendor/foo:evil/secret.rs:1:2",
+            Some("vendor/foo"),
+            &[]
+        ));
+        // Same shape, single-segment version (no trailing chunk suffix at
+        // all) — still must not match.
+        assert!(!matches_chunk_id(
+            "vendor/foo:evil/secret.rs",
+            Some("vendor/foo"),
+            &[]
+        ));
+        // And the extracted repro from the code-review comment.
+        assert!(!matches_chunk_id("src/foo:bar.rs", Some("src/foo"), &[]));
+    }
+
+    /// Canary: a `path_prefix` naming one exact file (no trailing
+    /// separator) must still match that file's own chunk ids, which carry a
+    /// `:start:end` (or `::type::name::start`) suffix rather than ending at
+    /// the file path — this is why `matches_chunk_id` accepts a validated
+    /// colon-led suffix as a boundary at all. Must NOT regress when the
+    /// boundary check is tightened against the colon-leak above.
     #[test]
     fn test_exact_file_prefix_matches_its_own_chunk_ids() {
-        assert!(matches("src/auth.rs:10:20", Some("src/auth.rs"), &[]));
-        assert!(matches(
+        assert!(matches_chunk_id(
+            "src/auth.rs:10:20",
+            Some("src/auth.rs"),
+            &[]
+        ));
+        assert!(matches_chunk_id(
             "src/auth.rs::function::login::10",
             Some("src/auth.rs"),
             &[]
         ));
-        // Still rejects a same-string-prefixed sibling file.
-        assert!(!matches("src/auth.rs.bak:1:2", Some("src/auth.rs"), &[]));
+        // Still rejects a same-string-prefixed sibling file (non-digit,
+        // non-double-colon after the single ':').
+        assert!(!matches_chunk_id(
+            "src/auth.rs.bak:1:2",
+            Some("src/auth.rs"),
+            &[]
+        ));
+        // A bare file path (no chunk suffix at all) for the SAME exact-file
+        // prefix must also match via matches_file (end-of-string boundary).
+        assert!(matches_file("src/auth.rs", Some("src/auth.rs"), &[]));
     }
 }

--- a/crates/trusty-search/src/core/store/path_match.rs
+++ b/crates/trusty-search/src/core/store/path_match.rs
@@ -115,32 +115,49 @@ fn chunk_id_prefix_boundary_ok(candidate: &str, prefix: &str) -> bool {
 }
 
 /// `true` when `suffix` (everything in a chunk id after a matched file-path
-/// prefix) is a syntactically valid chunk-id suffix — i.e. `suffix` starts
-/// with the literal grammar `make_chunk_id` emits, not merely a colon.
+/// prefix) is EXACTLY one of the two shapes `make_chunk_id` emits — the
+/// WHOLE remainder is validated, not just its first byte or two (code
+/// review finding, issue #3401: peeking only at the leading bytes let
+/// `src/foo::bar.rs:10:20` and `src/foo:9lives.rs:15:25` — neither of which
+/// is a real chunk-id suffix — pass as if they were, letting a
+/// coincidentally-named sibling file consume a slot in a lane's `want`
+/// candidate pool ahead of a genuine in-scope match — a recall bug, not a
+/// disclosure one, but the exact property #3401 exists to guarantee).
 ///
-/// `make_chunk_id` emits exactly two shapes after `file`:
+/// `make_chunk_id` emits exactly two shapes after `file`, and no others:
 ///
-///   - `:{start_line}:{end_line}` — a SINGLE `:` immediately followed by an
-///     ASCII digit (line numbers are `usize`, so always `\d+`).
-///   - `::{chunk_type}::{name}::{start_line}` — a DOUBLE `::`.
-///
-/// Requiring a digit after a single `:` (rather than accepting any byte) is
-/// what distinguishes the real suffix `:10:20` from a real path segment
-/// that merely starts with a colon, e.g. `:evil/secret.rs` (`e` is not a
-/// digit → rejected) or `:bar.rs` (`b` is not a digit → rejected).
+///   - `:{start_line}:{end_line}` — a single `:`, then a non-empty run of
+///     ASCII digits, then `:`, then a non-empty run of ASCII digits, with
+///     NOTHING else (line numbers are `usize`, so always plain `\d+`).
+///   - `::{chunk_type}::{name}::{start_line}` — `::`, then a non-empty
+///     colon-free run (`chunk_type`), then `::`, then a non-empty
+///     colon-free run (`name`), then `::`, then a non-empty run of ASCII
+///     digits (`start_line`), with NOTHING else.
 fn is_chunk_id_suffix(suffix: &str) -> bool {
-    let bytes = suffix.as_bytes();
-    let Some(&first) = bytes.first() else {
-        return false; // no suffix at all — file_prefix_boundary_ok already covers this case
-    };
-    if first != b':' {
-        return false;
+    fn all_digits(s: &str) -> bool {
+        !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
     }
-    match bytes.get(1) {
-        Some(b':') => true,            // "::type::name::start" shape
-        Some(b) => b.is_ascii_digit(), // "start:end" shape
-        None => false,                 // bare trailing ":" — not a real suffix
+    fn colon_free(s: &str) -> bool {
+        !s.is_empty() && !s.contains(':')
     }
+
+    if let Some(rest) = suffix.strip_prefix("::") {
+        // "::{chunk_type}::{name}::{start_line}" — must split into exactly
+        // three non-empty parts on "::", the last of which is all digits.
+        let parts: Vec<&str> = rest.split("::").collect();
+        return matches!(parts.as_slice(), [chunk_type, name, start]
+            if colon_free(chunk_type) && colon_free(name) && all_digits(start));
+    }
+    if let Some(rest) = suffix.strip_prefix(':') {
+        // "{start_line}:{end_line}" — must split into exactly two non-empty
+        // digit-only parts on the first remaining `:`.
+        let mut parts = rest.splitn(2, ':');
+        return match (parts.next(), parts.next()) {
+            (Some(start), Some(end)) => all_digits(start) && all_digits(end),
+            _ => false,
+        };
+    }
+    false
 }
 
 #[cfg(test)]
@@ -246,6 +263,29 @@ mod tests {
         ));
         // And the extracted repro from the code-review comment.
         assert!(!matches_chunk_id("src/foo:bar.rs", Some("src/foo"), &[]));
+    }
+
+    /// Third code-review pass (issue #3401): the boundary check must fully
+    /// parse the chunk-id suffix, not merely peek at its first byte or two.
+    /// Peeking accepted `src/foo::bar.rs:10:20` (the `::` branch matched
+    /// unconditionally past byte 2) and `src/foo:9lives.rs:15:25` (the
+    /// single-`:` branch accepted on one leading digit, never requiring the
+    /// rest of the segment to actually BE digits). Neither is a real
+    /// `make_chunk_id` suffix — both are real file names that happen to
+    /// start with a shape the old peek-based check mistook for one. Full
+    /// validation of the entire remainder rejects both.
+    #[test]
+    fn test_chunk_id_prefix_rejects_lookalike_full_suffix() {
+        assert!(!matches_chunk_id(
+            "src/foo::bar.rs:10:20",
+            Some("src/foo"),
+            &[]
+        ));
+        assert!(!matches_chunk_id(
+            "src/foo:9lives.rs:15:25",
+            Some("src/foo"),
+            &[]
+        ));
     }
 
     /// Canary: a `path_prefix` naming one exact file (no trailing

--- a/crates/trusty-search/src/core/store/path_match.rs
+++ b/crates/trusty-search/src/core/store/path_match.rs
@@ -21,7 +21,7 @@
 /// `repos: []`) always matches.
 pub(crate) fn matches(candidate: &str, path_prefix: Option<&str>, repos: &[String]) -> bool {
     if let Some(prefix) = path_prefix {
-        if !prefix.is_empty() && !candidate.starts_with(prefix) {
+        if !prefix.is_empty() && !prefix_matches_at_boundary(candidate, prefix) {
             return false;
         }
     }
@@ -37,6 +37,37 @@ pub(crate) fn matches(candidate: &str, path_prefix: Option<&str>, repos: &[Strin
         }
     }
     true
+}
+
+/// `true` when `candidate` starts with `prefix` at a genuine path-segment
+/// boundary — code review finding on issue #3401: a bare
+/// `candidate.starts_with(prefix)` lets `path_prefix: "/repos/foo"` also
+/// match `/repos/foobar/secret.rs`, silently leaking a sibling repo/dir into
+/// the "scoped" result set.
+///
+/// A boundary holds when `prefix` already ends in `/` (the caller opted in
+/// explicitly), `candidate` is exactly `prefix` (scoping to one exact file —
+/// no trailing content to bound), the byte immediately after `prefix` in
+/// `candidate` is `/` (the natural "next path segment" case, e.g.
+/// `prefix = "/repos/foo"`, `candidate = "/repos/foo/src/lib.rs"`), or that
+/// byte is `:` — `candidate` may be a chunk id rather than a bare file path
+/// (`"{file}:{start}:{end}"` / `"{file}::{type}::{name}::{start}"`, see
+/// `chunker::walk::make_chunk_id`), and `prefix` naming that file exactly
+/// (no trailing separator) must still match its own chunks. Falls through
+/// to `false` for anything else, including the `foo`/`foobar` collision and
+/// a prefix that lands mid-segment for any other reason (e.g.
+/// `candidate = "/repos/foo_backup/x.rs"` against `prefix = "/repos/foo"`).
+fn prefix_matches_at_boundary(candidate: &str, prefix: &str) -> bool {
+    if !candidate.starts_with(prefix) {
+        return false;
+    }
+    if prefix.ends_with('/') {
+        return true;
+    }
+    matches!(
+        candidate.as_bytes().get(prefix.len()),
+        None | Some(b'/') | Some(b':')
+    )
 }
 
 #[cfg(test)]
@@ -66,5 +97,53 @@ mod tests {
             Some("/repos/foo/src"),
             &repos
         ));
+    }
+
+    /// Code review finding (issue #3401): `path_prefix: "/repos/foo"` must
+    /// NOT match a sibling directory that merely shares the prefix as a
+    /// string, e.g. `/repos/foobar/...`.
+    #[test]
+    fn test_prefix_does_not_match_sibling_directory() {
+        assert!(!matches(
+            "/repos/foobar/secret.rs:1:2",
+            Some("/repos/foo"),
+            &[]
+        ));
+        // The true subtree entry (boundary at '/') still matches.
+        assert!(matches(
+            "/repos/foo/src/lib.rs:1:2",
+            Some("/repos/foo"),
+            &[]
+        ));
+        // A prefix the caller already terminated with '/' behaves the same
+        // (explicit opt-in boundary).
+        assert!(matches(
+            "/repos/foo/src/lib.rs:1:2",
+            Some("/repos/foo/"),
+            &[]
+        ));
+        assert!(!matches(
+            "/repos/foobar/secret.rs:1:2",
+            Some("/repos/foo/"),
+            &[]
+        ));
+        // Exact-file scoping: candidate equals prefix exactly.
+        assert!(matches("/repos/foo", Some("/repos/foo"), &[]));
+    }
+
+    /// A `path_prefix` naming one exact file (no trailing separator) must
+    /// still match that file's own chunk ids, which carry a `:start:end` (or
+    /// `::type::name::start`) suffix rather than ending at the file path —
+    /// this is why the boundary check also accepts `:` as a valid next byte.
+    #[test]
+    fn test_exact_file_prefix_matches_its_own_chunk_ids() {
+        assert!(matches("src/auth.rs:10:20", Some("src/auth.rs"), &[]));
+        assert!(matches(
+            "src/auth.rs::function::login::10",
+            Some("src/auth.rs"),
+            &[]
+        ));
+        // Still rejects a same-string-prefixed sibling file.
+        assert!(!matches("src/auth.rs.bak:1:2", Some("src/auth.rs"), &[]));
     }
 }

--- a/crates/trusty-search/src/core/store/path_match.rs
+++ b/crates/trusty-search/src/core/store/path_match.rs
@@ -1,0 +1,70 @@
+//! Shared path/repo predicate for `VectorStore::search_filtered` (issue #3401).
+//!
+//! Why: both [`super::types::VectorStore`]'s default over-fetch fallback and
+//! [`super::usearch_impl`]'s predicate-pushed `UsearchStore` override need
+//! the exact same "does this chunk id/file path satisfy the filter?" check.
+//! Living here (rather than in `core::indexer::search::path_filter`, which
+//! wraps this for its `SearchQuery`-shaped call site) keeps `core::store`
+//! free of any dependency on the indexer module — it takes the filter as
+//! plain `Option<&str>` / `&[String]` data instead of a `SearchQuery`.
+//! What: `matches` — AND-composed `path_prefix` + `repos` check, identical
+//! semantics to `core::indexer::search::path_filter::matches`.
+//! Test: `test_prefix_and_repos_compose_with_and`,
+//! `test_empty_filter_matches_everything` below;
+//! `core::indexer::search::path_filter`'s tests cover the `SearchQuery`-facing
+//! wrapper.
+
+/// Test whether `candidate` (a chunk id or file path — both begin with the
+/// literal file path, see `chunker::walk::make_chunk_id`) satisfies
+/// `path_prefix` (if set) AND every name in `repos` matching as a path
+/// segment (if non-empty). An empty filter (`path_prefix: None`,
+/// `repos: []`) always matches.
+pub(crate) fn matches(candidate: &str, path_prefix: Option<&str>, repos: &[String]) -> bool {
+    if let Some(prefix) = path_prefix {
+        if !prefix.is_empty() && !candidate.starts_with(prefix) {
+            return false;
+        }
+    }
+    if !repos.is_empty() {
+        let in_any_repo = repos.iter().any(|repo| {
+            if repo.is_empty() {
+                return false;
+            }
+            candidate.starts_with(&format!("{repo}/")) || candidate.contains(&format!("/{repo}/"))
+        });
+        if !in_any_repo {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_filter_matches_everything() {
+        assert!(matches("/any/path.rs:1:2", None, &[]));
+    }
+
+    #[test]
+    fn test_prefix_and_repos_compose_with_and() {
+        let repos = vec!["foo".to_string()];
+        assert!(matches(
+            "/repos/foo/src/lib.rs:1:2",
+            Some("/repos/foo"),
+            &repos
+        ));
+        assert!(!matches(
+            "/repos/bar/src/lib.rs:1:2",
+            Some("/repos/foo"),
+            &repos
+        ));
+        assert!(!matches(
+            "/repos/foo/tests/lib.rs:1:2",
+            Some("/repos/foo/src"),
+            &repos
+        ));
+    }
+}

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -886,3 +886,103 @@ async fn test_concurrent_saves_are_serialized_and_end_consistent() {
          partial/interleaved snapshot on disk"
     );
 }
+
+// ---- Predicate-pushed filtered search (issue #3401) --------------------
+
+/// This is the core proof for issue #3401's vector lane: a chunk that a
+/// plain `top_k` search would never surface (it ranks outside the window by
+/// raw cosine similarity) must still be found once the search is scoped to
+/// its repo/path, because `search_filtered` pushes the predicate INTO the
+/// HNSW traversal (`usearch::Index::filtered_search`) rather than filtering
+/// an already-truncated result set.
+///
+/// Why: a naive over-fetch-then-filter implementation would pass this test
+/// too IF the over-fetch factor happened to be deep enough, which is exactly
+/// the false confidence the issue warns about — so this test uses far more
+/// filler vectors (50) than any hard-coded over-fetch constant in this crate
+/// (`HNSW_OVERSAMPLE = 4`, so a `top_k=3` unfiltered call only ever
+/// considers ~12 candidates) to make sure the target is unreachable by
+/// over-fetch depth alone, and can only be found via genuine predicate
+/// pushdown.
+/// What: inserts 50 filler vectors near the query (under `"repoA/"`) plus
+/// one dissimilar target vector under `"repoB/target"`. Asserts (1) a plain
+/// `top_k=3` search never returns the target, then (2) `search_filtered`
+/// scoped to `"repoB/"` returns exactly the target.
+#[tokio::test]
+async fn test_filtered_search_finds_match_ranked_below_top_k() {
+    let store = UsearchStore::new(4).expect("store init");
+    let query = vec![1.0f32, 0.0, 0.0, 0.0];
+
+    // 50 filler vectors, all near-identical to the query — every one of them
+    // outranks the dissimilar target by cosine similarity.
+    for i in 0..50 {
+        store
+            .upsert(&format!("repoA/filler{i}"), vec![1.0, 0.0, 0.0, 0.0])
+            .await
+            .expect("upsert filler");
+    }
+    // The target: orthogonal to the query, so it ranks dead last among all
+    // 51 vectors by raw cosine similarity.
+    store
+        .upsert("repoB/target", vec![0.0, 1.0, 0.0, 0.0])
+        .await
+        .expect("upsert target");
+
+    // Precondition: a plain top_k=3 search never surfaces the target — it
+    // genuinely ranks outside the window, not just outside some arbitrary
+    // over-fetch depth.
+    let unfiltered = store.search(&query, 3).await.expect("unfiltered search");
+    assert_eq!(unfiltered.len(), 3);
+    assert!(
+        unfiltered.iter().all(|h| h.chunk_id != "repoB/target"),
+        "precondition failed: target must rank below top_k=3 unfiltered"
+    );
+
+    // Scoped search: the predicate is pushed into HNSW traversal, so it
+    // keeps exploring past the raw-similarity top_k window until it finds a
+    // match under "repoB/" — recovering the target despite its last-place
+    // global rank.
+    let repos = vec!["repoB".to_string()];
+    let filtered = store
+        .search_filtered(&query, 3, None, &repos)
+        .await
+        .expect("filtered search");
+    assert_eq!(
+        filtered.len(),
+        1,
+        "only one vector exists under repoB — filtered search must return exactly it"
+    );
+    assert_eq!(filtered[0].chunk_id, "repoB/target");
+}
+
+/// Companion correctness check: the predicate must also EXCLUDE non-matching
+/// keys, not just admit deep matches — a filter that always says "yes" would
+/// pass the recall test above for the wrong reason.
+#[tokio::test]
+async fn test_filtered_search_excludes_non_matching_keys() {
+    let store = UsearchStore::new(4).expect("store init");
+    let query = vec![1.0f32, 0.0, 0.0, 0.0];
+    for i in 0..5 {
+        store
+            .upsert(&format!("repoA/file{i}"), vec![1.0, 0.0, 0.0, 0.0])
+            .await
+            .expect("upsert repoA");
+    }
+    for i in 0..5 {
+        store
+            .upsert(&format!("repoB/file{i}"), vec![1.0, 0.0, 0.0, 0.0])
+            .await
+            .expect("upsert repoB");
+    }
+
+    let repos = vec!["repoA".to_string()];
+    let hits = store
+        .search_filtered(&query, 10, None, &repos)
+        .await
+        .expect("filtered search");
+    assert_eq!(hits.len(), 5, "only repoA's 5 vectors must be returned");
+    assert!(
+        hits.iter().all(|h| h.chunk_id.starts_with("repoA/")),
+        "no repoB chunk may leak through the filter: {hits:?}"
+    );
+}

--- a/crates/trusty-search/src/core/store/types.rs
+++ b/crates/trusty-search/src/core/store/types.rs
@@ -57,6 +57,54 @@ pub trait VectorStore: Send + Sync {
     async fn remove(&self, id: &str) -> Result<()>;
     async fn len(&self) -> Result<usize>;
 
+    /// Predicate-scoped nearest-neighbour search (issue #3401).
+    ///
+    /// Why: a caller-supplied path/repo filter must not lose recall to
+    /// `top_k` truncation. For an approximate index that means the predicate
+    /// has to be evaluated DURING traversal, not after — a chunk id ranked
+    /// far outside a raw-similarity `top_k` window by cosine distance alone
+    /// can still be the closest (or only) match once scoped to a repo, and no
+    /// over-fetch factor can guarantee catching it in general.
+    ///
+    /// Takes the filter as plain data (`path_prefix` / `repos`) rather than a
+    /// `dyn Fn` closure: `UsearchStore`'s override needs to call
+    /// `usearch::Index::filtered_search`'s synchronous `Fn(Key) -> bool`
+    /// callback from inside an `#[async_trait]` method, and a `&dyn Fn(&str)
+    /// -> bool` parameter threaded through `async_trait`'s generated
+    /// lifetime elision ties the callback's `&str` argument lifetime to the
+    /// parameter's own — plain borrowed data sidesteps that entirely, and it
+    /// is all either side actually needs (see [`path_match::matches`]).
+    /// What: default implementation is a best-effort fallback for backends
+    /// that cannot push a predicate into traversal — it over-fetches
+    /// (`top_k * 50`, capped) via plain [`Self::search`] and filters
+    /// client-side. This CAN still miss a match ranked beyond the over-fetch
+    /// window; it exists only so the trait stays total for mock/test stores
+    /// that never carry a real path filter. [`super::usearch_impl`]'s
+    /// `UsearchStore` overrides this with genuine predicate-pushed traversal
+    /// via `usearch::Index::filtered_search`, which is the only
+    /// implementation this crate actually relies on for correctness.
+    /// Test: `UsearchStore` — `test_filtered_search_finds_match_ranked_below_top_k`.
+    async fn search_filtered(
+        &self,
+        query: &[f32],
+        top_k: usize,
+        path_prefix: Option<&str>,
+        repos: &[String],
+    ) -> Result<Vec<VectorHit>> {
+        let overfetch = top_k.saturating_mul(50).max(top_k).min(100_000);
+        let hits = self.search(query, overfetch).await?;
+        let mut out = Vec::with_capacity(top_k.min(hits.len()));
+        for hit in hits {
+            if super::path_match::matches(hit.chunk_id.as_str(), path_prefix, repos) {
+                out.push(hit);
+                if out.len() >= top_k {
+                    break;
+                }
+            }
+        }
+        Ok(out)
+    }
+
     /// Bulk-upsert many `(chunk_id, embedding)` pairs.
     ///
     /// Why: per-chunk `upsert` acquires three write locks (`id_to_key`,

--- a/crates/trusty-search/src/core/store/types.rs
+++ b/crates/trusty-search/src/core/store/types.rs
@@ -73,7 +73,7 @@ pub trait VectorStore: Send + Sync {
     /// -> bool` parameter threaded through `async_trait`'s generated
     /// lifetime elision ties the callback's `&str` argument lifetime to the
     /// parameter's own — plain borrowed data sidesteps that entirely, and it
-    /// is all either side actually needs (see [`path_match::matches`]).
+    /// is all either side actually needs (see [`path_match::matches_chunk_id`]).
     /// What: default implementation is a best-effort fallback for backends
     /// that cannot push a predicate into traversal — it over-fetches
     /// (`top_k * 50`, capped) via plain [`Self::search`] and filters
@@ -95,7 +95,7 @@ pub trait VectorStore: Send + Sync {
         let hits = self.search(query, overfetch).await?;
         let mut out = Vec::with_capacity(top_k.min(hits.len()));
         for hit in hits {
-            if super::path_match::matches(hit.chunk_id.as_str(), path_prefix, repos) {
+            if super::path_match::matches_chunk_id(hit.chunk_id.as_str(), path_prefix, repos) {
                 out.push(hit);
                 if out.len() >= top_k {
                     break;

--- a/crates/trusty-search/src/core/store/usearch_impl.rs
+++ b/crates/trusty-search/src/core/store/usearch_impl.rs
@@ -114,7 +114,7 @@ impl VectorStore for UsearchStore {
     /// unfiltered search over the subgraph the predicate admits. The closure
     /// only has the `u64` HNSW key, so it resolves each candidate key back to
     /// its chunk id via `key_to_id` and checks it against `path_prefix` /
-    /// `repos` via [`super::path_match::matches`].
+    /// `repos` via [`super::path_match::matches_chunk_id`].
     /// What: holds `index` and `key_to_id` under READ locks for the duration
     /// of the (synchronous) `filtered_search` FFI call — safe to hold both
     /// simultaneously because no code path in this store acquires them as
@@ -143,10 +143,14 @@ impl VectorStore for UsearchStore {
 
         let index = self.index.read().await;
         let key_to_id = self.key_to_id.read().await;
+        // `key_to_id` resolves to chunk ids, not bare file paths — use
+        // `matches_chunk_id` (see `path_match` module docs for why the
+        // colon-suffix allowance it has must not leak into a bare-file-path
+        // check).
         let filter = |key: usearch::Key| {
-            key_to_id
-                .get(&key)
-                .is_some_and(|id| super::path_match::matches(id.as_str(), path_prefix, repos))
+            key_to_id.get(&key).is_some_and(|id| {
+                super::path_match::matches_chunk_id(id.as_str(), path_prefix, repos)
+            })
         };
         let matches = index
             .filtered_search(query, top_k, filter)

--- a/crates/trusty-search/src/core/store/usearch_impl.rs
+++ b/crates/trusty-search/src/core/store/usearch_impl.rs
@@ -102,6 +102,69 @@ impl VectorStore for UsearchStore {
         Ok(hits)
     }
 
+    /// Predicate-pushed HNSW traversal (issue #3401). See
+    /// [`VectorStore::search_filtered`] for why this must happen DURING
+    /// traversal rather than as a post-hoc filter, and for why the filter is
+    /// plain data (`path_prefix` / `repos`) rather than a `dyn Fn` closure.
+    ///
+    /// Why: `usearch::Index::filtered_search` takes a `Fn(Key) -> bool`
+    /// closure evaluated by the underlying C++ search itself, so it keeps
+    /// expanding the graph until `top_k` matches pass the predicate (or the
+    /// graph is exhausted) — genuinely no different, recall-wise, from an
+    /// unfiltered search over the subgraph the predicate admits. The closure
+    /// only has the `u64` HNSW key, so it resolves each candidate key back to
+    /// its chunk id via `key_to_id` and checks it against `path_prefix` /
+    /// `repos` via [`super::path_match::matches`].
+    /// What: holds `index` and `key_to_id` under READ locks for the duration
+    /// of the (synchronous) `filtered_search` FFI call — safe to hold both
+    /// simultaneously because no code path in this store acquires them as
+    /// writes together (see `upsert`/`upsert_batch`, which take them
+    /// sequentially, never nested) — then maps `(key, dist)` matches back to
+    /// `VectorHit`s exactly like [`Self::search`].
+    /// Test: `test_filtered_search_finds_match_ranked_below_top_k`,
+    /// `test_filtered_search_excludes_non_matching_keys`.
+    async fn search_filtered(
+        &self,
+        query: &[f32],
+        top_k: usize,
+        path_prefix: Option<&str>,
+        repos: &[String],
+    ) -> Result<Vec<VectorHit>> {
+        if query.len() != self.dim {
+            return Err(anyhow!(
+                "query dim mismatch: got {}, expected {}",
+                query.len(),
+                self.dim
+            ));
+        }
+        if top_k == 0 {
+            return Ok(Vec::new());
+        }
+
+        let index = self.index.read().await;
+        let key_to_id = self.key_to_id.read().await;
+        let filter = |key: usearch::Key| {
+            key_to_id
+                .get(&key)
+                .is_some_and(|id| super::path_match::matches(id.as_str(), path_prefix, repos))
+        };
+        let matches = index
+            .filtered_search(query, top_k, filter)
+            .map_err(|e| anyhow!("usearch filtered_search failed: {e}"))?;
+
+        let mut hits = Vec::with_capacity(matches.keys.len());
+        for (key, dist) in matches.keys.iter().zip(matches.distances.iter()) {
+            if let Some(chunk_id) = key_to_id.get(key) {
+                let score = 1.0 - *dist;
+                hits.push(VectorHit {
+                    chunk_id: chunk_id.clone(),
+                    score,
+                });
+            }
+        }
+        Ok(hits)
+    }
+
     async fn remove(&self, id: &str) -> Result<()> {
         // Promote view → mutable on first write. No-op when already mutable.
         self.ensure_mutable().await?;

--- a/crates/trusty-search/src/mcp/tools/descriptors.rs
+++ b/crates/trusty-search/src/mcp/tools/descriptors.rs
@@ -158,7 +158,7 @@ pub fn tool_descriptors() -> Value {
                     },
                     "path_prefix": {
                         "type": "string",
-                        "description": "Restrict results to chunks whose file path starts with this prefix. Applied during candidate selection in every retrieval lane (BM25, vector, KG) BEFORE top_k truncation, so a scoped match is never lost to the cutoff (issue #3401). Composes with `repos` (AND)."
+                        "description": "Restrict results to chunks whose file path starts with this prefix, matched at a path-segment boundary (\"foo\" will not also match a sibling \"foobar\" directory). Accepts either a root-relative path or the absolute form seen in a prior result's `file` field. Applied during candidate selection in every retrieval lane (BM25, vector, grep, KG) BEFORE top_k truncation, so a scoped match is never lost to the cutoff (issue #3401). Composes with `repos` (AND)."
                     },
                     "repos": {
                         "type": "array",

--- a/crates/trusty-search/src/mcp/tools/descriptors.rs
+++ b/crates/trusty-search/src/mcp/tools/descriptors.rs
@@ -41,7 +41,9 @@ pub fn tool_descriptors() -> Value {
                     "exclude_archived": { "type": "boolean", "default": false },
                     "branch_files":     { "type": "array", "items": { "type": "string" } },
                     "branch_boost":     { "type": "number" },
-                    "branch":           { "type": "string" }
+                    "branch":           { "type": "string" },
+                    "path_prefix":      { "type": "string", "description": "Restrict results to chunks whose file path starts with this prefix, applied before top_k truncation (issue #3401)." },
+                    "repos":            { "type": "array", "items": { "type": "string" }, "description": "Restrict results to chunks whose file path names one of these repos as a path segment (issue #3401)." }
                 },
                 "examples": [
                     { "index_id": "trusty-tools", "query": "apply_archive_downrank" },
@@ -61,7 +63,9 @@ pub fn tool_descriptors() -> Value {
                     "query":            { "type": "string", "description": "Conceptual query — meaning, not literal text" },
                     "top_k":            { "type": "integer", "default": 10 },
                     "mode":             { "type": "string", "enum": ["code", "text", "data"], "default": "code" },
-                    "exclude_archived": { "type": "boolean", "default": false }
+                    "exclude_archived": { "type": "boolean", "default": false },
+                    "path_prefix":      { "type": "string", "description": "Restrict results to chunks whose file path starts with this prefix, applied before top_k truncation (issue #3401)." },
+                    "repos":            { "type": "array", "items": { "type": "string" }, "description": "Restrict results to chunks whose file path names one of these repos as a path segment (issue #3401)." }
                 },
                 "examples": [
                     { "index_id": "trusty-tools", "query": "code that handles JWT verification" },
@@ -80,7 +84,9 @@ pub fn tool_descriptors() -> Value {
                     "query":         { "type": "string", "description": "Seed: a symbol name or chunk_id from a previous result" },
                     "top_k":         { "type": "integer", "default": 10 },
                     "mode":          { "type": "string", "enum": ["code", "text", "data"], "default": "code" },
-                    "refine_query":  { "type": "string", "description": "Optional: rerank and filter expanded KG neighbours by cosine similarity to this natural-language description. Neighbours below the 0.4 cosine threshold are dropped. Omit to use default KG expansion without filtering." }
+                    "refine_query":  { "type": "string", "description": "Optional: rerank and filter expanded KG neighbours by cosine similarity to this natural-language description. Neighbours below the 0.4 cosine threshold are dropped. Omit to use default KG expansion without filtering." },
+                    "path_prefix":   { "type": "string", "description": "Restrict results to chunks whose file path starts with this prefix, applied before top_k truncation (issue #3401)." },
+                    "repos":         { "type": "array", "items": { "type": "string" }, "description": "Restrict results to chunks whose file path names one of these repos as a path segment (issue #3401)." }
                 },
                 "examples": [
                     { "index_id": "trusty-tools", "query": "validate_token" },
@@ -105,7 +111,9 @@ pub fn tool_descriptors() -> Value {
                     "branch_boost":     { "type": "number" },
                     "branch":           { "type": "string" },
                     "serial":           { "type": "boolean", "default": false, "description": "Legacy fan-out only (issue #2845): force per-index searches to run one at a time instead of the bounded-concurrency default. Safety valve for memory/CPU-constrained hosts." },
-                    "max_fanout_concurrency": { "type": "integer", "description": "Legacy fan-out only (issue #2845): cap how many per-index searches run concurrently for this call, overriding the daemon default. Ignored when `serial` is true." }
+                    "max_fanout_concurrency": { "type": "integer", "description": "Legacy fan-out only (issue #2845): cap how many per-index searches run concurrently for this call, overriding the daemon default. Ignored when `serial` is true." },
+                    "path_prefix":      { "type": "string", "description": "Restrict results to chunks whose file path starts with this prefix, applied before top_k truncation (issue #3401)." },
+                    "repos":            { "type": "array", "items": { "type": "string" }, "description": "Restrict results to chunks whose file path names one of these repos as a path segment (issue #3401)." }
                 },
                 "examples": [
                     { "index_id": "trusty-tools", "query": "AuthValidator that handles refresh tokens" },
@@ -147,6 +155,15 @@ pub fn tool_descriptors() -> Value {
                     "branch": {
                         "type": "string",
                         "description": "Branch name; daemon will compute branch_files via git if branch_files is absent."
+                    },
+                    "path_prefix": {
+                        "type": "string",
+                        "description": "Restrict results to chunks whose file path starts with this prefix. Applied during candidate selection in every retrieval lane (BM25, vector, KG) BEFORE top_k truncation, so a scoped match is never lost to the cutoff (issue #3401). Composes with `repos` (AND)."
+                    },
+                    "repos": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Restrict results to chunks whose file path names one of these repos as a path segment. Same pre-truncation guarantee as `path_prefix` (issue #3401)."
                     }
                 }
             }

--- a/crates/trusty-search/src/mcp/tools/search.rs
+++ b/crates/trusty-search/src/mcp/tools/search.rs
@@ -74,6 +74,14 @@ pub(super) async fn dispatch_search_tool(
             if let Some(n) = args.get("max_fanout_concurrency").and_then(Value::as_u64) {
                 body["max_fanout_concurrency"] = Value::from(n);
             }
+            // Issue #3401: forward optional path/repo scoping to every
+            // per-index search in the fan-out.
+            if let Some(pp) = args.get("path_prefix").and_then(Value::as_str) {
+                body["path_prefix"] = Value::String(pp.to_string());
+            }
+            if let Some(repos) = args.get("repos") {
+                body["repos"] = repos.clone();
+            }
             Some(server.post("/search", &body).await)
         }
         "search" => {
@@ -122,6 +130,15 @@ pub(super) async fn dispatch_search_tool(
                     // downranking them.
                     if let Some(ea) = args.get("exclude_archived").and_then(Value::as_bool) {
                         b["exclude_archived"] = Value::Bool(ea);
+                    }
+                    // Issue #3401: forward optional path/repo scoping —
+                    // applied server-side BEFORE top_k truncation in every
+                    // retrieval lane.
+                    if let Some(pp) = args.get("path_prefix").and_then(Value::as_str) {
+                        b["path_prefix"] = Value::String(pp.to_string());
+                    }
+                    if let Some(repos) = args.get("repos") {
+                        b["repos"] = repos.clone();
                     }
                     b
                 }
@@ -308,6 +325,14 @@ impl McpServer {
         // `expand_with_kg` only reads it when the graph stage is active.
         if let Some(rq) = args.get("refine_query").and_then(Value::as_str) {
             body["refine_query"] = Value::String(rq.to_string());
+        }
+        // Issue #3401: forward optional path/repo scoping — applied
+        // server-side BEFORE top_k truncation in every retrieval lane.
+        if let Some(pp) = args.get("path_prefix").and_then(Value::as_str) {
+            body["path_prefix"] = Value::String(pp.to_string());
+        }
+        if let Some(repos) = args.get("repos") {
+            body["repos"] = repos.clone();
         }
 
         let resp = self

--- a/crates/trusty-search/src/service/server/search_global.rs
+++ b/crates/trusty-search/src/service/server/search_global.rs
@@ -71,6 +71,15 @@ pub struct GlobalSearchRequest {
     /// Takes precedence over `max_fanout_concurrency`.
     #[serde(default)]
     pub serial: bool,
+
+    /// Path/repo scoping forwarded to every per-index search (issue #3401).
+    /// See `SearchQuery::path_prefix` / `SearchQuery::repos` for the
+    /// pre-truncation guarantee; identical semantics here, just applied
+    /// per-index before this handler's own cross-index RRF fusion.
+    #[serde(default)]
+    pub path_prefix: Option<String>,
+    #[serde(default)]
+    pub repos: Vec<String>,
 }
 
 fn default_global_top_k() -> usize {
@@ -251,6 +260,9 @@ pub(super) async fn global_search_handler(
         // lexical when the semantic lane isn't ready (issue #109 Phase 1).
         stage: None,
         refine_query: None,
+        // Issue #3401: forward path/repo scoping to every per-index search.
+        path_prefix: req.path_prefix.clone(),
+        repos: req.repos.clone(),
     };
 
     // Run the per-index searches with *bounded* concurrency (issue #2845).

--- a/crates/trusty-search/src/service/server/search_global.rs
+++ b/crates/trusty-search/src/service/server/search_global.rs
@@ -22,7 +22,14 @@ use super::state::SearchAppState;
 /// project an answer lives in. A single fan-out search across every
 /// registered index, with results re-ranked via Reciprocal Rank Fusion, lets
 /// them ask one question and get one merged answer.
+///
+/// `deny_unknown_fields` (issue #3401 code review MEDIUM finding): this is
+/// one of the two public request surfaces that now carry `path_prefix` /
+/// `repos` (the other, `SearchQuery`, already derives this) — a misspelled
+/// filter field must be rejected here too, or the fan-out endpoint reopens
+/// the exact silently-ignored-filter trap the per-index endpoint just closed.
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct GlobalSearchRequest {
     pub query: String,
     #[serde(default = "default_global_top_k")]

--- a/crates/trusty-search/src/service/server/tests_health.rs
+++ b/crates/trusty-search/src/service/server/tests_health.rs
@@ -278,6 +278,8 @@ async fn global_search_fans_out_and_merges() {
             routing_threshold: None,
             max_fanout_concurrency: None,
             serial: false,
+            path_prefix: None,
+            repos: Vec::new(),
         }),
     )
     .await
@@ -338,6 +340,8 @@ async fn global_search_empty_registry_returns_empty_results() {
             routing_threshold: None,
             max_fanout_concurrency: None,
             serial: false,
+            path_prefix: None,
+            repos: Vec::new(),
         }),
     )
     .await
@@ -389,6 +393,8 @@ async fn global_search_restricts_to_named_indexes() {
             routing_threshold: None,
             max_fanout_concurrency: None,
             serial: false,
+            path_prefix: None,
+            repos: Vec::new(),
         }),
     )
     .await
@@ -519,6 +525,8 @@ fn routing_mode_from_request_resolves_strategy() {
             routing_threshold: t,
             max_fanout_concurrency: None,
             serial: false,
+            path_prefix: None,
+            repos: Vec::new(),
         }
     };
     assert!(matches!(

--- a/crates/trusty-search/src/service/server/tests_health.rs
+++ b/crates/trusty-search/src/service/server/tests_health.rs
@@ -7,6 +7,26 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
 
+/// Shared base for `GlobalSearchRequest` test literals — every field except
+/// `query` / `top_k` at its neutral no-op value. Keeps each test's `Json(...)`
+/// body down to the one or two fields it's actually exercising, via struct-
+/// update syntax, rather than repeating all eleven fields per call site.
+fn base_global_search_request(query: &str, top_k: usize) -> GlobalSearchRequest {
+    GlobalSearchRequest {
+        query: query.to_string(),
+        top_k,
+        full_content: false,
+        indexes: None,
+        routing: None,
+        routing_n: None,
+        routing_threshold: None,
+        max_fanout_concurrency: None,
+        serial: false,
+        path_prefix: None,
+        repos: Vec::new(),
+    }
+}
+
 /// Why: `/health` is consumed by external probes (open-mpm,
 /// `ensure_daemon_running`) — the contract `{ status, version, indexes,
 /// uptime_secs }` must remain stable.
@@ -266,24 +286,10 @@ async fn global_search_fans_out_and_merges() {
     }
 
     let state = Arc::new(SearchAppState::new(registry));
-    let Json(value) = global_search_handler(
-        State(state),
-        Json(GlobalSearchRequest {
-            query: "alpha".into(),
-            top_k: 10,
-            full_content: false,
-            indexes: None,
-            routing: None,
-            routing_n: None,
-            routing_threshold: None,
-            max_fanout_concurrency: None,
-            serial: false,
-            path_prefix: None,
-            repos: Vec::new(),
-        }),
-    )
-    .await
-    .expect("handler ok");
+    let Json(value) =
+        global_search_handler(State(state), Json(base_global_search_request("alpha", 10)))
+            .await
+            .expect("handler ok");
 
     let total = value["total_indexes"].as_u64().expect("total_indexes");
     assert_eq!(total, 2, "both indexes counted");
@@ -330,19 +336,7 @@ async fn global_search_empty_registry_returns_empty_results() {
     let state = Arc::new(SearchAppState::new(IndexRegistry::new()));
     let Json(value) = global_search_handler(
         State(state),
-        Json(GlobalSearchRequest {
-            query: "anything".into(),
-            top_k: 5,
-            full_content: false,
-            indexes: None,
-            routing: None,
-            routing_n: None,
-            routing_threshold: None,
-            max_fanout_concurrency: None,
-            serial: false,
-            path_prefix: None,
-            repos: Vec::new(),
-        }),
+        Json(base_global_search_request("anything", 5)),
     )
     .await
     .expect("handler ok");
@@ -384,17 +378,8 @@ async fn global_search_restricts_to_named_indexes() {
     let Json(value) = global_search_handler(
         State(state),
         Json(GlobalSearchRequest {
-            query: "alpha".into(),
-            top_k: 10,
-            full_content: false,
             indexes: Some(vec!["proj-a".into(), "proj-c".into()]),
-            routing: None,
-            routing_n: None,
-            routing_threshold: None,
-            max_fanout_concurrency: None,
-            serial: false,
-            path_prefix: None,
-            repos: Vec::new(),
+            ..base_global_search_request("alpha", 10)
         }),
     )
     .await
@@ -516,17 +501,10 @@ fn routing_threshold_keeps_neutral_indexes() {
 fn routing_mode_from_request_resolves_strategy() {
     let base = |routing: Option<&str>, n: Option<usize>, t: Option<f32>| -> GlobalSearchRequest {
         GlobalSearchRequest {
-            query: "x".into(),
-            top_k: 1,
-            full_content: false,
-            indexes: None,
             routing: routing.map(|s| s.to_string()),
             routing_n: n,
             routing_threshold: t,
-            max_fanout_concurrency: None,
-            serial: false,
-            path_prefix: None,
-            repos: Vec::new(),
+            ..base_global_search_request("x", 1)
         }
     };
     assert!(matches!(

--- a/crates/trusty-search/src/service/server/tests_list.rs
+++ b/crates/trusty-search/src/service/server/tests_list.rs
@@ -302,6 +302,8 @@ async fn global_search_nested_hierarchy_dedup_count_present() {
             routing_threshold: None,
             max_fanout_concurrency: None,
             serial: false,
+            path_prefix: None,
+            repos: Vec::new(),
         }),
     )
     .await
@@ -382,6 +384,8 @@ async fn global_search_sub_index_boost_applied() {
             routing_threshold: None,
             max_fanout_concurrency: None,
             serial: false,
+            path_prefix: None,
+            repos: Vec::new(),
         }),
     )
     .await
@@ -465,6 +469,8 @@ async fn global_search_serial_returns_all_results() {
             routing_threshold: None,
             max_fanout_concurrency: None,
             serial: true,
+            path_prefix: None,
+            repos: Vec::new(),
         }),
     )
     .await
@@ -526,6 +532,8 @@ async fn global_search_request_override_echoed() {
             routing_threshold: None,
             max_fanout_concurrency: Some(4),
             serial: false,
+            path_prefix: None,
+            repos: Vec::new(),
         }),
     )
     .await

--- a/crates/trusty-search/src/service/server/tests_search.rs
+++ b/crates/trusty-search/src/service/server/tests_search.rs
@@ -51,6 +51,8 @@ async fn search_handler_rejects_empty_query() {
                 mode: crate::core::indexer::SearchMode::Code,
                 exclude_archived: false,
                 refine_query: None,
+                path_prefix: None,
+                repos: Vec::new(),
             }),
         )
         .await;
@@ -228,6 +230,8 @@ async fn last_queried_cache_rate_limits_disk_writes() {
         mode: crate::core::indexer::SearchMode::Code,
         exclude_archived: false,
         refine_query: None,
+        path_prefix: None,
+        repos: Vec::new(),
     };
     let _ = search_handler(
         axum::extract::State(Arc::clone(&state)),
@@ -309,6 +313,8 @@ async fn search_handler_meta_includes_stale_index_root_field() {
             mode: crate::core::indexer::SearchMode::Code,
             exclude_archived: false,
             refine_query: None,
+            path_prefix: None,
+            repos: Vec::new(),
         }),
     )
     .await;
@@ -396,6 +402,8 @@ async fn test_global_search_surfaces_cold_indexes_skipped() {
             routing_threshold: None,
             max_fanout_concurrency: None,
             serial: false,
+            path_prefix: None,
+            repos: Vec::new(),
         }),
     )
     .await;

--- a/crates/trusty-search/src/service/ui.rs
+++ b/crates/trusty-search/src/service/ui.rs
@@ -424,6 +424,8 @@ async fn search_for_context(
         exclude_archived: false,
         stage: None,
         refine_query: None,
+        path_prefix: None,
+        repos: Vec::new(),
     };
     let indexer = handle.indexer.read().await;
     let results = indexer.search(&q).await.map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary

Adds server-side `path_prefix` / `repos` scoping to hybrid search, so a caller can restrict results to a repo/path subtree within a single unified index instead of needing a separate physical index per repo (closes #3401).

**The critical requirement**: the filter is applied during candidate selection — strictly BEFORE `top_k` truncation — in every retrieval lane, so a scoped-in chunk that ranks weakly against the *unscoped* query is never lost.

### Hook points per retrieval mode

- **Vector/HNSW** (`core/indexer/search/lanes.rs::vector_search_scoped`): when a filter is active, pushes the predicate directly INTO HNSW graph traversal via a new `VectorStore::search_filtered` (`core/store/types.rs`), implemented in `UsearchStore` (`core/store/usearch_impl.rs`) using `usearch::Index::filtered_search` — already available in the pinned `usearch = "2.25"` dependency, no version bump needed. This is genuinely recall-safe: the predicate is evaluated *during* graph exploration, not after, so a chunk ranking arbitrarily far outside the raw-similarity oversample window is still found. I did **not** need to fall back to a calibrated over-fetch multiplier (the "v1" option raised as the design fork) — the recall-safe primitive was already sitting in the pinned dependency at comparable implementation cost.
- **BM25/grep/KG**: every chunk id already encodes its literal file path (`chunker::walk::make_chunk_id` — `"{file}:{start}:{end}"` or `"{file}::{type}::{name}::{start}"`), so these lanes are filtered on the id string directly, no corpus lookup needed. There's a single **authoritative** retain in `apply_score_adjustments` (against the real `RawChunk::file`, already fetched there for the other score adjustments) — this is the one choke point every lane's candidates flow through immediately before `materialize_search_results`'s `take(query.top_k)`. I also had to add id-based retains right after the BM25/grep lanes themselves (before RRF fuse / MMR rerank), because those stages independently truncate to the internal `want` oversample window — without that, a heavily-matched-but-out-of-scope filler candidate could crowd the correctly-filtered vector-lane hit out of the fusion stage before the authoritative retain ever ran. Caught this via the pre-truncation test below (it initially failed with an empty result set).

### Test proving the pre-truncation property

`core/indexer/tests/path_filter_search.rs::test_path_prefix_filter_survives_top_k_truncation` (and its `repos` counterpart): constructs 20 filler chunks that dominate both BM25 and vector similarity for the query, plus one target chunk under a different path whose content shares zero BM25 tokens with the query. With `top_k=3` (internal oversample window ~12), the target ranks last among 21 candidates:
1. Asserts the **unfiltered** query never returns the target (precondition — proves it genuinely ranks below the cutoff, not just below some arbitrary post-filter).
2. Asserts the `path_prefix`-scoped query **does** return it — the property a post-hoc filter cannot satisfy.

Also: `core/store/tests.rs::test_filtered_search_finds_match_ranked_below_top_k` pins the same property directly at the `UsearchStore`/usearch level (50 filler vectors + 1 orthogonal target), plus `test_filtered_search_excludes_non_matching_keys` for the converse (no false positives). Composition tests cover `exclude_archived` and the branch-boost fields. A `deny_unknown_fields` test proves a misspelled filter field is now rejected rather than silently ignored.

### `deny_unknown_fields`

Added to `SearchQuery`. A silently-dropped filter field is a correctness trap for a *filter* specifically (it means "return too much data" instead of an error) — this is exactly how the issue's reporter proved the feature was absent (21 candidate field names all returned HTTP 200 unfiltered). Scoped to `SearchQuery` only (not `GlobalSearchRequest`, to keep the change tightly scoped to the struct the issue targets).

### Surface

`SearchQuery` (HTTP `/indexes/:id/search`), `GlobalSearchRequest` (fan-out `POST /search`), and the MCP `search` / `search_lexical` / `search_semantic` / `search_kg` / `search_all` tool schemas + dispatch.

### Gate (raw output)

```
cargo test -p trusty-search --lib
test result: ok. 1170 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out

cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --no-fail-fast
# trusty-search: 1170 passed; 0 failed; 1 ignored
# 2 unrelated pre-existing failures, confirmed to also fail/flake on unmodified origin/main in isolation:
#   - trusty-agents: workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts
#     (passes cleanly alone; flakes only under full-workspace parallel load — a pre-existing shared-state race, not touched by this PR)
#   - trusty-code: run_task::tests::repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap
#     (fails in isolation too, but due to a live trusty-memory daemon on this dev box returning
#     a stale palace-metadata error — an environment/daemon-state dependency, not this PR)

cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings
# 0 errors

cargo fmt --check
# clean, no diff
```

(trusty-mpm-gui / trusty-code-gui / trusty-agents-ui excluded per `.github/workflows/ci.yml`'s own exclusion — Tauri desktop apps needing a built frontend/WebKit2GTK.)

## Test plan

- [x] `cargo test -p trusty-search --lib` — 1170 passed
- [x] `cargo test --workspace` (CI exclusions) — green except 2 confirmed-unrelated pre-existing flakes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual review of `CHANGELOG.md` `[Unreleased]` entry for release-notes clarity

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools