### PR TITLE
fix(trusty-analyze): scope smell detection to accurate AST path, gate MissingDocstring on public items

### DIFF
--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -9,6 +9,22 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Smell-count false positives made the codebase-wide quality metric untrustworthy**
+  ([#3522](https://github.com/bobmatnyc/trusty-tools/issues/3522)): the
+  whole-codebase quality report and PR-review path (`core/quality.rs`,
+  `core/review/mod.rs`) always scored chunks with the language-agnostic text
+  heuristic, which over-counts `DeepNesting` on ordinary, idiomatically
+  formatted Rust (e.g. `for (i, x) in v.iter().enumerate()`) and flags
+  `MissingDocstring` on every undocumented function regardless of visibility.
+  Both paths now dispatch through the existing language-aware
+  `compute_complexity_for` (tree-sitter-backed for Rust/TypeScript), and
+  `MissingDocstring` now only fires for public API surface (`pub` items in
+  Rust; exported functions / non-private class methods in TS/JS). Measured on
+  this repo's own `crates/` tree: smell count dropped from 21,407 to 8,906
+  across ~47.8K chunks (0.448 → 0.186 smells/chunk).
+
 ### Changed
 
 - **UI tokens now CI-enforced against the canonical Foundry source** (refs [#3486](https://github.com/bobmatnyc/trusty-tools/issues/3486)): flipped from the `scripts/check_token_drift.mjs` allowlist to ENFORCED. The `token-drift` CI job now compares `ui/src/lib/styles/tokens.css`'s plain-CSS `--trusty-*: #hex` values directly to `docs/design/UI/design-system/tokens.css` on every push/PR (light `[data-theme="light"]`, dark `:root, [data-theme="dark"]`; the crate-local alias layer is ignored), so a hand-edit that drifts this crate's palette from canonical fails the build.

--- a/crates/trusty-analyze/src/core/complexity_ts.rs
+++ b/crates/trusty-analyze/src/core/complexity_ts.rs
@@ -312,7 +312,7 @@ fn has_child_kind(node: Node, kind: &str) -> bool {
 /// What: a private-by-default language (no `visibility_modifier` child)
 /// returns `false`; any `pub` variant returns `true`.
 /// Test: `missing_docstring_skips_private_rust_fn`,
-/// `missing_docstring_fires_for_undocumented_pub_rust_fn`.
+/// `missing_docstring_smell_for_undocumented_pub_rust_fn`.
 fn is_pub_rust(fn_node: Node) -> bool {
     has_child_kind(fn_node, "visibility_modifier")
 }
@@ -325,7 +325,7 @@ fn is_pub_rust(fn_node: Node) -> bool {
 /// `MissingDocstring` against the caller-supplied `thresholds`. `MissingDocstring`
 /// only fires for `pub` items — see `is_pub_rust`.
 /// Test: `long_function_smell_fires_for_long_fn` and
-/// `missing_docstring_smell_for_undocumented_rust_fn` in the tests module.
+/// `missing_docstring_smell_for_undocumented_pub_rust_fn` in the tests module.
 fn detect_smells_rust(
     root: Node,
     src: &[u8],

--- a/crates/trusty-analyze/src/core/complexity_ts.rs
+++ b/crates/trusty-analyze/src/core/complexity_ts.rs
@@ -302,12 +302,28 @@ fn has_child_kind(node: Node, kind: &str) -> bool {
     false
 }
 
+/// True if a Rust `function_item` is `pub` (including restricted forms like
+/// `pub(crate)`/`pub(super)`) — i.e. carries a `visibility_modifier` child.
+///
+/// Why: only public API items reasonably need doc comments; the previous
+/// unconditional `MissingDocstring` check fired on every private helper
+/// function, which dominates a typical Rust codebase and made the smell
+/// count useless (#see issue for the `.enumerate()`/false-positive report).
+/// What: a private-by-default language (no `visibility_modifier` child)
+/// returns `false`; any `pub` variant returns `true`.
+/// Test: `missing_docstring_skips_private_rust_fn`,
+/// `missing_docstring_fires_for_undocumented_pub_rust_fn`.
+fn is_pub_rust(fn_node: Node) -> bool {
+    has_child_kind(fn_node, "visibility_modifier")
+}
+
 /// AST-driven smell detection for Rust.
 ///
 /// Why: uses AST node positions for accurate line counts and parameter counting
 /// rather than text heuristics.
 /// What: checks `LongFunction`, `DeepNesting`, `TooManyParams`, and
-/// `MissingDocstring` against the caller-supplied `thresholds`.
+/// `MissingDocstring` against the caller-supplied `thresholds`. `MissingDocstring`
+/// only fires for `pub` items — see `is_pub_rust`.
 /// Test: `long_function_smell_fires_for_long_fn` and
 /// `missing_docstring_smell_for_undocumented_rust_fn` in the tests module.
 fn detect_smells_rust(
@@ -342,7 +358,7 @@ fn detect_smells_rust(
         if params > thresholds.too_many_params {
             smells.push(CodeSmell::TooManyParams { count: params });
         }
-        if !has_rust_doc(fn_n, src) {
+        if is_pub_rust(fn_n) && !has_rust_doc(fn_n, src) {
             smells.push(CodeSmell::MissingDocstring);
         }
     } else if !contains_doc_marker(src) {
@@ -352,11 +368,69 @@ fn detect_smells_rust(
     smells
 }
 
+/// True if `node` (or an ancestor, within a few hops) is an `export_statement`.
+///
+/// Why: a top-level `function`/arrow function is only part of the module's
+/// public surface if it is exported; TypeScript/JS has no `pub` keyword, so
+/// `export` is the closest equivalent signal.
+/// What: walks up to 4 parents looking for `export_statement`. The hop limit
+/// keeps this a cheap, local check — `export` always wraps its declaration
+/// directly (`export_statement -> function_declaration`) or through one
+/// intermediate `lexical_declaration`/`variable_declarator` for arrow
+/// functions (`export_statement -> lexical_declaration -> variable_declarator
+/// -> arrow_function`), so 4 hops comfortably covers both shapes.
+fn is_exported_ts(node: Node) -> bool {
+    let mut cur = node.parent();
+    let mut hops = 0u8;
+    while let Some(p) = cur {
+        if p.kind() == "export_statement" {
+            return true;
+        }
+        hops += 1;
+        if hops > 4 {
+            break;
+        }
+        cur = p.parent();
+    }
+    false
+}
+
+/// True if a class `method_definition` has an explicit `private`/`protected`
+/// `accessibility_modifier` child.
+fn has_private_or_protected_modifier(node: Node, src: &[u8]) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "accessibility_modifier" {
+            let txt = child.utf8_text(src).unwrap_or("");
+            return txt == "private" || txt == "protected";
+        }
+    }
+    false
+}
+
+/// True if `fn_node` is part of the TS/JS public API surface.
+///
+/// Why: only public API items reasonably need doc comments; see `is_pub_rust`
+/// for the Rust equivalent and the rationale.
+/// What: class methods are public unless explicitly marked
+/// `private`/`protected` (TypeScript's default member visibility is public);
+/// top-level functions/arrow functions are public only when `export`ed.
+/// Test: `missing_docstring_skips_non_exported_ts_function`,
+/// `missing_docstring_fires_for_undocumented_exported_ts_function`,
+/// `missing_docstring_skips_private_ts_method`.
+fn is_public_ts(fn_node: Node, src: &[u8]) -> bool {
+    if fn_node.kind() == "method_definition" {
+        return !has_private_or_protected_modifier(fn_node, src);
+    }
+    is_exported_ts(fn_node)
+}
+
 /// AST-driven smell detection for TypeScript / JavaScript.
 ///
 /// Why: uses AST node positions for accurate line and parameter counts.
 /// What: checks `LongFunction`, `DeepNesting`, `TooManyParams`, and
-/// `MissingDocstring` against the caller-supplied `thresholds`.
+/// `MissingDocstring` against the caller-supplied `thresholds`. `MissingDocstring`
+/// only fires for public items — see `is_public_ts`.
 /// Test: `compute_complexity_typescript_single_branch` and related tests.
 fn detect_smells_ts(
     root: Node,
@@ -392,7 +466,7 @@ fn detect_smells_ts(
         if params > thresholds.too_many_params {
             smells.push(CodeSmell::TooManyParams { count: params });
         }
-        if !has_jsdoc(fn_n, src) {
+        if is_public_ts(fn_n, src) && !has_jsdoc(fn_n, src) {
             smells.push(CodeSmell::MissingDocstring);
         }
     } else if !contains_doc_marker(src) {
@@ -907,8 +981,10 @@ fn classify(n: i32) -> &'static str {
     }
 
     #[test]
-    fn missing_docstring_smell_for_undocumented_rust_fn() {
-        let m = compute_complexity_rust("fn f() {}").expect("parse should succeed");
+    fn missing_docstring_smell_for_undocumented_pub_rust_fn() {
+        // Only `pub` items are part of the public API surface, so
+        // `MissingDocstring` requires `pub` — see `is_pub_rust`.
+        let m = compute_complexity_rust("pub fn f() {}").expect("parse should succeed");
         assert!(m
             .smells
             .iter()
@@ -916,9 +992,118 @@ fn classify(n: i32) -> &'static str {
     }
 
     #[test]
-    fn doc_comment_suppresses_missing_docstring() {
-        let m = compute_complexity_rust("/// hi\nfn f() {}").expect("parse should succeed");
+    fn doc_comment_suppresses_missing_docstring_on_pub_fn() {
+        let m = compute_complexity_rust("/// hi\npub fn f() {}").expect("parse should succeed");
         assert!(!m
+            .smells
+            .iter()
+            .any(|s| matches!(s, CodeSmell::MissingDocstring)));
+    }
+
+    #[test]
+    fn missing_docstring_skips_private_rust_fn() {
+        // Private (non-`pub`) functions are internal implementation detail —
+        // requiring doc comments on every one of them is what made the
+        // whole-codebase smell count useless (most functions in a typical
+        // Rust codebase are private helpers).
+        let m = compute_complexity_rust("fn helper() {}").expect("parse should succeed");
+        assert!(
+            !m.smells
+                .iter()
+                .any(|s| matches!(s, CodeSmell::MissingDocstring)),
+            "private fn must not be flagged MissingDocstring, got {:?}",
+            m.smells
+        );
+    }
+
+    #[test]
+    fn missing_docstring_skips_private_rust_fn_using_enumerate() {
+        // Regression test for the reported false positive: idiomatic
+        // `.iter().enumerate()` usage inside an ordinary private helper must
+        // not inflate the smell count. `.enumerate()` itself was never a
+        // distinct smell rule; the over-reporting came from `MissingDocstring`
+        // firing on every undocumented (i.e. almost every private) function.
+        let src = r#"fn process(items: &[i32]) -> i32 {
+    let mut total = 0;
+    for (i, item) in items.iter().enumerate() {
+        total += i as i32 + item;
+    }
+    total
+}
+"#;
+        let m = compute_complexity_rust(src).expect("parse should succeed");
+        assert!(
+            m.smells.is_empty(),
+            "idiomatic private fn using .enumerate() must have zero smells, got {:?}",
+            m.smells
+        );
+    }
+
+    #[test]
+    fn missing_docstring_fires_for_pub_rust_fn_using_enumerate_without_doc() {
+        // A `pub` fn still reasonably needs docs even if it uses `.enumerate()`
+        // — the fix must not silence real signal, only the false positive.
+        let src = r#"pub fn process(items: &[i32]) -> i32 {
+    let mut total = 0;
+    for (i, item) in items.iter().enumerate() {
+        total += i as i32 + item;
+    }
+    total
+}
+"#;
+        let m = compute_complexity_rust(src).expect("parse should succeed");
+        assert!(
+            m.smells
+                .iter()
+                .any(|s| matches!(s, CodeSmell::MissingDocstring)),
+            "undocumented pub fn should still be flagged, got {:?}",
+            m.smells
+        );
+    }
+
+    #[test]
+    fn missing_docstring_skips_non_exported_ts_function() {
+        let m = compute_complexity_typescript("function helper(a: number) { return a; }")
+            .expect("parse should succeed");
+        assert!(
+            !m.smells
+                .iter()
+                .any(|s| matches!(s, CodeSmell::MissingDocstring)),
+            "non-exported TS function must not be flagged, got {:?}",
+            m.smells
+        );
+    }
+
+    #[test]
+    fn missing_docstring_fires_for_undocumented_exported_ts_function() {
+        let m = compute_complexity_typescript("export function helper(a: number) { return a; }")
+            .expect("parse should succeed");
+        assert!(m
+            .smells
+            .iter()
+            .any(|s| matches!(s, CodeSmell::MissingDocstring)));
+    }
+
+    #[test]
+    fn missing_docstring_skips_private_ts_method() {
+        let src = "class C {\n  private helper(a: number) { return a; }\n}\n";
+        let m = compute_complexity_typescript(src).expect("parse should succeed");
+        assert!(
+            !m.smells
+                .iter()
+                .any(|s| matches!(s, CodeSmell::MissingDocstring)),
+            "private class method must not be flagged, got {:?}",
+            m.smells
+        );
+    }
+
+    #[test]
+    fn missing_docstring_fires_for_undocumented_public_ts_method() {
+        // Class methods are public by default in TS unless marked
+        // `private`/`protected`.
+        let src = "class C {\n  helper(a: number) { return a; }\n}\n";
+        let m = compute_complexity_typescript(src).expect("parse should succeed");
+        assert!(m
             .smells
             .iter()
             .any(|s| matches!(s, CodeSmell::MissingDocstring)));

--- a/crates/trusty-analyze/src/core/quality.rs
+++ b/crates/trusty-analyze/src/core/quality.rs
@@ -4,12 +4,30 @@
 //! both want a one-shot summary number — average cyclomatic complexity, %
 //! grade-A chunks, total smell count. Pulling the math into a pure function
 //! keeps the HTTP/MCP layers thin.
+//!
+//! Language dispatch: every chunk is scored via `compute_complexity_for`
+//! (dispatched on `crate::lang::ext_map::lang_for_extension(&c.file)`) rather
+//! than the raw text heuristic. The text heuristic's own module docs admit it
+//! is "wrong on common idioms" (see `complexity_ts.rs`); routing through the
+//! language-aware dispatcher gives Rust/TypeScript chunks accurate
+//! tree-sitter-backed smell detection instead of whitespace-based guesses,
+//! which is what made the whole-codebase smell count trustworthy again
+//! (previously every chunk was scored 3x redundantly with the text-only
+//! `compute_complexity`, regardless of its actual language).
 
-use crate::types::complexity::ComplexityGrade;
+use crate::types::complexity::{ComplexityGrade, ComplexityMetrics};
 use crate::types::CodeChunk;
 use serde::Serialize;
 
-use crate::core::complexity::compute_complexity;
+use crate::core::complexity::compute_complexity_for;
+
+/// Score a chunk once, using the language dispatcher keyed off its file
+/// extension, so callers don't each re-derive the language or re-run
+/// complexity analysis on the same content.
+fn metrics_of(c: &CodeChunk) -> ComplexityMetrics {
+    let lang = crate::lang::ext_map::lang_for_extension(&c.file);
+    compute_complexity_for(&c.content, lang)
+}
 
 /// One-shot quality summary over a chunk corpus.
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -43,13 +61,12 @@ pub struct HotspotItem {
 
 /// Sort `chunks` by descending cyclomatic complexity and return the top N,
 /// each carrying the cyclomatic + cognitive numbers it was ranked on.
-/// Chunks without a pre-computed `complexity` field are scored on demand from
-/// `content`.
+/// Chunks are scored via the language-aware `metrics_of` dispatcher.
 pub fn complexity_hotspots(chunks: &[CodeChunk], top_n: usize) -> Vec<HotspotItem> {
     let mut scored: Vec<HotspotItem> = chunks
         .iter()
         .map(|c| {
-            let metrics = compute_complexity(&c.content);
+            let metrics = metrics_of(c);
             HotspotItem {
                 chunk: c.clone(),
                 cyclomatic: metrics.cyclomatic,
@@ -62,13 +79,11 @@ pub fn complexity_hotspots(chunks: &[CodeChunk], top_n: usize) -> Vec<HotspotIte
     scored
 }
 
-/// Return chunks that have at least one detected smell. Re-runs `detect_smells`
-/// for chunks lacking pre-computed `complexity` so the caller doesn't have to
-/// require trusty-search to populate the field.
+/// Return chunks that have at least one detected smell.
 pub fn smelly_chunks(chunks: &[CodeChunk]) -> Vec<CodeChunk> {
     chunks
         .iter()
-        .filter(|c| !smells_of(c).is_empty())
+        .filter(|c| !metrics_of(c).smells.is_empty())
         .cloned()
         .collect()
 }
@@ -78,11 +93,17 @@ pub fn aggregate_quality(chunks: &[CodeChunk]) -> QualityReport {
     let chunk_count = chunks.len();
     let (sum_cyclo, grade_a, smell_count) =
         chunks.iter().fold((0u64, 0usize, 0usize), |(s, a, sm), c| {
-            let metrics_cyclo = cyclomatic_of(c);
-            let grade = grade_of(c);
-            let smell_total = smells_of(c).len();
-            let a_inc = if grade == ComplexityGrade::A { 1 } else { 0 };
-            (s + metrics_cyclo as u64, a + a_inc, sm + smell_total)
+            let metrics = metrics_of(c);
+            let a_inc = if metrics.grade == ComplexityGrade::A {
+                1
+            } else {
+                0
+            };
+            (
+                s + metrics.cyclomatic as u64,
+                a + a_inc,
+                sm + metrics.smells.len(),
+            )
         });
     let avg_cyclomatic = if chunk_count == 0 {
         0.0_f32
@@ -100,18 +121,6 @@ pub fn aggregate_quality(chunks: &[CodeChunk]) -> QualityReport {
         smell_count,
         chunk_count,
     }
-}
-
-fn cyclomatic_of(c: &CodeChunk) -> u32 {
-    compute_complexity(&c.content).cyclomatic
-}
-
-fn grade_of(c: &CodeChunk) -> ComplexityGrade {
-    compute_complexity(&c.content).grade
-}
-
-fn smells_of(c: &CodeChunk) -> Vec<crate::types::complexity::CodeSmell> {
-    crate::core::complexity::detect_smells(&c.content)
 }
 
 #[cfg(test)]
@@ -185,5 +194,40 @@ mod tests {
         let out = smelly_chunks(&[clean, big]);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].id, "b");
+    }
+
+    #[test]
+    fn idiomatic_private_enumerate_chunk_is_not_smelly() {
+        // End-to-end regression test for the reported false positive: a
+        // whole-codebase quality scan must not flag an ordinary, private
+        // helper function that uses idiomatic `.iter().enumerate()`.
+        let src = r#"fn process(items: &[i32]) -> i32 {
+    let mut total = 0;
+    for (i, item) in items.iter().enumerate() {
+        total += i as i32 + item;
+    }
+    total
+}
+"#;
+        let c = chunk("enum1", src);
+        assert!(
+            smelly_chunks(std::slice::from_ref(&c)).is_empty(),
+            "idiomatic private .enumerate() chunk must not be reported as smelly"
+        );
+        let report = aggregate_quality(&[c]);
+        assert_eq!(
+            report.smell_count, 0,
+            "idiomatic private .enumerate() chunk must contribute zero smells"
+        );
+    }
+
+    #[test]
+    fn undocumented_pub_chunk_still_counts_as_smelly() {
+        // The fix must not silence real signal: an undocumented `pub` item
+        // is still part of the public API and should still be flagged.
+        let c = chunk("pub1", "pub fn f() {}\n");
+        assert_eq!(smelly_chunks(std::slice::from_ref(&c)).len(), 1);
+        let report = aggregate_quality(&[c]);
+        assert_eq!(report.smell_count, 1);
     }
 }

--- a/crates/trusty-analyze/src/core/review/mod.rs
+++ b/crates/trusty-analyze/src/core/review/mod.rs
@@ -22,7 +22,7 @@
 //! the indexed-vs-new-file merge logic.
 
 use crate::core::client::TrustySearchClient;
-use crate::core::complexity::{compute_complexity_for, detect_smells};
+use crate::core::complexity::compute_complexity_for;
 use crate::types::complexity::{CodeSmell, ComplexityGrade};
 use crate::types::CodeChunk;
 
@@ -128,7 +128,11 @@ fn review_one_file(fd: &FileDiff, index_chunks: &[&CodeChunk]) -> FileReview {
         // New file: not yet indexed by trusty-search. Local fallback.
         let content = fd.added_content();
         let metrics = compute_complexity_for(&content, lang);
-        let smells = project_smells(&detect_smells(&content), anchor);
+        // Reuse the smells already computed by `compute_complexity_for` above
+        // instead of re-running the language-agnostic text heuristic (which
+        // is documented to misfire on common idioms) — see #core/quality.rs
+        // for the same fix on the whole-codebase quality report path.
+        let smells = project_smells(&metrics.smells, anchor);
         let recommendations = recommendations_for(
             metrics.grade,
             metrics.cyclomatic,
@@ -156,7 +160,7 @@ fn review_one_file(fd: &FileDiff, index_chunks: &[&CodeChunk]) -> FileReview {
         .collect::<Vec<_>>()
         .join("\n");
     let metrics = compute_complexity_for(&joined, lang);
-    let smells = project_smells(&detect_smells(&joined), anchor);
+    let smells = project_smells(&metrics.smells, anchor);
     let modified_chunks = index_chunks
         .iter()
         .filter(|c| fd.touches_range(c.start_line, c.end_line))


### PR DESCRIPTION
## Summary

- Fixes the `trusty-analyze` codebase-quality smell count being dominated by
  false positives (66,139 smells reported on this codebase, ~1.08/chunk,
  "mostly benign Rust idioms").
- Root cause: `core/quality.rs` (whole-codebase quality report) and
  `core/review/mod.rs` (PR review) always scored chunks with the
  language-agnostic **text heuristic** (`core/complexity.rs::detect_smells`)
  — whose own module docs admit it is "wrong on common idioms" — instead of
  the accurate tree-sitter **AST-backed detector** that already exists in the
  same crate (`core/complexity_ts.rs`). The text heuristic's whitespace-based
  nesting estimate over-flags `DeepNesting` on ordinary idiomatic Rust (most
  visibly functions using `.iter().enumerate()`), and `MissingDocstring`
  fired on every undocumented function regardless of visibility.
- Fix:
  - `core/quality.rs`: route every chunk through `compute_complexity_for`
    (language dispatched via `lang_for_extension(&chunk.file)`), scoring each
    chunk once instead of 3 redundant text-heuristic calls.
  - `core/review/mod.rs`: reuse the already-computed AST-based
    `metrics.smells` instead of discarding it and recomputing with the text
    heuristic.
  - `core/complexity_ts.rs`: scope `MissingDocstring` to public API surface
    only — `pub` items in Rust (`is_pub_rust`), exported functions /
    non-`private`/`protected` class methods in TS/JS (`is_public_ts`).
- Measured on this repo's own `crates/` tree (~47.8K chunks, same chunking
  shape trusty-search uses): smell count drops from **21,407 to 8,906**
  (0.448 → 0.186 smells/chunk).

Closes #3522

## Test plan

- [x] `cargo test -p trusty-analyze` (full, including integration tests) — 442 + 25 + 2 + 2 passed, 0 failed
- [x] `cargo fmt -p trusty-analyze --check` — clean
- [x] `cargo clippy -p trusty-analyze --all-targets -- -D warnings` — clean
- [x] `cargo check -p trusty-review -p trusty-console -p trusty-memory -p trusty-installer -p trusty-common` — all downstream consumers still build
- [x] New regression tests: idiomatic `.enumerate()` usage in a private helper produces zero smells; private/non-exported items no longer flagged for missing docs; public/exported undocumented items are still flagged (no loss of real signal)
- [x] Before/after smell count measured directly against this repo's own source (see above)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools