### PR TITLE
feat(trusty-agents): Foundry v2 CSS-variable token layer for Assistant GUI (#3387)

### DIFF
--- a/crates/trusty-agents/ui/src/app.css
+++ b/crates/trusty-agents/ui/src/app.css
@@ -2,6 +2,90 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Why: issue #3387 — Foundry v2 token layer (docs/design/UI/design-system/
+ * tokens.css). Before this, `tailwind.config.js`'s `colors.foundry.*`
+ * namespace hardcoded 15 hex literals directly, so every component paired
+ * `text-foundry-light-X dark:text-foundry-X` by hand and there was no
+ * CSS-variable indirection at all — a v2 tokens.css drop-in could not theme
+ * this crate. This block is the single place either theme's actual color
+ * VALUES live, 1:1 with the design system's hex values converted to
+ * space-separated RGB triples, following the same convention already
+ * established in `trusty-code-gui/ui/src/app.css` (issue #3153/#3380).
+ * What: each `--color-*` custom property is a SPACE-SEPARATED RGB triple
+ * (`"R G B"`, not `"#rrggbb"`) — required by `tailwind.config.js`'s
+ * `rgb(var(--color-*) / <alpha-value>)` format, the only way Tailwind can
+ * generate opacity-modified utilities (`bg-foundry-primary/10`,
+ * `text-foundry-text/60`, used throughout every component) for a
+ * CSS-variable-backed color. `:root` sets the light theme as the default;
+ * the `.dark` block overrides every variable for dark — `.dark` (not
+ * `[data-theme='dark']`) is this crate's existing activation selector
+ * (`stores/theme.ts` toggles `.dark` on `<html>`, matched by
+ * `tailwind.config.js`'s `darkMode: 'class'`), so no change to the theme
+ * store was needed.
+ *
+ * `tailwind.config.js` maps BOTH the dark-named key (`foundry-primary`) and
+ * the light-named key (`foundry-light-primary`) to the SAME `--color-*` var
+ * — the var itself already flips value between `:root` and `.dark`, so the
+ * existing `text-foundry-light-X dark:text-foundry-X` pairing throughout
+ * every component still resolves correctly with zero component edits: in
+ * light mode only the light-named class's rule is active and it reads the
+ * light value; in dark mode the `dark:`-prefixed rule wins the cascade (as
+ * it always did) and reads the dark value — both ultimately read the one
+ * token, so whichever wins renders identically either way.
+ *
+ * `--color-text-muted` is a deliberate value correction, not a 1:1 port:
+ * the old hand-port paired dark 'muted' (#A58A6B, actually
+ * --trusty-text-muted's DARK value) with light 'light-muted' (#6E5843,
+ * actually --trusty-text-secondary's LIGHT value) — two different DS
+ * semantic tokens mismatched into one Tailwind key. This now sources both
+ * ends from the DS's actual --trusty-text-muted pair (light #8A7460 / dark
+ * #A58A6B unchanged), a light-mode-only, DS-conformant value shift.
+ * `--color-info` (foundry-teal) and `--color-warning` (foundry-amber)
+ * previously had no light-mode counterpart at all (D4) — they now inherit
+ * real light values from --trusty-info / --trusty-warning automatically.
+ *
+ * `--trusty-surface-hover` is carried over verbatim (DS naming, not
+ * Tailwind-fed) — it already bakes its own alpha per theme, so it does not
+ * fit the `<alpha-value>` RGB-triple convention; it is read directly via
+ * `var()` in component `<style>` blocks (RecapPanel.svelte, ChatView.svelte)
+ * in place of the previous unsanctioned `rgb(20 184 166 / 0.04)` teal
+ * literal (B2).
+ * Test: manual — toggle ThemeToggle through light/dark/system and confirm
+ * every foundry-* surface, text, border, and accent utility recolors; no
+ * automated test exists for this crate's CSS layer (see PersonalityPanel /
+ * models.test.ts etc. — no CSS/token test precedent in this crate to
+ * follow).
+ */
+:root {
+  color-scheme: light dark;
+
+  --color-content-bg: 245 239 231; /* #F5EFE7 */
+  --color-card-bg: 255 253 249; /* #FFFDF9 */
+  --color-text-primary: 43 28 18; /* #2B1C12 */
+  --color-text-muted: 138 116 96; /* #8A7460 — --trusty-text-muted light */
+  --color-border: 216 201 180; /* #D8C9B4 */
+  --color-primary: 183 65 14; /* #B7410E — --trusty-accent light */
+  --color-info: 61 107 138; /* #3D6B8A — --trusty-info light */
+  --color-warning: 176 125 16; /* #B07D10 — --trusty-warning light */
+  --color-sidebar-accent: 233 185 138; /* #E9B98A — same both themes */
+
+  --trusty-surface-hover: rgba(183, 65, 14, 0.06);
+}
+
+.dark {
+  --color-content-bg: 32 22 18; /* #201612 */
+  --color-card-bg: 43 28 18; /* #2B1C12 */
+  --color-text-primary: 240 231 216; /* #F0E7D8 */
+  --color-text-muted: 165 138 107; /* #A58A6B — --trusty-text-muted dark */
+  --color-border: 70 49 31; /* #46311F */
+  --color-primary: 217 119 66; /* #D97742 — --trusty-accent dark */
+  --color-info: 123 167 196; /* #7BA7C4 — --trusty-info dark */
+  --color-warning: 217 168 58; /* #D9A83A — --trusty-warning dark */
+  --color-sidebar-accent: 233 185 138; /* #E9B98A — same both themes */
+
+  --trusty-surface-hover: rgba(217, 119, 66, 0.09);
+}
+
 html, body, #app {
   height: 100%;
   margin: 0;
@@ -14,18 +98,13 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Why: Default body palette in light mode — Tailwind classes on <body>
-   override these when the dark class is set on <html>. Avoids a flash of
-   the wrong palette before Svelte mounts. Values match the Foundry design
-   system (docs/design/gui/tokens.css): --trusty-content-bg / --trusty-text-primary. */
+/* Why: Default body palette — Tailwind classes on <body> override these
+   once Svelte mounts; this just avoids a flash of the wrong palette before
+   that happens. Reads the same tokens every foundry-bg/foundry-text utility
+   reads, so it can never drift out of sync with the rest of the app. */
 body {
-  background-color: #F5EFE7;
-  color: #2B1C12;
-}
-
-html.dark body {
-  background-color: #201612;
-  color: #F0E7D8;
+  background-color: rgb(var(--color-content-bg));
+  color: rgb(var(--color-text-primary));
 }
 
 code, pre, kbd, samp {

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -191,10 +191,16 @@
 </div>
 
 <style>
-  /* Why: Alternate-row striping for recap tables; using nth-child avoids
-     plumbing extra Tailwind classes per row. Test: Inspect a recap message
-     and verify even rows have a faint teal tint. */
+  /* Why (#3387): was an unsanctioned raw `rgb(20 184 166 / 0.04)` teal-500
+     literal with no token relationship (audit finding B2). Now reads
+     --trusty-surface-hover (app.css), the DS's own sanctioned hover/tint
+     token — same rust-derived hue family as the rest of the app, and
+     correctly light/dark-reactive. Alternate-row striping itself (nth-child)
+     is kept as-is; the DS's "no zebra-striped tables" guardrail is a
+     structural change out of scope for this token-layer pass — flagged as a
+     follow-up, not fixed here.
+     Test: Inspect a recap message and verify even rows have a faint tint. */
   tbody tr.recap-row:nth-child(even) {
-    background-color: rgb(20 184 166 / 0.04);
+    background-color: var(--trusty-surface-hover);
   }
 </style>

--- a/crates/trusty-agents/ui/src/components/Header.svelte
+++ b/crates/trusty-agents/ui/src/components/Header.svelte
@@ -53,7 +53,7 @@
   class="sticky top-0 z-20 flex h-[52px] w-full shrink-0 items-center justify-between border-b border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface px-4"
 >
   <div class="flex items-center gap-3 min-w-0">
-    <RobotIcon size={26} variant="mono" color="#B7410E" />
+    <RobotIcon size={26} variant="mono" color="var(--color-primary)" />
     <span class="font-display text-sm font-bold tracking-wide text-foundry-light-text dark:text-foundry-text">
       TRUSTY AGENTS
     </span>

--- a/crates/trusty-agents/ui/src/components/RecapPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/RecapPanel.svelte
@@ -168,10 +168,16 @@
 </aside>
 
 <style>
-  /* Why: Alternate-row striping for the folded recap table; nth-child avoids
-     plumbing extra Tailwind classes per row.
-     Test: Inspect the recap fold's table — even rows have a faint teal tint. */
+  /* Why (#3387): was an unsanctioned raw `rgb(20 184 166 / 0.04)` teal-500
+     literal with no token relationship (audit finding B2). Now reads
+     --trusty-surface-hover (app.css), the DS's own sanctioned hover/tint
+     token — same rust-derived hue family as the rest of the app, and
+     correctly light/dark-reactive. Alternate-row striping itself (nth-child)
+     is kept as-is; the DS's "no zebra-striped tables" guardrail is a
+     structural change out of scope for this token-layer pass — flagged as a
+     follow-up, not fixed here.
+     Test: Inspect the recap fold's table — even rows have a faint tint. */
   tbody tr.recap-row:nth-child(even) {
-    background-color: rgb(20 184 166 / 0.04);
+    background-color: var(--trusty-surface-hover);
   }
 </style>

--- a/crates/trusty-agents/ui/src/lib/icons/LogoMark.svelte
+++ b/crates/trusty-agents/ui/src/lib/icons/LogoMark.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <span class="inline-flex items-center gap-2 text-foundry-text font-display">
-  <RobotIcon {size} variant="mono" color="#B7410E" />
+  <RobotIcon {size} variant="mono" color="var(--color-primary)" />
   <span class="text-sm">
     <span class="font-normal">Trusty </span><span class="font-semibold">Assistant</span>
   </span>

--- a/crates/trusty-agents/ui/src/lib/icons/RobotIcon.svelte
+++ b/crates/trusty-agents/ui/src/lib/icons/RobotIcon.svelte
@@ -13,11 +13,23 @@
    * Test: Render <RobotIcon /> with each variant and visually confirm the
    * antenna dot, eyes, and `>_` mouth render at 32px without clipping.
    */
+  // Why (#3387): default reads the Foundry accent token (app.css's
+  // --color-primary, itself light/dark-reactive via the .dark class) rather
+  // than a hardcoded hex, so the icon's own color now inverts with theme
+  // like every other accent in the app. CSS custom properties resolve
+  // correctly when set via SVG presentation attributes (stroke/fill) in all
+  // engines this Tauri app targets. `bgFill`/`stroke`/`dotFill` for the
+  // 'full'/'badge' variants are left as fixed literals — see the two lines
+  // below — since neither variant is used anywhere in this crate today
+  // (only 'mono' is; see Header.svelte, LogoMark.svelte), so there is no
+  // rendered light/dark behavior to fix and no way to visually verify a
+  // token choice for them.
   export let size: number = 32;
-  export let color: string = '#B7410E';
+  export let color: string = 'var(--color-primary)';
   export let variant: 'full' | 'mono' | 'badge' = 'full';
 
-  // Derived presentation tokens per variant.
+  // Derived presentation tokens per variant. #2B1C12 / #FFFFFF: intentionally
+  // fixed (not theme tokens) — unused 'full'/'badge' variants, see comment above.
   $: bgFill = variant === 'full' ? '#2B1C12' : variant === 'badge' ? color : 'none';
   $: stroke = variant === 'badge' ? '#FFFFFF' : color;
   $: dotFill = variant === 'badge' ? '#FFFFFF' : color;

--- a/crates/trusty-agents/ui/tailwind.config.js
+++ b/crates/trusty-agents/ui/tailwind.config.js
@@ -1,4 +1,31 @@
 /** @type {import('tailwindcss').Config} */
+// Why: Foundry v2 token layer (issue #3387, docs/design/UI/design-system/).
+// Every `foundry-*` color used across the components now resolves to a CSS
+// custom property (`app.css`'s `:root` / `.dark` blocks) rather than a
+// hardcoded hex literal — previously this file baked 15 hex values directly
+// into `theme.extend.colors.foundry`, the root cause of the crate having no
+// CSS-variable indirection at all (issue #3387's audit finding B1/B3/D4).
+//
+// CRITICAL format note: each color is `rgb(var(--color-*) / <alpha-value>)`,
+// NOT a bare `var(--color-*)` — see `trusty-code-gui/ui/tailwind.config.js`
+// for the same established pattern. A bare `var()` reference cannot have its
+// opacity manipulated at build time, so the `bg-foundry-primary/10`-style
+// modifiers used throughout every component (hover states, dimmed text,
+// badges) would silently generate NO rule with a plain `var()` value.
+//
+// What: the dark-named key (`primary`) and the light-named key
+// (`light-primary`) intentionally map to the SAME `--color-*` variable — the
+// variable itself already changes value between `:root` (light) and `.dark`
+// (dark), so the app's existing `text-foundry-light-X dark:text-foundry-X`
+// pairing throughout every component keeps working with zero component
+// edits: whichever class wins Tailwind's dark: cascade, both ultimately read
+// the same token and render the same color for the active theme. `teal` and
+// `amber` now resolve to `--color-info`/`--color-warning` — previously
+// dark-only literals with no light-mode counterpart (audit finding D4) — so
+// they correctly invert in light mode as a side effect of this change.
+// `darkMode: 'class'` is unchanged: `stores/theme.ts` toggles the `.dark`
+// class on `<html>`, which both this config and `app.css` key off.
+// Test: manual — see `app.css`'s header comment for the verification note.
 export default {
   darkMode: 'class',
   content: [
@@ -8,38 +35,27 @@ export default {
   theme: {
     extend: {
       colors: {
-        // Foundry — Trusty Suite design system, "rust-on-paper" (light) /
-        // "Night Shift" (dark) palette. Values ported 1:1 from
-        // docs/design/gui/tokens.css — do not introduce new hues here;
-        // derive tints in oklch by shifting lightness only if a new tint
-        // is ever needed (see docs/design/gui/README.md guardrails).
         foundry: {
-          // Dark theme ("Night Shift") values — defaults, since this app
-          // renders unprefixed classes for dark:-inverted pairs below.
-          bg: '#201612',
-          surface: '#2b1c12',
-          text: '#f0e7d8',
-          muted: '#a58a6b',
-          border: '#46311f',
-          // Accent brightens one step on dark to hold contrast on oxide
-          // paper (tokens.css: --trusty-accent dark = #D97742). Unlike the
-          // other bare keys this is genuinely the DARK-theme accent value —
-          // see 'light-primary' below for the light-theme counterpart.
-          primary: '#d97742',
-          teal: '#7ba7c4',
-          amber: '#d9a83a',
-          // --trusty-sidebar-accent (docs/design/gui/tokens.css) — the warm
-          // tan/gold used for section labels in dark-themed sidebars/rails
-          // (e.g. RecapPanel's AGENTS ACTIVE/FILES TOUCHED/TOKENS headers).
-          'sidebar-accent': '#e9b98a',
-          // Light theme values (used via `dark:` prefix inversion, same
-          // pattern the app already used pre-rebrand).
-          'light-bg': '#f5efe7',
-          'light-surface': '#fffdf9',
-          'light-text': '#2b1c12',
-          'light-muted': '#6e5843',
-          'light-border': '#d8c9b4',
-          'light-primary': '#b7410e',
+          // Dark-named keys — kept for backward compatibility with every
+          // existing `dark:text-foundry-X` call site; resolve through the
+          // same variable as their light-named counterpart below.
+          bg: 'rgb(var(--color-content-bg) / <alpha-value>)',
+          surface: 'rgb(var(--color-card-bg) / <alpha-value>)',
+          text: 'rgb(var(--color-text-primary) / <alpha-value>)',
+          muted: 'rgb(var(--color-text-muted) / <alpha-value>)',
+          border: 'rgb(var(--color-border) / <alpha-value>)',
+          primary: 'rgb(var(--color-primary) / <alpha-value>)',
+          teal: 'rgb(var(--color-info) / <alpha-value>)',
+          amber: 'rgb(var(--color-warning) / <alpha-value>)',
+          'sidebar-accent': 'rgb(var(--color-sidebar-accent) / <alpha-value>)',
+          // Light-named keys (used via `dark:` prefix inversion) — same
+          // variables as above; the variable's own value differs per theme.
+          'light-bg': 'rgb(var(--color-content-bg) / <alpha-value>)',
+          'light-surface': 'rgb(var(--color-card-bg) / <alpha-value>)',
+          'light-text': 'rgb(var(--color-text-primary) / <alpha-value>)',
+          'light-muted': 'rgb(var(--color-text-muted) / <alpha-value>)',
+          'light-border': 'rgb(var(--color-border) / <alpha-value>)',
+          'light-primary': 'rgb(var(--color-primary) / <alpha-value>)',
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary

Addresses #3387's audit finding (A/B1/B2/D4): `crates/trusty-agents/ui` had
zero CSS-custom-property indirection — `tailwind.config.js`'s
`colors.foundry.*` namespace hardcoded 15 hex literals directly, and every
component hand-paired `text-foundry-light-X dark:text-foundry-X` classes.
This PR lands the issue's own recommended step 1 ("Land the token layer
first... mechanical, low-risk, unblocks everything else"):

- `src/app.css` — new `:root`/`.dark` `--color-*` blocks, RGB triples 1:1
  with `docs/design/UI/design-system/tokens.css`, following the same
  `rgb(var(--color-*) / <alpha-value>)` convention `trusty-code-gui` already
  uses (#3153/#3380).
- `tailwind.config.js` — every `colors.foundry.*` key now resolves through
  a `--color-*` variable instead of a literal hex. The dark-named key
  (`primary`) and light-named key (`light-primary`) intentionally map to the
  **same** variable — since the variable itself already flips value between
  `:root` and `.dark`, the existing `dark:`-paired class pattern in every
  component keeps rendering correctly with **zero component edits**.
- Fixed the true hardcoded-hex sites the mechanism above doesn't reach:
  `app.css`'s body-fallback literals, `RobotIcon.svelte`'s default accent
  color + its two call sites (`Header.svelte`, `LogoMark.svelte`), and the
  unsanctioned `rgb(20 184 166 / 0.04)` teal-500 literal used for zebra-row
  tinting in `RecapPanel.svelte`/`ChatView.svelte` (now
  `var(--trusty-surface-hover)`, the design system's own token).
- `foundry-teal`/`foundry-amber` previously had **no light-mode
  counterpart at all** (audit finding D4) — they now correctly invert via
  `--color-info`/`--color-warning`.
- One deliberate value correction (not a 1:1 port): the old hand-port
  paired dark `muted` (`#A58A6B`, actually `--trusty-text-muted`'s dark
  value) with light `light-muted` (`#6E5843`, actually
  `--trusty-text-secondary`'s light value) — two different DS tokens
  mismatched into one key. Both ends now source from the DS's actual
  `--trusty-text-muted` pair (light `#8A7460` / dark `#A58A6B` unchanged) —
  a light-mode-only, DS-conformant shift, documented in `app.css`.

## Hardcoded-color before/after

| | Before | After |
|---|---|---|
| Tailwind config hex literals | 15 | 0 |
| True hardcoded hex in components (app.css, RobotIcon default + call sites) | 7 site-groups | 0 (2 literals kept, see below) |
| Unsanctioned raw `rgb()` literal (teal-500 zebra tint) | 2 sites | 0 |
| `foundry-teal`/`foundry-amber` missing light-mode value (D4) | 2 tokens | 0 |

**Deliberately left hardcoded:** `RobotIcon.svelte`'s `bgFill`
(`'#2B1C12'`, `full` variant) and `stroke`/`dotFill` (`'#FFFFFF'`, `badge`
variant) literals. Neither the `full` nor `badge` variant is used anywhere
in this crate today (only `mono` is, in `Header.svelte`/`LogoMark.svelte`,
both now token-driven) — there is no rendered light/dark behavior to fix and
no way to visually verify a token choice for genuinely dead code paths.
Documented inline with a comment.

**Explicitly out of scope for this PR** (per the issue's own recommended
sequencing — these need design judgment, not a mechanical swap):
- B3: 33 sites of raw `red-/green-/yellow-*` Tailwind utilities used as
  status colors instead of `--trusty-success`/`--trusty-danger`/`--trusty-warning`.
- D1: rust-accent-per-region discipline (currently used as the default
  accent almost everywhere).
- D2: badge shape (pills → rectangular stamps).
- D3: shadows on resting surfaces.
- The "no zebra-striped tables" guardrail itself — the zebra striping in
  `RecapPanel`/`ChatView` is kept, just retinted onto a sanctioned token
  (removing it entirely is a layout decision, not a token substitution).

Recommend tracking these as a follow-up issue per #3387's own sequencing
(steps 2 and 3).

## Test plan

- [x] `pnpm build` (real Vite production build, not `SKIP_UI_BUILD=1`) —
      clean, only 2 pre-existing a11y warnings in `ProjectsView.svelte`
      (confirmed present and identical on unmodified `origin/main`, this PR
      makes no changes to that file).
- [x] `pnpm check` (svelte-check) — 1 pre-existing unused-var error in
      `App.svelte`, confirmed present and identical on unmodified
      `origin/main`.
- [x] `pnpm test:unit` — 38/38 tests pass.
- [x] `bash scripts/check_line_cap.sh` — 0 violations.
- [x] Inspected the compiled `dist/assets/index-*.css`: `:root`/`.dark`
      blocks carry the correct RGB-triple values; opacity-modified
      utilities (`bg-foundry-primary/30`) correctly compile to
      `rgb(var(--color-primary) / .3)` (not silently dropped); zero
      remaining occurrences of the old `20 184 166` teal-500 or `B7410E`
      literals in the built output.
- No Rust files touched — `cargo fmt`/`clippy` not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)