### PR TITLE
feat(trusty-agents): default assistant persona to Sonnet for latency

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
@@ -28,8 +28,11 @@ role = "assistant"
 # the claude-code CLI onto the direct-API credential path (AnthropicDirect
 # when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
 # in `src/llm/credentials.rs`. This is the base "Assistant" agent
-# (BASE_AGENT_ID in ui/src/lib/roster.ts) — testing default is Opus.
-model = "claude-opus-4-6"
+# (BASE_AGENT_ID in ui/src/lib/roster.ts) — default is Sonnet for latency
+# (owner directive 2026-07-23: trivial turns measured ~2.1s on Opus via
+# OpenRouter; Sonnet trades a small quality margin for materially lower
+# per-turn latency on the default persona).
+model = "claude-sonnet-4-6"
 description = "General-purpose productivity assistant (base template; personalize via `extends`)"
 # #3738: the generic default persona's professional display identity. Named
 # personas (izzie, cto-assistant) override these via `extends`; a user overlay

--- a/crates/trusty-agents/.trusty-agents/agents/personal-assistant.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/personal-assistant.toml
@@ -19,8 +19,8 @@ role = "assistant"
 # the claude-code CLI onto the direct-API credential path (AnthropicDirect
 # when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
 # in `src/llm/credentials.rs`. Model bumped Haiku -> Sonnet per the
-# personas-first testing default (Opus for the base Assistant, Sonnet for
-# every other persona).
+# personas-first testing default (Sonnet for every in-scope persona,
+# including the base Assistant itself since #3688).
 model = "claude-sonnet-4-6"
 description = "Izzie — personal assistant for Masa"
 display_name = "Izzie"

--- a/crates/trusty-agents/.trusty-agents/agents/pm.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/pm.toml
@@ -4,7 +4,8 @@ role = "orchestrator"
 # #3358: no `runner` — falls back to the default (Subprocess), routing off
 # the claude-code CLI onto the direct-API credential path (AnthropicDirect
 # when ANTHROPIC_API_KEY is set, else OpenRouter). See `pick_credentials()`
-# in `src/llm/credentials.rs`. Model is Opus, matching `assistant/agent.toml`
+# in `src/llm/credentials.rs`. Model is Opus (the base `assistant` moved to
+# Sonnet for latency in #3688; `pm` keeps Opus per the owner's ruling below)
 # — `pm` is the GUI's DEFAULT no-roster-selection chat backend
 # (`resolve_agent_config` in `src/ctrl/config.rs` prefers project
 # `pm.toml`), so a user who just opens the GUI and types must also get the

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- **Base `assistant` persona defaults to Sonnet instead of Opus (#3688):**
+  `claude-opus-4-6` → `claude-sonnet-4-6` on `assistant/agent.toml`, trading a
+  small quality margin for materially lower per-turn latency (a trivial turn
+  measured ~2.1s on Opus via OpenRouter). `pm` is unaffected and stays on Opus
+  per the prior owner ruling (PR #3360).
+
 ### Added
 
 - **Agent context knows "now", "here", and "who" (#3469, epic #3052):** the

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -1508,8 +1508,10 @@ fn extends_shadow_fallback_searches_home_tier_when_package_resolved_there() {
 // `claude-code-engineer` — deliberately claude-code) untouched. These tests
 // pin the resulting `runner`/`model` shape on the bundled configs so a
 // future edit can't silently reintroduce `runner = "claude-code"` on this
-// agent set, and so the Opus-for-the-base-Assistant /
-// Sonnet-for-every-other-persona testing default stays correct.
+// agent set, and so the Sonnet-for-every-in-scope-persona testing default
+// (owner directive 2026-07-23, #3688: the base `assistant` persona switched
+// from Opus to Sonnet for latency — a trivial turn measured ~2.1s on Opus
+// via OpenRouter) stays correct.
 // What: `bundled_persona_agents_do_not_use_claude_code_runner` loads each
 // in-scope agent by name (resolving through `AgentConfig::by_name`, which
 // prefers a directory package over a same-named flat file — #482) and
@@ -1527,15 +1529,17 @@ fn bundled_persona_agents_do_not_use_claude_code_runner() {
     use crate::agents::RunnerKind;
 
     let _guard = ENV_LOCK.blocking_lock();
-    // (agent name, expected model) — Opus for the base Assistant AND `pm`
-    // (the GUI's DEFAULT no-roster-selection chat backend — see
-    // `resolve_agent_config` in `src/ctrl/config.rs`, which prefers project
-    // `pm.toml` over `ctrl.toml`), Sonnet for every other in-scope persona
-    // (owner directive, #3358; `pm` bumped to Opus per the owner's ruling on
-    // the code-critic WARN on PR #3360 — the default chat must also get the
-    // Opus testing default, not just an explicit `assistant` roster pick).
+    // (agent name, expected model) — Opus for `pm` (the GUI's DEFAULT
+    // no-roster-selection chat backend — see `resolve_agent_config` in
+    // `src/ctrl/config.rs`, which prefers project `pm.toml` over
+    // `ctrl.toml`; bumped to Opus per the owner's ruling on the code-critic
+    // WARN on PR #3360 — the default chat must also get the Opus testing
+    // default, not just an explicit `assistant` roster pick), Sonnet for
+    // every other in-scope persona including the base `assistant` itself
+    // (owner directive 2026-07-23, #3688: switched from Opus to Sonnet for
+    // latency — a trivial turn measured ~2.1s on Opus via OpenRouter).
     let cases = [
-        ("assistant", "claude-opus-4-6"),
+        ("assistant", "claude-sonnet-4-6"),
         ("pm", "claude-opus-4-6"),
         ("personal-assistant", "claude-sonnet-4-6"),
         ("cto-assistant", "claude-sonnet-4-6"),

--- a/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
+++ b/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
@@ -19,7 +19,7 @@
 //! `/model` and `/provider` with no argument print their list as plain text
 //! instead of opening a ratatui modal — the whole point of this mode.
 //! What: `run_plain_cli` — builds a `TrustyAgentsRepl`, defaults its active
-//! conversational agent to `assistant` (Opus) by internally issuing
+//! conversational agent to `assistant` (Sonnet, #3688) by internally issuing
 //! `/switch assistant` — the same mechanism a user typing that command would
 //! trigger — so the owner's actual testing surface is answered by the
 //! assistant persona out of the box, not the `ctrl` coordinator (local


### PR DESCRIPTION
## Summary

- Owner directive: switch the base `assistant` persona's default model from `claude-opus-4-6` to `claude-sonnet-4-6` for latency. A trivial turn was measured at ~2.1s on Opus via OpenRouter; Sonnet trades a small quality margin for materially lower per-turn latency on the default persona.
- Updated `crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml` (the single load-bearing config — no flat `assistant.toml` sibling exists).
- Fixed the bundled-config test that pinned the old Opus expectation (`bundled_persona_agents_do_not_use_claude_code_runner` in `crates/trusty-agents/src/agents/tests/loading.rs`), plus stale comments elsewhere that claimed `assistant`'s model still matches `pm`'s or is Opus (`pm.toml`, `personal-assistant.toml`, `ctrl/repl/plain_cli.rs`).
- `pm` is untouched and stays on `claude-opus-4-6` per the prior owner ruling on the code-critic WARN on PR #3360 (it's the GUI's default no-roster-selection chat backend). No other persona's model was touched.

## Provider fallback (demo-morning runbook)

Bedrock was A/B-measured faster for non-streaming Sonnet turns (1078ms vs 1300ms median vs OpenRouter). It is selectable **config-only**, no code change needed: set `model = "bedrock/us.anthropic.claude-sonnet-4-6"` in the deployed `assistant`/`izzie` TOMLs. This is already a first-class path — `adapter_for_model`'s `bedrock/` prefix routes to the Bedrock adapter (`llm/adapter/mod.rs`), `chat_with_tools_gated`'s Bedrock branch builds the client from `TAGENT_AWS_PROFILE`/`TAGENT_AWS_REGION` (or SDK defaults) — and AWS creds were verified working.

Demo-morning decision: ship OpenRouter + token-streaming if the streaming PRs land in time; otherwise flip the deployed `~/.trusty-agents` assistant/izzie TOMLs to the `bedrock/` model string locally as a config-only fallback. Documenting it here keeps the runbook discoverable.

**Provider-prefix check (requested):** grepped every `agent.model` consumer in `crates/trusty-agents` — `adapter_for_model` (bedrock/, ollama/, fireworks/ prefixes), `qualify_openrouter_model` (explicitly leaves `bedrock/`-prefixed and any `/`-containing id alone), `merge_extends` (copies the model string as an opaque value, no parsing), and the self-identification banner in `ctrl/config.rs` (`render_user_context_block`, interpolates the raw string verbatim). Nothing assumes the model string has no provider prefix — a `bedrock/us.anthropic.claude-sonnet-4-6` value would display and merge correctly today. Confirmed only; the committed value in this PR is unchanged (`claude-sonnet-4-6`).

## Test plan

- [x] `cargo test -p trusty-agents --lib` — 2226 passed, 0 failed, 12 ignored
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-agents -- -D warnings` — clean
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling pointers

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools