### PR TITLE
feat(trusty-code): re-source Projects roster from the shared mpm registry

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -8,6 +8,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`ProjectPickerModal` marks unregistered (local-only) roster rows
+  (issue #3435).** The daemon's `GET /projects` roster is now primarily
+  sourced from trusty-mpm's shared project registry; a row without a
+  registry match (e.g. a scratch checkout the operator never registered)
+  now shows a small "local only" label, following `new-workstream.ts::
+  bindingLabel`'s existing state-driven-label precedent. No change to row
+  selection/binding behavior.
+
 ### Fixed
 
 - **SSE subscription churn in `WorkstreamActivity.svelte` and

--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -16,7 +16,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   registry match (e.g. a scratch checkout the operator never registered)
   now shows a small "local only" label, following `new-workstream.ts::
   bindingLabel`'s existing state-driven-label precedent. No change to row
-  selection/binding behavior.
+  selection/binding behavior. **Update (code-critic PR #3439 review,
+  HIGH 2):** when the shared registry itself was unreachable (not merely
+  empty), the modal now shows an amber banner — "shared registry
+  unavailable — showing local checkouts only" — driven by a new additive
+  `source` field on the roster response, so an outage is never mistaken for
+  "you have nothing registered."
 
 ### Fixed
 

--- a/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.svelte
+++ b/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.svelte
@@ -25,12 +25,21 @@
   // close the modal, keeping "what was picked" and "is the modal open" as
   // two separate pieces of state the parent owns, not duplicated here.
   // Backdrop click and the `×` button call `onClose` directly.
+  //
+  // Update (issue #3435, code-critic PR #3439 review HIGH 2): `roster.source`
+  // distinguishes "the shared mpm registry legitimately has nothing
+  // registered" from "the registry was unreachable, this is the local-only
+  // fallback view" — the #3363 lesson is that collapsing those into the same
+  // all-`registered: false` shape hides a real outage from the operator. A
+  // `source === 'fs_only'` roster renders a banner above the row list; row
+  // selection/binding behavior is unchanged either way.
   // Test: `ProjectPickerModal.test.ts`.
   import { apiBase } from '../lib/api-config';
   import {
     fetchProjectRoster,
     projectCandidateLabel,
     type ProjectCandidate,
+    type RosterSource,
   } from '../lib/project-roster';
   import type { ProjectSelection } from '../lib/new-workstream';
 
@@ -48,6 +57,7 @@
 
   let phase = $state<Phase>('loading');
   let entries = $state<ProjectCandidate[]>([]);
+  let source = $state<RosterSource | undefined>(undefined);
   let error = $state<string | null>(null);
 
   async function load(signal: AbortSignal) {
@@ -68,6 +78,7 @@
       const roster = await fetchProjectRoster(base, signal);
       if (signal.aborted) return;
       entries = roster.entries;
+      source = roster.source;
       phase = 'ready';
       error = null;
     } catch (e) {
@@ -126,6 +137,18 @@
         ×
       </button>
     </div>
+
+    {#if phase === 'ready' && source === 'fs_only'}
+      <!-- Issue #3435, code-critic PR #3439 review HIGH 2: mirrors
+           `WorkstreamSwitcher.svelte`'s existing inline warning-banner
+           pattern (`bg-status-warn/10` + `text-status-warn`), amber rather
+           than red — the picker is still usable, just degraded. -->
+      <p
+        class="mt-2 rounded-sm bg-status-warn/10 px-2 py-1.5 text-[11px] text-status-warn"
+      >
+        shared registry unavailable — showing local checkouts only
+      </p>
+    {/if}
 
     <div class="mt-3 max-h-72 space-y-1 overflow-y-auto">
       {#if phase === 'loading'}

--- a/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.svelte
+++ b/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.svelte
@@ -141,10 +141,20 @@
           <button
             type="button"
             title={entry.path}
-            class="block w-full truncate rounded-sm px-2 py-1.5 text-left font-mono text-xs text-trusty-text hover:bg-trusty-card"
+            class="flex w-full items-center justify-between gap-2 truncate rounded-sm px-2 py-1.5 text-left font-mono text-xs text-trusty-text hover:bg-trusty-card"
             onclick={() => pick(entry)}
           >
-            {projectCandidateLabel(entry)}
+            <span class="truncate">{projectCandidateLabel(entry)}</span>
+            {#if !entry.registered}
+              <!-- Issue #3435: the registry is now primary, so a row without
+                   it is a local-only, unregistered discovery — mirrors
+                   `new-workstream.ts::bindingLabel`'s existing precedent for
+                   a small state-driven label suffix (there: git repo vs.
+                   plain directory). -->
+              <span class="shrink-0 text-[10px] uppercase tracking-wide text-trusty-text-muted"
+                >local only</span
+              >
+            {/if}
           </button>
         {/each}
       {/if}

--- a/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.test.ts
@@ -27,8 +27,13 @@ async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void
 
 const ROSTER = {
   entries: [
-    { name: 'trusty-tools', path: '/home/bob/trusty-mpm-projects/bobmatnyc/trusty-tools', owner: 'bobmatnyc' },
-    { name: 'acme-api', path: '/home/bob/acme-api', owner: null },
+    {
+      name: 'trusty-tools',
+      path: '/home/bob/trusty-mpm-projects/bobmatnyc/trusty-tools',
+      owner: 'bobmatnyc',
+      registered: true,
+    },
+    { name: 'acme-api', path: '/home/bob/acme-api', owner: null, registered: true },
   ],
 };
 
@@ -99,6 +104,42 @@ describe('ProjectPickerModal', () => {
       displayPath: 'acme-api',
       isGitRepo: true,
     });
+  });
+
+  it('issue #3435: an unregistered (local-only) roster entry is visually marked, a registered one is not', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          entries: [
+            {
+              name: 'trusty-tools',
+              path: '/home/bob/trusty-mpm-projects/bobmatnyc/trusty-tools',
+              owner: 'bobmatnyc',
+              registered: true,
+            },
+            {
+              name: 'bakeoff-l1',
+              path: '/home/bob/trusty-mpm-projects/bobmatnyc/bakeoff-l1',
+              owner: 'bobmatnyc',
+              registered: false,
+            },
+          ],
+        }),
+      }) as Response),
+    );
+
+    mountModal({ open: true, onSelect: vi.fn(), onClose: vi.fn() });
+    await waitFor(() => target.textContent?.includes('bakeoff-l1') ?? false);
+
+    const rows = Array.from(target.querySelectorAll('button'));
+    const registeredRow = rows.find((b) => b.textContent?.includes('bobmatnyc/trusty-tools'));
+    const unregisteredRow = rows.find((b) => b.textContent?.includes('bakeoff-l1'));
+
+    expect(registeredRow?.textContent).not.toContain('local only');
+    expect(unregisteredRow?.textContent).toContain('local only');
   });
 
   it('"start chatting without a project" calls onSelect(null)', async () => {

--- a/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.test.ts
@@ -35,6 +35,7 @@ const ROSTER = {
     },
     { name: 'acme-api', path: '/home/bob/acme-api', owner: null, registered: true },
   ],
+  source: 'registry',
 };
 
 beforeEach(() => {
@@ -140,6 +141,37 @@ describe('ProjectPickerModal', () => {
 
     expect(registeredRow?.textContent).not.toContain('local only');
     expect(unregisteredRow?.textContent).toContain('local only');
+  });
+
+  it('code-critic PR #3439 review HIGH 2: shows a banner when the roster degraded to fs_only, not when registry-backed', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          entries: [{ name: 'bakeoff-l1', path: '/home/bob/bakeoff-l1', owner: null, registered: false }],
+          source: 'fs_only',
+        }),
+      }) as Response),
+    );
+
+    mountModal({ open: true, onSelect: vi.fn(), onClose: vi.fn() });
+    await waitFor(() => target.textContent?.includes('bakeoff-l1') ?? false);
+
+    expect(target.textContent).toContain('shared registry unavailable');
+  });
+
+  it('code-critic PR #3439 review HIGH 2: no banner when the roster is registry-backed', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => ROSTER }) as Response),
+    );
+
+    mountModal({ open: true, onSelect: vi.fn(), onClose: vi.fn() });
+    await waitFor(() => target.textContent?.includes('acme-api') ?? false);
+
+    expect(target.textContent).not.toContain('shared registry unavailable');
   });
 
   it('"start chatting without a project" calls onSelect(null)', async () => {

--- a/crates/trusty-code-gui/ui/src/components/StartWorkingForm.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/StartWorkingForm.test.ts
@@ -58,6 +58,7 @@ function openPickerButton(): HTMLButtonElement {
 
 const ROSTER = {
   entries: [{ name: 'acme-api', path: '/home/bob/acme-api', owner: null, registered: true }],
+  source: 'registry',
 };
 
 /** A `fetch` stub covering every route this component's full submit

--- a/crates/trusty-code-gui/ui/src/components/StartWorkingForm.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/StartWorkingForm.test.ts
@@ -57,7 +57,7 @@ function openPickerButton(): HTMLButtonElement {
 }
 
 const ROSTER = {
-  entries: [{ name: 'acme-api', path: '/home/bob/acme-api', owner: null }],
+  entries: [{ name: 'acme-api', path: '/home/bob/acme-api', owner: null, registered: true }],
 };
 
 /** A `fetch` stub covering every route this component's full submit

--- a/crates/trusty-code-gui/ui/src/lib/project-roster.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/project-roster.test.ts
@@ -58,6 +58,19 @@ describe('isProjectRoster', () => {
       isProjectRoster({ entries: [{ name: 'x', path: '/x', owner: null, registered: 'yes' }] }),
     ).toBe(false);
   });
+
+  it('code-critic PR #3439 review HIGH 2: accepts a top-level source of "registry" or "fs_only", or absent', () => {
+    expect(isProjectRoster({ entries: [], source: 'registry' })).toBe(true);
+    expect(isProjectRoster({ entries: [], source: 'fs_only' })).toBe(true);
+    // Backward compatibility: an older daemon predating this field must
+    // still validate.
+    expect(isProjectRoster({ entries: [] })).toBe(true);
+  });
+
+  it('code-critic PR #3439 review HIGH 2: rejects an unrecognized top-level source value', () => {
+    expect(isProjectRoster({ entries: [], source: 'unknown' })).toBe(false);
+    expect(isProjectRoster({ entries: [], source: true })).toBe(false);
+  });
 });
 
 describe('fetchProjectRoster', () => {

--- a/crates/trusty-code-gui/ui/src/lib/project-roster.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/project-roster.test.ts
@@ -40,6 +40,24 @@ describe('isProjectRoster', () => {
     expect(isProjectRoster({ entries: [{ name: 'x' }] })).toBe(false);
     expect(isProjectRoster({ entries: [{ name: 'x', path: '/x', owner: 7 }] })).toBe(false);
   });
+
+  it('issue #3435: accepts an entry with a boolean registered field, present or absent', () => {
+    expect(
+      isProjectRoster({ entries: [{ name: 'x', path: '/x', owner: null, registered: true }] }),
+    ).toBe(true);
+    expect(
+      isProjectRoster({ entries: [{ name: 'x', path: '/x', owner: null, registered: false }] }),
+    ).toBe(true);
+    // Backward compatibility: an older daemon predating this field must
+    // still validate.
+    expect(isProjectRoster({ entries: [{ name: 'x', path: '/x', owner: null }] })).toBe(true);
+  });
+
+  it('issue #3435: rejects an entry whose registered field is present but non-boolean', () => {
+    expect(
+      isProjectRoster({ entries: [{ name: 'x', path: '/x', owner: null, registered: 'yes' }] }),
+    ).toBe(false);
+  });
 });
 
 describe('fetchProjectRoster', () => {

--- a/crates/trusty-code-gui/ui/src/lib/project-roster.ts
+++ b/crates/trusty-code-gui/ui/src/lib/project-roster.ts
@@ -25,6 +25,12 @@
 // keeps working unchanged against an older daemon that predates the field —
 // additive-only wire evolution, per the daemon side's own backward-
 // compatibility goal.
+//
+// Update (code-critic PR #3439 review, HIGH 2): `ProjectRoster.source`
+// distinguishes "the registry has nothing registered" from "the registry was
+// unreachable" (the #3363 lesson — those must not collapse into the same
+// all-`registered: false` shape with no operator-visible signal). Also
+// OPTIONAL, for the same backward-compatibility reason.
 // Test: `project-roster.test.ts`.
 
 /** Mirrors `crate::fs_browse::roster::ProjectCandidate` field-for-field. */
@@ -38,10 +44,19 @@ export interface ProjectCandidate {
   registered?: boolean;
 }
 
+/** Mirrors `crate::fs_browse::roster::RosterSource` field-for-field (issue
+ * #3435, code-critic PR #3439 review HIGH 2). */
+export type RosterSource = 'registry' | 'fs_only';
+
 /** Mirrors `crate::fs_browse::roster::ProjectRoster` field-for-field — the
  * `GET /projects` response body. */
 export interface ProjectRoster {
   entries: ProjectCandidate[];
+  /** Which source produced `entries`. Optional for backward compatibility
+   * with a daemon predating this field; treat a missing value as unknown
+   * (the modal does not render the fs-only banner when absent, rather than
+   * guessing). */
+  source?: RosterSource;
 }
 
 /**
@@ -55,13 +70,15 @@ export interface ProjectRoster {
  * is an array whose members each carry string `name`/`path`, an `owner`
  * that is a string or `null`, and — if present at all — a boolean
  * `registered` (absent is accepted, for an older daemon; present-but-wrong-
- * typed is rejected, same strictness as every other field here).
+ * typed is rejected, same strictness as every other field here). Top-level
+ * `source`, if present, must be exactly `'registry'` or `'fs_only'`.
  * Test: `project-roster.test.ts::isProjectRoster`.
  */
 export function isProjectRoster(body: unknown): body is ProjectRoster {
   if (typeof body !== 'object' || body === null) return false;
   const b = body as Record<string, unknown>;
   if (!Array.isArray(b.entries)) return false;
+  if (b.source !== undefined && b.source !== 'registry' && b.source !== 'fs_only') return false;
   return b.entries.every((e: unknown) => {
     if (typeof e !== 'object' || e === null) return false;
     const c = e as Record<string, unknown>;

--- a/crates/trusty-code-gui/ui/src/lib/project-roster.ts
+++ b/crates/trusty-code-gui/ui/src/lib/project-roster.ts
@@ -17,6 +17,14 @@
 // answered the socket, so the shape must be verified before it becomes
 // reactive state. [`projectCandidateLabel`] is the one-line display label
 // the modal's row buttons render.
+//
+// Update (issue #3435): the daemon now merges trusty-mpm's shared project
+// registry (primary) with this crate's filesystem scan (secondary,
+// local-only/unregistered candidates) before responding — `registered`
+// distinguishes the two. It is OPTIONAL here (not required) so this client
+// keeps working unchanged against an older daemon that predates the field —
+// additive-only wire evolution, per the daemon side's own backward-
+// compatibility goal.
 // Test: `project-roster.test.ts`.
 
 /** Mirrors `crate::fs_browse::roster::ProjectCandidate` field-for-field. */
@@ -24,6 +32,10 @@ export interface ProjectCandidate {
   name: string;
   path: string;
   owner: string | null;
+  /** Known to trusty-mpm's shared project registry (issue #3435). Optional
+   * for backward compatibility with a daemon predating this field; treat a
+   * missing value the same as `false` (unregistered/unknown). */
+  registered?: boolean;
 }
 
 /** Mirrors `crate::fs_browse::roster::ProjectRoster` field-for-field — the
@@ -40,8 +52,10 @@ export interface ProjectRoster {
  * proxy, a future daemon) flow into `roster.entries` and throw once the
  * modal iterates it.
  * What: structural check of every field the modal dereferences: `entries`
- * is an array whose members each carry string `name`/`path` and an
- * `owner` that is a string or `null`.
+ * is an array whose members each carry string `name`/`path`, an `owner`
+ * that is a string or `null`, and — if present at all — a boolean
+ * `registered` (absent is accepted, for an older daemon; present-but-wrong-
+ * typed is rejected, same strictness as every other field here).
  * Test: `project-roster.test.ts::isProjectRoster`.
  */
 export function isProjectRoster(body: unknown): body is ProjectRoster {
@@ -54,7 +68,8 @@ export function isProjectRoster(body: unknown): body is ProjectRoster {
     return (
       typeof c.name === 'string' &&
       typeof c.path === 'string' &&
-      (c.owner === null || typeof c.owner === 'string')
+      (c.owner === null || typeof c.owner === 'string') &&
+      (c.registered === undefined || typeof c.registered === 'boolean')
     );
   });
 }

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -19,8 +19,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   scratch checkout) still appear, never silently dropped, now flagged via a
   new additive `registered: bool` field on each roster entry. An
   unreachable mpm daemon degrades gracefully to the filesystem-only roster
-  rather than erroring. New module:
-  `crates/trusty-code/src/fs_browse/mpm_registry.rs`. Spec: DOC-39 §5.8.1.
+  rather than erroring, and is now caller-distinguishable via a new
+  additive `source: "registry" | "fs_only"` field on the roster
+  (code-critic PR #3439 review, HIGH 2 — the #3363 lesson: "nothing
+  registered" and "registry unreachable" must not collapse into the same
+  shape). The merge also normalizes both sides (`std::fs::canonicalize`)
+  before comparing paths, so a case-differing or symlink-indirected path to
+  the SAME checkout no longer double-lists it (code-critic PR #3439 review,
+  HIGH 1), and `repo_url` parsing now rejects compound remainders (GitLab
+  subgroups, a port-qualified host) instead of fabricating a bogus
+  multi-level lookup path (code-critic PR #3439 review, MEDIUM 1). New
+  module: `crates/trusty-code/src/fs_browse/mpm_registry.rs`. Spec: DOC-39
+  §5.8.1.
 
 ### Fixed
 

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`fs.list_projects` / `GET /projects` re-sourced from trusty-mpm's shared
+  project registry (issue #3435).** The project-picker roster's PRIMARY
+  source is now a loopback call to the mpm daemon's `GET /api/v1/projects`
+  (`http://127.0.0.1:7880`, overridable via `TRUSTY_MPM_URL`); the prior
+  filesystem scan (`fs_browse::roster`, issue #3365) is demoted to
+  SECONDARY — local-only/unregistered candidates (e.g. a `bakeoff-l1`
+  scratch checkout) still appear, never silently dropped, now flagged via a
+  new additive `registered: bool` field on each roster entry. An
+  unreachable mpm daemon degrades gracefully to the filesystem-only roster
+  rather than erroring. New module:
+  `crates/trusty-code/src/fs_browse/mpm_registry.rs`. Spec: DOC-39 §5.8.1.
+
 ### Fixed
 
 - **`serve::DEFAULT_HTTP_PORT` moved from 7881 to 7882 (closes #3364).** The

--- a/crates/trusty-code/src/fs_browse/mod.rs
+++ b/crates/trusty-code/src/fs_browse/mod.rs
@@ -42,6 +42,7 @@
 //! Test: `fs_browse::tests::*` (resolution, git-ness incl. the linked-worktree
 //! `.git`-as-file shape, error distinguishability, 7a response shape).
 
+pub mod mpm_registry;
 pub mod protocol;
 pub mod roster;
 

--- a/crates/trusty-code/src/fs_browse/mpm_registry.rs
+++ b/crates/trusty-code/src/fs_browse/mpm_registry.rs
@@ -1,0 +1,584 @@
+//! Re-source the project-picker roster from trusty-mpm's shared project
+//! registry (issue #3435).
+//!
+//! Why: Bob's directive — "for 'Projects' we should be using the shared
+//! (mpm) projects manager to list projects" — per the tcode-as-harness,
+//! trusty-mpm-as-canonical-owner doctrine, `~/.trusty-mpm/project-registry/
+//! projects.json` (surfaced over the mpm daemon's `GET /api/v1/projects`,
+//! `crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs`)
+//! is the single owner of "what projects does this operator work with", not
+//! this crate's own filesystem scan (`super::roster`, issue #3365). That scan
+//! forked project knowledge away from the canonical registry — expedient at
+//! the time ("no pre-session roster endpoint exists yet"), wrong now that
+//! one exists.
+//!
+//! **Consumption path (survey result, issue #3435 design question 1):** a
+//! loopback HTTP call to the mpm daemon's `GET /api/v1/projects`
+//! (`http://127.0.0.1:7880` by default, overridable via `TRUSTY_MPM_URL` —
+//! the same env var `trusty-mpm-gui`'s `GuiState` already uses, so operators
+//! have exactly one knob for "where is the mpm daemon" across both GUIs), NOT
+//! a direct read of `projects.json`. Two reasons: (1) every existing
+//! cross-daemon consumer in this workspace goes over loopback HTTP —
+//! `trusty-mpm-gui/src/commands.rs`'s "1:1 proxy layer, never embed business
+//! logic" pattern is the precedent this module mirrors — and there is no
+//! workspace precedent for one daemon reading a sibling daemon's on-disk
+//! store directly; (2) ADR-0018 (the loopback-only doctrine; ADR-0011 is
+//! amended by it) explicitly sanctions same-machine loopback HTTP between
+//! sibling daemons, including for "same-machine GUI clients" — a daemon-to-
+//! daemon read is the same shape, one hop earlier. `crate::serve::mod` also
+//! already documents port 7880 as trusty-mpm's reserved port in this crate's
+//! own sibling-port table, so this module introduces no new fact, just a
+//! caller.
+//!
+//! **Merged view (design question 2):** the registry is keyed on
+//! `name`/`repo_url`, not a local filesystem path, and does not know about
+//! folders an operator has never registered (e.g. a `bakeoff-l1..l5`
+//! scratch checkout). Silently dropping those from the picker would be a
+//! regression versus today's fs-only scan. So [`merge`] treats the registry
+//! as PRIMARY (its entries win: `registered: true`, and its `name` overrides
+//! whatever the local directory happened to be called) and the filesystem
+//! scan as SECONDARY — any locally-discovered candidate NOT resolvable to a
+//! registry entry survives in the roster with `registered: false`
+//! ([`super::roster::ProjectCandidate::registered`]). A registry entry whose
+//! `repo_url` cannot be resolved to an existing local checkout under
+//! `~/trusty-mpm-projects/<owner>/<repo>` is skipped, not fabricated as a
+//! roster row with a made-up path — the picker can only bind to a directory
+//! that actually exists on this machine.
+//!
+//! **Registry hygiene (design question 3):** no `tm project remove` verb
+//! exists yet (see #3364-era findings on stale entries like
+//! `tm-throwaway-verify-2748`), so a stale registry entry becomes
+//! user-visible here if — and only if — a matching local checkout still
+//! exists under the owner-scoped layout; a stale entry with no local
+//! checkout is silently absent from the roster already (see the previous
+//! paragraph), which happens to filter most throwaway/no-longer-cloned
+//! entries for free. Filtering live-but-stale entries whose checkout DOES
+//! still exist is explicitly out of scope here — it depends on a future `tm
+//! project remove` (or a repo_url throwaway-pattern heuristic the issue
+//! itself calls out of scope) — this module deliberately does not guess.
+//!
+//! **Degradation:** if the mpm daemon is unreachable (down, wrong port,
+//! timeout), [`merged_roster`] degrades to the plain filesystem-only roster
+//! (every entry `registered: false`) rather than an empty picker or a
+//! caller-facing error — the same best-effort philosophy `super::roster`
+//! already documents.
+//!
+//! What: [`merged_roster`] is the real entry point `fs.list_projects`
+//! (`super::protocol::list_projects`) calls — it resolves the mpm daemon URL,
+//! runs the existing fs scan, and fetches the registry, then delegates to the
+//! two testable pure/near-pure pieces: [`fetch_registry_projects`] (the one
+//! network call) and [`merge`] (the merge logic, a plain function of already-
+//! fetched data plus filesystem existence checks against a given `home` —
+//! same real-vs-injectable split `super::roster::list_projects`/
+//! `list_projects_in` already uses, so tests never touch the developer's
+//! actual home directory or a real mpm daemon).
+//! Test: `tests::*`.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use super::is_git_repo;
+use super::roster::{MAX_ENTRIES, ProjectCandidate, ProjectRoster};
+
+/// Default loopback base URL for the trusty-mpm daemon's REST API.
+///
+/// Why: `crate::serve::mod`'s sibling-port table already reserves 7880 for
+/// trusty-mpm; this is that same fact, scoped to this module's one caller.
+/// Test: `tests::mpm_daemon_url_defaults_when_env_var_unset`.
+pub const DEFAULT_MPM_DAEMON_URL: &str = "http://127.0.0.1:7880";
+
+/// Env var overriding the mpm daemon's base URL.
+///
+/// Why: the SAME variable `trusty-mpm-gui::state::GuiState` already reads —
+/// reusing it (rather than inventing a `tcode`-specific name) means an
+/// operator who points one GUI at a non-default mpm daemon does not also
+/// have to remember a second env var for this one.
+const MPM_DAEMON_URL_ENV: &str = "TRUSTY_MPM_URL";
+
+/// Timeout budget for the registry call.
+///
+/// Why: this method backs an interactive picker modal — the operator must
+/// never be left staring at a spinner because a sibling daemon is wedged
+/// rather than simply down. A closed port fails near-instantly (connection
+/// refused); this bound only matters for a daemon that accepted the TCP
+/// connection but never answers.
+const REGISTRY_FETCH_TIMEOUT: Duration = Duration::from_millis(1500);
+
+/// The subset of trusty-mpm's `Project` registry record this module needs.
+///
+/// Why: a minimal mirror, not the full record
+/// (`trusty_mpm::project::record::Project`) — pulling in the whole
+/// `trusty-mpm` crate as a dependency just for a struct shape would be a
+/// heavier coupling than this thin consumer needs; `name` and `repo_url` are
+/// the only fields the merge step reads (see module docs). Extra fields the
+/// real response carries (`tags`, `description`, ...) are ignored by serde's
+/// default "unknown fields are fine" deserialization.
+#[derive(Debug, Clone, Deserialize)]
+struct RegistryProject {
+    name: String,
+    repo_url: String,
+}
+
+/// Mirrors `trusty_mpm::daemon::managed_routes::project_registry_routes::
+/// ProjectsListResponse`'s wire shape (`{ projects, count }`) — only
+/// `projects` is read; `count` is redundant with `projects.len()`.
+#[derive(Debug, Deserialize)]
+struct RegistryProjectsResponse {
+    projects: Vec<RegistryProject>,
+}
+
+/// Resolve the mpm daemon's base URL for THIS call.
+///
+/// Why: split out so [`merged_roster`] stays a one-line "resolve, then
+/// delegate" wrapper, matching `super::roster::list_projects`'s own shape.
+/// What: `TRUSTY_MPM_URL` if set (trailing slash trimmed), else
+/// [`DEFAULT_MPM_DAEMON_URL`].
+/// Test: `tests::mpm_daemon_url_defaults_when_env_var_unset`.
+fn mpm_daemon_url() -> String {
+    std::env::var(MPM_DAEMON_URL_ENV)
+        .unwrap_or_else(|_| DEFAULT_MPM_DAEMON_URL.to_string())
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// `GET {base_url}/api/v1/projects` — the one network call this module
+/// makes.
+///
+/// Why: isolated from [`merge`] so the merge logic is testable without any
+/// I/O, and this call is testable without any filesystem setup — see module
+/// docs.
+/// What: any transport failure, non-2xx status, or malformed body collapses
+/// to a single `Err(String)` — the caller ([`merged_roster_with`]) treats
+/// every failure mode identically (degrade to fs-only), so there is no value
+/// in a typed error here.
+/// Test: `tests::merged_roster_with_uses_registry_when_daemon_reachable`,
+/// `tests::merged_roster_with_degrades_to_fs_only_when_daemon_unreachable`.
+async fn fetch_registry_projects(
+    client: &reqwest::Client,
+    base_url: &str,
+) -> Result<Vec<RegistryProject>, String> {
+    let url = format!("{base_url}/api/v1/projects");
+    let resp = client
+        .get(&url)
+        .timeout(REGISTRY_FETCH_TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("mpm daemon returned HTTP {}", resp.status()));
+    }
+    resp.json::<RegistryProjectsResponse>()
+        .await
+        .map(|body| body.projects)
+        .map_err(|e| e.to_string())
+}
+
+/// Parse `(owner, repo)` out of a registry `repo_url`.
+///
+/// Why: the registry has no local filesystem path (it is keyed on
+/// `name`/`repo_url`, not a checkout location) — this recovers the
+/// `<owner>/<repo>` pair the workspace's own `~/trusty-mpm-projects/<owner>/
+/// <repo>` layout convention needs to resolve a local path (see
+/// [`resolve_local_path`]).
+/// What: handles both `https://github.com/<owner>/<repo>[.git]` and
+/// `git@github.com:<owner>/<repo>[.git]` (the two forms
+/// `trusty_mpm::project::record::Project::repo_url`'s own docs give as
+/// examples), trimming a trailing slash and `.git` suffix first. Returns
+/// `None` for anything that doesn't resolve to a non-empty `owner` and
+/// `repo` — a malformed/unexpected `repo_url` shape must never panic or
+/// fabricate a bogus path.
+/// Test: `tests::parse_owner_repo_handles_https_url`,
+/// `tests::parse_owner_repo_handles_https_url_with_git_suffix`,
+/// `tests::parse_owner_repo_handles_ssh_url`,
+/// `tests::parse_owner_repo_rejects_malformed_url`.
+fn parse_owner_repo(repo_url: &str) -> Option<(String, String)> {
+    let trimmed = repo_url.trim().trim_end_matches('/');
+    let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    // Strip a `<scheme>://` prefix when present (e.g. `https://`); an SSH
+    // shorthand URL (`git@host:owner/repo`) has no `://` and is left as-is.
+    let path_part = match trimmed.split_once("://") {
+        Some((_, rest)) => rest,
+        None => trimmed,
+    };
+    // `path_part` is now `<host>/<owner>/<repo>` (HTTPS) or
+    // `git@<host>:<owner>/<repo>` (SSH) — either way, the first `/` or `:`
+    // after the host separates it from the `<owner>/<repo>` pair.
+    let (_, after_host) = path_part.split_once(['/', ':'])?;
+    let (owner, repo) = after_host.rsplit_once('/')?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+/// Resolve `<home>/trusty-mpm-projects/<owner>/<repo>` to an existing local
+/// git-repo checkout, or `None` if it isn't one.
+///
+/// Why: a registry entry with no local checkout on THIS machine has nothing
+/// the picker could bind to — see module docs on why such an entry is
+/// skipped, not fabricated as a dead roster row.
+/// What: reuses [`super::is_git_repo`] — the identical discriminator
+/// `super::roster`'s own scan already filters on, so a registered project is
+/// held to the same "must be a real git checkout" bar as a discovered one.
+/// Test: `tests::merge_marks_registered_projects_with_local_checkout`,
+/// `tests::merge_skips_registry_projects_without_local_checkout`.
+fn resolve_local_path(home: &Path, owner: &str, repo: &str) -> Option<PathBuf> {
+    let candidate = home.join("trusty-mpm-projects").join(owner).join(repo);
+    (candidate.is_dir() && is_git_repo(&candidate)).then_some(candidate)
+}
+
+/// Merge the filesystem-scanned roster with registry projects, registry
+/// primary.
+///
+/// Why: the pure(-ish — filesystem existence checks against `home`, no
+/// network) core of the design question 2 policy — see module docs for the
+/// full rationale. Split out from [`merged_roster_with`] so it is testable
+/// with hand-built inputs, no mock server required.
+/// What: for each registry project that resolves to an existing local
+/// checkout ([`resolve_local_path`]): if a filesystem-scanned entry already
+/// has that exact path, it is promoted in place (`registered: true`, `name`
+/// and `owner` set from the registry's canonical values); otherwise a new
+/// entry is appended with `registered: true`. Filesystem-scanned entries
+/// with no matching registry project are kept as-is (`registered: false` —
+/// the local-only, unregistered secondary view). `home: None` (no resolvable
+/// home directory) short-circuits to the filesystem roster untouched, since
+/// no registry project could resolve a local path either. Result is
+/// re-sorted case-insensitively by `name` and re-capped at
+/// [`MAX_ENTRIES`] (a registered project can newly enter the roster, so the
+/// cap must be re-applied after merging, not just inherited from the fs
+/// scan).
+/// Test: `tests::merge_marks_registered_projects_with_local_checkout`,
+/// `tests::merge_marks_unregistered_local_only_projects`,
+/// `tests::merge_skips_registry_projects_without_local_checkout`.
+fn merge(
+    fs_roster: ProjectRoster,
+    registry_projects: &[RegistryProject],
+    home: Option<&Path>,
+) -> ProjectRoster {
+    let mut entries = fs_roster.entries;
+    if let Some(home) = home {
+        let mut path_index: HashMap<String, usize> = entries
+            .iter()
+            .enumerate()
+            .map(|(i, e)| (e.path.clone(), i))
+            .collect();
+        for rp in registry_projects {
+            let Some((owner, repo)) = parse_owner_repo(&rp.repo_url) else {
+                continue;
+            };
+            let Some(path) = resolve_local_path(home, &owner, &repo) else {
+                continue;
+            };
+            let path_str = path.display().to_string();
+            if let Some(&idx) = path_index.get(&path_str) {
+                entries[idx].registered = true;
+                entries[idx].name = rp.name.clone();
+                entries[idx].owner = Some(owner);
+            } else {
+                let idx = entries.len();
+                entries.push(ProjectCandidate {
+                    name: rp.name.clone(),
+                    path: path_str.clone(),
+                    owner: Some(owner),
+                    registered: true,
+                });
+                path_index.insert(path_str, idx);
+            }
+        }
+    }
+    entries.sort_by_key(|e| e.name.to_lowercase());
+    entries.truncate(MAX_ENTRIES);
+    ProjectRoster { entries }
+}
+
+/// Fetch the registry (if reachable) and merge it with an already-computed
+/// filesystem roster.
+///
+/// Why: the testable core of [`merged_roster`] — takes `fs_roster`/`home` as
+/// plain arguments (rather than re-scanning/re-resolving internally) so
+/// tests supply hand-built inputs instead of touching the real filesystem or
+/// spawning a real mpm daemon, mirroring `super::roster`'s
+/// `list_projects`/`list_projects_in` split.
+/// What: on a successful fetch, delegates to [`merge`]. On ANY failure
+/// (unreachable daemon, non-2xx, malformed body), logs a `tracing::warn!`
+/// and returns `fs_roster` unchanged — already all `registered: false`, i.e.
+/// exactly the graceful-degradation view module docs describe.
+/// Test: `tests::merged_roster_with_uses_registry_when_daemon_reachable`,
+/// `tests::merged_roster_with_degrades_to_fs_only_when_daemon_unreachable`.
+async fn merged_roster_with(
+    client: &reqwest::Client,
+    base_url: &str,
+    fs_roster: ProjectRoster,
+    home: Option<&Path>,
+) -> ProjectRoster {
+    match fetch_registry_projects(client, base_url).await {
+        Ok(registry_projects) => merge(fs_roster, &registry_projects, home),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                mpm_daemon_url = base_url,
+                "mpm project registry unavailable; falling back to filesystem-only roster"
+            );
+            fs_roster
+        }
+    }
+}
+
+/// `fs.list_projects()`'s real data source (issue #3435) — registry primary,
+/// filesystem-scan secondary/fallback.
+///
+/// Why: the one function `super::protocol::list_projects` calls; resolves
+/// every real input (a fresh `reqwest::Client`, the mpm daemon URL, the real
+/// filesystem scan, the real home directory) so the RPC handler itself stays
+/// a one-liner, exactly like `super::roster::list_projects`'s own shape. A
+/// fresh `Client` per call (rather than a pooled, shared one) matches this
+/// module family's existing "no shared state" design
+/// (`super::protocol`'s own module docs) and is appropriate for an
+/// interactive, low-frequency, user-triggered call — not a hot path.
+/// What: delegates to [`merged_roster_with`].
+/// Test: exercised indirectly via `super::protocol::tests::
+/// list_projects_returns_entries_array` (this function's own behavior beyond
+/// delegation is untestable without touching the real home directory and a
+/// real mpm daemon; [`merged_roster_with`] carries the real coverage).
+pub async fn merged_roster() -> ProjectRoster {
+    merged_roster_with(
+        &reqwest::Client::new(),
+        &mpm_daemon_url(),
+        super::roster::list_projects(),
+        dirs::home_dir().as_deref(),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::extract::State;
+    use axum::routing::get;
+    use axum::{Json, Router};
+    use serde_json::{Value, json};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    fn mkdir(p: &Path) {
+        std::fs::create_dir_all(p).expect("mkdir");
+    }
+
+    fn mk_git_repo(p: &Path) {
+        mkdir(p);
+        mkdir(&p.join(".git"));
+    }
+
+    // ── `parse_owner_repo` ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_owner_repo_handles_https_url() {
+        assert_eq!(
+            parse_owner_repo("https://github.com/bobmatnyc/trusty-tools"),
+            Some(("bobmatnyc".to_string(), "trusty-tools".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_owner_repo_handles_https_url_with_git_suffix() {
+        assert_eq!(
+            parse_owner_repo("https://github.com/bobmatnyc/trusty-tools.git"),
+            Some(("bobmatnyc".to_string(), "trusty-tools".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_owner_repo_handles_ssh_url() {
+        assert_eq!(
+            parse_owner_repo("git@github.com:bobmatnyc/trusty-tools.git"),
+            Some(("bobmatnyc".to_string(), "trusty-tools".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_owner_repo_rejects_malformed_url() {
+        assert_eq!(parse_owner_repo("not-a-url"), None);
+        assert_eq!(parse_owner_repo(""), None);
+    }
+
+    // ── `merge` ──────────────────────────────────────────────────────────
+
+    /// A registry project whose repo_url resolves to an existing local git
+    /// checkout must be marked `registered: true` — the registry-primary
+    /// merge's core case.
+    #[test]
+    fn merge_marks_registered_projects_with_local_checkout() {
+        let home = tempfile::tempdir().expect("tempdir");
+        mk_git_repo(
+            &home
+                .path()
+                .join("trusty-mpm-projects")
+                .join("bobmatnyc")
+                .join("trusty-tools"),
+        );
+        let fs_roster = super::super::roster::list_projects_in(home.path());
+        let registry = vec![RegistryProject {
+            name: "trusty-tools".to_string(),
+            repo_url: "https://github.com/bobmatnyc/trusty-tools".to_string(),
+        }];
+
+        let merged = merge(fs_roster, &registry, Some(home.path()));
+
+        assert_eq!(merged.entries.len(), 1);
+        assert!(merged.entries[0].registered, "must be marked registered");
+        assert_eq!(merged.entries[0].name, "trusty-tools");
+        assert_eq!(merged.entries[0].owner.as_deref(), Some("bobmatnyc"));
+    }
+
+    /// A filesystem-discovered project with NO matching registry entry must
+    /// survive the merge, marked `registered: false` — local-only projects
+    /// (e.g. `bakeoff-l1`) must never be silently dropped.
+    #[test]
+    fn merge_marks_unregistered_local_only_projects() {
+        let home = tempfile::tempdir().expect("tempdir");
+        mk_git_repo(
+            &home
+                .path()
+                .join("trusty-mpm-projects")
+                .join("bobmatnyc")
+                .join("bakeoff-l1"),
+        );
+        let fs_roster = super::super::roster::list_projects_in(home.path());
+
+        let merged = merge(fs_roster, &[], Some(home.path()));
+
+        assert_eq!(merged.entries.len(), 1);
+        assert!(!merged.entries[0].registered, "must stay unregistered");
+        assert_eq!(merged.entries[0].name, "bakeoff-l1");
+    }
+
+    /// A registry project with NO local checkout on this machine must be
+    /// skipped entirely — the picker cannot bind to a path that doesn't
+    /// exist, so no dead row is fabricated.
+    #[test]
+    fn merge_skips_registry_projects_without_local_checkout() {
+        let home = tempfile::tempdir().expect("tempdir");
+        // No `trusty-mpm-projects` dir at all on this machine.
+        let fs_roster = super::super::roster::list_projects_in(home.path());
+        let registry = vec![RegistryProject {
+            name: "ghost-project".to_string(),
+            repo_url: "https://github.com/someone/ghost-project".to_string(),
+        }];
+
+        let merged = merge(fs_roster, &registry, Some(home.path()));
+
+        assert!(merged.entries.is_empty());
+    }
+
+    // ── `merged_roster_with` (network integration) ──────────────────────
+
+    /// Spin up a one-route mock mpm daemon serving `GET /api/v1/projects`
+    /// and return its base URL.
+    async fn spawn_mock_mpm(projects: Value) -> String {
+        async fn handle(State(projects): State<Value>) -> Json<Value> {
+            Json(json!({"projects": projects, "count": 1}))
+        }
+        let app = Router::new()
+            .route("/api/v1/projects", get(handle))
+            .with_state(projects);
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+        let addr = listener.local_addr().expect("addr");
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}")
+    }
+
+    /// When the mpm daemon is reachable, its registry data must be used as
+    /// the merge's primary source end-to-end (real HTTP round trip, not just
+    /// the pure `merge` unit).
+    #[tokio::test]
+    async fn merged_roster_with_uses_registry_when_daemon_reachable() {
+        let home = tempfile::tempdir().expect("tempdir");
+        mk_git_repo(
+            &home
+                .path()
+                .join("trusty-mpm-projects")
+                .join("bobmatnyc")
+                .join("trusty-tools"),
+        );
+        let fs_roster = super::super::roster::list_projects_in(home.path());
+        let base_url = spawn_mock_mpm(json!([
+            {"name": "trusty-tools", "repo_url": "https://github.com/bobmatnyc/trusty-tools"}
+        ]))
+        .await;
+
+        let roster = merged_roster_with(
+            &reqwest::Client::new(),
+            &base_url,
+            fs_roster,
+            Some(home.path()),
+        )
+        .await;
+
+        assert_eq!(roster.entries.len(), 1);
+        assert!(roster.entries[0].registered);
+    }
+
+    /// When the mpm daemon is unreachable, the merge must degrade to the
+    /// plain filesystem roster rather than erroring or returning an empty
+    /// picker.
+    #[tokio::test]
+    async fn merged_roster_with_degrades_to_fs_only_when_daemon_unreachable() {
+        let home = tempfile::tempdir().expect("tempdir");
+        mk_git_repo(
+            &home
+                .path()
+                .join("trusty-mpm-projects")
+                .join("bobmatnyc")
+                .join("trusty-tools"),
+        );
+        let fs_roster = super::super::roster::list_projects_in(home.path());
+
+        // Grab a port and immediately drop the listener so nothing answers —
+        // a fast, deterministic "connection refused" rather than a real
+        // timeout.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let dead_addr = listener.local_addr().expect("addr");
+        drop(listener);
+        let dead_url = format!("http://{dead_addr}");
+
+        let roster = merged_roster_with(
+            &reqwest::Client::new(),
+            &dead_url,
+            fs_roster,
+            Some(home.path()),
+        )
+        .await;
+
+        assert_eq!(roster.entries.len(), 1);
+        assert!(
+            !roster.entries[0].registered,
+            "must degrade to fs-only (unregistered) view"
+        );
+    }
+
+    // ── `mpm_daemon_url` ─────────────────────────────────────────────────
+
+    /// Without `TRUSTY_MPM_URL` set, the default loopback URL is used.
+    ///
+    /// Why serial-unsafe env mutation is acceptable here: this crate's test
+    /// binary runs each `#[test]`/`#[tokio::test]` in its own thread but
+    /// shares process-wide env state; this test only READS the env var
+    /// (never sets it), so it cannot race a hypothetical other test that
+    /// does set it, and no other test in this module touches
+    /// `TRUSTY_MPM_URL`.
+    #[test]
+    fn mpm_daemon_url_defaults_when_env_var_unset() {
+        // Best-effort: only assert when the var is genuinely unset in this
+        // process, so this test cannot flake under an operator's shell that
+        // happens to export it.
+        if std::env::var(MPM_DAEMON_URL_ENV).is_ok() {
+            return;
+        }
+        assert_eq!(mpm_daemon_url(), DEFAULT_MPM_DAEMON_URL);
+    }
+}

--- a/crates/trusty-code/src/fs_browse/mpm_registry.rs
+++ b/crates/trusty-code/src/fs_browse/mpm_registry.rs
@@ -61,7 +61,14 @@
 //! timeout), [`merged_roster`] degrades to the plain filesystem-only roster
 //! (every entry `registered: false`) rather than an empty picker or a
 //! caller-facing error — the same best-effort philosophy `super::roster`
-//! already documents.
+//! already documents. Critically, this degraded roster is
+//! INDISTINGUISHABLE from "the registry has nothing registered" by its
+//! entries alone — the #3363 lesson is that silently collapsing "empty" and
+//! "unreachable" into the same shape hides a real outage from the operator.
+//! [`super::roster::ProjectRoster::source`] (`RosterSource::Registry` vs.
+//! `RosterSource::FsOnly`, code-critic PR #3439 review, HIGH 2) is the
+//! caller-visible signal that tells the two apart; the GUI renders a banner
+//! when `source` is `fs_only`.
 //!
 //! What: [`merged_roster`] is the real entry point `fs.list_projects`
 //! (`super::protocol::list_projects`) calls — it resolves the mpm daemon URL,
@@ -81,7 +88,7 @@ use std::time::Duration;
 use serde::Deserialize;
 
 use super::is_git_repo;
-use super::roster::{MAX_ENTRIES, ProjectCandidate, ProjectRoster};
+use super::roster::{MAX_ENTRIES, ProjectCandidate, ProjectRoster, RosterSource};
 
 /// Default loopback base URL for the trusty-mpm daemon's REST API.
 ///
@@ -190,10 +197,23 @@ async fn fetch_registry_projects(
 /// `None` for anything that doesn't resolve to a non-empty `owner` and
 /// `repo` — a malformed/unexpected `repo_url` shape must never panic or
 /// fabricate a bogus path.
+///
+/// **Only an EXACT `<owner>/<repo>` pair is supported** (code-critic PR
+/// #3439 review, MEDIUM 1): a compound remainder after the host — a GitLab
+/// subgroup path (`gitlab.com/group/subgroup/repo`) or a port-qualified host
+/// that this function's simple `split_once(['/', ':'])` mis-splits (e.g.
+/// `git.example.com:8443/owner/repo` splits on the PORT's `:`, leaving
+/// `8443/owner/repo`) — is rejected outright rather than silently absorbed
+/// into a multi-segment "owner" via `rsplit_once`. Letting that through
+/// would hand [`resolve_local_path`]'s `Path::join` an owner string
+/// containing `/`, fabricating a 3+-level lookup path no `repo_url` of this
+/// shape was ever meant to produce.
 /// Test: `tests::parse_owner_repo_handles_https_url`,
 /// `tests::parse_owner_repo_handles_https_url_with_git_suffix`,
 /// `tests::parse_owner_repo_handles_ssh_url`,
-/// `tests::parse_owner_repo_rejects_malformed_url`.
+/// `tests::parse_owner_repo_rejects_malformed_url`,
+/// `tests::parse_owner_repo_rejects_gitlab_style_subgroup_path`,
+/// `tests::parse_owner_repo_rejects_port_qualified_host_misparse`.
 fn parse_owner_repo(repo_url: &str) -> Option<(String, String)> {
     let trimmed = repo_url.trim().trim_end_matches('/');
     let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
@@ -207,6 +227,12 @@ fn parse_owner_repo(repo_url: &str) -> Option<(String, String)> {
     // `git@<host>:<owner>/<repo>` (SSH) — either way, the first `/` or `:`
     // after the host separates it from the `<owner>/<repo>` pair.
     let (_, after_host) = path_part.split_once(['/', ':'])?;
+    // Reject anything but an EXACT `<owner>/<repo>` pair — see the docs
+    // above for why a compound remainder must not fall through to
+    // `rsplit_once` below.
+    if after_host.matches('/').count() != 1 {
+        return None;
+    }
     let (owner, repo) = after_host.rsplit_once('/')?;
     if owner.is_empty() || repo.is_empty() {
         return None;
@@ -230,6 +256,35 @@ fn resolve_local_path(home: &Path, owner: &str, repo: &str) -> Option<PathBuf> {
     (candidate.is_dir() && is_git_repo(&candidate)).then_some(candidate)
 }
 
+/// Normalize `path` into the string [`merge`] indexes and compares on.
+///
+/// Why (code-critic PR #3439 review, HIGH 1): the fs scan's `path` string
+/// carries whatever casing `std::fs::read_dir` reported for the on-disk
+/// entry, while [`resolve_local_path`]'s candidate carries whatever casing
+/// the registry's `repo_url` happened to use. On a case-insensitive,
+/// case-preserving filesystem (default macOS APFS — the dev platform)
+/// `Path::is_dir` succeeds for BOTH castings of the identical directory, so
+/// exact-string equality between the two would miss the match and double
+/// the row: one `registered: false` (from the fs scan) and one
+/// `registered: true` (freshly appended from the registry) for the SAME
+/// checkout — precisely what DOC-39 §5.8.1 AC-20.7/AC-20.8 forbid. The same
+/// mismatch can also happen via symlink indirection (a registry-derived
+/// path reached through a symlinked alias of `home`) on ANY platform.
+/// What: `std::fs::canonicalize` resolves both symlinks and (on the
+/// platforms where the kernel's `realpath` does so, including macOS) case,
+/// collapsing every string representation of one real directory to the
+/// SAME canonical string. Degrades to `path` verbatim if canonicalization
+/// fails (a TOCTOU race, or a permission refusal) — matching this module's
+/// best-effort philosophy rather than dropping a candidate over a
+/// transient stat failure.
+/// Test: `tests::merge_dedupes_paths_reached_via_a_symlinked_home_alias`,
+/// `tests::merge_dedupes_case_differing_paths_on_case_insensitive_filesystems`.
+fn normalize_for_comparison(path: &Path) -> String {
+    std::fs::canonicalize(path)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
 /// Merge the filesystem-scanned roster with registry projects, registry
 /// primary.
 ///
@@ -239,20 +294,25 @@ fn resolve_local_path(home: &Path, owner: &str, repo: &str) -> Option<PathBuf> {
 /// with hand-built inputs, no mock server required.
 /// What: for each registry project that resolves to an existing local
 /// checkout ([`resolve_local_path`]): if a filesystem-scanned entry already
-/// has that exact path, it is promoted in place (`registered: true`, `name`
-/// and `owner` set from the registry's canonical values); otherwise a new
-/// entry is appended with `registered: true`. Filesystem-scanned entries
-/// with no matching registry project are kept as-is (`registered: false` —
-/// the local-only, unregistered secondary view). `home: None` (no resolvable
-/// home directory) short-circuits to the filesystem roster untouched, since
-/// no registry project could resolve a local path either. Result is
-/// re-sorted case-insensitively by `name` and re-capped at
-/// [`MAX_ENTRIES`] (a registered project can newly enter the roster, so the
-/// cap must be re-applied after merging, not just inherited from the fs
-/// scan).
+/// resolves ([`normalize_for_comparison`]) to that SAME real directory, it is
+/// promoted in place (`registered: true`, `name` and `owner` set from the
+/// registry's canonical values); otherwise a new entry is appended with
+/// `registered: true`, its `path` the normalized (canonical) string.
+/// Filesystem-scanned entries with no matching registry project are kept
+/// as-is (`registered: false` — the local-only, unregistered secondary
+/// view). `home: None` (no resolvable home directory) short-circuits to the
+/// filesystem roster untouched, since no registry project could resolve a
+/// local path either. Result is re-sorted case-insensitively by `name`,
+/// re-capped at [`MAX_ENTRIES`] (a registered project can newly enter the
+/// roster, so the cap must be re-applied after merging, not just inherited
+/// from the fs scan), and stamped [`RosterSource::Registry`] — this
+/// function is only ever called after a successful registry fetch (see
+/// [`merged_roster_with`]).
 /// Test: `tests::merge_marks_registered_projects_with_local_checkout`,
 /// `tests::merge_marks_unregistered_local_only_projects`,
-/// `tests::merge_skips_registry_projects_without_local_checkout`.
+/// `tests::merge_skips_registry_projects_without_local_checkout`,
+/// `tests::merge_dedupes_paths_reached_via_a_symlinked_home_alias`,
+/// `tests::merge_dedupes_case_differing_paths_on_case_insensitive_filesystems`.
 fn merge(
     fs_roster: ProjectRoster,
     registry_projects: &[RegistryProject],
@@ -263,7 +323,7 @@ fn merge(
         let mut path_index: HashMap<String, usize> = entries
             .iter()
             .enumerate()
-            .map(|(i, e)| (e.path.clone(), i))
+            .map(|(i, e)| (normalize_for_comparison(Path::new(&e.path)), i))
             .collect();
         for rp in registry_projects {
             let Some((owner, repo)) = parse_owner_repo(&rp.repo_url) else {
@@ -272,8 +332,8 @@ fn merge(
             let Some(path) = resolve_local_path(home, &owner, &repo) else {
                 continue;
             };
-            let path_str = path.display().to_string();
-            if let Some(&idx) = path_index.get(&path_str) {
+            let normalized = normalize_for_comparison(&path);
+            if let Some(&idx) = path_index.get(&normalized) {
                 entries[idx].registered = true;
                 entries[idx].name = rp.name.clone();
                 entries[idx].owner = Some(owner);
@@ -281,17 +341,20 @@ fn merge(
                 let idx = entries.len();
                 entries.push(ProjectCandidate {
                     name: rp.name.clone(),
-                    path: path_str.clone(),
+                    path: normalized.clone(),
                     owner: Some(owner),
                     registered: true,
                 });
-                path_index.insert(path_str, idx);
+                path_index.insert(normalized, idx);
             }
         }
     }
     entries.sort_by_key(|e| e.name.to_lowercase());
     entries.truncate(MAX_ENTRIES);
-    ProjectRoster { entries }
+    ProjectRoster {
+        entries,
+        source: RosterSource::Registry,
+    }
 }
 
 /// Fetch the registry (if reachable) and merge it with an already-computed
@@ -302,9 +365,11 @@ fn merge(
 /// tests supply hand-built inputs instead of touching the real filesystem or
 /// spawning a real mpm daemon, mirroring `super::roster`'s
 /// `list_projects`/`list_projects_in` split.
-/// What: on a successful fetch, delegates to [`merge`]. On ANY failure
-/// (unreachable daemon, non-2xx, malformed body), logs a `tracing::warn!`
-/// and returns `fs_roster` unchanged — already all `registered: false`, i.e.
+/// What: on a successful fetch, delegates to [`merge`] (stamps
+/// `RosterSource::Registry`). On ANY failure (unreachable daemon, non-2xx,
+/// malformed body), logs a `tracing::warn!` and returns `fs_roster`
+/// unchanged — already all `registered: false` AND already
+/// `RosterSource::FsOnly` (`super::roster::list_projects_in` sets it), i.e.
 /// exactly the graceful-degradation view module docs describe.
 /// Test: `tests::merged_roster_with_uses_registry_when_daemon_reachable`,
 /// `tests::merged_roster_with_degrades_to_fs_only_when_daemon_unreachable`.
@@ -404,6 +469,30 @@ mod tests {
         assert_eq!(parse_owner_repo(""), None);
     }
 
+    /// A GitLab-style subgroup path (`group/subgroup/repo`) must be
+    /// rejected, not absorbed into a bogus multi-segment "owner" (code-critic
+    /// PR #3439 review, MEDIUM 1).
+    #[test]
+    fn parse_owner_repo_rejects_gitlab_style_subgroup_path() {
+        assert_eq!(
+            parse_owner_repo("https://gitlab.com/group/subgroup/repo"),
+            None
+        );
+    }
+
+    /// A port-qualified host (`host:PORT/owner/repo`) must be rejected —
+    /// this function's simple `split_once(['/', ':'])` splits on the PORT's
+    /// `:`, not a host/path boundary, so without the compound-remainder
+    /// guard this would silently fabricate `owner = "PORT/owner"` (code-critic
+    /// PR #3439 review, MEDIUM 1).
+    #[test]
+    fn parse_owner_repo_rejects_port_qualified_host_misparse() {
+        assert_eq!(
+            parse_owner_repo("https://git.example.com:8443/owner/repo"),
+            None
+        );
+    }
+
     // ── `merge` ──────────────────────────────────────────────────────────
 
     /// A registry project whose repo_url resolves to an existing local git
@@ -473,6 +562,113 @@ mod tests {
         assert!(merged.entries.is_empty());
     }
 
+    /// Best-effort detection of a case-insensitive, case-preserving
+    /// filesystem (default macOS APFS, NTFS) — used to gate the case-folding
+    /// regression test below, which can only reproduce on such a volume.
+    fn fs_is_case_insensitive(dir: &Path) -> bool {
+        let probe = dir.join("CaseProbeDir3435");
+        if std::fs::create_dir(&probe).is_err() {
+            return false;
+        }
+        let insensitive = dir.join("caseprobedir3435").is_dir();
+        let _ = std::fs::remove_dir(&probe);
+        insensitive
+    }
+
+    /// Code-critic PR #3439 review, HIGH 1: on a case-insensitive,
+    /// case-preserving filesystem, a fs-scanned entry's on-disk casing and
+    /// the registry-derived candidate's `repo_url`-sourced casing must still
+    /// dedupe to exactly ONE roster row, not two. Gated to actually run only
+    /// when the temp filesystem is case-insensitive (CI's Linux ext4
+    /// typically is not); `merge_dedupes_paths_reached_via_a_symlinked_home_alias`
+    /// below covers the same `normalize_for_comparison` mechanism in a way
+    /// that reproduces on every platform.
+    #[test]
+    fn merge_dedupes_case_differing_paths_on_case_insensitive_filesystems() {
+        let home = tempfile::tempdir().expect("tempdir");
+        if !fs_is_case_insensitive(home.path()) {
+            return;
+        }
+
+        // The fs scan observes the on-disk casing "Trusty-Tools" — same
+        // characters as the registry's "trusty-tools" below, differing ONLY
+        // in case (not, e.g., hyphenation — a hyphen is not a case fold).
+        mk_git_repo(
+            &home
+                .path()
+                .join("trusty-mpm-projects")
+                .join("bobmatnyc")
+                .join("Trusty-Tools"),
+        );
+        let fs_roster = super::super::roster::list_projects_in(home.path());
+        assert_eq!(fs_roster.entries.len(), 1, "fs scan must find the repo");
+
+        // The registry's repo_url carries a DIFFERENT casing for the same repo.
+        let registry = vec![RegistryProject {
+            name: "trusty-tools".to_string(),
+            repo_url: "https://github.com/bobmatnyc/trusty-tools".to_string(),
+        }];
+
+        let merged = merge(fs_roster, &registry, Some(home.path()));
+
+        assert_eq!(
+            merged.entries.len(),
+            1,
+            "must dedupe to exactly one row, not two (DOC-39 AC-20.7/20.8)"
+        );
+        assert!(merged.entries[0].registered);
+    }
+
+    /// Code-critic PR #3439 review, HIGH 1: a portable (OS-independent)
+    /// equivalent of the case-folding scenario above. Filesystem case
+    /// sensitivity varies by platform, but symlink resolution does not: the
+    /// fs scan observes the repo under the REAL home dir, while `merge` is
+    /// given a symlinked ALIAS of that same home dir — two different path
+    /// strings, one real directory. Exact-string dedup (pre-fix) would
+    /// double the row; canonicalizing (post-fix) must not.
+    #[cfg(unix)]
+    #[test]
+    fn merge_dedupes_paths_reached_via_a_symlinked_home_alias() {
+        let real_home = tempfile::tempdir().expect("tempdir");
+        mk_git_repo(
+            &real_home
+                .path()
+                .join("trusty-mpm-projects")
+                .join("bobmatnyc")
+                .join("trusty-tools"),
+        );
+        let fs_roster = super::super::roster::list_projects_in(real_home.path());
+        assert_eq!(fs_roster.entries.len(), 1, "fs scan must find the repo");
+
+        let parent = real_home.path().parent().expect("tempdir has a parent");
+        let alias = parent.join(format!(
+            "alias-of-{}",
+            real_home
+                .path()
+                .file_name()
+                .expect("tempdir has a name")
+                .to_string_lossy()
+        ));
+        std::os::unix::fs::symlink(real_home.path(), &alias).expect("symlink alias");
+
+        let registry = vec![RegistryProject {
+            name: "trusty-tools".to_string(),
+            repo_url: "https://github.com/bobmatnyc/trusty-tools".to_string(),
+        }];
+
+        // `merge` resolves the registry entry against the ALIAS, not the
+        // real path the fs scan used.
+        let merged = merge(fs_roster, &registry, Some(&alias));
+        let _ = std::fs::remove_file(&alias);
+
+        assert_eq!(
+            merged.entries.len(),
+            1,
+            "must dedupe to exactly one row, not two (DOC-39 AC-20.7/20.8)"
+        );
+        assert!(merged.entries[0].registered);
+    }
+
     // ── `merged_roster_with` (network integration) ──────────────────────
 
     /// Spin up a one-route mock mpm daemon serving `GET /api/v1/projects`
@@ -521,6 +717,11 @@ mod tests {
 
         assert_eq!(roster.entries.len(), 1);
         assert!(roster.entries[0].registered);
+        assert_eq!(
+            roster.source,
+            RosterSource::Registry,
+            "a reachable registry must be signaled via `source` (code-critic PR #3439, HIGH 2)"
+        );
     }
 
     /// When the mpm daemon is unreachable, the merge must degrade to the
@@ -558,6 +759,12 @@ mod tests {
         assert!(
             !roster.entries[0].registered,
             "must degrade to fs-only (unregistered) view"
+        );
+        assert_eq!(
+            roster.source,
+            RosterSource::FsOnly,
+            "an unreachable registry must be signaled via `source`, distinct from \
+             'the registry legitimately has nothing registered' (code-critic PR #3439, HIGH 2)"
         );
     }
 

--- a/crates/trusty-code/src/fs_browse/protocol.rs
+++ b/crates/trusty-code/src/fs_browse/protocol.rs
@@ -108,23 +108,30 @@ async fn list_dir(params: Value, _ctx: ConnectionContext) -> Result<Value, RpcEr
 }
 
 /// `fs.list_projects() -> ProjectRoster` — the known-project roster for the
-/// GUI's workstream-first project-picker modal (issue #3365).
+/// GUI's workstream-first project-picker modal (issue #3365; re-sourced from
+/// trusty-mpm's shared project registry by issue #3435).
 ///
-/// Why: the modal's supported roster data source (see
-/// `crate::fs_browse::roster` module docs for the discovery heuristic and
-/// why this exists alongside, not instead of, `fs.list_dir`).
+/// Why: the modal's supported roster data source. As of #3435 this is no
+/// longer a pure filesystem scan — see `crate::fs_browse::mpm_registry`
+/// module docs for the registry-primary/fs-secondary merge policy and the
+/// mpm-daemon-unreachable degradation. `fs.list_dir` (this method's sibling)
+/// is untouched — it remains the manual browse-and-descend surface (7a), not
+/// re-sourced by this ticket.
 /// What: no params — `params` is ignored entirely (a caller passing `{}` or
 /// omitting params behaves identically, matching `fs.list_dir`'s tolerance
 /// for a no-argument call). Never returns a caller-facing error: an
-/// unreadable/missing scan root degrades to an empty roster (see
-/// `roster::list_projects`'s best-effort docs), so the only failure mode
-/// here is JSON serialization, which cannot fail for this struct shape in
-/// practice — kept as a `Result` only for symmetry with every other
-/// registered method and to surface a genuine bug rather than `unwrap`.
+/// unreachable mpm daemon degrades to the filesystem-only roster
+/// (`mpm_registry::merged_roster`'s docs), and an unreadable/missing scan
+/// root degrades further to an empty roster (`roster::list_projects`'s
+/// best-effort docs) — so the only failure mode here is JSON serialization,
+/// which cannot fail for this struct shape in practice — kept as a `Result`
+/// only for symmetry with every other registered method and to surface a
+/// genuine bug rather than `unwrap`.
 /// Test: `tests::list_projects_returns_entries_array`,
 /// `tests::register_wires_fs_list_projects`.
 async fn list_projects(_params: Value, _ctx: ConnectionContext) -> Result<Value, RpcError> {
-    serde_json::to_value(super::roster::list_projects())
+    let roster = super::mpm_registry::merged_roster().await;
+    serde_json::to_value(roster)
         .map_err(|e| RpcError::internal(format!("fs.list_projects: serializing roster: {e}")))
 }
 
@@ -307,10 +314,13 @@ mod tests {
 
     /// `fs.list_projects` must never error and must return an `entries`
     /// array — the response shape the picker modal dereferences. This runs
-    /// against the REAL developer/CI-runner home directory (the handler has
-    /// no injectable seam, unlike `roster::list_projects_in`, which carries
-    /// the real scan-behaviour coverage), so this only pins the wire shape,
-    /// not any particular content.
+    /// against the REAL developer/CI-runner home directory AND whatever real
+    /// mpm daemon (if any) happens to be reachable at the default loopback
+    /// URL (the handler has no injectable seam, unlike
+    /// `mpm_registry::merged_roster_with`, which carries the real
+    /// merge/degradation coverage), so this only pins the wire shape, not
+    /// any particular content — it must pass identically whether or not a
+    /// real mpm daemon is running locally.
     #[tokio::test]
     async fn list_projects_returns_entries_array() {
         let result = list_projects(Value::Null, test_ctx())

--- a/crates/trusty-code/src/fs_browse/roster.rs
+++ b/crates/trusty-code/src/fs_browse/roster.rs
@@ -103,19 +103,54 @@ pub struct ProjectCandidate {
     pub registered: bool,
 }
 
+/// Which source produced a [`ProjectRoster`] (issue #3435, code-critic PR
+/// #3439 review, HIGH 2).
+///
+/// Why: the #3363 lesson — "nothing registered" and "the registry was
+/// unreachable" are different operator-facing situations and must not
+/// collapse into the same-looking empty/all-unregistered roster. A bare
+/// `bool` would work, but a named enum reads at the call site
+/// (`source == RosterSource::FsOnly`) without a comment explaining which
+/// state `true`/`false` means, and its `serde` rendering (`"registry"` /
+/// `"fs_only"`) is self-describing on the wire too.
+/// What: [`Self::Registry`] means the mpm daemon was reached and `entries`
+/// is the registry-primary/fs-secondary merge (see `super::mpm_registry`);
+/// [`Self::FsOnly`] means the registry was never reached (unreachable
+/// daemon, or not yet queried) and `entries` is the bare filesystem scan,
+/// every candidate `registered: false`.
+/// Test: `super::mpm_registry::tests::merged_roster_with_uses_registry_when_daemon_reachable`,
+/// `super::mpm_registry::tests::merged_roster_with_degrades_to_fs_only_when_daemon_unreachable`.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RosterSource {
+    /// The mpm registry was reached; `entries` is the registry-primary merge.
+    Registry,
+    /// The mpm registry was unreachable (or never queried); `entries` is the
+    /// filesystem scan alone.
+    #[default]
+    FsOnly,
+}
+
 /// The `fs.list_projects` response body — everything the picker needs for
 /// one render.
 ///
 /// Why: a bare `Vec<ProjectCandidate>` would work equally well over the
 /// wire, but wrapping it in a named struct (mirroring [`super::DirListing`])
 /// leaves room to add roster-level metadata later (e.g. a `truncated: bool`
-/// flag) without a breaking wire-shape change.
+/// flag) without a breaking wire-shape change — `source` (issue #3435) is
+/// exactly that: an additive field a client predating it can simply ignore.
 /// Test: `tests::empty_home_returns_empty_roster`.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Default)]
 pub struct ProjectRoster {
     /// Candidate projects, sorted case-insensitively by `name`, capped at
     /// [`MAX_ENTRIES`].
     pub entries: Vec<ProjectCandidate>,
+    /// Which source produced `entries` (issue #3435). A bare filesystem scan
+    /// (this module's own [`list_projects`]/[`list_projects_in`]) always
+    /// reports [`RosterSource::FsOnly`] — only `super::mpm_registry::merge`
+    /// reports [`RosterSource::Registry`], on a successful registry fetch.
+    #[serde(default)]
+    pub source: RosterSource,
 }
 
 /// `fs.list_projects()` — the daemon-side entry point (issue #3365).
@@ -166,7 +201,10 @@ pub(super) fn list_projects_in(home: &Path) -> ProjectRoster {
     };
     entries.sort_by_key(|e| e.name.to_lowercase());
     entries.truncate(MAX_ENTRIES);
-    ProjectRoster { entries }
+    ProjectRoster {
+        entries,
+        source: RosterSource::FsOnly,
+    }
 }
 
 /// Scan `<home>/trusty-mpm-projects/<owner>/<repo>` two levels deep,

--- a/crates/trusty-code/src/fs_browse/roster.rs
+++ b/crates/trusty-code/src/fs_browse/roster.rs
@@ -13,6 +13,15 @@
 //! binding, not a multi-project registry), so this is a fresh, best-effort
 //! filesystem scan, deliberately narrow in scope (see `MAX_ENTRIES`).
 //!
+//! **Update (issue #3435):** trusty-mpm's shared project registry — a real
+//! cross-machine registry this crate does not own — is now the PRIMARY
+//! source for the roster the GUI actually renders; this module's scan has
+//! been demoted to the SECONDARY source (surfacing local-only, unregistered
+//! candidates the registry doesn't know about) plus the graceful-degradation
+//! fallback for when the mpm daemon is unreachable. See `super::mpm_registry`
+//! for the merge step and [`ProjectCandidate::registered`]. This module's own
+//! scan behavior and discovery heuristic below are otherwise unchanged.
+//!
 //! **Discovery heuristic.** This workspace's own convention — visible in the
 //! very checkout this crate lives in — is `~/trusty-mpm-projects/<owner>/
 //! <repo>` (an owner-scoped project root trusty-mpm's own tooling
@@ -54,9 +63,12 @@ use super::is_git_repo;
 /// the fallback case, a large home directory) must never turn a "small
 /// roster" call into a slow, huge response. 200 comfortably covers a
 /// realistic multi-owner project tree while staying obviously "small" per
-/// the issue's own requirement.
+/// the issue's own requirement. `pub(super)` (not private) so
+/// `super::mpm_registry`'s merge step (issue #3435) truncates the
+/// registry-augmented roster to the same cap rather than duplicating the
+/// magic number.
 /// Test: `tests::scan_is_capped_at_max_entries`.
-const MAX_ENTRIES: usize = 200;
+pub(super) const MAX_ENTRIES: usize = 200;
 
 /// One candidate project row — everything the picker needs to render and
 /// bind it without a further round-trip.
@@ -69,6 +81,11 @@ const MAX_ENTRIES: usize = 200;
 /// layout's owner segment when the scan found it that way, so the picker can
 /// disambiguate two repos that share a name under different owners; `None`
 /// on the home-directory fallback path, where there is no owner segment.
+/// `registered` (issue #3435) distinguishes a project known to trusty-mpm's
+/// shared project registry from one this crate found only by scanning the
+/// filesystem — a plain fs scan can never set it `true` on its own, so every
+/// candidate this module produces starts `false`; only
+/// `super::mpm_registry::merge` (the registry-primary merge step) flips it.
 /// Test: `tests::trusty_mpm_projects_layout_is_scanned_two_levels_deep`.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ProjectCandidate {
@@ -80,6 +97,10 @@ pub struct ProjectCandidate {
     /// scan found this candidate that way; `None` on the home-directory
     /// fallback path.
     pub owner: Option<String>,
+    /// Whether this candidate is also known to trusty-mpm's shared project
+    /// registry (issue #3435). Always `false` from a bare filesystem scan —
+    /// see the struct docs.
+    pub registered: bool,
 }
 
 /// The `fs.list_projects` response body — everything the picker needs for
@@ -131,7 +152,12 @@ pub fn list_projects() -> ProjectRoster {
 /// `tests::non_git_directories_are_excluded`,
 /// `tests::scan_is_capped_at_max_entries`,
 /// `tests::empty_home_returns_empty_roster`.
-fn list_projects_in(home: &Path) -> ProjectRoster {
+///
+/// `pub(super)` (not private) so `super::mpm_registry`'s tests (issue #3435)
+/// can build a hermetic filesystem-only `ProjectRoster` against a tempdir
+/// `home`, the same seam this module's own tests already use, rather than
+/// hand-rolling a second scan helper.
+pub(super) fn list_projects_in(home: &Path) -> ProjectRoster {
     let mpm_root = home.join("trusty-mpm-projects");
     let mut entries = if mpm_root.is_dir() {
         scan_owner_layout(&mpm_root)
@@ -184,6 +210,7 @@ fn scan_owner_layout(mpm_root: &Path) -> Vec<ProjectCandidate> {
                 name: repo_name,
                 path: repo_path.display().to_string(),
                 owner: Some(owner_name.clone()),
+                registered: false,
             });
         }
     }
@@ -217,6 +244,7 @@ fn scan_flat_layout(home: &Path) -> Vec<ProjectCandidate> {
             name,
             path: path.display().to_string(),
             owner: None,
+            registered: false,
         });
     }
     out

--- a/docs/specs/DOC-48-tcode-workstreams.md
+++ b/docs/specs/DOC-48-tcode-workstreams.md
@@ -19,7 +19,7 @@ spec_refs:
 **Status:** Draft (Rev 2)
 **Subsystem:** trusty-code — workstream persistence, session lifecycle, RPC/REST/CLI surfaces
 **Owner:** Engineering (trusty-code)
-**Last-updated:** 2026-07-20 (Rev 2: activation-lock exclusivity model, single-project binding; Rev 5: unprefixed REST paths; Rev 6: §8 Phase C+ — workstream-first GUI creation flow, issue #3365; Rev 7: §9 Q1–Q3 resolutions — prompt-text inference, registered project_slug, no auto-transition; Rev 8: §8 Phase C++ — implicit workstream inference + monitoring reframe, issue #3384)
+**Last-updated:** 2026-07-20 (Rev 2: activation-lock exclusivity model, single-project binding; Rev 5: unprefixed REST paths; Rev 6: §8 Phase C+ — workstream-first GUI creation flow, issue #3365; Rev 7: §9 Q1–Q3 resolutions — prompt-text inference, registered project_slug, no auto-transition; Rev 8: §8 Phase C++ — implicit workstream inference + monitoring reframe, issue #3384; Rev 9: §8 Phase C+ roster bullet note — project roster re-sourced from the shared mpm project registry, issue #3435, full spec in DOC-39 §5.8.1)
 **Spec ID:** `SPEC-WS-01~draft` … `SPEC-WS-08~draft`, `SPEC-WS-09~resolved` (DOC-48)
 **Builds on:**
 - [`docs/specs/trusty-code-harness-ui.md`](./trusty-code-harness-ui.md) (DOC-39, merged) — [`SPEC-TCUI-08~draft`](./trusty-code-harness-ui.md#SPEC-TCUI-08~draft) §4B defines the Workstream domain object as a NEW prerequisite: "an infinite thread with state `active · idle · closed`… resumable across daemon restarts." This spec is the Phase 2+ implementation of that domain object and its persistence layer.
@@ -540,6 +540,13 @@ This preserves DOC-40's "never silently multiplex" principle at the activation l
       is a "quick pick" shortlist for the modal only; §2.3's "workstreams
       are daemon-scoped, project implicit via `ProjectBinding`" model is
       unchanged.
+      **Update (Rev 9, issue #3435):** the roster's PRIMARY source is now
+      trusty-mpm's shared project registry (a loopback call to the mpm
+      daemon's `GET /api/v1/projects`); this crate's filesystem scan above
+      is demoted to SECONDARY (local-only/unregistered candidates, plus the
+      degrade path when the mpm daemon is unreachable). Full spec: DOC-39
+      §5.8.1; implementation: `crates/trusty-code/src/fs_browse/
+      mpm_registry.rs`.
 - [x] **Projectless mapping.** The modal's "start chatting without a
       project" option maps onto the workstream's first session carrying no
       `project` binding — §4.1's existing optional-binding rule, unchanged.

--- a/docs/specs/trusty-code-harness-ui.md
+++ b/docs/specs/trusty-code-harness-ui.md
@@ -953,13 +953,32 @@ settle is **where it lands when it lands**: cloning a repo is filesystem-and-pro
 so it is `project.clone_from_url` on the daemon (§5.1 #11) — **never** a UI-side git
 operation, and never Tauri-native. Deferring it therefore costs nothing architecturally.
 
-### 5.8.1 Project roster — `GET /projects` (NEW, Phase C, issue #3365)
+### 5.8.1 Project roster — `GET /projects` (Phase C, issue #3365; re-sourced Phase C+++, issue #3435)
 
 The `ProjectPickerModal` (§7A's Phase C update above) needs a **flat, pre-resolved
 shortlist** to render directly — a browse-and-descend tree (§4.2.1/§5.8) is the wrong
 shape for a modal the operator expects to click through in one step, not navigate. This
 is the "supported roster data source" the modal's own predecessor (`CreateSessionForm`)
 recorded as a gap ("no pre-session roster endpoint exists yet").
+
+**Amendment (issue #3435) — source of truth changed, shape additive-only.** Bob's
+directive: *"for 'Projects' we should be using the shared (mpm) projects manager to list
+projects."* trusty-mpm's shared project registry (`~/.trusty-mpm/project-registry/
+projects.json`, surfaced over the mpm daemon's `GET /api/v1/projects`,
+`crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs`) is now the
+PRIMARY source for this roster, reached over a loopback HTTP call
+(`http://127.0.0.1:7880`, overridable via `TRUSTY_MPM_URL` — the same env var
+`trusty-mpm-gui` already reads) — see `crate::fs_browse::mpm_registry` module docs for
+the full survey/rationale (workspace loopback-HTTP precedent, ADR-0018). The filesystem
+scan documented below is DEMOTED to secondary: a locally-discovered candidate not
+resolvable to a registry entry still appears in the roster (never silently dropped —
+e.g. a `bakeoff-l1` scratch checkout), now flagged via the new `registered: bool` field
+(`false` for such candidates, `true` for a registry-backed one). If the mpm daemon is
+unreachable, the roster degrades to the plain filesystem scan (every entry
+`registered: false`) rather than erroring or returning an empty picker. The wire shape
+change is additive-only (`registered` is a new field on each entry) — no existing field
+changed meaning, so `GET /projects` stays backward-compatible for any client predating
+this amendment.
 
 **Naming divergence from §5.8 (documented, deliberate, consistent with an existing
 gap):** §5.8 specifies `project.list_dir` as a `project.*`-namespaced `POST /rpc` method;
@@ -983,19 +1002,23 @@ fs.list_projects()
             name: String,           // "trusty-tools"
             path: String,           // "/Users/bob/trusty-mpm-projects/bobmatnyc/trusty-tools"
             owner: Option<String>,  // "bobmatnyc" under the owner-scoped layout; None otherwise
+            registered: bool,       // NEW (#3435): known to trusty-mpm's shared project registry
         }
     ]
 }
 ```
 
-**Discovery heuristic (best-effort, never a caller-facing error):** when
+**Discovery heuristic (best-effort, never a caller-facing error) — now the SECONDARY
+source (issue #3435; PRIMARY is the mpm registry, see the amendment above):** when
 `~/trusty-mpm-projects` exists, scans it two levels deep — owner dirs, then their repo
 dirs — keeping only repo dirs that are git repos (`crate::fs_browse::is_git_repo`, the
 same discriminator §4.2.1's picker badge already uses). When it does not exist, falls
-back to a one-level scan of the home directory itself, git repos only. Capped at 200
-entries (a "quick pick" shortlist, not a paginated browser). An unreadable/missing scan
-root degrades to an empty (or partial) roster, mirroring §5.8's own best-effort
-per-entry philosophy — never a `500`.
+back to a one-level scan of the home directory itself, git repos only. The merged result
+(registry primary + fs-scan secondary) is capped at 200 entries (a "quick pick"
+shortlist, not a paginated browser). An unreadable/missing scan root degrades to an
+empty (or partial) roster, mirroring §5.8's own best-effort per-entry philosophy — never
+a `500`; likewise an unreachable mpm daemon degrades to the fs-only roster rather than a
+`500` or an empty picker.
 
 **Relationship to §5.8's `list_dir`/`GET /fs`:** additive, not a replacement. `GET /fs`
 still exists and is unchanged; a future manual "browse for another folder" affordance
@@ -1003,12 +1026,27 @@ inside the modal (not built in this ticket — see the non-goals list on issue #
 layer on top of it. The roster is the DEFAULT, fast path; arbitrary-directory browse
 remains available as an API for whenever a UI surface needs it again.
 
-**AC-20.4** `fs.list_projects` returns `entries` with `name`/`path`/`owner` for every
-discovered candidate — the minimum the modal renders.
+**Registry hygiene note (issue #3435, deferred):** no `tm project remove` verb exists
+yet, so a stale registry entry becomes user-visible in this roster if — and only if — a
+matching local checkout still exists under the owner-scoped layout (a stale entry with
+no local checkout is already absent, since a registry entry with no resolvable local
+path is skipped, never fabricated as a dead row). Filtering a live-but-stale entry whose
+checkout DOES still exist depends on a future `tm project remove` and is explicitly out
+of scope here.
+
+**AC-20.4** `fs.list_projects` returns `entries` with `name`/`path`/`owner`/`registered`
+for every candidate — the minimum the modal renders.
 **AC-20.5** The endpoint never returns a caller-facing error; an unreadable or missing
-scan root yields an empty roster.
+scan root yields an empty roster, and an unreachable mpm daemon degrades to the
+filesystem-only roster rather than erroring.
 **AC-20.6** `GET /projects` is loopback-only, matching every other route this daemon
-serves (ADR-0011) — no new bind surface.
+serves (ADR-0018, the loopback-only doctrine that amends ADR-0011) — no new bind surface;
+its one outbound call (to the mpm daemon's `GET /api/v1/projects`) is itself loopback-only
+for the same reason.
+**AC-20.7** (NEW, #3435) A locally-discovered candidate with no matching registry entry
+is never dropped from the roster — it appears with `registered: false`.
+**AC-20.8** (NEW, #3435) A registry entry with no resolvable local checkout on this
+machine is never fabricated into a roster row with a made-up path.
 
 ---
 
@@ -1483,6 +1521,15 @@ This is carried forward verbatim because it is the one piece of the visual syste
 
 ## Changelog
 
+- **2026-07-20** — **Shared project registry becomes the roster's source of truth**
+  (issue #3435). Amends **§5.8.1** (`SPEC-TCUI-05~draft`): `GET /projects`/
+  `fs.list_projects` is re-sourced from trusty-mpm's shared project registry
+  (PRIMARY, via a loopback call to the mpm daemon's `GET /api/v1/projects`), with the
+  prior filesystem scan demoted to SECONDARY (local-only/unregistered candidates,
+  plus the fallback when the mpm daemon is unreachable). Adds the `registered: bool`
+  field to each roster entry (additive-only wire change) and AC-20.7/AC-20.8. See
+  `crates/trusty-code/src/fs_browse/mpm_registry.rs` module docs for the full survey
+  and design rationale; DOC-48 §8 (Phase C+ roster bullet) carries a pointer note.
 - **2026-07-20** — **Implicit workstream inference + monitoring reframe** (issue #3384,
   Phase C+). Amends §7A (`SPEC-TCUI-10~draft`) to record Bob's follow-up direction after
   test-driving the Phase C flow: the explicit **NEW WORKSTREAM** entry-control ceremony is

--- a/docs/specs/trusty-code-harness-ui.md
+++ b/docs/specs/trusty-code-harness-ui.md
@@ -1004,9 +1004,33 @@ fs.list_projects()
             owner: Option<String>,  // "bobmatnyc" under the owner-scoped layout; None otherwise
             registered: bool,       // NEW (#3435): known to trusty-mpm's shared project registry
         }
-    ]
+    ],
+    source: "registry" | "fs_only", // NEW (#3435, code-critic PR #3439 review HIGH 2)
 }
 ```
+
+**`source` (code-critic PR #3439 review, HIGH 2):** distinguishes "the registry legitimately
+has nothing registered" from "the registry was unreachable" — collapsing those into the same
+all-`registered: false` shape would hide a real mpm-daemon outage from the operator (the
+#3363 lesson). `"registry"` means the mpm daemon was reached and `entries` is the
+registry-primary/fs-secondary merge; `"fs_only"` means the registry was never reached and
+`entries` is the bare filesystem scan. `ProjectPickerModal` renders a banner ("shared
+registry unavailable — showing local checkouts only") when `source` is `"fs_only"`.
+
+**Path-identity normalization (code-critic PR #3439 review, HIGH 1):** the merge step
+canonicalizes (`std::fs::canonicalize`) both the filesystem-scanned entry's path and the
+registry-derived candidate path before comparing them, so a case-differing path (a
+case-insensitive, case-preserving filesystem — default macOS APFS — accepts both castings of
+the same on-disk directory) or a symlink-indirected path to the SAME checkout dedupes to
+exactly one roster row rather than appearing twice (once `registered: false` from the fs
+scan, once `registered: true` freshly appended from the registry).
+
+**`repo_url` parsing restriction (code-critic PR #3439 review, MEDIUM 1):** only an EXACT
+`<owner>/<repo>` pair after the host is accepted. A GitLab-style subgroup path
+(`gitlab.com/group/subgroup/repo`) or a port-qualified host that the simple host/path
+splitter mis-splits (`git.example.com:8443/owner/repo` splits on the port's `:`) is rejected
+outright — `None`, the registry entry is skipped — rather than silently absorbed into a
+multi-segment "owner" that would fabricate a bogus 3+-level lookup path.
 
 **Discovery heuristic (best-effort, never a caller-facing error) — now the SECONDARY
 source (issue #3435; PRIMARY is the mpm registry, see the amendment above):** when
@@ -1047,6 +1071,11 @@ for the same reason.
 is never dropped from the roster — it appears with `registered: false`.
 **AC-20.8** (NEW, #3435) A registry entry with no resolvable local checkout on this
 machine is never fabricated into a roster row with a made-up path.
+**AC-20.9** (NEW, code-critic PR #3439 review, HIGH 1) A filesystem-scanned entry and a
+registry-derived candidate that resolve to the SAME real directory (via case-folding or
+symlink indirection) dedupe to exactly one roster row, never two.
+**AC-20.10** (NEW, code-critic PR #3439 review, HIGH 2) `source` is `"fs_only"` whenever the
+mpm daemon was unreachable, distinct from a reachable registry with zero matching entries.
 
 ---
 
@@ -1530,6 +1559,13 @@ This is carried forward verbatim because it is the one piece of the visual syste
   field to each roster entry (additive-only wire change) and AC-20.7/AC-20.8. See
   `crates/trusty-code/src/fs_browse/mpm_registry.rs` module docs for the full survey
   and design rationale; DOC-48 §8 (Phase C+ roster bullet) carries a pointer note.
+  **Code-critic PR #3439 review fixes (same-day, before merge):** adds the
+  `source: "registry" | "fs_only"` roster-level field and AC-20.10 (HIGH 2 —
+  distinguishes "nothing registered" from "registry unreachable"); adds
+  path-identity normalization before the merge's dedup comparison and AC-20.9
+  (HIGH 1 — a case-differing or symlink-indirected path to the same checkout no
+  longer double-lists); restricts `repo_url` parsing to an exact `<owner>/<repo>`
+  pair, rejecting GitLab-style subgroup paths and port-qualified hosts (MEDIUM 1).
 - **2026-07-20** — **Implicit workstream inference + monitoring reframe** (issue #3384,
   Phase C+). Amends §7A (`SPEC-TCUI-10~draft`) to record Bob's follow-up direction after
   test-driving the Phase C flow: the explicit **NEW WORKSTREAM** entry-control ceremony is


### PR DESCRIPTION
## Summary

Bob's directive (issue #3435): *"for 'Projects' we should be using the shared (mpm) projects manager to list projects."* This PR re-sources the tcode GUI's `GET /projects` roster from trusty-mpm's shared project registry instead of tcode's own filesystem scan (added in PR #3375), per the tcode-as-harness / trusty-mpm-as-canonical-owner doctrine.

## Survey findings

1. **mpm registry surfaces:** `~/.trusty-mpm/project-registry/projects.json`, loaded via `ProjectStore`/`ProjectRegistry` (`crates/trusty-mpm/src/project/{store,registry}.rs`). Schema: `Project { name, repo_url, default_branch, stack_hint, tags, description, gh_user, gh_account, github, commit_name, commit_email }` — **no local filesystem path field**. `tm project list` is a thin HTTP client over `GET /api/v1/projects` (never reads the file directly). The mpm daemon already exposes this route (`crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs`), returning `{ projects, count }`.
2. **Cross-daemon precedent:** `crates/trusty-mpm-gui/src/commands.rs` is the exact pattern — a Tauri "1:1 proxy layer" doing `reqwest` loopback calls to `http://127.0.0.1:7880` (overridable via `TRUSTY_MPM_URL`), per its own module doc ("must never embed business logic"). No workspace precedent exists for one daemon reading a sibling's on-disk store directly. **ADR-0018** (loopback-only doctrine; amends ADR-0011) explicitly sanctions same-machine loopback HTTP between sibling daemons, including for GUI clients.
3. **Current tcode scan:** `fs_browse::roster` (`crates/trusty-code/src/fs_browse/roster.rs`) — a best-effort scan of `~/trusty-mpm-projects/<owner>/<repo>` (flat `~` fallback), filtered to git repos, capped at 200. `GET /projects` (`serve/rest/projects.rs`) is a thin shim over the `fs.list_projects` JSON-RPC method. GUI consumer: `lib/project-roster.ts` + `ProjectPickerModal.svelte`.

## Design choices

- **Consumption path:** loopback HTTP call to the mpm daemon's `GET /api/v1/projects` (default `http://127.0.0.1:7880`, overridable via `TRUSTY_MPM_URL` — reusing `trusty-mpm-gui`'s own env var rather than inventing a second one). New module `crates/trusty-code/src/fs_browse/mpm_registry.rs`.
- **Merged view:** registry is PRIMARY (`registered: true`, canonical `name`); the existing fs scan is SECONDARY — any locally-discovered candidate not resolvable to a registry entry (matched by deriving `<owner>/<repo>` from `repo_url` and checking `~/trusty-mpm-projects/<owner>/<repo>` exists as a git repo) still appears, `registered: false`. Nothing is silently dropped (e.g. `bakeoff-l1..l5`), and nothing is auto-registered.
- **Registry hygiene:** out of scope, as directed — a stale registry entry only becomes visible if a matching local checkout still exists (which incidentally filters most no-longer-cloned throwaway entries for free); filtering live-but-stale entries depends on a future `tm project remove`.
- **Degradation:** an unreachable mpm daemon (1.5s timeout) degrades to the plain filesystem-only roster (`registered: false` for everything) — never an empty picker or a caller-facing error. A `source: "registry" | "fs_only"` field (added in the review-fixes round below) makes this degradation caller-visible.
- **Wire compatibility:** `GET /projects` response shape is additive-only — `registered: bool` per entry, `source` at the roster level; the TS types mark both optional for compatibility with an older daemon. `ProjectPickerModal.svelte` shows a small "local only" label on unregistered rows (mirrors `new-workstream.ts::bindingLabel`'s existing state-driven-label precedent), plus an amber banner when `source` is `fs_only`.
- **Spec:** DOC-39 §5.8.1 amended (source of truth, new fields, discovery-heuristic-as-secondary, AC-20.7–20.10, ADR-0011→0018 citation fix); DOC-48 §8 Phase C+ roster bullet carries a pointer note (Rev 9).

## Review fixes (code-critic PR #3439 review — WARN, all four addressed)

- **HIGH 1 — path-identity dedup bug.** `merge()` deduped roster entries by exact path-STRING equality, but a fs-scanned entry's on-disk casing and a registry-derived candidate's `repo_url`-sourced casing can differ on a case-insensitive/case-preserving filesystem (default macOS APFS — the dev platform), or via symlink indirection on any platform — `Path::is_dir()` succeeds for both, the exact-string lookup misses, and the SAME checkout double-lists (one `registered: false`, one `registered: true`), violating DOC-39 AC-20.7/20.8. **Fix:** `normalize_for_comparison` canonicalizes (`std::fs::canonicalize`) both sides before indexing/lookup. **Regression tests:** `merge_dedupes_case_differing_paths_on_case_insensitive_filesystems` (runtime-gated on an actual case-insensitive tempdir — verified to genuinely reproduce and be fixed on this dev machine) + `merge_dedupes_paths_reached_via_a_symlinked_home_alias` (portable, OS-independent equivalent via a symlinked home alias).
- **HIGH 2 — no degradation signal.** `ProjectRoster` gave the GUI no way to tell "the registry has nothing registered" from "the registry was unreachable" (the #3363 lesson — those must not collapse into the same all-`registered: false` shape). **Fix:** added `ProjectRoster::source: RosterSource` (`Registry | FsOnly`, serializes as `"registry" | "fs_only"`), set in `merge()`/`merged_roster_with()`; `ProjectPickerModal.svelte` renders an amber banner ("shared registry unavailable — showing local checkouts only") when `source` is `fs_only`. Tests assert `source` on both the reachable and unreachable paths, plus GUI banner-presence/absence tests.
- **MEDIUM 1 — `repo_url` parsing fabricated bogus paths.** `parse_owner_repo` silently absorbed a compound remainder (a GitLab subgroup path, or a port-qualified host mis-split on the port's `:`) into a multi-segment "owner" via `rsplit_once`, which `Path::join` would then turn into a fabricated 3+-level lookup path. **Fix:** short-circuits to `None` unless the remainder after the host is an EXACT `<owner>/<repo>` pair. **Tests:** `parse_owner_repo_rejects_gitlab_style_subgroup_path`, `parse_owner_repo_rejects_port_qualified_host_misparse`.
- **MEDIUM 2 — test gaps.** Closed by the tests listed above; all pre-existing happy-path tests stay green.

`TRUSTY_MPM_URL` loopback-validation hardening is explicitly OUT of scope here — filed separately, covering both this call site and `trusty-mpm-gui`'s pre-existing one.

## Files changed

- `crates/trusty-code/src/fs_browse/mpm_registry.rs` (new) — loopback client, `repo_url` parsing (with compound-remainder rejection), path-identity-normalized local-path resolution, registry-primary merge, `RosterSource` propagation.
- `crates/trusty-code/src/fs_browse/roster.rs` — `ProjectCandidate.registered: bool`; new `RosterSource` enum + `ProjectRoster.source`; `MAX_ENTRIES`/`list_projects_in` visibility widened to `pub(super)` for the sibling module's tests.
- `crates/trusty-code/src/fs_browse/protocol.rs` — `fs.list_projects` now calls `mpm_registry::merged_roster()`.
- `crates/trusty-code/src/fs_browse/mod.rs` — registers the new module.
- `crates/trusty-code-gui/ui/src/lib/project-roster.ts` — `registered?: boolean`, `source?: RosterSource` (additive), guard updated for both.
- `crates/trusty-code-gui/ui/src/components/ProjectPickerModal.svelte` — "local only" marker on unregistered rows + `fs_only` degradation banner.
- Test fixtures updated (`ProjectPickerModal.test.ts`, `StartWorkingForm.test.ts`, `project-roster.test.ts`) + new coverage for registry-primary merge, mpm-unavailable degradation, unregistered marking, path-identity dedup, and `repo_url` compound-remainder rejection.
- `docs/specs/trusty-code-harness-ui.md` (DOC-39 §5.8.1 + changelog, AC-20.9/20.10), `docs/specs/DOC-48-tcode-workstreams.md` (Rev 9 note).
- `crates/trusty-code/CHANGELOG.md`, `crates/trusty-code-gui/CHANGELOG.md`.

## Gate results (raw)

- `cargo fmt --check` — clean.
- `cargo clippy -p trusty-code -p trusty-code-gui --all-targets -- -D warnings` — clean (0 warnings from touched code; 2 pre-existing unrelated workspace metadata warnings about duplicate bin targets in trusty-mpm/trusty-installer).
- `cargo test -p trusty-code` — **1392 passed; 0 failed; 4 ignored** (pre-existing OPENROUTER_API_KEY-gated tests, unrelated) + all integration test binaries green (`agent_fallback_e2e`, `agent_id_e2e`, `agents_e2e`, `cli_e2e`, `config_mount`, `connector_e2e`, `inference_shared_adapter_e2e`, `m1_cutline_e2e`, `readiness_e2e`, `recall_content_e2e`, `search_hits_e2e`, `session_e2e`, `task_e2e` — every one `0 failed`). Flake exclusion: `run_task::tests::*` intermittently fails/passes across runs on this box due to a `trusty-memory` loopback dependency unrelated to this change (observed both `no_changes_yields_no_changes_exit` and `repeated_llm_errors_trigger_redelegation_cap_not_pm_turn_cap` fail-then-pass on isolated reruns); every `fs_browse::*`/`mpm_registry::*` test is consistently green across all runs.
- `cargo test -p trusty-code-gui` — **4 passed; 0 failed**.
- `trusty-mpm` — not touched (survey-only); its test suite was not run per the gate's "if touched" condition.
- `pnpm test` (crates/trusty-code-gui/ui) — **204 passed; 0 failed** (18 test files).
- `pnpm build` (crates/trusty-code-gui/ui) — clean production build.
- `scripts/check_line_cap.sh` — `7 allowlisted, 0 violations — OK.`
- `scripts/check_test_pointers.sh` — `0 dangling pointers — OK.`
- `scripts/check_sld.sh` — `scanned 39 spec doc(s) + 2632 code file(s); 0 error(s), 0 warning(s)`.

## Test plan

- [x] Registry-primary merge logic (`merge_marks_registered_projects_with_local_checkout`, `merge_marks_unregistered_local_only_projects`, `merge_skips_registry_projects_without_local_checkout`)
- [x] mpm-source-unavailable degradation, including `source` (`merged_roster_with_degrades_to_fs_only_when_daemon_unreachable`)
- [x] Registry-reachable end-to-end via mock daemon, including `source` (`merged_roster_with_uses_registry_when_daemon_reachable`)
- [x] Unregistered marking surfaced in the GUI (`ProjectPickerModal.test.ts`)
- [x] `fs_only` degradation banner shown/hidden correctly (`ProjectPickerModal.test.ts`, code-critic HIGH 2)
- [x] Path-identity dedup: case-folding (gated, verified on dev machine) + portable symlink-alias (code-critic HIGH 1)
- [x] `repo_url` parsing: HTTPS, HTTPS+.git, SSH, malformed, GitLab subgroup, port-qualified host (code-critic MEDIUM 1)

Closes #3435

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
