### PR TITLE
fix: propagate merge failure as phase failure in parallel dispatch (#3671)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -51,6 +51,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   execution path) — a documented MVP scope limit, flagged for a follow-up
   RPC.
 
+### Fixed
+
+- **A parallel phase could not fail when its merge failed (#3671):**
+  `executor::dispatch` folded `ConflictResolver::merge`'s `Err` into a
+  `"merge failed: ..."` string appended to the phase's content and returned
+  `Ok(AgentOutput)` regardless. `merge()` only errors on a genuine I/O fault
+  (`create_dir_all`/`read_dir`/`read`/`write`) — every recoverable conflict
+  (a failed `git merge-file`, a failed LLM fallback) is already degraded to
+  `Ok` with the reason recorded in the merge report. So a real `Err` meant the
+  merged tree on disk was incomplete and nondeterministic (the collection
+  loop walks a `HashMap` and can bail partway through), yet downstream phases
+  consumed it as if it were whole, with the failure visible only as a buried
+  string. `merge`'s `Err` now propagates as `WorkflowError::PhaseFailed`,
+  failing the phase/workflow instead. Sibling of #3652/#3653/#3675 (the same
+  "silent success" bug class).
+
 ### Security
 
 - **Assistant no longer leaks internal orchestration or disclaims delegating

--- a/crates/trusty-agents/src/workflow/engine/executor/dispatch.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/dispatch.rs
@@ -90,10 +90,25 @@ impl WorkflowEngine {
                     let api_key = trusty_common::inference::credentials::resolve_key("openrouter")
                         .unwrap_or_default();
                     let resolver = ConflictResolver::new(api_key);
-                    let merge_report = resolver
-                        .merge(&results, &phase_out_dir)
-                        .await
-                        .unwrap_or_else(|e| format!("merge failed: {e:#}"));
+                    // #3671: `merge()` only returns `Err` for a genuine I/O
+                    // fault (create_dir_all/read_dir/read/write) — every
+                    // recoverable conflict (git failure, LLM failure) is
+                    // already degraded to `Ok` with a reason recorded in the
+                    // report body (see `resolver.rs`'s `resolve_conflict`
+                    // invariant). So an `Err` here means the merged tree on
+                    // disk is genuinely incomplete/nondeterministic (the
+                    // collection loop walks a `HashMap` and bails partway
+                    // through), and MUST fail the phase rather than be
+                    // folded into a success string that downstream phases
+                    // would consume as if the tree were whole.
+                    let merge_report =
+                        resolver
+                            .merge(&results, &phase_out_dir)
+                            .await
+                            .map_err(|source| WorkflowError::PhaseFailed {
+                                phase: phase.name.clone(),
+                                source,
+                            })?;
 
                     // Aggregate combined content + usage across sub-agents.
                     let mut combined = String::new();

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/mod.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/mod.rs
@@ -27,6 +27,7 @@ pub(crate) use crate::workflow::engine::helpers::reconcile_code_outputs_against;
 pub(crate) use crate::workflow::engine::step_dispatch::discover_project_dir;
 
 mod checkpoint_resume;
+mod parallel_merge;
 mod phase_order;
 mod relocate;
 mod retry;

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/parallel_merge.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/parallel_merge.rs
@@ -1,0 +1,184 @@
+//! Parallel-phase merge propagation tests (#3671).
+//!
+//! Why: `dispatch_phase`'s parallel branch used to fold `ConflictResolver
+//! ::merge`'s `Err` into a string appended to a success payload — a real I/O
+//! fault while assembling the merged output tree (a `create_dir_all`
+//! blocked by a colliding non-directory entry, in this test) reported as a
+//! successful phase with a partial, nondeterministic tree on disk. These
+//! tests pin the fix: a merge I/O failure must fail the phase/workflow, and
+//! a clean merge must still succeed exactly as before.
+//! What: Drives the full `WorkflowEngine::run` (not just `dispatch_phase`
+//! directly) through a single-phase workflow with `parallel_subtasks`, using
+//! a mock `AgentRunner` that writes real files into the sub-agent out_dirs
+//! `run_parallel_phase` computes, so `ConflictResolver::merge` does genuine
+//! filesystem work.
+//! Test: This file IS the test body.
+
+use super::*;
+
+/// Mock runner for the parallel-merge tests. Each subtask's agent call
+/// writes a fixed file tree directly into `base_out_dir/<label>/...`
+/// (mirroring what `run_parallel_phase` expects a real sub-agent to have
+/// produced under its assigned out_dir), keyed off the task text so a
+/// single mock instance can serve multiple differently-labeled subtasks.
+struct ParallelMergeMock {
+    base_out_dir: PathBuf,
+}
+
+#[async_trait]
+impl AgentRunner for ParallelMergeMock {
+    async fn run(&self, _agent_name: &str, task: &str) -> Result<AgentOutput> {
+        // The task text carries "LABEL:<label>:<relative/file/path>" so this
+        // single mock can place each subtask's file(s) without needing the
+        // AgentRunner trait to expose the out_dir it will land in.
+        for line in task.lines() {
+            if let Some(rest) = line.strip_prefix("LABEL:") {
+                let mut parts = rest.splitn(2, ':');
+                let label = parts.next().unwrap_or_default();
+                let rel = parts.next().unwrap_or_default();
+                let dest = self.base_out_dir.join(label).join(rel);
+                if let Some(parent) = dest.parent() {
+                    tokio::fs::create_dir_all(parent).await.ok();
+                }
+                tokio::fs::write(&dest, b"sub-agent content\n").await.ok();
+            }
+        }
+        Ok(AgentOutput {
+            content: "sub-agent done".to_string(),
+            summary: None,
+            usage: TokenUsage::default(),
+        })
+    }
+}
+
+fn parallel_workflow_json(label_a: &str, suffix_a: &str, label_b: &str, suffix_b: &str) -> String {
+    format!(
+        r#"{{
+            "name": "parallel-merge-test",
+            "description": "single parallel phase",
+            "phases": [
+                {{
+                    "name": "build",
+                    "agent": "parallel-mock",
+                    "context_template": "{{{{task}}}}",
+                    "parallel_subtasks": [
+                        {{"label": "{label_a}", "task_suffix": "{suffix_a}"}},
+                        {{"label": "{label_b}", "task_suffix": "{suffix_b}"}}
+                    ]
+                }}
+            ]
+        }}"#
+    )
+}
+
+/// #3671: A merge I/O fault (here, `create_dir_all` blocked by a
+/// pre-existing regular file at the exact path a merged sub-tree needs as a
+/// directory) must fail the phase/workflow — not be swallowed into a
+/// `"merge failed: ..."` string appended to a successful `AgentOutput`.
+#[tokio::test]
+async fn parallel_phase_merge_io_failure_fails_the_workflow() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out_dir = tmp.path().join("out");
+    tokio::fs::create_dir_all(&out_dir).await.unwrap();
+
+    // Block the merge's own `create_dir_all(out_dir/nested)`: a sub-agent's
+    // file lands at "nested/leaf.txt" (relative to its own out_dir), so the
+    // merge step will try to create `out_dir/nested` as a directory. Placing
+    // a plain file there first makes that create_dir_all fail with a real
+    // I/O error, distinct from run_parallel_phase's own (unrelated) subtask
+    // dir creation, which only ever touches `out_dir/<label>` itself.
+    tokio::fs::write(out_dir.join("nested"), b"blocker file, not a dir\n")
+        .await
+        .unwrap();
+
+    let workflows_dir = tmp.path().join("workflows");
+    tokio::fs::create_dir_all(&workflows_dir).await.unwrap();
+    let wf_path = workflows_dir.join("parallel-merge-test.json");
+    tokio::fs::write(
+        &wf_path,
+        parallel_workflow_json("a", "LABEL:a:nested/leaf.txt", "b", "LABEL:b:other.txt"),
+    )
+    .await
+    .unwrap();
+
+    let mock = Arc::new(ParallelMergeMock {
+        base_out_dir: out_dir.clone(),
+    });
+    let engine = WorkflowEngine::new(mock, workflows_dir.clone());
+    let result = engine
+        .run(
+            "parallel-merge-test",
+            "base task".into(),
+            Some(out_dir.clone()),
+        )
+        .await;
+
+    let err = result.expect_err(
+        "a merge I/O fault must fail the workflow, not be swallowed into a success payload",
+    );
+    match err {
+        WorkflowError::PhaseFailed { phase, source } => {
+            assert_eq!(phase, "build");
+            // The underlying I/O error is inspectable, not just a substring
+            // buried in a success payload's content string.
+            let msg = format!("{source:#}");
+            assert!(
+                !msg.is_empty(),
+                "PhaseFailed source should carry the real I/O error"
+            );
+        }
+        other => panic!("expected WorkflowError::PhaseFailed, got: {other:?}"),
+    }
+}
+
+/// Regression: a clean merge (no conflicts, no I/O faults) must still
+/// succeed exactly as before — both sub-agents' content shows up in the
+/// aggregated output and the merged files land on disk under `out_dir`.
+#[tokio::test]
+async fn parallel_phase_clean_merge_still_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out_dir = tmp.path().join("out");
+    tokio::fs::create_dir_all(&out_dir).await.unwrap();
+
+    let workflows_dir = tmp.path().join("workflows");
+    tokio::fs::create_dir_all(&workflows_dir).await.unwrap();
+    let wf_path = workflows_dir.join("parallel-merge-test.json");
+    tokio::fs::write(
+        &wf_path,
+        parallel_workflow_json("a", "LABEL:a:a-file.txt", "b", "LABEL:b:b-file.txt"),
+    )
+    .await
+    .unwrap();
+
+    let mock = Arc::new(ParallelMergeMock {
+        base_out_dir: out_dir.clone(),
+    });
+    let engine = WorkflowEngine::new(mock, workflows_dir.clone());
+    let ctx = engine
+        .run(
+            "parallel-merge-test",
+            "base task".into(),
+            Some(out_dir.clone()),
+        )
+        .await
+        .expect("clean parallel merge should still succeed");
+
+    assert!(ctx.phase_outputs.contains_key("build"));
+    let build_output = &ctx.phase_outputs["build"];
+    assert!(
+        build_output.contains("Sub-agent [a]") && build_output.contains("Sub-agent [b]"),
+        "merged phase output should include both sub-agents' content: {build_output}"
+    );
+
+    // Both disjoint files should have been merged through to disk.
+    assert!(
+        tokio::fs::try_exists(out_dir.join("a-file.txt"))
+            .await
+            .unwrap()
+    );
+    assert!(
+        tokio::fs::try_exists(out_dir.join("b-file.txt"))
+            .await
+            .unwrap()
+    );
+}


### PR DESCRIPTION
## Summary

`executor::dispatch`'s parallel branch swallowed `ConflictResolver::merge`'s
`Err` into a string and returned `Ok(AgentOutput)` regardless:

```rust
let merge_report = resolver
    .merge(&results, &phase_out_dir)
    .await
    .unwrap_or_else(|e| format!("merge failed: {e:#}"));
```

`merge()` only returns `Err` on a genuine I/O fault (`create_dir_all`/
`read_dir`/`read`/the `write` that puts resolved bytes into the output
tree) — every recoverable conflict (a failed `git merge-file`, a failed
LLM fallback) is already degraded to `Ok` with the reason recorded in the
merge report, per the invariant established in #3653's `resolve_conflict`.
So a real `Err` here means the merged tree on disk is genuinely incomplete
and nondeterministic (the collection loop walks a `HashMap` and can bail
partway through), yet the phase still reported success and downstream
phases consumed the partial tree as if it were whole — with the only trace
being a literal `"merge failed: ..."` string buried in the phase's content.

This is the third instance of the same "silent success" bug class found in
one day (#3652, #3653, this one — see #3671 for the full writeup and why
this fix was deliberately kept out of #3653).

## Fix

- `merge`'s `Err` now propagates via
  `.map_err(|source| WorkflowError::PhaseFailed { phase: phase.name.clone(), source })?`,
  matching the pattern used by every other error path in `dispatch_phase`
  (wave loop, persistent-session, plain single-shot).
- No change to `ConflictResolver` itself — its degrade-vs-error tradeoff for
  git/LLM failures is unaffected; only the genuine-I/O-fault `Err` path
  changes behavior.

## Tests

Added `crates/trusty-agents/src/workflow/engine/executor/tests/parallel_merge.rs`:

- `parallel_phase_merge_io_failure_fails_the_workflow`: drives the full
  `WorkflowEngine::run` through a single-phase parallel workflow, forces a
  real merge I/O fault (a pre-existing regular file blocks the
  `create_dir_all` the merge step needs for a sub-agent's file tree), and
  asserts the workflow returns `Err(WorkflowError::PhaseFailed)` with an
  inspectable, non-empty source error — not a substring buried in a success
  payload. Verified this test fails against the pre-fix code and passes
  with the fix.
- `parallel_phase_clean_merge_still_succeeds`: regression — a clean,
  conflict-free parallel merge still returns `Ok`, both sub-agents' content
  appears in the aggregated output, and both disjoint files land on disk.

## Gate

```
cargo fmt --check                                    # clean
cargo clippy -p trusty-agents --all-targets -- -D warnings   # clean
cargo test -p trusty-agents --no-fail-fast           # 2173 lib tests + all integration binaries: 0 failed
```

One lib test (`resume_replays_summary_not_full_content_into_downstream_prompts`)
flaked once in an earlier full-suite run but passed on every other run
(standalone and full-suite, before and after this change) — pre-existing
flake, unrelated to this fix, not touched here. The `tests/plain_cli_repl.rs`
failures noted in #3655 as pre-existing on main did not reproduce in this
session's runs (7/7 passed).

Closes #3671
Refs #3675

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools