### PR TITLE
chore(trusty-agents): rename "Trusty Assistant" → "Trusty Agents"

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -29,6 +29,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Product rename: "Trusty Assistant" → "Trusty Agents":** the last
+  remaining "Trusty Assistant" product-name references in the desktop UI
+  (macOS dock label / `productName` and window `title` in
+  `ui/src-tauri/tauri.conf.json`, the page `<title>`/meta description in
+  `ui/index.html`, the Tauri capabilities description, the visible
+  "desktop app only" copy in `PersonalityPanel.svelte`, `ui/README.md`'s
+  heading, the Playwright smoke-test describe block, and descriptive code
+  comments) now consistently read "Trusty Agents", matching the header/
+  sidebar wordmark and app branding already in place.
+
 - **Canonical Foundry icon set (#3486):** `ActionIcon`, `RobotIcon`, and
   `LogoMark` — previously only defined inline in this crate's
   `ui/src/lib/icons/` — now have a documented canonical source at

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -40,7 +40,7 @@ pub struct TaskRequest {
     pub task_file: Option<String>,
     /// #151 phase-4: when set, dispatch to a single sub-agent instead of a
     /// full workflow (via `trusty-agents --direct <agent>`) for
-    /// `IntentClass::Implementation`. #3223 (Trusty Assistant agent roster,
+    /// `IntentClass::Implementation`. #3223 (Trusty Agents agent roster,
     /// epic #3052) additionally threads this into the in-process
     /// Conversational/Research path (see [`agent_override`] and
     /// `submit_task`), so the same field selects the active persona for
@@ -290,7 +290,7 @@ pub(super) async fn submit_task(
         classify_intent(&req.task)
     };
 
-    // #3223 (Trusty Assistant agent roster, epic #3052): CTRL management
+    // #3223 (Trusty Agents agent roster, epic #3052): CTRL management
     // commands ("add project …", "list projects", …) must always run
     // through the full CTRL session (`run_pm_task_with_session`) regardless
     // of the roster's active agent — that's the only dispatch path wired to

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -110,7 +110,7 @@ pub async fn run_pm_task_with_persona(
 
     let sid = session_id.unwrap_or_default();
 
-    // #3223/#3224 (Trusty Assistant agent roster, epic #3052): resolve
+    // #3223/#3224 (Trusty Agents agent roster, epic #3052): resolve
     // through the canonical `AgentConfig::by_name_async` loader instead of
     // the hand-rolled project/$HOME `.toml`-only lookup this function used
     // to do inline. `by_name_async` walks the SAME tier order the old code

--- a/crates/trusty-agents/ui/README.md
+++ b/crates/trusty-agents/ui/README.md
@@ -1,4 +1,4 @@
-# Trusty Assistant desktop UI
+# Trusty Agents desktop UI
 
 A Tauri 2 + Svelte 4 chat interface for [trusty-agents](../) (`tagent`). Lets you:
 

--- a/crates/trusty-agents/ui/index.html
+++ b/crates/trusty-agents/ui/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="description" content="Trusty Assistant — AI agent orchestration" />
+    <meta name="description" content="Trusty Agents — AI agent orchestration" />
     <meta name="theme-color" content="#B7410E" />
     <meta name="color-scheme" content="light dark" />
-    <title>Trusty Assistant</title>
+    <title>Trusty Agents</title>
     <script>
       // Why: Apply the persisted theme before first paint so users don't see a
       // flash of the wrong palette during JS bootstrap. The theme store also

--- a/crates/trusty-agents/ui/src-tauri/capabilities/default.json
+++ b/crates/trusty-agents/ui/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default capabilities for the Trusty Assistant desktop app",
+  "description": "Default capabilities for the Trusty Agents desktop app",
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/crates/trusty-agents/ui/src-tauri/src/main.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 //! trusty-agents desktop chat (Tauri 2).
 //!
 //! Why: Gives users a native chat UI for talking to the CTRL controller,
-//! project-scoped PMs, and — as of #3223/#3224 (Trusty Assistant agent
+//! project-scoped PMs, and — as of #3223/#3224 (Trusty Agents agent
 //! roster, epic #3052) — named persona agents, without hand-running
 //! `trusty-agents --task '…'` at the command line. The Rust side here only
 //! does three things: (1) spawn the `trusty-agents --api` sidecar on startup

--- a/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
@@ -73,7 +73,7 @@ struct SubmitResponse {
 /// What: Submits the task, emits `task-progress` every 1.5s with a short
 /// "running…" tick, then emits `task-complete` (with the full PmResponse
 /// JSON) or `task-error` on failure. Returns the final narrative string.
-/// #3223 (Trusty Assistant agent roster, epic #3052): `agent`, when set,
+/// #3223 (Trusty Agents agent roster, epic #3052): `agent`, when set,
 /// is forwarded as the request body's `agent` field — the same field the
 /// `--direct <agent>` subprocess dispatch path already used — so the GUI's
 /// roster selection determines which persona answers.

--- a/crates/trusty-agents/ui/src-tauri/tauri.conf.json
+++ b/crates/trusty-agents/ui/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Trusty Assistant",
+  "productName": "Trusty Agents",
   "version": "0.1.0",
   "identifier": "com.trusty.assistant",
   "build": {
@@ -15,7 +15,7 @@
     },
     "windows": [
       {
-        "title": "Trusty Assistant",
+        "title": "Trusty Agents",
         "width": 1200,
         "height": 800,
         "minWidth": 800,

--- a/crates/trusty-agents/ui/src/components/AgentSwitcher.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentSwitcher.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   /**
-   * Why: #3223 (Trusty Assistant agent roster, epic #3052) — the GUI needs a
+   * Why: #3223 (Trusty Agents agent roster, epic #3052) — the GUI needs a
    * visible way to pick WHICH named agent (the base assistant, a bundled
    * catalog agent, or a user's personalization overlay) answers the current
    * chat, and to see at a glance who's currently active. A compact dropdown

--- a/crates/trusty-agents/ui/src/components/Header.svelte
+++ b/crates/trusty-agents/ui/src/components/Header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   /**
-   * Why (#3220 — Trusty Assistant header consolidation, epic #3052): the
+   * Why (#3220 — Trusty Agents header consolidation, epic #3052): the
    * app previously spread its "single source of orientation" state across
    * three places — a bare logo+theme-toggle Header, a separate `<nav>` tab
    * bar inside App.svelte's `<main>`, and a floating Desktop/Web pill

--- a/crates/trusty-agents/ui/src/components/PersonalityPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/PersonalityPanel.svelte
@@ -3,7 +3,7 @@
    * Why: #3061 introduced this panel as a minimal prose editor bound
    * directly to a SINGLE hardcoded personalization overlay
    * (`~/.trusty-agents/agents/my-assistant.md`, DOC-41 §2.5.1's `extends:`
-   * mechanism). #3224 (Trusty Assistant agent roster, epic #3052)
+   * mechanism). #3224 (Trusty Agents agent roster, epic #3052)
    * generalizes it to edit ANY overlay the user has created, plus a
    * "+ New agent" flow (name + pasted instructions + optional display name
    * + base to extend) — the roster's natural host for customizing an agent,
@@ -336,7 +336,7 @@ context it should always remember. This text is appended after the base
         <p class="max-w-sm text-xs text-foundry-light-muted dark:text-foundry-text/60">
           Editing a personalization overlay reads and writes files under
           <code class="font-mono">~/.trusty-agents/agents/</code> directly, which
-          is only available in the Trusty Assistant desktop app — not this
+          is only available in the Trusty Agents desktop app — not this
           browser preview.
         </p>
       </div>

--- a/crates/trusty-agents/ui/src/lib/roster.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.ts
@@ -1,4 +1,4 @@
-// Agent roster helpers (#3223, #3224 — Trusty Assistant agent roster, epic
+// Agent roster helpers (#3223, #3224 — Trusty Agents agent roster, epic
 // #3052).
 //
 // Why: The roster needs to merge two independent data sources — the

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -84,7 +84,7 @@ export const projects = writable<Project[]>([
 export const activeProjectId = writable<string>('ctrl');
 
 /**
- * Why (#3223 — Trusty Assistant agent roster, epic #3052; regression fix
+ * Why (#3223 — Trusty Agents agent roster, epic #3052; regression fix
  * flagged by code-critic on PR #3279): the roster's "active agent" is a
  * second, independent selection axis alongside `activeProjectId` — which
  * conversation thread/working directory vs. which persona voice answers.

--- a/crates/trusty-agents/ui/tests/smoke.spec.ts
+++ b/crates/trusty-agents/ui/tests/smoke.spec.ts
@@ -101,7 +101,7 @@ const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 // without waiting for external resources that may stall in headless mode.
 const GOTO_OPTS = { waitUntil: 'domcontentloaded' };
 
-test.describe('Trusty Assistant web UI smoke tests', () => {
+test.describe('Trusty Agents web UI smoke tests', () => {
 
   test('page loads and shows non-blank content', async ({ page }) => {
     // Why: Svelte renders the spinner into #app synchronously at parse time.


### PR DESCRIPTION
## Summary
- Renames the remaining "Trusty Assistant" product-name stragglers in the trusty-agents desktop UI to "Trusty Agents", matching the header/sidebar wordmark and app branding already in place.
- `productName` in `tauri.conf.json` drives the macOS dock label, so this also fixes what shows under the app icon.
- Updated: Tauri `productName` + window `title`, page `<title>` + meta description, capabilities description, visible "desktop app only" copy in `PersonalityPanel.svelte`, `ui/README.md` heading, Playwright smoke-test describe block, and descriptive code comments referencing "Trusty Assistant agent roster" / "Trusty Assistant header consolidation" / "Trusty Assistant desktop app".
- Added a CHANGELOG `[Unreleased]` entry documenting the rename.
- Left the CHANGELOG's historical line (`wordmark now reads "Trusty Agents" (was "Trusty Assistant")`) untouched, and left the lowercase `assistant` agent-role identifier untouched (functional name, not the product brand).

## Test plan
- [x] `git grep -n "Trusty Assistant" -- crates/trusty-agents` returns only the CHANGELOG historical line and the new `[Unreleased]` entry describing this rename.
- [x] `cargo check -p trusty-agents` — clean.
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations.
- [x] `pnpm install && pnpm build` from `crates/trusty-agents/ui` — clean build.
- [x] `pnpm check` — same pre-existing error count/location as before (unrelated `App.svelte` unused-variable error, file not touched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)