### PR TITLE
trusty-gworkspace: harden multi-account storage + expose MCP tools (closes #3502, #3503)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3158,6 +3158,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6538,7 +6549,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11534,6 +11545,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs 5.0.1",
+ "fd-lock",
  "open",
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,10 @@ base64 = "0.22"
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 sha2 = "0.10"
+# Cross-process advisory file locking for trusty-gworkspace's tokens.json
+# read-modify-write critical section (issue #3502) — small, actively
+# maintained, no unsafe beyond the platform lock syscalls it wraps.
+fd-lock = "4"
 # Gzip decompression for prebuilt-binary tarballs (trusty-installer Phase 2).
 flate2 = "1"
 # Tar archive extraction for prebuilt-binary tarballs (trusty-installer Phase 2).

--- a/crates/trusty-gworkspace/CHANGELOG.md
+++ b/crates/trusty-gworkspace/CHANGELOG.md
@@ -7,6 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- Multi-account management is now exposed as MCP tools, not just the CLI
+  (issue #3503): `set_default_account {name}`, `remove_account {name}`, and
+  `add_account` (runs the native OAuth consent flow for a new or re-auth
+  profile — see the README's "Managing accounts" section for the blocking-call
+  design and its tradeoffs). `list_accounts` is unchanged.
+
 ### Changed
 
 - **BREAKING:** the native binary is renamed from `gworkspace-mcp` to
@@ -42,3 +50,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (`BaseClient::get_access_token` calls it on every MCP tool invocation, plus
   again on 401 retry), so the warning is throttled to at most once per
   profile per process rather than repeating on every call.
+- `tokens.json` read-modify-write is now guarded against concurrent writers
+  losing each other's changes (issue #3502): two profiles refreshing at the
+  same moment — in the same or different processes — could each `load()` the
+  map before either `save()`d, silently dropping whichever write lost the
+  race. Every mutation path (`OAuthManager::refresh`, consent persistence,
+  `accounts default`/`accounts remove` and their new MCP-tool counterparts)
+  now goes through `TokenStorage::update`, which serialises callers
+  in-process and holds an advisory cross-process lock on a sidecar
+  `tokens.json.lock` file for the duration.
+- `accounts remove`/`remove_account` no longer orphans the default profile
+  (issue #3502): removing the current default now deterministically
+  reassigns it to another remaining profile (the alphabetically next one)
+  instead of leaving zero default entries, which previously broke
+  `BaseClient::resolve_stored`'s default-profile fallback for every
+  subsequent call with no explicit `account`.

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -29,6 +29,7 @@ tracing = { workspace = true }
 dirs = { workspace = true }
 clap = { workspace = true }
 open = { workspace = true }
+fd-lock = { workspace = true }
 
 [dev-dependencies]
 # serial_test: env-mutating tests (HOME override for oauth_client.json

--- a/crates/trusty-gworkspace/README.md
+++ b/crates/trusty-gworkspace/README.md
@@ -3,7 +3,7 @@
 Google Workspace MCP server for the Trusty suite — a Rust port of the
 Python [`gworkspace-mcp`](https://pypi.org/project/gworkspace-mcp/) project.
 
-Exposes 43 [Model Context Protocol](https://modelcontextprotocol.io/) tools
+Exposes 46 [Model Context Protocol](https://modelcontextprotocol.io/) tools
 across Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks, and Accounts.
 Authentication is fully native: the `trusty-gworkspace-mcp` binary runs the
 OAuth consent flow itself and reads/writes `~/.gworkspace-mcp/tokens.json` —
@@ -138,6 +138,25 @@ trusty-gworkspace-mcp accounts default work         # switch the default profile
 trusty-gworkspace-mcp accounts remove work          # forget a local token (no revoke)
 ```
 
+Removing the current default reassigns it to another remaining profile
+(alphabetically next) rather than leaving no default at all.
+
+The same operations are also available as MCP tools (issue #3503), so an
+agent can manage accounts without shelling out to the CLI:
+
+- `list_accounts` — read-only, as above.
+- `set_default_account {name}` — same behavior as `accounts default`.
+- `remove_account {name}` — same behavior as `accounts remove`, including the
+  default-reassignment above; the response reports which profile (if any)
+  became the new default.
+- `add_account` — runs the native OAuth consent flow for a new (or re-auth of
+  an existing) profile. This blocks the tool call for up to `timeout_secs`
+  (default 60s, clamped to 10-90s) waiting for the user to complete consent in
+  a browser, and always returns the consent URL in the response (whether it
+  succeeded or timed out) so the calling agent can relay it and, on a
+  time-out, simply call `add_account` again for a fresh URL. No partial or
+  corrupt token is ever written on a time-out or abandoned consent.
+
 ## Configuration
 
 | Env var                       | Purpose                                                        |
@@ -180,9 +199,10 @@ per profile (two-tier lookup) — useful for per-project accounts.
 
 ## Tool Surface
 
-43 tools, grouped by service:
+46 tools, grouped by service:
 
-- **Accounts:** `list_accounts`
+- **Accounts:** `list_accounts`, `set_default_account`, `remove_account`,
+  `add_account`
 - **Calendar:** `manage_calendars`, `manage_events`, `query_free_busy`
 - **Gmail:** `search_gmail_messages`, `get_gmail_message_content`,
   `download_gmail_attachment`, `list_message_attachments`, `compose_email`,
@@ -236,9 +256,25 @@ adding a new tool means: write the function, add a `match` arm in
   native; no external CLI is involved.
 - **Two-tier token lookup.** `./.gworkspace-mcp/tokens.json` overrides
   `~/.gworkspace-mcp/tokens.json` — useful for per-project profiles.
+- **Concurrency-safe token writes (issue #3502).** Every read-modify-write of
+  `tokens.json` (refresh, consent persistence, account default/remove) goes
+  through `TokenStorage::update`, which serialises callers in-process and
+  holds an advisory cross-process lock on a sidecar `tokens.json.lock` file
+  for the duration. Two profiles refreshing at the same moment — in the same
+  or different processes — can no longer silently lose one write.
 - **Errors as data.** Tool failures return `{"error": "..."}` inside the
   MCP `content` envelope rather than JSON-RPC framing errors, so the
   model gets actionable feedback.
+- **`add_account`'s blocking design (issue #3503).** Authorizing an account
+  needs a human to finish consent in a browser, which an MCP tool call can't
+  do end-to-end on its own. Rather than adding a background task + a separate
+  poll/status tool, `add_account` reuses the existing consent flow verbatim
+  with a short, bounded timeout (default 60s) and always returns the consent
+  URL in the response, success or time-out. This was a deliberate choice to
+  avoid new state-management machinery; it does mean the tool call itself
+  blocks for up to the timeout, so clients with a shorter built-in call
+  timeout may see it fail even though retrying is always safe (no token is
+  persisted until the exchange fully succeeds).
 - **Local filesystem access is intentionally broad.** `compose_email`
   attachments (`path`/`local_path`), `manage_drive_file`'s `upload` action
   (`local_path`), and `get_drive_file_content`'s `save_path` all read or

--- a/crates/trusty-gworkspace/src/api/auth/manager.rs
+++ b/crates/trusty-gworkspace/src/api/auth/manager.rs
@@ -152,9 +152,12 @@ impl OAuthManager {
         stored.token = new_token.clone();
         stored.metadata.last_refreshed = Some(Utc::now());
 
-        let mut all = storage.load()?;
-        all.insert(profile.to_string(), stored);
-        storage.save(&all)?;
+        // Guard against a concurrent refresh of a different profile (or the
+        // same one) losing this write — see `TokenStorage::update` (#3502).
+        storage.update(|all| {
+            all.insert(profile.to_string(), stored);
+            Ok(())
+        })?;
 
         Ok(new_token)
     }

--- a/crates/trusty-gworkspace/src/api/auth/oauth/flow/mod.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/flow/mod.rs
@@ -313,6 +313,48 @@ pub async fn run_consent(
     default_mode: DefaultMode,
     open_browser: bool,
 ) -> Result<ConsentOutcome> {
+    run_consent_with(
+        storage,
+        profile,
+        default_mode,
+        open_browser,
+        CONSENT_TIMEOUT,
+        |auth_url| {
+            for line in consent_prompt_lines(auth_url, open_browser, CONSENT_TIMEOUT.as_secs()) {
+                eprintln!("{line}");
+            }
+        },
+    )
+    .await
+}
+
+/// Run the consent flow with an explicit timeout and a caller-supplied hook
+/// for the consent URL, instead of the CLI's hardcoded stderr print.
+///
+/// Why: `setup` prints the URL to stderr and blocks up to
+/// [`CONSENT_TIMEOUT`] (5 minutes) — fine for an interactive terminal, but
+/// the `add_account` MCP tool (issue #3503) needs the URL back in its OWN
+/// tool response (the calling agent cannot see this process's stderr) and a
+/// much shorter bound (an MCP client may itself time out a single tool call
+/// long before 5 minutes). Splitting the URL hand-off into a callback lets
+/// both entry points share every byte of the PKCE / token-exchange /
+/// persistence logic — no OAuth reimplementation.
+/// What: Identical to [`run_consent`] except `timeout` replaces
+/// `CONSENT_TIMEOUT` for the browser-redirect wait, and `on_auth_url` runs
+/// synchronously with the built URL (before the browser is opened) instead
+/// of the hardcoded print. [`run_consent`] is just this function called with
+/// the default timeout and its stderr-printing closure.
+/// Test: Live browser round-trip stays deferred for both entry points; the
+/// pure helpers (`build_auth_url`, `consent_prompt_lines`, `should_set_default`)
+/// this calls are unit-tested.
+pub async fn run_consent_with(
+    storage: &TokenStorage,
+    profile: &str,
+    default_mode: DefaultMode,
+    open_browser: bool,
+    timeout: std::time::Duration,
+    on_auth_url: impl FnOnce(&str),
+) -> Result<ConsentOutcome> {
     let creds = resolve_client_creds()?;
 
     let existing = storage.load()?;
@@ -344,9 +386,7 @@ pub async fn run_consent(
         &state,
     );
 
-    for line in consent_prompt_lines(&auth_url, open_browser, CONSENT_TIMEOUT.as_secs()) {
-        eprintln!("{line}");
-    }
+    on_auth_url(&auth_url);
     if open_browser && let Err(e) = open::that(&auth_url) {
         warn!(error = %e, "failed to launch browser; user must open the URL manually");
     }
@@ -354,7 +394,7 @@ pub async fn run_consent(
     // Block for the redirect off the async runtime so we don't stall the reactor.
     let expected_state = state.clone();
     let code = tokio::task::spawn_blocking(move || {
-        callback::wait_for_code_with_timeout(&listener, &expected_state, CONSENT_TIMEOUT)
+        callback::wait_for_code_with_timeout(&listener, &expected_state, timeout)
     })
     .await
     .context("callback task panicked")??;
@@ -470,9 +510,11 @@ fn build_stored_token(
 /// Persist a freshly-minted token, optionally marking it the default profile.
 ///
 /// Why: `setup` must not clobber other profiles and must keep exactly one
-/// default when asked, matching Python multi-profile semantics.
-/// What: Loads the existing map, unsets other defaults when `set_default`,
-/// inserts the new entry, and saves.
+/// default when asked, matching Python multi-profile semantics. Routed
+/// through `TokenStorage::update` (#3502) so a concurrent write (e.g. another
+/// profile refreshing at the same moment) can't lose this one.
+/// What: Reloads the map under the shared lock, unsets other defaults when
+/// `set_default`, inserts the new entry, and saves.
 /// Test: `persist_marks_single_default` via a temp storage.
 fn persist(
     storage: &TokenStorage,
@@ -480,16 +522,16 @@ fn persist(
     mut stored: StoredToken,
     set_default: bool,
 ) -> Result<()> {
-    let mut all: HashMap<String, StoredToken> = storage.load()?;
-    if set_default {
-        for entry in all.values_mut() {
-            entry.metadata.is_default = false;
+    storage.update(|all| {
+        if set_default {
+            for entry in all.values_mut() {
+                entry.metadata.is_default = false;
+            }
+            stored.metadata.is_default = true;
         }
-        stored.metadata.is_default = true;
-    }
-    all.insert(profile.to_string(), stored);
-    storage.save(&all)?;
-    Ok(())
+        all.insert(profile.to_string(), stored);
+        Ok(())
+    })
 }
 
 /// Effective profile name: caller override, else the shared default.

--- a/crates/trusty-gworkspace/src/api/auth/oauth/mod.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/mod.rs
@@ -15,4 +15,6 @@ pub mod errors;
 pub mod flow;
 pub mod pkce;
 
-pub use flow::{ClientCreds, ConsentOutcome, DefaultMode, resolve_client_creds, run_consent};
+pub use flow::{
+    ClientCreds, ConsentOutcome, DefaultMode, resolve_client_creds, run_consent, run_consent_with,
+};

--- a/crates/trusty-gworkspace/src/api/auth/storage/mod.rs
+++ b/crates/trusty-gworkspace/src/api/auth/storage/mod.rs
@@ -8,14 +8,17 @@
 //! changing the override contract) when a project-level entry shadowing a
 //! profile is expired while the user-level entry it hides is still valid
 //! (issue #2946 — a stale worktree-local override otherwise silently wins
-//! and re-poisons `save()` on every re-auth).
+//! and re-poisons `save()` on every re-auth). [`TokenStorage::update`] guards
+//! every read-modify-write call site (refresh, consent persist, CLI
+//! `accounts default`/`accounts remove`) against concurrent writers losing
+//! each other's changes (issue #3502).
 //! Test: see integration test `tests/auth_models.rs`.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Utc};
 use tracing::warn;
 
@@ -36,6 +39,17 @@ pub struct TokenStorage {
     user_path: PathBuf,
     project_path: Option<PathBuf>,
     warned_stale_shadows: Arc<Mutex<HashSet<String>>>,
+    /// In-process mutex serialising [`TokenStorage::update`] calls across
+    /// every clone of this `TokenStorage` within the current process.
+    ///
+    /// Why: The cross-process file lock alone still lets two threads in the
+    /// *same* process interleave a load-mutate-save cycle between the point
+    /// one thread releases the lock and the next acquires it, if they are
+    /// not also serialised in-process; a plain `Mutex` closes that window
+    /// cheaply without relying on the file lock's fairness semantics.
+    /// What: Held for the full duration of `update`'s critical section.
+    /// Test: `concurrent_updates_do_not_lose_writes`.
+    write_guard: Arc<Mutex<()>>,
 }
 
 impl TokenStorage {
@@ -64,6 +78,7 @@ impl TokenStorage {
             user_path,
             project_path,
             warned_stale_shadows: Arc::new(Mutex::new(HashSet::new())),
+            write_guard: Arc::new(Mutex::new(())),
         }
     }
 
@@ -73,6 +88,7 @@ impl TokenStorage {
             user_path: path,
             project_path: None,
             warned_stale_shadows: Arc::new(Mutex::new(HashSet::new())),
+            write_guard: Arc::new(Mutex::new(())),
         }
     }
 
@@ -221,6 +237,78 @@ impl TokenStorage {
         Ok(())
     }
 
+    /// The path `save()` actually writes to (project override if known, else
+    /// the user-level file) — also the file this process's writes must be
+    /// serialised against.
+    fn primary_path(&self) -> PathBuf {
+        self.project_path
+            .clone()
+            .unwrap_or_else(|| self.user_path.clone())
+    }
+
+    /// Sidecar lock file path for [`TokenStorage::update`]'s cross-process
+    /// lock — never contains token data itself.
+    fn lock_path(&self) -> PathBuf {
+        let target = self.primary_path();
+        let file_name = target
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "tokens.json".to_string());
+        target.with_file_name(format!("{file_name}.lock"))
+    }
+
+    /// Perform an atomic read-modify-write on the stored token map.
+    ///
+    /// Why: `OAuthManager::refresh` and the consent flow's `persist` (and the
+    /// CLI's `accounts default`/`accounts remove`) each used to do
+    /// `load()` -> mutate -> `save()` with no synchronization. Two concurrent
+    /// writers — different profiles refreshing at once, in the same or
+    /// different processes — could each `load()` the map before either
+    /// `save()`d, silently losing whichever write lost the race (issue
+    /// #3502). Centralising the whole cycle here, guarded by a lock, means
+    /// every call site gets the fix for free instead of re-deriving it.
+    /// What: Acquires an in-process mutex (serialises clones of this
+    /// `TokenStorage` within the current process) and, inside that, an
+    /// advisory exclusive lock on a sidecar `<path>.lock` file (serialises
+    /// across processes; blocks until acquired — contention here is brief:
+    /// one JSON parse + one JSON write). Reloads the map fresh under both
+    /// locks (never trusts a caller's possibly-stale copy), applies `f`, and
+    /// saves before releasing. Both locks release automatically on return
+    /// (including on error, via `?` and RAII guards) so a failure never
+    /// leaves the file locked.
+    /// Test: `concurrent_updates_do_not_lose_writes`.
+    pub fn update<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&mut HashMap<String, StoredToken>) -> Result<T>,
+    {
+        let _in_process_guard = self
+            .write_guard
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let lock_path = self.lock_path();
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("mkdir {}", parent.display()))?;
+        }
+        let lock_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)
+            .with_context(|| format!("open lock file {}", lock_path.display()))?;
+        let mut rw_lock = fd_lock::RwLock::new(lock_file);
+        let _file_guard = rw_lock
+            .write()
+            .with_context(|| format!("acquire lock on {}", lock_path.display()))?;
+
+        let mut tokens = self.load()?;
+        let result = f(&mut tokens)?;
+        self.save(&tokens)?;
+        Ok(result)
+    }
+
     /// Return the default profile token (is_default=true), or the first one,
     /// or the entry matching `DEFAULT_PROFILE`, else None.
     pub fn get_default(&self) -> Result<Option<StoredToken>> {
@@ -255,6 +343,106 @@ impl TokenStorage {
         out.sort_by(|a, b| a.0.cmp(&b.0));
         Ok(out)
     }
+
+    /// Mark `name` as the default profile, clearing any other default.
+    ///
+    /// Why: Shared by the CLI (`accounts default`) and the `set_default_account`
+    /// MCP tool so both surfaces get the identical lock-guarded mutation
+    /// instead of each re-implementing load-mutate-save.
+    /// What: Errors if `name` is absent; otherwise unsets `is_default` on
+    /// every entry, sets it on `name`, and saves — all under [`Self::update`].
+    /// Test: `set_default_moves_flag`, `set_default_rejects_unknown` (via the
+    /// `cli::accounts` wrapper, which this backs).
+    pub fn set_default_profile(&self, name: &str) -> Result<()> {
+        self.update(|all| {
+            if !all.contains_key(name) {
+                return Err(anyhow!("no profile named '{name}'"));
+            }
+            for entry in all.values_mut() {
+                entry.metadata.is_default = false;
+            }
+            if let Some(entry) = all.get_mut(name) {
+                entry.metadata.is_default = true;
+            }
+            Ok(())
+        })
+    }
+
+    /// Remove `name`, reassigning the default if it was the one removed.
+    ///
+    /// Why: Shared by the CLI (`accounts remove`) and the `remove_account` MCP
+    /// tool. Removing the current default used to leave zero default entries,
+    /// silently breaking `BaseClient::resolve_stored`'s default-profile
+    /// fallback for every subsequent call with no explicit `account` (issue
+    /// #3502).
+    /// What: Errors if `name` is absent; otherwise removes it and, only when
+    /// it had `is_default = true` and other profiles remain, marks the
+    /// alphabetically-first remaining profile name as the new default. Saves
+    /// under [`Self::update`]. Returns [`RemoveOutcome`] naming the removed
+    /// profile and the reassigned default, if any.
+    /// Test: `remove_deletes_profile` (via `cli::accounts`),
+    /// `remove_default_reassigns_to_next_profile`,
+    /// `remove_default_leaves_none_when_last_profile`,
+    /// `remove_non_default_does_not_reassign`.
+    pub fn remove_profile(&self, name: &str) -> Result<RemoveOutcome> {
+        self.update(|all| remove_and_reassign_default(all, name))
+    }
+}
+
+/// Outcome of [`TokenStorage::remove_profile`]: which profile was removed,
+/// and — only when it had been the default — which remaining profile
+/// inherited that role.
+///
+/// Why: Both the CLI and the `remove_account` MCP tool need to report the
+/// reassignment (if any) to the user/caller rather than silently swapping
+/// which account subsequent default-scoped calls act against.
+/// What: `reassigned_default` is `None` when the removed profile was not the
+/// default, or when it was but no profiles remain.
+/// Test: see [`TokenStorage::remove_profile`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoveOutcome {
+    pub removed: String,
+    pub reassigned_default: Option<String>,
+}
+
+/// Pure mutation: remove `name` from `all`, reassigning the default if it was
+/// the one removed.
+///
+/// Why: Isolated as a pure function (no I/O, no locking) so the exact
+/// reassignment rule is directly unit-testable against a plain `HashMap`,
+/// mirroring the `stale_shadow_warning` / `should_set_default` pattern
+/// elsewhere in this crate.
+/// What: Errors if `name` is absent. Otherwise removes it; if it was
+/// `is_default` and `all` is non-empty afterward, marks the
+/// alphabetically-first remaining key `is_default = true` and returns it as
+/// `reassigned_default`.
+/// Test: `remove_default_reassigns_to_next_profile`,
+/// `remove_default_leaves_none_when_last_profile`,
+/// `remove_non_default_does_not_reassign`.
+fn remove_and_reassign_default(
+    all: &mut HashMap<String, StoredToken>,
+    name: &str,
+) -> Result<RemoveOutcome> {
+    let removed = all
+        .remove(name)
+        .ok_or_else(|| anyhow!("no profile named '{name}'"))?;
+
+    let mut reassigned_default = None;
+    if removed.metadata.is_default {
+        let mut remaining: Vec<&String> = all.keys().collect();
+        remaining.sort();
+        if let Some(next) = remaining.first().map(|s| s.to_string()) {
+            if let Some(entry) = all.get_mut(&next) {
+                entry.metadata.is_default = true;
+            }
+            reassigned_default = Some(next);
+        }
+    }
+
+    Ok(RemoveOutcome {
+        removed: name.to_string(),
+        reassigned_default,
+    })
 }
 
 /// Structured detail of a stale project-level shadow, for the `tracing::warn!`
@@ -314,230 +502,4 @@ impl Default for TokenStorage {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    #[cfg(unix)]
-    fn save_restricts_permissions_on_unix() {
-        use std::os::unix::fs::PermissionsExt;
-
-        let dir = std::env::temp_dir().join(format!("gw-storage-perms-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let path = dir.join("tokens.json");
-        let storage = TokenStorage::with_path(path.clone());
-
-        storage.save(&HashMap::new()).expect("save");
-
-        let mode = std::fs::metadata(&path)
-            .expect("metadata")
-            .permissions()
-            .mode();
-        assert_eq!(
-            mode & 0o777,
-            0o600,
-            "tokens.json must be owner-read/write only, got {:o}",
-            mode & 0o777
-        );
-    }
-
-    #[test]
-    fn save_still_round_trips_content() {
-        // Guards against the permissions change accidentally altering the
-        // byte-serde-compatible wire format.
-        let dir = std::env::temp_dir().join(format!("gw-storage-rt-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(&dir).unwrap();
-        let storage = TokenStorage::with_path(dir.join("tokens.json"));
-
-        let mut tokens = HashMap::new();
-        tokens.insert(
-            "primary".to_string(),
-            StoredToken {
-                version: 1,
-                metadata: crate::api::auth::models::TokenMetadata {
-                    service_name: "primary".into(),
-                    provider: "google".into(),
-                    created_at: chrono::Utc::now(),
-                    last_refreshed: None,
-                    email: Some("user@example.com".into()),
-                    is_default: true,
-                },
-                token: crate::api::auth::models::OAuthToken {
-                    access_token: "a".into(),
-                    refresh_token: Some("r".into()),
-                    expires_at: chrono::Utc::now() + chrono::Duration::seconds(3600),
-                    scopes: vec!["openid".into()],
-                    token_type: "Bearer".into(),
-                },
-            },
-        );
-
-        storage.save(&tokens).expect("save");
-        let loaded = storage.load().expect("load");
-        assert_eq!(
-            loaded["primary"].metadata.email.as_deref(),
-            Some("user@example.com")
-        );
-        assert!(loaded["primary"].metadata.is_default);
-    }
-
-    /// Build a `StoredToken` expiring `expires_in_secs` from now (negative =
-    /// already expired) for the stale-shadow-warning tests below.
-    fn make_stored(expires_in_secs: i64) -> StoredToken {
-        StoredToken {
-            version: 1,
-            metadata: crate::api::auth::models::TokenMetadata {
-                service_name: "test".into(),
-                provider: "google".into(),
-                created_at: chrono::Utc::now(),
-                last_refreshed: None,
-                email: Some("user@example.com".into()),
-                is_default: false,
-            },
-            token: crate::api::auth::models::OAuthToken {
-                access_token: "a".into(),
-                refresh_token: Some("r".into()),
-                expires_at: chrono::Utc::now() + chrono::Duration::seconds(expires_in_secs),
-                scopes: vec!["openid".into()],
-                token_type: "Bearer".into(),
-            },
-        }
-    }
-
-    #[test]
-    fn warns_when_project_stale_and_user_fresh() {
-        let project = make_stored(-3600);
-        let user = make_stored(3600);
-        let info = stale_shadow_warning(
-            &project,
-            &user,
-            Path::new("/proj/.gworkspace-mcp/tokens.json"),
-            Path::new("/home/user/.gworkspace-mcp/tokens.json"),
-        )
-        .expect("must warn: project stale, user fresh");
-        assert_eq!(
-            info.project_path,
-            Path::new("/proj/.gworkspace-mcp/tokens.json")
-        );
-        assert_eq!(
-            info.user_path,
-            Path::new("/home/user/.gworkspace-mcp/tokens.json")
-        );
-        assert_eq!(info.project_expires_at, project.token.expires_at);
-        assert_eq!(info.user_expires_at, user.token.expires_at);
-    }
-
-    #[test]
-    fn no_warning_when_both_fresh() {
-        let project = make_stored(3600);
-        let user = make_stored(7200);
-        assert!(stale_shadow_warning(&project, &user, Path::new("p"), Path::new("u")).is_none());
-    }
-
-    #[test]
-    fn no_warning_when_both_stale() {
-        // Both stale is not the silent-shadow failure mode — the caller gets
-        // an expired token either way, so no extra signal is needed here.
-        let project = make_stored(-3600);
-        let user = make_stored(-7200);
-        assert!(stale_shadow_warning(&project, &user, Path::new("p"), Path::new("u")).is_none());
-    }
-
-    #[test]
-    fn no_warning_when_project_is_fresher() {
-        let project = make_stored(3600);
-        let user = make_stored(-3600);
-        assert!(stale_shadow_warning(&project, &user, Path::new("p"), Path::new("u")).is_none());
-    }
-
-    /// Build a two-tier temp `TokenStorage` (separate user/project dirs) with
-    /// a `work` profile present on both sides, and write the given
-    /// user/project token maps to disk. Shared by the precedence and
-    /// warn-capture tests below.
-    fn temp_shadowed_storage(
-        label: &str,
-        user_expires_in_secs: i64,
-        project_expires_in_secs: i64,
-    ) -> TokenStorage {
-        let dir = std::env::temp_dir().join(format!("gw-storage-{label}-{}", uuid::Uuid::new_v4()));
-        let user_dir = dir.join("user");
-        let project_dir = dir.join("project");
-        std::fs::create_dir_all(&user_dir).unwrap();
-        std::fs::create_dir_all(&project_dir).unwrap();
-        let user_path = user_dir.join("tokens.json");
-        let project_path = project_dir.join("tokens.json");
-
-        let mut user_tokens = HashMap::new();
-        user_tokens.insert("work".to_string(), make_stored(user_expires_in_secs));
-        std::fs::write(&user_path, serde_json::to_string(&user_tokens).unwrap()).unwrap();
-
-        let mut project_tokens = HashMap::new();
-        let mut project_stored = make_stored(project_expires_in_secs);
-        project_stored.token.access_token = "stale-access-token".into();
-        project_tokens.insert("work".to_string(), project_stored);
-        std::fs::write(
-            &project_path,
-            serde_json::to_string(&project_tokens).unwrap(),
-        )
-        .unwrap();
-
-        TokenStorage {
-            user_path,
-            project_path: Some(project_path),
-            warned_stale_shadows: Arc::new(Mutex::new(HashSet::new())),
-        }
-    }
-
-    #[test]
-    fn load_still_prefers_project_override_after_warning() {
-        // Regression guard for the precedence contract: this fix only adds a
-        // warning, it does not change which entry wins (see PR body) — a
-        // stale project override must still be served, just noisily.
-        let storage = temp_shadowed_storage("precedence", 3600, -3600);
-
-        let loaded = storage.load().unwrap();
-        assert_eq!(
-            loaded["work"].token.access_token, "stale-access-token",
-            "project override must still win per the documented contract \
-             (warn, don't change precedence)"
-        );
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn load_warns_when_project_shadow_is_stale() {
-        let storage = temp_shadowed_storage("warns", 3600, -3600);
-
-        storage.load().unwrap();
-
-        assert!(logs_contain("work"));
-        assert!(logs_contain("STALE"));
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn load_does_not_rewarn_on_second_load() {
-        // PR #2949 review (HIGH): load() sits on the per-request hot path —
-        // an unthrottled warn would repeat on every single MCP tool call.
-        // Two loads on the same TokenStorage must produce exactly one
-        // stale-shadow warning, not two.
-        let storage = temp_shadowed_storage("norewarn", 3600, -3600);
-
-        storage.load().unwrap();
-        storage.load().unwrap();
-
-        logs_assert(|lines: &[&str]| {
-            let count = lines
-                .iter()
-                .filter(|l| l.contains("STALE") && l.contains("work"))
-                .count();
-            if count == 1 {
-                Ok(())
-            } else {
-                Err(format!(
-                    "expected exactly 1 stale-shadow warning after two load() calls, found {count}"
-                ))
-            }
-        });
-    }
-}
+mod tests;

--- a/crates/trusty-gworkspace/src/api/auth/storage/tests.rs
+++ b/crates/trusty-gworkspace/src/api/auth/storage/tests.rs
@@ -1,0 +1,328 @@
+//! Unit tests for the `storage` module.
+//!
+//! Why: split out of `storage/mod.rs` to keep the production file under the
+//! 500-SLOC cap (mirrors the `oauth/flow/mod.rs` + `flow/tests.rs` split).
+//! What: exercises `TokenStorage` load/save/permissions, the stale-shadow
+//! warning, `TokenStorage::update`'s concurrency guard, and the
+//! remove/default-reassignment pure helper.
+//! Test: this file IS the test module for `storage`.
+
+use super::*;
+
+#[test]
+#[cfg(unix)]
+fn save_restricts_permissions_on_unix() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = std::env::temp_dir().join(format!("gw-storage-perms-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("tokens.json");
+    let storage = TokenStorage::with_path(path.clone());
+
+    storage.save(&HashMap::new()).expect("save");
+
+    let mode = std::fs::metadata(&path)
+        .expect("metadata")
+        .permissions()
+        .mode();
+    assert_eq!(
+        mode & 0o777,
+        0o600,
+        "tokens.json must be owner-read/write only, got {:o}",
+        mode & 0o777
+    );
+}
+
+#[test]
+fn save_still_round_trips_content() {
+    // Guards against the permissions change accidentally altering the
+    // byte-serde-compatible wire format.
+    let dir = std::env::temp_dir().join(format!("gw-storage-rt-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let storage = TokenStorage::with_path(dir.join("tokens.json"));
+
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        "primary".to_string(),
+        StoredToken {
+            version: 1,
+            metadata: crate::api::auth::models::TokenMetadata {
+                service_name: "primary".into(),
+                provider: "google".into(),
+                created_at: chrono::Utc::now(),
+                last_refreshed: None,
+                email: Some("user@example.com".into()),
+                is_default: true,
+            },
+            token: crate::api::auth::models::OAuthToken {
+                access_token: "a".into(),
+                refresh_token: Some("r".into()),
+                expires_at: chrono::Utc::now() + chrono::Duration::seconds(3600),
+                scopes: vec!["openid".into()],
+                token_type: "Bearer".into(),
+            },
+        },
+    );
+
+    storage.save(&tokens).expect("save");
+    let loaded = storage.load().expect("load");
+    assert_eq!(
+        loaded["primary"].metadata.email.as_deref(),
+        Some("user@example.com")
+    );
+    assert!(loaded["primary"].metadata.is_default);
+}
+
+/// Build a `StoredToken` expiring `expires_in_secs` from now (negative =
+/// already expired) for the stale-shadow-warning tests below.
+fn make_stored(expires_in_secs: i64) -> StoredToken {
+    StoredToken {
+        version: 1,
+        metadata: crate::api::auth::models::TokenMetadata {
+            service_name: "test".into(),
+            provider: "google".into(),
+            created_at: chrono::Utc::now(),
+            last_refreshed: None,
+            email: Some("user@example.com".into()),
+            is_default: false,
+        },
+        token: crate::api::auth::models::OAuthToken {
+            access_token: "a".into(),
+            refresh_token: Some("r".into()),
+            expires_at: chrono::Utc::now() + chrono::Duration::seconds(expires_in_secs),
+            scopes: vec!["openid".into()],
+            token_type: "Bearer".into(),
+        },
+    }
+}
+
+#[test]
+fn warns_when_project_stale_and_user_fresh() {
+    let project = make_stored(-3600);
+    let user = make_stored(3600);
+    let info = stale_shadow_warning(
+        &project,
+        &user,
+        Path::new("/proj/.gworkspace-mcp/tokens.json"),
+        Path::new("/home/user/.gworkspace-mcp/tokens.json"),
+    )
+    .expect("must warn: project stale, user fresh");
+    assert_eq!(
+        info.project_path,
+        Path::new("/proj/.gworkspace-mcp/tokens.json")
+    );
+    assert_eq!(
+        info.user_path,
+        Path::new("/home/user/.gworkspace-mcp/tokens.json")
+    );
+    assert_eq!(info.project_expires_at, project.token.expires_at);
+    assert_eq!(info.user_expires_at, user.token.expires_at);
+}
+
+#[test]
+fn no_warning_when_both_fresh() {
+    let project = make_stored(3600);
+    let user = make_stored(7200);
+    assert!(stale_shadow_warning(&project, &user, Path::new("p"), Path::new("u")).is_none());
+}
+
+#[test]
+fn no_warning_when_both_stale() {
+    // Both stale is not the silent-shadow failure mode — the caller gets
+    // an expired token either way, so no extra signal is needed here.
+    let project = make_stored(-3600);
+    let user = make_stored(-7200);
+    assert!(stale_shadow_warning(&project, &user, Path::new("p"), Path::new("u")).is_none());
+}
+
+#[test]
+fn no_warning_when_project_is_fresher() {
+    let project = make_stored(3600);
+    let user = make_stored(-3600);
+    assert!(stale_shadow_warning(&project, &user, Path::new("p"), Path::new("u")).is_none());
+}
+
+/// Build a two-tier temp `TokenStorage` (separate user/project dirs) with
+/// a `work` profile present on both sides, and write the given
+/// user/project token maps to disk. Shared by the precedence and
+/// warn-capture tests below.
+fn temp_shadowed_storage(
+    label: &str,
+    user_expires_in_secs: i64,
+    project_expires_in_secs: i64,
+) -> TokenStorage {
+    let dir = std::env::temp_dir().join(format!("gw-storage-{label}-{}", uuid::Uuid::new_v4()));
+    let user_dir = dir.join("user");
+    let project_dir = dir.join("project");
+    std::fs::create_dir_all(&user_dir).unwrap();
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let user_path = user_dir.join("tokens.json");
+    let project_path = project_dir.join("tokens.json");
+
+    let mut user_tokens = HashMap::new();
+    user_tokens.insert("work".to_string(), make_stored(user_expires_in_secs));
+    std::fs::write(&user_path, serde_json::to_string(&user_tokens).unwrap()).unwrap();
+
+    let mut project_tokens = HashMap::new();
+    let mut project_stored = make_stored(project_expires_in_secs);
+    project_stored.token.access_token = "stale-access-token".into();
+    project_tokens.insert("work".to_string(), project_stored);
+    std::fs::write(
+        &project_path,
+        serde_json::to_string(&project_tokens).unwrap(),
+    )
+    .unwrap();
+
+    TokenStorage {
+        user_path,
+        project_path: Some(project_path),
+        warned_stale_shadows: Arc::new(Mutex::new(HashSet::new())),
+        write_guard: Arc::new(Mutex::new(())),
+    }
+}
+
+#[test]
+fn load_still_prefers_project_override_after_warning() {
+    // Regression guard for the precedence contract: this fix only adds a
+    // warning, it does not change which entry wins (see PR body) — a
+    // stale project override must still be served, just noisily.
+    let storage = temp_shadowed_storage("precedence", 3600, -3600);
+
+    let loaded = storage.load().unwrap();
+    assert_eq!(
+        loaded["work"].token.access_token, "stale-access-token",
+        "project override must still win per the documented contract \
+             (warn, don't change precedence)"
+    );
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn load_warns_when_project_shadow_is_stale() {
+    let storage = temp_shadowed_storage("warns", 3600, -3600);
+
+    storage.load().unwrap();
+
+    assert!(logs_contain("work"));
+    assert!(logs_contain("STALE"));
+}
+
+#[test]
+#[tracing_test::traced_test]
+fn load_does_not_rewarn_on_second_load() {
+    // PR #2949 review (HIGH): load() sits on the per-request hot path —
+    // an unthrottled warn would repeat on every single MCP tool call.
+    // Two loads on the same TokenStorage must produce exactly one
+    // stale-shadow warning, not two.
+    let storage = temp_shadowed_storage("norewarn", 3600, -3600);
+
+    storage.load().unwrap();
+    storage.load().unwrap();
+
+    logs_assert(|lines: &[&str]| {
+        let count = lines
+            .iter()
+            .filter(|l| l.contains("STALE") && l.contains("work"))
+            .count();
+        if count == 1 {
+            Ok(())
+        } else {
+            Err(format!(
+                "expected exactly 1 stale-shadow warning after two load() calls, found {count}"
+            ))
+        }
+    });
+}
+
+/// Best-effort regression test for issue #3502: two threads racing a
+/// load-mutate-save cycle through [`TokenStorage::update`] on clones of
+/// the same storage (the in-process half of the guard; the file lock
+/// additionally protects separate processes, which a unit test can't
+/// easily spin up) must not lose either writer's profile.
+#[test]
+fn concurrent_updates_do_not_lose_writes() {
+    let dir = std::env::temp_dir().join(format!("gw-storage-concurrent-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let storage = TokenStorage::with_path(dir.join("tokens.json"));
+    storage.save(&HashMap::new()).expect("seed empty map");
+
+    let writers: Vec<_> = (0..8)
+        .map(|i| {
+            let s = storage.clone();
+            std::thread::spawn(move || {
+                let name = format!("profile-{i}");
+                s.update(|all| {
+                    all.insert(name.clone(), make_stored(3600));
+                    Ok(())
+                })
+                .expect("update");
+            })
+        })
+        .collect();
+    for w in writers {
+        w.join().expect("writer thread panicked");
+    }
+
+    let all = storage.load().expect("load");
+    assert_eq!(
+        all.len(),
+        8,
+        "all 8 concurrent writers' profiles must be present, got {} — a write was lost",
+        all.len()
+    );
+    for i in 0..8 {
+        assert!(
+            all.contains_key(&format!("profile-{i}")),
+            "profile-{i} missing after concurrent updates"
+        );
+    }
+}
+
+#[test]
+fn remove_default_reassigns_to_next_profile() {
+    let mut all = HashMap::new();
+    all.insert("zeta".to_string(), make_stored(3600));
+    all.insert("alpha".to_string(), make_stored(3600));
+    all.get_mut("zeta").unwrap().metadata.is_default = true;
+
+    let outcome = remove_and_reassign_default(&mut all, "zeta").expect("remove");
+    assert_eq!(outcome.removed, "zeta");
+    assert_eq!(outcome.reassigned_default.as_deref(), Some("alpha"));
+    assert!(
+        all["alpha"].metadata.is_default,
+        "alpha must become default"
+    );
+    assert!(!all.contains_key("zeta"));
+}
+
+#[test]
+fn remove_default_leaves_none_when_last_profile() {
+    let mut all = HashMap::new();
+    all.insert("only".to_string(), make_stored(3600));
+    all.get_mut("only").unwrap().metadata.is_default = true;
+
+    let outcome = remove_and_reassign_default(&mut all, "only").expect("remove");
+    assert_eq!(outcome.reassigned_default, None);
+    assert!(all.is_empty());
+}
+
+#[test]
+fn remove_non_default_does_not_reassign() {
+    let mut all = HashMap::new();
+    all.insert("keep".to_string(), make_stored(3600));
+    all.get_mut("keep").unwrap().metadata.is_default = true;
+    all.insert("drop".to_string(), make_stored(3600));
+
+    let outcome = remove_and_reassign_default(&mut all, "drop").expect("remove");
+    assert_eq!(outcome.reassigned_default, None);
+    assert!(
+        all["keep"].metadata.is_default,
+        "unrelated default untouched"
+    );
+}
+
+#[test]
+fn remove_missing_profile_errors() {
+    let mut all: HashMap<String, StoredToken> = HashMap::new();
+    assert!(remove_and_reassign_default(&mut all, "missing").is_err());
+}

--- a/crates/trusty-gworkspace/src/api/client.rs
+++ b/crates/trusty-gworkspace/src/api/client.rs
@@ -102,6 +102,24 @@ impl BaseClient {
         &self.storage
     }
 
+    /// Test-only constructor with injectable storage and no refresh manager.
+    ///
+    /// Why: `services::accounts`' account-management tools (`set_default_account`,
+    /// `remove_account`) only ever touch `TokenStorage`, never the network, so
+    /// their tests need a `BaseClient` backed by a temp `TokenStorage` without
+    /// touching `~/.gworkspace-mcp` or real OAuth credentials.
+    /// What: Builds a plain `reqwest::Client`; `oauth` is always `None` since
+    /// nothing exercised by those tests calls `get_access_token`'s refresh path.
+    /// Test: exercised by `services::accounts::tests`.
+    #[cfg(test)]
+    pub(crate) fn for_test(storage: TokenStorage) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            storage: Arc::new(storage),
+            oauth: None,
+        }
+    }
+
     /// Resolve a stored token entry, preferring (in order):
     /// 1. The explicit `account` parameter
     /// 2. `GWORKSPACE_ACCOUNT` environment variable

--- a/crates/trusty-gworkspace/src/api/services/accounts.rs
+++ b/crates/trusty-gworkspace/src/api/services/accounts.rs
@@ -1,22 +1,36 @@
-//! Account / profile listing.
+//! Account / profile management.
 //!
-//! Why: Users with multiple Google accounts need to discover which profile
-//! names they can pass as the `account` MCP argument.
-//! What: Reads from `TokenStorage` (no network); returns a JSON array of
-//! `{name, email, is_default}` objects.
-//! Test: Indirect — covered by storage tests.
+//! Why: Users with multiple Google accounts need to discover, switch, remove,
+//! and add profiles without shelling out to the `trusty-gworkspace-mcp`
+//! CLI (issue #3503). `list_accounts` was the only MCP-exposed surface;
+//! `set_default_account` / `remove_account` / `add_account` close that gap.
+//! What: `set_default_account` / `remove_account` wrap the same lock-guarded
+//! `TokenStorage` methods the CLI uses (`api::auth::storage`, #3502) so both
+//! surfaces share one mutation implementation. `add_account` reuses the
+//! native PKCE consent flow (`api::auth::oauth::flow::run_consent_with`) —
+//! see its doc comment for the blocking-call design and why.
+//! Test: Indirect — covered by storage tests plus the argument-validation
+//! smoke tests below.
 
-use anyhow::Result;
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
 use serde_json::{Value, json};
 
+use crate::api::auth::oauth::{DefaultMode, flow};
 use crate::api::client::BaseClient;
+use crate::api::services::{opt_str, require_str};
 
-/// Why: Enumerate authenticated Google profiles stored locally so the model can pick one.
-/// What: Returns `{accounts: [{name, email, is_default}]}` read from `TokenStorage` — no network.
-/// Test: Covered indirectly via `TokenStorage` storage round-trip test.
-pub async fn list_accounts(client: &BaseClient, _args: Value) -> Result<Value> {
+/// Build the `[{name, email, is_default}, ...]` JSON array from storage.
+///
+/// Why: Shared by `list_accounts` and every mutating tool below so each
+/// response includes an up-to-date account list without repeating the
+/// row-to-JSON mapping.
+/// What: Reads via `TokenStorage::list_accounts` (no network).
+/// Test: Covered indirectly via `TokenStorage` storage round-trip tests.
+fn accounts_json(client: &BaseClient) -> Result<Vec<Value>> {
     let rows = client.storage().list_accounts()?;
-    let accounts: Vec<Value> = rows
+    Ok(rows
         .into_iter()
         .map(|(name, email, is_default)| {
             json!({
@@ -25,6 +39,282 @@ pub async fn list_accounts(client: &BaseClient, _args: Value) -> Result<Value> {
                 "is_default": is_default,
             })
         })
-        .collect();
-    Ok(json!({ "accounts": accounts }))
+        .collect())
+}
+
+/// Why: Enumerate authenticated Google profiles stored locally so the model can pick one.
+/// What: Returns `{accounts: [{name, email, is_default}]}` read from `TokenStorage` — no network.
+/// Test: Covered indirectly via `TokenStorage` storage round-trip test.
+pub async fn list_accounts(client: &BaseClient, _args: Value) -> Result<Value> {
+    Ok(json!({ "accounts": accounts_json(client)? }))
+}
+
+/// Why: Lets an agent switch which profile MCP tools use by default without
+/// shelling out to `trusty-gworkspace-mcp accounts default`.
+/// What: Validates `name` exists (via `TokenStorage::set_default_profile`,
+/// shared with the CLI), then returns the new default plus the full account
+/// list. No network call.
+/// Test: `set_default_account_switches_default`,
+/// `set_default_account_rejects_unknown_profile`.
+pub async fn set_default_account(client: &BaseClient, args: Value) -> Result<Value> {
+    let name = require_str(&args, "name")?;
+    client.storage().set_default_profile(name)?;
+    Ok(json!({
+        "default": name,
+        "accounts": accounts_json(client)?,
+    }))
+}
+
+/// Why: Lets an agent clean up a stale/revoked profile without shelling out
+/// to the CLI, and — unlike the CLI's original behavior — never silently
+/// orphans the default (issue #3502).
+/// What: Wraps `TokenStorage::remove_profile` (shared with the CLI); returns
+/// which profile was removed, which remaining profile inherited the default
+/// role (if any), and the updated account list. Does not revoke Google's
+/// grant, matching the CLI's `remove`. No network call.
+/// Test: `remove_account_reassigns_default`, `remove_account_rejects_unknown_profile`.
+pub async fn remove_account(client: &BaseClient, args: Value) -> Result<Value> {
+    let name = require_str(&args, "name")?;
+    let outcome = client.storage().remove_profile(name)?;
+    Ok(json!({
+        "removed": outcome.removed,
+        "reassigned_default": outcome.reassigned_default,
+        "accounts": accounts_json(client)?,
+    }))
+}
+
+/// Bounded wait for the `add_account` MCP tool's browser-consent step.
+///
+/// Why: The interactive CLI (`setup`) blocks up to 5 minutes
+/// (`oauth::flow::CONSENT_TIMEOUT`) waiting for the user to finish consent in
+/// a terminal session where that's expected. An MCP tool call is different:
+/// many MCP clients bound how long a single call may run, and a hung call
+/// blocks the whole exchange with no way for the agent to do anything else
+/// meanwhile. 60s is long enough for a human who already has the URL open to
+/// click through Google's consent screen, short enough to stay well inside
+/// typical client-side tool-call timeouts. See `add_account`'s doc comment
+/// for the full design tradeoff (flagged for owner review).
+const ADD_ACCOUNT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Lower/upper bounds for the optional `timeout_secs` override.
+const ADD_ACCOUNT_TIMEOUT_MIN_SECS: u64 = 10;
+const ADD_ACCOUNT_TIMEOUT_MAX_SECS: u64 = 90;
+
+/// Initiate the native OAuth consent flow to authorize a new (or re-auth an
+/// existing) Google account profile.
+///
+/// Why (design choice — flagged for owner review): completing consent
+/// requires a human in a browser, which an MCP tool call can't do
+/// synchronously end-to-end. Two shapes were considered: (a) return the URL
+/// immediately, run the callback listener in a background task, and expose a
+/// separate poll/status tool; or (b) a single bounded blocking call that
+/// returns the URL either way (success or timed-out) so the caller can
+/// relay/retry. This picks (b): it reuses `oauth::flow::run_consent_with`
+/// completely as-is (zero new machinery — no background task registry, no
+/// status store, no cancellation handling to get right) and mirrors the
+/// crate's existing `setup --print-url` mode, just with a much shorter,
+/// MCP-call-appropriate timeout ([`ADD_ACCOUNT_TIMEOUT`], overridable via
+/// `timeout_secs` within [`ADD_ACCOUNT_TIMEOUT_MIN_SECS`],
+/// [`ADD_ACCOUNT_TIMEOUT_MAX_SECS`]) instead of the CLI's 5 minutes. The
+/// tradeoff: the tool call itself blocks for up to that long, so a client
+/// with a shorter built-in tool-call timeout would see the call fail even
+/// though the flow is still safe to retry (no partial/corrupt token is ever
+/// written — `run_consent_with` only persists after a successful token
+/// exchange). Browser auto-launch is intentionally disabled here (unlike the
+/// CLI default) since an MCP server may run in a context with no reachable
+/// display for the calling human; the URL is always returned in the response
+/// so the agent can relay it.
+/// What: Args: `profile` (optional, defaults to the shared default profile
+/// name), `make_default` / `no_default` (mutually exclusive, mirrors `setup`
+/// flags; default is `DefaultMode::Auto`), `timeout_secs` (optional, clamped
+/// to the bounds above). Returns `{"status": "authorized", "auth_url", ...}`
+/// on success, or `{"status": "timed_out", "auth_url", "message"}` if the
+/// browser step didn't complete in time — the caller can retry `add_account`
+/// for a fresh URL. Any other failure (e.g. missing OAuth client
+/// credentials) propagates as a tool error.
+/// Test: `add_account_rejects_conflicting_default_flags`,
+/// `add_account_clamps_timeout_bounds`.
+pub async fn add_account(client: &BaseClient, args: Value) -> Result<Value> {
+    let profile = flow::effective_profile(opt_str(&args, "profile"));
+    let no_default = args
+        .get("no_default")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let make_default = args
+        .get("make_default")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if no_default && make_default {
+        return Err(anyhow!(
+            "no_default and make_default are mutually exclusive"
+        ));
+    }
+    let mode = if no_default {
+        DefaultMode::Never
+    } else if make_default {
+        DefaultMode::Force
+    } else {
+        DefaultMode::Auto
+    };
+    let timeout = clamp_timeout(args.get("timeout_secs").and_then(Value::as_u64));
+
+    // `std::sync::Mutex` (not `RefCell`) because the closure below is held
+    // across an `.await` inside a `Send` future (`run_stdio_loop` requires
+    // it) — `&Mutex<String>` is `Send`, `&RefCell<String>` is not.
+    let captured_url = std::sync::Mutex::new(String::new());
+    let outcome = flow::run_consent_with(client.storage(), &profile, mode, false, timeout, |url| {
+        *captured_url.lock().unwrap_or_else(|p| p.into_inner()) = url.to_string();
+    })
+    .await;
+    let auth_url = captured_url.into_inner().unwrap_or_else(|p| p.into_inner());
+
+    match outcome {
+        Ok(o) => Ok(json!({
+            "status": "authorized",
+            "auth_url": auth_url,
+            "profile": o.profile,
+            "email": o.email,
+            "default_applied": o.default_applied,
+        })),
+        Err(e) if e.to_string().contains("timed out") => Ok(json!({
+            "status": "timed_out",
+            "auth_url": auth_url,
+            "message": format!(
+                "Consent was not completed within {}s using this URL. Call add_account again for a fresh URL and retry.",
+                timeout.as_secs()
+            ),
+        })),
+        Err(e) => Err(e),
+    }
+}
+
+/// Clamp an optional caller-supplied timeout into the safe MCP-call bounds.
+///
+/// Why: Isolated as a pure function so the clamping rule is directly
+/// unit-testable without exercising the full (network-touching) consent flow.
+/// What: `None` -> [`ADD_ACCOUNT_TIMEOUT`]; otherwise clamps into
+/// `[ADD_ACCOUNT_TIMEOUT_MIN_SECS, ADD_ACCOUNT_TIMEOUT_MAX_SECS]`.
+/// Test: `add_account_clamps_timeout_bounds`.
+fn clamp_timeout(requested_secs: Option<u64>) -> Duration {
+    match requested_secs {
+        None => ADD_ACCOUNT_TIMEOUT,
+        Some(secs) => Duration::from_secs(
+            secs.clamp(ADD_ACCOUNT_TIMEOUT_MIN_SECS, ADD_ACCOUNT_TIMEOUT_MAX_SECS),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::auth::TokenStorage;
+    use crate::api::auth::models::{OAuthToken, StoredToken, TokenMetadata};
+    use chrono::{Duration as ChronoDuration, Utc};
+    use std::collections::HashMap;
+
+    fn test_client() -> BaseClient {
+        let dir = std::env::temp_dir().join(format!("gw-accounts-svc-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        BaseClient::for_test(TokenStorage::with_path(dir.join("tokens.json")))
+    }
+
+    fn entry(name: &str, is_default: bool) -> StoredToken {
+        StoredToken {
+            version: 1,
+            metadata: TokenMetadata {
+                service_name: name.to_string(),
+                provider: "google".into(),
+                created_at: Utc::now(),
+                last_refreshed: None,
+                email: Some(format!("{name}@example.com")),
+                is_default,
+            },
+            token: OAuthToken {
+                access_token: "a".into(),
+                refresh_token: Some("r".into()),
+                expires_at: Utc::now() + ChronoDuration::seconds(3600),
+                scopes: vec!["openid".into()],
+                token_type: "Bearer".into(),
+            },
+        }
+    }
+
+    fn seed(client: &BaseClient) {
+        let mut map = HashMap::new();
+        map.insert("a".to_string(), entry("a", true));
+        map.insert("b".to_string(), entry("b", false));
+        client.storage().save(&map).unwrap();
+    }
+
+    #[tokio::test]
+    async fn set_default_account_switches_default() {
+        let client = test_client();
+        seed(&client);
+
+        let result = set_default_account(&client, json!({ "name": "b" }))
+            .await
+            .unwrap();
+        assert_eq!(result["default"], "b");
+        let accounts = result["accounts"].as_array().unwrap();
+        assert_eq!(accounts.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn set_default_account_rejects_unknown_profile() {
+        let client = test_client();
+        seed(&client);
+
+        let err = set_default_account(&client, json!({ "name": "missing" }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[tokio::test]
+    async fn remove_account_reassigns_default() {
+        let client = test_client();
+        seed(&client);
+
+        let result = remove_account(&client, json!({ "name": "a" }))
+            .await
+            .unwrap();
+        assert_eq!(result["removed"], "a");
+        assert_eq!(result["reassigned_default"], "b");
+        let accounts = result["accounts"].as_array().unwrap();
+        assert_eq!(accounts.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn remove_account_rejects_unknown_profile() {
+        let client = test_client();
+        seed(&client);
+
+        let err = remove_account(&client, json!({ "name": "missing" }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("missing"));
+    }
+
+    #[tokio::test]
+    async fn add_account_rejects_conflicting_default_flags() {
+        let client = test_client();
+        let err = add_account(&client, json!({ "no_default": true, "make_default": true }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn add_account_clamps_timeout_bounds() {
+        assert_eq!(clamp_timeout(None), ADD_ACCOUNT_TIMEOUT);
+        assert_eq!(
+            clamp_timeout(Some(1)),
+            Duration::from_secs(ADD_ACCOUNT_TIMEOUT_MIN_SECS)
+        );
+        assert_eq!(
+            clamp_timeout(Some(10_000)),
+            Duration::from_secs(ADD_ACCOUNT_TIMEOUT_MAX_SECS)
+        );
+        assert_eq!(clamp_timeout(Some(45)), Duration::from_secs(45));
+    }
 }

--- a/crates/trusty-gworkspace/src/cli/accounts.rs
+++ b/crates/trusty-gworkspace/src/cli/accounts.rs
@@ -2,12 +2,17 @@
 //!
 //! Why: Once tokens can be minted natively, users need a way to inspect and
 //! manage the profiles in `tokens.json` without hand-editing JSON.
-//! What: Free functions over [`TokenStorage`] that load the map, mutate it,
-//! and save. All output goes to stdout (human-facing CLI), logs to stderr.
-//! Test: `set_default_moves_flag` and `remove_deletes_profile` exercise the
-//! mutation logic against a temp storage.
+//! What: Thin stdout-printing wrappers over the shared, lock-guarded
+//! [`TokenStorage::set_default_profile`] / [`TokenStorage::remove_profile`]
+//! (the same methods the `set_default_account` / `remove_account` MCP tools
+//! use — see `api::services::accounts`) so both surfaces get identical
+//! mutation semantics, including the remove-the-default reassignment
+//! (#3502). All output goes to stdout (human-facing CLI), logs to stderr.
+//! Test: `set_default_moves_flag` and `remove_deletes_profile` exercise this
+//! wrapper end-to-end against a temp storage; the mutation logic itself is
+//! unit-tested in `api::auth::storage::tests`.
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 
 use crate::api::auth::TokenStorage;
 
@@ -41,21 +46,11 @@ pub fn list(storage: &TokenStorage) -> Result<()> {
 ///
 /// Why: Users with multiple accounts need to choose which one tools use when
 /// no explicit `account` is passed.
-/// What: Loads the map, errors if `name` is absent, clears all defaults, sets
-/// the target's `is_default`, and saves.
+/// What: Delegates to [`TokenStorage::set_default_profile`] (errors if
+/// `name` is absent) and prints the confirmation.
 /// Test: `set_default_moves_flag`.
 pub fn set_default(storage: &TokenStorage, name: &str) -> Result<()> {
-    let mut all = storage.load()?;
-    if !all.contains_key(name) {
-        return Err(anyhow!("no profile named '{name}'"));
-    }
-    for entry in all.values_mut() {
-        entry.metadata.is_default = false;
-    }
-    if let Some(entry) = all.get_mut(name) {
-        entry.metadata.is_default = true;
-    }
-    storage.save(&all)?;
+    storage.set_default_profile(name)?;
     println!("Default profile set to '{name}'.");
     Ok(())
 }
@@ -63,16 +58,20 @@ pub fn set_default(storage: &TokenStorage, name: &str) -> Result<()> {
 /// Remove the named profile from storage.
 ///
 /// Why: Revoking or cleaning up an account should not require editing JSON.
-/// What: Loads the map, errors if absent, removes the entry, and saves. Note:
-/// this only forgets the local token; it does not revoke Google's grant.
+/// What: Delegates to [`TokenStorage::remove_profile`] (errors if absent;
+/// reassigns the default to another remaining profile if the removed one was
+/// it) and prints the outcome. Note: this only forgets the local token; it
+/// does not revoke Google's grant.
 /// Test: `remove_deletes_profile`.
 pub fn remove(storage: &TokenStorage, name: &str) -> Result<()> {
-    let mut all = storage.load()?;
-    if all.remove(name).is_none() {
-        return Err(anyhow!("no profile named '{name}'"));
+    let outcome = storage.remove_profile(name)?;
+    match &outcome.reassigned_default {
+        Some(new_default) => println!(
+            "Removed profile '{name}'. (Google's grant is not revoked.) \
+             Default profile reassigned to '{new_default}'."
+        ),
+        None => println!("Removed profile '{name}'. (Google's grant is not revoked.)"),
     }
-    storage.save(&all)?;
-    println!("Removed profile '{name}'. (Google's grant is not revoked.)");
     Ok(())
 }
 

--- a/crates/trusty-gworkspace/src/openrpc.rs
+++ b/crates/trusty-gworkspace/src/openrpc.rs
@@ -60,8 +60,12 @@ mod scopes {
 pub fn scopes_for_tool(name: &str) -> &'static [&'static str] {
     use scopes::*;
     match name {
-        // Accounts — only needs profile info to enumerate local profiles.
-        "list_accounts" => &[USERINFO_PROFILE],
+        // Accounts — only needs profile info to enumerate/manage local
+        // profiles (none of these call a Google data API; `add_account`
+        // mints the credential itself rather than requiring one up front).
+        "list_accounts" | "set_default_account" | "remove_account" | "add_account" => {
+            &[USERINFO_PROFILE]
+        }
 
         // Calendar
         "manage_calendars" => &[CALENDAR],

--- a/crates/trusty-gworkspace/src/server.rs
+++ b/crates/trusty-gworkspace/src/server.rs
@@ -40,6 +40,9 @@ pub async fn handle_tool_call(state: &AppState, name: &str, args: Value) -> Valu
     let result: anyhow::Result<Value> = match name {
         // Accounts
         "list_accounts" => services::accounts::list_accounts(&state.client, args).await,
+        "set_default_account" => services::accounts::set_default_account(&state.client, args).await,
+        "remove_account" => services::accounts::remove_account(&state.client, args).await,
+        "add_account" => services::accounts::add_account(&state.client, args).await,
 
         // Calendar
         "manage_calendars" => services::calendar::manage_calendars(&state.client, args).await,

--- a/crates/trusty-gworkspace/src/tools/accounts.rs
+++ b/crates/trusty-gworkspace/src/tools/accounts.rs
@@ -2,7 +2,8 @@
 //!
 //! Why: Groups the Google Workspace account/profile tools so the top-level
 //! registry stays a thin dispatcher.
-//! What: Appends the `list_accounts` tool to the shared registry vector.
+//! What: Appends `list_accounts`, `set_default_account`, `remove_account`,
+//! and `add_account` to the shared registry vector (issue #3503).
 //! Test: Covered via `tool_list_response()` in `tools::tests`.
 
 use super::schema::{account_schema, tool};
@@ -11,13 +12,65 @@ use serde_json::{Value, json};
 /// Append the accounts tool group to the registry.
 ///
 /// Why: Keeps account tools colocated and testable via the aggregate.
-/// What: Pushes `list_accounts` onto `tools`.
+/// What: Pushes `list_accounts`, `set_default_account`, `remove_account`, and
+/// `add_account` onto `tools`.
 /// Test: Covered via `tool_list_response()` in `tools::tests`.
 pub(super) fn append(tools: &mut Vec<Value>) {
     tools.push(tool(
         "list_accounts",
         "List configured Google Workspace account profiles available on this machine.",
         json!({ "account": account_schema() }),
+        &[],
+    ));
+    tools.push(tool(
+        "set_default_account",
+        "Set which configured Google Workspace account profile is used by default when a tool \
+         call omits `account`.",
+        json!({
+            "name": {
+                "type": "string",
+                "description": "The profile name to make the default (must already exist — see list_accounts).",
+            },
+        }),
+        &["name"],
+    ));
+    tools.push(tool(
+        "remove_account",
+        "Remove a configured Google Workspace account profile from local storage. Does not \
+         revoke Google's grant. If the removed profile was the default, another remaining \
+         profile is automatically promoted to default.",
+        json!({
+            "name": {
+                "type": "string",
+                "description": "The profile name to remove.",
+            },
+        }),
+        &["name"],
+    ));
+    tools.push(tool(
+        "add_account",
+        "Authorize a new Google Workspace account profile (or re-authorize an existing one) via \
+         OAuth consent. Returns a consent URL the user must open in a browser; this call blocks \
+         briefly waiting for that consent to complete and reports whether it succeeded or timed \
+         out (safe to retry either way — no partial state is ever stored).",
+        json!({
+            "profile": {
+                "type": "string",
+                "description": "Profile name to store the token under (default: the shared default profile name).",
+            },
+            "no_default": {
+                "type": "boolean",
+                "description": "Do NOT mark this profile as the default, even if none exists yet. Mutually exclusive with make_default.",
+            },
+            "make_default": {
+                "type": "boolean",
+                "description": "Explicitly make this profile the default, displacing any existing one. Mutually exclusive with no_default.",
+            },
+            "timeout_secs": {
+                "type": "integer",
+                "description": "How long to wait for the user to complete browser consent, in seconds (clamped to 10-90; default 60).",
+            },
+        }),
         &[],
     ));
 }


### PR DESCRIPTION
## Summary

- **Hardening (#3502).** `TokenStorage::update()` guards every
  `tokens.json` read-modify-write (refresh, consent persist, CLI
  `accounts default`/`accounts remove`) with an in-process mutex plus
  an advisory cross-process file lock on a sidecar `tokens.json.lock`,
  so two concurrent writers can no longer silently lose one another's
  profile. Removing the current default profile now deterministically
  reassigns the default to another remaining profile instead of
  orphaning it.
- **MCP tools (#3503).** Adds `set_default_account`, `remove_account`,
  and `add_account` MCP tools, backed by the same shared,
  lock-guarded `TokenStorage` methods the CLI uses — no logic
  duplication. `list_accounts` is unchanged.

Shipped as one PR (not split) since Part B's tools call the exact
`TokenStorage` methods Part A adds — splitting would require a stacked
branch with no real review benefit given the combined diff is a
moderate, coherent ~450 net new lines (excluding a same-content
`storage.rs` → `storage/mod.rs` + `storage/tests.rs` split needed to
stay under the repo's 500-SLOC file cap).

## `add_account` design choice (flagged for owner review)

Completing OAuth consent needs a human in a browser, which an MCP
tool call can't do synchronously end-to-end. Two shapes were
considered:
- (a) return the URL immediately, run the callback listener in a
  background task, and add a separate poll/status tool; or
- (b) a single bounded blocking call that returns the consent URL
  either way (success or timed out) so the caller can relay/retry.

This ships **(b)**: it reuses `oauth::flow::run_consent_with` (a
refactor of the existing `run_consent`, split only to hand the URL to
a caller-supplied callback before blocking) completely as-is — zero
new state-management machinery (no background task registry, no
status store, no cancellation handling) — and mirrors the crate's
existing `setup --print-url` mode, just with a much shorter default
timeout (60s, clamped 10–90s via an optional `timeout_secs` arg)
instead of the CLI's 5 minutes. Tradeoff: the tool call itself blocks
for up to that long, so an MCP client with a shorter built-in
tool-call timeout could see the call fail even though retrying is
always safe — no token is ever persisted until the exchange fully
succeeds, so there's no partial/corrupt state to clean up. Browser
auto-launch is disabled for this path (unlike the CLI default) since
an MCP server may run with no reachable display for the calling
human; the consent URL is always included in the tool response so the
agent can relay it.

## Authority/consent gating

No new gating was added beyond normal MCP tool-call approval. The
crate has no existing tool-annotation/gating convention (no
`destructiveHint`-style mechanism anywhere in `tools/schema.rs`), so
`set_default_account`/`remove_account`/`add_account` follow the same
uniform pattern as other state-changing tools already in the registry
(e.g. `manage_drive_file`'s delete action, `manage_gmail_messages`).

## Key locations

- Lock + read-modify-write guard: `crates/trusty-gworkspace/src/api/auth/storage/mod.rs:246` (`TokenStorage::update`)
- Orphan-default fix: `crates/trusty-gworkspace/src/api/auth/storage/mod.rs` (`TokenStorage::remove_profile` / `remove_and_reassign_default`)
- Shared mutation call sites updated: `api/auth/manager.rs::refresh`, `api/auth/oauth/flow/mod.rs::persist`, `cli/accounts.rs`
- URL-callback consent refactor: `api/auth/oauth/flow/mod.rs` (`run_consent_with`)
- New MCP tools: `api/services/accounts.rs` (`set_default_account`, `remove_account`, `add_account`), schemas in `tools/accounts.rs`, dispatch in `server.rs`, OAuth-scope entries in `openrpc.rs`

## Release note

**This crate is `publish = false` / not yet on crates.io in a way that
matters here** — either way, these changes only reach live MCP
clients after a `trusty-gworkspace` version bump + reinstall. That
release step is intentionally NOT done in this PR (owner-gated,
per the task).

## Test plan

- [x] `cargo test -p trusty-gworkspace` — 246 lib tests + 2 integration tests, 0 failed (includes new concurrency test `concurrent_updates_do_not_lose_writes`, orphan-default tests, and account-tool argument-validation tests)
- [x] `cargo fmt --check -p trusty-gworkspace` — clean
- [x] `cargo clippy -p trusty-gworkspace --all-targets -- -D warnings` — clean
- [x] `scripts/check_line_cap.sh` — 0 violations
- [x] `scripts/check_sld.sh` — 0 errors/warnings
- [ ] CI (awaiting `gh pr checks`)

Closes #3502, Closes #3503

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools