### PR TITLE
fix(trusty-common): bounded ETXTBSY retry in EmbedderSupervisor::spawn_stdio

### DIFF
--- a/crates/trusty-common/src/embedder_client/mod.rs
+++ b/crates/trusty-common/src/embedder_client/mod.rs
@@ -30,6 +30,7 @@
 pub mod error;
 pub mod in_process;
 pub mod remote;
+mod spawn_retry;
 pub mod stdio;
 pub mod supervisor;
 pub mod types;

--- a/crates/trusty-common/src/embedder_client/spawn_retry.rs
+++ b/crates/trusty-common/src/embedder_client/spawn_retry.rs
@@ -5,10 +5,11 @@
 //! sharing this crate's usual per-module split (`error.rs`, `stdio.rs`, …)
 //! rather than a test-only `#[path]` trick.
 //!
-//! Test: exercised indirectly via `supervisor::tests::shutdown_tests::supervisor_dropped_handle_does_not_busy_spin`
-//! (#3570) and `supervisor::tests::supervisor_spawns_mock_child_and_embeds`,
-//! both of which drive `EmbedderSupervisor::spawn_stdio` -> `spawn_child` ->
-//! `spawn_embedderd`.
+//! Test: exercised indirectly via every test in
+//! `supervisor::tests::shutdown_tests` (all of which call
+//! `EmbedderSupervisor::spawn_stdio` -> `spawn_child` -> `spawn_embedderd`
+//! before exercising shutdown), especially
+//! `supervisor_dropped_handle_does_not_busy_spin` (#3570).
 
 use std::path::Path;
 use std::process::Stdio;
@@ -29,7 +30,7 @@ use super::supervisor::SupervisorConfig;
 /// `config.sidecar_batch_size` is `Some(n)`) `TRUSTY_EMBED_BATCH_SIZE=n`
 /// (issue #747 Fix C) — then delegates to `spawn_with_etxtbsy_retry`.
 /// Test: `supervisor_dropped_handle_does_not_busy_spin`,
-/// `supervisor_spawns_mock_child_and_embeds`.
+/// `supervisor_shutdown_kills_child`.
 pub(super) async fn spawn_embedderd(
     binary_path: &Path,
     config: &SupervisorConfig,
@@ -66,7 +67,7 @@ pub(super) async fn spawn_embedderd(
 /// other error, or the success path, returns immediately. The bound keeps real
 /// failures (missing binary, permission denied) from being masked or delayed.
 /// Test: `supervisor_dropped_handle_does_not_busy_spin`,
-/// `supervisor_spawns_mock_child_and_embeds`.
+/// `supervisor_shutdown_kills_child`.
 async fn spawn_with_etxtbsy_retry<F>(mut build: F) -> std::io::Result<Child>
 where
     F: FnMut() -> Command,

--- a/crates/trusty-common/src/embedder_client/spawn_retry.rs
+++ b/crates/trusty-common/src/embedder_client/spawn_retry.rs
@@ -1,0 +1,103 @@
+//! Bounded ETXTBSY retry wrapper for spawning the `trusty-embedderd` sidecar.
+//!
+//! Why: isolated in a sibling file (rather than inline in `supervisor.rs`) to
+//! keep `supervisor.rs` under its 500-SLOC production-file cap while still
+//! sharing this crate's usual per-module split (`error.rs`, `stdio.rs`, …)
+//! rather than a test-only `#[path]` trick.
+//!
+//! Test: exercised indirectly via `supervisor::tests::shutdown_tests::supervisor_dropped_handle_does_not_busy_spin`
+//! (#3570) and `supervisor::tests::supervisor_spawns_mock_child_and_embeds`,
+//! both of which drive `EmbedderSupervisor::spawn_stdio` -> `spawn_child` ->
+//! `spawn_embedderd`.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::process::{Child, Command};
+
+use super::supervisor::SupervisorConfig;
+
+/// Build the `trusty-embedderd --stdio` command and spawn it with a bounded
+/// ETXTBSY retry.
+///
+/// Why: extracted out of `supervisor::spawn_child` so command construction
+/// and the retry live together — `Command` is not `Clone`, so retrying a
+/// spawn means rebuilding it from scratch on every attempt anyway.
+/// What: `Command::new(binary_path).arg("--stdio")` with piped stdin/stdout,
+/// inherited stderr, `kill_on_drop(true)`, and (when
+/// `config.sidecar_batch_size` is `Some(n)`) `TRUSTY_EMBED_BATCH_SIZE=n`
+/// (issue #747 Fix C) — then delegates to `spawn_with_etxtbsy_retry`.
+/// Test: `supervisor_dropped_handle_does_not_busy_spin`,
+/// `supervisor_spawns_mock_child_and_embeds`.
+pub(super) async fn spawn_embedderd(
+    binary_path: &Path,
+    config: &SupervisorConfig,
+) -> std::io::Result<Child> {
+    let build = || {
+        let mut cmd = Command::new(binary_path);
+        cmd.arg("--stdio")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true);
+        if let Some(bs) = config.sidecar_batch_size {
+            cmd.env("TRUSTY_EMBED_BATCH_SIZE", bs.to_string());
+        }
+        cmd
+    };
+    spawn_with_etxtbsy_retry(build).await
+}
+
+/// Spawn a freshly-built `Command`, retrying on ETXTBSY (os error 26).
+///
+/// Why: `execve` can fail with `ETXTBSY` ("Text file busy") when the kernel
+/// still considers the target inode open-for-write — e.g. when a just-written,
+/// just-chmod'd mock `trusty-embedderd` script is exec'd before the page-cache
+/// flush settles. This is the same race class already diagnosed and fixed in
+/// `trusty-agents` under #866, #1528, and #1634 (see
+/// `spawn_with_etxtbsy_retry` in `claude_code_runner/mod.rs`); this transplants
+/// that exact bounded-retry shape rather than inventing a new one, so the
+/// regression test `supervisor_dropped_handle_does_not_busy_spin` (#3570) — and
+/// the real sidecar spawn path — stop hitting the transient kernel state.
+/// What: calls `build()` to obtain a fresh `Command` on each attempt (required
+/// because `Command` is not `Clone`) and `.spawn()`s it. On `ETXTBSY` it backs
+/// off with a short exponential delay (≤3 attempts, 5 ms base) and retries; any
+/// other error, or the success path, returns immediately. The bound keeps real
+/// failures (missing binary, permission denied) from being masked or delayed.
+/// Test: `supervisor_dropped_handle_does_not_busy_spin`,
+/// `supervisor_spawns_mock_child_and_embeds`.
+async fn spawn_with_etxtbsy_retry<F>(mut build: F) -> std::io::Result<Child>
+where
+    F: FnMut() -> Command,
+{
+    const MAX_ATTEMPTS: u32 = 3;
+    const BACKOFF_MS: u64 = 5;
+
+    let mut last_err: Option<std::io::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match build().spawn() {
+            Ok(child) => return Ok(child),
+            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                last_err = Some(e);
+                // Exponential backoff: 5ms, 10ms, 20ms for MAX_ATTEMPTS=3.
+                // `attempt` is bounded by MAX_ATTEMPTS, so the shift is far
+                // below u64's 64-bit width. Use an explicit `1u64` shift and a
+                // saturating multiply so this stays overflow-safe for any
+                // reasonable MAX_ATTEMPTS value if it is ever raised.
+                let backoff_ms = BACKOFF_MS.saturating_mul(1u64 << attempt);
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    // Unreachable in practice: the loop only falls through after recording an
+    // ETXTBSY error, so `last_err` is always `Some`. Construct a defensive
+    // fallback rather than panicking.
+    Err(last_err.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::ExecutableFileBusy,
+            "spawn retries exhausted",
+        )
+    }))
+}

--- a/crates/trusty-common/src/embedder_client/supervisor.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor.rs
@@ -483,23 +483,33 @@ async fn spawn_child(
 ) -> Result<(Child, StdioEmbedderClient)> {
     use std::process::Stdio;
 
-    let mut cmd = Command::new(binary_path);
-    cmd.arg("--stdio")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .kill_on_drop(true);
-
-    // Forward resolved ONNX batch size (issue #747 Fix C).
+    // Forward resolved ONNX batch size (issue #747 Fix C). Logged once here
+    // (rather than inside `build_cmd`) so a retry doesn't repeat the log line.
     if let Some(bs) = config.sidecar_batch_size {
-        cmd.env("TRUSTY_EMBED_BATCH_SIZE", bs.to_string());
         tracing::debug!(
             bs,
             "EmbedderSupervisor: forwarding TRUSTY_EMBED_BATCH_SIZE={bs}"
         );
     }
 
-    let mut child = cmd.spawn().with_context(|| {
+    // Build the command inside a closure so the ETXTBSY retry wrapper can
+    // reconstruct it on each attempt (`Command` is not `Clone`). See
+    // `spawn_with_etxtbsy_retry` for why the retry exists (#3570 / #1634).
+    let build_cmd = || {
+        let mut cmd = Command::new(binary_path);
+        cmd.arg("--stdio")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true);
+
+        if let Some(bs) = config.sidecar_batch_size {
+            cmd.env("TRUSTY_EMBED_BATCH_SIZE", bs.to_string());
+        }
+        cmd
+    };
+
+    let mut child = spawn_with_etxtbsy_retry(build_cmd).await.with_context(|| {
         format!(
             "spawn trusty-embedderd --stdio from {}",
             binary_path.display()
@@ -553,6 +563,59 @@ async fn spawn_child(
     }
 
     Ok((child, client))
+}
+
+/// Spawn a freshly-built `Command`, retrying on ETXTBSY (os error 26).
+///
+/// Why: `execve` can fail with `ETXTBSY` ("Text file busy") when the kernel
+/// still considers the target inode open-for-write — e.g. when a just-written,
+/// just-chmod'd mock `trusty-embedderd` script is exec'd before the page-cache
+/// flush settles. This is the same race class already diagnosed and fixed in
+/// `trusty-agents` under #866, #1528, and #1634 (see
+/// `spawn_with_etxtbsy_retry` in `claude_code_runner/mod.rs`); this transplants
+/// that exact bounded-retry shape rather than inventing a new one, so the
+/// regression test `supervisor_dropped_handle_does_not_busy_spin` (#3570) — and
+/// the real sidecar spawn path — stop hitting the transient kernel state.
+/// What: calls `build()` to obtain a fresh `Command` on each attempt (required
+/// because `Command` is not `Clone`) and `.spawn()`s it. On `ETXTBSY` it backs
+/// off with a short exponential delay (≤3 attempts, 5 ms base) and retries; any
+/// other error, or the success path, returns immediately. The bound keeps real
+/// failures (missing binary, permission denied) from being masked or delayed.
+/// Test: `supervisor_dropped_handle_does_not_busy_spin`,
+/// `supervisor_spawns_mock_child_and_embeds`.
+async fn spawn_with_etxtbsy_retry<F>(mut build: F) -> std::io::Result<Child>
+where
+    F: FnMut() -> Command,
+{
+    const MAX_ATTEMPTS: u32 = 3;
+    const BACKOFF_MS: u64 = 5;
+
+    let mut last_err: Option<std::io::Error> = None;
+    for attempt in 0..MAX_ATTEMPTS {
+        match build().spawn() {
+            Ok(child) => return Ok(child),
+            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
+                last_err = Some(e);
+                // Exponential backoff: 5ms, 10ms, 20ms for MAX_ATTEMPTS=3.
+                // `attempt` is bounded by MAX_ATTEMPTS, so the shift is far
+                // below u64's 64-bit width. Use an explicit `1u64` shift and a
+                // saturating multiply so this stays overflow-safe for any
+                // reasonable MAX_ATTEMPTS value if it is ever raised.
+                let backoff_ms = BACKOFF_MS.saturating_mul(1u64 << attempt);
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    // Unreachable in practice: the loop only falls through after recording an
+    // ETXTBSY error, so `last_err` is always `Some`. Construct a defensive
+    // fallback rather than panicking.
+    Err(last_err.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::ExecutableFileBusy,
+            "spawn retries exhausted",
+        )
+    }))
 }
 
 /// Why a process-exit wait and an unhealthy-signal wait produce different

--- a/crates/trusty-common/src/embedder_client/supervisor.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor.rs
@@ -54,10 +54,10 @@ use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use tokio::process::{Child, Command};
+use tokio::process::Child;
 use tokio::sync::{RwLock, watch};
 
-use super::{EmbedderClient, StdioEmbedderClient};
+use super::{EmbedderClient, StdioEmbedderClient, spawn_retry};
 
 // ── Config ──────────────────────────────────────────────────────────────────
 
@@ -473,18 +473,14 @@ impl SupervisorHandle {
 ///
 /// Why: extracted so both the initial spawn and the respawn path call the same
 /// code.
-/// What: `Command::new(binary_path).arg("--stdio")` with piped stdin/stdout
-/// and inherited stderr. When `config.sidecar_batch_size` is `Some(n)`, sets
-/// `TRUSTY_EMBED_BATCH_SIZE=n` (issue #747 Fix C).
+/// What: delegates command construction and the bounded ETXTBSY retry (#3570)
+/// to `spawn_retry::spawn_embedderd`, then runs the startup probe.
 /// Test: called by `spawn_stdio` and the supervision loop.
 async fn spawn_child(
     binary_path: &Path,
     config: &SupervisorConfig,
 ) -> Result<(Child, StdioEmbedderClient)> {
-    use std::process::Stdio;
-
-    // Forward resolved ONNX batch size (issue #747 Fix C). Logged once here
-    // (rather than inside `build_cmd`) so a retry doesn't repeat the log line.
+    // Forward resolved ONNX batch size (issue #747 Fix C).
     if let Some(bs) = config.sidecar_batch_size {
         tracing::debug!(
             bs,
@@ -492,29 +488,16 @@ async fn spawn_child(
         );
     }
 
-    // Build the command inside a closure so the ETXTBSY retry wrapper can
-    // reconstruct it on each attempt (`Command` is not `Clone`). See
-    // `spawn_with_etxtbsy_retry` for why the retry exists (#3570 / #1634).
-    let build_cmd = || {
-        let mut cmd = Command::new(binary_path);
-        cmd.arg("--stdio")
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .kill_on_drop(true);
-
-        if let Some(bs) = config.sidecar_batch_size {
-            cmd.env("TRUSTY_EMBED_BATCH_SIZE", bs.to_string());
-        }
-        cmd
-    };
-
-    let mut child = spawn_with_etxtbsy_retry(build_cmd).await.with_context(|| {
-        format!(
-            "spawn trusty-embedderd --stdio from {}",
-            binary_path.display()
-        )
-    })?;
+    // Command construction + the bounded ETXTBSY retry (#3570 / #1634) both
+    // live in `spawn_retry` to keep this file under the 500-SLOC prod cap.
+    let mut child = spawn_retry::spawn_embedderd(binary_path, config)
+        .await
+        .with_context(|| {
+            format!(
+                "spawn trusty-embedderd --stdio from {}",
+                binary_path.display()
+            )
+        })?;
 
     let stdin = child
         .stdin
@@ -563,59 +546,6 @@ async fn spawn_child(
     }
 
     Ok((child, client))
-}
-
-/// Spawn a freshly-built `Command`, retrying on ETXTBSY (os error 26).
-///
-/// Why: `execve` can fail with `ETXTBSY` ("Text file busy") when the kernel
-/// still considers the target inode open-for-write — e.g. when a just-written,
-/// just-chmod'd mock `trusty-embedderd` script is exec'd before the page-cache
-/// flush settles. This is the same race class already diagnosed and fixed in
-/// `trusty-agents` under #866, #1528, and #1634 (see
-/// `spawn_with_etxtbsy_retry` in `claude_code_runner/mod.rs`); this transplants
-/// that exact bounded-retry shape rather than inventing a new one, so the
-/// regression test `supervisor_dropped_handle_does_not_busy_spin` (#3570) — and
-/// the real sidecar spawn path — stop hitting the transient kernel state.
-/// What: calls `build()` to obtain a fresh `Command` on each attempt (required
-/// because `Command` is not `Clone`) and `.spawn()`s it. On `ETXTBSY` it backs
-/// off with a short exponential delay (≤3 attempts, 5 ms base) and retries; any
-/// other error, or the success path, returns immediately. The bound keeps real
-/// failures (missing binary, permission denied) from being masked or delayed.
-/// Test: `supervisor_dropped_handle_does_not_busy_spin`,
-/// `supervisor_spawns_mock_child_and_embeds`.
-async fn spawn_with_etxtbsy_retry<F>(mut build: F) -> std::io::Result<Child>
-where
-    F: FnMut() -> Command,
-{
-    const MAX_ATTEMPTS: u32 = 3;
-    const BACKOFF_MS: u64 = 5;
-
-    let mut last_err: Option<std::io::Error> = None;
-    for attempt in 0..MAX_ATTEMPTS {
-        match build().spawn() {
-            Ok(child) => return Ok(child),
-            Err(e) if e.kind() == std::io::ErrorKind::ExecutableFileBusy => {
-                last_err = Some(e);
-                // Exponential backoff: 5ms, 10ms, 20ms for MAX_ATTEMPTS=3.
-                // `attempt` is bounded by MAX_ATTEMPTS, so the shift is far
-                // below u64's 64-bit width. Use an explicit `1u64` shift and a
-                // saturating multiply so this stays overflow-safe for any
-                // reasonable MAX_ATTEMPTS value if it is ever raised.
-                let backoff_ms = BACKOFF_MS.saturating_mul(1u64 << attempt);
-                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-            }
-            Err(e) => return Err(e),
-        }
-    }
-    // Unreachable in practice: the loop only falls through after recording an
-    // ETXTBSY error, so `last_err` is always `Some`. Construct a defensive
-    // fallback rather than panicking.
-    Err(last_err.unwrap_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::ExecutableFileBusy,
-            "spawn retries exhausted",
-        )
-    }))
 }
 
 /// Why a process-exit wait and an unhealthy-signal wait produce different


### PR DESCRIPTION
## Summary

- `spawn_child` (used by both `EmbedderSupervisor::spawn_stdio` and the supervision loop's respawn path) had no ETXTBSY retry, so a freshly written and chmod'd mock `trusty-embedderd` script could occasionally fail to exec under concurrent `cargo test` load ("Text file busy", os error 26), flaking `supervisor_dropped_handle_does_not_busy_spin`.
- This is the same fork/exec race already diagnosed and fixed in `trusty-agents` under #866, #1528, and #1634. This PR transplants that exact bounded-retry shape (`spawn_with_etxtbsy_retry`: ≤3 attempts, 5ms base exponential backoff, retry only on `ErrorKind::ExecutableFileBusy`) from `trusty-agents/src/agents/claude_code_runner/mod.rs` onto `trusty-common`'s `spawn_child`, rather than inventing a new pattern — keeping the fourth occurrence of this bug class consistent with the prior three.
- The command is now built via a closure (`Command` isn't `Clone`) so the retry wrapper can reconstruct a fresh `Command` on each attempt, matching the `run.rs` `build_cmd` pattern from #1634.

## Why this shape, not something else

Three prior fixes (#866, #1528, #1634) converged on the same bounded-retry shape in `trusty-agents`. I read #1634's implementation (`spawn_with_etxtbsy_retry` in `claude_code_runner/mod.rs`) and transplanted it verbatim (same bound, same backoff, same error-kind check) rather than designing something new, since a fourth divergent approach would make the codebase harder to reason about. I did not find a reason to deviate.

## Other spawn sites checked (not touched — different modules, out of scope)

Grepped `trusty-common` for other `.spawn()` call sites. Found several in unrelated modules that were NOT touched (different module, not a trivial identical fix, and out of scope per the task):
- `crates/trusty-common/src/daemon_guard.rs:146`
- `crates/trusty-common/src/mcp/daemon_bridge.rs:218`
- `crates/trusty-common/src/stdio_mcp_client/client.rs:82,140`
- `crates/trusty-common/src/rpc/transport/stdio.rs:58`

These may have the same theoretical gap but are a different call path with different callers/tests; flagging for a follow-up issue rather than sweeping them into this PR.

## Reproduction

This is a kernel-level fork/exec race (ETXTBSY), historically observed on Linux CI. I attempted to reproduce it locally on macOS (Darwin/APFS):

- Pre-fix: ran the target test 40 times sequentially, then 240 times across 16 parallel streams (280 total) — zero failures.
- I also directly verified that macOS does not reproduce the underlying kernel condition at all: opening a script for write and holding the fd open while exec'ing it (the core mechanism behind ETXTBSY on Linux) exits 0 with no busy error on this platform. This explains the non-repro and means local run counts here are not strong evidence either way for the race itself — the platform doesn't exhibit the failure mode this fixes.
- Post-fix: same 240-run stress (16 parallel × 15 iterations) — zero failures (no regression). Full `trusty-common` lib suite: 1393 passed, 0 failed (includes the target test). Full `cargo test --workspace` (excluding GUI crates): only one failure, the known pre-existing unrelated `trusty-search::service::colocated_storage::tests::gitignore_entry_added_idempotently` flake called out in the task brief.

**Honest confidence statement**: I cannot claim this definitively fixes the race, since I could not reproduce it on this dev machine (the mechanism appears Linux-specific and didn't trigger locally even under load). Confidence rests on: (1) the mechanism is well-established and previously fixed identically three times in this exact repo, (2) the transplanted fix is a faithful, minimal, direct copy of the previously-validated #1634 pattern applied to the same shape of bug, (3) it introduces no behavior change on the success path and only adds bounded, capped retry on the specific `ExecutableFileBusy` error kind. This should be monitored on the next few CI runs of this test for confirmation rather than treated as proven.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — clean
- [x] `cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` — only the known unrelated `trusty-search` flake failed
- [x] `cargo test -p trusty-common --features embedder-client,embedder-bundled-ort --lib` — 1393 passed, 0 failed
- [ ] `gh pr checks` after opening, to catch CI-only gates (file-size cap, doc-pointer lint, SLD lint) with no local equivalent

Closes #3570

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools