### PR TITLE
feat(trusty-agents): opaque dispatch_task tm/tcode bridge (epic #3052 lane 3)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`dispatch_task` — the opaque tm<->tcode PM bridge tool (epic #3052, PR
+  B, lane 3):** a new tool, distinct from lane 2's `delegate_to_agent`
+  in-process sub-agent delegation, that routes a unit of work to either
+  `tm` (orchestration / project / session / issue / PR / multi-agent work)
+  or `tcode` (direct coding in a repo) via a deterministic, pure-function
+  router (`intent::route::route_task`) — no LLM call, same input always
+  routes the same way. The tool's name, schema, and results are fully
+  black-boxed: neither backend's identity, nor `trusty-mpm`/`trusty-code`,
+  is ever named in the schema, and the full backend transcript is run
+  through `tools::pm_bridge::scrub_branding` (strips standalone
+  `tm`/`tcode`/`trusty-mpm`/`trusty-code` tokens and redacts
+  session-id-shaped artifacts) before returning, on both the success and
+  error paths. RBAC-locked to deny `ServiceTier::ReadOnly` AND
+  `ServiceTier::Analytics` — registered in the interactive assistant
+  registry (`ctrl::pm_task::dispatch::history`) and the PM CLI registry
+  (`runtime::pm_mode`), mirroring `delegate_to_agent`'s registration.
+  Backend dispatch: `tcode` runs as a one-shot blocking subprocess
+  (`tcode run-task pm <task> --project <dir> --json`), which itself blocks
+  until its daemon-owned session reaches a terminal state; `tm` spawns
+  `tm serve --stdio` and drives the managed-session lifecycle
+  (`session_new` / `session_activity` / `session_decommission`) with a
+  bounded poll, since tm has no synchronous "run this task headlessly"
+  RPC (`agent_delegate` is explicitly a tracking/gating companion, NOT an
+  execution path) — a documented MVP scope limit, flagged for a follow-up
+  RPC.
+
 ### Security
 
 - **Assistant no longer leaks internal orchestration or disclaims delegating

--- a/crates/trusty-agents/CLAUDE.md
+++ b/crates/trusty-agents/CLAUDE.md
@@ -45,6 +45,7 @@ OpenRouter API --> LLM response --> result returned to PM --> user
 - **Tool Calling** (`src/tools/`): OpenAI function-calling format. PM uses `delegate_to_agent` tool. Sub-agents may use additional tools.
 - **Agent Config** (`.trusty-agents/agents/*.toml`): Defines agent name, role, model, LLM parameters, and system prompt.
 - **Skills** (`.trusty-agents/skills/*.md`): Markdown files injected into agent system prompts for domain knowledge.
+- **PM Bridge / `dispatch_task`** (`src/tools/pm_bridge.rs`, `src/tools/pm_bridge_backend.rs`, `src/intent/route.rs`): epic #3052 PR B, lane 3 — distinct from lane 2's in-process `delegate_to_agent`. Routes a unit of work to an opaque EXTERNAL backend (`tm` for orchestration/project/session/issue/PR/multi-agent work, `tcode` for direct coding in a repo) via a deterministic pure-function router; the tool name, schema, and returned transcript never name either backend (`tools::pm_bridge::scrub_branding` strips backend-identity tokens and session ids). RBAC-denied to `ReadOnly`/`Analytics` tiers.
 
 ### IPC Message Format
 

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -465,6 +465,24 @@ pub async fn run_pm_task_with_history(
 /// `registry.filter_tools_for_user` computation
 /// `ctrl::pm_task::dispatch::persona::run_pm_task_with_persona` already uses
 /// for the same property (see `persona.rs`'s `allowed_by_tier`).
+///
+/// Reconciliation with #3576 (`fix(trusty-agents): enforce RBAC tier and
+/// agent-declared tool scopes at dispatch`, merged to main as this fix
+/// landed): #3576 closed two DIFFERENT enforcement gaps — `PythonToolPlugin`
+/// never overriding `restricted_tiers()` (#3236), and agent-declared
+/// `[tools].scopes` never being consulted inside
+/// `persona::filter_persona_tool_names` (#3208). Neither touches
+/// `dispatch_gated`, `dispatch_for_user`, or this (`run_pm_task_with_history`)
+/// code path — #3208's fix is entirely local to `persona.rs`'s OWN filter
+/// function, which this file does not call. So this fix is NOT redundant
+/// with, nor superseded by, #3576: it remains the ONLY RBAC-tier
+/// enforcement on the `run_pm_task_with_history` (ctrl/Slack/Telegram/API)
+/// dispatch path, complementary to (not overlapping with) #3576's
+/// persona-path and `PythonToolPlugin` fixes. `dispatch_task` also needs no
+/// `ToolExecutor::scope()` override for #3208's purposes — it is a native
+/// in-process tool (like `delegate_to_agent`/`run_bash`), gated entirely by
+/// name/glob allowlist + RBAC tier, exactly the category #3576's own scope
+/// doc comment says is unaffected by scope-pattern gating.
 /// What: `None` (no `UserIdentity` — the local REPL/CLI path never sets
 /// `overrides.user`) returns `None`, meaning NO filtering: every registered
 /// tool stays callable, preserving the existing unauthenticated-CLI

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -18,7 +18,10 @@ use anyhow::{Context, Result};
 use crate::events::{self, Event};
 use crate::intent::{IntentClass, classify_intent};
 use crate::llm;
+use crate::rbac::ServiceTier;
 use crate::subprocess::SubprocessAgentRunner;
+use crate::tools::pm_bridge::PmBridgeTool;
+use crate::tools::pm_bridge_backend::ProcessPmBridge;
 use crate::tools::{AgentRunner, ToolRegistry, delegate::DelegateToAgentTool};
 
 use super::super::super::claude_cli::run_pm_task_via_claude_cli;
@@ -335,6 +338,14 @@ pub async fn run_pm_task_with_history(
     registry.register(Arc::new(
         DelegateToAgentTool::new(runner).with_config_dir(config_dir.clone()),
     ));
+    // #3052 PR B (lane 3): the opaque tm<->tcode bridge, distinct from lane 2
+    // (`delegate_to_agent` above). RBAC-locked to deny ReadOnly + Analytics.
+    registry.register(Arc::new(
+        PmBridgeTool::new(Arc::new(ProcessPmBridge::from_project(
+            project_path.to_path_buf(),
+        )))
+        .with_restricted_tiers(vec![ServiceTier::ReadOnly, ServiceTier::Analytics]),
+    ));
     let stop_pending: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let active_project_slot: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));
     registry.register(Arc::new(AddProjectTool));
@@ -391,6 +402,13 @@ pub async fn run_pm_task_with_history(
 
     let adapter = llm::adapter::adapter_for_model(&pm_cfg.agent.model);
     let registry_arc = Arc::new(registry);
+    // code-critic BLOCK finding 2: this path backs Slack/Telegram/API, all of
+    // which can carry a real, less-than-`All` `ServiceTier` in
+    // `overrides.user` — without this, `dispatch_gated` (which only checks a
+    // NAME allowlist, never `restricted_tiers`) would let a ReadOnly/Analytics
+    // caller invoke `dispatch_task` regardless of its RBAC gate. See
+    // `allowed_tool_names_for`'s docs.
+    let allowed_tools = allowed_tool_names_for(&registry_arc, overrides.user.as_ref());
     let llm_t0 = std::time::Instant::now();
     tracing::info!(
         model = %pm_cfg.agent.model,
@@ -403,7 +421,7 @@ pub async fn run_pm_task_with_history(
         &*adapter,
         initial_messages,
         registry_arc,
-        None,
+        allowed_tools,
         pm_cfg.llm.temperature,
         pm_cfg.llm.max_tokens,
         4,
@@ -430,3 +448,58 @@ pub async fn run_pm_task_with_history(
     });
     Ok(content)
 }
+
+/// Compute `chat_with_tools_gated`'s `allowed_tools` argument from an
+/// optional caller `UserIdentity`.
+///
+/// Why (code-critic BLOCK, epic #3052 PR B finding 2): `chat_with_tools_gated`'s
+/// dispatch loop calls `registry.dispatch_gated`, which enforces ONLY a name
+/// allowlist (`llm/tool_loop/mod.rs`) — it never consults
+/// `ToolExecutor::restricted_tiers()` / `UserIdentity::can_access_tier`, so
+/// passing `None` unconditionally (the pre-fix behavior) let ANY caller
+/// invoke a tier-restricted tool like `dispatch_task` regardless of its RBAC
+/// gate. This path backs Slack/Telegram/API, and Slack plumbs a real,
+/// authenticated `ServiceTier` into `overrides.user`
+/// (`slack::rbac`/`slack::handlers`), so a ReadOnly/Analytics Slack user
+/// could otherwise reach `dispatch_task`. Mirrors the identical
+/// `registry.filter_tools_for_user` computation
+/// `ctrl::pm_task::dispatch::persona::run_pm_task_with_persona` already uses
+/// for the same property (see `persona.rs`'s `allowed_by_tier`).
+/// What: `None` (no `UserIdentity` — the local REPL/CLI path never sets
+/// `overrides.user`) returns `None`, meaning NO filtering: every registered
+/// tool stays callable, preserving the existing unauthenticated-CLI
+/// behavior exactly (the RBAC `ServiceTier` default is `All`, i.e.
+/// unrestricted, so this is not a silent widening). `Some(user)` returns
+/// `Some(names)` restricted to `registry.filter_tools_for_user(user)` — only
+/// the tools `user`'s tier may access. Passed straight through as
+/// `chat_with_tools_gated`'s `allowed_tools`, this makes `dispatch_gated`'s
+/// name-allowlist check ALSO enforce the RBAC tier, closing the gap without
+/// touching `dispatch_gated` itself.
+/// Test: `allowed_tool_names_for_no_user_returns_none_full_access`,
+/// `allowed_tool_names_for_read_only_excludes_dispatch_task`,
+/// `allowed_tool_names_for_analytics_excludes_dispatch_task`,
+/// `allowed_tool_names_for_all_tier_includes_dispatch_task`,
+/// `dispatch_task_not_invocable_for_read_only_user_through_dispatch_gated`
+/// (the integration-level proof: drives the REAL `ToolRegistry::dispatch_gated`
+/// enforcement path with the computed allowlist, not just the computation
+/// in isolation).
+fn allowed_tool_names_for(
+    registry: &ToolRegistry,
+    user: Option<&crate::rbac::UserIdentity>,
+) -> Option<Vec<String>> {
+    let user = user?;
+    Some(
+        registry
+            .filter_tools_for_user(user)
+            .into_iter()
+            .map(|t| t.name().to_string())
+            .collect(),
+    )
+}
+
+// Sibling `_tests.rs` file (this crate's `#[path=...]` pattern) — keeps
+// this production file under the 500-SLOC cap. See `history_tests.rs`'s
+// module docs for what code-critic finding this covers.
+#[cfg(test)]
+#[path = "history_tests.rs"]
+mod rbac_gate_tests;

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
@@ -1,0 +1,180 @@
+//! Tests for `history::allowed_tool_names_for` — the RBAC-tier gate fixing
+//! code-critic BLOCK finding 2 (epic #3052 PR B): `chat_with_tools_gated`'s
+//! dispatch loop (`registry.dispatch_gated`) enforces only a name allowlist,
+//! never `restricted_tiers`, so `run_pm_task_with_history` must compute and
+//! pass a tier-scoped `allowed_tools` list itself. Split out of `history.rs`
+//! (sibling `_tests.rs` file, this crate's `#[path=...]` pattern) to keep
+//! the production file under the 500-SLOC cap — see `history.rs`'s `#[cfg(test)]`
+//! declaration.
+
+use serde_json::json;
+
+use super::allowed_tool_names_for;
+use crate::rbac::{ServiceTier, UserIdentity};
+use crate::tools::ToolRegistry;
+use crate::tools::pm_bridge::PmBridgeTool;
+use crate::tools::pm_bridge_backend::PmBridgeBackend;
+
+/// Minimal always-succeeding `PmBridgeBackend` — these tests exercise
+/// RBAC gating only, never the real subprocess/MCP backends.
+struct NoopBackend;
+
+#[async_trait::async_trait]
+impl PmBridgeBackend for NoopBackend {
+    async fn run(
+        &self,
+        _route: crate::intent::route::BridgeRoute,
+        _task: &str,
+    ) -> anyhow::Result<String> {
+        Ok("ok".to_string())
+    }
+}
+
+/// Builds the SAME shape of registry `run_pm_task_with_history` builds
+/// for the purposes of this test: `dispatch_task` restricted to
+/// `ReadOnly`/`Analytics` (exactly as the production registration
+/// above), alongside one unrestricted tool (`add_project`) standing in
+/// for the rest of ctrl's ungated tool surface.
+fn registry_with_pm_bridge() -> ToolRegistry {
+    let mut registry = ToolRegistry::new();
+    registry.register(std::sync::Arc::new(
+        PmBridgeTool::new(std::sync::Arc::new(NoopBackend))
+            .with_restricted_tiers(vec![ServiceTier::ReadOnly, ServiceTier::Analytics]),
+    ));
+    registry.register(std::sync::Arc::new(super::AddProjectTool));
+    registry
+}
+
+#[test]
+fn allowed_tool_names_for_no_user_returns_none_full_access() {
+    let registry = registry_with_pm_bridge();
+    assert_eq!(
+        allowed_tool_names_for(&registry, None),
+        None,
+        "local REPL/CLI path (no UserIdentity) must be unaffected — full access, as before this fix"
+    );
+}
+
+#[test]
+fn allowed_tool_names_for_read_only_excludes_dispatch_task() {
+    let registry = registry_with_pm_bridge();
+    let user = UserIdentity::new("u1", "u1", ServiceTier::ReadOnly);
+    let names = allowed_tool_names_for(&registry, Some(&user)).expect("Some for a real user");
+    assert!(!names.iter().any(|n| n == "dispatch_task"));
+    assert!(names.iter().any(|n| n == "add_project"));
+}
+
+#[test]
+fn allowed_tool_names_for_analytics_excludes_dispatch_task() {
+    let registry = registry_with_pm_bridge();
+    let user = UserIdentity::new("u2", "u2", ServiceTier::Analytics);
+    let names = allowed_tool_names_for(&registry, Some(&user)).expect("Some for a real user");
+    assert!(!names.iter().any(|n| n == "dispatch_task"));
+    assert!(names.iter().any(|n| n == "add_project"));
+}
+
+#[test]
+fn allowed_tool_names_for_all_tier_includes_dispatch_task() {
+    let registry = registry_with_pm_bridge();
+    let user = UserIdentity::new("u3", "u3", ServiceTier::All);
+    let names = allowed_tool_names_for(&registry, Some(&user)).expect("Some for a real user");
+    assert!(names.iter().any(|n| n == "dispatch_task"));
+}
+
+/// The integration-level proof code-critic asked for: given the REAL
+/// registry (with `dispatch_task` restricted exactly as production
+/// registers it) and a ReadOnly `UserIdentity`, drive the ACTUAL
+/// `ToolRegistry::dispatch_gated` enforcement path — the same call
+/// `chat_with_tools_gated`'s dispatch loop makes
+/// (`llm/tool_loop/mod.rs:395-396`) — with the `allowed_tools` this fix
+/// computes, and assert the call is rejected. This is the mechanism that
+/// actually stops invocation; a ReadOnly/Analytics `UserIdentity`
+/// reaching this point can never successfully dispatch `dispatch_task`,
+/// regardless of what the LLM is told to call.
+#[tokio::test]
+async fn dispatch_task_not_invocable_for_read_only_user_through_dispatch_gated() {
+    let registry = registry_with_pm_bridge();
+    let user = UserIdentity::new("u4", "u4", ServiceTier::ReadOnly);
+    let allowed = allowed_tool_names_for(&registry, Some(&user));
+
+    let result = registry
+        .dispatch_gated(
+            "dispatch_task",
+            json!({ "task": "spawn a new session" }),
+            allowed.as_deref(),
+        )
+        .await;
+
+    assert!(
+        result.is_error(),
+        "dispatch_task must be rejected for a ReadOnly caller through the real dispatch path"
+    );
+    assert!(
+        result.content().contains("not permitted"),
+        "got: {}",
+        result.content()
+    );
+}
+
+/// Sibling proof for `Analytics`.
+#[tokio::test]
+async fn dispatch_task_not_invocable_for_analytics_user_through_dispatch_gated() {
+    let registry = registry_with_pm_bridge();
+    let user = UserIdentity::new("u5", "u5", ServiceTier::Analytics);
+    let allowed = allowed_tool_names_for(&registry, Some(&user));
+
+    let result = registry
+        .dispatch_gated(
+            "dispatch_task",
+            json!({ "task": "spawn a new session" }),
+            allowed.as_deref(),
+        )
+        .await;
+
+    assert!(result.is_error());
+}
+
+/// The positive case: an `All`-tier caller (or the unauthenticated local
+/// REPL/CLI path, `None`) must still be able to invoke `dispatch_task`
+/// through the same real dispatch path — this fix must not become a
+/// blanket denial.
+#[tokio::test]
+async fn dispatch_task_invocable_for_all_tier_user_through_dispatch_gated() {
+    let registry = registry_with_pm_bridge();
+    let user = UserIdentity::new("u6", "u6", ServiceTier::All);
+    let allowed = allowed_tool_names_for(&registry, Some(&user));
+
+    let result = registry
+        .dispatch_gated(
+            "dispatch_task",
+            json!({ "task": "spawn a new session" }),
+            allowed.as_deref(),
+        )
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "All tier must still reach dispatch_task: {}",
+        result.content()
+    );
+}
+
+#[tokio::test]
+async fn dispatch_task_invocable_when_no_user_through_dispatch_gated() {
+    let registry = registry_with_pm_bridge();
+    let allowed = allowed_tool_names_for(&registry, None);
+
+    let result = registry
+        .dispatch_gated(
+            "dispatch_task",
+            json!({ "task": "spawn a new session" }),
+            allowed.as_deref(),
+        )
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "no UserIdentity (local REPL/CLI) must preserve full access: {}",
+        result.content()
+    );
+}

--- a/crates/trusty-agents/src/intent/mod.rs
+++ b/crates/trusty-agents/src/intent/mod.rs
@@ -15,6 +15,19 @@
 //! research verbs, question words, action-verb tasks, and edge cases.
 //! See `tests` module below — fixes #199, #203.
 
+/// Deterministic Tm-vs-Tcode router for the `dispatch_task` bridge tool
+/// (epic #3052, PR B, lane 3).
+///
+/// Why: a separate, focused module rather than folding into
+/// `classify_intent` above — that classifier answers "how much machinery
+/// does this input need" (conversational / research / implementation);
+/// `route` answers an orthogonal question once the answer is already
+/// "hand this off": WHICH black-boxed backend (orchestration vs direct
+/// coding) should receive it.
+/// What: see `route::route_task` / `route::BridgeRoute`.
+/// Test: `route::route_tests`.
+pub mod route;
+
 /// Classification of user input for PM fast-pathing.
 ///
 /// Why: Distinguishes conversational chatter (no work) from research questions
@@ -172,7 +185,9 @@ const SELF_QUESTIONS: &[&str] = &[
 /// ACTION_VERBS).
 /// Test: Covered indirectly by classifier tests — "Hello!!!" must classify
 /// the same as "hello".
-fn normalize(input: &str) -> String {
+/// `pub(crate)` (not private) so `intent::route`'s `route_task` can reuse the
+/// exact same normalization instead of forking a second copy (#3052 PR B).
+pub(crate) fn normalize(input: &str) -> String {
     let mut out = String::with_capacity(input.len());
     for ch in input.chars() {
         if ch.is_alphanumeric() || ch == '\'' || ch == '-' || ch == '_' || ch.is_whitespace() {

--- a/crates/trusty-agents/src/intent/route.rs
+++ b/crates/trusty-agents/src/intent/route.rs
@@ -1,0 +1,183 @@
+//! `dispatch_task` backend router — decides `Tm` (orchestration) vs `Tcode`
+//! (direct coding) for a black-boxed unit of work (epic #3052, PR B, lane 3).
+//!
+//! Why: `dispatch_task` (see `crate::tools::pm_bridge`) is intentionally
+//! backend-agnostic from the caller's point of view — the LLM never names
+//! `tm`/`tcode`. Something still has to pick a real backend deterministically
+//! (same input -> same route, every time, no I/O, no LLM call) so the tool's
+//! behavior is testable and auditable independent of the model that calls it.
+//! What: `route_task` classifies a free-text task string into `BridgeRoute`
+//! using ordered heuristics over two signal tables (Tcode: coding verbs,
+//! repo-file tokens, error/stack-trace markers; Tm: orchestration/session/
+//! ticket/roadmap vocabulary) — modeled on `intent::classify_intent`'s
+//! constant-table + priority-order approach, reusing `intent::normalize` for
+//! punctuation-insensitive matching.
+//! Test: `route_tests` covers pure-Tcode, pure-Tm, the required ambiguous
+//! cases (including the locked Tm default), and a determinism/no-panic
+//! property sweep mirroring `intent::classifier_property_tests`.
+
+use super::normalize;
+
+/// Backend a `dispatch_task` call is routed to.
+///
+/// Why: the two black-boxed execution paths PR B bridges — `tm` (orchestration
+/// / project / session / issue / PR / multi-agent work) and `tcode` (direct
+/// coding in a repo). Never surfaced to the caller by name; see
+/// `crate::tools::pm_bridge`'s module docs for the black-box contract.
+/// What: `Tm` is the OWNER-LOCKED default for ambiguous/empty input —
+/// orchestration is the home lane. `Tcode` is chosen only when the task text
+/// carries a clear coding signal.
+/// Test: every case in `route_tests`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeRoute {
+    Tm,
+    Tcode,
+}
+
+/// The four "hard" Tcode verbs — concrete enough to win over ANY Tm signal
+/// in the same input (see `route_task`'s precedence rule 1).
+///
+/// Why: "fix the sprint backlog" reads like Tm vocabulary (sprint, backlog)
+/// but "fix" names concrete repo work; a human handed that sentence would
+/// reach for a code change, not a ticket. Keeping this list short and
+/// deliberately verb-only (not `write`/`add`/`create`, which are softer —
+/// see `GENERIC_CODE_VERBS`) avoids over-triggering the highest-precedence
+/// rule.
+const TCODE_HARD_VERBS: &[&str] = &["fix", "debug", "implement", "refactor"];
+
+/// Full Tcode single-token signal set (superset of `TCODE_HARD_VERBS`), used
+/// for the fallback per-side match count (precedence rule 4).
+const TCODE_WORDS: &[&str] = &[
+    "write",
+    "edit",
+    "implement",
+    "refactor",
+    "fix",
+    "bug",
+    "patch",
+    "debug",
+    "compile",
+    "rename",
+];
+
+/// Multi-word Tcode phrases, matched as substrings of the normalized string
+/// (they contain no punctuation, so normalization leaves them intact).
+const TCODE_PHRASES: &[&str] = &["unit test", "failing test", "stack trace"];
+
+/// File-extension tokens that name a source file — checked against the RAW
+/// (pre-normalization) lowercased input, because `intent::normalize` maps
+/// `.`/`/` to whitespace and would destroy `main.rs` / `src/` as tokens.
+const REPO_FILE_EXTENSIONS: &[&str] = &[".rs", ".ts", ".py"];
+
+/// Path-shaped token that names a source tree, checked the same
+/// pre-normalization way as `REPO_FILE_EXTENSIONS`.
+const REPO_FILE_PATH_TOKEN: &str = "src/";
+
+/// Raw (pre-normalization) substring markers — `error:` includes a colon,
+/// which `intent::normalize` also strips, so it must be checked before
+/// normalization like the repo-file tokens above.
+const RAW_TCODE_MARKERS: &[&str] = &["error:"];
+
+/// Generic code verbs that route to Tcode ONLY when no Tm signal is present
+/// (precedence rule 3) — deliberately softer than `TCODE_HARD_VERBS` because
+/// "write up the project roadmap" should NOT out-rank "project"/"roadmap".
+const GENERIC_CODE_VERBS: &[&str] = &["write", "add", "create"];
+
+/// Tm single-token signal set.
+const TM_WORDS: &[&str] = &[
+    "orchestrate",
+    "session",
+    "sessions",
+    "delegate",
+    "agents",
+    "multi-agent",
+    "project",
+    "issue",
+    "issues",
+    "ticket",
+    "pr",
+    "backlog",
+    "sprint",
+    "prioritize",
+    "roadmap",
+    "spawn",
+    "resume",
+    "pause",
+    "coordinate",
+];
+
+/// Multi-word Tm phrases, matched as substrings of the normalized string.
+const TM_PHRASES: &[&str] = &["pull request", "status of", "across repos"];
+
+/// Route a free-text task to a backend, deterministically and with no I/O.
+///
+/// Why: see the module docs — this is the single choke point every
+/// `dispatch_task` call passes through before a backend is ever invoked.
+/// What: applies the precedence order in the module docs: (1) a repo-file
+/// token or a hard Tcode verb wins outright; (2) else any Tm signal wins;
+/// (3) else a generic code verb (with no Tm signal already ruled out by (2))
+/// routes Tcode; (4) else the side with more matched signals wins; (5) a tie
+/// (including zero signals on both sides, and empty/whitespace-only input)
+/// falls back to the OWNER-LOCKED default, `Tm`.
+/// Test: `route_tests::*`.
+pub fn route_task(task: &str) -> BridgeRoute {
+    let raw_lower = task.to_lowercase();
+    let normalized = normalize(task);
+    if normalized.is_empty() {
+        // Empty / whitespace-only / all-punctuation input carries no signal.
+        return BridgeRoute::Tm;
+    }
+    let words: Vec<&str> = normalized.split_whitespace().collect();
+
+    // Rule 1: repo-file token or a hard Tcode verb wins outright, even over
+    // Tm vocabulary in the same sentence.
+    let has_repo_file_token = REPO_FILE_EXTENSIONS
+        .iter()
+        .any(|ext| raw_lower.contains(ext))
+        || raw_lower.contains(REPO_FILE_PATH_TOKEN);
+    let has_hard_tcode_verb = words.iter().any(|w| TCODE_HARD_VERBS.contains(w));
+    if has_repo_file_token || has_hard_tcode_verb {
+        return BridgeRoute::Tcode;
+    }
+
+    // Rule 2: any Tm signal wins once rule 1 has been ruled out.
+    let tm_count =
+        count_word_matches(&words, TM_WORDS) + count_phrase_matches(&normalized, TM_PHRASES);
+    if tm_count > 0 {
+        return BridgeRoute::Tm;
+    }
+
+    // Rule 3: a generic code verb routes Tcode — only reachable here because
+    // rule 2 already proved there is no competing Tm signal.
+    if words.iter().any(|w| GENERIC_CODE_VERBS.contains(w)) {
+        return BridgeRoute::Tcode;
+    }
+
+    // Rule 4/5: fall back to a full per-side count (tm_count is provably 0
+    // here, so this reduces to "any remaining Tcode signal -> Tcode, else
+    // the locked Tm default" — kept as an explicit comparison rather than a
+    // bare `> 0` check so the code reads as the documented "higher count
+    // wins, tie -> Tm" rule instead of a special case).
+    let tcode_count = count_word_matches(&words, TCODE_WORDS)
+        + count_phrase_matches(&normalized, TCODE_PHRASES)
+        + usize::from(RAW_TCODE_MARKERS.iter().any(|m| raw_lower.contains(m)));
+    if tcode_count > tm_count {
+        BridgeRoute::Tcode
+    } else {
+        BridgeRoute::Tm
+    }
+}
+
+/// Count how many words in `list` appear (exact token match) in `words`.
+fn count_word_matches(words: &[&str], list: &[&str]) -> usize {
+    list.iter().filter(|w| words.contains(w)).count()
+}
+
+/// Count how many phrases in `list` appear as substrings of `normalized`.
+fn count_phrase_matches(normalized: &str, list: &[&str]) -> usize {
+    list.iter().filter(|p| normalized.contains(*p)).count()
+}
+
+#[cfg(test)]
+#[path = "route_tests.rs"]
+mod route_tests;

--- a/crates/trusty-agents/src/intent/route_tests.rs
+++ b/crates/trusty-agents/src/intent/route_tests.rs
@@ -1,0 +1,206 @@
+//! Tests for `intent::route` — pure-Tcode, pure-Tm, the required ambiguous
+//! cases, and a determinism/no-panic property sweep (epic #3052, PR B).
+
+use super::*;
+
+// =====================================================================
+// Pure-Tcode cases
+// =====================================================================
+
+#[test]
+fn hard_verb_alone_routes_tcode() {
+    assert_eq!(route_task("please refactor the parser"), BridgeRoute::Tcode);
+}
+
+#[test]
+fn repo_file_extension_routes_tcode() {
+    assert_eq!(
+        route_task("something is wrong in main.rs"),
+        BridgeRoute::Tcode
+    );
+}
+
+#[test]
+fn src_path_token_routes_tcode() {
+    assert_eq!(
+        route_task("look under src/ for the bug"),
+        BridgeRoute::Tcode
+    );
+}
+
+#[test]
+fn count_based_tcode_signals_without_hard_verb_or_file_token() {
+    // No hard verb (fix/debug/implement/refactor), no repo-file token, no Tm
+    // signal — falls through to rule 4, where "patch"/"compile"/"rename"/
+    // "bug" (4 Tcode signals, 0 Tm signals) tip it to Tcode.
+    assert_eq!(
+        route_task("patch the compile error and rename the bug"),
+        BridgeRoute::Tcode
+    );
+}
+
+#[test]
+fn stack_trace_and_error_marker_route_tcode() {
+    assert_eq!(
+        route_task("here is a stack trace, error: null pointer"),
+        BridgeRoute::Tcode
+    );
+}
+
+#[test]
+fn unit_test_phrase_routes_tcode() {
+    assert_eq!(
+        route_task("the unit test for this module keeps failing"),
+        BridgeRoute::Tcode
+    );
+}
+
+// =====================================================================
+// Pure-Tm cases
+// =====================================================================
+
+#[test]
+fn session_and_backlog_route_tm() {
+    assert_eq!(
+        route_task("spawn a new session and check the backlog"),
+        BridgeRoute::Tm
+    );
+}
+
+#[test]
+fn delegate_and_agents_route_tm() {
+    assert_eq!(
+        route_task("delegate this across the agents roster"),
+        BridgeRoute::Tm
+    );
+}
+
+#[test]
+fn pull_request_phrase_routes_tm() {
+    assert_eq!(
+        route_task("what's the status of the pull request"),
+        BridgeRoute::Tm
+    );
+}
+
+#[test]
+fn multi_agent_hyphenated_token_routes_tm() {
+    assert_eq!(
+        route_task("coordinate the multi-agent rollout"),
+        BridgeRoute::Tm
+    );
+}
+
+#[test]
+fn across_repos_phrase_routes_tm() {
+    assert_eq!(
+        route_task("prioritize the roadmap across repos"),
+        BridgeRoute::Tm
+    );
+}
+
+// =====================================================================
+// Required ambiguous cases (spec-mandated)
+// =====================================================================
+
+/// "fix" is a hard Tcode verb — rule 1 fires before the Tm words
+/// ("sprint"/"backlog") are ever counted. This pins the documented
+/// precedence (hard verb beats Tm vocabulary), not a naive "ambiguous -> Tm"
+/// shortcut.
+#[test]
+fn ambiguous_fix_the_sprint_backlog_routes_tcode_via_hard_verb_precedence() {
+    assert_eq!(
+        route_task("fix the sprint backlog"),
+        BridgeRoute::Tcode,
+        "hard Tcode verb 'fix' must win over Tm words 'sprint'/'backlog' (rule 1 precedes rule 2)"
+    );
+}
+
+/// "write" is only a GENERIC code verb (rule 3), not a hard verb (rule 1) —
+/// so the Tm signals "project"/"roadmap" are checked FIRST (rule 2) and win.
+#[test]
+fn ambiguous_write_up_the_project_roadmap_routes_tm_via_signal_precedence() {
+    assert_eq!(
+        route_task("write up the project roadmap"),
+        BridgeRoute::Tm,
+        "Tm words 'project'/'roadmap' must win over the generic verb 'write' (rule 2 precedes rule 3)"
+    );
+}
+
+#[test]
+fn empty_string_routes_tm_default() {
+    assert_eq!(route_task(""), BridgeRoute::Tm);
+}
+
+#[test]
+fn whitespace_only_routes_tm_default() {
+    assert_eq!(route_task("   "), BridgeRoute::Tm);
+}
+
+/// No coding verb, no repo-file token, no Tm vocabulary at all — a genuine
+/// zero-signal tie, must fall back to the locked Tm default.
+#[test]
+fn no_signal_input_routes_tm_default() {
+    assert_eq!(route_task("do the thing"), BridgeRoute::Tm);
+}
+
+// =====================================================================
+// Determinism + no-panic property sweep (mirrors
+// intent::classifier_property_tests)
+// =====================================================================
+
+#[test]
+fn never_panics_on_adversarial_inputs() {
+    let adversarial: Vec<String> = vec![
+        "".into(),
+        " ".into(),
+        "\0".into(),
+        "\x01\x02\x03".into(),
+        "a".repeat(10_000),
+        "/".into(),
+        "src/".repeat(500),
+        "fix ".repeat(200),
+        "\n\n\n".into(),
+        "\u{1F525}\u{1F680}\u{1F480}".into(),
+        "caf\u{00E9} r\u{00E9}sum\u{00E9} na\u{00EF}ve".into(),
+        "\u{4E2D}\u{6587}\u{8F93}\u{5165}".into(),
+        "error:".into(),
+        "main.rs".into(),
+        "tm-tm-tm".into(),
+    ];
+    for input in &adversarial {
+        let _ = route_task(input);
+    }
+}
+
+#[test]
+fn deterministic_across_calls() {
+    let inputs = [
+        "",
+        "fix the sprint backlog",
+        "write up the project roadmap",
+        "spawn a new session and check the backlog",
+        "patch the compile error and rename the bug",
+        "the quick brown fox jumps over the lazy dog",
+    ];
+    for input in &inputs {
+        let first = route_task(input);
+        let second = route_task(input);
+        assert_eq!(first, second, "non-deterministic for '{input}'");
+    }
+}
+
+#[test]
+fn whitespace_padding_invariance() {
+    let inputs = [
+        "fix the parser",
+        "spawn a session",
+        "do the thing",
+        "write up the roadmap",
+    ];
+    for input in &inputs {
+        let plain = route_task(input);
+        let padded = route_task(&format!("  {input}  "));
+        assert_eq!(plain, padded, "whitespace changed the route for '{input}'");
+    }
+}

--- a/crates/trusty-agents/src/runtime/pm_mode.rs
+++ b/crates/trusty-agents/src/runtime/pm_mode.rs
@@ -63,7 +63,10 @@ use agents::AgentConfig;
 use subprocess::SubprocessAgentRunner;
 use tools::{ToolRegistry, delegate::DelegateToAgentTool};
 
+use crate::rbac::ServiceTier;
 use crate::subprocess;
+use crate::tools::pm_bridge::PmBridgeTool;
+use crate::tools::pm_bridge_backend::ProcessPmBridge;
 
 /// PM mode: interactive orchestrator.
 pub(super) async fn run_pm() -> Result<()> {
@@ -91,6 +94,15 @@ pub(super) async fn run_pm() -> Result<()> {
     let runner: Arc<dyn tools::AgentRunner> = Arc::new(SubprocessAgentRunner::new());
     let mut registry = ToolRegistry::new();
     registry.register(Arc::new(DelegateToAgentTool::new(runner)));
+    // #3052 PR B (lane 3): the opaque tm<->tcode bridge, distinct from lane 2
+    // (`delegate_to_agent` above). RBAC-locked to deny ReadOnly + Analytics.
+    {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        registry.register(Arc::new(
+            PmBridgeTool::new(Arc::new(ProcessPmBridge::from_project(cwd)))
+                .with_restricted_tiers(vec![ServiceTier::ReadOnly, ServiceTier::Analytics]),
+        ));
+    }
     // #304: Coordinator-facing shell executor — see `tools::run_bash`.
     {
         let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));

--- a/crates/trusty-agents/src/tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mod.rs
@@ -29,6 +29,8 @@ pub mod native_memory;
 pub mod native_search;
 pub mod native_ticketing;
 pub mod phase_audit;
+pub mod pm_bridge;
+pub mod pm_bridge_backend;
 pub mod registry;
 pub mod run_bash;
 pub mod shell;

--- a/crates/trusty-agents/src/tools/pm_bridge.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge.rs
@@ -156,7 +156,8 @@ fn session_id_pattern() -> &'static Regex {
 /// separator at all between `trusty` and `mpm`/`code`, so `trusty-mpm`,
 /// `trusty mpm`, `Trusty MPM`, and `trustympm` all match the same way.
 /// What: see `scrub_branding`'s docs for the two-pass replacement order.
-/// Test: `scrub_branding_removes_the_real_tm_launch_banner`,
+/// Test: `scrub_branding_removes_the_real_tm_launch_banner_plain_fallback`,
+/// `scrub_branding_removes_the_real_tm_launch_banner_box_form`,
 /// `scrub_branding_removes_every_forbidden_token`.
 fn branded_token_pattern() -> &'static Regex {
     static PATTERN: OnceLock<Regex> = OnceLock::new();

--- a/crates/trusty-agents/src/tools/pm_bridge.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge.rs
@@ -1,0 +1,196 @@
+//! `dispatch_task` — the opaque tm<->tcode "PM bridge" tool (epic #3052, PR
+//! B, lane 3).
+//!
+//! Why: the assistant needs to hand off orchestration/project/session/
+//! issue/PR/multi-agent work to `tm` and direct-coding-in-a-repo work to
+//! `tcode` WITHOUT the caller — the user, or the LLM itself — ever learning
+//! that either backend, or trusty-mpm/trusty-code by name, exists. Lane 2
+//! (`delegate_to_agent`, `crate::tools::delegate`) already handles in-process
+//! sub-agent delegation; this is the DISTINCT lane for routing to the two
+//! external opaque backends. `route_task` (`crate::intent::route`) decides
+//! WHICH backend deterministically and with no I/O so the routing decision
+//! itself is unit-testable independent of any LLM or subprocess; this tool
+//! is the thin glue that calls it, dispatches to a `PmBridgeBackend`, and
+//! scrubs the backend's identity out of both the schema text and the result
+//! before either can leak to a black-boxed persona.
+//! What: `PmBridgeTool` implements `ToolExecutor` as `dispatch_task`. Its
+//! schema never mentions `tm`/`tcode`/`trusty-mpm`/`trusty-code`/"routing".
+//! `restricted_tiers()` denies `ServiceTier::ReadOnly` AND
+//! `ServiceTier::Analytics` (owner-locked — see epic #3052's PR B decision
+//! log) so those tiers never see the tool at all. `execute()` returns the
+//! FULL backend transcript (not a summary) run through `scrub_branding`,
+//! win or lose — errors are scrubbed too, since a raw backend error (e.g.
+//! "failed to spawn tm serve --stdio") would otherwise leak identity through
+//! the failure path the owner's spec text didn't explicitly call out.
+//! Test: `pm_bridge_tests` — `RecordingBackend` proves routing reaches the
+//! right side, `scrub_branding` strips every forbidden token from a sample
+//! backend transcript, `name()`/`schema()` stay clean, and an RBAC test
+//! proves both denied tiers never see the tool via `filter_tools_for_user`.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use regex::Regex;
+use serde_json::{Value, json};
+
+use crate::intent::route::route_task;
+use crate::rbac::ServiceTier;
+use crate::tools::pm_bridge_backend::PmBridgeBackend;
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// `dispatch_task` — hands a task to whichever backend `route_task` decides,
+/// via an injected `PmBridgeBackend`.
+pub struct PmBridgeTool {
+    backend: Arc<dyn PmBridgeBackend>,
+    restricted: Vec<ServiceTier>,
+}
+
+impl PmBridgeTool {
+    /// Construct with an injected backend and no RBAC restriction.
+    ///
+    /// Why: mirrors `DelegateToAgentTool::new` — tests substitute a
+    /// `RecordingBackend` without touching the production subprocess/MCP
+    /// code; production call sites always chain `with_restricted_tiers`
+    /// (see `ctrl::pm_task::dispatch::history` / `runtime::pm_mode`).
+    /// What: stores `backend`; `restricted` starts empty (open access) until
+    /// `with_restricted_tiers` narrows it.
+    /// Test: `dispatch_task_routes_code_task_to_tcode` and siblings.
+    pub fn new(backend: Arc<dyn PmBridgeBackend>) -> Self {
+        Self {
+            backend,
+            restricted: Vec::new(),
+        }
+    }
+
+    /// Attach the RBAC-denied tiers.
+    ///
+    /// Why: the owner-locked decision denies BOTH `ReadOnly` and
+    /// `Analytics` (see the module docs) — a builder method keeps that
+    /// list a single source of truth at the registration call site rather
+    /// than hardcoded inside this file.
+    /// What: replaces `restricted` with `tiers`.
+    /// Test: `dispatch_task_denies_read_only_and_analytics_tiers`.
+    pub fn with_restricted_tiers(mut self, tiers: Vec<ServiceTier>) -> Self {
+        self.restricted = tiers;
+        self
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for PmBridgeTool {
+    fn name(&self) -> &str {
+        "dispatch_task"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "dispatch_task",
+                "description": "Hand off a self-contained unit of work — a coding change in a repo, a multi-step coordination or planning task, a status check — so it actually gets done. The system inspects the task and automatically picks the right way to execute it; you never need to say how. Returns the full result once the work completes.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "task": {
+                            "type": "string",
+                            "description": "A concrete, self-contained description of the work to hand off."
+                        }
+                    },
+                    "required": ["task"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(task) = args.get("task").and_then(Value::as_str) else {
+            return ToolResult::err("dispatch_task: missing 'task'");
+        };
+        if task.trim().is_empty() {
+            return ToolResult::err("dispatch_task: 'task' must not be empty");
+        }
+
+        let route = route_task(task);
+        match self.backend.run(route, task).await {
+            Ok(out) => ToolResult::ok(scrub_branding(&out)),
+            // Scrubbed too: a raw backend error can name the process it
+            // tried to spawn (see `ProcessPmBridge::run_tcode`/`run_tm`),
+            // which would defeat the whole point of a black-boxed tool.
+            Err(e) => ToolResult::err(scrub_branding(&format!("dispatch_task failed: {e:#}"))),
+        }
+    }
+
+    fn restricted_tiers(&self) -> &[ServiceTier] {
+        &self.restricted
+    }
+}
+
+/// Regex matching a tm-style ephemeral tmux session name (`tm-<word>-<word>`)
+/// or a UUIDv4-shaped session id — both are backend-identifying artifacts a
+/// raw transcript can carry (see `ProcessPmBridge::run_tm`'s pane content /
+/// `session_new`'s returned id).
+fn session_id_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(
+            r"(?i)\b(tm-[a-z0-9]+-[a-z0-9]+|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b",
+        )
+        .expect("session id pattern is a valid static regex")
+    })
+}
+
+/// Regex matching a standalone backend-identity token: `tm`, `tcode`,
+/// `trusty-mpm`/`Trusty MPM`, `trusty-code`/`Trusty Code`. Word-bounded so
+/// it does NOT match inside unrelated words (`tmux`, `atm`, `item`,
+/// `system`).
+///
+/// Why (code-critic BLOCK, finding 1): the original pattern required the
+/// literal hyphen (`trusty-mpm`), but `tm`'s own launch banner prints the
+/// space-separated title-case wordmark `Trusty MPM v{VERSION}` (see
+/// `crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs` and
+/// `.../banner/two_panel/mod.rs`'s `render_title_bar`) — and that banner is
+/// the FIRST thing `run_tm` captures via `session_activity`, so it leaked
+/// straight through `ToolResult::ok` untouched by the hyphen-only pattern.
+/// `[\s_-]*` accepts a hyphen, underscore, any run of whitespace, or no
+/// separator at all between `trusty` and `mpm`/`code`, so `trusty-mpm`,
+/// `trusty mpm`, `Trusty MPM`, and `trustympm` all match the same way.
+/// What: see `scrub_branding`'s docs for the two-pass replacement order.
+/// Test: `scrub_branding_removes_the_real_tm_launch_banner`,
+/// `scrub_branding_removes_every_forbidden_token`.
+fn branded_token_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(r"(?i)\b(trusty[\s_-]*mpm|trusty[\s_-]*code|tcode|tm)\b")
+            .expect("branded token pattern is a valid static regex")
+    })
+}
+
+/// Strip backend-identity tokens and session-id-shaped artifacts out of a
+/// raw backend transcript before it can reach a black-boxed persona.
+///
+/// Why: `dispatch_task`'s entire premise (owner-locked, epic #3052 PR B) is
+/// that the caller never learns which backend ran its task. The router
+/// (`route_task`) and the backend (`ProcessPmBridge`) both necessarily know
+/// — they spawn processes literally named `tm`/`tcode` — so the boundary
+/// where that knowledge must stop is exactly here, right before the tool
+/// returns anything to the LLM loop.
+/// What: replaces `tm-<word>-<word>` tmux session names and UUID-shaped
+/// session ids with `[session]`, THEN replaces standalone (word-bounded,
+/// case-insensitive) `tm`/`tcode`/`trusty-mpm`/`trusty-code` tokens with
+/// "the system". Session-id substitution runs first so a name like
+/// `tm-quiet-falcon` is replaced as one unit rather than leaving a
+/// dangling `-quiet-falcon` behind after the shorter `tm` token match.
+/// Test: `scrub_branding_removes_every_forbidden_token`,
+/// `scrub_branding_redacts_session_identifiers`,
+/// `scrub_branding_leaves_unrelated_words_alone`.
+pub fn scrub_branding(input: &str) -> String {
+    let redacted_sessions = session_id_pattern().replace_all(input, "[session]");
+    branded_token_pattern()
+        .replace_all(&redacted_sessions, "the system")
+        .into_owned()
+}
+
+#[cfg(test)]
+#[path = "pm_bridge_tests.rs"]
+mod pm_bridge_tests;

--- a/crates/trusty-agents/src/tools/pm_bridge_backend.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_backend.rs
@@ -1,0 +1,339 @@
+//! Backend seam for `dispatch_task` (epic #3052, PR B, lane 3): routes a
+//! `BridgeRoute` to either `tcode` (one-shot subprocess) or `tm` (MCP over
+//! stdio) and returns its raw output for the tool layer to scrub and return.
+//!
+//! Why: `PmBridgeTool` (see `crate::tools::pm_bridge`) must be testable
+//! without spawning real subprocesses — mirrors the `AgentRunner` DI seam
+//! `DelegateToAgentTool` already uses (`crate::tools::traits::AgentRunner`,
+//! tested via `delegate.rs`'s `RecordingRunner`). `PmBridgeBackend` is the
+//! same shape: one async method, object-safe, `Send + Sync`.
+//! What: `PmBridgeBackend` is the trait; `ProcessPmBridge` is the production
+//! implementation. Tcode invocation is a one-shot blocking subprocess —
+//! `tcode run-task pm <task> --project <dir> --json` (`crates/trusty-code/
+//! src/main.rs`'s `RunTask` variant, `crates/trusty-code/src/cli/run_task.rs`)
+//! — which itself blocks until the daemon-owned session reaches a terminal
+//! state before exiting, so a single subprocess call is genuinely
+//! synchronous end-to-end. Tm invocation spawns `tm serve --stdio`
+//! (`StdioMcpClient::spawn`) and calls the managed-session lifecycle tools;
+//! see `run_tm`'s docs for why this is a documented MVP deviation from a
+//! true one-shot RPC (tm has none — see the docs there).
+//! Test: `pm_bridge_backend_tests` covers `binary_on_path`, graceful
+//! "binary absent" errors for both routes, and binary-gated integration
+//! smokes against the real `tcode`/`tm` binaries when present on PATH.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::process::Command;
+use tokio::time::sleep;
+
+use crate::intent::route::BridgeRoute;
+use crate::plugins::stdio_mcp::StdioMcpClient;
+
+/// How many times `run_tm` polls `session_activity` before giving up and
+/// returning whatever transcript has been observed so far.
+///
+/// Why: tm's managed-session lifecycle is inherently async (tmux-attached,
+/// provisioned from a git clone) — there is no synchronous "run this and
+/// block until done" RPC (see `run_tm`'s docs). A bounded poll keeps
+/// `dispatch_task` from hanging the calling LLM turn indefinitely while
+/// still giving a fast-completing task a real chance to finish.
+const MAX_POLL_ATTEMPTS: u32 = 10;
+
+/// Delay between `session_activity` polls.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Number of trailing tmux pane lines requested per `session_activity` poll.
+const ACTIVITY_LINES: u64 = 200;
+
+/// Executes a routed `dispatch_task` call against a real backend.
+///
+/// Why: see the module docs — the DI seam that lets `PmBridgeTool` be unit
+/// tested with a `RecordingBackend` instead of spawning real subprocesses.
+/// What: `run` takes the already-decided `route` (never re-derives it) and
+/// the raw task text, and returns the backend's raw (un-scrubbed) output.
+/// Scrubbing is the TOOL layer's job (`crate::tools::pm_bridge::scrub_branding`),
+/// not the backend's — keeping backend identity out of this trait's contract
+/// would be a false promise given `ProcessPmBridge` inherently talks to
+/// processes named `tcode`/`tm`.
+/// Test: `RecordingBackend` in `pm_bridge_tests.rs`; `ProcessPmBridge` in
+/// `pm_bridge_backend_tests.rs`.
+#[async_trait]
+pub trait PmBridgeBackend: Send + Sync {
+    async fn run(&self, route: BridgeRoute, task: &str) -> Result<String>;
+}
+
+/// Production `PmBridgeBackend`: subprocess `tcode` for `Tcode`, MCP-over-
+/// stdio `tm` for `Tm`.
+pub struct ProcessPmBridge {
+    project_dir: PathBuf,
+}
+
+impl ProcessPmBridge {
+    /// Construct a backend rooted at `project_dir` — the repo/project both
+    /// backends operate against.
+    ///
+    /// Why: `dispatch_task` always acts on the calling session's own
+    /// project, never an LLM-supplied path (that would be an injection
+    /// vector); the project directory is threaded in once at registration
+    /// time (see `crate::ctrl::pm_task::dispatch::history` and
+    /// `crate::runtime::pm_mode`), not read from tool arguments.
+    /// What: stores `project_dir` for later use by both `run_tcode` and
+    /// `run_tm`.
+    /// Test: `process_pm_bridge_tcode_route_fails_closed_without_binary`,
+    /// `process_pm_bridge_tm_route_fails_closed_without_binary`.
+    pub fn from_project(project_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            project_dir: project_dir.into(),
+        }
+    }
+
+    /// Run the `Tcode` route: `tcode run-task pm <task> --project <dir> --json`.
+    ///
+    /// Why: see the module docs — this subcommand blocks until the
+    /// daemon-owned session it creates reaches a terminal state, so one
+    /// subprocess call is a genuine synchronous round trip. `--json` emits
+    /// the final `Session` snapshot (id/status/mode) as the process's only
+    /// stdout; it is NOT a full per-step transcript (no tool-call/diff
+    /// detail) — a documented scope limit, see the module docs' pointer to
+    /// `cli/run_task.rs`.
+    /// What: spawns the subprocess, waits for it to exit, and returns
+    /// stdout (falling back to stderr if stdout is empty) as the raw
+    /// transcript. Fails closed with a generic-shaped error when `tcode` is
+    /// not on PATH, mirroring `TrustySearchPlugin::try_spawn`'s
+    /// graceful-degradation contract.
+    /// Test: `process_pm_bridge_tcode_route_fails_closed_without_binary`;
+    /// `tcode_route_smoke` (binary-gated).
+    async fn run_tcode(&self, task: &str) -> Result<String> {
+        if !binary_on_path("tcode") {
+            bail!("tcode backend unavailable: binary not found on PATH");
+        }
+        let output = Command::new("tcode")
+            .arg("run-task")
+            .arg("pm")
+            .arg(task)
+            .arg("--project")
+            .arg(&self.project_dir)
+            .arg("--json")
+            .output()
+            .await
+            .context("failed to spawn tcode run-task subprocess")?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+        if !output.status.success() && stdout.trim().is_empty() {
+            bail!(
+                "tcode run-task exited with {}: {}",
+                output.status,
+                stderr.trim()
+            );
+        }
+        Ok(if stdout.trim().is_empty() {
+            stderr
+        } else {
+            stdout
+        })
+    }
+
+    /// Run the `Tm` route: spawn `tm serve --stdio` and drive the
+    /// managed-session lifecycle.
+    ///
+    /// Why (MVP DEVIATION — flagged design call): the owner's default
+    /// suggestion was `agent_delegate`, but that tool is explicitly
+    /// documented on the tm side as "a TRACKING/GATING companion, NOT an
+    /// execution path — it does not spawn the agent"
+    /// (`crates/trusty-mpm/src/mcp/tools/core.rs`). It cannot execute
+    /// anything. The only tm MCP surface that actually RUNS work is the
+    /// managed-session lifecycle (`session_new` / `session_activity` /
+    /// `session_decommission`), which is inherently asynchronous and
+    /// tmux-attached (it clones a repo into a fresh workspace and launches
+    /// a full harness) — there is no synchronous "run this task headlessly
+    /// and return the result" RPC on tm today. This implementation spawns
+    /// an EPHEMERAL managed session against `project_dir` (as a `file://`
+    /// URL) and does a BOUNDED poll of `session_activity` for its tmux pane
+    /// content, then best-effort tears the session down. For a task that
+    /// completes within the poll window this returns real output; for a
+    /// longer-running orchestration task it returns a partial transcript.
+    /// Recommend filing a follow-up for a proper synchronous tm "run task"
+    /// RPC so this bridge does not have to reimplement session polling.
+    /// What: `session_new(repo_url=file://<project_dir>, ref=HEAD, task,
+    /// ephemeral=true)` -> poll `session_activity` up to
+    /// `MAX_POLL_ATTEMPTS` times, `POLL_INTERVAL` apart, capturing the pane
+    /// content and stopping early once `runtime_active` goes false ->
+    /// best-effort `session_decommission` -> return the last captured pane
+    /// content.
+    /// Test: `process_pm_bridge_tm_route_fails_closed_without_binary`;
+    /// `tm_route_smoke` (binary-gated).
+    async fn run_tm(&self, task: &str) -> Result<String> {
+        if !binary_on_path("tm") {
+            bail!("tm backend unavailable: binary not found on PATH");
+        }
+        let mut client = StdioMcpClient::spawn("tm", &["serve", "--stdio"], "trusty-agents")
+            .await
+            .context("failed to spawn tm serve --stdio")?;
+        client
+            .initialize()
+            .await
+            .context("tm MCP handshake failed")?;
+
+        let repo_url = format!("file://{}", self.project_dir.display());
+        let new_result = client
+            .call_tool(
+                "session_new",
+                json!({
+                    "repo_url": repo_url,
+                    "ref": "HEAD",
+                    "task": task,
+                    "ephemeral": true,
+                }),
+            )
+            .await
+            .context("tm session_new failed")?;
+        let session_id = extract_session_id(&new_result)
+            .context("tm session_new response did not include a session id")?;
+
+        let mut transcript = String::new();
+        for _ in 0..MAX_POLL_ATTEMPTS {
+            sleep(POLL_INTERVAL).await;
+            match client
+                .call_tool(
+                    "session_activity",
+                    json!({ "session_id": session_id, "lines": ACTIVITY_LINES }),
+                )
+                .await
+            {
+                Ok(activity) => {
+                    if let Some(pane) = extract_pane_content(&activity) {
+                        transcript = pane;
+                    }
+                    if !is_runtime_active(&activity) {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "tm session_activity poll failed");
+                    break;
+                }
+            }
+        }
+
+        // Best-effort cleanup — an ephemeral session left running is
+        // eventually reaped, but tearing it down promptly avoids leaking
+        // fleet capacity across many dispatch_task calls. Never fails the
+        // overall call, but a failure here MUST be logged (code-critic HIGH
+        // finding 3): silently swallowing it left zero trace of an orphaned
+        // session/workspace, undiagnosable in production.
+        if let Err(e) = client
+            .call_tool("session_decommission", json!({ "session_id": session_id }))
+            .await
+        {
+            tracing::warn!(
+                session_id = %session_id,
+                error = %e,
+                "tm session_decommission failed; session may be orphaned"
+            );
+        }
+
+        if transcript.trim().is_empty() {
+            bail!("tm session produced no observable output within the poll window");
+        }
+        Ok(transcript)
+    }
+}
+
+#[async_trait]
+impl PmBridgeBackend for ProcessPmBridge {
+    async fn run(&self, route: BridgeRoute, task: &str) -> Result<String> {
+        match route {
+            BridgeRoute::Tcode => self.run_tcode(task).await,
+            BridgeRoute::Tm => self.run_tm(task).await,
+        }
+    }
+}
+
+/// Decide whether `name` is on `$PATH`, without spawning a subprocess.
+///
+/// Why: same rationale as `plugins::trusty_search::binary_on_path` (avoid a
+/// `which` fork/exec on every check) — kept as a small local copy rather
+/// than reusing that one because it is `pub(super)`-scoped to `plugins` and
+/// this module lives in `tools`, a sibling tree; duplicating ~5 lines is
+/// cheaper than widening that visibility for one caller.
+/// What: returns true iff `<dir>/<name>` is a regular file for some `dir` on
+/// `$PATH`.
+/// Test: `binary_on_path_recognises_sh` in `pm_bridge_backend_tests.rs`.
+pub(super) fn binary_on_path(name: &str) -> bool {
+    std::env::var_os("PATH")
+        .map(|paths| std::env::split_paths(&paths).any(|p| p.join(name).is_file()))
+        .unwrap_or(false)
+}
+
+/// Pull a session id out of an MCP `tools/call` result for `session_new`.
+///
+/// Why: the tm daemon wraps its JSON result as `{"content":[{"type":"text",
+/// "text":"<json>"}]}` (see `crates/trusty-mpm/src/mcp/mod.rs`'s
+/// `success_result`), matching the same convention
+/// `plugins::trusty_search::extract_text_results` already decodes.
+/// What: parses the first `content[].text` frame as JSON and returns its
+/// `id` (falling back to `session_id`) field as a string.
+/// Test: `extract_session_id_parses_wrapped_text_frame`,
+/// `extract_session_id_missing_id_returns_none`.
+fn extract_session_id(call_tool_result: &Value) -> Option<String> {
+    let inner = decode_first_text_frame(call_tool_result)?;
+    inner
+        .get("id")
+        .or_else(|| inner.get("session_id"))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// Pull the raw tmux pane content out of a `session_activity` MCP result.
+///
+/// Why: `session_activity`'s daemon-side payload carries `pane_content`
+/// (the raw trailing tmux lines) alongside structured lifecycle fields —
+/// this is the closest thing tm has to a "transcript" for a managed
+/// session.
+/// What: decodes the wrapped text frame (see `extract_session_id`) and
+/// returns its `pane_content` field, or `None` if absent/non-string.
+/// Test: `extract_pane_content_parses_wrapped_text_frame`.
+fn extract_pane_content(call_tool_result: &Value) -> Option<String> {
+    let inner = decode_first_text_frame(call_tool_result)?;
+    inner
+        .get("pane_content")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// Whether a `session_activity` result reports the runtime as still active.
+///
+/// Why: the poll loop in `run_tm` stops early once the session's harness is
+/// done rather than always burning the full `MAX_POLL_ATTEMPTS` window.
+/// What: decodes the wrapped text frame and reads its `runtime_active`
+/// boolean field, defaulting to `true` (keep polling) when absent/malformed
+/// — a fail-safe default that costs at most a few extra poll iterations
+/// rather than truncating a still-running session's transcript.
+/// Test: `is_runtime_active_defaults_true_when_absent`.
+fn is_runtime_active(call_tool_result: &Value) -> bool {
+    decode_first_text_frame(call_tool_result)
+        .and_then(|inner| inner.get("runtime_active").and_then(Value::as_bool))
+        .unwrap_or(true)
+}
+
+/// Shared decode step for `extract_session_id` / `extract_pane_content` /
+/// `is_runtime_active`: parse the first `content[].text` frame of an MCP
+/// `tools/call` result as JSON.
+fn decode_first_text_frame(call_tool_result: &Value) -> Option<Value> {
+    let text = call_tool_result
+        .get("content")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first())
+        .and_then(|item| item.get("text"))
+        .and_then(Value::as_str)?;
+    serde_json::from_str::<Value>(text).ok()
+}
+
+#[cfg(test)]
+#[path = "pm_bridge_backend_tests.rs"]
+mod pm_bridge_backend_tests;

--- a/crates/trusty-agents/src/tools/pm_bridge_backend_tests.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_backend_tests.rs
@@ -1,0 +1,235 @@
+//! Tests for `tools::pm_bridge_backend` — `binary_on_path`, the decode
+//! helpers, fail-closed behavior when the target binary is absent, and
+//! binary-gated integration smokes against the real `tcode`/`tm` binaries.
+//!
+//! Why `#![allow(clippy::await_holding_lock)]`: the two `fails_closed`
+//! tests hold `crate::test_env::ENV_LOCK` across `.await` points by design
+//! — they mutate the process-wide `$PATH` for their whole body, matching
+//! the established crate-wide convention documented in `crate::test_env`
+//! and already used by `system_status::daemons::tests` /
+//! `llm::credentials::tests`.
+#![allow(clippy::await_holding_lock)]
+
+use serde_json::json;
+
+use super::*;
+
+// =====================================================================
+// binary_on_path
+// =====================================================================
+
+#[test]
+#[cfg(unix)]
+fn binary_on_path_recognises_sh() {
+    assert!(binary_on_path("sh"));
+    assert!(!binary_on_path("definitely-not-a-real-binary-xyzzy"));
+}
+
+// =====================================================================
+// Decode helpers
+// =====================================================================
+
+#[test]
+fn extract_session_id_parses_wrapped_text_frame() {
+    let resp = json!({
+        "content": [{ "type": "text", "text": "{\"id\":\"sess-123\",\"status\":\"active\"}" }]
+    });
+    assert_eq!(extract_session_id(&resp).as_deref(), Some("sess-123"));
+}
+
+#[test]
+fn extract_session_id_falls_back_to_session_id_field() {
+    let resp = json!({
+        "content": [{ "type": "text", "text": "{\"session_id\":\"sess-456\"}" }]
+    });
+    assert_eq!(extract_session_id(&resp).as_deref(), Some("sess-456"));
+}
+
+#[test]
+fn extract_session_id_missing_id_returns_none() {
+    let resp = json!({
+        "content": [{ "type": "text", "text": "{\"status\":\"active\"}" }]
+    });
+    assert_eq!(extract_session_id(&resp), None);
+}
+
+#[test]
+fn extract_session_id_missing_content_returns_none() {
+    let resp = json!({ "isError": false });
+    assert_eq!(extract_session_id(&resp), None);
+}
+
+#[test]
+fn extract_pane_content_parses_wrapped_text_frame() {
+    let resp = json!({
+        "content": [{ "type": "text", "text": "{\"pane_content\":\"hello from the pane\"}" }]
+    });
+    assert_eq!(
+        extract_pane_content(&resp).as_deref(),
+        Some("hello from the pane")
+    );
+}
+
+#[test]
+fn is_runtime_active_defaults_true_when_absent() {
+    let resp = json!({
+        "content": [{ "type": "text", "text": "{\"pane_content\":\"x\"}" }]
+    });
+    assert!(is_runtime_active(&resp));
+}
+
+#[test]
+fn is_runtime_active_reads_false() {
+    let resp = json!({
+        "content": [{ "type": "text", "text": "{\"runtime_active\":false}" }]
+    });
+    assert!(!is_runtime_active(&resp));
+}
+
+// =====================================================================
+// Fail-closed behavior when the target binary is absent from PATH
+// =====================================================================
+
+/// Point `$PATH` at an empty tempdir (containing neither `tcode` nor `tm`),
+/// run `body`, then restore the original `$PATH`. Caller must hold
+/// `crate::test_env::ENV_LOCK` for the whole call — see the module docs.
+async fn with_empty_path<Fut: std::future::Future<Output = anyhow::Result<String>>>(
+    body: impl FnOnce() -> Fut,
+) -> anyhow::Result<String> {
+    let empty_dir = tempfile::tempdir().unwrap();
+    let original = std::env::var_os("PATH");
+    // SAFETY: ENV_LOCK held by the caller for the whole body.
+    unsafe {
+        std::env::set_var("PATH", empty_dir.path());
+    }
+    let result = body().await;
+    // SAFETY: see above.
+    unsafe {
+        match &original {
+            Some(v) => std::env::set_var("PATH", v),
+            None => std::env::remove_var("PATH"),
+        }
+    }
+    result
+}
+
+#[tokio::test]
+async fn process_pm_bridge_tcode_route_fails_closed_without_binary() {
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    let tmp = tempfile::tempdir().unwrap();
+    let bridge = ProcessPmBridge::from_project(tmp.path().to_path_buf());
+    let err = with_empty_path(|| bridge.run(BridgeRoute::Tcode, "fix the parser"))
+        .await
+        .expect_err("must fail closed when tcode is not on PATH");
+    assert!(
+        format!("{err:#}").contains("tcode"),
+        "error should name the missing binary for diagnosability: {err:#}"
+    );
+}
+
+#[tokio::test]
+async fn process_pm_bridge_tm_route_fails_closed_without_binary() {
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    let tmp = tempfile::tempdir().unwrap();
+    let bridge = ProcessPmBridge::from_project(tmp.path().to_path_buf());
+    let err = with_empty_path(|| bridge.run(BridgeRoute::Tm, "spawn a new session"))
+        .await
+        .expect_err("must fail closed when tm is not on PATH");
+    assert!(
+        format!("{err:#}").contains("tm"),
+        "error should name the missing binary for diagnosability: {err:#}"
+    );
+}
+
+// =====================================================================
+// Binary-gated integration smokes (skip when the real binary is absent —
+// mirrors plugins::trusty_search's try_spawn contract).
+// =====================================================================
+
+const FORBIDDEN_BRANDING_TOKENS: [&str; 4] = ["trusty-mpm", "trusty-code", "tcode", "tm"];
+
+/// Word-tokenized forbidden-token check — mirrors
+/// `pm_bridge_tests::scrub_branding_removes_every_forbidden_token`. A plain
+/// substring `.contains("tm")` false-positives on innocent text (observed
+/// live: macOS tempdir names like `.tmpBmUq52` contain "tm"), so the
+/// production contract this smoke actually verifies — no BRANDED WORD
+/// survives — is checked the same word-bounded way `scrub_branding`'s own
+/// regex enforces it, not a raw substring scan.
+fn assert_no_branded_word(text: &str) {
+    let lower = text.to_lowercase();
+    for word in lower.split_whitespace() {
+        let trimmed = word.trim_matches(|c: char| !c.is_alphanumeric() && c != '-');
+        assert!(
+            !FORBIDDEN_BRANDING_TOKENS.contains(&trimmed),
+            "backend-identity token '{trimmed}' leaked as a whole word in: {text}"
+        );
+    }
+}
+
+/// Real end-to-end run through `ProcessPmBridge::run_tcode` -> the tool
+/// layer's `scrub_branding`: skipped unless `tcode` is on PATH. Asserts a
+/// non-error result whose SCRUBBED text carries no backend-identity token —
+/// this is the actual production contract (`PmBridgeTool::execute` always
+/// scrubs before returning; the raw backend transcript alone is not
+/// guaranteed to be branding-free, e.g. an incidental tempdir path).
+///
+/// Holds `crate::test_env::ENV_LOCK` for the whole body (including the
+/// `binary_on_path` check and the subprocess spawn): without it this test
+/// races the `fails_closed` tests above, which mutate `$PATH` process-wide
+/// — observed live as a genuine flake (this test reporting "binary not
+/// found" while `tcode` was actually installed, because a sibling test's
+/// PATH-clearing window overlapped this one's `binary_on_path` check).
+#[tokio::test]
+async fn tcode_route_smoke() {
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if !binary_on_path("tcode") {
+        eprintln!("tcode not on PATH; skipping tcode_route_smoke");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude/agents")).unwrap();
+    let bridge = ProcessPmBridge::from_project(tmp.path().to_path_buf());
+    let result = bridge
+        .run(BridgeRoute::Tcode, "reply with a one-line status only")
+        .await;
+    match result {
+        Ok(out) => assert_no_branded_word(&crate::tools::pm_bridge::scrub_branding(&out)),
+        Err(e) => {
+            // A live smoke without a properly configured project (no pm
+            // agent, no credentials) failing is acceptable here — the
+            // binary-presence gate is what this test actually verifies.
+            eprintln!("tcode_route_smoke: run failed (acceptable in an unconfigured env): {e:#}");
+        }
+    }
+}
+
+/// Real end-to-end run through `ProcessPmBridge::run_tm` -> `scrub_branding`:
+/// skipped unless `tm` is on PATH. Holds `ENV_LOCK` for the same reason as
+/// `tcode_route_smoke`.
+#[tokio::test]
+async fn tm_route_smoke() {
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    if !binary_on_path("tm") {
+        eprintln!("tm not on PATH; skipping tm_route_smoke");
+        return;
+    }
+    let tmp = tempfile::tempdir().unwrap();
+    let bridge = ProcessPmBridge::from_project(tmp.path().to_path_buf());
+    let result = bridge.run(BridgeRoute::Tm, "report session status").await;
+    match result {
+        Ok(out) => assert_no_branded_word(&crate::tools::pm_bridge::scrub_branding(&out)),
+        Err(e) => {
+            eprintln!("tm_route_smoke: run failed (acceptable in an unconfigured env): {e:#}");
+        }
+    }
+}

--- a/crates/trusty-agents/src/tools/pm_bridge_tests.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_tests.rs
@@ -1,0 +1,312 @@
+//! Tests for `tools::pm_bridge` — `RecordingBackend`-driven routing
+//! assertions, `scrub_branding` coverage, schema/name black-box hygiene, and
+//! the RBAC gate (epic #3052, PR B).
+
+use std::sync::Mutex;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::json;
+
+use super::*;
+use crate::intent::route::BridgeRoute;
+use crate::tools::ToolRegistry;
+
+/// Mock backend that records the route it was invoked with and returns a
+/// fixed, caller-supplied transcript — mirrors `delegate.rs`'s
+/// `RecordingRunner`.
+struct RecordingBackend {
+    invoked_with: Mutex<Vec<(BridgeRoute, String)>>,
+    response: String,
+}
+
+impl RecordingBackend {
+    fn new(response: impl Into<String>) -> Self {
+        Self {
+            invoked_with: Mutex::new(Vec::new()),
+            response: response.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl PmBridgeBackend for RecordingBackend {
+    async fn run(&self, route: BridgeRoute, task: &str) -> Result<String> {
+        self.invoked_with
+            .lock()
+            .unwrap()
+            .push((route, task.to_string()));
+        Ok(self.response.clone())
+    }
+}
+
+/// Mock backend that always fails, to exercise the scrubbed-error path.
+struct FailingBackend {
+    message: String,
+}
+
+#[async_trait]
+impl PmBridgeBackend for FailingBackend {
+    async fn run(&self, _route: BridgeRoute, _task: &str) -> Result<String> {
+        Err(anyhow::anyhow!(self.message.clone()))
+    }
+}
+
+// =====================================================================
+// Routing
+// =====================================================================
+
+#[tokio::test]
+async fn dispatch_task_routes_code_task_to_tcode() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool
+        .execute(json!({ "task": "fix the failing unit test in parser.rs" }))
+        .await;
+
+    assert!(!result.is_error(), "expected success: {}", result.content());
+    let invoked = backend.invoked_with.lock().unwrap();
+    assert_eq!(invoked.len(), 1);
+    assert_eq!(invoked[0].0, BridgeRoute::Tcode);
+}
+
+#[tokio::test]
+async fn dispatch_task_routes_orchestration_task_to_tm() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool
+        .execute(json!({ "task": "spawn a new session and check the backlog" }))
+        .await;
+
+    assert!(!result.is_error(), "expected success: {}", result.content());
+    let invoked = backend.invoked_with.lock().unwrap();
+    assert_eq!(invoked.len(), 1);
+    assert_eq!(invoked[0].0, BridgeRoute::Tm);
+}
+
+#[tokio::test]
+async fn dispatch_task_missing_task_arg_is_rejected_without_invoking_backend() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool.execute(json!({})).await;
+
+    assert!(result.is_error());
+    assert!(backend.invoked_with.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn dispatch_task_empty_task_arg_is_rejected_without_invoking_backend() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool.execute(json!({ "task": "   " })).await;
+
+    assert!(result.is_error());
+    assert!(backend.invoked_with.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn dispatch_task_scrubs_a_failing_backend_error() {
+    let backend = Arc::new(FailingBackend {
+        message: "failed to spawn tm serve --stdio: No such file or directory".to_string(),
+    });
+    let tool = PmBridgeTool::new(backend);
+
+    let result = tool.execute(json!({ "task": "do something" })).await;
+
+    assert!(result.is_error());
+    let msg = result.content().to_lowercase();
+    assert!(
+        !msg.contains("tm serve") && !msg.contains(" tm "),
+        "backend error must be scrubbed of backend identity, got: {}",
+        result.content()
+    );
+}
+
+// =====================================================================
+// scrub_branding
+// =====================================================================
+
+#[test]
+fn scrub_branding_removes_every_forbidden_token() {
+    let sample = "Routed via tm to trusty-mpm, which handed off to tcode \
+                  (trusty-code) for the actual edit.";
+    let scrubbed = scrub_branding(sample);
+    for forbidden in ["tm", "tcode", "trusty-mpm", "trusty-code"] {
+        assert!(
+            !scrubbed.to_lowercase().split_whitespace().any(|w| {
+                w.trim_matches(|c: char| !c.is_alphanumeric() && c != '-') == forbidden
+            }),
+            "'{forbidden}' leaked into scrubbed output: {scrubbed}"
+        );
+    }
+}
+
+#[test]
+fn scrub_branding_redacts_session_identifiers() {
+    let sample = "session tm-quiet-falcon started; id=550e8400-e29b-41d4-a716-446655440000";
+    let scrubbed = scrub_branding(sample);
+    assert!(
+        !scrubbed.contains("tm-quiet-falcon"),
+        "tmux session name leaked: {scrubbed}"
+    );
+    assert!(
+        !scrubbed.contains("550e8400-e29b-41d4-a716-446655440000"),
+        "UUID session id leaked: {scrubbed}"
+    );
+    assert!(scrubbed.contains("[session]"), "got: {scrubbed}");
+}
+
+/// code-critic BLOCK finding 1 regression guard: `tm`'s own launch banner
+/// prints the space-separated, title-case wordmark `Trusty MPM v{VERSION}`
+/// (`crates/trusty-mpm/src/bin/tm/formatters/banner/mod.rs`'s narrow-terminal
+/// fallback), and that banner text is literally the FIRST thing `run_tm`
+/// observes via `session_activity`'s pane content — so it must scrub cleanly
+/// even though it has no hyphen at all. The three lines below are three
+/// SEPARATE `println!` calls in the real source
+/// (`println!("\x1B[2J\x1B[1;1H"); println!("Trusty MPM v{}", ...);
+/// println!("Launching...");`), each appending its own trailing `\n` — the
+/// wordmark is newline-bounded on the real stdout, not glued to the escape
+/// sequence.
+#[test]
+fn scrub_branding_removes_the_real_tm_launch_banner_plain_fallback() {
+    let sample = "\u{1b}[2J\u{1b}[1;1H\nTrusty MPM v0.30.0\nLaunching...\n";
+    let scrubbed = scrub_branding(sample);
+    assert!(
+        !scrubbed.to_lowercase().contains("trusty mpm"),
+        "the real tm plain-fallback banner leaked: {scrubbed}"
+    );
+    assert!(
+        scrubbed.contains("the system"),
+        "expected the banner wordmark to be replaced, got: {scrubbed}"
+    );
+}
+
+/// Sibling to the plain-fallback case: the two-panel box-drawing banner
+/// embeds the identical wordmark inside a title-bar border
+/// (`.../banner/two_panel/mod.rs`'s `render_title_bar`:
+/// `format!(" Trusty MPM v{version} ")`, framed by `╭──── … ────╮`). Box
+/// characters around the text must not defeat the word-bounded match.
+#[test]
+fn scrub_branding_removes_the_real_tm_launch_banner_box_form() {
+    let sample = "\u{256d}\u{2500}\u{2500}\u{2500}\u{2500} Trusty MPM v0.30.0 \u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{256e}";
+    let scrubbed = scrub_branding(sample);
+    assert!(
+        !scrubbed.to_lowercase().contains("trusty mpm"),
+        "the real tm two-panel banner title bar leaked: {scrubbed}"
+    );
+    assert!(
+        scrubbed.contains("the system"),
+        "expected the banner wordmark to be replaced, got: {scrubbed}"
+    );
+}
+
+/// Sanity-check other casings/spacings the real binaries could plausibly
+/// emit (env-derived strings, ALL-CAPS log prefixes, underscore-joined
+/// identifiers) beyond the two canonical banner forms above.
+#[test]
+fn scrub_branding_handles_assorted_casings_and_separators() {
+    let cases = [
+        "TRUSTY MPM daemon starting",
+        "trusty_mpm.log rotated",
+        "Trusty-Code session created",
+        "TRUSTYCODE ready", // no separator at all
+        "connecting to Trusty Code v0.2.0",
+    ];
+    for sample in cases {
+        let scrubbed = scrub_branding(sample);
+        let lower = scrubbed.to_lowercase();
+        assert!(
+            !lower.contains("trusty mpm")
+                && !lower.contains("trusty_mpm")
+                && !lower.contains("trusty-mpm")
+                && !lower.contains("trusty code")
+                && !lower.contains("trusty_code")
+                && !lower.contains("trusty-code")
+                && !lower.contains("trustycode"),
+            "backend identity leaked from '{sample}': {scrubbed}"
+        );
+    }
+}
+
+#[test]
+fn scrub_branding_leaves_unrelated_words_alone() {
+    // Regression guard: a naive substring replace of "tm" would corrupt
+    // "tmux", "atm", "item", "system" — the word-bounded regex must not.
+    let sample = "The tmux pane showed an atm withdrawal item in the system log.";
+    let scrubbed = scrub_branding(sample);
+    assert_eq!(scrubbed, sample);
+}
+
+#[test]
+fn scrub_branding_is_idempotent_on_clean_text() {
+    let sample = "The change compiled and all tests passed.";
+    assert_eq!(scrub_branding(sample), sample);
+}
+
+// =====================================================================
+// Schema / name black-box hygiene
+// =====================================================================
+
+#[test]
+fn name_and_schema_never_mention_backend_identity() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool = PmBridgeTool::new(backend);
+
+    assert_eq!(tool.name(), "dispatch_task");
+
+    let schema_text = tool.schema().to_string().to_lowercase();
+    for forbidden in ["trusty-mpm", "trusty-code", "tcode", "routing"] {
+        assert!(
+            !schema_text.contains(forbidden),
+            "schema leaks '{forbidden}': {schema_text}"
+        );
+    }
+    // "tm" alone is too common a substring to safely assert as absent from
+    // free-form schema prose (it would false-positive on "system", "item",
+    // etc.); the dedicated tokens above cover the actual backend names.
+}
+
+// =====================================================================
+// RBAC gate
+// =====================================================================
+
+#[test]
+fn dispatch_task_denies_read_only_and_analytics_tiers() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool = Arc::new(
+        PmBridgeTool::new(backend)
+            .with_restricted_tiers(vec![ServiceTier::ReadOnly, ServiceTier::Analytics]),
+    );
+    let mut registry = ToolRegistry::new();
+    registry.register(tool);
+
+    let read_only = crate::rbac::UserIdentity::new("u1", "u1", ServiceTier::ReadOnly);
+    let analytics = crate::rbac::UserIdentity::new("u2", "u2", ServiceTier::Analytics);
+    let all_tier = crate::rbac::UserIdentity::new("u3", "u3", ServiceTier::All);
+
+    assert!(
+        registry
+            .filter_tools_for_user(&read_only)
+            .iter()
+            .all(|t| t.name() != "dispatch_task"),
+        "ReadOnly must not see dispatch_task"
+    );
+    assert!(
+        registry
+            .filter_tools_for_user(&analytics)
+            .iter()
+            .all(|t| t.name() != "dispatch_task"),
+        "Analytics must not see dispatch_task"
+    );
+    assert!(
+        registry
+            .filter_tools_for_user(&all_tier)
+            .iter()
+            .any(|t| t.name() == "dispatch_task"),
+        "All tier must still see dispatch_task"
+    );
+}


### PR DESCRIPTION
## Summary

Introduces `dispatch_task` — a black-box assistant tool that deterministically routes work to tcode (coding) or tm (orchestration) via a pure classifier, runs it, and returns results with backend identity fully scrubbed. This is lane 3 of epic #3052 (assistant delegation model).

## What

- **dispatch_task tool**: single neutrally-named assistant tool for unified work routing
- **Classifier**: `intent::route_task` deterministically decides tm vs tcode based on task intent
- **Execution path**: tcode runs via one-shot `run-task pm --json`; tm via session_new/poll/decommission stopgap
- **Branding scrubbed**: user/LLM never see tm/tcode/trusty-mpm/trusty-code names or session IDs (applies to both success and error paths)
- **RBAC enforcement**: restricted_tiers blocks ReadOnly and Analytics tiers, enforced on shared Slack/Telegram/API PM loop via tool allowlist filtering by UserIdentity

## Design Decisions (Owner-Locked)

- **Tool name**: `dispatch_task` — ambiguous enough to be neutral; empty/unclear tasks default to Tm
- **Result formatting**: full transcript scrubbed; only safe payload returned
- **RBAC**: ReadOnly + Analytics tiers completely blocked from tool execution
- **Classifier purity**: `intent::route_task` has no side effects; deterministic on intent alone

## Known Limitations

**tm-route MVP caveat**: Uses session_new/poll/decommission as a stopgap because tm has no synchronous run-task RPC. A proper RPC is tracked in #3589 and will replace this polling approach.

**Schema visibility (non-blocking, pre-existing)**: The LLM schema list is not filtered by tier, so restricted users still see the tool schema in introspection though execution is hard-blocked. A follow-up ticket for schema-tier filtering is pending (related to broader schema filtering work across the agents system).

## Review

Passed code-critic review with APPROVE verdict after addressing two CRITICAL issues (black-box leak of tm's "Trusty MPM" banner in error response + RBAC bypass where restricted_tiers wasn't enforced on ctrl PM loop) and one HIGH (silent session-decommission leak on error paths). All CRITICAL and HIGH findings resolved.

## Verification

```
cargo test -p trusty-agents
# Result: 2097 passed / 0 failed / 9 ignored

cargo clippy -p trusty-agents -- -D warnings
# Result: clean (no warnings)

cargo fmt -p trusty-agents --check
# Result: clean (all formatted)

bash scripts/check_line_cap.sh
# Result: 0 violations (all committed files under SLOC caps)
```

All trusty-agents tests passing; code style and line-cap gates satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)