### PR TITLE
feat(trusty-agents): implement izzie get_weather + Metro-North tools (#3052)

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
@@ -76,6 +76,10 @@ allow = [
   "granola_*",
   # web search
   "web_search",
+  # weather + Metro-North (epic #3052; skills izzie-weather / izzie-metro-north)
+  "get_weather",
+  "get_train_schedule",
+  "get_train_alerts",
   # gworkspace — Gmail
   "compose_email",
   "download_gmail_attachment",

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -9,6 +9,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Izzie weather + Metro-North tools land as real platform-hosted tools
+  (epic #3052):** the `izzie-weather` and `izzie-metro-north` skills named
+  three tools — `get_weather`, `get_train_schedule`, `get_train_alerts` — that
+  the persona advertised but that were never implemented, so the assistant
+  could only refuse. All three now exist under `tools/izzie/`, are registered
+  into the persona dispatch superset alongside git / ticketing / `system_status`,
+  and are admitted by izzie's `[tools].allow`. `get_weather` returns current
+  conditions + a short daily forecast (Open-Meteo) plus active US severe-weather
+  alerts (NWS), keyless. `get_train_schedule` / `get_train_alerts` read the
+  keyless MTA Metro-North GTFS-Realtime feed via a small dependency-free
+  protobuf decoder, resolve station names to real GTFS stop_ids, and return the
+  next departures (with assigned track and downstream arrival) / active service
+  alerts as structured JSON in Eastern time. Any optional gateway credential is
+  read from `MTA_API_KEY` with graceful degradation; the feed URL is overridable
+  via `IZZIE_MNR_GTFS_RT_URL`.
+
 - **Fireworks AI is reachable as an inference provider (#2410 Step 3, epic
   #2400):** `fireworks/<model>` now resolves to a dedicated
   `FireworksAdapter` (new `Provider::Fireworks` / `AuthSource::Fireworks`)

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -294,6 +294,16 @@ pub async fn run_pm_task_with_persona(
                 ),
             ));
 
+            // #3052: izzie weather/Metro-North tools. Registered
+            // unconditionally into the platform-hosted superset (like git /
+            // ticketing / system_status above); whether a persona can call
+            // `get_weather`/`get_train_schedule`/`get_train_alerts` is still
+            // decided by `filter_persona_tool_names` against its
+            // `[tools].allow` globs — izzie opts in, other personas don't.
+            for tool in crate::tools::izzie::izzie_tools() {
+                registry.register(tool);
+            }
+
             for plugin in crate::tools::agent_plugin::plugins_for_persona(persona_name) {
                 for tool in &plugin.tools {
                     registry.register(std::sync::Arc::clone(tool));

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -162,6 +162,50 @@ fn filter_persona_tool_names_delegation_tools_surface_when_allowed() {
     );
 }
 
+/// #3052: izzie's three new platform-hosted tools (`get_weather`,
+/// `get_train_schedule`, `get_train_alerts`) — registered unconditionally
+/// into the persona registry — are admitted through the filter by izzie's
+/// exact-name `[tools].allow` entries. They carry no OpenRPC scope and no
+/// restricted tier, so they pass the tier + scope gates unconditionally, the
+/// same way `system_status` does. Regression guard that adding the tools to
+/// the registry AND the allowlist actually surfaces them.
+#[test]
+fn filter_persona_tool_names_admits_izzie_weather_and_metro_tools() {
+    let all_names = vec![
+        "get_weather".to_string(),
+        "get_train_schedule".to_string(),
+        "get_train_alerts".to_string(),
+        // a co-registered tool izzie does NOT allow — must stay hidden
+        "run_bash".to_string(),
+    ];
+    // The exact entries added to `izzie/agent.toml`'s `[tools].allow`.
+    let patterns = vec![
+        "get_weather".to_string(),
+        "get_train_schedule".to_string(),
+        "get_train_alerts".to_string(),
+        "web_search".to_string(),
+    ];
+    let allowed_by_tier: std::collections::HashSet<String> = all_names.iter().cloned().collect();
+
+    let kept = filter_persona_tool_names(
+        all_names,
+        &patterns,
+        &allowed_by_tier,
+        &std::collections::HashMap::new(),
+        &[],
+    );
+
+    assert_eq!(
+        kept,
+        vec![
+            "get_weather".to_string(),
+            "get_train_schedule".to_string(),
+            "get_train_alerts".to_string(),
+        ],
+        "izzie's three tools surface; run_bash (unallowed) does not"
+    );
+}
+
 /// RBAC tier filtering is an independent second gate — even a
 /// `[tools].allow` glob of `"*"` must not surface a name the tier filter
 /// excludes. Mirrors how `allowed_by_tier` (derived from

--- a/crates/trusty-agents/src/tools/izzie/gtfs_rt.rs
+++ b/crates/trusty-agents/src/tools/izzie/gtfs_rt.rs
@@ -1,0 +1,351 @@
+//! Minimal, dependency-free GTFS-Realtime protobuf decoder (epic #3052).
+//!
+//! Why: The MTA Metro-North real-time feed is published as GTFS-Realtime
+//! protobuf. The only alternatives for reading it are (a) pulling in a full
+//! `prost`/`protobuf-codegen` toolchain — which drags a `protoc` build
+//! dependency into CI and a large generated binding file that would blow the
+//! 500-SLOC file cap — or (b) decoding, by hand, the *tiny stable subset* of
+//! the wire format we actually consume (trip updates + service alerts). The
+//! GTFS-RT field numbers are frozen by the published spec and never change,
+//! so a hand-written reader for that subset is both smaller and more portable
+//! than a code-generation pipeline, and it is fully unit-testable against
+//! byte fixtures we encode ourselves (no live network, no `protoc`).
+//! What: A cursor-based reader over the four protobuf wire types plus typed
+//! extraction of exactly the fields the `get_train_schedule` /
+//! `get_train_alerts` tools need — `TripUpdate` (trip descriptor + per-stop
+//! arrival/departure epochs + assigned track) and `Alert` (informed routes +
+//! header/description text). Everything else in the feed is skipped.
+//! Test: `decode_feed_reads_trip_updates`, `decode_feed_reads_alerts`,
+//! `read_varint_multibyte`, `decode_feed_skips_unknown_fields`.
+
+use anyhow::{Result, bail};
+
+// ── GTFS-Realtime field numbers (frozen by the published .proto spec) ──────
+// FeedMessage
+const F_FEED_ENTITY: u32 = 2;
+// FeedEntity
+const F_ENTITY_TRIP_UPDATE: u32 = 3;
+const F_ENTITY_ALERT: u32 = 5;
+// TripUpdate
+const F_TU_TRIP: u32 = 1;
+const F_TU_STOP_TIME_UPDATE: u32 = 2;
+// TripDescriptor
+const F_TD_TRIP_ID: u32 = 1;
+const F_TD_START_TIME: u32 = 2;
+const F_TD_START_DATE: u32 = 3;
+const F_TD_ROUTE_ID: u32 = 5;
+// StopTimeUpdate
+const F_STU_STOP_SEQUENCE: u32 = 1;
+const F_STU_ARRIVAL: u32 = 2;
+const F_STU_DEPARTURE: u32 = 3;
+const F_STU_STOP_ID: u32 = 4;
+const F_STU_STOP_TIME_PROPERTIES: u32 = 6;
+// StopTimeEvent
+const F_STE_TIME: u32 = 2;
+// StopTimeProperties
+const F_STP_ASSIGNED_STOP_ID: u32 = 1;
+// Alert
+const F_ALERT_INFORMED_ENTITY: u32 = 5;
+const F_ALERT_HEADER_TEXT: u32 = 10;
+const F_ALERT_DESCRIPTION_TEXT: u32 = 11;
+// EntitySelector
+const F_ES_ROUTE_ID: u32 = 3;
+// TranslatedString
+const F_TS_TRANSLATION: u32 = 1;
+// Translation
+const F_TRANSLATION_TEXT: u32 = 1;
+
+/// One protobuf wire value borrowed from the underlying buffer.
+enum Wire<'a> {
+    Varint(u64),
+    Bytes(&'a [u8]),
+    /// 64-bit and 32-bit fixed fields — unused by our subset. The reader still
+    /// consumes their bytes so following fields stay correctly framed; the
+    /// value itself is discarded.
+    Fixed,
+}
+
+/// Cursor over a single protobuf message body.
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    /// Read a base-128 varint. Returns `None` at clean end-of-buffer.
+    fn read_varint(&mut self) -> Result<u64> {
+        let mut result: u64 = 0;
+        let mut shift = 0u32;
+        loop {
+            if self.pos >= self.buf.len() {
+                bail!("gtfs-rt: truncated varint");
+            }
+            let byte = self.buf[self.pos];
+            self.pos += 1;
+            if shift >= 64 {
+                bail!("gtfs-rt: varint overflow");
+            }
+            result |= u64::from(byte & 0x7f) << shift;
+            if byte & 0x80 == 0 {
+                return Ok(result);
+            }
+            shift += 7;
+        }
+    }
+
+    /// Yield the next `(field_number, wire_value)` or `None` at end-of-buffer.
+    fn next_field(&mut self) -> Result<Option<(u32, Wire<'a>)>> {
+        if self.pos >= self.buf.len() {
+            return Ok(None);
+        }
+        let key = self.read_varint()?;
+        let field = (key >> 3) as u32;
+        let wire_type = (key & 0x7) as u32;
+        let value = match wire_type {
+            0 => Wire::Varint(self.read_varint()?),
+            2 => {
+                let len = self.read_varint()? as usize;
+                let end = self
+                    .pos
+                    .checked_add(len)
+                    .filter(|e| *e <= self.buf.len())
+                    .ok_or_else(|| anyhow::anyhow!("gtfs-rt: length-delimited overrun"))?;
+                let slice = &self.buf[self.pos..end];
+                self.pos = end;
+                Wire::Bytes(slice)
+            }
+            1 => {
+                let end = self.pos + 8;
+                if end > self.buf.len() {
+                    bail!("gtfs-rt: truncated 64-bit field");
+                }
+                self.pos = end;
+                Wire::Fixed
+            }
+            5 => {
+                let end = self.pos + 4;
+                if end > self.buf.len() {
+                    bail!("gtfs-rt: truncated 32-bit field");
+                }
+                self.pos = end;
+                Wire::Fixed
+            }
+            other => bail!("gtfs-rt: unsupported wire type {other}"),
+        };
+        Ok(Some((field, value)))
+    }
+}
+
+/// A single upcoming stop within a trip: when the train reaches `stop_id` and
+/// (when the MTA has assigned it) the track it will be on.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct StopTimeUpdate {
+    pub stop_id: Option<String>,
+    pub stop_sequence: Option<u32>,
+    /// Arrival time as a Unix epoch (seconds), when present.
+    pub arrival: Option<i64>,
+    /// Departure time as a Unix epoch (seconds), when present.
+    pub departure: Option<i64>,
+    /// Assigned track, decoded from `StopTimeProperties.assigned_stop_id`.
+    pub assigned_track: Option<String>,
+}
+
+/// A real-time update for one scheduled trip.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TripUpdate {
+    pub trip_id: Option<String>,
+    pub route_id: Option<String>,
+    pub start_date: Option<String>,
+    pub start_time: Option<String>,
+    pub stops: Vec<StopTimeUpdate>,
+}
+
+/// A service alert: which routes it affects plus its human-readable text.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Alert {
+    pub route_ids: Vec<String>,
+    pub header: Option<String>,
+    pub description: Option<String>,
+}
+
+/// The decoded subset of a GTFS-Realtime feed.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Feed {
+    pub trip_updates: Vec<TripUpdate>,
+    pub alerts: Vec<Alert>,
+}
+
+/// Decode a GTFS-Realtime `FeedMessage` into the trip-update + alert subset.
+///
+/// Why: The tools only ever read departures and alerts; decoding the whole
+/// schema would be wasted work and wasted code.
+/// What: Walks each `FeedEntity`, dispatching `trip_update` (field 3) and
+/// `alert` (field 5) into their typed decoders and skipping everything else.
+/// Test: `decode_feed_reads_trip_updates`, `decode_feed_reads_alerts`.
+pub fn decode_feed(bytes: &[u8]) -> Result<Feed> {
+    let mut feed = Feed::default();
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        if field == F_FEED_ENTITY
+            && let Wire::Bytes(entity) = value
+        {
+            decode_entity(entity, &mut feed)?;
+        }
+    }
+    Ok(feed)
+}
+
+fn decode_entity(bytes: &[u8], feed: &mut Feed) -> Result<()> {
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        match (field, value) {
+            (F_ENTITY_TRIP_UPDATE, Wire::Bytes(b)) => {
+                feed.trip_updates.push(decode_trip_update(b)?)
+            }
+            (F_ENTITY_ALERT, Wire::Bytes(b)) => feed.alerts.push(decode_alert(b)?),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn decode_trip_update(bytes: &[u8]) -> Result<TripUpdate> {
+    let mut tu = TripUpdate::default();
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        match (field, value) {
+            (F_TU_TRIP, Wire::Bytes(b)) => decode_trip_descriptor(b, &mut tu)?,
+            (F_TU_STOP_TIME_UPDATE, Wire::Bytes(b)) => tu.stops.push(decode_stop_time_update(b)?),
+            _ => {}
+        }
+    }
+    Ok(tu)
+}
+
+fn decode_trip_descriptor(bytes: &[u8], tu: &mut TripUpdate) -> Result<()> {
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        if let Wire::Bytes(b) = value {
+            match field {
+                F_TD_TRIP_ID => tu.trip_id = Some(utf8(b)),
+                F_TD_START_TIME => tu.start_time = Some(utf8(b)),
+                F_TD_START_DATE => tu.start_date = Some(utf8(b)),
+                F_TD_ROUTE_ID => tu.route_id = Some(utf8(b)),
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn decode_stop_time_update(bytes: &[u8]) -> Result<StopTimeUpdate> {
+    let mut stu = StopTimeUpdate::default();
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        match (field, value) {
+            (F_STU_STOP_SEQUENCE, Wire::Varint(v)) => stu.stop_sequence = Some(v as u32),
+            (F_STU_STOP_ID, Wire::Bytes(b)) => stu.stop_id = Some(utf8(b)),
+            (F_STU_ARRIVAL, Wire::Bytes(b)) => stu.arrival = decode_stop_time_event(b)?,
+            (F_STU_DEPARTURE, Wire::Bytes(b)) => stu.departure = decode_stop_time_event(b)?,
+            (F_STU_STOP_TIME_PROPERTIES, Wire::Bytes(b)) => {
+                stu.assigned_track = decode_stop_time_properties(b)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(stu)
+}
+
+/// Extract `StopTimeEvent.time` (field 2, int64 varint) — the epoch seconds.
+fn decode_stop_time_event(bytes: &[u8]) -> Result<Option<i64>> {
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        if field == F_STE_TIME
+            && let Wire::Varint(v) = value
+        {
+            return Ok(Some(v as i64));
+        }
+    }
+    Ok(None)
+}
+
+/// Extract `StopTimeProperties.assigned_stop_id` (field 1) — the track label
+/// the MTA assigns ~20-30 min before departure at terminals.
+fn decode_stop_time_properties(bytes: &[u8]) -> Result<Option<String>> {
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        if field == F_STP_ASSIGNED_STOP_ID
+            && let Wire::Bytes(b) = value
+        {
+            return Ok(Some(utf8(b)));
+        }
+    }
+    Ok(None)
+}
+
+fn decode_alert(bytes: &[u8]) -> Result<Alert> {
+    let mut alert = Alert::default();
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        match (field, value) {
+            (F_ALERT_INFORMED_ENTITY, Wire::Bytes(b)) => {
+                if let Some(route) = decode_entity_selector(b)? {
+                    alert.route_ids.push(route);
+                }
+            }
+            (F_ALERT_HEADER_TEXT, Wire::Bytes(b)) => alert.header = decode_translated_string(b)?,
+            (F_ALERT_DESCRIPTION_TEXT, Wire::Bytes(b)) => {
+                alert.description = decode_translated_string(b)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(alert)
+}
+
+/// Extract `EntitySelector.route_id` (field 3) if present.
+fn decode_entity_selector(bytes: &[u8]) -> Result<Option<String>> {
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        if field == F_ES_ROUTE_ID
+            && let Wire::Bytes(b) = value
+        {
+            return Ok(Some(utf8(b)));
+        }
+    }
+    Ok(None)
+}
+
+/// Extract the first `Translation.text` from a `TranslatedString`.
+fn decode_translated_string(bytes: &[u8]) -> Result<Option<String>> {
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field()? {
+        if field == F_TS_TRANSLATION
+            && let Wire::Bytes(translation) = value
+        {
+            let mut inner = Reader::new(translation);
+            while let Some((tf, tv)) = inner.next_field()? {
+                if tf == F_TRANSLATION_TEXT
+                    && let Wire::Bytes(b) = tv
+                {
+                    return Ok(Some(utf8(b)));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// Lossy UTF-8 decode — feed text fields are UTF-8 but we never want a
+/// malformed byte to abort a whole feed parse.
+fn utf8(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+#[cfg(test)]
+#[path = "gtfs_rt_tests.rs"]
+mod tests;

--- a/crates/trusty-agents/src/tools/izzie/gtfs_rt_tests.rs
+++ b/crates/trusty-agents/src/tools/izzie/gtfs_rt_tests.rs
@@ -1,0 +1,189 @@
+//! Fixture-driven tests for the minimal GTFS-Realtime decoder.
+//!
+//! Why: The decoder is hand-written against the frozen wire format, so it
+//! needs direct proof it frames fields correctly. These tests encode known
+//! messages with a tiny local protobuf writer and assert the decoder returns
+//! exactly what was written — no live network, no `protoc`.
+//! What: A `Pb` builder emits the four wire types we consume, then each test
+//! composes a realistic `FeedMessage` and checks the decoded `Feed`.
+//! Test: This file IS the test module for `gtfs_rt`.
+
+use super::*;
+
+// ── Tiny protobuf writer (test-only fixture builder) ───────────────────────
+
+/// Minimal protobuf encoder producing exactly the wire shapes the decoder
+/// consumes: varint (type 0) and length-delimited (type 2).
+#[derive(Default)]
+struct Pb {
+    buf: Vec<u8>,
+}
+
+impl Pb {
+    fn varint(mut self, field: u32, value: u64) -> Self {
+        self.write_key(field, 0);
+        self.write_varint(value);
+        self
+    }
+
+    fn bytes(mut self, field: u32, value: &[u8]) -> Self {
+        self.write_key(field, 2);
+        self.write_varint(value.len() as u64);
+        self.buf.extend_from_slice(value);
+        self
+    }
+
+    fn string(self, field: u32, value: &str) -> Self {
+        self.bytes(field, value.as_bytes())
+    }
+
+    fn message(self, field: u32, inner: Pb) -> Self {
+        self.bytes(field, &inner.buf)
+    }
+
+    /// Emit a 32-bit fixed field (type 5) — used only to prove the decoder
+    /// skips wire types it does not consume without mis-framing.
+    fn fixed32(mut self, field: u32, value: u32) -> Self {
+        self.write_key(field, 5);
+        self.buf.extend_from_slice(&value.to_le_bytes());
+        self
+    }
+
+    fn write_key(&mut self, field: u32, wire_type: u32) {
+        self.write_varint(((field as u64) << 3) | wire_type as u64);
+    }
+
+    fn write_varint(&mut self, mut value: u64) {
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            self.buf.push(byte);
+            if value == 0 {
+                break;
+            }
+        }
+    }
+
+    fn done(self) -> Vec<u8> {
+        self.buf
+    }
+}
+
+/// StopTimeEvent { time }.
+fn stop_time_event(epoch: i64) -> Pb {
+    Pb::default().varint(2, epoch as u64)
+}
+
+#[test]
+fn read_varint_multibyte() {
+    // 300 = 0xAC 0x02 in base-128 varint; wrap it as field 1 varint.
+    let bytes = Pb::default().varint(1, 300).done();
+    let mut reader = Reader::new(&bytes);
+    let (field, value) = reader.next_field().unwrap().unwrap();
+    assert_eq!(field, 1);
+    match value {
+        Wire::Varint(v) => assert_eq!(v, 300),
+        _ => panic!("expected varint"),
+    }
+    assert!(reader.next_field().unwrap().is_none());
+}
+
+#[test]
+fn decode_feed_reads_trip_updates() {
+    // TripDescriptor { trip_id, route_id, start_date, start_time }
+    let trip = Pb::default()
+        .string(F_TD_TRIP_ID, "8501")
+        .string(F_TD_START_TIME, "18:42:00")
+        .string(F_TD_START_DATE, "20260722")
+        .string(F_TD_ROUTE_ID, "New Haven");
+    // StopTimeUpdate at Grand Central (stop_id "1") with a departure + track.
+    let stop_props = Pb::default().string(F_STP_ASSIGNED_STOP_ID, "24");
+    let stop = Pb::default()
+        .varint(F_STU_STOP_SEQUENCE, 1)
+        .string(F_STU_STOP_ID, "1")
+        .message(F_STU_DEPARTURE, stop_time_event(1_753_224_120))
+        .message(F_STU_STOP_TIME_PROPERTIES, stop_props);
+    let trip_update = Pb::default()
+        .message(F_TU_TRIP, trip)
+        .message(F_TU_STOP_TIME_UPDATE, stop);
+    let entity = Pb::default().message(F_ENTITY_TRIP_UPDATE, trip_update);
+    let feed_bytes = Pb::default().message(F_FEED_ENTITY, entity).done();
+
+    let feed = decode_feed(&feed_bytes).unwrap();
+    assert_eq!(feed.trip_updates.len(), 1);
+    let tu = &feed.trip_updates[0];
+    assert_eq!(tu.trip_id.as_deref(), Some("8501"));
+    assert_eq!(tu.route_id.as_deref(), Some("New Haven"));
+    assert_eq!(tu.start_date.as_deref(), Some("20260722"));
+    assert_eq!(tu.start_time.as_deref(), Some("18:42:00"));
+    assert_eq!(tu.stops.len(), 1);
+    let s = &tu.stops[0];
+    assert_eq!(s.stop_id.as_deref(), Some("1"));
+    assert_eq!(s.stop_sequence, Some(1));
+    assert_eq!(s.departure, Some(1_753_224_120));
+    assert_eq!(s.arrival, None);
+    assert_eq!(s.assigned_track.as_deref(), Some("24"));
+}
+
+#[test]
+fn decode_feed_reads_alerts() {
+    let informed = Pb::default().string(F_ES_ROUTE_ID, "Hudson");
+    let header = Pb::default().message(
+        F_TS_TRANSLATION,
+        Pb::default().string(F_TRANSLATION_TEXT, "Hudson Line Delays"),
+    );
+    let desc = Pb::default().message(
+        F_TS_TRANSLATION,
+        Pb::default().string(
+            F_TRANSLATION_TEXT,
+            "Trains delayed up to 20 minutes due to signal problems.",
+        ),
+    );
+    let alert = Pb::default()
+        .message(F_ALERT_INFORMED_ENTITY, informed)
+        .message(F_ALERT_HEADER_TEXT, header)
+        .message(F_ALERT_DESCRIPTION_TEXT, desc);
+    let entity = Pb::default().message(F_ENTITY_ALERT, alert);
+    let feed_bytes = Pb::default().message(F_FEED_ENTITY, entity).done();
+
+    let feed = decode_feed(&feed_bytes).unwrap();
+    assert_eq!(feed.alerts.len(), 1);
+    let a = &feed.alerts[0];
+    assert_eq!(a.route_ids, vec!["Hudson".to_string()]);
+    assert_eq!(a.header.as_deref(), Some("Hudson Line Delays"));
+    assert_eq!(
+        a.description.as_deref(),
+        Some("Trains delayed up to 20 minutes due to signal problems.")
+    );
+}
+
+#[test]
+fn decode_feed_skips_unknown_fields() {
+    // An entity carrying an unrelated fixed32 field plus a vehicle-position
+    // (field 4) message must be skipped without corrupting the trip update.
+    let trip = Pb::default().string(F_TD_TRIP_ID, "9001");
+    let trip_update = Pb::default().message(F_TU_TRIP, trip);
+    let entity = Pb::default()
+        .fixed32(99, 0xDEAD_BEEF)
+        .bytes(4, &Pb::default().string(1, "ignored-vehicle").done())
+        .message(F_ENTITY_TRIP_UPDATE, trip_update);
+    let feed_bytes = Pb::default()
+        .fixed32(1, 12345) // FeedHeader-ish noise at feed level
+        .message(F_FEED_ENTITY, entity)
+        .done();
+
+    let feed = decode_feed(&feed_bytes).unwrap();
+    assert_eq!(feed.trip_updates.len(), 1);
+    assert_eq!(feed.trip_updates[0].trip_id.as_deref(), Some("9001"));
+    assert!(feed.alerts.is_empty());
+}
+
+#[test]
+fn decode_feed_rejects_truncated_varint() {
+    // A key that promises a varint but ends the buffer must error, not panic.
+    let bytes = vec![0x08, 0x80]; // field 1, varint, continuation bit set, no more
+    assert!(decode_feed(&bytes).is_err());
+}

--- a/crates/trusty-agents/src/tools/izzie/metro_north.rs
+++ b/crates/trusty-agents/src/tools/izzie/metro_north.rs
@@ -1,0 +1,424 @@
+//! `get_train_schedule` + `get_train_alerts` — MTA Metro-North real-time
+//! departures and service alerts (epic #3052).
+//!
+//! Why: Izzie's `izzie-metro-north` skill promises live train times and
+//! service alerts with no API key, but the tools it names never existed. This
+//! implements both against the MTA Metro-North GTFS-Realtime feed. The feed is
+//! keyless as of 2023; if a deployment sits behind a gateway that still wants a
+//! key, `MTA_API_KEY` is sent as `x-api-key` when set and simply omitted
+//! otherwise (graceful degradation, never hardcoded). The feed URL itself is
+//! overridable via `IZZIE_MNR_GTFS_RT_URL`.
+//! What: `GetTrainScheduleTool` resolves origin/destination station names to
+//! GTFS stop_ids (see `stations`), decodes the protobuf feed (see `gtfs_rt`),
+//! and returns the next upcoming departures — with assigned track and, when a
+//! destination is given, the downstream arrival. `GetTrainAlertsTool` returns
+//! active alerts, optionally filtered to one line. Both emit structured JSON.
+//! Test: The HTTP-free feed->output mappers are unit-tested against decoded
+//! `Feed` fixtures; the live fetch path is an `#[ignore]` integration test.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::TimeZone;
+use chrono_tz::America::New_York;
+use serde_json::{Value, json};
+
+use super::gtfs_rt::{Feed, decode_feed};
+use super::stations::{Station, match_station, route_matches_line, route_name};
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Default keyless MNR GTFS-Realtime feed (overridable via env). The feed
+/// carries trip updates AND service alerts, so both tools read the same URL.
+const DEFAULT_FEED_URL: &str = "https://api-endpoint.mta.info/Dataservice/mnrtrpke.pb";
+const FEED_URL_ENV: &str = "IZZIE_MNR_GTFS_RT_URL";
+const API_KEY_ENV: &str = "MTA_API_KEY";
+
+/// Resolve the feed URL from env, falling back to the keyless default.
+fn feed_url() -> String {
+    std::env::var(FEED_URL_ENV)
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_FEED_URL.to_string())
+}
+
+/// Format a Unix epoch (seconds) as Eastern-time `HH:MM`.
+///
+/// Why: Metro-North schedules are always quoted in Eastern time; the feed
+/// carries UTC epochs.
+/// What: Converts via `America/New_York` (handles DST). Returns `None` for a
+/// non-representable timestamp rather than panicking.
+/// Test: `format_eastern_hhmm_known_epoch`.
+pub fn format_eastern_hhmm(epoch: i64) -> Option<String> {
+    New_York
+        .timestamp_opt(epoch, 0)
+        .single()
+        .map(|dt| dt.format("%H:%M").to_string())
+}
+
+/// Parsed `get_train_schedule` arguments after station resolution.
+struct ScheduleQuery {
+    from: &'static Station,
+    to: Option<&'static Station>,
+    line: Option<String>,
+    limit: usize,
+}
+
+/// The soonest relevant departure from a station within one trip.
+struct Departure {
+    trip_id: Option<String>,
+    route_id: Option<String>,
+    depart_epoch: i64,
+    track: Option<String>,
+    arrive_epoch: Option<i64>,
+}
+
+/// Build the schedule result from a decoded feed (pure — no I/O).
+///
+/// Why: Separating feed->JSON shaping from the HTTP fetch makes the departure
+/// selection, downstream-arrival matching, line filtering, sorting, and
+/// limiting all unit-testable against a hand-built `Feed`.
+/// What: For each trip, finds the origin stop with a future departure
+/// (`>= now_epoch`); when a destination is set, keeps only trips that also
+/// serve it later in the sequence and records that arrival; applies the
+/// optional line filter; sorts by departure time; truncates to `limit`.
+/// Test: `build_schedule_orders_filters_and_limits`,
+/// `build_schedule_requires_downstream_destination`.
+pub fn build_schedule(
+    feed: &Feed,
+    from: &Station,
+    to: Option<&Station>,
+    line: Option<&str>,
+    limit: usize,
+    now_epoch: i64,
+) -> Value {
+    let mut departures: Vec<Departure> = Vec::new();
+
+    for tu in &feed.trip_updates {
+        if let Some(l) = line
+            && let Some(route) = tu.route_id.as_deref()
+            && !route_matches_line(route, l)
+        {
+            continue;
+        }
+
+        // Find the origin stop with a usable future time + its sequence.
+        let origin = tu.stops.iter().find(|s| {
+            s.stop_id.as_deref() == Some(from.stop_id)
+                && s.departure
+                    .or(s.arrival)
+                    .map(|t| t >= now_epoch)
+                    .unwrap_or(false)
+        });
+        let Some(origin) = origin else { continue };
+        let Some(depart_epoch) = origin.departure.or(origin.arrival) else {
+            continue;
+        };
+
+        // Optional downstream destination arrival (must come after origin).
+        let arrive_epoch = match to {
+            Some(dest) => {
+                let dest_stop = tu.stops.iter().find(|s| {
+                    s.stop_id.as_deref() == Some(dest.stop_id)
+                        && seq_after(origin.stop_sequence, s.stop_sequence)
+                });
+                match dest_stop {
+                    Some(d) => d.arrival.or(d.departure),
+                    // Destination requested but this trip does not serve it.
+                    None => continue,
+                }
+            }
+            None => None,
+        };
+
+        departures.push(Departure {
+            trip_id: tu.trip_id.clone(),
+            route_id: tu.route_id.clone(),
+            depart_epoch,
+            track: origin.assigned_track.clone(),
+            arrive_epoch,
+        });
+    }
+
+    departures.sort_by_key(|d| d.depart_epoch);
+    departures.truncate(limit.max(1));
+
+    let items: Vec<Value> = departures
+        .iter()
+        .map(|d| {
+            json!({
+                "trip_id": d.trip_id,
+                "line": d.route_id.as_deref().map(route_name),
+                "depart": format_eastern_hhmm(d.depart_epoch),
+                "depart_epoch": d.depart_epoch,
+                "track": d.track,
+                "arrive": d.arrive_epoch.and_then(format_eastern_hhmm),
+                "arrive_epoch": d.arrive_epoch,
+            })
+        })
+        .collect();
+
+    json!({
+        "from": from.name,
+        "to": to.map(|s| s.name),
+        "line": line,
+        "count": items.len(),
+        "departures": items,
+        "timezone": "America/New_York",
+        "source": "MTA Metro-North GTFS-Realtime",
+    })
+}
+
+/// True when `later` comes strictly after `earlier` in a trip's stop sequence.
+/// When either sequence is absent, assume ordering holds (feed still lists
+/// stops in travel order).
+fn seq_after(earlier: Option<u32>, later: Option<u32>) -> bool {
+    match (earlier, later) {
+        (Some(e), Some(l)) => l > e,
+        _ => true,
+    }
+}
+
+/// Build the alerts result from a decoded feed (pure — no I/O).
+///
+/// Why: Alert filtering + shaping is testable without the network.
+/// What: Maps each alert to `{ lines, header, description }`, applying the
+/// optional line filter (an alert passes when ANY informed route matches, or
+/// when it names no routes — system-wide alerts always surface).
+/// Test: `build_alerts_filters_by_line`.
+pub fn build_alerts(feed: &Feed, line: Option<&str>) -> Value {
+    let items: Vec<Value> = feed
+        .alerts
+        .iter()
+        .filter(|a| match line {
+            Some(l) => {
+                a.route_ids.is_empty() || a.route_ids.iter().any(|r| route_matches_line(r, l))
+            }
+            None => true,
+        })
+        .map(|a| {
+            let lines: Vec<String> = a.route_ids.iter().map(|r| route_name(r)).collect();
+            json!({
+                "lines": lines,
+                "header": a.header,
+                "description": a.description,
+            })
+        })
+        .collect();
+
+    json!({
+        "line": line,
+        "count": items.len(),
+        "alerts": items,
+        "source": "MTA Metro-North GTFS-Realtime",
+    })
+}
+
+/// Fetch the raw GTFS-RT feed bytes, attaching `MTA_API_KEY` only if present.
+async fn fetch_feed_bytes(client: &reqwest::Client) -> anyhow::Result<Vec<u8>> {
+    let mut req = client.get(feed_url());
+    if let Ok(key) = std::env::var(API_KEY_ENV)
+        && !key.trim().is_empty()
+    {
+        req = req.header("x-api-key", key);
+    }
+    let resp = req.send().await?.error_for_status()?;
+    Ok(resp.bytes().await?.to_vec())
+}
+
+fn build_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(12))
+        .build()
+        .unwrap_or_default()
+}
+
+/// The `get_train_schedule` tool.
+pub struct GetTrainScheduleTool {
+    client: reqwest::Client,
+}
+
+impl Default for GetTrainScheduleTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GetTrainScheduleTool {
+    pub fn new() -> Self {
+        Self {
+            client: build_http_client(),
+        }
+    }
+
+    /// Resolve raw args into a validated query (station names -> stations).
+    fn parse_query(args: &Value) -> Result<ScheduleQuery, String> {
+        let from_raw = args
+            .get("from")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| "missing required argument `from` (origin station name)".to_string())?;
+        let from = match_station(from_raw)
+            .ok_or_else(|| format!("unknown origin station '{from_raw}'"))?;
+
+        let to = match args.get("to").and_then(Value::as_str).map(str::trim) {
+            Some(raw) if !raw.is_empty() => Some(
+                match_station(raw).ok_or_else(|| format!("unknown destination station '{raw}'"))?,
+            ),
+            _ => None,
+        };
+
+        let line = args
+            .get("line")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+
+        let limit = args
+            .get("limit")
+            .and_then(Value::as_u64)
+            .unwrap_or(3)
+            .clamp(1, 10) as usize;
+
+        Ok(ScheduleQuery {
+            from,
+            to,
+            line,
+            limit,
+        })
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for GetTrainScheduleTool {
+    fn name(&self) -> &str {
+        "get_train_schedule"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "get_train_schedule",
+                "description": "Get upcoming real-time MTA Metro-North departures from a station, optionally toward a destination and/or on a specific line. Returns the next departures in Eastern time with assigned track (when posted) and downstream arrival time when a destination is given. Keyless GTFS-Realtime data.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "from": { "type": "string", "description": "Origin station name, e.g. 'Grand Central', 'Stamford', 'White Plains'. Partial names accepted." },
+                        "to": { "type": "string", "description": "Optional destination station name to filter to trains that serve it and report the arrival time." },
+                        "line": { "type": "string", "description": "Optional line filter: Hudson, Harlem, New Haven, New Canaan, Danbury, or Waterbury." },
+                        "limit": { "type": "integer", "description": "How many upcoming departures to return (1-10, default 3)." }
+                    },
+                    "required": ["from"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let query = match Self::parse_query(&args) {
+            Ok(q) => q,
+            Err(e) => return ToolResult::err(e),
+        };
+        let bytes = match fetch_feed_bytes(&self.client).await {
+            Ok(b) => b,
+            Err(e) => {
+                return ToolResult::err(format!(
+                    "Metro-North feed request failed (service unreachable): {e}"
+                ));
+            }
+        };
+        let feed = match decode_feed(&bytes) {
+            Ok(f) => f,
+            Err(e) => return ToolResult::err(format!("failed to decode Metro-North feed: {e}")),
+        };
+        let now = chrono::Utc::now().timestamp();
+        let out = build_schedule(
+            &feed,
+            query.from,
+            query.to,
+            query.line.as_deref(),
+            query.limit,
+            now,
+        );
+        match serde_json::to_string(&out) {
+            Ok(s) => ToolResult::ok(s),
+            Err(e) => ToolResult::err(format!("failed to serialize schedule: {e}")),
+        }
+    }
+}
+
+/// The `get_train_alerts` tool.
+pub struct GetTrainAlertsTool {
+    client: reqwest::Client,
+}
+
+impl Default for GetTrainAlertsTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GetTrainAlertsTool {
+    pub fn new() -> Self {
+        Self {
+            client: build_http_client(),
+        }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for GetTrainAlertsTool {
+    fn name(&self) -> &str {
+        "get_train_alerts"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "get_train_alerts",
+                "description": "Get active MTA Metro-North service alerts (delays, suspensions, advisories), optionally filtered to one line. System-wide alerts always surface. Keyless GTFS-Realtime data.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "line": { "type": "string", "description": "Optional line filter: Hudson, Harlem, New Haven, New Canaan, Danbury, or Waterbury." }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let line = args
+            .get("line")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let bytes = match fetch_feed_bytes(&self.client).await {
+            Ok(b) => b,
+            Err(e) => {
+                return ToolResult::err(format!(
+                    "Metro-North feed request failed (service unreachable): {e}"
+                ));
+            }
+        };
+        let feed = match decode_feed(&bytes) {
+            Ok(f) => f,
+            Err(e) => return ToolResult::err(format!("failed to decode Metro-North feed: {e}")),
+        };
+        let out = build_alerts(&feed, line.as_deref());
+        match serde_json::to_string(&out) {
+            Ok(s) => ToolResult::ok(s),
+            Err(e) => ToolResult::err(format!("failed to serialize alerts: {e}")),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "metro_north_tests.rs"]
+mod tests;

--- a/crates/trusty-agents/src/tools/izzie/metro_north_tests.rs
+++ b/crates/trusty-agents/src/tools/izzie/metro_north_tests.rs
@@ -1,0 +1,212 @@
+//! Tests for the Metro-North feed->output mappers.
+//!
+//! Why: `execute` fetches the live protobuf feed; the logic worth pinning is
+//! departure selection, downstream-arrival matching, line filtering, sorting,
+//! limiting, alert filtering, and Eastern-time formatting. All are pure and
+//! tested here against hand-built `Feed` fixtures.
+//! What: Constructs `Feed`/`TripUpdate`/`StopTimeUpdate`/`Alert` directly and
+//! asserts on the shaped JSON, plus arg validation and an `#[ignore]` live
+//! smoke test.
+//! Test: This file IS the test module for `metro_north`.
+
+use super::super::gtfs_rt::{Alert, StopTimeUpdate, TripUpdate};
+use super::super::stations::match_station;
+use super::*;
+
+fn stop(
+    id: &str,
+    seq: u32,
+    depart: Option<i64>,
+    arrive: Option<i64>,
+    track: Option<&str>,
+) -> StopTimeUpdate {
+    StopTimeUpdate {
+        stop_id: Some(id.to_string()),
+        stop_sequence: Some(seq),
+        arrival: arrive,
+        departure: depart,
+        assigned_track: track.map(str::to_string),
+    }
+}
+
+fn trip(id: &str, route: &str, stops: Vec<StopTimeUpdate>) -> TripUpdate {
+    TripUpdate {
+        trip_id: Some(id.to_string()),
+        route_id: Some(route.to_string()),
+        start_date: Some("20260722".to_string()),
+        start_time: None,
+        stops,
+    }
+}
+
+#[test]
+fn format_eastern_hhmm_known_epoch() {
+    // 2026-07-22 18:42:00 UTC -> 14:42 EDT (UTC-4 in July).
+    let s = format_eastern_hhmm(1_753_209_720).unwrap();
+    assert_eq!(s, "14:42");
+}
+
+#[test]
+fn build_schedule_orders_filters_and_limits() {
+    let gct = match_station("Grand Central").unwrap(); // stop_id "1"
+    let now = 1_000_000_000;
+    let feed = Feed {
+        trip_updates: vec![
+            // New Haven (route 3) departs later.
+            trip(
+                "later",
+                "3",
+                vec![stop("1", 1, Some(now + 600), None, Some("24"))],
+            ),
+            // Hudson (route 1) departs sooner.
+            trip(
+                "sooner",
+                "1",
+                vec![stop("1", 1, Some(now + 120), None, None)],
+            ),
+            // A past departure -> excluded.
+            trip("past", "2", vec![stop("1", 1, Some(now - 300), None, None)]),
+            // Different origin -> excluded.
+            trip(
+                "other",
+                "2",
+                vec![stop("74", 1, Some(now + 60), None, None)],
+            ),
+        ],
+        alerts: vec![],
+    };
+
+    // No line filter: soonest-first, both future trips, limit 5.
+    let out = build_schedule(&feed, gct, None, None, 5, now);
+    let deps = out["departures"].as_array().unwrap();
+    assert_eq!(deps.len(), 2, "past + wrong-origin trips excluded");
+    assert_eq!(deps[0]["trip_id"], "sooner");
+    assert_eq!(deps[0]["line"], "Hudson");
+    assert_eq!(deps[1]["trip_id"], "later");
+    assert_eq!(deps[1]["line"], "New Haven");
+    assert_eq!(deps[1]["track"], "24");
+
+    // Limit truncates to the soonest.
+    let limited = build_schedule(&feed, gct, None, None, 1, now);
+    assert_eq!(limited["departures"].as_array().unwrap().len(), 1);
+    assert_eq!(limited["departures"][0]["trip_id"], "sooner");
+
+    // Line filter keeps only the New Haven trip.
+    let nh = build_schedule(&feed, gct, None, Some("New Haven"), 5, now);
+    let nh_deps = nh["departures"].as_array().unwrap();
+    assert_eq!(nh_deps.len(), 1);
+    assert_eq!(nh_deps[0]["trip_id"], "later");
+}
+
+#[test]
+fn build_schedule_requires_downstream_destination() {
+    let gct = match_station("Grand Central").unwrap(); // "1"
+    let stamford = match_station("Stamford").unwrap(); // "124"
+    let now = 1_000_000_000;
+    let feed = Feed {
+        trip_updates: vec![
+            // Serves GCT then Stamford downstream -> included with arrival.
+            trip(
+                "to-stamford",
+                "3",
+                vec![
+                    stop("1", 1, Some(now + 100), None, Some("30")),
+                    stop("124", 8, None, Some(now + 3000), None),
+                ],
+            ),
+            // Serves GCT but NOT Stamford -> excluded when `to` is set.
+            trip(
+                "to-nowhere",
+                "1",
+                vec![stop("1", 1, Some(now + 200), None, None)],
+            ),
+        ],
+        alerts: vec![],
+    };
+
+    let out = build_schedule(&feed, gct, Some(stamford), None, 5, now);
+    let deps = out["departures"].as_array().unwrap();
+    assert_eq!(deps.len(), 1, "only the trip serving Stamford survives");
+    assert_eq!(deps[0]["trip_id"], "to-stamford");
+    assert_eq!(deps[0]["arrive_epoch"], now + 3000);
+    assert!(deps[0]["arrive"].is_string());
+    assert_eq!(out["to"], "Stamford");
+}
+
+#[test]
+fn build_alerts_filters_by_line() {
+    let feed = Feed {
+        trip_updates: vec![],
+        alerts: vec![
+            Alert {
+                route_ids: vec!["1".to_string()], // Hudson
+                header: Some("Hudson delays".to_string()),
+                description: Some("Signal problems".to_string()),
+            },
+            Alert {
+                route_ids: vec!["3".to_string()], // New Haven
+                header: Some("New Haven suspended".to_string()),
+                description: None,
+            },
+            Alert {
+                route_ids: vec![], // system-wide -> always surfaces
+                header: Some("Holiday schedule".to_string()),
+                description: None,
+            },
+        ],
+    };
+
+    let all = build_alerts(&feed, None);
+    assert_eq!(all["count"], 3);
+
+    let hudson = build_alerts(&feed, Some("Hudson"));
+    let items = hudson["alerts"].as_array().unwrap();
+    // Hudson-specific + the system-wide alert.
+    assert_eq!(items.len(), 2);
+    let headers: Vec<&str> = items
+        .iter()
+        .map(|a| a["header"].as_str().unwrap())
+        .collect();
+    assert!(headers.contains(&"Hudson delays"));
+    assert!(headers.contains(&"Holiday schedule"));
+    assert!(!headers.contains(&"New Haven suspended"));
+    assert_eq!(items[0]["lines"][0], "Hudson");
+}
+
+#[test]
+fn parse_query_validates_stations() {
+    // Missing `from`.
+    assert!(GetTrainScheduleTool::parse_query(&json!({})).is_err());
+    // Unknown origin.
+    assert!(GetTrainScheduleTool::parse_query(&json!({ "from": "Narnia" })).is_err());
+    // Valid; limit clamps.
+    let q = GetTrainScheduleTool::parse_query(&json!({
+        "from": "Stamford", "to": "Grand Central", "line": "New Haven", "limit": 99
+    }))
+    .unwrap();
+    assert_eq!(q.from.stop_id, "124");
+    assert_eq!(q.to.unwrap().stop_id, "1");
+    assert_eq!(q.line.as_deref(), Some("New Haven"));
+    assert_eq!(q.limit, 10);
+    // Unknown destination errors.
+    assert!(
+        GetTrainScheduleTool::parse_query(&json!({ "from": "Stamford", "to": "Narnia" })).is_err()
+    );
+}
+
+#[test]
+fn tools_report_their_names() {
+    assert_eq!(GetTrainScheduleTool::new().name(), "get_train_schedule");
+    assert_eq!(GetTrainAlertsTool::new().name(), "get_train_alerts");
+}
+
+/// Live smoke test against the MTA feed — gated `#[ignore]` (network).
+#[tokio::test]
+#[ignore = "hits the live MTA Metro-North GTFS-RT feed; run manually with --ignored"]
+async fn live_alerts_smoke() {
+    let tool = GetTrainAlertsTool::new();
+    let result = tool.execute(json!({})).await;
+    assert!(!result.is_error(), "live alerts call failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(result.content()).unwrap();
+    assert!(parsed["alerts"].is_array());
+}

--- a/crates/trusty-agents/src/tools/izzie/mod.rs
+++ b/crates/trusty-agents/src/tools/izzie/mod.rs
@@ -1,0 +1,60 @@
+//! Izzie platform-hosted tools: weather + Metro-North (epic #3052).
+//!
+//! Why: The `izzie-weather` and `izzie-metro-north` skills reference three
+//! tools — `get_weather`, `get_train_schedule`, `get_train_alerts` — that were
+//! declared by the persona but never implemented, so the assistant could only
+//! ever refuse ("I don't have a weather tool"), the exact anti-pattern those
+//! skills warn against. This module implements them as ordinary
+//! platform-hosted `ToolExecutor`s, registered alongside git / ticketing /
+//! `system_status` in the persona dispatch path and admitted per-persona by
+//! the existing `[tools].allow` gate.
+//! What: `izzie_tools()` returns the three executors as a `Vec<Arc<dyn
+//! ToolExecutor>>` for one-call registration. All three are keyless (Open-Meteo
+//! + NWS for weather; the keyless MTA GTFS-Realtime feed for trains); any
+//! optional gateway credential is read from an env var with graceful
+//! degradation, never hardcoded.
+//! Test: Per-tool unit tests live beside each implementation; this module's
+//! `izzie_tools_exposes_expected_names` pins the registered name set.
+
+use std::sync::Arc;
+
+use crate::tools::traits::ToolExecutor;
+
+pub mod gtfs_rt;
+pub mod metro_north;
+pub mod stations;
+pub mod weather;
+
+pub use metro_north::{GetTrainAlertsTool, GetTrainScheduleTool};
+pub use weather::GetWeatherTool;
+
+/// Construct the three izzie platform-hosted tools for registration.
+///
+/// Why: Mirrors `git_tools()` — one call hands the dispatch path every tool in
+/// this family so the registration site stays a single line.
+/// What: Returns `get_weather`, `get_train_schedule`, `get_train_alerts` as
+/// boxed executors. Each builds its own short-timeout HTTP client; construction
+/// never performs I/O, so this is safe to call at session start.
+/// Test: `izzie_tools_exposes_expected_names`.
+pub fn izzie_tools() -> Vec<Arc<dyn ToolExecutor>> {
+    vec![
+        Arc::new(GetWeatherTool::new()),
+        Arc::new(GetTrainScheduleTool::new()),
+        Arc::new(GetTrainAlertsTool::new()),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn izzie_tools_exposes_expected_names() {
+        let tools = izzie_tools();
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(
+            names,
+            vec!["get_weather", "get_train_schedule", "get_train_alerts"]
+        );
+    }
+}

--- a/crates/trusty-agents/src/tools/izzie/stations.rs
+++ b/crates/trusty-agents/src/tools/izzie/stations.rs
@@ -1,0 +1,280 @@
+//! Metro-North station + line reference data (epic #3052).
+//!
+//! Why: The GTFS-Realtime feed identifies stops and routes only by their
+//! numeric GTFS ids; a human asks for "Stamford" or "the New Haven line". This
+//! module is the name<->id bridge, seeded from the MTA's published Metro-North
+//! GTFS static `stops.txt` / `routes.txt` (downloaded from
+//! `web.mta.info/developers/data/mnr/google_transit.zip`). The stop_ids here
+//! are the real values that appear in the live feed, so schedule matching
+//! works out of the box.
+//! What: `STATIONS` (curated key stations with aliases), `match_station` for
+//! fuzzy name lookup, `ROUTES` mapping the six GTFS route ids to line names,
+//! and `route_matches_line` for the optional `line` filter. Data-only; no I/O.
+//! Test: `match_station_exact_and_fuzzy`, `route_matches_line_by_name_or_id`.
+
+/// A Metro-North station: its canonical display name, GTFS `stop_id`, and the
+/// alias substrings a user might type.
+#[derive(Debug, Clone, Copy)]
+pub struct Station {
+    pub name: &'static str,
+    /// GTFS `stop_id` as it appears in the real-time feed (string form).
+    pub stop_id: &'static str,
+    pub aliases: &'static [&'static str],
+}
+
+/// Curated key stations (the set the `izzie-metro-north` skill advertises)
+/// with their real MNR GTFS stop_ids.
+pub const STATIONS: &[Station] = &[
+    Station {
+        name: "Grand Central Terminal",
+        stop_id: "1",
+        aliases: &["grand central", "gct", "grand central terminal"],
+    },
+    Station {
+        name: "Harlem-125th Street",
+        stop_id: "4",
+        aliases: &["harlem", "125th", "harlem-125", "harlem 125"],
+    },
+    Station {
+        name: "Fordham",
+        stop_id: "56",
+        aliases: &["fordham"],
+    },
+    Station {
+        name: "Yonkers",
+        stop_id: "18",
+        aliases: &["yonkers"],
+    },
+    Station {
+        name: "Greystone",
+        stop_id: "20",
+        aliases: &["greystone"],
+    },
+    Station {
+        name: "Dobbs Ferry",
+        stop_id: "23",
+        aliases: &["dobbs ferry", "dobbs"],
+    },
+    Station {
+        name: "Irvington",
+        stop_id: "25",
+        aliases: &["irvington"],
+    },
+    Station {
+        name: "Tarrytown",
+        stop_id: "27",
+        aliases: &["tarrytown"],
+    },
+    Station {
+        name: "Ossining",
+        stop_id: "31",
+        aliases: &["ossining"],
+    },
+    Station {
+        name: "Croton-Harmon",
+        stop_id: "33",
+        aliases: &["croton-harmon", "croton harmon", "croton"],
+    },
+    Station {
+        name: "Peekskill",
+        stop_id: "39",
+        aliases: &["peekskill"],
+    },
+    Station {
+        name: "Beacon",
+        stop_id: "46",
+        aliases: &["beacon"],
+    },
+    Station {
+        name: "Poughkeepsie",
+        stop_id: "51",
+        aliases: &["poughkeepsie"],
+    },
+    Station {
+        name: "Scarsdale",
+        stop_id: "71",
+        aliases: &["scarsdale"],
+    },
+    Station {
+        name: "White Plains",
+        stop_id: "74",
+        aliases: &["white plains"],
+    },
+    Station {
+        name: "North White Plains",
+        stop_id: "76",
+        aliases: &["north white plains"],
+    },
+    Station {
+        name: "Mount Kisco",
+        stop_id: "84",
+        aliases: &["mount kisco", "mt kisco", "kisco"],
+    },
+    Station {
+        name: "Bedford Hills",
+        stop_id: "85",
+        aliases: &["bedford hills"],
+    },
+    Station {
+        name: "Katonah",
+        stop_id: "86",
+        aliases: &["katonah"],
+    },
+    Station {
+        name: "Port Chester",
+        stop_id: "115",
+        aliases: &["port chester"],
+    },
+    Station {
+        name: "Greenwich",
+        stop_id: "116",
+        aliases: &["greenwich"],
+    },
+    Station {
+        name: "Old Greenwich",
+        stop_id: "121",
+        aliases: &["old greenwich"],
+    },
+    Station {
+        name: "Stamford",
+        stop_id: "124",
+        aliases: &["stamford"],
+    },
+    Station {
+        name: "New Haven",
+        stop_id: "149",
+        aliases: &["new haven"],
+    },
+    Station {
+        name: "Wassaic",
+        stop_id: "177",
+        aliases: &["wassaic"],
+    },
+];
+
+/// Resolve a user-typed station name to a known station.
+///
+/// Why: Users type partial, lowercase, or aliased names ("gct", "mt kisco").
+/// What: Normalizes to lowercase and matches, in priority order: exact
+/// canonical name, exact alias, canonical-name substring, then alias
+/// substring. Returns the first hit or `None`.
+/// Test: `match_station_exact_and_fuzzy`.
+pub fn match_station(query: &str) -> Option<&'static Station> {
+    let q = query.trim().to_lowercase();
+    if q.is_empty() {
+        return None;
+    }
+    // 1. exact canonical name.
+    if let Some(s) = STATIONS.iter().find(|s| s.name.to_lowercase() == q) {
+        return Some(s);
+    }
+    // 2. exact alias.
+    if let Some(s) = STATIONS.iter().find(|s| s.aliases.iter().any(|a| *a == q)) {
+        return Some(s);
+    }
+    // 3. canonical-name substring.
+    if let Some(s) = STATIONS.iter().find(|s| s.name.to_lowercase().contains(&q)) {
+        return Some(s);
+    }
+    // 4. alias substring (either direction).
+    STATIONS
+        .iter()
+        .find(|s| s.aliases.iter().any(|a| a.contains(&q) || q.contains(*a)))
+}
+
+/// A Metro-North line: its GTFS `route_id` and human name.
+#[derive(Debug, Clone, Copy)]
+pub struct Route {
+    pub route_id: &'static str,
+    pub name: &'static str,
+}
+
+/// The six MNR GTFS routes (from `routes.txt`).
+pub const ROUTES: &[Route] = &[
+    Route {
+        route_id: "1",
+        name: "Hudson",
+    },
+    Route {
+        route_id: "2",
+        name: "Harlem",
+    },
+    Route {
+        route_id: "3",
+        name: "New Haven",
+    },
+    Route {
+        route_id: "4",
+        name: "New Canaan",
+    },
+    Route {
+        route_id: "5",
+        name: "Danbury",
+    },
+    Route {
+        route_id: "6",
+        name: "Waterbury",
+    },
+];
+
+/// Human line name for a GTFS `route_id`, or the raw id if unknown.
+pub fn route_name(route_id: &str) -> String {
+    ROUTES
+        .iter()
+        .find(|r| r.route_id == route_id)
+        .map(|r| r.name.to_string())
+        .unwrap_or_else(|| route_id.to_string())
+}
+
+/// Whether a feed `route_id` matches a user-supplied `line` filter.
+///
+/// Why: The `line` argument accepts either a line name ("New Haven", "hudson")
+/// or a raw route id; both must resolve.
+/// What: True when the filter equals the route id, equals the mapped line name
+/// (case-insensitive), or is a substring of that name.
+/// Test: `route_matches_line_by_name_or_id`.
+pub fn route_matches_line(route_id: &str, line: &str) -> bool {
+    let want = line.trim().to_lowercase();
+    if want.is_empty() {
+        return true;
+    }
+    if route_id == want {
+        return true;
+    }
+    let name = route_name(route_id).to_lowercase();
+    name == want || name.contains(&want) || want.contains(&name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn match_station_exact_and_fuzzy() {
+        assert_eq!(match_station("Stamford").unwrap().stop_id, "124");
+        assert_eq!(match_station("gct").unwrap().stop_id, "1");
+        assert_eq!(match_station("GRAND CENTRAL").unwrap().stop_id, "1");
+        assert_eq!(match_station("mt kisco").unwrap().stop_id, "84");
+        // substring on canonical name
+        assert_eq!(match_station("haven").unwrap().stop_id, "149");
+        assert!(match_station("Nonexistent Town").is_none());
+        assert!(match_station("   ").is_none());
+    }
+
+    #[test]
+    fn route_matches_line_by_name_or_id() {
+        assert!(route_matches_line("3", "New Haven"));
+        assert!(route_matches_line("3", "new haven"));
+        assert!(route_matches_line("1", "hudson"));
+        assert!(route_matches_line("1", "1"));
+        assert!(!route_matches_line("1", "Harlem"));
+        // empty filter matches anything
+        assert!(route_matches_line("2", ""));
+    }
+
+    #[test]
+    fn route_name_falls_back_to_id() {
+        assert_eq!(route_name("3"), "New Haven");
+        assert_eq!(route_name("99"), "99");
+    }
+}

--- a/crates/trusty-agents/src/tools/izzie/weather.rs
+++ b/crates/trusty-agents/src/tools/izzie/weather.rs
@@ -1,0 +1,401 @@
+//! `get_weather` — current conditions + short forecast + severe alerts (#3052).
+//!
+//! Why: Izzie's `izzie-weather` skill promises real weather data with no API
+//! key, but the tool it names never existed. This implements it against two
+//! keyless endpoints: Open-Meteo (global forecast + geocoding) and the US
+//! National Weather Service (severe-weather alerts). No credential is required
+//! for either, so the tool is always registerable and never depends on env
+//! secrets.
+//! What: `GetWeatherTool` accepts a place name OR explicit lat/lon, geocodes a
+//! name through Open-Meteo when needed, fetches current + daily forecast, and
+//! best-effort overlays active NWS alerts (US only; a failure there degrades
+//! to "no alerts" rather than failing the whole call). Returns structured JSON
+//! (never prose) so the model can phrase it per the skill's response style.
+//! Test: The HTTP-free mapping/labelling/arg-parsing helpers are unit-tested
+//! against fixture JSON; the live path is covered by an `#[ignore]`
+//! integration test.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+const GEOCODE_URL: &str = "https://geocoding-api.open-meteo.com/v1/search";
+const FORECAST_URL: &str = "https://api.open-meteo.com/v1/forecast";
+const NWS_ALERTS_URL: &str = "https://api.weather.gov/alerts/active";
+/// NWS requires a descriptive User-Agent; requests without one are rejected.
+const NWS_USER_AGENT: &str = "trusty-agents-izzie (https://github.com/bobmatnyc/trusty-tools)";
+
+/// Default location when the caller supplies neither a place nor coordinates:
+/// Masa's home base per the `izzie-weather` skill.
+const DEFAULT_PLACE: &str = "Hastings-on-Hudson, NY";
+const DEFAULT_LAT: f64 = 41.0053;
+const DEFAULT_LON: f64 = -73.8779;
+
+/// Parsed `get_weather` arguments.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WeatherArgs {
+    /// A place name to geocode, when no explicit coordinates were given.
+    pub location: Option<String>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    /// Forecast horizon in days (clamped to 1..=7).
+    pub days: u8,
+}
+
+/// Parse and validate the raw tool arguments.
+///
+/// Why: Keeping arg parsing pure (no I/O) lets a unit test pin the defaulting
+/// and clamping rules without a network round-trip.
+/// What: Reads optional `location`, `latitude`, `longitude`, and `days`;
+/// clamps `days` into 1..=7 (default 3). All fields are optional — an empty
+/// object yields the home-base default resolved later in `execute`.
+/// Test: `parse_args_defaults_and_clamps`, `parse_args_reads_coordinates`.
+pub fn parse_args(args: &Value) -> WeatherArgs {
+    let location = args
+        .get("location")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let latitude = args.get("latitude").and_then(Value::as_f64);
+    let longitude = args.get("longitude").and_then(Value::as_f64);
+    let days = args
+        .get("days")
+        .and_then(Value::as_u64)
+        .unwrap_or(3)
+        .clamp(1, 7) as u8;
+    WeatherArgs {
+        location,
+        latitude,
+        longitude,
+        days,
+    }
+}
+
+/// Map a WMO weather-interpretation code to a short human label.
+///
+/// Why: Open-Meteo reports conditions as WMO codes; the model wants words.
+/// What: Covers the documented WMO code table; unknown codes fall back to a
+/// numeric label so we never fabricate a condition.
+/// Test: `weather_code_labels_known_and_unknown`.
+pub fn weather_code_label(code: i64) -> String {
+    let label = match code {
+        0 => "Clear sky",
+        1 => "Mainly clear",
+        2 => "Partly cloudy",
+        3 => "Overcast",
+        45 | 48 => "Fog",
+        51 | 53 | 55 => "Drizzle",
+        56 | 57 => "Freezing drizzle",
+        61 | 63 | 65 => "Rain",
+        66 | 67 => "Freezing rain",
+        71 | 73 | 75 => "Snow",
+        77 => "Snow grains",
+        80..=82 => "Rain showers",
+        85 | 86 => "Snow showers",
+        95 => "Thunderstorm",
+        96 | 99 => "Thunderstorm with hail",
+        other => return format!("WMO code {other}"),
+    };
+    label.to_string()
+}
+
+/// Extract the first geocoding hit as `(display_name, lat, lon)`.
+///
+/// Why: Turning a place name into coordinates is the first Open-Meteo call;
+/// isolating the JSON mapping keeps it testable against a captured response.
+/// What: Reads `results[0]`; assembles a "Name, Admin1, Country" label from
+/// whatever fields are present. Returns `None` when there are no results.
+/// Test: `geocode_first_result_maps_fields`, `geocode_first_result_empty`.
+pub fn geocode_first_result(body: &Value) -> Option<(String, f64, f64)> {
+    let first = body.get("results").and_then(Value::as_array)?.first()?;
+    let lat = first.get("latitude").and_then(Value::as_f64)?;
+    let lon = first.get("longitude").and_then(Value::as_f64)?;
+    let name = first.get("name").and_then(Value::as_str).unwrap_or("");
+    let admin1 = first.get("admin1").and_then(Value::as_str).unwrap_or("");
+    let country = first.get("country").and_then(Value::as_str).unwrap_or("");
+    let label = [name, admin1, country]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some((label, lat, lon))
+}
+
+/// Shape an Open-Meteo forecast response into the tool's structured output.
+///
+/// Why: The raw response is column-oriented (parallel arrays); the model wants
+/// a compact per-day object plus a `current` summary.
+/// What: Maps `current` fields and zips the `daily.*` arrays into day objects,
+/// translating WMO codes to labels. Missing fields degrade to `null` rather
+/// than aborting.
+/// Test: `forecast_maps_current_and_daily`.
+pub fn map_forecast(location: &str, lat: f64, lon: f64, body: &Value) -> Value {
+    let current = body.get("current").cloned().unwrap_or(Value::Null);
+    let current_out = json!({
+        "temperature_f": current.get("temperature_2m").and_then(Value::as_f64),
+        "feels_like_f": current.get("apparent_temperature").and_then(Value::as_f64),
+        "humidity_pct": current.get("relative_humidity_2m").and_then(Value::as_f64),
+        "wind_mph": current.get("wind_speed_10m").and_then(Value::as_f64),
+        "precipitation_in": current.get("precipitation").and_then(Value::as_f64),
+        "conditions": current
+            .get("weather_code")
+            .and_then(Value::as_i64)
+            .map(weather_code_label),
+    });
+
+    let daily = body.get("daily");
+    let dates = daily
+        .and_then(|d| d.get("time"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let col = |name: &str| -> Vec<Value> {
+        daily
+            .and_then(|d| d.get(name))
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
+    };
+    let highs = col("temperature_2m_max");
+    let lows = col("temperature_2m_min");
+    let codes = col("weather_code");
+    let precip_prob = col("precipitation_probability_max");
+    let precip_sum = col("precipitation_sum");
+    let get = |v: &[Value], i: usize| v.get(i).cloned().unwrap_or(Value::Null);
+
+    let days: Vec<Value> = dates
+        .iter()
+        .enumerate()
+        .map(|(i, date)| {
+            json!({
+                "date": date,
+                "high_f": get(&highs, i),
+                "low_f": get(&lows, i),
+                "conditions": get(&codes, i).as_i64().map(weather_code_label),
+                "precip_chance_pct": get(&precip_prob, i),
+                "precip_in": get(&precip_sum, i),
+            })
+        })
+        .collect();
+
+    json!({
+        "location": location,
+        "latitude": lat,
+        "longitude": lon,
+        "current": current_out,
+        "daily": days,
+    })
+}
+
+/// Extract active NWS alerts as compact objects.
+///
+/// Why: The `izzie-weather` skill surfaces severe-weather alerts proactively;
+/// the model needs event/severity/headline, not the full GeoJSON.
+/// What: Maps each `features[].properties`; empty/missing features yield an
+/// empty vector (the common no-alerts case).
+/// Test: `nws_alerts_maps_features`, `nws_alerts_empty`.
+pub fn map_nws_alerts(body: &Value) -> Vec<Value> {
+    body.get("features")
+        .and_then(Value::as_array)
+        .map(|features| {
+            features
+                .iter()
+                .filter_map(|f| f.get("properties"))
+                .map(|p| {
+                    json!({
+                        "event": p.get("event").and_then(Value::as_str),
+                        "severity": p.get("severity").and_then(Value::as_str),
+                        "headline": p.get("headline").and_then(Value::as_str),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The `get_weather` tool.
+pub struct GetWeatherTool {
+    client: reqwest::Client,
+}
+
+impl Default for GetWeatherTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GetWeatherTool {
+    /// Build the tool with a short-timeout HTTP client.
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(12))
+            .build()
+            .unwrap_or_default();
+        Self { client }
+    }
+
+    /// Geocode a place name to `(label, lat, lon)` via Open-Meteo.
+    async fn geocode(&self, place: &str) -> anyhow::Result<Option<(String, f64, f64)>> {
+        let resp = self
+            .client
+            .get(GEOCODE_URL)
+            .query(&[("name", place), ("count", "1"), ("language", "en")])
+            .send()
+            .await?
+            .error_for_status()?;
+        let body: Value = resp.json().await?;
+        Ok(geocode_first_result(&body))
+    }
+
+    /// Fetch the current + daily forecast for a coordinate.
+    async fn forecast(&self, lat: f64, lon: f64, days: u8) -> anyhow::Result<Value> {
+        let resp = self
+            .client
+            .get(FORECAST_URL)
+            .query(&[
+                ("latitude", lat.to_string()),
+                ("longitude", lon.to_string()),
+                (
+                    "current",
+                    "temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,\
+                     weather_code,wind_speed_10m"
+                        .to_string(),
+                ),
+                (
+                    "daily",
+                    "weather_code,temperature_2m_max,temperature_2m_min,\
+                     precipitation_probability_max,precipitation_sum"
+                        .to_string(),
+                ),
+                ("temperature_unit", "fahrenheit".to_string()),
+                ("wind_speed_unit", "mph".to_string()),
+                ("precipitation_unit", "inch".to_string()),
+                ("timezone", "auto".to_string()),
+                ("forecast_days", days.to_string()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(resp.json().await?)
+    }
+
+    /// Best-effort active NWS alerts for a coordinate (US only). Any failure
+    /// degrades to an empty list — a weather answer must not break because the
+    /// alerts service is unreachable or the point is outside the US.
+    async fn nws_alerts(&self, lat: f64, lon: f64) -> Vec<Value> {
+        let point = format!("{lat:.4},{lon:.4}");
+        let result = self
+            .client
+            .get(NWS_ALERTS_URL)
+            .header("User-Agent", NWS_USER_AGENT)
+            .header("Accept", "application/geo+json")
+            .query(&[("point", point.as_str())])
+            .send()
+            .await;
+        match result {
+            Ok(resp) => match resp.error_for_status() {
+                Ok(ok) => ok
+                    .json::<Value>()
+                    .await
+                    .map(|b| map_nws_alerts(&b))
+                    .unwrap_or_default(),
+                Err(_) => Vec::new(),
+            },
+            Err(_) => Vec::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for GetWeatherTool {
+    fn name(&self) -> &str {
+        "get_weather"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get current conditions plus a short daily forecast (and active US severe-weather alerts) for a location. Provide EITHER a place name via `location` OR explicit `latitude`/`longitude`. Keyless (Open-Meteo + National Weather Service). Defaults to Hastings-on-Hudson, NY when nothing is supplied. Temperatures in °F, wind in mph, precipitation in inches.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "Place name to look up, e.g. 'Stamford, CT' or 'Paris, France'. Omit if passing coordinates."
+                        },
+                        "latitude": { "type": "number", "description": "Latitude in decimal degrees (use with longitude)." },
+                        "longitude": { "type": "number", "description": "Longitude in decimal degrees (use with latitude)." },
+                        "days": { "type": "integer", "description": "Forecast horizon in days (1-7, default 3)." }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let parsed = parse_args(&args);
+
+        // Resolve coordinates: explicit lat/lon win; else geocode a place;
+        // else fall back to the home-base default.
+        let (label, lat, lon) = match (parsed.latitude, parsed.longitude) {
+            (Some(lat), Some(lon)) => (
+                parsed
+                    .location
+                    .unwrap_or_else(|| format!("{lat:.4},{lon:.4}")),
+                lat,
+                lon,
+            ),
+            _ => match parsed.location {
+                Some(place) => match self.geocode(&place).await {
+                    Ok(Some(hit)) => hit,
+                    Ok(None) => {
+                        return ToolResult::err(format!(
+                            "No location found matching '{place}'. Try a more specific name (city, state/country)."
+                        ));
+                    }
+                    Err(e) => {
+                        return ToolResult::err(format!(
+                            "Weather geocoding for '{place}' failed (service unreachable): {e}"
+                        ));
+                    }
+                },
+                None => (DEFAULT_PLACE.to_string(), DEFAULT_LAT, DEFAULT_LON),
+            },
+        };
+
+        let forecast = match self.forecast(lat, lon, parsed.days).await {
+            Ok(body) => body,
+            Err(e) => {
+                return ToolResult::err(format!(
+                    "Weather forecast request failed (Open-Meteo unreachable): {e}"
+                ));
+            }
+        };
+
+        let mut out = map_forecast(&label, lat, lon, &forecast);
+        let alerts = self.nws_alerts(lat, lon).await;
+        if let Value::Object(ref mut map) = out {
+            map.insert("alerts".to_string(), Value::Array(alerts));
+            map.insert(
+                "source".to_string(),
+                Value::String("Open-Meteo (forecast) + NWS (alerts)".to_string()),
+            );
+        }
+
+        match serde_json::to_string(&out) {
+            Ok(s) => ToolResult::ok(s),
+            Err(e) => ToolResult::err(format!("failed to serialize weather result: {e}")),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "weather_tests.rs"]
+mod tests;

--- a/crates/trusty-agents/src/tools/izzie/weather_tests.rs
+++ b/crates/trusty-agents/src/tools/izzie/weather_tests.rs
@@ -1,0 +1,153 @@
+//! Fixture-driven tests for the `get_weather` HTTP-free helpers.
+//!
+//! Why: `execute` does live I/O; the *logic* worth pinning is arg parsing,
+//! WMO-code labelling, and the geocode/forecast/alert JSON mappings. Those are
+//! pure and tested here against captured-shape fixtures — no network.
+//! What: Exercises `parse_args`, `weather_code_label`, `geocode_first_result`,
+//! `map_forecast`, and `map_nws_alerts`, plus an `#[ignore]` live smoke test.
+//! Test: This file IS the test module for `weather`.
+
+use super::*;
+use serde_json::json;
+
+#[test]
+fn parse_args_defaults_and_clamps() {
+    let a = parse_args(&json!({}));
+    assert_eq!(a.location, None);
+    assert_eq!(a.latitude, None);
+    assert_eq!(a.days, 3);
+
+    let clamped = parse_args(&json!({ "days": 99 }));
+    assert_eq!(clamped.days, 7);
+    let floored = parse_args(&json!({ "days": 0 }));
+    assert_eq!(floored.days, 1);
+
+    // Blank location string is treated as absent.
+    let blank = parse_args(&json!({ "location": "   " }));
+    assert_eq!(blank.location, None);
+}
+
+#[test]
+fn parse_args_reads_coordinates() {
+    let a = parse_args(&json!({ "latitude": 41.0, "longitude": -73.8, "days": 2 }));
+    assert_eq!(a.latitude, Some(41.0));
+    assert_eq!(a.longitude, Some(-73.8));
+    assert_eq!(a.days, 2);
+
+    let named = parse_args(&json!({ "location": "Stamford, CT" }));
+    assert_eq!(named.location.as_deref(), Some("Stamford, CT"));
+}
+
+#[test]
+fn weather_code_labels_known_and_unknown() {
+    assert_eq!(weather_code_label(0), "Clear sky");
+    assert_eq!(weather_code_label(2), "Partly cloudy");
+    assert_eq!(weather_code_label(65), "Rain");
+    assert_eq!(weather_code_label(95), "Thunderstorm");
+    assert_eq!(weather_code_label(123), "WMO code 123");
+}
+
+#[test]
+fn geocode_first_result_maps_fields() {
+    let body = json!({
+        "results": [
+            { "name": "Stamford", "admin1": "Connecticut", "country": "United States",
+              "latitude": 41.0534, "longitude": -73.5387 },
+            { "name": "Other" }
+        ]
+    });
+    let (label, lat, lon) = geocode_first_result(&body).expect("should match first result");
+    assert_eq!(label, "Stamford, Connecticut, United States");
+    assert!((lat - 41.0534).abs() < 1e-6);
+    assert!((lon + 73.5387).abs() < 1e-6);
+}
+
+#[test]
+fn geocode_first_result_empty() {
+    assert!(geocode_first_result(&json!({ "results": [] })).is_none());
+    assert!(geocode_first_result(&json!({})).is_none());
+}
+
+#[test]
+fn forecast_maps_current_and_daily() {
+    let body = json!({
+        "current": {
+            "temperature_2m": 72.4,
+            "apparent_temperature": 70.1,
+            "relative_humidity_2m": 55,
+            "wind_speed_10m": 8.3,
+            "precipitation": 0.0,
+            "weather_code": 2
+        },
+        "daily": {
+            "time": ["2026-07-22", "2026-07-23"],
+            "temperature_2m_max": [81.0, 84.2],
+            "temperature_2m_min": [63.0, 65.5],
+            "weather_code": [3, 95],
+            "precipitation_probability_max": [10, 80],
+            "precipitation_sum": [0.0, 0.6]
+        }
+    });
+    let out = map_forecast("Hastings-on-Hudson, NY", 41.0, -73.8, &body);
+    assert_eq!(out["location"], "Hastings-on-Hudson, NY");
+    assert_eq!(out["current"]["temperature_f"], 72.4);
+    assert_eq!(out["current"]["conditions"], "Partly cloudy");
+    let days = out["daily"].as_array().unwrap();
+    assert_eq!(days.len(), 2);
+    assert_eq!(days[0]["high_f"], 81.0);
+    assert_eq!(days[0]["conditions"], "Overcast");
+    assert_eq!(days[1]["conditions"], "Thunderstorm");
+    assert_eq!(days[1]["precip_chance_pct"], 80);
+    assert_eq!(days[1]["precip_in"], 0.6);
+}
+
+#[test]
+fn forecast_tolerates_missing_daily() {
+    let body = json!({ "current": { "temperature_2m": 60.0 } });
+    let out = map_forecast("Nowhere", 0.0, 0.0, &body);
+    assert_eq!(out["daily"].as_array().unwrap().len(), 0);
+    assert_eq!(out["current"]["temperature_f"], 60.0);
+    // Absent weather_code -> null conditions, not a fabricated label.
+    assert!(out["current"]["conditions"].is_null());
+}
+
+#[test]
+fn nws_alerts_maps_features() {
+    let body = json!({
+        "features": [
+            { "properties": {
+                "event": "Flood Watch",
+                "severity": "Moderate",
+                "headline": "Flood Watch until 8 PM"
+            } }
+        ]
+    });
+    let alerts = map_nws_alerts(&body);
+    assert_eq!(alerts.len(), 1);
+    assert_eq!(alerts[0]["event"], "Flood Watch");
+    assert_eq!(alerts[0]["severity"], "Moderate");
+}
+
+#[test]
+fn nws_alerts_empty() {
+    assert_eq!(map_nws_alerts(&json!({ "features": [] })).len(), 0);
+    assert_eq!(map_nws_alerts(&json!({})).len(), 0);
+}
+
+#[test]
+fn tool_reports_its_name() {
+    assert_eq!(GetWeatherTool::new().name(), "get_weather");
+}
+
+/// Live smoke test against Open-Meteo — gated `#[ignore]` (requires network).
+#[tokio::test]
+#[ignore = "hits the live Open-Meteo API; run manually with --ignored"]
+async fn live_weather_smoke() {
+    let tool = GetWeatherTool::new();
+    let result = tool
+        .execute(json!({ "location": "Hastings-on-Hudson, NY", "days": 2 }))
+        .await;
+    assert!(!result.is_error(), "live weather call failed: {result:?}");
+    let parsed: serde_json::Value = serde_json::from_str(result.content()).unwrap();
+    assert!(parsed["current"]["temperature_f"].is_number());
+}

--- a/crates/trusty-agents/src/tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mod.rs
@@ -20,6 +20,7 @@ pub mod finish_task;
 pub mod format_translator;
 pub mod fs_reader;
 pub mod git_tools;
+pub mod izzie;
 pub mod mcp_live;
 pub mod mcp_service_tools;
 pub mod mcp_tools;


### PR DESCRIPTION
## Summary

Addresses the **izzie weather + Metro-North tool gap** (epic **#3052**). The
`izzie-weather` and `izzie-metro-north` skills advertise three tools —
`get_weather`, `get_train_schedule`, `get_train_alerts` — that izzie's persona
referenced but that were **never implemented**, so the assistant could only
ever refuse ("I don't have a weather tool"), the exact anti-pattern those
skills warn against. This builds all three from scratch as ordinary
platform-hosted `ToolExecutor`s, registered the same way git / native
ticketing / `system_status` are.

_(Tracking issue is being filed in parallel — reference "izzie weather +
Metro-North tool gap, epic #3052"; exact `Closes #NNN` left for the owner to
reconcile.)_

Closes #3699

## Tools

- **`get_weather`** — current conditions + short daily forecast via **Open-Meteo**
  (place-name geocoding or explicit lat/lon), plus active US severe-weather
  alerts via **NWS**. Fully keyless. Defaults to Hastings-on-Hudson, NY.
- **`get_train_schedule`** — next real-time MTA Metro-North departures from a
  station, optionally toward a destination and/or filtered to a line; returns
  Eastern-time departures with assigned track and downstream arrival.
- **`get_train_alerts`** — active Metro-North service alerts, optionally filtered
  to one line (system-wide alerts always surface).

Both train tools read the **keyless MTA Metro-North GTFS-Realtime feed**. Any
optional gateway credential comes from `MTA_API_KEY` (sent as `x-api-key` only
when set; graceful degradation otherwise — never hardcoded). The feed URL is
overridable via `IZZIE_MNR_GTFS_RT_URL`.

## Design notes

- **No new dependencies.** Rather than pull in a `prost`/`protoc` GTFS-RT
  toolchain (a build-tool + CI portability cost, and a >500-SLOC generated
  binding that would blow the file cap), the feed is decoded by a small,
  dependency-free reader over the four protobuf wire types that extracts only
  the trip-update + alert subset we consume. The GTFS-RT field numbers are
  frozen by the published spec, so this is stable and fully fixture-testable.
- **Real station data.** Station→`stop_id` and line→`route_id` tables are seeded
  from the MTA's published MNR GTFS static `stops.txt` / `routes.txt`, so
  schedule matching works against the live feed out of the box.
- Registered unconditionally into the persona dispatch superset in
  `persona.rs` (next to `system_status`); whether izzie can call them is still
  gated by `filter_persona_tool_names` against izzie's `[tools].allow`, to
  which the three exact names were added.

## Files changed

**New tool family** (`crates/trusty-agents/src/tools/izzie/`)
- `mod.rs` — `izzie_tools()` registration bundle
- `weather.rs` (+ `weather_tests.rs`) — `get_weather`
- `metro_north.rs` (+ `metro_north_tests.rs`) — `get_train_schedule` / `get_train_alerts`
- `gtfs_rt.rs` (+ `gtfs_rt_tests.rs`) — minimal GTFS-Realtime decoder
- `stations.rs` — MNR station + line reference data

**Wiring**
- `src/tools/mod.rs` — `pub mod izzie;`
- `src/ctrl/pm_task/dispatch/persona.rs` — register the three tools
- `src/ctrl/pm_task/dispatch/persona_tests.rs` — admission regression test
- `.trusty-agents/agents/izzie/agent.toml` — add the three tools to `[tools].allow`
- `CHANGELOG.md` — `## [Unreleased]` entry

## Verification

- `cargo build -p trusty-agents` — clean
- `cargo test -p trusty-agents` — 2213 passed, 12 ignored (unit tests use
  fixtures; live API paths are `#[ignore]`)
- `cargo clippy -p trusty-agents -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — 0 violations (all production files < 500 SLOC)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools