### PR TITLE
fix(embedder): trip supervisor give-up on sustained crash-loop, not just respawn failures

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -37,10 +37,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     classification for a real killed process non-deterministic; fails
     against unfixed code, passes with the fix),
     `supervisor_single_transient_crash_then_health_does_not_give_up` (new —
-    guards against over-correction: one kill + sustained health must NOT
-    give up), plus `is_restart_storm_trigger_*` and
-    `should_give_up_restart_storm_trips_ceiling_even_with_failures_reset`
+    guards against over-correction: TWO forced restarts separated by more
+    than `wedge_reset_secs`, via the first restart's own back-off delay,
+    must NOT give up; mutation-verified against a disabled reset call site
+    to confirm it actually fails when the reset is broken — a naive
+    one-kill-then-sleep version of this test cannot ever fail regardless of
+    whether the reset works, since `max_restarts: 1` with a single kill can
+    never exceed the ceiling either way), plus `is_restart_storm_trigger_*`
+    and `should_give_up_restart_storm_trips_ceiling_even_with_failures_reset`
     pure-function unit tests.
+  - Note: the reset window is anchored to the LAST forced restart's own
+    cycle (its back-off delay plus respawn), not to a live/ticking clock —
+    `restart_storm_should_reset` is evaluated once per loop iteration, at
+    iteration entry, so a health period that unfolds entirely inside one
+    iteration's blocking wait is only observed by the restart that ends it,
+    one iteration late. In practice this means a crash cadence slower than
+    `wedge_reset_secs` legitimately never accumulates (each restart's own
+    back-off provides the elapsed time the following check needs), while a
+    genuinely tight loop keeps escalating. See `restart_storm_should_reset`'s
+    doc comment in `supervisor.rs` for the full explanation.
 
 ---
 ## [0.24.1] — 2026-07-21

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- **`EmbedderSupervisor` crash-storm give-up never reachable for a plain
+  process-exit crash loop (issue #3631).** `supervision_loop` tracked a
+  single non-resetting escalation counter
+  (`consecutive_wedge_restarts`, #1450 HIGH follow-up) for
+  `RestartTrigger::Unhealthy` only; `RestartTrigger::ProcessExit` (the
+  classification a `SIGKILL` or any real crash produces) only bumped the
+  ordinary `consecutive_failures` counter, which is unconditionally reset to
+  0 on every successful respawn. A sidecar that kept dying but whose
+  individual respawns kept succeeding — the normal shape of "kill it, it
+  comes back healthy" — could therefore oscillate `consecutive_failures`
+  0→1→0→1 forever and never satisfy `should_give_up` for any
+  `max_restarts`, so `terminated_signal()`/`is_confirmed_terminated()` never
+  fired and the python→ort swap-back watchdog (epic #3524 slice 6) never
+  engaged. Fix: renamed/generalized the counter to
+  `consecutive_restart_storm` and extended it to also cover a failing
+  `RestartTrigger::ProcessExit` (`is_restart_storm_trigger`), so a sustained
+  crash-loop escalates in bounded time (`max_restarts`, default 5) instead
+  of resetting on every successful respawn. Reset condition unchanged:
+  `wedge_reset_secs` (default 300s, env `TRUSTY_EMBEDDERD_WEDGE_RESET_SECS`)
+  of sustained health since the last forced restart — so a genuine one-off
+  crash followed by real recovery still does NOT trip give-up.
+  - Test: `supervisor_process_exit_crash_loop_reaches_give_up` (new,
+    deterministic — a mock child whose stdout pipe survives `kill -9` via an
+    orphaned backgrounded process, closing the OS-level race between
+    `child.wait()` and reader-task EOF detection that made trigger
+    classification for a real killed process non-deterministic; fails
+    against unfixed code, passes with the fix),
+    `supervisor_single_transient_crash_then_health_does_not_give_up` (new —
+    guards against over-correction: one kill + sustained health must NOT
+    give up), plus `is_restart_storm_trigger_*` and
+    `should_give_up_restart_storm_trips_ceiling_even_with_failures_reset`
+    pure-function unit tests.
+
+---
 ## [0.24.1] — 2026-07-21
 
 Patch release closing unpublished source drift under the already-published

--- a/crates/trusty-common/src/embedder_client/supervisor.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor.rs
@@ -556,6 +556,26 @@ fn is_restart_storm_trigger(trigger: &RestartTrigger) -> bool {
 /// process-exit crash-loop case (#3631) — one shared reset window, since both
 /// represent the same underlying condition: sustained real-world health since
 /// the last forced restart.
+///
+/// Timing note (inherited from the #1450 design, made explicit for #3631):
+/// `supervision_loop` calls this exactly once per loop iteration, at
+/// iteration entry — synchronously, immediately after the PREVIOUS
+/// iteration's respawn completes, with no further `.await` before it. So
+/// `elapsed_since_last_restart` at that call is anchored to time elapsed
+/// SINCE the last storm restart's OWN cycle (its back-off delay plus its
+/// respawn), not to "how long the sidecar has been sitting healthy waiting
+/// for the current iteration's next trigger" — a health period that unfolds
+/// entirely INSIDE one iteration's blocking wait is only observed by the
+/// NEXT iteration's check, i.e. after whatever restart ends that health
+/// period has already been counted. This is a deliberate, inherited
+/// tradeoff, not a defect: it means a crash cadence slower than
+/// `wedge_reset_secs` legitimately never accumulates (each restart's own
+/// back-off usually provides more than enough elapsed time for the
+/// following check to reset), while a genuinely tight loop — successive
+/// forced restarts closer together than `wedge_reset_secs` — correctly
+/// keeps escalating. See `supervisor_single_transient_crash_then_health_does_not_give_up`
+/// in `supervisor_tests.rs` for a worked example (and a mutation-verified
+/// proof) of exactly which elapsed window this check can and cannot see.
 /// Test: `restart_storm_should_reset_*` in `supervisor_tests.rs`.
 fn restart_storm_should_reset(
     elapsed_since_last_restart: Option<Duration>,

--- a/crates/trusty-common/src/embedder_client/supervisor.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor.rs
@@ -43,12 +43,29 @@
 //! child itself, clears the PID slot, and returns *without* ever entering the
 //! crash-restart path — the intentional stop can never be misclassified.
 //!
+//! Restart-storm escalation (issue #3631): `consecutive_failures` alone is
+//! reset to 0 on every successful respawn (the startup probe succeeding),
+//! so a sidecar that keeps dying but whose individual respawns keep
+//! succeeding — the normal shape of "kill it, it comes back healthy",
+//! including a plain `SIGKILL` — could oscillate that counter 0→1→0→1
+//! forever and NEVER trip `should_give_up`/`terminated_signal`, at any
+//! `max_restarts`. `consecutive_restart_storm` (see
+//! `is_restart_storm_trigger`) is a second, non-resetting counter — the same
+//! design #1450's wedge-storm fix introduced for `RestartTrigger::Unhealthy`
+//! — now also fed by `RestartTrigger::ProcessExit`, so a sustained crash
+//! loop escalates in bounded time instead of resetting on every successful
+//! respawn. It resets only after `config.wedge_reset_secs` of sustained
+//! health, so a genuine one-off crash followed by real recovery does not
+//! trip give-up.
+//!
 //! Test: `supervisor_shutdown_kills_child`,
 //! `supervisor_shutdown_handle_is_reachable_and_stops_child`,
 //! `supervisor_intentional_shutdown_does_not_respawn`,
 //! `stdio_eof_terminates_child`,
 //! `supervisor_gives_up_after_max_restarts_flips_has_given_up` (PR #3560
-//! HIGH fix) in this module's `tests` submodule.
+//! HIGH fix), `supervisor_process_exit_crash_loop_reaches_give_up`,
+//! `supervisor_single_transient_crash_then_health_does_not_give_up` (issue
+//! #3631 fix) in this module's `tests` submodule.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -470,34 +487,81 @@ enum RestartTrigger {
     RespawnFailed,
 }
 
-// ── Wedge-restart-storm prevention (#1450 HIGH follow-up) ──────────────────
+/// Does this trigger represent "the sidecar needed a forced restart, despite
+/// the respawn that follows likely succeeding" — i.e. should it feed the
+/// non-resetting restart-storm counter (issue #3631 fix, extending the
+/// #1450 HIGH follow-up's wedge-storm design)?
+///
+/// Why: extracted as a small pure function, independent of
+/// `supervision_loop`'s async/I-O machinery, so the exact classification
+/// this fix depends on is directly, deterministically unit-testable — no
+/// real process, no OS-level race. That matters because a REAL killed
+/// process's trigger classification (`ProcessExit` vs `Unhealthy`) is
+/// itself a genuine, non-deterministic OS/tokio-scheduler race between
+/// `child.wait()` resolving and the reader task noticing stdout EOF (see
+/// `write_mock_embedderd_pipe_survives_kill`'s doc comment in
+/// `supervisor_tests.rs` for the full empirical account) — a test that only
+/// exercises this decision through a real kill could pass "by accident" via
+/// one classification even when the OTHER classification's wiring is
+/// broken, exactly the false-confidence gap issue #3631 documents.
+/// What: `true` for `RestartTrigger::Unhealthy` (unchanged from the #1450
+/// fix) AND for a `RestartTrigger::ProcessExit` whose exit was NOT clean
+/// (`!status.success()`) — issue #3631's fix: a plain crash-loop is exactly
+/// as capable of recurring despite successful respawns as a wedge storm is,
+/// so it must feed the same non-resetting counter. `false` for a clean exit
+/// (supervision stops entirely before this matters) and for
+/// `RestartTrigger::RespawnFailed`, which already escalates correctly via
+/// `consecutive_failures` alone — that counter is never reset on this path
+/// because the `Ok` respawn arm is never reached, so folding it into the
+/// storm counter too would be redundant, not incorrect.
+/// Test: `is_restart_storm_trigger_*` in `supervisor_tests.rs`.
+fn is_restart_storm_trigger(trigger: &RestartTrigger) -> bool {
+    match trigger {
+        RestartTrigger::Unhealthy => true,
+        RestartTrigger::ProcessExit(status) => !status.success(),
+        RestartTrigger::RespawnFailed => false,
+    }
+}
+
+// ── Restart-storm prevention (#1450 HIGH follow-up; extended to plain
+//    process-exit crash loops by issue #3631) ───────────────────────────────
 //
 // A workload-deterministic wedge (the sidecar reliably wedges again shortly
 // after every respawn because the WORKLOAD — not the process — triggers the
 // stall) previously never escalated: `consecutive_failures` reset to 0 on
 // every successful respawn (the respawn *probe* itself succeeds), so the
 // detect(90s)→kill→backoff→reset→re-wedge cycle repeated forever without ever
-// tripping `max_restarts`. `consecutive_wedge_restarts` is a second counter,
+// tripping `max_restarts`. `consecutive_restart_storm` is a second counter,
 // tracked alongside `consecutive_failures` in `supervision_loop`, that is
 // reset ONLY after sustained real-world health — never by an ordinary
-// respawn-probe success. The two pure functions below implement its
-// reset/give-up decisions so that logic is unit-testable without driving the
-// full async supervision loop.
+// respawn-probe success. The #1450 fix wired only `RestartTrigger::Unhealthy`
+// into this counter; issue #3631 found that a `RestartTrigger::ProcessExit`
+// crash-loop (e.g. repeated `SIGKILL`) has the exact same shape — each
+// individual respawn's startup probe can succeed while the process keeps
+// dying moments later — and was left bumping only the resettable
+// `consecutive_failures` counter, so it could oscillate 0→1→0→1 forever and
+// NEVER trip `should_give_up`, for any `max_restarts`. `is_restart_storm_trigger`
+// now classifies both trigger kinds identically. The two pure functions below
+// implement the reset/give-up decisions so that logic is unit-testable
+// without driving the full async supervision loop.
 
-/// Decide whether the wedge-restart escalation counter should reset.
+/// Decide whether the restart-storm escalation counter should reset.
 ///
 /// Why: extracted as a pure function (no I/O, no locking, no `Instant::now()`
 /// call) so the reset decision is directly unit-testable.
-/// What: `true` iff a prior wedge-restart happened (`elapsed_since_last_wedge`
+/// What: `true` iff a prior storm-restart happened (`elapsed_since_last_restart`
 /// is `Some`) and at least `wedge_reset_secs` have elapsed since then. `None`
-/// (no prior wedge this supervision run) never resets — there is nothing to
-/// reset.
-/// Test: `wedge_counter_should_reset_*` in `supervisor_tests.rs`.
-fn wedge_counter_should_reset(
-    elapsed_since_last_wedge: Option<Duration>,
+/// (no prior storm-restart this supervision run) never resets — there is
+/// nothing to reset. Governs both the wedge-storm case (#1450) and the
+/// process-exit crash-loop case (#3631) — one shared reset window, since both
+/// represent the same underlying condition: sustained real-world health since
+/// the last forced restart.
+/// Test: `restart_storm_should_reset_*` in `supervisor_tests.rs`.
+fn restart_storm_should_reset(
+    elapsed_since_last_restart: Option<Duration>,
     wedge_reset_secs: u64,
 ) -> bool {
-    match elapsed_since_last_wedge {
+    match elapsed_since_last_restart {
         Some(elapsed) => elapsed >= Duration::from_secs(wedge_reset_secs),
         None => false,
     }
@@ -505,21 +569,22 @@ fn wedge_counter_should_reset(
 
 /// Decide whether the supervisor should give up (stop respawning).
 ///
-/// Why: extracted as a pure function so the "storm" ceiling check — which now
-/// considers TWO independent counters instead of one — is directly
-/// unit-testable. Either counter alone exceeding `max_restarts` is
-/// sufficient: an ordinary crash storm (`consecutive_failures`) or a wedge
-/// storm that keeps recurring despite each individual respawn's startup
-/// probe succeeding (`consecutive_wedge_restarts`).
-/// What: `consecutive_failures > max_restarts || consecutive_wedge_restarts >
+/// Why: extracted as a pure function so the "storm" ceiling check — which
+/// considers TWO independent counters — is directly unit-testable. Either
+/// counter alone exceeding `max_restarts` is sufficient: the respawn attempt
+/// itself repeatedly failing (`consecutive_failures`, e.g. `RespawnFailed` or
+/// a spawn/probe error), or a restart storm that keeps recurring despite each
+/// individual respawn succeeding (`consecutive_restart_storm` — covers both
+/// a wedge storm and, since issue #3631, a plain process-exit crash loop).
+/// What: `consecutive_failures > max_restarts || consecutive_restart_storm >
 /// max_restarts`.
 /// Test: `should_give_up_*` in `supervisor_tests.rs`.
 fn should_give_up(
     consecutive_failures: u32,
-    consecutive_wedge_restarts: u32,
+    consecutive_restart_storm: u32,
     max_restarts: u32,
 ) -> bool {
-    consecutive_failures > max_restarts || consecutive_wedge_restarts > max_restarts
+    consecutive_failures > max_restarts || consecutive_restart_storm > max_restarts
 }
 
 /// Background supervision loop.
@@ -541,14 +606,17 @@ fn should_give_up(
 /// and cleared to 0 when supervision terminates so RSS samplers stop sampling
 /// a dead PID.
 ///
-/// Restart-storm prevention (#1450 HIGH follow-up): `consecutive_wedge_restarts`
-/// tracks wedge-triggered restarts specifically and — unlike
-/// `consecutive_failures` — is NOT reset by an ordinary respawn-probe
-/// success; it only resets once `wedge_counter_should_reset` observes
-/// `config.wedge_reset_secs` of sustained health since the last wedge. Both
-/// counters feed `should_give_up` and both drive the exponential back-off, so
-/// a workload-deterministic wedge that recurs after every respawn eventually
-/// trips `max_restarts` instead of cycling forever at a 1s backoff.
+/// Restart-storm prevention (#1450 HIGH follow-up, extended to plain
+/// process-exit crash loops by issue #3631): `consecutive_restart_storm`
+/// tracks both wedge-triggered AND crash (`ProcessExit`) restarts — see
+/// `is_restart_storm_trigger` — and, unlike `consecutive_failures`, is NOT
+/// reset by an ordinary respawn-probe success; it only resets once
+/// `restart_storm_should_reset` observes `config.wedge_reset_secs` of
+/// sustained health since the last storm restart. Both counters feed
+/// `should_give_up` and both drive the exponential back-off, so a
+/// workload-deterministic wedge OR a plain crash-loop that recurs after every
+/// respawn eventually trips `max_restarts` instead of cycling forever at a 1s
+/// backoff.
 /// Test: `supervisor_restarts_on_crash`,
 /// `supervisor_intentional_shutdown_does_not_respawn`.
 /// Test-only iteration counter (issue #3023 regression test): bumped once per
@@ -580,8 +648,11 @@ async fn supervision_loop(
     gave_up_tx: watch::Sender<bool>,
 ) {
     let mut consecutive_failures: u32 = 0;
-    let mut consecutive_wedge_restarts: u32 = 0;
-    let mut last_wedge_restart_at: Option<tokio::time::Instant> = None;
+    // Non-resetting restart-storm counter (#1450 HIGH follow-up, extended to
+    // plain process-exit crash loops by issue #3631) — see
+    // `is_restart_storm_trigger` and `restart_storm_should_reset`.
+    let mut consecutive_restart_storm: u32 = 0;
+    let mut last_restart_storm_at: Option<tokio::time::Instant> = None;
     // Set once `shutdown_rx` observes its sender closed (issue #3023 HIGH):
     // `watch::Receiver::changed()` resolves `Ready(Err(_))` on every
     // subsequent poll once the sender drops without ever calling
@@ -595,19 +666,20 @@ async fn supervision_loop(
         #[cfg(test)]
         SUPERVISION_LOOP_ITERATIONS.fetch_add(1, AtomicOrdering::Relaxed);
 
-        // Reset the wedge-restart escalation counter once sustained health
-        // has been observed since the last wedge — see `wedge_counter_should_reset`.
-        if wedge_counter_should_reset(
-            last_wedge_restart_at.map(|t| t.elapsed()),
+        // Reset the restart-storm escalation counter once sustained health
+        // has been observed since the last storm restart (wedge OR
+        // process-exit crash, issue #3631) — see `restart_storm_should_reset`.
+        if restart_storm_should_reset(
+            last_restart_storm_at.map(|t| t.elapsed()),
             config.wedge_reset_secs,
         ) {
             tracing::info!(
-                "EmbedderSupervisor: {}s without a further wedge — resetting wedge-restart \
-                 escalation counter (was {consecutive_wedge_restarts})",
+                "EmbedderSupervisor: {}s without a further forced restart — resetting \
+                 restart-storm escalation counter (was {consecutive_restart_storm})",
                 config.wedge_reset_secs,
             );
-            consecutive_wedge_restarts = 0;
-            last_wedge_restart_at = None;
+            consecutive_restart_storm = 0;
+            last_restart_storm_at = None;
         }
 
         // Race the child actually exiting against the live client reporting
@@ -691,7 +763,12 @@ async fn supervision_loop(
             }
         };
 
-        let is_wedge_restart = matches!(trigger, RestartTrigger::Unhealthy);
+        // #3631 fix: classify BEFORE the match (which may `return` on a clean
+        // exit, in which case this value is simply unused) so both the
+        // `ProcessExit` and `Unhealthy` arms below escalate the same
+        // non-resetting restart-storm counter via the shared code after the
+        // match, instead of only `Unhealthy` doing so.
+        let is_storm_trigger = is_restart_storm_trigger(&trigger);
 
         match trigger {
             RestartTrigger::ProcessExit(exit_status) => {
@@ -703,22 +780,23 @@ async fn supervision_loop(
                     return;
                 }
                 tracing::warn!(
-                    "EmbedderSupervisor: sidecar exited with {:?} (failure #{}/{})",
+                    "EmbedderSupervisor: sidecar exited with {:?} (failure #{}/{}, \
+                     restart-storm #{}/{})",
                     exit_status.code(),
                     consecutive_failures + 1,
+                    config.max_restarts,
+                    consecutive_restart_storm + 1,
                     config.max_restarts,
                 );
             }
             RestartTrigger::Unhealthy => {
-                consecutive_wedge_restarts += 1;
-                last_wedge_restart_at = Some(tokio::time::Instant::now());
                 tracing::warn!(
                     "EmbedderSupervisor: sidecar client reported unhealthy (reader task \
                      died, or accumulating call timeouts indicate a wedged process) — \
-                     forcing restart (failure #{}/{}, wedge-restart #{}/{})",
+                     forcing restart (failure #{}/{}, restart-storm #{}/{})",
                     consecutive_failures + 1,
                     config.max_restarts,
-                    consecutive_wedge_restarts,
+                    consecutive_restart_storm + 1,
                     config.max_restarts,
                 );
                 // The process may still be running (that's the whole point of
@@ -747,22 +825,33 @@ async fn supervision_loop(
         }
 
         consecutive_failures += 1;
+        // #3631 fix: a restart-storm trigger (wedge OR process-exit crash)
+        // escalates a SECOND, non-resetting counter — unlike
+        // `consecutive_failures` above, this one survives a successful
+        // respawn (see the `Ok((new_child, new_client)) =>` arm below, which
+        // deliberately does NOT reset it) and only resets after
+        // `restart_storm_should_reset` observes sustained health.
+        if is_storm_trigger {
+            consecutive_restart_storm += 1;
+            last_restart_storm_at = Some(tokio::time::Instant::now());
+        }
 
         if should_give_up(
             consecutive_failures,
-            consecutive_wedge_restarts,
+            consecutive_restart_storm,
             config.max_restarts,
         ) {
             tracing::error!(
                 "EmbedderSupervisor: exceeded max_restarts={} ({}) — giving up. \
                  Set TRUSTY_EMBEDDERD_MAX_RESTARTS to increase the limit, or \
-                 TRUSTY_EMBEDDERD_WEDGE_RESET_SECS if wedges are recurring faster \
+                 TRUSTY_EMBEDDERD_WEDGE_RESET_SECS if the storm is recurring faster \
                  than the sustained-health reset window.",
                 config.max_restarts,
-                if consecutive_wedge_restarts > config.max_restarts {
-                    "wedge-restart storm — recurring despite successful respawns"
+                if consecutive_restart_storm > config.max_restarts {
+                    "restart storm — recurring (wedge stall or crash loop) despite \
+                     successful respawns"
                 } else {
-                    "process-exit crash storm"
+                    "respawn-attempt failure storm — the respawn itself keeps failing"
                 },
             );
             // PR #3560 HIGH fix: flip the one-way give-up signal so callers
@@ -780,11 +869,12 @@ async fn supervision_loop(
         }
 
         // Exponential back-off: 1s, 2s, 4s, …, capped at backoff_max_secs.
-        // A wedge-triggered restart backs off against its own (non-resetting)
-        // counter so a recurring wedge escalates delay across cycles instead
-        // of returning to 1s every time the respawn probe itself succeeds.
-        let backoff_attempt = if is_wedge_restart {
-            consecutive_wedge_restarts
+        // A storm-triggered restart (wedge OR process-exit crash, #3631)
+        // backs off against its own (non-resetting) counter so a recurring
+        // storm escalates delay across cycles instead of returning to 1s
+        // every time the respawn probe itself succeeds.
+        let backoff_attempt = if is_storm_trigger {
+            consecutive_restart_storm
         } else {
             consecutive_failures
         };
@@ -792,8 +882,8 @@ async fn supervision_loop(
         tracing::info!(
             "EmbedderSupervisor: restarting sidecar in {delay_secs}s (attempt \
              {consecutive_failures}{})",
-            if is_wedge_restart {
-                format!(", wedge-triggered, wedge-restart #{consecutive_wedge_restarts}")
+            if is_storm_trigger {
+                format!(", storm-triggered, restart-storm #{consecutive_restart_storm}")
             } else {
                 String::new()
             },
@@ -861,9 +951,13 @@ async fn supervision_loop(
                 child_pid_slot.store(new_pid, AtomicOrdering::Release);
 
                 // Reset the ordinary failure count — the new process is up.
-                // NOTE: `consecutive_wedge_restarts` is deliberately NOT reset
-                // here (see its doc comment and `wedge_counter_should_reset`)
-                // — only sustained real-world health resets it.
+                // NOTE: `consecutive_restart_storm` is deliberately NOT reset
+                // here (see its doc comment and `restart_storm_should_reset`)
+                // — only sustained real-world health resets it. This is the
+                // exact bug issue #3631 fixed: before that fix, a plain
+                // process-exit crash-loop had NO non-resetting counter at
+                // all, so `consecutive_failures` resetting here every time
+                // meant such a crash-loop could never trip `should_give_up`.
                 consecutive_failures = 0;
                 tracing::info!(
                     "EmbedderSupervisor: sidecar restarted successfully (pid={new_pid})"

--- a/crates/trusty-common/src/embedder_client/supervisor_config.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor_config.rs
@@ -59,19 +59,22 @@ pub struct SupervisorConfig {
     /// Test: `sidecar_batch_size_*` tests in this module.
     pub sidecar_batch_size: Option<usize>,
 
-    /// Seconds of sustained health (no further wedge-triggered restart)
-    /// required before the supervisor resets its wedge-restart escalation
-    /// counter back to zero (#1450 HIGH follow-up — restart-storm fix).
+    /// Seconds of sustained health (no further storm-triggered restart)
+    /// required before the supervisor resets its restart-storm escalation
+    /// counter back to zero (#1450 HIGH follow-up — restart-storm fix;
+    /// extended to plain process-exit crash loops by issue #3631).
     ///
     /// Why: a workload-deterministic wedge (the sidecar reliably wedges again
     /// shortly after every respawn, because the *workload* — not the process
-    /// — is what triggers the stall) would otherwise never escalate: the
-    /// ordinary `consecutive_failures` counter resets on every successful
-    /// respawn, since the respawn *probe* itself succeeds even though the
-    /// real workload re-wedges it moments later. `EmbedderSupervisor` tracks
-    /// wedge-triggered restarts in a separate counter that is reset ONLY
-    /// after this many seconds have elapsed since the last one — not by an
-    /// ordinary respawn-probe success — so a genuine storm eventually trips
+    /// — is what triggers the stall) — or, equally, a plain crash loop where
+    /// the process itself keeps dying and coming back up healthy — would
+    /// otherwise never escalate: the ordinary `consecutive_failures` counter
+    /// resets on every successful respawn, since the respawn *probe* itself
+    /// succeeds even though the sidecar dies (or re-wedges) again moments
+    /// later. `EmbedderSupervisor` tracks BOTH kinds of forced restart in a
+    /// separate, non-resetting counter that is reset ONLY after this many
+    /// seconds have elapsed since the last one — not by an ordinary
+    /// respawn-probe success — so a genuine storm eventually trips
     /// `max_restarts` instead of cycling forever.
     ///
     /// Env: `TRUSTY_EMBEDDERD_WEDGE_RESET_SECS` (default 300 = 5 minutes).

--- a/crates/trusty-common/src/embedder_client/supervisor_tests.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor_tests.rs
@@ -1114,29 +1114,61 @@ exit 1
         );
     }
 
-    /// Guards against over-correcting #3631's fix: a single transient
-    /// `ProcessExit`, followed by sustained health for the full
-    /// `wedge_reset_secs` window, must NOT trip give-up — only a *sustained*
-    /// crash-loop should.
+    /// Guards against over-correcting #3631's fix: TWO forced restarts, each
+    /// separated by enough real elapsed time for `restart_storm_should_reset`
+    /// to have fired in between, must NOT trip give-up — only a *sustained*
+    /// crash-loop (restarts recurring FASTER than the reset window) should.
     ///
-    /// Why: the fix for #3631 makes `ProcessExit` feed the same
-    /// non-resetting restart-storm counter as `Unhealthy` restarts. Without
-    /// this test, a regression that forgot the sustained-health reset
-    /// condition (e.g. making the counter never reset at all) would make
-    /// every sidecar permanently one crash away from a false give-up,
-    /// defeating the entire point of automatic respawn.
-    /// What: a short `wedge_reset_secs` (1s) so the test itself stays fast.
-    /// Kills the mock exactly once, confirms it respawns (a fresh non-zero
-    /// PID), then waits comfortably longer than `wedge_reset_secs` and
-    /// asserts `has_given_up()` is still `false` — proving the one-off kill
-    /// did not accumulate toward the ceiling.
+    /// Why — and why this is NOT the same shape as the original (defective)
+    /// version of this test: a code-critic mutation audit on PR #3645 proved
+    /// the original version (one kill, then an external `tokio::time::sleep`
+    /// in the TEST before asserting) could never fail even with the reset
+    /// call site fully disabled (`if false && restart_storm_should_reset(...)`
+    /// at supervisor.rs) — with `max_restarts: 1` and only ONE kill,
+    /// `consecutive_restart_storm` can only ever reach 1, and `should_give_up`
+    /// requires `> max_restarts`, so `has_given_up()` was `false` whether or
+    /// not the reset worked. The deeper reason a sleep AFTER observing the
+    /// respawn can never matter: `supervision_loop`'s reset-check
+    /// (supervisor.rs, top of the `loop`) runs exactly ONCE per iteration, at
+    /// iteration entry — i.e. synchronously, immediately after the PREVIOUS
+    /// iteration's respawn completes, with NO further `.await` before it. By
+    /// the time a test's poll notices the fresh PID (already past that
+    /// synchronous check) and starts sleeping, the reset decision for THIS
+    /// iteration has already been made and cannot be revisited — a sleep
+    /// injected afterward is invisible to it. The ONLY wall-clock gap that
+    /// check can ever observe is the elapsed time accumulated INSIDE the
+    /// PRECEDING iteration, i.e. its own exponential back-off delay
+    /// (`1 << consecutive_restart_storm`, capped at `backoff_max_secs`) —
+    /// that delay is a `.await` point BEFORE the respawn, so real time
+    /// genuinely passes there before the next iteration's check runs.
+    /// What: `max_restarts: 1`, `wedge_reset_secs: 1`, `backoff_max_secs: 5`
+    /// (uncapped for a 2s delay). First kill escalates
+    /// `consecutive_restart_storm` 0→1, whose back-off is
+    /// `1 << 1 = 2s` — comfortably longer than `wedge_reset_secs` (1s), so a
+    /// CORRECT reset fires at the very next iteration's entry (right after
+    /// that 2s back-off + the respawn that follows it), zeroing the counter
+    /// BEFORE the second kill is ever processed. The test waits for that
+    /// second respawn (proving the 2s cycle completed), then kills
+    /// immediately: a correct reset means this second kill only brings the
+    /// counter to 1 (not 2) — well under `max_restarts: 1` — so
+    /// `has_given_up()` must stay `false`. A broken/disabled reset leaves the
+    /// counter at 1 from the first kill, so the second kill pushes it to 2,
+    /// tripping give-up — which is exactly what the mutation check below
+    /// confirms.
+    /// Mutation-verified (issue #3631 PR #3645 review round 1): with the
+    /// reset call site disabled, this test fails (`has_given_up()` is
+    /// unexpectedly `true`); restored, it passes. See the PR body for both
+    /// raw runs.
     /// Test: this test.
     #[tokio::test]
     async fn supervisor_single_transient_crash_then_health_does_not_give_up() {
         let (_dir, binary) = write_mock_embedderd_pipe_survives_kill();
         let cfg = SupervisorConfig {
             startup_timeout_secs: 5,
-            backoff_max_secs: 0,
+            // Deliberately NOT clamped below the 2s delay the first kill's
+            // back-off computes (`1 << 1`) — that delay is the mechanism
+            // under test; see this test's doc comment.
+            backoff_max_secs: 5,
             max_restarts: 1,
             wedge_reset_secs: 1,
             ..SupervisorConfig::default()
@@ -1149,38 +1181,50 @@ exit 1
 
         let handle = supervisor.start_supervisor_task();
 
+        // First kill: escalates consecutive_restart_storm 0 -> 1, which
+        // computes a 2s back-off (1 << 1) before the respawn that follows.
         std::process::Command::new("kill")
             .args(["-9", &initial_pid.to_string()])
             .status()
-            .expect("kill -9 mock child");
+            .expect("kill -9 mock child (first)");
 
-        // Condition-based wait for the respawn to complete (fresh non-zero
-        // PID), not a fixed sleep-and-hope.
-        let respawned = tokio::time::timeout(Duration::from_secs(10), async {
+        // Condition-based wait for the SECOND respawn — a fresh non-zero PID
+        // distinct from `initial_pid`. By the time this resolves, the 2s
+        // back-off has elapsed and `supervision_loop`'s reset-check for the
+        // new iteration has already run synchronously (see doc comment) —
+        // a correct reset has already zeroed the counter at this point.
+        let second_pid = tokio::time::timeout(Duration::from_secs(10), async {
             loop {
                 let pid = pid_slot.load(Ordering::Acquire);
                 if pid != 0 && pid != initial_pid {
-                    return;
+                    return pid;
                 }
                 tokio::time::sleep(Duration::from_millis(5)).await;
             }
         })
-        .await;
-        assert!(
-            respawned.is_ok(),
-            "supervisor never respawned after the single kill within 10s"
-        );
+        .await
+        .expect("supervisor never respawned after the first kill within 10s");
 
-        // Sit past the sustained-health reset window (1s) comfortably —
-        // long enough that a correctly-implemented fix has reset the
-        // restart-storm counter, but short enough to keep the test fast.
-        tokio::time::sleep(Duration::from_millis(1500)).await;
+        // Second kill, immediately — no sleep needed or wanted here: the
+        // reset decision that matters was already made (or not) the instant
+        // the loop re-entered after the first kill's back-off, strictly
+        // BEFORE this second kill is even sent.
+        std::process::Command::new("kill")
+            .args(["-9", &second_pid.to_string()])
+            .status()
+            .expect("kill -9 mock child (second)");
+
+        // Bounded window for the second kill to be observed and processed
+        // (well under its own back-off delay, so this does not race a THIRD
+        // respawn).
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         assert!(
             !handle.has_given_up(),
-            "a single transient crash followed by sustained health past \
-             wedge_reset_secs must NOT trip give-up — only a sustained \
-             crash-loop should"
+            "two forced restarts separated by more than wedge_reset_secs \
+             (via the first restart's own back-off delay) must NOT trip \
+             give-up — the reset must have fired between them, leaving the \
+             second kill well under max_restarts=1"
         );
     }
 }

--- a/crates/trusty-common/src/embedder_client/supervisor_tests.rs
+++ b/crates/trusty-common/src/embedder_client/supervisor_tests.rs
@@ -255,51 +255,54 @@ fn locate_binary_respects_explicit_override() {
     }
 }
 
-// ── Wedge-restart-storm prevention (#1450 HIGH follow-up) ──────────────
+// ── Restart-storm prevention (#1450 HIGH follow-up; extended to plain
+//    process-exit crash loops by issue #3631) ────────────────────────────
 //
-// `wedge_counter_should_reset` and `should_give_up` are pure functions
-// (no async, no I/O) — the async supervision loop itself is exercised only
-// by the ignored real-binary e2e tests, so this logic is unit-tested
-// directly here per the review guidance ("test the counter logic as a pure
-// function if the async path is hard to drive").
+// `restart_storm_should_reset`, `should_give_up`, and `is_restart_storm_trigger`
+// are pure functions (no async, no I/O) — the async supervision loop itself
+// is exercised only by the real-process tests further down (plus the
+// ignored real-binary e2e tests), so this logic is unit-tested directly
+// here per the review guidance ("test the counter logic as a pure function
+// if the async path is hard to drive").
 
 #[test]
-fn wedge_counter_should_reset_none_never_resets() {
-    // Why: no prior wedge this run — nothing to reset.
-    // What: `elapsed_since_last_wedge = None` → always false regardless of
+fn restart_storm_should_reset_none_never_resets() {
+    // Why: no prior storm restart this run — nothing to reset.
+    // What: `elapsed_since_last_restart = None` → always false regardless of
     // the configured window.
     // Test: this test.
-    assert!(!wedge_counter_should_reset(None, 300));
-    assert!(!wedge_counter_should_reset(None, 0));
+    assert!(!restart_storm_should_reset(None, 300));
+    assert!(!restart_storm_should_reset(None, 0));
 }
 
 #[test]
-fn wedge_counter_should_reset_before_window_stays_escalated() {
-    // Why: a wedge that recurs before the sustained-health window elapses
-    // must NOT reset — that is exactly the storm case this fix targets.
+fn restart_storm_should_reset_before_window_stays_escalated() {
+    // Why: a storm restart that recurs before the sustained-health window
+    // elapses must NOT reset — that is exactly the storm case this fix
+    // targets.
     // What: elapsed < wedge_reset_secs → false.
     // Test: this test.
-    assert!(!wedge_counter_should_reset(
+    assert!(!restart_storm_should_reset(
         Some(Duration::from_secs(299)),
         300
     ));
-    assert!(!wedge_counter_should_reset(
+    assert!(!restart_storm_should_reset(
         Some(Duration::from_secs(0)),
         300
     ));
 }
 
 #[test]
-fn wedge_counter_should_reset_after_window_resets() {
+fn restart_storm_should_reset_after_window_resets() {
     // Why: sustained health for the configured window is the ONLY way the
     // counter resets (never an ordinary respawn-probe success).
     // What: elapsed >= wedge_reset_secs → true, at and beyond the boundary.
     // Test: this test.
-    assert!(wedge_counter_should_reset(
+    assert!(restart_storm_should_reset(
         Some(Duration::from_secs(300)),
         300
     ));
-    assert!(wedge_counter_should_reset(
+    assert!(restart_storm_should_reset(
         Some(Duration::from_secs(301)),
         300
     ));
@@ -325,14 +328,15 @@ fn should_give_up_crash_storm_trips_ceiling() {
 }
 
 #[test]
-fn should_give_up_wedge_storm_trips_ceiling_even_with_failures_reset() {
+fn should_give_up_restart_storm_trips_ceiling_even_with_failures_reset() {
     // Why: THIS is the restart-storm fix under test — a workload-
-    // deterministic wedge where every individual respawn probe succeeds
-    // (so `consecutive_failures` is reset to 0 each cycle by the caller)
-    // must still eventually give up once `consecutive_wedge_restarts`
-    // climbs past `max_restarts`.
+    // deterministic wedge, OR (since issue #3631) a plain process-exit
+    // crash loop, where every individual respawn probe succeeds (so
+    // `consecutive_failures` is reset to 0 each cycle by the caller) must
+    // still eventually give up once `consecutive_restart_storm` climbs past
+    // `max_restarts`.
     // What: consecutive_failures=0 (just reset by a successful respawn),
-    // consecutive_wedge_restarts=6 > max_restarts=5 → true.
+    // consecutive_restart_storm=6 > max_restarts=5 → true.
     // Test: this test.
     assert!(should_give_up(0, 6, 5));
 }
@@ -340,11 +344,68 @@ fn should_give_up_wedge_storm_trips_ceiling_even_with_failures_reset() {
 #[test]
 fn should_give_up_at_boundary_does_not_trip() {
     // Why: the ceiling is `> max_restarts`, not `>=` — exactly
-    // `max_restarts` consecutive failures/wedges is still tolerated (matches
-    // the pre-existing crash-storm semantics).
+    // `max_restarts` consecutive failures/storm-restarts is still tolerated
+    // (matches the pre-existing crash-storm semantics).
     // What: both counters exactly at max_restarts → false.
     // Test: this test.
     assert!(!should_give_up(5, 5, 5));
+}
+
+// ── `is_restart_storm_trigger` classification (issue #3631 fix) ────────
+
+#[test]
+fn is_restart_storm_trigger_unhealthy_is_storm() {
+    // Why: unchanged from the #1450 fix — an `Unhealthy` signal always
+    // represents a forced restart that must feed the non-resetting counter.
+    // What: `RestartTrigger::Unhealthy` → true.
+    // Test: this test.
+    assert!(is_restart_storm_trigger(&RestartTrigger::Unhealthy));
+}
+
+#[test]
+fn is_restart_storm_trigger_process_exit_failure_is_storm() {
+    // Why: THIS is the exact issue #3631 fix — a failing process exit (e.g.
+    // a `SIGKILL`) must now ALSO feed the non-resetting storm counter,
+    // unlike before this fix where it only bumped the resettable
+    // `consecutive_failures`.
+    // What: `RestartTrigger::ProcessExit` with a non-zero/signal exit status
+    // → true. Constructs a real `ExitStatus` via `ExitStatusExt::from_raw`
+    // (stable on Unix) rather than running a process — deterministic, no
+    // I/O, no OS-level race.
+    // Test: this test.
+    use std::os::unix::process::ExitStatusExt;
+    let killed = std::process::ExitStatus::from_raw(9);
+    assert!(!killed.success(), "raw status 9 must not report success()");
+    assert!(is_restart_storm_trigger(&RestartTrigger::ProcessExit(
+        killed
+    )));
+}
+
+#[test]
+fn is_restart_storm_trigger_process_exit_clean_is_not_storm() {
+    // Why: a clean exit stops supervision entirely before `should_give_up`
+    // is ever consulted — but the classification itself must still be
+    // correct (false), not merely unreachable, since it is unit-tested in
+    // isolation from `supervision_loop`'s control flow here.
+    // What: `RestartTrigger::ProcessExit` with a zero exit status → false.
+    // Test: this test.
+    use std::os::unix::process::ExitStatusExt;
+    let clean = std::process::ExitStatus::from_raw(0);
+    assert!(clean.success(), "raw status 0 must report success()");
+    assert!(!is_restart_storm_trigger(&RestartTrigger::ProcessExit(
+        clean
+    )));
+}
+
+#[test]
+fn is_restart_storm_trigger_respawn_failed_is_not_storm() {
+    // Why: `RespawnFailed` already escalates correctly via
+    // `consecutive_failures` alone (never reset on this path, since the `Ok`
+    // respawn arm is never reached) — folding it into the storm counter too
+    // would be redundant, not a correctness requirement.
+    // What: `RestartTrigger::RespawnFailed` → false.
+    // Test: this test.
+    assert!(!is_restart_storm_trigger(&RestartTrigger::RespawnFailed));
 }
 
 // ── Cooperative shutdown (issue #2979) ──────────────────────────────────
@@ -388,6 +449,60 @@ mod shutdown_tests {
         std::fs::write(
             &path,
             r#"#!/bin/sh
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+  [ -n "$id" ] || id=1
+  printf '{"jsonrpc":"2.0","result":{"embeddings":[[0.1]]},"id":%s}\n' "$id"
+done
+"#,
+        )
+        .expect("write mock script");
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&path, perms).expect("chmod +x");
+        (dir, path)
+    }
+
+    /// Like `write_mock_embedderd`, but backgrounds a detached `sleep` job
+    /// that inherits (and so keeps open) this process's stdout file
+    /// descriptor before entering its read loop.
+    ///
+    /// Why (issue #3631 deterministic reproduction): `EmbedderSupervisor`'s
+    /// `supervision_loop` races `child.wait()` against the live client's
+    /// reader task noticing stdout EOF (`unhealthy_signal`). Killing an
+    /// ordinary mock (`write_mock_embedderd`) with `kill -9` closes its
+    /// stdout immediately, so which future resolves first — SIGCHLD-driven
+    /// process reaping, or the reader task's next `read()` returning 0 bytes
+    /// — is a genuine OS/tokio-scheduler race with NO portable, deterministic
+    /// outcome (empirically this race can go either way depending on
+    /// environment — see this module's #3631 fix note). A test built on that
+    /// race cannot reliably prove the `ProcessExit`-specific escalation path
+    /// this fix adds: it would sometimes "pass" pre-fix purely by accident
+    /// (via the already-correct `Unhealthy` counter), exactly the false
+    /// confidence issue #3631 documents in
+    /// `supervisor_gives_up_after_max_restarts_flips_has_given_up`. This mock
+    /// closes that race: the backgrounded `sleep` job inherits fd 1 (stdout)
+    /// from the shell script and is NOT itself targeted by a `kill -9` of the
+    /// script's own PID (SIGKILL is delivered to exactly the PID named, not
+    /// its children), so it keeps the pipe's write end open as an orphan
+    /// after the script dies. The reader task's next read simply blocks (no
+    /// data, no EOF) instead of ever observing end-of-stream, so
+    /// `unhealthy_signal` can never fire from this kill — `child.wait()` is
+    /// the ONLY signal `supervision_loop` can observe, guaranteeing a pure,
+    /// deterministic `RestartTrigger::ProcessExit` classification every time.
+    /// What: identical wire protocol to `write_mock_embedderd` (answers
+    /// forever), preceded by `sleep 20 &` to fork the pipe-holding orphan.
+    /// The 20s bound self-terminates the orphan well after any test using
+    /// this mock has finished.
+    /// Test: `supervisor_process_exit_crash_loop_reaches_give_up`,
+    /// `supervisor_single_transient_crash_then_health_does_not_give_up`.
+    fn write_mock_embedderd_pipe_survives_kill() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let path = dir.path().join("mock-embedderd-pipe-survives-kill.sh");
+        std::fs::write(
+            &path,
+            r#"#!/bin/sh
+sleep 20 &
 while IFS= read -r line; do
   id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
   [ -n "$id" ] || id=1
@@ -918,5 +1033,154 @@ exit 1
             "an intentional cooperative shutdown must never set terminated_signal"
         );
         assert_eq!(pid_slot.load(Ordering::Acquire), 0);
+    }
+
+    /// Reproduces issue #3631: a sidecar that keeps getting killed, but whose
+    /// EVERY individual respawn's startup probe succeeds, must still
+    /// eventually reach give-up — not oscillate `consecutive_failures`
+    /// 0→1→0→1 forever.
+    ///
+    /// Why: the existing `supervisor_gives_up_after_max_restarts_flips_has_given_up`
+    /// test above uses `write_mock_embedderd_crash_once`, a mock that
+    /// self-exits right after answering its own startup probe. Issue #3631's
+    /// investigation found that self-exit reaches give-up only by
+    /// *accidentally* racing the reader task's pipe-EOF detection into an
+    /// `Unhealthy` classification (which already used the non-resetting
+    /// wedge counter) — a race that does not hold for a real external
+    /// `SIGKILL`: `child.wait()`'s SIGCHLD-driven resolution reliably beats
+    /// the reader task noticing EOF, so an externally killed process is
+    /// classified `RestartTrigger::ProcessExit` every time (verified
+    /// empirically against real hardware in the issue). Before the #3631
+    /// fix, `ProcessExit` only bumped the resettable `consecutive_failures`
+    /// counter, which reset to 0 the instant each respawn's startup probe
+    /// succeeded (supervisor.rs, the `Ok((new_child, new_client)) =>` arm) —
+    /// so THIS test (repeated external `kill -9`, never a self-exit) never
+    /// reached give-up and timed out against unfixed `origin/main` (see PR
+    /// body for the pre-fix failing run). After the fix, `ProcessExit` also
+    /// escalates the non-resetting restart-storm counter, so give-up is
+    /// reached deterministically instead of by accident.
+    /// What: spawns the idling mock (`write_mock_embedderd`, answers forever,
+    /// never self-exits), then repeatedly polls `pid_slot` for a fresh
+    /// non-zero PID and immediately `kill -9`s it — with `backoff_max_secs:
+    /// 0` (near-instant respawns) and `wedge_reset_secs: 3600` (the
+    /// sustained-health reset window can never fire mid-test) so the only
+    /// way this test can pass is via the crash-loop escalation path itself.
+    /// Asserts `has_given_up()` flips within a bounded timeout.
+    /// Test: this test.
+    #[tokio::test]
+    async fn supervisor_process_exit_crash_loop_reaches_give_up() {
+        let (_dir, binary) = write_mock_embedderd_pipe_survives_kill();
+        let cfg = SupervisorConfig {
+            startup_timeout_secs: 5,
+            backoff_max_secs: 0,
+            max_restarts: 2,
+            wedge_reset_secs: 3600,
+            ..SupervisorConfig::default()
+        };
+        let (supervisor, _client_slot, pid_slot) = EmbedderSupervisor::spawn_stdio(binary, cfg)
+            .await
+            .expect("spawn_stdio failed");
+        let initial_pid = pid_slot.load(Ordering::Acquire);
+        assert!(initial_pid > 0, "pid_slot must be populated after spawn");
+
+        let handle = supervisor.start_supervisor_task();
+
+        let gave_up = tokio::time::timeout(Duration::from_secs(30), async {
+            let mut last_killed_pid = 0u32;
+            loop {
+                if handle.has_given_up() {
+                    return;
+                }
+                let pid = pid_slot.load(Ordering::Acquire);
+                if pid != 0 && pid != last_killed_pid {
+                    last_killed_pid = pid;
+                    std::process::Command::new("kill")
+                        .args(["-9", &pid.to_string()])
+                        .status()
+                        .expect("kill -9 mock child");
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            gave_up.is_ok(),
+            "has_given_up() never flipped within 30s of a repeated external \
+             SIGKILL crash loop (max_restarts=2) where each individual \
+             respawn's startup probe succeeds — this reproduces issue \
+             #3631's oscillating consecutive_failures bug if the fix \
+             regresses"
+        );
+    }
+
+    /// Guards against over-correcting #3631's fix: a single transient
+    /// `ProcessExit`, followed by sustained health for the full
+    /// `wedge_reset_secs` window, must NOT trip give-up — only a *sustained*
+    /// crash-loop should.
+    ///
+    /// Why: the fix for #3631 makes `ProcessExit` feed the same
+    /// non-resetting restart-storm counter as `Unhealthy` restarts. Without
+    /// this test, a regression that forgot the sustained-health reset
+    /// condition (e.g. making the counter never reset at all) would make
+    /// every sidecar permanently one crash away from a false give-up,
+    /// defeating the entire point of automatic respawn.
+    /// What: a short `wedge_reset_secs` (1s) so the test itself stays fast.
+    /// Kills the mock exactly once, confirms it respawns (a fresh non-zero
+    /// PID), then waits comfortably longer than `wedge_reset_secs` and
+    /// asserts `has_given_up()` is still `false` — proving the one-off kill
+    /// did not accumulate toward the ceiling.
+    /// Test: this test.
+    #[tokio::test]
+    async fn supervisor_single_transient_crash_then_health_does_not_give_up() {
+        let (_dir, binary) = write_mock_embedderd_pipe_survives_kill();
+        let cfg = SupervisorConfig {
+            startup_timeout_secs: 5,
+            backoff_max_secs: 0,
+            max_restarts: 1,
+            wedge_reset_secs: 1,
+            ..SupervisorConfig::default()
+        };
+        let (supervisor, _client_slot, pid_slot) = EmbedderSupervisor::spawn_stdio(binary, cfg)
+            .await
+            .expect("spawn_stdio failed");
+        let initial_pid = pid_slot.load(Ordering::Acquire);
+        assert!(initial_pid > 0, "pid_slot must be populated after spawn");
+
+        let handle = supervisor.start_supervisor_task();
+
+        std::process::Command::new("kill")
+            .args(["-9", &initial_pid.to_string()])
+            .status()
+            .expect("kill -9 mock child");
+
+        // Condition-based wait for the respawn to complete (fresh non-zero
+        // PID), not a fixed sleep-and-hope.
+        let respawned = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let pid = pid_slot.load(Ordering::Acquire);
+                if pid != 0 && pid != initial_pid {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await;
+        assert!(
+            respawned.is_ok(),
+            "supervisor never respawned after the single kill within 10s"
+        );
+
+        // Sit past the sustained-health reset window (1s) comfortably —
+        // long enough that a correctly-implemented fix has reset the
+        // restart-storm counter, but short enough to keep the test fast.
+        tokio::time::sleep(Duration::from_millis(1500)).await;
+
+        assert!(
+            !handle.has_given_up(),
+            "a single transient crash followed by sustained health past \
+             wedge_reset_secs must NOT trip give-up — only a sustained \
+             crash-loop should"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3631: `EmbedderSupervisor::supervision_loop` tracked a single non-resetting escalation counter (`consecutive_wedge_restarts`, #1450 HIGH follow-up) for `RestartTrigger::Unhealthy` only. `RestartTrigger::ProcessExit` — the classification a `SIGKILL` or any real crash produces — only bumped the ordinary `consecutive_failures` counter, which is unconditionally reset to 0 on every successful respawn. A sidecar that kept dying but whose individual respawns kept succeeding (the normal "kill it, it comes back healthy" shape) could therefore oscillate `consecutive_failures` 0→1→0→1 forever and never satisfy `should_give_up` for any `max_restarts` — so `terminated_signal()`/`is_confirmed_terminated()` never fired and the python→ort swap-back watchdog (epic #3524 slice 6) never engaged.

## Fix

Renamed/generalized `consecutive_wedge_restarts` → `consecutive_restart_storm` and extended the new `is_restart_storm_trigger()` classifier to cover **both** `RestartTrigger::Unhealthy` (unchanged) **and** a failing `RestartTrigger::ProcessExit` (new). This is the exact "fold plain crash-exits into the same counter/reset-window as wedge restarts" option the issue suggested — no divergent mechanism, no third give-up signal, no second ort-builder. The two existing give-up signals (`terminated_signal()` / `has_given_up()`) are completely unchanged in shape; only the internal counter feeding `should_give_up()` was widened.

**Escalation threshold:** unchanged — `consecutive_restart_storm > max_restarts` (default `max_restarts = 5`), same ceiling the wedge-storm path already used.

**Reset condition:** unchanged — `restart_storm_should_reset()` requires `wedge_reset_secs` (default 300s, env `TRUSTY_EMBEDDERD_WEDGE_RESET_SECS`) of sustained health since the last storm-triggered restart (wedge OR crash) before the counter zeroes. This is deliberately the *same* window already governing the wedge path — the issue explicitly sanctions sharing it, and a single shared window means a genuine one-off crash followed by real recovery does NOT trip give-up (see `supervisor_single_transient_crash_then_health_does_not_give_up`), while a *sustained* crash-loop (repeated forced restarts inside that window) does.

`consecutive_failures` keeps its original job unchanged: it still resets on every successful respawn and still independently gates the "the respawn attempt itself keeps failing" case (`RestartTrigger::RespawnFailed` / spawn errors), which already worked correctly before this fix.

## Invariant confirmed intact

The latch still trips ONLY on the supervisor's real give-up (`has_given_up()` / `terminated_signal()`) — I did not touch `swap_back_watchdog.rs` or any request-failure/count proxy. `terminated.store(true, …)` and `gave_up_tx.send(true)` are still set at exactly the one `should_give_up` return path, never on a clean exit or a cooperative `shutdown()`.

## Deterministic reproduction (the crux)

A test built on a real `kill -9` of a real mock child turned out to be **non-deterministic** in this environment: killing a process closes its stdout pipe, and whether `child.wait()` (SIGCHLD-driven) or the reader task noticing EOF (which flips `unhealthy_signal`) resolves first is a genuine OS/tokio-scheduler race — sometimes racing into `Unhealthy` (which already used the non-resetting counter, pre-fix), silently masking the bug. This is exactly the false-confidence gap #3631 documents in the *existing* `supervisor_gives_up_after_max_restarts_flips_has_given_up` test.

To get a **deterministic** repro, the new mock (`write_mock_embedderd_pipe_survives_kill`) backgrounds a detached `sleep 20 &` before its read loop — that orphan inherits (and keeps open) the pipe's write-end fd even after `kill -9` reaps the parent script, so the reader task's next read just blocks (no EOF) instead of ever firing `unhealthy_signal`. This guarantees pure `RestartTrigger::ProcessExit` classification on every cycle, no race.

### Pre-fix (unfixed `origin/main` @ `d73afcb1`) — FAILS

```
DEBUG-TRACE: trigger="ProcessExit(...)" consecutive_failures(before_inc)=0 consecutive_wedge_restarts(before_inc)=0
DEBUG-TRACE: trigger="ProcessExit(...)" consecutive_failures(before_inc)=0 consecutive_wedge_restarts(before_inc)=0
... (repeats — consecutive_wedge_restarts NEVER increments; only ProcessExit ever fires)

thread 'embedder_client::supervisor::tests::shutdown_tests::supervisor_process_exit_crash_loop_reaches_give_up' panicked at crates/trusty-common/src/embedder_client/supervisor_tests.rs:1046:9:
has_given_up() never flipped within 30s of a repeated external SIGKILL crash loop (max_restarts=2) where each individual respawn's startup probe succeeds — this reproduces issue #3631's oscillating consecutive_failures bug if the fix regresses

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 286 filtered out; finished in 30.57s
```

### Post-fix — PASSES (fast, deterministic, 5/5 reruns ~0.16-0.19s)

```
test embedder_client::supervisor::tests::shutdown_tests::supervisor_process_exit_crash_loop_reaches_give_up ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 290 filtered out; finished in 0.18s
```

Also added `supervisor_single_transient_crash_then_health_does_not_give_up` (guards against over-correction: one kill + sustained health past `wedge_reset_secs` must NOT give up) and pure-function unit tests for the new `is_restart_storm_trigger()` classifier (using `std::os::unix::process::ExitStatusExt::from_raw` to construct `ExitStatus` values with zero I/O / zero race).

### Real-hardware ignored test (`crates/trusty-search/.../start/tests.rs:1980`)

Not touched (out of scope / other PRs' lane per instructions). This fix should make its expectation correct: `swap_back_real_hardware_kills_sidecar_past_max_restarts` repeatedly `kill -9`s a real sidecar with `max_restarts=1` and waits up to 90s for `is_confirmed_terminated()` — with this fix, a real SIGKILL crash-loop now escalates `consecutive_restart_storm` on every `ProcessExit` and should give up in a couple of cycles, well inside the deadline.

## Quality gate (raw output)

**`cargo fmt --all -- --check`** — exit 0, no diff.

**`cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings`** — exit 0. Only pre-existing, unrelated warnings (`tga` MSRV mismatch note, `proc-macro-error2` future-incompat) — nothing from this diff.

**`cargo test -p trusty-common -p trusty-search`** (not `--lib`, full integration surface):

```
test result: ok. 750 passed; 0 failed; 21 ignored; 0 measured; 0 filtered out; finished in 3.09s   (trusty-common lib)
test result: ok. 1221 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 14.83s  (trusty-search lib)
```
plus all trusty-search integration binaries (config_mount, data_dir_forward, integration_tests, ooc_quick_wins, residency_cold_park, typeahead, warm_boot_corpus_open_failure, etc.) — 0 failed across the board. `doctor_data_dir_returns_non_empty_path`, `patch_kg_off_is_instantaneous_soft_disable`, `patch_hygiene_only_leaves_components_untouched` all passed `... ok` in this run (no serialization needed this time).

One unrelated pre-existing flake was hit on one run: `mcp::daemon_bridge::tests::probe_health_once_returns_false_on_refused` (a network-port-refused timing probe, different module — `crates/trusty-common/src/mcp/daemon_bridge.rs` — untouched by this PR). Immediate rerun of the identical command was fully green (750/0/21). Not touched per the "don't paper over, don't touch" instruction — flagging for visibility only.

New tests specifically, confirmed `... ok`:
```
test embedder_client::supervisor::tests::is_restart_storm_trigger_process_exit_clean_is_not_storm ... ok
test embedder_client::supervisor::tests::is_restart_storm_trigger_process_exit_failure_is_storm ... ok
test embedder_client::supervisor::tests::is_restart_storm_trigger_respawn_failed_is_not_storm ... ok
test embedder_client::supervisor::tests::is_restart_storm_trigger_unhealthy_is_storm ... ok
test embedder_client::supervisor::tests::shutdown_tests::supervisor_process_exit_crash_loop_reaches_give_up ... ok
test embedder_client::supervisor::tests::shutdown_tests::supervisor_single_transient_crash_then_health_does_not_give_up ... ok
```

## Scope

Only `crates/trusty-common/src/embedder_client/{supervisor.rs,supervisor_config.rs,supervisor_tests.rs}` and `crates/trusty-common/CHANGELOG.md`. No changes to `crates/trusty-search/src/commands/start/` (PR #3624 / #3626 lanes), packaging/install, launcher signing, docs, or the default flip. Line-cap gate (`scripts/check_line_cap.sh`) passes with 0 violations.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
