### PR TITLE
chore(release): trusty-installer 0.4.4 + trusty-mpm 0.19.28 binary releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11563,7 +11563,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -11628,7 +11628,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.19.27"
+version = "0.19.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -8,6 +8,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.4.4] — 2026-07-20
+
 ### Added
 
 - `trusty-mpm-gui` joined the `trusty-mpm` signable set in `SIGNABLE_BINARIES` (`com.trusty.trusty-mpm.gui`), so `tctl sign trusty-mpm` and the automatic `tctl install` post-install hook also sign the GUI binary (if present under the install dir) with the stable Developer ID identity — fallback coverage for a bare `cargo install --path crates/trusty-mpm-gui`, alongside the GUI's own `bundle.macOS.signingIdentity` fix (closes #2951).

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-installer"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.19.28] — 2026-07-20
+
 ### Added
 
 - **`tm ls` / `tm sessions ls` gain an inline sort + filter grammar** ([#3483](https://github.com/bobmatnyc/trusty-tools/issues/3483)): `tm ls [recent|alpha] [filter-word...]` — a bare `recent` or `alpha` first word selects the order (`recent`, the default, is most-recently-active first via `last_activity_at` falling back to `created_at`; `alpha` is case-insensitive by session name), and every remaining word (or all words, if the first isn't a sort keyword) becomes a case-insensitive substring filter matched against the id, name, project (`source_id`), state, and task columns. Expressed as positional words rather than `--sort`/`--filter` flags per the repo owner's design call; applies to both the static table and the interactive picker's ordering, with `--json` staying a raw, unsorted/unfiltered passthrough (matching `--all`'s existing "no effect on `--json`" precedent). Backward compatible: bare `tm ls` is unchanged.

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.19.27"
+version = "0.19.28"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Cuts fresh binary releases so the web-URL installer (`curl … install.sh | sh`) delivers current, fixed binaries instead of stale ones.

- **trusty-installer 0.4.3 → 0.4.4**: carries #3527 (trusty-mpm supervisor launchd bootstrap now honors `--no-service`/`TCTL_NO_SERVICE_BOOTSTRAP`, plus a downgrade guard refusing to replace a newer live supervisor unless `--force`) and #2560 (`tctl install` now ends with a self-verifying post-install pass — `ensure` + per-daemon health sweep, printed VERIFIED/NOT VERIFIED summary, skippable via `--no-verify`). Both were already merged to main (#3533, #2975) but never shipped in a binary release.
- **trusty-mpm 0.19.27 → 0.19.28**: pure currency bump. The highest GH *binary* release tag for trusty-mpm was the stale `trusty-mpm-v0.16.0` even though main (and crates.io) is already at 0.19.27, and several tags in between (0.19.11-0.19.27) never got a binary release cut. This bump carries everything merged since 0.19.27: `tm ls`/`tm sessions ls` inline sort+filter grammar (#3483), native-first MCP connector routing preference (#3480), harness-scaffolding gitignore + collision detection (#3427), `tm doctor` output_style precedence-chain fix (#3453), hermetic test temp roots (#3450, #3382, #3390), and `InstallPolicy` now honored (Overwrite vs SeedOnce, #3381).

Both crates' `CHANGELOG.md` had their `[Unreleased]` section renamed to the new version + today's date — the existing entries were already accurate and complete for what shipped since the prior release, so no new bullets were needed.

## Verification performed

- `cargo build -p trusty-installer -p trusty-mpm` — clean build, no errors.
- `cargo test -p trusty-installer` — **404 passed, 0 failed, 3 ignored** (live-network probes, correctly gated).
- `cargo test -p trusty-mpm` — full suite (all test binaries) — **every `test result:` line shows `0 failed`** (largest binaries: 3408 passed / 1130 passed / 1130 passed, etc.), no `FAILED` or `error[` anywhere in the output. The known `checkpoint_resume` timing flake (#3514) did not appear in this run.
- `cargo publish --dry-run -p trusty-installer` — packaged, verified, and reached the upload step (aborted only because it's a dry run).
- `cargo publish --dry-run -p trusty-mpm` — same, packaged/verified/upload-dry-run-aborted cleanly.
- Confirmed neither crate depends on the other, and no other crate in the workspace declares `trusty-mpm`/`trusty-installer` as a dependency (the root `[workspace.dependencies]` `trusty-mpm = { version = "0.15.0" }` entry is unused/vestigial — no consumer references it via `workspace = true`), so no cross-crate publish-ordering constraint applies.

## What remains (Phase B — gated on merge + explicit go)

1. `cargo publish -p trusty-mpm` then `-p trusty-installer` from freshly-pulled merged main; verify both live via the crates.io API.
2. Push tags `trusty-mpm-v0.19.28` and `trusty-installer-v0.4.4` to trigger `release.yml`'s prebuilt-binary build.
3. Watch the release workflow to completion; verify GH releases exist with binary assets (at minimum `aarch64-apple-darwin` + `.sha256` for both crates).

Not yet done, per instructions: no real `cargo publish`, no tags pushed.

## Test plan

- [x] `cargo build -p trusty-installer -p trusty-mpm`
- [x] `cargo test -p trusty-installer` (404 passed, 0 failed)
- [x] `cargo test -p trusty-mpm` (full suite, 0 failed)
- [x] `cargo publish --dry-run` for both crates

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools