### PR TITLE
fix(trusty-mpm): prevent + reconcile duplicate managed-session records for one worktree

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- **Duplicate/stale/crossed managed-session records for one worktree** (closes [#3396](https://github.com/bobmatnyc/trusty-tools/issues/3396)): `reconcile_on_boot`'s external-adopt loop minted a brand-new `SessionRecord` for any live tmux session unknown to the store BY NAME ALONE, never checking whether its resolved cwd already belonged to an existing, non-`Decommissioned` record — so a renamed/replaced tmux session fronting an already-managed worktree got a second, uncorrelated identity (the same defect class #3599 fixed for native-process discovery). The stale sibling's drifted `tmux_name` then made `session_send`/`session_proxy_message` falsely refuse delivery (`PaneGone`) even though the pane was alive under its new name. The external-adopt loop now skips adoption (logging the crossed mapping) when a live session's resolved workspace already has a tracked owner, and a new `plan_workspace_duplicates` pass in `dedup_stale_duplicates` reconciles duplicates already on disk from before this fix — grouping strictly by canonicalized `workspace_path` (independent of `plan_dedup`'s per-repository `source_id`/live-group rules, which correctly never touch this shape): an SM-owned record is never a loser, a live sibling always survives over a dead one, and two simultaneously-live records at one path are left for manual review rather than guessed at.
+
+---
 ## [0.20.0] — 2026-07-21
 
 ### Added

--- a/crates/trusty-mpm/src/session_manager/dedup.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup.rs
@@ -48,7 +48,7 @@
 
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use tracing::{info, warn};
 
@@ -86,7 +86,29 @@ impl SessionManager {
             .filter(|n| crate::core::names::is_managed_session_name(n))
             .collect();
         let records = self.store.write().await.all().await?;
-        let losers = plan_dedup(&records, &live_names);
+        let mut losers = plan_dedup(&records, &live_names);
+
+        // #3396: also collapse EXACT-workspace_path duplicates — two+
+        // non-Decommissioned records resolving to the literal SAME on-disk
+        // worktree. `plan_dedup` above deliberately never touches this shape
+        // (its `source_id` grouping is per-repository, and a
+        // resolved-existing member is categorically immune there — both
+        // correct for the LEGITIMATE concurrent-worktree case, which is why
+        // the #3396 duplicate persisted across every prior dedup pass). See
+        // `plan_workspace_duplicates`'s doc for why "same literal path" is
+        // safe to treat differently. Track which ids came from THIS mechanism
+        // so the belt-and-suspenders recheck below applies the right predicate
+        // to each.
+        let workspace_dup_losers: HashSet<ManagedSessionId> =
+            plan_workspace_duplicates(&records, &live_names)
+                .into_iter()
+                .collect();
+        for id in &workspace_dup_losers {
+            if !losers.contains(id) {
+                losers.push(*id);
+            }
+        }
+
         if losers.is_empty() {
             return Ok(losers);
         }
@@ -94,7 +116,7 @@ impl SessionManager {
         info!(
             count = losers.len(),
             ids = ?losers.iter().map(ManagedSessionId::to_string).collect::<Vec<_>>(),
-            "dedup: plan computed stale duplicate(s) to decommission (#2306)"
+            "dedup: plan computed stale duplicate(s) to decommission (#2306, #3396)"
         );
 
         // Never auto-resume a record we are about to decommission.
@@ -102,13 +124,9 @@ impl SessionManager {
 
         let mut decommissioned = Vec::new();
         for id in &losers {
-            // Belt-and-suspenders (#2306 review fix): re-fetch and rerun the
-            // EXACT safety predicate used during planning immediately before
-            // acting, guarding a TOCTOU race between the plan snapshot above
-            // and this decommission call. A loser is only ever planned when
-            // unresolved/dead; if its workspace_path now resolves to an
-            // existing directory, refuse to decommission rather than risk
-            // deleting live work.
+            // Belt-and-suspenders: re-fetch immediately before acting, guarding
+            // a TOCTOU race between the plan snapshot above and this
+            // decommission call.
             let current = match self.get(id).await {
                 Ok(r) => r,
                 Err(e) => {
@@ -116,7 +134,40 @@ impl SessionManager {
                     continue;
                 }
             };
-            if is_resolved_existing(&current) {
+            if workspace_dup_losers.contains(id) {
+                // #3396 recheck: an exact-workspace-duplicate loser is
+                // EXPECTED to be resolved-existing (that is the grouping key),
+                // so the #2306 predicate below does not apply here. Instead
+                // refuse when the record turned out to be SM-owned (deletion
+                // would risk `git worktree remove --force`ing real work — see
+                // `plan_workspace_duplicates`'s categorical owned-record
+                // exclusion, rechecked here against a TOCTOU) or when its OWN
+                // tmux session has since gone live (decommission kills the
+                // whole tmux session — never do that to a live one).
+                if current.workspace_owned {
+                    warn!(
+                        id = %id,
+                        "dedup: #3396 belt-and-suspenders skip — loser is SM-owned; \
+                         refusing to decommission"
+                    );
+                    continue;
+                }
+                if live_names.contains(&current.tmux_name) {
+                    warn!(
+                        id = %id,
+                        name = %current.tmux_name,
+                        "dedup: #3396 belt-and-suspenders skip — loser's tmux session is now \
+                         live; refusing to decommission an active session"
+                    );
+                    continue;
+                }
+            } else if is_resolved_existing(&current) {
+                // Belt-and-suspenders (#2306 review fix): re-run the EXACT
+                // safety predicate used during planning immediately before
+                // acting. A `plan_dedup` loser is only ever planned when
+                // unresolved/dead; if its workspace_path now resolves to an
+                // existing directory, refuse to decommission rather than risk
+                // deleting live work.
                 warn!(
                     id = %id,
                     workspace = ?current.workspace_path,
@@ -130,7 +181,7 @@ impl SessionManager {
                     info!(
                         id = %id,
                         name = %rec.tmux_name,
-                        "dedup: decommissioned stale duplicate session record (#2306)"
+                        "dedup: decommissioned stale duplicate session record (#2306, #3396)"
                     );
                     decommissioned.push(*id);
                 }
@@ -271,6 +322,130 @@ pub(crate) fn plan_dedup(
             // resolved-existing members themselves are left untouched — even
             // if there are 2+ of them (legitimate concurrent sessions).
             losers.extend(candidates.iter().map(|r| r.id));
+        }
+    }
+    losers
+}
+
+/// Plan losers among records that share the IDENTICAL, resolved-existing
+/// `workspace_path` (#3396).
+///
+/// Why: [`plan_dedup`]'s `source_id` grouping is per-REPOSITORY by design
+/// (see the module docs) — it deliberately never touches two
+/// resolved-existing records with DIFFERENT `workspace_path`s, because that
+/// shape is the legitimate concurrent-worktree-sessions case, and it treats
+/// ANY resolved-existing member as categorically immune regardless of group
+/// size. But two records pointing at the exact SAME `workspace_path` are
+/// never that: a single worktree directory hosts at most one live managed
+/// identity, so a group of 2+ non-`Decommissioned` records sharing one
+/// resolved-existing path is ALWAYS a duplicate-identity bug (#3396 — e.g. a
+/// live tmux session renamed/replaced out from under its record, then
+/// re-discovered and adopted under a different name against the same cwd by
+/// [`super::reconcile::SessionManager::reconcile_on_boot`]'s external-adopt
+/// loop, before that loop's own #3396 duplicate-prevention check existed).
+/// `plan_dedup`'s live-group guard ("skip the WHOLE group if ANY member is
+/// live") and its resolved-existing categorical immunity both, correctly,
+/// refuse to touch this shape — which is exactly why a #3396 stale duplicate
+/// persists across every `plan_dedup`-only pass. This function is the
+/// narrowly-scoped exact-path counterpart: it groups by canonicalized
+/// `workspace_path` alone (ignoring `source_id`), and — because "same
+/// directory" is unambiguous where "same repository" is not — is allowed to
+/// pick a survivor even when one member is currently live.
+/// What: groups non-`Decommissioned`, resolved-existing (per
+/// [`is_resolved_existing`]) records by canonicalized `workspace_path`, then
+/// for each group of 2+:
+/// - A `workspace_owned = true` member (the SM provisioned this directory
+///   itself, e.g. via clone) is NEVER a loser — categorical protection
+///   against ever risking a real, SM-owned repository, mirroring
+///   [`is_resolved_existing`]'s role in `plan_dedup`. Two-or-more owned
+///   members sharing one path should structurally never happen; rather than
+///   guess, that shape leaves the WHOLE group untouched.
+/// - Exactly one owned member: it is the automatic survivor, and every
+///   `workspace_owned = false` sibling whose `tmux_name` is currently DEAD is
+///   a loser (a live one is left alone too — never decommission a currently
+///   active session).
+/// - Zero owned members: the survivor is chosen among the unowned members —
+///   if exactly one has a live `tmux_name` it survives; if none are live, the
+///   most recently active/created one survives (mirrors `plan_dedup`'s
+///   /unknown tie-break); if two or more are simultaneously live, the group
+///   is left untouched — two genuinely-live panes pointed at the same
+///   directory is ambiguous enough that guessing a survivor risks tearing
+///   down a real session, so this defers to the operator rather than picking
+///   one.
+///
+/// A loser selected here therefore always has both `workspace_owned = false`
+/// (decommission never deletes the directory) and a currently-DEAD
+/// `tmux_name` (decommission never kills a live tmux session).
+/// Test: the `plan_workspace_duplicates_*` tests in `dedup_tests.rs`.
+pub(crate) fn plan_workspace_duplicates(
+    records: &[SessionRecord],
+    live_names: &HashSet<String>,
+) -> Vec<ManagedSessionId> {
+    let mut groups: HashMap<PathBuf, Vec<&SessionRecord>> = HashMap::new();
+    for record in records {
+        if matches!(record.state, ManagedSessionState::Decommissioned) {
+            continue;
+        }
+        if !is_resolved_existing(record) {
+            continue;
+        }
+        // is_resolved_existing() only returns true when workspace_path is
+        // Some, so this is always populated for a grouped record.
+        let Some(path) = record.workspace_path.as_ref() else {
+            continue;
+        };
+        let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+        groups.entry(canon).or_default().push(record);
+    }
+
+    let mut losers = Vec::new();
+    for members in groups.values() {
+        if members.len() < 2 {
+            continue;
+        }
+        let (owned, unowned): (Vec<&SessionRecord>, Vec<&SessionRecord>) =
+            members.iter().copied().partition(|r| r.workspace_owned);
+
+        if owned.len() >= 2 {
+            // 2+ SM-owned records for one literal path should never happen;
+            // do not guess which is "real" — leave the whole group alone.
+            continue;
+        }
+        if owned.len() == 1 {
+            // The owned record is the permanent survivor. Every unowned
+            // sibling that is NOT currently live is a duplicate of it.
+            losers.extend(
+                unowned
+                    .iter()
+                    .filter(|r| !live_names.contains(&r.tmux_name))
+                    .map(|r| r.id),
+            );
+            continue;
+        }
+
+        // owned.is_empty(): pick a survivor among the unowned members.
+        if unowned.len() < 2 {
+            continue;
+        }
+        let live_candidates: Vec<&SessionRecord> = unowned
+            .iter()
+            .copied()
+            .filter(|r| live_names.contains(&r.tmux_name))
+            .collect();
+        match live_candidates.len() {
+            0 => {
+                if let Some(survivor) = unowned.iter().copied().max_by(|a, b| by_recency(a, b)) {
+                    losers.extend(unowned.iter().filter(|r| r.id != survivor.id).map(|r| r.id));
+                }
+            }
+            1 => {
+                let survivor_id = live_candidates[0].id;
+                losers.extend(unowned.iter().filter(|r| r.id != survivor_id).map(|r| r.id));
+            }
+            _ => {
+                // 2+ simultaneously-live candidates for one directory: leave
+                // the whole group untouched (see doc above).
+            }
         }
     }
     losers

--- a/crates/trusty-mpm/src/session_manager/dedup_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/dedup_tests.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 use chrono::{Duration, Utc};
 use tempfile::TempDir;
 
-use super::dedup::{is_resolved_existing, plan_dedup};
+use super::dedup::{is_resolved_existing, plan_dedup, plan_workspace_duplicates};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::tests::FakeTmuxDriver;
 use crate::session_manager::SessionManager;
@@ -595,5 +595,368 @@ async fn reconcile_dedup_skips_live_group() {
         mgr.get(&stale_id).await.unwrap().state,
         ManagedSessionState::Decommissioned,
         "a group with a live member must NOT be deduped"
+    );
+}
+
+// ---------------------------------------------------------------------
+// `plan_workspace_duplicates` — exact-workspace_path collapsing (#3396).
+// ---------------------------------------------------------------------
+
+/// Mark a record built via [`rec`] as SM-owned (the workspace was
+/// provisioned by the SM itself, e.g. via clone).
+fn owned(mut r: SessionRecord) -> SessionRecord {
+    r.workspace_owned = true;
+    r
+}
+
+/// THE #3396 regression case: two non-`Decommissioned` records resolve to
+/// the LITERAL SAME existing workspace directory. One's `tmux_name` is live,
+/// the other's is not (its tmux session was renamed/replaced out from under
+/// it). `plan_dedup` alone (proven by `plan_dedup_live_group_untouched`
+/// above, whose live-group guard skips the WHOLE group when ANY member is
+/// live) would never collapse this — that is exactly why the duplicate
+/// persisted in #3396. `plan_workspace_duplicates` must recognise "same
+/// literal path" as unambiguous and decommission the dead sibling while
+/// keeping the live one.
+/// Test: this function IS the test.
+#[test]
+fn plan_workspace_duplicates_collapses_dead_sibling_of_live_record() {
+    let dir = TempDir::new().unwrap();
+    let live = rec(
+        "tm-tcode-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Active,
+        1,
+    );
+    let stale = rec(
+        "tm-tm-tcode-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        50, // more recently "active" per the record, but must not matter —
+            // the live tmux_name always wins over recency.
+    );
+    let live_id = live.id;
+    let stale_id = stale.id;
+    let mut live_names = HashSet::new();
+    live_names.insert("tm-tcode-01".to_string());
+
+    let losers = plan_workspace_duplicates(&[live, stale], &live_names);
+    assert_eq!(
+        losers,
+        vec![stale_id],
+        "the dead-tmux_name sibling at the same literal path must be the loser"
+    );
+    assert!(!losers.contains(&live_id), "the live record must survive");
+}
+
+/// Two records at the same literal path, NEITHER currently live: the most
+/// recently active/created one survives (mirrors `plan_dedup`'s /unknown
+/// tie-break), the other is the loser.
+/// Test: this function IS the test.
+#[test]
+fn plan_workspace_duplicates_picks_most_recent_when_none_live() {
+    let dir = TempDir::new().unwrap();
+    let older = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    );
+    let newer = rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        99,
+    );
+    let older_id = older.id;
+    let newer_id = newer.id;
+
+    let losers = plan_workspace_duplicates(&[older, newer], &HashSet::new());
+    assert_eq!(losers, vec![older_id], "the older record must be the loser");
+    assert!(!losers.contains(&newer_id));
+}
+
+/// Two records at the same literal path, BOTH currently live: genuinely
+/// ambiguous (two live panes in one directory) — must NOT auto-collapse,
+/// since guessing a survivor risks tearing down a real, active session.
+/// Test: this function IS the test.
+#[test]
+fn plan_workspace_duplicates_leaves_two_live_records_untouched() {
+    let dir = TempDir::new().unwrap();
+    let a = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Active,
+        1,
+    );
+    let b = rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Active,
+        99,
+    );
+    let mut live_names = HashSet::new();
+    live_names.insert("tm-proj-01".to_string());
+    live_names.insert("tm-proj-02".to_string());
+
+    let losers = plan_workspace_duplicates(&[a, b], &live_names);
+    assert!(
+        losers.is_empty(),
+        "two simultaneously-live records at one path must be left for the operator: {losers:?}"
+    );
+}
+
+/// An SM-owned record can NEVER be a loser, even when a dead unowned
+/// duplicate shares its literal workspace path — the owned record is the
+/// permanent survivor and the dead unowned sibling is decommissioned.
+/// Test: this function IS the test.
+#[test]
+fn plan_workspace_duplicates_owned_record_is_permanent_survivor() {
+    let dir = TempDir::new().unwrap();
+    let canonical = owned(rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    ));
+    let phantom = rec(
+        "tm-tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        99, // more recent — must not matter, ownership always wins.
+    );
+    let canonical_id = canonical.id;
+    let phantom_id = phantom.id;
+
+    let losers = plan_workspace_duplicates(&[canonical, phantom], &HashSet::new());
+    assert_eq!(
+        losers,
+        vec![phantom_id],
+        "the unowned duplicate must be the loser"
+    );
+    assert!(
+        !losers.contains(&canonical_id),
+        "the SM-owned record must never be a loser"
+    );
+}
+
+/// An SM-owned record's duplicate is left alone while its `tmux_name` is
+/// live — never decommission (and thereby kill the tmux session of) a
+/// currently-active duplicate, even one that will eventually need manual
+/// cleanup.
+/// Test: this function IS the test.
+#[test]
+fn plan_workspace_duplicates_owned_record_never_kills_live_duplicate() {
+    let dir = TempDir::new().unwrap();
+    let canonical = owned(rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    ));
+    let live_dupe = rec(
+        "tm-tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Active,
+        99,
+    );
+    let mut live_names = HashSet::new();
+    live_names.insert("tm-tm-proj-01".to_string());
+
+    let losers = plan_workspace_duplicates(&[canonical, live_dupe], &live_names);
+    assert!(
+        losers.is_empty(),
+        "a live duplicate must never be decommissioned, even alongside an owned record: {losers:?}"
+    );
+}
+
+/// Two DIFFERENT SM-owned records sharing one literal path should never
+/// structurally happen; rather than guess which is "real", the whole group
+/// is left untouched.
+/// Test: this function IS the test.
+#[test]
+fn plan_workspace_duplicates_two_owned_records_untouched() {
+    let dir = TempDir::new().unwrap();
+    let a = owned(rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    ));
+    let b = owned(rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        99,
+    ));
+    let losers = plan_workspace_duplicates(&[a, b], &HashSet::new());
+    assert!(
+        losers.is_empty(),
+        "two owned records at one path must never be auto-collapsed: {losers:?}"
+    );
+}
+
+/// Records at DISTINCT workspace paths are never grouped, even sharing one
+/// `source_id` — sanity check that grouping keys on the literal path, not
+/// something coarser.
+/// Test: this function IS the test.
+#[test]
+fn plan_workspace_duplicates_distinct_paths_untouched() {
+    let dir_a = TempDir::new().unwrap();
+    let dir_b = TempDir::new().unwrap();
+    let a = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir_a.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    );
+    let b = rec(
+        "tm-proj-02",
+        Some("proj"),
+        Some(&dir_b.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        99,
+    );
+    let losers = plan_workspace_duplicates(&[a, b], &HashSet::new());
+    assert!(
+        losers.is_empty(),
+        "distinct paths must never be grouped: {losers:?}"
+    );
+}
+
+/// A single record at a path is never a duplicate.
+/// Test: this function IS the test.
+#[test]
+fn plan_workspace_duplicates_singleton_untouched() {
+    let dir = TempDir::new().unwrap();
+    let only = rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    );
+    assert!(plan_workspace_duplicates(&[only], &HashSet::new()).is_empty());
+}
+
+// ---------------------------------------------------------------------
+// `reconcile_on_boot` — end-to-end wiring for exact-workspace duplicates.
+// ---------------------------------------------------------------------
+
+/// End-to-end #3396 regression: reconcile collapses a dead duplicate at the
+/// SAME literal workspace path as a currently-live record — the exact shape
+/// `plan_dedup`'s live-group guard leaves untouched forever (proven by
+/// `reconcile_dedup_skips_live_group` above), which is why the #3396
+/// duplicate persisted across every prior reconcile pass.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reconcile_dedup_collapses_exact_workspace_duplicate_of_live_record() {
+    let dir = TempDir::new().unwrap();
+    let ws_dir = TempDir::new().unwrap();
+    let fake = FakeTmuxDriver::new();
+    fake.seeded_names.lock().unwrap().push("tm-tcode-01".into());
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let live = rec(
+        "tm-tcode-01",
+        Some("proj"),
+        Some(&ws_dir.path().to_path_buf()),
+        ManagedSessionState::Active,
+        1,
+    );
+    let stale = rec(
+        "tm-tm-tcode-01",
+        Some("proj"),
+        Some(&ws_dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        50,
+    );
+    let live_id = live.id;
+    let stale_id = stale.id;
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(live).await.unwrap();
+        store.upsert(stale).await.unwrap();
+    }
+
+    mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert_eq!(
+        mgr.get(&stale_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "the stale duplicate at the same literal path must be decommissioned"
+    );
+    assert_ne!(
+        mgr.get(&live_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "the live record must survive"
+    );
+    assert!(
+        ws_dir.path().exists(),
+        "the workspace directory must remain on disk (loser was never SM-owned)"
+    );
+}
+
+/// End-to-end: an SM-owned record's dead duplicate at the same literal path
+/// is decommissioned by reconcile, but the owned record and its on-disk
+/// workspace are never touched.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reconcile_dedup_collapses_dead_duplicate_of_owned_record() {
+    let dir = TempDir::new().unwrap();
+    let ws_dir = TempDir::new().unwrap();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let canonical = owned(rec(
+        "tm-proj-01",
+        Some("proj"),
+        Some(&ws_dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        1,
+    ));
+    let phantom = rec(
+        "tm-tm-proj-01",
+        Some("proj"),
+        Some(&ws_dir.path().to_path_buf()),
+        ManagedSessionState::Stopped,
+        99,
+    );
+    let canonical_id = canonical.id;
+    let phantom_id = phantom.id;
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(canonical).await.unwrap();
+        store.upsert(phantom).await.unwrap();
+    }
+
+    mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert_eq!(
+        mgr.get(&phantom_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "the unowned phantom duplicate must be decommissioned"
+    );
+    assert_ne!(
+        mgr.get(&canonical_id).await.unwrap().state,
+        ManagedSessionState::Decommissioned,
+        "the SM-owned record must never be decommissioned by dedup"
+    );
+    assert!(
+        ws_dir.path().exists(),
+        "the owned workspace directory must remain on disk"
     );
 }

--- a/crates/trusty-mpm/src/session_manager/naming_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/naming_tests.rs
@@ -300,3 +300,88 @@ async fn reconcile_flags_unresolvable_adopted_session_as_unmanaged() {
         adopted.task
     );
 }
+
+/// #3396 regression: a LIVE tmux session unknown to the store by NAME must
+/// NOT be externally-adopted as a second identity when its resolved pane cwd
+/// is the SAME literal workspace an EXISTING, non-`Decommissioned` record
+/// already tracks.
+///
+/// Why: this is the duplicate-record defect's creation path — a tmux session
+/// renamed (or replaced) out from under its original managed record, then
+/// rediscovered by `reconcile_on_boot`'s external-adopt loop under its new
+/// live name, minted a completely separate `SessionRecord` for the exact same
+/// worktree because the loop only ever checked `tmux_name` membership, never
+/// the resolved workspace path against records the store already tracks —
+/// the same class of bug `decide_native_registration` (#3599) fixed for the
+/// native-process discovery path. The fix must skip adoption instead of
+/// minting a duplicate.
+/// What: seeds a `Stopped` record for `workspace` under tmux_name
+/// `tm-known-01` (NOT live), then runs reconcile with a live tmux session
+/// `tm-crossed-01` (a different name, unknown to the store) whose pane cwd
+/// resolves to the SAME `workspace` directory. Asserts: no second record was
+/// minted (`mgr.list()` still has exactly one entry), and `tm-crossed-01`
+/// never appears in `report.external_adopted`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reconcile_skips_external_adopt_when_workspace_already_tracked() {
+    let dir = TempDir::new().unwrap();
+    let workspace = TempDir::new().unwrap();
+    let fake = std::sync::Arc::new(PaneCwdTmux {
+        alive: vec!["tm-crossed-01".into()],
+        pane_cwd: Some(workspace.path().to_path_buf()),
+    });
+
+    let mgr = SessionManager::new(dir.path(), fake).await.unwrap();
+    let existing = super::record::SessionRecord {
+        id: super::record::ManagedSessionId::new(),
+        tmux_name: "tm-known-01".into(),
+        cwd: workspace.path().to_path_buf(),
+        task: "existing task".into(),
+        state: ManagedSessionState::Stopped,
+        created_at: chrono::Utc::now(),
+        last_activity_at: None,
+        workspace_path: Some(workspace.path().to_path_buf()),
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: false,
+        workspace_owned: false,
+        source_id: None,
+        claude_session_id: None,
+        scrollback_path: None,
+        last_cwd: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: Default::default(),
+    };
+    let existing_id = existing.id;
+    mgr.store.write().await.upsert(existing).await.unwrap();
+
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    assert!(
+        !report
+            .external_adopted
+            .contains(&"tm-crossed-01".to_string()),
+        "a live session resolving to an already-tracked workspace must never be \
+         externally adopted; report: {report:?}"
+    );
+
+    let listed = mgr.list().await;
+    assert_eq!(
+        listed.len(),
+        1,
+        "no second record must be minted for the same workspace; records: {listed:?}"
+    );
+    assert_eq!(
+        listed[0].id, existing_id,
+        "the original record must be the only one"
+    );
+    assert!(
+        !listed.iter().any(|r| r.tmux_name == "tm-crossed-01"),
+        "no record must carry the crossed tmux_name"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -14,7 +14,7 @@
 //! Test: `manager_reconcile_gone_tmux_yields_stopped`,
 //! `manager_reconcile_adopts_new_prefix_session` in `tests.rs`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::Utc;
 use tracing::{info, warn};
@@ -93,6 +93,24 @@ impl SessionManager {
             guard.upsert(record).await?;
         }
 
+        // Canonical workspace paths already tracked by a non-terminal record
+        // (#3396): the external-adopt loop below must never mint a SECOND
+        // identity for a worktree an existing record already owns, mirroring
+        // the fix `decide_native_registration` (#3599) applied to the
+        // native-process discovery path. Built from the FRESH post-reconcile
+        // state (the per-record loop above already re-upserted every live/gone
+        // transition through `guard`), so a record whose tmux session just
+        // went live this pass is included too.
+        let known_workspaces: std::collections::HashSet<PathBuf> = guard
+            .all()
+            .await?
+            .iter()
+            .filter(|r| !matches!(r.state, ManagedSessionState::Decommissioned))
+            .filter_map(|r| r.workspace_path.clone())
+            .filter(|p| p.as_path() != Path::new("/unknown"))
+            .map(|p| std::fs::canonicalize(&p).unwrap_or(p))
+            .collect();
+
         // Adopt tmux sessions the store has never seen. Issue #2158: an
         // adopted session must never be left as a silent half-record with
         // cwd/workspace_path permanently stubbed to "/unknown" — re-resolve
@@ -105,6 +123,28 @@ impl SessionManager {
         for name in &live_names {
             if !known_names.contains(name) {
                 let resolved_cwd = self.tmux.get_pane_cwd(name).filter(|p| p.is_dir());
+                // #3396: a live tmux session unknown BY NAME can still resolve
+                // to a workspace an EXISTING record already tracks — e.g. a
+                // renamed/second tmux session fronting the same worktree.
+                // Minting a second record here is exactly the duplicate-record
+                // defect; skip adoption and surface the crossed mapping loudly
+                // instead so an operator can reconcile the tmux_name drift
+                // (`tm sessions ls`, `tmux list-panes`) rather than the daemon
+                // silently doubling the identity.
+                if let Some(path) = &resolved_cwd {
+                    let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+                    if known_workspaces.contains(&canon) {
+                        warn!(
+                            name = %name,
+                            workspace = %path.display(),
+                            "reconcile: skipping external-adopt — live tmux session resolves to \
+                             a workspace already tracked by another managed session record; its \
+                             tmux_name may be stale/crossed (#3396) — investigate with `tm sessions \
+                             ls` and `tmux list-panes` rather than auto-adopting a duplicate"
+                        );
+                        continue;
+                    }
+                }
                 let (cwd, workspace_path, task) = match &resolved_cwd {
                     Some(path) => (
                         path.clone(),


### PR DESCRIPTION
## Summary

Closes #3396 — the daemon could hold TWO managed-session records for the SAME worktree, with the stale one's `tmux_name` drifted from reality, causing `session_send`/`session_proxy_message` to falsely refuse delivery (`PaneGone`) to a session whose pane was actually alive.

## Root cause

1. **Duplicate creation**: `reconcile_on_boot`'s external-adopt loop (`session_manager/reconcile.rs`) minted a brand-new `SessionRecord` for any live tmux session unknown to the store **by name alone**, never checking whether its resolved `cwd` already belonged to an existing, non-`Decommissioned` record. A tmux session renamed/replaced out from under its original record (or a second session opened against the same worktree under a different name) got a second, uncorrelated identity. Same defect class as #3599 (`decide_native_registration`'s `managed_cwds` check), but on the tmux-reconcile path rather than native-process discovery.
2. **Symptom**: `ensure_pane_alive`/`pane_exists` (`session_manager/manager.rs`) correctly scopes its liveness check to `list-panes -t <record.tmux_name>` (by design, to prevent the sibling-window-hijack #2456/#2467/#2468 fixed). Once a record's `tmux_name` has drifted from the pane's actual current session, this reports the pane "gone" even though it's alive elsewhere — this is *correct* behavior once records are canonical, not something to weaken.
3. **Why existing dedup didn't clean it up**: `plan_dedup` (#2306) groups by `source_id` (per-repository) and (a) skips a whole group if any member is currently live, (b) treats any resolved-existing `workspace_path` as categorically immune — both correct, to protect legitimate concurrent worktree sessions of one repo. But two records sharing the **exact same** `workspace_path` (never a legitimate shape) fall through both protections and are never collapsed.

## Fix

- `reconcile_on_boot`'s external-adopt loop now checks the resolved cwd of a newly-discovered live tmux session against the canonicalized `workspace_path`/`cwd` of every existing non-`Decommissioned` record before minting; if already tracked, adoption is skipped with a `warn!` identifying the crossed tmux name instead of silently doubling the identity.
- New `plan_workspace_duplicates` in `dedup.rs`, wired into `dedup_stale_duplicates`, adds a narrowly-scoped exact-`workspace_path` collapsing pass (independent of `source_id`/live-group grouping) so **existing** on-disk duplicates get reconciled on the next daemon boot:
  - an SM-owned (`workspace_owned=true`) record is never a loser (never risk `git worktree remove --force`ing real work);
  - among the rest, a currently-live sibling always survives over a dead one;
  - recency breaks ties when none are live;
  - two simultaneously-live records at the same path are left untouched for manual operator review (never guess which "real" session to kill).
  - A loser selected by this mechanism is therefore always both unowned and currently tmux-dead — decommissioning it never deletes a real directory and never kills a live session.

This composes with, and does not duplicate or contradict, the already-merged #3599 (native-process discovery `managed_cwds` check) and #3604 (pane-identity cross-check for rename/pm_guard) — all three close different call paths onto the same "never trust a stale/uncorrelated identity" principle.

## Test plan

- [x] `cargo test -p trusty-mpm` (full suite, integration tests included) — all green, 0 failed
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] New regression tests:
  - `naming_tests::reconcile_skips_external_adopt_when_workspace_already_tracked` (duplicate-prevention on the canonical workspace key)
  - `dedup_tests::plan_workspace_duplicates_*` (8 pure-planner cases: dead-sibling-of-live collapse, recency tie-break, two-live ambiguity left alone, owned-record permanent-survivor + never-kills-live-duplicate + two-owned-untouched, distinct-paths untouched, singleton untouched)
  - `dedup_tests::reconcile_dedup_collapses_exact_workspace_duplicate_of_live_record` / `reconcile_dedup_collapses_dead_duplicate_of_owned_record` (end-to-end through `reconcile_on_boot`)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools