### PR TITLE
release: trusty-search 0.38.1 — eviction memory return, cgroup enforcement, redb open serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11780,7 +11780,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [0.38.1] — 2026-07-22
+
 ### Fixed
 
 - **Panic-safe, serialized redb corpus open on concurrent warm-boot (issue

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.38.0"
+version = "0.38.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Patch release for the memory-pressured serving box, shipping three prod fixes:

- **Eviction memory return + nested-cgroup limit enforcement** (issue #3657, merge d35d8ea1): idle-evicted chunk/BM25/entity caches now call `libc::malloc_trim(0)` after the clear so freed heap is actually returned to the OS (previously RSS climbed 20.3 -> 26.4 GiB toward an OOM-kill despite the maps being genuinely emptied); `TRUSTY_MEMORY_LIMIT_MB` auto-tune now resolves the process's own (possibly nested systemd/Docker/Kubernetes) cgroup ceiling instead of only host `/proc/meminfo`.
- **Panic-safe serialized redb corpus open** (issue #3659, merge df4eeaf2): concurrent warm-boot/lazy-load/`POST /indexes`/reindex paths racing to open the same `index.redb` are now serialized per-canonical-path, and any panic from a torn concurrent read is converted into a typed `Err` instead of crashing the daemon.
- #3658's sibling fix is in `trusty-review` and already merged separately — not part of this crate's release.

## Test plan
- [x] `cargo fmt --check -p trusty-search`
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings`
- [x] `cargo test -p trusty-search` (single-threaded: 1256+314 passed, 0 failed; parallel run hit two known env-mutation-race flakes unrelated to this change — `doctor_data_dir_returns_non_empty_path` and `fallback_logs_build_failure_exactly_once` — both pass clean under `--test-threads=1`)
- [x] `make release-prep` (ui-dist rebuilt fresh; no diff vs. committed bundle since no UI source changed)
- [x] `cargo publish -p trusty-search --dry-run` (resolves against live crates.io registry; packaged 344 files, 5.1MiB; verify build succeeded)
- [ ] CI green (pending)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools