### PR TITLE
chore(trusty-search): cut 0.36.0 (#3401, #3424)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11734,7 +11734,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -61,7 +61,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.19.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.35.0" }
+trusty-search = { path = "../trusty-search", version = "0.36.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,7 +5,20 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [0.36.0] — 2026-07-20
+
+### Changed
+
+- **BREAKING: unknown search-filter fields now error instead of being
+  silently ignored.** `SearchQuery` (`/indexes/:id/search`) and
+  `GlobalSearchRequest` (`/search`) both now derive `#[serde(deny_unknown_fields)]`.
+  A misspelled or unsupported filter field (e.g. `path_prefx` instead of
+  `path_prefix`) previously deserialized successfully and silently returned
+  an unscoped/unfiltered result set; it now fails deserialization with a
+  clear error. Any client sending fields the schema doesn't recognize —
+  intentionally or by typo — will start seeing request failures after this
+  upgrade. Check request payloads against the current `SearchQuery` /
+  `GlobalSearchRequest` field set before upgrading.
 
 ### Added
 

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Cuts trusty-search 0.36.0 for publish to crates.io. Ships two already-merged, unpublished features:

- **#3401 / PR #3410** — server-side `path_prefix` / `repos` search scoping, applied PRE-TRUNCATION in every retrieval lane (vector/HNSW via `usearch::filtered_search`, BM25, grep, KG). Also adds `#[serde(deny_unknown_fields)]` to `SearchQuery` and `GlobalSearchRequest`.
- **#3424 / PR #3408** — file watcher detects network-mounted (EFS/NFS/CIFS/SMB) index roots, refuses to silently start a watcher that can never fire, and surfaces the degraded state on `/health`; blesses `index-file`/`remove-file` as the supported incremental path for network mounts.

This is a **minor** bump (0.35.0 -> 0.36.0): new public API surface (`path_prefix`/`repos`) plus a **breaking behavior change** — `deny_unknown_fields` means a misspelled/unrecognized filter field now errors instead of silently returning an unscoped result. Called out prominently in the CHANGELOG.

## Why `crates/trusty-agents/Cargo.toml` is touched in a trusty-search release

`trusty-agents` depends on trusty-search via `{ path = "../trusty-search", version = "0.35.0" }`. Cargo enforces that a path dependency's local version satisfies its stated semver requirement even though `trusty-agents` is `publish = false` (never resolved from the registry) — so bumping trusty-search to 0.36.0 without updating this pin breaks `cargo check/clippy/test --workspace` workspace-wide resolution (`failed to select a version for the requirement`). Bumped the pin to `0.36.0` alongside the release; no behavior change in trusty-agents itself.

## Version-drift check (issue #3366)

- `trusty-common`: local 0.23.4 == published 0.23.4; trusty-search's caret requirement (`0.23.0`) is satisfied — no bump needed. (Note: an unpublished catch-up-module fix, `3563924e`/closes #1772, postdates the `trusty-common-v0.23.4` tag, but trusty-search never enables trusty-common's `catchup` feature and never references it — confirmed out of scope for this release.)
- `trusty-embedderd`: local 0.3.8 == published 0.3.8 == tag `trusty-embedderd-v0.3.8`, zero commits since — no bump needed.

## Quality gate (CI's exact invocations)

- `cargo fmt --all --check` — pass
- `SKIP_UI_BUILD=1 cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — pass
- `SKIP_UI_BUILD=1 cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` — 1991 passed, 1 pre-existing local-environment-only failure (`trusty-agents::llm::credentials::tests::other_configured_providers_empty_when_nothing_else_configured`, root-caused to a gitignored personal `.env.local` leaking real dev credentials via the bare-repo+worktree directory layout on this machine — cannot occur on CI, untouched by this diff). CI is the authoritative gate for this PR.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets` (excl. GUI crates) `-D warnings`
- [x] `cargo test --workspace` (excl. GUI crates)
- [ ] CI green on this PR
- [ ] Publish trusty-search 0.36.0 to crates.io from merged main
- [ ] Tag `trusty-search-v0.36.0` pushed

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools