### PR TITLE
chore(release): embedder perf fixes — common 0.23.6, embedderd 0.3.9, search 0.36.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,7 +6549,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11402,7 +11402,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11519,7 +11519,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-embedderd"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "axum",
@@ -11747,7 +11747,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,9 +7,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.23.6] — 2026-07-20
+
+Release cut of the two embedding-performance fixes below
+([#3500](https://github.com/bobmatnyc/trusty-tools/pull/3500),
+[#3511](https://github.com/bobmatnyc/trusty-tools/pull/3511); refs #3486 / #3493)
+so the shared embedder-inference path (`trusty-embedderd`, `trusty-search`)
+picks them up on rebuild.
+
 ### Fixed
 
-- **Performance:** `FastEmbedder`'s ORT intra-op thread default is now
+- **Performance (PR [#3500](https://github.com/bobmatnyc/trusty-tools/pull/3500)):** `FastEmbedder`'s ORT intra-op thread default is now
   platform/execution-provider-conditional instead of an unconditional `1`.
   The `1` pin was introduced by PR #1668 to fix a real CUDA deferred-embed
   deadlock (AL2023 Linux + CUDA EP + dynamically-loaded ORT,
@@ -25,7 +33,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   replaced by the `default_ort_intra_threads()` function — the only
   consumer was this crate's own resolver, so no downstream crate references
   it.
-- **Performance / accuracy:** `FastEmbedder`'s default embedding model is now
+- **Performance / accuracy (PR [#3511](https://github.com/bobmatnyc/trusty-tools/pull/3511)):** `FastEmbedder`'s default embedding model is now
   `EmbeddingModel::AllMiniLML6V2` (fp32, fastembed's own natively-shipped
   non-quantized variant), replacing the previous default,
   `AllMiniLML6V2Q` (INT8, dynamically quantised). INT8 was measured to be

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.23.5"
+version = "0.23.6"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-embedderd/CHANGELOG.md
+++ b/crates/trusty-embedderd/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [0.3.9] — 2026-07-20
+
+### Changed
+
+- Rebuild against `trusty-common` 0.23.6 to pick up the two embedding-performance
+  fixes ([#3500](https://github.com/bobmatnyc/trusty-tools/pull/3500),
+  [#3511](https://github.com/bobmatnyc/trusty-tools/pull/3511); refs #3486 / #3493):
+  platform-conditional ORT intra-op thread default (no longer pinned to `1` off
+  the CUDA path) and a non-quantized (fp32) default embedding model. This crate
+  is the sidecar that actually runs inference, so the fixes are inert until the
+  installed `trusty-embedderd` binary is rebuilt — no source change here beyond
+  the dependency bump. `TRUSTY_ORT_INTRA_THREADS` and `TRUSTY_EMBEDDER_MODEL=int8`
+  remain available to restore prior behaviour.
+
 ## [0.3.8] — 2026-07-13
 
 ### Fixed

--- a/crates/trusty-embedderd/Cargo.toml
+++ b/crates/trusty-embedderd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-embedderd"
-version = "0.3.8"
+version = "0.3.9"
 publish = true
 edition = "2021"
 license.workspace = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.36.1] — 2026-07-20
+
+### Changed
+
+- Rebuild against `trusty-common` 0.23.6 / `trusty-embedderd` 0.3.9 to pick up the
+  two embedding-performance fixes ([#3500](https://github.com/bobmatnyc/trusty-tools/pull/3500),
+  [#3511](https://github.com/bobmatnyc/trusty-tools/pull/3511); refs #3486 / #3493):
+  platform-conditional ORT intra-op thread default and a non-quantized (fp32)
+  default embedding model. `trusty-search` bundles the `trusty-embedderd` binary,
+  so this republish is what carries the faster/more-accurate embedder into the
+  single-install `cargo install trusty-search`. `TRUSTY_ORT_INTRA_THREADS` and
+  `TRUSTY_EMBEDDER_MODEL=int8` remain available to restore prior behaviour.
+
 ### Changed
 
 - **Migrated the admin UI to Foundry v2 design tokens** ([#3487](https://github.com/bobmatnyc/trusty-tools/issues/3487)):

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Release cut: embedding-performance fixes → crates.io + signed local install

Ships the two embedding-performance fixes now on `main` out through the crate release chain so the live embedder-inference path picks them up:

- **PR #3500** (`24f3f64a`) — platform-conditional ORT intra-op thread default (no longer pinned to `1` off the CUDA path; ~3.5× macOS embedding throughput). refs #3493
- **PR #3511** (`355e1a4d`) — non-quantized fp32 default embedding model (`AllMiniLML6V2`), ~2.1× faster + more accurate than the prior INT8 default. refs #3486 / #3493

Both fixes live in `crates/trusty-common/src/embedder/`. The inference sidecar (`trusty-embedderd`) and `trusty-search` (which bundles the `trusty-embedderd` binary) must republish + reinstall for the running daemon to actually benefit — hence all three bump.

### Version bumps (patch — additive, env-overridable)
| Crate | From | To |
|---|---|---|
| `trusty-common` | 0.23.5 | **0.23.6** |
| `trusty-embedderd` | 0.3.8 | **0.3.9** |
| `trusty-search` | 0.36.0 | **0.36.1** |

Bumps are **patch**: threading default is platform-conditional with `TRUSTY_ORT_INTRA_THREADS` override; model default change is reversible via `TRUSTY_EMBEDDER_MODEL=int8`. No public-API break.

### Notes
- No source change beyond `version` / `CHANGELOG.md` / `Cargo.lock`.
- Dep pins are `^` floors that 0.23.6 satisfies — no pin bump needed.
- Line-cap gate green (`scripts/check_line_cap.sh`: 8 allowlisted, 0 violations).
- CHANGELOG entry added per crate, citing #3500 / #3511 and referencing #3486 / #3493.

Publish order after merge: `trusty-common` → wait live → `trusty-embedderd` → `trusty-search`, then signed local install of the sidecar binaries.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools