### PR TITLE
fix(trusty-mpm): route statusline + MCP-injection git spawns through spawn_disclaim

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/statusline/branch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/statusline/branch.rs
@@ -101,9 +101,19 @@ fn is_managed_session_branch(branch: &str) -> bool {
 /// Why: `statusline` is on Claude Code's hot render path; a stuck credential
 /// helper, network filesystem, or git hook would otherwise block every render
 /// cycle. The bounded thread + `recv_timeout` pattern matches
-/// [`super::compaction::compaction_segment`].
-/// What: spawns a detached thread that calls `git rev-parse`, sends the result
-/// over an mpsc channel; the caller waits ≤100 ms, returns `None` on timeout.
+/// [`super::compaction::compaction_segment`]. Spawns via
+/// [`trusty_mpm::core::spawn_disclaim::disclaimed_output`] (issue #3580) rather than
+/// a raw `Command::new("git")`: this runs on EVERY prompt render, so — of the
+/// three sites #3580 fixes — it is the highest-frequency undisclaimed spawn in
+/// the crate, making the signed `trusty-mpm` binary TCC's misattributed
+/// "responsible process" for a git child on every single render.
+/// What: spawns a detached thread that calls `git rev-parse` through
+/// `disclaimed_output`, sends the result over an mpsc channel; the caller waits
+/// ≤100 ms, returns `None` on timeout. `disclaimed_output` mirrors
+/// `Command::new(program).args(args).output()` exactly (same captured
+/// stdout/stderr, same success/failure semantics) — on macOS it just spawns via
+/// `posix_spawnp` with the TCC disclaim attribute set instead of `std`'s
+/// internal spawn path; on non-macOS (no TCC) it IS `Command::output()`.
 /// Test: `render_statusline_full_payload` (in `mod.rs`) exercises the detected
 /// branch path; covered here via [`select_branch_label`]'s fallback tests.
 fn git_branch(cwd: &str) -> Option<String> {
@@ -114,12 +124,14 @@ fn git_branch(cwd: &str) -> Option<String> {
     let (tx, rx) = mpsc::channel::<Option<String>>();
     std::thread::spawn(move || {
         let result = (|| -> Option<String> {
-            let out = std::process::Command::new("git")
-                .arg("-C")
-                .arg(&cwd)
-                .args(["rev-parse", "--abbrev-ref", "HEAD"])
-                .output()
-                .ok()?;
+            let args = [
+                "-C".to_string(),
+                cwd.clone(),
+                "rev-parse".to_string(),
+                "--abbrev-ref".to_string(),
+                "HEAD".to_string(),
+            ];
+            let out = trusty_mpm::core::spawn_disclaim::disclaimed_output("git", &args).ok()?;
             if !out.status.success() {
                 return None;
             }

--- a/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp.rs
@@ -88,6 +88,7 @@ use serde_json::Value;
 use super::PrepError;
 use super::settings::inject_mcp_server;
 use crate::core::mcp_config;
+use crate::core::spawn_disclaim::disclaimed_output;
 use crate::core::trusty_tools_config::managed_claude_config_dir;
 
 /// Basename of the git-excluded file native MCP server secrets are delivered
@@ -480,17 +481,28 @@ pub(super) fn route_mcp_secrets_to_env_local(
 /// guarantees nothing the child writes can reach our stdout regardless). Any
 /// non-zero exit — including "not ignored" (which is what a tracked file, or a
 /// file with no matching ignore rule, both report) and a hard error (not a repo,
-/// no `git` binary) — is treated as `false`. Never panics.
+/// no `git` binary) — is treated as `false`. Never panics. Spawns via
+/// [`disclaimed_output`] (issue #3580) rather than a raw `Command::new("git")`:
+/// this runs inside the daemon during MCP config injection into an arbitrary
+/// user repository, structurally identical to the tmux-hosted git spawns
+/// PR #3562 already disclaims — `disclaimed_output` mirrors
+/// `Command::new(program).args(args).output()`'s captured stdout/stderr and
+/// exit-status contract exactly, so this is a pure spawn-mechanism swap with
+/// no observable behavior change on non-macOS (or when the disclaim SPI is
+/// absent).
 /// Test: `inject_native_skips_secrets_when_env_local_is_tracked`,
 /// `is_env_local_actually_ignored_true_when_excluded`,
 /// `is_env_local_actually_ignored_false_when_tracked`.
 pub(super) fn is_env_local_actually_ignored(project_path: &Path) -> bool {
-    std::process::Command::new("git")
-        .arg("-C")
-        .arg(project_path)
-        .args(["check-ignore", "-q", "--", ENV_LOCAL_FILENAME])
-        .output()
-        .is_ok_and(|output| output.status.success())
+    let args = [
+        "-C".to_string(),
+        project_path.to_string_lossy().to_string(),
+        "check-ignore".to_string(),
+        "-q".to_string(),
+        "--".to_string(),
+        ENV_LOCAL_FILENAME.to_string(),
+    ];
+    disclaimed_output("git", &args).is_ok_and(|output| output.status.success())
 }
 
 /// Ensure `.env.local` is listed in the workspace's real `info/exclude` file.
@@ -514,16 +526,23 @@ pub(super) fn is_env_local_actually_ignored(project_path: &Path) -> bool {
 /// `project_path` is not a git repo, `git` is not on `PATH`, or the exclude
 /// file could not be created/written. The caller treats `Err` as "skip secret
 /// delivery entirely", never as license to write the secret file unexcluded.
+/// Spawns via [`disclaimed_output`] (issue #3580) rather than a raw
+/// `Command::new("git")` — see [`is_env_local_actually_ignored`]'s doc for why
+/// this call site is TCC-sensitive in the same way; same captured-output,
+/// same-error-handling contract, no observable behavior change.
 /// Test: `inject_native_env_local_is_git_excluded_and_unstaged`,
 /// `inject_native_secrets_skipped_outside_git_repo`,
 /// `ensure_env_local_git_excluded_is_idempotent`,
 /// `ensure_env_local_git_excluded_fails_outside_git_repo`.
 pub(super) fn ensure_env_local_git_excluded(project_path: &Path) -> Result<(), String> {
-    let output = std::process::Command::new("git")
-        .arg("-C")
-        .arg(project_path)
-        .args(["rev-parse", "--git-path", "info/exclude"])
-        .output()
+    let args = [
+        "-C".to_string(),
+        project_path.to_string_lossy().to_string(),
+        "rev-parse".to_string(),
+        "--git-path".to_string(),
+        "info/exclude".to_string(),
+    ];
+    let output = disclaimed_output("git", &args)
         .map_err(|e| format!("git rev-parse failed to spawn: {e}"))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
## Summary

Fixes #3580 — three raw `std::process::Command::new("git")` spawn sites bypassed `spawn_disclaim`, so macOS TCC attributed their file access to the signed `trusty-mpm` binary instead of the git child itself:

1. **`crates/trusty-mpm/src/bin/tm/commands/statusline/branch.rs` (`git_branch`)** — `git rev-parse --abbrev-ref HEAD`, runs on **every prompt render**. Highest-priority site: a strong candidate for the owner's long-running, unresolved recurring macOS App-Data TCC prompts (#2721/#2957/#2997) that code-signing fixes never addressed, since a hot-path raw spawn is a TCC-attribution problem no amount of binary signing can fix.
2. **`crates/trusty-mpm/src/core/session_launch/native_mcp.rs::is_env_local_actually_ignored`** — `git check-ignore`, runs during MCP config injection into arbitrary user repos.
3. **`crates/trusty-mpm/src/core/session_launch/native_mcp.rs::ensure_env_local_git_excluded`** — `git rev-parse --git-path info/exclude`, same context.

All three now spawn through `disclaimed_output` (existing primitive, `crates/trusty-mpm/src/core/spawn_disclaim/mod.rs`), matching the pattern PR #3562 established for the tmux-hosted spawns. No new primitives introduced.

## Behavior preservation

`disclaimed_output(program, args)` mirrors `Command::new(program).args(args).output()`'s contract exactly — same captured stdout/stderr, same exit-status semantics, same error propagation. On non-macOS (or with `TM_DISABLE_SPAWN_DISCLAIM` set) it IS `Command::output()` — a pure pass-through, zero behavior change. On macOS it spawns via `posix_spawnp` with the TCC disclaim attribute set instead of std's internal spawn path.

## Performance (statusline hot-path site)

`git_branch` already runs on a bounded background thread with a 100ms `recv_timeout` (existing design, unchanged). `disclaimed_output`'s macOS path (`spawn_disclaim/macos/capture.rs`) does the same fundamental work std's `Command::output()` does internally — `posix_spawn` + two CLOEXEC pipes + a helper thread draining stdout while the caller drains stderr concurrently (the same "avoid pipe-deadlock" shape std uses). The only added cost is one `dlsym(RTLD_DEFAULT, "responsibility_spawnattrs_setdisclaim")` lookup per call — a process-local symbol-table hash lookup, no syscall — plus the same CString/argv marshalling std's own `Command` already does internally. This is not a meaningfully different cost class from the raw spawn it replaces; no regression expected on the hot render path. (Not independently microbenchmarked; reasoning is from reading both implementations side by side — see PR discussion for detail if warranted.)

## Test-causality position

Per the precedent set in #3562: I did NOT fabricate a "fails before this fix" test. The defect this closes (TCC responsible-process misattribution) is not mechanically observable from a `cargo test` process — it requires macOS's TCC subsystem and a real consent-prompt trigger, neither of which is testable in CI. All three call sites already have existing test coverage for their OBSERVABLE contract (captured output, exit status, error handling) — `is_env_local_actually_ignored_*`, `ensure_env_local_git_excluded_*`, `git_owner_repo_*`/`render_project_segment_*`/`select_branch_label_*` — and all of it stays green after the swap, which is exactly the guarantee this PR makes: identical observable behavior, different spawn mechanism. No new tests were added because none of the three sites currently lacks coverage.

## Scope / remaining raw spawn audit

Per #3580's ask, I also audited the ~40 other raw spawn sites in the crate for TCC-sensitivity (touches user files/repos/protected dirs + runs on a hot/background path) vs benign (narrowly-scoped system utility, or a one-shot human-watched CLI action). Classification reported separately to the issue reporter — no further fixes are in this PR; scope is the three sites above only. PR #3562 (open, not touched by this PR) separately covers `provisioner::clone_progress` and `formatters::info_box::probes::run_git_log`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings`
- [x] `cargo test -p trusty-mpm` (all passing, including the three sites' existing coverage)
- [x] `bash scripts/check_line_cap.sh`
- [x] `bash scripts/check_test_pointers.sh`
- [x] `bash scripts/check_sld.sh`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools