### PR TITLE
chore(trusty-common): bump 0.23.5 (unblock trusty-search 0.36.0 publish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6538,7 +6538,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11390,7 +11390,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [0.23.5] — 2026-07-20
 
 ### Added
 

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.23.4"
+version = "0.23.5"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Bump `trusty-common` 0.23.4 → 0.23.5 (additive patch). The new
  `BM25Index::score_query_all_with_filter` method (added by #3410) is
  already committed on main's trusty-common source, but crates.io's
  published max for trusty-common is 0.23.4, which predates it.
- **This unblocks the trusty-search 0.36.0 publish**: `trusty-search`
  0.36.0 calls `score_query_all_with_filter`, so
  `cargo publish --dry-run -p trusty-search` currently fails with
  `E0599: no method named score_query_all_with_filter` because it
  resolves dependencies against the live crates.io registry (where
  trusty-common is still at 0.23.4), not the local workspace path.
- No dependency-requirement edits needed: trusty-search's
  `trusty-common = { version = "0.23.0", ... }` requirement is a caret
  range that already permits 0.23.5.
- Moved the `[Unreleased]` CHANGELOG entry for
  `score_query_all_with_filter` under a new `[0.23.5]` heading.

## Test plan

- [x] `cargo test -p trusty-common` — 175 passed; 0 failed; 6 ignored
- [x] `cargo build -p trusty-search` (full build, not `--lib`) against
      the bumped local trusty-common — `Finished` with 0 errors,
      confirming the E0599 is resolved once 0.23.5 is available
- [x] `cargo check -p trusty-common -p trusty-search` — clean; Cargo.lock
      diff limited to the trusty-common version bump plus one deterministic
      minimum-version-selection shift (`num_enum_derive`'s `proc-macro-crate`
      dep 2.0.0 → 1.3.1), verified reproducible and NOT present against
      unmodified origin/main (confirmed via git stash A/B check)

## Remaining steps (gated on merge, not part of this PR)

1. Merge this PR
2. `cargo publish --dry-run -p trusty-common` then `-p trusty-search` from
   freshly-pulled main
3. `cargo publish -p trusty-common`, wait for propagation
4. `cargo publish -p trusty-search`
5. Tag `trusty-common-v0.23.5` and `trusty-search-v0.36.0`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools