### PR TITLE
chore(release): trusty-search 0.37.0 + trusty-embedderd-py 0.1.0 — Python/MPS sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11765,7 +11765,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -61,7 +61,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.19.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.36.0" }
+trusty-search = { path = "../trusty-search", version = "0.37.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-embedderd-py/CHANGELOG.md
+++ b/crates/trusty-embedderd-py/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [0.1.0] — 2026-07-20
+
+Initial release — opt-in Python/MPS embedding sidecar launcher for
+trusty-search (epic #3524, slices 2-4). **DEFAULT-OFF**: only active when
+`TRUSTY_EMBEDDER=python` selects it. Refs #3524, #3498, #3493.
 
 ### Fixed
 
@@ -59,15 +63,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   silently serving from a broken interpreter; if the rebuild itself fails, the
   error propagates so `commands/start/embedder.rs`'s existing
   fall-back-to-ort path fires.
-
----
-## [0.1.0] — 2026-07-20
-
-Initial release — opt-in Python/MPS embedding sidecar launcher for
-trusty-search (epic #3524, slices 2-4). **DEFAULT-OFF**: only active when
-`TRUSTY_EMBEDDER=python` selects it. Refs #3524, #3498, #3493.
-
-### Added
 
 - **Python sidecar module `trusty_embed_sidecar`** (slice 2): a hardened,
   production stdio JSON-RPC 2.0 server speaking the EXACT

--- a/crates/trusty-embedderd-py/README.md
+++ b/crates/trusty-embedderd-py/README.md
@@ -37,7 +37,39 @@ TRUSTY_EMBEDDER=python trusty-search start
 ```
 
 Requires `uv` on `PATH` (or `TRUSTY_UV_BIN`) and ~3 GB free disk for the
-one-time torch + sentence-transformers download.
+one-time torch + sentence-transformers download. The launcher binary must be
+installed **alongside** `trusty-search` (a sibling of `current_exe()`) or on
+`PATH` — that is how `EmbedderSupervisor` discovers it. Override with
+`TRUSTY_EMBEDDERD_PY_BIN`.
+
+## How it works
+
+1. **Bootstrap** (`bootstrap.rs`): materializes the embedded `python/` project
+   (via `include_dir!`), locates `uv`, installs a pinned CPython 3.11, creates a
+   venv in the trusty-search **data dir** keyed by the `uv.lock` content hash,
+   `uv pip sync`s a hashed requirements file, runs an import+embed smoke test,
+   and writes a `.ready` sentinel. Disk precheck + bounded timeout + one retry +
+   `flock` against concurrent bootstraps. A two-tier `.ready` recheck rebuilds a
+   corrupted venv rather than serving from a broken interpreter.
+2. **Launch** (`launcher.rs` / `main.rs`): the supervisor spawns
+   `trusty-embedderd-py --stdio`; the launcher ensures the venv (cheap
+   torch-free `.ready` recheck on respawn) then **`exec`s** the venv's
+   `python -m trusty_embed_sidecar --stdio`, inheriting stdio and env.
+3. **Serve** (`python/trusty_embed_sidecar`): a newline-JSON-RPC-2.0 stdio
+   server speaking the EXACT `trusty-embedderd` wire protocol — reader/worker
+   split (multi-flight safe, MPS-serialized), id echoed verbatim, stdout =
+   frames only / logs to stderr, empty batch → `[]`, EOF/SIGTERM → clean exit
+   under a progress-aware shutdown watchdog.
+
+Because the sidecar impersonates `trusty-embedderd` byte-for-byte, trusty-search
+drives it through the unchanged `EmbedderSupervisor` / `StdioEmbedderClient` /
+`LazyEmbedderHandle` — **zero** supervisor/stdio/protocol wire-code changes.
+
+**Full architecture, device selection, idle-shutdown lifecycle, Linux-CUDA
+build notes, and validated benchmark numbers:**
+[`docs/trusty-search/research/python-mps-embedder-sidecar-2026-07-20.md`](../../docs/trusty-search/research/python-mps-embedder-sidecar-2026-07-20.md).
+User-facing env reference: trusty-search `CLAUDE.md` → "Python/MPS sidecar
+tuning".
 
 ### Environment
 

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.37.0] — 2026-07-20
+
+Minor release: opt-in Python/MPS embedding sidecar (`TRUSTY_EMBEDDER=python`),
+a new default-off capability that embeds ~2.4x faster than the Rust ort path on
+Apple Silicon with numerically identical results, and falls back to ort on any
+failure. Unset/`auto`/`stdio` behaviour is unchanged. Epic #3524 (refs #3498,
+#3493); paired with the first release of the `trusty-embedderd-py` launcher
+crate (v0.1.0).
+
 ### Added
 
 - **Opt-in Python/MPS embedding sidecar (`TRUSTY_EMBEDDER=python`)** — epic

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.36.1"
+version = "0.37.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/docs/trusty-search/research/README.md
+++ b/docs/trusty-search/research/README.md
@@ -24,6 +24,7 @@ These are distinct from [regression-testing/](../regression-testing/) (which tra
 ### Validation / Audits
 
 - [`candle-metal-validation-2026-05-22.md`](candle-metal-validation-2026-05-22.md) — Candle vs ORT-CoreML embedder validation on Apple Silicon.
+- [`python-mps-embedder-sidecar-2026-07-20.md`](python-mps-embedder-sidecar-2026-07-20.md) — architecture & validation for the opt-in Python/MPS embedding sidecar (`TRUSTY_EMBEDDER=python`): wire protocol, launcher/supervisor seam, uv/venv bootstrap, idle-shutdown lifecycle, device selection, CUDA (g4dn) build notes, and validated numbers (epic #3524).
 - [`bm25-memory-2026-05-28.md`](bm25-memory-2026-05-28.md) — BM25 index memory-footprint investigation.
 - [`fjall-evaluation-2026-06-03.md`](fjall-evaluation-2026-06-03.md) — fjall LSM-tree vs. redb CoW B-tree: deeper evaluation and benchmark spike plan (refs #692, #694).
 

--- a/docs/trusty-search/research/python-mps-embedder-sidecar-2026-07-20.md
+++ b/docs/trusty-search/research/python-mps-embedder-sidecar-2026-07-20.md
@@ -1,0 +1,273 @@
+# Python/MPS embedding sidecar — architecture & validation
+
+**Date:** 2026-07-20 · **Epic:** #3524 (slices 2-4) · **Refs:** #3498, #3493 ·
+**Shipped:** trusty-search 0.37.0 + trusty-embedderd-py 0.1.0
+
+Developer/architecture reference for the opt-in Python/MPS embedding sidecar.
+The user-facing knobs live in the crate CLAUDE.md ("Embedder Configuration" +
+"Python/MPS sidecar tuning"); the crate README
+(`crates/trusty-embedderd-py/README.md`) is the code-adjacent entry point. This
+document is the deep dive: the wire protocol, the launcher/supervisor seam, the
+bootstrap lifecycle, and the cross-platform (Apple Silicon + Linux CUDA) build
+notes and validated numbers behind the release.
+
+## Why this exists
+
+On Apple Silicon, a torch/MPS `sentence-transformers` sidecar embeds
+**~2.4x faster** than the Rust `ort` (ONNX Runtime) path with numerically
+identical results. The spike measured **561 emb/s end-to-end through the real
+supervisor** (vs. the 457 emb/s target), fp32 cosine similarity **1.0** against
+the ort reference, and fp16 **~1.85x** on CUDA. The sidecar unlocks that
+throughput headroom **without** making torch a build- or run-time requirement:
+it is **default-off**, opt-in via `TRUSTY_EMBEDDER=python`, and falls back to the
+Rust ort embedder on any failure so search never hard-fails.
+
+The design constraint that shaped everything: **zero changes to the existing
+supervisor/stdio/protocol wire code.** The Python sidecar impersonates
+`trusty-embedderd` exactly, so trusty-search's `EmbedderSupervisor` /
+`StdioEmbedderClient` / `LazyEmbedderHandle` drive it unmodified.
+
+## Component map
+
+```
+trusty-search  commands/start/embedder.rs   TRUSTY_EMBEDDER=python arm:
+                                             eager venv bootstrap + arm LazyEmbedderHandle
+      │  (spawns a binary with --stdio, piped stdin/stdout — unchanged)
+      ▼
+trusty-embedderd-py  (Rust launcher crate — a signable Mach-O)
+   src/launcher.rs    sibling/PATH/env discovery + exec into the venv python
+   src/bootstrap.rs   uv → venv → uv pip sync → smoke test → .ready sentinel
+   src/main.rs        <bin> --stdio: ensure_venv() then exec python -m trusty_embed_sidecar
+      │  (exec replaces the process; env inherited across exec)
+      ▼
+python/trusty_embed_sidecar   (embedded via include_dir!, materialized at bootstrap)
+   protocol.py   pure JSON-RPC 2.0 frame parse/build/dispatch (torch-free)
+   sidecar.py    reader/worker stdio serve loop + progress-aware shutdown
+   model.py      device selection + the real SentenceTransformer encoder
+```
+
+## Wire protocol (newline-JSON-RPC over stdio)
+
+The contract is defined by the Rust client
+(`trusty-common/src/embedder_client/stdio.rs`) and the reference server
+(`trusty-embedderd/src/stdio_server.rs`). The Python sidecar reimplements it
+byte-for-byte in `protocol.py`:
+
+- **Framing:** one JSON object per line, newline-terminated. **stdout carries
+  ONLY frames**; every log line goes to stderr. stdout is flushed after each
+  frame so the client's `read_line` returns promptly.
+- **Request:** `{"jsonrpc":"2.0","method":"embed","params":{"texts":[...]},"id":<n>}`
+- **Success:** `{"jsonrpc":"2.0","result":{"embeddings":[[..384 f32..],..]},"id":<echo>}`
+- **Error:** `{"jsonrpc":"2.0","error":{"code":<i32>,"message":"..."},"id":<echo>}`
+- **id echo:** the request `id` is echoed **verbatim**; the client correlates
+  responses by id and discards any frame whose id it does not recognise.
+- **Readiness:** the model is loaded and given **one MPS warmup encode BEFORE
+  the first reply**, so the supervisor's readiness probe only succeeds once the
+  sidecar can actually serve.
+- **EOF/SIGTERM shutdown:** EOF on stdin (or SIGTERM) stops the reader, drains
+  queued work, joins the worker, and exits cleanly (see lifecycle below).
+- **Invariants:** empty `texts` → `embeddings: []` (matches the Rust
+  short-circuit); unknown method → JSON-RPC `-32601`; any exception inside
+  `embed` → `-32603` error frame (one bad request never crashes the loop);
+  **all-zero guard** — the Rust HNSW upsert rejects all-zero vectors, so a
+  degenerate encode result is nudged to a valid unit vector rather than emitted
+  as zeros. Vectors are 384-dim, L2-normalized, matching
+  `trusty-common::embedder::EMBED_DIM`.
+
+### Multi-flight concurrency
+
+`StdioEmbedderClient` is **multi-flight**: with `TRUSTY_EMBED_INFLIGHT`
+(default 2) it writes several requests before reading their replies. The
+sidecar therefore splits work across two threads — a **reader** thread drains
+stdin frames into a bounded queue, and a **single worker** thread does the
+(GPU-serialized) encode and writes replies. One worker keeps MPS access
+serialized (concurrent Metal encode gives no speedup and risks contention)
+while still decoupling reading from compute, so a slow or large batch can never
+wedge the stdin drain.
+
+## Launcher & the supervisor seam (zero wire changes)
+
+`trusty-search`'s `EmbedderSupervisor` spawns *a binary* with `--stdio` and
+piped stdin/stdout. The Python arm reuses that machinery verbatim:
+
+- **Discovery** (`launcher::locate_launcher_binary`) mirrors
+  `locate_embedderd_binary`'s search order: (1) `TRUSTY_EMBEDDERD_PY_BIN`
+  explicit override; (2) sibling of `current_exe()` (workspace/release build);
+  (3) `trusty-embedderd-py` on `PATH`. This is why the launcher must be
+  installed **alongside** `trusty-search` (or on PATH) for the opt-in path to
+  work.
+- **Exec** (`launcher::exec_sidecar`): the launcher process **replaces itself**
+  (`exec`) with `<venv>/bin/python -m trusty_embed_sidecar --stdio`, inheriting
+  stdio and forwarding args + env (`TRUSTY_EMBED_BATCH_SIZE` et al. survive
+  because env is inherited across `exec`). Because it is a real exec, the
+  supervisor sees a single long-lived child speaking the wire protocol — there
+  is no wrapper process to reap.
+- **Failure = clean non-zero exit.** On bootstrap failure the launcher logs to
+  stderr and exits non-zero so the supervisor's startup probe fails cleanly.
+  trusty-search's `python` arm already fell back to ort at `start` (eager
+  bootstrap); this is the belt-and-suspenders path for a lazy respawn onto a
+  broken venv.
+
+## Bootstrap lifecycle (uv → venv-in-data-dir → `.ready`)
+
+`bootstrap.rs` materializes the embedded Python project (`include_dir!` of
+`python/` — pyproject + hashed `uv.lock` + package + tests) into the
+**trusty-search data dir, never the repo**, and builds a pinned venv:
+
+1. **Locate `uv`** (`TRUSTY_UV_BIN` → PATH). Missing `uv` is a bootstrap
+   failure → ort fallback.
+2. `uv python install` a pinned **CPython 3.11**.
+3. `uv venv` at
+   `resolve_data_dir("trusty-search")/py-embedder/<lockfile-hash>/venv`
+   (honours `TRUSTY_DATA_DIR_OVERRIDE`). The venv dir is **keyed by the
+   `uv.lock` content hash**, so a lock change lands in a fresh directory rather
+   than mutating a live one.
+4. `uv export` narrows the **cross-platform** lock (resolved for BOTH
+   macOS-arm64 and linux-x86_64 via `pyproject.toml`
+   `tool.uv.environments`) to the *running* platform, emitting a hashed
+   requirements file that `uv pip sync` installs (torch 2.9.1 +
+   sentence-transformers 5.6.0).
+5. **Import+embed smoke test**, then write a **`.ready` sentinel** recording the
+   lockfile hash.
+
+Robustness: **disk-space precheck** (~3 GB, torch is large), **bounded
+timeout** per step (`TRUSTY_PY_BOOTSTRAP_TIMEOUT_SECS`, default 600) with **one
+retry** on transient failure, an advisory **`flock`** over the venv dir against
+concurrent bootstraps, and a double-checked `.ready` fast path.
+
+### Two-tier `.ready` re-verification
+
+`.ready` is **not** trusted forever — a post-build corruption (broken native
+`.so`, an ABI shift, a half-deleted directory) would otherwise route real
+traffic to a broken interpreter. The recheck depth depends on the caller:
+
+- **`ensure_venv()`** — called by the `trusty-embedderd-py` launcher on **every
+  respawn** — uses the **cheap, torch-free** `verify_venv_alive` (interpreter
+  liveness + an installed-package marker file, bounded ~5s, **no** `import
+  sentence_transformers`). A respawn never re-pays torch's import cost, which
+  would undercut the point of a longer idle-shutdown window.
+- **`ensure_venv_eager()`** — called **once** by the daemon at `start` — uses
+  the **full** `verify_full_import_smoke` (a real `import
+  sentence_transformers`, bounded ~10s), since that cost is paid only once per
+  daemon lifetime.
+
+A venv that fails its recheck is **rebuilt** rather than silently served from a
+broken interpreter; if the rebuild fails, the error propagates so the
+fall-back-to-ort path fires.
+
+## Idle-shutdown lifecycle
+
+The Python arm gets its own idle-shutdown default via
+**`TRUSTY_EMBEDDERD_PY_IDLE_SHUTDOWN_SECS`** (default **1800s / 30 min**),
+distinct from the shared `TRUSTY_EMBEDDERD_IDLE_SHUTDOWN_SECS` (300s, tuned for
+the lightweight ort sidecar). Rationale: the Python/MPS sidecar's cold restart
+is cheap (~2.5–3s: torch import + model load + one MPS warmup) but still worth
+avoiding mid-session, so the longer default keeps it warm through a typical work
+session while still reclaiming its ~500 MB after genuine extended idle (matters
+on the 16 GB minimum-spec tier).
+
+Resolution precedence preserves operator intent: the python var (if set,
+including `0`) always wins; else an explicitly-set shared var (any value,
+including `0`) is honoured; else the python-specific 1800s default applies. Set
+**`0` for always-warm** (idle-shutdown disabled) on higher-RAM machines. This
+has **zero impact** on the ort/default arm, which still calls
+`SupervisorConfig::from_env()` directly.
+
+### Progress-aware shutdown watchdog
+
+The sidecar's shutdown path does **not** bound the worker-join with a flat
+timeout (which would force-exit a legitimately slow-but-healthy drain — e.g. a
+reindex burst queued right at SIGTERM — dropping in-flight, not hung, replies).
+The worker marks a monotonic `_ProgressTracker` timestamp after each completed
+item; `_join_with_progress_watchdog` polls in 1s increments and only
+force-exits (`os._exit(1)`) once **no** item has completed for **20s** — a
+genuine wedge (e.g. a hung MPS `encode()` mid-batch), not merely a long drain.
+The SIGTERM handler raises a dedicated `_ShutdownRequested` exception rather
+than touching stdin (the earlier `sys.stdin.close()` inside the handler
+reentered a non-reentrant `BufferedReader` and hung the process); per PEP 475
+this propagates cleanly out of the interrupted read and `serve()`'s `finally`
+still drains and joins.
+
+## Device selection (`TRUSTY_DEVICE`)
+
+`model.py` selects the compute device (`TRUSTY_DEVICE` = `cpu` | `gpu` |
+`auto`):
+
+- **`auto`** (default): **MPS** if available (Apple Silicon), else **CUDA**,
+  else **CPU**.
+- **`gpu`**: MPS if available, else CUDA, else CPU **with a loud warning** — the
+  sidecar must not hard-fail (the launcher only falls back to ort on a *non-zero
+  exit*, so a working CPU sidecar beats a crash).
+- **`cpu`**: force CPU.
+
+**dtype:** fp32 by default (numerically identical to the CPU reference per the
+spike). `TRUSTY_PY_EMBED_FP16=1` opts into fp16 on MPS/CUDA (~1.3x faster on
+MPS, ~1.85x on CUDA; cosine still ≥ 0.9999). The model is pinned to a specific
+HuggingFace revision (`all-MiniLM-L6-v2`) so a bootstrapped venv always
+downloads bit-identical weights — the model-weights analogue of the pinned
+`uv.lock`. `TOKENIZERS_PARALLELISM=false` is set (via `setdefault`) before any
+`transformers` import to avoid an orphan-prone `resource_tracker` child the
+single-worker sidecar never benefits from.
+
+## Platform build notes
+
+### Apple Silicon (MPS) — the primary target
+
+Nothing extra: `uv` on PATH (or `TRUSTY_UV_BIN`) and ~3 GB free disk on first
+use. `TRUSTY_EMBEDDER=python trusty-search start` bootstraps the venv and, on
+`TRUSTY_DEVICE=auto`, uses MPS.
+
+### Linux CUDA (validated on AWS g4dn)
+
+The cross-platform `uv.lock` resolves torch for linux-x86_64, but a CUDA host
+needs these to build and run cleanly (validated on a g4dn instance, Ubuntu
+22.04, 16 GB GPU):
+
+- **`CC=gcc-12`** for the venv build on **Ubuntu 22.04** — the default toolchain
+  version fails the native build; gcc-12 succeeds.
+- **Use Microsoft's dynamic ONNX Runtime GPU release**, not pyke's static
+  `cu12` tarball, for the CUDA execution provider. (Relevant when the *ort*
+  reference path is also exercised on the box for the correctness comparison;
+  the pyke static tarball does not link cleanly against the g4dn CUDA stack.)
+- **`TRUSTY_SKIP_RAM_CHECK=1`** on 16 GB GPU boxes — the disk/RAM precheck is
+  tuned conservatively; a 16 GB GPU box is fine but trips the guard, so skip it
+  explicitly.
+
+### Validated numbers
+
+| Metric | Result |
+|--------|--------|
+| End-to-end throughput (real supervisor, Apple Silicon) | **561 emb/s** (target 457) |
+| MPS throughput headroom vs. Rust ort | **~2.4x** |
+| fp32 correctness vs. ort reference | cosine **1.0** |
+| fp16 speedup (CUDA) | **~1.85x**, cosine ≥ 0.9999 |
+| fp16 speedup (MPS) | ~1.3x, cosine ≥ 0.9999 |
+| Cold restart (torch import + model load + one MPS warmup) | ~2.5–3s |
+| Idle RSS reclaimed on shutdown | ~500 MB |
+
+## Testing
+
+- **Rust unit** (no torch/venv): `cargo test -p trusty-embedderd-py` —
+  `bootstrap_tests.rs` covers hash stability, layout derivation, both `.ready`
+  fast paths, and disk/uv-missing error surfaces.
+- **Python protocol conformance** (torch-free): `cd python && PYTHONPATH=.
+  python -m pytest tests/` — id-echo, out-of-order tolerance, empty batch, error
+  framing, real-signal SIGTERM shutdown, and the progress-aware watchdog.
+- **Real-model correctness gate** (needs torch + model): `TRUSTY_RUN_REAL_MODEL=1
+  ... pytest -m real_model` — ≥0.999 cosine vs. reference.
+- **Full real-venv e2e through the real supervisor** (`#[ignore]`d):
+  `TRUSTY_RUN_PY_E2E=1 cargo test -p trusty-embedderd-py --test e2e -- --ignored`.
+
+## Follow-ups (slices 5-7)
+
+Vendored / download-with-SHA256 `uv` acquisition, `doctor` polish, packaging +
+**default-on-Apple-Silicon**, and the bench / #24 soak.
+
+## Spec References
+
+- [`ARCHITECTURE.md`](../spec/ARCHITECTURE.md) — embedder sidecar in the overall
+  trusty-search process model.
+- [`cuda-embedder-0236-regression-2026-06-05.md`](cuda-embedder-0236-regression-2026-06-05.md)
+  — prior CUDA embedder validation context.
+- [`candle-metal-validation-2026-05-22.md`](candle-metal-validation-2026-05-22.md)
+  — the Candle/Metal vs. ort baseline this sidecar is measured against.


### PR DESCRIPTION
## MINOR release: opt-in Python/MPS embedding sidecar

Ships the sidecar merged in #3529 (epic #3524, slices 2-4) as a released crate set, with the documentation pass Bob asked for (help, changelog, dev docs).

### Versions
- **trusty-search 0.36.1 → 0.37.0** (MINOR — new opt-in, default-off capability)
- **trusty-embedderd-py 0.1.0** (NEW crate, first publish — the launcher for the sidecar)
- **trusty-agents**: dependency requirement on `trusty-search` relaxed `0.36.0` → `0.37.0` so the workspace resolves against the bumped crate (no trusty-agents version bump / republish — requirement fix only).

### Publish order (post-merge)
`trusty-embedderd-py` 0.1.0 first (depends only on already-live trusty-common 0.23.6), then `trusty-search` 0.37.0 (depends on embedderd-py 0.1.0). embedderd-py first-publish dry-run PASSED locally.

### Documentation (Bob's explicit ask)
- **New dev/architecture doc**: `docs/trusty-search/research/python-mps-embedder-sidecar-2026-07-20.md` — newline-JSON-RPC-over-stdio protocol (request/response/id-echo/readiness/EOF-shutdown), the exec launcher + zero-change supervisor seam, uv bootstrap + venv-in-data-dir + `.ready` sentinel + two-tier recheck + fallback-to-ort, idle-shutdown lifecycle (1800s default, `=0` always-warm), device selection (MPS/CUDA/CPU), Linux-CUDA (g4dn) build notes (`CC=gcc-12` on Ubuntu 22.04, Microsoft dynamic ORT-GPU vs pyke static cu12, `TRUSTY_SKIP_RAM_CHECK=1`), and validated numbers (561 emb/s e2e, fp32 cosine 1.0, fp16 ~1.85x CUDA). Indexed in `research/README.md`.
- **Expanded** `crates/trusty-embedderd-py/README.md` with a "How it works" section + architecture link.
- **Help/user docs**: env reference for `TRUSTY_EMBEDDER=python` and all tuning vars already in trusty-search `CLAUDE.md` (verified complete: `TRUSTY_UV_BIN`, `TRUSTY_EMBEDDERD_PY_BIN`, `TRUSTY_PY_BOOTSTRAP_TIMEOUT_SECS`, `TRUSTY_DEVICE`, `TRUSTY_PY_EMBED_FP16`, `TRUSTY_PY_EMBED_BATCH_SIZE`, `TRUSTY_EMBEDDERD_PY_IDLE_SHUTDOWN_SECS`).
- **CHANGELOGs** finalized: trusty-search `[0.37.0]`; trusty-embedderd-py folded pre-publish hardening into `[0.1.0]`.

The sidecar is **default-off** — no production-daemon behavior change.

refs #3524 #3498 #3493

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools