### PR TITLE
chore(release): trusty-search 0.39.0 + trusty-common 0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,7 +6549,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11404,7 +11404,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11781,7 +11781,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ trusty-code = { path = "crates/trusty-code" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.3.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.24.2" }
+trusty-common = { path = "crates/trusty-common", version = "0.25.0" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -61,7 +61,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.20.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.38.0" }
+trusty-search = { path = "../trusty-search", version = "0.39.0" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [0.25.0] — 2026-07-23
+
 ### Added
 
 - **`session_naming::dedupe_by_ordinal`** (issue #3692): auto-suffix-on-collision

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.24.2"
+version = "0.25.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -14,7 +14,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.24.0", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.25.0", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -83,7 +83,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.24.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }
+trusty-common = { path = "../trusty-common", version = "0.25.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
@@ -166,7 +166,7 @@ serial_test = { workspace = true }
 # which is gated behind `embedder-test-support`. Re-declaring trusty-common here
 # with the feature activates it for all integration tests without enabling it in
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
-trusty-common = { path = "../trusty-common", version = "0.24.0", default-features = false, features = ["memory-core", "embedder-test-support"] }
+trusty-common = { path = "../trusty-common", version = "0.25.0", default-features = false, features = ["memory-core", "embedder-test-support"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [0.39.0] — 2026-07-23
+
 ### Changed
 
 - **Cost-scaled idle-eviction threshold + oldest-idle-first sweep ordering

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.38.1"
+version = "0.39.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -54,7 +54,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.24.1", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
+trusty-common = { version = "0.25.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
 
 # ── Bundled sidecars ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue


### PR DESCRIPTION
## Summary

Owner-authorized release carrying the complete #3683 eviction P1
(detached rehydrate + observable degrade, cost-scaled eviction + budgeted
pressure sweep, anon-RSS enforcement gate — slices 1-3, PRs #3690/#3709/#3712)
for the i-0076 EFS 408-storm/eviction-thrash fix.

- **trusty-common 0.24.2 -> 0.25.0** (minor, Added): new
  `Bm25Index::upsert_document_reporting` (#3684) consumed by trusty-search's
  rehydrate path, plus `session_naming::dedupe_by_ordinal` (#3692).
  trusty-search's code already calls the new method
  (`crates/trusty-search/src/core/indexer/idle_evict.rs`), so this sibling
  publish is required before trusty-search can publish against the live
  registry.
- **trusty-search 0.38.1 -> 0.39.0** (minor, Changed/Fixed): the full
  #3683 slice 1-3 payload — new env knobs
  (`TRUSTY_REHYDRATE_COST_SCALE_UNIT_MS`, `TRUSTY_MEMORY_PRESSURE_EXEMPT_IDLE_SECS`,
  `TRUSTY_MEMORY_ENFORCE_MEASURE`) and a new `meta.bm25_lane_degraded`
  response field.
- Bumped every workspace-internal path-dependency version pin on these two
  crates (root `workspace.dependencies`, trusty-gworkspace, trusty-memory,
  trusty-agents) so their caret requirements resolve against the new
  versions — otherwise `cargo check --workspace` fails to select a version.
- `make -C crates/trusty-search release-prep` rebuilt the UI bundle fresh
  (byte-identical output — no UI source changes this cycle, confirmed not
  stale).
- Both CHANGELOGs: `Unreleased` moved under a dated release heading
  (2026-07-23).

This also closes the CI "Publish-version parity" (#3366) drift currently
red at tip of main for both `trusty-common` and `trusty-search`.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-common -p trusty-search --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace --all-targets` (excluding two pre-existing-broken Tauri GUI crates unrelated to this change, verified broken identically on a clean `main` clone) — clean
- [x] `cargo test -p trusty-common` — 175 passed, 0 failed
- [x] `cargo test -p trusty-search` — 1293 + 314 + integration suites passed, 0 failed
- [ ] CI green on this PR

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools