### PR TITLE
fix(embedder): CoreML opt-in on Apple Silicon, wire accuracy gate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,15 @@
 # intermittent HTTP 429 failures from HuggingFace that were causing ~31
 # trusty-memory tests to fail spuriously on cold runners.
 #
+# Issue #3493 P0 part 2 extends this to also pre-seed the fp32
+# Qdrant/all-MiniLM-L6-v2-onnx model (~90 MB, AllMiniLML6V2 — the default
+# model since #3486/#3493 P0): the accuracy correctness gate
+# `default_model_matches_sentence_transformers_reference`
+# (crates/trusty-common/src/embedder/mod.rs) was un-`#[ignore]`d so it
+# actually runs as a real CI gate against the CoreML-default regression
+# class, and it constructs the default `FastEmbedder` — see the "Pre-seed
+# fastembed models" step below for the download logic.
+#
 # The 7 env-sensitive trusty-memory tests (project_slug_returns_none_without_markers,
 # project_slug_at_returns_none_without_markers, cwd_palace_slug_falls_back_to_basename,
 # palace_slug_from_stdin_cwd_uses_stdin_path, resolve_palace_for_log_prefers_stdin_cwd,
@@ -281,20 +290,36 @@ jobs:
       #       to repo secrets fall back to the previous anonymous behavior.
       #   (b) The whole step is now fail-SOFT: any failure (rate limit,
       #       network blip, etc.) prints a ::warning:: annotation and lets
-      #       the job continue instead of hard-failing. This is safe because
-      #       the only tests that require the real downloaded model are
-      #       #[ignore]-gated (crates/trusty-common/src/embedder/mod.rs
+      #       the job continue instead of hard-failing. This is safe for
+      #       almost every real-model test — the vast majority require the
+      #       downloaded model are #[ignore]-gated
+      #       (crates/trusty-common/src/embedder/mod.rs
       #       fastembed_returns_correct_dim / fastembed_cache_hit_is_idempotent,
       #       crates/trusty-search/tests/migration_e2e.rs, crates/trusty-search/
       #       tests/embedder_supervisor_e2e.rs, crates/trusty-embedderd/tests/
       #       bit_identical.rs) and are never run by the plain `cargo test
-      #       --workspace` step below. Every non-ignored test that touches
-      #       the shared embedder pre-seeds a MockEmbedder instead via
+      #       --workspace` step below. Every other non-ignored test that
+      #       touches the shared embedder pre-seeds a MockEmbedder instead via
       #       seed_shared_embedder_with_mock() (issue #850,
       #       crates/trusty-common/src/memory_core/retrieval/embedder.rs), so
-      #       cargo test never needs HuggingFace network access — this step
-      #       is a best-effort latency/flake optimisation, not a correctness
-      #       dependency, and must not be allowed to fail the job.
+      #       cargo test never needs HuggingFace network access for those.
+      #
+      #       ONE exception (issue #3493 P0 part 2):
+      #       `default_model_matches_sentence_transformers_reference`
+      #       (crates/trusty-common/src/embedder/mod.rs) is the accuracy
+      #       correctness gate that would have caught the CoreML-default
+      #       regression, and is deliberately NOT `#[ignore]`d — it DOES run
+      #       under the plain `cargo test --workspace` step and DOES need the
+      #       real default (fp32, Qdrant/all-MiniLM-L6-v2-onnx) model. The
+      #       Qdrant pre-seed block above exists specifically to make that
+      #       test's model available from cache on every PR. Fail-soft is
+      #       still kept here rather than hard-failing the pre-seed step
+      #       itself: on a genuine HuggingFace outage the test will attempt
+      #       its own direct download at test time (fastembed's normal
+      #       cache-miss behaviour) and may then flake/fail for the same
+      #       underlying reason — that failure surfaces as a real, visible
+      #       `cargo test` failure rather than this optional latency step
+      #       aborting the whole job.
       #
       #       PR #2981 code-critic fix: fail-soft MUST NOT invoke seed_models
       #       directly as an `if`/`while` condition. Bash disables `errexit`
@@ -406,6 +431,67 @@ jobs:
               curl_retry \
                 "${HF_BASE}/${XENOVA_REPO}/resolve/${XENOVA_REV}/onnx/model_quantized.onnx" \
                 "${ONNX_DEST}"
+            fi
+
+            # ── Qdrant/all-MiniLM-L6-v2-onnx (AllMiniLML6V2 — fp32, the
+            # DEFAULT model since issue #3486 / #3493 P0, resolved by
+            # `resolve_default_embedding_model()`) ──
+            #
+            # Issue #3493 P0 part 2: the accuracy correctness gate
+            # `default_model_matches_sentence_transformers_reference`
+            # (crates/trusty-common/src/embedder/mod.rs) is no longer
+            # `#[ignore]`d — it runs as part of the plain `cargo test
+            # --workspace` step below and constructs the DEFAULT
+            # `FastEmbedder`, which downloads this fp32 model, not the
+            # Xenova quantized one above. Same resolution strategy as
+            # Xenova: try the classic `/resolve/<hash>/` redirect first: this
+            # repo actually serves gated files via a `resolve-cache` URL that
+            # does NOT match that pattern, so this intentionally falls
+            # through to the HF API sha lookup on every run — kept as the
+            # first attempt anyway so a future HF storage-backend change that
+            # restores the classic redirect is picked up for free without
+            # touching this script.
+            QDRANT_REPO="Qdrant/all-MiniLM-L6-v2-onnx"
+            QDRANT_DIR="${CACHE_DIR}/models--Qdrant--all-MiniLM-L6-v2-onnx"
+
+            mkdir -p "${QDRANT_DIR}/refs" "${QDRANT_DIR}/blobs"
+
+            echo "Resolving Qdrant/all-MiniLM-L6-v2-onnx HEAD revision …"
+            QDRANT_REV=$(curl -fsSL "${CURL_AUTH[@]}" \
+              "${HF_BASE}/${QDRANT_REPO}/resolve/main/tokenizer.json" \
+              -o /dev/null -w '%{url_effective}' | grep -oP '(?<=/resolve/)[^/]+' || true)
+
+            if [ -z "${QDRANT_REV}" ] || [ "${QDRANT_REV}" = "main" ]; then
+              QDRANT_REV=$(curl -fsSL "${CURL_AUTH[@]}" \
+                "https://huggingface.co/api/models/${QDRANT_REPO}?full=false" \
+                | grep -oP '"sha":"[^"]{40}"' | head -1 | grep -oP '[0-9a-f]{40}' || true)
+            fi
+
+            # Last-resort pinned hash (verified against the live repo while
+            # writing this step; matches fastembed 5.13.4's model registry).
+            QDRANT_REV="${QDRANT_REV:-5f1b8cd78bc4fb444dd171e59b18f3a3af89a079}"
+            echo "Using Qdrant/all-MiniLM-L6-v2-onnx revision: ${QDRANT_REV}"
+
+            echo "${QDRANT_REV}" > "${QDRANT_DIR}/refs/main"
+            QDRANT_SNAP_DIR="${QDRANT_DIR}/snapshots/${QDRANT_REV}"
+            mkdir -p "${QDRANT_SNAP_DIR}"
+
+            for FILE in tokenizer.json tokenizer_config.json special_tokens_map.json config.json; do
+              DEST="${QDRANT_SNAP_DIR}/${FILE}"
+              if [ ! -f "${DEST}" ]; then
+                echo "Downloading ${QDRANT_REPO}/${FILE} …"
+                curl_retry \
+                  "${HF_BASE}/${QDRANT_REPO}/resolve/${QDRANT_REV}/${FILE}" \
+                  "${DEST}"
+              fi
+            done
+
+            QDRANT_ONNX_DEST="${QDRANT_SNAP_DIR}/model.onnx"
+            if [ ! -f "${QDRANT_ONNX_DEST}" ]; then
+              echo "Downloading ${QDRANT_REPO}/model.onnx (~90 MB) …"
+              curl_retry \
+                "${HF_BASE}/${QDRANT_REPO}/resolve/${QDRANT_REV}/model.onnx" \
+                "${QDRANT_ONNX_DEST}"
             fi
 
             echo "fastembed model pre-seed complete."

--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -7,10 +7,10 @@
 # and /* ... */ block comments (including multi-line spans). Trailing-comment lines count.
 # Ratchet: budgets may only DECREASE; when a file drops <= its applicable cap, remove it.
 # Regenerate with: scripts/check_line_cap.sh --update  (use --seed only to bootstrap).
-crates/trusty-common/src/embedder/mod.rs	567
+crates/trusty-common/src/embedder/mod.rs	595
 crates/trusty-git-analytics/src/collect/collector.rs	766
 crates/trusty-mpm/src/daemon/api.rs	1272
 crates/trusty-mpm/src/daemon/api/control_routes.rs	543
 crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	836
-crates/trusty-search/src/main.rs	664
+crates/trusty-search/src/main.rs	658
 crates/trusty-search/src/service/walker.rs	1167

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -77,6 +77,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   workspace is never an OS-temp path — closing the ephemeral test/self-heal
   index leak into the production trusty-search index set.
 
+- **CoreML is now opt-in, not the default, execution provider on Apple
+  Silicon (issue #3493 P0 part 2).** CoreML measurably degraded embedding
+  accuracy (~0.99 mean cosine similarity vs a genuine
+  `sentence-transformers` reference, vs 1.000000 on the CPU EP), silently
+  erasing the fp32 default-model accuracy fix from #3486. `FastEmbedder`
+  now defaults to CPU on every platform, including Apple Silicon; set
+  `TRUSTY_DEVICE=gpu` to explicitly opt back into CoreML acceleration
+  (`TRUSTY_COREML_COMPUTE_UNITS` still selects the CoreML variant once
+  opted in). `TRUSTY_DEVICE=cpu` keeps working as before. Local
+  measurement on Apple Silicon showed no consistent throughput cost from
+  the CPU default (CPU and CoreML(ANE) landed within noise of each other,
+  ~127-141 texts/sec on a 300-text batch).
+- **`default_model_matches_sentence_transformers_reference` is no longer
+  `#[ignore]`d (issue #3493 P0 part 2).** This is the correctness gate that
+  would have caught the CoreML-default accuracy regression; CI now
+  pre-seeds its fp32 `Qdrant/all-MiniLM-L6-v2-onnx` model alongside the
+  existing quantized-model pre-seed so it runs on every PR without
+  HuggingFace-download flakiness.
+
+---
 ## [0.24.1] — 2026-07-21
 
 Patch release closing unpublished source drift under the already-published

--- a/crates/trusty-common/src/embedder/fast_embedder.rs
+++ b/crates/trusty-common/src/embedder/fast_embedder.rs
@@ -356,21 +356,27 @@ impl FastEmbedder {
         self.model_name
     }
 
-    /// Build `TextInitOptions` for the given model, attempting to register
-    /// the CoreML execution provider at runtime when on Apple Silicon.
+    /// Build `TextInitOptions` for the given model. CPU is the default
+    /// execution provider everywhere, including Apple Silicon; CoreML is an
+    /// explicit opt-in (`TRUSTY_DEVICE=gpu`).
     ///
-    /// Why: We want zero-friction GPU/ANE acceleration on Apple Silicon
-    /// without forcing users to pass `--features coreml`. fastembed-rs accepts
-    /// a `Vec<ExecutionProviderDispatch>` via `with_execution_providers`, and
-    /// our `ort` dep (pinned to the exact `=2.0.0-rc.12` fastembed uses) has
-    /// the `coreml` feature on by default on macOS, so we can always try to
-    /// build and register CoreML at runtime. On non-Apple platforms, or if
-    /// CoreML registration fails for any reason, we transparently fall back
-    /// to the default CPU provider.
+    /// Why: issue #3493 P0 (part 2) — CoreML was previously the unconditional
+    /// default on Apple Silicon, but it measurably degrades embedding
+    /// accuracy (~0.99 mean cosine similarity vs a genuine
+    /// `sentence-transformers` reference, vs 1.000000 on the CPU EP — see
+    /// `default_model_matches_sentence_transformers_reference`), silently
+    /// erasing the fp32 accuracy win from the #3486 default-model fix. CoreML
+    /// acceleration is still available for operators who explicitly want it
+    /// (`TRUSTY_DEVICE=gpu`) — our `ort` dep (pinned to the exact
+    /// `=2.0.0-rc.12` fastembed uses) has the `coreml` feature on by default
+    /// on macOS, so we can always build and register it at runtime on
+    /// request. On non-Apple platforms, or if CoreML registration fails for
+    /// any reason, we transparently fall back to the default CPU provider.
     /// What: returns `(TextInitOptions, ExecutionProvider)` where the tag
     /// reflects which backend was actually wired in.
-    /// Test: on an M-series Mac the tag is `CoreML`; on Intel/Linux/Windows
-    /// (or if CoreML build fails) the tag is `Cpu`.
+    /// Test: on an M-series Mac the tag is `Cpu` unless `TRUSTY_DEVICE=gpu`
+    /// is set (then `CoreML`/`CoreMLAne`); on Intel/Linux/Windows the tag is
+    /// always `Cpu`.
     pub(super) fn init_options(model: EmbeddingModel) -> (TextInitOptions, ExecutionProvider) {
         use ort::execution_providers::ExecutionProviderDispatch;
 
@@ -438,10 +444,24 @@ impl FastEmbedder {
 
         #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
         {
-            let force_cpu = std::env::var("TRUSTY_DEVICE")
-                .map(|v| v.eq_ignore_ascii_case("cpu"))
+            // Issue #3493 P0 (part 2): CoreML is OPT-IN, not the default, on
+            // Apple Silicon. `TRUSTY_DEVICE=gpu` is the explicit escape hatch
+            // (reusing the same value the CUDA branch above and the
+            // `require_gpu` check in `with_cache_size` already treat as "the
+            // operator explicitly wants acceleration" — see the doc comment
+            // on `TRUSTY_DEVICE=gpu` there). Anything else — unset, `cpu`, or
+            // any other value — resolves to plain CPU via the fallthrough
+            // block below, restoring the 1.000000 cosine accuracy the CPU EP
+            // reaches (vs ~0.99 under CoreML — see the correctness gate
+            // `default_model_matches_sentence_transformers_reference`).
+            // `TRUSTY_DEVICE=cpu` keeps working exactly as before: it was
+            // already a no-op once CoreML stops being the default, but the
+            // check is kept so any explicit `cpu` value is still honoured if
+            // this precedence ever changes again.
+            let enable_coreml = std::env::var("TRUSTY_DEVICE")
+                .map(|v| v.eq_ignore_ascii_case("gpu"))
                 .unwrap_or(false);
-            if !force_cpu {
+            if enable_coreml {
                 use ort::ep::coreml::{ComputeUnits, SpecializationStrategy};
 
                 let (units, units_tag) = match std::env::var("TRUSTY_COREML_COMPUTE_UNITS")
@@ -490,7 +510,10 @@ impl FastEmbedder {
                 return (opts.with_execution_providers(providers), units_tag);
             }
             tracing::info!(
-                "trusty-embedder: TRUSTY_DEVICE=cpu set — skipping CoreML EP registration (Apple Silicon)"
+                "trusty-embedder: CoreML EP not registered — CPU is the default execution \
+                 provider on Apple Silicon (issue #3493 P0: CoreML degraded embedding \
+                 accuracy to ~0.99 mean cosine vs 1.000000 on CPU). Set TRUSTY_DEVICE=gpu \
+                 to opt back into CoreML acceleration."
             );
         }
 

--- a/crates/trusty-common/src/embedder/mod.rs
+++ b/crates/trusty-common/src/embedder/mod.rs
@@ -13,8 +13,11 @@
 //! feature.
 //!
 //! Test: `cargo test -p trusty-common --features embedder,embedder-test-support`
-//! covers shape, cache hits, and the mock embedder. ONNX-backed tests are
-//! `#[ignore]` to keep CI under one cargo-feature umbrella.
+//! covers shape, cache hits, and the mock embedder. Most ONNX-backed tests
+//! are `#[ignore]` to keep CI under one cargo-feature umbrella; the
+//! numerical-accuracy gate `default_model_matches_sentence_transformers_reference`
+//! is the deliberate exception (issue #3493 P0 part 2) — CI pre-seeds its
+//! model so it runs on every PR instead of being silently skipped forever.
 
 // Issue #54: opt-in Candle BERT backend. Lives in its own submodule behind
 // the `embedder-candle` feature so the default fastembed/ORT build never
@@ -413,6 +416,9 @@ mod tests {
         assert_eq!(resolve_expected_provider(), ExecutionProvider::Cpu);
     }
 
+    /// Why: issue #3493 P0 (part 2) — CPU is now the default execution
+    /// provider on every platform, including Apple Silicon; CoreML no longer
+    /// activates just because `TRUSTY_DEVICE` is unset.
     #[test]
     fn resolve_expected_provider_default_matches_platform() {
         let _g = ENV_LOCK.lock().unwrap();
@@ -423,16 +429,7 @@ mod tests {
 
         #[cfg(feature = "embedder-cuda")]
         let expected = ExecutionProvider::Cuda;
-        #[cfg(all(
-            not(feature = "embedder-cuda"),
-            target_arch = "aarch64",
-            target_os = "macos"
-        ))]
-        let expected = ExecutionProvider::CoreMLAne;
-        #[cfg(all(
-            not(feature = "embedder-cuda"),
-            not(all(target_arch = "aarch64", target_os = "macos"))
-        ))]
+        #[cfg(not(feature = "embedder-cuda"))]
         let expected = ExecutionProvider::Cpu;
 
         assert_eq!(
@@ -441,12 +438,25 @@ mod tests {
         );
     }
 
+    /// Why: issue #3493 P0 (part 2) — CoreML is opt-in via `TRUSTY_DEVICE=gpu`
+    /// on Apple Silicon; unset/`cpu` must predict plain `Cpu` regardless of
+    /// `TRUSTY_COREML_COMPUTE_UNITS`, and `gpu` must predict the CoreML
+    /// variant selected by `TRUSTY_COREML_COMPUTE_UNITS`.
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     #[cfg(not(feature = "embedder-cuda"))]
     #[test]
     fn resolve_expected_provider_coreml_units() {
         let _g = ENV_LOCK.lock().unwrap();
-        let _d = EnvVarGuard::apply("TRUSTY_DEVICE", None);
+        {
+            let _d = EnvVarGuard::apply("TRUSTY_DEVICE", None);
+            let _u = EnvVarGuard::apply("TRUSTY_COREML_COMPUTE_UNITS", Some("all"));
+            assert_eq!(
+                resolve_expected_provider(),
+                ExecutionProvider::Cpu,
+                "TRUSTY_DEVICE unset must predict Cpu even with compute units set"
+            );
+        }
+        let _d = EnvVarGuard::apply("TRUSTY_DEVICE", Some("gpu"));
         {
             let _u = EnvVarGuard::apply("TRUSTY_COREML_COMPUTE_UNITS", Some("all"));
             assert_eq!(resolve_expected_provider(), ExecutionProvider::CoreML);
@@ -581,10 +591,12 @@ mod tests {
     /// mean cosine similarity against `REFERENCE_VECTORS` is `>= 0.999`
     /// (matching the experiment's fp32/fp16 threshold, well above INT8's
     /// measured 0.9897).
-    /// Test: this test (`#[ignore]` — downloads/loads a real ONNX model, like
-    /// the other fastembed-backed tests in this module).
+    /// Test: this test. NOT `#[ignore]`d (issue #3493 P0 part 2 — this is the
+    /// correctness gate that would have caught the CoreML-default accuracy
+    /// regression had it been wired into CI; see `ci.yml`'s `test` job for
+    /// the fastembed-model pre-seed step that makes this safe to run on every
+    /// PR without HuggingFace-download flakiness).
     #[tokio::test]
-    #[ignore]
     async fn default_model_matches_sentence_transformers_reference() {
         fn cosine(a: &[f32], b: &[f32]) -> f64 {
             let dot: f64 = a.iter().zip(b).map(|(x, y)| *x as f64 * *y as f64).sum();
@@ -617,6 +629,9 @@ mod tests {
         );
     }
 
+    /// Why: issue #3493 P0 (part 2) — `TRUSTY_DEVICE=cpu` must keep working as
+    /// an explicit-CPU escape hatch even though CPU is now the default
+    /// anyway, in case the opt-in precedence ever changes again.
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     #[test]
     fn trusty_device_cpu_disables_coreml_on_apple_silicon() {
@@ -640,9 +655,15 @@ mod tests {
         }
     }
 
+    /// Why: issue #3493 P0 (part 2) — CoreML measurably degraded embedding
+    /// accuracy (~0.99 mean cosine vs 1.000000 on CPU — see
+    /// `default_model_matches_sentence_transformers_reference`), so CPU is
+    /// now the DEFAULT execution provider on Apple Silicon, not CoreML. This
+    /// replaces the old `default_apple_silicon_uses_coreml_ane` test, which
+    /// asserted the opposite (now-reverted) default.
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     #[test]
-    fn default_apple_silicon_uses_coreml_ane() {
+    fn default_apple_silicon_uses_cpu() {
         use crate::embedder::fast_embedder::FastEmbedder as FE;
         let _guard = ENV_LOCK.lock().unwrap();
 
@@ -656,8 +677,9 @@ mod tests {
         let (_opts, provider) = FE::init_options(fastembed::EmbeddingModel::AllMiniLML6V2Q);
         assert_eq!(
             provider,
-            ExecutionProvider::CoreMLAne,
-            "default behaviour on Apple Silicon must register CoreML(ANE) — the OOM-safe replacement for CoreML(All)"
+            ExecutionProvider::Cpu,
+            "default behaviour on Apple Silicon must be CPU — CoreML is opt-in via \
+             TRUSTY_DEVICE=gpu (issue #3493 P0 part 2)"
         );
 
         unsafe {
@@ -672,6 +694,9 @@ mod tests {
         }
     }
 
+    /// Why: issue #3493 P0 (part 2) — CoreML must still be reachable as an
+    /// explicit opt-in (`TRUSTY_DEVICE=gpu`), and `TRUSTY_COREML_COMPUTE_UNITS`
+    /// must still select the CoreML(All) tag once opted in.
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     #[test]
     fn coreml_compute_units_all_opt_in() {
@@ -681,7 +706,7 @@ mod tests {
         let prev_device = std::env::var("TRUSTY_DEVICE").ok();
         let prev_units = std::env::var("TRUSTY_COREML_COMPUTE_UNITS").ok();
         unsafe {
-            std::env::remove_var("TRUSTY_DEVICE");
+            std::env::set_var("TRUSTY_DEVICE", "gpu");
             std::env::set_var("TRUSTY_COREML_COMPUTE_UNITS", "all");
         }
 
@@ -689,7 +714,43 @@ mod tests {
         assert_eq!(
             provider,
             ExecutionProvider::CoreML,
-            "TRUSTY_COREML_COMPUTE_UNITS=all must select the CoreML(All) tag"
+            "TRUSTY_DEVICE=gpu + TRUSTY_COREML_COMPUTE_UNITS=all must select the CoreML(All) tag"
+        );
+
+        unsafe {
+            match prev_device {
+                Some(v) => std::env::set_var("TRUSTY_DEVICE", v),
+                None => std::env::remove_var("TRUSTY_DEVICE"),
+            }
+            match prev_units {
+                Some(v) => std::env::set_var("TRUSTY_COREML_COMPUTE_UNITS", v),
+                None => std::env::remove_var("TRUSTY_COREML_COMPUTE_UNITS"),
+            }
+        }
+    }
+
+    /// Why: issue #3493 P0 (part 2) — `TRUSTY_DEVICE=gpu` is the explicit
+    /// opt-in that re-enables CoreML on Apple Silicon (mirroring the same
+    /// value's meaning for the CUDA branch and the `require_gpu` hard-fail
+    /// check in `with_cache_size`).
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    #[test]
+    fn trusty_device_gpu_enables_coreml_on_apple_silicon() {
+        use crate::embedder::fast_embedder::FastEmbedder as FE;
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        let prev_device = std::env::var("TRUSTY_DEVICE").ok();
+        let prev_units = std::env::var("TRUSTY_COREML_COMPUTE_UNITS").ok();
+        unsafe {
+            std::env::set_var("TRUSTY_DEVICE", "gpu");
+            std::env::remove_var("TRUSTY_COREML_COMPUTE_UNITS");
+        }
+
+        let (_opts, provider) = FE::init_options(fastembed::EmbeddingModel::AllMiniLML6V2Q);
+        assert_eq!(
+            provider,
+            ExecutionProvider::CoreMLAne,
+            "TRUSTY_DEVICE=gpu must opt back into CoreML(ANE) — the OOM-safe default variant"
         );
 
         unsafe {

--- a/crates/trusty-common/src/embedder/types.rs
+++ b/crates/trusty-common/src/embedder/types.rs
@@ -289,41 +289,51 @@ impl std::fmt::Display for ExecutionProvider {
 /// RPC round-trip or any change to the wire protocol.
 ///
 /// What: mirrors the provider-selection branches of `init_options` in the same
-/// precedence order — `TRUSTY_DEVICE=cpu` forces `Cpu`; otherwise an
-/// `embedder-cuda` build yields `Cuda`; otherwise Apple Silicon yields a
-/// `CoreML*` tag derived from `TRUSTY_COREML_COMPUTE_UNITS` (default
-/// `CoreMLAne`); every other host yields `Cpu`. It deliberately does **not**
-/// probe whether a CUDA device actually initialises — that runtime fallback is
-/// reflected by the in-process path's own `provider()` and, for the sidecar,
-/// is reported by the sidecar's startup log.
+/// precedence order — an `embedder-cuda` build yields `Cuda` unless
+/// `TRUSTY_DEVICE=cpu` forces `Cpu`; otherwise, on Apple Silicon, CoreML is
+/// only predicted when explicitly requested via `TRUSTY_DEVICE=gpu` (issue
+/// #3493 P0 part 2 — CoreML is opt-in, not the default; it measurably
+/// degraded embedding accuracy, see
+/// `default_model_matches_sentence_transformers_reference`), in which case the
+/// `CoreML*` tag is derived from `TRUSTY_COREML_COMPUTE_UNITS` (default
+/// `CoreMLAne`); every other case — including `TRUSTY_DEVICE` unset or `cpu`
+/// — yields `Cpu`. It deliberately does **not** probe whether a CUDA device
+/// actually initialises — that runtime fallback is reflected by the
+/// in-process path's own `provider()` and, for the sidecar, is reported by
+/// the sidecar's startup log.
 ///
 /// Test: `resolve_expected_provider_forces_cpu`,
 /// `resolve_expected_provider_default_matches_platform`, and (Apple Silicon)
 /// `resolve_expected_provider_coreml_units` below.
 pub fn resolve_expected_provider() -> ExecutionProvider {
-    let force_cpu = std::env::var("TRUSTY_DEVICE")
-        .map(|v| v.eq_ignore_ascii_case("cpu"))
-        .unwrap_or(false);
-    if force_cpu {
-        return ExecutionProvider::Cpu;
-    }
-
     #[cfg(feature = "embedder-cuda")]
     {
+        let force_cpu = std::env::var("TRUSTY_DEVICE")
+            .map(|v| v.eq_ignore_ascii_case("cpu"))
+            .unwrap_or(false);
+        if force_cpu {
+            return ExecutionProvider::Cpu;
+        }
         return ExecutionProvider::Cuda;
     }
 
     #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
     {
-        return match std::env::var("TRUSTY_COREML_COMPUTE_UNITS")
-            .ok()
-            .as_deref()
-            .map(|s| s.trim().to_ascii_lowercase())
-            .as_deref()
-        {
-            Some("all") | Some("cpu_gpu") | Some("cpuandgpu") => ExecutionProvider::CoreML,
-            _ => ExecutionProvider::CoreMLAne,
-        };
+        let enable_coreml = std::env::var("TRUSTY_DEVICE")
+            .map(|v| v.eq_ignore_ascii_case("gpu"))
+            .unwrap_or(false);
+        if enable_coreml {
+            return match std::env::var("TRUSTY_COREML_COMPUTE_UNITS")
+                .ok()
+                .as_deref()
+                .map(|s| s.trim().to_ascii_lowercase())
+                .as_deref()
+            {
+                Some("all") | Some("cpu_gpu") | Some("cpuandgpu") => ExecutionProvider::CoreML,
+                _ => ExecutionProvider::CoreMLAne,
+            };
+        }
+        return ExecutionProvider::Cpu;
     }
 
     #[allow(unreachable_code)]


### PR DESCRIPTION
## Summary

Addresses #3493 — the embedding accuracy regression caused by defaulting to
the CoreML execution provider on Apple Silicon.

- **CPU is now the default embedding execution provider on Apple Silicon.**
  CoreML measurably degraded embedding accuracy in prior investigation
  (~0.99 mean cosine similarity vs a genuine `sentence-transformers`
  reference, vs 1.000000 on CPU), silently erasing the fp32 default-model
  accuracy fix from #3486. CoreML is now an explicit opt-in via
  `TRUSTY_DEVICE=gpu` (reusing the existing "operator explicitly wants
  acceleration" semantic already used by the CUDA branch and the
  `require_gpu` hard-fail check) — it is not deleted, only demoted from
  default to opt-in. `TRUSTY_DEVICE=cpu` and `TRUSTY_COREML_COMPUTE_UNITS`
  keep working exactly as before.
- **`default_model_matches_sentence_transformers_reference` is no longer
  `#[ignore]`d.** This is the correctness gate that would have caught the
  CoreML-default regression; CI now pre-seeds its fp32
  `Qdrant/all-MiniLM-L6-v2-onnx` model (mirroring the existing Xenova
  quantized-model pre-seed pattern from issue #865) so it runs on every PR
  without HuggingFace-download flakiness.

## Why CPU by default costs no measured throughput

Measured locally on Apple Silicon (M4 Max), 300-text uncached batch,
`cargo test -p trusty-common --features embedder,embedder-test-support,embedder-bundled-ort --lib -- --ignored <probe> --nocapture`:

| Provider | texts/sec (3 runs) |
|---|---|
| CPU (new default) | 131.3, 135.1, 134.8 |
| CoreML(ANE) (`TRUSTY_DEVICE=gpu`) | 126.4, 127.2, 140.7 |
| CoreML(All) (`TRUSTY_DEVICE=gpu` + `TRUSTY_COREML_COMPUTE_UNITS=all`) | 132.0 |

CPU and CoreML land within noise of each other on this host; CPU is not
slower. This matches the earlier investigation's note that CoreML measured
net-negative on throughput in prior work.

## Scope

- Only `crates/trusty-common/src/embedder/{fast_embedder,mod,types}.rs`,
  `.github/workflows/ci.yml`, `.line-cap-allowlist.tsv`, and
  `crates/trusty-common/CHANGELOG.md` changed. The thread-pin (#3500) and
  model-repo/cache-safety (#3501) fixes are untouched.
- The P3 GPU/MPS acceleration path (#3498) is explicitly OUT of scope.
- Does not merge, does not touch any other branch/PR.

## Test plan

- [x] `cargo test -p trusty-common --features embedder,embedder-test-support,embedder-bundled-ort` — `default_model_matches_sentence_transformers_reference` now runs (was `#[ignore]`d) and passes at mean_cosine=1.000000, min_cosine=1.000000.
- [x] `cargo test -p trusty-common` (default features) — clean.
- [x] `CI="" cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` (mirrors `ci.yml`'s `test` job) — run twice locally. `trusty-common`'s own suite (feature-unified via `trusty-search`'s deps, exactly as in CI) passed cleanly both times, including the new gate. Each run separately hit ONE unrelated pre-existing flaky test in a *different* untouched package — `trusty-search::commands::doctor_checks::tests::doctor_data_dir_returns_non_empty_path` (a known `TRUSTY_DATA_DIR` cross-test env-var race; several sibling tests in that file are not `#[serial]`-guarded) and `trusty-agents::workflow::engine::executor::tests::checkpoint_resume::resume_replays_summary_not_full_content_into_downstream_prompts`. Both are unrelated to this diff (neither package's source was touched) and both pass cleanly when re-run in isolation — confirmed for each. Cargo halts the workspace run at the first failing binary without `--no-fail-fast`, which is why neither run reached a final "all green" summary line; that halting behavior is orthogonal to this PR.
- [x] `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `bash scripts/check_line_cap.sh` — clean (mod.rs's frozen SLOC budget raised from 567→595 via `--force-add`, the repo's sanctioned escape hatch for legitimate new test coverage; `trusty-search/src/main.rs`'s budget also mechanically tightened 664→658 by the same `--update` pass, unrelated pre-existing drift from a prior merge).
- [ ] `embedder-cuda` feature: could not be locally verified (this Mac has no `nvcc`; `cargo check -p trusty-common --features embedder-cuda` already fails identically on unmodified `main` for the same reason). The `embedder-cuda-check` CI job installs `nvcc` and will verify. The CUDA branch's own `TRUSTY_DEVICE=cpu` behavior is unchanged by this PR — only the Apple Silicon branch's default flipped.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
