### PR TITLE
fix(trusty-search): degrade file watcher loudly on network-mounted index roots

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **Network-mount detection for the file watcher** ([#3408](https://github.com/bobmatnyc/trusty-tools/issues/3408)):
+  the daemon now detects when a registered index's root is a network-mounted
+  filesystem (EFS/NFS/SMB/CIFS — via `statfs` on macOS/Linux) and refuses to
+  start the file watcher for that index instead of silently starting one that
+  can never observe another host's writes (inotify/FSEvents are local-host-only
+  kernel mechanisms — an OS-level limitation, not a bug). The condition is
+  surfaced on `GET /health` (`indexes_watcher_network_degraded`) and
+  `GET /indexes/:id/status` (`watcher.network_mount_degraded` +
+  `watcher.degraded_reason`), naming `POST /indexes/:id/index-file` and
+  `POST /indexes/:id/remove-file` as the actionable next step. Detection is
+  conservative (fails open to "local") so it never blocks a legitimate local
+  watcher. Also officially documents those two endpoints (and their `index_file`
+  / `remove_file` MCP equivalents) as the supported incremental-indexing path
+  for network-mounted and build/serve-split deployments, with a worked example —
+  see `README.md` and `CLAUDE.md`'s endpoint catalogue.
+
 ## [0.35.0] — 2026-07-19
 
 ### Security

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -108,9 +108,23 @@ daemon.
   ```json
   { "status": "ok", "version": "0.1.0", "indexes": 3 }
   ```
-  - `status`: always `"ok"` when the daemon is up.
+  - `status`: `"ok"` normally; `"degraded"` when at least one registered index
+    has a failed search lane (issue #1870) OR at least one index's file
+    watcher was refused because its root is network-mounted (issue #3408 —
+    see `indexes_watcher_network_degraded` below).
   - `version`: `CARGO_PKG_VERSION` of the running binary.
   - `indexes`: number of indexes currently registered in the in-memory registry.
+  - `indexes_watcher_network_degraded` (issue #3408): count of registered
+    indexes whose file watcher was refused because `root_path` was detected as
+    a network-mounted filesystem (NFS/EFS/SMB/CIFS). inotify/FSEvents cannot
+    observe writes made by a *different* host onto a shared network mount —
+    an OS-level limitation, not a bug — so starting the watcher there would
+    leave the daemon reporting healthy while silently never reacting to
+    cross-host changes. A non-zero count means those indexes must be kept in
+    sync via `POST /indexes/:id/index-file` / `POST /indexes/:id/remove-file`
+    instead — see "Supported network-mount pattern" under
+    `POST /indexes/:id/remove-file` below. Per-index detail (which index, and
+    the actionable message) is on `GET /indexes/:id/status`'s `watcher` field.
 
 ##### `GET /indexes`
 
@@ -158,9 +172,20 @@ Per-index stats.
   {
     "index_id": "my-project",
     "root_path": "/Users/me/code/my-project",
-    "chunk_count": 14823
+    "chunk_count": 14823,
+    "watcher": {
+      "active": true,
+      "network_mount_degraded": false,
+      "degraded_reason": null
+    }
   }
   ```
+  - `watcher` (issue #3408): `active` is whether a live OS-level watcher is
+    currently running for this index. `network_mount_degraded` is `true` when
+    the watcher was refused because `root_path` was detected as
+    network-mounted; `degraded_reason` then carries the full actionable
+    message (names the `index-file`/`remove-file` endpoints). Both are
+    `false`/`null` for a normal local-disk index.
 - **Response 404**: unknown `index_id`.
 
 ##### `POST /indexes/:id/search`
@@ -266,6 +291,71 @@ Remove a file (and all its chunks) from the index.
   ```json
   { "index_id": "my-project", "path": "src/auth.rs", "removed_chunks": 4 }
   ```
+
+###### Supported network-mount pattern (EFS/NFS/SMB) — issue #3408
+
+**`POST /indexes/:id/index-file` and `POST /indexes/:id/remove-file` are the
+officially supported, stability-committed incremental-indexing path for
+network-mounted (EFS/NFS/SMB/CIFS) and build/serve-split deployments.** This
+is not a fallback or a workaround — it is the correct integration point
+whenever the index root is not a local disk local to the daemon's host.
+
+Why this is necessary (rather than just a suggestion): the native file watcher
+(`service/watcher.rs`, backed by `notify`'s inotify/FSEvents) is a *local-host
+kernel notification* mechanism. It cannot observe a write made by a
+*different* host onto a shared network mount — this is a limitation of
+inotify/FSEvents themselves, not something this crate can fix by retrying or
+reconfiguring the debouncer. A build box that writes to a shared EFS/NFS mount
+will never wake a serving box's inotify watch. As of issue #3408 the daemon
+detects a network-mounted index root (via `statfs` — see
+`service/network_fs.rs`) and refuses to start the watcher for that index
+rather than silently reporting healthy while never reacting to changes; see
+`indexes_watcher_network_degraded` (`GET /health`) and the `watcher` field
+(`GET /indexes/:id/status`) above.
+
+Equivalent MCP tools: `index_file` (`{ index_id, path, content }`) and
+`remove_file` (`{ index_id, path }`) — see "MCP Tools" below.
+
+**Worked example — a build box pushes to shared storage; each consumer (e.g. a
+CI job, a git post-merge hook, or a small sidecar poller) detects its own
+changes and drives the daemon directly:**
+
+```bash
+#!/usr/bin/env bash
+# Run after `git pull` (or any local mutation of the network-mounted root),
+# from a process that has its own view of what changed — e.g. `git diff`
+# against the previous HEAD, an fswatch on the LOCAL side of a build step, or
+# a CI job's own manifest of touched files. Do NOT rely on the daemon's
+# watcher to discover these — see the "why" above.
+set -euo pipefail
+INDEX_ID="my-project"
+DAEMON="http://127.0.0.1:$(trusty-search port)"
+
+git diff --name-status "$PREV_HEAD" HEAD | while read -r status path; do
+  case "$status" in
+    D)
+      curl -sf -X POST "$DAEMON/indexes/$INDEX_ID/remove-file" \
+        -H 'Content-Type: application/json' \
+        -d "$(jq -n --arg path "$path" '{path: $path}')"
+      ;;
+    A|M)
+      content=$(jq -Rs . < "$path")
+      curl -sf -X POST "$DAEMON/indexes/$INDEX_ID/index-file" \
+        -H 'Content-Type: application/json' \
+        -d "$(jq -n --arg path "$path" --argjson content "$content" \
+              '{path: $path, content: $content}')"
+      ;;
+  esac
+done
+```
+
+Note: `index_file` triggers a full `rebuild_symbol_graph` per call
+(`core/indexer/ingest/mod.rs`) — fine for a handful of files per push. There is
+currently no HTTP/MCP-exposed batch variant (the internal
+`index_files_batch_no_rebuild` fast path is only used by the full-reindex
+pipeline); a consumer that needs to apply a LARGE batch of per-file changes at
+once (e.g. after pulling hundreds of commits) should prefer
+`POST /indexes/:id/reindex` over looping many single-file `index-file` calls.
 
 ##### `POST /indexes/:id/reindex`
 

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -331,7 +331,12 @@ set -euo pipefail
 INDEX_ID="my-project"
 DAEMON="http://127.0.0.1:$(trusty-search port)"
 
-git diff --name-status "$PREV_HEAD" HEAD | while read -r status path; do
+# IFS=$'\t': git's --name-status output is TAB-delimited (not generic
+# whitespace), so this also handles paths containing spaces correctly. A
+# rename line has a THIRD field ("R100<TAB>old_path<TAB>new_path"); reading
+# into three variables leaves $new_path empty for D/A/M lines and populated
+# only for renames.
+git diff --name-status "$PREV_HEAD" HEAD | while IFS=$'\t' read -r status path new_path; do
   case "$status" in
     D)
       curl -sf -X POST "$DAEMON/indexes/$INDEX_ID/remove-file" \
@@ -343,6 +348,20 @@ git diff --name-status "$PREV_HEAD" HEAD | while read -r status path; do
       curl -sf -X POST "$DAEMON/indexes/$INDEX_ID/index-file" \
         -H 'Content-Type: application/json' \
         -d "$(jq -n --arg path "$path" --argjson content "$content" \
+              '{path: $path, content: $content}')"
+      ;;
+    R*)
+      # Rename (any similarity index, e.g. R100 or R087): $path is the OLD
+      # path, $new_path is the new one. git diff --name-status gives no
+      # chunk-level delta for a rename, so remove the old path's chunks and
+      # index the new path fresh — simplest and correct.
+      curl -sf -X POST "$DAEMON/indexes/$INDEX_ID/remove-file" \
+        -H 'Content-Type: application/json' \
+        -d "$(jq -n --arg path "$path" '{path: $path}')"
+      content=$(jq -Rs . < "$new_path")
+      curl -sf -X POST "$DAEMON/indexes/$INDEX_ID/index-file" \
+        -H 'Content-Type: application/json' \
+        -d "$(jq -n --arg path "$new_path" --argjson content "$content" \
               '{path: $path, content: $content}')"
       ;;
   esac

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -220,7 +220,11 @@ candle-transformers = { version = "0.8", optional = true }
 hf-hub = { version = "0.3", optional = true, features = ["tokio"] }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["signal", "user"] }
+# `fs` enables `nix::sys::statfs` (issue #3408): the network-mount detector
+# uses it to read the filesystem type at the watcher's root path (macOS
+# `f_fstypename`; Linux `f_type` magic number) so the watcher can detect an
+# EFS/NFS/SMB mount instead of silently never firing.
+nix = { version = "0.29", features = ["signal", "user", "fs"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/trusty-search/README.md
+++ b/crates/trusty-search/README.md
@@ -579,6 +579,32 @@ fields that let operators diagnose why a reindex produced zero chunks:
 These fields are populated every time a reindex task runs. On a healthy index
 with chunks you will see `last_walk_error: null` and `last_walk_files_seen > 0`.
 
+## Network-mounted deployments (EFS/NFS/SMB) — issue #3408
+
+**`POST /indexes/:id/index-file` / `POST /indexes/:id/remove-file` (and the
+equivalent `index_file` / `remove_file` MCP tools) are the officially
+supported, stability-committed way to keep an index in sync when its root
+lives on a network mount (EFS/NFS/SMB/CIFS) or in a build/serve-split
+deployment** (an indexer box writes to shared storage; one or more serving
+boxes only read + query it).
+
+The native file watcher cannot be used there: inotify (Linux) and FSEvents
+(macOS) are local-host kernel mechanisms that cannot observe a write made by a
+*different* host onto a shared mount — this is an OS-level limitation, not a
+bug in this crate. As of issue #3408 the daemon detects a network-mounted
+index root at watcher-start time and refuses to start the watcher for that
+index (rather than starting it and silently never firing), surfacing the
+condition on `GET /health` (`indexes_watcher_network_degraded`) and
+`GET /indexes/:id/status` (`watcher.network_mount_degraded` +
+`watcher.degraded_reason`) so it is visible without tailing logs.
+
+Drive an index on a network mount by calling `index-file`/`remove-file`
+(directly, or via the MCP tools) from whatever process already knows what
+changed on your side — `git diff` on pull, a CI job's own change manifest, or
+a local-side build hook. See [CLAUDE.md](./CLAUDE.md)'s endpoint catalogue
+("Supported network-mount pattern" under `POST /indexes/:id/remove-file`) for
+the full request/response shapes and a worked example script.
+
 ## Stack
 
 | Component       | Choice                                              |
@@ -702,6 +728,14 @@ To fix:
 The same TCC restriction can affect Linux systemd deployments on mount points
 that require specific permissions — grant the service user read access to the
 data directory.
+
+**Watcher never fires / saves aren't picked up on a network mount (EFS/NFS/SMB)**
+
+This is expected — see [Network-mounted deployments](#network-mounted-deployments-efsnfssmb--issue-3408)
+above. Check `GET /health`'s `indexes_watcher_network_degraded` or
+`GET /indexes/:id/status`'s `watcher` field; a network-mounted root never gets
+a live watcher by design. Drive updates via `POST /indexes/:id/index-file` /
+`POST /indexes/:id/remove-file` instead.
 
 ## Architecture and HTTP API
 

--- a/crates/trusty-search/src/service/mod.rs
+++ b/crates/trusty-search/src/service/mod.rs
@@ -19,6 +19,7 @@ pub mod lazy_loader;
 pub(crate) mod lazy_restore;
 pub mod mcp_descriptor;
 pub mod metrics;
+pub mod network_fs;
 pub mod orphan_reaper;
 pub mod persistence;
 pub mod persistence_loader;

--- a/crates/trusty-search/src/service/network_fs.rs
+++ b/crates/trusty-search/src/service/network_fs.rs
@@ -163,7 +163,16 @@ mod imp {
         // Primary signal: the statfs magic number — a single syscall, no
         // /proc parsing, and unambiguous for NFS/legacy-SMB/CIFS.
         if let Ok(stat) = nix::sys::statfs::statfs(path) {
-            if classify_magic(stat.filesystem_type().0 as i64).is_network() {
+            // `nix`'s underlying `fs_type_t` varies by Linux arch/libc
+            // (`__fsword_t` — i64 — on the common glibc target CI runs on,
+            // but `c_uint`/`c_ulong`/`c_int` on s390x/musl/uclibc). The cast
+            // is a genuine no-op on x86_64-unknown-linux-gnu (hence clippy's
+            // complaint here), but is still required for the build to be
+            // portable to those other Linux targets, so it stays with an
+            // explicit `allow` rather than being deleted.
+            #[allow(clippy::unnecessary_cast)]
+            let magic = stat.filesystem_type().0 as i64;
+            if classify_magic(magic).is_network() {
                 return MountKind::Network;
             }
         } else {
@@ -196,15 +205,23 @@ mod imp {
             let Some(_device) = fields.next() else {
                 continue;
             };
-            let Some(mount_point) = fields.next() else {
+            let Some(raw_mount_point) = fields.next() else {
                 continue;
             };
             let Some(fstype) = fields.next() else {
                 continue;
             };
+            // `mounts(5)`: the kernel octal-escapes space/tab/backslash/newline
+            // in this field (` ` → `\040`, etc). Without unescaping first, a
+            // network mount at a path containing a space (e.g. `/mnt/My Docs`)
+            // never matches `starts_with` against the real (unescaped)
+            // canonical path and silently falls through to `Local` —
+            // reproducing the exact silent-watcher-never-fires bug this
+            // module exists to fix, for that one case.
+            let mount_point = unescape_proc_mounts_field(raw_mount_point);
             // Longest-prefix match: the deepest mount point that contains
             // `path` wins (mirrors how the kernel resolves nested mounts).
-            if canonical.starts_with(mount_point) {
+            if canonical.starts_with(&mount_point) {
                 let len = mount_point.len();
                 if best.as_ref().map(|(l, _)| len > *l).unwrap_or(true) {
                     best = Some((len, fstype.to_string()));
@@ -212,6 +229,105 @@ mod imp {
             }
         }
         best.map(|(_, fstype)| fstype)
+    }
+
+    /// Unescape the octal `\NNN` sequences the kernel uses in `/proc/mounts`
+    /// fields (`mounts(5)`): ` ` is `\040`, `\t` is `\011`, `\\` is `\134`,
+    /// `\n` is `\012`. Operates on raw bytes (not `char`s) so it never splits
+    /// a multi-byte UTF-8 sequence — the escape marker (`\`) and octal digits
+    /// are all single-byte ASCII, and UTF-8 continuation bytes can never
+    /// collide with them. An incomplete or non-octal `\NNN`-shaped sequence
+    /// (or a lone trailing `\`) is copied through byte-for-byte rather than
+    /// erroring — fail-open, matching the rest of this module.
+    ///
+    /// Test: `unescape_handles_space_tab_and_backslash`,
+    /// `unescape_leaves_plain_path_untouched`,
+    /// `unescape_passes_through_malformed_escape`.
+    fn unescape_proc_mounts_field(field: &str) -> String {
+        let bytes = field.as_bytes();
+        let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            let is_octal_digit = |b: u8| (b'0'..=b'7').contains(&b);
+            if bytes[i] == b'\\'
+                && i + 3 < bytes.len()
+                && is_octal_digit(bytes[i + 1])
+                && is_octal_digit(bytes[i + 2])
+                && is_octal_digit(bytes[i + 3])
+            {
+                let value = u32::from(bytes[i + 1] - b'0') * 64
+                    + u32::from(bytes[i + 2] - b'0') * 8
+                    + u32::from(bytes[i + 3] - b'0');
+                if let Ok(byte_value) = u8::try_from(value) {
+                    out.push(byte_value);
+                    i += 4;
+                    continue;
+                }
+            }
+            out.push(bytes[i]);
+            i += 1;
+        }
+        // Any escape sequence we decoded came from valid octal-encoded bytes
+        // reconstructing the original path bytes, and everything else was
+        // copied through verbatim, so this is UTF-8 iff the original field
+        // was (which it always is, since it came from a Rust `&str`). Fall
+        // back to the raw field on the (should-be-impossible) failure case
+        // rather than panicking.
+        String::from_utf8(out).unwrap_or_else(|_| field.to_string())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::unescape_proc_mounts_field;
+
+        /// Why: this is the exact regression from the code-critic review of
+        /// PR #3424 — a mount point containing a space (e.g. `/mnt/My Docs`,
+        /// a legitimate path) is octal-escaped by the kernel as `\040` in
+        /// `/proc/mounts`. Without unescaping, `starts_with` against the real
+        /// canonical path never matches and the lookup silently falls
+        /// through to `Local`, reproducing the silent-watcher-never-fires bug
+        /// this whole module exists to fix, for that one case. Also covers
+        /// `\t` (`\011`) and a literal backslash (`\134`) per `mounts(5)`.
+        /// Test: this test.
+        #[test]
+        fn unescape_handles_space_tab_and_backslash() {
+            assert_eq!(
+                unescape_proc_mounts_field(r"/mnt/My\040Docs"),
+                "/mnt/My Docs"
+            );
+            assert_eq!(
+                unescape_proc_mounts_field(r"/mnt/tab\011here"),
+                "/mnt/tab\there"
+            );
+            assert_eq!(
+                unescape_proc_mounts_field(r"/mnt/back\134slash"),
+                "/mnt/back\\slash"
+            );
+        }
+
+        /// Why: the overwhelming majority of real mount points have no
+        /// escapes at all — a plain path must round-trip unchanged.
+        /// Test: this test.
+        #[test]
+        fn unescape_leaves_plain_path_untouched() {
+            assert_eq!(unescape_proc_mounts_field("/mnt/data"), "/mnt/data");
+            assert_eq!(unescape_proc_mounts_field("/"), "/");
+        }
+
+        /// Why: a `\` not followed by exactly 3 octal digits (or at the very
+        /// end of the field) is not a valid `mounts(5)` escape — it must be
+        /// copied through byte-for-byte rather than panicking or eating
+        /// characters, matching this module's fail-open philosophy.
+        /// Test: this test.
+        #[test]
+        fn unescape_passes_through_malformed_escape() {
+            // Not enough digits after the backslash.
+            assert_eq!(unescape_proc_mounts_field(r"/mnt/x\04"), r"/mnt/x\04");
+            // Non-octal digit (8/9) in the escape.
+            assert_eq!(unescape_proc_mounts_field(r"/mnt/x\089"), r"/mnt/x\089");
+            // Trailing lone backslash.
+            assert_eq!(unescape_proc_mounts_field(r"/mnt/x\"), r"/mnt/x\");
+        }
     }
 }
 

--- a/crates/trusty-search/src/service/network_fs.rs
+++ b/crates/trusty-search/src/service/network_fs.rs
@@ -1,0 +1,323 @@
+//! Detect whether a path lives on a network-mounted filesystem (issue #3408).
+//!
+//! Why: `notify`'s inotify (Linux) / FSEvents (macOS) backends are local-host
+//! kernel notification mechanisms — they cannot observe writes made by a
+//! *different* host onto a shared network mount (EFS/NFS/SMB/CIFS). This is an
+//! OS-level limitation, not a bug in `notify` or in this crate's watcher: no
+//! amount of retrying or reconfiguring the debouncer fixes it. Today the
+//! watcher starts successfully on such a mount, the daemon reports healthy,
+//! and the watcher simply never fires for cross-host changes — a silent no-op
+//! that looks like correct behaviour. This module lets the watcher manager
+//! detect that condition *before* spawning the watcher so it can degrade
+//! loudly (see `service::watcher_manager`) instead of lying about liveness.
+//!
+//! What: [`classify_root`] resolves the filesystem type at a path via
+//! `statfs` — on macOS through `f_fstypename` (via the already-vendored `nix`
+//! crate's `filesystem_type_name`), on Linux through the `f_type` magic number
+//! plus a `/proc/mounts` fallback — and classifies it as [`MountKind::Local`]
+//! or [`MountKind::Network`].
+//!
+//! Detection is deliberately conservative (a false positive — refusing to
+//! watch a local disk — is worse than a false negative): a filesystem is only
+//! ever classified as `Network` when it matches a SPECIFIC, unambiguous
+//! network filesystem identifier (`nfs`, `nfs4`, `cifs`, `smbfs`/`smb3`, the
+//! NFS/CIFS/legacy-SMB `statfs` magic numbers, or an explicitly-named network
+//! FUSE backend like `fuse.sshfs`/`fuse.s3fs`). A bare/generic `fuse` mount
+//! (which covers many purely local use cases — encfs, unionfs, etc.) is never
+//! classified as network on its own. Any error resolving the filesystem type
+//! (path missing, permission denied, unsupported platform) fails open to
+//! `Local` — we only degrade the watcher when we are positively confident the
+//! root is network-backed.
+//!
+//! Test: [`classify_fstype_name`] and [`classify_magic`] are pure functions
+//! taking the raw OS-reported type directly, so the matching logic is fully
+//! unit-tested without requiring a real NFS/CIFS/SMB mount in CI. The
+//! platform-specific `statfs`/`/proc/mounts` glue is exercised indirectly via
+//! [`classify_root`] against real local paths (which must always resolve to
+//! `Local` in a CI sandbox).
+
+use std::path::Path;
+
+/// Whether a path resolves to a local or network-backed filesystem.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MountKind {
+    /// A local (or otherwise not positively-identified-as-network) filesystem.
+    /// This is also the fail-open outcome on any detection error.
+    Local,
+    /// Positively identified as a network-backed mount (NFS/EFS/SMB/CIFS/a
+    /// named network FUSE backend).
+    Network,
+}
+
+impl MountKind {
+    /// True when the mount was positively identified as network-backed.
+    pub fn is_network(self) -> bool {
+        matches!(self, MountKind::Network)
+    }
+}
+
+/// Known-network filesystem type names, matched case-insensitively against
+/// whatever the OS reports (macOS `f_fstypename`; Linux `/proc/mounts` field
+/// 3). Deliberately a narrow, explicit allowlist rather than a denylist or a
+/// substring match — see the module docs for the false-positive rationale.
+///
+/// `nfs`/`nfs4` covers plain NFS and AWS EFS (EFS mounts as NFSv4 on the
+/// client). `cifs`/`smbfs`/`smb3` cover Windows-file-share mounts. `afpfs`
+/// covers the legacy Apple Filing Protocol. The `fuse.*` entries are
+/// EXPLICITLY named network FUSE backends — a bare `fuse` type is never
+/// matched (see module docs).
+const NETWORK_FSTYPE_NAMES: &[&str] = &[
+    "nfs",
+    "nfs4",
+    "cifs",
+    "smbfs",
+    "smb3",
+    "afpfs",
+    "webdav",
+    "fuse.sshfs",
+    "fuse.s3fs",
+    "fuse.gcsfuse",
+    "fuse.rclone",
+];
+
+/// Classify a raw filesystem type NAME (as reported by the OS) as local or
+/// network. Pure and case-insensitive so it is directly unit-testable without
+/// mounting anything.
+///
+/// Test: `classify_fstype_name_matches_known_network_types`,
+/// `classify_fstype_name_is_case_insensitive`,
+/// `classify_fstype_name_does_not_flag_generic_fuse`.
+pub fn classify_fstype_name(name: &str) -> MountKind {
+    let lower = name.trim().to_ascii_lowercase();
+    if NETWORK_FSTYPE_NAMES.iter().any(|known| *known == lower) {
+        MountKind::Network
+    } else {
+        MountKind::Local
+    }
+}
+
+/// NFS magic number (`statfs.f_type` on Linux) — covers NFSv3/NFSv4 and thus
+/// AWS EFS, which mounts as NFSv4 on the client.
+const NFS_SUPER_MAGIC: i64 = 0x6969;
+/// Legacy `smbfs` magic number.
+const SMB_SUPER_MAGIC: i64 = 0x517b;
+/// CIFS magic number (kernel `fs/cifs/cifsfs.h` `CIFS_MAGIC_NUMBER`). Not
+/// exposed as a named constant by `libc`/`nix`, so declared directly here.
+const CIFS_MAGIC_NUMBER: i64 = 0xFF534D42u32 as i64;
+
+/// Classify a raw Linux `statfs.f_type` magic number as local or network.
+/// Pure so it is directly unit-testable without a real mount.
+///
+/// Test: `classify_magic_matches_known_network_magics`,
+/// `classify_magic_does_not_flag_local_magics`.
+pub fn classify_magic(magic: i64) -> MountKind {
+    match magic {
+        NFS_SUPER_MAGIC | SMB_SUPER_MAGIC | CIFS_MAGIC_NUMBER => MountKind::Network,
+        _ => MountKind::Local,
+    }
+}
+
+/// Determine whether `path` lives on a network-mounted filesystem.
+///
+/// Why: called by `service::watcher_manager` before spawning a watcher
+/// (issue #3408) so a network-mounted index root degrades loudly instead of
+/// silently starting a watcher that will never fire for cross-host writes.
+/// What: platform-specific `statfs` glue that resolves the OS-reported
+/// filesystem identifier and delegates the actual classification decision to
+/// the pure [`classify_fstype_name`] / [`classify_magic`] helpers above. Any
+/// error (`statfs` failing, unsupported platform) fails open to
+/// [`MountKind::Local`] — see module docs on the false-positive trade-off.
+/// Test: exercised against real local paths (must resolve `Local`) by
+/// `classify_root_local_tempdir_is_local` below; the network path is covered
+/// by the pure helpers since CI has no NFS/CIFS mount available.
+pub fn classify_root(path: &Path) -> MountKind {
+    imp::classify_root(path)
+}
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use super::{classify_fstype_name, MountKind};
+    use std::path::Path;
+
+    pub(super) fn classify_root(path: &Path) -> MountKind {
+        match nix::sys::statfs::statfs(path) {
+            Ok(stat) => classify_fstype_name(stat.filesystem_type_name()),
+            Err(err) => {
+                tracing::debug!(
+                    ?path,
+                    %err,
+                    "network_fs: statfs failed — treating as local (fail-open, issue #3408)"
+                );
+                MountKind::Local
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use super::{classify_fstype_name, classify_magic, MountKind};
+    use std::path::Path;
+
+    pub(super) fn classify_root(path: &Path) -> MountKind {
+        // Primary signal: the statfs magic number — a single syscall, no
+        // /proc parsing, and unambiguous for NFS/legacy-SMB/CIFS.
+        if let Ok(stat) = nix::sys::statfs::statfs(path) {
+            if classify_magic(stat.filesystem_type().0 as i64).is_network() {
+                return MountKind::Network;
+            }
+        } else {
+            tracing::debug!(
+                ?path,
+                "network_fs: statfs failed — falling back to /proc/mounts (issue #3408)"
+            );
+        }
+
+        // Secondary signal: /proc/mounts fstype string. Needed for
+        // explicitly-named network FUSE backends (`fuse.sshfs`, `fuse.s3fs`,
+        // …), which all share the same generic FUSE magic number at the
+        // statfs level and so cannot be distinguished from a purely local
+        // FUSE mount by magic number alone.
+        match mount_fstype_for_path(path) {
+            Some(fstype) => classify_fstype_name(&fstype),
+            None => MountKind::Local,
+        }
+    }
+
+    /// Resolve the filesystem type of the longest-matching mount point for
+    /// `path` by scanning `/proc/mounts`. Returns `None` on any read failure
+    /// or if no mount point matches (fail-open).
+    fn mount_fstype_for_path(path: &Path) -> Option<String> {
+        let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let contents = std::fs::read_to_string("/proc/mounts").ok()?;
+        let mut best: Option<(usize, String)> = None;
+        for line in contents.lines() {
+            let mut fields = line.split_whitespace();
+            let Some(_device) = fields.next() else {
+                continue;
+            };
+            let Some(mount_point) = fields.next() else {
+                continue;
+            };
+            let Some(fstype) = fields.next() else {
+                continue;
+            };
+            // Longest-prefix match: the deepest mount point that contains
+            // `path` wins (mirrors how the kernel resolves nested mounts).
+            if canonical.starts_with(mount_point) {
+                let len = mount_point.len();
+                if best.as_ref().map(|(l, _)| len > *l).unwrap_or(true) {
+                    best = Some((len, fstype.to_string()));
+                }
+            }
+        }
+        best.map(|(_, fstype)| fstype)
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+mod imp {
+    use super::MountKind;
+    use std::path::Path;
+
+    /// No detection support on this platform — fail open to `Local`.
+    pub(super) fn classify_root(_path: &Path) -> MountKind {
+        MountKind::Local
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Pure name-matching tests (no mount required) ────────────────────────
+
+    #[test]
+    fn classify_fstype_name_matches_known_network_types() {
+        for name in [
+            "nfs",
+            "nfs4",
+            "cifs",
+            "smbfs",
+            "smb3",
+            "afpfs",
+            "webdav",
+            "fuse.sshfs",
+            "fuse.s3fs",
+        ] {
+            assert_eq!(
+                classify_fstype_name(name),
+                MountKind::Network,
+                "{name:?} should classify as Network"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_fstype_name_is_case_insensitive() {
+        assert_eq!(classify_fstype_name("NFS"), MountKind::Network);
+        assert_eq!(classify_fstype_name("CIFS"), MountKind::Network);
+        assert_eq!(classify_fstype_name("Fuse.SSHFS"), MountKind::Network);
+    }
+
+    #[test]
+    fn classify_fstype_name_leaves_local_types_alone() {
+        for name in ["apfs", "ext4", "xfs", "btrfs", "tmpfs", "overlay", "hfs"] {
+            assert_eq!(
+                classify_fstype_name(name),
+                MountKind::Local,
+                "{name:?} should classify as Local"
+            );
+        }
+    }
+
+    /// Why: a bare/generic `fuse` mount covers many purely local use cases
+    /// (encfs, unionfs, various sync tools); only explicitly-named network
+    /// FUSE backends should be flagged — see module docs.
+    #[test]
+    fn classify_fstype_name_does_not_flag_generic_fuse() {
+        assert_eq!(classify_fstype_name("fuse"), MountKind::Local);
+        assert_eq!(classify_fstype_name("fuseblk"), MountKind::Local);
+    }
+
+    #[test]
+    fn classify_magic_matches_known_network_magics() {
+        assert_eq!(classify_magic(0x6969), MountKind::Network); // NFS_SUPER_MAGIC
+        assert_eq!(classify_magic(0x517b), MountKind::Network); // SMB_SUPER_MAGIC
+        assert_eq!(
+            classify_magic(0xFF534D42u32 as i64),
+            MountKind::Network // CIFS_MAGIC_NUMBER
+        );
+    }
+
+    #[test]
+    fn classify_magic_does_not_flag_local_magics() {
+        assert_eq!(classify_magic(0xEF53), MountKind::Local); // ext4
+        assert_eq!(classify_magic(0x9123683e), MountKind::Local); // btrfs
+        assert_eq!(classify_magic(0), MountKind::Local);
+    }
+
+    // ── Real-filesystem smoke test (must never false-positive in CI) ───────
+
+    /// Why: the single most important false-positive guard — a plain tempdir
+    /// on the CI sandbox's local disk must never be classified as network.
+    /// Exercises the real platform `statfs` glue (not just the pure helpers).
+    #[test]
+    fn classify_root_local_tempdir_is_local() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        assert_eq!(
+            classify_root(dir.path()),
+            MountKind::Local,
+            "a local tempdir must never be classified as a network mount"
+        );
+    }
+
+    /// Why: a nonexistent path must fail open rather than panic or crash the
+    /// caller (`statfs` returns an error; `/proc/mounts` lookup finds no
+    /// canonicalizable path).
+    #[test]
+    fn classify_root_missing_path_fails_open_to_local() {
+        let missing = std::path::Path::new("/definitely/does/not/exist/3408");
+        assert_eq!(classify_root(missing), MountKind::Local);
+    }
+}

--- a/crates/trusty-search/src/service/server/health.rs
+++ b/crates/trusty-search/src/service/server/health.rs
@@ -94,6 +94,22 @@ pub(super) struct HealthResponse {
     /// daemons with reconcile disabled via `TRUSTY_NO_BOOT_RECONCILE=1` omit it).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) boot_reconcile: Option<ReconcileSummary>,
+    /// Count of registered indexes whose file watcher was refused because
+    /// their root was detected as a network-mounted filesystem (issue
+    /// #3408).
+    ///
+    /// Why: inotify/FSEvents cannot observe writes made by another host onto
+    /// a shared EFS/NFS/SMB mount — an OS-level limitation. Starting the
+    /// watcher anyway would leave the daemon reporting healthy while the
+    /// watcher silently never fires for cross-host changes. This field is
+    /// the machine-readable signal that lets an operator/monitor catch that
+    /// condition without tailing logs. A non-zero value means those indexes
+    /// must be kept in sync via `POST /indexes/:id/index-file` and
+    /// `POST /indexes/:id/remove-file` instead (the supported
+    /// network-mount pattern — see the operator docs).
+    /// What: `WatcherManager::network_degraded_count()` at poll time.
+    /// Test: `health_surfaces_watcher_network_degraded_count`.
+    pub(super) indexes_watcher_network_degraded: usize,
 }
 
 /// Embedding-model metadata surfaced by `GET /health` (issue #38).
@@ -353,16 +369,27 @@ pub(super) async fn health_handler(
         })
         .unwrap_or(None);
 
+    // Issue #3408: count indexes whose watcher was refused because their root
+    // is network-mounted (EFS/NFS/SMB/CIFS) — inotify/FSEvents cannot observe
+    // another host's writes there, so starting the watcher would silently
+    // never fire. Cheap: just the degraded map's length under its own lock.
+    let indexes_watcher_network_degraded = state.watcher_manager.network_degraded_count().await;
+
     // Issue #1870: honest top-level status. `"ok"` used to be unconditional,
     // so a total silent search outage (all-lanes-Failed corpus) still read as
     // healthy. Downgrade to `"degraded"` when at least one registered index has
     // a failed lane so a simple `status != "ok"` gate catches it. The healthy
     // path is unchanged (`indexes_corpus_failed == 0` → `"ok"`).
-    let overall_status = if warmboot_summary.indexes_corpus_failed > 0 {
-        "degraded"
-    } else {
-        "ok"
-    };
+    // Issue #3408: also downgrade when a watcher was refused for a
+    // network-mounted root — the daemon is not silently broken, but it is
+    // running with a real capability gap that the same `status != "ok"`
+    // monitors should catch.
+    let overall_status =
+        if warmboot_summary.indexes_corpus_failed > 0 || indexes_watcher_network_degraded > 0 {
+            "degraded"
+        } else {
+            "ok"
+        };
 
     Json(HealthResponse {
         status: overall_status,
@@ -389,6 +416,7 @@ pub(super) async fn health_handler(
         indexes_component_catch_up_in_progress,
         warmboot_summary,
         boot_reconcile,
+        indexes_watcher_network_degraded,
     })
 }
 

--- a/crates/trusty-search/src/service/server/status.rs
+++ b/crates/trusty-search/src/service/server/status.rs
@@ -176,6 +176,17 @@ pub(super) async fn index_status_handler(
         .corpus_arc()
         .and_then(|c| c.chunk_count().ok())
         .unwrap_or_else(|| indexer.chunk_count());
+    // Issue #3408: surface the watcher's live/degraded state per-index. A
+    // network-mounted root never gets a live watcher (inotify/FSEvents can't
+    // observe another host's writes there); `network_mount_degraded` plus
+    // `degraded_reason` name the actionable per-file endpoints so an operator
+    // inspecting one index (rather than polling all of `/health`) sees why
+    // saves aren't triggering incremental indexing.
+    let watcher_active = state.watcher_manager.is_watching(&index_id).await;
+    let watcher_degraded_reason = state
+        .watcher_manager
+        .network_degraded_reason(&index_id)
+        .await;
     Ok(Json(serde_json::json!({
         "index_id": index_id.0,
         "root_path": handle.root_path,
@@ -205,6 +216,12 @@ pub(super) async fn index_status_handler(
         "last_walk_files_seen": walk_diag.last_walk_files_seen,
         "last_walk_files_skipped": walk_diag.last_walk_files_skipped,
         "last_walk_error": walk_diag.last_walk_error,
+        // Issue #3408: per-index watcher liveness + network-mount degradation.
+        "watcher": {
+            "active": watcher_active,
+            "network_mount_degraded": watcher_degraded_reason.is_some(),
+            "degraded_reason": watcher_degraded_reason,
+        },
     })))
 }
 

--- a/crates/trusty-search/src/service/server/tests_health.rs
+++ b/crates/trusty-search/src/service/server/tests_health.rs
@@ -47,6 +47,51 @@ async fn health_handler_reports_indexes_and_uptime() {
     assert_eq!(resp.embedder, "initializing");
 }
 
+/// Issue #3408 — a network-mounted index root must surface through
+/// `/health`: `indexes_watcher_network_degraded` counts it and the top-level
+/// `status` flips to `"degraded"`, mirroring the existing
+/// `indexes_corpus_failed` degraded-signal convention (issue #1870). Uses
+/// `WatcherManager::spawn_for_index_with_mount_kind` to inject
+/// `MountKind::Network` directly rather than requiring a real NFS/CIFS/SMB
+/// mount in CI.
+#[tokio::test]
+async fn health_surfaces_watcher_network_degraded_count() {
+    use crate::core::{
+        indexer::CodeIndexer,
+        registry::{IndexHandle, IndexId, IndexRegistry},
+    };
+    use crate::service::network_fs::MountKind;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let registry = IndexRegistry::new();
+    let id = IndexId::new("net-mount-test");
+    let handle = registry.register(IndexHandle::bare(
+        id.clone(),
+        Arc::new(RwLock::new(CodeIndexer::new(
+            "net-mount-test",
+            "/tmp/net-mount-test",
+        ))),
+        "/tmp/net-mount-test".into(),
+    ));
+    let state = Arc::new(SearchAppState::new(registry));
+
+    state
+        .watcher_manager
+        .spawn_for_index_with_mount_kind(&handle, MountKind::Network)
+        .await;
+
+    let Json(resp) = health_handler(State(Arc::clone(&state))).await;
+    assert_eq!(
+        resp.indexes_watcher_network_degraded, 1,
+        "the network-mount refusal must be counted on /health"
+    );
+    assert_eq!(
+        resp.status, "degraded",
+        "top-level status must flip to degraded, matching the indexes_corpus_failed convention"
+    );
+}
+
 /// Issue #128 — `GET /indexes/{id}/graph` exports the full SymbolGraph.
 /// With a registered index holding inter-calling functions, the response
 /// must carry node/edge lists, a `stats` block, a `generated_at` stamp,

--- a/crates/trusty-search/src/service/server/tests_stall.rs
+++ b/crates/trusty-search/src/service/server/tests_stall.rs
@@ -157,6 +157,7 @@ fn health_response_contains_stall_fields() {
         indexes_component_catch_up_in_progress: 0,
         warmboot_summary: WarmBootSummary::default(),
         boot_reconcile: None,
+        indexes_watcher_network_degraded: 0,
     };
 
     let json: Value = serde_json::to_value(&resp).expect("serialize");
@@ -212,6 +213,7 @@ fn health_response_omits_last_ok_when_none() {
         indexes_component_catch_up_in_progress: 0,
         warmboot_summary: WarmBootSummary::default(),
         boot_reconcile: None,
+        indexes_watcher_network_degraded: 0,
     };
 
     let json: Value = serde_json::to_value(&resp).expect("serialize");

--- a/crates/trusty-search/src/service/watcher_manager.rs
+++ b/crates/trusty-search/src/service/watcher_manager.rs
@@ -34,7 +34,30 @@ use tokio::sync::Mutex;
 
 use crate::core::registry::{IndexHandle, IndexId};
 use crate::service::indexed_files::IndexedFiles;
+use crate::service::network_fs::{classify_root, MountKind};
 use crate::service::watch_loop::{spawn_watch_loop, WatcherTask};
+
+/// Human-readable, actionable message logged (and surfaced via `/health` +
+/// `GET /indexes/:id/status`) when an index root is detected as
+/// network-mounted (issue #3408).
+///
+/// Why: inotify/FSEvents cannot observe writes made by another host onto a
+/// shared network mount — an OS-level limitation, not something retrying or
+/// reconfiguring the watcher can fix. Starting the watcher anyway would leave
+/// the daemon reporting healthy while silently never reacting to cross-host
+/// changes. This message names the supported alternative so an operator
+/// reading logs or `/health` knows exactly what to do next.
+fn network_mount_degraded_reason(index_id: &IndexId, root_path: &std::path::Path) -> String {
+    format!(
+        "index {index_id} root {root} is on a network-mounted filesystem (NFS/EFS/SMB/CIFS); \
+         the file watcher cannot reliably observe changes written by other hosts on a network \
+         mount, so it has been disabled for this index rather than silently never firing. \
+         Drive incremental updates explicitly via `POST /indexes/{index_id}/index-file` and \
+         `POST /indexes/{index_id}/remove-file` instead (see the operator docs for the \
+         supported network-mount pattern).",
+        root = root_path.display(),
+    )
+}
 
 /// Environment variable that disables the filesystem watcher entirely.
 ///
@@ -85,6 +108,14 @@ fn watcher_disabled() -> bool {
 #[derive(Clone, Default)]
 pub struct WatcherManager {
     inner: Arc<Mutex<HashMap<IndexId, WatcherTask>>>,
+    /// Indexes whose watcher was refused because `root_path` was detected as
+    /// network-mounted (issue #3408), keyed to the actionable message logged
+    /// at spawn time. Surfaced via `/health`
+    /// (`indexes_watcher_network_degraded`) and
+    /// `GET /indexes/:id/status` so the condition is visible without tailing
+    /// logs — the whole point of this feature is that the daemon must NOT
+    /// look silently healthy on a network mount.
+    network_degraded: Arc<Mutex<HashMap<IndexId, String>>>,
 }
 
 impl WatcherManager {
@@ -110,7 +141,9 @@ impl WatcherManager {
     /// and keep the existing one. A `spawn_watch_loop` failure (e.g. the root
     /// path vanished between registration and now) is logged at WARN and
     /// swallowed so registration never fails because of the watcher.
-    /// Test: `spawn_is_idempotent`, `disable_env_gate_only_matches_one`.
+    /// Test: `spawn_is_idempotent`, `disable_env_gate_only_matches_one`,
+    /// `network_mount_root_is_refused_and_reported`,
+    /// `local_root_is_unaffected_by_network_check`.
     pub async fn spawn_for_index(&self, handle: &Arc<IndexHandle>) {
         if watcher_disabled() {
             tracing::debug!(
@@ -119,6 +152,65 @@ impl WatcherManager {
             );
             return;
         }
+
+        // Issue #3408: the mount-kind check is factored into a testable inner
+        // function (`spawn_for_index_with_mount_kind`) so tests can inject
+        // `MountKind::Network` / `MountKind::Local` directly rather than
+        // requiring a real NFS/CIFS mount in CI. Production always resolves
+        // the real kind here via `classify_root`.
+        self.spawn_for_index_with_mount_kind(handle, classify_root(&handle.root_path))
+            .await;
+    }
+
+    /// Same as [`Self::spawn_for_index`], but with the network-mount
+    /// classification passed in explicitly instead of resolved via `statfs`.
+    ///
+    /// Why: isolates the one platform-dependent decision
+    /// (`network_fs::classify_root`) from the rest of the spawn logic so unit
+    /// tests can pin the network-degraded behaviour and the normal-spawn
+    /// behaviour deterministically, without needing a real network mount in
+    /// CI (issue #3408).
+    /// What: (1) refuses to spawn and records the actionable degraded reason
+    /// when `mount_kind` is `Network`; (2) otherwise proceeds with the
+    /// existing idempotent build-then-insert spawn path unchanged.
+    /// Test: `network_mount_root_is_refused_and_reported`,
+    /// `local_root_is_unaffected_by_network_check`.
+    ///
+    /// `pub(crate)` rather than private: `server::tests_health` also injects a
+    /// `MountKind` directly to cover the `/health` JSON surface end-to-end
+    /// without a real network mount. Not part of the public API.
+    pub(crate) async fn spawn_for_index_with_mount_kind(
+        &self,
+        handle: &Arc<IndexHandle>,
+        mount_kind: MountKind,
+    ) {
+        // Refuse to start a watcher whose root is positively identified as
+        // network-mounted (EFS/NFS/SMB/CIFS). inotify/FSEvents cannot observe
+        // another host's writes to a shared network mount — starting the
+        // watcher anyway would leave the daemon reporting healthy while
+        // silently never reacting to cross-host changes. This check runs
+        // BEFORE `spawn_watch_loop` so we never pay the OS-watch install cost
+        // (recursive inotify walk) for a mount that can't work anyway.
+        // `classify_root` fails open to `Local` on any detection error, so
+        // this can only ever produce a false negative, never a false
+        // positive that blocks a legitimate local watcher.
+        if mount_kind.is_network() {
+            let reason = network_mount_degraded_reason(&handle.id, &handle.root_path);
+            tracing::warn!(
+                index_id = %handle.id,
+                root = %handle.root_path.display(),
+                "{reason}"
+            );
+            self.network_degraded
+                .lock()
+                .await
+                .insert(handle.id.clone(), reason);
+            return;
+        }
+        // Clear any stale degraded entry from a previous root-path change for
+        // this id (defensive — ids are not normally re-registered with a
+        // different root, but this keeps the map from lying if they are).
+        self.network_degraded.lock().await.remove(&handle.id);
 
         // Build the watcher task BEFORE acquiring the lock (issue #1640). This
         // (a) closes the deadlock window — the `Mutex` is never held across the
@@ -172,6 +264,9 @@ impl WatcherManager {
     /// Test: `stop_for_index_removes_entry`.
     pub async fn stop_for_index(&self, id: &IndexId) -> bool {
         let task = self.inner.lock().await.remove(id);
+        // Issue #3408: `DELETE /indexes/:id` should not leave a stale
+        // network-mount-degraded entry behind for an id that no longer exists.
+        self.network_degraded.lock().await.remove(id);
         match task {
             Some(task) => {
                 task.stop();
@@ -219,6 +314,30 @@ impl WatcherManager {
     /// Test: `is_watching_reflects_spawn_and_stop`.
     pub async fn is_watching(&self, id: &IndexId) -> bool {
         self.inner.lock().await.contains_key(id)
+    }
+
+    /// Number of indexes whose watcher was refused because their root was
+    /// detected as network-mounted (issue #3408).
+    ///
+    /// Why: surfaced on `GET /health` as `indexes_watcher_network_degraded` so
+    /// operators/monitors can detect the condition without tailing logs or
+    /// polling every index's status individually.
+    /// What: length of the `network_degraded` map under the lock.
+    /// Test: `network_mount_root_is_refused_and_reported`.
+    pub async fn network_degraded_count(&self) -> usize {
+        self.network_degraded.lock().await.len()
+    }
+
+    /// The actionable degraded-reason message for a specific index, if its
+    /// watcher was refused due to a network-mounted root.
+    ///
+    /// Why: `GET /indexes/:id/status` surfaces this so an operator looking at
+    /// one index gets the full actionable message, not just a boolean.
+    /// What: `Some(reason)` when `id` is in the `network_degraded` map,
+    /// `None` otherwise (including for unknown ids).
+    /// Test: `network_mount_root_is_refused_and_reported`.
+    pub async fn network_degraded_reason(&self, id: &IndexId) -> Option<String> {
+        self.network_degraded.lock().await.get(id).cloned()
     }
 }
 
@@ -369,5 +488,109 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
         mgr.stop_all().await;
+    }
+
+    // ── Issue #3408: network-mount detection wired into the spawn path ──────
+
+    /// Why: this is the core acceptance criterion of issue #3408 — a root
+    /// positively identified as network-mounted must NOT get a live watcher
+    /// (it would silently never fire for cross-host writes), and the
+    /// refusal must be reported through `network_degraded_count` /
+    /// `network_degraded_reason` with an actionable message naming the
+    /// `index-file` / `remove-file` endpoints, rather than just logged and
+    /// forgotten. Uses `spawn_for_index_with_mount_kind` to inject
+    /// `MountKind::Network` directly instead of requiring a real NFS/CIFS/SMB
+    /// mount in CI.
+    /// Test: this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn network_mount_root_is_refused_and_reported() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mgr = WatcherManager::new();
+        let handle = handle_for("net-idx", dir.path());
+        let id = IndexId::new("net-idx");
+
+        mgr.spawn_for_index_with_mount_kind(&handle, MountKind::Network)
+            .await;
+
+        assert!(
+            !mgr.is_watching(&id).await,
+            "a network-mounted root must never get a live watcher"
+        );
+        assert_eq!(
+            mgr.watched_count().await,
+            0,
+            "no watcher should have been inserted"
+        );
+        assert_eq!(
+            mgr.network_degraded_count().await,
+            1,
+            "the refusal must be recorded so /health can surface it"
+        );
+        let reason = mgr
+            .network_degraded_reason(&id)
+            .await
+            .expect("reason must be present for a network-degraded index");
+        assert!(
+            reason.contains("index-file") && reason.contains("remove-file"),
+            "actionable message must name the supported per-file endpoints, got: {reason}"
+        );
+    }
+
+    /// Why: the network-mount check must be a pure gate in front of the
+    /// existing spawn path — passing `MountKind::Local` (the classification a
+    /// real local disk always resolves to, per `network_fs` tests) must leave
+    /// watcher startup completely unaffected, and must NOT record any
+    /// degraded entry. This is the regression guard against the network
+    /// check accidentally short-circuiting or corrupting the normal path.
+    /// Test: this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn local_root_is_unaffected_by_network_check() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mgr = WatcherManager::new();
+        let handle = handle_for("local-idx", dir.path());
+        let id = IndexId::new("local-idx");
+
+        mgr.spawn_for_index_with_mount_kind(&handle, MountKind::Local)
+            .await;
+
+        assert!(
+            mgr.is_watching(&id).await,
+            "a local root must still get a live watcher"
+        );
+        assert_eq!(mgr.watched_count().await, 1);
+        assert_eq!(
+            mgr.network_degraded_count().await,
+            0,
+            "a local root must never be recorded as network-degraded"
+        );
+        assert!(mgr.network_degraded_reason(&id).await.is_none());
+
+        mgr.stop_all().await;
+    }
+
+    /// Why: `stop_for_index` (e.g. `DELETE /indexes/:id`) must clear a stale
+    /// network-degraded entry too, not just live watchers — otherwise
+    /// `/health` would keep reporting a degraded index that no longer exists.
+    /// Test: this test.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stop_for_index_clears_network_degraded_entry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mgr = WatcherManager::new();
+        let handle = handle_for("net-idx-2", dir.path());
+        let id = IndexId::new("net-idx-2");
+
+        mgr.spawn_for_index_with_mount_kind(&handle, MountKind::Network)
+            .await;
+        assert_eq!(mgr.network_degraded_count().await, 1);
+
+        // stop_for_index normally reports `false` when there was no live
+        // watcher (there wasn't one here — the whole point of the refusal),
+        // but it must still clear the degraded bookkeeping.
+        mgr.stop_for_index(&id).await;
+        assert_eq!(
+            mgr.network_degraded_count().await,
+            0,
+            "stop_for_index must clear the network-degraded entry"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Issue #3408: the native file watcher (inotify/FSEvents) cannot observe writes
made by another host onto a shared EFS/NFS/SMB mount — an OS-level
limitation. Previously the watcher started successfully on such a mount, the
daemon reported healthy, and the watcher silently never fired for cross-host
changes. This PR fixes the silent failure and blesses the existing supported
path.

- **Part 2 (the bug):** `service::network_fs::classify_root` detects a
  network-mounted path via `statfs` (macOS `f_fstypename`; Linux `f_type`
  magic number + a `/proc/mounts` fallback for named network FUSE backends
  like `fuse.sshfs`), using the already-vendored `nix` crate's `fs` feature.
  Detection is conservative and **fails open to Local** on any error/ambiguity
  (a bare `fuse` mount is never flagged) — a false positive (refusing a local
  disk) is worse than a false negative, per the issue's guidance.
  `WatcherManager::spawn_for_index` now refuses to start a watcher for a
  network-mounted root instead of silently starting one that can never fire,
  and records the actionable reason. Surfaced on `GET /health`
  (`indexes_watcher_network_degraded`, folded into the existing
  `"ok"`/`"degraded"` convention from issue #1870) and
  `GET /indexes/:id/status` (`watcher.active` / `watcher.network_mount_degraded`
  / `watcher.degraded_reason`), naming `POST /indexes/:id/index-file` and
  `POST /indexes/:id/remove-file` as the next step. This mirrors the
  codebase's existing "log at WARN + degrade, never fail registration"
  convention for watcher failures rather than introducing a new hard-refusal
  semantic.
- **Part 1 (docs):** officially documents those two endpoints (plus the
  `index_file`/`remove_file` MCP tools) as the supported,
  stability-committed incremental-indexing path for network-mounted and
  build/serve-split deployments, with a worked example script, in
  `crates/trusty-search/README.md` and `CLAUDE.md`'s endpoint catalogue.

## Test plan

- [x] `cargo test -p trusty-search --lib` — 1169 passed, 0 failed (new tests:
      `network_fs::tests::*` pin the pure name/magic classifiers plus a
      real-tempdir false-positive guard; `watcher_manager::tests::*` inject
      `MountKind::Network`/`Local` via `spawn_for_index_with_mount_kind` to
      pin the refuse-and-report path and the local-unaffected path without a
      real NFS mount; `tests_health::health_surfaces_watcher_network_degraded_count`
      covers the `/health` JSON surface end-to-end)
- [x] `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — clean
- [x] `cargo check --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` — clean
- [x] `cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --no-fail-fast` — only 2 pre-existing/unrelated failures (trusty-agents `checkpoint_resume` parallel-load flake; trusty-code `run_task` test needing a live trusty-memory daemon), neither touched by this change
- [x] `cargo fmt --all --check` — clean

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools


Closes #3408
