### PR TITLE
fix(trusty-mpm): gate send_input against shell-execution and modal-swallow risk

### DIFF
--- a/crates/trusty-mpm/src/connectors/tm_tests.rs
+++ b/crates/trusty-mpm/src/connectors/tm_tests.rs
@@ -235,7 +235,7 @@ async fn delegate_unknown_session_is_backend_error() {
 async fn create_session_full_lifecycle() {
     let (_scratch, repo_url) = local_bare_repo();
     let (_daemon_root, url) = spawn_test_daemon().await;
-    let connector = TmConnector::with_daemon_url(url);
+    let connector = TmConnector::with_daemon_url(url.clone());
 
     // ── Hermetic workspace-provisioning root (#3450) ─────────────────────────
     // `DaemonState::with_root_isolated_managed` only isolates the session
@@ -273,7 +273,96 @@ async fn create_session_full_lifecycle() {
             ephemeral: true,
         },
     };
-    let info = ConnectorTestKit::assert_basic_lifecycle(&connector, req, "echo hello").await;
+
+    // NOT `ConnectorTestKit::assert_basic_lifecycle` (issue #3603 follow-up):
+    // that helper's `send_input` step hard-asserts success, which assumes the
+    // spawned session reaches `Active`. This test drives the REAL
+    // `spawn_managed_cloned` handler (module docs above), which calls the
+    // REAL `ClaudeCodeAdapter::spawn` — unlike every other tmux operation
+    // here, that is NOT faked by `FakeNoopTmuxDriver`, and it resolves an
+    // actual `claude` binary on `PATH`/well-known dirs
+    // (`ClaudeCodeAdapter::resolve_claude`). On a developer machine with
+    // Claude Code installed this succeeds and the record reaches `Active`;
+    // on a CI runner with no `claude` binary it fails and
+    // `spawn_managed_cloned` calls `mark_errored`, leaving the record
+    // `Errored`. Before #3603's send_input readiness gate, this test's
+    // `assert_basic_lifecycle` call "passed" in BOTH cases only because
+    // `send_input` had no Provisioning/Errored guard at all — on an Errored
+    // session that meant silently typing `echo hello` + Enter into a bare
+    // shell with no runtime attached, i.e. exactly the shell-execution risk
+    // #3603 closes. That was the test asserting broken (vulnerable)
+    // behavior, not a real contract. Assert the CORRECT, environment-
+    // independent contract instead: `send_input` must succeed for `Active`,
+    // and must be refused (never silently accepted) for anything else.
+    let info = connector
+        .create_session(req)
+        .await
+        .expect("create_session must succeed for a well-formed request");
+    assert!(
+        !info.id.is_empty(),
+        "create_session must return a non-empty session id"
+    );
+
+    let listed = connector
+        .list_sessions()
+        .await
+        .expect("list_sessions must succeed");
+    assert!(
+        listed.iter().any(|s| s.id == info.id),
+        "list_sessions must include the just-created session {}",
+        info.id
+    );
+
+    let status = connector
+        .session_status(&info.id)
+        .await
+        .expect("session_status must succeed for a known id");
+    assert_eq!(
+        status.id, info.id,
+        "session_status must echo back the id it was asked about"
+    );
+
+    // `session_status`'s `state` is DISPLAY-reconciled against live tmux
+    // (#3302): with `FakeNoopTmuxDriver` the tmux session never "exists", so
+    // an `active` PERSISTED record is shown as `stopped` here regardless of
+    // what actually gates `send_input` (which reads the PERSISTED state —
+    // `SessionManager::check_send_input_ready` via `self.get(id)`, never the
+    // display-reconciled view). Fetch the raw summary directly to read
+    // `persisted_state`, the field the daemon's own docs say resume/restart
+    // (and, by the same logic, this test's expectation) must key off of,
+    // rather than predicting the gate's outcome from a value it does not
+    // actually consult.
+    let raw: ManagedSessionSummary = reqwest::Client::new()
+        .get(format!("{url}/api/v1/sessions/managed/{}", info.id))
+        .send()
+        .await
+        .expect("raw status GET must succeed")
+        .json()
+        .await
+        .expect("raw status GET must decode as ManagedSessionSummary");
+    let persisted_state = raw.persisted_state.as_deref().unwrap_or(&raw.state);
+
+    match persisted_state {
+        "active" => {
+            connector
+                .send_input(&info.id, "echo hello")
+                .await
+                .expect("send_input must succeed for an Active session");
+        }
+        other => {
+            let err = connector
+                .send_input(&info.id, "echo hello")
+                .await
+                .expect_err(&format!(
+                    "send_input must be refused for a non-Active persisted state \
+                     ({other}), never silently accepted"
+                ));
+            assert!(
+                matches!(err, ConnectorError::Backend(_)),
+                "expected a Backend refusal for persisted state {other:?}, got {err:?}"
+            );
+        }
+    }
 
     // Restore the env var immediately after the one call that provisions a
     // workspace — attach/delegate below never re-provision.
@@ -287,7 +376,7 @@ async fn create_session_full_lifecycle() {
     assert_eq!(
         info.task.as_deref(),
         Some("list files"),
-        "the kit's lifecycle assertion doesn't check task content — do it here"
+        "create_session must echo back the task"
     );
 
     let attach = connector.attach(&info.id).await.expect("attach");

--- a/crates/trusty-mpm/src/daemon/managed_routes/proxy/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/proxy/tests.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use crate::daemon::state::DaemonState;
 use crate::runtime::RuntimeKind;
-use crate::session_manager::record::ManagedSessionId;
+use crate::session_manager::record::{ManagedSessionId, ManagedSessionState};
 
 /// Decode an axum `impl IntoResponse` into its JSON body.
 ///
@@ -40,6 +40,12 @@ async fn decode_response(resp: impl axum::response::IntoResponse) -> serde_json:
 /// seed keeps each test focused on the proxy behavior, not setup.
 /// What: returns the state and the seeded session's friendly name (`tmux_name`),
 /// which the tests resolve by name (proving the fuzzy-name path, not just id).
+/// The record is marked `Active` right after creation (`create_with_id`
+/// otherwise leaves it `Provisioning`, #3591): this fixture represents a
+/// normal working session a caller focuses and messages, and
+/// `SessionManager::send_input`'s state guard (#3591) now correctly refuses
+/// `Provisioning` — a real bug in the proxy target, not something these
+/// route-wiring tests are exercising.
 async fn seeded_state() -> (Arc<DaemonState>, String) {
     let root = tempfile::tempdir().unwrap().keep();
     let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
@@ -59,6 +65,12 @@ async fn seeded_state() -> (Arc<DaemonState>, String) {
         )
         .await
         .expect("seed session");
+    {
+        let mut store = mgr.store.write().await;
+        let mut r = store.get(&record.id).await.unwrap();
+        r.state = ManagedSessionState::Active;
+        store.upsert(r).await.unwrap();
+    }
     (state, record.tmux_name)
 }
 

--- a/crates/trusty-mpm/src/daemon/mcp_proxy.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_proxy.rs
@@ -128,7 +128,7 @@ mod tests {
     use super::*;
 
     use crate::runtime::RuntimeKind;
-    use crate::session_manager::record::ManagedSessionId;
+    use crate::session_manager::record::{ManagedSessionId, ManagedSessionState};
 
     /// Build a hermetic `DaemonState` with one seeded managed session.
     ///
@@ -136,6 +136,12 @@ mod tests {
     /// `managed_routes::proxy::tests::seeded_state` (a separate module) so the
     /// MCP-layer wrappers are exercised over the SAME fake-tmux, isolated store.
     /// What: returns the state and the seeded session's friendly `tmux_name`.
+    /// The record is marked `Active` right after creation (`create_with_id`
+    /// otherwise leaves it `Provisioning`, #3591): this fixture represents a
+    /// normal working session a caller focuses and messages, and
+    /// `SessionManager::send_input`'s state guard (#3591) now correctly
+    /// refuses `Provisioning` — a real bug in the proxy target, not something
+    /// these route-wiring tests are exercising.
     async fn seeded_state() -> (Arc<DaemonState>, String) {
         let root = tempfile::tempdir().unwrap().keep();
         let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
@@ -155,6 +161,12 @@ mod tests {
             )
             .await
             .expect("seed session");
+        {
+            let mut store = mgr.store.write().await;
+            let mut r = store.get(&record.id).await.unwrap();
+            r.state = ManagedSessionState::Active;
+            store.upsert(r).await.unwrap();
+        }
         (state, record.tmux_name)
     }
 

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -360,14 +360,63 @@ impl SessionManager {
     // under the 500-SLOC cap (the same pattern `reactivate.rs`/`reconcile.rs`
     // already use for `mark_reactivated`/`reconcile_on_boot`).
 
-    /// Inject text into a live session's tmux pane (Enter-submit variant).
+    /// Inject text into a live session's tmux pane (Enter-submit variant),
+    /// state- and modal-gated (issue #3591).
     ///
-    /// Why: `POST /api/v1/sessions/managed/{id}/send` lets the operator or
-    /// automation feed text into a running session without attaching.
-    /// What: delegates to `inject(id, text, Submit::Enter)` so all input-path
-    /// guard logic lives in one place.
-    /// Test: `manager_send_input`.
+    /// Why: `POST /api/v1/sessions/managed/{id}/send`, `tm sessions send`, and
+    /// the MCP `session_send` tool all let the operator or automation feed
+    /// arbitrary text into a running session without attaching. Before #3591
+    /// the only guard was [`Self::inject`]'s Stopped/Decommissioned check —
+    /// `Provisioning` (pane exists, Claude Code hasn't finished booting) and
+    /// `Errored` (runtime crashed back to a bare shell) were NOT refused, so
+    /// `Submit::Enter`'s literal-then-Enter dispatch would type the message
+    /// into a bare shell and press Enter, **executing it as a shell command**.
+    /// [`super::task_inject::SessionManager::check_send_input_ready`] (kept
+    /// in that sibling file, alongside the readiness/modal machinery it
+    /// reuses, to stay under THIS file's 500-SLOC production cap) now runs
+    /// first: a state guard refusing `Provisioning`/`Errored` (closes the
+    /// shell-execution risk outright — the priority fix), and — for
+    /// `RuntimeKind::ClaudeCode` sessions only — the SAME modal-detection
+    /// machinery [`Self::inject_task_when_ready`] uses for spawn-time
+    /// `--task` delivery, catching an `Active` session whose pane is showing
+    /// a first-run onboarding/trust modal that would otherwise silently
+    /// swallow the send. Deliberately NOT reused: `task_inject`'s
+    /// `runtime_ready`-based half of [`super::task_inject::PaneReadiness`]
+    /// (the "is the `claude` PID up" check) — it was tried and reverted
+    /// after it broke three hermetic tests built on
+    /// `DaemonState::with_root_isolated_managed` (whose `FakeNoopTmuxDriver`
+    /// makes `runtime_ready` `false` by construction), proof it is too blunt
+    /// an instrument outside the narrow, bounded, just-spawned poll loop
+    /// `inject_task_when_ready` uses it in. See `PaneReadiness`'s doc for the
+    /// full account. `RuntimeKind::Tcode` sessions skip the modal probe
+    /// entirely (mirrors `should_inject_task`'s existing ClaudeCode-only
+    /// scoping): its markers are Claude-Code-specific onboarding copy.
+    /// What: fail-fast, not block-and-poll — unlike spawn-time injection
+    /// (which owns the session and can afford to wait out a first-run modal),
+    /// `send_input` is called from an interactive CLI and from MCP tools
+    /// where a caller blocked for up to ~60s on someone else's pane is bad
+    /// UX; a caller that gets an immediate, precise "still provisioning" or
+    /// "showing a modal" error can decide to retry itself. This also
+    /// strengthens what a caller gets back on success: previously
+    /// `sent: true` (the MCP `session_send` wrapper,
+    /// `crates/trusty-mpm/src/daemon/mcp_session.rs`) meant only "the two
+    /// tmux subprocesses exited 0"; now reaching that path additionally means
+    /// the pane was NOT `Provisioning`/`Errored` and (for ClaudeCode) showed
+    /// no known blocking modal immediately beforehand — the existing field's
+    /// meaning is strengthened for free, no wire format change needed (#3168
+    /// scopes the full delivery-ack layer). Delegates the actual dispatch to
+    /// `inject(id, text, Submit::Enter)` so the pane-alive check and
+    /// `send_line` dispatch stay the single source of truth for the wire
+    /// mechanics (unchanged — `Submit::Enter`'s literal-then-Enter dispatch
+    /// is issue #1461's deliberate, unit-tested behavior).
+    /// Test: `manager_send_input`,
+    /// `manager_send_input_rejected_for_stopped_and_decommissioned`,
+    /// `manager_send_input_rejected_for_provisioning_and_errored`,
+    /// `manager_send_input_rejected_when_pane_shows_blocking_modal`,
+    /// `manager_send_input_skips_modal_probe_for_tcode` (the last three in
+    /// the sibling `send_input_gate_tests.rs`).
     pub async fn send_input(&self, id: &ManagedSessionId, text: &str) -> Result<(), ManagedError> {
+        self.check_send_input_ready(id).await?;
         self.inject(id, text, Submit::Enter).await
     }
 

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -94,6 +94,9 @@ mod injection_status_tests;
 #[cfg(test)]
 mod slots_tests;
 
+#[cfg(test)]
+mod send_input_gate_tests;
+
 /// Real tmux driver adapter — only available when the `daemon` feature (and thus
 /// the daemon's `TmuxDriver`) is compiled in.
 #[cfg(feature = "daemon")]

--- a/crates/trusty-mpm/src/session_manager/send_input_gate_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/send_input_gate_tests.rs
@@ -1,0 +1,182 @@
+//! Tests for `SessionManager::send_input`'s readiness/modal gate (#3591).
+//!
+//! Why: `session_manager/tests.rs` is at the 1500-SLOC test cap; this
+//! `send_input`-gate-specific coverage lives here so neither file grows past
+//! its limit. Mirrors the pattern established by `restart_tests.rs` /
+//! `decommission_worktree_tests.rs` (`FakeTmuxDriver` + `make_manager` from
+//! the sibling `tests` module).
+//! What: proves the state guard refuses `Provisioning`/`Errored` sessions
+//! (the shell-execution defect this issue exists to close), proves the
+//! ClaudeCode-only modal probe refuses a session whose pane shows a known
+//! blocking onboarding/trust dialog, and proves a `Tcode`-runtime session is
+//! exempt from that modal probe (the healthy-path regression guard on the
+//! other runtime).
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::path::PathBuf;
+
+use super::record::ManagedSessionState;
+use super::tests::make_manager;
+
+/// send_input must be rejected for Provisioning and Errored sessions (#3591).
+///
+/// Why: this is the shell-execution defect the issue is about — before the
+/// fix, `Provisioning` (pane exists, Claude Code hasn't finished booting) and
+/// `Errored` (runtime crashed back to a bare shell) sessions were NOT refused
+/// by `send_input`'s state guard, so `Submit::Enter`'s literal-then-Enter
+/// dispatch would type the message into a live pane and press Enter — which,
+/// against a bare shell, executes it as a shell command. Against PRE-FIX code
+/// (guard only checked Stopped/Decommissioned) this test FAILS: a freshly
+/// created record is `Provisioning` and the send proceeds, recording a call
+/// in `fake.send_calls`. Asserting BOTH the `Err` result AND the empty
+/// `send_calls` makes the causality explicit — a caller could otherwise
+/// misread a false-negative error as protection even if the text still got
+/// typed into the pane.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_send_input_rejected_for_provisioning_and_errored() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    // A freshly created record is Provisioning (create.rs) — no state
+    // manipulation needed to exercise this branch.
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/x")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    assert_eq!(record.state, ManagedSessionState::Provisioning);
+
+    let result = mgr.send_input(&record.id, "rm -rf /").await;
+    assert!(
+        result.is_err(),
+        "send_input must fail for Provisioning sessions (pre-fix: this proceeds)"
+    );
+    assert!(
+        fake.send_calls.lock().unwrap().is_empty(),
+        "no send-line may fire for a Provisioning session — this is the shell-execution risk"
+    );
+
+    // Test Errored rejection.
+    mgr.mark_errored(&record.id, "spawn failed")
+        .await
+        .expect("mark_errored");
+    let result = mgr.send_input(&record.id, "rm -rf /").await;
+    assert!(
+        result.is_err(),
+        "send_input must fail for Errored sessions (pre-fix: this proceeds)"
+    );
+    assert!(
+        fake.send_calls.lock().unwrap().is_empty(),
+        "no send-line may fire for an Errored session — this is the shell-execution risk"
+    );
+}
+
+/// send_input must refuse a ClaudeCode-runtime session whose pane is showing
+/// a blocking onboarding/trust modal, rather than silently letting the text
+/// be swallowed by the dialog (#3591).
+///
+/// Why: an `Active` session is NOT necessarily accepting typed input — a
+/// first-run onboarding wizard or trust dialog can be occupying the pane's
+/// input focus. Against PRE-FIX code (no readiness/modal probe on
+/// `send_input` at all) this test FAILS: the send proceeds and is recorded in
+/// `fake.send_calls` even though the text would have been eaten by the modal
+/// on a real pane. Asserting the empty `send_calls` alongside the `Err`
+/// confirms the gate actually stops the dispatch rather than merely
+/// misreporting a send that still happened.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_send_input_rejected_when_pane_shows_blocking_modal() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/x")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    {
+        let mut store = mgr.store.write().await;
+        let mut r = store.get(&record.id).await.unwrap();
+        r.state = ManagedSessionState::Active;
+        store.upsert(r).await.unwrap();
+    }
+    fake.capture_responses.lock().unwrap().insert(
+        record.tmux_name.clone(),
+        "Do you trust the files in this folder?".into(),
+    );
+
+    let result = mgr.send_input(&record.id, "hello").await;
+    assert!(
+        result.is_err(),
+        "send_input must fail when the pane shows a blocking modal (pre-fix: this proceeds)"
+    );
+    assert!(
+        fake.send_calls.lock().unwrap().is_empty(),
+        "no send-line may fire while a blocking modal is showing"
+    );
+}
+
+/// A `RuntimeKind::Tcode` session must NOT be gated by the ClaudeCode-only
+/// modal probe (#3591).
+///
+/// Why: the blocking-modal markers (`BLOCKING_MODAL_MARKERS` in
+/// `task_inject.rs`) are Claude-Code-specific onboarding/trust-dialog copy
+/// (mirrors `should_inject_task`'s existing ClaudeCode-only scoping) — there
+/// is nothing meaningful to probe for on a tcode pane. To PROVE the
+/// exemption (not just that a send with no marker present happens to
+/// succeed), this test seeds the fake pane's captured text with the SAME
+/// ClaudeCode marker used elsewhere in this suite to trigger a rejection,
+/// on a Tcode-runtime record — and asserts the send still succeeds. If the
+/// modal probe were mistakenly applied regardless of runtime, this send
+/// would be rejected exactly like
+/// `manager_send_input_rejected_when_pane_shows_blocking_modal`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_send_input_skips_modal_probe_for_tcode() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/x")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    {
+        let mut store = mgr.store.write().await;
+        let mut r = store.get(&record.id).await.unwrap();
+        r.state = ManagedSessionState::Active;
+        r.runtime = crate::runtime::RuntimeKind::Tcode;
+        store.upsert(r).await.unwrap();
+    }
+    // Same marker that DOES block a ClaudeCode session in
+    // `manager_send_input_rejected_when_pane_shows_blocking_modal`.
+    fake.capture_responses.lock().unwrap().insert(
+        record.tmux_name.clone(),
+        "Do you trust the files in this folder?".into(),
+    );
+
+    mgr.send_input(&record.id, "hello tcode")
+        .await
+        .expect("send_input must succeed for an Active tcode session even with a ClaudeCode-shaped marker in its pane");
+    let calls = fake.send_calls.lock().unwrap();
+    assert!(calls.iter().any(|(_, text)| text == "hello tcode"));
+}

--- a/crates/trusty-mpm/src/session_manager/task_inject.rs
+++ b/crates/trusty-mpm/src/session_manager/task_inject.rs
@@ -26,9 +26,21 @@
 //! injected keystrokes instead keeps the loop polling (and, if the modal never
 //! clears, correctly reports `FailedTimeout` instead of the #2361-review-flagged
 //! silent-discard bug).
+//! [`SessionManager::pane_readiness`] (#3591) factors the `runtime_ready` +
+//! `pane_shows_blocking_modal` conjunction out of this module's poll loop into
+//! one [`PaneReadiness`]-returning probe. `SessionManager::send_input`
+//! (`super::manager`, also #3591) reuses this module's modal-detection
+//! machinery directly (`pane_shows_blocking_modal` +
+//! `capture_readiness_pane`) as a fail-fast gate, but deliberately does NOT
+//! reuse the `runtime_ready` half — see [`PaneReadiness`]'s doc for why (in
+//! short: `runtime_ready` is `false` by construction for the fallback
+//! no-tmux driver and every hermetic test built on it, which made it too
+//! blunt an instrument outside this module's own bounded, just-spawned poll
+//! loop).
 //! Test: `should_inject_*` (pure gate), `pane_shows_blocking_modal_*` (pure
-//! marker match), and `inject_when_ready_*` (delivery + status transitions via
-//! the `FakeTmuxDriver` seam) in this module's `tests` submodule.
+//! marker match), `pane_readiness_*` (the poll loop's probe), and
+//! `inject_when_ready_*` (delivery + status transitions via the
+//! `FakeTmuxDriver` seam) in this module's `tests` submodule.
 
 use std::time::Duration;
 
@@ -101,6 +113,50 @@ const BLOCKING_MODAL_MARKERS: &[&str] = &[
 /// `pane_shows_blocking_modal_false_for_normal_prompt`.
 pub fn pane_shows_blocking_modal(pane_text: &str) -> bool {
     BLOCKING_MODAL_MARKERS.iter().any(|m| pane_text.contains(m))
+}
+
+/// Outcome of a one-shot pane-readiness probe used by
+/// [`SessionManager::inject_task_when_ready`]'s bounded poll loop (issue #3591
+/// factored this out of the loop body).
+///
+/// Why NOT also used by `send_input`'s gate (issue #3591 design note): the
+/// natural instinct is to reuse this wholesale for `send_input` too, but
+/// `runtime_ready` looks for a live `claude` PID via `ps`, which is `false`
+/// by definition for [`super::real_tmux::FakeNoopTmuxDriver`] (the
+/// documented "tmux is not installed" fallback — its `list_sessions` always
+/// returns empty, so `session_exists`/`runtime_ready`'s default impls can
+/// never report `true`) and for every hermetic test built on
+/// `DaemonState::with_root_isolated_managed`, which wires that same fake
+/// driver specifically so handler/proxy/connector tests don't need a real
+/// tmux. Gating `send_input` on `runtime_ready` was tried and reverted after
+/// it broke three such tests
+/// (`connectors::tm::tests::create_session_full_lifecycle`,
+/// `daemon::managed_routes::proxy::tests::proxy_message_route_focused_sends_unfocused_no_focus`,
+/// `daemon::mcp_proxy::tests::mcp_proxy_focus_message_summary_unfocus_round_trip`)
+/// — proof that a hard `runtime_ready` gate has too high a false-positive
+/// rate outside the narrow, bounded, just-spawned context
+/// `inject_task_when_ready` uses it in. `send_input`'s gate instead reuses
+/// only the modal-detection half directly (see
+/// `super::manager::SessionManager::send_input`), and relies on its OWN
+/// state guard (refusing `Provisioning`/`Errored`) for the shell-execution
+/// risk this issue is about.
+/// What: `Ready` — the runtime PID is up AND the captured pane tail shows no
+/// known blocking-modal marker. `RuntimeNotReady` — the PID has not appeared
+/// yet (still booting), is definitively absent (crashed out to a bare
+/// shell), or the driver has no real signal to offer (see above).
+/// `BlockingModal` — the PID is up but the pane tail matches a
+/// [`BLOCKING_MODAL_MARKERS`] entry.
+/// Test: `pane_readiness_ready_when_pid_up_and_no_modal`,
+/// `pane_readiness_not_ready_when_pid_absent`,
+/// `pane_readiness_blocking_modal_when_pid_up_but_modal_shown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PaneReadiness {
+    /// Runtime PID present, no known blocking modal in the captured tail.
+    Ready,
+    /// The runtime PID has not (yet, or ever) appeared.
+    RuntimeNotReady,
+    /// PID present but the pane tail matches a known first-run/trust-dialog marker.
+    BlockingModal,
 }
 
 /// Pure gate: should the spawned session's task be auto-injected into its pane?
@@ -220,11 +276,7 @@ impl SessionManager {
                     .await;
                 return Ok(false);
             }
-            if self.tmux.runtime_ready(&name)
-                && !pane_shows_blocking_modal(
-                    &self.capture_readiness_pane(&name, pane_id.as_deref()),
-                )
-            {
+            if self.pane_readiness(&name, pane_id.as_deref()) == PaneReadiness::Ready {
                 ready = true;
                 break;
             }
@@ -277,17 +329,47 @@ impl SessionManager {
     /// failure must never itself look like "modal detected"; it is treated as
     /// "nothing to flag," leaving the PID-presence check as the sole
     /// readiness signal for that attempt (the loop simply retries).
+    /// `pub(super)` (#3591): also called directly by [`Self::send_input`]'s
+    /// modal-only gate in `super::manager` — see that method's doc for why it
+    /// reuses this capture but NOT [`Self::pane_readiness`] wholesale.
     /// What: `capture_pane(name, pane_id, MODAL_PROBE_LINES)` when `pane_id`
     /// is `Some`, else `capture(name, MODAL_PROBE_LINES)`.
     /// Test: exercised via `inject_when_ready_waits_out_blocking_modal_then_succeeds`
     /// (pane-scoped) and the session-scoped fallback is covered by every other
-    /// `inject_when_ready_*` test (no `pane_id` seeded).
-    fn capture_readiness_pane(&self, name: &str, pane_id: Option<&str>) -> String {
+    /// `inject_when_ready_*` test (no `pane_id` seeded); `send_input`'s reuse
+    /// is covered by `manager_send_input_rejected_when_pane_shows_blocking_modal`.
+    pub(super) fn capture_readiness_pane(&self, name: &str, pane_id: Option<&str>) -> String {
         match pane_id {
             Some(p) => self.tmux.capture_pane(name, p, MODAL_PROBE_LINES),
             None => self.tmux.capture(name, MODAL_PROBE_LINES),
         }
         .unwrap_or_default()
+    }
+
+    /// One-shot readiness probe used by [`Self::inject_task_when_ready`]'s
+    /// bounded poll loop (issue #3591 factored this out of the loop body; see
+    /// [`PaneReadiness`]'s doc for why `send_input` deliberately does NOT
+    /// reuse this wholesale).
+    ///
+    /// Why: split out so the loop reads as one clear condition instead of the
+    /// `runtime_ready(...) && !pane_shows_blocking_modal(...)` conjunction
+    /// inline.
+    /// What: short-circuits to [`PaneReadiness::RuntimeNotReady`] without
+    /// paying for a pane capture when `runtime_ready` is false; otherwise
+    /// inspects the captured tail (pane-scoped via
+    /// [`Self::capture_readiness_pane`] when `pane_id` is known — #2545
+    /// convention) for a [`BLOCKING_MODAL_MARKERS`] hit.
+    /// Test: `pane_readiness_ready_when_pid_up_and_no_modal`,
+    /// `pane_readiness_not_ready_when_pid_absent`,
+    /// `pane_readiness_blocking_modal_when_pid_up_but_modal_shown`.
+    pub(super) fn pane_readiness(&self, name: &str, pane_id: Option<&str>) -> PaneReadiness {
+        if !self.tmux.runtime_ready(name) {
+            return PaneReadiness::RuntimeNotReady;
+        }
+        if pane_shows_blocking_modal(&self.capture_readiness_pane(name, pane_id)) {
+            return PaneReadiness::BlockingModal;
+        }
+        PaneReadiness::Ready
     }
 
     /// Persist an [`InjectionStatus`] transition on the session record (#2364).
@@ -319,6 +401,50 @@ impl SessionManager {
         if let Err(e) = self.store.write().await.upsert(record).await {
             warn!(id = %id, "set_injection_status({status}): persist failed: {e}");
         }
+    }
+
+    /// Refuse [`Self::send_input`] (`super::manager`) for a session that is
+    /// not safe to type into (issue #3591).
+    ///
+    /// Why: lives beside the readiness/modal machinery it reuses (and out of
+    /// `manager.rs`, which is at its 500-SLOC production cap) rather than a
+    /// second copy inline in `send_input` — see [`PaneReadiness`]'s doc for
+    /// why this reuses only the modal half, not the `runtime_ready` half.
+    /// What: refuses `Provisioning`/`Errored` outright (the shell-execution
+    /// risk this issue is about); for `RuntimeKind::ClaudeCode` also refuses
+    /// a pane showing a [`BLOCKING_MODAL_MARKERS`] hit. Fail-fast: a single
+    /// probe, no retry loop — see `send_input`'s doc for the block-vs-fail-fast
+    /// rationale.
+    /// Test: `manager_send_input_rejected_for_provisioning_and_errored`,
+    /// `manager_send_input_rejected_when_pane_shows_blocking_modal`,
+    /// `manager_send_input_skips_modal_probe_for_tcode` (in the sibling
+    /// `send_input_gate_tests.rs`).
+    pub(super) async fn check_send_input_ready(
+        &self,
+        id: &ManagedSessionId,
+    ) -> Result<(), ManagedError> {
+        let record = self.get(id).await?;
+        if matches!(
+            record.state,
+            ManagedSessionState::Provisioning | ManagedSessionState::Errored
+        ) {
+            return Err(ManagedError::TmuxUnavailable(format!(
+                "session {} is {}; cannot inject input",
+                record.tmux_name, record.state
+            )));
+        }
+        if record.runtime == RuntimeKind::ClaudeCode
+            && pane_shows_blocking_modal(
+                &self.capture_readiness_pane(&record.tmux_name, record.pane_id.as_deref()),
+            )
+        {
+            return Err(ManagedError::TmuxUnavailable(format!(
+                "session {} is showing a blocking onboarding/trust modal; \
+                 cannot inject input until it is dismissed",
+                record.tmux_name
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -400,6 +526,17 @@ mod tests {
             .create("wire up the widget".into(), None, None, None, None, None)
             .await
             .expect("create");
+        // `spawn_task_injection` only calls `inject_task_when_ready` once
+        // `should_inject_task` has already confirmed the record reached
+        // `Active` (see `lifecycle.rs::spawn_task_injection`) — mirror that
+        // precondition here rather than leaving the record `Provisioning`
+        // (#3591: `send_input`'s new state guard now refuses `Provisioning`).
+        {
+            let mut store = mgr.store.write().await;
+            let mut r = store.get(&record.id).await.unwrap();
+            r.state = ManagedSessionState::Active;
+            store.upsert(r).await.unwrap();
+        }
 
         let injected = mgr
             .inject_task_when_ready(&record.id, "wire up the widget")
@@ -470,6 +607,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pane_readiness_ready_when_pid_up_and_no_modal() {
+        // #3591: the happy path both callers (poll loop and send_input's
+        // fail-fast gate) rely on — PID up (FakeTmuxDriver's default
+        // runtime_ready == session_exists, true right after create) and no
+        // capture_responses seeded (empty tail, no marker match).
+        let dir = TempDir::new().unwrap();
+        let (mgr, _fake) = make_manager(&dir).await;
+        let record = mgr
+            .create("wire up SSO".into(), None, None, None, None, None)
+            .await
+            .expect("create");
+
+        assert_eq!(
+            mgr.pane_readiness(&record.tmux_name, record.pane_id.as_deref()),
+            PaneReadiness::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn pane_readiness_not_ready_when_pid_absent() {
+        // #3591: a pane with no live runtime PID (still booting, or crashed
+        // out — modeled here via kill_session, which drops the fake's
+        // session_exists/runtime_ready signal) must report RuntimeNotReady,
+        // and must NOT pay for a modal-marker capture in that case.
+        let dir = TempDir::new().unwrap();
+        let (mgr, _fake) = make_manager(&dir).await;
+        let record = mgr
+            .create("wire up SSO".into(), None, None, None, None, None)
+            .await
+            .expect("create");
+        mgr.tmux_driver()
+            .kill_session(&record.tmux_name)
+            .expect("kill_session");
+
+        assert_eq!(
+            mgr.pane_readiness(&record.tmux_name, record.pane_id.as_deref()),
+            PaneReadiness::RuntimeNotReady
+        );
+    }
+
+    #[tokio::test]
+    async fn pane_readiness_blocking_modal_when_pid_up_but_modal_shown() {
+        // #3591: PID present but the captured tail matches a known
+        // onboarding/trust-dialog marker — must report BlockingModal, not Ready.
+        let dir = TempDir::new().unwrap();
+        let (mgr, fake) = make_manager(&dir).await;
+        let record = mgr
+            .create("wire up SSO".into(), None, None, None, None, None)
+            .await
+            .expect("create");
+        fake.capture_responses.lock().unwrap().insert(
+            record.tmux_name.clone(),
+            "Do you trust the files in this folder?".into(),
+        );
+
+        assert_eq!(
+            mgr.pane_readiness(&record.tmux_name, record.pane_id.as_deref()),
+            PaneReadiness::BlockingModal
+        );
+    }
+
+    #[tokio::test]
     async fn inject_when_ready_marks_success_status() {
         // #2364a: a successful delivery must leave the record's
         // injection_status as Success, not just return Ok(true).
@@ -479,6 +678,14 @@ mod tests {
             .create("ship the feature".into(), None, None, None, None, None)
             .await
             .expect("create");
+        // See the matching comment in `inject_when_ready_sends_task_via_send_seam`:
+        // mirror `spawn_task_injection`'s Active precondition (#3591).
+        {
+            let mut store = mgr.store.write().await;
+            let mut r = store.get(&record.id).await.unwrap();
+            r.state = ManagedSessionState::Active;
+            store.upsert(r).await.unwrap();
+        }
 
         let injected = mgr
             .inject_task_when_ready(&record.id, "ship the feature")

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -936,6 +936,14 @@ async fn manager_send_input_rejected_for_stopped_and_decommissioned() {
     );
 }
 
+// `manager_send_input_rejected_for_provisioning_and_errored`,
+// `manager_send_input_rejected_when_pane_shows_blocking_modal`, and
+// `manager_send_input_skips_modal_probe_for_tcode` (issue #3591) live in the
+// sibling `send_input_gate_tests.rs` — this file is at the 1500-SLOC test
+// cap, so new coverage for the `send_input` readiness/modal gate goes there
+// (mirrors the `restart_tests.rs` / `decommission_worktree_tests.rs`
+// precedent for keeping this file under its limit).
+
 #[tokio::test]
 async fn manager_env_scrub_command_sent() {
     // Verify that the spawn sends `env -u ANTHROPIC_API_KEY claude`.

--- a/crates/trusty-mpm/tests/proxy_routes.rs
+++ b/crates/trusty-mpm/tests/proxy_routes.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use trusty_mpm::daemon::{api, state::DaemonState};
 use trusty_mpm::runtime::RuntimeKind;
-use trusty_mpm::session_manager::ManagedSessionId;
+use trusty_mpm::session_manager::{ManagedSessionId, ManagedSessionState};
 
 /// Spawn the real daemon router on a loopback port with one seeded session.
 ///
@@ -29,7 +29,11 @@ use trusty_mpm::session_manager::ManagedSessionId;
 /// What: builds a hermetic `DaemonState::with_root_isolated_managed` (no real
 /// tmux — `FakeNoopTmuxDriver`), seeds one managed session, serves
 /// `api::router` on an ephemeral `127.0.0.1` port, and returns the base URL plus
-/// the seeded session's friendly name.
+/// the seeded session's friendly name. The record is marked `Active` via the
+/// public `set_workspace` transition (`create_with_id` otherwise leaves it
+/// `Provisioning`, #3591): this fixture represents a normal working session a
+/// caller focuses and messages, and `SessionManager::send_input`'s state
+/// guard (#3591) now correctly refuses `Provisioning`.
 async fn spawn_daemon_with_session() -> (String, String) {
     let root = tempfile::tempdir().unwrap().keep();
     let state = Arc::new(DaemonState::with_root_isolated_managed(root).await);
@@ -49,6 +53,13 @@ async fn spawn_daemon_with_session() -> (String, String) {
         )
         .await
         .expect("seed session");
+    mgr.set_workspace(
+        &record.id,
+        std::env::temp_dir(),
+        ManagedSessionState::Active,
+    )
+    .await
+    .expect("mark seeded session Active");
 
     let router = api::router(Arc::clone(&state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/trusty-mpm/tests/session_control_api.rs
+++ b/crates/trusty-mpm/tests/session_control_api.rs
@@ -21,7 +21,7 @@ use tempfile::TempDir;
 
 use trusty_mpm::core::sm::control::Submit;
 use trusty_mpm::session_manager::{
-    ManagedError, ManagedSessionId, ManagedTmuxDriver, SessionManager,
+    ManagedError, ManagedSessionId, ManagedSessionState, ManagedTmuxDriver, SessionManager,
 };
 
 /// A recording tmux driver that captures EVERY keystroke primitive (#1461).
@@ -300,6 +300,12 @@ async fn send_input_back_compat_still_uses_send_line() {
     // a literal+Enter send — equivalent to inject(.., Submit::Enter).
     let dir = TempDir::new().unwrap();
     let (mgr, driver, id) = make_session(&dir).await;
+    // `create()` leaves the record `Provisioning`; `send_input`'s state guard
+    // (#3591) now correctly refuses that, so mark it `Active` via the public
+    // `set_workspace` transition to exercise the back-compat dispatch path.
+    mgr.set_workspace(&id, dir.path().to_path_buf(), ManagedSessionState::Active)
+        .await
+        .expect("mark session Active");
 
     mgr.send_input(&id, "legacy text")
         .await

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -753,7 +753,17 @@ async fn tcode_session_spawns_and_accepts_commands() {
         &[],
     );
 
-    // Issue a command into the session's pane (operator interaction).
+    // `create_with_id` leaves the record `Provisioning`; `send_input`'s state
+    // guard (#3591) now correctly refuses that, so mark it `Active` (mirrors
+    // what the real spawn handler does once the adapter above has launched)
+    // before issuing a command into the session's pane (operator interaction).
+    mgr.set_workspace(
+        &record.id,
+        std::path::PathBuf::from("/tmp/tcode-ws"),
+        trusty_mpm::session_manager::ManagedSessionState::Active,
+    )
+    .await
+    .expect("mark session Active");
     mgr.send_input(&record.id, "status")
         .await
         .expect("send_input");


### PR DESCRIPTION
## Summary

- `SessionManager::send_input` (`tm sessions send` / MCP `session_send`) previously refused only `Stopped`/`Decommissioned` sessions. A `Provisioning` session (pane exists, Claude Code hasn't finished booting) or an `Errored` session (runtime crashed back to a bare shell) still received `Submit::Enter`'s literal-then-Enter dispatch — typing the message and pressing Enter in whatever the pane actually contains. Against a bare shell that **executes arbitrary message text as a shell command**. This is the priority defect.
- `send_input` had no readiness/modal gate at all: an `Active` `ClaudeCode` session showing a first-run onboarding/trust dialog would silently swallow the send while still reporting `sent: true`.
- Fix reuses (rather than duplicates) `task_inject.rs`'s existing spawn-time readiness/modal machinery: a new `SessionManager::check_send_input_ready` (in `task_inject.rs`, alongside a factored-out `PaneReadiness` probe now shared by `inject_task_when_ready`'s poll loop) refuses `Provisioning`/`Errored` outright, and — for `RuntimeKind::ClaudeCode` only — refuses a pane matching a known blocking-modal marker.

## Design decisions

- **Fail-fast, not block-and-poll.** `send_input` is called from an interactive CLI and MCP tools where blocking on someone else's pane for up to ~60s (like spawn-time injection can afford) is bad UX. A caller gets an immediate, precise error and can retry.
- **Deliberately NOT reused: the `runtime_ready`-based half of the readiness probe.** `runtime_ready` looks for a live `claude` PID via `ps`, which is `false` by construction for `FakeNoopTmuxDriver` (the documented no-tmux-installed fallback) and therefore for every hermetic test built on `DaemonState::with_root_isolated_managed`. Gating `send_input` on it broke three hermetic tests outright — real proof it's too blunt an instrument outside the narrow, bounded, just-spawned poll loop `inject_task_when_ready` uses it in. Those fixtures are updated to mark their seeded session `Active` (mirroring what the real spawn handler does before task injection runs), which is the correct fixture shape independent of this change.
- **`Submit::Enter`'s literal-then-Enter dispatch is unchanged** (issue #1461, still unit-tested by `inject_dispatch_enter_sends_literal_then_enter`) — this PR only adds a pre-dispatch gate.
- **Response shape unchanged** — `sent: true` on success now carries a strictly stronger guarantee (pane was NOT `Provisioning`/`Errored`, and for ClaudeCode showed no known modal, immediately beforehand) with no wire format change. The full delivery-ack layer is #3168's scope, not this PR's.
- **File-size cap compliance**: `manager.rs`'s `send_input` now delegates to `check_send_input_ready` in `task_inject.rs` instead of inlining the checks, keeping `manager.rs` under its 500-SLOC production cap. Three new `send_input`-gate tests live in a new sibling `send_input_gate_tests.rs` (mirrors the existing `restart_tests.rs` / `decommission_worktree_tests.rs` split pattern) to keep `tests.rs` under its 1500-SLOC test cap.

## Tests

- `manager_send_input_rejected_for_provisioning_and_errored` — proves a `Provisioning` and then `Errored` session refuses `send_input` and never calls the driver's send-line (the shell-execution risk). Fails against pre-fix code.
- `manager_send_input_rejected_when_pane_shows_blocking_modal` — proves an `Active` ClaudeCode session whose captured pane matches a known modal marker refuses the send and never dispatches. Fails against pre-fix code.
- `manager_send_input_skips_modal_probe_for_tcode` — proves a `Tcode`-runtime session is exempt from the modal probe even when the SAME marker is present (the healthy-path regression guard on the other runtime).
- `manager_send_input` (pre-existing) — proves the healthy `Active` ClaudeCode path still submits normally.
- `pane_readiness_ready_when_pid_up_and_no_modal` / `pane_readiness_not_ready_when_pid_absent` / `pane_readiness_blocking_modal_when_pid_up_but_modal_shown` — unit tests for the factored-out `PaneReadiness` probe used by the spawn-time poll loop.

## Related issues (complementary, not superseded)

- #3396 — stale/crossed tmux pane_id mappings breaking `session_send` delivery (a mapping-correctness bug; this PR is a readiness/liveness bug — right pane, not safe to type into yet).
- #3168 (BUS-7) — migrating `session_send` to durable bus delivery for an audit trail (delivery tracking, not a pre-send safety gate).

Closes #3591

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings`
- [x] `cargo test -p trusty-mpm` (full suite, not `--lib`)
- [x] `bash scripts/check_line_cap.sh`
- [x] `bash scripts/check_test_pointers.sh`
- [x] `bash scripts/check_sld.sh`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
