### PR TITLE
feat(trusty-tui): workstream awareness + SSE status-line wiring (Slice 6)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -48,6 +48,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   unresolvable at runtime. Fixed to match the resolver's actual
   whole-catalog-replacement behavior (MEDIUM).
 
+### Fixed
+
+- **`CodeEngine`'s workstream-event SSE loop no longer stalls silently or loops forever (Slice 6, closes #3418, part of epic #3411).**
+  - `pump_session_events` reset its reconnect-attempt counter on every merely-successful TRANSPORT-level reconnect, before the inner loop ever observed whether the STREAM made progress. Against a daemon that accepts the connection but closes the stream immediately with no data every time, that made the retry budget un-exhaustible: the function looped forever and `handle_input` never returned. The counter now only resets on genuine progress (an actual data payload), so `SESSION_STREAM_MAX_RECONNECTS` is a real bound again.
+  - Every exhaustion path in `pump_session_events` (a non-2xx status, a transport error, a clean-but-premature stream close, an idle timeout) now sends a `done: true, is_error: true` `AssistantOutput` before returning, instead of some paths (the clean-close case) silently returning `Ok(())` — indistinguishable from a genuinely successful turn. This is the epic #3411 deferred Slice 3 review item: a terminal SSE failure now surfaces a visible error in the TUI rather than a stalled spinner with no error text.
+  - `run_workstream_subscription` discarded `refresh_workstream_cache`'s return value, so it never actually sent `ReplEvent::WorkstreamUpdated` after an activation change — only `EngineState`'s own internal cache was refreshed, not `ReplApp::active_workstream` (which the status line renders from). It now forwards the refreshed summary as `WorkstreamUpdated`, and also pushes the status line's `Workstream` segment via `ReplEvent::StatuslineUpdate` (`EngineState::statusline_segments`), clearing it (an empty segment list) on deactivation.
+
 ### Changed
 
 - **`fs.list_projects` / `GET /projects` re-sourced from trusty-mpm's shared

--- a/crates/trusty-code/src/tui_client/engine.rs
+++ b/crates/trusty-code/src/tui_client/engine.rs
@@ -187,6 +187,14 @@ impl TuiEngine for CodeEngine {
 
         if let Some(ws) = self.state.refresh_workstream_cache().await {
             let _ = tx.send(ReplEvent::WorkstreamUpdated(ws));
+            // Populate the status line's Workstream segment on first render
+            // (DOC-50 §5.3, Slice 6) — without this, the TUI would show a
+            // blank statusline until the background SSE subscription (which
+            // only starts after `setup` returns, see `run.rs::run`) happens
+            // to observe an activation change.
+            let _ = tx.send(ReplEvent::StatuslineUpdate(
+                self.state.statusline_segments(),
+            ));
         }
 
         let _ = tx.send(ReplEvent::StatusMessage(format!(

--- a/crates/trusty-code/src/tui_client/engine_state.rs
+++ b/crates/trusty-code/src/tui_client/engine_state.rs
@@ -28,14 +28,16 @@ use std::sync::atomic::AtomicBool;
 
 use serde_json::{Value, json};
 use tokio::sync::mpsc::UnboundedSender;
-use trusty_tui::{CommandDescriptor, PickerItem, ReplEvent, WorkstreamSummary};
+use trusty_tui::{CommandDescriptor, PickerItem, ReplEvent, StatuslineSegment, WorkstreamSummary};
 
 use crate::events::SessionEventEnvelope;
 
 use super::engine::{RECONNECT_BACKOFF, SESSION_STREAM_MAX_RECONNECTS, SSE_IDLE_TIMEOUT};
 use super::error::EngineError;
 use super::rpc::RpcHttpClient;
-use super::session_events::{forward_session_event, is_retryable_status};
+use super::session_events::{
+    forward_session_event, is_retryable_status, terminal_stream_failure_event,
+};
 use super::sse::SseLines;
 
 /// See module docs.
@@ -100,6 +102,42 @@ impl EngineState {
             .unwrap_or_else(|e| e.into_inner())
             .get(name)
             .cloned()
+    }
+
+    /// Snapshot the CURRENT `active_workstream` cache as a `StatuslineUpdate`
+    /// payload (DOC-50 §5.3, Slice 6), for callers that just changed it
+    /// (`setup`, the workstream-activation SSE loop) to push alongside
+    /// `WorkstreamUpdated`.
+    ///
+    /// Why: `ReplEvent::StatuslineUpdate` REPLACES `ReplApp::statusline`
+    /// wholesale (`crate::app::reduce::apply`'s `app.statusline = segments`)
+    /// — there is no per-segment upsert seam (DOC-50 §3.2's explicit
+    /// design: the ENGINE assembles the full current set on every push, the
+    /// shared TUI stays opaque to what each segment means). This MVP's
+    /// `CodeEngine` doesn't yet populate any OTHER segment (session id,
+    /// model, project — those are a future slice's work), so today this is
+    /// simply `[Workstream]` or `[]`; whoever adds those must fold them into
+    /// this same snapshot rather than pushing a second, competing
+    /// `StatuslineUpdate` that would stomp this one.
+    /// What: an empty `Vec` — collapsing the statusline's workstream segment
+    /// away entirely, not leaving a stale one — when no workstream is
+    /// active (deactivated, or never observed one); a one-element `Vec`
+    /// otherwise. Locks the SAME `active_workstream` mutex
+    /// `refresh_workstream_cache` just wrote, so callers should invoke this
+    /// immediately after awaiting that call.
+    /// Test: `engine_tests::statusline_segments_reflect_active_workstream_and_clear_on_none`.
+    pub(super) fn statusline_segments(&self) -> Vec<StatuslineSegment> {
+        self.active_workstream
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+            .map(|ws| {
+                vec![StatuslineSegment::Workstream {
+                    id: ws.id.clone(),
+                    name: ws.name.clone(),
+                }]
+            })
+            .unwrap_or_default()
     }
 
     /// Re-fetch `workstream.list` and refresh both `active_workstream` and
@@ -261,6 +299,17 @@ impl EngineState {
     /// [`SESSION_STREAM_MAX_RECONNECTS`]) on a `502`/`503` status, a
     /// transport error, an idle timeout, or a clean-but-premature stream
     /// close — surfacing each as `ReplEvent::ConnectionLost` first.
+    ///
+    /// Giving up (every exhaustion path below, not just the ones that return
+    /// `Err`) ALSO sends [`terminal_stream_failure_event`] before returning —
+    /// epic #3411's deferred Slice 3 review item: a `ConnectionLost` alone
+    /// during the retries is visible, but never clears `ReplApp::busy`, and
+    /// nothing downstream of this function yet turns an `Err` return into a
+    /// rendered event (that wiring is Slice 5's `process_event`, #3417, not
+    /// yet landed). Sending the terminal event here — rather than depending
+    /// on that future caller — is what actually rules out the "TUI looks
+    /// alive with a stuck spinner and no error text" silent-stall outcome the
+    /// review flagged.
     pub(super) async fn pump_session_events(
         &self,
         session_id: &str,
@@ -281,6 +330,10 @@ impl EngineState {
                         tokio::time::sleep(RECONNECT_BACKOFF).await;
                         continue 'reconnect;
                     }
+                    let _ = tx.send(terminal_stream_failure_event(format!(
+                        "daemon returned {status} after {SESSION_STREAM_MAX_RECONNECTS} \
+                         reconnect attempts; giving up"
+                    )));
                     return Err(EngineError::Status { url, status });
                 }
                 Err(source) => {
@@ -292,14 +345,34 @@ impl EngineState {
                         tokio::time::sleep(RECONNECT_BACKOFF).await;
                         continue 'reconnect;
                     }
+                    let _ = tx.send(terminal_stream_failure_event(format!(
+                        "connection failed after {SESSION_STREAM_MAX_RECONNECTS} reconnect \
+                         attempts: {source}; giving up"
+                    )));
                     return Err(EngineError::Transport { url, source });
                 }
             };
-            attempts = 0;
+            // NOT reset to 0 here (a prior revision did — HIGH finding: that
+            // reset `attempts` on every merely-successful TRANSPORT-level
+            // reconnect, before the inner loop ever got a chance to observe
+            // whether the STREAM itself made any progress. Against a daemon
+            // that accepts the connection but closes the stream immediately
+            // with no data every time — exactly `Ok(Ok(None))` below,
+            // exhausted — that made `attempts` count up to 1 and then get
+            // wiped back to 0 on every single reconnect, so
+            // `attempts < SESSION_STREAM_MAX_RECONNECTS` was permanently
+            // true and this function looped FOREVER, never reaching any
+            // exhaustion branch (`handle_input` never returning at all —
+            // strictly worse than the "silent `Ok(())`" stall epic #3411's
+            // review flagged, an unresponsive REPL rather than a merely
+            // quiet one). `attempts` now only resets on genuine progress:
+            // actually receiving a data payload, in the `Some(payload)` arm
+            // below.
             let mut lines = SseLines::new(resp);
             loop {
                 match tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_data()).await {
                     Ok(Ok(Some(payload))) => {
+                        attempts = 0;
                         let Ok(envelope) = serde_json::from_str::<SessionEventEnvelope>(&payload)
                         else {
                             continue;
@@ -317,7 +390,18 @@ impl EngineState {
                             tokio::time::sleep(RECONNECT_BACKOFF).await;
                             continue 'reconnect;
                         }
-                        return Ok(());
+                        // Was `return Ok(())` — indistinguishable from a
+                        // genuinely successful turn, the exact silent-stall
+                        // bug epic #3411's deferred review item warned about:
+                        // the stream closed prematurely (no SessionDone/
+                        // SessionCancelled ever observed) on EVERY reconnect
+                        // attempt, yet the caller saw no error at all.
+                        let _ = tx.send(terminal_stream_failure_event(format!(
+                            "daemon closed the event stream after \
+                             {SESSION_STREAM_MAX_RECONNECTS} reconnect attempts without a \
+                             terminal session event; giving up"
+                        )));
+                        return Err(EngineError::StreamClosed { url });
                     }
                     Ok(Err(source)) => {
                         if attempts < SESSION_STREAM_MAX_RECONNECTS {
@@ -328,6 +412,10 @@ impl EngineState {
                             tokio::time::sleep(RECONNECT_BACKOFF).await;
                             continue 'reconnect;
                         }
+                        let _ = tx.send(terminal_stream_failure_event(format!(
+                            "stream error after {SESSION_STREAM_MAX_RECONNECTS} reconnect \
+                             attempts: {source}; giving up"
+                        )));
                         return Err(EngineError::Transport { url, source });
                     }
                     Err(_elapsed) => {
@@ -341,6 +429,10 @@ impl EngineState {
                             tokio::time::sleep(RECONNECT_BACKOFF).await;
                             continue 'reconnect;
                         }
+                        let _ = tx.send(terminal_stream_failure_event(format!(
+                            "no data from daemon within the idle timeout after \
+                             {SESSION_STREAM_MAX_RECONNECTS} reconnect attempts; giving up"
+                        )));
                         return Err(EngineError::Status {
                             url,
                             status: reqwest::StatusCode::REQUEST_TIMEOUT,

--- a/crates/trusty-code/src/tui_client/engine_tests.rs
+++ b/crates/trusty-code/src/tui_client/engine_tests.rs
@@ -12,8 +12,11 @@ use tokio::sync::mpsc::unbounded_channel;
 
 use super::*;
 use crate::events::{Event, SessionEventEnvelope};
-use crate::tui_client::session_events::{forward_session_event, is_retryable_status};
+use crate::tui_client::session_events::{
+    forward_session_event, is_retryable_status, terminal_stream_failure_event,
+};
 use crate::tui_client::workstream_subscription::parse_workstream_envelope;
+use trusty_tui::{StatuslineSegment, WorkstreamSummary};
 
 fn envelope(event: Event) -> SessionEventEnvelope {
     SessionEventEnvelope::new("s-1".to_string(), 1, chrono::Utc::now(), event)
@@ -193,6 +196,25 @@ fn parse_workstream_envelope_round_trips_activation_changed() {
     }
 }
 
+/// `pump_session_events` giving up after exhausting reconnects must produce
+/// a `done: true, is_error: true` `AssistantOutput` — the epic #3411
+/// deferred-verification item: a `ConnectionLost` alone never clears
+/// `ReplApp::busy`, so this is what actually rules out a silent stall (a
+/// stuck spinner with no visible error) once the last reconnect attempt
+/// fails.
+#[test]
+fn terminal_stream_failure_event_is_a_done_error_output() {
+    let event = terminal_stream_failure_event("daemon unreachable".to_string());
+    assert_eq!(
+        event,
+        ReplEvent::AssistantOutput {
+            chunk: "connection lost: daemon unreachable".to_string(),
+            done: true,
+            is_error: true,
+        }
+    );
+}
+
 #[test]
 fn is_retryable_status_covers_502_and_503_only() {
     assert!(is_retryable_status(reqwest::StatusCode::BAD_GATEWAY));
@@ -230,4 +252,42 @@ fn workstream_picker_dispatch_command_round_trips_through_workstream_subcommand(
 fn picker_unknown_name_is_none() {
     let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), "http://127.0.0.1:1", None);
     assert!(engine.picker("model").is_none());
+}
+
+/// `EngineState::statusline_segments` must mirror the `active_workstream`
+/// cache exactly: no segment before any workstream is known, one
+/// `StatuslineSegment::Workstream` once it is, and — critically — an EMPTY
+/// list again (not a stale segment left behind) once deactivated. This is
+/// the seam `setup`/`run_workstream_subscription` push through
+/// `ReplEvent::StatuslineUpdate` so the status line's "WS: name (id)"
+/// segment (DOC-50 §5.3, Slice 6) tracks the daemon's actual active
+/// workstream, clearing on deactivation rather than showing stale text.
+#[test]
+fn statusline_segments_reflect_active_workstream_and_clear_on_none() {
+    let state = EngineState::new(
+        RpcHttpClient::new(reqwest::Client::new(), "http://127.0.0.1:1".to_string()),
+        None,
+    );
+    assert!(
+        state.statusline_segments().is_empty(),
+        "no active workstream observed yet -> no segments"
+    );
+
+    *state.active_workstream.lock().unwrap() = Some(WorkstreamSummary {
+        id: "ws-1".to_string(),
+        name: "Feature X".to_string(),
+    });
+    assert_eq!(
+        state.statusline_segments(),
+        vec![StatuslineSegment::Workstream {
+            id: "ws-1".to_string(),
+            name: "Feature X".to_string(),
+        }]
+    );
+
+    *state.active_workstream.lock().unwrap() = None;
+    assert!(
+        state.statusline_segments().is_empty(),
+        "deactivation must clear the segment, not leave a stale one"
+    );
 }

--- a/crates/trusty-code/src/tui_client/error.rs
+++ b/crates/trusty-code/src/tui_client/error.rs
@@ -50,6 +50,16 @@ pub enum EngineError {
         status: reqwest::StatusCode,
     },
 
+    /// The daemon closed an SSE stream cleanly (no transport error, no
+    /// non-2xx status) before this client observed a terminal event
+    /// (`SessionDone`/`SessionCancelled`) — and every reconnect attempt
+    /// (bounded by `SESSION_STREAM_MAX_RECONNECTS`) hit the same premature
+    /// close. Distinct from [`Self::Status`]/[`Self::Transport`]: nothing
+    /// about the individual HTTP request failed, only the STREAM never
+    /// reached a terminal state.
+    #[error("event stream for {url} closed repeatedly with no terminal session event observed")]
+    StreamClosed { url: String },
+
     /// The daemon's `POST /rpc` response body didn't have the shape this
     /// client expected (e.g. `session.create`'s result missing an `id`
     /// field) — a daemon/client version-skew symptom, not a transport

--- a/crates/trusty-code/src/tui_client/session_events.rs
+++ b/crates/trusty-code/src/tui_client/session_events.rs
@@ -23,6 +23,33 @@ pub(super) fn is_retryable_status(status: reqwest::StatusCode) -> bool {
     status == reqwest::StatusCode::BAD_GATEWAY || status == reqwest::StatusCode::SERVICE_UNAVAILABLE
 }
 
+/// Build the terminal, VISIBLE-in-the-TUI event `pump_session_events` sends
+/// when it gives up reconnecting (`SESSION_STREAM_MAX_RECONNECTS` exhausted)
+/// without ever observing a `SessionDone`/`SessionCancelled` terminal event
+/// (epic #3411's deferred Slice 3 review item, closed out by Slice 6).
+///
+/// Why: every `ReplEvent::ConnectionLost` sent DURING a retry already renders
+/// visibly (`ReplApp::apply` pushes it to the status area), but
+/// `ConnectionLost` alone never clears `ReplApp::busy`/`streaming_idx` — only
+/// `AssistantOutput{done: true}` does. Without an event like this one, the
+/// LAST reconnect attempt failing left the input composer stuck on
+/// "streaming" forever with no error rendered in the chat itself: a silent
+/// stall, exactly the failure mode the review flagged as one unit tests on
+/// either side of the engine/TUI boundary would both pass while the
+/// integrated behavior is wrong.
+/// What: an `AssistantOutput{done: true, is_error: true}` chunk carrying
+/// `reason` — reusing the SAME "terminal event" vocabulary
+/// `forward_session_event` uses for a failed `SessionDone`, so `ReplApp`
+/// needs no new rendering path to display it.
+/// Test: `engine_tests::terminal_stream_failure_event_is_a_done_error_output`.
+pub(super) fn terminal_stream_failure_event(reason: String) -> ReplEvent {
+    ReplEvent::AssistantOutput {
+        chunk: format!("connection lost: {reason}"),
+        done: true,
+        is_error: true,
+    }
+}
+
 /// Translate one [`SessionEventEnvelope`] into zero or more [`ReplEvent`]s
 /// on `tx`. Returns `true` iff this event is terminal for the current chat
 /// turn (`SessionDone`/`SessionCancelled`) — the caller stops pumping.

--- a/crates/trusty-code/src/tui_client/workstream_subscription.rs
+++ b/crates/trusty-code/src/tui_client/workstream_subscription.rs
@@ -98,7 +98,35 @@ pub(super) async fn run_workstream_subscription(
                         // (HIGH finding: silently skipping this arm left
                         // `active_workstream`/the `"workstream"` picker
                         // stale indefinitely).
-                        state.refresh_workstream_cache().await;
+                        //
+                        // Use the return value (Slice 6, #3418): it only
+                        // clears `EngineState::active_workstream` (this
+                        // client's OWN cache, used by `/workstream list`'s
+                        // marker and `subscribe_workstream_events`'s next
+                        // `current_id`) — the shared `ReplApp::active_workstream`
+                        // the STATUS LINE actually renders from lives entirely
+                        // on the `trusty-tui` side and is populated ONLY by
+                        // `ReplEvent::WorkstreamUpdated`. Discarding this
+                        // return value (as the code did before this fix) left
+                        // the status line showing a stale workstream name
+                        // forever after every activation change — a
+                        // `WorkstreamUpdated` was never actually sent, despite
+                        // `trusty-tui`'s reducer being written to expect one
+                        // as this event's follow-up.
+                        let refreshed = state.refresh_workstream_cache().await;
+                        if let Some(ws) = refreshed {
+                            let _ = tx.send(ReplEvent::WorkstreamUpdated(ws));
+                        }
+                        // Push the status line's Workstream segment in step
+                        // with the cache — `statusline_segments()` reads the
+                        // SAME `active_workstream` mutex `refresh_workstream_cache`
+                        // just wrote, so this is `[Workstream{..}]` when
+                        // `refreshed` was `Some` above and `[]` (collapsing
+                        // the segment away, not leaving it stale) when the
+                        // daemon reports no active workstream — covers BOTH
+                        // the `Some(new_id)` and `None` (deactivation) arms
+                        // below in one place.
+                        let _ = tx.send(ReplEvent::StatuslineUpdate(state.statusline_segments()));
                         match new_active_id {
                             Some(new_id) => {
                                 let _ = tx.send(ReplEvent::WorkstreamActivationChanged {
@@ -116,17 +144,24 @@ pub(super) async fn run_workstream_subscription(
                                 // (`trusty_tui::event`) now carries
                                 // `new_active_id: Option<String>`, so this
                                 // state is representable structurally rather
-                                // than as free text. The cache refresh above
-                                // is what actually clears the stale
-                                // indicator (`active_workstream` -> `None`,
-                                // the `"workstream"` picker's active marker
-                                // gone). Stay connected to `current_id`'s
-                                // stream rather than reconnecting anywhere:
-                                // deactivation is not closure (DOC-48 §4.4),
-                                // and `crate::workstreams::sse`'s
-                                // `classify()` still forwards a LATER
-                                // activation naming `current_id` as its
-                                // `prior_id` to this same connection.
+                                // than as free text — `ReplEvent::WorkstreamUpdated`
+                                // cannot represent "no active workstream" (its
+                                // payload is a concrete `WorkstreamSummary`,
+                                // not `Option`), which is exactly why this
+                                // event exists: `trusty-tui`'s reducer clears
+                                // `ReplApp::active_workstream` directly on
+                                // `new_active_id: None`, rather than waiting
+                                // for a `WorkstreamUpdated` that will never
+                                // come (see `refreshed` above — `None` here
+                                // too, since the daemon reports no active
+                                // workstream). Stay connected to
+                                // `current_id`'s stream rather than
+                                // reconnecting anywhere: deactivation is not
+                                // closure (DOC-48 §4.4), and
+                                // `crate::workstreams::sse`'s `classify()`
+                                // still forwards a LATER activation naming
+                                // `current_id` as its `prior_id` to this same
+                                // connection.
                                 let _ = tx.send(ReplEvent::WorkstreamActivationChanged {
                                     new_active_id: None,
                                     prior_id,

--- a/crates/trusty-code/tests/tui_client_engine.rs
+++ b/crates/trusty-code/tests/tui_client_engine.rs
@@ -313,6 +313,14 @@ async fn handle_input_streams_assistant_output_and_tool_invocation() {
 /// (`SESSION_STREAM_MAX_RECONNECTS` reconnects at the fixed
 /// `RECONNECT_BACKOFF`, neither test-overridable) — hermetic-but-slow beats
 /// mocking away the exact timing this test asserts on.
+///
+/// `handle_input` is wrapped in a 30s `tokio::time::timeout` (well above the
+/// real ~10s) — code-critic finding on PR #3482: this test's ENTIRE purpose
+/// is guarding against an un-exhaustible reconnect loop, so if that bug (or
+/// any regression like it) ever comes back, the un-timed-out `.await` would
+/// hang this test binary forever — exactly the failure mode a CI runner
+/// needs a manual kill to recover from, wrong for a test whose job is to
+/// catch this. The timeout turns "hangs forever" into "fails deterministically."
 #[tokio::test]
 async fn handle_input_surfaces_visible_error_after_exhausting_reconnects() {
     let server = MockServer::start().await;
@@ -332,7 +340,15 @@ async fn handle_input_surfaces_visible_error_after_exhausting_reconnects() {
     engine.setup(tx.clone()).await.expect("setup");
     while rx.try_recv().is_ok() {} // drain setup's own events
 
-    let result = engine.handle_input("hello".to_string(), tx).await;
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        engine.handle_input("hello".to_string(), tx),
+    )
+    .await
+    .expect(
+        "handle_input must not hang — an un-exhaustible reconnect loop must fail this test \
+         deterministically, not hang the test binary forever",
+    );
     assert!(
         result.is_err(),
         "handle_input must return Err once every reconnect attempt is exhausted with no \
@@ -501,6 +517,45 @@ async fn subscribe_workstream_events_refreshes_cache_on_deactivation_with_no_rep
         )
         .mount(&server)
         .await;
+    // `mount_common`'s `workstream.list` mock always reports WS_1 active —
+    // fine for `setup()`'s own call, but this test's whole point is the
+    // SECOND call (triggered by the SSE deactivation event's cache refresh)
+    // observing a genuinely deactivated daemon. Override it with two
+    // higher-priority (lower number = checked first, wiremock-rs) mocks:
+    // the FIRST `workstream.list` call gets the original WS_1-active
+    // response (`up_to_n_times(1)`); once that's exhausted, every
+    // subsequent call falls through to the `active_workstream_id: null`
+    // response — the real shape a client would see once the daemon
+    // actually deactivated.
+    Mock::given(method("POST"))
+        .and(path("/rpc"))
+        .and(RpcMethod("workstream.list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "active_workstream_id": WS_1,
+                "workstreams": [{"id": WS_1, "name": "Feature X"}],
+            },
+        })))
+        .up_to_n_times(1)
+        .with_priority(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/rpc"))
+        .and(RpcMethod("workstream.list"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "active_workstream_id": null,
+                "workstreams": [{"id": WS_1, "name": "Feature X"}],
+            },
+        })))
+        .with_priority(2)
+        .mount(&server)
+        .await;
 
     let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), server.uri(), None);
     let (tx, mut rx) = unbounded_channel();
@@ -533,25 +588,61 @@ async fn subscribe_workstream_events_refreshes_cache_on_deactivation_with_no_rep
 
     // Half 2 of the fix: the engine must not go silent — a structured
     // `WorkstreamActivationChanged { new_active_id: None, .. }` must report
-    // the deactivation.
-    let saw_deactivation_event = tokio::time::timeout(Duration::from_secs(5), async {
+    // the deactivation. Collect every event up through it (rather than
+    // discarding non-matching ones) so Half 3 below can also assert on the
+    // `StatuslineUpdate` this same cache refresh sends — which, per
+    // `run_workstream_subscription`, is sent BEFORE the activation-changed
+    // event, so a "hunt and discard" loop that only looked for the latter
+    // would have already thrown the `StatuslineUpdate` away.
+    let events = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut seen = Vec::new();
         loop {
             match rx.recv().await {
-                Some(ReplEvent::WorkstreamActivationChanged {
-                    new_active_id: None,
-                    prior_id,
-                }) => return prior_id,
-                Some(_) => continue,
+                Some(ev @ ReplEvent::WorkstreamActivationChanged { .. }) => {
+                    seen.push(ev);
+                    return seen;
+                }
+                Some(ev) => seen.push(ev),
                 None => panic!("channel closed before observing the deactivation event"),
             }
         }
     })
     .await
     .expect("timed out waiting for the deactivation event");
-    assert_eq!(
-        saw_deactivation_event.as_deref(),
-        Some(WS_1),
-        "expected WorkstreamActivationChanged{{new_active_id: None, prior_id: Some(WS_1)}}"
+
+    let activation = events
+        .iter()
+        .find(|e| matches!(e, ReplEvent::WorkstreamActivationChanged { .. }))
+        .expect("collected events must include WorkstreamActivationChanged");
+    match activation {
+        ReplEvent::WorkstreamActivationChanged {
+            new_active_id: None,
+            prior_id,
+        } => {
+            assert_eq!(
+                prior_id.as_deref(),
+                Some(WS_1),
+                "expected WorkstreamActivationChanged{{new_active_id: None, prior_id: Some(WS_1)}}"
+            );
+        }
+        other => panic!("expected new_active_id: None; got {other:?}"),
+    }
+
+    // Half 3 (code-critic finding on PR #3482, closing the asymmetric
+    // coverage vs. `subscribe_workstream_events_emits_activation_changed_with_wire_field_names`,
+    // which asserts the non-empty `StatuslineUpdate` for an activation): the
+    // SAME cache refresh must ALSO clear the status line's `Workstream`
+    // segment — an EMPTY segment list, not a stale one — so a regression
+    // that broke only the deactivation -> `StatuslineUpdate` wiring (wrong
+    // ordering vs. the `active_workstream` mutex write, sending before
+    // `refresh_workstream_cache` actually commits, etc.) would fail this
+    // test instead of passing every other green assertion here.
+    assert!(
+        events.iter().any(
+            |e| matches!(e, ReplEvent::StatuslineUpdate(segs) if segs.is_empty())
+        ),
+        "expected a StatuslineUpdate with an empty segment list clearing the Workstream segment \
+         on deactivation; got {events:?}"
     );
 
     engine.shutdown().await.expect("shutdown");

--- a/crates/trusty-code/tests/tui_client_engine.rs
+++ b/crates/trusty-code/tests/tui_client_engine.rs
@@ -638,9 +638,9 @@ async fn subscribe_workstream_events_refreshes_cache_on_deactivation_with_no_rep
     // `refresh_workstream_cache` actually commits, etc.) would fail this
     // test instead of passing every other green assertion here.
     assert!(
-        events.iter().any(
-            |e| matches!(e, ReplEvent::StatuslineUpdate(segs) if segs.is_empty())
-        ),
+        events
+            .iter()
+            .any(|e| matches!(e, ReplEvent::StatuslineUpdate(segs) if segs.is_empty())),
         "expected a StatuslineUpdate with an empty segment list clearing the Workstream segment \
          on deactivation; got {events:?}"
     );

--- a/crates/trusty-code/tests/tui_client_engine.rs
+++ b/crates/trusty-code/tests/tui_client_engine.rs
@@ -300,6 +300,63 @@ async fn handle_input_streams_assistant_output_and_tool_invocation() {
     );
 }
 
+/// Regression test for epic #3411's deferred Slice 3 review item: once
+/// `pump_session_events` exhausts every reconnect attempt (`GET
+/// /sessions/{id}/events` closing cleanly with no data, over and over)
+/// without ever observing a terminal `SessionDone`/`SessionCancelled` event,
+/// `handle_input` must return `Err` (not silently `Ok(true)`) AND the TUI
+/// must already have received a VISIBLE `done: true, is_error: true`
+/// `AssistantOutput` — not just a trail of `ConnectionLost`s that never clear
+/// `ReplApp::busy`. That combination is what rules out the "TUI looks alive
+/// with a stuck spinner and no error text" silent stall the review flagged.
+/// Takes ~10s of real wall-clock time
+/// (`SESSION_STREAM_MAX_RECONNECTS` reconnects at the fixed
+/// `RECONNECT_BACKOFF`, neither test-overridable) — hermetic-but-slow beats
+/// mocking away the exact timing this test asserts on.
+#[tokio::test]
+async fn handle_input_surfaces_visible_error_after_exhausting_reconnects() {
+    let server = MockServer::start().await;
+    mount_common(&server).await;
+    // Every open of GET /sessions/{id}/events closes immediately with no
+    // body — the "clean-but-premature close" case that used to `return
+    // Ok(())` silently once reconnects ran out (`pump_session_events`'s
+    // `Ok(Ok(None))` arm, before this fix).
+    Mock::given(method("GET"))
+        .and(path(format!("/sessions/{SESSION_ID}/events")))
+        .respond_with(ResponseTemplate::new(200).set_body_raw("", "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let engine = CodeEngine::with_daemon_url(reqwest::Client::new(), server.uri(), None);
+    let (tx, mut rx) = unbounded_channel();
+    engine.setup(tx.clone()).await.expect("setup");
+    while rx.try_recv().is_ok() {} // drain setup's own events
+
+    let result = engine.handle_input("hello".to_string(), tx).await;
+    assert!(
+        result.is_err(),
+        "handle_input must return Err once every reconnect attempt is exhausted with no \
+         terminal session event ever observed, not Ok(true)"
+    );
+
+    let mut saw_terminal_error = false;
+    while let Ok(ev) = rx.try_recv() {
+        if let ReplEvent::AssistantOutput {
+            done: true,
+            is_error: true,
+            ..
+        } = ev
+        {
+            saw_terminal_error = true;
+        }
+    }
+    assert!(
+        saw_terminal_error,
+        "expected a done:true, is_error:true AssistantOutput before handle_input returned Err \
+         — otherwise the TUI stalls silently (busy stays true, no error text rendered)"
+    );
+}
+
 /// `cancel_session` must call the daemon's `session.cancel` RPC — per the
 /// thin-client axiom (DOC-39 §2.1 C-2), client-side render-stop alone is
 /// never acceptable.
@@ -359,11 +416,20 @@ async fn subscribe_workstream_events_emits_activation_changed_with_wire_field_na
         .await
         .expect("subscribe_workstream_events");
 
-    let event = tokio::time::timeout(Duration::from_secs(5), async {
+    // Collect every event up through the first `WorkstreamActivationChanged`
+    // (rather than skipping straight to it) — this fix also pushes
+    // `WorkstreamUpdated`/`StatuslineUpdate` from the cache refresh that
+    // precedes it (DOC-50 §5.3, Slice 6), and this test asserts on those
+    // too, not just the activation-changed event itself.
+    let events = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut seen = Vec::new();
         loop {
             match rx.recv().await {
-                Some(ev @ ReplEvent::WorkstreamActivationChanged { .. }) => return ev,
-                Some(_) => continue,
+                Some(ev @ ReplEvent::WorkstreamActivationChanged { .. }) => {
+                    seen.push(ev);
+                    return seen;
+                }
+                Some(ev) => seen.push(ev),
                 None => panic!("channel closed before observing WorkstreamActivationChanged"),
             }
         }
@@ -371,7 +437,11 @@ async fn subscribe_workstream_events_emits_activation_changed_with_wire_field_na
     .await
     .expect("timed out waiting for WorkstreamActivationChanged");
 
-    match event {
+    let activation = events
+        .iter()
+        .find(|e| matches!(e, ReplEvent::WorkstreamActivationChanged { .. }))
+        .expect("collected events must include WorkstreamActivationChanged");
+    match activation {
         ReplEvent::WorkstreamActivationChanged {
             new_active_id,
             prior_id,
@@ -381,6 +451,25 @@ async fn subscribe_workstream_events_emits_activation_changed_with_wire_field_na
         }
         other => panic!("unexpected {other:?}"),
     }
+
+    // The SAME cache refresh that produced the activation-changed event must
+    // ALSO have pushed the status line's Workstream segment (DOC-50 §5.3's
+    // "SSE-driven status-line display") — not just the structured event a
+    // future picker/command layer consumes.
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, ReplEvent::WorkstreamUpdated(_))),
+        "expected a WorkstreamUpdated alongside the activation change; got {events:?}"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            ReplEvent::StatuslineUpdate(segs)
+                if segs.iter().any(|s| matches!(s, trusty_tui::StatuslineSegment::Workstream { .. }))
+        )),
+        "expected a StatuslineUpdate carrying a Workstream segment; got {events:?}"
+    );
 
     engine.shutdown().await.expect("shutdown");
 }

--- a/crates/trusty-tui/CHANGELOG.md
+++ b/crates/trusty-tui/CHANGELOG.md
@@ -20,6 +20,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`WorkstreamActivationChanged { new_active_id: None }` now clears `ReplApp::active_workstream` (Slice 6, closes #3418, part of epic #3411).** The reducer previously treated this event as an unconditional no-op for every `new_active_id` value, on the assumption that a follow-up `WorkstreamUpdated` always supplies the display name. That assumption doesn't hold for deactivation: `WorkstreamUpdated`'s payload is a concrete `WorkstreamSummary`, so it can never represent "no active workstream" — a deactivation left the status line showing the stale, no-longer-active workstream indefinitely. The `Some(new_id)` case is unchanged (still a deliberate no-op pending the engine's `WorkstreamUpdated`).
+
 - **`ReplEvent::WorkstreamActivationChanged.new_active_id` is now `Option<String>` (closes #3452, part of epic #3411).** The field was non-optional `String`, but the daemon legitimately publishes a `None` activation target when the active workstream is deactivated with no replacement (DOC-48 §4.2/§4.3) — mirroring `crate::events::Event::WorkstreamActivationChanged` in `trusty-code`, which already declares this field as `Option<String>`. The non-optional shape forced `trusty-code`'s Slice 3 consumer to fall back to a free-text `StatusMessage` for that case (PR #3436); this closes the gap found in that review, while `trusty-tui` still has essentially one consumer.
 
 ### Added

--- a/crates/trusty-tui/src/app/reduce.rs
+++ b/crates/trusty-tui/src/app/reduce.rs
@@ -96,12 +96,27 @@ pub fn apply(app: &mut ReplApp, ev: ReplEvent) {
         ReplEvent::ClearScrollback => app.clear_scrollback(),
         ReplEvent::StatuslineUpdate(segments) => app.statusline = segments,
         ReplEvent::WorkstreamUpdated(ws) => app.active_workstream = Some(ws),
-        ReplEvent::WorkstreamActivationChanged { .. } => {
-            // Intentional no-op: per `TuiEngine::subscribe_workstream_events`,
-            // the engine follows this with a `WorkstreamUpdated` carrying the
-            // full summary once it re-fetches — that's what actually changes
-            // the displayed workstream. This event alone names an id with no
-            // display name to show yet.
+        ReplEvent::WorkstreamActivationChanged { new_active_id, .. } => {
+            if new_active_id.is_none() {
+                // The workstream was deactivated with no replacement active
+                // (DOC-48 §4.2/§4.3, a real daemon-published state — see this
+                // variant's own doc comment). `WorkstreamUpdated`'s payload
+                // is a concrete `WorkstreamSummary`, so it structurally
+                // CANNOT represent "no active workstream" — there is no
+                // follow-up `WorkstreamUpdated` to wait for here, unlike the
+                // `Some(new_id)` case below. This is the only place the
+                // indicator gets cleared; skipping it (as a prior revision
+                // did, treating this whole variant as an unconditional
+                // no-op) left the status line showing a stale workstream
+                // name forever after a deactivation.
+                app.active_workstream = None;
+            }
+            // A `Some(new_id)` activation: per
+            // `TuiEngine::subscribe_workstream_events`'s contract, the
+            // engine follows this with a `WorkstreamUpdated` carrying the
+            // full re-fetched summary — that event, not this one, is what
+            // sets the displayed name (this event alone names an id with no
+            // display name to show yet).
         }
         ReplEvent::ConnectionLost { reason } => {
             app.push_status(format!("Connection lost: {reason}"))

--- a/crates/trusty-tui/src/app/reduce/tests.rs
+++ b/crates/trusty-tui/src/app/reduce/tests.rs
@@ -501,7 +501,10 @@ fn apply_workstream_updated_sets_active_workstream() {
 }
 
 #[test]
-fn apply_workstream_activation_changed_is_a_deliberate_noop() {
+fn apply_workstream_activation_changed_some_is_a_deliberate_noop() {
+    // `Some(new_id)` alone names an id with no display name — the engine's
+    // subsequent `WorkstreamUpdated` (asserted separately above) is what
+    // actually sets the displayed workstream in this case, not this event.
     let mut app = ReplApp::new("demo", "u");
     apply(
         &mut app,
@@ -512,6 +515,37 @@ fn apply_workstream_activation_changed_is_a_deliberate_noop() {
     );
     assert!(app.active_workstream.is_none());
     assert!(app.chat.is_empty());
+}
+
+/// Regression test (DOC-50 §5.3, Slice 6): a `WorkstreamActivationChanged`
+/// with `new_active_id: None` (the workstream was deactivated with no
+/// replacement, DOC-48 §4.2/§4.3) must clear `app.active_workstream`
+/// immediately. `ReplEvent::WorkstreamUpdated`'s payload is a concrete
+/// `WorkstreamSummary`, so it can never represent "no active workstream" —
+/// this event, and only this event, is what clears the indicator. Before
+/// this fix, `WorkstreamActivationChanged` was treated as an unconditional
+/// no-op for EVERY `new_active_id` value, so a deactivation left the status
+/// line showing the stale, no-longer-active workstream forever.
+#[test]
+fn apply_workstream_activation_changed_none_clears_active_workstream() {
+    let mut app = ReplApp::new("demo", "u");
+    app.active_workstream = Some(WorkstreamSummary {
+        id: "a1".into(),
+        name: "Token rotation".into(),
+    });
+
+    apply(
+        &mut app,
+        ReplEvent::WorkstreamActivationChanged {
+            new_active_id: None,
+            prior_id: Some("a1".into()),
+        },
+    );
+
+    assert!(
+        app.active_workstream.is_none(),
+        "deactivation must clear active_workstream, not leave the stale summary in place"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Slice 6 of the tcode TUI epic (#3411) — closes #3418. Audited what Slices 3/4 already shipped, then closed the remaining gaps in the CLIENT-SIDE workstream-awareness wiring.

**Already on main before this PR (Slices 3/4, verified — no changes needed):**
- `CodeEngine::subscribe_workstream_events` (SSE listener, reconnect loop, `WorkstreamActivationChanged{new_active_id: Option<String>}` incl. the `None`/deactivated case) — `crates/trusty-code/src/tui_client/workstream_subscription.rs`.
- `trusty-tui`'s `ReplApp` fields (`active_workstream`), `WorkstreamUpdated` reducer arm, and `widgets/status_line.rs`'s `StatuslineSegment::Workstream` rendering (`"WS: {name} ({id})"`).
- `trusty-tui::run()` (the shared event-loop entry point, Slice 2) already calls `engine.subscribe_workstream_events(tx.clone())` during setup — verified end-to-end, no change needed.

**What this PR adds (the actual gaps):**
1. **`ReplApp` now clears `active_workstream` on deactivation.** `reduce.rs`'s `WorkstreamActivationChanged` arm was an unconditional no-op for every `new_active_id` value, on the assumption a follow-up `WorkstreamUpdated` always supplies the display name — false for deactivation, since `WorkstreamUpdated`'s payload is a concrete `WorkstreamSummary` and can never represent "no active workstream." A deactivation left the status line showing the stale workstream forever. Fixed + tested (`apply_workstream_activation_changed_none_clears_active_workstream`).
2. **`CodeEngine` now actually populates the status line's `Workstream` segment.** `run_workstream_subscription` discarded `refresh_workstream_cache`'s return value, so `ReplEvent::WorkstreamUpdated` was never sent after an activation change — only the engine's OWN internal cache refreshed, not `ReplApp::active_workstream`. Now forwards the refreshed summary and pushes `ReplEvent::StatuslineUpdate` with the `Workstream` segment (new `EngineState::statusline_segments`), clearing it (empty segment list) on deactivation. Also wired into `setup()` so the first frame isn't blank.
3. **Fixed a real, previously-undetected infinite-loop bug in `pump_session_events`.** The reconnect-attempt counter reset to 0 on every merely-successful TRANSPORT-level reconnect, before the inner loop could observe whether the STREAM itself made progress. Against a daemon that accepts the connection but closes the stream immediately with no data every time, `SESSION_STREAM_MAX_RECONNECTS` was un-exhaustible — the function looped forever and `handle_input` never returned (found via the new regression test, which hung for 10+ minutes before the fix). Counter now only resets on genuine progress (an actual data payload).
4. **Closes epic #3411's deferred Slice 3 review item.** Every exhaustion path in `pump_session_events` now sends a `done: true, is_error: true` `AssistantOutput` before returning — including the clean-close case, which previously returned `Ok(())` silently, indistinguishable from a genuinely successful turn. **A terminal SSE failure now surfaces a visible error in the TUI instead of a silent stall** (confirmed via `handle_input_surfaces_visible_error_after_exhausting_reconnects`, which also caught bug #3 above).

## Test plan
- [x] `cargo build -p trusty-tui`
- [x] `cargo build --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui`
- [x] `cargo test -p trusty-tui` (140 passed) and `-- --test-threads=1` (140 passed)
- [x] `cargo test -p trusty-code --no-fail-fast` (all targets green incl. `tui_client_engine` 7/7) and `-- --test-threads=1` (same; `run_task::tests::*` intermittently fails under both parallel and serial due to an unreachable local `trusty-memory` daemon on this machine — confirmed via `git diff --stat origin/main...HEAD` that this PR touches no `run_task`/`catchup`/`trusty-search` files)
- [x] `cargo clippy --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` / `check_test_pointers.sh` — clean
- [x] Rebased onto latest `origin/main` (past Slice 7 #3476, merged during this PR's development) — additive conflict in `CHANGELOG.md` only, resolved; no conflicts in `app/reduce.rs` (Slice 7 didn't touch it)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools