### PR TITLE
fix(trusty-review): bounded dep probe + tri-state health — /health always answers fast (#3658)

### DIFF
--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- **`/health` no longer hangs when trusty-search is slow, not down**
+  (closes [#3658](https://github.com/bobmatnyc/trusty-tools/issues/3658),
+  follow-on to [#722](https://github.com/bobmatnyc/trusty-tools/issues/722)):
+  the trusty-search/trusty-analyze dependency probe in the HTTP `/health`
+  handler, the `review_health` MCP tool, and the `console_metrics` MCP tool
+  had no internal timeout — a memory-pressured (slow, not down)
+  trusty-search could hang all three indefinitely, bounded only by the
+  clients' own 30 s / 5 s HTTP-transport timeouts. Each dep probe now runs
+  under a strict, independent `tokio::time::timeout` (default 2 s,
+  configurable via `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS`), and both deps
+  are probed concurrently so total `/health` latency stays bounded
+  regardless of dep count. `DepInfo` gains a new tri-state `state` field
+  (`"ok"` / `"unreachable"` / `"timeout"`) so a slow-but-up dependency is no
+  longer collapsed into the same `reachable: false` signal as a hard-down
+  one; the existing `reachable` boolean is unchanged for back-compat.
+
+---
 ## [0.10.0] — 2026-07-21
 
 ### Security

--- a/crates/trusty-review/src/mcp/console_metrics.rs
+++ b/crates/trusty-review/src/mcp/console_metrics.rs
@@ -34,7 +34,7 @@ use trusty_common::console_metrics::{ServiceHealth, make_report};
 
 use crate::service::{
     AppState,
-    handlers::{DepInfo, DepStatus, compute_status},
+    handlers::{compute_status, probe_deps},
 };
 
 // ─── Descriptor ──────────────────────────────────────────────────────────────
@@ -93,30 +93,16 @@ pub(crate) async fn handle_console_metrics(state: &AppState) -> Value {
     let reviewer_model = state.config.role_models.reviewer.model.clone();
     let version = env!("CARGO_PKG_VERSION");
 
-    // Non-blocking dep probes — same logic as the HTTP /health handler.
-    let search_reachable = state.search.health().await.is_ok_and(|r| r.is_healthy());
-    let analyze_reachable = match &state.analyze {
-        Some(a) => a.health().await.is_ok(),
-        None => false,
-    };
+    // Bounded, concurrent dep probes (#3658) — same helper the HTTP /health
+    // handler and review_health use, so a slow (not down) dep cannot hang
+    // this console poll either.
+    let deps = probe_deps(state).await;
 
     // Cached inference-reachability probe (same as review_health).
     let inference = state
         .inference_probe
         .probe(&state.llm, &reviewer_model)
         .await;
-
-    // Build the deps struct so compute_status can inspect required flags.
-    let deps = DepStatus {
-        trusty_search: DepInfo {
-            required: true,
-            reachable: search_reachable,
-        },
-        trusty_analyze: DepInfo {
-            required: false,
-            reachable: analyze_reachable,
-        },
-    };
 
     // status is "degraded" when inference fails OR any required dep is down.
     let health_str = compute_status(inference, &deps);
@@ -134,8 +120,10 @@ pub(crate) async fn handle_console_metrics(state: &AppState) -> Value {
         "dry_run": state.config.dry_run,
         "version": version,
         "inference": inference,
-        "search_reachable": search_reachable,
-        "analyze_reachable": analyze_reachable,
+        "search_reachable": deps.trusty_search.reachable,
+        "analyze_reachable": deps.trusty_analyze.reachable,
+        "search_state": deps.trusty_search.state,
+        "analyze_state": deps.trusty_analyze.state,
     });
 
     let report = make_report(

--- a/crates/trusty-review/src/mcp/tools.rs
+++ b/crates/trusty-review/src/mcp/tools.rs
@@ -31,7 +31,7 @@ use crate::{
     pipeline::{DiffSource, ReviewDeps, ReviewInput, TriggerDecision, run_review},
     service::{
         AppState,
-        handlers::{DepInfo, DepStatus, compute_status},
+        handlers::{compute_status, probe_deps},
     },
 };
 
@@ -299,43 +299,31 @@ async fn call_review_diff(args: &Value, state: &AppState) -> Result<Value, ToolE
 /// when the LLM endpoint is down or credentials are expired.  #722 extends the
 /// status decision to factor in required-dep reachability so callers that gate
 /// on the top-level `status` field get an accurate signal even when only the
-/// search dep is down.
-/// What: probes the search dep (non-blocking health call) and the inference
-/// endpoint (via the cached `InferenceProbe`); computes `status` via the shared
-/// `compute_status` helper so the HTTP and MCP paths are always consistent;
-/// returns a JSON health snapshot with `status` (`"ok"` or `"degraded"`),
-/// `inference`, `dry_run`, `reviewer_model`, and a `deps` object with
-/// `reachable` flags for each dep.  When inference is not `"ok"` OR a required
-/// dep is unreachable, `status` becomes `"degraded"`.
+/// search dep is down.  #3658 bounds the dep probes so a slow (not down)
+/// trusty-search cannot hang this tool call either.
+/// What: probes both deps concurrently under a strict internal deadline via
+/// the shared `probe_deps` helper (same one the HTTP `/health` handler uses —
+/// #3658), and the inference endpoint (via the cached `InferenceProbe`);
+/// computes `status` via the shared `compute_status` helper so the HTTP and
+/// MCP paths are always consistent; returns a JSON health snapshot with
+/// `status` (`"ok"` or `"degraded"`), `inference`, `dry_run`,
+/// `reviewer_model`, and a `deps` object with `reachable` and tri-state
+/// `state` (`"ok"`/`"unreachable"`/`"timeout"`) for each dep.  When inference
+/// is not `"ok"` OR a required dep is unreachable, `status` becomes
+/// `"degraded"`.
 /// Test: `review_health_inference_ok`, `review_health_inference_auth_error_degraded`,
 /// `review_health_required_dep_down_degraded`, `review_health_optional_dep_down_ok`.
 async fn call_review_health(state: &AppState) -> Value {
     let reviewer_model = state.config.role_models.reviewer.model.clone();
 
-    // Non-blocking dep probes — same logic as the HTTP /health handler.
-    let search_reachable = state.search.health().await.is_ok_and(|r| r.is_healthy());
-    let analyze_reachable = match &state.analyze {
-        Some(a) => a.health().await.is_ok(),
-        None => false,
-    };
+    // Bounded, concurrent dep probes (#3658) — shared with the HTTP handler.
+    let deps = probe_deps(state).await;
 
     // Cached inference-reachability probe (#719).
     let inference = state
         .inference_probe
         .probe(&state.llm, &reviewer_model)
         .await;
-
-    // Build the deps struct so compute_status can inspect required flags (#722).
-    let deps = DepStatus {
-        trusty_search: DepInfo {
-            required: true,
-            reachable: search_reachable,
-        },
-        trusty_analyze: DepInfo {
-            required: false,
-            reachable: analyze_reachable,
-        },
-    };
 
     // #722: status is "degraded" when inference fails OR any required dep is down.
     let status = compute_status(inference, &deps);
@@ -350,10 +338,12 @@ async fn call_review_health(state: &AppState) -> Value {
             "trusty_search": {
                 "required": deps.trusty_search.required,
                 "reachable": deps.trusty_search.reachable,
+                "state": deps.trusty_search.state,
             },
             "trusty_analyze": {
                 "required": deps.trusty_analyze.required,
                 "reachable": deps.trusty_analyze.reachable,
+                "state": deps.trusty_analyze.state,
             },
         },
     });

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -15,6 +15,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
 };
+use std::time::Duration;
 
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
 use serde::{Deserialize, Serialize};
@@ -199,15 +200,51 @@ pub struct DepStatus {
 /// Per-dependency info node.
 ///
 /// Why: provides `required` alongside `reachable` so consumers know the
-/// severity of a `false` without reading the docs.
-/// What: `required` is hardcoded per dep; `reachable` is a non-blocking probe.
-/// Test: verified in `health_returns_ok_json`.
+/// severity of a `false` without reading the docs.  `state` (#3658) adds a
+/// tri-state view so a caller can distinguish "confirmed down" from "probe
+/// timed out" — a slow-but-up dependency is operationally different from a
+/// hard-down one, but both previously collapsed into `reachable: false`.
+/// What: `required` is hardcoded per dep; `reachable` and `state` come from a
+/// single bounded probe (see `bounded_probe`).  `reachable` is kept for
+/// backward compatibility with existing consumers (`true` iff `state == Ok`).
+/// Test: verified in `health_returns_ok_json`,
+/// `health_stalled_dep_returns_timeout_state`.
 #[derive(Debug, Serialize)]
 pub struct DepInfo {
     /// Whether this dep is required for the service to function.
     pub required: bool,
     /// Whether the dep responded to a liveness probe at last check.
+    /// `true` iff `state == DepState::Ok`.  Kept for back-compat: existing
+    /// consumers gate on this single boolean field (#3658 is additive).
     pub reachable: bool,
+    /// Tri-state probe result: `ok`, `unreachable`, or `timeout` (#3658).
+    pub state: DepState,
+}
+
+/// Tri-state outcome of a single bounded dependency probe (#3658).
+///
+/// Why: post-#722 the dep probe correctly reported reachability, but a slow
+/// (not down) dependency and a hard-down dependency both collapsed into
+/// `reachable: false`, with no bound on how long the probe could take. This
+/// type distinguishes "probe returned an error / unhealthy response"
+/// (`Unreachable`) from "probe did not complete within the internal deadline"
+/// (`Timeout`), so operators can tell "trusty-search is down" apart from
+/// "trusty-search is just slow right now".
+/// What: serialises as a lowercase string (`"ok"`, `"unreachable"`,
+/// `"timeout"`) via `#[serde(rename_all = "snake_case")]`.
+/// Test: `dep_state_serialises_lowercase`, `bounded_probe_*` in
+/// `handlers_tests.rs`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DepState {
+    /// Probe completed within the deadline and reported a healthy dependency.
+    Ok,
+    /// Probe completed within the deadline but reported an error or an
+    /// unhealthy response (e.g. embedder not ready).
+    Unreachable,
+    /// Probe did not complete within `dep_probe_timeout()` — the dependency
+    /// is slow, not necessarily down.
+    Timeout,
 }
 
 /// Response body for GET /status.
@@ -302,6 +339,119 @@ pub fn compute_status(inference: InferenceStatus, deps: &DepStatus) -> &'static 
     }
 }
 
+// ─── Bounded dependency probing (#3658) ───────────────────────────────────────
+
+/// Return the per-dependency-probe hard timeout, consulting
+/// `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS`.
+///
+/// Why: #3658 — the trusty-search/trusty-analyze reachability probes in
+/// `handle_health` previously had no internal bound.  A slow (not down)
+/// dependency could hang the whole health handler indefinitely, because the
+/// only bound was each client's own HTTP-transport timeout (30 s for search,
+/// 5 s for analyze) — far longer than any reasonable caller deadline.  This
+/// timeout is deliberately short (default 2 s) and fully decoupled from those
+/// client-level timeouts so `/health` always answers promptly regardless of
+/// dependency latency.
+/// What: reads `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS` from the environment;
+/// parses as `u64` seconds; falls back to `DEFAULT_DEP_PROBE_TIMEOUT_SECS` (2)
+/// on any parse failure, unset variable, or a value of 0 (to prevent an
+/// accidentally-zero timeout from making every probe report `timeout`).
+/// Test: `dep_probe_timeout_default`, `dep_probe_timeout_env_override`,
+/// `dep_probe_timeout_env_invalid_falls_back`,
+/// `dep_probe_timeout_env_zero_falls_back` in `handlers_tests.rs`.
+pub(crate) fn dep_probe_timeout() -> Duration {
+    const DEFAULT_DEP_PROBE_TIMEOUT_SECS: u64 = 2;
+    const ENV_VAR: &str = "TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS";
+
+    let secs = std::env::var(ENV_VAR)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .unwrap_or(DEFAULT_DEP_PROBE_TIMEOUT_SECS);
+
+    Duration::from_secs(secs)
+}
+
+/// Run a single dependency probe future under a strict internal deadline.
+///
+/// Why: centralises the "wrap in `tokio::time::timeout`, map the outcome to a
+/// `DepState`" logic so both `handle_health` and the MCP `review_health` tool
+/// get the same bounded-latency guarantee (#3658) instead of duplicating it.
+/// What: awaits `fut` under `tokio::time::timeout(timeout, fut)`.  A
+/// completed `Ok(v)` is passed to `is_healthy` to decide `DepState::Ok` vs
+/// `DepState::Unreachable`; a completed `Err(_)` is `DepState::Unreachable`;
+/// an elapsed deadline is `DepState::Timeout` — deliberately distinct from
+/// `Unreachable` so a slow-but-up dependency is never reported as hard-down.
+/// Test: `bounded_probe_ok_on_healthy_response`,
+/// `bounded_probe_unreachable_on_error`,
+/// `bounded_probe_unreachable_on_unhealthy_response`,
+/// `bounded_probe_timeout_on_stalled_future` in `handlers_tests.rs`.
+async fn bounded_probe<Fut, T, E>(
+    fut: Fut,
+    timeout: Duration,
+    is_healthy: impl FnOnce(T) -> bool,
+) -> DepState
+where
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    match tokio::time::timeout(timeout, fut).await {
+        Ok(Ok(v)) => {
+            if is_healthy(v) {
+                DepState::Ok
+            } else {
+                DepState::Unreachable
+            }
+        }
+        Ok(Err(_)) => DepState::Unreachable,
+        Err(_elapsed) => DepState::Timeout,
+    }
+}
+
+/// Probe trusty-search and trusty-analyze reachability concurrently, each
+/// bounded by `dep_probe_timeout()` (#3658).
+///
+/// Why: shared by the HTTP `/health` handler and the MCP `review_health` tool
+/// so both paths get the same bounded-latency guarantee and the same
+/// tri-state dep status, instead of each duplicating an unbounded sequential
+/// probe.  Probing concurrently (via `tokio::join!`) — rather than
+/// sequentially — bounds the total dep-probe latency to `dep_probe_timeout()`
+/// regardless of how many deps are probed or how slow each one is, per the
+/// issue's requirement that overall `/health` latency stay bounded (~2 s
+/// worst case) independent of every dependency.
+/// What: runs `state.search.health()` and (if configured)
+/// `state.analyze.health()` concurrently, each wrapped in `bounded_probe`;
+/// returns the fully-populated `DepStatus`.  An unconfigured `analyze` client
+/// is reported as `DepState::Unreachable` (unchanged back-compat behaviour:
+/// `reachable: false`).
+/// Test: `health_stalled_dep_returns_timeout_state`,
+/// `health_fast_dep_healthy_path_unchanged`,
+/// `health_hard_down_dep_reachable_false` in `handlers_tests.rs`.
+pub async fn probe_deps(state: &AppState) -> DepStatus {
+    let timeout = dep_probe_timeout();
+
+    let search_probe = bounded_probe(state.search.health(), timeout, |r| r.is_healthy());
+    let analyze_probe = async {
+        match &state.analyze {
+            Some(a) => bounded_probe(a.health(), timeout, |_| true).await,
+            None => DepState::Unreachable,
+        }
+    };
+    let (search_state, analyze_state) = tokio::join!(search_probe, analyze_probe);
+
+    DepStatus {
+        trusty_search: DepInfo {
+            required: true,
+            reachable: search_state == DepState::Ok,
+            state: search_state,
+        },
+        trusty_analyze: DepInfo {
+            required: false,
+            reachable: analyze_state == DepState::Ok,
+            state: analyze_state,
+        },
+    }
+}
+
 // ─── Route handlers ───────────────────────────────────────────────────────────
 
 /// GET /health — liveness, dependency reachability, and inference probe.
@@ -309,28 +459,28 @@ pub fn compute_status(inference: InferenceStatus, deps: &DepStatus) -> &'static 
 /// Why: required by load balancers and orchestrators to determine whether this
 /// instance is ready to handle traffic.  MPM uses the `inference` field to
 /// gate whether to attempt a `review_pr` call (closes #719).
-/// What: performs non-blocking health probes against trusty-search and
-/// trusty-analyze (both via `.health()` on the trait objects); runs the cached
-/// inference-reachability probe (10 s TTL, timeout configurable via
+/// What: performs bounded, concurrent health probes against trusty-search and
+/// trusty-analyze via `probe_deps` (each capped at `dep_probe_timeout()`,
+/// default 2 s, decoupled from any client's own HTTP timeout — #3658); runs
+/// the cached inference-reachability probe (10 s TTL, timeout configurable via
 /// `TRUSTY_REVIEW_HEALTH_TIMEOUT_SECS`, default 10 s — see #739) against the
 /// configured LLM provider; returns JSON with dep status, reviewer model, and
 /// inference result.  HTTP 200 always (degraded state is noted in the body,
 /// not via 5xx, to avoid false-positive load-balancer evictions).  When
 /// inference is `"unreachable"` or `"auth_error"` OR a required dep is
-/// unreachable, `status` becomes `"degraded"`.  A probe timeout returns
-/// `"unknown"` (not `"degraded"`) so a slow Bedrock cold-start does not
-/// falsely degrade status (#739).
+/// unreachable, `status` becomes `"degraded"`.  An inference probe timeout
+/// returns `"unknown"` (not `"degraded"`) so a slow Bedrock cold-start does not
+/// falsely degrade status (#739); a dep probe timeout reports
+/// `deps.trusty_search.state: "timeout"` with `reachable: false` (#3658).
 /// Test: `health_inference_ok_when_llm_ok`,
 /// `health_inference_auth_error_sets_degraded`,
 /// `health_required_dep_down_sets_degraded`,
-/// `health_optional_dep_down_stays_ok`.
+/// `health_optional_dep_down_stays_ok`,
+/// `health_stalled_dep_returns_timeout_state`.
 pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
-    // Non-blocking dep probes — treat errors as "unreachable".
-    let search_reachable = state.search.health().await.is_ok_and(|r| r.is_healthy());
-    let analyze_reachable = match &state.analyze {
-        Some(a) => a.health().await.is_ok(),
-        None => false,
-    };
+    // Bounded, concurrent dep probes (#3658) — total latency capped at
+    // `dep_probe_timeout()` regardless of dep count or individual slowness.
+    let deps = probe_deps(&state).await;
 
     // Cached inference-reachability probe (#719).
     let reviewer_model = state.config.role_models.reviewer.model.clone();
@@ -338,17 +488,6 @@ pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
         .inference_probe
         .probe(&state.llm, &reviewer_model)
         .await;
-
-    let deps = DepStatus {
-        trusty_search: DepInfo {
-            required: true,
-            reachable: search_reachable,
-        },
-        trusty_analyze: DepInfo {
-            required: false,
-            reachable: analyze_reachable,
-        },
-    };
 
     // #722: status is "degraded" when inference fails OR any required dep is down.
     let status = compute_status(inference, &deps);

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -208,7 +208,7 @@ pub struct DepStatus {
 /// single bounded probe (see `bounded_probe`).  `reachable` is kept for
 /// backward compatibility with existing consumers (`true` iff `state == Ok`).
 /// Test: verified in `health_returns_ok_json`,
-/// `health_stalled_dep_returns_timeout_state`.
+/// `health_stalled_dep_returns_timeout_state_within_bound`.
 #[derive(Debug, Serialize)]
 pub struct DepInfo {
     /// Whether this dep is required for the service to function.
@@ -385,7 +385,10 @@ pub(crate) fn dep_probe_timeout() -> Duration {
 /// Test: `bounded_probe_ok_on_healthy_response`,
 /// `bounded_probe_unreachable_on_error`,
 /// `bounded_probe_unreachable_on_unhealthy_response`,
-/// `bounded_probe_timeout_on_stalled_future` in `handlers_tests.rs`.
+/// `bounded_probe_timeout_on_stalled_future`,
+/// `health_unhealthy_search_response_reports_state_unreachable` (the
+/// `Ok(Ok(v))` + `is_healthy(v) == false` branch exercised end-to-end through
+/// a real `SearchClient`, e.g. a degraded embedder) in `handlers_tests.rs`.
 async fn bounded_probe<Fut, T, E>(
     fut: Fut,
     timeout: Duration,
@@ -423,9 +426,10 @@ where
 /// returns the fully-populated `DepStatus`.  An unconfigured `analyze` client
 /// is reported as `DepState::Unreachable` (unchanged back-compat behaviour:
 /// `reachable: false`).
-/// Test: `health_stalled_dep_returns_timeout_state`,
-/// `health_fast_dep_healthy_path_unchanged`,
-/// `health_hard_down_dep_reachable_false` in `handlers_tests.rs`.
+/// Test: `health_stalled_dep_returns_timeout_state_within_bound`,
+/// `health_inference_ok_when_llm_succeeds` (fast/healthy path),
+/// `health_required_dep_down_sets_degraded` (hard-down path) in
+/// `handlers_tests.rs` / `handlers_status_tests.rs`.
 pub async fn probe_deps(state: &AppState) -> DepStatus {
     let timeout = dep_probe_timeout();
 
@@ -476,7 +480,7 @@ pub async fn probe_deps(state: &AppState) -> DepStatus {
 /// `health_inference_auth_error_sets_degraded`,
 /// `health_required_dep_down_sets_degraded`,
 /// `health_optional_dep_down_stays_ok`,
-/// `health_stalled_dep_returns_timeout_state`.
+/// `health_stalled_dep_returns_timeout_state_within_bound`.
 pub async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
     // Bounded, concurrent dep probes (#3658) — total latency capped at
     // `dep_probe_timeout()` regardless of dep count or individual slowness.

--- a/crates/trusty-review/src/service/handlers_status_tests.rs
+++ b/crates/trusty-review/src/service/handlers_status_tests.rs
@@ -11,7 +11,9 @@ use std::sync::Arc;
 
 use axum::{body::to_bytes, extract::State, http::StatusCode, response::IntoResponse as _};
 
-use crate::service::handlers::{AppState, DepInfo, DepStatus, compute_status, handle_health};
+use crate::service::handlers::{
+    AppState, DepInfo, DepState, DepStatus, compute_status, handle_health,
+};
 use crate::service::inference_probe::InferenceStatus;
 
 // Re-use the fakes defined in `handlers_tests.rs` which is loaded first.
@@ -30,10 +32,12 @@ fn health_status_ok_all_good() {
         trusty_search: DepInfo {
             required: true,
             reachable: true,
+            state: DepState::Ok,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: true,
+            state: DepState::Ok,
         },
     };
     assert_eq!(
@@ -56,10 +60,12 @@ fn health_status_degraded_required_dep_down() {
         trusty_search: DepInfo {
             required: true,
             reachable: false, // required dep is down
+            state: DepState::Unreachable,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: true,
+            state: DepState::Ok,
         },
     };
     assert_eq!(
@@ -81,10 +87,12 @@ fn health_status_degraded_inference_auth_error() {
         trusty_search: DepInfo {
             required: true,
             reachable: true,
+            state: DepState::Ok,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: true,
+            state: DepState::Ok,
         },
     };
     assert_eq!(
@@ -110,10 +118,12 @@ fn health_status_ok_inference_unknown() {
         trusty_search: DepInfo {
             required: true,
             reachable: true,
+            state: DepState::Ok,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: true,
+            state: DepState::Ok,
         },
     };
     assert_eq!(
@@ -135,10 +145,12 @@ fn health_status_ok_optional_dep_down() {
         trusty_search: DepInfo {
             required: true,
             reachable: true,
+            state: DepState::Ok,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: false, // optional dep down — must not degrade
+            state: DepState::Unreachable,
         },
     };
     assert_eq!(
@@ -184,11 +196,18 @@ async fn health_required_dep_down_sets_degraded() {
     );
     assert_eq!(
         body["deps"]["trusty_search"]["reachable"], false,
-        "trusty_search.reachable must be false when search is down"
+        "trusty_search.reachable must be false when search is down (#3658 back-compat)"
     );
     assert_eq!(
         body["deps"]["trusty_search"]["required"], true,
         "trusty_search.required must remain true"
+    );
+    // #3658: a hard-down dep (health() returns Err immediately, no timeout)
+    // must report state:unreachable — distinct from state:timeout, which is
+    // reserved for a dep that did not respond within the probe deadline.
+    assert_eq!(
+        body["deps"]["trusty_search"]["state"], "unreachable",
+        "hard-down dep must report state:unreachable, not state:timeout (#3658)"
     );
 }
 

--- a/crates/trusty-review/src/service/handlers_tests.rs
+++ b/crates/trusty-review/src/service/handlers_tests.rs
@@ -106,6 +106,39 @@ impl SearchClient for FailSearch {
     }
 }
 
+/// A search stub whose `health()` succeeds at the transport level but reports
+/// an unhealthy embedder — exercises the `Ok(Ok(v))` + `is_healthy(v) ==
+/// false` branch of `bounded_probe` end-to-end through a real `SearchClient`
+/// (#3658 coverage gap: a degraded-but-answering dep must report
+/// `state:"unreachable"`, distinct from `state:"timeout"`).
+pub(super) struct UnhealthySearch;
+
+#[async_trait]
+impl SearchClient for UnhealthySearch {
+    async fn health(&self) -> Result<SearchHealth, SearchClientError> {
+        // Transport succeeds (HTTP 200, valid JSON) but the embedder isn't
+        // ready, so `HealthResponse::is_healthy()` is `false` — e.g. a
+        // degraded/cold-starting trusty-search that answers but isn't ready.
+        Ok(SearchHealth {
+            status: "ok".to_string(),
+            embedder: EmbedderState::Bool(false),
+        })
+    }
+
+    async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
+        Ok(vec![])
+    }
+
+    async fn search(
+        &self,
+        _index_id: &str,
+        _query: &str,
+        _top_k: Option<u32>,
+    ) -> Result<Vec<SearchResult>, SearchClientError> {
+        Ok(vec![])
+    }
+}
+
 // ── Fake LLM that returns auth error ─────────────────────────────────────────
 
 pub(super) struct AuthErrorLlm;
@@ -409,6 +442,22 @@ async fn health_inference_auth_error_sets_degraded() {
 // dep still reports `reachable:false` (covered above via
 // `health_status_degraded_required_dep_down` / `health_required_dep_down_sets_degraded`
 // in `handlers_status_tests.rs`, extended with a `state:"unreachable"` check).
+//
+// Env-var race note (code-review, #2688 postmortem class): the
+// `#[serial_test::serial]` tests below mutate `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS`
+// for the duration of the test, but the many NON-serial `handle_health` tests
+// in this file (`health_handler_returns_ok`, `health_inference_ok_when_llm_succeeds`,
+// etc.) also transitively read that var via `dep_probe_timeout()` — and
+// `serial_test::serial` only serialises against OTHER `#[serial]`-tagged tests,
+// not against every test in the binary, so a non-serial reader CAN observe a
+// transient override from one of these tests mid-run. This is benign today
+// only because `dep_probe_timeout()` itself treats every value these tests
+// ever set (`"0"`, `"not-a-number"`, `"1"`, `"5"`) as either a valid small
+// positive timeout or a safe fallback to the 2s default — never a value that
+// would hang or corrupt a concurrent reader. If a future test needs to set a
+// value that is NOT safely handled by `dep_probe_timeout()`'s own fallback
+// (there currently is no such value), it must serialise the readers too, not
+// just itself.
 
 /// `/health` returns within the bound, reporting `state:"timeout"`, when
 /// trusty-search accepts a connection but never responds (#3658).
@@ -485,6 +534,188 @@ async fn health_stalled_dep_returns_timeout_state_within_bound() {
     assert_eq!(
         body["deps"]["trusty_search"]["reachable"], false,
         "reachable must still be false for back-compat when the dep times out"
+    );
+}
+
+// ── DepState serialisation + bounded_probe unit tests (#3658) ─────────────────
+
+/// `DepState` serialises as the documented lowercase strings.
+///
+/// Why: `handlers.rs`'s doc comment on `DepState` promises `"ok"` /
+/// `"unreachable"` / `"timeout"` via `#[serde(rename_all = "snake_case")]`;
+/// this test locks that contract in so a future derive-attribute change is
+/// caught immediately rather than surfacing as a silent wire-format break.
+/// What: serialises each variant via `serde_json::to_value` and compares
+/// against the exact lowercase string.
+/// Test: this test itself.
+#[test]
+fn dep_state_serialises_lowercase() {
+    use super::DepState;
+
+    assert_eq!(
+        serde_json::to_value(DepState::Ok).unwrap(),
+        serde_json::json!("ok")
+    );
+    assert_eq!(
+        serde_json::to_value(DepState::Unreachable).unwrap(),
+        serde_json::json!("unreachable")
+    );
+    assert_eq!(
+        serde_json::to_value(DepState::Timeout).unwrap(),
+        serde_json::json!("timeout")
+    );
+}
+
+/// `bounded_probe` returns `DepState::Ok` when the future resolves `Ok(v)`
+/// within the deadline and `is_healthy(v)` is `true`.
+///
+/// Why: the straightforward happy path of `bounded_probe`'s match arms —
+/// locks in the mapping so a refactor can't silently invert it.
+/// What: awaits `bounded_probe` on an already-resolved `Ok(true)` future with
+/// a generous deadline and `is_healthy = |v| v`.
+/// Test: this test itself.
+#[tokio::test]
+async fn bounded_probe_ok_on_healthy_response() {
+    use super::{DepState, bounded_probe};
+
+    let result = bounded_probe(
+        async { Ok::<bool, ()>(true) },
+        std::time::Duration::from_millis(50),
+        |v| v,
+    )
+    .await;
+
+    assert_eq!(
+        result,
+        DepState::Ok,
+        "Ok(Ok(v)) with is_healthy(v)==true must be DepState::Ok"
+    );
+}
+
+/// `bounded_probe` returns `DepState::Unreachable` when the future resolves
+/// `Err(_)` within the deadline.
+///
+/// Why: a transport-level or API-level error (dep answered with a failure,
+/// or couldn't be reached at all) must map to `Unreachable`, never `Timeout`
+/// — `Timeout` is reserved exclusively for "did not respond within the
+/// deadline".
+/// What: awaits `bounded_probe` on an already-resolved `Err(())` future.
+/// Test: this test itself.
+#[tokio::test]
+async fn bounded_probe_unreachable_on_error() {
+    use super::{DepState, bounded_probe};
+
+    let result = bounded_probe(
+        async { Err::<bool, ()>(()) },
+        std::time::Duration::from_millis(50),
+        |v| v,
+    )
+    .await;
+
+    assert_eq!(
+        result,
+        DepState::Unreachable,
+        "Ok(Err(_)) must be DepState::Unreachable"
+    );
+}
+
+/// `bounded_probe` returns `DepState::Unreachable` — NOT `DepState::Ok` — when
+/// the future resolves `Ok(v)` within the deadline but `is_healthy(v)` is
+/// `false` (#3658 coverage gap).
+///
+/// Why: this is the previously-untested third branch of `bounded_probe`'s
+/// match: the dep answered (no transport error, no timeout) but reported
+/// itself unhealthy — e.g. a degraded embedder. That must NOT be silently
+/// treated as `Ok`, and must NOT be confused with `Timeout` (it definitely
+/// answered). See also `health_unhealthy_search_response_reports_state_unreachable`
+/// below for the same branch exercised through a real `SearchClient`.
+/// What: awaits `bounded_probe` on an already-resolved `Ok(false)` future with
+/// `is_healthy = |v| v` (so `is_healthy(false) == false`).
+/// Test: this test itself.
+#[tokio::test]
+async fn bounded_probe_unreachable_on_unhealthy_response() {
+    use super::{DepState, bounded_probe};
+
+    let result = bounded_probe(
+        async { Ok::<bool, ()>(false) },
+        std::time::Duration::from_millis(50),
+        |v| v,
+    )
+    .await;
+
+    assert_eq!(
+        result,
+        DepState::Unreachable,
+        "Ok(Ok(v)) with is_healthy(v)==false must be DepState::Unreachable, not DepState::Ok"
+    );
+}
+
+/// `bounded_probe` returns `DepState::Timeout` when the future never resolves
+/// within the deadline.
+///
+/// Why: the core guarantee of #3658 at the unit level (the real-socket
+/// integration test `health_stalled_dep_returns_timeout_state_within_bound`
+/// covers the same guarantee end-to-end through a real `SearchClient`) — a
+/// future that never completes must not hang `bounded_probe` itself.
+/// What: awaits `bounded_probe` on `std::future::pending()` (a future that
+/// never resolves) with a short deadline; asserts `DepState::Timeout`.
+/// Test: this test itself.
+#[tokio::test]
+async fn bounded_probe_timeout_on_stalled_future() {
+    use super::{DepState, bounded_probe};
+
+    let result = bounded_probe(
+        std::future::pending::<Result<bool, ()>>(),
+        std::time::Duration::from_millis(20),
+        |v| v,
+    )
+    .await;
+
+    assert_eq!(
+        result,
+        DepState::Timeout,
+        "a future that never resolves must be DepState::Timeout"
+    );
+}
+
+/// A dep that ANSWERS successfully but reports itself unhealthy (e.g. a
+/// degraded/cold-starting embedder) must be `state:"unreachable"`, not
+/// collapsed into `state:"timeout"` and not silently treated as healthy
+/// (#3658 coverage gap: the `Ok(Ok(v))` + `is_healthy(v) == false` branch of
+/// `bounded_probe`, exercised end-to-end through `handle_health` and a real
+/// `SearchClient` this time, rather than the generic unit test above).
+///
+/// Why: a hard transport error and a stalled probe are not the only ways a
+/// dep can be "not really up" — trusty-search can answer HTTP 200 while its
+/// embedder is still loading/degraded. That must still be `reachable:false`,
+/// and specifically `state:"unreachable"` (it definitely answered, just
+/// unhealthily), never `state:"timeout"` (it never answered at all).
+/// What: builds `AppState` with `UnhealthySearch` (health() returns
+/// `Ok(HealthResponse{status:"ok", embedder:false})`, so `is_healthy()` is
+/// `false`); calls `handle_health`; asserts `reachable:false` and
+/// `state:"unreachable"`.
+/// Test: this test itself.
+#[tokio::test]
+async fn health_unhealthy_search_response_reports_state_unreachable() {
+    let state = AppState::new(
+        crate::config::ReviewConfig::load(None),
+        Arc::new(FakeLlm),
+        Arc::new(UnhealthySearch),
+        None,
+    );
+    let response = handle_health(State(state)).await;
+    let resp: axum::response::Response = response.into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body_bytes = to_bytes(resp.into_body(), 65536).await.expect("body bytes");
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).expect("valid JSON");
+
+    assert_eq!(
+        body["deps"]["trusty_search"]["reachable"], false,
+        "a dep that answers but is unhealthy must still report reachable:false"
+    );
+    assert_eq!(
+        body["deps"]["trusty_search"]["state"], "unreachable",
+        "an unhealthy-but-answering dep must be state:unreachable, not state:timeout (#3658)"
     );
 }
 

--- a/crates/trusty-review/src/service/handlers_tests.rs
+++ b/crates/trusty-review/src/service/handlers_tests.rs
@@ -20,8 +20,8 @@ use crate::{
             AnalyzeClient, AnalyzeClientError, AnalyzeHealthResponse, ComplexityHotspot, Smell,
         },
         search_client::{
-            EmbedderState, HealthResponse as SearchHealth, IndexInfo, SearchClient,
-            SearchClientError, SearchResult,
+            EmbedderState, HealthResponse as SearchHealth, HttpSearchClient, IndexInfo,
+            SearchClient, SearchClientError, SearchResult,
         },
     },
     llm::{LlmError, LlmProvider, LlmRequest, LlmResponse},
@@ -351,6 +351,16 @@ async fn health_inference_ok_when_llm_succeeds() {
     );
     assert!(body["dry_run"].is_boolean(), "dry_run must be present");
     assert!(body["deps"].is_object(), "deps must be present");
+    // #3658: fast/healthy dep path must report the new tri-state field as
+    // "ok" without disturbing the pre-existing `reachable` boolean.
+    assert_eq!(
+        body["deps"]["trusty_search"]["state"], "ok",
+        "healthy fast dep must report state:ok (#3658)"
+    );
+    assert_eq!(
+        body["deps"]["trusty_search"]["reachable"], true,
+        "healthy fast dep must still report reachable:true (back-compat)"
+    );
 }
 
 /// /health sets `status: "degraded"` and `inference: "auth_error"` on LLM auth failure.
@@ -387,5 +397,182 @@ async fn health_inference_auth_error_sets_degraded() {
     assert_eq!(
         body["status"], "degraded",
         "status must be degraded when inference != ok"
+    );
+}
+
+// ── Bounded dep-probe tests (#3658) ───────────────────────────────────────────
+//
+// Why: trusty-review's /health hung with no internal timeout when
+// trusty-search was slow (not down) — the dep probe was unbounded. These
+// tests prove: (1) a stalled dep is bounded and reported distinctly as
+// `state:"timeout"`; (2) the fast/healthy path is unchanged; (3) a hard-down
+// dep still reports `reachable:false` (covered above via
+// `health_status_degraded_required_dep_down` / `health_required_dep_down_sets_degraded`
+// in `handlers_status_tests.rs`, extended with a `state:"unreachable"` check).
+
+/// `/health` returns within the bound, reporting `state:"timeout"`, when
+/// trusty-search accepts a connection but never responds (#3658).
+///
+/// Why: this is the exact prod repro from #3658 — a memory-pressured
+/// trusty-search that is slow, not down. Post-#722 the endpoint eventually
+/// reported `reachable:false`, but the probe itself was unbounded, so the
+/// whole handler could hang indefinitely. This test uses a real TCP listener
+/// that accepts but never writes a response — reproducing the actual hang at
+/// the transport layer, not just a mocked async delay — and asserts the
+/// handler still returns promptly.
+/// What: binds a listener, spawns a task that accepts the connection and then
+/// awaits forever (`std::future::pending`) without responding; points an
+/// `HttpSearchClient` at it; overrides `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS=1`
+/// so the test is fast and deterministic; calls `handle_health` and asserts
+/// wall-clock elapsed stays well under the old 30 s client-level timeout,
+/// and that the response reports `deps.trusty_search.state == "timeout"` with
+/// `reachable == false`.
+/// Test: this test itself (condition: bounded elapsed time + response shape,
+/// no arbitrary sleep-as-assertion).
+#[tokio::test]
+#[serial_test::serial]
+async fn health_stalled_dep_returns_timeout_state_within_bound() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    let base_url = format!("http://{addr}");
+
+    // Accept the connection but never read or write anything — the listener
+    // simply holds it open, simulating a memory-pressured trusty-search that
+    // is slow (not down): it answers the TCP handshake but never completes
+    // the HTTP response.
+    let _mock_handle = tokio::spawn(async move {
+        let _sock = listener.accept().await.expect("accept");
+        std::future::pending::<()>().await;
+    });
+
+    // SAFETY: #[serial_test::serial] ensures no other thread mutates env vars
+    // concurrently in this process during this test. A short override keeps
+    // the test fast without depending on the 2 s production default.
+    unsafe { std::env::set_var("TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS", "1") };
+
+    let search = Arc::new(HttpSearchClient::new(base_url).expect("client construction"));
+    let state = AppState::new(
+        crate::config::ReviewConfig::load(None),
+        Arc::new(FakeLlm),
+        search,
+        None,
+    );
+
+    let start = std::time::Instant::now();
+    let response = handle_health(State(state)).await;
+    let elapsed = start.elapsed();
+
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS") };
+
+    assert!(
+        elapsed < std::time::Duration::from_secs(5),
+        "/health must return within the bound even when trusty-search stalls \
+         (took {elapsed:?}); the whole point of #3658 is that it must NOT wait \
+         out the client's 30 s HTTP timeout"
+    );
+
+    let resp: axum::response::Response = response.into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body_bytes = to_bytes(resp.into_body(), 65536).await.expect("body bytes");
+    let body: serde_json::Value = serde_json::from_slice(&body_bytes).expect("valid JSON");
+
+    assert_eq!(
+        body["deps"]["trusty_search"]["state"], "timeout",
+        "stalled dep must report a distinct state:timeout, not collapsed into reachable:false-only (#3658)"
+    );
+    assert_eq!(
+        body["deps"]["trusty_search"]["reachable"], false,
+        "reachable must still be false for back-compat when the dep times out"
+    );
+}
+
+// ── dep_probe_timeout() unit tests (#3658) ────────────────────────────────────
+
+/// Returns 2 s when the env var is absent.
+///
+/// Why: verifies the documented default (short and decoupled from the
+/// search/analyze clients' own 30 s / 5 s HTTP-transport timeouts).
+/// What: calls `dep_probe_timeout()` with the env var unset.
+/// Test: this test (serial to prevent env-var races with sibling tests).
+#[test]
+#[serial_test::serial]
+fn dep_probe_timeout_default() {
+    use super::dep_probe_timeout;
+    // SAFETY: serial_test::serial ensures no other thread mutates env vars
+    // concurrently in this process during this test.
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS") };
+    assert_eq!(
+        dep_probe_timeout(),
+        std::time::Duration::from_secs(2),
+        "default dep-probe timeout must be 2 s (#3658)"
+    );
+}
+
+/// Returns the caller-supplied value when the env var is a valid non-zero u64.
+///
+/// Why: operators must be able to tune the dep-probe timeout without
+/// recompiling (e.g. a slower network path than the 2 s default assumes).
+/// What: sets `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS=5` and checks the result.
+/// Test: this test.
+#[test]
+#[serial_test::serial]
+fn dep_probe_timeout_env_override() {
+    use super::dep_probe_timeout;
+    // SAFETY: serial_test::serial ensures no other thread mutates env vars
+    // concurrently in this process during this test.
+    unsafe { std::env::set_var("TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS", "5") };
+    let t = dep_probe_timeout();
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS") };
+    assert_eq!(
+        t,
+        std::time::Duration::from_secs(5),
+        "env-var override must be honoured"
+    );
+}
+
+/// Falls back to 2 s when the env var contains a non-numeric value.
+///
+/// Why: a mis-typed env var must not panic or hang every probe; fallback to
+/// the safe default is the correct behaviour.
+/// What: sets an invalid value and asserts the default is used.
+/// Test: this test.
+#[test]
+#[serial_test::serial]
+fn dep_probe_timeout_env_invalid_falls_back() {
+    use super::dep_probe_timeout;
+    // SAFETY: serial_test::serial ensures no other thread mutates env vars
+    // concurrently in this process during this test.
+    unsafe { std::env::set_var("TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS", "not-a-number") };
+    let t = dep_probe_timeout();
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS") };
+    assert_eq!(
+        t,
+        std::time::Duration::from_secs(2),
+        "invalid env var must fall back to 2 s default"
+    );
+}
+
+/// Falls back to 2 s when the env var is zero (prevents a zero timeout from
+/// making every probe instantly report `timeout`).
+///
+/// Why: a zero timeout would make `/health` always report every dep as
+/// timed-out, which is as unhelpful as the original unbounded hang.
+/// What: sets `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS=0` and asserts the default.
+/// Test: this test.
+#[test]
+#[serial_test::serial]
+fn dep_probe_timeout_env_zero_falls_back() {
+    use super::dep_probe_timeout;
+    // SAFETY: serial_test::serial ensures no other thread mutates env vars
+    // concurrently in this process during this test.
+    unsafe { std::env::set_var("TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS", "0") };
+    let t = dep_probe_timeout();
+    unsafe { std::env::remove_var("TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS") };
+    assert_eq!(
+        t,
+        std::time::Duration::from_secs(2),
+        "zero env var must fall back to 2 s default"
     );
 }


### PR DESCRIPTION
## Summary

- `/health`'s trusty-search/trusty-analyze dependency probe had no internal timeout — post-#722 the endpoint correctly reported `reachable:false` on a hard-down dep, but a *slow* (not down) dep, e.g. a memory-pressured trusty-search, could hang the whole handler for as long as the client's own HTTP-transport timeout (30s for search, 5s for analyze) — far longer than any reasonable caller deadline. Prod repro: `curl -m 5 localhost:7880/health` timed out with 0 bytes while trusty-search answered direct queries fine.
- Added a shared `probe_deps` helper (`crates/trusty-review/src/service/handlers.rs`) that probes trusty-search and trusty-analyze **concurrently** via `tokio::join!`, each wrapped in its own `tokio::time::timeout` — default 2s, configurable via `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS`, fully decoupled from the clients' own transport-level timeouts. Total `/health` dep-probe latency is now bounded to ~2s regardless of dep count.
- `DepInfo` gains a new tri-state `state: "ok" | "unreachable" | "timeout"` field alongside the existing `reachable: bool` (kept unchanged for back-compat) — a slow-but-up dependency is no longer indistinguishable from a hard-down one.
- The same duplicated unbounded-probe logic existed in the `review_health` MCP tool and the `console_metrics` MCP tool (used by trusty-console's ~15s poll); both now share `probe_deps` too, so neither can hang on a slow dep either.

## Root cause

Post-#722, `handle_health` called `state.search.health().await` and `state.analyze.health().await` sequentially with no timeout of its own — the only bound was each `SearchClient`/`AnalyzeClient`'s own reqwest client timeout (30s / 5s respectively), which is far longer than any reasonable health-check caller deadline and is meant to bound the *transport*, not the health-check's own SLA.

## Test plan

- [x] `health_stalled_dep_returns_timeout_state_within_bound` — binds a real `TcpListener`, accepts the connection, then `std::future::pending()`s forever (never responds); asserts `handle_health` returns in well under 5s and reports `deps.trusty_search.state == "timeout"` with `reachable == false`.
- [x] `health_inference_ok_when_llm_succeeds` (extended) — fast/healthy dep path still reports `state:"ok"` and `reachable:true` unchanged.
- [x] `health_required_dep_down_sets_degraded` (extended) — hard-down dep (`health()` returns `Err` immediately) still reports `reachable:false`, now distinctly `state:"unreachable"` (not `"timeout"`).
- [x] `dep_probe_timeout_default` / `_env_override` / `_env_invalid_falls_back` / `_env_zero_falls_back` — mirrors the existing `health_probe_timeout` test pattern for the new dep-probe timeout knob.
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (excluding two pre-existing GUI crates whose `ui/dist` build artifact isn't present in this checkout — unrelated to this change).
- [x] `cargo test --workspace` — trusty-review: 1502 passed, 0 failed (was 1497 before this PR + 5 new tests). Two pre-existing failures in the unrelated `trusty-search` binary crate (`doctor_data_dir_returns_non_empty_path`, `fallback_logs_build_failure_exactly_once`) — neither touches trusty-review or this change.

Closes #3658

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools