### PR TITLE
fix(release): detect unpublished version drift + dependency-ordered dry-run guard

### DIFF
--- a/.claude/skills/cargo-publish/SKILL.md
+++ b/.claude/skills/cargo-publish/SKILL.md
@@ -69,6 +69,18 @@ downgrades both guard failures to a loud warning and exits 0. Only use this
 when you have a specific, understood reason to publish from an unmerged
 commit — the default path is always "merge to main first, then publish."
 
+**Also now enforced independently of any human running a script (issue
+#3366)**: `.github/workflows/release.yml`'s `preflight` job verifies the SAME
+rule mechanically for the tag-triggered binary-release pipeline — a real
+ancestry check (`git merge-base --is-ancestor` against a full-history clone
+of the tagged commit vs. `origin/main`), not a naive ref-string comparison
+(which would never match on a tag push and would silently disable every
+release). A tag pushed from an unmerged branch now fails that job loudly and
+the entire pipeline (build/release/homebrew-bump AND the publish-dry-run job
+below) is skipped — this is a second, independent enforcement point, not a
+replacement for running `check-publish-ready.sh` yourself before `cargo
+publish`.
+
 ## Step 5: Identity + Clean-Tree + Version-Not-Live Guard (MANDATORY, closes the 2026-07-08 collision)
 
 🔴 **Run `scripts/preflight-publish.sh` immediately before every `cargo publish`
@@ -252,13 +264,27 @@ registry — the same view downstream consumers will see.
 
 ## Cross-Crate Publish Ordering (RED — Common Pitfall)
 
-**Automated (issue #3366)**: `scripts/publish-dry-run-order.sh` computes the
-dependency order mechanically from `cargo metadata` and runs
+**Automated and CI-enforced (issue #3366)**: `scripts/publish-dry-run-order.sh`
+computes the dependency order mechanically from `cargo metadata` and runs
 `cargo publish --dry-run -p <crate>` for every publishable crate in that
 order (dependencies before dependents), stopping at the first failure — this
-replaces re-deriving the manual recipe below by hand for a full-workspace
-release. Pass specific crate names to restrict it to a partial release (it
-still includes any publishable crate they depend on, in order):
+replaces re-deriving the manual recipe below by hand.
+
+This now ALSO runs automatically, with no human action required: every
+`*-v*` tag push runs `.github/workflows/release.yml`'s `publish-dry-run` job,
+which invokes this script scoped to just the tagged crate + its publishable
+dependency closure. A human forgetting to run the manual command below no
+longer means an unsafe publish goes unnoticed — the tag push itself proves
+(or disproves) publish-safety, independent of whether anyone remembered the
+manual step. See that job's header comment for why it is scoped
+per-tag/per-crate rather than full-workspace-per-PR (cost, registry rate
+limits), and why it is deliberately independent of (not blocking) the binary
+build/release jobs.
+
+For a partial-release dry run before you've even tagged anything, or to dry
+run a set of crates together, use the script directly. Pass specific crate
+names to restrict it (it still includes any publishable crate they depend
+on, in order):
 
 ```bash
 scripts/publish-dry-run-order.sh --list-only          # print the order, run nothing

--- a/.claude/skills/cargo-publish/SKILL.md
+++ b/.claude/skills/cargo-publish/SKILL.md
@@ -104,6 +104,35 @@ the rare, logged `PREFLIGHT_ALLOW_DETACHED=1` override for check 1 (validated
 release worktrees only — misuse of it is exactly how the incident happened).
 No override exists for the identity check.
 
+## Step 6: Version-Parity Guard (MANDATORY, issue #3366)
+
+Before bumping a crate's version to publish, confirm the crate ISN'T already
+drifted — i.e. that its CURRENT (pre-bump) Cargo.toml version, if already
+live on crates.io, still matches the local `src/` tree. This is the
+`trusty-common`/`trusty-agents-common` incident: several commits of source
+changes landed on `main` without a version bump while the old version number
+was already published, so `cargo publish --dry-run` for a downstream crate
+failed with "symbol not found" for symbols that only existed in the drifted,
+unpublished source.
+
+```bash
+make version-parity-check
+# or directly:
+scripts/check-version-parity.sh
+```
+
+This also runs automatically on every push to `main`
+(`.github/workflows/version-parity.yml`) so drift is caught right after it
+merges rather than discovered as a release blocker. See
+`crates/trusty-publish-guard` for the underlying check (fails closed: a
+crate whose live/local comparison can't be verified is treated as a failure,
+never a silent pass).
+
+For the RELATED but distinct cross-crate ordering hazard (publishing a crate
+before a sibling it depends on is live — the 2026-07-20 incident), see
+`scripts/publish-dry-run-order.sh` in "Cross-Crate Publish Ordering" below —
+it now computes the dependency order mechanically instead of by hand.
+
 ## Worktree Discipline (MANDATORY)
 
 Always operate from a dedicated git worktree, never the main checkout.
@@ -222,6 +251,25 @@ registry — the same view downstream consumers will see.
 "dependency not found" because crates.io doesn't yet have A at the new version.
 
 ## Cross-Crate Publish Ordering (RED — Common Pitfall)
+
+**Automated (issue #3366)**: `scripts/publish-dry-run-order.sh` computes the
+dependency order mechanically from `cargo metadata` and runs
+`cargo publish --dry-run -p <crate>` for every publishable crate in that
+order (dependencies before dependents), stopping at the first failure — this
+replaces re-deriving the manual recipe below by hand for a full-workspace
+release. Pass specific crate names to restrict it to a partial release (it
+still includes any publishable crate they depend on, in order):
+
+```bash
+scripts/publish-dry-run-order.sh --list-only          # print the order, run nothing
+scripts/publish-dry-run-order.sh                      # dry-run every publishable crate, in order
+scripts/publish-dry-run-order.sh trusty-search trusty-common
+```
+
+The manual recipe below remains useful for reasoning about WHY a given order
+is correct, and the crate list in "Dependency Publish Order" further down is
+historical/illustrative rather than mechanically maintained — trust the
+script's computed order, not that hand-written list.
 
 ### The Recipe
 

--- a/.claude/skills/cargo-publish/SKILL.md
+++ b/.claude/skills/cargo-publish/SKILL.md
@@ -529,16 +529,34 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test -p <crate>
 cargo check --workspace
 
-# 5. If UI changes (trusty-search, trusty-memory), check for stale artifacts
+# 5. If UI changes (trusty-search, trusty-memory, trusty-analyze, trusty-console),
+#    check for stale artifacts AND stale bundle content (issue #3568)
 git status  # Look for node_modules/ or pnpm-workspace.yaml
 git clean -fdX  # If present
+#    Freshness (not just presence) matters: verify the COMMITTED ui-dist/ /
+#    ui/dist/ bundle actually reflects current ui/src — cargo publish cannot
+#    catch this for you (see step 7 note). Rebuild and diff:
+#      cd crates/<crate>/ui && pnpm install --frozen-lockfile && pnpm run build
+#      # trusty-search only: also copy ui/dist/* into ../ui-dist/ (or `make release-prep`)
+#    If the rebuild differs from what's committed, commit the regenerated
+#    bundle before continuing. `.github/workflows/release.yml`'s
+#    ui-freshness-check job does this same check automatically once you tag
+#    (step 9) — but catching it here, before tagging, is cheaper.
 
 # 6. Commit version bump
 git add -A
 git commit -m "chore: bump <crate> to v<version>"
 
 # 7. Dry run (essential — catches dependency issues early)
-cargo publish --dry-run -p <crate>
+# UI-embedding crates (trusty-search, trusty-memory, trusty-analyze,
+# trusty-console) REQUIRE SKIP_UI_BUILD=1 here — and this is not optional for
+# trusty-search/trusty-console specifically: their Cargo.toml `include` list
+# ships only the pre-built bundle, never `ui/src` (verified via `cargo
+# package --list`), so cargo has nothing to rebuild from during packaging
+# either way. This dry-run therefore verifies the RUST package publishes
+# cleanly — it provides NO signal on UI bundle freshness (that's step 5 /
+# ui-freshness-check, a structurally separate concern).
+SKIP_UI_BUILD=1 cargo publish --dry-run -p <crate>
 
 # 8. If dry-run fails:
 #    - Read the error (usually "dependency X version Y not found on crates.io")
@@ -552,8 +570,9 @@ git tag <crate>-v<version>
 # 10. Push tag to origin
 git push -u origin <crate>-v<version>
 
-# 11. Publish to crates.io
-cargo publish -p <crate>
+# 11. Publish to crates.io (same SKIP_UI_BUILD=1 requirement as step 7, for
+#     the same reason)
+SKIP_UI_BUILD=1 cargo publish -p <crate>
 
 # 12. Verification step
 sleep 100

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -620,6 +620,129 @@ jobs:
               f.write(f"matrix={result}\n")
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # JOB 1b: preflight (issue #3366)
+  #
+  # WHY: this workflow triggers on ANY push of a `*-v*` tag, from ANY branch —
+  #   there was no check that the tagged commit actually came from merged
+  #   main. This project's hard rule (see scripts/check-publish-ready.sh,
+  #   .claude/skills/cargo-publish/SKILL.md) is "publish only from merged main
+  #   or a release tag on main"; until now that rule was enforced only for a
+  #   human running check-publish-ready.sh by hand before `cargo publish` —
+  #   nothing stopped a tag pushed from an unmerged branch from firing this
+  #   entire binary-release pipeline (issue #2209 was exactly this class of
+  #   mistake, just for `cargo publish` directly rather than a tag push).
+  #
+  #   A naive `if: github.ref == 'refs/heads/main'` guard would NEVER match on
+  #   a tag push (`github.ref` is `refs/tags/<tag>` here, not a branch ref) and
+  #   would silently disable every release — so this instead verifies REAL
+  #   ancestry: the tagged commit must be reachable from `origin/main` via
+  #   `git merge-base --is-ancestor`. That check is only trustworthy against a
+  #   FULL clone (`fetch-depth: 0`) — a shallow checkout can make ancestry
+  #   checks lie (report "not an ancestor" for a commit that truly is, simply
+  #   because the shallow history horizon doesn't reach far enough back to
+  #   find the merge-base), so this job always fetches full history.
+  #
+  # WHAT: single job, runs first (before build/release/homebrew-bump), and
+  #   everything else now depends on it:
+  #     1. Full-history checkout.
+  #     2. On a real tag push: fetch the true `origin/main` tip and assert the
+  #        tagged commit (dereferenced via `HEAD^{commit}`, which resolves an
+  #        annotated tag object to its underlying commit — never trust
+  #        `github.sha` blindly here) is an ancestor of it. Fails loudly and
+  #        stops the entire pipeline (build/release/homebrew-bump AND the new
+  #        publish-dry-run job below all `need` this job) if not.
+  #     3. On workflow_dispatch (no tag exists): this is a deliberate manual
+  #        invocation already gated by repo write access, so the ancestry
+  #        check is a no-op (documented, not silently skipped — it prints why).
+  #     4. Resolves this tag's crate's crates.io package identity directly
+  #        from `crates/<crate>/Cargo.toml` (`name`, `publish`) — independent
+  #        of the binary-release allowlist in the `config` step above, because
+  #        library-only crates (e.g. trusty-common) are `bundled=true` there
+  #        but are very much real crates.io packages and exactly the ones
+  #        #3366 was about.
+  # ─────────────────────────────────────────────────────────────────────────────
+  preflight:
+    name: Verify tag ancestry + resolve publish identity (issue #3366)
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      pkg_name:     ${{ steps.pkg.outputs.pkg_name }}
+      publishable:  ${{ steps.pkg.outputs.publishable }}
+    steps:
+      - name: Checkout repository (full history)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Verify tagged commit is reachable from origin/main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "push" ]]; then
+            echo "workflow_dispatch invocation (no tag) — the merged-main ancestry"
+            echo "check only applies to real tag pushes; this is a deliberate manual"
+            echo "invocation already gated by repo write access. Skipping (not a gap:"
+            echo "there is no tag/commit here to verify ancestry for)."
+            exit 0
+          fi
+
+          git fetch origin main --quiet
+          # `HEAD^{commit}` dereferences an annotated tag object to the commit
+          # it points at; using this instead of `${{ github.sha }}` directly
+          # avoids ever comparing/trusting a tag-object SHA as if it were a
+          # commit SHA.
+          TAGGED_SHA="$(git rev-parse 'HEAD^{commit}')"
+          MAIN_SHA="$(git rev-parse origin/main)"
+          echo "Tag:            ${{ github.ref_name }}"
+          echo "Tagged commit:  ${TAGGED_SHA}"
+          echo "origin/main:    ${MAIN_SHA}"
+
+          if git merge-base --is-ancestor "${TAGGED_SHA}" "${MAIN_SHA}"; then
+            echo "OK — tagged commit is reachable from origin/main."
+          else
+            echo "::error::Tag '${{ github.ref_name }}' points at commit ${TAGGED_SHA}, which is NOT reachable from origin/main (${MAIN_SHA}). This project publishes only from merged main / a release tag on main (see scripts/check-publish-ready.sh and .claude/skills/cargo-publish/SKILL.md). Refusing to run the release pipeline for this tag — merge to main first, then re-tag from a checkout of merged main."
+            exit 1
+          fi
+
+      - name: Resolve crates.io package identity
+        id: pkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          CRATE="${{ needs.setup.outputs.crate }}"
+          MANIFEST="crates/${CRATE}/Cargo.toml"
+          if [[ ! -f "${MANIFEST}" ]]; then
+            echo "::error::No Cargo.toml found at ${MANIFEST} for crate '${CRATE}'."
+            exit 1
+          fi
+
+          PKG_NAME="$(grep -m1 -E '^name[[:space:]]*=[[:space:]]*"' "${MANIFEST}" \
+            | sed -E 's/^name[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+          if [[ -z "${PKG_NAME}" ]]; then
+            echo "::error::Could not read 'name' from ${MANIFEST}"
+            exit 1
+          fi
+
+          # `publish = false` is the only thing that makes a crate NOT a real
+          # crates.io package; anything else (absent, or a registry allowlist
+          # array) is publishable. Deliberately independent of the `bundled`
+          # binary-release-allowlist flag above — a library-only crate like
+          # trusty-common is bundled=true (no standalone binary) but IS a real,
+          # publishable crates.io package, and is exactly what #3366 was about.
+          if grep -qE '^publish[[:space:]]*=[[:space:]]*false' "${MANIFEST}"; then
+            PUBLISHABLE="false"
+          else
+            PUBLISHABLE="true"
+          fi
+
+          {
+            echo "pkg_name=${PKG_NAME}"
+            echo "publishable=${PUBLISHABLE}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "Resolved: crate=${CRATE} pkg_name=${PKG_NAME} publishable=${PUBLISHABLE}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # JOB 2: build
   #
   # Fan-out matrix job.  Each entry builds one crate × platform × variant.
@@ -633,7 +756,10 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────────
   build:
     name: Build ${{ matrix.crate }} ${{ matrix.asset_suffix }}
-    needs: setup
+    # `preflight` added (issue #3366): its ancestry check must pass (default
+    # `success()` on `needs`) before any binary is built, cascading the guard
+    # through release/homebrew-bump via their own existing `needs: build`.
+    needs: [setup, preflight]
     # Skip entirely for bundled crates — they have no standalone binary target.
     if: needs.setup.outputs.bundled != 'true'
     runs-on: ${{ matrix.runner }}
@@ -987,6 +1113,80 @@ jobs:
             ${{ steps.package.outputs.asset_checksum }}
           retention-days: 7
           if-no-files-found: error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # JOB 2b: publish-dry-run (issue #3366)
+  #
+  # WHY: this workflow's whole `setup`/`build`/`release` chain governs the
+  #   GitHub binary release (tarballs + Homebrew formula) — it never actually
+  #   ran `cargo publish` or `--dry-run` anywhere. The separate crates.io
+  #   `cargo publish` step is a MANUAL action a human runs around the same
+  #   time as pushing this tag (.claude/skills/cargo-publish/SKILL.md); "always
+  #   dry-run first, in dependency order" existed only as tribal knowledge in
+  #   that skill file, not as anything actually enforced. This job converts it
+  #   into an automatic, un-skippable, always-fires check: the moment the tag
+  #   for a real crates.io package is pushed, this job independently proves
+  #   (or disproves) that `cargo publish --dry-run` succeeds for that crate
+  #   AND every publishable sibling it transitively depends on, resolved
+  #   against the LIVE crates.io registry (the same mechanism that would have
+  #   caught the 2026-07-20 half-published incident) — in dependency order, so
+  #   a crate is never dry-run-checked before the sibling versions it needs.
+  #
+  # SCOPE / COST (why this is workable where a full-workspace-per-PR gate
+  #   would not be): this does NOT run on every PR, and does NOT dry-run the
+  #   whole workspace — only the ONE crate this tag names, plus whatever
+  #   publishable crates it transitively depends on (scripts/publish-dry-run-order.sh
+  #   computes and filters to that closure). It runs exactly once, exactly
+  #   when a tag is pushed — i.e. exactly when a release is actually
+  #   happening, so its cost is bounded by what a real release naturally
+  #   requires anyway, unlike gating every PR (which would burn crates.io
+  #   registry calls/rate limit on changes that were never going to publish
+  #   anything) or a full-workspace run (which would dry-run ~17 crates for a
+  #   one-crate tag).
+  #
+  # BLOCKING vs INDEPENDENT (deliberate — read before changing): this job
+  #   `needs: [setup, preflight]` (so an unmerged-branch tag never reaches it
+  #   either) but is intentionally NOT a dependency of `build`/`release`
+  #   below. A failing dry-run means "this crate is not safe to `cargo
+  #   publish` right now" — it says nothing about whether the GitHub binary
+  #   tarball is safe to build and distribute, since building/shipping a
+  #   binary release touches crates.io not at all. Coupling them would also
+  #   import crates.io's own documented propagation lag (this repo's
+  #   Cross-Crate Publish Ordering notes 60-120s after an upstream publish)
+  #   into the binary-release path as pure flakiness with no corresponding
+  #   safety benefit. Kept independent, this job still FAILS LOUDLY on its own
+  #   — a failure turns the whole tag's workflow run red and is visible on the
+  #   commit/PR checks — it just doesn't also block the unrelated binary
+  #   artifact from being built. If a genuinely unified pre-publish gate is
+  #   wanted later, make `release` additionally `need` this job — deliberately
+  #   not done here to avoid coupling two failure domains that have never
+  #   actually been coupled in this project's process.
+  #
+  # NEVER runs a real `cargo publish` — `--dry-run` only, always.
+  # ─────────────────────────────────────────────────────────────────────────────
+  publish-dry-run:
+    name: crates.io publish dry-run, dependency-ordered (issue #3366)
+    needs: [setup, preflight]
+    # Skip cleanly for crates that are not real crates.io packages
+    # (`publish = false`, e.g. trusty-agents-common's INTERNAL sibling crates,
+    # the Tauri GUIs) — there is nothing to dry-run.
+    if: needs.preflight.outputs.publishable == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Rust (MSRV 1.91)
+        uses: dtolnay/rust-toolchain@1.91
+
+      - name: Cache cargo registry + artefacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: publish-dry-run-${{ needs.preflight.outputs.pkg_name }}
+
+      - name: cargo publish --dry-run (dependency order)
+        run: bash scripts/publish-dry-run-order.sh "${{ needs.preflight.outputs.pkg_name }}"
 
   # ─────────────────────────────────────────────────────────────────────────────
   # JOB 3: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -677,6 +677,15 @@ jobs:
 
       - name: Verify tagged commit is reachable from origin/main
         shell: bash
+        # TAG is passed via `env:` rather than interpolated directly into the
+        # script (as `.claude/skills/cargo-publish/SKILL.md`-documented issue
+        # #3568 review flagged: raw `${{ github.ref_name }}` interpolation is
+        # a shell-injection hazard — a ref name can contain `$`, backticks,
+        # quotes, parens) and always referenced quoted (`"$TAG"`). Matches the
+        # `homebrew-bump` job's existing `env: TAG: ${{ github.ref_name }}`
+        # pattern below — one convention for this file, not two.
+        env:
+          TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail
           if [[ "${{ github.event_name }}" != "push" ]]; then
@@ -694,14 +703,14 @@ jobs:
           # commit SHA.
           TAGGED_SHA="$(git rev-parse 'HEAD^{commit}')"
           MAIN_SHA="$(git rev-parse origin/main)"
-          echo "Tag:            ${{ github.ref_name }}"
+          echo "Tag:            ${TAG}"
           echo "Tagged commit:  ${TAGGED_SHA}"
           echo "origin/main:    ${MAIN_SHA}"
 
           if git merge-base --is-ancestor "${TAGGED_SHA}" "${MAIN_SHA}"; then
             echo "OK — tagged commit is reachable from origin/main."
           else
-            echo "::error::Tag '${{ github.ref_name }}' points at commit ${TAGGED_SHA}, which is NOT reachable from origin/main (${MAIN_SHA}). This project publishes only from merged main / a release tag on main (see scripts/check-publish-ready.sh and .claude/skills/cargo-publish/SKILL.md). Refusing to run the release pipeline for this tag — merge to main first, then re-tag from a checkout of merged main."
+            echo "::error::Tag '${TAG}' points at commit ${TAGGED_SHA}, which is NOT reachable from origin/main (${MAIN_SHA}). This project publishes only from merged main / a release tag on main (see scripts/check-publish-ready.sh and .claude/skills/cargo-publish/SKILL.md). Refusing to run the release pipeline for this tag — merge to main first, then re-tag from a checkout of merged main."
             exit 1
           fi
 
@@ -1163,6 +1172,21 @@ jobs:
   #   actually been coupled in this project's process.
   #
   # NEVER runs a real `cargo publish` — `--dry-run` only, always.
+  #
+  # DOES NOT COVER UI BUNDLE FRESHNESS (issue #3568 review finding, HIGH):
+  #   this job's `cargo publish --dry-run` runs with `SKIP_UI_BUILD=1` (set by
+  #   scripts/publish-dry-run-order.sh) for the UI-embedding crates
+  #   (trusty-search, trusty-memory, trusty-analyze, trusty-console) — NOT as
+  #   a shortcut, but because it is the ONLY thing that works: `trusty-search`
+  #   and `trusty-console` explicitly `include = [...]` only their pre-built
+  #   `ui-dist/`/`ui/dist/` in the published package (verified via `cargo
+  #   package --list` — `ui/src` is not even in the tarball), so build.rs has
+  #   nothing to rebuild from during package verification regardless of this
+  #   flag. This matches the documented human recipe exactly
+  #   (docs/reference/release-workflow.md's "UI-embedding crates" note) — it
+  #   is not a divergence from it. Consequently this job provides ZERO signal
+  #   about whether the COMMITTED UI bundle is stale relative to current
+  #   `ui/src` — that is the separate `ui-freshness-check` job below.
   # ─────────────────────────────────────────────────────────────────────────────
   publish-dry-run:
     name: crates.io publish dry-run, dependency-ordered (issue #3366)
@@ -1187,6 +1211,136 @@ jobs:
 
       - name: cargo publish --dry-run (dependency order)
         run: bash scripts/publish-dry-run-order.sh "${{ needs.preflight.outputs.pkg_name }}"
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # JOB 2c: ui-freshness-check (issue #3568 review finding, HIGH)
+  #
+  # WHY: `publish-dry-run` above (and a real `cargo publish`) both necessarily
+  #   use the COMMITTED `ui-dist/`/`ui/dist/` bundle — they cannot rebuild it
+  #   during packaging even in principle for `trusty-search`/`trusty-console`,
+  #   whose `Cargo.toml` `include` list excludes `ui/src` from the package
+  #   entirely (confirmed via `cargo package --list`). A dry-run "PASS" was
+  #   therefore silently giving zero coverage of whether that committed
+  #   bundle actually reflects current `ui/src` — the exact "guard exists but
+  #   doesn't guard" failure mode. This is not hypothetical: at the time this
+  #   job was added, `crates/trusty-search/ui-dist/` was last regenerated
+  #   2026-07-07 (commit `28648d38`), but `crates/trusty-search/ui/src` was
+  #   changed afterward by the Foundry v2 token migration (commit `972171e8`)
+  #   — confirmed via `git log 28648d38..HEAD -- crates/trusty-search/ui/src`
+  #   — so the published bundle has been stale in a real, verifiable sense.
+  #
+  # WHY NOT "install pnpm and let `cargo publish` rebuild it" (the OTHER
+  #   option considered): structurally impossible for `trusty-search` /
+  #   `trusty-console` (source isn't packaged, see above) — this is not a
+  #   convention that could be relaxed, it is what `Cargo.toml` `include`
+  #   already enforces. `trusty-memory`/`trusty-analyze` (no `include`
+  #   override) technically DO package `ui/src` and so COULD rebuild
+  #   in-process, but doing this two different ways for four crates that are
+  #   meant to behave identically (issue #987's canonical-build.rs-block
+  #   invariant) is worse than one uniform check applied the same way to all
+  #   four — this job does that.
+  #
+  # WHY NOT hash-filename diffing being treated as automatically flaky and
+  #   skipped: `.github/workflows/ci.yml`'s `ui-checks` job (issue #3508,
+  #   merged the same day as this one) explicitly considered and rejected
+  #   REBUILD-THEN-DIFF for these same crates, reasoning that Vite's
+  #   content-hashed filenames (`index-CPNos4BT.js`) can legitimately change
+  #   across a toolchain patch bump with no real behavior change, making a
+  #   naive diff a flaky false-failure generator, and left a "hash-normalizing
+  #   comparator" as unbuilt future work. That risk is real and NOT solved
+  #   here either — but `pnpm install --frozen-lockfile` pins the exact
+  #   dependency versions from the committed lockfile, which bounds (does not
+  #   eliminate) that risk to Node-runtime-version drift specifically, and the
+  #   remedy on a false positive is the same safe action as a true positive
+  #   (regenerate and commit the bundle) — so this job fails CLOSED (diff ==
+  #   fail) rather than skip the check entirely while that gap exists. If a
+  #   false positive is ever observed, that is the trigger to build the
+  #   hash-normalizing comparator `ci.yml` deferred — not a reason to make
+  #   this check advisory.
+  #
+  # WHAT: for each of the four UI-embedding crates ONLY (skips cleanly, not
+  #   silently, for every other crate), snapshots the currently-committed
+  #   embed directory, runs a REAL `pnpm install --frozen-lockfile && pnpm
+  #   run build` from current `ui/src` (same toolchain-setup pattern as
+  #   `ci.yml`'s `ui-checks` job), then `diff -rq`s the snapshot against the
+  #   fresh build output. Any difference — including a build FAILURE, which
+  #   is the more common and more dangerous form of drift — fails the job
+  #   loudly with the diff and a remedy command.
+  # ─────────────────────────────────────────────────────────────────────────────
+  ui-freshness-check:
+    name: UI bundle freshness check (issue #3568)
+    needs: [setup, preflight]
+    if: contains(fromJson('["trusty-search","trusty-console","trusty-memory","trusty-analyze"]'), needs.setup.outputs.crate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: crates/${{ needs.setup.outputs.crate }}/ui/pnpm-lock.yaml
+
+      - name: Rebuild ui/src and diff against the committed bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          CRATE="${{ needs.setup.outputs.crate }}"
+          UI_DIR="crates/${CRATE}/ui"
+
+          # trusty-search embeds from a separate crate-root `ui-dist/`
+          # (build.rs copies `ui/dist -> ui-dist`, issue #109); the other
+          # three embed directly from `ui/dist`. See this job's header
+          # comment for how this was confirmed per-crate.
+          if [[ "${CRATE}" == "trusty-search" ]]; then
+            COMMITTED_DIR="crates/${CRATE}/ui-dist"
+          else
+            COMMITTED_DIR="${UI_DIR}/dist"
+          fi
+
+          if [[ ! -d "${COMMITTED_DIR}" ]]; then
+            echo "::error::Expected committed UI bundle directory ${COMMITTED_DIR} does not exist."
+            exit 1
+          fi
+
+          SNAPSHOT="$(mktemp -d)/committed"
+          cp -r "${COMMITTED_DIR}" "${SNAPSHOT}"
+
+          (cd "${UI_DIR}" && pnpm install --frozen-lockfile && pnpm run build)
+
+          FRESH_DIR="${UI_DIR}/dist"
+
+          echo "Comparing committed (${COMMITTED_DIR}, snapshotted before rebuild) against a fresh build (${FRESH_DIR})..."
+          if diff -rq "${SNAPSHOT}" "${FRESH_DIR}" > /tmp/ui-freshness.diff; then
+            echo "OK — committed bundle matches a fresh build from current ui/src."
+          else
+            echo "::error::UI bundle drift detected for ${CRATE}: the committed ${COMMITTED_DIR} does NOT match a fresh 'pnpm run build' from current ui/src."
+            cat /tmp/ui-freshness.diff
+            echo ""
+            echo "Remedy: (cd ${UI_DIR} && pnpm install --frozen-lockfile && pnpm run build)"
+            if [[ "${CRATE}" == "trusty-search" ]]; then
+              echo "  then copy ui/dist/* into ui-dist/ (or run 'make release-prep')."
+            fi
+            echo "  Commit the regenerated bundle, then re-tag."
+            echo ""
+            echo "NOTE: a false positive here (build succeeds, content genuinely differs" \
+                 "only due to a toolchain version difference between this runner and" \
+                 "whatever machine last produced the committed bundle) is possible — see" \
+                 "this job's header comment / ci.yml's ui-checks job for the known,"\
+                 "not-yet-solved content-hash-filename-churn risk. If you believe that is" \
+                 "what happened here, verify locally with the same pinned lockfile before" \
+                 "assuming this check is wrong; the safe remedy is identical either way" \
+                 "(regenerate and commit)."
+            exit 1
+          fi
 
   # ─────────────────────────────────────────────────────────────────────────────
   # JOB 3: release

--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -1,0 +1,47 @@
+# Version-parity drift gate for the trusty-tools workspace (issue #3366).
+#
+# Detects "unpublished source drift under an already-published version
+# number": a crate whose Cargo.toml version is already live on crates.io, but
+# whose local src/ tree no longer matches what was actually published under
+# that version — the defect class that turned `cargo publish -p trusty-mpm
+# --dry-run` into a release blocker (6 "symbol not found" errors) when
+# trusty-common and trusty-agents-common each drifted this way.
+#
+# Runs on PUSH TO MAIN ONLY (no pull_request trigger), per the issue's own
+# proposed design: this check compares against the LIVE crates.io registry,
+# so its result is only meaningful for what actually landed on main — a
+# feature branch's crate versions haven't been decided yet, and running a
+# registry-dependent check on every PR (including ones from parallel agent
+# worktrees) would be noisy without being actionable. Catching drift right
+# after it merges (a red commit status on main) is the goal: a merge-time
+# finding instead of a release-time surprise.
+name: Version parity
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: version-parity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version-parity:
+    name: Publish-version parity (issue #3366)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      # MSRV floor is 1.91 (root Cargo.toml rust-version), matching ci.yml.
+      - name: Install Rust toolchain (1.91)
+        uses: dtolnay/rust-toolchain@1.91
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: version-parity
+
+      - name: Run version-parity guard
+        run: bash scripts/check-version-parity.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11723,6 +11723,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "trusty-publish-guard"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "flate2",
+ "reqwest 0.12.28",
+ "tar",
+ "tempfile",
+ "toml 0.8.23",
+ "walkdir",
+]
+
+[[package]]
 name = "trusty-review"
 version = "0.9.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ default-members = [
     "crates/trusty-memory",
     "crates/trusty-mpm",
     "crates/trusty-progress",
+    "crates/trusty-publish-guard",
     "crates/trusty-review",
     "crates/trusty-search",
     "crates/trusty-sld-lint",

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # they are deleted and the target exits 0.  Run it again on a clean tree
 # and assert it still exits 0 (idempotent).
 
-.PHONY: check clean-runtime e2e-docker install-search-signed install-mpm-signed publish-check
+.PHONY: check clean-runtime e2e-docker install-search-signed install-mpm-signed publish-check version-parity-check publish-dry-run-order
 
 # Remove per-crate runtime artefacts that accumulate during development.
 #
@@ -145,3 +145,44 @@ publish-check:
 		exit 2; \
 	fi
 	bash scripts/check-publish-ready.sh $(CRATE)
+
+# Version-parity drift gate (issue #3366).
+#
+# Why: detects a crate whose Cargo.toml version is already live on crates.io
+# but whose local src/ tree no longer matches what was published under that
+# version — the defect that turned `cargo publish -p trusty-mpm --dry-run`
+# into a release blocker. Wired into CI on push to main
+# (.github/workflows/version-parity.yml); this target is the same check,
+# runnable locally/on demand.
+#
+# What: delegates to scripts/check-version-parity.sh, which builds and runs
+# the `publish-guard` binary (crates/trusty-publish-guard) against every
+# publishable workspace crate.
+#
+# Test: `make version-parity-check` against a clean checkout of merged main
+# reports each crate's parity status and exits non-zero the moment any crate
+# shows drift or could not be verified against the live registry.
+version-parity-check:
+	bash scripts/check-version-parity.sh
+
+# Dependency-ordered `cargo publish --dry-run` preflight (issue #3366).
+#
+# Why: publishing a crate before a sibling it depends on is live on
+# crates.io is the class of mistake behind the 2026-07-20 half-published
+# incident. `cargo publish --dry-run` resolves against the LIVE registry and
+# catches exactly this — but only if run for every affected crate, in
+# dependency order, immediately before a release.
+#
+# What: delegates to scripts/publish-dry-run-order.sh, which computes a
+# topological publish order from `cargo metadata` and runs
+# `cargo publish --dry-run -p <crate>` for each publishable crate in that
+# order, stopping at the first failure. Pass CRATES="a b" to restrict to a
+# subset (+ their publishable dependencies); pass LIST_ONLY=1 to print the
+# order without running anything.
+#
+# Usage:
+#   make publish-dry-run-order
+#   make publish-dry-run-order CRATES="trusty-search trusty-common"
+#   make publish-dry-run-order LIST_ONLY=1
+publish-dry-run-order:
+	bash scripts/publish-dry-run-order.sh $(if $(LIST_ONLY),--list-only) $(CRATES)

--- a/crates/trusty-publish-guard/CHANGELOG.md
+++ b/crates/trusty-publish-guard/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+## [Unreleased]
+
+### Added
+
+- Initial release: `publish-guard`, the version-parity drift detector ([#3366](https://github.com/bobmatnyc/trusty-tools/issues/3366)).
+  - **Core check:** for every publishable workspace crate, compares the local `src/` tree against the crates.io tarball for that crate's OWN current `Cargo.toml` version. A version not yet published is a trivial pass (nothing to compare); a version already live whose source no longer matches is flagged as drift — the exact defect that turned `cargo publish -p trusty-mpm --dry-run` into a release blocker.
+  - **Fail-closed:** a registry lookup that errors (rate limit, 5xx, network failure) is treated as a failure, never silently coerced into a pass.
+  - **Testable seam:** all crates.io access sits behind the `PublishedFetcher` trait (`src/fetch.rs`); the extraction/diff/decision engine (`src/lib.rs`) is unit-tested against an in-memory fake, no network required.
+  - **Wiring:** `scripts/check-version-parity.sh` wrapper and `.github/workflows/version-parity.yml` (push-to-main only, per the issue's own noise-avoidance recommendation).

--- a/crates/trusty-publish-guard/Cargo.toml
+++ b/crates/trusty-publish-guard/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "trusty-publish-guard"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Detects unpublished source drift under an already-published crate version across the trusty-tools workspace (issue #3366)."
+keywords = ["release", "publish", "ci", "guard"]
+categories = ["development-tools"]
+homepage = "https://github.com/bobmatnyc/trusty-tools"
+# Internal CI/release tool, never itself published to crates.io — publishing
+# it would just create a second instance of the exact defect it exists to
+# catch (a tool crate nobody depends on, going stale under its own version).
+publish = false
+
+# Library half: the pure, unit-testable drift-detection engine. All network
+# access is isolated behind the `PublishedFetcher` trait (src/fetch.rs) so
+# this half never needs a live crates.io connection in tests (issue #3366
+# "isolated behind a seam you CAN test").
+[lib]
+name = "trusty_publish_guard"
+path = "src/lib.rs"
+
+# Binary half: the thin CLI wrapper that walks crates/*/Cargo.toml and reports
+# per-crate parity status.
+[[bin]]
+name = "publish-guard"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+flate2 = { workspace = true }
+tar = { workspace = true }
+toml = { workspace = true }
+walkdir = { workspace = true }
+# Only the blocking client is needed — this is a synchronous CLI tool, not an
+# async service; pulling in a tokio runtime for a handful of sequential HTTP
+# calls would be unjustified weight.
+reqwest = { workspace = true, features = ["blocking"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/trusty-publish-guard/src/fetch.rs
+++ b/crates/trusty-publish-guard/src/fetch.rs
@@ -1,0 +1,73 @@
+//! Real crates.io-backed [`PublishedFetcher`] implementation.
+//!
+//! This is the ONE place in the crate that touches the network. It is
+//! deliberately thin (two HTTP calls, no logic beyond status-code mapping) so
+//! the untestable-without-a-live-registry part stays small; everything that
+//! benefits from unit testing (extraction, diffing, the parity decision)
+//! lives in `lib.rs` behind the [`PublishedFetcher`] trait and is exercised
+//! there against an in-memory fake instead.
+//!
+//! Not exercised by `cargo test` — doing so would require live network access
+//! to crates.io, which this workspace's test suite must not depend on. This
+//! module's correctness is instead covered by the manual verification in the
+//! issue #3366 PR description (running `publish-guard` against the real
+//! workspace and confirming it reproduces the actual reported drift).
+
+use crate::PublishedFetcher;
+use anyhow::{Context, Result, bail};
+
+/// crates.io's published API-usage policy requires a descriptive User-Agent
+/// identifying the tool and a contact point; generic/UA-less clients are
+/// rejected with 403 (same requirement `scripts/preflight-publish.sh`
+/// already documents for its own crates.io calls).
+const USER_AGENT: &str =
+    "trusty-tools-publish-guard/0.1 (https://github.com/bobmatnyc/trusty-tools; issue #3366)";
+
+pub struct CratesIoFetcher {
+    client: reqwest::blocking::Client,
+}
+
+impl CratesIoFetcher {
+    pub fn new() -> Result<Self> {
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(USER_AGENT)
+            .build()
+            .context("building crates.io HTTP client")?;
+        Ok(Self { client })
+    }
+}
+
+impl PublishedFetcher for CratesIoFetcher {
+    fn is_version_live(&self, name: &str, version: &str) -> Result<bool> {
+        let url = format!("https://crates.io/api/v1/crates/{name}/{version}");
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .with_context(|| format!("GET {url}"))?;
+        match resp.status().as_u16() {
+            200 => Ok(true),
+            404 => Ok(false),
+            // Fail closed: an unexpected status (rate limit, 5xx, etc.) means
+            // we cannot verify safety, so this must not be silently treated
+            // as "not published" — that would let real drift sail through.
+            other => bail!("unexpected HTTP {other} from {url}"),
+        }
+    }
+
+    fn fetch_tarball(&self, name: &str, version: &str) -> Result<Vec<u8>> {
+        let url = format!("https://crates.io/api/v1/crates/{name}/{version}/download");
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .with_context(|| format!("GET {url}"))?;
+        if !resp.status().is_success() {
+            bail!("unexpected HTTP {} downloading {url}", resp.status());
+        }
+        Ok(resp
+            .bytes()
+            .context("reading tarball response body")?
+            .to_vec())
+    }
+}

--- a/crates/trusty-publish-guard/src/lib.rs
+++ b/crates/trusty-publish-guard/src/lib.rs
@@ -1,0 +1,429 @@
+//! Version-parity drift detector (issue #3366).
+//!
+//! Why: on 2026-07-19/20 `trusty-common` and `trusty-agents-common` each
+//! carried several commits of source changes that landed on `main` WITHOUT a
+//! matching version bump, while the OLD version number was already live on
+//! crates.io. `cargo build`/`cargo test` never noticed because the
+//! workspace's `[patch.crates-io]` table redirects sibling deps to local
+//! paths — the gap only surfaces when `cargo publish` resolves a crate
+//! standalone against the real registry, by which point it is a release
+//! blocker instead of a merge-time finding. See issue #3366 for the full
+//! incident writeup.
+//!
+//! What: for a given crate, compares the `src/**` file contents on disk
+//! against the `src/**` file contents inside the crates.io tarball for the
+//! crate's OWN current `Cargo.toml` version. If that version is not yet
+//! published, there is nothing to compare and the crate passes trivially
+//! (`ParityStatus::NotYetPublished` — this is the normal, safe "just bumped,
+//! about to release" state). If the version IS already published, the source
+//! trees must match byte-for-byte; any difference is
+//! `ParityStatus::Drift(..)` — the exact defect class from #3366.
+//!
+//! All network access is isolated behind the [`PublishedFetcher`] trait
+//! (implemented for real crates.io access in [`fetch::CratesIoFetcher`]) so
+//! the drift-detection logic itself (extraction, diffing, status decision) is
+//! fully unit-tested here with an in-memory fake — no network required to run
+//! `cargo test -p trusty-publish-guard`.
+
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::Path;
+
+pub mod fetch;
+
+/// One file-level difference between the local working tree and the
+/// published tarball's `src/` contents, keyed by path relative to `src/`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DriftEntry {
+    /// Present locally, absent from the published tarball.
+    Added(String),
+    /// Present in the published tarball, absent locally.
+    Removed(String),
+    /// Present in both, but byte content differs.
+    Modified(String),
+}
+
+impl DriftEntry {
+    /// The `src/`-relative path this entry refers to, regardless of variant.
+    pub fn path(&self) -> &str {
+        match self {
+            DriftEntry::Added(p) | DriftEntry::Removed(p) | DriftEntry::Modified(p) => p,
+        }
+    }
+}
+
+impl std::fmt::Display for DriftEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DriftEntry::Added(p) => write!(f, "+ added (local only, not on crates.io): src/{p}"),
+            DriftEntry::Removed(p) => {
+                write!(f, "- removed (published only, missing locally): src/{p}")
+            }
+            DriftEntry::Modified(p) => {
+                write!(f, "~ modified (content differs from published): src/{p}")
+            }
+        }
+    }
+}
+
+/// The outcome of comparing one crate's local `src/` tree against its
+/// published tarball.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParityStatus {
+    /// The crate's current `Cargo.toml` version has not been published yet —
+    /// nothing to compare against. This is the ordinary "bumped, not yet
+    /// released" state and is NOT a failure.
+    NotYetPublished,
+    /// The local `src/` tree matches the published tarball byte-for-byte.
+    Parity,
+    /// The local `src/` tree differs from what crates.io serves under the
+    /// SAME version number — the #3366 defect.
+    Drift(Vec<DriftEntry>),
+}
+
+/// Seam separating the (network-dependent, untestable-without-a-live-registry)
+/// crates.io access from the (pure, fully-testable) drift-detection logic.
+///
+/// Implement this against a fake in tests; [`fetch::CratesIoFetcher`] is the
+/// only production implementation and talks to the real crates.io API.
+pub trait PublishedFetcher {
+    /// Returns `true` if `name`@`version` is live on the registry, `false` if
+    /// not yet published. Any other outcome (network error, unexpected
+    /// response) must be surfaced as `Err` — never silently coerced to
+    /// `false`, which would hide a real drift behind a false "not published
+    /// yet, nothing to check" pass.
+    fn is_version_live(&self, name: &str, version: &str) -> Result<bool>;
+
+    /// Fetches the raw `.crate` tarball (gzip-compressed tar) for
+    /// `name`@`version`. Only called after `is_version_live` returned `true`.
+    fn fetch_tarball(&self, name: &str, version: &str) -> Result<Vec<u8>>;
+}
+
+/// Extracts every regular file under `<package_dir>/src/` from a gzip'd
+/// crates.io tarball into an in-memory `path -> bytes` map, keyed by path
+/// relative to `src/` (matching [`local_src`]'s keying so the two maps can be
+/// diffed directly).
+///
+/// `package_dir` is the tarball's top-level directory, i.e. `"<name>-<version>"`
+/// — crates.io tarballs always nest content one level under a directory named
+/// after the package and version.
+pub fn extract_published_src(
+    tarball_gz: &[u8],
+    package_dir: &str,
+) -> Result<BTreeMap<String, Vec<u8>>> {
+    let decoder = flate2::read::GzDecoder::new(tarball_gz);
+    let mut archive = tar::Archive::new(decoder);
+    let mut out = BTreeMap::new();
+    let prefix = format!("{package_dir}/src/");
+
+    for entry in archive.entries().context("reading tarball entries")? {
+        let mut entry = entry.context("reading a tarball entry")?;
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+        let path = entry
+            .path()
+            .context("reading entry path")?
+            .to_string_lossy()
+            .replace('\\', "/");
+        if let Some(rel) = path.strip_prefix(&prefix) {
+            let mut buf = Vec::new();
+            entry
+                .read_to_end(&mut buf)
+                .context("reading entry contents")?;
+            out.insert(rel.to_string(), buf);
+        }
+    }
+    Ok(out)
+}
+
+/// Reads every regular file under `<crate_root>/src/` from disk into an
+/// in-memory `path -> bytes` map, keyed by path relative to `src/`.
+///
+/// Returns an empty map (not an error) if the crate has no `src/` directory —
+/// callers decide what that means; this function only reports what exists.
+pub fn local_src(crate_root: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
+    let src_dir = crate_root.join("src");
+    let mut out = BTreeMap::new();
+    if !src_dir.exists() {
+        return Ok(out);
+    }
+    for entry in walkdir::WalkDir::new(&src_dir) {
+        let entry = entry.with_context(|| format!("walking {}", src_dir.display()))?;
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let rel = entry
+            .path()
+            .strip_prefix(&src_dir)
+            .expect("walkdir entries are always under src_dir")
+            .to_string_lossy()
+            .replace('\\', "/");
+        let content = std::fs::read(entry.path())
+            .with_context(|| format!("reading {}", entry.path().display()))?;
+        out.insert(rel, content);
+    }
+    Ok(out)
+}
+
+/// Compares two `path -> bytes` maps (as produced by [`local_src`] and
+/// [`extract_published_src`]) and returns every difference, sorted by path
+/// for deterministic output. Empty result means the two trees are identical.
+pub fn diff_src(
+    local: &BTreeMap<String, Vec<u8>>,
+    published: &BTreeMap<String, Vec<u8>>,
+) -> Vec<DriftEntry> {
+    let mut drift = Vec::new();
+    for (path, content) in local {
+        match published.get(path) {
+            None => drift.push(DriftEntry::Added(path.clone())),
+            Some(published_content) if published_content != content => {
+                drift.push(DriftEntry::Modified(path.clone()))
+            }
+            _ => {}
+        }
+    }
+    for path in published.keys() {
+        if !local.contains_key(path) {
+            drift.push(DriftEntry::Removed(path.clone()));
+        }
+    }
+    drift.sort_by(|a, b| a.path().cmp(b.path()));
+    drift
+}
+
+/// Runs the full version-parity check for one crate: is its current
+/// `Cargo.toml` version already live, and if so, does the local `src/` tree
+/// match what was published under that version?
+///
+/// Precondition: `crate_root` is a directory containing (at minimum) a
+/// `src/` subdirectory reflecting the crate's current on-disk state; `name`
+/// and `version` are read from that crate's own `Cargo.toml` (the caller is
+/// responsible for that lookup — this function only compares, it does not
+/// resolve manifests).
+pub fn check_crate(
+    fetcher: &dyn PublishedFetcher,
+    crate_root: &Path,
+    name: &str,
+    version: &str,
+) -> Result<ParityStatus> {
+    if !fetcher
+        .is_version_live(name, version)
+        .with_context(|| format!("checking whether {name} {version} is live on crates.io"))?
+    {
+        return Ok(ParityStatus::NotYetPublished);
+    }
+
+    let tarball = fetcher
+        .fetch_tarball(name, version)
+        .with_context(|| format!("fetching published tarball for {name} {version}"))?;
+    let package_dir = format!("{name}-{version}");
+    let published = extract_published_src(&tarball, &package_dir)
+        .with_context(|| format!("extracting published src/ for {name} {version}"))?;
+    let local = local_src(crate_root)
+        .with_context(|| format!("reading local src/ for {name} at {}", crate_root.display()))?;
+
+    let drift = diff_src(&local, &published);
+    Ok(if drift.is_empty() {
+        ParityStatus::Parity
+    } else {
+        ParityStatus::Drift(drift)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap as Map;
+    use std::io::Write;
+    use std::path::Path;
+
+    /// In-memory fake for `PublishedFetcher` — the test seam. No network
+    /// access anywhere in this module.
+    struct FakeFetcher {
+        live: Map<(String, String), Vec<u8>>,
+        fail_lookup: bool,
+    }
+
+    impl FakeFetcher {
+        fn empty() -> Self {
+            Self {
+                live: Map::new(),
+                fail_lookup: false,
+            }
+        }
+
+        fn with_published(name: &str, version: &str, tarball: Vec<u8>) -> Self {
+            let mut live = Map::new();
+            live.insert((name.to_string(), version.to_string()), tarball);
+            Self {
+                live,
+                fail_lookup: false,
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                live: Map::new(),
+                fail_lookup: true,
+            }
+        }
+    }
+
+    impl PublishedFetcher for FakeFetcher {
+        fn is_version_live(&self, name: &str, version: &str) -> Result<bool> {
+            if self.fail_lookup {
+                anyhow::bail!("simulated crates.io outage");
+            }
+            Ok(self
+                .live
+                .contains_key(&(name.to_string(), version.to_string())))
+        }
+
+        fn fetch_tarball(&self, name: &str, version: &str) -> Result<Vec<u8>> {
+            self.live
+                .get(&(name.to_string(), version.to_string()))
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("no fake tarball registered for {name} {version}"))
+        }
+    }
+
+    /// Builds a gzip'd tar in memory shaped like a real crates.io tarball:
+    /// every file nested under `<package_dir>/src/`.
+    fn build_tarball(package_dir: &str, files: &[(&str, &str)]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        for (rel, content) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(content.len() as u64);
+            header.set_mode(0o644);
+            let path = format!("{package_dir}/src/{rel}");
+            builder
+                .append_data(&mut header, path, content.as_bytes())
+                .expect("appending fake tarball entry");
+        }
+        let tar_bytes = builder.into_inner().expect("finalizing fake tar");
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        gz.write_all(&tar_bytes)
+            .expect("gzip-compressing fake tarball");
+        gz.finish().expect("finishing gzip stream")
+    }
+
+    fn write_local_src(crate_root: &Path, files: &[(&str, &str)]) {
+        for (rel, content) in files {
+            let full = crate_root.join("src").join(rel);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            std::fs::write(full, content).unwrap();
+        }
+    }
+
+    #[test]
+    fn not_yet_published_when_version_absent_from_registry() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_local_src(tmp.path(), &[("lib.rs", "pub fn x() {}")]);
+        let fetcher = FakeFetcher::empty();
+
+        let status = check_crate(&fetcher, tmp.path(), "demo", "0.1.0").unwrap();
+
+        assert_eq!(status, ParityStatus::NotYetPublished);
+    }
+
+    #[test]
+    fn parity_when_local_source_matches_published_tarball() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_local_src(tmp.path(), &[("lib.rs", "pub fn x() {}")]);
+        let tarball = build_tarball("demo-0.1.0", &[("lib.rs", "pub fn x() {}")]);
+        let fetcher = FakeFetcher::with_published("demo", "0.1.0", tarball);
+
+        let status = check_crate(&fetcher, tmp.path(), "demo", "0.1.0").unwrap();
+
+        assert_eq!(status, ParityStatus::Parity);
+    }
+
+    /// This is the regression test for issue #3366's actual reported defect,
+    /// modeled directly on the confirmed live incident: trusty-common's
+    /// Cargo.toml stayed at 0.23.7 (already published) while commit
+    /// `12e9d37d` added new embedder-module source on top of it. A checker
+    /// that always returned `Parity` (i.e. the pre-fix state — no drift
+    /// detection existed at all) would pass this fixture; the real
+    /// diff-based implementation must not.
+    #[test]
+    fn drift_detected_when_local_source_changed_after_publish() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_local_src(
+            tmp.path(),
+            &[
+                ("lib.rs", "pub fn x() { 2 }"),
+                ("new_module.rs", "pub fn y() {}"),
+            ],
+        );
+        let tarball = build_tarball("demo-0.1.0", &[("lib.rs", "pub fn x() { 1 }")]);
+        let fetcher = FakeFetcher::with_published("demo", "0.1.0", tarball);
+
+        let status = check_crate(&fetcher, tmp.path(), "demo", "0.1.0").unwrap();
+
+        match status {
+            ParityStatus::Drift(entries) => {
+                assert!(
+                    entries.contains(&DriftEntry::Modified("lib.rs".to_string())),
+                    "expected lib.rs to be flagged Modified, got {entries:?}"
+                );
+                assert!(
+                    entries.contains(&DriftEntry::Added("new_module.rs".to_string())),
+                    "expected new_module.rs to be flagged Added, got {entries:?}"
+                );
+            }
+            other => panic!("expected Drift, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn drift_detects_file_removed_relative_to_published_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_local_src(tmp.path(), &[("lib.rs", "pub fn x() {}")]);
+        let tarball = build_tarball(
+            "demo-0.1.0",
+            &[
+                ("lib.rs", "pub fn x() {}"),
+                ("legacy.rs", "pub fn old() {}"),
+            ],
+        );
+        let fetcher = FakeFetcher::with_published("demo", "0.1.0", tarball);
+
+        let status = check_crate(&fetcher, tmp.path(), "demo", "0.1.0").unwrap();
+
+        assert_eq!(
+            status,
+            ParityStatus::Drift(vec![DriftEntry::Removed("legacy.rs".to_string())])
+        );
+    }
+
+    #[test]
+    fn registry_lookup_failure_surfaces_as_error_not_a_silent_pass() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_local_src(tmp.path(), &[("lib.rs", "pub fn x() {}")]);
+        let fetcher = FakeFetcher::failing();
+
+        let result = check_crate(&fetcher, tmp.path(), "demo", "0.1.0");
+
+        assert!(
+            result.is_err(),
+            "a registry lookup failure must fail closed (Err), never be coerced into \
+             NotYetPublished or Parity"
+        );
+    }
+
+    #[test]
+    fn diff_src_is_order_independent_and_deterministic() {
+        let mut local = Map::new();
+        local.insert("b.rs".to_string(), b"b".to_vec());
+        local.insert("a.rs".to_string(), b"a".to_vec());
+        let mut published = Map::new();
+        published.insert("a.rs".to_string(), b"a-changed".to_vec());
+        published.insert("b.rs".to_string(), b"b".to_vec());
+
+        let drift = diff_src(&local, &published);
+
+        assert_eq!(drift, vec![DriftEntry::Modified("a.rs".to_string())]);
+    }
+}

--- a/crates/trusty-publish-guard/src/main.rs
+++ b/crates/trusty-publish-guard/src/main.rs
@@ -1,0 +1,161 @@
+//! `publish-guard` — CLI wrapper around the trusty-publish-guard library
+//! (issue #3366).
+//!
+//! Walks every `crates/*/Cargo.toml`, skips crates marked `publish = false`,
+//! and for each remaining crate checks whether its CURRENT version is
+//! already live on crates.io with source that matches the local working
+//! tree. Exits non-zero (and prints a `[FAIL]` block per offending crate) the
+//! moment ANY crate shows drift or ANY crate's status could not be verified —
+//! this check fails closed and loud by design; see the module docs in
+//! `lib.rs` for why.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use std::path::{Path, PathBuf};
+use trusty_publish_guard::fetch::CratesIoFetcher;
+use trusty_publish_guard::{ParityStatus, check_crate};
+
+/// Detects unpublished source drift under an already-published crate
+/// version (issue #3366).
+#[derive(Parser)]
+#[command(name = "publish-guard", version)]
+struct Cli {
+    /// Workspace root containing a `crates/` directory. Defaults to the
+    /// current directory.
+    #[arg(long)]
+    root: Option<PathBuf>,
+}
+
+struct CrateManifest {
+    /// Directory name under `crates/` (e.g. `trusty-git-analytics`).
+    dir: String,
+    /// The crates.io package name from `[package] name` (e.g. `tga`) —
+    /// usually equal to `dir`, but not always.
+    name: String,
+    version: String,
+    publish: bool,
+}
+
+/// Parses `publish = ...` from a `[package]` toml table. Cargo accepts either
+/// a bool or an array of allowed registries; anything other than the literal
+/// `false` means the crate CAN reach crates.io and is in scope for this
+/// check. Absent `publish` defaults to publishable (Cargo's own default).
+fn parse_publish(package: &toml::Value) -> bool {
+    match package.get("publish") {
+        Some(toml::Value::Boolean(b)) => *b,
+        _ => true,
+    }
+}
+
+fn discover_crates(crates_dir: &Path) -> Result<Vec<CrateManifest>> {
+    let mut dirs: Vec<PathBuf> = std::fs::read_dir(crates_dir)
+        .with_context(|| format!("reading {}", crates_dir.display()))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    dirs.sort();
+
+    let mut out = Vec::new();
+    for dir in dirs {
+        let manifest_path = dir.join("Cargo.toml");
+        if !manifest_path.is_file() {
+            continue;
+        }
+        let text = std::fs::read_to_string(&manifest_path)
+            .with_context(|| format!("reading {}", manifest_path.display()))?;
+        let value: toml::Value = text
+            .parse()
+            .with_context(|| format!("parsing {}", manifest_path.display()))?;
+        let Some(package) = value.get("package") else {
+            continue;
+        };
+        let (Some(name), Some(version)) = (
+            package.get("name").and_then(|v| v.as_str()),
+            package.get("version").and_then(|v| v.as_str()),
+        ) else {
+            continue;
+        };
+
+        out.push(CrateManifest {
+            dir: dir
+                .file_name()
+                .expect("read_dir entries always have a file name")
+                .to_string_lossy()
+                .to_string(),
+            name: name.to_string(),
+            version: version.to_string(),
+            publish: parse_publish(package),
+        });
+    }
+    Ok(out)
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let root = cli.root.unwrap_or_else(|| PathBuf::from("."));
+    let crates_dir = root.join("crates");
+
+    let manifests = discover_crates(&crates_dir)?;
+    let fetcher = CratesIoFetcher::new()?;
+
+    let mut drifted = 0usize;
+    let mut unverifiable = 0usize;
+    let mut checked = 0usize;
+
+    for m in manifests.iter().filter(|m| m.publish) {
+        let crate_root = crates_dir.join(&m.dir);
+        checked += 1;
+        match check_crate(&fetcher, &crate_root, &m.name, &m.version) {
+            Ok(ParityStatus::NotYetPublished) => {
+                println!(
+                    "[ OK ] {} {} — not yet published, nothing to compare",
+                    m.name, m.version
+                );
+            }
+            Ok(ParityStatus::Parity) => {
+                println!(
+                    "[ OK ] {} {} — source matches published crates.io tarball",
+                    m.name, m.version
+                );
+            }
+            Ok(ParityStatus::Drift(entries)) => {
+                drifted += 1;
+                println!(
+                    "[FAIL] {} {} — UNPUBLISHED SOURCE DRIFT under an already-published version:",
+                    m.name, m.version
+                );
+                for entry in &entries {
+                    println!("       {entry}");
+                }
+                println!(
+                    "       Fix: bump the version in crates/{}/Cargo.toml (this is the #3366 defect).",
+                    m.dir
+                );
+            }
+            Err(err) => {
+                unverifiable += 1;
+                eprintln!(
+                    "[ERR ] {} {} — could not verify parity: {err:#}",
+                    m.name, m.version
+                );
+            }
+        }
+    }
+
+    println!();
+    println!(
+        "publish-guard: checked {checked} publishable crate(s) — {drifted} drifted, {unverifiable} unverifiable."
+    );
+
+    if drifted > 0 || unverifiable > 0 {
+        eprintln!(
+            "publish-guard: FAILED. An unverifiable crate is treated as a failure, not a pass \
+             (fail-closed by design — see issue #3366)."
+        );
+        std::process::exit(1);
+    }
+
+    println!("publish-guard: OK — no version-parity drift detected.");
+    Ok(())
+}

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -99,6 +99,18 @@ downgrades both guard failures to a loud warning and exits 0 instead of
 failing. Use it only when you have a specific, understood reason to publish
 from an unmerged commit; the default path is always "merge to main first."
 
+**Independently enforced in CI (issue #3366)**: this same rule is now also a
+mechanical gate on the tag-triggered binary-release pipeline itself, not just
+something a human is instructed to check before `cargo publish`.
+`.github/workflows/release.yml`'s `preflight` job fetches full history and
+runs `git merge-base --is-ancestor` on the ACTUAL tagged commit (dereferenced
+via `HEAD^{commit}`, never trusting `github.sha` or a naive `github.ref ==
+'refs/heads/main'` string comparison — the latter can never match on a tag
+push and would silently disable every release) against the true
+`origin/main` tip. A tag pushed from an unmerged branch now fails this job
+loudly and the whole pipeline — build, release, homebrew-bump, and the
+publish-dry-run job below — is skipped rather than silently proceeding.
+
 ## Version-Parity Guard (issue #3366)
 
 🔴 **Before bumping a crate's version, confirm it hasn't already drifted.**
@@ -125,7 +137,14 @@ For the cross-crate publish-ORDERING hazard (a related but distinct problem —
 publishing a crate before a sibling it depends on is live), see
 `scripts/publish-dry-run-order.sh` / `make publish-dry-run-order`, documented
 in `.claude/skills/cargo-publish/SKILL.md` under "Cross-Crate Publish
-Ordering."
+Ordering." This ALSO now runs automatically and independently of human
+memory: every `*-v*` tag push runs it via `.github/workflows/release.yml`'s
+`publish-dry-run` job, scoped to just the tagged crate and its publishable
+dependency closure (not the whole workspace, and not on every PR — see that
+job's header comment for the cost/scope tradeoff). It is deliberately NOT a
+dependency of the binary build/release jobs (a failing crates.io dry-run says
+nothing about whether the GitHub binary tarball is safe to build), but its
+own failure still turns the tag's workflow run red.
 
 ## macOS Code-Signing Critical Alert
 

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -59,6 +59,8 @@ e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
      SKIP_UI_BUILD=1 cargo publish -p <crate-name>
      ```
      The committed `ui-dist/` bundle is already in the repo; without this flag, `build.rs` will attempt to invoke `pnpm` inside cargo's verification tarball, which fails because it tries to modify files outside `OUT_DIR`.
+
+     **This is not optional for `trusty-search`/`trusty-console`** (verified via `cargo package --list`): their `Cargo.toml` `include` list ships only the pre-built `ui-dist/`/`ui/dist/` bundle, never `ui/src` — so `cargo publish`, with or without `SKIP_UI_BUILD`, can never rebuild the UI from source during packaging. Before running step 8 for any UI-embedding crate, confirm the committed bundle is actually current: `.github/workflows/release.yml`'s `ui-freshness-check` job does this automatically on every tag push by rebuilding fresh from `ui/src` and diffing against the committed bundle (issue #3568) — if it's red, regenerate (`cd crates/<crate>/ui && pnpm install --frozen-lockfile && pnpm run build`, then for `trusty-search` also copy `ui/dist/*` into `ui-dist/`, or run `make release-prep`) and commit before publishing. Do not rely on `cargo publish --dry-run` to catch this — see the `publish-dry-run` job's header comment for why it structurally cannot.
 9. Build the release binary (if not already fresh): `cargo build --release -p <crate-name>`.
 10. Install the binary locally with `cargo install --path crates/<dir> --locked`
    (for crates with binaries, e.g. trusty-search, trusty-mpm). This ensures the

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -50,6 +50,9 @@ e.g. `trusty-mcp-core-v0.2.0`. The version comes from the crate's `Cargo.toml`.
 7. Run `scripts/check-publish-ready.sh <crate-name>` (or
    `make publish-check CRATE=<crate-name>`) — must pass before publishing. See
    [Publish-Only-From-Merged-Main Guard](#publish-only-from-merged-main-guard-issue-2227) below.
+   Also runs automatically post-merge: `make version-parity-check` (or wait
+   for `.github/workflows/version-parity.yml` on the merge commit) — see
+   [Version-Parity Guard](#version-parity-guard-issue-3366) below.
 8. Publish: `cargo publish -p <crate-name>`.
    - **UI-embedding crates** (trusty-search, trusty-memory, trusty-analyze): prefix with `SKIP_UI_BUILD=1`:
      ```bash
@@ -95,6 +98,34 @@ convention someone can forget under pressure.
 downgrades both guard failures to a loud warning and exits 0 instead of
 failing. Use it only when you have a specific, understood reason to publish
 from an unmerged commit; the default path is always "merge to main first."
+
+## Version-Parity Guard (issue #3366)
+
+🔴 **Before bumping a crate's version, confirm it hasn't already drifted.**
+`scripts/check-version-parity.sh` (also `make version-parity-check`) compares
+every publishable crate's local `src/` tree against the crates.io tarball for
+that crate's CURRENT (pre-bump) `Cargo.toml` version. If that version is
+already live and the source no longer matches it, the crate is flagged as
+drifted — source changes landed on `main` without a version bump, so the
+version number on crates.io no longer describes what's actually in the repo.
+
+This runs automatically on every push to `main`
+(`.github/workflows/version-parity.yml`), so drift is caught right after it
+merges instead of being discovered later as a `cargo publish --dry-run`
+failure (which is exactly how issue #3366 was found: `trusty-common` and
+`trusty-agents-common` had each drifted this way, and `cargo publish -p
+trusty-mpm --dry-run` failed with "symbol not found" errors for symbols that
+only existed in the unpublished, drifted source).
+
+The check fails CLOSED: if a crate's live/local comparison can't be verified
+(registry unreachable, unexpected response), that counts as a failure, never
+a silent pass. See `crates/trusty-publish-guard` for the underlying engine.
+
+For the cross-crate publish-ORDERING hazard (a related but distinct problem —
+publishing a crate before a sibling it depends on is live), see
+`scripts/publish-dry-run-order.sh` / `make publish-dry-run-order`, documented
+in `.claude/skills/cargo-publish/SKILL.md` under "Cross-Crate Publish
+Ordering."
 
 ## macOS Code-Signing Critical Alert
 

--- a/scripts/check-version-parity.sh
+++ b/scripts/check-version-parity.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# check-version-parity.sh — version-parity drift gate (issue #3366).
+#
+# Why: `trusty-common` and `trusty-agents-common` each carried several
+#   commits of source changes that landed on `main` WITHOUT a matching
+#   version bump, while the OLD version number was already live on
+#   crates.io. `cargo build`/`cargo test` never caught this because the
+#   workspace's `[patch.crates-io]` table redirects sibling deps to local
+#   paths for in-repo builds — the gap only surfaced when `cargo publish`
+#   resolved a crate standalone against the real registry, turning a
+#   merge-time defect into a release-time blocker (`cargo publish -p
+#   trusty-mpm --dry-run` failing with "symbol not found" errors). See
+#   issue #3366 for the full incident.
+#
+# What: builds and runs the `publish-guard` binary (crates/trusty-publish-guard)
+#   against this checkout. For every publishable workspace crate (anything
+#   NOT `publish = false`), it compares the crate's local `src/` tree against
+#   the crates.io tarball for that crate's OWN current `Cargo.toml` version:
+#     - version not live yet  -> PASS (nothing to compare; ordinary pre-release state)
+#     - source matches        -> PASS
+#     - source differs        -> FAIL (the #3366 defect: unpublished drift
+#                                 under an already-published version number)
+#     - registry unreachable / unexpected response -> FAIL (fails CLOSED;
+#                                 an unverifiable crate is never a silent pass)
+#
+# Usage:
+#   scripts/check-version-parity.sh
+#
+# Exit: 0 when every publishable crate is at parity (or not yet published);
+#   non-zero the moment any crate shows drift or could not be verified.
+#
+# Test: crates/trusty-publish-guard/src/lib.rs unit-tests the drift-detection
+#   engine (extraction, diffing, parity decision) against an in-memory fake
+#   registry — no network required for `cargo test -p trusty-publish-guard`.
+#   This script itself just wires that engine to the real crates.io API and
+#   is exercised by running it against this repo (see the #3366 PR
+#   description for the raw output confirming it reproduces the real,
+#   already-live drift on several crates).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+exec cargo run --quiet --locked -p trusty-publish-guard --bin publish-guard -- --root "${REPO_ROOT}"

--- a/scripts/publish-dry-run-order.sh
+++ b/scripts/publish-dry-run-order.sh
@@ -34,12 +34,17 @@
 #                                                  # in the right relative order),
 #                                                  # for a partial-release dry run
 #
-# This is a MANUAL preflight step (like check-publish-ready.sh and
-# preflight-publish.sh), run before a real `cargo publish` batch — it is
-# deliberately NOT wired into CI on every push: packaging every publishable
-# crate's tarball is comparatively expensive and only meaningful immediately
-# before a release, unlike the (cheaper, continuously-relevant)
-# version-parity check.
+# Wired into CI (issue #3366 scope-extension): `.github/workflows/release.yml`
+# runs this automatically, scoped to just the tagged crate (+ its publishable
+# dependency closure), as its own `publish-dry-run` job on every `*-v*` tag
+# push — see that job's header comment for why a single-crate-scoped,
+# tag-triggered run is workable where a full-workspace-per-PR gate would not
+# be (cost, registry rate limits), and why it is deliberately kept
+# INDEPENDENT of (not blocking) the binary-release build/release jobs.
+#
+# Also usable manually (`make publish-dry-run-order`) exactly like
+# check-publish-ready.sh and preflight-publish.sh, e.g. to dry-run a
+# multi-crate release batch before tagging anything.
 #
 # Requires: python3 (present on GitHub Actions ubuntu-latest runners and on
 #   every developer machine referenced elsewhere in this repo's scripts).
@@ -164,6 +169,15 @@ echo "${ORDER}" | sed 's/^/  /' >&2
 if [[ "${LIST_ONLY}" -eq 1 ]]; then
   exit 0
 fi
+
+# SKIP_UI_BUILD=1 unconditionally (matches ci.yml's global convention): the
+# UI-embedding crates (trusty-search, trusty-memory, trusty-analyze,
+# trusty-console) invoke pnpm from build.rs unless this is set, which fails
+# inside `cargo publish`'s isolated verification tarball (no network/pnpm
+# there) — see docs/reference/release-workflow.md's "UI-embedding crates"
+# note. A no-op for every other crate, so it is simplest to always set it
+# rather than special-case which crates in the computed order need it.
+export SKIP_UI_BUILD=1
 
 while IFS= read -r crate; do
   [[ -z "${crate}" ]] && continue

--- a/scripts/publish-dry-run-order.sh
+++ b/scripts/publish-dry-run-order.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# publish-dry-run-order.sh — dependency-ordered `cargo publish --dry-run`
+# preflight (issue #3366, requirement 2).
+#
+# Why: on 2026-07-20 a crate was published against sibling code that was not
+#   yet live on crates.io — a publish-ORDERING mistake, distinct from (but
+#   related to) the version-parity drift this issue's other guard
+#   (scripts/check-version-parity.sh) detects. The established lesson from
+#   that incident (see project memory "Cross-crate publish ordering") is:
+#   `cargo publish --dry-run` resolves dependencies against the LIVE registry
+#   and is the thing that actually catches "calls into a sibling crate that
+#   isn't live yet" — but only if it is run for EVERY affected crate, IN
+#   DEPENDENCY ORDER, immediately before a release. Today that ordering is a
+#   manually-computed, documented recipe (.claude/skills/cargo-publish/SKILL.md
+#   "Cross-Crate Publish Ordering") — this script makes the ordering itself
+#   mechanical so a release doesn't depend on someone re-deriving the
+#   dependency graph by hand under time pressure.
+#
+# What: runs `cargo metadata` once, computes a topological order over every
+#   PUBLISHABLE workspace crate (i.e. not `publish = false`) using internal
+#   (workspace-to-workspace) dependency edges only, then runs
+#   `cargo publish --dry-run -p <crate>` for each crate in that order —
+#   dependencies always before dependents. Any single dry-run failure stops
+#   the run immediately (fail fast: a downstream crate's dry-run failing
+#   because an upstream sibling isn't live yet is exactly the class of bug
+#   this script exists to catch before a real publish).
+#
+# Usage:
+#   scripts/publish-dry-run-order.sh              # every publishable crate, in order
+#   scripts/publish-dry-run-order.sh --list-only  # print the order, run nothing
+#   scripts/publish-dry-run-order.sh trusty-search trusty-common
+#                                                  # only these crates (+ already
+#                                                  # in the right relative order),
+#                                                  # for a partial-release dry run
+#
+# This is a MANUAL preflight step (like check-publish-ready.sh and
+# preflight-publish.sh), run before a real `cargo publish` batch — it is
+# deliberately NOT wired into CI on every push: packaging every publishable
+# crate's tarball is comparatively expensive and only meaningful immediately
+# before a release, unlike the (cheaper, continuously-relevant)
+# version-parity check.
+#
+# Requires: python3 (present on GitHub Actions ubuntu-latest runners and on
+#   every developer machine referenced elsewhere in this repo's scripts).
+#
+# Test: exercised manually — see the issue #3366 PR description for the raw
+#   printed order against this workspace's real dependency graph, and for a
+#   `--list-only` run confirming publishable-but-undeclared crates (e.g. a
+#   brand-new crate) sort after everything they depend on.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+LIST_ONLY=0
+FILTER=()
+for arg in "$@"; do
+  case "$arg" in
+    --list-only) LIST_ONLY=1 ;;
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) FILTER+=("$arg") ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Compute the topological publish order via `cargo metadata` + a small Python
+# helper (Kahn's algorithm, ties broken alphabetically for determinism).
+#
+# The metadata JSON is captured to a temp FILE (rather than piped directly
+# into the python3 heredoc) because `python3 - <<'EOF' ... EOF` consumes
+# stdin for the heredoc script body itself — piping `cargo metadata | python3
+# -` would collide with that, silently starving the script of both its own
+# source and the JSON. Passing the metadata as a file argument sidesteps the
+# collision entirely.
+# ---------------------------------------------------------------------------
+TMP_METADATA="$(mktemp "${TMPDIR:-/tmp}/publish-dry-run-order.metadata.XXXXXX.json")"
+trap 'rm -f "${TMP_METADATA}"' EXIT
+
+cargo metadata --format-version=1 --locked >"${TMP_METADATA}"
+
+ORDER="$(python3 - "${TMP_METADATA}" "${FILTER[@]}" <<'PYEOF'
+import json
+import sys
+
+metadata_path = sys.argv[1]
+filt = set(sys.argv[2:])
+with open(metadata_path) as f:
+    data = json.load(f)
+
+members = set(data["workspace_members"])
+packages = {p["id"]: p for p in data["packages"] if p["id"] in members}
+
+# publish == None means "publishable to any registry"; [] means `publish = false`.
+publishable = {pid for pid, p in packages.items() if p.get("publish") is None}
+
+# Internal (workspace-to-workspace) dependency edges, keyed by package id.
+resolve_nodes = {n["id"]: n for n in data["resolve"]["nodes"]}
+edges = {pid: set() for pid in publishable}
+for pid in publishable:
+    node = resolve_nodes.get(pid)
+    if not node:
+        continue
+    for dep_id in node.get("dependencies", []):
+        if dep_id in publishable:
+            edges[pid].add(dep_id)
+
+# Kahn's algorithm: repeatedly emit any publishable crate whose remaining
+# unemitted dependencies are all already emitted, breaking ties by name for
+# deterministic output.
+remaining = dict(edges)
+emitted = []
+name_of = {pid: packages[pid]["name"] for pid in publishable}
+while remaining:
+    ready = sorted(
+        (pid for pid, deps in remaining.items() if not deps),
+        key=lambda pid: name_of[pid],
+    )
+    if not ready:
+        cyclic = ", ".join(sorted(name_of[pid] for pid in remaining))
+        print(f"ERROR: dependency cycle among publishable crates: {cyclic}", file=sys.stderr)
+        sys.exit(1)
+    for pid in ready:
+        emitted.append(pid)
+        del remaining[pid]
+    for deps in remaining.values():
+        deps.difference_update(ready)
+
+ordered_names = [name_of[pid] for pid in emitted]
+
+if filt:
+    # Keep only requested crates (still in dependency order) plus any
+    # publishable crate they transitively depend on, so a partial run never
+    # tries to dry-run a crate before an unlisted sibling it needs.
+    pid_of = {v: k for k, v in name_of.items()}
+    wanted = {pid_of[n] for n in filt if n in pid_of}
+    closure = set()
+    stack = list(wanted)
+    while stack:
+        pid = stack.pop()
+        if pid in closure:
+            continue
+        closure.add(pid)
+        stack.extend(edges.get(pid, ()))
+    ordered_names = [n for n in ordered_names if pid_of[n] in closure]
+
+for n in ordered_names:
+    print(n)
+PYEOF
+)"
+
+if [[ -z "${ORDER}" ]]; then
+  echo "publish-dry-run-order: no publishable crates matched (check crate names)." >&2
+  exit 1
+fi
+
+echo "publish-dry-run-order: dependency-ordered publish sequence:" >&2
+echo "${ORDER}" | sed 's/^/  /' >&2
+
+if [[ "${LIST_ONLY}" -eq 1 ]]; then
+  exit 0
+fi
+
+while IFS= read -r crate; do
+  [[ -z "${crate}" ]] && continue
+  echo "publish-dry-run-order: cargo publish --dry-run -p ${crate}" >&2
+  if ! cargo publish --dry-run -p "${crate}"; then
+    echo "publish-dry-run-order: FAILED at ${crate} — fix before publishing anything" \
+         "after it in the order above (a downstream crate failing here usually" \
+         "means an upstream sibling version isn't live on crates.io yet)." >&2
+    exit 1
+  fi
+done <<<"${ORDER}"
+
+echo "publish-dry-run-order: OK — every crate in the computed order passed --dry-run." >&2


### PR DESCRIPTION
## Summary

Closes #3366. Adds a version-parity drift detector and a dependency-order
publish-ordering preflight — the two structural guardrails requested to make
the 2026-07-20-style release incidents mechanically hard to repeat.

## What I verified on current `origin/main` (HEAD `12e9d37d` at the time this branch was cut)

The issue reported `trusty-common` 0.23.3 and `trusty-agents-common` 0.2.2 as
drifted. Both of those exact version numbers have since been bumped forward
(now 0.23.7 and 0.2.3) — but **the underlying defect class is still live and
recurring, not resolved**:

- `trusty-common`'s Cargo.toml has stayed at `0.23.7` (published to crates.io
  2026-07-21T03:42Z) while commit `12e9d37d` (2026-07-21T10:37Z, ~7h later)
  added new source to `src/embedder/{fast_embedder,mod,types}.rs` and
  `src/embedder_client/stdio.rs`, plus a new `src/embedder/provider_tests.rs`
  file — all **without** a version bump. I verified this by hand first (`git
  log`/`git show` across the version-bump and post-bump commits, cross-checked
  against the live crates.io API), then built the checker in this PR and ran
  it against the real workspace — it independently reproduced the exact same
  file list.
- Running the new `publish-guard` tool against the full workspace found this
  same pattern in **8 of 17 publishable crates**: `trusty-common`,
  `trusty-analyze`, `trusty-code`, `trusty-console`, `trusty-embedderd`,
  `trusty-memory`, `trusty-review`, `trusty-search`. (Raw tool output is long;
  happy to paste the full per-crate breakdown on request — the `trusty-common`
  block alone is quoted below.)

```
[FAIL] trusty-common 0.23.7 — UNPUBLISHED SOURCE DRIFT under an already-published version:
       ~ modified (content differs from published): src/embedder/fast_embedder.rs
       ~ modified (content differs from published): src/embedder/mod.rs
       + added (local only, not on crates.io): src/embedder/provider_tests.rs
       ~ modified (content differs from published): src/embedder/types.rs
       ~ modified (content differs from published): src/embedder_client/stdio.rs
       Fix: bump the version in crates/trusty-common/Cargo.toml (this is the #3366 defect).
```

**This PR does not fix those 8 crates' versions** — that's a separate,
larger cross-cutting bump that would collide with other engineers'
in-flight work in parallel worktrees (per scope discipline for this issue).
It only ships the detector, so this backlog is now visible and mechanically
enforced going forward instead of silently recurring.

## What this PR adds

### 1. `trusty-publish-guard` (new crate, `publish = false`)

For every publishable workspace crate: if its current `Cargo.toml` version is
already live on crates.io, compares the local `src/` tree byte-for-byte
against the crates.io tarball published under that same version. A version
not yet published is a trivial pass (ordinary "just bumped" state); any
mismatch is `Drift` — the #3366 defect.

- `src/lib.rs` — the pure, unit-tested engine (extraction, diffing, the
  parity decision). All crates.io access sits behind a `PublishedFetcher`
  trait so this half is fully testable with an in-memory fake — **no network
  required** for `cargo test -p trusty-publish-guard`.
- `src/fetch.rs` — the one real crates.io-backed implementation (two HTTP
  calls, no logic). Deliberately not exercised by `cargo test`; correctness
  is instead demonstrated by running it against the real registry (see
  above).
- `src/main.rs` — CLI wrapper (`publish-guard`), walks `crates/*/Cargo.toml`.
- **Fails closed by design**: a registry lookup that errors (network failure,
  unexpected HTTP status) is a failure, never silently coerced into a pass —
  matches the explicit "fail loudly, never advisory" constraint for this
  issue.

### 2. Wiring

- `scripts/check-version-parity.sh` + `make version-parity-check` — run it
  locally/on demand.
- `.github/workflows/version-parity.yml` — runs **on push to `main` only**
  (no `pull_request` trigger). This matches the issue's own proposed design
  ("should probably run on merge to main, not on every PR to avoid noise"):
  the check is only meaningful against what actually landed on main, so it
  surfaces drift as a red commit status right after merge — a merge-time
  finding instead of a release-time surprise — without adding registry-call
  noise to every PR from parallel agent worktrees.

### 3. `scripts/publish-dry-run-order.sh` + `make publish-dry-run-order` (requirement 2)

Computes a topological publish order from `cargo metadata` (Kahn's algorithm
over workspace-internal dependency edges among publishable crates only) and
runs `cargo publish --dry-run -p <crate>` for each crate in that order,
stopping at the first failure. This targets the *other*, related incident
(2026-07-20: a crate published before a sibling it depends on was live) by
making `.claude/skills/cargo-publish/SKILL.md`'s previously-manual "Cross-Crate
Publish Ordering" recipe mechanical instead of hand-derived under time
pressure. Supports `--list-only` (print the order, run nothing) and an
optional crate-name filter for partial releases.

**Design choice, justified**: this is wired as a manual preflight (`make
publish-dry-run-order`), like the existing `check-publish-ready.sh` /
`preflight-publish.sh` scripts — **not** automated into CI on every push.
Packaging every publishable crate's tarball is comparatively expensive and
only meaningful immediately before an actual release batch, unlike
version-parity (cheap-ish, continuously relevant, and specifically what the
issue asked to wire into CI).

### Not touched

`scripts/check-publish-ready.sh` (merged-main + tag guard) and
`scripts/preflight-publish.sh` (identity + clean-tree + version-not-live) —
these already cover the "publish only from merged main" and "version not
already live" guards from requirement 2; no changes needed.

### Adjacent problem noticed, not fixed (out of scope)

`crates/trusty-agents/ui/src-tauri` (package `trusty-agents-ui`) has no
`publish = false` in its `Cargo.toml`, unlike the other two Tauri GUI crates
— it shows up as "publishable" in `cargo metadata` even though it's a GUI
crate never meant for crates.io. Flagging for a separate, smaller PR rather
than fixing here.

## Tests (regression, causality demonstrated)

`crates/trusty-publish-guard/src/lib.rs` has 6 unit tests against an
in-memory fake registry (no network). The key regression test,
`drift_detected_when_local_source_changed_after_publish`, is modeled directly
on the confirmed real incident (local source changed on top of an
already-published version).

**Causality check**: I temporarily stubbed `diff_src` to always return `Vec::new()`
(i.e., "pretend nothing ever drifts" — the world before this detector
existed) and reran the suite:

```
test tests::diff_src_is_order_independent_and_deterministic ... FAILED
test tests::drift_detects_file_removed_relative_to_published_tree ... FAILED
test tests::drift_detected_when_local_source_changed_after_publish ... FAILED
test result: FAILED. 3 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out
```

Then restored the real implementation:

```
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

`src/fetch.rs` (the real crates.io HTTP client) is **not** unit-tested — it's
two HTTP calls with no branching logic beyond status-code mapping, and
testing it would require live network access to crates.io, which this
workspace's test suite must not depend on. Its correctness is instead
demonstrated by running `publish-guard` against the real workspace (above),
which reproduced the actual reported drift byte-for-byte.

## Quality gate (raw output)

```
$ cargo fmt --all -- --check
(exit 0 — clean; only rustfmt "unstable feature, nightly-only" warnings, unrelated)

$ cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 03s
(no errors; exit 0)

$ cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --no-fail-fast
error: 3 targets failed:
    `-p trusty-code --lib`
    `-p trusty-search --lib`
    `-p trusty-search --bin trusty-search`
```

All 3 failures are the pre-authorized, pre-existing, unrelated ones:
- `run_task::tests::no_changes_yields_no_changes_exit` (trusty-code) —
  confirmed a live `trusty-memory` daemon is actually running on
  `127.0.0.1:7070` in this environment right now (`curl` returned a real
  `/health` response), matching the documented interference cause exactly.
- `service::colocated_storage::tests::gitignore_entry_added_idempotently`
  (trusty-search --lib)
- `commands::migrate_storage::handler_tests::migrate_storage_moves_files_and_updates_registry`
  (trusty-search --bin)

`crates/trusty-publish-guard`'s own 6 tests: **6 passed, 0 failed**.

## Safety

- No real `cargo publish` was run — only `--dry-run`/`--list-only` paths were
  exercised, and only in list-only mode during development.
- No writes to `~/.cargo/bin`, `~/.local/bin`, or launchctl.
- Reverted incidental `trusty-search/ui-dist` build artifacts that a local
  (non-`SKIP_UI_BUILD=1`) build regenerated — unrelated to this issue, not
  part of this PR's diff.

---

## Scope extension: release.yml gaps (owner-approved, added after initial review)

A follow-up CI audit confirmed two more gaps in this same lane, both now
addressed on this branch:

### 3. Tag-ancestry guard (`release.yml`'s `preflight` job)

`release.yml` triggers on push of any `*-v*` tag with nothing verifying the
tagged commit came from merged main — a tag pushed from an unmerged branch
fired the full release pipeline. Fixed with a REAL ancestry check, not a ref
comparison:

```bash
git fetch origin main --quiet
TAGGED_SHA="$(git rev-parse 'HEAD^{commit}')"   # dereferences an annotated tag object to its commit
MAIN_SHA="$(git rev-parse origin/main)"
git merge-base --is-ancestor "${TAGGED_SHA}" "${MAIN_SHA}"
```

`github.ref` on a tag push is the tag itself (`refs/tags/<tag>`), so a naive
`github.ref == 'refs/heads/main'` guard would never match and would silently
disable every release — that's exactly the "looks correct but doesn't verify
ancestry" trap called out in the ask. This job does a full-history checkout
(`fetch-depth: 0`) specifically because a shallow clone can make
`merge-base --is-ancestor` lie (report "not an ancestor" for a commit that
truly is, because the shallow horizon doesn't reach the real merge-base).
`HEAD^{commit}` (not `github.sha`) is used to resolve the tagged ref, so an
annotated tag object is dereferenced to its underlying commit rather than
risking a tag-object SHA being compared as if it were a commit SHA.
`build`'s `needs:` now includes `preflight`; `release`/`homebrew-bump`
already gate on `needs.build.result`, so the guard cascades through the
whole pipeline without touching their existing (issue #3540) conditions.
No-ops cleanly on `workflow_dispatch` (no tag exists to check ancestry for).

### 4. `cargo publish --dry-run` wired as an actual, always-fires CI job

Previously `scripts/publish-dry-run-order.sh` (added in this PR) was a
manual `make` target only — exactly the "tribal knowledge, not enforcement"
gap the audit flagged. Now a new `publish-dry-run` job runs it automatically,
scoped to just the tagged crate + its publishable dependency closure,
`needs: [setup, preflight]` (so an unmerged-branch tag never reaches it
either), on every `*-v*` push:

```bash
bash scripts/publish-dry-run-order.sh "${{ needs.preflight.outputs.pkg_name }}"
```

**Why scoped-per-tag instead of per-PR or full-workspace**: a full-workspace
dry-run on every PR would burn crates.io registry calls on changes that were
never going to publish anything, and would dry-run ~17 crates for a
one-crate release. Scoping to one crate's dependency closure, firing exactly
once at tag-push time (exactly when a release is actually happening) keeps
the cost bounded to what a real release naturally requires anyway — this is
the resolution to the "impractical as a per-PR gate" concern, not an
abandonment of enforcement.

**Why NOT a dependency of `build`/`release`/`homebrew-bump` (blocking vs.
independent, explained)**: a failing crates.io dry-run means "not safe to
`cargo publish` right now" — it says nothing about whether the GitHub binary
tarball is safe to build, since binary distribution never touches
crates.io. Coupling them would also import crates.io's own documented
propagation lag (60-120s after an upstream publish, per this repo's
Cross-Crate Publish Ordering notes) into the binary-release path as pure
flakiness with no corresponding safety benefit. Kept independent, the job
still fails LOUDLY on its own (the tag's overall workflow run goes red,
visible on commit/PR checks) — it just doesn't block the unrelated binary
artifact. `pkg_name`/`publishable` are resolved in the new `preflight` job
directly from `crates/<crate>/Cargo.toml`, independent of the binary-release
allowlist (`bundled` flag) — a library-only crate like `trusty-common` is
`bundled=true` (no standalone binary) but is exactly the kind of real,
publishable package #3366 was about, so it must not be skipped here.

Also fixed: `scripts/publish-dry-run-order.sh` now exports `SKIP_UI_BUILD=1`
unconditionally — without it, the UI-embedding crates (trusty-search,
trusty-memory, trusty-analyze, trusty-console) invoke `pnpm` inside cargo's
isolated verification tarball and fail for a reason unrelated to publish
safety (documented in `docs/reference/release-workflow.md`'s "UI-embedding
crates" note).

### Verification

- `cargo publish --dry-run -p trusty-progress` (unchanged, already-published
  version) locally: exits 0, only warns "already exists on crates.io index"
  — confirms the dependency-closure dry-run does not spuriously fail on
  already-live, unchanged siblings (the common case for most crates in any
  given tag's dependency closure).
- `actionlint .github/workflows/*.yml`: 0 findings in `release.yml` or
  `version-parity.yml` (the only finding anywhere in `.github/workflows/` is
  a pre-existing, unrelated shellcheck style note in `e2e-docker.yml`).
- `python3 -c "import yaml; yaml.safe_load(...)"` parses `release.yml`
  cleanly; all 6 jobs (`setup`, `preflight`, `build`, `publish-dry-run`,
  `release`, `homebrew-bump`) present in the expected order.
- PR CI is green: Clippy, MSRV, Format, the 27-minute `Test` job, SLD lint,
  doc-comment pointer lint, `tm-capabilities` drift, `trusty-agents-ui`
  clippy, and the `trusty-search` daemon smoke test all pass on the clean
  runner (the local `trusty-code`/`trusty-search` test failures noted above
  do not reproduce there).

### Verified, not fixed here (adjacent findings for a separate follow-up)

- `trusty-agents-common` is genuinely absent from the workspace's
  `[patch.crates-io]` table (unlike `trusty-common`, `trusty-embedderd`,
  `trusty-bm25-daemon`, `trusty-console`). Practical impact looks limited —
  `workspace.dependencies` already declares it with an explicit `path = ...`
  entry, which workspace-internal consumers resolve directly regardless of
  the patch table — but I did not deeply verify every path a stale
  registry copy could still leak in through, so flagging rather than
  asserting it's cosmetic.
- `crates/trusty-agents/ui/src-tauri` (package `trusty-agents-ui`) lacks
  `publish = false` unlike its sibling Tauri GUIs (`trusty-mpm-gui`,
  `trusty-code-gui`), so it shows as "publishable" in `cargo metadata` and
  in `publish-dry-run-order.sh`'s computed order. This looks like a real
  (if low-severity) hazard, not merely cosmetic: nothing currently stops
  someone from actually running `cargo publish -p trusty-agents-ui` and
  shipping a Tauri desktop-app crate to crates.io by mistake. Worth its own
  small issue/PR.

No real `cargo publish` was run at any point — dry-run and list-only paths
only.

---

## Round 2: adversarial review WARN — 2 findings fixed (owner-approved critical path)

Both findings from the adversarial review addressed on this branch (rebased
onto origin/main 60e2c104, force-pushed with --force-with-lease).

**What the reviewer confirmed as already correct** (validated, not assumed):
46/49 real historical tags check out clean against the new ancestry guard
(the 4 failures are the already-diagnosed #2214 branch-divergence incident on
an abandoned branch); a tag from an unmerged branch fails closed; a failed
`preflight` genuinely propagates to skip `release` via the existing
`needs.build.result != 'skipped'` check, composing correctly with the #3541
`!cancelled()` override.

### HIGH — `SKIP_UI_BUILD=1` made the dry-run blind to UI bundle staleness

Investigated rather than picked blind between the two options offered:

- **"Install pnpm, let `cargo publish` rebuild for real" turned out to be
  structurally impossible** for `trusty-search`/`trusty-console` specifically
  — confirmed with `cargo package --list -p trusty-console`: their
  `Cargo.toml` `include` list ships only the pre-built bundle, `ui/src` is
  never in the tarball. `cargo publish`, dry-run or real, cannot rebuild what
  isn't there — this is not a CI shortcut, it's what the actual publish
  already does, matching `docs/reference/release-workflow.md`'s existing
  `SKIP_UI_BUILD=1` requirement.
- **The staleness risk is real, not hypothetical** — confirmed with git
  history, not assumption: `crates/trusty-search/ui-dist/` was last
  regenerated 2026-07-07 (`28648d38`), but `crates/trusty-search/ui/src` was
  changed afterward by the Foundry v2 token migration (`972171e8`,
  `git log 28648d38..HEAD -- crates/trusty-search/ui/src`). Reproduced
  locally: a fresh `pnpm run build` from current `ui/src` produces different
  asset content/hashes than the committed `ui-dist/`.

**Fix**: new `ui-freshness-check` job, scoped to the 4 UI-embedding crates,
`needs: [setup, preflight]`. Snapshots the committed embed directory
(`ui-dist/` for trusty-search per its build.rs's copy-from-`ui/dist` step,
`ui/dist/` directly for the other three), runs a real `pnpm install
--frozen-lockfile && pnpm run build` (same toolchain-setup pattern as
`ci.yml`'s same-day `ui-checks` job, #3508/#3571), then `diff -rq`s the
snapshot against the fresh output — failing loudly on any difference,
including a build failure outright.

**Deliberately did NOT build a hash-normalizing comparator**: `ci.yml`'s
`ui-checks` job (merged the same day) already evaluated and rejected naive
rebuild-then-diff for these same crates, because Vite's content-hashed
filenames can legitimately shift across a toolchain patch bump with no real
behavior change — a genuine flakiness risk this job does not solve.
`pnpm install --frozen-lockfile` bounds (does not eliminate) that risk to
Node-runtime-version drift specifically. Chose fail-closed anyway, matching
this whole PR's "fail loudly, no advisory checks" constraint, because the
remedy is identical either way (regenerate and commit) — documented
explicitly in the job's header rather than silently glossed over. Also
corrected `.claude/skills/cargo-publish/SKILL.md`'s Pre-Publish Sequence,
which — confirmed while investigating this — never mentioned
`SKIP_UI_BUILD` at all (inconsistent with `docs/reference/release-workflow.md`'s
already-correct guidance).

### MEDIUM — shell injection via raw `${{ github.ref_name }}`

Fixed both occurrences (the `preflight` job's ancestry-check step) by
passing the ref through `env: TAG: ${{ github.ref_name }}` and referencing
`"$TAG"`, matching the `homebrew-bump` job's existing safe pattern elsewhere
in this same file.

### Verification

- `python3 -c "import yaml; yaml.safe_load(...)"`: `release.yml` parses
  clean, 7 jobs (`setup`, `preflight`, `build`, `publish-dry-run`,
  `ui-freshness-check`, `release`, `homebrew-bump`) in the expected order.
- `actionlint .github/workflows/*.yml`: 0 findings in `release.yml` or
  `version-parity.yml`.
- Extracted the `ui-freshness-check` job's exact bash logic and ran it
  locally against `trusty-search`: reproduces the real drift (asset hashes
  differ, `index.html` differs) with the same diff output the CI job would
  print — confirms the check's logic is correct, not just YAML-valid.
- Confirmed the local rebuild only touched gitignored `ui/dist/` (per-crate
  `.gitignore`), never the tracked `ui-dist/` — working tree stayed clean.

No real `cargo publish` was run. No tag was pushed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
