### PR TITLE
feat(trusty-code-gui): download workstream transcript as Markdown (closes #3526)

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -8,6 +8,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Download workstream transcript as Markdown (closes #3526).** The active
+  workstream's chat pane header (`WorkstreamActivity.svelte`) gains a
+  `download transcript` button that saves the full run transcript — every
+  turn, including the tool-run lines (`` `AGENT` ran: write_files ``) that a
+  runaway-loop post-mortem needs — as a Markdown file named
+  `transcript-<workstream>-<YYYYMMDD-HHMMSS>.md`. The Markdown is rendered by
+  the DAEMON (`GET /sessions/{id}/transcript.md`, see the trusty-code
+  changelog), so the same document a developer can `curl` in local dev is
+  exactly what the button downloads — no second, drift-prone client-side
+  serializer. Motivating case: a workstream ran 48 min to
+  `deadline_exceeded` with a runaway loop and there was no way to pull the
+  transcript to inspect it.
+
 ### Fixed
 
 - **App / dock icon — stale "AI COMMANDER" placeholder replaced with the real

--- a/crates/trusty-code-gui/ui/src/components/WorkstreamActivity.svelte
+++ b/crates/trusty-code-gui/ui/src/components/WorkstreamActivity.svelte
@@ -114,7 +114,12 @@
     type SessionDetail,
     type SessionListResponse,
   } from '../lib/session-status';
-  import { formatElapsed, selectChatEntries, type TranscriptRecord } from '../lib/transcript';
+  import {
+    formatElapsed,
+    selectChatEntries,
+    transcriptFilename,
+    type TranscriptRecord,
+  } from '../lib/transcript';
   import { fetchWorkstreams, workstreamLabel, type Workstream } from '../lib/workstreams';
 
   const POLL_MS = 5000; // matches StatusBar.svelte's poll cadence
@@ -411,6 +416,53 @@
   let chatEntries = $derived(transcript ? selectChatEntries(transcript.turns) : []);
   let canCancel = $derived(session !== null && !TERMINAL_SESSION_STATUSES.has(session.status));
 
+  // Download-transcript affordance (issue #3526). Shown once a bound session
+  // is selected for the active workstream — that session's transcript is what
+  // the daemon renders to Markdown. The DAEMON is the single source of truth
+  // for the Markdown format (`GET /sessions/{id}/transcript.md`,
+  // `crate::serve::rest::sessions::render_transcript_markdown`), so the same
+  // bytes a developer gets via `curl` in local dev are what this button saves
+  // — no second, drift-prone TS serializer. See that endpoint's docs.
+  let canDownload = $derived(activeWorkstream !== null && session !== null);
+
+  /**
+   * Fetch the daemon-rendered Markdown transcript for the active workstream's
+   * session and trigger a browser download of it. The serialization happens
+   * server-side (single source of truth — see `canDownload`'s note); this is
+   * purely the DOM-side save (Blob + object URL + a synthetic `<a download>`
+   * click), so it lives in the component rather than `lib/transcript.ts`
+   * (`transcriptFilename` — the timestamped filename — stays pure there).
+   * No-ops when there is nothing to download or the runtime lacks the
+   * Blob/URL APIs (SSR/older environments); a fetch failure surfaces in the
+   * existing in-pane `error` line rather than throwing.
+   */
+  async function downloadTranscript() {
+    if (!session || !activeWorkstream) return;
+    if (typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') return;
+
+    let markdown: string;
+    try {
+      const base = await apiBase();
+      const res = await fetch(`${base}/sessions/${session.id}/transcript.md`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      markdown = await res.text();
+    } catch (e) {
+      error = `transcript download failed — ${e instanceof Error ? e.message : String(e)}`;
+      return;
+    }
+
+    const filename = transcriptFilename(activeWorkstream.id, Date.now());
+    const blob = new Blob([markdown], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  }
+
   $effect(() => {
     // Auto-scroll to the newest entry as the stream "builds up" (issue
     // #3446), unless the operator has scrolled up to read backlog. Reads
@@ -466,14 +518,26 @@
       <span class="font-mono text-[11px] uppercase tracking-wide text-trusty-text-secondary">
         {workstreamLabel(activeWorkstream)}
       </span>
-      {#if session}
-        <span class="flex items-center gap-2 font-mono text-[11px]">
-          <span class={`h-1.5 w-1.5 rounded-full ${statusDotClass(session.status)}`}></span>
-          <span class="font-semibold uppercase tracking-wide text-trusty-text">{session.status}</span>
-          <span class="text-trusty-text-muted">·</span>
-          <span class="text-trusty-text-secondary">{formatElapsed(session.created_at, now)}</span>
-        </span>
-      {/if}
+      <div class="flex items-center gap-3">
+        {#if session}
+          <span class="flex items-center gap-2 font-mono text-[11px]">
+            <span class={`h-1.5 w-1.5 rounded-full ${statusDotClass(session.status)}`}></span>
+            <span class="font-semibold uppercase tracking-wide text-trusty-text">{session.status}</span>
+            <span class="text-trusty-text-muted">·</span>
+            <span class="text-trusty-text-secondary">{formatElapsed(session.created_at, now)}</span>
+          </span>
+        {/if}
+        {#if canDownload}
+          <button
+            type="button"
+            class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-raised px-2.5 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
+            title="Download this workstream's full transcript as a Markdown file"
+            onclick={downloadTranscript}
+          >
+            download transcript
+          </button>
+        {/if}
+      </div>
     </div>
 
     <div

--- a/crates/trusty-code-gui/ui/src/components/WorkstreamActivity.test.ts
+++ b/crates/trusty-code-gui/ui/src/components/WorkstreamActivity.test.ts
@@ -101,6 +101,18 @@ function fakeDaemon(opts: {
         }),
       } as Response;
     }
+    const markdownMatch = url.match(/\/sessions\/([^/]+)\/transcript\.md$/);
+    if (markdownMatch) {
+      // The daemon renders the transcript to Markdown (issue #3526); the fake
+      // returns a recognizable canned document so the download-wiring test can
+      // assert the bytes it fetched are what got saved.
+      const md = `# Workstream transcript — ${markdownMatch[1]}\n\n- \`PYTHON-ENGINEER\` ran: write_files\n`;
+      return {
+        ok: true,
+        status: 200,
+        text: async () => md,
+      } as unknown as Response;
+    }
     const transcriptMatch = url.match(/\/sessions\/([^/]+)\/transcript$/);
     if (transcriptMatch) {
       if (transcriptMatch[1] === opts.transcript404For) {
@@ -402,6 +414,82 @@ describe('WorkstreamActivity chat stream (issue #3446)', () => {
     expect(iFirst).toBeGreaterThanOrEqual(0);
     expect(iFirst).toBeLessThan(iTool);
     expect(iTool).toBeLessThan(iLong);
+  });
+});
+
+describe('WorkstreamActivity download transcript (issue #3526)', () => {
+  it('fetches the daemon-rendered Markdown and triggers a download of it', async () => {
+    const createObjectURL = vi.fn(() => 'blob:mock-url');
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL } as unknown as typeof URL);
+
+    let capturedBlob: Blob | undefined;
+    let capturedDownload: string | undefined;
+    const realCreate = document.createElement.bind(document);
+    const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = realCreate(tag) as HTMLElement;
+      if (tag === 'a') {
+        // Capture the download filename and swallow the click so jsdom doesn't
+        // attempt a real navigation.
+        el.click = () => {
+          capturedDownload = (el as HTMLAnchorElement).download;
+        };
+      }
+      return el;
+    });
+    // Capture the Blob the component constructs, plus its Markdown payload —
+    // jsdom's Blob doesn't implement `.text()`, so read the constructor parts
+    // directly rather than round-tripping through the Blob.
+    let capturedMarkdown = '';
+    const RealBlob = globalThis.Blob;
+    vi.stubGlobal(
+      'Blob',
+      class extends RealBlob {
+        constructor(parts?: BlobPart[], options?: BlobPropertyBag) {
+          super(parts, options);
+          capturedBlob = this;
+          capturedMarkdown = (parts ?? []).map((p) => String(p)).join('');
+        }
+      },
+    );
+
+    vi.stubGlobal(
+      'fetch',
+      fakeDaemon({
+        activeWorkstreamId: 'ws-1',
+        workstreams: [ws('ws-1', 'my workstream', ['bound-session'])],
+        sessions: [session('bound-session', 'running', '2026-07-20T14:00:00Z', 'ship the feature')],
+        transcriptFor: {
+          'bound-session': [
+            { role: 'pm', text: 'delegating' },
+            { role: 'python-engineer', text: '', tool_calls: ['write_files'] },
+          ],
+        },
+      }),
+    );
+    instance = mount(WorkstreamActivity, { target }) as unknown as Record<string, unknown>;
+
+    await waitFor(() => target.textContent?.includes('delegating') ?? false);
+
+    const downloadButton = Array.from(target.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'download transcript',
+    ) as HTMLButtonElement;
+    expect(downloadButton).toBeTruthy();
+
+    downloadButton.click();
+
+    // The download awaits an async fetch of the `.md` endpoint before building
+    // the Blob, so wait for the object-URL call rather than asserting inline.
+    await waitFor(() => createObjectURL.mock.calls.length > 0);
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    expect(capturedDownload).toMatch(/^transcript-ws-1-\d{8}-\d{6}\.md$/);
+    expect(capturedBlob).toBeTruthy();
+    // The saved bytes are exactly what the daemon endpoint returned.
+    expect(capturedMarkdown).toContain('# Workstream transcript — bound-session');
+    expect(capturedMarkdown).toContain('- `PYTHON-ENGINEER` ran: write_files');
+
+    createSpy.mockRestore();
   });
 });
 

--- a/crates/trusty-code-gui/ui/src/lib/transcript.test.ts
+++ b/crates/trusty-code-gui/ui/src/lib/transcript.test.ts
@@ -11,7 +11,12 @@
 // 60s/3600s rollover points).
 // Test: this file.
 import { describe, expect, it } from 'vitest';
-import { formatElapsed, selectChatEntries, type TurnRecord } from './transcript';
+import {
+  formatElapsed,
+  selectChatEntries,
+  transcriptFilename,
+  type TurnRecord,
+} from './transcript';
 
 function turn(overrides: Partial<TurnRecord> = {}): TurnRecord {
   return {
@@ -92,5 +97,27 @@ describe('formatElapsed', () => {
 
   it('clamps a negative delta (now before created_at) to 0s', () => {
     expect(formatElapsed('2026-07-18T10:00:00Z', base - 5_000)).toBe('0s');
+  });
+});
+
+describe('transcriptFilename', () => {
+  // 2026-07-18T14:05:09 local — filename stamps in LOCAL time, so build the
+  // instant from local components to keep the assertion timezone-independent.
+  const generatedAtMs = new Date(2026, 6, 18, 14, 5, 9).getTime();
+
+  it('builds transcript-<id>-<YYYYMMDD-HHMMSS>.md from the export instant', () => {
+    expect(transcriptFilename('ws-123', generatedAtMs)).toBe('transcript-ws-123-20260718-140509.md');
+  });
+
+  it('sanitizes unsafe characters in the workstream id', () => {
+    expect(transcriptFilename('a/b c:d', generatedAtMs)).toBe(
+      'transcript-a-b-c-d-20260718-140509.md',
+    );
+  });
+
+  it('falls back to "workstream" when the id sanitizes to empty', () => {
+    expect(transcriptFilename('///', generatedAtMs)).toBe(
+      'transcript-workstream-20260718-140509.md',
+    );
   });
 });

--- a/crates/trusty-code-gui/ui/src/lib/transcript.ts
+++ b/crates/trusty-code-gui/ui/src/lib/transcript.ts
@@ -141,3 +141,45 @@ export function formatElapsed(createdAt: string, now: number): string {
   }
   return `${seconds}s`;
 }
+
+// ---------------------------------------------------------------------------
+// Markdown transcript export (issue #3526)
+//
+// Why: a workstream that ran 48 min to DEADLINE_EXCEEDED with a runaway loop
+// left no way to pull the full transcript out for inspection. The DAEMON now
+// renders the transcript as Markdown at `GET /sessions/{id}/transcript.md`
+// (`crate::serve::rest::sessions::render_transcript_markdown`) — the single
+// source of truth for the format, so the same bytes a developer `curl`s in
+// local dev are what the GUI's "Download transcript" button saves. This module
+// therefore holds only the ONE pure, GUI-side piece the daemon can't own: the
+// timestamped download filename (the browser's local clock, not the daemon's).
+// The serialization itself is deliberately NOT duplicated here — a second TS
+// serializer would drift from the Rust one.
+// Test: `transcript.test.ts`.
+
+/** Zero-pad a positive integer to two digits (local helper for the
+ * `YYYYMMDD-HHMMSS` filename stamp). */
+function pad2(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * Build the download filename: `transcript-<workstream>-<YYYYMMDD-HHMMSS>.md`.
+ *
+ * Why: the timestamp is derived from the passed-in export instant (never
+ * hardcoded), in LOCAL time so the operator who clicked "download" recognizes
+ * the moment. The workstream id is sanitized to `[A-Za-z0-9._-]` (collapsing
+ * any run of other characters to a single `-`) so the value is always a safe,
+ * predictable filename regardless of how the id is shaped.
+ * What: pure function of `(workstreamId, generatedAtMs)`.
+ * Test: `transcript.test.ts::transcriptFilename-*`.
+ */
+export function transcriptFilename(workstreamId: string, generatedAtMs: number): string {
+  const d = new Date(generatedAtMs);
+  const stamp =
+    `${d.getFullYear()}${pad2(d.getMonth() + 1)}${pad2(d.getDate())}` +
+    `-${pad2(d.getHours())}${pad2(d.getMinutes())}${pad2(d.getSeconds())}`;
+  const safeId = workstreamId.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  const idPart = safeId.length > 0 ? safeId : 'workstream';
+  return `transcript-${idPart}-${stamp}.md`;
+}

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Markdown transcript endpoint for dev observability (issue #3526).** New
+  `GET /sessions/{id}/transcript.md` (`crate::serve::rest::sessions`) renders
+  a session's full transcript as a readable `text/markdown` document —
+  a header (session id, workstream id, project, task, mode, status, start/
+  export timestamps, turn count, cost) then one section per turn, each
+  `tool_calls` entry rendered as its own `` - `ROLE` ran: <tool> `` bullet so
+  a runaway loop stays visible line-by-line. This makes a run inspectable in
+  local dev independent of the GUI (`curl
+  http://127.0.0.1:7882/sessions/<id>/transcript.md`) and is the single
+  source of truth for the Markdown the Foundry GUI's "Download transcript"
+  button saves. Session-scoped, loopback-only (no new bind — rides the
+  existing daemon listener), `404` on an unknown id like the JSON transcript
+  route.
 - **Agent/Skill catalog management endpoints (issue #3449).** New `agents.*`/
   `skills.*` JSON-RPC methods (`crate::agents::protocol`,
   `crate::skills::protocol`) plus their REST twins — `GET`/`POST /agents`,

--- a/crates/trusty-code/src/serve/rest/sessions.rs
+++ b/crates/trusty-code/src/serve/rest/sessions.rs
@@ -141,16 +141,28 @@ async fn get_transcript_markdown(
     Path(id): Path<String>,
 ) -> Response {
     let ctx = throwaway_ctx();
-    let transcript_val =
-        match call(&state.router, "session.get_transcript", json!({"session_id": id}), &ctx).await {
-            Ok(v) => v,
-            Err(err) => return (rpc_error_to_status(&err), err.message).into_response(),
-        };
-    let session_val =
-        match call(&state.router, "session.status", json!({"session_id": id}), &ctx).await {
-            Ok(v) => v,
-            Err(err) => return (rpc_error_to_status(&err), err.message).into_response(),
-        };
+    let transcript_val = match call(
+        &state.router,
+        "session.get_transcript",
+        json!({"session_id": id}),
+        &ctx,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(err) => return (rpc_error_to_status(&err), err.message).into_response(),
+    };
+    let session_val = match call(
+        &state.router,
+        "session.status",
+        json!({"session_id": id}),
+        &ctx,
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(err) => return (rpc_error_to_status(&err), err.message).into_response(),
+    };
 
     let record: TranscriptRecord = match serde_json::from_value(transcript_val) {
         Ok(r) => r,
@@ -208,7 +220,10 @@ fn render_transcript_markdown(
     ));
     out.push_str(&format!(
         "- **Project:** {}\n",
-        session.project.clone().unwrap_or_else(|| "_(none)_".to_string())
+        session
+            .project
+            .clone()
+            .unwrap_or_else(|| "_(none)_".to_string())
     ));
     out.push_str(&format!(
         "- **Task:** {}\n",
@@ -465,8 +480,11 @@ mod tests {
     #[tokio::test]
     async fn get_transcript_markdown_renders_turns_and_tool_calls() {
         let (app, sessions) = app_and_registry().await;
-        let session =
-            sessions.create("investigate the loop".to_string(), None, crate::binding::ProjectBinding::None);
+        let session = sessions.create(
+            "investigate the loop".to_string(),
+            None,
+            crate::binding::ProjectBinding::None,
+        );
         sessions.set_run_outcome(
             &session.id,
             vec![
@@ -498,13 +516,21 @@ mod tests {
             "text/markdown; charset=utf-8"
         );
         let md = body_text(resp).await;
-        assert!(md.contains("# Workstream transcript — investigate the loop"), "{md}");
-        assert!(md.contains(&format!("- **Session:** `{}`", session.id)), "{md}");
+        assert!(
+            md.contains("# Workstream transcript — investigate the loop"),
+            "{md}"
+        );
+        assert!(
+            md.contains(&format!("- **Session:** `{}`", session.id)),
+            "{md}"
+        );
         assert!(md.contains("- **Turns:** 2"), "{md}");
         assert!(md.contains("delegating to the engineer"), "{md}");
         // Each tool-run entry is its own bullet — a runaway loop stays visible.
         assert!(
-            md.contains("- `PYTHON-ENGINEER` ran: write_files\n- `PYTHON-ENGINEER` ran: write_files"),
+            md.contains(
+                "- `PYTHON-ENGINEER` ran: write_files\n- `PYTHON-ENGINEER` ran: write_files"
+            ),
             "{md}"
         );
     }
@@ -530,7 +556,10 @@ mod tests {
         let resp = get(&app, &format!("/sessions/{}/transcript.md", session.id)).await;
         assert_eq!(resp.status(), StatusCode::OK);
         let md = body_text(resp).await;
-        assert!(md.contains("_No turns were recorded for this session._"), "{md}");
+        assert!(
+            md.contains("_No turns were recorded for this session._"),
+            "{md}"
+        );
     }
 
     /// `GET /sessions/{id}/transcript` on an unknown id must 404.

--- a/crates/trusty-code/src/serve/rest/sessions.rs
+++ b/crates/trusty-code/src/serve/rest/sessions.rs
@@ -32,12 +32,18 @@ use std::sync::Arc;
 
 use axum::Router as AxumRouter;
 use axum::extract::{Path, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
+use chrono::{DateTime, Utc};
 use serde_json::json;
 
 use crate::jsonrpc::Router;
+use crate::mode::HarnessMode;
+use crate::session::model::Session;
+use crate::session::transcript::TranscriptRecord;
 
-use super::{RestResult, respond};
+use super::{RestResult, call, respond, rpc_error_to_status, throwaway_ctx};
 
 /// Shared axum state for every route in this module: just the JSON-RPC
 /// router — every handler here is read-only and goes through
@@ -61,6 +67,7 @@ pub fn routes(router: Arc<Router>) -> AxumRouter {
         .route("/sessions", get(list_sessions))
         .route("/sessions/{id}", get(get_session))
         .route("/sessions/{id}/transcript", get(get_transcript))
+        .route("/sessions/{id}/transcript.md", get(get_transcript_markdown))
         .route("/sessions/{id}/readiness", get(get_readiness))
         .route("/sessions/{id}/goals", get(get_goals))
         .route("/sessions/{id}/budget", get(get_context_budget))
@@ -104,6 +111,182 @@ async fn get_transcript(State(state): State<SessionsState>, Path(id): Path<Strin
         json!({"session_id": id}),
     )
     .await
+}
+
+/// `GET /sessions/{id}/transcript.md` -> the full transcript rendered as a
+/// human-readable Markdown document (`text/markdown`).
+///
+/// Why: issue #3526 — a workstream that ran 48 min to `deadline_exceeded`
+/// with a runaway loop left no way to pull its transcript out for inspection.
+/// The GUI's "Download transcript" button needs Markdown; making the DAEMON
+/// render it (rather than only the GUI) also makes the transcript observable
+/// in local dev independent of the packaged app — a developer running the
+/// daemon can `curl http://127.0.0.1:7882/sessions/<id>/transcript.md` and
+/// read/watch a run directly. This is the single source of truth for the
+/// Markdown format (the GUI download just fetches these bytes), so the format
+/// can never drift between a Rust and a TypeScript serializer.
+/// What: fetches the same `session.get_transcript` record the JSON route
+/// serves PLUS `session.status` (for the header's task/project/mode/workstream
+/// context, none of which live on `TranscriptRecord`), renders
+/// [`render_transcript_markdown`], and returns it with a
+/// `text/markdown; charset=utf-8` content type. A `session_not_found` from
+/// either inner call maps to a real `404` via [`rpc_error_to_status`], exactly
+/// like the JSON route; the whole surface stays loopback-only because it adds
+/// no new bind — it rides `crate::serve::http::build_axum_router`'s existing
+/// listener (loopback-only doctrine, ADR-0011).
+/// Test: `tests::get_transcript_markdown_renders_turns_and_tool_calls`,
+/// `tests::get_transcript_markdown_missing_returns_404`.
+async fn get_transcript_markdown(
+    State(state): State<SessionsState>,
+    Path(id): Path<String>,
+) -> Response {
+    let ctx = throwaway_ctx();
+    let transcript_val =
+        match call(&state.router, "session.get_transcript", json!({"session_id": id}), &ctx).await {
+            Ok(v) => v,
+            Err(err) => return (rpc_error_to_status(&err), err.message).into_response(),
+        };
+    let session_val =
+        match call(&state.router, "session.status", json!({"session_id": id}), &ctx).await {
+            Ok(v) => v,
+            Err(err) => return (rpc_error_to_status(&err), err.message).into_response(),
+        };
+
+    let record: TranscriptRecord = match serde_json::from_value(transcript_val) {
+        Ok(r) => r,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+    let session: Session = match serde_json::from_value(session_val) {
+        Ok(s) => s,
+        Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    };
+
+    let markdown = render_transcript_markdown(&session, &record, Utc::now());
+    (
+        [(header::CONTENT_TYPE, "text/markdown; charset=utf-8")],
+        markdown,
+    )
+        .into_response()
+}
+
+/// Render a session's transcript as a readable Markdown document.
+///
+/// Why: the pure core of [`get_transcript_markdown`] (no I/O, no `Utc::now()`
+/// inside — `generated_at` is passed in) so the format is unit-testable
+/// directly. The tool-run lines are the WHOLE point for the motivating
+/// diagnostic case (issue #3526): each `TurnRecord.tool_calls` entry renders
+/// as its own ``- `ROLE` ran: <tool>`` bullet so a runaway loop (the same tool
+/// fired turn after turn) reads as a visibly repeated column, never a
+/// collapsed summary.
+/// What: a title, a metadata bullet list (session id, workstream id, project,
+/// task, mode, status, session-start ISO, export ISO, turn count, cost), a
+/// horizontal rule, then one `##` section per turn — prose verbatim, each tool
+/// call as its own ``- `ROLE` ran: <tool>`` bullet, a ``ran the test command``
+/// note when flagged, and `_(no output)_` for a turn with neither. Roles are
+/// upper-cased to match the live GUI pane's styling and the issue's example.
+/// Test: `tests::render_transcript_markdown_*`.
+fn render_transcript_markdown(
+    session: &Session,
+    record: &TranscriptRecord,
+    generated_at: DateTime<Utc>,
+) -> String {
+    let mut out = String::new();
+    let title = if session.task.trim().is_empty() {
+        record.session_id.clone()
+    } else {
+        session.task.clone()
+    };
+    out.push_str(&format!("# Workstream transcript — {title}\n\n"));
+    out.push_str(&format!("- **Session:** `{}`\n", record.session_id));
+    out.push_str(&format!(
+        "- **Workstream:** {}\n",
+        session
+            .workstream_id
+            .as_ref()
+            .map(|w| format!("`{w}`"))
+            .unwrap_or_else(|| "_(unbound)_".to_string())
+    ));
+    out.push_str(&format!(
+        "- **Project:** {}\n",
+        session.project.clone().unwrap_or_else(|| "_(none)_".to_string())
+    ));
+    out.push_str(&format!(
+        "- **Task:** {}\n",
+        if session.task.trim().is_empty() {
+            "_(none)_".to_string()
+        } else {
+            session.task.clone()
+        }
+    ));
+    out.push_str(&format!("- **Mode:** {}\n", mode_label(&session.mode)));
+    out.push_str(&format!(
+        "- **Status:** {}\n",
+        serde_json::to_value(session.status)
+            .ok()
+            .and_then(|v| v.as_str().map(String::from))
+            .unwrap_or_else(|| "unknown".to_string())
+    ));
+    out.push_str(&format!(
+        "- **Session started:** {}\n",
+        session.created_at.to_rfc3339()
+    ));
+    out.push_str(&format!("- **Exported:** {}\n", generated_at.to_rfc3339()));
+    out.push_str(&format!("- **Turns:** {}\n", record.turns.len()));
+    out.push_str(&format!(
+        "- **Cost (USD):** {}\n",
+        record
+            .cost_usd
+            .map(|c| format!("{c:.4}"))
+            .unwrap_or_else(|| "_(n/a)_".to_string())
+    ));
+    out.push_str("\n---\n\n");
+
+    if record.turns.is_empty() {
+        out.push_str("_No turns were recorded for this session._\n");
+        return out;
+    }
+
+    for (i, turn) in record.turns.iter().enumerate() {
+        let role_upper = turn.role.to_uppercase();
+        if turn.model.is_empty() {
+            out.push_str(&format!("## {}. {role_upper}\n\n", i + 1));
+        } else {
+            out.push_str(&format!("## {}. {role_upper} · {}\n\n", i + 1, turn.model));
+        }
+
+        let body = turn.text.trim();
+        let mut had_activity = false;
+        if !body.is_empty() {
+            out.push_str(&turn.text);
+            out.push_str("\n\n");
+            had_activity = true;
+        }
+        for tool in &turn.tool_calls {
+            out.push_str(&format!("- `{role_upper}` ran: {tool}\n"));
+            had_activity = true;
+        }
+        if turn.ran_test_command {
+            out.push_str(&format!("- `{role_upper}` ran the test command\n"));
+            had_activity = true;
+        }
+        if !turn.tool_calls.is_empty() || turn.ran_test_command {
+            out.push('\n');
+        }
+        if !had_activity {
+            out.push_str("_(no output)_\n\n");
+        }
+    }
+
+    out
+}
+
+/// Short label for an optional [`HarnessMode`] in the Markdown header —
+/// the serde string form, or `_(default)_` when unset.
+fn mode_label(mode: &Option<HarnessMode>) -> String {
+    match serde_json::to_value(mode) {
+        Ok(serde_json::Value::String(s)) => s,
+        _ => "_(default)_".to_string(),
+    }
 }
 
 /// `GET /sessions/{id}/readiness` -> `session.get_readiness`.
@@ -190,6 +373,11 @@ mod tests {
         serde_json::from_slice(&bytes).unwrap()
     }
 
+    async fn body_text(response: axum::response::Response) -> String {
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
     async fn get(app: &AxumRouter, uri: &str) -> axum::response::Response {
         app.clone()
             .oneshot(
@@ -268,6 +456,81 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let v = body_json(resp).await;
         assert_eq!(v["turns"].as_array().unwrap().len(), 0);
+    }
+
+    /// `GET /sessions/{id}/transcript.md` (issue #3526) must render the stored
+    /// transcript as `text/markdown`, preserving every turn's prose AND each
+    /// tool-run entry as its own bullet (the runaway-loop diagnostic the
+    /// endpoint exists for), under a header carrying the session id + task.
+    #[tokio::test]
+    async fn get_transcript_markdown_renders_turns_and_tool_calls() {
+        let (app, sessions) = app_and_registry().await;
+        let session =
+            sessions.create("investigate the loop".to_string(), None, crate::binding::ProjectBinding::None);
+        sessions.set_run_outcome(
+            &session.id,
+            vec![
+                crate::run_task::TurnRecord {
+                    role: "pm".to_string(),
+                    model: "claude-sonnet".to_string(),
+                    text: "delegating to the engineer".to_string(),
+                    tool_calls: vec![],
+                    ran_test_command: false,
+                    usage: crate::perf::TokenUsage::default(),
+                },
+                crate::run_task::TurnRecord {
+                    role: "python-engineer".to_string(),
+                    model: "claude-sonnet".to_string(),
+                    text: String::new(),
+                    tool_calls: vec!["write_files".to_string(), "write_files".to_string()],
+                    ran_test_command: false,
+                    usage: crate::perf::TokenUsage::default(),
+                },
+            ],
+            crate::perf::TokenUsage::default(),
+            Some(0.25),
+        );
+
+        let resp = get(&app, &format!("/sessions/{}/transcript.md", session.id)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/markdown; charset=utf-8"
+        );
+        let md = body_text(resp).await;
+        assert!(md.contains("# Workstream transcript — investigate the loop"), "{md}");
+        assert!(md.contains(&format!("- **Session:** `{}`", session.id)), "{md}");
+        assert!(md.contains("- **Turns:** 2"), "{md}");
+        assert!(md.contains("delegating to the engineer"), "{md}");
+        // Each tool-run entry is its own bullet — a runaway loop stays visible.
+        assert!(
+            md.contains("- `PYTHON-ENGINEER` ran: write_files\n- `PYTHON-ENGINEER` ran: write_files"),
+            "{md}"
+        );
+    }
+
+    /// `GET /sessions/{id}/transcript.md` on an unknown id must 404 (same
+    /// mapping as the JSON route), not render an empty document.
+    #[tokio::test]
+    async fn get_transcript_markdown_missing_returns_404() {
+        let (app, _sessions) = app_and_registry().await;
+
+        let resp = get(&app, "/sessions/does-not-exist/transcript.md").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// `GET /sessions/{id}/transcript.md` on a never-run session must still be
+    /// a 200 Markdown document (empty-turns note), not an error — mirrors the
+    /// JSON route's never-run behavior.
+    #[tokio::test]
+    async fn get_transcript_markdown_never_run_returns_200_empty_note() {
+        let (app, sessions) = app_and_registry().await;
+        let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let resp = get(&app, &format!("/sessions/{}/transcript.md", session.id)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let md = body_text(resp).await;
+        assert!(md.contains("_No turns were recorded for this session._"), "{md}");
     }
 
     /// `GET /sessions/{id}/transcript` on an unknown id must 404.


### PR DESCRIPTION
## What

Adds a way to pull a workstream's full conversation transcript out for inspection. Motivating case: a workstream ran 48 min to `deadline_exceeded` with a runaway loop and there was no way to get the transcript to diagnose it.

## Data source (investigation)

The chat pane (`WorkstreamActivity.svelte`, landed in PR #3460) already holds the complete transcript in memory: it polls `GET /sessions/{id}/transcript` (JSON) → `TranscriptRecord { session_id, turns: TurnRecord[], usage, cost_usd, mode, compaction_events, goals }`, where each `TurnRecord` is `{ role, model, text, tool_calls[], ran_test_command, usage }`. `selectChatEntries` renders every turn (no truncation since #3446). So the client had the full data — but only the packaged GUI could see it.

## Approach — daemon endpoint (not frontend-only)

Per the added scope (transcript must be observable in **local dev** independent of the GUI), the Markdown is rendered **server-side**:

- **New endpoint:** `GET /sessions/{id}/transcript.md` → `text/markdown; charset=utf-8` (`crate::serve::rest::sessions::render_transcript_markdown`). Session-scoped; pulls `session.get_transcript` (turns) + `session.status` (header context); `404` on unknown id like the JSON route; **loopback-only** (no new bind — rides the existing `build_axum_router` listener on `127.0.0.1:7882`).
- **Single source of truth:** the daemon owns the Markdown format, so the same bytes a dev `curl`s are exactly what the GUI saves. The earlier client-side TS serializer was removed to avoid a drift-prone second renderer; only the pure `transcriptFilename` (timestamped filename, browser-local clock) stays client-side.
- **GUI button:** `download transcript` in the workstream chat-pane header (right side, next to the session status), styled with existing Foundry tokens. On click it fetches the `.md` endpoint and triggers a Blob download `transcript-<workstream>-<YYYYMMDD-HHMMSS>.md`; a fetch failure surfaces in the existing in-pane error line.

## Dev observability

With a daemon running (`tcode serve --http`) and the GUI on `vite dev` (or nothing but the daemon), a developer inspects any run with:

```
curl http://127.0.0.1:7882/sessions/<session-id>/transcript.md
```

Verified live against a running daemon (created a session over REST, curled the endpoint): `200`, `content-type: text/markdown; charset=utf-8`, loopback-only bind confirmed via `lsof` (`127.0.0.1`, not `0.0.0.0`).

## Markdown format (sample)

```
# Workstream transcript — investigate the runaway loop

- **Session:** `d738fa8f-…`
- **Workstream:** `f2c19397-…`
- **Project:** _(none)_
- **Task:** investigate the runaway loop
- **Mode:** _(default)_
- **Status:** running
- **Session started:** 2026-07-20T23:39:17+00:00
- **Exported:** 2026-07-20T23:39:24+00:00
- **Turns:** 2
- **Cost (USD):** 0.2500

---

## 1. PM · claude-sonnet

delegating to the engineer

## 2. PYTHON-ENGINEER · claude-sonnet

- `PYTHON-ENGINEER` ran: write_files
- `PYTHON-ENGINEER` ran: write_files
```

Each `tool_calls` entry is its own bullet, so a runaway loop reads as a visibly repeated column — exactly what the diagnostic case needs.

## Tests / gates

- `cargo test -p trusty-code`: **1487 passed** (incl. 3 new endpoint tests: renders turns + tool bullets, `404` on unknown id, `200` empty-turns note on a never-run session). `cargo clippy -p trusty-code` clean. (CI runs `--workspace`.)
- `pnpm run test` (trusty-code-gui/ui): **276 passed** (updated download-wiring test + `transcriptFilename` tests).
- `pnpm run build`: OK.
- `node scripts/check_token_drift.mjs`: trusty-code-gui **OK** (no token changes).

## Scope

Download/observability only. Does **not** touch the runaway-loop / PM-redelegation behavior (separate concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)