### PR TITLE
fix(trusty-mpm): hermetic temp roots for remaining git-scaffolding tests (closes #3390)

### DIFF
--- a/crates/trusty-mpm/src/content/catalog_sync.rs
+++ b/crates/trusty-mpm/src/content/catalog_sync.rs
@@ -597,7 +597,7 @@ mod tests {
 
     #[test]
     fn catalog_sync_fetches_on_first_call() {
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
 
         let result = sync.sync(false).unwrap();
@@ -610,7 +610,7 @@ mod tests {
         // repo/.claude/agents must report `agents_empty()` so the CLI/daemon can
         // warn honestly instead of presenting "0 agents" as a silent success. The
         // FakeGitBackend clone does not populate an agents dir, so the count is 0.
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
 
         let result = sync.sync(false).unwrap();
@@ -626,7 +626,7 @@ mod tests {
     fn catalog_sync_not_empty_when_agents_present() {
         // The inverse: once composable agents exist at repo/.claude/agents, the
         // result must NOT be flagged empty.
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
         sync.sync(false).unwrap();
 
@@ -641,7 +641,7 @@ mod tests {
 
     #[test]
     fn catalog_sync_skips_on_ttl_valid() {
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
 
         // First sync writes the sentinel.
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn catalog_sync_force_bypasses_ttl() {
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
 
         // Establish a fresh sentinel.
@@ -668,7 +668,7 @@ mod tests {
 
     #[test]
     fn catalog_ls_lists_agents() {
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
         sync.sync(false).unwrap();
 
@@ -689,7 +689,7 @@ mod tests {
 
     #[test]
     fn catalog_ls_lists_skills() {
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
         sync.sync(false).unwrap();
 
@@ -720,7 +720,7 @@ mod tests {
         // HR-2: a `[manifest]` config value must win over the env var and the
         // compiled-in default. Config has highest precedence, so this holds
         // regardless of whether the env vars happen to be set in the test host.
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let cfg = crate::core::config::ManifestConfig {
             repo: Some("https://github.com/me/fork".to_owned()),
             git_ref: Some("dev".to_owned()),
@@ -738,7 +738,7 @@ mod tests {
         // HR-2: the catalog-layer manifest path must be
         // <catalog>/repo/.claude/manifest.toml so it lines up with the synced
         // claude-mpm repo layout the resolver reads.
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
         assert_eq!(
             sync.manifest_path(),
@@ -753,7 +753,7 @@ mod tests {
     fn catalog_root_returns_catalog_dir() {
         // The catalog root accessor must return the constructed catalog_dir so a
         // caller can thread the configured root into manifest resolution.
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
         assert_eq!(sync.catalog_root(), root.path());
     }
@@ -773,7 +773,7 @@ mod tests {
     fn for_framework_uses_catalog_root() {
         // `for_framework` must root the sync at <framework>/catalog (the same root
         // `catalog_root_for` yields) so the CLI and launcher share one checkout.
-        let fw_root = TempDir::new().unwrap();
+        let fw_root = crate::test_support::hermetic_temp_dir();
         let sync = CatalogSync::for_framework(FakeGitBackend::new(), fw_root.path(), None);
         assert_eq!(sync.catalog_root(), fw_root.path().join("catalog"));
     }
@@ -781,7 +781,7 @@ mod tests {
     #[test]
     fn catalog_ls_falls_back_to_legacy_agent_path() {
         // When .claude/agents doesn't exist, should fall back to repo/agents/.
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let sync = make_sync(&root);
         sync.sync(false).unwrap();
 
@@ -801,7 +801,7 @@ mod tests {
     fn guard_remove_rejects_path_outside_catalog() {
         // Verify canonicalized guard rejects paths outside the catalog boundary
         // and also refuses to remove the catalog root itself.
-        let root = TempDir::new().unwrap();
+        let root = crate::test_support::hermetic_temp_dir();
         let catalog_dir = root.path().join("catalog");
         std::fs::create_dir_all(&catalog_dir).unwrap();
         let outside = root.path().join("not-catalog");

--- a/crates/trusty-mpm/src/core/session_launch/worktree_sync.rs
+++ b/crates/trusty-mpm/src/core/session_launch/worktree_sync.rs
@@ -346,8 +346,18 @@ mod tests {
             .output();
     }
 
+    /// Not purely mechanical (#3390): the four `TempDir::new().ok()?` sites
+    /// below became `crate::test_support::hermetic_temp_dir()` calls with the
+    /// trailing `?` dropped — `hermetic_temp_dir()` returns `TempDir`
+    /// directly (it panics via `.expect(...)` internally on temp-dir-creation
+    /// failure) rather than `Option<TempDir>`. Practically equivalent: OS
+    /// temp-directory creation failing at all is exceedingly rare (disk full
+    /// / permission denied), and unlike the git-unavailable checks below
+    /// (which legitimately `return None` to skip cleanly), an actual failure
+    /// to create a scratch directory is a real test-environment problem worth
+    /// a hard failure rather than a silent skip.
     fn build_fixture() -> Option<Fixture> {
-        let origin_dir = TempDir::new().ok()?;
+        let origin_dir = crate::test_support::hermetic_temp_dir();
         let origin = origin_dir.path().to_path_buf();
         if !git_ok(&origin, &["init", "--bare"]) {
             eprintln!("worktree_sync tests: git unavailable, skipping");
@@ -358,7 +368,7 @@ mod tests {
         // pushes it to `main` on the bare origin, then anchors the bare
         // repo's HEAD symref at `main` so a later `git clone` resolves a
         // real default branch instead of an empty/detached one.
-        let seed_dir = TempDir::new().ok()?;
+        let seed_dir = crate::test_support::hermetic_temp_dir();
         let seed = seed_dir.path().to_path_buf();
         if !git_ok(&seed, &["init"]) {
             return None;
@@ -389,7 +399,7 @@ mod tests {
         }
 
         // Base clone: stands in for the shared `.base` checkout.
-        let base_dir = TempDir::new().ok()?;
+        let base_dir = crate::test_support::hermetic_temp_dir();
         let base = base_dir.path().to_path_buf();
         // `TempDir::new` already created the directory; `git clone` refuses
         // to clone into a non-empty existing dir in some git versions, so
@@ -407,7 +417,7 @@ mod tests {
         // `configure_session_branch_tracking` (issue #2189): a new branch
         // checked out from `base`'s HEAD, with its upstream explicitly
         // pointed at `origin/main`.
-        let worktree_dir = TempDir::new().ok()?;
+        let worktree_dir = crate::test_support::hermetic_temp_dir();
         let worktree = worktree_dir.path().to_path_buf();
         let _ = std::fs::remove_dir(&worktree);
         if !git_ok(
@@ -500,7 +510,7 @@ mod tests {
 
     #[test]
     fn sync_skips_when_no_upstream_configured() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = crate::test_support::hermetic_temp_dir();
         let dir = tmp.path();
         if !git_ok(dir, &["init"]) {
             return;
@@ -516,7 +526,7 @@ mod tests {
 
     #[test]
     fn sync_reports_not_a_git_worktree_for_non_git_dir() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = crate::test_support::hermetic_temp_dir();
         assert_eq!(
             sync_worktree_with_upstream(tmp.path()),
             SyncOutcome::NotAGitWorktree
@@ -599,7 +609,7 @@ mod tests {
 
     #[test]
     fn self_heal_claude_md_strips_legacy_block() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = crate::test_support::hermetic_temp_dir();
         let begin = "<!-- trusty-mpm:delegation-directive:begin \
             (framework-owned — do not edit; regenerated on every session start, see issue #2125) -->";
         let end = "<!-- trusty-mpm:delegation-directive:end -->";
@@ -618,7 +628,7 @@ mod tests {
 
     #[test]
     fn self_heal_claude_md_noop_when_clean() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = crate::test_support::hermetic_temp_dir();
         let clean = "# My Project\n\nNotes.\n";
         std::fs::write(tmp.path().join("CLAUDE.md"), clean).unwrap();
 
@@ -631,7 +641,7 @@ mod tests {
 
     #[test]
     fn self_heal_claude_md_noop_when_absent() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = crate::test_support::hermetic_temp_dir();
         assert!(!self_heal_claude_md(tmp.path()));
     }
 }

--- a/crates/trusty-mpm/src/core/standalone/load.rs
+++ b/crates/trusty-mpm/src/core/standalone/load.rs
@@ -242,7 +242,6 @@ fn write_marker(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
 
     /// RAII guard that clears an env var for the duration of a test and restores
     /// the prior value on drop.
@@ -296,7 +295,7 @@ mod tests {
     fn run_prepare_session_pins_palace_from_clone_url() {
         // Hermetic: an ambient override would win over the URL-derived slug.
         let _guard = EnvClearGuard::clear("TRUSTY_MEMORY_PALACE");
-        let tmp = TempDir::new().unwrap();
+        let tmp = crate::test_support::hermetic_temp_dir();
         // Deliberately a session-id-like basename: the pin must come from the
         // clone URL, NOT this directory name.
         let repo = tmp.path().join("0c8f1a2b3c4d");
@@ -339,7 +338,7 @@ mod tests {
     #[serial_test::serial]
     fn run_prepare_session_bare_stub_when_no_identity() {
         let _guard = EnvClearGuard::clear("TRUSTY_MEMORY_PALACE");
-        let tmp = TempDir::new().unwrap();
+        let tmp = crate::test_support::hermetic_temp_dir();
         // A basename that slugifies to empty (only separators) cannot yield a
         // parent-dir slug, so with no URL/remote/override the stub stays bare.
         let repo = tmp.path().join("---");
@@ -413,7 +412,7 @@ mod tests {
     fn run_prepare_session_never_writes_real_home_claude_dirs() {
         let _palace_guard = EnvClearGuard::clear("TRUSTY_MEMORY_PALACE");
 
-        let fake_home = TempDir::new().unwrap();
+        let fake_home = crate::test_support::hermetic_temp_dir();
         let _home_guard = {
             let prior = std::env::var("HOME").ok();
             // SAFETY: serialized via `#[serial_test::serial]`.
@@ -435,7 +434,7 @@ mod tests {
 
         // repo/ lives under a SEPARATE temp dir so it can never coincidentally
         // land inside the fake home tree.
-        let project_root = TempDir::new().unwrap();
+        let project_root = crate::test_support::hermetic_temp_dir();
         let repo = project_root.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
 
@@ -472,7 +471,7 @@ mod tests {
 
     #[test]
     fn test_marker_write_round_trip() {
-        let tmp = TempDir::new().unwrap();
+        let tmp = crate::test_support::hermetic_temp_dir();
         let repo = tmp.path().join("repo");
         std::fs::create_dir_all(&repo).unwrap();
         let cfg = tmp.path().join("claude-config");

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
@@ -77,7 +77,7 @@ fn launch_and_daemon_agree_on_repos_root_env() {
 #[test]
 fn ensure_base_clone_migrates_old_layout_dir_aside() {
     // 1. Build a real source repo to clone from.
-    let src = tempfile::TempDir::new().expect("src tmp dir");
+    let src = crate::test_support::hermetic_temp_dir();
     let src_path = src.path();
     let init = std::process::Command::new("git")
         .args(["init", src_path.to_str().expect("src utf8")])
@@ -111,7 +111,7 @@ fn ensure_base_clone_migrates_old_layout_dir_aside() {
 
     // 2. Build an OLD-LAYOUT base dir: <parent>/owner/repo/ containing a fake
     //    per-session UUID full-clone subdir and NO top-level `.git`.
-    let parent = tempfile::TempDir::new().expect("parent tmp dir");
+    let parent = crate::test_support::hermetic_temp_dir();
     let base = parent.path().join("owner").join("repo");
     let old_session = base.join("00000000-old-session-uuid");
     std::fs::create_dir_all(&old_session).expect("create old-layout subdir");
@@ -164,7 +164,7 @@ fn ensure_base_clone_migrates_old_layout_dir_aside() {
 #[test]
 fn migrate_old_layout_aside_ignores_empty_and_git_dirs() {
     // Empty dir → Ok(None), dir untouched.
-    let empty = tempfile::TempDir::new().expect("empty tmp");
+    let empty = crate::test_support::hermetic_temp_dir();
     let empty_base = empty.path().join("owner").join("repo");
     std::fs::create_dir_all(&empty_base).expect("create empty base");
     assert!(
@@ -176,7 +176,7 @@ fn migrate_old_layout_aside_ignores_empty_and_git_dirs() {
     assert!(empty_base.is_dir(), "empty base dir must remain in place");
 
     // Dir with a top-level `.git` → Ok(None), dir untouched.
-    let git = tempfile::TempDir::new().expect("git tmp");
+    let git = crate::test_support::hermetic_temp_dir();
     let git_base = git.path().join("owner").join("repo");
     std::fs::create_dir_all(git_base.join(".git")).expect("create .git");
     std::fs::write(git_base.join("file"), b"x").expect("write file");
@@ -269,7 +269,7 @@ fn session_worktree_path_uses_dot_prefix() {
     // — NOT derived from production code. If `create_session_worktree` changed
     // to `base_path.join("worktrees").join(...)` the `starts_with` assertion
     // would fail because `base/worktrees/<name>` does NOT start with `base/.worktrees`.
-    let tmp = tempfile::TempDir::new().expect("tmp dir");
+    let tmp = crate::test_support::hermetic_temp_dir();
     let base = tmp.path();
 
     // Initialise a real git repo so `git worktree add` can run.
@@ -355,7 +355,7 @@ fn session_worktree_path_uses_dot_prefix() {
 /// Test: this function IS the test.
 #[test]
 fn worktree_name_collides_detects_existing_dir_and_branch() {
-    let tmp = tempfile::TempDir::new().expect("tmp dir");
+    let tmp = crate::test_support::hermetic_temp_dir();
     let base = tmp.path();
 
     let init = std::process::Command::new("git")
@@ -434,7 +434,7 @@ fn worktree_name_collides_detects_existing_dir_and_branch() {
 /// Test: this function IS the test.
 #[test]
 fn create_session_worktree_rejects_existing_worktree_dir() {
-    let tmp = tempfile::TempDir::new().expect("tmp dir");
+    let tmp = crate::test_support::hermetic_temp_dir();
     let base = tmp.path();
 
     let init = std::process::Command::new("git")
@@ -479,7 +479,7 @@ fn create_session_worktree_rejects_existing_worktree_dir() {
 fn ensure_worktrees_gitignored_idempotent() {
     // ensure_worktrees_gitignored must write .worktrees/ to .git/info/exclude
     // exactly ONCE even when called multiple times (idempotent) (#1803).
-    let tmp = tempfile::TempDir::new().expect("tmp dir");
+    let tmp = crate::test_support::hermetic_temp_dir();
     let base = tmp.path();
     // Create a minimal .git dir (not a real git repo, but enough for the function).
     std::fs::create_dir_all(base.join(".git")).expect("create .git");
@@ -536,7 +536,7 @@ async fn ensure_base_clone_emits_cloning_repo_only_on_fresh_clone() {
 
     // 1. Build a real source repo to clone from (mirrors the fixture used by
     //    `ensure_base_clone_migrates_old_layout_dir_aside` above).
-    let src = tempfile::TempDir::new().expect("src tmp dir");
+    let src = crate::test_support::hermetic_temp_dir();
     let src_path = src.path();
     let init = std::process::Command::new("git")
         .args(["init", src_path.to_str().expect("src utf8")])
@@ -568,7 +568,7 @@ async fn ensure_base_clone_emits_cloning_repo_only_on_fresh_clone() {
         .expect("git commit");
     assert!(commit.success(), "git commit failed");
 
-    let parent = tempfile::TempDir::new().expect("parent tmp dir");
+    let parent = crate::test_support::hermetic_temp_dir();
     let base = parent.path().join("owner").join("repo");
     let url = src_path.to_str().expect("src url utf8").to_string();
 
@@ -635,7 +635,7 @@ async fn ensure_base_clone_emits_cloning_repo_only_on_fresh_clone() {
 fn create_session_worktree_sets_pull_upstream_and_worktree_scoped_push() {
     // 1. A real bare `origin` remote, explicitly on `main` so the assertions
     //    below are not at the mercy of the host's `init.defaultBranch`.
-    let origin_dir = tempfile::TempDir::new().expect("origin tmp dir");
+    let origin_dir = crate::test_support::hermetic_temp_dir();
     let origin_path = origin_dir.path();
     let init = std::process::Command::new("git")
         .args([
@@ -655,7 +655,7 @@ fn create_session_worktree_sets_pull_upstream_and_worktree_scoped_push() {
 
     // 2. Seed the bare origin with one commit via a scratch clone (a bare repo
     //    has no working tree to commit into directly).
-    let seed = tempfile::TempDir::new().expect("seed tmp dir");
+    let seed = crate::test_support::hermetic_temp_dir();
     let seed_path = seed.path();
     let clone_seed = std::process::Command::new("git")
         .args([
@@ -709,7 +709,7 @@ fn create_session_worktree_sets_pull_upstream_and_worktree_scoped_push() {
     // 3. Clone the now-non-empty bare origin into `base` — this mirrors what
     //    `ensure_base_clone` produces in production: `origin` remote wired up
     //    and `refs/remotes/origin/HEAD` set by the clone itself.
-    let base_parent = tempfile::TempDir::new().expect("base parent tmp dir");
+    let base_parent = crate::test_support::hermetic_temp_dir();
     let base = base_parent.path().join("base");
     let clone_base = std::process::Command::new("git")
         .args([


### PR DESCRIPTION
## Summary

Follow-up to #3382 / PR #3385. The `hermetic_temp_dir()` helper landed for the 25 (later 65, after #3385's own fix-up rounds) originally-flagged sites, but the critic verified four more files still create REAL git repos/worktrees — the exact litter shape from the #3382 incident, not benign small-file tests — rooted at bare `TempDir::new()`, which honors a polluted `$TMPDIR`.

## Sites converted (all mechanical unless noted)

- `content/catalog_sync.rs`: 13 sites, real `git clone` (`FakeGitBackend`-driven `CatalogSync` tests)
- `core/session_launch/worktree_sync.rs`: 9 sites, real `git clone` + `git worktree add` (the `#2647`-shape fixture: bare origin → seed clone → base clone → session worktree)
- `core/standalone/load.rs`: 5 sites, `run_prepare_session` tests including one that redirects `$HOME` to a fake temp dir
- `daemon/managed_routes/inproject/tests.rs`: 13 sites, `git init` + `git worktree add`

All → `crate::test_support::hermetic_temp_dir()`. `grep -c "TempDir::new()"` on all four files after the change: `0`.

## Non-mechanical case (disclosed per the issue's ask)

`core/session_launch/worktree_sync.rs::build_fixture()` had four `TempDir::new().ok()?` sites (not `.unwrap()`/`.expect()`). `hermetic_temp_dir()` returns `TempDir` directly — it panics via an internal `.expect(...)` on creation failure rather than returning `Option<TempDir>` — so these four became `hermetic_temp_dir()` calls with the trailing `?` dropped. Documented inline at the top of `build_fixture()`. Practically equivalent: OS temp-directory creation failing at all is exceedingly rare (disk full / permission denied), and unlike the git-unavailable checks in the same function (which legitimately `return None` to let callers skip cleanly when `git` isn't on the runner), a failure to create a scratch directory is a real test-environment problem worth a hard failure rather than a silent skip.

Also dropped `core/standalone/load.rs`'s now-unused `use tempfile::TempDir;` import (the type was only ever named via the removed `TempDir::new()` calls in that file, unlike the other three files where `TempDir` is still used as a field/parameter type and the import stays).

## Explicitly out of scope (per the issue)

- The ~700 other bare `TempDir::new()` sites in small-file tests (no litter shape) — unchanged.
- A crate-wide clippy `disallowed-methods` ban — previously assessed as disproportionate in PR #3385 (726 errors across ~105 unrelated files) and not revisited here; no new cheap targeted guard emerged during this conversion that wasn't already disproportionate for the same reason, so none was added.

## TMPDIR-pollution canary proof (scoped to these four suites)

Baseline (before) and after running all four converted suites under a polluted `TMPDIR`:

```
$ find "$HOME/trusty-mpm-projects" -maxdepth 1 | sort > before.txt
$ TMPDIR="$HOME/trusty-mpm-projects" cargo test -p trusty-mpm catalog_sync::
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 3374 filtered out
$ TMPDIR="$HOME/trusty-mpm-projects" cargo test -p trusty-mpm worktree_sync::
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 3379 filtered out
$ TMPDIR="$HOME/trusty-mpm-projects" cargo test -p trusty-mpm standalone::load::
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 3384 filtered out
$ TMPDIR="$HOME/trusty-mpm-projects" cargo test -p trusty-mpm managed_routes::inproject::
To /tmp/tm-test-90Vhjx   # <- real git push output, confirms hermetic root in use
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 3361 filtered out

$ find "$HOME/trusty-mpm-projects" -maxdepth 1 | sort > after.txt
$ diff before.txt after.txt
$ echo $?
0
```

Zero diff — despite `TMPDIR` pointing straight at the project tree, every scaffold (git clones, worktrees, inits) landed under `/tmp/tm-test-*`, never under `~/trusty-mpm-projects`. (Numerous pre-existing `tmp*` litter directories from unrelated concurrent sessions on other worktrees — still running old code from before either fix — were present in both before/after listings, unchanged; not created by this run.)

## Gate results (raw)

`cargo fmt --check -p trusty-mpm`: exit 0, no diff.

`cargo clippy -p trusty-mpm --all-targets -- -D warnings`: `Finished` clean, zero errors (only pre-existing unrelated warnings from the `tga` crate and duplicate-bin-target notices).

`cargo test -p trusty-mpm` (parallel, full surface, no `--lib`): 36 `test result:` lines, all `ok`, zero failures, zero panics.

`cargo test -p trusty-mpm -- --test-threads=1` (serial, full surface): identical — 36 `test result:` lines, all `ok`, zero failures.

`scripts/check_line_cap.sh`: `line-cap: 7 allowlisted, 0 violations — OK.`

`scripts/check_test_pointers.sh`: `test-pointers: 0 dangling pointers — OK.`

`scripts/check_sld.sh`: `sld-lint: scanned 39 spec doc(s) + 2626 code file(s); 0 error(s), 0 warning(s)`

## Test plan

- [x] `cargo test -p trusty-mpm catalog_sync::` — 14/14 pass
- [x] `cargo test -p trusty-mpm worktree_sync::` — 9/9 pass (incl. the real git-fixture tests)
- [x] `cargo test -p trusty-mpm standalone::load::` — 4/4 pass (incl. the `$HOME`-redirecting test)
- [x] `cargo test -p trusty-mpm managed_routes::inproject::` — 27/27 pass
- [x] Full-surface `cargo test -p trusty-mpm` in both parallel and `--test-threads=1` modes — zero failures
- [x] TMPDIR-pollution canary proof (above) — zero new entries under `~/trusty-mpm-projects`

Closes #3390

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools