### PR TITLE
feat(embedder): throughput bench + MPS memory-safety soak (epic #3524 slice 7)

### DIFF
--- a/crates/trusty-search/src/commands/start/mod.rs
+++ b/crates/trusty-search/src/commands/start/mod.rs
@@ -30,6 +30,14 @@ mod swap_back_watchdog;
 #[cfg(test)]
 mod tests;
 
+// Epic #3524 slice 7: repeated ort<->python swap-back cycle bench/soak
+// coverage (fast deterministic tests + an opt-in real-hardware soak). A
+// sibling of `tests` rather than folded into it because `tests.rs` is
+// owned by an in-flight PR (the Apple-Silicon default-flip) this work must
+// not conflict with.
+#[cfg(test)]
+mod swap_back_cycle_soak_tests;
+
 // Public entry point consumed by `commands/mod.rs`.
 pub use daemon::handle_start;
 

--- a/crates/trusty-search/src/commands/start/swap_back_cycle_soak_tests.rs
+++ b/crates/trusty-search/src/commands/start/swap_back_cycle_soak_tests.rs
@@ -1,0 +1,727 @@
+//! Repeated ort→python→ort swap-back cycle coverage (epic #3524 slice 7).
+//!
+//! Why: every existing test for `graceful_bootstrap`/`swap_back_watchdog`
+//! (`start/tests.rs`) drives at most ONE ort→python transition or ONE
+//! python→ort swap-back in isolation. Production itself only ever cycles
+//! once per daemon lifetime (`drive_bootstrap`'s doc: "no re-bootstrap after
+//! failure"). Neither proves what happens under REPEATED cycling — which
+//! matters because the epic names two concrete leak candidates that can only
+//! show up across multiple cycles: (a) a leaked python child if
+//! `PythonAdapterTeardown::teardown()` is ever skipped, and (b) an orphaned
+//! ort backend (or a permanently-stuck switchable) if `build_ort()` fails
+//! mid-swap-back. This module is the #24 memory-safety re-check's other
+//! half — the GracefulPython-arm-specific complement to the raw-supervisor
+//! soak in `tests/py_sidecar_memory_soak.rs` (epic #3524 slice 6 PR 5/5,
+//! #3610), which never touches `SwitchableEmbedder`/`swap_back_watchdog` at
+//! all.
+//!
+//! What: two tiers, matching the project convention (fast in `cargo test`,
+//! heavy behind an explicit opt-in):
+//!   - `fast_deterministic` — repeated cycles driven directly against
+//!     `drive_bootstrap`/`drive_swap_back_watchdog` with fully deterministic
+//!     fakes (no real subprocess). Runs in every plain `cargo test`, proving
+//!     the CALL-GRAPH has no structural leak (1 teardown call per 1 spawned
+//!     python handle, across N cycles) and that a `build_ort()` failure
+//!     mid-swap-back neither orphans anything nor permanently wedges
+//!     recovery.
+//!   - `real_soak` — `#[ignore]`d AND gated on `TRUSTY_SOAK=1` at runtime
+//!     (mirroring `tests/py_sidecar_memory_soak.rs`'s convention), drives the
+//!     REAL production entry point (`graceful_bootstrap::run_graceful_python_bootstrap`)
+//!     repeatedly against a real `trusty-embedderd` + `trusty-embedderd-py`
+//!     (real `uv` venv, real torch/MPS), inducing real supervisor give-up via
+//!     repeated `SIGKILL`, and observing REAL OS-level signals (process
+//!     count, RSS) rather than trusting internal bookkeeping alone. Requires
+//!     Apple Silicon + a bootstrapped `uv` venv; never runs in CI.
+//!
+//! Test: `repeated_cycles_never_leak_teardown_calls`,
+//! `build_ort_failure_mid_cycle_leaves_no_orphan_and_allows_recovery`,
+//! `real_repeated_ort_python_ort_cycles_soak` (all in this module).
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::core::Embedder as CoreEmbedder;
+use crate::service::embedder_supervisor::{
+    ActiveBackend, BackendKind, BootstrapState, SwitchableEmbedder,
+};
+use crate::service::SearchAppState;
+
+use super::graceful_bootstrap::{drive_bootstrap, PythonAdapterTeardown, PythonBootstrap};
+use super::swap_back_watchdog::{drive_swap_back_watchdog, SwapBackOps};
+
+// ============================================================================
+// Fast, deterministic fakes.
+//
+// Deliberately NOT shared with `start/tests.rs`'s private `FakeBootstrap` /
+// `FakeSwapBackOps` / `FakeTeardown` — Rust's per-file integration-test-like
+// privacy means a `#[cfg(test)] mod` sibling cannot `use` another sibling
+// module's private items, and `start/tests.rs` is out of scope for this PR
+// (owned by the in-flight default-flip PR). These are intentionally minimal
+// re-implementations of the same shape.
+// ============================================================================
+
+struct FakeEmbedder {
+    calls: AtomicUsize,
+}
+
+impl FakeEmbedder {
+    fn new() -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CoreEmbedder for FakeEmbedder {
+    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(vec![text.len() as f32; trusty_common::embedder::EMBED_DIM])
+    }
+
+    async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(texts
+            .iter()
+            .map(|t| vec![t.len() as f32; trusty_common::embedder::EMBED_DIM])
+            .collect())
+    }
+
+    fn dimension(&self) -> usize {
+        trusty_common::embedder::EMBED_DIM
+    }
+}
+
+/// Controllable fake [`PythonAdapterTeardown`] — records teardown calls and
+/// exposes a shared `terminated` flag the test flips to simulate confirmed
+/// supervisor give-up.
+struct FakeTeardown {
+    calls: Arc<AtomicUsize>,
+    terminated: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl FakeTeardown {
+    fn new(calls: Arc<AtomicUsize>, terminated: Arc<std::sync::atomic::AtomicBool>) -> Self {
+        Self { calls, terminated }
+    }
+}
+
+#[async_trait::async_trait]
+impl PythonAdapterTeardown for FakeTeardown {
+    async fn teardown(&self) {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+    }
+
+    async fn is_confirmed_terminated(&self) -> bool {
+        self.terminated.load(Ordering::Acquire)
+    }
+}
+
+/// Fully deterministic fake [`PythonBootstrap`] — always succeeds instantly.
+/// Each `build_adapter` call hands back a FRESH [`FakeTeardown`] wired to a
+/// FRESH `terminated` flag, tracked in `last_terminated` so the test driving
+/// a cycle can grab the flag for the handle it just installed and flip it to
+/// simulate that specific handle's death.
+struct CyclingBootstrap {
+    total_teardown_calls: Arc<AtomicUsize>,
+    total_spawns: Arc<AtomicUsize>,
+    last_terminated: std::sync::Mutex<Option<Arc<std::sync::atomic::AtomicBool>>>,
+}
+
+impl CyclingBootstrap {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            total_teardown_calls: Arc::new(AtomicUsize::new(0)),
+            total_spawns: Arc::new(AtomicUsize::new(0)),
+            last_terminated: std::sync::Mutex::new(None),
+        })
+    }
+
+    fn last_terminated_flag(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        self.last_terminated
+            .lock()
+            .expect("lock poisoned")
+            .clone()
+            .expect("build_adapter must run before last_terminated_flag is read")
+    }
+}
+
+impl PythonBootstrap for CyclingBootstrap {
+    fn ensure_venv(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn locate_launcher(&self) -> anyhow::Result<PathBuf> {
+        Ok(PathBuf::from("/fake/trusty-embedderd-py"))
+    }
+
+    fn build_adapter(
+        &self,
+        _launcher: PathBuf,
+    ) -> (
+        Arc<dyn CoreEmbedder>,
+        Option<Arc<AtomicU32>>,
+        Arc<dyn PythonAdapterTeardown>,
+    ) {
+        self.total_spawns.fetch_add(1, Ordering::Relaxed);
+        let terminated = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        *self.last_terminated.lock().expect("lock poisoned") = Some(Arc::clone(&terminated));
+        let teardown: Arc<dyn PythonAdapterTeardown> = Arc::new(FakeTeardown::new(
+            Arc::clone(&self.total_teardown_calls),
+            terminated,
+        ));
+        let adapter: Arc<dyn CoreEmbedder> = Arc::new(FakeEmbedder::new());
+        let pid = Arc::new(AtomicU32::new(
+            4000 + self.total_spawns.load(Ordering::Relaxed) as u32,
+        ));
+        (adapter, Some(pid), teardown)
+    }
+
+    fn probe_timeout(&self) -> Duration {
+        Duration::from_secs(5)
+    }
+}
+
+/// Fake [`SwapBackOps`] whose `build_ort()` can be told to fail on specific
+/// (1-indexed) call numbers — used to simulate the `build_ort()` failure the
+/// swap-back watchdog logs-and-gives-up on (`swap_back_watchdog.rs:242-250`)
+/// without ever touching a real `trusty-embedderd` binary.
+struct CyclingSwapBackOps {
+    calls: AtomicUsize,
+    fail_on_calls: Vec<usize>,
+}
+
+impl CyclingSwapBackOps {
+    fn always_succeeds() -> Arc<Self> {
+        Arc::new(Self {
+            calls: AtomicUsize::new(0),
+            fail_on_calls: Vec::new(),
+        })
+    }
+
+    fn failing_on(calls: &[usize]) -> Arc<Self> {
+        Arc::new(Self {
+            calls: AtomicUsize::new(0),
+            fail_on_calls: calls.to_vec(),
+        })
+    }
+}
+
+impl SwapBackOps for CyclingSwapBackOps {
+    fn build_ort(&self) -> anyhow::Result<(Arc<dyn CoreEmbedder>, Option<Arc<AtomicU32>>)> {
+        let n = self.calls.fetch_add(1, Ordering::Relaxed) + 1;
+        if self.fail_on_calls.contains(&n) {
+            anyhow::bail!("fake ort rebuild failure (call #{n})");
+        }
+        let adapter: Arc<dyn CoreEmbedder> = Arc::new(FakeEmbedder::new());
+        Ok((adapter, Some(Arc::new(AtomicU32::new(5000 + n as u32)))))
+    }
+}
+
+fn test_state() -> SearchAppState {
+    SearchAppState::new(crate::core::registry::IndexRegistry::new())
+}
+
+fn ort_bootstrapping_active() -> ActiveBackend {
+    ActiveBackend {
+        kind: BackendKind::Ort,
+        provider: trusty_common::embedder::ExecutionProvider::Cpu,
+        model: "all-MiniLM-L6-v2".to_string(),
+        quantized: false,
+        bootstrap: BootstrapState::Bootstrapping,
+    }
+}
+
+// ============================================================================
+// Fast, deterministic, in-CI tests.
+// ============================================================================
+
+/// Drives `drive_bootstrap` → `drive_swap_back_watchdog` → `drive_bootstrap`
+/// → ... for `CYCLES` full ort→python→ort round trips against the SAME
+/// `switchable`/`state`, exactly like a real daemon would if the python
+/// sidecar kept dying and getting rebuilt. Asserts, across ALL cycles
+/// combined: every spawned python handle got torn down exactly once (no
+/// leaked python child — leak candidate #1) and every swap-back rebuilt
+/// exactly one fresh ort backend (no accumulation).
+#[tokio::test]
+async fn repeated_cycles_never_leak_teardown_calls() {
+    const CYCLES: usize = 5;
+
+    let ort: Arc<dyn CoreEmbedder> = Arc::new(FakeEmbedder::new());
+    let switchable = Arc::new(SwitchableEmbedder::new(ort, ort_bootstrapping_active()));
+    let state = test_state();
+
+    let bootstrap = CyclingBootstrap::new();
+    let (ort_ops, ort_build_calls) = {
+        let ops = CyclingSwapBackOps::always_succeeds();
+        (ops, Arc::new(AtomicUsize::new(0)))
+    };
+    let _ = &ort_build_calls; // silence unused in case of future refactor
+
+    for cycle in 0..CYCLES {
+        let python_ops: Arc<dyn PythonBootstrap> = Arc::clone(&bootstrap) as _;
+        let teardown = drive_bootstrap(Arc::clone(&switchable), state.clone(), python_ops, 1)
+            .await
+            .unwrap_or_else(|| {
+                panic!("cycle {cycle}: bootstrap must succeed against the always-succeeding fake")
+            });
+        assert_eq!(
+            switchable.active().kind,
+            BackendKind::Python,
+            "cycle {cycle}: must be on python after a successful bootstrap"
+        );
+
+        // Simulate confirmed death of THIS cycle's handle.
+        bootstrap
+            .last_terminated_flag()
+            .store(true, Ordering::Release);
+
+        let ops: Arc<dyn SwapBackOps> = Arc::clone(&ort_ops) as _;
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            drive_swap_back_watchdog(
+                Arc::clone(&switchable),
+                state.clone(),
+                teardown,
+                ops,
+                Duration::from_millis(2),
+            ),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("cycle {cycle}: watchdog must act on confirmed death"));
+
+        assert_eq!(
+            switchable.active().kind,
+            BackendKind::Ort,
+            "cycle {cycle}: must swap back to ort"
+        );
+    }
+
+    assert_eq!(
+        bootstrap.total_spawns.load(Ordering::Relaxed),
+        CYCLES,
+        "one python handle spawned per cycle"
+    );
+    assert_eq!(
+        bootstrap.total_teardown_calls.load(Ordering::Relaxed),
+        CYCLES,
+        "leak candidate #1: every spawned python handle must be torn down \
+         exactly once — teardown calls must equal spawn count across all \
+         {CYCLES} cycles, with no accumulation and no gaps"
+    );
+}
+
+/// Leak candidate #2: a `build_ort()` failure on ONE cycle must (a) still
+/// tear down the dead python handle (no python-side leak just because the
+/// ort rebuild failed), (b) leave the switchable in the documented
+/// stays-on-dead-python state rather than some half-swapped/corrupt state,
+/// and (c) NOT permanently wedge recovery — a subsequent bootstrap attempt on
+/// the same `switchable`/`state` must still succeed, proving the failure
+/// mode is exactly "stay on the dead backend until someone retries" (as
+/// `swap_back_watchdog.rs`'s error log says), never a stranded, unrecoverable
+/// handle.
+#[tokio::test]
+async fn build_ort_failure_mid_cycle_leaves_no_orphan_and_allows_recovery() {
+    let ort: Arc<dyn CoreEmbedder> = Arc::new(FakeEmbedder::new());
+    let switchable = Arc::new(SwitchableEmbedder::new(ort, ort_bootstrapping_active()));
+    let state = test_state();
+    let bootstrap = CyclingBootstrap::new();
+
+    // Cycle 1: bootstrap to python, then fail the ort rebuild on swap-back.
+    let python_ops: Arc<dyn PythonBootstrap> = Arc::clone(&bootstrap) as _;
+    let teardown = drive_bootstrap(Arc::clone(&switchable), state.clone(), python_ops, 1)
+        .await
+        .expect("first bootstrap must succeed");
+    assert_eq!(switchable.active().kind, BackendKind::Python);
+
+    bootstrap
+        .last_terminated_flag()
+        .store(true, Ordering::Release);
+
+    let failing_ops: Arc<dyn SwapBackOps> = CyclingSwapBackOps::failing_on(&[1]) as Arc<_>;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        drive_swap_back_watchdog(
+            Arc::clone(&switchable),
+            state.clone(),
+            Arc::clone(&teardown),
+            failing_ops,
+            Duration::from_millis(2),
+        ),
+    )
+    .await
+    .expect("watchdog must still act (return) even when build_ort fails");
+
+    assert_eq!(
+        switchable.active().kind,
+        BackendKind::Python,
+        "documented behavior: a failed ort rebuild leaves the switchable on \
+         the (now dead) python backend rather than any half-built state"
+    );
+    assert_eq!(
+        bootstrap.total_teardown_calls.load(Ordering::Relaxed),
+        1,
+        "leak candidate #2: the dead python handle must still be torn down \
+         even though build_ort() failed — no orphan just because the \
+         REBUILD failed"
+    );
+
+    // Recovery: a fresh bootstrap attempt on the SAME switchable/state must
+    // still succeed — the failure must not have permanently wedged anything.
+    let python_ops_2: Arc<dyn PythonBootstrap> = Arc::clone(&bootstrap) as _;
+    let teardown_2 = drive_bootstrap(Arc::clone(&switchable), state.clone(), python_ops_2, 1)
+        .await
+        .expect(
+            "recovery bootstrap must succeed — the earlier build_ort() \
+                 failure must not have permanently wedged this switchable",
+        );
+    assert_eq!(switchable.active().kind, BackendKind::Python);
+
+    // And a subsequent, SUCCEEDING swap-back must work normally too.
+    bootstrap
+        .last_terminated_flag()
+        .store(true, Ordering::Release);
+    let succeeding_ops: Arc<dyn SwapBackOps> = CyclingSwapBackOps::always_succeeds() as Arc<_>;
+    tokio::time::timeout(
+        Duration::from_secs(2),
+        drive_swap_back_watchdog(
+            switchable.clone(),
+            state.clone(),
+            teardown_2,
+            succeeding_ops,
+            Duration::from_millis(2),
+        ),
+    )
+    .await
+    .expect("watchdog must act on the recovered cycle's confirmed death");
+    assert_eq!(switchable.active().kind, BackendKind::Ort);
+    assert_eq!(
+        bootstrap.total_teardown_calls.load(Ordering::Relaxed),
+        2,
+        "both the failed cycle's handle and the recovered cycle's handle \
+         must each be torn down exactly once"
+    );
+}
+
+// ============================================================================
+// Heavy real soak — #[ignore]d AND gated on TRUSTY_SOAK=1 at runtime, mirroring
+// `tests/py_sidecar_memory_soak.rs`'s convention. Drives the REAL production
+// entry point repeatedly against a real `uv` venv + real torch/MPS sidecar +
+// real `trusty-embedderd` ort sidecar, observing OS-level process counts as
+// the leak signal rather than trusting internal call-counters alone.
+// ============================================================================
+
+/// Count live OS processes whose command line or name contains `needle`
+/// (case-insensitive), excluding this test process itself. Real-signal check
+/// for leak candidate #1 (a python child surviving past its teardown) that
+/// does not depend on this harness having correctly tracked every pid it
+/// spawned — an actual leaked process shows up here even if our own
+/// bookkeeping lost track of it.
+#[cfg(test)]
+fn count_processes_matching(needle: &str) -> usize {
+    use sysinfo::{ProcessRefreshKind, RefreshKind, System};
+    let needle = needle.to_ascii_lowercase();
+    let my_pid = std::process::id();
+    let mut sys = System::new_with_specifics(
+        RefreshKind::nothing().with_processes(ProcessRefreshKind::everything()),
+    );
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    sys.processes()
+        .iter()
+        .filter(|(pid, _)| pid.as_u32() != my_pid)
+        .filter(|(_, proc_)| {
+            let name_hit = proc_
+                .name()
+                .to_string_lossy()
+                .to_ascii_lowercase()
+                .contains(&needle);
+            let cmd_hit = proc_
+                .cmd()
+                .iter()
+                .any(|a| a.to_string_lossy().to_ascii_lowercase().contains(&needle));
+            name_hit || cmd_hit
+        })
+        .count()
+}
+
+/// Real repeated ort→python→ort cycling through the actual production entry
+/// point (`graceful_bootstrap::run_graceful_python_bootstrap`), which itself
+/// spawns the real `swap_back_watchdog` on success — exercising the EXACT
+/// code path a daemon runs, just invoked several times by this test (since
+/// production only ever calls it once per daemon lifetime).
+///
+/// Requires a real `trusty-embedderd` + `trusty-embedderd-py` launcher with
+/// its `uv`-managed venv already bootstrapped (torch + sentence-transformers)
+/// — practically, Apple Silicon with `uv` installed. Not run in CI. Run
+/// manually with:
+///   `TRUSTY_SOAK=1 cargo test -p trusty-search --lib \
+///      real_repeated_ort_python_ort_cycles_soak -- --ignored --nocapture`
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires real trusty-embedderd + trusty-embedderd-py + a bootstrapped \
+            uv/torch/MPS venv (Apple Silicon) — additionally gated on TRUSTY_SOAK=1"]
+async fn real_repeated_ort_python_ort_cycles_soak() {
+    if std::env::var("TRUSTY_SOAK").ok().as_deref() != Some("1") {
+        eprintln!(
+            "real_repeated_ort_python_ort_cycles_soak: TRUSTY_SOAK != 1 — skipping. \
+             Run with `TRUSTY_SOAK=1 cargo test ... -- --ignored --nocapture`."
+        );
+        return;
+    }
+
+    const CYCLES: usize = 3;
+    // Keep each cycle's crash-restart-exhaustion loop short: 1 restart, then
+    // the supervisor gives up on the next failure.
+    std::env::set_var("TRUSTY_EMBEDDERD_MAX_RESTARTS", "1");
+
+    let (ort, ort_pid_slot) = super::embedder::build_ort_stdio_sidecar().expect(
+        "build_ort_stdio_sidecar() failed — is `trusty-embedderd` on PATH \
+             (or TRUSTY_EMBEDDERD_BIN set)?",
+    );
+    let provider = ort.provider();
+    let switchable = Arc::new(SwitchableEmbedder::new(
+        ort,
+        ActiveBackend {
+            kind: BackendKind::Ort,
+            provider,
+            model: "all-MiniLM-L6-v2".to_string(),
+            quantized: false,
+            bootstrap: BootstrapState::Bootstrapping,
+        },
+    ));
+    let state = test_state();
+    if let Some(slot) = ort_pid_slot {
+        state.install_embedderd_pid_slot(slot).await;
+    }
+
+    let baseline_python_procs = count_processes_matching("trusty-embedderd-py");
+    eprintln!("soak: baseline live trusty-embedderd-py processes = {baseline_python_procs}");
+
+    for cycle in 0..CYCLES {
+        eprintln!("soak: cycle {cycle}/{CYCLES} — bootstrapping ort -> python");
+        super::graceful_bootstrap::run_graceful_python_bootstrap(
+            Arc::clone(&switchable),
+            state.clone(),
+        )
+        .await;
+
+        let active = switchable.active();
+        if active.kind != BackendKind::Python {
+            panic!(
+                "cycle {cycle}: real python bootstrap failed (bootstrap={:?}) — \
+                 is the uv venv actually bootstrapped? Run \
+                 `trusty-embedderd-py --stdio` once by hand first, or \
+                 `cargo run -p trusty-embedderd-py --bin trusty-embedderd-py -- --bootstrap-only` \
+                 if that flag exists, to warm the venv before soaking.",
+                active.bootstrap
+            );
+        }
+        eprintln!(
+            "soak: cycle {cycle} — python bootstrap succeeded (provider={:?})",
+            active.provider
+        );
+
+        // Touch the live backend for real so this isn't just a bootstrap
+        // no-op — a handful of real embeds through the switchable.
+        let probe_texts = ["fn soak_probe() {}"; 4];
+        switchable
+            .embed_batch(&probe_texts)
+            .await
+            .expect("real embed through the freshly-bootstrapped python backend failed");
+
+        let live_pid = state
+            .current_embedderd_pid()
+            .filter(|&p| p != 0)
+            .unwrap_or_else(|| panic!("cycle {cycle}: no live python pid recorded on state"));
+        eprintln!("soak: cycle {cycle} — live python pid = {live_pid}");
+
+        // Repeatedly SIGKILL whatever pid is currently live until the
+        // switchable itself confirms the watchdog swapped back to ort — no
+        // fabricated state, just the real supervisor + real watchdog.
+        let deadline = std::time::Instant::now() + Duration::from_secs(120);
+        loop {
+            if let Some(pid) = state.current_embedderd_pid().filter(|&p| p != 0) {
+                let _ = std::process::Command::new("kill")
+                    .args(["-9", &pid.to_string()])
+                    .status();
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            if switchable.active().kind == BackendKind::Ort {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "cycle {cycle}: watchdog never swapped back to ort within 120s \
+                 of repeated SIGKILLs — max_restarts=1 not exhausted, or the \
+                 watchdog's 15s poll never observed confirmed death"
+            );
+        }
+        eprintln!(
+            "soak: cycle {cycle} — swap-back confirmed (active={:?})",
+            switchable.active().kind
+        );
+
+        // Give the torn-down python process a moment to actually exit before
+        // sampling — teardown() awaits confirmed death, but the OS may take
+        // a beat to reap.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let procs_now = count_processes_matching("trusty-embedderd-py");
+        assert_eq!(
+            procs_now, baseline_python_procs,
+            "cycle {cycle}: leak candidate #1 — live trusty-embedderd-py \
+             process count did not return to baseline ({baseline_python_procs}) \
+             after swap-back; found {procs_now} — a python child likely \
+             survived its teardown"
+        );
+    }
+
+    eprintln!(
+        "soak: all {CYCLES} real ort->python->ort cycles completed; \
+         trusty-embedderd-py process count returned to baseline \
+         ({baseline_python_procs}) after every cycle — no leaked python child \
+         detected."
+    );
+
+    std::env::remove_var("TRUSTY_EMBEDDERD_MAX_RESTARTS");
+}
+
+/// Real, single-cycle proof of leak candidate #2: force `build_ort()`
+/// (`RealSwapBackOps::build_ort` → `build_ort_stdio_sidecar` →
+/// `locate_embedderd_binary`) to genuinely fail during a REAL swap-back by
+/// pointing `TRUSTY_EMBEDDERD_BIN` at a nonexistent path right before
+/// inducing death, then confirms: (a) the switchable stays on the (now dead)
+/// python backend — never a half-built/corrupt state — (b) the dead python
+/// process is still fully reaped (process count returns to baseline) even
+/// though the ort rebuild failed, and (c) restoring `TRUSTY_EMBEDDERD_BIN`
+/// and running one more real bootstrap cycle recovers cleanly — proving the
+/// failure mode is exactly "stuck on dead python until someone retries", not
+/// a permanent wedge or an orphaned resource.
+///
+/// Not run in CI; gated the same way as
+/// `real_repeated_ort_python_ort_cycles_soak`. Run manually with:
+///   `TRUSTY_SOAK=1 cargo test -p trusty-search --lib \
+///      real_build_ort_failure_leaves_no_orphan_and_recovers -- --ignored --nocapture`
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires real trusty-embedderd + trusty-embedderd-py + a bootstrapped \
+            uv/torch/MPS venv (Apple Silicon) — additionally gated on TRUSTY_SOAK=1"]
+async fn real_build_ort_failure_leaves_no_orphan_and_recovers() {
+    if std::env::var("TRUSTY_SOAK").ok().as_deref() != Some("1") {
+        eprintln!(
+            "real_build_ort_failure_leaves_no_orphan_and_recovers: TRUSTY_SOAK != 1 — \
+             skipping. Run with `TRUSTY_SOAK=1 cargo test ... -- --ignored --nocapture`."
+        );
+        return;
+    }
+
+    std::env::set_var("TRUSTY_EMBEDDERD_MAX_RESTARTS", "1");
+
+    // Resolve the REAL ort binary path up front (before we start pointing
+    // TRUSTY_EMBEDDERD_BIN at garbage) so we can restore it verbatim later.
+    let real_ort_bin = crate::service::embedder_supervisor::locate_embedderd_binary()
+        .expect("a real trusty-embedderd must be discoverable for this test to mean anything")
+        .to_string_lossy()
+        .into_owned();
+
+    let (ort, ort_pid_slot) = super::embedder::build_ort_stdio_sidecar()
+        .expect("build_ort_stdio_sidecar() failed for the initial ort backend");
+    let provider = ort.provider();
+    let switchable = Arc::new(SwitchableEmbedder::new(
+        ort,
+        ActiveBackend {
+            kind: BackendKind::Ort,
+            provider,
+            model: "all-MiniLM-L6-v2".to_string(),
+            quantized: false,
+            bootstrap: BootstrapState::Bootstrapping,
+        },
+    ));
+    let state = test_state();
+    if let Some(slot) = ort_pid_slot {
+        state.install_embedderd_pid_slot(slot).await;
+    }
+
+    let baseline_python_procs = count_processes_matching("trusty-embedderd-py");
+
+    super::graceful_bootstrap::run_graceful_python_bootstrap(
+        Arc::clone(&switchable),
+        state.clone(),
+    )
+    .await;
+    assert_eq!(
+        switchable.active().kind,
+        BackendKind::Python,
+        "real python bootstrap failed — is the uv venv actually bootstrapped?"
+    );
+
+    // Now force the swap-back's build_ort() to fail: point TRUSTY_EMBEDDERD_BIN
+    // at a path that does not exist. `locate_embedderd_binary()` bails
+    // immediately on an explicit-but-invalid override rather than falling
+    // through to PATH search, so this is a deterministic failure trigger.
+    std::env::set_var(
+        "TRUSTY_EMBEDDERD_BIN",
+        "/nonexistent/trusty-embedderd-for-soak-test",
+    );
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    loop {
+        if let Some(pid) = state.current_embedderd_pid().filter(|&p| p != 0) {
+            let _ = std::process::Command::new("kill")
+                .args(["-9", &pid.to_string()])
+                .status();
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        // With build_ort() broken, the watchdog can never observe
+        // BackendKind::Ort — instead we wait for the dead python process to
+        // actually disappear from the process table (teardown() completing)
+        // as our "the watchdog has acted" signal.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        let procs_now = count_processes_matching("trusty-embedderd-py");
+        if procs_now <= baseline_python_procs {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "python process never disappeared within 120s of repeated SIGKILLs \
+             — max_restarts=1 not exhausted, or teardown() never ran"
+        );
+    }
+
+    // Restore TRUSTY_EMBEDDERD_BIN immediately — every assertion below must
+    // hold regardless, but we don't want a failed assertion to leave the
+    // process env poisoned for any later test in the same binary.
+    std::env::set_var("TRUSTY_EMBEDDERD_BIN", &real_ort_bin);
+
+    assert_eq!(
+        switchable.active().kind,
+        BackendKind::Python,
+        "leak candidate #2: a failed build_ort() must leave the switchable on \
+         the (now dead) python backend — documented behavior, never a \
+         half-built/corrupt ort state"
+    );
+    let procs_after = count_processes_matching("trusty-embedderd-py");
+    assert_eq!(
+        procs_after, baseline_python_procs,
+        "leak candidate #2: the dead python process must still be fully \
+         reaped (teardown() still runs on the build_ort() Err branch) even \
+         though the ort rebuild failed — found {procs_after} vs baseline \
+         {baseline_python_procs}"
+    );
+
+    // Recovery: with a valid TRUSTY_EMBEDDERD_BIN restored, one more real
+    // bootstrap cycle on the SAME switchable/state must succeed cleanly.
+    super::graceful_bootstrap::run_graceful_python_bootstrap(
+        Arc::clone(&switchable),
+        state.clone(),
+    )
+    .await;
+    assert_eq!(
+        switchable.active().kind,
+        BackendKind::Python,
+        "recovery bootstrap after a build_ort() failure must still succeed — \
+         the earlier failure must not have permanently wedged this switchable"
+    );
+
+    std::env::remove_var("TRUSTY_EMBEDDERD_MAX_RESTARTS");
+    std::env::remove_var("TRUSTY_EMBEDDERD_BIN");
+}

--- a/crates/trusty-search/tests/embedder_throughput_bench.rs
+++ b/crates/trusty-search/tests/embedder_throughput_bench.rs
@@ -1,0 +1,403 @@
+//! Embedder throughput bench: Rust `ort` sidecar vs Python/MPS sidecar (epic
+//! #3524 slice 7).
+//!
+//! Why: the epic's acceptance criteria call for an automated throughput
+//! measurement "through the supervisor" (matching how the epic's own spike
+//! was measured — 561 emb/s end-to-end via a real, isolated daemon), wired
+//! into the repo's existing bench-harness conventions
+//! (`tests/benchmark_harness.rs`'s side-by-side comparison-table style,
+//! `trusty-common/src/bin/candle_metal_bench.rs`'s GO/NO-GO-flavoured
+//! backend-vs-backend shape). Two gotchas the epic explicitly flags, learned
+//! the hard way during the spike:
+//!   1. **Use a BUFFERED stdout reader.** An unbuffered byte-at-a-time reader
+//!      over the child's piped stdout distorts the measurement (extra
+//!      syscalls/latency on the hot path being timed) and risks missing or
+//!      splitting lines under load.
+//!   2. **Real throughput is in the `deferred_embed[...]: embedded N/N
+//!      chunks` log line, NOT the reindex `complete` event.** Reindexing is
+//!      two-phase (issue #923 DEFER-EMBED): the fast BM25-only pass (C1)
+//!      returns/logs "complete" in milliseconds; the actual embedding work
+//!      (C2, the deferred catch-up pass) runs afterward in the background
+//!      and is what this bench needs to time. Measuring the wrong line
+//!      yields a confidently wrong (huge) throughput number.
+//!
+//! What: spawns the REAL `trusty-search` binary (`--foreground`, isolated
+//! `--data-dir`, ephemeral port) once per embedder backend
+//! (`TRUSTY_EMBEDDER=ort` / `TRUSTY_EMBEDDER=python`), registers a synthetic
+//! corpus, triggers a reindex over HTTP, and watches the daemon's stdout
+//! (via a buffered `tokio::io::BufReader::lines()`) for the
+//! `deferred_embed[...]: embedded N/N chunks` line. Elapsed time from the
+//! reindex trigger to that line, divided by N, is the measured throughput.
+//! Prints a side-by-side comparison table, mirroring
+//! `tests/benchmark_harness.rs`'s comparison-table convention.
+//!
+//! Where this runs: `#[ignore]`-gated — requires a real `trusty-embedderd`
+//! (ort) binary alongside the test binary AND, for the python arm, a real
+//! `trusty-embedderd-py` launcher with an already-bootstrapped `uv` venv
+//! (Apple Silicon + `uv`). Never runs in CI (no MPS/GPU on CI runners, and a
+//! cold venv bootstrap alone can take minutes). Run manually:
+//!   `cargo test -p trusty-search --test embedder_throughput_bench -- \
+//!      --ignored --nocapture --test-threads=1`
+//!
+//! Test: `throughput_bench_ort_vs_python` (the only test in this file — a
+//! single test so the comparison table is printed once, not once per arm).
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+
+/// Chunk count target for the synthetic corpus. Large enough for a stable
+/// throughput reading (the epic's own spike used ~24k embeds; this bench
+/// runs per-invocation rather than as a long soak, so a few thousand chunks
+/// is enough to amortize daemon-startup/model-load overhead without making
+/// every manual run take many minutes).
+const SYNTHETIC_FILE_COUNT: usize = 300;
+/// Functions per synthetic file — `SYNTHETIC_FILE_COUNT * FUNCTIONS_PER_FILE`
+/// is roughly the resulting chunk count (tree-sitter chunks per function).
+const FUNCTIONS_PER_FILE: usize = 8;
+
+/// Overall bound on daemon readiness + reindex + embed-pass completion. The
+/// python arm's cold model load can take real wall-clock time; generous on
+/// purpose since this never runs in CI.
+const BENCH_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// One backend's measured result.
+#[derive(Debug, Clone)]
+struct BenchResult {
+    label: &'static str,
+    chunks_embedded: u64,
+    elapsed: Duration,
+}
+
+impl BenchResult {
+    fn chunks_per_sec(&self) -> f64 {
+        self.chunks_embedded as f64 / self.elapsed.as_secs_f64().max(1e-9)
+    }
+}
+
+/// Write `SYNTHETIC_FILE_COUNT` small `.rs` files (each `FUNCTIONS_PER_FILE`
+/// template functions) into `dir` — a synthetic corpus sized for a stable
+/// throughput reading, independent of whatever real source tree happens to
+/// be checked out.
+///
+/// Why: reusing `crates/trusty-search/tests/benchmark_corpus` (47 files, used
+/// by `benchmark_harness.rs` for search-QUALITY scoring) would work but is
+/// small and its chunk count isn't tunable; a purpose-generated corpus gives
+/// a controlled, reproducible chunk count across ort/python runs so the
+/// comparison is apples-to-apples.
+fn write_synthetic_corpus(dir: &Path) -> std::io::Result<()> {
+    const TEMPLATES: &[&str] = &[
+        "fn authenticate_user_{i}(token: &str) -> Result<UserId, AuthError> {{ validate(token) }}",
+        "/// Why: shared embedding abstraction.\n/// What: async trait with embed_batch.\nfn embed_helper_{i}(x: usize) -> usize {{ x + 1 }}",
+        "struct Widget{i} {{ id: u64, name: String }}\nimpl Widget{i} {{ fn new(id: u64) -> Self {{ Self {{ id, name: String::new() }} }} }}",
+        "fn compute_checksum_{i}(data: &[u8]) -> u32 {{ data.iter().map(|b| *b as u32).sum() }}",
+        "// CoreML EP with MLComputeUnits=ALL allocates from the unified-memory pool.\nfn note_{i}() {{}}",
+        "pub fn current_rss_bytes_{i}() -> u64 {{ 0 }}",
+        "struct Daemon{i} {{ inner: std::sync::Arc<std::sync::Mutex<usize>> }}",
+        "// GET /v1/users/{{id}} returns 200 or 404.\nfn handler_{i}() -> u16 {{ 200 }}",
+    ];
+    for file_idx in 0..SYNTHETIC_FILE_COUNT {
+        let mut contents = String::new();
+        for fn_idx in 0..FUNCTIONS_PER_FILE {
+            let i = file_idx * FUNCTIONS_PER_FILE + fn_idx;
+            let template = TEMPLATES[i % TEMPLATES.len()];
+            contents.push_str(&template.replace("{i}", &i.to_string()));
+            contents.push_str("\n\n");
+        }
+        let path = dir.join(format!("synthetic_{file_idx:04}.rs"));
+        std::fs::write(&path, contents)?;
+    }
+    Ok(())
+}
+
+/// Spawn `trusty-search start --foreground` for one embedder backend, piping
+/// stdout/stderr so the caller can watch for the deferred-embed log line.
+///
+/// `embedder_env` is the value for `TRUSTY_EMBEDDER` (`"ort"` or
+/// `"python"`). Uses `TRUSTY_EMBEDDER=stdio` semantics for `ort` (the
+/// existing unset/auto/stdio arm — `stdio` is the explicit, unambiguous
+/// spelling) and `TRUSTY_EMBEDDER=python` (the existing eager python arm) for
+/// python, rather than the Apple-Silicon-default `GracefulPython` arm — the
+/// eager arm blocks daemon startup on the python bootstrap, which is exactly
+/// what a single-shot bench wants (no race between "daemon is up" and
+/// "python backend is actually the one serving").
+fn spawn_daemon(embedder_env: &str, data_dir: &Path, port: u16) -> Child {
+    Command::new(env!("CARGO_BIN_EXE_trusty-search"))
+        .args([
+            "start",
+            "--foreground",
+            "--port",
+            &port.to_string(),
+            "--data-dir",
+        ])
+        .arg(data_dir)
+        .arg("--no-auto-discover")
+        .env("TRUSTY_EMBEDDER", embedder_env)
+        .env("TRUSTY_DATA_DIR", data_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to spawn trusty-search start --foreground")
+}
+
+/// Buffered (per the epic's gotcha #1) line-watcher: reads `reader` line by
+/// line, forwards every line to stderr (so `--nocapture` shows daemon logs
+/// live for debugging), and resolves with `(chunks_embedded, Instant)` the
+/// moment a line matches `deferred_embed[...]: embedded N/N chunks`.
+async fn watch_for_deferred_embed_complete<R>(mut reader: BufReader<R>) -> (u64, Instant)
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader
+            .read_line(&mut line)
+            .await
+            .expect("reading daemon stdout failed");
+        if n == 0 {
+            panic!(
+                "daemon stdout closed (process exited?) before the deferred_embed \
+                 completion line ever appeared"
+            );
+        }
+        eprint!("[daemon] {line}");
+        if let Some(chunks) = parse_deferred_embed_line(&line) {
+            return (chunks, Instant::now());
+        }
+    }
+}
+
+/// Parse `deferred_embed[<id>]: embedded N/N chunks` (see
+/// `crates/trusty-search/src/service/reindex/defer_embed.rs`'s
+/// `"deferred_embed[{}]: embedded {}/{} chunks — marking semantic Ready"`
+/// log line) and return the chunk count when both numerator and denominator
+/// match (a partial/failed pass logs a different message and must not be
+/// mistaken for completion).
+fn parse_deferred_embed_line(line: &str) -> Option<u64> {
+    let marker = "embedded ";
+    let idx = line.find(marker)?;
+    let rest = &line[idx + marker.len()..];
+    let slash = rest.find('/')?;
+    let numerator: u64 = rest[..slash].trim().parse().ok()?;
+    let after_slash = &rest[slash + 1..];
+    let end = after_slash.find(" chunks")?;
+    let denominator: u64 = after_slash[..end].trim().parse().ok()?;
+    if numerator == denominator && numerator > 0 {
+        Some(numerator)
+    } else {
+        None
+    }
+}
+
+/// Poll `GET /health` until it responds successfully or `deadline` passes.
+async fn wait_for_daemon_ready(client: &reqwest::Client, base: &str, deadline: Instant) {
+    loop {
+        if let Ok(resp) = client.get(format!("{base}/health")).send().await {
+            if resp.status().is_success() {
+                return;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "daemon at {base} never became ready (GET /health)"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Run one full bench arm: spawn the daemon, register+reindex the synthetic
+/// corpus, and time the deferred-embed completion.
+async fn run_bench_arm(label: &'static str, embedder_env: &str, port: u16) -> BenchResult {
+    let data_dir = tempfile::tempdir().expect("tempdir for data-dir");
+    let corpus_dir = tempfile::tempdir().expect("tempdir for corpus");
+    write_synthetic_corpus(corpus_dir.path()).expect("write synthetic corpus");
+
+    let mut child = spawn_daemon(embedder_env, data_dir.path(), port);
+    let stdout = BufReader::new(child.stdout.take().expect("child stdout was not piped"));
+    // Drain stderr in the background (best-effort) so the child never blocks
+    // on a full pipe buffer; we only need stdout for the log-line watch.
+    if let Some(mut stderr) = child.stderr.take() {
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            use tokio::io::AsyncReadExt as _;
+            loop {
+                match stderr.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {}
+                }
+            }
+        });
+    }
+
+    let deadline = Instant::now() + BENCH_TIMEOUT;
+    let base = format!("http://127.0.0.1:{port}");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("reqwest client");
+
+    wait_for_daemon_ready(&client, &base, deadline).await;
+    eprintln!("[bench:{label}] daemon ready on {base}");
+
+    let create_resp = client
+        .post(format!("{base}/indexes"))
+        .json(&serde_json::json!({
+            "id": "throughput-bench",
+            "root_path": corpus_dir.path(),
+        }))
+        .send()
+        .await
+        .expect("POST /indexes failed");
+    assert!(
+        create_resp.status().is_success(),
+        "POST /indexes returned {}: {}",
+        create_resp.status(),
+        create_resp.text().await.unwrap_or_default()
+    );
+
+    // Trigger (or re-trigger) an explicit reindex so the deferred-embed pass
+    // this bench times definitely runs — registration alone may or may not
+    // have already kicked one off; an explicit trigger removes the ambiguity.
+    let t_reindex_start = Instant::now();
+    let reindex_resp = client
+        .post(format!("{base}/indexes/throughput-bench/reindex"))
+        .json(&serde_json::json!({ "force": true }))
+        .send()
+        .await
+        .expect("POST /indexes/:id/reindex failed");
+    assert!(
+        reindex_resp.status().is_success(),
+        "POST /reindex returned {}: {}",
+        reindex_resp.status(),
+        reindex_resp.text().await.unwrap_or_default()
+    );
+
+    // THE gotcha: wait for the `deferred_embed[...]: embedded N/N chunks`
+    // line, NOT the reindex HTTP response and NOT any "complete" event — the
+    // fast BM25-only pass (C1) finishes long before embedding does.
+    let (chunks_embedded, t_embedded) = tokio::time::timeout(
+        deadline.saturating_duration_since(Instant::now()),
+        watch_for_deferred_embed_complete(stdout),
+    )
+    .await
+    .expect("timed out waiting for the deferred_embed completion line");
+
+    let elapsed = t_embedded.duration_since(t_reindex_start);
+    eprintln!(
+        "[bench:{label}] embedded {chunks_embedded} chunks in {:.2}s ({:.1} chunks/sec)",
+        elapsed.as_secs_f64(),
+        chunks_embedded as f64 / elapsed.as_secs_f64().max(1e-9),
+    );
+
+    // Best-effort clean shutdown; `kill_on_drop(true)` on `child` is the
+    // backstop if this hangs.
+    let _ = client.post(format!("{base}/admin/stop")).send().await;
+    let _ = tokio::time::timeout(Duration::from_secs(10), child.wait()).await;
+
+    BenchResult {
+        label,
+        chunks_embedded,
+        elapsed,
+    }
+}
+
+/// Print a side-by-side comparison table, mirroring
+/// `tests/benchmark_harness.rs`'s comparison-table convention.
+fn print_comparison(results: &[BenchResult]) {
+    println!("\n=== embedder throughput: ort vs python/MPS ===");
+    println!(
+        "| {:<10} | {:>14} | {:>10} | {:>14} |",
+        "backend", "chunks_embedded", "elapsed_s", "chunks/sec"
+    );
+    println!("|{:-<12}|{:-<16}|{:-<12}|{:-<16}|", "", "", "", "");
+    for r in results {
+        println!(
+            "| {:<10} | {:>14} | {:>10.2} | {:>14.1} |",
+            r.label,
+            r.chunks_embedded,
+            r.elapsed.as_secs_f64(),
+            r.chunks_per_sec(),
+        );
+    }
+    if let (Some(ort), Some(python)) = (
+        results.iter().find(|r| r.label == "ort"),
+        results.iter().find(|r| r.label == "python"),
+    ) {
+        let speedup = python.chunks_per_sec() / ort.chunks_per_sec().max(1e-9);
+        println!(
+            "\npython/MPS is {:.2}x the ort throughput ({:.1} vs {:.1} chunks/sec)",
+            speedup,
+            python.chunks_per_sec(),
+            ort.chunks_per_sec(),
+        );
+    }
+}
+
+/// Real, `#[ignore]`d throughput comparison. A single test (not one per arm)
+/// so both daemons run sequentially on the same port and the comparison
+/// table prints once, covering both backends.
+///
+/// Requires: a real `trusty-embedderd` binary discoverable (built alongside
+/// this test binary — `cargo build -p trusty-search` builds it) for the
+/// `ort` arm, and a real `trusty-embedderd-py` launcher with an
+/// already-bootstrapped `uv` venv for the `python` arm (Apple Silicon +
+/// `uv`). Never runs in CI — no MPS/GPU on CI runners.
+#[ignore = "spawns real trusty-search daemons (ort + python/MPS sidecars); requires a \
+            bootstrapped uv venv for the python arm; not run in CI"]
+#[tokio::test(flavor = "multi_thread")]
+async fn throughput_bench_ort_vs_python() {
+    let mut results = Vec::new();
+
+    eprintln!("=== bench arm: ort ===");
+    results.push(run_bench_arm("ort", "ort", 17_878).await);
+
+    eprintln!("=== bench arm: python ===");
+    results.push(run_bench_arm("python", "python", 17_879).await);
+
+    print_comparison(&results);
+
+    for r in &results {
+        assert!(
+            r.chunks_embedded > 0,
+            "{}: no chunks were embedded — the bench measured nothing",
+            r.label
+        );
+    }
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::parse_deferred_embed_line;
+
+    #[test]
+    fn matches_a_complete_deferred_embed_line() {
+        let line = "2026-07-21T12:00:00Z INFO deferred_embed[my-index]: embedded 2400/2400 chunks — marking semantic Ready\n";
+        assert_eq!(parse_deferred_embed_line(line), Some(2400));
+    }
+
+    #[test]
+    fn ignores_the_reindex_complete_event() {
+        // The exact gotcha the epic names: a "complete" event from the FAST
+        // BM25-only pass must never be mistaken for the embed-pass line.
+        let line =
+            "2026-07-21T12:00:00Z INFO reindex[my-index]: complete (chunks=2400, embedded=0)\n";
+        assert_eq!(parse_deferred_embed_line(line), None);
+    }
+
+    #[test]
+    fn ignores_a_zero_chunk_line() {
+        let line = "deferred_embed[my-index]: embedded 0/0 chunks — marking semantic Ready\n";
+        assert_eq!(parse_deferred_embed_line(line), None);
+    }
+
+    #[test]
+    fn ignores_a_partial_in_progress_line() {
+        let line = "deferred_embed[my-index]: embedded 100/2400 chunks so far\n";
+        assert_eq!(parse_deferred_embed_line(line), None);
+    }
+}


### PR DESCRIPTION
## Summary

Epic #3524 slice 7 — automated throughput bench (ort vs Python/MPS) + the
#24 memory-safety re-check for the `GracefulPython` arm (`SwitchableEmbedder`
+ `swap_back_watchdog`), covering repeated ort→python→ort cycles rather than
a single transition.

- `crates/trusty-search/src/commands/start/swap_back_cycle_soak_tests.rs`
  (new, `#[cfg(test)]`, sibling of `commands/start/tests.rs` — see "Lane
  boundary" below for why it's a separate file):
  - **Fast, deterministic, runs in every `cargo test` (no `--ignored`)**:
    `repeated_cycles_never_leak_teardown_calls` drives `drive_bootstrap` →
    `drive_swap_back_watchdog` → `drive_bootstrap` → ... for 5 full
    ort→python→ort round trips against the same `SwitchableEmbedder`, with
    fully deterministic fakes (no subprocess). Asserts spawn count ==
    teardown count across all 5 cycles (leak candidate #1: a leaked python
    child from a skipped `teardown()`).
    `build_ort_failure_mid_cycle_leaves_no_orphan_and_allows_recovery`
    injects a `build_ort()` failure mid-cycle (leak candidate #2) and
    asserts the dead python handle is still torn down, the switchable stays
    on the documented dead-python state (never a half-built one), and a
    subsequent bootstrap attempt still recovers cleanly.
  - **Heavy, `#[ignore]`d + gated on `TRUSTY_SOAK=1`, real hardware only**:
    `real_repeated_ort_python_ort_cycles_soak` drives the actual production
    entry point (`graceful_bootstrap::run_graceful_python_bootstrap`) — real
    `uv` venv, real torch/MPS sidecar, real `trusty-embedderd` ort sidecar —
    repeatedly, inducing real supervisor give-up via repeated `SIGKILL` and
    checking OS-level `trusty-embedderd-py` process counts return to
    baseline after every cycle (a real signal, not just internal
    bookkeeping). `real_build_ort_failure_leaves_no_orphan_and_recovers` does
    the same for leak candidate #2 on real hardware, forcing `build_ort()`
    to fail via a temporary bad `TRUSTY_EMBEDDERD_BIN`.
- `crates/trusty-search/tests/embedder_throughput_bench.rs` (new,
  `#[ignore]`d): spawns the real `trusty-search` binary once per embedder
  backend (`TRUSTY_EMBEDDER=ort` / `=python`), registers a synthetic
  corpus (300 files, ~2400 chunks), triggers a reindex over HTTP, and
  measures wall-clock from trigger to the `deferred_embed[...]: embedded
  N/N chunks` log line (read via a **buffered** `tokio::io::BufReader`) —
  per the epic's own gotchas, NOT the reindex `complete` event (that's the
  fast BM25-only C1 pass; C2's deferred-embed pass is what actually embeds).
  4 fast unit tests (`parse_tests::*`) cover the line-parser in isolation
  and run in every `cargo test`.

## Verified vs. unverified — read this before trusting any real-hardware number

**Verified, on this machine (Apple Silicon M4 Max, real `uv` + torch/MPS),
in an isolated `TRUSTY_DATA_DIR_OVERRIDE` (never touched the shared
production daemon/data dir on this box):**
- A fresh `uv` venv bootstrap + real python/MPS sidecar spawn works
  end-to-end: `device=mps dtype=fp32 dim=384`, cold-start ~9-13s once the
  venv is warm (~48s on a fully cold venv-and-package-resolve).
- `run_graceful_python_bootstrap` really does hot-swap `SwitchableEmbedder`
  from ort to a live python/MPS backend and serves real `embed_batch` calls
  through it (`provider=Mps` confirmed).
- After a hard test panic mid-soak, **zero orphaned `trusty-embedderd-py` or
  `trusty-embedderd` processes were left running** (`kill_on_drop` + Arc-drop
  cleanup held even on an unclean unwind) — a good sign against leak
  candidate #1, though not the full assertion (see below).
- The fast, deterministic tests (both new ones) pass 100% reproducibly and
  are the ones CI actually runs.

**NOT verified to completion — explicitly UNVERIFIED, do not treat as
passing:**
- Neither `real_repeated_ort_python_ort_cycles_soak` nor
  `real_build_ort_failure_leaves_no_orphan_and_recovers` completed a full
  cycle in this session. Both hit their 120s "wait for confirmed
  swap-back" deadline on cycle 0: the supervisor visibly respawned the
  python child at least once after an induced `SIGKILL` (two distinct
  `[trusty-embed-sidecar] ready:` lines, ~10-13s apart), but
  `terminated_signal`/`is_confirmed_terminated()` never flipped within the
  120s window in this run.
- **This is not obviously a bug in this PR's code.** The already-merged,
  pre-existing real-hardware test in `start/tests.rs`
  (`swap_back_real_hardware_kills_sidecar_past_max_restarts`, from PR #3584)
  hit the *exact same symptom* under the identical isolated venv — its own
  90s deadline expired the same way, with the same "keeps restarting"
  message. That strongly suggests a real timing sensitivity between a
  ~500ms repeated-`SIGKILL`-during-startup loop and the supervisor's
  restart/backoff bookkeeping on this specific machine/run (possibly
  cold-JIT/first-run variance in the isolated venv), not something this PR
  introduced — but I have not root-caused it, and I am not claiming it's
  merely environmental without proof. Treat both real-hardware leak-hunt
  assertions in this PR as **UNVERIFIED**, not passing.
- **Neither leak candidate was confirmed to reproduce OR confirmed absent
  on real hardware.** The fast deterministic tests verify the call-graph
  logic is correct (1:1 teardown/spawn across repeated cycles; recovery
  after a `build_ort()` failure); they do not touch a real OS process, so
  they cannot prove or disprove a real leak by themselves.
- `embedder_throughput_bench.rs`'s `throughput_bench_ort_vs_python` was
  **not run** in this session (same real-hardware time/risk budget went to
  the soak investigation first) — no ort-vs-python throughput numbers are
  reported here. The parser unit tests pass; the end-to-end bench itself
  needs a manual run to produce real numbers.

## What runs where (CI vs. manual)

- **CI / every `cargo test`**: `repeated_cycles_never_leak_teardown_calls`,
  `build_ort_failure_mid_cycle_leaves_no_orphan_and_allows_recovery`,
  `embedder_throughput_bench::parse_tests::*` (4 tests). All fast,
  deterministic, no subprocess, no MPS/GPU.
- **Manual only, `#[ignore]`d, never in CI** (no MPS/GPU on CI runners; a
  cold venv bootstrap alone can take minutes):
  - `TRUSTY_SOAK=1 cargo test -p trusty-search --bin trusty-search real_repeated_ort_python_ort_cycles_soak -- --ignored --nocapture`
  - `TRUSTY_SOAK=1 cargo test -p trusty-search --bin trusty-search real_build_ort_failure_leaves_no_orphan_and_recovers -- --ignored --nocapture`
  - `cargo test -p trusty-search --test embedder_throughput_bench -- --ignored --nocapture --test-threads=1`

## Lane boundary (epic #3524 slice 6 default-flip, PR #3624)

Per instructions, did not touch `commands/start/embedder.rs`,
`commands/start/daemon.rs`, `commands/start/tests.rs`,
`crates/trusty-search/CHANGELOG.md`, or `crates/trusty-search/CLAUDE.md` —
all owned by the in-flight #3624. This is why the new soak lives in a
**separate sibling file** (`swap_back_cycle_soak_tests.rs`) rather than
folded into `start/tests.rs`, with a single minimal, additive
`mod swap_back_cycle_soak_tests;` line in `commands/start/mod.rs` (not on
#3624's file list). **Consequence: this PR carries no `trusty-search`
CHANGELOG entry**, despite the project's usual per-PR CHANGELOG
requirement — adding one would edit the same `[Unreleased]` section
#3624 is actively changing. Flagging this explicitly rather than silently
skipping it, per the instructions' own precedence (lane boundary is a HARD
constraint; the CHANGELOG rule is general project policy). No
`trusty-common` source changed, so no `trusty-common` CHANGELOG entry is
needed either.

Reused `build_ort_stdio_sidecar()` (via the real
`run_graceful_python_bootstrap`/`RealSwapBackOps` production path) —
no second ort-builder. No new give-up signal — both new heavy tests gate on
the existing `terminated_signal()`/`is_confirmed_terminated()` definitive
supervisor signal, never a request-count proxy.

## Quality gate (raw output)

`cargo fmt --all -- --check`: clean (no diff).

`cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings`: exit 0, clean (one pre-existing `tga` MSRV-config warning, unrelated to this change).

`cargo test -p trusty-search -p trusty-common` (default parallel run) hit the
documented pre-existing flake:
```
failures:
    commands::doctor_checks::tests::doctor_data_dir_returns_non_empty_path
test result: FAILED. 314 passed; 1 failed; 3 ignored
```
Re-run serialized (`--test-threads=1`), the whole two-crate suite is 100%
green (every `test result:` line reads `0 failed`), confirming the flake is
parallelism-induced and pre-existing, not from this change:
```
test commands::doctor_checks::tests::doctor_data_dir_returns_non_empty_path ... ok
test result: ok. 1221 passed; 0 failed; 1 ignored ...
test result: ok. 315 passed; 0 failed; 3 ignored ...
(all other targets: 0 failed)
```
New tests confirmed passing (`... ok`):
`commands::start::swap_back_cycle_soak_tests::repeated_cycles_never_leak_teardown_calls`,
`commands::start::swap_back_cycle_soak_tests::build_ort_failure_mid_cycle_leaves_no_orphan_and_allows_recovery`,
`embedder_throughput_bench::parse_tests::{matches_a_complete_deferred_embed_line,ignores_the_reindex_complete_event,ignores_a_zero_chunk_line,ignores_a_partial_in_progress_line}`.

`scripts/check_line_cap.sh`: `0 violations` — both new files under their
applicable cap (`swap_back_cycle_soak_tests.rs` matches the `*_tests.rs`
1500-SLOC test cap; `embedder_throughput_bench.rs` is under `tests/`, same
cap).

## Not done in this PR

- Real ort-vs-python throughput numbers (bench exists, gated `#[ignore]`,
  not executed here — see "Verified vs. unverified").
- Root-causing why the real-hardware kill-until-confirmed-death loop timed
  out on this run (affects both the pre-existing merged test and this PR's
  new ones) — worth a follow-up issue if it reproduces again.

Refs #3524

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
