### PR TITLE
feat(trusty-code): CodeEngine HTTP daemon adapter for the shared TUI (Slice 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11369,7 +11369,9 @@ dependencies = [
  "tracing-subscriber",
  "trusty-agents-common",
  "trusty-common",
+ "trusty-tui",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,10 @@ authors = ["Bob Matsuoka <bob@matsuoka.com>"]
 # trusty-code: per-project Claude-Code-compatible MPM orchestration harness (#587).
 # First published to crates.io at version 0.1.0.
 trusty-code = { path = "crates/trusty-code" }
+# trusty-tui: engine-agnostic terminal-UI seam (`TuiEngine` trait + `ReplEvent`)
+# shared by trusty-code's `tcode tui` and trusty-agents' tagent REPL (DOC-50,
+# epic #3411). Not yet published (Slice 1, #3425).
+trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.2.1" }
 trusty-common = { path = "crates/trusty-common", version = "0.23.2" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,7 +8,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`CodeEngine`'s workstream-activation subscription no longer drops
+  deactivation events (code-critic HIGH, PR #3436).** The daemon
+  legitimately publishes `WorkstreamActivationChanged{new_active_id: None,
+  ...}` when the active workstream is deactivated with no replacement
+  (DOC-48 §4.2/§4.3); the subscription's `if let` previously matched only
+  `new_active_id: Some(..)`, silently dropping the `None` case — no cache
+  refresh, no user-visible signal, a stale status line/picker indefinitely.
+  Both arms now refresh `EngineState`'s workstream cache; the `None` case
+  surfaces a `StatusMessage` (the shared `ReplEvent::WorkstreamActivationChanged`
+  declares `new_active_id` as a non-optional `String`, so it cannot carry
+  this state without a `trusty-tui` change).
+
 ### Added
+
+- **`CodeEngine::commands()`/`picker()` implement `trusty-tui`'s
+  synchronous `TuiEngine` accessors (Slice 1.5, #3428).** Previously shipped
+  as inherent methods (ahead of #3428 landing); now real trait-impl
+  overrides, so the shared TUI's generic `E: TuiEngine` path picks up the
+  real implementations instead of silently falling back to the trait's
+  default "supply nothing." Backed by the same `std::sync::Mutex`-guarded
+  caches populated in `setup()`/on workstream changes.
 
 - **`tui_client::CodeEngine` — `trusty-tui` engine adapter for `tcode tui`
   (issue #3415, DOC-50 §3.3/§3.4, epic #3411 Slice 3).** A thin

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`tui_client::CodeEngine` — `trusty-tui` engine adapter for `tcode tui`
+  (issue #3415, DOC-50 §3.3/§3.4, epic #3411 Slice 3).** A thin
+  `trusty_tui::TuiEngine` implementation driving a long-lived
+  `tcode serve --http` daemon over pooled HTTP + SSE: daemon discovery
+  (`TCODE_DAEMON_URL` env var → the `http_addr` discovery file → a
+  `/health` liveness ping), `session.create`/`task.run` for chat turns
+  streamed back via `GET /sessions/{id}/events`, `session.cancel` on
+  cancellation (never a client-side-only stop), and a long-lived
+  `GET /workstreams/{id}/events` subscription translating
+  `WorkstreamActivationChanged` into `ReplEvent`s. `crate::serve::discovery`
+  adds the daemon-side write half of the discovery file (`http_addr` under
+  `resolve_data_dir("trusty-code")`), following the same convention
+  `trusty-memory`/`trusty-search` already use rather than inventing a new
+  JSON-shaped one.
+
 ### Fixed
 
 - **Every daemon-default task run (including every GUI-initiated run) failed

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -105,6 +105,11 @@ globset = { workspace = true }
 # task startup.
 trusty-common = { workspace = true, features = ["catchup", "mcp", "stdio-mcp-client", "axum-server", "inference-client", "config-cli", "bedrock-client", "search-index"] }
 
+# `tui_client::CodeEngine` (#3415, DOC-50 §3.3/§3.4, epic #3411 Slice 3): the
+# shared engine-adapter trait + event vocabulary (`TuiEngine`/`ReplEvent`)
+# both `tcode tui` and tagent's REPL implement against.
+trusty-tui = { workspace = true }
+
 # `tcode serve --http`: POST /rpc + GET /health over axum (#2053). Per
 # CLAUDE.md, axum stays feature-gated in *library* crates
 # (`trusty-common`'s `axum-server` flag); trusty-code is a binary crate that
@@ -140,3 +145,8 @@ tokio = { workspace = true }
 # HTTP router test-only helper (`tower::util::ServiceExt::oneshot`) for
 # driving the `tcode serve --http` axum router without a real socket (#2053).
 tower = { workspace = true }
+# `tests/tui_client_engine.rs` (#3415): a hermetic mock HTTP daemon for
+# `CodeEngine`, mirroring `trusty-channels/tests/client_http.rs`'s pattern —
+# a real bound socket so `reqwest` (SSE included) drives it exactly like a
+# real `tcode serve --http` daemon, without spawning the real binary.
+wiremock = { workspace = true }

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -468,6 +468,30 @@ pub mod task;
 /// end-to-end coverage in `tests/cli_e2e.rs`.
 pub mod cli_client;
 
+/// `CodeEngine` — the `trusty-tui` engine adapter driving a long-lived
+/// `tcode serve --http` daemon for the interactive `tcode tui` (#3415,
+/// DOC-50 §3.3/§3.4, epic #3411 Slice 3).
+///
+/// Why: `cli_client` (above) spawns an EPHEMERAL `--stdio` child per CLI
+/// invocation — the right shape for one-shot commands, wrong for an
+/// interactive REPL that needs to hold a session open, stream responses
+/// live, and observe workstream activation pushed from OTHER clients. This
+/// module is the HTTP counterpart: a thin `trusty_tui::TuiEngine`
+/// implementation that discovers an already-running daemon and drives it
+/// over pooled HTTP + SSE, translating daemon responses into
+/// `trusty_tui::ReplEvent`s — no business logic of its own (DOC-39 §2.1
+/// thin-client axiom).
+/// What: `tui_client::discovery` (daemon lookup: `TCODE_DAEMON_URL` env var
+/// -> `serve::discovery`'s `http_addr` file -> liveness ping), `tui_client::rpc`
+/// (pooled `POST /rpc` client, reusing `trusty_common::mcp::{Request,Response}`
+/// exactly like `cli_client::stdio` does over STDIO), `tui_client::sse` (a
+/// minimal SSE line pump over `reqwest`'s byte stream), and
+/// `tui_client::engine::CodeEngine` (the `TuiEngine` impl itself).
+/// Test: `tui_client::*::tests` for the pure helpers; the full
+/// discover/setup/stream/cancel/workstream-activation flow against a mock
+/// HTTP daemon in `tests/tui_client_engine.rs`.
+pub mod tui_client;
+
 // ── Package-level re-exports ──
 
 /// Version string, re-exported so integration tests can assert it without

--- a/crates/trusty-code/src/serve/discovery.rs
+++ b/crates/trusty-code/src/serve/discovery.rs
@@ -1,0 +1,189 @@
+//! `tcode serve --http` daemon discovery file (issue #3415, DOC-50 §3.4).
+//!
+//! Why: `tcode tui` (`crate::tui_client::CodeEngine`) needs to find a running
+//! `tcode serve --http` daemon without the operator copying a port number by
+//! hand. DOC-50 §3.4's prose sketched a NEW, tcode-specific JSON file
+//! (`~/.trusty-code/daemon.json`, `{daemon_url, pid, started_at}`) for this —
+//! but this crate's siblings already solve the identical problem, and their
+//! convention is different: `trusty-memory` (`crates/trusty-memory/src/http_server.rs::write_http_addr_file`)
+//! and `trusty-search` (`crates/trusty-search/src/service/daemon.rs`) both
+//! write the bound `host:port` as PLAIN TEXT to a file named `http_addr`
+//! under `trusty_common::resolve_data_dir(<app_name>)`, atomically (tmp +
+//! rename) so a reader never observes a half-written value. This module
+//! follows THAT established convention for tcode instead of inventing a
+//! second, JSON-shaped one: `pid`/`started_at` have no consumer anywhere in
+//! this codebase yet, and a plain-text `host:port` is exactly what
+//! `discover_daemon_url` (`crate::tui_client::discovery`) needs to build
+//! `http://{addr}`.
+//! What: [`http_addr_path`] resolves `{resolve_data_dir("trusty-code")}/http_addr`
+//! (server AND client side share this one path-resolution function so they
+//! can never drift onto two different locations); [`write_http_addr_file`]
+//! (called from `crate::serve::http::run_http` after binding) atomically
+//! writes the bound address; [`remove_http_addr_file`] (called on graceful
+//! shutdown) clears it so a stopped daemon doesn't leave a stale pointer for
+//! the next reader; [`read_http_addr_file`] (called from
+//! `crate::tui_client::discovery`) reads and trims it back. Every operation
+//! is best-effort: a write/remove failure only degrades discovery to the
+//! `TCODE_DAEMON_URL` env var; a read failure (file absent, stale content,
+//! unreadable) means "no candidate from this source," not a hard error — the
+//! caller's overall discovery still fails with a clear, actionable message
+//! when no source yields a live daemon.
+//! Test: `discovery_tests::*`.
+
+use std::io;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+/// Filename of the discovery file, written under
+/// `resolve_data_dir("trusty-code")` — mirrors `trusty-memory`'s
+/// `http_addr` convention exactly (same filename, same directory-resolution
+/// helper, same plain-text `host:port` content).
+pub const HTTP_ADDR_FILENAME: &str = "http_addr";
+
+/// Resolve `{resolve_data_dir("trusty-code")}/http_addr`, or `None` if the
+/// data directory cannot be resolved (matches
+/// `trusty-memory::http_server::http_addr_path`'s degrade-gracefully
+/// contract — a resolution failure here is never fatal, only a missing
+/// discovery source).
+pub fn http_addr_path() -> Option<PathBuf> {
+    trusty_common::resolve_data_dir("trusty-code")
+        .ok()
+        .map(|d| d.join(HTTP_ADDR_FILENAME))
+}
+
+/// Atomically write `addr` to `path` (tmp + rename).
+///
+/// Why: a client reading this file mid-write must never observe a partial
+/// value; writing to a `.addr.tmp` sibling and renaming over the target
+/// gives POSIX atomicity. Mirrors
+/// `trusty-memory::http_server::write_http_addr_file` byte-for-byte in
+/// behaviour — duplicated here (rather than adding a cross-product
+/// dependency on trusty-memory for one ~10-line helper) since both crates
+/// are independent binaries with no other shared coupling.
+/// What: creates the parent directory if missing; writes `addr` followed by
+/// a trailing newline; renames the tmp file over `path`.
+/// Test: `discovery_tests::write_then_read_round_trips_bound_addr`.
+pub(crate) fn write_http_addr_file(path: &Path, addr: &SocketAddr) -> io::Result<()> {
+    use std::io::Write;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("addr.tmp");
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        writeln!(f, "{addr}")?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Best-effort remove of the discovery file.
+///
+/// Why: called on graceful `tcode serve --http` shutdown so a stopped
+/// daemon doesn't leave a stale `http_addr` pointing at a dead port for the
+/// next `CodeEngine::discover` call — a reader would otherwise pass the
+/// "candidate found" step and only fail at the liveness ping, which is a
+/// worse error message than "no daemon found" for the common
+/// stop-then-later-reconnect case.
+/// What: `std::fs::remove_file`, ignoring any error (already-absent is the
+/// common case, e.g. `write_http_addr_file` itself failed earlier).
+/// Test: `discovery_tests::remove_is_best_effort_on_missing_file`.
+pub(crate) fn remove_http_addr_file(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+/// Read and trim the discovery file's contents (just `host:port`), or
+/// `None` if it's absent/unreadable/empty.
+///
+/// Why: the client side of discovery — deliberately infallible (`Option`,
+/// not `Result`) since "no file" and "unreadable file" are both just "no
+/// candidate from this source" to the caller, not distinct error states
+/// worth surfacing.
+/// Test: `discovery_tests::write_then_read_round_trips_bound_addr`,
+/// `discovery_tests::read_missing_file_returns_none`.
+pub(crate) fn read_http_addr_file(path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod discovery_tests {
+    use super::*;
+
+    /// The write/read round trip must recover exactly the address that was
+    /// written, with no surrounding whitespace.
+    #[test]
+    fn write_then_read_round_trips_bound_addr() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(HTTP_ADDR_FILENAME);
+        let addr: SocketAddr = "127.0.0.1:7882".parse().expect("parse addr");
+        write_http_addr_file(&path, &addr).expect("write");
+        assert_eq!(
+            read_http_addr_file(&path).as_deref(),
+            Some("127.0.0.1:7882")
+        );
+    }
+
+    /// A missing file is "no candidate," not an error.
+    #[test]
+    fn read_missing_file_returns_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(HTTP_ADDR_FILENAME);
+        assert_eq!(read_http_addr_file(&path), None);
+    }
+
+    /// An empty (or whitespace-only) file must also read back as "no
+    /// candidate" — a truncated write mid-crash should never hand the
+    /// client an empty daemon URL.
+    #[test]
+    fn read_blank_file_returns_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(HTTP_ADDR_FILENAME);
+        std::fs::write(&path, "   \n").expect("write blank");
+        assert_eq!(read_http_addr_file(&path), None);
+    }
+
+    /// Removing an already-absent file must not panic or return an
+    /// observable error — this is the common case (daemon exits after a
+    /// write failure, or two shutdown paths race).
+    #[test]
+    fn remove_is_best_effort_on_missing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(HTTP_ADDR_FILENAME);
+        remove_http_addr_file(&path); // must not panic
+        assert!(!path.exists());
+    }
+
+    /// `remove_http_addr_file` must actually delete an existing file (not
+    /// just no-op on the missing case).
+    #[test]
+    fn remove_deletes_an_existing_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join(HTTP_ADDR_FILENAME);
+        let addr: SocketAddr = "127.0.0.1:7882".parse().expect("parse addr");
+        write_http_addr_file(&path, &addr).expect("write");
+        assert!(path.exists());
+        remove_http_addr_file(&path);
+        assert!(!path.exists());
+    }
+
+    /// `http_addr_path` must join the filename onto whatever base
+    /// `resolve_data_dir` returns — not asserting the exact OS-standard base
+    /// (platform-dependent), only that the join is correct when resolution
+    /// succeeds.
+    #[test]
+    fn http_addr_path_ends_with_filename() {
+        if let Some(p) = http_addr_path() {
+            assert_eq!(
+                p.file_name().and_then(|f| f.to_str()),
+                Some(HTTP_ADDR_FILENAME)
+            );
+        }
+    }
+}

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -281,12 +281,30 @@ pub async fn run_http(
     info!("tcode serve --http: listening on http://{bound}");
     eprintln!("tcode serve --http: listening on http://{bound}");
 
+    // Issue #3415 (DOC-50 §3.4): write the discovery file `CodeEngine` reads
+    // to find this daemon without a hardcoded port. Best-effort — a write
+    // failure only means discovery degrades to the `TCODE_DAEMON_URL` env
+    // var; it must never block the daemon from serving.
+    let discovery_path = crate::serve::discovery::http_addr_path();
+    if let Some(path) = &discovery_path
+        && let Err(e) = crate::serve::discovery::write_http_addr_file(path, &bound)
+    {
+        tracing::warn!(
+            error = %e,
+            path = %path.display(),
+            "tcode serve --http: failed to write daemon discovery file"
+        );
+    }
+
     let app = build_axum_router(Arc::new(router), sessions, workstreams);
     axum::serve(listener, app)
         .with_graceful_shutdown(trusty_common::shutdown_signal())
         .await
         .context("tcode serve --http: axum serve failed")?;
 
+    if let Some(path) = &discovery_path {
+        crate::serve::discovery::remove_http_addr_file(path);
+    }
     info!("tcode serve --http: stopped");
     Ok(())
 }

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -33,6 +33,7 @@
 //!
 //! Test: `serve::tests::*`.
 
+pub mod discovery;
 pub mod http;
 pub mod methods;
 pub mod rest;

--- a/crates/trusty-code/src/tui_client/discovery.rs
+++ b/crates/trusty-code/src/tui_client/discovery.rs
@@ -1,0 +1,217 @@
+//! Daemon discovery for [`crate::tui_client::CodeEngine`] (issue #3415,
+//! DOC-50 §3.4).
+//!
+//! Why: `tcode tui` needs to find an already-running `tcode serve --http`
+//! daemon without the operator hand-copying a port. DOC-50 §3.4 specifies
+//! the lookup priority — explicit override, then a discovery file, then a
+//! liveness check — but its prose sketched a NEW `~/.trusty-code/daemon.json`
+//! shape; `crate::serve::discovery` documents why this crate follows the
+//! ALREADY-ESTABLISHED sibling convention (`trusty-memory`/`trusty-search`'s
+//! plain-text `http_addr` file) instead. This module is the READ side of
+//! that convention; `crate::serve::discovery`'s `write_http_addr_file` is
+//! the write side, called from `crate::serve::http::run_http`.
+//! What: [`discover_daemon_url`] tries, in order, [`DAEMON_URL_ENV`] (an
+//! explicit override — trusted without a liveness check of its own source,
+//! but still ping-verified before use, same as the file-sourced candidate)
+//! then the `http_addr` discovery file; whichever candidate is found is
+//! verified alive via `GET {url}/health` (the SAME route
+//! `crate::serve::methods::health_payload` answers, already the
+//! ecosystem-standard liveness probe per `crate::serve::http`'s docs) before
+//! being returned. No candidate, or a candidate that fails the liveness
+//! ping, produces a [`DiscoveryError`] with an actionable message — never a
+//! silent `None`/default.
+//! Test: `discovery_tests::*` for the pure candidate-selection logic (env
+//! var precedence, file fallback, "neither present" case); the liveness-ping
+//! branch is covered end-to-end in `tests/tui_client_engine.rs` against a
+//! mock daemon (a unit test would need a real bound socket to ping, which
+//! belongs in that hermetic integration suite, not here).
+
+use std::time::Duration;
+
+/// Environment variable that, when set to a non-empty value, names the
+/// daemon URL directly — highest-priority discovery source (DOC-50 §3.4
+/// point 1).
+pub const DAEMON_URL_ENV: &str = "TCODE_DAEMON_URL";
+
+/// How long the liveness ping (`GET {url}/health`) waits before treating the
+/// candidate as dead. Short and fixed — this call happens once, at REPL
+/// startup, and a slow/hung `/health` response is itself a strong "don't use
+/// this daemon" signal.
+const PING_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Which discovery source produced a candidate URL — carried into
+/// [`DiscoveryError::NotAlive`] so the error message tells the operator
+/// WHERE the stale/wrong pointer came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Source {
+    Env,
+    File,
+}
+
+impl Source {
+    fn as_str(self) -> &'static str {
+        match self {
+            Source::Env => "TCODE_DAEMON_URL",
+            Source::File => "discovery file",
+        }
+    }
+}
+
+/// See module docs.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum DiscoveryError {
+    /// Neither `TCODE_DAEMON_URL` nor the discovery file named a candidate
+    /// daemon URL.
+    #[error(
+        "no tcode daemon found — start one with `tcode serve --http`, or point \
+         `tcode tui` at a running instance with `{DAEMON_URL_ENV}=http://host:port`"
+    )]
+    NotFound,
+
+    /// A candidate URL was found (from `source`) but did not answer
+    /// `GET {url}/health` with a success status within [`PING_TIMEOUT`].
+    #[error(
+        "found a tcode daemon reference at {url} (from {found_via}) but it is not responding \
+         — is it still running? Start one with `tcode serve --http`, or update {DAEMON_URL_ENV} \
+         to point at a live daemon"
+    )]
+    NotAlive {
+        url: String,
+        found_via: &'static str,
+    },
+}
+
+/// Resolve and verify a live daemon URL, per this module's docs.
+///
+/// Why/What: see module docs. `client` is caller-supplied (rather than built
+/// internally) so `CodeEngine` can reuse the SAME pooled `reqwest::Client`
+/// for both this ping and every later `POST /rpc`/SSE call — one connection
+/// pool for the engine's whole lifetime, not one throwaway client per call.
+/// Test: `discovery_tests::env_var_wins_over_file`,
+/// `discovery_tests::env_var_trailing_slash_is_stripped`,
+/// `discovery_tests::blank_env_var_is_ignored`; the liveness branch (and the
+/// "neither source present" -> `NotFound` case) is covered by
+/// `tests/tui_client_engine.rs`.
+pub async fn discover_daemon_url(client: &reqwest::Client) -> Result<String, DiscoveryError> {
+    let (url, source) = candidate_url().ok_or(DiscoveryError::NotFound)?;
+    if ping_alive(client, &url).await {
+        Ok(url)
+    } else {
+        Err(DiscoveryError::NotAlive {
+            url,
+            found_via: source.as_str(),
+        })
+    }
+}
+
+/// Pick a candidate URL from the env var or the discovery file, per the
+/// documented priority. Pure (no network I/O) so it's directly unit
+/// testable.
+fn candidate_url() -> Option<(String, Source)> {
+    if let Ok(raw) = std::env::var(DAEMON_URL_ENV) {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            return Some((trimmed.trim_end_matches('/').to_string(), Source::Env));
+        }
+    }
+    let path = crate::serve::discovery::http_addr_path()?;
+    let addr = crate::serve::discovery::read_http_addr_file(&path)?;
+    Some((format!("http://{addr}"), Source::File))
+}
+
+/// `GET {base_url}/health`, bounded by [`PING_TIMEOUT`] — `true` iff it
+/// returns a success (2xx) status.
+async fn ping_alive(client: &reqwest::Client, base_url: &str) -> bool {
+    let url = format!("{base_url}/health");
+    match client.get(&url).timeout(PING_TIMEOUT).send().await {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod discovery_tests {
+    use super::*;
+
+    /// Serializes every test in this module that mutates `DAEMON_URL_ENV` —
+    /// mirrors `crate::task::mock_llm::MOCK_LLM_ENV_LOCK`'s established
+    /// pattern for env-mutating tests in this crate (a plain `tokio::sync::Mutex`
+    /// guard rather than pulling in `serial_test` for one file).
+    static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// Both a `TCODE_DAEMON_URL` and a discovery file present: the env var
+    /// must win (DOC-50 §3.4 point 1's explicit priority).
+    #[tokio::test]
+    async fn env_var_wins_over_file() {
+        let _guard = ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation; serialized by `ENV_LOCK`.
+        unsafe {
+            std::env::set_var(DAEMON_URL_ENV, "http://127.0.0.1:9999");
+        }
+        let (url, source) = candidate_url().expect("candidate");
+        unsafe {
+            std::env::remove_var(DAEMON_URL_ENV);
+        }
+        assert_eq!(url, "http://127.0.0.1:9999");
+        assert_eq!(source, Source::Env);
+    }
+
+    /// A trailing slash on the env var is stripped, so URL-joining callers
+    /// (`{base}/rpc`, `{base}/health`) never produce a doubled `//`.
+    #[tokio::test]
+    async fn env_var_trailing_slash_is_stripped() {
+        let _guard = ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation; serialized by `ENV_LOCK`.
+        unsafe {
+            std::env::set_var(DAEMON_URL_ENV, "http://127.0.0.1:9999/");
+        }
+        let (url, _source) = candidate_url().expect("candidate");
+        unsafe {
+            std::env::remove_var(DAEMON_URL_ENV);
+        }
+        assert_eq!(url, "http://127.0.0.1:9999");
+    }
+
+    /// An empty/whitespace `TCODE_DAEMON_URL` must be treated as unset, not
+    /// as a (broken) candidate.
+    #[tokio::test]
+    async fn blank_env_var_is_ignored() {
+        let _guard = ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation; serialized by `ENV_LOCK`.
+        unsafe {
+            std::env::set_var(DAEMON_URL_ENV, "   ");
+        }
+        // With the env var blank, resolution falls through to the discovery
+        // file — assert only that the env var itself did not win.
+        let result = candidate_url();
+        unsafe {
+            std::env::remove_var(DAEMON_URL_ENV);
+        }
+        if let Some((_, source)) = result {
+            assert_ne!(source, Source::Env);
+        }
+    }
+
+    /// `DiscoveryError::NotFound`'s message must name the actionable fix
+    /// (start a daemon, or set the env var) — pinned so a future edit can't
+    /// silently regress it into an unhelpful "not found".
+    #[test]
+    fn not_found_message_is_actionable() {
+        let msg = DiscoveryError::NotFound.to_string();
+        assert!(msg.contains("tcode serve --http"));
+        assert!(msg.contains(DAEMON_URL_ENV));
+    }
+
+    /// `DiscoveryError::NotAlive`'s message must name both the dead URL and
+    /// which source produced it.
+    #[test]
+    fn not_alive_message_names_url_and_source() {
+        let err = DiscoveryError::NotAlive {
+            url: "http://127.0.0.1:7882".to_string(),
+            found_via: Source::File.as_str(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("http://127.0.0.1:7882"));
+        assert!(msg.contains("discovery file"));
+    }
+}

--- a/crates/trusty-code/src/tui_client/engine.rs
+++ b/crates/trusty-code/src/tui_client/engine.rs
@@ -14,10 +14,14 @@
 //! What: [`CodeEngine`] is a thin `Arc<EngineState>` wrapper so the
 //! background workstream-subscription task spawned by
 //! `subscribe_workstream_events` can share the SAME state (and refresh the
-//! SAME caches) without a second, divergent copy. Ahead of `trusty-tui`
-//! Slice 1.5's SYNCHRONOUS `TuiEngine::commands()`/`picker(name)`
-//! accessors (#3428) — see [`CodeEngine::commands`]/[`CodeEngine::picker`]'s
-//! docs.
+//! SAME caches) without a second, divergent copy. `trusty-tui` Slice 1.5
+//! (#3428, merged) added the SYNCHRONOUS `TuiEngine::commands()`/
+//! `picker(name)` accessors this `impl TuiEngine` block implements directly
+//! (not as inherent methods — see the `impl TuiEngine for CodeEngine`
+//! block's `commands`/`picker` for why serving from `EngineState`'s
+//! `std::sync::Mutex`-guarded caches, populated during `setup()`, is the
+//! only way to satisfy a synchronous trait method with no I/O on the
+//! calling path).
 //! Test: `engine_tests::*` (in the sibling `engine_tests.rs`, included
 //! below) for the pure event-mapping/parsing helpers this module's siblings
 //! define; the full discover -> setup -> stream -> cancel ->
@@ -31,7 +35,7 @@ use std::time::Duration;
 
 use serde_json::{Value, json};
 use tokio::sync::mpsc::UnboundedSender;
-use trusty_tui::{CommandDescriptor, PickerItem, ReplEvent, TuiEngine};
+use trusty_tui::{CommandDescriptor, CommandRouting, PickerRequest, ReplEvent, TuiEngine};
 
 use super::discovery::discover_daemon_url;
 use super::engine_state::EngineState;
@@ -128,25 +132,6 @@ impl CodeEngine {
     pub fn daemon_url(&self) -> &str {
         self.state.rpc.base_url()
     }
-
-    /// Engine-routed slash commands this MVP supports (ahead of
-    /// `trusty-tui` Slice 1.5's synchronous `TuiEngine::commands()`, #3428 —
-    /// see module docs). Returns the cache populated during `setup()`;
-    /// **move this into the `impl TuiEngine for CodeEngine` block once this
-    /// crate rebases onto the trait revision that declares `commands()`.**
-    pub fn commands(&self) -> Vec<CommandDescriptor> {
-        self.state.commands()
-    }
-
-    /// Picker items for `name` (ahead of `trusty-tui` Slice 1.5's
-    /// synchronous `TuiEngine::picker(name)`, #3428 — see module docs).
-    /// Returns the cache populated during `setup()`/refreshed on workstream
-    /// changes; `[]` for an unknown picker name. **Move this into the
-    /// `impl TuiEngine for CodeEngine` block once this crate rebases onto
-    /// the trait revision that declares `picker()`.**
-    pub fn picker(&self, name: &str) -> Vec<PickerItem> {
-        self.state.picker(name)
-    }
 }
 
 #[async_trait::async_trait]
@@ -187,8 +172,8 @@ impl TuiEngine for CodeEngine {
             .lock()
             .unwrap_or_else(|e| e.into_inner()) = Some(session_id.clone());
 
-        // Ahead-of-Slice-1.5 `commands()` cache — see struct docs. The one
-        // engine-routed command this MVP supports.
+        // `TuiEngine::commands()` cache — see `EngineState`'s struct docs.
+        // The one engine-routed command this MVP supports.
         *self
             .state
             .commands_cache
@@ -196,6 +181,8 @@ impl TuiEngine for CodeEngine {
             .unwrap_or_else(|e| e.into_inner()) = vec![CommandDescriptor {
             name: "workstream".to_string(),
             summary: "List or activate the daemon's workstreams".to_string(),
+            routing: CommandRouting::Engine,
+            args_hint: Some("[list | activate <id>]".to_string()),
         }];
 
         if let Some(ws) = self.state.refresh_workstream_cache().await {
@@ -264,6 +251,37 @@ impl TuiEngine for CodeEngine {
     async fn shutdown(&self) -> anyhow::Result<()> {
         self.state.shutting_down.store(true, Ordering::SeqCst);
         Ok(())
+    }
+
+    /// Engine-routed slash commands this MVP supports — served from the
+    /// cache `setup()` populates (`EngineState::commands_cache`). This is a
+    /// SYNCHRONOUS trait method (#3428) — the cache exists precisely so
+    /// this never needs to perform network I/O on the calling path; see
+    /// `EngineState::commands`'s docs for the `std::sync::Mutex` rationale.
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        self.state.commands()
+    }
+
+    /// The `"workstream"` picker — served from the cache
+    /// `EngineState::refresh_workstream_cache` populates (in `setup()`,
+    /// after `/workstream activate`, and on every observed
+    /// `WorkstreamActivationChanged`). `None` for any other picker name
+    /// (this engine has exactly one) or before the cache has been
+    /// populated at least once. `dispatch_command` is `"/workstream
+    /// activate"` — matching `workstream_subcommand`'s parsing exactly, so
+    /// the shared event loop's `"{dispatch_command} {selected.id}"`
+    /// resubmission (`"/workstream activate <id>"`) round-trips through
+    /// `handle_input` correctly.
+    fn picker(&self, name: &str) -> Option<PickerRequest> {
+        if name != "workstream" {
+            return None;
+        }
+        let items = self.state.picker_items("workstream")?;
+        Some(PickerRequest {
+            title: "Workstreams".to_string(),
+            items,
+            dispatch_command: "/workstream activate".to_string(),
+        })
     }
 }
 

--- a/crates/trusty-code/src/tui_client/engine.rs
+++ b/crates/trusty-code/src/tui_client/engine.rs
@@ -1,0 +1,966 @@
+//! [`CodeEngine`]: the `trusty_tui::TuiEngine` adapter driving a long-lived
+//! `tcode serve --http` daemon (issue #3415, DOC-50 §3.3/§3.4).
+//!
+//! Why: see `crate::tui_client`'s module docs for the ephemeral-`--stdio`
+//! vs. long-lived-`--http` client distinction. This module is the `TuiEngine`
+//! impl itself — everything else in `tui_client` (`discovery`, `rpc`, `sse`)
+//! exists to support it.
+//! What: [`EngineState`] holds every piece of daemon-observed state this
+//! client caches (current session id, last-known active workstream, and —
+//! ahead of `trusty-tui` Slice 1.5's SYNCHRONOUS `TuiEngine::commands()`/
+//! `picker(name)` accessors (#3428, landing into `crates/trusty-tui`
+//! alongside this slice) — a `commands`/`picker` cache populated during the
+//! async `setup()`/event-handling paths so those future sync accessors never
+//! need to perform network I/O inline (see [`EngineState::commands`]/
+//! [`EngineState::picker`]'s docs for why `std::sync::Mutex`, not
+//! `tokio::sync::Mutex`, guards this state). `CodeEngine` itself is a thin
+//! `Arc<EngineState>` wrapper so the background workstream-subscription task
+//! spawned by `subscribe_workstream_events` can share the SAME state (and
+//! refresh the SAME caches) without a second, divergent copy.
+//! Test: `engine_tests::*` for the pure event-mapping/parsing helpers below;
+//! the full discover -> setup -> stream -> cancel -> workstream-activation
+//! flow against a mock HTTP daemon lives in `tests/tui_client_engine.rs`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use serde_json::{Value, json};
+use tokio::sync::mpsc::UnboundedSender;
+use trusty_tui::{CommandDescriptor, PickerItem, ReplEvent, TuiEngine, WorkstreamSummary};
+
+use crate::events::{Event, SessionEventEnvelope};
+
+use super::discovery::discover_daemon_url;
+use super::error::EngineError;
+use super::rpc::RpcHttpClient;
+use super::sse::SseLines;
+
+/// How long a session-event / workstream-event SSE read may sit idle (no
+/// bytes, not even a keep-alive comment) before this client treats the
+/// connection as dead and reconnects. Axum's default `KeepAlive` sends a
+/// comment roughly every 15s (`crate::serve::http::session_events_sse`'s
+/// `KeepAlive::default()`), so three missed beats is a generous margin
+/// before declaring the daemon unreachable.
+const SSE_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
+
+/// Fixed backoff between SSE reconnect attempts. Not exponential — MVP
+/// scope (DOC-50 §5 Slice 3); a persistently-down daemon retries at a
+/// steady, human-visible cadence rather than hot-looping.
+const RECONNECT_BACKOFF: Duration = Duration::from_secs(2);
+
+/// How many times [`EngineState::pump_session_events`] reconnects before
+/// giving up and returning control to the caller (`handle_input` must
+/// eventually return so the REPL's input loop stays responsive — unlike the
+/// workstream-activation subscription, which is meant to run for the whole
+/// TUI session).
+const SESSION_STREAM_MAX_RECONNECTS: u32 = 5;
+
+/// Every piece of daemon-observed state [`CodeEngine`] caches, shared (via
+/// `Arc`) between the foreground `TuiEngine` calls and the background
+/// workstream-subscription task.
+struct EngineState {
+    rpc: RpcHttpClient,
+    /// Project root to bind the session to, if any (mirrors `session.create`'s
+    /// `project` param — see `crate::session::protocol::create`'s docs).
+    project_path: Option<PathBuf>,
+    session_id: Mutex<Option<String>>,
+    active_workstream: Mutex<Option<WorkstreamSummary>>,
+    /// Ahead-of-Slice-1.5 cache for `TuiEngine::commands()` (#3428) — see
+    /// module docs. Populated once, in `setup()`; static for this MVP (the
+    /// one engine-routed command, `/workstream`, never changes at runtime).
+    commands_cache: Mutex<Vec<CommandDescriptor>>,
+    /// Ahead-of-Slice-1.5 cache for `TuiEngine::picker(name)` (#3428) — see
+    /// module docs. Keyed by picker name (matches the DOC-50-noted
+    /// convention that a command name doubles as its picker name, e.g.
+    /// `/workstream` <-> `picker("workstream")`). Refreshed in `setup()`,
+    /// after a successful `/workstream activate`, and whenever the
+    /// background subscription observes a `WorkstreamActivationChanged`
+    /// event — see [`EngineState::refresh_workstream_cache`].
+    picker_cache: Mutex<HashMap<String, Vec<PickerItem>>>,
+    shutting_down: AtomicBool,
+}
+
+impl EngineState {
+    /// `std::sync::Mutex`, not `tokio::sync::Mutex` — see module docs:
+    /// `commands()`/`picker()` are, per #3428, plain synchronous `fn`s (no
+    /// `.await` available), so the cache they read MUST be lockable without
+    /// an async runtime. Every lock here is held only long enough to clone a
+    /// small `Vec`/`Option` — never across an `.await` point.
+    fn commands(&self) -> Vec<CommandDescriptor> {
+        self.commands_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    fn picker(&self, name: &str) -> Vec<PickerItem> {
+        self.picker_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(name)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Re-fetch `workstream.list` and refresh both `active_workstream` and
+    /// the `"workstream"` picker cache entry. Best-effort: an RPC failure
+    /// here (daemon transiently unreachable) leaves the previous cache
+    /// contents in place rather than clearing them — a stale picker list is
+    /// strictly better than an empty one.
+    async fn refresh_workstream_cache(&self) -> Option<WorkstreamSummary> {
+        let result = self.rpc.call("workstream.list", json!({})).await.ok()?;
+        let active_id = result
+            .get("active_workstream_id")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let workstreams: Vec<Value> = result
+            .get("workstreams")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        let items: Vec<PickerItem> = workstreams
+            .iter()
+            .filter_map(|w| {
+                let id = w.get("id").and_then(Value::as_str)?.to_string();
+                let name = w.get("name").and_then(Value::as_str).unwrap_or_default();
+                let label = if name.is_empty() {
+                    id.clone()
+                } else {
+                    name.to_string()
+                };
+                Some(PickerItem { id, label })
+            })
+            .collect();
+        *self.picker_cache.lock().unwrap_or_else(|e| e.into_inner()) = {
+            let mut map = HashMap::new();
+            map.insert("workstream".to_string(), items);
+            map
+        };
+
+        let active = active_id.and_then(|id| {
+            workstreams
+                .iter()
+                .find(|w| w.get("id").and_then(Value::as_str) == Some(id.as_str()))
+                .map(|w| WorkstreamSummary {
+                    id: id.clone(),
+                    name: w
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                })
+                .or(Some(WorkstreamSummary {
+                    id,
+                    name: String::new(),
+                }))
+        });
+        *self
+            .active_workstream
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = active.clone();
+        active
+    }
+
+    /// Route one submitted `/workstream`/`/ws` subcommand (`rest` is
+    /// whatever followed the command name, already trimmed; empty means
+    /// "no subcommand" -> defaults to `list`).
+    async fn handle_workstream_command(
+        &self,
+        rest: &str,
+        tx: &UnboundedSender<ReplEvent>,
+    ) -> Result<(), EngineError> {
+        if rest.is_empty() || rest == "list" {
+            let ws = self.refresh_workstream_cache().await;
+            let items = self.picker("workstream");
+            let active_id = ws.as_ref().map(|w| w.id.as_str());
+            let rows: Vec<String> = items
+                .iter()
+                .map(|item| {
+                    let marker = if Some(item.id.as_str()) == active_id {
+                        "*"
+                    } else {
+                        " "
+                    };
+                    format!("{marker} {} {}", item.id, item.label)
+                })
+                .collect();
+            let msg = if rows.is_empty() {
+                "no workstreams".to_string()
+            } else {
+                rows.join("\n")
+            };
+            let _ = tx.send(ReplEvent::StatusMessage(msg));
+            return Ok(());
+        }
+
+        if let Some(id) = rest.strip_prefix("activate ") {
+            let id = id.trim().to_string();
+            let result = self
+                .rpc
+                .call("workstream.activate", json!({ "id": id }))
+                .await?;
+            let active_id = result
+                .get("active_id")
+                .and_then(Value::as_str)
+                .unwrap_or(&id)
+                .to_string();
+            let ws = self
+                .refresh_workstream_cache()
+                .await
+                .unwrap_or(WorkstreamSummary {
+                    id: active_id.clone(),
+                    name: String::new(),
+                });
+            let _ = tx.send(ReplEvent::WorkstreamUpdated(ws));
+            let _ = tx.send(ReplEvent::StatusMessage(format!(
+                "activated workstream {active_id}"
+            )));
+            return Ok(());
+        }
+
+        let _ = tx.send(ReplEvent::StatusMessage(format!(
+            "unknown /workstream subcommand: {rest} (try `list` or `activate <id>`)"
+        )));
+        Ok(())
+    }
+
+    /// Send one chat line as a fresh `task.run` against the current session,
+    /// then stream its response back via [`Self::pump_session_events`].
+    async fn run_chat_turn(
+        &self,
+        line: &str,
+        tx: &UnboundedSender<ReplEvent>,
+    ) -> Result<(), EngineError> {
+        let session_id = {
+            self.session_id
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
+        }
+        .ok_or(EngineError::NoSession)?;
+        self.rpc
+            .call(
+                "task.run",
+                json!({
+                    "task_description": line,
+                    "session_id": session_id,
+                }),
+            )
+            .await?;
+        self.pump_session_events(&session_id, tx).await
+    }
+
+    /// Stream `GET /sessions/{session_id}/events` until a terminal event
+    /// (`SessionDone`/`SessionCancelled`) is observed, translating every
+    /// event into `ReplEvent`s along the way. Reconnects (bounded by
+    /// [`SESSION_STREAM_MAX_RECONNECTS`]) on a `502`/`503` status, a
+    /// transport error, an idle timeout, or a clean-but-premature stream
+    /// close — surfacing each as `ReplEvent::ConnectionLost` first.
+    async fn pump_session_events(
+        &self,
+        session_id: &str,
+        tx: &UnboundedSender<ReplEvent>,
+    ) -> Result<(), EngineError> {
+        let url = format!("{}/sessions/{session_id}/events", self.rpc.base_url());
+        let mut attempts = 0u32;
+        'reconnect: loop {
+            let resp = match self.rpc.http().get(&url).send().await {
+                Ok(r) if r.status().is_success() => r,
+                Ok(r) => {
+                    let status = r.status();
+                    if is_retryable_status(status) && attempts < SESSION_STREAM_MAX_RECONNECTS {
+                        attempts += 1;
+                        let _ = tx.send(ReplEvent::ConnectionLost {
+                            reason: format!("daemon returned {status}; reconnecting…"),
+                        });
+                        tokio::time::sleep(RECONNECT_BACKOFF).await;
+                        continue 'reconnect;
+                    }
+                    return Err(EngineError::Status { url, status });
+                }
+                Err(source) => {
+                    if attempts < SESSION_STREAM_MAX_RECONNECTS {
+                        attempts += 1;
+                        let _ = tx.send(ReplEvent::ConnectionLost {
+                            reason: format!("connection failed: {source}; reconnecting…"),
+                        });
+                        tokio::time::sleep(RECONNECT_BACKOFF).await;
+                        continue 'reconnect;
+                    }
+                    return Err(EngineError::Transport { url, source });
+                }
+            };
+            attempts = 0;
+            let mut lines = SseLines::new(resp);
+            loop {
+                match tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_data()).await {
+                    Ok(Ok(Some(payload))) => {
+                        let Ok(envelope) = serde_json::from_str::<SessionEventEnvelope>(&payload)
+                        else {
+                            continue;
+                        };
+                        if forward_session_event(envelope, tx) {
+                            return Ok(());
+                        }
+                    }
+                    Ok(Ok(None)) => {
+                        if attempts < SESSION_STREAM_MAX_RECONNECTS {
+                            attempts += 1;
+                            let _ = tx.send(ReplEvent::ConnectionLost {
+                                reason: "daemon closed the event stream; reconnecting…".to_string(),
+                            });
+                            tokio::time::sleep(RECONNECT_BACKOFF).await;
+                            continue 'reconnect;
+                        }
+                        return Ok(());
+                    }
+                    Ok(Err(source)) => {
+                        if attempts < SESSION_STREAM_MAX_RECONNECTS {
+                            attempts += 1;
+                            let _ = tx.send(ReplEvent::ConnectionLost {
+                                reason: format!("stream error: {source}; reconnecting…"),
+                            });
+                            tokio::time::sleep(RECONNECT_BACKOFF).await;
+                            continue 'reconnect;
+                        }
+                        return Err(EngineError::Transport { url, source });
+                    }
+                    Err(_elapsed) => {
+                        if attempts < SESSION_STREAM_MAX_RECONNECTS {
+                            attempts += 1;
+                            let _ = tx.send(ReplEvent::ConnectionLost {
+                                reason: "no data from daemon within the idle timeout; \
+                                         reconnecting…"
+                                    .to_string(),
+                            });
+                            tokio::time::sleep(RECONNECT_BACKOFF).await;
+                            continue 'reconnect;
+                        }
+                        return Err(EngineError::Status {
+                            url,
+                            status: reqwest::StatusCode::REQUEST_TIMEOUT,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `true` for HTTP statuses worth retrying (daemon restarting) rather than
+/// failing immediately.
+fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::BAD_GATEWAY || status == reqwest::StatusCode::SERVICE_UNAVAILABLE
+}
+
+/// Translate one [`SessionEventEnvelope`] into zero or more [`ReplEvent`]s
+/// on `tx`. Returns `true` iff this event is terminal for the current chat
+/// turn (`SessionDone`/`SessionCancelled`) — the caller stops pumping.
+///
+/// Why: kept as a free function (not a method) so it's directly unit
+/// testable against a hand-built envelope, no HTTP/mock server needed.
+/// What: `Message`/`AgentMessage`/`PmThinking` -> `AssistantOutput` chunks
+/// (`done: false`); `ToolStarted` -> `ToolInvocation{result: None}`;
+/// `ToolFinished`/`ToolError` -> `ToolInvocation{result: Some(..)}`, keyed
+/// by the SAME `call_id` so the (future) tool-card renderer can pair them;
+/// `SessionDone` -> a final `AssistantOutput{done: true}` (`is_error` iff
+/// `status == "failed"`); `SessionCancelled` -> a status message. Every
+/// other event kind (progress/telemetry/agent-lifecycle events this MVP
+/// doesn't yet render) is silently ignored — forward-compatible with new
+/// `Event` variants (no `match` arm needed per new kind, thanks to the
+/// catch-all).
+/// Test: `engine_tests::forward_message_emits_assistant_output_chunk_not_done`,
+/// `engine_tests::forward_tool_started_emits_tool_invocation_with_call_id`,
+/// `engine_tests::forward_tool_finished_carries_result_and_shares_call_id`,
+/// `engine_tests::forward_session_done_is_terminal`,
+/// `engine_tests::forward_session_done_failed_marks_is_error`,
+/// `engine_tests::forward_session_cancelled_is_terminal`,
+/// `engine_tests::forward_unrelated_event_is_ignored`.
+fn forward_session_event(envelope: SessionEventEnvelope, tx: &UnboundedSender<ReplEvent>) -> bool {
+    match envelope.event {
+        Event::Message { text, .. }
+        | Event::AgentMessage { text, .. }
+        | Event::PmThinking { text, .. } => {
+            let _ = tx.send(ReplEvent::AssistantOutput {
+                chunk: text,
+                done: false,
+                is_error: false,
+            });
+            false
+        }
+        Event::ToolStarted {
+            tool,
+            call_id,
+            args_preview,
+            ..
+        } => {
+            let _ = tx.send(ReplEvent::ToolInvocation {
+                id: call_id,
+                tool_name: tool,
+                args: json!(args_preview),
+                result: None,
+            });
+            false
+        }
+        Event::ToolFinished {
+            tool,
+            call_id,
+            result_preview,
+            success,
+            ..
+        } => {
+            let result = if success {
+                result_preview
+            } else {
+                format!("FAILED: {result_preview}")
+            };
+            let _ = tx.send(ReplEvent::ToolInvocation {
+                id: call_id,
+                tool_name: tool,
+                args: Value::Null,
+                result: Some(result),
+            });
+            false
+        }
+        Event::ToolError {
+            tool,
+            call_id,
+            error,
+            ..
+        } => {
+            let _ = tx.send(ReplEvent::ToolInvocation {
+                id: call_id,
+                tool_name: tool,
+                args: Value::Null,
+                result: Some(format!("ERROR: {error}")),
+            });
+            false
+        }
+        Event::SessionDone { status, .. } => {
+            let _ = tx.send(ReplEvent::AssistantOutput {
+                chunk: String::new(),
+                done: true,
+                is_error: status == "failed",
+            });
+            true
+        }
+        Event::SessionCancelled { .. } => {
+            let _ = tx.send(ReplEvent::StatusMessage("cancelled".to_string()));
+            true
+        }
+        _ => false,
+    }
+}
+
+/// The AC-7.2 wire envelope this client deserialises off
+/// `GET /workstreams/{id}/events` — mirrors
+/// `crate::workstreams::sse::WorkstreamEventEnvelope`
+/// (`trusty_agents_common::transport::EventEnvelope<Event>`) exactly, but
+/// with `Deserialize` (the shared type only derives `Serialize` — it's
+/// built server-side, never parsed) — see module docs for why a small
+/// mirror struct here is preferable to adding `Deserialize` to the shared
+/// type for one client.
+#[derive(Debug, serde::Deserialize)]
+struct WireWorkstreamEnvelope {
+    #[allow(dead_code)]
+    session_id: String,
+    #[allow(dead_code)]
+    event_type: String,
+    payload: Event,
+}
+
+fn parse_workstream_envelope(payload_json: &str) -> Option<WireWorkstreamEnvelope> {
+    serde_json::from_str(payload_json).ok()
+}
+
+/// Whether `rest` (already trimmed) names the `/workstream`/`/ws`
+/// engine-routed command, and if so, what follows it (empty string if bare).
+///
+/// Why: kept pure (no `&self`) so slash-command recognition is unit
+/// testable without constructing an engine. Requires a word boundary after
+/// the command name (a bare `strip_prefix` would wrongly match
+/// `"/workstreamx"`).
+fn workstream_subcommand(line: &str) -> Option<&str> {
+    let trimmed = line.trim();
+    for prefix in ["/workstream", "/ws"] {
+        if trimmed == prefix {
+            return Some("");
+        }
+        if let Some(rest) = trimmed.strip_prefix(prefix)
+            && let Some(rest) = rest.strip_prefix(' ')
+        {
+            return Some(rest.trim());
+        }
+    }
+    None
+}
+
+/// Long-lived background loop for `subscribe_workstream_events`: holds one
+/// SSE connection to `GET /workstreams/{current_id}/events` at a time,
+/// reconnecting (to a possibly-NEW workstream id, per DOC-48 §5.3 point 5)
+/// on activation changes, transport errors, or idle timeouts, until
+/// `state.shutting_down` is set.
+async fn run_workstream_subscription(
+    state: Arc<EngineState>,
+    mut current_id: String,
+    tx: UnboundedSender<ReplEvent>,
+) {
+    loop {
+        if state.shutting_down.load(Ordering::SeqCst) {
+            return;
+        }
+        let url = format!("{}/workstreams/{current_id}/events", state.rpc.base_url());
+        let resp = match state.rpc.http().get(&url).send().await {
+            Ok(r) if r.status().is_success() => r,
+            _ => {
+                let _ = tx.send(ReplEvent::ConnectionLost {
+                    reason: format!(
+                        "could not reach workstream events endpoint for {current_id}; retrying…"
+                    ),
+                });
+                tokio::time::sleep(RECONNECT_BACKOFF).await;
+                continue;
+            }
+        };
+
+        let mut lines = SseLines::new(resp);
+        loop {
+            if state.shutting_down.load(Ordering::SeqCst) {
+                return;
+            }
+            match tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_data()).await {
+                Ok(Ok(Some(payload))) => {
+                    let Some(env) = parse_workstream_envelope(&payload) else {
+                        continue;
+                    };
+                    if let Event::WorkstreamActivationChanged {
+                        new_active_id: Some(new_id),
+                        prior_id,
+                    } = env.payload
+                    {
+                        let _ = tx.send(ReplEvent::WorkstreamActivationChanged {
+                            new_active_id: new_id.clone(),
+                            prior_id,
+                        });
+                        state.refresh_workstream_cache().await;
+                        if new_id != current_id {
+                            current_id = new_id;
+                            break; // reconnect to the newly-active workstream's endpoint
+                        }
+                    }
+                }
+                Ok(Ok(None)) => {
+                    let _ = tx.send(ReplEvent::ConnectionLost {
+                        reason: "workstream event stream closed; reconnecting…".to_string(),
+                    });
+                    tokio::time::sleep(RECONNECT_BACKOFF).await;
+                    break;
+                }
+                Ok(Err(_)) | Err(_) => {
+                    let _ = tx.send(ReplEvent::ConnectionLost {
+                        reason: "workstream event stream error; reconnecting…".to_string(),
+                    });
+                    tokio::time::sleep(RECONNECT_BACKOFF).await;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn build_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .pool_idle_timeout(Duration::from_secs(90))
+        .connect_timeout(Duration::from_secs(5))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+/// The `trusty_tui::TuiEngine` adapter for `tcode tui` — see module docs.
+pub struct CodeEngine {
+    state: Arc<EngineState>,
+}
+
+impl CodeEngine {
+    /// Discover a running `tcode serve --http` daemon (per
+    /// `crate::tui_client::discovery`'s priority) and build a `CodeEngine`
+    /// targeting it. `project_path` is forwarded to `session.create` in
+    /// `setup()` (mirrors `session::protocol::create`'s `project` param —
+    /// `None` is a fully valid, projectless session).
+    pub async fn discover(project_path: Option<PathBuf>) -> Result<Self, EngineError> {
+        let http = build_http_client();
+        let base_url = discover_daemon_url(&http).await?;
+        Ok(Self::with_daemon_url(http, base_url, project_path))
+    }
+
+    /// Build a `CodeEngine` targeting an explicit daemon URL, bypassing
+    /// discovery — the constructor every test in `tests/tui_client_engine.rs`
+    /// uses (against a `wiremock`-mocked daemon).
+    pub fn with_daemon_url(
+        http: reqwest::Client,
+        base_url: impl Into<String>,
+        project_path: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            state: Arc::new(EngineState {
+                rpc: RpcHttpClient::new(http, base_url.into()),
+                project_path,
+                session_id: Mutex::new(None),
+                active_workstream: Mutex::new(None),
+                commands_cache: Mutex::new(Vec::new()),
+                picker_cache: Mutex::new(HashMap::new()),
+                shutting_down: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// The daemon URL this engine targets (test/debug convenience).
+    pub fn daemon_url(&self) -> &str {
+        self.state.rpc.base_url()
+    }
+
+    /// Engine-routed slash commands this MVP supports (ahead of
+    /// `trusty-tui` Slice 1.5's synchronous `TuiEngine::commands()`, #3428 —
+    /// see module docs). Returns the cache populated during `setup()`;
+    /// **move this into the `impl TuiEngine for CodeEngine` block once this
+    /// crate rebases onto the trait revision that declares `commands()`.**
+    pub fn commands(&self) -> Vec<CommandDescriptor> {
+        self.state.commands()
+    }
+
+    /// Picker items for `name` (ahead of `trusty-tui` Slice 1.5's
+    /// synchronous `TuiEngine::picker(name)`, #3428 — see module docs).
+    /// Returns the cache populated during `setup()`/refreshed on workstream
+    /// changes; `[]` for an unknown picker name. **Move this into the
+    /// `impl TuiEngine for CodeEngine` block once this crate rebases onto
+    /// the trait revision that declares `picker()`.**
+    pub fn picker(&self, name: &str) -> Vec<PickerItem> {
+        self.state.picker(name)
+    }
+}
+
+#[async_trait::async_trait]
+impl TuiEngine for CodeEngine {
+    async fn handle_input(
+        &self,
+        line: String,
+        tx: UnboundedSender<ReplEvent>,
+    ) -> anyhow::Result<bool> {
+        if let Some(rest) = workstream_subcommand(&line) {
+            self.state.handle_workstream_command(rest, &tx).await?;
+            return Ok(true);
+        }
+        self.state.run_chat_turn(line.trim(), &tx).await?;
+        Ok(true)
+    }
+
+    async fn setup(&self, tx: UnboundedSender<ReplEvent>) -> anyhow::Result<()> {
+        let result = self
+            .state
+            .rpc
+            .call(
+                "session.create",
+                json!({
+                    "task": "tcode tui session",
+                    "project": self.state.project_path,
+                }),
+            )
+            .await?;
+        let session_id = result
+            .get("id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| EngineError::Malformed("session.create: response missing `id`".into()))?
+            .to_string();
+        *self
+            .state
+            .session_id
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = Some(session_id.clone());
+
+        // Ahead-of-Slice-1.5 `commands()` cache — see struct docs. The one
+        // engine-routed command this MVP supports.
+        *self
+            .state
+            .commands_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = vec![CommandDescriptor {
+            name: "workstream".to_string(),
+            summary: "List or activate the daemon's workstreams".to_string(),
+        }];
+
+        if let Some(ws) = self.state.refresh_workstream_cache().await {
+            let _ = tx.send(ReplEvent::WorkstreamUpdated(ws));
+        }
+
+        let _ = tx.send(ReplEvent::StatusMessage(format!(
+            "connected to tcode daemon at {} (session {session_id})",
+            self.state.rpc.base_url(),
+        )));
+        Ok(())
+    }
+
+    async fn cancel_session(&self) -> anyhow::Result<()> {
+        let session_id = {
+            self.state
+                .session_id
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
+        };
+        let Some(session_id) = session_id else {
+            return Ok(());
+        };
+        // Thin-client axiom (DOC-39 §2.1 C-2): the daemon performs the real
+        // cancellation via `session.cancel` — this call is not optional
+        // client-side render-stop.
+        self.state
+            .rpc
+            .call("session.cancel", json!({ "session_id": session_id }))
+            .await?;
+        Ok(())
+    }
+
+    async fn subscribe_workstream_events(
+        &self,
+        tx: UnboundedSender<ReplEvent>,
+    ) -> anyhow::Result<()> {
+        let current_id = {
+            self.state
+                .active_workstream
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
+        }
+        .map(|ws| ws.id);
+        // No workstream is known yet: DOC-48 §5.3's SSE fan-out is scoped
+        // PER workstream id (there is no daemon-wide "tell me about any
+        // future activation" feed), so there is genuinely nothing to
+        // subscribe to until at least one workstream id is known. See this
+        // crate's PR description for this as a reported daemon-API gap
+        // rather than a client-side workaround — matches the default no-op
+        // `TuiEngine::subscribe_workstream_events` contract for engines with
+        // no push transport available right now.
+        let Some(current_id) = current_id else {
+            return Ok(());
+        };
+        tokio::spawn(run_workstream_subscription(
+            self.state.clone(),
+            current_id,
+            tx,
+        ));
+        Ok(())
+    }
+
+    async fn shutdown(&self) -> anyhow::Result<()> {
+        self.state.shutting_down.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod engine_tests {
+    use super::*;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    fn envelope(event: Event) -> SessionEventEnvelope {
+        SessionEventEnvelope::new("s-1".to_string(), 1, chrono::Utc::now(), event)
+    }
+
+    #[test]
+    fn forward_message_emits_assistant_output_chunk_not_done() {
+        let (tx, mut rx) = unbounded_channel();
+        let terminal = forward_session_event(
+            envelope(Event::Message {
+                session_id: "s-1".into(),
+                text: "hi".into(),
+            }),
+            &tx,
+        );
+        assert!(!terminal);
+        assert_eq!(
+            rx.try_recv().expect("event"),
+            ReplEvent::AssistantOutput {
+                chunk: "hi".into(),
+                done: false,
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn forward_tool_started_emits_tool_invocation_with_call_id() {
+        let (tx, mut rx) = unbounded_channel();
+        let terminal = forward_session_event(
+            envelope(Event::ToolStarted {
+                session_id: "s-1".into(),
+                agent: "pm".into(),
+                agent_id: String::new(),
+                tool: "bash".into(),
+                call_id: "call-1".into(),
+                args_preview: "ls".into(),
+            }),
+            &tx,
+        );
+        assert!(!terminal);
+        match rx.try_recv().expect("event") {
+            ReplEvent::ToolInvocation {
+                id,
+                tool_name,
+                result,
+                ..
+            } => {
+                assert_eq!(id, "call-1");
+                assert_eq!(tool_name, "bash");
+                assert!(result.is_none());
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forward_tool_finished_carries_result_and_shares_call_id() {
+        let (tx, mut rx) = unbounded_channel();
+        forward_session_event(
+            envelope(Event::ToolFinished {
+                session_id: "s-1".into(),
+                agent: "pm".into(),
+                agent_id: String::new(),
+                tool: "bash".into(),
+                call_id: "call-1".into(),
+                success: true,
+                result_preview: "done".into(),
+            }),
+            &tx,
+        );
+        match rx.try_recv().expect("event") {
+            ReplEvent::ToolInvocation { id, result, .. } => {
+                assert_eq!(id, "call-1");
+                assert_eq!(result.as_deref(), Some("done"));
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn forward_session_done_is_terminal() {
+        let (tx, mut rx) = unbounded_channel();
+        let terminal = forward_session_event(
+            envelope(Event::SessionDone {
+                session_id: "s-1".into(),
+                status: "finished".into(),
+            }),
+            &tx,
+        );
+        assert!(terminal);
+        assert_eq!(
+            rx.try_recv().expect("event"),
+            ReplEvent::AssistantOutput {
+                chunk: String::new(),
+                done: true,
+                is_error: false,
+            }
+        );
+    }
+
+    #[test]
+    fn forward_session_done_failed_marks_is_error() {
+        let (tx, mut rx) = unbounded_channel();
+        forward_session_event(
+            envelope(Event::SessionDone {
+                session_id: "s-1".into(),
+                status: "failed".into(),
+            }),
+            &tx,
+        );
+        assert_eq!(
+            rx.try_recv().expect("event"),
+            ReplEvent::AssistantOutput {
+                chunk: String::new(),
+                done: true,
+                is_error: true,
+            }
+        );
+    }
+
+    #[test]
+    fn forward_session_cancelled_is_terminal() {
+        let (tx, mut rx) = unbounded_channel();
+        let terminal = forward_session_event(
+            envelope(Event::SessionCancelled {
+                session_id: "s-1".into(),
+            }),
+            &tx,
+        );
+        assert!(terminal);
+        assert!(rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn forward_unrelated_event_is_ignored() {
+        let (tx, mut rx) = unbounded_channel();
+        let terminal = forward_session_event(envelope(Event::Ping), &tx);
+        assert!(!terminal);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn workstream_subcommand_parses_list_and_activate() {
+        assert_eq!(workstream_subcommand("/workstream list"), Some("list"));
+        assert_eq!(
+            workstream_subcommand("/ws activate abc-123"),
+            Some("activate abc-123")
+        );
+        assert_eq!(workstream_subcommand("/workstream"), Some(""));
+        assert_eq!(workstream_subcommand("/workstreamx foo"), None);
+        assert_eq!(workstream_subcommand("hello"), None);
+    }
+
+    #[test]
+    fn parse_workstream_envelope_round_trips_activation_changed() {
+        let json = serde_json::json!({
+            "session_id": "",
+            "event_type": "workstream_activation_changed",
+            "payload": {
+                "type": "workstream_activation_changed",
+                "new_active_id": "ws-2",
+                "prior_id": "ws-1",
+            },
+        })
+        .to_string();
+        let env = parse_workstream_envelope(&json).expect("parse");
+        match env.payload {
+            Event::WorkstreamActivationChanged {
+                new_active_id,
+                prior_id,
+            } => {
+                assert_eq!(new_active_id.as_deref(), Some("ws-2"));
+                assert_eq!(prior_id.as_deref(), Some("ws-1"));
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn is_retryable_status_covers_502_and_503_only() {
+        assert!(is_retryable_status(reqwest::StatusCode::BAD_GATEWAY));
+        assert!(is_retryable_status(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE
+        ));
+        assert!(!is_retryable_status(reqwest::StatusCode::NOT_FOUND));
+    }
+
+    /// The caches must start empty before `setup()` populates them —
+    /// `commands()`/`picker()` must degrade to "nothing yet," never panic,
+    /// when queried before `setup()` runs.
+    #[test]
+    fn caches_are_empty_before_setup() {
+        let engine =
+            CodeEngine::with_daemon_url(reqwest::Client::new(), "http://127.0.0.1:1", None);
+        assert!(engine.commands().is_empty());
+        assert!(engine.picker("workstream").is_empty());
+    }
+}

--- a/crates/trusty-code/src/tui_client/engine.rs
+++ b/crates/trusty-code/src/tui_client/engine.rs
@@ -4,478 +4,62 @@
 //! Why: see `crate::tui_client`'s module docs for the ephemeral-`--stdio`
 //! vs. long-lived-`--http` client distinction. This module is the `TuiEngine`
 //! impl itself — everything else in `tui_client` (`discovery`, `rpc`, `sse`)
-//! exists to support it.
-//! What: [`EngineState`] holds every piece of daemon-observed state this
-//! client caches (current session id, last-known active workstream, and —
-//! ahead of `trusty-tui` Slice 1.5's SYNCHRONOUS `TuiEngine::commands()`/
-//! `picker(name)` accessors (#3428, landing into `crates/trusty-tui`
-//! alongside this slice) — a `commands`/`picker` cache populated during the
-//! async `setup()`/event-handling paths so those future sync accessors never
-//! need to perform network I/O inline (see [`EngineState::commands`]/
-//! [`EngineState::picker`]'s docs for why `std::sync::Mutex`, not
-//! `tokio::sync::Mutex`, guards this state). `CodeEngine` itself is a thin
-//! `Arc<EngineState>` wrapper so the background workstream-subscription task
-//! spawned by `subscribe_workstream_events` can share the SAME state (and
-//! refresh the SAME caches) without a second, divergent copy.
-//! Test: `engine_tests::*` for the pure event-mapping/parsing helpers below;
-//! the full discover -> setup -> stream -> cancel -> workstream-activation
-//! flow against a mock HTTP daemon lives in `tests/tui_client_engine.rs`.
+//! exists to support it. Split across sibling files (issue #610's 500-SLOC
+//! production-file cap): `engine_state.rs` holds [`super::engine_state::EngineState`]
+//! (the actual session/cache/streaming logic), `session_events.rs` holds
+//! the pure `Event` -> `ReplEvent` mapping, `workstream_subscription.rs`
+//! holds the background workstream-activation SSE loop. This file keeps
+//! only the public `CodeEngine` wrapper and the `TuiEngine` impl that
+//! delegates into `EngineState`.
+//! What: [`CodeEngine`] is a thin `Arc<EngineState>` wrapper so the
+//! background workstream-subscription task spawned by
+//! `subscribe_workstream_events` can share the SAME state (and refresh the
+//! SAME caches) without a second, divergent copy. Ahead of `trusty-tui`
+//! Slice 1.5's SYNCHRONOUS `TuiEngine::commands()`/`picker(name)`
+//! accessors (#3428) — see [`CodeEngine::commands`]/[`CodeEngine::picker`]'s
+//! docs.
+//! Test: `engine_tests::*` (in the sibling `engine_tests.rs`, included
+//! below) for the pure event-mapping/parsing helpers this module's siblings
+//! define; the full discover -> setup -> stream -> cancel ->
+//! workstream-activation flow against a mock HTTP daemon lives in
+//! `tests/tui_client_engine.rs`.
 
-use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use serde_json::{Value, json};
 use tokio::sync::mpsc::UnboundedSender;
-use trusty_tui::{CommandDescriptor, PickerItem, ReplEvent, TuiEngine, WorkstreamSummary};
-
-use crate::events::{Event, SessionEventEnvelope};
+use trusty_tui::{CommandDescriptor, PickerItem, ReplEvent, TuiEngine};
 
 use super::discovery::discover_daemon_url;
+use super::engine_state::EngineState;
 use super::error::EngineError;
 use super::rpc::RpcHttpClient;
-use super::sse::SseLines;
+use super::workstream_subscription::run_workstream_subscription;
 
 /// How long a session-event / workstream-event SSE read may sit idle (no
 /// bytes, not even a keep-alive comment) before this client treats the
 /// connection as dead and reconnects. Axum's default `KeepAlive` sends a
 /// comment roughly every 15s (`crate::serve::http::session_events_sse`'s
 /// `KeepAlive::default()`), so three missed beats is a generous margin
-/// before declaring the daemon unreachable.
-const SSE_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
+/// before declaring the daemon unreachable. Shared with `engine_state.rs`
+/// and `workstream_subscription.rs`.
+pub(super) const SSE_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
 
 /// Fixed backoff between SSE reconnect attempts. Not exponential — MVP
 /// scope (DOC-50 §5 Slice 3); a persistently-down daemon retries at a
-/// steady, human-visible cadence rather than hot-looping.
-const RECONNECT_BACKOFF: Duration = Duration::from_secs(2);
+/// steady, human-visible cadence rather than hot-looping. Shared with
+/// `engine_state.rs` and `workstream_subscription.rs`.
+pub(super) const RECONNECT_BACKOFF: Duration = Duration::from_secs(2);
 
-/// How many times [`EngineState::pump_session_events`] reconnects before
+/// How many times `EngineState::pump_session_events` reconnects before
 /// giving up and returning control to the caller (`handle_input` must
 /// eventually return so the REPL's input loop stays responsive — unlike the
 /// workstream-activation subscription, which is meant to run for the whole
-/// TUI session).
-const SESSION_STREAM_MAX_RECONNECTS: u32 = 5;
-
-/// Every piece of daemon-observed state [`CodeEngine`] caches, shared (via
-/// `Arc`) between the foreground `TuiEngine` calls and the background
-/// workstream-subscription task.
-struct EngineState {
-    rpc: RpcHttpClient,
-    /// Project root to bind the session to, if any (mirrors `session.create`'s
-    /// `project` param — see `crate::session::protocol::create`'s docs).
-    project_path: Option<PathBuf>,
-    session_id: Mutex<Option<String>>,
-    active_workstream: Mutex<Option<WorkstreamSummary>>,
-    /// Ahead-of-Slice-1.5 cache for `TuiEngine::commands()` (#3428) — see
-    /// module docs. Populated once, in `setup()`; static for this MVP (the
-    /// one engine-routed command, `/workstream`, never changes at runtime).
-    commands_cache: Mutex<Vec<CommandDescriptor>>,
-    /// Ahead-of-Slice-1.5 cache for `TuiEngine::picker(name)` (#3428) — see
-    /// module docs. Keyed by picker name (matches the DOC-50-noted
-    /// convention that a command name doubles as its picker name, e.g.
-    /// `/workstream` <-> `picker("workstream")`). Refreshed in `setup()`,
-    /// after a successful `/workstream activate`, and whenever the
-    /// background subscription observes a `WorkstreamActivationChanged`
-    /// event — see [`EngineState::refresh_workstream_cache`].
-    picker_cache: Mutex<HashMap<String, Vec<PickerItem>>>,
-    shutting_down: AtomicBool,
-}
-
-impl EngineState {
-    /// `std::sync::Mutex`, not `tokio::sync::Mutex` — see module docs:
-    /// `commands()`/`picker()` are, per #3428, plain synchronous `fn`s (no
-    /// `.await` available), so the cache they read MUST be lockable without
-    /// an async runtime. Every lock here is held only long enough to clone a
-    /// small `Vec`/`Option` — never across an `.await` point.
-    fn commands(&self) -> Vec<CommandDescriptor> {
-        self.commands_cache
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clone()
-    }
-
-    fn picker(&self, name: &str) -> Vec<PickerItem> {
-        self.picker_cache
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .get(name)
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    /// Re-fetch `workstream.list` and refresh both `active_workstream` and
-    /// the `"workstream"` picker cache entry. Best-effort: an RPC failure
-    /// here (daemon transiently unreachable) leaves the previous cache
-    /// contents in place rather than clearing them — a stale picker list is
-    /// strictly better than an empty one.
-    async fn refresh_workstream_cache(&self) -> Option<WorkstreamSummary> {
-        let result = self.rpc.call("workstream.list", json!({})).await.ok()?;
-        let active_id = result
-            .get("active_workstream_id")
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        let workstreams: Vec<Value> = result
-            .get("workstreams")
-            .and_then(Value::as_array)
-            .cloned()
-            .unwrap_or_default();
-
-        let items: Vec<PickerItem> = workstreams
-            .iter()
-            .filter_map(|w| {
-                let id = w.get("id").and_then(Value::as_str)?.to_string();
-                let name = w.get("name").and_then(Value::as_str).unwrap_or_default();
-                let label = if name.is_empty() {
-                    id.clone()
-                } else {
-                    name.to_string()
-                };
-                Some(PickerItem { id, label })
-            })
-            .collect();
-        *self.picker_cache.lock().unwrap_or_else(|e| e.into_inner()) = {
-            let mut map = HashMap::new();
-            map.insert("workstream".to_string(), items);
-            map
-        };
-
-        let active = active_id.and_then(|id| {
-            workstreams
-                .iter()
-                .find(|w| w.get("id").and_then(Value::as_str) == Some(id.as_str()))
-                .map(|w| WorkstreamSummary {
-                    id: id.clone(),
-                    name: w
-                        .get("name")
-                        .and_then(Value::as_str)
-                        .unwrap_or_default()
-                        .to_string(),
-                })
-                .or(Some(WorkstreamSummary {
-                    id,
-                    name: String::new(),
-                }))
-        });
-        *self
-            .active_workstream
-            .lock()
-            .unwrap_or_else(|e| e.into_inner()) = active.clone();
-        active
-    }
-
-    /// Route one submitted `/workstream`/`/ws` subcommand (`rest` is
-    /// whatever followed the command name, already trimmed; empty means
-    /// "no subcommand" -> defaults to `list`).
-    async fn handle_workstream_command(
-        &self,
-        rest: &str,
-        tx: &UnboundedSender<ReplEvent>,
-    ) -> Result<(), EngineError> {
-        if rest.is_empty() || rest == "list" {
-            let ws = self.refresh_workstream_cache().await;
-            let items = self.picker("workstream");
-            let active_id = ws.as_ref().map(|w| w.id.as_str());
-            let rows: Vec<String> = items
-                .iter()
-                .map(|item| {
-                    let marker = if Some(item.id.as_str()) == active_id {
-                        "*"
-                    } else {
-                        " "
-                    };
-                    format!("{marker} {} {}", item.id, item.label)
-                })
-                .collect();
-            let msg = if rows.is_empty() {
-                "no workstreams".to_string()
-            } else {
-                rows.join("\n")
-            };
-            let _ = tx.send(ReplEvent::StatusMessage(msg));
-            return Ok(());
-        }
-
-        if let Some(id) = rest.strip_prefix("activate ") {
-            let id = id.trim().to_string();
-            let result = self
-                .rpc
-                .call("workstream.activate", json!({ "id": id }))
-                .await?;
-            let active_id = result
-                .get("active_id")
-                .and_then(Value::as_str)
-                .unwrap_or(&id)
-                .to_string();
-            let ws = self
-                .refresh_workstream_cache()
-                .await
-                .unwrap_or(WorkstreamSummary {
-                    id: active_id.clone(),
-                    name: String::new(),
-                });
-            let _ = tx.send(ReplEvent::WorkstreamUpdated(ws));
-            let _ = tx.send(ReplEvent::StatusMessage(format!(
-                "activated workstream {active_id}"
-            )));
-            return Ok(());
-        }
-
-        let _ = tx.send(ReplEvent::StatusMessage(format!(
-            "unknown /workstream subcommand: {rest} (try `list` or `activate <id>`)"
-        )));
-        Ok(())
-    }
-
-    /// Send one chat line as a fresh `task.run` against the current session,
-    /// then stream its response back via [`Self::pump_session_events`].
-    async fn run_chat_turn(
-        &self,
-        line: &str,
-        tx: &UnboundedSender<ReplEvent>,
-    ) -> Result<(), EngineError> {
-        let session_id = {
-            self.session_id
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .clone()
-        }
-        .ok_or(EngineError::NoSession)?;
-        self.rpc
-            .call(
-                "task.run",
-                json!({
-                    "task_description": line,
-                    "session_id": session_id,
-                }),
-            )
-            .await?;
-        self.pump_session_events(&session_id, tx).await
-    }
-
-    /// Stream `GET /sessions/{session_id}/events` until a terminal event
-    /// (`SessionDone`/`SessionCancelled`) is observed, translating every
-    /// event into `ReplEvent`s along the way. Reconnects (bounded by
-    /// [`SESSION_STREAM_MAX_RECONNECTS`]) on a `502`/`503` status, a
-    /// transport error, an idle timeout, or a clean-but-premature stream
-    /// close — surfacing each as `ReplEvent::ConnectionLost` first.
-    async fn pump_session_events(
-        &self,
-        session_id: &str,
-        tx: &UnboundedSender<ReplEvent>,
-    ) -> Result<(), EngineError> {
-        let url = format!("{}/sessions/{session_id}/events", self.rpc.base_url());
-        let mut attempts = 0u32;
-        'reconnect: loop {
-            let resp = match self.rpc.http().get(&url).send().await {
-                Ok(r) if r.status().is_success() => r,
-                Ok(r) => {
-                    let status = r.status();
-                    if is_retryable_status(status) && attempts < SESSION_STREAM_MAX_RECONNECTS {
-                        attempts += 1;
-                        let _ = tx.send(ReplEvent::ConnectionLost {
-                            reason: format!("daemon returned {status}; reconnecting…"),
-                        });
-                        tokio::time::sleep(RECONNECT_BACKOFF).await;
-                        continue 'reconnect;
-                    }
-                    return Err(EngineError::Status { url, status });
-                }
-                Err(source) => {
-                    if attempts < SESSION_STREAM_MAX_RECONNECTS {
-                        attempts += 1;
-                        let _ = tx.send(ReplEvent::ConnectionLost {
-                            reason: format!("connection failed: {source}; reconnecting…"),
-                        });
-                        tokio::time::sleep(RECONNECT_BACKOFF).await;
-                        continue 'reconnect;
-                    }
-                    return Err(EngineError::Transport { url, source });
-                }
-            };
-            attempts = 0;
-            let mut lines = SseLines::new(resp);
-            loop {
-                match tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_data()).await {
-                    Ok(Ok(Some(payload))) => {
-                        let Ok(envelope) = serde_json::from_str::<SessionEventEnvelope>(&payload)
-                        else {
-                            continue;
-                        };
-                        if forward_session_event(envelope, tx) {
-                            return Ok(());
-                        }
-                    }
-                    Ok(Ok(None)) => {
-                        if attempts < SESSION_STREAM_MAX_RECONNECTS {
-                            attempts += 1;
-                            let _ = tx.send(ReplEvent::ConnectionLost {
-                                reason: "daemon closed the event stream; reconnecting…".to_string(),
-                            });
-                            tokio::time::sleep(RECONNECT_BACKOFF).await;
-                            continue 'reconnect;
-                        }
-                        return Ok(());
-                    }
-                    Ok(Err(source)) => {
-                        if attempts < SESSION_STREAM_MAX_RECONNECTS {
-                            attempts += 1;
-                            let _ = tx.send(ReplEvent::ConnectionLost {
-                                reason: format!("stream error: {source}; reconnecting…"),
-                            });
-                            tokio::time::sleep(RECONNECT_BACKOFF).await;
-                            continue 'reconnect;
-                        }
-                        return Err(EngineError::Transport { url, source });
-                    }
-                    Err(_elapsed) => {
-                        if attempts < SESSION_STREAM_MAX_RECONNECTS {
-                            attempts += 1;
-                            let _ = tx.send(ReplEvent::ConnectionLost {
-                                reason: "no data from daemon within the idle timeout; \
-                                         reconnecting…"
-                                    .to_string(),
-                            });
-                            tokio::time::sleep(RECONNECT_BACKOFF).await;
-                            continue 'reconnect;
-                        }
-                        return Err(EngineError::Status {
-                            url,
-                            status: reqwest::StatusCode::REQUEST_TIMEOUT,
-                        });
-                    }
-                }
-            }
-        }
-    }
-}
-
-/// `true` for HTTP statuses worth retrying (daemon restarting) rather than
-/// failing immediately.
-fn is_retryable_status(status: reqwest::StatusCode) -> bool {
-    status == reqwest::StatusCode::BAD_GATEWAY || status == reqwest::StatusCode::SERVICE_UNAVAILABLE
-}
-
-/// Translate one [`SessionEventEnvelope`] into zero or more [`ReplEvent`]s
-/// on `tx`. Returns `true` iff this event is terminal for the current chat
-/// turn (`SessionDone`/`SessionCancelled`) — the caller stops pumping.
-///
-/// Why: kept as a free function (not a method) so it's directly unit
-/// testable against a hand-built envelope, no HTTP/mock server needed.
-/// What: `Message`/`AgentMessage`/`PmThinking` -> `AssistantOutput` chunks
-/// (`done: false`); `ToolStarted` -> `ToolInvocation{result: None}`;
-/// `ToolFinished`/`ToolError` -> `ToolInvocation{result: Some(..)}`, keyed
-/// by the SAME `call_id` so the (future) tool-card renderer can pair them;
-/// `SessionDone` -> a final `AssistantOutput{done: true}` (`is_error` iff
-/// `status == "failed"`); `SessionCancelled` -> a status message. Every
-/// other event kind (progress/telemetry/agent-lifecycle events this MVP
-/// doesn't yet render) is silently ignored — forward-compatible with new
-/// `Event` variants (no `match` arm needed per new kind, thanks to the
-/// catch-all).
-/// Test: `engine_tests::forward_message_emits_assistant_output_chunk_not_done`,
-/// `engine_tests::forward_tool_started_emits_tool_invocation_with_call_id`,
-/// `engine_tests::forward_tool_finished_carries_result_and_shares_call_id`,
-/// `engine_tests::forward_session_done_is_terminal`,
-/// `engine_tests::forward_session_done_failed_marks_is_error`,
-/// `engine_tests::forward_session_cancelled_is_terminal`,
-/// `engine_tests::forward_unrelated_event_is_ignored`.
-fn forward_session_event(envelope: SessionEventEnvelope, tx: &UnboundedSender<ReplEvent>) -> bool {
-    match envelope.event {
-        Event::Message { text, .. }
-        | Event::AgentMessage { text, .. }
-        | Event::PmThinking { text, .. } => {
-            let _ = tx.send(ReplEvent::AssistantOutput {
-                chunk: text,
-                done: false,
-                is_error: false,
-            });
-            false
-        }
-        Event::ToolStarted {
-            tool,
-            call_id,
-            args_preview,
-            ..
-        } => {
-            let _ = tx.send(ReplEvent::ToolInvocation {
-                id: call_id,
-                tool_name: tool,
-                args: json!(args_preview),
-                result: None,
-            });
-            false
-        }
-        Event::ToolFinished {
-            tool,
-            call_id,
-            result_preview,
-            success,
-            ..
-        } => {
-            let result = if success {
-                result_preview
-            } else {
-                format!("FAILED: {result_preview}")
-            };
-            let _ = tx.send(ReplEvent::ToolInvocation {
-                id: call_id,
-                tool_name: tool,
-                args: Value::Null,
-                result: Some(result),
-            });
-            false
-        }
-        Event::ToolError {
-            tool,
-            call_id,
-            error,
-            ..
-        } => {
-            let _ = tx.send(ReplEvent::ToolInvocation {
-                id: call_id,
-                tool_name: tool,
-                args: Value::Null,
-                result: Some(format!("ERROR: {error}")),
-            });
-            false
-        }
-        Event::SessionDone { status, .. } => {
-            let _ = tx.send(ReplEvent::AssistantOutput {
-                chunk: String::new(),
-                done: true,
-                is_error: status == "failed",
-            });
-            true
-        }
-        Event::SessionCancelled { .. } => {
-            let _ = tx.send(ReplEvent::StatusMessage("cancelled".to_string()));
-            true
-        }
-        _ => false,
-    }
-}
-
-/// The AC-7.2 wire envelope this client deserialises off
-/// `GET /workstreams/{id}/events` — mirrors
-/// `crate::workstreams::sse::WorkstreamEventEnvelope`
-/// (`trusty_agents_common::transport::EventEnvelope<Event>`) exactly, but
-/// with `Deserialize` (the shared type only derives `Serialize` — it's
-/// built server-side, never parsed) — see module docs for why a small
-/// mirror struct here is preferable to adding `Deserialize` to the shared
-/// type for one client.
-#[derive(Debug, serde::Deserialize)]
-struct WireWorkstreamEnvelope {
-    #[allow(dead_code)]
-    session_id: String,
-    #[allow(dead_code)]
-    event_type: String,
-    payload: Event,
-}
-
-fn parse_workstream_envelope(payload_json: &str) -> Option<WireWorkstreamEnvelope> {
-    serde_json::from_str(payload_json).ok()
-}
+/// TUI session). Shared with `engine_state.rs`.
+pub(super) const SESSION_STREAM_MAX_RECONNECTS: u32 = 5;
 
 /// Whether `rest` (already trimmed) names the `/workstream`/`/ws`
 /// engine-routed command, and if so, what follows it (empty string if bare).
@@ -497,79 +81,6 @@ fn workstream_subcommand(line: &str) -> Option<&str> {
         }
     }
     None
-}
-
-/// Long-lived background loop for `subscribe_workstream_events`: holds one
-/// SSE connection to `GET /workstreams/{current_id}/events` at a time,
-/// reconnecting (to a possibly-NEW workstream id, per DOC-48 §5.3 point 5)
-/// on activation changes, transport errors, or idle timeouts, until
-/// `state.shutting_down` is set.
-async fn run_workstream_subscription(
-    state: Arc<EngineState>,
-    mut current_id: String,
-    tx: UnboundedSender<ReplEvent>,
-) {
-    loop {
-        if state.shutting_down.load(Ordering::SeqCst) {
-            return;
-        }
-        let url = format!("{}/workstreams/{current_id}/events", state.rpc.base_url());
-        let resp = match state.rpc.http().get(&url).send().await {
-            Ok(r) if r.status().is_success() => r,
-            _ => {
-                let _ = tx.send(ReplEvent::ConnectionLost {
-                    reason: format!(
-                        "could not reach workstream events endpoint for {current_id}; retrying…"
-                    ),
-                });
-                tokio::time::sleep(RECONNECT_BACKOFF).await;
-                continue;
-            }
-        };
-
-        let mut lines = SseLines::new(resp);
-        loop {
-            if state.shutting_down.load(Ordering::SeqCst) {
-                return;
-            }
-            match tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_data()).await {
-                Ok(Ok(Some(payload))) => {
-                    let Some(env) = parse_workstream_envelope(&payload) else {
-                        continue;
-                    };
-                    if let Event::WorkstreamActivationChanged {
-                        new_active_id: Some(new_id),
-                        prior_id,
-                    } = env.payload
-                    {
-                        let _ = tx.send(ReplEvent::WorkstreamActivationChanged {
-                            new_active_id: new_id.clone(),
-                            prior_id,
-                        });
-                        state.refresh_workstream_cache().await;
-                        if new_id != current_id {
-                            current_id = new_id;
-                            break; // reconnect to the newly-active workstream's endpoint
-                        }
-                    }
-                }
-                Ok(Ok(None)) => {
-                    let _ = tx.send(ReplEvent::ConnectionLost {
-                        reason: "workstream event stream closed; reconnecting…".to_string(),
-                    });
-                    tokio::time::sleep(RECONNECT_BACKOFF).await;
-                    break;
-                }
-                Ok(Err(_)) | Err(_) => {
-                    let _ = tx.send(ReplEvent::ConnectionLost {
-                        reason: "workstream event stream error; reconnecting…".to_string(),
-                    });
-                    tokio::time::sleep(RECONNECT_BACKOFF).await;
-                    break;
-                }
-            }
-        }
-    }
 }
 
 fn build_http_client() -> reqwest::Client {
@@ -606,15 +117,10 @@ impl CodeEngine {
         project_path: Option<PathBuf>,
     ) -> Self {
         Self {
-            state: Arc::new(EngineState {
-                rpc: RpcHttpClient::new(http, base_url.into()),
+            state: Arc::new(EngineState::new(
+                RpcHttpClient::new(http, base_url.into()),
                 project_path,
-                session_id: Mutex::new(None),
-                active_workstream: Mutex::new(None),
-                commands_cache: Mutex::new(Vec::new()),
-                picker_cache: Mutex::new(HashMap::new()),
-                shutting_down: AtomicBool::new(false),
-            }),
+            )),
         }
     }
 
@@ -762,205 +268,5 @@ impl TuiEngine for CodeEngine {
 }
 
 #[cfg(test)]
-mod engine_tests {
-    use super::*;
-    use tokio::sync::mpsc::unbounded_channel;
-
-    fn envelope(event: Event) -> SessionEventEnvelope {
-        SessionEventEnvelope::new("s-1".to_string(), 1, chrono::Utc::now(), event)
-    }
-
-    #[test]
-    fn forward_message_emits_assistant_output_chunk_not_done() {
-        let (tx, mut rx) = unbounded_channel();
-        let terminal = forward_session_event(
-            envelope(Event::Message {
-                session_id: "s-1".into(),
-                text: "hi".into(),
-            }),
-            &tx,
-        );
-        assert!(!terminal);
-        assert_eq!(
-            rx.try_recv().expect("event"),
-            ReplEvent::AssistantOutput {
-                chunk: "hi".into(),
-                done: false,
-                is_error: false,
-            }
-        );
-    }
-
-    #[test]
-    fn forward_tool_started_emits_tool_invocation_with_call_id() {
-        let (tx, mut rx) = unbounded_channel();
-        let terminal = forward_session_event(
-            envelope(Event::ToolStarted {
-                session_id: "s-1".into(),
-                agent: "pm".into(),
-                agent_id: String::new(),
-                tool: "bash".into(),
-                call_id: "call-1".into(),
-                args_preview: "ls".into(),
-            }),
-            &tx,
-        );
-        assert!(!terminal);
-        match rx.try_recv().expect("event") {
-            ReplEvent::ToolInvocation {
-                id,
-                tool_name,
-                result,
-                ..
-            } => {
-                assert_eq!(id, "call-1");
-                assert_eq!(tool_name, "bash");
-                assert!(result.is_none());
-            }
-            other => panic!("unexpected {other:?}"),
-        }
-    }
-
-    #[test]
-    fn forward_tool_finished_carries_result_and_shares_call_id() {
-        let (tx, mut rx) = unbounded_channel();
-        forward_session_event(
-            envelope(Event::ToolFinished {
-                session_id: "s-1".into(),
-                agent: "pm".into(),
-                agent_id: String::new(),
-                tool: "bash".into(),
-                call_id: "call-1".into(),
-                success: true,
-                result_preview: "done".into(),
-            }),
-            &tx,
-        );
-        match rx.try_recv().expect("event") {
-            ReplEvent::ToolInvocation { id, result, .. } => {
-                assert_eq!(id, "call-1");
-                assert_eq!(result.as_deref(), Some("done"));
-            }
-            other => panic!("unexpected {other:?}"),
-        }
-    }
-
-    #[test]
-    fn forward_session_done_is_terminal() {
-        let (tx, mut rx) = unbounded_channel();
-        let terminal = forward_session_event(
-            envelope(Event::SessionDone {
-                session_id: "s-1".into(),
-                status: "finished".into(),
-            }),
-            &tx,
-        );
-        assert!(terminal);
-        assert_eq!(
-            rx.try_recv().expect("event"),
-            ReplEvent::AssistantOutput {
-                chunk: String::new(),
-                done: true,
-                is_error: false,
-            }
-        );
-    }
-
-    #[test]
-    fn forward_session_done_failed_marks_is_error() {
-        let (tx, mut rx) = unbounded_channel();
-        forward_session_event(
-            envelope(Event::SessionDone {
-                session_id: "s-1".into(),
-                status: "failed".into(),
-            }),
-            &tx,
-        );
-        assert_eq!(
-            rx.try_recv().expect("event"),
-            ReplEvent::AssistantOutput {
-                chunk: String::new(),
-                done: true,
-                is_error: true,
-            }
-        );
-    }
-
-    #[test]
-    fn forward_session_cancelled_is_terminal() {
-        let (tx, mut rx) = unbounded_channel();
-        let terminal = forward_session_event(
-            envelope(Event::SessionCancelled {
-                session_id: "s-1".into(),
-            }),
-            &tx,
-        );
-        assert!(terminal);
-        assert!(rx.try_recv().is_ok());
-    }
-
-    #[test]
-    fn forward_unrelated_event_is_ignored() {
-        let (tx, mut rx) = unbounded_channel();
-        let terminal = forward_session_event(envelope(Event::Ping), &tx);
-        assert!(!terminal);
-        assert!(rx.try_recv().is_err());
-    }
-
-    #[test]
-    fn workstream_subcommand_parses_list_and_activate() {
-        assert_eq!(workstream_subcommand("/workstream list"), Some("list"));
-        assert_eq!(
-            workstream_subcommand("/ws activate abc-123"),
-            Some("activate abc-123")
-        );
-        assert_eq!(workstream_subcommand("/workstream"), Some(""));
-        assert_eq!(workstream_subcommand("/workstreamx foo"), None);
-        assert_eq!(workstream_subcommand("hello"), None);
-    }
-
-    #[test]
-    fn parse_workstream_envelope_round_trips_activation_changed() {
-        let json = serde_json::json!({
-            "session_id": "",
-            "event_type": "workstream_activation_changed",
-            "payload": {
-                "type": "workstream_activation_changed",
-                "new_active_id": "ws-2",
-                "prior_id": "ws-1",
-            },
-        })
-        .to_string();
-        let env = parse_workstream_envelope(&json).expect("parse");
-        match env.payload {
-            Event::WorkstreamActivationChanged {
-                new_active_id,
-                prior_id,
-            } => {
-                assert_eq!(new_active_id.as_deref(), Some("ws-2"));
-                assert_eq!(prior_id.as_deref(), Some("ws-1"));
-            }
-            other => panic!("unexpected {other:?}"),
-        }
-    }
-
-    #[test]
-    fn is_retryable_status_covers_502_and_503_only() {
-        assert!(is_retryable_status(reqwest::StatusCode::BAD_GATEWAY));
-        assert!(is_retryable_status(
-            reqwest::StatusCode::SERVICE_UNAVAILABLE
-        ));
-        assert!(!is_retryable_status(reqwest::StatusCode::NOT_FOUND));
-    }
-
-    /// The caches must start empty before `setup()` populates them —
-    /// `commands()`/`picker()` must degrade to "nothing yet," never panic,
-    /// when queried before `setup()` runs.
-    #[test]
-    fn caches_are_empty_before_setup() {
-        let engine =
-            CodeEngine::with_daemon_url(reqwest::Client::new(), "http://127.0.0.1:1", None);
-        assert!(engine.commands().is_empty());
-        assert!(engine.picker("workstream").is_empty());
-    }
-}
+#[path = "engine_tests.rs"]
+mod engine_tests;

--- a/crates/trusty-code/src/tui_client/engine_state.rs
+++ b/crates/trusty-code/src/tui_client/engine_state.rs
@@ -86,13 +86,20 @@ impl EngineState {
             .clone()
     }
 
-    pub(super) fn picker(&self, name: &str) -> Vec<PickerItem> {
+    /// Raw cached picker items for `name`, or `None` if this engine has no
+    /// picker under that name (distinct from `Some(vec![])`, which means
+    /// "this picker exists but currently has zero items" — e.g. the
+    /// `"workstream"` picker after `refresh_workstream_cache` observes a
+    /// daemon with zero workstreams). `engine.rs`'s `TuiEngine::picker` wraps
+    /// this into the trait's `PickerRequest` shape (title + dispatch
+    /// command), which is a per-picker-name concern this cache-only helper
+    /// deliberately doesn't know about.
+    pub(super) fn picker_items(&self, name: &str) -> Option<Vec<PickerItem>> {
         self.picker_cache
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .get(name)
             .cloned()
-            .unwrap_or_default()
     }
 
     /// Re-fetch `workstream.list` and refresh both `active_workstream` and
@@ -122,7 +129,11 @@ impl EngineState {
                 } else {
                     name.to_string()
                 };
-                Some(PickerItem { id, label })
+                Some(PickerItem {
+                    id,
+                    label,
+                    description: None,
+                })
             })
             .collect();
         *self.picker_cache.lock().unwrap_or_else(|e| e.into_inner()) = {
@@ -165,7 +176,7 @@ impl EngineState {
     ) -> Result<(), EngineError> {
         if rest.is_empty() || rest == "list" {
             let ws = self.refresh_workstream_cache().await;
-            let items = self.picker("workstream");
+            let items = self.picker_items("workstream").unwrap_or_default();
             let active_id = ws.as_ref().map(|w| w.id.as_str());
             let rows: Vec<String> = items
                 .iter()

--- a/crates/trusty-code/src/tui_client/engine_state.rs
+++ b/crates/trusty-code/src/tui_client/engine_state.rs
@@ -1,0 +1,342 @@
+//! [`EngineState`]: every piece of daemon-observed state [`super::CodeEngine`]
+//! caches, shared (via `Arc`) between the foreground `TuiEngine` calls and
+//! the background workstream-subscription task (issue #3415).
+//!
+//! Why: split out of `engine.rs` (issue #610's 500-SLOC production-file
+//! cap) — this struct and its methods are the bulk of `CodeEngine`'s real
+//! logic (session lifecycle, the commands/picker caches, the chat-turn SSE
+//! pump), so they earn their own file; `engine.rs` keeps the public
+//! `CodeEngine` wrapper and the `TuiEngine` impl that delegates into this.
+//! What: [`EngineState`] itself, and every method DOC-50's design puts on
+//! the engine adapter: `commands`/`picker` (ahead of `trusty-tui` Slice
+//! 1.5's synchronous accessors, #3428 — see [`EngineState::commands`]'s
+//! docs for why these caches use `std::sync::Mutex`, not
+//! `tokio::sync::Mutex`), `refresh_workstream_cache` (re-fetches
+//! `workstream.list`), `handle_workstream_command` (`/workstream`/`/ws`
+//! subcommand routing), `run_chat_turn` + `pump_session_events` (the
+//! `task.run` -> `GET /sessions/{id}/events` streaming path).
+//! Test: `engine_tests::*` (in the sibling `engine_tests.rs`, included from
+//! `engine.rs`) for the pure helpers this module calls into
+//! (`session_events::forward_session_event`); the full
+//! setup/stream/cancel/workstream flow against a mock HTTP daemon lives in
+//! `tests/tui_client_engine.rs`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+
+use serde_json::{Value, json};
+use tokio::sync::mpsc::UnboundedSender;
+use trusty_tui::{CommandDescriptor, PickerItem, ReplEvent, WorkstreamSummary};
+
+use crate::events::SessionEventEnvelope;
+
+use super::engine::{RECONNECT_BACKOFF, SESSION_STREAM_MAX_RECONNECTS, SSE_IDLE_TIMEOUT};
+use super::error::EngineError;
+use super::rpc::RpcHttpClient;
+use super::session_events::{forward_session_event, is_retryable_status};
+use super::sse::SseLines;
+
+/// See module docs.
+pub(super) struct EngineState {
+    pub(super) rpc: RpcHttpClient,
+    /// Project root to bind the session to, if any (mirrors `session.create`'s
+    /// `project` param — see `crate::session::protocol::create`'s docs).
+    pub(super) project_path: Option<PathBuf>,
+    pub(super) session_id: Mutex<Option<String>>,
+    pub(super) active_workstream: Mutex<Option<WorkstreamSummary>>,
+    /// Ahead-of-Slice-1.5 cache for `TuiEngine::commands()` (#3428) — see
+    /// module docs. Populated once, in `setup()`; static for this MVP (the
+    /// one engine-routed command, `/workstream`, never changes at runtime).
+    pub(super) commands_cache: Mutex<Vec<CommandDescriptor>>,
+    /// Ahead-of-Slice-1.5 cache for `TuiEngine::picker(name)` (#3428) — see
+    /// module docs. Keyed by picker name (matches the DOC-50-noted
+    /// convention that a command name doubles as its picker name, e.g.
+    /// `/workstream` <-> `picker("workstream")`). Refreshed in `setup()`,
+    /// after a successful `/workstream activate`, and whenever the
+    /// background subscription observes a `WorkstreamActivationChanged`
+    /// event — see [`EngineState::refresh_workstream_cache`].
+    pub(super) picker_cache: Mutex<HashMap<String, Vec<PickerItem>>>,
+    pub(super) shutting_down: AtomicBool,
+}
+
+impl EngineState {
+    pub(super) fn new(rpc: RpcHttpClient, project_path: Option<PathBuf>) -> Self {
+        Self {
+            rpc,
+            project_path,
+            session_id: Mutex::new(None),
+            active_workstream: Mutex::new(None),
+            commands_cache: Mutex::new(Vec::new()),
+            picker_cache: Mutex::new(HashMap::new()),
+            shutting_down: AtomicBool::new(false),
+        }
+    }
+
+    /// `std::sync::Mutex`, not `tokio::sync::Mutex` — see module docs:
+    /// `commands()`/`picker()` are, per #3428, plain synchronous `fn`s (no
+    /// `.await` available), so the cache they read MUST be lockable without
+    /// an async runtime. Every lock here is held only long enough to clone a
+    /// small `Vec`/`Option` — never across an `.await` point.
+    pub(super) fn commands(&self) -> Vec<CommandDescriptor> {
+        self.commands_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    pub(super) fn picker(&self, name: &str) -> Vec<PickerItem> {
+        self.picker_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(name)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Re-fetch `workstream.list` and refresh both `active_workstream` and
+    /// the `"workstream"` picker cache entry. Best-effort: an RPC failure
+    /// here (daemon transiently unreachable) leaves the previous cache
+    /// contents in place rather than clearing them — a stale picker list is
+    /// strictly better than an empty one.
+    pub(super) async fn refresh_workstream_cache(&self) -> Option<WorkstreamSummary> {
+        let result = self.rpc.call("workstream.list", json!({})).await.ok()?;
+        let active_id = result
+            .get("active_workstream_id")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let workstreams: Vec<Value> = result
+            .get("workstreams")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+
+        let items: Vec<PickerItem> = workstreams
+            .iter()
+            .filter_map(|w| {
+                let id = w.get("id").and_then(Value::as_str)?.to_string();
+                let name = w.get("name").and_then(Value::as_str).unwrap_or_default();
+                let label = if name.is_empty() {
+                    id.clone()
+                } else {
+                    name.to_string()
+                };
+                Some(PickerItem { id, label })
+            })
+            .collect();
+        *self.picker_cache.lock().unwrap_or_else(|e| e.into_inner()) = {
+            let mut map = HashMap::new();
+            map.insert("workstream".to_string(), items);
+            map
+        };
+
+        let active = active_id.and_then(|id| {
+            workstreams
+                .iter()
+                .find(|w| w.get("id").and_then(Value::as_str) == Some(id.as_str()))
+                .map(|w| WorkstreamSummary {
+                    id: id.clone(),
+                    name: w
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string(),
+                })
+                .or(Some(WorkstreamSummary {
+                    id,
+                    name: String::new(),
+                }))
+        });
+        *self
+            .active_workstream
+            .lock()
+            .unwrap_or_else(|e| e.into_inner()) = active.clone();
+        active
+    }
+
+    /// Route one submitted `/workstream`/`/ws` subcommand (`rest` is
+    /// whatever followed the command name, already trimmed; empty means
+    /// "no subcommand" -> defaults to `list`).
+    pub(super) async fn handle_workstream_command(
+        &self,
+        rest: &str,
+        tx: &UnboundedSender<ReplEvent>,
+    ) -> Result<(), EngineError> {
+        if rest.is_empty() || rest == "list" {
+            let ws = self.refresh_workstream_cache().await;
+            let items = self.picker("workstream");
+            let active_id = ws.as_ref().map(|w| w.id.as_str());
+            let rows: Vec<String> = items
+                .iter()
+                .map(|item| {
+                    let marker = if Some(item.id.as_str()) == active_id {
+                        "*"
+                    } else {
+                        " "
+                    };
+                    format!("{marker} {} {}", item.id, item.label)
+                })
+                .collect();
+            let msg = if rows.is_empty() {
+                "no workstreams".to_string()
+            } else {
+                rows.join("\n")
+            };
+            let _ = tx.send(ReplEvent::StatusMessage(msg));
+            return Ok(());
+        }
+
+        if let Some(id) = rest.strip_prefix("activate ") {
+            let id = id.trim().to_string();
+            let result = self
+                .rpc
+                .call("workstream.activate", json!({ "id": id }))
+                .await?;
+            let active_id = result
+                .get("active_id")
+                .and_then(Value::as_str)
+                .unwrap_or(&id)
+                .to_string();
+            let ws = self
+                .refresh_workstream_cache()
+                .await
+                .unwrap_or(WorkstreamSummary {
+                    id: active_id.clone(),
+                    name: String::new(),
+                });
+            let _ = tx.send(ReplEvent::WorkstreamUpdated(ws));
+            let _ = tx.send(ReplEvent::StatusMessage(format!(
+                "activated workstream {active_id}"
+            )));
+            return Ok(());
+        }
+
+        let _ = tx.send(ReplEvent::StatusMessage(format!(
+            "unknown /workstream subcommand: {rest} (try `list` or `activate <id>`)"
+        )));
+        Ok(())
+    }
+
+    /// Send one chat line as a fresh `task.run` against the current session,
+    /// then stream its response back via [`Self::pump_session_events`].
+    pub(super) async fn run_chat_turn(
+        &self,
+        line: &str,
+        tx: &UnboundedSender<ReplEvent>,
+    ) -> Result<(), EngineError> {
+        let session_id = {
+            self.session_id
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clone()
+        }
+        .ok_or(EngineError::NoSession)?;
+        self.rpc
+            .call(
+                "task.run",
+                json!({
+                    "task_description": line,
+                    "session_id": session_id,
+                }),
+            )
+            .await?;
+        self.pump_session_events(&session_id, tx).await
+    }
+
+    /// Stream `GET /sessions/{session_id}/events` until a terminal event
+    /// (`SessionDone`/`SessionCancelled`) is observed, translating every
+    /// event into `ReplEvent`s along the way. Reconnects (bounded by
+    /// [`SESSION_STREAM_MAX_RECONNECTS`]) on a `502`/`503` status, a
+    /// transport error, an idle timeout, or a clean-but-premature stream
+    /// close — surfacing each as `ReplEvent::ConnectionLost` first.
+    pub(super) async fn pump_session_events(
+        &self,
+        session_id: &str,
+        tx: &UnboundedSender<ReplEvent>,
+    ) -> Result<(), EngineError> {
+        let url = format!("{}/sessions/{session_id}/events", self.rpc.base_url());
+        let mut attempts = 0u32;
+        'reconnect: loop {
+            let resp = match self.rpc.http().get(&url).send().await {
+                Ok(r) if r.status().is_success() => r,
+                Ok(r) => {
+                    let status = r.status();
+                    if is_retryable_status(status) && attempts < SESSION_STREAM_MAX_RECONNECTS {
+                        attempts += 1;
+                        let _ = tx.send(ReplEvent::ConnectionLost {
+                            reason: format!("daemon returned {status}; reconnecting…"),
+                        });
+                        tokio::time::sleep(RECONNECT_BACKOFF).await;
+                        continue 'reconnect;
+                    }
+                    return Err(EngineError::Status { url, status });
+                }
+                Err(source) => {
+                    if attempts < SESSION_STREAM_MAX_RECONNECTS {
+                        attempts += 1;
+                        let _ = tx.send(ReplEvent::ConnectionLost {
+                            reason: format!("connection failed: {source}; reconnecting…"),
+                        });
+                        tokio::time::sleep(RECONNECT_BACKOFF).await;
+                        continue 'reconnect;
+                    }
+                    return Err(EngineError::Transport { url, source });
+                }
+            };
+            attempts = 0;
+            let mut lines = SseLines::new(resp);
+            loop {
+                match tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_data()).await {
+                    Ok(Ok(Some(payload))) => {
+                        let Ok(envelope) = serde_json::from_str::<SessionEventEnvelope>(&payload)
+                        else {
+                            continue;
+                        };
+                        if forward_session_event(envelope, tx) {
+                            return Ok(());
+                        }
+                    }
+                    Ok(Ok(None)) => {
+                        if attempts < SESSION_STREAM_MAX_RECONNECTS {
+                            attempts += 1;
+                            let _ = tx.send(ReplEvent::ConnectionLost {
+                                reason: "daemon closed the event stream; reconnecting…".to_string(),
+                            });
+                            tokio::time::sleep(RECONNECT_BACKOFF).await;
+                            continue 'reconnect;
+                        }
+                        return Ok(());
+                    }
+                    Ok(Err(source)) => {
+                        if attempts < SESSION_STREAM_MAX_RECONNECTS {
+                            attempts += 1;
+                            let _ = tx.send(ReplEvent::ConnectionLost {
+                                reason: format!("stream error: {source}; reconnecting…"),
+                            });
+                            tokio::time::sleep(RECONNECT_BACKOFF).await;
+                            continue 'reconnect;
+                        }
+                        return Err(EngineError::Transport { url, source });
+                    }
+                    Err(_elapsed) => {
+                        if attempts < SESSION_STREAM_MAX_RECONNECTS {
+                            attempts += 1;
+                            let _ = tx.send(ReplEvent::ConnectionLost {
+                                reason: "no data from daemon within the idle timeout; \
+                                         reconnecting…"
+                                    .to_string(),
+                            });
+                            tokio::time::sleep(RECONNECT_BACKOFF).await;
+                            continue 'reconnect;
+                        }
+                        return Err(EngineError::Status {
+                            url,
+                            status: reqwest::StatusCode::REQUEST_TIMEOUT,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/trusty-code/src/tui_client/engine_tests.rs
+++ b/crates/trusty-code/src/tui_client/engine_tests.rs
@@ -203,11 +203,31 @@ fn is_retryable_status_covers_502_and_503_only() {
 }
 
 /// The caches must start empty before `setup()` populates them —
-/// `commands()`/`picker()` must degrade to "nothing yet," never panic,
-/// when queried before `setup()` runs.
+/// `TuiEngine::commands()`/`picker()` must degrade to "nothing yet," never
+/// panic, when queried before `setup()` runs.
 #[test]
 fn caches_are_empty_before_setup() {
     let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), "http://127.0.0.1:1", None);
     assert!(engine.commands().is_empty());
-    assert!(engine.picker("workstream").is_empty());
+    assert!(engine.picker("workstream").is_none());
+}
+
+/// `picker("workstream")` must carry the exact dispatch command
+/// `workstream_subcommand` parses back — proves the picker-selection
+/// round trip (`"{dispatch_command} {selected.id}"`) actually reaches
+/// `handle_workstream_command`'s `activate <id>` branch, not some other
+/// unparsed string.
+#[test]
+fn workstream_picker_dispatch_command_round_trips_through_workstream_subcommand() {
+    let dispatch_command = "/workstream activate";
+    let resubmitted = format!("{dispatch_command} ws-1");
+    assert_eq!(workstream_subcommand(&resubmitted), Some("activate ws-1"));
+}
+
+/// An unknown picker name must be `None`, not an empty-but-`Some` request —
+/// this engine has exactly one picker.
+#[test]
+fn picker_unknown_name_is_none() {
+    let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), "http://127.0.0.1:1", None);
+    assert!(engine.picker("model").is_none());
 }

--- a/crates/trusty-code/src/tui_client/engine_tests.rs
+++ b/crates/trusty-code/src/tui_client/engine_tests.rs
@@ -1,0 +1,213 @@
+//! Tests for `engine.rs` and its sibling modules (`engine_state.rs`,
+//! `session_events.rs`, `workstream_subscription.rs`) — issue #3415.
+//!
+//! Why: kept as a sibling `_tests.rs` file (not inline in `engine.rs`), per
+//! this crate's established convention (`serve/http.rs` -> `http_tests.rs`,
+//! `workstreams/sse.rs` -> `sse_tests.rs`) — a `_tests.rs` suffix is scored
+//! against the 1500-SLOC TEST cap (issue #610/#1131), not the 500-SLOC
+//! PRODUCTION cap, so splitting tests out of `engine.rs` is what keeps that
+//! file itself under cap without shrinking coverage.
+
+use tokio::sync::mpsc::unbounded_channel;
+
+use super::*;
+use crate::events::{Event, SessionEventEnvelope};
+use crate::tui_client::session_events::{forward_session_event, is_retryable_status};
+use crate::tui_client::workstream_subscription::parse_workstream_envelope;
+
+fn envelope(event: Event) -> SessionEventEnvelope {
+    SessionEventEnvelope::new("s-1".to_string(), 1, chrono::Utc::now(), event)
+}
+
+#[test]
+fn forward_message_emits_assistant_output_chunk_not_done() {
+    let (tx, mut rx) = unbounded_channel();
+    let terminal = forward_session_event(
+        envelope(Event::Message {
+            session_id: "s-1".into(),
+            text: "hi".into(),
+        }),
+        &tx,
+    );
+    assert!(!terminal);
+    assert_eq!(
+        rx.try_recv().expect("event"),
+        ReplEvent::AssistantOutput {
+            chunk: "hi".into(),
+            done: false,
+            is_error: false,
+        }
+    );
+}
+
+#[test]
+fn forward_tool_started_emits_tool_invocation_with_call_id() {
+    let (tx, mut rx) = unbounded_channel();
+    let terminal = forward_session_event(
+        envelope(Event::ToolStarted {
+            session_id: "s-1".into(),
+            agent: "pm".into(),
+            agent_id: String::new(),
+            tool: "bash".into(),
+            call_id: "call-1".into(),
+            args_preview: "ls".into(),
+        }),
+        &tx,
+    );
+    assert!(!terminal);
+    match rx.try_recv().expect("event") {
+        ReplEvent::ToolInvocation {
+            id,
+            tool_name,
+            result,
+            ..
+        } => {
+            assert_eq!(id, "call-1");
+            assert_eq!(tool_name, "bash");
+            assert!(result.is_none());
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+}
+
+#[test]
+fn forward_tool_finished_carries_result_and_shares_call_id() {
+    let (tx, mut rx) = unbounded_channel();
+    forward_session_event(
+        envelope(Event::ToolFinished {
+            session_id: "s-1".into(),
+            agent: "pm".into(),
+            agent_id: String::new(),
+            tool: "bash".into(),
+            call_id: "call-1".into(),
+            success: true,
+            result_preview: "done".into(),
+        }),
+        &tx,
+    );
+    match rx.try_recv().expect("event") {
+        ReplEvent::ToolInvocation { id, result, .. } => {
+            assert_eq!(id, "call-1");
+            assert_eq!(result.as_deref(), Some("done"));
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+}
+
+#[test]
+fn forward_session_done_is_terminal() {
+    let (tx, mut rx) = unbounded_channel();
+    let terminal = forward_session_event(
+        envelope(Event::SessionDone {
+            session_id: "s-1".into(),
+            status: "finished".into(),
+        }),
+        &tx,
+    );
+    assert!(terminal);
+    assert_eq!(
+        rx.try_recv().expect("event"),
+        ReplEvent::AssistantOutput {
+            chunk: String::new(),
+            done: true,
+            is_error: false,
+        }
+    );
+}
+
+#[test]
+fn forward_session_done_failed_marks_is_error() {
+    let (tx, mut rx) = unbounded_channel();
+    forward_session_event(
+        envelope(Event::SessionDone {
+            session_id: "s-1".into(),
+            status: "failed".into(),
+        }),
+        &tx,
+    );
+    assert_eq!(
+        rx.try_recv().expect("event"),
+        ReplEvent::AssistantOutput {
+            chunk: String::new(),
+            done: true,
+            is_error: true,
+        }
+    );
+}
+
+#[test]
+fn forward_session_cancelled_is_terminal() {
+    let (tx, mut rx) = unbounded_channel();
+    let terminal = forward_session_event(
+        envelope(Event::SessionCancelled {
+            session_id: "s-1".into(),
+        }),
+        &tx,
+    );
+    assert!(terminal);
+    assert!(rx.try_recv().is_ok());
+}
+
+#[test]
+fn forward_unrelated_event_is_ignored() {
+    let (tx, mut rx) = unbounded_channel();
+    let terminal = forward_session_event(envelope(Event::Ping), &tx);
+    assert!(!terminal);
+    assert!(rx.try_recv().is_err());
+}
+
+#[test]
+fn workstream_subcommand_parses_list_and_activate() {
+    assert_eq!(workstream_subcommand("/workstream list"), Some("list"));
+    assert_eq!(
+        workstream_subcommand("/ws activate abc-123"),
+        Some("activate abc-123")
+    );
+    assert_eq!(workstream_subcommand("/workstream"), Some(""));
+    assert_eq!(workstream_subcommand("/workstreamx foo"), None);
+    assert_eq!(workstream_subcommand("hello"), None);
+}
+
+#[test]
+fn parse_workstream_envelope_round_trips_activation_changed() {
+    let json = serde_json::json!({
+        "session_id": "",
+        "event_type": "workstream_activation_changed",
+        "payload": {
+            "type": "workstream_activation_changed",
+            "new_active_id": "ws-2",
+            "prior_id": "ws-1",
+        },
+    })
+    .to_string();
+    let env = parse_workstream_envelope(&json).expect("parse");
+    match env.payload {
+        Event::WorkstreamActivationChanged {
+            new_active_id,
+            prior_id,
+        } => {
+            assert_eq!(new_active_id.as_deref(), Some("ws-2"));
+            assert_eq!(prior_id.as_deref(), Some("ws-1"));
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+}
+
+#[test]
+fn is_retryable_status_covers_502_and_503_only() {
+    assert!(is_retryable_status(reqwest::StatusCode::BAD_GATEWAY));
+    assert!(is_retryable_status(
+        reqwest::StatusCode::SERVICE_UNAVAILABLE
+    ));
+    assert!(!is_retryable_status(reqwest::StatusCode::NOT_FOUND));
+}
+
+/// The caches must start empty before `setup()` populates them —
+/// `commands()`/`picker()` must degrade to "nothing yet," never panic,
+/// when queried before `setup()` runs.
+#[test]
+fn caches_are_empty_before_setup() {
+    let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), "http://127.0.0.1:1", None);
+    assert!(engine.commands().is_empty());
+    assert!(engine.picker("workstream").is_empty());
+}

--- a/crates/trusty-code/src/tui_client/error.rs
+++ b/crates/trusty-code/src/tui_client/error.rs
@@ -1,0 +1,76 @@
+//! [`EngineError`]: [`crate::tui_client::CodeEngine`]'s unified error type.
+//!
+//! Why: `CodeEngine`'s `TuiEngine` methods return `anyhow::Result` (the
+//! trait's signature, `crates/trusty-tui/src/engine.rs`), but the engine's
+//! own internal helpers need a concrete, matchable error type — both so
+//! tests can assert on WHICH failure occurred (discovery vs. transport vs.
+//! an RPC error envelope) and so `?` composes cleanly across the
+//! discovery/rpc/sse submodules before the outer `TuiEngine` method converts
+//! the final error into `anyhow::Error` (automatic via `anyhow`'s blanket
+//! `From<E: std::error::Error>` impl).
+//! What: one variant per failure class this client can observe: daemon
+//! discovery failure, an HTTP-transport-level failure (DNS/connect/decode),
+//! a non-2xx HTTP status without a JSON-RPC error envelope (e.g. `502`), a
+//! JSON-RPC error envelope from the daemon, and "no active session" (a
+//! caller-usage error, not a transport one — `handle_input` before `setup`
+//! completed).
+//! Test: exercised indirectly through every `tui_client` submodule's own
+//! tests and `tests/tui_client_engine.rs`.
+
+use serde_json::Value;
+
+use super::discovery::DiscoveryError;
+
+/// See module docs.
+#[derive(Debug, thiserror::Error)]
+pub enum EngineError {
+    /// No live daemon could be found (see [`DiscoveryError`] for the
+    /// specific reason — no candidate source, or a candidate that didn't
+    /// answer the liveness ping).
+    #[error(transparent)]
+    Discovery(#[from] DiscoveryError),
+
+    /// A `reqwest`-level failure: DNS/connect/TLS, a request timeout, or a
+    /// response-body decode failure. Carries the URL for context.
+    #[error("request to {url} failed: {source}")]
+    Transport {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+
+    /// The daemon answered with a non-2xx HTTP status that carries no
+    /// JSON-RPC error envelope to parse (the SSE routes return a bare HTTP
+    /// status on failure, unlike `POST /rpc`, which always returns `200`
+    /// with the error carried in the envelope — see
+    /// `crate::serve::http::rpc_handler`'s docs).
+    #[error("request to {url} returned HTTP {status}")]
+    Status {
+        url: String,
+        status: reqwest::StatusCode,
+    },
+
+    /// The daemon's `POST /rpc` response body didn't have the shape this
+    /// client expected (e.g. `session.create`'s result missing an `id`
+    /// field) — a daemon/client version-skew symptom, not a transport
+    /// failure.
+    #[error("malformed response from daemon: {0}")]
+    Malformed(String),
+
+    /// The daemon's JSON-RPC error envelope for a `POST /rpc` call
+    /// (verbatim: code + message + optional `data`).
+    #[error("daemon returned an error ({code}): {message}")]
+    Rpc {
+        code: i32,
+        message: String,
+        #[allow(dead_code)]
+        // surfaced for callers that want to inspect it; not read internally yet
+        data: Option<Value>,
+    },
+
+    /// `handle_input`/`cancel_session` was called before `setup` minted a
+    /// session (or after a session was never successfully created) — a
+    /// caller-sequencing error, never a transport failure.
+    #[error("no active tcode session — `setup` must complete before sending input")]
+    NoSession,
+}

--- a/crates/trusty-code/src/tui_client/mod.rs
+++ b/crates/trusty-code/src/tui_client/mod.rs
@@ -13,9 +13,12 @@
 
 pub mod discovery;
 pub mod engine;
+mod engine_state;
 pub mod error;
 pub mod rpc;
+mod session_events;
 pub mod sse;
+mod workstream_subscription;
 
 pub use engine::CodeEngine;
 pub use error::EngineError;

--- a/crates/trusty-code/src/tui_client/mod.rs
+++ b/crates/trusty-code/src/tui_client/mod.rs
@@ -1,0 +1,21 @@
+//! `CodeEngine` — the `trusty-tui` engine adapter for `tcode tui` (issue
+//! #3415, DOC-50 §3.3/§3.4, epic #3411 Slice 3).
+//!
+//! Why: see `crate::tui_client`'s doc comment on the `pub mod tui_client;`
+//! declaration in `lib.rs` for the full rationale (ephemeral `--stdio` CLI
+//! client vs. long-lived `--http` TUI client).
+//! What: [`discovery`] (daemon lookup), [`rpc`] (pooled `POST /rpc` client),
+//! [`sse`] (SSE line pump), [`error::EngineError`] (this module's unified
+//! error type), and [`engine::CodeEngine`] (the `trusty_tui::TuiEngine`
+//! impl itself — the module most callers want).
+//! Test: see each submodule's own docs; the full engine flow against a mock
+//! HTTP daemon lives in `tests/tui_client_engine.rs`.
+
+pub mod discovery;
+pub mod engine;
+pub mod error;
+pub mod rpc;
+pub mod sse;
+
+pub use engine::CodeEngine;
+pub use error::EngineError;

--- a/crates/trusty-code/src/tui_client/rpc.rs
+++ b/crates/trusty-code/src/tui_client/rpc.rs
@@ -1,0 +1,215 @@
+//! [`RpcHttpClient`]: a pooled JSON-RPC 2.0 client speaking `POST {base}/rpc`
+//! against a long-lived `tcode serve --http` daemon (issue #3415).
+//!
+//! Why: mirrors `crate::cli_client::stdio::StdioRpcClient`'s role over
+//! STDIO — one place that builds the wire request, sends it, and unwraps the
+//! envelope — but over HTTP against an ALREADY-RUNNING daemon instead of a
+//! per-call spawned child. Reuses the exact same wire types
+//! (`trusty_common::mcp::{Request, Response}`) `StdioRpcClient` and
+//! `crate::serve::http::rpc_handler` already use, so there is exactly one
+//! `Request`/`Response` shape in this crate regardless of transport.
+//! What: [`RpcHttpClient::call`] mints a monotonic request id, POSTs the
+//! envelope, and unwraps the response into either `Ok(result)` or an
+//! [`EngineError::Rpc`]/[`EngineError::Transport`]. Holds one
+//! `reqwest::Client` for its whole lifetime (pooled keep-alive connections,
+//! DOC-50 §3.4 point 5) — callers needing the SSE routes (`sse.rs`) reuse
+//! the SAME client via [`RpcHttpClient::http`] rather than building a second
+//! one.
+//! Test: `rpc_tests::*` against a `wiremock` mock server.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use serde_json::Value;
+use trusty_common::mcp::{Request, Response};
+
+use super::error::EngineError;
+
+/// How long a single `POST /rpc` call waits for a response before giving
+/// up. Every method this client calls today (`session.*`, `task.run`,
+/// `workstream.*`) is a fast, synchronous handler — `task.run` reserves its
+/// execution slot and returns immediately rather than blocking on the LLM
+/// run (mirrors `crate::cli_client::stdio::DEFAULT_CALL_TIMEOUT`'s docs) —
+/// so a real hang here means a genuine daemon-side regression, not a slow
+/// but legitimate call.
+pub const DEFAULT_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// See module docs.
+pub struct RpcHttpClient {
+    http: reqwest::Client,
+    base_url: String,
+    next_id: AtomicI64,
+}
+
+impl RpcHttpClient {
+    /// Build a client targeting `base_url` (no trailing slash), reusing the
+    /// caller-supplied pooled `reqwest::Client`.
+    pub fn new(http: reqwest::Client, base_url: String) -> Self {
+        Self {
+            http,
+            base_url,
+            next_id: AtomicI64::new(1),
+        }
+    }
+
+    /// The daemon base URL this client targets (e.g.
+    /// `http://127.0.0.1:7882`) — callers building SSE URLs
+    /// (`{base}/sessions/{id}/events`) read this rather than duplicating it.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// The shared pooled HTTP client — callers building their own requests
+    /// (the SSE routes, which aren't JSON-RPC) reuse this rather than
+    /// constructing a second `reqwest::Client` (defeating the connection
+    /// pool).
+    pub fn http(&self) -> &reqwest::Client {
+        &self.http
+    }
+
+    /// Call `method` with `params` against `POST {base_url}/rpc`, waiting
+    /// (bounded by [`DEFAULT_CALL_TIMEOUT`]) for the matching response.
+    ///
+    /// Why: the one call every `session.*`/`task.*`/`workstream.*` RPC in
+    /// this engine goes through.
+    /// What: mints a monotonic id, builds the `Request` envelope, POSTs it,
+    /// decodes the `Response` envelope, and returns `Ok(result)` or maps a
+    /// JSON-RPC error object onto [`EngineError::Rpc`]. A transport-level
+    /// failure (connect/timeout/decode) maps onto [`EngineError::Transport`].
+    /// Test: `rpc_tests::call_returns_result_on_success`,
+    /// `rpc_tests::call_maps_rpc_error_envelope`,
+    /// `rpc_tests::call_maps_transport_failure`.
+    pub async fn call(&self, method: &str, params: Value) -> Result<Value, EngineError> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let req = Request {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(serde_json::json!(id)),
+            method: method.to_string(),
+            params: Some(params),
+        };
+        let url = format!("{}/rpc", self.base_url);
+        let resp = self
+            .http
+            .post(&url)
+            .json(&req)
+            .timeout(DEFAULT_CALL_TIMEOUT)
+            .send()
+            .await
+            .map_err(|source| EngineError::Transport {
+                url: url.clone(),
+                source,
+            })?;
+        let body: Response = resp
+            .json()
+            .await
+            .map_err(|source| EngineError::Transport { url, source })?;
+        if let Some(err) = body.error {
+            return Err(EngineError::Rpc {
+                code: err.code,
+                message: err.message,
+                data: err.data,
+            });
+        }
+        Ok(body.result.unwrap_or(Value::Null))
+    }
+}
+
+#[cfg(test)]
+mod rpc_tests {
+    use super::*;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// A successful `POST /rpc` call must return the envelope's `result`.
+    #[tokio::test]
+    async fn call_returns_result_on_success() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rpc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"pong": true},
+            })))
+            .mount(&server)
+            .await;
+
+        let client = RpcHttpClient::new(reqwest::Client::new(), server.uri());
+        let result = client.call("ping", json!({})).await.expect("call");
+        assert_eq!(result, json!({"pong": true}));
+    }
+
+    /// A JSON-RPC error envelope must map onto `EngineError::Rpc`, carrying
+    /// the code/message through verbatim.
+    #[tokio::test]
+    async fn call_maps_rpc_error_envelope() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rpc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": {"code": -32002, "message": "workstream not found"},
+            })))
+            .mount(&server)
+            .await;
+
+        let client = RpcHttpClient::new(reqwest::Client::new(), server.uri());
+        let err = client
+            .call("workstream.get", json!({"id": "missing"}))
+            .await
+            .expect_err("must be an error");
+        match err {
+            EngineError::Rpc { code, message, .. } => {
+                assert_eq!(code, -32002);
+                assert_eq!(message, "workstream not found");
+            }
+            other => panic!("expected EngineError::Rpc, got {other:?}"),
+        }
+    }
+
+    /// A transport-level failure (daemon unreachable) must map onto
+    /// `EngineError::Transport`, not panic or silently swallow the error.
+    #[tokio::test]
+    async fn call_maps_transport_failure() {
+        // Nothing is listening on this port — a real connection failure.
+        let client = RpcHttpClient::new(reqwest::Client::new(), "http://127.0.0.1:1".to_string());
+        let err = client
+            .call("ping", json!({}))
+            .await
+            .expect_err("must be an error");
+        assert!(matches!(err, EngineError::Transport { .. }));
+    }
+
+    /// Two calls in sequence must use two DIFFERENT ids — proves the
+    /// monotonic counter actually advances (a daemon matching on id would
+    /// otherwise silently misroute a second in-flight call).
+    #[tokio::test]
+    async fn successive_calls_use_distinct_ids() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/rpc"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {},
+            })))
+            .mount(&server)
+            .await;
+
+        let client = RpcHttpClient::new(reqwest::Client::new(), server.uri());
+        client.call("ping", json!({})).await.expect("call 1");
+        client.call("ping", json!({})).await.expect("call 2");
+
+        let requests = server.received_requests().await.expect("received");
+        assert_eq!(requests.len(), 2);
+        let ids: Vec<i64> = requests
+            .iter()
+            .map(|r| {
+                let body: Value = r.body_json().expect("body json");
+                body["id"].as_i64().expect("id")
+            })
+            .collect();
+        assert_ne!(ids[0], ids[1]);
+    }
+}

--- a/crates/trusty-code/src/tui_client/session_events.rs
+++ b/crates/trusty-code/src/tui_client/session_events.rs
@@ -1,0 +1,126 @@
+//! Translating one `GET /sessions/{id}/events` [`SessionEventEnvelope`] into
+//! [`ReplEvent`]s, and classifying which HTTP statuses are worth an SSE
+//! reconnect (issue #3415).
+//!
+//! Why: split out of `engine.rs` (issue #610's 500-SLOC production-file cap)
+//! — this is the one piece of `EngineState::pump_session_events`
+//! (`engine_state.rs`) that is pure and directly unit-testable without an
+//! HTTP round trip, so it earns its own file rather than staying inline.
+//! What: [`forward_session_event`] (the `Event` -> `ReplEvent` mapping) and
+//! [`is_retryable_status`] (502/503 -> reconnect, everything else -> fail).
+//! Test: `engine_tests::*` (in the sibling `engine_tests.rs`, included from
+//! `engine.rs`).
+
+use serde_json::{Value, json};
+use tokio::sync::mpsc::UnboundedSender;
+use trusty_tui::ReplEvent;
+
+use crate::events::{Event, SessionEventEnvelope};
+
+/// `true` for HTTP statuses worth retrying (daemon restarting) rather than
+/// failing immediately.
+pub(super) fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    status == reqwest::StatusCode::BAD_GATEWAY || status == reqwest::StatusCode::SERVICE_UNAVAILABLE
+}
+
+/// Translate one [`SessionEventEnvelope`] into zero or more [`ReplEvent`]s
+/// on `tx`. Returns `true` iff this event is terminal for the current chat
+/// turn (`SessionDone`/`SessionCancelled`) — the caller stops pumping.
+///
+/// Why: kept as a free function (not a method) so it's directly unit
+/// testable against a hand-built envelope, no HTTP/mock server needed.
+/// What: `Message`/`AgentMessage`/`PmThinking` -> `AssistantOutput` chunks
+/// (`done: false`); `ToolStarted` -> `ToolInvocation{result: None}`;
+/// `ToolFinished`/`ToolError` -> `ToolInvocation{result: Some(..)}`, keyed
+/// by the SAME `call_id` so the (future) tool-card renderer can pair them;
+/// `SessionDone` -> a final `AssistantOutput{done: true}` (`is_error` iff
+/// `status == "failed"`); `SessionCancelled` -> a status message. Every
+/// other event kind (progress/telemetry/agent-lifecycle events this MVP
+/// doesn't yet render) is silently ignored — forward-compatible with new
+/// `Event` variants (no `match` arm needed per new kind, thanks to the
+/// catch-all).
+/// Test: `engine_tests::forward_message_emits_assistant_output_chunk_not_done`,
+/// `engine_tests::forward_tool_started_emits_tool_invocation_with_call_id`,
+/// `engine_tests::forward_tool_finished_carries_result_and_shares_call_id`,
+/// `engine_tests::forward_session_done_is_terminal`,
+/// `engine_tests::forward_session_done_failed_marks_is_error`,
+/// `engine_tests::forward_session_cancelled_is_terminal`,
+/// `engine_tests::forward_unrelated_event_is_ignored`.
+pub(super) fn forward_session_event(
+    envelope: SessionEventEnvelope,
+    tx: &UnboundedSender<ReplEvent>,
+) -> bool {
+    match envelope.event {
+        Event::Message { text, .. }
+        | Event::AgentMessage { text, .. }
+        | Event::PmThinking { text, .. } => {
+            let _ = tx.send(ReplEvent::AssistantOutput {
+                chunk: text,
+                done: false,
+                is_error: false,
+            });
+            false
+        }
+        Event::ToolStarted {
+            tool,
+            call_id,
+            args_preview,
+            ..
+        } => {
+            let _ = tx.send(ReplEvent::ToolInvocation {
+                id: call_id,
+                tool_name: tool,
+                args: json!(args_preview),
+                result: None,
+            });
+            false
+        }
+        Event::ToolFinished {
+            tool,
+            call_id,
+            result_preview,
+            success,
+            ..
+        } => {
+            let result = if success {
+                result_preview
+            } else {
+                format!("FAILED: {result_preview}")
+            };
+            let _ = tx.send(ReplEvent::ToolInvocation {
+                id: call_id,
+                tool_name: tool,
+                args: Value::Null,
+                result: Some(result),
+            });
+            false
+        }
+        Event::ToolError {
+            tool,
+            call_id,
+            error,
+            ..
+        } => {
+            let _ = tx.send(ReplEvent::ToolInvocation {
+                id: call_id,
+                tool_name: tool,
+                args: Value::Null,
+                result: Some(format!("ERROR: {error}")),
+            });
+            false
+        }
+        Event::SessionDone { status, .. } => {
+            let _ = tx.send(ReplEvent::AssistantOutput {
+                chunk: String::new(),
+                done: true,
+                is_error: status == "failed",
+            });
+            true
+        }
+        Event::SessionCancelled { .. } => {
+            let _ = tx.send(ReplEvent::StatusMessage("cancelled".to_string()));
+            true
+        }
+        _ => false,
+    }
+}

--- a/crates/trusty-code/src/tui_client/sse.rs
+++ b/crates/trusty-code/src/tui_client/sse.rs
@@ -1,0 +1,150 @@
+//! [`SseLines`]: a minimal Server-Sent-Events line pump over a
+//! `reqwest::Response` body (issue #3415).
+//!
+//! Why: `CodeEngine` consumes two SSE routes
+//! (`GET /sessions/{id}/events`, `GET /workstreams/{id}/events`) that both
+//! frame their payloads as plain `data: <json>\n\n` lines (axum's
+//! `axum::response::sse::Event::default().json_data(..)`, see
+//! `crate::serve::http::sse_event_for`/`crate::workstreams::sse::sse_event_for`).
+//! Pulling in a full SSE client crate for "read `data:` lines from a byte
+//! stream" would be disproportionate; `crate::cli_client::stdio` already
+//! shows this crate's convention of hand-rolling the minimal wire parser
+//! for a trusted, in-house transport rather than adding a dependency for a
+//! few lines of line-splitting (mirrors
+//! `trusty_common::chat::openai_compat::sse_pump::pump_openai_sse`'s
+//! `buf.find('\n')` loop, adapted to this crate's own `data:` framing).
+//! What: [`SseLines::new`] wraps a `reqwest::Response`'s byte stream;
+//! [`SseLines::next_data`] returns the next non-empty `data:` payload
+//! (already stripped of the prefix and trimmed) as `Ok(Some(json_text))`,
+//! `Ok(None)` on a clean upstream close, or `Err` on a stream I/O failure.
+//! SSE comment lines (`:` keep-alive pings) and blank `data:` lines are
+//! silently skipped, never surfaced.
+//! Test: `sse_tests::*` against synthetic byte chunks (no network).
+
+use std::pin::Pin;
+
+use futures_util::{Stream, StreamExt};
+
+/// See module docs.
+pub struct SseLines {
+    stream: Pin<Box<dyn Stream<Item = reqwest::Result<Vec<u8>>> + Send>>,
+    buf: String,
+}
+
+impl SseLines {
+    /// Wrap `resp`'s body as an SSE line source.
+    pub fn new(resp: reqwest::Response) -> Self {
+        // `.map` converts each `bytes::Bytes` chunk to `Vec<u8>` so this
+        // module never needs to name the `bytes` crate's type directly (not
+        // otherwise a dependency of this crate).
+        let stream = resp.bytes_stream().map(|r| r.map(|b| b.to_vec()));
+        Self {
+            stream: Box::pin(stream),
+            buf: String::new(),
+        }
+    }
+
+    /// Return the next `data:` payload, reading more of the underlying byte
+    /// stream as needed.
+    ///
+    /// Why/What: see module docs.
+    /// Test: `sse_tests::next_data_skips_comments_and_blank_lines`,
+    /// `sse_tests::next_data_returns_none_on_clean_close`,
+    /// `sse_tests::next_data_on_empty_body_returns_none`.
+    pub async fn next_data(&mut self) -> Result<Option<String>, reqwest::Error> {
+        loop {
+            if let Some(idx) = self.buf.find('\n') {
+                let line: String = self.buf.drain(..=idx).collect();
+                let line = line.trim();
+                if let Some(payload) = line.strip_prefix("data:") {
+                    let payload = payload.trim();
+                    if !payload.is_empty() {
+                        return Ok(Some(payload.to_string()));
+                    }
+                }
+                // Every other line shape (blank keep-alive, `event:`,
+                // `id:`, `:comment`) is intentionally ignored — neither SSE
+                // route this client consumes uses named events or ids.
+                continue;
+            }
+            match self.stream.next().await {
+                Some(Ok(bytes)) => {
+                    if let Ok(text) = std::str::from_utf8(&bytes) {
+                        self.buf.push_str(text);
+                    }
+                    // Invalid UTF-8 mid-chunk is dropped rather than erroring
+                    // — SSE framing here is always JSON text; a malformed
+                    // chunk boundary is exceedingly unlikely and, if it
+                    // happens, the next chunk still resyncs on the next
+                    // `\n`.
+                }
+                Some(Err(e)) => return Err(e),
+                None => return Ok(None),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod sse_tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Build an `SseLines` whose byte stream comes from a `wiremock`
+    /// response body — the simplest way to get a REAL `reqwest::Response`
+    /// (needed for `.bytes_stream()`) without standing up a hand-rolled
+    /// hyper server.
+    async fn sse_lines_for_body(body: &str) -> SseLines {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/events"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_raw(body.to_string(), "text/event-stream"),
+            )
+            .mount(&server)
+            .await;
+        let resp = reqwest::get(format!("{}/events", server.uri()))
+            .await
+            .expect("get");
+        SseLines::new(resp)
+    }
+
+    /// Comment lines (`: keep-alive`) and blank `data:` framing must be
+    /// skipped; only real payloads are returned, in order.
+    #[tokio::test]
+    async fn next_data_skips_comments_and_blank_lines() {
+        let mut lines =
+            sse_lines_for_body(": keep-alive\n\ndata: {\"a\":1}\n\ndata:\n\ndata: {\"a\":2}\n\n")
+                .await;
+        assert_eq!(
+            lines.next_data().await.expect("read"),
+            Some("{\"a\":1}".to_string())
+        );
+        assert_eq!(
+            lines.next_data().await.expect("read"),
+            Some("{\"a\":2}".to_string())
+        );
+        assert_eq!(lines.next_data().await.expect("read"), None);
+    }
+
+    /// A clean upstream close (no more bytes) must yield `Ok(None)`, not an
+    /// error — this is the normal "server finished the stream" case, not a
+    /// transport failure.
+    #[tokio::test]
+    async fn next_data_returns_none_on_clean_close() {
+        let mut lines = sse_lines_for_body("data: {\"only\":true}\n\n").await;
+        assert_eq!(
+            lines.next_data().await.expect("read"),
+            Some("{\"only\":true}".to_string())
+        );
+        assert_eq!(lines.next_data().await.expect("read"), None);
+    }
+
+    /// An empty body must yield `Ok(None)` on the very first call.
+    #[tokio::test]
+    async fn next_data_on_empty_body_returns_none() {
+        let mut lines = sse_lines_for_body("").await;
+        assert_eq!(lines.next_data().await.expect("read"), None);
+    }
+}

--- a/crates/trusty-code/src/tui_client/workstream_subscription.rs
+++ b/crates/trusty-code/src/tui_client/workstream_subscription.rs
@@ -87,18 +87,53 @@ pub(super) async fn run_workstream_subscription(
                         continue;
                     };
                     if let Event::WorkstreamActivationChanged {
-                        new_active_id: Some(new_id),
+                        new_active_id,
                         prior_id,
                     } = env.payload
                     {
-                        let _ = tx.send(ReplEvent::WorkstreamActivationChanged {
-                            new_active_id: new_id.clone(),
-                            prior_id,
-                        });
+                        // Always refresh — a `None` new_active_id (this
+                        // workstream deactivated with no replacement, DOC-48
+                        // §4.2/§4.3) is just as real a state change as an
+                        // activation and must invalidate the cache too
+                        // (HIGH finding: silently skipping this arm left
+                        // `active_workstream`/the `"workstream"` picker
+                        // stale indefinitely).
                         state.refresh_workstream_cache().await;
-                        if new_id != current_id {
-                            current_id = new_id;
-                            break; // reconnect to the newly-active workstream's endpoint
+                        match new_active_id {
+                            Some(new_id) => {
+                                let _ = tx.send(ReplEvent::WorkstreamActivationChanged {
+                                    new_active_id: new_id.clone(),
+                                    prior_id,
+                                });
+                                if new_id != current_id {
+                                    current_id = new_id;
+                                    break; // reconnect to the newly-active workstream's endpoint
+                                }
+                            }
+                            None => {
+                                // Deactivated, no replacement active. The
+                                // SHARED `ReplEvent::WorkstreamActivationChanged`
+                                // (`trusty_tui::event`) declares `new_active_id`
+                                // as a non-optional `String` — this state
+                                // genuinely cannot be carried by that variant
+                                // without a breaking change to `trusty-tui`
+                                // (out of this crate's ownership), so a
+                                // `StatusMessage` is the honest signal
+                                // available today; the cache refresh above
+                                // is what actually clears the stale
+                                // indicator (`active_workstream` -> `None`,
+                                // the `"workstream"` picker's active marker
+                                // gone). Stay connected to `current_id`'s
+                                // stream rather than reconnecting anywhere:
+                                // deactivation is not closure (DOC-48 §4.4),
+                                // and `crate::workstreams::sse`'s
+                                // `classify()` still forwards a LATER
+                                // activation naming `current_id` as its
+                                // `prior_id` to this same connection.
+                                let _ = tx.send(ReplEvent::StatusMessage(format!(
+                                    "workstream {current_id} deactivated — no workstream is now active"
+                                )));
+                            }
                         }
                     }
                 }

--- a/crates/trusty-code/src/tui_client/workstream_subscription.rs
+++ b/crates/trusty-code/src/tui_client/workstream_subscription.rs
@@ -1,0 +1,122 @@
+//! The long-lived `GET /workstreams/{id}/events` background subscription
+//! `TuiEngine::subscribe_workstream_events` spawns (issue #3415, DOC-48
+//! §5.3).
+//!
+//! Why: split out of `engine.rs` (issue #610's 500-SLOC production-file
+//! cap) — this is the one self-contained loop with its own wire-parsing
+//! helper, so it earns its own file rather than staying inline alongside
+//! `EngineState`.
+//! What: [`WireWorkstreamEnvelope`]/[`parse_workstream_envelope`] (the
+//! AC-7.2 wire shape this client deserialises SSE payloads into) and
+//! [`run_workstream_subscription`] (the reconnect loop itself, spawned via
+//! `tokio::spawn` by `engine.rs`'s `TuiEngine::subscribe_workstream_events`).
+//! Test: `engine_tests::parse_workstream_envelope_round_trips_activation_changed`
+//! (in the sibling `engine_tests.rs`, included from `engine.rs`); the full
+//! reconnect-to-a-new-workstream behaviour is covered end-to-end against a
+//! mock daemon in `tests/tui_client_engine.rs`.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use tokio::sync::mpsc::UnboundedSender;
+use trusty_tui::ReplEvent;
+
+use crate::events::Event;
+
+use super::engine::{RECONNECT_BACKOFF, SSE_IDLE_TIMEOUT};
+use super::engine_state::EngineState;
+use super::sse::SseLines;
+
+/// The AC-7.2 wire envelope this client deserialises off
+/// `GET /workstreams/{id}/events` — mirrors
+/// `crate::workstreams::sse::WorkstreamEventEnvelope`
+/// (`trusty_agents_common::transport::EventEnvelope<Event>`) exactly, but
+/// with `Deserialize` (the shared type only derives `Serialize` — it's
+/// built server-side, never parsed) — see module docs for why a small
+/// mirror struct here is preferable to adding `Deserialize` to the shared
+/// type for one client.
+#[derive(Debug, serde::Deserialize)]
+pub(super) struct WireWorkstreamEnvelope {
+    #[allow(dead_code)]
+    session_id: String,
+    #[allow(dead_code)]
+    event_type: String,
+    pub(super) payload: Event,
+}
+
+pub(super) fn parse_workstream_envelope(payload_json: &str) -> Option<WireWorkstreamEnvelope> {
+    serde_json::from_str(payload_json).ok()
+}
+
+/// Long-lived background loop for `subscribe_workstream_events`: holds one
+/// SSE connection to `GET /workstreams/{current_id}/events` at a time,
+/// reconnecting (to a possibly-NEW workstream id, per DOC-48 §5.3 point 5)
+/// on activation changes, transport errors, or idle timeouts, until
+/// `state.shutting_down` is set.
+pub(super) async fn run_workstream_subscription(
+    state: Arc<EngineState>,
+    mut current_id: String,
+    tx: UnboundedSender<ReplEvent>,
+) {
+    loop {
+        if state.shutting_down.load(Ordering::SeqCst) {
+            return;
+        }
+        let url = format!("{}/workstreams/{current_id}/events", state.rpc.base_url());
+        let resp = match state.rpc.http().get(&url).send().await {
+            Ok(r) if r.status().is_success() => r,
+            _ => {
+                let _ = tx.send(ReplEvent::ConnectionLost {
+                    reason: format!(
+                        "could not reach workstream events endpoint for {current_id}; retrying…"
+                    ),
+                });
+                tokio::time::sleep(RECONNECT_BACKOFF).await;
+                continue;
+            }
+        };
+
+        let mut lines = SseLines::new(resp);
+        loop {
+            if state.shutting_down.load(Ordering::SeqCst) {
+                return;
+            }
+            match tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_data()).await {
+                Ok(Ok(Some(payload))) => {
+                    let Some(env) = parse_workstream_envelope(&payload) else {
+                        continue;
+                    };
+                    if let Event::WorkstreamActivationChanged {
+                        new_active_id: Some(new_id),
+                        prior_id,
+                    } = env.payload
+                    {
+                        let _ = tx.send(ReplEvent::WorkstreamActivationChanged {
+                            new_active_id: new_id.clone(),
+                            prior_id,
+                        });
+                        state.refresh_workstream_cache().await;
+                        if new_id != current_id {
+                            current_id = new_id;
+                            break; // reconnect to the newly-active workstream's endpoint
+                        }
+                    }
+                }
+                Ok(Ok(None)) => {
+                    let _ = tx.send(ReplEvent::ConnectionLost {
+                        reason: "workstream event stream closed; reconnecting…".to_string(),
+                    });
+                    tokio::time::sleep(RECONNECT_BACKOFF).await;
+                    break;
+                }
+                Ok(Err(_)) | Err(_) => {
+                    let _ = tx.send(ReplEvent::ConnectionLost {
+                        reason: "workstream event stream error; reconnecting…".to_string(),
+                    });
+                    tokio::time::sleep(RECONNECT_BACKOFF).await;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/crates/trusty-code/tests/tui_client_engine.rs
+++ b/crates/trusty-code/tests/tui_client_engine.rs
@@ -161,10 +161,48 @@ fn workstream_activation_body() -> String {
     format!("data: {activation}\n\n")
 }
 
+/// An SSE body for `GET /workstreams/{WS_1}/events`: one
+/// `WorkstreamActivationChanged` event with `new_active_id: null` — the
+/// "deactivated, no replacement active" case (DOC-48 §4.2/§4.3), verified
+/// server-side by `workstreams::activation_tests` and forwarded to THIS
+/// stream (not just the new active workstream's) by `workstreams::sse`'s
+/// `classify()`, which matches on `prior_id == target` too.
+fn workstream_deactivated_body() -> String {
+    let deactivated = json!({
+        "session_id": "",
+        "event_type": "workstream_activation_changed",
+        "payload": {
+            "type": "workstream_activation_changed",
+            "new_active_id": null,
+            "prior_id": WS_1,
+        },
+    });
+    format!("data: {deactivated}\n\n")
+}
+
+/// Count how many `POST /rpc` requests the mock daemon has received for
+/// `method`.
+async fn count_rpc_calls(server: &MockServer, method: &str) -> usize {
+    server
+        .received_requests()
+        .await
+        .expect("received requests")
+        .iter()
+        .filter(|r| {
+            r.url.path() == "/rpc"
+                && serde_json::from_slice::<serde_json::Value>(&r.body)
+                    .ok()
+                    .and_then(|v| v.get("method").and_then(|m| m.as_str()).map(str::to_string))
+                    .as_deref()
+                    == Some(method)
+        })
+        .count()
+}
+
 /// `setup` must create a session via `session.create` and report the
-/// daemon's active workstream — and, ahead of `trusty-tui` Slice 1.5's
-/// synchronous `TuiEngine::commands()`/`picker()` accessors (#3428), must
-/// have already populated `CodeEngine`'s pre-fetched caches for them.
+/// daemon's active workstream — and must have already populated
+/// `CodeEngine`'s pre-fetched caches for `trusty-tui`'s synchronous
+/// `TuiEngine::commands()`/`picker()` accessors (#3428).
 #[tokio::test]
 async fn setup_creates_session_and_reports_active_workstream() {
     let server = MockServer::start().await;
@@ -189,13 +227,13 @@ async fn setup_creates_session_and_reports_active_workstream() {
     assert_eq!(
         engine.commands().len(),
         1,
-        "setup must populate the commands cache ahead of TuiEngine::commands() (#3428)"
+        "setup must populate the commands cache for TuiEngine::commands() (#3428)"
     );
-    assert_eq!(
-        engine.picker("workstream").len(),
-        1,
-        "setup must populate the workstream picker cache ahead of TuiEngine::picker() (#3428)"
-    );
+    let picker = engine
+        .picker("workstream")
+        .expect("setup must populate the workstream picker cache for TuiEngine::picker() (#3428)");
+    assert_eq!(picker.items.len(), 1);
+    assert_eq!(picker.dispatch_command, "/workstream activate");
 }
 
 /// `handle_input` on a chat line must call `task.run` against the current
@@ -276,17 +314,9 @@ async fn cancel_session_calls_session_cancel_rpc() {
 
     engine.cancel_session().await.expect("cancel_session");
 
-    let requests = server.received_requests().await.expect("received requests");
-    let saw_cancel = requests.iter().any(|r| {
-        r.url.path() == "/rpc"
-            && serde_json::from_slice::<serde_json::Value>(&r.body)
-                .ok()
-                .and_then(|v| v.get("method").and_then(|m| m.as_str()).map(str::to_string))
-                .as_deref()
-                == Some("session.cancel")
-    });
-    assert!(
-        saw_cancel,
+    assert_eq!(
+        count_rpc_calls(&server, "session.cancel").await,
+        1,
         "cancel_session must call the daemon's session.cancel RPC, not just stop client-side \
          rendering (DOC-39 §2.1 C-2)"
     );
@@ -351,6 +381,83 @@ async fn subscribe_workstream_events_emits_activation_changed_with_wire_field_na
         }
         other => panic!("unexpected {other:?}"),
     }
+
+    engine.shutdown().await.expect("shutdown");
+}
+
+/// Regression test (HIGH finding, code-critic review of PR #3436): a
+/// `WorkstreamActivationChanged` event with `new_active_id: null` (this
+/// workstream deactivated with no replacement active — a state the daemon
+/// legitimately publishes, DOC-48 §4.2/§4.3) must NOT be silently dropped.
+/// Before the fix, `run_workstream_subscription` only matched
+/// `new_active_id: Some(..)`, so the whole event fell through the `if let`
+/// unhandled: no `ReplEvent` was sent and `refresh_workstream_cache` never
+/// ran, leaving the TUI's status line and the `"workstream"` picker cache
+/// stale indefinitely. This asserts BOTH halves of the fix: the cache
+/// actually refreshes (a second `workstream.list` call beyond `setup()`'s
+/// own), and the engine surfaces a user-visible signal (a `StatusMessage`
+/// naming the deactivation — `trusty-tui`'s `ReplEvent::WorkstreamActivationChanged`
+/// declares `new_active_id` as a non-optional `String`, so it structurally
+/// cannot carry this state; see `workstream_subscription.rs`'s docs).
+#[tokio::test]
+async fn subscribe_workstream_events_refreshes_cache_on_deactivation_with_no_replacement() {
+    let server = MockServer::start().await;
+    mount_common(&server).await;
+    Mock::given(method("GET"))
+        .and(path(format!("/workstreams/{WS_1}/events")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(workstream_deactivated_body(), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), server.uri(), None);
+    let (tx, mut rx) = unbounded_channel();
+    engine.setup(tx.clone()).await.expect("setup");
+    while rx.try_recv().is_ok() {} // drain setup's own events
+
+    let calls_before = count_rpc_calls(&server, "workstream.list").await;
+    assert_eq!(
+        calls_before, 1,
+        "setup must have called workstream.list exactly once so far"
+    );
+
+    engine
+        .subscribe_workstream_events(tx)
+        .await
+        .expect("subscribe_workstream_events");
+
+    // Half 1 of the fix: the cache must actually refresh on the `None` arm
+    // — proven by a SECOND workstream.list call beyond setup()'s own.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if count_rpc_calls(&server, "workstream.list").await > calls_before {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for refresh_workstream_cache to re-call workstream.list");
+
+    // Half 2 of the fix: the engine must not go silent — some ReplEvent
+    // must report the deactivation.
+    let saw_deactivation_status = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await {
+                Some(ReplEvent::StatusMessage(msg)) if msg.contains("deactivated") => return true,
+                Some(_) => continue,
+                None => return false,
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for a deactivation status message");
+    assert!(
+        saw_deactivation_status,
+        "expected a StatusMessage naming the deactivation"
+    );
 
     engine.shutdown().await.expect("shutdown");
 }

--- a/crates/trusty-code/tests/tui_client_engine.rs
+++ b/crates/trusty-code/tests/tui_client_engine.rs
@@ -1,0 +1,381 @@
+//! Hermetic integration test for [`trusty_code::tui_client::CodeEngine`]
+//! against a mock HTTP daemon (issue #3415, DOC-50 §3.3/§3.4).
+//!
+//! Why: `CodeEngine` is the thin-client seam over a `tcode serve --http`
+//! daemon — its correctness is entirely about the wire contract (which RPC
+//! methods it calls, with what params, and how it turns the daemon's
+//! responses/SSE events into `trusty_tui::ReplEvent`s), not about any real
+//! agent-loop behaviour. A `wiremock`-backed mock daemon (mirroring
+//! `crates/trusty-channels/tests/client_http.rs`'s pattern) lets this suite
+//! assert on that wire contract without spawning the real `tcode` binary —
+//! this file is deliberately NOT named `*_e2e.rs` (this crate's convention
+//! for tests that drive the real binary, see `tests/support/mod.rs`'s
+//! docs) since it never does.
+//! What: one scenario per `TuiEngine` method this slice implements —
+//! `setup` (session creation + initial workstream), `handle_input`
+//! (streamed assistant output + a tool invocation, correlated by `call_id`),
+//! `cancel_session` (asserts the daemon's `session.cancel` RPC was actually
+//! called — the thin-client axiom, DOC-39 §2.1 C-2), `subscribe_workstream_events`
+//! (a `WorkstreamActivationChanged` SSE event, asserting the wire field
+//! names `new_active_id`/`prior_id` match DOC-48 §5.3 exactly), and
+//! `CodeEngine::discover` (the full daemon-discovery path via
+//! `TCODE_DAEMON_URL`, verified against a live mock daemon's `/health`).
+//! Test: this file is the test.
+
+use std::time::Duration;
+
+use serde_json::json;
+use tokio::sync::mpsc::unbounded_channel;
+use trusty_code::tui_client::CodeEngine;
+use trusty_code::tui_client::discovery::DAEMON_URL_ENV;
+use trusty_tui::{ReplEvent, TuiEngine};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+const SESSION_ID: &str = "sess-1";
+const WS_1: &str = "ws-1";
+const WS_2: &str = "ws-2";
+
+/// Matches a `POST /rpc` body whose `"method"` field equals `.0` — `POST
+/// /rpc` is a single endpoint carrying many logical methods, so matching on
+/// `path("/rpc")` alone can't distinguish them; this is the custom
+/// `wiremock::Match` every mock below layers on top of `path("/rpc")`.
+struct RpcMethod(&'static str);
+
+impl wiremock::Match for RpcMethod {
+    fn matches(&self, request: &Request) -> bool {
+        serde_json::from_slice::<serde_json::Value>(&request.body)
+            .ok()
+            .and_then(|v| v.get("method").and_then(|m| m.as_str()).map(str::to_string))
+            .as_deref()
+            == Some(self.0)
+    }
+}
+
+/// Mount every `POST /rpc` method + `GET /health` this suite's scenarios
+/// need, EXCEPT the per-scenario SSE routes (`GET /sessions/{id}/events`,
+/// `GET /workstreams/{id}/events`) — those vary per test and are mounted by
+/// each test individually.
+async fn mount_common(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/rpc"))
+        .and(RpcMethod("session.create"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"id": SESSION_ID, "task": "tcode tui session", "status": "running"},
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/rpc"))
+        .and(RpcMethod("workstream.list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "active_workstream_id": WS_1,
+                "workstreams": [{"id": WS_1, "name": "Feature X"}],
+            },
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/rpc"))
+        .and(RpcMethod("task.run"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"session_id": SESSION_ID, "status": "running"},
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/rpc"))
+        .and(RpcMethod("session.cancel"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {},
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/rpc"))
+        .and(RpcMethod("workstream.activate"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {"active_id": WS_2, "prior_id": WS_1},
+        })))
+        .mount(server)
+        .await;
+}
+
+/// An SSE body for `GET /sessions/{SESSION_ID}/events`: a tool invocation
+/// (`ToolStarted`), a chunk of assistant text (`Message`), then a terminal
+/// `SessionDone` — the full shape `handle_input`'s scenario asserts on.
+fn session_events_body() -> String {
+    let tool_started = json!({
+        "session_id": SESSION_ID, "seq": 1, "at": "2026-07-20T00:00:00Z", "kind": "tool_started",
+        "event": {
+            "type": "tool_started", "session_id": SESSION_ID, "agent": "pm", "agent_id": "",
+            "tool": "bash", "call_id": "call-1", "args_preview": "ls",
+        },
+    });
+    let message = json!({
+        "session_id": SESSION_ID, "seq": 2, "at": "2026-07-20T00:00:01Z", "kind": "message",
+        "event": {"type": "message", "session_id": SESSION_ID, "text": "hello from the daemon"},
+    });
+    let done = json!({
+        "session_id": SESSION_ID, "seq": 3, "at": "2026-07-20T00:00:02Z", "kind": "session_done",
+        "event": {"type": "session_done", "session_id": SESSION_ID, "status": "finished"},
+    });
+    format!("data: {tool_started}\n\ndata: {message}\n\ndata: {done}\n\n")
+}
+
+/// An SSE body for `GET /workstreams/{WS_1}/events`: one
+/// `WorkstreamActivationChanged` event, wire-shaped exactly as DOC-48 §5.3
+/// specifies (`new_active_id`/`prior_id`, NOT the drifted `new_id` DOC-50 §5
+/// Slice 6's prose used).
+fn workstream_activation_body() -> String {
+    let activation = json!({
+        "session_id": "",
+        "event_type": "workstream_activation_changed",
+        "payload": {
+            "type": "workstream_activation_changed",
+            "new_active_id": WS_2,
+            "prior_id": WS_1,
+        },
+    });
+    format!("data: {activation}\n\n")
+}
+
+/// `setup` must create a session via `session.create` and report the
+/// daemon's active workstream — and, ahead of `trusty-tui` Slice 1.5's
+/// synchronous `TuiEngine::commands()`/`picker()` accessors (#3428), must
+/// have already populated `CodeEngine`'s pre-fetched caches for them.
+#[tokio::test]
+async fn setup_creates_session_and_reports_active_workstream() {
+    let server = MockServer::start().await;
+    mount_common(&server).await;
+
+    let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), server.uri(), None);
+    let (tx, mut rx) = unbounded_channel();
+    engine.setup(tx).await.expect("setup");
+
+    let mut saw_workstream_updated = false;
+    while let Ok(ev) = rx.try_recv() {
+        if let ReplEvent::WorkstreamUpdated(ws) = ev {
+            assert_eq!(ws.id, WS_1);
+            assert_eq!(ws.name, "Feature X");
+            saw_workstream_updated = true;
+        }
+    }
+    assert!(
+        saw_workstream_updated,
+        "setup must emit WorkstreamUpdated for the daemon's active workstream"
+    );
+    assert_eq!(
+        engine.commands().len(),
+        1,
+        "setup must populate the commands cache ahead of TuiEngine::commands() (#3428)"
+    );
+    assert_eq!(
+        engine.picker("workstream").len(),
+        1,
+        "setup must populate the workstream picker cache ahead of TuiEngine::picker() (#3428)"
+    );
+}
+
+/// `handle_input` on a chat line must call `task.run` against the current
+/// session, then stream the response as `ReplEvent`s: a `ToolInvocation`
+/// (carrying the daemon's `call_id`), an `AssistantOutput` chunk, and a
+/// final `AssistantOutput{done: true}`.
+#[tokio::test]
+async fn handle_input_streams_assistant_output_and_tool_invocation() {
+    let server = MockServer::start().await;
+    mount_common(&server).await;
+    Mock::given(method("GET"))
+        .and(path(format!("/sessions/{SESSION_ID}/events")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(session_events_body(), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+
+    let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), server.uri(), None);
+    let (tx, mut rx) = unbounded_channel();
+    engine.setup(tx.clone()).await.expect("setup");
+    while rx.try_recv().is_ok() {} // drain setup's own events
+
+    let keep_going = engine
+        .handle_input("hello".to_string(), tx)
+        .await
+        .expect("handle_input");
+    assert!(
+        keep_going,
+        "handle_input must return Ok(true) to keep the REPL running"
+    );
+
+    let mut events = Vec::new();
+    while let Ok(ev) = rx.try_recv() {
+        events.push(ev);
+    }
+
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            ReplEvent::ToolInvocation { id, tool_name, result: None, .. }
+                if id == "call-1" && tool_name == "bash"
+        )),
+        "expected a ToolInvocation for call-1/bash with no result yet; got {events:?}"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            ReplEvent::AssistantOutput { chunk, done: false, is_error: false }
+                if chunk == "hello from the daemon"
+        )),
+        "expected an in-progress AssistantOutput chunk; got {events:?}"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            ReplEvent::AssistantOutput {
+                done: true,
+                is_error: false,
+                ..
+            }
+        )),
+        "expected a final AssistantOutput{{done: true}} on SessionDone; got {events:?}"
+    );
+}
+
+/// `cancel_session` must call the daemon's `session.cancel` RPC — per the
+/// thin-client axiom (DOC-39 §2.1 C-2), client-side render-stop alone is
+/// never acceptable.
+#[tokio::test]
+async fn cancel_session_calls_session_cancel_rpc() {
+    let server = MockServer::start().await;
+    mount_common(&server).await;
+
+    let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), server.uri(), None);
+    let (tx, _rx) = unbounded_channel();
+    engine.setup(tx).await.expect("setup");
+
+    engine.cancel_session().await.expect("cancel_session");
+
+    let requests = server.received_requests().await.expect("received requests");
+    let saw_cancel = requests.iter().any(|r| {
+        r.url.path() == "/rpc"
+            && serde_json::from_slice::<serde_json::Value>(&r.body)
+                .ok()
+                .and_then(|v| v.get("method").and_then(|m| m.as_str()).map(str::to_string))
+                .as_deref()
+                == Some("session.cancel")
+    });
+    assert!(
+        saw_cancel,
+        "cancel_session must call the daemon's session.cancel RPC, not just stop client-side \
+         rendering (DOC-39 §2.1 C-2)"
+    );
+}
+
+/// `subscribe_workstream_events` must open `GET /workstreams/{id}/events`
+/// and translate a `WorkstreamActivationChanged` event into
+/// `ReplEvent::WorkstreamActivationChanged`, preserving the DOC-48 §5.3 wire
+/// field names (`new_active_id`/`prior_id`) exactly.
+#[tokio::test]
+async fn subscribe_workstream_events_emits_activation_changed_with_wire_field_names() {
+    let server = MockServer::start().await;
+    mount_common(&server).await;
+    Mock::given(method("GET"))
+        .and(path(format!("/workstreams/{WS_1}/events")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(workstream_activation_body(), "text/event-stream"),
+        )
+        .mount(&server)
+        .await;
+    // The subscription reconnects to ws-2's endpoint after observing the
+    // activation change (DOC-48 §5.3 point 5) — give that reconnect a
+    // well-formed (empty, never-ending in practice but fine for this
+    // assertion) stream too, so the background task doesn't emit spurious
+    // `ConnectionLost` events after the assertion below already passed.
+    Mock::given(method("GET"))
+        .and(path(format!("/workstreams/{WS_2}/events")))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("", "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), server.uri(), None);
+    let (tx, mut rx) = unbounded_channel();
+    engine.setup(tx.clone()).await.expect("setup");
+    while rx.try_recv().is_ok() {} // drain setup's own events
+
+    engine
+        .subscribe_workstream_events(tx)
+        .await
+        .expect("subscribe_workstream_events");
+
+    let event = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match rx.recv().await {
+                Some(ev @ ReplEvent::WorkstreamActivationChanged { .. }) => return ev,
+                Some(_) => continue,
+                None => panic!("channel closed before observing WorkstreamActivationChanged"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for WorkstreamActivationChanged");
+
+    match event {
+        ReplEvent::WorkstreamActivationChanged {
+            new_active_id,
+            prior_id,
+        } => {
+            assert_eq!(new_active_id, WS_2);
+            assert_eq!(prior_id.as_deref(), Some(WS_1));
+        }
+        other => panic!("unexpected {other:?}"),
+    }
+
+    engine.shutdown().await.expect("shutdown");
+}
+
+/// `CodeEngine::discover` must find and verify a daemon named by
+/// `TCODE_DAEMON_URL` (the highest-priority discovery source, DOC-50 §3.4
+/// point 1), pinging its real `/health` route before returning.
+#[tokio::test]
+async fn discover_finds_daemon_via_env_var_override() {
+    let server = MockServer::start().await;
+    mount_common(&server).await;
+
+    // SAFETY: test-only env mutation. This is the only test in this binary
+    // that reads or writes `TCODE_DAEMON_URL`, so no cross-test lock is
+    // needed (mirrors this crate's existing convention of a shared lock only
+    // when more than one test in the same file touches the same var — see
+    // `crate::task::mock_llm::MOCK_LLM_ENV_LOCK`).
+    unsafe {
+        std::env::set_var(DAEMON_URL_ENV, server.uri());
+    }
+    let result = CodeEngine::discover(None).await;
+    unsafe {
+        std::env::remove_var(DAEMON_URL_ENV);
+    }
+
+    let engine = result.expect("discover must succeed against a live mock daemon");
+    assert_eq!(engine.daemon_url(), server.uri());
+}


### PR DESCRIPTION
## Summary

Implements Slice 3 of the tcode TUI build (#3415, epic #3411): `CodeEngine`, the `trusty_tui::TuiEngine` adapter that drives a long-lived `tcode serve --http` daemon over pooled HTTP + SSE.

- **Daemon discovery** (`crates/trusty-code/src/tui_client/discovery.rs`): `TCODE_DAEMON_URL` env var → the `http_addr` discovery file → `GET /health` liveness ping. Actionable errors when nothing is found or the candidate isn't alive.
- **Discovery-file convention** (`crates/trusty-code/src/serve/discovery.rs`, wired into `serve::http::run_http`): I checked first for an existing convention rather than inventing one — `trusty-memory`/`trusty-search` already solve this with a plain-text `host:port` file named `http_addr` under `resolve_data_dir(<app>)`, atomically written (tmp+rename). tcode now follows that exact convention instead of DOC-50 §3.4's sketched `~/.trusty-code/daemon.json {daemon_url,pid,started_at}` shape — `pid`/`started_at` have no consumer anywhere in this codebase, and a second discovery-file format for one product would fork an established repo convention for no gain.
- **`TuiEngine` methods**: `setup` (session.create + initial workstream), `handle_input` (task.run streamed back via `GET /sessions/{id}/events`, translated into `AssistantOutput`/`ToolInvocation` events correlated by `call_id`; `/workstream list`/`/workstream activate <id>` routed client-side), `cancel_session` (calls the daemon's **`session.cancel` RPC** — verified by an integration test that inspects the daemon's received requests, per the thin-client axiom DOC-39 §2.1 C-2), `subscribe_workstream_events` (long-lived `GET /workstreams/{id}/events` SSE listener, reconnecting to a newly-active workstream's endpoint on `WorkstreamActivationChanged`), `shutdown`.
- **Resilience**: pooled `reqwest::Client`; SSE reconnect (bounded backoff) on 502/503/transport error/idle timeout; `ReplEvent::ConnectionLost` surfaced on every reconnect attempt.
- **Ahead of Slice 1.5 (#3428)**: the PM flagged mid-task that `TuiEngine::commands()`/`picker(name)` are landing as *synchronous* accessors, so `CodeEngine` can't do network I/O inline in them. I pre-fetch into a `std::sync::Mutex`-guarded cache during `setup()`/on workstream changes and expose it via plain inherent methods (`CodeEngine::commands()`/`picker()`) today — **these need to move into the `impl TuiEngine for CodeEngine` block once this crate rebases onto a `trusty-tui` revision that declares them** (#3428 hadn't landed on `main` as of this branch; see `crates/trusty-code/src/tui_client/engine.rs`'s doc comments on both methods for the exact TODO).

## Notable spec-vs-main discrepancies (verified against actual code, not spec prose)

- `serve::DEFAULT_HTTP_PORT` is **7882**, not 7881 as DOC-50 §3.3's prose says — 7881 was reassigned away from a real port collision with `trusty-mpm`'s supervisor (#3364, see the constant's doc comment). Discovery reads the daemon's real bound port from the `http_addr` file, so this doesn't affect correctness, just noting it since the brief cited 7881.
- DOC-48 §5.3's `WorkstreamActivationChanged` wire fields are confirmed `new_active_id`/`prior_id` (checked against `crate::events::Event` and `crate::workstreams::sse`) — verified byte-for-byte with a wire-shaped test.

## Test plan

- [x] `cargo build -p trusty-code`
- [x] `cargo build --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui`
- [x] `cargo test -p trusty-code` (parallel and `-- --test-threads=1`) — all green except the pre-documented `run_task::tests::*` flake (a live local `trusty-memory` daemon on port 7070 interferes with `catchup`; confirmed via `git diff --stat origin/main...HEAD -- crates/trusty-code/src/run_task` showing zero touches to that module, and the failure message is literally "could not reach trusty-memory")
- [x] `cargo clippy --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --all-targets -- -D warnings` → exit 0
- [x] `cargo fmt --check` → clean
- [x] New integration test `tests/tui_client_engine.rs` (hermetic, `wiremock`-backed mock daemon — no real `tcode` binary spawned) covers discovery, a streaming chat turn (assistant output + tool invocation), `cancel_session` hitting `session.cancel`, and the `WorkstreamActivationChanged` SSE event with exact wire field names.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools