### PR TITLE
fix(trusty-code-gui): replace placeholder diamond with Foundry robot mark in header

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -8,6 +8,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Header brand mark — placeholder diamond replaced with the canonical
+  Foundry robot mark.** `AppHeader.svelte` rendered a literal `◆` diamond
+  glyph to the left of the "Trusty Code" wordmark — a placeholder, not the
+  brand identity (reported by Bob: the header logo was wrong). It now renders
+  the canonical Foundry / Trusty Assistant robot mark, vendored as
+  `ui/src/lib/icons/RobotIcon.svelte` from the design-system source
+  (`docs/design/UI/design-system/icons/RobotIcon.svelte`, refs #3486/#3495),
+  used in its `mono` variant at 18px and colored via the existing
+  `text-trusty-primary` header token (through `currentColor`) so it themes in
+  light/dark. Scope is the mark only — the wordmark, window title, and layout
+  are unchanged.
+
 ### Added
 
 - **CI token drift-check (refs #3486):** a new `scripts/check_token_drift.mjs`

--- a/crates/trusty-code-gui/ui/src/components/AppHeader.svelte
+++ b/crates/trusty-code-gui/ui/src/components/AppHeader.svelte
@@ -21,13 +21,16 @@
   // covers the switcher itself — this component has no branchy logic of its
   // own to test independently.
   import WorkstreamSwitcher from './WorkstreamSwitcher.svelte';
+  import RobotIcon from '../lib/icons/RobotIcon.svelte';
 </script>
 
 <header
   class="hdr flex h-14 shrink-0 items-center justify-between gap-4 border-b border-trusty-border bg-trusty-raised px-4"
 >
   <div class="flex items-center gap-2">
-    <span class="font-display text-sm font-bold tracking-wide text-trusty-primary">◆</span>
+    <span class="flex items-center text-trusty-primary">
+      <RobotIcon variant="mono" size={18} color="currentColor" />
+    </span>
     <span class="font-display text-sm font-bold uppercase tracking-wide text-trusty-text">
       Trusty Code
     </span>

--- a/crates/trusty-code-gui/ui/src/lib/icons/RobotIcon.svelte
+++ b/crates/trusty-code-gui/ui/src/lib/icons/RobotIcon.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  /**
+   * Canonical source: docs/design/UI/design-system/icons/RobotIcon.svelte
+   * (refs #3486/#3495). This is a vendored copy — fix bugs/add variants there
+   * first, then propagate here, until #3492 (`@trusty/foundry` package)
+   * replaces copy-paste vendoring with a real import.
+   *
+   * Why: The robot mark is the Foundry / Trusty Assistant visual identity —
+   * a friendly PM orchestrator face used at brand moments (here: the app
+   * header lockup next to the "Trusty Code" wordmark). Centralizing it as a
+   * component lets every trusty-* UI swap the entire brand mark in one place
+   * and reuse it at multiple sizes/variants without duplicating SVG.
+   * What: Renders a 32x32 robot face SVG (rounded-square head, two eyes,
+   * `>_` terminal mouth, antenna w/ dot tip) in one of three variants:
+   * - "full":  filled dark bg square + colored stroke/details (hero usage)
+   * - "mono":  transparent fill, single-color stroke (inline w/ text)
+   * - "badge": filled colored circle, white details (chip / avatar)
+   * The default `color` reads the Foundry accent token
+   * (`--trusty-primary`), with a `currentColor` fallback for consumers that
+   * haven't loaded that var — trusty-code-gui is one such consumer: it does
+   * NOT define `--trusty-primary` (its Tailwind `--color-primary` triple
+   * powers the `text-trusty-primary` utility instead), so the mark inherits
+   * whatever text color the header sets on it via `currentColor`, which
+   * itself inverts light/dark. `bgFill`/`stroke`/`dotFill` for the
+   * 'full'/'badge' variants use fixed literals (#2B1C12 / #FFFFFF) rather
+   * than tokens — those variants are chassis/chip colors, not text-adjacent
+   * accents, so they intentionally don't invert with theme.
+   * Test: Render <RobotIcon /> with each variant and visually confirm the
+   * antenna dot, eyes, and `>_` mouth render at 32px without clipping.
+   */
+  export let size: number = 32;
+  export let color: string = 'var(--trusty-primary, currentColor)';
+  export let variant: 'full' | 'mono' | 'badge' = 'full';
+
+  // Derived presentation tokens per variant. #2B1C12 / #FFFFFF: intentionally
+  // fixed (not theme tokens) — chassis/chip colors for the 'full'/'badge'
+  // variants, not text-adjacent accents.
+  $: bgFill = variant === 'full' ? '#2B1C12' : variant === 'badge' ? color : 'none';
+  $: stroke = variant === 'badge' ? '#FFFFFF' : color;
+  $: dotFill = variant === 'badge' ? '#FFFFFF' : color;
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width={size}
+  height={size}
+  viewBox="0 0 32 32"
+  fill="none"
+  stroke={stroke}
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-label="Trusty Assistant robot"
+  role="img"
+>
+  {#if variant === 'badge'}
+    <!-- Badge: colored circle container -->
+    <circle cx="16" cy="16" r="14" fill={bgFill} stroke="none" />
+  {:else}
+    <!-- Full / mono: rounded square face -->
+    <rect x="6" y="9" width="20" height="18" rx="4" fill={bgFill} stroke={stroke} />
+  {/if}
+
+  <!-- Antenna -->
+  <line x1="16" y1="9" x2="16" y2="4" stroke={stroke} />
+  <circle cx="16" cy="3" r="1.25" fill={dotFill} stroke="none" />
+
+  <!-- Eyes -->
+  <circle cx="12" cy="16" r="1.25" fill={dotFill} stroke="none" />
+  <circle cx="20" cy="16" r="1.25" fill={dotFill} stroke="none" />
+
+  <!-- Mouth: chevron `>` + underscore `_` -->
+  <polyline points="11.5,21 13.5,22.5 11.5,24" stroke={stroke} fill="none" />
+  <line x1="15" y1="24" x2="20.5" y2="24" stroke={stroke} />
+
+  {#if variant === 'full'}
+    <!-- Sparkle accent (only on full hero variant) -->
+    <path d="M26 6 L26 9 M24.5 7.5 L27.5 7.5" stroke={color} stroke-width="1.25" />
+  {/if}
+</svg>


### PR DESCRIPTION
## What

Bob reported the Trusty Code GUI header logo was wrong: the mark to the left of the "Trusty Code" wordmark was a literal `◆` diamond glyph — a leftover placeholder, not the brand identity. This adopts the **canonical Foundry / Trusty Assistant robot mark**.

## Changes

- **Vendor `RobotIcon.svelte`** into trusty-code-gui at `crates/trusty-code-gui/ui/src/lib/icons/RobotIcon.svelte`, copied from the design-system canonical source `docs/design/UI/design-system/icons/RobotIcon.svelte` (refs #3486/#3495). Carries the same "canonical source" vendoring header comment convention as trusty-agents' `ActionIcon.svelte`, pointing back at the design-system file until #3492 (`@trusty/foundry` package) replaces copy-paste vendoring with a real import.
- **`AppHeader.svelte`**: replaced the `◆` glyph with `<RobotIcon variant="mono" size={18} color="currentColor" />` wrapped in a `text-trusty-primary` span, so the mark inherits the header's primary token and themes in light/dark. Layout `[robot mark][Trusty Code]` and spacing intent preserved.

## Scope

Mark only. The "Trusty Code" wordmark, window title, and everything else are unchanged. No token changes.

## Notes on color/token

trusty-code-gui does not define a `--trusty-primary` CSS var (its Tailwind `--color-primary` RGB triple powers the `text-trusty-primary` utility). The vendored RobotIcon's default `var(--trusty-primary, currentColor)` therefore falls back to `currentColor`, which the wrapper's `text-trusty-primary` supplies — no token drift introduced.

## Gate

- `pnpm run build` — pass (145 modules transformed)
- `pnpm run test` — 272 tests pass (24 files)
- `node scripts/check_token_drift.mjs` — trusty-code-gui OK (40 tokens match canonical)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools