### PR TITLE
fix(trusty-agents): resolve bundled agents + credentials from any directory

### DIFF
--- a/crates/trusty-agents/src/agents/bundled.rs
+++ b/crates/trusty-agents/src/agents/bundled.rs
@@ -1,0 +1,196 @@
+//! Compile-time embedded bundled agent set + user-tier first-run deploy.
+//!
+//! Why (#3405/#3406 follow-up): `tagent` launched from OUTSIDE this repo
+//! checkout (e.g. `cd ~ && tagent --plain`, the owner's reported clean-shell
+//! failure) has no project-tier `.trusty-agents/agents/` at all, and — until
+//! this module — nothing ever populated the resolver's `$HOME` fallback tier
+//! ([`super::loader`]'s `agents_dir_candidates`, and
+//! [`super::registry::agent_search_paths`]) either. The bundled roster
+//! (`assistant`, `ctrl`, `pm`, the specialist set, …) only ever existed as
+//! plain files under THIS crate's own `.trusty-agents/agents/` — reachable
+//! only when the process happens to run inside (or was built to auto-detect)
+//! this checkout. A `cargo install`ed binary run from any other directory had
+//! no bundled roster to fall back to, so `/switch assistant` (and the plain
+//! CLI's default-persona switch) failed with a bare "file not found" and
+//! silently degraded to `ctrl` (local Ollama) with no explanation.
+//!
+//! trusty-mpm solves the identical problem for ITS bundled agents/skills via
+//! `include_str!` + an explicit `install` deploy step
+//! (`crates/trusty-mpm/src/core/bundle.rs`); this module is the same pattern
+//! adapted to trusty-agents' directory-package + flat-`.toml` agent formats
+//! (too varied in shape for one `include_str!` constant per file, so this
+//! uses `rust-embed` — already a dependency for the web UI bundle, see
+//! `api/server/ui.rs` — to embed the whole `.trusty-agents/agents/` tree at
+//! once).
+//!
+//! What: [`deploy_bundled_agents`] is the hermetic, path-injectable core —
+//! writes every embedded file under `target_dir`, but ONLY when that path
+//! doesn't already exist there, so a user's own edits/overrides (or a
+//! previous deploy) are never clobbered. [`ensure_bundled_agents_deployed`]
+//! is the production entry point: resolves `target_dir` to
+//! `$HOME/.trusty-agents/agents` (the exact fallback tier
+//! `agents_dir_candidates()` and `agent_search_paths()` already search) and
+//! deploys there. Once deployed, NO other resolver code needed to change —
+//! `AgentConfig::by_name`/`by_name_in`/`by_name_async` and the REPL's own
+//! `[agents_dir, $HOME fallback]` list all already check that tier.
+//!
+//! Test: `deploy_writes_missing_files_only`, `deploy_is_idempotent_on_rerun`,
+//! `deploy_never_overwrites_existing_file`,
+//! `deploy_writes_directory_package_agents` (this file);
+//! `ensure_bundled_agents_deployed` itself is exercised end-to-end by the
+//! live-verify transcript in the PR description (it reaches into the real
+//! `$HOME`, so it is not independently unit tested — mirrors every other
+//! best-effort `dirs::home_dir()` operation in this crate, e.g. the REPL log
+//! dir and user-profile save).
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Embeds this crate's own `.trusty-agents/agents/` tree — the shared
+/// persona set (`assistant`, `ctrl`, `pm`, `cto-assistant`, `izzie`) and the
+/// specialist roster (`python-engineer`, `qa-agent`, …) — into the compiled
+/// binary at build time.
+#[derive(rust_embed::RustEmbed)]
+#[folder = ".trusty-agents/agents/"]
+struct BundledAgents;
+
+/// Idempotently materialise every embedded bundled-agent file under
+/// `target_dir`, without ever overwriting a file that is already there.
+///
+/// Why: the hermetic core — takes `target_dir` as a parameter (rather than
+/// resolving `$HOME` itself) so tests can point it at a tempdir instead of
+/// touching the real filesystem outside the sandbox.
+/// What: for each path `rust-embed` walked out of `.trusty-agents/agents/`,
+/// skips it when `target_dir.join(path)` already exists (preserving any
+/// prior deploy or user customization), otherwise creates parent
+/// directories and writes the embedded bytes verbatim. Returns the count of
+/// newly-written files.
+/// Test: `deploy_writes_missing_files_only`, `deploy_is_idempotent_on_rerun`,
+/// `deploy_never_overwrites_existing_file`,
+/// `deploy_writes_directory_package_agents`.
+pub fn deploy_bundled_agents(target_dir: &Path) -> Result<usize> {
+    let mut written = 0usize;
+    for rel in BundledAgents::iter() {
+        let dest = target_dir.join(rel.as_ref());
+        if dest.exists() {
+            continue;
+        }
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create directory {}", parent.display()))?;
+        }
+        let file = BundledAgents::get(&rel)
+            .with_context(|| format!("embedded bundled-agent asset vanished: {rel}"))?;
+        std::fs::write(&dest, file.data.as_ref())
+            .with_context(|| format!("failed to write {}", dest.display()))?;
+        written += 1;
+    }
+    Ok(written)
+}
+
+/// Production entry point: deploy the bundled agent set to
+/// `$HOME/.trusty-agents/agents/` — the resolver's `$HOME` fallback tier —
+/// so `tagent` launched from ANY directory resolves `assistant` (and the
+/// rest of the bundled roster) instead of failing with "agent not found".
+///
+/// Why: called once per process from `runtime::startup::run_startup_init`,
+/// mirroring where the credential-onboarding banner already runs — this is
+/// the single choke point every interactive/one-shot invocation passes
+/// through, but NOT `TrustyAgentsRepl::new` (many unit tests construct a REPL
+/// directly without sandboxing `$HOME`; hooking there would make routine
+/// `cargo test` runs write into a developer's real home directory).
+/// What: no-op (`Ok(0)`) when `$HOME` cannot be resolved at all — matches
+/// every other best-effort `dirs::home_dir()` operation in this crate (the
+/// REPL log dir, the user-profile save). Never fatal: a deploy failure (e.g.
+/// a read-only `$HOME`) is reported to the caller as an `Err` so it can log a
+/// `warn` and continue — a missing bundled roster degrades to the pre-fix
+/// "not found" error, it does not crash the harness.
+pub fn ensure_bundled_agents_deployed() -> Result<usize> {
+    let Some(home) = dirs::home_dir() else {
+        return Ok(0);
+    };
+    let target = home.join(".trusty-agents").join("agents");
+    deploy_bundled_agents(&target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: the core contract — a fresh empty target directory gets every
+    /// embedded file, and the count matches what was actually written.
+    /// Test: itself.
+    #[test]
+    fn deploy_writes_missing_files_only() {
+        let tmp = tempfile::tempdir().unwrap();
+        let written = deploy_bundled_agents(tmp.path()).unwrap();
+        assert!(written > 0, "expected at least one bundled file deployed");
+        assert!(
+            tmp.path().join("analysis-agent.toml").is_file(),
+            "flat .toml bundled agent should be deployed"
+        );
+    }
+
+    /// Why: directory-package agents (`assistant/agent.toml` +
+    /// `assistant/persona.md`) are the primary format the REPL's
+    /// `/switch assistant` resolves — the exact case the owner's clean-shell
+    /// repro hit. Both files inside the package directory must land.
+    /// Test: itself.
+    #[test]
+    fn deploy_writes_directory_package_agents() {
+        let tmp = tempfile::tempdir().unwrap();
+        deploy_bundled_agents(tmp.path()).unwrap();
+        assert!(
+            tmp.path().join("assistant").join("agent.toml").is_file(),
+            "assistant/agent.toml must be deployed"
+        );
+        assert!(
+            tmp.path().join("assistant").join("persona.md").is_file(),
+            "assistant/persona.md must be deployed"
+        );
+    }
+
+    /// Why: re-running the deploy (every process startup) must not re-write
+    /// files that already exist — the idempotency contract.
+    /// Test: itself.
+    #[test]
+    fn deploy_is_idempotent_on_rerun() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = deploy_bundled_agents(tmp.path()).unwrap();
+        assert!(first > 0);
+        let second = deploy_bundled_agents(tmp.path()).unwrap();
+        assert_eq!(second, 0, "re-running the deploy must write nothing new");
+    }
+
+    /// Why: a user who has customized a bundled agent (or a prior deploy's
+    /// output) must never be silently overwritten — the "never clobber"
+    /// contract that lets a user safely edit their deployed copy.
+    /// Test: itself.
+    #[test]
+    fn deploy_never_overwrites_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("analysis-agent.toml"),
+            "# user customized\n",
+        )
+        .unwrap();
+        deploy_bundled_agents(tmp.path()).unwrap();
+        let contents = std::fs::read_to_string(tmp.path().join("analysis-agent.toml")).unwrap();
+        assert_eq!(contents, "# user customized\n");
+    }
+
+    /// Why: `PathBuf` returned by `deploy_bundled_agents` must be usable
+    /// directly as an `agents_dir_candidates()`/REPL `$HOME` tier — assert
+    /// the deployed layout round-trips through `AgentConfig::by_name_in`
+    /// exactly like a real `$HOME/.trusty-agents/agents` would.
+    /// Test: itself.
+    #[test]
+    fn deployed_assistant_resolves_via_by_name_in() {
+        let tmp = tempfile::tempdir().unwrap();
+        deploy_bundled_agents(tmp.path()).unwrap();
+        let cfg = crate::agents::AgentConfig::by_name_in(&[tmp.path().to_path_buf()], "assistant")
+            .expect("deployed assistant package must resolve");
+        assert_eq!(cfg.agent.name, "assistant");
+    }
+}

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -11,6 +11,7 @@
 //! Test: `AgentConfig::load` on bundled `pm.toml` / `python-engineer.toml`
 //! returns Ok with expected `agent.name` / `agent.model`; see `tests.rs`.
 
+pub mod bundled;
 pub mod claude_code_runner;
 pub mod claude_mpm_loader;
 mod config;

--- a/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
+++ b/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
@@ -241,8 +241,25 @@ fn resolve_endpoint_agent(repl: &crate::repl::TrustyAgentsRepl) -> (String, Stri
 /// configured" even though dispatch would resolve and use it fine. Routes
 /// through the same `pick_credentials` resolver the TUI's own startup
 /// banner uses (`repl/run.rs`), which checks env → `.env.local` → the store.
-fn resolved_credential_label(runner: RunnerKind) -> &'static str {
-    crate::llm::credentials::pick_credentials(Some(runner))
-        .map(|c| c.label())
-        .unwrap_or("none")
+///
+/// Issue #3406 follow-up: a bare `credential=none` was confusing when the
+/// secure store demonstrably HAD a key — just for a provider (e.g.
+/// `fireworks`) ctrl/PM's own LLM calls don't route through. When
+/// `pick_credentials` finds nothing but
+/// [`crate::llm::credentials::other_configured_providers`] names one, the
+/// label now says so explicitly instead of a bare "none".
+fn resolved_credential_label(runner: RunnerKind) -> String {
+    if let Some(c) = crate::llm::credentials::pick_credentials(Some(runner)) {
+        return c.label().to_string();
+    }
+    let other = crate::llm::credentials::other_configured_providers();
+    if other.is_empty() {
+        "none".to_string()
+    } else {
+        format!(
+            "none (configured: {} — not usable for this agent's model; need one of \
+             openrouter/anthropic/claude-code)",
+            other.join(", ")
+        )
+    }
 }

--- a/crates/trusty-agents/src/ctrl/repl/profile.rs
+++ b/crates/trusty-agents/src/ctrl/repl/profile.rs
@@ -3,15 +3,42 @@
 //! Why: The profile setup is a self-contained side concern of CTRL startup;
 //! splitting it from the command dispatcher + stdin loop keeps both files under
 //! the line cap.
-//! What: `load_or_create_user_profile` (load-or-interview) and
+//! What: `load_or_create_user_profile` (load-or-env-or-interview) and
 //! `conduct_user_interview` (the interactive prompts).
 //! Test: Smoke-tested via the tmux REPL harness; the load path short-circuits
-//! when a complete profile already exists.
+//! when a complete profile already exists; the env-resolution path is unit
+//! tested on `UserProfile::from_env` directly (`identity::user_profile::tests`)
+//! since it needs no REPL/stdin scaffolding.
 
 use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
-/// Load `~/.trusty-agents/user.toml`, or run the first-run interview to create it. (#193)
+/// Load `~/.trusty-agents/user.toml`, resolve from the environment
+/// (`.env.local`), or run the first-run interview to create it (#193,
+/// extended by #3406 follow-up).
+///
+/// Why: the interactive interview blocks on stdin every time
+/// `~/.trusty-agents/user.toml` is absent/incomplete — friction for a user
+/// who already has `TAGENT_USER_NAME`/`_EMAIL`/`_TIMEZONE` in a `.env.local`
+/// (owner directive: "I don't want to have to set the credential. You have
+/// them, use them." — extended from credentials to the profile). Precedence
+/// mirrors the credential resolver's shape: an already-saved, complete
+/// `user.toml` wins outright (never overwritten here); otherwise the
+/// environment (which `run_startup_init` has already merged from process env
+/// > project `.env.local` > user `$HOME/.env.local`, per
+/// `UserProfile::from_env`'s docs) is tried BEFORE the interactive prompt;
+/// the prompt is the last resort.
+/// What: `UserProfile::load()` short-circuits when complete. Otherwise
+/// `UserProfile::from_env()` is tried; a hit is persisted to `user.toml` (so
+/// later runs skip straight to the fast path and stop depending on
+/// `.env.local` still being present/unchanged) and returned WITHOUT
+/// prompting. A save failure is logged, not fatal — the resolved profile is
+/// still used in-memory for this run. Only when neither source yields a
+/// profile does the interactive interview (or the `TAGENT_NONINTERACTIVE`
+/// placeholder) run.
+/// Test: `identity::user_profile::tests::from_env_*` cover the resolution
+/// rules; this function's persistence step is exercised via the tmux REPL
+/// harness (module docs) since it drives real stdin/`$HOME`.
 pub(super) async fn load_or_create_user_profile()
 -> Result<Option<crate::identity::user_profile::UserProfile>> {
     use crate::identity::user_profile::UserProfile;
@@ -20,6 +47,22 @@ pub(super) async fn load_or_create_user_profile()
         && p.is_complete()
     {
         return Ok(Some(p));
+    }
+
+    if let Some(profile) = UserProfile::from_env() {
+        if let Err(e) = profile.save() {
+            tracing::warn!(
+                error = %e,
+                "failed to persist env-resolved user profile (continuing in-memory)"
+            );
+        } else {
+            eprintln!(
+                "[trusty-agents] resolved profile for {} from the environment (.env.local); \
+                 saved to ~/.trusty-agents/user.toml",
+                profile.name
+            );
+        }
+        return Ok(Some(profile));
     }
 
     let noninteractive =

--- a/crates/trusty-agents/src/identity/user_profile.rs
+++ b/crates/trusty-agents/src/identity/user_profile.rs
@@ -85,6 +85,53 @@ impl UserProfile {
     pub fn is_complete(&self) -> bool {
         !self.name.trim().is_empty()
     }
+
+    /// Zero-config profile capture from the process environment (issue
+    /// #3406 follow-up — owner directive: "I don't want to have to set the
+    /// credential. You have them, use them.", extended to the profile).
+    ///
+    /// Why: the first-run interactive interview
+    /// (`ctrl::repl::profile::conduct_user_interview`) blocks on stdin every
+    /// time `~/.trusty-agents/user.toml` is missing or incomplete — annoying
+    /// for a user who already has these values in a `.env.local` (project OR
+    /// the user-global `$HOME/.env.local` tier). By the time
+    /// `load_or_create_user_profile` calls this, `runtime::startup::
+    /// run_startup_init` has already merged BOTH `.env.local` tiers into the
+    /// process env via `trusty_common::inference::credentials::
+    /// load_env_local_once` (precedence: process env > project `.env.local`
+    /// > user `$HOME/.env.local`) — so a plain `std::env::var` read here
+    /// transparently sees whichever tier supplied the value, with no
+    /// separate file-parsing logic needed.
+    /// What: reads `TAGENT_USER_NAME` (required — `None` overall when absent
+    /// or blank), `TAGENT_USER_EMAIL` (optional), and `TAGENT_USER_TIMEZONE`
+    /// (optional, falling back to the POSIX `TZ` var when unset — a
+    /// widely-set convention that's an unambiguous stand-in when the
+    /// TAGENT-specific var isn't present). `preferred_model` is always
+    /// `None` (no env var maps to it; users needing that use `/model`).
+    /// Test: `from_env_reads_name_email_timezone`,
+    /// `from_env_falls_back_to_tz_for_timezone`,
+    /// `from_env_returns_none_when_name_absent`,
+    /// `from_env_treats_blank_name_as_absent`.
+    pub fn from_env() -> Option<Self> {
+        let name = std::env::var("TAGENT_USER_NAME")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())?;
+        let email = std::env::var("TAGENT_USER_EMAIL")
+            .ok()
+            .filter(|s| !s.is_empty());
+        let timezone = std::env::var("TAGENT_USER_TIMEZONE")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .or_else(|| std::env::var("TZ").ok().filter(|s| !s.is_empty()));
+        Some(Self {
+            name,
+            email,
+            preferred_model: None,
+            timezone,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -126,5 +173,105 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("does-not-exist.toml");
         assert!(UserProfile::load_from(&path).is_none());
+    }
+
+    /// Clears every var `from_env` reads. Callers must hold
+    /// `crate::test_env::ENV_LOCK` for the whole test body.
+    fn clear_profile_env() {
+        unsafe {
+            std::env::remove_var("TAGENT_USER_NAME");
+            std::env::remove_var("TAGENT_USER_EMAIL");
+            std::env::remove_var("TAGENT_USER_TIMEZONE");
+            std::env::remove_var("TZ");
+        }
+    }
+
+    /// Why: the core zero-config contract — all three vars set must produce
+    /// a matching, immediately-complete profile.
+    /// Test: itself.
+    #[test]
+    fn from_env_reads_name_email_timezone() {
+        let _g = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_profile_env();
+        unsafe {
+            std::env::set_var("TAGENT_USER_NAME", "Masa");
+            std::env::set_var("TAGENT_USER_EMAIL", "masa@matsuoka.com");
+            std::env::set_var("TAGENT_USER_TIMEZONE", "America/New_York");
+        }
+        let p = UserProfile::from_env().expect("expected a profile from env");
+        assert_eq!(p.name, "Masa");
+        assert_eq!(p.email.as_deref(), Some("masa@matsuoka.com"));
+        assert_eq!(p.timezone.as_deref(), Some("America/New_York"));
+        assert!(p.is_complete());
+        clear_profile_env();
+    }
+
+    /// Why: `TAGENT_USER_TIMEZONE` is the primary var, but a bare `TZ` (a
+    /// widely-set POSIX convention) is an unambiguous fallback when only
+    /// that is present — avoids forcing a redundant var for users who
+    /// already export `TZ`.
+    /// Test: itself.
+    #[test]
+    fn from_env_falls_back_to_tz_for_timezone() {
+        let _g = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_profile_env();
+        unsafe {
+            std::env::set_var("TAGENT_USER_NAME", "Masa");
+            std::env::set_var("TZ", "America/New_York");
+        }
+        let p = UserProfile::from_env().expect("expected a profile from env");
+        assert_eq!(p.timezone.as_deref(), Some("America/New_York"));
+        clear_profile_env();
+    }
+
+    /// Why: `TAGENT_USER_TIMEZONE`, when present, must win over a bare `TZ`
+    /// — the TAGENT-specific var is the more deliberate signal.
+    /// Test: itself.
+    #[test]
+    fn from_env_prefers_tagent_timezone_over_tz() {
+        let _g = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_profile_env();
+        unsafe {
+            std::env::set_var("TAGENT_USER_NAME", "Masa");
+            std::env::set_var("TAGENT_USER_TIMEZONE", "UTC");
+            std::env::set_var("TZ", "America/New_York");
+        }
+        let p = UserProfile::from_env().expect("expected a profile from env");
+        assert_eq!(p.timezone.as_deref(), Some("UTC"));
+        clear_profile_env();
+    }
+
+    /// Why: no name means no profile — the interactive interview must still
+    /// run rather than silently creating a nameless profile.
+    /// Test: itself.
+    #[test]
+    fn from_env_returns_none_when_name_absent() {
+        let _g = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_profile_env();
+        assert!(UserProfile::from_env().is_none());
+    }
+
+    /// Why: a `TAGENT_USER_NAME` set to whitespace-only is effectively
+    /// absent, not a valid (blank) name.
+    /// Test: itself.
+    #[test]
+    fn from_env_treats_blank_name_as_absent() {
+        let _g = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_profile_env();
+        unsafe {
+            std::env::set_var("TAGENT_USER_NAME", "   ");
+        }
+        assert!(UserProfile::from_env().is_none());
+        clear_profile_env();
     }
 }

--- a/crates/trusty-agents/src/llm/credentials.rs
+++ b/crates/trusty-agents/src/llm/credentials.rs
@@ -124,6 +124,34 @@ pub fn missing_credentials_error() -> String {
         .to_string()
 }
 
+/// Providers configured (via any resolver tier) that ctrl/PM's own LLM calls
+/// cannot route through — `openrouter`/`anthropic`/`claude-code` are the only
+/// three [`pick_credentials`] ever selects.
+///
+/// Why (#3406 follow-up, live-confirmed): a store entry for e.g. `fireworks`
+/// (configured for a DIFFERENT consumer, such as a sub-agent's own model)
+/// makes `pick_credentials` correctly return `None` for ctrl/PM — but a bare
+/// "credential=none" then reads as "nothing is configured anywhere", which is
+/// misleading when the store demonstrably has a working key. Naming the
+/// mismatched provider turns a confusing dead end into an actionable
+/// diagnostic ("you have `fireworks` configured, but ctrl/PM needs
+/// openrouter/anthropic/claude-code").
+/// What: walks the shared provider registry, excludes the three providers
+/// `pick_credentials` already checks, and returns the `id` of every
+/// remaining provider whose credential resolves via
+/// [`trusty_common::inference::credentials::resolve_key`]. Never exposes a
+/// value — names only, same discipline as `config keys list`.
+/// Test: `other_configured_providers_names_fireworks_when_store_has_it`,
+/// `other_configured_providers_empty_when_nothing_else_configured`.
+pub fn other_configured_providers() -> Vec<&'static str> {
+    trusty_common::inference::registry::all()
+        .iter()
+        .map(|caps| caps.id.as_str())
+        .filter(|id| !matches!(*id, "openrouter" | "anthropic" | "claude-code"))
+        .filter(|id| resolve_key_set(id))
+        .collect()
+}
+
 /// Whether `provider`'s credential resolves via the shared 3-tier resolver,
 /// without ever exposing the resolved value.
 ///
@@ -437,5 +465,93 @@ mod tests {
     fn leaves_unrelated_id_alone() {
         let r = qualify_openrouter_model(&LlmCredentials::OpenRouter, "gpt-4o");
         assert_eq!(r, "gpt-4o");
+    }
+
+    /// Why: the exact confusing case the owner hit live — `fireworks`
+    /// configured via the secure store (a real, working key for a DIFFERENT
+    /// consumer) while ctrl/PM's own three providers are all absent. The
+    /// diagnostic must name `fireworks` rather than reporting a bare "none".
+    /// Sandboxes `$HOME` (mirrors `pick_consults_store_when_env_absent`) so
+    /// the store write never touches the real machine's store.
+    /// Test: itself.
+    #[test]
+    #[serial]
+    fn other_configured_providers_names_fireworks_when_store_has_it() {
+        let _env_guard = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _home_guard = crate::test_env::HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_all();
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let prev_home = std::env::var_os("HOME");
+        // SAFETY: HOME_LOCK held for the entire test body.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+        }
+
+        let store = trusty_common::inference::credentials::FileKeyStore::at(tmp.path());
+        trusty_common::inference::credentials::KeyStore::set(
+            &store,
+            "fireworks",
+            "fw-from-store", // pragma: allowlist secret
+        )
+        .expect("seed store");
+
+        assert_eq!(pick_credentials(None), None);
+        let other = other_configured_providers();
+        assert!(
+            other.contains(&"fireworks"),
+            "expected fireworks to be named: {other:?}"
+        );
+        assert!(
+            !other
+                .iter()
+                .any(|p| matches!(*p, "openrouter" | "anthropic" | "claude-code")),
+            "the three providers pick_credentials already checks must never \
+             appear here: {other:?}"
+        );
+
+        // SAFETY: HOME_LOCK still held.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    /// Why: when NOTHING is configured anywhere, the diagnostic must be
+    /// empty — the plain-CLI banner falls back to a bare "none" in that case.
+    /// Test: itself.
+    #[test]
+    #[serial]
+    fn other_configured_providers_empty_when_nothing_else_configured() {
+        let _env_guard = crate::test_env::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _home_guard = crate::test_env::HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        clear_all();
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let prev_home = std::env::var_os("HOME");
+        // SAFETY: HOME_LOCK held for the entire test body.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+        }
+
+        assert_eq!(other_configured_providers(), Vec::<&'static str>::new());
+
+        // SAFETY: HOME_LOCK still held.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
     }
 }

--- a/crates/trusty-agents/src/runtime/cli_def.rs
+++ b/crates/trusty-agents/src/runtime/cli_def.rs
@@ -288,6 +288,40 @@ pub(super) struct Cli {
     pub(super) rest: Vec<String>,
 }
 
+/// Whether at least one of the three credential providers ctrl/PM's own LLM
+/// calls route through (`openrouter`, `anthropic`, `claude-code`) resolves
+/// via ANY tier (process env, `.env.local`, or the secure store).
+///
+/// Why: `check_credentials_and_warn` couples this decision to printing a
+/// stderr banner, which makes the decision itself impossible to unit test
+/// without capturing/parsing stderr output. Extracting the pure predicate
+/// (issue #3429 code-critic follow-up on PR #3431 — the doc-pointer lint
+/// caught that this logic had NO real test coverage, only a dangling
+/// `Test:` citation) lets tests assert the resolve / no-resolve outcome
+/// directly. Hermeticity: rather than injecting a resolver closure, this
+/// reuses the SAME `$HOME`-sandboxed `FileKeyStore` convention
+/// `llm::credentials::tests::pick_consults_store_when_env_absent` already
+/// established for testing this exact production `resolve_key` call
+/// (`resolve_key`'s store tier resolves via `dirs::home_dir()`, so
+/// redirecting `$HOME` to a tempdir makes the real function hermetic
+/// without needing a seam) — the tests below (`banner_suppressed_when_
+/// store_configures_a_key`, `banner_fires_when_nothing_resolves`) never
+/// touch the real developer machine's env or store.
+/// What: `true` when `trusty_common::inference::credentials::resolve_key`
+/// finds `claude-code`, `anthropic`, OR `openrouter` — the exact same three
+/// providers `llm::credentials::pick_credentials` checks (this predicate
+/// does NOT gate `claude-code` on an agent's `runner` the way
+/// `pick_credentials` does, since the banner's question is simply "is ANY
+/// of these three configured at all," not "which one would THIS agent
+/// use").
+/// Test: `banner_suppressed_when_store_configures_a_key`,
+/// `banner_fires_when_nothing_resolves`.
+fn any_credential_resolves() -> bool {
+    trusty_common::inference::credentials::resolve_key("claude-code").is_some()
+        || trusty_common::inference::credentials::resolve_key("anthropic").is_some()
+        || trusty_common::inference::credentials::resolve_key("openrouter").is_some()
+}
+
 /// Print a prominent onboarding banner when no API credential resolves via
 /// ANY tier (env, project `.env.local`, user `$HOME/.env.local`, or the
 /// secure store).
@@ -318,22 +352,17 @@ pub(super) struct Cli {
 /// `.env.local` line AND `tagent config keys set <provider>` (the durable,
 /// works-from-any-directory option `.env.local` alone cannot offer from
 /// `$HOME`). Non-fatal — the REPL still opens so CLI-only subcommands
-/// (memory search, skills list) keep working.
+/// (memory search, skills list) keep working. Delegates the actual
+/// resolve-or-not DECISION to `any_credential_resolves` — a pure,
+/// independently-testable predicate — rather than inlining it here, since
+/// this function's own stderr side effects make ITS behavior awkward to
+/// assert directly.
 /// Test: `banner_suppressed_when_store_configures_a_key`,
-/// `banner_fires_when_nothing_resolves` (tests module below) exercise the
-/// resolve-tier gate via `pick_credentials`'s own store-backed tests, since
-/// this function's stderr output itself is not asserted (manual/live-verify
-/// per the module docs above).
+/// `banner_fires_when_nothing_resolves` (both in the `tests` module below)
+/// exercise `any_credential_resolves` directly — the gate this function
+/// wraps.
 pub(super) fn check_credentials_and_warn() {
-    // #3406 follow-up: match the SAME resolver real dispatch uses instead of
-    // a raw env-var read, so a store- or `.env.local`-only credential is
-    // correctly recognized.
-    let has_claude_code =
-        trusty_common::inference::credentials::resolve_key("claude-code").is_some();
-    let has_anthropic = trusty_common::inference::credentials::resolve_key("anthropic").is_some();
-    let has_openrouter = trusty_common::inference::credentials::resolve_key("openrouter").is_some();
-
-    if has_claude_code || has_anthropic || has_openrouter {
+    if any_credential_resolves() {
         return;
     }
 
@@ -454,5 +483,126 @@ mod tests {
         // is_tty()-vs-piped-loop dispatch branch is unchanged (no regression
         // for desktop TUI users).
         assert!(!should_force_plain_cli(false, None));
+    }
+
+    /// Coverage for `any_credential_resolves` — the pure decision
+    /// `check_credentials_and_warn`'s banner gate wraps (issue #3429
+    /// code-critic follow-up on PR #3431: the doc-comment pointer lint
+    /// caught that this logic had zero real test coverage).
+    mod credential_banner {
+        use super::super::any_credential_resolves;
+        use serial_test::serial;
+
+        /// Clears every env var `any_credential_resolves` (transitively, via
+        /// `resolve_key`) consults. Callers must hold both
+        /// `crate::test_env::ENV_LOCK` and `crate::test_env::HOME_LOCK` for
+        /// the whole test body — mirrors
+        /// `llm::credentials::tests::clear_all` in the sibling module that
+        /// tests the same underlying `resolve_key` calls.
+        fn clear_all() {
+            unsafe {
+                std::env::remove_var("OPENROUTER_API_KEY");
+                std::env::remove_var("ANTHROPIC_API_KEY");
+                std::env::remove_var("CLAUDE_CODE_OAUTH_TOKEN");
+            }
+        }
+
+        /// Why: this is the exact bug the owner's live clean-shell repro
+        /// hit — `openrouter` configured ONLY via the secure store (never
+        /// exported to the shell), with all three credential env vars
+        /// absent. The pre-fix banner (a raw `std::env::var` check) would
+        /// have fired here even though real dispatch resolves the key fine;
+        /// `any_credential_resolves` must say "resolved" so
+        /// `check_credentials_and_warn` suppresses the banner.
+        /// What: sandboxes `$HOME` to a tempdir (mirrors
+        /// `llm::credentials::tests::pick_consults_store_when_env_absent`,
+        /// which tests the identical `resolve_key` call), seeds `openrouter`
+        /// directly into a `FileKeyStore` rooted there, clears every
+        /// credential env var, and asserts `any_credential_resolves()` is
+        /// `true`. Never touches the real developer machine's store — the
+        /// sandboxed `$HOME` is a fresh tempdir for the duration of the
+        /// test only.
+        /// Test: itself.
+        #[test]
+        #[serial]
+        fn banner_suppressed_when_store_configures_a_key() {
+            let _env_guard = crate::test_env::ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let _home_guard = crate::test_env::HOME_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            clear_all();
+
+            let tmp = tempfile::TempDir::new().expect("tempdir");
+            let prev_home = std::env::var_os("HOME");
+            // SAFETY: HOME_LOCK held for the entire test body.
+            unsafe {
+                std::env::set_var("HOME", tmp.path());
+            }
+
+            let store = trusty_common::inference::credentials::FileKeyStore::at(tmp.path());
+            trusty_common::inference::credentials::KeyStore::set(
+                &store,
+                "openrouter",
+                "sk-or-from-store", // pragma: allowlist secret
+            )
+            .expect("seed store");
+
+            assert!(
+                any_credential_resolves(),
+                "a store-only openrouter key must resolve and suppress the banner"
+            );
+
+            // SAFETY: HOME_LOCK still held.
+            unsafe {
+                match prev_home {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
+
+        /// Why: the banner's legitimate-fire case — nothing configured
+        /// anywhere (no env var, no `.env.local` loaded into this test's
+        /// process env, no store entry). Sandboxing `$HOME` to a FRESH,
+        /// never-written-to tempdir guarantees the store tier is genuinely
+        /// empty rather than accidentally reading the real developer
+        /// machine's `~/.trusty-agents`/keychain state.
+        /// What: clears every credential env var, sandboxes `$HOME` to an
+        /// empty tempdir (no `FileKeyStore` entries seeded), and asserts
+        /// `any_credential_resolves()` is `false`.
+        /// Test: itself.
+        #[test]
+        #[serial]
+        fn banner_fires_when_nothing_resolves() {
+            let _env_guard = crate::test_env::ENV_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let _home_guard = crate::test_env::HOME_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            clear_all();
+
+            let tmp = tempfile::TempDir::new().expect("tempdir");
+            let prev_home = std::env::var_os("HOME");
+            // SAFETY: HOME_LOCK held for the entire test body.
+            unsafe {
+                std::env::set_var("HOME", tmp.path());
+            }
+
+            assert!(
+                !any_credential_resolves(),
+                "with nothing configured anywhere, the banner must fire"
+            );
+
+            // SAFETY: HOME_LOCK still held.
+            unsafe {
+                match prev_home {
+                    Some(v) => std::env::set_var("HOME", v),
+                    None => std::env::remove_var("HOME"),
+                }
+            }
+        }
     }
 }

--- a/crates/trusty-agents/src/runtime/cli_def.rs
+++ b/crates/trusty-agents/src/runtime/cli_def.rs
@@ -288,48 +288,92 @@ pub(super) struct Cli {
     pub(super) rest: Vec<String>,
 }
 
-/// Print a prominent onboarding banner when no API credential is configured.
+/// Print a prominent onboarding banner when no API credential resolves via
+/// ANY tier (env, project `.env.local`, user `$HOME/.env.local`, or the
+/// secure store).
 ///
 /// Why: New users who clone the repo and run `om` without configuring a key
 /// get confusing LLM errors. Surfacing setup instructions before the REPL
 /// opens is friendlier and self-service. OpenRouter is recommended because
 /// it's free-tier, supports many models, and is already the deployment
 /// fallback.
-/// What: Checks for any of the three supported credential env vars; when
-/// none are set, prints a boxed banner to stderr with setup steps and the
-/// OpenRouter sign-up URL. Non-fatal — the REPL still opens so CLI-only
-/// subcommands (memory search, skills list) keep working.
-/// Test: Manual — unset all three env vars and run `cargo run`. Banner should
-/// appear once on stderr; setting any one of the three suppresses it.
+///
+/// Issue #3406 follow-up (confirmed live): the previous implementation
+/// checked ONLY raw `std::env::var` for the three credential names — so a
+/// key configured via `tagent config keys set <provider>` (the secure store)
+/// or a project/user `.env.local` produced a FALSE "no API key found" banner
+/// even though real dispatch (`llm::credentials::pick_credentials`, which
+/// this now matches) would resolve and use it fine. This is the exact bug
+/// the owner's clean-shell repro hit: `openrouter` was configured via the
+/// secure store, `tagent config keys list` correctly reported it, yet the
+/// startup banner still claimed no key existed.
+/// What: Consults the same 3-tier resolver
+/// (`trusty_common::inference::credentials::resolve_key`) `pick_credentials`
+/// uses for the three provider names this binary's own LLM calls route
+/// through (`openrouter`, `anthropic`, `claude-code`); when at least one
+/// resolves, no banner prints. When none resolve, prints a boxed banner
+/// listing every location actually checked (env var names, the project
+/// `.env.local` path when one is in scope, the user `$HOME/.env.local` path,
+/// and the secure store) plus BOTH remediation options — a project/user
+/// `.env.local` line AND `tagent config keys set <provider>` (the durable,
+/// works-from-any-directory option `.env.local` alone cannot offer from
+/// `$HOME`). Non-fatal — the REPL still opens so CLI-only subcommands
+/// (memory search, skills list) keep working.
+/// Test: `banner_suppressed_when_store_configures_a_key`,
+/// `banner_fires_when_nothing_resolves` (tests module below) exercise the
+/// resolve-tier gate via `pick_credentials`'s own store-backed tests, since
+/// this function's stderr output itself is not asserted (manual/live-verify
+/// per the module docs above).
 pub(super) fn check_credentials_and_warn() {
-    let has_claude_code = std::env::var("CLAUDE_CODE_OAUTH_TOKEN")
-        .map(|v| !v.is_empty())
-        .unwrap_or(false);
-    let has_anthropic = std::env::var("ANTHROPIC_API_KEY")
-        .map(|v| !v.is_empty())
-        .unwrap_or(false);
-    let has_openrouter = std::env::var(trusty_common::env_vars::ENV_OPENROUTER_API_KEY)
-        .map(|v| !v.is_empty())
-        .unwrap_or(false);
+    // #3406 follow-up: match the SAME resolver real dispatch uses instead of
+    // a raw env-var read, so a store- or `.env.local`-only credential is
+    // correctly recognized.
+    let has_claude_code =
+        trusty_common::inference::credentials::resolve_key("claude-code").is_some();
+    let has_anthropic = trusty_common::inference::credentials::resolve_key("anthropic").is_some();
+    let has_openrouter = trusty_common::inference::credentials::resolve_key("openrouter").is_some();
 
     if has_claude_code || has_anthropic || has_openrouter {
         return;
     }
+
+    let project_env_local = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| trusty_common::inference::credentials::find_workspace_env_local(&cwd));
+    let user_env_local = dirs::home_dir()
+        .and_then(|h| trusty_common::inference::credentials::user_env_local_path(&h));
 
     eprintln!();
     eprintln!("┌─────────────────────────────────────────────────────────────────┐");
     eprintln!("│  ⚡  No API key found — trusty-agents needs a key to talk to an LLM  │");
     eprintln!("├─────────────────────────────────────────────────────────────────┤");
     eprintln!("│                                                                 │");
+    eprintln!("│  Checked (none resolved):                                       │");
+    eprintln!("│    env: OPENROUTER_API_KEY / ANTHROPIC_API_KEY /                │");
+    eprintln!("│         CLAUDE_CODE_OAUTH_TOKEN                                  │");
+    match &project_env_local {
+        Some(p) => eprintln!("│    project .env.local: {}", p.display()),
+        None => eprintln!("│    project .env.local: none found above this directory          │"),
+    }
+    match &user_env_local {
+        Some(p) => eprintln!("│    user .env.local: {}", p.display()),
+        None => eprintln!("│    user ~/.env.local: not present                                │"),
+    }
+    eprintln!("│    secure store (`tagent config keys list`): empty              │");
+    eprintln!("│                                                                 │");
+    eprintln!("│  Durable option — works from ANY directory:                     │");
+    eprintln!("│    tagent config keys set openrouter                            │");
+    eprintln!("│                                                                 │");
     eprintln!("│  Quickest option — get a free OpenRouter key (5 min):           │");
     eprintln!("│    https://openrouter.ai/keys                                   │");
     eprintln!("│                                                                 │");
-    eprintln!("│  Then create .env.local in your project root:                   │");
-    eprintln!("│    echo 'OPENROUTER_API_KEY=sk-or-v1-...' >> .env.local         │");
+    eprintln!("│  Or drop it in ~/.env.local (works from any directory) or a     │");
+    eprintln!("│  project .env.local (project-scoped only):                      │");
+    eprintln!("│    echo 'OPENROUTER_API_KEY=sk-or-v1-...' >> ~/.env.local       │");
     eprintln!("│                                                                 │");
     eprintln!("│  Or use Claude Code OAuth (if you have Claude Code installed):  │");
     eprintln!("│    claude setup-token   # copies token to clipboard             │");
-    eprintln!("│    echo 'CLAUDE_CODE_OAUTH_TOKEN=...' >> .env.local             │");
+    eprintln!("│    tagent config keys set claude-code                           │");
     eprintln!("│                                                                 │");
     eprintln!("│  Restart trusty-agents after adding the key. (REPL continues below)  │");
     eprintln!("└─────────────────────────────────────────────────────────────────┘");

--- a/crates/trusty-agents/src/runtime/mod.rs
+++ b/crates/trusty-agents/src/runtime/mod.rs
@@ -120,6 +120,15 @@ pub async fn run() -> Result<()> {
     // which would otherwise skew `config keys list`'s tier report by folding the
     // file into the process env before the verb inspects it.
     if args.len() > 1 && args[1] == "config" {
+        // #3406 follow-up: `tagent config profile show|set` manages
+        // `~/.trusty-agents/user.toml` directly (a trusty-agents-only
+        // concept — unlike `keys`, it isn't part of the shared
+        // `trusty_common::inference::config::ConfigCommand` surface every
+        // trusty-* binary mounts) — so it's intercepted here rather than
+        // folded into that shared parser.
+        if args.len() > 2 && args[2] == "profile" {
+            return subcommands::run_config_profile_subcommand(&args[3..]).await;
+        }
         return subcommands::run_config_subcommand(&args[1..]).await;
     }
 

--- a/crates/trusty-agents/src/runtime/registry_cmds/mod.rs
+++ b/crates/trusty-agents/src/runtime/registry_cmds/mod.rs
@@ -116,16 +116,36 @@ use tools::write_file::WriteFileTool;
 use tools::{ToolRegistry, delegate::DelegateToAgentTool, shell_exec::ShellExecTool};
 use workflow::WorkflowEngine;
 
-/// Handle `trusty-agents agents <subcommand>` (#167).
+/// Handle `trusty-agents agents <subcommand>` (#167, `deploy` added by
+/// #3405/#3406 follow-up).
 ///
 /// Why: Exposes the discovery results to operators. Without this, there's
 /// no way to verify which agents were picked up from which directory.
-/// What: Currently supports `agents list`. Prints discovered agents with
-/// their source and capability tags in the format described in the issue.
-/// Test: Covered manually; unit-tested via `AgentRegistry::list`.
+/// `deploy` gives an explicit, re-runnable repair path for the automatic
+/// first-run deploy in `runtime::startup::run_startup_init` — useful when a
+/// user deletes `~/.trusty-agents/agents/` or wants to confirm the bundled
+/// roster landed without waiting for the next interactive startup.
+/// What: `list` (default) prints discovered agents with their source and
+/// capability tags. `deploy` writes any bundled agent files missing from
+/// `$HOME/.trusty-agents/agents/`, reporting how many were newly written
+/// (idempotent — a repeat run reports 0).
+/// Test: Covered manually; unit-tested via `AgentRegistry::list` and
+/// `agents::bundled::deploy_bundled_agents`'s own tests.
 pub(super) async fn run_agents_subcommand(args: &[String]) -> Result<()> {
     let sub = args.first().map(String::as_str).unwrap_or("list");
     match sub {
+        "deploy" => {
+            let written = agents::bundled::ensure_bundled_agents_deployed()
+                .context("failed to deploy bundled agents to $HOME/.trusty-agents/agents")?;
+            if written > 0 {
+                println!("Deployed {written} bundled agent file(s) to ~/.trusty-agents/agents/.");
+            } else {
+                println!(
+                    "Bundled agents already present in ~/.trusty-agents/agents/ — nothing to deploy."
+                );
+            }
+            Ok(())
+        }
         "list" => {
             let reg = agents::registry::AgentRegistry::load(&agents::registry::agent_search_paths(
                 &default_bundled_config_dir(),
@@ -168,11 +188,11 @@ pub(super) async fn run_agents_subcommand(args: &[String]) -> Result<()> {
         other => {
             // #366: Surface a "did you mean?" hint for typos like
             // `agents lst` -> `agents list`.
-            let known = &["list"];
+            let known = &["list", "deploy"];
             if let Some(s) = cli::did_you_mean(other, known, 2) {
                 eprintln!("tagent agents: unknown subcommand '{other}'. Did you mean '{s}'?");
             } else {
-                eprintln!("tagent agents: unknown subcommand '{other}'. Try: list");
+                eprintln!("tagent agents: unknown subcommand '{other}'. Try: list, deploy");
             }
             bail!("unknown agents subcommand: {other}");
         }

--- a/crates/trusty-agents/src/runtime/registry_cmds/mod.rs
+++ b/crates/trusty-agents/src/runtime/registry_cmds/mod.rs
@@ -126,11 +126,18 @@ use workflow::WorkflowEngine;
 /// user deletes `~/.trusty-agents/agents/` or wants to confirm the bundled
 /// roster landed without waiting for the next interactive startup.
 /// What: `list` (default) prints discovered agents with their source and
-/// capability tags. `deploy` writes any bundled agent files missing from
+/// capability tags. `deploy` writes any bundled agent files MISSING from
 /// `$HOME/.trusty-agents/agents/`, reporting how many were newly written
-/// (idempotent — a repeat run reports 0).
+/// (idempotent — a repeat run reports 0). Deliberate tradeoff, stated in the
+/// output text below (code-critic follow-up on #3429/#3431): a file that
+/// ALREADY EXISTS there — whether from a prior deploy or a user's own
+/// edit — is never touched, even if the bundled version has since changed.
+/// A future release that improves a bundled persona will NOT reach a user
+/// who already has the old file; `rm ~/.trusty-agents/agents/<name>` (or the
+/// whole directory) before re-running `deploy` is the escape hatch.
 /// Test: Covered manually; unit-tested via `AgentRegistry::list` and
-/// `agents::bundled::deploy_bundled_agents`'s own tests.
+/// `agents::bundled::deploy_bundled_agents`'s own tests
+/// (`deploy_never_overwrites_existing_file`).
 pub(super) async fn run_agents_subcommand(args: &[String]) -> Result<()> {
     let sub = args.first().map(String::as_str).unwrap_or("list");
     match sub {
@@ -138,10 +145,18 @@ pub(super) async fn run_agents_subcommand(args: &[String]) -> Result<()> {
             let written = agents::bundled::ensure_bundled_agents_deployed()
                 .context("failed to deploy bundled agents to $HOME/.trusty-agents/agents")?;
             if written > 0 {
-                println!("Deployed {written} bundled agent file(s) to ~/.trusty-agents/agents/.");
+                println!(
+                    "Deployed {written} bundled agent file(s) to ~/.trusty-agents/agents/ \
+                     (only files that did not already exist there — existing files, including \
+                     prior deploys and your own edits, are never overwritten or updated)."
+                );
             } else {
                 println!(
-                    "Bundled agents already present in ~/.trusty-agents/agents/ — nothing to deploy."
+                    "Bundled agents already present in ~/.trusty-agents/agents/ — nothing to \
+                     deploy. Note: deploy only WRITES MISSING files; it never updates an \
+                     existing file even if the bundled version has changed. To pick up an \
+                     updated bundled agent, remove it from ~/.trusty-agents/agents/ first, \
+                     then re-run `tagent agents deploy`."
                 );
             }
             Ok(())

--- a/crates/trusty-agents/src/runtime/startup.rs
+++ b/crates/trusty-agents/src/runtime/startup.rs
@@ -59,8 +59,8 @@ use anyhow::Result;
 
 use super::cli_def::check_credentials_and_warn;
 use crate::{
-    api, build_info, bus, ctrl, logging, mcp, memory, process_tracker, registry, repl, search,
-    session_registry, workflow,
+    agents, api, build_info, bus, ctrl, logging, mcp, memory, process_tracker, registry, repl,
+    search, session_registry, workflow,
 };
 
 use build_info::BuildInfo;
@@ -140,6 +140,20 @@ pub(super) async fn run_startup_init(_args: &[String]) -> Result<bool> {
     // Test: `trusty-agents-local` integration; `trusty-agents` standalone has an
     //       empty plugin list.
 
+    // #3405/#3406 follow-up: deploy the bundled agent roster (`assistant`,
+    // `ctrl`, `pm`, the specialist set) to `$HOME/.trusty-agents/agents/` so
+    // `tagent` launched from ANY directory — not just inside this repo
+    // checkout — resolves `assistant` instead of failing with "agent not
+    // found" and silently degrading to `ctrl`. Idempotent (never overwrites
+    // an existing file) and best-effort: a failure (e.g. a read-only
+    // `$HOME`) is logged, not fatal — the pre-fix "not found" error is the
+    // worst case, not a crash. Runs unconditionally (even in quiet modes)
+    // since it has no stdout/stderr output of its own beyond an optional
+    // one-time note gated the same way the credentials banner is.
+    let bundled_agents_deployed = agents::bundled::ensure_bundled_agents_deployed()
+        .inspect_err(|e| tracing::warn!(error = %e, "failed to deploy bundled agents to $HOME"))
+        .unwrap_or(0);
+
     // #366: Credential onboarding banner. After env loading is the right time
     // to check — both `.env.local` files and the host environment have been
     // merged in. Suppress in quiet/non-interactive modes (sub-agent IPC,
@@ -151,6 +165,12 @@ pub(super) async fn run_startup_init(_args: &[String]) -> Result<bool> {
             .iter()
             .any(|a| matches!(a.as_str(), "--agent" | "--serve" | "--api" | "--workflow"));
         if !quiet_mode {
+            if bundled_agents_deployed > 0 {
+                eprintln!(
+                    "[trusty-agents] deployed {bundled_agents_deployed} bundled agent file(s) to \
+                     ~/.trusty-agents/agents/ (first run outside a project checkout)"
+                );
+            }
             check_credentials_and_warn();
         }
     }

--- a/crates/trusty-agents/src/runtime/subcommands.rs
+++ b/crates/trusty-agents/src/runtime/subcommands.rs
@@ -53,7 +53,7 @@
 //! `start`/`stop`/`status`, `session`, `dashboard`, …) and the
 //! flag-aware subcommand locator used by the `om` shell alias.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use super::{postmortem, registry_cmds, service_cmds, session_cmds};
 use crate::{cli, debugger, inspection};
@@ -271,6 +271,101 @@ pub(super) async fn run_config_subcommand(argv_tail: &[String]) -> Result<()> {
     }
 
     ConfigParser::parse_from(argv_tail).cmd.run().await
+}
+
+/// Parse and run `tagent config profile show|set` (#3406 follow-up).
+///
+/// Why: managing `~/.trusty-agents/user.toml` (name/email/timezone) today
+/// means hand-editing TOML or deleting the file to re-trigger the
+/// interactive first-run interview — this gives it a proper CLI, mirroring
+/// `config keys`'s `show`/`set` shape. Kept local to trusty-agents (not
+/// folded into the shared `trusty_common::inference::config::ConfigCommand`)
+/// since `UserProfile` is a trusty-agents-only concept, not something every
+/// trusty-* binary shares.
+/// What: `argv_tail` starts after the literal `profile` token. `show` prints
+/// the current profile (or "not set"); `set --name/--email/--timezone`
+/// loads the existing profile (or starts a fresh default), overwrites only
+/// the flags actually passed, and saves. Unlike credential values, profile
+/// fields are not secrets — printed in full.
+/// Test: `crates/trusty-agents/tests/config_mount.rs::profile_show_then_set_round_trips`.
+pub(super) async fn run_config_profile_subcommand(argv_tail: &[String]) -> Result<()> {
+    use crate::identity::user_profile::UserProfile;
+    use clap::Parser as _;
+
+    /// `tagent config profile <verb>`.
+    #[derive(clap::Parser)]
+    #[command(
+        name = "tagent config profile",
+        about = "Manage the CTRL user profile."
+    )]
+    struct ProfileParser {
+        #[command(subcommand)]
+        verb: ProfileVerb,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum ProfileVerb {
+        /// Print the current profile (or "not set").
+        Show,
+        /// Update one or more profile fields, creating the profile if absent.
+        Set {
+            #[arg(long)]
+            name: Option<String>,
+            #[arg(long)]
+            email: Option<String>,
+            #[arg(long)]
+            timezone: Option<String>,
+        },
+    }
+
+    let parsed = ProfileParser::parse_from(
+        std::iter::once("tagent config profile".to_string()).chain(argv_tail.iter().cloned()),
+    );
+
+    match parsed.verb {
+        ProfileVerb::Show => match UserProfile::load() {
+            Some(p) => {
+                println!("name:     {}", p.name);
+                println!("email:    {}", p.email.as_deref().unwrap_or("(not set)"));
+                println!("timezone: {}", p.timezone.as_deref().unwrap_or("(not set)"));
+                println!("saved at: {}", UserProfile::profile_path().display());
+            }
+            None => println!(
+                "No profile set. Run `tagent` interactively (first-run interview), set \
+                 TAGENT_USER_NAME/_EMAIL/_TIMEZONE in .env.local, or run \
+                 `tagent config profile set --name <name>`."
+            ),
+        },
+        ProfileVerb::Set {
+            name,
+            email,
+            timezone,
+        } => {
+            let mut profile = UserProfile::load().unwrap_or_default();
+            if let Some(name) = name {
+                profile.name = name;
+            }
+            if email.is_some() {
+                profile.email = email;
+            }
+            if timezone.is_some() {
+                profile.timezone = timezone;
+            }
+            if profile.created_at.is_empty() {
+                profile.created_at = chrono::Utc::now().to_rfc3339();
+            }
+            if !profile.is_complete() {
+                anyhow::bail!("refusing to save a profile with no name — pass --name");
+            }
+            profile.save().context("failed to save user profile")?;
+            println!(
+                "Saved profile for {} to {}.",
+                profile.name,
+                UserProfile::profile_path().display()
+            );
+        }
+    }
+    Ok(())
 }
 
 // #409: Find the subcommand position even when preceded by mode flags.

--- a/crates/trusty-agents/tests/config_mount.rs
+++ b/crates/trusty-agents/tests/config_mount.rs
@@ -51,3 +51,63 @@ fn config_keys_list_runs_offline() {
         "`config keys list` should print the status header; got:\n{stdout}"
     );
 }
+
+/// Why (#3406 follow-up): `tagent config profile show|set` manages
+/// `~/.trusty-agents/user.toml` — this drives the REAL binary against an
+/// isolated `HOME` (a fresh tempdir) so it never touches the real developer
+/// machine's profile, and proves `show` reports "not set" before any
+/// profile exists, `set` persists one, and a subsequent `show` reads it
+/// back.
+/// What: spawns three sequential invocations sharing one isolated `HOME`.
+/// Test: itself.
+#[test]
+fn profile_show_then_set_round_trips() {
+    let home = tempfile::tempdir().expect("tempdir for isolated HOME");
+
+    let before = Command::new(BIN)
+        .args(["config", "profile", "show"])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn `config profile show` (before)");
+    assert!(before.status.success());
+    let before_stdout = String::from_utf8_lossy(&before.stdout);
+    assert!(
+        before_stdout.contains("No profile set"),
+        "expected 'not set' before any profile exists; got:\n{before_stdout}"
+    );
+
+    let set = Command::new(BIN)
+        .args([
+            "config",
+            "profile",
+            "set",
+            "--name",
+            "Ada",
+            "--email",
+            "ada@example.com",
+            "--timezone",
+            "UTC",
+        ])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn `config profile set`");
+    assert!(
+        set.status.success(),
+        "`config profile set` should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&set.stderr)
+    );
+
+    let after = Command::new(BIN)
+        .args(["config", "profile", "show"])
+        .env("HOME", home.path())
+        .output()
+        .expect("spawn `config profile show` (after)");
+    assert!(after.status.success());
+    let after_stdout = String::from_utf8_lossy(&after.stdout);
+    assert!(after_stdout.contains("Ada"), "got:\n{after_stdout}");
+    assert!(
+        after_stdout.contains("ada@example.com"),
+        "got:\n{after_stdout}"
+    );
+    assert!(after_stdout.contains("UTC"), "got:\n{after_stdout}");
+}

--- a/crates/trusty-agents/tests/plain_cli_repl.rs
+++ b/crates/trusty-agents/tests/plain_cli_repl.rs
@@ -66,6 +66,19 @@ fn run_piped(
 /// isolated cwd and before spawning — lets a test seed fixture files (e.g. a
 /// minimal `assistant.toml`) into the isolated project without touching the
 /// real crate-root `.trusty-agents/`.
+///
+/// Also pins `$HOME` to a fresh, isolated tempdir by default (issue #3406
+/// follow-up). Why: since `runtime::startup::run_startup_init` now
+/// unconditionally deploys the bundled agent roster to
+/// `$HOME/.trusty-agents/agents/` (`agents::bundled::
+/// ensure_bundled_agents_deployed`), every test in this file that spawned the
+/// real binary WITHOUT overriding `HOME` was writing ~30 real files into the
+/// developer machine's actual `$HOME/.trusty-agents/agents/` on every
+/// `cargo test` run — the exact kind of test-time side effect on the host
+/// this harness must never cause. A caller that needs to observe/assert
+/// against `HOME` (e.g. the bundled-deploy and profile-env tests below)
+/// still can: an explicit `("HOME", ...)` in `extra_env` is applied AFTER
+/// this default and wins.
 fn run_piped_with_setup(
     extra_args: &[&str],
     extra_env: &[(&str, &str)],
@@ -74,6 +87,10 @@ fn run_piped_with_setup(
 ) -> (bool, String, String) {
     let isolated_cwd = tempfile::tempdir().expect("create isolated tempdir for tagent cwd");
     setup(isolated_cwd.path());
+    // Kept alive for the whole function body (dropped only after the child
+    // has exited and output is captured) so `$HOME` stays valid throughout.
+    let default_isolated_home =
+        tempfile::tempdir().expect("create isolated tempdir for tagent $HOME");
 
     let mut cmd = Command::new(BIN);
     cmd.args(extra_args)
@@ -81,6 +98,7 @@ fn run_piped_with_setup(
         // Deterministic: skip the interactive first-run profile interview,
         // which would otherwise consume lines meant for the REPL loop.
         .env("TAGENT_NONINTERACTIVE", "1")
+        .env("HOME", default_isolated_home.path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -220,6 +238,166 @@ fn plain_cli_defaults_active_agent_to_assistant_not_ctrl() {
     assert!(
         !stdout.contains("agent=ctrl"),
         "default agent must not be ctrl; got:\n{stdout}"
+    );
+}
+
+/// Same as [`run_piped_with_setup`] but does NOT force
+/// `TAGENT_NONINTERACTIVE=1` — used only by the profile-resolution test
+/// below, which must exercise the REAL `load_or_create_user_profile`
+/// precedence (saved `user.toml` -> env -> interactive interview) rather
+/// than short-circuiting straight to the noninteractive placeholder.
+///
+/// Also defaults `$HOME` to a fresh isolated tempdir (same rationale as
+/// [`run_piped_with_setup`] — never let a spawned-binary test touch the real
+/// developer machine's `$HOME`); an explicit `("HOME", ...)` in `extra_env`
+/// is applied after and wins.
+fn run_piped_no_forced_noninteractive(
+    extra_args: &[&str],
+    extra_env: &[(&str, &str)],
+    stdin_input: &str,
+) -> (bool, String, String) {
+    let isolated_cwd = tempfile::tempdir().expect("create isolated tempdir for tagent cwd");
+    let default_isolated_home =
+        tempfile::tempdir().expect("create isolated tempdir for tagent $HOME");
+
+    let mut cmd = Command::new(BIN);
+    cmd.args(extra_args)
+        .current_dir(isolated_cwd.path())
+        .env("HOME", default_isolated_home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+
+    let mut child = cmd.spawn().expect("spawn tagent");
+    {
+        let mut stdin = child.stdin.take().expect("child stdin was piped");
+        stdin
+            .write_all(stdin_input.as_bytes())
+            .expect("write stdin");
+    }
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let out = child.wait_with_output();
+        let _ = tx.send(out);
+    });
+    let out = rx
+        .recv_timeout(WAIT_TIMEOUT)
+        .unwrap_or_else(|_| {
+            panic!("tagent did not exit within {WAIT_TIMEOUT:?} (hang regression?)")
+        })
+        .expect("wait_with_output failed");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+/// Why (#3406 follow-up — owner directive: "I don't want to have to set the
+/// credential. You have them, use them.", extended to the user profile): a
+/// user with `TAGENT_USER_NAME`/`_EMAIL`/`_TIMEZONE` resolvable from the
+/// environment (a `.env.local`, in production — here injected directly as
+/// process env, which is the tier `UserProfile::from_env` actually reads)
+/// must NEVER see the blocking interactive first-run interview, even though
+/// `TAGENT_NONINTERACTIVE` is deliberately NOT set here (proving the skip is
+/// real, not just falling through to the noninteractive placeholder). Uses
+/// an isolated `$HOME` with no pre-existing `user.toml` so the env tier is
+/// actually exercised, not short-circuited by the "already saved" tier.
+/// What: asserts stderr shows the env-resolution note (not the interactive
+/// "First-run setup" prompt text) and that the resolved profile was
+/// persisted to the isolated `$HOME/.trusty-agents/user.toml` with the
+/// expected fields.
+/// Test: itself.
+#[test]
+fn profile_resolves_from_env_without_interactive_prompt() {
+    let isolated_home = tempfile::tempdir().expect("isolated HOME for profile-env test");
+    let home_str = isolated_home
+        .path()
+        .to_str()
+        .expect("tempdir path is valid UTF-8")
+        .to_string();
+
+    let (success, _stdout, stderr) = run_piped_no_forced_noninteractive(
+        &["--plain"],
+        &[
+            ("HOME", home_str.as_str()),
+            ("TAGENT_USER_NAME", "Ada"),
+            ("TAGENT_USER_EMAIL", "ada@example.com"),
+            ("TAGENT_USER_TIMEZONE", "UTC"),
+        ],
+        "/quit\n",
+    );
+    assert!(success, "should exit 0 on /quit; stderr:\n{stderr}");
+    assert!(
+        stderr.contains("resolved profile for Ada from the environment"),
+        "expected the env-resolution note in stderr; got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("First-run setup"),
+        "the interactive interview must NOT run when the env resolves a profile; got:\n{stderr}"
+    );
+
+    let saved = isolated_home
+        .path()
+        .join(".trusty-agents")
+        .join("user.toml");
+    let contents = std::fs::read_to_string(&saved)
+        .unwrap_or_else(|e| panic!("expected profile saved to {}: {e}", saved.display()));
+    assert!(contents.contains("Ada"), "got:\n{contents}");
+    assert!(contents.contains("ada@example.com"), "got:\n{contents}");
+    assert!(contents.contains("UTC"), "got:\n{contents}");
+}
+
+/// Why (#3405/#3406 — GAP1 live regression): the owner's clean-shell repro
+/// was `tagent --plain` run from `~` with NO project-tier
+/// `.trusty-agents/agents/` at all — `agent 'assistant' not found: failed to
+/// read agent config ~/.trusty-agents/agents/assistant.toml`, silently
+/// falling back to `ctrl`. This drives the REAL compiled binary with BOTH
+/// the isolated CWD (no project tier — already the harness default) AND an
+/// isolated `$HOME` that starts completely empty (no
+/// `~/.trusty-agents/agents/` either), proving `runtime::startup::
+/// run_startup_init`'s bundled-agent deploy
+/// (`agents::bundled::ensure_bundled_agents_deployed`) populates the `$HOME`
+/// fallback tier and the plain CLI's default `/switch assistant` resolves
+/// the REAL bundled assistant persona — not a test fixture — without ever
+/// touching the developer machine's actual `$HOME`.
+/// What: asserts the startup banner shows `Switched to: assistant` (not a
+/// degrade to ctrl) and that the bundled `assistant/agent.toml` actually
+/// landed on disk under the isolated `$HOME`.
+/// Test: itself.
+#[test]
+fn plain_cli_resolves_assistant_via_bundled_deploy_when_no_project_tier() {
+    let isolated_home = tempfile::tempdir().expect("isolated HOME for bundled-deploy test");
+    let home_str = isolated_home
+        .path()
+        .to_str()
+        .expect("tempdir path is valid UTF-8")
+        .to_string();
+
+    let (success, stdout, stderr) =
+        run_piped(&["--plain"], &[("HOME", home_str.as_str())], "/quit\n");
+    assert!(success, "should exit 0 on /quit; stderr:\n{stderr}");
+    assert!(
+        stdout.contains("Switched to: assistant"),
+        "expected the plain CLI to default-switch to the bundled assistant persona \
+         deployed to $HOME/.trusty-agents/agents/; got stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("agent=ctrl"),
+        "must not silently degrade to ctrl when no project-tier agents exist; got:\n{stdout}"
+    );
+    assert!(
+        isolated_home
+            .path()
+            .join(".trusty-agents")
+            .join("agents")
+            .join("assistant")
+            .join("agent.toml")
+            .is_file(),
+        "bundled assistant/agent.toml should have been deployed to the isolated $HOME"
     );
 }
 

--- a/crates/trusty-agents/tests/support/api_server.rs
+++ b/crates/trusty-agents/tests/support/api_server.rs
@@ -29,6 +29,19 @@ pub struct ApiServer {
     /// Tempdir containing the bundled `.trusty-agents/` config. Held so it lives
     /// as long as the server child does.
     _root: TempDir,
+    /// Isolated `$HOME` for the child process. Held so it lives as long as
+    /// the server does.
+    ///
+    /// Why (issue #3429 code-critic HIGH follow-up): `runtime::startup::
+    /// run_startup_init` now unconditionally deploys the bundled agent
+    /// roster to `$HOME/.trusty-agents/agents/` before the `--api` mode
+    /// check even runs. Without this override the spawned child inherited
+    /// whatever `$HOME` the `cargo test` process itself ran under — on a
+    /// real dev machine, that's the developer's actual home directory —
+    /// so every `cargo test -p trusty-agents --test api_e2e` run was
+    /// writing ~30 real files into it. Never referenced after construction;
+    /// kept alive purely so the tempdir isn't cleaned up mid-run.
+    _home: TempDir,
     port: u16,
     child: Option<Child>,
     base_url: String,
@@ -49,12 +62,16 @@ impl ApiServer {
         let src_cfg = manifest.join(".trusty-agents");
         let dst_cfg = root.path().join(".trusty-agents");
         copy_dir_recursive(&src_cfg, &dst_cfg).context("copy .trusty-agents")?;
+        // Isolated `$HOME` — see the `_home` field doc for why this is
+        // required, not optional.
+        let home = tempfile::tempdir().context("create isolated HOME tempdir")?;
 
         let port = pick_free_port().context("pick free port")?;
         let binary = PathBuf::from(env!("CARGO_BIN_EXE_tagent"));
 
         let child = Command::new(&binary)
             .current_dir(root.path())
+            .env("HOME", home.path())
             .arg("--api")
             .arg("--port")
             .arg(port.to_string())
@@ -68,6 +85,7 @@ impl ApiServer {
         let base_url = format!("http://127.0.0.1:{port}");
         let server = Self {
             _root: root,
+            _home: home,
             port,
             child: Some(child),
             base_url,

--- a/crates/trusty-agents/tests/support/project.rs
+++ b/crates/trusty-agents/tests/support/project.rs
@@ -27,6 +27,19 @@ use tokio::process::Command;
 pub struct Project {
     pub root: TempDir,
     pub binary: PathBuf,
+    /// Isolated `$HOME` every spawned child is pinned to.
+    ///
+    /// Why (issue #3429 code-critic HIGH follow-up): `runtime::startup::
+    /// run_startup_init` now unconditionally deploys the bundled agent
+    /// roster to `$HOME/.trusty-agents/agents/` before either `--workflow`
+    /// or `inspect` mode even runs. Without pinning `$HOME` here, every
+    /// `run_task`/`run_inspect` call inherited the real `cargo test`
+    /// process's `$HOME` — on a developer machine, that's the actual home
+    /// directory — so every `cargo test -p trusty-agents --test
+    /// cli_project` run was writing ~30 real files into it. Never read
+    /// directly outside this module; kept alive so the tempdir isn't
+    /// cleaned up mid-run.
+    home: TempDir,
 }
 
 /// Parsed result of running the binary in workflow mode.
@@ -58,7 +71,8 @@ impl Project {
         let dst_cfg = root.path().join(".trusty-agents");
         copy_dir_recursive(&src_cfg, &dst_cfg).expect("copy .trusty-agents");
         let binary = PathBuf::from(env!("CARGO_BIN_EXE_tagent"));
-        Self { root, binary }
+        let home = tempfile::tempdir().expect("create isolated HOME tempdir");
+        Self { root, binary, home }
     }
 
     /// Run the binary in workflow mode against this tempdir.
@@ -78,6 +92,7 @@ impl Project {
         std::fs::create_dir_all(&out_dir).ok();
         let mut child = Command::new(&self.binary)
             .current_dir(self.root.path())
+            .env("HOME", self.home.path())
             .arg("--workflow")
             .arg(workflow)
             .arg("--task")
@@ -124,6 +139,7 @@ impl Project {
     pub async fn run_inspect(&self, task: &str) -> Result<Value> {
         let output = Command::new(&self.binary)
             .current_dir(self.root.path())
+            .env("HOME", self.home.path())
             .arg("inspect")
             .arg("--task")
             .arg(task)

--- a/crates/trusty-common/src/inference/credentials/dotenv.rs
+++ b/crates/trusty-common/src/inference/credentials/dotenv.rs
@@ -26,6 +26,21 @@
 //! [`find_workspace_env_local`] and [`load_env_from_path`] are the hermetic
 //! cores used by the resolver's precedence tests, which must not depend on
 //! `OnceLock`'s once-only semantics or the real repo's `.env.local`.
+//!
+//! Issue #3406 follow-up (trusty-agents "unusable outside a project
+//! directory"): [`load_env_local_once`] previously only ever searched
+//! upward from the cwd for a PROJECT-scoped `.env.local`. A binary launched
+//! from `$HOME` (or any directory with no project/workspace ancestor at
+//! all — the common case for a globally `cargo install`ed tool) found
+//! nothing, even when the user had deliberately set up a personal,
+//! machine-wide credential file. [`load_env_local_once`] now ALSO loads
+//! `$HOME/.env.local` as a fourth tier, loaded strictly AFTER the project
+//! tier — since `dotenvy::from_path` never overrides an already-set var,
+//! this gives the full precedence: process env > project `.env.local` >
+//! user `$HOME/.env.local` > secure store (the store tier is the
+//! resolver's, not this module's). [`user_env_local_path`] is the hermetic
+//! core (HOME is injected, not read from the real environment) so the
+//! precedence is unit-testable without `OnceLock`'s once-only semantics.
 //! Test: `dotenv_tests` (sibling file).
 
 use std::path::{Path, PathBuf};
@@ -222,17 +237,45 @@ pub fn load_env_from_path(path: &Path) -> bool {
     dotenvy::from_path(path).is_ok()
 }
 
+/// `$HOME/.env.local` path, when it exists — the hermetic core for the
+/// user-global tier.
+///
+/// Why: separated from [`load_env_local_once`] so the tier is unit-testable
+/// with an injected `home` directory, without depending on `OnceLock`'s
+/// once-only semantics or the real `$HOME`.
+/// What: `Some(home.join(".env.local"))` when that path is a file, else
+/// `None`. Pure — never touches the process environment.
+/// Test: `dotenv_tests::user_env_local_path_finds_file`,
+/// `dotenv_tests::user_env_local_path_absent_is_none`.
+pub fn user_env_local_path(home: &Path) -> Option<PathBuf> {
+    let candidate = home.join(".env.local");
+    candidate.is_file().then_some(candidate)
+}
+
 /// Idempotent, cwd-upward-search `.env.local` loader for production use.
 ///
 /// Why: the resolver calls this once before checking `std::env::var` so a
 /// developer's `.env.local` (at the repo root, or any ancestor of cwd) is
 /// picked up regardless of which subdirectory a binary was launched from —
 /// the same problem `trusty-agents` fixed ad hoc for itself in #250.
+///
+/// Issue #3406 follow-up: a binary launched from OUTSIDE any project/
+/// workspace tree at all (e.g. `tagent` run from `$HOME` — no ancestor ever
+/// has a `.git`/workspace `Cargo.toml` boundary to search within) previously
+/// had NO `.env.local` tier whatsoever. This now ALSO loads
+/// `$HOME/.env.local` as a fourth precedence tier, loaded strictly AFTER the
+/// project tier so the documented precedence holds: process env > project
+/// `.env.local` (searched upward from cwd) > user `$HOME/.env.local` >
+/// secure store (the resolver's tier, not this module's) — `dotenvy` never
+/// overrides an already-set var, so loading the user tier second is what
+/// gives the project tier priority for free, exactly like the project-tier
+/// vs. process-env precedence already worked.
 /// What: on first call, searches upward from the current working directory
 /// via [`find_workspace_env_local`] and loads the first hit (if any) via
-/// `dotenvy::from_path`. Subsequent calls are a no-op `OnceLock` check.
-/// Errors (missing file, malformed file) are swallowed — a missing
-/// `.env.local` is the common case (production/CI), not a failure.
+/// `dotenvy::from_path`, then does the same for [`user_env_local_path`].
+/// Subsequent calls are a no-op `OnceLock` check. Errors (missing file,
+/// malformed file) are swallowed — a missing `.env.local` is the common case
+/// (production/CI), not a failure.
 /// Test: exercised indirectly via `resolver::resolve_key`'s production path;
 /// the once-only + cwd-search behaviour itself is not independently unit
 /// tested because `OnceLock` fires exactly once per test binary — see
@@ -242,6 +285,11 @@ pub fn load_env_local_once() {
     LOADED.get_or_init(|| {
         if let Ok(cwd) = std::env::current_dir()
             && let Some(path) = find_workspace_env_local(&cwd)
+        {
+            let _ = dotenvy::from_path(&path);
+        }
+        if let Some(home) = dirs::home_dir()
+            && let Some(path) = user_env_local_path(&home)
         {
             let _ = dotenvy::from_path(&path);
         }
@@ -782,6 +830,102 @@ mod tests {
         assert_eq!(std::env::var(var).unwrap(), "already-set");
         unsafe {
             std::env::remove_var(var);
+        }
+    }
+
+    /// Why: the user-global tier's hermetic core must find `$HOME/.env.local`
+    /// when it exists — the building block [`load_env_local_once`]'s new
+    /// fourth tier depends on (issue #3406 follow-up).
+    /// Test: itself.
+    #[test]
+    fn user_env_local_path_finds_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join(".env.local"), "X=1\n").unwrap();
+        assert_eq!(
+            user_env_local_path(tmp.path()),
+            Some(tmp.path().join(".env.local"))
+        );
+    }
+
+    /// Why: an absent `$HOME/.env.local` must resolve to `None`, not a
+    /// phantom path — `load_env_local_once` skips the `dotenvy::from_path`
+    /// call entirely in that case.
+    /// Test: itself.
+    #[test]
+    fn user_env_local_path_absent_is_none() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert_eq!(user_env_local_path(tmp.path()), None);
+    }
+
+    /// Why: issue #3406 follow-up's whole point — a project `.env.local`
+    /// must still win over a user `$HOME/.env.local` when both bind the same
+    /// variable, matching the documented precedence (process env > project
+    /// `.env.local` > user `$HOME/.env.local` > secure store). Drives the
+    /// exact two `dotenvy::from_path` calls `load_env_local_once` makes, in
+    /// the same order (project tier first), against the hermetic
+    /// `load_env_from_path` core rather than the `OnceLock`-guarded
+    /// production function — the same pattern
+    /// `dotenv_loaded_value_beats_store` uses for the store-precedence leg.
+    /// What: writes `OPENROUTER_API_KEY=from-project` to a project
+    /// `.env.local` and `OPENROUTER_API_KEY=from-user` to a separate "user"
+    /// `.env.local`, loads the project one first (as `load_env_local_once`
+    /// does), then the user one, and asserts the process env still reads
+    /// `from-project` — `dotenvy` never overrides an already-set var, so
+    /// load ORDER is what implements the precedence.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn project_env_local_beats_user_env_local() {
+        // SAFETY: see `load_env_from_path_sets_new_var`.
+        unsafe {
+            std::env::remove_var("OPENROUTER_API_KEY");
+        }
+        let project_tmp = tempfile::TempDir::new().unwrap();
+        let project_env = project_tmp.path().join(".env.local");
+        std::fs::write(&project_env, "OPENROUTER_API_KEY=from-project\n").unwrap();
+
+        let user_tmp = tempfile::TempDir::new().unwrap();
+        let user_env = user_env_local_path(user_tmp.path());
+        // Not yet written — `user_env_local_path` should report absent.
+        assert_eq!(user_env, None);
+        let user_env_path = user_tmp.path().join(".env.local");
+        std::fs::write(&user_env_path, "OPENROUTER_API_KEY=from-user\n").unwrap();
+        assert_eq!(
+            user_env_local_path(user_tmp.path()),
+            Some(user_env_path.clone())
+        );
+
+        // Load order mirrors `load_env_local_once`: project tier first.
+        assert!(load_env_from_path(&project_env));
+        assert!(load_env_from_path(&user_env_path));
+
+        assert_eq!(std::env::var("OPENROUTER_API_KEY").unwrap(), "from-project");
+        unsafe {
+            std::env::remove_var("OPENROUTER_API_KEY");
+        }
+    }
+
+    /// Why: when NO project `.env.local` is in scope at all (the exact
+    /// clean-shell scenario — `tagent` launched from `$HOME`, no ancestor
+    /// `.git`/workspace boundary), the user tier must still supply the
+    /// value — this is the actual bug fix, not just the precedence-ordering
+    /// leg above.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn user_env_local_supplies_value_when_no_project_tier() {
+        // SAFETY: see `load_env_from_path_sets_new_var`.
+        unsafe {
+            std::env::remove_var("OPENROUTER_API_KEY");
+        }
+        let user_tmp = tempfile::TempDir::new().unwrap();
+        let user_env_path = user_tmp.path().join(".env.local");
+        std::fs::write(&user_env_path, "OPENROUTER_API_KEY=from-user\n").unwrap();
+
+        assert!(load_env_from_path(&user_env_path));
+        assert_eq!(std::env::var("OPENROUTER_API_KEY").unwrap(), "from-user");
+        unsafe {
+            std::env::remove_var("OPENROUTER_API_KEY");
         }
     }
 }

--- a/crates/trusty-common/src/inference/credentials/mod.rs
+++ b/crates/trusty-common/src/inference/credentials/mod.rs
@@ -32,7 +32,7 @@ mod resolver;
 
 pub use dotenv::{
     env_local_value, find_workspace_env_local, load_env_from_path, load_env_local_once,
-    read_var_from_env_local,
+    read_var_from_env_local, user_env_local_path,
 };
 pub use file_store::FileKeyStore;
 #[cfg(feature = "keyring-store")]


### PR DESCRIPTION
## Summary

Fixes two compounding first-run/global-install gaps that make `tagent`
unusable from outside a project checkout (e.g. `~`), confirmed live by the
owner running `tagent --plain`. Closes #3429. Part of epic #3052; surfaced
via the plain CLI (#3405/#3406).

**GAP 1 — bundled agents not resolvable at the user tier.** Nothing
deployed the bundled roster (`assistant`, `ctrl`, `pm`, the specialist set)
to `~/.trusty-agents/agents/`, so `/switch assistant` failed with
`agent 'assistant' not found` and silently fell back to `ctrl`.
- Embeds the crate's own `.trusty-agents/agents/` tree into the binary via
  `rust-embed` (already used for the web UI bundle) — see
  `crates/trusty-agents/src/agents/bundled.rs`.
- `runtime::startup::run_startup_init` deploys it to
  `$HOME/.trusty-agents/agents/` on every run — idempotent, never
  overwrites an existing file/user customization.
- No resolver code needed to change: `AgentConfig::by_name`/`by_name_in` and
  the REPL's own `[agents_dir, $HOME]` list already search that tier.
- Adds an explicit `tagent agents deploy` repair command.

**GAP 2 — credential discovery + the "no API key" banner lied.** Live
evidence during review: a key configured via `tagent config keys set
openrouter` (secure store) resolved fine for real dispatch, but the
pre-flight banner (`check_credentials_and_warn`) still claimed no key
existed — it used a raw `std::env::var` check instead of the real resolver.
- Fixed `check_credentials_and_warn` to consult
  `trusty_common::inference::credentials::resolve_key` (the same resolver
  `pick_credentials` uses) — a working store- or `.env.local`-only
  credential now correctly suppresses the banner.
- Added `$HOME/.env.local` as a fourth credential tier: **process env >
  project `.env.local` > user `~/.env.local` > secure store**. `dotenvy`
  never overrides an already-set var, so load order alone implements the
  precedence (`crates/trusty-common/src/inference/credentials/dotenv.rs`).
- When the banner legitimately fires (nothing resolves anywhere), it now
  lists every location actually checked and leads with
  `tagent config keys set <provider>` as the durable, works-from-anywhere
  option.
- Sanity diagnostic: if the store has a key for a provider ctrl/PM's own
  LLM calls can't route through (e.g. only `fireworks`), the endpoint
  banner now names it instead of a bare `credential=none`
  (`llm::credentials::other_configured_providers`).

**Extended scope (owner directive mid-review — "you have them, use
them"):** the same zero-config philosophy now applies to the user profile.
`.env.local` (project or `~/.env.local`) can supply `TAGENT_USER_NAME` /
`TAGENT_USER_EMAIL` / `TAGENT_USER_TIMEZONE` (with a bare `TZ` fallback for
timezone); when resolvable, the blocking first-run interactive interview is
skipped entirely and the resolved profile is persisted to
`~/.trusty-agents/user.toml`. Precedence: saved `user.toml` (already
complete) > environment > interactive interview (last resort). Added
`tagent config profile show|set` since there was previously no CLI to
inspect/change the profile.

## Live verification (clean, isolated `$HOME` — never the real machine)

No credentials configured anywhere — legitimate banner fires, agent still resolves:
```
$ env -i HOME=$ISOLATED_HOME PATH=$PATH TAGENT_NONINTERACTIVE=1 tagent --plain
[trusty-agents] Switched to: assistant
resolved agent endpoint: agent=assistant model=claude-opus-4-6 runner=Subprocess credential=none

(stderr)
[trusty-agents] deployed 29 bundled agent file(s) to ~/.trusty-agents/agents/ (first run outside a project checkout)
┌─────────────────────────────────────────────────────────────────┐
│  ⚡  No API key found — trusty-agents needs a key to talk to an LLM  │
├─────────────────────────────────────────────────────────────────┤
│  Checked (none resolved):                                       │
│    env: OPENROUTER_API_KEY / ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN
│    project .env.local: none found above this directory          │
│    user ~/.env.local: not present                                │
│    secure store (`tagent config keys list`): empty              │
│  Durable option — works from ANY directory:                     │
│    tagent config keys set openrouter                            │
└─────────────────────────────────────────────────────────────────┘
```

Key stored via `tagent config keys set openrouter` (isolated `$HOME`), then `env -u OPENROUTER_API_KEY` equivalent (`env -i`, no credential env vars at all):
```
$ tagent config keys list
  openrouter   configured via secure store

$ env -i HOME=$ISOLATED_HOME PATH=$PATH TAGENT_NONINTERACTIVE=1 tagent --plain
[trusty-agents] Switched to: assistant
resolved agent endpoint: agent=assistant model=claude-opus-4-6 runner=Subprocess credential=openrouter
(no "No API key found" banner)
```

`~/.env.local` tier (no project `.env.local`, no env var):
```
$ echo 'OPENROUTER_API_KEY=sk-or-v1-fake' > $ISOLATED_HOME/.env.local
$ env -i HOME=$ISOLATED_HOME PATH=$PATH TAGENT_NONINTERACTIVE=1 tagent --plain
resolved agent endpoint: agent=assistant model=claude-opus-4-6 runner=Subprocess credential=openrouter
(no banner)
```

Profile resolved from env, interactive interview skipped (integration test `profile_resolves_from_env_without_interactive_prompt`):
```
TAGENT_USER_NAME=Ada TAGENT_USER_EMAIL=ada@example.com TAGENT_USER_TIMEZONE=UTC tagent --plain
(stderr) [trusty-agents] resolved profile for Ada from the environment (.env.local); saved to ~/.trusty-agents/user.toml
(no "First-run setup" prompt)
```

## Gate (raw output)

`cargo check -p trusty-agents` — clean.
`cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean, 0 warnings.
`cargo fmt -p trusty-agents --check` — clean.
`bash scripts/check_line_cap.sh` — `line-cap: 7 allowlisted, 0 violations — OK.`

`cargo test -p trusty-agents` — 1978-1979 passed, 0-2 failed depending on run (see note below), 8 ignored.

**Pre-existing flaky tests (not caused by this PR):** under full concurrent
`cargo test`, 1-2 tests intermittently fail — a different subset each run
(`workflow::engine::executor::tests::checkpoint_resume::
resume_replays_summary_not_full_content_into_downstream_prompts` on one
run; `tools::mcp_tools::tests::dispatch_mcp_add_persists_service` +
`skills::registry::tests_persistence::
load_with_index_merges_persisted_effectiveness` on another). None of these
files were touched by this PR (workflow/, tools/mcp_tools, skills/registry
are untouched). All three pass individually / in isolation
(`--test-threads=1`), confirming pre-existing parallel-execution
resource-contention flakiness in this ~1980-test suite, not a regression.

New/changed tests specific to this PR, all passing:
- `agents::bundled::tests::*` (5) — deploy idempotency, never-overwrite, directory-package format, `by_name_in` round-trip.
- `identity::user_profile::tests::from_env_*` (5) — env profile resolution, TZ fallback, precedence.
- `llm::credentials::tests::other_configured_providers_*` (2) — the "configured but wrong provider" diagnostic.
- `trusty-common`'s `dotenv::tests::*_env_local*` (4 new) — `$HOME/.env.local` tier + precedence, run via `cargo test -p trusty-common --features credentials -- inference::credentials::` (46 passed, 0 failed).
- `tests/plain_cli_repl.rs`: `plain_cli_resolves_assistant_via_bundled_deploy_when_no_project_tier`, `profile_resolves_from_env_without_interactive_prompt` (both spawn the real binary against a fully isolated `$HOME`).
- `tests/config_mount.rs`: `profile_show_then_set_round_trips`.

**Test-hygiene fix along the way:** discovered that spawning the real
binary in `tests/plain_cli_repl.rs` without isolating `$HOME` was writing
the newly-deployed bundled-agent files into the *real* developer machine's
`$HOME` on every `cargo test` run. Fixed by defaulting `$HOME` to a fresh
isolated tempdir in the shared test helpers (`run_piped_with_setup`,
`run_piped_no_forced_noninteractive`) — an explicit `HOME` in a test's
`extra_env` still overrides it.

## Test plan
- [x] `cargo check -p trusty-agents`
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings`
- [x] `cargo fmt -p trusty-agents --check`
- [x] `cargo test -p trusty-agents` (all new/changed tests pass; pre-existing flakes documented above)
- [x] `cargo test -p trusty-common --features credentials -- inference::credentials::`
- [x] `bash scripts/check_line_cap.sh`
- [x] Live verify from an isolated clean shell (no false banner, `assistant` resolves, secure-store + `~/.env.local` credential tiers both work)
- [x] Real developer machine `$HOME` confirmed untouched after every verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)