### PR TITLE
chore(release): trusty-common 0.23.7 (publish catchup::pause API, #3544)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,7 +6549,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11402,7 +11402,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,9 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+## [0.23.7] — 2026-07-21
+
+Publishes the `catchup::{pause, generate_catchup_json}` API to crates.io.
+This module was merged to main under PR [#3544](https://github.com/bobmatnyc/trusty-tools/pull/3544)
+without a corresponding version bump, so it landed in the `0.23.6` source tree
+but is absent from the `0.23.6` package already published on crates.io — the
+published `0.23.6` predates this module. That mismatch blocked publishing
+`trusty-mpm`, whose `core::catchup` re-exports these symbols. `0.23.7` exists
+solely to give the catchup API a real, publishable version.
+
 ### Added
 
-- **`catchup::generate_catchup_json` + `catchup::pause` module** ([#3543](https://github.com/bobmatnyc/trusty-tools/issues/3543)): a structured (JSON) sibling to `generate_catchup_context`'s markdown digest (`CatchupJson`/`PausedSessionJson`/`RecentMemoryJson`), plus a new `pause::write_pause_snapshot` writer that emits the exact session-snapshot section shape `session_finder` already parses, and a `git::capture_git_status` helper (branch/last-commit/uncommitted-summary) for its `## Git Context` section. Backs trusty-mpm's new `session_context_catchup` / `session_context_pause` MCP tools.
+- **`catchup::generate_catchup_json` + `catchup::pause` module** ([#3543](https://github.com/bobmatnyc/trusty-tools/issues/3543), [#3544](https://github.com/bobmatnyc/trusty-tools/pull/3544)): a structured (JSON) sibling to `generate_catchup_context`'s markdown digest (`CatchupJson`/`PausedSessionJson`/`RecentMemoryJson`), plus a new `pause::write_pause_snapshot` writer that emits the exact session-snapshot section shape `session_finder` already parses, and a `git::capture_git_status` helper (branch/last-commit/uncommitted-summary) for its `## Git Context` section. Backs trusty-mpm's new `session_context_catchup` / `session_context_pause` MCP tools.
 
 ## [0.23.6] — 2026-07-20
 

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.23.6"
+version = "0.23.7"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Main's `trusty-common` `Cargo.toml` is at `0.23.6`, but the `0.23.6` package already published on crates.io is **stale**: it predates the `catchup::{pause, generate_catchup_json}` module (`CatchupJson`/`PausedSessionJson`/`RecentMemoryJson` + `pause::write_pause_snapshot` + `git::capture_git_status`) that landed on main under PR #3544 without a corresponding version bump.
- Because `trusty-mpm`'s `core::catchup` re-exports those symbols, `cargo publish -p trusty-mpm` cannot resolve against the live registry — the published `trusty-common` 0.23.6 doesn't have them, and the local `0.23.6` cannot be re-published (crates.io rejects re-uploading an existing version).
- This PR bumps `trusty-common` to `0.23.7` purely to give the catchup API a real, publishable version, and updates `CHANGELOG.md` accordingly. No source changes beyond the version bump — `Cargo.lock` is refreshed to match.
- This unblocks the separate `trusty-mpm` 0.19.29 release branch (`trusty-mpm`'s workspace dependency requirement on `trusty-common` is `version = "0.23.2"`, i.e. `^0.23.2`, which 0.23.7 satisfies automatically — no change needed there).

## Test plan

- [x] `cargo update -p trusty-common` + `cargo check --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui` — clean build
- [x] `cargo publish -p trusty-common --dry-run` — Packaged, Verified, compiled cleanly, dry-run upload aborted as expected
- [ ] CI green on this PR
- [ ] Real `cargo publish -p trusty-common` (NOT done in this PR — publish-only branch, no merge/tag/publish performed here)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools