### PR TITLE
fix(trusty-agents): izzie's own tools reach the --direct dispatch path (#3745 item C)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -15,6 +15,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   measured ~2.1s on Opus via OpenRouter). `pm` is unaffected and stays on Opus
   per the prior owner ruling (PR #3360).
 
+### Fixed
+
+- **Izzie's own tools now reach the `--direct`/`--agent` dispatch path (#3745
+  item C):** `tagent --direct izzie` loaded a tool registry of only
+  `[git_log, git_status, web_search, delegate_to_agent]` and the model answered
+  "weather tool unavailable" — despite `izzie/agent.toml` declaring
+  `get_weather`, `get_train_schedule`, and `get_train_alerts` in `[tools].allow`.
+  Root cause: the assistant-tier subprocess registry
+  (`runtime::tool_registry::build_assistant_tier_registry`) never registered the
+  izzie platform-hosted executors, so `scope_assistant_allowed_tools` intersected
+  the (correct) allow list against a registry lacking those tools and dropped
+  them. The persona-chat REPL path (`run_pm_task_with_persona`) already registered
+  them via `crate::tools::izzie::izzie_tools()`; the two dispatch paths had
+  diverged. Fix registers `izzie_tools()` into the assistant-tier registry so both
+  paths behave identically — reachability is still gated per-persona by
+  `[tools].allow`, so no other assistant-tier persona is widened. Config
+  resolution (package-vs-flat, `extends` merge) was verified correct and is
+  unchanged.
+
 ### Added
 
 - **Agent context knows "now", "here", and "who" (#3469, epic #3052):** the

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -411,7 +411,10 @@ pub(super) fn build_registry_for_agent(
 /// (`run_subagent`) applying the persona's `[tools].allow` glob patterns —
 /// registering a tool here is not the same as granting it.
 /// What: Registers `git_log`/`git_status` (when CWD is a git repo),
-/// `web_search`, and `delegate_to_agent` (pre-flight-validated against every
+/// `web_search`, the izzie platform-hosted tools (`get_weather`,
+/// `get_train_schedule`, `get_train_alerts` via `crate::tools::izzie::izzie_tools`,
+/// mirroring the persona-chat dispatch path — #3745 item C), and
+/// `delegate_to_agent` (pre-flight-validated against every
 /// tier `agents::agents_dir_candidates()` searches — CWD/`TAGENT_CONFIG_DIR`
 /// first, then `$HOME/.trusty-agents/agents`, the SAME tiers the actual
 /// sub-agent spawn resolves against — see #3555 delegate-resolve follow-up
@@ -421,7 +424,9 @@ pub(super) fn build_registry_for_agent(
 /// omits `list_skills`, `load_skill`, and every generic coding-agent tool
 /// (`write_file`, `run_bash`, analysis tools, …).
 /// Test: `assistant_tier_registry_excludes_skill_catalog_tools`,
-/// `assistant_tier_registry_includes_curated_tools`.
+/// `assistant_tier_registry_includes_curated_tools`,
+/// `assistant_tier_registry_includes_izzie_tools`,
+/// `izzie_allow_list_surfaces_persona_tools_through_scoping`.
 pub(super) fn build_assistant_tier_registry() -> ToolRegistry {
     let mut reg = ToolRegistry::new();
     let cwd = std::env::current_dir().unwrap_or_default();
@@ -466,6 +471,25 @@ pub(super) fn build_assistant_tier_registry() -> ToolRegistry {
                     .collect(),
             ),
     ));
+
+    // #3745 item C: register the izzie platform-hosted tools
+    // (`get_weather`, `get_train_schedule`, `get_train_alerts`) into the
+    // `--direct`/`--agent` assistant-tier registry, exactly as the
+    // persona-chat dispatch path already does
+    // (`ctrl::pm_task::dispatch::persona::run_pm_task_with_persona`, which
+    // calls `crate::tools::izzie::izzie_tools()`). Without this the two
+    // assistant dispatch paths DIVERGED: `izzie/agent.toml` declares
+    // `get_weather` et al. in `[tools].allow`, but the subprocess path's
+    // registry never registered those executors, so
+    // `scope_assistant_allowed_tools` intersected them away — leaving only
+    // git/web_search/delegate and forcing the model to answer "weather tool
+    // unavailable". Registering here only makes the tools REACHABLE; whether a
+    // given persona can call them is still gated by its `[tools].allow` globs
+    // via `scope_assistant_allowed_tools` (only izzie opts in), so other
+    // assistant-tier personas are unaffected.
+    for tool in crate::tools::izzie::izzie_tools() {
+        reg.register(tool);
+    }
 
     reg
 }

--- a/crates/trusty-agents/src/runtime/tool_registry_tests.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry_tests.rs
@@ -376,6 +376,77 @@ fn assistant_tier_registry_includes_curated_tools() {
 }
 
 #[test]
+fn assistant_tier_registry_includes_izzie_tools() {
+    // #3745 item C regression guard: the `--direct`/`--agent` assistant-tier
+    // registry must register the izzie platform-hosted tools so a persona
+    // whose `[tools].allow` opts into them (izzie) can actually reach them —
+    // exactly as the persona-chat dispatch path
+    // (`run_pm_task_with_persona`) already does. Before the fix these three
+    // tools were only registered on the REPL `/agent` path, so `--direct
+    // izzie` scoped them away and the model answered "weather tool
+    // unavailable".
+    let reg = build_registry_for_agent(
+        "izzie",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+    )
+    .expect("assistant-tier agent builds a registry");
+    for expected in ["get_weather", "get_train_schedule", "get_train_alerts"] {
+        assert!(
+            reg.contains(expected),
+            "{expected} missing from assistant-tier registry (#3745 item C)"
+        );
+    }
+}
+
+#[test]
+fn izzie_allow_list_surfaces_persona_tools_through_scoping() {
+    // End-to-end of the two functions the `--direct` path chains: the
+    // assistant-tier registry (`build_assistant_tier_registry`) plus the REAL
+    // glob-scoping (`scope_assistant_allowed_tools`). With izzie's declared
+    // `[tools].allow` including `get_weather`, the scoped result must retain
+    // it — proving the fix at the exact seam that dropped it (the allow list
+    // was correct; the tool simply was not in the registry to survive the
+    // intersection).
+    let reg = build_assistant_tier_registry();
+    let allow = vec![
+        "delegate_to_agent".to_string(),
+        "web_search".to_string(),
+        "get_weather".to_string(),
+        "get_train_schedule".to_string(),
+        "get_train_alerts".to_string(),
+    ];
+    let kept =
+        scope_assistant_allowed_tools(true, None, Some(&allow), Some(&reg)).unwrap_or_default();
+    for expected in ["get_weather", "get_train_schedule", "get_train_alerts"] {
+        assert!(
+            kept.iter().any(|n| n == expected),
+            "{expected} declared in [tools].allow must survive assistant-tier scoping, got: {kept:?}"
+        );
+    }
+}
+
+#[test]
+fn non_opted_in_persona_does_not_get_izzie_tools() {
+    // Registering the izzie tools into the shared assistant-tier registry
+    // must NOT widen a persona that never declared them: `scope_assistant_
+    // allowed_tools` still gates by the persona's own `[tools].allow`. A
+    // persona allowing only `web_search` gets only `web_search`, never
+    // `get_weather`.
+    let reg = build_assistant_tier_registry();
+    let allow = vec!["web_search".to_string()];
+    let kept =
+        scope_assistant_allowed_tools(true, None, Some(&allow), Some(&reg)).unwrap_or_default();
+    assert!(
+        !kept.iter().any(|n| n == "get_weather"),
+        "a persona that did not opt into get_weather must not receive it, got: {kept:?}"
+    );
+}
+
+#[test]
 fn role_takes_precedence_over_name_for_assistant_tier() {
     // Role gating is checked BEFORE the `name`-based match — an agent named
     // like a coding sub-agent (e.g. a persona overlay someone accidentally


### PR DESCRIPTION
## Summary

Fixes **item C of #3745** (demo-critical): `tagent --direct izzie --task "what's the weather"` loaded a tool registry of only `[git_log, git_status, web_search, delegate_to_agent]` and the model answered "weather tool unavailable" — despite `izzie/agent.toml` declaring `get_weather`, `get_train_schedule`, and `get_train_alerts` in `[tools].allow`. This kills the demo centerpiece.

## Root cause

Two assistant dispatch paths had **diverged** in what they register:

- The persona-chat REPL path (`ctrl::pm_task::dispatch::persona::run_pm_task_with_persona`) registers the izzie platform-hosted executors via `crate::tools::izzie::izzie_tools()`.
- The `--direct`/`--agent` subprocess path builds its registry with `runtime::tool_registry::build_assistant_tier_registry()`, which registered **only** git / web_search / delegate — never `izzie_tools()`.

`scope_assistant_allowed_tools` then intersects a persona's `[tools].allow` globs against the registry's schemas. Since `get_weather` et al. were never in the `--direct` registry, they were filtered out — leaving exactly the 4 tools that were both registered and allowed.

**Not** a flat-vs-package shadow bug and **not** an `extends`-merge bug: `AgentConfig::by_name_async` prefers the directory package (loader.rs), whose `[tools].allow` already lists `get_weather`. Config resolution was verified correct and is unchanged — the allow list was right; the tool simply was not in the registry to survive the intersection.

## Fix

Register `izzie_tools()` into `build_assistant_tier_registry()`, mirroring the persona-chat path so both dispatch paths behave identically. Reachability is still gated per-persona by `[tools].allow` (only izzie opts in), so no other assistant-tier persona is widened.

## Tests (deterministic)

- `assistant_tier_registry_includes_izzie_tools` — the `--direct` registry registers the three tools.
- `izzie_allow_list_surfaces_persona_tools_through_scoping` — end-to-end of `build_assistant_tier_registry` + real `scope_assistant_allowed_tools`: an izzie-shaped allow list retains `get_weather`/`get_train_schedule`/`get_train_alerts`.
- `non_opted_in_persona_does_not_get_izzie_tools` — a persona allowing only `web_search` still never receives `get_weather` (no widening).

## Verification (raw)

Gates (all green):
- `cargo test -p trusty-agents` → `test result: ok. 2229 passed; 0 failed; 12 ignored`
- `cargo clippy -p trusty-agents --all-targets -- -D warnings` → exit 0
- `cargo fmt -p trusty-agents --check` → clean
- `scripts/check_test_pointers.sh` → `0 dangling pointers — OK`
- `scripts/check_line_cap.sh` → `8 allowlisted, 0 violations — OK`

Live (`./target/debug/tagent --direct izzie`):
```
assistant-tier tool registry scoped to [tools].allow agent=izzie
  tools=Some(["web_search", "get_train_alerts", "delegate_to_agent",
              "get_weather", "git_status", "git_log", "get_train_schedule"])

Right now in NYC it's 81.7°F with clear skies and low humidity (29%) ...
No weather alerts active.
```
(Before: `tools=Some(["git_log", "git_status", "web_search", "delegate_to_agent"])`, answer "weather tool unavailable".)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools