### PR TITLE
fix(docs): remove stray </content> and leaked </invoke> tool-call artifacts

### DIFF
--- a/docs/design/UI/design-system-svelte/src/styles/tokens.css
+++ b/docs/design/UI/design-system-svelte/src/styles/tokens.css
@@ -72,8 +72,6 @@
   --trusty-space-5: 24px;
   --trusty-space-6: 32px;
 }
-</content>
-
 
 /*
  * Dark theme — "NIGHT SHIFT". Activate with <html data-theme="dark"> or the

--- a/docs/design/UI/design-system/tokens.css
+++ b/docs/design/UI/design-system/tokens.css
@@ -72,8 +72,6 @@
   --trusty-space-5: 24px;
   --trusty-space-6: 32px;
 }
-</content>
-
 
 /*
  * Dark theme — "NIGHT SHIFT". Activate with <html data-theme="dark"> or the

--- a/docs/design/archive/gui-v1/tokens.css
+++ b/docs/design/archive/gui-v1/tokens.css
@@ -72,8 +72,6 @@
   --trusty-space-5: 24px;
   --trusty-space-6: 32px;
 }
-</content>
-
 
 /*
  * Dark theme — "NIGHT SHIFT". Activate with <html data-theme="dark"> or the

--- a/docs/specs/sessions-tui-interactive.md
+++ b/docs/specs/sessions-tui-interactive.md
@@ -662,5 +662,3 @@ surfacing for the statusline.
   inference + `summarizing` signal; daemon-persisted daily cost; managed-API
   delivery; fixed `user` palace). Work-items STUI-0…STUI-10 mapped to epic #1272
   and children #1275–#1279.
-</content>
-</invoke>

--- a/docs/specs/telui-telegram-ui.md
+++ b/docs/specs/telui-telegram-ui.md
@@ -280,5 +280,3 @@ TELUI-11 (hardening + tests) lands last, over TELUI-0…10.
 - Issues: **#1272** (SM TUI epic / feature parent), **#1275** (daemon `last_summary` +
   `summarizing`, DONE), **#1399** (cost-daily endpoint, STUI-2), **#1402** (per-adapter
   termination sequence, STUI-7).
-</content>
-</invoke>


### PR DESCRIPTION
## Summary
- Removes the stray `</content>` artifact reported in #3499 at `docs/design/UI/design-system/tokens.css:75` — a leftover copy/paste or generation glitch sitting right after the `:root` block's closing brace, between two unrelated CSS rule blocks.
- A repo-wide sweep for the same artifact pattern (per the issue's instruction to check for siblings) turned up **four more instances** beyond the one reported. All five are fixed in this PR:
  1. `docs/design/UI/design-system/tokens.css:75` — the reported instance.
  2. `docs/design/UI/design-system-svelte/src/styles/tokens.css:75` — identical `</content>` artifact at the identical line number.
  3. `docs/design/archive/gui-v1/tokens.css:75` — identical `</content>` artifact at the identical line number.
  4. `docs/specs/sessions-tui-interactive.md` — trailing `</content>` + `</invoke>` leaked tool-call fragment at EOF (not just a stray closing tag — a full leaked `<invoke>`-block ending, presumably from a Write tool call whose output landed in the file itself).
  5. `docs/specs/telui-telegram-ui.md` — the same trailing `</content>` + `</invoke>` leaked fragment at EOF.
- `git log --follow` confirms the artifact has been present since the tokens.css file's introduction (commit `3e25f6bc`, "docs(design): land Foundry v1 design system for trusty-* UIs (#3170)") — it was never a regression, it shipped in the original commit.
- No reformatting, reordering, or unrelated style changes — each fix is a pure deletion of the artifact line(s) (plus one redundant blank line left behind by the same paste, to match the single-blank-line convention used consistently elsewhere in these files).

## Does the token-drift job cover this?
No — worth stating plainly so nobody assumes it does. `.github/workflows/token-drift.yml` runs `scripts/check_token_drift.mjs`, which parses `:root { ... }` and the dark-theme block out of the canonical `docs/design/UI/design-system/tokens.css` via the block-scoped regex `:root\s*\{([\s\S]*?)\n\}`. That regex is non-greedy and stops at the **first** `\n}` — i.e., the `:root` block's own closing brace — so the `</content>` artifact on the very next line sat entirely **outside** the parsed block. The checker never saw it. I confirmed this both by reasoning through the regex and empirically: ran `node --test scripts/check_token_drift.test.mjs` (11/11 pass) and `node scripts/check_token_drift.mjs` (all 7 enforced UI crates match canonical, 0 drift) both before and after this fix — identical clean result either way. This is a real blind spot in the existing gate for this class of artifact, not something this PR needed to work around.

## Open question — is there any lint that would catch leaked generation artifacts in `docs/`?
No. Checked the repo's other doc/text lints and none are positioned to catch this:
- `scripts/check_line_cap.sh` — line-length allowlist enforcement only.
- `scripts/check_test_pointers.sh` — validates Rust doc-comment `Test:` pointers against real `fn`/`mod` names; irrelevant to prose/CSS.
- `scripts/check_sld.sh` — Spec-Linked Documentation (DOC-38) grammar checks (Why/What/Test + Spec-References), not content sanity.
- `token-drift.yml` — value-parity only, and as above, blind to anything outside its matched blocks.

Two spec docs shipped with raw `</content></invoke>` tool-call syntax at EOF and nothing in CI flagged it. That's a real gap and likely worth its own issue — a cheap regex-based grep lint (e.g. `</content>`, `</invoke>`, `<invoke name=`, `<parameter name=` as bare lines) over `docs/**/*.md` and `docs/**/*.css` would have caught all five instances fixed here. Not fixed in this PR — out of scope per the issue's trivial-cleanup framing.

## Test plan
- [x] Confirmed artifact is spurious via `git log --follow -p` (present since introduction, sits outside any matched block, breaks no functionality)
- [x] `node --test scripts/check_token_drift.test.mjs` — 11/11 pass
- [x] `node scripts/check_token_drift.mjs` — all 7 enforced UI crates match canonical, 0 drift
- [x] CSS brace-balance sanity check on all three token files post-edit
- [x] `cargo fmt --all -- --check` — clean, no diff
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations
- [x] `bash scripts/check_sld.sh` — OK, 0 errors/warnings
- [x] `bash scripts/check_test_pointers.sh` — OK, 0 dangling pointers (expected: this PR touches zero Rust/doc-comments)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
