### PR TITLE
fix(trusty-agents): stop assistant leaking internal orchestration + owning delegation at runtime

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/assistant/persona.md
+++ b/crates/trusty-agents/.trusty-agents/agents/assistant/persona.md
@@ -126,11 +126,15 @@ specialist" or "my team" — describe outcomes, not internal mechanics or
 which system ran what. Never enumerate internal system/daemon/service names,
 even when explaining what you can or can't do.
 
-## What you are not
-- **Not a coding agent** — you don't write code, scripts, functions, or SQL
-  yourself, even as a quick sketch or prototype. That work goes to a
-  specialist (see "Getting hands-on work done" above) — you delegate it and
-  relay the result, you don't punt or refuse.
+## Coding work: you own getting it done, by delegating it
+For any code, script, function, or SQL — even a quick sketch or prototype —
+bring in an engineering specialist to write it (see "Getting hands-on work
+done" above), then relay the result in your own words. You own the outcome
+end to end; delegating the writing IS how you get it done, not a fallback or
+a limitation. Never frame this as something you can't do or aren't equipped
+for — don't say (or imply) "I'm not a coding agent", "that's for engineering
+agents, not me", "I'd hand off... rather than writing code myself", or
+similar. Just bring in the specialist and get it done.
 
 ## Tool Use Framing
 When using tools, include a brief acknowledgment before the tool call, like "Let

--- a/crates/trusty-agents/.trusty-agents/agents/izzie.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie.toml
@@ -259,8 +259,15 @@ describe it as bringing in "a specialist" or "my team" — describe outcomes,
 not internal mechanics or which system ran what. Never enumerate internal
 system/daemon/service names, even when explaining what you can or can't do.
 
-## What you are not
-- **Not a coding agent** — NEVER write code, scripts, functions, or SQL, even as a quick sketch or prototype. If Masa asks for code, bring in an engineering specialist to do the actual work, then relay the result — don't punt or refuse, and don't produce even a stub or pseudocode yourself.
+## Coding work: you own getting it done, by delegating it
+For any code, script, function, or SQL — even a quick sketch or prototype —
+bring in an engineering specialist to write it, then relay the result. You
+own the outcome end to end; delegating the writing IS how you get it done.
+Never frame this as something you can't do — don't say (or imply) "I'm not a
+coding agent" or similar. Just bring in the specialist and get it done, don't
+punt or refuse.
+
+## Org-question routing
 - **Not the CTO Assistant** — for ANY Duetto org questions (team size, reporting lines, org chart, vendor contracts, project ownership), do NOT search notes or guess. Reply immediately: "That's Duetto org territory — try `/switch cto` for accurate info." Do NOT use words like "headcount" or "team size figures" even when redirecting — describe the redirect plainly without naming the restricted metric.
 
 ## Tool Use Framing

--- a/crates/trusty-agents/.trusty-agents/agents/personal-assistant.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/personal-assistant.toml
@@ -113,8 +113,12 @@ NEVER fabricate any of the following — always use a tool, or say plainly that 
 
 If a tool fails or returns nothing, say so explicitly. Don't paper over with plausible-sounding fabrications.
 
+## Coding work: you own getting it done, by delegating it
+For any code task, bring in an engineering specialist to write it, then
+relay the result. You own the outcome end to end; delegating the writing IS
+how you get it done — never frame it as something you can't do.
+
 ## What you are not
-- Not a coding agent — for code tasks, say plainly you'll bring in an engineering specialist rather than writing code yourself
 - Not connected to live data sources unless those tools are enabled — if a tool isn't available, say so plainly rather than naming internal system/service names
 
 ## Response format

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -9,6 +9,65 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
+- **Assistant no longer leaks internal orchestration or disclaims delegating
+  when dispatched via `--direct`/`--agent` (#3550 follow-up):** a live smoke
+  test (`tagent --direct assistant --task "..."`) proved the black-box/tool
+  hardening from PR A (epic #3052, below) did NOT cover this dispatch path —
+  it still leaked `trusty-mpm`, `subagent`, and `subprocess`, recited the
+  entire bundled skill catalog ("wave planning", "git worktree discipline",
+  the full engineering language/framework bench), and disclaimed delegating
+  ("not a coding agent myself", "I'd hand off... rather than writing code
+  myself"). Root cause: `--direct`/`--agent` route through `run_subagent`
+  (`src/runtime/subagent_mode.rs`), a SEPARATE dispatch path from the
+  persona-chat path (`run_pm_task_with_persona`) PR A actually hardened.
+  `run_subagent` treated every agent — including `role == "assistant"`
+  personas — as a generic coding sub-agent:
+  - `SystemPromptBuilder::walk_project_instructions` unconditionally injected
+    every ancestor `CLAUDE.md`/`AGENTS.md` verbatim, including this crate's
+    own `CLAUDE.md` (which literally documents "PM Orchestrator", "Sub-Agent
+    Process", "subprocess IPC") and the workspace root `CLAUDE.md`
+    (`trusty-mpm`, worktree/PR-workflow conventions).
+  - The binary's coding-harness protocol (`agents::harness_protocol::
+    BASE_PROTOCOL` — "## trusty-agents Harness Protocol", `out_dir`,
+    "workflow phases") was injected regardless of role, priming the model to
+    describe itself as a phase-based coding harness.
+  - `build_registry_for_agent`'s catch-all branch (`src/runtime/
+    tool_registry.rs`) unconditionally wired `list_skills`/`load_skill` to
+    the FULL tag-indexed skill registry (every language/framework/workflow
+    skill, including `workflow/wave-planning.md` and `workflow/
+    delegation.md`) with no restriction: `run_subagent_with_tools` gates
+    tool reachability on `cfg.tools.allowed` (an exact-name list), but
+    persona TOMLs declare `[tools].allow` (glob patterns) instead — a field
+    this path never read — so `allowed` stayed `None`, which
+    `chat_with_tools_gated` treats as unrestricted.
+
+  Fixed with a role-scoped gate (`ASSISTANT_TIER_ROLE = "assistant"`,
+  matches `AgentInfo.role` — covers `assistant`/`cto-assistant`/`izzie`/
+  `personal-assistant` uniformly, independent of display name) in
+  `run_subagent`: skips the CLAUDE.md walk and harness-protocol layers for
+  assistant-tier agents, routes registry construction to a new curated
+  `build_assistant_tier_registry` (delegation + read-only git/web lookups,
+  no catalog-browsing tools), and adds `scope_assistant_allowed_tools` to
+  translate `[tools].allow` glob patterns into the `[tools].allowed`
+  exact-name list the existing gate enforces. Engineer/qa/research/docs/ops/
+  plan/pm/ctrl dispatch is untouched — the gate only fires for
+  `role == "assistant"`.
+
+  `assistant/persona.md`, `izzie.toml`, and `personal-assistant.toml`'s
+  "What you are not — Not a coding agent" sections were reworded from an
+  identity-negation frame (which the model was echoing near-verbatim as
+  "I'm not a coding agent myself") to a positive delegation-ownership frame
+  ("you own getting it done, by delegating it") that explicitly forbids the
+  disclaiming phrasing.
+
+  New tests: `assistant_tier_registry_excludes_skill_catalog_tools`,
+  `assistant_tier_registry_includes_curated_tools`,
+  `role_takes_precedence_over_name_for_assistant_tier`,
+  `scope_assistant_allowed_tools_filters_by_glob`,
+  `scope_assistant_allowed_tools_noop_for_non_assistant`,
+  `scope_assistant_allowed_tools_noop_when_allowed_already_set`
+  (`src/runtime/tool_registry_tests.rs`).
+
 - **`delegate_to_agent` no longer leaks internal agent names (PR A code-critic
   fix, epic #3052):** granting `delegate_to_agent` to assistant-tier personas
   (see below) exposed two leaks in the shared tool implementation

--- a/crates/trusty-agents/src/ctrl/pm_task/mod.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/mod.rs
@@ -18,10 +18,17 @@ mod helpers;
 // actor loop in state.rs.
 pub(crate) use helpers::run_pm_task;
 
-// Test-only re-exports — `ctrl::tests::pm_task_tests` reaches these pure helpers
-// via `super::super::pm_task::<item>`; they are otherwise internal to `helpers`.
+// Crate-wide re-export — `runtime::subagent_mode` (assistant-tier tool
+// scoping, #3550 follow-up) reuses the same glob-match semantics the
+// persona-chat allow-list gate (`filter_persona_tool_names`) relies on, so
+// both dispatch paths interpret a persona's `[tools].allow` patterns
+// identically.
+pub(crate) use helpers::match_any_glob;
+
+// Test-only re-export — `ctrl::tests::pm_task_tests` reaches this pure helper
+// via `super::super::pm_task::<item>`; it is otherwise internal to `helpers`.
 #[cfg(test)]
-pub(crate) use helpers::{extract_name_from_input, match_any_glob};
+pub(crate) use helpers::extract_name_from_input;
 
 // Public surface — the `run_pm_task_*` API consumed by ctrl/mod.rs re-exports.
 pub use dispatch::{run_pm_task_with_history, run_pm_task_with_persona};

--- a/crates/trusty-agents/src/runtime/subagent_mode.rs
+++ b/crates/trusty-agents/src/runtime/subagent_mode.rs
@@ -119,6 +119,19 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
     let mut cfg = AgentConfig::by_name(name)
         .with_context(|| format!("failed to load agent config for '{name}'"))?;
 
+    // Black-box persona/assistant-tier gate (#3550 follow-up — live smoke
+    // proved the assistant still leaked `trusty-mpm`/`subagent` and
+    // disclaimed delegating when invoked via `--direct`/`--agent`, even
+    // though PR #3550 hardened the SEPARATE persona-chat dispatch path,
+    // `run_pm_task_with_persona`). `run_subagent` is a generic coding
+    // sub-agent harness; it never routed through that hardening. Every check
+    // below keyed on `is_assistant_tier` restores parity: no raw CLAUDE.md
+    // project-instruction dump, no coding-harness protocol framing, and a
+    // curated (not catalog-unrestricted) tool registry — mirroring what the
+    // persona-chat path already does. Engineer/qa/research/docs/ops/plan
+    // agents (role != "assistant") are completely unaffected.
+    let is_assistant_tier = cfg.agent.role == super::tool_registry::ASSISTANT_TIER_ROLE;
+
     // #88: Per-call `max_turns` override via `TAGENT_MAX_TURNS`. The wave
     // loop sets this to tighten the turn budget per file (e.g. 20) so a
     // single invocation can't absorb an entire wave's work. Applied after
@@ -222,20 +235,42 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
     //   2. CLAUDE.md ancestor walk from CWD (project + home instructions).
     //   3. Any resolved skills declared by the agent.
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let mut builder =
-        SystemPromptBuilder::new(cfg.system_prompt.content.clone()).walk_project_instructions(&cwd);
+    let mut builder = SystemPromptBuilder::new(cfg.system_prompt.content.clone());
+
+    // Assistant-tier personas are black-boxed (persona.md/#3550): the user
+    // must never see internal system/architecture names. `CLAUDE.md`/
+    // `AGENTS.md` project-instruction files are written FOR engineers and
+    // routinely document exactly the internal mechanics the persona is
+    // forbidden from naming (this repo's own `crates/trusty-agents/CLAUDE.md`
+    // literally describes "PM Orchestrator" / "Sub-Agent Process" /
+    // "subprocess IPC"). Walking and injecting them verbatim into a
+    // persona's system prompt is a direct leak path, independent of the
+    // tool-schema allow-list PR #3550 fixed. Skip the walk entirely for
+    // assistant-tier agents; every other role keeps today's behavior.
+    if !is_assistant_tier {
+        builder = builder.walk_project_instructions(&cwd);
+    }
 
     // Harness protocol layers (single source of truth for write_file /
     // finish_task / out_dir / ## Summary rules). Injected between goal block
     // and base TOML prompt. Content is compiled into the binary via
     // `agents::harness_protocol` — the protocol is binary behavior, not user
     // config, so it cannot be disabled by editing files on disk.
-    builder = builder.add_harness_layer(BASE_PROTOCOL);
-    if matches!(cfg.agent.runner, agents::RunnerKind::ClaudeCode) && !cfg.llm.use_finish_task {
-        builder = builder.add_harness_layer(CLAUDE_CODE_PROTOCOL);
-    }
-    if cfg.llm.use_finish_task {
-        builder = builder.add_harness_layer(FINISH_TASK_PROTOCOL);
+    //
+    // Assistant-tier personas never write files, never call `finish_task`,
+    // and aren't given an `out_dir` — none of this coding-harness framing
+    // applies to them, and its "## trusty-agents Harness Protocol" /
+    // "workflow phases" language actively undermines persona.md's
+    // conversational, delegate-don't-disclaim framing. Skip it for
+    // assistant-tier; unaffected for every coding sub-agent.
+    if !is_assistant_tier {
+        builder = builder.add_harness_layer(BASE_PROTOCOL);
+        if matches!(cfg.agent.runner, agents::RunnerKind::ClaudeCode) && !cfg.llm.use_finish_task {
+            builder = builder.add_harness_layer(CLAUDE_CODE_PROTOCOL);
+        }
+        if cfg.llm.use_finish_task {
+            builder = builder.add_harness_layer(FINISH_TASK_PROTOCOL);
+        }
     }
 
     if let Some(skills) = &cfg.system_prompt.skills
@@ -300,9 +335,11 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
         &default_bundled_config_dir(),
     ));
 
-    // Build the per-agent tool registry based on agent name.
+    // Build the per-agent tool registry based on agent name (and role, for
+    // the assistant-tier gate — see `ASSISTANT_TIER_ROLE`).
     let mut registry = super::tool_registry::build_registry_for_agent(
         name,
+        &cfg.agent.role,
         out_dir.as_deref(),
         code_dir.as_deref(),
         skill_registry.clone(),
@@ -341,6 +378,25 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
         for tool in tools::mcp_live::live_mcp_tool_executors(&cwd, &existing_names).await {
             reg.register(tool);
         }
+    }
+
+    // Assistant-tier tool scoping (#3550 follow-up): mirrors
+    // `filter_persona_tool_names` in the persona-chat dispatch path
+    // (`ctrl::pm_task::dispatch::persona`) so a persona's `[tools].allow`
+    // glob patterns are honored here too, not just in `/agent` REPL chat.
+    // See `scope_assistant_allowed_tools` for why this is necessary.
+    cfg.tools.allowed = super::tool_registry::scope_assistant_allowed_tools(
+        is_assistant_tier,
+        cfg.tools.allowed.clone(),
+        cfg.tools.allow.as_deref(),
+        registry.as_ref(),
+    );
+    if is_assistant_tier {
+        tracing::info!(
+            agent = %name,
+            tools = ?cfg.tools.allowed,
+            "assistant-tier tool registry scoped to [tools].allow"
+        );
     }
 
     let result = if let Some(reg) = registry {

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -56,7 +56,9 @@ use std::sync::Arc;
 
 use crate::{skills, tools};
 
+use tools::AgentRunner;
 use tools::SkillResolver;
+use tools::delegate::DelegateToAgentTool;
 use tools::fs_reader::{GrepFilesTool, ListDirTool, ReadFileTool};
 #[allow(unused_imports)]
 use tools::memory::{MemoryRecallTool, VectorSearchTool};
@@ -67,6 +69,26 @@ use tools::web_search::{BraveSearchTool, FetchUrlTool};
 use tools::write_file::WriteFileTool;
 use tools::{ToolRegistry, shell_exec::ShellExecTool};
 
+/// Role string shared by every black-box persona/assistant-tier agent
+/// (`assistant`, `cto-assistant`, `izzie`, `personal-assistant`, …).
+///
+/// Why: `run_subagent` (the `--direct`/`--agent` subprocess dispatch path)
+/// previously treated every agent — including personas — as a generic
+/// coding sub-agent: full CLAUDE.md project-instruction injection, the
+/// binary's coding-harness protocol, and an UNRESTRICTED
+/// `list_skills`/`load_skill` tool pair wired to the entire bundled skill
+/// catalog (every language/framework/workflow skill, not just the persona's
+/// declared `system_prompt.skills`). None of that black-box scoping the
+/// persona-chat path (`run_pm_task_with_persona`, #3550) applies here,
+/// because this path never routed through it. This constant is the single
+/// place both `tool_registry.rs` and `subagent_mode.rs` check so the
+/// definition of "assistant tier" can't drift between the two call sites.
+/// What: Matches `AgentInfo.role`, not the agent's `name` — every persona
+/// TOML/overlay sets `role = "assistant"` regardless of its display name.
+/// Test: `assistant_tier_registry_excludes_skill_catalog_tools`,
+/// `assistant_tier_registry_includes_curated_tools`.
+pub(super) const ASSISTANT_TIER_ROLE: &str = "assistant";
+
 /// Build a tool registry tailored to a specific agent.
 ///
 /// Why: Different agents need different tools (research -> web_search,
@@ -74,14 +96,26 @@ use tools::{ToolRegistry, shell_exec::ShellExecTool};
 /// discoverable; a later version could drive it from the agent TOML.
 /// What: Returns `Some(ToolRegistry)` for agents that use tools, else None.
 /// `out_dir`, if present, is used to register `advance_workflow_phase`.
-/// Test: Called during `run_subagent`.
+/// `role` (`AgentInfo.role`) is checked FIRST, ahead of the `name` match
+/// below: any agent whose role is [`ASSISTANT_TIER_ROLE`] gets the curated,
+/// black-box-safe registry from `build_assistant_tier_registry` instead of
+/// falling into the generic coding-subagent branches (or the catch-all,
+/// which would otherwise hand it an unrestricted `list_skills`/`load_skill`
+/// pair over the ENTIRE bundled skill catalog — see #3550 follow-up).
+/// Test: `assistant_tier_registry_excludes_skill_catalog_tools`,
+/// `assistant_tier_registry_includes_curated_tools`; called during
+/// `run_subagent`.
 pub(super) fn build_registry_for_agent(
     name: &str,
+    role: &str,
     out_dir: Option<&std::path::Path>,
     code_dir: Option<&std::path::Path>,
     skill_registry: Arc<skills::SkillRegistry>,
     tag_skill_registry: Arc<skills::registry::SkillRegistry>,
 ) -> Option<ToolRegistry> {
+    if role == ASSISTANT_TIER_ROLE {
+        return Some(build_assistant_tier_registry());
+    }
     // #222: When `code_dir` is set and distinct from `out_dir`, the code-agent
     // and any future tool that writes *generated source files* should root at
     // `code_dir` (the user's project tree). All other agents (plan, docs,
@@ -316,6 +350,104 @@ pub(super) fn build_registry_for_agent(
             Some(reg)
         }
     }
+}
+
+/// Curated tool registry for black-box persona/assistant-tier agents
+/// (`role == "assistant"`) dispatched via the `--direct`/`--agent`
+/// subprocess path.
+///
+/// Why: The generic per-agent branches above (and the `_` catch-all) are
+/// built for coding sub-agents and unconditionally wire an unrestricted
+/// `list_skills`/`load_skill` pair over the ENTIRE bundled skill catalog
+/// (every language, framework, and workflow skill — including
+/// `workflow/wave-planning.md` and `workflow/delegation.md`, which name
+/// internal orchestration concepts the assistant must never recite). A
+/// persona's actual domain skills are already injected as system-prompt
+/// CONTENT from its declared `system_prompt.skills` list (see
+/// `run_subagent`'s skill-resolution loop) — it never needs a
+/// catalog-browsing tool. This function gives the assistant tier a small,
+/// fixed tool set instead: delegation (so it can still genuinely act on
+/// "bring in a specialist") plus read-only git/web lookups, mirroring the
+/// tool families the persona-chat path (`run_pm_task_with_persona`)
+/// registers. Actual reachability is still narrowed by the caller
+/// (`run_subagent`) applying the persona's `[tools].allow` glob patterns —
+/// registering a tool here is not the same as granting it.
+/// What: Registers `git_log`/`git_status` (when CWD is a git repo),
+/// `web_search`, and `delegate_to_agent` (pre-flight-validated against
+/// `<cwd>/.trusty-agents/agents/`). Deliberately omits `list_skills`,
+/// `load_skill`, and every generic coding-agent tool (`write_file`,
+/// `run_bash`, analysis tools, …).
+/// Test: `assistant_tier_registry_excludes_skill_catalog_tools`,
+/// `assistant_tier_registry_includes_curated_tools`.
+pub(super) fn build_assistant_tier_registry() -> ToolRegistry {
+    let mut reg = ToolRegistry::new();
+    let cwd = std::env::current_dir().unwrap_or_default();
+
+    if let Ok(repo) = crate::git::GitRepo::open(&cwd) {
+        for tool in crate::tools::git_tools::git_tools(repo.root.clone()) {
+            reg.register(tool);
+        }
+    }
+
+    reg.register(Arc::new(BraveSearchTool::from_env()));
+
+    let config_dir = cwd.join(".trusty-agents").join("agents");
+    let runner: Arc<dyn AgentRunner> = Arc::new(
+        crate::subprocess::SubprocessAgentRunner::new().with_config_dir(Some(config_dir.clone())),
+    );
+    reg.register(Arc::new(
+        DelegateToAgentTool::new(runner).with_config_dir(config_dir),
+    ));
+
+    reg
+}
+
+/// Resolve the effective `[tools].allowed` override for the assistant-tier
+/// glob-scoping gate.
+///
+/// Why: `run_subagent_with_tools`/`run_subagent_single_shot` pass
+/// `cfg.tools.allowed` (an exact-name allowlist, `None` = unrestricted)
+/// straight into `chat_with_tools_gated`. Persona TOMLs (`assistant`,
+/// `cto-assistant`, `izzie`, `personal-assistant`) declare `[tools].allow`
+/// instead — GLOB patterns, the field the persona-chat dispatch path
+/// (`run_pm_task_with_persona` / `filter_persona_tool_names`) reads. Because
+/// `run_subagent` never consulted `allow`, an assistant-tier agent dispatched
+/// via `--direct`/`--agent` got `allowed_tools = None` — no restriction at
+/// all — regardless of its curated `allow` list. This pure function is the
+/// fix, pulled out of `run_subagent` so the glob-matching behavior is
+/// unit-testable without an LLM call.
+/// What: When `is_assistant_tier` is true, `existing_allowed` is `None`, and
+/// `allow` is `Some(patterns)`, returns `Some(<names from `registry` matching
+/// any pattern>)`. Otherwise returns `existing_allowed` unchanged — every
+/// non-persona agent, and any persona that already sets `allowed` explicitly,
+/// is untouched.
+/// Test: `scope_assistant_allowed_tools_filters_by_glob`,
+/// `scope_assistant_allowed_tools_noop_for_non_assistant`,
+/// `scope_assistant_allowed_tools_noop_when_allowed_already_set`.
+pub(super) fn scope_assistant_allowed_tools(
+    is_assistant_tier: bool,
+    existing_allowed: Option<Vec<String>>,
+    allow: Option<&[String]>,
+    registry: Option<&ToolRegistry>,
+) -> Option<Vec<String>> {
+    if !is_assistant_tier || existing_allowed.is_some() {
+        return existing_allowed;
+    }
+    let (Some(patterns), Some(reg)) = (allow, registry) else {
+        return existing_allowed;
+    };
+    let kept: Vec<String> = reg
+        .schemas()
+        .into_iter()
+        .filter_map(|s| {
+            s.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .map(String::from)
+        })
+        .filter(|n| crate::ctrl::pm_task::match_any_glob(n, patterns))
+        .collect();
+    Some(kept)
 }
 
 #[cfg(test)]

--- a/crates/trusty-agents/src/runtime/tool_registry_tests.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry_tests.rs
@@ -66,6 +66,7 @@ fn empty_tag_registry() -> Arc<skills::registry::SkillRegistry> {
 fn research_agent_registry_has_web_tools() {
     let reg = build_registry_for_agent(
         "research-agent",
+        "researcher",
         None,
         None,
         empty_skill_registry(),
@@ -87,6 +88,7 @@ fn research_agent_registry_has_memory_tools() {
     // #53: memory_recall + vector_search registered for the research agent.
     let reg = build_registry_for_agent(
         "research-agent",
+        "researcher",
         None,
         None,
         empty_skill_registry(),
@@ -103,6 +105,7 @@ fn research_agent_registry_has_readonly_fs_tools() {
     // single "find out" agent and must be able to read/grep the codebase.
     let reg = build_registry_for_agent(
         "research-agent",
+        "researcher",
         None,
         None,
         empty_skill_registry(),
@@ -120,6 +123,7 @@ fn plan_agent_registry_has_memory_tools() {
     // plans in existing code / project knowledge.
     let reg = build_registry_for_agent(
         "plan-agent",
+        "planner",
         None,
         None,
         empty_skill_registry(),
@@ -147,6 +151,7 @@ fn all_known_agents_get_skill_tools() {
     ] {
         let reg = build_registry_for_agent(
             agent,
+            "engineer",
             None,
             None,
             empty_skill_registry(),
@@ -164,6 +169,7 @@ fn plan_agent_registry_has_write_file_tool() {
     // assignments.json for interface-first decomposition.
     let reg = build_registry_for_agent(
         "plan-agent",
+        "planner",
         None,
         None,
         empty_skill_registry(),
@@ -182,6 +188,7 @@ fn docs_agent_registry_has_write_and_read_tools() {
     // can inspect generated code and emit documentation files.
     let reg = build_registry_for_agent(
         "docs-agent",
+        "documentation",
         None,
         None,
         empty_skill_registry(),
@@ -219,6 +226,7 @@ async fn list_skills_uses_tag_registry_when_wired() {
 
     let reg = build_registry_for_agent(
         "research-agent",
+        "researcher",
         None,
         None,
         empty_skill_registry(),
@@ -252,6 +260,7 @@ async fn list_skills_falls_back_to_legacy_when_tag_registry_empty() {
     // register and return a non-panicking response.
     let reg = build_registry_for_agent(
         "research-agent",
+        "researcher",
         None,
         None,
         empty_skill_registry(),
@@ -287,4 +296,151 @@ async fn web_search_without_api_key_returns_graceful_error() {
         "error should mention BRAVE_API_KEY, got: {}",
         out.content()
     );
+}
+
+// #3550 follow-up: a live smoke test proved the assistant persona still
+// leaked internal names (`trusty-mpm`, `subagent`) and recited the entire
+// bundled skill catalog (wave planning, git worktree discipline, the full
+// engineering skill bench) when dispatched via `tagent --direct assistant`,
+// even after PR #3550 hardened the SEPARATE persona-chat dispatch path. Root
+// cause: `build_registry_for_agent`'s catch-all branch unconditionally wired
+// `list_skills`/`load_skill` to the full tag-indexed skill registry for ANY
+// agent without a dedicated branch — including role=="assistant" — and the
+// caller never applied the persona's `[tools].allow` glob restriction on
+// this path (see `scope_assistant_allowed_tools` below). These tests pin
+// the fix: role-keyed dispatch to `build_assistant_tier_registry`.
+
+#[test]
+fn assistant_tier_registry_excludes_skill_catalog_tools() {
+    // A non-empty tag registry (as production wires via
+    // `default_bundled_config_dir()`) must NOT leak `list_skills`/
+    // `load_skill` into the assistant-tier registry — those tools are how
+    // the assistant could recite the entire engineering skill catalog
+    // (languages, frameworks, `workflow/wave-planning.md`,
+    // `workflow/delegation.md`, …) it has no business knowing about.
+    use tempfile::TempDir;
+    let dir = TempDir::new().unwrap();
+    std::fs::write(
+        dir.path().join("wave-planning.md"),
+        "---\nname: wave-planning\ndescription: decompose\ntags: [workflow]\n---\nbody\n",
+    )
+    .unwrap();
+    let tag_reg = Arc::new(skills::registry::SkillRegistry::load(&[dir
+        .path()
+        .to_path_buf()]));
+    assert!(!tag_reg.is_empty(), "sanity: tag registry loaded a skill");
+
+    let reg = build_registry_for_agent(
+        "assistant",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        tag_reg,
+    )
+    .expect("assistant-tier agent builds a registry");
+
+    assert!(
+        !reg.contains("list_skills"),
+        "list_skills must not be reachable from the assistant tier"
+    );
+    assert!(
+        !reg.contains("load_skill"),
+        "load_skill must not be reachable from the assistant tier"
+    );
+}
+
+#[test]
+fn assistant_tier_registry_includes_curated_tools() {
+    // The assistant tier still needs SOME way to genuinely act on "bring in
+    // a specialist" rather than only ever talking about it — delegation and
+    // web search are registered (actual reachability is still gated by
+    // `[tools].allow` at the `run_subagent` call site).
+    let reg = build_registry_for_agent(
+        "assistant",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+    )
+    .expect("assistant-tier agent builds a registry");
+    assert!(
+        reg.contains("delegate_to_agent"),
+        "delegate_to_agent missing from assistant-tier registry"
+    );
+    assert!(
+        reg.contains("web_search"),
+        "web_search missing from assistant-tier registry"
+    );
+}
+
+#[test]
+fn role_takes_precedence_over_name_for_assistant_tier() {
+    // Role gating is checked BEFORE the `name`-based match — an agent named
+    // like a coding sub-agent (e.g. a persona overlay someone accidentally
+    // names "docs-agent") must still get the curated assistant-tier
+    // registry, never the generic coding-agent tool set, when its role is
+    // "assistant".
+    let reg = build_registry_for_agent(
+        "docs-agent",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+    )
+    .expect("builds a registry");
+    assert!(
+        !reg.contains("write_file"),
+        "assistant-tier role must not get docs-agent's write_file tool"
+    );
+    assert!(reg.contains("delegate_to_agent"));
+}
+
+#[test]
+fn scope_assistant_allowed_tools_filters_by_glob() {
+    // The exact gap that caused the leak: `[tools].allow` (glob) must be
+    // translated into `[tools].allowed` (exact names) for the assistant
+    // tier, or `chat_with_tools_gated` treats the persona as unrestricted.
+    let reg = build_registry_for_agent(
+        "assistant",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+    )
+    .expect("assistant-tier agent builds a registry");
+
+    let allow = vec!["delegate_to_agent".to_string()];
+    let kept =
+        scope_assistant_allowed_tools(true, None, Some(&allow), Some(&reg)).unwrap_or_default();
+
+    assert_eq!(kept, vec!["delegate_to_agent".to_string()]);
+    assert!(
+        !kept.iter().any(|n| n == "web_search"),
+        "web_search not in the allow list must not survive scoping"
+    );
+}
+
+#[test]
+fn scope_assistant_allowed_tools_noop_for_non_assistant() {
+    // Coding sub-agents rely on `allowed == None` meaning "unrestricted"
+    // (see `ToolsConfig::allowed` doc comment) — the assistant-tier gate
+    // must never touch that default for role != "assistant".
+    let allow = vec!["git_*".to_string()];
+    let kept = scope_assistant_allowed_tools(false, None, Some(&allow), None);
+    assert_eq!(kept, None);
+}
+
+#[test]
+fn scope_assistant_allowed_tools_noop_when_allowed_already_set() {
+    // An assistant-tier agent that already sets `[tools].allowed` explicitly
+    // keeps that list untouched rather than being overwritten by the
+    // glob-derived set.
+    let existing = Some(vec!["only_this_tool".to_string()]);
+    let allow = vec!["*".to_string()];
+    let kept = scope_assistant_allowed_tools(true, existing.clone(), Some(&allow), None);
+    assert_eq!(kept, existing);
 }


### PR DESCRIPTION
## Summary

A live smoke test (`tagent --direct assistant --task "What kinds of specialists or subagents can you bring in, and how do you get engineering work done?" --plain`, built from `0d58cc85` / PR #3550) proved the assistant STILL leaked internal names and STILL disclaimed delegating, even after #3550 hardened the tool-schema/allow-list layer.

**Root cause**: `--direct`/`--agent` dispatch through `run_subagent` (`crates/trusty-agents/src/runtime/subagent_mode.rs`) — a completely separate code path from the persona-chat dispatch (`run_pm_task_with_persona`) that #3550 actually hardened. `run_subagent` treated every agent, including `role == "assistant"` personas, as a generic coding sub-agent:

- `SystemPromptBuilder::walk_project_instructions` unconditionally injected every ancestor `CLAUDE.md`/`AGENTS.md` verbatim — including this crate's own `CLAUDE.md` (documents "PM Orchestrator", "Sub-Agent Process", "subprocess IPC") and the workspace root `CLAUDE.md` (`trusty-mpm`, worktree/PR-workflow conventions).
- The binary's coding-harness protocol (`BASE_PROTOCOL` — "workflow phases", `out_dir`) was injected regardless of role.
- `build_registry_for_agent`'s catch-all branch unconditionally wired `list_skills`/`load_skill` to the FULL bundled skill catalog (every language/framework/workflow skill, including `workflow/wave-planning.md`, `workflow/delegation.md`) with **no restriction**: `run_subagent_with_tools` gates on `cfg.tools.allowed` (exact-name list), but persona TOMLs declare `[tools].allow` (glob patterns) — a field this path never read — so `allowed` stayed `None`, which `chat_with_tools_gated` treats as unrestricted.

## Fix

Role-scoped gate (`role == "assistant"`, covers `assistant`/`cto-assistant`/`izzie`/`personal-assistant` uniformly, keyed off `AgentInfo.role` not display name) inside `run_subagent`:

- Skip the CLAUDE.md/AGENTS.md project-instruction walk for assistant-tier agents.
- Skip the coding-harness-protocol layers for assistant-tier agents.
- Route registry construction to a new curated `build_assistant_tier_registry` (delegation + read-only git/web lookups; no catalog-browsing tools) instead of the generic catch-all.
- New `scope_assistant_allowed_tools` translates `[tools].allow` glob patterns into the `[tools].allowed` exact-name list the existing gate already enforces.

Engineer/qa/research/docs/ops/plan/pm/ctrl dispatch is byte-for-byte unaffected — the gate only fires for `role == "assistant"`.

Also reworded the "What you are not — Not a coding agent" identity-negation framing in `assistant/persona.md`, `izzie.toml`, and `personal-assistant.toml` (the model was echoing it near-verbatim as "not a coding agent myself") into a positive delegation-ownership frame that explicitly forbids the disclaiming phrasing.

**Triage (reported, not fixed — out of scope for this worktree):** 11 of 42 claude-mpm-format `.md` agent files under the outer checkout's `.claude/agents/` fail YAML frontmatter parsing ("mapping values are not allowed") because their `description:` field is unquoted with an embedded colon. The checked-in source templates (`crates/trusty-mpm/src/assets/agents/*.md`) already quote these correctly — the deployed copies are just stale and need redeploying (not a code bug). Confirmed this does NOT block the assistant's own delegation roster (it resolves generic names like `python-engineer` via `.trusty-agents/agents/*.toml` first, a different tier).

## Verification

Rebuilt (`SKIP_UI_BUILD=1 cargo build -p trusty-agents`) and re-ran the exact smoke test 5 times:

```
$ tagent --direct assistant --task "What kinds of specialists or subagents can you bring in, and how do you get engineering work done?" --plain
```

All 5 replies: **zero** hits for `trusty-mpm`/`trusty-code`/`tcode`/`PM session`/`subprocess`/`subagent`/`sub-agent`, and no disclaiming language — the assistant now owns delegation ("I own the outcome end to end... I get it done by bringing in a specialist").

## Test plan

- [x] `cargo check -p trusty-agents` — clean
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-agents -- --check` — clean
- [x] `cargo test -p trusty-agents --lib` — 2029 passed, 0 failed, 8 ignored
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] Live smoke test x5 — all clean, no banned terms, no disclaiming
- [x] New regression tests: `assistant_tier_registry_excludes_skill_catalog_tools`, `assistant_tier_registry_includes_curated_tools`, `role_takes_precedence_over_name_for_assistant_tier`, `scope_assistant_allowed_tools_filters_by_glob`, `scope_assistant_allowed_tools_noop_for_non_assistant`, `scope_assistant_allowed_tools_noop_when_allowed_already_set`
- [x] CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)