### PR TITLE
ci(design): token drift-check pinning adopted UIs to Foundry canonical (refs #3486)

### DIFF
--- a/.github/workflows/token-drift.yml
+++ b/.github/workflows/token-drift.yml
@@ -1,0 +1,45 @@
+# Design-token drift gate for the trusty-tools workspace (epic #3486).
+#
+# Foundry v2 design tokens (docs/design/UI/design-system/tokens.css) are the
+# canonical hex source. Adopted UIs hand-transcribe that hex into Tailwind's
+# `--color-*: R G B` RGB-triple convention in their own `src/app.css`, so
+# nothing previously stopped the two from silently drifting apart. This job
+# re-derives each enforced crate's expected values from the canonical source
+# and fails with a per-token diff on any mismatch.
+#
+# Only trusty-agents and trusty-code-gui are enforced right now; the 5
+# pre-Foundry crates (trusty-search, trusty-memory, trusty-mpm-gui,
+# trusty-console, trusty-analyze) are allowlisted pending their own migration
+# issues (#3487/#3488/#3489/#3490) — see scripts/check_token_drift.mjs.
+#
+# Pure Node script, zero dependencies — no pnpm install / lockfile needed, so
+# this runs as its own lightweight job (matches line-cap.yml / test-pointers.yml's
+# checkout style).
+name: Token drift
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs for the same ref to save CI minutes (matches
+# line-cap.yml).
+concurrency:
+  group: token-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  token-drift:
+    name: Foundry token drift check (trusty-agents, trusty-code-gui)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Check adopted-UI tokens against canonical Foundry source
+        run: node scripts/check_token_drift.mjs

--- a/.github/workflows/token-drift.yml
+++ b/.github/workflows/token-drift.yml
@@ -15,6 +15,12 @@
 # Pure Node script, zero dependencies — no pnpm install / lockfile needed, so
 # this runs as its own lightweight job (matches line-cap.yml / test-pointers.yml's
 # checkout style).
+#
+# scripts/check_token_drift.test.mjs is a `node:test` regression suite for
+# the checker itself (drift detection, missing-block/missing-token parse
+# failures, and the zero-comparison guard — see that file's header for why).
+# It runs BEFORE the real check: if the checker's own logic is broken, its
+# verdict on the real crates isn't trustworthy either.
 name: Token drift
 
 on:
@@ -40,6 +46,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+
+      - name: Run check_token_drift.mjs regression tests
+        run: node --test scripts/check_token_drift.test.mjs
 
       - name: Check adopted-UI tokens against canonical Foundry source
         run: node scripts/check_token_drift.mjs

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -39,6 +39,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   #3492 (`@trusty/foundry` package) replaces copy-paste vendoring with a real
   import.
 
+- **CI token drift-check (refs #3486):** a new `scripts/check_token_drift.mjs`
+  pins this crate's `app.css` Foundry `--color-*` RGB-triple values to
+  `docs/design/UI/design-system/tokens.css` (the canonical hex source),
+  wired into CI as the `token-drift` workflow. Fails with a per-token diff if
+  the two silently diverge; run locally via `pnpm run check:tokens`. No
+  drift was found in this crate — every value already matched canonical.
+
 ### Fixed
 
 - **Favicon/RobotIcon drift (#3486):** `ui/public/favicon.svg` was a fourth,
@@ -47,6 +54,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   actual markup. Regenerated the favicon's geometry from `RobotIcon.svelte`'s
   `full`-variant paths (same head rect, antenna, eye positions, and stroked
   chevron+underscore mouth) so there is a single robot design instead of two.
+
+### Added
 
 - **Shared-inference seam, Step 1+2 (#2410):** `llm::inference_bridge` is a
   pure, field-by-field conversion between `async-openai`'s wire types

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -45,6 +45,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   wired into CI as the `token-drift` workflow. Fails with a per-token diff if
   the two silently diverge; run locally via `pnpm run check:tokens`. No
   drift was found in this crate — every value already matched canonical.
+  Guards against a zero-comparison false-green (an ENFORCED entry with an
+  emptied `mappings`/`passthrough` previously reported "matches canonical"
+  regardless of the file's real contents — caught by code-critic review) and
+  ships `scripts/check_token_drift.test.mjs`, a `node:test` regression suite
+  covering drift detection, missing-block/missing-token parse failures, and
+  the zero-comparison guard, run in CI ahead of the real check.
 
 ### Fixed
 

--- a/crates/trusty-agents/ui/package.json
+++ b/crates/trusty-agents/ui/package.json
@@ -11,7 +11,8 @@
     "tauri": "tauri",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "test:unit": "vitest run"
+    "test:unit": "vitest run",
+    "check:tokens": "node ../../../scripts/check_token_drift.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",

--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -10,6 +10,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **CI token drift-check (refs #3486):** a new `scripts/check_token_drift.mjs`
+  pins this crate's `app.css` Foundry `--color-*` RGB-triple values to
+  `docs/design/UI/design-system/tokens.css` (the canonical hex source),
+  wired into CI as the `token-drift` workflow. Fails with a per-token diff if
+  the two silently diverge; run locally via `pnpm run check:tokens`. Closes
+  the gap `lib/theme.test.ts` left open — that test only checks internal
+  light/dark self-consistency, not agreement with canonical. No drift was
+  found in this crate — every value already matched canonical.
+
 - **Agents + Skills management tabs (issue #3449).** Two new nav tabs —
   `AgentsTab.svelte` (replacing the prior per-session-roster stub) and the
   new `SkillsTab.svelte` — list the daemon's full agent/skill catalog with

--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -18,6 +18,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the gap `lib/theme.test.ts` left open — that test only checks internal
   light/dark self-consistency, not agreement with canonical. No drift was
   found in this crate — every value already matched canonical.
+  Guards against a zero-comparison false-green (an ENFORCED entry with an
+  emptied `mappings`/`passthrough` previously reported "matches canonical"
+  regardless of the file's real contents — caught by code-critic review) and
+  ships `scripts/check_token_drift.test.mjs`, a `node:test` regression suite
+  covering drift detection, missing-block/missing-token parse failures, and
+  the zero-comparison guard, run in CI ahead of the real check.
 
 - **Agents + Skills management tabs (issue #3449).** Two new nav tabs —
   `AgentsTab.svelte` (replacing the prior per-session-roster stub) and the

--- a/crates/trusty-code-gui/ui/package.json
+++ b/crates/trusty-code-gui/ui/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "vite build",
     "test": "vitest run",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "check:tokens": "node ../../../scripts/check_token_drift.mjs"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",

--- a/scripts/check_token_drift.mjs
+++ b/scripts/check_token_drift.mjs
@@ -208,24 +208,31 @@ function normalizeColorString(raw) {
 // Canonical source parsing
 // ---------------------------------------------------------------------------
 
-function parseCanonical(tokensCssPath) {
-  const source = readFileSync(tokensCssPath, "utf8");
+// Pure — takes canonical CSS source text directly (no file I/O), so tests
+// can exercise the real parsing/matching logic against small inline
+// fixtures instead of the actual tokens.css.
+function parseCanonicalFromSource(source, sourceLabel = TOKENS_CSS_PATH) {
   const lightBlock = extractBlock(
     source,
     /:root\s*\{([\s\S]*?)\n\}/,
     ":root (light)",
-    tokensCssPath,
+    sourceLabel,
   );
   const darkBlock = extractBlock(
     source,
     /\[data-theme=(['"])dark\1\][^{]*\{([\s\S]*?)\n\}/,
     "[data-theme='dark'] (dark)",
-    tokensCssPath,
+    sourceLabel,
   );
   return {
     light: parseDeclarations(lightBlock),
     dark: parseDeclarations(darkBlock),
   };
+}
+
+function parseCanonical(tokensCssPath) {
+  const source = readFileSync(tokensCssPath, "utf8");
+  return parseCanonicalFromSource(source, tokensCssPath);
 }
 
 function canonicalRgbTriple(canonicalMap, token, ctx) {
@@ -249,8 +256,18 @@ function canonicalRgbTriple(canonicalMap, token, ctx) {
 // Crate parsing + diffing
 // ---------------------------------------------------------------------------
 
+// `crate.file` is relative-to-REPO_ROOT for every real ENFORCED entry; tests
+// pass an absolute path to a temp fixture instead, so resolve conditionally
+// rather than blindly `path.join`-ing (path.join does NOT treat a second
+// absolute segment as a root reset).
+function resolveCrateFilePath(crate) {
+  return path.isAbsolute(crate.file)
+    ? crate.file
+    : path.join(REPO_ROOT, crate.file);
+}
+
 function parseCrate(crate) {
-  const filePath = path.join(REPO_ROOT, crate.file);
+  const filePath = resolveCrateFilePath(crate);
   const source = readFileSync(filePath, "utf8");
   const lightBlock = extractBlock(
     source,
@@ -271,9 +288,28 @@ function parseCrate(crate) {
   };
 }
 
-function checkCrate(crate, canonical) {
+// `parsedOverride`, when supplied, is used instead of reading+parsing
+// `crate.file` from disk — lets tests exercise the real comparison logic
+// against synthetic {light, dark} declaration maps without touching the
+// filesystem at all.
+function checkCrate(crate, canonical, parsedOverride) {
+  // Invariant: a crate with zero comparisons configured is not "verified
+  // clean" — it's unverified. Without this guard, an ENFORCED entry whose
+  // `mappings`/`passthrough` were accidentally (or maliciously) emptied out
+  // would silently report "OK ... matches canonical" and exit 0 regardless
+  // of what the crate's app.css actually contains — the exact false-green
+  // this whole script exists to prevent. Every other failure path here
+  // throws loudly on a structural problem; a vacuously-true pass must too.
+  const tokenCount = crate.mappings.length + crate.passthrough.length;
+  if (tokenCount === 0) {
+    throw new Error(
+      `mappings+passthrough is empty — refusing to report a pass with ` +
+        `zero comparisons`,
+    );
+  }
+
   const diffs = [];
-  const parsed = parseCrate(crate);
+  const parsed = parsedOverride ?? parseCrate(crate);
 
   for (const theme of ["light", "dark"]) {
     const canonicalMap = canonical[theme];
@@ -407,4 +443,29 @@ function main() {
   console.log("All enforced crates match the canonical token source.");
 }
 
-main();
+// Only run the CLI when executed directly (`node check_token_drift.mjs`),
+// not when imported by scripts/check_token_drift.test.mjs — an import must
+// not have the side effect of running the full check and calling
+// `process.exit()`.
+const isMainModule = import.meta.url === `file://${process.argv[1]}`;
+if (isMainModule) {
+  main();
+}
+
+export {
+  ENFORCED,
+  ALLOWLIST,
+  REPO_ROOT,
+  TOKENS_CSS_PATH,
+  hexToRgbTriple,
+  rgbTripleToHex,
+  normalizeTriple,
+  normalizeColorString,
+  parseDeclarations,
+  extractBlock,
+  parseCanonical,
+  parseCanonicalFromSource,
+  parseCrate,
+  checkCrate,
+  main,
+};

--- a/scripts/check_token_drift.mjs
+++ b/scripts/check_token_drift.mjs
@@ -1,0 +1,410 @@
+#!/usr/bin/env node
+/**
+ * Token drift-check (issue #3486, epic quick-win).
+ *
+ * Why: docs/design/UI/design-system/tokens.css is the canonical Foundry v2
+ * design-token source (hex values, light + `[data-theme='dark']` blocks).
+ * crates/trusty-agents/ui/src/app.css and crates/trusty-code-gui/ui/src/app.css
+ * both adopted it, but by HAND-TRANSCRIBING the hex into Tailwind's
+ * `--color-*: R G B` space-separated RGB-triple convention (consumed as
+ * `rgb(var(--color-*) / <alpha-value>)`), so a hand-edit to either side can
+ * silently drift the two apart. Nothing previously checked the two stay in
+ * sync — `trusty-code-gui/ui/src/lib/theme.test.ts` only asserts internal
+ * self-consistency (light/dark blocks both exist and actually differ), not
+ * agreement with the canonical source. This script closes that gap.
+ *
+ * What: parses `:root { ... }` (light) and the dark-theme block (each
+ * crate's own dark-activation selector) out of both the canonical file and
+ * each enforced crate's app.css via block-scoped regex — not a full CSS
+ * parser, but sufficient for these small, flat, hand-maintained files (no
+ * nested `{}` inside a declaration block). An explicit MAPPING per crate
+ * pins which crate custom property corresponds to which canonical
+ * `--trusty-*` token (derived from that crate's own app.css comments, which
+ * already document the 1:1 correspondence — see #3387/#3153/#3380). Canonical
+ * hex is converted to the same `"R G B"` triple format the crates use and
+ * diffed per theme. A small number of tokens are carried over verbatim as
+ * `rgba(...)` passthroughs rather than converted (e.g. `--trusty-surface-hover`
+ * in trusty-agents) — those are diffed as normalized raw strings instead.
+ *
+ * The 5 pre-Foundry crates (trusty-search, trusty-memory, trusty-mpm-gui,
+ * trusty-console, trusty-analyze) are NOT enforced yet — each is tracked in
+ * ALLOWLIST below against the issue that migrates it and removes its
+ * exemption (#3487/#3488/#3489/#3490).
+ *
+ * Test: run directly — `node scripts/check_token_drift.mjs` — or via
+ * `pnpm run check:tokens` from either enforced crate's `ui/` directory.
+ * Exits non-zero with a per-token expected/actual diff on drift, or on any
+ * parse failure (missing block/token is treated as a failure, not a silent
+ * pass — a structural change to either file should fail loudly).
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+
+const TOKENS_CSS_PATH = path.join(
+  REPO_ROOT,
+  "docs/design/UI/design-system/tokens.css",
+);
+
+// ---------------------------------------------------------------------------
+// Pending-migration crates — NOT enforced yet. Each entry is removed by the
+// PR that migrates that crate onto the canonical `--color-*` RGB-triple
+// convention. Do not add an entry here without a tracking issue.
+// ---------------------------------------------------------------------------
+const ALLOWLIST = [
+  { crate: "trusty-search", issue: "#3487" },
+  { crate: "trusty-memory", issue: "#3487" },
+  { crate: "trusty-mpm-gui", issue: "#3488" },
+  { crate: "trusty-console", issue: "#3489" },
+  { crate: "trusty-analyze", issue: "#3490" },
+];
+
+// ---------------------------------------------------------------------------
+// Enforced crates + their canonical-token mapping.
+// `mappings`: [crateVarSuffix, canonicalTokenName] — crateVarSuffix is the
+//   part after `--color-`; canonicalTokenName is the part after `--`.
+//   Compared as an RGB triple (canonical hex -> "R G B") per theme.
+// `passthrough`: [crateVarName, canonicalTokenName] — full var names,
+//   compared as normalized raw rgba(...)/hex strings (no RGB-triple
+//   conversion; the crate carries the canonical value over verbatim).
+// ---------------------------------------------------------------------------
+const ENFORCED = [
+  {
+    name: "trusty-agents",
+    file: "crates/trusty-agents/ui/src/app.css",
+    lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
+    darkSelector: /\.dark\s*\{([\s\S]*?)\n\}/,
+    mappings: [
+      ["content-bg", "trusty-content-bg"],
+      ["card-bg", "trusty-card-bg"],
+      ["text-primary", "trusty-text-primary"],
+      ["text-muted", "trusty-text-muted"],
+      ["border", "trusty-border"],
+      ["primary", "trusty-accent"],
+      ["info", "trusty-info"],
+      ["warning", "trusty-warning"],
+      ["sidebar-accent", "trusty-sidebar-accent"],
+    ],
+    passthrough: [["trusty-surface-hover", "trusty-surface-hover"]],
+  },
+  {
+    name: "trusty-code-gui",
+    file: "crates/trusty-code-gui/ui/src/app.css",
+    lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
+    darkSelector: /\[data-theme=(['"])dark\1\]\s*\{([\s\S]*?)\n\}/,
+    mappings: [
+      ["primary", "trusty-accent"],
+      ["primary-hover", "trusty-accent-hover"],
+      ["surface", "trusty-content-bg"],
+      ["card", "trusty-card-bg"],
+      ["raised", "trusty-surface-raised"],
+      ["border", "trusty-border"],
+      ["border-strong", "trusty-border-strong"],
+      ["text", "trusty-text-primary"],
+      ["text-secondary", "trusty-text-secondary"],
+      ["text-muted", "trusty-text-muted"],
+      ["text-inverse", "trusty-text-inverse"],
+      ["status-ok", "trusty-success"],
+      ["status-error", "trusty-danger"],
+      ["status-warn", "trusty-warning"],
+      ["status-neutral", "trusty-text-muted"],
+      ["sidebar-bg", "trusty-sidebar-bg"],
+      ["sidebar-text", "trusty-sidebar-text"],
+      ["sidebar-muted", "trusty-sidebar-muted"],
+      ["sidebar-border", "trusty-sidebar-border"],
+      ["sidebar-active", "trusty-sidebar-active"],
+    ],
+    passthrough: [],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+/** Strip /* ... *\/ block comments so they can't confuse declaration parsing. */
+function stripComments(text) {
+  return text.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+/** Extract a `{ ... }` block's inner text via a block-scoped regex. */
+function extractBlock(source, regex, label, filePath) {
+  const match = regex.exec(source);
+  if (!match) {
+    throw new Error(
+      `could not find ${label} block in ${filePath} (regex ${regex}) — ` +
+        `file structure changed; update check_token_drift.mjs`,
+    );
+  }
+  // Last capture group holds the block body regardless of how many groups
+  // the selector regex needed (e.g. a quote-matching backreference group).
+  return match[match.length - 1];
+}
+
+/** Parse `--name: value;` declarations out of block text into a Map. */
+function parseDeclarations(blockText) {
+  const decls = new Map();
+  const re = /--([a-z0-9-]+)\s*:\s*([^;]+);/gi;
+  let m;
+  for (const clean = stripComments(blockText); (m = re.exec(clean)); ) {
+    decls.set(m[1], m[2].trim());
+  }
+  return decls;
+}
+
+function hexToRgbTriple(hex) {
+  const clean = hex.replace("#", "");
+  if (!/^[0-9a-fA-F]{6}$/.test(clean)) {
+    throw new Error(`not a 6-digit hex color: "${hex}"`);
+  }
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return `${r} ${g} ${b}`;
+}
+
+function rgbTripleToHex(triple) {
+  const parts = triple.trim().split(/\s+/).map(Number);
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+    throw new Error(`not a valid "R G B" triple: "${triple}"`);
+  }
+  return (
+    "#" +
+    parts.map((n) => n.toString(16).padStart(2, "0")).join("")
+  );
+}
+
+function normalizeTriple(raw) {
+  const parts = raw.trim().split(/\s+/).map(Number);
+  if (parts.length !== 3 || parts.some((n) => Number.isNaN(n))) {
+    throw new Error(`not a valid "R G B" triple: "${raw}"`);
+  }
+  return parts.join(" ");
+}
+
+/** Normalize an rgba()/rgb()/hex passthrough value for string comparison. */
+function normalizeColorString(raw) {
+  const trimmed = raw.trim();
+  const fnMatch = /^rgba?\(([^)]+)\)$/i.exec(trimmed);
+  if (fnMatch) {
+    const nums = fnMatch[1]
+      .split(",")
+      .map((s) => s.trim())
+      .map((s) => (s.includes(".") ? parseFloat(s) : parseInt(s, 10)));
+    const fnName = trimmed.slice(0, trimmed.indexOf("(")).toLowerCase();
+    return `${fnName}(${nums.join(", ")})`;
+  }
+  if (trimmed.startsWith("#")) {
+    return trimmed.toLowerCase();
+  }
+  return trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// Canonical source parsing
+// ---------------------------------------------------------------------------
+
+function parseCanonical(tokensCssPath) {
+  const source = readFileSync(tokensCssPath, "utf8");
+  const lightBlock = extractBlock(
+    source,
+    /:root\s*\{([\s\S]*?)\n\}/,
+    ":root (light)",
+    tokensCssPath,
+  );
+  const darkBlock = extractBlock(
+    source,
+    /\[data-theme=(['"])dark\1\][^{]*\{([\s\S]*?)\n\}/,
+    "[data-theme='dark'] (dark)",
+    tokensCssPath,
+  );
+  return {
+    light: parseDeclarations(lightBlock),
+    dark: parseDeclarations(darkBlock),
+  };
+}
+
+function canonicalRgbTriple(canonicalMap, token, ctx) {
+  if (!canonicalMap.has(token)) {
+    throw new Error(
+      `canonical token "--${token}" not found in ${ctx} block of ` +
+        `${TOKENS_CSS_PATH} — mapping in check_token_drift.mjs is stale`,
+    );
+  }
+  const raw = canonicalMap.get(token);
+  if (!raw.startsWith("#")) {
+    throw new Error(
+      `canonical token "--${token}" (${ctx}) is not a hex value ("${raw}") ` +
+        `— it can't be used in an RGB-triple mapping; use "passthrough" instead`,
+    );
+  }
+  return hexToRgbTriple(raw);
+}
+
+// ---------------------------------------------------------------------------
+// Crate parsing + diffing
+// ---------------------------------------------------------------------------
+
+function parseCrate(crate) {
+  const filePath = path.join(REPO_ROOT, crate.file);
+  const source = readFileSync(filePath, "utf8");
+  const lightBlock = extractBlock(
+    source,
+    crate.lightSelector,
+    ":root (light)",
+    filePath,
+  );
+  const darkBlock = extractBlock(
+    source,
+    crate.darkSelector,
+    "dark",
+    filePath,
+  );
+  return {
+    filePath,
+    light: parseDeclarations(lightBlock),
+    dark: parseDeclarations(darkBlock),
+  };
+}
+
+function checkCrate(crate, canonical) {
+  const diffs = [];
+  const parsed = parseCrate(crate);
+
+  for (const theme of ["light", "dark"]) {
+    const canonicalMap = canonical[theme];
+    const crateMap = parsed[theme];
+
+    for (const [crateSuffix, canonicalToken] of crate.mappings) {
+      const crateVar = `color-${crateSuffix}`;
+      const expected = canonicalRgbTriple(canonicalMap, canonicalToken, theme);
+
+      if (!crateMap.has(crateVar)) {
+        diffs.push({
+          crate: crate.name,
+          theme,
+          var: `--${crateVar}`,
+          canonicalToken,
+          expected: `${expected} (${rgbTripleToHex(expected)})`,
+          actual: "<missing>",
+        });
+        continue;
+      }
+
+      const actualRaw = crateMap.get(crateVar);
+      const actual = normalizeTriple(actualRaw);
+      if (actual !== expected) {
+        diffs.push({
+          crate: crate.name,
+          theme,
+          var: `--${crateVar}`,
+          canonicalToken,
+          expected: `${expected} (${rgbTripleToHex(expected)})`,
+          actual: `${actual} (${rgbTripleToHex(actual)})`,
+        });
+      }
+    }
+
+    for (const [crateVarName, canonicalToken] of crate.passthrough) {
+      if (!canonicalMap.has(canonicalToken)) {
+        throw new Error(
+          `canonical token "--${canonicalToken}" (${theme}) not found for ` +
+            `passthrough mapping in ${crate.name} — mapping is stale`,
+        );
+      }
+      const expectedRaw = canonicalMap.get(canonicalToken);
+      const expected = normalizeColorString(expectedRaw);
+
+      if (!crateMap.has(crateVarName)) {
+        diffs.push({
+          crate: crate.name,
+          theme,
+          var: `--${crateVarName}`,
+          canonicalToken,
+          expected,
+          actual: "<missing>",
+        });
+        continue;
+      }
+
+      const actual = normalizeColorString(crateMap.get(crateVarName));
+      if (actual !== expected) {
+        diffs.push({
+          crate: crate.name,
+          theme,
+          var: `--${crateVarName}`,
+          canonicalToken,
+          expected,
+          actual,
+        });
+      }
+    }
+  }
+
+  return diffs;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  console.log(`Canonical source: ${path.relative(REPO_ROOT, TOKENS_CSS_PATH)}`);
+  console.log("");
+
+  let canonical;
+  try {
+    canonical = parseCanonical(TOKENS_CSS_PATH);
+  } catch (err) {
+    console.error(`FATAL: failed to parse canonical tokens.css: ${err.message}`);
+    process.exit(1);
+  }
+
+  const allDiffs = [];
+  for (const crate of ENFORCED) {
+    try {
+      const diffs = checkCrate(crate, canonical);
+      if (diffs.length === 0) {
+        console.log(`OK   ${crate.name} (${crate.file}) — matches canonical`);
+      } else {
+        console.log(`DRIFT ${crate.name} (${crate.file}) — ${diffs.length} mismatch(es)`);
+      }
+      allDiffs.push(...diffs);
+    } catch (err) {
+      console.error(`FATAL: ${crate.name}: ${err.message}`);
+      process.exit(1);
+    }
+  }
+
+  console.log("");
+  console.log("Allowlisted (not yet enforced — pending Foundry migration):");
+  for (const entry of ALLOWLIST) {
+    console.log(`  - ${entry.crate} (${entry.issue})`);
+  }
+
+  if (allDiffs.length > 0) {
+    console.log("");
+    console.error(`TOKEN DRIFT DETECTED (${allDiffs.length} mismatch(es)):`);
+    for (const d of allDiffs) {
+      console.error(
+        `  [${d.crate}/${d.theme}] ${d.var} (canonical --${d.canonicalToken}): ` +
+          `expected "${d.expected}", found "${d.actual}"`,
+      );
+    }
+    console.error("");
+    console.error(
+      "Fix: update the crate's app.css value(s) to match docs/design/UI/design-system/tokens.css, " +
+        "or if the canonical file changed intentionally, this diff confirms the crate needs updating too.",
+    );
+    process.exit(1);
+  }
+
+  console.log("");
+  console.log("All enforced crates match the canonical token source.");
+}
+
+main();

--- a/scripts/check_token_drift.test.mjs
+++ b/scripts/check_token_drift.test.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for check_token_drift.mjs (issue #3486 review follow-up).
+ *
+ * Why: the manual negative-test performed while authoring the script
+ * (mutate a value, confirm failure, revert) was run once, by hand, locally
+ * — CI never re-runs it, so a future refactor of the comparison/guard logic
+ * could reintroduce a false-green with nothing to catch it. Concretely: a
+ * code-critic review of this script found that emptying an ENFORCED
+ * crate's `mappings`/`passthrough` to `[]` made the script print
+ * "OK ... matches canonical" and exit 0 even with a simultaneously wrong
+ * `app.css` value — the exact false-green this whole check exists to
+ * prevent. This file mechanizes that finding (and the general drift/parse-
+ * failure paths) as an executable, CI-run regression suite using only
+ * Node's built-in test runner (`node:test` + `node:assert/strict`) — no new
+ * dependency.
+ *
+ * What: uses `node scripts/check_token_drift.mjs`'s exported pure helpers
+ * (`checkCrate`, `parseCanonicalFromSource`, `parseCrate`, `ENFORCED`)
+ * against small inline CSS fixtures (and one on-disk temp fixture for the
+ * missing-block case, since that path is disk-based) rather than the real
+ * tokens.css / app.css files, so these tests are independent of whatever
+ * the real design tokens currently say.
+ *
+ * Test: `node --test scripts/check_token_drift.test.mjs` (see the
+ * `token-drift` CI job, which runs this after the drift check itself).
+ */
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  ENFORCED,
+  checkCrate,
+  parseCanonicalFromSource,
+  parseCrate,
+} from "./check_token_drift.mjs";
+
+// A minimal canonical source with one token that differs between light and
+// dark, used by the in-memory (no-disk) fixture tests below.
+const CANONICAL_SOURCE = `
+:root {
+  --trusty-foo: #112233;
+}
+
+[data-theme='dark'], .dark {
+  --trusty-foo: #445566;
+}
+`;
+
+function makeFixtureCrate(overrides = {}) {
+  return {
+    name: "fixture-crate",
+    file: "unused-when-parsedOverride-is-supplied.css",
+    lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
+    darkSelector: /\.dark\s*\{([\s\S]*?)\n\}/,
+    mappings: [["foo", "trusty-foo"]],
+    passthrough: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// (a) drift on a mutated value is detected — non-zero (throws-free; the
+//     caller inspects the returned diffs and CLI is the one that exits 1).
+// ---------------------------------------------------------------------------
+
+test("checkCrate detects a mutated dark-theme value as drift", () => {
+  const canonical = parseCanonicalFromSource(CANONICAL_SOURCE, "<inline canonical fixture>");
+
+  const parsedCrate = {
+    light: new Map([["color-foo", "17 34 51"]]), // correct: #112233
+    dark: new Map([["color-foo", "1 2 3"]]), // WRONG: should be 68 85 102 (#445566)
+  };
+
+  const diffs = checkCrate(makeFixtureCrate(), canonical, parsedCrate);
+
+  assert.equal(diffs.length, 1, "expected exactly one drift (dark theme only)");
+  assert.equal(diffs[0].theme, "dark");
+  assert.equal(diffs[0].var, "--color-foo");
+  assert.match(diffs[0].actual, /^1 2 3/);
+  assert.match(diffs[0].expected, /^68 85 102/);
+});
+
+test("checkCrate reports zero diffs when every value matches canonical", () => {
+  const canonical = parseCanonicalFromSource(CANONICAL_SOURCE, "<inline canonical fixture>");
+
+  const parsedCrate = {
+    light: new Map([["color-foo", "17 34 51"]]), // #112233
+    dark: new Map([["color-foo", "68 85 102"]]), // #445566
+  };
+
+  const diffs = checkCrate(makeFixtureCrate(), canonical, parsedCrate);
+  assert.equal(diffs.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// (b) a missing :root/dark block throws (disk-based — extractBlock's
+//     failure path is exercised against a real temp file).
+// ---------------------------------------------------------------------------
+
+test("parseCrate throws when the dark block is missing from the file", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "token-drift-test-"));
+  const filePath = path.join(dir, "app.css");
+  try {
+    // Valid :root block, but no `.dark { ... }` block at all.
+    writeFileSync(
+      filePath,
+      `:root {\n  --color-foo: 17 34 51;\n}\n`,
+      "utf8",
+    );
+
+    const crate = makeFixtureCrate({ file: filePath });
+    assert.throws(
+      () => parseCrate(crate),
+      /could not find dark block/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (c) a missing canonical token throws (crate mapping references a token
+//     that doesn't exist in the canonical source).
+// ---------------------------------------------------------------------------
+
+test("checkCrate throws when a mapped canonical token doesn't exist", () => {
+  const canonical = parseCanonicalFromSource(CANONICAL_SOURCE, "<inline canonical fixture>");
+
+  const parsedCrate = {
+    light: new Map([["color-bar", "1 2 3"]]),
+    dark: new Map([["color-bar", "1 2 3"]]),
+  };
+
+  const crate = makeFixtureCrate({
+    mappings: [["bar", "trusty-does-not-exist"]],
+  });
+
+  assert.throws(
+    () => checkCrate(crate, canonical, parsedCrate),
+    /canonical token "--trusty-does-not-exist" not found/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// (d) the zero-comparison guard — both as a data invariant over the real
+//     ENFORCED table (protects the #3487-#3490 migration PRs from silently
+//     emptying an entry) and as a direct exercise of checkCrate's own throw.
+// ---------------------------------------------------------------------------
+
+test("every ENFORCED crate has at least one mapping or passthrough entry", () => {
+  assert.ok(ENFORCED.length > 0, "ENFORCED must not itself be empty");
+  for (const crate of ENFORCED) {
+    const tokenCount = crate.mappings.length + crate.passthrough.length;
+    assert.ok(
+      tokenCount > 0,
+      `${crate.name}: mappings+passthrough is empty — an enforced crate ` +
+        `must compare at least one token`,
+    );
+  }
+});
+
+test("checkCrate refuses to report a pass with zero comparisons configured", () => {
+  const canonical = parseCanonicalFromSource(CANONICAL_SOURCE, "<inline canonical fixture>");
+  const crate = makeFixtureCrate({ mappings: [], passthrough: [] });
+
+  // Even with a bogus, never-read file path and no parsedOverride, the
+  // guard must fire before any file I/O is attempted.
+  assert.throws(
+    () => checkCrate(crate, canonical),
+    /mappings\+passthrough is empty/,
+  );
+});


### PR DESCRIPTION
## Summary

Quick-win PR for epic #3486. Adds a CI gate that pins each Foundry-adopted UI's design tokens to the canonical source (`docs/design/UI/design-system/tokens.css`) so hand-transcribed hex values can't silently diverge.

**Enforced (checked against canonical, fails CI on drift):**
- `trusty-agents` (`crates/trusty-agents/ui/src/app.css`)
- `trusty-code-gui` (`crates/trusty-code-gui/ui/src/app.css`)

**Allowlisted (pre-Foundry palettes, pending migration — not enforced yet):**
- `trusty-search` — #3487
- `trusty-memory` — #3487
- `trusty-mpm-gui` — #3488
- `trusty-console` — #3489
- `trusty-analyze` — #3490

Each allowlist entry is inline-commented with its issue in `scripts/check_token_drift.mjs`; the PR that migrates a crate deletes its entry.

## Drift state found

Ran the check against current `main` (via `origin/main`) before making any other change: **both enforced crates already matched canonical exactly**, per-token, per theme (light + dark) — no `app.css` fixes were needed. This closes a real gap rather than a hypothetical one: `crates/trusty-code-gui/ui/src/lib/theme.test.ts` only asserts internal light/dark self-consistency, never agreement with the canonical hex source, so a future hand-edit drifting either file would previously have gone undetected.

I also negative-tested the checker itself (deliberately mutated one hex value in a scratch copy, confirmed it fails with a precise diff, then restored the file) before trusting the green result — see verification output below.

## What changed

- `scripts/check_token_drift.mjs` (new) — zero-dependency Node script. Parses `:root`/dark blocks from the canonical `tokens.css` and each enforced crate's `app.css` via block-scoped regex, converts canonical hex → the `"R G B"` triple format the crates use, and diffs per mapped token/theme. A couple of tokens (e.g. `trusty-agents`'s `--trusty-surface-hover`) are carried over verbatim as `rgba(...)` passthroughs rather than RGB-triple-converted, and are diffed as normalized raw strings.
- `.github/workflows/token-drift.yml` (new) — dedicated CI job (matches the style of `line-cap.yml`/`test-pointers.yml`), runs `node scripts/check_token_drift.mjs` via `actions/setup-node`. No pnpm install needed — the script has zero deps.
- `crates/trusty-agents/ui/package.json`, `crates/trusty-code-gui/ui/package.json` — added `"check:tokens"` script so it's runnable locally as `pnpm run check:tokens` from either crate's `ui/` directory.
- `crates/trusty-agents/CHANGELOG.md`, `crates/trusty-code-gui/CHANGELOG.md` — `[Unreleased]` entries per changelog-per-PR standard.

## Test plan

- [x] `node scripts/check_token_drift.mjs` from repo root — exits 0, both enforced crates report "matches canonical"
- [x] `pnpm run check:tokens` from `crates/trusty-agents/ui` and `crates/trusty-code-gui/ui` — both exit 0
- [x] Negative test: injected a deliberate 1-value drift into a scratch copy of `trusty-agents/ui/src/app.css`, confirmed the script exits 1 with an exact expected/actual diff, then restored the file (verified clean via `git diff --stat`)
- [x] `pnpm test` (vitest) in `crates/trusty-code-gui/ui` — 24 files / 272 tests passed, including `lib/theme.test.ts`
- [x] `pnpm run test:unit` (vitest) in `crates/trusty-agents/ui` — 3 files / 38 tests passed
- [x] YAML-validated the new workflow file

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools