### PR TITLE
fix(trusty-code-gui): scale small hardcoded px labels + bump root font to 120%

### DIFF
--- a/crates/trusty-code-gui/CHANGELOG.md
+++ b/crates/trusty-code-gui/CHANGELOG.md
@@ -10,6 +10,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **Base font still too small, take two (issue #3447).** PR #3460's 110% root
+  bump only reached `rem`-based Tailwind utilities; the ~69 hardcoded
+  `text-[9px]`/`text-[10px]`/`text-[11px]` arbitrary-px labels used for
+  badges/status/rail/tab text across `WorkstreamRail`, `StatusBar`,
+  `StartWorkingForm`, `SearchTab`, `ProjectPickerModal`, `AppHeader`,
+  `ServiceNav`, `WorkstreamSwitcher`, `AgentsTab`, `SkillsTab`, and
+  `WorkstreamActivity` never scaled since Tailwind emits arbitrary `px`
+  literals as-is. Converted every one to its rem equivalent
+  (`text-[11px]` -> `text-[0.6875rem]`, `text-[10px]` -> `text-[0.625rem]`,
+  `text-[9px]` -> `text-[0.5625rem]`) so they inherit the root multiplier
+  like every other token, preserving the relative size hierarchy between
+  the three tiers. Root bumped from 110% to 120% (`app.css`) on top of that
+  fix for a perceptibly larger base.
 - **Workstream/agents UX corrections: hide base agents, PM-only agent choice, immutable project (refs #3465).**
   - The Agents tab and the start-working agent selector no longer list the 5
     `BASE-*` composition-template agents (`base-agent`, `base-engineer`,

--- a/crates/trusty-code-gui/ui/src/app.css
+++ b/crates/trusty-code-gui/ui/src/app.css
@@ -102,17 +102,24 @@
   --color-sidebar-active: 56 37 19; /* #382513 */
 }
 
-/* Issue #3447 item 3 — Bob: "10% larger base font." A rem-scale bump on the
+/* Issue #3447 — Bob: "base font still too small." A rem-scale bump on the
  * root element: every Tailwind utility class in this codebase (`text-xs`,
- * `text-[11px]`, `p-4`, etc.) that resolves to a `rem` value scales with it
- * automatically, so this one line reaches the whole app rather than
- * touching each component. Arbitrary `px`-bracket utilities (`text-[11px]`,
- * `w-[46px]`) do NOT scale (Tailwind emits those as literal `px`, not
- * `rem`) — verified by manual inspection (`pnpm build` + `pnpm test`, see
- * the PR's own gate output) that no rail/header/switcher/input-bar text
- * clips or overflows at the new size; nothing needed adjusting. */
+ * `p-4`, etc.) that resolves to a `rem` value scales with it automatically,
+ * so this one line reaches the whole app rather than touching each
+ * component. PR #3460 first tried a 110% bump but it barely moved the
+ * needle — most of the UI's small labels/badges/status text were written
+ * as Tailwind arbitrary `px`-bracket utilities (`text-[11px]`, `text-[10px]`,
+ * `text-[9px]`), which Tailwind emits as literal `px`, NOT `rem` — those
+ * never scaled with this root at all. Fixed by converting every such
+ * literal to its rem equivalent (`text-[11px]` -> `text-[0.6875rem]`, etc.,
+ * see components/*.svelte) so they inherit this multiplier like every
+ * other token; relative hierarchy between the 9/10/11px tiers is preserved
+ * exactly since each keeps its own distinct rem value. Root bumped again to
+ * 120% on top of that fix for a perceptibly larger base. Arbitrary
+ * `w-[Npx]`-style *non-text* utilities are unaffected by design — only
+ * font-size needed to track the root. */
 html {
-  font-size: 110%;
+  font-size: 120%;
 }
 
 html,

--- a/crates/trusty-code-gui/ui/src/components/AgentsTab.svelte
+++ b/crates/trusty-code-gui/ui/src/components/AgentsTab.svelte
@@ -175,7 +175,7 @@
     <button
       type="button"
       onclick={toggleAdd}
-      class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
+      class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2 py-0.5 font-mono text-[0.625rem] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
     >
       {addOpen ? 'cancel' : '+ add agent'}
     </button>
@@ -185,7 +185,7 @@
     {#if addOpen}
       <div class="mb-4 rounded border-1.5 border-trusty-border bg-trusty-raised p-3">
         <label
-          class="font-mono text-[10px] font-semibold uppercase tracking-wide text-trusty-text-muted"
+          class="font-mono text-[0.625rem] font-semibold uppercase tracking-wide text-trusty-text-muted"
           for="agent-add-name"
         >
           name (lowercase, digits, hyphens)
@@ -198,7 +198,7 @@
         />
 
         <label
-          class="mt-2 block font-mono text-[10px] font-semibold uppercase tracking-wide text-trusty-text-muted"
+          class="mt-2 block font-mono text-[0.625rem] font-semibold uppercase tracking-wide text-trusty-text-muted"
           for="agent-add-content"
         >
           content (Markdown + frontmatter)
@@ -216,7 +216,7 @@
             type="file"
             accept=".md,text/markdown,text/plain"
             onchange={onFilePicked}
-            class="font-mono text-[10px] text-trusty-text-muted"
+            class="font-mono text-[0.625rem] text-trusty-text-muted"
           />
         </div>
 
@@ -228,7 +228,7 @@
           type="button"
           disabled={addBusy || !addName.trim() || !addContent.trim()}
           onclick={submitAdd}
-          class="mt-2 rounded-sm border-1.5 border-trusty-primary bg-trusty-primary px-2.5 py-1 font-mono text-[11px] uppercase tracking-wide text-trusty-surface disabled:cursor-not-allowed disabled:opacity-50"
+          class="mt-2 rounded-sm border-1.5 border-trusty-primary bg-trusty-primary px-2.5 py-1 font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-surface disabled:cursor-not-allowed disabled:opacity-50"
         >
           {addBusy ? 'creating…' : 'create'}
         </button>
@@ -254,13 +254,13 @@
               <div class="flex items-center gap-2">
                 <span class="truncate font-mono text-xs text-trusty-text">{agent.name}</span>
                 <span
-                  class="shrink-0 rounded-sm border border-trusty-border-strong px-1 font-mono text-[9px] uppercase tracking-wide text-trusty-text-muted"
+                  class="shrink-0 rounded-sm border border-trusty-border-strong px-1 font-mono text-[0.5625rem] uppercase tracking-wide text-trusty-text-muted"
                 >
                   {tierLabel(agent.tier)}
                 </span>
               </div>
               {#if agent.description}
-                <p class="truncate text-[11px] text-trusty-text-secondary">{agent.description}</p>
+                <p class="truncate text-[0.6875rem] text-trusty-text-secondary">{agent.description}</p>
               {/if}
             </div>
 
@@ -269,7 +269,7 @@
                 <div class="flex shrink-0 items-center gap-1.5">
                   <button
                     type="button"
-                    class="font-mono text-[10px] uppercase tracking-wide text-status-error"
+                    class="font-mono text-[0.625rem] uppercase tracking-wide text-status-error"
                     disabled={removeBusy}
                     onclick={() => doRemove(agent.name)}
                   >
@@ -277,7 +277,7 @@
                   </button>
                   <button
                     type="button"
-                    class="font-mono text-[10px] uppercase tracking-wide text-trusty-text-muted"
+                    class="font-mono text-[0.625rem] uppercase tracking-wide text-trusty-text-muted"
                     disabled={removeBusy}
                     onclick={() => (removeConfirmName = null)}
                   >
@@ -287,7 +287,7 @@
               {:else}
                 <button
                   type="button"
-                  class="shrink-0 px-1 font-mono text-[11px] text-trusty-text-muted hover:text-status-error"
+                  class="shrink-0 px-1 font-mono text-[0.6875rem] text-trusty-text-muted hover:text-status-error"
                   aria-label={`remove ${agent.name}`}
                   onclick={() => (removeConfirmName = agent.name)}
                 >

--- a/crates/trusty-code-gui/ui/src/components/AppHeader.svelte
+++ b/crates/trusty-code-gui/ui/src/components/AppHeader.svelte
@@ -42,7 +42,7 @@
 
   <div class="flex items-center gap-3">
     <span
-      class="font-mono text-[11px] uppercase tracking-wide text-trusty-text-muted"
+      class="font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-text-muted"
       title="Global tokens/cost readout — live cost tracking is issue #3254, not yet shipped"
     >
       tokens: — · cost: —
@@ -52,7 +52,7 @@
       disabled
       aria-label="settings"
       title="Settings — not yet implemented"
-      class="rounded-sm border-1.5 border-trusty-border bg-trusty-card px-1.5 py-1 font-mono text-[11px] text-trusty-text-muted disabled:cursor-not-allowed disabled:opacity-50"
+      class="rounded-sm border-1.5 border-trusty-border bg-trusty-card px-1.5 py-1 font-mono text-[0.6875rem] text-trusty-text-muted disabled:cursor-not-allowed disabled:opacity-50"
     >
       ⚙
     </button>

--- a/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.svelte
+++ b/crates/trusty-code-gui/ui/src/components/ProjectPickerModal.svelte
@@ -144,7 +144,7 @@
            pattern (`bg-status-warn/10` + `text-status-warn`), amber rather
            than red — the picker is still usable, just degraded. -->
       <p
-        class="mt-2 rounded-sm bg-status-warn/10 px-2 py-1.5 text-[11px] text-status-warn"
+        class="mt-2 rounded-sm bg-status-warn/10 px-2 py-1.5 text-[0.6875rem] text-status-warn"
       >
         shared registry unavailable — showing local checkouts only
       </p>
@@ -174,7 +174,7 @@
                    `new-workstream.ts::bindingLabel`'s existing precedent for
                    a small state-driven label suffix (there: git repo vs.
                    plain directory). -->
-              <span class="shrink-0 text-[10px] uppercase tracking-wide text-trusty-text-muted"
+              <span class="shrink-0 text-[0.625rem] uppercase tracking-wide text-trusty-text-muted"
                 >local only</span
               >
             {/if}
@@ -186,7 +186,7 @@
     <div class="mt-3 border-t border-trusty-border pt-3">
       <button
         type="button"
-        class="w-full rounded-sm border-1.5 border-dashed border-trusty-border-strong px-2 py-1.5 text-center font-mono text-[11px] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
+        class="w-full rounded-sm border-1.5 border-dashed border-trusty-border-strong px-2 py-1.5 text-center font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
         onclick={pickProjectless}
       >
         start chatting without a project

--- a/crates/trusty-code-gui/ui/src/components/SearchTab.svelte
+++ b/crates/trusty-code-gui/ui/src/components/SearchTab.svelte
@@ -212,12 +212,12 @@
         <table class="w-full text-left font-mono text-xs">
           <thead>
             <tr class="border-b border-trusty-border text-trusty-text-muted">
-              <th class="pb-2 pr-3 text-[10px] font-semibold uppercase tracking-wide">lane</th>
-              <th class="pb-2 pr-3 text-[10px] font-semibold uppercase tracking-wide">query</th>
-              <th class="pb-2 pr-3 text-[10px] font-semibold uppercase tracking-wide">hits</th>
-              <th class="pb-2 pr-3 text-[10px] font-semibold uppercase tracking-wide">latency</th>
-              <th class="pb-2 pr-3 text-[10px] font-semibold uppercase tracking-wide">agent</th>
-              <th class="pb-2 text-[10px] font-semibold uppercase tracking-wide">age</th>
+              <th class="pb-2 pr-3 text-[0.625rem] font-semibold uppercase tracking-wide">lane</th>
+              <th class="pb-2 pr-3 text-[0.625rem] font-semibold uppercase tracking-wide">query</th>
+              <th class="pb-2 pr-3 text-[0.625rem] font-semibold uppercase tracking-wide">hits</th>
+              <th class="pb-2 pr-3 text-[0.625rem] font-semibold uppercase tracking-wide">latency</th>
+              <th class="pb-2 pr-3 text-[0.625rem] font-semibold uppercase tracking-wide">agent</th>
+              <th class="pb-2 text-[0.625rem] font-semibold uppercase tracking-wide">age</th>
             </tr>
           </thead>
           <tbody>

--- a/crates/trusty-code-gui/ui/src/components/ServiceNav.svelte
+++ b/crates/trusty-code-gui/ui/src/components/ServiceNav.svelte
@@ -54,7 +54,7 @@
       disabled={visibility.locked}
       title={visibility.locked ? `${tab.label} — locked until a project is bound` : tab.label}
       onclick={() => onSelect(tab.id)}
-      class={`flex items-center gap-1.5 border-b-2 px-3 py-2 font-mono text-[11px] font-semibold uppercase tracking-wide disabled:cursor-not-allowed disabled:opacity-40 ${
+      class={`flex items-center gap-1.5 border-b-2 px-3 py-2 font-mono text-[0.6875rem] font-semibold uppercase tracking-wide disabled:cursor-not-allowed disabled:opacity-40 ${
         activeTab === tab.id
           ? 'border-trusty-primary text-trusty-primary'
           : 'border-transparent text-trusty-text-secondary hover:text-trusty-text'

--- a/crates/trusty-code-gui/ui/src/components/SkillsTab.svelte
+++ b/crates/trusty-code-gui/ui/src/components/SkillsTab.svelte
@@ -184,7 +184,7 @@
       onclick={toggleAdd}
       disabled={!hasProject}
       title={hasProject ? undefined : 'skills are project-scoped — bind a project to add one'}
-      class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary disabled:cursor-not-allowed disabled:opacity-50"
+      class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2 py-0.5 font-mono text-[0.625rem] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary disabled:cursor-not-allowed disabled:opacity-50"
     >
       {addOpen ? 'cancel' : '+ add skill'}
     </button>
@@ -192,7 +192,7 @@
 
   <div class="p-4">
     {#if !hasProject}
-      <p class="mb-3 text-[11px] text-trusty-text-muted">
+      <p class="mb-3 text-[0.6875rem] text-trusty-text-muted">
         skills are project-scoped (no user-level tier) — bind a project to add or remove one; the
         bundled catalog below is always available.
       </p>
@@ -201,7 +201,7 @@
     {#if addOpen}
       <div class="mb-4 rounded border-1.5 border-trusty-border bg-trusty-raised p-3">
         <label
-          class="font-mono text-[10px] font-semibold uppercase tracking-wide text-trusty-text-muted"
+          class="font-mono text-[0.625rem] font-semibold uppercase tracking-wide text-trusty-text-muted"
           for="skill-add-name"
         >
           name (lowercase, digits, hyphens)
@@ -214,7 +214,7 @@
         />
 
         <label
-          class="mt-2 block font-mono text-[10px] font-semibold uppercase tracking-wide text-trusty-text-muted"
+          class="mt-2 block font-mono text-[0.625rem] font-semibold uppercase tracking-wide text-trusty-text-muted"
           for="skill-add-content"
         >
           SKILL.md content (Markdown + frontmatter)
@@ -232,7 +232,7 @@
             type="file"
             accept=".md,text/markdown,text/plain"
             onchange={onFilePicked}
-            class="font-mono text-[10px] text-trusty-text-muted"
+            class="font-mono text-[0.625rem] text-trusty-text-muted"
           />
         </div>
 
@@ -244,7 +244,7 @@
           type="button"
           disabled={addBusy || !addName.trim() || !addContent.trim()}
           onclick={submitAdd}
-          class="mt-2 rounded-sm border-1.5 border-trusty-primary bg-trusty-primary px-2.5 py-1 font-mono text-[11px] uppercase tracking-wide text-trusty-surface disabled:cursor-not-allowed disabled:opacity-50"
+          class="mt-2 rounded-sm border-1.5 border-trusty-primary bg-trusty-primary px-2.5 py-1 font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-surface disabled:cursor-not-allowed disabled:opacity-50"
         >
           {addBusy ? 'creating…' : 'create'}
         </button>
@@ -270,13 +270,13 @@
               <div class="flex items-center gap-2">
                 <span class="truncate font-mono text-xs text-trusty-text">{skill.name}</span>
                 <span
-                  class="shrink-0 rounded-sm border border-trusty-border-strong px-1 font-mono text-[9px] uppercase tracking-wide text-trusty-text-muted"
+                  class="shrink-0 rounded-sm border border-trusty-border-strong px-1 font-mono text-[0.5625rem] uppercase tracking-wide text-trusty-text-muted"
                 >
                   {tierLabel(skill.tier)}
                 </span>
               </div>
               {#if skill.description}
-                <p class="truncate text-[11px] text-trusty-text-secondary">{skill.description}</p>
+                <p class="truncate text-[0.6875rem] text-trusty-text-secondary">{skill.description}</p>
               {/if}
             </div>
 
@@ -285,7 +285,7 @@
                 <div class="flex shrink-0 items-center gap-1.5">
                   <button
                     type="button"
-                    class="font-mono text-[10px] uppercase tracking-wide text-status-error"
+                    class="font-mono text-[0.625rem] uppercase tracking-wide text-status-error"
                     disabled={removeBusy}
                     onclick={() => doRemove(skill.name)}
                   >
@@ -293,7 +293,7 @@
                   </button>
                   <button
                     type="button"
-                    class="font-mono text-[10px] uppercase tracking-wide text-trusty-text-muted"
+                    class="font-mono text-[0.625rem] uppercase tracking-wide text-trusty-text-muted"
                     disabled={removeBusy}
                     onclick={() => (removeConfirmName = null)}
                   >
@@ -303,7 +303,7 @@
               {:else}
                 <button
                   type="button"
-                  class="shrink-0 px-1 font-mono text-[11px] text-trusty-text-muted hover:text-status-error"
+                  class="shrink-0 px-1 font-mono text-[0.6875rem] text-trusty-text-muted hover:text-status-error"
                   aria-label={`remove ${skill.name}`}
                   onclick={() => (removeConfirmName = skill.name)}
                 >

--- a/crates/trusty-code-gui/ui/src/components/StartWorkingForm.svelte
+++ b/crates/trusty-code-gui/ui/src/components/StartWorkingForm.svelte
@@ -644,14 +644,14 @@
       <button
         type="button"
         onclick={openPicker}
-        class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-raised px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
+        class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-raised px-1.5 py-0.5 font-mono text-[0.625rem] uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
       >
         choose project
       </button>
       {#if selectedProjectState.project}
         <button
           type="button"
-          class="font-mono text-[11px] uppercase tracking-wide text-trusty-text-muted underline hover:text-trusty-primary"
+          class="font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-text-muted underline hover:text-trusty-primary"
           onclick={clearSelection}
         >
           clear

--- a/crates/trusty-code-gui/ui/src/components/StatusBar.svelte
+++ b/crates/trusty-code-gui/ui/src/components/StatusBar.svelte
@@ -204,7 +204,7 @@
 </script>
 
 <footer
-  class="statusbar flex items-center justify-between gap-4 border-t border-trusty-border bg-trusty-raised px-4 py-2 font-mono text-[11px] uppercase tracking-wide text-trusty-text-secondary"
+  class="statusbar flex items-center justify-between gap-4 border-t border-trusty-border bg-trusty-raised px-4 py-2 font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-text-secondary"
 >
   {#if phase === 'connecting'}
     <span class="text-trusty-text-muted">connecting…</span>

--- a/crates/trusty-code-gui/ui/src/components/WorkstreamActivity.svelte
+++ b/crates/trusty-code-gui/ui/src/components/WorkstreamActivity.svelte
@@ -656,12 +656,12 @@
     <div
       class="flex shrink-0 items-center justify-between gap-2 border-b border-trusty-border bg-trusty-raised px-4 py-2"
     >
-      <span class="font-mono text-[11px] uppercase tracking-wide text-trusty-text-secondary">
+      <span class="font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-text-secondary">
         {workstreamLabel(activeWorkstream)}
       </span>
       <div class="flex items-center gap-3">
         {#if session}
-          <span class="flex items-center gap-2 font-mono text-[11px]">
+          <span class="flex items-center gap-2 font-mono text-[0.6875rem]">
             <span class={`h-1.5 w-1.5 rounded-full ${statusDotClass(session.status)}`}></span>
             <span class="font-semibold uppercase tracking-wide text-trusty-text">{session.status}</span>
             <span class="text-trusty-text-muted">·</span>
@@ -671,7 +671,7 @@
         {#if canDownload}
           <button
             type="button"
-            class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-raised px-2.5 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
+            class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-raised px-2.5 py-1 font-mono text-[0.6875rem] font-semibold uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
             title="Download this workstream's full transcript as a Markdown file"
             onclick={downloadTranscript}
           >
@@ -735,31 +735,31 @@
           {#if cancelPhase === 'idle'}
             <button
               type="button"
-              class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-raised px-2.5 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
+              class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-raised px-2.5 py-1 font-mono text-[0.6875rem] font-semibold uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
               onclick={() => (cancelPhase = 'confirming')}
             >
               cancel
             </button>
           {:else if cancelPhase === 'confirming'}
-            <span class="font-mono text-[11px] uppercase tracking-wide text-trusty-text-muted"
+            <span class="font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-text-muted"
               >confirm cancel?</span
             >
             <button
               type="button"
-              class="rounded-sm border-1.5 border-trusty-primary bg-trusty-primary/10 px-2.5 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide text-trusty-primary-hover hover:bg-trusty-primary hover:text-trusty-text-inverse"
+              class="rounded-sm border-1.5 border-trusty-primary bg-trusty-primary/10 px-2.5 py-1 font-mono text-[0.6875rem] font-semibold uppercase tracking-wide text-trusty-primary-hover hover:bg-trusty-primary hover:text-trusty-text-inverse"
               onclick={doCancel}
             >
               confirm cancel
             </button>
             <button
               type="button"
-              class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2.5 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
+              class="rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2.5 py-1 font-mono text-[0.6875rem] font-semibold uppercase tracking-wide text-trusty-text-secondary hover:border-trusty-primary hover:text-trusty-primary"
               onclick={() => (cancelPhase = 'idle')}
             >
               never mind
             </button>
           {:else}
-            <span class="font-mono text-[11px] uppercase tracking-wide text-trusty-text-muted"
+            <span class="font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-text-muted"
               >cancelling…</span
             >
           {/if}
@@ -768,7 +768,7 @@
     {/if}
 
     <p
-      class="shrink-0 border-t border-trusty-border px-4 py-1 text-[11px] text-trusty-text-muted"
+      class="shrink-0 border-t border-trusty-border px-4 py-1 text-[0.6875rem] text-trusty-text-muted"
       title={`DOC-39 §4.6 AC-6.3's live search/memory-recall monitor (lane/query/hit_count/latency, docked-rail → inline settle) is not implemented here — GET /sessions/{id}/search-audit now exists (issue #3072) but this card has not been wired to it yet. Tracked at ${SEARCH_RECALL_GAP_ISSUE}`}
     >
       search/recall monitor (AC-6.3): not yet implemented — see issue #3108

--- a/crates/trusty-code-gui/ui/src/components/WorkstreamRail.svelte
+++ b/crates/trusty-code-gui/ui/src/components/WorkstreamRail.svelte
@@ -161,7 +161,7 @@
       <button
         type="button"
         onclick={() => (railView = 'workstream')}
-        class={`flex-1 rounded-sm px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-wide ${
+        class={`flex-1 rounded-sm px-2 py-1 font-mono text-[0.625rem] font-semibold uppercase tracking-wide ${
           railView === 'workstream'
             ? 'bg-trusty-sidebar-active text-trusty-sidebar-text'
             : 'text-trusty-sidebar-muted hover:text-trusty-sidebar-text'
@@ -172,7 +172,7 @@
       <button
         type="button"
         onclick={() => (railView = 'project')}
-        class={`flex-1 rounded-sm px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-wide ${
+        class={`flex-1 rounded-sm px-2 py-1 font-mono text-[0.625rem] font-semibold uppercase tracking-wide ${
           railView === 'project'
             ? 'bg-trusty-sidebar-active text-trusty-sidebar-text'
             : 'text-trusty-sidebar-muted hover:text-trusty-sidebar-text'
@@ -189,40 +189,40 @@
             class="rounded-sm border-l-4 border-status-warn bg-trusty-sidebar-active px-2 py-1.5"
             title={activeSession.id}
           >
-            <p class="font-mono text-[11px] font-semibold uppercase tracking-wide">
+            <p class="font-mono text-[0.6875rem] font-semibold uppercase tracking-wide">
               {activeSession.status}
             </p>
-            <p class="truncate text-[11px] text-trusty-sidebar-muted">
+            <p class="truncate text-[0.6875rem] text-trusty-sidebar-muted">
               {activeSession.project ?? 'projectless'}
             </p>
           </div>
         {:else}
-          <p class="px-1 py-2 text-[11px] text-trusty-sidebar-muted">
+          <p class="px-1 py-2 text-[0.6875rem] text-trusty-sidebar-muted">
             no active workstream yet — start working from the Workstream tab
           </p>
         {/if}
       {:else if projectPhase === 'loading'}
-        <p class="px-1 py-2 text-[11px] text-trusty-sidebar-muted">loading…</p>
+        <p class="px-1 py-2 text-[0.6875rem] text-trusty-sidebar-muted">loading…</p>
       {:else if projectPhase === 'daemon-unreachable'}
-        <p class="px-1 py-2 text-[11px] text-status-error">
+        <p class="px-1 py-2 text-[0.6875rem] text-status-error">
           daemon unreachable{projectError ? ` — ${projectError}` : ''}
         </p>
       {:else}
         {#if projectSource === 'fs_only'}
-          <p class="rounded-sm bg-status-warn/10 px-2 py-1.5 text-[10px] text-status-warn">
+          <p class="rounded-sm bg-status-warn/10 px-2 py-1.5 text-[0.625rem] text-status-warn">
             shared registry unavailable — showing local checkouts only
           </p>
         {/if}
 
         {#if projectEntries.length === 0}
-          <p class="px-1 py-2 text-[11px] text-trusty-sidebar-muted">no known projects found</p>
+          <p class="px-1 py-2 text-[0.6875rem] text-trusty-sidebar-muted">no known projects found</p>
         {:else}
           {#each projectEntries as entry (entry.path)}
             <button
               type="button"
               title={entry.path}
               onclick={() => pickProject(entry)}
-              class={`flex w-full items-center justify-between gap-2 truncate rounded-sm px-2 py-1.5 text-left font-mono text-[11px] ${
+              class={`flex w-full items-center justify-between gap-2 truncate rounded-sm px-2 py-1.5 text-left font-mono text-[0.6875rem] ${
                 selectedProjectState.project?.path === entry.path
                   ? 'bg-trusty-sidebar-active text-trusty-sidebar-text'
                   : 'text-trusty-sidebar-muted hover:text-trusty-sidebar-text'
@@ -230,7 +230,7 @@
             >
               <span class="truncate">{projectCandidateLabel(entry)}</span>
               {#if !entry.registered}
-                <span class="shrink-0 text-[10px] uppercase tracking-wide">local only</span>
+                <span class="shrink-0 text-[0.625rem] uppercase tracking-wide">local only</span>
               {/if}
             </button>
           {/each}
@@ -239,7 +239,7 @@
         <button
           type="button"
           onclick={pickProjectless}
-          class={`w-full rounded-sm border-1.5 border-dashed px-2 py-1.5 text-center font-mono text-[11px] uppercase tracking-wide ${
+          class={`w-full rounded-sm border-1.5 border-dashed px-2 py-1.5 text-center font-mono text-[0.6875rem] uppercase tracking-wide ${
             selectedProjectState.project === null
               ? 'border-trusty-sidebar-active text-trusty-sidebar-text'
               : 'border-trusty-sidebar-border text-trusty-sidebar-muted hover:text-trusty-sidebar-text'

--- a/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.svelte
+++ b/crates/trusty-code-gui/ui/src/components/WorkstreamSwitcher.svelte
@@ -325,7 +325,7 @@
 <div class="wsswitch relative">
   <button
     type="button"
-    class="wsswitch-trigger flex items-center gap-1.5 truncate rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2.5 py-1 font-mono text-[11px] uppercase tracking-wide text-trusty-text-secondary disabled:cursor-not-allowed disabled:opacity-50"
+    class="wsswitch-trigger flex items-center gap-1.5 truncate rounded-sm border-1.5 border-trusty-border-strong bg-trusty-card px-2.5 py-1 font-mono text-[0.6875rem] uppercase tracking-wide text-trusty-text-secondary disabled:cursor-not-allowed disabled:opacity-50"
     disabled={phase !== 'ready' || !list || list.workstreams.length === 0}
     aria-label="switch workstream"
     aria-expanded={open}
@@ -349,11 +349,11 @@
       class="wsswitch-panel absolute left-1/2 top-full z-20 mt-1.5 w-72 -translate-x-1/2 rounded-sm border-1.5 border-trusty-border bg-trusty-raised p-1.5 shadow-lg"
     >
       {#if conflictMessage}
-        <div class="mb-1.5 flex items-center justify-between gap-2 rounded-sm bg-status-error/10 px-2 py-1.5 text-[11px] text-status-error">
+        <div class="mb-1.5 flex items-center justify-between gap-2 rounded-sm bg-status-error/10 px-2 py-1.5 text-[0.6875rem] text-status-error">
           <span>{conflictMessage}</span>
           <button
             type="button"
-            class="shrink-0 rounded-sm border-1.5 border-status-error px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide"
+            class="shrink-0 rounded-sm border-1.5 border-status-error px-1.5 py-0.5 font-mono text-[0.625rem] uppercase tracking-wide"
             onclick={onRefreshConflict}
           >
             refresh
@@ -365,13 +365,13 @@
         <div class="wsswitch-row flex items-center gap-1 rounded-sm px-1.5 py-1.5 hover:bg-trusty-card">
           {#if renameId === w.id}
             <input
-              class="min-w-0 flex-1 rounded-sm border-1.5 border-trusty-primary bg-trusty-card px-1.5 py-0.5 font-mono text-[11px] text-trusty-text"
+              class="min-w-0 flex-1 rounded-sm border-1.5 border-trusty-primary bg-trusty-card px-1.5 py-0.5 font-mono text-[0.6875rem] text-trusty-text"
               bind:value={renameDraft}
               aria-label={`rename ${workstreamLabel(w)}`}
             />
             <button
               type="button"
-              class="shrink-0 font-mono text-[10px] uppercase tracking-wide text-trusty-primary"
+              class="shrink-0 font-mono text-[0.625rem] uppercase tracking-wide text-trusty-primary"
               disabled={renameBusy}
               onclick={saveRename}
             >
@@ -379,7 +379,7 @@
             </button>
             <button
               type="button"
-              class="shrink-0 font-mono text-[10px] uppercase tracking-wide text-trusty-text-muted"
+              class="shrink-0 font-mono text-[0.625rem] uppercase tracking-wide text-trusty-text-muted"
               disabled={renameBusy}
               onclick={cancelRename}
             >
@@ -388,7 +388,7 @@
           {:else}
             <button
               type="button"
-              class="flex min-w-0 flex-1 items-center gap-1.5 truncate text-left font-mono text-[11px] text-trusty-text disabled:cursor-not-allowed disabled:opacity-60"
+              class="flex min-w-0 flex-1 items-center gap-1.5 truncate text-left font-mono text-[0.6875rem] text-trusty-text disabled:cursor-not-allowed disabled:opacity-60"
               disabled={w.state === 'active' || w.state === 'closed' || busyId === w.id}
               title={w.id}
               onclick={() => onActivateClick(w)}
@@ -403,7 +403,7 @@
             {#if closeConfirmId === w.id}
               <button
                 type="button"
-                class="shrink-0 font-mono text-[10px] uppercase tracking-wide text-status-error"
+                class="shrink-0 font-mono text-[0.625rem] uppercase tracking-wide text-status-error"
                 disabled={closeBusy}
                 onclick={() => doClose(w.id)}
               >
@@ -411,7 +411,7 @@
               </button>
               <button
                 type="button"
-                class="shrink-0 font-mono text-[10px] uppercase tracking-wide text-trusty-text-muted"
+                class="shrink-0 font-mono text-[0.625rem] uppercase tracking-wide text-trusty-text-muted"
                 disabled={closeBusy}
                 onclick={() => (closeConfirmId = null)}
               >
@@ -420,7 +420,7 @@
             {:else}
               <button
                 type="button"
-                class="shrink-0 px-1 font-mono text-[11px] text-trusty-text-muted hover:text-trusty-primary disabled:cursor-not-allowed disabled:opacity-50"
+                class="shrink-0 px-1 font-mono text-[0.6875rem] text-trusty-text-muted hover:text-trusty-primary disabled:cursor-not-allowed disabled:opacity-50"
                 aria-label={`rename ${workstreamLabel(w)}`}
                 onclick={() => startRename(w)}
               >
@@ -428,7 +428,7 @@
               </button>
               <button
                 type="button"
-                class="shrink-0 px-1 font-mono text-[11px] text-trusty-text-muted hover:text-status-error disabled:cursor-not-allowed disabled:opacity-50"
+                class="shrink-0 px-1 font-mono text-[0.6875rem] text-trusty-text-muted hover:text-status-error disabled:cursor-not-allowed disabled:opacity-50"
                 aria-label={`close ${workstreamLabel(w)}`}
                 disabled={w.state === 'closed'}
                 onclick={() => (closeConfirmId = w.id)}
@@ -439,7 +439,7 @@
           {/if}
         </div>
       {:else}
-        <p class="px-1.5 py-2 text-[11px] text-trusty-text-muted">no workstreams yet</p>
+        <p class="px-1.5 py-2 text-[0.6875rem] text-trusty-text-muted">no workstreams yet</p>
       {/each}
     </div>
   {/if}


### PR DESCRIPTION
## Summary

The +10% root font bump from #3460 only reached rem-based text. The 60+ hardcoded `text-[9/10/11px]` literals across 11 components didn't scale, which is why the base font "still" looked too small.

This PR bumps root 110% → 120% AND converts all 69 px literals to rem so they track the root multiplier, preserving the 9/10/11px hierarchy (chosen over `text-xs` promotion per Foundry type scale consultation).

## Verification Results
- `vite build`: ✓
- `pnpm test`: 277/277 passed
- Token-drift check: OK
- Code-critic: APPROVE

Closes #3447

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools