### PR TITLE
release: trusty-search 0.38.0 + trusty-embedderd-py 0.1.1 (epic #3524 slice 6 ship)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11539,7 +11539,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-embedderd-py"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "fs4 0.8.4",
@@ -11780,7 +11780,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.37.2"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -61,7 +61,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.20.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.37.1" }
+trusty-search = { path = "../trusty-search", version = "0.38.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-embedderd-py/CHANGELOG.md
+++ b/crates/trusty-embedderd-py/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [0.1.1] — 2026-07-21
+
+Patch release closing unpublished source drift under the already-published
+0.1.0 (issue #3366 defect class): the epic #3524 slice 5 device-echo change
+below landed on `main` after 0.1.0 was published to crates.io without a
+version bump, so the live 0.1.0 tarball (this crate embeds its Python
+payload via `include_dir!` at publish time) does not contain it. Published
+now as the direct dependency of trusty-search 0.38.0's slice 6 default flip,
+whose live `/health` provider readback relies on this field.
 
 ### Added
 

--- a/crates/trusty-embedderd-py/Cargo.toml
+++ b/crates/trusty-embedderd-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-embedderd-py"
-version = "0.1.0"
+version = "0.1.1"
 publish = true
 edition = "2021"
 license.workspace = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [0.38.0] — 2026-07-21
+
+Ships the epic #3524 slice 6 default flip. Depends on trusty-embedderd-py
+0.1.1 (drift-closed in this same release) for the `/health` provider
+readback used to verify the flip below.
 
 ### Changed
 

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.37.2"
+version = "0.38.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -85,7 +85,7 @@ trusty-embedderd = { path = "../trusty-embedderd", version = "0.3.10", default-f
 # in NO torch/ORT — it is a lightweight uv/venv bootstrapper + launcher used
 # only when `TRUSTY_EMBEDDER=python` selects it (DEFAULT-OFF). Building it does
 # not require a venv; that is all runtime.
-trusty-embedderd-py = { path = "../trusty-embedderd-py", version = "0.1.0" }
+trusty-embedderd-py = { path = "../trusty-embedderd-py", version = "0.1.1" }
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-search (single-owner-per-binary); the
 # standalone `trusty-console` crate is its sole producer.


### PR DESCRIPTION
## Summary

Final ship step of epic #3524 slice 6 (graceful-Python default embedder on Apple Silicon). Publishes:

- **trusty-search 0.38.0** (MINOR) — the default flip from #3624: `trusty-search start` with `TRUSTY_EMBEDDER` unset/`auto` on aarch64 macOS now serves on the ort stdio sidecar immediately while bootstrapping the python/MPS sidecar in the background and hot-swapping to it once proven. `TRUSTY_EMBEDDER=stdio` remains as the permanent escape hatch.
- **trusty-embedderd-py 0.1.1** (PATCH, drift-close) — closes unpublished source drift (issue #3366 defect class): the epic #3524 slice 5 `/health` device-echo change (PR #3560, `909dd4cb`) landed on main after 0.1.0 published to crates.io without a version bump, so the live 0.1.0 tarball (this crate embeds its Python payload via `include_dir!` at publish time) lacks it. trusty-search's `/health` provider readback for this release depends on this field being live, so it ships now.

**trusty-common needed NO bump.** Verified via `git diff --stat 88cfacad..HEAD -- crates/trusty-common/` (empty): 0.24.1, already live on crates.io, already carries `EmbedderSupervisor::terminated_signal()` — it shipped in the prior `88cfacad` release commit, before the flip landed. Re-bumping it would be gratuitous drift in the other direction.

**trusty-embedderd needed NO bump.** Zero source diff since its last release commit (`831103dd`); 0.3.10 stays current.

Also updates trusty-agents' path-dependency version requirement on trusty-search (0.37.1 → 0.38.0) — required for `cargo build --workspace` to resolve; trusty-agents itself is not being republished.

## Verification

- `cargo build --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` — clean (GUI crates excluded per CI's documented Tauri-desktop-app exclusion)
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — clean
- `cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` — 185 test-result lines, all `0 failed`
- `cargo test -p trusty-review` — 0 failed
- `cargo publish --dry-run -p trusty-embedderd-py` — PASS
- `cargo publish --dry-run -p trusty-search` — packaging succeeds; fails only on `trusty-embedderd-py = "^0.1.1"` not yet being live on crates.io (expected pre-merge; will be re-validated against the live registry after trusty-embedderd-py publishes, per the repo's documented cross-crate publish ordering)

## Test plan

- [x] CI green on this PR
- [ ] After merge: publish trusty-embedderd-py 0.1.1 → wait for propagation → re-run `cargo publish --dry-run -p trusty-search` against the live registry (must pass) → publish trusty-search 0.38.0
- [ ] Tag both crates at the merge commit
- [ ] Signed-install + restart live search daemon, verify `/health` backend: python / provider: MPS

Refs #3524

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools