### PR TITLE
fix(trusty-agents): assistant can delegate to bundled worker agents regardless of cwd

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -127,6 +127,53 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     corrected to assert the NOW-CORRECT real-inheritance behavior (it
     previously asserted the absence of inheritance, which was the bug).
 
+### Fixed
+
+- **Assistant can now actually delegate to bundled worker agents (`engineer`,
+  `qa-agent`, …) regardless of the invoking CWD (#3555 follow-up):** a live
+  run (`tagent --direct assistant --task "have an engineer run cargo check
+  and report back"`) proved `delegate_to_agent` always failed with
+  `is_error=true` and no `engineer` sub-agent was ever spawned, whenever the
+  assistant was launched from a directory with no local
+  `.trusty-agents/agents/` of its own (a bare worktree root, `/tmp`, …) — the
+  model honestly reported "no engineering agent is wired up right now."
+  Root cause: `build_assistant_tier_registry`
+  (`src/runtime/tool_registry.rs`) built `delegate_to_agent`'s pre-flight
+  validation directory as a single, hand-rolled
+  `<cwd>/.trusty-agents/agents` — invisible to the bundled worker roster
+  `agents::bundled::ensure_bundled_agents_deployed` deploys to
+  `$HOME/.trusty-agents/agents/` at every startup. `AgentConfig::by_name`
+  (used by the actual spawn) already resolves through
+  `agents_dir_candidates()` — CWD/`TAGENT_CONFIG_DIR` tier, THEN the `$HOME`
+  fallback — so validation rejected names the spawn would have happily
+  found, killing the delegate call before the runner was ever invoked.
+  - `DelegateToAgentTool` (`src/tools/delegate.rs`) now validates against a
+    `Vec<PathBuf>` of candidate directories (`with_config_dirs`) instead of a
+    single `Option<PathBuf>`, checked via the new `agents::agent_name_resolves`
+    predicate (package/flat-toml/flat-md tiers — the same tiers the loader's
+    `by_name_unresolved_src_in` uses). `with_config_dir` (single dir) is kept
+    unchanged for `pm`/`ctrl`, which intentionally validate against exactly
+    one project-scoped roster.
+  - `build_assistant_tier_registry` now sources its directories from the
+    newly crate-visible `agents::agents_dir_candidates()` — the SAME
+    multi-tier list `AgentConfig::by_name` resolves against — so validation
+    and the actual spawn can never diverge again.
+  - Observability: `delegate_to_agent`'s pre-flight rejection and any
+    sub-agent run error are now logged at `debug` with the actual failure
+    reason (`src/tools/delegate.rs`); the tool-loop's per-call log
+    (`src/llm/tool_loop/mod.rs`) now includes the error content on failure
+    instead of only `is_error=true` with no payload — previously a failing
+    `delegate_to_agent` call was undebuggable at any log level.
+  - New tests: `delegate_resolves_agent_from_secondary_config_dir` and
+    `delegate_rejects_agent_absent_from_all_config_dirs`
+    (`src/tools/delegate.rs`); `agent_name_resolves_tests::*`
+    (`src/agents/tests/loading.rs`) pin the three resolution tiers plus the
+    negative/traversal cases.
+  - Live-verified end-to-end (`RUST_LOG=debug`, CWD = bare worktree root with
+    no local `.trusty-agents/agents/`): `delegate_to_agent` dispatches with
+    `is_error=false`, a real `agent=engineer` sub-agent spawns and completes,
+    and the assistant relays the engineer's actual `cargo check` findings.
+
 ### Changed
 
 - **Assistant delegates to specialists + peers; black-boxes internal tooling

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -173,6 +173,77 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     no local `.trusty-agents/agents/`): `delegate_to_agent` dispatches with
     `is_error=false`, a real `agent=engineer` sub-agent spawns and completes,
     and the assistant relays the engineer's actual `cargo check` findings.
+  - **`agent_name_resolves` edge-case fix (code-critic MEDIUM):** the real
+    resolver (`AgentConfig::by_name_in`, via `load_agent_package`'s `?`) hard
+    -aborts the ENTIRE search the moment `<dir>/<name>/` exists as a
+    directory without a readable `agent.toml`/`persona.md` inside it — it
+    does NOT fall through to a flat `<name>.toml` in a later directory.
+    `agent_name_resolves` previously kept scanning in that case (a
+    `.iter().any(...)` over all dirs), so validation could accept a name the
+    real spawn then hard-errors on. Rewrote it as an explicit per-`dir` loop
+    that mirrors the same short-circuit: on the first `<dir>/<name>/`
+    directory hit, it returns immediately based on whether BOTH
+    `agent.toml` and `persona.md` are present, exactly like the real
+    resolver either resolves or aborts right there. New pinning test
+    `agent_name_resolves_tests::short_circuits_on_malformed_directory_package_matching_real_resolver`
+    proves both `agent_name_resolves` and `AgentConfig::by_name_in` agree in
+    the same scenario. (Known, documented, deliberately-deferred limitation:
+    `agent_name_resolves` still doesn't check the legacy
+    `~/.claude/agents`/`<cwd>/.claude/agents` claude-mpm-format tier the real
+    resolver's final fallback searches — never affects the bundled roster
+    `delegate_to_agent` actually targets, since every bundled agent lives
+    under the `.trusty-agents/agents` tiers this function does check.)
+
+### Security
+
+- **CRITICAL — privilege escalation via unrestricted assistant-tier
+  delegation target, closed with a fail-closed role allowlist (#3555
+  follow-up, code-critic):** widening `delegate_to_agent`'s pre-flight
+  validation to the full `agents_dir_candidates()` multi-tier search (the fix
+  directly above) had an unreviewed consequence — it made the ENTIRE bundled
+  roster resolvable from an assistant-tier call regardless of cwd, including
+  `pm` (role `orchestrator`), `ctrl` (role `controller`), `observe-agent`
+  (role `observer`), and `postmortem-agent`/`analysis-agent` (role
+  `analysis`). `run_subagent`'s tool registry is built from the SPAWNED
+  child's own role, so an assistant delegating to `pm`/`ctrl` would have
+  handed the resulting subprocess an UNRESTRICTED orchestrator/controller
+  registry (shell, `write_file`, unrestricted `delegate_to_agent`) — an
+  escalation straight out of the sandboxed assistant tier, reopening the
+  internal-orchestration-leak class PR A (epic #3052) closed.
+  - `DelegateToAgentTool` (`src/tools/delegate.rs`) gained
+    `allowed_target_roles: Option<Vec<String>>` and a
+    `with_allowed_target_roles` builder. When set, `execute()` resolves the
+    TARGET's `AgentConfig` (via `config_dirs`) and requires its resolved
+    `agent.role` to be in the allowlist — checked BEFORE the runner is ever
+    invoked. Both "unknown agent name" and "role not allowed" return the
+    IDENTICAL generic error text, so neither leaks which case occurred or any
+    role taxonomy. `pm`/`ctrl` never call this builder — the full roster
+    remains a legitimate delegation target for them, completely unaffected.
+  - `build_assistant_tier_registry` (`src/runtime/tool_registry.rs`) now
+    wires a new `ASSISTANT_ALLOWED_DELEGATE_ROLES` constant: the exact `role`
+    field values of the bundled worker agents (`engineer`, `qa`,
+    `researcher`, `documentation`, `ops`, `planner`) plus `ASSISTANT_TIER_ROLE`
+    itself — so the Izzie ↔ cto-assistant peer-consult lane keeps working
+    (spawning a peer assistant is safe: it's routed through the SAME
+    restricted `build_assistant_tier_registry`, never an unrestricted one).
+    Any other role — orchestrator, controller, observer, analysis, or
+    anything undeclared — is rejected.
+  - New tests: `delegate_assistant_role_gate_rejects_orchestrator_role`,
+    `delegate_assistant_role_gate_rejects_controller_role`,
+    `delegate_assistant_role_gate_allows_worker_role`,
+    `delegate_assistant_role_gate_allows_peer_assistant_role`, and
+    `delegate_without_role_gate_allows_any_resolvable_role` (pins that
+    pm/ctrl are unaffected) — all in `src/tools/delegate.rs`. A `#[ignore]`d
+    live-wiring test, `runtime::tool_registry::registry_tests::
+    live_assistant_registry_rejects_pm_role`, exercises the REAL
+    `build_assistant_tier_registry()` against whatever roster is actually
+    deployed at `$HOME/.trusty-agents/agents/` (manual verification aid, not
+    a CI gate — CI's `$HOME` may have no deployed roster at all).
+  - Live-verified: the REAL production registry (built from the machine's
+    actual deployed `$HOME/.trusty-agents/agents/pm.toml`, role
+    `orchestrator`) rejects `delegate_to_agent(agent_name="pm")` without
+    invoking the runner, while a real `engineer` delegation still spawns and
+    completes normally.
 
 ### Changed
 

--- a/crates/trusty-agents/src/agents/loader.rs
+++ b/crates/trusty-agents/src/agents/loader.rs
@@ -659,7 +659,7 @@ fn agents_dir() -> PathBuf {
 /// `same_name_project_local_shadows_home_tier` (+ async),
 /// `extends_shadow_fallback_searches_home_tier_when_package_resolved_there`
 /// (tests/loading.rs).
-fn agents_dir_candidates() -> Vec<PathBuf> {
+pub(crate) fn agents_dir_candidates() -> Vec<PathBuf> {
     let primary = agents_dir();
     let mut dirs = vec![primary.clone()];
     if let Some(home) = std::env::var_os("HOME") {
@@ -669,6 +669,43 @@ fn agents_dir_candidates() -> Vec<PathBuf> {
         }
     }
     dirs
+}
+
+/// Cheap, parse-free existence check for an agent name across candidate
+/// directories, using the SAME resolution tiers as
+/// [`AgentConfig::by_name_unresolved_src_in`] (directory package, flat
+/// `.toml`, flat `.md`) — minus the `extends`-chain resolution and the
+/// `claude_mpm_loader` legacy tier, neither of which is needed to answer
+/// "does a file for this name exist somewhere in `dirs`".
+///
+/// Why (#3555 delegate-resolve follow-up): `delegate_to_agent`'s pre-flight
+/// validation must accept exactly the names `run_subagent`'s later
+/// `AgentConfig::by_name` call will actually spawn. Before this fix,
+/// `build_assistant_tier_registry` hand-rolled a SINGLE cwd-relative
+/// directory (`<cwd>/.trusty-agents/agents`) for that check — invisible to
+/// the bundled worker roster deployed at `$HOME/.trusty-agents/agents/` by
+/// [`super::bundled::ensure_bundled_agents_deployed`] — so validation
+/// rejected every delegate call whenever the assistant was launched from a
+/// directory with no local `.trusty-agents/agents/` of its own, even though
+/// the actual spawn (which resolves via [`agents_dir_candidates`]) would
+/// have found the agent fine. This function is the single source of truth
+/// both sides now share, so validation and spawn can never diverge again.
+/// What: rejects path-traversal names via `validate_agent_name`, then for
+/// each `dir` in `dirs` (in order) checks `<dir>/<name>/agent.toml`,
+/// `<dir>/<name>.toml`, `<dir>/<name>.md`; returns `true` on first hit.
+/// Test: `agent_name_resolves_finds_flat_toml_in_secondary_dir`,
+/// `agent_name_resolves_finds_directory_package`,
+/// `agent_name_resolves_false_when_absent_everywhere`,
+/// `agent_name_resolves_false_for_traversal_name` (agents/tests/loading.rs).
+pub(crate) fn agent_name_resolves(dirs: &[PathBuf], name: &str) -> bool {
+    if validate_agent_name(name).is_err() {
+        return false;
+    }
+    dirs.iter().any(|dir| {
+        dir.join(name).join("agent.toml").is_file()
+            || dir.join(format!("{name}.toml")).is_file()
+            || dir.join(format!("{name}.md")).is_file()
+    })
 }
 
 // Why: Helper kept available for ad-hoc tooling that needs the flat

--- a/crates/trusty-agents/src/agents/loader.rs
+++ b/crates/trusty-agents/src/agents/loader.rs
@@ -678,6 +678,18 @@ pub(crate) fn agents_dir_candidates() -> Vec<PathBuf> {
 /// `claude_mpm_loader` legacy tier, neither of which is needed to answer
 /// "does a file for this name exist somewhere in `dirs`".
 ///
+/// KNOWN LIMITATION (#3555 LOW follow-up, code-critic, tracked not fixed):
+/// unlike [`Self::by_name_unresolved_src_in`]'s final fallback tier
+/// (`crate::agents::claude_mpm_loader::find_agent_sync`, which additionally
+/// searches `~/.claude/agents` / `<cwd>/.claude/agents` for legacy
+/// claude-mpm-format agents), this function does NOT check that tier — a
+/// false NEGATIVE for a name that exists ONLY as a claude-mpm-format agent
+/// there. Every BUNDLED worker/assistant agent lives under the
+/// `.trusty-agents/agents` tiers this function does check, so this never
+/// affects the roster `delegate_to_agent` actually targets; adding the tier
+/// is deferred rather than folded in here since it would require this
+/// crate-visible predicate to also depend on `claude_mpm_loader`.
+///
 /// Why (#3555 delegate-resolve follow-up): `delegate_to_agent`'s pre-flight
 /// validation must accept exactly the names `run_subagent`'s later
 /// `AgentConfig::by_name` call will actually spawn. Before this fix,
@@ -690,22 +702,42 @@ pub(crate) fn agents_dir_candidates() -> Vec<PathBuf> {
 /// the actual spawn (which resolves via [`agents_dir_candidates`]) would
 /// have found the agent fine. This function is the single source of truth
 /// both sides now share, so validation and spawn can never diverge again.
-/// What: rejects path-traversal names via `validate_agent_name`, then for
-/// each `dir` in `dirs` (in order) checks `<dir>/<name>/agent.toml`,
-/// `<dir>/<name>.toml`, `<dir>/<name>.md`; returns `true` on first hit.
-/// Test: `agent_name_resolves_finds_flat_toml_in_secondary_dir`,
-/// `agent_name_resolves_finds_directory_package`,
-/// `agent_name_resolves_false_when_absent_everywhere`,
-/// `agent_name_resolves_false_for_traversal_name` (agents/tests/loading.rs).
+/// What: rejects path-traversal names via `validate_agent_name`, then walks
+/// `dirs` in order. For each `dir`, if `<dir>/<name>/` exists as a
+/// directory, this MIRRORS `load_agent_package`'s `?`-propagation in
+/// [`Self::by_name_unresolved_src_in`] (#3555 MEDIUM follow-up, code-critic):
+/// the real resolver commits to that directory as the canonical source and
+/// hard-errors — aborting the ENTIRE search, not just this `dir` — if
+/// `agent.toml` or `persona.md` inside it is missing, rather than falling
+/// through to a flat `<name>.toml` in this or a later directory. So this
+/// function returns immediately (`true` only if BOTH files are present,
+/// `false` otherwise) the moment it sees `<dir>/<name>/` as a directory,
+/// exactly like the real resolver would either resolve or hard-abort right
+/// there. Otherwise it checks `<dir>/<name>.toml` then `<dir>/<name>.md`
+/// and, on a miss, continues to the next `dir`. Returns `false` once every
+/// `dir` is exhausted with no match.
+/// Test: `agent_name_resolves_tests::finds_flat_toml_in_secondary_dir`,
+/// `agent_name_resolves_tests::finds_directory_package`,
+/// `agent_name_resolves_tests::finds_flat_md`,
+/// `agent_name_resolves_tests::false_when_absent_everywhere`,
+/// `agent_name_resolves_tests::false_for_traversal_name`,
+/// `agent_name_resolves_tests::false_on_empty_dirs`,
+/// `agent_name_resolves_tests::short_circuits_on_malformed_directory_package_matching_real_resolver`
+/// (agents/tests/loading.rs).
 pub(crate) fn agent_name_resolves(dirs: &[PathBuf], name: &str) -> bool {
     if validate_agent_name(name).is_err() {
         return false;
     }
-    dirs.iter().any(|dir| {
-        dir.join(name).join("agent.toml").is_file()
-            || dir.join(format!("{name}.toml")).is_file()
-            || dir.join(format!("{name}.md")).is_file()
-    })
+    for dir in dirs {
+        let pkg_dir = dir.join(name);
+        if pkg_dir.is_dir() {
+            return pkg_dir.join("agent.toml").is_file() && pkg_dir.join("persona.md").is_file();
+        }
+        if dir.join(format!("{name}.toml")).is_file() || dir.join(format!("{name}.md")).is_file() {
+            return true;
+        }
+    }
+    false
 }
 
 // Why: Helper kept available for ad-hoc tooling that needs the flat

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -52,3 +52,14 @@ pub use model::{FALLBACK_MODEL, ModelSource, resolve_model};
 pub(crate) use loader::agent_config_path;
 #[cfg(test)]
 pub(crate) use model::agent_env_suffix;
+
+// #3555 delegate-resolve follow-up: `agents_dir_candidates` (the
+// `[TAGENT_CONFIG_DIR`/project-local, `$HOME` fallback]` tier list
+// `AgentConfig::by_name` searches) and `agent_name_resolves` (the matching
+// existence predicate) are needed outside `agents::loader` — by
+// `tools::delegate::DelegateToAgentTool`'s pre-flight validation and by
+// `runtime::tool_registry::build_assistant_tier_registry`, so both use the
+// SAME resolution tiers the actual spawn uses instead of a hand-rolled,
+// cwd-only directory. `loader` itself stays a private submodule; only these
+// two items are widened to crate visibility.
+pub(crate) use loader::{agent_name_resolves, agents_dir_candidates};

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -1596,7 +1596,7 @@ fn all_bundled_agent_tomls_outside_the_specialist_allowlist_avoid_claude_code_ru
 /// tiers (directory package / flat toml / flat md) plus the negative cases,
 /// independent of any `AgentConfig` parsing so they don't need `ENV_LOCK`.
 mod agent_name_resolves_tests {
-    use crate::agents::agent_name_resolves;
+    use crate::agents::{AgentConfig, agent_name_resolves};
 
     #[test]
     fn finds_flat_toml_in_secondary_dir() {
@@ -1620,11 +1620,20 @@ mod agent_name_resolves_tests {
 
     #[test]
     fn finds_directory_package() {
+        // A real directory-package agent needs BOTH agent.toml AND
+        // persona.md (`load_agent_package` reads both, `?`-propagating if
+        // either is missing) — write both so this positive case matches the
+        // real resolver's requirements exactly.
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("assistant")).unwrap();
         std::fs::write(
             dir.path().join("assistant").join("agent.toml"),
             "[agent]\nname = \"assistant\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("assistant").join("persona.md"),
+            "persona body",
         )
         .unwrap();
 
@@ -1665,5 +1674,45 @@ mod agent_name_resolves_tests {
     #[test]
     fn false_on_empty_dirs() {
         assert!(!agent_name_resolves(&[], "engineer"));
+    }
+
+    /// #3555 MEDIUM follow-up (code-critic): a directory `<name>/` present
+    /// WITHOUT `agent.toml` inside it makes the REAL resolver
+    /// (`AgentConfig::by_name_in`, via `load_agent_package`'s `?`)
+    /// hard-abort the ENTIRE search the moment it hits that directory — it
+    /// does NOT fall through to a flat `<name>.toml` in a later directory.
+    /// `agent_name_resolves` must mirror that short-circuit exactly, or
+    /// validation would accept a name the actual spawn then hard-errors on.
+    /// This test proves BOTH sides agree in the same scenario.
+    #[test]
+    fn short_circuits_on_malformed_directory_package_matching_real_resolver() {
+        let malformed_primary = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(malformed_primary.path().join("engineer")).unwrap();
+        // Deliberately no agent.toml (or persona.md) inside engineer/.
+
+        let secondary_with_valid_flat = tempfile::tempdir().unwrap();
+        std::fs::write(
+            secondary_with_valid_flat.path().join("engineer.toml"),
+            "[agent]\nname = \"engineer\"\n",
+        )
+        .unwrap();
+
+        let dirs = vec![
+            malformed_primary.path().to_path_buf(),
+            secondary_with_valid_flat.path().to_path_buf(),
+        ];
+
+        assert!(
+            !agent_name_resolves(&dirs, "engineer"),
+            "must short-circuit to false, matching the real resolver's hard-abort, \
+             even though a later dir has a valid flat engineer.toml"
+        );
+
+        // Sanity: the real resolver actually agrees — it hard-errors here
+        // too, rather than silently falling through to the flat file.
+        assert!(
+            AgentConfig::by_name_in(&dirs, "engineer").is_err(),
+            "sanity: the real resolver must also hard-abort in this scenario"
+        );
     }
 }

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -1589,3 +1589,81 @@ fn all_bundled_agent_tomls_outside_the_specialist_allowlist_avoid_claude_code_ru
         dir.display()
     );
 }
+
+/// #3555 delegate-resolve follow-up: `agent_name_resolves` is the shared
+/// predicate `delegate_to_agent`'s pre-flight validation now uses instead of
+/// a single hand-rolled directory. These tests pin its three resolution
+/// tiers (directory package / flat toml / flat md) plus the negative cases,
+/// independent of any `AgentConfig` parsing so they don't need `ENV_LOCK`.
+mod agent_name_resolves_tests {
+    use crate::agents::agent_name_resolves;
+
+    #[test]
+    fn finds_flat_toml_in_secondary_dir() {
+        let empty_primary = tempfile::tempdir().unwrap();
+        let secondary = tempfile::tempdir().unwrap();
+        std::fs::write(
+            secondary.path().join("engineer.toml"),
+            "[agent]\nname = \"engineer\"\n",
+        )
+        .unwrap();
+
+        let dirs = vec![
+            empty_primary.path().to_path_buf(),
+            secondary.path().to_path_buf(),
+        ];
+        assert!(
+            agent_name_resolves(&dirs, "engineer"),
+            "must find engineer.toml in the second candidate directory"
+        );
+    }
+
+    #[test]
+    fn finds_directory_package() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("assistant")).unwrap();
+        std::fs::write(
+            dir.path().join("assistant").join("agent.toml"),
+            "[agent]\nname = \"assistant\"\n",
+        )
+        .unwrap();
+
+        let dirs = vec![dir.path().to_path_buf()];
+        assert!(agent_name_resolves(&dirs, "assistant"));
+    }
+
+    #[test]
+    fn finds_flat_md() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("izzie.md"),
+            "---\nname: izzie\nrole: assistant\n---\nbody",
+        )
+        .unwrap();
+
+        let dirs = vec![dir.path().to_path_buf()];
+        assert!(agent_name_resolves(&dirs, "izzie"));
+    }
+
+    #[test]
+    fn false_when_absent_everywhere() {
+        let primary = tempfile::tempdir().unwrap();
+        let secondary = tempfile::tempdir().unwrap();
+        let dirs = vec![primary.path().to_path_buf(), secondary.path().to_path_buf()];
+        assert!(!agent_name_resolves(&dirs, "nonexistent-agent"));
+    }
+
+    #[test]
+    fn false_for_traversal_name() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("secret.toml"), "[agent]\nname = \"x\"\n").unwrap();
+        let dirs = vec![dir.path().to_path_buf()];
+        assert!(!agent_name_resolves(&dirs, "../secret"));
+        assert!(!agent_name_resolves(&dirs, "..\\secret"));
+    }
+
+    #[test]
+    fn false_on_empty_dirs() {
+        assert!(!agent_name_resolves(&[], "engineer"));
+    }
+}

--- a/crates/trusty-agents/src/llm/tool_loop/mod.rs
+++ b/crates/trusty-agents/src/llm/tool_loop/mod.rs
@@ -402,7 +402,23 @@ pub async fn chat_with_tools_gated(
         let mut results_by_id: std::collections::HashMap<String, (String, ToolResult)> =
             std::collections::HashMap::with_capacity(tool_calls.len());
         while let Some((id, name, result)) = futs.next().await {
-            tracing::debug!(tool = %name, is_error = result.is_error(), "tool result");
+            // #3555 delegate-resolve follow-up: previously this logged only
+            // `is_error` with no payload — a tool failure (e.g.
+            // `delegate_to_agent` rejecting an unresolved agent name, or a
+            // sub-agent spawn error) was completely invisible at any log
+            // level. Log the error content too so a failing tool call is
+            // diagnosable from `RUST_LOG=debug` alone, without needing to
+            // add ad-hoc prints at every call site.
+            if result.is_error() {
+                tracing::debug!(
+                    tool = %name,
+                    is_error = true,
+                    error = %result.content(),
+                    "tool result"
+                );
+            } else {
+                tracing::debug!(tool = %name, is_error = false, "tool result");
+            }
             if result.is_fatal() {
                 tracing::warn!(
                     tool = %name,

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -89,6 +89,44 @@ use tools::{ToolRegistry, shell_exec::ShellExecTool};
 /// `assistant_tier_registry_includes_curated_tools`.
 pub(super) const ASSISTANT_TIER_ROLE: &str = "assistant";
 
+/// Fail-closed allowlist of `agent.role` values an assistant-tier
+/// `delegate_to_agent` call may target — see
+/// [`crate::tools::delegate::DelegateToAgentTool::with_allowed_target_roles`]
+/// for the full rationale.
+///
+/// Why (#3555 CRITICAL follow-up, code-critic): `agents::agents_dir_candidates()`
+/// (wired into `build_assistant_tier_registry` below) makes the ENTIRE
+/// bundled roster resolvable from any CWD, including `pm` (role
+/// `orchestrator`), `ctrl` (role `controller`), `observe-agent` (role
+/// `observer`), and `postmortem-agent`/`analysis-agent` (role `analysis`).
+/// `run_subagent`'s registry is keyed on the SPAWNED child's own role, so an
+/// assistant delegating to one of those would hand the resulting subprocess
+/// an unrestricted orchestrator/controller registry — shell, `write_file`,
+/// unrestricted `delegate_to_agent` — a privilege escalation out of the
+/// sandboxed assistant tier.
+/// What: the exact `role` field values declared in each bundled worker's
+/// `agent.toml` (NOT the agent/file name — `qa-agent.toml` declares
+/// `role = "qa"`, not `"qa-agent"`) plus [`ASSISTANT_TIER_ROLE`] itself, so
+/// the Izzie <-> cto-assistant peer-consult lane keeps working: spawning a
+/// peer assistant is safe because IT ALSO gets routed through
+/// `build_assistant_tier_registry` (the same restricted registry), never an
+/// unrestricted one. Any role not in this list — including anything not yet
+/// declared in the bundled roster — is rejected.
+/// Test: `delegate_assistant_role_gate_rejects_orchestrator_role`,
+/// `delegate_assistant_role_gate_rejects_controller_role`,
+/// `delegate_assistant_role_gate_allows_worker_role`,
+/// `delegate_assistant_role_gate_allows_peer_assistant_role`
+/// (`src/tools/delegate.rs`).
+pub(super) const ASSISTANT_ALLOWED_DELEGATE_ROLES: &[&str] = &[
+    "engineer",          // engineer.toml, code-agent.toml, python-engineer.toml, …
+    "qa",                // qa-agent.toml
+    "researcher",        // research-agent.toml
+    "documentation",     // docs-agent.toml
+    "ops",               // local-ops-agent.toml
+    "planner",           // plan-agent.toml
+    ASSISTANT_TIER_ROLE, // peer assistant personas: izzie, cto-assistant, personal-assistant, …
+];
+
 /// Build a tool registry tailored to a specific agent.
 ///
 /// Why: Different agents need different tools (research -> web_search,
@@ -377,8 +415,11 @@ pub(super) fn build_registry_for_agent(
 /// tier `agents::agents_dir_candidates()` searches — CWD/`TAGENT_CONFIG_DIR`
 /// first, then `$HOME/.trusty-agents/agents`, the SAME tiers the actual
 /// sub-agent spawn resolves against — see #3555 delegate-resolve follow-up
-/// below). Deliberately omits `list_skills`, `load_skill`, and every generic
-/// coding-agent tool (`write_file`, `run_bash`, analysis tools, …).
+/// below — AND gated to [`ASSISTANT_ALLOWED_DELEGATE_ROLES`] via
+/// `with_allowed_target_roles`, #3555 CRITICAL follow-up, so a wider
+/// resolution search can never turn into a privilege escalation). Deliberately
+/// omits `list_skills`, `load_skill`, and every generic coding-agent tool
+/// (`write_file`, `run_bash`, analysis tools, …).
 /// Test: `assistant_tier_registry_excludes_skill_catalog_tools`,
 /// `assistant_tier_registry_includes_curated_tools`.
 pub(super) fn build_assistant_tier_registry() -> ToolRegistry {
@@ -410,8 +451,20 @@ pub(super) fn build_assistant_tier_registry() -> ToolRegistry {
     let runner: Arc<dyn AgentRunner> = Arc::new(
         crate::subprocess::SubprocessAgentRunner::new().with_config_dir(primary_config_dir),
     );
+    // #3555 CRITICAL follow-up: role-gate the assistant tier's delegation
+    // target to workers + peer assistants ONLY — see
+    // `ASSISTANT_ALLOWED_DELEGATE_ROLES`. `pm`/`ctrl` build their own
+    // `DelegateToAgentTool` elsewhere (`ctrl/pm_task/dispatch/*.rs`) and never
+    // call `with_allowed_target_roles`, so they are completely unaffected.
     reg.register(Arc::new(
-        DelegateToAgentTool::new(runner).with_config_dirs(config_dirs),
+        DelegateToAgentTool::new(runner)
+            .with_config_dirs(config_dirs)
+            .with_allowed_target_roles(
+                ASSISTANT_ALLOWED_DELEGATE_ROLES
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            ),
     ));
 
     reg

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -373,10 +373,12 @@ pub(super) fn build_registry_for_agent(
 /// (`run_subagent`) applying the persona's `[tools].allow` glob patterns —
 /// registering a tool here is not the same as granting it.
 /// What: Registers `git_log`/`git_status` (when CWD is a git repo),
-/// `web_search`, and `delegate_to_agent` (pre-flight-validated against
-/// `<cwd>/.trusty-agents/agents/`). Deliberately omits `list_skills`,
-/// `load_skill`, and every generic coding-agent tool (`write_file`,
-/// `run_bash`, analysis tools, …).
+/// `web_search`, and `delegate_to_agent` (pre-flight-validated against every
+/// tier `agents::agents_dir_candidates()` searches — CWD/`TAGENT_CONFIG_DIR`
+/// first, then `$HOME/.trusty-agents/agents`, the SAME tiers the actual
+/// sub-agent spawn resolves against — see #3555 delegate-resolve follow-up
+/// below). Deliberately omits `list_skills`, `load_skill`, and every generic
+/// coding-agent tool (`write_file`, `run_bash`, analysis tools, …).
 /// Test: `assistant_tier_registry_excludes_skill_catalog_tools`,
 /// `assistant_tier_registry_includes_curated_tools`.
 pub(super) fn build_assistant_tier_registry() -> ToolRegistry {
@@ -391,12 +393,25 @@ pub(super) fn build_assistant_tier_registry() -> ToolRegistry {
 
     reg.register(Arc::new(BraveSearchTool::from_env()));
 
-    let config_dir = cwd.join(".trusty-agents").join("agents");
+    // #3555 delegate-resolve follow-up: previously this was a single
+    // hand-rolled `cwd.join(".trusty-agents").join("agents")` — invisible to
+    // the bundled worker roster (`engineer`, `qa-agent`, …) that
+    // `agents::bundled::ensure_bundled_agents_deployed` deploys to
+    // `$HOME/.trusty-agents/agents/` at startup. Any assistant launched from
+    // a directory without its OWN local `.trusty-agents/agents/` (e.g. a bare
+    // worktree root, `/tmp`) failed `delegate_to_agent`'s pre-flight check
+    // before ever reaching the runner — `is_error=true` with no engineer
+    // sub-agent ever spawned. `agents_dir_candidates()` is the exact
+    // multi-tier list `AgentConfig::by_name` uses for the actual spawn (see
+    // `run_subagent`), so validation and spawn now share one source of truth
+    // and can never diverge.
+    let config_dirs = crate::agents::agents_dir_candidates();
+    let primary_config_dir = config_dirs.first().cloned();
     let runner: Arc<dyn AgentRunner> = Arc::new(
-        crate::subprocess::SubprocessAgentRunner::new().with_config_dir(Some(config_dir.clone())),
+        crate::subprocess::SubprocessAgentRunner::new().with_config_dir(primary_config_dir),
     );
     reg.register(Arc::new(
-        DelegateToAgentTool::new(runner).with_config_dir(config_dir),
+        DelegateToAgentTool::new(runner).with_config_dirs(config_dirs),
     ));
 
     reg

--- a/crates/trusty-agents/src/runtime/tool_registry_tests.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry_tests.rs
@@ -444,3 +444,50 @@ fn scope_assistant_allowed_tools_noop_when_allowed_already_set() {
     let kept = scope_assistant_allowed_tools(true, existing.clone(), Some(&allow), None);
     assert_eq!(kept, existing);
 }
+
+/// #3555 CRITICAL follow-up (code-critic) — live wiring check, `#[ignore]`d
+/// by default.
+///
+/// Why: The deterministic regression tests for the role gate itself live in
+/// `src/tools/delegate.rs` (`delegate_assistant_role_gate_rejects_*`), using
+/// a hand-built `DelegateToAgentTool` + tempdir so they're fast and
+/// environment-independent. This test instead exercises the REAL production
+/// wiring — `build_assistant_tier_registry()` unmodified, resolving against
+/// whatever roster is ACTUALLY deployed at `$HOME/.trusty-agents/agents/` on
+/// the machine running it (via `agents::bundled::ensure_bundled_agents_deployed`,
+/// which every `tagent` invocation runs at startup) — as an end-to-end proof
+/// that the role gate is really wired into the registry an assistant-tier
+/// sub-agent actually gets, not just proven in isolation. `#[ignore]`d
+/// because CI's `$HOME` may not have a deployed roster at all (in which case
+/// `pm` simply fails to resolve rather than exercising the role check
+/// specifically) — this is a manual/local verification aid, not a CI gate.
+/// Run with `cargo test -p trusty-agents --lib -- --ignored
+/// live_assistant_registry_rejects_pm_role`.
+/// What: builds the real registry, dispatches `delegate_to_agent` with
+/// `agent_name: "pm"`, and asserts the result is an error. Never spawns a
+/// subprocess (the role gate rejects before the runner is invoked) — no
+/// network or credentials required either way.
+/// Test: itself (manual verification only).
+#[tokio::test]
+#[ignore]
+async fn live_assistant_registry_rejects_pm_role() {
+    let reg = build_assistant_tier_registry();
+    assert!(
+        reg.contains("delegate_to_agent"),
+        "sanity: delegate_to_agent must be registered"
+    );
+
+    let result = reg
+        .dispatch(
+            "delegate_to_agent",
+            serde_json::json!({"agent_name": "pm", "task": "diagnostic ping"}),
+        )
+        .await;
+
+    assert!(
+        result.is_error(),
+        "delegate_to_agent(agent_name=\"pm\") against the REAL deployed roster \
+         must be rejected by the role gate, got: {}",
+        result.content()
+    );
+}

--- a/crates/trusty-agents/src/tools/delegate.rs
+++ b/crates/trusty-agents/src/tools/delegate.rs
@@ -51,6 +51,36 @@ pub struct DelegateToAgentTool {
     /// (`agents::agents_dir_candidates()`) the actual spawn resolves
     /// against, so validation and spawn can never diverge.
     config_dirs: Vec<PathBuf>,
+    /// Fail-closed allowlist of TARGET agent `role` strings this instance may
+    /// delegate to. `None` (the default / `pm`/`ctrl` callers) performs no
+    /// role check — the full on-disk roster is a legitimate target for those
+    /// callers. `Some(roles)` requires the resolved target's `agent.role` to
+    /// be a member of `roles`; anything else (including a name that fails to
+    /// resolve at all) is rejected with the SAME generic error `config_dirs`
+    /// validation already returns, before any resolution artifact or role
+    /// name is ever surfaced.
+    ///
+    /// Why (#3555 CRITICAL follow-up, code-critic): widening `config_dirs` to
+    /// include the `$HOME` fallback tier means an assistant-tier
+    /// `delegate_to_agent` can now resolve ANY bundled agent from that tier —
+    /// including `pm` (role `orchestrator`), `ctrl` (role `controller`),
+    /// `observe-agent` (role `observer`), and `postmortem-agent`/
+    /// `analysis-agent` (role `analysis`). `run_subagent`'s tool registry is
+    /// built from the SPAWNED child's own role
+    /// (`build_registry_for_agent`/`build_assistant_tier_registry`), so
+    /// spawning `pm` or `ctrl` from an assistant-tier call would hand the
+    /// resulting subprocess an UNRESTRICTED orchestrator/controller registry
+    /// (shell, `write_file`, unrestricted `delegate_to_agent`) — a privilege
+    /// escalation straight out of the sandboxed assistant, and a reopening
+    /// of the internal-orchestration-leak class #3052 PR A closed. This field
+    /// gates that at the SAME choke point every other pre-flight check
+    /// already lives at, before resolution or spawn.
+    /// What: See `with_allowed_target_roles`.
+    /// Test: `delegate_assistant_role_gate_rejects_orchestrator_role`,
+    /// `delegate_assistant_role_gate_rejects_controller_role`,
+    /// `delegate_assistant_role_gate_allows_worker_role`,
+    /// `delegate_assistant_role_gate_allows_peer_assistant_role`.
+    allowed_target_roles: Option<Vec<String>>,
 }
 
 impl DelegateToAgentTool {
@@ -67,6 +97,7 @@ impl DelegateToAgentTool {
         Self {
             runner,
             config_dirs: Vec::new(),
+            allowed_target_roles: None,
         }
     }
 
@@ -108,6 +139,31 @@ impl DelegateToAgentTool {
     /// `delegate_rejects_agent_absent_from_all_config_dirs`.
     pub fn with_config_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
         self.config_dirs = dirs;
+        self
+    }
+
+    /// Restrict delegation targets to agents whose resolved `agent.role` is
+    /// in `roles` — a fail-closed allowlist gate (#3555 CRITICAL follow-up).
+    ///
+    /// Why: See the field doc on `allowed_target_roles`. `pm`/`ctrl` never
+    /// call this — the full roster is a legitimate delegation target for
+    /// them; only `build_assistant_tier_registry` wires it, so an
+    /// assistant-tier persona can genuinely act on "bring in a specialist"
+    /// (or consult a peer assistant) WITHOUT being able to spawn an
+    /// orchestrator/controller/observer subprocess with an unrestricted tool
+    /// registry.
+    /// What: Stores `roles`. `execute()` resolves the target's `AgentConfig`
+    /// (via `config_dirs`) and rejects with the SAME generic "not a
+    /// recognized specialist" error used for a missing agent, whether the
+    /// name fails to resolve at all OR resolves to a role outside `roles` —
+    /// the caller never learns which case it hit, so no role taxonomy or
+    /// on-disk roster leaks.
+    /// Test: `delegate_assistant_role_gate_rejects_orchestrator_role`,
+    /// `delegate_assistant_role_gate_rejects_controller_role`,
+    /// `delegate_assistant_role_gate_allows_worker_role`,
+    /// `delegate_assistant_role_gate_allows_peer_assistant_role`.
+    pub fn with_allowed_target_roles(mut self, roles: Vec<String>) -> Self {
+        self.allowed_target_roles = Some(roles);
         self
     }
 }
@@ -175,21 +231,58 @@ impl ToolExecutor for DelegateToAgentTool {
         // The failure reason is logged at `debug` here (content never left
         // the tool before #3555 — `is_error=true` with no payload anywhere
         // made this undebuggable in production).
-        if !self.config_dirs.is_empty()
-            && !crate::agents::agent_name_resolves(&self.config_dirs, agent_name)
-        {
-            tracing::debug!(
-                agent_name,
-                config_dirs = ?self.config_dirs,
-                "delegate_to_agent: agent not found in any candidate directory"
-            );
-            return ToolResult::err(format!(
-                "'{agent_name}' is not a recognized specialist. Check your own \
-                 instructions for the specialists available to you — native tools \
-                 (search_code, web_search, move_file, create_dir, memory_store, \
-                 memory_recall, etc.) are NOT specialist names; call them directly \
-                 as tools instead of via delegate_to_agent."
-            ));
+        //
+        // #3555 CRITICAL follow-up (code-critic): when `allowed_target_roles`
+        // is set (assistant tier only), existence is NOT enough — the
+        // TARGET's resolved role must also be in the allowlist, checked
+        // BEFORE any resolution artifact is used further or a spawn is
+        // attempted. See the field doc on `allowed_target_roles` for why
+        // (privilege escalation via delegating to `pm`/`ctrl`/etc.). Both the
+        // "unknown name" and "role not allowed" cases return the identical
+        // generic message below so neither leaks which one occurred.
+        if !self.config_dirs.is_empty() {
+            let rejected = if let Some(allowed_roles) = &self.allowed_target_roles {
+                match crate::agents::AgentConfig::by_name_in(&self.config_dirs, agent_name) {
+                    Ok(cfg) => {
+                        let allowed = allowed_roles.iter().any(|r| r == &cfg.agent.role);
+                        if !allowed {
+                            tracing::debug!(
+                                agent_name,
+                                target_role = %cfg.agent.role,
+                                allowed_roles = ?allowed_roles,
+                                "delegate_to_agent: target role not in the assistant-tier allowlist"
+                            );
+                        }
+                        !allowed
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            agent_name,
+                            error = %format!("{e:#}"),
+                            "delegate_to_agent: role-gated target failed to resolve"
+                        );
+                        true
+                    }
+                }
+            } else if !crate::agents::agent_name_resolves(&self.config_dirs, agent_name) {
+                tracing::debug!(
+                    agent_name,
+                    config_dirs = ?self.config_dirs,
+                    "delegate_to_agent: agent not found in any candidate directory"
+                );
+                true
+            } else {
+                false
+            };
+            if rejected {
+                return ToolResult::err(format!(
+                    "'{agent_name}' is not a recognized specialist. Check your own \
+                     instructions for the specialists available to you — native tools \
+                     (search_code, web_search, move_file, create_dir, memory_store, \
+                     memory_recall, etc.) are NOT specialist names; call them directly \
+                     as tools instead of via delegate_to_agent."
+                ));
+            }
         }
 
         // Detect coding persona + language idiom skill from the task and
@@ -469,5 +562,202 @@ mod tests {
 
         assert!(result.is_error(), "must reject an agent absent everywhere");
         assert!(runner.invoked.lock().unwrap().is_empty());
+    }
+
+    /// Writes a minimal, fully-parseable agent TOML with the given `role` —
+    /// the shape `AgentConfig::by_name_in` (used by the role gate) actually
+    /// requires, unlike the bare `[agent]\nname = "..."` fixtures the
+    /// existence-only tests above use (those never parse the file).
+    fn write_agent_toml_with_role(dir: &std::path::Path, name: &str, role: &str) {
+        std::fs::write(
+            dir.join(format!("{name}.toml")),
+            format!(
+                r#"
+[agent]
+name = "{name}"
+role = "{role}"
+model = "anthropic/claude-sonnet-4-6"
+description = "test fixture"
+
+[llm]
+temperature = 0.2
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#
+            ),
+        )
+        .unwrap();
+    }
+
+    /// #3555 CRITICAL follow-up (code-critic): privilege escalation via
+    /// unrestricted delegation target. Widening `config_dirs` to include the
+    /// `$HOME` fallback tier makes the FULL bundled roster resolvable from
+    /// any cwd — including `pm` (role `orchestrator`). Without a role gate,
+    /// an assistant-tier `delegate_to_agent(agent_name="pm")` would pass
+    /// validation and spawn a subprocess with `run_subagent`'s UNRESTRICTED
+    /// orchestrator registry (shell, write_file, unrestricted
+    /// delegate_to_agent) — an escalation straight out of the sandboxed
+    /// assistant. This test proves the role gate rejects it before the
+    /// runner is ever invoked, with the SAME generic error text (no role
+    /// taxonomy leak).
+    #[tokio::test]
+    async fn delegate_assistant_role_gate_rejects_orchestrator_role() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent_toml_with_role(dir.path(), "pm", "orchestrator");
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone())
+            .with_config_dirs(vec![dir.path().to_path_buf()])
+            .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
+
+        let result = tool
+            .execute(json!({
+                "agent_name": "pm",
+                "task": "do orchestrator-tier things"
+            }))
+            .await;
+
+        assert!(
+            result.is_error(),
+            "role gate must reject a resolvable but disallowed-role target"
+        );
+        assert!(
+            result.content().contains("pm"),
+            "error may echo back the caller's own rejected input, got: {}",
+            result.content()
+        );
+        assert!(
+            !result.content().to_lowercase().contains("orchestrator"),
+            "error must not leak the target's actual role, got: {}",
+            result.content()
+        );
+        assert!(
+            runner.invoked.lock().unwrap().is_empty(),
+            "runner must not be called when the role gate rejects"
+        );
+    }
+
+    /// Sibling to `delegate_assistant_role_gate_rejects_orchestrator_role`
+    /// for `ctrl` (role `controller`) — the other privileged meta-agent
+    /// named in the CRITICAL finding.
+    #[tokio::test]
+    async fn delegate_assistant_role_gate_rejects_controller_role() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent_toml_with_role(dir.path(), "ctrl", "controller");
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone())
+            .with_config_dirs(vec![dir.path().to_path_buf()])
+            .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
+
+        let result = tool
+            .execute(json!({
+                "agent_name": "ctrl",
+                "task": "do controller-tier things"
+            }))
+            .await;
+
+        assert!(result.is_error(), "role gate must reject role=controller");
+        assert!(runner.invoked.lock().unwrap().is_empty());
+    }
+
+    /// The positive case: a worker role (`engineer`) IS in the allowlist and
+    /// must still reach the runner — the role gate must not become a
+    /// blanket denial.
+    #[tokio::test]
+    async fn delegate_assistant_role_gate_allows_worker_role() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent_toml_with_role(dir.path(), "engineer", "engineer");
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone())
+            .with_config_dirs(vec![dir.path().to_path_buf()])
+            .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
+
+        let result = tool
+            .execute(json!({
+                "agent_name": "engineer",
+                "task": "run cargo check"
+            }))
+            .await;
+
+        assert!(
+            !result.is_error(),
+            "worker role must pass the gate: {}",
+            result.content()
+        );
+        assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+    }
+
+    /// The other positive case: a PEER assistant (role `assistant`, e.g.
+    /// `cto-assistant`) must still reach the runner — this is the
+    /// Izzie <-> cto-assistant peer-consult lane the role gate must
+    /// preserve. Spawning a peer is safe because IT ALSO gets routed
+    /// through the restricted assistant-tier registry, never an
+    /// unrestricted one.
+    #[tokio::test]
+    async fn delegate_assistant_role_gate_allows_peer_assistant_role() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent_toml_with_role(dir.path(), "cto-assistant", "assistant");
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone())
+            .with_config_dirs(vec![dir.path().to_path_buf()])
+            .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
+
+        let result = tool
+            .execute(json!({
+                "agent_name": "cto-assistant",
+                "task": "consult on architecture"
+            }))
+            .await;
+
+        assert!(
+            !result.is_error(),
+            "peer assistant role must pass the gate: {}",
+            result.content()
+        );
+        assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+    }
+
+    /// Without `with_allowed_target_roles` (pm/ctrl callers), the role gate
+    /// is a no-op — the existing existence-only check still governs, and a
+    /// name resolving to ANY role (including `orchestrator`/`controller`)
+    /// reaches the runner. Pins that widening the assistant tier's gate did
+    /// NOT change pm/ctrl's own delegation behavior.
+    #[tokio::test]
+    async fn delegate_without_role_gate_allows_any_resolvable_role() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent_toml_with_role(dir.path(), "pm", "orchestrator");
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone())
+            .with_config_dirs(vec![dir.path().to_path_buf()]);
+
+        let result = tool
+            .execute(json!({
+                "agent_name": "pm",
+                "task": "do orchestrator-tier things"
+            }))
+            .await;
+
+        assert!(
+            !result.is_error(),
+            "pm/ctrl callers (no role gate) must be unaffected: {}",
+            result.content()
+        );
+        assert_eq!(runner.invoked.lock().unwrap().len(), 1);
     }
 }

--- a/crates/trusty-agents/src/tools/delegate.rs
+++ b/crates/trusty-agents/src/tools/delegate.rs
@@ -35,12 +35,22 @@ use crate::tools::traits::{AgentRunner, ToolExecutor, ToolResult};
 /// Tool executor that delegates a task to a named specialist agent.
 pub struct DelegateToAgentTool {
     runner: Arc<dyn AgentRunner>,
-    /// Directory holding `<agent>.toml` files. When `Some`, `execute()` will
-    /// reject calls whose `agent_name` does not have a matching TOML, with a
-    /// generic error (#3052 PR A: no on-disk roster enumeration — see the
-    /// module docs). When `None` (legacy callers / tests), validation is
-    /// skipped and the runner is invoked directly.
-    config_dir: Option<PathBuf>,
+    /// Candidate directories searched (in order) for `<agent>.toml` /
+    /// `<agent>/agent.toml` / `<agent>.md` during pre-flight `agent_name`
+    /// validation. When non-empty, `execute()` rejects calls whose
+    /// `agent_name` resolves in NONE of them, with a generic error (#3052 PR
+    /// A: no on-disk roster enumeration — see the module docs). When empty
+    /// (legacy callers / tests via `new()` alone), validation is skipped and
+    /// the runner is invoked directly.
+    ///
+    /// #3555 delegate-resolve follow-up: this used to be a single
+    /// `Option<PathBuf>`, populated by `build_assistant_tier_registry` with
+    /// only the CWD-relative `.trusty-agents/agents` — invisible to the
+    /// bundled worker roster deployed at `$HOME/.trusty-agents/agents/`.
+    /// Widening to a `Vec` lets callers pass the same multi-tier list
+    /// (`agents::agents_dir_candidates()`) the actual spawn resolves
+    /// against, so validation and spawn can never diverge.
+    config_dirs: Vec<PathBuf>,
 }
 
 impl DelegateToAgentTool {
@@ -49,19 +59,19 @@ impl DelegateToAgentTool {
     /// Why: Lets tests substitute an in-process mock runner without touching
     /// production subprocess code.
     /// What: Stores the `Arc<dyn AgentRunner>` for later dispatch. No
-    /// pre-flight name validation is performed unless `with_config_dir` is
-    /// also called.
+    /// pre-flight name validation is performed unless `with_config_dir`/
+    /// `with_config_dirs` is also called.
     /// Test: `DelegateToAgentTool::new(Arc::new(MockRunner))` compiles and
     /// yields a tool whose `name()` is `delegate_to_agent`.
     pub fn new(runner: Arc<dyn AgentRunner>) -> Self {
         Self {
             runner,
-            config_dir: None,
+            config_dirs: Vec::new(),
         }
     }
 
-    /// Attach an agent config directory used for pre-flight `agent_name`
-    /// validation.
+    /// Attach a SINGLE agent config directory used for pre-flight
+    /// `agent_name` validation.
     ///
     /// Why: When the LLM hallucinates an agent name (e.g. `code-searcher`
     /// from the `search_code` native tool, #204), spawning the subprocess
@@ -70,11 +80,34 @@ impl DelegateToAgentTool {
     /// the next turn by re-checking its OWN instructions for the specialists
     /// legitimately available to it — this tool does not enumerate the
     /// on-disk roster (#3052 PR A code-critic CRITICAL-2).
-    /// What: Stores `dir`. Files matching `<dir>/<agent_name>.toml` are
-    /// considered valid. Missing dir is treated like "no agents available".
+    /// What: Sets `config_dirs` to the single-element `[dir]`. Kept as the
+    /// primary constructor for callers (`pm`, `ctrl`) that intentionally
+    /// validate against exactly one project-scoped roster and must NOT fall
+    /// back to any other tier. Use `with_config_dirs` for a multi-tier
+    /// search (e.g. the assistant tier's bundled-roster fallback).
     /// Test: `unknown_agent_is_rejected_without_naming_the_agent_or_roster`.
     pub fn with_config_dir(mut self, dir: PathBuf) -> Self {
-        self.config_dir = Some(dir);
+        self.config_dirs = vec![dir];
+        self
+    }
+
+    /// Attach MULTIPLE candidate agent config directories, searched in order,
+    /// for pre-flight `agent_name` validation.
+    ///
+    /// Why (#3555 delegate-resolve follow-up): the assistant tier must
+    /// delegate to the bundled worker roster (`engineer`, `qa-agent`, …)
+    /// regardless of the invoking CWD. `AgentConfig::by_name` already
+    /// resolves this way via `agents_dir_candidates()` (CWD/`TAGENT_CONFIG_DIR`
+    /// tier, then `$HOME/.trusty-agents/agents`, which
+    /// `agents::bundled::ensure_bundled_agents_deployed` populates at
+    /// startup) — a single-directory check here would reject names the
+    /// actual spawn resolves fine.
+    /// What: Sets `config_dirs` to `dirs` verbatim. An empty `Vec` behaves
+    /// identically to the default (unset) constructor — validation skipped.
+    /// Test: `delegate_resolves_agent_from_secondary_config_dir`,
+    /// `delegate_rejects_agent_absent_from_all_config_dirs`.
+    pub fn with_config_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
+        self.config_dirs = dirs;
         self
     }
 }
@@ -118,10 +151,10 @@ impl ToolExecutor for DelegateToAgentTool {
             return ToolResult::err("delegate_to_agent: missing 'task'");
         };
 
-        // Pre-flight validation (#204): if a config_dir was attached, verify
-        // the agent TOML exists before spawning a subprocess. This converts a
-        // generic "subprocess failed" IO error into a structured tool error
-        // the LLM can act on.
+        // Pre-flight validation (#204): if any config_dirs were attached,
+        // verify the agent resolves in at least one of them before spawning
+        // a subprocess. This converts a generic "subprocess failed" IO error
+        // into a structured tool error the LLM can act on.
         //
         // #3052 PR A code-critic CRITICAL-2: the error message MUST NOT
         // enumerate the on-disk agent roster — this tool is now reachable
@@ -135,17 +168,28 @@ impl ToolExecutor for DelegateToAgentTool {
         // conversation. `available_agents()` is kept (used by tests only
         // now) rather than deleted, since a future caller-gated surface
         // (e.g. an internal-only diagnostic) may still want it.
-        if let Some(dir) = &self.config_dir {
-            let agent_toml = dir.join(format!("{agent_name}.toml"));
-            if !agent_toml.exists() {
-                return ToolResult::err(format!(
-                    "'{agent_name}' is not a recognized specialist. Check your own \
-                     instructions for the specialists available to you — native tools \
-                     (search_code, web_search, move_file, create_dir, memory_store, \
-                     memory_recall, etc.) are NOT specialist names; call them directly \
-                     as tools instead of via delegate_to_agent."
-                ));
-            }
+        //
+        // #3555 delegate-resolve follow-up: uses `agents::agent_name_resolves`
+        // (package/flat-toml/flat-md tiers) across ALL `config_dirs`, not a
+        // single hand-rolled directory — see the field doc on `config_dirs`.
+        // The failure reason is logged at `debug` here (content never left
+        // the tool before #3555 — `is_error=true` with no payload anywhere
+        // made this undebuggable in production).
+        if !self.config_dirs.is_empty()
+            && !crate::agents::agent_name_resolves(&self.config_dirs, agent_name)
+        {
+            tracing::debug!(
+                agent_name,
+                config_dirs = ?self.config_dirs,
+                "delegate_to_agent: agent not found in any candidate directory"
+            );
+            return ToolResult::err(format!(
+                "'{agent_name}' is not a recognized specialist. Check your own \
+                 instructions for the specialists available to you — native tools \
+                 (search_code, web_search, move_file, create_dir, memory_store, \
+                 memory_recall, etc.) are NOT specialist names; call them directly \
+                 as tools instead of via delegate_to_agent."
+            ));
         }
 
         // Detect coding persona + language idiom skill from the task and
@@ -157,7 +201,20 @@ impl ToolExecutor for DelegateToAgentTool {
         match self.runner.run(agent_name, &final_task).await {
             // PM gets the full content (it may want to inspect code sections).
             Ok(out) => ToolResult::ok(out.content),
-            Err(e) => ToolResult::err(format!("sub-agent '{agent_name}' failed: {e:#}")),
+            Err(e) => {
+                // #3555 delegate-resolve follow-up: log the full error chain
+                // at debug so a spawn/resolution failure is diagnosable
+                // locally, even though the ToolResult sent back to the LLM
+                // stays generic-safe (it already carries `{e:#}` too, but
+                // `tool_loop`'s turn-level log previously logged only
+                // `is_error=true` and dropped the content entirely).
+                tracing::debug!(
+                    agent_name,
+                    error = %format!("{e:#}"),
+                    "delegate_to_agent: sub-agent run failed"
+                );
+                ToolResult::err(format!("sub-agent '{agent_name}' failed: {e:#}"))
+            }
         }
     }
 }
@@ -339,5 +396,78 @@ mod tests {
 
         assert!(!result.is_error(), "legacy mode should bypass validation");
         assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+    }
+
+    /// #3555 delegate-resolve regression guard: the primary use case this
+    /// fix targets — an assistant launched from a CWD with NO local
+    /// `.trusty-agents/agents/` (empty tempdir, standing in for e.g. a bare
+    /// worktree root) must still successfully delegate to a bundled worker
+    /// agent that only exists in the SECONDARY tier (standing in for
+    /// `$HOME/.trusty-agents/agents/`, populated by
+    /// `agents::bundled::ensure_bundled_agents_deployed`). Before the fix,
+    /// `DelegateToAgentTool` only ever checked a single directory, so this
+    /// would have rejected the call before the runner was ever invoked —
+    /// exactly the reported symptom (`is_error=true`, no `engineer` spawn).
+    #[tokio::test]
+    async fn delegate_resolves_agent_from_secondary_config_dir() {
+        let empty_primary = tempfile::tempdir().unwrap();
+        let secondary = tempfile::tempdir().unwrap();
+        std::fs::write(
+            secondary.path().join("engineer.toml"),
+            "[agent]\nname = \"engineer\"\n",
+        )
+        .unwrap();
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone()).with_config_dirs(vec![
+            empty_primary.path().to_path_buf(),
+            secondary.path().to_path_buf(),
+        ]);
+
+        let result = tool
+            .execute(json!({
+                "agent_name": "engineer",
+                "task": "run cargo check and report back"
+            }))
+            .await;
+
+        assert!(
+            !result.is_error(),
+            "agent present only in the secondary (fallback) tier must still resolve: {}",
+            result.content()
+        );
+        let invoked = runner.invoked.lock().unwrap();
+        assert_eq!(invoked.len(), 1, "runner should be called exactly once");
+        assert_eq!(invoked[0].0, "engineer");
+    }
+
+    /// The multi-tier counterpart to
+    /// `unknown_agent_is_rejected_without_naming_the_agent_or_roster`: when
+    /// an agent name is absent from EVERY candidate directory, validation
+    /// still rejects before the runner is invoked.
+    #[tokio::test]
+    async fn delegate_rejects_agent_absent_from_all_config_dirs() {
+        let primary = tempfile::tempdir().unwrap();
+        let secondary = tempfile::tempdir().unwrap();
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone()).with_config_dirs(vec![
+            primary.path().to_path_buf(),
+            secondary.path().to_path_buf(),
+        ]);
+
+        let result = tool
+            .execute(json!({
+                "agent_name": "nonexistent-agent",
+                "task": "do the thing"
+            }))
+            .await;
+
+        assert!(result.is_error(), "must reject an agent absent everywhere");
+        assert!(runner.invoked.lock().unwrap().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- `delegate_to_agent` always failed with `is_error=true` and never spawned a worker sub-agent when the assistant was launched from a directory with no local `.trusty-agents/agents/` of its own (a bare worktree root, `/tmp`, ...). Root cause: `build_assistant_tier_registry` (`src/runtime/tool_registry.rs`) hand-rolled a single `<cwd>/.trusty-agents/agents` directory for `delegate_to_agent`'s pre-flight validation — invisible to the bundled worker roster (`engineer`, `qa-agent`, ...) that `agents::bundled::ensure_bundled_agents_deployed` deploys to `$HOME/.trusty-agents/agents/` at every startup. `AgentConfig::by_name` (used by the actual spawn) already resolves through `agents_dir_candidates()` (cwd/`TAGENT_CONFIG_DIR` tier, then `$HOME` fallback), so validation rejected names the spawn would have found fine, killing the delegate call before the runner was ever invoked.
- `DelegateToAgentTool` now validates against a `Vec<PathBuf>` of candidate directories (`with_config_dirs`) via the new `agents::agent_name_resolves` predicate (package/flat-toml/flat-md tiers), instead of a single `Option<PathBuf>`. `with_config_dir` (single dir) is unchanged for `pm`/`ctrl`, which intentionally validate against exactly one project-scoped roster — worker/pm/ctrl behavior is otherwise untouched.
- `build_assistant_tier_registry` now sources its directories from the newly crate-visible `agents::agents_dir_candidates()` — the SAME multi-tier list `AgentConfig::by_name` resolves against for the actual spawn — so validation and spawn can never diverge again.
- Observability: `delegate_to_agent`'s pre-flight rejection and any sub-agent run error now log at `debug` with the actual failure reason; the tool loop's per-call log (`src/llm/tool_loop/mod.rs`) now includes the error content on failure instead of only `is_error=true` with no payload.

## Test plan

- [x] `cargo check -p trusty-agents`
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings`
- [x] `cargo fmt -p trusty-agents -- --check`
- [x] `cargo test -p trusty-agents --lib` — 2037 passed, 0 failed, 8 ignored
- [x] `bash scripts/check_line_cap.sh` — 7 allowlisted, 0 violations
- [x] New regression tests: `delegate_resolves_agent_from_secondary_config_dir`, `delegate_rejects_agent_absent_from_all_config_dirs` (`src/tools/delegate.rs`); `agent_name_resolves_tests::*` (`src/agents/tests/loading.rs`)
- [x] Live-verified end-to-end: `RUST_LOG=debug tagent --direct assistant --task "Have an engineer run cargo check on this repo and report back exactly what they found. Actually delegate it." --plain`, run from the worktree root (no local `.trusty-agents/agents/`) — `delegate_to_agent` dispatched with `is_error=false`, a real `agent=engineer` sub-agent spawned and completed, and the assistant relayed the engineer's actual `cargo check` findings in its final reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)