### PR TITLE
fix(trusty-installer): safe + self-verifying install (macOS)

### DIFF
--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -13,10 +13,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `trusty-mpm-gui` joined the `trusty-mpm` signable set in `SIGNABLE_BINARIES` (`com.trusty.trusty-mpm.gui`), so `tctl sign trusty-mpm` and the automatic `tctl install` post-install hook also sign the GUI binary (if present under the install dir) with the stable Developer ID identity — fallback coverage for a bare `cargo install --path crates/trusty-mpm-gui`, alongside the GUI's own `bundle.macOS.signingIdentity` fix (closes #2951).
 - `tctl sign --verbose` (via the existing global `-v`/`--verbose` flag): prints the raw `security find-identity` probe output and which identity was selected, to help diagnose "no identity found" failures (closes #2939).
 - `tctl install --dry-run` previews the blast radius (members, binaries, planned launchd service actions) and exits 0 without installing anything — identical behaviour in TTY, non-TTY, and `--json` contexts (closes #2112).
+- `tctl install` now ends VERIFIED: after binaries + service bootstrap land, it automatically runs the `ensure` pass (`.mcp.json` patch + trusty-search index / trusty-memory palace registration) and a per-daemon health sweep, retrying a `down` launchd daemon once via `launchctl kickstart -k` before accepting the verdict (the #2498 "bootstrap succeeded but RunAtLoad never fired" flake). Prints a final green/red `VERIFIED`/`NOT VERIFIED` summary and folds the result into the same `--json` report / exit code CI already gates on. Skip with the new `--no-verify` flag (closes #2560).
+- `tctl install --force` overrides the new trusty-mpm supervisor downgrade guard (see Fixed, below) to explicitly allow replacing a registered supervisor with an older-or-equal version.
 
 ### Changed
 
 - **BREAKING for automation:** `tctl install` now REFUSES to run (exit 3) when stdin is not a TTY and neither `--yes` nor `--dry-run` was passed, instead of silently proceeding with a real install. Previously the blast-radius confirmation prompt was skipped entirely in non-TTY contexts (piped/scripted/agent-driven invocations), so an exploratory `tctl install` could reactivate real launchd services with no confirmation (#2112). Scripts and CI that relied on the old silent-proceed path must add `--yes`.
+
+### Fixed
+
+- `tctl install`'s trusty-mpm launchd supervisor bootstrap now honours `--no-service` / `TCTL_NO_SERVICE_BOOTSTRAP` like every other daemon member — previously it ran unconditionally regardless of the flag, which could bootout + replace a live production supervisor even when the operator explicitly opted out of touching launchd. It also now REFUSES to replace an already-registered supervisor with an older-or-equal version (comparing the registered vs. candidate `tm --version`, via `--force` to override), preventing a stale release from silently downgrading a newer live daemon (closes #3527).
 
 ### Fixed
 

--- a/crates/trusty-installer/src/cli.rs
+++ b/crates/trusty-installer/src/cli.rs
@@ -223,6 +223,19 @@ pub enum Commands {
         /// context.
         #[arg(long)]
         dry_run: bool,
+
+        /// Allow the trusty-mpm supervisor bootstrap to replace an
+        /// already-registered launchd supervisor with an older-or-equal
+        /// version (#3527 downgrade guard override). Has no effect on any
+        /// other member or check.
+        #[arg(long)]
+        force: bool,
+
+        /// Skip the post-install `ensure` + `stack health` verify tail
+        /// (#2560). The install itself (binaries + service bootstrap) still
+        /// runs; only the final automated verification pass is skipped.
+        #[arg(long)]
+        no_verify: bool,
     },
 
     /// Upgrade the stack (or named members) to the BOM-pinned versions, then restart. (DOC-9)

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -109,8 +109,12 @@ pub struct InstallReport {
     pub members: Vec<InstallOutcome>,
     /// Whether every member installed AND every attempted service bootstrap
     /// succeeded (see [`InstallOutcome`]'s field docs for what counts as a
-    /// service failure).
+    /// service failure) AND, when the verify tail ran, it reported verified.
     pub all_ok: bool,
+    /// The post-install verify-tail result (#2560): `ensure` + health (with
+    /// the #2498 kickstart retry). `None` when `--no-verify` skipped it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify: Option<super::verify_tail::VerifyTailReport>,
 }
 
 impl InstallReport {
@@ -119,7 +123,7 @@ impl InstallReport {
     /// Why: Centralises the `all_ok` derivation so the exit code and JSON agree,
     /// and so the report cannot claim success while a genuine service-bootstrap
     /// failure occurred (#2566 review finding).
-    /// What: Sets `command = "install"` and
+    /// What: Sets `command = "install"`, `verify = None`, and
     /// `all_ok = every outcome has ok == true AND service_ok == true`.
     /// Test: `tests::report_all_ok`, `tests::report_all_ok_reflects_service_failure`.
     fn build(members: Vec<InstallOutcome>) -> Self {
@@ -128,7 +132,28 @@ impl InstallReport {
             command: "install",
             members,
             all_ok,
+            verify: None,
         }
+    }
+
+    /// Fold the post-install verify-tail result into this report (#2560).
+    ///
+    /// Why: `--json` consumers must see ONE object whose `all_ok` (and hence
+    /// exit code) already reflects the verify-tail outcome — a caller must
+    /// never read `all_ok: true` while the verify tail reported an unhealthy
+    /// stack (the exact "looks installed, actually broken" class #2557 /
+    /// #2498 existed because of).
+    /// What: attaches `verify`; if it reports `!verified`, flips `all_ok` to
+    /// `false` (binary + service success alone does not override a verify
+    /// failure).
+    /// Test: `tests::with_verify_failure_flips_all_ok`,
+    /// `tests::with_verify_success_preserves_all_ok`.
+    fn with_verify(mut self, verify: super::verify_tail::VerifyTailReport) -> Self {
+        if !verify.verified {
+            self.all_ok = false;
+        }
+        self.verify = Some(verify);
+        self
     }
 
     /// Process exit code: 0 when all installed, 2 when any failed.
@@ -199,6 +224,23 @@ pub struct DryRunReport {
 /// path.
 fn plans_service_bootstrap(m: &StableMember, service_enabled: bool) -> bool {
     service_enabled && m.manage == ManageStrategy::Launchd
+}
+
+/// Whether an install would attempt the trusty-mpm launchd SUPERVISOR
+/// bootstrap for `m` (#3527).
+///
+/// Why: `install_mpm_supervisor()` used to run UNCONDITIONALLY whenever
+/// trusty-mpm installed — the one member exempt from the #2556
+/// `plans_service_bootstrap` opt-out, because trusty-mpm's
+/// [`ManageStrategy::OwnVerb`] makes that Launchd-only predicate always return
+/// `false` for it regardless of `service_enabled`. This mirrors
+/// `plans_service_bootstrap`'s *intent* (respect `--no-service` /
+/// `TCTL_NO_SERVICE_BOOTSTRAP`) for the supervisor specifically, so trusty-mpm
+/// is no longer the one member that ignores the opt-out.
+/// What: `true` iff `service_enabled` AND `m.crate_name == "trusty-mpm"`.
+/// Test: `tests::plans_mpm_supervisor_bootstrap_respects_flag`.
+fn plans_mpm_supervisor_bootstrap(m: &StableMember, service_enabled: bool) -> bool {
+    service_enabled && m.crate_name == "trusty-mpm"
 }
 
 /// Build the `--dry-run` preview report from the resolved member set.
@@ -288,13 +330,29 @@ fn print_dry_run(selected: &[StableMember], service_enabled: bool, json: bool) -
 /// (#2556) so operators who manage launchd themselves, or CI, install binaries
 /// only.
 ///
+/// `force` (#3527) overrides the trusty-mpm supervisor downgrade guard (see
+/// `plist_bootstrap::decide_downgrade`) — it has no effect on any other member.
+///
+/// `no_verify` (#2560) skips the post-install `ensure` + health verify tail
+/// (see `super::verify_tail`); the install itself (binaries + services) is
+/// unaffected — only the final verification pass is skipped.
+///
 /// Test: `tests::run_unknown_member_is_error`, `tests::run_dry_run_exits_zero`,
 /// `tests::dry_run_full_set_when_no_members_named`. The non-TTY refusal gate
 /// itself is TTY-independent and exhaustively covered by
 /// `super::install_gate::tests` (see that module's doc for why a `run()`-level
 /// refusal test is unsound — it would block forever on a real terminal). The
 /// install path is side-effecting (`cargo install`) and validated manually.
-pub fn run(members: &[String], yes: bool, json: bool, no_service: bool, dry_run: bool) -> i32 {
+#[allow(clippy::too_many_arguments)]
+pub fn run(
+    members: &[String],
+    yes: bool,
+    json: bool,
+    no_service: bool,
+    dry_run: bool,
+    force: bool,
+    no_verify: bool,
+) -> i32 {
     // Phase 4: interactive component picker.
     // Only activates when: no explicit members, stdin is a TTY, not --json,
     // and not --dry-run (a preview must behave identically regardless of TTY).
@@ -431,7 +489,17 @@ pub fn run(members: &[String], yes: bool, json: bool, no_service: bool, dry_run:
         }
     }
 
-    let report = block_on(install_all(&selected, json, service_enabled));
+    let mut report = block_on(install_all(&selected, json, service_enabled, force));
+
+    // #2560: post-install verify tail — ensure + health (with the #2498
+    // kickstart retry), folded into the SAME report/exit-code so `--json`
+    // consumers never see `all_ok: true` while the stack is actually down.
+    // Skipped entirely by `--no-verify` (the install itself is unaffected).
+    if !no_verify {
+        let verify = super::verify_tail::run_verify_tail(&selected);
+        report = report.with_verify(verify);
+    }
+
     if json {
         // A failed machine-readable write must not exit 0: automation would
         // read success from the exit code while the JSON never arrived.
@@ -441,6 +509,11 @@ pub fn run(members: &[String], yes: bool, json: bool, no_service: bool, dry_run:
         }
     } else {
         print_human_summary(&report);
+        // The verify tail is printed LAST — it is the final, authoritative
+        // "did this actually work" signal the operator should see (#2560).
+        if let Some(verify) = &report.verify {
+            super::verify_tail::print_human(verify);
+        }
     }
     report.exit_code()
 }
@@ -461,6 +534,7 @@ async fn install_all(
     selected: &[StableMember],
     json: bool,
     service_enabled: bool,
+    force: bool,
 ) -> InstallReport {
     let narr = narrator(json);
     let _ = narr.info(&format!("installing {} component(s)", selected.len()));
@@ -481,11 +555,25 @@ async fn install_all(
             Ok(()) => {
                 tracker.add(Component::new(m.binary.clone(), binary_size(&m.binary)));
                 // Phase 7: bootstrap trusty-mpm supervisor plist (fail-soft).
+                // #3527: gated behind the SAME `--no-service` /
+                // `TCTL_NO_SERVICE_BOOTSTRAP` decision as every other daemon —
+                // previously this ran unconditionally and could tear down /
+                // downgrade a live production supervisor regardless of the
+                // opt-out. A refusal from the downgrade guard inside
+                // `install_mpm_supervisor` also surfaces here as a (non-fatal)
+                // `Err`, which correctly leaves the running daemon untouched.
                 if m.crate_name == "trusty-mpm" {
-                    if let Err(e) = super::plist_bootstrap::install_mpm_supervisor() {
-                        let _ = narr.info(&format!(
-                            "warning: trusty-mpm supervisor bootstrap failed (non-fatal): {e}"
-                        ));
+                    if plans_mpm_supervisor_bootstrap(m, service_enabled) {
+                        if let Err(e) = super::plist_bootstrap::install_mpm_supervisor(force) {
+                            let _ = narr.info(&format!(
+                                "warning: trusty-mpm supervisor bootstrap failed (non-fatal): {e}"
+                            ));
+                        }
+                    } else {
+                        let _ = narr.info(
+                            "trusty-mpm supervisor bootstrap skipped (--no-service / \
+                             TCTL_NO_SERVICE_BOOTSTRAP)",
+                        );
                     }
                 }
                 // Phase 8: codesign + FDA guidance for trusty-search (single
@@ -685,230 +773,10 @@ fn print_human_summary(report: &InstallReport) {
     }
 }
 
+// ── Unit tests ───────────────────────────────────────────────────────────────
+// Tests are in a sibling file to keep this definition file under the 500-line
+// production cap (CLAUDE.md / scripts/check_line_cap.sh) — mirrors the
+// `cli.rs` / `cli_tests.rs` split.
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Build an `InstallOutcome` with the pre-#2566 default service state
-    /// (not attempted — `service_ok: true`, empty detail), so tests that only
-    /// care about the binary-install dimension don't have to repeat the two
-    /// new fields at every call site.
-    fn outcome(member: &str, ok: bool, detail: &str) -> InstallOutcome {
-        InstallOutcome {
-            member: member.to_owned(),
-            ok,
-            detail: detail.to_owned(),
-            service_ok: true,
-            service_detail: String::new(),
-        }
-    }
-
-    /// Why: The JSON envelope is a public contract; pin its shape.
-    /// What: Builds a report and asserts the serialised keys/values.
-    /// Test: This is the test.
-    #[test]
-    fn report_serialises() {
-        let report = InstallReport::build(vec![outcome("trusty-search", true, "installed")]);
-        let v = serde_json::to_value(&report).expect("serialises");
-        assert_eq!(v["command"], "install");
-        assert_eq!(v["all_ok"], true);
-        assert_eq!(v["members"][0]["member"], "trusty-search");
-        assert_eq!(v["members"][0]["service_ok"], true);
-    }
-
-    /// Why: `all_ok` must be false if any member's BINARY install failed.
-    /// What: Mixes an ok and a failed outcome; asserts `all_ok = false`.
-    /// Test: This is the test.
-    #[test]
-    fn report_all_ok() {
-        let report =
-            InstallReport::build(vec![outcome("a", true, ""), outcome("b", false, "boom")]);
-        assert!(!report.all_ok);
-    }
-
-    /// Why: #2566 review — a binary can install cleanly (`ok: true`) while its
-    /// SERVICE bootstrap genuinely fails; the report must not claim
-    /// `all_ok: true` in that case (the exact failure class #2557 existed
-    /// because of: a "successfully installed" daemon that never actually
-    /// works). A `Skipped` service outcome (opt-out, non-service member, or
-    /// plist already present) must NOT be treated as a failure.
-    /// What: one member with `ok: true, service_ok: false` → `all_ok == false`;
-    /// a second report with `ok: true, service_ok: true` (skip case) →
-    /// `all_ok == true`.
-    /// Test: this is the test.
-    #[test]
-    fn report_all_ok_reflects_service_failure() {
-        let failed = InstallReport::build(vec![InstallOutcome {
-            member: "trusty-search".to_owned(),
-            ok: true,
-            detail: "installed".to_owned(),
-            service_ok: false,
-            service_detail: "service bootstrap failed (non-fatal): boom".to_owned(),
-        }]);
-        assert!(
-            !failed.all_ok,
-            "a genuine service bootstrap failure must flip all_ok to false"
-        );
-        assert_eq!(failed.exit_code(), 2);
-
-        let skipped = InstallReport::build(vec![InstallOutcome {
-            member: "trusty-search".to_owned(),
-            ok: true,
-            detail: "installed".to_owned(),
-            service_ok: true,
-            service_detail: "launchd plist already present — left untouched".to_owned(),
-        }]);
-        assert!(
-            skipped.all_ok,
-            "a skipped (not failed) service bootstrap must not flip all_ok"
-        );
-        assert_eq!(skipped.exit_code(), 0);
-    }
-
-    /// Why: The exit code must track the verdict for automation.
-    /// What: Asserts 0 for all-ok and 2 for a failure.
-    /// Test: This is the test.
-    #[test]
-    fn exit_code_reflects_all_ok() {
-        let ok = InstallReport::build(vec![outcome("a", true, "")]);
-        assert_eq!(ok.exit_code(), 0);
-        let bad = InstallReport::build(vec![outcome("a", false, "x")]);
-        assert_eq!(bad.exit_code(), 2);
-    }
-
-    /// Why: Re-review fix — `binary_size` must resolve under a non-default
-    /// `CARGO_HOME` (CI installs there). The rule lives in the pure
-    /// `cargo_bin_dir_from_env`, exercised here WITHOUT mutating the process
-    /// environment so the test is safe to run in parallel with any other test.
-    /// What: A non-empty value yields `<that>/bin`.
-    /// Test: This is the test.
-    #[test]
-    fn cargo_bin_dir_from_env_honours_value() {
-        assert_eq!(
-            cargo_bin_dir_from_env(Some("/tmp/fake-cargo-home")),
-            Some(std::path::PathBuf::from("/tmp/fake-cargo-home").join("bin"))
-        );
-    }
-
-    /// Why: An empty or absent `CARGO_HOME` must fall back to `~/.cargo/bin`.
-    /// What: Both `Some("")` and `None` resolve to a path ending in `.cargo/bin`.
-    /// Test: This is the test.
-    #[test]
-    fn cargo_bin_dir_from_env_falls_back() {
-        for value in [Some(""), None] {
-            if let Some(p) = cargo_bin_dir_from_env(value) {
-                assert!(p.ends_with(std::path::Path::new(".cargo").join("bin")));
-            }
-        }
-    }
-
-    /// Why: An unknown member must be a clean error (exit 3), not a silent skip.
-    /// What: Calls `run` with a bogus member in `--json` mode; asserts exit 3.
-    /// Test: This is the test.
-    #[test]
-    fn run_unknown_member_is_error() {
-        let code = run(&["not-a-real-tool".to_owned()], true, true, false, false);
-        assert_eq!(code, 3);
-    }
-
-    /// Why: #2112 — `--dry-run` must preview and exit 0 WITHOUT installing,
-    /// regardless of `--yes`. A `--json` invocation keeps the test hermetic
-    /// (no interactive picker, no TTY-dependent branch).
-    /// What: Calls `run` with `dry_run: true`, `yes: false`; asserts exit 0.
-    /// Test: This is the test.
-    #[test]
-    fn run_dry_run_exits_zero() {
-        let code = run(&["tga".to_owned()], false, true, false, true);
-        assert_eq!(code, 0);
-    }
-
-    // #2112 review (HIGH): a `run_non_tty_no_yes_refuses` test previously
-    // called the real `run()` relying on the test harness's ambient stdin not
-    // being a TTY. That is unsound: on a developer's interactive terminal
-    // `is_tty()` returns true → `InstallGate::NeedsPrompt` → `prompt_yes_no`
-    // blocks forever on `stdin().read_line()`, hanging the test suite. The
-    // #2112 regression this was meant to guard — non-TTY + no `--yes` must
-    // REFUSE — is already exhaustively covered, TTY-independent, by
-    // `super::install_gate::tests::decide_non_tty_refuses` (mirrors the
-    // established `upgrade.rs`/`update_engine.rs` split: `resolve_and_apply`
-    // is side-effecting and validated manually, `decide_apply` is the unit-
-    // tested pure gate). No `run()`-level replacement is added here.
-
-    /// Why: The `--dry-run` JSON envelope is a public contract; pin its shape
-    /// and the `service_bootstrap` derivation (enabled AND launchd-managed).
-    /// What: Builds a report over a launchd daemon + a non-daemon with service
-    /// bootstrap enabled; asserts per-member `service_bootstrap` values.
-    /// Test: This is the test.
-    #[test]
-    fn dry_run_report_shape() {
-        let members = vec![
-            stable_member_for_test("trusty-search", "trusty-search", ManageStrategy::Launchd),
-            stable_member_for_test("tga", "tga", ManageStrategy::None),
-        ];
-        let report = build_dry_run_report(&members, true);
-        assert_eq!(report.command, "install");
-        assert!(report.dry_run);
-        assert!(report.service_bootstrap_enabled);
-        assert_eq!(report.members.len(), 2);
-        assert!(
-            report.members[0].service_bootstrap,
-            "launchd member should plan a service bootstrap"
-        );
-        assert!(
-            !report.members[1].service_bootstrap,
-            "non-daemon member must not plan a service bootstrap"
-        );
-
-        let disabled = build_dry_run_report(&members, false);
-        assert!(
-            !disabled.members[0].service_bootstrap,
-            "disabled service bootstrap must suppress every member"
-        );
-    }
-
-    /// Why: #2112 review (MEDIUM) — `--dry-run` always bypasses the
-    /// interactive picker (`run`'s picker gate requires `!dry_run`), so a
-    /// no-members `--dry-run` must preview the FULL stable set, not whatever
-    /// subset a TTY-driven picker might otherwise offer. `run()`'s exit code
-    /// can't be inspected for the resolved set without capturing stdout, so
-    /// this pins the composition `run()` itself uses:
-    /// `select_members_transitive(&[])` (what an empty `members` slice
-    /// resolves to) fed into `build_dry_run_report`.
-    /// What: Resolving `&[]` yields every [`stable_set`] member, in order,
-    /// and the dry-run report carries them all.
-    /// Test: This is the test.
-    #[test]
-    fn dry_run_full_set_when_no_members_named() {
-        let resolved = select_members_transitive(&[]);
-        let all = super::super::stable_set::stable_set();
-        assert_eq!(
-            resolved.members.len(),
-            all.len(),
-            "empty members must resolve to the full stable set"
-        );
-
-        let report = build_dry_run_report(&resolved.members, true);
-        let names: Vec<&str> = report.members.iter().map(|m| m.member.as_str()).collect();
-        let expected: Vec<&str> = all.iter().map(|m| m.crate_name.as_str()).collect();
-        assert_eq!(
-            names, expected,
-            "dry-run preview must list every stable-set member, in order, when none are named"
-        );
-    }
-
-    /// Test-only `StableMember` builder — its fields are public for reads but
-    /// `stable_set` only constructs instances via its own invariant-deriving
-    /// constructor; this builds one directly for the dry-run shaping test.
-    fn stable_member_for_test(
-        crate_name: &str,
-        binary: &str,
-        manage: ManageStrategy,
-    ) -> StableMember {
-        StableMember {
-            crate_name: crate_name.to_owned(),
-            binary: binary.to_owned(),
-            daemon: manage == ManageStrategy::Launchd,
-            manage,
-        }
-    }
-}
+#[path = "install_tests.rs"]
+mod tests;

--- a/crates/trusty-installer/src/commands/install_tests.rs
+++ b/crates/trusty-installer/src/commands/install_tests.rs
@@ -1,0 +1,311 @@
+//! Unit tests for the `install` module.
+//!
+//! Why: Keeping tests in a sibling file rather than inline in `install.rs` lets
+//! the definition file stay under the 500-line production cap (CLAUDE.md /
+//! `scripts/check_line_cap.sh`) while retaining full coverage — mirrors the
+//! `cli.rs` / `cli_tests.rs` split.
+//!
+//! What: Covers the `InstallReport` JSON shaping and `all_ok` derivation
+//! (including the #2560 verify-tail fold and the #3527 supervisor-bootstrap
+//! gating predicate), the `--dry-run` preview report, and the unknown-member /
+//! dry-run exit-code paths of `run`. The network / `cargo install` path and
+//! the confirmation gate's TTY plumbing are side-effecting and covered
+//! elsewhere (see `install.rs`'s module doc).
+//!
+//! Test: `cargo test -p trusty-installer` runs all tests in this file.
+
+use super::*;
+
+/// Build an `InstallOutcome` with the pre-#2566 default service state
+/// (not attempted — `service_ok: true`, empty detail), so tests that only
+/// care about the binary-install dimension don't have to repeat the two
+/// new fields at every call site.
+fn outcome(member: &str, ok: bool, detail: &str) -> InstallOutcome {
+    InstallOutcome {
+        member: member.to_owned(),
+        ok,
+        detail: detail.to_owned(),
+        service_ok: true,
+        service_detail: String::new(),
+    }
+}
+
+/// Why: The JSON envelope is a public contract; pin its shape.
+/// What: Builds a report and asserts the serialised keys/values.
+/// Test: This is the test.
+#[test]
+fn report_serialises() {
+    let report = InstallReport::build(vec![outcome("trusty-search", true, "installed")]);
+    let v = serde_json::to_value(&report).expect("serialises");
+    assert_eq!(v["command"], "install");
+    assert_eq!(v["all_ok"], true);
+    assert_eq!(v["members"][0]["member"], "trusty-search");
+    assert_eq!(v["members"][0]["service_ok"], true);
+}
+
+/// Why: `all_ok` must be false if any member's BINARY install failed.
+/// What: Mixes an ok and a failed outcome; asserts `all_ok = false`.
+/// Test: This is the test.
+#[test]
+fn report_all_ok() {
+    let report = InstallReport::build(vec![outcome("a", true, ""), outcome("b", false, "boom")]);
+    assert!(!report.all_ok);
+}
+
+/// Why: #2566 review — a binary can install cleanly (`ok: true`) while its
+/// SERVICE bootstrap genuinely fails; the report must not claim
+/// `all_ok: true` in that case (the exact failure class #2557 existed
+/// because of: a "successfully installed" daemon that never actually
+/// works). A `Skipped` service outcome (opt-out, non-service member, or
+/// plist already present) must NOT be treated as a failure.
+/// What: one member with `ok: true, service_ok: false` → `all_ok == false`;
+/// a second report with `ok: true, service_ok: true` (skip case) →
+/// `all_ok == true`.
+/// Test: this is the test.
+#[test]
+fn report_all_ok_reflects_service_failure() {
+    let failed = InstallReport::build(vec![InstallOutcome {
+        member: "trusty-search".to_owned(),
+        ok: true,
+        detail: "installed".to_owned(),
+        service_ok: false,
+        service_detail: "service bootstrap failed (non-fatal): boom".to_owned(),
+    }]);
+    assert!(
+        !failed.all_ok,
+        "a genuine service bootstrap failure must flip all_ok to false"
+    );
+    assert_eq!(failed.exit_code(), 2);
+
+    let skipped = InstallReport::build(vec![InstallOutcome {
+        member: "trusty-search".to_owned(),
+        ok: true,
+        detail: "installed".to_owned(),
+        service_ok: true,
+        service_detail: "launchd plist already present — left untouched".to_owned(),
+    }]);
+    assert!(
+        skipped.all_ok,
+        "a skipped (not failed) service bootstrap must not flip all_ok"
+    );
+    assert_eq!(skipped.exit_code(), 0);
+}
+
+/// Why: #3527 — trusty-mpm's supervisor bootstrap must respect the SAME
+/// `--no-service` / `TCTL_NO_SERVICE_BOOTSTRAP` opt-out as every other
+/// daemon, even though its `ManageStrategy::OwnVerb` makes
+/// `plans_service_bootstrap` always `false` for it.
+/// What: asserts the predicate is `true` only when `service_enabled` AND
+/// the member is trusty-mpm; `false` for a disabled flag or a different
+/// member.
+/// Test: This is the test.
+#[test]
+fn plans_mpm_supervisor_bootstrap_respects_flag() {
+    let mpm = stable_member_for_test("trusty-mpm", "trusty-mpm", ManageStrategy::OwnVerb);
+    let search = stable_member_for_test("trusty-search", "trusty-search", ManageStrategy::Launchd);
+
+    assert!(plans_mpm_supervisor_bootstrap(&mpm, true));
+    assert!(
+        !plans_mpm_supervisor_bootstrap(&mpm, false),
+        "--no-service / TCTL_NO_SERVICE_BOOTSTRAP must disable the supervisor bootstrap too"
+    );
+    assert!(
+        !plans_mpm_supervisor_bootstrap(&search, true),
+        "the predicate must only ever apply to trusty-mpm"
+    );
+}
+
+/// Why: #2560 — the folded report's `all_ok` (and hence exit code) must
+/// reflect a verify-tail failure even though the binary + service install
+/// itself succeeded — never silently report success over a down daemon.
+/// What: an all-ok binary install report folded with a `verified: false`
+/// verify tail flips to `all_ok == false`; folded with `verified: true` it
+/// stays `true`.
+/// Test: This is the test.
+#[test]
+fn with_verify_failure_flips_all_ok() {
+    let base = InstallReport::build(vec![outcome("trusty-search", true, "installed")]);
+    assert!(base.all_ok);
+
+    let verify_failed = crate::commands::verify_tail::VerifyTailReport {
+        command: "install.verify",
+        ensure_ok: true,
+        members: Vec::new(),
+        verified: false,
+    };
+    let folded = base.clone().with_verify(verify_failed);
+    assert!(
+        !folded.all_ok,
+        "a verify-tail failure must flip all_ok to false"
+    );
+    assert_eq!(folded.exit_code(), 2);
+}
+
+/// Why: the converse of the above — a verified success must NOT disturb an
+/// already-ok report.
+/// What: folding a `verified: true` verify tail leaves `all_ok == true`.
+/// Test: This is the test.
+#[test]
+fn with_verify_success_preserves_all_ok() {
+    let base = InstallReport::build(vec![outcome("trusty-search", true, "installed")]);
+    let verify_ok = crate::commands::verify_tail::VerifyTailReport {
+        command: "install.verify",
+        ensure_ok: true,
+        members: Vec::new(),
+        verified: true,
+    };
+    let folded = base.with_verify(verify_ok);
+    assert!(folded.all_ok);
+    assert_eq!(folded.exit_code(), 0);
+}
+
+/// Why: The exit code must track the verdict for automation.
+/// What: Asserts 0 for all-ok and 2 for a failure.
+/// Test: This is the test.
+#[test]
+fn exit_code_reflects_all_ok() {
+    let ok = InstallReport::build(vec![outcome("a", true, "")]);
+    assert_eq!(ok.exit_code(), 0);
+    let bad = InstallReport::build(vec![outcome("a", false, "x")]);
+    assert_eq!(bad.exit_code(), 2);
+}
+
+/// Why: Re-review fix — `binary_size` must resolve under a non-default
+/// `CARGO_HOME` (CI installs there). The rule lives in the pure
+/// `cargo_bin_dir_from_env`, exercised here WITHOUT mutating the process
+/// environment so the test is safe to run in parallel with any other test.
+/// What: A non-empty value yields `<that>/bin`.
+/// Test: This is the test.
+#[test]
+fn cargo_bin_dir_from_env_honours_value() {
+    assert_eq!(
+        cargo_bin_dir_from_env(Some("/tmp/fake-cargo-home")),
+        Some(std::path::PathBuf::from("/tmp/fake-cargo-home").join("bin"))
+    );
+}
+
+/// Why: An empty or absent `CARGO_HOME` must fall back to `~/.cargo/bin`.
+/// What: Both `Some("")` and `None` resolve to a path ending in `.cargo/bin`.
+/// Test: This is the test.
+#[test]
+fn cargo_bin_dir_from_env_falls_back() {
+    for value in [Some(""), None] {
+        if let Some(p) = cargo_bin_dir_from_env(value) {
+            assert!(p.ends_with(std::path::Path::new(".cargo").join("bin")));
+        }
+    }
+}
+
+/// Why: An unknown member must be a clean error (exit 3), not a silent skip.
+/// What: Calls `run` with a bogus member in `--json` mode; asserts exit 3.
+/// Test: This is the test.
+#[test]
+fn run_unknown_member_is_error() {
+    let code = run(
+        &["not-a-real-tool".to_owned()],
+        true,
+        true,
+        false,
+        false,
+        false,
+        true,
+    );
+    assert_eq!(code, 3);
+}
+
+/// Why: #2112 — `--dry-run` must preview and exit 0 WITHOUT installing,
+/// regardless of `--yes`. A `--json` invocation keeps the test hermetic
+/// (no interactive picker, no TTY-dependent branch).
+/// What: Calls `run` with `dry_run: true`, `yes: false`; asserts exit 0.
+/// Test: This is the test.
+#[test]
+fn run_dry_run_exits_zero() {
+    let code = run(&["tga".to_owned()], false, true, false, true, false, true);
+    assert_eq!(code, 0);
+}
+
+// #2112 review (HIGH): a `run_non_tty_no_yes_refuses` test previously
+// called the real `run()` relying on the test harness's ambient stdin not
+// being a TTY. That is unsound: on a developer's interactive terminal
+// `is_tty()` returns true → `InstallGate::NeedsPrompt` → `prompt_yes_no`
+// blocks forever on `stdin().read_line()`, hanging the test suite. The
+// #2112 regression this was meant to guard — non-TTY + no `--yes` must
+// REFUSE — is already exhaustively covered, TTY-independent, by
+// `super::install_gate::tests::decide_non_tty_refuses` (mirrors the
+// established `upgrade.rs`/`update_engine.rs` split: `resolve_and_apply`
+// is side-effecting and validated manually, `decide_apply` is the unit-
+// tested pure gate). No `run()`-level replacement is added here.
+
+/// Why: The `--dry-run` JSON envelope is a public contract; pin its shape
+/// and the `service_bootstrap` derivation (enabled AND launchd-managed).
+/// What: Builds a report over a launchd daemon + a non-daemon with service
+/// bootstrap enabled; asserts per-member `service_bootstrap` values.
+/// Test: This is the test.
+#[test]
+fn dry_run_report_shape() {
+    let members = vec![
+        stable_member_for_test("trusty-search", "trusty-search", ManageStrategy::Launchd),
+        stable_member_for_test("tga", "tga", ManageStrategy::None),
+    ];
+    let report = build_dry_run_report(&members, true);
+    assert_eq!(report.command, "install");
+    assert!(report.dry_run);
+    assert!(report.service_bootstrap_enabled);
+    assert_eq!(report.members.len(), 2);
+    assert!(
+        report.members[0].service_bootstrap,
+        "launchd member should plan a service bootstrap"
+    );
+    assert!(
+        !report.members[1].service_bootstrap,
+        "non-daemon member must not plan a service bootstrap"
+    );
+
+    let disabled = build_dry_run_report(&members, false);
+    assert!(
+        !disabled.members[0].service_bootstrap,
+        "disabled service bootstrap must suppress every member"
+    );
+}
+
+/// Why: #2112 review (MEDIUM) — `--dry-run` always bypasses the
+/// interactive picker (`run`'s picker gate requires `!dry_run`), so a
+/// no-members `--dry-run` must preview the FULL stable set, not whatever
+/// subset a TTY-driven picker might otherwise offer. `run()`'s exit code
+/// can't be inspected for the resolved set without capturing stdout, so
+/// this pins the composition `run()` itself uses:
+/// `select_members_transitive(&[])` (what an empty `members` slice
+/// resolves to) fed into `build_dry_run_report`.
+/// What: Resolving `&[]` yields every [`stable_set`] member, in order,
+/// and the dry-run report carries them all.
+/// Test: This is the test.
+#[test]
+fn dry_run_full_set_when_no_members_named() {
+    let resolved = select_members_transitive(&[]);
+    let all = super::super::stable_set::stable_set();
+    assert_eq!(
+        resolved.members.len(),
+        all.len(),
+        "empty members must resolve to the full stable set"
+    );
+
+    let report = build_dry_run_report(&resolved.members, true);
+    let names: Vec<&str> = report.members.iter().map(|m| m.member.as_str()).collect();
+    let expected: Vec<&str> = all.iter().map(|m| m.crate_name.as_str()).collect();
+    assert_eq!(
+        names, expected,
+        "dry-run preview must list every stable-set member, in order, when none are named"
+    );
+}
+
+/// Test-only `StableMember` builder — its fields are public for reads but
+/// `stable_set` only constructs instances via its own invariant-deriving
+/// constructor; this builds one directly for the dry-run shaping test.
+fn stable_member_for_test(crate_name: &str, binary: &str, manage: ManageStrategy) -> StableMember {
+    StableMember {
+        crate_name: crate_name.to_owned(),
+        binary: binary.to_owned(),
+        daemon: manage == ManageStrategy::Launchd,
+        manage,
+    }
+}

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -41,6 +41,7 @@ pub mod up;
 pub mod update_engine;
 pub mod updates;
 pub mod upgrade;
+pub mod verify_tail;
 pub mod version;
 
 use crate::cli::AnalyzeCoreArg;

--- a/crates/trusty-installer/src/commands/plist_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/plist_bootstrap.rs
@@ -11,8 +11,25 @@
 //! platforms the function is a no-op and prints a hint toward the systemd unit.
 //! Idempotent: if the label is already loaded it is booted out first.
 //!
-//! Test: `tests` covers the placeholder replacement as a pure function (no
-//! launchctl calls in tests).
+//! `#3527` hardening — this used to run UNCONDITIONALLY whenever trusty-mpm
+//! installed, the one member exempt from the #2556 `plans_service_bootstrap`
+//! opt-out, and with no protection against clobbering a newer live daemon with
+//! an older one:
+//! 1. The caller (`install.rs`) now gates the call itself behind the same
+//!    `--no-service` / `TCTL_NO_SERVICE_BOOTSTRAP` decision every other daemon
+//!    honours (see `install::plans_mpm_supervisor_bootstrap`); when skipped,
+//!    this module is never invoked and never touches launchd.
+//! 2. [`decide_downgrade`] refuses to replace an already-registered supervisor
+//!    with an older-or-equal version unless `force` is set — see
+//!    [`install_mpm_supervisor`]'s `force` parameter.
+//! 3. [`HOME_OVERRIDE_ENV`] / [`SKIP_LAUNCHCTL_ENV`] let a sandboxed test
+//!    exercise the plist-write + downgrade-guard decision without touching the
+//!    real user's `~/Library/LaunchAgents` or the real `gui/<uid>` launchd
+//!    domain.
+//!
+//! Test: `tests` covers the placeholder replacement, the downgrade-guard
+//! decision table, and the registered-binary-path parser as pure functions (no
+//! launchctl calls in tests unless `SKIP_LAUNCHCTL_ENV` is set).
 
 /// The plist label for the trusty-mpm supervisor.
 ///
@@ -23,6 +40,29 @@
 ///
 /// Test: `tests::label_constant_matches_plist`.
 pub const PLIST_LABEL: &str = "com.trusty.mpm.supervisor";
+
+/// Test/E2E escape hatch: overrides the home directory used to resolve the
+/// plist path, the log directory, and the `__HOME__` template token (#3527).
+///
+/// Why: a sandboxed installer E2E needs to exercise the plist-write +
+/// downgrade-guard decision without writing into the real user's
+/// `~/Library/LaunchAgents`. Mirrors the `TRUSTY_DATA_DIR_OVERRIDE` pattern
+/// already used by `ensure::project_setup` for the same reason.
+///
+/// **Intended for tests only** — never set in production.
+///
+/// Test: `tests::resolve_home_honours_override`.
+pub const HOME_OVERRIDE_ENV: &str = "TCTL_MPM_SUPERVISOR_HOME_OVERRIDE";
+
+/// Test/E2E escape hatch: when set (to any value), skips the actual
+/// `launchctl bootout`/`bootstrap` subprocess calls — the plist is still
+/// written to disk (so the write + downgrade-guard logic is exercised) but the
+/// real `gui/<uid>` launchd domain is never touched (#3527).
+///
+/// **Intended for tests only** — never set in production.
+///
+/// Test: `tests::install_mpm_supervisor_writes_plist_and_skips_launchctl`.
+pub const SKIP_LAUNCHCTL_ENV: &str = "TCTL_MPM_SUPERVISOR_SKIP_LAUNCHCTL";
 
 /// The embedded plist template with `__HOME__` and `__TM_BINARY_PATH__` tokens.
 ///
@@ -101,21 +141,32 @@ pub fn fill_template(home: &str, tm_path: &str) -> String {
 /// step so the operator does not need to follow the README manually.
 ///
 /// What: On macOS only (cfg gate): resolves home dir and tm binary path, fills
-/// the template, creates the log directory, writes the plist to
+/// the template, creates the log directory, applies the [`decide_downgrade`]
+/// guard against a previously-registered plist, writes the plist to
 /// `~/Library/LaunchAgents/com.trusty.mpm.supervisor.plist`, and runs
 /// `launchctl bootstrap gui/<uid> <plist>` (booting out first if the label is
-/// already loaded). On non-macOS: prints a short hint toward the systemd unit
-/// and returns Ok(()).
+/// already loaded) — unless [`SKIP_LAUNCHCTL_ENV`] is set, in which case the
+/// plist is written but launchd is never touched. On non-macOS: prints a short
+/// hint toward the systemd unit and returns Ok(()).
 ///
-/// Test: `tests` covers template filling (pure); launchctl calls are
-/// side-effecting and not invoked in tests.
-pub fn install_mpm_supervisor() -> anyhow::Result<()> {
+/// `force` (#3527) bypasses the downgrade guard — see [`decide_downgrade`].
+/// The caller (`install::install_all`) is responsible for gating whether this
+/// function is called at all (`--no-service` / `TCTL_NO_SERVICE_BOOTSTRAP`);
+/// this function itself never re-checks that opt-out.
+///
+/// Test: `tests` covers template filling, the downgrade decision, and the
+/// registered-binary parser (all pure); the plist write + `launchctl` calls are
+/// side-effecting — `tests::install_mpm_supervisor_writes_plist_and_skips_launchctl`
+/// exercises the full write path via [`HOME_OVERRIDE_ENV`] / [`SKIP_LAUNCHCTL_ENV`]
+/// without touching the real user domain.
+pub fn install_mpm_supervisor(force: bool) -> anyhow::Result<()> {
     #[cfg(target_os = "macos")]
     {
-        install_mpm_supervisor_macos()
+        install_mpm_supervisor_macos(force)
     }
     #[cfg(not(target_os = "macos"))]
     {
+        let _ = force;
         eprintln!(
             "trusty-mpm supervisor: on Linux, install the systemd unit \
              at `crates/trusty-mpm/deploy/supervisor/trusty-mpm-supervisor.service`."
@@ -124,12 +175,114 @@ pub fn install_mpm_supervisor() -> anyhow::Result<()> {
     }
 }
 
+/// Resolve the home directory used for the plist/log paths, honouring
+/// [`HOME_OVERRIDE_ENV`] (#3527 sandboxed-E2E escape hatch).
+///
+/// Why: extracted so the override check is exercised by
+/// [`install_mpm_supervisor_macos`] without duplicating the env lookup.
+/// What: returns the override when set and non-empty, else `dirs::home_dir()`.
+/// Test: `tests::resolve_home_honours_override`.
 #[cfg(target_os = "macos")]
-fn install_mpm_supervisor_macos() -> anyhow::Result<()> {
+fn resolve_home() -> anyhow::Result<std::path::PathBuf> {
+    if let Some(v) = std::env::var_os(HOME_OVERRIDE_ENV) {
+        if !v.is_empty() {
+            return Ok(std::path::PathBuf::from(v));
+        }
+    }
+    dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("cannot determine home directory for plist bootstrap"))
+}
+
+/// The downgrade-guard verdict (#3527).
+///
+/// Why: a pure enum keeps [`decide_downgrade`] trivially unit-testable
+/// independent of the filesystem/subprocess calls that gather its inputs.
+/// What: [`DowngradeDecision::Proceed`] — safe to write the new plist and
+/// (re-)bootstrap; [`DowngradeDecision::Refuse`] — leave the existing
+/// registration untouched.
+/// Test: `tests::decide_downgrade_*`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DowngradeDecision {
+    /// Safe to replace the registered supervisor.
+    Proceed,
+    /// The candidate is not newer than what is currently registered — refuse.
+    Refuse,
+}
+
+/// Decide whether replacing a registered supervisor with `candidate` is safe.
+///
+/// Why: THE #3527 safety property — `tctl install` must never silently
+/// downgrade a live trusty-mpm supervisor (e.g. a stale GitHub release
+/// clobbering a newer crates.io install). Encoding the comparison as one pure
+/// function makes it exhaustively testable without a real plist or subprocess.
+///
+/// What:
+/// - `force` → always [`DowngradeDecision::Proceed`] (explicit operator
+///   override).
+/// - `current` is `None` (nothing registered yet, or its version could not be
+///   determined) → [`DowngradeDecision::Proceed`] — there is nothing to guard
+///   against.
+/// - Both `current` and `candidate` parse as [`semver::Version`] and
+///   `candidate <= current` → [`DowngradeDecision::Refuse`] ("older-or-equal").
+/// - Otherwise (candidate is strictly newer, or either string fails to parse
+///   as semver and no comparison is possible) → [`DowngradeDecision::Proceed`].
+///   An unparseable version means we cannot prove this IS a downgrade, so we
+///   fail open rather than block a legitimate install on a version-string
+///   quirk — the guard exists to catch the *provable* downgrade case.
+///
+/// Test: `tests::decide_downgrade_force_always_proceeds`,
+/// `tests::decide_downgrade_no_current_proceeds`,
+/// `tests::decide_downgrade_newer_proceeds`,
+/// `tests::decide_downgrade_older_refuses`,
+/// `tests::decide_downgrade_equal_refuses`,
+/// `tests::decide_downgrade_unparseable_proceeds`.
+pub fn decide_downgrade(
+    current: Option<&str>,
+    candidate: Option<&str>,
+    force: bool,
+) -> DowngradeDecision {
+    if force {
+        return DowngradeDecision::Proceed;
+    }
+    let (Some(current), Some(candidate)) = (current, candidate) else {
+        return DowngradeDecision::Proceed;
+    };
+    let parsed = (
+        semver::Version::parse(current.trim_start_matches('v')),
+        semver::Version::parse(candidate.trim_start_matches('v')),
+    );
+    match parsed {
+        (Ok(cur), Ok(cand)) if cand <= cur => DowngradeDecision::Refuse,
+        _ => DowngradeDecision::Proceed,
+    }
+}
+
+/// Extract the registered `tm` binary path from an existing plist's
+/// `ProgramArguments` array.
+///
+/// Why: the downgrade guard needs to probe the CURRENTLY-registered binary's
+/// `--version` before overwriting the plist. Parsing the already-on-disk plist
+/// (rather than shelling out to `launchctl print`) keeps the guard
+/// self-contained and unit-testable as pure text parsing.
+/// What: finds the `<key>ProgramArguments</key>` marker, then returns the
+/// content of the first `<string>…</string>` element after it (the `tm` binary
+/// path — `supervisor` is the second array entry). Returns `None` if either
+/// marker is missing.
+/// Test: `tests::extract_program_path_finds_binary`,
+/// `tests::extract_program_path_missing_key_is_none`.
+pub fn extract_program_path(plist_xml: &str) -> Option<String> {
+    let idx = plist_xml.find("<key>ProgramArguments</key>")?;
+    let rest = &plist_xml[idx..];
+    let start = rest.find("<string>")? + "<string>".len();
+    let end = rest[start..].find("</string>")? + start;
+    Some(rest[start..end].to_owned())
+}
+
+#[cfg(target_os = "macos")]
+fn install_mpm_supervisor_macos(force: bool) -> anyhow::Result<()> {
     use anyhow::Context;
 
-    let home = dirs::home_dir()
-        .ok_or_else(|| anyhow::anyhow!("cannot determine home directory for plist bootstrap"))?;
+    let home = resolve_home()?;
     let home_str = home
         .to_str()
         .ok_or_else(|| anyhow::anyhow!("home directory path is not valid UTF-8"))?;
@@ -151,8 +304,43 @@ fn install_mpm_supervisor_macos() -> anyhow::Result<()> {
     std::fs::create_dir_all(&agents_dir)
         .with_context(|| format!("creating LaunchAgents dir {}", agents_dir.display()))?;
     let plist_path = agents_dir.join(format!("{PLIST_LABEL}.plist"));
+
+    // #3527: downgrade guard — refuse to replace an already-registered
+    // supervisor with an older-or-equal version unless `force`.
+    if let Ok(existing) = std::fs::read_to_string(&plist_path) {
+        if let Some(old_binary) = extract_program_path(&existing) {
+            let current_version = super::update_engine::installed_version(&old_binary);
+            let candidate_version = super::update_engine::installed_version(tm_path_str);
+            if decide_downgrade(
+                current_version.as_deref(),
+                candidate_version.as_deref(),
+                force,
+            ) == DowngradeDecision::Refuse
+            {
+                anyhow::bail!(
+                    "refusing to replace trusty-mpm supervisor: registered version {} is not \
+                     older than the candidate version {} being installed; pass --force to \
+                     override (this refusal leaves the currently-running supervisor untouched)",
+                    current_version.as_deref().unwrap_or("<unknown>"),
+                    candidate_version.as_deref().unwrap_or("<unknown>"),
+                );
+            }
+        }
+    }
+
     std::fs::write(&plist_path, &plist_content)
         .with_context(|| format!("writing plist to {}", plist_path.display()))?;
+
+    // #3527: sandboxed E2E escape hatch — the plist above is still written
+    // (so the write + downgrade-guard logic is exercised) but the real
+    // `gui/<uid>` launchd domain is never touched.
+    if std::env::var_os(SKIP_LAUNCHCTL_ENV).is_some() {
+        eprintln!(
+            "trusty-mpm supervisor: plist written to {} ({SKIP_LAUNCHCTL_ENV} set — launchctl skipped).",
+            plist_path.display()
+        );
+        return Ok(());
+    }
 
     // Resolve the current user UID for launchctl gui/<uid>.
     let uid = resolve_uid();
@@ -237,6 +425,11 @@ pub fn resolve_uid() -> u32 {
 mod tests {
     use super::*;
 
+    /// Process-wide lock serialising tests that mutate [`HOME_OVERRIDE_ENV`] /
+    /// [`SKIP_LAUNCHCTL_ENV`] (process-global env vars would otherwise race
+    /// across parallel test threads — mirrors `ensure::ENV_TEST_LOCK`).
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// Why: The template must contain the two placeholder tokens so fill_template
     /// has something to replace.
     /// What: Asserts both `__HOME__` and `__TM_BINARY_PATH__` appear in the raw
@@ -317,5 +510,214 @@ mod tests {
         let uid = resolve_uid();
         // uid is always a valid u32 — the function never panics.
         let _ = uid; // just confirm it compiled and ran without panic
+    }
+
+    // ── decide_downgrade (#3527) ─────────────────────────────────────────────
+
+    /// Why: `--force` is the explicit operator override; it must always win
+    /// regardless of the version comparison.
+    /// What: A strictly-older candidate with `force = true` still proceeds.
+    /// Test: This is the test.
+    #[test]
+    fn decide_downgrade_force_always_proceeds() {
+        assert_eq!(
+            decide_downgrade(Some("2.0.0"), Some("1.0.0"), true),
+            DowngradeDecision::Proceed
+        );
+    }
+
+    /// Why: with nothing currently registered (or its version undeterminable),
+    /// there is nothing to guard against — a fresh install must proceed.
+    /// What: `current = None` proceeds regardless of the candidate.
+    /// Test: This is the test.
+    #[test]
+    fn decide_downgrade_no_current_proceeds() {
+        assert_eq!(
+            decide_downgrade(None, Some("0.1.0"), false),
+            DowngradeDecision::Proceed
+        );
+    }
+
+    /// Why: the core happy path — a strictly newer candidate must always
+    /// proceed without needing `--force`.
+    /// What: candidate > current → Proceed.
+    /// Test: This is the test.
+    #[test]
+    fn decide_downgrade_newer_proceeds() {
+        assert_eq!(
+            decide_downgrade(Some("0.19.27"), Some("0.20.0"), false),
+            DowngradeDecision::Proceed
+        );
+    }
+
+    /// Why: THE #3527 regression this guard exists for — an older candidate
+    /// (e.g. a stale GitHub release) must be refused without `--force`.
+    /// What: candidate < current → Refuse.
+    /// Test: This is the test.
+    #[test]
+    fn decide_downgrade_older_refuses() {
+        assert_eq!(
+            decide_downgrade(Some("0.19.27"), Some("0.16.0"), false),
+            DowngradeDecision::Refuse
+        );
+    }
+
+    /// Why: "older-or-equal" per the #3527 spec — a same-version reinstall
+    /// must also be refused (no-op re-bootstrap is not worth a live daemon
+    /// bootout/bootstrap cycle).
+    /// What: candidate == current → Refuse.
+    /// Test: This is the test.
+    #[test]
+    fn decide_downgrade_equal_refuses() {
+        assert_eq!(
+            decide_downgrade(Some("0.19.27"), Some("0.19.27"), false),
+            DowngradeDecision::Refuse
+        );
+    }
+
+    /// Why: an unparseable version string means we cannot PROVE a downgrade;
+    /// failing open avoids blocking a legitimate install on a version-string
+    /// quirk. Also covers a leading `v` prefix being stripped correctly.
+    /// What: unparseable current/candidate → Proceed; `v`-prefixed versions
+    /// parse and compare normally.
+    /// Test: This is the test.
+    #[test]
+    fn decide_downgrade_unparseable_proceeds() {
+        assert_eq!(
+            decide_downgrade(Some("not-a-version"), Some("0.1.0"), false),
+            DowngradeDecision::Proceed
+        );
+        assert_eq!(
+            decide_downgrade(Some("0.1.0"), Some("not-a-version"), false),
+            DowngradeDecision::Proceed
+        );
+        // `v`-prefixed versions must still compare correctly (not treated as
+        // unparseable).
+        assert_eq!(
+            decide_downgrade(Some("v0.19.27"), Some("v0.16.0"), false),
+            DowngradeDecision::Refuse
+        );
+    }
+
+    // ── extract_program_path (#3527) ─────────────────────────────────────────
+
+    /// Why: the downgrade guard parses the EXISTING on-disk plist to find which
+    /// binary is currently registered; pin the happy path against a real
+    /// filled template.
+    /// What: fills the template with a synthetic path and asserts the parser
+    /// recovers it exactly.
+    /// Test: This is the test.
+    #[test]
+    fn extract_program_path_finds_binary() {
+        let filled = fill_template("/home/testuser", "/home/testuser/.local/bin/tm");
+        assert_eq!(
+            extract_program_path(&filled),
+            Some("/home/testuser/.local/bin/tm".to_owned())
+        );
+    }
+
+    /// Why: a plist missing the `ProgramArguments` key (malformed / unexpected
+    /// content) must not panic — the guard should just skip the comparison.
+    /// What: asserts `None` on XML without the key.
+    /// Test: This is the test.
+    #[test]
+    fn extract_program_path_missing_key_is_none() {
+        assert_eq!(extract_program_path("<plist><dict></dict></plist>"), None);
+    }
+
+    // ── resolve_home (#3527) ──────────────────────────────────────────────────
+
+    /// Why: the sandboxed-E2E escape hatch must actually redirect the resolved
+    /// home directory when set.
+    /// What: sets [`HOME_OVERRIDE_ENV`] to a temp dir; asserts `resolve_home`
+    /// returns it verbatim.
+    /// Test: This is the test.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn resolve_home_honours_override() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var(HOME_OVERRIDE_ENV, tmp.path());
+        let resolved = resolve_home().expect("resolve_home");
+        std::env::remove_var(HOME_OVERRIDE_ENV);
+        assert_eq!(resolved, tmp.path());
+    }
+
+    // ── install_mpm_supervisor end-to-end (macOS, sandboxed) ────────────────
+
+    /// Why: the full write path (home resolution, plist write, downgrade
+    /// guard) must be exercisable WITHOUT touching the real user's
+    /// `~/Library/LaunchAgents` or the real `gui/<uid>` launchd domain — the
+    /// whole point of the #3527 sandboxed-E2E escape hatches.
+    /// What: with both `HOME_OVERRIDE_ENV` (a temp dir) and
+    /// `SKIP_LAUNCHCTL_ENV` set, calls `install_mpm_supervisor(false)` and
+    /// asserts it succeeds and the plist actually landed under the temp home
+    /// — never under the real home directory.
+    /// Test: This is the test.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn install_mpm_supervisor_writes_plist_and_skips_launchctl() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var(HOME_OVERRIDE_ENV, tmp.path());
+        std::env::set_var(SKIP_LAUNCHCTL_ENV, "1");
+
+        let result = install_mpm_supervisor(false);
+
+        std::env::remove_var(HOME_OVERRIDE_ENV);
+        std::env::remove_var(SKIP_LAUNCHCTL_ENV);
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        let plist_path = tmp
+            .path()
+            .join("Library")
+            .join("LaunchAgents")
+            .join(format!("{PLIST_LABEL}.plist"));
+        assert!(
+            plist_path.exists(),
+            "plist should have been written under the overridden home"
+        );
+    }
+
+    /// Why: when a plist is ALREADY registered but its `ProgramArguments`
+    /// binary no longer exists (so its `--version` cannot be probed), there is
+    /// no PROVABLE downgrade — the guard must fail open rather than block a
+    /// legitimate install on an unprobeable predecessor. Seeding the existing
+    /// plist by hand (rather than depending on whatever `tm` happens to be on
+    /// the test machine's PATH) keeps this hermetic and deterministic
+    /// regardless of the host environment.
+    /// What: writes a plist whose `ProgramArguments[0]` points at a
+    /// guaranteed-nonexistent path, then calls `install_mpm_supervisor(false)`;
+    /// asserts it proceeds (`Ok`).
+    /// Test: This is the test.
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn install_mpm_supervisor_proceeds_when_existing_binary_unprobeable() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var(HOME_OVERRIDE_ENV, tmp.path());
+        std::env::set_var(SKIP_LAUNCHCTL_ENV, "1");
+
+        // Seed an existing plist by hand, pointing at a binary that cannot
+        // possibly exist, so `installed_version` deterministically returns
+        // `None` for the "current" side of the comparison.
+        let agents_dir = tmp.path().join("Library").join("LaunchAgents");
+        std::fs::create_dir_all(&agents_dir).expect("create LaunchAgents dir");
+        let plist_path = agents_dir.join(format!("{PLIST_LABEL}.plist"));
+        let seeded = fill_template(
+            &tmp.path().to_string_lossy(),
+            "/nonexistent/fake-tm-binary-for-test-xyz",
+        );
+        std::fs::write(&plist_path, seeded).expect("seed plist");
+
+        let result = install_mpm_supervisor(false);
+
+        std::env::remove_var(HOME_OVERRIDE_ENV);
+        std::env::remove_var(SKIP_LAUNCHCTL_ENV);
+
+        assert!(
+            result.is_ok(),
+            "an unprobeable existing binary must not block the install: {result:?}"
+        );
     }
 }

--- a/crates/trusty-installer/src/commands/plist_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/plist_bootstrap.rs
@@ -428,6 +428,10 @@ mod tests {
     /// Process-wide lock serialising tests that mutate [`HOME_OVERRIDE_ENV`] /
     /// [`SKIP_LAUNCHCTL_ENV`] (process-global env vars would otherwise race
     /// across parallel test threads — mirrors `ensure::ENV_TEST_LOCK`).
+    ///
+    /// Only referenced by the macOS-only tests below — cfg-gated so a non-macOS
+    /// CI run (where those tests don't exist) doesn't hit `-D dead_code`.
+    #[cfg(target_os = "macos")]
     static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     /// Why: The template must contain the two placeholder tokens so fill_template

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -1,0 +1,325 @@
+//! Post-install verify tail: `ensure` + health, with the #2498 kickstart retry
+//! (#2560).
+//!
+//! Why: `tctl install` placed binaries (and, when enabled, bootstrapped launchd
+//! services) but never confirmed the stack actually came up — an operator
+//! following the `curl | sh` one-liner had no automated signal that a daemon
+//! silently stayed down (the exact "looks installed, actually broken" failure
+//! class #2557 / #2498 exist because of). This module runs immediately after
+//! `install_all` (skipped entirely by `--no-verify`) and its result is folded
+//! into the SAME [`super::install::InstallReport`] so the exit code CI/automation
+//! gates on already reflects it.
+//!
+//! What: [`run_verify_tail`]:
+//! 1. Runs the `.mcp.json` patch + trusty-search index / trusty-memory palace
+//!    registration — the same logic `tctl ensure` runs (reused directly via
+//!    [`super::ensure::mcp_patch`] / [`super::ensure::project_setup`], not
+//!    reimplemented; only the CLI-level render is skipped so `--json` install
+//!    output stays a single JSON object).
+//! 2. Probes health for every selected daemon member.
+//! 3. For any `down` LAUNCHD daemon (the #2498 failure signature: `launchctl
+//!    bootstrap` succeeds but `RunAtLoad` doesn't fire), issues one
+//!    `launchctl kickstart -k gui/<uid>/<label>` and re-probes once before
+//!    accepting `down` as the final verdict for that member.
+//!
+//! [`print_human`] renders the final green/red pass/fail summary — the last
+//! thing the installer prints.
+//!
+//! Test: the pure decision (`needs_kickstart`) and the report's `verified`
+//! derivation are unit-tested; the `ensure` phase and `launchctl kickstart` are
+//! side-effecting and validated manually.
+
+use serde::Serialize;
+
+use super::probe::{health_str, probe_member_health};
+use super::stable_set::{ManageStrategy, StableMember};
+
+/// One member's verify-tail outcome.
+///
+/// Why: a typed row keeps the `--json` output stable + testable.
+/// What: `member` crate name; `health` the (possibly kickstart-retried) health
+/// verdict string; `kickstarted` whether a #2498 kickstart retry was attempted
+/// for this member.
+/// Test: `tests::report_serialises`.
+#[derive(Clone, Debug, Serialize)]
+pub struct VerifyRow {
+    /// Crate name.
+    pub member: String,
+    /// Health verdict after any kickstart retry.
+    pub health: String,
+    /// Whether a `launchctl kickstart -k` retry was attempted (#2498).
+    pub kickstarted: bool,
+}
+
+/// The aggregate verify-tail report (#2560).
+///
+/// Why: `--json` consumers need the ensure + health verdict as one object,
+/// nested inside [`super::install::InstallReport`].
+/// What: `ensure_ok` — whether the `.mcp.json` patch and project-setup stages
+/// all succeeded; `members` — per-daemon health rows; `verified` — the overall
+/// verdict this module derives (see [`VerifyTailReport::build`]).
+/// Test: `tests::verified_requires_ensure_and_health`.
+#[derive(Clone, Debug, Serialize)]
+pub struct VerifyTailReport {
+    /// Fixed command tag for JSON consumers.
+    pub command: &'static str,
+    /// Whether the `.mcp.json` patch + project-setup stages all succeeded.
+    pub ensure_ok: bool,
+    /// Per-daemon-member verify rows.
+    pub members: Vec<VerifyRow>,
+    /// Overall verdict: `ensure_ok` AND every member healthy/stale/unknown
+    /// (never `down`/`not_installed`).
+    pub verified: bool,
+}
+
+impl VerifyTailReport {
+    /// Build a report and derive the overall `verified` verdict.
+    ///
+    /// Why: one place derives the verdict so the JSON and the folded
+    /// `InstallReport.all_ok` can never disagree.
+    /// What: `verified = ensure_ok AND no member is `down`/`not_installed``. A
+    /// `stale` or `unknown` member does NOT fail verification — mirrors
+    /// `stack::health::HealthReport`'s degrade policy exactly (an
+    /// under-the-version-floor daemon is still up; an unprobeable
+    /// process-managed member is not a verified gap).
+    /// Test: `tests::verified_requires_ensure_and_health`,
+    /// `tests::verified_tolerates_stale_and_unknown`.
+    fn build(ensure_ok: bool, members: Vec<VerifyRow>) -> Self {
+        let health_ok = members
+            .iter()
+            .all(|m| m.health != health_str::DOWN && m.health != health_str::NOT_INSTALLED);
+        Self {
+            command: "install.verify",
+            ensure_ok,
+            verified: ensure_ok && health_ok,
+            members,
+        }
+    }
+}
+
+/// Whether a member's health verdict warrants a #2498 kickstart retry.
+///
+/// Why: only a `down` LAUNCHD daemon is the #2498 failure signature
+/// (`launchctl bootstrap` succeeded, `RunAtLoad` never fired); a
+/// `not_installed` member, an `unknown` process-managed member (trusty-mpm),
+/// or a non-launchd member must never trigger a kickstart attempt.
+/// What: `true` iff `health == "down"` AND `manage == Launchd`.
+/// Test: `tests::needs_kickstart_only_for_down_launchd`.
+pub fn needs_kickstart(health: &str, manage: ManageStrategy) -> bool {
+    health == health_str::DOWN && manage == ManageStrategy::Launchd
+}
+
+/// Run `launchctl kickstart -k gui/<uid>/<label>` for a member (macOS only).
+///
+/// Why: the #2498 recovery step — `launchctl bootstrap` can report success
+/// while `RunAtLoad` never actually fires; `kickstart -k` force-starts the job.
+/// What: resolves the uid + launchd label, spawns the command, returns whether
+/// it exited successfully. On non-macOS, always returns `false` (no-op).
+/// Test: side-effecting; not invoked in the test suite.
+#[cfg(target_os = "macos")]
+fn kickstart(binary: &str) -> bool {
+    let uid = super::plist_bootstrap::resolve_uid();
+    let label = super::plist_label::plist_label_for(binary);
+    std::process::Command::new("launchctl")
+        .args(["kickstart", "-k", &format!("gui/{uid}/{label}")])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn kickstart(_binary: &str) -> bool {
+    false
+}
+
+/// Verify one daemon member, applying the #2498 kickstart retry when needed.
+///
+/// Why: isolates the per-member side effect (probe, maybe kickstart, re-probe)
+/// so [`run_verify_tail`] stays a plain fold over `selected`.
+/// What: probes health; if [`needs_kickstart`], attempts one kickstart and
+/// re-probes; returns the (possibly updated) health plus whether a kickstart
+/// was attempted.
+/// Test: side-effecting (subprocess); the decision half is `needs_kickstart`.
+fn verify_one(m: &StableMember) -> VerifyRow {
+    let mut health = probe_member_health(&m.binary, m.manage);
+    let mut kickstarted = false;
+    if needs_kickstart(&health, m.manage) {
+        kickstarted = kickstart(&m.binary);
+        if kickstarted {
+            health = probe_member_health(&m.binary, m.manage);
+        }
+    }
+    VerifyRow {
+        member: m.crate_name.clone(),
+        health,
+        kickstarted,
+    }
+}
+
+/// Run the post-install verify tail over the selected members (#2560).
+///
+/// Why: THE entry point `install::run` calls (unless `--no-verify`) right
+/// after `install_all` — the final "did this actually work" pass.
+/// What: runs the `.mcp.json` patch + project-setup stages (reusing
+/// `ensure`'s own logic, not its CLI render, so no duplicate JSON/stdout is
+/// emitted), then verifies every DAEMON member in `selected` (with the #2498
+/// kickstart retry), and builds the report.
+/// Test: side-effecting (filesystem + network + subprocess); the pure pieces
+/// it composes (`needs_kickstart`, `VerifyTailReport::build`) are unit tested.
+pub fn run_verify_tail(selected: &[StableMember]) -> VerifyTailReport {
+    use super::ensure::{mcp_patch, project_setup, report::EnsureReport};
+    use super::runtime::block_on;
+
+    let root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let mcp_members = mcp_patch::patch_all();
+    let stages = block_on(project_setup::run_stages(&root));
+    // `wait`/`ready` are not evaluated here — `install`'s verify tail uses its
+    // own targeted daemon health + kickstart retry instead of `ensure --wait`'s
+    // generic readiness poll.
+    let ensure_report = EnsureReport::build(mcp_members, stages, false, false);
+    let ensure_ok = ensure_report.all_ok;
+
+    let members: Vec<VerifyRow> = selected
+        .iter()
+        .filter(|m| m.daemon)
+        .map(verify_one)
+        .collect();
+
+    VerifyTailReport::build(ensure_ok, members)
+}
+
+/// Whether stdout is a terminal (controls ANSI colour in [`print_human`]).
+///
+/// Why: a piped/CI invocation (e.g. inside `curl | sh`) must not emit raw
+/// escape codes into a log file.
+/// What: `true` iff stdout is a TTY.
+/// Test: `tests::use_color_returns_bool`.
+fn use_color() -> bool {
+    std::io::IsTerminal::is_terminal(&std::io::stdout())
+}
+
+/// Render `label` in green (colour) or plain text.
+fn colour(label: &str, ansi: &str) -> String {
+    if use_color() {
+        format!("\x1b[{ansi}m{label}\x1b[0m")
+    } else {
+        label.to_owned()
+    }
+}
+
+/// Print the final human-readable verify-tail summary — green/red pass/fail.
+///
+/// Why: the last thing the `curl | sh` one-liner (via `install.sh` ->
+/// `tctl install`) prints must be an unambiguous verified/not-verified signal.
+/// What: prints the ensure verdict, one line per daemon member (noting a
+/// kickstart retry), and a final colour-coded `VERIFIED`/`NOT VERIFIED` line.
+/// Test: side-effect-only (stdout); the data it reads is unit-tested via
+/// `VerifyTailReport::build`.
+pub fn print_human(report: &VerifyTailReport) {
+    println!("tctl install — verify");
+    println!(
+        "  ensure               {}",
+        if report.ensure_ok { "ok" } else { "FAILED" }
+    );
+    for m in &report.members {
+        let note = if m.kickstarted { " (kickstarted)" } else { "" };
+        println!("  {:<20} {}{}", m.member, m.health, note);
+    }
+    let verdict = if report.verified {
+        colour("VERIFIED", "32")
+    } else {
+        colour("NOT VERIFIED", "31")
+    };
+    println!("verify: {verdict}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(member: &str, health: &str) -> VerifyRow {
+        VerifyRow {
+            member: member.to_owned(),
+            health: health.to_owned(),
+            kickstarted: false,
+        }
+    }
+
+    /// Why: only a `down` LAUNCHD daemon is the #2498 failure signature.
+    /// What: asserts the truth table across health x manage-strategy.
+    /// Test: This is the test.
+    #[test]
+    fn needs_kickstart_only_for_down_launchd() {
+        assert!(needs_kickstart(health_str::DOWN, ManageStrategy::Launchd));
+        assert!(!needs_kickstart(
+            health_str::HEALTHY,
+            ManageStrategy::Launchd
+        ));
+        assert!(!needs_kickstart(
+            health_str::NOT_INSTALLED,
+            ManageStrategy::Launchd
+        ));
+        assert!(!needs_kickstart(health_str::DOWN, ManageStrategy::OwnVerb));
+        assert!(!needs_kickstart(health_str::DOWN, ManageStrategy::None));
+    }
+
+    /// Why: the JSON envelope is a contract; pin its shape.
+    /// What: builds a report and asserts the keys.
+    /// Test: This is the test.
+    #[test]
+    fn report_serialises() {
+        let report = VerifyTailReport::build(true, vec![row("trusty-search", "healthy")]);
+        let v = serde_json::to_value(&report).expect("serialises");
+        assert_eq!(v["command"], "install.verify");
+        assert_eq!(v["ensure_ok"], true);
+        assert_eq!(v["verified"], true);
+        assert_eq!(v["members"][0]["member"], "trusty-search");
+    }
+
+    /// Why: THE #2560 safety property — a down/missing daemon OR a failed
+    /// ensure pass must both flip `verified` to `false`; only when BOTH are
+    /// clean is the install considered verified.
+    /// What: exercises each failure axis independently.
+    /// Test: This is the test.
+    #[test]
+    fn verified_requires_ensure_and_health() {
+        let ensure_failed = VerifyTailReport::build(false, vec![row("trusty-search", "healthy")]);
+        assert!(!ensure_failed.verified, "a failed ensure must not verify");
+
+        let health_failed = VerifyTailReport::build(true, vec![row("trusty-search", "down")]);
+        assert!(!health_failed.verified, "a down daemon must not verify");
+
+        let not_installed =
+            VerifyTailReport::build(true, vec![row("trusty-search", health_str::NOT_INSTALLED)]);
+        assert!(!not_installed.verified, "not_installed must not verify");
+
+        let both_ok = VerifyTailReport::build(true, vec![row("trusty-search", "healthy")]);
+        assert!(both_ok.verified);
+    }
+
+    /// Why: `stale` (running, below version floor) and `unknown`
+    /// (process-managed, unprobeable — trusty-mpm) must NOT fail verification
+    /// — mirrors `stack::health::HealthReport`'s degrade policy exactly.
+    /// What: a report with only stale/unknown members still verifies.
+    /// Test: This is the test.
+    #[test]
+    fn verified_tolerates_stale_and_unknown() {
+        let report = VerifyTailReport::build(
+            true,
+            vec![
+                row("trusty-search", health_str::STALE),
+                row("trusty-mpm", health_str::UNKNOWN),
+            ],
+        );
+        assert!(report.verified);
+    }
+
+    /// Why: `print_human`'s colour path must never panic regardless of the
+    /// harness's stdout fd; this just confirms it is callable.
+    /// What: calls `use_color`, binds the result.
+    /// Test: This is the test.
+    #[test]
+    fn use_color_returns_bool() {
+        let _v: bool = use_color();
+    }
+}

--- a/crates/trusty-installer/src/main.rs
+++ b/crates/trusty-installer/src/main.rs
@@ -127,8 +127,12 @@ fn dispatch(cli: Cli) {
             members,
             no_service,
             dry_run,
+            force,
+            no_verify,
         } => {
-            std::process::exit(install::run(&members, yes, json, no_service, dry_run));
+            std::process::exit(install::run(
+                &members, yes, json, no_service, dry_run, force, no_verify,
+            ));
         }
 
         Commands::Ensure { wait } => {

--- a/install.sh
+++ b/install.sh
@@ -530,16 +530,20 @@ post_install() {
 }
 
 # Why: Leave the user with concrete next steps regardless of platform/path.
+#      `${BIN} install` (#2560) already ran its own ensure + `stack health`
+#      verify tail and exited non-zero here if the stack was not verified
+#      (see `post_install`'s exit-code propagation) — these are follow-up
+#      commands for later checks, not a substitute for that automated pass.
 # What: Print the final next-steps box.
 # Test: Run end-to-end and confirm the box is the last thing printed.
 print_next_steps() {
     say ""
     say "==================================================================="
-    say "Installation complete!"
+    say "Installation complete and verified (ensure + stack health passed)."
     say ""
     say "Next steps:"
     say "  ${BIN} status          # check all daemon statuses"
-    say "  ${BIN} stack health    # full platform health check"
+    say "  ${BIN} stack health    # re-run the platform health check anytime"
     say ""
     say "Restart Claude Code to load the new MCP servers."
     say ""


### PR DESCRIPTION
## Summary

Two coupled trusty-installer safety fixes, found via an isolated installer E2E — macOS-first, closes #3527 and #2560.

### Fix 1 — #3527: supervisor bootstrap safety (P0)

`install_mpm_supervisor()` (the trusty-mpm launchd/supervisor bootstrap) was called **unconditionally** whenever the trusty-mpm member installed — the one member exempt from the #2556 `plans_service_bootstrap` opt-out every other daemon honours. It ran `launchctl bootout` + `bootstrap gui/$(id -u) <plist>` against the real UID launchd domain regardless of `--no-service` / `TCTL_NO_SERVICE_BOOTSTRAP`, and with no protection against downgrading a newer live daemon with an older one.

- **Gating** (`install.rs`): a new `plans_mpm_supervisor_bootstrap(m, service_enabled)` predicate (mirrors `plans_service_bootstrap`'s intent, since trusty-mpm's `ManageStrategy::OwnVerb` makes the Launchd-only predicate always `false` for it) now gates the call in `install_all`. When skipped, `install_mpm_supervisor` is never invoked and launchd is never touched.
- **Downgrade guard** (`plist_bootstrap.rs`): `decide_downgrade(current, candidate, force)` refuses to replace an already-registered supervisor with an older-or-equal version unless `--force`. The registered binary path is recovered from the existing on-disk plist (`extract_program_path`) and probed via the existing `update_engine::installed_version` (`<binary> --version`); an unparseable/unprobeable version fails open (nothing provably wrong) rather than blocking a legitimate install.
- **Sandboxed E2E escape hatches**: `TCTL_MPM_SUPERVISOR_HOME_OVERRIDE` (redirect the plist/log paths) and `TCTL_MPM_SUPERVISOR_SKIP_LAUNCHCTL` (write the plist but never shell out to `launchctl`) let a test exercise the full write + downgrade-guard path without touching the real user's `~/Library/LaunchAgents` or `gui/<uid>` domain.
- New `tctl install --force` flag threads through to override the guard.

### Fix 2 — #2560: install ends VERIFIED

`tctl install` placed binaries + services but never ran a health check, so the one-liner could end with daemons down/unverified with no signal.

- New `commands/verify_tail.rs`: after install (unless `--no-verify`), runs the `.mcp.json` patch + trusty-search index / trusty-memory palace registration (reusing `ensure::mcp_patch` / `ensure::project_setup` directly — not reimplemented, and not `ensure::run`'s own CLI render, so `--json` install output stays one JSON object), then probes health for every selected daemon.
- **#2498 kickstart retry**: a `down` **launchd** daemon (the "bootstrap succeeded but `RunAtLoad` never fired" flake) gets one `launchctl kickstart -k gui/<uid>/<label>` and a re-probe before the verdict is accepted.
- Folded into the *same* `InstallReport`/exit code (`InstallReport::with_verify`) so `--json` consumers never see `all_ok: true` while the verify tail reports unhealthy — satisfies #2560's "exit non-zero if unhealthy" requirement for free.
- Prints a final green/red `VERIFIED` / `NOT VERIFIED` summary (colour only on a TTY).
- `install.sh`'s `print_next_steps` text updated to reflect that install now already verifies before it prints "complete".

### Scope

macOS-first per the ticket — Linux glibc-floor/ABI fallback, the GitHub-Releases pagination bug, and Linux systemd bootstrap are explicitly **deferred**, not touched here.

### File-size cap

`install.rs` grew past the 500-SLOC production cap with these additions, so its `#[cfg(test)] mod tests` was extracted to a sibling `install_tests.rs` (mirrors the existing `cli.rs` / `cli_tests.rs` split) — pure mechanical move, no test behavior change.

## Test plan

- [x] `cargo test -p trusty-installer` — 404 passed, 0 failed (full surface: lib + bin + `tests/config_mount.rs` integration test + doc-tests)
- [x] `cargo fmt -p trusty-installer --check` — clean
- [x] `cargo clippy -p trusty-installer --all-targets -- -D warnings` — clean
- [x] `scripts/check_line_cap.sh` — 0 violations
- [x] `scripts/check_sld.sh` — 0 errors/warnings
- [x] `scripts/check_capabilities.sh` — up to date (trusty-mpm's own CLI/MCP/agent/skill catalog untouched by this PR)
- [x] New tests: supervisor bootstrap skipped under `--no-service`/`TCTL_NO_SERVICE_BOOTSTRAP` (`plans_mpm_supervisor_bootstrap_respects_flag`); downgrade guard truth table incl. force/equal/older/newer/unparseable (`decide_downgrade_*`); end-to-end sandboxed plist write (`install_mpm_supervisor_writes_plist_and_skips_launchctl`, `install_mpm_supervisor_proceeds_when_existing_binary_unprobeable`); verify-tail fold into exit code (`with_verify_failure_flips_all_ok`, `with_verify_success_preserves_all_ok`); kickstart-eligibility predicate (`needs_kickstart_only_for_down_launchd`); verify verdict derivation (`verified_requires_ensure_and_health`, `verified_tolerates_stale_and_unknown`).

Not self-merging — for PM admin-merge on green CI.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools