### PR TITLE
fix(trusty-search): honor TRUSTY_DATA_DIR in CLI daemon discovery

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -779,7 +779,6 @@ crates/trusty-review/src/service/webhook.rs	webhook_ignores_non_review_requested
 crates/trusty-review/src/store/outcome_store.rs	record_below_threshold
 crates/trusty-search/src/allowlist/mod.rs	denylist_allows_path_with_sensitive_word_in_name
 crates/trusty-search/src/allowlist/mod.rs	upsert_appends_new
-crates/trusty-search/src/commands/daemon_utils.rs	daemon_base_url_falls_back_when_http_addr_dead
 crates/trusty-search/src/commands/hook.rs	hook_scripts_all_exit_zero
 crates/trusty-search/src/commands/hook.rs	install_creates_and_is_idempotent
 crates/trusty-search/src/commands/hook.rs	resolve_repo_root_falls_back_to_git

--- a/crates/trusty-common/src/monitor/search_client.rs
+++ b/crates/trusty-common/src/monitor/search_client.rs
@@ -640,6 +640,7 @@ pub fn parse_reindex_event(value: &serde_json::Value) -> ReindexEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn default_search_url_is_local() {
@@ -676,6 +677,42 @@ mod tests {
         // or the documented default — both are non-empty and HTTP-schemed.
         let url = resolve_search_url();
         assert!(url.starts_with("http://") || url.starts_with("https://"));
+    }
+
+    /// Regression for the trusty-search#3602 review finding: `resolve_search_url`
+    /// (backing `trusty-search monitor status`/`monitor indexes`/`monitor tui`)
+    /// must discover a daemon on a NON-default port once it is registered via
+    /// `write_daemon_addr("trusty-search", …)` -- the exact primitive
+    /// `trusty-search`'s `run_daemon()` now calls for its default instance.
+    /// Before that producer-side fix this resolver had no writer at all and
+    /// would silently fall back to `DEFAULT_SEARCH_URL`, sending
+    /// `monitor`/the TUI's `[r]` reindex hotkey at the WRONG (or no) daemon.
+    ///
+    /// Why safe: redirects `resolve_data_dir` via `TRUSTY_DATA_DIR_OVERRIDE`
+    /// into a tempdir, so this never reads or writes a real `$HOME`/platform
+    /// data dir.
+    /// What: write a non-default-port address, call `resolve_search_url()`,
+    /// assert it returns that exact address rather than the default.
+    /// Test: this function.
+    #[test]
+    #[serial]
+    fn resolve_search_url_discovers_non_default_registered_address() {
+        let _guard = crate::data_dir::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV, tmp.path());
+        }
+        crate::write_daemon_addr("trusty-search", "127.0.0.1:59321").unwrap();
+        let url = resolve_search_url();
+        unsafe {
+            std::env::remove_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV);
+        }
+        assert_eq!(
+            url, "http://127.0.0.1:59321",
+            "resolve_search_url must discover a registered non-default-port address"
+        );
     }
 
     #[test]

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -23,6 +23,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (mirroring `daemon_dir()`), and every CLI call site reads/writes through
   that single resolver instead of the generic one, so `start` and every
   client subcommand always agree on which daemon they mean.
+  - **Follow-up (code-critic review):** the first cut of this fix removed
+    the only writer of the generic `trusty_common::write_daemon_addr`
+    registry without replacing it, silently breaking two other consumers
+    that still read it exclusively — `trusty_common::monitor::search_client`
+    (`trusty-search monitor status`/`monitor indexes`/`monitor tui`, whose
+    `[r]` hotkey reindexes via that resolved address) and trusty-installer's
+    `ensure` (register-index + readiness-poll stages). `run_daemon()` now
+    also populates that registry, but **only for the default
+    (`TRUSTY_DATA_DIR`-unset) instance** — an isolated instance still never
+    writes it, preserving the original fix's isolation guarantee. The CLI's
+    reachability-probe refresh write also now goes through the same atomic
+    tmp+rename helper the daemon itself uses, instead of a bare
+    `std::fs::write` that could race a torn read.
 
 ### Added
 

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **CLI daemon discovery (`index`/`list`/`reindex`/`search`/`port`/`serve`)
+  now honors `TRUSTY_DATA_DIR` (issue #3545).** These subcommands resolved
+  the daemon's address via a generic `trusty_common` resolver keyed only to
+  the test-only `TRUSTY_DATA_DIR_OVERRIDE` env var and a file location
+  distinct from the one `start`/`run_daemon()` actually wrote
+  (`$HOME/.trusty-search/http_addr`, hardcoded regardless of
+  `TRUSTY_DATA_DIR`) — so an isolated instance's clients could silently
+  reconnect to a stale, cached production-daemon address instead of the
+  isolated instance, even with `TRUSTY_DATA_DIR` and a non-default port set.
+  This caused an accidental production-daemon index mutation during PR
+  #3529. `service::daemon::http_addr_path()` now honors `TRUSTY_DATA_DIR`
+  (mirroring `daemon_dir()`), and every CLI call site reads/writes through
+  that single resolver instead of the generic one, so `start` and every
+  client subcommand always agree on which daemon they mean.
+
 ### Added
 
 - **Graceful Apple-Silicon default gating + background bootstrap→hot-swap

--- a/crates/trusty-search/src/commands/daemon_utils.rs
+++ b/crates/trusty-search/src/commands/daemon_utils.rs
@@ -1,20 +1,26 @@
 //! Daemon discovery + reachability helpers shared across CLI subcommands.
 //!
 //! Why: every subcommand that talks to the running daemon needs the same
-//! "where is it listening?" logic -- preferring the canonical
-//! `{data_dir}/trusty-search/http_addr` file (written via
-//! `trusty_common::write_daemon_addr`), falling back to the legacy port
-//! lockfile, and finally to the compiled-in default port. Centralising it
-//! removes duplication and gives `main.rs` a thinner footprint.
+//! "where is it listening?" logic -- preferring the canonical `http_addr`
+//! discovery file, falling back to the legacy port lockfile, and finally to
+//! the compiled-in default port. Centralising it removes duplication and
+//! gives `main.rs` a thinner footprint.
 //!
-//! Issue #984: `read_http_addr_file()` / `http_addr_path()` have been replaced
-//! with `trusty_common::read_daemon_addr("trusty-search")` /
-//! `trusty_common::write_daemon_addr("trusty-search", ...)` so that the CLI
-//! reads the same file the daemon writes, regardless of platform data-dir
-//! layout. The old `~/.trusty-search/http_addr` path was only correct on
-//! platforms where `dirs::home_dir()` happens to equal the data dir fallback;
-//! on macOS the canonical path is
-//! `~/Library/Application Support/trusty-search/http_addr`.
+//! Issue #3545: `daemon_base_url()` previously preferred
+//! `trusty_common::read_daemon_addr("trusty-search")` /
+//! `write_daemon_addr("trusty-search", ...)` -- a generic per-app resolver
+//! (`trusty_common::resolve_data_dir`) that only honours the test-only
+//! `TRUSTY_DATA_DIR_OVERRIDE` env var, never `TRUSTY_DATA_DIR`. That path is
+//! also a *third*, distinct location from the one the daemon itself writes
+//! (`trusty_search::service::http_addr_path()`), so it almost never matched
+//! what `start` actually wrote -- and once the TCP-probe fallback below
+//! populated it (from whichever daemon happened to be reachable on the
+//! default port), it stuck as a stale cross-instance cache that silently
+//! outranked an isolated `TRUSTY_DATA_DIR` instance on every later call. The
+//! fix: read and refresh `trusty_search::service::http_addr_path()` directly
+//! -- the exact same, now `TRUSTY_DATA_DIR`-aware resolver `run_daemon()` uses
+//! to write the file -- so client subcommands and `start` always agree on
+//! which file they mean.
 //!
 //! What: pure path resolvers and one async TCP probe.
 //! Test: covered indirectly by every CLI subcommand that calls into the
@@ -26,9 +32,11 @@ use std::time::Duration;
 ///
 /// Why: stdio MCP servers and CLI subcommands need to find the running daemon
 /// without configuration. We check the canonical address-discovery file
-/// (via `trusty_common::read_daemon_addr`, issue #984) first, then fall back
-/// to the legacy port file (`daemon.port`) for backward compatibility, and
-/// finally to `127.0.0.1:7878` if neither exists.
+/// (`trusty_search::service::http_addr_path()`, issue #3545) first, then fall
+/// back to the legacy port file (`daemon.port`) for backward compatibility,
+/// and finally to `127.0.0.1:7878` if neither exists. Both the discovery file
+/// and the port file honour `TRUSTY_DATA_DIR`, so an isolated instance's
+/// clients never fall through to the production daemon's address.
 ///
 /// Defensive TCP probe (issue #117): if the discovery file points at a dead
 /// address (e.g. left behind by a SIGKILL'd `serve --http`, or by a stopped
@@ -38,13 +46,19 @@ use std::time::Duration;
 /// the file is current, long enough to tolerate a busy machine.
 ///
 /// What: returns `http://{host}:{port}` (no trailing slash).
-/// Test: `daemon_base_url_falls_back_when_http_addr_dead` exercises this path.
+/// Test: `daemon_base_url_falls_back_when_http_addr_dead` exercises this path;
+/// `daemon_base_url_prefers_isolated_instance_over_stale_default_cache`
+/// (issue #3545) proves an isolated `TRUSTY_DATA_DIR` instance is addressed
+/// instead of a stale, non-isolated discovery cache.
 pub fn daemon_base_url() -> String {
-    if let Ok(Some(addr)) = trusty_common::read_daemon_addr("trusty-search") {
-        if !addr.is_empty() && address_reachable_blocking(&addr) {
-            return format!("http://{addr}");
+    if let Some(path) = trusty_search::service::http_addr_path() {
+        if let Ok(raw) = std::fs::read_to_string(&path) {
+            let addr = raw.trim();
+            if !addr.is_empty() && address_reachable_blocking(addr) {
+                return format!("http://{addr}");
+            }
         }
-        // Stale file -- fall through to the port-file fallback and refresh.
+        // Missing or stale file -- fall through to the port-file fallback and refresh.
     }
     let port = daemon_port_path()
         .and_then(|p| std::fs::read_to_string(p).ok())
@@ -55,7 +69,12 @@ pub fn daemon_base_url() -> String {
     // Best-effort: a write failure (no $HOME, read-only fs) is non-fatal.
     let live_addr = format!("127.0.0.1:{port}");
     if address_reachable_blocking(&live_addr) {
-        let _ = trusty_common::write_daemon_addr("trusty-search", &live_addr);
+        if let Some(path) = trusty_search::service::http_addr_path() {
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let _ = std::fs::write(&path, &live_addr);
+        }
     }
     format!("http://{live_addr}")
 }
@@ -132,6 +151,7 @@ pub async fn port_reachable(host: &str, port: u16) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn address_reachable_returns_false_for_dead_port() {
@@ -176,5 +196,113 @@ mod tests {
         if let Some(p) = mcp_http_addr_path() {
             assert!(p.ends_with(".trusty-search/mcp_http_addr"));
         }
+    }
+
+    /// Regression for issue #3545: an isolated `TRUSTY_DATA_DIR` instance must
+    /// be addressed by `daemon_base_url()` even when a *different* daemon's
+    /// address is cached at the old, non-isolated location that pre-fix code
+    /// consulted first (`trusty_common::write_daemon_addr("trusty-search",
+    /// ...)`, resolved via `resolve_data_dir` -- keyed only to the test-only
+    /// `TRUSTY_DATA_DIR_OVERRIDE`, never `TRUSTY_DATA_DIR`).
+    ///
+    /// Why: this is exactly the production incident from PR #3529 -- an
+    /// operator ran an isolated instance with `TRUSTY_DATA_DIR` set and a
+    /// non-default port, but the CLI silently reconnected to whatever daemon
+    /// was cached at the generic discovery location (standing in for the
+    /// default/production daemon here as `decoy_addr`) and mutated its index.
+    /// What: binds two independent real TCP listeners (`isolated_addr` and
+    /// `decoy_addr`); seeds the OLD wrong cache with `decoy_addr` (guarded by
+    /// `TRUSTY_DATA_DIR_OVERRIDE` so the write lands in a tempdir, never a
+    /// real `$HOME`/platform data dir); seeds the isolated instance's real
+    /// `http_addr` file (`{TRUSTY_DATA_DIR}/http_addr`) with `isolated_addr`;
+    /// asserts `daemon_base_url()` returns `isolated_addr`, proving the
+    /// isolated instance wins and the decoy (standing in for the default
+    /// daemon) is never targeted. This test fails against the pre-fix
+    /// implementation (it would return `decoy_addr`).
+    /// Test: this function.
+    #[test]
+    #[serial]
+    fn daemon_base_url_prefers_isolated_instance_over_stale_default_cache() {
+        let isolated_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let isolated_addr = isolated_listener.local_addr().unwrap().to_string();
+        let decoy_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let decoy_addr = decoy_listener.local_addr().unwrap().to_string();
+
+        let override_tmp = tempfile::tempdir().unwrap();
+        let data_dir_tmp = tempfile::tempdir().unwrap();
+
+        unsafe {
+            std::env::set_var("TRUSTY_DATA_DIR_OVERRIDE", override_tmp.path());
+        }
+        // Simulate a stale cache at the OLD, non-isolated discovery location --
+        // this is what any prior non-isolated invocation would have left behind.
+        trusty_common::write_daemon_addr("trusty-search", &decoy_addr).unwrap();
+
+        unsafe {
+            std::env::set_var("TRUSTY_DATA_DIR", data_dir_tmp.path());
+        }
+        // Simulate the isolated instance's real discovery file, as `run_daemon()`
+        // would write it under the fixed `http_addr_path()`.
+        let isolated_http_addr = trusty_search::service::http_addr_path().unwrap();
+        std::fs::write(&isolated_http_addr, &isolated_addr).unwrap();
+
+        let url = daemon_base_url();
+
+        unsafe {
+            std::env::remove_var("TRUSTY_DATA_DIR");
+            std::env::remove_var("TRUSTY_DATA_DIR_OVERRIDE");
+        }
+
+        assert_eq!(
+            url,
+            format!("http://{isolated_addr}"),
+            "daemon_base_url() must target the isolated TRUSTY_DATA_DIR instance \
+             ({isolated_addr}), not the stale default-location cache ({decoy_addr})"
+        );
+    }
+
+    /// Regression for issue #3545: when the isolated instance's discovery file
+    /// points at a dead address, `daemon_base_url()` must fall back to the
+    /// isolated `daemon.port` file -- never to a different `TRUSTY_DATA_DIR`
+    /// instance or the production default.
+    ///
+    /// Why: covers the reachability-probe + refresh path
+    /// (`address_reachable_blocking` returning false) entirely within an
+    /// isolated `TRUSTY_DATA_DIR`, so the refresh write never touches a real
+    /// `$HOME`/platform-data-dir file.
+    /// What: sets `TRUSTY_DATA_DIR` to a tempdir; writes a dead address to its
+    /// `http_addr` file and a live listener's port to its `daemon.port` file;
+    /// asserts `daemon_base_url()` returns the live listener's address.
+    /// Test: this function.
+    #[test]
+    #[serial]
+    fn daemon_base_url_falls_back_when_http_addr_dead() {
+        let live_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let live_port = live_listener.local_addr().unwrap().port();
+
+        let data_dir_tmp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("TRUSTY_DATA_DIR", data_dir_tmp.path());
+        }
+
+        let http_addr_path = trusty_search::service::http_addr_path().unwrap();
+        std::fs::write(&http_addr_path, "127.0.0.1:1").unwrap(); // dead: reserved port
+        let port_path = daemon_port_path().unwrap();
+        std::fs::write(&port_path, live_port.to_string()).unwrap();
+
+        let url = daemon_base_url();
+
+        unsafe {
+            std::env::remove_var("TRUSTY_DATA_DIR");
+        }
+
+        assert_eq!(
+            url,
+            format!("http://127.0.0.1:{live_port}"),
+            "must fall back to the isolated instance's daemon.port when http_addr is dead"
+        );
+        // The refresh write should have corrected the discovery file in place.
+        let refreshed = std::fs::read_to_string(&http_addr_path).unwrap();
+        assert_eq!(refreshed.trim(), format!("127.0.0.1:{live_port}"));
     }
 }

--- a/crates/trusty-search/src/commands/daemon_utils.rs
+++ b/crates/trusty-search/src/commands/daemon_utils.rs
@@ -67,13 +67,15 @@ pub fn daemon_base_url() -> String {
 
     // Refresh the discovery file so subsequent calls skip the TCP probe.
     // Best-effort: a write failure (no $HOME, read-only fs) is non-fatal.
+    // Issue #3602 review: route through the same atomic tmp+rename helper
+    // `run_daemon()` uses (`write_http_addr_file`), not a bare `std::fs::write`
+    // -- a false-positive reachability probe here must never tear a
+    // concurrent reader's view of the file that trusty-console/trusty-mpm's
+    // discovery trusts as ground truth.
     let live_addr = format!("127.0.0.1:{port}");
     if address_reachable_blocking(&live_addr) {
         if let Some(path) = trusty_search::service::http_addr_path() {
-            if let Some(parent) = path.parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-            let _ = std::fs::write(&path, &live_addr);
+            let _ = trusty_search::service::write_http_addr_file(&path, &live_addr);
         }
     }
     format!("http://{live_addr}")

--- a/crates/trusty-search/src/commands/port.rs
+++ b/crates/trusty-search/src/commands/port.rs
@@ -6,9 +6,11 @@
 //! records the exact address the daemon bound; this command exposes it as a
 //! first-class, machine-parsable CLI surface.
 //!
-//! What: reads the daemon's persisted address via `trusty_common::read_daemon_addr`
-//! (issue #984: `daemon_utils::read_http_addr_file` was replaced by this shared helper)
-//! and prints one of
+//! What: reads the daemon's persisted address via
+//! `trusty_search::service::http_addr_path()` (issue #3545: switched from the
+//! generic, `TRUSTY_DATA_DIR`-oblivious `trusty_common::read_daemon_addr` so
+//! `port` agrees with `start`/`index`/`list`/`reindex`/`search` on which
+//! daemon instance is addressed) and prints one of
 //! three formats to stdout based on the caller's flags:
 //!   - default: bare port number  →  `7879\n`
 //!   - `--addr`: `host:port`      →  `127.0.0.1:7879\n`
@@ -43,7 +45,7 @@ pub enum PortFormat {
 
 /// Parse a `host:port` string and return the port as `u16`.
 ///
-/// Why: `read_daemon_addr` returns the full `host:port` string; extracting the
+/// Why: the discovery file stores the full `host:port` string; extracting the
 /// port number for the `Port` and `Json` output modes requires splitting on
 /// the last `:` (to handle IPv6 addresses where the host itself contains `:`).
 /// What: splits on the final `:`, parses the port, returns `None` on any parse
@@ -84,18 +86,22 @@ pub fn format_output(addr: &str, format: PortFormat) -> Option<String> {
 /// shell substitutions like `curl http://127.0.0.1:$(trusty-search port)/health`
 /// work without guessing. Issue #526.
 /// What: reads the address from the `http_addr` discovery file via
-/// `trusty_common::read_daemon_addr("trusty-search")`, formats it per the
-/// caller's flags, and prints to stdout. On any error (no daemon, missing file,
-/// corrupt address) the message goes to stderr and the function returns `Err`
-/// so `main` exits non-zero.
+/// `trusty_search::service::http_addr_path()` (issue #3545 -- honours
+/// `TRUSTY_DATA_DIR` so an isolated instance's port is reported instead of the
+/// production daemon's), formats it per the caller's flags, and prints to
+/// stdout. On any error (no daemon, missing file, corrupt address) the
+/// message goes to stderr and the function returns `Err` so `main` exits
+/// non-zero.
 /// Test: unit tests cover all format variants; integration tests in
 /// `tests/port_command.rs` cover the end-to-end path with a real lockfile.
 pub fn handle_port(format: PortFormat) -> Result<()> {
     // Prefer the canonical address-discovery file written by a running daemon.
     // Fall back to the legacy daemon_port_path (daemon.port) when available.
-    let addr = match trusty_common::read_daemon_addr("trusty-search") {
-        Ok(Some(a)) if !a.is_empty() => a,
-        Ok(Some(_)) | Ok(None) => {
+    let addr = match trusty_search::service::http_addr_path()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+    {
+        Some(a) if !a.trim().is_empty() => a.trim().to_string(),
+        _ => {
             // Legacy fallback: try the port-only daemon.port file.
             match read_legacy_port_file() {
                 Some(port) => format!("127.0.0.1:{port}"),
@@ -107,10 +113,6 @@ pub fn handle_port(format: PortFormat) -> Result<()> {
                     std::process::exit(1);
                 }
             }
-        }
-        Err(e) => {
-            eprintln!("trusty-search: could not read daemon address: {e:#}");
-            std::process::exit(1);
         }
     };
 

--- a/crates/trusty-search/src/commands/serve.rs
+++ b/crates/trusty-search/src/commands/serve.rs
@@ -98,6 +98,11 @@ pub async fn handle_serve(
 /// trusty-search-specific config: health path `/health`, spawn args
 /// `start --foreground` (which binds a fixed port written to the discovery
 /// file), and a `base_url_fn` that re-reads the address file on every poll.
+/// Issue #3545: `base_url_fn` now delegates straight to `daemon_base_url()`,
+/// the same `TRUSTY_DATA_DIR`-aware resolver every other CLI subcommand uses,
+/// instead of a separate inline call to `trusty_common::read_daemon_addr`
+/// (which only honoured the test-only `TRUSTY_DATA_DIR_OVERRIDE` env var and
+/// could re-discover the wrong daemon instance).
 /// Test: covered by `trusty_common::mcp::daemon_bridge` unit tests; the live
 /// path is exercised by `cargo run -- serve` with no daemon running.
 async fn ensure_search_daemon_up() -> Result<String> {
@@ -109,16 +114,7 @@ async fn ensure_search_daemon_up() -> Result<String> {
         // iteration to discover the live address.
         spawn_args: vec!["start".to_string(), "--foreground".to_string()],
         health_path: "/health".to_string(),
-        base_url_fn: Box::new(|| match trusty_common::read_daemon_addr("trusty-search") {
-            Ok(Some(addr)) if !addr.is_empty() => {
-                if addr.starts_with("http://") || addr.starts_with("https://") {
-                    addr
-                } else {
-                    format!("http://{addr}")
-                }
-            }
-            _ => daemon_base_url(),
-        }),
+        base_url_fn: Box::new(daemon_base_url),
         startup_timeout: None,
         poll_interval: None,
         no_spawn: false,     // trusty-search bridge may auto-start its daemon

--- a/crates/trusty-search/src/main.rs
+++ b/crates/trusty-search/src/main.rs
@@ -1506,16 +1506,10 @@ async fn run() -> Result<()> {
 
         Commands::Monitor { target } => match target {
             MonitorTarget::Web => {
-                // Prefer the live address written by a running daemon; fall
-                // back to the default loopback port so the command still
-                // prints something useful when the daemon has not started.
-                let url = match trusty_common::read_daemon_addr("trusty-search") {
-                    Ok(Some(addr)) => format!("{addr}/ui"),
-                    _ => format!(
-                        "http://127.0.0.1:{}/ui",
-                        trusty_search::service::DEFAULT_PORT
-                    ),
-                };
+                // Issue #3545: `daemon_base_url()` is the shared, TRUSTY_DATA_DIR
+                // -aware resolver every other subcommand uses; it already falls
+                // back to the default loopback port when no daemon is discovered.
+                let url = format!("{}/ui", commands::daemon_utils::daemon_base_url());
                 println!("{url}");
                 open::that(&url).ok();
             }

--- a/crates/trusty-search/src/service/daemon.rs
+++ b/crates/trusty-search/src/service/daemon.rs
@@ -184,19 +184,32 @@ pub fn load_daemon_env() {
     }
 }
 
-/// Path to `~/.trusty-search/http_addr` — the canonical address-discovery
-/// file used by `trusty-search dashboard` and other client tools to locate
-/// the running daemon. Distinct from the legacy `daemon.port` file (which
-/// stores only the port number under the platform-specific data-local dir).
+/// Path to the canonical address-discovery file used by `trusty-search
+/// dashboard` and other client tools to locate the running daemon. Distinct
+/// from the legacy `daemon.port` file (which stores only the port number
+/// under the platform-specific data-local dir).
 ///
 /// Why: aligns trusty-search with the trusty-memory address-discovery
-/// contract — both daemons write a fully-qualified `host:port` line to
-/// `~/.trusty-*/http_addr`. Clients can read either file to discover the
-/// daemon without DNS or service registration.
-/// What: returns `$HOME/.trusty-search/http_addr` (creating the parent
-/// directory on demand is the caller's responsibility).
-/// Test: with HOME=/tmp/xyz → returns "/tmp/xyz/.trusty-search/http_addr".
+/// contract — both daemons write a fully-qualified `host:port` line to a
+/// well-known file. Clients can read it to discover the daemon without DNS or
+/// service registration.
+///
+/// Issue #3545: when `TRUSTY_DATA_DIR` is set (by `--data-dir` or the env
+/// var), the file lives *inside* that directory instead of the fixed
+/// `$HOME/.trusty-search/` location, mirroring [`daemon_dir`]'s precedence.
+/// Before this fix, an isolated daemon still wrote its address to the one
+/// shared `$HOME/.trusty-search/http_addr` file regardless of `TRUSTY_DATA_DIR`,
+/// clobbering the production daemon's discovery file with the isolated
+/// instance's port (and vice versa on the next production restart).
+/// What: returns `$TRUSTY_DATA_DIR/http_addr` when the env var is set,
+/// otherwise `$HOME/.trusty-search/http_addr` (unchanged default, preserving
+/// the existing cross-crate discovery contract for the production daemon).
+/// Test: `http_addr_path_respects_trusty_data_dir` below; with `HOME=/tmp/xyz`
+/// and no override → returns "/tmp/xyz/.trusty-search/http_addr".
 pub fn http_addr_path() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("TRUSTY_DATA_DIR") {
+        return Some(PathBuf::from(dir).join("http_addr"));
+    }
     dirs::home_dir().map(|h| h.join(".trusty-search").join("http_addr"))
 }
 
@@ -710,6 +723,36 @@ mod tests {
         assert!(
             port.starts_with(&override_path),
             "port path {port:?} should be under override {override_path:?}"
+        );
+    }
+
+    /// Regression for issue #3545: `http_addr_path()` must respect
+    /// `TRUSTY_DATA_DIR` exactly like `daemon_dir()`/`daemon_port_path()` do,
+    /// so an isolated daemon's discovery file never lands in the shared
+    /// `$HOME/.trusty-search/http_addr` location used by the production daemon.
+    /// What: set `TRUSTY_DATA_DIR` to a tempdir; assert the returned path is
+    /// `{tempdir}/http_addr`, not the `$HOME`-relative default.
+    /// Test: `http_addr_path_respects_trusty_data_dir` (this test).
+    ///
+    /// `#[serial]` for the same reason as the other `TRUSTY_DATA_DIR` tests in
+    /// this module: the env var is process-global.
+    #[test]
+    #[serial]
+    fn http_addr_path_respects_trusty_data_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let override_path = tmp.path().to_path_buf();
+        unsafe {
+            std::env::set_var("TRUSTY_DATA_DIR", &override_path);
+        }
+        let path = http_addr_path();
+        unsafe {
+            std::env::remove_var("TRUSTY_DATA_DIR");
+        }
+        let path = path.expect("http_addr_path should resolve with TRUSTY_DATA_DIR set");
+        assert_eq!(
+            path,
+            override_path.join("http_addr"),
+            "http_addr_path should land under the TRUSTY_DATA_DIR override, not $HOME"
         );
     }
 }

--- a/crates/trusty-search/src/service/daemon.rs
+++ b/crates/trusty-search/src/service/daemon.rs
@@ -452,10 +452,13 @@ pub async fn run_daemon(state: SearchAppState, requested_port: u16) -> Result<()
     // Atomically write the port file (write + rename).
     write_port_file(&port_path, port)?;
 
-    // Write ~/.trusty-search/http_addr (host:port) for client discovery.
+    // Write the http_addr discovery file (host:port) for client discovery.
     // Issue #117: unconditional write corrects stale files from crashed daemons.
+    // Issue #3545: this path honors TRUSTY_DATA_DIR so an isolated instance
+    // never clobbers the default instance's file (or vice versa).
+    let addr_string = addr.to_string();
     let http_addr_written = match http_addr_path() {
-        Some(path) => match write_http_addr_file(&path, &addr) {
+        Some(path) => match write_http_addr_file(&path, &addr_string) {
             Ok(()) => Some(path),
             Err(e) => {
                 tracing::warn!("could not write {}: {e}", path.display());
@@ -464,6 +467,16 @@ pub async fn run_daemon(state: SearchAppState, requested_port: u16) -> Result<()
         },
         None => None,
     };
+
+    // Issue #3602 review (post-#3545): also populate the generic,
+    // TRUSTY_DATA_DIR-oblivious discovery registry that predates
+    // http_addr_path()'s TRUSTY_DATA_DIR-awareness -- trusty-common's monitor
+    // dashboard client (`resolve_search_url`) and trusty-installer's `ensure`
+    // (`resolve_base_url`) still read it via
+    // `trusty_common::read_daemon_addr("trusty-search")` and have no other
+    // way to discover the daemon. Gated to the default instance only; see
+    // `register_shared_discovery`'s doc for why.
+    register_shared_discovery(&addr);
 
     // Startup banner (stderr only — stdout is JSON-RPC transport).
     eprintln!(
@@ -541,6 +554,7 @@ pub async fn run_daemon(state: SearchAppState, requested_port: u16) -> Result<()
     if let Some(path) = http_addr_written {
         let _ = std::fs::remove_file(&path);
     }
+    deregister_shared_discovery();
 
     serve_result.map_err(|e| DaemonError::Server(e.to_string()))?;
     drop(lock_file);
@@ -552,14 +566,20 @@ pub use crate::service::shutdown_flush::{
     flush_all_indexes_on_shutdown, shutdown_flush_timeout_override,
 };
 
-/// Write the canonical `host:port` discovery line to `~/.trusty-search/http_addr`.
+/// Write the canonical `host:port` discovery line to the given `http_addr`
+/// path, atomically.
 ///
 /// Why: separate from `write_port_file` because the format and location differ
 /// — port file stores `12345`, http_addr stores `127.0.0.1:12345`. Both write
-/// atomically via tmp-file + rename so partial reads are impossible.
+/// atomically via tmp-file + rename so partial reads are impossible. Exported
+/// (issue #3602 review) so `commands::daemon_utils::daemon_base_url()`'s
+/// reachability-probe refresh writes through the same atomic path instead of
+/// a bare `std::fs::write`, which could tear a concurrent reader's view of the
+/// file that `trusty-console`/`trusty-mpm`'s daemon discovery trust as ground
+/// truth.
 /// What: creates parent directory if missing; writes via temp + rename.
 /// Test: with a fresh tempdir, write addr → read back → matches `host:port`.
-fn write_http_addr_file(path: &Path, addr: &SocketAddr) -> Result<(), DaemonError> {
+pub fn write_http_addr_file(path: &Path, addr: &str) -> Result<(), DaemonError> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -571,6 +591,58 @@ fn write_http_addr_file(path: &Path, addr: &SocketAddr) -> Result<(), DaemonErro
     }
     std::fs::rename(&tmp, path)?;
     Ok(())
+}
+
+/// Populate the generic, non-`TRUSTY_DATA_DIR`-aware discovery registry
+/// (`trusty_common::write_daemon_addr("trusty-search", …)`) for the DEFAULT
+/// daemon instance only.
+///
+/// Why (issue #3602 review, following #3545): `http_addr_path()` and
+/// `daemon_port_path()` are `TRUSTY_DATA_DIR`-aware, but two older consumers
+/// predate that and only know how to read the generic, per-app registry at
+/// `trusty_common::resolve_data_dir("trusty-search")` via
+/// `trusty_common::read_daemon_addr`: the monitor dashboard client
+/// (`trusty_common::monitor::search_client::resolve_search_url`, backing
+/// `trusty-search monitor status`/`monitor indexes`/`monitor tui`) and
+/// trusty-installer's `ensure` (`resolve_base_url`, backing its
+/// register-index and readiness-poll stages). #3545's first cut removed the
+/// only writer of that file (a CLI-side reachability-probe cache) without
+/// replacing it, silently breaking both. This restores a writer -- the
+/// daemon itself, which is the one place that unambiguously knows its own
+/// bound address -- but ONLY for the default instance: an isolated
+/// `TRUSTY_DATA_DIR` instance must never overwrite this shared,
+/// non-isolated registry with its own address, which is the exact
+/// cross-instance pollution #3545 fixed for `http_addr_path()`. Any I/O
+/// failure is logged, not propagated -- this registry is best-effort
+/// back-compat, never load-bearing for the daemon's own operation.
+/// What: no-ops when `TRUSTY_DATA_DIR` is set; otherwise calls
+/// `trusty_common::write_daemon_addr("trusty-search", addr)`.
+/// Test: `register_shared_discovery_writes_when_default_instance`,
+/// `register_shared_discovery_noop_when_isolated`.
+fn register_shared_discovery(addr: &SocketAddr) {
+    if std::env::var("TRUSTY_DATA_DIR").is_ok() {
+        return;
+    }
+    if let Err(e) = trusty_common::write_daemon_addr("trusty-search", &addr.to_string()) {
+        tracing::warn!("could not write shared discovery registry entry: {e:#}");
+    }
+}
+
+/// Shutdown-time mirror of [`register_shared_discovery`].
+///
+/// Why: cleaning up the generic registry on graceful shutdown matches the
+/// existing `http_addr_written` cleanup a few lines above, so a stopped
+/// default instance never leaves a stale, unreachable address behind for
+/// `resolve_search_url`/`resolve_base_url` to hand out.
+/// What: no-ops when `TRUSTY_DATA_DIR` is set; otherwise calls
+/// `trusty_common::remove_daemon_addr("trusty-search")`, ignoring any error
+/// (best-effort, same as the sibling `http_addr_path` removal).
+/// Test: `deregister_shared_discovery_removes_when_default_instance`.
+fn deregister_shared_discovery() {
+    if std::env::var("TRUSTY_DATA_DIR").is_ok() {
+        return;
+    }
+    let _ = trusty_common::remove_daemon_addr("trusty-search");
 }
 
 fn write_port_file(path: &PathBuf, port: u16) -> Result<(), DaemonError> {
@@ -585,174 +657,5 @@ fn write_port_file(path: &PathBuf, port: u16) -> Result<(), DaemonError> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use serial_test::serial;
-    use std::net::TcpListener as StdTcpListener;
-
-    #[test]
-    fn http_addr_file_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("http_addr");
-        let addr: SocketAddr = "127.0.0.1:54321".parse().unwrap();
-        write_http_addr_file(&path, &addr).unwrap();
-        let read = std::fs::read_to_string(&path).unwrap();
-        assert_eq!(read.trim(), "127.0.0.1:54321");
-    }
-
-    #[test]
-    fn port_file_roundtrip() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("daemon.port");
-        write_port_file(&path, 12345).unwrap();
-        let read = std::fs::read_to_string(&path).unwrap();
-        assert_eq!(read.trim(), "12345");
-    }
-
-    #[test]
-    fn pid_alive_current_process_is_alive() {
-        // Why: smoke-test the PID-aliveness predicate so the launchd
-        // crash-loop fix has explicit coverage. Our own PID must register
-        // as alive; a clearly-invalid PID must not.
-        assert!(pid_alive(std::process::id()));
-        // Find a clearly-dead PID. macOS `pid_max` defaults to 99999 and
-        // Linux to 4194304; on both, a value just under i32::MAX is well
-        // beyond the legal range and `kill(pid, 0)` returns ESRCH.
-        // (u32::MAX would narrow to -1 on i32 cast, which `kill` interprets
-        // as "every process the caller can signal" — never ESRCH.)
-        assert!(!pid_alive(2_000_000_000));
-    }
-
-    #[test]
-    fn read_lockfile_pid_parses_pid() {
-        // Why: `running_daemon_pid` depends on this parser. A malformed
-        // file must return None rather than panic.
-        let dir = tempfile::tempdir().unwrap();
-        let good = dir.path().join("good.lock");
-        std::fs::write(&good, "12345\n").unwrap();
-        assert_eq!(read_lockfile_pid(&good), Some(12345));
-
-        let bad = dir.path().join("bad.lock");
-        std::fs::write(&bad, "not-a-pid").unwrap();
-        assert_eq!(read_lockfile_pid(&bad), None);
-    }
-
-    #[test]
-    fn lockfile_contention_errors() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("daemon.lock");
-        let _first = acquire_lock(&path).unwrap();
-        let err = acquire_lock(&path).unwrap_err();
-        assert!(matches!(err, DaemonError::AlreadyRunning(_)));
-    }
-
-    #[tokio::test]
-    async fn auto_port_walks_forward() {
-        // Bind a port, then ask the auto-port allocator to start there.
-        let occupied = StdTcpListener::bind("127.0.0.1:0").unwrap();
-        let occupied_port = occupied.local_addr().unwrap().port();
-        let next = bind_with_auto_port(occupied_port, 64).await.unwrap();
-        assert_ne!(next.local_addr().unwrap().port(), occupied_port);
-    }
-
-    #[tokio::test]
-    async fn auto_port_zero_uses_os() {
-        // Note: port 0 is special — the shared helper delegates to the OS.
-        let l = bind_with_auto_port(0, 1).await.unwrap();
-        assert!(l.local_addr().unwrap().port() > 0);
-    }
-
-    /// Why: `daemon_dir()` must respect `TRUSTY_DATA_DIR` so an isolated daemon
-    /// can run alongside the production daemon without lockfile conflicts (#281).
-    /// What: set env var to a tempdir path; assert `daemon_dir()` returns it.
-    /// Test: `daemon_dir_respects_trusty_data_dir_env_var` (this test).
-    ///
-    /// `#[serial]` is required because this test mutates the `TRUSTY_DATA_DIR`
-    /// process env var; running it concurrently with other `TRUSTY_DATA_DIR`
-    /// mutations in `daemon_paths_under_data_dir_override` or the `start.rs`
-    /// auto-discover tests causes a flaky race condition.
-    #[test]
-    #[serial]
-    fn daemon_dir_respects_trusty_data_dir_env_var() {
-        let tmp = tempfile::tempdir().unwrap();
-        let override_path = tmp.path().to_path_buf();
-        // SAFETY: test-only, single-threaded portion; no other thread reads
-        // TRUSTY_DATA_DIR in this test binary at the same time.
-        unsafe {
-            std::env::set_var("TRUSTY_DATA_DIR", &override_path);
-        }
-        let result = daemon_dir();
-        unsafe {
-            std::env::remove_var("TRUSTY_DATA_DIR");
-        }
-        let dir = result.expect("daemon_dir with TRUSTY_DATA_DIR should succeed");
-        assert_eq!(dir, override_path, "daemon_dir should return the override");
-        assert!(dir.exists(), "daemon_dir should create the directory");
-    }
-
-    /// Why: `daemon_lock_path()` and `daemon_port_path()` (service side) must
-    /// land under the override directory, not the platform default.
-    /// What: set env var, call both path functions, confirm they start with the
-    /// override root rather than the default data-local dir.
-    /// Test: `daemon_paths_under_data_dir_override` (this test).
-    ///
-    /// `#[serial]` is required because this test mutates the `TRUSTY_DATA_DIR`
-    /// process env var; running it concurrently with other `TRUSTY_DATA_DIR`
-    /// mutations (e.g. `daemon_dir_respects_trusty_data_dir_env_var` or the
-    /// `start.rs` auto-discover tests) causes a flaky race on the env-var read
-    /// inside `daemon_dir()`.
-    #[test]
-    #[serial]
-    fn daemon_paths_under_data_dir_override() {
-        let tmp = tempfile::tempdir().unwrap();
-        let override_path = tmp.path().to_path_buf();
-        unsafe {
-            std::env::set_var("TRUSTY_DATA_DIR", &override_path);
-        }
-        let lock = daemon_lock_path();
-        let port = daemon_port_path();
-        unsafe {
-            std::env::remove_var("TRUSTY_DATA_DIR");
-        }
-        let lock = lock.expect("lock path must resolve");
-        let port = port.expect("port path must resolve");
-        assert!(
-            lock.starts_with(&override_path),
-            "lock path {lock:?} should be under override {override_path:?}"
-        );
-        assert!(
-            port.starts_with(&override_path),
-            "port path {port:?} should be under override {override_path:?}"
-        );
-    }
-
-    /// Regression for issue #3545: `http_addr_path()` must respect
-    /// `TRUSTY_DATA_DIR` exactly like `daemon_dir()`/`daemon_port_path()` do,
-    /// so an isolated daemon's discovery file never lands in the shared
-    /// `$HOME/.trusty-search/http_addr` location used by the production daemon.
-    /// What: set `TRUSTY_DATA_DIR` to a tempdir; assert the returned path is
-    /// `{tempdir}/http_addr`, not the `$HOME`-relative default.
-    /// Test: `http_addr_path_respects_trusty_data_dir` (this test).
-    ///
-    /// `#[serial]` for the same reason as the other `TRUSTY_DATA_DIR` tests in
-    /// this module: the env var is process-global.
-    #[test]
-    #[serial]
-    fn http_addr_path_respects_trusty_data_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let override_path = tmp.path().to_path_buf();
-        unsafe {
-            std::env::set_var("TRUSTY_DATA_DIR", &override_path);
-        }
-        let path = http_addr_path();
-        unsafe {
-            std::env::remove_var("TRUSTY_DATA_DIR");
-        }
-        let path = path.expect("http_addr_path should resolve with TRUSTY_DATA_DIR set");
-        assert_eq!(
-            path,
-            override_path.join("http_addr"),
-            "http_addr_path should land under the TRUSTY_DATA_DIR override, not $HOME"
-        );
-    }
-}
+#[path = "daemon_tests.rs"]
+mod tests;

--- a/crates/trusty-search/src/service/daemon_tests.rs
+++ b/crates/trusty-search/src/service/daemon_tests.rs
@@ -1,0 +1,355 @@
+//! Unit tests for `service::daemon` (extracted from `daemon.rs` to keep the
+//! production file under the 500-SLOC cap — mirrors the `persistence_tests.rs`
+//! split, issue #1372's pattern).
+//!
+//! Why: `daemon.rs` carries the lockfile/port-file/http_addr resolution and
+//! the `run_daemon()` entry point itself; the #3602-review fix (shared
+//! discovery registration/deregistration) plus its regression tests pushed
+//! the file over the production SLOC cap. Splitting the tests into this
+//! sibling `#[path]`-included module restores compliance without changing
+//! coverage.
+//! What: lockfile/port-file/PID-liveness/auto-port tests, the `TRUSTY_DATA_DIR`
+//! path-resolution regression tests (issue #3545), and the shared-discovery
+//! registration/deregistration regression tests (issue #3602 review).
+//! Test: this module IS the tests.
+
+use super::*;
+use serial_test::serial;
+use std::net::TcpListener as StdTcpListener;
+
+#[test]
+fn http_addr_file_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("http_addr");
+    write_http_addr_file(&path, "127.0.0.1:54321").unwrap();
+    let read = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(read.trim(), "127.0.0.1:54321");
+}
+
+#[test]
+fn port_file_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("daemon.port");
+    write_port_file(&path, 12345).unwrap();
+    let read = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(read.trim(), "12345");
+}
+
+#[test]
+fn pid_alive_current_process_is_alive() {
+    // Why: smoke-test the PID-aliveness predicate so the launchd
+    // crash-loop fix has explicit coverage. Our own PID must register
+    // as alive; a clearly-invalid PID must not.
+    assert!(pid_alive(std::process::id()));
+    // Find a clearly-dead PID. macOS `pid_max` defaults to 99999 and
+    // Linux to 4194304; on both, a value just under i32::MAX is well
+    // beyond the legal range and `kill(pid, 0)` returns ESRCH.
+    // (u32::MAX would narrow to -1 on i32 cast, which `kill` interprets
+    // as "every process the caller can signal" — never ESRCH.)
+    assert!(!pid_alive(2_000_000_000));
+}
+
+#[test]
+fn read_lockfile_pid_parses_pid() {
+    // Why: `running_daemon_pid` depends on this parser. A malformed
+    // file must return None rather than panic.
+    let dir = tempfile::tempdir().unwrap();
+    let good = dir.path().join("good.lock");
+    std::fs::write(&good, "12345\n").unwrap();
+    assert_eq!(read_lockfile_pid(&good), Some(12345));
+
+    let bad = dir.path().join("bad.lock");
+    std::fs::write(&bad, "not-a-pid").unwrap();
+    assert_eq!(read_lockfile_pid(&bad), None);
+}
+
+#[test]
+fn lockfile_contention_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("daemon.lock");
+    let _first = acquire_lock(&path).unwrap();
+    let err = acquire_lock(&path).unwrap_err();
+    assert!(matches!(err, DaemonError::AlreadyRunning(_)));
+}
+
+#[tokio::test]
+async fn auto_port_walks_forward() {
+    // Bind a port, then ask the auto-port allocator to start there.
+    let occupied = StdTcpListener::bind("127.0.0.1:0").unwrap();
+    let occupied_port = occupied.local_addr().unwrap().port();
+    let next = bind_with_auto_port(occupied_port, 64).await.unwrap();
+    assert_ne!(next.local_addr().unwrap().port(), occupied_port);
+}
+
+#[tokio::test]
+async fn auto_port_zero_uses_os() {
+    // Note: port 0 is special — the shared helper delegates to the OS.
+    let l = bind_with_auto_port(0, 1).await.unwrap();
+    assert!(l.local_addr().unwrap().port() > 0);
+}
+
+/// Why: `daemon_dir()` must respect `TRUSTY_DATA_DIR` so an isolated daemon
+/// can run alongside the production daemon without lockfile conflicts (#281).
+/// What: set env var to a tempdir path; assert `daemon_dir()` returns it.
+/// Test: `daemon_dir_respects_trusty_data_dir_env_var` (this test).
+///
+/// `#[serial]` is required because this test mutates the `TRUSTY_DATA_DIR`
+/// process env var; running it concurrently with other `TRUSTY_DATA_DIR`
+/// mutations in `daemon_paths_under_data_dir_override` or the `start.rs`
+/// auto-discover tests causes a flaky race condition.
+#[test]
+#[serial]
+fn daemon_dir_respects_trusty_data_dir_env_var() {
+    let tmp = tempfile::tempdir().unwrap();
+    let override_path = tmp.path().to_path_buf();
+    // SAFETY: test-only, single-threaded portion; no other thread reads
+    // TRUSTY_DATA_DIR in this test binary at the same time.
+    unsafe {
+        std::env::set_var("TRUSTY_DATA_DIR", &override_path);
+    }
+    let result = daemon_dir();
+    unsafe {
+        std::env::remove_var("TRUSTY_DATA_DIR");
+    }
+    let dir = result.expect("daemon_dir with TRUSTY_DATA_DIR should succeed");
+    assert_eq!(dir, override_path, "daemon_dir should return the override");
+    assert!(dir.exists(), "daemon_dir should create the directory");
+}
+
+/// Why: `daemon_lock_path()` and `daemon_port_path()` (service side) must
+/// land under the override directory, not the platform default.
+/// What: set env var, call both path functions, confirm they start with the
+/// override root rather than the default data-local dir.
+/// Test: `daemon_paths_under_data_dir_override` (this test).
+///
+/// `#[serial]` is required because this test mutates the `TRUSTY_DATA_DIR`
+/// process env var; running it concurrently with other `TRUSTY_DATA_DIR`
+/// mutations (e.g. `daemon_dir_respects_trusty_data_dir_env_var` or the
+/// `start.rs` auto-discover tests) causes a flaky race on the env-var read
+/// inside `daemon_dir()`.
+#[test]
+#[serial]
+fn daemon_paths_under_data_dir_override() {
+    let tmp = tempfile::tempdir().unwrap();
+    let override_path = tmp.path().to_path_buf();
+    unsafe {
+        std::env::set_var("TRUSTY_DATA_DIR", &override_path);
+    }
+    let lock = daemon_lock_path();
+    let port = daemon_port_path();
+    unsafe {
+        std::env::remove_var("TRUSTY_DATA_DIR");
+    }
+    let lock = lock.expect("lock path must resolve");
+    let port = port.expect("port path must resolve");
+    assert!(
+        lock.starts_with(&override_path),
+        "lock path {lock:?} should be under override {override_path:?}"
+    );
+    assert!(
+        port.starts_with(&override_path),
+        "port path {port:?} should be under override {override_path:?}"
+    );
+}
+
+/// Regression for issue #3545: `http_addr_path()` must respect
+/// `TRUSTY_DATA_DIR` exactly like `daemon_dir()`/`daemon_port_path()` do,
+/// so an isolated daemon's discovery file never lands in the shared
+/// `$HOME/.trusty-search/http_addr` location used by the production daemon.
+/// What: set `TRUSTY_DATA_DIR` to a tempdir; assert the returned path is
+/// `{tempdir}/http_addr`, not the `$HOME`-relative default.
+/// Test: `http_addr_path_respects_trusty_data_dir` (this test).
+///
+/// `#[serial]` for the same reason as the other `TRUSTY_DATA_DIR` tests in
+/// this module: the env var is process-global.
+#[test]
+#[serial]
+fn http_addr_path_respects_trusty_data_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let override_path = tmp.path().to_path_buf();
+    unsafe {
+        std::env::set_var("TRUSTY_DATA_DIR", &override_path);
+    }
+    let path = http_addr_path();
+    unsafe {
+        std::env::remove_var("TRUSTY_DATA_DIR");
+    }
+    let path = path.expect("http_addr_path should resolve with TRUSTY_DATA_DIR set");
+    assert_eq!(
+        path,
+        override_path.join("http_addr"),
+        "http_addr_path should land under the TRUSTY_DATA_DIR override, not $HOME"
+    );
+}
+
+/// Regression for the #3602 review finding: `register_shared_discovery`
+/// must populate the generic `trusty_common` registry for the default
+/// (non-isolated) instance, since `resolve_search_url`
+/// (`trusty-search monitor status`/`monitor indexes`/`monitor tui`) and
+/// trusty-installer's `resolve_base_url` have no other way to discover it.
+///
+/// Why safe: only `trusty_common::write_daemon_addr`/`read_daemon_addr`
+/// are exercised here, both redirected into a tempdir via
+/// `TRUSTY_DATA_DIR_OVERRIDE` -- this never touches `daemon_lock_path`/
+/// `daemon_port_path`/`http_addr_path` (which would resolve to a REAL
+/// production path with `TRUSTY_DATA_DIR` unset), so it cannot collide
+/// with a real running daemon on this machine.
+/// What: unset `TRUSTY_DATA_DIR`, call `register_shared_discovery`, assert
+/// the address round-trips through `trusty_common::read_daemon_addr`.
+/// Test: this function.
+#[test]
+#[serial]
+fn register_shared_discovery_writes_when_default_instance() {
+    let tmp = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::remove_var("TRUSTY_DATA_DIR");
+        std::env::set_var("TRUSTY_DATA_DIR_OVERRIDE", tmp.path());
+    }
+    let addr: SocketAddr = "127.0.0.1:54321".parse().unwrap();
+    register_shared_discovery(&addr);
+    let got = trusty_common::read_daemon_addr("trusty-search").unwrap();
+    unsafe {
+        std::env::remove_var("TRUSTY_DATA_DIR_OVERRIDE");
+    }
+    assert_eq!(
+        got.as_deref(),
+        Some("127.0.0.1:54321"),
+        "default instance must populate the shared discovery registry"
+    );
+}
+
+/// Regression for the #3602 review finding: an isolated `TRUSTY_DATA_DIR`
+/// instance must NEVER populate the shared registry -- that would
+/// reintroduce the exact cross-instance pollution issue #3545 fixed.
+///
+/// Why safe: same reasoning as the sibling test above -- only the
+/// `TRUSTY_DATA_DIR_OVERRIDE`-redirected generic registry is touched.
+/// What: set both `TRUSTY_DATA_DIR` (isolation) and
+/// `TRUSTY_DATA_DIR_OVERRIDE` (safety redirect); call
+/// `register_shared_discovery`; assert the registry stays empty.
+/// Test: this function.
+#[test]
+#[serial]
+fn register_shared_discovery_noop_when_isolated() {
+    let override_tmp = tempfile::tempdir().unwrap();
+    let data_dir_tmp = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("TRUSTY_DATA_DIR_OVERRIDE", override_tmp.path());
+        std::env::set_var("TRUSTY_DATA_DIR", data_dir_tmp.path());
+    }
+    let addr: SocketAddr = "127.0.0.1:54322".parse().unwrap();
+    register_shared_discovery(&addr);
+    let got = trusty_common::read_daemon_addr("trusty-search").unwrap();
+    unsafe {
+        std::env::remove_var("TRUSTY_DATA_DIR");
+        std::env::remove_var("TRUSTY_DATA_DIR_OVERRIDE");
+    }
+    assert!(
+        got.is_none(),
+        "isolated instance must not populate the shared discovery registry; got {got:?}"
+    );
+}
+
+/// Regression for the #3602 review finding: shutdown must clear the
+/// shared registry entry for the default instance, mirroring the
+/// `http_addr_written` cleanup.
+///
+/// Why safe: same `TRUSTY_DATA_DIR_OVERRIDE` redirection as the writer
+/// tests above.
+/// What: seed the registry, unset `TRUSTY_DATA_DIR`, call
+/// `deregister_shared_discovery`, assert the entry is gone.
+/// Test: this function.
+#[test]
+#[serial]
+fn deregister_shared_discovery_removes_when_default_instance() {
+    let tmp = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::remove_var("TRUSTY_DATA_DIR");
+        std::env::set_var("TRUSTY_DATA_DIR_OVERRIDE", tmp.path());
+    }
+    trusty_common::write_daemon_addr("trusty-search", "127.0.0.1:1").unwrap();
+    deregister_shared_discovery();
+    let got = trusty_common::read_daemon_addr("trusty-search").unwrap();
+    unsafe {
+        std::env::remove_var("TRUSTY_DATA_DIR_OVERRIDE");
+    }
+    assert!(
+        got.is_none(),
+        "default instance must clear the shared registry on shutdown"
+    );
+}
+
+/// End-to-end regression for the #3602 review finding: a REAL isolated
+/// `run_daemon()` instance must write its own `TRUSTY_DATA_DIR`-scoped
+/// `http_addr` file (so its own CLI clients still work, issue #3545)
+/// while never touching the shared, non-isolated registry that
+/// `resolve_search_url`/`resolve_base_url` read.
+///
+/// Why this is the only `run_daemon()` variant safe to execute directly:
+/// with `TRUSTY_DATA_DIR` set, `daemon_lock_path()`/`daemon_port_path()`/
+/// `http_addr_path()` all resolve entirely under the tempdir -- never a
+/// real production path -- so binding a real ephemeral port (`0`) and
+/// running the full daemon lifecycle here cannot collide with, or
+/// mutate, a real daemon on this machine. The mirror case (default
+/// instance actually writes) is covered above by testing
+/// `register_shared_discovery`/`deregister_shared_discovery` directly,
+/// because that variant would otherwise need `TRUSTY_DATA_DIR` unset --
+/// which would make `daemon_lock_path()` resolve to the REAL production
+/// lockfile.
+/// What: spawns `run_daemon(SearchAppState::new(..), 0)` with
+/// `TRUSTY_DATA_DIR` + `TRUSTY_DATA_DIR_OVERRIDE` both pointed at
+/// tempdirs; polls for the isolated `http_addr` file to appear; asserts
+/// the shared registry stays empty throughout; triggers graceful
+/// shutdown via `state.shutdown_tx`; asserts the isolated `http_addr`
+/// file is cleaned up.
+/// Test: this function.
+#[tokio::test]
+#[serial]
+async fn run_daemon_isolated_instance_never_pollutes_shared_discovery() {
+    use crate::core::registry::IndexRegistry;
+
+    let override_tmp = tempfile::tempdir().unwrap();
+    let data_dir_tmp = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("TRUSTY_DATA_DIR_OVERRIDE", override_tmp.path());
+        std::env::set_var("TRUSTY_DATA_DIR", data_dir_tmp.path());
+    }
+
+    let state = SearchAppState::new(IndexRegistry::new());
+    let shutdown_tx = state.shutdown_tx.clone();
+    let handle = tokio::spawn(run_daemon(state, 0));
+
+    let isolated_http_addr = data_dir_tmp.path().join("http_addr");
+    let mut seen = false;
+    for _ in 0..100 {
+        if isolated_http_addr.exists() {
+            seen = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert!(
+        seen,
+        "isolated instance must still write its own TRUSTY_DATA_DIR-scoped http_addr"
+    );
+
+    let shared_during = trusty_common::read_daemon_addr("trusty-search").unwrap();
+
+    let _ = shutdown_tx.send(true);
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+
+    let isolated_gone = !isolated_http_addr.exists();
+    unsafe {
+        std::env::remove_var("TRUSTY_DATA_DIR");
+        std::env::remove_var("TRUSTY_DATA_DIR_OVERRIDE");
+    }
+
+    assert!(
+        shared_during.is_none(),
+        "isolated instance must never appear in the shared discovery registry; got {shared_during:?}"
+    );
+    assert!(
+        isolated_gone,
+        "isolated instance's own http_addr file must be removed on shutdown"
+    );
+}

--- a/crates/trusty-search/src/service/mod.rs
+++ b/crates/trusty-search/src/service/mod.rs
@@ -44,8 +44,8 @@ pub use config::{load_user_config, LoadedUserConfig};
 pub use constants::DEFAULT_PORT;
 pub use daemon::{
     daemon_env_path, daemon_lock_path, daemon_port_path, http_addr_path, is_already_running,
-    load_daemon_env, run_daemon, running_daemon_pid, save_daemon_env, DaemonError, DaemonHandle,
-    PERSISTED_ENV_VARS,
+    load_daemon_env, run_daemon, running_daemon_pid, save_daemon_env, write_http_addr_file,
+    DaemonError, DaemonHandle, PERSISTED_ENV_VARS,
 };
 pub use indexed_files::IndexedFiles;
 pub use server::SearchAppState;


### PR DESCRIPTION
## Summary

`index`/`list`/`reindex`/`search` (and `port`/`serve`/`monitor web`, which share the same discovery helper) resolved the trusty-search daemon's address via `trusty_common::read_daemon_addr("trusty-search")` / `write_daemon_addr`, a generic per-app resolver (`trusty_common::resolve_data_dir`) keyed **only** to the test-only `TRUSTY_DATA_DIR_OVERRIDE` env var — never `TRUSTY_DATA_DIR`, which `start` and the `daemon.port` file already honored.

That generic resolver also points at a **third**, distinct file location from the one the daemon itself writes: `service::daemon::http_addr_path()` was hardcoded to `$HOME/.trusty-search/http_addr` regardless of `TRUSTY_DATA_DIR`. So in practice the "preferred" discovery path in `daemon_base_url()` almost never matched what `start` had written — until its own reachability-probe fallback populated it from whichever daemon happened to be listening on the default port. Once that happened, it stuck as a stale, cross-instance cache: any later invocation with `TRUSTY_DATA_DIR` set for an isolated instance would still hit that cache first and silently reconnect to the (wrong) default/production daemon. This is exactly what caused the accidental production-index mutation during PR #3529.

## Root cause

Not "shared helper not used" — the four client subcommands DO share one helper (`commands::daemon_utils::daemon_base_url()`). The divergence was inside that shared helper and the daemon-side discovery-file writer:

1. `service::daemon::http_addr_path()` (what `run_daemon()` writes) ignored `TRUSTY_DATA_DIR` entirely — always `$HOME/.trusty-search/http_addr`.
2. `daemon_base_url()`'s *first* choice, `trusty_common::read_daemon_addr("trusty-search")` / `write_daemon_addr`, resolves through `trusty_common::resolve_data_dir`, which only honors `TRUSTY_DATA_DIR_OVERRIDE` (a *different*, test-only env var) — never `TRUSTY_DATA_DIR`. That's a third file location, disconnected from both `start`'s port file and its own `http_addr_path()`.

Only the port-file fallback (`daemon_port_path()`) was ever `TRUSTY_DATA_DIR`-aware, but the buggy first-choice branch above almost always won once populated.

## Fix (round 1)

- `service::daemon::http_addr_path()` now honors `TRUSTY_DATA_DIR` (mirroring `daemon_dir()`'s existing precedence), falling back to the unchanged `$HOME/.trusty-search/http_addr` default so the production/no-override contract with other consumers is untouched.
- `commands::daemon_utils::daemon_base_url()` now reads/refreshes through `trusty_search::service::http_addr_path()` directly instead of the generic `trusty_common` resolver — the exact same function `run_daemon()` uses to write the file.
- `commands::port::handle_port()`, `commands::serve::ensure_search_daemon_up()`'s `base_url_fn`, and `main.rs`'s `monitor web` had the identical bug pattern and are fixed the same way for consistency.

No explicit `--data-dir`/`--port` override flag was added to `index`/`list`/`reindex`/`search`: `TRUSTY_DATA_DIR` is already the existing idiom `start` uses for isolation.

## Fix (round 2 — code-critic review, HIGH finding)

Round 1 removed the CLI-side reachability-probe write to `trusty_common::write_daemon_addr("trusty-search", …)` without noticing it was the **only writer** of that generic registry in the entire workspace. Two other consumers read it exclusively and silently broke:

1. **`crates/trusty-common/src/monitor/search_client.rs`** — `resolve_search_url()`, backing `trusty-search monitor status`/`monitor indexes`/`monitor tui` (including the TUI's `[r]` reindex hotkey). After round 1 this always fell back to the hardcoded `DEFAULT_SEARCH_URL = "http://127.0.0.1:7878"`, reproducing the exact PR #3529 incident class through a sibling command whenever the daemon wasn't on the default port.
2. **`crates/trusty-installer/src/commands/ensure/daemon.rs`** — `resolve_base_url()`, consumed by `project_setup.rs` (register-index) and `readiness.rs` (readiness poll). **Correction to my earlier PR description**, which wrongly claimed trusty-installer was untouched: it never goes through `http_addr_path()` at all, so `ensure`'s register-index and readiness stages could no longer discover a running daemon after round 1.

**Fix:** `run_daemon()` now also calls `trusty_common::write_daemon_addr("trusty-search", …)` (via a new `register_shared_discovery()` helper) right after writing `http_addr_path()`, and `trusty_common::remove_daemon_addr("trusty-search")` (`deregister_shared_discovery()`) at shutdown — **gated on `TRUSTY_DATA_DIR` being unset**. This restores the registry for the one unambiguous default instance without reintroducing the cross-instance pollution round 1 fixed: an isolated instance still never writes it.

Also fixed per review (MEDIUM): the CLI's reachability-probe refresh write in `daemon_base_url()` now goes through the same atomic tmp+rename helper `run_daemon()` uses (`write_http_addr_file`, now `pub` and taking `&str` instead of `&SocketAddr`) instead of a bare `std::fs::write`, so a false-positive probe can no longer tear a concurrent reader's view of the file `trusty-console`/`trusty-mpm`'s discovery trusts as ground truth.

`service/daemon.rs`'s test module was split into a sibling `daemon_tests.rs` (mirroring the existing `persistence_tests.rs` pattern) to stay under the 500-SLOC production cap after the new coverage.

## Tests

Round 1:
- `service::daemon::tests::http_addr_path_respects_trusty_data_dir` — pure path-resolution check under `TRUSTY_DATA_DIR`.
- `commands::daemon_utils::tests::daemon_base_url_prefers_isolated_instance_over_stale_default_cache` — binds two real listeners, seeds the *old* wrong cache location with one address and the isolated instance's real discovery file with the other, asserts `daemon_base_url()` returns the isolated address. Fails against the pre-fix implementation.
- `commands::daemon_utils::tests::daemon_base_url_falls_back_when_http_addr_dead` — exercises the reachability-probe + refresh path entirely inside an isolated `TRUSTY_DATA_DIR`.

Round 2 (new, verifying both flagged readers):
- `service::daemon::tests::register_shared_discovery_writes_when_default_instance` / `_noop_when_isolated` / `deregister_shared_discovery_removes_when_default_instance` — pure gating tests, redirected via `TRUSTY_DATA_DIR_OVERRIDE` into a tempdir so they never touch a real `$HOME`/platform path.
- `service::daemon::tests::run_daemon_isolated_instance_never_pollutes_shared_discovery` — spins up a REAL `run_daemon()` with both `TRUSTY_DATA_DIR` and `TRUSTY_DATA_DIR_OVERRIDE` pointed at tempdirs (the only variant of this test safe to execute directly — the default-instance variant would need `TRUSTY_DATA_DIR` unset, which would resolve `daemon_lock_path()` to a REAL production path), binds an ephemeral port, and asserts the shared registry stays empty throughout while the isolated `http_addr` file is written and cleaned up correctly.
- `trusty_common::monitor::search_client::tests::resolve_search_url_discovers_non_default_registered_address` (in `crates/trusty-common`) — proves **reader #1** (`monitor status`/`monitor indexes`/`monitor tui`) discovers a non-default-port address once `write_daemon_addr` is called (the exact primitive `register_shared_discovery` now calls).
- **Reader #2** (trusty-installer's `resolve_base_url`) is already covered by its pre-existing `resolve_base_url_present`/`resolve_base_url_absent_is_none` tests in `crates/trusty-installer/src/commands/ensure/daemon.rs` — those test the same `write_daemon_addr` → `read_daemon_addr` contract my fix restores the daemon-side writer for; re-ran them as part of this gate to confirm they still pass unchanged.

## Quality gate (raw output)

`cargo fmt --all -- --check` — clean, no output.

`cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` (matches `ci.yml`'s clippy job) — exit 0, `Finished` clean.

`cargo test -p trusty-search -- --test-threads=2` (full suite, integration tests included):
```
running 1219 tests
test service::daemon::tests::register_shared_discovery_writes_when_default_instance ... ok
test service::daemon::tests::register_shared_discovery_noop_when_isolated ... ok
test service::daemon::tests::deregister_shared_discovery_removes_when_default_instance ... ok
test service::daemon::tests::run_daemon_isolated_instance_never_pollutes_shared_discovery ... ok
test service::daemon::tests::http_addr_path_respects_trusty_data_dir ... ok
...
test result: ok. 1218 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 20-32s

running 309 tests
test commands::daemon_utils::tests::daemon_base_url_prefers_isolated_instance_over_stale_default_cache ... ok
test commands::daemon_utils::tests::daemon_base_url_falls_back_when_http_addr_dead ... ok
test result: ok. 309 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.3s
```
(reduced `--test-threads` avoids pre-existing timing-sensitive flakes in `service::server::tests_components` / `commands::start::embedder_fallback` under this sandbox's contention — both independently reproduced against unmodified `main` via `git stash`, unrelated to this change; single-threaded/isolated reruns of each pass)

`cargo test -p trusty-common --features monitor-tui`:
```
test monitor::search_client::tests::resolve_search_url_discovers_non_default_registered_address ... ok
test result: ok. 328 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.21s
```

`cargo test -p trusty-installer`:
```
test commands::ensure::daemon::tests::resolve_base_url_present ... ok
test commands::ensure::daemon::tests::resolve_base_url_absent_is_none ... ok
test result: ok. 420 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 10.0s
```

## Constraints honored

- Branched off current `origin/main` (fast-forwarded to `179f903a` at PR time; includes `e62408d6`).
- Did not touch `supervisor.rs`, `swap_back_watchdog.rs`, or any embedder/sidecar file (epic #3524 slices 6/7 lane).
- All touched production files stay under the 500-SLOC cap (`scripts/check_line_cap.sh`: 0 violations); `service/daemon.rs`'s test module was split to a sibling `daemon_tests.rs` to make room for the new coverage.
- No test in this change starts a real daemon against a real `TRUSTY_DATA_DIR`-unset/default location; every new test either binds its own ephemeral `127.0.0.1:0` listener(s), is guarded by `TRUSTY_DATA_DIR_OVERRIDE` into a tempdir, or (the one real `run_daemon()` integration test) sets `TRUSTY_DATA_DIR` itself so every path it touches resolves under a tempdir.

Closes #3545

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
