### PR TITLE
fix(embedder): platform-conditional ORT intra-op thread default (macOS was throttled ~3.5x by the Linux/CUDA #1668 pin)

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- **Performance:** `FastEmbedder`'s ORT intra-op thread default is now
+  platform/execution-provider-conditional instead of an unconditional `1`.
+  The `1` pin was introduced by PR #1668 to fix a real CUDA deferred-embed
+  deadlock (AL2023 Linux + CUDA EP + dynamically-loaded ORT,
+  code-intelligence #1542) but applied to every build, including the
+  CoreML/CPU-EP path used on Apple Silicon where no such deadlock exists —
+  throttling macOS embedding throughput ~3.5× for no safety benefit (issue
+  #3493 P0). `default_ort_intra_threads()` now resolves to `1` only when the
+  `embedder-cuda` feature is compiled in (the only build that can register
+  the CUDA EP); every other build resolves to
+  `std::thread::available_parallelism()`, matching fastembed's own
+  per-session default. `TRUSTY_ORT_INTRA_THREADS` remains the operator
+  override for either default. `DEFAULT_ORT_INTRA_THREADS` (a constant) is
+  replaced by the `default_ort_intra_threads()` function — the only
+  consumer was this crate's own resolver, so no downstream crate references
+  it.
+
 ## [0.23.5] — 2026-07-20
 
 ### Added

--- a/crates/trusty-common/src/embedder/fast_embedder.rs
+++ b/crates/trusty-common/src/embedder/fast_embedder.rs
@@ -65,7 +65,8 @@ static ORT_RUNTIME: OnceLock<OrtThreadingOptions> = OnceLock::new();
 /// `with_intra_threads(available_parallelism())` (= logical CPU count) — it
 /// exposes no hook to override per-session thread counts. On the CUDA
 /// deferred-embed path that multi-threaded intra-op barrier deadlocks inside
-/// `libonnxruntime` 1.24.2 (code-intelligence #1542): the pool reports
+/// `libonnxruntime` 1.24.2 (code-intelligence #1542, fixed in this repo by
+/// PR #1668): the pool reports
 /// `workers: 2` yet 8 ORT threads spin, two busy-wait at ~70% CPU while the
 /// rest block forever in `condition_variable::wait`, yielding 0 embeddings and
 /// an empty 112-byte HNSW. ORT's *global* thread pool is the one lever that
@@ -74,7 +75,10 @@ static ORT_RUNTIME: OnceLock<OrtThreadingOptions> = OnceLock::new();
 /// so fastembed's `with_intra_threads(N)` is ignored and the global pool's
 /// thread count + spin policy govern instead.
 /// What: resolves [`OrtThreadingOptions`] from the environment (defaults:
-/// intra=1, inter=1, spinning=off), commits `ort::init().with_global_thread_pool(..)`,
+/// intra=platform/EP-conditional — `1` under the `embedder-cuda` feature
+/// (the only build that can hit the PR #1668 CUDA deadlock), else
+/// `available_parallelism()` — inter=1, spinning=off), commits
+/// `ort::init().with_global_thread_pool(..)`,
 /// and caches the result in [`ORT_RUNTIME`]. Must be called *before* any
 /// `TextEmbedding::try_new`; `ort::init().commit()` is a no-op once any
 /// session/environment already exists. Idempotent and thread-safe via
@@ -100,15 +104,15 @@ fn init_ort_runtime() -> OrtThreadingOptions {
                         inter_threads = opts.inter_threads,
                         allow_spinning = opts.allow_spinning,
                         "trusty-embedder: committed ORT global thread pool \
-                         (deadlock fix #1542 — overrides fastembed's per-session \
+                         (deadlock fix PR #1668 — overrides fastembed's per-session \
                          with_intra_threads(num_cpus) via DisablePerSessionThreads)"
                     );
                 } else {
                     tracing::warn!(
                         intra_threads = opts.intra_threads,
                         "trusty-embedder: ORT environment already committed before \
-                         init_ort_runtime() — the single-intra-op-thread deadlock fix \
-                         (#1542) did NOT take effect; ensure no ORT session is created \
+                         init_ort_runtime() — the intra-op thread pin from \
+                         PR #1668 did NOT take effect; ensure no ORT session is created \
                          before the embedder initialises"
                     );
                 }
@@ -117,7 +121,7 @@ fn init_ort_runtime() -> OrtThreadingOptions {
                 tracing::error!(
                     error = %e,
                     "trusty-embedder: failed to build ORT global thread pool options; \
-                     falling back to fastembed defaults (deadlock fix #1542 NOT applied)"
+                     falling back to fastembed defaults (deadlock fix PR #1668 NOT applied)"
                 );
             }
         }
@@ -504,11 +508,14 @@ impl FastEmbedder {
 
         let (model, provider) =
             tokio::task::spawn_blocking(|| -> Result<(TextEmbedding, ExecutionProvider)> {
-                // Commit the ORT global thread pool (intra=1, spinning=off by
-                // default) BEFORE fastembed creates any session, so the
-                // per-session `with_intra_threads(num_cpus)` it hardcodes is
-                // overridden via DisablePerSessionThreads. This is the
-                // deferred-embed deadlock fix (#1542).
+                // Commit the ORT global thread pool (intra=platform/EP-
+                // conditional, spinning=off by default) BEFORE fastembed
+                // creates any session, so the per-session
+                // `with_intra_threads(num_cpus)` it hardcodes is overridden
+                // via DisablePerSessionThreads. This is the deferred-embed
+                // deadlock fix (PR #1668), scoped to keep intra=1 only under
+                // the `embedder-cuda` feature — the only build that can hit
+                // the CUDA barrier deadlock (issue #3493 P0).
                 init_ort_runtime();
 
                 let require_gpu = std::env::var("TRUSTY_DEVICE")

--- a/crates/trusty-common/src/embedder/mod.rs
+++ b/crates/trusty-common/src/embedder/mod.rs
@@ -43,8 +43,8 @@ mod mock;
 pub use fast_embedder::FastEmbedder;
 pub use types::{
     CudaOptions, DEFAULT_CACHE_CAPACITY, DEFAULT_CUDA_GPU_MEM_LIMIT_BYTES,
-    DEFAULT_ORT_INTER_THREADS, DEFAULT_ORT_INTRA_THREADS, EMBED_DIM, Embedder, ExecutionProvider,
-    OrtThreadingOptions, embed_one, resolve_cuda_options, resolve_expected_provider,
+    DEFAULT_ORT_INTER_THREADS, EMBED_DIM, Embedder, ExecutionProvider, OrtThreadingOptions,
+    default_ort_intra_threads, embed_one, resolve_cuda_options, resolve_expected_provider,
     resolve_fastembed_cache_dir, resolve_ort_threading_options,
 };
 
@@ -248,13 +248,20 @@ mod tests {
         }
     }
 
-    /// Why: #1542 — the CUDA deferred-embed deadlock is fixed by pinning ORT's
-    /// intra-/inter-op threads to 1 and disabling intra-op spinning. With no
-    /// operator override the resolver must default to that safe single-threaded,
-    /// no-spin profile so the daemon never reproduces the 8-ORT-thread barrier
-    /// deadlock out of the box.
-    /// What: clears all three knobs and asserts the defaults.
-    /// Test: this test.
+    /// Why: PR #1668 — the CUDA deferred-embed deadlock is fixed by pinning
+    /// ORT's intra-/inter-op threads to 1 and disabling intra-op spinning
+    /// under the `embedder-cuda` feature (the only build that can register
+    /// the CUDA EP). With no operator override the resolver must default to
+    /// [`default_ort_intra_threads`]'s platform/EP-conditional value and to
+    /// `1` inter-op / no-spin, so CUDA builds never reproduce the
+    /// 8-ORT-thread barrier deadlock out of the box, while CoreML/CPU-EP
+    /// builds (e.g. macOS) are not throttled by a pin that does not apply to
+    /// them (issue #3493 P0).
+    /// What: clears all three knobs and asserts the defaults match
+    /// `default_ort_intra_threads()` / `DEFAULT_ORT_INTER_THREADS`.
+    /// Test: this test; see also `ort_intra_threads_default_pinned_under_cuda_feature`
+    /// and `ort_intra_threads_default_uses_available_parallelism` below for
+    /// the two build-variant assertions.
     #[test]
     fn ort_threading_defaults() {
         let _g = ENV_LOCK.lock().unwrap();
@@ -264,16 +271,56 @@ mod tests {
 
         let opts = resolve_ort_threading_options();
         assert_eq!(
-            opts.intra_threads, DEFAULT_ORT_INTRA_THREADS,
-            "default intra-op threads must be 1 to avoid the #1542 barrier deadlock"
+            opts.intra_threads,
+            default_ort_intra_threads(),
+            "default intra-op threads must match the platform/EP-conditional resolver"
         );
         assert_eq!(opts.inter_threads, DEFAULT_ORT_INTER_THREADS);
         assert!(
             !opts.allow_spinning,
             "spinning must default to off — it is the busy-wait half of the deadlock"
         );
-        assert_eq!(DEFAULT_ORT_INTRA_THREADS, 1);
         assert_eq!(DEFAULT_ORT_INTER_THREADS, 1);
+    }
+
+    /// Why: PR #1668's CUDA barrier deadlock only exists when the CUDA EP can
+    /// be registered — i.e. the `embedder-cuda` feature — so that is the only
+    /// build variant where `default_ort_intra_threads()` must stay pinned to
+    /// `1` (issue #3493 P0: an earlier unconditional pin throttled macOS
+    /// CoreML/CPU-EP throughput ~3.5× with no corresponding safety benefit).
+    /// What: asserts the CUDA-feature default is exactly `1`.
+    /// Test: this test (only compiled into `--features embedder-cuda` builds).
+    #[cfg(feature = "embedder-cuda")]
+    #[test]
+    fn ort_intra_threads_default_pinned_under_cuda_feature() {
+        assert_eq!(
+            default_ort_intra_threads(),
+            1,
+            "CUDA-EP builds must keep the PR #1668 single-intra-op-thread pin"
+        );
+    }
+
+    /// Why: outside the `embedder-cuda` feature (CoreML on Apple Silicon, or
+    /// any other CPU-only build) there is no CUDA barrier to deadlock on, so
+    /// the intra-op default should recover fastembed's own
+    /// `available_parallelism()` behaviour instead of the CUDA-only `1` pin
+    /// (issue #3493 P0).
+    /// What: asserts the non-CUDA default equals
+    /// `std::thread::available_parallelism()` (falling back to `1` only if
+    /// the host cannot report a count) — on any real multi-core CI/dev
+    /// machine (including macOS) this is `> 1`.
+    /// Test: this test (only compiled into non-`embedder-cuda` builds).
+    #[cfg(not(feature = "embedder-cuda"))]
+    #[test]
+    fn ort_intra_threads_default_uses_available_parallelism() {
+        let expected = std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1);
+        assert_eq!(
+            default_ort_intra_threads(),
+            expected,
+            "non-CUDA builds must use available_parallelism(), not the CUDA-only pin of 1"
+        );
     }
 
     /// Why: operators on hosts proven free of the ORT barrier bug may want to
@@ -314,7 +361,8 @@ mod tests {
 
         let opts = resolve_ort_threading_options();
         assert_eq!(
-            opts.intra_threads, DEFAULT_ORT_INTRA_THREADS,
+            opts.intra_threads,
+            default_ort_intra_threads(),
             "malformed intra-op count must fall back to the safe default"
         );
         assert_eq!(

--- a/crates/trusty-common/src/embedder/types.rs
+++ b/crates/trusty-common/src/embedder/types.rs
@@ -88,21 +88,50 @@ pub fn resolve_cuda_options() -> CudaOptions {
     }
 }
 
-/// Default ORT intra-op thread count for embedder sessions.
+/// Resolve the platform/execution-provider-conditional default ORT intra-op
+/// thread count for embedder sessions, used when `TRUSTY_ORT_INTRA_THREADS`
+/// is unset or unparseable.
 ///
-/// Why: fastembed-rs hardcodes `with_intra_threads(available_parallelism())` on
-/// every session it builds, so each embed-pool worker's ORT session spins up
-/// one intra-op thread *per logical CPU*. On the CUDA deferred-embed path this
-/// multi-threaded intra-op barrier deadlocks inside `libonnxruntime` 1.24.2: a
-/// couple of workers busy-spin while the rest block forever in
-/// `condition_variable::wait`, producing 0 embeddings and an empty HNSW index
-/// (code-intelligence #1542). Pinning intra-op to a single thread removes the
-/// barrier entirely — there is no second worker to wait on — so the pass can
-/// never deadlock. `1` is the safe default; raise it only on hosts proven not
-/// to hit the ORT barrier bug.
-/// What: `1`, used when `TRUSTY_ORT_INTRA_THREADS` is unset or unparseable.
-/// Test: `ort_threading_defaults` asserts the resolver returns this value.
-pub const DEFAULT_ORT_INTRA_THREADS: usize = 1;
+/// Why: fastembed-rs hardcodes `with_intra_threads(available_parallelism())`
+/// on every session it builds, so each embed-pool worker's ORT session spins
+/// up one intra-op thread *per logical CPU* by default. On the CUDA
+/// deferred-embed path this multi-threaded intra-op barrier deadlocks inside
+/// `libonnxruntime` 1.24.2: a couple of workers busy-spin while the rest
+/// block forever in `condition_variable::wait`, producing 0 embeddings and an
+/// empty HNSW index (code-intelligence #1542, fixed here by PR #1668).
+/// Pinning intra-op to a single thread removes the barrier entirely — there
+/// is no second worker to wait on — so the pass can never deadlock. But that
+/// deadlock only exists on the CUDA execution-provider path (AL2023 Linux +
+/// dynamically-loaded ORT, the `embedder-cuda` feature — see
+/// `FastEmbedder::init_options`'s CUDA branch): the CoreML/CPU-EP path used
+/// everywhere else (Apple Silicon, and any other non-CUDA CPU-only build) has
+/// no such barrier, and pinning it to `1` there was an unconditional
+/// over-application of the PR #1668 fix that throttled macOS embedding
+/// throughput ~3.5× for no safety benefit (issue #3493 P0).
+/// What: `1` when the `embedder-cuda` feature is compiled in (the only build
+/// variant that can ever register the CUDA EP and hit the PR #1668
+/// deadlock); otherwise `std::thread::available_parallelism()` (num_cpus,
+/// falling back to `1` if the host cannot report a count), matching
+/// fastembed's own per-session default and recovering full CPU-EP/CoreML
+/// throughput. Raise the CUDA-feature default only on hosts proven not to hit
+/// the ORT barrier bug, via `TRUSTY_ORT_INTRA_THREADS`.
+/// Test: `ort_intra_threads_default_pinned_under_cuda_feature` and
+/// `ort_intra_threads_default_uses_available_parallelism` in `mod.rs` cover
+/// the two build variants.
+#[cfg(feature = "embedder-cuda")]
+pub fn default_ort_intra_threads() -> usize {
+    1
+}
+
+/// Non-CUDA (CoreML/CPU-EP) variant of [`default_ort_intra_threads`] — see
+/// that function's doc comment (compiled under `feature = "embedder-cuda"`)
+/// for the full rationale.
+#[cfg(not(feature = "embedder-cuda"))]
+pub fn default_ort_intra_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1)
+}
 
 /// Default ORT inter-op thread count for embedder sessions.
 ///
@@ -110,7 +139,10 @@ pub const DEFAULT_ORT_INTRA_THREADS: usize = 1;
 /// branches under `with_parallel_execution(true)`, which the all-MiniLM
 /// embedder does not use. Pinning it to `1` keeps the total ORT thread count
 /// deterministic (= number of embed-pool workers) instead of
-/// workers × CPUs, which is the workers-vs-threads mismatch behind #1542.
+/// workers × CPUs, which is the workers-vs-threads mismatch PR #1668 fixed.
+/// Unlike intra-op threads, this default is platform/EP-independent: no
+/// build variant benefits from inter-op parallelism here, so it is not
+/// gated by the `embedder-cuda` feature.
 /// What: `1`, used when `TRUSTY_ORT_INTER_THREADS` is unset or unparseable.
 /// Test: `ort_threading_defaults`.
 pub const DEFAULT_ORT_INTER_THREADS: usize = 1;
@@ -135,8 +167,8 @@ pub struct OrtThreadingOptions {
     /// Threads used for parallelization *between* ORT operators.
     pub inter_threads: usize,
     /// Whether ORT worker threads may busy-spin when their queue is empty.
-    /// Disabled by default: spinning is the half of the #1542 deadlock that
-    /// pins two workers at ~70% CPU, and the embed pass is bursty (not a
+    /// Disabled by default: spinning is the half of the PR #1668 deadlock
+    /// that pins two workers at ~70% CPU, and the embed pass is bursty (not a
     /// constant inference stream) so spinning buys nothing here.
     pub allow_spinning: bool,
 }
@@ -145,14 +177,18 @@ pub struct OrtThreadingOptions {
 ///
 /// Why: centralises the `TRUSTY_ORT_*` knob parsing so the live global-thread-
 /// pool builder and the unit tests agree on precedence and defaults, keeping
-/// the deadlock fix (#1542) verifiable without ORT/CUDA.
-/// What: reads `TRUSTY_ORT_INTRA_THREADS` and `TRUSTY_ORT_INTER_THREADS`
-/// (positive integers; malformed/zero values fall back to the safe defaults of
-/// `1`) and `TRUSTY_ORT_ALLOW_SPINNING` (truthy = `1`/`true`/`yes`/`on`,
+/// the deadlock fix (PR #1668) verifiable without ORT/CUDA.
+/// What: reads `TRUSTY_ORT_INTRA_THREADS` (default: platform/EP-conditional,
+/// see [`default_ort_intra_threads`]) and `TRUSTY_ORT_INTER_THREADS` (default:
+/// [`DEFAULT_ORT_INTER_THREADS`], always `1`) — both positive integers, with
+/// malformed/zero values falling back to their default — and
+/// `TRUSTY_ORT_ALLOW_SPINNING` (truthy = `1`/`true`/`yes`/`on`,
 /// case-insensitive; anything else, including unset, means spinning stays
 /// disabled).
 /// Test: `ort_threading_defaults`, `ort_threading_reads_env`,
-/// `ort_threading_ignores_malformed`, `ort_threading_spinning_truthy`.
+/// `ort_threading_ignores_malformed`, `ort_threading_spinning_truthy`,
+/// `ort_intra_threads_default_pinned_under_cuda_feature`,
+/// `ort_intra_threads_default_uses_available_parallelism`.
 pub fn resolve_ort_threading_options() -> OrtThreadingOptions {
     fn positive_thread_count(key: &str, default: usize) -> usize {
         std::env::var(key)
@@ -173,7 +209,10 @@ pub fn resolve_ort_threading_options() -> OrtThreadingOptions {
         .unwrap_or(false);
 
     OrtThreadingOptions {
-        intra_threads: positive_thread_count("TRUSTY_ORT_INTRA_THREADS", DEFAULT_ORT_INTRA_THREADS),
+        intra_threads: positive_thread_count(
+            "TRUSTY_ORT_INTRA_THREADS",
+            default_ort_intra_threads(),
+        ),
         inter_threads: positive_thread_count("TRUSTY_ORT_INTER_THREADS", DEFAULT_ORT_INTER_THREADS),
         allow_spinning,
     }


### PR DESCRIPTION
## Summary

`DEFAULT_ORT_INTRA_THREADS` was an unconditional global constant of `1`, applied to every embedder build via `init_ort_runtime()`'s ORT global-thread-pool commit (PR #1668). That pin exists to fix a real deadlock: on AL2023 Linux with the CUDA execution provider and a dynamically-loaded `libonnxruntime` (`embedder-cuda` feature), fastembed's hardcoded per-session `with_intra_threads(available_parallelism())` creates a multi-threaded intra-op barrier that deadlocks — a couple of ORT worker threads busy-spin while the rest block forever (tracked upstream as code-intelligence #1542; fixed here by PR #1668).

That deadlock condition **only exists on the CUDA EP path**. It does not exist on the CoreML/CPU-EP path used everywhere else (Apple Silicon, and any other non-CUDA CPU-only build) — but the global pin applied there too, throttling macOS embedding throughput **~3.5x** for no safety benefit. This was independently confirmed on this repo's #3493 (P0, M5 Pro) and reproduced in the parallel #3486 CoreML/fp16 experiment's threading-only A/B (`intra=1` vs full `available_parallelism()` threading, same model/EP/format — 83.3 → 291.5 emb/s, a 3.50x delta; see the 6/12/18-thread QA note and the full 11-config ladder in that experiment's results).

## Change

`crates/trusty-common/src/embedder/types.rs`:
- Replaces the `DEFAULT_ORT_INTRA_THREADS` constant with `default_ort_intra_threads()`, a platform/EP-conditional resolver:
  - `#[cfg(feature = "embedder-cuda")]` → `1` (preserves the PR #1668 deadlock fix — this feature is the only build variant that ever registers the CUDA EP, matching `FastEmbedder::init_options`'s own CUDA branch gating).
  - `#[cfg(not(feature = "embedder-cuda"))]` → `std::thread::available_parallelism()` (falling back to `1` only if the host can't report a count), matching fastembed's own hardcoded per-session default and recovering full CoreML/CPU-EP throughput.
- `DEFAULT_ORT_INTER_THREADS` (still `1`) is unchanged — inter-op parallelism doesn't help this model regardless of platform (no parallelizable branches), so it isn't part of this fix.
- `TRUSTY_ORT_INTRA_THREADS` remains the operator override for either default (unchanged).

`crates/trusty-common/src/embedder/fast_embedder.rs`:
- Updates `init_ort_runtime()`'s doc/log comments to describe the new conditional default.
- Fixes several stale bare `#1542` comment references (in log messages and doc comments) that would auto-link to **this repo's own unrelated issue #1542** (a BM25 camelCase-tokenizer bug) instead of the actual fix, **PR #1668**. The one correctly-disambiguated `(code-intelligence #1542)` reference is kept and annotated with "fixed in this repo by PR #1668" for clarity.

`crates/trusty-common/src/embedder/mod.rs`:
- Re-exports `default_ort_intra_threads` in place of the removed `DEFAULT_ORT_INTRA_THREADS` const (no other crate referenced the const — verified via repo-wide grep).
- Updates `ort_threading_defaults` to assert against the new resolver instead of a hardcoded `1`.
- Adds two new cfg-gated unit tests: `ort_intra_threads_default_pinned_under_cuda_feature` (asserts `1` under `--features embedder-cuda`) and `ort_intra_threads_default_uses_available_parallelism` (asserts `std::thread::available_parallelism()` otherwise — this is the one that actually ran in CI/local verification below, on macOS, and passed).

`crates/trusty-common/CHANGELOG.md`: `[Unreleased]` entry.

## Why this condition is unambiguous

The CUDA EP is *only ever* registered under the `embedder-cuda` Cargo feature (see `FastEmbedder::init_options`'s `#[cfg(feature = "embedder-cuda")]` branch, `fast_embedder.rs:~320-345`) — there is no runtime path where CUDA is active without that feature compiled in. So gating `default_ort_intra_threads()` on that same feature flag exactly matches the scope of the PR #1668 deadlock, with no guesswork.

## Testing

All run against this branch (not the throwaway experiment harness):

```
$ cargo test -p trusty-common --features embedder-bundled-ort
test result: ok. 202 passed; 0 failed; 8 ignored; 0 measured; 0 filtered out
(+ 4 empty integration-test binaries, 0 doctests)

$ cargo test -p trusty-common --features embedder-bundled-ort ort_
test embedder::tests::ort_intra_threads_default_uses_available_parallelism ... ok
test embedder::tests::ort_threading_ignores_malformed ... ok
test embedder::tests::ort_threading_defaults ... ok
test embedder::tests::ort_threading_reads_env ... ok
test embedder::tests::ort_threading_spinning_truthy ... ok
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 161 filtered out

$ cargo clippy -p trusty-common --features embedder-bundled-ort --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.41s   # zero warnings

$ cargo fmt -p trusty-common -- --check
(no output — clean)
```

`cargo check -p trusty-common --features embedder-cuda` was also run to confirm the `#[cfg(feature = "embedder-cuda")]` branch of `default_ort_intra_threads()` type-checks; the full CUDA build cannot link on this macOS host (`cudarc`'s build script requires `nvcc`) — this is the same pre-existing limitation PR #1668 itself documented, not something new here.

## Expected gain

Per the #3486 experiment (same model/EP/format, threading-only change): **~3.5x** embedding throughput on macOS/CoreML (83.3 → ~291.5 emb/s in that harness's config 1→6). Combined with PR 2 (dropping INT8 quantization) the two changes compound toward the ~5.2-5.5x total measured in that experiment.

Refs #3493

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools