### PR TITLE
feat(embedder): default to graceful-Python embedder on Apple Silicon (epic #3524 slice 6, default flip)

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Changed
+
+- **Graceful-Python embedder is now the DEFAULT on Apple Silicon (epic #3524
+  slice 6, PR 5/5 — the default flip).** `trusty-search start` with
+  `TRUSTY_EMBEDDER` unset/`auto` on aarch64 macOS now serves on the ort
+  stdio sidecar immediately while bootstrapping the python/MPS sidecar in
+  the background and hot-swapping to it once proven — previously this
+  required opting in via the now-retired `TRUSTY_PY_DEFAULT` ship-gate.
+  Validated by the epic #3524 slice 2-4 spike (numerically identical
+  results, ~2.4x faster end-to-end) and soaked per PR #3610 before this
+  flip. Every other platform (Linux, Intel mac, CUDA) is completely
+  unaffected — the flip is scoped to `cfg!(all(target_arch = "aarch64",
+  target_os = "macos"))` only. `TRUSTY_EMBEDDER=stdio` remains, and is now
+  the sole, permanent per-invocation escape hatch back to the unchanged ort
+  path on Apple Silicon.
+
 ## [0.37.2] — 2026-07-21
 
 Patch release closing unpublished source drift under the already-published

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -644,29 +644,33 @@ environment variable (issue #110 Phase 2):
 
 | `TRUSTY_EMBEDDER` value | Behaviour |
 |-------------------------|-----------|
-| unset / `auto`          | **Default, platform-aware (epic #3524 slice 6, PR 3/5).** Resolves via `resolve_default_embedder_mode()`: on Apple Silicon with `TRUSTY_PY_DEFAULT` enabled, serves on the ort stdio sidecar immediately while bootstrapping the python/MPS sidecar in the background and hot-swapping when ready (see "Graceful Apple-Silicon default" below); with `TRUSTY_EMBEDDER_PYTHON_EAGER` enabled, takes the eager blocking `python` path below (any platform); otherwise (the shipped default everywhere today, since `TRUSTY_PY_DEFAULT` defaults OFF) arms a `LazyEmbedderHandle` at boot (issue #315 — deferred spawn): `trusty-embedderd --stdio` is spawned on the **first embed request** (reindex, hybrid search, `context_inference`), not at daemon startup. |
-| `stdio`                 | **Permanent opt-out.** Always the plain ort stdio sidecar (identical to the unset/`auto` fallback above), even after `TRUSTY_PY_DEFAULT` ships on for real — never routed through the platform-aware resolution. `trusty-embedderd` is a **required runtime dependency** for this and the default ort path — binary discovery runs at boot and fails fast with an install hint if the binary is missing. **`cargo install trusty-search` installs `trusty-embedderd` automatically.** |
-| `python`                | **Opt-in Python/MPS sidecar (epic #3524).** Eagerly bootstraps a pinned `uv`-managed venv (torch + sentence-transformers) at `start`, then lazy-spawns `trusty-embedderd-py` speaking the exact same stdio JSON-RPC 2.0 protocol as the Rust sidecar. On Apple Silicon this embeds ~2.4x faster than the ort path with numerically identical (>=0.999 cosine) results. On ANY bootstrap or launcher-discovery failure, falls back to the Rust ort stdio sidecar so search never hard-fails — see "Python/MPS sidecar tuning" below. **Default-off**; requires `uv` installed (or `TRUSTY_UV_BIN` set) and ~3 GB free disk on first use. |
+| unset / `auto`          | **Default, platform-aware (epic #3524 slice 6, PR 5/5 — the default flip).** Resolves via `resolve_default_embedder_mode()`: **on Apple Silicon (aarch64 macOS), always** serves on the ort stdio sidecar immediately while bootstrapping the python/MPS sidecar in the background and hot-swapping when ready (see "Graceful Apple-Silicon default" below) — no ship-gate env var required; with `TRUSTY_EMBEDDER_PYTHON_EAGER` enabled on a non-Apple-Silicon host, takes the eager blocking `python` path below instead; otherwise (every other platform) arms a `LazyEmbedderHandle` at boot (issue #315 — deferred spawn): `trusty-embedderd --stdio` is spawned on the **first embed request** (reindex, hybrid search, `context_inference`), not at daemon startup. |
+| `stdio`                 | **Permanent user override back to ort — the escape hatch.** Always the plain ort stdio sidecar (identical to the unset/`auto` fallback on non-Apple-Silicon hosts), even on Apple Silicon where it is now the ONLY way to opt back out of the graceful-Python default — never routed through the platform-aware resolution (see `is_forced_ort_override`). `trusty-embedderd` is a **required runtime dependency** for this and the default ort path — binary discovery runs at boot and fails fast with an install hint if the binary is missing. **`cargo install trusty-search` installs `trusty-embedderd` automatically.** |
+| `python`                | **Explicit Python/MPS sidecar, eager/blocking, any platform (epic #3524).** Eagerly bootstraps a pinned `uv`-managed venv (torch + sentence-transformers) at `start`, then lazy-spawns `trusty-embedderd-py` speaking the exact same stdio JSON-RPC 2.0 protocol as the Rust sidecar. On Apple Silicon this embeds ~2.4x faster than the ort path with numerically identical (>=0.999 cosine) results — though on Apple Silicon the unset/`auto` default already reaches the same sidecar non-blocking, so this explicit value is mainly useful for testing the sidecar off Apple Silicon or forcing the eager/blocking startup path. On ANY bootstrap or launcher-discovery failure, falls back to the Rust ort stdio sidecar so search never hard-fails — see "Python/MPS sidecar tuning" below. Requires `uv` installed (or `TRUSTY_UV_BIN` set) and ~3 GB free disk on first use. |
 | `in-process` / `local`  | Explicit escape hatch — in-process ONNX embedding. Use for tests, debugging, or environments where the sidecar cannot be installed. **Never activated silently**: you must set this variable explicitly to use the in-process path. |
 | `http://…`              | HTTP remote — `POST /embed` to a manually-managed `trusty-embedderd` HTTP listener. |
 | `unix:/path/to/sock`    | UDS remote — JSON-RPC 2.0 to a manually-managed `trusty-embedderd --socket` listener. |
 | `candle`                | Candle Metal backend (requires `--features candle`). |
 
-### Graceful Apple-Silicon default (epic #3524 slice 6, PR 3/5)
+### Graceful Apple-Silicon default (epic #3524 slice 6, PR 5/5 — the default flip)
 
-On Apple Silicon, once ship-gated on, `trusty-search start` serves on the ort
+On Apple Silicon (aarch64 macOS), `trusty-search start` serves on the ort
 stdio sidecar immediately (zero HTTP-listener delay) while a detached
 background task bootstraps the python/MPS sidecar, proves it with one real
 readiness-probe embed call, and hot-swaps the running embedder over to it.
 On any bootstrap or probe failure the daemon stays permanently on ort for
 that daemon's lifetime and `/health`'s `embedder_bootstrap` reports
-`"failed"`. Ships **default OFF** in this PR — a later slice flips the
-default on after a soak period.
+`"failed"`. **This is now the default on Apple Silicon** — validated by the
+epic #3524 slice 2-4 spike (numerically identical results, ~2.4x faster) and
+soaked per PR #3610 before this flip. The prior ship-gate env var
+(`TRUSTY_PY_DEFAULT`) has been retired; `TRUSTY_EMBEDDER=stdio` is now the
+one documented, permanent way back to the unchanged ort behavior. Non-Apple-
+Silicon hosts are completely unaffected (unchanged ort default).
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `TRUSTY_PY_DEFAULT` | unset (off) | **Ship-gate.** Set to `1`/`true`/`yes`/`on` to enable the graceful background path on Apple Silicon for unset/`auto` `TRUSTY_EMBEDDER`. Unset/falsy leaves Apple-Silicon resolution completely unchanged (ort) — this is why the PR that introduces the mechanism ships with zero user-facing behavior change. Has no effect off Apple Silicon. |
-| `TRUSTY_EMBEDDER_PYTHON_EAGER` | unset (off) | Reaches the existing eager, blocking `python` arm (identical to explicit `TRUSTY_EMBEDDER=python`) via unset/`auto` instead of an explicit value. Not platform-gated. `TRUSTY_PY_DEFAULT` wins outright when both are set. |
+| `TRUSTY_EMBEDDER=stdio` | — | **User escape hatch.** Forces the unchanged ort stdio sidecar on any platform, including Apple Silicon — bypasses the platform-aware default resolution entirely (see `is_forced_ort_override`). |
+| `TRUSTY_EMBEDDER_PYTHON_EAGER` | unset (off) | Reaches the existing eager, blocking `python` arm (identical to explicit `TRUSTY_EMBEDDER=python`) via unset/`auto` instead of an explicit value. Not platform-gated, but only reachable off Apple Silicon — on Apple Silicon the graceful default wins outright (see `resolve_default_embedder_mode_for`'s precedence doc). |
 | `TRUSTY_PY_BOOTSTRAP_RETRIES` | `2` | Number of bootstrap→probe attempts the background orchestrator makes (linear backoff between attempts) before giving up and marking the bootstrap `Failed` while staying on ort. A malformed or `0` value falls back to the default. |
 
 ### Python/MPS sidecar tuning (`TRUSTY_EMBEDDER=python` path only)

--- a/crates/trusty-search/src/commands/start/daemon.rs
+++ b/crates/trusty-search/src/commands/start/daemon.rs
@@ -372,16 +372,17 @@ pub async fn handle_start(
                 // handle without downcasting the trait object.
                 install_state.install_switchable_embedder(Arc::clone(&switchable));
                 install_state.install_embedder(Arc::clone(&embedder)).await;
-                // Epic #3524 slice 6 (PR 3/5): the graceful Apple-Silicon
-                // default arm serves on ort above and needs the python/MPS
-                // bootstrap to run in the background — spawn it now, right
-                // after both the switchable handle and the embedder slot are
-                // visible, so the orchestrator's eventual `swap_to` /
-                // `install_embedderd_pid_slot` calls race no in-progress
-                // install. Detached: never blocks the HTTP listener or the
-                // rest of this init task. No-op (never spawned) unless
-                // `TRUSTY_PY_DEFAULT` is enabled — this PR ships with the
-                // default OFF, so this branch does not run for real users yet.
+                // Epic #3524 slice 6 (PR 5/5 — the default flip): the
+                // graceful Apple-Silicon default arm serves on ort above and
+                // needs the python/MPS bootstrap to run in the background —
+                // spawn it now, right after both the switchable handle and
+                // the embedder slot are visible, so the orchestrator's
+                // eventual `swap_to` / `install_embedderd_pid_slot` calls
+                // race no in-progress install. Detached: never blocks the
+                // HTTP listener or the rest of this init task. No-op (never
+                // spawned) unless the platform is Apple Silicon (aarch64
+                // macOS) and the user did not force `TRUSTY_EMBEDDER=stdio`
+                // — see `resolve_default_embedder_mode_for`.
                 if needs_graceful_bootstrap {
                     tokio::spawn(run_graceful_python_bootstrap(
                         switchable,

--- a/crates/trusty-search/src/commands/start/embedder.rs
+++ b/crates/trusty-search/src/commands/start/embedder.rs
@@ -77,34 +77,38 @@ pub(super) fn backend_respects_quantized_env(kind: BackendKind) -> bool {
 }
 
 /// Which arm `build_embedder_raw` should take for `TRUSTY_EMBEDDER` unset /
-/// `auto` (epic #3524 slice 6, PR 3/5).
+/// `auto` (epic #3524 slice 6, PR 5/5 — the default flip).
 ///
-/// Why: the unset/`auto` resolution needs to become platform-aware (Apple
-/// Silicon defaults to the graceful hot-swap path once ship-gated) without
-/// disturbing the explicit-value arms (`stdio`, `python`, `in-process`, …),
-/// which are unaffected by this enum and keep matching directly on the raw
-/// env string. Splitting resolution into its own pure function
-/// ([`resolve_default_embedder_mode_for`]) makes the platform/env precedence
-/// unit-testable without depending on the actual build target or process
-/// environment.
+/// Why: the unset/`auto` resolution is platform-aware (Apple Silicon defaults
+/// to the graceful hot-swap path) without disturbing the explicit-value arms
+/// (`stdio`, `python`, `in-process`, …), which are unaffected by this enum
+/// and keep matching directly on the raw env string. Splitting resolution
+/// into its own pure function ([`resolve_default_embedder_mode_for`]) makes
+/// the platform/env precedence unit-testable without depending on the actual
+/// build target or process environment.
 /// What: one variant per arm `build_embedder_raw`'s `"" | "auto"` match takes.
 /// Test: `resolve_default_embedder_mode_for_*` in `start/tests.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum DefaultEmbedderMode {
     /// Build the ort stdio sidecar synchronously — unchanged pre-#3524
-    /// behavior. Selected on every non-Apple-Silicon host, and on Apple
-    /// Silicon whenever the graceful default is not ship-gated on
-    /// (`TRUSTY_PY_DEFAULT` unset/falsy).
+    /// behavior. Selected on every non-Apple-Silicon host. On Apple Silicon
+    /// this is reachable only via the explicit `TRUSTY_EMBEDDER=stdio`
+    /// escape hatch, which bypasses this resolution entirely (see
+    /// [`is_forced_ort_override`]).
     Ort,
-    /// Apple Silicon + `TRUSTY_PY_DEFAULT` enabled: serve on ort immediately,
-    /// bootstrap the python/MPS sidecar in the background, then hot-swap
-    /// (this PR's new arm). **Default OFF** — see `TRUSTY_PY_DEFAULT`'s doc.
+    /// Apple Silicon: serve on ort immediately, bootstrap the python/MPS
+    /// sidecar in the background, then hot-swap. **The default on Apple
+    /// Silicon (aarch64 macOS) as of epic #3524 slice 6 PR 5/5** — no
+    /// ship-gate env var required. `TRUSTY_EMBEDDER=stdio` still forces the
+    /// unchanged ort path.
     GracefulPython,
     /// `TRUSTY_EMBEDDER_PYTHON_EAGER` truthy: the existing eager, blocking
     /// `python` arm (identical to explicit `TRUSTY_EMBEDDER=python`) reached
     /// via unset/`auto` instead of an explicit value. Not gated to Apple
     /// Silicon — mirrors the explicit `python` arm, which has never been
-    /// platform-gated (useful for testing the sidecar on any host).
+    /// platform-gated (useful for testing the sidecar on any host). Only
+    /// reachable off Apple Silicon: on Apple Silicon `GracefulPython` wins
+    /// outright (see [`resolve_default_embedder_mode_for`]'s precedence doc).
     EagerPython,
 }
 
@@ -112,21 +116,22 @@ pub(super) enum DefaultEmbedderMode {
 /// testable without depending on `cfg!(target_arch/target_os)` or real
 /// process env vars.
 ///
-/// Precedence: Apple-Silicon + the ship-gate flag enabled wins outright
-/// (→ [`DefaultEmbedderMode::GracefulPython`]); otherwise an explicit
-/// `TRUSTY_EMBEDDER_PYTHON_EAGER` opt-in wins (→
-/// [`DefaultEmbedderMode::EagerPython`], any platform); otherwise the
-/// unchanged ort default (→ [`DefaultEmbedderMode::Ort`]).
+/// Precedence: Apple-Silicon wins outright (→
+/// [`DefaultEmbedderMode::GracefulPython`], the epic #3524 slice 6 PR 5/5
+/// default flip); otherwise an explicit `TRUSTY_EMBEDDER_PYTHON_EAGER`
+/// opt-in wins (→ [`DefaultEmbedderMode::EagerPython`], any platform);
+/// otherwise the unchanged ort default (→ [`DefaultEmbedderMode::Ort`]).
 ///
-/// Note: `TRUSTY_EMBEDDER=stdio` (the permanent opt-out) never reaches this
-/// function at all — `build_embedder_raw`'s match dispatches it straight to
-/// `build_ort_stdio_sidecar()` before this resolution is consulted.
+/// Note: `TRUSTY_EMBEDDER=stdio` (the permanent user escape hatch back to
+/// ort, including on Apple Silicon) never reaches this function at all —
+/// `build_embedder_raw`'s match dispatches it straight to
+/// `build_ort_stdio_sidecar()` before this resolution is consulted; see
+/// [`is_forced_ort_override`].
 pub(super) fn resolve_default_embedder_mode_for(
     is_apple_silicon: bool,
-    py_default_enabled: bool,
     eager_python: bool,
 ) -> DefaultEmbedderMode {
-    if is_apple_silicon && py_default_enabled {
+    if is_apple_silicon {
         return DefaultEmbedderMode::GracefulPython;
     }
     if eager_python {
@@ -136,27 +141,42 @@ pub(super) fn resolve_default_embedder_mode_for(
 }
 
 /// Resolve the `TRUSTY_EMBEDDER` unset/`auto` default, reading the real
-/// build target and process environment (epic #3524 slice 6, PR 3/5).
+/// build target and process environment (epic #3524 slice 6, PR 5/5).
 ///
 /// Why: on Apple Silicon a torch/MPS sidecar embeds ~2.4x faster than ort
-/// with numerically identical results (see the epic #3524 slice 2-4 spike);
-/// once soaked, this should become the transparent default with zero
-/// required user configuration. This PR wires the mechanism behind
-/// `TRUSTY_PY_DEFAULT` (default OFF) so it can ship and be verified without
-/// changing any real user's behavior — a later slice (PR-5) flips the
-/// default on after the soak.
+/// with numerically identical results (see the epic #3524 slice 2-4 spike,
+/// soaked per PR #3610). This is now the transparent default with zero
+/// required user configuration — the prior ship-gate (`TRUSTY_PY_DEFAULT`)
+/// has been retired now that the soak is complete; `TRUSTY_EMBEDDER=stdio`
+/// remains the permanent per-invocation override back to ort.
 /// What: `cfg!(all(target_arch = "aarch64", target_os = "macos"))` for the
-/// platform check, `TRUSTY_PY_DEFAULT` for the ship-gate, and
-/// `TRUSTY_EMBEDDER_PYTHON_EAGER` for the eager escape hatch — delegates the
-/// actual precedence to [`resolve_default_embedder_mode_for`].
+/// platform check and `TRUSTY_EMBEDDER_PYTHON_EAGER` for the eager escape
+/// hatch — delegates the actual precedence to
+/// [`resolve_default_embedder_mode_for`].
 /// Test: `resolve_default_embedder_mode_for_*` in `start/tests.rs` cover the
 /// pure precedence; this wrapper has no independent branches to test.
 pub(super) fn resolve_default_embedder_mode() -> DefaultEmbedderMode {
     resolve_default_embedder_mode_for(
         cfg!(all(target_arch = "aarch64", target_os = "macos")),
-        truthy_env("TRUSTY_PY_DEFAULT"),
         truthy_env("TRUSTY_EMBEDDER_PYTHON_EAGER"),
     )
+}
+
+/// Whether `TRUSTY_EMBEDDER`'s raw value is the permanent force-ort escape
+/// hatch that bypasses [`resolve_default_embedder_mode`] entirely (epic
+/// #3524 slice 6, PR 5/5 — the default flip).
+///
+/// Why: once Apple Silicon defaults to the graceful-Python path, operators
+/// need a documented, always-available way back to the unchanged ort
+/// behavior (e.g. to isolate a regression, or because the sidecar is
+/// unavailable in a given environment). `build_embedder_raw` already
+/// special-cases `"stdio"` ahead of the `"" | "auto"` resolution arm; this
+/// predicate names that behavior so it is unit-testable independent of the
+/// rest of the (async, I/O-performing) match.
+/// What: exact match on `"stdio"`.
+/// Test: `is_forced_ort_override_*` in `start/tests.rs`.
+pub(super) fn is_forced_ort_override(raw_env: &str) -> bool {
+    raw_env == "stdio"
 }
 
 /// Shared truthy-env-var parser: `1`/`true`/`yes`/`on` (case-insensitive,
@@ -200,13 +220,13 @@ pub(super) fn truthy_env(name: &str) -> bool {
 /// `uds_adapter_reports_resolved_provider`) is unaffected; `switchable.rs`
 /// unit tests cover the wrapper itself.
 ///
-/// The 4th return element (epic #3524 slice 6, PR 3/5) is `true` only when
-/// `build_embedder_raw` took the new [`DefaultEmbedderMode::GracefulPython`]
+/// The 4th return element (epic #3524 slice 6) is `true` only when
+/// `build_embedder_raw` took the [`DefaultEmbedderMode::GracefulPython`]
 /// arm — the signal `commands::start::daemon` uses to decide whether to
 /// spawn the background bootstrap→hot-swap orchestrator right after
-/// installing the returned `switchable` handle. Every pre-existing arm
-/// returns `false`, so this PR ships as a no-op for every caller that
-/// doesn't opt in via `TRUSTY_PY_DEFAULT`.
+/// installing the returned `switchable` handle. Every other arm returns
+/// `false`. As of PR 5/5 (the default flip) this is `true` for every Apple
+/// Silicon host that does not set `TRUSTY_EMBEDDER=stdio`.
 pub(super) async fn build_embedder() -> Result<(
     std::sync::Arc<dyn crate::core::Embedder>,
     Option<Arc<AtomicU32>>,
@@ -302,15 +322,19 @@ async fn build_embedder_raw() -> Result<(
 
     match trusty_embedder_env.as_str() {
         // ── Explicit force-ort opt-out — the ONLY way to permanently pin
-        // the ort sidecar on Apple Silicon once TRUSTY_PY_DEFAULT ships on
-        // (epic #3524 slice 6, PR 3/5). Never routed through
-        // `resolve_default_embedder_mode` below.
-        "stdio" => build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort, false)),
+        // the ort sidecar on Apple Silicon now that the graceful-Python path
+        // is the default there (epic #3524 slice 6, PR 5/5). Never routed
+        // through `resolve_default_embedder_mode` below — see
+        // `is_forced_ort_override`.
+        s if is_forced_ort_override(s) => {
+            build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort, false))
+        }
 
         // ── unset / `auto` — platform-aware resolution (epic #3524 slice 6,
-        // PR 3/5). `resolve_default_embedder_mode` decides between the
-        // unchanged ort default, the new graceful-python background path, and
-        // the existing eager-blocking python path (reachable here only via
+        // PR 5/5). `resolve_default_embedder_mode` decides between the
+        // graceful-python background path (the Apple-Silicon default), the
+        // unchanged ort default (every other platform), and the existing
+        // eager-blocking python path (reachable here only via
         // `TRUSTY_EMBEDDER_PYTHON_EAGER`, mirroring explicit
         // `TRUSTY_EMBEDDER=python` below).
         "" | "auto" => match resolve_default_embedder_mode() {
@@ -321,31 +345,37 @@ async fn build_embedder_raw() -> Result<(
                 .await
                 .map(|(e, p, k)| (e, p, k, false)),
             DefaultEmbedderMode::GracefulPython => {
-                // Epic #3524 slice 6 (PR 3/5): serve on ort IMMEDIATELY — the
-                // exact same synchronous construction as the unchanged default
-                // path — while the caller (`build_embedder`) marks the
-                // resulting `ActiveBackend::bootstrap` `Bootstrapping` and
+                // Epic #3524 slice 6 (PR 5/5 — the default flip): serve on
+                // ort IMMEDIATELY — the exact same synchronous construction
+                // as the unchanged ort path — while the caller
+                // (`build_embedder`) marks the resulting
+                // `ActiveBackend::bootstrap` `Bootstrapping` and
                 // `commands::start::daemon` spawns the background
                 // bootstrap→hot-swap orchestrator right after installing it.
                 // Nothing here blocks the HTTP listener or startup.
                 tracing::info!(
-                    "embedder mode: graceful Apple-Silicon default (TRUSTY_PY_DEFAULT) — \
-                     serving on the ort stdio sidecar immediately while the python/MPS \
-                     sidecar bootstraps in the background; hot-swaps in when ready"
+                    "embedder mode: graceful Apple-Silicon default — serving on the ort \
+                     stdio sidecar immediately while the python/MPS sidecar bootstraps in \
+                     the background; hot-swaps in when ready (set TRUSTY_EMBEDDER=stdio to \
+                     force ort)"
                 );
                 build_ort_stdio_sidecar().map(|(e, p)| (e, p, BackendKind::Ort, true))
             }
         },
 
-        // ── Opt-in Python/MPS sidecar (epic #3524, slices 2-4) — DEFAULT-OFF ──
+        // ── Explicit `TRUSTY_EMBEDDER=python` (epic #3524, slices 2-4) ──────
         //
         // Why: on Apple Silicon a torch/MPS sentence-transformers sidecar
         // embeds ~2.4x faster than the Rust ort path with numerically
         // identical results (the spike measured 561 emb/s end-to-end through
-        // the real supervisor). Selection is strictly opt-in; default-on is a
-        // LATER slice. Reuses `LazyEmbedderHandle` / `EmbedderSupervisor` with
-        // ZERO changes to the supervisor/stdio/protocol wire code — the
-        // launcher speaks the exact same JSON-RPC 2.0 stdio protocol.
+        // the real supervisor). This explicit value takes the eager,
+        // blocking path on ANY platform (unlike the unset/`auto` default,
+        // which is Apple-Silicon-gated and non-blocking — see
+        // `DefaultEmbedderMode::GracefulPython`); useful for testing the
+        // sidecar off Apple Silicon. Reuses `LazyEmbedderHandle` /
+        // `EmbedderSupervisor` with ZERO changes to the supervisor/stdio/
+        // protocol wire code — the launcher speaks the exact same JSON-RPC
+        // 2.0 stdio protocol.
         //
         // Robustness: eager-bootstrap the venv here (at `start`). On ANY
         // bootstrap or launcher-discovery failure, log a loud actionable

--- a/crates/trusty-search/src/commands/start/embedder.rs
+++ b/crates/trusty-search/src/commands/start/embedder.rs
@@ -421,9 +421,10 @@ async fn build_embedder_raw() -> Result<(
 
         other => anyhow::bail!(
             "invalid TRUSTY_EMBEDDER value: {other:?}. \
-             Expected: unset (default stdio sidecar), 'auto', 'stdio', 'python' \
-             (opt-in Python/MPS sidecar), 'in-process', \
-             'http://...', or 'unix:/path/to/socket'"
+             Expected: unset or 'auto' (default: graceful hot-swap to the Python/MPS \
+             sidecar on Apple Silicon, plain ort sidecar elsewhere), 'stdio' (forces \
+             the plain ort sidecar permanently), 'python' (opt-in Python/MPS sidecar), \
+             'in-process', 'http://...', or 'unix:/path/to/socket'"
         ),
     }
 }

--- a/crates/trusty-search/src/commands/start/tests.rs
+++ b/crates/trusty-search/src/commands/start/tests.rs
@@ -944,75 +944,98 @@ impl Drop for EnvGuard {
     }
 }
 
-// ── Graceful Apple-Silicon default resolution (epic #3524 slice 6, PR 3/5) ──
+// ── Graceful Apple-Silicon default resolution (epic #3524 slice 6, PR 5/5 —
+//    the default flip) ────────────────────────────────────────────────────
 
-use super::embedder::{resolve_default_embedder_mode_for, truthy_env, DefaultEmbedderMode};
+use super::embedder::{
+    is_forced_ort_override, resolve_default_embedder_mode_for, truthy_env, DefaultEmbedderMode,
+};
 
-/// Apple Silicon + the ship-gate flag enabled must resolve to the new
-/// background graceful path — the whole point of this PR.
+/// Apple Silicon with no user override must resolve to the graceful
+/// background python path — this is now the default (the whole point of
+/// this PR).
 #[test]
-fn resolve_default_embedder_mode_for_apple_silicon_with_flag_is_graceful() {
+fn resolve_default_embedder_mode_for_apple_silicon_no_override_is_graceful() {
     assert_eq!(
-        resolve_default_embedder_mode_for(true, true, false),
+        resolve_default_embedder_mode_for(true, false),
         DefaultEmbedderMode::GracefulPython
     );
 }
 
-/// Apple Silicon with the ship-gate flag OFF (this PR's shipped default —
-/// `TRUSTY_PY_DEFAULT` unset) must resolve to the unchanged ort path, proving
-/// this PR ships as a no-op for real users.
+/// Apple Silicon + `TRUSTY_EMBEDDER_PYTHON_EAGER` must still resolve to the
+/// graceful background path, NOT the eager blocking arm — Apple Silicon wins
+/// outright, since blocking startup for the eager path is strictly worse
+/// than the non-blocking graceful path already reaching the same sidecar.
 #[test]
-fn resolve_default_embedder_mode_for_apple_silicon_opted_out_is_ort() {
+fn resolve_default_embedder_mode_for_apple_silicon_eager_env_stays_graceful() {
     assert_eq!(
-        resolve_default_embedder_mode_for(true, false, false),
+        resolve_default_embedder_mode_for(true, true),
+        DefaultEmbedderMode::GracefulPython
+    );
+}
+
+/// Non-Apple-Silicon (Linux, Intel mac, etc.) with no override must resolve
+/// to the unchanged ort path — the flip is scoped to Apple Silicon only.
+#[test]
+fn resolve_default_embedder_mode_for_non_apple_silicon_is_ort() {
+    assert_eq!(
+        resolve_default_embedder_mode_for(false, false),
         DefaultEmbedderMode::Ort
     );
 }
 
-/// Apple Silicon + `TRUSTY_EMBEDDER_PYTHON_EAGER` (and the ship-gate flag
-/// OFF) must resolve to the existing eager blocking python arm, not the new
-/// background path.
+/// Non-Apple-Silicon (Linux/CUDA) + `TRUSTY_EMBEDDER_PYTHON_EAGER` must
+/// resolve to the eager blocking python arm — the eager escape hatch is not
+/// platform-gated, unlike the Apple-Silicon graceful default.
 #[test]
-fn resolve_default_embedder_mode_for_apple_silicon_eager_env_is_eager() {
+fn resolve_default_embedder_mode_for_non_apple_silicon_eager_env_is_eager() {
     assert_eq!(
-        resolve_default_embedder_mode_for(true, false, true),
+        resolve_default_embedder_mode_for(false, true),
         DefaultEmbedderMode::EagerPython
     );
 }
 
-/// The ship-gate flag wins outright over the eager env when both are set —
-/// there is no reason to run the slow blocking path when the background
-/// graceful path is available.
+/// `TRUSTY_EMBEDDER=stdio` is the permanent user escape hatch back to ort,
+/// including on Apple Silicon now that the graceful-Python path is the
+/// default there — `build_embedder_raw` dispatches it before
+/// `resolve_default_embedder_mode` is ever consulted (see
+/// `is_forced_ort_override`'s doc).
 #[test]
-fn resolve_default_embedder_mode_for_apple_silicon_flag_wins_over_eager_env() {
+fn is_forced_ort_override_stdio_true() {
+    assert!(is_forced_ort_override("stdio"));
+}
+
+/// Every other raw `TRUSTY_EMBEDDER` value (including unset/`auto`, which
+/// `build_embedder_raw` matches separately) must NOT be treated as the
+/// force-ort override.
+#[test]
+fn is_forced_ort_override_other_values_false() {
+    for value in ["", "auto", "python", "in-process", "local", "candle"] {
+        assert!(
+            !is_forced_ort_override(value),
+            "{value:?} must not be treated as the force-ort override"
+        );
+    }
+}
+
+/// Real-environment sanity check (epic #3524 slice 6, PR 5/5): on an actual
+/// Apple Silicon macOS host, with `TRUSTY_EMBEDDER_PYTHON_EAGER` unset, the
+/// real `resolve_default_embedder_mode()` wrapper — not just the pure
+/// [`resolve_default_embedder_mode_for`] — must resolve to
+/// `GracefulPython`. This exercises the actual `cfg!(target_arch =
+/// "aarch64", target_os = "macos")` platform check the wrapper reads,
+/// closing the gap the pure-function tests above intentionally leave open
+/// (they take `is_apple_silicon` as a param precisely so they don't depend
+/// on the build host). Only compiled/run on aarch64 macOS; CI's Linux
+/// runners never build this test.
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[test]
+#[serial]
+fn resolve_default_embedder_mode_on_real_apple_silicon_host_is_graceful() {
+    let _g = EnvGuard::remove("TRUSTY_EMBEDDER_PYTHON_EAGER");
     assert_eq!(
-        resolve_default_embedder_mode_for(true, true, true),
+        super::embedder::resolve_default_embedder_mode(),
         DefaultEmbedderMode::GracefulPython
-    );
-}
-
-/// Non-Apple-Silicon (Linux, Intel mac, etc.) with NEITHER env var set must
-/// resolve to the unchanged ort path.
-#[test]
-fn resolve_default_embedder_mode_for_non_apple_silicon_is_ort() {
-    assert_eq!(
-        resolve_default_embedder_mode_for(false, false, false),
-        DefaultEmbedderMode::Ort
-    );
-}
-
-/// Non-Apple-Silicon (Linux/CUDA) resolution MUST return the ort path even
-/// when the ship-gate flag is enabled — `TRUSTY_PY_DEFAULT` only ever
-/// applies on Apple Silicon; a CUDA/Linux box never reaches the python
-/// bootstrap through this default-resolution path (`GracefulPython` is
-/// unreachable off Apple Silicon regardless of env), so `ensure_venv` /
-/// `uv` / torch are never invoked there.
-#[test]
-fn resolve_default_embedder_mode_for_non_apple_silicon_ignores_flag() {
-    assert_eq!(
-        resolve_default_embedder_mode_for(false, true, false),
-        DefaultEmbedderMode::Ort,
-        "GracefulPython must never be selected off Apple Silicon"
     );
 }
 


### PR DESCRIPTION
Refs #3524

## Summary

Makes the graceful-Python embedder (ort immediately, hot-swap to the Python/MPS sidecar once it proves itself in the background) the **DEFAULT** on Apple Silicon (aarch64 macOS) for `TRUSTY_EMBEDDER` unset/`auto`. Previously this required opting in via the `TRUSTY_PY_DEFAULT` ship-gate env var, which this PR retires.

- **Platform scoping**: the flip is gated purely on `cfg!(all(target_arch = "aarch64", target_os = "macos"))` — the same idiom `resolve_default_embedder_mode()` already used pre-flip. Every other platform (Linux, Intel mac, CUDA) keeps the unchanged ort default; `resolve_default_embedder_mode_for_non_apple_silicon_is_ort` proves it.
- **User override preserved**: `TRUSTY_EMBEDDER=stdio` remains the permanent, highest-priority per-invocation escape hatch back to ort, on every platform including Apple Silicon — `build_embedder_raw`'s match dispatches it (now via the extracted `is_forced_ort_override` predicate) before `resolve_default_embedder_mode` is ever consulted, so it is unaffected by the flip.
- **Scope**: diff is limited to the default-selection logic (`commands/start/embedder.rs`, `commands/start/daemon.rs` comments) plus doc/CHANGELOG updates. No changes to the sidecar internals, the hot-swap orchestrator, the swap-back watchdog (#3584), or the soak harness (#3610).
- **Soak evidence**: validated by the epic #3524 slice 2-4 spike (numerically identical embeddings, ~2.4x faster end-to-end) and soaked per #3610 before this flip.

## Test plan

- [x] `cargo build --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — clean
- [x] `cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --no-fail-fast` — only pre-existing, unrelated parallel-execution flakes (verified to pass in isolation, on both this branch and origin/main); `trusty-search`'s own suite is 100% green including under `--test-threads=1`
- [x] `bash scripts/check_sld.sh` (SLD/doc-comment pointer lint) — clean
- [x] New/updated unit tests: `resolve_default_embedder_mode_for_apple_silicon_no_override_is_graceful`, `resolve_default_embedder_mode_for_apple_silicon_eager_env_stays_graceful`, `resolve_default_embedder_mode_for_non_apple_silicon_is_ort`, `resolve_default_embedder_mode_for_non_apple_silicon_eager_env_is_eager`, `is_forced_ort_override_stdio_true`, `is_forced_ort_override_other_values_false`
- [x] Real-host sanity test (cfg-gated to aarch64 macOS): `resolve_default_embedder_mode_on_real_apple_silicon_host_is_graceful` — exercises the actual `resolve_default_embedder_mode()` wrapper (not just the pure function) on a real Apple Silicon box
- [x] Live `trusty-search start` sanity run on this Apple Silicon machine with `TRUSTY_EMBEDDER` unset and an isolated `--data-dir`: startup log shows `embedder mode: graceful Apple-Silicon default`, daemon serves immediately on ort, hot-swaps to `python/MPS` ~7s later (`embedder hot-swapped ort -> python/MPS (sidecar ready)`), and `/health` reports `embedder_bootstrap: "ready"`, `backend: "python"`, `provider: "MPS"`. A real semantic search ("sum of two numbers" / "function that multiplies two numbers") correctly ranked the matching function first both before and after the hot-swap.

**Not merging** — owner-gated per the epic; opened for review only.