### PR TITLE
feat(trusty-agents): live Slack conversation mirror in GUI (#3752)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -59,9 +59,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (badged `CTO Bot (as itself)`, the honest label — there is no impersonation
   mode in code). Implemented as a **low-risk relay**, not a process merge: two
   additive `Event` variants (`SlackMessageReceived` / `SlackReplySent`); a new
-  loopback-guarded `POST /api/internal/relay-event` endpoint on the `--api`
-  server that whitelists only those two `Slack*` kinds and re-publishes them onto
-  the bus feeding `/api/events`; a fire-and-forget relay call from
+  `POST /api/internal/relay-event` endpoint on the `--api` server, gated by a
+  **mandatory shared secret** (`TAGENT_RELAY_TOKEN`, sent as `x-relay-token`) —
+  the endpoint **fails closed**, rejecting every post when the secret is unset
+  server-side, since the origin guard alone admits absent-`Origin` local callers
+  who could otherwise forge a reply with a fabricated identity badge. It also
+  whitelists only those two `Slack*` kinds, validates the inbound `tier` against
+  the closed `ServiceTier` set, and re-publishes survivors onto the bus feeding
+  `/api/events`; a fire-and-forget relay call from
   `slack/handlers.rs` (inbound after dispatch, reply after `post_message`
   succeeds — Slack handling never blocks or fails on relay errors,
   `TAGENT_API_RELAY_URL` default `http://127.0.0.1:8765`); and a Foundry-styled

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -52,6 +52,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   covering ordered fragments, the terminal `done` flag, and assembled-text
   equality.
 
+- **Live Slack conversation mirror in the GUI (#3752, epic #3052):** when the
+  CTO Bot converses on Slack (`tagent --slack`), the trusty-agents GUI now shows
+  both sides of the exchange live — the inbound human message (with an honest
+  RBAC-tier badge resolved from `ChatSession.user_identity`) and the bot's reply
+  (badged `CTO Bot (as itself)`, the honest label — there is no impersonation
+  mode in code). Implemented as a **low-risk relay**, not a process merge: two
+  additive `Event` variants (`SlackMessageReceived` / `SlackReplySent`); a new
+  loopback-guarded `POST /api/internal/relay-event` endpoint on the `--api`
+  server that whitelists only those two `Slack*` kinds and re-publishes them onto
+  the bus feeding `/api/events`; a fire-and-forget relay call from
+  `slack/handlers.rs` (inbound after dispatch, reply after `post_message`
+  succeeds — Slack handling never blocks or fails on relay errors,
+  `TAGENT_API_RELAY_URL` default `http://127.0.0.1:8765`); and a Foundry-styled
+  `SlackMirror` pane that mounts only once Slack activity arrives. Badges surface
+  only introspectable facts (RBAC tier + bot identity); no invented auth states.
 - **Agent context knows "now", "here", and "who" (#3469, epic #3052):** the
   `## User Context` block prefixed onto every tagent system prompt (PM, persona,
   and ctrl turns) now carries three things the model previously had to guess at,

--- a/crates/trusty-agents/src/api/server/mod.rs
+++ b/crates/trusty-agents/src/api/server/mod.rs
@@ -33,6 +33,7 @@ mod handlers;
 mod models;
 mod project_registration;
 mod projects;
+mod relay;
 mod routes;
 mod state;
 mod task_runner;

--- a/crates/trusty-agents/src/api/server/relay.rs
+++ b/crates/trusty-agents/src/api/server/relay.rs
@@ -6,44 +6,115 @@
 //! reply events onto the API process's bus so the GUI's `/api/events` SSE
 //! stream (and thus the desktop app) sees them. Rather than merge the two
 //! processes, the gateway POSTs a serialized `Event` here and this handler
-//! re-publishes it locally — a minimal, fire-and-forget relay.
-//! What: `POST /api/internal/relay-event` accepts one JSON `Event`, rejects any
-//! kind that is not a `Slack*` mirror event (whitelist — keeps the injection
-//! surface minimal), and publishes accepted events on the process-global bus.
-//! The route inherits the router-wide same-origin write guard + optional
-//! bearer auth registered in `routes::build_router_with_origins`: a browser
-//! cross-origin POST is rejected by the guard, a server-to-server POST (no
-//! `Origin` header, e.g. the loopback Slack gateway or `curl`) is admitted, and
-//! when `--api-token` is set the caller must present the bearer token.
-//! Test: `relay_accepts_slack_event`, `relay_rejects_non_slack_kind`,
-//! `relay_rejects_malformed_body` in `super::tests::relay`.
+//! re-publishes it locally — a minimal relay.
+//! What: `POST /api/internal/relay-event` accepts one JSON `Event` ONLY when the
+//! caller presents the shared relay secret (`x-relay-token` header matching the
+//! `TAGENT_RELAY_TOKEN` env on this process); it then rejects any kind that is
+//! not a `Slack*` mirror event (whitelist) and any `SlackMessageReceived` whose
+//! `tier` is not a known `ServiceTier`, and publishes what survives. The route
+//! also inherits the router-wide same-origin write guard + optional bearer auth
+//! from `routes::build_router_with_origins`, but the mandatory shared secret is
+//! the load-bearing control: the origin guard fails OPEN for absent-`Origin`
+//! (server-to-server) callers, so without this token ANY local process could
+//! forge a reply with a fabricated identity badge — the exact honesty the pane
+//! promises. The gate is FAIL CLOSED: if `TAGENT_RELAY_TOKEN` is unset on this
+//! process, every relay POST is rejected.
+//! Test: `relay_accepts_with_matching_token`, `relay_rejects_missing_token`,
+//! `relay_rejects_wrong_token`, `relay_rejects_when_token_unset_server_side`,
+//! `relay_rejects_non_slack_kind`, `relay_rejects_unknown_tier`,
+//! `relay_rejects_malformed_body`, `relay_authorized_fails_closed_when_unset`,
+//! `tier_is_known_accepts_the_closed_set` in `super::tests::relay`.
 
 use axum::{
     Json,
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 
 use crate::events::{self, Event};
 
-/// `POST /api/internal/relay-event` — inject one `Slack*` event onto the local
-/// bus. (#3752)
+/// Header carrying the shared relay secret. MUST match the header the Slack
+/// gateway sends (`crate::slack::relay::RELAY_TOKEN_HEADER`).
+pub(super) const RELAY_TOKEN_HEADER: &str = "x-relay-token";
+
+/// Env var holding the mandatory shared secret on the `--api` process.
+pub(super) const RELAY_TOKEN_ENV: &str = "TAGENT_RELAY_TOKEN";
+
+/// Decide whether a relay request is authorized. FAIL CLOSED.
 ///
-/// Why: The only supported cross-process injection is the Slack conversation
-/// mirror, so the accepted set is deliberately a two-variant whitelist rather
-/// than "any `Event`". Admitting arbitrary events here would let a caller forge
-/// task/agent telemetry the GUI trusts; restricting to the conversation-scoped
-/// `Slack*` variants (which carry no `session_id` and drive only the mirror
-/// pane) bounds the blast radius.
-/// What: On `SlackMessageReceived` / `SlackReplySent`, publishes and returns
-/// `202 Accepted`. Any other well-formed `Event` returns `400` with a JSON
-/// error. A body that does not deserialize to `Event` is rejected upstream by
-/// axum's `Json` extractor (`422`).
-/// Test: `relay_accepts_slack_event`, `relay_rejects_non_slack_kind`,
-/// `relay_rejects_malformed_body`.
-pub(super) async fn relay_event_handler(Json(event): Json<Event>) -> Response {
+/// Why: The relay injects displayed-identity events the pane presents as
+/// truth. The origin guard admits absent-`Origin` local callers, so a shared
+/// secret is the only thing stopping a local process from forging one. Absence
+/// of a configured secret must therefore DENY, never allow.
+/// What: Returns `true` only when `expected` is present and non-empty AND
+/// `provided` equals it exactly. Any `None`/empty `expected` (secret not
+/// configured server-side) → `false`.
+/// Test: `relay_authorized_fails_closed_when_unset`,
+/// `relay_authorized_requires_exact_match`.
+pub(super) fn relay_authorized(expected: Option<&str>, provided: Option<&str>) -> bool {
+    match expected {
+        Some(exp) if !exp.is_empty() => provided == Some(exp),
+        _ => false,
+    }
+}
+
+/// Whether `tier` names a known `ServiceTier` (the closed RBAC set).
+///
+/// Why: The inbound badge renders an RBAC tier; an attacker (or a bug) must not
+/// be able to inject an arbitrary badge string, so the server validates against
+/// the enum's own serde form rather than trusting the wire value.
+/// What: Parses `tier` as a `ServiceTier` via serde (`all` / `analytics` /
+/// `read_only`); `true` iff it deserializes.
+/// Test: `tier_is_known_accepts_the_closed_set`, `tier_is_known_rejects_unknown`.
+pub(super) fn tier_is_known(tier: &str) -> bool {
+    serde_json::from_value::<crate::rbac::ServiceTier>(serde_json::Value::String(tier.to_string()))
+        .is_ok()
+}
+
+/// `POST /api/internal/relay-event` — inject one `Slack*` event onto the local
+/// bus, gated by the mandatory shared secret. (#3752)
+///
+/// Why: See the module doc — the whitelist bounds WHICH events can be injected;
+/// the shared secret bounds WHO can inject them (fail closed); the tier check
+/// bounds what a badge can claim.
+/// What: `401` when the secret is unset server-side or the `x-relay-token`
+/// header is missing/wrong; `400` for a well-formed non-`Slack*` event; `422`
+/// for an unknown tier (or a body that does not deserialize to `Event`, via the
+/// `Json` extractor); `202 Accepted` + publish otherwise.
+/// Test: `relay_accepts_with_matching_token`, `relay_rejects_missing_token`,
+/// `relay_rejects_wrong_token`, `relay_rejects_when_token_unset_server_side`,
+/// `relay_rejects_non_slack_kind`, `relay_rejects_unknown_tier`.
+pub(super) async fn relay_event_handler(headers: HeaderMap, Json(event): Json<Event>) -> Response {
+    // Mandatory shared-secret gate (fail closed).
+    let expected = std::env::var(RELAY_TOKEN_ENV).ok();
+    let expected = expected.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    let provided = headers
+        .get(RELAY_TOKEN_HEADER)
+        .and_then(|h| h.to_str().ok())
+        .map(str::trim);
+    if !relay_authorized(expected, provided) {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "error": "relay unauthorized: set TAGENT_RELAY_TOKEN on the --api process and send a matching x-relay-token header"
+            })),
+        )
+            .into_response();
+    }
+
     match &event {
-        Event::SlackMessageReceived { .. } | Event::SlackReplySent { .. } => {
+        Event::SlackMessageReceived { tier, .. } => {
+            if !tier_is_known(tier) {
+                return (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    Json(serde_json::json!({ "error": "unknown RBAC tier" })),
+                )
+                    .into_response();
+            }
+            events::publish(event);
+            StatusCode::ACCEPTED.into_response()
+        }
+        Event::SlackReplySent { .. } => {
             events::publish(event);
             StatusCode::ACCEPTED.into_response()
         }

--- a/crates/trusty-agents/src/api/server/relay.rs
+++ b/crates/trusty-agents/src/api/server/relay.rs
@@ -1,0 +1,64 @@
+//! Internal loopback relay endpoint for cross-process event injection (#3752).
+//!
+//! Why: The Slack Socket-Mode gateway (`tagent --slack`) and the GUI backend
+//! (`tagent --api`) are **separate processes** with independent event buses.
+//! For the live Slack-conversation mirror the gateway must push its inbound /
+//! reply events onto the API process's bus so the GUI's `/api/events` SSE
+//! stream (and thus the desktop app) sees them. Rather than merge the two
+//! processes, the gateway POSTs a serialized `Event` here and this handler
+//! re-publishes it locally — a minimal, fire-and-forget relay.
+//! What: `POST /api/internal/relay-event` accepts one JSON `Event`, rejects any
+//! kind that is not a `Slack*` mirror event (whitelist — keeps the injection
+//! surface minimal), and publishes accepted events on the process-global bus.
+//! The route inherits the router-wide same-origin write guard + optional
+//! bearer auth registered in `routes::build_router_with_origins`: a browser
+//! cross-origin POST is rejected by the guard, a server-to-server POST (no
+//! `Origin` header, e.g. the loopback Slack gateway or `curl`) is admitted, and
+//! when `--api-token` is set the caller must present the bearer token.
+//! Test: `relay_accepts_slack_event`, `relay_rejects_non_slack_kind`,
+//! `relay_rejects_malformed_body` in `super::tests::relay`.
+
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+use crate::events::{self, Event};
+
+/// `POST /api/internal/relay-event` — inject one `Slack*` event onto the local
+/// bus. (#3752)
+///
+/// Why: The only supported cross-process injection is the Slack conversation
+/// mirror, so the accepted set is deliberately a two-variant whitelist rather
+/// than "any `Event`". Admitting arbitrary events here would let a caller forge
+/// task/agent telemetry the GUI trusts; restricting to the conversation-scoped
+/// `Slack*` variants (which carry no `session_id` and drive only the mirror
+/// pane) bounds the blast radius.
+/// What: On `SlackMessageReceived` / `SlackReplySent`, publishes and returns
+/// `202 Accepted`. Any other well-formed `Event` returns `400` with a JSON
+/// error. A body that does not deserialize to `Event` is rejected upstream by
+/// axum's `Json` extractor (`422`).
+/// Test: `relay_accepts_slack_event`, `relay_rejects_non_slack_kind`,
+/// `relay_rejects_malformed_body`.
+pub(super) async fn relay_event_handler(Json(event): Json<Event>) -> Response {
+    match &event {
+        Event::SlackMessageReceived { .. } | Event::SlackReplySent { .. } => {
+            events::publish(event);
+            StatusCode::ACCEPTED.into_response()
+        }
+        other => {
+            tracing::warn!(
+                kind = ?std::mem::discriminant(other),
+                "relay-event rejected: only slack_* event kinds are accepted"
+            );
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "relay endpoint accepts only slack_message_received / slack_reply_sent"
+                })),
+            )
+                .into_response()
+        }
+    }
+}

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -36,6 +36,7 @@ use super::handlers::{
 use super::models::get_models;
 use super::project_registration::{connect_project, get_project_config};
 use super::projects::{list_agents_route, list_projects, list_sessions_route};
+use super::relay::relay_event_handler;
 use super::state::AppState;
 use super::tm::{
     tm_capture_pane, tm_create_session, tm_kill_session, tm_list_sessions, tm_pause_session,
@@ -176,6 +177,12 @@ pub fn build_router_with_origins(
         .route("/api/tm/tell", post(tm_tell))
         // #192 Phase B: SSE event stream — replaces 2s stderr polling.
         .route("/api/events", get(events_handler))
+        // #3752: internal loopback relay — the separate `tagent --slack`
+        // process POSTs its Slack-mirror events here so they reach this
+        // process's bus (and the GUI's `/api/events` stream). Guarded by the
+        // router-wide same-origin/bearer stack applied below; the handler
+        // additionally whitelists only `Slack*` event kinds.
+        .route("/api/internal/relay-event", post(relay_event_handler))
         // #460: unified rpc.discover from linked ServiceDescriptor impls.
         // JSON-RPC POST endpoint that returns the merged OpenRPC manifest
         // covering every in-process MCP service (trusty-memory linked,

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -12,6 +12,7 @@ mod ctrl_sessions;
 mod guard;
 mod listing;
 mod models;
+mod relay;
 
 use super::routes::{build_router, build_router_with_config};
 use super::state::{AppState, MAX_RETAINED};

--- a/crates/trusty-agents/src/api/server/tests/relay.rs
+++ b/crates/trusty-agents/src/api/server/tests/relay.rs
@@ -2,43 +2,111 @@
 //!
 //! Why: `POST /api/internal/relay-event` injects events onto the GUI bus from
 //! the separate `tagent --slack` process. Its contract is narrow and
-//! security-relevant: accept only the two `Slack*` mirror kinds, publish them
-//! so `/api/events` subscribers see them, and reject everything else (a forged
-//! task/agent event, or a malformed body). These cases lock that contract.
-//! What: oneshots the endpoint on a default (loopback-only) router — the guard
-//! fails open on the absent `Origin` header, mirroring the real server-to-server
-//! POST from the loopback Slack gateway.
+//! security-relevant: it is the load-bearing honesty control for the mirror
+//! pane, so it must FAIL CLOSED without the shared secret, reject a wrong/
+//! missing token, accept only with a matching token, then accept only the two
+//! `Slack*` kinds with a known RBAC tier. These cases lock that contract.
+//! What: oneshots the endpoint on a default (loopback-only) router — the origin
+//! guard fails open on the absent `Origin` header (the real server-to-server
+//! posture), so the shared-secret gate is what actually protects the route.
+//! `TAGENT_RELAY_TOKEN` is a process-global env var, so every test that sets it
+//! holds `RELAY_ENV_LOCK` for its whole body (the parent `tests` module allows
+//! `await_holding_lock`), and only relay tests read this var.
 //! Test: this module IS the test.
+
+use std::sync::Mutex;
 
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
 use tower::ServiceExt;
 
+use crate::api::server::relay::{relay_authorized, tier_is_known};
 use crate::api::server::routes::build_router;
 use crate::api::server::state::AppState;
 use crate::events;
 
-/// POST a raw JSON body to the relay endpoint and return the status.
-async fn post_relay(json_body: &str) -> StatusCode {
+/// Serializes tests that mutate `TAGENT_RELAY_TOKEN` (process-global env).
+static RELAY_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const RELAY_TOKEN_ENV: &str = "TAGENT_RELAY_TOKEN";
+const RELAY_TOKEN_HEADER: &str = "x-relay-token";
+
+/// Set (`Some`) or clear (`None`) the server-side relay secret.
+///
+/// SAFETY: every caller holds `RELAY_ENV_LOCK` for its whole body and only
+/// relay tests read this var, so no concurrent get/set can race.
+fn set_relay_env(val: Option<&str>) {
+    unsafe {
+        match val {
+            Some(v) => std::env::set_var(RELAY_TOKEN_ENV, v),
+            None => std::env::remove_var(RELAY_TOKEN_ENV),
+        }
+    }
+}
+
+/// POST a raw JSON body to the relay endpoint (optionally with an
+/// `x-relay-token` header) and return the response status.
+async fn post_relay(json_body: &str, token_header: Option<&str>) -> StatusCode {
     let app = build_router(AppState::default());
-    let req = Request::builder()
+    let mut builder = Request::builder()
         .method(Method::POST)
         .uri("/api/internal/relay-event")
-        .header(header::CONTENT_TYPE, "application/json")
-        .body(Body::from(json_body.to_string()))
-        .unwrap();
+        .header(header::CONTENT_TYPE, "application/json");
+    if let Some(t) = token_header {
+        builder = builder.header(RELAY_TOKEN_HEADER, t);
+    }
+    let req = builder.body(Body::from(json_body.to_string())).unwrap();
     app.oneshot(req).await.unwrap().status()
 }
 
-#[tokio::test]
-async fn relay_accepts_slack_event() {
-    // Subscribe BEFORE the request so we can confirm the handler actually
-    // published the event onto the process bus (not merely returned 202).
-    let mut rx = events::subscribe();
+fn inbound_body(tier: &str) -> String {
+    serde_json::to_string(&events::Event::SlackMessageReceived {
+        channel: "C0123ABC".into(),
+        user_display: "Masa".into(),
+        text: "deploy status?".into(),
+        tier: tier.into(),
+    })
+    .unwrap()
+}
 
-    // The bus is process-global and other tests publish onto it concurrently,
-    // so key on a unique channel id and drain to find our injected event
-    // rather than assuming it is the very next message.
+// -- shared-secret gate (fail closed) ---------------------------------------
+
+#[tokio::test]
+async fn relay_rejects_when_token_unset_server_side() {
+    let _g = RELAY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set_relay_env(None); // secret not configured → reject everything.
+    // Even a well-formed event carrying *some* token is rejected.
+    let status = post_relay(&inbound_body("all"), Some("anything")).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn relay_rejects_missing_token() {
+    let _g = RELAY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set_relay_env(Some("s3cret"));
+    let status = post_relay(&inbound_body("all"), None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    set_relay_env(None);
+}
+
+#[tokio::test]
+async fn relay_rejects_wrong_token() {
+    let _g = RELAY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set_relay_env(Some("s3cret"));
+    let status = post_relay(&inbound_body("all"), Some("nope")).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    set_relay_env(None);
+}
+
+// -- accept path + payload validation (with a matching token) ---------------
+
+#[tokio::test]
+async fn relay_accepts_with_matching_token() {
+    let _g = RELAY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set_relay_env(Some("s3cret"));
+
+    // Subscribe BEFORE the request to confirm the handler actually published.
+    let mut rx = events::subscribe();
     let unique_channel = "C_RELAY_ACCEPT_TEST";
     let body = serde_json::to_string(&events::Event::SlackMessageReceived {
         channel: unique_channel.into(),
@@ -48,22 +116,17 @@ async fn relay_accepts_slack_event() {
     })
     .unwrap();
 
-    assert_eq!(post_relay(&body).await, StatusCode::ACCEPTED);
+    assert_eq!(
+        post_relay(&body, Some("s3cret")).await,
+        StatusCode::ACCEPTED
+    );
 
-    // Publish is synchronous, so by the time `oneshot` returned our event is
-    // already queued. Drain everything currently buffered and confirm ours is
-    // present with the honest tier badge intact.
+    // The bus is process-global, so drain and find our unique event.
     let mut found = false;
     while let Ok(ev) = rx.try_recv() {
-        if let events::Event::SlackMessageReceived {
-            channel,
-            user_display,
-            tier,
-            ..
-        } = ev
+        if let events::Event::SlackMessageReceived { channel, tier, .. } = ev
             && channel == unique_channel
         {
-            assert_eq!(user_display, "Masa");
             assert_eq!(tier, "all");
             found = true;
         }
@@ -72,27 +135,72 @@ async fn relay_accepts_slack_event() {
         found,
         "relay did not publish the injected event onto the bus"
     );
+    set_relay_env(None);
 }
 
 #[tokio::test]
 async fn relay_rejects_non_slack_kind() {
+    let _g = RELAY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set_relay_env(Some("s3cret"));
     // A well-formed, non-Slack event kind is rejected by the whitelist so the
     // GUI can't be fed forged task/agent telemetry through this surface.
     let body = serde_json::to_string(&events::Event::Ping).unwrap();
-    assert_eq!(post_relay(&body).await, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        post_relay(&body, Some("s3cret")).await,
+        StatusCode::BAD_REQUEST
+    );
+    set_relay_env(None);
+}
+
+#[tokio::test]
+async fn relay_rejects_unknown_tier() {
+    let _g = RELAY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set_relay_env(Some("s3cret"));
+    // A tier outside the closed ServiceTier set must not become a badge.
+    let status = post_relay(&inbound_body("root"), Some("s3cret")).await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    set_relay_env(None);
 }
 
 #[tokio::test]
 async fn relay_rejects_malformed_body() {
+    let _g = RELAY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set_relay_env(Some("s3cret"));
     // An unknown `type` tag never deserializes to `Event`; axum's `Json`
-    // extractor rejects it before the handler runs (422). Either way it is a
+    // extractor rejects it (422) before the handler runs. Either way it is a
     // client error, never a 2xx.
-    let status = post_relay(r#"{"type":"not_a_real_kind","x":1}"#).await;
+    let status = post_relay(r#"{"type":"not_a_real_kind","x":1}"#, Some("s3cret")).await;
     assert!(status.is_client_error(), "expected 4xx, got {status}");
+    set_relay_env(None);
 }
 
-#[tokio::test]
-async fn relay_rejects_non_json_body() {
-    let status = post_relay("this is not json").await;
-    assert!(status.is_client_error(), "expected 4xx, got {status}");
+// -- pure helpers -----------------------------------------------------------
+
+#[test]
+fn relay_authorized_fails_closed_when_unset() {
+    // No secret configured server-side → deny, regardless of what's provided.
+    assert!(!relay_authorized(None, Some("anything")));
+    assert!(!relay_authorized(None, None));
+    assert!(!relay_authorized(Some(""), Some("")));
+}
+
+#[test]
+fn relay_authorized_requires_exact_match() {
+    assert!(relay_authorized(Some("abc"), Some("abc")));
+    assert!(!relay_authorized(Some("abc"), Some("abcd")));
+    assert!(!relay_authorized(Some("abc"), None));
+}
+
+#[test]
+fn tier_is_known_accepts_the_closed_set() {
+    assert!(tier_is_known("all"));
+    assert!(tier_is_known("analytics"));
+    assert!(tier_is_known("read_only"));
+}
+
+#[test]
+fn tier_is_known_rejects_unknown() {
+    assert!(!tier_is_known("root"));
+    assert!(!tier_is_known(""));
+    assert!(!tier_is_known("ALL"));
 }

--- a/crates/trusty-agents/src/api/server/tests/relay.rs
+++ b/crates/trusty-agents/src/api/server/tests/relay.rs
@@ -1,0 +1,98 @@
+//! Tests for the internal Slack-mirror relay endpoint (#3752).
+//!
+//! Why: `POST /api/internal/relay-event` injects events onto the GUI bus from
+//! the separate `tagent --slack` process. Its contract is narrow and
+//! security-relevant: accept only the two `Slack*` mirror kinds, publish them
+//! so `/api/events` subscribers see them, and reject everything else (a forged
+//! task/agent event, or a malformed body). These cases lock that contract.
+//! What: oneshots the endpoint on a default (loopback-only) router — the guard
+//! fails open on the absent `Origin` header, mirroring the real server-to-server
+//! POST from the loopback Slack gateway.
+//! Test: this module IS the test.
+
+use axum::body::Body;
+use axum::http::{Method, Request, StatusCode, header};
+use tower::ServiceExt;
+
+use crate::api::server::routes::build_router;
+use crate::api::server::state::AppState;
+use crate::events;
+
+/// POST a raw JSON body to the relay endpoint and return the status.
+async fn post_relay(json_body: &str) -> StatusCode {
+    let app = build_router(AppState::default());
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/api/internal/relay-event")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(json_body.to_string()))
+        .unwrap();
+    app.oneshot(req).await.unwrap().status()
+}
+
+#[tokio::test]
+async fn relay_accepts_slack_event() {
+    // Subscribe BEFORE the request so we can confirm the handler actually
+    // published the event onto the process bus (not merely returned 202).
+    let mut rx = events::subscribe();
+
+    // The bus is process-global and other tests publish onto it concurrently,
+    // so key on a unique channel id and drain to find our injected event
+    // rather than assuming it is the very next message.
+    let unique_channel = "C_RELAY_ACCEPT_TEST";
+    let body = serde_json::to_string(&events::Event::SlackMessageReceived {
+        channel: unique_channel.into(),
+        user_display: "Masa".into(),
+        text: "deploy status?".into(),
+        tier: "all".into(),
+    })
+    .unwrap();
+
+    assert_eq!(post_relay(&body).await, StatusCode::ACCEPTED);
+
+    // Publish is synchronous, so by the time `oneshot` returned our event is
+    // already queued. Drain everything currently buffered and confirm ours is
+    // present with the honest tier badge intact.
+    let mut found = false;
+    while let Ok(ev) = rx.try_recv() {
+        if let events::Event::SlackMessageReceived {
+            channel,
+            user_display,
+            tier,
+            ..
+        } = ev
+            && channel == unique_channel
+        {
+            assert_eq!(user_display, "Masa");
+            assert_eq!(tier, "all");
+            found = true;
+        }
+    }
+    assert!(
+        found,
+        "relay did not publish the injected event onto the bus"
+    );
+}
+
+#[tokio::test]
+async fn relay_rejects_non_slack_kind() {
+    // A well-formed, non-Slack event kind is rejected by the whitelist so the
+    // GUI can't be fed forged task/agent telemetry through this surface.
+    let body = serde_json::to_string(&events::Event::Ping).unwrap();
+    assert_eq!(post_relay(&body).await, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn relay_rejects_malformed_body() {
+    // An unknown `type` tag never deserializes to `Event`; axum's `Json`
+    // extractor rejects it before the handler runs (422). Either way it is a
+    // client error, never a 2xx.
+    let status = post_relay(r#"{"type":"not_a_real_kind","x":1}"#).await;
+    assert!(status.is_client_error(), "expected 4xx, got {status}");
+}
+
+#[tokio::test]
+async fn relay_rejects_non_json_body() {
+    let status = post_relay("this is not json").await;
+    assert!(status.is_client_error(), "expected 4xx, got {status}");
+}

--- a/crates/trusty-agents/src/events.rs
+++ b/crates/trusty-agents/src/events.rs
@@ -269,6 +269,43 @@ pub enum Event {
         table_rows: Vec<(String, String)>,
     },
 
+    // -- Slack conversation mirror (#3752, epic #3052) --
+    /// Emitted (via the `--api` relay endpoint) when the Slack gateway
+    /// receives an inbound human message it is about to dispatch to ctrl.
+    ///
+    /// Why: The GUI mirrors both sides of a live Slack conversation so an
+    /// operator watching the desktop app sees what the bot is fielding in
+    /// real time. This is the inbound half; `SlackReplySent` is the reply.
+    /// `tier` is the resolved RBAC `ServiceTier` label (`all` / `analytics`
+    /// / `read_only`) so the UI can render an honest access-level badge —
+    /// only introspectable facts, never an invented auth state.
+    /// What: `channel` is the Slack channel id; `user_display` is the RBAC
+    /// display name; `text` is the raw inbound message; `tier` is the
+    /// snake_case tier label. Carries no `session_id` (see `session_id`).
+    /// Test: `slack_message_received_round_trips`.
+    SlackMessageReceived {
+        channel: String,
+        user_display: String,
+        text: String,
+        tier: String,
+    },
+
+    /// Emitted (via the `--api` relay endpoint) after the Slack gateway has
+    /// successfully posted the bot's reply back to the channel.
+    ///
+    /// Why: The reply half of the live Slack mirror. `identity` is the
+    /// honest speaker label — the bot always replies *as itself*; there is
+    /// no impersonation ("as-Bob") mode in code, so the UI must not fabricate
+    /// one.
+    /// What: `channel` is the Slack channel id; `text` is the reply body;
+    /// `identity` is the honest bot-identity label. Carries no `session_id`.
+    /// Test: `slack_reply_sent_round_trips`.
+    SlackReplySent {
+        channel: String,
+        text: String,
+        identity: String,
+    },
+
     // -- Keepalive --
     Ping,
 }
@@ -306,7 +343,10 @@ impl Event {
             | Event::AgentStarted { session_id, .. }
             | Event::ReportGenerated { session_id, .. }
             | Event::RecapGenerated { session_id, .. } => Some(session_id),
-            Event::Ping => None,
+            // Slack-mirror events are conversation-scoped, not task-scoped:
+            // like `Ping` they carry no `session_id`, so they always pass the
+            // SSE session filter and reach the GUI's app-lifetime EventSource.
+            Event::SlackMessageReceived { .. } | Event::SlackReplySent { .. } | Event::Ping => None,
         }
     }
 }
@@ -509,6 +549,62 @@ mod tests {
         assert_eq!(out.chars().count(), 4); // 3 + ellipsis
         assert!(out.starts_with("abc"));
         assert!(out.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn slack_message_received_round_trips() {
+        let ev = Event::SlackMessageReceived {
+            channel: "C0123ABC".into(),
+            user_display: "Masa".into(),
+            text: "what's the deploy status?".into(),
+            tier: "all".into(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"type\":\"slack_message_received\""), "{s}");
+        assert!(s.contains("\"tier\":\"all\""), "{s}");
+        // Slack-mirror events must not carry a session_id (always pass the filter).
+        assert_eq!(ev.session_id(), None);
+        let back: Event = serde_json::from_str(&s).unwrap();
+        match back {
+            Event::SlackMessageReceived {
+                channel,
+                user_display,
+                text,
+                tier,
+            } => {
+                assert_eq!(channel, "C0123ABC");
+                assert_eq!(user_display, "Masa");
+                assert_eq!(text, "what's the deploy status?");
+                assert_eq!(tier, "all");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slack_reply_sent_round_trips() {
+        let ev = Event::SlackReplySent {
+            channel: "C0123ABC".into(),
+            text: "Deploy is green.".into(),
+            identity: "CTO Bot (as itself)".into(),
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"type\":\"slack_reply_sent\""), "{s}");
+        assert!(s.contains("CTO Bot (as itself)"), "{s}");
+        assert_eq!(ev.session_id(), None);
+        let back: Event = serde_json::from_str(&s).unwrap();
+        match back {
+            Event::SlackReplySent {
+                channel,
+                text,
+                identity,
+            } => {
+                assert_eq!(channel, "C0123ABC");
+                assert_eq!(text, "Deploy is green.");
+                assert_eq!(identity, "CTO Bot (as itself)");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/trusty-agents/src/repl/event_display.rs
+++ b/crates/trusty-agents/src/repl/event_display.rs
@@ -97,6 +97,9 @@ pub fn format_event(event: &Event) -> Option<String> {
         | Event::AgentStarted { .. }
         | Event::ReportGenerated { .. }
         | Event::AstOperation { .. } => None,
+        // #3752: Slack-mirror events are a GUI-only concern (injected onto the
+        // `--api` bus via the relay endpoint); the REPL never surfaces them.
+        Event::SlackMessageReceived { .. } | Event::SlackReplySent { .. } => None,
         // #371: render a one-line recap banner when a session recap is generated.
         Event::RecapGenerated { summary, .. } => {
             Some(dim.paint(format!("  ※ recap: {summary}")).to_string())

--- a/crates/trusty-agents/src/slack/handlers.rs
+++ b/crates/trusty-agents/src/slack/handlers.rs
@@ -309,6 +309,19 @@ pub(super) async fn handle_message(
         "slack dispatch"
     );
 
+    // #3752: mirror the inbound human message to the GUI live-activity pane.
+    // Detached (fire-and-forget) so a slow/absent `--api` process never delays
+    // the Slack reply; the honest RBAC-tier badge comes from the resolved
+    // identity, not an invented auth state.
+    tokio::spawn(super::relay::relay_event(
+        crate::events::Event::SlackMessageReceived {
+            channel: channel.clone(),
+            user_display: user_cfg.name.clone(),
+            text: text.clone(),
+            tier: super::relay::tier_label(&user_identity.tier).to_string(),
+        },
+    ));
+
     let result = ctrl::run_pm_task_with_persona(
         &path,
         &active_persona,
@@ -343,7 +356,24 @@ pub(super) async fn handle_message(
         }
     };
 
-    send_long_message(bot_token, &channel, thread_ts.as_deref(), &response_text).await
+    let send_result =
+        send_long_message(bot_token, &channel, thread_ts.as_deref(), &response_text).await;
+
+    // #3752: mirror the reply to the GUI only after it was actually posted to
+    // Slack, so the pane never shows a reply the channel never received. The
+    // identity label is honest — the bot replies as itself (no impersonation
+    // mode exists). Detached so relay latency/failure never affects the reply.
+    if send_result.is_ok() {
+        tokio::spawn(super::relay::relay_event(
+            crate::events::Event::SlackReplySent {
+                channel: channel.clone(),
+                text: response_text.clone(),
+                identity: super::relay::BOT_IDENTITY.to_string(),
+            },
+        ));
+    }
+
+    send_result
 }
 
 /// Post a single message via `chat.postMessage`.

--- a/crates/trusty-agents/src/slack/mod.rs
+++ b/crates/trusty-agents/src/slack/mod.rs
@@ -28,6 +28,7 @@ mod format;
 mod handlers;
 mod pairing;
 mod rbac;
+mod relay;
 
 #[cfg(test)]
 mod tests;

--- a/crates/trusty-agents/src/slack/relay.rs
+++ b/crates/trusty-agents/src/slack/relay.rs
@@ -1,0 +1,153 @@
+//! Fire-and-forget relay client: pushes Slack-mirror events to the `--api`
+//! process so the GUI can render both sides of a live conversation (#3752).
+//!
+//! Why: The Slack gateway (`tagent --slack`) and the GUI backend
+//! (`tagent --api`) are separate processes. To mirror a conversation in the
+//! GUI the gateway POSTs each inbound / reply event to the API process's
+//! `/api/internal/relay-event` endpoint, which re-publishes it on the bus that
+//! feeds `/api/events`. This MUST never block or fail Slack handling: the relay
+//! is best-effort telemetry, so every failure path logs and returns rather than
+//! propagating — the human on Slack still gets their reply even when no GUI is
+//! running.
+//! What: `relay_event` resolves the target URL (`TAGENT_API_RELAY_URL`, default
+//! `http://127.0.0.1:8765`), POSTs the serialized `Event` with a short timeout,
+//! and swallows all errors. `tier_label` renders an RBAC `ServiceTier` as the
+//! honest snake_case badge string; `BOT_IDENTITY` is the honest reply-speaker
+//! label (the bot always speaks as itself — there is no impersonation mode).
+//! Test: `relay_tolerates_unreachable_server`, `tier_label_matches_serde`,
+//! `relay_endpoint_defaults_and_trims` in `super::tests`.
+
+use std::time::Duration;
+
+use tracing::warn;
+
+use crate::events::Event;
+use crate::rbac::ServiceTier;
+
+/// Default relay target when `TAGENT_API_RELAY_URL` is unset — the loopback
+/// port the Tauri shell launches `tagent --api` on (`App.svelte` bootstrap).
+pub(super) const DEFAULT_RELAY_URL: &str = "http://127.0.0.1:8765";
+
+/// Short per-request timeout. The relay is fire-and-forget; a hung GUI backend
+/// must not stall the Slack reply path, so we cap the attempt aggressively.
+const RELAY_TIMEOUT_MS: u64 = 500;
+
+/// Honest reply-speaker label. The bot always replies AS ITSELF — there is no
+/// "as-Bob" impersonation mode in code, so the mirror must never claim one.
+pub(super) const BOT_IDENTITY: &str = "CTO Bot (as itself)";
+
+/// Render an RBAC `ServiceTier` as its snake_case badge label.
+///
+/// Why: The GUI mirror shows an honest access-level badge next to the inbound
+/// human message. The label must match the tier's serde wire form so the
+/// front-end and any logs agree on the same three strings.
+/// What: `All` → `"all"`, `Analytics` → `"analytics"`, `ReadOnly` →
+/// `"read_only"` (identical to `ServiceTier`'s `snake_case` serde).
+/// Test: `tier_label_matches_serde`.
+pub(super) fn tier_label(tier: &ServiceTier) -> &'static str {
+    match tier {
+        ServiceTier::All => "all",
+        ServiceTier::Analytics => "analytics",
+        ServiceTier::ReadOnly => "read_only",
+    }
+}
+
+/// Resolve the relay endpoint URL from env (or the loopback default).
+///
+/// Why: The Tauri shell launches `--api` on `127.0.0.1:8765`; a manual
+/// `--api --port N` launch overrides it via `TAGENT_API_RELAY_URL`. Trailing
+/// slashes are trimmed so the joined path never doubles up.
+/// What: `<base>/api/internal/relay-event`, base from `TAGENT_API_RELAY_URL`
+/// (non-empty) or `DEFAULT_RELAY_URL`.
+/// Test: `relay_endpoint_defaults_and_trims`.
+pub(super) fn relay_endpoint() -> String {
+    let base = std::env::var("TAGENT_API_RELAY_URL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_RELAY_URL.to_string());
+    format!("{}/api/internal/relay-event", base.trim_end_matches('/'))
+}
+
+/// POST one event to the resolved relay endpoint, swallowing every failure.
+///
+/// Why: Best-effort telemetry — see the module doc. Owns its `Event` so it is
+/// `'static` and can be detached via `tokio::spawn` from the Slack handler,
+/// guaranteeing the reply path never awaits the network.
+/// What: Resolves the endpoint, POSTs the JSON event (attaching a bearer token
+/// from `TAGENT_API_TOKEN` when the API is token-guarded), and logs — never
+/// returns — on any error.
+/// Test: `relay_tolerates_unreachable_server`.
+pub(super) async fn relay_event(event: Event) {
+    post_event(&relay_endpoint(), &event).await;
+}
+
+/// Inner POST against an explicit endpoint, so tests can target a closed port
+/// without mutating process env.
+///
+/// Test: `relay_tolerates_unreachable_server`.
+async fn post_event(endpoint: &str, event: &Event) {
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_millis(RELAY_TIMEOUT_MS))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, "slack relay: client build failed (non-fatal)");
+            return;
+        }
+    };
+    let mut req = client.post(endpoint).json(event);
+    if let Ok(token) = std::env::var("TAGENT_API_TOKEN")
+        && !token.trim().is_empty()
+    {
+        req = req.bearer_auth(token.trim());
+    }
+    match req.send().await {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => warn!(status = %resp.status(), "slack relay: non-success status (non-fatal)"),
+        Err(e) => warn!(error = %e, "slack relay: send failed (non-fatal)"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_label_matches_serde() {
+        for tier in [
+            ServiceTier::All,
+            ServiceTier::Analytics,
+            ServiceTier::ReadOnly,
+        ] {
+            // The badge label must equal the tier's serde wire form (the quotes
+            // are stripped) so the UI and logs share one vocabulary.
+            let serde = serde_json::to_string(&tier).unwrap();
+            let serde = serde.trim_matches('"');
+            assert_eq!(tier_label(&tier), serde);
+        }
+    }
+
+    #[test]
+    fn relay_endpoint_defaults_and_trims() {
+        // Default path (env unset in the normal test env).
+        let ep = relay_endpoint();
+        assert!(
+            ep.ends_with("/api/internal/relay-event"),
+            "unexpected endpoint: {ep}"
+        );
+        assert!(!ep.contains("//api/internal"), "double slash in {ep}");
+    }
+
+    #[tokio::test]
+    async fn relay_tolerates_unreachable_server() {
+        // Port 59999 has no listener → connection refused. The relay must
+        // return (not panic, not hang) — the fire-and-forget contract.
+        let ev = Event::SlackReplySent {
+            channel: "C0".into(),
+            text: "hi".into(),
+            identity: BOT_IDENTITY.into(),
+        };
+        post_event("http://127.0.0.1:59999/api/internal/relay-event", &ev).await;
+    }
+}

--- a/crates/trusty-agents/src/slack/relay.rs
+++ b/crates/trusty-agents/src/slack/relay.rs
@@ -32,6 +32,16 @@ pub(super) const DEFAULT_RELAY_URL: &str = "http://127.0.0.1:8765";
 /// must not stall the Slack reply path, so we cap the attempt aggressively.
 const RELAY_TIMEOUT_MS: u64 = 500;
 
+/// Env var holding the mandatory shared relay secret. MUST be set to the SAME
+/// value on the `--api` process, which rejects (401) any post whose
+/// `x-relay-token` header does not match — and rejects ALL posts when the
+/// secret is unset there (fail closed). See `api::server::relay`.
+pub(super) const RELAY_TOKEN_ENV: &str = "TAGENT_RELAY_TOKEN";
+
+/// Header carrying the shared relay secret. MUST match
+/// `crate::api::server::relay::RELAY_TOKEN_HEADER`.
+const RELAY_TOKEN_HEADER: &str = "x-relay-token";
+
 /// Honest reply-speaker label. The bot always replies AS ITSELF — there is no
 /// "as-Bob" impersonation mode in code, so the mirror must never claim one.
 pub(super) const BOT_IDENTITY: &str = "CTO Bot (as itself)";
@@ -72,20 +82,43 @@ pub(super) fn relay_endpoint() -> String {
 ///
 /// Why: Best-effort telemetry — see the module doc. Owns its `Event` so it is
 /// `'static` and can be detached via `tokio::spawn` from the Slack handler,
-/// guaranteeing the reply path never awaits the network.
-/// What: Resolves the endpoint, POSTs the JSON event (attaching a bearer token
-/// from `TAGENT_API_TOKEN` when the API is token-guarded), and logs — never
-/// returns — on any error.
+/// guaranteeing the reply path never awaits the network. All env reads happen
+/// HERE (not in `post_event`) so the inner POST is env-free and unit-testable
+/// without racing the process environment.
+/// What: Resolves the endpoint + the shared relay secret (`TAGENT_RELAY_TOKEN`,
+/// sent as `x-relay-token` — REQUIRED by the `--api` side) + an optional
+/// `TAGENT_API_TOKEN` bearer (when the API is `--api-token`-guarded), then
+/// delegates to `post_event`.
 /// Test: `relay_tolerates_unreachable_server`.
 pub(super) async fn relay_event(event: Event) {
-    post_event(&relay_endpoint(), &event).await;
+    let relay_token = std::env::var(RELAY_TOKEN_ENV)
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+    let api_token = std::env::var("TAGENT_API_TOKEN")
+        .ok()
+        .filter(|s| !s.trim().is_empty());
+    post_event(
+        &relay_endpoint(),
+        &event,
+        relay_token.as_deref(),
+        api_token.as_deref(),
+    )
+    .await;
 }
 
-/// Inner POST against an explicit endpoint, so tests can target a closed port
-/// without mutating process env.
+/// Inner POST against an explicit endpoint with explicit tokens, so tests can
+/// target a closed port without mutating process env.
 ///
+/// What: Attaches `x-relay-token: <relay_token>` (the shared secret the API
+/// side mandates) and, when present, an `Authorization: Bearer <api_token>`.
+/// Logs — never returns — on any error.
 /// Test: `relay_tolerates_unreachable_server`.
-async fn post_event(endpoint: &str, event: &Event) {
+async fn post_event(
+    endpoint: &str,
+    event: &Event,
+    relay_token: Option<&str>,
+    api_token: Option<&str>,
+) {
     let client = match reqwest::Client::builder()
         .timeout(Duration::from_millis(RELAY_TIMEOUT_MS))
         .build()
@@ -97,10 +130,11 @@ async fn post_event(endpoint: &str, event: &Event) {
         }
     };
     let mut req = client.post(endpoint).json(event);
-    if let Ok(token) = std::env::var("TAGENT_API_TOKEN")
-        && !token.trim().is_empty()
-    {
-        req = req.bearer_auth(token.trim());
+    if let Some(t) = relay_token {
+        req = req.header(RELAY_TOKEN_HEADER, t.trim());
+    }
+    if let Some(t) = api_token {
+        req = req.bearer_auth(t.trim());
     }
     match req.send().await {
         Ok(resp) if resp.status().is_success() => {}
@@ -142,12 +176,19 @@ mod tests {
     #[tokio::test]
     async fn relay_tolerates_unreachable_server() {
         // Port 59999 has no listener → connection refused. The relay must
-        // return (not panic, not hang) — the fire-and-forget contract.
+        // return (not panic, not hang) — the fire-and-forget contract. Passes
+        // explicit tokens so it never reads process env (race-free).
         let ev = Event::SlackReplySent {
             channel: "C0".into(),
             text: "hi".into(),
             identity: BOT_IDENTITY.into(),
         };
-        post_event("http://127.0.0.1:59999/api/internal/relay-event", &ev).await;
+        post_event(
+            "http://127.0.0.1:59999/api/internal/relay-event",
+            &ev,
+            Some("secret"),
+            None,
+        )
+        .await;
     }
 }

--- a/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
+++ b/crates/trusty-agents/ui/src-tauri/CHANGELOG.md
@@ -9,6 +9,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Live Slack mirror reaches the desktop shell (#3752):** `sse_bridge.rs` now
+  also forwards the two Slack-mirror event kinds (`slack_message_received` /
+  `slack_reply_sent`) from the sidecar's `/api/events` as a `slack-event` Tauri
+  event carrying the raw event object. Without this the `SlackMirror` pane would
+  populate only in browser mode (the Tauri shell skips App.svelte's browser SSE
+  bridge on `isDesktop()`), leaving the packaged demo app blank; App.svelte's
+  `onMount` listens for `slack-event` and calls `pushSlackEvent`, a no-op in
+  browser mode so exactly one push happens per event in each transport.
+
 - **Live token streaming in the chat reply bubble (desktop + browser):** when
   the backend streams a reply (the new `agent_message_delta` SSE event), the
   in-flight assistant bubble now grows token-by-token instead of showing a

--- a/crates/trusty-agents/ui/src-tauri/src/sse_bridge.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/sse_bridge.rs
@@ -15,11 +15,17 @@
 //! `event:`/`data:` framing off `Response::chunk()` (no extra deps — reqwest's
 //! chunk reader is available without the `stream` feature), and for every
 //! `agent_message_delta` frame emits `app.emit("task-delta", DeltaPayload)`.
-//! Ping/lag/other events are ignored (the poll loop still drives
-//! progress/complete). The connection auto-reconnects with a short backoff so
-//! a sidecar restart or idle reap doesn't permanently kill streaming.
+//! #3752: it ALSO forwards the two Slack-mirror kinds
+//! (`slack_message_received` / `slack_reply_sent`) as a `slack-event` Tauri
+//! event carrying the raw event object — otherwise the SlackMirror pane would
+//! populate only in browser mode (App.svelte's browser SSE bridge is skipped
+//! on `isDesktop()`), leaving the packaged demo app blank. Ping/lag/other
+//! events are ignored (the poll loop still drives progress/complete). The
+//! connection auto-reconnects with a short backoff so a sidecar restart or idle
+//! reap doesn't permanently kill streaming.
 //! Test: `parse_dispatches_agent_message_delta`,
-//! `parse_ignores_non_delta_frames`, `parse_handles_split_frames`.
+//! `parse_ignores_non_delta_frames`, `parse_handles_split_frames`,
+//! `parse_slack_frame_matches_both_kinds`, `parse_slack_frame_ignores_others`.
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
@@ -74,12 +80,27 @@ async fn pump_stream(app: &AppHandle, url: &str) -> Result<(), String> {
     let mut parser = SseParser::default();
     while let Some(chunk) = resp.chunk().await.map_err(|e| format!("read: {e}"))? {
         for data in parser.push(&chunk) {
-            if let Some(payload) = parse_delta_frame(&data) {
-                let _ = app.emit("task-delta", payload);
-            }
+            dispatch_frame(app, &data);
         }
     }
     Ok(())
+}
+
+/// Route one completed SSE `data:` payload to the matching Tauri event.
+///
+/// Why: The desktop shell forwards two disjoint event families — streaming
+/// `agent_message_delta` (→ `task-delta`, browser-parity) and the Slack-mirror
+/// kinds (→ `slack-event`, #3752). Everything else stays on the poll loop.
+/// What: Emits `task-delta` for a delta frame, else `slack-event` (carrying the
+/// raw event object) for a Slack frame, else nothing.
+/// Test: `parse_dispatches_agent_message_delta`,
+/// `parse_slack_frame_matches_both_kinds`.
+fn dispatch_frame(app: &AppHandle, data: &str) {
+    if let Some(payload) = parse_delta_frame(data) {
+        let _ = app.emit("task-delta", payload);
+    } else if let Some(value) = parse_slack_frame(data) {
+        let _ = app.emit("slack-event", value);
+    }
 }
 
 /// Incremental SSE frame parser.
@@ -148,6 +169,24 @@ fn parse_delta_frame(data: &str) -> Option<DeltaPayload> {
     })
 }
 
+/// Parse an SSE `data:` JSON payload into the raw event `Value` iff it is one
+/// of the two Slack-mirror kinds; otherwise `None`. (#3752)
+///
+/// Why: The desktop SlackMirror pane consumes the SAME event shape the browser
+/// bridge feeds `pushSlackEvent`, so we forward the whole object unchanged
+/// rather than reshaping it into a bespoke payload — the frontend listener
+/// calls `pushSlackEvent` on it identically in both transports.
+/// What: JSON-decodes `data`, returns it iff `type` is `slack_message_received`
+/// or `slack_reply_sent`.
+/// Test: `parse_slack_frame_matches_both_kinds`, `parse_slack_frame_ignores_others`.
+fn parse_slack_frame(data: &str) -> Option<serde_json::Value> {
+    let value: serde_json::Value = serde_json::from_str(data).ok()?;
+    match value.get("type").and_then(|t| t.as_str()) {
+        Some("slack_message_received") | Some("slack_reply_sent") => Some(value),
+        _ => None,
+    }
+}
+
 fn field_str(value: &serde_json::Value, key: &str) -> String {
     value
         .get(key)
@@ -193,6 +232,28 @@ mod tests {
         assert_eq!(parse_delta_frame(&frames[0]).unwrap().text, "hi");
         // Ping frame yields nothing.
         assert!(p.push(b"event: ping\ndata: {}\n\n").is_empty());
+    }
+
+    #[test]
+    fn parse_slack_frame_matches_both_kinds() {
+        // #3752: both Slack-mirror kinds are forwarded verbatim (raw object).
+        let inbound = r#"{"type":"slack_message_received","channel":"C0","user_display":"Masa","text":"hi","tier":"all"}"#;
+        let v = parse_slack_frame(inbound).expect("inbound should match");
+        assert_eq!(v.get("type").unwrap(), "slack_message_received");
+        assert_eq!(v.get("tier").unwrap(), "all");
+
+        let reply = r#"{"type":"slack_reply_sent","channel":"C0","text":"ok","identity":"CTO Bot (as itself)"}"#;
+        let v = parse_slack_frame(reply).expect("reply should match");
+        assert_eq!(v.get("type").unwrap(), "slack_reply_sent");
+        assert_eq!(v.get("identity").unwrap(), "CTO Bot (as itself)");
+    }
+
+    #[test]
+    fn parse_slack_frame_ignores_others() {
+        // A streaming delta is NOT a slack frame (it goes to `task-delta`).
+        assert!(parse_slack_frame(r#"{"type":"agent_message_delta","text":"x"}"#).is_none());
+        assert!(parse_slack_frame(r#"{"type":"pm_thinking","text":"x"}"#).is_none());
+        assert!(parse_slack_frame("not json").is_none());
     }
 
     #[test]

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -436,10 +436,24 @@
     }).then((fn) => {
       unlistenWorkflowProgress = fn;
     });
+    // #3752: desktop parity for the Slack mirror. In browser mode
+    // `bridgeEventToWebBus` calls `pushSlackEvent` directly off the SSE stream;
+    // the Tauri shell skips that browser bridge (`startEventStream` early-
+    // returns on `isDesktop()`), so its Rust `sse_bridge` re-emits the two
+    // Slack kinds as a `slack-event` Tauri event that we fold in here. This
+    // listener is a harmless no-op in browser mode (nothing emits `slack-event`
+    // on the web bus), so exactly one push happens per event in each transport.
+    let unlistenSlack: (() => void) | null = null;
+    listenEvent<AppEvent>('slack-event', (ev) => {
+      pushSlackEvent(ev);
+    }).then((fn) => {
+      unlistenSlack = fn;
+    });
     return () => {
       window.removeEventListener('beforeunload', onUnload);
       unlistenWorkflowComplete?.();
       unlistenWorkflowProgress?.();
+      unlistenSlack?.();
       stopEventStream();
     };
   });

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -8,6 +8,10 @@
   import RecapPanel from './components/RecapPanel.svelte';
   import Header from './components/Header.svelte';
   import PersonalityPanel from './components/PersonalityPanel.svelte';
+  import SlackMirror from './components/SlackMirror.svelte';
+  // #3752: live Slack conversation mirror — the SSE bridge feeds these two
+  // event kinds into the store the SlackMirror pane renders.
+  import { pushSlackEvent, slackMirror } from './lib/slack-mirror';
   import { invoke, isDesktop, connectEventSource, listenEvent, emitWebEvent, type AppEvent } from './lib/transport';
   import { bridgeDelta } from './lib/chatStream';
   import { apiAuthRequired, getCurrentApiToken, setApiToken, addMessage } from './stores/app';
@@ -358,6 +362,14 @@
         }
         break;
       }
+      case 'slack_message_received':
+      case 'slack_reply_sent':
+        // #3752: live Slack conversation mirror. These are conversation-scoped
+        // (no session_id), so they don't belong on the task web-bus — fold them
+        // straight into the SlackMirror store and stop (no default fall-through
+        // to a `task-progress` emit).
+        pushSlackEvent(ev);
+        break;
       case 'ping':
       case 'lag':
         // Diagnostic — no UI action; consumers that care can listen for the
@@ -516,6 +528,11 @@
             <InputArea />
           </div>
           <RecapPanel />
+          <!-- #3752: the live Slack mirror only mounts once there's activity,
+               so normal (non-Slack) usage is visually unchanged. -->
+          {#if $slackMirror.length > 0}
+            <SlackMirror />
+          {/if}
         </div>
       {:else if activeView === 'projects'}
         <ProjectsView on:navigate={(e) => switchView(e.detail.view)} />

--- a/crates/trusty-agents/ui/src/components/SlackMirror.svelte
+++ b/crates/trusty-agents/ui/src/components/SlackMirror.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  /**
+   * Why: #3752 (epic #3052) — when the CTO Bot converses on Slack (`tagent
+   * --slack`), the GUI mirrors BOTH sides live so an operator watching the
+   * desktop app sees the inbound human message and the bot's reply as they
+   * happen. The bubbles + honest badges come from the `slackMirror` store,
+   * which App.svelte's SSE bridge feeds from the two `slack_message_received`
+   * / `slack_reply_sent` events on the existing `/api/events` stream.
+   * What: A right-hand `<aside>` (own vertical scroll, Foundry styling to
+   * match RecapPanel) listing conversation bubbles: inbound = left, with the
+   * sender name + honest RBAC-tier badge; reply = right, with the honest bot
+   * identity badge (`CTO Bot (as itself)` — there is NO impersonation mode).
+   * The parent only mounts this when the store is non-empty, so normal usage
+   * with no Slack activity is unaffected.
+   * Test: `slack-mirror.test.ts` covers the event→bubble transform + store
+   * fold this renders; live render is exercised via the runbook (PR body).
+   */
+  import { slackMirror, clearSlackMirror, type SlackBubble } from '../lib/slack-mirror';
+
+  // Truncate a Slack channel id for the compact header/meta line.
+  function shortChannel(c: string): string {
+    return c ? `#${c}` : '#—';
+  }
+
+  function badgeClass(b: SlackBubble): string {
+    // Reply badge uses the teal bot-identity accent; inbound tier badge uses
+    // the neutral surface chip so access level reads as metadata, not status.
+    return b.kind === 'reply'
+      ? 'bg-foundry-teal/15 text-foundry-teal'
+      : 'bg-foundry-light-border/60 dark:bg-black/40 text-foundry-light-muted dark:text-foundry-text/60';
+  }
+</script>
+
+<aside
+  class="flex w-[320px] flex-shrink-0 flex-col border-l border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface overflow-hidden"
+>
+  <div
+    class="flex items-center gap-2 px-4 py-3 border-b border-foundry-light-border dark:border-foundry-border font-mono text-[10px] font-semibold uppercase tracking-widest text-foundry-light-muted dark:text-foundry-text/60"
+  >
+    <span class="h-1.5 w-1.5 rounded-full bg-foundry-teal animate-pulse" aria-hidden="true"></span>
+    <span>Slack Live</span>
+    <button
+      type="button"
+      class="ml-auto text-foundry-light-muted/70 dark:text-foundry-text/40 hover:text-foundry-teal normal-case tracking-normal"
+      on:click={clearSlackMirror}
+      title="Clear the mirror"
+    >
+      clear
+    </button>
+  </div>
+
+  <div class="flex flex-1 flex-col gap-3 overflow-y-auto px-3 py-3">
+    {#if $slackMirror.length === 0}
+      <p class="px-1 text-xs font-mono text-foundry-light-muted dark:text-foundry-text/40">
+        Waiting for Slack activity…
+      </p>
+    {:else}
+      {#each $slackMirror as b, i (b.received_at + '-' + i)}
+        <div class="flex flex-col {b.kind === 'reply' ? 'items-end' : 'items-start'}">
+          <div class="mb-0.5 flex items-center gap-1.5 px-1 text-[10px] font-mono">
+            {#if b.kind === 'inbound'}
+              <span class="font-semibold text-foundry-light-text dark:text-foundry-text">{b.speaker || 'unknown'}</span>
+            {:else}
+              <span class="font-semibold text-foundry-teal">{b.badge}</span>
+            {/if}
+            {#if b.kind === 'inbound'}
+              <span class="rounded px-1 py-px uppercase tracking-wide {badgeClass(b)}" title="RBAC tier">{b.badge}</span>
+            {/if}
+            <span class="text-foundry-light-muted dark:text-foundry-text/40" title={b.channel}>{shortChannel(b.channel)}</span>
+          </div>
+          <div
+            class="max-w-[85%] whitespace-pre-wrap break-words rounded-lg px-3 py-2 text-sm {b.kind === 'reply'
+              ? 'bg-foundry-teal/10 text-foundry-light-text dark:text-foundry-text rounded-tr-sm'
+              : 'bg-foundry-light-bg dark:bg-foundry-bg text-foundry-light-text dark:text-foundry-text rounded-tl-sm border border-foundry-light-border dark:border-foundry-border'}"
+          >
+            {b.text}
+          </div>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</aside>

--- a/crates/trusty-agents/ui/src/lib/slack-mirror.test.ts
+++ b/crates/trusty-agents/ui/src/lib/slack-mirror.test.ts
@@ -1,0 +1,121 @@
+// Vitest unit tests for the Slack conversation mirror reducer + store (#3752).
+//
+// Why: The mirror pane's correctness lives in the pure event→bubble transform
+// and the bounded store fold, not in Svelte markup — so we test those directly
+// (no DOM/jsdom needed), mirroring retask.test.ts. This asserts the pane would
+// render both conversation sides from synthetic SSE events with honest badges.
+// What: Covers `slackBubbleFromEvent`, `tierBadgeLabel`, and the `slackMirror`
+// store via `pushSlackEvent` (append order, non-mirror no-op, overflow trim).
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import type { AppEvent } from './transport';
+import {
+  slackBubbleFromEvent,
+  tierBadgeLabel,
+  pushSlackEvent,
+  slackMirror,
+  clearSlackMirror,
+  SLACK_MIRROR_MAX,
+} from './slack-mirror';
+
+const inbound = (over: Partial<AppEvent> = {}): AppEvent => ({
+  type: 'slack_message_received',
+  channel: 'C0123ABC',
+  user_display: 'Masa',
+  text: 'deploy status?',
+  tier: 'all',
+  ...over,
+});
+
+const reply = (over: Partial<AppEvent> = {}): AppEvent => ({
+  type: 'slack_reply_sent',
+  channel: 'C0123ABC',
+  text: 'Deploy is green.',
+  identity: 'CTO Bot (as itself)',
+  ...over,
+});
+
+beforeEach(() => clearSlackMirror());
+
+describe('slackBubbleFromEvent', () => {
+  it('maps an inbound message with an honest RBAC tier badge', () => {
+    const b = slackBubbleFromEvent(inbound());
+    expect(b).not.toBeNull();
+    expect(b).toMatchObject({
+      kind: 'inbound',
+      channel: 'C0123ABC',
+      speaker: 'Masa',
+      text: 'deploy status?',
+      badge: 'ALL',
+    });
+  });
+
+  it('maps a reply with the honest bot-identity badge', () => {
+    const b = slackBubbleFromEvent(reply());
+    expect(b).not.toBeNull();
+    expect(b).toMatchObject({
+      kind: 'reply',
+      channel: 'C0123ABC',
+      text: 'Deploy is green.',
+      badge: 'CTO Bot (as itself)',
+      speaker: '',
+    });
+  });
+
+  it('falls back to a safe identity label when the backend omits one', () => {
+    const b = slackBubbleFromEvent(reply({ identity: undefined }));
+    expect(b?.badge).toBe('CTO Bot (as itself)');
+  });
+
+  it('returns null for unrelated event types', () => {
+    expect(slackBubbleFromEvent({ type: 'pm_thinking', text: 'x' })).toBeNull();
+    expect(slackBubbleFromEvent({ type: 'ping' })).toBeNull();
+  });
+
+  it('degrades missing string fields to empty strings instead of throwing', () => {
+    const b = slackBubbleFromEvent({ type: 'slack_message_received' });
+    expect(b).toMatchObject({ channel: '', text: '', speaker: '' });
+    // Unknown/empty tier still yields a non-empty badge, never an invented state.
+    expect(b?.badge).toBe('UNKNOWN');
+  });
+});
+
+describe('tierBadgeLabel', () => {
+  it('renders the three known tiers', () => {
+    expect(tierBadgeLabel('all')).toBe('ALL');
+    expect(tierBadgeLabel('analytics')).toBe('ANALYTICS');
+    expect(tierBadgeLabel('read_only')).toBe('READ-ONLY');
+  });
+  it('passes an unknown tier through uppercased-as-is (no fabrication)', () => {
+    expect(tierBadgeLabel('vip')).toBe('vip');
+    expect(tierBadgeLabel('')).toBe('UNKNOWN');
+  });
+});
+
+describe('slackMirror store via pushSlackEvent', () => {
+  it('appends both conversation sides in arrival order', () => {
+    pushSlackEvent(inbound());
+    pushSlackEvent(reply());
+    const log = get(slackMirror);
+    expect(log.map((b) => b.kind)).toEqual(['inbound', 'reply']);
+    expect(log[0].speaker).toBe('Masa');
+    expect(log[1].badge).toBe('CTO Bot (as itself)');
+  });
+
+  it('is a no-op for non-mirror events', () => {
+    expect(pushSlackEvent({ type: 'agent_message', agent: 'python', text: 'hi' })).toBeNull();
+    expect(get(slackMirror)).toHaveLength(0);
+  });
+
+  it('trims to SLACK_MIRROR_MAX, dropping the oldest', () => {
+    for (let i = 0; i < SLACK_MIRROR_MAX + 5; i++) {
+      pushSlackEvent(inbound({ text: `msg-${i}` }));
+    }
+    const log = get(slackMirror);
+    expect(log).toHaveLength(SLACK_MIRROR_MAX);
+    // Oldest five dropped: the first retained bubble is msg-5.
+    expect(log[0].text).toBe('msg-5');
+    expect(log[log.length - 1].text).toBe(`msg-${SLACK_MIRROR_MAX + 4}`);
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/slack-mirror.ts
+++ b/crates/trusty-agents/ui/src/lib/slack-mirror.ts
@@ -1,0 +1,120 @@
+// Pure, framework-free reducer + store for the live Slack conversation mirror
+// (#3752, epic #3052).
+//
+// Why: The GUI mirrors both sides of a live Slack conversation the CTO Bot is
+// having — the inbound human message and the bot's reply — driven by the two
+// `slack_message_received` / `slack_reply_sent` events that arrive over the
+// existing `/api/events` SSE stream. Keeping the event→bubble transform as a
+// pure function (mirroring lib/retask.ts) lets vitest verify rendering logic
+// without mounting Svelte or a DOM; the Svelte component is then a thin view
+// over the store.
+// What: `slackBubbleFromEvent` maps one `AppEvent` to a `SlackBubble` (or
+// `null` for unrelated events); `slackMirror` is the writable bubble log;
+// `pushSlackEvent` folds an event into it (bounded). Badges are HONEST — the
+// inbound badge is the resolved RBAC tier, the reply badge is the bot's own
+// identity string as sent by the backend; this module never invents a label.
+// Test: `slack-mirror.test.ts`.
+
+import { writable } from 'svelte/store';
+import type { AppEvent } from './transport';
+
+/** One rendered line in the mirror pane. */
+export interface SlackBubble {
+  /** `inbound` = human message; `reply` = bot reply. Drives bubble side/color. */
+  kind: 'inbound' | 'reply';
+  /** Slack channel id the message belonged to. */
+  channel: string;
+  /** Message body (raw inbound text, or the posted reply text). */
+  text: string;
+  /**
+   * Honest badge:
+   *  - inbound → RBAC tier label (`all` / `analytics` / `read_only`)
+   *  - reply   → bot identity (`CTO Bot (as itself)`)
+   * Never a fabricated auth state.
+   */
+  badge: string;
+  /** Display name of the human sender (inbound only; empty for replies). */
+  speaker: string;
+  /** Client receive time (ms) — used only for a stable list key + ordering. */
+  received_at: number;
+}
+
+/** Cap on retained bubbles so a long-lived session can't grow unbounded. */
+export const SLACK_MIRROR_MAX = 100;
+
+/** Human-facing label for an inbound RBAC tier badge. Unknown → the raw value. */
+export function tierBadgeLabel(tier: string): string {
+  switch (tier) {
+    case 'all':
+      return 'ALL';
+    case 'analytics':
+      return 'ANALYTICS';
+    case 'read_only':
+      return 'READ-ONLY';
+    default:
+      return tier || 'UNKNOWN';
+  }
+}
+
+/**
+ * Why: The single place that decides whether an incoming SSE event is part of
+ * the Slack mirror and, if so, what bubble it renders. Isolating it keeps the
+ * transform testable and the component declarative.
+ * What: Returns a `SlackBubble` for `slack_message_received` /
+ * `slack_reply_sent`; returns `null` for every other event type so callers can
+ * cheaply skip non-mirror traffic. Missing string fields degrade to empty
+ * strings rather than throwing (the stream is best-effort telemetry).
+ * Test: `slack-mirror.test.ts` — both kinds map correctly; other types → null.
+ */
+export function slackBubbleFromEvent(ev: AppEvent): SlackBubble | null {
+  const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+  if (ev.type === 'slack_message_received') {
+    return {
+      kind: 'inbound',
+      channel: str(ev.channel),
+      text: str(ev.text),
+      badge: tierBadgeLabel(str(ev.tier)),
+      speaker: str(ev.user_display),
+      received_at: Date.now(),
+    };
+  }
+  if (ev.type === 'slack_reply_sent') {
+    return {
+      kind: 'reply',
+      channel: str(ev.channel),
+      text: str(ev.text),
+      // Honest label straight from the backend — the bot speaks as itself.
+      badge: str(ev.identity) || 'CTO Bot (as itself)',
+      speaker: '',
+      received_at: Date.now(),
+    };
+  }
+  return null;
+}
+
+/** The rolling bubble log, oldest first. */
+export const slackMirror = writable<SlackBubble[]>([]);
+
+/**
+ * Why: App.svelte's SSE bridge calls this for every event; a non-mirror event
+ * is a cheap no-op so the call site doesn't need to pre-filter.
+ * What: If `ev` maps to a bubble, appends it (trimming to `SLACK_MIRROR_MAX`).
+ * Returns the bubble it pushed, or `null` when the event wasn't a mirror event
+ * (useful for tests + callers that want to know whether anything happened).
+ * Test: `slack-mirror.test.ts` — pushing both kinds grows the store in order;
+ * unrelated events leave it unchanged; overflow trims the oldest.
+ */
+export function pushSlackEvent(ev: AppEvent): SlackBubble | null {
+  const bubble = slackBubbleFromEvent(ev);
+  if (!bubble) return null;
+  slackMirror.update((log) => {
+    const next = [...log, bubble];
+    return next.length > SLACK_MIRROR_MAX ? next.slice(next.length - SLACK_MIRROR_MAX) : next;
+  });
+  return bubble;
+}
+
+/** Reset the mirror (used by tests and a future "clear" affordance). */
+export function clearSlackMirror(): void {
+  slackMirror.set([]);
+}


### PR DESCRIPTION
## Live Slack conversation mirror in the trusty-agents GUI

Closes #3752 (epic #3052; channel/events context #3057).

When the CTO Bot converses on Slack (`tagent --slack`), the GUI (`tagent --api` +
web UI) now shows **both sides live** — the inbound human message and the bot's
reply — with **honest identity badges**. Implemented as the **low-risk relay**
variant: no process merge, fire-and-forget, best-effort telemetry.

### Architecture (relay, not merge)
The `--slack` gateway and the `--api` GUI backend are separate processes with
independent event buses. The gateway POSTs its mirror events to a loopback relay
endpoint on the `--api` server, which re-publishes them onto the bus feeding the
existing `/api/events` SSE stream. Slack handling **never** blocks or fails on
relay errors.

1. **`events.rs`** — two additive variants (no `session_id` → always pass the SSE
   session filter, like `Ping`):
   - `SlackMessageReceived { channel, user_display, text, tier }`
   - `SlackReplySent { channel, text, identity }`
2. **`POST /api/internal/relay-event`** (`api/server/relay.rs`) — see Security
   below. Whitelists only the two `Slack*` kinds (any other well-formed event →
   `400`; non-`Event` body → `422`), validates the inbound `tier` against the
   closed `ServiceTier` set (unknown → `422`), and publishes survivors.
3. **`slack/relay.rs` + `slack/handlers.rs`** — fire-and-forget relay client
   (500 ms timeout, `tokio::spawn`, log-and-continue): inbound event after
   dispatch, reply event **after `post_message` succeeds** (so the pane never
   shows a reply the channel never received). Target = `TAGENT_API_RELAY_URL`
   (default `http://127.0.0.1:8765`); sends the shared secret as `x-relay-token`
   and an optional `TAGENT_API_TOKEN` bearer.
4. **GUI** — a pure event→bubble reducer + store (`lib/slack-mirror.ts`,
   vitest-tested) and a Foundry-styled `SlackMirror` pane that mounts **only once
   Slack activity arrives** (normal usage visually unchanged). Inbound bubble =
   sender + RBAC-tier badge; reply bubble = `CTO Bot (as itself)` badge.

### Security — critic BLOCK (CRITICAL) addressed
The relay endpoint was openly writable by any local process in the default
tokenless config: the router-wide origin guard **fails open** for absent-`Origin`
(server-to-server) callers, so a local process could `curl` a forged
`slack_reply_sent` with identity `CTO Bot (as itself)` — defeating the exact
displayed-identity honesty this pane promises.

Fix: a **mandatory shared secret**, `TAGENT_RELAY_TOKEN`, validated inside
`relay_event_handler` **unconditionally** (independent of `--api-token`). The
Slack side sends it as `x-relay-token`; the handler returns `401` on a
missing/mismatched token, and — critically — **fails closed**: if
`TAGENT_RELAY_TOKEN` is unset on the `--api` side, **every** relay post is
rejected. Both processes must export the same value (see runbook).

### Honesty constraint
Badges surface only introspectable facts: the RBAC `ServiceTier` from
`ChatSession.user_identity` and the bot's own identity. **There is no "as-Bob"
impersonation mode in code and none is fabricated.**

### Accepted-for-demo (MEDIUM, follow-up to be filed by the critic)
Slack-mirror events carry no `session_id`, so **every** SSE client receives them
process-wide. Acceptable for the single-operator demo; multi-viewer session
scoping is tracked as a follow-up, not fixed tonight.

### Event shapes (wire, `serde(tag="type", rename_all="snake_case")`)
```json
{"type":"slack_message_received","channel":"C0123ABC","user_display":"Masa","text":"deploy status?","tier":"all"}
{"type":"slack_reply_sent","channel":"C0123ABC","text":"Deploy is green.","identity":"CTO Bot (as itself)"}
```

### Tests / gates (raw)
- `cargo test -p trusty-agents` — lib **2242 passed; 0 failed; 12 ignored** +
  all integration suites green. New: 2 event serde round-trips; relay endpoint
  (fail-closed/missing/wrong token, accept-with-token, non-Slack whitelist,
  unknown-tier, malformed) + pure `relay_authorized`/`tier_is_known` helpers; 3
  Slack relay-client cases.
- `cargo clippy -p trusty-agents --all-targets -D warnings` — clean.
- `cargo clippy -p trusty-agents-ui --all-targets -D warnings` — clean.
- `cargo fmt -p trusty-agents --check` — clean.
- `scripts/check_line_cap.sh` — `8 allowlisted, 0 violations — OK`.
- `scripts/check_test_pointers.sh` — `0 dangling pointers — OK`.
- `pnpm test:unit` — **56 passed** (incl. `slack-mirror.test.ts`, 12 cases).
- `pnpm check` (svelte-check) — **0 errors** (2 pre-existing ProjectsView warnings).

### Live verification runbook (NOT run in CI — real Slack workspace)
Deliberately not exercised here (no live gateway against the real workspace).
Both processes MUST share the same `TAGENT_RELAY_TOKEN`, or the relay fails
closed and the pane stays empty.

```bash
# Shared secret — export in the SAME shell/env file both processes read.
export TAGENT_RELAY_TOKEN=$(openssl rand -hex 16)

# Terminal 1 — GUI backend (relay target = default 127.0.0.1:8765)
cd ~/Duetto/cto
tagent --api --port 8765            # or launch the Tauri desktop shell (spawns --api on 8765)

# Terminal 2 — Slack gateway with the CTO env sourced (same TAGENT_RELAY_TOKEN!)
cd ~/Duetto/cto
set -a; source .env.local; set +a   # SLACK_APP_TOKEN (xapp-…) + SLACK_BOT_TOKEN (xoxb-…)
tagent --slack
```

Then, from a paired Slack channel, message the bot. Expected in the GUI (Chat
view): a **"Slack Live"** pane appears on the right; an **inbound** bubble shows
the sender name + tier badge (e.g. `ALL`), and once the bot replies a **reply**
bubble shows the `CTO Bot (as itself)` badge with the posted text. If the GUI
runs on a non-default port, set `TAGENT_API_RELAY_URL=http://127.0.0.1:<port>`
in Terminal 2; if `--api` is token-guarded, also export `TAGENT_API_TOKEN`.

### Coordination / expected conflicts
- **#3753 `feat-agents-chat-streaming`** (events.rs + App.svelte + ChatView/transport):
  - `events.rs` — both add `Event` variants and touch the `session_id()` match arm.
    My variants are appended just before `Ping` to minimize collision; expect a
    small merge in the enum body + the `None` match arm (and in
    `repl/event_display.rs` if that PR also adds a suppressed variant).
  - `App.svelte` — both add imports + a `bridgeEventToWebBus` switch case; expect a
    localized merge in the import block and the switch.
- **#3747 `fix-agent-picker-catalog`** — touches `transport.ts` only, which this PR
  does **not** modify; no conflict expected.

Do not merge until the coordinating PRs land / are sequenced.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools


---
### Update — rebased onto current origin/main (post #3753 merge, 21a924b7)
Conflicts resolved:
- `events.rs` — both variant sets coexist: #3753's `AgentMessageDelta` (with its
  `session_id` arm) + my two Slack variants (appended near `Ping`, `session_id → None`).
- `App.svelte` — both bridges in the event switch: #3753's `agent_message_delta`
  → `task-delta`, plus my two Slack cases → `pushSlackEvent`. Both import blocks kept.
- CHANGELOGs — all entries kept.

**Desktop-shell parity added (separate commit `feat(trusty-agents-ui): bridge
Slack-mirror events to the desktop shell`).** #3753 also added
`ui/src-tauri/src/sse_bridge.rs`, which forwarded only `agent_message_delta` — so
in the packaged Tauri app (the demo vehicle) the SlackMirror pane would have
populated in browser mode ONLY. `sse_bridge.rs` now also forwards the two Slack
kinds as a `slack-event` Tauri event (raw object); `App.svelte`'s `onMount`
listens for it and calls `pushSlackEvent` (a no-op in browser mode, so exactly
one push per event in each transport). New `parse_slack_frame` + 2 tests.

Gates re-run green on the rebased tree: `cargo test -p trusty-agents` **2267 passed**;
`cargo test -p trusty-agents-ui` **24 passed** (incl. 2 new sse_bridge cases);
`clippy` both crates `-D warnings` clean; `fmt --check` clean;
`pnpm test:unit` **66 passed**; `pnpm check` **0 errors**;
`check_line_cap.sh` OK; `check_test_pointers.sh` `0 dangling pointers`.
Head: `21b7f450`. Mergeable.
