### PR TITLE
fix(trusty-search): eliminate stack-overflow crash in chunker/entity AST walk (#3537)

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -23,6 +23,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   the sole, permanent per-invocation escape hatch back to the unchanged ort
   path on Apple Silicon.
 
+### Fixed
+
+- **Daemon stack-overflow crash from deep recursion in the AST chunker/entity
+  walk (issue #3537).** `walk_for_chunks` (`core/chunker/walk.rs`) and
+  `walk_rust` (`core/entity.rs`) were native recursive descents whose stack
+  depth tracked raw tree-sitter parse-tree depth — attacker-influenced, since
+  it comes directly from file content being indexed. A deeply nested
+  global-scope construct (e.g. deeply templated C++ headers, or any deeply
+  nested expression/type outside a function body, which is already pruned)
+  could exceed the process stack and abort the whole daemon with `fatal
+  runtime error: stack overflow`, taking every other index down with it.
+  Both walks are now iterative (explicit heap-allocated work stack, matching
+  the pattern `collect_calls` already used), which removes the crash
+  regardless of nesting depth, plus a bounded max-walk-depth guard (logged,
+  not silent) so a single pathological file degrades to "partially chunked"
+  rather than either crashing or — since `classify_node`'s per-node
+  `Node::parent()` lookups are not O(1) — hanging the indexing worker on
+  superlinear traversal cost.
+
 ## [0.37.2] — 2026-07-21
 
 Patch release closing unpublished source drift under the already-published

--- a/crates/trusty-search/src/core/chunker/tests.rs
+++ b/crates/trusty-search/src/core/chunker/tests.rs
@@ -1132,3 +1132,92 @@ fn test_rust_symbol_graph_resolves_caller() {
         "expected alpha among callers of beta, got {callers:?}"
     );
 }
+
+/// Regression test for issue #3537: a deeply nested, non-chunk-producing
+/// global-scope expression must not stack-overflow the chunker.
+///
+/// Why: `walk_for_chunks` used to be a native recursive descent whose stack
+/// depth tracked raw AST depth. A global-scope declaration containing a
+/// deeply parenthesized expression (the reported shape: "extreme nesting
+/// depth" in deeply templated/generated headers) is never pruned the way a
+/// function *body* is, so it drove unbounded recursion and crashed the whole
+/// daemon process with `fatal runtime error: stack overflow`. Confirmed via
+/// an out-of-tree repro before this fix: the exact same construction (scaled
+/// up to 200,000 levels) reliably aborted the process with SIGABRT.
+/// What: 50,000 levels of nested parens is two orders of magnitude past the
+/// walker's internal depth ceiling and far beyond anything the previous
+/// recursive implementation could survive on a normal thread stack — if this
+/// test completes at all (rather than aborting the whole `cargo test`
+/// process), the fix holds.
+/// Test: this is the test — asserts `chunk_ast` returns normally (a single
+/// fallback chunk, since nothing in a bare expression is chunk-classified)
+/// instead of crashing.
+#[test]
+fn test_deeply_nested_expression_does_not_crash() {
+    const DEPTH: usize = 50_000;
+    let mut src = String::from("const X: i32 = ");
+    src.push_str(&"(".repeat(DEPTH));
+    src.push('1');
+    src.push_str(&")".repeat(DEPTH));
+    src.push_str(";\n");
+
+    let (chunks, _entities) = chunk_ast("deeply_nested.rs", &src);
+
+    // Nothing in a bare parenthesized expression is chunk-classified, so
+    // this falls back to a single generic chunk covering the whole file.
+    assert_eq!(
+        chunks.len(),
+        1,
+        "expected the single-file fallback chunk, got {} chunks",
+        chunks.len()
+    );
+}
+
+/// Regression test for issue #3537: deeply nested *classified* containers
+/// (the `walk_for_chunks` branch that recurses into impl/class/module
+/// bodies) must not stack-overflow the chunker either.
+///
+/// Why: unlike the unclassified-node branch covered by
+/// `test_deeply_nested_expression_does_not_crash`, this branch increments
+/// `chunk_depth` and additionally calls `collect_calls`/`collect_inherits`
+/// per classified node — both of which perform their own subtree walk. A
+/// long chain of nested containers (e.g. `mod a { mod a { … } }`) exercises
+/// a different, previously-quadratic cost path (each classified node's
+/// `collect_calls` call re-walking its full remaining subtree) that the
+/// depth ceiling on the outer walk alone does not bound; `collect_calls`
+/// itself needed a matching depth cap to keep this bounded.
+/// What: 50,000 nested `mod` blocks — completes quickly and returns a
+/// bounded chunk count (capped by the walker's internal depth ceiling)
+/// rather than either crashing or taking superlinear time.
+/// Test: this is the test.
+#[test]
+fn test_deeply_nested_modules_does_not_crash() {
+    const DEPTH: usize = 50_000;
+    let mut src = String::new();
+    src.push_str(&"mod a{".repeat(DEPTH));
+    src.push_str("fn f(){}");
+    src.push_str(&"}".repeat(DEPTH));
+
+    let (chunks, entities) = chunk_ast("deeply_nested_mods.rs", &src);
+
+    // Chunk count is bounded by the walker's internal depth ceiling, not by
+    // DEPTH — the key assertion is simply that this returns at all (rather
+    // than crashing) and stays well under DEPTH, proving the walk was
+    // truncated rather than paying O(DEPTH) or worse.
+    assert!(
+        !chunks.is_empty(),
+        "expected at least the outermost mod chunks to be emitted"
+    );
+    assert!(
+        chunks.len() < DEPTH,
+        "expected the walk to be depth-capped well below {DEPTH}, got {} chunks",
+        chunks.len()
+    );
+    // Entity extraction (`walk_rust` in `core/entity.rs`) shares the same
+    // failure mode and the same depth cap; it must also stay bounded.
+    assert!(
+        entities.len() < DEPTH,
+        "expected entity extraction to be depth-capped well below {DEPTH}, got {} entities",
+        entities.len()
+    );
+}

--- a/crates/trusty-search/src/core/chunker/walk.rs
+++ b/crates/trusty-search/src/core/chunker/walk.rs
@@ -69,10 +69,25 @@ pub(super) fn make_chunk_id(
 /// Collect call expressions reachable inside `node` without descending into
 /// nested function/method bodies (so a parent function doesn't claim its
 /// inner-fn's calls).
+///
+/// Depth-capped at `MAX_WALK_DEPTH` relative to `node` (not just iterative —
+/// see `walk_for_chunks` for why iteration alone isn't sufficient here):
+/// `walk_for_chunks` classifies at most `MAX_WALK_DEPTH` container nodes
+/// (mod/impl/class/…) per file, but each classified node triggers its own
+/// call to `collect_calls`, which — uncapped — would re-walk that node's
+/// *entire remaining subtree*. For a pathological chain of nested
+/// containers (e.g. thousands of nested `mod` blocks) that's
+/// O(MAX_WALK_DEPTH * subtree size) work, i.e. still effectively quadratic
+/// in the nesting depth even though the outer walk is bounded. Capping this
+/// walk's own depth keeps total per-file cost bounded by a constant
+/// regardless of how deeply the input nests (issue #3537).
 pub(super) fn collect_calls(node: Node<'_>, src: &[u8], lang: &str) -> Vec<String> {
     let mut out: HashSet<String> = HashSet::new();
-    let mut stack: Vec<Node> = vec![node];
-    while let Some(n) = stack.pop() {
+    let mut stack: Vec<(Node, usize)> = vec![(node, 0)];
+    while let Some((n, depth)) = stack.pop() {
+        if depth > MAX_WALK_DEPTH {
+            continue;
+        }
         let kind = n.kind();
         let is_fn_kind = matches!(
             (lang, kind),
@@ -149,7 +164,7 @@ pub(super) fn collect_calls(node: Node<'_>, src: &[u8], lang: &str) -> Vec<Strin
 
         let mut cursor = n.walk();
         for child in n.children(&mut cursor) {
-            stack.push(child);
+            stack.push((child, depth + 1));
         }
     }
     let mut v: Vec<String> = out.into_iter().collect();
@@ -281,9 +296,46 @@ fn is_function_body_node(kind: &str) -> bool {
     )
 }
 
-/// Recursive tree walk that emits one `RawChunk` per classified node.
+/// Ceiling on raw tree-sitter AST depth (distinct from `chunk_depth`, which
+/// only increments for *classified* container nodes — see below). Past this,
+/// a subtree stops being descended into and the file is logged as truncated
+/// rather than continuing to pay the cost of walking arbitrarily deep,
+/// pathological structure.
+///
+/// Why this exists in addition to the iterative rewrite: converting the walk
+/// to iteration removes the stack-overflow crash (issue #3537) regardless of
+/// depth, but `classify_node` calls `Node::parent()` on every visited node,
+/// and tree-sitter's `parent()` is not O(1) — it re-derives ancestry from the
+/// tree, so it costs roughly O(depth). Visiting every node of an
+/// N-deep pathological chain then costs O(N) calls at up to O(N) each, i.e.
+/// O(N^2) total — confirmed experimentally (a synthetic 5,000-deep nested
+/// expression took 16s+ of wall time despite tree-sitter *parsing* the same
+/// input in ~20ms). That's a real world hang, not just a theoretical one, for
+/// the "deeply templated headers" / deeply nested generated-code shape this
+/// issue describes. The depth cap bounds that cost to a constant regardless
+/// of how deep the input actually nests.
+///
+/// 1000 is comfortably past any legitimate nesting seen in real code (deeply
+/// nested closures/match arms/blocks rarely exceed a few dozen levels) while
+/// keeping worst-case per-file walk cost small and constant.
+const MAX_WALK_DEPTH: usize = 1000;
+
+/// Tree walk that emits one `RawChunk` per classified node.
+///
+/// Iterative (explicit heap-allocated work stack) rather than recursive: the
+/// walk depth tracks the tree-sitter parse-tree depth, which is attacker
+/// influenced (it comes directly from file content being indexed). A native
+/// recursive descent here could blow the process stack on pathological input
+/// — e.g. deeply nested template arguments or a deeply parenthesized
+/// global-scope expression in a generated/templated C++ header — and crash
+/// the whole daemon, not just the one file being indexed (issue #3537).
+/// Mirrors the explicit-stack pattern `collect_calls` already uses in this
+/// file, and removes the failure mode entirely rather than merely raising
+/// the stack-size ceiling. Combined with `MAX_WALK_DEPTH` above so a
+/// pathological file degrades to "partially chunked, logged" rather than
+/// either crashing or hanging the indexing worker.
 pub(super) fn walk_for_chunks(
-    node: Node<'_>,
+    root: Node<'_>,
     src: &[u8],
     file: &str,
     lang: &str,
@@ -291,57 +343,90 @@ pub(super) fn walk_for_chunks(
     depth: usize,
     out: &mut Vec<RawChunk>,
 ) {
-    // Try to classify this node.
-    if let Some(chunk_type) = classify_node(lang, node) {
-        let start_byte = node.start_byte();
-        let end_byte = node.end_byte();
-        let start_line = line_for_byte(line_offsets, start_byte);
-        let end_line = line_for_byte(line_offsets, end_byte.saturating_sub(1));
-        let content = std::str::from_utf8(&src[start_byte..end_byte])
-            .unwrap_or("")
-            .to_string();
-        let name = qualify_method_name(lang, &chunk_type, node, src, name_of(node, src));
+    // (node, chunk_depth-for-this-node, raw AST depth from `root`).
+    // `chunk_depth` only increments when descending into a *classified*
+    // container (see push sites below) — it does not bound raw AST depth for
+    // long chains of unclassified nodes (e.g. a deeply parenthesized
+    // expression), which is exactly the shape that originally crashed the
+    // daemon. `raw_depth` tracks true tree depth unconditionally and is what
+    // `MAX_WALK_DEPTH` is checked against.
+    //
+    // Children are pushed in reverse order so the leftmost child is popped
+    // (and therefore fully processed, including its own descendants) first —
+    // this reproduces the same pre-order, left-to-right emission sequence
+    // the original recursive walk produced.
+    let mut stack: Vec<(Node<'_>, usize, usize)> = vec![(root, depth, 0)];
+    let mut depth_capped = false;
 
-        let calls = collect_calls(node, src, lang);
-        let inherits_from = collect_inherits(node, src, lang);
-        let doc = preceding_doc_comments(node, src);
-        let (nlp_keywords, nlp_code_refs) = nlp_from_doc(&doc);
-
-        let id = make_chunk_id(file, &chunk_type, &name, start_line, end_line);
-        out.push(RawChunk {
-            id,
-            file: file.to_string(),
-            start_line,
-            end_line,
-            content,
-            function_name: if name.is_empty() { None } else { Some(name) },
-            language: Some(lang.to_string()),
-            chunk_type,
-            calls,
-            inherits_from,
-            chunk_depth: depth,
-            parent_chunk_id: None,
-            child_chunk_ids: Vec::new(),
-            nlp_keywords,
-            nlp_code_refs,
-            virtual_terms: Vec::new(),
-        });
-
-        // Descend into impl/class/module to capture their methods/inner items,
-        // but don't recurse into function/method bodies (no inner-fn chunks).
-        if !is_function_body_node(node.kind()) {
-            let mut cursor = node.walk();
-            for child in node.children(&mut cursor) {
-                walk_for_chunks(child, src, file, lang, line_offsets, depth + 1, out);
+    while let Some((node, depth, raw_depth)) = stack.pop() {
+        if raw_depth > MAX_WALK_DEPTH {
+            if !depth_capped {
+                depth_capped = true;
+                tracing::warn!(
+                    file,
+                    max_depth = MAX_WALK_DEPTH,
+                    "chunker: AST nesting exceeds max walk depth; chunking was \
+                     truncated past this depth for this file (issue #3537 guard)"
+                );
             }
+            continue;
         }
-        return;
-    }
 
-    // Not a chunk-producing node: continue walking.
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_for_chunks(child, src, file, lang, line_offsets, depth, out);
+        // Try to classify this node.
+        if let Some(chunk_type) = classify_node(lang, node) {
+            let start_byte = node.start_byte();
+            let end_byte = node.end_byte();
+            let start_line = line_for_byte(line_offsets, start_byte);
+            let end_line = line_for_byte(line_offsets, end_byte.saturating_sub(1));
+            let content = std::str::from_utf8(&src[start_byte..end_byte])
+                .unwrap_or("")
+                .to_string();
+            let name = qualify_method_name(lang, &chunk_type, node, src, name_of(node, src));
+
+            let calls = collect_calls(node, src, lang);
+            let inherits_from = collect_inherits(node, src, lang);
+            let doc = preceding_doc_comments(node, src);
+            let (nlp_keywords, nlp_code_refs) = nlp_from_doc(&doc);
+
+            let id = make_chunk_id(file, &chunk_type, &name, start_line, end_line);
+            out.push(RawChunk {
+                id,
+                file: file.to_string(),
+                start_line,
+                end_line,
+                content,
+                function_name: if name.is_empty() { None } else { Some(name) },
+                language: Some(lang.to_string()),
+                chunk_type,
+                calls,
+                inherits_from,
+                chunk_depth: depth,
+                parent_chunk_id: None,
+                child_chunk_ids: Vec::new(),
+                nlp_keywords,
+                nlp_code_refs,
+                virtual_terms: Vec::new(),
+            });
+
+            // Descend into impl/class/module to capture their methods/inner
+            // items, but don't recurse into function/method bodies (no
+            // inner-fn chunks).
+            if !is_function_body_node(node.kind()) {
+                let mut cursor = node.walk();
+                let children: Vec<Node<'_>> = node.children(&mut cursor).collect();
+                for child in children.into_iter().rev() {
+                    stack.push((child, depth + 1, raw_depth + 1));
+                }
+            }
+            continue;
+        }
+
+        // Not a chunk-producing node: continue walking at the same chunk_depth.
+        let mut cursor = node.walk();
+        let children: Vec<Node<'_>> = node.children(&mut cursor).collect();
+        for child in children.into_iter().rev() {
+            stack.push((child, depth, raw_depth + 1));
+        }
     }
 }
 

--- a/crates/trusty-search/src/core/entity.rs
+++ b/crates/trusty-search/src/core/entity.rs
@@ -154,39 +154,108 @@ fn extract_rust(tree: &Tree, src: &[u8], file: &str) -> Vec<RawEntity> {
     out
 }
 
-fn walk_rust(node: Node<'_>, src: &[u8], file: &str, in_test_fn: bool, out: &mut Vec<RawEntity>) {
-    let kind = node.kind();
-    let line = node.start_position().row + 1;
-    let span = (node.start_byte(), node.end_byte());
+/// Ceiling on raw AST depth for the entity walk. Mirrors `MAX_WALK_DEPTH` in
+/// `chunker/walk.rs` (kept as a separate constant since `walk` is private to
+/// the `chunker` module) — bounds worst-case entity-list size and traversal
+/// cost for pathologically deep input rather than growing unboundedly with
+/// nesting depth (issue #3537).
+const MAX_WALK_DEPTH: usize = 1000;
 
-    match kind {
-        "type_identifier" => {
-            let t = node_text(node, src);
-            if !t.is_empty() {
-                out.push(RawEntity::new(EntityType::NamedType, t, span, file, line));
+/// Iterative (explicit heap-allocated work stack) rather than recursive: see
+/// `walk_for_chunks` in `chunker/walk.rs` for the rationale — walk depth
+/// tracks tree-sitter parse-tree depth, which is attacker influenced, so a
+/// native recursive descent here is the same unbounded-stack failure mode
+/// tracked in issue #3537, just for the Rust entity extractor rather than
+/// the chunker.
+fn walk_rust(root: Node<'_>, src: &[u8], file: &str, in_test_fn: bool, out: &mut Vec<RawEntity>) {
+    // (node, in_test_fn-for-this-node, raw AST depth from `root`). Children
+    // pushed in reverse so traversal order (and therefore entity emission
+    // order) matches the original pre-order recursive walk.
+    let mut stack: Vec<(Node<'_>, bool, usize)> = vec![(root, in_test_fn, 0)];
+    let mut depth_capped = false;
+
+    while let Some((node, in_test_fn, raw_depth)) = stack.pop() {
+        if raw_depth > MAX_WALK_DEPTH {
+            if !depth_capped {
+                depth_capped = true;
+                tracing::warn!(
+                    file,
+                    max_depth = MAX_WALK_DEPTH,
+                    "entity extraction: AST nesting exceeds max walk depth; \
+                     extraction was truncated past this depth for this file (issue #3537 guard)"
+                );
             }
+            continue;
         }
-        "trait_bounds" => {
-            let t = node_text(node, src);
-            out.push(RawEntity::new(EntityType::TraitBound, t, span, file, line));
-        }
-        "scoped_identifier" => {
-            let t = node_text(node, src);
-            if t.contains("::") {
-                out.push(RawEntity::new(EntityType::ModulePath, t, span, file, line));
+
+        let kind = node.kind();
+        let line = node.start_position().row + 1;
+        let span = (node.start_byte(), node.end_byte());
+
+        match kind {
+            "type_identifier" => {
+                let t = node_text(node, src);
+                if !t.is_empty() {
+                    out.push(RawEntity::new(EntityType::NamedType, t, span, file, line));
+                }
             }
-        }
-        "macro_invocation" => {
-            // e.g. `bail!(...)`, `anyhow::bail!(...)`, `panic!(...)`. The `macro`
-            // field can be either an `identifier` or a `scoped_identifier`; we
-            // care about the final segment.
-            if let Some(name_node) = node.child_by_field_name("macro") {
-                let name = node_text(name_node, src);
-                let last = name.rsplit("::").next().unwrap_or(&name).trim();
-                if matches!(last, "bail" | "anyhow" | "panic" | "unwrap" | "expect") {
-                    let t = node_text(node, src);
+            "trait_bounds" => {
+                let t = node_text(node, src);
+                out.push(RawEntity::new(EntityType::TraitBound, t, span, file, line));
+            }
+            "scoped_identifier" => {
+                let t = node_text(node, src);
+                if t.contains("::") {
+                    out.push(RawEntity::new(EntityType::ModulePath, t, span, file, line));
+                }
+            }
+            "macro_invocation" => {
+                // e.g. `bail!(...)`, `anyhow::bail!(...)`, `panic!(...)`. The `macro`
+                // field can be either an `identifier` or a `scoped_identifier`; we
+                // care about the final segment.
+                if let Some(name_node) = node.child_by_field_name("macro") {
+                    let name = node_text(name_node, src);
+                    let last = name.rsplit("::").next().unwrap_or(&name).trim();
+                    if matches!(last, "bail" | "anyhow" | "panic" | "unwrap" | "expect") {
+                        let t = node_text(node, src);
+                        out.push(RawEntity::new(
+                            EntityType::ErrorVariant,
+                            t,
+                            span,
+                            file,
+                            line,
+                        ));
+                    }
+                }
+            }
+            "call_expression" => {
+                // `.unwrap()` and `.expect()` method calls also count.
+                if let Some(func) = node.child_by_field_name("function") {
+                    let txt = node_text(func, src);
+                    let last = txt.rsplit('.').next().unwrap_or(&txt);
+                    if matches!(last, "unwrap" | "expect") {
+                        let t = node_text(node, src);
+                        out.push(RawEntity::new(
+                            EntityType::ErrorVariant,
+                            t,
+                            span,
+                            file,
+                            line,
+                        ));
+                    }
+                }
+            }
+            "attribute_item" | "inner_attribute_item" => {
+                let t = node_text(node, src);
+                out.push(RawEntity::new(EntityType::Annotation, t, span, file, line));
+            }
+            "string_literal" => {
+                let t = node_text(node, src);
+                // Strip surrounding quotes for length check.
+                let inner = t.trim_matches('"');
+                if inner.len() > 10 {
                     out.push(RawEntity::new(
-                        EntityType::ErrorVariant,
+                        EntityType::LiteralString,
                         t,
                         span,
                         file,
@@ -194,16 +263,15 @@ fn walk_rust(node: Node<'_>, src: &[u8], file: &str, in_test_fn: bool, out: &mut
                     ));
                 }
             }
-        }
-        "call_expression" => {
-            // `.unwrap()` and `.expect()` method calls also count.
-            if let Some(func) = node.child_by_field_name("function") {
-                let txt = node_text(func, src);
-                let last = txt.rsplit('.').next().unwrap_or(&txt);
-                if matches!(last, "unwrap" | "expect") {
-                    let t = node_text(node, src);
+            "type_item" => {
+                let t = node_text(node, src);
+                out.push(RawEntity::new(EntityType::TypeAlias, t, span, file, line));
+            }
+            "identifier" if in_test_fn => {
+                let t = node_text(node, src);
+                if !t.is_empty() {
                     out.push(RawEntity::new(
-                        EntityType::ErrorVariant,
+                        EntityType::TestRelation,
                         t,
                         span,
                         file,
@@ -211,50 +279,18 @@ fn walk_rust(node: Node<'_>, src: &[u8], file: &str, in_test_fn: bool, out: &mut
                     ));
                 }
             }
+            _ => {}
         }
-        "attribute_item" | "inner_attribute_item" => {
-            let t = node_text(node, src);
-            out.push(RawEntity::new(EntityType::Annotation, t, span, file, line));
-        }
-        "string_literal" => {
-            let t = node_text(node, src);
-            // Strip surrounding quotes for length check.
-            let inner = t.trim_matches('"');
-            if inner.len() > 10 {
-                out.push(RawEntity::new(
-                    EntityType::LiteralString,
-                    t,
-                    span,
-                    file,
-                    line,
-                ));
-            }
-        }
-        "type_item" => {
-            let t = node_text(node, src);
-            out.push(RawEntity::new(EntityType::TypeAlias, t, span, file, line));
-        }
-        "identifier" if in_test_fn => {
-            let t = node_text(node, src);
-            if !t.is_empty() {
-                out.push(RawEntity::new(
-                    EntityType::TestRelation,
-                    t,
-                    span,
-                    file,
-                    line,
-                ));
-            }
-        }
-        _ => {}
-    }
 
-    // Detect entry into a test function so identifiers inside count as TestRelation.
-    let entering_test_fn = kind == "function_item" && function_has_test_attr(node, src);
+        // Detect entry into a test function so identifiers inside count as TestRelation.
+        let entering_test_fn = kind == "function_item" && function_has_test_attr(node, src);
+        let next_in_test_fn = in_test_fn || entering_test_fn;
 
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        walk_rust(child, src, file, in_test_fn || entering_test_fn, out);
+        let mut cursor = node.walk();
+        let children: Vec<Node<'_>> = node.children(&mut cursor).collect();
+        for child in children.into_iter().rev() {
+            stack.push((child, next_in_test_fn, raw_depth + 1));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #3537 — a deeply nested/pathological file (e.g. deeply templated C++
headers) could crash the entire `trusty-search` daemon with `fatal runtime
error: stack overflow`, taking every other index down with it.

## Root cause

- `walk_for_chunks` (`crates/trusty-search/src/core/chunker/walk.rs`) and
  `walk_rust` (`crates/trusty-search/src/core/entity.rs`) were native
  recursive descents over the tree-sitter parse tree. Recursion depth
  tracked raw AST depth, which is attacker-influenced (it comes directly
  from file content being indexed).
- For C/C++, `classify_node` only recognizes `function_definition`,
  `class_specifier`, and `struct_specifier` as chunk-worthy. Function
  *bodies* are pruned (not descended into), but everything else —
  critically, deeply nested global-scope constructs (deeply nested template
  arguments, deeply parenthesized initializers, etc., exactly what shows up
  in generated/templated headers like onnxruntime's) — fell into the
  unclassified branch and kept recursing one native stack frame per AST
  node, with no bound.

Confirmed with an out-of-tree repro: a global-scope declaration with
200,000 levels of nested parens reliably aborted the process with
`fatal runtime error: stack overflow, aborting` on both a constrained 1 MiB
thread stack and a normal 8 MiB stack. The same input now completes
cleanly.

## Fix

Preferred approach from the issue, in order:

1. **Convert recursion to iteration (chosen, primary fix).** Both walks now
   use an explicit heap-allocated work stack (the same pattern
   `collect_calls` in the same file already used), reproducing the original
   pre-order traversal/emission order. This removes the crash entirely,
   regardless of how deep the input nests — bounded only by available heap
   memory, which is trivial even at extreme depths.
2. **Explicit depth limit (added as a supplement, not the primary fix).**
   While building a large-scale regression test, I found that iteration
   alone isn't sufficient to keep the daemon *responsive*: `classify_node`
   calls `Node::parent()` on every visited node, and tree-sitter's
   `parent()` is not O(1) — it re-derives ancestry, costing roughly
   O(depth). Visiting an N-deep pathological chain then costs O(N) calls at
   up to O(N) each, i.e. O(N²) total (confirmed experimentally: a
   5,000-deep nested expression took 16s+ of *chunking* time despite
   tree-sitter *parsing* the same input in ~20ms). A long chain of nested
   *classified* containers (e.g. deeply nested `mod`/`class`/`namespace`)
   has a second, similar quadratic path through `collect_calls`, which also
   needed its own depth cap. Both walks now stop descending past
   `MAX_WALK_DEPTH` (1000, well past any legitimate nesting) and log a
   single warning per file rather than silently truncating — the file is
   still indexed with whatever was chunked before the cap.
3. **Growing the thread stack** — not used as the fix; it only raises the
   ceiling, as the issue's workaround section already notes.

The daemon now survives pathological input: one bad file degrades to
"partially chunked, warning logged" rather than crashing the process or
hanging the indexing worker.

## Regression tests

Added to `crates/trusty-search/src/core/chunker/tests.rs`:
- `test_deeply_nested_expression_does_not_crash` — 50,000 levels of nested
  parens in a global-scope Rust const expression (the unclassified-node
  branch — the shape that originally crashed the daemon).
- `test_deeply_nested_modules_does_not_crash` — 50,000 nested `mod` blocks
  (the classified-node branch, exercising the `collect_calls`/entity-walk
  quadratic-cost path).

Both complete in under a second and assert the walk completed without
crashing, with output bounded well below the input depth.

(Rust shapes were used for the checked-in tests rather than C++, because
tree-sitter-cpp's own grammar has pre-existing ambiguity-resolution costs
for deeply nested parens/templates — unrelated to this fix — that would
make a C++-shaped test slow/flaky. The actual crash was reproduced and
verified against C++ input during investigation; see commit message.)

## Verification

```
cargo test -p trusty-search               # 1223 lib + 313 bin + all integration binaries, 0 failures (single-threaded to rule out an unrelated env-pollution flake in doctor_checks, confirmed pre-existing and unrelated to this change)
cargo clippy -p trusty-search --all-targets -- -D warnings   # clean
cargo fmt --all --check                   # clean
```

Progress comment with root cause posted on #3537 before implementation:
https://github.com/bobmatnyc/trusty-tools/issues/3537#issuecomment-5039108668

Closes #3537

---

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
