### PR TITLE
docs(trusty-memory): fix dangling test pointer left by #3731 fix round

### DIFF
--- a/crates/trusty-memory/src/attribution.rs
+++ b/crates/trusty-memory/src/attribution.rs
@@ -334,7 +334,7 @@ impl CreatorInfo {
     /// Test: `creator_info_renders_all_fields`,
     /// `creator_info_omits_cwd_when_absent`,
     /// `creator_info_renders_workstream_tags_when_resolvable`,
-    /// `creator_info_omits_workstream_tags_when_absent`.
+    /// `creator_info_omits_workstream_tags_when_absent_or_invalid`.
     pub fn into_tags(self) -> Vec<String> {
         let mut out = Vec::with_capacity(6);
         out.push(format!("{CREATOR_CLIENT_PREFIX}{}", self.client));


### PR DESCRIPTION
## Summary
- Fixes CI's "Test: doc-comment pointer lint" job on main, which is failing because `crates/trusty-memory/src/attribution.rs:334`'s `Test:` pointer cites the pre-rename `creator_info_omits_workstream_tags_when_absent` instead of the actual test `creator_info_omits_workstream_tags_when_absent_or_invalid`.
- Swept the rest of the file for other stale `Test:` pointers left by #3731's fix round — no other dangling citations found.

## Test plan
- [x] `scripts/check_test_pointers.sh` → `test-pointers: 0 dangling pointers — OK.`
- [x] `cargo test -p trusty-memory --lib attribution::` → 24 passed, 0 failed
- [x] `cargo fmt --check` → clean

Refs #3725

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools