### PR TITLE
docs(trusty-agents): reconcile #3469 agent-context self-identification record (date/time + location + self-id already shipped in #3461)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -9,6 +9,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Agent context knows "now", "here", and "who" (#3469, epic #3052):** the
+  `## User Context` block prefixed onto every tagent system prompt (PM, persona,
+  and ctrl turns) now carries three things the model previously had to guess at,
+  which matters for the weather / Metro-North tools that answer time- and
+  location-sensitive questions. (1) A per-turn, timezone-aware date/time line
+  with explicit day-of-week, rendered in the user's configured IANA zone via
+  `chrono-tz` (falling back to UTC and saying so when the zone is missing or
+  unparseable) — fixing the "hope your Sunday's going well" / "happy Monday!"
+  drift from a once-computed timestamp. (2) An optional, user-supplied
+  `location` profile field (`tagent config profile set --location`,
+  `TAGENT_USER_LOCATION`, or the first-run interview; no IP geolocation, no
+  inference from timezone, omitted entirely when unset). (3) An agent
+  self-identification sentence built from the SAME resolved values used for the
+  turn's real LLM dispatch (`creds.label()`, `agent.runner`, `agent.model`), so
+  the persona can no longer claim "Anthropic's API" while actually running via
+  OpenRouter. This change reconciles the self-identification decision-record
+  that had drifted out of sync after PR #3461 (whose body declared the line
+  descoped even though it shipped), documents the previously-undocumented
+  `AgentIdentity` carrier, and records the whole capability under its tracking
+  issue.
+
 - **Izzie weather + Metro-North tools land as real platform-hosted tools
   (epic #3052):** the `izzie-weather` and `izzie-metro-north` skills named
   three tools — `get_weather`, `get_train_schedule`, `get_train_alerts` — that

--- a/crates/trusty-agents/src/ctrl/config.rs
+++ b/crates/trusty-agents/src/ctrl/config.rs
@@ -114,6 +114,25 @@ pub(crate) fn resolve_overridden_credentials(
     }
 }
 
+/// The resolved agent/model/provider/runner quartet for one dispatch (#3469).
+///
+/// Why: The assistant persona once answered "What model and provider are you
+/// using?" with a confident *wrong* answer — claiming Anthropic's API while
+/// actually running `claude-opus-4-6` via OpenRouter. The harness already
+/// resolves these values for the turn's real LLM call (`creds.label()`,
+/// `agent.runner`, `agent.model`); bundling them into one borrowed struct lets
+/// `render_user_context_block` emit a self-identification line built from the
+/// SAME resolved values, so the injected sentence can never disagree with what
+/// is actually dispatching. This is introspection, not a hardcoded literal:
+/// every field is read from the live resolution, only the sentence template is
+/// fixed.
+/// What: Borrowed string slices for the agent name, model id, runner (the
+/// `Debug` form of `RunnerKind`), and provider label (`LlmCredentials::label()`).
+/// Purely a parameter bundle — carries no behavior of its own.
+/// Test: `render_user_context_block_includes_self_identification` asserts the
+/// rendered sentence names each field verbatim.
+// #3469: self-identification carrier — resolves the descope/re-scope drift from
+// PR #3461 by making the struct's own doc record match the shipped behavior.
 pub(crate) struct AgentIdentity<'a> {
     pub agent_name: &'a str,
     pub model: &'a str,
@@ -162,23 +181,27 @@ pub(crate) fn render_user_datetime(
     }
 }
 
-/// Render the `## User Context` block: user profile fields plus a fresh
-/// tz-aware date/time line (#3052 follow-up).
+/// Render the `## User Context` block: user profile fields, a fresh tz-aware
+/// date/time line, and an agent self-identification line (#3052 → #3469).
 ///
 /// Why: Split out of `build_user_context_prefix` so `ctrl_chat_turn`'s
 /// system-prompt assembly (which appends context AFTER the base prompt,
 /// rather than prefixing it) can reuse the exact same block instead of
 /// hand-rolling a second, drifted copy — the original defect this whole
-/// helper exists to prevent. Note: agent/model/provider self-identification
-/// is deliberately NOT part of this block — that's handled by dedicated
-/// self-inspection tools, not a literal injected into the prompt.
+/// helper exists to prevent. Self-identification (agent/model/provider/runner)
+/// IS part of this block, authorized by #3469: it is built from `identity`,
+/// whose fields are the SAME values resolved for the turn's real LLM dispatch,
+/// so the injected sentence can never disagree with what is actually running.
+/// (An earlier iteration of PR #3461 declared this line descoped; #3469
+/// re-scoped it and this doc now matches the shipped behavior — see the
+/// `AgentIdentity` doc for the full history.)
 /// What: Loads `UserProfile` fresh (so a `config profile set` mid-session
 /// takes effect on the very next turn); when a profile with a non-empty name
 /// exists, emits `user_name`/optional `email`/optional `timezone`/optional
 /// `location` lines (each omitted when unset — no placeholders, no
 /// guessing); otherwise emits `user_name = "(unknown)"`. Always appends a
-/// freshly-computed `render_user_datetime` line, regardless of profile
-/// state.
+/// freshly-computed `render_user_datetime` line, then the self-identification
+/// sentence, regardless of profile state.
 /// Test: `render_user_context_block_includes_location_when_set`,
 /// `render_user_context_block_omits_location_when_unset`,
 /// `render_user_context_block_unknown_user_still_gets_datetime`,
@@ -209,6 +232,8 @@ pub(crate) fn render_user_context_block(identity: &AgentIdentity<'_>) -> String 
         }
     }
     block.push('\n');
+    // #3469: self-identification from the resolved dispatch values, so the
+    // model can answer "what model/provider am I?" without guessing.
     block.push_str(&format!(
         "\nYou are running as agent '{}' on model {} via {} (runner: {}, trusty-agents v{}).\n",
         identity.agent_name,


### PR DESCRIPTION
## What this PR does

Closes #3469 by **reconciling the code's own record** with what already ships,
not by adding runtime behavior — because the behavior #3469 asks for is already
present on `main`.

### The situation (please read before reviewing as a feature PR)

Issue #3469 asks for three additions to the tagent `## User Context` block:

1. Per-turn, timezone-aware date/time with day-of-week.
2. An optional, user-supplied `location` profile field.
3. Agent self-identification built from the resolved dispatch values.

**All three already landed on `main` in PR #3461** (commit `3f294900`). PR
#3461's body declared self-identification "descoped by the owner," yet the
merged code contains it — the scope-reintroduction that #3469 was then filed
(35 min after #3461 merged) to formally re-scope and authorize. So the runtime
is done and tested:

- `render_user_datetime` + `render_user_context_block` render date/time and
  `location` per turn; location is wired through `config profile set/show
  --location`, `TAGENT_USER_LOCATION`, and the first-run interview.
- Self-identification is built from `AgentIdentity`, whose fields are the SAME
  values used for the turn's real LLM dispatch — `creds.label()`,
  `agent.runner`, `agent.model` — at all three call sites (`pm_task/dispatch/
  history.rs`, `pm_task/dispatch/persona.rs`, `ctrl_turn/mod.rs`). This is what
  fixes the "claimed Anthropic while actually on OpenRouter" defect.
- Tests already cover all three: `render_user_datetime_*`,
  `render_user_context_block_includes_location_when_set` /
  `_omits_location_when_unset` / `_unknown_user_still_gets_datetime` /
  `_includes_self_identification`, `from_env_reads_location`,
  `profile_round_trip_through_toml_with_location`.

### What was actually wrong

The **record** had drifted, not the behavior:

- `render_user_context_block`'s doc-comment claimed self-identification was
  "deliberately NOT part of this block" — contradicting the code directly below
  it and the authorizing issue. Rewritten to state self-id IS part of the
  block per #3469, sourced from the resolved dispatch values (introspection,
  not a hardcoded literal — only the sentence template is fixed).
- `AgentIdentity` had no `Why/What/Test` doc (CI doc-lint scopes to functions,
  so it slipped through; also #3473 item 2). Added.
- Added `// #3469:` provenance markers at the carrier and the render site.
- Added a CHANGELOG `[Unreleased]` entry recording the date/time + location +
  self-identification capability under its tracking issue — it was never
  recorded (neither #3461 nor #3469 appeared in the changelog).

### Sources (per the "introspection over injection" directive)

- **Date/time:** the system clock (`chrono::Utc::now()`), rendered in the user's
  configured IANA timezone via `chrono-tz`. Runtime data, never a literal.
- **Location:** real user config only — `~/.trusty-agents/user.toml`
  (`UserProfile.location`) / `TAGENT_USER_LOCATION` / first-run interview. No IP
  geolocation, no inference from timezone, omitted when unset.
- **Self-identification:** the resolved `creds.label()` / `agent.runner` /
  `agent.model` used for the same turn's dispatch, so the sentence can never
  disagree with what is actually running.

### Why type `docs`, not `feat`

There is no functional diff here — the feature shipped in #3461. Labeling this
`feat` would be inaccurate. If the reviewer/owner would rather just close #3469
as already-delivered and drop this PR, that is a reasonable alternative; this
PR exists to (a) make the codebase's decision-record internally consistent and
(b) get the capability into the CHANGELOG for the 2026-07-24 demo.

## Gates (raw)

- `cargo fmt --check` — clean (only nightly-feature warnings).
- `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean.
- `cargo test -p trusty-agents` — `2214 passed; 0 failed; 12 ignored` (unit
  binary) + all integration binaries green.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
