### PR TITLE
feat(ui): migrate trusty-mpm-gui to Foundry v2 tokens (closes #3488)

### DIFF
--- a/crates/trusty-mpm-gui/CHANGELOG.md
+++ b/crates/trusty-mpm-gui/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Migrated the Svelte UI from its placeholder indigo/slate palette to Foundry v2 design tokens (closes #3488, part of epic #3486): `ui/src/app.css` now defines `--color-*` RGB-triple custom properties (light `:root` + `[data-theme='dark']`) sourced 1:1 from `docs/design/UI/design-system/tokens.css`, and `ui/tailwind.config.js` resolves every `trusty-*`/`status-*` color through `rgb(var(--color-*) / <alpha-value>)` instead of hardcoded hex literals — the same CSS-var bridge `crates/trusty-code-gui/ui` uses, keeping the crates in lockstep for a future `scripts/check_token_drift.mjs` enforcement flip. Dark-mode activation switched from a bare `<html class="dark">` to the `[data-theme='dark']` attribute (`ui/src/stores/theme.ts`); the existing manual `ThemeToggle` + `localStorage`-persisted preference is unchanged, only the DOM attribute it drives. All components dropped their `-light` token suffix + `dark:` variant pairs in favor of the single self-theming token each now resolves through.
+
 ### Security
 
 - Set an explicit Content-Security-Policy (`default-src 'self'; connect-src 'self' ipc: http://ipc.localhost http://127.0.0.1:7880; style-src 'self' 'unsafe-inline'`) in `tauri.conf.json`, replacing `"csp": null` (architecture-review tranche 0). Added a hand-authored `capabilities/default.json` (`core:default` only, scoped to the `main` window) so the app's ACL is explicit rather than implicit.

--- a/crates/trusty-mpm-gui/ui/index.html
+++ b/crates/trusty-mpm-gui/ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/crates/trusty-mpm-gui/ui/src/app.css
+++ b/crates/trusty-mpm-gui/ui/src/app.css
@@ -2,10 +2,71 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Base, dark-first styling. The theme store toggles `.dark` on <html>;
-   light mode is expressed via `dark:` inversion in components. */
+/* Why: Foundry v2 retheme (issue #3488, docs/design/UI/design-system/tokens.css)
+ * — replaces the placeholder indigo/slate palette with the Foundry
+ * rust-on-paper (light) / Night Shift (dark) values, 1:1 with the design
+ * system's hex values converted to space-separated RGB triples (see the
+ * format note below). This mirrors `crates/trusty-code-gui/ui/src/app.css`'s
+ * structure exactly (the reference implementation for this migration) so a
+ * future `scripts/check_token_drift.mjs` enforcement flip for this crate is
+ * a same-shape MAPPING addition, not a rewrite.
+ * What: each `--color-*` value is a SPACE-SEPARATED RGB triple (`"R G B"`,
+ * not `"#rrggbb"`) — required by `tailwind.config.js`'s
+ * `rgb(var(--color-*) / <alpha-value>)` format, the only way Tailwind can
+ * still generate opacity-modified utilities (`bg-trusty-primary/15`,
+ * `hover:bg-trusty-border/60`, used throughout every component) for a
+ * CSS-variable-backed color. `:root` sets the light theme as the default
+ * (`color-scheme: light dark` tells the UA both are supported); the
+ * `[data-theme='dark']` block overrides every variable for dark.
+ *
+ * Activation: matches trusty-code-gui's mechanism — `<html data-theme="dark">`,
+ * not a bare `.dark` class or a `prefers-color-scheme` media query. Unlike
+ * trusty-code-gui (OS-only, no manual toggle), this crate keeps its existing
+ * manual `ThemeToggle` + `localStorage`-persisted preference
+ * (`src/stores/theme.ts`) — only the DOM attribute that preference drives
+ * changed, from `<html class="dark">` to `<html data-theme="dark">`, so it
+ * reads the same `[data-theme='dark']` selector this file defines.
+ */
 :root {
-  color-scheme: dark;
+  color-scheme: light dark;
+
+  --color-primary: 183 65 14; /* rust accent #B7410E */
+  --color-primary-hover: 138 47 11; /* #8A2F0B */
+  --color-surface: 245 239 231; /* warm paper #F5EFE7 */
+  --color-card: 255 253 249; /* #FFFDF9 */
+  --color-raised: 239 230 216; /* header strip / raised surface #EFE6D8 */
+  --color-border: 216 201 180; /* #D8C9B4 */
+  --color-border-strong: 196 176 150; /* #C4B096 */
+  --color-text: 43 28 18; /* #2B1C12 */
+  --color-text-secondary: 110 88 67; /* #6E5843 */
+  --color-text-muted: 138 116 96; /* #8A7460 */
+  --color-text-inverse: 255 255 255;
+  --color-status-ok: 63 111 42; /* #3F6F2A */
+  --color-status-error: 194 51 31; /* #C2331F */
+  --color-status-warn: 176 125 16; /* #B07D10 */
+  --color-status-neutral: 138 116 96; /* reuses text-muted — no new hue, per README guardrail */
+}
+
+[data-theme='dark'] {
+  /* Night Shift — same rust hue family, accent brightens one step to hold
+   * contrast on oxide paper; soft/translucent fills (the `/NN` opacity
+   * modifiers every component already uses) carry the overlay treatment
+   * automatically since they derive from these same base values. */
+  --color-primary: 217 119 66; /* #D97742 */
+  --color-primary-hover: 232 144 92; /* #E8905C */
+  --color-surface: 32 22 18; /* #201612 */
+  --color-card: 43 28 18; /* #2B1C12 */
+  --color-raised: 56 37 19; /* #382513 */
+  --color-border: 70 49 31; /* #46311F */
+  --color-border-strong: 92 65 38; /* #5C4126 */
+  --color-text: 240 231 216; /* #F0E7D8 */
+  --color-text-secondary: 203 182 156; /* #CBB69C */
+  --color-text-muted: 165 138 107; /* #A58A6B */
+  --color-text-inverse: 32 22 18; /* #201612 */
+  --color-status-ok: 143 191 106; /* #8FBF6A */
+  --color-status-error: 224 106 82; /* #E06A52 */
+  --color-status-warn: 217 168 58; /* #D9A83A */
+  --color-status-neutral: 165 138 107; /* reuses dark text-muted */
 }
 
 html,
@@ -16,10 +77,6 @@ body {
 
 body {
   @apply bg-trusty-surface text-trusty-text font-sans antialiased;
-}
-
-html:not(.dark) body {
-  @apply bg-trusty-surface-light text-trusty-text-light;
 }
 
 #app {

--- a/crates/trusty-mpm-gui/ui/src/components/CoordinatorChat.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/CoordinatorChat.svelte
@@ -185,17 +185,17 @@
       {#if msg.role === 'coordinator'}
         <div class="flex max-w-[80%] items-start gap-2 self-start">
           <span
-            class="mt-0.5 shrink-0 rounded-full bg-trusty-border-light p-1 text-trusty-primary dark:bg-trusty-border"
+            class="mt-0.5 shrink-0 rounded-full bg-trusty-border p-1 text-trusty-primary"
           >
             <Bot size={14} />
           </span>
           <div
-            class="rounded-lg bg-trusty-surface-light px-3 py-2 text-sm dark:bg-trusty-surface"
+            class="rounded-lg bg-trusty-surface px-3 py-2 text-sm"
           >
             <p class="whitespace-pre-wrap break-words">{msg.content}</p>
             {#if msg.command_output}
               <details
-                class="mt-2 rounded border border-trusty-border-light dark:border-trusty-border"
+                class="mt-2 rounded border border-trusty-border"
               >
                 <summary
                   class="cursor-pointer select-none px-2 py-1 text-xs opacity-70"
@@ -237,12 +237,12 @@
     {#if sending}
       <div class="flex items-center gap-2 self-start">
         <span
-          class="shrink-0 rounded-full bg-trusty-border-light p-1 text-trusty-primary dark:bg-trusty-border"
+          class="shrink-0 rounded-full bg-trusty-border p-1 text-trusty-primary"
         >
           <Bot size={14} />
         </span>
         <div
-          class="flex gap-1 rounded-lg bg-trusty-surface-light px-3 py-2.5 dark:bg-trusty-surface"
+          class="flex gap-1 rounded-lg bg-trusty-surface px-3 py-2.5"
         >
           <span class="h-1.5 w-1.5 animate-bounce rounded-full bg-current opacity-40"></span>
           <span
@@ -260,14 +260,14 @@
 
   <!-- Input bar -->
   <div
-    class="flex items-end gap-2 border-t border-trusty-border-light bg-trusty-surface-light p-3 dark:border-trusty-border dark:bg-trusty-surface"
+    class="flex items-end gap-2 border-t border-trusty-border bg-trusty-surface p-3"
   >
     <textarea
       bind:value={draft}
       on:keydown={onKeydown}
       rows="1"
       placeholder="@session-name: message or just ask anything..."
-      class="max-h-32 min-h-[2.5rem] flex-1 resize-none rounded-md border border-trusty-border-light bg-white px-3 py-2 text-sm outline-none focus:border-trusty-primary dark:border-trusty-border dark:bg-trusty-surface"
+      class="max-h-32 min-h-[2.5rem] flex-1 resize-none rounded-md border border-trusty-border bg-trusty-card px-3 py-2 text-sm outline-none focus:border-trusty-primary"
     ></textarea>
     <button
       type="button"

--- a/crates/trusty-mpm-gui/ui/src/components/Dashboard.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/Dashboard.svelte
@@ -41,7 +41,7 @@
         type="button"
         on:click={() => sidebarVisible.set(true)}
         aria-label="Show sidebar"
-        class="flex w-8 flex-none items-center justify-center border-r border-trusty-border-light opacity-60 hover:opacity-100 dark:border-trusty-border"
+        class="flex w-8 flex-none items-center justify-center border-r border-trusty-border opacity-60 hover:opacity-100"
       >
         <Menu size={16} />
       </button>
@@ -50,7 +50,7 @@
     <!-- Dismissable sidebar -->
     {#if $sidebarVisible}
       <aside
-        class="w-64 flex-none overflow-y-auto border-r border-trusty-border-light dark:border-trusty-border"
+        class="w-64 flex-none overflow-y-auto border-r border-trusty-border"
       >
         <SessionList />
       </aside>

--- a/crates/trusty-mpm-gui/ui/src/components/EventFeed.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/EventFeed.svelte
@@ -53,7 +53,7 @@
       type="text"
       bind:value={filter}
       placeholder="filter…"
-      class="ml-auto w-40 rounded border border-trusty-border-light bg-transparent px-2 py-0.5 text-xs dark:border-trusty-border"
+      class="ml-auto w-40 rounded border border-trusty-border bg-transparent px-2 py-0.5 text-xs"
     />
   </div>
 
@@ -63,7 +63,7 @@
     {/if}
     {#each visible as event, i (i)}
       <div
-        class="flex items-center gap-2 border-b border-trusty-border-light/50 py-1 dark:border-trusty-border/50"
+        class="flex items-center gap-2 border-b border-trusty-border/50 py-1"
       >
         <span class="rounded bg-trusty-primary/15 px-1.5 py-0.5 text-trusty-primary">
           {event.event_type}

--- a/crates/trusty-mpm-gui/ui/src/components/FileTracking.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/FileTracking.svelte
@@ -120,7 +120,7 @@
   <ul class="py-1">
     {#each files as path (path)}
       <li
-        class="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-trusty-border-light/60 dark:hover:bg-trusty-border/60"
+        class="flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-trusty-border/60"
         title={path}
       >
         <svelte:component

--- a/crates/trusty-mpm-gui/ui/src/components/Header.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/Header.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <header
-  class="flex items-center gap-3 border-b border-trusty-border-light bg-trusty-surface-light px-4 py-2 dark:border-trusty-border dark:bg-trusty-surface"
+  class="flex items-center gap-3 border-b border-trusty-border bg-trusty-surface px-4 py-2"
 >
   <button
     type="button"

--- a/crates/trusty-mpm-gui/ui/src/components/MemoryGauge.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/MemoryGauge.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <div
-  class="h-1 w-full overflow-hidden rounded-full bg-trusty-border-light dark:bg-trusty-border"
+  class="h-1 w-full overflow-hidden rounded-full bg-trusty-border"
   title={`memory ${clamped}%`}
 >
   <div

--- a/crates/trusty-mpm-gui/ui/src/components/SessionDetail.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/SessionDetail.svelte
@@ -77,7 +77,7 @@
       {/if}
     </dl>
 
-    <div class="my-3 border-t border-trusty-border-light dark:border-trusty-border"></div>
+    <div class="my-3 border-t border-trusty-border"></div>
 
     <h3 class="text-xs font-semibold uppercase tracking-wide opacity-70">
       Circuit breakers
@@ -95,7 +95,7 @@
       </ul>
     {/if}
 
-    <div class="my-3 border-t border-trusty-border-light dark:border-trusty-border"></div>
+    <div class="my-3 border-t border-trusty-border"></div>
 
     <div class="min-h-[200px] flex-1">
       <EventFeed sessionId={session.id} />

--- a/crates/trusty-mpm-gui/ui/src/components/SessionList.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/SessionList.svelte
@@ -169,11 +169,11 @@
 </script>
 
 <aside
-  class="flex h-full w-full flex-col overflow-y-auto bg-trusty-surface-light dark:bg-trusty-surface"
+  class="flex h-full w-full flex-col overflow-y-auto bg-trusty-surface"
 >
   <!-- Sidebar header: tab switcher + close button -->
   <div
-    class="flex items-center border-b border-trusty-border-light dark:border-trusty-border"
+    class="flex items-center border-b border-trusty-border"
   >
     <button
       type="button"
@@ -214,10 +214,10 @@
     <button
       type="button"
       on:click={() => activeSessionId.set(null)}
-      class={`flex items-center gap-2 border-b border-trusty-border-light px-3 py-2 text-left dark:border-trusty-border ${
+      class={`flex items-center gap-2 border-b border-trusty-border px-3 py-2 text-left ${
         $activeSessionId === null
           ? 'bg-trusty-primary/10'
-          : 'hover:bg-trusty-border-light/60 dark:hover:bg-trusty-border/60'
+          : 'hover:bg-trusty-border/60'
       }`}
     >
       <span class="h-2 w-2 shrink-0 rounded-full bg-trusty-primary"></span>
@@ -231,11 +231,11 @@
 
     {#each [...$groupedSessions] as [projectKey, group] (projectKey)}
       {@const collapsed = $collapsedProjects.has(projectKey)}
-      <div class="border-b border-trusty-border-light dark:border-trusty-border">
+      <div class="border-b border-trusty-border">
         <button
           type="button"
           on:click={() => toggleProject(projectKey)}
-          class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] font-medium uppercase tracking-wide opacity-80 hover:bg-trusty-border-light/60 dark:hover:bg-trusty-border/60"
+          class="flex w-full items-center gap-2 px-3 py-1.5 text-left text-[11px] font-medium uppercase tracking-wide opacity-80 hover:bg-trusty-border/60"
         >
           {#if collapsed}
             <ChevronRight size={12} />
@@ -260,10 +260,10 @@
             tabindex="0"
             on:click={() => select(session.id)}
             on:keydown={(e) => handleRowKeydown(session.id, e)}
-            class={`flex flex-col gap-1 border-t border-trusty-border-light pl-6 pr-3 py-2 text-left dark:border-trusty-border ${
+            class={`flex flex-col gap-1 border-t border-trusty-border pl-6 pr-3 py-2 text-left ${
               $activeSessionId === session.id
                 ? 'bg-trusty-primary/10'
-                : 'hover:bg-trusty-border-light/60 dark:hover:bg-trusty-border/60'
+                : 'hover:bg-trusty-border/60'
             }`}
           >
             <div class="flex items-center gap-2">
@@ -286,7 +286,7 @@
                 type="button"
                 on:click={(e) => toggle(session, e)}
                 aria-label={session.status === 'paused' ? 'Resume' : 'Pause'}
-                class="rounded p-0.5 hover:bg-trusty-border-light dark:hover:bg-trusty-border"
+                class="rounded p-0.5 hover:bg-trusty-border"
               >
                 {#if session.status === 'paused'}
                   <Play size={13} />
@@ -298,7 +298,7 @@
                 type="button"
                 on:click={(e) => stop(session, e)}
                 aria-label="Stop"
-                class="rounded p-0.5 hover:bg-trusty-border-light dark:hover:bg-trusty-border"
+                class="rounded p-0.5 hover:bg-trusty-border"
               >
                 <Square size={13} />
               </button>

--- a/crates/trusty-mpm-gui/ui/src/components/ThemeToggle.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/ThemeToggle.svelte
@@ -4,7 +4,7 @@
   // What: An icon button showing a Moon in dark mode and a Sun in light mode;
   // clicking calls `toggleTheme()`.
   // Test: Click the button and assert the icon swaps and `<html>` toggles its
-  // `dark` class.
+  // `data-theme="dark"` attribute.
   import { Moon, Sun } from 'lucide-svelte';
   import { theme, toggleTheme } from '../stores/theme';
 </script>
@@ -14,7 +14,7 @@
   on:click={toggleTheme}
   aria-label="Toggle theme"
   title="Toggle theme"
-  class="rounded-md p-1.5 text-trusty-text-light hover:bg-trusty-border-light dark:text-trusty-text dark:hover:bg-trusty-border"
+  class="rounded-md p-1.5 text-trusty-text hover:bg-trusty-border"
 >
   {#if $theme === 'dark'}
     <Moon size={16} />

--- a/crates/trusty-mpm-gui/ui/src/components/TransportPill.svelte
+++ b/crates/trusty-mpm-gui/ui/src/components/TransportPill.svelte
@@ -2,8 +2,8 @@
   // Why: Users (and bug reports) benefit from knowing instantly whether they
   // are in the native desktop app or the browser build, since transport and
   // capabilities differ.
-  // What: A small pill — indigo "Desktop" under Tauri, amber "Web" otherwise —
-  // decided once at mount via runtime detection.
+  // What: A small pill — rust-accent "Desktop" under Tauri, amber "Web"
+  // otherwise — decided once at mount via runtime detection.
   // Test: Stub `window.__TAURI_INTERNALS__` and assert the pill reads
   // "Desktop"; remove it and assert "Web".
   import { isTauri } from '../lib/api-config';

--- a/crates/trusty-mpm-gui/ui/src/stores/theme.ts
+++ b/crates/trusty-mpm-gui/ui/src/stores/theme.ts
@@ -1,9 +1,15 @@
 // Why: Dark/light preference must survive reloads and apply before paint to
-// avoid a flash; one store owns the value and the `<html>` class side effect.
+// avoid a flash; one store owns the value and the `<html>` attribute side
+// effect. Foundry v2 (issue #3488, docs/design/UI/design-system/tokens.css)
+// activates dark via the `[data-theme='dark']` attribute — the same
+// mechanism `crates/trusty-code-gui/ui/src/lib/theme-bootstrap.ts` uses —
+// rather than a bare `.dark` class, so `app.css`'s `[data-theme='dark']`
+// block is what this store's DOM sync now drives.
 // What: A `theme` writable persisted to `localStorage['trusty-mpm.theme']`,
 // an `applyTheme()` DOM sync, and a `toggleTheme()` helper for ThemeToggle.
-// Test: Call `toggleTheme()` and assert `<html>` gains/loses the `dark` class
-// and `localStorage` holds the new value across a simulated reload.
+// Test: Call `toggleTheme()` and assert `<html>` gains/loses the
+// `data-theme="dark"` attribute and `localStorage` holds the new value
+// across a simulated reload.
 
 import { writable } from 'svelte/store';
 
@@ -18,10 +24,14 @@ function initialTheme(): Theme {
   return localStorage.getItem(STORAGE_KEY) === 'light' ? 'light' : 'dark';
 }
 
-/** Sync the `<html>` `dark` class to the given theme. */
+/** Sync the `<html data-theme="dark">` attribute to the given theme. */
 function applyTheme(value: Theme): void {
   if (typeof document === 'undefined') return;
-  document.documentElement.classList.toggle('dark', value === 'dark');
+  if (value === 'dark') {
+    document.documentElement.setAttribute('data-theme', 'dark');
+  } else {
+    document.documentElement.removeAttribute('data-theme');
+  }
 }
 
 /** Current theme; updates persist to localStorage and the DOM. */

--- a/crates/trusty-mpm-gui/ui/tailwind.config.js
+++ b/crates/trusty-mpm-gui/ui/tailwind.config.js
@@ -1,26 +1,56 @@
 /** @type {import('tailwindcss').Config} */
+// Why: Foundry v2 retheme (issue #3488, docs/design/UI/design-system/). Every
+// `trusty-*`/`status-*` color token used across the components resolves to a
+// CSS custom property rather than a hardcoded hex literal — the actual
+// light/dark VALUES live in `src/app.css`'s `:root` block (light default)
+// and its `[data-theme='dark']` override. This mirrors
+// `crates/trusty-code-gui/ui/tailwind.config.js` (the reference
+// implementation for this migration) so `--color-*` naming stays 1:1 across
+// crates for a future `scripts/check_token_drift.mjs` enforcement flip.
+//
+// CRITICAL format note: each color is `rgb(var(--color-*) / <alpha-value>)`,
+// NOT a bare `var(--color-*)`. This is Tailwind's documented CSS-variable
+// pattern (https://tailwindcss.com/docs/customizing-colors#using-css-variables)
+// — a bare `var()` reference cannot have its opacity manipulated at build
+// time, so `bg-trusty-primary/15`/`hover:bg-trusty-border/60`-style
+// modifiers (used throughout every component) silently generate NO rule at
+// all with a plain `var()` value. The `/* alpha-value */` placeholder only
+// works when the referenced custom property holds space-separated RGB
+// channel numbers (`"15 23 42"`, not `"#0f172a"`) — see `app.css`'s
+// custom-property declarations.
+// What: `darkMode` is intentionally OMITTED — activation is the
+// `[data-theme='dark']` attribute `src/stores/theme.ts` manages directly
+// (persisted via localStorage, unlike trusty-code-gui's OS-only bootstrap)
+// in `app.css`'s custom properties, not a Tailwind `dark:` variant strategy
+// (no component needs a `dark:` prefix anymore — every color already
+// resolves through a CSS var that itself changes value under
+// `[data-theme='dark']`). `status-*` keeps this crate's existing
+// session-lifecycle names (running/paused/error/stopped) rather than
+// trusty-code-gui's generic ok/warn/neutral names, since components already
+// reference them — they resolve to the same underlying `--color-status-*`
+// custom properties.
 export default {
-  // `class` strategy: the theme store toggles `class="dark"` on <html> at
-  // runtime, matching isTauri()-style runtime detection used elsewhere.
-  darkMode: 'class',
   content: ['./index.html', './web.html', './src/**/*.{svelte,js,ts}'],
   theme: {
     extend: {
       colors: {
-        // Brand + surface tokens. Each token has a base (dark-first) value
-        // and a `-light` variant consumed via the `dark:` inversion pattern.
-        'trusty-primary': '#4f46e5', // indigo-600
-        'trusty-surface': '#0f172a', // slate-900 (dark)
-        'trusty-surface-light': '#ffffff', // white (light)
-        'trusty-border': '#334155', // slate-700 (dark)
-        'trusty-border-light': '#e2e8f0', // slate-200 (light)
-        'trusty-text': '#f1f5f9', // slate-100 (dark)
-        'trusty-text-light': '#0f172a', // slate-900 (light)
-        // Session status palette.
-        'status-running': '#22c55e', // green-500
-        'status-paused': '#f59e0b', // amber-500
-        'status-error': '#ef4444', // red-500
-        'status-stopped': '#6b7280', // gray-500
+        'trusty-primary': 'rgb(var(--color-primary) / <alpha-value>)',
+        'trusty-primary-hover': 'rgb(var(--color-primary-hover) / <alpha-value>)',
+        'trusty-surface': 'rgb(var(--color-surface) / <alpha-value>)',
+        'trusty-card': 'rgb(var(--color-card) / <alpha-value>)',
+        'trusty-raised': 'rgb(var(--color-raised) / <alpha-value>)',
+        'trusty-border': 'rgb(var(--color-border) / <alpha-value>)',
+        'trusty-border-strong': 'rgb(var(--color-border-strong) / <alpha-value>)',
+        'trusty-text': 'rgb(var(--color-text) / <alpha-value>)',
+        'trusty-text-secondary': 'rgb(var(--color-text-secondary) / <alpha-value>)',
+        'trusty-text-muted': 'rgb(var(--color-text-muted) / <alpha-value>)',
+        'trusty-text-inverse': 'rgb(var(--color-text-inverse) / <alpha-value>)',
+        // Session status palette — same tokens components already use,
+        // now sourced from the shared Foundry status custom properties.
+        'status-running': 'rgb(var(--color-status-ok) / <alpha-value>)',
+        'status-paused': 'rgb(var(--color-status-warn) / <alpha-value>)',
+        'status-error': 'rgb(var(--color-status-error) / <alpha-value>)',
+        'status-stopped': 'rgb(var(--color-status-neutral) / <alpha-value>)',
       },
     },
   },

--- a/crates/trusty-mpm-gui/ui/web.html
+++ b/crates/trusty-mpm-gui/ui/web.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary
- Replace `trusty-mpm-gui/ui`'s hardcoded indigo/slate Tailwind palette with the same CSS-var bridge `crates/trusty-code-gui/ui` uses: `src/app.css` now defines `--color-*` RGB-triple custom properties (light `:root` + `[data-theme='dark']`) sourced 1:1 from `docs/design/UI/design-system/tokens.css`; `tailwind.config.js` resolves every `trusty-*`/`status-*` color through `rgb(var(--color-*) / <alpha-value>)` instead of hex literals.
- Dark-mode activation switches from a bare `<html class="dark">` to the `[data-theme='dark']` attribute, matching trusty-code-gui's mechanism — the existing manual `ThemeToggle` + `localStorage`-persisted preference (`src/stores/theme.ts`) is unchanged, only the DOM attribute it drives.
- Every component drops its `-light` token suffix + `dark:` variant pair in favor of the single self-theming token each now resolves through (grepped clean — no `dark:`, no `-light` token, no raw indigo/slate Tailwind classes remain in `src/`).
- `scripts/check_token_drift.mjs` untouched — `trusty-mpm-gui` stays on the `#3488` allowlist entry per instructions; the enforced-flip is a coordinated follow-up. `app.css`'s `--color-*` naming now matches `trusty-code-gui`'s 1:1, so that flip is a same-shape MAPPING addition later.
- CHANGELOG.md entry added under `[Unreleased]`.

Closes #3488. Refs #3486.

## Test plan
- [x] `pnpm run build` (Tauri/index.html target) — clean, see raw output below
- [x] `pnpm run build:web` (browser/web.html target) — clean, see raw output below
- [x] `cargo test -p trusty-mpm-gui` — compiles clean, 0 tests (no Rust suite for this crate)
- [x] `node scripts/check_token_drift.mjs` — still passes, trusty-mpm-gui remains allowlisted
- [x] Verified compiled CSS contains the canonical Foundry RGB triples (`183 65 14` light / `217 119 66` dark) and a `[data-theme='dark']` selector

### Raw `pnpm run build` output
```
vite v6.4.3 building for production...
transforming...
✓ 1665 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                  0.41 kB │ gzip:  0.28 kB
dist/assets/index-BU5noCxO.css  12.88 kB │ gzip:  3.46 kB
dist/assets/core-DV6XEvTN.js     0.10 kB │ gzip:  0.11 kB
dist/assets/index-BqhO73FW.js   82.42 kB │ gzip: 28.79 kB
✓ built in 5.47s
```

### Raw `pnpm run build:web` output
```
vite v6.4.3 building for production...
transforming...
✓ 1665 modules transformed.
rendering chunks...
computing gzip size...
dist-web/web.html                  0.42 kB │ gzip:  0.29 kB
dist-web/assets/web-BU5noCxO.css  12.88 kB │ gzip:  3.46 kB
dist-web/assets/core-DV6XEvTN.js   0.10 kB │ gzip:  0.11 kB
dist-web/assets/web-DpP1QrlL.js   81.76 kB │ gzip: 28.57 kB
✓ built in 2.82s
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools