### PR TITLE
fix(test): eliminate env-mutation-race flakes (#3607, #3608)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -157,6 +157,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Flaky `HOME`-race unit tests in `skills::sources::tests` fixed (#3607):**
+  `remote_git_without_subdir_uses_cache_dir_directly` and its siblings
+  `remote_git_cache_path_computed_correctly` /
+  `sources_resolved_paths_expands_tilde` each called `dirs::home_dir()`
+  twice — once implicitly inside `SkillSourceRegistry::resolved_paths()`,
+  once directly to build the expected value — without holding
+  `test_env::HOME_LOCK`, so a concurrent test's `$HOME` sandboxing could
+  change the value in between the two calls under `cargo test`'s default
+  multi-threaded runner. All three now hold `HOME_LOCK` for their full
+  body, matching the crate-wide convention documented in `test_env.rs`.
 - **`gworkspace` OpenRPC endpoint no longer silently discovers zero tools
   (#3577):** `DirectDriver::discover()` deserialized `rpc.discover`'s raw
   result directly into `EndpointManifest`, which expected a top-level

--- a/crates/trusty-agents/src/skills/sources/tests.rs
+++ b/crates/trusty-agents/src/skills/sources/tests.rs
@@ -34,6 +34,13 @@ fn sources_load_handles_malformed_file() {
 
 #[test]
 fn sources_resolved_paths_expands_tilde() {
+    // #3607-class: same HOME race — `resolved_paths()` calls
+    // `dirs::home_dir()` internally to expand the tilde, and this test calls
+    // it again directly below. Hold `HOME_LOCK` across both.
+    let _guard = crate::test_env::HOME_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
     let project = TempDir::new().unwrap();
     let sources = vec![
         SkillSource {
@@ -107,6 +114,14 @@ fn sources_disabled_source_excluded() {
 
 #[test]
 fn remote_git_cache_path_computed_correctly() {
+    // #3607: `reg.resolved_paths()` calls `dirs::home_dir()` internally, and
+    // this test calls it again directly to build the expected value. Both
+    // calls must observe the same `$HOME` — hold `HOME_LOCK` for the whole
+    // body so no concurrent HOME-mutating test can change it in between.
+    let _guard = crate::test_env::HOME_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
     let project = TempDir::new().unwrap();
     let sources = vec![SkillSource {
         source_type: SkillSourceType::RemoteGit,
@@ -135,6 +150,13 @@ fn remote_git_cache_path_computed_correctly() {
 
 #[test]
 fn remote_git_without_subdir_uses_cache_dir_directly() {
+    // #3607: same HOME race as `remote_git_cache_path_computed_correctly`
+    // above — hold `HOME_LOCK` across both the implicit `dirs::home_dir()`
+    // call inside `resolved_paths()` and the explicit one below.
+    let _guard = crate::test_env::HOME_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
     let project = TempDir::new().unwrap();
     let sources = vec![SkillSource {
         source_type: SkillSourceType::RemoteGit,

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- **Flaky env-mutation-race unit test fixed (#3608), plus an audit sweep
+  for the same bug class (#3607/#3608 cross-reference #2718):**
+  - `update::tests::verify_installed_binary_finds_binary_via_path` (#3608)
+    mutated `PATH` via `unsafe { std::env::set_var(...) }` OUTSIDE any
+    `ENV_LOCK` critical section, so both that mutation and the awaited
+    `verify_installed_binary` call ran unguarded against the other
+    `verify_installed_binary_*` tests in the same file. Now wraps the PATH
+    mutation in its own brief `ENV_LOCK` section (matching the file's
+    existing convention) AND tags all four `verify_installed_binary_*`
+    tests `#[serial(update_verify_installed_binary_env)]` so the whole
+    async body — including the `.await` a `std::sync::Mutex` guard can't
+    span without tripping `clippy::await_holding_lock` — is isolated from
+    sibling tests touching the same `HOME`/`CARGO_HOME`/`PATH` vars.
+  - Audit follow-up: `OPENROUTER_API_KEY` was mutated (or read as an
+    implicit fallback) by tests in three places using three UNCOORDINATED
+    lock groups — `inference::credentials::{resolver,dotenv}::tests` under
+    the named `#[serial(dotenv_credential_env)]` group,
+    `memory_core::semantic_consolidation::tests::resolve_openrouter_api_key_falls_back_to_env`
+    under a bare (unnamed, and therefore different) `#[serial]`, and
+    `memory_core::dream::tests`'s five `EnvVarGuard`-based tests under NO
+    lock at all. `memory_core::semantic_consolidation::tests::inference_available_false_without_key`
+    also implicitly depends on the var being absent (via
+    `inference_available`'s env fallback) with no lock whatsoever. All of
+    these now share the single `dotenv_credential_env` serial group.
+
 ## [0.24.1] — 2026-07-21
 
 Patch release closing unpublished source drift under the already-published

--- a/crates/trusty-common/src/memory_core/dream/tests.rs
+++ b/crates/trusty-common/src/memory_core/dream/tests.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::memory_core::palace::{Palace, PalaceId, RoomType};
 use crate::memory_core::retrieval::{PalaceHandle, seed_shared_embedder_with_mock};
 use chrono::{Duration as ChronoDuration, Utc};
+use serial_test::serial;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -766,6 +767,12 @@ async fn dream_cycle_semantic_consolidation_skips_task_drawers() {
 /// assert semantically_consolidated == 0 and the cycle succeeds.
 /// Test: This test itself.
 #[tokio::test]
+// Audit finding (same class as #3607/#3608): `OPENROUTER_API_KEY` is also
+// mutated by `inference::credentials::{resolver,dotenv}::tests` under
+// `#[serial(dotenv_credential_env)]`. This file's `EnvVarGuard` has no lock
+// of its own, so join that same serial group rather than relying on the
+// (false) assumption that this is the only mutator of the var.
+#[serial(dotenv_credential_env)]
 async fn dream_cycle_semantic_consolidation_no_inference() {
     // Ensure no env key is set for this test.
     let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
@@ -820,6 +827,7 @@ async fn dream_cycle_semantic_consolidation_no_inference() {
 /// second cycle short-circuited before rebuilding/retrying the backend.
 /// Test: This test itself.
 #[tokio::test]
+#[serial(dotenv_credential_env)]
 async fn dream_cycle_semantic_consolidation_invalid_model_disables_once() {
     let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
 
@@ -879,6 +887,7 @@ async fn dream_cycle_semantic_consolidation_invalid_model_disables_once() {
 /// (build + attempt) proceeded unchanged.
 /// Test: This test itself.
 #[tokio::test]
+#[serial(dotenv_credential_env)]
 async fn dream_cycle_semantic_consolidation_valid_local_model_not_disabled() {
     let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
 
@@ -1548,6 +1557,7 @@ async fn consolidate_scoped_skips_task_drawers() {
 /// `consolidate_scoped_invalid_model_returns_err`) instead of a silent no-op.
 /// Test: this function.
 #[tokio::test]
+#[serial(dotenv_credential_env)]
 async fn consolidate_scoped_no_inference_is_noop() {
     let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
     let handle = open_test_handle("scoped-no-inference").await;
@@ -1574,6 +1584,7 @@ async fn consolidate_scoped_no_inference_is_noop() {
 /// misconfiguration. Asserts `consolidate_scoped` returns `Err` naming both
 /// the model and Ollama.
 #[tokio::test]
+#[serial(dotenv_credential_env)]
 async fn consolidate_scoped_invalid_model_returns_err() {
     let _guard = EnvVarGuard::remove("OPENROUTER_API_KEY");
     let handle = open_test_handle("scoped-invalid-model").await;

--- a/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
+++ b/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
@@ -94,7 +94,19 @@ mod tests {
 
     /// Why: the gate function must return false when no key is configured so
     /// the dream cycle skips LLM calls on unconfigured deployments.
+    ///
+    /// Audit finding (same class as #3607/#3608, found while fixing those
+    /// issues): `inference_available("", false)` falls back to reading
+    /// `OPENROUTER_API_KEY` from the process environment when neither an
+    /// inline key nor a local model is configured, so this test's PASS/FAIL
+    /// depends on that var being absent for its whole body — exactly like a
+    /// writer of the var would. It raced `resolve_openrouter_api_key_falls_back_to_env`
+    /// (and, cross-file, `memory_core::dream::tests`'s `OPENROUTER_API_KEY`
+    /// mutators) because it held no lock at all. Join the same
+    /// `dotenv_credential_env` group as every other test that reads or
+    /// writes this var.
     #[test]
+    #[serial_test::serial(dotenv_credential_env)]
     fn inference_available_false_without_key() {
         assert!(!inference_available("", false));
         assert!(!inference_available("   ", false));
@@ -125,10 +137,16 @@ mod tests {
     /// process environment before picking a backend; `resolve_openrouter_api_key`
     /// must do the same so every caller (including
     /// `trusty-memory::dream_config_from_user_config`) agrees on the
-    /// resolved key. `#[serial]` + a local `EnvVarGuard` avoid racing other
-    /// tests that read/write the same real env var.
+    /// resolved key. `#[serial(dotenv_credential_env)]` + a local
+    /// `EnvVarGuard` avoid racing other tests that read/write the same real
+    /// env var — the named group joins the SAME lock used by
+    /// `inference::credentials::{resolver,dotenv}::tests` and
+    /// `memory_core::dream::tests` (audit finding, same class as
+    /// #3607/#3608: a bare unnamed `#[serial]` here does NOT coordinate with
+    /// those other files' named group, since serial_test treats each group
+    /// name as an independent lock).
     #[test]
-    #[serial_test::serial]
+    #[serial_test::serial(dotenv_credential_env)]
     fn resolve_openrouter_api_key_falls_back_to_env() {
         let _guard = EnvVarGuard::set("OPENROUTER_API_KEY", "sk-from-env");
         assert_eq!(resolve_openrouter_api_key(""), "sk-from-env");
@@ -137,8 +155,9 @@ mod tests {
     // ─── RAII env-var guard for tests (mirrors
     // trusty_common::memory_core::dream::tests::EnvVarGuard) ───────────────
     //
-    // Safety: test-only; `#[serial_test::serial]` on every caller serialises
-    // access to the real process environment across test threads.
+    // Safety: test-only; `#[serial_test::serial(dotenv_credential_env)]` on
+    // every caller serialises access to the real process environment across
+    // test threads (and across the other files sharing this named group).
 
     struct EnvVarGuard {
         key: &'static str,

--- a/crates/trusty-common/src/update/tests.rs
+++ b/crates/trusty-common/src/update/tests.rs
@@ -5,6 +5,7 @@
 //! in test mode.
 
 use super::*;
+use serial_test::serial;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -417,6 +418,7 @@ fn restore_home_env(snapshot: EnvSnapshot) {
 
 #[cfg(unix)]
 #[tokio::test]
+#[serial(update_verify_installed_binary_env)]
 async fn verify_installed_binary_finds_binary_in_cargo_bin() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let cargo_bin = tmp.path().join(".cargo").join("bin");
@@ -432,6 +434,7 @@ async fn verify_installed_binary_finds_binary_in_cargo_bin() {
 
 #[cfg(unix)]
 #[tokio::test]
+#[serial(update_verify_installed_binary_env)]
 async fn verify_installed_binary_finds_binary_in_local_bin() {
     let tmp = tempfile::tempdir().expect("tempdir");
     // Deliberately do NOT create ~/.cargo/bin — only ~/.local/bin has the
@@ -452,6 +455,7 @@ async fn verify_installed_binary_finds_binary_in_local_bin() {
 
 #[cfg(unix)]
 #[tokio::test]
+#[serial(update_verify_installed_binary_env)]
 async fn verify_installed_binary_honours_cargo_home_override() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let custom_cargo_home = tmp.path().join("custom-cargo-home");
@@ -477,6 +481,17 @@ async fn verify_installed_binary_honours_cargo_home_override() {
 
 #[cfg(unix)]
 #[tokio::test]
+// #3608: this test additionally mutates PATH (beyond what `set_home_env`
+// covers), so it needs full-body isolation from every other test in this
+// file that touches HOME/CARGO_HOME/PATH — not just the brief per-mutation
+// `ENV_LOCK` critical sections `set_home_env`/`restore_home_env` take. A
+// `std::sync::Mutex` guard can't span the `.await` below without tripping
+// `clippy::await_holding_lock`, so `#[serial]` (already used elsewhere in
+// this crate for the same class of problem, e.g.
+// `inference::credentials::resolver::tests`) is the correct primitive: it
+// serializes the whole async test body, including the await, against every
+// other test carrying the same group tag.
+#[serial(update_verify_installed_binary_env)]
 async fn verify_installed_binary_finds_binary_via_path() {
     // HOME points at an empty tempdir with neither ~/.cargo/bin nor
     // ~/.local/bin containing the binary, forcing the PATH/`which` fallback.
@@ -485,9 +500,20 @@ async fn verify_installed_binary_finds_binary_via_path() {
     write_fake_binary(&path_tmp.path().join("fake_trusty_bin_path"));
 
     let snapshot = set_home_env(home_tmp.path(), None);
-    let prev_path = std::env::var("PATH").unwrap_or_default();
-    let new_path = format!("{}:{prev_path}", path_tmp.path().display());
-    unsafe { std::env::set_var("PATH", &new_path) };
+    // #3608: this mutation used to run with no lock held at all (the guard
+    // taken by `set_home_env` above is already released by the time this
+    // line runs). Take a fresh, brief `ENV_LOCK` critical section around it,
+    // matching the convention every other synchronous env mutation in this
+    // file uses (e.g. `check_throttled_skips_when_no_update_check_set`).
+    {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev_path = std::env::var("PATH").unwrap_or_default();
+        let new_path = format!("{}:{prev_path}", path_tmp.path().display());
+        // Safety: env mutation is serialized by ENV_LOCK (held above) and by
+        // `#[serial(update_verify_installed_binary_env)]` for the full
+        // async body including the await below.
+        unsafe { std::env::set_var("PATH", &new_path) };
+    }
 
     let result = super::verify_installed_binary("fake_trusty_bin_path").await;
     restore_home_env(snapshot);


### PR DESCRIPTION
## Summary

Fixes two flaky tests producing false-red CI on unrelated PRs — they cost a full rebase-and-rerun cycle on PRs #3603 and #3604 earlier today.

- **#3607** (trusty-agents): `remote_git_without_subdir_uses_cache_dir_directly` and its two siblings (`remote_git_cache_path_computed_correctly`, `sources_resolved_paths_expands_tilde`) each call `dirs::home_dir()` twice — once implicitly inside `SkillSourceRegistry::resolved_paths()`, once directly to build the expected value — without holding `test_env::HOME_LOCK`. All three now hold `HOME_LOCK` for the full test body, matching the crate-wide convention documented in `test_env.rs`.
- **#3608** (trusty-common): `verify_installed_binary_finds_binary_via_path` mutated `PATH` via `unsafe { std::env::set_var(...) }` OUTSIDE any `ENV_LOCK` critical section, so the mutation and the awaited `verify_installed_binary` call both ran unguarded against sibling `verify_installed_binary_*` tests in the same file. Fixed by (a) wrapping the PATH mutation in its own brief `ENV_LOCK` section, matching the file's existing convention, and (b) tagging all four `verify_installed_binary_*` tests `#[serial(update_verify_installed_binary_env)]` so the whole async body — including the `.await` a `std::sync::Mutex` guard can't span without tripping `clippy::await_holding_lock` — is isolated from siblings touching the same `HOME`/`CARGO_HOME`/`PATH` vars.

### #3609 reclassified — NOT included in this PR

`supervisor_gives_up_after_max_restarts_flips_has_given_up` was originally believed to be a contention flake and included here with a `#[serial]` fix. CI proved that wrong: the test failed **even fully serialized at its existing 45s bound**, which rules out contention. This is a real production bug in the give-up latch, not a test isolation problem — see the new tracking issue linked below. The `#[serial]` change to `supervisor_tests.rs` has been reverted out of this PR entirely; fixing the latch is separate scope.

### Audit follow-up (same bug class as #3607/#3608)

While in there, audited both crates for the same "process-wide env mutation with incomplete lock coverage" pattern (#3607/#3608 both cross-reference #2718). Found and fixed:

- `OPENROUTER_API_KEY` was mutated or implicitly read by tests in **three uncoordinated lock groups**:
  - `inference::credentials::{resolver,dotenv}::tests` — named `#[serial(dotenv_credential_env)]`
  - `memory_core::semantic_consolidation::tests::resolve_openrouter_api_key_falls_back_to_env` — bare `#[serial]` (a **different**, unnamed lock — does not coordinate with the named group above)
  - `memory_core::dream::tests`'s five `EnvVarGuard`-based tests — **no lock at all**
  - `memory_core::semantic_consolidation::tests::inference_available_false_without_key` implicitly depends on the var being absent (via `inference_available`'s env fallback) — **no lock at all**

  All five now share the single `dotenv_credential_env` serial group.

Reviewed but found already correctly guarded (no change needed): every other `HOME`/`PATH`/credential-env-mutating test file in `trusty-agents` (all already hold `HOME_LOCK` or use `#[allow(clippy::await_holding_lock)]` + full-body `HOME_LOCK`), plus `trusty-common`'s `memory_core/timeouts.rs`, `error_capture/layer.rs`, `bm25.rs`, `inference/providers/local.rs`, `inference/configurator/*`, `catchup/mod.rs`, `memory_core/registry_tests.rs`, `bm25_client.rs` (each already has its own consistent lock, or is the sole mutator of its var). `memory_core/retrieval/timeout_tests.rs`'s env-mutating test is deliberately `#[ignore]`d and run in isolation — not a live CI flake.

## Test plan

All runs below use `unset OPENROUTER_API_KEY` first — this dev sandbox inherits a real key from the shell, which is unrelated environment noise, not a code issue.

- [x] `cargo test -p trusty-agents skills::sources::tests --lib` → 8 passed, repeated 5x under `--test-threads=8`, all green
- [x] `cargo test -p trusty-agents --lib` (2138 tests) → 0 failed
- [x] `cargo test -p trusty-common --features memory-core,embedder-client,embedder-bundled-ort,embedder-test-support,update-check` (672 lib tests + all integration suites) → 0 failed, repeated at `--test-threads=16` and `--test-threads=32`
- [x] `cargo test -p trusty-common ... update::tests` → repeated 8x under `--test-threads=16`, all green including `verify_installed_binary_finds_binary_via_path`
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` → clean
- [x] `cargo clippy -p trusty-common --all-targets --features memory-core,embedder-client,embedder-bundled-ort,embedder-test-support,update-check -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean
- [x] Rebased onto latest `origin/main` (`d73afcb1`), all of the above re-verified post-rebase

No `#[ignore]`, no cfg-gating, no deleted assertions, no weakened bounds. Not merged — leaving that to the PM.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools