### PR TITLE
chore(release): trusty-common 0.24.2 — close unpublished source drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,7 +6549,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11403,7 +11403,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ trusty-code = { path = "crates/trusty-code" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.3.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.24.1" }
+trusty-common = { path = "crates/trusty-common", version = "0.24.2" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [0.24.2] — 2026-07-22
+
+Patch release closing unpublished source drift under the already-published
+0.24.1 (issue #3366 defect class): five commits landed on `main` *after*
+0.24.1 was published to crates.io without a version bump, so the live 0.24.1
+tarball does not contain them — most notably the `search_index::ensure_project_indexed`
+signature change below, which blocked `trusty-mpm` 0.20.0 from publishing
+against the live registry. This release carries all five.
+
 ### Fixed
 
 - **Flaky env-mutation-race unit test fixed (#3608), plus an audit sweep

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.24.1"
+version = "0.24.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Five commits landed on `main` after `trusty-common` 0.24.1 was published to crates.io without a version bump (issue #3366 defect class), so the live 0.24.1 tarball predates them.
- Most notably, #3630's `search_index::ensure_project_indexed` signature change (added the required `allow_sensitive_path` parameter) blocks `trusty-mpm` 0.20.0 from resolving `trusty-common` against the live registry during `cargo publish --dry-run`.
- Bumps `trusty-common` to 0.24.2 (patch, matching the established 0.24.0→0.24.1 drift-closing precedent) and dates the CHANGELOG's `[Unreleased]` section as `[0.24.2]`. No functional source changes — the underlying fixes already merged individually.

## Test plan

- [x] `cargo fmt -p trusty-common -- --check`
- [x] `cargo clippy -p trusty-common --all-targets -- -D warnings`
- [x] `cargo test -p trusty-common` (175 passed, 0 failed, 6 ignored)
- [x] `cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui --exclude trusty-agents-ui` (the three excluded GUI crates fail in this checkout for an unrelated, pre-existing reason — missing built frontend `dist/` — not touched by this change)
- [ ] CI green
- [ ] Publish trusty-common 0.24.2 to crates.io once merged, to unblock trusty-mpm 0.20.0

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools