### PR TITLE
fix(trusty-agents): render chat stream inside one stable bubble — no flicker

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -17,6 +17,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Chat stream renders inside ONE stable assistant bubble — no mid-stream
+  flicker:** as `task-delta` tokens arrived the reply bubble visibly flashed.
+  Two causes: (1) each delta fired two separate store writes (content, then
+  speaker), doubling the keyed-`{#each}` re-render + forced scroll reflow per
+  token, and (2) deltas carry the real backend id while the placeholder bubble
+  still held its `pending-<ts>` id, so the first tokens were dropped and the
+  poll loop's interim "Running…" text flashed into the bubble before streaming
+  text replaced it. Now a single `streamDeltaIntoTask` write funnels content +
+  speaker through one store update, adopts the in-flight placeholder on the
+  first delta (`fillDeltaIntoList`) so token #1 lands in the one existing
+  bubble (id preserved ⇒ no keyed-each re-mount), and no-ops on unchanged
+  frames. `InputArea`'s reconcile and `ChatView`'s progress handler both gate
+  on a shared `streamAccumulator` so neither overwrites live streamed text.
 - **Izzie's own tools now reach the `--direct`/`--agent` dispatch path (#3745
   item C):** `tagent --direct izzie` loaded a tool registry of only
   `[git_log, git_status, web_search, delegate_to_agent]` and the model answered

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -18,18 +18,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - **Chat stream renders inside ONE stable assistant bubble — no mid-stream
-  flicker:** as `task-delta` tokens arrived the reply bubble visibly flashed.
-  Two causes: (1) each delta fired two separate store writes (content, then
+  flicker:** as `task-delta` tokens arrived the reply bubble visibly flashed
+  because each delta fired two separate `messages` store writes (content, then
   speaker), doubling the keyed-`{#each}` re-render + forced scroll reflow per
-  token, and (2) deltas carry the real backend id while the placeholder bubble
-  still held its `pending-<ts>` id, so the first tokens were dropped and the
-  poll loop's interim "Running…" text flashed into the bubble before streaming
-  text replaced it. Now a single `streamDeltaIntoTask` write funnels content +
-  speaker through one store update, adopts the in-flight placeholder on the
-  first delta (`fillDeltaIntoList`) so token #1 lands in the one existing
-  bubble (id preserved ⇒ no keyed-each re-mount), and no-ops on unchanged
-  frames. `InputArea`'s reconcile and `ChatView`'s progress handler both gate
-  on a shared `streamAccumulator` so neither overwrites live streamed text.
+  token. Now a single `streamDeltaIntoTask` write funnels content + speaker
+  into the ONE bubble whose `taskId` matches the delta's globally-unique
+  backend id, rewriting only `content`/`speaker` so the message `id` is
+  preserved (the keyed `{#each}` patches, never re-mounts). Attribution is by
+  exact backend id, searched across every conversation — never by list position
+  and never scoped to the currently-viewed project — so a background stream
+  reaches its own bubble after a project switch and one turn's tokens can never
+  land in another turn's or project's bubble; an unattributable frame (e.g.
+  arriving before the poll loop reconciles the `pending-<ts>` id) is dropped,
+  and its text — held by the shared `streamAccumulator` — appears on the first
+  matching write. No-op frames skip the store `set` entirely, so they notify no
+  subscribers. `InputArea`'s reconcile and `ChatView`'s progress handler both
+  gate on the shared `streamAccumulator` so neither overwrites live streamed
+  text.
 - **Izzie's own tools now reach the `--direct`/`--agent` dispatch path (#3745
   item C):** `tagent --direct izzie` loaded a tool registry of only
   `[git_log, git_status, web_search, delegate_to_agent]` and the model answered

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -82,14 +82,16 @@
         streams.finalize(p.task_id);
         return;
       }
-      // Grow the SINGLE in-flight bubble in place via one store write. Empty
-      // fragments still `append('')` so the task is marked streaming (gating
-      // progress ticks) and its `pending-` id is reconciled on the very first
-      // delta — so token #1 lands in the one existing bubble rather than being
-      // dropped until the poll loop swaps the id. Content + speaker go through
-      // a single update: no second render, no mid-stream flash/flicker.
+      // Grow the SINGLE in-flight bubble in place via one store write, keyed by
+      // the delta's unique backend id (attributed to its OWNING conversation,
+      // not the viewed one). Empty fragments still `append('')` so the task is
+      // marked streaming (gating progress ticks). Content + speaker go through a
+      // single update: no second render, no mid-stream flash/flicker. Frames
+      // that arrive before the poll loop reconciles the bubble's `pending-` id
+      // match nothing and are dropped; the accumulator keeps their text, so the
+      // first matching write shows everything so far — no lost tokens.
       const full = streams.append(p.task_id, p.text ?? '');
-      streamDeltaIntoTask($activeProjectId, p.task_id, full, p.agent || undefined);
+      streamDeltaIntoTask(p.task_id, full, p.agent || undefined);
     });
     unlistenProgress = await listenEvent<ProgressPayload>('task-progress', (p) => {
       // Don't let a polling "Running…" tick overwrite live streamed text.

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -8,11 +8,12 @@
     agentRoster,
     setMessageSpeakerByTask,
     updateMessageByTask,
+    streamDeltaIntoTask,
     isRunning,
   } from '../stores/app';
   import { responderDisplayName } from '../lib/roster';
   import { listenEvent, type UnlistenFn } from '../lib/transport';
-  import { StreamAccumulator, type DeltaPayload } from '../lib/chatStream';
+  import { streamAccumulator, type DeltaPayload } from '../lib/chatStream';
   import ActionIcon from '../lib/icons/ActionIcon.svelte';
   import WorkflowPhaseCard from './WorkflowPhaseCard.svelte';
   import { workflowState } from '../stores/workflow';
@@ -27,8 +28,9 @@
   // `task-delta` fragments and lets the progress handler know which tasks are
   // streaming (so "Running…" ticks don't clobber the live text). Cleared on
   // task completion so the authoritative narrative replaces — not appends to —
-  // the accumulation.
-  const streams = new StreamAccumulator();
+  // the accumulation. Shared (module singleton) so `InputArea`'s reconcile
+  // handler consults the SAME streaming state and never overwrites live text.
+  const streams = streamAccumulator;
 
   interface ProgressPayload {
     task_id: string;
@@ -80,17 +82,14 @@
         streams.finalize(p.task_id);
         return;
       }
-      if (p.text) {
-        const full = streams.append(p.task_id, p.text);
-        updateMessageByTask($activeProjectId, p.task_id, full);
-      } else {
-        // Ensure the task is marked streaming even if the first fragment was
-        // empty, so progress ticks stay suppressed until completion.
-        streams.append(p.task_id, '');
-      }
-      if (p.agent) {
-        setMessageSpeakerByTask($activeProjectId, p.task_id, p.agent);
-      }
+      // Grow the SINGLE in-flight bubble in place via one store write. Empty
+      // fragments still `append('')` so the task is marked streaming (gating
+      // progress ticks) and its `pending-` id is reconciled on the very first
+      // delta — so token #1 lands in the one existing bubble rather than being
+      // dropped until the poll loop swaps the id. Content + speaker go through
+      // a single update: no second render, no mid-stream flash/flicker.
+      const full = streams.append(p.task_id, p.text ?? '');
+      streamDeltaIntoTask($activeProjectId, p.task_id, full, p.agent || undefined);
     });
     unlistenProgress = await listenEvent<ProgressPayload>('task-progress', (p) => {
       // Don't let a polling "Running…" tick overwrite live streamed text.

--- a/crates/trusty-agents/ui/src/components/InputArea.svelte
+++ b/crates/trusty-agents/ui/src/components/InputArea.svelte
@@ -17,6 +17,7 @@
   import { get } from 'svelte/store';
   import { cancelTask, invoke, listenEvent, type CancelTaskResult } from '../lib/transport';
   import { buildRetaskPayload, isPendingTaskId } from '../lib/retask';
+  import { streamAccumulator } from '../lib/chatStream';
   import { resolveOverride } from '../lib/models';
   import { agentRoster } from '../stores/app';
   import { rosterDisplayName } from '../lib/roster';
@@ -165,8 +166,16 @@
         if (reconciled || !p.task_id || mySeq !== submissionSeq) return;
         reconciled = true;
         replaceMessageTaskId(projectId, placeholderTaskId, p.task_id);
-        // Apply the message that triggered the swap so it isn't lost.
-        updateMessageByTask(projectId, p.task_id, p.message);
+        // Apply the message that triggered the swap so it isn't lost — but NOT
+        // while the bubble is streaming token deltas: writing this interim
+        // "Running…" progress text over the live streamed text is exactly the
+        // mid-stream flash the single-bubble fix removes. ChatView's own
+        // progress handler is likewise gated on the shared streaming state, so
+        // during a stream the authoritative `task-complete` narrative is what
+        // finally replaces the accumulated text.
+        if (!streamAccumulator.isStreaming(p.task_id)) {
+          updateMessageByTask(projectId, p.task_id, p.message);
+        }
         activeTaskId.set(p.task_id);
         if (cancelQueued) {
           cancelQueued = false;

--- a/crates/trusty-agents/ui/src/lib/chatStream.test.ts
+++ b/crates/trusty-agents/ui/src/lib/chatStream.test.ts
@@ -121,30 +121,19 @@ describe('StreamAccumulator', () => {
 });
 
 describe('fillDeltaIntoList', () => {
-  it('adopts the pending placeholder on the first delta and fills it in place', () => {
-    // The delta carries the REAL backend id while the bubble still holds its
-    // client-side `pending-` id: the first token must still land in the ONE
-    // existing bubble (id preserved), reconciling the id — not be dropped.
+  it('fills the bubble whose taskId matches EXACTLY, in place (id preserved)', () => {
     const list: Message[] = [
       { id: 'user-1', role: 'user', content: 'hi', timestamp: 0 },
-      asst({ id: 'asst-1', taskId: 'pending-1', content: '' }),
+      asst({ id: 'asst-1', taskId: 'real-99', content: 'Hel' }),
     ];
-    const next = fillDeltaIntoList(list, 'real-99', 'Hel', 'Izzie');
+    const next = fillDeltaIntoList(list, 'real-99', 'Hello, world', 'Izzie');
     expect(next).not.toBe(list); // changed ⇒ new array
     expect(next.length).toBe(2); // no new bubble created
     const bubble = next[1];
     expect(bubble.id).toBe('asst-1'); // SAME node id ⇒ no keyed-each re-mount
-    expect(bubble.taskId).toBe('real-99'); // id reconciled
-    expect(bubble.content).toBe('Hel');
+    expect(bubble.taskId).toBe('real-99'); // id unchanged
+    expect(bubble.content).toBe('Hello, world');
     expect(bubble.speaker).toBe('Izzie'); // speaker applied in the same write
-  });
-
-  it('grows the same bubble in place across subsequent deltas (matched by real id)', () => {
-    const list: Message[] = [asst({ id: 'asst-1', taskId: 'real-99', content: 'Hel' })];
-    const next = fillDeltaIntoList(list, 'real-99', 'Hello, world', 'Izzie');
-    expect(next[0].id).toBe('asst-1');
-    expect(next[0].content).toBe('Hello, world');
-    expect(next).not.toBe(list);
   });
 
   it('returns the SAME array reference for a no-op write (no re-render churn)', () => {
@@ -157,25 +146,24 @@ describe('fillDeltaIntoList', () => {
   });
 
   it('keeps the existing speaker when the delta carries none', () => {
-    const list: Message[] = [asst({ id: 'asst-1', taskId: 'pending-1', speaker: 'CTO Assistant', content: '' })];
-    const next = fillDeltaIntoList(list, 'real-99', 'x');
+    const list: Message[] = [asst({ id: 'asst-1', taskId: 'real-99', speaker: 'CTO Assistant', content: 'a' })];
+    const next = fillDeltaIntoList(list, 'real-99', 'ab');
     expect(next[0].speaker).toBe('CTO Assistant');
-    expect(next[0].taskId).toBe('real-99');
+    expect(next[0].content).toBe('ab');
   });
 
-  it('adopts the MOST RECENT pending assistant bubble, never an earlier turn', () => {
+  it('NEVER adopts a pending bubble by position — an unmatched id is dropped', () => {
+    // Guards PR #3763 code-critic HIGH: the delta's real id must not be
+    // steered into "the newest pending- bubble" (that swapped answers across
+    // turns on a retask race). No exact match ⇒ list returned unchanged.
     const list: Message[] = [
       asst({ id: 'asst-old', taskId: 'pending-old', content: 'stale' }),
-      { id: 'user-2', role: 'user', content: 'again', timestamp: 1 },
       asst({ id: 'asst-new', taskId: 'pending-new', content: '' }),
     ];
-    const next = fillDeltaIntoList(list, 'real-99', 'live', 'Izzie');
-    expect(next.find((m) => m.id === 'asst-new')?.taskId).toBe('real-99');
-    expect(next.find((m) => m.id === 'asst-new')?.content).toBe('live');
-    expect(next.find((m) => m.id === 'asst-old')?.taskId).toBe('pending-old'); // untouched
+    expect(fillDeltaIntoList(list, 'real-99', 'live', 'Izzie')).toBe(list);
   });
 
-  it('is a no-op when there is no assistant bubble to fill', () => {
+  it('is a no-op when there is no matching bubble to fill', () => {
     const list: Message[] = [{ id: 'user-1', role: 'user', content: 'hi', timestamp: 0 }];
     expect(fillDeltaIntoList(list, 'real-99', 'x')).toBe(list);
   });

--- a/crates/trusty-agents/ui/src/lib/chatStream.test.ts
+++ b/crates/trusty-agents/ui/src/lib/chatStream.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { bridgeDelta, StreamAccumulator } from './chatStream';
+import {
+  bridgeDelta,
+  StreamAccumulator,
+  streamAccumulator,
+  fillDeltaIntoList,
+} from './chatStream';
 import type { AppEvent } from './transport';
+import type { Message } from '../stores/app';
+
+/** Minimal assistant-bubble factory for the fill-in-place tests. */
+function asst(overrides: Partial<Message> = {}): Message {
+  return {
+    id: 'asst-1',
+    role: 'assistant',
+    content: '',
+    timestamp: 0,
+    taskId: 'pending-1',
+    speaker: 'Assistant',
+    ...overrides,
+  };
+}
 
 describe('bridgeDelta', () => {
   it('maps an agent_message_delta event to a task-delta payload', () => {
@@ -88,5 +107,76 @@ describe('StreamAccumulator', () => {
     // the bubble content (handled by the component's updateMessageByTask).
     acc.finalize('t');
     expect(acc.isStreaming('t')).toBe(false);
+  });
+
+  it('exposes a shared singleton instance for cross-component streaming state', () => {
+    // ChatView (grows the bubble) and InputArea (gates its progress reconcile)
+    // must observe the SAME streaming state, so the export is one instance.
+    expect(streamAccumulator).toBeInstanceOf(StreamAccumulator);
+    streamAccumulator.append('shared-task', 'x');
+    expect(streamAccumulator.isStreaming('shared-task')).toBe(true);
+    streamAccumulator.finalize('shared-task');
+    expect(streamAccumulator.isStreaming('shared-task')).toBe(false);
+  });
+});
+
+describe('fillDeltaIntoList', () => {
+  it('adopts the pending placeholder on the first delta and fills it in place', () => {
+    // The delta carries the REAL backend id while the bubble still holds its
+    // client-side `pending-` id: the first token must still land in the ONE
+    // existing bubble (id preserved), reconciling the id — not be dropped.
+    const list: Message[] = [
+      { id: 'user-1', role: 'user', content: 'hi', timestamp: 0 },
+      asst({ id: 'asst-1', taskId: 'pending-1', content: '' }),
+    ];
+    const next = fillDeltaIntoList(list, 'real-99', 'Hel', 'Izzie');
+    expect(next).not.toBe(list); // changed ⇒ new array
+    expect(next.length).toBe(2); // no new bubble created
+    const bubble = next[1];
+    expect(bubble.id).toBe('asst-1'); // SAME node id ⇒ no keyed-each re-mount
+    expect(bubble.taskId).toBe('real-99'); // id reconciled
+    expect(bubble.content).toBe('Hel');
+    expect(bubble.speaker).toBe('Izzie'); // speaker applied in the same write
+  });
+
+  it('grows the same bubble in place across subsequent deltas (matched by real id)', () => {
+    const list: Message[] = [asst({ id: 'asst-1', taskId: 'real-99', content: 'Hel' })];
+    const next = fillDeltaIntoList(list, 'real-99', 'Hello, world', 'Izzie');
+    expect(next[0].id).toBe('asst-1');
+    expect(next[0].content).toBe('Hello, world');
+    expect(next).not.toBe(list);
+  });
+
+  it('returns the SAME array reference for a no-op write (no re-render churn)', () => {
+    // An identical content+speaker frame (e.g. a duplicate/empty delta) must
+    // not replace the list, or the store would fire a redundant render + a
+    // forced scroll reflow per token — a source of the visible flicker.
+    const list: Message[] = [asst({ id: 'asst-1', taskId: 'real-99', content: 'Hi', speaker: 'Izzie' })];
+    const same = fillDeltaIntoList(list, 'real-99', 'Hi', 'Izzie');
+    expect(same).toBe(list);
+  });
+
+  it('keeps the existing speaker when the delta carries none', () => {
+    const list: Message[] = [asst({ id: 'asst-1', taskId: 'pending-1', speaker: 'CTO Assistant', content: '' })];
+    const next = fillDeltaIntoList(list, 'real-99', 'x');
+    expect(next[0].speaker).toBe('CTO Assistant');
+    expect(next[0].taskId).toBe('real-99');
+  });
+
+  it('adopts the MOST RECENT pending assistant bubble, never an earlier turn', () => {
+    const list: Message[] = [
+      asst({ id: 'asst-old', taskId: 'pending-old', content: 'stale' }),
+      { id: 'user-2', role: 'user', content: 'again', timestamp: 1 },
+      asst({ id: 'asst-new', taskId: 'pending-new', content: '' }),
+    ];
+    const next = fillDeltaIntoList(list, 'real-99', 'live', 'Izzie');
+    expect(next.find((m) => m.id === 'asst-new')?.taskId).toBe('real-99');
+    expect(next.find((m) => m.id === 'asst-new')?.content).toBe('live');
+    expect(next.find((m) => m.id === 'asst-old')?.taskId).toBe('pending-old'); // untouched
+  });
+
+  it('is a no-op when there is no assistant bubble to fill', () => {
+    const list: Message[] = [{ id: 'user-1', role: 'user', content: 'hi', timestamp: 0 }];
+    expect(fillDeltaIntoList(list, 'real-99', 'x')).toBe(list);
   });
 });

--- a/crates/trusty-agents/ui/src/lib/chatStream.ts
+++ b/crates/trusty-agents/ui/src/lib/chatStream.ts
@@ -20,7 +20,6 @@
 
 import type { AppEvent } from './transport';
 import type { Message } from '../stores/app';
-import { isPendingTaskId } from './retask';
 
 /** Web-bus payload for an accumulated token batch. */
 export interface DeltaPayload {
@@ -115,24 +114,25 @@ export class StreamAccumulator {
 export const streamAccumulator = new StreamAccumulator();
 
 /**
- * Fill a streamed token batch into the ONE in-flight assistant bubble, in
- * place, returning the next message list (or the SAME array reference when the
- * write is a no-op so the store — and therefore Svelte's keyed `{#each}` and
- * the scroll reflow — does not churn a redundant re-render).
+ * Fill a streamed token batch into the in-flight assistant bubble whose
+ * `taskId` EXACTLY equals the delta's (globally-unique) backend id, in place,
+ * returning the next message list — or the SAME array reference when nothing
+ * changes (no match, or an identical/duplicate frame) so the store, Svelte's
+ * keyed `{#each}`, and the scroll reflow do not churn a redundant re-render.
  *
  * Why: The chat renders `{#each $activeMessages as msg (msg.id)}`, so a stable
- * bubble requires (a) never changing the matched message's `id` and (b) not
- * dropping early deltas. Before reconciliation the placeholder bubble still
- * carries its client-side `pending-<ts>` id while `task-delta` events already
- * carry the REAL backend id, so a plain id-equality update missed the bubble
- * until the poll loop swapped the id — the first tokens were lost and the poll
- * loop's interim progress text flashed in, which is the flicker the owner saw.
- * This adopts the most recent in-flight `pending-` assistant bubble on the
- * first delta, so token #1 onward render inside the single existing bubble.
- * What: Locates the target bubble by exact `taskId`, else the newest assistant
- * bubble still on a `pending-` id; rewrites its `content` (and `speaker`, when
- * the delta carries one) while preserving its `id`; returns `list` unchanged
- * when nothing would change.
+ * bubble requires never changing the matched message's `id` — we rewrite only
+ * `content`/`speaker` and keep `id`, so the keyed block is patched, never
+ * re-mounted. Attribution is by exact backend id ONLY: an earlier version
+ * adopted "the newest `pending-` bubble" by list position, which — on a retask
+ * race or a background stream after a project switch — let one turn's delta
+ * land in another turn's (or project's) bubble (PR #3763 code-critic HIGH). A
+ * frame whose id matches no bubble here is intentionally dropped (returned
+ * unchanged); the poll loop reconciles the placeholder `pending-<ts>` id to the
+ * real id (`InputArea` → `replaceMessageTaskId`), after which every delta for
+ * that turn matches and fills the one bubble.
+ * What: Rewrites the exact-`taskId` bubble's `content` (and `speaker`, when the
+ * delta carries one), preserving `id`; returns `list` unchanged otherwise.
  * Test: `chatStream.test.ts` (`fillDeltaIntoList`).
  */
 export function fillDeltaIntoList(
@@ -141,29 +141,16 @@ export function fillDeltaIntoList(
   content: string,
   speaker?: string,
 ): Message[] {
-  let idx = list.findIndex((m) => m.taskId === taskId);
-  if (idx === -1) {
-    for (let i = list.length - 1; i >= 0; i--) {
-      const m = list[i];
-      if (m.role === 'assistant' && isPendingTaskId(m.taskId ?? null)) {
-        idx = i;
-        break;
-      }
-    }
-  }
-  if (idx === -1) return list;
+  const idx = list.findIndex((m) => m.taskId === taskId);
+  if (idx === -1) return list; // unattributable frame ⇒ drop (never guess)
 
   const target = list[idx];
   const nextSpeaker = speaker && speaker.length > 0 ? speaker : target.speaker;
-  if (
-    target.taskId === taskId &&
-    target.content === content &&
-    target.speaker === nextSpeaker
-  ) {
+  if (target.content === content && target.speaker === nextSpeaker) {
     return list;
   }
 
   const next = list.slice();
-  next[idx] = { ...target, taskId, content, speaker: nextSpeaker };
+  next[idx] = { ...target, content, speaker: nextSpeaker };
   return next;
 }

--- a/crates/trusty-agents/ui/src/lib/chatStream.ts
+++ b/crates/trusty-agents/ui/src/lib/chatStream.ts
@@ -19,6 +19,8 @@
 // Test: `chatStream.test.ts`.
 
 import type { AppEvent } from './transport';
+import type { Message } from '../stores/app';
+import { isPendingTaskId } from './retask';
 
 /** Web-bus payload for an accumulated token batch. */
 export interface DeltaPayload {
@@ -96,4 +98,72 @@ export class StreamAccumulator {
   finalize(taskId: string): boolean {
     return this.buffers.delete(taskId);
   }
+}
+
+/**
+ * Why: The streaming write path spans TWO components — `ChatView` grows the
+ * bubble from `task-delta` events, while `InputArea`'s poll-loop reconcile
+ * must NOT overwrite that live text with a "Running…" progress tick. Both need
+ * the same "is task T streaming?" answer, so a single shared instance is the
+ * source of truth instead of a per-component `new StreamAccumulator()` (which
+ * left `InputArea` blind to `ChatView`'s streaming state, so its reconcile
+ * clobbered streamed text — a visible mid-stream flash). Finalized per task on
+ * completion, so nothing leaks across turns.
+ * What: The process-wide accumulator both components import.
+ * Test: `chatStream.test.ts` (`streamAccumulator singleton`).
+ */
+export const streamAccumulator = new StreamAccumulator();
+
+/**
+ * Fill a streamed token batch into the ONE in-flight assistant bubble, in
+ * place, returning the next message list (or the SAME array reference when the
+ * write is a no-op so the store — and therefore Svelte's keyed `{#each}` and
+ * the scroll reflow — does not churn a redundant re-render).
+ *
+ * Why: The chat renders `{#each $activeMessages as msg (msg.id)}`, so a stable
+ * bubble requires (a) never changing the matched message's `id` and (b) not
+ * dropping early deltas. Before reconciliation the placeholder bubble still
+ * carries its client-side `pending-<ts>` id while `task-delta` events already
+ * carry the REAL backend id, so a plain id-equality update missed the bubble
+ * until the poll loop swapped the id — the first tokens were lost and the poll
+ * loop's interim progress text flashed in, which is the flicker the owner saw.
+ * This adopts the most recent in-flight `pending-` assistant bubble on the
+ * first delta, so token #1 onward render inside the single existing bubble.
+ * What: Locates the target bubble by exact `taskId`, else the newest assistant
+ * bubble still on a `pending-` id; rewrites its `content` (and `speaker`, when
+ * the delta carries one) while preserving its `id`; returns `list` unchanged
+ * when nothing would change.
+ * Test: `chatStream.test.ts` (`fillDeltaIntoList`).
+ */
+export function fillDeltaIntoList(
+  list: Message[],
+  taskId: string,
+  content: string,
+  speaker?: string,
+): Message[] {
+  let idx = list.findIndex((m) => m.taskId === taskId);
+  if (idx === -1) {
+    for (let i = list.length - 1; i >= 0; i--) {
+      const m = list[i];
+      if (m.role === 'assistant' && isPendingTaskId(m.taskId ?? null)) {
+        idx = i;
+        break;
+      }
+    }
+  }
+  if (idx === -1) return list;
+
+  const target = list[idx];
+  const nextSpeaker = speaker && speaker.length > 0 ? speaker : target.speaker;
+  if (
+    target.taskId === taskId &&
+    target.content === content &&
+    target.speaker === nextSpeaker
+  ) {
+    return list;
+  }
+
+  const next = list.slice();
+  next[idx] = { ...target, taskId, content, speaker: nextSpeaker };
+  return next;
 }

--- a/crates/trusty-agents/ui/src/stores/app.stream.test.ts
+++ b/crates/trusty-agents/ui/src/stores/app.stream.test.ts
@@ -1,0 +1,111 @@
+// Store-level tests for `streamDeltaIntoTask` — the function `ChatView`
+// actually calls on every `task-delta` frame. The pure attribution core is
+// covered in `lib/chatStream.test.ts`; these exercise the real `messages`
+// `writable<Map>` end to end, including the two misattribution races the
+// PR #3763 code-critic reproduced (retask race + cross-project write) and the
+// "no-op ⇒ no notify" suppression that a same-reference return alone does NOT
+// give you on an object-valued Svelte store.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  messages,
+  addMessage,
+  replaceMessageTaskId,
+  streamDeltaIntoTask,
+  activeProjectId,
+  type Message,
+} from './app';
+
+function asst(id: string, taskId: string, content = '', speaker = 'Assistant'): Message {
+  return { id, role: 'assistant', content, timestamp: 0, taskId, speaker };
+}
+
+function contentOf(projectId: string, msgId: string): string | undefined {
+  return get(messages)
+    .get(projectId)
+    ?.find((m) => m.id === msgId)?.content;
+}
+
+beforeEach(() => {
+  messages.set(new Map());
+  activeProjectId.set('ctrl');
+});
+
+describe('streamDeltaIntoTask', () => {
+  it('grows the matching bubble in place, preserving its id, without adding messages', () => {
+    addMessage('ctrl', { id: 'user-1', role: 'user', content: 'hi', timestamp: 0 });
+    addMessage('ctrl', asst('asst-1', 'real-1', ''));
+
+    streamDeltaIntoTask('real-1', 'Hel', 'Izzie');
+    streamDeltaIntoTask('real-1', 'Hello', 'Izzie');
+
+    const list = get(messages).get('ctrl')!;
+    expect(list.length).toBe(2); // no bubble spawned
+    const bubble = list.find((m) => m.id === 'asst-1')!;
+    expect(bubble.id).toBe('asst-1'); // stable node ⇒ no keyed-each re-mount
+    expect(bubble.content).toBe('Hello');
+    expect(bubble.speaker).toBe('Izzie');
+  });
+
+  it('retask race: a superseded task’s late delta lands in ITS OWN bubble, never the new one', () => {
+    // Two turns in the same conversation. Turn 1 reconciled to real-1; turn 2
+    // is the newer placeholder (`pending-2`). A late delta for real-1 must fill
+    // turn 1 — NOT be steered by position into the newest bubble.
+    addMessage('ctrl', asst('asst-1', 'real-1', 'first '));
+    addMessage('ctrl', asst('asst-2', 'pending-2', ''));
+
+    streamDeltaIntoTask('real-1', 'first answer', 'Izzie');
+
+    expect(contentOf('ctrl', 'asst-1')).toBe('first answer'); // correct bubble
+    expect(contentOf('ctrl', 'asst-2')).toBe(''); // new placeholder untouched
+    expect(get(messages).get('ctrl')!.find((m) => m.id === 'asst-2')!.taskId).toBe('pending-2');
+  });
+
+  it('drops a delta whose id matches nothing yet (pre-reconcile), corrupting no bubble', () => {
+    addMessage('ctrl', asst('asst-2', 'pending-2', ''));
+    streamDeltaIntoTask('real-unknown', 'leak?', 'Izzie');
+    expect(contentOf('ctrl', 'asst-2')).toBe(''); // still the placeholder, untouched
+  });
+
+  it('cross-project: a delta for project A fills A even while project B is viewed', () => {
+    addMessage('proj-a', asst('asst-a', 'real-a', ''));
+    addMessage('proj-b', asst('asst-b', 'real-b', 'B-content'));
+    activeProjectId.set('proj-b'); // user is looking at project B
+
+    streamDeltaIntoTask('real-a', 'A-answer', 'Izzie');
+
+    expect(contentOf('proj-a', 'asst-a')).toBe('A-answer'); // routed to owner
+    expect(contentOf('proj-b', 'asst-b')).toBe('B-content'); // viewed project intact
+  });
+
+  it('a no-op frame performs NO store set (subscribers are not notified)', () => {
+    addMessage('ctrl', asst('asst-1', 'real-1', 'Hi', 'Izzie'));
+
+    let notifyCount = 0;
+    const unsub = messages.subscribe(() => {
+      notifyCount++;
+    });
+    notifyCount = 0; // discount the initial synchronous subscribe call
+
+    streamDeltaIntoTask('real-1', 'Hi', 'Izzie'); // identical ⇒ no-op
+    expect(notifyCount).toBe(0);
+
+    streamDeltaIntoTask('real-1', 'Hi there', 'Izzie'); // real change ⇒ one notify
+    expect(notifyCount).toBe(1);
+
+    unsub();
+  });
+
+  it('reconcile + stream: after replaceMessageTaskId swaps pending→real, deltas fill the bubble', () => {
+    // Mirrors the live flow: InputArea creates the bubble on a `pending-` id,
+    // the poll loop reconciles it to the real id, then deltas match and fill.
+    addMessage('ctrl', asst('asst-1', 'pending-1', ''));
+    streamDeltaIntoTask('real-1', 'early', 'Izzie'); // arrives pre-reconcile ⇒ dropped
+    expect(contentOf('ctrl', 'asst-1')).toBe('');
+
+    replaceMessageTaskId('ctrl', 'pending-1', 'real-1'); // poll loop reconciles
+    streamDeltaIntoTask('real-1', 'early answer', 'Izzie');
+    expect(contentOf('ctrl', 'asst-1')).toBe('early answer');
+  });
+});

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -1,4 +1,4 @@
-import { writable, derived } from 'svelte/store';
+import { writable, derived, get } from 'svelte/store';
 import { apiBase } from '../lib/api-config';
 import { invoke, isDesktop } from '../lib/transport';
 import {
@@ -358,32 +358,40 @@ export function updateMessageByTask(projectId: string, taskId: string, content: 
 /**
  * Why: Token-streaming (`task-delta`) must grow the SINGLE in-flight assistant
  * bubble in place — one stable node per turn, no per-token re-mount or flash.
- * A plain `updateMessageByTask` misses two things: it does a full second store
- * write for the mid-stream speaker stamp (two re-renders + two scroll reflows
- * per token), and it can't land the first tokens because the bubble still
- * carries its `pending-<ts>` id while deltas already carry the real one. This
- * funnels content + speaker through ONE store write and reconciles the
- * placeholder id on the first delta (see `fillDeltaIntoList`), and no-ops when
- * nothing changed so an idle/duplicate frame triggers no render.
- * What: Applies a delta batch to the in-flight bubble for `projectId`, updating
- * the outer `Map` only when the list actually changed.
- * Test: `chatStream.test.ts` exercises the pure `fillDeltaIntoList` core.
+ * A plain `updateMessageByTask` did a second store write for the mid-stream
+ * speaker stamp (two re-renders + two scroll reflows per token); this funnels
+ * content + speaker through ONE write. Attribution is by the delta's
+ * globally-unique backend `taskId` and is resolved by SEARCHING EVERY
+ * conversation — never the currently-viewed project (`$activeProjectId`) —
+ * because a background stream must reach its own conversation's bubble after a
+ * project switch, and must never write into whatever project happens to be on
+ * screen (PR #3763 code-critic HIGH). A frame whose id matches no in-flight
+ * bubble is dropped. Uses `get` + a conditional `set` (not `update`) so a no-op
+ * frame performs NO `set` at all: because `messages` is a `writable<Map>` and
+ * Svelte's `safe_not_equal` always notifies for object values, returning the
+ * same Map from `update` would still notify subscribers — only skipping `set`
+ * truly suppresses the churn.
+ * What: Applies a delta batch to the bubble whose `taskId` matches, in its
+ * owning project; `set`s the outer `Map` only when a list actually changed.
+ * Test: `app.stream.test.ts` (store-level) + `chatStream.test.ts` (pure core).
  */
-export function streamDeltaIntoTask(
-  projectId: string,
-  taskId: string,
-  content: string,
-  speaker?: string,
-): void {
-  messages.update((map) => {
-    const list = map.get(projectId);
-    if (!list) return map;
+export function streamDeltaIntoTask(taskId: string, content: string, speaker?: string): void {
+  const map = get(messages);
+  let changedProject: string | null = null;
+  let changedList: Message[] | null = null;
+  // taskId is globally unique ⇒ at most one project's list changes; stop early.
+  for (const [projectId, list] of map) {
     const nextList = fillDeltaIntoList(list, taskId, content, speaker);
-    if (nextList === list) return map; // no-op ⇒ no store churn
-    const next = new Map(map);
-    next.set(projectId, nextList);
-    return next;
-  });
+    if (nextList !== list) {
+      changedProject = projectId;
+      changedList = nextList;
+      break;
+    }
+  }
+  if (changedProject === null || changedList === null) return; // no change ⇒ no notify
+  const next = new Map(map);
+  next.set(changedProject, changedList);
+  messages.set(next);
 }
 
 /**

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -9,6 +9,7 @@ import {
   type RosterEntry,
 } from '../lib/roster';
 import type { ModelsCatalogResponse, PickerEntry } from '../lib/models';
+import { fillDeltaIntoList } from '../lib/chatStream';
 
 /**
  * Why: The sidebar needs a single source of truth for the list of chat
@@ -350,6 +351,37 @@ export function updateMessageByTask(projectId: string, taskId: string, content: 
       projectId,
       list.map((m) => (m.taskId === taskId ? { ...m, content } : m)),
     );
+    return next;
+  });
+}
+
+/**
+ * Why: Token-streaming (`task-delta`) must grow the SINGLE in-flight assistant
+ * bubble in place — one stable node per turn, no per-token re-mount or flash.
+ * A plain `updateMessageByTask` misses two things: it does a full second store
+ * write for the mid-stream speaker stamp (two re-renders + two scroll reflows
+ * per token), and it can't land the first tokens because the bubble still
+ * carries its `pending-<ts>` id while deltas already carry the real one. This
+ * funnels content + speaker through ONE store write and reconciles the
+ * placeholder id on the first delta (see `fillDeltaIntoList`), and no-ops when
+ * nothing changed so an idle/duplicate frame triggers no render.
+ * What: Applies a delta batch to the in-flight bubble for `projectId`, updating
+ * the outer `Map` only when the list actually changed.
+ * Test: `chatStream.test.ts` exercises the pure `fillDeltaIntoList` core.
+ */
+export function streamDeltaIntoTask(
+  projectId: string,
+  taskId: string,
+  content: string,
+  speaker?: string,
+): void {
+  messages.update((map) => {
+    const list = map.get(projectId);
+    if (!list) return map;
+    const nextList = fillDeltaIntoList(list, taskId, content, speaker);
+    if (nextList === list) return map; // no-op ⇒ no store churn
+    const next = new Map(map);
+    next.set(projectId, nextList);
     return next;
   });
 }


### PR DESCRIPTION
## Problem

Reported live by the owner during a demo dry-run: *"there's a flicker as the bubble re-renders. Can we just keep a single response bubble and render the response inside?"*

As `chat_stream` (`task-delta`) tokens arrive, the assistant reply bubble visibly flickers instead of one stable node filling in place.

## Root cause

The delta handler fired **two** separate `messages` store mutations per token — `updateMessageByTask` (content) **and** `setMessageSpeakerByTask` (speaker, sent on every frame) — so the keyed `{#each ... (msg.id)}` reconciled and the `afterUpdate` scroll reflow ran **twice per token** (`ChatView.svelte`).

## Fix — one stable bubble, filled in place

- **`streamDeltaIntoTask` (store, `app.ts`)** — funnels content + speaker through **one** store write per delta (was two). It rewrites only `content`/`speaker`, preserving the message `id`, so the keyed `{#each}` is patched, never re-mounted.
- **`fillDeltaIntoList` (pure, `chatStream.ts`)** — attributes each delta to a bubble by **exact backend `taskId`** (globally unique). No exact match ⇒ the frame is dropped; the shared `streamAccumulator` keeps its text so the first matching write shows everything so far.
- **`streamAccumulator` shared singleton** — `ChatView` (grows the bubble) and `InputArea` (gates its progress reconcile) consult the **same** streaming state, so neither overwrites live streamed text. The authoritative `task-complete` narrative still replaces the accumulation on completion.

---

## Code-critic fix round (BLOCK → addressed)

Round-2 commit `fix(trusty-agents): attribute chat deltas by exact backend id, not list position`.

**HIGH — cross-task / cross-project misattribution (confirmed, reproduced).** The first cut adopted "the newest `pending-` bubble" by list position and wrote into `$activeProjectId` (the viewed project). Fixed by removing all position guessing: attribution is now by exact, globally-unique backend `taskId`, and `streamDeltaIntoTask` searches **every** conversation (not the viewed one) so a delta always reaches its owning bubble and never any other. Unattributable frames (e.g. arriving before the poll loop reconciles the `pending-<ts>` id) are dropped. The bubble still receives its real id via the existing `InputArea` → `replaceMessageTaskId` reconcile.

**MEDIUM 1 — the "no-op ⇒ no re-render" guarantee was false.** `messages` is a `writable<Map>`; Svelte's `safe_not_equal` notifies for object values even on a same-reference return, so `update()` returning the same Map still churned subscribers. `streamDeltaIntoTask` now uses `get` + a **conditional `set`** and skips `set` entirely on a no-op, so unchanged/duplicate frames notify nobody — asserted via a subscriber notify-count test.

**MEDIUM 2 — coverage.** Added `stores/app.stream.test.ts` (store-level) and rewrote the `fillDeltaIntoList` tests (the old ones encoded the buggy newest-pending assumption).

New test names:
- `streamDeltaIntoTask › grows the matching bubble in place, preserving its id, without adding messages`
- `streamDeltaIntoTask › retask race: a superseded task’s late delta lands in ITS OWN bubble, never the new one`
- `streamDeltaIntoTask › drops a delta whose id matches nothing yet (pre-reconcile), corrupting no bubble`
- `streamDeltaIntoTask › cross-project: a delta for project A fills A even while project B is viewed`
- `streamDeltaIntoTask › a no-op frame performs NO store set (subscribers are not notified)`
- `streamDeltaIntoTask › reconcile + stream: after replaceMessageTaskId swaps pending→real, deltas fill the bubble`
- `fillDeltaIntoList › fills the bubble whose taskId matches EXACTLY, in place (id preserved)`
- `fillDeltaIntoList › returns the SAME array reference for a no-op write (no re-render churn)`
- `fillDeltaIntoList › keeps the existing speaker when the delta carries none`
- `fillDeltaIntoList › NEVER adopts a pending bubble by position — an unmatched id is dropped`
- `fillDeltaIntoList › is a no-op when there is no matching bubble to fill`

## Verification

- `pnpm test:unit` — **78 passed** (7 files).
- `pnpm check` (svelte-check) — **0 errors** (2 warnings pre-existing in `ProjectsView.svelte`, untouched).
- `pnpm build` — bundle compiles clean.
- No Rust crate touched (frontend TS/Svelte only), so no `cargo` gate applies.

Frontend-only; CHANGELOG updated under `## [Unreleased]`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools