### PR TITLE
fix(test): kill env-pollution flakes in doctor_data_dir + verify_installed_binary (#3673, #3608)

### DIFF
--- a/crates/trusty-search/src/commands/doctor_checks/tests.rs
+++ b/crates/trusty-search/src/commands/doctor_checks/tests.rs
@@ -4,6 +4,7 @@
 //! 500-SLOC cap; behaviour is unchanged (see #1195).
 
 use super::*;
+use serial_test::serial;
 
 #[test]
 fn check_result_classifiers() {
@@ -187,9 +188,33 @@ fn read_daemon_port_returns_some_u16() {
     let _ = p;
 }
 
+/// #3673: `doctor_data_dir()` reads the process-global `TRUSTY_DATA_DIR` env
+/// var, which 40+ other tests across this test binary also mutate (e.g.
+/// `service/data_dir.rs`, `commands/start/tests.rs`). Without `#[serial]`
+/// this test can observe a sibling test's tempdir value mid-flight and fail
+/// an assertion that has nothing to do with this test's own behaviour.
+///
+/// Why: `#[serial]` (bare — the crate-wide default lock, matching the
+/// convention in `service/data_dir.rs`'s `data_dir_override_yields_absolute_path`
+/// and `commands/daemon_utils.rs`) serializes this test against every other
+/// `TRUSTY_DATA_DIR`-mutating test in the crate. We additionally clear
+/// `TRUSTY_DATA_DIR` ourselves (rather than merely hoping no sibling left it
+/// set) so the assertion always exercises the platform-default fallback path
+/// — the one that actually contains `"trusty-search"` — deterministically,
+/// and restore whatever was there beforehand so we don't pollute later tests.
+/// What: clear `TRUSTY_DATA_DIR` under the lock, call `doctor_data_dir()`,
+/// assert the default fallback path contains `"trusty-search"`, restore.
+/// Test: `doctor_data_dir_returns_non_empty_path`.
 #[test]
+#[serial]
 fn doctor_data_dir_returns_non_empty_path() {
+    let prev = std::env::var("TRUSTY_DATA_DIR").ok();
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
     let p = doctor_data_dir();
+    match prev {
+        Some(v) => unsafe { std::env::set_var("TRUSTY_DATA_DIR", v) },
+        None => unsafe { std::env::remove_var("TRUSTY_DATA_DIR") },
+    }
     assert!(p.to_string_lossy().contains("trusty-search"));
 }
 
@@ -271,7 +296,6 @@ fn fake_layout(base: std::path::PathBuf) -> trusty_embedderd_py::VenvLayout {
 // test`'s default parallel threads race on the same env var across the two
 // files and can flip a "disabled" assertion into an "enabled" one (or vice
 // versa) depending on scheduling (caught by CI, PR #3560).
-use serial_test::serial;
 
 #[test]
 #[serial]


### PR DESCRIPTION
## Summary
- **#3673** (trusty-search): `doctor_data_dir_returns_non_empty_path` neither controlled `TRUSTY_DATA_DIR` nor carried a `#[serial]` guard, so any of the 40+ other tests in the same binary that mutate `TRUSTY_DATA_DIR` could race it mid-flight and turn a passing assertion into a false red (already cost a rerun on PR #3653). Fixed by adding the crate's existing bare `#[serial]` convention (matching `service/data_dir.rs`'s `data_dir_override_yields_absolute_path` and `commands/daemon_utils.rs`) and having the test itself clear `TRUSTY_DATA_DIR` under the lock and restore whatever was there afterward, so it deterministically exercises the platform-default fallback path it's actually meant to test.
- **#3608** (trusty-common): `verify_installed_binary_finds_binary_via_path` was already fixed by #3629 — `ENV_LOCK` now spans the `PATH` mutation and the whole async test body carries `#[serial(update_verify_installed_binary_env)]`. Verified against current `main`; no code change needed. Closing via this PR to tidy the backlog.

Closes #3673
Closes #3608

## Test plan
- [x] `cargo fmt --check -p trusty-search -p trusty-common`
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings`
- [x] `cargo clippy -p trusty-common --all-targets --features update-check -- -D warnings`
- [x] `cargo test -p trusty-search --bin trusty-search` looped 30x at `--test-threads=16` — `doctor_data_dir_returns_non_empty_path` green every run
- [x] `cargo test -p trusty-common --features update-check update::` looped 20x at `--test-threads=16` — `verify_installed_binary_finds_binary_via_path` green every run
- [x] `cargo test -p trusty-search` and `cargo test -p trusty-common` (full suites) — green

Noted two **pre-existing, unrelated** flakes in the same env-race bug class hit during looped runs (not touched by this PR, out of scope for #3673/#3608): `commands::start::embedder_fallback::tests::fallback_logs_build_failure_exactly_once` (trusty-search) and `service::reindex::root_hijack_tests::reindex_refuses_untrusted_root_move_and_preserves_corpus` (trusty-search), plus an occasional `update::tests::cache_fresh_returns_some_when_newer` (trusty-common) race against the `CI_ENV`/`NO_UPDATE_CHECK_ENV`-mutating tests. Will file separate issues if not already tracked.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools