### PR TITLE
chore(release): bump trusty-common 0.24.1 + trusty-search 0.37.2 to ship the #3545 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11403,7 +11403,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11780,7 +11780,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ trusty-code = { path = "crates/trusty-code" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.3.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.24.0" }
+trusty-common = { path = "crates/trusty-common", version = "0.24.1" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [0.24.0] — 2026-07-21
+## [0.24.1] — 2026-07-21
+
+Patch release closing unpublished source drift under the already-published
+0.24.0 (issue #3366 defect class): two commits landed on `main` *after*
+0.24.0 was published to crates.io (from `831103dd`) without a version bump,
+so the live 0.24.0 tarball does not contain them. This release carries both.
 
 ### Added
 
@@ -18,13 +23,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   permanently (`should_give_up`: exhausted `max_restarts` or a wedge-restart
   storm) — never on a clean exit, an intentional cooperative `shutdown()`,
   or an ordinary respawn. Gives callers (trusty-search's swap-back watchdog)
-  a DEFINITIVE "this supervised process is unrecoverably dead" signal instead
-  of inferring it from `child_pid_slot == 0`, which is also `0` during an
-  ordinary intentional shutdown and therefore ambiguous on its own.
+  a DEFINITIVE "this supervised process is unrecoverably dead" signal
+  instead of inferring it from `child_pid_slot == 0`, which is also `0`
+  during an ordinary intentional shutdown and therefore ambiguous on its
+  own.
   - Test: `supervisor_terminated_signal_fires_after_exhausting_max_restarts`
     (a real, always-crashing mock child with `max_restarts: 1`),
     `supervisor_terminated_signal_stays_false_on_intentional_shutdown` (a
     real cooperative `shutdown()` must never set it).
+- **`monitor::search_client::resolve_search_url` regression coverage (issue
+  #3545 follow-up, trusty-search PR #3602 review).** No production behavior
+  change in this crate — `resolve_search_url` already discovered a daemon
+  registered via `write_daemon_addr("trusty-search", …)`. The trusty-search
+  PR #3602 review found that trusty-search's CLI daemon-discovery fix had
+  stopped calling `write_daemon_addr` at all, silently starving this
+  resolver (and its trusty-search/trusty-installer consumers) of any
+  writer. trusty-search restored a writer for the default
+  (`TRUSTY_DATA_DIR`-unset) instance; this crate adds
+  `resolve_search_url_discovers_non_default_registered_address`, a
+  regression test pinning that `resolve_search_url` correctly picks up a
+  non-default-port address written that way, so a future regression here
+  fails loudly instead of silently breaking `trusty-search monitor
+  status`/`monitor indexes`/`monitor tui`'s `[r]` reindex hotkey.
+
+## [0.24.0] — 2026-07-21
+
+### Added
+
 - **`ExecutionProvider::Mps` + `resolve_expected_python_provider` (epic #3524
   slice 6, PR 2/5, refs #3530, #3493 P1)** — a new `Mps` variant on
   `embedder::ExecutionProvider` for the opt-in Python/MPS embedding sidecar

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.24.0"
+version = "0.24.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,16 +5,15 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [0.37.1] — 2026-07-21
+## [0.37.2] — 2026-07-21
 
-### Fixed
-
-- **Regenerated the `ui-dist` bundle** (#3590, `b76e08ea`): the published
-  0.37.0 tarball shipped a stale prebuilt dashboard bundle that predated the
-  Foundry v2 dark-mode migration, so the installed dashboard was missing the
-  dark-mode feature entirely. The bundle under `ui-dist/` is rebuilt from the
-  current `ui/` source so a fresh install/upgrade gets the dark-themed
-  dashboard. No Rust source changes.
+Patch release closing unpublished source drift under the already-published
+0.37.1 (issue #3366 defect class). 0.37.1 was published to crates.io (from
+`831103dd`) containing only the `ui-dist` regeneration below; every other
+entry in this section — the #3545 CLI daemon-discovery fix and the epic
+#3524 slice 5/6 embedder work — landed on `main` in later commits that
+never bumped the version, so none of it is in the live 0.37.1 tarball. This
+release carries all of it.
 
 ### Fixed
 
@@ -240,6 +239,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   over the build-features prediction when one is available — fixes the
   sidecar reporting `CoreML(ANE)` while torch actually selected `mps` (issue
   #3493 P1).
+
+## [0.37.1] — 2026-07-21
+
+### Fixed
+
+- **Regenerated the `ui-dist` bundle** (#3590, `b76e08ea`): the published
+  0.37.0 tarball shipped a stale prebuilt dashboard bundle that predated the
+  Foundry v2 dark-mode migration, so the installed dashboard was missing the
+  dark-mode feature entirely. The bundle under `ui-dist/` is rebuilt from the
+  current `ui/` source so a fresh install/upgrade gets the dark-themed
+  dashboard. No Rust source changes.
 
 ## [0.37.0] — 2026-07-20
 

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.37.1"
+version = "0.37.2"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -54,7 +54,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.24.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
+trusty-common = { version = "0.24.1", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
 
 # ── Bundled sidecars ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue


### PR DESCRIPTION
## Summary

`trusty-common 0.24.0` and `trusty-search 0.37.1` are already LIVE on
crates.io, published from `831103dd`. Two later merges to `main` changed
both crates' source without a version bump — an unpublished-drift defect
(issue #3366 class), confirmed by `scripts/check-version-parity.sh`
(`trusty-publish-guard`, added in #3568):

- `d21ba6a0` (#3602, closes #3545): daemon-discovery fix, touching
  `crates/trusty-common/src/monitor/search_client.rs` (test-only, a new
  regression test) and all of `crates/trusty-search/src/**` for the actual
  `TRUSTY_DATA_DIR` CLI-discovery fix.
- `5d4d3b55` + `fb3c2c86` (epic #3524 slice 6 PR 4/5 + code-critic
  follow-up): swap-back-to-ort watchdog, touching
  `crates/trusty-common/src/embedder_client/{supervisor.rs,supervisor_tests.rs}`
  and more of `crates/trusty-search/src/**`.

This bumps both crates so their version numbers honestly reflect that
source has changed since the last publish, and updates the CHANGELOGs to
correct the record: several entries were previously written under the
`## [0.37.1]` / `## [0.24.0]` headings by their respective PRs even though
those versions were already published without them (the actual #3366 root
cause — appending to a stale "current version" heading instead of bumping).
Those entries are now relocated to the new `0.24.1`/`0.37.2` sections; the
true (already-published) `0.37.1` section is left with only the `ui-dist`
regeneration entry that was genuinely in that tarball.

- `crates/trusty-common`: `0.24.0` → `0.24.1` (patch)
- `crates/trusty-search`: `0.37.1` → `0.37.2` (patch)

## Dependents — no edits needed beyond the two called out

`version = "0.24.0"` in a Cargo dependency table is a caret requirement
(`^0.24.0`), which `0.24.1` already satisfies. Besides the workspace root
`Cargo.toml` (~line 98) and `crates/trusty-search/Cargo.toml` (~line 57),
two other manifests also pin `trusty-common` by explicit
`version = "0.24.0"` — `crates/trusty-memory/Cargo.toml` (two spots) and
`crates/trusty-gworkspace/Cargo.toml` — but since caret semantics already
resolve them to `0.24.1`, they need no edit. Verified: no crate in the
workspace declares an exact/`=` pin on `trusty-common` (the only `=` pin in
the workspace is an unrelated `ort` crate pin at
`crates/trusty-common/Cargo.toml:222,231`). Kept the diff minimal per scope
discipline — no workspace-wide sweep.

## Other unpublished drift (found, NOT bumped here)

Ran `scripts/check-version-parity.sh` (the #3568 tool, wired into
`.github/workflows/version-parity.yml`) against `origin/main` before this
branch's changes: **only `trusty-common` and `trusty-search` were
drifted** — 0 other crates. After this bump, the same check reports
`0 drifted, 0 unverifiable` across all 17 publishable crates. Nothing else
needs bumping to make this PR's two crates shippable.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — clean (exit 0)
- [x] `cargo test -p trusty-search -p trusty-common` — 2 tests flaked under
      default parallel execution due to pre-existing env-var
      test-isolation gaps unrelated to this change
      (`doctor_data_dir_returns_non_empty_path` reads real `TRUSTY_DATA_DIR`;
      `patch_kg_off_is_instantaneous_soft_disable` is a shared-resource
      timing flake); confirmed clean with `--test-threads=1`:
      `1221 passed; 0 failed` (trusty-search) and `744 passed; 0 failed`
      (trusty-common), 0 failures anywhere across both crates.
- [x] `cargo publish --dry-run -p trusty-common` — **PASSES** against the
      live registry (the real proof the bump is coherent).
- [x] `cargo publish --dry-run -p trusty-search` — resolves and packages
      correctly, then **fails as expected**:
      `failed to select a version for the requirement `trusty-common = "^0.24.1"`` —
      because `trusty-common 0.24.1` is not actually published yet. This is
      the expected/correct outcome per the publish ordering
      (trusty-common must publish first), not a defect in this PR.

Refs #3545

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
