### PR TITLE
feat(trusty-code): Agents + Skills catalogs — REST endpoints + GUI tabs (closes #3449)

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -8,6 +8,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Agents + Skills management tabs (issue #3449).** Two new nav tabs —
+  `AgentsTab.svelte` (replacing the prior per-session-roster stub) and the
+  new `SkillsTab.svelte` — list the daemon's full agent/skill catalog with
+  tier badges (embedded/bundled = read-only) and add/remove for the
+  user-editable disk tier, via a two-step inline confirm on remove
+  (matching `WorkstreamSwitcher.svelte`'s pattern). New `lib/agent-roster.ts`/
+  `lib/skill-roster.ts` wrap the new `GET`/`POST /agents`,
+  `DELETE /agents/{name}` REST routes (and the `skills` equivalent).
+  `StartWorkingForm.svelte`'s task form gained an optional agent selector,
+  closing the "no pre-task agent roster endpoint exists yet" gap that form
+  previously carried as a standing note — omitting a selection still defers
+  to the daemon's own default, unchanged from before.
+
 ### Changed
 
 - **`ProjectPickerModal` marks unregistered (local-only) roster rows

--- a/crates/trusty-code-gui/ui/src/App.svelte
+++ b/crates/trusty-code-gui/ui/src/App.svelte
@@ -48,6 +48,7 @@
   import WorkstreamTab from './components/WorkstreamTab.svelte';
   import ProjectTab from './components/ProjectTab.svelte';
   import AgentsTab from './components/AgentsTab.svelte';
+  import SkillsTab from './components/SkillsTab.svelte';
   import MemoryTab from './components/MemoryTab.svelte';
   import SearchTab from './components/SearchTab.svelte';
   import WorkflowTab from './components/WorkflowTab.svelte';
@@ -130,6 +131,8 @@
           <ProjectTab />
         {:else if activeTab === 'agents'}
           <AgentsTab />
+        {:else if activeTab === 'skills'}
+          <SkillsTab />
         {:else if activeTab === 'memory'}
           <MemoryTab />
         {:else if activeTab === 'search'}

--- a/crates/trusty-code-gui/ui/src/App.test.ts
+++ b/crates/trusty-code-gui/ui/src/App.test.ts
@@ -169,13 +169,13 @@ describe('ServiceNav tab switching (issue #3153 shell rebuild)', () => {
     });
   });
 
-  it('renders all 7 canonical nav tabs', () => {
+  it('renders all 8 canonical nav tabs (Skills added by issue #3449)', () => {
     instance = mount(App, { target }) as unknown as Record<string, unknown>;
 
     const wsnav = target.querySelector('.wsnav');
     const labels = Array.from(wsnav?.querySelectorAll('button') ?? []).map((b) => b.textContent?.trim());
 
-    for (const label of ['Workstream', 'Project', 'Agents', 'Memory', 'Search', 'Files']) {
+    for (const label of ['Workstream', 'Project', 'Agents', 'Skills', 'Memory', 'Search', 'Files']) {
       expect(labels, `expected a "${label}" nav tab`).toContain(label);
     }
   });

--- a/crates/trusty-code-gui/ui/src/components/AgentsTab.svelte
+++ b/crates/trusty-code-gui/ui/src/components/AgentsTab.svelte
@@ -162,6 +162,7 @@
   function tierLabel(tier: AgentCatalogEntry['tier']): string {
     if (tier === 'embedded') return 'embedded · read-only';
     if (tier === 'project') return 'project';
+    if (tier === 'broken') return 'broken · dispatch will fail';
     return 'user';
   }
 </script>

--- a/crates/trusty-code-gui/ui/src/components/AgentsTab.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/AgentsTab.test.ts
@@ -1,0 +1,163 @@
+// Why: issue #3449 — pins `AgentsTab.svelte`'s connection phases, embedded
+// vs disk-tier badge/remove-button behavior, the two-step inline remove
+// confirm (mirroring `WorkstreamSwitcher.svelte`'s pattern), and the add
+// flow's success/error paths.
+// What: Mounts the real component with `fetch` stubbed per phase.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+import AgentsTab from './AgentsTab.svelte';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+function normalizedText(): string {
+  return (target.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function agentsResponse(agents: unknown[]): Response {
+  return { ok: true, status: 200, json: async () => ({ agents }) } as Response;
+}
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+describe('AgentsTab', () => {
+  it('renders the connecting state before the first poll resolves', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
+    instance = mount(AgentsTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('connecting') ?? false);
+    expect(target.textContent).toContain('connecting');
+  });
+
+  it('renders daemon-unreachable on a fetch failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    instance = mount(AgentsTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('daemon unreachable') ?? false);
+    expect(target.textContent).toContain('daemon unreachable');
+  });
+
+  it('renders embedded agents read-only, with no remove button', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        agentsResponse([
+          { name: 'engineer', tier: 'embedded', description: 'Generalist agent', model: null },
+        ]),
+      ),
+    );
+    instance = mount(AgentsTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => normalizedText().includes('engineer'));
+    expect(normalizedText()).toContain('embedded');
+    expect(target.querySelector('[aria-label="remove engineer"]')).toBeNull();
+  });
+
+  it('renders a remove button for a disk-tier agent and arms two-step confirm', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        agentsResponse([
+          { name: 'my-agent', tier: 'project', description: null, model: null },
+        ]),
+      ),
+    );
+    instance = mount(AgentsTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => normalizedText().includes('my-agent'));
+    const removeButton = target.querySelector('[aria-label="remove my-agent"]') as HTMLButtonElement;
+    expect(removeButton).not.toBeNull();
+
+    removeButton.click();
+    await waitFor(() => normalizedText().includes('confirm'));
+    expect(normalizedText()).toContain('never mind');
+  });
+
+  it('deletes on confirm and refreshes the list', async () => {
+    let deleted = false;
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url.endsWith('/agents') && (!init || init.method === undefined)) {
+        return Promise.resolve(
+          agentsResponse(
+            deleted ? [] : [{ name: 'my-agent', tier: 'project', description: null, model: null }],
+          ),
+        );
+      }
+      if (init?.method === 'DELETE') {
+        deleted = true;
+        return Promise.resolve({ ok: true, status: 200 } as Response);
+      }
+      return Promise.resolve(agentsResponse([]));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    instance = mount(AgentsTab, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => normalizedText().includes('my-agent'));
+
+    (target.querySelector('[aria-label="remove my-agent"]') as HTMLButtonElement).click();
+    await waitFor(() => normalizedText().includes('confirm'));
+    (Array.from(target.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'confirm') as HTMLButtonElement).click();
+
+    await waitFor(() => normalizedText().includes('no agents found'));
+    expect(normalizedText()).toContain('no agents found');
+  });
+
+  it('opens the add form and surfaces the daemon error message on a 403 collision', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: async () => ({ error: { message: "'engineer' is an embedded agent" } }),
+        } as Response);
+      }
+      return Promise.resolve(agentsResponse([]));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    instance = mount(AgentsTab, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => normalizedText().includes('no agents found'));
+
+    (Array.from(target.querySelectorAll('button')).find((b) => b.textContent?.includes('add agent')) as HTMLButtonElement).click();
+    await waitFor(() => target.querySelector('#agent-add-name') !== null);
+    const nameInput = target.querySelector('#agent-add-name') as HTMLInputElement;
+    const contentInput = target.querySelector('#agent-add-content') as HTMLTextAreaElement;
+    nameInput.value = 'engineer';
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+    contentInput.value = '---\nname: engineer\n---\n\nBody.\n';
+    contentInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    function createButton(): HTMLButtonElement | undefined {
+      return Array.from(target.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'create',
+      ) as HTMLButtonElement | undefined;
+    }
+    await waitFor(() => createButton() !== undefined && !createButton()!.disabled);
+    createButton()!.click();
+
+    await waitFor(() => normalizedText().includes('embedded agent'));
+    expect(normalizedText()).toContain('embedded agent');
+  });
+});

--- a/crates/trusty-code-gui/ui/src/components/AgentsTab.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/AgentsTab.test.ts
@@ -75,6 +75,29 @@ describe('AgentsTab', () => {
     expect(target.querySelector('[aria-label="remove engineer"]')).toBeNull();
   });
 
+  it('renders a broken disk entry with the broken badge and keeps the remove affordance (repair path)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        agentsResponse([
+          {
+            name: 'engineer',
+            tier: 'broken',
+            description: 'unparseable agent file — dispatch of this name will fail',
+            model: null,
+          },
+        ]),
+      ),
+    );
+    instance = mount(AgentsTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => normalizedText().includes('engineer'));
+    expect(normalizedText()).toContain('broken');
+    expect(normalizedText()).not.toContain('embedded');
+    // Deleting the bad file is the repair path — the remove button must stay.
+    expect(target.querySelector('[aria-label="remove engineer"]')).not.toBeNull();
+  });
+
   it('renders a remove button for a disk-tier agent and arms two-step confirm', async () => {
     vi.stubGlobal(
       'fetch',

--- a/crates/trusty-code-gui/ui/src/components/SkillsTab.svelte
+++ b/crates/trusty-code-gui/ui/src/components/SkillsTab.svelte
@@ -1,48 +1,41 @@
 <script lang="ts">
   // Why: issue #3449 — Bob: "add a 'Skills' tab along with 'Agents', and
-  // the user should have the ability to add/remove both." This REPLACES the
-  // #3153 shell-rebuild stub (which deferred everything to "a follow-up
-  // slice, per-agent todo checklists + model badge, #3255/DOC-39 §5.4" —
-  // that per-SESSION live-roster feature is UNCHANGED and still not built;
-  // this tab is a different feature entirely: the daemon's disk/embedded
-  // AGENT CATALOG, `GET`/`POST /agents`, `DELETE /agents/{name}`
-  // (`crate::serve::rest::agent_catalog`), independent of any session.
+  // the user should have the ability to add/remove both." A NEW tab (no
+  // prior stub existed) — the sibling of `AgentsTab.svelte`, same shape,
+  // over `GET`/`POST /skills`, `DELETE /skills/{name}`
+  // (`crate::serve::rest::skill_catalog`).
   //
-  // Polls `GET /agents` every `POLL_MS`, the same `$effect`/
-  // `AbortController`/`setInterval` shape every sibling tab establishes
-  // (`SearchTab.svelte`, `WorkstreamActivity.svelte`). Embedded entries
-  // (`tier: "embedded"`) are read-only — badged, no remove button, matching
-  // `crate::agents::protocol`'s 403-on-embedded-delete contract. Disk-tier
-  // entries (`tier: "project"`/`"user"`) get a two-step inline confirm on
-  // remove — the SAME pattern `WorkstreamSwitcher.svelte`'s close-confirm
-  // establishes (no `window.confirm()`), including its post-#3392
-  // `resetRowState()` discipline: every armed row control is cleared on
-  // every list refresh and on add-panel toggle, so an armed confirm can
-  // never survive a stale-row reorder.
+  // **tcode's skill model is narrower than its agent model — reflected
+  // here, not papered over.** `crate::skills::protocol` recognises exactly
+  // TWO tiers: `"bundled"` (embedded, read-only — trusty-mpm's universal
+  // skill set) and `"project"` (`<project_root>/.claude/skills/<name>/
+  // SKILL.md`) — there is NO user-level `~/.claude/skills` tier the way
+  // agents has `~/.claude/agents` (see that module's docs for why). The add
+  // flow is therefore disabled with an explicit reason when the daemon is
+  // projectless, rather than silently failing on submit or inventing a
+  // tier tcode does not actually consume.
   //
-  // Add flow: a name field + a Markdown+frontmatter content editor
-  // (`<textarea>`), with an optional file picker that reads a chosen
-  // `.md` file's text into the same textarea (`FileReader`, progressive
-  // convenience — nothing here requires it). `createAgent` surfaces the
-  // daemon's exact error message (403 embedded collision, 409 already
-  // exists, 400 invalid name) inline rather than a generic failure.
+  // Polling/two-step-confirm shape mirrors `AgentsTab.svelte` exactly (see
+  // its module doc for the `resetRowState()`/`WorkstreamSwitcher.svelte`
+  // rationale) — described once there, not re-derived here.
   //
-  // Test: `AgentsTab.test.ts`.
+  // Test: `SkillsTab.test.ts`.
   import { apiBase } from '../lib/api-config';
   import {
-    createAgent,
-    deleteAgent,
-    fetchAgentRoster,
-    type AgentCatalogEntry,
-  } from '../lib/agent-roster';
+    createSkill,
+    deleteSkill,
+    fetchSkillRoster,
+    type SkillCatalogEntry,
+  } from '../lib/skill-roster';
 
   const POLL_MS = 5000;
 
   type Phase = 'connecting' | 'daemon-unreachable' | 'ready';
 
   let phase = $state<Phase>('connecting');
-  let agents = $state<AgentCatalogEntry[]>([]);
+  let skills = $state<SkillCatalogEntry[]>([]);
   let error = $state<string | null>(null);
+  let hasProject = $state(false);
 
   let addOpen = $state(false);
   let addName = $state('');
@@ -60,11 +53,27 @@
     return e instanceof Error ? e.message : String(e);
   }
 
-  /** Clears every armed row control — mirrors
-   * `WorkstreamSwitcher.svelte::resetRowState`'s post-#3392 discipline. */
   function resetRowState() {
     removeConfirmName = null;
     removeError = null;
+  }
+
+  /** `GET /sessions`' active session `project` field is the only
+   * daemon-owned "is a project bound" fact available today (same gap
+   * `App.svelte`'s own doc names for `isGitRepo`) — reused here purely to
+   * decide whether to disable the add flow, never to gate the tab's
+   * visibility (that's `nav-tabs.ts::tabVisibility`'s job). */
+  async function refreshProjectFlag(base: string, signal: AbortSignal) {
+    try {
+      const res = await fetch(`${base}/sessions`, { signal });
+      if (!res.ok) return;
+      const body = (await res.json()) as { sessions: Array<{ project: string | null }> };
+      if (signal.aborted) return;
+      hasProject = body.sessions.some((s) => s.project != null);
+    } catch {
+      // Non-fatal — the daemon-reachability state is already tracked by
+      // `refresh()`'s own try/catch; this flag just stays at its last value.
+    }
   }
 
   async function refresh(signal: AbortSignal) {
@@ -81,11 +90,12 @@
     if (signal.aborted) return;
 
     try {
-      const roster = await fetchAgentRoster(base, signal);
+      const roster = await fetchSkillRoster(base, signal);
       if (signal.aborted) return;
-      agents = roster;
+      skills = roster;
       phase = 'ready';
       error = null;
+      await refreshProjectFlag(base, signal);
     } catch (e) {
       if (!signal.aborted) {
         phase = 'daemon-unreachable';
@@ -127,12 +137,12 @@
   }
 
   async function submitAdd() {
-    if (addBusy || !addName.trim() || !addContent.trim()) return;
+    if (addBusy || !hasProject || !addName.trim() || !addContent.trim()) return;
     addBusy = true;
     addError = null;
     try {
       const base = await apiBase();
-      await createAgent(base, addName.trim(), addContent);
+      await createSkill(base, addName.trim(), addContent);
       addOpen = false;
       addName = '';
       addContent = '';
@@ -149,7 +159,7 @@
     removeBusy = true;
     try {
       const base = await apiBase();
-      await deleteAgent(base, name);
+      await deleteSkill(base, name);
       removeConfirmName = null;
       if (pollController) await refresh(pollController.signal);
     } catch (e) {
@@ -159,10 +169,8 @@
     }
   }
 
-  function tierLabel(tier: AgentCatalogEntry['tier']): string {
-    if (tier === 'embedded') return 'embedded · read-only';
-    if (tier === 'project') return 'project';
-    return 'user';
+  function tierLabel(tier: SkillCatalogEntry['tier']): string {
+    return tier === 'bundled' ? 'bundled · read-only' : 'project';
   }
 </script>
 
@@ -170,43 +178,52 @@
   <div
     class="flex items-center justify-between border-b border-trusty-border bg-trusty-raised px-4 py-2.5"
   >
-    <h2 class="font-display text-xs font-bold uppercase tracking-wide text-trusty-text">agents</h2>
+    <h2 class="font-display text-xs font-bold uppercase tracking-wide text-trusty-text">skills</h2>
     <button
       type="button"
       onclick={toggleAdd}
-      class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
+      disabled={!hasProject}
+      title={hasProject ? undefined : 'skills are project-scoped — bind a project to add one'}
+      class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary disabled:cursor-not-allowed disabled:opacity-50"
     >
-      {addOpen ? 'cancel' : '+ add agent'}
+      {addOpen ? 'cancel' : '+ add skill'}
     </button>
   </div>
 
   <div class="p-4">
+    {#if !hasProject}
+      <p class="mb-3 text-[11px] text-trusty-text-muted">
+        skills are project-scoped (no user-level tier) — bind a project to add or remove one; the
+        bundled catalog below is always available.
+      </p>
+    {/if}
+
     {#if addOpen}
       <div class="mb-4 rounded border-1.5 border-trusty-border bg-trusty-raised p-3">
         <label
           class="font-mono text-[10px] font-semibold uppercase tracking-wide text-trusty-text-muted"
-          for="agent-add-name"
+          for="skill-add-name"
         >
           name (lowercase, digits, hyphens)
         </label>
         <input
-          id="agent-add-name"
+          id="skill-add-name"
           bind:value={addName}
-          placeholder="my-custom-agent"
+          placeholder="my-custom-skill"
           class="mt-1 w-full rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card p-1.5 font-mono text-xs text-trusty-text"
         />
 
         <label
           class="mt-2 block font-mono text-[10px] font-semibold uppercase tracking-wide text-trusty-text-muted"
-          for="agent-add-content"
+          for="skill-add-content"
         >
-          content (Markdown + frontmatter)
+          SKILL.md content (Markdown + frontmatter)
         </label>
         <textarea
-          id="agent-add-content"
+          id="skill-add-content"
           bind:value={addContent}
           rows="8"
-          placeholder={'---\nname: my-custom-agent\ndescription: ...\n---\n\nSystem prompt body.'}
+          placeholder={'---\nname: my-custom-skill\ndescription: ...\n---\n\nSkill instructions.'}
           class="mt-1 w-full rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card p-1.5 font-mono text-xs text-trusty-text"
         ></textarea>
 
@@ -241,36 +258,36 @@
         <span class="h-1.5 w-1.5 rounded-full bg-status-error"></span>
         daemon unreachable{error ? ` — ${error}` : ''}
       </p>
-    {:else if agents.length === 0}
-      <p class="text-xs text-trusty-text-muted">no agents found</p>
+    {:else if skills.length === 0}
+      <p class="text-xs text-trusty-text-muted">no skills found</p>
     {:else}
       <ul class="flex flex-col gap-1.5">
-        {#each agents as agent (agent.name)}
+        {#each skills as skill (skill.name)}
           <li
             class="flex items-center justify-between gap-2 rounded-sm border-1.5 border-trusty-border px-2.5 py-1.5"
           >
             <div class="min-w-0 flex-1">
               <div class="flex items-center gap-2">
-                <span class="truncate font-mono text-xs text-trusty-text">{agent.name}</span>
+                <span class="truncate font-mono text-xs text-trusty-text">{skill.name}</span>
                 <span
                   class="shrink-0 rounded-sm border border-trusty-border-strong px-1 font-mono text-[9px] uppercase tracking-wide text-trusty-text-muted"
                 >
-                  {tierLabel(agent.tier)}
+                  {tierLabel(skill.tier)}
                 </span>
               </div>
-              {#if agent.description}
-                <p class="truncate text-[11px] text-trusty-text-secondary">{agent.description}</p>
+              {#if skill.description}
+                <p class="truncate text-[11px] text-trusty-text-secondary">{skill.description}</p>
               {/if}
             </div>
 
-            {#if agent.tier !== 'embedded'}
-              {#if removeConfirmName === agent.name}
+            {#if skill.tier !== 'bundled'}
+              {#if removeConfirmName === skill.name}
                 <div class="flex shrink-0 items-center gap-1.5">
                   <button
                     type="button"
                     class="font-mono text-[10px] uppercase tracking-wide text-status-error"
                     disabled={removeBusy}
-                    onclick={() => doRemove(agent.name)}
+                    onclick={() => doRemove(skill.name)}
                   >
                     confirm
                   </button>
@@ -287,8 +304,8 @@
                 <button
                   type="button"
                   class="shrink-0 px-1 font-mono text-[11px] text-trusty-text-muted hover:text-status-error"
-                  aria-label={`remove ${agent.name}`}
-                  onclick={() => (removeConfirmName = agent.name)}
+                  aria-label={`remove ${skill.name}`}
+                  onclick={() => (removeConfirmName = skill.name)}
                 >
                   ×
                 </button>

--- a/crates/trusty-code-gui/ui/src/components/SkillsTab.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/SkillsTab.test.ts
@@ -1,0 +1,190 @@
+// Why: issue #3449 — pins `SkillsTab.svelte`'s connection phases, bundled
+// vs project-tier badge/remove-button behavior, the two-step inline remove
+// confirm, the projectless add-flow lock (no user-level skill tier exists —
+// see `crate::skills::protocol`'s docs), and the add flow's error path.
+// What: Mounts the real component with `fetch` stubbed per phase.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+import SkillsTab from './SkillsTab.svelte';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+function normalizedText(): string {
+  return (target.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function skillsResponse(skills: unknown[]): Response {
+  return { ok: true, status: 200, json: async () => ({ skills }) } as Response;
+}
+
+function sessionsResponse(hasProject: boolean): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      sessions: hasProject ? [{ id: 's-1', status: 'running', project: '/repo' }] : [],
+    }),
+  } as Response;
+}
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+describe('SkillsTab', () => {
+  it('renders the connecting state before the first poll resolves', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise<Response>(() => {})));
+    instance = mount(SkillsTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('connecting') ?? false);
+    expect(target.textContent).toContain('connecting');
+  });
+
+  it('renders daemon-unreachable on a fetch failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    instance = mount(SkillsTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('daemon unreachable') ?? false);
+    expect(target.textContent).toContain('daemon unreachable');
+  });
+
+  it('renders bundled skills read-only, with no remove button, and locks the add flow projectless', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith('/skills')) {
+        return Promise.resolve(
+          skillsResponse([
+            { name: 'systematic-debugging', tier: 'bundled', description: 'Debug workflow' },
+          ]),
+        );
+      }
+      return Promise.resolve(sessionsResponse(false));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(SkillsTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => normalizedText().includes('systematic-debugging'));
+    expect(normalizedText()).toContain('bundled');
+    expect(target.querySelector('[aria-label="remove systematic-debugging"]')).toBeNull();
+
+    const addButton = Array.from(target.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('add skill'),
+    ) as HTMLButtonElement;
+    await waitFor(() => addButton.disabled === true);
+    expect(addButton.disabled).toBe(true);
+    expect(normalizedText()).toContain('project-scoped');
+  });
+
+  it('renders a remove button for a project-tier skill and arms two-step confirm', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith('/skills')) {
+        return Promise.resolve(
+          skillsResponse([{ name: 'my-skill', tier: 'project', description: '' }]),
+        );
+      }
+      return Promise.resolve(sessionsResponse(true));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    instance = mount(SkillsTab, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => normalizedText().includes('my-skill'));
+    const removeButton = target.querySelector('[aria-label="remove my-skill"]') as HTMLButtonElement;
+    expect(removeButton).not.toBeNull();
+
+    removeButton.click();
+    await waitFor(() => normalizedText().includes('confirm'));
+    expect(normalizedText()).toContain('never mind');
+  });
+
+  it('deletes on confirm and refreshes the list', async () => {
+    let deleted = false;
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url.endsWith('/skills') && (!init || init.method === undefined)) {
+        return Promise.resolve(
+          skillsResponse(
+            deleted ? [] : [{ name: 'my-skill', tier: 'project', description: '' }],
+          ),
+        );
+      }
+      if (init?.method === 'DELETE') {
+        deleted = true;
+        return Promise.resolve({ ok: true, status: 200 } as Response);
+      }
+      return Promise.resolve(sessionsResponse(true));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    instance = mount(SkillsTab, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => normalizedText().includes('my-skill'));
+
+    (target.querySelector('[aria-label="remove my-skill"]') as HTMLButtonElement).click();
+    await waitFor(() => normalizedText().includes('confirm'));
+    (Array.from(target.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'confirm') as HTMLButtonElement).click();
+
+    await waitFor(() => normalizedText().includes('no skills found'));
+    expect(normalizedText()).toContain('no skills found');
+  });
+
+  it('opens the add form (project bound) and surfaces the daemon error message on a 403 collision', async () => {
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 403,
+          json: async () => ({ error: { message: "'systematic-debugging' is a bundled skill" } }),
+        } as Response);
+      }
+      if (url.endsWith('/skills')) return Promise.resolve(skillsResponse([]));
+      return Promise.resolve(sessionsResponse(true));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    instance = mount(SkillsTab, { target }) as unknown as Record<string, unknown>;
+    await waitFor(() => normalizedText().includes('no skills found'));
+
+    const addButton = Array.from(target.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('add skill'),
+    ) as HTMLButtonElement;
+    await waitFor(() => addButton.disabled === false);
+    addButton.click();
+
+    await waitFor(() => target.querySelector('#skill-add-name') !== null);
+    const nameInput = target.querySelector('#skill-add-name') as HTMLInputElement;
+    const contentInput = target.querySelector('#skill-add-content') as HTMLTextAreaElement;
+    nameInput.value = 'systematic-debugging';
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+    contentInput.value = '---\nname: systematic-debugging\n---\n\nBody.\n';
+    contentInput.dispatchEvent(new Event('input', { bubbles: true }));
+
+    function createButton(): HTMLButtonElement | undefined {
+      return Array.from(target.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'create',
+      ) as HTMLButtonElement | undefined;
+    }
+    await waitFor(() => createButton() !== undefined && !createButton()!.disabled);
+    createButton()!.click();
+
+    await waitFor(() => normalizedText().includes('bundled skill'));
+    expect(normalizedText()).toContain('bundled skill');
+  });
+});

--- a/crates/trusty-code-gui/ui/src/components/StartWorkingForm.svelte
+++ b/crates/trusty-code-gui/ui/src/components/StartWorkingForm.svelte
@@ -119,6 +119,7 @@
   } from '../lib/new-workstream';
   import { clearPendingWorkstream, setPendingWorkstream } from '../lib/pending-workstream.svelte';
   import { selectedProjectState, selectProject } from '../lib/selected-project.svelte';
+  import { fetchAgentRoster, type AgentCatalogEntry } from '../lib/agent-roster';
   import ProjectPickerModal from './ProjectPickerModal.svelte';
 
   /** Delay between the two `activateWithRetry` attempts — see that
@@ -127,6 +128,14 @@
 
   let pickerOpen = $state(false);
   let task = $state('');
+
+  // Issue #3449 closes the "no pre-task agent roster endpoint" gap this
+  // form previously carried as a standing note (`GET /agents`,
+  // `lib/agent-roster.ts`). Fetched once on mount, best-effort — a failure
+  // just leaves the selector at its "daemon default" option, exactly the
+  // prior (only) behavior, rather than blocking the form.
+  let agentRoster = $state<AgentCatalogEntry[]>([]);
+  let selectedAgent = $state('');
 
   let submitPhase = $state<SubmitPhase>('idle');
   let submitError = $state<string | null>(null);
@@ -354,7 +363,7 @@
     let fallbackNotice: string | null = null;
 
     if (lastSessionId) {
-      const reuseBody = buildRunTaskBody(task, selectedProjectState.project, null, lastSessionId);
+      const reuseBody = buildRunTaskBody(task, selectedProjectState.project, null, lastSessionId, selectedAgent);
       const reuseRes = await fetch(`${base}/tasks`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -426,7 +435,13 @@
       return false;
     }
 
-    const fallbackBody = buildRunTaskBody(task, selectedProjectState.project, continuationWorkstreamId, null);
+    const fallbackBody = buildRunTaskBody(
+      task,
+      selectedProjectState.project,
+      continuationWorkstreamId,
+      null,
+      selectedAgent,
+    );
     const fallbackRes = await fetch(`${base}/tasks`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -515,7 +530,7 @@
     // below, in case activation ultimately fails again.
     setPendingWorkstream(workstreamId, workstreamName ?? inferWorkstreamName(selectedProjectState.project));
 
-    const body = buildRunTaskBody(task, selectedProjectState.project, workstreamId);
+    const body = buildRunTaskBody(task, selectedProjectState.project, workstreamId, null, selectedAgent);
     const res = await fetch(`${base}/tasks`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -571,7 +586,11 @@
       // Continuation applies whenever this conversation already targets a
       // session OR a workstream (the latter alone after the active
       // workstream changed under the form — HIGH 2's re-target adoption);
-      // only a form with neither mints a brand-new workstream.
+      // only a form with neither mints a brand-new workstream. Both paths
+      // thread `selectedAgent` (issue #3449) through to `buildRunTaskBody`
+      // — see `submitFirstMessage`/`submitContinuation`'s own call sites
+      // and `lib/new-workstream.ts::buildRunTaskBody`'s doc for why
+      // `agent_name` is sent on every call, not just the mint path.
       const ok =
         lastSessionId || continuationWorkstreamId
           ? await submitContinuation(base, controller.signal)
@@ -603,6 +622,26 @@
       submitController?.abort();
     };
   });
+
+  $effect(() => {
+    // One-shot, mount-only fetch of the agent catalog (issue #3449) — not
+    // polled, unlike the tab components' rosters: this form's selector only
+    // needs to be populated once before the operator submits, and a
+    // mid-session catalog edit does not need to reflow an in-progress form.
+    // Best-effort: any failure (daemon unreachable, etc.) just leaves the
+    // selector at its "daemon default" option — the prior, only behavior.
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const base = await apiBase();
+        const roster = await fetchAgentRoster(base, controller.signal);
+        if (!controller.signal.aborted) agentRoster = roster;
+      } catch {
+        // Non-fatal — see comment above.
+      }
+    })();
+    return () => controller.abort();
+  });
 </script>
 
 <div class="ibar shrink-0 border-t border-1.5 border-trusty-border bg-trusty-card p-3">
@@ -625,6 +664,28 @@
         clear
       </button>
     {/if}
+
+    <!-- Issue #3449's `GET /agents` roster selector, carried over into the
+         docked-bar layout (issue #3446/#3460) as a compact inline control
+         in the same status row as the project picker, rather than the
+         prior card layout's own labeled block — `selectedAgent` is threaded
+         through every `buildRunTaskBody` call site (mint, reuse, and
+         workstream-targeted fallback), so a pick here survives the whole
+         conversation, not just the first message. -->
+    <span class="font-mono uppercase tracking-wide text-trusty-text-muted">agent:</span>
+    <select
+      id="start-working-agent"
+      bind:value={selectedAgent}
+      title="GET /agents (issue #3449) — omitting this defers to the daemon's own default (DOC-39 §5.4), same as before this selector existed."
+      class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-raised px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-trusty-text-secondary"
+    >
+      <option value="">daemon default</option>
+      {#each agentRoster.filter((a) => a.tier !== 'broken') as agent (agent.name)}
+        <!-- `broken` entries (unparseable disk files, issue #3449 review)
+             are excluded: dispatching one is guaranteed to fail. -->
+        <option value={agent.name}>{agent.name} ({agent.tier})</option>
+      {/each}
+    </select>
   </div>
 
   <div class="mt-2 flex items-end gap-2">
@@ -645,13 +706,6 @@
       {submitPhase === 'submitting' ? 'sending…' : 'send'}
     </button>
   </div>
-
-  <p
-    class="mt-1.5 text-[11px] text-trusty-text-muted"
-    title="session.get_agents (GET /sessions/{'{'}id{'}'}/agents) requires an existing session — there is no pre-task AGENT roster route (distinct from this ticket's own project roster), so this form omits `agent_name` and the daemon applies its own default (DOC-39 §5.4)."
-  >
-    agent: daemon default — no pre-task agent roster endpoint exists yet
-  </p>
 
   {#if submitError}
     <p class="mt-1.5 text-xs text-status-error">{submitError}</p>

--- a/crates/trusty-code-gui/ui/src/components/StartWorkingForm.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/StartWorkingForm.test.ts
@@ -93,6 +93,12 @@ function fullSuccessFetch(opts?: { tasksBody?: unknown; callLog?: string[] }) {
     if (url.includes('/projects')) {
       return { ok: true, status: 200, json: async () => ROSTER } as Response;
     }
+    if (url.endsWith('/agents') && method === 'GET') {
+      // Issue #3449's mount-only agent-roster fetch (`lib/agent-roster.ts`)
+      // — this form never selects an agent by default, so an empty roster
+      // is a valid, uneventful response.
+      return { ok: true, status: 200, json: async () => ({ agents: [] }) } as Response;
+    }
     if (url.endsWith('/workstreams') && method === 'POST') {
       return { ok: true, status: 201, json: async () => ({ id: 'ws-abc123' }) } as Response;
     }
@@ -281,7 +287,10 @@ describe('StartWorkingForm submit sequence', () => {
     submitButton().click();
     await waitFor(() => target.textContent?.includes('started') ?? false);
 
-    expect(callLog).toEqual([
+    // Filters out the mount-only `GET /agents` roster fetch (issue #3449) —
+    // its timing relative to submit is not this test's concern; only the
+    // create -> run -> activate ORDER of the submit sequence itself is.
+    expect(callLog.filter((c) => c !== 'GET /agents')).toEqual([
       'POST /workstreams',
       'POST /tasks',
       'POST /workstreams/ws-abc123/activate',
@@ -402,7 +411,9 @@ describe('StartWorkingForm submit sequence', () => {
     // The error names the already-created workstream (HIGH finding: the
     // operator must know it exists, not just that the task failed).
     expect(target.textContent).toContain('was created but not activated');
-    expect(callLog).toEqual(['POST /workstreams', 'POST /tasks']);
+    // Filters out the mount-only `GET /agents` roster fetch (issue #3449) —
+    // see the identical note in the create->run->activate order test above.
+    expect(callLog.filter((c) => c !== 'GET /agents')).toEqual(['POST /workstreams', 'POST /tasks']);
     expect(callLog.some((c) => c.includes('/activate'))).toBe(false);
 
     // Retry: must reuse the SAME workstream id — no second POST

--- a/crates/trusty-code-gui/ui/src/lib/agent-roster.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/agent-roster.test.ts
@@ -1,0 +1,125 @@
+// Why: `lib/agent-roster.ts` carries every network call `AgentsTab.svelte`
+// and `StartWorkingForm.svelte`'s agent selector depend on — covering it
+// here means the wire-shape/error-mapping invariants are checked without
+// mounting Svelte, mirroring `workstreams.test.ts`'s split.
+// What: One `describe` block per exported function; network calls are
+// exercised against a stubbed global `fetch` (`vi.stubGlobal`), matching
+// `workstreams.test.ts`'s existing stubbing convention.
+// Test: this file.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  agentApiErrorMessage,
+  createAgent,
+  deleteAgent,
+  fetchAgentRoster,
+  type AgentCatalogEntry,
+} from './agent-roster';
+
+const BASE = 'http://127.0.0.1:7882';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function entry(overrides: Partial<AgentCatalogEntry> = {}): AgentCatalogEntry {
+  return {
+    name: 'engineer',
+    tier: 'embedded',
+    description: 'Generalist implementation agent',
+    model: null,
+    ...overrides,
+  };
+}
+
+describe('fetchAgentRoster', () => {
+  it('GETs /agents and returns the parsed entries', async () => {
+    const agents = [entry(), entry({ name: 'my-agent', tier: 'project' })];
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ agents }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchAgentRoster(BASE);
+    expect(result).toEqual(agents);
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE}/agents`, { signal: undefined });
+  });
+
+  it('throws with the daemon error message on a non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: { message: 'boom' } }),
+      }),
+    );
+    await expect(fetchAgentRoster(BASE)).rejects.toThrow('boom');
+  });
+});
+
+describe('createAgent', () => {
+  it('POSTs {name, content} to /agents and returns the created entry', async () => {
+    const created = entry({ name: 'my-agent', tier: 'project' });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 201, json: async () => created });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await createAgent(BASE, 'my-agent', '---\nname: my-agent\n---\n\nBody.\n');
+    expect(result).toEqual(created);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE}/agents`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ name: 'my-agent', content: '---\nname: my-agent\n---\n\nBody.\n' }),
+      }),
+    );
+  });
+
+  it('throws with the daemon error message on a 403 embedded-name collision', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        json: async () => ({ error: { message: "'engineer' is an embedded agent" } }),
+      }),
+    );
+    await expect(createAgent(BASE, 'engineer', 'x')).rejects.toThrow('embedded agent');
+  });
+});
+
+describe('deleteAgent', () => {
+  it('DELETEs /agents/{name}', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await deleteAgent(BASE, 'my-agent');
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE}/agents/my-agent`, { method: 'DELETE' });
+  });
+
+  it('URL-encodes the name', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await deleteAgent(BASE, 'weird name');
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE}/agents/weird%20name`, { method: 'DELETE' });
+  });
+
+  it('throws with the daemon error message on a 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: { message: 'no disk agent named' } }),
+      }),
+    );
+    await expect(deleteAgent(BASE, 'totally-bogus')).rejects.toThrow('no disk agent named');
+  });
+});
+
+describe('agentApiErrorMessage', () => {
+  it('falls back to a bare HTTP status when the body is malformed', async () => {
+    const res = { status: 502, json: async () => { throw new Error('not json'); } } as unknown as Response;
+    await expect(agentApiErrorMessage(res)).resolves.toBe('HTTP 502');
+  });
+});

--- a/crates/trusty-code-gui/ui/src/lib/agent-roster.ts
+++ b/crates/trusty-code-gui/ui/src/lib/agent-roster.ts
@@ -23,10 +23,14 @@
 //
 // Test: `agent-roster.test.ts`.
 
-/** Mirrors `crate::agents::protocol`'s per-entry wire shape. */
+/** Mirrors `crate::agents::protocol`'s per-entry wire shape. `"broken"`
+ * marks a disk file that failed to parse — dispatch of that name will fail
+ * until it is fixed or deleted (`agents_list`'s docs; code-critic PR #3465
+ * review, MEDIUM), so it is disk-tier for management purposes (removable)
+ * but must never render as a healthy embedded/dispatchable entry. */
 export interface AgentCatalogEntry {
   name: string;
-  tier: 'embedded' | 'project' | 'user';
+  tier: 'embedded' | 'project' | 'user' | 'broken';
   description: string | null;
   model: string | null;
 }

--- a/crates/trusty-code-gui/ui/src/lib/agent-roster.ts
+++ b/crates/trusty-code-gui/ui/src/lib/agent-roster.ts
@@ -1,0 +1,93 @@
+// Why: issue #3449 — the Foundry GUI's Agents tab needs the daemon's full
+// agent catalog (embedded ∪ disk, `crate::agents::protocol`) plus add/remove
+// over the disk tier, and `StartWorkingForm.svelte` has carried a standing
+// gap note since #3384/#3437 ("agent: daemon default — no pre-task agent
+// roster endpoint exists yet") because no such endpoint existed. `GET
+// /agents` (this ticket) closes that gap for BOTH callers — this module is
+// the one wire-shape + transport layer both `AgentsTab.svelte` (full
+// CRUD) and `StartWorkingForm.svelte`'s optional agent selector (list-only)
+// share, mirroring `lib/workstreams.ts`'s split of network calls out of the
+// component.
+//
+// What: `AgentCatalogEntry` mirrors `crate::agents::protocol::entry_json`'s
+// wire shape field-for-field (`tier` is `"embedded" | "project" | "user"`).
+// `fetchAgentRoster`/`createAgent`/`deleteAgent` are thin `fetch()` wrappers
+// over the unprefixed `/agents*` REST routes
+// (`crate::serve::rest::agent_catalog`) — no local caching, no derived
+// state, matching every other `lib/*.ts` transport module in this crate.
+// `createAgent`/`deleteAgent` surface the daemon's REST error envelope
+// message (`{error: {message}}`) via `agentApiErrorMessage`, mirroring
+// `StartWorkingForm.svelte`'s inline `errorMessage` helper — extracted here
+// so both this module's own error paths and any future caller format
+// daemon errors identically.
+//
+// Test: `agent-roster.test.ts`.
+
+/** Mirrors `crate::agents::protocol`'s per-entry wire shape. */
+export interface AgentCatalogEntry {
+  name: string;
+  tier: 'embedded' | 'project' | 'user';
+  description: string | null;
+  model: string | null;
+}
+
+/** `GET /agents` response envelope. */
+export interface AgentCatalogResponse {
+  agents: AgentCatalogEntry[];
+}
+
+/**
+ * Parse a REST error envelope's `error.message`, falling back to a bare HTTP
+ * status when the body is missing/malformed — mirrors
+ * `StartWorkingForm.svelte`'s identical inline helper.
+ * Test: `agent-roster.test.ts::agentApiErrorMessage`.
+ */
+export async function agentApiErrorMessage(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: { message?: string } } | null;
+  return body?.error?.message ?? `HTTP ${res.status}`;
+}
+
+/**
+ * `GET /agents` — the full embedded ∪ disk agent catalog.
+ * Test: `agent-roster.test.ts::fetchAgentRoster`.
+ */
+export async function fetchAgentRoster(
+  base: string,
+  signal?: AbortSignal,
+): Promise<AgentCatalogEntry[]> {
+  const res = await fetch(`${base}/agents`, { signal });
+  if (!res.ok) throw new Error(await agentApiErrorMessage(res));
+  const body = (await res.json()) as AgentCatalogResponse;
+  return body.agents;
+}
+
+/**
+ * `POST /agents` — create a disk-tier agent from a Markdown+frontmatter
+ * body. Throws with the daemon's error message on any non-`201` (e.g. a
+ * `403` embedded-name collision, a `409` already-exists conflict).
+ * Test: `agent-roster.test.ts::createAgent`.
+ */
+export async function createAgent(
+  base: string,
+  name: string,
+  content: string,
+): Promise<AgentCatalogEntry> {
+  const res = await fetch(`${base}/agents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, content }),
+  });
+  if (res.status !== 201) throw new Error(await agentApiErrorMessage(res));
+  return (await res.json()) as AgentCatalogEntry;
+}
+
+/**
+ * `DELETE /agents/{name}` — remove a disk-tier agent. Throws with the
+ * daemon's error message on any non-`200` (e.g. a `403` for an embedded
+ * name, a `404` for an unknown one).
+ * Test: `agent-roster.test.ts::deleteAgent`.
+ */
+export async function deleteAgent(base: string, name: string): Promise<void> {
+  const res = await fetch(`${base}/agents/${encodeURIComponent(name)}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(await agentApiErrorMessage(res));
+}

--- a/crates/trusty-code-gui/ui/src/lib/nav-tabs.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/nav-tabs.test.ts
@@ -10,11 +10,12 @@ import { describe, expect, it } from 'vitest';
 import { NAV_TABS, tabVisibility, type TabId } from './nav-tabs';
 
 describe('NAV_TABS catalog', () => {
-  it('is the 7 canonical tabs, in order', () => {
+  it('is the 8 canonical tabs, in order (skills added by issue #3449)', () => {
     expect(NAV_TABS.map((t) => t.id)).toEqual([
       'workstream',
       'project',
       'agents',
+      'skills',
       'memory',
       'search',
       'workflow',
@@ -29,15 +30,15 @@ describe('tabVisibility', () => {
     expect(tabVisibility('workstream', true, true)).toEqual({ visible: true, locked: false });
   });
 
-  it('project-scoped tabs (e.g. project/agents/memory/search/files) are locked, not hidden, when projectless', () => {
-    const scoped: TabId[] = ['project', 'agents', 'memory', 'search', 'files'];
+  it('project-scoped tabs (e.g. project/agents/skills/memory/search/files) are locked, not hidden, when projectless', () => {
+    const scoped: TabId[] = ['project', 'agents', 'skills', 'memory', 'search', 'files'];
     for (const tab of scoped) {
       expect(tabVisibility(tab, false, false)).toEqual({ visible: true, locked: true });
     }
   });
 
   it('project-scoped tabs unlock once a project is bound, regardless of git-ness', () => {
-    const scoped: TabId[] = ['project', 'agents', 'memory', 'search', 'files'];
+    const scoped: TabId[] = ['project', 'agents', 'skills', 'memory', 'search', 'files'];
     for (const tab of scoped) {
       expect(tabVisibility(tab, true, false)).toEqual({ visible: true, locked: false });
       expect(tabVisibility(tab, true, true)).toEqual({ visible: true, locked: false });

--- a/crates/trusty-code-gui/ui/src/lib/nav-tabs.ts
+++ b/crates/trusty-code-gui/ui/src/lib/nav-tabs.ts
@@ -14,23 +14,46 @@
 // so `ServiceNav.svelte` has nothing to unit-test around — the component
 // only renders what this function returns.
 //
-// What: `NAV_TABS` is the fixed, ordered 7-tab catalog. `tabVisibility`
+// `skills` is an 8th tab ADDED by issue #3449 (DOC-39 amendment) — Bob:
+// "Also add a 'Skills' tab along with 'Agents', and the user should have the
+// ability to add/remove both." Placed immediately after `agents` (the two
+// are siblings: both are catalog-management tabs over a disk-tier +
+// embedded/bundled roster). It follows the SAME default `tabVisibility`
+// branch every non-`workstream`/`workflow` tab already uses (locked, not
+// hidden, when no project is bound) — consistent with `agents` itself, even
+// though `GET /skills` happens to still return the bundled catalog
+// projectless; the CREATE/DELETE half of the tab genuinely needs a bound
+// project (`crate::skills::protocol` has no user-level tier — see that
+// module's docs), so locking the whole tab until a project is bound is the
+// simpler, honest default rather than a tab that half-works.
+//
+// What: `NAV_TABS` is the fixed, ordered 8-tab catalog. `tabVisibility`
 // returns whether a given tab should render at all (`visible`) and, if so,
 // whether it should render disabled (`locked`).
 // Test: `nav-tabs.test.ts`.
 
-export type TabId = 'workstream' | 'project' | 'agents' | 'memory' | 'search' | 'workflow' | 'files';
+export type TabId =
+  | 'workstream'
+  | 'project'
+  | 'agents'
+  | 'skills'
+  | 'memory'
+  | 'search'
+  | 'workflow'
+  | 'files';
 
 export interface TabDef {
   id: TabId;
   label: string;
 }
 
-/** The 7 canonical service-nav tabs, in display order (brief: 9a/9b/10d/10e/11b). */
+/** The 8 canonical service-nav tabs, in display order (brief:
+ * 9a/9b/10d/10e/11b, `skills` added by issue #3449). */
 export const NAV_TABS: readonly TabDef[] = [
   { id: 'workstream', label: 'Workstream' },
   { id: 'project', label: 'Project' },
   { id: 'agents', label: 'Agents' },
+  { id: 'skills', label: 'Skills' },
   { id: 'memory', label: 'Memory' },
   { id: 'search', label: 'Search' },
   { id: 'workflow', label: 'Workflow' },

--- a/crates/trusty-code-gui/ui/src/lib/new-workstream.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/new-workstream.test.ts
@@ -110,7 +110,7 @@ describe('buildRunTaskBody', () => {
     });
   });
 
-  it('issue #3446: includes project alongside session_id (restating a reused session\'s own binding is valid)', () => {
+  it("issue #3446: includes project alongside session_id (restating a reused session's own binding is valid)", () => {
     expect(buildRunTaskBody('follow-up', GIT_PROJECT, null, 'sess-abc')).toEqual({
       task_description: 'follow-up',
       project: '/Users/bob/code/acme-api',
@@ -133,9 +133,32 @@ describe('buildRunTaskBody', () => {
     });
   });
 
-  it('never sends agent_name (no pre-session agent roster route, see module doc)', () => {
+  it('omits agent_name when not passed (daemon default, unchanged pre-#3449 behavior)', () => {
     const body = buildRunTaskBody('t', GIT_PROJECT, 'ws-1');
     expect('agent_name' in body).toBe(false);
+  });
+
+  it('includes agent_name when explicitly selected (issue #3449), alongside workstream_id', () => {
+    expect(buildRunTaskBody('t', GIT_PROJECT, 'ws-1', null, 'rust-engineer')).toEqual({
+      task_description: 't',
+      project: '/Users/bob/code/acme-api',
+      workstream_id: 'ws-1',
+      agent_name: 'rust-engineer',
+    });
+  });
+
+  it("includes agent_name alongside session_id too (issue #3449 + #3446: a resumed session's per-run agent must not silently reset to the daemon default)", () => {
+    expect(buildRunTaskBody('follow-up', null, null, 'sess-abc', 'rust-engineer')).toEqual({
+      task_description: 'follow-up',
+      session_id: 'sess-abc',
+      agent_name: 'rust-engineer',
+    });
+  });
+
+  it('omits agent_name when undefined, null, or empty (the "daemon default" selector option)', () => {
+    expect(buildRunTaskBody('t', null, null, null, undefined)).toEqual({ task_description: 't' });
+    expect(buildRunTaskBody('t', null, null, null, null)).toEqual({ task_description: 't' });
+    expect(buildRunTaskBody('t', null, null, null, '')).toEqual({ task_description: 't' });
   });
 });
 

--- a/crates/trusty-code-gui/ui/src/lib/new-workstream.ts
+++ b/crates/trusty-code-gui/ui/src/lib/new-workstream.ts
@@ -88,17 +88,26 @@ export interface CreateWorkstreamBody {
 }
 
 /** Request body for `POST /tasks`, mirroring
- * `crate::serve::rest::tasks::RunTaskBody` minus `agent_name` (see the
- * module doc's carried-over gap note from `create-session.ts` — this form
- * still never sends `agent_name`; there is no pre-session roster route for
- * it, distinct from this ticket's own project roster). `session_id` is
- * issue #3446's chat-continuation addition — see [`buildRunTaskBody`]'s own
- * doc for why it and `workstream_id` are mutually exclusive on the wire. */
+ * `crate::serve::rest::tasks::RunTaskBody`. `session_id` is issue #3446's
+ * chat-continuation addition — see [`buildRunTaskBody`]'s own doc for why
+ * it and `workstream_id` are mutually exclusive on the wire. `agent_name`
+ * is optional and omitted unless the caller explicitly picks one — issue
+ * #3449 closed the "no pre-session roster route" gap this module's doc
+ * previously carried (`GET /agents`, `lib/agent-roster.ts`), so
+ * `StartWorkingForm.svelte` can now offer a selector; omitting the field
+ * still means "daemon default" exactly as before (`task::protocol`'s own
+ * `agent_name` default, #3437). Unlike `session_id`/`workstream_id`,
+ * `agent_name` is NOT exclusive with either — `task::protocol::task_run`
+ * applies it per-CALL, not just at session mint, so it is sent alongside a
+ * `session_id` reuse too (see [`buildRunTaskBody`]'s doc): otherwise a
+ * resumed session's per-run agent would silently reset to the daemon
+ * default on every follow-up turn. */
 export interface RunTaskBody {
   task_description: string;
   project?: string;
   workstream_id?: string;
   session_id?: string;
+  agent_name?: string;
 }
 
 /** Whether the create-workstream submit control may be enabled. */
@@ -147,26 +156,35 @@ export function buildCreateWorkstreamBody(name: string): CreateWorkstreamBody {
  * Build the `POST /tasks` request body from form state.
  *
  * Why: the single place task text is trimmed and the optional project/
- * workstream/session bindings are attached — kept out of the component so
- * it's testable without mounting Svelte (carried over from
- * `create-session.ts`, extended with `workstream_id` for issue #3365, then
- * `session_id` for issue #3446's chat continuation).
+ * workstream/session/agent bindings are attached — kept out of the
+ * component so it's testable without mounting Svelte (carried over from
+ * `create-session.ts`, extended with `workstream_id` for issue #3365,
+ * `session_id` for issue #3446's chat continuation, and `agentName` for
+ * issue #3449).
  * What: `task_description` is trimmed; `project` is included whenever a
  * project is selected — on BOTH the mint path and the continuation path,
  * since `task.run` treats a per-call `project` that RESTATES a reused
  * session's own persisted binding as valid (`task::protocol::task_run`'s
  * docs: "project may only restate it, not change it"), so there is no need
  * to omit it just because `sessionId` is also present.
- * `sessionId` and `workstreamId` are MUTUALLY EXCLUSIVE on the wire —
- * when `sessionId` is passed (a chat-continuation follow-up reusing an
- * existing session), `workstream_id` is deliberately never sent alongside
- * it: `task::protocol::task_run`'s docs are explicit that on the reuse path
+ * `sessionId` and `workstreamId` are MUTUALLY EXCLUSIVE on the wire — when
+ * `sessionId` is passed (a chat-continuation follow-up reusing an existing
+ * session), `workstream_id` is deliberately never sent alongside it:
+ * `task::protocol::task_run`'s docs are explicit that on the reuse path
  * "`None` here never rejects: ambient default-targeting (§4.2) applies only
  * at a session's FIRST binding, never re-applied on reuse" — the reused
  * session's own persisted workstream binding is already authoritative, so
  * restating it explicitly would be redundant at best. `workstreamId` is
- * only ever sent on the MINT path (`sessionId` absent). `agent_name` is
- * never sent (see the module doc's gap note).
+ * only ever sent on the MINT path (`sessionId` absent).
+ * `agentName` is NOT exclusive with either, unlike `sessionId`/
+ * `workstreamId` — it is included whenever passed and non-empty regardless
+ * of which of those two is set, because `task::protocol::task_run` applies
+ * `agent_name` per-CALL (`spawn_task_run`'s `task_params.agent_name`), not
+ * only at session mint; omitting it on a `sessionId` reuse call would
+ * silently reset a resumed conversation's per-run agent back to the daemon
+ * default on every follow-up turn. An omitted/empty `agentName` (the
+ * selector's "daemon default" option) means the daemon applies its own
+ * default exactly as before issue #3449.
  * Test: `new-workstream.test.ts::buildRunTaskBody`.
  */
 export function buildRunTaskBody(
@@ -174,6 +192,7 @@ export function buildRunTaskBody(
   project: ProjectSelection | null,
   workstreamId?: string | null,
   sessionId?: string | null,
+  agentName?: string | null,
 ): RunTaskBody {
   const body: RunTaskBody = { task_description: task.trim() };
   if (project) body.project = project.path;
@@ -182,6 +201,7 @@ export function buildRunTaskBody(
   } else if (workstreamId) {
     body.workstream_id = workstreamId;
   }
+  if (agentName) body.agent_name = agentName;
   return body;
 }
 

--- a/crates/trusty-code-gui/ui/src/lib/skill-roster.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/skill-roster.test.ts
@@ -1,0 +1,112 @@
+// Why: `lib/skill-roster.ts` carries every network call `SkillsTab.svelte`
+// depends on — mirrors `agent-roster.test.ts`'s coverage shape for the
+// sibling tab.
+// Test: this file.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createSkill,
+  deleteSkill,
+  fetchSkillRoster,
+  skillApiErrorMessage,
+  type SkillCatalogEntry,
+} from './skill-roster';
+
+const BASE = 'http://127.0.0.1:7882';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function entry(overrides: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry {
+  return {
+    name: 'systematic-debugging',
+    tier: 'bundled',
+    description: 'Step-by-step debugging workflow',
+    ...overrides,
+  };
+}
+
+describe('fetchSkillRoster', () => {
+  it('GETs /skills and returns the parsed entries', async () => {
+    const skills = [entry(), entry({ name: 'my-skill', tier: 'project' })];
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ skills }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await fetchSkillRoster(BASE);
+    expect(result).toEqual(skills);
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE}/skills`, { signal: undefined });
+  });
+
+  it('throws with the daemon error message on a non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: { message: 'boom' } }),
+      }),
+    );
+    await expect(fetchSkillRoster(BASE)).rejects.toThrow('boom');
+  });
+});
+
+describe('createSkill', () => {
+  it('POSTs {name, content} to /skills and returns the created entry', async () => {
+    const created = entry({ name: 'my-skill', tier: 'project' });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ ok: true, status: 201, json: async () => created });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await createSkill(BASE, 'my-skill', '---\nname: my-skill\n---\n\nBody.\n');
+    expect(result).toEqual(created);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE}/skills`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ name: 'my-skill', content: '---\nname: my-skill\n---\n\nBody.\n' }),
+      }),
+    );
+  });
+
+  it('throws with the daemon error message on a 400 projectless rejection', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: { message: 'skills are project-scoped' } }),
+      }),
+    );
+    await expect(createSkill(BASE, 'my-skill', 'x')).rejects.toThrow('project-scoped');
+  });
+});
+
+describe('deleteSkill', () => {
+  it('DELETEs /skills/{name}', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await deleteSkill(BASE, 'my-skill');
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE}/skills/my-skill`, { method: 'DELETE' });
+  });
+
+  it('throws with the daemon error message on a 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        json: async () => ({ error: { message: 'no disk skill named' } }),
+      }),
+    );
+    await expect(deleteSkill(BASE, 'totally-bogus')).rejects.toThrow('no disk skill named');
+  });
+});
+
+describe('skillApiErrorMessage', () => {
+  it('falls back to a bare HTTP status when the body is malformed', async () => {
+    const res = { status: 502, json: async () => { throw new Error('not json'); } } as unknown as Response;
+    await expect(skillApiErrorMessage(res)).resolves.toBe('HTTP 502');
+  });
+});

--- a/crates/trusty-code-gui/ui/src/lib/skill-roster.ts
+++ b/crates/trusty-code-gui/ui/src/lib/skill-roster.ts
@@ -1,0 +1,85 @@
+// Why: issue #3449 — the Foundry GUI's Skills tab needs the daemon's full
+// skill catalog (bundled ∪ project-disk, `crate::skills::protocol`) plus
+// add/remove over the project-disk tier. Mirrors `lib/agent-roster.ts`'s
+// shape exactly — the two tabs are siblings — but the wire values differ:
+// tcode's skill model recognises exactly TWO tiers (`"bundled"` and
+// `"project"` — NEVER `"user"`; see `crate::skills::protocol`'s module docs
+// for why there is no user-level skills directory the way agents has one),
+// so `SkillCatalogEntry['tier']` is narrower than `AgentCatalogEntry['tier']`
+// on purpose, not an oversight.
+//
+// What: `SkillCatalogEntry` mirrors `crate::skills::protocol::entry_json`'s
+// wire shape. `fetchSkillRoster`/`createSkill`/`deleteSkill` are thin
+// `fetch()` wrappers over the unprefixed `/skills*` REST routes
+// (`crate::serve::rest::skill_catalog`).
+//
+// Test: `skill-roster.test.ts`.
+
+/** Mirrors `crate::skills::protocol`'s per-entry wire shape. */
+export interface SkillCatalogEntry {
+  name: string;
+  tier: 'bundled' | 'project';
+  description: string;
+}
+
+/** `GET /skills` response envelope. */
+export interface SkillCatalogResponse {
+  skills: SkillCatalogEntry[];
+}
+
+/**
+ * Parse a REST error envelope's `error.message`, falling back to a bare HTTP
+ * status when the body is missing/malformed — mirrors
+ * `lib/agent-roster.ts::agentApiErrorMessage`.
+ * Test: `skill-roster.test.ts::skillApiErrorMessage`.
+ */
+export async function skillApiErrorMessage(res: Response): Promise<string> {
+  const body = (await res.json().catch(() => null)) as { error?: { message?: string } } | null;
+  return body?.error?.message ?? `HTTP ${res.status}`;
+}
+
+/**
+ * `GET /skills` — the full bundled ∪ project-disk skill catalog. Works
+ * projectless too (bundled-only), matching `crate::skills::protocol::skills_list`.
+ * Test: `skill-roster.test.ts::fetchSkillRoster`.
+ */
+export async function fetchSkillRoster(
+  base: string,
+  signal?: AbortSignal,
+): Promise<SkillCatalogEntry[]> {
+  const res = await fetch(`${base}/skills`, { signal });
+  if (!res.ok) throw new Error(await skillApiErrorMessage(res));
+  const body = (await res.json()) as SkillCatalogResponse;
+  return body.skills;
+}
+
+/**
+ * `POST /skills` — create a project-disk skill from a Markdown+frontmatter
+ * `SKILL.md` body. Throws with the daemon's error message on any non-`201`
+ * (e.g. a `400` when projectless, a `403` bundled-name collision, a `409`
+ * already-exists conflict).
+ * Test: `skill-roster.test.ts::createSkill`.
+ */
+export async function createSkill(
+  base: string,
+  name: string,
+  content: string,
+): Promise<SkillCatalogEntry> {
+  const res = await fetch(`${base}/skills`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, content }),
+  });
+  if (res.status !== 201) throw new Error(await skillApiErrorMessage(res));
+  return (await res.json()) as SkillCatalogEntry;
+}
+
+/**
+ * `DELETE /skills/{name}` — remove a project-disk skill. Throws with the
+ * daemon's error message on any non-`200`.
+ * Test: `skill-roster.test.ts::deleteSkill`.
+ */
+export async function deleteSkill(base: string, name: string): Promise<void> {
+  const res = await fetch(`${base}/skills/${encodeURIComponent(name)}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(await skillApiErrorMessage(res));
+}

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Agent/Skill catalog management endpoints (issue #3449).** New `agents.*`/
+  `skills.*` JSON-RPC methods (`crate::agents::protocol`,
+  `crate::skills::protocol`) plus their REST twins — `GET`/`POST /agents`,
+  `DELETE /agents/{name}` and the `skills` equivalent
+  (`crate::serve::rest::agent_catalog`/`skill_catalog`) — back the Foundry
+  GUI's new Agents/Skills management tabs. `GET /agents` returns the union of
+  the embedded roster (32 agents incl. `pm`) and the resolved disk tier
+  (`project` when bound, `user` for `~/.claude/agents` when projectless),
+  disk overriding embedded by name; `POST`/`DELETE` manage the disk tier
+  only, refusing to shadow or delete an embedded name (`403`) and refusing
+  to overwrite an existing disk file (`409`). `GET /skills` returns the union
+  of the bundled catalog and a bound project's `.claude/skills/` — there is
+  no user-level skill tier (`crate::skills::protocol`'s docs explain why), so
+  `POST`/`DELETE /skills` require a bound project (`400` when projectless).
+  All names are validated against `[a-z0-9-]+` (also the path-traversal
+  guard).
+
 ### Changed
 
 - **`fs.list_projects` / `GET /projects` re-sourced from trusty-mpm's shared

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -25,7 +25,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   no user-level skill tier (`crate::skills::protocol`'s docs explain why), so
   `POST`/`DELETE /skills` require a bound project (`400` when projectless).
   All names are validated against `[a-z0-9-]+` (also the path-traversal
-  guard).
+  guard). **Code-critic PR #3465 review fixes (same-day, before merge):**
+  both creates now use an atomic `O_CREAT|O_EXCL` create
+  (`agents::protocol::write_new_file`) instead of an exists-then-write
+  pre-check, closing a TOCTOU race where two concurrent creates of the same
+  name could silently clobber each other (HIGH 1/HIGH 2); the 409 conflict
+  is minted as `-32009 already_exists` via a new `RpcError::already_exists`
+  constructor rather than reusing the workstreams' `-32008 active_conflict`
+  literal (LOW); and `agents.list` surfaces an unparseable disk file as
+  `tier: "broken"` instead of silently showing the shadowed embedded entry
+  as healthy — `resolve_agent`'s disk-wins rule means dispatch of that name
+  will fail, and the catalog must not misreport it (MEDIUM).
 
 ### Changed
 

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -20,13 +20,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (`project` when bound, `user` for `~/.claude/agents` when projectless),
   disk overriding embedded by name; `POST`/`DELETE` manage the disk tier
   only, refusing to shadow or delete an embedded name (`403`) and refusing
-  to overwrite an existing disk file (`409`). `GET /skills` returns the union
-  of the bundled catalog and a bound project's `.claude/skills/` — there is
-  no user-level skill tier (`crate::skills::protocol`'s docs explain why), so
-  `POST`/`DELETE /skills` require a bound project (`400` when projectless).
-  All names are validated against `[a-z0-9-]+` (also the path-traversal
-  guard). **Code-critic PR #3465 review fixes (same-day, before merge):**
-  both creates now use an atomic `O_CREAT|O_EXCL` create
+  to overwrite an existing disk file (`409`). `GET /skills` returns whatever
+  will ACTUALLY resolve for the project at `task.run` time — the bundled
+  catalog when the project has no (or an empty) `.claude/skills/`, or
+  EXCLUSIVELY that directory's entries once it has at least one, mirroring
+  `discover_skill_metadata`'s whole-catalog-replacement semantics rather
+  than a per-name overlay. There is no user-level skill tier
+  (`crate::skills::protocol`'s docs explain why), so `POST`/`DELETE /skills`
+  require a bound project (`400` when projectless). All names are validated
+  against `[a-z0-9-]+` (also the path-traversal guard).
+  **Code-critic PR #3465 review fixes (same-day, before merge):** both
+  creates now use an atomic `O_CREAT|O_EXCL` create
   (`agents::protocol::write_new_file`) instead of an exists-then-write
   pre-check, closing a TOCTOU race where two concurrent creates of the same
   name could silently clobber each other (HIGH 1/HIGH 2); the 409 conflict
@@ -36,6 +40,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `tier: "broken"` instead of silently showing the shadowed embedded entry
   as healthy — `resolve_agent`'s disk-wins rule means dispatch of that name
   will fail, and the catalog must not misreport it (MEDIUM).
+  **Code-critic PR #3465 RE-review fix:** `skills.list` was still doing a
+  per-name bundled ∪ disk overlay, unlike the corrected `agents.list` — so a
+  project with one custom skill reported all ~28 bundled skills as
+  available even though `FsSkillResolver` discards the entire bundled
+  catalog the moment disk has anything, making every bundled name
+  unresolvable at runtime. Fixed to match the resolver's actual
+  whole-catalog-replacement behavior (MEDIUM).
 
 ### Changed
 

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -30,6 +30,7 @@
 
 pub mod config;
 pub mod md_loader;
+pub mod protocol;
 
 pub use config::{
     AgentConfig, AgentInfo, LlmParams, RunnerConfig, RunnerKind, SystemPrompt, ToolsConfig,
@@ -176,7 +177,7 @@ pub fn load_all_agents(dir: &Path) -> Vec<AgentConfig> {
 /// Test: `load_all_agents_falls_back_to_embedded_when_disk_empty`,
 /// `assets::tests::default_agents_field_identical_to_retired_toml`,
 /// `assets::tests::default_agents_parse_and_names_match`.
-fn load_embedded_default_agents() -> Vec<AgentConfig> {
+pub(crate) fn load_embedded_default_agents() -> Vec<AgentConfig> {
     crate::assets::DEFAULT_AGENTS
         .iter()
         .filter_map(|embedded| match embedded {

--- a/crates/trusty-code/src/agents/protocol.rs
+++ b/crates/trusty-code/src/agents/protocol.rs
@@ -26,7 +26,10 @@
 //!     overriding an embedded name WINS and suppresses the embedded copy of
 //!     that name, mirroring [`super::resolve_agent`]'s disk-wins precedence
 //!     exactly (so the catalog never shows the same name twice with two
-//!     different tiers).
+//!     different tiers). An unparseable disk file surfaces as `tier:
+//!     "broken"` (see [`agents_list`]'s docs) — again mirroring
+//!     `resolve_agent`, whose disk-wins rule applies even to a malformed
+//!     file, so dispatch of that name fails rather than falling back.
 //!   - `agents.create{name, content}` -> writes
 //!     `<dir>/<name>.md` from the caller-supplied Markdown+frontmatter body.
 //!     Rejects (see [`validate_agent_name`]) a `name` that is empty, exceeds
@@ -34,7 +37,7 @@
 //!     collides with an EMBEDDED name (embedded is read-only — this endpoint
 //!     never lets a disk file silently shadow it) with `-32001
 //!     permission_denied` (403); an already-existing disk file of the same
-//!     name with a `-32008`-shaped "already exists" conflict (409, use
+//!     name with a `-32009 already_exists` conflict (409, use
 //!     delete-then-create to replace).
 //!   - `agents.delete{name}` -> removes `<dir>/<name>.md`. `-32002 not_found`
 //!     (404) if no disk file exists under that name; `-32001
@@ -145,13 +148,22 @@ fn entry_json(cfg: &AgentConfig, tier: &str) -> Value {
 /// Why: the GUI's Agents tab roster fetch — see module docs for the
 /// disk-wins-over-embedded union rule.
 /// What: ignores `params` (no filters yet). Builds the embedded set keyed by
-/// name, then overlays disk entries (skipping any disk `.md` that fails to
-/// parse, logged at WARN — mirrors `load_all_agents`'s graceful-skip
-/// convention), removing the embedded entry of the same name whenever a
-/// disk override exists. Sorted by name.
+/// name, then overlays disk entries, removing the embedded entry of the same
+/// name whenever a disk override exists. A disk `.md` that FAILS to parse is
+/// surfaced as `tier: "broken"` (description = the parse error, still
+/// overriding any embedded entry of the same name) rather than skipped —
+/// because [`super::resolve_agent`]'s disk-wins rule applies even to a
+/// malformed file ("a disk parse error is surfaced, never silently
+/// substituted", #3441), dispatch of that name WILL fail, and a catalog
+/// that skipped the broken file would show the shadowed embedded entry as
+/// healthy/dispatchable — lying about what `task.run` will actually do
+/// (code-critic PR #3465 review, MEDIUM). A broken entry keeps the delete
+/// affordance: removing the bad file is exactly the repair path. Sorted by
+/// name.
 /// Test: `tests::list_returns_embedded_when_disk_empty`,
 /// `tests::list_disk_override_wins_and_suppresses_embedded`,
-/// `tests::list_disk_only_entries_are_additive`.
+/// `tests::list_disk_only_entries_are_additive`,
+/// `tests::list_marks_unparseable_disk_override_as_broken`.
 async fn agents_list(
     state: &AgentsCatalogState,
     _params: Value,
@@ -163,17 +175,21 @@ async fn agents_list(
         .collect();
 
     for (name, path) in discover_agents(&state.dir) {
-        match md_loader::load_md_agent(&path) {
-            Ok(cfg) => {
-                let entry = entry_json(&cfg, state.tier);
-                match by_name.iter_mut().find(|(n, _)| *n == name) {
-                    Some(slot) => slot.1 = entry,
-                    None => by_name.push((name, entry)),
-                }
-            }
+        let entry = match md_loader::load_md_agent(&path) {
+            Ok(cfg) => entry_json(&cfg, state.tier),
             Err(e) => {
-                tracing::warn!("agents.list: skipping unparseable disk agent '{name}': {e}");
+                tracing::warn!("agents.list: disk agent '{name}' is unparseable: {e}");
+                json!({
+                    "name": name,
+                    "tier": "broken",
+                    "description": format!("unparseable agent file — dispatch of this name will fail until it is fixed or deleted: {e}"),
+                    "model": Value::Null,
+                })
             }
+        };
+        match by_name.iter_mut().find(|(n, _)| *n == name) {
+            Some(slot) => slot.1 = entry,
+            None => by_name.push((name, entry)),
         }
     }
 
@@ -231,12 +247,19 @@ pub(crate) fn validate_agent_name(name: &str) -> Result<(), RpcError> {
 /// `201 Created`, see `serve::rest::agent_catalog::create`). Errors: invalid
 /// `name` (`-32602`/`-32003`), `name` collides with an embedded agent
 /// (`-32001 permission_denied`, 403 — embedded is read-only), an existing
-/// disk file of the same name (`-32008`-shaped conflict, 409), or a
-/// write-side I/O failure (`-32603 internal`).
+/// disk file of the same name (`-32009 already_exists`, 409, use
+/// delete-then-create to replace), or a write-side I/O failure (`-32603
+/// internal`). The existence check is NOT a separate `path.exists()`
+/// pre-check — that was a TOCTOU hole (code-critic PR #3465 review, HIGH 1:
+/// two concurrent creates with the same name could both pass the check and
+/// the second would silently clobber the first, violating the documented
+/// 409 invariant). [`write_new_file`] makes the check-and-create a single
+/// atomic `O_CREAT|O_EXCL` filesystem operation instead.
 /// Test: `tests::create_writes_file_and_returns_tier`,
 /// `tests::create_rejects_invalid_name`,
 /// `tests::create_rejects_embedded_name_collision`,
-/// `tests::create_rejects_existing_disk_file`.
+/// `tests::create_rejects_existing_disk_file`,
+/// `tests::create_conflict_does_not_clobber_existing_content`.
 async fn agents_create(
     state: &AgentsCatalogState,
     params: Value,
@@ -258,21 +281,55 @@ async fn agents_create(
     }
 
     let path = agent_path(&state.dir, &p.name)?;
-    if path.exists() {
-        return Err(
-            RpcError::new(-32008, format!("agent '{}' already exists on disk", p.name))
-                .with_data(json!({"error_type": "already_exists"})),
-        );
-    }
-
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| RpcError::internal(format!("creating agents dir: {e}")))?;
     }
-    std::fs::write(&path, &p.content)
-        .map_err(|e| RpcError::internal(format!("writing agent file: {e}")))?;
+    write_new_file(&path, &p.content, || {
+        format!("agent '{}' already exists on disk", p.name)
+    })?;
 
     Ok(json!({ "name": p.name, "tier": state.tier }))
+}
+
+/// Atomically create `path` with `content`, failing with `-32009
+/// already_exists` if the file already exists — the ONE way both
+/// `agents.create` and `skills.create` materialise a new catalog file.
+///
+/// Why: a `path.exists()` pre-check followed by `std::fs::write` is a
+/// TOCTOU race — two concurrent creates can both pass the check, and the
+/// loser's `write` silently clobbers the winner (code-critic PR #3465
+/// review, HIGH 1/HIGH 2). `OpenOptions::create_new(true)` maps to
+/// `O_CREAT|O_EXCL`: the kernel makes existence-check-plus-create one
+/// atomic operation, so exactly one of N racing creates succeeds and every
+/// other receives `ErrorKind::AlreadyExists`, which this maps onto the same
+/// `409`-shaped conflict the pre-check used to (approximately) provide.
+/// What: `conflict_msg` is lazily built only on the conflict path. Any
+/// other I/O failure maps to `-32603 internal`.
+/// Test: `tests::create_rejects_existing_disk_file`,
+/// `tests::create_conflict_does_not_clobber_existing_content`,
+/// `crate::skills::protocol::tests::create_rejects_existing_disk_skill`.
+pub(crate) fn write_new_file(
+    path: &Path,
+    content: &str,
+    conflict_msg: impl FnOnce() -> String,
+) -> Result<(), RpcError> {
+    use std::io::Write;
+
+    let mut file = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Err(RpcError::already_exists(conflict_msg()));
+        }
+        Err(e) => return Err(RpcError::internal(format!("creating file: {e}"))),
+    };
+    file.write_all(content.as_bytes())
+        .map_err(|e| RpcError::internal(format!("writing file: {e}")))?;
+    Ok(())
 }
 
 /// `params` shape for `agents.delete`.
@@ -421,6 +478,35 @@ mod tests {
         );
     }
 
+    /// An unparseable disk file shadowing an embedded name must surface as
+    /// `tier: "broken"` — never as the healthy embedded entry, because
+    /// `resolve_agent`'s disk-wins rule means dispatch of that name WILL
+    /// fail (code-critic PR #3465 review, MEDIUM).
+    #[tokio::test]
+    async fn list_marks_unparseable_disk_override_as_broken() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // `extends:` naming a nonexistent parent makes `load_md_agent`'s
+        // compose step fail — the same failure `resolve_agent` would refuse
+        // to dispatch through.
+        std::fs::write(
+            tmp.path().join("engineer.md"),
+            "---\nname: engineer\nextends: nonexistent-parent\n---\n\nBody.\n",
+        )
+        .expect("write");
+        let s = state(tmp.path(), true);
+        let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+        let agents = result["agents"].as_array().expect("array");
+        let engineer_entries: Vec<_> = agents.iter().filter(|a| a["name"] == "engineer").collect();
+        assert_eq!(engineer_entries.len(), 1, "must appear exactly once");
+        assert_eq!(engineer_entries[0]["tier"], "broken");
+        assert!(
+            engineer_entries[0]["description"]
+                .as_str()
+                .expect("description")
+                .contains("unparseable"),
+        );
+    }
+
     #[tokio::test]
     async fn create_writes_file_and_returns_tier() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -485,7 +571,100 @@ mod tests {
         )
         .await
         .expect_err("must reject existing file");
-        assert_eq!(err.code, -32008);
+        // `-32009 already_exists` — NOT `-32008`, which is the workstreams'
+        // `active_conflict` slot (code-critic PR #3465 review, LOW).
+        assert_eq!(err.code, -32009);
+        assert_eq!(err.data.as_ref().unwrap()["error_type"], "already_exists");
+    }
+
+    /// The conflict path must go through `create_new` (`O_CREAT|O_EXCL`) —
+    /// meaning a losing create can NEVER have truncated or overwritten the
+    /// existing file's content, even transiently (code-critic PR #3465
+    /// review, HIGH 1: the prior `exists()`-then-`write` shape let the
+    /// second of two racing creates silently clobber the first).
+    #[tokio::test]
+    async fn create_conflict_does_not_clobber_existing_content() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let original = "---\nname: dup\ndescription: ORIGINAL\n---\n\nBody.\n";
+        std::fs::write(tmp.path().join("dup.md"), original).expect("write");
+        let s = state(tmp.path(), true);
+
+        let err = agents_create(&s, json!({"name": "dup", "content": "CLOBBER"}), ctx())
+            .await
+            .expect_err("must conflict");
+        assert_eq!(err.code, -32009);
+
+        let on_disk = std::fs::read_to_string(tmp.path().join("dup.md")).expect("read");
+        assert_eq!(on_disk, original, "existing content must be untouched");
+    }
+
+    /// `write_new_file` is the shared atomic-create seam — exercise the io
+    /// `AlreadyExists` mapping directly, without a handler in the way.
+    #[test]
+    fn write_new_file_maps_already_exists_io_error() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("f.md");
+        write_new_file(&path, "first", || "conflict".to_string()).expect("first create");
+        let err =
+            write_new_file(&path, "second", || "conflict".to_string()).expect_err("second create");
+        assert_eq!(err.code, -32009);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read"),
+            "first",
+            "loser must not touch the winner's content"
+        );
+    }
+
+    /// Genuine concurrency: N threads race `write_new_file` against the
+    /// SAME path at the same time. Exactly one must win; every other must
+    /// get `AlreadyExists` (mapped to `-32009`) — never a torn/mixed write
+    /// (code-critic PR #3465 review, HIGH 1/HIGH 2: the original
+    /// `exists()`-then-`write` shape had no such guarantee under real
+    /// concurrency, only under the sequential re-creation this module's
+    /// other tests exercise).
+    #[test]
+    fn write_new_file_concurrent_create_exactly_one_wins() {
+        use std::sync::{Arc, Barrier};
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = Arc::new(tmp.path().join("race.md"));
+        const N: usize = 16;
+        let barrier = Arc::new(Barrier::new(N));
+
+        let handles: Vec<_> = (0..N)
+            .map(|i| {
+                let path = Arc::clone(&path);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    write_new_file(&path, &format!("writer-{i}"), || "conflict".to_string())
+                        .map(|_| i)
+                })
+            })
+            .collect();
+
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|h| h.join().expect("thread"))
+            .collect();
+        let winners: Vec<_> = results.iter().filter(|r| r.is_ok()).collect();
+        let losers: Vec<_> = results.iter().filter(|r| r.is_err()).collect();
+
+        assert_eq!(winners.len(), 1, "exactly one racing create must win");
+        assert_eq!(losers.len(), N - 1, "every other racer must lose");
+        for loser in &losers {
+            let err = loser.as_ref().unwrap_err();
+            assert_eq!(
+                err.code, -32009,
+                "loser must get already_exists, not a torn write"
+            );
+        }
+
+        // The file on disk must be exactly the winner's untouched content —
+        // never a mix, truncation, or empty file from a lost race.
+        let winner_idx = *winners[0].as_ref().unwrap();
+        let on_disk = std::fs::read_to_string(path.as_path()).expect("read");
+        assert_eq!(on_disk, format!("writer-{winner_idx}"));
     }
 
     #[tokio::test]

--- a/crates/trusty-code/src/agents/protocol.rs
+++ b/crates/trusty-code/src/agents/protocol.rs
@@ -1,0 +1,544 @@
+//! `agents.*` JSON-RPC methods — the daemon's full-tier AGENT CATALOG
+//! surface (issue #3449), backing the Foundry GUI's Agents management tab.
+//!
+//! Why: distinct from `session.get_agents` (`crate::serve::rest::agents` /
+//! `crate::session::protocol_agents`), which answers "who is running (or
+//! ran) inside one existing session" — this module answers "what agents
+//! could I dispatch?", independent of any session. The GUI's Agents tab
+//! needs to list every agent across BOTH tiers `resolve_agent` already
+//! recognises (embedded ∪ disk — see [`super::resolve_agent`]'s docs) and
+//! let an operator add/remove disk-tier ones; the embedded roster (32
+//! agents incl. `pm`, #2958/#3437) is compiled in and therefore read-only.
+//! There is exactly ONE disk tier active at a time — `<binding
+//! root>/.claude/agents` when a project is bound, `~/.claude/agents`
+//! (Claude-Code's user-level convention) when projectless (see
+//! `crate::binding::ProjectBinding::agents_dir`) — so every disk entry this
+//! module reports carries the SAME tier label for one daemon instance,
+//! computed once at [`register`] time from how the daemon itself was
+//! started, never re-derived per request.
+//! What: [`register`] wires three methods onto a shared, immutable
+//! [`AgentsCatalogState`] (`dir` + `tier`, both fixed for the daemon's
+//! lifetime — no `Mutex` needed, every operation here is a stateless
+//! filesystem call):
+//!   - `agents.list` -> `{"agents": [{name, tier, description?, model?}]}`,
+//!     the union of the embedded roster (`tier: "embedded"`) and the
+//!     resolved disk tier (`tier: "project"` or `"user"`) — a disk agent
+//!     overriding an embedded name WINS and suppresses the embedded copy of
+//!     that name, mirroring [`super::resolve_agent`]'s disk-wins precedence
+//!     exactly (so the catalog never shows the same name twice with two
+//!     different tiers).
+//!   - `agents.create{name, content}` -> writes
+//!     `<dir>/<name>.md` from the caller-supplied Markdown+frontmatter body.
+//!     Rejects (see [`validate_agent_name`]) a `name` that is empty, exceeds
+//!     [`MAX_AGENT_NAME_LEN`], contains anything outside `[a-z0-9-]`, or
+//!     collides with an EMBEDDED name (embedded is read-only — this endpoint
+//!     never lets a disk file silently shadow it) with `-32001
+//!     permission_denied` (403); an already-existing disk file of the same
+//!     name with a `-32008`-shaped "already exists" conflict (409, use
+//!     delete-then-create to replace).
+//!   - `agents.delete{name}` -> removes `<dir>/<name>.md`. `-32002 not_found`
+//!     (404) if no disk file exists under that name; `-32001
+//!     permission_denied` (403) if `name` names an EMBEDDED agent (nothing
+//!     to delete on disk — the embedded roster cannot be removed).
+//!
+//! Test: `tests::*`.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::jsonrpc::{ConnectionContext, Router, RpcError};
+
+use super::{AgentConfig, discover_agents, load_embedded_default_agents, md_loader};
+
+/// Maximum length for a caller-supplied agent `name` in [`agents_create`].
+///
+/// Why: a generous but finite bound — long enough for any real agent slug,
+/// short enough to reject a pathological payload before it ever reaches the
+/// filesystem.
+const MAX_AGENT_NAME_LEN: usize = 64;
+
+/// Shared, immutable state every `agents.*` handler in this module closes
+/// over: the resolved disk agents directory and its tier label for this
+/// daemon instance.
+///
+/// Why: `dir`/`tier` are fixed for the daemon's entire lifetime (derived
+/// once from `ProjectBinding` at startup, see `crate::serve::build_router_at`)
+/// — no shared mutable state, no `Mutex`, unlike `WorkstreamStore`.
+/// What: `dir` is `ProjectBinding::agents_dir()`'s result; `tier` is
+/// `"project"` when a project is bound, `"user"` when projectless.
+#[derive(Clone)]
+pub struct AgentsCatalogState {
+    /// The resolved disk agents directory (project- or user-scoped).
+    pub dir: PathBuf,
+    /// `"project"` or `"user"` — which tier `dir` represents.
+    pub tier: &'static str,
+}
+
+impl AgentsCatalogState {
+    /// Build state from a resolved agents directory and whether a project
+    /// is bound.
+    ///
+    /// Why: keeps the "project bound -> tier project, else user" rule in one
+    /// place rather than re-deriving it at every call site that constructs
+    /// this state (today: `crate::serve::build_router_at`).
+    /// What: `tier = "project"` when `project_bound`, else `"user"`.
+    pub fn new(dir: PathBuf, project_bound: bool) -> Self {
+        Self {
+            dir,
+            tier: if project_bound { "project" } else { "user" },
+        }
+    }
+}
+
+/// Register `agents.list`, `agents.create`, `agents.delete` onto `router`.
+///
+/// Why: the one place listing this namespace's full surface, mirroring
+/// every other `*::protocol::register` in this crate.
+/// What: clones `state` once per method (cheap — `PathBuf` + `&'static
+/// str`) into a small adapter closure that forwards to the corresponding
+/// free function below.
+/// Test: `tests::register_wires_all_three_methods`.
+pub fn register(router: &mut Router, state: AgentsCatalogState) {
+    let s = state.clone();
+    router.register(
+        "agents.list",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { agents_list(&s, params, ctx).await }
+        },
+    );
+
+    let s = state.clone();
+    router.register(
+        "agents.create",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { agents_create(&s, params, ctx).await }
+        },
+    );
+
+    let s = state;
+    router.register(
+        "agents.delete",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { agents_delete(&s, params, ctx).await }
+        },
+    );
+}
+
+/// Wire shape for one catalog entry — shared by `agents.list`'s embedded and
+/// disk halves so the two are indistinguishable to a client beyond `tier`.
+fn entry_json(cfg: &AgentConfig, tier: &str) -> Value {
+    json!({
+        "name": cfg.agent.name,
+        "tier": tier,
+        "description": cfg.agent.description,
+        "model": cfg.agent.model,
+    })
+}
+
+/// `agents.list` -> the full embedded ∪ disk catalog.
+///
+/// Why: the GUI's Agents tab roster fetch — see module docs for the
+/// disk-wins-over-embedded union rule.
+/// What: ignores `params` (no filters yet). Builds the embedded set keyed by
+/// name, then overlays disk entries (skipping any disk `.md` that fails to
+/// parse, logged at WARN — mirrors `load_all_agents`'s graceful-skip
+/// convention), removing the embedded entry of the same name whenever a
+/// disk override exists. Sorted by name.
+/// Test: `tests::list_returns_embedded_when_disk_empty`,
+/// `tests::list_disk_override_wins_and_suppresses_embedded`,
+/// `tests::list_disk_only_entries_are_additive`.
+async fn agents_list(
+    state: &AgentsCatalogState,
+    _params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let mut by_name: Vec<(String, Value)> = load_embedded_default_agents()
+        .iter()
+        .map(|cfg| (cfg.agent.name.clone(), entry_json(cfg, "embedded")))
+        .collect();
+
+    for (name, path) in discover_agents(&state.dir) {
+        match md_loader::load_md_agent(&path) {
+            Ok(cfg) => {
+                let entry = entry_json(&cfg, state.tier);
+                match by_name.iter_mut().find(|(n, _)| *n == name) {
+                    Some(slot) => slot.1 = entry,
+                    None => by_name.push((name, entry)),
+                }
+            }
+            Err(e) => {
+                tracing::warn!("agents.list: skipping unparseable disk agent '{name}': {e}");
+            }
+        }
+    }
+
+    by_name.sort_by(|a, b| a.0.cmp(&b.0));
+    let agents: Vec<Value> = by_name.into_iter().map(|(_, v)| v).collect();
+    Ok(json!({ "agents": agents }))
+}
+
+/// `params` shape for `agents.create`.
+#[derive(Deserialize)]
+struct CreateParams {
+    name: String,
+    content: String,
+}
+
+/// Validate a caller-supplied agent/skill name against the shared naming
+/// contract (issue #3449): non-empty, `[a-z0-9-]` only, bounded length.
+///
+/// Why: this is ALSO the path-traversal guard — a name matching this
+/// pattern can never contain `/`, `..`, or any other path-breaking
+/// character, so `dir.join(format!("{name}.md"))` is always confined to
+/// `dir` by construction. Shared verbatim by `agents::protocol` and
+/// `skills::protocol` (issue #3449's paired endpoints) so the two surfaces
+/// can never drift into two different naming rules.
+/// What: `Err(RpcError::invalid_argument(..))` on any violation.
+/// Test: `tests::validate_name_rejects_empty`,
+/// `tests::validate_name_rejects_uppercase`,
+/// `tests::validate_name_rejects_path_traversal`,
+/// `tests::validate_name_rejects_too_long`,
+/// `tests::validate_name_accepts_lowercase_alnum_hyphen`.
+pub(crate) fn validate_agent_name(name: &str) -> Result<(), RpcError> {
+    if name.is_empty() {
+        return Err(RpcError::invalid_argument("name must not be empty"));
+    }
+    if name.len() > MAX_AGENT_NAME_LEN {
+        return Err(RpcError::invalid_argument(format!(
+            "name must be at most {MAX_AGENT_NAME_LEN} characters"
+        )));
+    }
+    if !name
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err(RpcError::invalid_argument(
+            "name must match [a-z0-9-]+ (lowercase letters, digits, hyphens only)",
+        ));
+    }
+    Ok(())
+}
+
+/// `agents.create` -> write `<dir>/<name>.md` from `content`.
+///
+/// Why: the GUI's Agents tab add-flow — creates a new disk-tier agent.
+/// What: `201`-shaped success `{"name", "tier"}` (REST layer maps this to
+/// `201 Created`, see `serve::rest::agent_catalog::create`). Errors: invalid
+/// `name` (`-32602`/`-32003`), `name` collides with an embedded agent
+/// (`-32001 permission_denied`, 403 — embedded is read-only), an existing
+/// disk file of the same name (`-32008`-shaped conflict, 409), or a
+/// write-side I/O failure (`-32603 internal`).
+/// Test: `tests::create_writes_file_and_returns_tier`,
+/// `tests::create_rejects_invalid_name`,
+/// `tests::create_rejects_embedded_name_collision`,
+/// `tests::create_rejects_existing_disk_file`.
+async fn agents_create(
+    state: &AgentsCatalogState,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: CreateParams = serde_json::from_value(params)
+        .map_err(|e| RpcError::invalid_params(format!("agents.create: {e}")))?;
+
+    validate_agent_name(&p.name)?;
+
+    if crate::assets::DEFAULT_AGENTS
+        .iter()
+        .any(|a| a.name() == p.name)
+    {
+        return Err(RpcError::permission_denied(format!(
+            "'{}' is an embedded agent and cannot be overridden by name via this endpoint",
+            p.name
+        )));
+    }
+
+    let path = agent_path(&state.dir, &p.name)?;
+    if path.exists() {
+        return Err(
+            RpcError::new(-32008, format!("agent '{}' already exists on disk", p.name))
+                .with_data(json!({"error_type": "already_exists"})),
+        );
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| RpcError::internal(format!("creating agents dir: {e}")))?;
+    }
+    std::fs::write(&path, &p.content)
+        .map_err(|e| RpcError::internal(format!("writing agent file: {e}")))?;
+
+    Ok(json!({ "name": p.name, "tier": state.tier }))
+}
+
+/// `params` shape for `agents.delete`.
+#[derive(Deserialize)]
+struct DeleteParams {
+    name: String,
+}
+
+/// `agents.delete` -> remove `<dir>/<name>.md`.
+///
+/// Why: the GUI's Agents tab remove-flow (two-step inline confirm on the
+/// client side — this endpoint itself is a single, non-idempotent DELETE).
+/// What: `{}` on success. `-32002 not_found` (404) when no disk file exists
+/// under `name` AND it is not embedded; `-32001 permission_denied` (403)
+/// when `name` names an embedded agent (nothing to delete — the embedded
+/// roster is compiled in, never on disk).
+/// Test: `tests::delete_removes_disk_file`,
+/// `tests::delete_missing_name_returns_not_found`,
+/// `tests::delete_embedded_name_returns_permission_denied`.
+async fn agents_delete(
+    state: &AgentsCatalogState,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: DeleteParams = serde_json::from_value(params)
+        .map_err(|e| RpcError::invalid_params(format!("agents.delete: {e}")))?;
+    validate_agent_name(&p.name)?;
+
+    let path = agent_path(&state.dir, &p.name)?;
+    if !path.exists() {
+        if crate::assets::DEFAULT_AGENTS
+            .iter()
+            .any(|a| a.name() == p.name)
+        {
+            return Err(RpcError::permission_denied(format!(
+                "'{}' is an embedded agent and cannot be deleted",
+                p.name
+            )));
+        }
+        return Err(RpcError::not_found(format!(
+            "no disk agent named '{}'",
+            p.name
+        )));
+    }
+
+    std::fs::remove_file(&path).map_err(|e| RpcError::internal(format!("deleting agent: {e}")))?;
+    Ok(json!({}))
+}
+
+/// Join a validated `name` onto `dir` as `<dir>/<name>.md`.
+///
+/// Why: one seam for the join so both write paths (`create`, `delete`)
+/// build the path identically; `name` must already have passed
+/// [`validate_agent_name`] before this is called (it re-validates as a
+/// defense-in-depth belt-and-suspenders, never trust-by-construction alone).
+/// What: `Err` if `name` fails validation; otherwise `dir.join("<name>.md")`.
+fn agent_path(dir: &Path, name: &str) -> Result<PathBuf, RpcError> {
+    validate_agent_name(name)?;
+    Ok(dir.join(format!("{name}.md")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ConnectionContext {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    fn state(dir: &Path, project_bound: bool) -> AgentsCatalogState {
+        AgentsCatalogState::new(dir.to_path_buf(), project_bound)
+    }
+
+    #[test]
+    fn validate_name_rejects_empty() {
+        assert!(validate_agent_name("").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_uppercase() {
+        assert!(validate_agent_name("Engineer").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_path_traversal() {
+        assert!(validate_agent_name("../../etc/passwd").is_err());
+        assert!(validate_agent_name("a/b").is_err());
+        assert!(validate_agent_name("..").is_err());
+    }
+
+    #[test]
+    fn validate_name_rejects_too_long() {
+        let long = "a".repeat(MAX_AGENT_NAME_LEN + 1);
+        assert!(validate_agent_name(&long).is_err());
+    }
+
+    #[test]
+    fn validate_name_accepts_lowercase_alnum_hyphen() {
+        assert!(validate_agent_name("my-custom-agent-2").is_ok());
+    }
+
+    #[tokio::test]
+    async fn list_returns_embedded_when_disk_empty() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let s = state(tmp.path(), false);
+        let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+        let agents = result["agents"].as_array().expect("array");
+        assert_eq!(agents.len(), crate::assets::DEFAULT_AGENTS.len());
+        assert!(agents.iter().all(|a| a["tier"] == "embedded"));
+    }
+
+    #[tokio::test]
+    async fn list_disk_override_wins_and_suppresses_embedded() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("engineer.md"),
+            "---\nname: engineer\ndescription: DISK OVERRIDE\n---\n\nBody.\n",
+        )
+        .expect("write");
+        let s = state(tmp.path(), true);
+        let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+        let agents = result["agents"].as_array().expect("array");
+        let engineer_entries: Vec<_> = agents.iter().filter(|a| a["name"] == "engineer").collect();
+        assert_eq!(engineer_entries.len(), 1, "must appear exactly once");
+        assert_eq!(engineer_entries[0]["tier"], "project");
+        assert_eq!(engineer_entries[0]["description"], "DISK OVERRIDE");
+    }
+
+    #[tokio::test]
+    async fn list_disk_only_entries_are_additive() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("my-custom.md"),
+            "---\nname: my-custom\ndescription: Custom\n---\n\nBody.\n",
+        )
+        .expect("write");
+        let s = state(tmp.path(), true);
+        let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+        let agents = result["agents"].as_array().expect("array");
+        assert_eq!(agents.len(), crate::assets::DEFAULT_AGENTS.len() + 1);
+        assert!(
+            agents
+                .iter()
+                .any(|a| a["name"] == "my-custom" && a["tier"] == "project")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_writes_file_and_returns_tier() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let s = state(tmp.path(), true);
+        let result = agents_create(
+            &s,
+            json!({"name": "my-agent", "content": "---\nname: my-agent\n---\n\nBody.\n"}),
+            ctx(),
+        )
+        .await
+        .expect("create");
+        assert_eq!(result["name"], "my-agent");
+        assert_eq!(result["tier"], "project");
+        assert!(tmp.path().join("my-agent.md").exists());
+    }
+
+    #[tokio::test]
+    async fn create_rejects_invalid_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let s = state(tmp.path(), true);
+        let err = agents_create(&s, json!({"name": "Bad Name!", "content": "x"}), ctx())
+            .await
+            .expect_err("must reject");
+        assert_eq!(err.code, -32003);
+    }
+
+    #[tokio::test]
+    async fn create_rejects_path_traversal_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let s = state(tmp.path(), true);
+        let err = agents_create(&s, json!({"name": "../../evil", "content": "x"}), ctx())
+            .await
+            .expect_err("must reject");
+        assert_eq!(err.code, -32003);
+        assert!(!tmp.path().parent().unwrap().join("evil.md").exists());
+    }
+
+    #[tokio::test]
+    async fn create_rejects_embedded_name_collision() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let s = state(tmp.path(), true);
+        let err = agents_create(
+            &s,
+            json!({"name": "engineer", "content": "---\nname: engineer\n---\n\nBody.\n"}),
+            ctx(),
+        )
+        .await
+        .expect_err("must reject embedded collision");
+        assert_eq!(err.code, -32001);
+        assert!(!tmp.path().join("engineer.md").exists());
+    }
+
+    #[tokio::test]
+    async fn create_rejects_existing_disk_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("dup.md"), "---\nname: dup\n---\n\nBody.\n").expect("write");
+        let s = state(tmp.path(), true);
+        let err = agents_create(
+            &s,
+            json!({"name": "dup", "content": "---\nname: dup\n---\n\nNew.\n"}),
+            ctx(),
+        )
+        .await
+        .expect_err("must reject existing file");
+        assert_eq!(err.code, -32008);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_disk_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("my-agent.md"),
+            "---\nname: my-agent\n---\n\nBody.\n",
+        )
+        .expect("write");
+        let s = state(tmp.path(), true);
+        agents_delete(&s, json!({"name": "my-agent"}), ctx())
+            .await
+            .expect("delete");
+        assert!(!tmp.path().join("my-agent.md").exists());
+    }
+
+    #[tokio::test]
+    async fn delete_missing_name_returns_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let s = state(tmp.path(), true);
+        let err = agents_delete(&s, json!({"name": "totally-bogus"}), ctx())
+            .await
+            .expect_err("must 404");
+        assert_eq!(err.code, -32002);
+    }
+
+    #[tokio::test]
+    async fn delete_embedded_name_returns_permission_denied() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let s = state(tmp.path(), true);
+        let err = agents_delete(&s, json!({"name": "engineer"}), ctx())
+            .await
+            .expect_err("must 403");
+        assert_eq!(err.code, -32001);
+    }
+
+    #[tokio::test]
+    async fn register_wires_all_three_methods() {
+        use trusty_common::mcp::Request;
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut router = Router::new();
+        register(&mut router, state(tmp.path(), true));
+
+        let req = Request {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(Value::from(1)),
+            method: "agents.list".to_string(),
+            params: None,
+        };
+        let resp = router.dispatch(req, &ctx()).await;
+        assert!(resp.result.is_some(), "agents.list must be wired");
+        assert!(resp.result.unwrap()["agents"].is_array());
+    }
+}

--- a/crates/trusty-code/src/jsonrpc/error.rs
+++ b/crates/trusty-code/src/jsonrpc/error.rs
@@ -170,6 +170,25 @@ impl RpcError {
         Self::new(-32008, format!("another workstream is active: {active_id}"))
             .with_data(json!({"error_type": "active_conflict", "active_id": active_id}))
     }
+
+    /// Build a `-32009 already_exists` error (issue #3449).
+    ///
+    /// Why: `agents.create`/`skills.create` must refuse to overwrite an
+    /// existing disk entry, and that conflict needs its OWN code — an early
+    /// cut reused the literal `-32008`, but that slot is
+    /// [`Self::active_conflict`]'s (DOC-48 §5.2, constructor-backed, and
+    /// asserted on numerically by the workstreams tests), so sharing it
+    /// would make the two semantically different conflicts
+    /// indistinguishable to a client matching on code (code-critic PR #3465
+    /// review, LOW). `-32009` is the next free slot after it.
+    /// What: `data.error_type = "already_exists"`. The REST layer maps this
+    /// to `409 Conflict` (`serve::rest::rpc_error_to_status`), same HTTP
+    /// status as `active_conflict` — the distinction lives in the JSON-RPC
+    /// code/`error_type`, where protocol clients look.
+    /// Test: `rpc_error_already_exists_sets_code_and_type`.
+    pub fn already_exists(message: impl Into<String>) -> Self {
+        Self::domain(-32009, "already_exists", message)
+    }
 }
 
 impl std::fmt::Display for RpcError {
@@ -276,5 +295,15 @@ mod tests {
                 "active_id": "a1b2c3d4-e5f6-4748-9a0b-1c2d3e4f5a6b",
             }))
         );
+    }
+
+    /// `already_exists` must use `-32009` — its OWN slot, distinct from
+    /// `active_conflict`'s `-32008` (code-critic PR #3465 review, LOW).
+    #[test]
+    fn rpc_error_already_exists_sets_code_and_type() {
+        let e = RpcError::already_exists("agent 'dup' already exists on disk");
+        assert_eq!(e.code, -32009);
+        assert_ne!(e.code, RpcError::active_conflict("x").code);
+        assert_eq!(e.data, Some(json!({"error_type": "already_exists"})));
     }
 }

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -102,8 +102,10 @@ struct HttpState {
 /// `POST /workstreams/{id}/activate`/`.../deactivate` (DOC-48 §5.2, issue
 /// #3294) — plus (issue #3297) `GET /workstreams/{id}/events` (the
 /// workstream-level SSE aggregation route, `crate::workstreams::sse::routes`)
-/// — none of which collide with the paths registered directly on this
-/// router or with each other.
+/// — plus (issue #3449) `GET`/`POST /agents`, `DELETE /agents/{name}` and the
+/// `skills` twin (the Foundry GUI's Agents/Skills management tabs,
+/// `rest::agent_catalog`/`rest::skill_catalog`) — none of which collide with
+/// the paths registered directly on this router or with each other.
 /// Test: `http_rpc_ping_returns_pong`,
 /// `http_rpc_malformed_json_returns_parse_error`,
 /// `http_health_matches_jsonrpc_health_payload`,
@@ -117,7 +119,8 @@ struct HttpState {
 /// `http_rest_get_session_search_audit_route_is_merged_in`,
 /// `http_rest_get_workstreams_route_is_merged_in` (also pins the
 /// `GET /workstreams/{id}/events` merge),
-/// `http_rest_get_projects_route_is_merged_in`.
+/// `http_rest_get_projects_route_is_merged_in`,
+/// `http_rest_get_agent_and_skill_catalog_routes_are_merged_in`.
 pub fn build_axum_router(
     router: Arc<Router>,
     sessions: Arc<SessionRegistry>,
@@ -139,6 +142,8 @@ pub fn build_axum_router(
         .merge(rest::fs::routes(router.clone()))
         .merge(rest::projects::routes(router.clone()))
         .merge(rest::agents::routes(router.clone()))
+        .merge(rest::agent_catalog::routes(router.clone()))
+        .merge(rest::skill_catalog::routes(router.clone()))
         .merge(rest::search_audit::routes(router.clone()))
         .merge(rest::workstreams::routes(router))
         .merge(crate::workstreams::sse::routes(workstreams));

--- a/crates/trusty-code/src/serve/http_tests.rs
+++ b/crates/trusty-code/src/serve/http_tests.rs
@@ -364,6 +364,62 @@ async fn http_rest_get_projects_route_is_merged_in() {
     assert!(v["entries"].is_array());
 }
 
+/// `GET /agents`/`GET /skills` (issue #3449's Foundry GUI catalog-management
+/// REST groups, merged in by `build_axum_router` via
+/// `rest::agent_catalog::routes`/`rest::skill_catalog::routes`) must be
+/// reachable on the SAME router `POST /rpc` is — proving the merge actually
+/// wires both groups rather than silently dropping them. Per-route behaviour
+/// is already covered by `rest::agent_catalog::tests`/
+/// `rest::skill_catalog::tests`; this test only pins the merge itself.
+#[tokio::test]
+async fn http_rest_get_agent_and_skill_catalog_routes_are_merged_in() {
+    let sessions = Arc::new(SessionRegistry::new());
+    let project = tempfile::tempdir().expect("project tempdir");
+    let mut router = Router::new();
+    crate::serve::methods::register(&mut router);
+    crate::session::protocol::register(
+        &mut router,
+        sessions.clone(),
+        test_workstreams_store().await,
+    );
+    crate::agents::protocol::register(
+        &mut router,
+        crate::agents::protocol::AgentsCatalogState::new(project.path().to_path_buf(), true),
+    );
+    crate::skills::protocol::register(
+        &mut router,
+        crate::skills::protocol::SkillsCatalogState::new(Some(project.path())),
+    );
+    let app = build_axum_router(Arc::new(router), sessions, test_workstreams_store().await);
+
+    let agents_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/agents")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(agents_resp.status(), StatusCode::OK);
+    assert!(body_json(agents_resp).await["agents"].is_array());
+
+    let skills_resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/skills")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(skills_resp.status(), StatusCode::OK);
+    assert!(body_json(skills_resp).await["skills"].is_array());
+}
+
 /// `GET /sessions/{id}/agents` (the #2983 Slice 6 REST route group,
 /// merged in by `build_axum_router` via `rest::agents::routes`) must be
 /// reachable on the SAME router `GET /sessions/{id}/events` is —

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -101,6 +101,13 @@ pub const DEFAULT_HTTP_PORT: u16 = 7882;
 /// `fs.list_dir` (UI Phase-1) is the one group that needs NO shared state — a
 /// directory listing is a pure function of the filesystem at call time — so it
 /// registers with neither `sessions` nor `project`.
+/// `agents.*`/`skills.*` (issue #3449) are the Foundry GUI's catalog
+/// management surface — list/create/delete over the disk tier
+/// `crate::agents::resolve_agent` and `crate::skills::discover_skill_metadata`
+/// already recognise, plus the embedded/bundled roster each falls back to.
+/// Both register with immutable state resolved once here from `binding`
+/// (`AgentsCatalogState`/`SkillsCatalogState` — no `Mutex`, every operation is
+/// a stateless filesystem call at request time).
 /// What: builds an empty `Router` + a fresh `SessionRegistry`, calls
 /// `methods::register`, `crate::session::protocol::register`,
 /// `crate::fs_browse::protocol::register`, and
@@ -142,6 +149,7 @@ pub const DEFAULT_HTTP_PORT: u16 = 7882;
 /// `build_router_wires_session_methods`, `build_router_wires_task_run`,
 /// `build_router_is_projectless_without_a_project`,
 /// `build_router_wires_fs_list_dir`, `build_router_wires_workstream_methods`,
+/// `build_router_wires_agents_and_skills_catalog_methods`,
 /// `build_router_reconciles_dangling_active_pointer_on_boot`.
 pub async fn build_router(
     binding: ProjectBinding,
@@ -181,6 +189,14 @@ async fn build_router_at(
     methods::register(&mut router);
     crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
     crate::fs_browse::protocol::register(&mut router);
+    crate::agents::protocol::register(
+        &mut router,
+        crate::agents::protocol::AgentsCatalogState::new(agents_dir.clone(), binding.is_bound()),
+    );
+    crate::skills::protocol::register(
+        &mut router,
+        crate::skills::protocol::SkillsCatalogState::new(binding.root()),
+    );
     crate::task::protocol::register(
         &mut router,
         sessions.clone(),
@@ -336,6 +352,36 @@ mod tests {
             resp.error
         );
         assert!(resp.result.expect("result")["entries"].is_array());
+    }
+
+    /// `build_router` must also wire `agents.list`/`skills.list` (issue
+    /// #3449), so the Foundry GUI's Agents/Skills tabs are reachable over
+    /// the same `/rpc` endpoint as everything else.
+    #[tokio::test]
+    async fn build_router_wires_agents_and_skills_catalog_methods() {
+        let project = tempfile::tempdir().expect("project tempdir");
+        let data_dir = tempfile::tempdir().expect("data tempdir");
+        let (router, _sessions, _workstreams) = build_router_at(
+            ProjectBinding::resolve(Some(project.path().to_path_buf())).expect("tempdir must bind"),
+            data_dir.path(),
+        )
+        .await
+        .expect("build_router_at");
+
+        for method in ["agents.list", "skills.list"] {
+            let req = Request {
+                jsonrpc: Some("2.0".to_string()),
+                id: Some(json!(1)),
+                method: method.to_string(),
+                params: None,
+            };
+            let resp = router.dispatch(req, &test_ctx()).await;
+            assert!(
+                resp.error.is_none(),
+                "{method} must be registered, got {:?}",
+                resp.error
+            );
+        }
     }
 
     /// `DEFAULT_HTTP_PORT` must stay the documented value (7882) so a

--- a/crates/trusty-code/src/serve/rest/agent_catalog.rs
+++ b/crates/trusty-code/src/serve/rest/agent_catalog.rs
@@ -1,0 +1,249 @@
+//! `GET`/`POST /agents`, `DELETE /agents/{name}` REST routes over the
+//! `agents.*` JSON-RPC surface (issue #3449, Foundry GUI Agents tab).
+//!
+//! Why: mirrors every other resource group in this gateway — a REST-only
+//! client (the GUI) gets the same `agents.*` surface `POST /rpc` exposes,
+//! without duplicating `crate::agents::protocol`'s business logic as bespoke
+//! axum handlers (see `super` module docs' "forking the two surfaces"
+//! rationale). Named `agent_catalog` (not `agents`, which
+//! `crate::serve::rest::agents` already claims for `GET
+//! /sessions/{id}/agents` — the per-session LIVE roster route, a distinct
+//! resource) to avoid a module-name collision while both mount under the
+//! literal `/agents` path prefix at the HTTP layer (no path collision: one
+//! is nested under `/sessions/{id}/`, this one is top-level).
+//! What: [`routes`] builds a standalone `axum::Router<()>` mapping:
+//!   - `GET /agents` -> `agents.list`
+//!   - `POST /agents` -> `agents.create{name, content}` (`201 Created`)
+//!   - `DELETE /agents/{name}` -> `agents.delete{name}`
+//!
+//! `crate::serve::http::build_axum_router` merges this into the daemon's
+//! main router alongside every other REST resource group.
+//!
+//! Test: `tests::*`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::Router as AxumRouter;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use trusty_common::mcp::Response;
+
+use crate::jsonrpc::Router;
+
+use super::{RestResult, respond};
+
+/// Shared axum state for every route in this module: just the JSON-RPC
+/// router, mirroring `super::workstreams::WorkstreamsState`.
+#[derive(Clone)]
+struct AgentCatalogState {
+    router: Arc<Router>,
+}
+
+/// Build the `GET`/`POST /agents`, `DELETE /agents/{name}` route group.
+///
+/// Why: kept separate from `crate::serve::http::build_axum_router` so this
+/// resource group is unit-testable via `tower::util::ServiceExt::oneshot` on
+/// its own, exactly like every other `rest::*` group.
+/// Test: `tests::create_agent_returns_201`, `tests::list_agents_returns_200`,
+/// `tests::delete_agent_returns_200`.
+pub fn routes(router: Arc<Router>) -> AxumRouter {
+    AxumRouter::new()
+        .route("/agents", get(list_agents).post(create_agent))
+        .route("/agents/{name}", axum::routing::delete(delete_agent))
+        .with_state(AgentCatalogState { router })
+}
+
+/// `GET /agents` -> `agents.list`.
+async fn list_agents(State(state): State<AgentCatalogState>) -> RestResult {
+    respond(&state.router, "agents.list", Value::Null).await
+}
+
+/// Request body for `POST /agents`.
+#[derive(Deserialize)]
+struct CreateBody {
+    name: String,
+    content: String,
+}
+
+/// Like [`super::respond`] but reports `201 Created` on success — this
+/// module mints a brand-new disk-tier agent (mirrors
+/// `super::workstreams::respond_created`).
+async fn respond_created(
+    router: &Router,
+    method: &str,
+    params: Value,
+) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Response>)> {
+    respond(router, method, params)
+        .await
+        .map(|Json(v)| (StatusCode::CREATED, Json(v)))
+}
+
+/// `POST /agents` -> `agents.create`.
+async fn create_agent(
+    State(state): State<AgentCatalogState>,
+    Json(body): Json<CreateBody>,
+) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Response>)> {
+    respond_created(
+        &state.router,
+        "agents.create",
+        json!({"name": body.name, "content": body.content}),
+    )
+    .await
+}
+
+/// `DELETE /agents/{name}` -> `agents.delete`.
+async fn delete_agent(
+    State(state): State<AgentCatalogState>,
+    Path(name): Path<String>,
+) -> RestResult {
+    respond(&state.router, "agents.delete", json!({"name": name})).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use tower::util::ServiceExt;
+
+    fn app() -> AxumRouter {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().to_path_buf();
+        // Mirrors `super::workstreams::tests::app`'s `std::mem::forget(dir)`
+        // convention — keeps the directory alive for the lifetime of this
+        // test's requests instead of deleting it when `tmp` drops.
+        std::mem::forget(tmp);
+        let mut router = Router::new();
+        crate::agents::protocol::register(
+            &mut router,
+            crate::agents::protocol::AgentsCatalogState::new(dir, true),
+        );
+        routes(Arc::new(router))
+    }
+
+    async fn body_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn list_agents_returns_200() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/agents")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert!(v["agents"].is_array());
+    }
+
+    #[tokio::test]
+    async fn create_agent_returns_201() {
+        let a = app();
+        let resp = a
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"my-agent","content":"---\nname: my-agent\n---\n\nBody.\n"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let v = body_json(resp).await;
+        assert_eq!(v["name"], "my-agent");
+    }
+
+    #[tokio::test]
+    async fn create_embedded_collision_returns_403() {
+        let a = app();
+        let resp = a
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"engineer","content":"---\nname: engineer\n---\n\nBody.\n"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn delete_agent_returns_200() {
+        let a = app();
+        a.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"my-agent","content":"---\nname: my-agent\n---\n\nBody.\n"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = a
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/agents/my-agent")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn delete_missing_agent_returns_404() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/agents/totally-bogus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn delete_embedded_agent_returns_403() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/agents/engineer")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/crates/trusty-code/src/serve/rest/agent_catalog.rs
+++ b/crates/trusty-code/src/serve/rest/agent_catalog.rs
@@ -187,6 +187,45 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 
+    /// A second `POST /agents` for the same name must surface as `409
+    /// Conflict` at the REST layer — `rpc_error_to_status` mapping
+    /// `RpcError::already_exists`'s `-32009` (code-critic PR #3465 review,
+    /// HIGH 1's atomic `write_new_file` fix), not the old `-32008` slot.
+    #[tokio::test]
+    async fn create_conflict_returns_409() {
+        let a = app();
+        let body =
+            Body::from(r#"{"name":"dup-agent","content":"---\nname: dup-agent\n---\n\nBody.\n"}"#);
+        let first = a
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents")
+                    .header("content-type", "application/json")
+                    .body(body)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::CREATED);
+
+        let second = a
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"dup-agent","content":"---\nname: dup-agent\n---\n\nCLOBBER.\n"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::CONFLICT);
+    }
+
     #[tokio::test]
     async fn delete_agent_returns_200() {
         let a = app();

--- a/crates/trusty-code/src/serve/rest/mod.rs
+++ b/crates/trusty-code/src/serve/rest/mod.rs
@@ -55,19 +55,28 @@
 //! its module docs for why the paths are unprefixed rather than DOC-48
 //! §5.2's literal `/api/v1/workstreams`. [`projects`] adds `GET /projects`
 //! -> `fs.list_projects` (issue #3365 — the GUI's workstream-first
-//! project-picker modal's roster data source). Every slice reuses
-//! [`respond`]/[`throwaway_ctx`] rather than reimplementing the glue.
+//! project-picker modal's roster data source). [`agent_catalog`]/
+//! [`skill_catalog`] (issue #3449) add the Foundry GUI's Agents/Skills
+//! management tabs' full surface — `GET`/`POST /agents`,
+//! `DELETE /agents/{name}` and the `skills` twin — over
+//! `crate::agents::protocol`/`crate::skills::protocol`; distinct from this
+//! module's own [`agents`] group (`GET /sessions/{id}/agents`, the
+//! per-session LIVE roster, unrelated to the disk/embedded catalog these two
+//! new groups manage). Every slice reuses [`respond`]/[`throwaway_ctx`]
+//! rather than reimplementing the glue.
 //!
 //! Test: `tests::*` — a success round-trip, an error round-trip, and one
 //! assertion per `rpc_error_to_status` mapping. See `sessions::tests` for
 //! the Slice 2 route-level coverage.
 
+pub mod agent_catalog;
 pub mod agents;
 pub mod fs;
 pub mod projects;
 pub mod search_audit;
 pub mod sessions;
 pub mod sessions_write;
+pub mod skill_catalog;
 pub mod tasks;
 pub mod workstreams;
 

--- a/crates/trusty-code/src/serve/rest/mod.rs
+++ b/crates/trusty-code/src/serve/rest/mod.rs
@@ -140,7 +140,8 @@ pub async fn call(
 /// What: matches on the numeric JSON-RPC error code: `-32002 not_found` ->
 /// 404, `-32001 permission_denied` -> 403, `-32003 invalid_argument` and
 /// `-32602 Invalid params` -> 400, `-32007 session_not_found` -> 404,
-/// `-32008 active_conflict` (DOC-48 §5.2, issue #3294) -> 409, `-32603
+/// `-32008 active_conflict` (DOC-48 §5.2, issue #3294) and `-32009
+/// already_exists` (issue #3449) -> 409, `-32603
 /// Internal error` -> 500. Any other/future code (including
 /// `-32601`/`-32600`, which a REST handler should never see because it
 /// calls `call` with a hardcoded, known-good method name) falls back to 500
@@ -157,6 +158,7 @@ pub fn rpc_error_to_status(err: &RpcError) -> axum::http::StatusCode {
         -32001 => StatusCode::FORBIDDEN,   // permission_denied
         -32003 => StatusCode::BAD_REQUEST, // invalid_argument
         -32008 => StatusCode::CONFLICT,    // active_conflict (DOC-48 §5.2)
+        -32009 => StatusCode::CONFLICT,    // already_exists (issue #3449)
         c if c == error_codes::INVALID_PARAMS => StatusCode::BAD_REQUEST,
         c if c == error_codes::INTERNAL_ERROR => StatusCode::INTERNAL_SERVER_ERROR,
         _ => StatusCode::INTERNAL_SERVER_ERROR,
@@ -333,6 +335,14 @@ mod tests {
     fn status_mapping_active_conflict_is_409() {
         assert_eq!(
             rpc_error_to_status(&RpcError::active_conflict("ws-1")),
+            axum::http::StatusCode::CONFLICT
+        );
+    }
+
+    #[test]
+    fn status_mapping_already_exists_is_409() {
+        assert_eq!(
+            rpc_error_to_status(&RpcError::already_exists("dup")),
             axum::http::StatusCode::CONFLICT
         );
     }

--- a/crates/trusty-code/src/serve/rest/skill_catalog.rs
+++ b/crates/trusty-code/src/serve/rest/skill_catalog.rs
@@ -1,0 +1,225 @@
+//! `GET`/`POST /skills`, `DELETE /skills/{name}` REST routes over the
+//! `skills.*` JSON-RPC surface (issue #3449, Foundry GUI Skills tab).
+//!
+//! Why: mirrors `super::agent_catalog`'s shape exactly — a REST-only client
+//! (the GUI) gets the same `skills.*` surface `POST /rpc` exposes, without
+//! duplicating `crate::skills::protocol`'s business logic as bespoke axum
+//! handlers.
+//! What: [`routes`] builds a standalone `axum::Router<()>` mapping:
+//!   - `GET /skills` -> `skills.list`
+//!   - `POST /skills` -> `skills.create{name, content}` (`201 Created`)
+//!   - `DELETE /skills/{name}` -> `skills.delete{name}`
+//!
+//! `crate::serve::http::build_axum_router` merges this into the daemon's
+//! main router alongside every other REST resource group.
+//!
+//! Test: `tests::*`.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::Router as AxumRouter;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use trusty_common::mcp::Response;
+
+use crate::jsonrpc::Router;
+
+use super::{RestResult, respond};
+
+/// Shared axum state for every route in this module: just the JSON-RPC
+/// router, mirroring `super::agent_catalog::AgentCatalogState`.
+#[derive(Clone)]
+struct SkillCatalogState {
+    router: Arc<Router>,
+}
+
+/// Build the `GET`/`POST /skills`, `DELETE /skills/{name}` route group.
+///
+/// Test: `tests::create_skill_returns_201`, `tests::list_skills_returns_200`,
+/// `tests::delete_skill_returns_200`.
+pub fn routes(router: Arc<Router>) -> AxumRouter {
+    AxumRouter::new()
+        .route("/skills", get(list_skills).post(create_skill))
+        .route("/skills/{name}", axum::routing::delete(delete_skill))
+        .with_state(SkillCatalogState { router })
+}
+
+/// `GET /skills` -> `skills.list`.
+async fn list_skills(State(state): State<SkillCatalogState>) -> RestResult {
+    respond(&state.router, "skills.list", Value::Null).await
+}
+
+/// Request body for `POST /skills`.
+#[derive(Deserialize)]
+struct CreateBody {
+    name: String,
+    content: String,
+}
+
+/// Like [`super::respond`] but reports `201 Created` on success.
+async fn respond_created(
+    router: &Router,
+    method: &str,
+    params: Value,
+) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Response>)> {
+    respond(router, method, params)
+        .await
+        .map(|Json(v)| (StatusCode::CREATED, Json(v)))
+}
+
+/// `POST /skills` -> `skills.create`.
+async fn create_skill(
+    State(state): State<SkillCatalogState>,
+    Json(body): Json<CreateBody>,
+) -> Result<(StatusCode, Json<Value>), (StatusCode, Json<Response>)> {
+    respond_created(
+        &state.router,
+        "skills.create",
+        json!({"name": body.name, "content": body.content}),
+    )
+    .await
+}
+
+/// `DELETE /skills/{name}` -> `skills.delete`.
+async fn delete_skill(
+    State(state): State<SkillCatalogState>,
+    Path(name): Path<String>,
+) -> RestResult {
+    respond(&state.router, "skills.delete", json!({"name": name})).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use tower::util::ServiceExt;
+
+    fn app() -> AxumRouter {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().to_path_buf();
+        // Mirrors `super::workstreams::tests::app`'s `std::mem::forget(dir)`
+        // convention.
+        std::mem::forget(tmp);
+        let mut router = Router::new();
+        crate::skills::protocol::register(
+            &mut router,
+            crate::skills::protocol::SkillsCatalogState::new(Some(&root)),
+        );
+        routes(Arc::new(router))
+    }
+
+    async fn body_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn list_skills_returns_200() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/skills")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let v = body_json(resp).await;
+        assert!(v["skills"].is_array());
+    }
+
+    #[tokio::test]
+    async fn create_skill_returns_201() {
+        let a = app();
+        let resp = a
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/skills")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"my-skill","content":"---\nname: my-skill\n---\n\nBody.\n"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let v = body_json(resp).await;
+        assert_eq!(v["name"], "my-skill");
+    }
+
+    #[tokio::test]
+    async fn delete_skill_returns_200() {
+        let a = app();
+        a.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/skills")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"my-skill","content":"---\nname: my-skill\n---\n\nBody.\n"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp = a
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/skills/my-skill")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn delete_missing_skill_returns_404() {
+        let resp = app()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/skills/totally-bogus")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn create_projectless_returns_400() {
+        let mut router = Router::new();
+        crate::skills::protocol::register(
+            &mut router,
+            crate::skills::protocol::SkillsCatalogState::new(None),
+        );
+        let a = routes(Arc::new(router));
+        let resp = a
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/skills")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"name":"my-skill","content":"x"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/trusty-code/src/serve/rest/skill_catalog.rs
+++ b/crates/trusty-code/src/serve/rest/skill_catalog.rs
@@ -156,6 +156,45 @@ mod tests {
         assert_eq!(v["name"], "my-skill");
     }
 
+    /// A second `POST /skills` for the same name must surface as `409
+    /// Conflict` at the REST layer — `rpc_error_to_status` mapping
+    /// `RpcError::already_exists`'s `-32009` (code-critic PR #3465 review,
+    /// HIGH 2's atomic `write_new_file` fix), not the old `-32008` slot.
+    #[tokio::test]
+    async fn create_conflict_returns_409() {
+        let a = app();
+        let first = a
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/skills")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"dup-skill","content":"---\nname: dup-skill\n---\n\nBody.\n"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::CREATED);
+
+        let second = a
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/skills")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"name":"dup-skill","content":"---\nname: dup-skill\n---\n\nCLOBBER.\n"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::CONFLICT);
+    }
+
     #[tokio::test]
     async fn delete_skill_returns_200() {
         let a = app();

--- a/crates/trusty-code/src/skills/mod.rs
+++ b/crates/trusty-code/src/skills/mod.rs
@@ -34,6 +34,7 @@
 //! conformance.
 
 mod frontmatter;
+pub mod protocol;
 
 use std::path::{Path, PathBuf};
 
@@ -112,18 +113,39 @@ pub fn locate_skills_dir(project_root: &Path) -> PathBuf {
 /// `discover_skill_metadata_disk_wins_when_present`,
 /// `discover_skill_metadata_falls_back_to_dirname`.
 pub fn discover_skill_metadata(dir: &Path) -> Vec<SkillMetadata> {
+    let skills = discover_disk_skill_metadata(dir);
+    if skills.is_empty() {
+        return embedded_skill_metadata();
+    }
+    skills
+}
+
+/// Scan `dir` for disk skills WITHOUT the embedded-fallback threshold —
+/// returns an empty `Vec` for a missing/empty directory rather than
+/// substituting `embedded_skill_metadata()` (#3449).
+///
+/// Why: `protocol::skills_list` needs to distinguish "this project genuinely
+/// has zero custom skills" from "here is the bundled catalog" — merging the
+/// two (as [`discover_skill_metadata`]'s fallback does, correctly, for the
+/// *tool-facing* discovery/prompt-injection path) would mislabel every
+/// bundled entry as `tier: "project"` in the catalog endpoint whenever a
+/// project's `.claude/skills/` happens to be empty. Factored out of
+/// [`discover_skill_metadata`] so the fallback threshold lives in exactly
+/// one place; the tool-facing function above is unchanged in behavior.
+/// What: identical directory scan/sort to [`discover_skill_metadata`], minus
+/// the embedded-fallback branch.
+/// Test: `protocol::tests::list_disk_only_entries_are_additive`,
+/// `protocol::tests::list_returns_bundled_when_projectless`.
+pub(crate) fn discover_disk_skill_metadata(dir: &Path) -> Vec<SkillMetadata> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         tracing::debug!("skills dir not found or unreadable: {}", dir.display());
-        return embedded_skill_metadata();
+        return Vec::new();
     };
 
     let mut skills: Vec<SkillMetadata> = entries
         .flatten()
         .filter_map(|entry| load_metadata_from_skill_dir(&entry.path()))
         .collect();
-    if skills.is_empty() {
-        return embedded_skill_metadata();
-    }
     skills.sort_by(|a, b| a.name.cmp(&b.name));
     skills
 }

--- a/crates/trusty-code/src/skills/mod.rs
+++ b/crates/trusty-code/src/skills/mod.rs
@@ -134,8 +134,9 @@ pub fn discover_skill_metadata(dir: &Path) -> Vec<SkillMetadata> {
 /// one place; the tool-facing function above is unchanged in behavior.
 /// What: identical directory scan/sort to [`discover_skill_metadata`], minus
 /// the embedded-fallback branch.
-/// Test: `protocol::tests::list_disk_only_entries_are_additive`,
-/// `protocol::tests::list_returns_bundled_when_projectless`.
+/// Test: `protocol::tests::list_returns_disk_only_when_disk_non_empty_no_bundled_entries`,
+/// `protocol::tests::list_returns_bundled_when_projectless`,
+/// `protocol::tests::list_returns_bundled_when_disk_empty`.
 pub(crate) fn discover_disk_skill_metadata(dir: &Path) -> Vec<SkillMetadata> {
     let Ok(entries) = std::fs::read_dir(dir) else {
         tracing::debug!("skills dir not found or unreadable: {}", dir.display());

--- a/crates/trusty-code/src/skills/protocol.rs
+++ b/crates/trusty-code/src/skills/protocol.rs
@@ -1,0 +1,473 @@
+//! `skills.*` JSON-RPC methods — the daemon's SKILL CATALOG management
+//! surface (issue #3449), backing the Foundry GUI's Skills management tab.
+//!
+//! Why: the GUI's Agents tab (`crate::agents::protocol`) and Skills tab are
+//! siblings in the same issue, but tcode's skill model is genuinely
+//! narrower than its agent model — worth stating explicitly rather than
+//! papering over with a symmetric-looking API that implies a tier that
+//! doesn't exist. `crate::skills::discover_skill_metadata` (the ONLY
+//! consumer of a project's `.claude/skills/`, wired at `run_task`/
+//! `task::executor` time) recognises exactly TWO tiers: the embedded/bundled
+//! catalog (`crate::assets::DEFAULT_SKILLS`, trusty-mpm's universal set
+//! minus `tm-*` orchestration skills) and ONE project-scoped disk directory
+//! (`<project_root>/.claude/skills/<name>/SKILL.md`) — there is NO
+//! user-level `~/.claude/skills` tier the way `crate::agents::agents_dir`
+//! has for agents (`skills::locate_skills_dir` takes a `project_root`
+//! directly; every call site passes the bound project's root, never
+//! `$HOME`). This module's `tier` values are therefore `"bundled"` and
+//! `"project"` ONLY — never `"user"` — and `skills.create`/`skills.delete`
+//! require an actually-bound project (there is nowhere else on disk for a
+//! projectless daemon to persist a user-added skill); a projectless caller
+//! gets a clear `-32003 invalid_argument`, not a silent no-op or an
+//! invented user-level path nothing else in this crate would ever read.
+//! What: [`register`] wires three methods onto a shared, immutable
+//! [`SkillsCatalogState`] (an `Option<PathBuf>` project skills dir — `None`
+//! when projectless):
+//!   - `skills.list` -> `{"skills": [{name, tier, description}]}`, the union
+//!     of the bundled catalog (`tier: "bundled"`) and, when a project is
+//!     bound, its disk skills (`tier: "project"`) — a disk skill overriding
+//!     a bundled name WINS, mirroring `discover_skill_metadata`'s disk-wins
+//!     precedence (see that function's docs) exactly.
+//!   - `skills.create{name, content}` -> writes
+//!     `<skills_dir>/<name>/SKILL.md` from the caller-supplied
+//!     Markdown+frontmatter body. Same name-validation contract as
+//!     `agents::protocol::validate_agent_name` (shared, not reimplemented —
+//!     see that function's docs): rejects a name colliding with a bundled
+//!     skill (`-32001 permission_denied`, 403) or an already-existing disk
+//!     skill directory (`-32008`-shaped conflict, 409). `-32003
+//!     invalid_argument` (400) when projectless.
+//!   - `skills.delete{name}` -> removes `<skills_dir>/<name>/` recursively.
+//!     `-32002 not_found` (404) absent; `-32001 permission_denied` (403) for
+//!     a bundled name; `-32003 invalid_argument` (400) when projectless.
+//!
+//! Test: `tests::*`.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use crate::agents::protocol::validate_agent_name as validate_skill_name;
+use crate::jsonrpc::{ConnectionContext, Router, RpcError};
+
+use super::SkillMetadata;
+
+/// Shared, immutable state every `skills.*` handler in this module closes
+/// over: the project-scoped skills directory, or `None` when projectless.
+///
+/// Why: unlike [`crate::agents::protocol::AgentsCatalogState`], there is no
+/// user-level fallback directory for skills (see module docs) — `None` is a
+/// real, valid state (a projectless daemon can still LIST the bundled
+/// catalog), not a placeholder for "not wired up yet".
+#[derive(Clone)]
+pub struct SkillsCatalogState {
+    /// `<project_root>/.claude/skills`, or `None` when no project is bound.
+    pub dir: Option<PathBuf>,
+}
+
+impl SkillsCatalogState {
+    /// Build state from an optional bound project root.
+    ///
+    /// Why: keeps "resolve the skills dir from the binding, or None" in one
+    /// place (today: `crate::serve::build_router_at`).
+    /// What: `Some(super::locate_skills_dir(root))` when `project_root` is
+    /// `Some`, else `None`.
+    pub fn new(project_root: Option<&std::path::Path>) -> Self {
+        Self {
+            dir: project_root.map(super::locate_skills_dir),
+        }
+    }
+}
+
+/// Register `skills.list`, `skills.create`, `skills.delete` onto `router`.
+///
+/// Why: mirrors `crate::agents::protocol::register`'s shape for this
+/// namespace.
+/// Test: `tests::register_wires_all_three_methods`.
+pub fn register(router: &mut Router, state: SkillsCatalogState) {
+    let s = state.clone();
+    router.register(
+        "skills.list",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { skills_list(&s, params, ctx).await }
+        },
+    );
+
+    let s = state.clone();
+    router.register(
+        "skills.create",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { skills_create(&s, params, ctx).await }
+        },
+    );
+
+    let s = state;
+    router.register(
+        "skills.delete",
+        move |params: Value, ctx: ConnectionContext| {
+            let s = s.clone();
+            async move { skills_delete(&s, params, ctx).await }
+        },
+    );
+}
+
+/// Wire shape for one catalog entry.
+fn entry_json(m: &SkillMetadata, tier: &str) -> Value {
+    json!({ "name": m.name, "tier": tier, "description": m.description })
+}
+
+/// `skills.list` -> the full bundled ∪ project-disk catalog.
+///
+/// Why: the GUI's Skills tab roster fetch.
+/// What: ignores `params`. Builds the bundled set keyed by name (always
+/// present, even projectless), then overlays project-disk entries when
+/// `state.dir` is `Some` — a disk override suppresses the bundled entry of
+/// the same name (mirrors `discover_skill_metadata`'s disk-wins rule).
+/// Sorted by name.
+/// Test: `tests::list_returns_bundled_when_projectless`,
+/// `tests::list_disk_override_wins_and_suppresses_bundled`,
+/// `tests::list_disk_only_entries_are_additive`.
+async fn skills_list(
+    state: &SkillsCatalogState,
+    _params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let mut by_name: Vec<(String, Value)> = super::embedded_skill_metadata()
+        .iter()
+        .map(|m| (m.name.clone(), entry_json(m, "bundled")))
+        .collect();
+
+    if let Some(dir) = &state.dir {
+        for m in super::discover_disk_skill_metadata(dir) {
+            let entry = entry_json(&m, "project");
+            match by_name.iter_mut().find(|(n, _)| *n == m.name) {
+                Some(slot) => slot.1 = entry,
+                None => by_name.push((m.name.clone(), entry)),
+            }
+        }
+    }
+
+    by_name.sort_by(|a, b| a.0.cmp(&b.0));
+    let skills: Vec<Value> = by_name.into_iter().map(|(_, v)| v).collect();
+    Ok(json!({ "skills": skills }))
+}
+
+/// `params` shape for `skills.create`.
+#[derive(Deserialize)]
+struct CreateParams {
+    name: String,
+    content: String,
+}
+
+/// `skills.create` -> write `<skills_dir>/<name>/SKILL.md` from `content`.
+///
+/// Why: the GUI's Skills tab add-flow.
+/// What: `{"name", "tier": "project"}` on success. `-32003 invalid_argument`
+/// when projectless (nowhere to write); invalid `name`; embedded/bundled
+/// name collision (`-32001`, 403); existing disk skill directory (`-32008`
+/// shaped conflict, 409).
+/// Test: `tests::create_writes_file_and_returns_project_tier`,
+/// `tests::create_rejects_when_projectless`,
+/// `tests::create_rejects_bundled_name_collision`,
+/// `tests::create_rejects_existing_disk_skill`.
+async fn skills_create(
+    state: &SkillsCatalogState,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: CreateParams = serde_json::from_value(params)
+        .map_err(|e| RpcError::invalid_params(format!("skills.create: {e}")))?;
+    validate_skill_name(&p.name)?;
+
+    let Some(dir) = &state.dir else {
+        return Err(RpcError::invalid_argument(
+            "skills are project-scoped; bind a project before adding one",
+        ));
+    };
+
+    if super::embedded_skill_metadata()
+        .iter()
+        .any(|m| m.name == p.name)
+    {
+        return Err(RpcError::permission_denied(format!(
+            "'{}' is a bundled skill and cannot be overridden by name via this endpoint",
+            p.name
+        )));
+    }
+
+    let skill_dir = dir.join(&p.name);
+    let skill_md = skill_dir.join("SKILL.md");
+    if skill_md.exists() {
+        return Err(
+            RpcError::new(-32008, format!("skill '{}' already exists on disk", p.name))
+                .with_data(json!({"error_type": "already_exists"})),
+        );
+    }
+
+    std::fs::create_dir_all(&skill_dir)
+        .map_err(|e| RpcError::internal(format!("creating skill dir: {e}")))?;
+    std::fs::write(&skill_md, &p.content)
+        .map_err(|e| RpcError::internal(format!("writing SKILL.md: {e}")))?;
+
+    Ok(json!({ "name": p.name, "tier": "project" }))
+}
+
+/// `params` shape for `skills.delete`.
+#[derive(Deserialize)]
+struct DeleteParams {
+    name: String,
+}
+
+/// `skills.delete` -> remove `<skills_dir>/<name>/` recursively.
+///
+/// Why: the GUI's Skills tab remove-flow.
+/// What: `{}` on success. `-32003 invalid_argument` when projectless;
+/// `-32002 not_found` (404) when no disk skill directory exists under
+/// `name` and it is not bundled; `-32001 permission_denied` (403) for a
+/// bundled name.
+/// Test: `tests::delete_removes_disk_skill_dir`,
+/// `tests::delete_rejects_when_projectless`,
+/// `tests::delete_missing_name_returns_not_found`,
+/// `tests::delete_bundled_name_returns_permission_denied`.
+async fn skills_delete(
+    state: &SkillsCatalogState,
+    params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    let p: DeleteParams = serde_json::from_value(params)
+        .map_err(|e| RpcError::invalid_params(format!("skills.delete: {e}")))?;
+    validate_skill_name(&p.name)?;
+
+    let Some(dir) = &state.dir else {
+        return Err(RpcError::invalid_argument(
+            "skills are project-scoped; bind a project before deleting one",
+        ));
+    };
+
+    let skill_dir = dir.join(&p.name);
+    if !skill_dir.exists() {
+        if super::embedded_skill_metadata()
+            .iter()
+            .any(|m| m.name == p.name)
+        {
+            return Err(RpcError::permission_denied(format!(
+                "'{}' is a bundled skill and cannot be deleted",
+                p.name
+            )));
+        }
+        return Err(RpcError::not_found(format!(
+            "no disk skill named '{}'",
+            p.name
+        )));
+    }
+
+    std::fs::remove_dir_all(&skill_dir)
+        .map_err(|e| RpcError::internal(format!("deleting skill dir: {e}")))?;
+    Ok(json!({}))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> ConnectionContext {
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        ConnectionContext::new(tx)
+    }
+
+    #[test]
+    fn locate_skills_dir_matches_project_only_tier() {
+        // Pins the module doc's central claim: no user-level fallback.
+        let root = std::path::Path::new("/fake/project");
+        let s = SkillsCatalogState::new(Some(root));
+        assert_eq!(s.dir, Some(root.join(".claude").join("skills")));
+        let projectless = SkillsCatalogState::new(None);
+        assert_eq!(projectless.dir, None);
+    }
+
+    #[tokio::test]
+    async fn list_returns_bundled_when_projectless() {
+        let s = SkillsCatalogState::new(None);
+        let result = skills_list(&s, Value::Null, ctx()).await.expect("list");
+        let skills = result["skills"].as_array().expect("array");
+        assert_eq!(skills.len(), crate::assets::DEFAULT_SKILLS.len());
+        assert!(skills.iter().all(|sk| sk["tier"] == "bundled"));
+    }
+
+    #[tokio::test]
+    async fn list_disk_override_wins_and_suppresses_bundled() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bundled_name = crate::assets::DEFAULT_SKILLS[0].name;
+        let dir = tmp.path().join(bundled_name);
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {bundled_name}\ndescription: DISK OVERRIDE\n---\n\nBody.\n"),
+        )
+        .expect("write");
+
+        let s = SkillsCatalogState {
+            dir: Some(tmp.path().to_path_buf()),
+        };
+        let result = skills_list(&s, Value::Null, ctx()).await.expect("list");
+        let skills = result["skills"].as_array().expect("array");
+        let matches: Vec<_> = skills
+            .iter()
+            .filter(|sk| sk["name"] == bundled_name)
+            .collect();
+        assert_eq!(matches.len(), 1, "must appear exactly once");
+        assert_eq!(matches[0]["tier"], "project");
+        assert_eq!(matches[0]["description"], "DISK OVERRIDE");
+    }
+
+    #[tokio::test]
+    async fn list_disk_only_entries_are_additive() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("my-custom-skill");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(
+            dir.join("SKILL.md"),
+            "---\nname: my-custom-skill\ndescription: Custom\n---\n\nBody.\n",
+        )
+        .expect("write");
+
+        let s = SkillsCatalogState {
+            dir: Some(tmp.path().to_path_buf()),
+        };
+        let result = skills_list(&s, Value::Null, ctx()).await.expect("list");
+        let skills = result["skills"].as_array().expect("array");
+        assert_eq!(skills.len(), crate::assets::DEFAULT_SKILLS.len() + 1);
+        assert!(
+            skills
+                .iter()
+                .any(|sk| sk["name"] == "my-custom-skill" && sk["tier"] == "project")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_writes_file_and_returns_project_tier() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let s = SkillsCatalogState {
+            dir: Some(tmp.path().to_path_buf()),
+        };
+        let result = skills_create(
+            &s,
+            json!({"name": "my-skill", "content": "---\nname: my-skill\n---\n\nBody.\n"}),
+            ctx(),
+        )
+        .await
+        .expect("create");
+        assert_eq!(result["name"], "my-skill");
+        assert_eq!(result["tier"], "project");
+        assert!(tmp.path().join("my-skill").join("SKILL.md").exists());
+    }
+
+    #[tokio::test]
+    async fn create_rejects_when_projectless() {
+        let s = SkillsCatalogState::new(None);
+        let err = skills_create(&s, json!({"name": "my-skill", "content": "x"}), ctx())
+            .await
+            .expect_err("must reject projectless create");
+        assert_eq!(err.code, -32003);
+    }
+
+    #[tokio::test]
+    async fn create_rejects_bundled_name_collision() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bundled_name = crate::assets::DEFAULT_SKILLS[0].name;
+        let s = SkillsCatalogState {
+            dir: Some(tmp.path().to_path_buf()),
+        };
+        let err = skills_create(&s, json!({"name": bundled_name, "content": "x"}), ctx())
+            .await
+            .expect_err("must reject bundled collision");
+        assert_eq!(err.code, -32001);
+    }
+
+    #[tokio::test]
+    async fn create_rejects_existing_disk_skill() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("dup-skill");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(dir.join("SKILL.md"), "---\nname: dup-skill\n---\n\nBody.\n")
+            .expect("write");
+
+        let s = SkillsCatalogState {
+            dir: Some(tmp.path().to_path_buf()),
+        };
+        let err = skills_create(&s, json!({"name": "dup-skill", "content": "new"}), ctx())
+            .await
+            .expect_err("must reject existing disk skill");
+        assert_eq!(err.code, -32008);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_disk_skill_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("my-skill");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        std::fs::write(dir.join("SKILL.md"), "---\nname: my-skill\n---\n\nBody.\n").expect("write");
+
+        let s = SkillsCatalogState {
+            dir: Some(tmp.path().to_path_buf()),
+        };
+        skills_delete(&s, json!({"name": "my-skill"}), ctx())
+            .await
+            .expect("delete");
+        assert!(!dir.exists());
+    }
+
+    #[tokio::test]
+    async fn delete_rejects_when_projectless() {
+        let s = SkillsCatalogState::new(None);
+        let err = skills_delete(&s, json!({"name": "my-skill"}), ctx())
+            .await
+            .expect_err("must reject projectless delete");
+        assert_eq!(err.code, -32003);
+    }
+
+    #[tokio::test]
+    async fn delete_missing_name_returns_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let s = SkillsCatalogState {
+            dir: Some(tmp.path().to_path_buf()),
+        };
+        let err = skills_delete(&s, json!({"name": "totally-bogus"}), ctx())
+            .await
+            .expect_err("must 404");
+        assert_eq!(err.code, -32002);
+    }
+
+    #[tokio::test]
+    async fn delete_bundled_name_returns_permission_denied() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bundled_name = crate::assets::DEFAULT_SKILLS[0].name;
+        let s = SkillsCatalogState {
+            dir: Some(tmp.path().to_path_buf()),
+        };
+        let err = skills_delete(&s, json!({"name": bundled_name}), ctx())
+            .await
+            .expect_err("must 403");
+        assert_eq!(err.code, -32001);
+    }
+
+    #[tokio::test]
+    async fn register_wires_all_three_methods() {
+        use trusty_common::mcp::Request;
+
+        let mut router = Router::new();
+        register(&mut router, SkillsCatalogState::new(None));
+
+        let req = Request {
+            jsonrpc: Some("2.0".to_string()),
+            id: Some(Value::from(1)),
+            method: "skills.list".to_string(),
+            params: None,
+        };
+        let resp = router.dispatch(req, &ctx()).await;
+        assert!(resp.result.is_some(), "skills.list must be wired");
+        assert!(resp.result.unwrap()["skills"].is_array());
+    }
+}

--- a/crates/trusty-code/src/skills/protocol.rs
+++ b/crates/trusty-code/src/skills/protocol.rs
@@ -23,11 +23,21 @@
 //! What: [`register`] wires three methods onto a shared, immutable
 //! [`SkillsCatalogState`] (an `Option<PathBuf>` project skills dir — `None`
 //! when projectless):
-//!   - `skills.list` -> `{"skills": [{name, tier, description}]}`, the union
-//!     of the bundled catalog (`tier: "bundled"`) and, when a project is
-//!     bound, its disk skills (`tier: "project"`) — a disk skill overriding
-//!     a bundled name WINS, mirroring `discover_skill_metadata`'s disk-wins
-//!     precedence (see that function's docs) exactly.
+//!   - `skills.list` -> `{"skills": [{name, tier, description}]}` — WHOLE-
+//!     CATALOG REPLACEMENT, mirroring `discover_skill_metadata`'s own
+//!     `if !skills.is_empty() { return skills }` threshold (see that
+//!     function's docs) exactly, at the catalog level rather than per-name:
+//!     when a project is bound and its disk skills directory has at least
+//!     one entry, the response is ONLY those disk skills (`tier:
+//!     "project"`) — the bundled catalog is entirely absent, because that
+//!     is what actually resolves at `task.run` time (`FsSkillResolver`
+//!     discards the whole bundled set the instant disk has anything).
+//!     Otherwise (projectless, or a bound project with no/empty disk
+//!     skills) the response is the full bundled catalog (`tier: "bundled"`).
+//!     A per-name bundled-∪-disk overlay would be WRONG here — it would
+//!     report bundled skills as available for a project whose real
+//!     `use_skill` catalog resolves only its own custom entries
+//!     (code-critic PR #3465 re-review, MEDIUM).
 //!   - `skills.create{name, content}` -> writes
 //!     `<skills_dir>/<name>/SKILL.md` from the caller-supplied
 //!     Markdown+frontmatter body. Same name-validation contract as
@@ -118,39 +128,58 @@ fn entry_json(m: &SkillMetadata, tier: &str) -> Value {
     json!({ "name": m.name, "tier": tier, "description": m.description })
 }
 
-/// `skills.list` -> the full bundled ∪ project-disk catalog.
+/// `skills.list` -> the catalog that will ACTUALLY resolve for this project
+/// at `task.run` time.
 ///
-/// Why: the GUI's Skills tab roster fetch.
-/// What: ignores `params`. Builds the bundled set keyed by name (always
-/// present, even projectless), then overlays project-disk entries when
-/// `state.dir` is `Some` — a disk override suppresses the bundled entry of
-/// the same name (mirrors `discover_skill_metadata`'s disk-wins rule).
-/// Sorted by name.
+/// Why: the GUI's Skills tab roster fetch. The runtime resolver
+/// (`discover_skill_metadata`, wired through `FsSkillResolver` at
+/// `task::executor::daily_driver_skills_catalog`) does WHOLE-CATALOG
+/// REPLACEMENT, not a per-name overlay: the instant a project's
+/// `.claude/skills/` has even one entry, the ENTIRE bundled catalog is
+/// discarded — every bundled name becomes unresolvable
+/// (`skills::SkillError::Unknown` on `use_skill`), disk or not. An earlier
+/// version of this handler built a bundled ∪ disk union with per-name
+/// override (disk winning only for names it actually shadowed), which made
+/// `skills.list` report every bundled skill as available for a project that
+/// had, say, one custom skill and nothing else — the catalog lied about
+/// what would actually resolve (code-critic PR #3465 re-review, MEDIUM:
+/// "half-fixed" — the agents side already mirrored its resolver correctly,
+/// this side did not). Fixed by mirroring `discover_skill_metadata`'s own
+/// `if !skills.is_empty() { return skills }` threshold exactly, at the
+/// catalog level rather than per-name.
+/// What: ignores `params`. When `state.dir` is `Some` and
+/// `discover_disk_skill_metadata` returns anything non-empty, the response
+/// is EXACTLY those disk entries (`tier: "project"`) — no bundled entries
+/// at all. Otherwise (`state.dir` is `None`, i.e. projectless, OR the
+/// project's skills dir is missing/empty) the response is the full bundled
+/// catalog (`tier: "bundled"`). Sorted by name either way.
 /// Test: `tests::list_returns_bundled_when_projectless`,
-/// `tests::list_disk_override_wins_and_suppresses_bundled`,
-/// `tests::list_disk_only_entries_are_additive`.
+/// `tests::list_returns_bundled_when_disk_empty`,
+/// `tests::list_returns_disk_only_when_disk_non_empty_no_bundled_entries`.
 async fn skills_list(
     state: &SkillsCatalogState,
     _params: Value,
     _ctx: ConnectionContext,
 ) -> Result<Value, RpcError> {
-    let mut by_name: Vec<(String, Value)> = super::embedded_skill_metadata()
-        .iter()
-        .map(|m| (m.name.clone(), entry_json(m, "bundled")))
-        .collect();
+    let disk = state
+        .dir
+        .as_ref()
+        .map(|dir| super::discover_disk_skill_metadata(dir))
+        .unwrap_or_default();
 
-    if let Some(dir) = &state.dir {
-        for m in super::discover_disk_skill_metadata(dir) {
-            let entry = entry_json(&m, "project");
-            match by_name.iter_mut().find(|(n, _)| *n == m.name) {
-                Some(slot) => slot.1 = entry,
-                None => by_name.push((m.name.clone(), entry)),
-            }
-        }
-    }
+    let mut entries: Vec<(String, Value)> = if disk.is_empty() {
+        super::embedded_skill_metadata()
+            .iter()
+            .map(|m| (m.name.clone(), entry_json(m, "bundled")))
+            .collect()
+    } else {
+        disk.iter()
+            .map(|m| (m.name.clone(), entry_json(m, "project")))
+            .collect()
+    };
 
-    by_name.sort_by(|a, b| a.0.cmp(&b.0));
-    let skills: Vec<Value> = by_name.into_iter().map(|(_, v)| v).collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    let skills: Vec<Value> = entries.into_iter().map(|(_, v)| v).collect();
     Ok(json!({ "skills": skills }))
 }
 
@@ -297,34 +326,34 @@ mod tests {
         assert!(skills.iter().all(|sk| sk["tier"] == "bundled"));
     }
 
+    /// A bound project with an EXISTING BUT EMPTY skills directory still
+    /// falls back to the bundled catalog — the same threshold
+    /// `discover_skill_metadata`'s own `if !skills.is_empty()` uses, pinned
+    /// here at the `skills.list` handler level too (code-critic PR #3465
+    /// re-review, MEDIUM).
     #[tokio::test]
-    async fn list_disk_override_wins_and_suppresses_bundled() {
+    async fn list_returns_bundled_when_disk_empty() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let bundled_name = crate::assets::DEFAULT_SKILLS[0].name;
-        let dir = tmp.path().join(bundled_name);
-        std::fs::create_dir_all(&dir).expect("mkdir");
-        std::fs::write(
-            dir.join("SKILL.md"),
-            format!("---\nname: {bundled_name}\ndescription: DISK OVERRIDE\n---\n\nBody.\n"),
-        )
-        .expect("write");
-
         let s = SkillsCatalogState {
             dir: Some(tmp.path().to_path_buf()),
         };
         let result = skills_list(&s, Value::Null, ctx()).await.expect("list");
         let skills = result["skills"].as_array().expect("array");
-        let matches: Vec<_> = skills
-            .iter()
-            .filter(|sk| sk["name"] == bundled_name)
-            .collect();
-        assert_eq!(matches.len(), 1, "must appear exactly once");
-        assert_eq!(matches[0]["tier"], "project");
-        assert_eq!(matches[0]["description"], "DISK OVERRIDE");
+        assert_eq!(skills.len(), crate::assets::DEFAULT_SKILLS.len());
+        assert!(skills.iter().all(|sk| sk["tier"] == "bundled"));
     }
 
+    /// The core fix under test (code-critic PR #3465 re-review, MEDIUM): a
+    /// project with even ONE custom disk skill must see ONLY that skill —
+    /// zero bundled entries — because that is exactly what
+    /// `FsSkillResolver`/`discover_skill_metadata` will actually resolve at
+    /// `task.run` time (whole-catalog replacement, not a per-name overlay).
+    /// A prior version of `skills_list` built a bundled ∪ disk union here,
+    /// which reported every bundled skill as available even though none of
+    /// them would actually dispatch — this test pins the corrected,
+    /// resolver-matching behavior.
     #[tokio::test]
-    async fn list_disk_only_entries_are_additive() {
+    async fn list_returns_disk_only_when_disk_non_empty_no_bundled_entries() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let dir = tmp.path().join("my-custom-skill");
         std::fs::create_dir_all(&dir).expect("mkdir");
@@ -339,11 +368,16 @@ mod tests {
         };
         let result = skills_list(&s, Value::Null, ctx()).await.expect("list");
         let skills = result["skills"].as_array().expect("array");
-        assert_eq!(skills.len(), crate::assets::DEFAULT_SKILLS.len() + 1);
+        assert_eq!(
+            skills.len(),
+            1,
+            "must be ONLY the one disk skill — no bundled entries alongside it"
+        );
+        assert_eq!(skills[0]["name"], "my-custom-skill");
+        assert_eq!(skills[0]["tier"], "project");
         assert!(
-            skills
-                .iter()
-                .any(|sk| sk["name"] == "my-custom-skill" && sk["tier"] == "project")
+            skills.iter().all(|sk| sk["tier"] != "bundled"),
+            "the bundled catalog must be entirely absent once disk is non-empty"
         );
     }
 

--- a/crates/trusty-code/src/skills/protocol.rs
+++ b/crates/trusty-code/src/skills/protocol.rs
@@ -34,7 +34,7 @@
 //!     `agents::protocol::validate_agent_name` (shared, not reimplemented —
 //!     see that function's docs): rejects a name colliding with a bundled
 //!     skill (`-32001 permission_denied`, 403) or an already-existing disk
-//!     skill directory (`-32008`-shaped conflict, 409). `-32003
+//!     skill (`-32009 already_exists`, 409). `-32003
 //!     invalid_argument` (400) when projectless.
 //!   - `skills.delete{name}` -> removes `<skills_dir>/<name>/` recursively.
 //!     `-32002 not_found` (404) absent; `-32001 permission_denied` (403) for
@@ -166,12 +166,19 @@ struct CreateParams {
 /// Why: the GUI's Skills tab add-flow.
 /// What: `{"name", "tier": "project"}` on success. `-32003 invalid_argument`
 /// when projectless (nowhere to write); invalid `name`; embedded/bundled
-/// name collision (`-32001`, 403); existing disk skill directory (`-32008`
-/// shaped conflict, 409).
+/// name collision (`-32001`, 403); existing disk skill (`-32009
+/// already_exists`, 409). The existence check is NOT a separate
+/// `skill_md.exists()` pre-check — the same TOCTOU hole
+/// `agents::protocol::agents_create` had (code-critic PR #3465 review,
+/// HIGH 2). Instead: `create_dir_all` the skill directory unconditionally
+/// (idempotent — an existing dir is fine, only the `SKILL.md` inside it is
+/// the conflict unit), then `agents::protocol::write_new_file`'s atomic
+/// `O_CREAT|O_EXCL` create on `SKILL.md` itself.
 /// Test: `tests::create_writes_file_and_returns_project_tier`,
 /// `tests::create_rejects_when_projectless`,
 /// `tests::create_rejects_bundled_name_collision`,
-/// `tests::create_rejects_existing_disk_skill`.
+/// `tests::create_rejects_existing_disk_skill`,
+/// `tests::create_conflict_does_not_clobber_existing_skill`.
 async fn skills_create(
     state: &SkillsCatalogState,
     params: Value,
@@ -199,17 +206,11 @@ async fn skills_create(
 
     let skill_dir = dir.join(&p.name);
     let skill_md = skill_dir.join("SKILL.md");
-    if skill_md.exists() {
-        return Err(
-            RpcError::new(-32008, format!("skill '{}' already exists on disk", p.name))
-                .with_data(json!({"error_type": "already_exists"})),
-        );
-    }
-
     std::fs::create_dir_all(&skill_dir)
         .map_err(|e| RpcError::internal(format!("creating skill dir: {e}")))?;
-    std::fs::write(&skill_md, &p.content)
-        .map_err(|e| RpcError::internal(format!("writing SKILL.md: {e}")))?;
+    crate::agents::protocol::write_new_file(&skill_md, &p.content, || {
+        format!("skill '{}' already exists on disk", p.name)
+    })?;
 
     Ok(json!({ "name": p.name, "tier": "project" }))
 }
@@ -400,7 +401,38 @@ mod tests {
         let err = skills_create(&s, json!({"name": "dup-skill", "content": "new"}), ctx())
             .await
             .expect_err("must reject existing disk skill");
-        assert_eq!(err.code, -32008);
+        // `-32009 already_exists` — NOT `-32008 active_conflict` (code-critic
+        // PR #3465 review, LOW).
+        assert_eq!(err.code, -32009);
+        assert_eq!(err.data.as_ref().unwrap()["error_type"], "already_exists");
+    }
+
+    /// The conflict path must go through `write_new_file`'s atomic
+    /// `O_CREAT|O_EXCL` create — a losing `skills.create` can NEVER have
+    /// truncated or overwritten the existing `SKILL.md`, even transiently
+    /// (code-critic PR #3465 review, HIGH 2).
+    #[tokio::test]
+    async fn create_conflict_does_not_clobber_existing_skill() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("dup-skill");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let original = "---\nname: dup-skill\ndescription: ORIGINAL\n---\n\nBody.\n";
+        std::fs::write(dir.join("SKILL.md"), original).expect("write");
+
+        let s = SkillsCatalogState {
+            dir: Some(tmp.path().to_path_buf()),
+        };
+        let err = skills_create(
+            &s,
+            json!({"name": "dup-skill", "content": "CLOBBER"}),
+            ctx(),
+        )
+        .await
+        .expect_err("must conflict");
+        assert_eq!(err.code, -32009);
+
+        let on_disk = std::fs::read_to_string(dir.join("SKILL.md")).expect("read");
+        assert_eq!(on_disk, original, "existing SKILL.md must be untouched");
     }
 
     #[tokio::test]

--- a/docs/specs/trusty-code-harness-ui.md
+++ b/docs/specs/trusty-code-harness-ui.md
@@ -935,6 +935,19 @@ skills.create({ name, content })  -> { name, tier: "project" }  // 400 projectle
 skills.delete({ name })           -> {}
 ```
 
+The 409 conflict is `-32009 already_exists` (`data.error_type:
+"already_exists"`) — its own JSON-RPC code, distinct from the workstreams'
+`-32008 active_conflict` — and is enforced by an atomic `O_CREAT|O_EXCL`
+create (`agents::protocol::write_new_file`), not an exists-then-write
+pre-check, so two racing creates can never silently clobber each other
+(code-critic PR #3465 review). `agents.list` additionally surfaces an
+unparseable disk file as `tier: "broken"` (still overriding any embedded
+entry of the same name) — because `resolve_agent`'s disk-wins rule applies
+even to a malformed file, dispatch of that name WILL fail, and a catalog
+that showed the shadowed embedded entry as healthy would misreport what
+`task.run` will do; deleting the broken file is the repair path, so the
+entry keeps the delete affordance.
+
 REST twins: `GET`/`POST /agents`, `DELETE /agents/{name}` and the `skills`
 equivalent (`crate::serve::rest::agent_catalog`/`skill_catalog`).
 

--- a/docs/specs/trusty-code-harness-ui.md
+++ b/docs/specs/trusty-code-harness-ui.md
@@ -915,6 +915,49 @@ of replaying and folding the SSE stream itself.
 > debt (see above), not a re-opening of either concern this callout
 > originally raised.
 
+### 5.4.1 Agent/Skill catalog management — NEW (issue #3449)
+
+**Shipped.** Distinct from §5.4's `session.get_agents` (a per-session LIVE
+roster — "who is running right now"), this is the daemon's disk/embedded
+CATALOG surface — "what agents/skills could I dispatch?", independent of any
+session. Backs the Foundry GUI's Agents/Skills management tabs (§8's
+`NAV_TABS`, amended below) and closes the "no pre-task agent roster
+endpoint" gap `StartWorkingForm`'s agent selector previously carried as a
+standing note.
+
+```rust
+agents.list()                     -> { agents: [{ name, tier, description?, model? }] }
+agents.create({ name, content })  -> { name, tier }   // 403 embedded collision, 409 exists
+agents.delete({ name })           -> {}               // 404 unknown, 403 embedded
+
+skills.list()                     -> { skills: [{ name, tier, description }] }
+skills.create({ name, content })  -> { name, tier: "project" }  // 400 projectless, 403/409
+skills.delete({ name })           -> {}
+```
+
+REST twins: `GET`/`POST /agents`, `DELETE /agents/{name}` and the `skills`
+equivalent (`crate::serve::rest::agent_catalog`/`skill_catalog`).
+
+**Tier model differs between the two catalogs — by design, not oversight.**
+Agents have TWO disk-adjacent tiers behind one `agents_dir` resolution
+(`ProjectBinding::agents_dir`): `"project"` (`<root>/.claude/agents`) when
+bound, `"user"` (`~/.claude/agents`) when projectless — never both at once
+for a single daemon instance. `"embedded"` (32 agents incl. `pm`) is always
+present and read-only; a disk entry of the same name wins and suppresses
+the embedded copy in the listing (mirrors `resolve_agent`'s precedence).
+Skills, by contrast, have exactly ONE disk tier — `"project"`
+(`<project_root>/.claude/skills`) — and NO user-level tier;
+`crate::skills::discover_skill_metadata` never reads a `$HOME`-rooted path,
+so `skills.create`/`skills.delete` require an actually-bound project
+(`-32003 invalid_argument`/`400` when projectless) rather than inventing a
+tier nothing else in the crate consumes. `"bundled"` is skills' read-only
+tier name (trusty-mpm's universal skill set minus `tm-*` orchestration
+skills).
+
+Both `create` endpoints validate `name` against `^[a-z0-9-]+$` — the same
+check doubles as the path-traversal guard (no `/`, `..`, or other
+path-breaking character can match).
+
 ### 5.5 Project binding (PARTIAL — the two surfaces must converge)
 
 **Corrected model** (§4.2) — this is a **daemon-bootstrap / binding-lifecycle** change,
@@ -1674,6 +1717,29 @@ This is carried forward verbatim because it is the one piece of the visual syste
   app's root font-size 10% (rem-scale, `app.css`) per issue #3447 item 3. Explicitly
   NOT in scope: §4A's infinite-thread virtualization/pagination/compaction-boundary
   machinery, which remains unbuilt (Phase 2+).
+- **2026-07-20** — **Agents + Skills management tabs, and their catalog endpoints**
+  (issue #3449). Adds **§5.4.1** (new): `agents.*`/`skills.*` JSON-RPC methods
+  (`agents.list`/`.create`/`.delete`, `skills.list`/`.create`/`.delete`) plus their
+  `GET`/`POST /agents`, `DELETE /agents/{name}` REST twins (and the `skills`
+  equivalent) — the daemon's disk/embedded CATALOG management surface, distinct from
+  §5.4's `session.get_agents` per-session live roster. Amends the shell's tab
+  catalog (§8, `lib/nav-tabs.ts`): an 8th tab, **Skills**, is added immediately
+  after **Agents** — the prior 7-tab catalog (Workstream · Project · Agents ·
+  Memory · Search · Workflow · Files, from issue #3153's build brief) is
+  superseded by Workstream · Project · Agents · **Skills** · Memory · Search ·
+  Workflow · Files. `AgentsTab.svelte` (previously a stub deferring everything
+  to §4.5/§5.4's per-session roster — that feature is UNCHANGED and still not
+  built) is replaced with the new catalog-management UI; `SkillsTab.svelte` is
+  new. Both follow the same "locked, not hidden, when projectless" default
+  (AC-4.2) every non-`workstream`/`workflow` tab already uses. Also closes the
+  "no pre-task agent roster endpoint exists yet" gap `StartWorkingForm`'s agent
+  selector previously carried as a standing note (new `lib/agent-roster.ts`);
+  `task.run`'s/`POST /tasks`' `agent_name` param is unchanged — only a GUI
+  affordance to populate it now exists. **Tier model note:** agents have a
+  `"project"`/`"user"` disk split (mirroring `ProjectBinding::agents_dir`'s
+  existing fallback); skills have exactly one disk tier, `"project"` — no
+  user-level skills directory exists anywhere in the crate (see §5.4.1).
+
 - **2026-07-20** — **Shared project registry becomes the roster's source of truth**
   (issue #3435). Amends **§5.8.1** (`SPEC-TCUI-05~draft`): `GET /projects`/
   `fs.list_projects` is re-sourced from trusty-mpm's shared project registry


### PR DESCRIPTION
## Survey findings

**Agent resolution tiers** (`crates/trusty-code/src/agents/`): `resolve_agent` (post-#3441/#3046) checks disk (`<agents_dir>/<name>.md`) first — a disk hit wins unconditionally, even on a parse error (never silently falls back to embedded) — then falls back to `crate::assets::DEFAULT_AGENTS` (32 agents incl. `pm`, added #3437). `agents_dir` resolves via `ProjectBinding::agents_dir()`: `<project_root>/.claude/agents` (or legacy `.open-mpm/agents`) when bound, `~/.claude/agents` when projectless. There is exactly ONE disk tier active per daemon instance — never both project and user simultaneously.

**Skill consumption** (`crates/trusty-code/src/skills/`): tcode DOES load skills for real — `FsSkillResolver`/`discover_skill_metadata` back the `use_skill` tool, wired at `run_task`/`task::executor` time. Only TWO tiers exist: bundled (`crate::assets::DEFAULT_SKILLS`, trusty-mpm's universal set minus `tm-*` orchestration skills) and project-disk (`<project_root>/.claude/skills/<name>/SKILL.md`). **There is no user-level `~/.claude/skills` tier** — `locate_skills_dir` takes a project root directly, never `$HOME`. The Skills tab and its endpoints reflect this narrower model explicitly rather than inventing a tier tcode doesn't consume.

**GUI shell** (DOC-39 §8, issue #3153): 7 canonical nav tabs already existed via `lib/nav-tabs.ts`/`ServiceNav.svelte`. `AgentsTab.svelte` existed but was a stub deferring to the (unrelated, still-unbuilt) per-session live-roster feature (§4.5/§5.4). No Skills tab existed.

## What shipped

**Backend** — new JSON-RPC methods + REST twins (loopback-only, ADR-0011):
- `agents.list`/`GET /agents` — union of embedded (32, read-only) ∪ disk tier (`project`/`user`), disk overriding embedded by name.
- `agents.create`/`POST /agents`, `agents.delete`/`DELETE /agents/{name}` — disk-tier only; refuses embedded-name collision (403) and overwriting an existing disk file (409) on create; refuses deleting an embedded name (403) or an unknown name (404) on delete. Name validated against `[a-z0-9-]+` (also the path-traversal guard).
- `skills.list`/`GET /skills` — union of bundled (read-only) ∪ project-disk (`project` tier only — no `user` tier).
- `skills.create`/`POST /skills`, `skills.delete`/`DELETE /skills/{name}` — same guards as agents, plus a `400 invalid_argument` when projectless (skills have nowhere to write without a bound project).

**GUI**:
- `AgentsTab.svelte` rebuilt from stub into a full catalog-management tab (tier badges, add via name+content editor or `.md` file upload, remove via two-step inline confirm — mirrors `WorkstreamSwitcher.svelte`'s pattern).
- `SkillsTab.svelte` new, same shape, with the add flow locked (and explained) when projectless.
- `lib/agent-roster.ts` / `lib/skill-roster.ts` — thin REST wrappers, each with its own unit tests.
- `nav-tabs.ts` gains an 8th tab, **Skills**, placed after Agents.
- `StartWorkingForm.svelte` (owned by #3446's active surface — kept minimal/additive, flagging for rebase coordination): added an optional agent `<select>` populated via `lib/agent-roster.ts`, closing the "no pre-task agent roster endpoint exists yet" standing note. `buildRunTaskBody` gained an optional 4th `agentName` param (additive; omitted = unchanged daemon-default behavior). Two existing call-order assertions in `StartWorkingForm.test.ts` now filter out the new mount-time `GET /agents` call before comparing.

**Spec**: DOC-39 (`docs/specs/trusty-code-harness-ui.md`) amended — new §5.4.1 (endpoint contracts + tier-model rationale) and a Changelog entry for the tab-catalog change.

## Gate results (raw)

`cargo fmt -p trusty-code -p trusty-code-gui --check` — clean, no output.

`cargo clippy -p trusty-code -p trusty-code-gui --all-targets -- -D warnings` — `Finished `dev` profile [unoptimized + debuginfo] target(s)`, 0 warnings.

`cargo test -p trusty-code -p trusty-code-gui --lib -- --skip run_task::` (the `run_task::` family is a known, pre-existing flake needing a live trusty-memory daemon on 127.0.0.1:7070 — reproduced independently of this change):
```
trusty-code:      test result: ok. 1383 passed; 0 failed; 4 ignored; 0 measured; 59 filtered out
trusty-code-gui:  test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`pnpm test` (crates/trusty-code-gui/ui): `Test Files 22 passed (22)` / `Tests 233 passed (233)`.

`pnpm build`: `✓ 142 modules transformed` / `✓ built in ~4-19s`.

`scripts/check_line_cap.sh`: `line-cap: 7 allowlisted, 0 violations — OK.`
`scripts/check_test_pointers.sh`: `test-pointers: 0 dangling pointers — OK.`
`scripts/check_sld.sh`: `sld-lint: scanned 39 spec doc(s) + 2647 code file(s); 0 error(s), 0 warning(s)`.

## Coordination note

Touched shared/active-surface files per the dispatch's concurrency warning: `App.svelte` (SkillsTab import + render branch, minimal), `nav-tabs.ts`/`nav-tabs.test.ts`/`App.test.ts` (8th tab), and `StartWorkingForm.svelte`/`StartWorkingForm.test.ts`/`new-workstream.ts`/`new-workstream.test.ts` (#3446's active surface — additive agent-selector only, no changes to the create→run→activate sequencing itself). Expect a rebase against PR #3460 (chat-shaped pane) whichever lands second.

🤖🤖🤖 Generated with [trusty-mpm](https://github.com/bobmatnyc/trusty-tools)