### PR TITLE
ci(design): enforce all 7 UIs against canonical Foundry tokens (refs #3486)

### DIFF
--- a/.github/workflows/token-drift.yml
+++ b/.github/workflows/token-drift.yml
@@ -1,16 +1,17 @@
 # Design-token drift gate for the trusty-tools workspace (epic #3486).
 #
 # Foundry v2 design tokens (docs/design/UI/design-system/tokens.css) are the
-# canonical hex source. Adopted UIs hand-transcribe that hex into Tailwind's
-# `--color-*: R G B` RGB-triple convention in their own `src/app.css`, so
-# nothing previously stopped the two from silently drifting apart. This job
-# re-derives each enforced crate's expected values from the canonical source
-# and fails with a per-token diff on any mismatch.
+# canonical hex source. Adopted UIs consume it two ways: Tailwind crates
+# (trusty-agents, trusty-code-gui, trusty-mpm-gui) hand-transcribe the hex
+# into Tailwind's `--color-*: R G B` RGB-triple convention; plain-CSS crates
+# (trusty-console, trusty-analyze, trusty-search, trusty-memory) keep the
+# canonical `--trusty-*` names with `#hex` values verbatim. Nothing previously
+# stopped either from silently drifting apart. This job re-derives each
+# enforced crate's expected values from the canonical source and fails with a
+# per-token diff on any mismatch.
 #
-# Only trusty-agents and trusty-code-gui are enforced right now; the 5
-# pre-Foundry crates (trusty-search, trusty-memory, trusty-mpm-gui,
-# trusty-console, trusty-analyze) are allowlisted pending their own migration
-# issues (#3487/#3488/#3489/#3490) — see scripts/check_token_drift.mjs.
+# All 7 UI crates are enforced (epic #3486); the allowlist is empty. Both
+# comparison modes ("rgb-triple" and "hex") live in scripts/check_token_drift.mjs.
 #
 # Pure Node script, zero dependencies — no pnpm install / lockfile needed, so
 # this runs as its own lightweight job (matches line-cap.yml / test-pointers.yml's
@@ -37,7 +38,7 @@ concurrency:
 
 jobs:
   token-drift:
-    name: Foundry token drift check (trusty-agents, trusty-code-gui)
+    name: Foundry token drift check (all 7 UI crates)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ### Changed
 
+- **UI tokens now CI-enforced against the canonical Foundry source** (refs [#3486](https://github.com/bobmatnyc/trusty-tools/issues/3486)): flipped from the `scripts/check_token_drift.mjs` allowlist to ENFORCED. The `token-drift` CI job now compares `ui/src/lib/styles/tokens.css`'s plain-CSS `--trusty-*: #hex` values directly to `docs/design/UI/design-system/tokens.css` on every push/PR (light `[data-theme="light"]`, dark `:root, [data-theme="dark"]`; the crate-local alias layer is ignored), so a hand-edit that drifts this crate's palette from canonical fails the build.
 - **UI design tokens migrated to Foundry v2** ([#3490](https://github.com/bobmatnyc/trusty-tools/issues/3490),
   epic [#3486](https://github.com/bobmatnyc/trusty-tools/issues/3486)): the dashboard's
   `tokens.css` now sources its light/dark palette from the canonical Foundry

--- a/crates/trusty-console/CHANGELOG.md
+++ b/crates/trusty-console/CHANGELOG.md
@@ -8,6 +8,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **UI tokens now CI-enforced against the canonical Foundry source** (refs [#3486](https://github.com/bobmatnyc/trusty-tools/issues/3486)): flipped from the `scripts/check_token_drift.mjs` allowlist to ENFORCED. The `token-drift` CI job now compares `ui/src/theme.css`'s plain-CSS `--trusty-*: #hex` values directly (case-insensitively) to `docs/design/UI/design-system/tokens.css` on every push/PR. Enforcement is over the intersection of tokens both files define, so this crate's console-only extension tokens (`--trusty-status-degraded`, `--trusty-status-absent`) are ignored; a hand-edit that drifts a shared token from canonical fails the build.
+
 ### Added
 
 - **Known-sibling port guard extended to `trusty-mpm`'s supervisor metrics

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -16,6 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **UI tokens now CI-enforced against the canonical Foundry source** (refs [#3486](https://github.com/bobmatnyc/trusty-tools/issues/3486)): flipped from the `scripts/check_token_drift.mjs` allowlist to ENFORCED. The `token-drift` CI job now compares `ui/src/lib/styles/tokens.css`'s plain-CSS `--trusty-*: #hex` values directly to `docs/design/UI/design-system/tokens.css` on every push/PR (light `:root`, dark `[data-theme='dark']`), so a hand-edit that drifts this crate's palette from canonical fails the build.
 - **Migrated the admin UI to Foundry v2 design tokens** ([#3487](https://github.com/bobmatnyc/trusty-tools/issues/3487)):
   `ui/src/lib/styles/tokens.css` now sources its palette, fonts, radii, and
   shadows from the canonical `docs/design/UI/design-system/tokens.css`

--- a/crates/trusty-mpm-gui/CHANGELOG.md
+++ b/crates/trusty-mpm-gui/CHANGELOG.md
@@ -10,6 +10,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **UI tokens now CI-enforced against the canonical Foundry source** (refs [#3486](https://github.com/bobmatnyc/trusty-tools/issues/3486)): flipped from the `scripts/check_token_drift.mjs` allowlist to ENFORCED. The `token-drift` CI job now re-derives `ui/src/app.css`'s Tailwind `--color-*: R G B` triples from `docs/design/UI/design-system/tokens.css` on every push/PR, so a hand-edit that drifts this crate's palette from canonical fails the build.
 - Migrated the Svelte UI from its placeholder indigo/slate palette to Foundry v2 design tokens (closes #3488, part of epic #3486): `ui/src/app.css` now defines `--color-*` RGB-triple custom properties (light `:root` + `[data-theme='dark']`) sourced 1:1 from `docs/design/UI/design-system/tokens.css`, and `ui/tailwind.config.js` resolves every `trusty-*`/`status-*` color through `rgb(var(--color-*) / <alpha-value>)` instead of hardcoded hex literals — the same CSS-var bridge `crates/trusty-code-gui/ui` uses, keeping the crates in lockstep for a future `scripts/check_token_drift.mjs` enforcement flip. Dark-mode activation switched from a bare `<html class="dark">` to the `[data-theme='dark']` attribute (`ui/src/stores/theme.ts`); the existing manual `ThemeToggle` + `localStorage`-persisted preference is unchanged, only the DOM attribute it drives. All components dropped their `-light` token suffix + `dark:` variant pairs in favor of the single self-theming token each now resolves through.
 
 ### Security

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **UI tokens now CI-enforced against the canonical Foundry source** (refs [#3486](https://github.com/bobmatnyc/trusty-tools/issues/3486)): flipped from the `scripts/check_token_drift.mjs` allowlist to ENFORCED. The `token-drift` CI job now compares `ui/src/lib/styles/tokens.css`'s plain-CSS `--trusty-*: #hex` values directly to `docs/design/UI/design-system/tokens.css` on every push/PR (light `:root`, dark `[data-theme='dark']`), so a hand-edit that drifts this crate's palette from canonical fails the build.
 - **Migrated the admin UI to Foundry v2 design tokens** ([#3487](https://github.com/bobmatnyc/trusty-tools/issues/3487)):
   `ui/src/lib/styles/tokens.css` now sources its palette, fonts, radii, and
   shadows from the canonical `docs/design/UI/design-system/tokens.css`

--- a/scripts/check_token_drift.mjs
+++ b/scripts/check_token_drift.mjs
@@ -15,21 +15,38 @@
  *
  * What: parses `:root { ... }` (light) and the dark-theme block (each
  * crate's own dark-activation selector) out of both the canonical file and
- * each enforced crate's app.css via block-scoped regex — not a full CSS
+ * each enforced crate's token file via block-scoped regex — not a full CSS
  * parser, but sufficient for these small, flat, hand-maintained files (no
- * nested `{}` inside a declaration block). An explicit MAPPING per crate
- * pins which crate custom property corresponds to which canonical
- * `--trusty-*` token (derived from that crate's own app.css comments, which
- * already document the 1:1 correspondence — see #3387/#3153/#3380). Canonical
- * hex is converted to the same `"R G B"` triple format the crates use and
- * diffed per theme. A small number of tokens are carried over verbatim as
- * `rgba(...)` passthroughs rather than converted (e.g. `--trusty-surface-hover`
- * in trusty-agents) — those are diffed as normalized raw strings instead.
+ * nested `{}` inside a declaration block). Two comparison MODES exist:
  *
- * The 5 pre-Foundry crates (trusty-search, trusty-memory, trusty-mpm-gui,
- * trusty-console, trusty-analyze) are NOT enforced yet — each is tracked in
- * ALLOWLIST below against the issue that migrates it and removes its
- * exemption (#3487/#3488/#3489/#3490).
+ *   - `rgb-triple` (Tailwind crates: trusty-agents, trusty-code-gui,
+ *     trusty-mpm-gui): the crate hand-transcribes canonical hex into
+ *     Tailwind's `--color-*: R G B` space-separated triple convention. An
+ *     explicit MAPPING per crate pins which `--color-*` var corresponds to
+ *     which canonical `--trusty-*` token (derived from that crate's own
+ *     app.css comments — see #3387/#3153/#3380). Canonical hex is converted
+ *     to the same `"R G B"` triple and diffed per theme. A few tokens are
+ *     carried over verbatim as `rgba(...)` passthroughs (e.g.
+ *     `--trusty-surface-hover` in trusty-agents) and diffed as normalized
+ *     raw strings instead.
+ *
+ *   - `hex` (plain-CSS crates: trusty-console, trusty-analyze,
+ *     trusty-search, trusty-memory): the crate keeps the canonical
+ *     `--trusty-*` names verbatim with `#rrggbb` hex values, so no mapping
+ *     table or RGB-triple conversion is needed — the crate hex is compared
+ *     DIRECTLY (case-insensitively) to the canonical hex of the same token
+ *     name. Enforcement is over the INTERSECTION: every canonical *hex*
+ *     token the crate also defines must match; crate-only extension tokens
+ *     (e.g. trusty-console's `--trusty-status-degraded`) are ignored, and a
+ *     crate is never required to define a canonical token it doesn't use.
+ *     Non-hex canonical values (rgba/font/spacing) are not diffed in this
+ *     mode. Each crate's differing dark/light selectors are configured
+ *     per-entry (`:root[data-theme=...]`, `[data-theme=...]`, and
+ *     `:root`+`[data-theme='dark']`).
+ *
+ * All 7 UI crates are now ENFORCED (epic #3486); the ALLOWLIST is empty. A
+ * runtime guard throws if any enforced crate performs zero comparisons, so a
+ * mis-configured file path or selector can't silently pass.
  *
  * Test: run directly — `node scripts/check_token_drift.mjs` — or via
  * `pnpm run check:tokens` from either enforced crate's `ui/` directory.
@@ -52,30 +69,43 @@ const TOKENS_CSS_PATH = path.join(
 
 // ---------------------------------------------------------------------------
 // Pending-migration crates — NOT enforced yet. Each entry is removed by the
-// PR that migrates that crate onto the canonical `--color-*` RGB-triple
-// convention. Do not add an entry here without a tracking issue.
+// PR that migrates that crate onto canonical Foundry tokens. Do not add an
+// entry here without a tracking issue.
+//
+// EMPTY as of epic #3486: all 7 UI crates are now ENFORCED below (the last 5
+// — trusty-search/-memory/-mpm-gui/-console/-analyze, #3487-#3490 — landed
+// and were flipped in refs #3486). New pre-Foundry crates would be tracked
+// here against a migration issue until they adopt the canonical tokens.
 // ---------------------------------------------------------------------------
-const ALLOWLIST = [
-  { crate: "trusty-search", issue: "#3487" },
-  { crate: "trusty-memory", issue: "#3487" },
-  { crate: "trusty-mpm-gui", issue: "#3488" },
-  { crate: "trusty-console", issue: "#3489" },
-  { crate: "trusty-analyze", issue: "#3490" },
-];
+const ALLOWLIST = [];
 
 // ---------------------------------------------------------------------------
-// Enforced crates + their canonical-token mapping.
-// `mappings`: [crateVarSuffix, canonicalTokenName] — crateVarSuffix is the
-//   part after `--color-`; canonicalTokenName is the part after `--`.
-//   Compared as an RGB triple (canonical hex -> "R G B") per theme.
-// `passthrough`: [crateVarName, canonicalTokenName] — full var names,
-//   compared as normalized raw rgba(...)/hex strings (no RGB-triple
-//   conversion; the crate carries the canonical value over verbatim).
+// Enforced crates + their canonical-token comparison config.
+//
+// `mode`: "rgb-triple" (default) | "hex".
+//
+// mode "rgb-triple" (Tailwind `--color-*: R G B` crates):
+//   `mappings`: [crateVarSuffix, canonicalTokenName] — crateVarSuffix is the
+//     part after `--color-`; canonicalTokenName is the part after `--`.
+//     Compared as an RGB triple (canonical hex -> "R G B") per theme.
+//   `passthrough`: [crateVarName, canonicalTokenName] — full var names,
+//     compared as normalized raw rgba(...)/hex strings (no RGB-triple
+//     conversion; the crate carries the canonical value over verbatim).
+//
+// mode "hex" (plain-CSS `--trusty-*: #hex` crates):
+//   no mapping table — the crate reuses canonical `--trusty-*` names, so the
+//   crate's hex is compared DIRECTLY to canonical hex for every canonical
+//   *hex* token the crate also defines (the intersection). Crate-only
+//   extension tokens are ignored; non-hex canonical tokens are skipped.
+//
+// `lightSelector`/`darkSelector`: block-scoped regex for each theme block
+//   (the last capture group is the block body).
 // ---------------------------------------------------------------------------
 const ENFORCED = [
   {
     name: "trusty-agents",
     file: "crates/trusty-agents/ui/src/app.css",
+    mode: "rgb-triple",
     lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
     darkSelector: /\.dark\s*\{([\s\S]*?)\n\}/,
     mappings: [
@@ -94,6 +124,7 @@ const ENFORCED = [
   {
     name: "trusty-code-gui",
     file: "crates/trusty-code-gui/ui/src/app.css",
+    mode: "rgb-triple",
     lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
     darkSelector: /\[data-theme=(['"])dark\1\]\s*\{([\s\S]*?)\n\}/,
     mappings: [
@@ -119,6 +150,71 @@ const ENFORCED = [
       ["sidebar-active", "trusty-sidebar-active"],
     ],
     passthrough: [],
+  },
+  {
+    // Same Tailwind `--color-*: R G B` convention as trusty-code-gui (#3488).
+    name: "trusty-mpm-gui",
+    file: "crates/trusty-mpm-gui/ui/src/app.css",
+    mode: "rgb-triple",
+    lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
+    darkSelector: /\[data-theme=(['"])dark\1\]\s*\{([\s\S]*?)\n\}/,
+    mappings: [
+      ["primary", "trusty-accent"],
+      ["primary-hover", "trusty-accent-hover"],
+      ["surface", "trusty-content-bg"],
+      ["card", "trusty-card-bg"],
+      ["raised", "trusty-surface-raised"],
+      ["border", "trusty-border"],
+      ["border-strong", "trusty-border-strong"],
+      ["text", "trusty-text-primary"],
+      ["text-secondary", "trusty-text-secondary"],
+      ["text-muted", "trusty-text-muted"],
+      ["text-inverse", "trusty-text-inverse"],
+      ["status-ok", "trusty-success"],
+      ["status-error", "trusty-danger"],
+      ["status-warn", "trusty-warning"],
+      ["status-neutral", "trusty-text-muted"],
+    ],
+    passthrough: [],
+  },
+  {
+    // Plain CSS `--trusty-*: #hex`, light/dark under
+    // `:root[data-theme="light"]` / `:root[data-theme="dark"]` (#3489).
+    // Crate-only extensions (`--trusty-status-degraded`, `--trusty-status-absent`)
+    // are ignored by the intersection rule.
+    name: "trusty-console",
+    file: "crates/trusty-console/ui/src/theme.css",
+    mode: "hex",
+    lightSelector: /:root\[data-theme="light"\]\s*\{([\s\S]*?)\n\}/,
+    darkSelector: /:root\[data-theme="dark"\]\s*\{([\s\S]*?)\n\}/,
+  },
+  {
+    // Plain CSS `--trusty-*: #hex`. Light under `[data-theme="light"]`; dark
+    // (the default) under the combined `:root, [data-theme="dark"]` selector.
+    // A trailing `:root { ... }` alias layer repoints crate-local names to
+    // `--trusty-*` — not matched by either theme selector (#3490).
+    name: "trusty-analyze",
+    file: "crates/trusty-analyze/ui/src/lib/styles/tokens.css",
+    mode: "hex",
+    lightSelector: /\[data-theme="light"\]\s*\{([\s\S]*?)\n\}/,
+    darkSelector: /:root\s*,\s*\[data-theme="dark"\]\s*\{([\s\S]*?)\n\}/,
+  },
+  {
+    // Plain CSS `--trusty-*: #hex`, light under `:root`, dark under
+    // `[data-theme='dark']` (#3487).
+    name: "trusty-search",
+    file: "crates/trusty-search/ui/src/lib/styles/tokens.css",
+    mode: "hex",
+    lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
+    darkSelector: /\[data-theme=(['"])dark\1\]\s*\{([\s\S]*?)\n\}/,
+  },
+  {
+    // Identical token file + selectors to trusty-search (#3487).
+    name: "trusty-memory",
+    file: "crates/trusty-memory/ui/src/lib/styles/tokens.css",
+    mode: "hex",
+    lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
+    darkSelector: /\[data-theme=(['"])dark\1\]\s*\{([\s\S]*?)\n\}/,
   },
 ];
 
@@ -176,6 +272,16 @@ function rgbTripleToHex(triple) {
     "#" +
     parts.map((n) => n.toString(16).padStart(2, "0")).join("")
   );
+}
+
+/** True iff `raw` is a 6-digit `#rrggbb` hex color (ignoring surrounding ws). */
+function isHex6(raw) {
+  return /^#[0-9a-fA-F]{6}$/.test(raw.trim());
+}
+
+/** Normalize a 6-digit hex for case-insensitive comparison. */
+function normalizeHex(raw) {
+  return raw.trim().toLowerCase();
 }
 
 function normalizeTriple(raw) {
@@ -293,29 +399,78 @@ function parseCrate(crate) {
 // against synthetic {light, dark} declaration maps without touching the
 // filesystem at all.
 function checkCrate(crate, canonical, parsedOverride) {
-  // Invariant: a crate with zero comparisons configured is not "verified
-  // clean" — it's unverified. Without this guard, an ENFORCED entry whose
-  // `mappings`/`passthrough` were accidentally (or maliciously) emptied out
-  // would silently report "OK ... matches canonical" and exit 0 regardless
-  // of what the crate's app.css actually contains — the exact false-green
-  // this whole script exists to prevent. Every other failure path here
-  // throws loudly on a structural problem; a vacuously-true pass must too.
-  const tokenCount = crate.mappings.length + crate.passthrough.length;
-  if (tokenCount === 0) {
-    throw new Error(
-      `mappings+passthrough is empty — refusing to report a pass with ` +
-        `zero comparisons`,
-    );
+  const mode = crate.mode ?? "rgb-triple";
+
+  // Config-level invariant for rgb-triple crates: a crate with zero
+  // comparisons CONFIGURED is not "verified clean" — it's unverified. Without
+  // this guard, an ENFORCED entry whose `mappings`/`passthrough` were
+  // accidentally (or maliciously) emptied out would silently report
+  // "OK ... matches canonical" and exit 0 regardless of what the crate's
+  // app.css actually contains — the exact false-green this whole script
+  // exists to prevent. (hex crates have no static mapping table; they are
+  // guarded by the runtime `comparedCount` check below instead.)
+  if (mode === "rgb-triple") {
+    const tokenCount = crate.mappings.length + crate.passthrough.length;
+    if (tokenCount === 0) {
+      throw new Error(
+        `mappings+passthrough is empty — refusing to report a pass with ` +
+          `zero comparisons`,
+      );
+    }
   }
 
   const diffs = [];
   const parsed = parsedOverride ?? parseCrate(crate);
+  // Runtime guard: however the crate is configured, if the actual comparison
+  // pass touches zero tokens (e.g. a mis-configured selector matched a block
+  // with no canonical tokens in it), that's an unverified pass, not a clean
+  // one — throw loudly like every other structural failure.
+  let comparedCount = 0;
+
+  if (mode === "hex") {
+    // Plain-CSS-hex: compare the crate's own `--trusty-*: #hex` values
+    // DIRECTLY to canonical hex, over the INTERSECTION of tokens the crate
+    // defines and canonical defines-as-hex. Crate-only extension tokens and
+    // non-hex canonical values (rgba/font/spacing) are ignored.
+    for (const theme of ["light", "dark"]) {
+      const canonicalMap = canonical[theme];
+      const crateMap = parsed[theme];
+      for (const [name, crateRaw] of crateMap) {
+        if (!canonicalMap.has(name)) continue; // crate-only extension token
+        const canonRaw = canonicalMap.get(name);
+        if (!isHex6(canonRaw)) continue; // only enforce hex-valued canonical tokens
+        comparedCount++;
+        const expected = normalizeHex(canonRaw);
+        const actual = isHex6(crateRaw) ? normalizeHex(crateRaw) : crateRaw.trim();
+        if (actual !== expected) {
+          diffs.push({
+            crate: crate.name,
+            theme,
+            var: `--${name}`,
+            canonicalToken: name,
+            expected,
+            actual,
+          });
+        }
+      }
+    }
+    diffs.comparedCount = comparedCount;
+    if (comparedCount === 0) {
+      throw new Error(
+        `${crate.name}: zero token comparisons performed (hex mode) — the ` +
+          `configured file/selectors matched no canonical hex tokens; ` +
+          `check ${crate.file} and the light/dark selectors`,
+      );
+    }
+    return diffs;
+  }
 
   for (const theme of ["light", "dark"]) {
     const canonicalMap = canonical[theme];
     const crateMap = parsed[theme];
 
     for (const [crateSuffix, canonicalToken] of crate.mappings) {
+      comparedCount++;
       const crateVar = `color-${crateSuffix}`;
       const expected = canonicalRgbTriple(canonicalMap, canonicalToken, theme);
 
@@ -346,6 +501,7 @@ function checkCrate(crate, canonical, parsedOverride) {
     }
 
     for (const [crateVarName, canonicalToken] of crate.passthrough) {
+      comparedCount++;
       if (!canonicalMap.has(canonicalToken)) {
         throw new Error(
           `canonical token "--${canonicalToken}" (${theme}) not found for ` +
@@ -381,6 +537,13 @@ function checkCrate(crate, canonical, parsedOverride) {
     }
   }
 
+  diffs.comparedCount = comparedCount;
+  if (comparedCount === 0) {
+    throw new Error(
+      `${crate.name}: zero token comparisons performed — ` +
+        `check ${crate.file} and its selectors`,
+    );
+  }
   return diffs;
 }
 
@@ -404,10 +567,16 @@ function main() {
   for (const crate of ENFORCED) {
     try {
       const diffs = checkCrate(crate, canonical);
+      const mode = crate.mode ?? "rgb-triple";
+      const n = diffs.comparedCount ?? 0;
       if (diffs.length === 0) {
-        console.log(`OK   ${crate.name} (${crate.file}) — matches canonical`);
+        console.log(
+          `OK   ${crate.name} (${crate.file}) — ${n} tokens match canonical [${mode}]`,
+        );
       } else {
-        console.log(`DRIFT ${crate.name} (${crate.file}) — ${diffs.length} mismatch(es)`);
+        console.log(
+          `DRIFT ${crate.name} (${crate.file}) — ${diffs.length} mismatch(es) of ${n} compared [${mode}]`,
+        );
       }
       allDiffs.push(...diffs);
     } catch (err) {
@@ -417,9 +586,13 @@ function main() {
   }
 
   console.log("");
-  console.log("Allowlisted (not yet enforced — pending Foundry migration):");
-  for (const entry of ALLOWLIST) {
-    console.log(`  - ${entry.crate} (${entry.issue})`);
+  if (ALLOWLIST.length > 0) {
+    console.log("Allowlisted (not yet enforced — pending Foundry migration):");
+    for (const entry of ALLOWLIST) {
+      console.log(`  - ${entry.crate} (${entry.issue})`);
+    }
+  } else {
+    console.log("Allowlist empty — all UI crates are enforced.");
   }
 
   if (allDiffs.length > 0) {
@@ -459,6 +632,8 @@ export {
   TOKENS_CSS_PATH,
   hexToRgbTriple,
   rgbTripleToHex,
+  isHex6,
+  normalizeHex,
   normalizeTriple,
   normalizeColorString,
   parseDeclarations,

--- a/scripts/check_token_drift.test.mjs
+++ b/scripts/check_token_drift.test.mjs
@@ -35,8 +35,10 @@ import path from "node:path";
 import {
   ENFORCED,
   checkCrate,
+  parseCanonical,
   parseCanonicalFromSource,
   parseCrate,
+  TOKENS_CSS_PATH,
 } from "./check_token_drift.mjs";
 
 // A minimal canonical source with one token that differs between light and
@@ -55,10 +57,38 @@ function makeFixtureCrate(overrides = {}) {
   return {
     name: "fixture-crate",
     file: "unused-when-parsedOverride-is-supplied.css",
+    mode: "rgb-triple",
     lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
     darkSelector: /\.dark\s*\{([\s\S]*?)\n\}/,
     mappings: [["foo", "trusty-foo"]],
     passthrough: [],
+    ...overrides,
+  };
+}
+
+// A canonical source for the hex-mode fixtures: two hex tokens plus one
+// non-hex (rgba) token that hex mode must SKIP, in each theme block.
+const HEX_CANONICAL_SOURCE = `
+:root {
+  --trusty-bg: #f0f0f0;
+  --trusty-text: #101010;
+  --trusty-hover: rgba(1, 2, 3, 0.5);
+}
+
+[data-theme='dark'], .dark {
+  --trusty-bg: #202020;
+  --trusty-text: #e0e0e0;
+  --trusty-hover: rgba(9, 8, 7, 0.5);
+}
+`;
+
+function makeHexFixtureCrate(overrides = {}) {
+  return {
+    name: "hex-fixture-crate",
+    file: "unused-when-parsedOverride-is-supplied.css",
+    mode: "hex",
+    lightSelector: /:root\s*\{([\s\S]*?)\n\}/,
+    darkSelector: /\[data-theme=(['"])dark\1\]\s*\{([\s\S]*?)\n\}/,
     ...overrides,
   };
 }
@@ -152,16 +182,37 @@ test("checkCrate throws when a mapped canonical token doesn't exist", () => {
 //     emptying an entry) and as a direct exercise of checkCrate's own throw.
 // ---------------------------------------------------------------------------
 
-test("every ENFORCED crate has at least one mapping or passthrough entry", () => {
-  assert.ok(ENFORCED.length > 0, "ENFORCED must not itself be empty");
+test("every ENFORCED crate compares >0 real tokens against canonical", () => {
+  // Covers all 7 UI crates (epic #3486): trusty-agents, trusty-code-gui,
+  // trusty-mpm-gui (rgb-triple) + trusty-console, trusty-analyze,
+  // trusty-search, trusty-memory (hex). Running the REAL comparison against
+  // the REAL canonical file is the strongest form of "at least one token is
+  // compared" — checkCrate throws if a crate performs zero comparisons (a
+  // mis-configured path/selector), so a bare doesNotThrow here would already
+  // catch that; we additionally assert the returned comparedCount is > 0 and
+  // that no crate has drifted, making this the CI regression for the flip.
+  assert.ok(ENFORCED.length === 7, `expected 7 enforced crates, got ${ENFORCED.length}`);
+  const canonical = parseCanonical(TOKENS_CSS_PATH);
   for (const crate of ENFORCED) {
-    const tokenCount = crate.mappings.length + crate.passthrough.length;
+    let diffs;
+    assert.doesNotThrow(() => {
+      diffs = checkCrate(crate, canonical);
+    }, `${crate.name}: checkCrate threw (mis-configured path/selector?)`);
     assert.ok(
-      tokenCount > 0,
-      `${crate.name}: mappings+passthrough is empty — an enforced crate ` +
-        `must compare at least one token`,
+      diffs.comparedCount > 0,
+      `${crate.name}: compared zero tokens — an enforced crate must compare ≥1`,
+    );
+    assert.equal(
+      diffs.length,
+      0,
+      `${crate.name}: ${diffs.length} token(s) drifted from canonical`,
     );
   }
+});
+
+test("ALLOWLIST is empty — no UI crate is exempt from enforcement", async () => {
+  const { ALLOWLIST } = await import("./check_token_drift.mjs");
+  assert.equal(ALLOWLIST.length, 0);
 });
 
 test("checkCrate refuses to report a pass with zero comparisons configured", () => {
@@ -174,4 +225,92 @@ test("checkCrate refuses to report a pass with zero comparisons configured", () 
     () => checkCrate(crate, canonical),
     /mappings\+passthrough is empty/,
   );
+});
+
+// ---------------------------------------------------------------------------
+// (e) plain-CSS-hex comparison mode (mode: "hex", used by trusty-console,
+//     trusty-analyze, trusty-search, trusty-memory).
+// ---------------------------------------------------------------------------
+
+test("hex mode: matching hex values report zero diffs (intersection + skips)", () => {
+  const canonical = parseCanonicalFromSource(HEX_CANONICAL_SOURCE, "<inline hex canonical>");
+
+  const parsedCrate = {
+    // Correct hex for the two canonical hex tokens; a crate-only extension
+    // token (--trusty-extra) that must be IGNORED; and --trusty-hover which
+    // is non-hex in canonical, so it must be SKIPPED (not compared) even
+    // though the crate defines it.
+    light: new Map([
+      ["trusty-bg", "#F0F0F0"], // case-insensitive match of #f0f0f0
+      ["trusty-text", "#101010"],
+      ["trusty-hover", "rgba(1, 2, 3, 0.5)"],
+      ["trusty-extra", "#abcdef"],
+    ]),
+    dark: new Map([
+      ["trusty-bg", "#202020"],
+      ["trusty-text", "#e0e0e0"],
+    ]),
+  };
+
+  const diffs = checkCrate(makeHexFixtureCrate(), canonical, parsedCrate);
+  assert.equal(diffs.length, 0, "expected no drift");
+  // 2 hex tokens in light + 2 in dark = 4; hover skipped, extra ignored.
+  assert.equal(diffs.comparedCount, 4);
+});
+
+test("hex mode: a mutated hex value is detected as drift", () => {
+  const canonical = parseCanonicalFromSource(HEX_CANONICAL_SOURCE, "<inline hex canonical>");
+
+  const parsedCrate = {
+    light: new Map([
+      ["trusty-bg", "#f0f0f0"],
+      ["trusty-text", "#101010"],
+    ]),
+    dark: new Map([
+      ["trusty-bg", "#999999"], // WRONG: canonical dark is #202020
+      ["trusty-text", "#e0e0e0"],
+    ]),
+  };
+
+  const diffs = checkCrate(makeHexFixtureCrate(), canonical, parsedCrate);
+  assert.equal(diffs.length, 1, "expected exactly one drift (dark bg)");
+  assert.equal(diffs[0].theme, "dark");
+  assert.equal(diffs[0].var, "--trusty-bg");
+  assert.equal(diffs[0].expected, "#202020");
+  assert.equal(diffs[0].actual, "#999999");
+});
+
+test("hex mode: throws when the crate defines no canonical tokens (zero comparisons)", () => {
+  const canonical = parseCanonicalFromSource(HEX_CANONICAL_SOURCE, "<inline hex canonical>");
+
+  const parsedCrate = {
+    light: new Map([["trusty-only-mine", "#123456"]]),
+    dark: new Map([["trusty-only-mine", "#123456"]]),
+  };
+
+  assert.throws(
+    () => checkCrate(makeHexFixtureCrate(), canonical, parsedCrate),
+    /zero token comparisons performed \(hex mode\)/,
+  );
+});
+
+test("hex mode: a missing dark block throws (disk-based)", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "token-drift-hex-test-"));
+  const filePath = path.join(dir, "tokens.css");
+  try {
+    // Valid light block, but no `[data-theme='dark']` block at all.
+    writeFileSync(
+      filePath,
+      `:root {\n  --trusty-bg: #f0f0f0;\n}\n`,
+      "utf8",
+    );
+
+    const crate = makeHexFixtureCrate({ file: filePath });
+    assert.throws(
+      () => parseCrate(crate),
+      /could not find dark block/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

The 5 migrated UI crates (trusty-mpm-gui #3488, trusty-console #3489, trusty-analyze #3490, trusty-search + trusty-memory #3487) just landed on `main`. This flips them from the `scripts/check_token_drift.mjs` **ALLOWLIST** to **ENFORCED**, leaving the allowlist **empty** — every `crates/*/ui` is now permanently pinned to the canonical Foundry source `docs/design/UI/design-system/tokens.css`, in both light and dark themes.

## Now-enforced crates + comparison mode

| Crate | Token file | Mode | Tokens compared |
|---|---|---|---|
| trusty-agents | `ui/src/app.css` | rgb-triple | 20 |
| trusty-code-gui | `ui/src/app.css` | rgb-triple | 40 |
| **trusty-mpm-gui** (#3488) | `ui/src/app.css` | rgb-triple | 30 |
| **trusty-console** (#3489) | `ui/src/theme.css` | hex | 26 |
| **trusty-analyze** (#3490) | `ui/src/lib/styles/tokens.css` | hex | 47 |
| **trusty-search** (#3487) | `ui/src/lib/styles/tokens.css` | hex | 49 |
| **trusty-memory** (#3487) | `ui/src/lib/styles/tokens.css` | hex | 49 |

## What changed in the checker

- **New `hex` comparison mode.** The 4 plain-CSS crates keep the canonical `--trusty-*` names with `#rrggbb` values, so their hex is compared **directly** (case-insensitively) to canonical hex of the same token name — no RGB-triple conversion. The 3 Tailwind crates keep the existing `rgb-triple` mode (`--color-*: R G B`, mapping table).
- **Intersection enforcement (hex mode).** Every canonical *hex* token the crate also defines must match; crate-only extension tokens (e.g. console's `--trusty-status-degraded`/`--trusty-status-absent`) and non-hex canonical tokens (rgba/font/spacing) are ignored — a crate is never forced to define a token it doesn't use.
- **Per-crate selector config** for the differing dark/light blocks: `:root[data-theme=...]` (console), `[data-theme=...]` + `:root, [data-theme="dark"]` (analyze), `:root` + `[data-theme='dark']` (search/memory).
- **Zero-comparison false-green guard kept and extended:** the static `mappings+passthrough` check still fires for rgb-triple crates, and a new runtime `comparedCount` check throws for **any** mode when a mis-configured path/selector would compare 0 tokens.
- `main()` now prints per-crate compared-token count + mode.

## Tests (`scripts/check_token_drift.test.mjs`)

- ENFORCED-invariant test now covers **all 7** crates by running the real comparison against the real canonical file (asserts no-throw, `comparedCount > 0`, zero drift) + asserts `ALLOWLIST` is empty.
- Added hex-mode cases: intersection/skip on match, drift on a mutated hex, zero-comparison throw, missing-block throw. All prior tests kept.

## Verification (raw)

All 7 crates already match canonical exactly — **no crate token edits needed, no mismatches found**.

```
OK   trusty-agents   (crates/trusty-agents/ui/src/app.css) — 20 tokens match canonical [rgb-triple]
OK   trusty-code-gui (crates/trusty-code-gui/ui/src/app.css) — 40 tokens match canonical [rgb-triple]
OK   trusty-mpm-gui  (crates/trusty-mpm-gui/ui/src/app.css) — 30 tokens match canonical [rgb-triple]
OK   trusty-console  (crates/trusty-console/ui/src/theme.css) — 26 tokens match canonical [hex]
OK   trusty-analyze  (crates/trusty-analyze/ui/src/lib/styles/tokens.css) — 47 tokens match canonical [hex]
OK   trusty-search   (crates/trusty-search/ui/src/lib/styles/tokens.css) — 49 tokens match canonical [hex]
OK   trusty-memory   (crates/trusty-memory/ui/src/lib/styles/tokens.css) — 49 tokens match canonical [hex]

Allowlist empty — all UI crates are enforced.
All enforced crates match the canonical token source.
```

`node --test scripts/check_token_drift.test.mjs` → 11/11 pass.

## Changelog

Per repo convention (matching PR #3496), added a CHANGELOG entry to each of the 5 newly-enforced crates noting they are now CI-pinned to canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)