### PR TITLE
feat(trusty-agents-ui): per-message agent attribution + clearable recent tasks (#3737)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -30,6 +30,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `AgentIdentity` carrier, and records the whole capability under its tracking
   issue.
 
+- **Chat speaker attribution — `GET /api/agents` exposes `display_name`
+  (#3737, epic #3052):** the agents catalog now surfaces each agent's
+  `display_name` (read from the TOML `[agent].display_name`, empty for the
+  nameless base assistant) so the desktop GUI can label each assistant chat
+  bubble with the specific persona that produced it ("Izzie", "CTO Assistant")
+  instead of a generic "agent".
+
 - **Izzie weather + Metro-North tools land as real platform-hosted tools
   (epic #3052):** the `izzie-weather` and `izzie-metro-north` skills named
   three tools — `get_weather`, `get_train_schedule`, `get_train_alerts` — that

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -30,12 +30,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `AgentIdentity` carrier, and records the whole capability under its tracking
   issue.
 
-- **Chat speaker attribution — `GET /api/agents` exposes `display_name`
-  (#3737, epic #3052):** the agents catalog now surfaces each agent's
-  `display_name` (read from the TOML `[agent].display_name`, empty for the
-  nameless base assistant) so the desktop GUI can label each assistant chat
-  bubble with the specific persona that produced it ("Izzie", "CTO Assistant")
-  instead of a generic "agent".
+- **Chat speaker attribution reflects who ANSWERED (#3737, epic #3052):** two
+  API-layer additions so the desktop GUI can label each assistant chat bubble
+  with the specific persona that produced it ("Izzie", "CTO Assistant") instead
+  of a generic "agent". (1) `GET /api/agents` surfaces each agent's
+  `display_name` (from the TOML `[agent].display_name`; per the #3740 contract
+  it is never empty — a blank/absent value falls back to the agent name).
+  (2) `PmResponse` gains a `responder_agent` field: when a conversational/
+  research turn DELEGATES (e.g. base "Assistant" hands a weather question to
+  Izzie via `delegate_to_agent`), the server records the specialist that
+  actually answered — `delegate_to_agent` now emits `AgentSpawned` on a
+  successful delegation and `submit_task` captures the last such event for the
+  turn — so the GUI relabels the bubble to the responder rather than the caller.
+  `responder_agent` is omitted from the wire when no delegation fired, keeping
+  the common-case shape byte-identical.
 
 - **`DELETE /api/tasks` clears the finished-task history (#3737, epic
   #3052):** backs the GUI's "Recent tasks" Clear affordance. Removes only

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -37,6 +37,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   bubble with the specific persona that produced it ("Izzie", "CTO Assistant")
   instead of a generic "agent".
 
+- **`DELETE /api/tasks` clears the finished-task history (#3737, epic
+  #3052):** backs the GUI's "Recent tasks" Clear affordance. Removes only
+  terminal (success/error/partial/cancelled) tasks and leaves any still-running
+  task in place, re-persisting the trimmed snapshot to `tasks.json`.
+  Deliberately distinct from `POST /api/clear-context`, which additionally
+  aborts in-flight work — tidying the history list must not kill a running
+  task.
+
 - **Izzie weather + Metro-North tools land as real platform-hosted tools
   (epic #3052):** the `izzie-weather` and `izzie-metro-north` skills named
   three tools — `get_weather`, `get_train_schedule`, `get_train_alerts` — that

--- a/crates/trusty-agents/src/api/builder.rs
+++ b/crates/trusty-agents/src/api/builder.rs
@@ -104,6 +104,10 @@ pub fn build_from_workflow(
         out_dir: out_dir_str,
         errors,
         phases_completed,
+        // #3737: the subprocess workflow path carries no in-process delegation
+        // signal to attribute; the in-process chat path sets this in
+        // `api/server/handlers.rs::submit_task` instead.
+        responder_agent: None,
     }
 }
 

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -228,6 +228,48 @@ fn session_overrides_for(req: &TaskRequest) -> crate::ctrl::SessionOverrides {
     }
 }
 
+/// Drain already-buffered events and return the agent that last delegation
+/// handed the turn to, if any (#3737, per-message chat attribution).
+///
+/// Why: Chat attribution must reflect who ANSWERED, not who was asked. When a
+/// turn delegates (e.g. base "Assistant" hands a weather question to Izzie via
+/// `delegate_to_agent`), `delegate.rs` publishes `AgentSpawned { session_id,
+/// agent }` on the process event bus. The caller subscribes BEFORE running the
+/// turn, then calls this AFTER it returns to read back the last delegation
+/// target for this session — the substantive responder. `None` means no
+/// delegation fired, so the caller keeps the request-time speaker stamp.
+/// What: Non-blocking drain of `rx` via `try_recv` (all relevant events were
+/// published synchronously during the just-finished turn, so they are already
+/// buffered). Filters to `sid`; the LAST `AgentSpawned`/`PmDelegating` agent
+/// wins (multiple delegations → the final one answered). A `Lagged` receiver
+/// keeps draining its retained tail (a late `AgentSpawned` is among the most
+/// recent events); an exhausted/closed channel ends the drain.
+/// Test: `drain_last_responder_returns_last_delegated_agent`.
+fn drain_last_responder(
+    rx: &mut tokio::sync::broadcast::Receiver<Event>,
+    sid: &str,
+) -> Option<String> {
+    use tokio::sync::broadcast::error::TryRecvError;
+    let mut responder = None;
+    loop {
+        match rx.try_recv() {
+            Ok(ev) => {
+                if ev.session_id() == Some(sid) {
+                    match ev {
+                        Event::AgentSpawned { agent, .. } | Event::PmDelegating { agent, .. } => {
+                            responder = Some(agent);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Err(TryRecvError::Lagged(_)) => continue,
+            Err(TryRecvError::Empty) | Err(TryRecvError::Closed) => break,
+        }
+    }
+    responder
+}
+
 /// `POST /api/task` — kick off a workflow/agent/conversational run.
 ///
 /// Why: Single entry point the WebUI / CLI hit to submit work; the server
@@ -332,6 +374,11 @@ pub(super) async fn submit_task(
             };
 
             let join = tokio::spawn(async move {
+                // #3737: subscribe BEFORE running so a delegation's
+                // `AgentSpawned` event (published inside `delegate_to_agent`)
+                // is captured for responder attribution — reflecting who
+                // actually ANSWERED, not who was asked.
+                let mut ev_rx = crate::events::subscribe();
                 let result = if let Some(agent_name) = agent_bg {
                     crate::ctrl::run_pm_task_with_persona(
                         &project_path,
@@ -359,12 +406,18 @@ pub(super) async fn submit_task(
                     .await
                 };
 
+                // #3737: after the turn finishes, read back who (if anyone)
+                // it delegated to. `None` → the caller answered itself, so the
+                // GUI keeps its request-time speaker stamp.
+                let responder = drain_last_responder(&mut ev_rx, &id_bg);
+
                 let resp = match result {
                     Ok(content) => {
                         let mut r = PmResponse::running(&id_bg);
                         r.response_type = crate::api::types::PmResponseType::AgentResponse;
                         r.status = PmStatus::Success;
                         r.narrative = content;
+                        r.responder_agent = responder;
                         r
                     }
                     Err(e) => {
@@ -501,9 +554,10 @@ pub(super) struct ClearRecentTasksBody {
 pub(super) async fn clear_recent_tasks(
     State(state): State<AppState>,
 ) -> Json<ClearRecentTasksBody> {
-    let before = state.list().await.len();
-    let removed = state.clear_terminal_tasks().await;
-    let retained_running = before.saturating_sub(removed);
+    // Both counts come from a single lock guard inside `clear_terminal_tasks`
+    // so they can't disagree under a concurrent status transition (code-critic
+    // TOCTOU finding — was previously a separate `list()` + subtraction).
+    let (removed, retained_running) = state.clear_terminal_tasks().await;
     Json(ClearRecentTasksBody {
         cleared: true,
         removed,
@@ -594,6 +648,42 @@ mod tests {
             model_id: None,
             provider_id: None,
         }
+    }
+
+    /// #3737: `drain_last_responder` returns the LAST agent this session
+    /// delegated to (who actually answered), ignores other sessions' events,
+    /// and returns `None` when no delegation fired (the caller answered
+    /// itself, so the GUI keeps its request-time speaker stamp).
+    #[tokio::test]
+    async fn drain_last_responder_returns_last_delegated_agent() {
+        let sid = "responder-drain-test";
+        let mut rx = events::subscribe();
+
+        // A delegation to another session must be ignored.
+        events::publish(Event::AgentSpawned {
+            session_id: "some-other-session".to_string(),
+            agent: "not-me".to_string(),
+        });
+        // Two delegations for our session; the LAST one is the responder.
+        events::publish(Event::PmDelegating {
+            session_id: sid.to_string(),
+            agent: "engineer".to_string(),
+            task_preview: "first".to_string(),
+        });
+        events::publish(Event::AgentSpawned {
+            session_id: sid.to_string(),
+            agent: "izzie".to_string(),
+        });
+
+        assert_eq!(drain_last_responder(&mut rx, sid).as_deref(), Some("izzie"));
+
+        // With no delegation events, the responder is None.
+        let mut rx2 = events::subscribe();
+        events::publish(Event::PmThinking {
+            session_id: sid.to_string(),
+            text: "thinking".to_string(),
+        });
+        assert_eq!(drain_last_responder(&mut rx2, sid), None);
     }
 
     #[test]

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -473,6 +473,44 @@ pub(super) async fn list_tasks(State(state): State<AppState>) -> Json<Vec<PmResp
     Json(state.list().await)
 }
 
+/// Response body for `DELETE /api/tasks`.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct ClearRecentTasksBody {
+    cleared: bool,
+    /// Number of terminal (finished) tasks removed from the history.
+    removed: usize,
+    /// Number of still-running tasks left untouched (kept visible).
+    retained_running: usize,
+}
+
+/// `DELETE /api/tasks` — clear the finished-task history, keeping running
+/// tasks (#3737).
+///
+/// Why: The GUI's "Recent tasks" panel offers a "Clear" affordance. Unlike
+/// `POST /api/clear-context` (which aborts in-flight tasks and wipes the whole
+/// store), clearing the *history list* must not kill work that is still
+/// running — a user tidying the list should keep any in-flight task visible
+/// and cancellable. This deletes only terminal entries; because the task
+/// store persists to `.trusty-agents/state/tasks.json` and reloads on
+/// restart, the removal is written back so it sticks.
+/// What: Delegates to `AppState::clear_terminal_tasks`, then reports how many
+/// were removed and how many running tasks remain, so the client can refresh
+/// its list deterministically.
+/// Test: `clear_recent_tasks_removes_terminal_only` (route-level, in
+/// `super::tests`).
+pub(super) async fn clear_recent_tasks(
+    State(state): State<AppState>,
+) -> Json<ClearRecentTasksBody> {
+    let before = state.list().await.len();
+    let removed = state.clear_terminal_tasks().await;
+    let retained_running = before.saturating_sub(removed);
+    Json(ClearRecentTasksBody {
+        cleared: true,
+        removed,
+        retained_running,
+    })
+}
+
 /// Response body for `POST /api/clear-context`.
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct ClearContextBody {

--- a/crates/trusty-agents/src/api/server/projects.rs
+++ b/crates/trusty-agents/src/api/server/projects.rs
@@ -261,7 +261,7 @@ pub(super) async fn list_agents_route(State(_state): State<AppState>) -> Json<se
 /// `provider_id`, `description`, and `display_name` (each defaulting to `""`
 /// when absent). Returns `None` when `raw` fails to parse as TOML.
 /// Test: `scan_agents_dir_parses_toml`, `patch_agent_persists_model_and_round_trips`,
-/// `parse_agent_toml_surfaces_display_name`.
+/// `parse_agent_toml_surfaces_display_name`, `scan_agents_dir_exposes_display_name`.
 pub(super) fn parse_agent_toml(raw: &str, fallback_name: &str) -> Option<serde_json::Value> {
     let parsed: toml::Value = toml::from_str(raw).ok()?;
     let agent = parsed.get("agent");

--- a/crates/trusty-agents/src/api/server/projects.rs
+++ b/crates/trusty-agents/src/api/server/projects.rs
@@ -258,8 +258,11 @@ pub(super) async fn list_agents_route(State(_state): State<AppState>) -> Json<se
 /// two routes' response shapes from drifting apart.
 /// What: Parses `raw` as TOML; reads `[agent]`'s `name` (falling back to
 /// `fallback_name`, typically the file stem), `role`, `model`, `runner`,
-/// `provider_id`, `description`, and `display_name` (each defaulting to `""`
-/// when absent). Returns `None` when `raw` fails to parse as TOML.
+/// `provider_id`, and `description` (each defaulting to `""` when absent),
+/// plus `display_name` — which, per the shared cross-PR contract (#3740),
+/// is NEVER empty: a blank/absent/whitespace-only `display_name` falls back
+/// to the agent `name` rather than `""`. Returns `None` when `raw` fails to
+/// parse as TOML.
 /// Test: `scan_agents_dir_parses_toml`, `patch_agent_persists_model_and_round_trips`,
 /// `parse_agent_toml_surfaces_display_name`, `scan_agents_dir_exposes_display_name`.
 pub(super) fn parse_agent_toml(raw: &str, fallback_name: &str) -> Option<serde_json::Value> {
@@ -272,12 +275,17 @@ pub(super) fn parse_agent_toml(raw: &str, fallback_name: &str) -> Option<serde_j
             .map(str::to_string)
     };
     let name = get_str("name").unwrap_or_else(|| fallback_name.to_string());
-    // #3738: surface `display_name` ("Assistant" / "Izzie" / "CTO Bot") so the
-    // GUI's per-message speaker attribution reads the persona's human-facing
-    // label straight from the catalog. Falls back to `name` (matching
-    // `AgentInfo::display_label`'s contract) rather than "" so a consumer can
-    // always render SOME label without re-deriving the mapping client-side.
-    let display_name = get_str("display_name").unwrap_or_else(|| name.clone());
+    // #3738/#3739: surface `display_name` ("Assistant" / "Izzie" / "CTO Bot")
+    // so the GUI's per-message speaker attribution reads the persona's
+    // human-facing label straight from the catalog. Per the cross-PR contract
+    // (#3740) it is NEVER empty: falls back to `name` (matching
+    // `AgentInfo::display_label`'s contract) — and the `.filter(!empty)` guard
+    // (#3739) additionally treats a blank/whitespace-only value (e.g. a
+    // hand-edited manifest) as absent, so a consumer can always render SOME
+    // non-empty label without re-deriving the mapping client-side.
+    let display_name = get_str("display_name")
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| name.clone());
     Some(serde_json::json!({
         "name": name,
         "role": get_str("role").unwrap_or_default(),

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -30,7 +30,8 @@ use super::ctrl_sessions::{
 };
 use super::events_sse::events_handler;
 use super::handlers::{
-    clear_context, docs_search, get_session_recap, get_task, health, list_tasks, submit_task,
+    clear_context, clear_recent_tasks, docs_search, get_session_recap, get_task, health,
+    list_tasks, submit_task,
 };
 use super::models::get_models;
 use super::project_registration::{connect_project, get_project_config};
@@ -107,7 +108,10 @@ pub fn build_router_with_origins(
         // #3063: DELETE aborts an in-flight task (cancellation/retask
         // primitive — see `cancel::cancel_task` for the full contract).
         .route("/api/task/{id}", get(get_task).delete(cancel_task))
-        .route("/api/tasks", get(list_tasks))
+        // #3737: GET lists recent tasks; DELETE clears the finished-task
+        // history while keeping any still-running task (distinct from
+        // /api/clear-context, which also aborts in-flight work).
+        .route("/api/tasks", get(list_tasks).delete(clear_recent_tasks))
         .route("/api/clear-context", post(clear_context))
         .route("/api/health", get(health))
         .route("/api/config", config_route)

--- a/crates/trusty-agents/src/api/server/state.rs
+++ b/crates/trusty-agents/src/api/server/state.rs
@@ -347,7 +347,7 @@ impl AppState {
     }
 
     /// Clear terminal (non-`Running`) tasks, preserving any still in flight,
-    /// and return the count removed (#3737).
+    /// and return `(removed, retained_running)` (#3737).
     ///
     /// Why: The GUI's "Recent tasks" panel needs a "Clear" affordance that
     /// wipes the finished-task history without the collateral damage
@@ -364,11 +364,14 @@ impl AppState {
     /// their handle removed by `finalize_task`/`try_cancel` — but stay in
     /// lockstep defensively), re-persists the trimmed snapshot so the removal
     /// survives a restart (the store is reloaded from `tasks.json` on boot),
-    /// and returns how many were removed. Emits no events: nothing was
-    /// cancelled.
-    /// Test: `clear_terminal_tasks_removes_terminal_keeps_running`.
-    pub(super) async fn clear_terminal_tasks(&self) -> usize {
-        let (removed, snapshot) = {
+    /// and returns `(removed, retained_running)`. BOTH counts are computed
+    /// under the SINGLE lock guard so they are internally consistent — a prior
+    /// version derived `retained_running` from a separate `list()` call in the
+    /// handler, which could disagree under a concurrent status transition
+    /// (code-critic TOCTOU finding). Emits no events: nothing was cancelled.
+    /// Test: `clear_recent_tasks_removes_terminal_only`.
+    pub(super) async fn clear_terminal_tasks(&self) -> (usize, usize) {
+        let (removed, retained_running, snapshot) = {
             let mut store = self.inner.lock().await;
             let to_remove: Vec<String> = store
                 .responses
@@ -384,12 +387,15 @@ impl AppState {
                 responses, order, ..
             } = &mut *store;
             order.retain(|id| responses.contains_key(id));
-            (to_remove.len(), responses.clone())
+            // Only `Running` entries remain, so the retained count is simply
+            // what's left — computed here, under the same guard, so it can't
+            // race a concurrent finalize/cancel.
+            (to_remove.len(), responses.len(), responses.clone())
         };
         // Persist outside the lock — a restart reloads from tasks.json, so the
         // cleared list must be written back to actually stick.
         persist_tasks(&snapshot).await;
-        removed
+        (removed, retained_running)
     }
 }
 

--- a/crates/trusty-agents/src/api/server/state.rs
+++ b/crates/trusty-agents/src/api/server/state.rs
@@ -345,6 +345,52 @@ impl AppState {
         }
         cancelled
     }
+
+    /// Clear terminal (non-`Running`) tasks, preserving any still in flight,
+    /// and return the count removed (#3737).
+    ///
+    /// Why: The GUI's "Recent tasks" panel needs a "Clear" affordance that
+    /// wipes the finished-task history without the collateral damage
+    /// `clear_tasks` (`POST /api/clear-context`) inflicts — that one aborts
+    /// every running task and drops the whole store, which is the wrong
+    /// semantics for "clear the history list": a user tidying the list should
+    /// not thereby kill work that is still running. This retains `Running`
+    /// entries (and their abort handles) untouched so an in-flight task stays
+    /// visible and cancellable, and only drops rows that have reached a
+    /// terminal status (`Success`/`Failed`/`Partial`/`Cancelled`).
+    /// What: Removes every response whose status isn't `Running` from
+    /// `responses`, prunes `order` to match, drops any stray handles for
+    /// removed ids (there should be none — terminal tasks have already had
+    /// their handle removed by `finalize_task`/`try_cancel` — but stay in
+    /// lockstep defensively), re-persists the trimmed snapshot so the removal
+    /// survives a restart (the store is reloaded from `tasks.json` on boot),
+    /// and returns how many were removed. Emits no events: nothing was
+    /// cancelled.
+    /// Test: `clear_terminal_tasks_removes_terminal_keeps_running`.
+    pub(super) async fn clear_terminal_tasks(&self) -> usize {
+        let (removed, snapshot) = {
+            let mut store = self.inner.lock().await;
+            let to_remove: Vec<String> = store
+                .responses
+                .iter()
+                .filter(|(_, r)| r.status != PmStatus::Running)
+                .map(|(id, _)| id.clone())
+                .collect();
+            for id in &to_remove {
+                store.responses.remove(id);
+                store.handles.remove(id);
+            }
+            let TaskStore {
+                responses, order, ..
+            } = &mut *store;
+            order.retain(|id| responses.contains_key(id));
+            (to_remove.len(), responses.clone())
+        };
+        // Persist outside the lock — a restart reloads from tasks.json, so the
+        // cleared list must be written back to actually stick.
+        persist_tasks(&snapshot).await;
+        removed
+    }
 }
 
 /// In-memory task result store.

--- a/crates/trusty-agents/src/api/server/tests/cancel.rs
+++ b/crates/trusty-agents/src/api/server/tests/cancel.rs
@@ -171,7 +171,10 @@ async fn clear_recent_tasks_removes_terminal_only() {
     failed.status = PmStatus::Failed;
     state.upsert("done-fail".to_string(), failed).await;
     state
-        .upsert("still-running".to_string(), PmResponse::running("still-running"))
+        .upsert(
+            "still-running".to_string(),
+            PmResponse::running("still-running"),
+        )
         .await;
 
     let app = router(state.clone());

--- a/crates/trusty-agents/src/api/server/tests/cancel.rs
+++ b/crates/trusty-agents/src/api/server/tests/cancel.rs
@@ -154,6 +154,48 @@ async fn clear_context_now_aborts_running_task() {
     );
 }
 
+/// #3737: `DELETE /api/tasks` clears the finished-task history but must leave
+/// a still-running task in place (unlike `POST /api/clear-context`, which
+/// aborts and wipes everything). Verifies the route removes only terminal
+/// entries, keeps the running one visible, and reports accurate counts.
+#[tokio::test]
+async fn clear_recent_tasks_removes_terminal_only() {
+    let state = AppState::default();
+
+    // Two terminal tasks + one running placeholder (no background future — we
+    // only care that the running record survives, not about abort wiring).
+    let mut ok = PmResponse::running("done-ok");
+    ok.status = PmStatus::Success;
+    state.upsert("done-ok".to_string(), ok).await;
+    let mut failed = PmResponse::running("done-fail");
+    failed.status = PmStatus::Failed;
+    state.upsert("done-fail".to_string(), failed).await;
+    state
+        .upsert("still-running".to_string(), PmResponse::running("still-running"))
+        .await;
+
+    let app = router(state.clone());
+    let req = Request::builder()
+        .method(Method::DELETE)
+        .uri("/api/tasks")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(v["cleared"], true);
+    assert_eq!(v["removed"], 2);
+    assert_eq!(v["retained_running"], 1);
+
+    // Terminal tasks gone; the running one survives and is still listed.
+    assert!(state.get("done-ok").await.is_none());
+    assert!(state.get("done-fail").await.is_none());
+    let running = state.get("still-running").await.expect("running task kept");
+    assert_eq!(running.status, PmStatus::Running);
+    assert_eq!(state.list().await.len(), 1);
+}
+
 /// Regression test for the FIFO-eviction bug found in code review (#3063):
 /// `insert_and_trim` used to evict strictly by insertion order (index 0),
 /// so a long-running task submitted first and left running while

--- a/crates/trusty-agents/src/api/server/tests/listing.rs
+++ b/crates/trusty-agents/src/api/server/tests/listing.rs
@@ -50,9 +50,11 @@ async fn list_agents_returns_agents_envelope() {
 /// Why (#3737, per-message chat attribution, epic #3052): the GUI's agent
 /// roster labels each assistant chat bubble with the persona's `display_name`
 /// ("Izzie", "CTO Assistant"), so `GET /api/agents` must surface that field.
-/// A named agent carries its `display_name`; a nameless one (the base
-/// `assistant`) defaults to `""`, which the frontend renders as "Assistant".
-/// What: Writes one named + one nameless fixture, scans, asserts the field.
+/// A named agent carries its `display_name`; an agent WITHOUT one falls back
+/// to its `name` per the cross-PR contract (#3740) — `display_name` is never
+/// empty, so consumers always have a non-empty label to render.
+/// What: Writes one named + one display_name-less fixture, scans, asserts the
+/// field (present → verbatim; absent → the agent name).
 #[tokio::test]
 async fn scan_agents_dir_exposes_display_name() {
     let tmp = tempfile::tempdir().unwrap();
@@ -62,17 +64,17 @@ async fn scan_agents_dir_exposes_display_name() {
     )
     .unwrap();
     std::fs::write(
-        tmp.path().join("assistant.toml"),
-        "[agent]\nname = \"assistant\"\nrole = \"assistant\"\n",
+        tmp.path().join("engineer.toml"),
+        "[agent]\nname = \"engineer\"\nrole = \"engineer\"\n",
     )
     .unwrap();
 
     let agents = scan_agents_dir(tmp.path()).await;
-    // Sorted by name: assistant < izzie.
-    assert_eq!(agents[0]["name"], "assistant");
+    // Sorted by name: engineer < izzie.
+    assert_eq!(agents[0]["name"], "engineer");
     assert_eq!(
-        agents[0]["display_name"], "",
-        "nameless base agent must default display_name to empty"
+        agents[0]["display_name"], "engineer",
+        "an agent without display_name falls back to its name, never empty (#3740 contract)"
     );
     assert_eq!(agents[1]["name"], "izzie");
     assert_eq!(agents[1]["display_name"], "Izzie");

--- a/crates/trusty-agents/src/api/server/tests/listing.rs
+++ b/crates/trusty-agents/src/api/server/tests/listing.rs
@@ -47,6 +47,37 @@ async fn list_agents_returns_agents_envelope() {
     assert_eq!(arr[1]["runner"], "claude-code");
 }
 
+/// Why (#3737, per-message chat attribution, epic #3052): the GUI's agent
+/// roster labels each assistant chat bubble with the persona's `display_name`
+/// ("Izzie", "CTO Assistant"), so `GET /api/agents` must surface that field.
+/// A named agent carries its `display_name`; a nameless one (the base
+/// `assistant`) defaults to `""`, which the frontend renders as "Assistant".
+/// What: Writes one named + one nameless fixture, scans, asserts the field.
+#[tokio::test]
+async fn scan_agents_dir_exposes_display_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("izzie.toml"),
+        "[agent]\nname = \"izzie\"\nrole = \"assistant\"\ndisplay_name = \"Izzie\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("assistant.toml"),
+        "[agent]\nname = \"assistant\"\nrole = \"assistant\"\n",
+    )
+    .unwrap();
+
+    let agents = scan_agents_dir(tmp.path()).await;
+    // Sorted by name: assistant < izzie.
+    assert_eq!(agents[0]["name"], "assistant");
+    assert_eq!(
+        agents[0]["display_name"], "",
+        "nameless base agent must default display_name to empty"
+    );
+    assert_eq!(agents[1]["name"], "izzie");
+    assert_eq!(agents[1]["display_name"], "Izzie");
+}
+
 /// Why: When the agents directory is missing, the route must still
 /// return a valid empty envelope so the UI does not crash.
 /// What: Points scan at a nonexistent path, asserts empty vec.

--- a/crates/trusty-agents/src/api/types.rs
+++ b/crates/trusty-agents/src/api/types.rs
@@ -46,6 +46,24 @@ pub struct PmResponse {
     /// Test: `phase_progress_serializes_to_json`.
     #[serde(default)]
     pub phases_completed: Vec<PhaseProgress>,
+    /// #3737 (per-message chat attribution, epic #3052): the name of the
+    /// specialist agent that actually produced this answer, when the turn
+    /// delegated away from the caller. `None` for a turn the caller answered
+    /// itself (no delegation fired). Populated server-side from the session's
+    /// last `AgentSpawned`/`PmDelegating` event (`api/server/handlers.rs`).
+    ///
+    /// Why: chat attribution must reflect who ANSWERED, not who was asked —
+    /// e.g. base "Assistant" delegating a weather question to Izzie must label
+    /// the bubble "Izzie", not "Assistant". This carries the server-authoritative
+    /// responder identity so the GUI can overwrite its request-time speaker
+    /// stamp on `task-complete`. It is an agent NAME (roster id); the GUI maps
+    /// it to a display name via the `/api/agents` catalog.
+    /// What: `Option<String>`; `skip_serializing_if` keeps the wire shape
+    /// byte-identical to pre-#3737 for the common (no-delegation) case, and
+    /// `default` keeps deserializing older persisted `tasks.json` snapshots.
+    /// Test: `responder_agent_defaults_to_none_and_omits_when_absent`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub responder_agent: Option<String>,
 }
 
 /// One entry in the live progress stream returned by `GET /api/task/:id`.
@@ -161,6 +179,7 @@ impl PmResponse {
             out_dir: None,
             errors: Vec::new(),
             phases_completed: Vec::new(),
+            responder_agent: None,
         }
     }
 
@@ -179,6 +198,7 @@ impl PmResponse {
             out_dir: None,
             errors: vec![m],
             phases_completed: Vec::new(),
+            responder_agent: None,
         }
     }
 
@@ -206,6 +226,7 @@ impl PmResponse {
             out_dir: None,
             errors: Vec::new(),
             phases_completed: Vec::new(),
+            responder_agent: None,
         }
     }
 }
@@ -275,6 +296,33 @@ mod tests {
     fn pm_response_running_includes_empty_phases_completed() {
         let r = PmResponse::running("abc");
         assert!(r.phases_completed.is_empty());
+    }
+
+    /// #3737: `responder_agent` defaults to `None`, is OMITTED from the wire
+    /// when absent (so the common no-delegation case is byte-identical to the
+    /// pre-#3737 shape), and round-trips when present (the delegated case the
+    /// GUI reads to relabel a bubble to the agent that actually answered).
+    #[test]
+    fn responder_agent_defaults_to_none_and_omits_when_absent() {
+        let r = PmResponse::running("abc");
+        assert_eq!(r.responder_agent, None);
+        let j = serde_json::to_string(&r).unwrap();
+        assert!(
+            !j.contains("responder_agent"),
+            "absent responder must be omitted from the wire, got: {j}"
+        );
+
+        let mut delegated = PmResponse::running("abc");
+        delegated.responder_agent = Some("izzie".to_string());
+        let j2 = serde_json::to_string(&delegated).unwrap();
+        assert!(j2.contains("\"responder_agent\":\"izzie\""), "got: {j2}");
+        let back: PmResponse = serde_json::from_str(&j2).unwrap();
+        assert_eq!(back.responder_agent.as_deref(), Some("izzie"));
+
+        // An older snapshot without the field still deserializes.
+        let legacy = r#"{"id":"x","timestamp":"t","type":"task_submitted","status":"running","narrative":"","metadata":{"processing_time_ms":0,"total_tokens_in":0,"total_tokens_out":0,"cache_read_tokens":0,"cache_creation_tokens":0,"total_cost_usd":0.0,"model":null,"workflow":null,"build_number":null},"phases":[],"files_modified":[],"out_dir":null,"errors":[]}"#;
+        let parsed: PmResponse = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.responder_agent, None);
     }
 
     #[test]

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -336,7 +336,12 @@ pub async fn run_pm_task_with_history(
 
     let mut registry = ToolRegistry::new();
     registry.register(Arc::new(
-        DelegateToAgentTool::new(runner).with_config_dir(config_dir.clone()),
+        // #3737: thread the task's session id so a successful delegation emits
+        // `AgentSpawned` and the API server can attribute the answer to the
+        // specialist that produced it (chat-bubble responder attribution).
+        DelegateToAgentTool::new(runner)
+            .with_config_dir(config_dir.clone())
+            .with_session_id(sid.clone()),
     ));
     // #3052 PR B (lane 3): the opaque tm<->tcode bridge, distinct from lane 2
     // (`delegate_to_agent` above). RBAC-locked to deny ReadOnly + Analytics.

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -175,7 +175,6 @@ pub async fn run_pm_task_with_persona(
         persona_cfg.agent.model = m.clone();
     }
 
-    let _ = sid;
     let creds = resolve_overridden_credentials(&mut persona_cfg, overrides.provider.as_deref())?;
     let claude_cli_short_circuit = apply_credential_routing(&mut persona_cfg, &creds);
     tracing::info!(
@@ -241,7 +240,12 @@ pub async fn run_pm_task_with_persona(
             let runner: Arc<dyn AgentRunner> =
                 Arc::new(SubprocessAgentRunner::new().with_config_dir(Some(config_dir.clone())));
             registry.register(Arc::new(
-                DelegateToAgentTool::new(runner).with_config_dir(config_dir.clone()),
+                // #3737: thread the session id so a persona that delegates
+                // onward attributes the answer to the specialist that produced
+                // it (chat-bubble responder attribution).
+                DelegateToAgentTool::new(runner)
+                    .with_config_dir(config_dir.clone())
+                    .with_session_id(sid.clone()),
             ));
             registry.register(Arc::new(AddProjectTool));
             registry.register(Arc::new(ListProjectsTool));

--- a/crates/trusty-agents/src/tools/delegate.rs
+++ b/crates/trusty-agents/src/tools/delegate.rs
@@ -81,6 +81,23 @@ pub struct DelegateToAgentTool {
     /// `delegate_assistant_role_gate_allows_worker_role`,
     /// `delegate_assistant_role_gate_allows_peer_assistant_role`.
     allowed_target_roles: Option<Vec<String>>,
+    /// #3737 (per-message chat attribution, epic #3052): the id of the task
+    /// whose turn this tool is delegating within, used as the `session_id` on
+    /// the `AgentSpawned` event emitted on a successful delegation so the API
+    /// server can attribute the answer to the agent that actually produced it
+    /// (base "Assistant" delegating a weather question to Izzie → the bubble
+    /// reads "Izzie", not "Assistant").
+    ///
+    /// Why: `AgentSpawned`/`PmDelegating` were previously defined and consumed
+    /// (REPL display) but never emitted in the in-process dispatch path, so
+    /// there was no server-authoritative signal of WHO answered a delegated
+    /// turn. Emitting from this single shared delegation choke point makes the
+    /// signal real for every caller that opts in via `with_session_id`.
+    /// `None` (every existing caller / test) emits nothing — behavior is
+    /// byte-identical to before this field existed.
+    /// What: See `with_session_id`.
+    /// Test: `delegate_emits_agent_spawned_with_session_id`.
+    session_id: Option<String>,
 }
 
 impl DelegateToAgentTool {
@@ -98,7 +115,31 @@ impl DelegateToAgentTool {
             runner,
             config_dirs: Vec::new(),
             allowed_target_roles: None,
+            session_id: None,
         }
+    }
+
+    /// Attach the current task's session id so a successful delegation emits
+    /// an `AgentSpawned` event the API server can attribute the answer to
+    /// (#3737).
+    ///
+    /// Why: The in-process chat dispatch (`run_pm_task_with_history` /
+    /// `run_pm_task_with_persona`) knows the task's `session_id`; threading it
+    /// into this tool lets the tool publish `AgentSpawned { session_id, agent }`
+    /// the moment it hands work to a specialist, which `submit_task`'s event
+    /// listener captures as the turn's `responder_agent`. Without it there is
+    /// no server-side record of who actually answered a delegated turn.
+    /// What: Stores `sid`. A blank string is treated as unset (no emit).
+    /// Test: `delegate_emits_agent_spawned_with_session_id`,
+    /// `session_id_gate_normalizes_blank_to_none`.
+    pub fn with_session_id(mut self, sid: impl Into<String>) -> Self {
+        let sid = sid.into();
+        self.session_id = if sid.trim().is_empty() {
+            None
+        } else {
+            Some(sid)
+        };
+        self
     }
 
     /// Attach a SINGLE agent config directory used for pre-flight
@@ -293,7 +334,22 @@ impl ToolExecutor for DelegateToAgentTool {
         let final_task = crate::agents::persona::assemble_task_with_context(agent_name, task);
         match self.runner.run(agent_name, &final_task).await {
             // PM gets the full content (it may want to inspect code sections).
-            Ok(out) => ToolResult::ok(out.content),
+            Ok(out) => {
+                // #3737: a successful delegation is the server-authoritative
+                // record of who actually answered this turn. Emit `AgentSpawned`
+                // (only when a session id was threaded in) so `submit_task`'s
+                // listener captures `agent_name` as the turn's `responder_agent`
+                // and the GUI can relabel the bubble accordingly. Emitting on
+                // success (not on dispatch) means a delegation that errored and
+                // was then answered by the caller itself does not mis-attribute.
+                if let Some(sid) = self.session_id.as_deref() {
+                    crate::events::publish(crate::events::Event::AgentSpawned {
+                        session_id: sid.to_string(),
+                        agent: agent_name.to_string(),
+                    });
+                }
+                ToolResult::ok(out.content)
+            }
             Err(e) => {
                 // #3555 delegate-resolve follow-up: log the full error chain
                 // at debug so a spawn/resolution failure is diagnosable
@@ -313,451 +369,5 @@ impl ToolExecutor for DelegateToAgentTool {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use anyhow::Result;
-    use async_trait::async_trait;
-    use serde_json::json;
-
-    use super::DelegateToAgentTool;
-    use crate::perf::TokenUsage;
-    use crate::tools::traits::{AgentOutput, AgentRunner, ToolExecutor};
-
-    /// Mock runner that records whether it was invoked and with what args.
-    struct RecordingRunner {
-        invoked: std::sync::Mutex<Vec<(String, String)>>,
-    }
-
-    #[async_trait]
-    impl AgentRunner for RecordingRunner {
-        async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
-            self.invoked
-                .lock()
-                .unwrap()
-                .push((agent_name.to_string(), task.to_string()));
-            Ok(AgentOutput {
-                content: "ok".into(),
-                summary: None,
-                usage: TokenUsage::default(),
-            })
-        }
-    }
-
-    /// #3052 PR A code-critic CRITICAL-2 regression guard: calling
-    /// `delegate_to_agent` with an unknown agent name (e.g. the hallucinated
-    /// `code-searcher` from #204) must return a GENERIC error — it must
-    /// echo back the caller's OWN rejected input, but it must NOT enumerate
-    /// the on-disk agent roster, name any bundled agent filename, or leak
-    /// any internal trusty-* system/daemon name. This tool is reachable
-    /// from black-boxed assistant-tier personas (`assistant`, `izzie`,
-    /// `cto-assistant`), so its own error text must be as safe to surface
-    /// to a user as the persona prompt that calls it — the seeded config
-    /// dir intentionally includes names spanning the full roster (workers,
-    /// meta/infra agents, and internal system terms) so this test would
-    /// catch a regression regardless of which category leaked.
-    #[tokio::test]
-    async fn unknown_agent_is_rejected_without_naming_the_agent_or_roster() {
-        let tmp = tempfile::tempdir().unwrap();
-        // Seed a realistic roster — worker + meta/infra agent names — so a
-        // regression that reintroduces roster enumeration is caught no
-        // matter which name it would have leaked.
-        for name in [
-            "engineer",
-            "python-engineer",
-            "qa-agent",
-            "research-agent",
-            "docs-agent",
-            "local-ops-agent",
-            "plan-agent",
-            "ctrl",
-            "pm",
-            "postmortem-agent",
-        ] {
-            std::fs::write(
-                tmp.path().join(format!("{name}.toml")),
-                format!("[agent]\nname = \"{name}\"\n"),
-            )
-            .unwrap();
-        }
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool =
-            DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "code-searcher",
-                "task": "find the intent classifier"
-            }))
-            .await;
-
-        assert!(result.is_error(), "must reject unknown agent");
-        let msg = result.content();
-        assert!(
-            msg.contains("code-searcher"),
-            "error may echo back the caller's own rejected input, got: {msg}"
-        );
-        // No roster enumeration: none of the seeded agent names may leak,
-        // regardless of whether they're workers or meta/infra agents.
-        for leaked in [
-            "engineer",
-            "python-engineer",
-            "qa-agent",
-            "research-agent",
-            "docs-agent",
-            "local-ops-agent",
-            "plan-agent",
-            "ctrl",
-            "postmortem-agent",
-        ] {
-            assert!(
-                !msg.contains(leaked),
-                "error must NOT enumerate the on-disk roster (found '{leaked}'), got: {msg}"
-            );
-        }
-        // No internal system/daemon names either.
-        for leaked in ["trusty-mpm", "trusty-code", "tcode", "subprocess"] {
-            assert!(
-                !msg.to_lowercase().contains(&leaked.to_lowercase()),
-                "error must NOT leak internal system name '{leaked}', got: {msg}"
-            );
-        }
-        assert!(
-            msg.contains("native tools") && msg.contains("search_code"),
-            "error must clarify native-vs-agent distinction, got: {msg}"
-        );
-        // Crucially, the runner must NOT have been invoked — no subprocess spawn.
-        assert!(
-            runner.invoked.lock().unwrap().is_empty(),
-            "runner must not be called when validation fails"
-        );
-    }
-
-    /// A valid agent name passes validation and reaches the runner.
-    #[tokio::test]
-    async fn known_agent_reaches_runner() {
-        let tmp = tempfile::tempdir().unwrap();
-        std::fs::write(
-            tmp.path().join("engineer.toml"),
-            "[agent]\nname = \"engineer\"\n",
-        )
-        .unwrap();
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool =
-            DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "engineer",
-                "task": "do the thing"
-            }))
-            .await;
-
-        assert!(
-            !result.is_error(),
-            "valid agent should succeed: {}",
-            result.content()
-        );
-        let invoked = runner.invoked.lock().unwrap();
-        assert_eq!(invoked.len(), 1, "runner should be called exactly once");
-        assert_eq!(invoked[0].0, "engineer");
-    }
-
-    /// Without `with_config_dir` (legacy callers), validation is skipped —
-    /// the runner is invoked unchanged. This preserves backward compatibility
-    /// with `main.rs:1901` and any test double that constructs the tool
-    /// without a config dir.
-    #[tokio::test]
-    async fn no_config_dir_skips_validation() {
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone());
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "anything-goes",
-                "task": "do the thing"
-            }))
-            .await;
-
-        assert!(!result.is_error(), "legacy mode should bypass validation");
-        assert_eq!(runner.invoked.lock().unwrap().len(), 1);
-    }
-
-    /// #3555 delegate-resolve regression guard: the primary use case this
-    /// fix targets — an assistant launched from a CWD with NO local
-    /// `.trusty-agents/agents/` (empty tempdir, standing in for e.g. a bare
-    /// worktree root) must still successfully delegate to a bundled worker
-    /// agent that only exists in the SECONDARY tier (standing in for
-    /// `$HOME/.trusty-agents/agents/`, populated by
-    /// `agents::bundled::ensure_bundled_agents_deployed`). Before the fix,
-    /// `DelegateToAgentTool` only ever checked a single directory, so this
-    /// would have rejected the call before the runner was ever invoked —
-    /// exactly the reported symptom (`is_error=true`, no `engineer` spawn).
-    #[tokio::test]
-    async fn delegate_resolves_agent_from_secondary_config_dir() {
-        let empty_primary = tempfile::tempdir().unwrap();
-        let secondary = tempfile::tempdir().unwrap();
-        std::fs::write(
-            secondary.path().join("engineer.toml"),
-            "[agent]\nname = \"engineer\"\n",
-        )
-        .unwrap();
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone()).with_config_dirs(vec![
-            empty_primary.path().to_path_buf(),
-            secondary.path().to_path_buf(),
-        ]);
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "engineer",
-                "task": "run cargo check and report back"
-            }))
-            .await;
-
-        assert!(
-            !result.is_error(),
-            "agent present only in the secondary (fallback) tier must still resolve: {}",
-            result.content()
-        );
-        let invoked = runner.invoked.lock().unwrap();
-        assert_eq!(invoked.len(), 1, "runner should be called exactly once");
-        assert_eq!(invoked[0].0, "engineer");
-    }
-
-    /// The multi-tier counterpart to
-    /// `unknown_agent_is_rejected_without_naming_the_agent_or_roster`: when
-    /// an agent name is absent from EVERY candidate directory, validation
-    /// still rejects before the runner is invoked.
-    #[tokio::test]
-    async fn delegate_rejects_agent_absent_from_all_config_dirs() {
-        let primary = tempfile::tempdir().unwrap();
-        let secondary = tempfile::tempdir().unwrap();
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone()).with_config_dirs(vec![
-            primary.path().to_path_buf(),
-            secondary.path().to_path_buf(),
-        ]);
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "nonexistent-agent",
-                "task": "do the thing"
-            }))
-            .await;
-
-        assert!(result.is_error(), "must reject an agent absent everywhere");
-        assert!(runner.invoked.lock().unwrap().is_empty());
-    }
-
-    /// Writes a minimal, fully-parseable agent TOML with the given `role` —
-    /// the shape `AgentConfig::by_name_in` (used by the role gate) actually
-    /// requires, unlike the bare `[agent]\nname = "..."` fixtures the
-    /// existence-only tests above use (those never parse the file).
-    fn write_agent_toml_with_role(dir: &std::path::Path, name: &str, role: &str) {
-        std::fs::write(
-            dir.join(format!("{name}.toml")),
-            format!(
-                r#"
-[agent]
-name = "{name}"
-role = "{role}"
-model = "anthropic/claude-sonnet-4-6"
-description = "test fixture"
-
-[llm]
-temperature = 0.2
-max_tokens = 1024
-
-[system_prompt]
-content = "test"
-"#
-            ),
-        )
-        .unwrap();
-    }
-
-    /// #3555 CRITICAL follow-up (code-critic): privilege escalation via
-    /// unrestricted delegation target. Widening `config_dirs` to include the
-    /// `$HOME` fallback tier makes the FULL bundled roster resolvable from
-    /// any cwd — including `pm` (role `orchestrator`). Without a role gate,
-    /// an assistant-tier `delegate_to_agent(agent_name="pm")` would pass
-    /// validation and spawn a subprocess with `run_subagent`'s UNRESTRICTED
-    /// orchestrator registry (shell, write_file, unrestricted
-    /// delegate_to_agent) — an escalation straight out of the sandboxed
-    /// assistant. This test proves the role gate rejects it before the
-    /// runner is ever invoked, with the SAME generic error text (no role
-    /// taxonomy leak).
-    #[tokio::test]
-    async fn delegate_assistant_role_gate_rejects_orchestrator_role() {
-        let dir = tempfile::tempdir().unwrap();
-        write_agent_toml_with_role(dir.path(), "pm", "orchestrator");
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone())
-            .with_config_dirs(vec![dir.path().to_path_buf()])
-            .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "pm",
-                "task": "do orchestrator-tier things"
-            }))
-            .await;
-
-        assert!(
-            result.is_error(),
-            "role gate must reject a resolvable but disallowed-role target"
-        );
-        assert!(
-            result.content().contains("pm"),
-            "error may echo back the caller's own rejected input, got: {}",
-            result.content()
-        );
-        assert!(
-            !result.content().to_lowercase().contains("orchestrator"),
-            "error must not leak the target's actual role, got: {}",
-            result.content()
-        );
-        assert!(
-            runner.invoked.lock().unwrap().is_empty(),
-            "runner must not be called when the role gate rejects"
-        );
-    }
-
-    /// Sibling to `delegate_assistant_role_gate_rejects_orchestrator_role`
-    /// for `ctrl` (role `controller`) — the other privileged meta-agent
-    /// named in the CRITICAL finding.
-    #[tokio::test]
-    async fn delegate_assistant_role_gate_rejects_controller_role() {
-        let dir = tempfile::tempdir().unwrap();
-        write_agent_toml_with_role(dir.path(), "ctrl", "controller");
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone())
-            .with_config_dirs(vec![dir.path().to_path_buf()])
-            .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "ctrl",
-                "task": "do controller-tier things"
-            }))
-            .await;
-
-        assert!(result.is_error(), "role gate must reject role=controller");
-        assert!(runner.invoked.lock().unwrap().is_empty());
-    }
-
-    /// The positive case: a worker role (`engineer`) IS in the allowlist and
-    /// must still reach the runner — the role gate must not become a
-    /// blanket denial.
-    #[tokio::test]
-    async fn delegate_assistant_role_gate_allows_worker_role() {
-        let dir = tempfile::tempdir().unwrap();
-        write_agent_toml_with_role(dir.path(), "engineer", "engineer");
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone())
-            .with_config_dirs(vec![dir.path().to_path_buf()])
-            .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "engineer",
-                "task": "run cargo check"
-            }))
-            .await;
-
-        assert!(
-            !result.is_error(),
-            "worker role must pass the gate: {}",
-            result.content()
-        );
-        assert_eq!(runner.invoked.lock().unwrap().len(), 1);
-    }
-
-    /// The other positive case: a PEER assistant (role `assistant`, e.g.
-    /// `cto-assistant`) must still reach the runner — this is the
-    /// Izzie <-> cto-assistant peer-consult lane the role gate must
-    /// preserve. Spawning a peer is safe because IT ALSO gets routed
-    /// through the restricted assistant-tier registry, never an
-    /// unrestricted one.
-    #[tokio::test]
-    async fn delegate_assistant_role_gate_allows_peer_assistant_role() {
-        let dir = tempfile::tempdir().unwrap();
-        write_agent_toml_with_role(dir.path(), "cto-assistant", "assistant");
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone())
-            .with_config_dirs(vec![dir.path().to_path_buf()])
-            .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "cto-assistant",
-                "task": "consult on architecture"
-            }))
-            .await;
-
-        assert!(
-            !result.is_error(),
-            "peer assistant role must pass the gate: {}",
-            result.content()
-        );
-        assert_eq!(runner.invoked.lock().unwrap().len(), 1);
-    }
-
-    /// Without `with_allowed_target_roles` (pm/ctrl callers), the role gate
-    /// is a no-op — the existing existence-only check still governs, and a
-    /// name resolving to ANY role (including `orchestrator`/`controller`)
-    /// reaches the runner. Pins that widening the assistant tier's gate did
-    /// NOT change pm/ctrl's own delegation behavior.
-    #[tokio::test]
-    async fn delegate_without_role_gate_allows_any_resolvable_role() {
-        let dir = tempfile::tempdir().unwrap();
-        write_agent_toml_with_role(dir.path(), "pm", "orchestrator");
-
-        let runner = Arc::new(RecordingRunner {
-            invoked: std::sync::Mutex::new(Vec::new()),
-        });
-        let tool = DelegateToAgentTool::new(runner.clone())
-            .with_config_dirs(vec![dir.path().to_path_buf()]);
-
-        let result = tool
-            .execute(json!({
-                "agent_name": "pm",
-                "task": "do orchestrator-tier things"
-            }))
-            .await;
-
-        assert!(
-            !result.is_error(),
-            "pm/ctrl callers (no role gate) must be unaffected: {}",
-            result.content()
-        );
-        assert_eq!(runner.invoked.lock().unwrap().len(), 1);
-    }
-}
+#[path = "delegate_tests.rs"]
+mod tests;

--- a/crates/trusty-agents/src/tools/delegate_tests.rs
+++ b/crates/trusty-agents/src/tools/delegate_tests.rs
@@ -1,0 +1,520 @@
+//! Unit tests for the `delegate_to_agent` tool (`super::delegate`).
+//!
+//! Why: split out of `delegate.rs` so that module stays under the 500-SLOC
+//! production cap — the #3737 `AgentSpawned`-emit + session-id-gate additions
+//! pushed the combined file over. Moved verbatim; `super::*` / `super::` still
+//! resolve to the `delegate` module since `#[path]` does not change the module
+//! hierarchy (mirrors the sibling `izzie/*_tests.rs` split idiom).
+//! Test: this file IS the test module for `delegate`.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::json;
+
+use super::DelegateToAgentTool;
+use crate::perf::TokenUsage;
+use crate::tools::traits::{AgentOutput, AgentRunner, ToolExecutor};
+
+/// Mock runner that records whether it was invoked and with what args.
+struct RecordingRunner {
+    invoked: std::sync::Mutex<Vec<(String, String)>>,
+}
+
+#[async_trait]
+impl AgentRunner for RecordingRunner {
+    async fn run(&self, agent_name: &str, task: &str) -> Result<AgentOutput> {
+        self.invoked
+            .lock()
+            .unwrap()
+            .push((agent_name.to_string(), task.to_string()));
+        Ok(AgentOutput {
+            content: "ok".into(),
+            summary: None,
+            usage: TokenUsage::default(),
+        })
+    }
+}
+
+/// #3052 PR A code-critic CRITICAL-2 regression guard: calling
+/// `delegate_to_agent` with an unknown agent name (e.g. the hallucinated
+/// `code-searcher` from #204) must return a GENERIC error — it must
+/// echo back the caller's OWN rejected input, but it must NOT enumerate
+/// the on-disk agent roster, name any bundled agent filename, or leak
+/// any internal trusty-* system/daemon name. This tool is reachable
+/// from black-boxed assistant-tier personas (`assistant`, `izzie`,
+/// `cto-assistant`), so its own error text must be as safe to surface
+/// to a user as the persona prompt that calls it — the seeded config
+/// dir intentionally includes names spanning the full roster (workers,
+/// meta/infra agents, and internal system terms) so this test would
+/// catch a regression regardless of which category leaked.
+#[tokio::test]
+async fn unknown_agent_is_rejected_without_naming_the_agent_or_roster() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Seed a realistic roster — worker + meta/infra agent names — so a
+    // regression that reintroduces roster enumeration is caught no
+    // matter which name it would have leaked.
+    for name in [
+        "engineer",
+        "python-engineer",
+        "qa-agent",
+        "research-agent",
+        "docs-agent",
+        "local-ops-agent",
+        "plan-agent",
+        "ctrl",
+        "pm",
+        "postmortem-agent",
+    ] {
+        std::fs::write(
+            tmp.path().join(format!("{name}.toml")),
+            format!("[agent]\nname = \"{name}\"\n"),
+        )
+        .unwrap();
+    }
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "code-searcher",
+            "task": "find the intent classifier"
+        }))
+        .await;
+
+    assert!(result.is_error(), "must reject unknown agent");
+    let msg = result.content();
+    assert!(
+        msg.contains("code-searcher"),
+        "error may echo back the caller's own rejected input, got: {msg}"
+    );
+    // No roster enumeration: none of the seeded agent names may leak,
+    // regardless of whether they're workers or meta/infra agents.
+    for leaked in [
+        "engineer",
+        "python-engineer",
+        "qa-agent",
+        "research-agent",
+        "docs-agent",
+        "local-ops-agent",
+        "plan-agent",
+        "ctrl",
+        "postmortem-agent",
+    ] {
+        assert!(
+            !msg.contains(leaked),
+            "error must NOT enumerate the on-disk roster (found '{leaked}'), got: {msg}"
+        );
+    }
+    // No internal system/daemon names either.
+    for leaked in ["trusty-mpm", "trusty-code", "tcode", "subprocess"] {
+        assert!(
+            !msg.to_lowercase().contains(&leaked.to_lowercase()),
+            "error must NOT leak internal system name '{leaked}', got: {msg}"
+        );
+    }
+    assert!(
+        msg.contains("native tools") && msg.contains("search_code"),
+        "error must clarify native-vs-agent distinction, got: {msg}"
+    );
+    // Crucially, the runner must NOT have been invoked — no subprocess spawn.
+    assert!(
+        runner.invoked.lock().unwrap().is_empty(),
+        "runner must not be called when validation fails"
+    );
+}
+
+/// A valid agent name passes validation and reaches the runner.
+#[tokio::test]
+async fn known_agent_reaches_runner() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("engineer.toml"),
+        "[agent]\nname = \"engineer\"\n",
+    )
+    .unwrap();
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone()).with_config_dir(tmp.path().to_path_buf());
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "engineer",
+            "task": "do the thing"
+        }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "valid agent should succeed: {}",
+        result.content()
+    );
+    let invoked = runner.invoked.lock().unwrap();
+    assert_eq!(invoked.len(), 1, "runner should be called exactly once");
+    assert_eq!(invoked[0].0, "engineer");
+}
+
+/// Without `with_config_dir` (legacy callers), validation is skipped —
+/// the runner is invoked unchanged. This preserves backward compatibility
+/// with `main.rs:1901` and any test double that constructs the tool
+/// without a config dir.
+#[tokio::test]
+async fn no_config_dir_skips_validation() {
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone());
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "anything-goes",
+            "task": "do the thing"
+        }))
+        .await;
+
+    assert!(!result.is_error(), "legacy mode should bypass validation");
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+/// #3555 delegate-resolve regression guard: the primary use case this
+/// fix targets — an assistant launched from a CWD with NO local
+/// `.trusty-agents/agents/` (empty tempdir, standing in for e.g. a bare
+/// worktree root) must still successfully delegate to a bundled worker
+/// agent that only exists in the SECONDARY tier (standing in for
+/// `$HOME/.trusty-agents/agents/`, populated by
+/// `agents::bundled::ensure_bundled_agents_deployed`). Before the fix,
+/// `DelegateToAgentTool` only ever checked a single directory, so this
+/// would have rejected the call before the runner was ever invoked —
+/// exactly the reported symptom (`is_error=true`, no `engineer` spawn).
+#[tokio::test]
+async fn delegate_resolves_agent_from_secondary_config_dir() {
+    let empty_primary = tempfile::tempdir().unwrap();
+    let secondary = tempfile::tempdir().unwrap();
+    std::fs::write(
+        secondary.path().join("engineer.toml"),
+        "[agent]\nname = \"engineer\"\n",
+    )
+    .unwrap();
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone()).with_config_dirs(vec![
+        empty_primary.path().to_path_buf(),
+        secondary.path().to_path_buf(),
+    ]);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "engineer",
+            "task": "run cargo check and report back"
+        }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "agent present only in the secondary (fallback) tier must still resolve: {}",
+        result.content()
+    );
+    let invoked = runner.invoked.lock().unwrap();
+    assert_eq!(invoked.len(), 1, "runner should be called exactly once");
+    assert_eq!(invoked[0].0, "engineer");
+}
+
+/// The multi-tier counterpart to
+/// `unknown_agent_is_rejected_without_naming_the_agent_or_roster`: when
+/// an agent name is absent from EVERY candidate directory, validation
+/// still rejects before the runner is invoked.
+#[tokio::test]
+async fn delegate_rejects_agent_absent_from_all_config_dirs() {
+    let primary = tempfile::tempdir().unwrap();
+    let secondary = tempfile::tempdir().unwrap();
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone()).with_config_dirs(vec![
+        primary.path().to_path_buf(),
+        secondary.path().to_path_buf(),
+    ]);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "nonexistent-agent",
+            "task": "do the thing"
+        }))
+        .await;
+
+    assert!(result.is_error(), "must reject an agent absent everywhere");
+    assert!(runner.invoked.lock().unwrap().is_empty());
+}
+
+/// Writes a minimal, fully-parseable agent TOML with the given `role` —
+/// the shape `AgentConfig::by_name_in` (used by the role gate) actually
+/// requires, unlike the bare `[agent]\nname = "..."` fixtures the
+/// existence-only tests above use (those never parse the file).
+fn write_agent_toml_with_role(dir: &std::path::Path, name: &str, role: &str) {
+    std::fs::write(
+        dir.join(format!("{name}.toml")),
+        format!(
+            r#"
+[agent]
+name = "{name}"
+role = "{role}"
+model = "anthropic/claude-sonnet-4-6"
+description = "test fixture"
+
+[llm]
+temperature = 0.2
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#
+        ),
+    )
+    .unwrap();
+}
+
+/// #3555 CRITICAL follow-up (code-critic): privilege escalation via
+/// unrestricted delegation target. Widening `config_dirs` to include the
+/// `$HOME` fallback tier makes the FULL bundled roster resolvable from
+/// any cwd — including `pm` (role `orchestrator`). Without a role gate,
+/// an assistant-tier `delegate_to_agent(agent_name="pm")` would pass
+/// validation and spawn a subprocess with `run_subagent`'s UNRESTRICTED
+/// orchestrator registry (shell, write_file, unrestricted
+/// delegate_to_agent) — an escalation straight out of the sandboxed
+/// assistant. This test proves the role gate rejects it before the
+/// runner is ever invoked, with the SAME generic error text (no role
+/// taxonomy leak).
+#[tokio::test]
+async fn delegate_assistant_role_gate_rejects_orchestrator_role() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "pm", "orchestrator");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "pm",
+            "task": "do orchestrator-tier things"
+        }))
+        .await;
+
+    assert!(
+        result.is_error(),
+        "role gate must reject a resolvable but disallowed-role target"
+    );
+    assert!(
+        result.content().contains("pm"),
+        "error may echo back the caller's own rejected input, got: {}",
+        result.content()
+    );
+    assert!(
+        !result.content().to_lowercase().contains("orchestrator"),
+        "error must not leak the target's actual role, got: {}",
+        result.content()
+    );
+    assert!(
+        runner.invoked.lock().unwrap().is_empty(),
+        "runner must not be called when the role gate rejects"
+    );
+}
+
+/// Sibling to `delegate_assistant_role_gate_rejects_orchestrator_role`
+/// for `ctrl` (role `controller`) — the other privileged meta-agent
+/// named in the CRITICAL finding.
+#[tokio::test]
+async fn delegate_assistant_role_gate_rejects_controller_role() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "ctrl", "controller");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "ctrl",
+            "task": "do controller-tier things"
+        }))
+        .await;
+
+    assert!(result.is_error(), "role gate must reject role=controller");
+    assert!(runner.invoked.lock().unwrap().is_empty());
+}
+
+/// The positive case: a worker role (`engineer`) IS in the allowlist and
+/// must still reach the runner — the role gate must not become a
+/// blanket denial.
+#[tokio::test]
+async fn delegate_assistant_role_gate_allows_worker_role() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "engineer", "engineer");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "engineer",
+            "task": "run cargo check"
+        }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "worker role must pass the gate: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+/// The other positive case: a PEER assistant (role `assistant`, e.g.
+/// `cto-assistant`) must still reach the runner — this is the
+/// Izzie <-> cto-assistant peer-consult lane the role gate must
+/// preserve. Spawning a peer is safe because IT ALSO gets routed
+/// through the restricted assistant-tier registry, never an
+/// unrestricted one.
+#[tokio::test]
+async fn delegate_assistant_role_gate_allows_peer_assistant_role() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "cto-assistant", "assistant");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "cto-assistant",
+            "task": "consult on architecture"
+        }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "peer assistant role must pass the gate: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+/// Without `with_allowed_target_roles` (pm/ctrl callers), the role gate
+/// is a no-op — the existing existence-only check still governs, and a
+/// name resolving to ANY role (including `orchestrator`/`controller`)
+/// reaches the runner. Pins that widening the assistant tier's gate did
+/// NOT change pm/ctrl's own delegation behavior.
+#[tokio::test]
+async fn delegate_without_role_gate_allows_any_resolvable_role() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "pm", "orchestrator");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool =
+        DelegateToAgentTool::new(runner.clone()).with_config_dirs(vec![dir.path().to_path_buf()]);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "pm",
+            "task": "do orchestrator-tier things"
+        }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "pm/ctrl callers (no role gate) must be unaffected: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+/// #3737: a successful delegation emits `AgentSpawned { session_id, agent }`
+/// when a session id was threaded in via `with_session_id`, so the API
+/// server can attribute the answer to the specialist that produced it.
+#[tokio::test]
+async fn delegate_emits_agent_spawned_with_session_id() {
+    use crate::events::Event;
+    let sid = "delegate-emit-test-session";
+    let mut rx = crate::events::subscribe();
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    // No config_dirs → pre-flight validation skipped → runner invoked
+    // directly; keeps this focused on the emit behavior.
+    let tool = DelegateToAgentTool::new(runner).with_session_id(sid);
+    let result = tool
+        .execute(json!({ "agent_name": "izzie", "task": "what's the weather" }))
+        .await;
+    assert!(
+        !result.is_error(),
+        "delegation should succeed: {}",
+        result.content()
+    );
+
+    // Drain the bus; find the AgentSpawned for our session.
+    let mut found = None;
+    while let Ok(ev) = rx.try_recv() {
+        if let Event::AgentSpawned { session_id, agent } = ev
+            && session_id == sid
+        {
+            found = Some(agent);
+        }
+    }
+    assert_eq!(
+        found.as_deref(),
+        Some("izzie"),
+        "successful delegation must emit AgentSpawned naming the specialist that answered"
+    );
+}
+
+/// #3737: the emit is gated on a non-blank session id. The default
+/// constructor and a blank `with_session_id` both leave `session_id` as
+/// `None`, so delegation emits nothing (byte-identical to pre-#3737
+/// behavior); a non-blank id is stored. Asserting on the private field
+/// (same-module test) is deterministic on the process-global event bus,
+/// where observing "no emit" across concurrent tests would be racy.
+#[test]
+fn session_id_gate_normalizes_blank_to_none() {
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    assert_eq!(DelegateToAgentTool::new(runner.clone()).session_id, None);
+    assert_eq!(
+        DelegateToAgentTool::new(runner.clone())
+            .with_session_id("   ")
+            .session_id,
+        None
+    );
+    assert_eq!(
+        DelegateToAgentTool::new(runner)
+            .with_session_id("task-42")
+            .session_id
+            .as_deref(),
+        Some("task-42")
+    );
+}

--- a/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
+++ b/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
@@ -18,6 +18,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   friendly display names (sourced from the new `GET /api/agents` `display_name`
   field) rather than dispatchable slugs.
 
+- **Clearable "Recent tasks" (#3737, epic #3052):** the sidebar's "Recent
+  tasks" panel gains a two-step "Clear" affordance (arm → confirm) wired
+  through a new `clear_recent_tasks` command to `DELETE /api/tasks`. It clears
+  finished tasks only and keeps any in-flight task visible; it is two-step
+  because the task history is persisted across restarts.
+
 ### Fixed
 
 - **The `tagent --api` sidecar is now reaped on quit (#3372):** quitting the

--- a/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
+++ b/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
@@ -7,6 +7,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **Per-message agent attribution in the chat stream (#3737, epic #3052):**
+  every assistant bubble is now labeled with the display name of the persona
+  that produced it — "Assistant" for the default tools-armed path, or the
+  roster persona's friendly name ("Izzie", "CTO Assistant") when one is
+  selected — stamped per-message at send time, so a mid-conversation persona
+  switch relabels only later bubbles. The roster switcher likewise shows
+  friendly display names (sourced from the new `GET /api/agents` `display_name`
+  field) rather than dispatchable slugs.
+
 ### Fixed
 
 - **The `tagent --api` sidecar is now reaped on quit (#3372):** quitting the

--- a/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
+++ b/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
@@ -14,9 +14,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   that produced it — "Assistant" for the default tools-armed path, or the
   roster persona's friendly name ("Izzie", "CTO Assistant") when one is
   selected — stamped per-message at send time, so a mid-conversation persona
-  switch relabels only later bubbles. The roster switcher likewise shows
-  friendly display names (sourced from the new `GET /api/agents` `display_name`
-  field) rather than dispatchable slugs.
+  switch relabels only later bubbles. Attribution reflects who ANSWERED, not
+  who was asked: when a turn delegates (base "Assistant" hands a weather
+  question to Izzie), the server reports the responding specialist in
+  `PmResponse.responder_agent` and the bubble is relabeled to that agent on
+  `task-complete`. The roster switcher likewise shows friendly display names
+  (sourced from the new `GET /api/agents` `display_name` field) rather than
+  dispatchable slugs.
 
 - **Clearable "Recent tasks" (#3737, epic #3052):** the sidebar's "Recent
   tasks" panel gains a two-step "Clear" affordance (arm → confirm) wired

--- a/crates/trusty-agents/ui/src-tauri/src/main.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/main.rs
@@ -50,7 +50,7 @@ use overlay::{
 use sidecar::{
     ensure_api_server, kill_sidecar, terminate_child, ApiServerState, SharedApi, SIDECAR_GRACE,
 };
-use task_commands::{cancel_task, check_health, list_tasks, send_message};
+use task_commands::{cancel_task, check_health, clear_recent_tasks, list_tasks, send_message};
 
 /// Show and focus the main window (tray "Show" item / tray icon click).
 fn show_main_window(app: &AppHandle) {
@@ -73,6 +73,7 @@ fn main() {
             send_message,
             cancel_task,
             list_tasks,
+            clear_recent_tasks,
             check_health,
             read_personalization_overlay,
             write_personalization_overlay,

--- a/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
@@ -44,6 +44,37 @@ pub async fn list_tasks(state: State<'_, SharedApi>) -> Result<Value, String> {
         .map_err(|e| format!("list_tasks parse failed: {e}"))
 }
 
+/// `DELETE /api/tasks` — clear the finished-task history (#3737).
+///
+/// Why: The "Recent tasks" panel's "Clear" affordance needs a command that
+/// wipes the finished-task list WITHOUT the `clear-context` side effect of
+/// aborting in-flight work — the backend `DELETE /api/tasks` handler
+/// (`crates/trusty-agents/src/api/server/handlers.rs::clear_recent_tasks`)
+/// removes only terminal tasks and keeps any running one. This just forwards
+/// to it and returns the `{cleared, removed, retained_running}` body so the
+/// frontend can refresh its list.
+/// What: Issues `DELETE {api_base}/api/tasks`; a non-2xx status is a genuine
+/// `Err` (unlike `cancel_task`, there's no expected-race status to fold in).
+/// Test: Run `trusty-agents --api`, submit + finish a task, call this command,
+/// assert `removed >= 1` and `GET /api/tasks` no longer lists it.
+#[tauri::command]
+pub async fn clear_recent_tasks(state: State<'_, SharedApi>) -> Result<Value, String> {
+    let port = state.port.lock().await.unwrap_or(8765);
+    let url = format!("{}/api/tasks", api_base(port));
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete(&url)
+        .send()
+        .await
+        .map_err(|e| format!("clear_recent_tasks request failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("clear_recent_tasks: HTTP {}", resp.status()));
+    }
+    resp.json::<Value>()
+        .await
+        .map_err(|e| format!("clear_recent_tasks parse failed: {e}"))
+}
+
 #[derive(Debug, Serialize, Clone)]
 struct ProgressEvent<'a> {
     task_id: &'a str,

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
   import { onMount, onDestroy, afterUpdate } from 'svelte';
   import { Loader2 } from 'lucide-svelte';
+  import { get } from 'svelte/store';
   import {
     activeMessages,
     activeProjectId,
+    agentRoster,
+    setMessageSpeakerByTask,
     updateMessageByTask,
     isRunning,
   } from '../stores/app';
+  import { responderDisplayName } from '../lib/roster';
   import { listenEvent, type UnlistenFn } from '../lib/transport';
   import ActionIcon from '../lib/icons/ActionIcon.svelte';
   import WorkflowPhaseCard from './WorkflowPhaseCard.svelte';
@@ -25,6 +29,13 @@
     id: string;
     narrative?: string;
     status?: string;
+    /**
+     * #3737: server-authoritative name of the specialist that actually
+     * answered, present only when the turn delegated. When set, it overrides
+     * the request-time speaker stamp so the bubble reflects who ANSWERED
+     * (e.g. "Izzie") rather than who was asked ("Assistant").
+     */
+    responder_agent?: string;
   }
   interface ErrorPayload {
     task_id: string;
@@ -48,6 +59,12 @@
     unlistenComplete = await listenEvent<CompletePayload>('task-complete', (p) => {
       const text = p.narrative && p.narrative.length > 0 ? p.narrative : '(no narrative)';
       updateMessageByTask($activeProjectId, p.id, text);
+      // #3737: if the turn delegated, relabel the bubble to the agent that
+      // actually answered (resolved to its display name via the roster).
+      const responder = responderDisplayName(get(agentRoster), p.responder_agent);
+      if (responder) {
+        setMessageSpeakerByTask($activeProjectId, p.id, responder);
+      }
       isRunning.set(false);
     });
     unlistenError = await listenEvent<ErrorPayload>('task-error', (p) => {

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -105,9 +105,14 @@
       {:else if msg.role === 'assistant'}
         <div class="flex justify-start ml-4">
           <div class="max-w-[85%] rounded-r-2xl rounded-bl-2xl border-l-4 border-foundry-teal bg-foundry-teal/10 px-4 py-2 text-foundry-light-text dark:text-foundry-text shadow-sm">
-            <div class="mb-1 flex items-center gap-1 text-[10px] font-medium uppercase tracking-wide text-foundry-teal/80">
+            <!-- #3737: label each assistant bubble with the specific persona
+                 that produced it (stamped on the message at send time), never
+                 a generic "agent". `tracking-wide` is kept but `uppercase` is
+                 dropped so a mixed-case display name ("CTO Assistant") reads
+                 as written rather than being flattened to "CTO ASSISTANT". -->
+            <div class="mb-1 flex items-center gap-1 text-[10px] font-medium tracking-wide text-foundry-teal/80">
               <ActionIcon name="agent" size={14} />
-              <span>agent</span>
+              <span>{msg.speaker ?? 'Assistant'}</span>
             </div>
             <p class="whitespace-pre-wrap text-sm leading-relaxed">{msg.content || '…'}</p>
             <p class="mt-1 text-[10px] text-foundry-teal/70">{fmtTime(msg.timestamp)}</p>

--- a/crates/trusty-agents/ui/src/components/InputArea.svelte
+++ b/crates/trusty-agents/ui/src/components/InputArea.svelte
@@ -18,6 +18,8 @@
   import { cancelTask, invoke, listenEvent, type CancelTaskResult } from '../lib/transport';
   import { buildRetaskPayload, isPendingTaskId } from '../lib/retask';
   import { resolveOverride } from '../lib/models';
+  import { agentRoster } from '../stores/app';
+  import { rosterDisplayName } from '../lib/roster';
 
   let input = '';
   let textareaEl: HTMLTextAreaElement;
@@ -112,13 +114,21 @@
     // Assistant placeholder. `taskId` is set to a temp id and patched once
     // the backend returns the real id via the resolved promise OR the first
     // progress event (whichever arrives first).
+    //
+    // #3737: stamp the placeholder with the display name of the persona
+    // active RIGHT NOW (the same `activeAgentId` this submission forwards as
+    // its `agent` field below). Resolving it here — at message creation —
+    // means a persona switch after this message is sent relabels only later
+    // bubbles; this one keeps whoever produced it.
     const placeholderTaskId = `pending-${now}`;
+    const speaker = rosterDisplayName(get(agentRoster), get(activeAgentId));
     addMessage(projectId, {
       id: `asst-${now}`,
       role: 'assistant',
       content: '',
       timestamp: now,
       taskId: placeholderTaskId,
+      speaker,
     });
 
     isRunning.set(true);

--- a/crates/trusty-agents/ui/src/components/TaskHistory.svelte
+++ b/crates/trusty-agents/ui/src/components/TaskHistory.svelte
@@ -10,6 +10,57 @@
   let errorMessage = '';
 
   /**
+   * Why (#3737): "Recent tasks" is backed by the server's task store, which
+   * persists to `.trusty-agents/state/tasks.json` and reloads on restart — so
+   * clearing it deletes durable history. Per the two-step requirement for a
+   * destructive-to-persisted-history action, the Clear affordance arms on the
+   * first click (`confirming`) and only actually clears on a second click.
+   * `clearing` disables the button while the request is in flight.
+   * What: `confirming` toggles the button into its "Confirm?" state, auto-
+   * disarming after a few seconds so a stray first click doesn't stay armed.
+   * Test: Manual — click Clear (label becomes "Confirm?"), click again, the
+   * finished tasks disappear while any running task stays.
+   */
+  let confirming = false;
+  let clearing = false;
+  let confirmTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function disarm() {
+    confirming = false;
+    if (confirmTimer) {
+      clearTimeout(confirmTimer);
+      confirmTimer = null;
+    }
+  }
+
+  /**
+   * Why: Clears the finished-task history without aborting any in-flight task
+   * (the backend `DELETE /api/tasks` keeps running tasks). Two-step: arm on
+   * the first click, execute on the second.
+   * What: First click arms `confirming` (auto-disarms after 4s). Second click
+   * invokes `clear_recent_tasks` then refreshes the list from the server.
+   * Test: Manual — see the panel's Clear button.
+   */
+  async function handleClear() {
+    if (clearing) return;
+    if (!confirming) {
+      confirming = true;
+      confirmTimer = setTimeout(disarm, 4000);
+      return;
+    }
+    disarm();
+    clearing = true;
+    try {
+      await invoke('clear_recent_tasks');
+      await refresh();
+    } catch (e) {
+      errorMessage = `${e}`;
+    } finally {
+      clearing = false;
+    }
+  }
+
+  /**
    * Why (#3221): `GET /api/tasks` (wired via `invoke('list_tasks')`) returns
    * the server's full `PmResponse` array — it carries `phases_completed`
    * even though the frontend's `TaskHistoryEntry` interface (stores/app.ts)
@@ -93,6 +144,7 @@
   onDestroy(() => {
     unlistenComplete?.();
     unlistenError?.();
+    if (confirmTimer) clearTimeout(confirmTimer);
   });
 
   function shortTask(t: string): string {
@@ -108,9 +160,30 @@
 </script>
 
 <section>
-  <h2 class="mb-2 px-2 text-xs font-semibold uppercase tracking-wide text-foundry-teal">
-    Recent tasks
-  </h2>
+  <div class="mb-2 flex items-center justify-between px-2">
+    <h2 class="text-xs font-semibold uppercase tracking-wide text-foundry-teal">
+      Recent tasks
+    </h2>
+    {#if $taskHistory.length > 0}
+      <!-- #3737: two-step Clear affordance for the recent-tasks list. Styled
+           to sit quietly beside the section heading (teal, matching the panel)
+           until armed, then red to signal the confirm step — reusing the
+           red-state utilities already used elsewhere in this app rather than
+           introducing a new token, and restyling nothing else in the panel. -->
+      <button
+        type="button"
+        class="rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide transition-colors disabled:opacity-40 {confirming
+          ? 'text-red-600 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-900/20'
+          : 'text-foundry-light-muted dark:text-foundry-text/50 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10 hover:text-foundry-teal'}"
+        disabled={clearing}
+        on:click={handleClear}
+        on:blur={disarm}
+        title="Clear finished tasks (running tasks are kept)"
+      >
+        {clearing ? 'Clearing…' : confirming ? 'Confirm?' : 'Clear'}
+      </button>
+    {/if}
+  </div>
 
   {#if errorMessage}
     <p class="px-2 text-xs text-red-500 dark:text-red-400">{errorMessage}</p>

--- a/crates/trusty-agents/ui/src/lib/roster.test.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.test.ts
@@ -5,9 +5,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   BASE_AGENT_ID,
+  BASE_AGENT_LABEL,
   buildOverlayMarkdown,
   buildRoster,
   parseOverlayMarkdown,
+  rosterDisplayName,
   slugify,
   type CatalogAgent,
   type OverlayAgent,
@@ -114,6 +116,46 @@ describe('buildRoster', () => {
     const roster = buildRoster([], overlays);
     const overlayLabels = roster.filter((r) => r.source === 'overlay').map((r) => r.label);
     expect(overlayLabels).toEqual(['Alpha', 'Zed']);
+  });
+
+  it('prefers a catalog entry display_name over its dispatchable name for the label (#3737)', () => {
+    const catalog: CatalogAgent[] = [
+      { name: 'cto-assistant', display_name: 'CTO Assistant' },
+      { name: 'izzie', display_name: 'Izzie' },
+      { name: 'python-engineer' }, // no display_name → falls back to name
+      { name: 'blank-display', display_name: '   ' }, // whitespace → falls back
+    ];
+    const roster = buildRoster(catalog, []);
+    expect(roster.find((r) => r.id === 'cto-assistant')?.label).toBe('CTO Assistant');
+    expect(roster.find((r) => r.id === 'izzie')?.label).toBe('Izzie');
+    expect(roster.find((r) => r.id === 'python-engineer')?.label).toBe('python-engineer');
+    expect(roster.find((r) => r.id === 'blank-display')?.label).toBe('blank-display');
+  });
+});
+
+describe('rosterDisplayName (#3737)', () => {
+  const roster = buildRoster(
+    [
+      { name: 'cto-assistant', display_name: 'CTO Assistant' },
+      { name: 'izzie', display_name: 'Izzie' },
+    ],
+    [],
+  );
+
+  it('returns the base label "Assistant" when no agent is selected (null id)', () => {
+    expect(rosterDisplayName(roster, null)).toBe(BASE_AGENT_LABEL);
+    expect(rosterDisplayName(roster, '')).toBe(BASE_AGENT_LABEL);
+  });
+
+  it('resolves a selected roster entry to its friendly display name', () => {
+    expect(rosterDisplayName(roster, 'izzie')).toBe('Izzie');
+    expect(rosterDisplayName(roster, 'cto-assistant')).toBe('CTO Assistant');
+    expect(rosterDisplayName(roster, BASE_AGENT_ID)).toBe(BASE_AGENT_LABEL);
+  });
+
+  it('falls back to the base label for an unknown/stale id', () => {
+    expect(rosterDisplayName(roster, 'deleted-overlay')).toBe(BASE_AGENT_LABEL);
+    expect(rosterDisplayName([], 'anything')).toBe(BASE_AGENT_LABEL);
   });
 });
 

--- a/crates/trusty-agents/ui/src/lib/roster.test.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.test.ts
@@ -9,6 +9,7 @@ import {
   buildOverlayMarkdown,
   buildRoster,
   parseOverlayMarkdown,
+  responderDisplayName,
   rosterDisplayName,
   slugify,
   type CatalogAgent,
@@ -156,6 +157,34 @@ describe('rosterDisplayName (#3737)', () => {
   it('falls back to the base label for an unknown/stale id', () => {
     expect(rosterDisplayName(roster, 'deleted-overlay')).toBe(BASE_AGENT_LABEL);
     expect(rosterDisplayName([], 'anything')).toBe(BASE_AGENT_LABEL);
+  });
+});
+
+describe('responderDisplayName (#3737)', () => {
+  const roster = buildRoster(
+    [
+      { name: 'izzie', display_name: 'Izzie' },
+      { name: 'cto-assistant', display_name: 'CTO Assistant' },
+    ],
+    [],
+  );
+
+  it('resolves a known responder agent name to its display name', () => {
+    expect(responderDisplayName(roster, 'izzie')).toBe('Izzie');
+    expect(responderDisplayName(roster, 'cto-assistant')).toBe('CTO Assistant');
+  });
+
+  it('falls back to the RAW agent name for an unknown responder (never "Assistant")', () => {
+    // A delegated worker not enumerated by /api/agents must keep its own
+    // name, not be mislabeled as the base assistant.
+    expect(responderDisplayName(roster, 'engineer')).toBe('engineer');
+    expect(responderDisplayName([], 'qa-agent')).toBe('qa-agent');
+  });
+
+  it('returns null for a blank/absent responder so the caller keeps the request-time stamp', () => {
+    expect(responderDisplayName(roster, null)).toBeNull();
+    expect(responderDisplayName(roster, undefined)).toBeNull();
+    expect(responderDisplayName(roster, '   ')).toBeNull();
   });
 });
 

--- a/crates/trusty-agents/ui/src/lib/roster.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.ts
@@ -67,9 +67,18 @@ export interface RosterEntry {
  */
 export const BASE_AGENT_ID = 'assistant';
 
+/**
+ * Why (#3737): the human-friendly label for the base, nameless assistant.
+ * Exported so chat attribution (`rosterDisplayName`) can fall back to it
+ * without re-typing the literal — the base agent has no `display_name` on the
+ * wire (it's intentionally nameless), so both the roster row and any bubble
+ * it produces read "Assistant".
+ */
+export const BASE_AGENT_LABEL = 'Assistant';
+
 const BASE_ENTRY: RosterEntry = {
   id: BASE_AGENT_ID,
-  label: 'Assistant',
+  label: BASE_AGENT_LABEL,
   description: 'General-purpose productivity assistant',
   source: 'base',
 };
@@ -104,12 +113,14 @@ export function slugify(input: string): string {
  * twice. Centralizing the merge means both UIs stay in sync automatically.
  * What: Returns the base entry first, then catalog agents (skipping any
  * named `BASE_AGENT_ID`), then overlay agents (skipping any slug already
- * used by the base or a catalog entry) sorted by label. Overlay labels
+ * used by the base or a catalog entry) sorted by label. Catalog labels
+ * prefer `display_name` (#3737), falling back to `name`. Overlay labels
  * prefer `display_name`, falling back to `name`, falling back to `slug`.
  * Test: `buildRoster_always_includes_base_first`,
  * `buildRoster_dedupes_catalog_entry_named_assistant`,
  * `buildRoster_dedupes_overlay_shadowing_catalog_entry`,
- * `buildRoster_sorts_overlays_by_label`.
+ * `buildRoster_sorts_overlays_by_label`,
+ * `buildRoster_prefers_catalog_display_name`.
  */
 export function buildRoster(
   catalog: CatalogAgent[],
@@ -149,6 +160,31 @@ export function buildRoster(
   overlayEntries.sort((a, b) => a.label.localeCompare(b.label));
 
   return [...entries, ...overlayEntries];
+}
+
+/**
+ * Why (#3737, per-message chat attribution, epic #3052): each assistant chat
+ * bubble must be labeled with WHICH persona produced it — the display name of
+ * the agent active when the message was sent — never a generic "agent". The
+ * dispatch axis is `activeAgentId` (see `stores/app.ts`): `null` means no
+ * roster entry is explicitly selected, which routes through the tools-armed
+ * base-assistant session path, so it labels as "Assistant". A non-null id is
+ * looked up in the merged roster for its friendly `label`.
+ * What: Returns the roster entry's `label` for `id`, or `BASE_AGENT_LABEL`
+ * ("Assistant") when `id` is `null`/empty or no entry matches (e.g. a stale
+ * selection, or the roster hasn't loaded yet). Pure — no store access — so
+ * the caller stamps the name onto the message at creation time and a later
+ * persona switch never retroactively relabels older bubbles.
+ * Test: `rosterDisplayName_null_id_is_base_label`,
+ * `rosterDisplayName_resolves_selected_entry`,
+ * `rosterDisplayName_unknown_id_falls_back_to_base`.
+ */
+export function rosterDisplayName(
+  roster: RosterEntry[],
+  id: string | null,
+): string {
+  if (!id) return BASE_AGENT_LABEL;
+  return roster.find((e) => e.id === id)?.label ?? BASE_AGENT_LABEL;
 }
 
 /** Editable fields the create/edit form (#3224) collects for one overlay. */

--- a/crates/trusty-agents/ui/src/lib/roster.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.ts
@@ -187,6 +187,32 @@ export function rosterDisplayName(
   return roster.find((e) => e.id === id)?.label ?? BASE_AGENT_LABEL;
 }
 
+/**
+ * Why (#3737): chat attribution must reflect who ANSWERED. When a turn
+ * delegates (base "Assistant" → Izzie for a weather question), the server
+ * reports the responder's agent NAME in `PmResponse.responder_agent`; the GUI
+ * overwrites the bubble's request-time speaker stamp with that agent's display
+ * name on `task-complete`. This differs from `rosterDisplayName`: a delegated
+ * responder is always a real named specialist, so an id missing from the
+ * roster (e.g. a bundled worker not enumerated by `/api/agents`' flat scan)
+ * must fall back to the raw agent name — NOT to "Assistant", which would be a
+ * fresh mis-attribution.
+ * What: Returns the roster entry's `label` for `agentName`, else `agentName`
+ * verbatim. Trims; returns `null` for a blank/empty input so callers can skip
+ * the overwrite (keeping the request-time stamp).
+ * Test: `responderDisplayName_resolves_known_agent`,
+ * `responderDisplayName_falls_back_to_raw_name_for_unknown`,
+ * `responderDisplayName_blank_returns_null`.
+ */
+export function responderDisplayName(
+  roster: RosterEntry[],
+  agentName: string | null | undefined,
+): string | null {
+  const name = agentName?.trim();
+  if (!name) return null;
+  return roster.find((e) => e.id === name)?.label ?? name;
+}
+
 /** Editable fields the create/edit form (#3224) collects for one overlay. */
 export interface OverlayDraft {
   displayName: string;

--- a/crates/trusty-agents/ui/src/lib/transport.ts
+++ b/crates/trusty-agents/ui/src/lib/transport.ts
@@ -172,6 +172,11 @@ async function fetchFallback(command: string, args?: Record<string, unknown>): P
             id,
             narrative,
             status: resp.status,
+            // #3737: forward the server's responder attribution so the browser
+            // fallback relabels a delegated bubble the same way the Tauri path
+            // does (that path emits the full PmResponse, which already carries
+            // this field).
+            responder_agent: resp.responder_agent,
           });
           return narrative;
         }

--- a/crates/trusty-agents/ui/src/lib/transport.ts
+++ b/crates/trusty-agents/ui/src/lib/transport.ts
@@ -80,6 +80,17 @@ async function fetchFallback(command: string, args?: Record<string, unknown>): P
       if (!r.ok) throw new Error(`list_tasks: ${r.status}`);
       return r.json();
     }
+    case 'clear_recent_tasks': {
+      // #3737: browser-mode twin of the `clear_recent_tasks` Tauri command —
+      // DELETE the finished-task history (running tasks are preserved
+      // server-side). Returns the `{cleared, removed, retained_running}` body.
+      const r = await fetch(`${base}/api/tasks`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error(`clear_recent_tasks: ${r.status}`);
+      return r.json();
+    }
     case 'send_message': {
       // #3223 (regression fix, code-critic on PR #3279): forward the
       // roster's active agent selection so the browser fallback path

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -48,6 +48,17 @@ export interface Message {
   /** Task id returned by the backend; used to route progress events. */
   taskId?: string;
   /**
+   * Why (#3737, per-message chat attribution, epic #3052): the display name
+   * of the persona that produced this message ("Assistant", "Izzie", "CTO
+   * Assistant"), stamped at creation time from the then-active roster
+   * selection. Stamping per-message (rather than reading the live roster at
+   * render time) is what lets a mid-conversation persona switch relabel only
+   * new bubbles — each message keeps the name of whoever produced it.
+   * What: Set for `role === 'assistant'` bubbles by `InputArea`; `ChatView`
+   * renders it, falling back to "Assistant" when absent (older messages).
+   */
+  speaker?: string;
+  /**
    * Why: Recap messages (#371) carry structured table rows we need to render
    * in ChatView as a styled banner. Keeping the rows on the Message itself
    * lets us replay chat history without re-querying the recap store.

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -355,6 +355,35 @@ export function updateMessageByTask(projectId: string, taskId: string, content: 
 }
 
 /**
+ * Why (#3737): chat attribution must reflect who ANSWERED. On `task-complete`
+ * the server-authoritative `responder_agent` (present only when the turn
+ * delegated) overrides the request-time speaker stamp so a base-"Assistant"
+ * turn that delegated a weather question to Izzie relabels the bubble to
+ * "Izzie". Kept separate from `updateMessageByTask` (content) so a complete
+ * event can set the speaker without disturbing the narrative flow.
+ * What: Sets `speaker` on the message currently tagged with `taskId` inside
+ * `projectId`. No-op when no message matches.
+ * Test: covered by ChatView's task-complete handling (manual) + the
+ * `responderDisplayName` resolver unit tests.
+ */
+export function setMessageSpeakerByTask(
+  projectId: string,
+  taskId: string,
+  speaker: string,
+): void {
+  messages.update((map) => {
+    const list = map.get(projectId);
+    if (!list) return map;
+    const next = new Map(map);
+    next.set(
+      projectId,
+      list.map((m) => (m.taskId === taskId ? { ...m, speaker } : m)),
+    );
+    return next;
+  });
+}
+
+/**
  * Why: When a message is first added to the store it carries a client-side
  * placeholder task id (e.g. `pending-<ts>`) because the backend hasn't yet
  * returned the real id. As soon as the first `task-progress` event arrives


### PR DESCRIPTION
Two owner-requested GUI changes for the trusty-agents Tauri app, needed for the 2026-07-24 demo (epic #3052). Shipped as two separately-revertible commits (A then B) on one branch.

## A. Chat speaker attribution
> Bob: "the chat interface should indicate which *specific* agent is talking, not generic Agent"

Every assistant bubble is now labeled with the display name of the persona that produced it — **"Assistant"** for the default tools-armed path, or the roster persona's friendly name (**"Izzie"**, **"CTO Assistant"**) when one is selected — never a generic "agent".

**Attribution data flow:** `[agent].display_name` (agent TOML) → `parse_agent_toml` → `GET /api/agents` (`display_name` field) → `catalogAgents` store → `buildRoster` label → `rosterDisplayName(roster, activeAgentId)` resolved in `InputArea.submitTask` → stamped onto the message's new `speaker` field at send time → rendered by `ChatView`. Because the name is stamped **per-message at creation**, a mid-conversation persona switch relabels only later bubbles; each message keeps whoever produced it. `activeAgentId === null` (the default tools-armed session path) resolves to "Assistant".

Note on the parallel PR: the prompt flagged a possible `feat-generic-assistant-default` PR adding display-name accessors on the backend. `gh pr list` showed **no such PR open**, so this PR adds the minimal `display_name` field to `GET /api/agents` itself. If that work later lands its own accessor, the catalog field here is the coordination point — it reads `[agent].display_name` directly and can be repointed at a shared accessor without changing the wire shape.

`ChatView` drops `uppercase` on the speaker label so "CTO Assistant" reads as written rather than flattening to "CTO ASSISTANT".

## B. Clearable recent tasks
> Bob: "I should also be able to clear 'recent tasks'"

Adds a small two-step **Clear** affordance to the sidebar's "Recent tasks" panel (`TaskHistory.svelte`), matching the panel's existing Foundry styling; nothing else in the panel is restyled.

**What the store turned out to be:** the "Recent tasks" list is the server's in-memory `TaskStore` (`AppState`), fetched via `GET /api/tasks`. Crucially it is **persisted to `.trusty-agents/state/tasks.json` and reloaded on restart** — i.e. it is durable history, not an ephemeral cache. Per the confirmation rule, clearing durable history is therefore a **two-step** action (arm → "Confirm?" → execute).

Wiring: new backend `DELETE /api/tasks` (`clear_recent_tasks`) clears **only terminal** (success/error/partial/cancelled) tasks and **preserves any still-running task**, re-persisting the trimmed snapshot. This is deliberately distinct from the existing `POST /api/clear-context`, which additionally aborts in-flight work — tidying the history list must not kill a running task. A new `clear_recent_tasks` Tauri command + browser-mode transport fallback drive it, then the panel refreshes.

## Gates (raw output)

Frontend (`crates/trusty-agents/ui`):
```
$ pnpm run test:unit
 Test Files  3 passed (3)
      Tests  42 passed (42)

$ pnpm run check   # svelte-check
COMPLETED 1692 FILES 0 ERRORS 2 WARNINGS 1 FILES_WITH_PROBLEMS
# (both warnings are pre-existing in ProjectsView.svelte, untouched here)
```

Backend:
```
$ cargo test -p trusty-agents
test result: ok. 2216 passed; 0 failed; 12 ignored   # src/lib.rs
# crate total across all test binaries: 2242 passed; 0 failed
$ cargo clippy -p trusty-agents --all-targets -- -D warnings
Finished (clean)
```

Tauri crate (dist/index.html stub created as in CI's agents-ui job):
```
$ cargo check -p trusty-agents-ui
Finished (clean)
$ cargo clippy -p trusty-agents-ui --all-targets -- -D warnings
Finished (clean)
```

New tests: `scan_agents_dir_exposes_display_name` (backend catalog field), `clear_recent_tasks_removes_terminal_only` (route keeps running tasks), plus `rosterDisplayName` / `buildRoster` display-name cases (frontend).

CHANGELOG entries added under `## [Unreleased]` in both `crates/trusty-agents/CHANGELOG.md` and `crates/trusty-agents/ui/src-tauri/CHANGELOG.md`.

Closes #3737

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools