### PR TITLE
fix(trusty-agents-ui): reap tagent sidecar on quit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11252,6 +11252,7 @@ name = "trusty-agents-ui"
 version = "0.16.1"
 dependencies = [
  "anyhow",
+ "libc",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
+++ b/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes are documented in this file.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+---
+## [Unreleased]
+
+### Fixed
+
+- **The `tagent --api` sidecar is now reaped on quit (#3372):** quitting the
+  desktop app (tray "Quit", Cmd+Q, app-menu Quit, or an AppleScript `quit`)
+  previously left the sidecar running and holding its fixed port, so repeated
+  GUI restarts accumulated orphaned processes and port conflicts. The
+  `RunEvent::ExitRequested` path no longer merely signals the child and returns
+  without awaiting the reap. Termination is now graceful-then-forced: a SIGTERM
+  lets the sidecar unbind its listener, and if it hasn't exited within a short
+  grace window it is SIGKILLed; either way the child is `wait`ed (reaped) before
+  the app actually exits, so no orphan survives a normal quit. An
+  already-exited child is handled without panicking. The new `terminate_child`
+  helper carries this logic and is unit-tested against real child processes
+  (no display server required).

--- a/crates/trusty-agents/ui/src-tauri/Cargo.toml
+++ b/crates/trusty-agents/ui/src-tauri/Cargo.toml
@@ -21,6 +21,14 @@ anyhow = "1"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 tracing = "0.1"
 
+[target.'cfg(unix)'.dependencies]
+# Graceful sidecar shutdown: tokio's `Child` only exposes `start_kill`
+# (SIGKILL). We send a SIGTERM first (via `libc::kill`) and fall back to
+# SIGKILL after a grace window, so the `tagent --api` sidecar gets a chance to
+# release its port cleanly on quit (#3372). Unix-only; the SIGTERM path is
+# `#[cfg(unix)]`-gated and non-unix targets go straight to `start_kill`.
+libc = { workspace = true }
+
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]

--- a/crates/trusty-agents/ui/src-tauri/src/main.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/main.rs
@@ -192,9 +192,18 @@ fn main() {
                         // proceed.
                     }
                     Err(_) => {
-                        // Lock contended by a concurrent
-                        // `ensure_api_server`/`kill_sidecar`. Defer and reap
-                        // via the shared path, which re-takes the lock itself.
+                        // Contended path: unlike the `Ok` arm, we cannot see
+                        // whether a child is present without the lock, so we
+                        // defer on *contention* — treating "someone is holding
+                        // the mutex" (a concurrent `ensure_api_server` /
+                        // `kill_sidecar`) as a proxy for "the child may be
+                        // mid-mutation, so play safe and reap via the shared
+                        // path", which re-takes the lock itself. If the slot
+                        // turns out to be empty, `kill_sidecar` is a no-op and
+                        // the subsequent `handle.exit(0)` re-raises
+                        // `ExitRequested` into the uncontended `Ok`/`None`
+                        // branch, which lets the process exit — so this cannot
+                        // loop indefinitely on transient contention.
                         api.prevent_exit();
                         let state = state.inner().clone();
                         let handle = app_handle.clone();

--- a/crates/trusty-agents/ui/src-tauri/src/main.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/main.rs
@@ -47,7 +47,9 @@ use overlay::{
     delete_personalization_overlay, list_personalization_overlays, read_personalization_overlay,
     write_personalization_overlay,
 };
-use sidecar::{ensure_api_server, kill_sidecar, ApiServerState, SharedApi};
+use sidecar::{
+    ensure_api_server, kill_sidecar, terminate_child, ApiServerState, SharedApi, SIDECAR_GRACE,
+};
 use task_commands::{cancel_task, check_health, list_tasks, send_message};
 
 /// Show and focus the main window (tray "Show" item / tray icon click).
@@ -150,27 +152,49 @@ fn main() {
 
     app.run(|app_handle, event| {
         if let RunEvent::ExitRequested { api, .. } = event {
-            // Real quit path: Cmd+Q or the app-menu Quit item (the tray
-            // "Quit" item already reaped the sidecar itself before calling
-            // `exit`, so this is a no-op in that case thanks to `take()`).
-            // We must not block this callback on the async mutex — the
-            // runtime checks for a pending `prevent_exit()` via a
-            // synchronous `try_recv()` immediately after this closure
-            // returns, so a bare fire-and-forget spawn here can lose the
-            // race and let the process exit before `kill_sidecar` runs.
-            // Try a non-blocking lock first (the common case); if it's
-            // contended, call `prevent_exit()` synchronously *before*
-            // returning, finish the kill asynchronously, then trigger the
-            // real exit ourselves once it's done — mirroring the tray
-            // "Quit" pattern above.
+            // Real quit path: Cmd+Q, the app-menu Quit item, or the tray
+            // "Quit" item (which reaps the sidecar itself, then calls
+            // `AppHandle::exit`, which re-raises `ExitRequested`).
+            //
+            // #3372: the previous fast path only called `child.start_kill()`
+            // and returned *without awaiting the reap* — and did no graceful
+            // shutdown — so the `tagent --api` sidecar could outlive the GUI
+            // and keep holding its fixed port. Graceful-then-forced
+            // termination is inherently async (SIGTERM, then wait up to a
+            // grace window, then SIGKILL), so whenever there is a child to
+            // reap we defer the real exit: call `prevent_exit()` synchronously
+            // *before* this closure returns (the runtime checks for a pending
+            // `prevent_exit` via a synchronous `try_recv()` immediately after
+            // this closure returns — a bare fire-and-forget spawn would lose
+            // that race and let the process exit first), reap the sidecar
+            // asynchronously, then trigger the real exit ourselves.
+            //
+            // Crucially we only defer when a child is actually present. Our own
+            // `handle.exit(0)` below re-raises `ExitRequested`; by then the
+            // child slot is empty (`take()`), so this branch does nothing and
+            // the process exits — which is what breaks the re-entrant loop.
             if let Some(state) = app_handle.try_state::<SharedApi>() {
                 match state.child.try_lock() {
                     Ok(mut guard) => {
-                        if let Some(mut child) = guard.take() {
-                            let _ = child.start_kill();
+                        if let Some(child) = guard.take() {
+                            // Release the lock before awaiting the (up to
+                            // `SIDECAR_GRACE`) termination.
+                            drop(guard);
+                            api.prevent_exit();
+                            let handle = app_handle.clone();
+                            tauri::async_runtime::spawn(async move {
+                                terminate_child(child, SIDECAR_GRACE).await;
+                                handle.exit(0);
+                            });
                         }
+                        // else: no child (already reaped by the tray "Quit"
+                        // path, or the re-entrant exit above) — let the exit
+                        // proceed.
                     }
                     Err(_) => {
+                        // Lock contended by a concurrent
+                        // `ensure_api_server`/`kill_sidecar`. Defer and reap
+                        // via the shared path, which re-takes the lock itself.
                         api.prevent_exit();
                         let state = state.inner().clone();
                         let handle = app_handle.clone();

--- a/crates/trusty-agents/ui/src-tauri/src/sidecar.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/sidecar.rs
@@ -11,7 +11,7 @@
 //! checks and API base URL).
 //! What: `ApiServerState`/`SharedApi`, `api_base`, `ensure_api_server`
 //! (Tauri command), `resolve_tagent_binary`, `sidecar_candidate_names`,
-//! `http_health`, `kill_sidecar`.
+//! `http_health`, `kill_sidecar`, `terminate_child`.
 //! Test: `cargo check` in `ui/src-tauri/`; the process-spawn/respawn logic
 //! itself isn't unit-testable without an actual `tagent` binary on disk (see
 //! the module-level doc in the original `main.rs` for prior manual test
@@ -24,11 +24,22 @@
 //! remove this whole resolution dance. Out of scope here; tracked as a
 //! follow-up, not fixed in this pass.
 
+use std::process::ExitStatus;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tauri::State;
 use tokio::process::Child;
 use tokio::sync::Mutex;
+
+/// How long we let the sidecar shut down gracefully after SIGTERM before we
+/// escalate to SIGKILL.
+///
+/// Why: `tagent --api` handles SIGTERM and releases its port cleanly, but a
+/// hung or wedged sidecar must not stall app quit indefinitely. Two seconds is
+/// long enough for a healthy sidecar to unbind its listener and short enough
+/// that a wedged one doesn't make quit feel broken during the demo.
+pub(crate) const SIDECAR_GRACE: Duration = Duration::from_secs(2);
 
 /// Shared handle to the spawned `trusty-agents --api` sidecar.
 ///
@@ -243,16 +254,69 @@ pub(crate) async fn http_health(port: u16) -> bool {
 /// `AppHandle::exit`, which raises a fresh `ExitRequested`). `guard.take()`
 /// empties the slot on first use, so a second caller finds `None` and is a
 /// safe no-op — no double-kill, no error.
-/// What: Locks `state.child`, takes the `Child` if present, sends it a kill
-/// signal and awaits reaping.
-/// Test: Manually — quit via the tray item, confirm the sidecar process
-/// exits (`ps` shows no `trusty-agents --api`); quit via Cmd+Q, same check.
+/// What: Locks `state.child`, takes the `Child` if present, and hands it to
+/// [`terminate_child`] for graceful-then-forced reaping. Releases the lock
+/// *before* awaiting termination so a concurrent `ensure_api_server` isn't
+/// blocked for the whole grace window.
+/// Test: `terminate_child` is unit-tested against real child processes (see
+/// the `tests` module); the quit wiring itself is smoke-tested manually —
+/// quit via the tray item / Cmd+Q and confirm `ps` shows no `tagent --api`.
 pub async fn kill_sidecar(state: &SharedApi) {
-    let mut guard = state.child.lock().await;
-    if let Some(mut child) = guard.take() {
-        let _ = child.start_kill();
-        let _ = child.wait().await;
+    // Take the child out under the lock, then drop the lock before awaiting so
+    // the (up to `SIDECAR_GRACE`) termination doesn't hold off other callers.
+    let child = {
+        let mut guard = state.child.lock().await;
+        guard.take()
+    };
+    if let Some(child) = child {
+        terminate_child(child, SIDECAR_GRACE).await;
     }
+}
+
+/// Terminate a sidecar child gracefully, escalating to SIGKILL after `grace`,
+/// and reap it so no zombie or orphan survives.
+///
+/// Why: `#3372` — the app quit path sent SIGKILL without awaiting the reap (or,
+/// on the fast path, never awaited at all), so the `tagent --api` sidecar could
+/// outlive the GUI and keep holding its fixed port. Repeated demo restarts then
+/// accumulated orphans and port conflicts. We now (1) send SIGTERM so the
+/// sidecar can unbind its listener cleanly, (2) wait up to `grace` for it to
+/// exit, and (3) SIGKILL + reap if it's still alive. An already-exited child is
+/// handled without panicking (`try_wait` reaps it and returns early).
+/// What: Consumes the `Child`. Returns the observed `ExitStatus`, or `None`
+/// only if the final reap itself errors (e.g. the child was already reaped
+/// elsewhere). Pure process lifecycle — no Tauri/window state — so it is
+/// unit-testable without a display server.
+/// Test: `terminate_child_reaps_running_process`,
+/// `terminate_child_handles_already_exited`.
+pub(crate) async fn terminate_child(mut child: Child, grace: Duration) -> Option<ExitStatus> {
+    // Already dead? Reap it (non-blocking) and we're done — no signal, no panic.
+    if let Ok(Some(status)) = child.try_wait() {
+        return Some(status);
+    }
+
+    // Graceful phase (unix): SIGTERM, then wait up to `grace` for a clean exit.
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        // SAFETY: `pid` names a child process we own and have not yet reaped;
+        // `SIGTERM` is a valid signal. `kill` has no memory-safety effects — a
+        // stale pid merely returns ESRCH, which we intentionally ignore.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+        if let Ok(Ok(status)) = tokio::time::timeout(grace, child.wait()).await {
+            return Some(status);
+        }
+        tracing::warn!(
+            pid,
+            ?grace,
+            "sidecar did not exit on SIGTERM within grace; sending SIGKILL"
+        );
+    }
+
+    // Force phase: SIGKILL and reap. Also the sole path on non-unix targets.
+    let _ = child.start_kill();
+    child.wait().await.ok()
 }
 
 #[cfg(test)]
@@ -311,6 +375,68 @@ mod tests {
         assert_eq!(
             resolved,
             std::path::PathBuf::from("/tmp/custom-tagent-build")
+        );
+    }
+
+    /// The #3372 regression guard: a running sidecar must actually be reaped by
+    /// `terminate_child`, not merely signalled-and-forgotten. We spawn a real
+    /// long-lived child (`sleep 300`), confirm it is alive, terminate it, and
+    /// assert (a) we get an `ExitStatus` back (proof the reap `wait` completed)
+    /// and (b) the OS no longer knows the pid — i.e. no orphan survives. Uses
+    /// real OS processes, so it needs no display server and runs in CI.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn terminate_child_reaps_running_process() {
+        let child = tokio::process::Command::new("sleep")
+            .arg("300")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id().expect("running child has a pid") as libc::pid_t;
+
+        // Sanity: the process is alive before we terminate it.
+        // SAFETY: signal 0 performs existence/permission checks only, no delivery.
+        assert_eq!(unsafe { libc::kill(pid, 0) }, 0, "child should be alive");
+
+        let status = terminate_child(child, SIDECAR_GRACE).await;
+        assert!(
+            status.is_some(),
+            "terminate_child must reap the child and yield an ExitStatus"
+        );
+
+        // The pid must be gone (reaped): kill(pid, 0) fails with ESRCH.
+        // SAFETY: signal 0, existence check only.
+        let rc = unsafe { libc::kill(pid, 0) };
+        assert_eq!(rc, -1, "reaped child's pid must no longer exist");
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH),
+            "kill on the reaped pid must fail with ESRCH (no such process)"
+        );
+    }
+
+    /// An already-exited child must be handled without panicking or hanging —
+    /// `terminate_child` should reap it via the fast `try_wait` path and return
+    /// its status rather than signalling a dead pid or blocking on `wait`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn terminate_child_handles_already_exited() {
+        let mut child = tokio::process::Command::new("true")
+            .spawn()
+            .expect("spawn true");
+        // Let it run to completion, but do NOT reap it here — leave that to
+        // `terminate_child` so we exercise the already-exited branch.
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) => break,
+                Ok(None) => tokio::time::sleep(Duration::from_millis(10)).await,
+                Err(e) => panic!("try_wait failed: {e}"),
+            }
+        }
+
+        let status = terminate_child(child, SIDECAR_GRACE).await;
+        assert!(
+            status.is_some(),
+            "an already-exited child must be reaped, not left hanging"
         );
     }
 }

--- a/crates/trusty-agents/ui/src-tauri/src/sidecar.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/sidecar.rs
@@ -424,11 +424,20 @@ mod tests {
             .spawn()
             .expect("spawn true");
         // Let it run to completion, but do NOT reap it here — leave that to
-        // `terminate_child` so we exercise the already-exited branch.
+        // `terminate_child` so we exercise the already-exited branch. Bound the
+        // wait with a hard deadline so a wedged `true` fails loudly instead of
+        // hanging the test runner (condition-based-waiting).
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
             match child.try_wait() {
                 Ok(Some(_)) => break,
-                Ok(None) => tokio::time::sleep(Duration::from_millis(10)).await,
+                Ok(None) => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "`true` did not exit within 5s"
+                    );
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
                 Err(e) => panic!("try_wait failed: {e}"),
             }
         }
@@ -437,6 +446,90 @@ mod tests {
         assert!(
             status.is_some(),
             "an already-exited child must be reaped, not left hanging"
+        );
+    }
+
+    /// Pins the SIGKILL-escalation branch: a child that *ignores* SIGTERM must
+    /// still be forcibly reaped after the grace window elapses. We spawn a
+    /// `python3` that installs `SIG_IGN` for SIGTERM and only then touches a
+    /// marker file — we wait for that marker before signalling, otherwise the
+    /// SIGTERM could race process startup and land before the handler is
+    /// installed (which would let the graceful phase succeed and never exercise
+    /// escalation). We assert (a) at least `grace` elapsed — proof we waited out
+    /// the graceful window rather than killing immediately, (b) the child died
+    /// from signal 9 (SIGKILL), and (c) its pid is gone. Skips cleanly if
+    /// `python3` isn't on PATH.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn terminate_child_escalates_to_sigkill_when_sigterm_ignored() {
+        use std::os::unix::process::ExitStatusExt;
+
+        // Unique marker path this child touches once its SIGTERM handler is in.
+        let marker = std::env::temp_dir().join(format!(
+            "trusty-3372-sigterm-ignore-{}-{}.marker",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock before epoch")
+                .as_nanos()
+        ));
+        // Best-effort clean slate in case a previous run left one behind.
+        let _ = std::fs::remove_file(&marker);
+
+        let spawn = tokio::process::Command::new("python3")
+            .arg("-c")
+            .arg(
+                "import signal,sys,time\n\
+                 signal.signal(signal.SIGTERM, signal.SIG_IGN)\n\
+                 open(sys.argv[1], 'w').close()\n\
+                 time.sleep(300)",
+            )
+            .arg(&marker)
+            .spawn();
+        let child = match spawn {
+            Ok(c) => c,
+            Err(_) => {
+                eprintln!("skipping: python3 not available on PATH");
+                return;
+            }
+        };
+        let pid = child.id().expect("running child has a pid") as libc::pid_t;
+
+        // Wait (bounded) until the child has installed its SIGTERM handler.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while !marker.exists() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child never signalled SIGTERM-handler readiness within 5s"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let grace = Duration::from_millis(200);
+        let start = std::time::Instant::now();
+        let status = terminate_child(child, grace).await;
+        let elapsed = start.elapsed();
+        let _ = std::fs::remove_file(&marker);
+
+        assert!(
+            elapsed >= grace,
+            "must wait out the full grace window before SIGKILL (elapsed {elapsed:?} < {grace:?})"
+        );
+        let status = status.expect("child must be reaped and yield an ExitStatus");
+        assert_eq!(
+            status.signal(),
+            Some(libc::SIGKILL),
+            "a SIGTERM-ignoring child must be killed by SIGKILL (signal 9)"
+        );
+
+        // The pid must be gone (reaped): kill(pid, 0) fails with ESRCH.
+        // SAFETY: signal 0, existence check only.
+        let rc = unsafe { libc::kill(pid, 0) };
+        assert_eq!(rc, -1, "reaped child's pid must no longer exist");
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH),
+            "kill on the reaped pid must fail with ESRCH (no such process)"
         );
     }
 }


### PR DESCRIPTION
## What & why

Fixes #3372 (P1 for the trusty-agents demo, milestone 18). The desktop app
(`Trusty Assistant.app`) spawns a `tagent --api` sidecar on startup but did
**not** reliably reap it on quit, so the sidecar kept running and holding its
fixed port. Repeated GUI restarts during the demo then accumulate orphaned
processes and cause port conflicts (a later launch may fail to bind or silently
attach to a stale backend).

## Root cause

In `main.rs`, the `RunEvent::ExitRequested` handler's fast path called
`child.start_kill()` and **returned without awaiting the reap**, and performed
no graceful shutdown — exactly the "does not fire / does not await the child's
termination" behavior the issue describes.

## Fix

New `terminate_child` helper (`sidecar.rs`) implements proper
graceful-then-forced lifecycle:

1. If the child already exited, reap it via `try_wait` — no signal, no panic.
2. Otherwise send **SIGTERM** (unix, `libc::kill`) so the sidecar can unbind its
   listener cleanly, then `wait` up to `SIDECAR_GRACE` (2s).
3. If still alive, escalate to **SIGKILL** (`start_kill`) and `wait` (reap).

Non-unix targets skip the `#[cfg(unix)]` SIGTERM phase and go straight to
`start_kill`. `kill_sidecar` (tray "Quit" path) now delegates to it.

The `ExitRequested` handler now defers the real exit
(`prevent_exit()` → async reap → `handle.exit(0)`) **only when a child is
actually present**. Deferring exclusively when there's something to reap is what
breaks the re-entrant `ExitRequested` loop that our own `handle.exit(0)` would
otherwise trigger.

## Tests

`terminate_child` is deliberately pure process-lifecycle logic (no Tauri/window
state), so it is unit-testable in CI without a display server, against real OS
processes:

- `terminate_child_reaps_running_process` — spawns `sleep 300`, terminates it,
  asserts an `ExitStatus` is returned **and** the pid is gone (`kill(pid, 0)`
  fails with `ESRCH`), i.e. no orphan survives.
- `terminate_child_handles_already_exited` — spawns `true`, lets it exit, and
  confirms `terminate_child` reaps it without panicking or hanging.

The Tauri window-manager event loop itself remains manually smoke-tested (quit
via tray "Quit" / Cmd+Q / AppleScript `quit`, confirm `ps` shows no
`tagent --api`) — it is not unit-testable from this crate.

## Verification (crate-scoped)

```
cargo fmt -p trusty-agents-ui -- --check   → clean (exit 0)
cargo check -p trusty-agents-ui            → Finished (2 pre-existing workspace warnings, unrelated)
cargo clippy -p trusty-agents-ui --all-targets -- -D warnings → clean
cargo test -p trusty-agents-ui             → test result: ok. 16 passed; 0 failed; 0 ignored
```

(Note: `trusty-agents-ui` is intentionally NOT in `default-members`; commands
are `-p`-scoped. `cargo check` needs a `crates/trusty-agents/ui/dist/index.html`
stub for `generate_context!()` — gitignored, same as CI's `agents-ui` job.)

## Changelog

Added an `## [Unreleased] → Fixed` entry to the new
`crates/trusty-agents/ui/src-tauri/CHANGELOG.md`.

Closes #3372. Part of epic #3052.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools