### PR TITLE
fix(trusty-tui): make new_active_id optional so deactivation is representable

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -45,6 +45,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   surfaces a `StatusMessage` (the shared `ReplEvent::WorkstreamActivationChanged`
   declares `new_active_id` as a non-optional `String`, so it cannot carry
   this state without a `trusty-tui` change).
+- **The `StatusMessage` fallback above is now a structured event (closes #3452, part of epic #3411).** `trusty-tui`'s `ReplEvent::WorkstreamActivationChanged.new_active_id` is now `Option<String>`, matching the wire shape exactly; `workstream_subscription.rs`'s deactivation arm now emits `ReplEvent::WorkstreamActivationChanged { new_active_id: None, prior_id: Some(..) }` instead of free text, so a UI can structurally clear its "active workstream" indicator.
 
 ### Added
 

--- a/crates/trusty-code/src/tui_client/workstream_subscription.rs
+++ b/crates/trusty-code/src/tui_client/workstream_subscription.rs
@@ -102,7 +102,7 @@ pub(super) async fn run_workstream_subscription(
                         match new_active_id {
                             Some(new_id) => {
                                 let _ = tx.send(ReplEvent::WorkstreamActivationChanged {
-                                    new_active_id: new_id.clone(),
+                                    new_active_id: Some(new_id.clone()),
                                     prior_id,
                                 });
                                 if new_id != current_id {
@@ -112,14 +112,11 @@ pub(super) async fn run_workstream_subscription(
                             }
                             None => {
                                 // Deactivated, no replacement active. The
-                                // SHARED `ReplEvent::WorkstreamActivationChanged`
-                                // (`trusty_tui::event`) declares `new_active_id`
-                                // as a non-optional `String` — this state
-                                // genuinely cannot be carried by that variant
-                                // without a breaking change to `trusty-tui`
-                                // (out of this crate's ownership), so a
-                                // `StatusMessage` is the honest signal
-                                // available today; the cache refresh above
+                                // shared `ReplEvent::WorkstreamActivationChanged`
+                                // (`trusty_tui::event`) now carries
+                                // `new_active_id: Option<String>`, so this
+                                // state is representable structurally rather
+                                // than as free text. The cache refresh above
                                 // is what actually clears the stale
                                 // indicator (`active_workstream` -> `None`,
                                 // the `"workstream"` picker's active marker
@@ -130,9 +127,10 @@ pub(super) async fn run_workstream_subscription(
                                 // `classify()` still forwards a LATER
                                 // activation naming `current_id` as its
                                 // `prior_id` to this same connection.
-                                let _ = tx.send(ReplEvent::StatusMessage(format!(
-                                    "workstream {current_id} deactivated — no workstream is now active"
-                                )));
+                                let _ = tx.send(ReplEvent::WorkstreamActivationChanged {
+                                    new_active_id: None,
+                                    prior_id,
+                                });
                             }
                         }
                     }

--- a/crates/trusty-code/tests/tui_client_engine.rs
+++ b/crates/trusty-code/tests/tui_client_engine.rs
@@ -376,7 +376,7 @@ async fn subscribe_workstream_events_emits_activation_changed_with_wire_field_na
             new_active_id,
             prior_id,
         } => {
-            assert_eq!(new_active_id, WS_2);
+            assert_eq!(new_active_id.as_deref(), Some(WS_2));
             assert_eq!(prior_id.as_deref(), Some(WS_1));
         }
         other => panic!("unexpected {other:?}"),
@@ -389,16 +389,17 @@ async fn subscribe_workstream_events_emits_activation_changed_with_wire_field_na
 /// `WorkstreamActivationChanged` event with `new_active_id: null` (this
 /// workstream deactivated with no replacement active — a state the daemon
 /// legitimately publishes, DOC-48 §4.2/§4.3) must NOT be silently dropped.
-/// Before the fix, `run_workstream_subscription` only matched
+/// Before the original fix, `run_workstream_subscription` only matched
 /// `new_active_id: Some(..)`, so the whole event fell through the `if let`
 /// unhandled: no `ReplEvent` was sent and `refresh_workstream_cache` never
 /// ran, leaving the TUI's status line and the `"workstream"` picker cache
 /// stale indefinitely. This asserts BOTH halves of the fix: the cache
 /// actually refreshes (a second `workstream.list` call beyond `setup()`'s
-/// own), and the engine surfaces a user-visible signal (a `StatusMessage`
-/// naming the deactivation — `trusty-tui`'s `ReplEvent::WorkstreamActivationChanged`
-/// declares `new_active_id` as a non-optional `String`, so it structurally
-/// cannot carry this state; see `workstream_subscription.rs`'s docs).
+/// own), and the engine surfaces a structured signal — now that
+/// `trusty-tui`'s `ReplEvent::WorkstreamActivationChanged` carries
+/// `new_active_id: Option<String>`, deactivation-with-no-replacement is
+/// `WorkstreamActivationChanged { new_active_id: None, prior_id: Some(..) }`
+/// rather than a free-text `StatusMessage` fallback.
 #[tokio::test]
 async fn subscribe_workstream_events_refreshes_cache_on_deactivation_with_no_replacement() {
     let server = MockServer::start().await;
@@ -441,22 +442,27 @@ async fn subscribe_workstream_events_refreshes_cache_on_deactivation_with_no_rep
     .await
     .expect("timed out waiting for refresh_workstream_cache to re-call workstream.list");
 
-    // Half 2 of the fix: the engine must not go silent — some ReplEvent
-    // must report the deactivation.
-    let saw_deactivation_status = tokio::time::timeout(Duration::from_secs(5), async {
+    // Half 2 of the fix: the engine must not go silent — a structured
+    // `WorkstreamActivationChanged { new_active_id: None, .. }` must report
+    // the deactivation.
+    let saw_deactivation_event = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             match rx.recv().await {
-                Some(ReplEvent::StatusMessage(msg)) if msg.contains("deactivated") => return true,
+                Some(ReplEvent::WorkstreamActivationChanged {
+                    new_active_id: None,
+                    prior_id,
+                }) => return prior_id,
                 Some(_) => continue,
-                None => return false,
+                None => panic!("channel closed before observing the deactivation event"),
             }
         }
     })
     .await
-    .expect("timed out waiting for a deactivation status message");
-    assert!(
-        saw_deactivation_status,
-        "expected a StatusMessage naming the deactivation"
+    .expect("timed out waiting for the deactivation event");
+    assert_eq!(
+        saw_deactivation_event.as_deref(),
+        Some(WS_1),
+        "expected WorkstreamActivationChanged{{new_active_id: None, prior_id: Some(WS_1)}}"
     );
 
     engine.shutdown().await.expect("shutdown");

--- a/crates/trusty-tui/CHANGELOG.md
+++ b/crates/trusty-tui/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ReplEvent::WorkstreamActivationChanged.new_active_id` is now `Option<String>` (closes #3452, part of epic #3411).** The field was non-optional `String`, but the daemon legitimately publishes a `None` activation target when the active workstream is deactivated with no replacement (DOC-48 §4.2/§4.3) — mirroring `crate::events::Event::WorkstreamActivationChanged` in `trusty-code`, which already declares this field as `Option<String>`. The non-optional shape forced `trusty-code`'s Slice 3 consumer to fall back to a free-text `StatusMessage` for that case (PR #3436); this closes the gap found in that review, while `trusty-tui` still has essentially one consumer.
+
 ### Added
 
 - Initial crate scaffold (Slice 1, closes #3412, part of epic #3411, DOC-50 §3/§5): the `TuiEngine` trait (`setup`, `handle_input`, `cancel_session`, `subscribe_workstream_events`, `shutdown`) and the `ReplEvent` enum (terminal input, submit/cancel, streamed assistant output, tool invocation, statusline/workstream updates, connection loss, clear-scrollback), generalized from tagent's existing `crates/trusty-agents/src/repl/tui/` REPL event model. Also ships the small shared payload stubs (`StatuslineSegment`, `PickerItem`, `CommandDescriptor`, `WorkstreamSummary`) that Slice 1.5 (#3413) will flesh out. No ratatui/crossterm dependency yet — the terminal layer lands in Slice 2 (#3414).

--- a/crates/trusty-tui/src/event.rs
+++ b/crates/trusty-tui/src/event.rs
@@ -111,7 +111,11 @@ pub enum ReplEvent {
     /// The daemon activated a different workstream (DOC-48 §5.3
     /// `WorkstreamActivationChanged`), pushed via
     /// `TuiEngine::subscribe_workstream_events`. `prior_id` is `None` on the
-    /// very first activation observed in this session.
+    /// very first activation observed in this session. `new_active_id` is
+    /// `None` when the active workstream was deactivated and none is now
+    /// active (DOC-48 §4.2/§4.3) — a real, daemon-published state, not an
+    /// absence of data; distinct from `prior_id: None`, which means "no
+    /// activation happened before this one."
     ///
     /// Field names are chosen to match the DOC-48 §5.3 SSE wire event
     /// exactly (`new_active_id`, `prior_id`) — NOT DOC-50 §5 Slice 6's prose
@@ -119,9 +123,13 @@ pub enum ReplEvent {
     /// adapters deserialize this from JSON (Slice 3/6), a Rust/wire name
     /// mismatch here would not be caught at compile time, only at runtime
     /// deserialization — so the Rust field is kept byte-identical to the
-    /// wire field on purpose.
+    /// wire field on purpose, including its optionality: the wire event
+    /// (`crate::events::Event::WorkstreamActivationChanged` in
+    /// `trusty-code`) declares `new_active_id: Option<String>` for exactly
+    /// this reason, and this variant now mirrors that shape rather than
+    /// forcing a lossy `StatusMessage` fallback for the `None` case.
     WorkstreamActivationChanged {
-        new_active_id: String,
+        new_active_id: Option<String>,
         prior_id: Option<String>,
     },
     /// The backend connection was lost (daemon restart, SSE stream closed,
@@ -265,7 +273,7 @@ mod tests {
     #[test]
     fn workstream_activation_changed_uses_wire_field_name() {
         let ev = ReplEvent::WorkstreamActivationChanged {
-            new_active_id: "a1b2c3d4".to_string(),
+            new_active_id: Some("a1b2c3d4".to_string()),
             prior_id: Some("00000000".to_string()),
         };
         let ReplEvent::WorkstreamActivationChanged {
@@ -275,8 +283,30 @@ mod tests {
         else {
             unreachable!()
         };
-        assert_eq!(new_active_id, "a1b2c3d4");
+        assert_eq!(new_active_id.as_deref(), Some("a1b2c3d4"));
         assert_eq!(prior_id.as_deref(), Some("00000000"));
+    }
+
+    /// `new_active_id: None` must be representable and distinguishable from
+    /// `prior_id: None` — the whole point of this fix (issue tracked in the
+    /// commit landing this test): the daemon legitimately publishes
+    /// "deactivated, no replacement active" (DOC-48 §4.2/§4.3), and the
+    /// shared event must carry that without falling back to free text.
+    #[test]
+    fn workstream_activation_changed_represents_deactivation_with_no_replacement() {
+        let ev = ReplEvent::WorkstreamActivationChanged {
+            new_active_id: None,
+            prior_id: Some("a1b2c3d4".to_string()),
+        };
+        let ReplEvent::WorkstreamActivationChanged {
+            new_active_id,
+            prior_id,
+        } = &ev
+        else {
+            unreachable!()
+        };
+        assert_eq!(*new_active_id, None);
+        assert_eq!(prior_id.as_deref(), Some("a1b2c3d4"));
     }
 
     /// `KeyInput` default modifiers must be "nothing held" so a bare


### PR DESCRIPTION
## Summary

- `ReplEvent::WorkstreamActivationChanged.new_active_id` was a non-optional `String`, but the daemon legitimately publishes `new_active_id: None` when the active workstream is deactivated with no replacement (DOC-48 §4.2/§4.3). `trusty-code`'s own wire event, `Event::WorkstreamActivationChanged`, already declares this field `Option<String>` — the shared `trusty-tui` shape had drifted from it.
- That mismatch forced Slice 3's `CodeEngine` consumer (`crates/trusty-code/src/tui_client/workstream_subscription.rs`, merged as `e8a4dae6`, PR #3436) to fall back to a free-text `ReplEvent::StatusMessage` for the deactivation case, with an inline comment documenting the gap.
- This closes the gap while `trusty-tui` still has essentially one consumer, before a second UI makes the fix more expensive.

## Changes

- `crates/trusty-tui/src/event.rs`: `new_active_id: String` → `Option<String>`; doc comment now states `None` means "deactivated, none now active," and confirms the field mirrors the wire shape exactly (including optionality) against `crates/trusty-code/src/events.rs`'s `Event::WorkstreamActivationChanged`. Added a regression test for the `None` case alongside the existing wire-field-name test.
- `crates/trusty-code/src/tui_client/workstream_subscription.rs`: the deactivation arm now emits `ReplEvent::WorkstreamActivationChanged { new_active_id: None, prior_id: Some(..) }` instead of a `StatusMessage`; removed the now-closed inline gap comment. Kept the cache refresh and the "stay connected to the same SSE stream" behavior on both arms.
- `crates/trusty-code/tests/tui_client_engine.rs`: updated `subscribe_workstream_events_refreshes_cache_on_deactivation_with_no_replacement` to assert the structured event (`new_active_id: None`, `prior_id: Some(WS_1)`) instead of a `StatusMessage` substring; still asserts the cache-refresh half (second `workstream.list` call) unchanged.
- CHANGELOG entries in both `crates/trusty-tui/CHANGELOG.md` and `crates/trusty-code/CHANGELOG.md`.

Diff confined to these four files (plus changelogs) — no changes to widget/rendering code, so this should not conflict with the parallel Slice 4 widget migration.

Closes #3452
Part of #3411

## Test plan

- [x] `cargo build --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui` — clean
- [x] `cargo test -p trusty-tui` (parallel and `--test-threads=1`) — 33/33 passed both ways
- [x] `cargo test -p trusty-code` (parallel and `--test-threads=1`) — 1430/1430 lib passed single-threaded (one unrelated environment flake in parallel mode, touching a local trusty-memory palace file — passes in isolation, pre-existing and unrelated to this change); all integration binaries (tui_client_engine, task_e2e, session_e2e, etc.) green both ways
- [x] `cargo test -p trusty-code --lib serve::` — 106/106 passed, no daemon regression
- [x] `cargo clippy --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --all-targets -- -D warnings` — exit 0
- [x] `cargo fmt --check` — exit 0
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling pointers
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] Reverted stray `crates/trusty-search/ui-dist/*` build artifacts before committing

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools