### PR TITLE
fix(trusty-code): embedded pm default agent + valid model IDs (closes #3437, closes #3438)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Every daemon-default task run (including every GUI-initiated run) failed
+  instantly with "unknown agent 'pm'" (closes #3437).** `task.run` defaults an
+  omitted `agent_name` to the literal `"pm"`, but no embedded `pm` agent
+  existed in `assets::DEFAULT_AGENTS` and no disk `~/.claude/agents/pm.md`
+  existed either — 100% of daemon-default runs failed agent resolution before
+  a single turn executed. Added an embedded `pm` orchestrator/default agent
+  (`assets/agents/pm.md`, tcode's 4th self-contained default alongside
+  `engineer`/`qa-agent`/`code-reviewer`) plus a drift guard
+  (`task::protocol::DEFAULT_TASK_RUN_AGENT_NAME`, referenced from both the
+  `task.run` default and a dedicated test) so the default literal can never
+  again point at a name the embedded roster doesn't carry.
+- **LLM calls failed with `API error 400: "opus is not a valid model ID"` on
+  daemon task runs (closes #3438).** Several embedded agents' `.md`
+  frontmatter (and any `resource_tier`-composed agent) declares its model as
+  a bare Claude CLI alias (`opus`/`sonnet`/`haiku`) rather than a concrete
+  provider slug; `provider::routing::resolve_model` — the single function
+  every call site resolves its final model slug through — now normalizes
+  these three known aliases to a concrete OpenRouter slug
+  (`provider::routing::normalize_model_alias`) before returning, so no bare
+  alias ever reaches a provider unnormalized regardless of which tier
+  (`RunContext` override, `[agent].model`, `[llm].model_override`) it came
+  from.
 - **`serve::DEFAULT_HTTP_PORT` moved from 7881 to 7882 (closes #3364).** The
   old default silently collided with `trusty-mpm`'s supervisor metrics
   listener (`DEFAULT_METRICS_ADDR`, also 7881) — the supervisor's generic

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -372,17 +372,18 @@ pub fn available_agent_names(dir: &Path) -> Vec<String> {
 mod tests {
     use super::*;
 
-    /// The 31-name default embedded roster, in `crate::assets::DEFAULT_AGENTS`'s
-    /// declared order (Slice E3, #2958) — shared by every fallback test in
-    /// this module so the expected list is written once, not duplicated
-    /// per-test with the risk of one copy drifting from another.
+    /// The 32-name default embedded roster, in `crate::assets::DEFAULT_AGENTS`'s
+    /// declared order (Slice E3, #2958; `pm` added for #3437) — shared by
+    /// every fallback test in this module so the expected list is written
+    /// once, not duplicated per-test with the risk of one copy drifting from
+    /// another.
     ///
     /// Why: three separate fallback scenarios (empty dir, all-invalid dir,
-    /// only-orphaned-toml dir) all assert the identical 31-name outcome; a
+    /// only-orphaned-toml dir) all assert the identical 32-name outcome; a
     /// single source avoids a silent typo in one copy passing review
     /// unnoticed.
-    /// What: tcode's original 3 (`engineer`, `qa-agent`, `code-reviewer`)
-    /// followed by the 28 roster names, alphabetical, matching
+    /// What: tcode's original 4 (`engineer`, `qa-agent`, `code-reviewer`,
+    /// `pm`) followed by the 28 roster names, alphabetical, matching
     /// `DEFAULT_AGENTS`'s literal declaration order.
     /// Test: every `load_all_agents_falls_back_*` test below.
     fn expected_default_agent_names() -> Vec<&'static str> {
@@ -390,6 +391,7 @@ mod tests {
             "engineer",
             "qa-agent",
             "code-reviewer",
+            "pm",
             "api-qa",
             "code-analyzer",
             "code-critic",

--- a/crates/trusty-code/src/assets/agents/pm.md
+++ b/crates/trusty-code/src/assets/agents/pm.md
@@ -1,0 +1,21 @@
+---
+name: pm
+role: pm
+description: General-purpose orchestrator and default agent — plans the work, delegates to specialist sub-agents when delegation is available, and does the work directly when it is not.
+model: sonnet
+max_tokens: 8192
+tools: [read_file, write_file, write_files, edit, grep, glob, list_dir, bash, search_code, use_skill, finish_task]
+skills: [writing-plans, brainstorming, requesting-code-review]
+---
+
+You are the PM (project manager) sub-agent — the default top-level agent for both open-ended chat/planning and task dispatch when no other agent is named. You own the task from intake to completion.
+
+Rules:
+- Understand the request before acting: restate the goal to yourself, identify what "done" looks like, and note any constraints before making changes.
+- When a `delegate_to_agent` tool is available, break the task into concrete sub-tasks and delegate implementation work to the right specialist rather than doing everything yourself — write clear, self-contained briefs (what to build, relevant files, acceptance criteria) since a delegated agent starts with no memory of this conversation.
+- When no delegation tool is available, or the task is small enough that delegating would cost more than it saves, do the work directly using the same standards you would hold a delegated agent to: read existing code before writing new code, follow established patterns, and test what you change.
+- Track the plan as you go. If a delegated attempt fails partway with real progress on disk, hand the next attempt a brief that says what already exists and what remains — never restart from zero when partial work is reusable.
+- Never fabricate a result you did not observe. Report actual command output and actual sub-agent outcomes, not assumed ones.
+- Keep the user or caller informed of material scope changes (new blockers, a plan that no longer fits the original ask) rather than silently re-scoping.
+
+When you believe the task is complete, call `finish_task` with a summary of what was done (directly or via delegation) and how it was verified.

--- a/crates/trusty-code/src/assets/mod.rs
+++ b/crates/trusty-code/src/assets/mod.rs
@@ -9,12 +9,12 @@
 //! disk-based `.claude/agents/` and `.claude/skills/` always take precedence
 //! when present (see `agents::load_all_agents` and
 //! `skills::discover_skill_metadata`'s embedded-fallback branches).
-//! What: [`EmbeddedAgent`]/[`DEFAULT_AGENTS`] — the 31-agent dispatchable
-//! roster (Slice E3, #2958): tcode's own 3 defaults (`engineer`, `qa-agent`,
-//! `code-reviewer`, no `extends:` chain — projected via
-//! `agents::md_loader::project_embedded_md`) plus the 28 coding-relevant tm
-//! agents Bob selected in #2958 (`extends:`-chained through the 5 `BASE-*`
-//! templates — projected via
+//! What: [`EmbeddedAgent`]/[`DEFAULT_AGENTS`] — the 32-agent dispatchable
+//! roster (Slice E3, #2958, plus `pm` added for #3437): tcode's own 4
+//! defaults (`engineer`, `qa-agent`, `code-reviewer`, `pm`, no `extends:`
+//! chain — projected via `agents::md_loader::project_embedded_md`) plus the
+//! 28 coding-relevant tm agents Bob selected in #2958 (`extends:`-chained
+//! through the 5 `BASE-*` templates — projected via
 //! `agents::md_loader::project_embedded_md_with_extends`, which resolves
 //! against [`EMBEDDED_TM_AGENT_SOURCES`]). Authored as Markdown+frontmatter
 //! (`.md`) as of #2897 Slice C (previously native TOML; Slice D subsequently
@@ -161,24 +161,33 @@ pub struct EmbeddedSkill {
 const ENGINEER_MD: &str = include_str!("agents/engineer.md");
 const QA_AGENT_MD: &str = include_str!("agents/qa-agent.md");
 const CODE_REVIEWER_MD: &str = include_str!("agents/code-reviewer.md");
+const PM_MD: &str = include_str!("agents/pm.md");
 
-/// The 31-agent dispatchable default roster, embedded at compile time
-/// (Slice E3, #2958): tcode's original 3 defaults plus the 28
-/// coding-relevant tm roster agents. The 5 `BASE-*` extends templates in
-/// [`EMBEDDED_TM_AGENT_SOURCES`] are deliberately NOT entries here — they are
-/// extends-sources only, never dispatchable — and trusty-mpm's own
-/// `engineer` agent is excluded from the roster upstream (#2958's roster
-/// decision) precisely because it would collide with tcode's `engineer`
-/// below; `assets::tests::no_name_collisions_across_the_31_agent_roster`
-/// pins that no collision exists in the final table.
+/// The 32-agent dispatchable default roster, embedded at compile time
+/// (Slice E3, #2958, plus `pm` added for #3437): tcode's original 3
+/// defaults plus `pm` plus the 28 coding-relevant tm roster agents. The 5
+/// `BASE-*` extends templates in [`EMBEDDED_TM_AGENT_SOURCES`] are
+/// deliberately NOT entries here — they are extends-sources only, never
+/// dispatchable — and trusty-mpm's own `engineer` agent is excluded from the
+/// roster upstream (#2958's roster decision) precisely because it would
+/// collide with tcode's `engineer` below;
+/// `assets::tests::no_name_collisions_across_the_32_agent_roster` pins that
+/// no collision exists in the final table.
 ///
 /// Why: gives `agents::load_all_agents`'s embedded-fallback branch a fixed,
 /// ordered table to parse when the disk `.claude/agents/` directory is empty
-/// or absent.
+/// or absent. `pm` specifically fixes #3437: `task::protocol::task_run`
+/// defaults an omitted `agent_name` to the literal `"pm"`
+/// (`task/protocol.rs`), which resolved against NEITHER a disk
+/// `~/.claude/agents/pm.md` NOR this table before #3437 — so every
+/// daemon-default (including every GUI-initiated, agent-name-omitting) run
+/// failed agent resolution before a single turn executed.
 /// What: `engineer` (general implementation, full read/write tool set),
 /// `qa-agent` (verification — read/inspect/run only, no `write_file`/`edit`,
 /// hands bugs back to the engineer rather than fixing them), `code-reviewer`
-/// (adversarial, read-only review, no `bash`) — all three [`EmbeddedAgent::Direct`].
+/// (adversarial, read-only review, no `bash`), `pm` (orchestrator/default —
+/// delegates when `delegate_to_agent` is available, executes directly
+/// otherwise; see `assets/agents/pm.md`) — all four [`EmbeddedAgent::Direct`].
 /// Then the 28 [`EmbeddedAgent::Composed`] roster agents, alphabetical,
 /// matching [`EMBEDDED_TM_AGENT_SOURCES`]'s roster ordering. Four of them
 /// (`qa`, `code-critic`, `code-analyzer`, `web-qa`) carry a tcode-only
@@ -186,9 +195,11 @@ const CODE_REVIEWER_MD: &str = include_str!("agents/code-reviewer.md");
 /// "Tools-restriction deviation" doc section above.
 /// Test: `assets::tests::default_agents_parse_and_names_match`,
 /// `assets::tests::base_templates_are_never_dispatchable`,
-/// `assets::tests::no_name_collisions_across_the_31_agent_roster`,
+/// `assets::tests::no_name_collisions_across_the_32_agent_roster`,
 /// `assets::tests::restricted_reviewer_agents_carry_read_only_tools`,
-/// `assets::tests::documentation_and_research_remain_unrestricted`.
+/// `assets::tests::documentation_and_research_remain_unrestricted`,
+/// `assets::tests::default_task_run_agent_resolves_against_default_agents`,
+/// `assets::tests::every_embedded_agent_model_normalizes_to_a_valid_slug`.
 pub const DEFAULT_AGENTS: &[EmbeddedAgent] = &[
     EmbeddedAgent::Direct {
         name: "engineer",
@@ -201,6 +212,10 @@ pub const DEFAULT_AGENTS: &[EmbeddedAgent] = &[
     EmbeddedAgent::Direct {
         name: "code-reviewer",
         md: CODE_REVIEWER_MD,
+    },
+    EmbeddedAgent::Direct {
+        name: "pm",
+        md: PM_MD,
     },
     EmbeddedAgent::Composed { name: "api-qa" },
     EmbeddedAgent::Composed {

--- a/crates/trusty-code/src/assets/tests.rs
+++ b/crates/trusty-code/src/assets/tests.rs
@@ -20,13 +20,17 @@ use crate::agents::md_loader::{project_embedded_md, project_embedded_md_with_ext
 /// Why: A typo in either the `.md` frontmatter or the table entry would
 /// silently break `agents::load_all_agents`'s embedded-fallback at runtime
 /// instead of failing fast in CI. This is also the acceptance test for Slice
-/// E3 (#2958): every one of the 31 entries must actually compose (a `Composed`
+/// E3 (#2958): every one of the 32 entries must actually compose (a `Composed`
 /// variant that panics here rather than resolving would otherwise only be
 /// caught at runtime by `load_embedded_default_agents`'s log-and-skip path).
 /// Test: this test.
 #[test]
 fn default_agents_parse_and_names_match() {
-    assert_eq!(DEFAULT_AGENTS.len(), 31, "3 originals + 28 roster agents");
+    assert_eq!(
+        DEFAULT_AGENTS.len(),
+        32,
+        "4 originals (engineer, qa-agent, code-reviewer, pm) + 28 roster agents"
+    );
     for agent in DEFAULT_AGENTS {
         let cfg = match agent {
             EmbeddedAgent::Direct { name, md } => project_embedded_md(name, md),
@@ -138,32 +142,32 @@ fn default_agents_field_identical_to_retired_toml() {
 }
 
 /// The embedded fallback still fires when the disk `.claude/agents` dir is
-/// empty, and yields the full 31-agent roster with the original 3 defaults
-/// intact as the first three entries — proving Slice E3's roster expansion
-/// did not disturb the original fallback wiring `.md` (#2897 Slice C)
-/// established.
+/// empty, and yields the full 32-agent roster with the original 4 defaults
+/// intact as the first four entries — proving Slice E3's roster expansion
+/// (and #3437's `pm` addition) did not disturb the original fallback wiring
+/// `.md` (#2897 Slice C) established.
 ///
 /// Why: #2897 Slice C's non-breaking claim rests on this: a fresh project
 /// with no `.claude/agents/` must still boot with `engineer`/`qa-agent`/
-/// `code-reviewer` available, exactly as it did when the defaults were TOML
-/// — Slice E3 only ADDS the 28 roster agents after them, never replaces or
-/// reorders the original 3.
+/// `code-reviewer`/`pm` available, exactly as it did when the defaults were
+/// TOML — Slice E3 only ADDS the 28 roster agents after them, never replaces
+/// or reorders the originals.
 /// What: calls `crate::agents::load_all_agents` on a nonexistent directory;
-/// asserts the returned names' first three entries are exactly
-/// `["engineer", "qa-agent", "code-reviewer"]` and the full 31-name list
-/// matches `crate::assets::DEFAULT_AGENTS`'s declared order with no
+/// asserts the returned names' first four entries are exactly
+/// `["engineer", "qa-agent", "code-reviewer", "pm"]` and the full 32-name
+/// list matches `crate::assets::DEFAULT_AGENTS`'s declared order with no
 /// duplicates.
 /// Test: this test.
 #[test]
-fn embedded_fallback_still_fires_and_yields_31_agents_with_original_3_intact() {
+fn embedded_fallback_still_fires_and_yields_32_agents_with_original_4_intact() {
     let agents = crate::agents::load_all_agents(std::path::Path::new("/nonexistent/agents/dir"));
     let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
 
-    assert_eq!(names.len(), 31, "31-agent roster: 3 originals + 28 roster");
+    assert_eq!(names.len(), 32, "32-agent roster: 4 originals + 28 roster");
     assert_eq!(
-        &names[..3],
-        &["engineer", "qa-agent", "code-reviewer"],
-        "the original 3 defaults must remain first and intact"
+        &names[..4],
+        &["engineer", "qa-agent", "code-reviewer", "pm"],
+        "the original 4 defaults must remain first and intact"
     );
 
     let expected: Vec<&str> = DEFAULT_AGENTS.iter().map(|a| a.name()).collect();
@@ -186,7 +190,7 @@ fn embedded_fallback_still_fires_and_yields_31_agents_with_original_3_intact() {
 /// `BASE-*` entry leaking into the dispatchable roster would let a caller
 /// invoke a template fragment (no concrete role, designed to be composed
 /// into a leaf agent, not run standalone) as if it were a real agent.
-/// What: asserts none of the 31 `DEFAULT_AGENTS` names matches any of the 5
+/// What: asserts none of the 32 `DEFAULT_AGENTS` names matches any of the 5
 /// base template names (case-insensitive, since the source table keys them
 /// `BASE-QA.md` while `extends:` references use `base-qa`).
 /// Test: this test.
@@ -209,7 +213,7 @@ fn base_templates_are_never_dispatchable() {
     }
 }
 
-/// No two entries in the 31-agent `DEFAULT_AGENTS` roster share a dispatch
+/// No two entries in the 32-agent `DEFAULT_AGENTS` roster share a dispatch
 /// name — in particular, trusty-mpm's own `engineer` agent (excluded from
 /// the roster upstream specifically because it collides with tcode's
 /// `engineer` default) does not sneak back in under any composed entry.
@@ -219,13 +223,13 @@ fn base_templates_are_never_dispatchable() {
 /// default)" — this test is the regression pin for that exclusion, and a
 /// general guard against any future roster addition silently shadowing an
 /// existing dispatch name.
-/// What: collects all 31 names, dedupes, asserts the length is unchanged;
+/// What: collects all 32 names, dedupes, asserts the length is unchanged;
 /// separately asserts `"engineer"` appears exactly once.
 /// Test: this test.
 #[test]
-fn no_name_collisions_across_the_31_agent_roster() {
+fn no_name_collisions_across_the_32_agent_roster() {
     let names: Vec<&str> = DEFAULT_AGENTS.iter().map(|a| a.name()).collect();
-    assert_eq!(names.len(), 31);
+    assert_eq!(names.len(), 32);
 
     let mut deduped = names.clone();
     deduped.sort_unstable();
@@ -233,7 +237,7 @@ fn no_name_collisions_across_the_31_agent_roster() {
     assert_eq!(
         deduped.len(),
         names.len(),
-        "no name collisions across the 31-agent roster: {names:?}"
+        "no name collisions across the 32-agent roster: {names:?}"
     );
 
     assert_eq!(
@@ -344,6 +348,108 @@ fn every_composed_roster_name_resolves_in_embedded_tm_agent_sources() {
             );
         }
     }
+}
+
+/// `task::protocol::DEFAULT_TASK_RUN_AGENT_NAME` (the literal `task.run`
+/// falls back to when `agent_name` is omitted) resolves against the embedded
+/// roster via the SAME resolver the daemon uses (#3437's drift guard).
+///
+/// Why: #3437's root cause was exactly this pairing silently drifting apart —
+/// `task/protocol.rs` defaulted an omitted `agent_name` to `"pm"` while
+/// neither disk nor [`DEFAULT_AGENTS`] had a `pm` entry, so every
+/// daemon-default (including every GUI-initiated, agent-name-omitting) run
+/// failed agent resolution before a single turn executed. Referencing the
+/// shared [`crate::task::protocol::DEFAULT_TASK_RUN_AGENT_NAME`] const from
+/// both this test and the `task_run` call site (rather than two independent
+/// `"pm"` string literals, one here and one there) means a future rename of
+/// either side is a compile-time rename, not a silent divergence a test could
+/// miss.
+/// What: calls `crate::agents::resolve_agent` — the exact function
+/// `task::executor::run_and_record`'s `pm_config` resolution uses — with a
+/// nonexistent disk dir and `DEFAULT_TASK_RUN_AGENT_NAME`, and asserts it
+/// resolves `Ok` to an `AgentConfig` named `"pm"`.
+/// Test: this test.
+#[test]
+fn default_task_run_agent_resolves_against_default_agents() {
+    let cfg = crate::agents::resolve_agent(
+        std::path::Path::new("/nonexistent/agents/dir"),
+        crate::task::protocol::DEFAULT_TASK_RUN_AGENT_NAME,
+    )
+    .unwrap_or_else(|e| {
+        panic!(
+            "task.run's default agent_name '{}' must resolve against the embedded \
+             roster (disk-then-embedded, `agents::resolve_agent`) — it did not: {e}",
+            crate::task::protocol::DEFAULT_TASK_RUN_AGENT_NAME
+        )
+    });
+    assert_eq!(cfg.agent.name, "pm");
+}
+
+/// Every embedded default agent's resolved model slug (`agent.model`, when
+/// set) is either a real concrete provider slug already, or one of the three
+/// short Claude aliases (`opus`/`sonnet`/`haiku`) that
+/// `provider::routing::resolve_model` now normalizes to a concrete slug
+/// (#3438) — never a bare alias that would reach a provider unnormalized.
+///
+/// Why: #3438 traced `"API error 400: \"opus is not a valid model ID\""` to a
+/// roster agent's bare `model: sonnet`/`opus`/`haiku` frontmatter value (the
+/// `claude` CLI's own shorthand, composed for some roster agents from
+/// `resource_tier` via `trusty_agents_common::agents::builder::tier_to_model`)
+/// reaching `llm::client::OpenAiCompatClient`'s wire request unnormalized.
+/// The runtime fix (`provider::routing::normalize_model_alias`, applied
+/// inside `resolve_model`) makes every CALL SITE safe; this test is the
+/// static acceptance check that every embedded agent's declared model is
+/// something that fix actually knows how to handle — an agent with a model
+/// string that ISN'T one of the three known aliases and doesn't look like a
+/// real `vendor/model` slug would silently mean `normalize_model_alias`
+/// leaves an invalid string untouched.
+/// What: composes every [`DEFAULT_AGENTS`] entry (same dual-path projection
+/// as `default_agents_parse_and_names_match`), and for every agent whose
+/// `agent.model` is `Some`, asserts the value is one of the three known
+/// aliases OR contains a `/` (the `vendor/model` shape every real slug in
+/// this codebase uses — `anthropic/claude-sonnet-4-5`, `openai/gpt-4o-mini`,
+/// `bedrock/us.anthropic.claude-sonnet-4-6`, etc.). Also asserts the new
+/// `pm` agent specifically resolves through
+/// `provider::routing::resolve_model` to a valid concrete slug (not a bare
+/// alias) end-to-end, closing the loop #3438 asked for on the agent #3437
+/// adds.
+/// Test: this test.
+#[test]
+fn every_embedded_agent_model_normalizes_to_a_valid_slug() {
+    const KNOWN_ALIASES: &[&str] = &["opus", "sonnet", "haiku"];
+
+    for agent in DEFAULT_AGENTS {
+        let cfg = match agent {
+            EmbeddedAgent::Direct { name, md } => project_embedded_md(name, md),
+            EmbeddedAgent::Composed { name } => project_embedded_md_with_extends(name)
+                .unwrap_or_else(|e| panic!("roster agent '{name}' failed to compose: {e}")),
+        };
+        if let Some(model) = cfg.agent.model.as_deref() {
+            let is_known_alias = KNOWN_ALIASES.contains(&model.to_ascii_lowercase().as_str());
+            let looks_like_a_real_slug = model.contains('/');
+            assert!(
+                is_known_alias || looks_like_a_real_slug,
+                "embedded agent '{}' has model '{model}', which is neither a known \
+                 short alias ({KNOWN_ALIASES:?}) normalize_model_alias maps, nor a \
+                 vendor/model-shaped slug — it would reach a provider unnormalized",
+                agent.name()
+            );
+        }
+    }
+
+    // The new `pm` agent (#3437) specifically: its declared `model: sonnet`
+    // must resolve, end-to-end through `resolve_model`, to a concrete slug —
+    // not the bare alias — closing #3438 for the exact agent #3437 adds.
+    let pm_cfg = project_embedded_md("pm", PM_MD);
+    let resolved = crate::provider::resolve_model(&pm_cfg, None);
+    assert!(
+        resolved.contains('/'),
+        "pm agent's model must resolve to a concrete vendor/model slug, got '{resolved}'"
+    );
+    assert_ne!(
+        resolved, "sonnet",
+        "pm's model must not resolve to the bare alias"
+    );
 }
 
 /// Every embedded skill name is unique and non-empty.

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -153,15 +153,16 @@ pub mod rbac;
 pub mod llm;
 
 /// Embedded default agents & skills (#2895; roster expanded to 31 agents in
-/// Slice E3, #2958).
+/// Slice E3, #2958; `pm` added as a 4th tcode-own default for #3437).
 ///
 /// Why: A fresh project has no `.claude/agents/` or `.claude/skills/` yet;
 /// bundling a working default set at compile time (mirroring, not sharing,
 /// `trusty-mpm`'s embed pattern) gives every project a usable harness before
 /// any project-level config exists. Disk-based config always wins when present.
-/// What: `EmbeddedAgent`/`DEFAULT_AGENTS` (31 dispatchable tcode agents: the
-/// original 3, authored as Markdown+frontmatter as of #2897 Slice C, plus 28
-/// coding-relevant tm agents bundled and wired in as of Slice E, #2958);
+/// What: `EmbeddedAgent`/`DEFAULT_AGENTS` (32 dispatchable tcode agents: the
+/// original 4 (`engineer`/`qa-agent`/`code-reviewer`/`pm`), authored as
+/// Markdown+frontmatter as of #2897 Slice C, plus 28 coding-relevant tm
+/// agents bundled and wired in as of Slice E, #2958);
 /// `EmbeddedSkill`/`DEFAULT_SKILLS` (trusty-mpm's universal skill set, minus
 /// the `tm-*` orchestration skills).
 /// Test: `assets::tests::*`.

--- a/crates/trusty-code/src/provider/routing.rs
+++ b/crates/trusty-code/src/provider/routing.rs
@@ -93,6 +93,39 @@ pub fn resolve_deadline_secs(cli_override: Option<u64>) -> u64 {
     DEFAULT_RUN_DEADLINE_SECS
 }
 
+/// Short Claude model aliases (`opus`/`sonnet`/`haiku`) mapped to a concrete,
+/// provider-valid OpenRouter slug (#3438).
+///
+/// Why: these three bare words are the `claude` CLI's own `--model` shorthand
+/// (see `trusty_agents_common::agents::builder::tier_to_model`, which composes
+/// them from an agent's `resource_tier`, and every embedded roster agent's
+/// `.md` frontmatter — e.g. `assets/agents/python-engineer.md`'s
+/// `model: sonnet`) — valid input for the `claude` subprocess trusty-agents
+/// spawns, but NOT a real OpenRouter/Anthropic-API model id. trusty-code talks
+/// to providers directly (`llm::client::OpenAiCompatClient`), so a bare alias
+/// reaching the wire produces `API error 400: "opus is not a valid model ID"`
+/// verbatim — the exact failure #3438 traced. [`resolve_model`] is the single
+/// funnel every call site resolves its final slug through
+/// (`runner::in_process::InProcessAgentRunner::run_pipeline`,
+/// `task::executor`, `run_task::execute_run_task`), so normalising here fixes
+/// every path at once rather than patching each `.md` file or call site
+/// individually.
+/// What: Case-insensitive exact match on the trimmed slug; anything else
+/// (an already-concrete slug, a routed `bedrock/`/`fireworks/`/etc. prefix, an
+/// unrecognised alias) passes through unchanged — [`resolve_model`] never
+/// errors on an unmapped model, it just doesn't rewrite it.
+/// Test: `routing::tests::normalize_model_alias_maps_short_aliases`,
+/// `routing::tests::normalize_model_alias_passes_through_concrete_slugs`,
+/// `assets::tests::every_embedded_agent_model_normalizes_to_a_valid_slug`.
+fn normalize_model_alias(model: &str) -> &str {
+    match model.trim().to_ascii_lowercase().as_str() {
+        "opus" => "anthropic/claude-opus-4.5",
+        "sonnet" => "anthropic/claude-sonnet-4.5",
+        "haiku" => "anthropic/claude-haiku-4.5",
+        _ => model,
+    }
+}
+
 /// Resolve the model slug for an invocation.
 ///
 /// Why: Centralises the precedence so per-call overrides, per-agent config, and
@@ -101,24 +134,28 @@ pub fn resolve_deadline_secs(cli_override: Option<u64>) -> u64 {
 /// (1) `run_context.model` (per-call override),
 /// (2) `agent_config.agent.model`,
 /// (3) `agent_config.llm.model_override`,
-/// else (4) [`DEFAULT_MODEL`].
-/// Test: `routing::tests::resolve_model_*` cover every tier.
+/// else (4) [`DEFAULT_MODEL`] — each candidate passed through
+/// [`normalize_model_alias`] (#3438) so a bare `opus`/`sonnet`/`haiku` alias
+/// never reaches a provider as-is.
+/// Test: `routing::tests::resolve_model_*` cover every tier;
+/// `routing::tests::resolve_model_normalizes_short_alias_from_agent_config`
+/// and `resolve_model_normalizes_short_alias_from_run_context` cover #3438.
 pub fn resolve_model(agent_config: &AgentConfig, run_context: Option<&RunContext>) -> String {
     // 1. Per-call override wins.
     if let Some(ctx) = run_context
         && let Some(model) = non_empty(ctx.model.as_deref())
     {
-        return model.to_string();
+        return normalize_model_alias(model).to_string();
     }
 
     // 2. Agent-level model.
     if let Some(model) = non_empty(agent_config.agent.model.as_deref()) {
-        return model.to_string();
+        return normalize_model_alias(model).to_string();
     }
 
     // 3. `[llm].model_override` (lower precedence than `[agent].model`).
     if let Some(model) = non_empty(agent_config.llm.model_override.as_deref()) {
-        return model.to_string();
+        return normalize_model_alias(model).to_string();
     }
 
     // 4. Built-in default.
@@ -290,6 +327,94 @@ mod tests {
     fn resolve_model_falls_back_to_default() {
         let config = cfg(None, None);
         assert_eq!(resolve_model(&config, None), DEFAULT_MODEL);
+    }
+
+    // ── #3438: short-alias normalization ────────────────────────────────────
+
+    /// `normalize_model_alias` maps all three short Claude aliases to a
+    /// concrete OpenRouter slug, case-insensitively and trimmed.
+    ///
+    /// Why: `opus`/`sonnet`/`haiku` are the `claude` CLI's own shorthand
+    /// (`trusty_agents_common::agents::builder::tier_to_model`'s output and
+    /// every composed roster agent's `.md` `model:` field), not valid
+    /// OpenRouter/API model ids — this is the exact substitution that fixes
+    /// the `"opus is not a valid model ID"` 400 (#3438).
+    /// What: Each of the three aliases, plus an uppercase/padded variant,
+    /// resolves to its mapped concrete slug.
+    /// Test: this test.
+    #[test]
+    fn normalize_model_alias_maps_short_aliases() {
+        assert_eq!(normalize_model_alias("opus"), "anthropic/claude-opus-4.5");
+        assert_eq!(
+            normalize_model_alias("sonnet"),
+            "anthropic/claude-sonnet-4.5"
+        );
+        assert_eq!(normalize_model_alias("haiku"), "anthropic/claude-haiku-4.5");
+        assert_eq!(
+            normalize_model_alias("  Opus  "),
+            "anthropic/claude-opus-4.5",
+            "must be case-insensitive and trim surrounding whitespace"
+        );
+    }
+
+    /// An already-concrete slug (or any string that isn't one of the three
+    /// bare aliases) passes through [`normalize_model_alias`] unchanged.
+    ///
+    /// Why: The normalizer must not mangle a valid `vendor/model` slug, a
+    /// routed `bedrock/`/`fireworks/`/`together/`/`atlascloud/` prefix, or an
+    /// unrecognised model string — it only rewrites the three known aliases.
+    /// What: A realistic OpenRouter slug and an arbitrary unknown string both
+    /// round-trip unchanged.
+    /// Test: this test.
+    #[test]
+    fn normalize_model_alias_passes_through_concrete_slugs() {
+        assert_eq!(
+            normalize_model_alias("anthropic/claude-sonnet-4-5"),
+            "anthropic/claude-sonnet-4-5"
+        );
+        assert_eq!(
+            normalize_model_alias("bedrock/us.anthropic.claude-opus-4-6"),
+            "bedrock/us.anthropic.claude-opus-4-6"
+        );
+        assert_eq!(
+            normalize_model_alias("some-vendor/unheard-of-model"),
+            "some-vendor/unheard-of-model"
+        );
+    }
+
+    /// [`resolve_model`] normalizes a bare alias sourced from `[agent].model`
+    /// (the tier-composed or `.md`-frontmatter case #3438 actually hit).
+    ///
+    /// Why: Regression guard at the public `resolve_model` seam, not just the
+    /// private helper — this is what every real call site invokes.
+    /// What: `agent.model = "opus"` resolves to the concrete slug, not the
+    /// bare alias.
+    /// Test: this test.
+    #[test]
+    fn resolve_model_normalizes_short_alias_from_agent_config() {
+        let config = cfg(Some("opus"), None);
+        assert_eq!(resolve_model(&config, None), "anthropic/claude-opus-4.5");
+    }
+
+    /// [`resolve_model`] normalizes a bare alias sourced from a per-call
+    /// `RunContext.model` override too.
+    ///
+    /// Why: The highest-precedence tier must not bypass normalization — a
+    /// caller pinning `RunContext.model = "sonnet"` must still reach the
+    /// provider with a valid concrete id.
+    /// What: `RunContext.model = "sonnet"` resolves to the concrete slug.
+    /// Test: this test.
+    #[test]
+    fn resolve_model_normalizes_short_alias_from_run_context() {
+        let config = cfg(Some("anthropic/claude-haiku-4-5"), None);
+        let ctx = RunContext {
+            model: Some("sonnet".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_model(&config, Some(&ctx)),
+            "anthropic/claude-sonnet-4.5"
+        );
     }
 
     /// Empty / whitespace strings are treated as absent at each tier.

--- a/crates/trusty-code/src/run_task/mod.rs
+++ b/crates/trusty-code/src/run_task/mod.rs
@@ -714,7 +714,7 @@ fn drain_transcript(transcript: &SharedTranscript) -> Vec<TurnRecord> {
 /// What: Returns a `RunReport` with an empty diff, the (likely empty) transcript,
 /// zero usage, and `ExitCode::ConfigError`; the error text rides in the task line
 /// of the human form via a synthesized note.
-/// Test: `run_task::tests::missing_pm_config_is_config_error`.
+/// Test: `run_task::tests::missing_agent_config_is_config_error`.
 fn config_error_report(
     params: &RunTaskParams,
     transcript: &SharedTranscript,

--- a/crates/trusty-code/src/run_task/tests.rs
+++ b/crates/trusty-code/src/run_task/tests.rs
@@ -501,17 +501,65 @@ async fn no_changes_yields_no_changes_exit() {
     assert!(report.diff.trim().is_empty(), "diff must be empty");
 }
 
-/// A missing PM config is a configuration error (no panic, distinct exit code).
+/// An agent name with NEITHER a disk config NOR an embedded default is a
+/// configuration error (no panic, distinct exit code).
 ///
 /// Why: Bad configuration must produce a faithful `ConfigError`, not a crash.
-/// What: Point the params at an agents dir with no `pm.md`; assert
-/// exit=ConfigError.
+/// This is the regression pin `missing_pm_config_is_config_error` used to
+/// cover with `agent: "pm"` before #3437 added an embedded `pm` default —
+/// `"pm"` now ALWAYS resolves (see
+/// `missing_disk_pm_config_falls_back_to_embedded_pm` below), so the
+/// still-valid "unresolvable agent is a config error" case is exercised here
+/// with an agent name that is genuinely absent from both disk and
+/// [`crate::assets::DEFAULT_AGENTS`].
+/// What: Point the params at an empty agents dir with agent name
+/// `"totally-not-a-real-agent"`; assert exit=ConfigError.
 /// Test: this test.
 #[tokio::test]
-async fn missing_pm_config_is_config_error() {
+async fn missing_agent_config_is_config_error() {
     let empty_agents = tempfile::tempdir().expect("agents tempdir");
     let project = tempfile::tempdir().expect("project tempdir");
     let llm = Arc::new(ScriptedLlm::from_json(&[stop_response("unused")]));
+
+    let report = execute_run_task(
+        RunTaskParams {
+            agent: "totally-not-a-real-agent".into(),
+            task: "anything".into(),
+            project: project.path().to_path_buf(),
+            agents_dir: empty_agents.path().to_path_buf(),
+            engineer_model: None,
+            deadline_secs: None,
+        },
+        llm,
+    )
+    .await;
+
+    assert_eq!(
+        report.exit,
+        ExitCode::ConfigError,
+        "an agent name absent from both disk and the embedded roster must be a config error"
+    );
+}
+
+/// `agent: "pm"` with NO disk `pm.md` now resolves via the embedded default
+/// (#3437) instead of failing agent resolution.
+///
+/// Why: this is the acceptance test for #3437 at the `run_task` level — the
+/// exact call shape (`agent: "pm"`, empty `agents_dir`) that used to hit
+/// `ConfigError` before the embedded `pm` agent existed must now actually
+/// run the PM loop and reach a normal exit code.
+/// What: Same empty-agents-dir shape as `missing_agent_config_is_config_error`,
+/// but `agent: "pm"` with a scripted `[PM stop]` response; asserts the run
+/// reaches `ExitCode::NoChanges` (the PM concluded without delegating), not
+/// `ConfigError`.
+/// Test: this test.
+#[tokio::test]
+async fn missing_disk_pm_config_falls_back_to_embedded_pm() {
+    let empty_agents = tempfile::tempdir().expect("agents tempdir");
+    let project = tempfile::tempdir().expect("project tempdir");
+    let llm = Arc::new(ScriptedLlm::from_json(&[stop_response(
+        "pm: nothing to do",
+    )]));
 
     let report = execute_run_task(
         RunTaskParams {
@@ -528,8 +576,9 @@ async fn missing_pm_config_is_config_error() {
 
     assert_eq!(
         report.exit,
-        ExitCode::ConfigError,
-        "missing pm.md must be a config error"
+        ExitCode::NoChanges,
+        "'pm' with no disk config must resolve via the embedded default (#3437) and run, \
+         not fail with ConfigError; report: {report:?}"
     );
 }
 

--- a/crates/trusty-code/src/task/protocol.rs
+++ b/crates/trusty-code/src/task/protocol.rs
@@ -37,6 +37,27 @@ use crate::workstreams::SharedWorkstreamStore;
 use super::executor::{TaskRunParams, spawn_task_run};
 use super::mock_llm::build_llm_client;
 
+/// Default top-level/PM agent name used when `task.run`'s `agent_name` param
+/// is omitted (#3437).
+///
+/// Why: #3437 — every GUI-initiated run omits `agent_name` (no agent-roster
+/// endpoint exists yet for the GUI to pick from), so [`task_run`]'s default
+/// MUST resolve against a real agent in every resolution tier (disk then
+/// embedded, see `agents::resolve_agent`) or 100% of daemon-default runs fail
+/// agent resolution before a single turn executes — exactly the failure mode
+/// #3437 traced. A shared `pub` const (referenced from both this call site
+/// and `assets::tests::default_task_run_agent_resolves_against_default_agents`)
+/// is the drift-guard: the literal here and the embedded roster entry it must
+/// resolve against can never independently rot out of sync the way two
+/// separately-typed `"pm"` string literals could.
+/// What: `"pm"` — must have a matching `EmbeddedAgent` entry in
+/// [`crate::assets::DEFAULT_AGENTS`] (see `assets/agents/pm.md`).
+/// Test: `task::protocol::tests::task_run_creates_session_when_none_given`
+/// (exercises the default through a real `task_run` call);
+/// `assets::tests::default_task_run_agent_resolves_against_default_agents`
+/// (pins that the literal resolves against the embedded roster).
+pub const DEFAULT_TASK_RUN_AGENT_NAME: &str = "pm";
+
 /// Register `task.run` onto `router`.
 ///
 /// Why: the one place that wires the method, mirroring
@@ -224,7 +245,9 @@ async fn task_run(
             .map_err(|e| RpcError::invalid_argument(format!("task.run: {e}")))?,
         None => binding,
     };
-    let agent_name = p.agent_name.unwrap_or_else(|| "pm".to_string());
+    let agent_name = p
+        .agent_name
+        .unwrap_or_else(|| DEFAULT_TASK_RUN_AGENT_NAME.to_string());
 
     let session_id = match &p.session_id {
         Some(id) => {

--- a/scripts/check_agent_assets.sh
+++ b/scripts/check_agent_assets.sh
@@ -34,11 +34,12 @@
 #      FAIL so a human reconciles the tcode copy on purpose (re-apply the
 #      tools: restriction / read-only prose rewrite against the new upstream
 #      content) rather than the deviation silently going stale.
-#   Three tcode-only files (engineer.md, qa-agent.md, code-reviewer.md — tcode's
-#   pre-existing defaults, never sourced from trusty-mpm; tcode's own
+#   Four tcode-only files (engineer.md, qa-agent.md, code-reviewer.md, pm.md —
+#   tcode's own defaults, never sourced from trusty-mpm; tcode's own
 #   `engineer.md` deliberately does NOT track trusty-mpm's `engineer.md`,
 #   which is excluded from the roster specifically to avoid the name
-#   collision) are skipped entirely.
+#   collision; `pm.md` was added for #3437 as tcode's own orchestrator
+#   default and has no trusty-mpm counterpart to track) are skipped entirely.
 #   Any other tcode `.md` file not in the parity set, the deviated set, or the
 #   tcode-only exclude list is flagged as "new roster file unaccounted" — add
 #   it to TCODE_ONLY (if genuinely tcode's own) or verify its trusty-mpm
@@ -89,8 +90,8 @@ TCODE_DIR="crates/trusty-code/src/assets/agents"
 MPM_DIR="crates/trusty-mpm/src/assets/agents"
 PINS="scripts/agent-asset-pins.tsv"
 
-# tcode's own pre-existing defaults — never sourced from trusty-mpm.
-TCODE_ONLY="engineer.md qa-agent.md code-reviewer.md"
+# tcode's own defaults — never sourced from trusty-mpm.
+TCODE_ONLY="engineer.md qa-agent.md code-reviewer.md pm.md"
 
 # The 4 files with a Bob-approved deliberate deviation from byte-parity
 # (Slice E3, PR #3041). Pinned by trusty-mpm SOURCE hash, not byte-compared.


### PR DESCRIPTION
## Root cause recap

**#3437 — missing `pm` agent.** `task/protocol.rs`'s `task_run` defaults an
omitted `agent_name` to the literal `"pm"` (the GUI's "daemon default" option
deliberately omits `agent_name` — no agent-roster endpoint exists yet — so
this is the path EVERY GUI-initiated run takes). Neither
`assets::DEFAULT_AGENTS` (the 31-entry embedded roster) nor
`~/.claude/agents/pm.md` (disk) carried a `pm` agent, so `agents::resolve_agent`
failed in every tier — 100% of daemon-default runs failed before a single
turn executed.

**#3438 — `"opus is not a valid model ID"`.** Confirmed live against
OpenRouter (`curl .../chat/completions -d '{"model":"opus",...}'` →
`{"error":{"message":"opus is not a valid model ID"...}}`). Traced to
`provider::routing::resolve_model`: several embedded roster agents' `.md`
frontmatter sets `model: sonnet`/`opus`/`haiku` — the bare short aliases the
`claude` CLI understands (and that `trusty_agents_common::agents::builder::
tier_to_model` also produces from an agent's `resource_tier`) — but
`trusty-code` talks to providers directly
(`llm::client::OpenAiCompatClient`), which forwards the slug to OpenRouter
verbatim with no alias translation.

## Fix approach

**#3437:** Added `crates/trusty-code/src/assets/agents/pm.md` — a
self-contained (`EmbeddedAgent::Direct`, no `extends:` chain) 4th tcode-own
default alongside `engineer`/`qa-agent`/`code-reviewer`, wired into
`DEFAULT_AGENTS` (now 32 entries). Drift guard: `task/protocol.rs` now
exposes `pub const DEFAULT_TASK_RUN_AGENT_NAME: &str = "pm"` and both the
`task_run` default and a new test
(`assets::tests::default_task_run_agent_resolves_against_default_agents`)
reference the SAME const, so the literal and the roster entry it must resolve
against can never independently drift apart the way two separate `"pm"`
string literals could. `scripts/check_agent_assets.sh`'s `TCODE_ONLY`
allowlist was updated (`pm.md` has no trusty-mpm counterpart to track).

**pm persona rationale:** modeled directly on the codebase's own `"pm"`
conventions (`identity/mod.rs`'s `CallerIdentity::Pm`, the `role == "pm"`
turn-recorder label throughout `task::executor`/`run_task`) — the top-level
daemon loop that owns `delegate_to_agent`/`finish_task`/`set_goal`/
`clear_goal`. Body mirrors `engineer.md`'s tone/length/rule-list structure:
plans the task, delegates via `delegate_to_agent` when it's available (the
persistent daemon-session path), does the work directly with the same
standards otherwise (dispatch/CLI paths where no delegation tool is
injected) — "the general default for chat/planning AND task dispatch" per
the issue's fix direction. `model: sonnet` (matches 25/28 roster agents;
now safely normalized, see below), full read/write/bash tool access (same
allowlist as `engineer`, since a bare dispatch/CLI invocation of `pm` gets no
injected `delegate_to_agent` and must be able to do real work).

**#3438:** Added `provider::routing::normalize_model_alias` — maps
`opus`/`sonnet`/`haiku` (case-insensitive, trimmed) to a concrete,
live-verified-working OpenRouter slug (`anthropic/claude-{opus,sonnet,haiku}-4.5`).
Applied inside `resolve_model` at all three overridable tiers (`RunContext`
override, `[agent].model`, `[llm].model_override`) so every call site
(`runner::in_process`, `task::executor`, `run_task::execute_run_task`) is
fixed at the one place they all already funnel through — no per-call-site
patching, no `.md` file edits needed. Checked for a reusable alias map in
`trusty-agents`/`trusty-agents-common` first (per the issue's steer): the
only existing mapping goes the OPPOSITE direction (`ClaudeCodeAgentRunner::
normalize_model` strips `anthropic/` so the `claude` CLI subprocess sees a
name it understands) — not reusable here, since `trusty-code` talks to
providers directly rather than spawning `claude`. New
`assets::tests::every_embedded_agent_model_normalizes_to_a_valid_slug`
statically asserts every embedded agent's `model:` is either a known alias
or already `vendor/model`-shaped, plus resolves `pm`'s own model end-to-end
to prove it never reaches a provider as a bare alias.

## E2E acceptance (real LLM call, real daemon)

Built `tcode` from this branch, started `tcode serve --http --port 7899`
projectless, called `POST /tasks` with **no `agent_name`**:

```
$ curl -s -X POST http://127.0.0.1:7899/tasks \
    -H "Content-Type: application/json" \
    -d '{"task_description":"say hi in one short sentence","deadline_secs":60}'
{"binding":{"root":null,"state":"projectless"},"mode":"daily-driver","session_id":"47a4b9cd-50ac-4d64-80e3-8f6f8d45e46f","status":"running"}

$ curl -s -X POST http://127.0.0.1:7899/rpc -d '{"jsonrpc":"2.0","id":1,"method":"session.status","params":{"session_id":"47a4b9cd-50ac-4d64-80e3-8f6f8d45e46f"}}'
{"jsonrpc":"2.0","id":1,"result":{"agent":"pm","status":"finished", ...}}

$ curl -s -X POST http://127.0.0.1:7899/rpc -d '{"jsonrpc":"2.0","id":2,"method":"session.get_transcript","params":{"session_id":"47a4b9cd-50ac-4d64-80e3-8f6f8d45e46f"}}'
{
  "result": {
    "turns": [
      {
        "model": "anthropic/claude-sonnet-4.5",
        "role": "pm",
        "text": "Hi! I'm ready to help you with your coding tasks and project management needs.",
        "usage": {"completion_tokens": 20, "prompt_tokens": 4569, "cost_usd": 0.0174315}
      }
    ]
  }
}
```

Session reached `status: "finished"` with the default (omitted) `agent_name`
resolving to `pm`, 1 real turn recorded, model resolved to the concrete
`anthropic/claude-sonnet-4.5` slug (not the bare `sonnet` alias) — proving
both fixes together, live against OpenRouter. Test daemon killed afterward
(`daemon down, confirmed killed`).

## Gate results (raw)

`cargo fmt --check` — clean, no output.

`cargo clippy -p trusty-code --all-targets -- -D warnings` — clean, `Finished` with 0 warnings.

`cargo test -p trusty-code` (no `--lib`, full binary set — unit + all 8 integration test binaries):
```
test result: ok. 1385 passed; 0 failed; 4 ignored; ... (lib)
test result: ok. 5 passed; 0 failed; ...
test result: ok. 3 passed; 0 failed; ...
test result: ok. 1 passed; 0 failed; ...
test result: ok. 2 passed; 0 failed; ...
test result: ok. 14 passed; 0 failed; ...
test result: ok. 2 passed; 0 failed; ...
test result: ok. 7 passed; 0 failed; ...
test result: ok. 4 passed; 0 failed; ...
test result: ok. 4 passed; 0 failed; ...
test result: ok. 2 passed; 0 failed; ...
test result: ok. 1 passed; 0 failed; ...
test result: ok. 1 passed; 0 failed; ...
test result: ok. 2 passed; 0 failed; ...
test result: ok. 6 passed; 0 failed; ...
```
Every binary green, 0 failures. **Known flake noted:** `run_task::tests::
no_changes_yields_no_changes_exit` and `run_task::tests::
exit_code_reflects_run_failure` intermittently fail ONLY under high test
parallelism (both pre-existing, reproduced identically against unpatched
`origin/main`, unrelated to agent-resolution/model-normalization) — a
background indexing thread races a scripted-LLM exit-code assertion in that
module and occasionally leaks a `.trusty-search/index.redb` file into a
tempdir-based diff capture. Both pass reliably in isolation and with
`--test-threads=1`; not touched by this change.

`bash scripts/check_line_cap.sh` — `line-cap: 7 allowlisted, 0 violations — OK.`
`bash scripts/check_test_pointers.sh` — `test-pointers: 0 dangling pointers — OK.`
`bash scripts/check_sld.sh` — `sld-lint: scanned 39 spec doc(s) + 2629 code file(s); 0 error(s), 0 warning(s)`
`bash scripts/check_agent_assets.sh` — `agent-assets: 29 byte-parity file(s) match, 4 pinned deviation(s) match upstream — OK.`

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)