### PR TITLE
fix(trusty-agents): gworkspace OpenRPC discovery silently found zero tools (#3577)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -129,11 +129,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`gworkspace` OpenRPC endpoint no longer silently discovers zero tools
+  (#3577):** `DirectDriver::discover()` deserialized `rpc.discover`'s raw
+  result directly into `EndpointManifest`, which expected a top-level
+  `tools` array; every real server (`trusty-memory`, `trusty-search`,
+  `trusty-gworkspace`) actually emits standard OpenRPC's `methods` array.
+  Because `EndpointManifest.tools` carried `#[serde(default)]`, the shape
+  mismatch deserialized successfully with `tools: vec![]` instead of
+  erroring — the `gworkspace` endpoint (enabled by default since #3056)
+  contributed zero tools in production with no error anywhere. New
+  `discovery::parse_manifest` recognizes the real `methods` shape (and the
+  legacy `tools` shape), converts each OpenRPC method into a
+  `DiscoveredTool` (JSON Schema `input_schema`/`output_schema`
+  reconstructed from `params[]`/`result.schema`), and resolves scope from
+  `x-scopes` (dotted string, used as-is) or `x-google-scopes` (OAuth URLs,
+  mapped to a dotted scope via the new `google_scope` module — classified
+  by what the OAuth grant permits, not by today's per-tool behavior). A
+  payload with neither `methods` nor `tools` now returns a hard error
+  naming the endpoint and the keys actually present, instead of silently
+  producing an empty tool list; a manifest that parses successfully but
+  advertises zero tools now logs a loud warning naming the endpoint.
+  `default-config.toml`'s gworkspace endpoint scopes gained
+  `google.slides.*` and `google.accounts.*`, without which the Slides and
+  local-account-management tools would parse but then be dropped by scope
+  filtering.
+
 - **Test-isolation cluster: env-var and CWD races between concurrently-running tests (issues #3398, #3516).**
   - `ctrl/tests/tools_tests.rs`'s `detect_self_project_finds_via_env_var` / `detect_self_project_returns_none_when_no_marker` used to mutate the process-global `TAGENT_PROJECT_DIR` env var directly, with no `#[serial]` guard — but `workflow::engine::executor::tests::checkpoint_resume` mutates the SAME var under its own `#[serial]` convention, so the unguarded pair could clobber it mid-flight and produce a `CheckpointNotFound` failure in a completely unrelated test (#3398). `ctrl::util::detect_self_project` now delegates to a new `detect_self_project_with_hint(Option<&str>)`; the tests call the hinted version directly, so no env var is touched at all.
   - `telegram::tests::tempdir_for_test` hand-rolled tempdir "uniqueness" from `std::process::id()` (constant across every thread of one test binary) plus a nanosecond timestamp, which can collide under very high `--test-threads` if two threads sample the same clock tick — silently sharing one `telegram.pid` fixture between two of the `telegram_pid_guard_*` tests (#3516). Now uses `tempfile::tempdir()`, which guarantees a collision-free unique directory.
   - `default_bundled_config_dir`'s legacy-migration test (`env_compat.rs`) used to `std::env::set_current_dir` into a scratch tempdir under `#[serial]` — but CWD is process-global exactly like an env var, and `api::server::tests` handler tests resolve their own CWD-relative paths (`.trusty-agents/projects`, `.trusty-agents/agents`) while holding a *different* lock (`HOME_LOCK`), so `#[serial]` alone did not protect them from this CWD swap. `default_bundled_config_dir` now delegates to a new `default_bundled_config_dir_checking(&Path)` that roots its existence checks at an explicit parameter; the test points it at a tempdir directly, so no CWD mutation occurs at all.
   - Verified with the full `trusty-agents` lib suite run repeatedly at `--test-threads=64` and `128` (9 full runs total) with zero failures in `checkpoint_resume`, `telegram_pid_guard_*`, `get_project_config_falls_back_to_registry_when_toml_missing`, or `gather_specs_does_not_spawn_mcp_add_discover_bypass` — not proof the underlying rare flakes (#3514, #3516's second sub-issue) are fully eliminated, but no regression observed either.
+
 - **Assistant can now actually delegate to bundled worker agents (`engineer`,
   `qa-agent`, …) regardless of the invoking CWD (#3555 follow-up):** a live
   run (`tagent --direct assistant --task "have an engineer run cargo check

--- a/crates/trusty-agents/assets/config/default-config.toml
+++ b/crates/trusty-agents/assets/config/default-config.toml
@@ -245,17 +245,27 @@ timeout_ms = 5000
 [[tool_registry.endpoints]]
 name = "gworkspace"
 driver = "direct"
-description = "Google Workspace — Gmail, Calendar, Drive, Docs, Sheets, Tasks"
+description = "Google Workspace — Gmail, Calendar, Drive, Docs, Sheets, Slides, Tasks"
 command = "trusty-gworkspace-mcp"
 args = []
 enabled = true
+# #3577: "google.slides.*" and "google.accounts.*" added alongside the
+# wire-format fix. Without them, the Slides tools (get_slides,
+# manage_slides, add_slide_content — Google's PRESENTATIONS OAuth scope)
+# and the local account-management tools (list_accounts, add_account,
+# remove_account, set_default_account — Google's USERINFO_PROFILE scope)
+# would parse correctly but then be dropped by scope filtering below,
+# reproducing a milder version of the same "endpoint contributes fewer
+# tools than it should" symptom this issue fixed.
 scopes = [
     "google.gmail.*",
     "google.calendar.*",
     "google.drive.*",
     "google.docs.*",
     "google.sheets.*",
+    "google.slides.*",
     "google.tasks.*",
+    "google.accounts.*",
 ]
 discovery_ttl_secs = 0
 eager_discovery = true

--- a/crates/trusty-agents/src/tools/registry/direct.rs
+++ b/crates/trusty-agents/src/tools/registry/direct.rs
@@ -34,7 +34,7 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use super::config::EndpointConfig;
-use super::discovery::{EndpointCapabilities, EndpointManifest};
+use super::discovery::{EndpointCapabilities, EndpointManifest, parse_manifest};
 use super::driver::{BatchCall, BatchResult, RegistryDriver};
 
 const PROTOCOL_VERSION: &str = "openrpc/1";
@@ -245,9 +245,13 @@ impl RegistryDriver for DirectDriver {
             "protocol_versions": [PROTOCOL_VERSION],
         });
         let v = self.rpc_call("rpc.discover", params).await?;
-        let manifest: EndpointManifest = serde_json::from_value(v.clone())
-            .with_context(|| format!("malformed rpc.discover result: {v}"))?;
-        Ok(manifest)
+        // #3577: `parse_manifest` recognizes both the real OpenRPC
+        // `methods[]` shape every current server emits and the legacy
+        // `tools[]` shape; a raw `serde_json::from_value::<EndpointManifest>`
+        // here (the pre-fix behavior) silently produced `tools: vec![]` on
+        // any shape mismatch instead of erroring — see
+        // `discovery::parse_manifest` for the full rationale.
+        parse_manifest(&self.name, &v)
     }
 
     async fn call_tool(&self, name: &str, args: Value) -> Result<Value> {

--- a/crates/trusty-agents/src/tools/registry/discovery.rs
+++ b/crates/trusty-agents/src/tools/registry/discovery.rs
@@ -5,14 +5,23 @@
 //! while a TTL keeps the registry honest about server-side changes.
 //! What: `DiscoveredTool` is one tool advertised by an endpoint;
 //! `EndpointManifest` is the full response shape. `DiscoveryCache` is a
-//! simple in-memory TTL map; eviction is lazy on read.
-//! Test: Round-trip serialization and TTL expiry covered below.
+//! simple in-memory TTL map; eviction is lazy on read. `parse_manifest`
+//! is the entry point that turns a raw `rpc.discover` JSON-RPC `result`
+//! into an `EndpointManifest` — see its doc comment for why this is no
+//! longer a bare `serde_json::from_value` call (#3577).
+//! Test: Round-trip serialization and TTL expiry covered below;
+//! `parse_manifest` wire-shape coverage in the `parse_manifest` tests
+//! module.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::google_scope::dotted_scope_for_google_scopes;
 
 /// `side_effects` field — kept as the OpenRPC enum.
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
@@ -78,6 +87,207 @@ fn default_protocol_version() -> String {
     "openrpc/1".to_string()
 }
 
+/// Parse a raw `rpc.discover` JSON-RPC `result` value into an
+/// `EndpointManifest`.
+///
+/// Why (#3577): every real `rpc.discover` implementation in this repo
+/// (`trusty-memory`, `trusty-search` — both via the shared
+/// `trusty_common::mcp::openrpc::discover_response` builder — and
+/// `trusty-gworkspace`, which predates that helper but emits the
+/// structurally identical envelope) is standard OpenRPC 1.3.2:
+/// `{ "openrpc": "1.3.2", "info": {...}, "methods": [...] }`. No endpoint
+/// anywhere in this codebase emits the bespoke `{ "tools": [...] }` shape
+/// this type used to deserialize directly via `serde_json::from_value`.
+/// Because `EndpointManifest.tools` carried `#[serde(default)]`, that call
+/// silently succeeded with `tools: vec![]` on every real payload instead
+/// of erroring — the exact bug this function replaces. This is a
+/// consume-side fix, not an emit-side one: OpenRPC is the converged,
+/// deliberately-shared wire format across all three current/planned
+/// `driver = "direct"` endpoints, so teaching the client to speak it
+/// properly (rather than changing three server crates, one of which
+/// exists specifically to avoid this duplication) is the durable fix —
+/// the next OpenRPC server added to `[[tool_registry.endpoints]]` is
+/// consumable for free.
+///
+/// What: Recognizes a top-level `methods` array (the real, standard
+/// shape) and converts each entry via `method_to_tool`. A top-level
+/// `tools` array (the originally-speced-but-never-implemented shape,
+/// still exercised by this module's own round-trip tests and any future
+/// endpoint that happens to emit it) is accepted as-is by delegating to
+/// `serde_json::from_value`. When the raw value is a JSON object with
+/// NEITHER key, that is precisely the condition that used to silently
+/// deserialize to an empty tool list — this now returns a hard `Err`
+/// naming the endpoint, the top-level keys actually present, and the
+/// keys we know how to parse, so the failure is loud and diagnostic
+/// instead of indistinguishable from "this server genuinely has zero
+/// tools" (that legitimate case is handled one layer up, in
+/// `mod.rs::build_endpoint`, as a warning once a manifest DID parse).
+/// Test: `parse_manifest_methods_shape_gworkspace_fixture`,
+/// `parse_manifest_tools_shape_still_accepted`,
+/// `parse_manifest_unrecognized_shape_errors_loudly`.
+pub fn parse_manifest(endpoint: &str, raw: &Value) -> Result<EndpointManifest> {
+    let obj = raw.as_object().ok_or_else(|| {
+        anyhow::anyhow!(
+            "endpoint '{endpoint}': rpc.discover result is not a JSON object (got: {raw})"
+        )
+    })?;
+
+    if let Some(methods) = obj.get("methods") {
+        let methods = methods.as_array().ok_or_else(|| {
+            anyhow::anyhow!(
+                "endpoint '{endpoint}': rpc.discover `methods` is not an array (got: {methods})"
+            )
+        })?;
+        let mut tools = Vec::with_capacity(methods.len());
+        for (i, m) in methods.iter().enumerate() {
+            match method_to_tool(endpoint, m) {
+                Ok(t) => tools.push(t),
+                Err(e) => {
+                    tracing::warn!(
+                        endpoint = %endpoint,
+                        index = i,
+                        error = %e,
+                        "tool registry: skipping malformed OpenRPC method entry",
+                    );
+                }
+            }
+        }
+        let server = obj
+            .get("info")
+            .and_then(|info| {
+                Some(ServerInfo {
+                    name: info.get("title")?.as_str()?.to_string(),
+                    version: info
+                        .get("version")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                })
+            })
+            .unwrap_or_default();
+        return Ok(EndpointManifest {
+            server,
+            protocol_version: default_protocol_version(),
+            capabilities: EndpointCapabilities::default(),
+            tools,
+        });
+    }
+
+    if obj.contains_key("tools") {
+        return serde_json::from_value(raw.clone())
+            .with_context(|| format!("endpoint '{endpoint}': malformed `tools`-shaped manifest"));
+    }
+
+    let present_keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+    bail!(
+        "endpoint '{endpoint}': rpc.discover result has neither a `methods` array (standard \
+         OpenRPC, emitted by every trusty-* server today) nor a `tools` array (the legacy \
+         shape). Top-level keys present: {present_keys:?}. This is the #3577 failure mode: a \
+         wire-format we don't recognize must not silently deserialize to zero tools."
+    );
+}
+
+/// Convert one OpenRPC `methods[]` entry into a `DiscoveredTool`.
+///
+/// Why: OpenRPC represents a tool's input as `params[]` (one named
+/// `ContentDescriptor` per property) and its output as `result.schema`,
+/// while `DiscoveredTool` wants a single JSON Schema object for each —
+/// matching what `RegistryToolExecutor::schema()` hands the LLM as
+/// OpenAI-style function parameters (`adapter.rs`). Scope resolution
+/// prefers the generic `x-scopes` extension (already a dotted string,
+/// emitted by `trusty-memory`/`trusty-search` via the shared
+/// `trusty_common::mcp::openrpc` builder) and falls back to
+/// `x-google-scopes` (OAuth URLs, `trusty-gworkspace`-specific) via
+/// `google_scope::dotted_scope_for_google_scopes`.
+/// What: Rebuilds `input_schema` as `{"type":"object","properties":{...},
+/// "required":[...]}` from `params[]`; takes `output_schema` from
+/// `result.schema` when present. `idempotent`/`side_effects` are not part
+/// of the real wire format from any current server, so they keep their
+/// struct defaults (`false` / `SideEffects::None`) — this is the same
+/// `#[serde(default)]` behavior as before, but now applied to genuinely
+/// optional metadata rather than to the `tools` array itself.
+/// Test: `parse_manifest_methods_shape_gworkspace_fixture` covers the
+/// full conversion; `method_to_tool_errors_on_missing_name` covers the
+/// per-entry failure path.
+fn method_to_tool(endpoint: &str, method: &Value) -> Result<DiscoveredTool> {
+    let name = method
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("endpoint '{endpoint}': method entry missing `name`"))?
+        .to_string();
+
+    let description = method
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+    if let Some(params) = method.get("params").and_then(|v| v.as_array()) {
+        for p in params {
+            let Some(pname) = p.get("name").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let schema = p.get("schema").cloned().unwrap_or(default_schema());
+            properties.insert(pname.to_string(), schema);
+            if p.get("required").and_then(|v| v.as_bool()).unwrap_or(false) {
+                required.push(Value::String(pname.to_string()));
+            }
+        }
+    }
+    let input_schema = serde_json::json!({
+        "type": "object",
+        "properties": Value::Object(properties),
+        "required": Value::Array(required),
+    });
+
+    let output_schema = method.get("result").and_then(|r| r.get("schema")).cloned();
+
+    let scope = if let Some(scopes) = method.get("x-scopes").and_then(|v| v.as_array()) {
+        scopes
+            .iter()
+            .find_map(|v| v.as_str())
+            .map(str::to_string)
+            .unwrap_or_default()
+    } else if let Some(scopes) = method.get("x-google-scopes").and_then(|v| v.as_array()) {
+        let urls: Vec<String> = scopes
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect();
+        match dotted_scope_for_google_scopes(&urls) {
+            Some(s) => s,
+            None => {
+                tracing::warn!(
+                    endpoint = %endpoint,
+                    tool = %name,
+                    scopes = ?urls,
+                    "tool registry: could not map x-google-scopes to a dotted scope \
+                     (unrecognized OAuth scope URL); tool will be dropped by scope filtering",
+                );
+                String::new()
+            }
+        }
+    } else {
+        tracing::debug!(
+            endpoint = %endpoint,
+            tool = %name,
+            "tool registry: method has neither x-scopes nor x-google-scopes; no scope \
+             could be derived, tool will be dropped by scope filtering",
+        );
+        String::new()
+    };
+
+    Ok(DiscoveredTool {
+        name,
+        description,
+        scope,
+        input_schema,
+        output_schema,
+        idempotent: false,
+        side_effects: SideEffects::default(),
+    })
+}
+
 /// TTL cache keyed by endpoint name.
 ///
 /// Why: Avoid hammering remote `rpc.discover` on every tool list request.
@@ -116,43 +326,9 @@ impl DiscoveryCache {
     }
 }
 
+// Extracted to `discovery_tests.rs` to keep this file under the 500-SLOC
+// production cap (#3577 added `parse_manifest` + `method_to_tool`); see
+// `scripts/check_line_cap.sh`.
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn discovered_tool_roundtrip() {
-        let raw = serde_json::json!({
-            "name": "gmail_read",
-            "description": "Read mail",
-            "scope": "google.gmail.read",
-            "input_schema": {"type": "object"},
-            "idempotent": true,
-            "side_effects": "read"
-        });
-        let t: DiscoveredTool = serde_json::from_value(raw).unwrap();
-        assert_eq!(t.name, "gmail_read");
-        assert_eq!(t.scope, "google.gmail.read");
-        assert!(t.idempotent);
-        assert_eq!(t.side_effects, SideEffects::Read);
-    }
-
-    #[test]
-    fn cache_returns_value_within_ttl() {
-        let cache = DiscoveryCache::new(Duration::from_secs(60));
-        let m = EndpointManifest {
-            server: ServerInfo::default(),
-            protocol_version: "openrpc/1".into(),
-            capabilities: EndpointCapabilities::default(),
-            tools: vec![],
-        };
-        cache.put("ep".into(), m);
-        assert!(cache.get("ep").is_some());
-    }
-
-    #[test]
-    fn cache_misses_on_unknown_key() {
-        let cache = DiscoveryCache::new(Duration::from_secs(60));
-        assert!(cache.get("missing").is_none());
-    }
-}
+#[path = "discovery_tests.rs"]
+mod tests;

--- a/crates/trusty-agents/src/tools/registry/discovery_tests.rs
+++ b/crates/trusty-agents/src/tools/registry/discovery_tests.rs
@@ -1,0 +1,331 @@
+//! Unit tests for `discovery.rs` (#453, #3577).
+//!
+//! Why: Extracted to a sibling file to keep `discovery.rs` under the
+//! 500-SLOC production cap once `parse_manifest`/`method_to_tool` were
+//! added for #3577; see `scripts/check_line_cap.sh`.
+//! What: Struct round-trip + TTL cache tests (pre-existing), plus
+//! `parse_manifest` wire-shape coverage: the real gworkspace OpenRPC
+//! payload shape, the legacy `tools`-shape fallback, and the
+//! loud-error-not-silent-empty regression guard for #3577.
+//! Test: This *is* the test module.
+
+use super::*;
+
+#[test]
+fn discovered_tool_roundtrip() {
+    let raw = serde_json::json!({
+        "name": "gmail_read",
+        "description": "Read mail",
+        "scope": "google.gmail.read",
+        "input_schema": {"type": "object"},
+        "idempotent": true,
+        "side_effects": "read"
+    });
+    let t: DiscoveredTool = serde_json::from_value(raw).unwrap();
+    assert_eq!(t.name, "gmail_read");
+    assert_eq!(t.scope, "google.gmail.read");
+    assert!(t.idempotent);
+    assert_eq!(t.side_effects, SideEffects::Read);
+}
+
+#[test]
+fn cache_returns_value_within_ttl() {
+    let cache = DiscoveryCache::new(Duration::from_secs(60));
+    let m = EndpointManifest {
+        server: ServerInfo::default(),
+        protocol_version: "openrpc/1".into(),
+        capabilities: EndpointCapabilities::default(),
+        tools: vec![],
+    };
+    cache.put("ep".into(), m);
+    assert!(cache.get("ep").is_some());
+}
+
+#[test]
+fn cache_misses_on_unknown_key() {
+    let cache = DiscoveryCache::new(Duration::from_secs(60));
+    assert!(cache.get("missing").is_none());
+}
+
+/// The real `trusty-gworkspace-mcp --rpc` `rpc.discover` payload shape,
+/// quoted from `crates/trusty-gworkspace/src/openrpc.rs`
+/// (`discover_response()` lines ~133-152, `tool_to_method()` lines
+/// ~166-213): top-level `openrpc`/`info`/`methods`, each method carrying
+/// `params`/`result`/`x-google-scopes`. This is a fixture captured from
+/// the actual emitted format, not an idealized one — three tools
+/// exercising three distinct scope-mapping paths: a single-scope gmail
+/// tool, a multi-scope gmail tool (`compose_email` requests both
+/// `gmail.send` and `gmail.modify`), and a docs tool that also requests
+/// the generic `drive` scope (exercising the priority rule in
+/// `google_scope.rs`).
+#[test]
+fn parse_manifest_methods_shape_gworkspace_fixture() {
+    let raw = serde_json::json!({
+        "openrpc": "1.3.2",
+        "info": {
+            "title": "gworkspace-mcp",
+            "version": "0.4.2",
+            "description": "Google Workspace tools exposed as JSON-RPC 2.0 methods over stdio.",
+            "license": {
+                "name": "Elastic-2.0",
+                "url": "https://www.elastic.co/licensing/elastic-license"
+            }
+        },
+        "methods": [
+            {
+                "name": "search_gmail_messages",
+                "description": "Search Gmail messages",
+                "params": [
+                    {
+                        "name": "query",
+                        "description": "Gmail search query",
+                        "required": true,
+                        "schema": {"type": "string"}
+                    },
+                    {
+                        "name": "max_results",
+                        "description": "Maximum results to return",
+                        "required": false,
+                        "schema": {"type": "integer"}
+                    }
+                ],
+                "result": {
+                    "name": "search_gmail_messages_result",
+                    "description": "Tool result envelope; structure varies by tool.",
+                    "schema": {"type": "object"}
+                },
+                "x-google-scopes": ["https://www.googleapis.com/auth/gmail.modify"]
+            },
+            {
+                "name": "compose_email",
+                "description": "Compose and send an email",
+                "params": [
+                    {
+                        "name": "to",
+                        "description": "Recipient address",
+                        "required": true,
+                        "schema": {"type": "string"}
+                    }
+                ],
+                "result": {
+                    "name": "compose_email_result",
+                    "description": "Tool result envelope; structure varies by tool.",
+                    "schema": {"type": "object"}
+                },
+                "x-google-scopes": [
+                    "https://www.googleapis.com/auth/gmail.send",
+                    "https://www.googleapis.com/auth/gmail.modify"
+                ]
+            },
+            {
+                "name": "create_document",
+                "description": "Create a Google Doc",
+                "params": [],
+                "result": {
+                    "name": "create_document_result",
+                    "description": "Tool result envelope; structure varies by tool.",
+                    "schema": {"type": "object"}
+                },
+                "x-google-scopes": [
+                    "https://www.googleapis.com/auth/documents",
+                    "https://www.googleapis.com/auth/drive"
+                ]
+            }
+        ]
+    });
+
+    let manifest = parse_manifest("gworkspace", &raw).expect("real gworkspace shape must parse");
+
+    // This is the #3577 headline assertion: pre-fix, this manifest would
+    // deserialize successfully with `tools: vec![]` because `methods` (not
+    // `tools`) was the top-level key. Post-fix, all three tools survive.
+    assert_eq!(manifest.tools.len(), 3, "expected all 3 methods to convert");
+    assert_eq!(manifest.server.name, "gworkspace-mcp");
+
+    let search = manifest
+        .tools
+        .iter()
+        .find(|t| t.name == "search_gmail_messages")
+        .expect("search_gmail_messages present");
+    assert_eq!(search.scope, "google.gmail.write");
+    assert_eq!(search.input_schema["type"], "object");
+    assert_eq!(search.input_schema["properties"]["query"]["type"], "string");
+    assert_eq!(
+        search.input_schema["required"],
+        serde_json::json!(["query"])
+    );
+
+    let compose = manifest
+        .tools
+        .iter()
+        .find(|t| t.name == "compose_email")
+        .expect("compose_email present");
+    assert_eq!(
+        compose.scope, "google.gmail.write",
+        "multiple gmail scopes collapse to one dotted scope"
+    );
+
+    let create_doc = manifest
+        .tools
+        .iter()
+        .find(|t| t.name == "create_document")
+        .expect("create_document present");
+    assert_eq!(
+        create_doc.scope, "google.docs.write",
+        "documents scope must win over the generic drive scope also requested"
+    );
+}
+
+/// The legacy `{"tools": [...]}` shape (originally speced in
+/// `docs/trusty-agents/research/openrpc-trusty-contract.md`, never
+/// implemented by any real server) is still accepted so a future/test
+/// endpoint that emits it directly is not broken by this fix.
+#[test]
+fn parse_manifest_tools_shape_still_accepted() {
+    let raw = serde_json::json!({
+        "server": {"name": "trusty-memory", "version": "0.4.0"},
+        "protocol_version": "openrpc/1",
+        "capabilities": {"supports_batch": true, "supports_streaming": false},
+        "tools": [
+            {
+                "name": "memory_remember",
+                "description": "Persist content",
+                "scope": "memory.write",
+                "input_schema": {"type": "object"},
+                "idempotent": false,
+                "side_effects": "write"
+            }
+        ]
+    });
+
+    let manifest = parse_manifest("trusty-memory", &raw).expect("legacy tools shape must parse");
+    assert_eq!(manifest.tools.len(), 1);
+    assert_eq!(manifest.tools[0].name, "memory_remember");
+    assert_eq!(manifest.tools[0].scope, "memory.write");
+}
+
+/// Regression guard for #3577: a payload with neither `methods` nor
+/// `tools` must produce a LOUD error, not a silent empty tool list.
+///
+/// Causality, confirmed explicitly: the first assertion below exercises
+/// the exact PRE-FIX code path (`serde_json::from_value::<EndpointManifest>`
+/// — still valid since the struct's `Deserialize` impl is unchanged) and
+/// shows it succeeds with `tools: vec![]` on this input. The second
+/// assertion exercises `parse_manifest`, the POST-FIX path used by
+/// `DirectDriver::discover()`, and shows it errors instead. Running this
+/// test against pre-fix `direct.rs` (which called
+/// `serde_json::from_value` directly, as the first assertion still does
+/// here) would fail at the second assertion because `parse_manifest`
+/// itself is new in this change — i.e. the second assertion is exactly
+/// the behavior that did not exist before this fix.
+#[test]
+fn parse_manifest_unrecognized_shape_errors_loudly() {
+    let raw = serde_json::json!({
+        "openrpc": "1.3.2",
+        "info": {"title": "some-future-server", "version": "0.1.0"},
+        // Neither `methods` nor `tools` — an unrecognized/future shape.
+        "endpoints": [{"name": "foo"}]
+    });
+
+    // Pre-fix behavior, still reachable via the derived Deserialize impl:
+    // silently succeeds with an empty tool list.
+    let legacy: EndpointManifest = serde_json::from_value(raw.clone())
+        .expect("pre-fix path: struct deserialize silently succeeds on this input");
+    assert!(
+        legacy.tools.is_empty(),
+        "pre-fix path silently produces zero tools — this is the #3577 bug"
+    );
+
+    // Fix: parse_manifest must recognize this as an unrecognized shape
+    // and error loudly instead of returning the same empty manifest.
+    let err = parse_manifest("gworkspace", &raw)
+        .expect_err("unrecognized shape must error, not silently produce zero tools");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("gworkspace"),
+        "error must name the endpoint: {msg}"
+    );
+    assert!(
+        msg.contains("methods") && msg.contains("tools"),
+        "error must name both the expected and missing shapes: {msg}"
+    );
+}
+
+#[test]
+fn parse_manifest_methods_not_an_array_errors() {
+    let raw = serde_json::json!({"methods": "not-an-array"});
+    let err = parse_manifest("bad-endpoint", &raw).unwrap_err();
+    assert!(err.to_string().contains("bad-endpoint"));
+}
+
+#[test]
+fn parse_manifest_non_object_errors() {
+    let raw = serde_json::json!(["not", "an", "object"]);
+    let err = parse_manifest("bad-endpoint", &raw).unwrap_err();
+    assert!(err.to_string().contains("bad-endpoint"));
+}
+
+/// A malformed individual method entry (missing `name`) is skipped with a
+/// warning rather than failing the whole endpoint's discovery — one bad
+/// entry from a misbehaving server should not take down every other tool
+/// it advertises correctly.
+#[test]
+fn parse_manifest_skips_malformed_method_entry() {
+    let raw = serde_json::json!({
+        "openrpc": "1.3.2",
+        "info": {"title": "t", "version": "0.1.0"},
+        "methods": [
+            {"description": "missing name field", "params": []},
+            {
+                "name": "ok_tool",
+                "description": "fine",
+                "params": [],
+                "x-google-scopes": ["https://www.googleapis.com/auth/tasks"]
+            }
+        ]
+    });
+    let manifest = parse_manifest("ep", &raw).expect("valid entries still parse");
+    assert_eq!(manifest.tools.len(), 1);
+    assert_eq!(manifest.tools[0].name, "ok_tool");
+}
+
+/// A method with no recognizable scope extension gets an empty `scope`
+/// (which every `ScopePattern` rejects) rather than panicking — the tool
+/// is still returned so the "zero tools" warning in `mod.rs` distinguishes
+/// "we understood the manifest but nothing survives scope filtering" from
+/// a discovery-level failure.
+#[test]
+fn parse_manifest_method_without_scope_extension_gets_empty_scope() {
+    let raw = serde_json::json!({
+        "openrpc": "1.3.2",
+        "info": {"title": "t", "version": "0.1.0"},
+        "methods": [
+            {"name": "no_scope_tool", "description": "d", "params": []}
+        ]
+    });
+    let manifest = parse_manifest("ep", &raw).unwrap();
+    assert_eq!(manifest.tools.len(), 1);
+    assert_eq!(manifest.tools[0].scope, "");
+}
+
+/// `x-scopes` (the generic dotted-string extension emitted by
+/// `trusty-memory`/`trusty-search` via the shared
+/// `trusty_common::mcp::openrpc` builder) is used as-is with no OAuth
+/// translation.
+#[test]
+fn parse_manifest_generic_x_scopes_used_directly() {
+    let raw = serde_json::json!({
+        "openrpc": "1.3.2",
+        "info": {"title": "trusty-search-mcp", "version": "0.1.0"},
+        "methods": [
+            {
+                "name": "search",
+                "description": "search",
+                "params": [],
+                "x-scopes": ["search.read"]
+            }
+        ]
+    });
+    let manifest = parse_manifest("trusty-search", &raw).unwrap();
+    assert_eq!(manifest.tools[0].scope, "search.read");
+}

--- a/crates/trusty-agents/src/tools/registry/google_scope.rs
+++ b/crates/trusty-agents/src/tools/registry/google_scope.rs
@@ -1,0 +1,257 @@
+//! Google OAuth scope URL -> dotted RBAC scope mapping (#3577).
+//!
+//! Why: `trusty-gworkspace`'s `rpc.discover` advertises each tool's
+//! required permissions as `x-google-scopes`: an array of full Google
+//! OAuth 2.0 scope URLs (`https://www.googleapis.com/auth/gmail.modify`).
+//! Everything downstream of discovery — `ScopePattern` matching in
+//! `scope.rs`, the operator-declared `[[endpoints]].scopes` allowlist, and
+//! the agent-level `[tools].scopes` enforcement fed by PR #3576 — operates
+//! on `DiscoveredTool.scope`, a single dotted string like
+//! `google.gmail.write`. This module is the single place that bridges the
+//! two vocabularies, so the mapping is auditable and testable in isolation
+//! from the wire-parsing code in `discovery.rs`.
+//!
+//! What: A fixed, literal table of every OAuth scope URL
+//! `trusty-gworkspace` actually requests (`crates/trusty-gworkspace/src/
+//! openrpc.rs::scopes` — a closed, small set), each mapped to a
+//! `(family, access)` pair. `dotted_scope_for_google_scopes` resolves a
+//! tool's full scope-URL list down to ONE dotted string (`DiscoveredTool`
+//! carries a single `scope`, not a set) by walking the table in priority
+//! order and returning the first match — see "Priority" below.
+//!
+//! Read vs. write: every `trusty-gworkspace` OAuth scope except
+//! `userinfo.profile` is the FULL-ACCESS variant of its Google API (never
+//! a `.readonly` scope) — see the literal constants in
+//! `trusty-gworkspace/src/openrpc.rs::scopes`. Classifying by tool
+//! behavior instead (e.g. `search_gmail_messages` "feels" read-only) would
+//! understate what the underlying OAuth grant actually permits: the same
+//! `gmail.modify` token that a "read" tool holds can also delete mail.
+//! Scope is a trust boundary computed once at discovery time from the
+//! wire payload — it must reflect what the credential CAN do, not what
+//! today's call happens to do, or a future behavior change silently
+//! escapes a `google.*.read`-gated policy. `userinfo.profile` is the one
+//! scope that is genuinely read-only by Google's own definition (no write
+//! capability exists for it), so it is the only `Read` entry.
+//!
+//! Priority: `create_document_from_template` and friends request BOTH a
+//! resource-specific scope (`documents`) and the generic `drive` scope
+//! (Docs/Sheets/Slides need Drive-level access for file operations). The
+//! table lists narrow, resource-specific scopes before the generic `drive`
+//! catch-all, so `dotted_scope_for_google_scopes` prefers `google.docs.*`
+//! over `google.drive.*` for a Docs tool — the operator-facing scope
+//! should name the resource the tool actually operates on, not the
+//! incidental broader grant it also needs.
+//!
+//! Test: `family_and_access_examples`, `priority_prefers_specific_over_drive`,
+//! `unknown_scope_returns_none`, `empty_scopes_returns_none`.
+
+/// Read vs. write classification, mirrored into the dotted scope's last
+/// segment (`google.gmail.read` / `google.gmail.write`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScopeAccess {
+    Read,
+    Write,
+}
+
+impl ScopeAccess {
+    fn as_str(self) -> &'static str {
+        match self {
+            ScopeAccess::Read => "read",
+            ScopeAccess::Write => "write",
+        }
+    }
+}
+
+/// `(OAuth scope URL, dotted family, access)`, ordered by priority: entries
+/// earlier in the list win when a tool advertises multiple scopes. See the
+/// module-level "Priority" note for why resource-specific scopes precede
+/// the generic `drive` catch-all.
+const FAMILY_TABLE: &[(&str, &str, ScopeAccess)] = &[
+    (
+        "https://www.googleapis.com/auth/documents",
+        "docs",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/spreadsheets",
+        "sheets",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/presentations",
+        "slides",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/calendar.events",
+        "calendar",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/calendar",
+        "calendar",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/gmail.send",
+        "gmail",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/gmail.modify",
+        "gmail",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/gmail.labels",
+        "gmail",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/gmail.settings.basic",
+        "gmail",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/drive",
+        "drive",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/tasks",
+        "tasks",
+        ScopeAccess::Write,
+    ),
+    (
+        "https://www.googleapis.com/auth/userinfo.profile",
+        "accounts",
+        ScopeAccess::Read,
+    ),
+];
+
+/// Resolve a tool's `x-google-scopes` list to one dotted scope string.
+///
+/// Why: `DiscoveredTool.scope` is a single `String` (the shape every
+/// downstream consumer — `ScopePattern`, endpoint allowlists, agent-level
+/// enforcement — already matches against); a tool's OAuth grant can list
+/// several scope URLs, so this collapses that set deterministically.
+/// What: Walks `FAMILY_TABLE` in priority order and returns
+/// `Some("google.<family>.<access>")` for the first entry whose URL is
+/// present in `scopes`. Returns `None` when `scopes` is empty or contains
+/// no URL this table recognizes — callers must treat `None` as "no scope
+/// could be derived" and surface that loudly rather than silently
+/// defaulting to an empty string that would vacuously fail every
+/// `ScopePattern` match.
+/// Test: `family_and_access_examples`, `priority_prefers_specific_over_drive`.
+pub fn dotted_scope_for_google_scopes(scopes: &[String]) -> Option<String> {
+    if scopes.is_empty() {
+        return None;
+    }
+    FAMILY_TABLE
+        .iter()
+        .find(|(url, _, _)| scopes.iter().any(|s| s == url))
+        .map(|(_, family, access)| format!("google.{family}.{}", access.as_str()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| (*x).to_string()).collect()
+    }
+
+    #[test]
+    fn family_and_access_examples() {
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&["https://www.googleapis.com/auth/gmail.modify"])),
+            Some("google.gmail.write".to_string())
+        );
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&["https://www.googleapis.com/auth/calendar"])),
+            Some("google.calendar.write".to_string())
+        );
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&["https://www.googleapis.com/auth/tasks"])),
+            Some("google.tasks.write".to_string())
+        );
+    }
+
+    /// `userinfo.profile` is Google's one genuinely read-only scope in
+    /// this table — no write capability exists for it, unlike every other
+    /// entry which is the full-access (never `.readonly`) variant.
+    #[test]
+    fn userinfo_profile_is_read() {
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&[
+                "https://www.googleapis.com/auth/userinfo.profile"
+            ])),
+            Some("google.accounts.read".to_string())
+        );
+    }
+
+    /// `compose_email` requests both `gmail.send` and `gmail.modify`
+    /// (`trusty-gworkspace/src/openrpc.rs::scopes_for_tool`); both map to
+    /// the same family/access, so the result is stable regardless of
+    /// table order within the gmail cluster.
+    #[test]
+    fn multiple_scopes_same_family_collapse_to_one() {
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&[
+                "https://www.googleapis.com/auth/gmail.send",
+                "https://www.googleapis.com/auth/gmail.modify",
+            ])),
+            Some("google.gmail.write".to_string())
+        );
+    }
+
+    /// Docs/Sheets/Slides tools request BOTH their resource-specific scope
+    /// AND the generic `drive` scope. The resource-specific scope must
+    /// win so the RBAC-facing family names the resource, not the
+    /// incidental Drive-level grant.
+    #[test]
+    fn priority_prefers_specific_over_drive() {
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&[
+                "https://www.googleapis.com/auth/documents",
+                "https://www.googleapis.com/auth/drive",
+            ])),
+            Some("google.docs.write".to_string())
+        );
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&[
+                "https://www.googleapis.com/auth/spreadsheets",
+                "https://www.googleapis.com/auth/drive",
+            ])),
+            Some("google.sheets.write".to_string())
+        );
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&[
+                "https://www.googleapis.com/auth/presentations",
+                "https://www.googleapis.com/auth/drive",
+            ])),
+            Some("google.slides.write".to_string())
+        );
+    }
+
+    #[test]
+    fn drive_only_tool_maps_to_drive() {
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&["https://www.googleapis.com/auth/drive"])),
+            Some("google.drive.write".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_scopes_returns_none() {
+        assert_eq!(dotted_scope_for_google_scopes(&[]), None);
+    }
+
+    #[test]
+    fn unknown_scope_returns_none() {
+        assert_eq!(
+            dotted_scope_for_google_scopes(&s(&["https://www.googleapis.com/auth/unknown.thing"])),
+            None
+        );
+    }
+}

--- a/crates/trusty-agents/src/tools/registry/mod.rs
+++ b/crates/trusty-agents/src/tools/registry/mod.rs
@@ -22,6 +22,7 @@ pub mod config;
 pub mod direct;
 pub mod discovery;
 pub mod driver;
+mod google_scope;
 pub mod scope;
 
 use std::sync::Arc;
@@ -129,6 +130,27 @@ async fn build_endpoint(ep: &EndpointConfig) -> Result<Vec<Arc<dyn ToolExecutor>
     }
 
     let manifest = driver.discover().await?;
+
+    // #3577: zero tools from a manifest we successfully understood is a
+    // DIFFERENT condition from zero tools because the wire shape didn't
+    // parse (that case is a hard `Err` from `driver.discover()`, above,
+    // and never reaches this line). A well-formed manifest can still
+    // legitimately advertise nothing — a server mid-feature-rollout, for
+    // example — so this is a warning, not an error: it must be loud
+    // enough that an operator staring at "gworkspace contributed 0 tools"
+    // in the startup log has an immediate next step, without treating a
+    // genuinely-empty server as a hard startup failure.
+    if manifest.tools.is_empty() {
+        tracing::warn!(
+            endpoint = %ep.name,
+            "tool registry: endpoint '{}' discovery succeeded but advertised zero tools \
+             — verify the server implements the tools it's expected to, and that its \
+             rpc.discover response shape matches what this registry parses \
+             (see crates/trusty-agents/src/tools/registry/discovery.rs)",
+            ep.name,
+        );
+    }
+
     let patterns: Vec<ScopePattern> = ep
         .scopes
         .iter()


### PR DESCRIPTION
## Summary

`DirectDriver::discover()` deserialized the raw `rpc.discover` JSON-RPC
result directly into `EndpointManifest` (`serde_json::from_value`).
Because `EndpointManifest.tools` carries `#[serde(default)]`, a payload
whose top-level array key is `methods` (not `tools`) deserialized
**successfully** with `tools: vec![]` — no error, anywhere. Every real
server in this repo (`trusty-memory`, `trusty-search`, `trusty-gworkspace`)
emits standard OpenRPC 1.3.2 (`{"openrpc", "info", "methods": [...]}`),
never the bespoke `{"tools": [...]}` shape the client expected. Practical
effect: the `gworkspace` endpoint (`enabled = true` by default since
#3056) has been discovering **zero tools** in production.

## Part A — which side is authoritative (survey + decision)

Only `[[tool_registry.endpoints]]` entries with `driver = "direct"` go
through this discovery path — that's the entire population that could
ever hit this bug:

| Endpoint | `enabled` | Wire shape it emits |
|---|---|---|
| `trusty-memory` | `false` (pending `--rpc` mode) | OpenRPC `methods[]`, via the **shared** `trusty_common::mcp::openrpc::discover_response` builder (`crates/trusty-memory/src/openrpc.rs`) |
| `trusty-search` | `false` (pending `--rpc` mode) | OpenRPC `methods[]`, via the same shared builder (`crates/trusty-search/src/mcp/openrpc.rs`) |
| `gworkspace` | `true` | OpenRPC `methods[]`, bespoke-but-structurally-identical implementation (`crates/trusty-gworkspace/src/openrpc.rs`) |

(`[[mcp.services]]` entries — `trusty-mpm`, `granola-notes`,
`duetto-memory` — are a completely separate, unaffected mechanism; they
don't go through `rpc.discover`/`EndpointManifest` at all.)

**Decision: fix the consumer (trusty-agents), not the emitters.** OpenRPC
is not just "what gworkspace happens to do" — `trusty_common::mcp::openrpc`
is a shared crate built *specifically* to keep trusty-memory and
trusty-search's manifests identically OpenRPC-shaped ("Consolidating the
builder here ... ensures every server emits an identically-structured
document"). Every current AND every currently-planned `direct` endpoint
speaks OpenRPC. The client-side `EndpointManifest`/`tools[]` shape was
speced in `docs/trusty-agents/research/openrpc-trusty-contract.md` but
**never implemented by any server** — it's dead documentation, not a
convention anything follows. Teaching the client to consume real OpenRPC
means the next OpenRPC endpoint added to the registry (trusty-memory,
trusty-search, once `--rpc` mode ships) works for free; fixing gworkspace
alone would leave the underlying client bug for the next server to
rediscover.

## Part B — loud failure, not silent empty

New `discovery::parse_manifest(endpoint, raw)` replaces the bare
`serde_json::from_value` call in `DirectDriver::discover()`:

- Top-level `methods` array present → real shape, converted via
  `method_to_tool` (JSON Schema `input_schema` rebuilt from `params[]`,
  `output_schema` from `result.schema`, scope from `x-scopes` or
  `x-google-scopes`).
- Top-level `tools` array present (no `methods`) → legacy shape, accepted
  as-is (keeps the door open for the originally-speced shape / tests).
- **Neither key present → hard `Err`**, naming the endpoint and the
  top-level keys actually received. This is exactly the condition that
  used to silently produce `tools: vec![]`.

A **separate** decision, one layer up in `mod.rs::build_endpoint`: a
manifest that parses successfully but advertises zero tools now emits a
`tracing::warn!` naming the endpoint. This is a *warning*, not a hard
error — a server can legitimately expose nothing (e.g. mid-feature-
rollout) — but it must never be silent. The two failure modes are now
distinguishable: "we didn't understand the response" (hard error, wrong
shape) vs. "we understood it and it says zero" (warning, plausibly
legitimate).

A malformed individual `methods[]` entry (e.g. missing `name`) is skipped
with a warning rather than failing the whole endpoint — one bad entry
from a misbehaving server shouldn't take down every tool it advertises
correctly.

## OAuth scope → dotted scope mapping

New `google_scope::dotted_scope_for_google_scopes` (`crates/trusty-agents/
src/tools/registry/google_scope.rs`) resolves a tool's `x-google-scopes`
OAuth URL list to the single dotted string `DiscoveredTool.scope` expects
— this feeds both the endpoint-level scope allowlist and, per #3576, the
agent-level RBAC enforcement, so I mapped it deliberately rather than
just gluing strings together:

- **Read vs. write is classified by what the OAuth grant *permits*, not
  by what a given tool call does today.** Every gworkspace OAuth scope
  except `userinfo.profile` is the full-access variant of its API (never
  the `.readonly` variant) — e.g. `search_gmail_messages` "feels"
  read-only but holds `gmail.modify`, which can also delete mail. If I
  classified by tool behavior, a future change that makes a "read" tool
  also write would silently escape a `google.gmail.read`-gated policy.
  Classifying by the credential's actual power is the safer, audit-stable
  choice. `userinfo.profile` is the one scope in the table that's
  genuinely read-only by Google's own definition, so it's the only `read`
  entry (`google.accounts.read`).
- **Multiple scopes on one tool collapse deterministically.** `compose_email`
  requests both `gmail.send` and `gmail.modify` — both map to
  `google.gmail.write`, so the result is stable.
- **Resource-specific scopes beat the generic `drive` catch-all.** Docs/
  Sheets/Slides tools request both their resource scope (`documents`/
  `spreadsheets`/`presentations`) AND `drive` (needed for file-level
  operations). A fixed priority table picks the resource-specific scope
  first, so `create_document` maps to `google.docs.write`, not
  `google.drive.write` — the RBAC-facing name should say what the tool
  actually operates on.
- **Config gap found and closed alongside this:** `default-config.toml`'s
  gworkspace endpoint declared `scopes` had no `google.slides.*` or
  `google.accounts.*` pattern, so Slides tools (`PRESENTATIONS` scope) and
  local account-management tools (`USERINFO_PROFILE` scope) would parse
  correctly under this fix but then be silently dropped by scope
  filtering — a milder version of the same class of bug. Added both.

## Tests

- `parse_manifest_methods_shape_gworkspace_fixture` — a fixture quoted
  from `trusty-gworkspace/src/openrpc.rs`'s actual emitted shape (not an
  idealized one), covering a single-scope tool, a multi-scope tool
  (scope collapse), and a docs tool (resource-over-drive priority).
- `parse_manifest_unrecognized_shape_errors_loudly` — **causality
  confirmed explicitly in the test itself**: the first assertion runs the
  exact pre-fix code path (`serde_json::from_value::<EndpointManifest>`,
  still reachable via the derived `Deserialize` impl) and shows it
  succeeds with `tools: vec![]` on the mismatched payload; the second
  assertion runs `parse_manifest` (the fix) on the same input and shows it
  errors instead, naming the endpoint.
- `google_scope`'s own test module: family/access examples, the
  `userinfo.profile`-is-read case, multi-scope collapse, and the
  specific-over-drive priority rule (docs/sheets/slides each verified
  independently).
- Plus: legacy `tools`-shape still accepted, malformed-method-entry
  skip-with-warning, missing-scope-extension → empty scope (not a panic),
  and generic `x-scopes` used as-is (no OAuth translation) for
  trusty-memory/trusty-search-shaped payloads.

`discovery.rs` grew past the 500-SLOC production cap once
`parse_manifest`/`method_to_tool` were added, so tests were extracted to
the sibling `discovery_tests.rs` (existing repo convention, see
`crates/trusty-agents/src/tools/registry_tests.rs`).

## Scope discipline

Stayed entirely in the discovery/deserialization layer
(`discovery.rs`, `direct.rs`, new `google_scope.rs`, plus the
zero-tools warning in `mod.rs::build_endpoint`). Did not touch
`persona.rs`, `scope.rs`'s matching algorithm, or the dispatch path —
that's PR #3576's territory.

## Quality gate (raw output)

```
$ cargo fmt --all -- --check
(clean, exit 0)

$ cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 31s
(exit 0, no clippy warnings)

$ cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
test result: ok. 3428 passed; 0 failed; 6 ignored ... (trusty-mpm --lib)
test result: ok. 1141 passed; 1 failed; 1 ignored ... (trusty-mpm --bin tm)
  commands::statusline::branch::tests::project_segment_basename_fallback_non_git — FAILED,
  passes in isolation (`cargo test -p trusty-mpm --bin tm <name>` → ok);
  tmux/env-dependent flake in unrelated statusline code, untouched by this PR.
trusty-agents: all tests passed on a clean re-run (0 failed); one run earlier
  hit workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_...,
  confirmed flaky in isolation (passes standalone) and in code this PR never touches.

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 40 spec doc(s) + 2721 code file(s); 0 error(s), 0 warning(s)
```

Targeted registry test run for reference:
`cargo test -p trusty-agents tools::registry` → 46 passed, 0 failed.

Closes #3577

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools