### PR TITLE
feat(trusty-agents): generic Assistant as default persona; Izzie/CTO Bot selectable

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
@@ -2,11 +2,19 @@
 #
 # This is the reusable, UN-personalized productivity assistant template. It
 # carries a functional role, the curated Google Workspace tool surface, and
-# generic helpful/productivity instructions (in persona.md) — but deliberately
-# NO persona identity: no display_name, no personal name, no user-identity
-# binding, and no user-specific skills. A concrete persona (e.g. "Izzie") is
-# supplied by a USER via an `extends = "assistant"` personalization overlay
-# (Eve §2.5.1). See `../izzie/` for the reference overlay example.
+# generic helpful/productivity instructions (in persona.md) — with NO
+# user-identity binding and no user-specific skills.
+#
+# #3738 (owner decision 2026-07-23): this base is ALSO the concrete GENERIC
+# "Assistant" persona — the DEFAULT starting agent for a fresh session. It
+# therefore now carries a professional, un-personalized display identity
+# (`display_name = "Assistant"`), REVERSING the prior "bases are nameless"
+# decision (2026-07-18). It remains the `extends` base for the named personas
+# (`../izzie/`, `../cto-assistant/`); each of those overrides `display_name`
+# via child-Some-wins per-key merge (`agents::extends::merge_extends`), so the
+# generic "Assistant" identity is only ever seen when the base is used
+# directly as the default. A user's own `extends = "assistant"` overlay may
+# still supply its own name (Eve §2.5.1) — see `../izzie/` for the reference.
 #
 # NOTE: the `extends`-based overlay resolver landed in #3055/#3106
 # (`crate::agents::extends`) — a personalization overlay's `[tools].allow`
@@ -23,8 +31,11 @@ role = "assistant"
 # (BASE_AGENT_ID in ui/src/lib/roster.ts) — testing default is Opus.
 model = "claude-opus-4-6"
 description = "General-purpose productivity assistant (base template; personalize via `extends`)"
-# Intentionally NO display_name / prompt_label: the base is nameless. A persona
-# identity (name + prompt label) is contributed by the personalization overlay.
+# #3738: the generic default persona's professional display identity. Named
+# personas (izzie, cto-assistant) override these via `extends`; a user overlay
+# may override them too. Kept intentionally plain — no personal name.
+display_name = "Assistant"
+prompt_label = "assistant"
 
 [llm]
 # Conversational productivity assistant — warm, short replies by default.

--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant.toml
@@ -16,7 +16,9 @@ role = "assistant"
 # particular — same discipline as `izzie.toml`.
 model = "claude-sonnet-4-6"
 description = "CTO Assistant — private assistant for Robert Matsuoka (CTO, Duetto)"
-display_name = "CTO Assistant"
+# #3738: user-facing display name is "CTO Bot" (kept in sync with the package
+# form `cto-assistant/agent.toml`; this flat file is the extends-shadow fallback).
+display_name = "CTO Bot"
 prompt_label = "cto"
 
 [llm]

--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
@@ -29,7 +29,9 @@ extends = "assistant"
 # in `src/llm/credentials.rs`.
 model = "claude-sonnet-4-6"
 description = "CTO Assistant — private assistant for Robert Matsuoka (CTO, Duetto)"
-display_name = "CTO Assistant"
+# #3738 (owner decision 2026-07-23): user-facing display name is "CTO Bot"
+# (was "CTO Assistant"). Selectable named persona, never the default.
+display_name = "CTO Bot"
 prompt_label = "cto"
 
 [llm]

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -88,6 +88,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   execution path) — a documented MVP scope limit, flagged for a follow-up
   RPC.
 
+### Changed
+
+- **Generic "Assistant" is the default persona; Izzie / CTO Bot are selectable
+  (owner decision, #3738, epic #3052):** the base `assistant/` package is now
+  the concrete GENERIC default persona with a professional display name
+  `"Assistant"` (reversing the prior "bases are nameless" decision) — it stays
+  the un-personalized `extends` base for the named personas, which override
+  `display_name` via child-Some-wins per-key merge. `cto-assistant`'s display
+  name is renamed `"CTO Assistant"` → `"CTO Bot"` (a new `"cto bot"` `/switch`
+  alias is added; existing aliases still work). Izzie keeps display name
+  `"Izzie"` and her flavor in her own overlay. The deprecated `ctrl` coordinator
+  persona stays in place and reachable via `/switch ctrl`, but nothing defaults
+  to it (the plain-CLI startup already auto-switches to `assistant`; the
+  `/switch` help and picker now list Assistant first and mark ctrl deprecated).
+  A single canonical accessor `AgentInfo::display_label()` (`display_name` →
+  `name` fallback) now drives the speaker label, and `GET /api/agents` surfaces
+  `display_name` so the GUI's per-message speaker attribution reads
+  "Assistant" / "Izzie" / "CTO Bot" from the backend without re-deriving the
+  mapping client-side. Tool registrations (weather / Metro-North on Izzie) are
+  unchanged — no tool scopes moved.
+
 ### Fixed
 
 - **A parallel phase could not fail when its merge failed (#3671):**

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -375,6 +375,26 @@ pub struct AgentInfo {
     pub extends: Option<String>,
 }
 
+impl AgentInfo {
+    /// The human-facing speaker label for this persona (#3738).
+    ///
+    /// Why: The chat surface (GUI per-message speaker attribution, the REPL
+    /// `/switch` "Switched to:" line, the `GET /api/agents` catalog) all need
+    /// the SAME "Assistant" / "Izzie" / "CTO Bot" string, resolved one way:
+    /// the persona's declared `display_name`, falling back to its stable
+    /// `name` id when a persona (e.g. a worker agent) declares none. Centralizing
+    /// this here is the single canonical accessor the owner decision asked for,
+    /// so the backend and every front end stay in agreement without each
+    /// re-deriving the mapping (which is how "CTO Assistant" vs "CTO Bot" drift
+    /// creeps in).
+    /// What: Returns `display_name` when set, else `name`.
+    /// Test: `display_label_prefers_display_name`,
+    /// `display_label_falls_back_to_name`.
+    pub fn display_label(&self) -> &str {
+        self.display_name.as_deref().unwrap_or(&self.name)
+    }
+}
+
 /// Declarative capability tags for `AgentRegistry` matching (#167).
 ///
 /// Why: Replaces hard-coded delegation logic with data-driven agent

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -388,8 +388,8 @@ impl AgentInfo {
     /// re-deriving the mapping (which is how "CTO Assistant" vs "CTO Bot" drift
     /// creeps in).
     /// What: Returns `display_name` when set, else `name`.
-    /// Test: `display_label_prefers_display_name`,
-    /// `display_label_falls_back_to_name`.
+    /// Test: `bundled_personas_expose_expected_display_names` (prefers
+    /// display_name), `display_label_falls_back_to_name_when_unset`.
     pub fn display_label(&self) -> &str {
         self.display_name.as_deref().unwrap_or(&self.name)
     }

--- a/crates/trusty-agents/src/agents/extends/mod.rs
+++ b/crates/trusty-agents/src/agents/extends/mod.rs
@@ -159,10 +159,12 @@ fn clear_extends(mut cfg: AgentConfig) -> AgentConfig {
 ///     carries a non-neutral value, else inherits base (a `.md` child that
 ///     omits `model` leaves it empty and inherits the base's; a `.toml` child
 ///     always declares `model`);
-///   - `display_name` / `prompt_label`: `Option` child-`Some`-wins — critically
-///     this lets a child set `display_name` even when the base has NONE (owner
-///     naming decision 2026-07-18: bases are nameless, the persona name comes
-///     from the child);
+///   - `display_name` / `prompt_label`: child-`Some`-wins; a child that OMITS
+///     it falls back to its OWN name rather than inheriting the base's
+///     (#3738 — the base `assistant` is now the named generic default
+///     "Assistant", so a nameless overlay must NOT report "Assistant" as its
+///     identity). A child can still set `display_name` even when the base has
+///     none (the reverse case);
 ///   - list fields (`tools.allowed`, `tools.allow`, `tools.scopes`,
 ///     `system_prompt.skills`, and every `capabilities` sub-list): UNION,
 ///     de-duplicated in first-seen base-first order;
@@ -174,11 +176,18 @@ fn clear_extends(mut cfg: AgentConfig) -> AgentConfig {
 /// loader after model resolution.
 /// Test: `extends_two_level_merge`, `extends_prose_base_first`,
 /// `extends_tools_union_dedup`, `extends_child_sets_display_name_over_none`,
+/// `extends_nameless_child_does_not_inherit_named_base_display`,
 /// `extends_scalar_child_override`, `extends_llm_child_overrides_temperature_only`,
 /// `extends_llm_child_overrides_max_tokens_only`,
 /// `extends_llm_child_inherits_when_omitted`.
 pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
     let mut merged = base;
+
+    // #3738: capture the base's identity BEFORE overwriting it with the
+    // child's, so the display_name/prompt_label rule below can distinguish a
+    // value the CHILD declared from one it would merely INHERIT from the base
+    // template.
+    let base_name = merged.agent.name.clone();
 
     // Identity always comes from the child — it is the concrete agent being
     // loaded, not the template it extends.
@@ -205,11 +214,26 @@ pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
     if !child.agent.description.is_empty() {
         merged.agent.description = child.agent.description;
     }
+    // `display_name` / `prompt_label`: a child that declares its own value
+    // wins (child-`Some`-wins). A child that OMITS it must fall back to its
+    // OWN name, NOT silently inherit the base's brand. Before #3738 bases were
+    // nameless (base `display_name == None`), so inheriting was a harmless
+    // no-op; now the base `assistant` is the named generic default
+    // (`display_name = "Assistant"`), and a nameless `extends = "assistant"`
+    // overlay that inherited it would report "Assistant" as its identity
+    // (e.g. `/agent my-overlay` printing "Switched to: Assistant"). A genuine
+    // extends child always has a name distinct from its base, so clear the
+    // inherited value here and let `AgentInfo::display_label` resolve to the
+    // child's own `name`.
     if child.agent.display_name.is_some() {
         merged.agent.display_name = child.agent.display_name;
+    } else if merged.agent.name != base_name {
+        merged.agent.display_name = None;
     }
     if child.agent.prompt_label.is_some() {
         merged.agent.prompt_label = child.agent.prompt_label;
+    } else if merged.agent.name != base_name {
+        merged.agent.prompt_label = None;
     }
     // `runner`: child-overrides when the child chose a non-default runner. The
     // enum has no "unset", so a non-default child value is treated as a

--- a/crates/trusty-agents/src/agents/extends/tests.rs
+++ b/crates/trusty-agents/src/agents/extends/tests.rs
@@ -302,9 +302,10 @@ content = "b"
 
 #[test]
 fn extends_child_sets_display_name_over_none() {
-    // Owner naming decision 2026-07-18: bases are nameless; the persona name
-    // comes from the child overlay. A child MUST be able to set display_name
-    // even when the base has NONE.
+    // Reverse case (still valid): when a base is nameless (display_name None),
+    // a child MUST be able to set its own. The forward case — a nameless child
+    // over the now-NAMED base `assistant` — is covered by
+    // `extends_nameless_child_does_not_inherit_named_base_display` (#3738).
     let base = cfg(r#"
 [agent]
 name = "assistant"
@@ -336,6 +337,58 @@ content = "c"
     assert_eq!(merged.agent.display_name.as_deref(), Some("Izzie"));
     // Base model inherited (child left it empty).
     assert_eq!(merged.agent.model, "m");
+}
+
+#[test]
+fn extends_nameless_child_does_not_inherit_named_base_display() {
+    // #3738: the base `assistant` is now the NAMED generic default
+    // ("Assistant"). A child overlay that omits its own display_name must NOT
+    // silently inherit that brand — it must fall back to its OWN name (via
+    // `display_label`), so `/agent my-overlay` reads "my-overlay", never
+    // "Assistant". This fixture matches PRODUCTION (base carries
+    // Some("Assistant") + prompt_label "assistant"), unlike the older
+    // `extends_child_sets_display_name_over_none` synthetic (base None).
+    let base = cfg(r#"
+[agent]
+name = "assistant"
+role = "assistant"
+model = "m"
+description = "d"
+display_name = "Assistant"
+prompt_label = "assistant"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "b"
+"#);
+    assert_eq!(base.agent.display_name.as_deref(), Some("Assistant"));
+    let ch = cfg(r#"
+[agent]
+name = "my-overlay"
+role = "agent"
+model = ""
+description = ""
+extends = "assistant"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "c"
+"#);
+    assert!(ch.agent.display_name.is_none());
+    let merged = merge_extends(base, ch);
+    // Inherited brand cleared → falls back to the child's own identity.
+    assert_eq!(
+        merged.agent.display_name, None,
+        "nameless overlay must not inherit the base's 'Assistant' brand"
+    );
+    assert_eq!(merged.agent.prompt_label, None);
+    assert_eq!(
+        merged.agent.display_label(),
+        "my-overlay",
+        "display_label must resolve to the child's own name, not 'Assistant'"
+    );
 }
 
 #[test]

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -469,6 +469,49 @@ fn bundled_agents_dir() -> PathBuf {
         .join("agents")
 }
 
+/// #3738 (MEDIUM): `cto-assistant` ships as TWO hand-maintained files — the
+/// flat `cto-assistant.toml` (what `GET /api/agents` scans, so it drives the
+/// GUI label) and the directory package `cto-assistant/agent.toml` (what the
+/// runtime loads, so it drives the actual persona identity). Both hand-carry
+/// `[agent].display_name`/`model`; nothing keeps them in sync. This guard
+/// fails CI if a future single-file edit desyncs the GUI label from the
+/// runtime identity ("CTO Bot" in one, stale in the other).
+/// Test: This function IS the test.
+#[test]
+fn cto_assistant_flat_and_package_display_name_stay_in_sync() {
+    let dir = bundled_agents_dir();
+    let read_agent_field = |path: PathBuf, field: &str| -> Option<String> {
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{} must be readable: {e}", path.display()));
+        let parsed: toml::Value =
+            toml::from_str(&raw).unwrap_or_else(|e| panic!("{} must parse: {e}", path.display()));
+        parsed
+            .get("agent")
+            .and_then(|a| a.get(field))
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    };
+    let flat = dir.join("cto-assistant.toml");
+    let package = dir.join("cto-assistant").join("agent.toml");
+
+    let flat_display = read_agent_field(flat.clone(), "display_name");
+    let package_display = read_agent_field(package.clone(), "display_name");
+    assert_eq!(
+        flat_display.as_deref(),
+        Some("CTO Bot"),
+        "flat cto-assistant.toml must declare display_name 'CTO Bot'"
+    );
+    assert_eq!(
+        flat_display, package_display,
+        "cto-assistant flat + package display_name must match (GUI label vs runtime identity)"
+    );
+    assert_eq!(
+        read_agent_field(flat, "model"),
+        read_agent_field(package, "model"),
+        "cto-assistant flat + package model must match"
+    );
+}
+
 #[test]
 fn base_assistant_package_is_generic_default_and_curated() {
     // #3054: The base `assistant` agent must load from its directory-package

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -470,11 +470,15 @@ fn bundled_agents_dir() -> PathBuf {
 }
 
 #[test]
-fn base_assistant_package_is_nameless_and_curated() {
+fn base_assistant_package_is_generic_default_and_curated() {
     // #3054: The base `assistant` agent must load from its directory-package
-    // form, carry the curated gworkspace tool surface + productivity scopes,
-    // and be NAMELESS — no persona display_name/prompt_label. Persona identity
-    // is supplied later by a user's `extends` overlay (#3055).
+    // form and carry the curated gworkspace tool surface + productivity scopes.
+    // #3738 (owner decision 2026-07-23, REVERSING the 2026-07-18 "bases are
+    // nameless" decision): the base is ALSO the concrete GENERIC "Assistant"
+    // persona — the default starting agent — so it now carries a professional,
+    // un-personalized display identity ("Assistant"). It must stay UNFLAVORED:
+    // no user binding, no user-specific (izzie-*) skills, no personal name in
+    // the persona body. A user `extends` overlay may still rename it (#3055).
     let _guard = ENV_LOCK.blocking_lock();
     clear_model_env("assistant");
     // SAFETY: guarded by ENV_LOCK.
@@ -490,15 +494,18 @@ fn base_assistant_package_is_nameless_and_curated() {
 
     assert_eq!(cfg.agent.name, "assistant");
     assert_eq!(cfg.agent.role, "assistant");
-    // Nameless: the base carries NO persona identity.
+    // #3738: the generic default carries the professional "Assistant" identity.
     assert_eq!(
-        cfg.agent.display_name, None,
-        "base assistant must be nameless (no display_name)"
+        cfg.agent.display_name.as_deref(),
+        Some("Assistant"),
+        "base assistant is the generic default persona named 'Assistant'"
     );
     assert_eq!(
-        cfg.agent.prompt_label, None,
-        "base assistant must be nameless (no prompt_label)"
+        cfg.agent.display_label(),
+        "Assistant",
+        "display_label resolves to the declared display_name"
     );
+    assert_eq!(cfg.agent.prompt_label.as_deref(), Some("assistant"));
     // Curated tool surface + scopes are present on the base.
     let allow = cfg
         .tools
@@ -618,6 +625,69 @@ fn izzie_overlay_package_parses_with_personal_deltas() {
     assert!(
         cfg.system_prompt.content.contains("Anti-Hallucination"),
         "overlay persona must carry the anti-hallucination guardrail"
+    );
+}
+
+/// #3738 (owner decision 2026-07-23): pins the canonical display names the
+/// chat surface serves — generic "Assistant" (the default), "Izzie", and
+/// "CTO Bot" — resolved through `AgentInfo::display_label` from each bundled
+/// persona's `display_name`. This is the single-source-of-truth guard that
+/// keeps the GUI's per-message speaker attribution and the REPL `/switch`
+/// label from drifting (e.g. "CTO Assistant" vs "CTO Bot").
+/// Test: This function IS the test.
+#[test]
+fn bundled_personas_expose_expected_display_names() {
+    let _guard = ENV_LOCK.blocking_lock();
+    for (agent_name, expected) in [
+        ("assistant", "Assistant"),
+        ("izzie", "Izzie"),
+        ("cto-assistant", "CTO Bot"),
+    ] {
+        clear_model_env(agent_name);
+        // SAFETY: guarded by ENV_LOCK.
+        unsafe {
+            std::env::set_var("TAGENT_CONFIG_DIR", bundled_agents_dir());
+        }
+        let cfg = AgentConfig::by_name(agent_name);
+        // SAFETY: guarded by ENV_LOCK.
+        unsafe {
+            std::env::remove_var("TAGENT_CONFIG_DIR");
+        }
+        let cfg = cfg.unwrap_or_else(|e| panic!("'{agent_name}' must resolve: {e}"));
+        assert_eq!(
+            cfg.agent.display_label(),
+            expected,
+            "'{agent_name}' must surface display name '{expected}'"
+        );
+    }
+}
+
+/// #3738: `display_label` falls back to the stable `name` id for a persona
+/// that declares no `display_name` (e.g. a worker agent), so a consumer can
+/// always render SOME label. Uses the bundled `engineer` (no display_name).
+/// Test: This function IS the test.
+#[test]
+fn display_label_falls_back_to_name_when_unset() {
+    let _guard = ENV_LOCK.blocking_lock();
+    clear_model_env("engineer");
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        std::env::set_var("TAGENT_CONFIG_DIR", bundled_agents_dir());
+    }
+    let cfg = AgentConfig::by_name("engineer");
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+    }
+    let cfg = cfg.expect("engineer must resolve");
+    assert!(
+        cfg.agent.display_name.is_none(),
+        "engineer is a worker agent with no display_name"
+    );
+    assert_eq!(
+        cfg.agent.display_label(),
+        "engineer",
+        "display_label falls back to name when display_name is unset"
     );
 }
 

--- a/crates/trusty-agents/src/api/server/projects.rs
+++ b/crates/trusty-agents/src/api/server/projects.rs
@@ -258,9 +258,10 @@ pub(super) async fn list_agents_route(State(_state): State<AppState>) -> Json<se
 /// two routes' response shapes from drifting apart.
 /// What: Parses `raw` as TOML; reads `[agent]`'s `name` (falling back to
 /// `fallback_name`, typically the file stem), `role`, `model`, `runner`,
-/// `provider_id`, and `description` (each defaulting to `""` when absent).
-/// Returns `None` when `raw` fails to parse as TOML.
-/// Test: `scan_agents_dir_parses_toml`, `patch_agent_persists_model_and_round_trips`.
+/// `provider_id`, `description`, and `display_name` (each defaulting to `""`
+/// when absent). Returns `None` when `raw` fails to parse as TOML.
+/// Test: `scan_agents_dir_parses_toml`, `patch_agent_persists_model_and_round_trips`,
+/// `parse_agent_toml_surfaces_display_name`.
 pub(super) fn parse_agent_toml(raw: &str, fallback_name: &str) -> Option<serde_json::Value> {
     let parsed: toml::Value = toml::from_str(raw).ok()?;
     let agent = parsed.get("agent");
@@ -271,6 +272,12 @@ pub(super) fn parse_agent_toml(raw: &str, fallback_name: &str) -> Option<serde_j
             .map(str::to_string)
     };
     let name = get_str("name").unwrap_or_else(|| fallback_name.to_string());
+    // #3738: surface `display_name` ("Assistant" / "Izzie" / "CTO Bot") so the
+    // GUI's per-message speaker attribution reads the persona's human-facing
+    // label straight from the catalog. Falls back to `name` (matching
+    // `AgentInfo::display_label`'s contract) rather than "" so a consumer can
+    // always render SOME label without re-deriving the mapping client-side.
+    let display_name = get_str("display_name").unwrap_or_else(|| name.clone());
     Some(serde_json::json!({
         "name": name,
         "role": get_str("role").unwrap_or_default(),
@@ -278,6 +285,7 @@ pub(super) fn parse_agent_toml(raw: &str, fallback_name: &str) -> Option<serde_j
         "runner": get_str("runner").unwrap_or_default(),
         "provider_id": get_str("provider_id").unwrap_or_default(),
         "description": get_str("description").unwrap_or_default(),
+        "display_name": display_name,
     }))
 }
 

--- a/crates/trusty-agents/src/api/server/tests/agent_patch.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_patch.rs
@@ -419,3 +419,28 @@ async fn patch_agent_invalid_name_returns_400() {
     .await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
+
+/// #3738: `GET /api/agents` must surface `[agent].display_name` so the GUI's
+/// per-message speaker attribution reads the persona's human-facing label
+/// ("CTO Bot") straight from the catalog — and must fall back to `name` when
+/// no `display_name` is declared, matching `AgentInfo::display_label`.
+#[test]
+fn parse_agent_toml_surfaces_display_name() {
+    let with_display = r#"
+[agent]
+name = "cto-assistant"
+role = "assistant"
+display_name = "CTO Bot"
+"#;
+    let parsed = parse_agent_toml(with_display, "cto-assistant").expect("valid TOML");
+    assert_eq!(parsed["display_name"], "CTO Bot");
+
+    // No display_name → falls back to name (never "").
+    let without_display = r#"
+[agent]
+name = "engineer"
+role = "engineer"
+"#;
+    let parsed = parse_agent_toml(without_display, "engineer").expect("valid TOML");
+    assert_eq!(parsed["display_name"], "engineer");
+}

--- a/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
+++ b/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
@@ -42,9 +42,10 @@ use crate::agents::RunnerKind;
 use crate::ctrl::state::ConversationTurn;
 
 /// Persona the plain CLI defaults its conversational agent to at startup
-/// (owner decision, #3406 follow-up): the assistant (Opus) is what an SSH
-/// tester is actually exercising, not the `ctrl` machine-coordination
-/// persona (local ollama). `ctrl` stays one `/switch ctrl` away.
+/// (owner decision, #3406 follow-up; reaffirmed by #3738): the generic
+/// "Assistant" is the default starting agent an SSH tester exercises, NOT the
+/// deprecated `ctrl` machine-coordination persona (local ollama). `ctrl`
+/// stays one `/switch ctrl` away but nothing defaults to it.
 const DEFAULT_PERSONA: &str = "assistant";
 
 /// Cap on retained conversation turns for the plain CLI loop.
@@ -261,5 +262,18 @@ fn resolved_credential_label(runner: RunnerKind) -> String {
              openrouter/anthropic/claude-code)",
             other.join(", ")
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DEFAULT_PERSONA;
+
+    /// #3738/#3406: the plain CLI must default to the generic "assistant"
+    /// persona at startup, never the deprecated `ctrl` coordinator.
+    #[test]
+    fn default_persona_is_generic_assistant_not_ctrl() {
+        assert_eq!(DEFAULT_PERSONA, "assistant");
+        assert_ne!(DEFAULT_PERSONA, "ctrl");
     }
 }

--- a/crates/trusty-agents/src/repl/agent_commands.rs
+++ b/crates/trusty-agents/src/repl/agent_commands.rs
@@ -80,37 +80,43 @@ impl TrustyAgentsRepl {
     /// Handle `/switch [<persona>]` — flip the active front-end "voice".
     ///
     /// Why: Users want a single discoverable command to switch between the
-    /// blessed personas (ctrl, Izzie, CTO Assistant, assistant #3303) without
+    /// blessed personas (Assistant #3738/#3303, Izzie, CTO Bot, ctrl) without
     /// memorising TOML stems. `/agent` is the more general primitive (any
     /// agent in the dir); `/switch` is the curated subset.
-    /// What: Accepts friendly aliases — "ctrl" / "izzie" / "Izzie" /
-    /// "cto" / "cto-assistant" / "CTO Assistant" / "assistant"
-    /// (case-insensitive). Empty arg lists the choices (the no-arg picker
-    /// path is handled upstream in `ReplBridge`). Switching to "ctrl" clears
-    /// any active persona.
+    /// What: Accepts friendly aliases — "assistant" (the generic default,
+    /// #3738) / "izzie" / "Izzie" / "cto" / "cto-assistant" / "cto bot" /
+    /// "ctrl" (case-insensitive). Empty arg lists the choices (the no-arg
+    /// picker path is handled upstream in `ReplBridge`). Switching to "ctrl"
+    /// (deprecated) clears any active persona.
     /// Test: `try_handle_slash_switch_*` unit tests below.
     pub(crate) fn handle_switch_command_into(&mut self, arg: &str, out: &mut String) {
         if arg.is_empty() {
             let _ = writeln!(out, "Usage: /switch <persona>");
             let _ = writeln!(out, "Available personas:");
+            // #3738: Assistant is the default; ctrl is deprecated (kept
+            // reachable, but nothing starts on it).
             let _ = writeln!(
                 out,
-                "  ctrl            project-aware orchestrator (default)"
+                "  Assistant       generic productivity assistant (default)"
             );
             let _ = writeln!(out, "  Izzie           friendly personal assistant");
-            let _ = writeln!(out, "  CTO Assistant   strategic Duetto-aware advisor");
-            let _ = writeln!(out, "  assistant       base productivity assistant");
+            let _ = writeln!(out, "  CTO Bot         strategic Duetto-aware advisor");
+            let _ = writeln!(
+                out,
+                "  ctrl            project-aware orchestrator (deprecated)"
+            );
             return;
         }
         let stem = match arg.to_lowercase().trim() {
             "ctrl" => "ctrl",
             "izzie" => "izzie",
             "assistant" => "assistant",
-            "cto" | "cto-assistant" | "cto assistant" => "cto-assistant",
+            // #3738: "cto bot" is the current display name; older aliases stay.
+            "cto" | "cto-assistant" | "cto assistant" | "cto bot" => "cto-assistant",
             other => {
                 let _ = writeln!(
                     out,
-                    "Unknown persona: {}. Valid: ctrl, Izzie, CTO Assistant, assistant",
+                    "Unknown persona: {}. Valid: Assistant, Izzie, CTO Bot, ctrl",
                     other
                 );
                 return;
@@ -148,11 +154,9 @@ impl TrustyAgentsRepl {
         cfg: &crate::agents::AgentConfig,
         out: &mut String,
     ) {
-        let display = cfg
-            .agent
-            .display_name
-            .clone()
-            .unwrap_or_else(|| cfg.agent.name.clone());
+        // #3738: single canonical accessor for the speaker label — see
+        // `AgentInfo::display_label`.
+        let display = cfg.agent.display_label().to_string();
         let label = cfg
             .agent
             .prompt_label

--- a/crates/trusty-agents/src/repl/bridge.rs
+++ b/crates/trusty-agents/src/repl/bridge.rs
@@ -124,10 +124,13 @@ impl tui::ReplHandler for ReplBridge {
                 // tag tells the inline-choice Enter handler to directly
                 // dispatch `/switch <selected>` instead of inserting the
                 // selected text into the input buffer for a second Enter.
+                // #3738: Assistant (generic default) first; CTO Bot display
+                // name; ctrl kept last (deprecated but reachable).
                 let items: Vec<String> = vec![
-                    "ctrl".to_string(),
+                    "Assistant".to_string(),
                     "Izzie".to_string(),
-                    "CTO Assistant".to_string(),
+                    "CTO Bot".to_string(),
+                    "ctrl".to_string(),
                 ];
                 let _ = tx.send(tui::ReplEvent::SetChoices {
                     items,

--- a/crates/trusty-agents/src/repl/commands/help.rs
+++ b/crates/trusty-agents/src/repl/commands/help.rs
@@ -23,7 +23,7 @@ pub(crate) fn write_help(out: &mut String) {
     /status              Controller liveness
     /session             Session ID, socket, project path
     /agent [<name>]      Switch persona, or list assistant agents
-    /switch [<name>]     Switch front-end voice (ctrl | Izzie | CTO Assistant)
+    /switch [<name>]     Switch front-end voice (Assistant | Izzie | CTO Bot | ctrl)
     /agents              List available agents
     /skills              List available skills
     /memories [query]    Search the memory store

--- a/crates/trusty-agents/src/repl/tests.rs
+++ b/crates/trusty-agents/src/repl/tests.rs
@@ -153,16 +153,18 @@ async fn try_handle_slash_switch_accepts_aliases() {
 /// picker path is opened by `ReplBridge` upstream; once the slash
 /// handler sees an empty arg it means the user typed `/switch`
 /// literally and wants the text help).
-/// What: Assert the listing mentions all three personas.
+/// What: Assert the listing mentions all personas by their #3738 display
+/// names (Assistant default, Izzie, CTO Bot) and still lists ctrl.
 /// Test: Self-explanatory.
 #[tokio::test]
 async fn try_handle_slash_switch_empty_lists_choices() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
     let r = repl.try_handle_slash("/switch").await.unwrap().unwrap();
     assert!(r.0);
-    assert!(r.1.contains("ctrl"));
+    assert!(r.1.contains("Assistant"));
     assert!(r.1.contains("Izzie"));
-    assert!(r.1.contains("CTO Assistant"));
+    assert!(r.1.contains("CTO Bot"));
+    assert!(r.1.contains("ctrl"));
 }
 
 /// Why: Garbage args must not silently activate a persona; surface a

--- a/crates/trusty-agents/tests/plain_cli_repl.rs
+++ b/crates/trusty-agents/tests/plain_cli_repl.rs
@@ -364,9 +364,10 @@ fn profile_resolves_from_env_without_interactive_prompt() {
 /// fallback tier and the plain CLI's default `/switch assistant` resolves
 /// the REAL bundled assistant persona — not a test fixture — without ever
 /// touching the developer machine's actual `$HOME`.
-/// What: asserts the startup banner shows `Switched to: assistant` (not a
-/// degrade to ctrl) and that the bundled `assistant/agent.toml` actually
-/// landed on disk under the isolated `$HOME`.
+/// What: asserts the startup banner shows `Switched to: Assistant` (the
+/// generic default persona's display name, #3738 — not a degrade to ctrl) and
+/// that the bundled `assistant/agent.toml` actually landed on disk under the
+/// isolated `$HOME`.
 /// Test: itself.
 #[test]
 fn plain_cli_resolves_assistant_via_bundled_deploy_when_no_project_tier() {
@@ -381,7 +382,10 @@ fn plain_cli_resolves_assistant_via_bundled_deploy_when_no_project_tier() {
         run_piped(&["--plain"], &[("HOME", home_str.as_str())], "/quit\n");
     assert!(success, "should exit 0 on /quit; stderr:\n{stderr}");
     assert!(
-        stdout.contains("Switched to: assistant"),
+        // #3738: the base assistant is the named generic default, so the
+        // banner now shows its display name "Assistant" (was lowercase
+        // "assistant" when the base was nameless).
+        stdout.contains("Switched to: Assistant"),
         "expected the plain CLI to default-switch to the bundled assistant persona \
          deployed to $HOME/.trusty-agents/agents/; got stdout:\n{stdout}\nstderr:\n{stderr}"
     );

--- a/crates/trusty-agents/ui/src/lib/roster.test.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.test.ts
@@ -59,6 +59,18 @@ describe('buildRoster', () => {
     expect(roster[1].description).toBe('CTO Assistant');
   });
 
+  it('prefers a catalog entry display_name over its id for the label (#3738)', () => {
+    const catalog: CatalogAgent[] = [
+      { name: 'cto-assistant', display_name: 'CTO Bot', description: 'CTO Assistant' },
+      { name: 'engineer' },
+    ];
+    const roster = buildRoster(catalog, []);
+    const cto = roster.find((r) => r.id === 'cto-assistant');
+    expect(cto?.label).toBe('CTO Bot');
+    // No display_name → label falls back to the id.
+    expect(roster.find((r) => r.id === 'engineer')?.label).toBe('engineer');
+  });
+
   it('dedupes a catalog entry literally named "assistant" against the base entry', () => {
     const catalog: CatalogAgent[] = [{ name: 'assistant' }, { name: 'engineer' }];
     const roster = buildRoster(catalog, []);

--- a/crates/trusty-agents/ui/src/lib/roster.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.ts
@@ -124,8 +124,12 @@ export function buildRoster(
     entries.push({
       id: agent.name,
       // #3738: prefer the persona's display_name ("CTO Bot") over its stable
-      // id ("cto-assistant") for the human-facing roster label.
-      label: agent.display_name || agent.name,
+      // id ("cto-assistant") for the human-facing roster label. Canonical
+      // single form shared with PR #3739 — `.trim() || name` so a blank or
+      // whitespace-only display_name (the backend already falls back to name,
+      // but a hand-edited overlay could slip one through) never yields an
+      // empty label.
+      label: agent.display_name?.trim() || agent.name,
       description: agent.description || undefined,
       source: 'catalog',
     });

--- a/crates/trusty-agents/ui/src/lib/roster.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.ts
@@ -24,6 +24,14 @@ export interface CatalogAgent {
   model?: string;
   runner?: string;
   description?: string;
+  /**
+   * #3738: the persona's human-facing speaker label ("Assistant" / "Izzie" /
+   * "CTO Bot"), served straight from `[agent].display_name` (falling back to
+   * `name` backend-side — see `parse_agent_toml`). The roster row's `label`
+   * and the per-message speaker attribution both read this so the display
+   * name is never re-derived client-side.
+   */
+  display_name?: string;
 }
 
 /** Shape of one entry returned by the Tauri `list_personalization_overlays` command. */
@@ -115,7 +123,9 @@ export function buildRoster(
     seen.add(agent.name);
     entries.push({
       id: agent.name,
-      label: agent.name,
+      // #3738: prefer the persona's display_name ("CTO Bot") over its stable
+      // id ("cto-assistant") for the human-facing roster label.
+      label: agent.display_name || agent.name,
       description: agent.description || undefined,
       source: 'catalog',
     });


### PR DESCRIPTION
Closes #3738.

Owner decision (Bob, 2026-07-23; epic #3052), for the 2026-07-24 demo: the DEFAULT starting agent is a **generic "Assistant"** persona. **Izzie** and **CTO Bot** (`cto-assistant`) are distinct, selectable identities — never the default. The deprecated `ctrl` coordinator's successor is the generic Assistant.

## What moved where

**Config packages (the decision):**
- `assistant/agent.toml` — the base package is now the concrete **generic default** persona: `display_name = "Assistant"`, `prompt_label = "assistant"`. This **reverses** the prior "bases are nameless" decision (2026-07-18). It remains the un-personalized `extends` base; `izzie`/`cto-assistant` override `display_name` via child-Some-wins per-key merge (`agents::extends::merge_extends`), so "Assistant" is only ever seen when the base is used directly as the default. Its `persona.md` is unchanged (still generic — no user binding, no `izzie-*` skills).
- `cto-assistant/agent.toml` + flat `cto-assistant.toml` — `display_name` **"CTO Assistant" → "CTO Bot"**. `prompt_label` stays `cto`.
- Izzie — **no change**: keeps `display_name = "Izzie"` and her flavor in her own `izzie/` overlay (it already lived there, not in the base).
- `ctrl` — package **left in place** (not deleted). Nothing defaults to it.

**Canonical display-name accessor (coordinates with the GUI speaker-attribution PR):**
- New `AgentInfo::display_label()` in `agents/config.rs` — `display_name` → `name` fallback. Single source of truth for the speaker label; `repl::agent_commands::activate_persona_into` now uses it (removed a duplicated `unwrap_or` mapping).
- `GET /api/agents` (`api/server/projects.rs::parse_agent_toml`) now surfaces `display_name` (falling back to `name`, never `""`), so the GUI's per-message speaker attribution reads "Assistant" / "Izzie" / "CTO Bot" from the backend without re-deriving the mapping.
- GUI `roster.ts` — `CatalogAgent.display_name` carried through; catalog rows prefer it for their label. `BASE_AGENT_ID`/`BASE_ENTRY` already label the default "Assistant".

**Nothing defaults to ctrl (user-facing default sites):**
- plain-CLI (`ctrl/repl/plain_cli.rs`) already auto-switches to `assistant` at startup (`DEFAULT_PERSONA`); doc reaffirmed, deprecation of `ctrl` noted.
- `/switch` help + inline picker (`repl/agent_commands.rs`, `repl/bridge.rs`, `repl/commands/help.rs`) now list **Assistant first (default)**, use **CTO Bot**, and mark **ctrl deprecated**. Added a `"cto bot"` alias so selecting the renamed picker item resolves.

## Decisions / scope notes for the reviewer

- **Tool scopes were NOT moved.** Izzie's weather / Metro-North tools (`get_weather`, `get_train_schedule`, `get_train_alerts`) stay on Izzie only, exactly as before — the generic Assistant does not gain them. If Bob wants those reachable from the generic Assistant, that's a deliberate follow-up (add the tools + skills to `assistant/`), not something I moved silently.
- **`--api` no-agent session path unchanged (deliberate).** When the GUI sends no roster agent, the backend routes through the tool-armed CTRL/PM session path (`run_pm_task_with_session`), NOT a tools-off persona. Re-pointing that default at a persona would reintroduce the #3279 regression (default chat silently losing delegation/tools). The "generic Assistant" identity for the GUI is served via the roster's default `Assistant` entry + the `display_name` accessor above, not by rerouting dispatch.
- **TUI (ratatui) default routing left as-is.** With no active persona the TUI's User-scope dispatch still hits `run_pm_task_with_persona("ctrl", …)`. That path carries socket/scope handling; retargeting it is riskier than tonight warrants and the TUI is gated behind #3303 (not the demo surface). Flagged as a follow-up so "nothing defaults to ctrl" holds there too.
- One prior test encoded the reversed decision (`base_assistant_package_is_nameless_and_curated`) — renamed to `base_assistant_package_is_generic_default_and_curated` and updated to assert `display_name == "Assistant"`.

## Tests

New/updated: `bundled_personas_expose_expected_display_names` (Assistant/Izzie/CTO Bot), `display_label_falls_back_to_name_when_unset`, `base_assistant_package_is_generic_default_and_curated`, `parse_agent_toml_surfaces_display_name`, `default_persona_is_generic_assistant_not_ctrl`, `try_handle_slash_switch_empty_lists_choices` (updated), roster.ts `prefers a catalog entry display_name…`.

## Gates (raw)

```
cargo fmt -p trusty-agents -- --check   → FMT_CLEAN
cargo clippy -p trusty-agents --all-targets -- -D warnings
  → Finished `dev` profile ... (no warnings from trusty-agents; only an unrelated
    proc-macro-error2 future-incompat note from a dependency)
cargo test -p trusty-agents --lib
  → test result: ok. 2218 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out
cargo test -p trusty-agents integration (api_e2e, cli_project, config_mount, plain_cli_repl, system_status_cli)
  → 4/2/3/7/2 passed; 0 failed
UI: npx vitest run src/lib/roster.test.ts
  → Test Files 1 passed (1); Tests 17 passed (17)
```

Note: a pre-existing flaky test in `workflow::…::checkpoint_resume` (a filesystem/cwd race — cf. #3673/#3608) fails intermittently under the full concurrent lib run and passes single-threaded / on a clean re-run. Unrelated to persona code.

## Merge coordination (this PR merges FIRST; #3739 rebases onto it)

This PR and #3739 both add a `display_name` field to `GET /api/agents` + `roster.ts`. The canonical contract is **this** PR's — **#3739 must rebase onto this and adopt it**:

- **Backend (`parse_agent_toml`):** `display_name` falls back to **`name`**, never `""` (`unwrap_or_else(|| name.clone())`), matching `AgentInfo::display_label()`. #3739 used `unwrap_or_default()` ("") — drop it in favor of this. Update #3739's `scan_agents_dir_exposes_display_name` test: **expected `""` → expected the agent's `name`** for a nameless agent.
- **Frontend (`roster.ts`):** reconcile to the ONE canonical line — `label: agent.display_name?.trim() || agent.name`. (Safe because the backend already guarantees non-empty; the `.trim()` only guards a whitespace-only hand-edited overlay.)
- **Extends contract (`merge_extends`):** a nameless `extends`-child does NOT inherit the now-named base's `display_name`/`prompt_label` — it falls back to its own `name`. Any #3739 code/tests that assumed inheritance of the base brand must adopt this.

## Code-critic follow-ups addressed (2 HIGH + 1 MEDIUM)

- **HIGH — inherited-label bug:** `merge_extends` now clears an inherited `display_name`/`prompt_label` when the child declared none (base `assistant` → "Assistant" no longer leaks onto nameless overlays). New test `extends_nameless_child_does_not_inherit_named_base_display` (fixture matches production `Some("Assistant")`); the older `extends_child_sets_display_name_over_none` synthetic is re-scoped as the reverse (nameless-base) case.
- **HIGH — cross-PR contract:** kept the fallback-to-name contract as canonical; see the Merge coordination note above.
- **MEDIUM — dual cto-assistant files:** new `cto_assistant_flat_and_package_display_name_stay_in_sync` guards that the flat `cto-assistant.toml` (GUI label) and package `cto-assistant/agent.toml` (runtime identity) keep matching `display_name` + `model`, failing CI on a single-file desync.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
