### PR TITLE
feat(trusty-code): add AgentMessageDelta stream event (streaming epic slice 0) (#3696)

### DIFF
--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -435,15 +435,27 @@ pub enum Event {
     /// final `done: true` marker. Consumers must handle both without special-
     /// casing which shape a given session uses. `agent_id` mirrors
     /// [`Event::AgentSpawned`]'s rationale — `agent` alone cannot disambiguate
-    /// two concurrently-delegated sub-agents sharing one name.
-    /// What: `turn_id` is opaque and stable for every delta belonging to one
-    /// assistant turn — consumers concatenate `delta` in arrival order keyed
-    /// by `turn_id` to reconstruct the turn's text. `done: false` means more
-    /// deltas for this `turn_id` are coming; `done: true` means this turn's
-    /// bubble is complete and no further deltas for this `turn_id` will
-    /// arrive. `agent_id` is `#[serde(default)]` so a transcript recorded
-    /// before this field existed still deserializes (decoding to `""`).
-    /// Test: `agent_message_delta_round_trips_through_json`.
+    /// two concurrently-delegated sub-agents sharing one name — and this
+    /// codebase runs sub-agents concurrently (`AgentLoop`/`InProcessAgentRunner`
+    /// delegation), so `turn_id` scoping is a correctness requirement, not a
+    /// nicety: see `turn_id`'s own note below.
+    /// What: `turn_id` is opaque and MUST be unique within a session across
+    /// ALL agents, INCLUDING two agents streaming concurrently — a UUID or a
+    /// session-global monotonic counter satisfies this; a per-agent-local
+    /// counter (e.g. each `AgentLoop` restarting its own turn counter from 0)
+    /// does NOT, and would let two concurrently-streaming agents collide on
+    /// the same `turn_id` and interleave into one bubble. Consumers SHOULD
+    /// therefore group/concatenate deltas by the tuple `(agent_id, turn_id)`,
+    /// not `turn_id` alone, as defensive practice against a producer that
+    /// gets this id-scoping requirement wrong — reconstructing one turn's
+    /// text is "concatenate `delta` in arrival order for one `(agent_id,
+    /// turn_id)` key". `done: false` means more deltas for this key are
+    /// coming; `done: true` means this turn's bubble is complete and no
+    /// further deltas for this key will arrive. `agent_id` is
+    /// `#[serde(default)]` so a transcript recorded before this field existed
+    /// still deserializes (decoding to `""`).
+    /// Test: `agent_message_delta_round_trips_through_json`,
+    /// `agent_message_delta_full_text_in_one_delta_round_trips` (Gap A shape).
     AgentMessageDelta {
         session_id: String,
         agent: String,

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -420,6 +420,39 @@ pub enum Event {
         agent: String,
         text: String,
     },
+    /// A streamed chunk of one assistant turn's text (tcode streaming epic
+    /// #3696 Slice 0 — contract only, no producer/consumer wired yet).
+    ///
+    /// Why: [`Event::AgentMessage`] carries a turn's full text as a single
+    /// atomic event, which is fine for a batch-completed turn but cannot
+    /// represent a turn arriving incrementally — the UI has nothing to render
+    /// until the whole turn lands. This variant lets a producer emit the SAME
+    /// turn as a sequence of deltas correlated by `turn_id`, with two
+    /// intentionally-supported shapes: Gap A (a harness that only exposes a
+    /// turn's full text once it is done) emits ONE delta carrying the whole
+    /// turn text with `done: true`; Gap B (a harness with real token-level
+    /// streaming) emits many small deltas with `done: false` followed by one
+    /// final `done: true` marker. Consumers must handle both without special-
+    /// casing which shape a given session uses. `agent_id` mirrors
+    /// [`Event::AgentSpawned`]'s rationale — `agent` alone cannot disambiguate
+    /// two concurrently-delegated sub-agents sharing one name.
+    /// What: `turn_id` is opaque and stable for every delta belonging to one
+    /// assistant turn — consumers concatenate `delta` in arrival order keyed
+    /// by `turn_id` to reconstruct the turn's text. `done: false` means more
+    /// deltas for this `turn_id` are coming; `done: true` means this turn's
+    /// bubble is complete and no further deltas for this `turn_id` will
+    /// arrive. `agent_id` is `#[serde(default)]` so a transcript recorded
+    /// before this field existed still deserializes (decoding to `""`).
+    /// Test: `agent_message_delta_round_trips_through_json`.
+    AgentMessageDelta {
+        session_id: String,
+        agent: String,
+        #[serde(default)]
+        agent_id: String,
+        turn_id: String,
+        delta: String,
+        done: bool,
+    },
     /// (DOC-39 AC-13) see [`Event::AgentSpawned`]'s note — not yet emitted.
     AgentDone {
         session_id: String,
@@ -960,6 +993,7 @@ impl Event {
             | Event::PmDelegating { session_id, .. }
             | Event::AgentSpawned { session_id, .. }
             | Event::AgentMessage { session_id, .. }
+            | Event::AgentMessageDelta { session_id, .. }
             | Event::AgentDone { session_id, .. }
             | Event::AgentFailed { session_id, .. }
             | Event::ToolCalled { session_id, .. }
@@ -1015,6 +1049,7 @@ impl Event {
             Event::PmDelegating { .. } => "pm_delegating",
             Event::AgentSpawned { .. } => "agent_spawned",
             Event::AgentMessage { .. } => "agent_message",
+            Event::AgentMessageDelta { .. } => "agent_message_delta",
             Event::AgentDone { .. } => "agent_done",
             Event::AgentFailed { .. } => "agent_failed",
             Event::ToolCalled { .. } => "tool_called",

--- a/crates/trusty-code/src/events_tests.rs
+++ b/crates/trusty-code/src/events_tests.rs
@@ -617,6 +617,46 @@ fn agent_message_delta_round_trips_through_json() {
     assert!(!done);
 }
 
+/// Gap A shape: a harness that only exposes a turn's full text once it is
+/// done emits exactly ONE delta carrying the ENTIRE turn text with
+/// `done: true`. This must round-trip identically to the Gap B (many small
+/// chunks) shape above — the wire format makes no distinction between "one
+/// long delta" and "one short delta", so pinning a full-paragraph-sized
+/// `delta` here guards against a future producer/consumer accidentally
+/// assuming deltas are always short token chunks (e.g. truncating, or
+/// chunking on write).
+#[test]
+fn agent_message_delta_full_text_in_one_delta_round_trips() {
+    let full_turn_text = "This is the entire assistant turn's text, delivered \
+        as a single delta because the underlying harness (Gap A) only \
+        exposes a turn once it has finished generating — there is no partial \
+        token stream to forward, so the whole turn arrives in one shot."
+        .to_string();
+    let event = Event::AgentMessageDelta {
+        session_id: "s1".into(),
+        agent: "pm".into(),
+        agent_id: "pm-1".into(),
+        turn_id: "turn-99".into(),
+        delta: full_turn_text.clone(),
+        done: true,
+    };
+    let envelope = SessionEventEnvelope::new("s1".into(), 10, Utc::now(), event);
+    let value = serde_json::to_value(&envelope).unwrap();
+
+    assert_eq!(value["event"]["delta"], full_turn_text);
+    assert_eq!(value["event"]["done"], true);
+
+    let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
+    let Event::AgentMessageDelta { delta, done, .. } = back.event else {
+        panic!("expected AgentMessageDelta");
+    };
+    assert_eq!(
+        delta, full_turn_text,
+        "a full-turn-sized delta must survive the wire byte-for-byte, same as a short chunk"
+    );
+    assert!(done, "Gap A's single delta must carry done: true");
+}
+
 /// `agent_id` on `AgentMessageDelta` is `#[serde(default)]` — a producer
 /// that predates per-spawn ids (or a stripped-down test fixture) must still
 /// deserialize, defaulting to an empty string rather than failing.

--- a/crates/trusty-code/src/events_tests.rs
+++ b/crates/trusty-code/src/events_tests.rs
@@ -561,6 +561,85 @@ fn session_event_envelope_round_trips_through_json() {
     assert_eq!(back.seq, 7);
 }
 
+/// `AgentMessageDelta` (tcode streaming epic #3696 Slice 0) must round-trip
+/// through JSON with every field intact, and `kind()`/`session_id()` must
+/// agree with the serde tag and the carried `session_id`.
+///
+/// Why: this variant is the wire contract every downstream streaming slice
+/// builds on — a field that silently failed to round-trip (or a `kind()`/
+/// `session_id()` arm that drifted from the serde tag) would strand every
+/// later slice on a broken foundation. `done: false` is exercised here since
+/// it is the more failure-prone case (`bool` defaults can hide a missed
+/// field); the Gap A single-delta `done: true` shape is documented on the
+/// variant itself and is structurally identical.
+/// Test: this test.
+#[test]
+fn agent_message_delta_round_trips_through_json() {
+    let event = Event::AgentMessageDelta {
+        session_id: "s1".into(),
+        agent: "python-engineer".into(),
+        agent_id: "eng-1".into(),
+        turn_id: "turn-42".into(),
+        delta: "partial toke".into(),
+        done: false,
+    };
+    assert_eq!(event.kind(), "agent_message_delta");
+    assert_eq!(event.session_id(), Some("s1"));
+
+    let envelope = SessionEventEnvelope::new("s1".into(), 9, Utc::now(), event);
+    let value = serde_json::to_value(&envelope).unwrap();
+
+    assert_eq!(value["kind"], "agent_message_delta");
+    assert_eq!(value["event"]["type"], "agent_message_delta");
+    assert_eq!(value["event"]["agent"], "python-engineer");
+    assert_eq!(value["event"]["agent_id"], "eng-1");
+    assert_eq!(value["event"]["turn_id"], "turn-42");
+    assert_eq!(value["event"]["delta"], "partial toke");
+    assert_eq!(value["event"]["done"], false);
+
+    let back: SessionEventEnvelope = serde_json::from_value(value).unwrap();
+    let Event::AgentMessageDelta {
+        session_id,
+        agent,
+        agent_id,
+        turn_id,
+        delta,
+        done,
+    } = back.event
+    else {
+        panic!("expected AgentMessageDelta");
+    };
+    assert_eq!(session_id, "s1");
+    assert_eq!(agent, "python-engineer");
+    assert_eq!(agent_id, "eng-1");
+    assert_eq!(turn_id, "turn-42");
+    assert_eq!(delta, "partial toke");
+    assert!(!done);
+}
+
+/// `agent_id` on `AgentMessageDelta` is `#[serde(default)]` — a producer
+/// that predates per-spawn ids (or a stripped-down test fixture) must still
+/// deserialize, defaulting to an empty string rather than failing.
+#[test]
+fn agent_message_delta_deserializes_without_agent_id() {
+    let old_shape = serde_json::json!({
+        "type": "agent_message_delta",
+        "session_id": "s1",
+        "agent": "pm",
+        "turn_id": "turn-1",
+        "delta": "hello",
+        "done": true
+    });
+    let back: Event = serde_json::from_value(old_shape).unwrap();
+    match back {
+        Event::AgentMessageDelta { agent_id, done, .. } => {
+            assert_eq!(agent_id, "");
+            assert!(done);
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
 #[test]
 fn preview_truncates_at_char_boundary() {
     assert_eq!(preview("hi", 5), "hi");


### PR DESCRIPTION
## Summary

This is Slice 0 of the tcode response-streaming epic — it freezes the `Event::AgentMessageDelta { session_id, agent, agent_id, turn_id, delta, done }` contract that the downstream producer/consumer slices depend on.

## Design

The design accommodates two gap scales:

- **Gap A (per-agent, degenerate)**: one full-text delta with `done:true` per turn
- **Gap B (token-level)**: N chunk deltas then a closing `done:true`

Both ride the same event type — Gap A is the single-delta case of Gap B.

## Contract Rules

Consumers group by `(agent_id, turn_id)` (unique within a session across concurrent agents) and order by envelope seq. No producer/consumer is wired in this slice.

## Verification

- Full `cargo test -p trusty-code`: 1552 pass
- Clippy `-D warnings`: clean
- Formatter: clean
- Code-critic feedback (turn_id uniqueness documentation): resolved

This slice does NOT close #3696 — it is Slice 1 of approximately 6 slices in the epic.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools