### PR TITLE
feat(trusty-gworkspace): per-profile OAuth-client support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11558,6 +11558,7 @@ dependencies = [
  "tracing-test",
  "trusty-common",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/trusty-gworkspace/CHANGELOG.md
+++ b/crates/trusty-gworkspace/CHANGELOG.md
@@ -14,6 +14,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `add_account` (runs the native OAuth consent flow for a new or re-auth
   profile — see the README's "Managing accounts" section for the blocking-call
   design and its tradeoffs). `list_accounts` is unchanged.
+- Per-profile OAuth-client support (issue #3518, follow-up to #3502/#3503):
+  each account profile can now authorize (and forever after refresh) against
+  its OWN OAuth client — e.g. a per-domain "Internal" Google Workspace app —
+  instead of one shared global client. `setup --oauth-client <path>` and
+  `add_account`'s new `oauth_client_path` argument persist a profile's client
+  to `~/.gworkspace-mcp/clients/<profile>.json` (0600); it is reused
+  automatically on every subsequent refresh. Profiles with no per-profile
+  client keep using the global `oauth_client.json`/env vars exactly as
+  before — no migration needed. `accounts list` / `list_accounts` / `doctor`
+  now show which client each profile uses.
 
 ### Changed
 

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -41,3 +41,8 @@ serial_test = { workspace = true }
 # [workspace.dependencies]; pinned locally, matching the existing
 # trusty-git-analytics precedent.
 tracing-test = "0.2"
+# wiremock: async HTTP mock server for the OAuthManager::refresh tests
+# (issue #3518) — asserts the exact client_id/secret sent to the token
+# endpoint without hitting Google, matching the trusty-channels /
+# trusty-git-analytics precedent.
+wiremock = { workspace = true }

--- a/crates/trusty-gworkspace/README.md
+++ b/crates/trusty-gworkspace/README.md
@@ -59,6 +59,25 @@ console's downloaded shape are accepted:
 (`web` is accepted in place of `installed`.) Environment variables take
 precedence over the file.
 
+#### Per-profile OAuth clients
+
+Every profile uses this global client by default. A profile can instead
+authorize (and forever after refresh) against its OWN client — useful for a
+per-domain "Internal" Google Workspace app instead of one shared client:
+
+```sh
+trusty-gworkspace-mcp setup --profile work --oauth-client ~/Downloads/client_secret_work.json
+```
+
+`--oauth-client` takes a PATH to a client JSON file (same flat or
+`installed`/`web` shapes as above) — never inline `client_id`/`client_secret`.
+It is validated, then persisted to
+`~/.gworkspace-mcp/clients/<profile>.json` (0600) and reused automatically on
+every future refresh for that profile. A profile with no per-profile client
+keeps using the global one exactly as before — no migration is needed for
+existing accounts. `accounts list` and `doctor` both show which client each
+profile is using.
+
 ### 2. Authorize an account
 
 ```sh
@@ -133,10 +152,13 @@ unreachable rather than failing the whole diagnostic.
 ## Managing accounts
 
 ```sh
-trusty-gworkspace-mcp accounts list                 # show profiles + which is default
+trusty-gworkspace-mcp accounts list                 # show profiles + which is default + client
 trusty-gworkspace-mcp accounts default work         # switch the default profile
 trusty-gworkspace-mcp accounts remove work          # forget a local token (no revoke)
 ```
+
+`accounts list` shows a `CLIENT` column: `global`, or `per-profile (<path>)`
+for a profile authorized via `setup --oauth-client` (see above).
 
 Removing the current default reassigns it to another remaining profile
 (alphabetically next) rather than leaving no default at all.
@@ -144,7 +166,8 @@ Removing the current default reassigns it to another remaining profile
 The same operations are also available as MCP tools (issue #3503), so an
 agent can manage accounts without shelling out to the CLI:
 
-- `list_accounts` — read-only, as above.
+- `list_accounts` — read-only, as above; each entry includes a `client` field
+  (`"global"` or `"per-profile (<path>)"`).
 - `set_default_account {name}` — same behavior as `accounts default`.
 - `remove_account {name}` — same behavior as `accounts remove`, including the
   default-reassignment above; the response reports which profile (if any)
@@ -155,7 +178,10 @@ agent can manage accounts without shelling out to the CLI:
   a browser, and always returns the consent URL in the response (whether it
   succeeded or timed out) so the calling agent can relay it and, on a
   time-out, simply call `add_account` again for a fresh URL. No partial or
-  corrupt token is ever written on a time-out or abandoned consent.
+  corrupt token is ever written on a time-out or abandoned consent. Pass
+  `oauth_client_path` (a FILE PATH, never inline secrets) to authorize this
+  profile against its own OAuth client instead of the shared global one — see
+  "Per-profile OAuth clients" above.
 
 ## Configuration
 
@@ -275,6 +301,16 @@ adding a new tool means: write the function, add a `match` arm in
   blocks for up to the timeout, so clients with a shorter built-in call
   timeout may see it fail even though retrying is always safe (no token is
   persisted until the exchange fully succeeds).
+- **Per-profile OAuth clients (issue #3518).** A Google refresh token is bound
+  to the client that issued it, so `oauth::client_store` resolves the client
+  to use PER PROFILE — its own file at `~/.gworkspace-mcp/clients/<profile>.json`
+  if one was persisted (via `setup --oauth-client` or `add_account`'s
+  `oauth_client_path`), else the shared global `oauth_client.json`/env vars.
+  `oauth::flow::run_consent_with` (authorization) and
+  `auth::manager::OAuthManager::refresh` (every subsequent refresh) both
+  resolve through the same function, so a profile can never be authorized
+  with one client and refreshed with another. `list_accounts` / `doctor`
+  label each profile's resolved client for diagnosability.
 - **Local filesystem access is intentionally broad.** `compose_email`
   attachments (`path`/`local_path`), `manage_drive_file`'s `upload` action
   (`local_path`), and `get_drive_file_content`'s `save_path` all read or

--- a/crates/trusty-gworkspace/src/api/auth/manager.rs
+++ b/crates/trusty-gworkspace/src/api/auth/manager.rs
@@ -8,19 +8,25 @@
 //! What: POSTs `grant_type=refresh_token` to Google's OAuth token endpoint,
 //! updates the on-disk record on success, and routes failures through the
 //! shared [`refresh_failure_message`] helper (actionable re-auth hint on
-//! `invalid_grant`, sanitized error otherwise).
-//! Test: Manual — requires real Google credentials. The failure-message mapping
-//! is unit-tested in `oauth::errors`
-//! (`refresh_failure_message_names_profile_and_setup_command`).
+//! `invalid_grant`, sanitized error otherwise). Issue #3518: the client used
+//! for the exchange is resolved PER-PROFILE (`oauth::client_store`) — a
+//! profile authorized against its own client is always refreshed with that
+//! same client, falling back to the global client only for profiles that
+//! have none (backward compatible with every profile authorized before this
+//! feature existed).
+//! Test: The live HTTP exchange is covered against a `wiremock` server —
+//! `refresh_uses_per_profile_client_when_present` and
+//! `refresh_falls_back_to_global_client_when_absent` assert the exact
+//! `client_id` sent on the wire. The failure-message mapping is unit-tested
+//! in `oauth::errors` (`refresh_failure_message_names_profile_and_setup_command`).
 
 use anyhow::{Context, Result, anyhow};
 use chrono::{Duration, Utc};
 use serde::Deserialize;
-use tracing::warn;
 
 use super::models::{OAuthToken, StoredToken};
 use super::oauth::errors::{redact_token_response, refresh_failure_message};
-use super::oauth::resolve_client_creds;
+use super::oauth::resolve_client_creds_for_profile;
 use super::storage::TokenStorage;
 use crate::api::constants::OAUTH_TOKEN_URL;
 
@@ -39,53 +45,37 @@ struct GoogleTokenResponse {
 
 /// OAuth refresh manager.
 ///
-/// Why: Encapsulates Google's OAuth client credentials so `BaseClient` only
-/// needs to call one method to get a fresh token.
-/// What: Resolves `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` env
-/// vars first, falling back to `~/.gworkspace-mcp/oauth_client.json` (see
-/// `from_env`), on construction. `refresh` performs the HTTP exchange.
-/// Test: Construction is covered by `from_env_falls_back_to_oauth_client_json`,
-/// `from_env_returns_none_when_both_absent`, and
-/// `from_env_prefers_env_vars_over_file`.
+/// Why: Centralises the token-endpoint HTTP exchange so `BaseClient` only
+/// needs to call one method to get a fresh token; the OAuth CLIENT itself is
+/// no longer fixed at construction time (issue #3518) — it is resolved
+/// per-profile on every call via [`resolve_client_creds_for_profile`], since
+/// different profiles may be bound to different clients.
+/// What: Holds a `reqwest::Client` and the token endpoint URL (overridable
+/// in tests via [`OAuthManager::with_token_url`] to point at a `wiremock`
+/// server instead of Google's real endpoint).
+/// Test: `refresh_uses_per_profile_client_when_present`,
+/// `refresh_falls_back_to_global_client_when_absent`.
 pub struct OAuthManager {
     http: reqwest::Client,
-    client_id: String,
-    client_secret: String,
+    token_url: String,
 }
 
 impl OAuthManager {
-    /// Construct from env vars, falling back to `oauth_client.json` on disk.
-    ///
-    /// Why: Issue #2946 — no tm-managed session sets
-    /// `GOOGLE_OAUTH_CLIENT_ID`/`SECRET`, so `from_env` previously always
-    /// returned `None` there, silently disabling self-refresh: every
-    /// tm-managed MCP server ran read-only-token mode and 401'd on Google
-    /// once the access token expired (~1h). `setup`/`doctor` already resolve
-    /// client credentials with an env-first, file-fallback strategy via
-    /// `resolve_client_creds`; reusing it here (rather than duplicating the
-    /// parse logic) gives the refresh path the same fallback for free.
-    /// What: Delegates to [`resolve_client_creds`] (env vars win when
-    /// present, else reads `~/.gworkspace-mcp/oauth_client.json`). Returns
-    /// `Ok(None)` — with a warning logged — only when neither source yields
-    /// credentials (read-only token mode: refresh disabled).
-    /// Test: `from_env_falls_back_to_oauth_client_json`,
-    /// `from_env_returns_none_when_both_absent`,
-    /// `from_env_prefers_env_vars_over_file`.
-    pub fn from_env() -> Result<Option<Self>> {
-        match resolve_client_creds() {
-            Ok(creds) => Ok(Some(Self {
-                http: reqwest::Client::new(),
-                client_id: creds.client_id,
-                client_secret: creds.client_secret,
-            })),
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    "no OAuth client credentials found (env vars or oauth_client.json); \
-                     token refresh disabled — expired tokens will not self-refresh"
-                );
-                Ok(None)
-            }
+    /// Construct against Google's real token endpoint.
+    pub fn new() -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            token_url: OAUTH_TOKEN_URL.to_string(),
+        }
+    }
+
+    /// Test-only constructor pointing the refresh exchange at `token_url`
+    /// (a `wiremock` mock server) instead of Google's real endpoint.
+    #[cfg(test)]
+    pub(crate) fn with_token_url(token_url: impl Into<String>) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            token_url: token_url.into(),
         }
     }
 
@@ -93,14 +83,21 @@ impl OAuthManager {
     ///
     /// Why: The stored token is near or past expiry; we need a fresh one
     /// before the next API call.
-    /// What: POSTs to Google's OAuth endpoint with `grant_type=refresh_token`,
-    /// parses the response, updates `expires_at` to `now + expires_in`, and
-    /// writes the updated `StoredToken` back to disk. On an HTTP failure it
-    /// returns [`refresh_failure_message`]'s actionable error (naming the exact
+    /// What: Resolves `profile`'s own OAuth client (falling back to the
+    /// global one — see [`resolve_client_creds_for_profile`]), POSTs to
+    /// Google's OAuth endpoint with `grant_type=refresh_token`, parses the
+    /// response, updates `expires_at` to `now + expires_in`, and writes the
+    /// updated `StoredToken` back to disk. On an HTTP failure it returns
+    /// [`refresh_failure_message`]'s actionable error (naming the exact
     /// re-auth command on `invalid_grant`).
-    /// Test: live path needs real Google creds; the failure-message mapping is
-    /// covered by `refresh_failure_message_names_profile_and_setup_command`.
+    /// Test: `refresh_uses_per_profile_client_when_present`,
+    /// `refresh_falls_back_to_global_client_when_absent`; the failure-message
+    /// mapping is covered by
+    /// `refresh_failure_message_names_profile_and_setup_command`.
     pub async fn refresh(&self, storage: &TokenStorage, profile: &str) -> Result<OAuthToken> {
+        let creds = resolve_client_creds_for_profile(profile)
+            .with_context(|| format!("resolve OAuth client for profile '{profile}'"))?;
+
         let mut stored: StoredToken = storage
             .get_profile(profile)?
             .ok_or_else(|| anyhow!("no stored token for profile '{profile}'"))?;
@@ -111,14 +108,14 @@ impl OAuthManager {
             .ok_or_else(|| anyhow!("no refresh_token available for profile '{profile}'"))?;
 
         let params = [
-            ("client_id", self.client_id.as_str()),
-            ("client_secret", self.client_secret.as_str()),
+            ("client_id", creds.client_id.as_str()),
+            ("client_secret", creds.client_secret.as_str()),
             ("refresh_token", refresh_token.as_str()),
             ("grant_type", "refresh_token"),
         ];
         let resp = self
             .http
-            .post(OAUTH_TOKEN_URL)
+            .post(&self.token_url)
             .form(&params)
             .send()
             .await
@@ -163,11 +160,23 @@ impl OAuthManager {
     }
 }
 
+impl Default for OAuthManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::auth::TokenStorage;
+    use crate::api::auth::models::TokenMetadata;
+    use crate::api::auth::oauth::client_store::profile_client_path;
+    use crate::api::auth::test_support::{EnvGuard, fresh_temp_home};
     use serial_test::serial;
     use std::path::PathBuf;
+    use wiremock::matchers::{body_string_contains, method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     /// Env vars mutated by the fallback tests below; captured/restored as a
     /// group so a panic mid-test never leaks a fake `HOME` or client id into
@@ -178,115 +187,145 @@ mod tests {
         "GOOGLE_OAUTH_CLIENT_SECRET",
     ];
 
-    /// RAII guard that snapshots and restores a fixed set of env vars, even
-    /// on panic.
-    ///
-    /// Why: `from_env`'s fallback path reads `HOME` (via `dirs::home_dir`)
-    /// indirectly through `resolve_client_creds`; testing it in-process means
-    /// mutating real process env state, which must never leak across tests
-    /// (issue #2946 fallback tests run `#[serial]` for the same reason).
-    /// What: Captures each var's current value on construction; `Drop`
-    /// restores it (`set_var` if it was present, `remove_var` if absent).
-    /// Test: exercised by every test in this module — a leaked var would
-    /// make a later, unrelated test flaky.
-    struct EnvGuard {
-        saved: Vec<(&'static str, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn capture(vars: &[&'static str]) -> Self {
-            let saved = vars.iter().map(|&v| (v, std::env::var(v).ok())).collect();
-            Self { saved }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (k, v) in &self.saved {
-                // SAFETY: every caller of `EnvGuard` runs under `#[serial]`,
-                // so no other thread reads/writes these vars concurrently.
-                match v {
-                    Some(val) => unsafe { std::env::set_var(k, val) },
-                    None => unsafe { std::env::remove_var(k) },
-                }
-            }
-        }
-    }
-
-    /// Build a fresh temp dir with a `.gworkspace-mcp/` subdir, never
-    /// touching the real `~/.gworkspace-mcp`.
-    fn fresh_temp_home(label: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join(format!("gw-manager-{label}-{}", uuid::Uuid::new_v4()));
-        std::fs::create_dir_all(dir.join(".gworkspace-mcp")).expect("mkdir temp home");
-        dir
-    }
-
-    #[test]
-    #[serial]
-    fn from_env_falls_back_to_oauth_client_json() {
-        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
-        // SAFETY: serialised via #[serial]; EnvGuard restores on drop.
+    fn isolated_home(label: &str) -> PathBuf {
+        let home = fresh_temp_home(label);
+        // SAFETY: caller runs under #[serial]; EnvGuard (held by the caller)
+        // restores every var on drop.
         unsafe {
             std::env::remove_var("GOOGLE_OAUTH_CLIENT_ID");
             std::env::remove_var("GOOGLE_OAUTH_CLIENT_SECRET");
-        }
-        let home = fresh_temp_home("fallback");
-        std::fs::write(
-            home.join(".gworkspace-mcp").join("oauth_client.json"),
-            r#"{"client_id":"file-id","client_secret":"file-secret"}"#,
-        )
-        .expect("write oauth_client.json");
-        // SAFETY: see above.
-        unsafe { std::env::set_var("HOME", &home) };
-
-        let mgr = OAuthManager::from_env()
-            .expect("from_env should not error")
-            .expect("oauth_client.json fallback should enable refresh");
-        assert_eq!(mgr.client_id, "file-id");
-        assert_eq!(mgr.client_secret, "file-secret");
-    }
-
-    #[test]
-    #[serial]
-    fn from_env_returns_none_when_both_absent() {
-        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
-        // SAFETY: see EnvGuard doc.
-        unsafe {
-            std::env::remove_var("GOOGLE_OAUTH_CLIENT_ID");
-            std::env::remove_var("GOOGLE_OAUTH_CLIENT_SECRET");
-        }
-        let home = fresh_temp_home("absent");
-        // SAFETY: see EnvGuard doc.
-        unsafe { std::env::set_var("HOME", &home) };
-
-        let mgr = OAuthManager::from_env().expect("from_env should not error (warn, not error)");
-        assert!(
-            mgr.is_none(),
-            "refresh must stay disabled with neither env vars nor oauth_client.json present"
-        );
-    }
-
-    #[test]
-    #[serial]
-    fn from_env_prefers_env_vars_over_file() {
-        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
-        let home = fresh_temp_home("precedence");
-        std::fs::write(
-            home.join(".gworkspace-mcp").join("oauth_client.json"),
-            r#"{"client_id":"file-id","client_secret":"file-secret"}"#,
-        )
-        .expect("write oauth_client.json");
-        // SAFETY: see EnvGuard doc.
-        unsafe {
             std::env::set_var("HOME", &home);
-            std::env::set_var("GOOGLE_OAUTH_CLIENT_ID", "env-id");
-            std::env::set_var("GOOGLE_OAUTH_CLIENT_SECRET", "env-secret");
         }
+        home
+    }
 
-        let mgr = OAuthManager::from_env()
-            .expect("from_env should not error")
-            .expect("env vars should enable refresh");
-        assert_eq!(mgr.client_id, "env-id", "env vars must win over the file");
-        assert_eq!(mgr.client_secret, "env-secret");
+    fn write_client_json(path: &std::path::Path, client_id: &str, client_secret: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(
+            path,
+            format!(r#"{{"client_id":"{client_id}","client_secret":"{client_secret}"}}"#),
+        )
+        .unwrap();
+    }
+
+    fn temp_storage_with_token(profile: &str, refresh_token: &str) -> TokenStorage {
+        let dir = std::env::temp_dir().join(format!("gw-manager-tokens-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let storage = TokenStorage::with_path(dir.join("tokens.json"));
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            profile.to_string(),
+            StoredToken {
+                version: 1,
+                metadata: TokenMetadata {
+                    service_name: profile.to_string(),
+                    provider: "google".into(),
+                    created_at: Utc::now(),
+                    last_refreshed: None,
+                    email: Some(format!("{profile}@example.com")),
+                    is_default: true,
+                },
+                token: OAuthToken {
+                    access_token: "stale".into(),
+                    refresh_token: Some(refresh_token.to_string()),
+                    expires_at: Utc::now() - Duration::seconds(10),
+                    scopes: vec!["openid".into()],
+                    token_type: "Bearer".into(),
+                },
+            },
+        );
+        storage.save(&map).unwrap();
+        storage
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn refresh_uses_per_profile_client_when_present() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        let home = isolated_home("refresh-per-profile");
+        // A DIFFERENT global client is present too, to prove it is not used.
+        write_client_json(
+            &home.join(".gworkspace-mcp").join("oauth_client.json"),
+            "global-client",
+            "global-secret",
+        );
+        write_client_json(
+            &profile_client_path("work"),
+            "profile-client",
+            "profile-secret",
+        );
+        let storage = temp_storage_with_token("work", "r-work");
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/token"))
+            .and(body_string_contains("client_id=profile-client"))
+            .and(body_string_contains("client_secret=profile-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "new-access-token",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            })))
+            .mount(&server)
+            .await;
+
+        let mgr = OAuthManager::with_token_url(format!("{}/token", server.uri()));
+        let refreshed = mgr
+            .refresh(&storage, "work")
+            .await
+            .expect("refresh should succeed using the profile's own client");
+        assert_eq!(refreshed.access_token, "new-access-token");
+
+        let stored = storage.get_profile("work").unwrap().unwrap();
+        assert_eq!(stored.token.access_token, "new-access-token");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn refresh_falls_back_to_global_client_when_absent() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        let home = isolated_home("refresh-global-fallback");
+        write_client_json(
+            &home.join(".gworkspace-mcp").join("oauth_client.json"),
+            "global-client",
+            "global-secret",
+        );
+        // No per-profile client file for "legacy" — must keep using global.
+        let storage = temp_storage_with_token("legacy", "r-legacy");
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wm_path("/token"))
+            .and(body_string_contains("client_id=global-client"))
+            .and(body_string_contains("client_secret=global-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "legacy-new-token",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+            })))
+            .mount(&server)
+            .await;
+
+        let mgr = OAuthManager::with_token_url(format!("{}/token", server.uri()));
+        let refreshed = mgr.refresh(&storage, "legacy").await.expect(
+            "a profile with no per-profile client must still refresh via the global client \
+                 (backward compatibility)",
+        );
+        assert_eq!(refreshed.access_token, "legacy-new-token");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn refresh_errors_when_no_client_resolves_for_profile() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        isolated_home("refresh-no-creds");
+        // Neither a per-profile client file nor a global oauth_client.json.
+        let storage = temp_storage_with_token("orphan", "r-orphan");
+
+        let mgr = OAuthManager::new();
+        let err = mgr.refresh(&storage, "orphan").await.unwrap_err();
+        assert!(err.to_string().contains("resolve OAuth client"), "{err}");
     }
 }

--- a/crates/trusty-gworkspace/src/api/auth/mod.rs
+++ b/crates/trusty-gworkspace/src/api/auth/mod.rs
@@ -12,7 +12,11 @@
 pub mod manager;
 pub mod models;
 pub mod oauth;
+pub mod perms;
 pub mod storage;
+
+#[cfg(test)]
+pub(crate) mod test_support;
 
 pub use manager::OAuthManager;
 pub use models::{OAuthToken, StoredToken, TokenMetadata};

--- a/crates/trusty-gworkspace/src/api/auth/oauth/client_store.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/client_store.rs
@@ -1,0 +1,329 @@
+//! Per-profile OAuth client credential storage (issue #3518).
+//!
+//! Why: A Google refresh token is bound to the OAuth client (client_id) that
+//! issued it — refreshing it with a DIFFERENT client fails with
+//! `invalid_client`/`invalid_grant`. Multi-account setups (#3502/#3503) often
+//! want per-domain "Internal" Google Workspace apps rather than one shared
+//! client, so each profile must be able to record — and every subsequent
+//! refresh must reuse — the exact client it was authorized with.
+//! What: Persists an optional per-profile client credentials file under
+//! `~/.gworkspace-mcp/clients/<profile>.json` (same 0600 hardening as
+//! `tokens.json`). [`resolve_client_creds_for_profile`] prefers this file,
+//! falling back to the existing global [`resolve_client_creds`] (env vars,
+//! then `oauth_client.json`) when the profile has none — so an
+//! already-authorized profile with no per-profile client keeps working
+//! completely unchanged (backward compatible, no migration).
+//! Test: `resolve_prefers_per_profile_file_over_global`,
+//! `resolve_falls_back_to_global_when_absent`,
+//! `resolve_propagates_malformed_per_profile_file`,
+//! `persist_and_resolve_roundtrip`, `persist_rejects_malformed_source`,
+//! `persist_restricts_permissions_on_unix` (cfg(unix)),
+//! `profile_client_source_reports_global_and_per_profile`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use super::flow::{ClientCreds, parse_client_creds_json, resolve_client_creds};
+use crate::api::auth::perms::restrict_to_owner;
+
+/// Directory holding per-profile OAuth client credential files.
+///
+/// Why: A `clients/` subdirectory (not flat files at the `.gworkspace-mcp/`
+/// root) so a profile named e.g. `tokens` or `oauth_client` can never
+/// collide with the existing fixed filenames there.
+/// What: `~/.gworkspace-mcp/clients/`.
+fn clients_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".gworkspace-mcp")
+        .join("clients")
+}
+
+/// The on-disk path for `profile`'s per-profile OAuth client file, if any.
+///
+/// What: `~/.gworkspace-mcp/clients/<profile>.json`. Existence is the only
+/// signal of whether a per-profile client is configured — no separate index.
+pub fn profile_client_path(profile: &str) -> PathBuf {
+    clients_dir().join(format!("{profile}.json"))
+}
+
+/// Which OAuth client a profile actually uses — for diagnostics
+/// (`list_accounts`, `doctor`), not for the refresh decision itself (that is
+/// [`resolve_client_creds_for_profile`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClientSource {
+    /// No per-profile client file; falls back to the shared global client.
+    Global,
+    /// A per-profile client file exists at this path.
+    PerProfile(PathBuf),
+}
+
+impl ClientSource {
+    /// Human-readable label for MCP/CLI surfaces (`"global"` or
+    /// `"per-profile (<path>)"`).
+    pub fn label(&self) -> String {
+        match self {
+            ClientSource::Global => "global".to_string(),
+            ClientSource::PerProfile(path) => format!("per-profile ({})", path.display()),
+        }
+    }
+}
+
+/// Cheap existence check — which client `profile` is configured to use.
+///
+/// Why: `list_accounts` / `doctor` need to *label* every profile without
+/// paying for a full parse of every client file.
+/// What: `PerProfile` iff the file exists; does not validate its contents
+/// (a malformed per-profile file still shows as `PerProfile` here — the
+/// content problem surfaces via [`resolve_client_creds_for_profile`] instead).
+pub fn profile_client_source(profile: &str) -> ClientSource {
+    let path = profile_client_path(profile);
+    if path.exists() {
+        ClientSource::PerProfile(path)
+    } else {
+        ClientSource::Global
+    }
+}
+
+/// Resolve the OAuth client credentials to use for `profile`.
+///
+/// Why: THE correctness crux (issue #3518) — a refresh token is bound to the
+/// client that issued it, so every refresh (and the initial authorization,
+/// see `oauth::flow::run_consent_with`) for a profile with its own client
+/// MUST use that exact client, never the global one.
+/// What: Reads and parses `~/.gworkspace-mcp/clients/<profile>.json` if
+/// present — any read/parse error here is returned, NOT swallowed:
+/// misconfiguration must surface loudly rather than silently falling back to
+/// a global client that would produce a confusing `invalid_client` error
+/// instead. Falls back to [`resolve_client_creds`] (env vars, then the global
+/// `oauth_client.json`) only when the profile has no per-profile file at all
+/// — this is the backward-compat path for every profile authorized before
+/// this feature existed.
+/// Test: `resolve_prefers_per_profile_file_over_global`,
+/// `resolve_falls_back_to_global_when_absent`,
+/// `resolve_propagates_malformed_per_profile_file`.
+pub fn resolve_client_creds_for_profile(profile: &str) -> Result<ClientCreds> {
+    let path = profile_client_path(profile);
+    if path.exists() {
+        let data = std::fs::read_to_string(&path)
+            .with_context(|| format!("read per-profile OAuth client {}", path.display()))?;
+        return parse_client_creds_json(&data)
+            .with_context(|| format!("parse per-profile OAuth client {}", path.display()));
+    }
+    resolve_client_creds()
+}
+
+/// Validate and persist `source` as `profile`'s own OAuth client.
+///
+/// Why: Backs both the `setup --oauth-client <path>` CLI flag and the
+/// `add_account` MCP tool's `oauth_client_path` argument — neither ever
+/// accepts a client_id/secret inline (the MCP arg is a file path so raw
+/// secrets never appear in a tool call or its logs).
+/// What: Reads `source`, validates it parses as [`ClientCreds`] (flat or
+/// Google's `installed`/`web` download shape) BEFORE writing anything, then
+/// copies the raw bytes to [`profile_client_path`] and restricts the target
+/// to owner-only (0600 on Unix), matching `tokens.json` hardening. Returns
+/// the persisted path. Never logs the parsed secret values.
+/// Test: `persist_and_resolve_roundtrip`, `persist_rejects_malformed_source`,
+/// `persist_restricts_permissions_on_unix` (cfg(unix)).
+pub fn persist_profile_client(profile: &str, source: &Path) -> Result<PathBuf> {
+    let data = std::fs::read_to_string(source)
+        .with_context(|| format!("read OAuth client file {}", source.display()))?;
+    parse_client_creds_json(&data)
+        .with_context(|| format!("invalid OAuth client JSON in {}", source.display()))?;
+
+    let target = profile_client_path(profile);
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent).with_context(|| format!("mkdir {}", parent.display()))?;
+    }
+    std::fs::write(&target, &data).with_context(|| format!("write {}", target.display()))?;
+    restrict_to_owner(&target)?;
+    Ok(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::auth::test_support::{EnvGuard, fresh_temp_home};
+    use serial_test::serial;
+
+    const MUTATED_ENV_VARS: &[&str] = &[
+        "HOME",
+        "GOOGLE_OAUTH_CLIENT_ID",
+        "GOOGLE_OAUTH_CLIENT_SECRET",
+    ];
+
+    /// Point `dirs::home_dir()` at a fresh temp dir with no env-var
+    /// credentials set, so only file-based resolution is in play.
+    fn isolated_home(label: &str) -> PathBuf {
+        let home = fresh_temp_home(label);
+        // SAFETY: caller runs under #[serial]; EnvGuard (held by the caller)
+        // restores every var on drop.
+        unsafe {
+            std::env::remove_var("GOOGLE_OAUTH_CLIENT_ID");
+            std::env::remove_var("GOOGLE_OAUTH_CLIENT_SECRET");
+            std::env::set_var("HOME", &home);
+        }
+        home
+    }
+
+    fn write_client_json(path: &Path, client_id: &str, client_secret: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(
+            path,
+            format!(r#"{{"client_id":"{client_id}","client_secret":"{client_secret}"}}"#),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_prefers_per_profile_file_over_global() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        let home = isolated_home("prefer-per-profile");
+        write_client_json(
+            &home.join(".gworkspace-mcp").join("oauth_client.json"),
+            "global-id",
+            "global-secret",
+        );
+        write_client_json(&profile_client_path("work"), "profile-id", "profile-secret");
+
+        let creds = resolve_client_creds_for_profile("work").expect("resolve");
+        assert_eq!(creds.client_id, "profile-id");
+        assert_eq!(creds.client_secret, "profile-secret");
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_falls_back_to_global_when_absent() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        let home = isolated_home("fallback-global");
+        write_client_json(
+            &home.join(".gworkspace-mcp").join("oauth_client.json"),
+            "global-id",
+            "global-secret",
+        );
+
+        let creds = resolve_client_creds_for_profile("legacy").expect("resolve");
+        assert_eq!(
+            creds.client_id, "global-id",
+            "a profile with no per-profile client file must keep using the global one"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_errors_when_neither_source_exists() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        isolated_home("no-creds-anywhere");
+
+        let err = resolve_client_creds_for_profile("ghost").unwrap_err();
+        assert!(
+            err.to_string().contains("no OAuth client credentials"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_propagates_malformed_per_profile_file() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        let home = isolated_home("malformed-per-profile");
+        write_client_json(
+            &home.join(".gworkspace-mcp").join("oauth_client.json"),
+            "global-id",
+            "global-secret",
+        );
+        let broken = profile_client_path("broken");
+        std::fs::create_dir_all(broken.parent().unwrap()).unwrap();
+        std::fs::write(&broken, "not json").unwrap();
+
+        let err = resolve_client_creds_for_profile("broken").unwrap_err();
+        assert!(
+            !err.to_string().contains("global-id"),
+            "must not silently substitute the global client on a broken per-profile file: {err}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn persist_and_resolve_roundtrip() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        isolated_home("persist-roundtrip");
+        let source_dir = std::env::temp_dir().join(format!("gw-src-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source = source_dir.join("client.json");
+        write_client_json(&source, "new-id", "new-secret");
+
+        let target = persist_profile_client("work", &source).expect("persist");
+        assert_eq!(target, profile_client_path("work"));
+
+        let creds = resolve_client_creds_for_profile("work").expect("resolve after persist");
+        assert_eq!(creds.client_id, "new-id");
+        assert_eq!(creds.client_secret, "new-secret");
+        assert_eq!(
+            profile_client_source("work"),
+            ClientSource::PerProfile(target)
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn persist_rejects_malformed_source() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        isolated_home("persist-rejects");
+        let source_dir = std::env::temp_dir().join(format!("gw-src-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source = source_dir.join("client.json");
+        std::fs::write(&source, "not json").unwrap();
+
+        let err = persist_profile_client("work", &source).unwrap_err();
+        assert!(err.to_string().contains("invalid OAuth client"), "{err}");
+        assert!(
+            !profile_client_path("work").exists(),
+            "a malformed source must never be written to the profile client path"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[serial]
+    fn persist_restricts_permissions_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        isolated_home("persist-perms");
+        let source_dir = std::env::temp_dir().join(format!("gw-src-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source = source_dir.join("client.json");
+        write_client_json(&source, "id", "secret");
+
+        let target = persist_profile_client("work", &source).expect("persist");
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+    }
+
+    #[test]
+    #[serial]
+    fn profile_client_source_reports_global_and_per_profile() {
+        let _guard = EnvGuard::capture(MUTATED_ENV_VARS);
+        isolated_home("source-labels");
+
+        assert_eq!(profile_client_source("no-file"), ClientSource::Global);
+        assert_eq!(profile_client_source("no-file").label(), "global");
+
+        write_client_json(&profile_client_path("work"), "id", "secret");
+        match profile_client_source("work") {
+            ClientSource::PerProfile(p) => assert_eq!(p, profile_client_path("work")),
+            ClientSource::Global => panic!("expected PerProfile"),
+        }
+        assert!(
+            profile_client_source("work")
+                .label()
+                .starts_with("per-profile (")
+        );
+    }
+}

--- a/crates/trusty-gworkspace/src/api/auth/oauth/flow/mod.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/flow/mod.rs
@@ -164,11 +164,13 @@ pub fn resolve_client_creds() -> Result<ClientCreds> {
 /// Why: Google's console downloads credentials as
 /// `{"installed":{"client_id":...,"client_secret":...}}`; supporting that
 /// verbatim lets users drop the file in unchanged, while a flat shape is
-/// simpler to hand-write.
+/// simpler to hand-write. `pub(super)` so `oauth::client_store` (issue #3518)
+/// can validate/parse a per-profile client file with the identical accepted
+/// shapes instead of re-implementing this.
 /// What: Accepts `{"client_id","client_secret"}` or the nested `installed`
 /// (or `web`) object.
 /// Test: `parses_flat_creds`, `parses_installed_creds`.
-fn parse_client_creds_json(data: &str) -> Result<ClientCreds> {
+pub(super) fn parse_client_creds_json(data: &str) -> Result<ClientCreds> {
     let v: serde_json::Value = serde_json::from_str(data).context("invalid client creds JSON")?;
     let obj = v.get("installed").or_else(|| v.get("web")).unwrap_or(&v);
     let client_id = obj
@@ -355,7 +357,14 @@ pub async fn run_consent_with(
     timeout: std::time::Duration,
     on_auth_url: impl FnOnce(&str),
 ) -> Result<ConsentOutcome> {
-    let creds = resolve_client_creds()?;
+    // Issue #3518: resolve THIS profile's own client (persisted via
+    // `setup --oauth-client` / `add_account`'s `oauth_client_path`) if it has
+    // one, falling back to the global client otherwise. The minted refresh
+    // token is bound to whichever client authorizes it, so authorization and
+    // every later refresh (`OAuthManager::refresh`) MUST agree on the same
+    // client for a given profile — this is the single call site that decides
+    // it for authorization.
+    let creds = super::client_store::resolve_client_creds_for_profile(profile)?;
 
     let existing = storage.load()?;
     let set_default = should_set_default(default_mode, profile, &existing);

--- a/crates/trusty-gworkspace/src/api/auth/oauth/mod.rs
+++ b/crates/trusty-gworkspace/src/api/auth/oauth/mod.rs
@@ -6,15 +6,26 @@
 //! interactive flow while writing the identical on-disk token schema.
 //! What: `pkce` holds the offline crypto/encoding primitives, `callback`
 //! runs the loopback redirect receiver, and `flow` orchestrates the end-to-end
-//! consent → token-exchange → persist sequence.
+//! consent → token-exchange → persist sequence. `client_store` (issue #3518)
+//! adds PER-PROFILE OAuth client persistence/resolution so a profile can
+//! authorize (and later refresh) against its own client instead of the
+//! shared global one — `flow::run_consent_with` and `manager::OAuthManager`
+//! both resolve through it.
 //! Test: `pkce`, `callback`, and the pure helpers in `flow` are unit-tested;
 //! the live browser round-trip is deferred (needs real Google creds).
+//! `client_store`'s file-resolution logic is fully unit-tested (isolated
+//! `HOME`); `manager`'s wiremock tests cover the end-to-end refresh choice.
 
 pub mod callback;
+pub mod client_store;
 pub mod errors;
 pub mod flow;
 pub mod pkce;
 
+pub use client_store::{
+    ClientSource, persist_profile_client, profile_client_path, profile_client_source,
+    resolve_client_creds_for_profile,
+};
 pub use flow::{
     ClientCreds, ConsentOutcome, DefaultMode, resolve_client_creds, run_consent, run_consent_with,
 };

--- a/crates/trusty-gworkspace/src/api/auth/perms.rs
+++ b/crates/trusty-gworkspace/src/api/auth/perms.rs
@@ -1,0 +1,29 @@
+//! Shared owner-only (0600) file permission hardening for on-disk secrets.
+//!
+//! Why: `tokens.json` and per-profile OAuth client files (issue #3518) both
+//! hold credential material and must be unreadable by other local users;
+//! duplicating the chmod logic across `storage` and `oauth::client_store`
+//! would drift.
+//! What: [`restrict_to_owner`] chmods 0600 on Unix; no-op elsewhere (Windows
+//! ACLs already default to the owning user for files under the user profile).
+//! Test: `storage::tests::save_restricts_permissions_on_unix` and
+//! `oauth::client_store::tests::persist_restricts_permissions_on_unix` both
+//! exercise this via their callers.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Restrict `path` to owner read/write only (Unix: mode 0600).
+#[cfg(unix)]
+pub fn restrict_to_owner(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("chmod 0600 {}", path.display()))
+}
+
+/// No-op on non-Unix targets.
+#[cfg(not(unix))]
+pub fn restrict_to_owner(_path: &Path) -> Result<()> {
+    Ok(())
+}

--- a/crates/trusty-gworkspace/src/api/auth/test_support.rs
+++ b/crates/trusty-gworkspace/src/api/auth/test_support.rs
@@ -1,0 +1,54 @@
+//! Shared test-only helpers for env-mutating OAuth credential tests.
+//!
+//! Why: Both `manager` and `oauth::client_store` tests need to point
+//! `dirs::home_dir()` at an isolated temp directory (to exercise the
+//! per-profile-client / global-client-fallback file resolution, issue #3518)
+//! without ever touching the real `~/.gworkspace-mcp`. Duplicating this per
+//! module risks drift, and every caller must run `#[serial]` since `HOME` is
+//! process-global state.
+//! What: [`EnvGuard`] snapshots/restores a fixed set of env vars (RAII, even
+//! on panic); [`fresh_temp_home`] creates a scratch dir with a
+//! `.gworkspace-mcp/` subdir already present.
+//! Test: exercised transitively by every caller (`manager::tests`,
+//! `oauth::client_store::tests`).
+
+use std::path::PathBuf;
+
+/// RAII guard that snapshots and restores a fixed set of env vars.
+///
+/// Why: Tests that override `HOME` (and OAuth client env vars) to isolate
+/// credential-resolution behavior must never leak that override into later,
+/// unrelated tests — even if the test body panics.
+/// What: Captures each var's current value on construction; `Drop` restores
+/// it (`set_var` if it was present, `remove_var` if absent).
+pub(crate) struct EnvGuard {
+    saved: Vec<(&'static str, Option<String>)>,
+}
+
+impl EnvGuard {
+    pub(crate) fn capture(vars: &[&'static str]) -> Self {
+        let saved = vars.iter().map(|&v| (v, std::env::var(v).ok())).collect();
+        Self { saved }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in &self.saved {
+            // SAFETY: every caller of `EnvGuard` runs under `#[serial]`, so no
+            // other thread reads/writes these vars concurrently.
+            match v {
+                Some(val) => unsafe { std::env::set_var(k, val) },
+                None => unsafe { std::env::remove_var(k) },
+            }
+        }
+    }
+}
+
+/// Build a fresh temp dir with a `.gworkspace-mcp/` subdir, never touching
+/// the real `~/.gworkspace-mcp`.
+pub(crate) fn fresh_temp_home(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("gw-test-home-{label}-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(dir.join(".gworkspace-mcp")).expect("mkdir temp home");
+    dir
+}

--- a/crates/trusty-gworkspace/src/api/client.rs
+++ b/crates/trusty-gworkspace/src/api/client.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result, anyhow};
 use serde_json::Value;
 use tracing::{debug, warn};
 
+use crate::api::auth::oauth::resolve_client_creds_for_profile;
 use crate::api::auth::{OAuthManager, StoredToken, TokenStorage};
 
 /// Request body variants understood by [`BaseClient::send_with_retry`].
@@ -72,28 +73,31 @@ pub struct RawResponse {
 ///
 /// Why: One handle per process; `Arc<TokenStorage>` because tools may run
 /// concurrently and we don't want to re-read the file each call.
-/// What: Holds an `Option<OAuthManager>` — `None` when env credentials are
-/// missing (read-only token mode: requests still work until the token
-/// expires).
+/// What: Holds an `OAuthManager` — the OAuth CLIENT it refreshes with is no
+/// longer fixed at construction time (issue #3518): `get_access_token` /
+/// `send_with_retry` each resolve the ACTING profile's own client via
+/// [`resolve_client_creds_for_profile`] before calling `refresh`, falling
+/// back to read-only token mode (return the stale access token, no error)
+/// only when neither a per-profile nor the global client resolves for that
+/// profile.
 /// Test: Smoke test asserts construction succeeds with no env vars.
 pub struct BaseClient {
     http: reqwest::Client,
     pub(crate) storage: Arc<TokenStorage>,
-    oauth: Option<OAuthManager>,
+    oauth: OAuthManager,
 }
 
 impl BaseClient {
-    /// Construct with default token storage and optional refresh manager.
+    /// Construct with default token storage and refresh manager.
     pub fn new() -> Result<Self> {
         let storage = Arc::new(TokenStorage::new());
-        let oauth = OAuthManager::from_env()?;
         Ok(Self {
             http: reqwest::Client::builder()
                 .user_agent("trusty-gworkspace/0.1")
                 .build()
                 .context("build reqwest client")?,
             storage,
-            oauth,
+            oauth: OAuthManager::new(),
         })
     }
 
@@ -102,21 +106,22 @@ impl BaseClient {
         &self.storage
     }
 
-    /// Test-only constructor with injectable storage and no refresh manager.
+    /// Test-only constructor with injectable storage.
     ///
     /// Why: `services::accounts`' account-management tools (`set_default_account`,
     /// `remove_account`) only ever touch `TokenStorage`, never the network, so
     /// their tests need a `BaseClient` backed by a temp `TokenStorage` without
     /// touching `~/.gworkspace-mcp` or real OAuth credentials.
-    /// What: Builds a plain `reqwest::Client`; `oauth` is always `None` since
-    /// nothing exercised by those tests calls `get_access_token`'s refresh path.
+    /// What: Builds a plain `reqwest::Client` and a stock `OAuthManager`
+    /// (never invoked over the network by those tests, since nothing they
+    /// exercise calls `get_access_token`'s refresh path).
     /// Test: exercised by `services::accounts::tests`.
     #[cfg(test)]
     pub(crate) fn for_test(storage: TokenStorage) -> Self {
         Self {
             http: reqwest::Client::new(),
             storage: Arc::new(storage),
-            oauth: None,
+            oauth: OAuthManager::new(),
         }
     }
 
@@ -145,19 +150,32 @@ impl BaseClient {
     }
 
     /// Return an access token, refreshing if expired and possible.
+    ///
+    /// Why: A refresh is only possible when SOME OAuth client resolves for
+    /// this profile — its own per-profile client, or (issue #3518) the
+    /// global fallback. Checking that up front (rather than letting
+    /// `OAuthManager::refresh` fail) keeps the existing graceful
+    /// read-only-token degradation distinct from a genuine HTTP/refresh
+    /// failure, which must still propagate as an error.
+    /// What: Resolves credentials for `profile` via
+    /// `resolve_client_creds_for_profile`; on success, refreshes and returns
+    /// the new access token (any HTTP/refresh error propagates). When no
+    /// client resolves at all, warns and returns the stale access token
+    /// instead of failing the call.
     pub async fn get_access_token(&self, account: Option<&str>) -> Result<String> {
         let (profile, stored) = self.resolve_stored(account)?;
         if !stored.token.is_expired() {
             return Ok(stored.token.access_token);
         }
-        if let Some(oauth) = &self.oauth {
+        if resolve_client_creds_for_profile(&profile).is_ok() {
             debug!(profile = %profile, "refreshing expired token");
-            let new = oauth.refresh(&self.storage, &profile).await?;
+            let new = self.oauth.refresh(&self.storage, &profile).await?;
             return Ok(new.access_token);
         }
         warn!(
             profile = %profile,
-            "token expired and refresh disabled (no GOOGLE_OAUTH_CLIENT_ID/SECRET); returning stale token"
+            "token expired and refresh disabled (no OAuth client credentials for this profile); \
+             returning stale token"
         );
         Ok(stored.token.access_token)
     }
@@ -188,8 +206,10 @@ impl BaseClient {
             .with_context(|| format!("{method} {url}"))?;
         if resp.status() == reqwest::StatusCode::UNAUTHORIZED {
             warn!(url = %url, "401 received — forcing refresh and retrying once");
-            if let (Some(oauth), Ok((profile, _))) = (&self.oauth, self.resolve_stored(account)) {
-                let new = oauth.refresh(&self.storage, &profile).await?;
+            if let Ok((profile, _)) = self.resolve_stored(account)
+                && resolve_client_creds_for_profile(&profile).is_ok()
+            {
+                let new = self.oauth.refresh(&self.storage, &profile).await?;
                 let retry = body.apply(
                     self.http
                         .request(method.clone(), url)

--- a/crates/trusty-gworkspace/src/api/services/accounts.rs
+++ b/crates/trusty-gworkspace/src/api/services/accounts.rs
@@ -4,39 +4,51 @@
 //! and add profiles without shelling out to the `trusty-gworkspace-mcp`
 //! CLI (issue #3503). `list_accounts` was the only MCP-exposed surface;
 //! `set_default_account` / `remove_account` / `add_account` close that gap.
+//! `add_account` also accepts an optional `oauth_client_path` (issue #3518)
+//! so a profile can authorize against its OWN OAuth client instead of the
+//! shared global one — see its doc comment.
 //! What: `set_default_account` / `remove_account` wrap the same lock-guarded
 //! `TokenStorage` methods the CLI uses (`api::auth::storage`, #3502) so both
 //! surfaces share one mutation implementation. `add_account` reuses the
 //! native PKCE consent flow (`api::auth::oauth::flow::run_consent_with`) —
-//! see its doc comment for the blocking-call design and why.
+//! see its doc comment for the blocking-call design and why. `accounts_json`
+//! labels every profile with which OAuth client it uses
+//! (`oauth::profile_client_source`).
 //! Test: Indirect — covered by storage tests plus the argument-validation
 //! smoke tests below.
 
+use std::path::Path;
 use std::time::Duration;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use serde_json::{Value, json};
 
-use crate::api::auth::oauth::{DefaultMode, flow};
+use crate::api::auth::oauth::{self, DefaultMode, flow};
 use crate::api::client::BaseClient;
 use crate::api::services::{opt_str, require_str};
 
-/// Build the `[{name, email, is_default}, ...]` JSON array from storage.
+/// Build the `[{name, email, is_default, client}, ...]` JSON array from
+/// storage.
 ///
 /// Why: Shared by `list_accounts` and every mutating tool below so each
 /// response includes an up-to-date account list without repeating the
-/// row-to-JSON mapping.
-/// What: Reads via `TokenStorage::list_accounts` (no network).
+/// row-to-JSON mapping. `client` (issue #3518) reports `"global"` or
+/// `"per-profile (<path>)"` so a per-profile-client misconfiguration is
+/// diagnosable from the same response, without a separate `doctor` round trip.
+/// What: Reads via `TokenStorage::list_accounts` plus
+/// `oauth::profile_client_source` per profile (no network).
 /// Test: Covered indirectly via `TokenStorage` storage round-trip tests.
 fn accounts_json(client: &BaseClient) -> Result<Vec<Value>> {
     let rows = client.storage().list_accounts()?;
     Ok(rows
         .into_iter()
         .map(|(name, email, is_default)| {
+            let client_label = oauth::profile_client_source(&name).label();
             json!({
                 "name": name,
                 "email": email,
                 "is_default": is_default,
+                "client": client_label,
             })
         })
         .collect())
@@ -127,13 +139,22 @@ const ADD_ACCOUNT_TIMEOUT_MAX_SECS: u64 = 90;
 /// What: Args: `profile` (optional, defaults to the shared default profile
 /// name), `make_default` / `no_default` (mutually exclusive, mirrors `setup`
 /// flags; default is `DefaultMode::Auto`), `timeout_secs` (optional, clamped
-/// to the bounds above). Returns `{"status": "authorized", "auth_url", ...}`
-/// on success, or `{"status": "timed_out", "auth_url", "message"}` if the
-/// browser step didn't complete in time — the caller can retry `add_account`
-/// for a fresh URL. Any other failure (e.g. missing OAuth client
-/// credentials) propagates as a tool error.
+/// to the bounds above), `oauth_client_path` (optional, issue #3518 — a FILE
+/// PATH to a JSON file holding this profile's OWN OAuth client; never a raw
+/// client_id/secret, so no secret material ever appears in a tool call or its
+/// logs). When `oauth_client_path` is given it is validated and persisted to
+/// `~/.gworkspace-mcp/clients/<profile>.json` BEFORE the consent flow runs
+/// (fast-failing on a missing/malformed file with no network call), so the
+/// authorization that follows uses that client, and every later refresh for
+/// this profile reuses it automatically. Returns
+/// `{"status": "authorized", "auth_url", ...}` on success, or
+/// `{"status": "timed_out", "auth_url", "message"}` if the browser step
+/// didn't complete in time — the caller can retry `add_account` for a fresh
+/// URL. Any other failure (e.g. missing OAuth client credentials, or an
+/// invalid `oauth_client_path`) propagates as a tool error.
 /// Test: `add_account_rejects_conflicting_default_flags`,
-/// `add_account_clamps_timeout_bounds`.
+/// `add_account_clamps_timeout_bounds`,
+/// `add_account_rejects_invalid_oauth_client_path_before_consent`.
 pub async fn add_account(client: &BaseClient, args: Value) -> Result<Value> {
     let profile = flow::effective_profile(opt_str(&args, "profile"));
     let no_default = args
@@ -157,6 +178,11 @@ pub async fn add_account(client: &BaseClient, args: Value) -> Result<Value> {
         DefaultMode::Auto
     };
     let timeout = clamp_timeout(args.get("timeout_secs").and_then(Value::as_u64));
+
+    if let Some(path) = opt_str(&args, "oauth_client_path") {
+        oauth::persist_profile_client(&profile, Path::new(path))
+            .with_context(|| format!("persist OAuth client for profile '{profile}'"))?;
+    }
 
     // `std::sync::Mutex` (not `RefCell`) because the closure below is held
     // across an `.await` inside a `Send` future (`run_stdio_loop` requires
@@ -209,7 +235,9 @@ mod tests {
     use super::*;
     use crate::api::auth::TokenStorage;
     use crate::api::auth::models::{OAuthToken, StoredToken, TokenMetadata};
+    use crate::api::auth::test_support::{EnvGuard, fresh_temp_home};
     use chrono::{Duration as ChronoDuration, Utc};
+    use serial_test::serial;
     use std::collections::HashMap;
 
     fn test_client() -> BaseClient {
@@ -316,5 +344,62 @@ mod tests {
             Duration::from_secs(ADD_ACCOUNT_TIMEOUT_MAX_SECS)
         );
         assert_eq!(clamp_timeout(Some(45)), Duration::from_secs(45));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn add_account_rejects_invalid_oauth_client_path_before_consent() {
+        // Issue #3518: an invalid `oauth_client_path` must fail fast — no
+        // network call, no browser, no partial file — before entering the
+        // (slow, network-touching) consent flow at all.
+        let _guard = EnvGuard::capture(&["HOME"]);
+        let home = fresh_temp_home("add-account-bad-client");
+        // SAFETY: serialised via #[serial]; EnvGuard restores on drop.
+        unsafe { std::env::set_var("HOME", &home) };
+
+        let client = test_client();
+        let missing = home.join("does-not-exist.json");
+        let err = add_account(
+            &client,
+            json!({
+                "profile": "newprof",
+                "oauth_client_path": missing.to_string_lossy(),
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("OAuth client"), "{err}");
+        assert!(
+            !oauth::profile_client_path("newprof").exists(),
+            "a failed persist must never leave a partial per-profile client file"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn list_accounts_labels_client_source() {
+        let _guard = EnvGuard::capture(&["HOME"]);
+        let home = fresh_temp_home("list-accounts-client-label");
+        // SAFETY: see above.
+        unsafe { std::env::set_var("HOME", &home) };
+
+        let client = test_client();
+        seed(&client);
+        // Give profile "a" its own client; "b" keeps using the global one.
+        let source_dir = std::env::temp_dir().join(format!("gw-src-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let source = source_dir.join("client.json");
+        std::fs::write(&source, r#"{"client_id":"id","client_secret":"secret"}"#).unwrap();
+        oauth::persist_profile_client("a", &source).unwrap();
+
+        let result = list_accounts(&client, json!({})).await.unwrap();
+        let accounts = result["accounts"].as_array().unwrap();
+        let a = accounts.iter().find(|v| v["name"] == "a").unwrap();
+        let b = accounts.iter().find(|v| v["name"] == "b").unwrap();
+        assert!(
+            a["client"].as_str().unwrap().starts_with("per-profile ("),
+            "{a}"
+        );
+        assert_eq!(b["client"], "global");
     }
 }

--- a/crates/trusty-gworkspace/src/cli/accounts.rs
+++ b/crates/trusty-gworkspace/src/cli/accounts.rs
@@ -15,13 +15,17 @@
 use anyhow::Result;
 
 use crate::api::auth::TokenStorage;
+use crate::api::auth::oauth::profile_client_source;
 
 /// Print all stored profiles as an aligned table.
 ///
 /// Why: The primary discovery command — shows which `account` values the MCP
-/// tools accept and which one is the default.
+/// tools accept, which one is the default, and (issue #3518) which OAuth
+/// client each profile authorizes/refreshes with, so a per-profile-client
+/// misconfiguration is diagnosable from this one command.
 /// What: Loads via [`TokenStorage::list_accounts`] and prints one row per
-/// profile; prints a hint when empty.
+/// profile (name, email, default marker, client source); prints a hint when
+/// empty.
 /// Test: Output is cosmetic; the underlying listing is covered by storage
 /// round-trip tests.
 pub fn list(storage: &TokenStorage) -> Result<()> {
@@ -30,10 +34,11 @@ pub fn list(storage: &TokenStorage) -> Result<()> {
         println!("No accounts found. Run `trusty-gworkspace-mcp setup` to authorize one.");
         return Ok(());
     }
-    println!("{:<24} {:<32} DEFAULT", "PROFILE", "EMAIL");
+    println!("{:<24} {:<32} {:<8} CLIENT", "PROFILE", "EMAIL", "DEFAULT");
     for (name, email, is_default) in rows {
+        let client = profile_client_source(&name).label();
         println!(
-            "{:<24} {:<32} {}",
+            "{:<24} {:<32} {:<8} {client}",
             name,
             email.unwrap_or_else(|| "-".to_string()),
             if is_default { "*" } else { "" }

--- a/crates/trusty-gworkspace/src/cli/doctor.rs
+++ b/crates/trusty-gworkspace/src/cli/doctor.rs
@@ -23,7 +23,9 @@ use anyhow::Result;
 use crate::api::auth::TokenStorage;
 use crate::api::auth::oauth::errors::is_invalid_grant;
 use crate::api::auth::oauth::flow::ClientCreds;
-use crate::api::auth::oauth::resolve_client_creds;
+use crate::api::auth::oauth::{
+    profile_client_source, resolve_client_creds, resolve_client_creds_for_profile,
+};
 use crate::api::constants::OAUTH_TOKEN_URL;
 
 /// Per-profile refresh-token health, as classified by the live probe.
@@ -53,16 +55,19 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(6);
 /// Run the doctor check and print a report to stdout.
 ///
 /// Why: Human-facing entry point for `trusty-gworkspace-mcp doctor`.
-/// What: Prints the static credential/storage checks, then — when client
-/// credentials resolve — live-probes each stored profile and prints its health.
-/// Always returns `Ok` (the report *is* the result); never mutates tokens.json.
+/// What: Prints the static credential/storage checks, then live-probes each
+/// stored profile using ITS OWN resolved OAuth client (issue #3518:
+/// per-profile client if configured, else the global one — see
+/// `resolve_client_creds_for_profile`) and prints its health, labeled with
+/// which client it used. Always returns `Ok` (the report *is* the result);
+/// never mutates tokens.json.
 /// Test: Delegates to `report_lines` and `health_lines`, both unit-tested.
 pub async fn run(storage: &TokenStorage) -> Result<()> {
-    let creds = resolve_client_creds().ok();
+    let global_creds_ok = resolve_client_creds().is_ok();
     let accounts = storage.list_accounts().unwrap_or_default();
     let has_default = accounts.iter().any(|(_, _, d)| *d);
 
-    for line in report_lines(creds.is_some(), accounts.len(), has_default) {
+    for line in report_lines(global_creds_ok, accounts.len(), has_default) {
         println!("{line}");
     }
 
@@ -72,36 +77,33 @@ pub async fn run(storage: &TokenStorage) -> Result<()> {
 
     println!();
     println!("Per-profile refresh-token health:");
-    match &creds {
-        Some(creds) => {
-            // Never fall back to `Client::default()` on builder failure: that
-            // client has no request timeout, so a hung endpoint would stall
-            // doctor indefinitely. If the bounded client can't be built, report
-            // every profile as Unknown rather than probe without a timeout.
-            match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
-                Ok(http) => {
-                    for (name, email, _is_default) in &accounts {
-                        let result = probe_profile(&http, storage, creds, name).await;
-                        for line in health_lines(name, email.as_deref(), &result) {
-                            println!("{line}");
-                        }
-                    }
-                }
-                Err(e) => {
-                    eprintln!("      Could not build a bounded HTTP client: {e}");
-                    for (name, email, _is_default) in &accounts {
-                        for line in health_lines(name, email.as_deref(), &ProbeResult::Unknown) {
-                            println!("{line}");
-                        }
-                    }
+    // Never fall back to `Client::default()` on builder failure: that client
+    // has no request timeout, so a hung endpoint would stall doctor
+    // indefinitely. If the bounded client can't be built, report every
+    // profile as Unknown rather than probe without a timeout.
+    match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
+        Ok(http) => {
+            for (name, email, _is_default) in &accounts {
+                let client_label = profile_client_source(name).label();
+                let result = match resolve_client_creds_for_profile(name) {
+                    Ok(creds) => probe_profile(&http, storage, &creds, name).await,
+                    Err(_) => ProbeResult::Unknown,
+                };
+                for line in health_lines(name, email.as_deref(), &client_label, &result) {
+                    println!("{line}");
                 }
             }
         }
-        None => {
-            println!(
-                "      Skipped — set OAuth client credentials to enable live probing \
-                 (see the check above)."
-            );
+        Err(e) => {
+            eprintln!("      Could not build a bounded HTTP client: {e}");
+            for (name, email, _is_default) in &accounts {
+                let client_label = profile_client_source(name).label();
+                for line in
+                    health_lines(name, email.as_deref(), &client_label, &ProbeResult::Unknown)
+                {
+                    println!("{line}");
+                }
+            }
         }
     }
 
@@ -167,11 +169,15 @@ async fn probe_profile(
 pub fn report_lines(creds_ok: bool, account_count: usize, has_default: bool) -> Vec<String> {
     let mut lines = vec!["trusty-gworkspace-mcp doctor".to_string(), String::new()];
 
-    lines.push(format!("[{}] OAuth client credentials", mark(creds_ok)));
+    lines.push(format!(
+        "[{}] Global OAuth client credentials",
+        mark(creds_ok)
+    ));
     if !creds_ok {
         lines.push(
             "      Set GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET, or write \
-             ~/.gworkspace-mcp/oauth_client.json"
+             ~/.gworkspace-mcp/oauth_client.json (a profile with its own per-profile client, \
+             see `setup --oauth-client`, does not need this)."
                 .to_string(),
         );
     }
@@ -203,13 +209,22 @@ pub fn report_lines(creds_ok: bool, account_count: usize, has_default: bool) -> 
 ///
 /// Why: The live-probe verdict must render identically whether it came from a
 /// real network call or a test — and a `Dead` profile must always print the
-/// exact re-auth command so the fix is copy-pasteable.
-/// What: `Live` → one OK line (email + access-token lifetime); `Dead` → a
-/// failure line plus the `trusty-gworkspace-mcp setup --profile <name>` command;
-/// `Unknown` → one graceful "could not determine" line (never fatal).
+/// exact re-auth command so the fix is copy-pasteable. Issue #3518: each line
+/// also names which OAuth client (`global` or `per-profile (<path>)`) the
+/// profile actually used, so a misconfigured per-profile client is
+/// diagnosable straight from `doctor` output.
+/// What: `Live` → one OK line (email + access-token lifetime + client);
+/// `Dead` → a failure line plus the `trusty-gworkspace-mcp setup --profile
+/// <name>` command; `Unknown` → one graceful "could not determine" line
+/// (never fatal).
 /// Test: `health_lines_ok_shows_email`, `health_lines_dead_names_setup_command`,
 /// `health_lines_unknown_is_graceful`.
-pub fn health_lines(profile: &str, email: Option<&str>, result: &ProbeResult) -> Vec<String> {
+pub fn health_lines(
+    profile: &str,
+    email: Option<&str>,
+    client_label: &str,
+    result: &ProbeResult,
+) -> Vec<String> {
     let who = email.unwrap_or("email unknown");
     match result {
         ProbeResult::Live { expires_in } => {
@@ -217,14 +232,20 @@ pub fn health_lines(profile: &str, email: Option<&str>, result: &ProbeResult) ->
                 Some(secs) => format!("access token valid ~{secs}s"),
                 None => "access token valid".to_string(),
             };
-            vec![format!("[+] {profile}: OK ({who}, {expiry})")]
+            vec![format!(
+                "[+] {profile}: OK ({who}, {expiry}, client: {client_label})"
+            )]
         }
         ProbeResult::Dead => vec![
-            format!("[!] {profile}: DEAD — refresh token for {who} is expired or revoked"),
+            format!(
+                "[!] {profile}: DEAD — refresh token for {who} is expired or revoked \
+                 (client: {client_label})"
+            ),
             format!("      re-authenticate with: trusty-gworkspace-mcp setup --profile {profile}"),
         ],
         ProbeResult::Unknown => vec![format!(
-            "[?] {profile}: UNKNOWN — could not reach Google to verify ({who}); check your connection"
+            "[?] {profile}: UNKNOWN — could not reach Google to verify ({who}, client: \
+             {client_label}); check your connection"
         )],
     }
 }
@@ -242,7 +263,7 @@ mod tests {
     fn report_lines_flags_missing_creds() {
         let lines = report_lines(false, 0, false);
         let joined = lines.join("\n");
-        assert!(joined.contains("[!] OAuth client credentials"));
+        assert!(joined.contains("[!] Global OAuth client credentials"));
         assert!(joined.contains("GOOGLE_OAUTH_CLIENT_ID"));
         assert!(joined.contains("Run `trusty-gworkspace-mcp setup`"));
         assert!(joined.contains("need attention"));
@@ -252,7 +273,7 @@ mod tests {
     fn report_lines_all_green() {
         let lines = report_lines(true, 2, true);
         let joined = lines.join("\n");
-        assert!(joined.contains("[+] OAuth client credentials"));
+        assert!(joined.contains("[+] Global OAuth client credentials"));
         assert!(joined.contains("Authorized accounts: 2"));
         assert!(joined.contains("All checks passed."));
         assert!(!joined.contains("need attention"));
@@ -273,6 +294,7 @@ mod tests {
         let lines = health_lines(
             "work",
             Some("user@example.com"),
+            "global",
             &ProbeResult::Live {
                 expires_in: Some(3599),
             },
@@ -281,6 +303,7 @@ mod tests {
         assert!(joined.contains("[+] work: OK"), "OK marker: {joined}");
         assert!(joined.contains("user@example.com"), "email shown: {joined}");
         assert!(joined.contains("3599s"), "expiry shown: {joined}");
+        assert!(joined.contains("client: global"), "client shown: {joined}");
         assert!(
             !joined.contains("setup --profile"),
             "a healthy profile must not suggest re-auth: {joined}"
@@ -289,10 +312,19 @@ mod tests {
 
     #[test]
     fn health_lines_dead_names_setup_command() {
-        let lines = health_lines("work", Some("user@example.com"), &ProbeResult::Dead);
+        let lines = health_lines(
+            "work",
+            Some("user@example.com"),
+            "per-profile (/home/u/.gworkspace-mcp/clients/work.json)",
+            &ProbeResult::Dead,
+        );
         let joined = lines.join("\n");
         assert!(joined.contains("DEAD"), "dead marker: {joined}");
         assert!(joined.contains("expired or revoked"), "cause: {joined}");
+        assert!(
+            joined.contains("client: per-profile ("),
+            "per-profile client label shown: {joined}"
+        );
         assert!(
             joined.contains("trusty-gworkspace-mcp setup --profile work"),
             "must name the exact re-auth command for the dead profile: {joined}"
@@ -301,7 +333,7 @@ mod tests {
 
     #[test]
     fn health_lines_unknown_is_graceful() {
-        let lines = health_lines("work", None, &ProbeResult::Unknown);
+        let lines = health_lines("work", None, "global", &ProbeResult::Unknown);
         let joined = lines.join("\n");
         assert!(joined.contains("UNKNOWN"), "unknown marker: {joined}");
         assert!(

--- a/crates/trusty-gworkspace/src/cli/mod.rs
+++ b/crates/trusty-gworkspace/src/cli/mod.rs
@@ -14,11 +14,13 @@
 pub mod accounts;
 pub mod doctor;
 
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 use crate::api::auth::TokenStorage;
-use crate::api::auth::oauth::{DefaultMode, flow, run_consent};
+use crate::api::auth::oauth::{DefaultMode, flow, persist_profile_client, run_consent};
 
 /// `trusty-gworkspace-mcp` — Google Workspace MCP server + onboarding CLI.
 ///
@@ -71,6 +73,14 @@ pub enum Command {
         /// context (the loopback callback still captures the redirect).
         #[arg(long = "no-browser", visible_alias = "print-url")]
         no_browser: bool,
+        /// Authorize this profile against a SPECIFIC OAuth client instead of
+        /// the shared global one (issue #3518). Path to a JSON file — flat
+        /// `{"client_id","client_secret"}` or Google's downloaded
+        /// `installed`/`web` shape. Persisted to
+        /// `~/.gworkspace-mcp/clients/<profile>.json` (0600) and reused on
+        /// every future refresh for this profile.
+        #[arg(long = "oauth-client", value_name = "PATH")]
+        oauth_client: Option<PathBuf>,
     },
     /// Check OAuth client credentials and token state.
     Doctor,
@@ -117,8 +127,17 @@ pub async fn dispatch(command: Command) -> Result<()> {
             no_default,
             make_default,
             no_browser,
+            oauth_client,
         } => {
             let profile = flow::effective_profile(profile.as_deref());
+            if let Some(path) = &oauth_client {
+                let target = persist_profile_client(&profile, path)?;
+                println!(
+                    "Using OAuth client from {} for profile '{profile}' (persisted to {}).",
+                    path.display(),
+                    target.display()
+                );
+            }
             let mode = if no_default {
                 DefaultMode::Never
             } else if make_default {
@@ -174,7 +193,13 @@ mod tests {
             Cli::try_parse_from(["gworkspace-mcp", "setup", "--profile", "work"]).expect("setup");
         assert!(matches!(
             setup.command,
-            Some(Command::Setup { profile: Some(p), no_default: false, make_default: false, no_browser: false }) if p == "work"
+            Some(Command::Setup {
+                profile: Some(p),
+                no_default: false,
+                make_default: false,
+                no_browser: false,
+                oauth_client: None,
+            }) if p == "work"
         ));
 
         let doctor = Cli::try_parse_from(["gworkspace-mcp", "doctor"]).expect("doctor");
@@ -213,6 +238,7 @@ mod tests {
                 no_default: true,
                 make_default: false,
                 no_browser: false,
+                oauth_client: None,
             })
         ));
     }
@@ -228,6 +254,7 @@ mod tests {
                 no_default: false,
                 make_default: true,
                 no_browser: false,
+                oauth_client: None,
             })
         ));
     }
@@ -264,5 +291,25 @@ mod tests {
             result.is_err(),
             "--no-default and --make-default must conflict"
         );
+    }
+
+    #[test]
+    fn setup_oauth_client_flag_parses() {
+        let cli = Cli::try_parse_from([
+            "gworkspace-mcp",
+            "setup",
+            "--profile",
+            "work",
+            "--oauth-client",
+            "/tmp/client.json",
+        ])
+        .expect("parse");
+        assert!(matches!(
+            cli.command,
+            Some(Command::Setup {
+                oauth_client: Some(p),
+                ..
+            }) if p.as_path() == std::path::Path::new("/tmp/client.json")
+        ));
     }
 }

--- a/crates/trusty-gworkspace/src/tools/accounts.rs
+++ b/crates/trusty-gworkspace/src/tools/accounts.rs
@@ -18,7 +18,8 @@ use serde_json::{Value, json};
 pub(super) fn append(tools: &mut Vec<Value>) {
     tools.push(tool(
         "list_accounts",
-        "List configured Google Workspace account profiles available on this machine.",
+        "List configured Google Workspace account profiles available on this machine, including \
+         which OAuth client each one uses (\"global\" or a per-profile client path).",
         json!({ "account": account_schema() }),
         &[],
     ));
@@ -69,6 +70,10 @@ pub(super) fn append(tools: &mut Vec<Value>) {
             "timeout_secs": {
                 "type": "integer",
                 "description": "How long to wait for the user to complete browser consent, in seconds (clamped to 10-90; default 60).",
+            },
+            "oauth_client_path": {
+                "type": "string",
+                "description": "Optional path to a JSON file holding THIS profile's own OAuth client (flat {client_id,client_secret}, or Google's downloaded installed/web shape). When given, this profile authorizes and refreshes with that client instead of the shared global one — never pass raw client_id/secret values here, only a file path.",
             },
         }),
         &[],


### PR DESCRIPTION
## Summary

Follow-up to the multi-account work in #3502/#3503 (merged in #3510). Each
account profile can now authorize (and forever after refresh) against its
OWN OAuth client instead of the shared global one — e.g. a per-domain
"Internal" Google Workspace app.

## The correctness crux

A Google refresh token is bound to the OAuth client that issued it —
`grant_type=refresh_token` must be exchanged with the SAME client that
originally authorized the profile. This PR adds a single resolution point,
`oauth::client_store::resolve_client_creds_for_profile`, that BOTH the
consent flow (`oauth::flow::run_consent_with`) and every refresh
(`OAuthManager::refresh`) go through, so authorization and refresh can never
disagree on which client a profile uses.

## Storage representation + precedence

- Per-profile client: `~/.gworkspace-mcp/clients/<profile>.json` (0600, same
  hardening as `tokens.json`), same accepted shapes as the existing global
  file (flat `{client_id,client_secret}` or Google's `installed`/`web`
  download shape).
- Precedence: per-profile file → global `oauth_client.json`/env vars
  fallback. A malformed per-profile file is a hard error (never silently
  substitutes the global client, which would otherwise produce a confusing
  `invalid_client` failure instead).
- Backward compatible: a profile with no per-profile file keeps refreshing
  via the global client exactly as before — no migration needed.

## Surfaces

- CLI: `setup --profile <name> --oauth-client <path>`
- MCP: `add_account` accepts an optional `oauth_client_path` (a FILE PATH,
  never inline client_id/secret — no secret material ever appears in a tool
  call or log)
- `accounts list` / `list_accounts` / `doctor` all now label which client
  each profile is using (`global` or `per-profile (<path>)`)

## Key files

- `crates/trusty-gworkspace/src/api/auth/oauth/client_store.rs` (new) —
  storage/resolution/persistence
- `crates/trusty-gworkspace/src/api/auth/manager.rs` — `OAuthManager::refresh`
  resolves per-profile; test-only `token_url` override for wiremock
- `crates/trusty-gworkspace/src/api/auth/oauth/flow/mod.rs` —
  `run_consent_with` resolves per-profile instead of the global client
- `crates/trusty-gworkspace/src/api/client.rs` — `BaseClient` gates
  refresh-vs-graceful-degradation per profile
- `crates/trusty-gworkspace/src/cli/mod.rs`, `src/cli/doctor.rs`,
  `src/cli/accounts.rs`, `src/api/services/accounts.rs`,
  `src/tools/accounts.rs` — CLI/MCP surfaces + diagnostics
- `crates/trusty-gworkspace/src/api/auth/perms.rs` (new) — shared 0600
  permission helper (deduped out of `storage.rs`)

## Test plan

- [x] `refresh_uses_per_profile_client_when_present` /
      `refresh_falls_back_to_global_client_when_absent` — `wiremock`-backed,
      assert the exact `client_id`/`client_secret` sent to the token endpoint
      in each case
- [x] `resolve_prefers_per_profile_file_over_global`,
      `resolve_falls_back_to_global_when_absent`,
      `resolve_propagates_malformed_per_profile_file` — pure resolution logic
- [x] `persist_and_resolve_roundtrip`, `persist_rejects_malformed_source`,
      `persist_restricts_permissions_on_unix` — persistence + validation +
      0600 hardening
- [x] `add_account_rejects_invalid_oauth_client_path_before_consent`,
      `list_accounts_labels_client_source` — MCP wiring
- [x] `setup_oauth_client_flag_parses` — CLI flag parsing
- [x] `cargo test -p trusty-gworkspace`: 259 passed, 0 failed
- [x] `cargo fmt --check -p trusty-gworkspace`: clean
- [x] `cargo clippy -p trusty-gworkspace --all-targets -- -D warnings`: clean
- [x] `scripts/check_line_cap.sh`: 0 violations
- [x] `scripts/check_sld.sh`: 0 errors, 0 warnings

## Release note

Ships together with #3502/#3503 in one owner-gated `trusty-gworkspace`
release (no version bump/publish in this PR).

Closes #3518

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools