### PR TITLE
feat(embedder): swap-back to ort on python sidecar death + CAS bootstrap-state (epic #3524 slice 6, PR 4/5)

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -9,6 +9,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`EmbedderSupervisor::terminated_signal()` (epic #3524 slice 6 PR-4
+  follow-up, code-critic BLOCK on trusty-search PR #3584).** A new
+  `Arc<AtomicBool>` accessor, captured the same way `child_pid_slot` is
+  captured from `spawn_stdio`'s return tuple — before
+  `start_supervisor_task()` consumes `self`. The supervision loop sets it to
+  `true` at the exact instant, and ONLY the instant, it decides to give up
+  permanently (`should_give_up`: exhausted `max_restarts` or a wedge-restart
+  storm) — never on a clean exit, an intentional cooperative `shutdown()`,
+  or an ordinary respawn. Gives callers (trusty-search's swap-back watchdog)
+  a DEFINITIVE "this supervised process is unrecoverably dead" signal instead
+  of inferring it from `child_pid_slot == 0`, which is also `0` during an
+  ordinary intentional shutdown and therefore ambiguous on its own.
+  - Test: `supervisor_terminated_signal_fires_after_exhausting_max_restarts`
+    (a real, always-crashing mock child with `max_restarts: 1`),
+    `supervisor_terminated_signal_stays_false_on_intentional_shutdown` (a
+    real cooperative `shutdown()` must never set it).
 - **`ExecutionProvider::Mps` + `resolve_expected_python_provider` (epic #3524
   slice 6, PR 2/5, refs #3530, #3493 P1)** — a new `Mps` variant on
   `embedder::ExecutionProvider` for the opt-in Python/MPS embedding sidecar

--- a/crates/trusty-common/src/embedder_client/supervisor.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor.rs
@@ -110,6 +110,14 @@ pub struct EmbedderSupervisor {
     /// `child.wait()` and re-fetches a fresh receiver from each respawned
     /// client (see `StdioEmbedderClient::unhealthy_signal`).
     unhealthy_signal: watch::Receiver<bool>,
+    /// Definitive "gave up permanently" flag (epic #3524 slice 6 PR-4
+    /// follow-up, code-critic BLOCK on PR #3584). `false` for the entire
+    /// supervised lifetime except the one instant `supervision_loop` decides
+    /// `should_give_up` and is about to `return` without respawning — never
+    /// set on a clean exit, an intentional `shutdown()`, or any ordinary
+    /// respawn. See [`Self::terminated_signal`] for why callers need this
+    /// distinct from `child_pid_slot` reading `0`.
+    terminated: Arc<std::sync::atomic::AtomicBool>,
     config: SupervisorConfig,
 }
 
@@ -159,10 +167,40 @@ impl EmbedderSupervisor {
             client_slot,
             child_pid_slot,
             unhealthy_signal,
+            terminated: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             config,
         };
 
         Ok((supervisor, client_slot_clone, child_pid_slot_clone))
+    }
+
+    /// Clone the definitive "gave up permanently" signal — must be called
+    /// BEFORE [`Self::start_supervisor_task`] (which consumes `self`), the
+    /// same way callers capture `child_pid_slot` from `spawn_stdio`'s return
+    /// tuple before detaching.
+    ///
+    /// Why (epic #3524 slice 6 PR-4 follow-up, code-critic BLOCK on PR
+    /// #3584): the swap-back watchdog originally inferred "the python sidecar
+    /// is unrecoverably dead" from `child_pid_slot == 0` combined with
+    /// `EmbedderStallTracker::recent_timeout_count() > 0`. That heuristic has
+    /// a real false-positive window: an ordinary idle-shutdown ALSO zeroes
+    /// the pid slot, and a stale non-zero timeout count left over from an
+    /// earlier transient failure is never cleared by the idle-shutdown path
+    /// (only a subsequent SUCCESSFUL embed clears it) — so a quiet period
+    /// with zero further embed traffic after an idle-shutdown could
+    /// satisfy the heuristic and permanently swap away a perfectly healthy
+    /// backend. This method gives callers the actual, unambiguous signal
+    /// instead: `true` if and only if the supervision loop itself decided to
+    /// give up (exhausted `max_restarts` or a wedge-restart storm) — never
+    /// true for a clean exit, an intentional `shutdown()`, or an ordinary
+    /// respawn.
+    /// What: clones and returns the `Arc<AtomicBool>` `supervision_loop` sets
+    /// to `true` at the exact instant it decides `should_give_up` and returns
+    /// without respawning.
+    /// Test: `supervisor_terminated_signal_fires_after_exhausting_max_restarts`,
+    /// `supervisor_terminated_signal_stays_false_on_intentional_shutdown`.
+    pub fn terminated_signal(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        Arc::clone(&self.terminated)
     }
 
     /// Detach the supervisor background task.
@@ -203,6 +241,7 @@ impl EmbedderSupervisor {
             self.client_slot,
             self.child_pid_slot,
             self.unhealthy_signal,
+            self.terminated,
             self.config,
             shutdown_rx,
             gave_up_tx,
@@ -531,9 +570,10 @@ pub(crate) static SUPERVISION_LOOP_ITERATIONS: std::sync::atomic::AtomicU64 =
 // Each parameter is a distinct piece of shared state this internal (private,
 // not part of any public API) orchestration loop threads through — spawn
 // target, live child/client slots, the two independent signal channels
-// (unhealthy, shutdown) plus the new one-way give-up signal (PR #3560 HIGH
-// fix), and config. Bundling them into a struct would not reduce complexity,
-// only relocate it.
+// (unhealthy, shutdown), the one-way give-up signal (PR #3560 HIGH fix), the
+// definitive terminated signal (epic #3524 slice 6 PR-4 follow-up, code-critic
+// BLOCK on PR #3584), and config. Bundling them into a struct would not reduce
+// complexity, only relocate it.
 #[allow(clippy::too_many_arguments)]
 async fn supervision_loop(
     binary_path: PathBuf,
@@ -541,6 +581,7 @@ async fn supervision_loop(
     client_slot: Arc<RwLock<Arc<dyn EmbedderClient>>>,
     child_pid_slot: Arc<AtomicU32>,
     mut unhealthy_signal: watch::Receiver<bool>,
+    terminated: Arc<std::sync::atomic::AtomicBool>,
     config: SupervisorConfig,
     mut shutdown_rx: watch::Receiver<bool>,
     gave_up_tx: watch::Sender<bool>,
@@ -736,6 +777,12 @@ async fn supervision_loop(
             // the REAL give-up ceiling instead of an independently-counted
             // proxy. `send` on a channel with no live receiver is harmless.
             let _ = gave_up_tx.send(true);
+            // The definitive "gave up permanently" signal (epic #3524 slice 6
+            // PR-4 follow-up) — set ONLY on this exact path, never on a clean
+            // exit or an intentional shutdown. See `terminated_signal`'s doc
+            // for why callers need this instead of inferring death from
+            // `child_pid_slot == 0` alone.
+            terminated.store(true, AtomicOrdering::Release);
             return;
         }
 

--- a/crates/trusty-common/src/embedder_client/supervisor_tests.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor_tests.rs
@@ -812,4 +812,100 @@ exit 1
              persistent crash loop with max_restarts=1"
         );
     }
+
+    /// The definitive death signal (epic #3524 slice 6 PR-4 follow-up,
+    /// code-critic BLOCK on PR #3584) must flip to `true` when the supervisor
+    /// actually exhausts `max_restarts` — never respawning again.
+    ///
+    /// Why: this is the regression the swap-back watchdog now depends on
+    /// instead of the ambiguous `pid==0` + stall-tracker heuristic that could
+    /// false-trigger against a healthy sidecar recovering from an ordinary
+    /// idle-shutdown (see `trusty-search`'s `swap_back_watchdog` module doc
+    /// for the full false-positive analysis this signal replaces).
+    /// What: a mock child that always crashes after answering exactly one
+    /// startup probe (`write_mock_embedderd_crash_once`), `max_restarts: 1`
+    /// so exhaustion is fast, `backoff_max_secs: 1` to keep the test itself
+    /// fast. Captures `terminated_signal()` BEFORE detaching (must happen
+    /// before `start_supervisor_task` consumes `self`), then polls it until
+    /// `true` or a generous timeout.
+    /// Test: this test.
+    #[tokio::test]
+    async fn supervisor_terminated_signal_fires_after_exhausting_max_restarts() {
+        let (_dir, binary) = write_mock_embedderd_crash_once();
+        let cfg = SupervisorConfig {
+            startup_timeout_secs: 5,
+            backoff_max_secs: 1,
+            max_restarts: 1,
+            ..SupervisorConfig::default()
+        };
+        let (supervisor, _client_slot, pid_slot) = EmbedderSupervisor::spawn_stdio(binary, cfg)
+            .await
+            .expect("spawn_stdio failed");
+        let initial_pid = pid_slot.load(Ordering::Acquire);
+        assert!(initial_pid > 0, "pid_slot must be populated after spawn");
+
+        // Must capture this BEFORE start_supervisor_task consumes `supervisor`.
+        let terminated = supervisor.terminated_signal();
+        assert!(
+            !terminated.load(Ordering::Acquire),
+            "must start false — nothing has failed yet"
+        );
+
+        let _handle = supervisor.start_supervisor_task();
+
+        let gave_up = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if terminated.load(Ordering::Acquire) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(
+            gave_up.is_ok(),
+            "terminated_signal never flipped true within 10s of exhausting \
+             max_restarts=1 against an always-crashing mock child"
+        );
+        assert_eq!(
+            pid_slot.load(Ordering::Acquire),
+            0,
+            "pid_slot must also be 0 once the supervisor has given up"
+        );
+    }
+
+    /// The definitive death signal must NEVER flip true on an intentional,
+    /// cooperative `shutdown()` — only on genuine restart exhaustion.
+    ///
+    /// Why: this is the other half of the regression guard — a watchdog
+    /// gating on `terminated_signal()` must not fire just because the daemon
+    /// (or the idle-shutdown watchdog) deliberately stopped a perfectly
+    /// healthy sidecar.
+    /// What: a long-lived mock child, shut down cooperatively via
+    /// `SupervisorHandle::shutdown()`, asserts `terminated_signal()` stays
+    /// `false` throughout and after.
+    /// Test: this test.
+    #[tokio::test]
+    async fn supervisor_terminated_signal_stays_false_on_intentional_shutdown() {
+        let (_dir, binary) = write_mock_embedderd();
+        let cfg = SupervisorConfig {
+            startup_timeout_secs: 5,
+            ..SupervisorConfig::default()
+        };
+        let (supervisor, _client_slot, pid_slot) = EmbedderSupervisor::spawn_stdio(binary, cfg)
+            .await
+            .expect("spawn_stdio failed");
+        assert!(pid_slot.load(Ordering::Acquire) > 0);
+
+        let terminated = supervisor.terminated_signal();
+        let handle = supervisor.start_supervisor_task();
+
+        handle.shutdown().await;
+
+        assert!(
+            !terminated.load(Ordering::Acquire),
+            "an intentional cooperative shutdown must never set terminated_signal"
+        );
+        assert_eq!(pid_slot.load(Ordering::Acquire), 0);
+    }
 }

--- a/crates/trusty-common/src/embedder_client/supervisor_tests.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor_tests.rs
@@ -796,7 +796,11 @@ exit 1
              supervisor has not even observed the first crash yet"
         );
 
-        let gave_up = tokio::time::timeout(Duration::from_secs(10), async {
+        // Generous ceiling (45s) so a loaded CI runner cannot false-fail —
+        // the poll interval is short (10ms) so a passing run still returns
+        // in milliseconds; only a genuinely stuck supervisor eats the full
+        // budget.
+        let gave_up = tokio::time::timeout(Duration::from_secs(45), async {
             loop {
                 if handle.has_given_up() {
                     return;
@@ -808,7 +812,7 @@ exit 1
 
         assert!(
             gave_up.is_ok(),
-            "has_given_up() never flipped to true within 10s of a \
+            "has_given_up() never flipped to true within 45s of a \
              persistent crash loop with max_restarts=1"
         );
     }
@@ -834,7 +838,10 @@ exit 1
         let (_dir, binary) = write_mock_embedderd_crash_once();
         let cfg = SupervisorConfig {
             startup_timeout_secs: 5,
-            backoff_max_secs: 1,
+            // Zero backoff so the crash -> respawn -> exhaustion sequence
+            // completes as fast as possible; this test asserts on the
+            // give-up signal, not on backoff timing.
+            backoff_max_secs: 0,
             max_restarts: 1,
             ..SupervisorConfig::default()
         };
@@ -853,7 +860,11 @@ exit 1
 
         let _handle = supervisor.start_supervisor_task();
 
-        let gave_up = tokio::time::timeout(Duration::from_secs(10), async {
+        // Generous ceiling (45s) so a loaded CI runner cannot false-fail —
+        // the poll interval is short (10ms) so a passing run still returns
+        // in milliseconds; only a genuinely stuck supervisor eats the full
+        // budget.
+        let gave_up = tokio::time::timeout(Duration::from_secs(45), async {
             loop {
                 if terminated.load(Ordering::Acquire) {
                     return;
@@ -864,7 +875,7 @@ exit 1
         .await;
         assert!(
             gave_up.is_ok(),
-            "terminated_signal never flipped true within 10s of exhausting \
+            "terminated_signal never flipped true within 45s of exhausting \
              max_restarts=1 against an always-crashing mock child"
         );
         assert_eq!(

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -18,18 +18,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `EmbedderStallTracker`, and swaps `SwitchableEmbedder` back to a fresh ort
   backend if the python sidecar is ever confirmed dead beyond recovery —
   search never degrades permanently, with no daemon restart required.
-  - **The swap-back predicate is deliberately conservative**: it fires only
-    when the active backend is python, its pid slot reads `0` (no live
-    child), AND at least one embed attempt has failed since the last success
-    (`EmbedderStallTracker::recent_timeout_count() > 0`), confirmed across 2
-    consecutive polling ticks (15s apart). Bare pid-zero is NOT the trigger —
-    it also occurs on ordinary idle-shutdown (`LazyEmbedderHandle`'s own idle
-    watchdog), whose respawn resets `recent_timeout_count` to `0` on its next
-    successful embed, keeping the predicate false. Only a genuinely dead
-    sidecar (the underlying `EmbedderSupervisor` exhausted
-    `TRUSTY_EMBEDDERD_MAX_RESTARTS`) keeps failing every subsequent embed
-    attempt, since `LazyEmbedderHandle`'s own spawn gate is never reset in
-    that case.
+  - **The swap-back predicate uses a DEFINITIVE supervisor signal, not a
+    heuristic (post-merge-review fix — code-critic BLOCK on PR #3584).** The
+    first version of this predicate fired on `active.kind == Python &&
+    pid_slot == 0 && recent_timeout_count > 0`, debounced across 2 polling
+    ticks. Code-critic caught a real false-positive window before merge: an
+    ordinary idle-shutdown ALSO zeros the pid slot, and a stale non-zero
+    `recent_timeout_count` left over from an earlier TRANSIENT failure is
+    never cleared by idle-shutdown (only a subsequent successful embed clears
+    it) — so a quiet period with zero further embed traffic after an
+    idle-shutdown could satisfy the heuristic and PERMANENTLY swap away a
+    perfectly healthy sidecar. Fixed by adding
+    `trusty-common`'s new `EmbedderSupervisor::terminated_signal()` (see that
+    crate's changelog) — an `Arc<AtomicBool>` the supervision loop sets ONLY
+    at the instant it exhausts `max_restarts` / a wedge-restart storm, never
+    on a clean exit or an intentional shutdown. `LazyEmbedderHandle::is_confirmed_terminated()`
+    exposes this (via the extended `PythonAdapterTeardown` trait), and the
+    predicate is now simply `active.kind == Python &&
+    is_confirmed_terminated()` — no debounce needed, since the flag is
+    monotonic and unambiguous the instant it's observed. The regression test
+    `swap_back_does_not_fire_on_stale_timeout_count_plus_idle_shutdown`
+    reproduces the exact scenario code-critic named and fails against the
+    pre-fix heuristic.
   - On confirmed death: builds a fresh ort backend via the same
     `build_ort_stdio_sidecar()` the daemon's default path uses, hot-swaps
     `SwitchableEmbedder` to it (`ActiveBackend { kind: Ort, bootstrap:

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -9,6 +9,52 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Swap-BACK watchdog: python/MPS → ort on confirmed sidecar death (epic
+  #3524 slice 6, PR 4/5) — ships DEFAULT OFF (unchanged behind
+  `TRUSTY_PY_DEFAULT`).** PR-3 hot-swaps ort→python once the sidecar proves
+  itself, then stops watching. This PR adds the other half: once hot-swapped,
+  a new detached watchdog task (`commands/start/swap_back_watchdog.rs`)
+  watches the python sidecar's pid slot and the existing
+  `EmbedderStallTracker`, and swaps `SwitchableEmbedder` back to a fresh ort
+  backend if the python sidecar is ever confirmed dead beyond recovery —
+  search never degrades permanently, with no daemon restart required.
+  - **The swap-back predicate is deliberately conservative**: it fires only
+    when the active backend is python, its pid slot reads `0` (no live
+    child), AND at least one embed attempt has failed since the last success
+    (`EmbedderStallTracker::recent_timeout_count() > 0`), confirmed across 2
+    consecutive polling ticks (15s apart). Bare pid-zero is NOT the trigger —
+    it also occurs on ordinary idle-shutdown (`LazyEmbedderHandle`'s own idle
+    watchdog), whose respawn resets `recent_timeout_count` to `0` on its next
+    successful embed, keeping the predicate false. Only a genuinely dead
+    sidecar (the underlying `EmbedderSupervisor` exhausted
+    `TRUSTY_EMBEDDERD_MAX_RESTARTS`) keeps failing every subsequent embed
+    attempt, since `LazyEmbedderHandle`'s own spawn gate is never reset in
+    that case.
+  - On confirmed death: builds a fresh ort backend via the same
+    `build_ort_stdio_sidecar()` the daemon's default path uses, hot-swaps
+    `SwitchableEmbedder` to it (`ActiveBackend { kind: Ort, bootstrap:
+    FellBackToOrt }`), reinstalls the ort pid slot, and cleanly shuts down the
+    dead python handle via `LazyEmbedderHandle::shutdown()` (no orphan). Logs
+    a loud `warn`: "python/MPS sidecar unrecoverable — fell back to ort;
+    search unaffected". `/health`'s `embedder_bootstrap` already reports
+    `"fell_back_to_ort"` for this state (wired in PR-2/PR-3).
+  - **CAS upgrade (code-critic LOW follow-up from PR-3 review)**:
+    `SwitchableEmbedder::set_bootstrap_state` was a non-atomic
+    read-modify-write on `active`, safe only because PR-3's orchestrator was
+    the sole writer. PR-4 introduces a second writer (the watchdog's own
+    `swap_to`), so `set_bootstrap_state` now uses `ArcSwap::rcu` — a real
+    compare-and-swap retry loop — so a concurrent `swap_to` and
+    `set_bootstrap_state` can never lose either side's update.
+  - Bounded and quiet: polls every 15s (not a tight loop), and stops
+    permanently once it either acts (swaps back) or notices the active
+    backend already moved away from python — never watches a backend it no
+    longer owns.
+  - New file: `commands/start/swap_back_watchdog.rs`. `drive_bootstrap`
+    (`graceful_bootstrap.rs`) now returns the python adapter's teardown
+    handle on success so `run_graceful_python_bootstrap` can hand it to the
+    watchdog — a pure return-type addition; no existing call site needed to
+    change.
+
 - **Graceful Apple-Silicon default gating + background bootstrap→hot-swap
   orchestrator (epic #3524 slice 6, PR 3/5) — ships DEFAULT OFF.** On Apple
   Silicon, once `TRUSTY_PY_DEFAULT` is enabled, `trusty-search start` now

--- a/crates/trusty-search/src/commands/start/embedder.rs
+++ b/crates/trusty-search/src/commands/start/embedder.rs
@@ -573,12 +573,17 @@ pub(super) fn resolve_python_idle_shutdown_secs(
 /// (`lazy_adapter_reports_resolved_provider`).
 /// The pair every embedder-construction path returns: the `Arc<dyn Embedder>`
 /// plus the optional sidecar PID slot (`Some` only for stdio-sidecar paths).
-type BuiltEmbedder = (
+pub(super) type BuiltEmbedder = (
     std::sync::Arc<dyn crate::core::Embedder>,
     Option<Arc<AtomicU32>>,
 );
 
-fn build_ort_stdio_sidecar() -> Result<BuiltEmbedder> {
+/// `pub(super)` (epic #3524 slice 6, PR 4/5): the swap-back watchdog
+/// (`start::swap_back_watchdog`) reuses this exact construction on confirmed
+/// python-sidecar death — a fresh ort backend must be built exactly the same
+/// way the daemon's normal default/fallback paths build it, so there is only
+/// ever one code path that knows how to stand up the ort stdio sidecar.
+pub(super) fn build_ort_stdio_sidecar() -> Result<BuiltEmbedder> {
     use crate::service::embedder_supervisor::{
         locate_embedderd_binary, LazyEmbedderHandle, SupervisorConfig,
     };

--- a/crates/trusty-search/src/commands/start/embedder_fallback.rs
+++ b/crates/trusty-search/src/commands/start/embedder_fallback.rs
@@ -718,7 +718,7 @@ exit 1
         // `consecutive_failures` crosses `max_restarts=1` after exactly two
         // detected crash-cycles, typically in low single-digit milliseconds
         // (two process spawn/exec cycles, no backoff since
-        // `backoff_max_secs: 0`). The 10s bound below is pure headroom for
+        // `backoff_max_secs: 0`). The 45s bound below is pure headroom for
         // real `fork`+`exec` scheduling variance under host contention — not
         // part of the mechanism that makes this test pass. Measured
         // locally: 130+ consecutive runs at a 5s bound had exactly one
@@ -727,12 +727,14 @@ exit 1
         // failing to escalate — i.e. the residual variance is real OS
         // scheduling noise, not the same non-deterministic "coin flip" the
         // old mock design had (where the counter could fail to escalate at
-        // all, for arbitrarily long). Widening this bound is therefore
-        // headroom for that noise, not a re-run of the original mistake of
-        // trading a hard failure for a slower flake. This is still a
+        // all, for arbitrarily long). The bound was widened from 10s to 45s
+        // (matching the sibling fixed-ceiling flakes in this same family —
+        // epic #3524 slice 6) to give a CI-loaded runner a safe margin; this
+        // is headroom for that noise, not a re-run of the original mistake
+        // of trading a hard failure for a slower flake. This is still a
         // condition-based poll (returns the instant the flag flips), never
         // a fixed sleep.
-        let gave_up = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        let gave_up = tokio::time::timeout(std::time::Duration::from_secs(45), async {
             loop {
                 if handle.supervisor_gave_up() {
                     return;
@@ -744,7 +746,7 @@ exit 1
         .await;
         assert!(
             gave_up.is_ok(),
-            "the real supervisor never reached its give-up ceiling within 10s \
+            "the real supervisor never reached its give-up ceiling within 45s \
              of a persistent crash loop with max_restarts=1 — the deterministic \
              marker-file mock should make this converge in milliseconds"
         );

--- a/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
+++ b/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
@@ -69,18 +69,29 @@ const DEFAULT_BOOTSTRAP_RETRIES: u32 = 2;
 /// This trait is the seam that lets [`try_bootstrap_once`] force an
 /// IMMEDIATE, cooperative kill on every failure path that occurs after a
 /// handle may have spawned, before ever dropping it.
-/// What: one method, `teardown()`, async so the real implementation can
-/// await `SupervisorHandle::shutdown()`'s "confirmed dead" guarantee.
+/// What: `teardown()`, async so the real implementation can await
+/// `SupervisorHandle::shutdown()`'s "confirmed dead" guarantee; plus
+/// `is_confirmed_terminated()` (epic #3524 slice 6 PR-4 follow-up,
+/// code-critic BLOCK on PR #3584) — the DEFINITIVE "this python sidecar's
+/// supervisor gave up permanently" signal the swap-back watchdog gates on,
+/// replacing the earlier ambiguous pid==0 + stall-tracker heuristic. See
+/// `LazyEmbedderHandle::is_confirmed_terminated`'s doc for the full
+/// false-positive analysis that signal fixes.
 /// Test: see the module-level `Test:` pointer.
 #[async_trait::async_trait]
 pub(crate) trait PythonAdapterTeardown: Send + Sync {
     async fn teardown(&self);
+    async fn is_confirmed_terminated(&self) -> bool;
 }
 
 #[async_trait::async_trait]
 impl PythonAdapterTeardown for crate::service::embedder_supervisor::LazyEmbedderHandle {
     async fn teardown(&self) {
         self.shutdown().await;
+    }
+
+    async fn is_confirmed_terminated(&self) -> bool {
+        crate::service::embedder_supervisor::LazyEmbedderHandle::is_confirmed_terminated(self).await
     }
 }
 

--- a/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
+++ b/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
@@ -21,12 +21,13 @@
 //! `TRUSTY_EMBEDDER=python` arm performs
 //! (`embedder::build_eager_python_embedder`).
 //!
-//! This PR implements SWAP-IN ONLY: once hot-swapped to python, this module
-//! is done — it never runs again for the lifetime of the daemon. Detecting a
-//! live python sidecar dying later and swapping back to ort is PR-4's scope;
-//! the seam for that is the same `switchable` handle and the pid-slot /
-//! stall-tracker machinery [`drive_bootstrap`] already wires up on success
-//! (see the `TODO(PR-4)` below).
+//! PR-3 implemented SWAP-IN ONLY. PR-4 (epic #3524 slice 6) adds the other
+//! half: once [`drive_bootstrap`] hot-swaps to python, [`run_graceful_python_bootstrap`]
+//! spawns `start::swap_back_watchdog::run_swap_back_watchdog` — a sibling
+//! detached task that watches the same `switchable` handle and the pid-slot /
+//! stall-tracker machinery this module already wires up on success, and
+//! swaps back to ort if the python sidecar is ever confirmed dead beyond
+//! recovery. See that module's docs for the swap-back predicate.
 //!
 //! Test: `graceful_bootstrap_swaps_to_python_on_success`,
 //! `graceful_bootstrap_stays_ort_and_failed_after_probe_failure`,
@@ -183,15 +184,36 @@ pub(super) fn resolve_bootstrap_retries() -> u32 {
 /// What: constructs the production [`RealPythonBootstrap`] and delegates to
 /// [`drive_bootstrap`]. Never panics — every failure path is caught and
 /// logged; the daemon and the ort backend it is already serving on are
-/// completely unaffected regardless of outcome.
+/// completely unaffected regardless of outcome. On a successful hot-swap
+/// (epic #3524 slice 6, PR 4/5), spawns the swap-back watchdog as a detached
+/// sibling task so a later confirmed death of the python sidecar falls back
+/// to ort without anyone needing to restart the daemon.
 /// Test: `drive_bootstrap` (this function's callee) is what carries the
-/// actual test coverage — this wrapper has no independent branches.
+/// actual test coverage for the bootstrap state machine itself; the
+/// watchdog hand-off has no independent branches worth a dedicated test here
+/// (it is one `if let Some`) — `start::swap_back_watchdog`'s own tests cover
+/// the watchdog's behavior.
 pub(super) async fn run_graceful_python_bootstrap(
     switchable: Arc<SwitchableEmbedder>,
     state: SearchAppState,
 ) {
     let ops: Arc<dyn PythonBootstrap> = Arc::new(RealPythonBootstrap);
-    drive_bootstrap(switchable, state, ops, resolve_bootstrap_retries()).await;
+    if let Some(python_teardown) = drive_bootstrap(
+        Arc::clone(&switchable),
+        state.clone(),
+        ops,
+        resolve_bootstrap_retries(),
+    )
+    .await
+    {
+        let swap_back_ops = super::swap_back_watchdog::real_swap_back_ops();
+        tokio::spawn(super::swap_back_watchdog::run_swap_back_watchdog(
+            switchable,
+            state,
+            python_teardown,
+            swap_back_ops,
+        ));
+    }
 }
 
 /// Drive the ort→python hot-swap state machine: bootstrap the venv, locate
@@ -208,13 +230,14 @@ pub(super) async fn run_graceful_python_bootstrap(
 /// ort backend (`inner`) is never touched, so search keeps serving on ort
 /// exactly as it was before this task ever ran.
 ///
-/// TODO(PR-4): this function currently has no way to notice the python
-/// sidecar dying AFTER a successful hot-swap and fall back to ort. The seam
-/// for that is here: `switchable` and the installed pid slot / the daemon's
-/// existing `embedder_stall_tracker` are already wired up by the time this
-/// function returns `Ok` from a caller's perspective — PR-4 only needs to
-/// add a supervising task that watches those and calls
-/// `switchable.swap_to`/`set_bootstrap_state` again on death.
+/// Returns the python adapter's [`PythonAdapterTeardown`] handle on a
+/// successful hot-swap (epic #3524 slice 6, PR 4/5) — `None` on exhaustion.
+/// [`run_graceful_python_bootstrap`] uses the `Some` case to hand the live
+/// python handle's teardown to the swap-back watchdog, which needs it to
+/// cleanly shut down the dead sidecar once IT confirms death and swaps back
+/// to ort. This is a pure return-type addition: every existing PR-3 test
+/// calls this function without using its return value, so none of them
+/// needed to change.
 ///
 /// Test: `graceful_bootstrap_swaps_to_python_on_success`,
 /// `graceful_bootstrap_stays_ort_and_failed_after_probe_failure`,
@@ -225,15 +248,15 @@ pub(super) async fn drive_bootstrap(
     state: SearchAppState,
     ops: Arc<dyn PythonBootstrap>,
     retries: u32,
-) {
+) -> Option<Arc<dyn PythonAdapterTeardown>> {
     let retries = retries.max(1);
     let mut last_err = None;
 
     for attempt in 1..=retries {
         match try_bootstrap_once(&switchable, &state, &ops).await {
-            Ok(()) => {
+            Ok(python_teardown) => {
                 tracing::info!("embedder hot-swapped ort -> python/MPS (sidecar ready)");
-                return;
+                return Some(python_teardown);
             }
             Err(e) => {
                 tracing::warn!(
@@ -255,15 +278,21 @@ pub(super) async fn drive_bootstrap(
          retry, or set TRUSTY_EMBEDDER=python for the eager blocking path",
         last_err.expect("at least one attempt runs when retries >= 1"),
     );
+    None
 }
 
 /// One bootstrap→probe→swap attempt. See [`drive_bootstrap`] for the retry
-/// loop around this.
+/// loop around this. Returns the newly-installed python adapter's
+/// [`PythonAdapterTeardown`] handle on success (epic #3524 slice 6, PR 4/5)
+/// — the SAME underlying handle just installed into `switchable`, viewed
+/// through the teardown trait so the swap-back watchdog can shut it down
+/// later without needing to downcast the trait object `switchable` now
+/// holds.
 async fn try_bootstrap_once(
     switchable: &SwitchableEmbedder,
     state: &SearchAppState,
     ops: &Arc<dyn PythonBootstrap>,
-) -> Result<()> {
+) -> Result<Arc<dyn PythonAdapterTeardown>> {
     // Step a: blocking venv bootstrap off the async runtime — mirrors the
     // eager `TRUSTY_EMBEDDER=python` arm's `ensure_venv_eager` off-thread call.
     let venv_ops = Arc::clone(ops);
@@ -337,5 +366,5 @@ async fn try_bootstrap_once(
         state.install_embedderd_pid_slot(slot).await;
     }
 
-    Ok(())
+    Ok(teardown)
 }

--- a/crates/trusty-search/src/commands/start/mod.rs
+++ b/crates/trusty-search/src/commands/start/mod.rs
@@ -7,6 +7,10 @@
 //!   - `embedder` — embedder construction and adapter types
 //!     (`build_embedder`, `UdsEmbedderAdapter`, `LazySlotEmbedderAdapter`,
 //!     `tune_batch_size_for_provider`)
+//!   - `graceful_bootstrap` — background ort→python hot-swap orchestrator
+//!     (epic #3524 slice 6, PR 3/5)
+//!   - `swap_back_watchdog` — background python→ort swap-back watchdog on
+//!     confirmed sidecar death (epic #3524 slice 6, PR 4/5)
 //!   - `daemon`   — main boot sequence (`handle_start`)
 //!
 //! What: re-exports `handle_start` (the public CLI entry point) and the
@@ -21,6 +25,7 @@ mod embedder;
 mod embedder_fallback;
 mod graceful_bootstrap;
 mod restore;
+mod swap_back_watchdog;
 
 #[cfg(test)]
 mod tests;

--- a/crates/trusty-search/src/commands/start/swap_back_watchdog.rs
+++ b/crates/trusty-search/src/commands/start/swap_back_watchdog.rs
@@ -1,0 +1,328 @@
+//! Swap-BACK watchdog: python/MPS → ort on confirmed sidecar death (epic
+//! #3524 slice 6, PR 4/5).
+//!
+//! Why: PR-3's background orchestrator (`graceful_bootstrap`) hot-swaps
+//! ort → python once the sidecar proves itself with a real embed call, then
+//! is done — nothing ever watches that python sidecar again. If it later
+//! dies for good (the underlying `EmbedderSupervisor` exhausts
+//! `TRUSTY_EMBEDDERD_MAX_RESTARTS` and gives up), search would silently keep
+//! trying to route through a dead backend forever, with no automatic
+//! recovery short of a full daemon restart. This module is the other half:
+//! once [`run_swap_back_watchdog`] is spawned (by
+//! `graceful_bootstrap::run_graceful_python_bootstrap`, right after a
+//! successful hot-swap), it watches for CONFIRMED death and swaps the
+//! `SwitchableEmbedder` back to a fresh ort backend so search never degrades
+//! permanently.
+//!
+//! ## The false-positive hazard — why "pid == 0" alone is not the trigger
+//!
+//! The python sidecar's pid slot (`SearchAppState::current_embedderd_pid`)
+//! reads `0` (`None`) in TWO completely different situations:
+//!
+//!   1. **Intentional idle-shutdown** — `LazyEmbedderHandle`'s own idle
+//!      watchdog (`embedder_supervisor::idle_watchdog`) killed the child
+//!      after `TRUSTY_EMBEDDERD_PY_IDLE_SHUTDOWN_SECS` of no requests, and
+//!      reset its internal spawn gate. The NEXT embed request transparently
+//!      triggers a fresh spawn and succeeds — this is normal, expected,
+//!      memory-saving behavior, not a failure.
+//!   2. **Genuine, unrecoverable death** — the `EmbedderSupervisor`'s
+//!      crash-restart loop exhausted `TRUSTY_EMBEDDERD_MAX_RESTARTS` and gave
+//!      up. Critically, `LazyEmbedderHandle`'s OWN spawn gate (the
+//!      `state: Arc<Mutex<Option<SpawnedState>>>` cell) is untouched in this
+//!      case — only the idle watchdog or `LazyEmbedderHandle::shutdown()`
+//!      ever clears it. So the handle keeps reusing the same, now-dead
+//!      `client_slot` on every subsequent embed call: every one of those
+//!      calls fails (the underlying stdio pipe is gone), and NONE of them
+//!      trigger a fresh respawn.
+//!
+//! Swapping back to ort on case 1 would be actively wrong — it would
+//! permanently abandon a perfectly healthy python sidecar just because it
+//! happened to be idle for a moment, thrashing the two backends back and
+//! forth. The predicate below is deliberately conservative to tell the two
+//! apart without adding any new signal: it composes the pid slot with
+//! [`EmbedderStallTracker::recent_timeout_count`] (`service/stall_tracker.rs`,
+//! already wired onto every embed call via `EmbedPool`).
+//!
+//! **The predicate**: `active.kind == Python && pid == 0 && recent_timeout_count > 0`,
+//! confirmed across [`CONFIRM_TICKS`] CONSECUTIVE polling ticks before acting.
+//!
+//! Why this composition is safe against case 1 (idle-shutdown): a successful
+//! embed call (the respawn succeeding) calls
+//! `EmbedderStallTracker::record_success`, which unconditionally resets
+//! `recent_timeout_count` to `0` — see `stall_tracker.rs`. So the moment an
+//! idle-shutdown's automatic respawn serves one successful request,
+//! `recent_timeout_count` drops back to `0` and the predicate goes false
+//! again, even though the pid slot may still read `0` for the brief window
+//! between the respawn starting and the pid-forwarder task's next tick. Only
+//! a SUSTAINED run of embed failures — which only happens in case 2, because
+//! case 1's respawn always succeeds cold-restart-cheaply — keeps
+//! `recent_timeout_count > 0` across multiple consecutive watchdog polls.
+//! The `CONFIRM_TICKS`-consecutive-poll debounce is an extra conservative
+//! margin on top of that: a single blip (one transient timeout right before
+//! a respawn lands) cannot trip the watchdog; it must observe the composed
+//! condition on `CONFIRM_TICKS` back-to-back ticks, `POLL_INTERVAL` apart.
+//!
+//! ## Bounded and quiet
+//!
+//! The watchdog polls every [`POLL_INTERVAL`] (seconds, not milliseconds —
+//! this is a background health check, not a hot loop) and stops permanently
+//! the moment it either (a) observes `switchable`'s active backend is no
+//! longer `Python` (something else already moved it — nothing left to
+//! watch), or (b) it acts on confirmed death and swaps back itself. It never
+//! blocks the reactor: every step is either a cheap atomic load or an
+//! `.await`.
+//!
+//! Test: `swap_back_fires_on_confirmed_death`,
+//! `swap_back_does_not_fire_on_idle_shutdown_respawn`,
+//! `swap_back_does_not_fire_while_healthy`,
+//! `is_confirmed_dead_predicate_matrix` in `start/tests.rs`.
+
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::core::Embedder;
+use crate::service::embedder_supervisor::{
+    ActiveBackend, BackendKind, BootstrapState, SwitchableEmbedder,
+};
+use crate::service::SearchAppState;
+
+use super::graceful_bootstrap::PythonAdapterTeardown;
+
+/// Seconds between watchdog polls. Deliberately measured in seconds (not
+/// milliseconds) — this is a background health check, not a hot loop; see
+/// the "no tight poll loop" convention this codebase follows elsewhere
+/// (`idle_watchdog`'s own 10s tick, the residency sweep, etc).
+const POLL_INTERVAL_SECS: u64 = 15;
+
+/// Number of CONSECUTIVE confirming polls required before the watchdog acts.
+/// A conservative debounce margin on top of the `recent_timeout_count`
+/// signal itself — see the module doc's false-positive-hazard section.
+const CONFIRM_TICKS: u32 = 2;
+
+/// Abstracts the one truly real/external step the swap-back path performs —
+/// standing up a fresh ort backend — so [`drive_swap_back_watchdog`] (the
+/// predicate + swap-back state machine) is unit-testable with a deterministic
+/// fake. No real `trusty-embedderd` binary/subprocess is ever touched in
+/// tests.
+pub(crate) trait SwapBackOps: Send + Sync {
+    /// Build a fresh ort backend exactly like the daemon's normal default
+    /// path does. Mirrors `embedder::build_ort_stdio_sidecar`'s return shape.
+    #[allow(clippy::type_complexity)]
+    fn build_ort(&self) -> Result<(Arc<dyn Embedder>, Option<Arc<AtomicU32>>)>;
+}
+
+/// Production [`SwapBackOps`]: delegates to the exact same
+/// `build_ort_stdio_sidecar` the daemon's default/fallback paths use, so
+/// there is only ever one implementation of "how to stand up the ort stdio
+/// sidecar" in this crate.
+struct RealSwapBackOps;
+
+impl SwapBackOps for RealSwapBackOps {
+    fn build_ort(&self) -> Result<(Arc<dyn Embedder>, Option<Arc<AtomicU32>>)> {
+        super::embedder::build_ort_stdio_sidecar()
+    }
+}
+
+/// Construct the production [`SwapBackOps`].
+///
+/// Why: `graceful_bootstrap::run_graceful_python_bootstrap` needs a
+/// trait-object handle to pass into [`run_swap_back_watchdog`] without
+/// reaching into this module's private `RealSwapBackOps` type.
+pub(super) fn real_swap_back_ops() -> Arc<dyn SwapBackOps> {
+    Arc::new(RealSwapBackOps)
+}
+
+/// Pure death predicate — see the module doc's "the predicate" section for
+/// the full reasoning.
+///
+/// Why: extracted as a pure function so the exact false-positive-avoidance
+/// logic (idle-shutdown vs. genuine death) has a small, deterministic,
+/// exhaustive unit test independent of the polling loop / real time.
+/// What: `true` only when the switchable's active backend is still `Python`,
+/// its pid slot reads `0` (no live child), AND at least one embed has failed
+/// since the last success (`recent_timeout_count > 0`). Any other
+/// combination — healthy python (pid > 0), or pid == 0 with no failures yet
+/// (idle-shutdown that hasn't been asked to respawn, or a respawn that
+/// already succeeded) — is `false`.
+/// Test: `is_confirmed_dead_predicate_matrix`.
+fn is_confirmed_dead(
+    active_kind: BackendKind,
+    python_pid: Option<u32>,
+    recent_timeout_count: u32,
+) -> bool {
+    active_kind == BackendKind::Python && python_pid.is_none() && recent_timeout_count > 0
+}
+
+/// Entry point spawned by `graceful_bootstrap::run_graceful_python_bootstrap`
+/// right after a successful ort→python hot-swap.
+///
+/// Why: thin wrapper around [`drive_swap_back_watchdog`] that supplies the
+/// real timing constants, mirroring `graceful_bootstrap::run_graceful_python_bootstrap`'s
+/// own thin-wrapper-around-a-testable-driver shape.
+/// What: delegates to [`drive_swap_back_watchdog`] with [`POLL_INTERVAL_SECS`]
+/// and [`CONFIRM_TICKS`].
+/// Test: `drive_swap_back_watchdog` (this function's callee) carries the
+/// actual test coverage — this wrapper has no independent branches.
+pub(super) async fn run_swap_back_watchdog(
+    switchable: Arc<SwitchableEmbedder>,
+    state: SearchAppState,
+    python_teardown: Arc<dyn PythonAdapterTeardown>,
+    ops: Arc<dyn SwapBackOps>,
+) {
+    drive_swap_back_watchdog(
+        switchable,
+        state,
+        python_teardown,
+        ops,
+        Duration::from_secs(POLL_INTERVAL_SECS),
+        CONFIRM_TICKS,
+    )
+    .await;
+}
+
+/// The actual swap-back state machine, parameterized so tests can inject a
+/// near-zero `poll_interval` and a fake [`SwapBackOps`] and run in
+/// milliseconds under no real time or subprocess.
+///
+/// What: polls every `poll_interval`. On each tick, reads
+/// `switchable.active()`: if it is no longer [`BackendKind::Python`],
+/// something else already moved the backend away — nothing left for this
+/// watchdog to do, so it returns immediately (bounded: never watches a
+/// backend it already abandoned). Otherwise composes
+/// [`is_confirmed_dead`] from the current pid slot
+/// (`SearchAppState::current_embedderd_pid`) and
+/// `state.embedder_stall_tracker.recent_timeout_count()`. A confirming tick
+/// increments a consecutive-ticks counter; a non-confirming tick resets it
+/// to `0`. Once the counter reaches `confirm_ticks`, builds a fresh ort
+/// backend via `ops.build_ort()`, hot-swaps `switchable` to it
+/// (`ActiveBackend { kind: Ort, bootstrap: FellBackToOrt, .. }`), installs
+/// the new ort pid slot on `state`, tears down the dead python handle via
+/// `python_teardown.teardown()` (cooperative — no orphan), logs loudly at
+/// `warn`, and returns (this watchdog's job is done — python was already
+/// abandoned, permanently, for this daemon's lifetime, matching PR-3's own
+/// "no re-bootstrap after failure" convention). If `ops.build_ort()` itself
+/// fails, the dead python handle is still torn down (no orphan) but the
+/// switchable is left as-is (still python, now truly unrecoverable) with a
+/// loud `error` log — an extremely unlikely double-failure (the ort sidecar
+/// binary going missing at the exact moment the python one died), but never
+/// silently swallowed.
+/// Test: `swap_back_fires_on_confirmed_death`,
+/// `swap_back_does_not_fire_on_idle_shutdown_respawn`,
+/// `swap_back_does_not_fire_while_healthy`.
+pub(super) async fn drive_swap_back_watchdog(
+    switchable: Arc<SwitchableEmbedder>,
+    state: SearchAppState,
+    python_teardown: Arc<dyn PythonAdapterTeardown>,
+    ops: Arc<dyn SwapBackOps>,
+    poll_interval: Duration,
+    confirm_ticks: u32,
+) {
+    let mut consecutive_confirms = 0u32;
+
+    loop {
+        tokio::time::sleep(poll_interval).await;
+
+        let active = switchable.active();
+        if active.kind != BackendKind::Python {
+            tracing::debug!(
+                "swap_back_watchdog: active backend is no longer python (kind={:?}) — \
+                 nothing left to watch, exiting",
+                active.kind
+            );
+            return;
+        }
+
+        let python_pid = state.current_embedderd_pid();
+        let recent_timeouts = state.embedder_stall_tracker.recent_timeout_count();
+
+        if is_confirmed_dead(active.kind, python_pid, recent_timeouts) {
+            consecutive_confirms += 1;
+        } else {
+            consecutive_confirms = 0;
+        }
+
+        if consecutive_confirms < confirm_ticks {
+            continue;
+        }
+
+        tracing::warn!(
+            "python/MPS sidecar unrecoverable — fell back to ort; search unaffected \
+             (recent_timeout_count={recent_timeouts}, confirmed over {confirm_ticks} \
+             consecutive checks)"
+        );
+
+        match ops.build_ort() {
+            Ok((ort_adapter, ort_pid_slot)) => {
+                let provider = ort_adapter.provider();
+                switchable.swap_to(
+                    ort_adapter,
+                    ActiveBackend {
+                        kind: BackendKind::Ort,
+                        provider,
+                        model: super::embedder::EMBEDDER_MODEL_NAME.to_string(),
+                        quantized: super::embedder::backend_respects_quantized_env(
+                            BackendKind::Ort,
+                        ) && super::embedder::quantized_from_env(),
+                        bootstrap: BootstrapState::FellBackToOrt,
+                    },
+                );
+                if let Some(slot) = ort_pid_slot {
+                    state.install_embedderd_pid_slot(slot).await;
+                }
+                // Shut down the dead python handle cleanly — no orphan. Safe
+                // to do after swap_to: `switchable` no longer routes any
+                // caller through this handle, so there is no live traffic
+                // left to interrupt; any in-flight call that was already
+                // routed through the old (dead) handle when swap_to landed
+                // simply errors and is retried by the caller, landing on the
+                // now-installed ort backend (both backends are
+                // vector-interchangeable, verified this epic).
+                python_teardown.teardown().await;
+            }
+            Err(e) => {
+                tracing::error!(
+                    "swap-back-to-ort failed to build a fresh ort sidecar ({e:#}) — \
+                     search remains on the unrecoverable python backend and will error \
+                     on every embed call. Restart the daemon to recover (or fix the ort \
+                     binary discovery issue and it will resolve on next start)."
+                );
+                python_teardown.teardown().await;
+            }
+        }
+
+        return;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exhaustive matrix over the predicate's three inputs — every
+    /// combination is spelled out explicitly rather than looped, so a
+    /// reviewer can see at a glance exactly which combination is/isn't a
+    /// confirmed death.
+    #[test]
+    fn is_confirmed_dead_predicate_matrix() {
+        // Healthy python, serving fine.
+        assert!(!is_confirmed_dead(BackendKind::Python, Some(1234), 0));
+        // Healthy python but a transient timeout blip (pid still alive) —
+        // not a death signal, the process itself is still up.
+        assert!(!is_confirmed_dead(BackendKind::Python, Some(1234), 3));
+        // Idle-shutdown, not yet asked to respawn (or respawn already
+        // succeeded and reset the counter) — pid 0, no failures recorded.
+        assert!(!is_confirmed_dead(BackendKind::Python, None, 0));
+        // THE confirmed-death case: pid 0 AND failures piling up.
+        assert!(is_confirmed_dead(BackendKind::Python, None, 1));
+        assert!(is_confirmed_dead(BackendKind::Python, None, 5));
+        // Never fires for any other active backend kind, regardless of the
+        // other two signals — this predicate only ever judges the python arm.
+        assert!(!is_confirmed_dead(BackendKind::Ort, None, 5));
+        assert!(!is_confirmed_dead(BackendKind::Remote, None, 5));
+        assert!(!is_confirmed_dead(BackendKind::InProcess, None, 5));
+        assert!(!is_confirmed_dead(BackendKind::Candle, None, 5));
+    }
+}

--- a/crates/trusty-search/src/commands/start/swap_back_watchdog.rs
+++ b/crates/trusty-search/src/commands/start/swap_back_watchdog.rs
@@ -14,68 +14,68 @@
 //! `SwitchableEmbedder` back to a fresh ort backend so search never degrades
 //! permanently.
 //!
-//! ## The false-positive hazard — why "pid == 0" alone is not the trigger
+//! ## History: the pid+stall-tracker heuristic was UNSAFE (code-critic
+//! ## BLOCK on PR #3584) — fixed via a definitive supervisor signal
 //!
-//! The python sidecar's pid slot (`SearchAppState::current_embedderd_pid`)
-//! reads `0` (`None`) in TWO completely different situations:
+//! The first version of this module inferred death from
+//! `active.kind == Python && pid_slot == 0 && recent_timeout_count > 0`,
+//! debounced across a couple of polling ticks. That heuristic has a real
+//! false-positive window that code-critic caught before merge:
 //!
-//!   1. **Intentional idle-shutdown** — `LazyEmbedderHandle`'s own idle
-//!      watchdog (`embedder_supervisor::idle_watchdog`) killed the child
-//!      after `TRUSTY_EMBEDDERD_PY_IDLE_SHUTDOWN_SECS` of no requests, and
-//!      reset its internal spawn gate. The NEXT embed request transparently
-//!      triggers a fresh spawn and succeeds — this is normal, expected,
-//!      memory-saving behavior, not a failure.
-//!   2. **Genuine, unrecoverable death** — the `EmbedderSupervisor`'s
-//!      crash-restart loop exhausted `TRUSTY_EMBEDDERD_MAX_RESTARTS` and gave
-//!      up. Critically, `LazyEmbedderHandle`'s OWN spawn gate (the
-//!      `state: Arc<Mutex<Option<SpawnedState>>>` cell) is untouched in this
-//!      case — only the idle watchdog or `LazyEmbedderHandle::shutdown()`
-//!      ever clears it. So the handle keeps reusing the same, now-dead
-//!      `client_slot` on every subsequent embed call: every one of those
-//!      calls fails (the underlying stdio pipe is gone), and NONE of them
-//!      trigger a fresh respawn.
+//!   1. A single TRANSIENT embed failure leaves `recent_timeout_count > 0`
+//!      (and bumps `last_use`).
+//!   2. A genuine quiet period elapses with NO further embed traffic.
+//!   3. `LazyEmbedderHandle`'s own idle watchdog
+//!      (`embedder_supervisor::idle_watchdog`) kills the child at
+//!      `idle_shutdown_secs` (up to 1800s) — this is normal, expected,
+//!      memory-saving behavior, not a failure. It zeroes the pid slot AND
+//!      resets the spawn gate so the next request transparently respawns.
+//!      Critically, it does **not** touch `EmbedderStallTracker` —
+//!      `recent_timeout_count` is cleared to `0` ONLY by a subsequent
+//!      SUCCESSFUL embed (`EmbedderStallTracker::record_success`), and step 2
+//!      guarantees there isn't one.
+//!   4. The next two watchdog ticks (needing zero further traffic) then
+//!      observe `pid == 0 && recent_timeout_count > 0` and PERMANENTLY swap a
+//!      perfectly healthy, merely-idle sidecar to ort.
 //!
-//! Swapping back to ort on case 1 would be actively wrong — it would
-//! permanently abandon a perfectly healthy python sidecar just because it
-//! happened to be idle for a moment, thrashing the two backends back and
-//! forth. The predicate below is deliberately conservative to tell the two
-//! apart without adding any new signal: it composes the pid slot with
-//! [`EmbedderStallTracker::recent_timeout_count`] (`service/stall_tracker.rs`,
-//! already wired onto every embed call via `EmbedPool`).
+//! The fix replaces the heuristic with a DEFINITIVE signal from the
+//! supervisor itself: [`trusty_common::embedder_client::EmbedderSupervisor::terminated_signal`]
+//! is an `Arc<AtomicBool>` the supervision loop sets to `true` at the exact
+//! instant — and ONLY the instant — it decides to give up permanently
+//! (exhausted `max_restarts` or a wedge-restart storm). It is never set on a
+//! clean exit, an intentional `shutdown()` (which is exactly what
+//! idle-shutdown performs), or an ordinary respawn. `LazyEmbedderHandle`
+//! exposes this through `is_confirmed_terminated()` — which ALSO returns
+//! `false` whenever its own spawn gate has been reset (idle-shutdown or an
+//! explicit `shutdown()` already cleared `state` to `None`), so there is no
+//! window where a stale flag from a previous spawn generation could leak
+//! into a fresh, healthy one. This eliminates the ambiguity entirely: there
+//! is no longer a heuristic to fool with a quiet period, because idle-
+//! shutdown and genuine death now produce categorically different signals
+//! rather than the same "pid == 0" observation plus a stale side-counter.
 //!
-//! **The predicate**: `active.kind == Python && pid == 0 && recent_timeout_count > 0`,
-//! confirmed across [`CONFIRM_TICKS`] CONSECUTIVE polling ticks before acting.
-//!
-//! Why this composition is safe against case 1 (idle-shutdown): a successful
-//! embed call (the respawn succeeding) calls
-//! `EmbedderStallTracker::record_success`, which unconditionally resets
-//! `recent_timeout_count` to `0` — see `stall_tracker.rs`. So the moment an
-//! idle-shutdown's automatic respawn serves one successful request,
-//! `recent_timeout_count` drops back to `0` and the predicate goes false
-//! again, even though the pid slot may still read `0` for the brief window
-//! between the respawn starting and the pid-forwarder task's next tick. Only
-//! a SUSTAINED run of embed failures — which only happens in case 2, because
-//! case 1's respawn always succeeds cold-restart-cheaply — keeps
-//! `recent_timeout_count > 0` across multiple consecutive watchdog polls.
-//! The `CONFIRM_TICKS`-consecutive-poll debounce is an extra conservative
-//! margin on top of that: a single blip (one transient timeout right before
-//! a respawn lands) cannot trip the watchdog; it must observe the composed
-//! condition on `CONFIRM_TICKS` back-to-back ticks, `POLL_INTERVAL` apart.
+//! **The predicate is now simply**: `active.kind == Python &&
+//! python_teardown.is_confirmed_terminated()`. No debounce is needed — the
+//! flag is monotonic (set at most once, never reset) and unambiguous the
+//! instant it is observed `true`.
 //!
 //! ## Bounded and quiet
 //!
-//! The watchdog polls every [`POLL_INTERVAL`] (seconds, not milliseconds —
-//! this is a background health check, not a hot loop) and stops permanently
-//! the moment it either (a) observes `switchable`'s active backend is no
-//! longer `Python` (something else already moved it — nothing left to
-//! watch), or (b) it acts on confirmed death and swaps back itself. It never
-//! blocks the reactor: every step is either a cheap atomic load or an
-//! `.await`.
+//! The watchdog polls every [`POLL_INTERVAL_SECS`] (seconds, not
+//! milliseconds — this is a background health check, not a hot loop) and
+//! stops permanently the moment it either (a) observes `switchable`'s active
+//! backend is no longer `Python` (something else already moved it — nothing
+//! left to watch), or (b) it acts on confirmed death and swaps back itself.
+//! It never blocks the reactor: every step is either a cheap atomic load or
+//! an `.await`.
 //!
 //! Test: `swap_back_fires_on_confirmed_death`,
-//! `swap_back_does_not_fire_on_idle_shutdown_respawn`,
-//! `swap_back_does_not_fire_while_healthy`,
-//! `is_confirmed_dead_predicate_matrix` in `start/tests.rs`.
+//! `swap_back_does_not_fire_on_stale_timeout_count_plus_idle_shutdown`
+//! (THE false-positive regression code-critic named — stale
+//! `recent_timeout_count > 0` left over from a transient failure, then a
+//! real idle-shutdown to pid 0, then zero further embed traffic — must NOT
+//! fire, unlike the pre-fix heuristic), `swap_back_does_not_fire_while_healthy`,
+//! `swap_back_stops_watching_once_backend_already_moved` in `start/tests.rs`.
 
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
@@ -96,11 +96,6 @@ use super::graceful_bootstrap::PythonAdapterTeardown;
 /// the "no tight poll loop" convention this codebase follows elsewhere
 /// (`idle_watchdog`'s own 10s tick, the residency sweep, etc).
 const POLL_INTERVAL_SECS: u64 = 15;
-
-/// Number of CONSECUTIVE confirming polls required before the watchdog acts.
-/// A conservative debounce margin on top of the `recent_timeout_count`
-/// signal itself — see the module doc's false-positive-hazard section.
-const CONFIRM_TICKS: u32 = 2;
 
 /// Abstracts the one truly real/external step the swap-back path performs —
 /// standing up a fresh ort backend — so [`drive_swap_back_watchdog`] (the
@@ -135,35 +130,14 @@ pub(super) fn real_swap_back_ops() -> Arc<dyn SwapBackOps> {
     Arc::new(RealSwapBackOps)
 }
 
-/// Pure death predicate — see the module doc's "the predicate" section for
-/// the full reasoning.
-///
-/// Why: extracted as a pure function so the exact false-positive-avoidance
-/// logic (idle-shutdown vs. genuine death) has a small, deterministic,
-/// exhaustive unit test independent of the polling loop / real time.
-/// What: `true` only when the switchable's active backend is still `Python`,
-/// its pid slot reads `0` (no live child), AND at least one embed has failed
-/// since the last success (`recent_timeout_count > 0`). Any other
-/// combination — healthy python (pid > 0), or pid == 0 with no failures yet
-/// (idle-shutdown that hasn't been asked to respawn, or a respawn that
-/// already succeeded) — is `false`.
-/// Test: `is_confirmed_dead_predicate_matrix`.
-fn is_confirmed_dead(
-    active_kind: BackendKind,
-    python_pid: Option<u32>,
-    recent_timeout_count: u32,
-) -> bool {
-    active_kind == BackendKind::Python && python_pid.is_none() && recent_timeout_count > 0
-}
-
 /// Entry point spawned by `graceful_bootstrap::run_graceful_python_bootstrap`
 /// right after a successful ort→python hot-swap.
 ///
 /// Why: thin wrapper around [`drive_swap_back_watchdog`] that supplies the
-/// real timing constants, mirroring `graceful_bootstrap::run_graceful_python_bootstrap`'s
-/// own thin-wrapper-around-a-testable-driver shape.
-/// What: delegates to [`drive_swap_back_watchdog`] with [`POLL_INTERVAL_SECS`]
-/// and [`CONFIRM_TICKS`].
+/// real poll interval, mirroring
+/// `graceful_bootstrap::run_graceful_python_bootstrap`'s own
+/// thin-wrapper-around-a-testable-driver shape.
+/// What: delegates to [`drive_swap_back_watchdog`] with [`POLL_INTERVAL_SECS`].
 /// Test: `drive_swap_back_watchdog` (this function's callee) carries the
 /// actual test coverage — this wrapper has no independent branches.
 pub(super) async fn run_swap_back_watchdog(
@@ -178,7 +152,6 @@ pub(super) async fn run_swap_back_watchdog(
         python_teardown,
         ops,
         Duration::from_secs(POLL_INTERVAL_SECS),
-        CONFIRM_TICKS,
     )
     .await;
 }
@@ -191,15 +164,14 @@ pub(super) async fn run_swap_back_watchdog(
 /// `switchable.active()`: if it is no longer [`BackendKind::Python`],
 /// something else already moved the backend away — nothing left for this
 /// watchdog to do, so it returns immediately (bounded: never watches a
-/// backend it already abandoned). Otherwise composes
-/// [`is_confirmed_dead`] from the current pid slot
-/// (`SearchAppState::current_embedderd_pid`) and
-/// `state.embedder_stall_tracker.recent_timeout_count()`. A confirming tick
-/// increments a consecutive-ticks counter; a non-confirming tick resets it
-/// to `0`. Once the counter reaches `confirm_ticks`, builds a fresh ort
-/// backend via `ops.build_ort()`, hot-swaps `switchable` to it
-/// (`ActiveBackend { kind: Ort, bootstrap: FellBackToOrt, .. }`), installs
-/// the new ort pid slot on `state`, tears down the dead python handle via
+/// backend it already abandoned). Otherwise checks
+/// `python_teardown.is_confirmed_terminated()` — the DEFINITIVE signal from
+/// the underlying `EmbedderSupervisor` (see the module doc's history
+/// section for why this replaced the earlier pid+stall-tracker heuristic).
+/// The moment it observes `true`, builds a fresh ort backend via
+/// `ops.build_ort()`, hot-swaps `switchable` to it (`ActiveBackend { kind:
+/// Ort, bootstrap: FellBackToOrt, .. }`), installs the new ort pid slot on
+/// `state`, tears down the dead python handle via
 /// `python_teardown.teardown()` (cooperative — no orphan), logs loudly at
 /// `warn`, and returns (this watchdog's job is done — python was already
 /// abandoned, permanently, for this daemon's lifetime, matching PR-3's own
@@ -210,18 +182,16 @@ pub(super) async fn run_swap_back_watchdog(
 /// binary going missing at the exact moment the python one died), but never
 /// silently swallowed.
 /// Test: `swap_back_fires_on_confirmed_death`,
-/// `swap_back_does_not_fire_on_idle_shutdown_respawn`,
-/// `swap_back_does_not_fire_while_healthy`.
+/// `swap_back_does_not_fire_on_stale_timeout_count_plus_idle_shutdown`,
+/// `swap_back_does_not_fire_while_healthy`,
+/// `swap_back_stops_watching_once_backend_already_moved`.
 pub(super) async fn drive_swap_back_watchdog(
     switchable: Arc<SwitchableEmbedder>,
     state: SearchAppState,
     python_teardown: Arc<dyn PythonAdapterTeardown>,
     ops: Arc<dyn SwapBackOps>,
     poll_interval: Duration,
-    confirm_ticks: u32,
 ) {
-    let mut consecutive_confirms = 0u32;
-
     loop {
         tokio::time::sleep(poll_interval).await;
 
@@ -235,24 +205,11 @@ pub(super) async fn drive_swap_back_watchdog(
             return;
         }
 
-        let python_pid = state.current_embedderd_pid();
-        let recent_timeouts = state.embedder_stall_tracker.recent_timeout_count();
-
-        if is_confirmed_dead(active.kind, python_pid, recent_timeouts) {
-            consecutive_confirms += 1;
-        } else {
-            consecutive_confirms = 0;
-        }
-
-        if consecutive_confirms < confirm_ticks {
+        if !python_teardown.is_confirmed_terminated().await {
             continue;
         }
 
-        tracing::warn!(
-            "python/MPS sidecar unrecoverable — fell back to ort; search unaffected \
-             (recent_timeout_count={recent_timeouts}, confirmed over {confirm_ticks} \
-             consecutive checks)"
-        );
+        tracing::warn!("python/MPS sidecar unrecoverable — fell back to ort; search unaffected");
 
         match ops.build_ort() {
             Ok((ort_adapter, ort_pid_slot)) => {
@@ -294,35 +251,5 @@ pub(super) async fn drive_swap_back_watchdog(
         }
 
         return;
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Exhaustive matrix over the predicate's three inputs — every
-    /// combination is spelled out explicitly rather than looped, so a
-    /// reviewer can see at a glance exactly which combination is/isn't a
-    /// confirmed death.
-    #[test]
-    fn is_confirmed_dead_predicate_matrix() {
-        // Healthy python, serving fine.
-        assert!(!is_confirmed_dead(BackendKind::Python, Some(1234), 0));
-        // Healthy python but a transient timeout blip (pid still alive) —
-        // not a death signal, the process itself is still up.
-        assert!(!is_confirmed_dead(BackendKind::Python, Some(1234), 3));
-        // Idle-shutdown, not yet asked to respawn (or respawn already
-        // succeeded and reset the counter) — pid 0, no failures recorded.
-        assert!(!is_confirmed_dead(BackendKind::Python, None, 0));
-        // THE confirmed-death case: pid 0 AND failures piling up.
-        assert!(is_confirmed_dead(BackendKind::Python, None, 1));
-        assert!(is_confirmed_dead(BackendKind::Python, None, 5));
-        // Never fires for any other active backend kind, regardless of the
-        // other two signals — this predicate only ever judges the python arm.
-        assert!(!is_confirmed_dead(BackendKind::Ort, None, 5));
-        assert!(!is_confirmed_dead(BackendKind::Remote, None, 5));
-        assert!(!is_confirmed_dead(BackendKind::InProcess, None, 5));
-        assert!(!is_confirmed_dead(BackendKind::Candle, None, 5));
     }
 }

--- a/crates/trusty-search/src/commands/start/tests.rs
+++ b/crates/trusty-search/src/commands/start/tests.rs
@@ -1564,3 +1564,521 @@ async fn graceful_bootstrap_gives_up_after_exhausting_retries() {
         "must attempt exactly `retries` times, no more, no less"
     );
 }
+
+// ── Swap-BACK watchdog (epic #3524 slice 6, PR 4/5) ─────────────────────────
+//
+// These drive `swap_back_watchdog::drive_swap_back_watchdog` — the death
+// predicate + swap-back state machine — with a deterministic fake
+// `SwapBackOps` and a real `SearchAppState` (its pid slot / stall tracker are
+// plain atomics, cheap to manipulate directly; no real subprocess involved).
+// The critical false-positive test (`swap_back_does_not_fire_on_idle_shutdown_respawn`)
+// is what proves the swap-back trigger is NOT bare pid-zero.
+
+use super::swap_back_watchdog::{drive_swap_back_watchdog, SwapBackOps};
+use std::time::Duration as SwapBackDuration;
+
+/// Deterministic fake ort adapter installed by [`FakeSwapBackOps::build_ort`]
+/// — never a real ONNX/sidecar.
+struct FakeOrtBackendForSwapBack;
+
+#[async_trait::async_trait]
+impl crate::core::Embedder for FakeOrtBackendForSwapBack {
+    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        Ok(vec![text.len() as f32; trusty_common::embedder::EMBED_DIM])
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        Ok(texts
+            .iter()
+            .map(|t| vec![t.len() as f32; trusty_common::embedder::EMBED_DIM])
+            .collect())
+    }
+
+    fn dimension(&self) -> usize {
+        trusty_common::embedder::EMBED_DIM
+    }
+}
+
+/// Fake [`SwapBackOps`] — records how many times `build_ort` was invoked so
+/// tests can assert the watchdog acted exactly once (and never, on the
+/// false-positive paths).
+struct FakeSwapBackOps {
+    build_calls: OrchestratorArc<AtomicUsize>,
+}
+
+impl FakeSwapBackOps {
+    fn new() -> (OrchestratorArc<Self>, OrchestratorArc<AtomicUsize>) {
+        let calls = OrchestratorArc::new(AtomicUsize::new(0));
+        (
+            OrchestratorArc::new(Self {
+                build_calls: OrchestratorArc::clone(&calls),
+            }),
+            calls,
+        )
+    }
+}
+
+impl SwapBackOps for FakeSwapBackOps {
+    #[allow(clippy::type_complexity)]
+    fn build_ort(
+        &self,
+    ) -> anyhow::Result<(
+        OrchestratorArc<dyn crate::core::Embedder>,
+        Option<OrchestratorArc<OrchestratorAtomicU32>>,
+    )> {
+        self.build_calls
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let adapter: OrchestratorArc<dyn crate::core::Embedder> =
+            OrchestratorArc::new(FakeOrtBackendForSwapBack);
+        Ok((
+            adapter,
+            Some(OrchestratorArc::new(OrchestratorAtomicU32::new(9999))),
+        ))
+    }
+}
+
+/// The `ActiveBackend` a successful PR-3 hot-swap installs: python, `Ready`.
+fn test_python_ready_active() -> SwitchableActiveBackend {
+    SwitchableActiveBackend {
+        kind: SwitchableBackendKind::Python,
+        provider: trusty_common::embedder::ExecutionProvider::Mps,
+        model: "all-MiniLM-L6-v2".to_string(),
+        quantized: false,
+        bootstrap: SwitchableBootstrapState::Ready,
+    }
+}
+
+/// THE false-positive regression test: pid slot reads 0 (idle-shutdown) but
+/// every embed attempt keeps SUCCEEDING (the respawn works) — the watchdog
+/// must never swap back. `EmbedderStallTracker::record_success` resets
+/// `recent_timeout_count` to 0, which is exactly the signal that must keep
+/// the death predicate false.
+///
+/// What: pid slot installed at 0 throughout; `record_success()` called
+/// repeatedly (simulating a respawn that keeps working) so
+/// `recent_timeout_count` never leaves 0. Drives the watchdog under a short
+/// timeout and asserts it NEVER returns (never fires) and `build_ort` is
+/// never called.
+/// Test: this test.
+#[tokio::test]
+async fn swap_back_does_not_fire_on_idle_shutdown_respawn() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(ort, test_python_ready_active()));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    // pid 0 the whole time — idle-shutdown convention.
+    state
+        .install_embedderd_pid_slot(OrchestratorArc::new(OrchestratorAtomicU32::new(0)))
+        .await;
+    // Every "respawn attempt" succeeds — recent_timeout_count stays 0.
+    state.embedder_stall_tracker.record_success();
+
+    let teardown_calls = OrchestratorArc::new(AtomicUsize::new(0));
+    let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
+        OrchestratorArc::new(FakeTeardown {
+            calls: OrchestratorArc::clone(&teardown_calls),
+        });
+    let (fake_ops, build_calls) = FakeSwapBackOps::new();
+    let ops: OrchestratorArc<dyn SwapBackOps> = OrchestratorArc::clone(&fake_ops) as _;
+
+    let result = tokio::time::timeout(
+        SwapBackDuration::from_millis(80),
+        drive_swap_back_watchdog(
+            OrchestratorArc::clone(&switchable),
+            state,
+            teardown,
+            ops,
+            SwapBackDuration::from_millis(5),
+            2,
+        ),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "watchdog must keep watching (never return) when death is never confirmed"
+    );
+    assert_eq!(
+        switchable.active().kind,
+        SwitchableBackendKind::Python,
+        "must stay on python — idle-shutdown-then-successful-respawn is not death"
+    );
+    assert_eq!(
+        build_calls.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "build_ort must never be called on the idle-shutdown path"
+    );
+    assert_eq!(
+        teardown_calls.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "the still-healthy python handle must never be torn down"
+    );
+}
+
+/// A healthy, actively-serving python sidecar (nonzero pid, zero recent
+/// timeouts) must never trigger a swap-back.
+#[tokio::test]
+async fn swap_back_does_not_fire_while_healthy() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(ort, test_python_ready_active()));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    state
+        .install_embedderd_pid_slot(OrchestratorArc::new(OrchestratorAtomicU32::new(4242)))
+        .await;
+
+    let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
+        OrchestratorArc::new(FakeTeardown {
+            calls: OrchestratorArc::new(AtomicUsize::new(0)),
+        });
+    let (fake_ops, build_calls) = FakeSwapBackOps::new();
+    let ops: OrchestratorArc<dyn SwapBackOps> = OrchestratorArc::clone(&fake_ops) as _;
+
+    let result = tokio::time::timeout(
+        SwapBackDuration::from_millis(80),
+        drive_swap_back_watchdog(
+            OrchestratorArc::clone(&switchable),
+            state,
+            teardown,
+            ops,
+            SwapBackDuration::from_millis(5),
+            2,
+        ),
+    )
+    .await;
+
+    assert!(result.is_err(), "watchdog must keep watching while healthy");
+    assert_eq!(switchable.active().kind, SwitchableBackendKind::Python);
+    assert_eq!(
+        build_calls.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "build_ort must never be called while healthy"
+    );
+}
+
+/// Confirmed death — pid slot reads 0 AND embed attempts keep failing
+/// (`recent_timeout_count > 0`, never reset by a success) across
+/// `confirm_ticks` consecutive polls — must swap back to a fresh ort
+/// backend exactly once, tear down the dead python handle, and reinstall
+/// the ort pid slot.
+#[tokio::test]
+async fn swap_back_fires_on_confirmed_death() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(ort, test_python_ready_active()));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    // pid 0 — the supervisor gave up, no live child.
+    state
+        .install_embedderd_pid_slot(OrchestratorArc::new(OrchestratorAtomicU32::new(0)))
+        .await;
+    // Every subsequent embed attempt failed too — never reset by a success.
+    state.embedder_stall_tracker.record_timeout();
+    state.embedder_stall_tracker.record_timeout();
+    state.embedder_stall_tracker.record_timeout();
+
+    let teardown_calls = OrchestratorArc::new(AtomicUsize::new(0));
+    let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
+        OrchestratorArc::new(FakeTeardown {
+            calls: OrchestratorArc::clone(&teardown_calls),
+        });
+    let (fake_ops, build_calls) = FakeSwapBackOps::new();
+    let ops: OrchestratorArc<dyn SwapBackOps> = OrchestratorArc::clone(&fake_ops) as _;
+
+    tokio::time::timeout(
+        SwapBackDuration::from_secs(2),
+        drive_swap_back_watchdog(
+            OrchestratorArc::clone(&switchable),
+            state.clone(),
+            teardown,
+            ops,
+            SwapBackDuration::from_millis(5),
+            2,
+        ),
+    )
+    .await
+    .expect("watchdog must act (return) on confirmed death, not loop forever");
+
+    let active = switchable.active();
+    assert_eq!(
+        active.kind,
+        SwitchableBackendKind::Ort,
+        "must swap back to a fresh ort backend"
+    );
+    assert_eq!(active.bootstrap, SwitchableBootstrapState::FellBackToOrt);
+    assert_eq!(
+        build_calls.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "must build exactly one fresh ort backend"
+    );
+    assert_eq!(
+        teardown_calls.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "the dead python handle must be torn down exactly once — no orphan"
+    );
+    assert_eq!(
+        state.current_embedderd_pid(),
+        Some(9999),
+        "the new ort pid slot must be installed on state"
+    );
+}
+
+/// Once something else has already moved the switchable away from python
+/// (e.g. a concurrent/duplicate watchdog, or a manual intervention), this
+/// watchdog must notice on its next tick and stop watching — never act on a
+/// backend it no longer owns.
+#[tokio::test]
+async fn swap_back_stops_watching_once_backend_already_moved() {
+    let ort: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(FakeOrtEmbedder::new());
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
+        ort,
+        test_ort_bootstrapping_active(), // already ort, not python
+    ));
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+
+    let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
+        OrchestratorArc::new(FakeTeardown {
+            calls: OrchestratorArc::new(AtomicUsize::new(0)),
+        });
+    let (fake_ops, build_calls) = FakeSwapBackOps::new();
+    let ops: OrchestratorArc<dyn SwapBackOps> = OrchestratorArc::clone(&fake_ops) as _;
+
+    tokio::time::timeout(
+        SwapBackDuration::from_secs(2),
+        drive_swap_back_watchdog(
+            OrchestratorArc::clone(&switchable),
+            state,
+            teardown,
+            ops,
+            SwapBackDuration::from_millis(5),
+            2,
+        ),
+    )
+    .await
+    .expect("watchdog must return promptly once the active backend is not python");
+
+    assert_eq!(
+        build_calls.load(std::sync::atomic::Ordering::Relaxed),
+        0,
+        "must never act on a backend it doesn't own"
+    );
+}
+
+/// Real-hardware end-to-end (epic #3524 slice 6, PR 4/5). Every other test in
+/// this module drives the watchdog with fakes/spies; this is the one place
+/// that proves the FULL real stack — a real `trusty-embedderd-py` child,
+/// killed past `max_restarts`, the real `EmbedPool` recording real embed
+/// failures into the real `EmbedderStallTracker`, the real
+/// `drive_swap_back_watchdog`, and a real axum router's `/health` + search
+/// endpoints — actually falls back and keeps serving.
+///
+/// Why: every other test substitutes a fake `SwapBackOps`/pid-slot/tracker
+/// so the pure predicate and state-machine logic can be verified
+/// deterministically in milliseconds. None of them prove that a REAL
+/// `EmbedderSupervisor` crash-restart exhaustion actually produces the exact
+/// signal `is_confirmed_dead` depends on (pid slot pinned at 0, `client_slot`
+/// never reset so every subsequent embed keeps failing rather than
+/// transparently respawning) — this test is that proof, on real hardware.
+///
+/// Requires a real `trusty-embedderd-py` launcher discoverable on PATH (or
+/// `TRUSTY_EMBEDDERD_PY_BIN`) with its `uv`-managed venv already bootstrapped
+/// (torch + sentence-transformers) — practically, Apple Silicon with `uv`
+/// installed. Not run in CI (too slow, requires real hardware/GPU). Run
+/// manually with:
+///   `cargo test -p trusty-search --bin trusty-search -- --ignored \
+///      swap_back_real_hardware_kills_sidecar_past_max_restarts --nocapture`
+///
+/// What: builds a real `LazyEmbedderHandle` (max_restarts=1, idle-shutdown
+/// disabled so only this test's kills matter) around the python launcher,
+/// forces the first spawn with a real embed call, then repeatedly SIGKILLs
+/// whatever child pid is currently live until the pid slot settles at `0`
+/// and stays there (confirming the supervisor gave up rather than mid-crash-
+/// restart). Wraps the handle in a real `SwitchableEmbedder` (active =
+/// Python/Ready, mirroring what PR-3's hot-swap installs) and a real
+/// `EmbedPool` with a real `EmbedderStallTracker`; issues a few real `.embed()`
+/// calls against the dead sidecar (each records a real timeout). Runs the
+/// real `drive_swap_back_watchdog` (short poll interval, bounded by an
+/// overall test timeout) and waits for it to act. Finally boots a real axum
+/// router (`service::server::build_router`) on an ephemeral port and asserts,
+/// via real HTTP calls: `GET /health` reports `embedder_bootstrap:
+/// "fell_back_to_ort"`, and a real search against a freshly-registered empty
+/// index still returns `200` (proving search is unaffected, not just that the
+/// switchable's in-memory state flipped).
+/// Test: this test.
+#[tokio::test]
+#[ignore = "requires a real trusty-embedderd-py launcher + bootstrapped torch/MPS venv \
+            (Apple Silicon + uv) — not run in CI"]
+async fn swap_back_real_hardware_kills_sidecar_past_max_restarts() {
+    use crate::service::embed_pool::{EmbedPool, RequestPriority};
+    use crate::service::embedder_supervisor::LazyEmbedderHandle;
+    use std::sync::atomic::Ordering;
+    use std::time::Instant;
+
+    trusty_embedderd_py::ensure_venv_eager()
+        .expect("py venv bootstrap failed — install `uv` and bootstrap the venv once first");
+    let launcher = trusty_embedderd_py::locate_launcher_binary()
+        .expect("trusty-embedderd-py launcher not found on PATH");
+
+    let mut config = super::embedder::resolve_python_supervisor_config();
+    config.max_restarts = 1;
+    config.backoff_max_secs = 2;
+    // Disable idle-shutdown so only THIS test's explicit kills matter — an
+    // idle-shutdown racing in would confound the confirmed-death signal.
+    config.idle_shutdown_secs = 0;
+
+    let handle = OrchestratorArc::new(LazyEmbedderHandle::new(launcher, config));
+    let pid_slot = handle.app_pid_slot();
+
+    // Force the first real spawn.
+    handle
+        .embed_via(|client| async move { client.embed_batch(vec!["warm".to_string()]).await })
+        .await
+        .expect("initial embed (forces spawn) failed — is the venv actually bootstrapped?");
+    let pid1 = pid_slot.load(Ordering::Acquire);
+    assert!(pid1 > 0, "expected a live child after the first embed");
+
+    // Repeatedly SIGKILL whatever child is currently live until the pid slot
+    // settles at 0 and STAYS there for a few seconds straight — proof the
+    // supervisor gave up (exhausted max_restarts) rather than being mid
+    // crash-restart.
+    let deadline = Instant::now() + SwapBackDuration::from_secs(90);
+    loop {
+        let current = pid_slot.load(Ordering::Acquire);
+        if current > 0 {
+            let _ = std::process::Command::new("kill")
+                .args(["-9", &current.to_string()])
+                .status();
+        }
+        tokio::time::sleep(SwapBackDuration::from_millis(500)).await;
+
+        if pid_slot.load(Ordering::Acquire) == 0 {
+            tokio::time::sleep(SwapBackDuration::from_secs(3)).await;
+            if pid_slot.load(Ordering::Acquire) == 0 {
+                break;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "sidecar kept restarting past the 90s test deadline — \
+             max_restarts=1 was not exhausted?"
+        );
+    }
+
+    // Wrap the (now-dead) handle exactly like PR-3's hot-swap does, and run
+    // a few real embeds through a real EmbedPool + real stall tracker so the
+    // watchdog's real signal is populated the same way production traffic
+    // would populate it.
+    let adapter: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::new(super::embedder::LazySlotEmbedderAdapter {
+            handle: OrchestratorArc::clone(&handle),
+            is_python: true,
+        });
+    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
+        OrchestratorArc::clone(&adapter),
+        test_python_ready_active(),
+    ));
+    let switchable_dyn: OrchestratorArc<dyn crate::core::Embedder> =
+        OrchestratorArc::clone(&switchable) as _;
+
+    let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
+    state.install_switchable_embedder(OrchestratorArc::clone(&switchable));
+    state
+        .install_embedder(OrchestratorArc::clone(&switchable_dyn))
+        .await;
+    state
+        .install_embedderd_pid_slot(OrchestratorArc::clone(&pid_slot))
+        .await;
+
+    let pool = OrchestratorArc::new(
+        EmbedPool::with_autotune(switchable_dyn)
+            .with_stall_tracker(OrchestratorArc::clone(&state.embedder_stall_tracker)),
+    );
+    state
+        .install_embed_pool(OrchestratorArc::clone(&pool))
+        .await;
+
+    for _ in 0..3 {
+        let _ = pool
+            .embed(
+                vec!["probe against a dead sidecar".to_string()],
+                RequestPriority::Interactive,
+            )
+            .await;
+    }
+    assert!(
+        state.embedder_stall_tracker.recent_timeout_count() > 0,
+        "embeds against the dead sidecar must have recorded real timeouts"
+    );
+
+    let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
+        OrchestratorArc::clone(&handle) as _;
+    let ops = super::swap_back_watchdog::real_swap_back_ops();
+
+    tokio::time::timeout(
+        SwapBackDuration::from_secs(60),
+        drive_swap_back_watchdog(
+            OrchestratorArc::clone(&switchable),
+            state.clone(),
+            teardown,
+            ops,
+            SwapBackDuration::from_secs(1),
+            2,
+        ),
+    )
+    .await
+    .expect("watchdog did not act within 60s of confirmed real death");
+
+    assert_eq!(switchable.active().kind, SwitchableBackendKind::Ort);
+    assert_eq!(
+        switchable.active().bootstrap,
+        SwitchableBootstrapState::FellBackToOrt
+    );
+
+    // Real HTTP layer: boot the actual router and assert /health + search.
+    let app = crate::service::server::build_router(state.clone());
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind failed");
+    let addr = listener.local_addr().expect("local_addr failed");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let client = reqwest::Client::new();
+    let health: serde_json::Value = client
+        .get(format!("http://{addr}/health"))
+        .send()
+        .await
+        .expect("GET /health failed")
+        .json()
+        .await
+        .expect("/health did not return JSON");
+    assert_eq!(
+        health.get("embedder_bootstrap").and_then(|v| v.as_str()),
+        Some("fell_back_to_ort"),
+        "/health must report the swap-back: {health:?}"
+    );
+
+    // Register an empty index and confirm search still returns 200 —
+    // proving the fallback did not just flip in-memory state but that
+    // search actually keeps working end-to-end.
+    let create_resp = client
+        .post(format!("http://{addr}/indexes"))
+        .json(&serde_json::json!({ "id": "swap-back-e2e", "root_path": "/tmp" }))
+        .send()
+        .await
+        .expect("POST /indexes failed");
+    assert!(create_resp.status().is_success());
+
+    let search_resp = client
+        .post(format!("http://{addr}/indexes/swap-back-e2e/search"))
+        .json(&serde_json::json!({ "text": "fn main", "top_k": 5 }))
+        .send()
+        .await
+        .expect("POST /indexes/:id/search failed");
+    assert!(
+        search_resp.status().is_success(),
+        "search must still succeed after swap-back: {}",
+        search_resp.status()
+    );
+}

--- a/crates/trusty-search/src/commands/start/tests.rs
+++ b/crates/trusty-search/src/commands/start/tests.rs
@@ -1194,8 +1194,29 @@ impl crate::core::Embedder for FakePythonEmbedderHangs {
 /// `teardown()` was invoked so tests can assert it fires on the probe
 /// failure/timeout paths and NEVER on success or on a pre-adapter
 /// (venv-bootstrap) failure (epic #3524 slice 6 PR-3 fix — code-critic HIGH).
+///
+/// `terminated` (epic #3524 slice 6 PR-4 follow-up, code-critic BLOCK on PR
+/// #3584) is the fake's controllable stand-in for the real
+/// `LazyEmbedderHandle::is_confirmed_terminated()` — the DEFINITIVE
+/// supervisor-gave-up signal the swap-back watchdog gates on. Defaults to
+/// `false` (never confirmed dead); swap-back tests flip it via a shared
+/// `Arc<AtomicBool>` to simulate genuine, unrecoverable death without any
+/// real supervisor/subprocess.
 struct FakeTeardown {
     calls: OrchestratorArc<AtomicUsize>,
+    terminated: OrchestratorArc<std::sync::atomic::AtomicBool>,
+}
+
+impl FakeTeardown {
+    /// Construct a fake that is never confirmed-terminated — the default for
+    /// every graceful_bootstrap test, none of which exercise the swap-back
+    /// watchdog's death predicate.
+    fn new(calls: OrchestratorArc<AtomicUsize>) -> Self {
+        Self {
+            calls,
+            terminated: OrchestratorArc::new(std::sync::atomic::AtomicBool::new(false)),
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -1203,6 +1224,10 @@ impl super::graceful_bootstrap::PythonAdapterTeardown for FakeTeardown {
     async fn teardown(&self) {
         self.calls
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    async fn is_confirmed_terminated(&self) -> bool {
+        self.terminated.load(std::sync::atomic::Ordering::Acquire)
     }
 }
 
@@ -1316,9 +1341,9 @@ impl PythonBootstrap for FakeBootstrap {
             OrchestratorArc::new(FakePythonEmbedderOk)
         };
         let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
-            OrchestratorArc::new(FakeTeardown {
-                calls: OrchestratorArc::clone(&self.teardown_calls),
-            });
+            OrchestratorArc::new(FakeTeardown::new(OrchestratorArc::clone(
+                &self.teardown_calls,
+            )));
         (
             adapter,
             Some(OrchestratorArc::new(OrchestratorAtomicU32::new(4242))),
@@ -1569,10 +1594,21 @@ async fn graceful_bootstrap_gives_up_after_exhausting_retries() {
 //
 // These drive `swap_back_watchdog::drive_swap_back_watchdog` — the death
 // predicate + swap-back state machine — with a deterministic fake
-// `SwapBackOps` and a real `SearchAppState` (its pid slot / stall tracker are
-// plain atomics, cheap to manipulate directly; no real subprocess involved).
-// The critical false-positive test (`swap_back_does_not_fire_on_idle_shutdown_respawn`)
-// is what proves the swap-back trigger is NOT bare pid-zero.
+// `SwapBackOps` and a fake `PythonAdapterTeardown` (`FakeTeardown`, defined
+// above, whose `terminated` flag stands in for the real
+// `LazyEmbedderHandle::is_confirmed_terminated()` — the DEFINITIVE
+// supervisor-gave-up signal this module gates on since the code-critic BLOCK
+// on PR #3584). No real subprocess/supervisor involved in these tests — see
+// `swap_back_real_hardware_kills_sidecar_past_max_restarts` (`#[ignore]`,
+// below) for the real-process proof.
+//
+// THE critical false-positive regression test is
+// `swap_back_does_not_fire_on_stale_timeout_count_plus_idle_shutdown` — it
+// reproduces the EXACT scenario code-critic identified (a stale
+// `recent_timeout_count > 0` left over from an earlier transient failure,
+// combined with a real idle-shutdown zeroing the pid slot, with zero further
+// embed traffic) and asserts the watchdog does NOT fire, because the new
+// predicate no longer reads either of those two signals at all.
 
 use super::swap_back_watchdog::{drive_swap_back_watchdog, SwapBackOps};
 use std::time::Duration as SwapBackDuration;
@@ -1648,36 +1684,49 @@ fn test_python_ready_active() -> SwitchableActiveBackend {
     }
 }
 
-/// THE false-positive regression test: pid slot reads 0 (idle-shutdown) but
-/// every embed attempt keeps SUCCEEDING (the respawn works) — the watchdog
-/// must never swap back. `EmbedderStallTracker::record_success` resets
-/// `recent_timeout_count` to 0, which is exactly the signal that must keep
-/// the death predicate false.
+/// THE false-positive regression test named by code-critic's BLOCK review of
+/// PR #3584: a stale `recent_timeout_count > 0` (left over from an earlier
+/// TRANSIENT embed failure that was never followed by a success) combined
+/// with a real idle-shutdown (pid slot zeroed) and ZERO further embed calls
+/// in between — the exact sequence that tripped the old
+/// pid==0-plus-stall-tracker heuristic. The watchdog must NOT fire, because
+/// `is_confirmed_terminated()` (the fake's `terminated` flag, standing in
+/// for the real supervisor signal) stays `false` throughout — an
+/// intentional idle-shutdown never sets it.
 ///
-/// What: pid slot installed at 0 throughout; `record_success()` called
-/// repeatedly (simulating a respawn that keeps working) so
-/// `recent_timeout_count` never leaves 0. Drives the watchdog under a short
-/// timeout and asserts it NEVER returns (never fires) and `build_ort` is
-/// never called.
+/// This test FAILS against the pre-fix heuristic (which read
+/// `state.current_embedderd_pid()` and
+/// `state.embedder_stall_tracker.recent_timeout_count()` directly) and
+/// PASSES against the definitive-signal fix, because the fix no longer reads
+/// either of those two fields at all.
+/// What: sets a stale non-zero `recent_timeout_count` and a zeroed pid slot
+/// on `state` (reproducing the exact stale-state shape the old heuristic
+/// would have observed), while `teardown.is_confirmed_terminated()` stays
+/// `false`. Drives the watchdog under a short timeout and asserts it NEVER
+/// returns (never fires) and `build_ort` is never called.
 /// Test: this test.
 #[tokio::test]
-async fn swap_back_does_not_fire_on_idle_shutdown_respawn() {
+async fn swap_back_does_not_fire_on_stale_timeout_count_plus_idle_shutdown() {
     let ort: OrchestratorArc<dyn crate::core::Embedder> =
         OrchestratorArc::new(FakeOrtEmbedder::new());
     let switchable = OrchestratorArc::new(SwitchableEmbedder::new(ort, test_python_ready_active()));
     let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
-    // pid 0 the whole time — idle-shutdown convention.
+
+    // Reproduce the exact stale-state shape that fooled the old heuristic:
+    // one transient timeout recorded (never followed by a success)...
+    state.embedder_stall_tracker.record_timeout();
+    // ...then a real idle-shutdown zeroes the pid slot...
     state
         .install_embedderd_pid_slot(OrchestratorArc::new(OrchestratorAtomicU32::new(0)))
         .await;
-    // Every "respawn attempt" succeeds — recent_timeout_count stays 0.
-    state.embedder_stall_tracker.record_success();
+    // ...and ZERO further embed traffic follows (the scenario the old
+    // heuristic could not distinguish from genuine death).
 
     let teardown_calls = OrchestratorArc::new(AtomicUsize::new(0));
     let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
-        OrchestratorArc::new(FakeTeardown {
-            calls: OrchestratorArc::clone(&teardown_calls),
-        });
+        OrchestratorArc::new(FakeTeardown::new(OrchestratorArc::clone(&teardown_calls)));
+    // `terminated` defaults to false via `FakeTeardown::new` — the
+    // supervisor never actually gave up; this was an ordinary idle-shutdown.
     let (fake_ops, build_calls) = FakeSwapBackOps::new();
     let ops: OrchestratorArc<dyn SwapBackOps> = OrchestratorArc::clone(&fake_ops) as _;
 
@@ -1685,23 +1734,23 @@ async fn swap_back_does_not_fire_on_idle_shutdown_respawn() {
         SwapBackDuration::from_millis(80),
         drive_swap_back_watchdog(
             OrchestratorArc::clone(&switchable),
-            state,
+            state.clone(),
             teardown,
             ops,
             SwapBackDuration::from_millis(5),
-            2,
         ),
     )
     .await;
 
     assert!(
         result.is_err(),
-        "watchdog must keep watching (never return) when death is never confirmed"
+        "watchdog must keep watching (never return) — a stale timeout count \
+         plus an ordinary idle-shutdown is NOT confirmed death"
     );
     assert_eq!(
         switchable.active().kind,
         SwitchableBackendKind::Python,
-        "must stay on python — idle-shutdown-then-successful-respawn is not death"
+        "must stay on python — this was an idle-shutdown, not a death"
     );
     assert_eq!(
         build_calls.load(std::sync::atomic::Ordering::Relaxed),
@@ -1713,10 +1762,18 @@ async fn swap_back_does_not_fire_on_idle_shutdown_respawn() {
         0,
         "the still-healthy python handle must never be torn down"
     );
+    // Sanity: confirm the stale-state shape really was present (otherwise
+    // this test would not be exercising the regression it claims to).
+    assert_eq!(state.current_embedderd_pid(), None, "pid must read 0/None");
+    assert!(
+        state.embedder_stall_tracker.recent_timeout_count() > 0,
+        "the stale timeout count must still be non-zero — proving the fix \
+         does not depend on this field ever clearing"
+    );
 }
 
-/// A healthy, actively-serving python sidecar (nonzero pid, zero recent
-/// timeouts) must never trigger a swap-back.
+/// A healthy, actively-serving python sidecar must never trigger a
+/// swap-back.
 #[tokio::test]
 async fn swap_back_does_not_fire_while_healthy() {
     let ort: OrchestratorArc<dyn crate::core::Embedder> =
@@ -1727,10 +1784,9 @@ async fn swap_back_does_not_fire_while_healthy() {
         .install_embedderd_pid_slot(OrchestratorArc::new(OrchestratorAtomicU32::new(4242)))
         .await;
 
+    let teardown_calls = OrchestratorArc::new(AtomicUsize::new(0));
     let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
-        OrchestratorArc::new(FakeTeardown {
-            calls: OrchestratorArc::new(AtomicUsize::new(0)),
-        });
+        OrchestratorArc::new(FakeTeardown::new(teardown_calls));
     let (fake_ops, build_calls) = FakeSwapBackOps::new();
     let ops: OrchestratorArc<dyn SwapBackOps> = OrchestratorArc::clone(&fake_ops) as _;
 
@@ -1742,7 +1798,6 @@ async fn swap_back_does_not_fire_while_healthy() {
             teardown,
             ops,
             SwapBackDuration::from_millis(5),
-            2,
         ),
     )
     .await;
@@ -1756,31 +1811,28 @@ async fn swap_back_does_not_fire_while_healthy() {
     );
 }
 
-/// Confirmed death — pid slot reads 0 AND embed attempts keep failing
-/// (`recent_timeout_count > 0`, never reset by a success) across
-/// `confirm_ticks` consecutive polls — must swap back to a fresh ort
-/// backend exactly once, tear down the dead python handle, and reinstall
-/// the ort pid slot.
+/// Confirmed death — `is_confirmed_terminated()` reports `true` (the
+/// supervisor genuinely gave up) — must swap back to a fresh ort backend
+/// exactly once, tear down the dead python handle, and reinstall the ort pid
+/// slot.
 #[tokio::test]
 async fn swap_back_fires_on_confirmed_death() {
     let ort: OrchestratorArc<dyn crate::core::Embedder> =
         OrchestratorArc::new(FakeOrtEmbedder::new());
     let switchable = OrchestratorArc::new(SwitchableEmbedder::new(ort, test_python_ready_active()));
     let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
-    // pid 0 — the supervisor gave up, no live child.
     state
         .install_embedderd_pid_slot(OrchestratorArc::new(OrchestratorAtomicU32::new(0)))
         .await;
-    // Every subsequent embed attempt failed too — never reset by a success.
-    state.embedder_stall_tracker.record_timeout();
-    state.embedder_stall_tracker.record_timeout();
-    state.embedder_stall_tracker.record_timeout();
 
     let teardown_calls = OrchestratorArc::new(AtomicUsize::new(0));
+    let fake_teardown = FakeTeardown::new(OrchestratorArc::clone(&teardown_calls));
+    // The definitive signal: the supervisor genuinely gave up.
+    fake_teardown
+        .terminated
+        .store(true, std::sync::atomic::Ordering::Release);
     let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
-        OrchestratorArc::new(FakeTeardown {
-            calls: OrchestratorArc::clone(&teardown_calls),
-        });
+        OrchestratorArc::new(fake_teardown);
     let (fake_ops, build_calls) = FakeSwapBackOps::new();
     let ops: OrchestratorArc<dyn SwapBackOps> = OrchestratorArc::clone(&fake_ops) as _;
 
@@ -1792,7 +1844,6 @@ async fn swap_back_fires_on_confirmed_death() {
             teardown,
             ops,
             SwapBackDuration::from_millis(5),
-            2,
         ),
     )
     .await
@@ -1836,10 +1887,9 @@ async fn swap_back_stops_watching_once_backend_already_moved() {
     ));
     let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
 
+    let teardown_calls = OrchestratorArc::new(AtomicUsize::new(0));
     let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
-        OrchestratorArc::new(FakeTeardown {
-            calls: OrchestratorArc::new(AtomicUsize::new(0)),
-        });
+        OrchestratorArc::new(FakeTeardown::new(teardown_calls));
     let (fake_ops, build_calls) = FakeSwapBackOps::new();
     let ops: OrchestratorArc<dyn SwapBackOps> = OrchestratorArc::clone(&fake_ops) as _;
 
@@ -1851,7 +1901,6 @@ async fn swap_back_stops_watching_once_backend_already_moved() {
             teardown,
             ops,
             SwapBackDuration::from_millis(5),
-            2,
         ),
     )
     .await
@@ -1867,18 +1916,16 @@ async fn swap_back_stops_watching_once_backend_already_moved() {
 /// Real-hardware end-to-end (epic #3524 slice 6, PR 4/5). Every other test in
 /// this module drives the watchdog with fakes/spies; this is the one place
 /// that proves the FULL real stack — a real `trusty-embedderd-py` child,
-/// killed past `max_restarts`, the real `EmbedPool` recording real embed
-/// failures into the real `EmbedderStallTracker`, the real
-/// `drive_swap_back_watchdog`, and a real axum router's `/health` + search
-/// endpoints — actually falls back and keeps serving.
+/// killed past `max_restarts`, the REAL `EmbedderSupervisor::terminated_signal`
+/// firing, the real `drive_swap_back_watchdog`, and a real axum router's
+/// `/health` + search endpoints — actually falls back and keeps serving.
 ///
-/// Why: every other test substitutes a fake `SwapBackOps`/pid-slot/tracker
+/// Why: every other test substitutes a fake `SwapBackOps` / `PythonAdapterTeardown`
 /// so the pure predicate and state-machine logic can be verified
 /// deterministically in milliseconds. None of them prove that a REAL
-/// `EmbedderSupervisor` crash-restart exhaustion actually produces the exact
-/// signal `is_confirmed_dead` depends on (pid slot pinned at 0, `client_slot`
-/// never reset so every subsequent embed keeps failing rather than
-/// transparently respawning) — this test is that proof, on real hardware.
+/// `EmbedderSupervisor` crash-restart exhaustion actually flips
+/// `terminated_signal` end-to-end through `LazyEmbedderHandle::is_confirmed_terminated()`
+/// — this test is that proof, on real hardware.
 ///
 /// Requires a real `trusty-embedderd-py` launcher discoverable on PATH (or
 /// `TRUSTY_EMBEDDERD_PY_BIN`) with its `uv`-managed venv already bootstrapped
@@ -1891,25 +1938,23 @@ async fn swap_back_stops_watching_once_backend_already_moved() {
 /// What: builds a real `LazyEmbedderHandle` (max_restarts=1, idle-shutdown
 /// disabled so only this test's kills matter) around the python launcher,
 /// forces the first spawn with a real embed call, then repeatedly SIGKILLs
-/// whatever child pid is currently live until the pid slot settles at `0`
-/// and stays there (confirming the supervisor gave up rather than mid-crash-
-/// restart). Wraps the handle in a real `SwitchableEmbedder` (active =
-/// Python/Ready, mirroring what PR-3's hot-swap installs) and a real
-/// `EmbedPool` with a real `EmbedderStallTracker`; issues a few real `.embed()`
-/// calls against the dead sidecar (each records a real timeout). Runs the
-/// real `drive_swap_back_watchdog` (short poll interval, bounded by an
-/// overall test timeout) and waits for it to act. Finally boots a real axum
-/// router (`service::server::build_router`) on an ephemeral port and asserts,
-/// via real HTTP calls: `GET /health` reports `embedder_bootstrap:
+/// whatever child pid is currently live until `handle.is_confirmed_terminated()`
+/// itself reports `true` (the real supervisor gave up — no fabricated
+/// stall-tracker state needed, unlike the pre-fix version of this test).
+/// Wraps the handle in a real `SwitchableEmbedder` (active = Python/Ready,
+/// mirroring what PR-3's hot-swap installs). Runs the real
+/// `drive_swap_back_watchdog` (short poll interval, bounded by an overall
+/// test timeout) and waits for it to act. Finally boots a real axum router
+/// (`service::server::build_router`) on an ephemeral port and asserts, via
+/// real HTTP calls: `GET /health` reports `embedder_bootstrap:
 /// "fell_back_to_ort"`, and a real search against a freshly-registered empty
-/// index still returns `200` (proving search is unaffected, not just that the
-/// switchable's in-memory state flipped).
+/// index still returns `200` (proving search is unaffected, not just that
+/// the switchable's in-memory state flipped).
 /// Test: this test.
 #[tokio::test]
 #[ignore = "requires a real trusty-embedderd-py launcher + bootstrapped torch/MPS venv \
             (Apple Silicon + uv) — not run in CI"]
 async fn swap_back_real_hardware_kills_sidecar_past_max_restarts() {
-    use crate::service::embed_pool::{EmbedPool, RequestPriority};
     use crate::service::embedder_supervisor::LazyEmbedderHandle;
     use std::sync::atomic::Ordering;
     use std::time::Instant;
@@ -1937,10 +1982,8 @@ async fn swap_back_real_hardware_kills_sidecar_past_max_restarts() {
     let pid1 = pid_slot.load(Ordering::Acquire);
     assert!(pid1 > 0, "expected a live child after the first embed");
 
-    // Repeatedly SIGKILL whatever child is currently live until the pid slot
-    // settles at 0 and STAYS there for a few seconds straight — proof the
-    // supervisor gave up (exhausted max_restarts) rather than being mid
-    // crash-restart.
+    // Repeatedly SIGKILL whatever child is currently live until the REAL
+    // supervisor signal confirms it gave up — no fabricated state.
     let deadline = Instant::now() + SwapBackDuration::from_secs(90);
     loop {
         let current = pid_slot.load(Ordering::Acquire);
@@ -1951,64 +1994,30 @@ async fn swap_back_real_hardware_kills_sidecar_past_max_restarts() {
         }
         tokio::time::sleep(SwapBackDuration::from_millis(500)).await;
 
-        if pid_slot.load(Ordering::Acquire) == 0 {
-            tokio::time::sleep(SwapBackDuration::from_secs(3)).await;
-            if pid_slot.load(Ordering::Acquire) == 0 {
-                break;
-            }
+        if handle.is_confirmed_terminated().await {
+            break;
         }
         assert!(
             Instant::now() < deadline,
-            "sidecar kept restarting past the 90s test deadline — \
-             max_restarts=1 was not exhausted?"
+            "sidecar kept restarting (or terminated_signal never flipped) \
+             past the 90s test deadline — max_restarts=1 was not exhausted?"
         );
     }
 
-    // Wrap the (now-dead) handle exactly like PR-3's hot-swap does, and run
-    // a few real embeds through a real EmbedPool + real stall tracker so the
-    // watchdog's real signal is populated the same way production traffic
-    // would populate it.
+    // Wrap the (now-dead) handle exactly like PR-3's hot-swap does.
     let adapter: OrchestratorArc<dyn crate::core::Embedder> =
         OrchestratorArc::new(super::embedder::LazySlotEmbedderAdapter {
             handle: OrchestratorArc::clone(&handle),
             is_python: true,
         });
-    let switchable = OrchestratorArc::new(SwitchableEmbedder::new(
-        OrchestratorArc::clone(&adapter),
-        test_python_ready_active(),
-    ));
-    let switchable_dyn: OrchestratorArc<dyn crate::core::Embedder> =
-        OrchestratorArc::clone(&switchable) as _;
+    let switchable =
+        OrchestratorArc::new(SwitchableEmbedder::new(adapter, test_python_ready_active()));
 
     let state = SearchAppState::new(crate::core::registry::IndexRegistry::new());
     state.install_switchable_embedder(OrchestratorArc::clone(&switchable));
     state
-        .install_embedder(OrchestratorArc::clone(&switchable_dyn))
-        .await;
-    state
         .install_embedderd_pid_slot(OrchestratorArc::clone(&pid_slot))
         .await;
-
-    let pool = OrchestratorArc::new(
-        EmbedPool::with_autotune(switchable_dyn)
-            .with_stall_tracker(OrchestratorArc::clone(&state.embedder_stall_tracker)),
-    );
-    state
-        .install_embed_pool(OrchestratorArc::clone(&pool))
-        .await;
-
-    for _ in 0..3 {
-        let _ = pool
-            .embed(
-                vec!["probe against a dead sidecar".to_string()],
-                RequestPriority::Interactive,
-            )
-            .await;
-    }
-    assert!(
-        state.embedder_stall_tracker.recent_timeout_count() > 0,
-        "embeds against the dead sidecar must have recorded real timeouts"
-    );
 
     let teardown: OrchestratorArc<dyn super::graceful_bootstrap::PythonAdapterTeardown> =
         OrchestratorArc::clone(&handle) as _;
@@ -2022,7 +2031,6 @@ async fn swap_back_real_hardware_kills_sidecar_past_max_restarts() {
             teardown,
             ops,
             SwapBackDuration::from_secs(1),
-            2,
         ),
     )
     .await

--- a/crates/trusty-search/src/service/embedder_supervisor/mod.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/mod.rs
@@ -267,6 +267,12 @@ struct SpawnedState {
     /// clone if the caller drops their reference.
     #[allow(dead_code)]
     pid_slot: Arc<AtomicU32>,
+    /// Definitive "the supervisor for THIS spawn gave up permanently" signal
+    /// (epic #3524 slice 6 PR-4 follow-up, code-critic BLOCK on PR #3584).
+    /// `None` only in hand-seeded test states that never went through
+    /// `do_spawn`. See [`LazyEmbedderHandle::is_confirmed_terminated`] for
+    /// why this exists instead of inferring death from the pid slot alone.
+    terminated: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
 /// Deferred-spawn handle for the `trusty-embedderd` sidecar (issue #315).
@@ -574,6 +580,42 @@ impl LazyEmbedderHandle {
             handle.shutdown().await;
         }
     }
+
+    /// Definitive "the underlying supervisor gave up permanently" check
+    /// (epic #3524 slice 6 PR-4 follow-up, code-critic BLOCK on PR #3584).
+    ///
+    /// Why: the swap-back watchdog originally inferred death from
+    /// `app_pid_slot == 0` combined with `EmbedderStallTracker::recent_timeout_count()
+    /// > 0` — a heuristic with a real false-positive window: an ordinary
+    /// idle-shutdown ALSO zeroes the pid slot, and a stale non-zero timeout
+    /// count left over from an earlier transient failure is never cleared by
+    /// idle-shutdown (only a subsequent SUCCESSFUL embed clears it via
+    /// `record_success`), so a quiet period with zero further embed traffic
+    /// after an idle-shutdown could satisfy the old heuristic and
+    /// permanently swap away a perfectly healthy backend. This method
+    /// answers the question unambiguously instead.
+    /// What: `true` iff a sidecar is currently "spawned" from this handle's
+    /// perspective (`state` is `Some`) AND that spawn's supervisor set its
+    /// [`trusty_common::embedder_client::EmbedderSupervisor::terminated_signal`]
+    /// to `true` (exhausted `max_restarts` / a wedge-restart storm — never a
+    /// clean exit or an intentional `shutdown()`). Returns `false` whenever
+    /// `state` is `None` — which covers BOTH "never spawned yet" and "an
+    /// idle-shutdown (or an explicit `shutdown()`) already reset the spawn
+    /// gate": in either case there is no reason to believe this handle is
+    /// unrecoverably dead, so `false` is the only safe answer.
+    /// Test: `lazy_handle_is_confirmed_terminated_false_when_never_spawned`,
+    /// `lazy_handle_is_confirmed_terminated_reflects_supervisor_signal` in
+    /// this module's `tests` submodule.
+    pub async fn is_confirmed_terminated(&self) -> bool {
+        let guard = self.state.lock().await;
+        match guard.as_ref() {
+            Some(spawned) => spawned
+                .terminated
+                .as_ref()
+                .is_some_and(|flag| flag.load(AtomicOrdering::Acquire)),
+            None => false,
+        }
+    }
 }
 
 /// RAII guard that tracks an in-flight embed request (issue #2315).
@@ -732,6 +774,12 @@ async fn do_spawn(
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
 
+    // Capture the definitive "gave up permanently" signal (epic #3524 slice
+    // 6 PR-4 follow-up) BEFORE detaching — `start_supervisor_task` consumes
+    // `supervisor`, so this is the last point it's reachable, mirroring how
+    // `child_pid_slot` above is captured from `spawn_stdio`'s return tuple.
+    let terminated = supervisor.terminated_signal();
+
     // Detach the crash-restart loop. `start_supervisor_task` returns a
     // `SupervisorHandle` (issue #2979) that `idle_watchdog` uses for
     // cooperative shutdown — flipping its internal shutdown flag makes the
@@ -765,6 +813,7 @@ async fn do_spawn(
         supervisor_handle: Some(supervisor_handle),
         shutdown_tx,
         pid_slot: child_pid_slot,
+        terminated: Some(terminated),
     })
 }
 

--- a/crates/trusty-search/src/service/embedder_supervisor/switchable.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/switchable.rs
@@ -199,32 +199,41 @@ impl SwitchableEmbedder {
     /// forever) while explicitly staying on the still-installed ort
     /// backend — i.e. `inner` must NOT change. [`Self::swap_to`] always
     /// replaces both fields together, so it is the wrong tool here.
-    /// What: reads the current [`ActiveBackend`], clones every field except
-    /// `bootstrap`, and stores a fresh snapshot with `bootstrap` replaced.
+    /// What: a compare-and-swap retry loop (`ArcSwap::rcu`) that reads the
+    /// CURRENT `active` snapshot, clones every field except `bootstrap`,
+    /// and attempts to install a fresh snapshot with `bootstrap` replaced —
+    /// retrying against whatever the latest value is if a concurrent writer
+    /// (another `set_bootstrap_state` call, or [`Self::swap_to`]) landed
+    /// first.
     ///
-    /// Concurrency note (code-critic LOW, epic #3524 slice 6 PR-3 review):
-    /// this is a non-atomic read-modify-write on `active` — `self.active()`
-    /// then `self.active.store(..)` — NOT a compare-and-swap. Two concurrent
-    /// callers (or a concurrent [`Self::swap_to`]) can race: the read in one
-    /// call may be stale by the time its store lands, silently clobbering
-    /// whatever the other caller/`swap_to` just wrote. Safe today ONLY
-    /// because the graceful-default orchestrator (PR-3) is the sole writer
-    /// of `bootstrap` transitions and never runs concurrently with itself
-    /// (one orchestrator task per daemon lifetime, swap-in only). PR-4
-    /// (swap-back-on-death) introduces a SECOND writer of `active` racing
-    /// this one — at that point this method must become a real CAS loop
-    /// (`ArcSwap::rcu` or a compare-and-swap retry) instead of a plain
-    /// load-then-store.
-    /// Test: `set_bootstrap_state_leaves_inner_untouched`.
+    /// Concurrency note (code-critic LOW, epic #3524 slice 6 PR-3 review;
+    /// fixed in PR-4/5): the PR-3 implementation was a non-atomic
+    /// read-modify-write — `self.active()` then `self.active.store(..)` —
+    /// NOT a compare-and-swap. It was safe only because the graceful-default
+    /// orchestrator (PR-3) was the sole writer of `bootstrap` transitions and
+    /// never ran concurrently with itself. PR-4's swap-back watchdog
+    /// introduces a SECOND writer of `active` (racing this one when the
+    /// watchdog's `swap_to` and a stray `set_bootstrap_state` call overlap),
+    /// so this is now a real `ArcSwap::rcu` CAS loop: `rcu` re-invokes the
+    /// closure against the LATEST value on every failed
+    /// `compare_and_swap`, so a `set_bootstrap_state` call that started
+    /// against a stale (pre-`swap_to`) snapshot can never resurrect that
+    /// stale `kind`/`provider`/`model` — it always retries against whatever
+    /// `swap_to` (or another `set_bootstrap_state` call) most recently
+    /// installed, and its own `bootstrap` write is layered on top rather than
+    /// lost.
+    /// Test: `set_bootstrap_state_leaves_inner_untouched`,
+    /// `set_bootstrap_state_cas_survives_concurrent_swap_to`.
     pub fn set_bootstrap_state(&self, new_state: BootstrapState) {
-        let current = self.active();
-        self.active.store(Arc::new(ActiveBackend {
-            kind: current.kind,
-            provider: current.provider,
-            model: current.model.clone(),
-            quantized: current.quantized,
-            bootstrap: new_state,
-        }));
+        self.active.rcu(|current| {
+            Arc::new(ActiveBackend {
+                kind: current.kind,
+                provider: current.provider,
+                model: current.model.clone(),
+                quantized: current.quantized,
+                bootstrap: new_state,
+            })
+        });
     }
 
     /// Snapshot the currently-installed backend itself.
@@ -475,5 +484,88 @@ mod tests {
 
         // The last swap_to call in the loop above installed Python.
         assert_eq!(sw.active().kind, BackendKind::Python);
+    }
+
+    /// Regression test for the code-critic LOW fixed in PR-4/5: a concurrent
+    /// [`SwitchableEmbedder::swap_to`] and a burst of
+    /// [`SwitchableEmbedder::set_bootstrap_state`] calls must never lose
+    /// either side's update — the CAS retry loop in `set_bootstrap_state`
+    /// (via `ArcSwap::rcu`) must re-read the LATEST `active` snapshot on
+    /// every retry rather than resurrecting a stale one captured before
+    /// `swap_to` ran.
+    ///
+    /// Why: the pre-fix implementation was a plain read-then-store. Had a
+    /// `set_bootstrap_state` call read `active` (kind=Ort) BEFORE `swap_to`
+    /// installed kind=Python, and then stored its own `Failed` write AFTER
+    /// `swap_to` returned, that store would silently overwrite `swap_to`'s
+    /// just-written `kind=Python` with a resurrected, stale `kind=Ort` —
+    /// exactly the lost-update race this test targets.
+    ///
+    /// What: spawns many tasks that each hammer `set_bootstrap_state(Failed)`
+    /// in a tight, yielding loop; while they are in flight, the main task
+    /// yields a few times (to let some iterations interleave with the
+    /// upcoming write) and then calls `swap_to` exactly once, installing
+    /// `kind=Python` with `bootstrap=NotApplicable`. The hammering tasks keep
+    /// running (and keep calling `set_bootstrap_state(Failed)`) for a while
+    /// longer after `swap_to` returns, so the very last `set_bootstrap_state`
+    /// call is guaranteed to run chronologically after `swap_to`. Asserts
+    /// both effects are observable in the final snapshot:
+    ///   - `kind == Python` (proves `swap_to`'s write was never resurrected
+    ///     back to the stale `Ort` a racing `set_bootstrap_state` caller may
+    ///     have read).
+    ///   - `bootstrap == Failed` (proves the last `set_bootstrap_state` call
+    ///     — which necessarily ran after `swap_to` — was correctly layered on
+    ///     top of the new `Python` snapshot rather than being lost).
+    /// Test: this test.
+    #[tokio::test]
+    async fn set_bootstrap_state_cas_survives_concurrent_swap_to() {
+        let fake_ort: Arc<dyn Embedder> = Arc::new(FakeEmbedder::new());
+        let sw = Arc::new(SwitchableEmbedder::new(
+            fake_ort,
+            test_active(BackendKind::Ort),
+        ));
+
+        let mut handles = Vec::new();
+        for _ in 0..20 {
+            let sw = Arc::clone(&sw);
+            handles.push(tokio::spawn(async move {
+                for _ in 0..25 {
+                    sw.set_bootstrap_state(BootstrapState::Failed);
+                    tokio::task::yield_now().await;
+                }
+            }));
+        }
+
+        // Let some hammering iterations run before the swap so at least one
+        // `set_bootstrap_state` call is racing against a still-Ort snapshot.
+        for _ in 0..5 {
+            tokio::task::yield_now().await;
+        }
+
+        let fake_python: Arc<dyn Embedder> = Arc::new(FakeEmbedder::new());
+        let mut python_active = test_active(BackendKind::Python);
+        python_active.bootstrap = BootstrapState::NotApplicable;
+        sw.swap_to(fake_python, python_active);
+
+        // Let the hammering tasks keep running past the swap so the LAST
+        // set_bootstrap_state call is guaranteed to be chronologically after
+        // swap_to.
+        for h in handles {
+            h.await.expect("hammering task panicked");
+        }
+
+        let active = sw.active();
+        assert_eq!(
+            active.kind,
+            BackendKind::Python,
+            "swap_to's kind must never be resurrected by a racing, stale \
+             set_bootstrap_state write"
+        );
+        assert_eq!(
+            active.bootstrap,
+            BootstrapState::Failed,
+            "the last set_bootstrap_state call (necessarily after swap_to) \
+             must still be observable, layered on top of the new backend"
+        );
     }
 }

--- a/crates/trusty-search/src/service/embedder_supervisor/tests.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/tests.rs
@@ -1021,7 +1021,10 @@ exit 1
             binary,
             SupervisorConfig {
                 startup_timeout_secs: 5,
-                backoff_max_secs: 1,
+                // Zero backoff so the crash -> respawn -> exhaustion sequence
+                // completes as fast as possible; this test asserts on the
+                // give-up signal, not on backoff timing.
+                backoff_max_secs: 0,
                 max_restarts: 1,
                 idle_shutdown_secs: 0, // no watchdog racing this test
                 ..SupervisorConfig::default()
@@ -1039,7 +1042,11 @@ exit 1
             .embed_via(|client| async move { client.embed_batch(vec!["probe".to_string()]).await })
             .await;
 
-        let gave_up = tokio::time::timeout(Duration::from_secs(10), async {
+        // Generous ceiling (45s) so a loaded CI runner cannot false-fail —
+        // the poll interval is short (20ms) so a passing run still returns
+        // in milliseconds; only a genuinely stuck supervisor eats the full
+        // budget.
+        let gave_up = tokio::time::timeout(Duration::from_secs(45), async {
             loop {
                 if handle.is_confirmed_terminated().await {
                     return;
@@ -1050,7 +1057,7 @@ exit 1
         .await;
         assert!(
             gave_up.is_ok(),
-            "is_confirmed_terminated() never flipped true within 10s of \
+            "is_confirmed_terminated() never flipped true within 45s of \
              exhausting max_restarts=1 against an always-crashing mock child"
         );
     }

--- a/crates/trusty-search/src/service/embedder_supervisor/tests.rs
+++ b/crates/trusty-search/src/service/embedder_supervisor/tests.rs
@@ -450,6 +450,7 @@ async fn lazy_handle_supervisor_gave_up_reflects_handle_state() {
         supervisor_handle: None,
         shutdown_tx,
         pid_slot: Arc::new(AtomicU32::new(0)),
+        terminated: None,
     });
 
     assert!(
@@ -592,6 +593,7 @@ async fn lazy_handle_last_reported_device_reflects_client() {
         supervisor_handle: None,
         shutdown_tx,
         pid_slot: Arc::new(AtomicU32::new(0)),
+        terminated: None,
     });
 
     assert_eq!(
@@ -628,6 +630,7 @@ async fn lazy_handle_idle_shutdown_waits_for_inflight_request() {
         supervisor_handle: None,
         shutdown_tx,
         pid_slot: inner_pid_slot,
+        terminated: None,
     })));
     let app_pid_slot = Arc::new(AtomicU32::new(0));
     // Already well past the 1s idle window.
@@ -724,6 +727,7 @@ async fn embed_via_defers_watchdog_eviction_while_request_in_flight() {
             supervisor_handle: None,
             shutdown_tx,
             pid_slot: Arc::new(AtomicU32::new(0)),
+            terminated: None,
         });
     }
     // Mark last_use as already well past the 1s idle deadline so the
@@ -875,6 +879,33 @@ done
         (dir, path)
     }
 
+    /// Like `write_mock_embedderd`, but answers exactly one request and then
+    /// exits non-zero — drives the real `EmbedderSupervisor` into its
+    /// crash-restart path deterministically (epic #3524 slice 6 PR-4
+    /// follow-up, code-critic BLOCK on PR #3584).
+    /// Why/What: see `trusty_common::embedder_client::supervisor`'s own
+    /// `write_mock_embedderd_crash_once` (private to that crate —
+    /// reimplemented here, identical wire behaviour).
+    fn write_mock_embedderd_crash_once() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("mock-embedderd-crash-once.sh");
+        std::fs::write(
+            &path,
+            r#"#!/bin/sh
+IFS= read -r line
+id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+[ -n "$id" ] || id=1
+printf '{"jsonrpc":"2.0","result":{"embeddings":[[0.1]]},"id":%s}\n' "$id"
+exit 1
+"#,
+        )
+        .expect("write mock script");
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod +x");
+        (dir, path)
+    }
+
     /// Best-effort liveness check via `kill -0 <pid>` (no signal sent, just
     /// an existence probe).
     fn process_alive(pid: u32) -> bool {
@@ -951,6 +982,76 @@ done
             handle.app_pid_slot().load(Ordering::Acquire),
             0,
             "pid slot must be cleared after shutdown()"
+        );
+    }
+
+    /// `is_confirmed_terminated()` must be `false` when the handle has never
+    /// spawned anything — there is no reason to believe an unspawned handle
+    /// is "unrecoverably dead" (epic #3524 slice 6 PR-4 follow-up,
+    /// code-critic BLOCK on PR #3584).
+    /// Test: this test.
+    #[tokio::test]
+    async fn lazy_handle_is_confirmed_terminated_false_when_never_spawned() {
+        let handle = LazyEmbedderHandle::new(
+            PathBuf::from("/nonexistent/trusty-embedderd"),
+            SupervisorConfig::default(),
+        );
+        assert!(!handle.is_confirmed_terminated().await);
+    }
+
+    /// `is_confirmed_terminated()` must reflect the REAL underlying
+    /// `EmbedderSupervisor::terminated_signal()` once it flips true —
+    /// proving the wiring through `do_spawn` → `SpawnedState::terminated`
+    /// actually works end-to-end, not just the pure predicate in
+    /// `swap_back_watchdog`'s own tests (which use a fake).
+    ///
+    /// Why: this is the regression the swap-back watchdog now depends on
+    /// instead of the ambiguous pid==0 + stall-tracker heuristic (see
+    /// `commands::start::swap_back_watchdog`'s module doc for the full
+    /// false-positive analysis).
+    /// What: a real, always-crashing mock child (`write_mock_embedderd_crash_once`)
+    /// with `max_restarts: 1` so exhaustion is fast. Forces the first real
+    /// spawn via `embed_via`, then polls `is_confirmed_terminated()` until it
+    /// flips `true` (the real supervisor gave up) within a generous timeout.
+    /// Test: this test.
+    #[tokio::test]
+    async fn lazy_handle_is_confirmed_terminated_reflects_supervisor_signal() {
+        let (_dir, binary) = write_mock_embedderd_crash_once();
+        let handle = LazyEmbedderHandle::new(
+            binary,
+            SupervisorConfig {
+                startup_timeout_secs: 5,
+                backoff_max_secs: 1,
+                max_restarts: 1,
+                idle_shutdown_secs: 0, // no watchdog racing this test
+                ..SupervisorConfig::default()
+            },
+        );
+        assert!(
+            !handle.is_confirmed_terminated().await,
+            "must start false — nothing has failed yet"
+        );
+
+        // Force the first real spawn; the mock crashes immediately after,
+        // and every respawn attempt crashes the same way, so max_restarts=1
+        // is exhausted quickly.
+        let _ = handle
+            .embed_via(|client| async move { client.embed_batch(vec!["probe".to_string()]).await })
+            .await;
+
+        let gave_up = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if handle.is_confirmed_terminated().await {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(
+            gave_up.is_ok(),
+            "is_confirmed_terminated() never flipped true within 10s of \
+             exhausting max_restarts=1 against an always-crashing mock child"
         );
     }
 }


### PR DESCRIPTION
## Summary

PR-4 of the graceful-default embedder work (epic #3524 slice 6). Adds the
swap-BACK watchdog: if the python/MPS sidecar dies past recovery after a
hot-swap (PR-3), swap the active embedder back to ort so search never
degrades permanently.

- New `commands/start/swap_back_watchdog.rs`: a detached watchdog spawned
  right after a successful ort→python hot-swap. Polls every 15s (bounded,
  quiet — not a tight loop) and swaps back to a fresh ort backend on
  **confirmed** death.
- **The swap-back predicate** (the false-positive hazard called out in the
  spec): fires only when `active.kind == Python && pid_slot == 0 &&
  recent_timeout_count > 0`, confirmed across 2 consecutive polling ticks.
  Bare pid-zero is deliberately NOT the trigger — the pid slot also reads 0
  on ordinary idle-shutdown (`LazyEmbedderHandle`'s own idle watchdog), whose
  next successful respawn resets `EmbedderStallTracker::recent_timeout_count`
  to `0`, keeping the predicate false. Only a genuinely dead sidecar (the
  `EmbedderSupervisor` exhausted `TRUSTY_EMBEDDERD_MAX_RESTARTS`) keeps every
  subsequent embed attempt failing, because `LazyEmbedderHandle`'s own spawn
  gate is never reset in that case (only the idle watchdog or an explicit
  `shutdown()` reset it) — so `recent_timeout_count` stays non-zero.
- On confirmed death: builds a fresh ort backend via the same
  `build_ort_stdio_sidecar()` the daemon's default path uses, hot-swaps
  `SwitchableEmbedder` to it (`ActiveBackend { kind: Ort, bootstrap:
  FellBackToOrt }`), reinstalls the ort pid slot, and cleanly shuts down the
  dead python handle via `LazyEmbedderHandle::shutdown()` — no orphan. Logs
  loudly at `warn`.
- **CAS upgrade** (code-critic LOW follow-up from the PR-3 review):
  `SwitchableEmbedder::set_bootstrap_state` was a non-atomic
  read-modify-write, safe only while PR-3's orchestrator was the sole
  writer. PR-4 introduces a second writer (the watchdog's own `swap_to`), so
  `set_bootstrap_state` now uses `ArcSwap::rcu` — a real CAS retry loop —
  proven by a new concurrency stress test
  (`set_bootstrap_state_cas_survives_concurrent_swap_to`).
- `drive_bootstrap` (`graceful_bootstrap.rs`) now returns the python
  adapter's teardown handle on success so `run_graceful_python_bootstrap` can
  hand it to the watchdog — a pure return-type addition; no existing PR-3
  test needed to change.

**Default stays OFF** — still gated behind `TRUSTY_PY_DEFAULT` (unset/off).
This PR ships as a no-op for real users, same as PR-3.

## Tests

- `swap_back_fires_on_confirmed_death` — pid 0 + repeated embed failure →
  `swap_to(Ort, FellBackToOrt)` fires once, python handle torn down, ort pid
  slot reinstalled.
- `swap_back_does_not_fire_on_idle_shutdown_respawn` — THE false-positive
  regression test: pid 0 but embeds keep succeeding (respawn works) → never
  fires.
- `swap_back_does_not_fire_while_healthy` — healthy python (nonzero pid) →
  never fires.
- `swap_back_stops_watching_once_backend_already_moved` — active backend no
  longer python → watchdog exits promptly, never acts.
- `is_confirmed_dead_predicate_matrix` — exhaustive matrix over the pure
  predicate.
- `set_bootstrap_state_cas_survives_concurrent_swap_to` — concurrent
  `swap_to` + `set_bootstrap_state` never lose either side's update.
- `swap_back_real_hardware_kills_sidecar_past_max_restarts` (`#[ignore]`) —
  kills a REAL `trusty-embedderd-py` child past `max_restarts`, runs the real
  watchdog, and asserts a real `/health` shows
  `embedder_bootstrap=fell_back_to_ort` and a real search call still
  succeeds. Not run in CI (requires bootstrapped torch/MPS venv on Apple
  Silicon).

All fakes/spies — no real torch/MPS/subprocess in the CI-run test suite.

## Gate (raw output)

```
cargo test -p trusty-search (lib target)
test result: FAILED. 1205 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out
  (only failure: gitignore_entry_added_idempotently — known local-env failure)

cargo test -p trusty-search (bin target)
test result: FAILED. 293 passed; 1 failed; 1 ignored; 0 measured; 0 filtered out
  (only failure: migrate_storage_moves_files_and_updates_registry — known local-env failure)
  (the 1 ignored test is the new real-hardware e2e test above)

every integration test binary (tests/*.rs): all "ok", 0 failed

cargo clippy -p trusty-search -- -D warnings   -> clean
cargo clippy -p trusty-search --all-targets -- -D warnings -> clean
cargo fmt --check -p trusty-search             -> clean
scripts/check_line_cap.sh                      -> line-cap: 7 allowlisted, 0 violations — OK.
scripts/check_test_pointers.sh                 -> test-pointers: 0 dangling pointers — OK.
```

Both failures are the two known/pre-existing local-env failures called out
in the task spec — nothing else fails.

Refs #3524

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools