### PR TITLE
fix(trusty-agents): reap tagent sidecar on Cmd+Q + parent-death watchdog

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -143,7 +143,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   SIGTERM/SIGKILL previously left `tagent --api` running and holding its fixed
   port, so a later GUI launch could fail to bind or attach to a stale backend.
   Absent the flag (e.g. a hand-run `tagent --api` in a shell) the watchdog is
-  simply not armed. Unix-only; a no-op on other targets.
+  simply not armed. Unix-only; a no-op on other targets. `GET /api/health` now
+  also reports the sidecar's `pid` and `ppid` so a GUI can verify it is talking
+  to the sidecar it spawned rather than a reparented orphan on the same port.
 
 - **A parallel phase could not fail when its merge failed (#3671):**
   `executor::dispatch` folded `ConflictResolver::merge`'s `Err` into a

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -134,6 +134,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`tagent --api` self-exits when its parent GUI dies (#3734):** the sidecar
+  now accepts `--parent-pid <pid>` and, when given one, arms a parent-death
+  watchdog that self-exits the process once that parent is gone (detected by
+  reparenting away from it — on macOS to launchd, pid 1 — or the pid vanishing
+  outright). This closes the orphan class the Tauri-side quit reap cannot cover:
+  a GUI killed by macOS's synchronous Cmd+Q teardown, a crash, or an external
+  SIGTERM/SIGKILL previously left `tagent --api` running and holding its fixed
+  port, so a later GUI launch could fail to bind or attach to a stale backend.
+  Absent the flag (e.g. a hand-run `tagent --api` in a shell) the watchdog is
+  simply not armed. Unix-only; a no-op on other targets.
+
 - **A parallel phase could not fail when its merge failed (#3671):**
   `executor::dispatch` folded `ConflictResolver::merge`'s `Err` into a
   `"merge failed: ..."` string appended to the phase's content and returned

--- a/crates/trusty-agents/src/api/mod.rs
+++ b/crates/trusty-agents/src/api/mod.rs
@@ -12,6 +12,7 @@
 pub mod builder;
 pub mod server;
 pub mod types;
+pub mod watchdog;
 
 #[allow(unused_imports)]
 pub use types::{PhaseProgress, PhaseResult, PmMetadata, PmResponse, PmResponseType, PmStatus};

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -111,6 +111,16 @@ pub(super) struct TaskSubmittedBody {
 pub(super) struct HealthBody {
     status: &'static str,
     version: &'static str,
+    /// This sidecar process's own pid.
+    pid: u32,
+    /// This sidecar's parent pid (`getppid`), or `None` off unix.
+    ///
+    /// Why: #3734 — a desktop GUI must be able to tell the sidecar IT spawned
+    /// apart from a reparented orphan of a previous GUI still answering on the
+    /// same fixed port (whose own parent-death watchdog has not fired yet).
+    /// Adopting such an orphan, or marking the app "ready" against it, would go
+    /// dark the instant it self-exits. The GUI compares this to its own pid.
+    ppid: Option<u32>,
 }
 
 /// Directory under `.trusty-agents/` holding per-project TOML configs.
@@ -136,12 +146,34 @@ pub(super) fn agents_dir() -> std::path::PathBuf {
     std::path::PathBuf::from(".trusty-agents/agents")
 }
 
-/// `GET /api/health` — liveness + version probe.
+/// `GET /api/health` — liveness + version + parentage probe.
+///
+/// Why: Beyond liveness, a GUI sidecar caller uses `pid`/`ppid` to verify it is
+/// talking to the sidecar it spawned rather than a reparented orphan on the same
+/// fixed port (#3734 adoption race).
+/// What: Returns `status`/`version` plus this process's `pid` and, on unix, its
+/// `getppid()`.
+/// Test: `health_returns_ok_and_version` (asserts the pid field is present).
 pub(super) async fn health() -> Json<HealthBody> {
     Json(HealthBody {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
+        pid: std::process::id(),
+        ppid: parent_pid(),
     })
+}
+
+/// This process's parent pid, or `None` where `getppid` is unavailable.
+#[cfg(unix)]
+fn parent_pid() -> Option<u32> {
+    // SAFETY: `getppid` takes no arguments and is always safe to call.
+    Some(unsafe { libc::getppid() } as u32)
+}
+
+/// Non-unix stub: no `getppid`, so parentage is unreported.
+#[cfg(not(unix))]
+fn parent_pid() -> Option<u32> {
+    None
 }
 
 /// Extract a non-empty agent override from a task request (#3223).

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -39,6 +39,16 @@ async fn health_returns_ok_and_version() {
     let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     assert_eq!(body["status"], "ok");
     assert!(body["version"].is_string());
+    // #3734: parentage fields let a GUI verify it spawned this sidecar.
+    assert!(
+        body["pid"].is_number(),
+        "health must report the sidecar pid"
+    );
+    // `ppid` is present (a number) on unix, null off unix; either is valid JSON.
+    assert!(
+        body.get("ppid").is_some(),
+        "health must include a ppid field"
+    );
 }
 
 #[tokio::test]

--- a/crates/trusty-agents/src/api/watchdog.rs
+++ b/crates/trusty-agents/src/api/watchdog.rs
@@ -1,0 +1,178 @@
+//! Parent-death watchdog for the `tagent --api` sidecar (#3734).
+//!
+//! Why: When the trusty-agents desktop GUI spawns `tagent --api` as a sidecar,
+//! the sidecar must not outlive its parent. PR #3728 reaps it on the Tauri
+//! quit event, but that path does not fire for every GUI death: an external
+//! SIGTERM/SIGKILL, a crash, or macOS's synchronous Cmd+Q teardown can all
+//! exit the GUI without the reap running, leaving `tagent --api` orphaned
+//! (reparented to launchd, pid 1) and still holding its fixed port. A watchdog
+//! INSIDE the sidecar closes the whole orphan class: whatever kills the parent,
+//! the sidecar notices and self-exits, releasing the port.
+//! What: `arm_parent_death_watchdog(parent_pid)` spawns a background task that
+//! self-exits the process once `parent_pid` (the GUI, passed via `--parent-pid`)
+//! is gone. `watch_parent` is the pure, testable detection loop and `pid_alive`
+//! the liveness primitive. Unix-only (macOS/Linux); a no-op elsewhere.
+//! Test: `watchdog_exits_when_named_parent_dies`, `pid_alive_tracks_process`.
+
+#[cfg(unix)]
+use std::time::Duration;
+
+/// Poll interval for the parent-liveness loop. 2s keeps the watchdog cheap
+/// (a `getppid`/`kill(0)` pair costs effectively nothing) while bounding the
+/// worst-case orphan lifetime after a parent death to a couple of seconds —
+/// well within demo tolerances and far better than "forever".
+#[cfg(unix)]
+const WATCH_INTERVAL: Duration = Duration::from_secs(2);
+
+/// True while a process with `pid` still exists (we can signal it, or are
+/// merely denied permission); false once it is gone (`ESRCH`).
+///
+/// Why: The fallback death signal is "the named parent pid vanished". `kill`
+/// with signal 0 is the canonical existence probe — it delivers nothing and
+/// only reports whether the target is signalable.
+/// What: Returns `true` for `rc == 0` (alive) or `EPERM` (exists, not ours to
+/// signal); `false` for `ESRCH` (no such process) or any other error.
+/// Test: `pid_alive_tracks_process`.
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    // SAFETY: `kill` with signal 0 performs existence/permission checks only,
+    // delivering no signal; every return value is memory-safe to observe.
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    if rc == 0 {
+        return true;
+    }
+    matches!(
+        std::io::Error::last_os_error().raw_os_error(),
+        Some(libc::EPERM)
+    )
+}
+
+/// Block until the parent identified by `parent_pid` is gone, polling every
+/// `interval`.
+///
+/// Why: Two independent death signals make this robust against pid reuse. The
+/// primary one — being reparented away from whoever spawned us — is reuse-proof:
+/// our real parent dying is the only thing that changes our `getppid()` (on
+/// macOS we are reparented to launchd, pid 1). We capture our parent at entry
+/// (`armed_ppid`) and watch for it to change, rather than comparing against the
+/// passed `parent_pid`, so the check is correct even if `--parent-pid` names a
+/// pid that is not literally our direct spawner (in the GUI-sidecar case the two
+/// are identical). The secondary signal — the named `parent_pid` no longer
+/// existing — covers exactly that not-our-spawner case.
+/// What: Returns when EITHER `getppid()` changes from its entry value OR
+/// `!pid_alive(parent_pid)`. Pure control flow with no process-global side
+/// effects, so it is unit-testable without booting the API server or calling
+/// `process::exit`.
+/// Test: `watchdog_exits_when_named_parent_dies`.
+#[cfg(unix)]
+async fn watch_parent(parent_pid: u32, interval: Duration) {
+    // SAFETY: `getppid` takes no arguments and is always safe.
+    let armed_ppid = unsafe { libc::getppid() } as u32;
+    loop {
+        // Reparented away from our spawner? Fast and immune to pid reuse.
+        // SAFETY: `getppid` takes no arguments and is always safe.
+        if unsafe { libc::getppid() } as u32 != armed_ppid {
+            return;
+        }
+        // Belt-and-suspenders: the named parent pid vanished outright.
+        if !pid_alive(parent_pid) {
+            return;
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// Arm the parent-death watchdog: spawn a background task that self-exits this
+/// process once `parent_pid` is gone.
+///
+/// Why: #3734 — no GUI failure mode (Cmd+Q, crash, external SIGTERM/SIGKILL)
+/// may leave the `--api` sidecar orphaned on its fixed port. This is the
+/// guaranteed backstop that runs regardless of whether the GUI's own Tauri-side
+/// reap fires.
+/// What: Only arms for a watchable `parent_pid` (> 1). Spawns a Tokio task that
+/// awaits `watch_parent` and then `process::exit(0)`s — abrupt but reliable, so
+/// the listener/port is released immediately (the GUI is already gone, so there
+/// is no in-flight work to drain). Call once, only when running as a sidecar
+/// (i.e. the GUI passed `--parent-pid`).
+/// Test: `watchdog_exits_when_named_parent_dies` covers the detection loop the
+/// spawned task awaits; the `process::exit` shell is deliberately not unit-
+/// tested (it would terminate the test runner).
+#[cfg(unix)]
+pub fn arm_parent_death_watchdog(parent_pid: u32) {
+    if parent_pid <= 1 {
+        eprintln!(
+            "[tagent] parent-death watchdog not armed: parent pid {parent_pid} is not watchable"
+        );
+        return;
+    }
+    eprintln!("[tagent] parent-death watchdog armed for parent pid {parent_pid}");
+    tokio::spawn(async move {
+        watch_parent(parent_pid, WATCH_INTERVAL).await;
+        eprintln!(
+            "[tagent] parent pid {parent_pid} exited; shutting down --api sidecar to release its port"
+        );
+        std::process::exit(0);
+    });
+}
+
+/// Non-unix stub: the watchdog relies on `getppid`/`kill`, so arming is a no-op
+/// off unix. The desktop GUI ships on macOS; this only keeps the crate
+/// compiling on other targets.
+#[cfg(not(unix))]
+pub fn arm_parent_death_watchdog(_parent_pid: u32) {}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// `pid_alive` must read a live child as alive and a reaped one as gone —
+    /// the liveness primitive the fallback death signal depends on.
+    #[tokio::test]
+    async fn pid_alive_tracks_process() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id().expect("child pid");
+        assert!(pid_alive(pid), "freshly spawned child must read as alive");
+        child.start_kill().expect("kill child");
+        child.wait().await.expect("reap child");
+        // After reap the pid is freed and `kill(pid, 0)` returns ESRCH.
+        assert!(!pid_alive(pid), "reaped child must read as gone");
+    }
+
+    /// The headless equivalent of "spawn `tagent --api` under a short-lived
+    /// fake parent, assert self-exit": the watchdog loop must keep running
+    /// while its named parent is alive and return promptly once it dies. We
+    /// watch a real `sleep` child by pid (rather than boot the API server or
+    /// call `process::exit`, which would kill the test runner). Our own
+    /// `getppid()` never changes during the test, so only the pid-liveness
+    /// branch of `watch_parent` can fire — exactly the branch a fake parent
+    /// exercises.
+    #[tokio::test]
+    async fn watchdog_exits_when_named_parent_dies() {
+        let mut fake_parent = tokio::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn fake parent");
+        let pid = fake_parent.id().expect("fake parent pid");
+
+        let handle = tokio::spawn(watch_parent(pid, Duration::from_millis(50)));
+
+        // While the parent lives, the watchdog must not resolve.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !handle.is_finished(),
+            "watchdog must keep running while its parent is alive"
+        );
+
+        // Kill the fake parent; the watchdog must detect it and return.
+        fake_parent.start_kill().expect("kill fake parent");
+        fake_parent.wait().await.expect("reap fake parent");
+
+        tokio::time::timeout(Duration::from_secs(3), handle)
+            .await
+            .expect("watchdog must detect parent death within 3s")
+            .expect("watchdog task must not panic");
+    }
+}

--- a/crates/trusty-agents/src/runtime/startup.rs
+++ b/crates/trusty-agents/src/runtime/startup.rs
@@ -327,6 +327,34 @@ pub(super) async fn run_startup_init(_args: &[String]) -> Result<bool> {
                     break;
                 }
             }
+            // #3734: parent-death watchdog. When the desktop GUI spawns this
+            // binary as its API sidecar it passes `--parent-pid <gui_pid>`.
+            // Arm a watchdog that self-exits when that parent dies, so NO GUI
+            // failure mode (Cmd+Q's synchronous teardown, a crash, an external
+            // SIGTERM/SIGKILL) can orphan the sidecar holding its fixed port.
+            // Absent the flag (e.g. a hand-run `tagent --api` in a shell) the
+            // watchdog is simply not armed.
+            let mut parent_pid: Option<u32> = None;
+            let mut iter = raw_args.iter();
+            while let Some(a) = iter.next() {
+                if a == "--parent-pid"
+                    && let Some(v) = iter.next()
+                    && let Ok(n) = v.parse::<u32>()
+                {
+                    parent_pid = Some(n);
+                    break;
+                }
+                if let Some(rest) = a.strip_prefix("--parent-pid=")
+                    && let Ok(n) = rest.parse::<u32>()
+                {
+                    parent_pid = Some(n);
+                    break;
+                }
+            }
+            if let Some(pp) = parent_pid {
+                api::watchdog::arm_parent_death_watchdog(pp);
+            }
+
             api::server::serve_with_config(api::server::ApiConfig { bind, port, token }).await?;
             return Ok(false);
         }

--- a/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
+++ b/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
@@ -31,19 +31,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - **Cmd+Q now actually reaps the sidecar; sidecar self-exits if the GUI dies
-  any other way (#3734):** the #3372 reap was DEFERRED onto an async task
-  (`prevent_exit()` + `spawn` + `handle.exit(0)`), which never ran on macOS
-  Cmd+Q — that quit is a synchronous AppKit teardown that exits the process in
-  ~3ms, before the task is polled, so the sidecar was orphaned and kept holding
-  port 8765 (live-reproduced). The quit reap is now SYNCHRONOUS: the
-  `RunEvent::ExitRequested`/`Exit` handler blocks on `kill_sidecar` for a short
-  bounded window (500ms) so SIGTERM→(wait)→SIGKILL completes before control
-  returns to AppKit — no `prevent_exit`/`handle.exit` dance. As a guaranteed
-  backstop for every GUI failure mode the Tauri event loop can miss (Cmd+Q race,
-  crash, external SIGTERM/SIGKILL), the GUI now spawns the sidecar with
-  `--parent-pid <gui_pid>`, arming the sidecar's own parent-death watchdog
-  (trusty-agents #3734). The tray "Quit" item is simplified to route through the
-  same single synchronous reap.
+  any other way (#3734):** the #3372 reap only matched `RunEvent::ExitRequested`
+  and deferred the work onto an async task. In this tray app the window is never
+  destroyed on Cmd+Q (close only hides it), so tao maps that quit to
+  `applicationWillTerminate:` and emits `RunEvent::Exit`, NOT `ExitRequested` —
+  #3728's handler never fired, and even if it had, the deferred task never ran
+  before the ~3ms process teardown. The sidecar was orphaned and kept holding
+  port 8765 (live-reproduced). Now the handler matches BOTH `ExitRequested` and
+  `Exit` and reaps SYNCHRONOUSLY: it blocks on `kill_sidecar` for a short bounded
+  window (500ms) so SIGTERM→(wait)→SIGKILL completes before control returns to
+  AppKit — no `prevent_exit`/`handle.exit` dance. The tray "Quit" item routes
+  through the same single synchronous reap.
+- **Guaranteed backstop + no stale-sidecar adoption (#3734):** the GUI now
+  spawns the sidecar with `--parent-pid <gui_pid>`, arming the sidecar's own
+  parent-death watchdog (trusty-agents #3734) so no GUI failure mode the event
+  loop can miss (crash, SIGKILL) leaves an orphan. The health probe is now
+  parentage-aware: it accepts a sidecar as "healthy" only when it reports it is
+  parented to THIS GUI (via the new `/api/health` `ppid` field), so a fresh GUI
+  can no longer silently adopt — or mark itself ready against — a reparented
+  orphan of a previous GUI still answering on the port during the watchdog's
+  poll window. `ensure_api_server` then spawns its own sidecar and the boot
+  retry heals once the orphan releases the port.
 
 - **The `tagent --api` sidecar is now reaped on quit (#3372):** quitting the
   desktop app (tray "Quit", Cmd+Q, app-menu Quit, or an AppleScript `quit`)

--- a/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
+++ b/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
@@ -30,6 +30,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Cmd+Q now actually reaps the sidecar; sidecar self-exits if the GUI dies
+  any other way (#3734):** the #3372 reap was DEFERRED onto an async task
+  (`prevent_exit()` + `spawn` + `handle.exit(0)`), which never ran on macOS
+  Cmd+Q — that quit is a synchronous AppKit teardown that exits the process in
+  ~3ms, before the task is polled, so the sidecar was orphaned and kept holding
+  port 8765 (live-reproduced). The quit reap is now SYNCHRONOUS: the
+  `RunEvent::ExitRequested`/`Exit` handler blocks on `kill_sidecar` for a short
+  bounded window (500ms) so SIGTERM→(wait)→SIGKILL completes before control
+  returns to AppKit — no `prevent_exit`/`handle.exit` dance. As a guaranteed
+  backstop for every GUI failure mode the Tauri event loop can miss (Cmd+Q race,
+  crash, external SIGTERM/SIGKILL), the GUI now spawns the sidecar with
+  `--parent-pid <gui_pid>`, arming the sidecar's own parent-death watchdog
+  (trusty-agents #3734). The tray "Quit" item is simplified to route through the
+  same single synchronous reap.
+
 - **The `tagent --api` sidecar is now reaped on quit (#3372):** quitting the
   desktop app (tray "Quit", Cmd+Q, app-menu Quit, or an AppleScript `quit`)
   previously left the sidecar running and holding its fixed port, so repeated

--- a/crates/trusty-agents/ui/src-tauri/src/main.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/main.rs
@@ -144,35 +144,45 @@ fn main() {
         .expect("error while building tauri application");
 
     app.run(|app_handle, event| {
-        // Reap the `tagent --api` sidecar on the way out. This fires for every
-        // quit path — Cmd+Q, app-menu Quit, and the tray "Quit" item (which
-        // raises `ExitRequested` via `AppHandle::exit`).
+        // Reap the `tagent --api` sidecar on the way out. We match BOTH
+        // `ExitRequested` and `Exit` deliberately.
         //
-        // #3734 root cause: PR #3728 DEFERRED the reap onto an async task
-        // (`prevent_exit()` + `tauri::async_runtime::spawn` + `handle.exit(0)`).
-        // On macOS, Cmd+Q is a SYNCHRONOUS AppKit teardown —
-        // `applicationShouldTerminate:` is answered and the process exits in a
-        // few milliseconds. `prevent_exit()` does not retract AppKit's native
-        // termination, and the spawned task was never polled before the process
-        // was gone (live logs showed the entire quit completing in ~3.2ms with
-        // ZERO Rust log lines from the reap task). The sidecar was orphaned,
-        // reparented to launchd, and kept holding port 8765.
+        // #3734 root cause: PR #3728 handled ONLY `RunEvent::ExitRequested`, and
+        // deferred the reap onto an async task (`prevent_exit()` +
+        // `tauri::async_runtime::spawn` + `handle.exit(0)`). In this app's TRAY
+        // configuration the window is never destroyed on Cmd+Q (CloseRequested
+        // only hides it), and tao 0.35.2's macOS backend maps a Cmd+Q with no
+        // window teardown to `applicationWillTerminate:` — i.e. it emits
+        // `RunEvent::Exit`, NOT `ExitRequested`. So #3728's `ExitRequested`-only
+        // handler NEVER FIRED on Cmd+Q; the process exited in ~3ms with zero
+        // Rust log lines and the sidecar was orphaned (reparented to launchd,
+        // still holding port 8765). Two independent bugs stacked: the wrong
+        // event was matched, and even the matched path deferred work that AppKit
+        // never let run.
         //
-        // The fix is to reap SYNCHRONOUSLY inside the quit event, blocking this
-        // handler for a short bounded window (`SIDECAR_GRACE`, 500ms) so the
-        // SIGTERM→(bounded wait)→SIGKILL reap completes BEFORE we hand control
-        // back to AppKit — no deferral, no `prevent_exit`/`handle.exit` dance.
-        // `kill_sidecar` `take()`s the child, so the re-entrant `ExitRequested`
-        // (Exit follows ExitRequested) finds `None` and is a no-op. The
-        // sidecar's own parent-death watchdog (#3734) backstops any residual
-        // case (contention here, or a quit path that never reaches this event).
+        // The fix: handle `Exit` too, and reap SYNCHRONOUSLY — block this
+        // handler on `kill_sidecar` for a short bounded window (`SIDECAR_GRACE`,
+        // 500ms) so SIGTERM→(bounded wait)→SIGKILL completes BEFORE control
+        // returns to AppKit. `block_on` is safe here: this closure runs on the
+        // main event-loop thread, not a Tokio worker. `kill_sidecar` `take()`s
+        // the child, so if both events fire the second is a no-op. The sidecar's
+        // own parent-death watchdog (#3734) backstops anything this still misses
+        // (a crash, SIGKILL, or lock contention here).
+        //
+        // The eprintln is intentional and load-bearing for verification: a
+        // packaged-app Cmd+Q must show this line in the console, proving the
+        // reap branch actually ENTERS — a released port alone is insufficient
+        // evidence, because the watchdog would free the port even if this
+        // handler never ran (see the PR's manual-verification note).
         let should_reap = matches!(event, RunEvent::ExitRequested { .. } | RunEvent::Exit);
         if should_reap {
             if let Some(state) = app_handle.try_state::<SharedApi>() {
+                eprintln!("[trusty-agents-ui] quit event: reaping tagent sidecar (bounded)");
                 let state = state.inner().clone();
                 tauri::async_runtime::block_on(async move {
                     kill_sidecar(&state).await;
                 });
+                eprintln!("[trusty-agents-ui] quit event: sidecar reap complete");
             }
         }
     });

--- a/crates/trusty-agents/ui/src-tauri/src/main.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/main.rs
@@ -47,9 +47,7 @@ use overlay::{
     delete_personalization_overlay, list_personalization_overlays, read_personalization_overlay,
     write_personalization_overlay,
 };
-use sidecar::{
-    ensure_api_server, kill_sidecar, terminate_child, ApiServerState, SharedApi, SIDECAR_GRACE,
-};
+use sidecar::{ensure_api_server, kill_sidecar, ApiServerState, SharedApi};
 use task_commands::{cancel_task, check_health, clear_recent_tasks, list_tasks, send_message};
 
 /// Show and focus the main window (tray "Show" item / tray icon click).
@@ -101,17 +99,11 @@ fn main() {
                 .on_menu_event(|app, event| match event.id().as_ref() {
                     "show" => show_main_window(app),
                     "quit" => {
-                        // Reap the sidecar fully before exiting so we don't
-                        // race the process teardown, then trigger the real
-                        // exit (which also fires `RunEvent::ExitRequested`,
-                        // but `kill_sidecar` is idempotent by then).
-                        let handle = app.clone();
-                        tauri::async_runtime::spawn(async move {
-                            if let Some(state) = handle.try_state::<SharedApi>() {
-                                kill_sidecar(&state).await;
-                            }
-                            handle.exit(0);
-                        });
+                        // Just trigger the real exit. The sidecar reap is
+                        // centralized in the synchronous `RunEvent::ExitRequested`
+                        // handler below (which this `exit` raises), so every quit
+                        // path — tray, Cmd+Q, app-menu — reaps through one place.
+                        app.exit(0);
                     }
                     _ => {}
                 })
@@ -152,68 +144,35 @@ fn main() {
         .expect("error while building tauri application");
 
     app.run(|app_handle, event| {
-        if let RunEvent::ExitRequested { api, .. } = event {
-            // Real quit path: Cmd+Q, the app-menu Quit item, or the tray
-            // "Quit" item (which reaps the sidecar itself, then calls
-            // `AppHandle::exit`, which re-raises `ExitRequested`).
-            //
-            // #3372: the previous fast path only called `child.start_kill()`
-            // and returned *without awaiting the reap* — and did no graceful
-            // shutdown — so the `tagent --api` sidecar could outlive the GUI
-            // and keep holding its fixed port. Graceful-then-forced
-            // termination is inherently async (SIGTERM, then wait up to a
-            // grace window, then SIGKILL), so whenever there is a child to
-            // reap we defer the real exit: call `prevent_exit()` synchronously
-            // *before* this closure returns (the runtime checks for a pending
-            // `prevent_exit` via a synchronous `try_recv()` immediately after
-            // this closure returns — a bare fire-and-forget spawn would lose
-            // that race and let the process exit first), reap the sidecar
-            // asynchronously, then trigger the real exit ourselves.
-            //
-            // Crucially we only defer when a child is actually present. Our own
-            // `handle.exit(0)` below re-raises `ExitRequested`; by then the
-            // child slot is empty (`take()`), so this branch does nothing and
-            // the process exits — which is what breaks the re-entrant loop.
+        // Reap the `tagent --api` sidecar on the way out. This fires for every
+        // quit path — Cmd+Q, app-menu Quit, and the tray "Quit" item (which
+        // raises `ExitRequested` via `AppHandle::exit`).
+        //
+        // #3734 root cause: PR #3728 DEFERRED the reap onto an async task
+        // (`prevent_exit()` + `tauri::async_runtime::spawn` + `handle.exit(0)`).
+        // On macOS, Cmd+Q is a SYNCHRONOUS AppKit teardown —
+        // `applicationShouldTerminate:` is answered and the process exits in a
+        // few milliseconds. `prevent_exit()` does not retract AppKit's native
+        // termination, and the spawned task was never polled before the process
+        // was gone (live logs showed the entire quit completing in ~3.2ms with
+        // ZERO Rust log lines from the reap task). The sidecar was orphaned,
+        // reparented to launchd, and kept holding port 8765.
+        //
+        // The fix is to reap SYNCHRONOUSLY inside the quit event, blocking this
+        // handler for a short bounded window (`SIDECAR_GRACE`, 500ms) so the
+        // SIGTERM→(bounded wait)→SIGKILL reap completes BEFORE we hand control
+        // back to AppKit — no deferral, no `prevent_exit`/`handle.exit` dance.
+        // `kill_sidecar` `take()`s the child, so the re-entrant `ExitRequested`
+        // (Exit follows ExitRequested) finds `None` and is a no-op. The
+        // sidecar's own parent-death watchdog (#3734) backstops any residual
+        // case (contention here, or a quit path that never reaches this event).
+        let should_reap = matches!(event, RunEvent::ExitRequested { .. } | RunEvent::Exit);
+        if should_reap {
             if let Some(state) = app_handle.try_state::<SharedApi>() {
-                match state.child.try_lock() {
-                    Ok(mut guard) => {
-                        if let Some(child) = guard.take() {
-                            // Release the lock before awaiting the (up to
-                            // `SIDECAR_GRACE`) termination.
-                            drop(guard);
-                            api.prevent_exit();
-                            let handle = app_handle.clone();
-                            tauri::async_runtime::spawn(async move {
-                                terminate_child(child, SIDECAR_GRACE).await;
-                                handle.exit(0);
-                            });
-                        }
-                        // else: no child (already reaped by the tray "Quit"
-                        // path, or the re-entrant exit above) — let the exit
-                        // proceed.
-                    }
-                    Err(_) => {
-                        // Contended path: unlike the `Ok` arm, we cannot see
-                        // whether a child is present without the lock, so we
-                        // defer on *contention* — treating "someone is holding
-                        // the mutex" (a concurrent `ensure_api_server` /
-                        // `kill_sidecar`) as a proxy for "the child may be
-                        // mid-mutation, so play safe and reap via the shared
-                        // path", which re-takes the lock itself. If the slot
-                        // turns out to be empty, `kill_sidecar` is a no-op and
-                        // the subsequent `handle.exit(0)` re-raises
-                        // `ExitRequested` into the uncontended `Ok`/`None`
-                        // branch, which lets the process exit — so this cannot
-                        // loop indefinitely on transient contention.
-                        api.prevent_exit();
-                        let state = state.inner().clone();
-                        let handle = app_handle.clone();
-                        tauri::async_runtime::spawn(async move {
-                            kill_sidecar(&state).await;
-                            handle.exit(0);
-                        });
-                    }
-                }
+                let state = state.inner().clone();
+                tauri::async_runtime::block_on(async move {
+                    kill_sidecar(&state).await;
+                });
             }
         }
     });

--- a/crates/trusty-agents/ui/src-tauri/src/sidecar.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/sidecar.rs
@@ -35,11 +35,15 @@ use tokio::sync::Mutex;
 /// How long we let the sidecar shut down gracefully after SIGTERM before we
 /// escalate to SIGKILL.
 ///
-/// Why: `tagent --api` handles SIGTERM and releases its port cleanly, but a
-/// hung or wedged sidecar must not stall app quit indefinitely. Two seconds is
-/// long enough for a healthy sidecar to unbind its listener and short enough
-/// that a wedged one doesn't make quit feel broken during the demo.
-pub(crate) const SIDECAR_GRACE: Duration = Duration::from_secs(2);
+/// Why: On macOS the Cmd+Q quit path is a SYNCHRONOUS AppKit teardown
+/// (`applicationShouldTerminate:` → reply → exit) that completes in a few
+/// milliseconds (#3734 root cause). The Tauri-side reap therefore has to run
+/// synchronously inside the quit event and must stay short so it does not make
+/// quit feel laggy. 500ms is ample for a healthy `tagent --api` to catch
+/// SIGTERM and unbind its listener; anything slower is covered by the sidecar's
+/// own parent-death watchdog (#3734), which is the real guarantee against
+/// orphans — so a short bounded window here is safe.
+pub(crate) const SIDECAR_GRACE: Duration = Duration::from_millis(500);
 
 /// Shared handle to the spawned `trusty-agents --api` sidecar.
 ///
@@ -132,10 +136,17 @@ pub async fn ensure_api_server(port: u16, state: State<'_, SharedApi>) -> Result
         "spawning trusty-agents --api sidecar"
     );
 
+    // #3734: pass our own pid as `--parent-pid` so the sidecar arms its
+    // parent-death watchdog and self-exits if this GUI dies by any path the
+    // Tauri quit-event reap can miss (macOS Cmd+Q sudden teardown, a crash, an
+    // external SIGTERM/SIGKILL) — no orphan can then hold the port across a
+    // GUI restart.
     let child = tokio::process::Command::new(&binary)
         .arg("--api")
         .arg("--port")
         .arg(port.to_string())
+        .arg("--parent-pid")
+        .arg(std::process::id().to_string())
         .env("TAGENT_PROJECT_DIR", &project_root)
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())

--- a/crates/trusty-agents/ui/src-tauri/src/sidecar.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/sidecar.rs
@@ -245,15 +245,45 @@ fn which(name: &str) -> Result<std::path::PathBuf, ()> {
     Err(())
 }
 
+/// Probe `/api/health`, returning `true` only when a sidecar THIS process owns
+/// is answering on `port`.
+///
+/// Why: #3734 adoption race. A plain 200 is not enough. If a previous GUI died
+/// without its sidecar being reaped, that orphan keeps answering on the fixed
+/// port until its own parent-death watchdog fires (~2s). Both callers of this
+/// function would otherwise trust it: `ensure_api_server`'s fast path would
+/// ADOPT it (recording no child, so it can never respawn it) and `check_health`
+/// would mark the app READY against it — either way the app goes dark the
+/// instant the orphan self-exits, with no auto-heal. Gating on parentage makes
+/// "healthy" mean "MY sidecar is up": `ensure_api_server` then spawns its own
+/// and the boot loop's `ensure`-retry heals once the orphan releases the port.
+/// What: Accepts a 200 only when the reported `ppid` equals our pid. If the
+/// sidecar does not report `ppid` (older build, or non-unix where `getppid` is
+/// absent), falls back to trusting the 200 so those setups still work.
+/// Test: covered end-to-end by the desktop app; the parentage field it reads is
+/// unit-tested server-side by `health_returns_ok_and_version`.
 pub(crate) async fn http_health(port: u16) -> bool {
     let url = format!("{}/api/health", api_base(port));
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_millis(500))
         .build();
     let Ok(client) = client else { return false };
-    match client.get(&url).send().await {
-        Ok(r) => r.status().is_success(),
-        Err(_) => false,
+    let Ok(resp) = client.get(&url).send().await else {
+        return false;
+    };
+    if !resp.status().is_success() {
+        return false;
+    }
+    let Ok(body) = resp.json::<serde_json::Value>().await else {
+        // 200 but the body did not parse — trust liveness (defensive; the real
+        // server always returns JSON here).
+        return true;
+    };
+    match body.get("ppid").and_then(serde_json::Value::as_u64) {
+        // Only OUR sidecar (parented to this GUI process) counts as healthy.
+        Some(ppid) => ppid == u64::from(std::process::id()),
+        // Sidecar didn't report parentage (older/non-unix) — trust the 200.
+        None => true,
     }
 }
 


### PR DESCRIPTION
## Demo-critical regression + durable fix

Live-reproduced by Bob via a real Cmd+Q on the packaged app (`a05f82c3` build): the `tagent --api` sidecar survived, reparented to launchd (ppid 1), and kept holding port 8765. This is the reopened #3372 orphan class (tracked as #3734) plus a genuine regression on the Cmd+Q path that PR #3728 believed it had covered.

## Root cause of the non-firing reap (corrected)

Two independent bugs stacked:

1. **Wrong event matched.** This is a **tray app**: the window is never destroyed on Cmd+Q — `WindowEvent::CloseRequested` only hides it. tao 0.35.2's macOS backend maps a Cmd+Q with no window teardown to `applicationWillTerminate:`, which it surfaces as **`RunEvent::Exit`, not `RunEvent::ExitRequested`**. PR #3728 handled **only** `ExitRequested`, so on Cmd+Q its handler **never fired at all** — matching the forensics (whole quit in ~3.2ms, zero Rust log lines from the reap path).
2. **Deferred work AppKit never ran.** Even had the event matched, #3728 deferred the reap onto an async task (`prevent_exit()` + `tauri::async_runtime::spawn` + `handle.exit(0)`); `prevent_exit()` does not retract AppKit's native termination and the task was never polled before the process was gone.

## Fix — two layers

### Layer 2 (the actual Cmd+Q fix): match `Exit` + reap synchronously

The `app.run` handler now matches **both** `RunEvent::ExitRequested` and `RunEvent::Exit`, and reaps **synchronously**: it blocks on `kill_sidecar` via `tauri::async_runtime::block_on` for a short bounded window (`SIDECAR_GRACE`, lowered 2s → **500ms**), so SIGTERM→(bounded wait)→SIGKILL completes **before** control returns to AppKit — no `prevent_exit`/`handle.exit` dance. `block_on` is sound here: the closure runs on the main event-loop thread, not a Tokio worker. `kill_sidecar` `take()`s the child, so if both events fire the second is a no-op. The tray "Quit" item is simplified to `app.exit(0)`, routing every quit path through the one synchronous reap. An `eprintln` marks reap-branch entry (see manual verification below).

### Layer 1 (guaranteed backstop, closes #3734): parent-death watchdog inside `tagent`

New `crates/trusty-agents/src/api/watchdog.rs`. `--api` invoked with `--parent-pid <pid>` (the GUI now passes its own pid) arms a background task that self-exits once that parent is gone — detected by reparenting away from the armed ppid (macOS: to launchd pid 1) **or** the named pid vanishing (`kill(pid,0)`→`ESRCH`). Closes the orphan class for **any** GUI death the event loop can miss (crash, SIGKILL). Unix-only; no-op stub elsewhere.

### HIGH fix — no stale-sidecar adoption race

Previously a fresh GUI launching within the watchdog's ~2s poll window could silently **adopt** — or mark itself **ready** against — a reparented orphan of a previous GUI still answering on port 8765; when that orphan self-exited the new GUI went dark with no auto-heal. Now `GET /api/health` reports the sidecar's `pid` and `ppid`, and the GUI's `http_health` treats a sidecar as healthy **only** when it reports it is parented to this GUI process (falling back to trusting a plain 200 when parentage is unreported — older or non-unix builds). Both consumers — `ensure_api_server`'s adoption fast path and `check_health`'s readiness probe — route through `http_health`, so a fresh GUI no longer adopts a foreign sidecar: it spawns its own, and the boot loop's `ensure`-retry heals once the orphan releases the port.

## Tests

**Automated, headless (no display server, no API boot, no `process::exit`):**
- `pid_alive_tracks_process` — liveness primitive.
- `watchdog_exits_when_named_parent_dies` — the watchdog loop keeps running while a real short-lived `sleep` parent lives and returns promptly once it's killed (exercises the ESRCH/liveness branch).
- `health_returns_ok_and_version` — asserts the new `pid`/`ppid` parentage fields.

**MEDIUM — reparent-to-launchd branch has no automated test, by necessity.** A double-fork test's grandchild reparents to init/launchd (pid 1), which the test process cannot `wait` on to assert an outcome, and running the async watchdog in a `fork()`ed child of a multithreaded test binary is UB — so a fork-based test is genuinely impractical. The ESRCH branch is covered; the reparent branch is a **manual-verification** item (below).

## Manual verification required (post-merge, packaged app)

1. **Reap branch entry on real Cmd+Q** — a freed port ALONE is insufficient evidence, because the watchdog would free the port even if the Tauri handler never ran. Launch the packaged app from a terminal (so stderr is visible), Cmd+Q, and confirm the console shows `[trusty-agents-ui] quit event: reaping tagent sidecar (bounded)` followed by `… sidecar reap complete`, and that `ps` shows no `tagent --api`.
2. **Watchdog reparent path** — launch the app, `kill -9` the GUI pid (bypasses the Tauri loop entirely), and confirm the sidecar self-exits within ~2s (console shows `[tagent] parent pid <n> exited; shutting down --api sidecar …`) and the port is released.
3. **No adoption dark-GUI** — with an orphan still answering on 8765, launch a fresh GUI and confirm it comes up healthy (spawns its own sidecar) rather than going dark.

## Gates (crate-scoped, raw)

```
cargo fmt -p trusty-agents -- --check           → rc=0
cargo fmt -p trusty-agents-ui -- --check        → rc=0
cargo clippy -p trusty-agents --all-targets -- -D warnings      → Finished (clean)
cargo clippy -p trusty-agents-ui --all-targets -- -D warnings   → Finished (clean)
cargo test -p trusty-agents --lib      → test result: ok. 2228 passed; 0 failed; 12 ignored
cargo test -p trusty-agents-ui         → test result: ok. 17 passed; 0 failed; 0 ignored
scripts/check_test_pointers.sh         → test-pointers: 0 dangling pointers — OK.
scripts/check_line_cap.sh              → line-cap: 8 allowlisted, 0 violations — OK.
```

(The two `multiple build targets` clippy lines are pre-existing workspace warnings for `trusty-mpm`/`trusty-installer`, unrelated. `trusty-agents-ui` check/clippy/test require a gitignored `crates/trusty-agents/ui/dist/index.html` stub for `generate_context!()`, created the same way CI's `agents-ui` job does; not committed.)

## Changelog

`## [Unreleased]` entries in both `crates/trusty-agents/CHANGELOG.md` and `crates/trusty-agents/ui/src-tauri/CHANGELOG.md`.

Closes #3734. Refs #3372.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools