### PR TITLE
feat(embedder): graceful Apple-Silicon default gating + background hot-swap orchestrator (epic #3524 slice 6, PR 3/5, default OFF behind TRUSTY_PY_DEFAULT)

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -49,6 +49,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     Extended: `SwitchableEmbedder::set_bootstrap_state` (updates only the
     bootstrap status, leaving the live backend untouched — used to mark
     `Failed` without disturbing the still-serving ort backend).
+  - **Fix (code-critic HIGH, pre-merge review): no more orphaned python
+    child on a bootstrap-probe failure/timeout.** The readiness probe forces
+    a REAL `trusty-embedderd-py` child to spawn (torch+MPS, hundreds of
+    MB-GB); previously, dropping the adapter on a failed/timed-out probe left
+    that child alive until the idle watchdog reaped it up to 1800s later —
+    with retries, up to `TRUSTY_PY_BOOTSTRAP_RETRIES` such orphans
+    concurrently on the memory-constrained Apple-Silicon machines this
+    targets. Added `LazyEmbedderHandle::shutdown()`
+    (`service/embedder_supervisor/mod.rs`) — an eager, cooperative
+    counterpart to the existing idle-shutdown watchdog's own teardown
+    (`SupervisorHandle::shutdown()`, issue #2979) — and a
+    `PythonAdapterTeardown` seam so `try_bootstrap_once` calls it
+    immediately on every probe failure/timeout path, before ever dropping
+    the handle.
 
 ### Changed
 

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,49 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **Graceful Apple-Silicon default gating + background bootstrap→hot-swap
+  orchestrator (epic #3524 slice 6, PR 3/5) — ships DEFAULT OFF.** On Apple
+  Silicon, once `TRUSTY_PY_DEFAULT` is enabled, `trusty-search start` now
+  serves on the ort stdio sidecar IMMEDIATELY (identical to today's default)
+  while a new background task bootstraps the python/MPS sidecar (venv +
+  launcher discovery), proves it with one real readiness-probe embed call,
+  and hot-swaps the running `SwitchableEmbedder` (epic #3524 PR-1) over to it
+  — with zero HTTP-listener or startup delay. On any bootstrap or
+  readiness-probe failure (after `TRUSTY_PY_BOOTSTRAP_RETRIES` attempts,
+  default 2, with a linear backoff between attempts) the daemon stays
+  permanently on the still-installed ort backend for that daemon's lifetime
+  and `/health`'s `embedder_bootstrap` reports `"failed"` instead of
+  `"bootstrapping"` forever.
+  - **`TRUSTY_PY_DEFAULT`** (env, default OFF): the ship-gate for this PR.
+    Unset/falsy leaves Apple-Silicon unset/`auto` resolution completely
+    unchanged (ort) — this PR is a no-op for real users until a later slice
+    (PR-5) flips the default on after a soak period. `TRUSTY_EMBEDDER=stdio`
+    remains the permanent per-invocation opt-out even after that flip.
+  - **`TRUSTY_EMBEDDER_PYTHON_EAGER`** (env, default OFF): reaches the
+    existing eager, blocking `python` arm (identical to explicit
+    `TRUSTY_EMBEDDER=python`) via unset/`auto` instead of an explicit value;
+    not platform-gated. Takes precedence over the ship-gate flag being off,
+    but the ship-gate flag wins outright when both are set (no reason to
+    block startup when the background path is available).
+  - **`TRUSTY_PY_BOOTSTRAP_RETRIES`** (env, default `2`): number of
+    bootstrap→probe attempts the background orchestrator makes before giving
+    up and marking the bootstrap `Failed`. A malformed or `0` value falls
+    back to the default rather than disabling retries.
+  - Linux/CUDA/Intel-mac hosts are completely unaffected: the new
+    `DefaultEmbedderMode::GracefulPython` resolution is unreachable off
+    Apple Silicon regardless of env — `ensure_venv`/`uv`/torch are never
+    invoked there.
+  - This PR is swap-in only: detecting a live python sidecar dying after a
+    successful hot-swap and falling back to ort is epic #3524 slice 6 PR-4's
+    scope (seam left in `commands/start/graceful_bootstrap.rs`'s
+    `drive_bootstrap` doc comment).
+  - New files: `commands/start/graceful_bootstrap.rs` (the orchestrator).
+    Extended: `SwitchableEmbedder::set_bootstrap_state` (updates only the
+    bootstrap status, leaving the live backend untouched — used to mark
+    `Failed` without disturbing the still-serving ort backend).
+
 ### Changed
 
 - **`/health` reports the true active embedder backend + MPS provider (epic

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -644,12 +644,30 @@ environment variable (issue #110 Phase 2):
 
 | `TRUSTY_EMBEDDER` value | Behaviour |
 |-------------------------|-----------|
-| unset / `auto` / `stdio` | **Default.** Arms a `LazyEmbedderHandle` at boot (issue #315 — deferred spawn). `trusty-embedderd --stdio` is spawned on the **first embed request** (reindex, hybrid search, `context_inference`), not at daemon startup. `trusty-embedderd` is a **required runtime dependency** — binary discovery still runs at boot and fails fast with an install hint if the binary is missing. **`cargo install trusty-search` installs `trusty-embedderd` automatically.** |
+| unset / `auto`          | **Default, platform-aware (epic #3524 slice 6, PR 3/5).** Resolves via `resolve_default_embedder_mode()`: on Apple Silicon with `TRUSTY_PY_DEFAULT` enabled, serves on the ort stdio sidecar immediately while bootstrapping the python/MPS sidecar in the background and hot-swapping when ready (see "Graceful Apple-Silicon default" below); with `TRUSTY_EMBEDDER_PYTHON_EAGER` enabled, takes the eager blocking `python` path below (any platform); otherwise (the shipped default everywhere today, since `TRUSTY_PY_DEFAULT` defaults OFF) arms a `LazyEmbedderHandle` at boot (issue #315 — deferred spawn): `trusty-embedderd --stdio` is spawned on the **first embed request** (reindex, hybrid search, `context_inference`), not at daemon startup. |
+| `stdio`                 | **Permanent opt-out.** Always the plain ort stdio sidecar (identical to the unset/`auto` fallback above), even after `TRUSTY_PY_DEFAULT` ships on for real — never routed through the platform-aware resolution. `trusty-embedderd` is a **required runtime dependency** for this and the default ort path — binary discovery runs at boot and fails fast with an install hint if the binary is missing. **`cargo install trusty-search` installs `trusty-embedderd` automatically.** |
 | `python`                | **Opt-in Python/MPS sidecar (epic #3524).** Eagerly bootstraps a pinned `uv`-managed venv (torch + sentence-transformers) at `start`, then lazy-spawns `trusty-embedderd-py` speaking the exact same stdio JSON-RPC 2.0 protocol as the Rust sidecar. On Apple Silicon this embeds ~2.4x faster than the ort path with numerically identical (>=0.999 cosine) results. On ANY bootstrap or launcher-discovery failure, falls back to the Rust ort stdio sidecar so search never hard-fails — see "Python/MPS sidecar tuning" below. **Default-off**; requires `uv` installed (or `TRUSTY_UV_BIN` set) and ~3 GB free disk on first use. |
 | `in-process` / `local`  | Explicit escape hatch — in-process ONNX embedding. Use for tests, debugging, or environments where the sidecar cannot be installed. **Never activated silently**: you must set this variable explicitly to use the in-process path. |
 | `http://…`              | HTTP remote — `POST /embed` to a manually-managed `trusty-embedderd` HTTP listener. |
 | `unix:/path/to/sock`    | UDS remote — JSON-RPC 2.0 to a manually-managed `trusty-embedderd --socket` listener. |
 | `candle`                | Candle Metal backend (requires `--features candle`). |
+
+### Graceful Apple-Silicon default (epic #3524 slice 6, PR 3/5)
+
+On Apple Silicon, once ship-gated on, `trusty-search start` serves on the ort
+stdio sidecar immediately (zero HTTP-listener delay) while a detached
+background task bootstraps the python/MPS sidecar, proves it with one real
+readiness-probe embed call, and hot-swaps the running embedder over to it.
+On any bootstrap or probe failure the daemon stays permanently on ort for
+that daemon's lifetime and `/health`'s `embedder_bootstrap` reports
+`"failed"`. Ships **default OFF** in this PR — a later slice flips the
+default on after a soak period.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `TRUSTY_PY_DEFAULT` | unset (off) | **Ship-gate.** Set to `1`/`true`/`yes`/`on` to enable the graceful background path on Apple Silicon for unset/`auto` `TRUSTY_EMBEDDER`. Unset/falsy leaves Apple-Silicon resolution completely unchanged (ort) — this is why the PR that introduces the mechanism ships with zero user-facing behavior change. Has no effect off Apple Silicon. |
+| `TRUSTY_EMBEDDER_PYTHON_EAGER` | unset (off) | Reaches the existing eager, blocking `python` arm (identical to explicit `TRUSTY_EMBEDDER=python`) via unset/`auto` instead of an explicit value. Not platform-gated. `TRUSTY_PY_DEFAULT` wins outright when both are set. |
+| `TRUSTY_PY_BOOTSTRAP_RETRIES` | `2` | Number of bootstrap→probe attempts the background orchestrator makes (linear backoff between attempts) before giving up and marking the bootstrap `Failed` while staying on ort. A malformed or `0` value falls back to the default. |
 
 ### Python/MPS sidecar tuning (`TRUSTY_EMBEDDER=python` path only)
 

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -239,6 +239,11 @@ nix = { version = "0.29", features = ["signal", "user", "fs"] }
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+# test-util enables tokio's paused-clock (`tokio::time::pause` /
+# `start_paused = true`), used by the graceful-python-bootstrap orchestrator
+# retry test (epic #3524 slice 6, PR 3/5) so the linear backoff between
+# attempts advances instantly instead of sleeping in real time.
+tokio = { version = "1", features = ["test-util"] }
 # Why: tower::ServiceExt::oneshot is used in the unit tests for the new
 # `service::concurrency` and `service::metrics` modules (issue #41 Phase 1)
 # to exercise router behaviour without binding a TCP port.

--- a/crates/trusty-search/src/commands/start/daemon.rs
+++ b/crates/trusty-search/src/commands/start/daemon.rs
@@ -20,6 +20,7 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 
 use super::embedder::build_embedder;
+use super::graceful_bootstrap::run_graceful_python_bootstrap;
 use super::restore::restore_indexes;
 use crate::commands::prior_index_count::load_prior_index_count;
 
@@ -351,7 +352,7 @@ pub async fn handle_start(
             tokio::time::timeout(Duration::from_secs(init_timeout_secs), init_handle).await;
 
         match init_result {
-            Ok(Ok(Ok((embedder, pid_slot, switchable)))) => {
+            Ok(Ok(Ok((embedder, pid_slot, switchable, needs_graceful_bootstrap)))) => {
                 // Issue #282: if the sidecar path returned a PID slot, install
                 // it on the state so `/health` and the reindex RSS poller can
                 // read the child PID lock-free.
@@ -369,8 +370,24 @@ pub async fn handle_start(
                 // entirely). A later slice's hot-swap orchestrator and
                 // `/health` both reach `swap_to`/`active()` through this
                 // handle without downcasting the trait object.
-                install_state.install_switchable_embedder(switchable);
+                install_state.install_switchable_embedder(Arc::clone(&switchable));
                 install_state.install_embedder(Arc::clone(&embedder)).await;
+                // Epic #3524 slice 6 (PR 3/5): the graceful Apple-Silicon
+                // default arm serves on ort above and needs the python/MPS
+                // bootstrap to run in the background — spawn it now, right
+                // after both the switchable handle and the embedder slot are
+                // visible, so the orchestrator's eventual `swap_to` /
+                // `install_embedderd_pid_slot` calls race no in-progress
+                // install. Detached: never blocks the HTTP listener or the
+                // rest of this init task. No-op (never spawned) unless
+                // `TRUSTY_PY_DEFAULT` is enabled — this PR ships with the
+                // default OFF, so this branch does not run for real users yet.
+                if needs_graceful_bootstrap {
+                    tokio::spawn(run_graceful_python_bootstrap(
+                        switchable,
+                        install_state.clone(),
+                    ));
+                }
                 // Issue #41: worker pool — priority-aware dispatch, bounded queue.
                 let tracker = Arc::clone(&install_state.embedder_stall_tracker);
                 use crate::service::embed_pool::EmbedPool;

--- a/crates/trusty-search/src/commands/start/embedder.rs
+++ b/crates/trusty-search/src/commands/start/embedder.rs
@@ -30,7 +30,7 @@ use crate::service::embedder_supervisor::{
 /// family space — only quantization (see [`quantized_from_env`]) differs.
 /// Purely informational: nothing in this PR reads it, PR-2's `/health` work
 /// will.
-const EMBEDDER_MODEL_NAME: &str = "all-MiniLM-L6-v2";
+pub(super) const EMBEDDER_MODEL_NAME: &str = "all-MiniLM-L6-v2";
 
 /// Best-effort mirror of `trusty_common::embedder::fast_embedder`'s private
 /// `resolve_default_embedding_model` env-var convention, for descriptive
@@ -76,6 +76,104 @@ pub(super) fn backend_respects_quantized_env(kind: BackendKind) -> bool {
     matches!(kind, BackendKind::Ort | BackendKind::InProcess)
 }
 
+/// Which arm `build_embedder_raw` should take for `TRUSTY_EMBEDDER` unset /
+/// `auto` (epic #3524 slice 6, PR 3/5).
+///
+/// Why: the unset/`auto` resolution needs to become platform-aware (Apple
+/// Silicon defaults to the graceful hot-swap path once ship-gated) without
+/// disturbing the explicit-value arms (`stdio`, `python`, `in-process`, …),
+/// which are unaffected by this enum and keep matching directly on the raw
+/// env string. Splitting resolution into its own pure function
+/// ([`resolve_default_embedder_mode_for`]) makes the platform/env precedence
+/// unit-testable without depending on the actual build target or process
+/// environment.
+/// What: one variant per arm `build_embedder_raw`'s `"" | "auto"` match takes.
+/// Test: `resolve_default_embedder_mode_for_*` in `start/tests.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DefaultEmbedderMode {
+    /// Build the ort stdio sidecar synchronously — unchanged pre-#3524
+    /// behavior. Selected on every non-Apple-Silicon host, and on Apple
+    /// Silicon whenever the graceful default is not ship-gated on
+    /// (`TRUSTY_PY_DEFAULT` unset/falsy).
+    Ort,
+    /// Apple Silicon + `TRUSTY_PY_DEFAULT` enabled: serve on ort immediately,
+    /// bootstrap the python/MPS sidecar in the background, then hot-swap
+    /// (this PR's new arm). **Default OFF** — see `TRUSTY_PY_DEFAULT`'s doc.
+    GracefulPython,
+    /// `TRUSTY_EMBEDDER_PYTHON_EAGER` truthy: the existing eager, blocking
+    /// `python` arm (identical to explicit `TRUSTY_EMBEDDER=python`) reached
+    /// via unset/`auto` instead of an explicit value. Not gated to Apple
+    /// Silicon — mirrors the explicit `python` arm, which has never been
+    /// platform-gated (useful for testing the sidecar on any host).
+    EagerPython,
+}
+
+/// Pure resolution logic for [`resolve_default_embedder_mode`] — unit
+/// testable without depending on `cfg!(target_arch/target_os)` or real
+/// process env vars.
+///
+/// Precedence: Apple-Silicon + the ship-gate flag enabled wins outright
+/// (→ [`DefaultEmbedderMode::GracefulPython`]); otherwise an explicit
+/// `TRUSTY_EMBEDDER_PYTHON_EAGER` opt-in wins (→
+/// [`DefaultEmbedderMode::EagerPython`], any platform); otherwise the
+/// unchanged ort default (→ [`DefaultEmbedderMode::Ort`]).
+///
+/// Note: `TRUSTY_EMBEDDER=stdio` (the permanent opt-out) never reaches this
+/// function at all — `build_embedder_raw`'s match dispatches it straight to
+/// `build_ort_stdio_sidecar()` before this resolution is consulted.
+pub(super) fn resolve_default_embedder_mode_for(
+    is_apple_silicon: bool,
+    py_default_enabled: bool,
+    eager_python: bool,
+) -> DefaultEmbedderMode {
+    if is_apple_silicon && py_default_enabled {
+        return DefaultEmbedderMode::GracefulPython;
+    }
+    if eager_python {
+        return DefaultEmbedderMode::EagerPython;
+    }
+    DefaultEmbedderMode::Ort
+}
+
+/// Resolve the `TRUSTY_EMBEDDER` unset/`auto` default, reading the real
+/// build target and process environment (epic #3524 slice 6, PR 3/5).
+///
+/// Why: on Apple Silicon a torch/MPS sidecar embeds ~2.4x faster than ort
+/// with numerically identical results (see the epic #3524 slice 2-4 spike);
+/// once soaked, this should become the transparent default with zero
+/// required user configuration. This PR wires the mechanism behind
+/// `TRUSTY_PY_DEFAULT` (default OFF) so it can ship and be verified without
+/// changing any real user's behavior — a later slice (PR-5) flips the
+/// default on after the soak.
+/// What: `cfg!(all(target_arch = "aarch64", target_os = "macos"))` for the
+/// platform check, `TRUSTY_PY_DEFAULT` for the ship-gate, and
+/// `TRUSTY_EMBEDDER_PYTHON_EAGER` for the eager escape hatch — delegates the
+/// actual precedence to [`resolve_default_embedder_mode_for`].
+/// Test: `resolve_default_embedder_mode_for_*` in `start/tests.rs` cover the
+/// pure precedence; this wrapper has no independent branches to test.
+pub(super) fn resolve_default_embedder_mode() -> DefaultEmbedderMode {
+    resolve_default_embedder_mode_for(
+        cfg!(all(target_arch = "aarch64", target_os = "macos")),
+        truthy_env("TRUSTY_PY_DEFAULT"),
+        truthy_env("TRUSTY_EMBEDDER_PYTHON_EAGER"),
+    )
+}
+
+/// Shared truthy-env-var parser: `1`/`true`/`yes`/`on` (case-insensitive,
+/// trimmed) → `true`; unset or anything else → `false`.
+/// Test: `truthy_env_*` in `start/tests.rs`.
+pub(super) fn truthy_env(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+}
+
 /// Resolve the embedder back-end, wrap it in a [`SwitchableEmbedder`], and
 /// return both the trait-object handle and the concrete switchable handle.
 ///
@@ -101,12 +199,21 @@ pub(super) fn backend_respects_quantized_env(kind: BackendKind) -> bool {
 /// Test: `build_embedder_raw`'s existing coverage (`lazy_adapter_reports_resolved_provider`,
 /// `uds_adapter_reports_resolved_provider`) is unaffected; `switchable.rs`
 /// unit tests cover the wrapper itself.
+///
+/// The 4th return element (epic #3524 slice 6, PR 3/5) is `true` only when
+/// `build_embedder_raw` took the new [`DefaultEmbedderMode::GracefulPython`]
+/// arm — the signal `commands::start::daemon` uses to decide whether to
+/// spawn the background bootstrap→hot-swap orchestrator right after
+/// installing the returned `switchable` handle. Every pre-existing arm
+/// returns `false`, so this PR ships as a no-op for every caller that
+/// doesn't opt in via `TRUSTY_PY_DEFAULT`.
 pub(super) async fn build_embedder() -> Result<(
     std::sync::Arc<dyn crate::core::Embedder>,
     Option<Arc<AtomicU32>>,
     Arc<SwitchableEmbedder>,
+    bool,
 )> {
-    let (raw, pid_slot, kind) = build_embedder_raw().await?;
+    let (raw, pid_slot, kind, needs_graceful_bootstrap) = build_embedder_raw().await?;
     let provider = raw.provider();
     let active = ActiveBackend {
         kind,
@@ -116,12 +223,19 @@ pub(super) async fn build_embedder() -> Result<(
         // path actually honours `TRUSTY_EMBEDDER_MODEL` — see
         // `backend_respects_quantized_env`'s doc for why.
         quantized: backend_respects_quantized_env(kind) && quantized_from_env(),
-        bootstrap: BootstrapState::NotApplicable,
+        // Epic #3524 slice 6 PR-3: the graceful-python arm starts the
+        // background bootstrap immediately, so `/health` must report
+        // `Bootstrapping` from the very first read rather than `NotApplicable`.
+        bootstrap: if needs_graceful_bootstrap {
+            BootstrapState::Bootstrapping
+        } else {
+            BootstrapState::NotApplicable
+        },
     };
     let switchable = Arc::new(SwitchableEmbedder::new(raw, active));
     let embedder: Arc<dyn crate::core::Embedder> =
         Arc::clone(&switchable) as Arc<dyn crate::core::Embedder>;
-    Ok((embedder, pid_slot, switchable))
+    Ok((embedder, pid_slot, switchable, needs_graceful_bootstrap))
 }
 
 /// Resolve the embedder back-end and return the raw `Arc<dyn Embedder>` ready
@@ -150,20 +264,21 @@ pub(super) async fn build_embedder() -> Result<(
 /// first request is served, and `"spawning trusty-embedderd"` only when the
 /// first hybrid search or reindex arrives.
 ///
-/// Returns `(embedder, embedderd_pid_slot, kind)`. `embedderd_pid_slot` is
-/// `Some` only for the stdio-sidecar path and holds an `Arc<AtomicU32>` that
-/// the `LazyEmbedderHandle` keeps updated with the current child OS PID (0
-/// when no live process) so callers can sample the sidecar's RSS without
-/// holding any mutex. Non-stdio paths return `None`. `kind` (epic #3524
-/// slice 6) tags which [`BackendKind`] was constructed so [`build_embedder`]
-/// can build an accurate [`ActiveBackend`] snapshot around it.
+/// Returns `(embedder, embedderd_pid_slot, kind, needs_graceful_bootstrap)`.
+/// `embedderd_pid_slot` is `Some` only for the stdio-sidecar path and holds
+/// an `Arc<AtomicU32>` that the `LazyEmbedderHandle` keeps updated with the
+/// current child OS PID (0 when no live process) so callers can sample the
+/// sidecar's RSS without holding any mutex. Non-stdio paths return `None`.
+/// `kind` (epic #3524 slice 6) tags which [`BackendKind`] was constructed so
+/// [`build_embedder`] can build an accurate [`ActiveBackend`] snapshot around
+/// it. `needs_graceful_bootstrap` (PR 3/5) is `true` only for the
+/// `DefaultEmbedderMode::GracefulPython` arm — see [`build_embedder`]'s doc.
 async fn build_embedder_raw() -> Result<(
     std::sync::Arc<dyn crate::core::Embedder>,
     Option<Arc<AtomicU32>>,
     BackendKind,
+    bool,
 )> {
-    use crate::service::embedder_supervisor::LazyEmbedderHandle;
-
     let trusty_embedder_env = std::env::var("TRUSTY_EMBEDDER").unwrap_or_default();
 
     // Issue #41 phase 4: candle Metal path (feature-gated, explicit opt-in).
@@ -176,13 +291,51 @@ async fn build_embedder_raw() -> Result<(
                     .map_err(|e| anyhow::anyhow!("candle embedder init task panicked: {e}"))??;
             let dim = candle.dimension();
             tracing::info!("embedder initialized: model=all-MiniLM-L6-v2 dim={dim} backend=candle");
-            return Ok((std::sync::Arc::new(candle), None, BackendKind::Candle));
+            return Ok((
+                std::sync::Arc::new(candle),
+                None,
+                BackendKind::Candle,
+                false,
+            ));
         }
     }
 
     match trusty_embedder_env.as_str() {
-        // ── Lazy-spawn stdio sidecar (issue #315 — deferred boot default) ──
-        "" | "auto" | "stdio" => build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort)),
+        // ── Explicit force-ort opt-out — the ONLY way to permanently pin
+        // the ort sidecar on Apple Silicon once TRUSTY_PY_DEFAULT ships on
+        // (epic #3524 slice 6, PR 3/5). Never routed through
+        // `resolve_default_embedder_mode` below.
+        "stdio" => build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort, false)),
+
+        // ── unset / `auto` — platform-aware resolution (epic #3524 slice 6,
+        // PR 3/5). `resolve_default_embedder_mode` decides between the
+        // unchanged ort default, the new graceful-python background path, and
+        // the existing eager-blocking python path (reachable here only via
+        // `TRUSTY_EMBEDDER_PYTHON_EAGER`, mirroring explicit
+        // `TRUSTY_EMBEDDER=python` below).
+        "" | "auto" => match resolve_default_embedder_mode() {
+            DefaultEmbedderMode::Ort => {
+                build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort, false))
+            }
+            DefaultEmbedderMode::EagerPython => build_eager_python_embedder()
+                .await
+                .map(|(e, p, k)| (e, p, k, false)),
+            DefaultEmbedderMode::GracefulPython => {
+                // Epic #3524 slice 6 (PR 3/5): serve on ort IMMEDIATELY — the
+                // exact same synchronous construction as the unchanged default
+                // path — while the caller (`build_embedder`) marks the
+                // resulting `ActiveBackend::bootstrap` `Bootstrapping` and
+                // `commands::start::daemon` spawns the background
+                // bootstrap→hot-swap orchestrator right after installing it.
+                // Nothing here blocks the HTTP listener or startup.
+                tracing::info!(
+                    "embedder mode: graceful Apple-Silicon default (TRUSTY_PY_DEFAULT) — \
+                     serving on the ort stdio sidecar immediately while the python/MPS \
+                     sidecar bootstraps in the background; hot-swaps in when ready"
+                );
+                build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort, true))
+            }
+        },
 
         // ── Opt-in Python/MPS sidecar (epic #3524, slices 2-4) — DEFAULT-OFF ──
         //
@@ -198,64 +351,15 @@ async fn build_embedder_raw() -> Result<(
         // bootstrap or launcher-discovery failure, log a loud actionable
         // warning and FALL BACK to the Rust ort path so search never
         // hard-fails.
-        "python" => {
-            // The bootstrap is a blocking, potentially minutes-long one-time
-            // build; run it off the async runtime. `ensure_venv_eager` (not the
-            // plain `ensure_venv` the per-respawn launcher binary uses) pays for
-            // the FULL torch-importing `.ready` recheck — worth it here since
-            // this call happens once per daemon lifetime, not once per respawn.
-            let bootstrap = tokio::task::spawn_blocking(trusty_embedderd_py::ensure_venv_eager)
-                .await
-                .map_err(|e| anyhow::anyhow!("py-embedder bootstrap task panicked: {e}"));
-
-            match bootstrap.and_then(|r| r.map_err(|e| e.context("py-embedder venv bootstrap"))) {
-                Ok(_layout) => match trusty_embedderd_py::locate_launcher_binary() {
-                    Ok(launcher) => {
-                        let config = resolve_python_supervisor_config();
-                        tracing::info!(
-                            "embedder mode: python/MPS sidecar lazy \
-                             (launcher={}, idle_shutdown_secs={})",
-                            launcher.display(),
-                            config.idle_shutdown_secs,
-                        );
-                        let handle = Arc::new(LazyEmbedderHandle::new(launcher, config));
-                        let pid_slot = handle.app_pid_slot();
-                        Ok((
-                            Arc::new(LazySlotEmbedderAdapter {
-                                handle,
-                                is_python: true,
-                            }),
-                            Some(pid_slot),
-                            BackendKind::Python,
-                        ))
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "TRUSTY_EMBEDDER=python: could not locate the \
-                             trusty-embedderd-py launcher ({e:#}) — FALLING BACK to the \
-                             Rust ort stdio sidecar. Set TRUSTY_EMBEDDERD_PY_BIN or ensure \
-                             the launcher is on PATH to use the Python/MPS sidecar."
-                        );
-                        build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort))
-                    }
-                },
-                Err(e) => {
-                    tracing::warn!(
-                        "TRUSTY_EMBEDDER=python: venv bootstrap failed ({e:#}) — FALLING \
-                         BACK to the Rust ort stdio sidecar so search does not hard-fail. \
-                         Ensure `uv` is installed (or set TRUSTY_UV_BIN) and there is \
-                         ~3 GB free disk, then restart to retry the Python/MPS sidecar."
-                    );
-                    build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort))
-                }
-            }
-        }
+        "python" => build_eager_python_embedder()
+            .await
+            .map(|(e, p, k)| (e, p, k, false)),
 
         // ── In-process safety-valve ────────────────────────────────────────
         "in-process" | "local" => {
             tracing::info!("embedder mode: in-process (override via TRUSTY_EMBEDDER=in-process)");
             let embedder = build_in_process_embedder().await?;
-            Ok((embedder, None, BackendKind::InProcess))
+            Ok((embedder, None, BackendKind::InProcess, false))
         }
 
         // ── HTTP remote (manually managed embedderd) ───────────────────────
@@ -268,6 +372,7 @@ async fn build_embedder_raw() -> Result<(
                 }),
                 None,
                 BackendKind::Remote,
+                false,
             ))
         }
 
@@ -280,6 +385,7 @@ async fn build_embedder_raw() -> Result<(
                 Arc::new(UdsEmbedderAdapter { client }),
                 None,
                 BackendKind::Remote,
+                false,
             ))
         }
 
@@ -289,6 +395,78 @@ async fn build_embedder_raw() -> Result<(
              (opt-in Python/MPS sidecar), 'in-process', \
              'http://...', or 'unix:/path/to/socket'"
         ),
+    }
+}
+
+/// Eagerly bootstrap the python venv and arm a lazy-spawn `LazyEmbedderHandle`
+/// for the python/MPS sidecar, falling back to the ort stdio sidecar on ANY
+/// bootstrap or launcher-discovery failure so search never hard-fails.
+///
+/// Why: extracted from the former inline `"python"` match arm body (epic
+/// #3524 slices 2-4) so the exact same eager-blocking logic is reachable both
+/// from the explicit `TRUSTY_EMBEDDER=python` value AND from unset/`auto` +
+/// `TRUSTY_EMBEDDER_PYTHON_EAGER` (PR 3/5) without duplicating it.
+/// What: blocking `ensure_venv_eager` off the async runtime, then
+/// `locate_launcher_binary`, then arms a `LazyEmbedderHandle` exactly like
+/// `build_ort_stdio_sidecar` does for the ort binary.
+/// Test: unaffected by this extraction — same behavior, same call path,
+/// covered by the existing `lazy_adapter_python_reports_mps_provider`.
+async fn build_eager_python_embedder() -> Result<(
+    std::sync::Arc<dyn crate::core::Embedder>,
+    Option<Arc<AtomicU32>>,
+    BackendKind,
+)> {
+    use crate::service::embedder_supervisor::LazyEmbedderHandle;
+
+    // The bootstrap is a blocking, potentially minutes-long one-time
+    // build; run it off the async runtime. `ensure_venv_eager` (not the
+    // plain `ensure_venv` the per-respawn launcher binary uses) pays for
+    // the FULL torch-importing `.ready` recheck — worth it here since
+    // this call happens once per daemon lifetime, not once per respawn.
+    let bootstrap = tokio::task::spawn_blocking(trusty_embedderd_py::ensure_venv_eager)
+        .await
+        .map_err(|e| anyhow::anyhow!("py-embedder bootstrap task panicked: {e}"));
+
+    match bootstrap.and_then(|r| r.map_err(|e| e.context("py-embedder venv bootstrap"))) {
+        Ok(_layout) => match trusty_embedderd_py::locate_launcher_binary() {
+            Ok(launcher) => {
+                let config = resolve_python_supervisor_config();
+                tracing::info!(
+                    "embedder mode: python/MPS sidecar lazy \
+                     (launcher={}, idle_shutdown_secs={})",
+                    launcher.display(),
+                    config.idle_shutdown_secs,
+                );
+                let handle = Arc::new(LazyEmbedderHandle::new(launcher, config));
+                let pid_slot = handle.app_pid_slot();
+                Ok((
+                    Arc::new(LazySlotEmbedderAdapter {
+                        handle,
+                        is_python: true,
+                    }),
+                    Some(pid_slot),
+                    BackendKind::Python,
+                ))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "TRUSTY_EMBEDDER=python: could not locate the \
+                     trusty-embedderd-py launcher ({e:#}) — FALLING BACK to the \
+                     Rust ort stdio sidecar. Set TRUSTY_EMBEDDERD_PY_BIN or ensure \
+                     the launcher is on PATH to use the Python/MPS sidecar."
+                );
+                build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort))
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                "TRUSTY_EMBEDDER=python: venv bootstrap failed ({e:#}) — FALLING \
+                 BACK to the Rust ort stdio sidecar so search does not hard-fail. \
+                 Ensure `uv` is installed (or set TRUSTY_UV_BIN) and there is \
+                 ~3 GB free disk, then restart to retry the Python/MPS sidecar."
+            );
+            build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort))
+        }
     }
 }
 

--- a/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
+++ b/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
@@ -31,7 +31,10 @@
 //! Test: `graceful_bootstrap_swaps_to_python_on_success`,
 //! `graceful_bootstrap_stays_ort_and_failed_after_probe_failure`,
 //! `graceful_bootstrap_stays_ort_and_failed_after_bootstrap_failure`,
-//! `graceful_bootstrap_retries_before_giving_up` in `start/tests.rs`.
+//! `graceful_bootstrap_retries_before_giving_up`,
+//! `graceful_bootstrap_probe_failure_tears_down_the_handle`,
+//! `graceful_bootstrap_probe_timeout_tears_down_the_handle` in
+//! `start/tests.rs`.
 
 use std::path::PathBuf;
 use std::sync::atomic::AtomicU32;
@@ -50,6 +53,36 @@ use crate::service::SearchAppState;
 /// is unset or malformed.
 const DEFAULT_BOOTSTRAP_RETRIES: u32 = 2;
 
+/// Abstracts "the thing that must be torn down if the readiness probe fails
+/// or times out after an adapter/handle has already been built" — real:
+/// `LazyEmbedderHandle::shutdown()`; fakes: a spy that records the call
+/// (epic #3524 slice 6 PR-3 fix — code-critic HIGH: orphaned python child on
+/// bootstrap-probe failure).
+///
+/// Why: the readiness probe (`adapter.embed_batch(...)` in
+/// [`try_bootstrap_once`]) forces `LazyEmbedderHandle` to spawn a REAL child
+/// process (torch+MPS, hundreds of MB-GB). If the probe then fails or times
+/// out, simply dropping the adapter left that child running until the
+/// detached idle watchdog reaped it — up to 1800s later for the python arm,
+/// with up to `TRUSTY_PY_BOOTSTRAP_RETRIES` such orphans alive concurrently.
+/// This trait is the seam that lets [`try_bootstrap_once`] force an
+/// IMMEDIATE, cooperative kill on every failure path that occurs after a
+/// handle may have spawned, before ever dropping it.
+/// What: one method, `teardown()`, async so the real implementation can
+/// await `SupervisorHandle::shutdown()`'s "confirmed dead" guarantee.
+/// Test: see the module-level `Test:` pointer.
+#[async_trait::async_trait]
+pub(crate) trait PythonAdapterTeardown: Send + Sync {
+    async fn teardown(&self);
+}
+
+#[async_trait::async_trait]
+impl PythonAdapterTeardown for crate::service::embedder_supervisor::LazyEmbedderHandle {
+    async fn teardown(&self) {
+        self.shutdown().await;
+    }
+}
+
 /// Abstracts the three fallible, real-world steps of standing up the python
 /// sidecar (venv bootstrap, launcher discovery, adapter construction) plus
 /// the probe timeout, so [`drive_bootstrap`] — the retry/probe/swap state
@@ -63,13 +96,22 @@ const DEFAULT_BOOTSTRAP_RETRIES: u32 = 2;
 /// succeed deterministically at each step.
 /// What: `ensure_venv` (blocking bootstrap), `locate_launcher` (binary
 /// discovery), `build_adapter` (constructs the live `Arc<dyn Embedder>` +
-/// optional pid slot from the located launcher), `probe_timeout` (bound on
-/// the one real embed call `try_bootstrap_once` makes before hot-swapping).
+/// optional pid slot + the [`PythonAdapterTeardown`] handle for that same
+/// adapter, from the located launcher), `probe_timeout` (bound on the one
+/// real embed call `try_bootstrap_once` makes before hot-swapping).
 /// Test: see the module-level `Test:` pointer.
 pub(crate) trait PythonBootstrap: Send + Sync {
     fn ensure_venv(&self) -> Result<()>;
     fn locate_launcher(&self) -> Result<PathBuf>;
-    fn build_adapter(&self, launcher: PathBuf) -> (Arc<dyn Embedder>, Option<Arc<AtomicU32>>);
+    #[allow(clippy::type_complexity)]
+    fn build_adapter(
+        &self,
+        launcher: PathBuf,
+    ) -> (
+        Arc<dyn Embedder>,
+        Option<Arc<AtomicU32>>,
+        Arc<dyn PythonAdapterTeardown>,
+    );
     fn probe_timeout(&self) -> Duration;
 }
 
@@ -92,17 +134,25 @@ impl PythonBootstrap for RealPythonBootstrap {
         trusty_embedderd_py::locate_launcher_binary()
     }
 
-    fn build_adapter(&self, launcher: PathBuf) -> (Arc<dyn Embedder>, Option<Arc<AtomicU32>>) {
+    fn build_adapter(
+        &self,
+        launcher: PathBuf,
+    ) -> (
+        Arc<dyn Embedder>,
+        Option<Arc<AtomicU32>>,
+        Arc<dyn PythonAdapterTeardown>,
+    ) {
         use crate::service::embedder_supervisor::LazyEmbedderHandle;
 
         let config = super::embedder::resolve_python_supervisor_config();
         let handle = Arc::new(LazyEmbedderHandle::new(launcher, config));
         let pid_slot = handle.app_pid_slot();
+        let teardown: Arc<dyn PythonAdapterTeardown> = Arc::clone(&handle) as _;
         let adapter: Arc<dyn Embedder> = Arc::new(super::embedder::LazySlotEmbedderAdapter {
             handle,
             is_python: true,
         });
-        (adapter, Some(pid_slot))
+        (adapter, Some(pid_slot), teardown)
     }
 
     fn probe_timeout(&self) -> Duration {
@@ -225,8 +275,12 @@ async fn try_bootstrap_once(
     let launcher = ops.locate_launcher()?;
 
     // Step c: build the python `LazyEmbedderHandle` + adapter exactly like
-    // the existing eager `python` arm.
-    let (adapter, pid_slot) = ops.build_adapter(launcher);
+    // the existing eager `python` arm. `teardown` is the SAME underlying
+    // handle as `adapter` (just viewed through `PythonAdapterTeardown`
+    // instead of `Embedder`) — see that trait's doc for why an explicit,
+    // awaited teardown is required on every failure path below rather than
+    // relying on `Drop`.
+    let (adapter, pid_slot, teardown) = ops.build_adapter(launcher);
     let probe_timeout = ops.probe_timeout();
 
     // Step d: readiness probe — force the lazy spawn + torch import + model
@@ -240,14 +294,20 @@ async fn try_bootstrap_once(
     match probe {
         Ok(Ok(_vectors)) => {}
         Ok(Err(e)) => {
-            // Drop our only reference to the adapter so the underlying
-            // `LazyEmbedderHandle` (if the probe spawned a child) is
-            // reclaimed via its own idle-shutdown watchdog rather than left
-            // dangling — see PR-4's seam note on `drive_bootstrap`.
+            // code-critic HIGH fix (epic #3524 slice 6 PR-3): the probe call
+            // above may have forced a REAL child spawn. Cooperatively kill
+            // it now, BEFORE dropping our only references, so a
+            // probe-failure never leaves an orphaned python/MPS process
+            // alive for up to 1800s waiting on the idle watchdog.
+            teardown.teardown().await;
             drop(adapter);
             return Err(e.context("python readiness probe failed"));
         }
         Err(_elapsed) => {
+            // Same fix, timeout path: the probe may still be in flight
+            // against a live (just-spawned) child when the timeout fires —
+            // tear it down immediately rather than abandon it.
+            teardown.teardown().await;
             drop(adapter);
             anyhow::bail!(
                 "python readiness probe timed out after {}s",

--- a/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
+++ b/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
@@ -1,0 +1,281 @@
+//! Background bootstrap→hot-swap orchestrator for the graceful Apple-Silicon
+//! default (epic #3524 slice 6, PR 3/5).
+//!
+//! Why: `DefaultEmbedderMode::GracefulPython` (see `embedder.rs`) serves on
+//! the ort stdio sidecar immediately so the HTTP listener never blocks on a
+//! multi-second-to-multi-minute python/MPS venv bootstrap. Something still
+//! has to DO that bootstrap, though — off the request path, with retries,
+//! and hot-swap the `SwitchableEmbedder` (epic #3524 PR-1) over to the
+//! python adapter once (and only once) it has proven itself with a real
+//! embed call through the supervisor. This module is that "something":
+//! `commands::start::daemon` spawns [`run_graceful_python_bootstrap`] as a
+//! detached `tokio::spawn` task right after installing the switchable
+//! handle, and this module owns the whole retry/probe/swap state machine.
+//!
+//! What: [`PythonBootstrap`] abstracts the three fallible, slow, real-world
+//! steps (venv bootstrap, launcher discovery, adapter construction) behind a
+//! trait so [`drive_bootstrap`] — the actual retry/probe/swap logic — can be
+//! unit tested with deterministic fakes; no real `uv`/torch/MPS ever runs in
+//! CI for these tests. [`RealPythonBootstrap`] is the only production
+//! implementation, reusing the exact same steps the pre-existing eager
+//! `TRUSTY_EMBEDDER=python` arm performs
+//! (`embedder::build_eager_python_embedder`).
+//!
+//! This PR implements SWAP-IN ONLY: once hot-swapped to python, this module
+//! is done — it never runs again for the lifetime of the daemon. Detecting a
+//! live python sidecar dying later and swapping back to ort is PR-4's scope;
+//! the seam for that is the same `switchable` handle and the pid-slot /
+//! stall-tracker machinery [`drive_bootstrap`] already wires up on success
+//! (see the `TODO(PR-4)` below).
+//!
+//! Test: `graceful_bootstrap_swaps_to_python_on_success`,
+//! `graceful_bootstrap_stays_ort_and_failed_after_probe_failure`,
+//! `graceful_bootstrap_stays_ort_and_failed_after_bootstrap_failure`,
+//! `graceful_bootstrap_retries_before_giving_up` in `start/tests.rs`.
+
+use std::path::PathBuf;
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::core::Embedder;
+use crate::service::embedder_supervisor::{
+    ActiveBackend, BackendKind, BootstrapState, SwitchableEmbedder,
+};
+use crate::service::SearchAppState;
+
+/// Default number of bootstrap attempts when `TRUSTY_PY_BOOTSTRAP_RETRIES`
+/// is unset or malformed.
+const DEFAULT_BOOTSTRAP_RETRIES: u32 = 2;
+
+/// Abstracts the three fallible, real-world steps of standing up the python
+/// sidecar (venv bootstrap, launcher discovery, adapter construction) plus
+/// the probe timeout, so [`drive_bootstrap`] — the retry/probe/swap state
+/// machine — is unit-testable with deterministic fakes.
+///
+/// Why: `trusty_embedderd_py::ensure_venv_eager` and `locate_launcher_binary`
+/// do real, slow, disk/network-dependent work (see their own docs); a real
+/// python/MPS adapter needs actual torch + a real GPU to serve the readiness
+/// probe. None of that is available or desirable in CI. [`RealPythonBootstrap`]
+/// is the only production implementation; tests substitute fakes that fail or
+/// succeed deterministically at each step.
+/// What: `ensure_venv` (blocking bootstrap), `locate_launcher` (binary
+/// discovery), `build_adapter` (constructs the live `Arc<dyn Embedder>` +
+/// optional pid slot from the located launcher), `probe_timeout` (bound on
+/// the one real embed call `try_bootstrap_once` makes before hot-swapping).
+/// Test: see the module-level `Test:` pointer.
+pub(crate) trait PythonBootstrap: Send + Sync {
+    fn ensure_venv(&self) -> Result<()>;
+    fn locate_launcher(&self) -> Result<PathBuf>;
+    fn build_adapter(&self, launcher: PathBuf) -> (Arc<dyn Embedder>, Option<Arc<AtomicU32>>);
+    fn probe_timeout(&self) -> Duration;
+}
+
+/// Production [`PythonBootstrap`]: the exact same steps the pre-existing
+/// eager `TRUSTY_EMBEDDER=python` arm performs
+/// (`embedder::build_eager_python_embedder`), reused here for the background
+/// graceful path. The probe timeout reuses the existing, already-tunable
+/// `TRUSTY_EMBEDDERD_STARTUP_TIMEOUT_SECS` (via `SupervisorConfig`) rather
+/// than introducing a new env var for a single bounded async call.
+struct RealPythonBootstrap;
+
+impl PythonBootstrap for RealPythonBootstrap {
+    fn ensure_venv(&self) -> Result<()> {
+        trusty_embedderd_py::ensure_venv_eager()
+            .map(|_layout| ())
+            .map_err(|e| e.context("py-embedder venv bootstrap"))
+    }
+
+    fn locate_launcher(&self) -> Result<PathBuf> {
+        trusty_embedderd_py::locate_launcher_binary()
+    }
+
+    fn build_adapter(&self, launcher: PathBuf) -> (Arc<dyn Embedder>, Option<Arc<AtomicU32>>) {
+        use crate::service::embedder_supervisor::LazyEmbedderHandle;
+
+        let config = super::embedder::resolve_python_supervisor_config();
+        let handle = Arc::new(LazyEmbedderHandle::new(launcher, config));
+        let pid_slot = handle.app_pid_slot();
+        let adapter: Arc<dyn Embedder> = Arc::new(super::embedder::LazySlotEmbedderAdapter {
+            handle,
+            is_python: true,
+        });
+        (adapter, Some(pid_slot))
+    }
+
+    fn probe_timeout(&self) -> Duration {
+        Duration::from_secs(
+            super::embedder::resolve_python_supervisor_config().startup_timeout_secs,
+        )
+    }
+}
+
+/// Resolve `TRUSTY_PY_BOOTSTRAP_RETRIES` (default 2, clamped to a minimum of
+/// 1 — a malformed or zero value falls back to the default rather than
+/// silently never retrying).
+/// Test: `resolve_bootstrap_retries_*` in `start/tests.rs`.
+pub(super) fn resolve_bootstrap_retries() -> u32 {
+    std::env::var("TRUSTY_PY_BOOTSTRAP_RETRIES")
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .filter(|&n| n >= 1)
+        .unwrap_or(DEFAULT_BOOTSTRAP_RETRIES)
+}
+
+/// Entry point spawned by `commands::start::daemon` right after the embedder
+/// + switchable handle are installed (epic #3524 slice 6, PR 3/5).
+///
+/// Why: the daemon's init task is the only place that has both the
+/// `Arc<SwitchableEmbedder>` handle and the `SearchAppState` (needed to
+/// install the python pid slot on success) at the same time.
+/// What: constructs the production [`RealPythonBootstrap`] and delegates to
+/// [`drive_bootstrap`]. Never panics — every failure path is caught and
+/// logged; the daemon and the ort backend it is already serving on are
+/// completely unaffected regardless of outcome.
+/// Test: `drive_bootstrap` (this function's callee) is what carries the
+/// actual test coverage — this wrapper has no independent branches.
+pub(super) async fn run_graceful_python_bootstrap(
+    switchable: Arc<SwitchableEmbedder>,
+    state: SearchAppState,
+) {
+    let ops: Arc<dyn PythonBootstrap> = Arc::new(RealPythonBootstrap);
+    drive_bootstrap(switchable, state, ops, resolve_bootstrap_retries()).await;
+}
+
+/// Drive the ort→python hot-swap state machine: bootstrap the venv, locate
+/// the launcher, build the adapter, probe it once, and hot-swap on success.
+///
+/// Why: isolated from [`run_graceful_python_bootstrap`] so tests can inject
+/// a fake [`PythonBootstrap`] and a hand-built `SwitchableEmbedder` /
+/// `SearchAppState` without touching any real subprocess, venv, or GPU.
+/// What: retries up to `retries` times (linear backoff between attempts —
+/// `2 * attempt` seconds); on success hot-swaps `switchable` to the python
+/// adapter (`ActiveBackend::bootstrap = Ready`) and installs the pid slot on
+/// `state`; on final exhaustion marks `switchable`'s bootstrap state
+/// `Failed` via `SwitchableEmbedder::set_bootstrap_state` — the still-live
+/// ort backend (`inner`) is never touched, so search keeps serving on ort
+/// exactly as it was before this task ever ran.
+///
+/// TODO(PR-4): this function currently has no way to notice the python
+/// sidecar dying AFTER a successful hot-swap and fall back to ort. The seam
+/// for that is here: `switchable` and the installed pid slot / the daemon's
+/// existing `embedder_stall_tracker` are already wired up by the time this
+/// function returns `Ok` from a caller's perspective — PR-4 only needs to
+/// add a supervising task that watches those and calls
+/// `switchable.swap_to`/`set_bootstrap_state` again on death.
+///
+/// Test: `graceful_bootstrap_swaps_to_python_on_success`,
+/// `graceful_bootstrap_stays_ort_and_failed_after_probe_failure`,
+/// `graceful_bootstrap_stays_ort_and_failed_after_bootstrap_failure`,
+/// `graceful_bootstrap_retries_before_giving_up` in `start/tests.rs`.
+pub(super) async fn drive_bootstrap(
+    switchable: Arc<SwitchableEmbedder>,
+    state: SearchAppState,
+    ops: Arc<dyn PythonBootstrap>,
+    retries: u32,
+) {
+    let retries = retries.max(1);
+    let mut last_err = None;
+
+    for attempt in 1..=retries {
+        match try_bootstrap_once(&switchable, &state, &ops).await {
+            Ok(()) => {
+                tracing::info!("embedder hot-swapped ort -> python/MPS (sidecar ready)");
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "graceful python bootstrap attempt {attempt}/{retries} failed \
+                     ({e:#}) — staying on the ort sidecar"
+                );
+                last_err = Some(e);
+                if attempt < retries {
+                    tokio::time::sleep(Duration::from_secs(2 * u64::from(attempt))).await;
+                }
+            }
+        }
+    }
+
+    switchable.set_bootstrap_state(BootstrapState::Failed);
+    tracing::warn!(
+        "graceful python bootstrap exhausted {retries} attempt(s) — staying permanently \
+         on the ort sidecar for this daemon's lifetime (last error: {:#}); restart to \
+         retry, or set TRUSTY_EMBEDDER=python for the eager blocking path",
+        last_err.expect("at least one attempt runs when retries >= 1"),
+    );
+}
+
+/// One bootstrap→probe→swap attempt. See [`drive_bootstrap`] for the retry
+/// loop around this.
+async fn try_bootstrap_once(
+    switchable: &SwitchableEmbedder,
+    state: &SearchAppState,
+    ops: &Arc<dyn PythonBootstrap>,
+) -> Result<()> {
+    // Step a: blocking venv bootstrap off the async runtime — mirrors the
+    // eager `TRUSTY_EMBEDDER=python` arm's `ensure_venv_eager` off-thread call.
+    let venv_ops = Arc::clone(ops);
+    tokio::task::spawn_blocking(move || venv_ops.ensure_venv())
+        .await
+        .map_err(|e| anyhow::anyhow!("py-embedder bootstrap task panicked: {e}"))??;
+
+    // Step b: locate the launcher binary.
+    let launcher = ops.locate_launcher()?;
+
+    // Step c: build the python `LazyEmbedderHandle` + adapter exactly like
+    // the existing eager `python` arm.
+    let (adapter, pid_slot) = ops.build_adapter(launcher);
+    let probe_timeout = ops.probe_timeout();
+
+    // Step d: readiness probe — force the lazy spawn + torch import + model
+    // load + one real embed THROUGH the supervisor, bounded by a timeout.
+    let probe = tokio::time::timeout(
+        probe_timeout,
+        adapter.embed_batch(&["trusty readiness probe"]),
+    )
+    .await;
+
+    match probe {
+        Ok(Ok(_vectors)) => {}
+        Ok(Err(e)) => {
+            // Drop our only reference to the adapter so the underlying
+            // `LazyEmbedderHandle` (if the probe spawned a child) is
+            // reclaimed via its own idle-shutdown watchdog rather than left
+            // dangling — see PR-4's seam note on `drive_bootstrap`.
+            drop(adapter);
+            return Err(e.context("python readiness probe failed"));
+        }
+        Err(_elapsed) => {
+            drop(adapter);
+            anyhow::bail!(
+                "python readiness probe timed out after {}s",
+                probe_timeout.as_secs()
+            );
+        }
+    }
+
+    // Step e: hot-swap. Read `provider()` before moving `adapter` into
+    // `swap_to`.
+    let provider = adapter.provider();
+    switchable.swap_to(
+        adapter,
+        ActiveBackend {
+            kind: BackendKind::Python,
+            provider,
+            model: super::embedder::EMBEDDER_MODEL_NAME.to_string(),
+            quantized: false,
+            bootstrap: BootstrapState::Ready,
+        },
+    );
+
+    // Install the python pid slot so `/health` RSS tracking follows the new
+    // child instead of the (still technically alive, but no longer serving)
+    // ort sidecar.
+    if let Some(slot) = pid_slot {
+        state.install_embedderd_pid_slot(slot).await;
+    }
+
+    Ok(())
+}

--- a/crates/trusty-search/src/commands/start/mod.rs
+++ b/crates/trusty-search/src/commands/start/mod.rs
@@ -18,6 +18,7 @@
 
 mod daemon;
 mod embedder;
+mod graceful_bootstrap;
 mod restore;
 
 #[cfg(test)]

--- a/crates/trusty-search/src/commands/start/tests.rs
+++ b/crates/trusty-search/src/commands/start/tests.rs
@@ -872,3 +872,463 @@ impl Drop for EnvGuard {
         }
     }
 }
+
+// ── Graceful Apple-Silicon default resolution (epic #3524 slice 6, PR 3/5) ──
+
+use super::embedder::{resolve_default_embedder_mode_for, truthy_env, DefaultEmbedderMode};
+
+/// Apple Silicon + the ship-gate flag enabled must resolve to the new
+/// background graceful path — the whole point of this PR.
+#[test]
+fn resolve_default_embedder_mode_for_apple_silicon_with_flag_is_graceful() {
+    assert_eq!(
+        resolve_default_embedder_mode_for(true, true, false),
+        DefaultEmbedderMode::GracefulPython
+    );
+}
+
+/// Apple Silicon with the ship-gate flag OFF (this PR's shipped default —
+/// `TRUSTY_PY_DEFAULT` unset) must resolve to the unchanged ort path, proving
+/// this PR ships as a no-op for real users.
+#[test]
+fn resolve_default_embedder_mode_for_apple_silicon_opted_out_is_ort() {
+    assert_eq!(
+        resolve_default_embedder_mode_for(true, false, false),
+        DefaultEmbedderMode::Ort
+    );
+}
+
+/// Apple Silicon + `TRUSTY_EMBEDDER_PYTHON_EAGER` (and the ship-gate flag
+/// OFF) must resolve to the existing eager blocking python arm, not the new
+/// background path.
+#[test]
+fn resolve_default_embedder_mode_for_apple_silicon_eager_env_is_eager() {
+    assert_eq!(
+        resolve_default_embedder_mode_for(true, false, true),
+        DefaultEmbedderMode::EagerPython
+    );
+}
+
+/// The ship-gate flag wins outright over the eager env when both are set —
+/// there is no reason to run the slow blocking path when the background
+/// graceful path is available.
+#[test]
+fn resolve_default_embedder_mode_for_apple_silicon_flag_wins_over_eager_env() {
+    assert_eq!(
+        resolve_default_embedder_mode_for(true, true, true),
+        DefaultEmbedderMode::GracefulPython
+    );
+}
+
+/// Non-Apple-Silicon (Linux, Intel mac, etc.) with NEITHER env var set must
+/// resolve to the unchanged ort path.
+#[test]
+fn resolve_default_embedder_mode_for_non_apple_silicon_is_ort() {
+    assert_eq!(
+        resolve_default_embedder_mode_for(false, false, false),
+        DefaultEmbedderMode::Ort
+    );
+}
+
+/// Non-Apple-Silicon (Linux/CUDA) resolution MUST return the ort path even
+/// when the ship-gate flag is enabled — `TRUSTY_PY_DEFAULT` only ever
+/// applies on Apple Silicon; a CUDA/Linux box never reaches the python
+/// bootstrap through this default-resolution path (`GracefulPython` is
+/// unreachable off Apple Silicon regardless of env), so `ensure_venv` /
+/// `uv` / torch are never invoked there.
+#[test]
+fn resolve_default_embedder_mode_for_non_apple_silicon_ignores_flag() {
+    assert_eq!(
+        resolve_default_embedder_mode_for(false, true, false),
+        DefaultEmbedderMode::Ort,
+        "GracefulPython must never be selected off Apple Silicon"
+    );
+}
+
+/// `truthy_env` must recognize the common truthy spellings, case-insensitive
+/// and trimmed.
+#[test]
+#[serial]
+fn truthy_env_recognizes_common_truthy_values() {
+    for value in ["1", "true", "TRUE", " yes ", "On"] {
+        let _g = EnvGuard::set("TRUSTY_TEST_TRUTHY_3524", value);
+        assert!(
+            truthy_env("TRUSTY_TEST_TRUTHY_3524"),
+            "{value:?} must be truthy"
+        );
+    }
+}
+
+/// Unset or any non-truthy value must resolve to `false`.
+#[test]
+#[serial]
+fn truthy_env_false_for_unset_or_other() {
+    let _g = EnvGuard::remove("TRUSTY_TEST_TRUTHY_3524");
+    assert!(!truthy_env("TRUSTY_TEST_TRUTHY_3524"));
+
+    let _g2 = EnvGuard::set("TRUSTY_TEST_TRUTHY_3524", "0");
+    assert!(!truthy_env("TRUSTY_TEST_TRUTHY_3524"));
+
+    let _g3 = EnvGuard::set("TRUSTY_TEST_TRUTHY_3524", "nope");
+    assert!(!truthy_env("TRUSTY_TEST_TRUTHY_3524"));
+}
+
+// ── TRUSTY_PY_BOOTSTRAP_RETRIES resolution (epic #3524 slice 6, PR 3/5) ─────
+
+use super::graceful_bootstrap::resolve_bootstrap_retries;
+
+#[test]
+#[serial]
+fn resolve_bootstrap_retries_defaults_to_2_when_unset() {
+    let _g = EnvGuard::remove("TRUSTY_PY_BOOTSTRAP_RETRIES");
+    assert_eq!(resolve_bootstrap_retries(), 2);
+}
+
+#[test]
+#[serial]
+fn resolve_bootstrap_retries_honors_explicit_value() {
+    let _g = EnvGuard::set("TRUSTY_PY_BOOTSTRAP_RETRIES", "5");
+    assert_eq!(resolve_bootstrap_retries(), 5);
+}
+
+/// A malformed or zero value must fall back to the default rather than
+/// disabling retries entirely (zero attempts would never even try once).
+#[test]
+#[serial]
+fn resolve_bootstrap_retries_malformed_or_zero_falls_back_to_default() {
+    let _g = EnvGuard::set("TRUSTY_PY_BOOTSTRAP_RETRIES", "not_a_number");
+    assert_eq!(resolve_bootstrap_retries(), 2);
+
+    let _g2 = EnvGuard::set("TRUSTY_PY_BOOTSTRAP_RETRIES", "0");
+    assert_eq!(resolve_bootstrap_retries(), 2);
+}
+
+// ── Background bootstrap→hot-swap orchestrator (epic #3524 slice 6, PR 3/5) ─
+//
+// These drive `graceful_bootstrap::drive_bootstrap` — the actual retry/probe/
+// swap state machine — with a fully deterministic fake `PythonBootstrap` and
+// a fake in-memory `Embedder`. No real `uv`, torch, MPS, or subprocess ever
+// runs; every test completes in milliseconds.
+
+use super::graceful_bootstrap::{drive_bootstrap, PythonBootstrap};
+use crate::core::Embedder as _;
+use crate::service::embedder_supervisor::{
+    ActiveBackend as SwitchableActiveBackend, BackendKind as SwitchableBackendKind,
+    BootstrapState as SwitchableBootstrapState, SwitchableEmbedder,
+};
+use crate::service::SearchAppState;
+use std::sync::atomic::{AtomicU32 as OrchestratorAtomicU32, AtomicUsize};
+use std::sync::Arc as OrchestratorArc;
+
+/// The initial ort "backend" installed into the `SwitchableEmbedder` under
+/// test — a fake, not the real ort stdio sidecar. Its call counter proves
+/// `inner` is untouched when the orchestrator gives up and stays on ort.
+struct FakeOrtEmbedder {
+    calls: AtomicUsize,
+}
+
+impl FakeOrtEmbedder {
+    fn new() -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::core::Embedder for FakeOrtEmbedder {
+    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        self.calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(vec![text.len() as f32; trusty_common::embedder::EMBED_DIM])
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        self.calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        Ok(texts
+            .iter()
+            .map(|t| vec![t.len() as f32; trusty_common::embedder::EMBED_DIM])
+            .collect())
+    }
+
+    fn dimension(&self) -> usize {
+        trusty_common::embedder::EMBED_DIM
+    }
+}
+
+/// Fake python adapter whose `embed_batch` (the readiness probe) always
+/// succeeds.
+struct FakePythonEmbedderOk;
+
+#[async_trait::async_trait]
+impl crate::core::Embedder for FakePythonEmbedderOk {
+    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![text.len() as f32; trusty_common::embedder::EMBED_DIM])
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        Ok(texts
+            .iter()
+            .map(|t| vec![t.len() as f32; trusty_common::embedder::EMBED_DIM])
+            .collect())
+    }
+
+    fn dimension(&self) -> usize {
+        trusty_common::embedder::EMBED_DIM
+    }
+}
+
+/// Fake python adapter whose readiness probe always fails (simulates a
+/// spawn/import/model-load failure discovered through the real embed call).
+struct FakePythonEmbedderErr;
+
+#[async_trait::async_trait]
+impl crate::core::Embedder for FakePythonEmbedderErr {
+    async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        anyhow::bail!("fake readiness probe failure")
+    }
+
+    async fn embed_batch(&self, _texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        anyhow::bail!("fake readiness probe failure")
+    }
+
+    fn dimension(&self) -> usize {
+        trusty_common::embedder::EMBED_DIM
+    }
+}
+
+/// Fully deterministic fake [`PythonBootstrap`] — no real `uv`/torch/venv or
+/// subprocess ever runs.
+struct FakeBootstrap {
+    /// Number of leading `ensure_venv()` calls that fail before succeeding.
+    venv_failures_remaining: AtomicUsize,
+    /// When true, the built adapter's readiness probe always fails.
+    fail_probe: bool,
+    /// Total `ensure_venv()` invocations observed — lets tests assert retry
+    /// behavior actually re-ran the bootstrap step.
+    venv_attempts: AtomicUsize,
+}
+
+impl FakeBootstrap {
+    fn always_succeeds() -> Self {
+        Self {
+            venv_failures_remaining: AtomicUsize::new(0),
+            fail_probe: false,
+            venv_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn probe_always_fails() -> Self {
+        Self {
+            venv_failures_remaining: AtomicUsize::new(0),
+            fail_probe: true,
+            venv_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn venv_always_fails() -> Self {
+        Self {
+            venv_failures_remaining: AtomicUsize::new(u32::MAX as usize),
+            fail_probe: false,
+            venv_attempts: AtomicUsize::new(0),
+        }
+    }
+
+    fn venv_fails_once_then_succeeds() -> Self {
+        Self {
+            venv_failures_remaining: AtomicUsize::new(1),
+            fail_probe: false,
+            venv_attempts: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl PythonBootstrap for FakeBootstrap {
+    fn ensure_venv(&self) -> anyhow::Result<()> {
+        self.venv_attempts
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let remaining = self
+            .venv_failures_remaining
+            .load(std::sync::atomic::Ordering::Relaxed);
+        if remaining > 0 {
+            self.venv_failures_remaining
+                .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            anyhow::bail!("fake venv bootstrap failure");
+        }
+        Ok(())
+    }
+
+    fn locate_launcher(&self) -> anyhow::Result<std::path::PathBuf> {
+        Ok(std::path::PathBuf::from("/fake/trusty-embedderd-py"))
+    }
+
+    fn build_adapter(
+        &self,
+        _launcher: std::path::PathBuf,
+    ) -> (
+        OrchestratorArc<dyn crate::core::Embedder>,
+        Option<OrchestratorArc<OrchestratorAtomicU32>>,
+    ) {
+        let adapter: OrchestratorArc<dyn crate::core::Embedder> = if self.fail_probe {
+            OrchestratorArc::new(FakePythonEmbedderErr)
+        } else {
+            OrchestratorArc::new(FakePythonEmbedderOk)
+        };
+        (
+            adapter,
+            Some(OrchestratorArc::new(OrchestratorAtomicU32::new(4242))),
+        )
+    }
+
+    fn probe_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(5)
+    }
+}
+
+/// The `ActiveBackend` `build_embedder`'s new graceful-python arm installs:
+/// ort, `Bootstrapping`.
+fn test_ort_bootstrapping_active() -> SwitchableActiveBackend {
+    SwitchableActiveBackend {
+        kind: SwitchableBackendKind::Ort,
+        provider: trusty_common::embedder::ExecutionProvider::Cpu,
+        model: "all-MiniLM-L6-v2".to_string(),
+        quantized: false,
+        bootstrap: SwitchableBootstrapState::Bootstrapping,
+    }
+}
+
+/// Happy path: a successful bootstrap + readiness probe must hot-swap the
+/// switchable from ort/Bootstrapping to python/Ready.
+#[tokio::test]
+async fn graceful_bootstrap_swaps_to_python_on_success() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
+        ort,
+        test_ort_bootstrapping_active(),
+    ));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    let ops: OrchestratorArc<dyn PythonBootstrap> =
+        OrchestratorArc::new(FakeBootstrap::always_succeeds());
+
+    drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 2).await;
+
+    let active = switchable.active();
+    assert_eq!(active.kind, SwitchableBackendKind::Python);
+    assert_eq!(active.bootstrap, SwitchableBootstrapState::Ready);
+}
+
+/// A readiness-probe failure must leave the switchable on the still-installed
+/// ort backend, marked `Failed` — never a torn or missing backend.
+#[tokio::test]
+async fn graceful_bootstrap_stays_ort_and_failed_after_probe_failure() {
+    let ort = OrchestratorArc::new(FakeOrtEmbedder::new());
+    let ort_dyn: OrchestratorArc<dyn crate::core::Embedder> = OrchestratorArc::clone(&ort) as _;
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
+        ort_dyn,
+        test_ort_bootstrapping_active(),
+    ));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    let ops: OrchestratorArc<dyn PythonBootstrap> =
+        OrchestratorArc::new(FakeBootstrap::probe_always_fails());
+
+    drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 1).await;
+
+    let active = switchable.active();
+    assert_eq!(
+        active.kind,
+        SwitchableBackendKind::Ort,
+        "must stay on the still-installed ort backend"
+    );
+    assert_eq!(active.bootstrap, SwitchableBootstrapState::Failed);
+
+    // Prove the ort backend is still live and serving (not swapped away).
+    switchable
+        .embed("probe")
+        .await
+        .expect("ort backend must still serve after a failed python bootstrap");
+    assert_eq!(ort.calls.load(std::sync::atomic::Ordering::Relaxed), 1);
+}
+
+/// A venv-bootstrap failure (before a python adapter is even built) must
+/// also leave the switchable on ort, marked `Failed`.
+#[tokio::test]
+async fn graceful_bootstrap_stays_ort_and_failed_after_bootstrap_failure() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
+        ort,
+        test_ort_bootstrapping_active(),
+    ));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    let ops: OrchestratorArc<dyn PythonBootstrap> =
+        OrchestratorArc::new(FakeBootstrap::venv_always_fails());
+
+    drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 1).await;
+
+    let active = switchable.active();
+    assert_eq!(active.kind, SwitchableBackendKind::Ort);
+    assert_eq!(active.bootstrap, SwitchableBootstrapState::Failed);
+}
+
+/// A transient failure on the first attempt must be retried, succeeding on
+/// the second — proving the retry loop actually re-invokes every bootstrap
+/// step rather than giving up after one failure. Uses paused virtual time so
+/// the linear backoff between attempts resolves instantly.
+#[tokio::test(start_paused = true)]
+async fn graceful_bootstrap_retries_before_giving_up() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
+        ort,
+        test_ort_bootstrapping_active(),
+    ));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    let fake = OrchestratorArc::new(FakeBootstrap::venv_fails_once_then_succeeds());
+    let ops: OrchestratorArc<dyn PythonBootstrap> = OrchestratorArc::clone(&fake) as _;
+
+    drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 2).await;
+
+    let active = switchable.active();
+    assert_eq!(
+        active.kind,
+        SwitchableBackendKind::Python,
+        "the second attempt must succeed and hot-swap"
+    );
+    assert_eq!(active.bootstrap, SwitchableBootstrapState::Ready);
+    assert_eq!(
+        fake.venv_attempts
+            .load(std::sync::atomic::Ordering::Relaxed),
+        2,
+        "ensure_venv must have been retried, not just called once"
+    );
+}
+
+/// Exhausting every retry attempt must mark the switchable `Failed` while
+/// staying on ort — confirms the retry loop actually bounds itself at
+/// `retries` attempts rather than looping forever.
+#[tokio::test(start_paused = true)]
+async fn graceful_bootstrap_gives_up_after_exhausting_retries() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
+        ort,
+        test_ort_bootstrapping_active(),
+    ));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    let fake = OrchestratorArc::new(FakeBootstrap::venv_always_fails());
+    let ops: OrchestratorArc<dyn PythonBootstrap> = OrchestratorArc::clone(&fake) as _;
+
+    drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 3).await;
+
+    let active = switchable.active();
+    assert_eq!(active.kind, SwitchableBackendKind::Ort);
+    assert_eq!(active.bootstrap, SwitchableBootstrapState::Failed);
+    assert_eq!(
+        fake.venv_attempts
+            .load(std::sync::atomic::Ordering::Relaxed),
+        3,
+        "must attempt exactly `retries` times, no more, no less"
+    );
+}

--- a/crates/trusty-search/src/commands/start/tests.rs
+++ b/crates/trusty-search/src/commands/start/tests.rs
@@ -1098,6 +1098,43 @@ impl crate::core::Embedder for FakePythonEmbedderErr {
     }
 }
 
+/// Fake python adapter whose readiness probe never resolves within any
+/// reasonable timeout (simulates a hung/stalled real embed call) — used to
+/// drive the orchestrator's probe-TIMEOUT teardown path deterministically
+/// under paused virtual time.
+struct FakePythonEmbedderHangs;
+
+#[async_trait::async_trait]
+impl crate::core::Embedder for FakePythonEmbedderHangs {
+    async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        std::future::pending().await
+    }
+
+    async fn embed_batch(&self, _texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        std::future::pending().await
+    }
+
+    fn dimension(&self) -> usize {
+        trusty_common::embedder::EMBED_DIM
+    }
+}
+
+/// Controllable fake [`PythonAdapterTeardown`] — records how many times
+/// `teardown()` was invoked so tests can assert it fires on the probe
+/// failure/timeout paths and NEVER on success or on a pre-adapter
+/// (venv-bootstrap) failure (epic #3524 slice 6 PR-3 fix — code-critic HIGH).
+struct FakeTeardown {
+    calls: OrchestratorArc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl super::graceful_bootstrap::PythonAdapterTeardown for FakeTeardown {
+    async fn teardown(&self) {
+        self.calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 /// Fully deterministic fake [`PythonBootstrap`] — no real `uv`/torch/venv or
 /// subprocess ever runs.
 struct FakeBootstrap {
@@ -1105,9 +1142,15 @@ struct FakeBootstrap {
     venv_failures_remaining: AtomicUsize,
     /// When true, the built adapter's readiness probe always fails.
     fail_probe: bool,
+    /// When true, the built adapter's readiness probe hangs forever (the
+    /// probe timeout fires instead of an `Err`).
+    hang_probe: bool,
     /// Total `ensure_venv()` invocations observed — lets tests assert retry
     /// behavior actually re-ran the bootstrap step.
     venv_attempts: AtomicUsize,
+    /// Total `PythonAdapterTeardown::teardown()` invocations observed across
+    /// every `build_adapter` call this fake made.
+    teardown_calls: OrchestratorArc<AtomicUsize>,
 }
 
 impl FakeBootstrap {
@@ -1115,7 +1158,9 @@ impl FakeBootstrap {
         Self {
             venv_failures_remaining: AtomicUsize::new(0),
             fail_probe: false,
+            hang_probe: false,
             venv_attempts: AtomicUsize::new(0),
+            teardown_calls: OrchestratorArc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -1123,7 +1168,19 @@ impl FakeBootstrap {
         Self {
             venv_failures_remaining: AtomicUsize::new(0),
             fail_probe: true,
+            hang_probe: false,
             venv_attempts: AtomicUsize::new(0),
+            teardown_calls: OrchestratorArc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn probe_always_hangs() -> Self {
+        Self {
+            venv_failures_remaining: AtomicUsize::new(0),
+            fail_probe: false,
+            hang_probe: true,
+            venv_attempts: AtomicUsize::new(0),
+            teardown_calls: OrchestratorArc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -1131,7 +1188,9 @@ impl FakeBootstrap {
         Self {
             venv_failures_remaining: AtomicUsize::new(u32::MAX as usize),
             fail_probe: false,
+            hang_probe: false,
             venv_attempts: AtomicUsize::new(0),
+            teardown_calls: OrchestratorArc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -1139,8 +1198,15 @@ impl FakeBootstrap {
         Self {
             venv_failures_remaining: AtomicUsize::new(1),
             fail_probe: false,
+            hang_probe: false,
             venv_attempts: AtomicUsize::new(0),
+            teardown_calls: OrchestratorArc::new(AtomicUsize::new(0)),
         }
+    }
+
+    fn teardown_calls(&self) -> usize {
+        self.teardown_calls
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 }
 
@@ -1169,20 +1235,34 @@ impl PythonBootstrap for FakeBootstrap {
     ) -> (
         OrchestratorArc<dyn crate::core::Embedder>,
         Option<OrchestratorArc<OrchestratorAtomicU32>>,
+        OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown>,
     ) {
         let adapter: OrchestratorArc<dyn crate::core::Embedder> = if self.fail_probe {
             OrchestratorArc::new(FakePythonEmbedderErr)
+        } else if self.hang_probe {
+            OrchestratorArc::new(FakePythonEmbedderHangs)
         } else {
             OrchestratorArc::new(FakePythonEmbedderOk)
         };
+        let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
+            OrchestratorArc::new(FakeTeardown {
+                calls: OrchestratorArc::clone(&self.teardown_calls),
+            });
         (
             adapter,
             Some(OrchestratorArc::new(OrchestratorAtomicU32::new(4242))),
+            teardown,
         )
     }
 
     fn probe_timeout(&self) -> std::time::Duration {
-        std::time::Duration::from_secs(5)
+        if self.hang_probe {
+            // Short enough that the paused-clock test resolves instantly,
+            // long enough to be unambiguous in intent.
+            std::time::Duration::from_millis(50)
+        } else {
+            std::time::Duration::from_secs(5)
+        }
     }
 }
 
@@ -1209,14 +1289,19 @@ async fn graceful_bootstrap_swaps_to_python_on_success() {
         test_ort_bootstrapping_active(),
     ));
     let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
-    let ops: OrchestratorArc<dyn PythonBootstrap> =
-        OrchestratorArc::new(FakeBootstrap::always_succeeds());
+    let fake = OrchestratorArc::new(FakeBootstrap::always_succeeds());
+    let ops: OrchestratorArc<dyn PythonBootstrap> = OrchestratorArc::clone(&fake) as _;
 
     drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 2).await;
 
     let active = switchable.active();
     assert_eq!(active.kind, SwitchableBackendKind::Python);
     assert_eq!(active.bootstrap, SwitchableBootstrapState::Ready);
+    assert_eq!(
+        fake.teardown_calls(),
+        0,
+        "teardown must never fire on the success path — the handle stays live"
+    );
 }
 
 /// A readiness-probe failure must leave the switchable on the still-installed
@@ -1230,8 +1315,8 @@ async fn graceful_bootstrap_stays_ort_and_failed_after_probe_failure() {
         test_ort_bootstrapping_active(),
     ));
     let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
-    let ops: OrchestratorArc<dyn PythonBootstrap> =
-        OrchestratorArc::new(FakeBootstrap::probe_always_fails());
+    let fake = OrchestratorArc::new(FakeBootstrap::probe_always_fails());
+    let ops: OrchestratorArc<dyn PythonBootstrap> = OrchestratorArc::clone(&fake) as _;
 
     drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 1).await;
 
@@ -1262,14 +1347,90 @@ async fn graceful_bootstrap_stays_ort_and_failed_after_bootstrap_failure() {
         test_ort_bootstrapping_active(),
     ));
     let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
-    let ops: OrchestratorArc<dyn PythonBootstrap> =
-        OrchestratorArc::new(FakeBootstrap::venv_always_fails());
+    let fake = OrchestratorArc::new(FakeBootstrap::venv_always_fails());
+    let ops: OrchestratorArc<dyn PythonBootstrap> = OrchestratorArc::clone(&fake) as _;
 
     drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 1).await;
 
     let active = switchable.active();
     assert_eq!(active.kind, SwitchableBackendKind::Ort);
     assert_eq!(active.bootstrap, SwitchableBootstrapState::Failed);
+    assert_eq!(
+        fake.teardown_calls(),
+        0,
+        "no adapter/handle was ever built (venv bootstrap failed first) — \
+         nothing to tear down"
+    );
+}
+
+/// code-critic HIGH fix (epic #3524 slice 6 PR-3): a probe-failure path must
+/// cooperatively tear down the just-spawned handle BEFORE dropping it, so a
+/// failed bootstrap never orphans a real python/MPS child process waiting on
+/// the idle watchdog (up to 1800s later).
+///
+/// Why: this is the dedicated regression test for the exact leak code-critic
+/// flagged — earlier `graceful_bootstrap_stays_ort_and_failed_after_probe_failure`
+/// proves the SWITCHABLE state; this test proves the TEARDOWN CALL itself
+/// fires exactly once per failed attempt.
+/// What: 2 retries, both probe failures — `teardown_calls()` must equal 2
+/// (one per attempt, each attempt builds a fresh adapter/handle).
+/// Test: this test.
+#[tokio::test(start_paused = true)]
+async fn graceful_bootstrap_probe_failure_tears_down_the_handle() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
+        ort,
+        test_ort_bootstrapping_active(),
+    ));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    let fake = OrchestratorArc::new(FakeBootstrap::probe_always_fails());
+    let ops: OrchestratorArc<dyn PythonBootstrap> = OrchestratorArc::clone(&fake) as _;
+
+    drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 2).await;
+
+    assert_eq!(
+        switchable.active().bootstrap,
+        SwitchableBootstrapState::Failed
+    );
+    assert_eq!(
+        fake.teardown_calls(),
+        2,
+        "teardown must fire once per failed attempt — a probe failure must \
+         never leave a spawned handle un-shut-down"
+    );
+}
+
+/// code-critic HIGH fix, timeout variant: a probe TIMEOUT (not just an
+/// `Err`) must ALSO tear down the handle before dropping it — the probe may
+/// still be in flight against a live, just-spawned child when the timeout
+/// fires.
+/// What: a hanging fake adapter + a short fake probe timeout, under paused
+/// virtual time so the test resolves instantly; asserts the switchable stays
+/// ort/Failed and `teardown_calls() == 1`.
+/// Test: this test.
+#[tokio::test(start_paused = true)]
+async fn graceful_bootstrap_probe_timeout_tears_down_the_handle() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
+        ort,
+        test_ort_bootstrapping_active(),
+    ));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    let fake = OrchestratorArc::new(FakeBootstrap::probe_always_hangs());
+    let ops: OrchestratorArc<dyn PythonBootstrap> = OrchestratorArc::clone(&fake) as _;
+
+    drive_bootstrap(OrchestratorArc::clone(&switchable), state, ops, 1).await;
+
+    let active = switchable.active();
+    assert_eq!(active.kind, SwitchableBackendKind::Ort);
+    assert_eq!(active.bootstrap, SwitchableBootstrapState::Failed);
+    assert_eq!(
+        fake.teardown_calls(),
+        1,
+        "a probe TIMEOUT must also tear down the handle, not just a probe Err"
+    );
 }
 
 /// A transient failure on the first attempt must be retried, succeeding on

--- a/crates/trusty-search/src/service/embedder_supervisor/mod.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/mod.rs
@@ -474,6 +474,54 @@ impl LazyEmbedderHandle {
 
         result
     }
+
+    /// Immediately, cooperatively shut down the sidecar this handle owns, if
+    /// one has spawned — an EAGER counterpart to `idle_watchdog`'s own
+    /// teardown (epic #3524 slice 6, PR 3/5 fix — code-critic HIGH, orphaned
+    /// python child on bootstrap-probe failure).
+    ///
+    /// Why: the graceful-python background bootstrap orchestrator
+    /// (`commands::start::graceful_bootstrap`) builds a fresh
+    /// `LazyEmbedderHandle` per bootstrap attempt and forces a real spawn via
+    /// its readiness-probe embed call (`embed_via` → `do_spawn`). If that
+    /// probe fails or times out, the orchestrator's only reference to the
+    /// handle is dropped — but `LazyEmbedderHandle` has no `Drop` impl (its
+    /// `SpawnedState` teardown is an async cooperative shutdown, which
+    /// `Drop::drop` cannot perform), so without this method the just-spawned
+    /// child (torch+MPS, hundreds of MB-GB on the memory-constrained
+    /// Apple-Silicon machines this targets) would only be reaped
+    /// `idle_shutdown_secs` later (up to 1800s for the python arm) by the
+    /// detached `idle_watchdog` — with `TRUSTY_PY_BOOTSTRAP_RETRIES`, up to N
+    /// such orphans could be alive concurrently.
+    ///
+    /// What: takes the state lock, takes the `SpawnedState` out (so the spawn
+    /// gate is reset — a concurrent caller would trigger a fresh spawn rather
+    /// than reuse a killed one), clears the PID slot, and — mirroring
+    /// `idle_watchdog`'s own teardown exactly — calls
+    /// `SupervisorHandle::shutdown()` (cooperative: flips the shared shutdown
+    /// flag; the supervision loop kills + reaps the child itself, clears
+    /// `child_pid_slot`, and never enters the crash-restart path, so this can
+    /// never be misclassified as a crash and respawned; this method then
+    /// awaits that confirmation before returning). Dropping the taken
+    /// `SpawnedState` afterwards also drops its `shutdown_tx`, which signals
+    /// this same instance's `idle_watchdog` task (if one was armed) to exit
+    /// immediately rather than tick uselessly against an already-empty
+    /// state. A no-op (returns immediately) if no child has spawned yet.
+    ///
+    /// Test: `lazy_handle_shutdown_kills_spawned_child`,
+    /// `lazy_handle_shutdown_is_noop_when_never_spawned` in this module's
+    /// `tests` submodule.
+    pub async fn shutdown(&self) {
+        let mut guard = self.state.lock().await;
+        let Some(spawned) = guard.take() else {
+            return;
+        };
+        drop(guard);
+        self.app_pid_slot.store(0, AtomicOrdering::Release);
+        if let Some(handle) = spawned.supervisor_handle {
+            handle.shutdown().await;
+        }
+    }
 }
 
 /// RAII guard that tracks an in-flight embed request (issue #2315).

--- a/crates/trusty-search/src/service/embedder_supervisor/switchable.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/switchable.rs
@@ -201,6 +201,20 @@ impl SwitchableEmbedder {
     /// replaces both fields together, so it is the wrong tool here.
     /// What: reads the current [`ActiveBackend`], clones every field except
     /// `bootstrap`, and stores a fresh snapshot with `bootstrap` replaced.
+    ///
+    /// Concurrency note (code-critic LOW, epic #3524 slice 6 PR-3 review):
+    /// this is a non-atomic read-modify-write on `active` — `self.active()`
+    /// then `self.active.store(..)` — NOT a compare-and-swap. Two concurrent
+    /// callers (or a concurrent [`Self::swap_to`]) can race: the read in one
+    /// call may be stale by the time its store lands, silently clobbering
+    /// whatever the other caller/`swap_to` just wrote. Safe today ONLY
+    /// because the graceful-default orchestrator (PR-3) is the sole writer
+    /// of `bootstrap` transitions and never runs concurrently with itself
+    /// (one orchestrator task per daemon lifetime, swap-in only). PR-4
+    /// (swap-back-on-death) introduces a SECOND writer of `active` racing
+    /// this one — at that point this method must become a real CAS loop
+    /// (`ArcSwap::rcu` or a compare-and-swap retry) instead of a plain
+    /// load-then-store.
     /// Test: `set_bootstrap_state_leaves_inner_untouched`.
     pub fn set_bootstrap_state(&self, new_state: BootstrapState) {
         let current = self.active();

--- a/crates/trusty-search/src/service/embedder_supervisor/switchable.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/switchable.rs
@@ -189,6 +189,30 @@ impl SwitchableEmbedder {
         self.active.load_full()
     }
 
+    /// Update only the [`BootstrapState`] of the descriptive snapshot,
+    /// leaving the live backend (`inner`) untouched (epic #3524 slice 6,
+    /// PR 3/5).
+    ///
+    /// Why: the graceful-default background orchestrator serves on ort
+    /// while a python bootstrap runs; on final bootstrap/probe failure it
+    /// must record `Failed` (so `/health` stops reporting `Bootstrapping`
+    /// forever) while explicitly staying on the still-installed ort
+    /// backend — i.e. `inner` must NOT change. [`Self::swap_to`] always
+    /// replaces both fields together, so it is the wrong tool here.
+    /// What: reads the current [`ActiveBackend`], clones every field except
+    /// `bootstrap`, and stores a fresh snapshot with `bootstrap` replaced.
+    /// Test: `set_bootstrap_state_leaves_inner_untouched`.
+    pub fn set_bootstrap_state(&self, new_state: BootstrapState) {
+        let current = self.active();
+        self.active.store(Arc::new(ActiveBackend {
+            kind: current.kind,
+            provider: current.provider,
+            model: current.model.clone(),
+            quantized: current.quantized,
+            bootstrap: new_state,
+        }));
+    }
+
     /// Snapshot the currently-installed backend itself.
     ///
     /// Why: shared by `embed`/`embed_batch` so both go through the same
@@ -299,6 +323,32 @@ mod tests {
         assert_eq!(sw.active().kind, BackendKind::Python);
         assert_eq!(sw.active().model, "test-model");
         assert_eq!(sw.active().bootstrap, BootstrapState::NotApplicable);
+    }
+
+    /// `set_bootstrap_state` must update only `active.bootstrap`, leaving the
+    /// installed backend (`inner`) — and every other `ActiveBackend` field —
+    /// unchanged. This is the mechanism the graceful-default orchestrator
+    /// (PR-3) uses to mark a failed python bootstrap `Failed` while staying
+    /// on the still-installed ort backend.
+    #[tokio::test]
+    async fn set_bootstrap_state_leaves_inner_untouched() {
+        let fake = Arc::new(FakeEmbedder::new());
+        let fake_dyn: Arc<dyn Embedder> = Arc::clone(&fake) as Arc<dyn Embedder>;
+        let mut active = test_active(BackendKind::Ort);
+        active.bootstrap = BootstrapState::Bootstrapping;
+        let sw = SwitchableEmbedder::new(fake_dyn, active);
+
+        sw.set_bootstrap_state(BootstrapState::Failed);
+
+        let after = sw.active();
+        assert_eq!(after.kind, BackendKind::Ort);
+        assert_eq!(after.bootstrap, BootstrapState::Failed);
+        assert_eq!(after.model, "test-model");
+
+        // The backend itself must still be the original fake — prove it by
+        // observing the call counter increment on a fresh embed call.
+        sw.embed("probe").await.expect("embed must still work");
+        assert_eq!(fake.calls.load(Ordering::Relaxed), 1);
     }
 
     /// Proves the wait-free-swap contract under load: many concurrent

--- a/crates/trusty-search/src/service/embedder_supervisor/tests.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/tests.rs
@@ -2,9 +2,14 @@
 //!
 //! Why: we validate the deterministic, pure parts of the supervisor
 //! (config parsing, socket path, binary discovery, lazy-handle spawn
-//! accounting) without needing a live ONNX binary. Process-lifecycle
-//! tests (spawn/restart/shutdown) are in `tests/embedder_supervisor_e2e.rs`
-//! and marked `#[ignore]`.
+//! accounting) without needing a live ONNX binary. Real-ONNX-binary
+//! process-lifecycle tests (spawn/restart) are in
+//! `tests/embedder_supervisor_e2e.rs` and marked `#[ignore]`; the
+//! `shutdown_tests` submodule below is the exception — it exercises
+//! `LazyEmbedderHandle::shutdown()`'s real process-lifecycle teardown
+//! against a fast POSIX-shell mock stdio server instead, so it runs in every
+//! CI pass without `#[ignore]` (mirrors `trusty-common`'s own
+//! `supervisor.rs` `shutdown_tests` module).
 //! Test: `cargo test -p trusty-search -- embedder_supervisor`.
 
 use super::*;
@@ -720,5 +725,124 @@ impl Drop for EnvGuard {
                 None => std::env::remove_var(&self.key),
             }
         }
+    }
+}
+
+// ── LazyEmbedderHandle::shutdown() (epic #3524 slice 6 PR-3 fix — ──────────
+// code-critic HIGH: orphaned python child on bootstrap-probe failure)
+//
+// These spawn a real (but tiny) child process — a POSIX shell script that
+// speaks just enough of the trusty-embedderd stdio JSON-RPC wire protocol to
+// pass `spawn_child`'s startup probe, then idles until killed — so
+// `LazyEmbedderHandle::shutdown()` exercises its real process-lifecycle
+// teardown without needing the actual ONNX binary or `#[ignore]`. Mirrors
+// trusty-common's own `supervisor.rs` `shutdown_tests` module.
+#[cfg(unix)]
+mod shutdown_tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    /// Write a minimal stdio JSON-RPC mock of `trusty-embedderd --stdio` to a
+    /// temp file; returns the path plus the guarding `TempDir`.
+    /// Why/What: see `trusty_common::embedder_client::supervisor`'s own
+    /// `write_mock_embedderd` (private to that crate — reimplemented here,
+    /// identical wire behaviour).
+    fn write_mock_embedderd() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("mock-embedderd.sh");
+        std::fs::write(
+            &path,
+            r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  [ -n "$id" ] || id=1
+  printf '{"jsonrpc":"2.0","result":{"embeddings":[[0.1]]},"id":%s}\n' "$id"
+done
+"#,
+        )
+        .expect("write mock script");
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod +x");
+        (dir, path)
+    }
+
+    /// Best-effort liveness check via `kill -0 <pid>` (no signal sent, just
+    /// an existence probe).
+    fn process_alive(pid: u32) -> bool {
+        std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// `shutdown()` must be a no-op when the handle never spawned — nothing
+    /// to tear down, so it must return immediately without touching the pid
+    /// slot or panicking on an absent `SpawnedState`.
+    /// Test: this test.
+    #[tokio::test]
+    async fn lazy_handle_shutdown_is_noop_when_never_spawned() {
+        let handle = LazyEmbedderHandle::new(
+            PathBuf::from("/nonexistent/trusty-embedderd"),
+            SupervisorConfig::default(),
+        );
+        handle.shutdown().await;
+        assert_eq!(handle.app_pid_slot().load(Ordering::Acquire), 0);
+    }
+
+    /// `shutdown()` must cooperatively kill a REAL (mocked) spawned child
+    /// through its `SupervisorHandle` — the exact orphan-leak fix the
+    /// graceful-python bootstrap orchestrator's probe-failure path relies on
+    /// (epic #3524 slice 6 PR-3, code-critic HIGH: "orphaned python child on
+    /// bootstrap-probe failure").
+    ///
+    /// Why: without this method, a probe failure/timeout in
+    /// `commands::start::graceful_bootstrap::try_bootstrap_once` dropped the
+    /// orchestrator's only `LazyEmbedderHandle` reference and left the
+    /// just-spawned child alive until the detached idle watchdog reaped it
+    /// (up to 1800s later for the python arm) — with retries, up to N such
+    /// orphans concurrently.
+    /// What: forces a real spawn via `embed_via` against the mock stdio
+    /// script (the same real spawn path the readiness probe drives),
+    /// captures the child PID, calls `handle.shutdown()`, and asserts the OS
+    /// process is actually gone and the PID slot is cleared.
+    /// Test: this test.
+    #[tokio::test]
+    async fn lazy_handle_shutdown_kills_spawned_child() {
+        let (_dir, binary) = write_mock_embedderd();
+        let handle = LazyEmbedderHandle::new(
+            binary,
+            SupervisorConfig {
+                startup_timeout_secs: 5,
+                idle_shutdown_secs: 0, // no watchdog racing this test
+                ..SupervisorConfig::default()
+            },
+        );
+
+        // Force a real spawn — mirrors the readiness-probe embed call the
+        // graceful-python orchestrator makes before deciding to hot-swap.
+        handle
+            .embed_via(|client| async move { client.embed_batch(vec!["probe".to_string()]).await })
+            .await
+            .expect("mock embed_batch must succeed");
+
+        let pid = handle.app_pid_slot().load(Ordering::Acquire);
+        assert!(pid > 0, "pid slot must be populated after a real spawn");
+        assert!(process_alive(pid), "child must be alive right after spawn");
+
+        handle.shutdown().await;
+
+        assert!(
+            !process_alive(pid),
+            "child process {pid} must be gone after LazyEmbedderHandle::shutdown()"
+        );
+        assert_eq!(
+            handle.app_pid_slot().load(Ordering::Acquire),
+            0,
+            "pid slot must be cleared after shutdown()"
+        );
     }
 }


### PR DESCRIPTION
## Summary

PR-3 of the graceful-default work (epic #3524 slice 6). Wires the
Apple-Silicon default gating + the background bootstrap→hot-swap
orchestrator. **The default stays OFF behind `TRUSTY_PY_DEFAULT` in this
PR — no user-facing behavior change ships yet.**

Builds on `main` (has PR-1 `SwitchableEmbedder` + PR-2 `/health` truth,
squash `12e9d37d`).

### Mechanism

On Apple Silicon, once `TRUSTY_PY_DEFAULT` is enabled, `trusty-search start`:
1. Serves on the ort stdio sidecar **immediately** (identical construction
   to today's default) — the `SwitchableEmbedder`'s `ActiveBackend.bootstrap`
   starts `Bootstrapping`.
2. A detached background task (`commands/start/graceful_bootstrap.rs`)
   bootstraps the python/MPS venv, locates the launcher, builds the adapter,
   and proves it with **one real readiness-probe embed call** through the
   supervisor (bounded by the existing `TRUSTY_EMBEDDERD_STARTUP_TIMEOUT_SECS`).
3. On success: hot-swaps the running `SwitchableEmbedder` (epic #3524 PR-1)
   to the python adapter (`bootstrap: Ready`) and installs the python pid
   slot so `/health` RSS tracking follows the new child.
4. On failure (after `TRUSTY_PY_BOOTSTRAP_RETRIES` attempts, default 2, with
   a linear backoff): marks `bootstrap: Failed` via the new
   `SwitchableEmbedder::set_bootstrap_state` (updates only the bootstrap
   flag, leaving the still-installed ort backend untouched) and stays on
   ort permanently for that daemon's lifetime.

None of this blocks the HTTP listener or daemon startup.

### Ship-gate

- `TRUSTY_PY_DEFAULT` (default OFF) — the ship-gate. Unset/falsy leaves
  Apple-Silicon unset/`auto` resolution **completely unchanged** (ort). A
  later slice (PR-5) flips the default on after a soak. `TRUSTY_EMBEDDER=stdio`
  remains the permanent per-invocation opt-out.
- `TRUSTY_EMBEDDER_PYTHON_EAGER` — reaches the existing eager blocking
  `python` arm via unset/`auto` instead of an explicit value (any platform).
- `TRUSTY_PY_BOOTSTRAP_RETRIES` (default 2) — bootstrap→probe attempt count.

### Linux/CUDA/Intel-mac

Completely unaffected — `resolve_default_embedder_mode_for` structurally
never returns `GracefulPython` off Apple Silicon regardless of env, so
`ensure_venv`/`uv`/torch are never invoked there. Covered by
`resolve_default_embedder_mode_for_non_apple_silicon_ignores_flag`.

### Scope note

This PR is **swap-in only**. Detecting a live python sidecar dying after a
successful hot-swap and falling back to ort is epic #3524 slice 6 PR-4's
scope — a seam is documented in `drive_bootstrap`'s doc comment.

## Files

- `crates/trusty-search/src/commands/start/embedder.rs` — `DefaultEmbedderMode`
  + `resolve_default_embedder_mode()`/`_for()`; new `GracefulPython` arm;
  extracted `build_eager_python_embedder()`.
- `crates/trusty-search/src/commands/start/graceful_bootstrap.rs` (new) —
  `PythonBootstrap` trait + `RealPythonBootstrap` + `drive_bootstrap()`
  retry/probe/swap state machine.
- `crates/trusty-search/src/commands/start/daemon.rs` — spawns the
  orchestrator right after the embedder + switchable are installed.
- `crates/trusty-search/src/service/embedder_supervisor/switchable.rs` —
  `SwitchableEmbedder::set_bootstrap_state()`.
- `crates/trusty-search/src/commands/start/tests.rs` — new unit tests.
- `crates/trusty-search/CLAUDE.md`, `CHANGELOG.md` — env var docs.
- `crates/trusty-search/Cargo.toml` — `tokio/test-util` dev-dependency
  (paused-clock retry test).

## Test plan

- [x] `cargo test -p trusty-search` (lib target) — 1202 passed, 1 failed
      (`gitignore_entry_added_idempotently`, known local-env failure)
- [x] `cargo test -p trusty-search --bin trusty-search` (bin target, where
      `commands::start` lives) — 286 passed, 1 failed
      (`migrate_storage_moves_files_and_updates_registry`, known local-env
      failure)
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-search --check` — clean
- [x] `scripts/check_line_cap.sh` — 0 violations
- [x] `scripts/check_test_pointers.sh` — 0 dangling pointers
- [x] New tests: `resolve_default_embedder_mode_for_*` (precedence),
      `truthy_env_*`, `resolve_bootstrap_retries_*`,
      `graceful_bootstrap_swaps_to_python_on_success`,
      `graceful_bootstrap_stays_ort_and_failed_after_probe_failure`,
      `graceful_bootstrap_stays_ort_and_failed_after_bootstrap_failure`,
      `graceful_bootstrap_retries_before_giving_up`,
      `graceful_bootstrap_gives_up_after_exhausting_retries`,
      `set_bootstrap_state_leaves_inner_untouched` — all use fakes, no real
      uv/torch/MPS/subprocess in CI.

Refs #3524

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools