### PR TITLE
chore(release): trusty-review 0.10.1 — ship the #3693 context_gate fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11740,7 +11740,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [0.10.1] — 2026-07-23
 
 ### Fixed
 
@@ -36,22 +36,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   to inspect `warm_boot_degraded` for those specific cases either — same
   blind spot the old `is_healthy` had, since both only ever look at the
   top-level `status` string.
-
-- **`/health` no longer hangs when trusty-search is slow, not down**
-  (closes [#3658](https://github.com/bobmatnyc/trusty-tools/issues/3658),
-  follow-on to [#722](https://github.com/bobmatnyc/trusty-tools/issues/722)):
-  the trusty-search/trusty-analyze dependency probe in the HTTP `/health`
-  handler, the `review_health` MCP tool, and the `console_metrics` MCP tool
-  had no internal timeout — a memory-pressured (slow, not down)
-  trusty-search could hang all three indefinitely, bounded only by the
-  clients' own 30 s / 5 s HTTP-transport timeouts. Each dep probe now runs
-  under a strict, independent `tokio::time::timeout` (default 2 s,
-  configurable via `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS`), and both deps
-  are probed concurrently so total `/health` latency stays bounded
-  regardless of dep count. `DepInfo` gains a new tri-state `state` field
-  (`"ok"` / `"unreachable"` / `"timeout"`) so a slow-but-up dependency is no
-  longer collapsed into the same `reachable: false` signal as a hard-down
-  one; the existing `reachable` boolean is unchanged for back-compat.
 
 ---
 ## [0.10.0] — 2026-07-21
@@ -98,6 +82,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `trusty-review`'s old default (7890, e.g. `curl http://127.0.0.1:7890/health`)
   must either pass `--port 7890` explicitly to `trusty-review serve` to keep
   the old behavior, or update that tooling to the new default (7891).
+- **`/health` no longer hangs when trusty-search is slow, not down**
+  (closes [#3658](https://github.com/bobmatnyc/trusty-tools/issues/3658),
+  follow-on to [#722](https://github.com/bobmatnyc/trusty-tools/issues/722)):
+  the trusty-search/trusty-analyze dependency probe in the HTTP `/health`
+  handler, the `review_health` MCP tool, and the `console_metrics` MCP tool
+  had no internal timeout — a memory-pressured (slow, not down)
+  trusty-search could hang all three indefinitely, bounded only by the
+  clients' own 30 s / 5 s HTTP-transport timeouts. Each dep probe now runs
+  under a strict, independent `tokio::time::timeout` (default 2 s,
+  configurable via `TRUSTY_REVIEW_DEP_PROBE_TIMEOUT_SECS`), and both deps
+  are probed concurrently so total `/health` latency stays bounded
+  regardless of dep count. `DepInfo` gains a new tri-state `state` field
+  (`"ok"` / `"unreachable"` / `"timeout"`) so a slow-but-up dependency is no
+  longer collapsed into the same `reachable: false` signal as a hard-down
+  one; the existing `reachable` boolean is unchanged for back-compat.
+  (**Note:** this fix shipped in the 0.10.0 *code* — commit `8f614980`
+  merged 2026-07-22 11:18, before the 0.10.0 tag was cut at 14:36 the same
+  day — but its changelog entry was mistakenly left under `[Unreleased]`
+  instead of being moved here. Backfilled 2026-07-23 during the 0.10.1
+  release-prep pass; not re-released under 0.10.1.)
 
 ## [0.9.2] — 2026-07-17
 

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.10.0"
+version     = "0.10.1"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true


### PR DESCRIPTION
## Summary

- Bumps `trusty-review` 0.10.0 → 0.10.1 (PATCH per repo semver table — both entries are `Fixed`).
- Ships the #3693 `context_gate` degraded-serving fix (merged as PR #3704) that unblocks EFS deployments from upgrading `trusty-search` to 0.38.1.
- CHANGELOG release-prep:
  - Moved the #3693 entry from `[Unreleased]` under a new `## [0.10.1] — 2026-07-23` heading.
  - Backfilled the #3658 entry under the `## [0.10.0]` heading with a note: that fix's code (commit `8f614980`) had already merged before the 0.10.0 tag was cut, but its changelog entry was mistakenly left under Unreleased instead of being moved at release time. It is not re-released under 0.10.1.

## Test plan

- [x] `cargo check -p trusty-review` — clean, Cargo.lock updated
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-review --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-review` — 1601 passed, 0 failed, 5 pre-existing ignored
- [x] `cargo check --workspace` (excluding two pre-existing, unrelated Tauri GUI crates missing a built `ui/dist` frontend bundle — `trusty-code-gui`, `trusty-mpm-gui`; not touched by this change) — clean

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools