### PR TITLE
fix(trusty-agents): make credential-resolution tests isolatable from the process-global .env.local loader

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -54,6 +54,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Credential-test env isolation flake (#3464):** several `llm::credentials`,
+  `llm::helpers`, `llm::adapter`, `llm::http`, `ctrl::ctrl_turn::dispatch`, and
+  `runtime::cli_def` tests that assert "no credential resolves" or "the store
+  wins when env is absent" intermittently failed under `cargo test --workspace`
+  (and deterministically on any machine/CI runner with a real project or
+  `$HOME` `.env.local`). Root cause: `trusty_common`'s `.env.local` loader is a
+  process-global `OnceLock` that fires at most once per test binary; whichever
+  test's credential-resolution call happened to be first could have it silently
+  re-populate an env var a test had just cleared, mid-call. Fixed by forcing
+  that loader to have already run (`test_env::force_env_local_loaded`) before
+  any test clears credential env vars, and by clearing every registry-mapped
+  provider's env var (not just the three `openrouter`/`anthropic`/`claude-code`
+  names) in `other_configured_providers()`'s tests
+  (`test_env::clear_all_credential_env_vars`). Also sandboxes `$HOME` in
+  `ctrl_creds_errors_when_nothing_configured`, a pre-existing gap that made it
+  fail deterministically on any machine with a real secure-store credential.
 - **Favicon/RobotIcon drift (#3486):** `ui/public/favicon.svg` was a fourth,
   independently hand-drawn robot face (different rect/circle coordinates, a
   `<text>`-rendered `>_` mouth) that had drifted from `RobotIcon.svelte`'s

--- a/crates/trusty-agents/src/ctrl/ctrl_turn/dispatch.rs
+++ b/crates/trusty-agents/src/ctrl/ctrl_turn/dispatch.rs
@@ -304,7 +304,13 @@ mod tests {
     /// known-empty environment. SAFETY: every test below is `#[serial]` AND
     /// holds `crate::test_env::ENV_LOCK` to serialize against the rest of the
     /// crate's env-touching tests (#274 / #408).
+    ///
+    /// #3464: forces the process-global `.env.local` `OnceLock` loader to
+    /// have already fired before removing anything — see
+    /// `crate::test_env::force_env_local_loaded`'s docs for why a
+    /// remove-only helper is not reliably idempotent against that loader.
     fn clear_creds_env() {
+        crate::test_env::force_env_local_loaded();
         unsafe {
             std::env::remove_var("OPENROUTER_API_KEY");
             std::env::remove_var("ANTHROPIC_API_KEY");
@@ -368,19 +374,47 @@ mod tests {
 
     /// With no credentials configured the legacy path must surface an error
     /// instead of defaulting to OpenRouter.
+    ///
+    /// Also sandboxes `$HOME` to a fresh, never-written-to tempdir (a
+    /// pre-existing gap independent of #3464 — this test cleared only the
+    /// three env vars and never isolated the secure-store tier, so on any
+    /// machine/CI runner with a real `~/.trusty-tools/credentials.toml`
+    /// entry for openrouter/anthropic, `resolve_ctrl_turn_credentials` would
+    /// resolve a real credential from the store and this always-erroring
+    /// expectation would fail deterministically). Holds `HOME_LOCK` for the
+    /// whole body per `test_env`'s documented convention.
     #[test]
     #[serial]
     fn ctrl_creds_errors_when_nothing_configured() {
         let _g = crate::test_env::ENV_LOCK
             .lock()
             .unwrap_or_else(|e| e.into_inner());
+        let _home_guard = crate::test_env::HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         clear_creds_env();
+
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let prev_home = std::env::var_os("HOME");
+        // SAFETY: HOME_LOCK held for the entire test body.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+        }
+
         let mut cfg = AgentConfig::ctrl_default();
         let res = resolve_ctrl_turn_credentials(&mut cfg, &SessionOverrides::default());
         assert!(
             res.is_err(),
             "no credentials must be an error, not a default"
         );
+
+        // SAFETY: HOME_LOCK still held.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
     }
 
     /// A session `/model` override (when plumbed) must replace the agent model

--- a/crates/trusty-agents/src/llm/adapter/tests.rs
+++ b/crates/trusty-agents/src/llm/adapter/tests.rs
@@ -521,6 +521,8 @@ fn openrouter_endpoint_resolves_key_from_store_when_env_absent() {
     let _home_guard = crate::test_env::HOME_LOCK
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
+    crate::test_env::force_env_local_loaded();
 
     let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
     let prev_home = std::env::var_os("HOME");
@@ -571,6 +573,8 @@ fn openrouter_endpoint_env_beats_store() {
     let _home_guard = crate::test_env::HOME_LOCK
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
+    crate::test_env::force_env_local_loaded();
 
     let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
     let prev_home = std::env::var_os("HOME");
@@ -620,6 +624,8 @@ fn anthropic_direct_endpoint_resolves_key_from_store_when_env_absent() {
     let _home_guard = crate::test_env::HOME_LOCK
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
+    crate::test_env::force_env_local_loaded();
 
     let prev_anthropic = std::env::var_os("ANTHROPIC_API_KEY");
     let prev_home = std::env::var_os("HOME");
@@ -671,6 +677,8 @@ fn anthropic_direct_endpoint_env_beats_store() {
     let _home_guard = crate::test_env::HOME_LOCK
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
+    crate::test_env::force_env_local_loaded();
 
     let prev_anthropic = std::env::var_os("ANTHROPIC_API_KEY");
     let prev_home = std::env::var_os("HOME");

--- a/crates/trusty-agents/src/llm/credentials.rs
+++ b/crates/trusty-agents/src/llm/credentials.rs
@@ -205,18 +205,26 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
-    /// Helper: clear all three env vars before exercising precedence rules.
-    /// SAFETY: env-mutation tests below are guarded by `#[serial]` AND
-    /// `crate::test_env::ENV_LOCK` to prevent CI data races (#274). The
-    /// `#[serial]` attribute serializes against any other `#[serial]` test in
-    /// the binary; ENV_LOCK additionally serializes against the rest of the
-    /// crate's env-touching tests that don't use serial_test.
+    /// Helper: clear every registry-provider + ctrl/PM credential env var
+    /// before exercising precedence rules. SAFETY: env-mutation tests below
+    /// are guarded by `#[serial]` AND `crate::test_env::ENV_LOCK` to prevent
+    /// CI data races (#274). The `#[serial]` attribute serializes against any
+    /// other `#[serial]` test in the binary; ENV_LOCK additionally serializes
+    /// against the rest of the crate's env-touching tests that don't use
+    /// serial_test.
+    ///
+    /// #3464: forces the process-global `.env.local` `OnceLock` loader to
+    /// have already fired (via `force_env_local_loaded`) BEFORE clearing —
+    /// otherwise, on a machine/CI runner with a real `.env.local` (this
+    /// repo's own worktree layout resolves that search up to the shared main
+    /// checkout root), whichever test's `resolve_key` call happens to be the
+    /// very first in the process can have it fire mid-test, silently
+    /// re-populating a var this function just removed. Also clears every
+    /// registry provider's env var (not just the three `pick_credentials`
+    /// names), since `other_configured_providers()` checks all of them.
     fn clear_all() {
-        unsafe {
-            std::env::remove_var("OPENROUTER_API_KEY");
-            std::env::remove_var("ANTHROPIC_API_KEY");
-            std::env::remove_var("CLAUDE_CODE_OAUTH_TOKEN");
-        }
+        crate::test_env::force_env_local_loaded();
+        crate::test_env::clear_all_credential_env_vars();
     }
 
     /// Why: since #3248, `pick_credentials()` also consults the shared secure

--- a/crates/trusty-agents/src/llm/helpers/tests.rs
+++ b/crates/trusty-agents/src/llm/helpers/tests.rs
@@ -264,6 +264,10 @@ fn create_client_resolves_key_from_store_when_env_absent() {
     let _home_guard = crate::test_env::HOME_LOCK
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    // #3464: force the `.env.local` `OnceLock` loader to have already fired
+    // BEFORE capturing/removing vars below — see
+    // `crate::test_env::force_env_local_loaded`'s docs.
+    crate::test_env::force_env_local_loaded();
 
     let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
     let prev_anthropic = std::env::var_os("ANTHROPIC_API_KEY");
@@ -329,6 +333,8 @@ fn create_client_env_beats_store() {
     let _home_guard = crate::test_env::HOME_LOCK
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    // #3464: see `force_env_local_loaded`'s docs.
+    crate::test_env::force_env_local_loaded();
 
     let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
     let prev_anthropic = std::env::var_os("ANTHROPIC_API_KEY");
@@ -394,6 +400,8 @@ fn create_client_missing_everywhere_errors_clearly() {
     let _home_guard = crate::test_env::HOME_LOCK
         .lock()
         .unwrap_or_else(|e| e.into_inner());
+    // #3464: see `force_env_local_loaded`'s docs.
+    crate::test_env::force_env_local_loaded();
 
     let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
     let prev_anthropic = std::env::var_os("ANTHROPIC_API_KEY");

--- a/crates/trusty-agents/src/llm/http.rs
+++ b/crates/trusty-agents/src/llm/http.rs
@@ -444,6 +444,8 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn send_raw_completion_resolves_key_from_store_when_env_absent() {
+        // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
+        crate::test_env::force_env_local_loaded();
         let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
         let prev_home = std::env::var_os("HOME");
         // SAFETY: `#[serial]` (unnamed group) serializes against every other
@@ -509,6 +511,8 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn send_raw_completion_missing_everywhere_errors_with_provider_name() {
+        // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
+        crate::test_env::force_env_local_loaded();
         let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
         let prev_home = std::env::var_os("HOME");
         // SAFETY: `#[serial]` (unnamed group) provides exclusion.
@@ -585,6 +589,8 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn send_raw_completion_empty_endpoint_credential_falls_back_to_store() {
+        // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
+        crate::test_env::force_env_local_loaded();
         let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
         let prev_home = std::env::var_os("HOME");
         // SAFETY: `#[serial]` (unnamed group) provides exclusion.

--- a/crates/trusty-agents/src/runtime/cli_def.rs
+++ b/crates/trusty-agents/src/runtime/cli_def.rs
@@ -499,7 +499,12 @@ mod tests {
         /// the whole test body — mirrors
         /// `llm::credentials::tests::clear_all` in the sibling module that
         /// tests the same underlying `resolve_key` calls.
+        ///
+        /// #3464: forces the process-global `.env.local` `OnceLock` loader
+        /// to have already fired before removing anything — see
+        /// `crate::test_env::force_env_local_loaded`'s docs.
         fn clear_all() {
+            crate::test_env::force_env_local_loaded();
             unsafe {
                 std::env::remove_var("OPENROUTER_API_KEY");
                 std::env::remove_var("ANTHROPIC_API_KEY");

--- a/crates/trusty-agents/src/test_env.rs
+++ b/crates/trusty-agents/src/test_env.rs
@@ -44,6 +44,78 @@ pub static HOME_LOCK: Mutex<()> = Mutex::new(());
 /// concurrent credential-routing tests would race.
 pub static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+/// Force `trusty_common::inference::credentials::load_env_local_once` to
+/// have already run in this process, before any test-local `remove_var`.
+///
+/// Why (#3464): that loader is a process-global `OnceLock` — it fires at
+/// most once per test binary, on whichever call (from ANY test, in ANY
+/// module) happens to be first, and folds `.env.local` content into the
+/// process environment (searched upward from cwd — which, for this repo's
+/// own linked-worktree layout, resolves all the way up to the shared main
+/// checkout root — AND from `$HOME`). A credential test that clears a few
+/// env vars and then calls production code that transitively calls
+/// `resolve_key` implicitly assumes that call is a no-op; if it is instead
+/// the FIRST call in the whole process, the loader can silently re-populate
+/// a var the test just removed, in the middle of the very function under
+/// test, purely because a `.env.local` happens to exist on that machine (a
+/// real, gitignored dev file — confirmed live as the cause of #3464's
+/// `other_configured_providers_empty_when_nothing_else_configured` flake).
+/// Calling this FIRST, before any `remove_var`, guarantees the one-time load
+/// has already happened (whether it was this call or an earlier test's), so
+/// every subsequent `remove_var` in the same locked critical section is the
+/// last word — no future call in this process can ever repopulate it.
+/// What: thin wrapper over `load_env_local_once()` (itself idempotent).
+/// Callers should hold `ENV_LOCK` (and `HOME_LOCK` if they also sandbox
+/// `$HOME`) for their entire body, same convention as every other
+/// env-mutating test; async tests that cannot hold a `std::sync::Mutex`
+/// guard across `.await` may call this un-guarded and rely on `#[serial]`
+/// instead, matching the existing convention for those tests.
+/// Test: exercised indirectly via every test that now calls this before
+/// clearing credential env vars (`llm::credentials::tests::clear_all`,
+/// `llm::helpers::tests::create_client_*`, `llm::adapter::tests::*_when_env_absent`,
+/// `llm::http::tests::send_raw_completion_*`, `ctrl::ctrl_turn::dispatch::tests::clear_creds_env`,
+/// `runtime::cli_def::tests::credential_banner::clear_all`) — not
+/// independently unit tested since it depends on real process/filesystem
+/// state, exactly like `load_env_local_once` itself.
+pub fn force_env_local_loaded() {
+    trusty_common::inference::credentials::load_env_local_once();
+}
+
+/// Clear the process env var for every provider the shared inference
+/// registry maps to a credential env var, plus `CLAUDE_CODE_OAUTH_TOKEN`
+/// (ctrl/PM-only, not in the registry).
+///
+/// Why (#3464): `llm::credentials::other_configured_providers()` checks
+/// EVERY registry provider (`fireworks`, `atlascloud`, `openai`, `together`,
+/// ...), not just the three `openrouter`/`anthropic`/`claude-code` names
+/// `pick_credentials` cares about. A test asserting "nothing else is
+/// configured" must clear all of them, not a hand-picked subset — otherwise
+/// it silently depends on the local machine (or CI runner) never having any
+/// of those provider credentials configured anywhere resolvable (env,
+/// `.env.local`, or the secure store). Must be called AFTER
+/// [`force_env_local_loaded`], never before — see that function's docs.
+/// What: iterates `trusty_common::inference::registry::all()`, removing
+/// each provider's `env_var_for` mapping when one exists, then removes
+/// `CLAUDE_CODE_OAUTH_TOKEN` explicitly (it has no registry entry — it's
+/// ctrl/PM's own OAuth routing credential, not an inference provider).
+/// Test: `llm::credentials::tests::other_configured_providers_empty_when_nothing_else_configured`.
+pub fn clear_all_credential_env_vars() {
+    for caps in trusty_common::inference::registry::all() {
+        if let Some(var) = trusty_common::inference::credentials::env_var_for(caps.id.as_str()) {
+            // SAFETY: caller holds `ENV_LOCK` for the whole body (documented
+            // requirement, same convention as every other env mutation in
+            // this module).
+            unsafe {
+                std::env::remove_var(var);
+            }
+        }
+    }
+    // SAFETY: see above.
+    unsafe {
+        std::env::remove_var("CLAUDE_CODE_OAUTH_TOKEN");
+    }
+}
+
 /// Write a shell script to `dir/name`, flush and close the file handle, THEN
 /// set the execute bit — eliminating the ETXTBSY race (#1528).
 ///


### PR DESCRIPTION
## Summary

- Confirms and fixes issue #3464 — a test-isolation defect in trusty-agents that intermittently reddens the workspace `Test` CI job.
- **Root cause (confirmed):** `trusty_common::inference::credentials::dotenv::load_env_local_once` is a process-global `OnceLock` — it fires at most once per test binary, on whichever call happens to be first, and folds `.env.local` content (searched upward from cwd — including through this repo's own linked-worktree layout, up to the shared main checkout root — and from `$HOME`) into the process environment. Several credential-resolution tests assumed clearing a handful of env vars was enough to reach "nothing configured" / "store is authoritative", but if their own call was the first to trigger the loader, it could silently re-populate a var they had just cleared, mid-call, whenever a real `.env.local` exists on that machine/CI runner.
- **Reproduced deterministically** using this repo's own worktree-root `.env.local` (a real, gitignored dev file with `FIREWORKS_API_KEY`/`ATLASCLOUD_API_KEY`), which made `llm::credentials::tests::other_configured_providers_empty_when_nothing_else_configured` fail 100% of runs (both in the full suite and in isolation) with `left: ["fireworks", "atlascloud"], right: []`.
- **Fix:** added two helpers to `test_env.rs`:
  - `force_env_local_loaded()` — forces the loader to have already run *before* a test clears any credential env var, so the clear is always the last word (idempotent, safe to call from any test).
  - `clear_all_credential_env_vars()` — clears every registry-mapped provider's env var (not just the three `openrouter`/`anthropic`/`claude-code` names `pick_credentials` checks), since `other_configured_providers()` iterates the whole provider registry.
  - Applied consistently everywhere the same "nothing resolves" / "store wins when env absent" pattern appears: `llm::credentials`, `llm::helpers::tests` (the two tests named in #3464), `llm::adapter::tests`, `llm::http::tests`, `ctrl::ctrl_turn::dispatch::tests`, `runtime::cli_def::tests::credential_banner`.
- Also fixed `ctrl_creds_errors_when_nothing_configured`, a **pre-existing**, separate gap discovered while verifying this fix: it never sandboxed `$HOME`, so it failed deterministically on any machine with a real secure-store credential (unrelated to the `OnceLock`, but same theme — verified it already failed on unmodified `origin/main`).
- Noted but explicitly **out of scope**: `workflow::engine::executor::tests::checkpoint_resume::*` showed a rare, unrelated flake under heavy parallel load (`--test-threads=16`+ full-suite runs only, never in isolation) — a different subsystem (workflow checkpoint/resume), not touched by this change, confirmed to pre-exist on unmodified `origin/main` too. Worth its own ticket.

## Verification

`cargo test -p trusty-agents --lib`, run 6× after the fix: all green, `2015 passed; 0 failed; 8 ignored`.

The two tests named in #3464, run together 10× via libtest substring filters (order alternates each run — libtest randomizes):
```
test llm::helpers::tests::create_client_resolves_key_from_store_when_env_absent ... ok
test llm::credentials::tests::other_configured_providers_empty_when_nothing_else_configured ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2021 filtered out
```
(repeated identically across all 10 runs)

Full test surface (`cargo test -p trusty-agents`, unit + all integration test binaries): all green.

`cargo fmt -p trusty-agents -- --check`: clean.
`cargo clippy -p trusty-agents --all-targets -- -D warnings`: clean.
`cargo test -p trusty-common --features credentials -- inference::credentials::`: 46 passed, 0 failed (untouched, confirms no regression to the shared resolver).

## Test plan

- [x] Reproduced the flake deterministically (100% failure) before the fix
- [x] `cargo test -p trusty-agents --lib` green across 6+ repeated runs after the fix
- [x] The two originally-named tests green across 10 repeated runs, order randomized
- [x] Full `cargo test -p trusty-agents` (unit + integration) green
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test -p trusty-common --features credentials` unaffected (46/46 green)

Closes #3464

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools