### PR TITLE
feat(trusty-code): Claude Code plugin support Phase 1 — local agents + skills (closes #3539)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -26,7 +26,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   dropped with a warning rather than failing the load; an `extends:` chain
   is treated as leaf-only (warned, not composed). Phase 1 is local-directory
   agents + skills only — no marketplace/git fetch, no commands/hooks/MCP
-  (later phases, tracked against #3539).
+  (later phases, tracked against #3539). Plugin content is treated as
+  HOSTILE input throughout (code-critic PR #3547 review): a `plugin.json`
+  `agents`/`skills` override that is absolute, contains `..`, or resolves
+  outside the plugin directory is rejected and falls back to the default
+  convention; every namespaced `<plugin>:<name>` dispatch/resolution path
+  (`use_skill`, `delegate_to_agent`, `agent_config_exists`, `tcode run-task`)
+  validates both segments against the existing `[a-z0-9-]+`
+  (<= 64 chars) safe charset before ever building a filesystem path, making
+  a traversal payload syntactically impossible to construct. A namespaced
+  plugin agent is also now genuinely delegatable end-to-end — the PM's
+  `delegate_to_agent` tool, the CLI, and the pre-flight existence gate all
+  accept the `<plugin>:<name>` shape (previously only `agents::resolve_agent`
+  itself could resolve one; every caller in front of it rejected `:`
+  outright).
 - **Markdown transcript endpoint for dev observability (issue #3526).** New
   `GET /sessions/{id}/transcript.md` (`crate::serve::rest::sessions`) renders
   a session's full transcript as a readable `text/markdown` document —

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -39,7 +39,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `delegate_to_agent` tool, the CLI, and the pre-flight existence gate all
   accept the `<plugin>:<name>` shape (previously only `agents::resolve_agent`
   itself could resolve one; every caller in front of it rejected `:`
-  outright).
+  outright). A further hardening pass (code-critic re-review) closed a
+  leaf-file-identity gap (CWE-59): a discovered `agents/*.md` or
+  `skills/<name>/SKILL.md` — or the `skills/<name>` directory itself — that
+  is a symlink escaping the plugin's `agents_dir`/`skills_dir` is now
+  rejected via `plugins::path_is_contained` (canonicalize + containment,
+  applied at both the listing and resolve/dispatch paths for both agents
+  and skills) before its content is ever read, closing a host-file
+  disclosure vector the directory- and name-level guards above didn't
+  cover. `runner::agent_config_exists`'s pre-flight gate now also requires
+  a namespaced plugin agent to resolve CLEANLY (not merely be found) to
+  count as "exists".
 - **Markdown transcript endpoint for dev observability (issue #3526).** New
   `GET /sessions/{id}/transcript.md` (`crate::serve::rest::sessions`) renders
   a session's full transcript as a readable `text/markdown` document —

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Claude Code plugin support, Phase 1: local-directory agents + skills
+  (issue #3539, DOC-51).** New `crate::plugins` module auto-scans
+  `<project_root>/.claude/plugins/<plugin>/` (honoring an optional
+  `.claude-plugin/plugin.json`'s `name`/`agents`/`skills` overrides) and
+  surfaces each plugin's `agents/*.md` and `skills/<name>/SKILL.md` in
+  `agents.list`/`skills.list` under a new `plugin` tier, namespaced
+  `<plugin>:<name>` and resolvable by that name via `agents::resolve_agent`
+  and the `use_skill` skill resolver. Plugin entries are additive only — the
+  namespaced key can never collide with (and so never overrides) a project
+  or embedded/bundled name, and plugin skills are independent of the
+  bundled-vs-project whole-catalog-replacement threshold (PR #3465) for
+  `skills.list`. A plugin agent's unsupported trusty-mpm-style frontmatter
+  fields (`effort`/`maxTurns`/`memory`/`isolation`/`disallowedTools`) are
+  dropped with a warning rather than failing the load; an `extends:` chain
+  is treated as leaf-only (warned, not composed). Phase 1 is local-directory
+  agents + skills only — no marketplace/git fetch, no commands/hooks/MCP
+  (later phases, tracked against #3539).
 - **Markdown transcript endpoint for dev observability (issue #3526).** New
   `GET /sessions/{id}/transcript.md` (`crate::serve::rest::sessions`) renders
   a session's full transcript as a readable `text/markdown` document —

--- a/crates/trusty-code/src/agents/md_loader.rs
+++ b/crates/trusty-code/src/agents/md_loader.rs
@@ -171,7 +171,11 @@ pub fn project_embedded_md_with_extends(name: &str) -> anyhow::Result<AgentConfi
 /// Test: `hr1_initial_prompt_not_leaked_into_body`,
 /// `interior_horizontal_rule_survives_in_body`,
 /// `frontmatter_only_agent_has_empty_body`.
-fn extract_body(composed: &str) -> String {
+///
+/// `pub(crate)`: also reused by `plugins::agents::load_plugin_agent` (#3539)
+/// so a plugin agent's body is stripped identically to a disk agent's,
+/// without a second frontmatter-fence scanner.
+pub(crate) fn extract_body(composed: &str) -> String {
     let mut lines = composed.lines();
     match lines.next() {
         Some(first) if first.trim() == "---" => {}
@@ -223,7 +227,17 @@ fn extract_body(composed: &str) -> String {
 ///   (DOC-42/#2889), but mapping it into a dead field would fabricate a
 ///   consumer that doesn't exist. Left as a gap for a future slice that adds
 ///   an actual skills consumer to tcode.
-fn project_to_agent_config(default_name: &str, meta: AgentMetadata, body: String) -> AgentConfig {
+///
+/// `pub(crate)`: also reused by `plugins::agents::load_plugin_agent` (#3539),
+/// which calls this with the plugin's LOCAL agent name (not yet namespaced)
+/// and overrides `agent.name` with the namespaced form afterward — so the
+/// frontmatter -> `AgentConfig` mapping stays written exactly once across
+/// disk, embedded, and plugin agents.
+pub(crate) fn project_to_agent_config(
+    default_name: &str,
+    meta: AgentMetadata,
+    body: String,
+) -> AgentConfig {
     AgentConfig {
         agent: AgentInfo {
             name: meta.name.unwrap_or_else(|| default_name.to_string()),

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -297,11 +297,22 @@ pub enum ResolveAgentError {
 /// not-found case below rather than propagating. If nothing matches
 /// anywhere, returns `ResolveAgentError::NotFound` with the disk ∪ embedded
 /// name list ([`available_agent_names`]) for a caller to surface.
+/// A namespaced `<plugin>:<local-name>` (issue #3539 — Phase 1 Claude Code
+/// plugin support) routes to [`crate::plugins::agents::find_plugin_agent_config`]
+/// instead of the disk/embedded precedence below: plugin agents are an
+/// independent, additive tier, never falling back to (or being shadowed
+/// by) disk/embedded resolution of the bare local name.
 /// Test: `resolve_agent_disk_wins_over_embedded`,
 /// `resolve_agent_falls_back_to_embedded_when_disk_misses`,
 /// `resolve_agent_disk_parse_error_does_not_fall_back_to_embedded`,
-/// `resolve_agent_unknown_name_lists_available_agents`.
+/// `resolve_agent_unknown_name_lists_available_agents`,
+/// `resolve_agent_namespaced_name_resolves_plugin_agent`,
+/// `resolve_agent_namespaced_unknown_plugin_is_not_found`.
 pub fn resolve_agent(dir: &Path, name: &str) -> Result<AgentConfig, ResolveAgentError> {
+    if let Some((plugin, agent_name)) = name.split_once(':') {
+        return resolve_plugin_agent(dir, plugin, agent_name, name);
+    }
+
     let disk_path = dir.join(format!("{name}.md"));
     if disk_path.exists() {
         return md_loader::load_md_agent(&disk_path).map_err(|source| ResolveAgentError::Load {
@@ -339,6 +350,47 @@ pub fn resolve_agent(dir: &Path, name: &str) -> Result<AgentConfig, ResolveAgent
         dir: dir.to_path_buf(),
         available: available_agent_names(dir).join(", "),
     })
+}
+
+/// Resolve a namespaced `<plugin>:<agent_name>` for [`resolve_agent`]
+/// (issue #3539).
+///
+/// Why: split out so `resolve_agent`'s own precedence chain (disk ->
+/// embedded -> not-found) stays a single, unbranched read for the common
+/// unnamespaced case.
+/// What: recovers a project root from `dir` via
+/// [`crate::plugins::project_root_two_levels_up`] (works whether `dir` is
+/// project- or user-scoped — see that function's docs), then delegates to
+/// [`crate::plugins::agents::find_plugin_agent_config`]. `None` (no such
+/// plugin, or no such agent within it) maps to the same `NotFound` shape
+/// `resolve_agent`'s bare-name path uses, `full_name` preserving the
+/// caller's original namespaced spelling; `Some(Err)` (found but failed to
+/// parse) maps to `Load`.
+/// Test: `resolve_agent_namespaced_name_resolves_plugin_agent`,
+/// `resolve_agent_namespaced_unknown_plugin_is_not_found`,
+/// `resolve_agent_namespaced_unknown_agent_is_not_found`.
+fn resolve_plugin_agent(
+    dir: &Path,
+    plugin: &str,
+    agent_name: &str,
+    full_name: &str,
+) -> Result<AgentConfig, ResolveAgentError> {
+    let found = crate::plugins::project_root_two_levels_up(dir).and_then(|root| {
+        crate::plugins::agents::find_plugin_agent_config(&root, plugin, agent_name)
+    });
+
+    match found {
+        Some(Ok(cfg)) => Ok(cfg),
+        Some(Err(source)) => Err(ResolveAgentError::Load {
+            name: full_name.to_string(),
+            source,
+        }),
+        None => Err(ResolveAgentError::NotFound {
+            name: full_name.to_string(),
+            dir: dir.to_path_buf(),
+            available: available_agent_names(dir).join(", "),
+        }),
+    }
 }
 
 /// List every agent name resolvable via [`resolve_agent`] for `dir`: disk ∪
@@ -773,6 +825,78 @@ mod tests {
         assert!(
             msg.contains("engineer"),
             "expected the available-agents hint to name a real embedded agent, got: {msg}"
+        );
+    }
+
+    /// `resolve_agent` routes a namespaced `<plugin>:<name>` to
+    /// `plugins::agents::find_plugin_agent_config`, recovering the project
+    /// root from the `.claude/agents` dir it was given (#3539).
+    ///
+    /// Why: this is the acceptance criterion for the dispatch half of
+    /// #3539's namespacing decision — a namespaced name must actually
+    /// dispatch, not just appear in `agents.list`.
+    /// Test: this test.
+    #[test]
+    fn resolve_agent_namespaced_name_resolves_plugin_agent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agents_dir = tmp.path().join(".claude").join("agents");
+        let plugin_agents_dir = tmp
+            .path()
+            .join(".claude")
+            .join("plugins")
+            .join("my-plugin")
+            .join("agents");
+        std::fs::create_dir_all(&plugin_agents_dir).expect("mkdir");
+        std::fs::write(
+            plugin_agents_dir.join("reviewer.md"),
+            "---\nname: reviewer\ndescription: Plugin reviewer\n---\n\nReview things.\n",
+        )
+        .expect("write");
+
+        let cfg = resolve_agent(&agents_dir, "my-plugin:reviewer").expect("resolve plugin agent");
+        assert_eq!(cfg.agent.name, "my-plugin:reviewer");
+        assert_eq!(cfg.agent.description.as_deref(), Some("Plugin reviewer"));
+        assert_eq!(cfg.system_prompt.content, "Review things.");
+    }
+
+    /// A namespaced name whose plugin does not exist errors `NotFound`, not
+    /// a silent fall-through to disk/embedded resolution of the bare name.
+    ///
+    /// Test: this test.
+    #[test]
+    fn resolve_agent_namespaced_unknown_plugin_is_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agents_dir = tmp.path().join(".claude").join("agents");
+
+        let err = resolve_agent(&agents_dir, "no-such-plugin:reviewer")
+            .expect_err("unknown plugin must not resolve");
+        assert!(
+            matches!(err, ResolveAgentError::NotFound { .. }),
+            "expected NotFound, got: {err:?}"
+        );
+    }
+
+    /// A namespaced name for a known plugin but an unknown local agent name
+    /// errors `NotFound`.
+    ///
+    /// Test: this test.
+    #[test]
+    fn resolve_agent_namespaced_unknown_agent_is_not_found() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let agents_dir = tmp.path().join(".claude").join("agents");
+        let plugin_agents_dir = tmp
+            .path()
+            .join(".claude")
+            .join("plugins")
+            .join("my-plugin")
+            .join("agents");
+        std::fs::create_dir_all(&plugin_agents_dir).expect("mkdir");
+
+        let err = resolve_agent(&agents_dir, "my-plugin:ghost")
+            .expect_err("unknown agent within a known plugin must not resolve");
+        assert!(
+            matches!(err, ResolveAgentError::NotFound { .. }),
+            "expected NotFound, got: {err:?}"
         );
     }
 

--- a/crates/trusty-code/src/agents/protocol.rs
+++ b/crates/trusty-code/src/agents/protocol.rs
@@ -153,7 +153,12 @@ pub fn register(router: &mut Router, state: AgentsCatalogState) {
 /// the frontmatter `name:`/`extends:` convention is lowercase `base-qa`, so
 /// this must tolerate either.
 /// Test: `tests::list_excludes_base_agents_but_resolve_agent_still_finds_them`.
-fn is_base_agent(name: &str) -> bool {
+///
+/// `pub(crate)`: also reused by `plugins::agents::discover_plugin_agents`
+/// (#3539) so a plugin literally shipping `base-engineer.md` etc. is
+/// excluded from the catalog exactly like the embedded/disk tiers, via the
+/// same single filter.
+pub(crate) fn is_base_agent(name: &str) -> bool {
     crate::assets::BASE_AGENT_NAMES.contains(&name.to_ascii_lowercase().as_str())
 }
 
@@ -193,11 +198,25 @@ fn entry_json(cfg: &AgentConfig, tier: &str) -> Value {
 /// `md_loader::load_md_agent` are untouched, so composition (a leaf agent's
 /// `extends: base-engineer`) keeps working exactly as before — only the
 /// user-facing catalog an operator browses/picks from hides them.
+///
+/// A FOURTH tier, `"plugin"`, is layered on top when `state.tier ==
+/// "project"` (issue #3539 — Phase 1 Claude Code plugin support): every
+/// agent discovered under `<project_root>/.claude/plugins/*/agents/` is
+/// added, namespaced `<plugin>:<name>` by
+/// `plugins::agents::discover_plugin_agents`. This is ADDITIVE ONLY — the
+/// namespaced key can never collide with an embedded or disk agent's
+/// unnamespaced name, so a plugin agent never overrides (or is suppressed
+/// by) a project/embedded entry of the "same" local name; see that
+/// function's docs for the base-agent-name exclusion it applies too.
+/// Projectless daemons (`state.tier == "user"`) see no plugin tier — #3539
+/// scopes plugin discovery to a bound project's `.claude/plugins/`.
 /// Test: `tests::list_returns_embedded_when_disk_empty`,
 /// `tests::list_disk_override_wins_and_suppresses_embedded`,
 /// `tests::list_disk_only_entries_are_additive`,
 /// `tests::list_marks_unparseable_disk_override_as_broken`,
-/// `tests::list_excludes_base_agents_but_resolve_agent_still_finds_them`.
+/// `tests::list_excludes_base_agents_but_resolve_agent_still_finds_them`,
+/// `tests::list_includes_namespaced_plugin_agents`,
+/// `tests::list_plugin_agent_does_not_override_project_agent_of_same_local_name`.
 async fn agents_list(
     state: &AgentsCatalogState,
     _params: Value,
@@ -228,6 +247,21 @@ async fn agents_list(
         match by_name.iter_mut().find(|(n, _)| *n == name) {
             Some(slot) => slot.1 = entry,
             None => by_name.push((name, entry)),
+        }
+    }
+
+    if state.tier == "project"
+        && let Some(project_root) = crate::plugins::project_root_two_levels_up(&state.dir)
+    {
+        for cfg in crate::plugins::agents::discover_plugin_agents(&project_root) {
+            let name = cfg.agent.name.clone();
+            // Namespacing already guarantees no collision with an
+            // unnamespaced project/embedded name; the containment check is
+            // defense-in-depth so "additive only" holds even if two plugins
+            // resolved to the same namespaced name (first one found wins).
+            if !by_name.iter().any(|(n, _)| *n == name) {
+                by_name.push((name, entry_json(&cfg, "plugin")));
+            }
         }
     }
 

--- a/crates/trusty-code/src/agents/protocol_tests.rs
+++ b/crates/trusty-code/src/agents/protocol_tests.rs
@@ -490,3 +490,48 @@ async fn list_plugin_agent_does_not_override_project_agent_of_same_local_name() 
     assert_eq!(plugin_entry["tier"], "plugin");
     assert_eq!(plugin_entry["description"], "PLUGIN engineer");
 }
+
+/// `agents.list` never surfaces a plugin agent that is a symlink escaping
+/// the plugin's `agents/` directory — the secret content a hostile plugin
+/// would otherwise disclose never appears anywhere in the JSON response
+/// (code-critic PR #3547 re-review, CRITICAL 5, CWE-59).
+///
+/// Test: this test.
+#[tokio::test]
+#[cfg(unix)]
+async fn list_excludes_symlinked_plugin_agent_leak_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+    let plugin_agents_dir = tmp
+        .path()
+        .join(".claude")
+        .join("plugins")
+        .join("my-plugin")
+        .join("agents");
+    std::fs::create_dir_all(&plugin_agents_dir).expect("mkdir");
+    std::fs::write(
+        plugin_agents_dir.join("reviewer.md"),
+        "---\nname: reviewer\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let secret_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&secret_dir).expect("mkdir");
+    let secret_path = secret_dir.join("id_rsa");
+    std::fs::write(&secret_path, "SECRET_KEY_MATERIAL").expect("write secret");
+    std::os::unix::fs::symlink(&secret_path, plugin_agents_dir.join("leak.md")).expect("symlink");
+
+    let s = state(&agents_dir, true);
+    let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+    let agents = result["agents"].as_array().expect("array");
+
+    assert!(
+        !agents.iter().any(|a| a["name"] == "my-plugin:leak"),
+        "the symlinked entry must not be listed, got: {agents:?}"
+    );
+    assert!(
+        !result.to_string().contains("SECRET_KEY_MATERIAL"),
+        "the secret content must never appear anywhere in the response"
+    );
+}

--- a/crates/trusty-code/src/agents/protocol_tests.rs
+++ b/crates/trusty-code/src/agents/protocol_tests.rs
@@ -398,3 +398,95 @@ async fn register_wires_all_three_methods() {
     assert!(resp.result.is_some(), "agents.list must be wired");
     assert!(resp.result.unwrap()["agents"].is_array());
 }
+
+/// `agents.list` includes a `plugin`-tier entry, namespaced
+/// `<plugin>:<name>`, for every agent discovered under
+/// `<project_root>/.claude/plugins/*/agents/` (issue #3539).
+///
+/// Why: this is the acceptance criterion for #3539's namespacing decision
+/// at the catalog-listing level — `project_root_two_levels_up` must
+/// correctly recover the project root from `state.dir` (a real
+/// `.claude/agents` directory, unlike this file's other tests which pass a
+/// bare tempdir root as `dir` for brevity — plugin discovery specifically
+/// needs the real on-disk shape).
+/// Test: this test.
+#[tokio::test]
+async fn list_includes_namespaced_plugin_agents() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+    let plugin_agents_dir = tmp
+        .path()
+        .join(".claude")
+        .join("plugins")
+        .join("my-plugin")
+        .join("agents");
+    std::fs::create_dir_all(&plugin_agents_dir).expect("mkdir");
+    std::fs::write(
+        plugin_agents_dir.join("reviewer.md"),
+        "---\nname: reviewer\ndescription: Plugin reviewer\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let s = state(&agents_dir, true);
+    let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+    let agents = result["agents"].as_array().expect("array");
+    let plugin_entry = agents
+        .iter()
+        .find(|a| a["name"] == "my-plugin:reviewer")
+        .unwrap_or_else(|| panic!("expected a namespaced plugin entry, got: {agents:?}"));
+    assert_eq!(plugin_entry["tier"], "plugin");
+    assert_eq!(plugin_entry["description"], "Plugin reviewer");
+}
+
+/// A plugin shipping an agent whose LOCAL name matches an existing project
+/// agent's name does NOT override the project entry — both appear, the
+/// project one unnamespaced and unchanged, the plugin one namespaced
+/// (issue #3539's additive-only guarantee).
+///
+/// Why: this is the explicit collision test #3539 calls for — namespacing
+/// makes the "additive only, never overrides project/bundled" contract
+/// structural (the keys literally cannot collide), and this test pins that
+/// outcome rather than just trusting the mechanism.
+/// Test: this test.
+#[tokio::test]
+async fn list_plugin_agent_does_not_override_project_agent_of_same_local_name() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+    std::fs::write(
+        agents_dir.join("engineer.md"),
+        "---\nname: engineer\ndescription: PROJECT engineer\n---\n\nProject body.\n",
+    )
+    .expect("write");
+    let plugin_agents_dir = tmp
+        .path()
+        .join(".claude")
+        .join("plugins")
+        .join("my-plugin")
+        .join("agents");
+    std::fs::create_dir_all(&plugin_agents_dir).expect("mkdir");
+    std::fs::write(
+        plugin_agents_dir.join("engineer.md"),
+        "---\nname: engineer\ndescription: PLUGIN engineer\n---\n\nPlugin body.\n",
+    )
+    .expect("write");
+
+    let s = state(&agents_dir, true);
+    let result = agents_list(&s, Value::Null, ctx()).await.expect("list");
+    let agents = result["agents"].as_array().expect("array");
+
+    let project_entry = agents
+        .iter()
+        .find(|a| a["name"] == "engineer")
+        .expect("project 'engineer' must still be present, untouched");
+    assert_eq!(project_entry["tier"], "project");
+    assert_eq!(project_entry["description"], "PROJECT engineer");
+
+    let plugin_entry = agents
+        .iter()
+        .find(|a| a["name"] == "my-plugin:engineer")
+        .expect("namespaced plugin entry must be present alongside it");
+    assert_eq!(plugin_entry["tier"], "plugin");
+    assert_eq!(plugin_entry["description"], "PLUGIN engineer");
+}

--- a/crates/trusty-code/src/lib.rs
+++ b/crates/trusty-code/src/lib.rs
@@ -195,6 +195,23 @@ pub mod agents;
 /// Test: `skills::tests::*`.
 pub mod skills;
 
+/// Claude Code plugin ingestion, Phase 1: local-directory agents + skills
+/// only (issue #3539).
+///
+/// Why: a plugin packages agents/skills for drop-in use the same way a
+/// project's own `.claude/agents`/`.claude/skills` do; this module scans
+/// `.claude/plugins/<plugin>/` and layers the result additively, namespaced
+/// `<plugin>:<name>`, onto `agents::protocol::agents_list`,
+/// `skills::protocol::skills_list`, `agents::resolve_agent`, and
+/// `skills::FsSkillResolver` — never overriding an unnamespaced
+/// project/embedded/bundled entry.
+/// What: `discover_plugin_roots`, `agents::discover_plugin_agents`/
+/// `agents::find_plugin_agent_config`,
+/// `skills::discover_plugin_skills`/`skills::resolve_plugin_skill_body`.
+/// Test: `plugins::tests::*`, `plugins::agents::tests::*`,
+/// `plugins::skills::tests::*`.
+pub mod plugins;
+
 /// Harness mode selection: `daily-driver` (default, token-efficiency
 /// consumption point) vs `parity` (full-schema benchmark mode) — #2059,
 /// vision spec §5.9.

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -33,6 +33,7 @@ use clap::{Parser, Subcommand};
 use tracing::info;
 
 use trusty_code::llm::{DispatchingLlmClient, LlmClientTrait};
+use trusty_code::plugins::is_valid_namespaced_name;
 use trusty_code::run_task::{ExitCode, RunTaskParams, execute_run_task};
 
 mod cli;
@@ -603,27 +604,46 @@ async fn run_serve(
     process::exit(1);
 }
 
-/// Validate that `agent_name` contains only safe filesystem characters.
+/// Validate that `agent_name` contains only safe filesystem characters —
+/// either a plain name, or a `<plugin>:<name>` namespaced plugin agent
+/// dispatch name (issue #3539/#3547).
 ///
 /// Why: The agent name is joined into a filesystem path
 /// (`<agents_dir>/<agent_name>.md`). Without this guard a crafted name such
 /// as `../../etc/passwd` escapes the agents directory and enables path
 /// traversal. Restricting to `[a-zA-Z0-9_-]` is safe, predictable, and covers
-/// every real agent name in use.
-/// What: Returns `Ok(())` when every character is ASCII alphanumeric, `_`, or
-/// `-`, and the name is non-empty. Returns `Err` with a descriptive message
-/// otherwise.
-/// Test: `validate_agent_name_rejects_traversal` and
-/// `validate_agent_name_accepts_valid` in this module.
+/// every real plain agent name in use. A namespaced plugin agent name
+/// (`<plugin>:<name>`) previously had no valid shape at all here — any name
+/// containing `:` was rejected outright, so a plugin agent could never be
+/// dispatched via `tcode run-task` even though `agents::resolve_agent`
+/// already resolves it (code-critic PR #3547 review, HIGH 4).
+/// What: a namespaced shape is checked FIRST via
+/// `trusty_code::plugins::is_valid_namespaced_name` (exactly two
+/// `:`-separated segments, each `[a-z0-9-]+` and ≤64 chars — the SAME
+/// charset `agents::protocol::validate_agent_name` already enforces for the
+/// disk-catalog write path, reused rather than re-derived) and accepted
+/// immediately if it matches; this is strictly stricter than the plain-name
+/// charset below (no need to also run the looser check). Otherwise, returns
+/// `Ok(())` when every character is ASCII alphanumeric, `_`, or `-`, and the
+/// name is non-empty (the original plain-name contract, unchanged). `Err`
+/// with a descriptive message otherwise.
+/// Test: `validate_agent_name_rejects_traversal`,
+/// `validate_agent_name_accepts_valid`,
+/// `validate_agent_name_accepts_namespaced_plugin_agent`,
+/// `validate_agent_name_rejects_namespaced_traversal` in this module.
 fn validate_agent_name(agent_name: &str) -> Result<()> {
+    if is_valid_namespaced_name(agent_name) {
+        return Ok(());
+    }
     if agent_name.is_empty()
         || !agent_name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
     {
         anyhow::bail!(
-            "invalid agent name '{agent_name}': \
-             agent names must be non-empty and contain only [a-zA-Z0-9_-]"
+            "invalid agent name '{agent_name}': agent names must be non-empty and contain \
+             only [a-zA-Z0-9_-], or be a namespaced <plugin>:<name> where both segments are \
+             [a-z0-9-]+ (<= 64 chars)"
         );
     }
     Ok(())
@@ -844,6 +864,34 @@ mod tests {
         assert!(
             validate_agent_name("A").is_ok(),
             "single ASCII letter must pass"
+        );
+    }
+
+    /// A well-formed `<plugin>:<name>` namespaced plugin agent dispatch
+    /// name is accepted (issue #3547 HIGH 4 — this is what actually enables
+    /// `tcode run-task <plugin>:<name>` to reach `resolve_agent` at all;
+    /// previously every namespaced name was rejected here before `run-task`
+    /// ever looked up an agent).
+    ///
+    /// Test: this test.
+    #[test]
+    fn validate_agent_name_accepts_namespaced_plugin_agent() {
+        assert!(validate_agent_name("my-plugin:reviewer").is_ok());
+        assert!(validate_agent_name("a:b").is_ok());
+    }
+
+    /// A traversal or malformed payload disguised as a namespaced name is
+    /// still rejected (issue #3547 HIGH 4 — accepting the `<plugin>:<name>`
+    /// shape must not reopen the traversal guard it sits next to).
+    ///
+    /// Test: this test.
+    #[test]
+    fn validate_agent_name_rejects_namespaced_traversal() {
+        assert!(validate_agent_name("my-plugin:../../etc/passwd").is_err());
+        assert!(validate_agent_name("../../etc:reviewer").is_err());
+        assert!(
+            validate_agent_name("my-plugin:a:b").is_err(),
+            "extra colon must be rejected"
         );
     }
 }

--- a/crates/trusty-code/src/plugins/agents.rs
+++ b/crates/trusty-code/src/plugins/agents.rs
@@ -71,7 +71,7 @@ pub fn discover_plugin_agents(project_root: &Path) -> Vec<AgentConfig> {
             if crate::agents::protocol::is_base_agent(&agent_name) {
                 continue;
             }
-            match load_plugin_agent(&root.name, &agent_name, &path) {
+            match load_plugin_agent(&root.name, &agent_name, &path, &root.agents_dir) {
                 Ok(cfg) => out.push(cfg),
                 Err(e) => tracing::warn!("skipping plugin agent '{}:{agent_name}': {e}", root.name),
             }
@@ -87,25 +87,43 @@ pub fn discover_plugin_agents(project_root: &Path) -> Vec<AgentConfig> {
 /// [`find_plugin_agent_config`] (dispatch resolution) share, so the
 /// namespacing + unsupported-field-drop + extends-warn contract is written
 /// exactly once.
-/// What: reads `path`, parses frontmatter via
-/// `trusty_agents_common::agents::metadata::agent_metadata_from_str` (no
-/// `compose_agent` call — a plugin agent is a leaf, #3539), warns and drops
-/// any [`UNSUPPORTED_AGENT_FIELDS`] present (see [`warn_unsupported_fields`]),
-/// warns (never errors) on a present `extends:` — the agent is still loaded
-/// as a direct/leaf document with no inheritance resolved — then projects
-/// via `agents::md_loader::project_to_agent_config` exactly as a disk agent
+/// What: FIRST requires `path`'s canonicalized identity to stay contained
+/// within `agents_dir`'s own canonicalization
+/// (`plugins::path_is_contained` — code-critic PR #3547 re-review,
+/// CRITICAL 5, CWE-59) — rejects a `path` that is (or resolves through) a
+/// symlink escaping `agents_dir`, e.g. `agents/leak.md -> ~/.ssh/id_rsa`,
+/// BEFORE any content is read. Only then reads `path`, parses frontmatter
+/// via `trusty_agents_common::agents::metadata::agent_metadata_from_str`
+/// (no `compose_agent` call — a plugin agent is a leaf, #3539), warns and
+/// drops any [`UNSUPPORTED_AGENT_FIELDS`] present (see
+/// [`warn_unsupported_fields`]), warns (never errors) on a present
+/// `extends:` — the agent is still loaded as a direct/leaf document with no
+/// inheritance resolved — then projects via
+/// `agents::md_loader::project_to_agent_config` exactly as a disk agent
 /// would, overriding only `agent.name` with the namespaced form. An
-/// unreadable file is the only real error path.
+/// unreadable file or a rejected symlink are the only error paths.
 /// Test: `tests::load_plugin_agent_projects_fields`,
 /// `tests::load_plugin_agent_warns_and_drops_unsupported_fields`,
 /// `tests::load_plugin_agent_warns_on_extends_and_treats_as_leaf`,
-/// `tests::load_plugin_agent_missing_file_errors`.
+/// `tests::load_plugin_agent_missing_file_errors`,
+/// `tests::load_plugin_agent_rejects_symlinked_file`.
 pub(crate) fn load_plugin_agent(
     plugin: &str,
     agent_name: &str,
     path: &Path,
+    agents_dir: &Path,
 ) -> anyhow::Result<AgentConfig> {
     let namespaced = format!("{plugin}:{agent_name}");
+
+    if !super::path_is_contained(path, agents_dir) {
+        anyhow::bail!(
+            "plugin agent '{namespaced}' at {} is a symlink (or resolves through one) outside \
+             the plugin's agents directory — rejected as a potential host-file disclosure \
+             (#3547)",
+            path.display()
+        );
+    }
+
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("reading plugin agent {}", path.display()))?;
 
@@ -191,7 +209,12 @@ pub fn find_plugin_agent_config(
     if !path.exists() {
         return None;
     }
-    Some(load_plugin_agent(&root.name, agent_name, &path))
+    Some(load_plugin_agent(
+        &root.name,
+        agent_name,
+        &path,
+        &root.agents_dir,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/trusty-code/src/plugins/agents.rs
+++ b/crates/trusty-code/src/plugins/agents.rs
@@ -1,0 +1,189 @@
+//! Phase-1 plugin AGENT ingestion: discovery, namespacing, and resolution
+//! (issue #3539).
+//!
+//! Why: a plugin's `agents/*.md` files are the exact same
+//! Markdown+frontmatter format `agents::md_loader` already parses for
+//! project/embedded agents — the only new work is namespacing
+//! (`<plugin>:<name>`) and two Phase-1 leaf-only guarantees #3539 locks in:
+//! unsupported frontmatter fields (`effort`/`maxTurns`/`memory`/`isolation`/
+//! `disallowedTools` — trusty-mpm's own agent schema, which a plugin may
+//! carry over) are dropped with a warning rather than failing the load, and
+//! an `extends:` chain is never composed (a plugin agent is always a leaf —
+//! cross-catalog compose is a later-phase item).
+//! What: [`discover_plugin_agents`] lists every plugin agent as a fully
+//! projected [`AgentConfig`] (used by `agents::protocol::agents_list`'s
+//! `plugin` tier); [`find_plugin_agent_config`] resolves one namespaced
+//! `<plugin>:<name>` on demand (used by `agents::resolve_agent`, the
+//! dispatch path). Both route through [`load_plugin_agent`], which reuses
+//! `agents::md_loader`'s frontmatter/body parsing
+//! ([`crate::agents::md_loader::extract_body`],
+//! [`crate::agents::md_loader::project_to_agent_config`]) rather than
+//! duplicating the projection — the only difference from a disk agent load
+//! is the namespaced name and the two Phase-1 guards above.
+//! Test: `tests::*` — discovery finds and namespaces agents, unsupported
+//! fields are dropped with a warning, `extends:` is warned-and-ignored,
+//! resolution finds/misses a namespaced name, a base-agent-named plugin
+//! agent is excluded from listing.
+
+use std::path::Path;
+
+use anyhow::Context;
+use trusty_agents_common::agents::metadata::agent_metadata_from_str;
+
+use crate::agents::AgentConfig;
+use crate::agents::md_loader::{extract_body, project_to_agent_config};
+
+use super::discover_plugin_roots;
+
+/// trusty-mpm agent-frontmatter fields tcode's `AgentConfig` has no slot
+/// for. Present on a plugin agent, they are dropped with one aggregated
+/// warning rather than failing the load (#3539's locked Phase-1 contract).
+const UNSUPPORTED_AGENT_FIELDS: &[&str] = &[
+    "effort",
+    "maxTurns",
+    "memory",
+    "isolation",
+    "disallowedTools",
+];
+
+/// List every plugin agent across every discovered plugin, fully projected
+/// and namespaced.
+///
+/// Why: `agents::protocol::agents_list`'s `plugin` tier needs the same
+/// `AgentConfig` shape (for `description`/`model` in its wire entry) the
+/// embedded and disk tiers already produce.
+/// What: for each [`PluginRoot`], scans `agents_dir` via
+/// `agents::discover_agents` (the same `.md`-only, `.toml`-warns scan disk
+/// agents use), skips any local name `agents::protocol::is_base_agent`
+/// recognizes (a plugin literally shipping `base-engineer.md` etc. is
+/// excluded exactly like the embedded/disk tiers — #3539's base-filter
+/// interaction clause), and loads the rest via
+/// [`load_plugin_agent`]. A load failure is logged at WARN and skipped
+/// (never aborts the whole scan), mirroring `agents::load_all_agents`'s
+/// per-file resilience. Sorted by the final namespaced name.
+/// Test: `tests::discover_plugin_agents_namespaces_entries`,
+/// `tests::discover_plugin_agents_excludes_base_named_agent`,
+/// `tests::discover_plugin_agents_skips_unparseable_agent`.
+pub fn discover_plugin_agents(project_root: &Path) -> Vec<AgentConfig> {
+    let mut out: Vec<AgentConfig> = Vec::new();
+    for root in discover_plugin_roots(project_root) {
+        for (agent_name, path) in crate::agents::discover_agents(&root.agents_dir) {
+            if crate::agents::protocol::is_base_agent(&agent_name) {
+                continue;
+            }
+            match load_plugin_agent(&root.name, &agent_name, &path) {
+                Ok(cfg) => out.push(cfg),
+                Err(e) => tracing::warn!("skipping plugin agent '{}:{agent_name}': {e}", root.name),
+            }
+        }
+    }
+    out.sort_by(|a, b| a.agent.name.cmp(&b.agent.name));
+    out
+}
+
+/// Load one plugin agent file, namespaced `<plugin>:<agent_name>`.
+///
+/// Why: the single load path both [`discover_plugin_agents`] (listing) and
+/// [`find_plugin_agent_config`] (dispatch resolution) share, so the
+/// namespacing + unsupported-field-drop + extends-warn contract is written
+/// exactly once.
+/// What: reads `path`, parses frontmatter via
+/// `trusty_agents_common::agents::metadata::agent_metadata_from_str` (no
+/// `compose_agent` call — a plugin agent is a leaf, #3539), warns and drops
+/// any [`UNSUPPORTED_AGENT_FIELDS`] present (see [`warn_unsupported_fields`]),
+/// warns (never errors) on a present `extends:` — the agent is still loaded
+/// as a direct/leaf document with no inheritance resolved — then projects
+/// via `agents::md_loader::project_to_agent_config` exactly as a disk agent
+/// would, overriding only `agent.name` with the namespaced form. An
+/// unreadable file is the only real error path.
+/// Test: `tests::load_plugin_agent_projects_fields`,
+/// `tests::load_plugin_agent_warns_and_drops_unsupported_fields`,
+/// `tests::load_plugin_agent_warns_on_extends_and_treats_as_leaf`,
+/// `tests::load_plugin_agent_missing_file_errors`.
+pub(crate) fn load_plugin_agent(
+    plugin: &str,
+    agent_name: &str,
+    path: &Path,
+) -> anyhow::Result<AgentConfig> {
+    let namespaced = format!("{plugin}:{agent_name}");
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("reading plugin agent {}", path.display()))?;
+
+    warn_unsupported_fields(&namespaced, &raw);
+
+    let meta = agent_metadata_from_str(&raw);
+    if let Some(parent) = &meta.extends {
+        tracing::warn!(
+            "plugin agent '{namespaced}' declares extends: '{parent}' — tcode Phase 1 plugin \
+             agents are leaf-only (no cross-catalog compose, #3539); loading its own \
+             frontmatter/body only, the parent is not resolved"
+        );
+    }
+
+    let body = extract_body(&raw);
+    let mut cfg = project_to_agent_config(agent_name, meta, body);
+    cfg.agent.name = namespaced;
+    Ok(cfg)
+}
+
+/// Warn once (one aggregated line) when `raw`'s frontmatter declares any
+/// [`UNSUPPORTED_AGENT_FIELDS`].
+///
+/// Why: `#3539` requires "DROP unsupported plugin fields ... with a
+/// one-line warn per agent" — one line naming every dropped field, not one
+/// line per field (mirrors `agents::warn_on_orphaned_toml`'s aggregation
+/// convention). Uses `skills::frontmatter::parse_frontmatter`'s generic
+/// flat key/value scan (reused across the agents/skills domain split
+/// rather than re-implemented) purely to detect KEY PRESENCE — the
+/// supported-field values themselves are parsed separately via
+/// `agent_metadata_from_str`.
+/// What: no-op when none of the fields are present.
+/// Test: `tests::load_plugin_agent_warns_and_drops_unsupported_fields`.
+fn warn_unsupported_fields(namespaced: &str, raw: &str) {
+    let map = crate::skills::frontmatter::parse_frontmatter(raw);
+    let dropped: Vec<&str> = UNSUPPORTED_AGENT_FIELDS
+        .iter()
+        .copied()
+        .filter(|k| map.contains_key(*k))
+        .collect();
+    if !dropped.is_empty() {
+        tracing::warn!(
+            "plugin agent '{namespaced}' declares unsupported field(s) {} — dropped (tcode \
+             Phase 1 plugin support maps role/description/model/max_tokens/tools only, #3539)",
+            dropped.join(", ")
+        );
+    }
+}
+
+/// Resolve one namespaced `<plugin>:<agent_name>` to its [`AgentConfig`], or
+/// `None` when no such plugin/agent exists.
+///
+/// Why: `agents::resolve_agent`'s dispatch-time entry point for a
+/// namespaced name — mirrors that function's own `NotFound`
+/// (nothing found, `None`) vs `Load` (found but failed to parse, `Some(Err)`)
+/// distinction so its caller can build the identical error shape.
+/// What: finds the [`PluginRoot`] whose resolved `name` equals `plugin`
+/// (not the directory name, which may differ — see [`PluginRoot`]'s doc);
+/// `None` if no such plugin. Within it, `None` if `<agent_name>.md` does not
+/// exist; otherwise `Some` wrapping [`load_plugin_agent`]'s result.
+/// Test: `tests::find_plugin_agent_config_resolves_known_agent`,
+/// `tests::find_plugin_agent_config_unknown_plugin_is_none`,
+/// `tests::find_plugin_agent_config_unknown_agent_is_none`.
+pub fn find_plugin_agent_config(
+    project_root: &Path,
+    plugin: &str,
+    agent_name: &str,
+) -> Option<anyhow::Result<AgentConfig>> {
+    let root = discover_plugin_roots(project_root)
+        .into_iter()
+        .find(|p| p.name == plugin)?;
+    let path = root.agents_dir.join(format!("{agent_name}.md"));
+    if !path.exists() {
+        return None;
+    }
+    Some(load_plugin_agent(&root.name, agent_name, &path))
+}
+
+#[cfg(test)]
+#[path = "agents_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/plugins/agents.rs
+++ b/crates/trusty-code/src/plugins/agents.rs
@@ -162,18 +162,28 @@ fn warn_unsupported_fields(namespaced: &str, raw: &str) {
 /// namespaced name — mirrors that function's own `NotFound`
 /// (nothing found, `None`) vs `Load` (found but failed to parse, `Some(Err)`)
 /// distinction so its caller can build the identical error shape.
-/// What: finds the [`PluginRoot`] whose resolved `name` equals `plugin`
-/// (not the directory name, which may differ — see [`PluginRoot`]'s doc);
-/// `None` if no such plugin. Within it, `None` if `<agent_name>.md` does not
-/// exist; otherwise `Some` wrapping [`load_plugin_agent`]'s result.
+/// What: validates `plugin:agent_name` via
+/// `plugins::is_valid_namespaced_name` FIRST, before any path is built
+/// (code-critic PR #3547 review, HIGH 3 — the guard belongs to this
+/// function, not merely to an upstream caller that happens to reject `:`
+/// today) — `None` on a traversal/unsafe-charset payload like
+/// `plugin:../../etc`. Then finds the [`PluginRoot`] whose resolved `name`
+/// equals `plugin` (not the directory name, which may differ — see
+/// [`PluginRoot`]'s doc); `None` if no such plugin. Within it, `None` if
+/// `<agent_name>.md` does not exist; otherwise `Some` wrapping
+/// [`load_plugin_agent`]'s result.
 /// Test: `tests::find_plugin_agent_config_resolves_known_agent`,
 /// `tests::find_plugin_agent_config_unknown_plugin_is_none`,
-/// `tests::find_plugin_agent_config_unknown_agent_is_none`.
+/// `tests::find_plugin_agent_config_unknown_agent_is_none`,
+/// `tests::find_plugin_agent_config_rejects_traversal_name`.
 pub fn find_plugin_agent_config(
     project_root: &Path,
     plugin: &str,
     agent_name: &str,
 ) -> Option<anyhow::Result<AgentConfig>> {
+    if !super::is_valid_namespaced_name(&format!("{plugin}:{agent_name}")) {
+        return None;
+    }
     let root = discover_plugin_roots(project_root)
         .into_iter()
         .find(|p| p.name == plugin)?;

--- a/crates/trusty-code/src/plugins/agents_tests.rs
+++ b/crates/trusty-code/src/plugins/agents_tests.rs
@@ -230,3 +230,44 @@ fn find_plugin_agent_config_unknown_agent_is_none() {
 
     assert!(find_plugin_agent_config(tmp.path(), "my-plugin", "ghost").is_none());
 }
+
+/// A traversal payload in the local `agent_name` segment is rejected
+/// BEFORE any path is built — even when a file that would satisfy the
+/// naive `<dir>/<name>.md` join actually exists on disk outside the
+/// plugin's `agents_dir` (code-critic PR #3547 review, HIGH 3).
+///
+/// Why: this is the exact repro shape the review flagged —
+/// `agents_dir.join(format!("{agent_name}.md"))` built directly from a
+/// caller-supplied segment. Planting a REAL file at the escape target and
+/// asserting it is never read proves the guard fires before the
+/// filesystem is ever touched with the unsafe path, not merely that the
+/// (possibly nonexistent) target happens to miss.
+/// Test: this test.
+#[test]
+fn find_plugin_agent_config_rejects_traversal_name() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_agent(
+        &plugins_dir,
+        "my-plugin",
+        "reviewer",
+        "---\nname: reviewer\n---\n\nBody.\n",
+    );
+    // A real file at the traversal target — if the guard did not fire, this
+    // is exactly what `agents_dir.join("../../secret.md")` would resolve to
+    // and successfully load.
+    std::fs::write(
+        tmp.path().join("secret.md"),
+        "---\nname: secret\n---\n\nSHOULD NEVER BE READ.\n",
+    )
+    .expect("write secret");
+
+    assert!(
+        find_plugin_agent_config(tmp.path(), "my-plugin", "../../secret").is_none(),
+        "a traversal payload in agent_name must be rejected, not resolved"
+    );
+    assert!(
+        find_plugin_agent_config(tmp.path(), "my-plugin", "/etc/passwd").is_none(),
+        "an absolute-path-shaped agent_name must be rejected"
+    );
+}

--- a/crates/trusty-code/src/plugins/agents_tests.rs
+++ b/crates/trusty-code/src/plugins/agents_tests.rs
@@ -99,7 +99,7 @@ fn load_plugin_agent_projects_fields() {
     )
     .expect("write");
 
-    let cfg = load_plugin_agent("plug", "solo", &path).expect("load");
+    let cfg = load_plugin_agent("plug", "solo", &path, tmp.path()).expect("load");
     assert_eq!(cfg.agent.name, "plug:solo");
     assert_eq!(cfg.agent.role.as_deref(), Some("engineer"));
     assert_eq!(cfg.agent.description.as_deref(), Some("A lone agent"));
@@ -131,7 +131,8 @@ fn load_plugin_agent_warns_and_drops_unsupported_fields() {
     )
     .expect("write");
 
-    let cfg = load_plugin_agent("plug", "fancy", &path).expect("load must still succeed");
+    let cfg =
+        load_plugin_agent("plug", "fancy", &path, tmp.path()).expect("load must still succeed");
     assert_eq!(cfg.agent.name, "plug:fancy");
 
     let captured = crate::test_support::captured_at_least(tracing::Level::WARN);
@@ -165,7 +166,8 @@ fn load_plugin_agent_warns_on_extends_and_treats_as_leaf() {
     )
     .expect("write");
 
-    let cfg = load_plugin_agent("plug", "child", &path).expect("load must still succeed");
+    let cfg =
+        load_plugin_agent("plug", "child", &path, tmp.path()).expect("load must still succeed");
     assert_eq!(cfg.system_prompt.content, "Only my own body.");
 
     let captured = crate::test_support::captured_at_least(tracing::Level::WARN);
@@ -182,8 +184,50 @@ fn load_plugin_agent_warns_on_extends_and_treats_as_leaf() {
 /// Test: this test.
 #[test]
 fn load_plugin_agent_missing_file_errors() {
-    let result = load_plugin_agent("plug", "ghost", Path::new("/nonexistent/ghost.md"));
+    let result = load_plugin_agent(
+        "plug",
+        "ghost",
+        Path::new("/nonexistent/ghost.md"),
+        Path::new("/nonexistent"),
+    );
     assert!(result.is_err());
+}
+
+/// A plugin agent file that is (or resolves through) a symlink escaping
+/// `agents_dir` is rejected — the secret content it would otherwise expose
+/// is planted at the escape target and asserted never read (code-critic PR
+/// #3547 re-review, CRITICAL 5, CWE-59).
+///
+/// Why: this is the exact repro shape the re-review flagged — a real
+/// `agents/leak.md` symlinked to an arbitrary host file (`~/.ssh/id_rsa` in
+/// the wild; a planted "secret" file here).
+/// Test: this test.
+#[test]
+#[cfg(unix)]
+fn load_plugin_agent_rejects_symlinked_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+
+    let secret_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&secret_dir).expect("mkdir");
+    let secret_path = secret_dir.join("id_rsa");
+    std::fs::write(
+        &secret_path,
+        "-----BEGIN OPENSSH PRIVATE KEY-----\nSECRET\n",
+    )
+    .expect("write secret");
+
+    let leak_path = agents_dir.join("leak.md");
+    std::os::unix::fs::symlink(&secret_path, &leak_path).expect("create symlink");
+
+    let result = load_plugin_agent("plug", "leak", &leak_path, &agents_dir);
+    let err = result.expect_err("a symlinked leaf file must be rejected");
+    let msg = format!("{err:#}");
+    assert!(
+        !msg.contains("SECRET"),
+        "the secret content must never appear anywhere, even in an error message, got: {msg}"
+    );
 }
 
 /// [`find_plugin_agent_config`] resolves a known plugin/agent pair.
@@ -270,4 +314,79 @@ fn find_plugin_agent_config_rejects_traversal_name() {
         find_plugin_agent_config(tmp.path(), "my-plugin", "/etc/passwd").is_none(),
         "an absolute-path-shaped agent_name must be rejected"
     );
+}
+
+/// `discover_plugin_agents` (the `agents.list` listing path) excludes a
+/// symlinked plugin agent file — a real, legitimate agent alongside it is
+/// still listed, but the symlinked one, and the secret content it points
+/// at, never appear (code-critic PR #3547 re-review, CRITICAL 5, CWE-59).
+///
+/// Test: this test.
+#[test]
+#[cfg(unix)]
+fn discover_plugin_agents_excludes_symlinked_leak_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_agent(
+        &plugins_dir,
+        "my-plugin",
+        "reviewer",
+        "---\nname: reviewer\n---\n\nBody.\n",
+    );
+
+    let secret_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&secret_dir).expect("mkdir");
+    let secret_path = secret_dir.join("id_rsa");
+    std::fs::write(&secret_path, "SECRET_KEY_MATERIAL").expect("write secret");
+    let leak_path = plugins_dir.join("my-plugin").join("agents").join("leak.md");
+    std::os::unix::fs::symlink(&secret_path, &leak_path).expect("create symlink");
+
+    let agents = discover_plugin_agents(tmp.path());
+    let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["my-plugin:reviewer"],
+        "the symlinked entry must be excluded; the real agent must still be listed"
+    );
+    assert!(
+        agents
+            .iter()
+            .all(|a| !a.system_prompt.content.contains("SECRET_KEY_MATERIAL")),
+        "the secret content must never appear in any listed agent's body"
+    );
+}
+
+/// `find_plugin_agent_config` (the dispatch/`delegate_to_agent` resolution
+/// path) rejects a symlinked plugin agent file, never surfacing the target
+/// file's content (code-critic PR #3547 re-review, CRITICAL 5, CWE-59).
+///
+/// Test: this test.
+#[test]
+#[cfg(unix)]
+fn find_plugin_agent_config_rejects_symlinked_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    std::fs::create_dir_all(plugins_dir.join("my-plugin").join("agents")).expect("mkdir");
+
+    let secret_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&secret_dir).expect("mkdir");
+    let secret_path = secret_dir.join("id_rsa");
+    std::fs::write(&secret_path, "SECRET_KEY_MATERIAL").expect("write secret");
+    let leak_path = plugins_dir.join("my-plugin").join("agents").join("leak.md");
+    std::os::unix::fs::symlink(&secret_path, &leak_path).expect("create symlink");
+
+    match find_plugin_agent_config(tmp.path(), "my-plugin", "leak") {
+        None => {}
+        Some(Ok(cfg)) => panic!(
+            "a symlinked agent must never resolve successfully, got: {:?}",
+            cfg.system_prompt.content
+        ),
+        Some(Err(e)) => {
+            let msg = format!("{e:#}");
+            assert!(
+                !msg.contains("SECRET_KEY_MATERIAL"),
+                "the secret content must never leak into the error message, got: {msg}"
+            );
+        }
+    }
 }

--- a/crates/trusty-code/src/plugins/agents_tests.rs
+++ b/crates/trusty-code/src/plugins/agents_tests.rs
@@ -1,0 +1,232 @@
+use super::*;
+
+fn write_plugin_agent(plugins_dir: &Path, plugin: &str, agent_name: &str, content: &str) {
+    let dir = plugins_dir.join(plugin).join("agents");
+    std::fs::create_dir_all(&dir).expect("mkdir agents dir");
+    std::fs::write(dir.join(format!("{agent_name}.md")), content).expect("write agent");
+}
+
+/// Discovery namespaces every plugin agent `<plugin>:<name>` and projects
+/// its fields.
+///
+/// Why: this is the acceptance criterion for #3539's namespacing decision.
+/// Test: this test.
+#[test]
+fn discover_plugin_agents_namespaces_entries() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_agent(
+        &plugins_dir,
+        "my-plugin",
+        "reviewer",
+        "---\nname: reviewer\ndescription: Reviews code\nmodel: sonnet\n---\n\nYou review code.\n",
+    );
+
+    let agents = discover_plugin_agents(tmp.path());
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].agent.name, "my-plugin:reviewer");
+    assert_eq!(agents[0].agent.description.as_deref(), Some("Reviews code"));
+    assert_eq!(agents[0].agent.model.as_deref(), Some("sonnet"));
+    assert_eq!(agents[0].system_prompt.content, "You review code.");
+}
+
+/// A plugin agent literally named a `BASE-*` template name is excluded from
+/// discovery, exactly like the embedded/disk tiers (#3539's base-filter
+/// interaction clause).
+///
+/// Test: this test.
+#[test]
+fn discover_plugin_agents_excludes_base_named_agent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_agent(
+        &plugins_dir,
+        "my-plugin",
+        "base-engineer",
+        "---\nname: base-engineer\n---\n\nTemplate only.\n",
+    );
+    write_plugin_agent(
+        &plugins_dir,
+        "my-plugin",
+        "real-agent",
+        "---\nname: real-agent\n---\n\nBody.\n",
+    );
+
+    let agents = discover_plugin_agents(tmp.path());
+    let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
+    assert_eq!(names, vec!["my-plugin:real-agent"]);
+}
+
+/// A plugin agent that fails to load (unreadable/malformed) is skipped with
+/// a warning, never aborting the whole scan.
+///
+/// Test: this test.
+#[test]
+fn discover_plugin_agents_skips_unparseable_agent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    // A directory named `broken.md` (unreadable as a file) exercises the
+    // read failure path without depending on filesystem permissions.
+    std::fs::create_dir_all(
+        plugins_dir
+            .join("my-plugin")
+            .join("agents")
+            .join("broken.md"),
+    )
+    .expect("mkdir");
+    write_plugin_agent(
+        &plugins_dir,
+        "my-plugin",
+        "good-agent",
+        "---\nname: good-agent\n---\n\nBody.\n",
+    );
+
+    let agents = discover_plugin_agents(tmp.path());
+    let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
+    assert_eq!(names, vec!["my-plugin:good-agent"]);
+}
+
+/// [`load_plugin_agent`] projects every supported field.
+///
+/// Test: this test.
+#[test]
+fn load_plugin_agent_projects_fields() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("solo.md");
+    std::fs::write(
+        &path,
+        "---\nname: solo\nrole: engineer\ndescription: A lone agent\nmodel: sonnet\nmax_tokens: 4096\ntools: [read_file]\n---\n\nBody text.\n",
+    )
+    .expect("write");
+
+    let cfg = load_plugin_agent("plug", "solo", &path).expect("load");
+    assert_eq!(cfg.agent.name, "plug:solo");
+    assert_eq!(cfg.agent.role.as_deref(), Some("engineer"));
+    assert_eq!(cfg.agent.description.as_deref(), Some("A lone agent"));
+    assert_eq!(cfg.agent.model.as_deref(), Some("sonnet"));
+    assert_eq!(cfg.llm.max_tokens, Some(4096));
+    assert_eq!(cfg.system_prompt.content, "Body text.");
+    assert_eq!(
+        cfg.tools.and_then(|t| t.allowed),
+        Some(vec!["read_file".to_string()])
+    );
+}
+
+/// Unsupported trusty-mpm-style frontmatter fields
+/// (`effort`/`maxTurns`/`memory`/`isolation`/`disallowedTools`) are dropped
+/// with one aggregated warning, never a load failure.
+///
+/// Why: this is the acceptance criterion for #3539's "DROP unsupported
+/// plugin fields ... with a one-line warn per agent" requirement.
+/// Test: this test.
+#[test]
+fn load_plugin_agent_warns_and_drops_unsupported_fields() {
+    crate::test_support::begin_capture();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("fancy.md");
+    std::fs::write(
+        &path,
+        "---\nname: fancy\neffort: high\nmaxTurns: 10\nmemory: enabled\nisolation: worktree\ndisallowedTools: [Bash]\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let cfg = load_plugin_agent("plug", "fancy", &path).expect("load must still succeed");
+    assert_eq!(cfg.agent.name, "plug:fancy");
+
+    let captured = crate::test_support::captured_at_least(tracing::Level::WARN);
+    let warning = captured
+        .iter()
+        .find(|m| m.contains("unsupported field"))
+        .unwrap_or_else(|| panic!("expected an unsupported-field warning, got: {captured:?}"));
+    assert!(warning.contains("plug:fancy"), "got: {warning}");
+    assert!(warning.contains("effort"), "got: {warning}");
+    assert!(warning.contains("maxTurns"), "got: {warning}");
+    assert!(warning.contains("memory"), "got: {warning}");
+    assert!(warning.contains("isolation"), "got: {warning}");
+    assert!(warning.contains("disallowedTools"), "got: {warning}");
+}
+
+/// An `extends:` chain on a plugin agent is warned-and-ignored — the agent
+/// still loads as a leaf, its own body only, with no parent content pulled
+/// in.
+///
+/// Why: #3539 — "a plugin agent with extends: -> warn + treat as direct".
+/// Test: this test.
+#[test]
+fn load_plugin_agent_warns_on_extends_and_treats_as_leaf() {
+    crate::test_support::begin_capture();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("child.md");
+    std::fs::write(
+        &path,
+        "---\nname: child\nextends: some-base\n---\n\nOnly my own body.\n",
+    )
+    .expect("write");
+
+    let cfg = load_plugin_agent("plug", "child", &path).expect("load must still succeed");
+    assert_eq!(cfg.system_prompt.content, "Only my own body.");
+
+    let captured = crate::test_support::captured_at_least(tracing::Level::WARN);
+    let warning = captured
+        .iter()
+        .find(|m| m.contains("extends"))
+        .unwrap_or_else(|| panic!("expected an extends warning, got: {captured:?}"));
+    assert!(warning.contains("plug:child"), "got: {warning}");
+    assert!(warning.contains("some-base"), "got: {warning}");
+}
+
+/// A missing plugin agent file surfaces a descriptive error, never a panic.
+///
+/// Test: this test.
+#[test]
+fn load_plugin_agent_missing_file_errors() {
+    let result = load_plugin_agent("plug", "ghost", Path::new("/nonexistent/ghost.md"));
+    assert!(result.is_err());
+}
+
+/// [`find_plugin_agent_config`] resolves a known plugin/agent pair.
+///
+/// Test: this test.
+#[test]
+fn find_plugin_agent_config_resolves_known_agent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_agent(
+        &plugins_dir,
+        "my-plugin",
+        "reviewer",
+        "---\nname: reviewer\n---\n\nBody.\n",
+    );
+
+    let result = find_plugin_agent_config(tmp.path(), "my-plugin", "reviewer");
+    let cfg = result.expect("must find").expect("must load");
+    assert_eq!(cfg.agent.name, "my-plugin:reviewer");
+}
+
+/// An unknown plugin name resolves to `None` (not found), never an error.
+///
+/// Test: this test.
+#[test]
+fn find_plugin_agent_config_unknown_plugin_is_none() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(find_plugin_agent_config(tmp.path(), "no-such-plugin", "reviewer").is_none());
+}
+
+/// A known plugin but an unknown agent name resolves to `None`.
+///
+/// Test: this test.
+#[test]
+fn find_plugin_agent_config_unknown_agent_is_none() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_agent(
+        &plugins_dir,
+        "my-plugin",
+        "reviewer",
+        "---\nname: reviewer\n---\n\nBody.\n",
+    );
+
+    assert!(find_plugin_agent_config(tmp.path(), "my-plugin", "ghost").is_none());
+}

--- a/crates/trusty-code/src/plugins/mod.rs
+++ b/crates/trusty-code/src/plugins/mod.rs
@@ -46,6 +46,22 @@
 //! `..` escapes the plugin's `agents_dir`/`skills_dir` — CRITICAL 2 / HIGH
 //! 3) before [`agents::find_plugin_agent_config`]/
 //! [`skills::resolve_plugin_skill_body`] ever join it onto a directory.
+//! A third, independent hole (re-review, CRITICAL 5, CWE-59): the
+//! DIRECTORY-path and NAME guards above say nothing about the LEAF FILE a
+//! validated name resolves to — `std::fs::read_to_string`,
+//! `Path::is_dir`/`is_file` all FOLLOW symlinks, so a plugin can ship
+//! `agents/leak.md` (or a `skills/<name>/SKILL.md`, or even `skills/<name>`
+//! itself) as a symlink to an arbitrary host file/directory (e.g.
+//! `~/.ssh/id_rsa`); discovery would read the TARGET's content as that
+//! agent's system prompt or skill body, which then reaches an LLM prompt
+//! verbatim once dispatched. [`path_is_contained`] closes this: every
+//! point a discovered `.md`/`SKILL.md` file's content is actually read
+//! (`agents::load_plugin_agent`, `skills::discover_one_plugin_skills`,
+//! `skills::resolve_plugin_skill_body`) canonicalizes the full leaf path
+//! and requires it stay contained within the already-validated
+//! `agents_dir`/`skills_dir` — since `canonicalize` resolves every symlink
+//! in the path, not just the final component, one check catches a
+//! symlinked leaf file, a symlinked intermediate directory, or both.
 
 pub mod agents;
 pub mod skills;
@@ -312,6 +328,40 @@ pub fn is_valid_namespaced_name(name: &str) -> bool {
             crate::agents::protocol::validate_agent_name(plugin).is_ok()
                 && crate::agents::protocol::validate_agent_name(local).is_ok()
         }
+        _ => false,
+    }
+}
+
+/// Whether `leaf`'s canonicalized path is contained within `container`'s
+/// own canonicalization — the LEAF-FILE-IDENTITY guard neither
+/// [`safe_plugin_subdir`] (guards a `plugin.json` directory override) nor
+/// [`is_valid_namespaced_name`] (guards the dispatch NAME) provides
+/// (code-critic PR #3547 re-review, CRITICAL 5, CWE-59).
+///
+/// Why: `std::fs::read_to_string`, `Path::is_dir`, and `Path::is_file` all
+/// FOLLOW symlinks. A validated directory (`agents_dir`/`skills_dir`) and a
+/// validated namespaced NAME together still say nothing about what the
+/// resulting `<dir>/<name>` (or `<dir>/<name>/SKILL.md`) path actually
+/// points AT on disk — a hostile plugin can make that exact leaf entry (or
+/// an intermediate path component, e.g. `skills/<name>` itself) a symlink
+/// to an arbitrary host file/directory (`~/.ssh/id_rsa`). Reading it would
+/// feed the target's content into an LLM prompt verbatim once the
+/// (legitimately namespaced, legitimately-directoried) name is dispatched.
+/// What: canonicalizes both `leaf` and `container`; `true` only when BOTH
+/// canonicalize successfully AND the canonicalized `leaf` starts with the
+/// canonicalized `container`. A leaf that fails to canonicalize (broken
+/// symlink, race, doesn't exist) is treated as NOT contained — fail
+/// closed, never fail open into "assume safe". Because `canonicalize`
+/// resolves EVERY symlink in the path (not merely the final component),
+/// ONE call here catches a symlinked leaf file, a symlinked intermediate
+/// directory, or both, uniformly — callers do not need a separate check
+/// for "is the containing directory itself a symlink".
+/// Test: `tests::path_is_contained_accepts_real_file_within_container`,
+/// `tests::path_is_contained_rejects_symlink_escaping_container`,
+/// `tests::path_is_contained_rejects_nonexistent_leaf`.
+pub(crate) fn path_is_contained(leaf: &Path, container: &Path) -> bool {
+    match (leaf.canonicalize(), container.canonicalize()) {
+        (Ok(canon_leaf), Ok(canon_container)) => canon_leaf.starts_with(&canon_container),
         _ => false,
     }
 }

--- a/crates/trusty-code/src/plugins/mod.rs
+++ b/crates/trusty-code/src/plugins/mod.rs
@@ -1,0 +1,222 @@
+//! Claude Code plugin ingestion, Phase 1: local-directory agents + skills
+//! only (issue #3539).
+//!
+//! Why: Claude Code plugins package reusable agents/skills (and, in later
+//! phases, commands/hooks/MCP servers) for drop-in use by a harness. tcode
+//! already parses the exact on-disk formats a plugin ships agents
+//! (`.md`+frontmatter, see `agents::md_loader`) and skills (`SKILL.md`,
+//! progressive disclosure, see `crate::skills`) in — so Phase 1 is a
+//! discovery + namespacing layer over those existing parsers, not a new
+//! format. Phase 1 is deliberately narrow (#3539's locked scope): a plugin
+//! is a LOCAL directory under `<project_root>/.claude/plugins/<plugin>/`
+//! (no marketplace/git fetch), and only `agents/` + `skills/` are ingested
+//! (no commands/hooks/MCP — later phases). Plugin entries are ADDITIVE
+//! ONLY: they are namespaced `<plugin>:<name>` in every surface that lists
+//! or resolves them, so they can never collide with — and therefore never
+//! override — an unnamespaced project or embedded/bundled name.
+//! What: [`PluginRoot`] is one discovered plugin (resolved name + its
+//! agents/skills directories, honoring `.claude-plugin/plugin.json`'s
+//! `name`/`agents`/`skills` overrides when present). [`discover_plugin_roots`]
+//! scans `<project_root>/.claude/plugins/` for plugin subdirectories.
+//! [`project_root_two_levels_up`] is the shared seam every integration point
+//! (`agents::protocol::agents_list`, `agents::resolve_agent`,
+//! `skills::protocol::skills_list`, `skills::FsSkillResolver`) uses to
+//! recover a project root from the `.claude/agents` or `.claude/skills`
+//! directory it already holds, without threading a new parameter through
+//! every call site. Submodules [`agents`] and [`skills`] do the actual
+//! agent/skill discovery, namespacing, and resolution.
+//! Test: `tests::*` here cover manifest parsing (present/absent/malformed,
+//! name/agents/skills overrides, later-phase key detection) and
+//! `discover_plugin_roots` scanning; `agents::tests`/`skills::tests` cover
+//! the per-domain ingestion contracts.
+
+pub mod agents;
+pub mod skills;
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// The `.claude/plugins` directory name, relative to a project root.
+const PLUGINS_DIRNAME: &str = "plugins";
+
+/// `.claude-plugin/plugin.json` keys Phase 1 recognizes as later-phase
+/// surfaces (commands/hooks/MCP) — present but intentionally unimplemented,
+/// per #3539's scope.
+///
+/// Why: names the exact set [`load_plugin_root`] checks for so a plugin
+/// author sees a debug log explaining why e.g. its `hooks` declaration had
+/// no effect, rather than silent nothing.
+const LATER_PHASE_MANIFEST_KEYS: &[&str] = &["commands", "hooks", "mcpServers", "mcp"];
+
+/// One discovered plugin: its resolved name and the directories its agents
+/// and skills live under.
+///
+/// Why: the resolved `name` (manifest `name:`, falling back to the
+/// directory name) is what every namespaced `<plugin>:<local-name>` entry
+/// uses — it may differ from the on-disk subdirectory name, so callers must
+/// always go through this struct rather than re-deriving a plugin's
+/// identity from its path.
+/// What: `root` is the plugin's own directory
+/// (`<project_root>/.claude/plugins/<dir>`); `agents_dir`/`skills_dir` are
+/// already-joined, ready-to-scan paths (manifest overrides applied, or the
+/// `agents`/`skills` convention when absent) — neither is guaranteed to
+/// exist on disk.
+/// Test: `tests::discover_plugin_roots_*`.
+#[derive(Debug, Clone)]
+pub struct PluginRoot {
+    /// Resolved plugin name — manifest `name:`, or the directory name.
+    pub name: String,
+    /// The plugin's own root directory.
+    pub root: PathBuf,
+    /// Where this plugin's `*.md` agents live.
+    pub agents_dir: PathBuf,
+    /// Where this plugin's `<skill>/SKILL.md` skills live.
+    pub skills_dir: PathBuf,
+}
+
+/// The subset of `.claude-plugin/plugin.json` Phase 1 understands.
+///
+/// Why: a plugin manifest is optional (#3539 — a plugin with no manifest
+/// falls back to the directory name + the `agents`/`skills` convention);
+/// when present, Phase 1 only acts on `name`/`agents`/`skills` — every
+/// other key (description, version, author, and the later-phase
+/// `commands`/`hooks`/`mcpServers`) is captured in `other` purely so
+/// [`load_plugin_root`] can detect and log the later-phase ones, never to
+/// drive behavior.
+/// Test: `tests::manifest_parses_name_and_overrides`,
+/// `tests::manifest_flattens_unknown_keys`.
+#[derive(Debug, Default, Deserialize)]
+struct PluginManifest {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    agents: Option<String>,
+    #[serde(default)]
+    skills: Option<String>,
+    #[serde(flatten)]
+    other: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Discover every plugin under `<project_root>/.claude/plugins/`.
+///
+/// Why: the single scan point [`agents::discover_plugin_agents`],
+/// [`skills::discover_plugin_skills`], and the namespaced-name resolvers in
+/// both submodules all build on.
+/// What: each immediate subdirectory of `.claude/plugins/` is one plugin
+/// root, resolved via [`load_plugin_root`]. A missing/unreadable
+/// `.claude/plugins/` directory yields an empty list (never an error — a
+/// project simply using no plugins is the common case, mirroring
+/// `agents::discover_agents`'s missing-dir handling). Non-directory entries
+/// are skipped. Sorted by resolved name.
+/// Test: `tests::discover_plugin_roots_missing_dir_is_empty`,
+/// `tests::discover_plugin_roots_finds_subdirs`,
+/// `tests::discover_plugin_roots_honors_manifest_name_override`.
+pub fn discover_plugin_roots(project_root: &Path) -> Vec<PluginRoot> {
+    let plugins_dir = project_root.join(".claude").join(PLUGINS_DIRNAME);
+    let Ok(entries) = std::fs::read_dir(&plugins_dir) else {
+        tracing::debug!(
+            "plugins dir not found or unreadable: {}",
+            plugins_dir.display()
+        );
+        return Vec::new();
+    };
+
+    let mut roots: Vec<PluginRoot> = entries
+        .flatten()
+        .filter(|entry| entry.path().is_dir())
+        .filter_map(|entry| {
+            let path = entry.path();
+            let dir_name = path.file_name()?.to_str()?.to_string();
+            Some(load_plugin_root(&path, &dir_name))
+        })
+        .collect();
+    roots.sort_by(|a, b| a.name.cmp(&b.name));
+    roots
+}
+
+/// Resolve one plugin subdirectory into a [`PluginRoot`].
+///
+/// Why: factored out of [`discover_plugin_roots`] so the
+/// manifest-or-convention resolution (name, agents dir, skills dir) is a
+/// single, independently readable unit.
+/// What: reads `<plugin_dir>/.claude-plugin/plugin.json` if present; a
+/// missing or malformed manifest degrades to `dir_name` +
+/// the `agents`/`skills` directory convention (never an error — see the
+/// module doc's "no manifest" case). When a manifest IS present and
+/// declares any [`LATER_PHASE_MANIFEST_KEYS`], logs one aggregated
+/// `tracing::debug!` naming them.
+/// Test: `tests::discover_plugin_roots_honors_manifest_name_override`,
+/// `tests::discover_plugin_roots_honors_path_overrides`,
+/// `tests::discover_plugin_roots_falls_back_without_manifest`,
+/// `tests::discover_plugin_roots_warns_on_later_phase_keys`.
+fn load_plugin_root(plugin_dir: &Path, dir_name: &str) -> PluginRoot {
+    let manifest_path = plugin_dir.join(".claude-plugin").join("plugin.json");
+    let manifest: Option<PluginManifest> = std::fs::read_to_string(&manifest_path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok());
+
+    let name = manifest
+        .as_ref()
+        .and_then(|m| m.name.clone())
+        .unwrap_or_else(|| dir_name.to_string());
+    let agents_rel = manifest
+        .as_ref()
+        .and_then(|m| m.agents.clone())
+        .unwrap_or_else(|| "agents".to_string());
+    let skills_rel = manifest
+        .as_ref()
+        .and_then(|m| m.skills.clone())
+        .unwrap_or_else(|| "skills".to_string());
+
+    if let Some(m) = &manifest {
+        let later_phase: Vec<&str> = LATER_PHASE_MANIFEST_KEYS
+            .iter()
+            .copied()
+            .filter(|k| m.other.contains_key(*k))
+            .collect();
+        if !later_phase.is_empty() {
+            tracing::debug!(
+                "plugin '{name}' declares plugin.json key(s) {} — tcode Phase 1 ingests \
+                 agents+skills only; ignored until a later phase (#3539)",
+                later_phase.join(", ")
+            );
+        }
+    }
+
+    PluginRoot {
+        agents_dir: plugin_dir.join(agents_rel),
+        skills_dir: plugin_dir.join(skills_rel),
+        root: plugin_dir.to_path_buf(),
+        name,
+    }
+}
+
+/// Recover a project root from a `.claude/agents` or `.claude/skills`
+/// directory two levels below it.
+///
+/// Why: `agents::protocol::AgentsCatalogState`/`skills::protocol::SkillsCatalogState`
+/// and `skills::FsSkillResolver` already hold a resolved `.claude/agents` or
+/// `.claude/skills` directory (see `binding::ProjectBinding::agents_dir`,
+/// `skills::locate_skills_dir`) — both are always exactly `<root>/.claude/<x>`.
+/// Deriving the root from that existing path lets every plugin-aware call
+/// site (`agents::resolve_agent`, `agents::protocol::agents_list`,
+/// `skills::protocol::skills_list`, `skills::FsSkillResolver::new`) opt into
+/// plugin discovery without a new `project_root` parameter threaded through
+/// their existing signatures/constructors.
+/// What: `dir.parent().parent()` — works identically whether `dir` is the
+/// `.claude/agents` convention or the legacy `.open-mpm/agents` one, since
+/// both are exactly two segments below the root. Returns `None` when `dir`
+/// has fewer than two ancestors (e.g. a bare relative path in tests).
+/// Test: `tests::project_root_two_levels_up_recovers_root`,
+/// `tests::project_root_two_levels_up_none_when_too_shallow`.
+pub(crate) fn project_root_two_levels_up(dot_claude_child_dir: &Path) -> Option<PathBuf> {
+    dot_claude_child_dir
+        .parent()?
+        .parent()
+        .map(Path::to_path_buf)
+}
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/plugins/mod.rs
+++ b/crates/trusty-code/src/plugins/mod.rs
@@ -117,8 +117,9 @@ pub struct PluginRoot {
 /// `commands`/`hooks`/`mcpServers`) is captured in `other` purely so
 /// [`load_plugin_root`] can detect and log the later-phase ones, never to
 /// drive behavior.
-/// Test: `tests::manifest_parses_name_and_overrides`,
-/// `tests::manifest_flattens_unknown_keys`.
+/// Test: `tests::discover_plugin_roots_honors_manifest_name_override`,
+/// `tests::discover_plugin_roots_honors_path_overrides`,
+/// `tests::discover_plugin_roots_warns_on_later_phase_keys`.
 #[derive(Debug, Default, Deserialize)]
 struct PluginManifest {
     #[serde(default)]

--- a/crates/trusty-code/src/plugins/mod.rs
+++ b/crates/trusty-code/src/plugins/mod.rs
@@ -29,6 +29,23 @@
 //! name/agents/skills overrides, later-phase key detection) and
 //! `discover_plugin_roots` scanning; `agents::tests`/`skills::tests` cover
 //! the per-domain ingestion contracts.
+//!
+//! ## Security: plugin content is HOSTILE input (issue #3547)
+//!
+//! Everything under `.claude/plugins/` — `plugin.json`, agent/skill
+//! directory names, and frontmatter content — is THIRD-PARTY, not authored
+//! by the project owner the way `.claude/agents|skills/` is. Two path-join
+//! sites are therefore treated as adversarial and validated BEFORE any
+//! filesystem join, exactly like `agents::protocol::validate_agent_name`
+//! already treats a caller-supplied catalog name:
+//! [`load_plugin_root`] validates a `plugin.json` `agents`/`skills`
+//! override (a `PathBuf::join` of an absolute or `..`-bearing override
+//! escapes `plugin_dir` outright — code-critic PR #3547 review, CRITICAL 1)
+//! and [`is_valid_namespaced_name`] validates every caller-supplied
+//! `<plugin>:<local>` dispatch name (a raw local segment containing `/` or
+//! `..` escapes the plugin's `agents_dir`/`skills_dir` — CRITICAL 2 / HIGH
+//! 3) before [`agents::find_plugin_agent_config`]/
+//! [`skills::resolve_plugin_skill_body`] ever join it onto a directory.
 
 pub mod agents;
 pub mod skills;
@@ -145,11 +162,14 @@ pub fn discover_plugin_roots(project_root: &Path) -> Vec<PluginRoot> {
 /// the `agents`/`skills` directory convention (never an error — see the
 /// module doc's "no manifest" case). When a manifest IS present and
 /// declares any [`LATER_PHASE_MANIFEST_KEYS`], logs one aggregated
-/// `tracing::debug!` naming them.
+/// `tracing::debug!` naming them. `agents`/`skills` overrides route through
+/// [`safe_plugin_subdir`] — `plugin.json` is hostile input (#3547).
 /// Test: `tests::discover_plugin_roots_honors_manifest_name_override`,
 /// `tests::discover_plugin_roots_honors_path_overrides`,
 /// `tests::discover_plugin_roots_falls_back_without_manifest`,
-/// `tests::discover_plugin_roots_warns_on_later_phase_keys`.
+/// `tests::discover_plugin_roots_warns_on_later_phase_keys`,
+/// `tests::load_plugin_root_rejects_absolute_agents_override`,
+/// `tests::load_plugin_root_rejects_dotdot_skills_override`.
 fn load_plugin_root(plugin_dir: &Path, dir_name: &str) -> PluginRoot {
     let manifest_path = plugin_dir.join(".claude-plugin").join("plugin.json");
     let manifest: Option<PluginManifest> = std::fs::read_to_string(&manifest_path)
@@ -160,14 +180,15 @@ fn load_plugin_root(plugin_dir: &Path, dir_name: &str) -> PluginRoot {
         .as_ref()
         .and_then(|m| m.name.clone())
         .unwrap_or_else(|| dir_name.to_string());
-    let agents_rel = manifest
-        .as_ref()
-        .and_then(|m| m.agents.clone())
-        .unwrap_or_else(|| "agents".to_string());
-    let skills_rel = manifest
-        .as_ref()
-        .and_then(|m| m.skills.clone())
-        .unwrap_or_else(|| "skills".to_string());
+
+    let agents_dir = match manifest.as_ref().and_then(|m| m.agents.clone()) {
+        Some(rel) => safe_plugin_subdir(plugin_dir, &rel, "agents", &name, "agents"),
+        None => plugin_dir.join("agents"),
+    };
+    let skills_dir = match manifest.as_ref().and_then(|m| m.skills.clone()) {
+        Some(rel) => safe_plugin_subdir(plugin_dir, &rel, "skills", &name, "skills"),
+        None => plugin_dir.join("skills"),
+    };
 
     if let Some(m) = &manifest {
         let later_phase: Vec<&str> = LATER_PHASE_MANIFEST_KEYS
@@ -185,10 +206,113 @@ fn load_plugin_root(plugin_dir: &Path, dir_name: &str) -> PluginRoot {
     }
 
     PluginRoot {
-        agents_dir: plugin_dir.join(agents_rel),
-        skills_dir: plugin_dir.join(skills_rel),
+        agents_dir,
+        skills_dir,
         root: plugin_dir.to_path_buf(),
         name,
+    }
+}
+
+/// Validate and resolve a `plugin.json` `agents`/`skills` path override
+/// against `plugin_dir`, rejecting anything that could escape it
+/// (code-critic PR #3547 review, CRITICAL 1).
+///
+/// Why: `plugin.json` is THIRD-PARTY, caller-controlled content.
+/// `PathBuf::join` REPLACES the base entirely when the joined component is
+/// absolute (`plugin_dir.join("/etc")` == `/etc`), and a relative
+/// `../../..` override escapes upward even though it isn't absolute —
+/// either lets a malicious `plugin.json` point `agents`/`skills` at an
+/// arbitrary host directory (e.g. `~/.ssh`), which discovery would then
+/// scan and load `.md`/`SKILL.md` files out of.
+/// What: rejects `rel` outright (before any join) when it is absolute or
+/// contains a `..` component — this alone blocks every practical escape and
+/// keeps the warning specific about which shape failed. As defense in
+/// depth, the accepted candidate is additionally required to canonicalize
+/// to a path contained within `plugin_dir`'s own canonicalization (this
+/// also catches a symlink planted inside `plugin_dir` that resolves
+/// outside it). Any rejection logs one `tracing::warn!` naming the plugin,
+/// field, and offending value, and falls back to `plugin_dir.join(default)`
+/// — the un-overridden convention — rather than ever returning the
+/// untrusted path. `default` itself (`"agents"`/`"skills"`, never
+/// attacker-controlled) is never routed through this validation.
+/// Test: `tests::load_plugin_root_rejects_absolute_agents_override`,
+/// `tests::load_plugin_root_rejects_dotdot_skills_override`,
+/// `tests::discover_plugin_roots_honors_path_overrides`.
+fn safe_plugin_subdir(
+    plugin_dir: &Path,
+    rel: &str,
+    default: &str,
+    plugin_name: &str,
+    field: &str,
+) -> PathBuf {
+    let fallback = || plugin_dir.join(default);
+
+    let rel_path = Path::new(rel);
+    if rel_path.is_absolute()
+        || rel_path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        tracing::warn!(
+            "plugin '{plugin_name}' plugin.json '{field}' override {rel:?} is absolute or \
+             contains '..' — rejected as a path-traversal attempt, falling back to the \
+             default '{default}' convention (#3547)"
+        );
+        return fallback();
+    }
+
+    let joined = plugin_dir.join(rel);
+    match (plugin_dir.canonicalize(), joined.canonicalize()) {
+        (Ok(canon_root), Ok(canon_joined)) if canon_joined.starts_with(&canon_root) => joined,
+        _ => {
+            tracing::warn!(
+                "plugin '{plugin_name}' plugin.json '{field}' override {rel:?} does not resolve \
+                 within the plugin directory — rejected, falling back to the default \
+                 '{default}' convention (#3547)"
+            );
+            fallback()
+        }
+    }
+}
+
+/// Whether `name` is a well-formed `<plugin>:<local>` namespaced dispatch
+/// name — the ONE shape every plugin-aware caller (`agents::resolve_agent`,
+/// `plugins::agents::find_plugin_agent_config`,
+/// `plugins::skills::resolve_plugin_skill_body`,
+/// `skills::FsSkillResolver::resolve`, `tools::delegate::DelegateToAgentTool`,
+/// the CLI's `run-task` validation, `runner::agent_config_exists`) accepts
+/// (code-critic PR #3547 review, CRITICAL 2 / HIGH 3 / HIGH 4).
+///
+/// Why: a namespaced name's `local` segment is joined onto a plugin's
+/// `agents_dir`/`skills_dir` — e.g. `plugins::skills::resolve_plugin_skill_body`
+/// builds `skills_dir.join(skill_name).join("SKILL.md")` directly from the
+/// caller-supplied (and, via `use_skill`, LLM-supplied) segment. Restricting
+/// BOTH segments to `agents::protocol::validate_agent_name`'s existing safe
+/// charset (`[a-z0-9-]+`, 1-64 chars — reused, not re-derived, so the two
+/// concepts of "a safe catalog name" never drift apart) makes a traversal
+/// payload like `foo:../../../../x` or `foo:/etc/passwd` syntactically
+/// impossible to construct: the charset contains no `/` and no `.` at all,
+/// so no join built from a validated segment can ever leave the directory
+/// it was joined onto, regardless of what the discovered catalog happens to
+/// list (closes the residual gap where a plugin's own frontmatter could
+/// declare a spoofed `name:` that would otherwise appear "known").
+/// What: `true` only for EXACTLY two `:`-separated segments, each accepted
+/// by `agents::protocol::validate_agent_name`. Zero or one segment (a plain
+/// name), more than two (multiple colons), or either segment failing the
+/// charset/length check all return `false`.
+/// Test: `tests::is_valid_namespaced_name_accepts_two_safe_segments`,
+/// `tests::is_valid_namespaced_name_rejects_traversal_segment`,
+/// `tests::is_valid_namespaced_name_rejects_absolute_segment`,
+/// `tests::is_valid_namespaced_name_rejects_plain_name`,
+/// `tests::is_valid_namespaced_name_rejects_extra_colon`.
+pub fn is_valid_namespaced_name(name: &str) -> bool {
+    let segments: Vec<&str> = name.splitn(3, ':').collect();
+    match segments.as_slice() {
+        [plugin, local] => {
+            crate::agents::protocol::validate_agent_name(plugin).is_ok()
+                && crate::agents::protocol::validate_agent_name(local).is_ok()
+        }
+        _ => false,
     }
 }
 

--- a/crates/trusty-code/src/plugins/mod_tests.rs
+++ b/crates/trusty-code/src/plugins/mod_tests.rs
@@ -60,6 +60,9 @@ fn discover_plugin_roots_honors_manifest_name_override() {
 /// convention.
 ///
 /// Why: #3539 explicitly locks in "the `agents`/`skills` path overrides".
+/// What: the override targets must actually exist on disk — `safe_plugin_subdir`
+/// (#3547) requires the joined candidate to canonicalize, since a
+/// non-existent path can't be verified as contained within `plugin_dir`.
 /// Test: this test.
 #[test]
 fn discover_plugin_roots_honors_path_overrides() {
@@ -70,6 +73,8 @@ fn discover_plugin_roots_honors_path_overrides() {
         "custom-layout",
         r#"{"name": "custom", "agents": "my-agents", "skills": "my-skills"}"#,
     );
+    std::fs::create_dir_all(plugins_dir.join("custom-layout").join("my-agents")).expect("mkdir");
+    std::fs::create_dir_all(plugins_dir.join("custom-layout").join("my-skills")).expect("mkdir");
 
     let roots = discover_plugin_roots(tmp.path());
     assert_eq!(roots.len(), 1);
@@ -81,6 +86,133 @@ fn discover_plugin_roots_honors_path_overrides() {
         roots[0].skills_dir,
         plugins_dir.join("custom-layout/my-skills")
     );
+}
+
+/// An absolute-path `agents` override in `plugin.json` does NOT escape the
+/// plugin root — it is rejected and falls back to the default `agents`
+/// convention (code-critic PR #3547 review, CRITICAL 1).
+///
+/// Why: `PathBuf::join` replaces the base entirely when the joined
+/// component is absolute — `plugin_dir.join("/etc")` == `/etc` — so an
+/// unvalidated override would let a malicious `plugin.json` point
+/// discovery at an arbitrary host directory (here, a decoy "victim" dir
+/// standing in for something like `~/.ssh`).
+/// What: asserts the resolved `agents_dir` is NOT the absolute victim path,
+/// and IS the plugin-root-relative default instead.
+/// Test: this test.
+#[test]
+fn load_plugin_root_rejects_absolute_agents_override() {
+    crate::test_support::begin_capture();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let victim_dir = tmp.path().join("victim");
+    std::fs::create_dir_all(&victim_dir).expect("mkdir victim");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    let manifest_json = format!(r#"{{"name": "evil", "agents": {victim_dir:?}}}"#);
+    write_plugin_manifest(&plugins_dir, "evil-plugin", &manifest_json);
+
+    let roots = discover_plugin_roots(tmp.path());
+    assert_eq!(roots.len(), 1);
+    assert_ne!(
+        roots[0].agents_dir, victim_dir,
+        "an absolute override must never be honored"
+    );
+    assert_eq!(
+        roots[0].agents_dir,
+        plugins_dir.join("evil-plugin").join("agents"),
+        "must fall back to the default 'agents' convention"
+    );
+
+    let captured = crate::test_support::captured_at_least(tracing::Level::WARN);
+    assert!(
+        captured.iter().any(|m| m.contains("absolute")),
+        "expected a rejection warning, got: {captured:?}"
+    );
+}
+
+/// A `..`-bearing `skills` override in `plugin.json` does NOT escape the
+/// plugin root (code-critic PR #3547 review, CRITICAL 1).
+///
+/// Test: this test.
+#[test]
+fn load_plugin_root_rejects_dotdot_skills_override() {
+    crate::test_support::begin_capture();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_manifest(
+        &plugins_dir,
+        "evil-plugin",
+        r#"{"name": "evil", "skills": "../../../../etc"}"#,
+    );
+
+    let roots = discover_plugin_roots(tmp.path());
+    assert_eq!(roots.len(), 1);
+    assert_eq!(
+        roots[0].skills_dir,
+        plugins_dir.join("evil-plugin").join("skills"),
+        "must fall back to the default 'skills' convention"
+    );
+    assert!(
+        !roots[0].skills_dir.to_string_lossy().contains(".."),
+        "the resolved path must never contain a literal '..' escape"
+    );
+
+    let captured = crate::test_support::captured_at_least(tracing::Level::WARN);
+    assert!(
+        captured.iter().any(|m| m.contains("..")),
+        "expected a rejection warning, got: {captured:?}"
+    );
+}
+
+/// [`is_valid_namespaced_name`] accepts exactly two safe segments.
+///
+/// Test: this test.
+#[test]
+fn is_valid_namespaced_name_accepts_two_safe_segments() {
+    assert!(is_valid_namespaced_name("my-plugin:reviewer"));
+    assert!(is_valid_namespaced_name("a:b"));
+}
+
+/// [`is_valid_namespaced_name`] rejects a local segment containing `..` or
+/// `/` — the exact traversal payload shape (code-critic PR #3547 review,
+/// CRITICAL 2).
+///
+/// Test: this test.
+#[test]
+fn is_valid_namespaced_name_rejects_traversal_segment() {
+    assert!(!is_valid_namespaced_name("foo:../../../../etc/passwd"));
+    assert!(!is_valid_namespaced_name("foo:..veryless"));
+    assert!(!is_valid_namespaced_name("foo:a/b"));
+    assert!(!is_valid_namespaced_name("../../etc:foo"));
+}
+
+/// [`is_valid_namespaced_name`] rejects an absolute-path-shaped segment.
+///
+/// Test: this test.
+#[test]
+fn is_valid_namespaced_name_rejects_absolute_segment() {
+    assert!(!is_valid_namespaced_name("foo:/etc/passwd"));
+}
+
+/// [`is_valid_namespaced_name`] rejects a plain (unnamespaced) name — it is
+/// not this validator's job to accept those, callers fall through to their
+/// existing plain-name path instead.
+///
+/// Test: this test.
+#[test]
+fn is_valid_namespaced_name_rejects_plain_name() {
+    assert!(!is_valid_namespaced_name("engineer"));
+    assert!(!is_valid_namespaced_name(""));
+}
+
+/// [`is_valid_namespaced_name`] rejects more than one colon.
+///
+/// Test: this test.
+#[test]
+fn is_valid_namespaced_name_rejects_extra_colon() {
+    assert!(!is_valid_namespaced_name("foo:bar:baz"));
+    assert!(!is_valid_namespaced_name("foo:bar:baz:qux"));
 }
 
 /// A malformed `plugin.json` degrades to the no-manifest fallback rather

--- a/crates/trusty-code/src/plugins/mod_tests.rs
+++ b/crates/trusty-code/src/plugins/mod_tests.rs
@@ -1,0 +1,169 @@
+use super::*;
+
+fn write_plugin_manifest(plugins_dir: &Path, plugin_dir_name: &str, manifest_json: &str) {
+    let dir = plugins_dir.join(plugin_dir_name).join(".claude-plugin");
+    std::fs::create_dir_all(&dir).expect("mkdir manifest dir");
+    std::fs::write(dir.join("plugin.json"), manifest_json).expect("write manifest");
+}
+
+/// A missing `.claude/plugins/` directory yields an empty list, not an
+/// error — most projects use no plugins.
+///
+/// Why: mirrors `agents::discover_agents_missing_dir_is_empty`'s
+/// graceful-absence contract for the plugin scan root.
+/// Test: this test.
+#[test]
+fn discover_plugin_roots_missing_dir_is_empty() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(discover_plugin_roots(tmp.path()).is_empty());
+}
+
+/// A plugin subdirectory with no manifest falls back to its directory name
+/// and the `agents`/`skills` convention.
+///
+/// Why: pins the "no manifest" path #3539 requires — plugin discovery must
+/// not require a `.claude-plugin/plugin.json`.
+/// What: one bare subdirectory under `.claude/plugins/`, no manifest file;
+/// asserts the resolved name equals the directory name and the agents/skills
+/// dirs follow the convention.
+/// Test: this test.
+#[test]
+fn discover_plugin_roots_falls_back_without_manifest() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    std::fs::create_dir_all(plugins_dir.join("my-plugin")).expect("mkdir");
+
+    let roots = discover_plugin_roots(tmp.path());
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].name, "my-plugin");
+    assert_eq!(roots[0].agents_dir, plugins_dir.join("my-plugin/agents"));
+    assert_eq!(roots[0].skills_dir, plugins_dir.join("my-plugin/skills"));
+}
+
+/// A manifest's `name:` overrides the directory name.
+///
+/// Why: #3539 — "honor its `name`" is the manifest's whole point when the
+/// directory name is not the identity a plugin author wants surfaced.
+/// Test: this test.
+#[test]
+fn discover_plugin_roots_honors_manifest_name_override() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_manifest(&plugins_dir, "on-disk-dir", r#"{"name": "pretty-name"}"#);
+
+    let roots = discover_plugin_roots(tmp.path());
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].name, "pretty-name");
+}
+
+/// A manifest's `agents`/`skills` keys override the default subdirectory
+/// convention.
+///
+/// Why: #3539 explicitly locks in "the `agents`/`skills` path overrides".
+/// Test: this test.
+#[test]
+fn discover_plugin_roots_honors_path_overrides() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_manifest(
+        &plugins_dir,
+        "custom-layout",
+        r#"{"name": "custom", "agents": "my-agents", "skills": "my-skills"}"#,
+    );
+
+    let roots = discover_plugin_roots(tmp.path());
+    assert_eq!(roots.len(), 1);
+    assert_eq!(
+        roots[0].agents_dir,
+        plugins_dir.join("custom-layout/my-agents")
+    );
+    assert_eq!(
+        roots[0].skills_dir,
+        plugins_dir.join("custom-layout/my-skills")
+    );
+}
+
+/// A malformed `plugin.json` degrades to the no-manifest fallback rather
+/// than erroring or panicking.
+///
+/// Why: discovery must never crash the harness over one plugin's bad JSON.
+/// Test: this test.
+#[test]
+fn discover_plugin_roots_malformed_manifest_falls_back() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_manifest(&plugins_dir, "broken", "{not valid json");
+
+    let roots = discover_plugin_roots(tmp.path());
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].name, "broken");
+}
+
+/// Multiple plugins are all discovered, sorted by resolved name.
+///
+/// Test: this test.
+#[test]
+fn discover_plugin_roots_finds_subdirs() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    std::fs::create_dir_all(plugins_dir.join("zeta")).expect("mkdir");
+    std::fs::create_dir_all(plugins_dir.join("alpha")).expect("mkdir");
+
+    let roots = discover_plugin_roots(tmp.path());
+    let names: Vec<&str> = roots.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(names, vec!["alpha", "zeta"], "sorted by resolved name");
+}
+
+/// A manifest declaring a later-phase key (`hooks`, `commands`,
+/// `mcpServers`) is still ingested for agents/skills — the unsupported key
+/// is logged, never a hard failure.
+///
+/// Why: #3539 — "ignore commands/hooks with a debug log if present".
+/// Test: this test.
+#[test]
+fn discover_plugin_roots_warns_on_later_phase_keys() {
+    crate::test_support::begin_capture();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_manifest(
+        &plugins_dir,
+        "full-featured",
+        r#"{"name": "full", "hooks": {"pre": "x"}, "commands": ["y"]}"#,
+    );
+
+    let roots = discover_plugin_roots(tmp.path());
+    assert_eq!(
+        roots.len(),
+        1,
+        "plugin is still discovered despite later-phase keys"
+    );
+    assert_eq!(roots[0].name, "full");
+
+    let captured = crate::test_support::captured_at_least(tracing::Level::DEBUG);
+    let line = captured
+        .iter()
+        .find(|m| m.contains("later-phase") || m.contains("Phase 1 ingests agents+skills only"))
+        .unwrap_or_else(|| panic!("expected a later-phase-keys debug log, got: {captured:?}"));
+    assert!(line.contains("hooks"), "got: {line}");
+    assert!(line.contains("commands"), "got: {line}");
+}
+
+/// [`project_root_two_levels_up`] recovers `<root>` from `<root>/.claude/agents`.
+///
+/// Test: this test.
+#[test]
+fn project_root_two_levels_up_recovers_root() {
+    let root = Path::new("/fake/project");
+    let dir = root.join(".claude").join("agents");
+    assert_eq!(project_root_two_levels_up(&dir), Some(root.to_path_buf()));
+}
+
+/// A path with fewer than two ancestors yields `None` rather than panicking.
+///
+/// Test: this test.
+#[test]
+fn project_root_two_levels_up_none_when_too_shallow() {
+    assert_eq!(project_root_two_levels_up(Path::new("agents")), None);
+    assert_eq!(project_root_two_levels_up(Path::new("/")), None);
+}

--- a/crates/trusty-code/src/plugins/mod_tests.rs
+++ b/crates/trusty-code/src/plugins/mod_tests.rs
@@ -299,3 +299,65 @@ fn project_root_two_levels_up_none_when_too_shallow() {
     assert_eq!(project_root_two_levels_up(Path::new("agents")), None);
     assert_eq!(project_root_two_levels_up(Path::new("/")), None);
 }
+
+/// [`path_is_contained`] accepts a real file directly inside its container.
+///
+/// Test: this test.
+#[test]
+fn path_is_contained_accepts_real_file_within_container() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let file = tmp.path().join("real.md");
+    std::fs::write(&file, "content").expect("write");
+
+    assert!(path_is_contained(&file, tmp.path()));
+}
+
+/// [`path_is_contained`] rejects a symlink whose target resolves outside
+/// the container — the exact CWE-59 shape (code-critic PR #3547 re-review,
+/// CRITICAL 5).
+///
+/// Test: this test.
+#[test]
+#[cfg(unix)]
+fn path_is_contained_rejects_symlink_escaping_container() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let container = tmp.path().join("container");
+    std::fs::create_dir_all(&container).expect("mkdir");
+    let outside = tmp.path().join("outside.txt");
+    std::fs::write(&outside, "secret").expect("write");
+    let leak = container.join("leak.md");
+    std::os::unix::fs::symlink(&outside, &leak).expect("symlink");
+
+    assert!(!path_is_contained(&leak, &container));
+}
+
+/// [`path_is_contained`] rejects a symlink escaping via an intermediate
+/// directory component, not just the final leaf.
+///
+/// Test: this test.
+#[test]
+#[cfg(unix)]
+fn path_is_contained_rejects_symlinked_intermediate_dir() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let container = tmp.path().join("container");
+    std::fs::create_dir_all(&container).expect("mkdir");
+    let outside_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside_dir).expect("mkdir");
+    std::fs::write(outside_dir.join("SKILL.md"), "secret").expect("write");
+    // `container/linked-dir` is a symlinked DIRECTORY pointing outside.
+    std::os::unix::fs::symlink(&outside_dir, container.join("linked-dir")).expect("symlink");
+
+    let leaf = container.join("linked-dir").join("SKILL.md");
+    assert!(!path_is_contained(&leaf, &container));
+}
+
+/// [`path_is_contained`] fails closed (rejects) a leaf that does not exist
+/// / cannot be canonicalized, rather than assuming it's safe.
+///
+/// Test: this test.
+#[test]
+fn path_is_contained_rejects_nonexistent_leaf() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let ghost = tmp.path().join("does-not-exist.md");
+    assert!(!path_is_contained(&ghost, tmp.path()));
+}

--- a/crates/trusty-code/src/plugins/skills.rs
+++ b/crates/trusty-code/src/plugins/skills.rs
@@ -86,25 +86,54 @@ fn discover_one_plugin_skills(root: &PluginRoot) -> Vec<SkillMetadata> {
 ///
 /// Why: `skills::FsSkillResolver::resolve`'s namespaced-name entry point —
 /// the "on invoke" half of progressive disclosure for a plugin skill,
-/// mirroring `skills::load_skill_body`'s lazy-load contract.
-/// What: finds the [`PluginRoot`] whose resolved `name` equals `plugin`;
-/// reads `<skills_dir>/<skill_name>/SKILL.md`; strips the frontmatter fence
-/// via `skills::frontmatter::strip_frontmatter` (the same generic stripper
-/// project/embedded skill bodies use). `None` on any miss (unknown plugin,
-/// unknown skill, unreadable file) — the resolver trait's `Option`-returning
-/// API has no separate error channel, matching `FsSkillResolver::resolve`'s
-/// existing unknown-name handling.
+/// mirroring `skills::load_skill_body`'s lazy-load contract. This is the
+/// LLM-reachable path — `tools::skill::UseSkillTool::execute` forwards the
+/// model's raw `name` argument straight through
+/// `skills::FsSkillResolver::resolve` to here — so `skill_name` is HOSTILE
+/// input (code-critic PR #3547 review, CRITICAL 2).
+/// What: validates `plugin:skill_name` via `plugins::is_valid_namespaced_name`
+/// FIRST, before any path is built — rejects a traversal/unsafe-charset
+/// payload like `skill_name = "../../../../x"` outright (this alone makes
+/// escaping `skills_dir` syntactically impossible, since the accepted
+/// charset contains no `/` or `.`). Then finds the [`PluginRoot`] whose
+/// resolved `name` equals `plugin`; as a second, independent guard,
+/// additionally requires `<plugin>:<skill_name>` to be a name
+/// [`discover_plugin_skills`] actually found on disk this scan — mirroring
+/// `skills::load_skill_body`'s "reject anything not in `known`" contract —
+/// which also closes the residual gap where a plugin's own `SKILL.md`
+/// frontmatter could declare a spoofed `name:` that passed the charset
+/// check but was never a real, scanned skill. Only once both guards pass
+/// does it read `<skills_dir>/<skill_name>/SKILL.md` and strip the
+/// frontmatter fence via `skills::frontmatter::strip_frontmatter` (the same
+/// generic stripper project/embedded skill bodies use). `None` on any miss
+/// (failed validation, unknown plugin, unknown skill, unreadable file) —
+/// the resolver trait's `Option`-returning API has no separate error
+/// channel, matching `FsSkillResolver::resolve`'s existing unknown-name
+/// handling.
 /// Test: `tests::resolve_plugin_skill_body_returns_body`,
 /// `tests::resolve_plugin_skill_body_unknown_plugin_is_none`,
-/// `tests::resolve_plugin_skill_body_unknown_skill_is_none`.
+/// `tests::resolve_plugin_skill_body_unknown_skill_is_none`,
+/// `tests::resolve_plugin_skill_body_rejects_traversal_name`.
 pub fn resolve_plugin_skill_body(
     project_root: &Path,
     plugin: &str,
     skill_name: &str,
 ) -> Option<String> {
+    if !super::is_valid_namespaced_name(&format!("{plugin}:{skill_name}")) {
+        return None;
+    }
     let root = discover_plugin_roots(project_root)
         .into_iter()
         .find(|p| p.name == plugin)?;
+
+    let namespaced = format!("{}:{skill_name}", root.name);
+    if !discover_one_plugin_skills(&root)
+        .iter()
+        .any(|m| m.name == namespaced)
+    {
+        return None;
+    }
+
     let raw = std::fs::read_to_string(root.skills_dir.join(skill_name).join("SKILL.md")).ok()?;
     Some(
         crate::skills::frontmatter::strip_frontmatter(&raw)

--- a/crates/trusty-code/src/plugins/skills.rs
+++ b/crates/trusty-code/src/plugins/skills.rs
@@ -18,7 +18,8 @@
 //! body on demand (used by `skills::FsSkillResolver::resolve`).
 //! Test: `tests::*` — discovery finds and namespaces skills, a skill
 //! directory without `SKILL.md` is skipped, body resolution finds/misses a
-//! namespaced name.
+//! namespaced name, a symlinked `<name>`/`SKILL.md` is rejected at both the
+//! discovery and resolution paths (issue #3547 CRITICAL 5).
 
 use std::path::Path;
 
@@ -53,10 +54,22 @@ pub fn discover_plugin_skills(project_root: &Path) -> Vec<SkillMetadata> {
 ///
 /// Why: factored out of [`discover_plugin_skills`] so the per-plugin scan
 /// (mirroring `skills::load_metadata_from_skill_dir`'s shape) is
-/// independently readable.
+/// independently readable. This is the ONE place a plugin skill's
+/// `SKILL.md` content is read for listing purposes, so it is also the
+/// enforcement point for the leaf-file-identity guard (code-critic PR
+/// #3547 re-review, CRITICAL 5, CWE-59) — see [`super::path_is_contained`].
 /// What: a missing/unreadable `skills_dir` yields an empty `Vec` (not an
-/// error — most plugins ship agents only, or vice versa).
-/// Test: covered via `discover_plugin_skills`'s tests above.
+/// error — most plugins ship agents only, or vice versa). `path.is_dir()`
+/// FOLLOWS symlinks (so a symlinked `<name>` directory is not rejected by
+/// this check alone), but every candidate's full `<name>/SKILL.md` leaf
+/// path is additionally required to canonicalize within `skills_dir`'s own
+/// canonicalization before its content is read — this single check catches
+/// a symlinked `<name>` directory, a symlinked `SKILL.md` leaf file inside
+/// a real `<name>` directory, or both, uniformly (see
+/// [`super::path_is_contained`]'s doc). A rejected candidate is skipped
+/// with a `WARN`, never surfacing the escaped target's content.
+/// Test: covered via `discover_plugin_skills`'s tests above,
+/// `tests::discover_plugin_skills_excludes_symlinked_skill_md`.
 fn discover_one_plugin_skills(root: &PluginRoot) -> Vec<SkillMetadata> {
     let Ok(entries) = std::fs::read_dir(&root.skills_dir) else {
         return Vec::new();
@@ -69,7 +82,18 @@ fn discover_one_plugin_skills(root: &PluginRoot) -> Vec<SkillMetadata> {
                 return None;
             }
             let dirname = path.file_name()?.to_str()?.to_string();
-            let raw = std::fs::read_to_string(path.join("SKILL.md")).ok()?;
+            let skill_md = path.join("SKILL.md");
+            if !super::path_is_contained(&skill_md, &root.skills_dir) {
+                tracing::warn!(
+                    "plugin '{}' skill dir '{dirname}' SKILL.md at {} is a symlink (or resolves \
+                     through one) outside the plugin's skills directory — rejected as a \
+                     potential host-file disclosure (#3547)",
+                    root.name,
+                    skill_md.display()
+                );
+                return None;
+            }
+            let raw = std::fs::read_to_string(&skill_md).ok()?;
             let front = crate::skills::frontmatter::parse_frontmatter(&raw);
             let local_name = front.get("name").cloned().unwrap_or(dirname);
             let description = front.get("description").cloned().unwrap_or_default();
@@ -102,18 +126,26 @@ fn discover_one_plugin_skills(root: &PluginRoot) -> Vec<SkillMetadata> {
 /// `skills::load_skill_body`'s "reject anything not in `known`" contract —
 /// which also closes the residual gap where a plugin's own `SKILL.md`
 /// frontmatter could declare a spoofed `name:` that passed the charset
-/// check but was never a real, scanned skill. Only once both guards pass
-/// does it read `<skills_dir>/<skill_name>/SKILL.md` and strip the
-/// frontmatter fence via `skills::frontmatter::strip_frontmatter` (the same
-/// generic stripper project/embedded skill bodies use). `None` on any miss
-/// (failed validation, unknown plugin, unknown skill, unreadable file) —
-/// the resolver trait's `Option`-returning API has no separate error
-/// channel, matching `FsSkillResolver::resolve`'s existing unknown-name
-/// handling.
+/// check but was never a real, scanned skill. Because
+/// [`discover_one_plugin_skills`] itself now rejects a symlinked
+/// `<name>`/`SKILL.md` (code-critic PR #3547 re-review, CRITICAL 5), a
+/// symlinked skill is never "found on disk" and this membership check
+/// alone already excludes it — a THIRD, independent
+/// [`super::path_is_contained`] check is still applied immediately before
+/// the read below as defense in depth, so the guard holds even if the two
+/// callers of [`discover_one_plugin_skills`] ever drift. Only once all
+/// guards pass does it read `<skills_dir>/<skill_name>/SKILL.md` and strip
+/// the frontmatter fence via `skills::frontmatter::strip_frontmatter` (the
+/// same generic stripper project/embedded skill bodies use). `None` on any
+/// miss (failed validation, unknown plugin, unknown/symlinked skill,
+/// unreadable file) — the resolver trait's `Option`-returning API has no
+/// separate error channel, matching `FsSkillResolver::resolve`'s existing
+/// unknown-name handling.
 /// Test: `tests::resolve_plugin_skill_body_returns_body`,
 /// `tests::resolve_plugin_skill_body_unknown_plugin_is_none`,
 /// `tests::resolve_plugin_skill_body_unknown_skill_is_none`,
-/// `tests::resolve_plugin_skill_body_rejects_traversal_name`.
+/// `tests::resolve_plugin_skill_body_rejects_traversal_name`,
+/// `tests::resolve_plugin_skill_body_rejects_symlinked_file`.
 pub fn resolve_plugin_skill_body(
     project_root: &Path,
     plugin: &str,
@@ -134,7 +166,18 @@ pub fn resolve_plugin_skill_body(
         return None;
     }
 
-    let raw = std::fs::read_to_string(root.skills_dir.join(skill_name).join("SKILL.md")).ok()?;
+    let skill_md = root.skills_dir.join(skill_name).join("SKILL.md");
+    if !super::path_is_contained(&skill_md, &root.skills_dir) {
+        tracing::warn!(
+            "plugin skill '{namespaced}' SKILL.md at {} is a symlink (or resolves through one) \
+             outside the plugin's skills directory — rejected as a potential host-file \
+             disclosure (#3547)",
+            skill_md.display()
+        );
+        return None;
+    }
+
+    let raw = std::fs::read_to_string(&skill_md).ok()?;
     Some(
         crate::skills::frontmatter::strip_frontmatter(&raw)
             .trim()

--- a/crates/trusty-code/src/plugins/skills.rs
+++ b/crates/trusty-code/src/plugins/skills.rs
@@ -1,0 +1,118 @@
+//! Phase-1 plugin SKILL ingestion: discovery, namespacing, and body
+//! resolution (issue #3539).
+//!
+//! Why: a plugin's `skills/<name>/SKILL.md` files are the exact same
+//! progressive-disclosure format `crate::skills` already parses for project
+//! skills — cheap frontmatter (`name`/`description`) at discovery time, the
+//! full body only on demand. This module adds namespacing
+//! (`<plugin>:<name>`) on top; it deliberately does NOT interact with
+//! `crate::skills::discover_skill_metadata`'s bundled/project
+//! whole-catalog-replacement threshold (PR #3465) — plugin skills are an
+//! independent additive tier that is listed and resolved regardless of
+//! which side of that threshold a project's own `.claude/skills/` falls on
+//! (#3539's locked precedence-interaction requirement).
+//! What: [`discover_plugin_skills`] lists every plugin skill's cheap
+//! metadata, namespaced (used by `skills::protocol::skills_list`'s `plugin`
+//! tier and `skills::FsSkillResolver`'s cached catalog).
+//! [`resolve_plugin_skill_body`] lazily loads one namespaced skill's full
+//! body on demand (used by `skills::FsSkillResolver::resolve`).
+//! Test: `tests::*` — discovery finds and namespaces skills, a skill
+//! directory without `SKILL.md` is skipped, body resolution finds/misses a
+//! namespaced name.
+
+use std::path::Path;
+
+use crate::skills::SkillMetadata;
+
+use super::{PluginRoot, discover_plugin_roots};
+
+/// List every plugin skill's cheap metadata across every discovered plugin,
+/// namespaced `<plugin>:<local-name>`.
+///
+/// Why: the additive `plugin` tier `skills::protocol::skills_list` and
+/// `skills::FsSkillResolver`'s cached catalog both need.
+/// What: for each [`PluginRoot`], scans immediate subdirectories of
+/// `skills_dir` for a readable `SKILL.md`; a subdirectory without one is
+/// skipped (mirrors `skills::discover_skill_metadata`'s graceful-skip
+/// convention, never an error). `name`/`description` come from frontmatter,
+/// falling back to the skill's directory name when `name:` is absent.
+/// Sorted by the final namespaced name.
+/// Test: `tests::discover_plugin_skills_namespaces_entries`,
+/// `tests::discover_plugin_skills_skips_dir_without_skill_md`,
+/// `tests::discover_plugin_skills_missing_plugins_dir_is_empty`.
+pub fn discover_plugin_skills(project_root: &Path) -> Vec<SkillMetadata> {
+    let mut out: Vec<SkillMetadata> = discover_plugin_roots(project_root)
+        .iter()
+        .flat_map(discover_one_plugin_skills)
+        .collect();
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+/// Scan a single plugin's `skills_dir` for its `<name>/SKILL.md` skills.
+///
+/// Why: factored out of [`discover_plugin_skills`] so the per-plugin scan
+/// (mirroring `skills::load_metadata_from_skill_dir`'s shape) is
+/// independently readable.
+/// What: a missing/unreadable `skills_dir` yields an empty `Vec` (not an
+/// error — most plugins ship agents only, or vice versa).
+/// Test: covered via `discover_plugin_skills`'s tests above.
+fn discover_one_plugin_skills(root: &PluginRoot) -> Vec<SkillMetadata> {
+    let Ok(entries) = std::fs::read_dir(&root.skills_dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_dir() {
+                return None;
+            }
+            let dirname = path.file_name()?.to_str()?.to_string();
+            let raw = std::fs::read_to_string(path.join("SKILL.md")).ok()?;
+            let front = crate::skills::frontmatter::parse_frontmatter(&raw);
+            let local_name = front.get("name").cloned().unwrap_or(dirname);
+            let description = front.get("description").cloned().unwrap_or_default();
+            Some(SkillMetadata {
+                name: format!("{}:{local_name}", root.name),
+                description,
+            })
+        })
+        .collect()
+}
+
+/// Lazily load one namespaced plugin skill's full body (frontmatter
+/// stripped), or `None` when the plugin or the skill is unknown.
+///
+/// Why: `skills::FsSkillResolver::resolve`'s namespaced-name entry point —
+/// the "on invoke" half of progressive disclosure for a plugin skill,
+/// mirroring `skills::load_skill_body`'s lazy-load contract.
+/// What: finds the [`PluginRoot`] whose resolved `name` equals `plugin`;
+/// reads `<skills_dir>/<skill_name>/SKILL.md`; strips the frontmatter fence
+/// via `skills::frontmatter::strip_frontmatter` (the same generic stripper
+/// project/embedded skill bodies use). `None` on any miss (unknown plugin,
+/// unknown skill, unreadable file) — the resolver trait's `Option`-returning
+/// API has no separate error channel, matching `FsSkillResolver::resolve`'s
+/// existing unknown-name handling.
+/// Test: `tests::resolve_plugin_skill_body_returns_body`,
+/// `tests::resolve_plugin_skill_body_unknown_plugin_is_none`,
+/// `tests::resolve_plugin_skill_body_unknown_skill_is_none`.
+pub fn resolve_plugin_skill_body(
+    project_root: &Path,
+    plugin: &str,
+    skill_name: &str,
+) -> Option<String> {
+    let root = discover_plugin_roots(project_root)
+        .into_iter()
+        .find(|p| p.name == plugin)?;
+    let raw = std::fs::read_to_string(root.skills_dir.join(skill_name).join("SKILL.md")).ok()?;
+    Some(
+        crate::skills::frontmatter::strip_frontmatter(&raw)
+            .trim()
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+#[path = "skills_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/plugins/skills_tests.rs
+++ b/crates/trusty-code/src/plugins/skills_tests.rs
@@ -172,3 +172,76 @@ fn resolve_plugin_skill_body_rejects_traversal_name() {
         "an absolute-path-shaped skill_name must be rejected"
     );
 }
+
+/// `discover_plugin_skills` (the `skills.list` listing path) excludes a
+/// skill whose `SKILL.md` is a symlink escaping the plugin's `skills_dir`
+/// — a real, legitimate skill alongside it is still listed, but the
+/// symlinked one, and the secret content it points at, never appear
+/// (code-critic PR #3547 re-review, CRITICAL 5, CWE-59).
+///
+/// Test: this test.
+#[test]
+#[cfg(unix)]
+fn discover_plugin_skills_excludes_symlinked_skill_md() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_skill(
+        &plugins_dir,
+        "my-plugin",
+        "real-skill",
+        "---\nname: real-skill\n---\n\nBody.\n",
+    );
+
+    let secret_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&secret_dir).expect("mkdir");
+    let secret_path = secret_dir.join("id_rsa");
+    std::fs::write(&secret_path, "SECRET_KEY_MATERIAL").expect("write secret");
+    let leak_skill_dir = plugins_dir.join("my-plugin").join("skills").join("leak");
+    std::fs::create_dir_all(&leak_skill_dir).expect("mkdir leak dir");
+    std::os::unix::fs::symlink(&secret_path, leak_skill_dir.join("SKILL.md"))
+        .expect("create symlink");
+
+    let skills = discover_plugin_skills(tmp.path());
+    let names: Vec<&str> = skills.iter().map(|m| m.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["my-plugin:real-skill"],
+        "the symlinked entry must be excluded; the real skill must still be listed"
+    );
+    assert!(
+        skills
+            .iter()
+            .all(|m| !m.description.contains("SECRET_KEY_MATERIAL")),
+        "the secret content must never appear in any listed skill's metadata"
+    );
+}
+
+/// `resolve_plugin_skill_body` (the `use_skill` resolution path) rejects a
+/// symlinked `SKILL.md`, never surfacing the target file's content
+/// (code-critic PR #3547 re-review, CRITICAL 5, CWE-59).
+///
+/// What: the symlinked skill directory is planted DIRECTLY (bypassing
+/// `discover_plugin_skills`) to prove `resolve_plugin_skill_body`'s own
+/// defense-in-depth containment check fires independently, not merely
+/// because the membership check upstream already filtered it.
+/// Test: this test.
+#[test]
+#[cfg(unix)]
+fn resolve_plugin_skill_body_rejects_symlinked_file() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    let secret_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&secret_dir).expect("mkdir");
+    let secret_path = secret_dir.join("id_rsa");
+    std::fs::write(&secret_path, "SECRET_KEY_MATERIAL").expect("write secret");
+    let leak_skill_dir = plugins_dir.join("my-plugin").join("skills").join("leak");
+    std::fs::create_dir_all(&leak_skill_dir).expect("mkdir leak dir");
+    std::os::unix::fs::symlink(&secret_path, leak_skill_dir.join("SKILL.md"))
+        .expect("create symlink");
+
+    let result = resolve_plugin_skill_body(tmp.path(), "my-plugin", "leak");
+    assert!(
+        result.is_none(),
+        "a symlinked skill must never resolve, got: {result:?}"
+    );
+}

--- a/crates/trusty-code/src/plugins/skills_tests.rs
+++ b/crates/trusty-code/src/plugins/skills_tests.rs
@@ -1,0 +1,133 @@
+use super::*;
+
+fn write_plugin_skill(plugins_dir: &Path, plugin: &str, skill_dir_name: &str, content: &str) {
+    let dir = plugins_dir.join(plugin).join("skills").join(skill_dir_name);
+    std::fs::create_dir_all(&dir).expect("mkdir skill dir");
+    std::fs::write(dir.join("SKILL.md"), content).expect("write skill");
+}
+
+/// Discovery namespaces every plugin skill `<plugin>:<name>` and reads its
+/// cheap frontmatter.
+///
+/// Why: the acceptance criterion for #3539's skill-namespacing decision.
+/// Test: this test.
+#[test]
+fn discover_plugin_skills_namespaces_entries() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_skill(
+        &plugins_dir,
+        "my-plugin",
+        "review-checklist",
+        "---\nname: review-checklist\ndescription: A checklist\n---\n\nFull body.\n",
+    );
+
+    let skills = discover_plugin_skills(tmp.path());
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0].name, "my-plugin:review-checklist");
+    assert_eq!(skills[0].description, "A checklist");
+}
+
+/// A skill directory name is used as a fallback when frontmatter declares
+/// no `name:`.
+///
+/// Test: this test.
+#[test]
+fn discover_plugin_skills_falls_back_to_dirname() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_skill(
+        &plugins_dir,
+        "my-plugin",
+        "no-frontmatter",
+        "# Just a body\n",
+    );
+
+    let skills = discover_plugin_skills(tmp.path());
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0].name, "my-plugin:no-frontmatter");
+}
+
+/// A skill subdirectory without a readable `SKILL.md` is skipped, not an
+/// error.
+///
+/// Test: this test.
+#[test]
+fn discover_plugin_skills_skips_dir_without_skill_md() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    std::fs::create_dir_all(
+        plugins_dir
+            .join("my-plugin")
+            .join("skills")
+            .join("empty-dir"),
+    )
+    .expect("mkdir");
+    write_plugin_skill(
+        &plugins_dir,
+        "my-plugin",
+        "real-skill",
+        "---\nname: real-skill\n---\n\nBody.\n",
+    );
+
+    let skills = discover_plugin_skills(tmp.path());
+    assert_eq!(skills.len(), 1);
+    assert_eq!(skills[0].name, "my-plugin:real-skill");
+}
+
+/// A project with no `.claude/plugins/` directory yields no plugin skills.
+///
+/// Test: this test.
+#[test]
+fn discover_plugin_skills_missing_plugins_dir_is_empty() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(discover_plugin_skills(tmp.path()).is_empty());
+}
+
+/// [`resolve_plugin_skill_body`] returns the body with frontmatter stripped
+/// for a known plugin/skill pair.
+///
+/// Test: this test.
+#[test]
+fn resolve_plugin_skill_body_returns_body() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_skill(
+        &plugins_dir,
+        "my-plugin",
+        "demo-skill",
+        "---\nname: demo-skill\ndescription: Demo\n---\n\n# Demo Skill\nFull instructions.\n",
+    );
+
+    let body = resolve_plugin_skill_body(tmp.path(), "my-plugin", "demo-skill")
+        .expect("must resolve body");
+    assert!(body.contains("# Demo Skill"));
+    assert!(body.contains("Full instructions."));
+    assert!(!body.contains("description: Demo"));
+}
+
+/// An unknown plugin name resolves to `None`.
+///
+/// Test: this test.
+#[test]
+fn resolve_plugin_skill_body_unknown_plugin_is_none() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(resolve_plugin_skill_body(tmp.path(), "no-such-plugin", "demo-skill").is_none());
+}
+
+/// A known plugin but an unknown skill name resolves to `None`.
+///
+/// Test: this test.
+#[test]
+fn resolve_plugin_skill_body_unknown_skill_is_none() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_skill(
+        &plugins_dir,
+        "my-plugin",
+        "demo-skill",
+        "---\nname: demo-skill\n---\n\nBody.\n",
+    );
+
+    assert!(resolve_plugin_skill_body(tmp.path(), "my-plugin", "ghost-skill").is_none());
+}

--- a/crates/trusty-code/src/plugins/skills_tests.rs
+++ b/crates/trusty-code/src/plugins/skills_tests.rs
@@ -131,3 +131,44 @@ fn resolve_plugin_skill_body_unknown_skill_is_none() {
 
     assert!(resolve_plugin_skill_body(tmp.path(), "my-plugin", "ghost-skill").is_none());
 }
+
+/// A traversal payload in `skill_name` — exactly the `use_skill` LLM-input
+/// shape (`tools::skill::UseSkillTool::execute` -> `FsSkillResolver::resolve`
+/// -> here) — is rejected BEFORE any path is built, even when a real file
+/// sits at the escape target outside the plugin's `skills_dir`
+/// (code-critic PR #3547 review, CRITICAL 2).
+///
+/// Why: planting a REAL `SKILL.md` at the traversal target and asserting it
+/// is never read proves the guard fires before the filesystem is touched
+/// with the unsafe path — not merely that the target happens to miss.
+/// Test: this test.
+#[test]
+fn resolve_plugin_skill_body_rejects_traversal_name() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let plugins_dir = tmp.path().join(".claude").join("plugins");
+    write_plugin_skill(
+        &plugins_dir,
+        "my-plugin",
+        "demo-skill",
+        "---\nname: demo-skill\n---\n\nBody.\n",
+    );
+    // A real "secret" SKILL.md at the traversal target — if the guard did
+    // not fire, `skills_dir.join("../../../secret").join("SKILL.md")`
+    // resolves exactly here.
+    let secret_dir = tmp.path().join("secret");
+    std::fs::create_dir_all(&secret_dir).expect("mkdir secret");
+    std::fs::write(
+        secret_dir.join("SKILL.md"),
+        "---\nname: secret\n---\n\nSHOULD NEVER BE READ.\n",
+    )
+    .expect("write secret");
+
+    assert!(
+        resolve_plugin_skill_body(tmp.path(), "my-plugin", "../../../secret").is_none(),
+        "a traversal payload in skill_name must be rejected, not resolved"
+    );
+    assert!(
+        resolve_plugin_skill_body(tmp.path(), "my-plugin", "/etc/passwd").is_none(),
+        "an absolute-path-shaped skill_name must be rejected"
+    );
+}

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -497,21 +497,45 @@ impl AgentRunner for InProcessAgentRunner {
 }
 
 /// Convenience: discover whether an agent config exists for `name` under
-/// `dir`, on disk OR in the embedded default roster (#3046).
+/// `dir`, on disk, in the embedded default roster (#3046), OR as a plugin
+/// agent (issue #3539/#3547).
 ///
 /// Why: Callers (e.g. `tools::delegate::DelegateToAgentTool::execute`'s
 /// pre-flight gate) sometimes need to pre-check an agent name without
-/// constructing a runner; exposing the same disk-then-embedded rule
-/// [`crate::agents::resolve_agent`] uses keeps the two in lockstep — a
+/// constructing a runner; exposing the same disk-then-embedded(-then-plugin)
+/// rule [`crate::agents::resolve_agent`] uses keeps the two in lockstep — a
 /// pre-flight check that only saw disk would reject a real embedded roster
-/// name (e.g. `rust-engineer`) before the runner ever got a chance to
-/// resolve it.
-/// What: Returns `true` iff `<dir>/<name>.md` exists (#2897 Slice D —
-/// `.toml` is no longer a loadable source) OR `name` matches an entry in
-/// `crate::assets::DEFAULT_AGENTS`.
+/// name (e.g. `rust-engineer`) — or, as of #3539, a real plugin agent —
+/// before the runner ever got a chance to resolve it. Before this fix, a
+/// namespaced `<plugin>:<name>` always failed here (neither join matched),
+/// so `delegate_to_agent`'s pre-flight gate rejected every plugin agent as
+/// "unknown" even though `resolve_agent` could resolve it — plugin agents
+/// were listed but never actually dispatchable (code-critic PR #3547
+/// review, HIGH 4).
+/// What: a namespaced `name` (containing `:`) is routed to
+/// `plugins::agents::find_plugin_agent_config` — gated first by
+/// `plugins::is_valid_namespaced_name` (the traversal guard; also
+/// redundantly enforced inside `find_plugin_agent_config` itself, issue
+/// #3547 HIGH 3) and by recovering a project root from `dir` via
+/// `plugins::project_root_two_levels_up`. `true` iff that resolves to
+/// `Some` (found on disk, whether or not it parsed cleanly — mirrors the
+/// plain-name path below, which is also a bare existence check, not a
+/// parseability one). Otherwise, unchanged: `true` iff `<dir>/<name>.md`
+/// exists (#2897 Slice D — `.toml` is no longer a loadable source) OR
+/// `name` matches an entry in `crate::assets::DEFAULT_AGENTS`.
 /// Test: `runner::tests::agent_config_exists_detects_present_and_absent`,
-/// `runner::tests::agent_config_exists_detects_embedded_default`.
+/// `runner::tests::agent_config_exists_detects_embedded_default`,
+/// `runner::tests::agent_config_exists_detects_plugin_agent`,
+/// `runner::tests::agent_config_exists_rejects_plugin_traversal_name`.
 pub fn agent_config_exists(dir: &Path, name: &str) -> bool {
+    if let Some((plugin, local)) = name.split_once(':') {
+        if !crate::plugins::is_valid_namespaced_name(name) {
+            return false;
+        }
+        return crate::plugins::project_root_two_levels_up(dir)
+            .and_then(|root| crate::plugins::agents::find_plugin_agent_config(&root, plugin, local))
+            .is_some();
+    }
     dir.join(format!("{name}.md")).exists()
         || crate::assets::DEFAULT_AGENTS
             .iter()

--- a/crates/trusty-code/src/runner/in_process.rs
+++ b/crates/trusty-code/src/runner/in_process.rs
@@ -518,15 +518,27 @@ impl AgentRunner for InProcessAgentRunner {
 /// redundantly enforced inside `find_plugin_agent_config` itself, issue
 /// #3547 HIGH 3) and by recovering a project root from `dir` via
 /// `plugins::project_root_two_levels_up`. `true` iff that resolves to
-/// `Some` (found on disk, whether or not it parsed cleanly — mirrors the
-/// plain-name path below, which is also a bare existence check, not a
-/// parseability one). Otherwise, unchanged: `true` iff `<dir>/<name>.md`
-/// exists (#2897 Slice D — `.toml` is no longer a loadable source) OR
-/// `name` matches an entry in `crate::assets::DEFAULT_AGENTS`.
+/// `Some(Ok(_))` — a plugin agent must actually load cleanly, NOT merely be
+/// found-but-broken, to pass this gate. This is DELIBERATELY stricter than
+/// the plain-name path below (a bare existence check, not a parseability
+/// one): `find_plugin_agent_config` can return `Some(Err(_))` for a
+/// SECURITY rejection (a symlinked `.md` file escaping `agents_dir` —
+/// issue #3547 CRITICAL 5, CWE-59), and that must fail this pre-flight gate
+/// outright rather than let `delegate_to_agent` proceed to invoke the
+/// runner on a name that can never actually resolve (code-critic PR #3547
+/// re-review — `Some(Err(_))` counting as "exists" let a symlink-rejected
+/// name slip past the pre-flight gate; the real `InProcessAgentRunner`
+/// would still refuse it one layer later via `resolve_agent`, so content
+/// never reached an LLM prompt either way, but the gate's whole purpose is
+/// to fail fast with a clear "unknown agent" error before ever attempting
+/// dispatch). Otherwise, unchanged: `true` iff `<dir>/<name>.md` exists
+/// (#2897 Slice D — `.toml` is no longer a loadable source) OR `name`
+/// matches an entry in `crate::assets::DEFAULT_AGENTS`.
 /// Test: `runner::tests::agent_config_exists_detects_present_and_absent`,
 /// `runner::tests::agent_config_exists_detects_embedded_default`,
 /// `runner::tests::agent_config_exists_detects_plugin_agent`,
-/// `runner::tests::agent_config_exists_rejects_plugin_traversal_name`.
+/// `runner::tests::agent_config_exists_rejects_plugin_traversal_name`,
+/// `runner::tests::agent_config_exists_rejects_symlinked_plugin_agent`.
 pub fn agent_config_exists(dir: &Path, name: &str) -> bool {
     if let Some((plugin, local)) = name.split_once(':') {
         if !crate::plugins::is_valid_namespaced_name(name) {
@@ -534,7 +546,7 @@ pub fn agent_config_exists(dir: &Path, name: &str) -> bool {
         }
         return crate::plugins::project_root_two_levels_up(dir)
             .and_then(|root| crate::plugins::agents::find_plugin_agent_config(&root, plugin, local))
-            .is_some();
+            .is_some_and(|r| r.is_ok());
     }
     dir.join(format!("{name}.md")).exists()
         || crate::assets::DEFAULT_AGENTS

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -328,6 +328,67 @@ fn agent_config_exists_detects_embedded_default() {
     assert!(!super::agent_config_exists(tmp.path(), "totally-bogus"));
 }
 
+/// `agent_config_exists` recognises a namespaced `<plugin>:<name>` plugin
+/// agent, proving the `delegate_to_agent` pre-flight gate actually wires
+/// plugin agents through to dispatch (code-critic PR #3547 review, HIGH 4 —
+/// previously this always returned `false` for any namespaced name, so a
+/// plugin agent was listed in `agents.list` but could never actually be
+/// delegated to).
+///
+/// What: `dir` shaped `<root>/.claude/agents` (required so
+/// `plugins::project_root_two_levels_up` can recover the root) plus a
+/// plugin agent on disk under `<root>/.claude/plugins/my-plugin/agents/`.
+/// Test: this test.
+#[test]
+fn agent_config_exists_detects_plugin_agent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+    let plugin_agents_dir = tmp
+        .path()
+        .join(".claude")
+        .join("plugins")
+        .join("my-plugin")
+        .join("agents");
+    std::fs::create_dir_all(&plugin_agents_dir).expect("mkdir");
+    std::fs::write(
+        plugin_agents_dir.join("reviewer.md"),
+        "---\nname: reviewer\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    assert!(super::agent_config_exists(
+        &agents_dir,
+        "my-plugin:reviewer"
+    ));
+    assert!(!super::agent_config_exists(&agents_dir, "my-plugin:ghost"));
+    assert!(!super::agent_config_exists(
+        &agents_dir,
+        "no-such-plugin:reviewer"
+    ));
+}
+
+/// A traversal payload in a namespaced name is rejected, never treated as
+/// "exists" (code-critic PR #3547 review, HIGH 4's guard must hold even at
+/// this pre-flight layer, not only inside `find_plugin_agent_config`).
+///
+/// Test: this test.
+#[test]
+fn agent_config_exists_rejects_plugin_traversal_name() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+
+    assert!(!super::agent_config_exists(
+        &agents_dir,
+        "my-plugin:../../etc/passwd"
+    ));
+    assert!(!super::agent_config_exists(
+        &agents_dir,
+        "my-plugin:/etc/passwd"
+    ));
+}
+
 /// Dispatching to an embedded, tools-restricted roster agent (`qa` — one of
 /// the four Slice E3 restricted agents) with NO disk config at all still
 /// enforces its `tools.allowed` — the embedded-fallback path in `load_agent`

--- a/crates/trusty-code/src/runner/tests.rs
+++ b/crates/trusty-code/src/runner/tests.rs
@@ -389,6 +389,39 @@ fn agent_config_exists_rejects_plugin_traversal_name() {
     ));
 }
 
+/// A namespaced plugin agent whose `.md` FILE is a symlink escaping the
+/// plugin's `agents/` directory must NOT count as "exists" — even though
+/// the name is validly namespaced and the file literally exists on disk
+/// (code-critic PR #3547 re-review, CRITICAL 5, CWE-59).
+///
+/// Why: `find_plugin_agent_config` returns `Some(Err(_))` for a symlinked
+/// leaf file (found, but rejected) — before this fix, `agent_config_exists`
+/// treated ANY `Some(_)` as "exists", letting a symlink-rejected name slip
+/// past the `delegate_to_agent` pre-flight gate.
+/// Test: this test.
+#[test]
+#[cfg(unix)]
+fn agent_config_exists_rejects_symlinked_plugin_agent() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+    let plugin_agents_dir = tmp
+        .path()
+        .join(".claude")
+        .join("plugins")
+        .join("my-plugin")
+        .join("agents");
+    std::fs::create_dir_all(&plugin_agents_dir).expect("mkdir");
+
+    let secret_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&secret_dir).expect("mkdir");
+    let secret_path = secret_dir.join("id_rsa");
+    std::fs::write(&secret_path, "SECRET_KEY_MATERIAL").expect("write secret");
+    std::os::unix::fs::symlink(&secret_path, plugin_agents_dir.join("leak.md")).expect("symlink");
+
+    assert!(!super::agent_config_exists(&agents_dir, "my-plugin:leak"));
+}
+
 /// Dispatching to an embedded, tools-restricted roster agent (`qa` — one of
 /// the four Slice E3 restricted agents) with NO disk config at all still
 /// enforces its `tools.allowed` — the embedded-fallback path in `load_agent`

--- a/crates/trusty-code/src/skills/mod.rs
+++ b/crates/trusty-code/src/skills/mod.rs
@@ -337,6 +337,16 @@ impl FsSkillResolver {
 }
 
 impl SkillResolver for FsSkillResolver {
+    /// A namespaced `<plugin>:<name>` (the exact shape a plugin skill
+    /// listing surfaces, and — via `tools::skill::UseSkillTool` — the exact
+    /// shape an LLM's raw `use_skill` argument can be) routes to
+    /// `plugins::skills::resolve_plugin_skill_body`, which is itself the
+    /// authoritative traversal guard (validates the namespaced shape and
+    /// discovered-catalog membership before ever building a path — issue
+    /// #3547 CRITICAL 2). This wrapper does not re-validate; it only
+    /// recovers the cached `project_root` (`None` short-circuits to `None`
+    /// rather than falling through to the plain-name path below, since a
+    /// namespaced name is never a valid plain skill name either way).
     fn resolve(&self, name: &str) -> Option<String> {
         if let Some((plugin, skill_name)) = name.split_once(':') {
             return self.project_root.as_deref().and_then(|root| {

--- a/crates/trusty-code/src/skills/mod.rs
+++ b/crates/trusty-code/src/skills/mod.rs
@@ -33,7 +33,11 @@
 //! embedded-fallback threshold, and `FsSkillResolver`'s `SkillResolver` trait
 //! conformance.
 
-mod frontmatter;
+// `pub(crate)`: also reused by `plugins::agents`/`plugins::skills` (#3539)
+// — both are generic frontmatter helpers, not skill-specific, so a plugin
+// agent's unsupported-field detection and a plugin skill's body-stripping
+// share this one parser rather than forking a second copy.
+pub(crate) mod frontmatter;
 pub mod protocol;
 
 use std::path::{Path, PathBuf};
@@ -282,12 +286,24 @@ pub fn format_skill_catalog(skills: &[SkillMetadata]) -> String {
 /// What: Wraps `skills_dir` plus the metadata discovered from it at
 /// construction time. `metadata()`/`list()` return the cached catalog;
 /// `resolve()` calls `load_skill_body` per invocation.
+/// As of #3539 (Phase 1 Claude Code plugin support), also namespaces and
+/// resolves plugin skills (`<plugin>:<name>`) — see `plugins::skills`,
+/// which this struct delegates to additively (never suppressing, never
+/// suppressed by, the project/embedded threshold above).
 /// Test: `fs_skill_resolver_resolves_known_skill`,
 /// `fs_skill_resolver_list_matches_metadata_names`,
-/// `fs_skill_resolver_resolve_unknown_returns_none`.
+/// `fs_skill_resolver_resolve_unknown_returns_none`,
+/// `fs_skill_resolver_resolves_namespaced_plugin_skill`,
+/// `fs_skill_resolver_metadata_includes_plugin_skills_alongside_project_skill`.
 pub struct FsSkillResolver {
     skills_dir: PathBuf,
     metadata: Vec<SkillMetadata>,
+    /// The project root recovered from `skills_dir`
+    /// (`crate::plugins::project_root_two_levels_up`), or `None` when
+    /// `skills_dir` isn't shaped `<root>/.claude/skills` (e.g. a bare
+    /// tempdir in a unit test that doesn't exercise plugins). Cached once at
+    /// construction so `resolve` never re-derives it per call.
+    project_root: Option<PathBuf>,
 }
 
 impl FsSkillResolver {
@@ -296,20 +312,37 @@ impl FsSkillResolver {
     /// Why: Metadata discovery is a directory scan plus frontmatter parsing
     /// only — cheap enough to do once at construction so every later
     /// `metadata()`/`list()` call is a clone of an in-memory `Vec`.
-    /// What: Calls `discover_skill_metadata(&skills_dir)` and stores both.
-    /// Test: `fs_skill_resolver_resolves_known_skill`.
+    /// What: Calls `discover_skill_metadata(&skills_dir)`, then additively
+    /// extends it with `plugins::skills::discover_plugin_skills` when a
+    /// project root can be recovered from `skills_dir` (#3539) — plugin
+    /// skills are independent of the project/embedded threshold
+    /// `discover_skill_metadata` applies, so they are appended regardless
+    /// of whether that call returned the project's own catalog or the
+    /// embedded fallback.
+    /// Test: `fs_skill_resolver_resolves_known_skill`,
+    /// `fs_skill_resolver_metadata_includes_plugin_skills_alongside_project_skill`.
     pub fn new(skills_dir: impl Into<PathBuf>) -> Self {
         let skills_dir = skills_dir.into();
-        let metadata = discover_skill_metadata(&skills_dir);
+        let mut metadata = discover_skill_metadata(&skills_dir);
+        let project_root = crate::plugins::project_root_two_levels_up(&skills_dir);
+        if let Some(root) = &project_root {
+            metadata.extend(crate::plugins::skills::discover_plugin_skills(root));
+        }
         Self {
             skills_dir,
             metadata,
+            project_root,
         }
     }
 }
 
 impl SkillResolver for FsSkillResolver {
     fn resolve(&self, name: &str) -> Option<String> {
+        if let Some((plugin, skill_name)) = name.split_once(':') {
+            return self.project_root.as_deref().and_then(|root| {
+                crate::plugins::skills::resolve_plugin_skill_body(root, plugin, skill_name)
+            });
+        }
         load_skill_body(&self.skills_dir, name, &self.metadata).ok()
     }
 
@@ -601,5 +634,76 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let resolver = FsSkillResolver::new(tmp.path());
         assert!(resolver.resolve("ghost").is_none());
+    }
+
+    /// `FsSkillResolver::resolve` routes a namespaced `<plugin>:<name>` to
+    /// the plugin's own `SKILL.md` (issue #3539).
+    ///
+    /// Why: this is the acceptance criterion for the resolution half of
+    /// #3539's skill-namespacing decision — a namespaced skill must
+    /// actually load its body via `use_skill`, not just appear in a catalog
+    /// listing.
+    /// Test: this test.
+    #[test]
+    fn fs_skill_resolver_resolves_namespaced_plugin_skill() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let skills_dir = tmp.path().join(".claude").join("skills");
+        std::fs::create_dir_all(&skills_dir).expect("mkdir");
+        write_skill(
+            &tmp.path()
+                .join(".claude")
+                .join("plugins")
+                .join("my-plugin")
+                .join("skills"),
+            "demo-skill",
+            "---\nname: demo-skill\n---\n",
+            "Plugin skill body.\n",
+        );
+
+        let resolver = FsSkillResolver::new(&skills_dir);
+        let body = resolver
+            .resolve("my-plugin:demo-skill")
+            .expect("resolve namespaced plugin skill");
+        assert!(body.contains("Plugin skill body."));
+    }
+
+    /// `FsSkillResolver`'s cached metadata includes plugin skills ADDITIVELY
+    /// alongside a project's own custom skill catalog — the
+    /// project-vs-bundled whole-catalog-replacement threshold (PR #3465)
+    /// neither suppresses nor is suppressed by the plugin tier (#3539's
+    /// locked precedence-interaction requirement).
+    ///
+    /// Test: this test.
+    #[test]
+    fn fs_skill_resolver_metadata_includes_plugin_skills_alongside_project_skill() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let skills_dir = tmp.path().join(".claude").join("skills");
+        write_skill(
+            &skills_dir,
+            "project-only-skill",
+            "---\nname: project-only-skill\n---\n",
+            "body\n",
+        );
+        write_skill(
+            &tmp.path()
+                .join(".claude")
+                .join("plugins")
+                .join("my-plugin")
+                .join("skills"),
+            "plugin-skill",
+            "---\nname: plugin-skill\n---\n",
+            "body\n",
+        );
+
+        let resolver = FsSkillResolver::new(&skills_dir);
+        let names = resolver.list();
+        assert!(
+            names.contains(&"project-only-skill".to_string()),
+            "the project's own custom skill must still be listed, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"my-plugin:plugin-skill".to_string()),
+            "the namespaced plugin skill must be listed too, got: {names:?}"
+        );
     }
 }

--- a/crates/trusty-code/src/skills/protocol.rs
+++ b/crates/trusty-code/src/skills/protocol.rs
@@ -153,9 +153,22 @@ fn entry_json(m: &SkillMetadata, tier: &str) -> Value {
 /// at all. Otherwise (`state.dir` is `None`, i.e. projectless, OR the
 /// project's skills dir is missing/empty) the response is the full bundled
 /// catalog (`tier: "bundled"`). Sorted by name either way.
+///
+/// A FOURTH tier, `"plugin"`, is layered on top when `state.dir` is `Some`
+/// and a project root can be recovered from it (issue #3539 — Phase 1
+/// Claude Code plugin support): every skill discovered under
+/// `<project_root>/.claude/plugins/*/skills/` is added, namespaced
+/// `<plugin>:<name>` by `plugins::skills::discover_plugin_skills`. This
+/// layer is DELIBERATELY INDEPENDENT of the bundled-vs-project threshold
+/// above — it is added identically whether the response above was the
+/// bundled catalog or the project's own disk skills, so a project with one
+/// custom skill AND a plugin still sees both its custom skill and every
+/// plugin skill (#3539's locked precedence-interaction requirement; see
+/// `tests::list_plugin_skills_are_additive_alongside_project_custom_skill`).
 /// Test: `tests::list_returns_bundled_when_projectless`,
 /// `tests::list_returns_bundled_when_disk_empty`,
-/// `tests::list_returns_disk_only_when_disk_non_empty_no_bundled_entries`.
+/// `tests::list_returns_disk_only_when_disk_non_empty_no_bundled_entries`,
+/// `tests::list_plugin_skills_are_additive_alongside_project_custom_skill`.
 async fn skills_list(
     state: &SkillsCatalogState,
     _params: Value,
@@ -177,6 +190,14 @@ async fn skills_list(
             .map(|m| (m.name.clone(), entry_json(m, "project")))
             .collect()
     };
+
+    if let Some(dir) = &state.dir
+        && let Some(project_root) = crate::plugins::project_root_two_levels_up(dir)
+    {
+        for m in crate::plugins::skills::discover_plugin_skills(&project_root) {
+            entries.push((m.name.clone(), entry_json(&m, "plugin")));
+        }
+    }
 
     entries.sort_by(|a, b| a.0.cmp(&b.0));
     let skills: Vec<Value> = entries.into_iter().map(|(_, v)| v).collect();
@@ -535,5 +556,66 @@ mod tests {
         let resp = router.dispatch(req, &ctx()).await;
         assert!(resp.result.is_some(), "skills.list must be wired");
         assert!(resp.result.unwrap()["skills"].is_array());
+    }
+
+    /// `skills.list`'s `plugin` tier is independent of the bundled-vs-project
+    /// whole-catalog-replacement threshold (PR #3465): a project with ONE
+    /// custom skill (which alone would suppress the bundled catalog, see
+    /// `list_returns_disk_only_when_disk_non_empty_no_bundled_entries`)
+    /// PLUS a plugin still shows both the project's custom skill and every
+    /// namespaced plugin skill (issue #3539's locked precedence-interaction
+    /// requirement).
+    ///
+    /// Why: this is the exact test #3539 calls for — proof that neither
+    /// side of the interaction suppresses the other.
+    /// Test: this test.
+    #[tokio::test]
+    async fn list_plugin_skills_are_additive_alongside_project_custom_skill() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let skills_dir = tmp.path().join(".claude").join("skills");
+        let custom_dir = skills_dir.join("my-custom-skill");
+        std::fs::create_dir_all(&custom_dir).expect("mkdir");
+        std::fs::write(
+            custom_dir.join("SKILL.md"),
+            "---\nname: my-custom-skill\ndescription: Custom\n---\n\nBody.\n",
+        )
+        .expect("write");
+
+        let plugin_skill_dir = tmp
+            .path()
+            .join(".claude")
+            .join("plugins")
+            .join("my-plugin")
+            .join("skills")
+            .join("plugin-skill");
+        std::fs::create_dir_all(&plugin_skill_dir).expect("mkdir");
+        std::fs::write(
+            plugin_skill_dir.join("SKILL.md"),
+            "---\nname: plugin-skill\ndescription: From a plugin\n---\n\nBody.\n",
+        )
+        .expect("write");
+
+        let s = SkillsCatalogState {
+            dir: Some(skills_dir),
+        };
+        let result = skills_list(&s, Value::Null, ctx()).await.expect("list");
+        let skills = result["skills"].as_array().expect("array");
+
+        let project_entry = skills
+            .iter()
+            .find(|sk| sk["name"] == "my-custom-skill")
+            .expect("the project's own custom skill must still be listed");
+        assert_eq!(project_entry["tier"], "project");
+
+        let plugin_entry = skills
+            .iter()
+            .find(|sk| sk["name"] == "my-plugin:plugin-skill")
+            .expect("the namespaced plugin skill must be listed too");
+        assert_eq!(plugin_entry["tier"], "plugin");
+
+        assert!(
+            skills.iter().all(|sk| sk["tier"] != "bundled"),
+            "the bundled catalog must still be entirely absent (unrelated to the plugin tier)"
+        );
     }
 }

--- a/crates/trusty-code/src/tools/delegate.rs
+++ b/crates/trusty-code/src/tools/delegate.rs
@@ -327,14 +327,22 @@ impl ToolExecutor for DelegateToAgentTool {
         // joined into a filesystem path. Reject any name that is not strictly
         // [a-zA-Z0-9_-] before the path join so a crafted value like
         // "../../etc/passwd" cannot escape the agents config directory.
-        if agent_name.is_empty()
-            || !agent_name
+        // A namespaced `<plugin>:<name>` plugin agent dispatch name (#3539)
+        // is checked FIRST via `plugins::is_valid_namespaced_name` — exactly
+        // two `[a-z0-9-]+`-charset segments, which is itself the traversal
+        // guard for a plugin agent's path (issue #3547 HIGH 4): previously
+        // ANY name containing `:` was rejected here, so a plugin agent could
+        // never reach the runner even though `agents::resolve_agent` already
+        // resolved it.
+        let is_valid_plain_name = !agent_name.is_empty()
+            && agent_name
                 .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        {
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+        if !is_valid_plain_name && !crate::plugins::is_valid_namespaced_name(agent_name) {
             return ToolResult::err(format!(
-                "Invalid agent name '{agent_name}': \
-                 agent names must be non-empty and contain only [a-zA-Z0-9_-]"
+                "Invalid agent name '{agent_name}': agent names must be non-empty and contain \
+                 only [a-zA-Z0-9_-], or be a namespaced <plugin>:<name> where both segments \
+                 are [a-z0-9-]+ (<= 64 chars)"
             ));
         }
 

--- a/crates/trusty-code/src/tools/delegate_tests.rs
+++ b/crates/trusty-code/src/tools/delegate_tests.rs
@@ -106,6 +106,82 @@ async fn known_agent_reaches_runner() {
     assert_eq!(invoked[0].0, "engineer");
 }
 
+/// A valid namespaced `<plugin>:<name>` agent name reaches the runner —
+/// proves the full pre-flight-gate-to-runner path actually dispatches a
+/// plugin agent, not merely that `agents::resolve_agent` CAN (code-critic
+/// PR #3547 review, HIGH 4). Before this fix, the pre-flight char-class
+/// guard rejected any `agent_name` containing `:` outright, so a plugin
+/// agent was listed in `agents.list` but could never be delegated to.
+///
+/// What: `config_dir` shaped `<root>/.claude/agents` (required so
+/// `plugins::project_root_two_levels_up` can recover the project root) with
+/// a plugin agent on disk under `<root>/.claude/plugins/my-plugin/agents/`.
+/// Test: this test.
+#[tokio::test]
+async fn namespaced_plugin_agent_reaches_runner() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+    let plugin_agents_dir = tmp
+        .path()
+        .join(".claude")
+        .join("plugins")
+        .join("my-plugin")
+        .join("agents");
+    std::fs::create_dir_all(&plugin_agents_dir).expect("mkdir");
+    std::fs::write(
+        plugin_agents_dir.join("reviewer.md"),
+        "---\nname: reviewer\n---\n\nBody.\n",
+    )
+    .expect("write");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone()).with_config_dir(agents_dir);
+
+    let result = tool
+        .execute(json!({"agent_name": "my-plugin:reviewer", "task": "review this"}))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "a valid namespaced plugin agent should succeed: {}",
+        result.content()
+    );
+    let invoked = runner.invoked.lock().expect("lock");
+    assert_eq!(invoked.len(), 1, "runner should be called exactly once");
+    assert_eq!(invoked[0].0, "my-plugin:reviewer");
+}
+
+/// A traversal payload disguised as a namespaced agent name is rejected
+/// BEFORE the runner is ever invoked (code-critic PR #3547 review, HIGH 4 —
+/// accepting the `<plugin>:<name>` shape must not reopen the traversal
+/// guard immediately above it).
+///
+/// Test: this test.
+#[tokio::test]
+async fn namespaced_traversal_agent_name_is_rejected_before_runner() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone()).with_config_dir(agents_dir);
+
+    let result = tool
+        .execute(json!({"agent_name": "my-plugin:../../etc/passwd", "task": "x"}))
+        .await;
+
+    assert!(result.is_error(), "traversal payload must be rejected");
+    assert!(
+        runner.invoked.lock().expect("lock").is_empty(),
+        "the runner must never be invoked for a rejected name"
+    );
+}
+
 /// Without `with_config_dir`, validation is skipped — the runner is invoked.
 ///
 /// Why: Preserves backward compatibility with callers that don't need

--- a/crates/trusty-code/src/tools/delegate_tests.rs
+++ b/crates/trusty-code/src/tools/delegate_tests.rs
@@ -182,6 +182,60 @@ async fn namespaced_traversal_agent_name_is_rejected_before_runner() {
     );
 }
 
+/// `delegate_to_agent my-plugin:leak` — a validly-namespaced, validly-pathed
+/// name whose FILE is a symlink escaping the plugin's `agents/` directory —
+/// is rejected at the pre-flight gate, and the runner is never invoked
+/// (code-critic PR #3547 re-review, CRITICAL 5, CWE-59).
+///
+/// Why: this is the exact end-to-end shape the re-review's PoC targeted —
+/// `is_valid_namespaced_name` and the directory guard both pass for
+/// `my-plugin:leak` (the name and the directory are both fine); only the
+/// LEAF FILE identity is wrong. Proves `runner::agent_config_exists`'s
+/// `find_plugin_agent_config` call (which now enforces
+/// `plugins::path_is_contained`) actually blocks it before `execute` ever
+/// reaches the runner.
+/// Test: this test.
+#[tokio::test]
+#[cfg(unix)]
+async fn namespaced_symlinked_agent_leak_is_rejected_before_runner() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let agents_dir = tmp.path().join(".claude").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("mkdir");
+    let plugin_agents_dir = tmp
+        .path()
+        .join(".claude")
+        .join("plugins")
+        .join("my-plugin")
+        .join("agents");
+    std::fs::create_dir_all(&plugin_agents_dir).expect("mkdir");
+
+    let secret_dir = tmp.path().join("outside");
+    std::fs::create_dir_all(&secret_dir).expect("mkdir");
+    let secret_path = secret_dir.join("id_rsa");
+    std::fs::write(&secret_path, "SECRET_KEY_MATERIAL").expect("write secret");
+    std::os::unix::fs::symlink(&secret_path, plugin_agents_dir.join("leak.md")).expect("symlink");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone()).with_config_dir(agents_dir);
+
+    let result = tool
+        .execute(json!({"agent_name": "my-plugin:leak", "task": "x"}))
+        .await;
+
+    assert!(result.is_error(), "symlinked plugin agent must be rejected");
+    assert!(
+        !result.content().contains("SECRET_KEY_MATERIAL"),
+        "the secret content must never appear in the tool result, got: {}",
+        result.content()
+    );
+    assert!(
+        runner.invoked.lock().expect("lock").is_empty(),
+        "the runner must never be invoked for a rejected symlinked agent"
+    );
+}
+
 /// Without `with_config_dir`, validation is skipped — the runner is invoked.
 ///
 /// Why: Preserves backward compatibility with callers that don't need

--- a/crates/trusty-code/src/tools/skill.rs
+++ b/crates/trusty-code/src/tools/skill.rs
@@ -243,6 +243,55 @@ mod tests {
         }
     }
 
+    /// `use_skill` with `name: "my-plugin:leak"` — a validly-namespaced,
+    /// validly-pathed name whose `SKILL.md` is a symlink escaping the
+    /// plugin's `skills/` directory — is rejected end-to-end through the
+    /// REAL `skills::FsSkillResolver`, and the secret content it points at
+    /// never reaches the tool result (code-critic PR #3547 re-review,
+    /// CRITICAL 5, CWE-59).
+    ///
+    /// Why: `is_valid_namespaced_name` and the directory guard both pass
+    /// for `my-plugin:leak` — only the LEAF FILE identity is wrong. This
+    /// proves `plugins::skills::resolve_plugin_skill_body`'s containment
+    /// check actually fires on the exact production path `use_skill`
+    /// drives.
+    /// Test: this test.
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn use_skill_rejects_symlinked_plugin_skill_leak() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let skills_dir = tmp.path().join(".claude").join("skills");
+        std::fs::create_dir_all(&skills_dir).expect("mkdir skills");
+
+        let leak_skill_dir = tmp
+            .path()
+            .join(".claude")
+            .join("plugins")
+            .join("my-plugin")
+            .join("skills")
+            .join("leak");
+        std::fs::create_dir_all(&leak_skill_dir).expect("mkdir leak dir");
+
+        let secret_dir = tmp.path().join("outside");
+        std::fs::create_dir_all(&secret_dir).expect("mkdir");
+        let secret_path = secret_dir.join("id_rsa");
+        std::fs::write(&secret_path, "SECRET_KEY_MATERIAL").expect("write secret");
+        std::os::unix::fs::symlink(&secret_path, leak_skill_dir.join("SKILL.md")).expect("symlink");
+
+        let resolver: Arc<dyn SkillResolver> =
+            Arc::new(crate::skills::FsSkillResolver::new(skills_dir));
+        let tool = UseSkillTool::new(resolver);
+
+        let result = tool.execute(json!({"name": "my-plugin:leak"})).await;
+
+        assert!(result.is_error(), "symlinked plugin skill must be rejected");
+        assert!(
+            !result.content().contains("SECRET_KEY_MATERIAL"),
+            "the secret content must never appear in the tool result, got: {}",
+            result.content()
+        );
+    }
+
     /// `name()` and the schema's `function.name` both match
     /// `USE_SKILL_TOOL_NAME` — no drift between the constant and the wire
     /// name (#2070 depends on this identifying skill outputs for pinning).

--- a/crates/trusty-code/src/tools/skill.rs
+++ b/crates/trusty-code/src/tools/skill.rs
@@ -183,6 +183,66 @@ mod tests {
         assert!(result.content().contains("missing required argument"));
     }
 
+    /// `use_skill` rejects a path-traversal payload in a namespaced
+    /// `<plugin>:<name>` argument end-to-end — through the REAL
+    /// `skills::FsSkillResolver` (not the in-memory `StubResolver` the
+    /// other tests here use), which is what actually backs this tool in
+    /// production (code-critic PR #3547 review, CRITICAL 2).
+    ///
+    /// Why: `UseSkillTool::execute` forwards the LLM's raw `name` argument
+    /// straight to `resolver.resolve()` with no validation of its own — the
+    /// guard must live in the resolver, and this test proves it actually
+    /// does, using the exact production wiring. A real "secret" file sits
+    /// at the traversal target outside the plugin's `skills_dir`; if the
+    /// guard did not fire, both payloads would resolve to it.
+    /// What: a tempdir shaped `<root>/.claude/skills` (empty) +
+    /// `<root>/.claude/plugins/my-plugin/skills/demo-skill/SKILL.md`;
+    /// `name: "my-plugin:../../secret"` and `name: "my-plugin:.."` both
+    /// error, and the returned error never contains the secret's content.
+    /// Test: this test.
+    #[tokio::test]
+    async fn use_skill_rejects_plugin_traversal_end_to_end() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let skills_dir = tmp.path().join(".claude").join("skills");
+        std::fs::create_dir_all(&skills_dir).expect("mkdir skills");
+
+        let plugin_skills_dir = tmp
+            .path()
+            .join(".claude")
+            .join("plugins")
+            .join("my-plugin")
+            .join("skills");
+        std::fs::create_dir_all(plugin_skills_dir.join("demo-skill")).expect("mkdir");
+        std::fs::write(
+            plugin_skills_dir.join("demo-skill").join("SKILL.md"),
+            "---\nname: demo-skill\n---\n\nDemo body.\n",
+        )
+        .expect("write demo skill");
+
+        // The traversal target, one level above `.claude/plugins/my-plugin/skills/`.
+        let secret_dir = tmp.path().join(".claude").join("plugins").join("secret");
+        std::fs::create_dir_all(&secret_dir).expect("mkdir secret");
+        std::fs::write(
+            secret_dir.join("SKILL.md"),
+            "---\nname: secret\n---\n\nSHOULD NEVER BE READ.\n",
+        )
+        .expect("write secret");
+
+        let resolver: Arc<dyn SkillResolver> =
+            Arc::new(crate::skills::FsSkillResolver::new(skills_dir));
+        let tool = UseSkillTool::new(resolver);
+
+        for payload in ["my-plugin:../secret", "my-plugin:.."] {
+            let result = tool.execute(json!({"name": payload})).await;
+            assert!(result.is_error(), "payload {payload:?} must be rejected");
+            assert!(
+                !result.content().contains("SHOULD NEVER BE READ"),
+                "payload {payload:?} must never read the secret file, got: {}",
+                result.content()
+            );
+        }
+    }
+
     /// `name()` and the schema's `function.name` both match
     /// `USE_SKILL_TOOL_NAME` — no drift between the constant and the wire
     /// name (#2070 depends on this identifying skill outputs for pinning).

--- a/docs/specs/DOC-51-tcode-plugin-support-phase1.md
+++ b/docs/specs/DOC-51-tcode-plugin-support-phase1.md
@@ -177,7 +177,35 @@ trust boundary (code-critic review on PR #3547):
   dispatchable. All three now check `plugins::is_valid_namespaced_name`
   first (falling through to their original plain-name charset check when it
   doesn't match), which both ENABLES dispatch and IS the traversal guard for
-  each of those three call sites.
+  each of those three call sites. `runner::agent_config_exists`'s namespaced
+  branch additionally requires the plugin agent to have RESOLVED CLEANLY
+  (`Some(Ok(_))`, not merely `Some(_)`) to count as "exists" — a plugin
+  agent found-but-rejected (e.g. by the leaf-file-identity guard directly
+  below) must fail the pre-flight gate outright, not slip through to the
+  runner.
+- **Leaf-file identity (CRITICAL, CWE-59, re-review finding).** The two
+  guards above validate the plugin's DIRECTORY and the dispatch NAME — they
+  say nothing about what the resulting `<agents_dir>/<name>.md` or
+  `<skills_dir>/<name>/SKILL.md` leaf path actually points AT on disk.
+  `std::fs::read_to_string`, `Path::is_dir`, and `Path::is_file` all FOLLOW
+  symlinks, so a plugin could ship `agents/leak.md` (or make `skills/<name>`
+  itself, or the `SKILL.md` inside it, a symlink) pointing at an arbitrary
+  host file such as `~/.ssh/id_rsa`; discovery would read the TARGET's
+  content as that agent's system prompt / skill body, reaching an LLM
+  prompt verbatim once the (validly namespaced, validly directoried) name
+  is dispatched. `plugins::path_is_contained` closes this: every point a
+  discovered `.md`/`SKILL.md` file's content is actually read
+  (`plugins::agents::load_plugin_agent`,
+  `plugins::skills::discover_one_plugin_skills`,
+  `plugins::skills::resolve_plugin_skill_body`) canonicalizes the full leaf
+  path and requires it stay contained within the already-validated
+  `agents_dir`/`skills_dir`. Because `canonicalize` resolves EVERY symlink
+  in the path, not merely the final component, this ONE check per call site
+  catches a symlinked leaf file, a symlinked intermediate directory (e.g.
+  `skills/<name>` itself), or both, uniformly — applied at BOTH the
+  discovery/listing path and the resolve-body/dispatch path for both agents
+  and skills, so a symlink is never read as content whether it is merely
+  listed or actually invoked.
 
 ## 3. Non-Goals (Explicitly Out of Scope, Phase 1)
 
@@ -206,3 +234,4 @@ trust boundary (code-critic review on PR #3547):
 | Ignore commands/hooks/MCP with a debug log | `plugins::load_plugin_root` | Implemented |
 | Reject `plugin.json` `agents`/`skills` overrides that escape `plugin_dir` (§2.5) | `plugins::safe_plugin_subdir` | Implemented |
 | Reject a traversal/unsafe-charset namespaced dispatch name before any path is built (§2.5) | `plugins::is_valid_namespaced_name` | Implemented |
+| Reject a discovered `.md`/`SKILL.md` leaf file (or an intermediate skill directory) that is a symlink escaping `agents_dir`/`skills_dir`, at both the listing and resolve-body paths (§2.5) | `plugins::path_is_contained`, `plugins::agents::load_plugin_agent`, `plugins::skills::discover_one_plugin_skills`, `plugins::skills::resolve_plugin_skill_body` | Implemented |

--- a/docs/specs/DOC-51-tcode-plugin-support-phase1.md
+++ b/docs/specs/DOC-51-tcode-plugin-support-phase1.md
@@ -12,8 +12,8 @@ spec_refs:
 **Owner:** Engineering (trusty-code)
 **Last-updated:** 2026-07-20
 **Spec ID:** `SPEC-TCPLUGIN-01~draft` (DOC-51)
-**Linked issues:** [#3539](https://github.com/bobmatnyc/trusty-tools/issues/3539) (Phase 1 scope decision); [#3542](https://github.com/bobmatnyc/trusty-tools/issues/3542) (base-agent listing filter, consumed unchanged); [#3465](https://github.com/bobmatnyc/trusty-tools/pull/3465) (skills whole-catalog-replacement threshold, consumed unchanged)
-**Cross-ref:** `crates/trusty-code/src/plugins/{mod,agents,skills}.rs` (this spec's implementation); `crates/trusty-code/src/agents/{mod,md_loader,protocol}.rs` (agent discovery/loading/catalog, reused not forked); `crates/trusty-code/src/skills/{mod,protocol}.rs` (skill discovery/catalog, reused not forked)
+**Linked issues:** [#3539](https://github.com/bobmatnyc/trusty-tools/issues/3539) (Phase 1 scope decision); [#3542](https://github.com/bobmatnyc/trusty-tools/issues/3542) (base-agent listing filter, consumed unchanged); [#3465](https://github.com/bobmatnyc/trusty-tools/pull/3465) (skills whole-catalog-replacement threshold, consumed unchanged); [PR #3547 code-critic review](https://github.com/bobmatnyc/trusty-tools/pull/3547) (hostile-plugin-input hardening + dispatch wiring, §2.5)
+**Cross-ref:** `crates/trusty-code/src/plugins/{mod,agents,skills}.rs` (this spec's implementation, incl. `is_valid_namespaced_name`/`safe_plugin_subdir`); `crates/trusty-code/src/agents/{mod,md_loader,protocol}.rs` (agent discovery/loading/catalog, reused not forked); `crates/trusty-code/src/skills/{mod,protocol}.rs` (skill discovery/catalog, reused not forked); `crates/trusty-code/src/tools/{delegate,skill}.rs`, `crates/trusty-code/src/runner/in_process.rs`, `crates/trusty-code/src/main.rs` (namespaced-dispatch validation gates, §2.5)
 
 > **Scope note.** This is a **behavior contract** for Phase 1 of Claude Code
 > plugin support: ingesting a plugin's `agents/` and `skills/` from a **local
@@ -122,6 +122,63 @@ it already holds — `<root>/.claude/agents` (agents catalog state,
 Projectless (no bound project) daemons see no plugin tier anywhere: there is
 no `.claude/plugins/` to scan without a project root.
 
+**Dispatch is wired end-to-end**, not merely resolvable at the
+`agents::resolve_agent` layer: `tools::delegate::DelegateToAgentTool::execute`
+(the PM's `delegate_to_agent` tool), the CLI's `tcode run-task` argument
+validation, and `runner::agent_config_exists` (the pre-flight existence
+gate both of those call before ever reaching the runner) all accept the
+`<plugin>:<name>` shape — see §2.5. A namespaced plugin agent is therefore
+genuinely delegatable by the PM, not just listed in `agents.list`.
+
+### 2.5 Security: plugin content is hostile input {#SPEC-TCPLUGIN-01~draft}
+
+Everything under `.claude/plugins/` — `plugin.json`, directory names, and
+frontmatter content — is THIRD-PARTY input, unlike a project's own
+`.claude/agents|skills/` (first-party, authored by the project owner). Two
+path-join sites and the dispatch-validation gates were hardened against this
+trust boundary (code-critic review on PR #3547):
+
+- **`plugin.json` `agents`/`skills` overrides (CRITICAL).**
+  `plugins::load_plugin_root` previously joined a manifest's `agents`/
+  `skills` string directly onto `plugin_dir` — `PathBuf::join` REPLACES the
+  base entirely for an absolute component (`plugin_dir.join("/etc")` ==
+  `/etc`), and a relative `../../..` override escapes upward even when not
+  absolute. `plugins::safe_plugin_subdir` now rejects an override that is
+  absolute or contains a `..` component outright, and additionally requires
+  the joined candidate to canonicalize to a path contained within
+  `plugin_dir`'s own canonicalization (also catching a symlink planted
+  inside `plugin_dir` that resolves outside it). Any rejection logs one
+  `WARN` and falls back to the un-overridden `agents`/`skills` convention —
+  it never returns the untrusted path.
+- **Namespaced dispatch names (CRITICAL/HIGH).** A caller-supplied
+  `<plugin>:<local>` name — reachable from an LLM via the `use_skill` and
+  `delegate_to_agent` tool arguments — is joined onto a plugin's
+  `agents_dir`/`skills_dir` to build a filesystem path
+  (`plugins::agents::find_plugin_agent_config`,
+  `plugins::skills::resolve_plugin_skill_body`). `plugins::is_valid_namespaced_name`
+  is the ONE shared guard: it requires EXACTLY two `:`-separated segments,
+  each matching `agents::protocol::validate_agent_name`'s existing safe
+  charset (`[a-z0-9-]+`, 1-64 chars — reused, not re-derived). Because that
+  charset contains no `/` and no `.` at all, a traversal payload like
+  `plugin:../../../../etc/passwd` or `plugin:/etc/passwd` is syntactically
+  impossible to construct — the guard runs BEFORE any path is built, in the
+  function that actually builds it (not merely in an upstream caller).
+  `plugins::skills::resolve_plugin_skill_body` additionally requires the
+  namespaced name to be one `discover_plugin_skills` actually found on disk
+  this scan — closing the residual gap where a plugin's own `SKILL.md`
+  frontmatter could declare a spoofed `name:` that passed the charset check
+  but was never a real, scanned skill.
+- **Dispatch-path validators updated to ACCEPT the namespaced shape.**
+  Before this fix, `tools::delegate::DelegateToAgentTool::execute`, the
+  CLI's `validate_agent_name` (`main.rs`), and `runner::agent_config_exists`
+  each rejected ANY name containing `:` outright — so even though
+  `agents::resolve_agent` could resolve a namespaced name, nothing upstream
+  ever let one reach it: a plugin agent was listed but never actually
+  dispatchable. All three now check `plugins::is_valid_namespaced_name`
+  first (falling through to their original plain-name charset check when it
+  doesn't match), which both ENABLES dispatch and IS the traversal guard for
+  each of those three call sites.
+
 ## 3. Non-Goals (Explicitly Out of Scope, Phase 1)
 
 - Marketplace or git-fetched plugin sources.
@@ -141,8 +198,11 @@ no `.claude/plugins/` to scan without a project root.
 | Discover plugins from `.claude/plugins/<plugin>/`, honoring `plugin.json` overrides | `plugins::discover_plugin_roots` | Implemented |
 | Namespace + list plugin agents in `agents.list` (`plugin` tier, additive) | `plugins::agents::discover_plugin_agents`, `agents::protocol::agents_list` | Implemented |
 | Resolve `<plugin>:<name>` for dispatch | `plugins::agents::find_plugin_agent_config`, `agents::resolve_agent` | Implemented |
+| `<plugin>:<name>` is genuinely delegatable end-to-end (PM tool, CLI, pre-flight gate) | `tools::delegate::DelegateToAgentTool`, `main.rs::validate_agent_name`, `runner::agent_config_exists` | Implemented |
 | Drop unsupported agent frontmatter fields with a warning | `plugins::agents::load_plugin_agent` | Implemented |
 | Treat `extends:` as leaf-only with a warning | `plugins::agents::load_plugin_agent` | Implemented |
 | Namespace + list plugin skills in `skills.list` (`plugin` tier, independent of PR #3465 threshold) | `plugins::skills::discover_plugin_skills`, `skills::protocol::skills_list` | Implemented |
 | Resolve `<plugin>:<name>` skill bodies for `use_skill` | `plugins::skills::resolve_plugin_skill_body`, `skills::FsSkillResolver` | Implemented |
 | Ignore commands/hooks/MCP with a debug log | `plugins::load_plugin_root` | Implemented |
+| Reject `plugin.json` `agents`/`skills` overrides that escape `plugin_dir` (§2.5) | `plugins::safe_plugin_subdir` | Implemented |
+| Reject a traversal/unsafe-charset namespaced dispatch name before any path is built (§2.5) | `plugins::is_valid_namespaced_name` | Implemented |

--- a/docs/specs/DOC-51-tcode-plugin-support-phase1.md
+++ b/docs/specs/DOC-51-tcode-plugin-support-phase1.md
@@ -1,0 +1,148 @@
+---
+spec_refs:
+  - id: SPEC-TCPLUGIN-01~draft
+    path: docs/specs/DOC-51-tcode-plugin-support-phase1.md
+    anchor: SPEC-TCPLUGIN-01~draft
+---
+
+# DOC-51 — trusty-code Claude Code Plugin Support, Phase 1: Local-Directory Agents + Skills
+
+**Status:** Draft
+**Subsystem:** trusty-code — agent/skill catalog, discovery, dispatch
+**Owner:** Engineering (trusty-code)
+**Last-updated:** 2026-07-20
+**Spec ID:** `SPEC-TCPLUGIN-01~draft` (DOC-51)
+**Linked issues:** [#3539](https://github.com/bobmatnyc/trusty-tools/issues/3539) (Phase 1 scope decision); [#3542](https://github.com/bobmatnyc/trusty-tools/issues/3542) (base-agent listing filter, consumed unchanged); [#3465](https://github.com/bobmatnyc/trusty-tools/pull/3465) (skills whole-catalog-replacement threshold, consumed unchanged)
+**Cross-ref:** `crates/trusty-code/src/plugins/{mod,agents,skills}.rs` (this spec's implementation); `crates/trusty-code/src/agents/{mod,md_loader,protocol}.rs` (agent discovery/loading/catalog, reused not forked); `crates/trusty-code/src/skills/{mod,protocol}.rs` (skill discovery/catalog, reused not forked)
+
+> **Scope note.** This is a **behavior contract** for Phase 1 of Claude Code
+> plugin support: ingesting a plugin's `agents/` and `skills/` from a **local
+> directory** only. It explicitly does **not** cover marketplace/git-fetched
+> plugins, commands, hooks, or MCP servers — those are later phases, tracked
+> separately against #3539. This spec does not re-specify tcode's existing
+> agent/skill formats (Markdown+frontmatter, progressive-disclosure
+> `SKILL.md`) — it specifies only the discovery, namespacing, and precedence
+> layer a plugin adds on top of them.
+
+---
+
+## 1. Motivation
+
+tcode already parses the exact on-disk formats a Claude Code plugin ships
+agents (`.md`+frontmatter) and skills (`SKILL.md`, progressive disclosure)
+in. A plugin is conceptually just a third source of agents/skills, alongside
+the embedded/bundled roster and a project's own `.claude/agents|skills/`.
+Phase 1 answers one question narrowly: given a local plugin directory, how
+does tcode discover its agents/skills, name them so they never collide with
+anything else, and dispatch/resolve them — without touching the later-phase
+surfaces (commands, hooks, MCP) a real Claude Code plugin manifest may also
+declare.
+
+## 2. Behavior Contract {#SPEC-TCPLUGIN-01~draft}
+
+### 2.1 Source and discovery
+
+- **Input:** a project root. Plugins are auto-scanned from
+  `<project_root>/.claude/plugins/<plugin>/` — every immediate subdirectory
+  of `.claude/plugins/` is one plugin root. No marketplace or git-fetch
+  source is consulted in Phase 1; a plugin not physically present on disk
+  under this path does not exist as far as tcode is concerned.
+- **Manifest (optional):** if `<plugin_dir>/.claude-plugin/plugin.json`
+  exists and parses, its `name` field overrides the resolved plugin
+  identity (falling back to the directory name), and its `agents`/`skills`
+  fields override the default `agents/`/`skills` subdirectory convention
+  (relative to the plugin root). A missing or malformed manifest degrades
+  to the directory-name + convention fallback — never an error.
+- **Later-phase manifest keys** (`commands`, `hooks`, `mcpServers`, `mcp`):
+  detected and logged at `DEBUG`, never acted on and never a hard failure.
+- **Output:** a `PluginRoot` per discovered plugin (resolved name, agents
+  dir, skills dir), sorted by name.
+- **Implementing module:** `plugins::{PluginRoot, discover_plugin_roots}`.
+
+### 2.2 Agent ingestion and namespacing
+
+- **Input:** each `PluginRoot`'s `agents_dir`, scanned via the same
+  `.md`-only, `.toml`-warns discovery disk agents already use
+  (`agents::discover_agents`).
+- **Namespacing:** every plugin agent is surfaced as `<plugin>:<name>` in
+  `agents.list` (tier `"plugin"`) and is the ONLY name it resolves under via
+  `agents::resolve_agent`. The namespaced key structurally cannot collide
+  with an unnamespaced project or embedded/bundled agent name, so plugin
+  agents are additive-only by construction — they never override, and are
+  never suppressed by, a project/embedded entry of the same local name (both
+  simply coexist in the catalog under different keys).
+- **Base-agent filter:** a plugin agent whose LOCAL name matches one of the
+  five `BASE-*` composition-template names is excluded from the listing,
+  exactly like the embedded/disk tiers (issue #3542's filter, reused
+  unchanged via `agents::protocol::is_base_agent`).
+- **Frontmatter projection:** parsed via the same
+  `agents::md_loader::project_to_agent_config` mapping disk/embedded agents
+  use (role, description, model, `max_tokens`, `tools`). Fields tcode's
+  `AgentConfig` has no slot for — `effort`, `maxTurns`, `memory`,
+  `isolation`, `disallowedTools` (trusty-mpm's own agent-frontmatter
+  superset, which a plugin agent may carry over) — are DROPPED, with one
+  aggregated `WARN` per agent naming every dropped field. This never fails
+  the load.
+- **`extends:` (leaf-only):** a plugin agent declaring `extends:` is loaded
+  as a direct/leaf document — its own frontmatter and body only, no
+  cross-catalog compose — with one `WARN` naming the ignored parent.
+  Cross-catalog inheritance is an explicit non-goal of Phase 1.
+- **Implementing module:** `plugins::agents::{discover_plugin_agents,
+  load_plugin_agent, find_plugin_agent_config}`.
+
+### 2.3 Skill ingestion and namespacing
+
+- **Input:** each `PluginRoot`'s `skills_dir`, scanned for immediate
+  `<name>/SKILL.md` subdirectories — cheap frontmatter only
+  (`name`/`description`), matching tcode's progressive-disclosure discovery
+  contract (`skills::discover_skill_metadata`'s shape). A skill's full body
+  is loaded lazily, only on invoke.
+- **Namespacing:** every plugin skill is surfaced as `<plugin>:<name>` in
+  `skills.list` (tier `"plugin"`) and in `use_skill`'s resolvable catalog.
+- **Precedence independence (locked decision):** plugin skills are an
+  INDEPENDENT additive tier with respect to the project-vs-bundled
+  whole-catalog-replacement threshold PR #3465 established for
+  `skills.list` (a project's own non-empty `.claude/skills/` entirely
+  replaces the bundled catalog in the response). The plugin tier is added
+  identically regardless of which side of that threshold the response
+  landed on — a project with exactly one custom skill AND an installed
+  plugin sees its custom skill, no bundled entries, AND every namespaced
+  plugin skill, all at once.
+- **Implementing module:** `plugins::skills::{discover_plugin_skills,
+  resolve_plugin_skill_body}`.
+
+### 2.4 Resolution seam (no new parameters)
+
+Every integration point recovers the project root it needs from a directory
+it already holds — `<root>/.claude/agents` (agents catalog state,
+`agents::resolve_agent`'s `dir` argument) or `<root>/.claude/skills`
+(skills catalog state, `skills::FsSkillResolver`'s `skills_dir`) — via
+`plugins::project_root_two_levels_up`, rather than threading a new
+`project_root` parameter through existing public signatures/constructors.
+Projectless (no bound project) daemons see no plugin tier anywhere: there is
+no `.claude/plugins/` to scan without a project root.
+
+## 3. Non-Goals (Explicitly Out of Scope, Phase 1)
+
+- Marketplace or git-fetched plugin sources.
+- Plugin `commands/`, `hooks/`, or MCP server declarations — detected and
+  logged only, never executed or registered.
+- Cross-catalog `extends:` composition for plugin agents (a plugin agent
+  extending a project/embedded/another-plugin agent).
+- A GUI plugin install/management flow — Phase 1 is config/CLI-driven via
+  the `.claude/plugins/` directory convention only.
+- Overriding an unnamespaced project or embedded/bundled agent/skill name —
+  namespacing makes this structurally impossible, not merely policy.
+
+## 4. Conformance Matrix
+
+| Requirement | Implementing module | Status |
+|---|---|---|
+| Discover plugins from `.claude/plugins/<plugin>/`, honoring `plugin.json` overrides | `plugins::discover_plugin_roots` | Implemented |
+| Namespace + list plugin agents in `agents.list` (`plugin` tier, additive) | `plugins::agents::discover_plugin_agents`, `agents::protocol::agents_list` | Implemented |
+| Resolve `<plugin>:<name>` for dispatch | `plugins::agents::find_plugin_agent_config`, `agents::resolve_agent` | Implemented |
+| Drop unsupported agent frontmatter fields with a warning | `plugins::agents::load_plugin_agent` | Implemented |
+| Treat `extends:` as leaf-only with a warning | `plugins::agents::load_plugin_agent` | Implemented |
+| Namespace + list plugin skills in `skills.list` (`plugin` tier, independent of PR #3465 threshold) | `plugins::skills::discover_plugin_skills`, `skills::protocol::skills_list` | Implemented |
+| Resolve `<plugin>:<name>` skill bodies for `use_skill` | `plugins::skills::resolve_plugin_skill_body`, `skills::FsSkillResolver` | Implemented |
+| Ignore commands/hooks/MCP with a debug log | `plugins::load_plugin_root` | Implemented |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -66,6 +66,7 @@ normative grammar — this note does not restate it.
 | DOC-47 | `SPEC-EVTING-01~draft` … `-04~draft` | [External Event Ingestion — Webhooks & Connector Push](./DOC-47-external-event-ingestion.md) | trusty-agents-common — event seam; trusty-mpm — webhook ingress + goal store; trusty-console — Tailscale Funnel binding |
 | DOC-48 | `SPEC-WS-01~draft` … `-09~draft` | [tcode Workstreams: Durable Named Work Aggregation](./DOC-48-tcode-workstreams.md) | trusty-code — activation-lock exclusivity model, multi-client attach transport (shared with trusty-agents #3052), RPC/REST/CLI surfaces |
 | DOC-50 | `SPEC-TTUI-01~draft` … `-09~draft` | [trusty-code Interactive TUI: Claude Code Clone over Shared REPL Layer](./DOC-50-tcode-tui-claude-code-clone.md) | trusty-code — interactive terminal UI thin client; trusty-tui shared crate (ratatui REPL extraction from trusty-agents) |
+| DOC-51 | `SPEC-TCPLUGIN-01~draft` | [trusty-code Claude Code Plugin Support, Phase 1: Local-Directory Agents + Skills](./DOC-51-tcode-plugin-support-phase1.md) | trusty-code — agent/skill catalog, discovery, dispatch |
 
 > **Catalog note — `DOC-34` gap.** `DOC-34` (`SPEC-CFGDIR-01~draft`…`-05~draft`,
 > [Managed sessions launch with a tm-owned `CLAUDE_CONFIG_DIR`](./managed-session-config-dir.md))
@@ -79,8 +80,9 @@ normative grammar — this note does not restate it.
 > file is **not** in this catalog. The collision is flagged here rather than resolved by
 > renumbering the file in-place (its self-label and any inbound references are left
 > untouched); a follow-up should assign it the next free `DOC-N` and add a catalog row.
-> **Next free `DOC-N` = `DOC-51`** (re-scan of the whole `docs/` tree, 2026-07-20): the
-> highest cataloged number is now **DOC-50** ([trusty-code Interactive TUI](./DOC-50-tcode-tui-claude-code-clone.md),
+> **Next free `DOC-N` = `DOC-52`** (updated 2026-07-20 — DOC-51 claimed below by
+> [trusty-code Claude Code Plugin Support Phase 1](./DOC-51-tcode-plugin-support-phase1.md)):
+> before that claim, the highest cataloged number was **DOC-50** ([trusty-code Interactive TUI](./DOC-50-tcode-tui-claude-code-clone.md),
 > the entry above), which claimed the next free number after **DOC-48**
 > ([tcode Workstreams](./DOC-48-tcode-workstreams.md)) per the
 > scan-before-claim rule ([DOC-38 §4.1](./spec-linked-documentation.md) — a catalog's "next free"


### PR DESCRIPTION
## Summary

Phase 1 of Claude Code plugin support in trusty-code (issue #3539): ingest a plugin's **agents** and **skills** from a **local directory** only. No marketplace/git fetch, no commands/hooks/MCP — those are later phases, explicitly out of scope here.

**Update (code-critic review, this PR):** the initial version was BLOCKED on 2 CRITICAL + 2 HIGH findings — plugin content (`plugin.json`, directory names, frontmatter) was not being treated as hostile third-party input the way the rest of the agent/skill code already treats caller-supplied names. All four are fixed below, with regression tests, and dispatch is now genuinely wired end-to-end (see "Dispatch is now real" below) rather than only resolvable at the `resolve_agent` layer.

### How a user points tcode at a plugin

Drop a plugin under `<project_root>/.claude/plugins/<plugin-dir>/`:

```
.claude/plugins/my-plugin/
├── .claude-plugin/plugin.json   # optional
├── agents/
│   └── reviewer.md
└── skills/
    └── review-checklist/
        └── SKILL.md
```

- No manifest → the plugin's identity is the directory name, and `agents/`/`skills/` are the default subdirectories.
- With a manifest, `plugin.json`'s `name` overrides the identity, and `agents`/`skills` override the subdirectory paths:
  ```json
  { "name": "my-plugin", "agents": "custom-agents-dir", "skills": "custom-skills-dir" }
  ```
- `commands`/`hooks`/`mcpServers` keys, if present, are detected and logged at `DEBUG` — never acted on, never a hard failure.

### Namespacing

Every plugin agent/skill is surfaced in `agents.list`/`skills.list` under a new `"plugin"` tier, namespaced `<plugin>:<name>` (e.g. `my-plugin:reviewer`), and is resolvable **only** under that namespaced name — via `agents::resolve_agent` for dispatch, and the `use_skill` tool's `FsSkillResolver` for skill bodies. Because the namespaced key can never collide with an unnamespaced project/embedded/bundled name, plugin entries are **structurally additive-only**.

Plugin skills are also independent of the PR #3465 bundled-vs-project whole-catalog-replacement threshold for `skills.list`.

### Dispatch is now real (fixed in this update)

`agents::resolve_agent` could already resolve a namespaced name, but every caller in front of it — `tools::delegate::DelegateToAgentTool::execute` (the PM's `delegate_to_agent` tool), the CLI's `tcode run-task` argument validation, and `runner::agent_config_exists` (the pre-flight existence gate both of those call) — rejected any name containing `:` outright. A plugin agent was listed in `agents.list` but could never actually be dispatched. All three now accept the `<plugin>:<name>` shape.

### Security: plugin content is hostile input

- **CRITICAL 1 — `plugin.json` path escape.** `agents`/`skills` overrides were joined onto `plugin_dir` unvalidated; `PathBuf::join` replaces the base outright for an absolute component, and a relative `../..` escapes upward. Fix: `plugins::safe_plugin_subdir` rejects an absolute or `..`-bearing override before any join, and requires the joined candidate to canonicalize within `plugin_dir`'s own canonicalization (also catches a symlink escape). Rejection warns and falls back to the default convention.
- **CRITICAL 2 — `use_skill` traversal.** An LLM-supplied namespaced skill name reached `plugins::skills::resolve_plugin_skill_body`, which built `skills_dir.join(skill_name)` from the raw segment. Fix: validates via the new `plugins::is_valid_namespaced_name` (two `[a-z0-9-]+` segments, ≤64 chars each — no `/` or `.` at all, so escape is syntactically impossible) before any path is built, plus requires the name to be one `discover_plugin_skills` actually found on disk.
- **HIGH 3 — `plugins/agents.rs` had the identical unguarded join.** The guard now belongs to `find_plugin_agent_config` itself, not an upstream `:` rejection.
- **HIGH 4 — the three dispatch-path validators rejected `:` outright.** Now they accept `<plugin>:<name>` via `is_valid_namespaced_name`, which both enables dispatch and is the traversal guard for each site.

**Second update (code-critic re-review):** confirmed all 4 above are genuinely closed, but found a DIFFERENT vector — a symlinked leaf file (CWE-59):

- **CRITICAL 5 — symlinked `.md`/`SKILL.md` leaf files.** `discover_agents`/`load_plugin_agent` and `discover_one_plugin_skills`/`resolve_plugin_skill_body` read discovered files with `std::fs::read_to_string` and test with `is_dir()`/`is_file()` — all of which FOLLOW symlinks. A hostile plugin could ship `agents/leak.md` (or `skills/leak/SKILL.md`, or make the skill directory itself a symlink) pointing at an arbitrary host file (e.g. `~/.ssh/id_rsa`); discovery would read the TARGET's content as that agent's system prompt / skill body, reaching an LLM prompt verbatim once dispatched — the directory guard (`safe_plugin_subdir`) and name guard (`is_valid_namespaced_name`) both pass for this, since neither inspects the leaf file's identity. Fix: new `plugins::path_is_contained` canonicalizes the full leaf path and requires it stay contained within the already-validated `agents_dir`/`skills_dir` — since `canonicalize` resolves every symlink in the path, one check catches a symlinked leaf file, a symlinked intermediate directory (`skills/<name>` itself), or both. Applied at every content-read site: `plugins::agents::load_plugin_agent` (covers both `agents.list` listing and `find_plugin_agent_config` dispatch, since both route through it), `plugins::skills::discover_one_plugin_skills` (`skills.list` listing), and `plugins::skills::resolve_plugin_skill_body` (`use_skill` resolution, with a second independent check as defense in depth). Also fixed a bug this surfaced: `runner::agent_config_exists` treated `Some(Err(_))` (found but rejected) as "exists", letting a symlink-rejected namespaced name slip past `delegate_to_agent`'s pre-flight gate — now requires `Some(Ok(_))`.

## New module layout

```
crates/trusty-code/src/plugins/
├── mod.rs          — manifest parsing, PluginRoot, discover_plugin_roots,
│                      project_root_two_levels_up, safe_plugin_subdir,
│                      is_valid_namespaced_name, path_is_contained
│                      (leaf-file-identity guard, CWE-59)
├── agents.rs        — discover_plugin_agents, load_plugin_agent, find_plugin_agent_config
├── skills.rs         — discover_plugin_skills, resolve_plugin_skill_body
└── {mod,agents,skills}_tests.rs — test files (1500-SLOC test cap)
```

## Integration points (minimal edits)

- `agents/protocol.rs` — `agents_list` layers the `plugin` tier when a project is bound.
- `agents/mod.rs` — `resolve_agent` routes a namespaced name to `plugins::agents::find_plugin_agent_config`.
- `agents/md_loader.rs` — `extract_body`/`project_to_agent_config` made `pub(crate)`, reused (not forked).
- `agents/protocol.rs` — `is_base_agent` made `pub(crate)`, reused by plugin listing.
- `skills/protocol.rs` — `skills_list` layers the `plugin` tier, independent of the bundled/project threshold.
- `skills/mod.rs` — `frontmatter` module made `pub(crate)`; `FsSkillResolver` merges + resolves plugin skills.
- `tools/delegate.rs`, `tools/skill.rs`, `runner/in_process.rs`, `main.rs` — namespaced-dispatch validation gates (see Security above).
- `lib.rs` — wires `pub mod plugins;`.

No `project_root` parameter threaded through any existing public signature/constructor — every integration point recovers it from a directory it already holds via `plugins::project_root_two_levels_up`.

## Spec doc

`docs/specs/DOC-51-tcode-plugin-support-phase1.md` (SLD-compliant, catalogued in `docs/specs/README.md`, `SPEC-TCPLUGIN-01~draft`) — updated with a new §2.5 covering the hostile-input hardening (including the symlinked-leaf-file fix) and the now-wired dispatch path.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p trusty-code --tests -- -D warnings` — 0 warnings
- [x] `cargo test -p trusty-code --lib -- --test-threads=1` — 1549/1549 passed, 0 failed, clean; default parallel `cargo test -p trusty-code` intermittently reproduces a DIFFERENT pre-existing `run_task::tests::*` failure each run, always tracing to `catchup: could not reach trusty-memory at http://127.0.0.1:7070` — confirmed unrelated (every failing test passes individually and serially)
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] `bash scripts/check_sld.sh` — 0 errors, 0 warnings
- [x] `node scripts/check_token_drift.mjs` — unaffected, still OK
- [x] New tests: plugin agents+skills discovered/namespaced/resolvable, skills-precedence independence, unsupported-field-drop, `extends:` leaf-only warning, plugin-vs-project name collision does NOT override, `plugin.json` absolute/`..` override rejected, `use_skill`/`delegate_to_agent` traversal rejected end-to-end through the real resolver/runner, PLUS: a symlinked `agents/leak.md` and `skills/leak/SKILL.md` each pointing at a secret file outside the plugin dir — asserted the secret never appears via `agents.list`/`delegate_to_agent` nor `discover_plugin_skills`/`use_skill`, at both the unit level and end-to-end (`agents::protocol::agents_list`, `tools::delegate`, `tools::skill`, `runner::agent_config_exists`), plus direct `path_is_contained` unit tests (real file, symlinked leaf, symlinked intermediate dir, nonexistent leaf)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
