### PR TITLE
fix(trusty-agents): show no interim status text in the chat bubble — spinner only

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -12,12 +12,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **No interim status text in the chat response bubble — the spinner is the
   sole waiting indicator:** the assistant bubble no longer fills with
   "Running…"/"submitted…"-style `task-progress` status strings. It stays empty
-  (with the animated spinner shown beneath the thread) until the first streamed
-  `task-delta` or, for non-streaming providers, the final `task-complete`
-  narrative arrives. Removed the two progress-text writes into message content
-  (`ChatView`'s `task-progress` listener, dropped entirely; `InputArea`'s
-  poll-reconcile write); the pending→real id reconcile itself is retained (it's
-  load-bearing for streamed-delta attribution).
+  (with a bare animated spinner shown beneath the thread — no "Running…" text
+  label; `role="status"` + `aria-label` preserve the accessible busy-state
+  name) until the first streamed `task-delta` or, for non-streaming providers,
+  the final `task-complete` narrative arrives. Removed the two progress-text
+  writes into message content (`ChatView`'s `task-progress` listener, dropped
+  entirely; `InputArea`'s poll-reconcile write) and the spinner-row text label;
+  the pending→real id reconcile itself is retained (it's load-bearing for
+  streamed-delta attribution).
 - **Base `assistant` persona defaults to Sonnet instead of Opus (#3688):**
   `claude-opus-4-6` → `claude-sonnet-4-6` on `assistant/agent.toml`, trading a
   small quality margin for materially lower per-turn latency (a trivial turn

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -9,6 +9,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **No interim status text in the chat response bubble — the spinner is the
+  sole waiting indicator:** the assistant bubble no longer fills with
+  "Running…"/"submitted…"-style `task-progress` status strings. It stays empty
+  (with the animated spinner shown beneath the thread) until the first streamed
+  `task-delta` or, for non-streaming providers, the final `task-complete`
+  narrative arrives. Removed the two progress-text writes into message content
+  (`ChatView`'s `task-progress` listener, dropped entirely; `InputArea`'s
+  poll-reconcile write); the pending→real id reconcile itself is retained (it's
+  load-bearing for streamed-delta attribution).
 - **Base `assistant` persona defaults to Sonnet instead of Opus (#3688):**
   `claude-opus-4-6` → `claude-sonnet-4-6` on `assistant/agent.toml`, trading a
   small quality margin for materially lower per-turn latency (a trivial turn

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -246,9 +246,16 @@
     {/if}
 
     {#if $isRunning}
-      <div class="flex items-center justify-start gap-2 text-xs text-foundry-teal">
-        <Loader2 class="h-3 w-3 animate-spin" />
-        <span>Running…</span>
+      <!-- Spinner only — no "Running…" text label (the animation is the sole
+           waiting indicator). `role="status"` + `aria-label` keep an accessible
+           name for the busy state now that the visible label is gone; the icon
+           is decorative. -->
+      <div
+        class="flex items-center justify-start text-foundry-teal"
+        role="status"
+        aria-label="Assistant is responding"
+      >
+        <Loader2 class="h-3 w-3 animate-spin" aria-hidden="true" />
       </div>
     {/if}
   </div>

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -19,7 +19,6 @@
   import { workflowState } from '../stores/workflow';
 
   let scrollEl: HTMLDivElement | undefined;
-  let unlistenProgress: UnlistenFn | null = null;
   let unlistenComplete: UnlistenFn | null = null;
   let unlistenError: UnlistenFn | null = null;
   let unlistenDelta: UnlistenFn | null = null;
@@ -32,10 +31,6 @@
   // handler consults the SAME streaming state and never overwrites live text.
   const streams = streamAccumulator;
 
-  interface ProgressPayload {
-    task_id: string;
-    message: string;
-  }
   interface CompletePayload {
     id: string;
     narrative?: string;
@@ -93,11 +88,12 @@
       const full = streams.append(p.task_id, p.text ?? '');
       streamDeltaIntoTask(p.task_id, full, p.agent || undefined);
     });
-    unlistenProgress = await listenEvent<ProgressPayload>('task-progress', (p) => {
-      // Don't let a polling "Running…" tick overwrite live streamed text.
-      if (streams.isStreaming(p.task_id)) return;
-      updateMessageByTask($activeProjectId, p.task_id, p.message);
-    });
+    // Note: `task-progress` events are intentionally NOT consumed here. Their
+    // only former job was writing interim "Running…" status text into the
+    // bubble; that text is no longer shown (the spinner is the sole waiting
+    // indicator), so the bubble stays empty until the first `task-delta` or the
+    // final `task-complete` narrative. The pending→real id reconcile still
+    // happens in InputArea's own one-shot progress listener.
     unlistenComplete = await listenEvent<CompletePayload>('task-complete', (p) => {
       // Drop any streamed buffer FIRST so the authoritative narrative replaces
       // (never appends to) the accumulation — the streaming dedupe contract.
@@ -126,7 +122,6 @@
   });
 
   onDestroy(() => {
-    unlistenProgress?.();
     unlistenComplete?.();
     unlistenError?.();
     unlistenDelta?.();

--- a/crates/trusty-agents/ui/src/components/InputArea.svelte
+++ b/crates/trusty-agents/ui/src/components/InputArea.svelte
@@ -17,7 +17,6 @@
   import { get } from 'svelte/store';
   import { cancelTask, invoke, listenEvent, type CancelTaskResult } from '../lib/transport';
   import { buildRetaskPayload, isPendingTaskId } from '../lib/retask';
-  import { streamAccumulator } from '../lib/chatStream';
   import { resolveOverride } from '../lib/models';
   import { agentRoster } from '../stores/app';
   import { rosterDisplayName } from '../lib/roster';
@@ -160,22 +159,19 @@
     // the reconciliation point for a queued cancel (see `queueCancel` above).
     let reconciled = false;
     let unlistenReconcile: (() => void) | null = null;
-    const unlistenP = await listenEvent<{ task_id: string; message: string }>(
+    const unlistenP = await listenEvent<{ task_id: string }>(
       'task-progress',
       (p) => {
         if (reconciled || !p.task_id || mySeq !== submissionSeq) return;
         reconciled = true;
+        // Reconcile the placeholder id to the real backend id — load-bearing:
+        // it's what lets subsequent `task-delta`/`task-complete` events (keyed
+        // by the real id) find and fill this bubble. We deliberately do NOT
+        // write the progress message's status text into the bubble: interim
+        // "Running…"/"submitted…" strings are not shown in the response bubble
+        // (the spinner is the sole waiting indicator); the bubble stays empty
+        // until the first streamed delta or the final narrative arrives.
         replaceMessageTaskId(projectId, placeholderTaskId, p.task_id);
-        // Apply the message that triggered the swap so it isn't lost — but NOT
-        // while the bubble is streaming token deltas: writing this interim
-        // "Running…" progress text over the live streamed text is exactly the
-        // mid-stream flash the single-bubble fix removes. ChatView's own
-        // progress handler is likewise gated on the shared streaming state, so
-        // during a stream the authoritative `task-complete` narrative is what
-        // finally replaces the accumulated text.
-        if (!streamAccumulator.isStreaming(p.task_id)) {
-          updateMessageByTask(projectId, p.task_id, p.message);
-        }
         activeTaskId.set(p.task_id);
         if (cancelQueued) {
           cancelQueued = false;


### PR DESCRIPTION
## Owner request

> Remove the "Running…" (and any "submitted…"-style) interim progress TEXT from the assistant response bubble — the spinner alone is the waiting indicator. The bubble should stay empty (spinner only) until either the first streamed delta or, for non-streaming providers, the final text arrives.

Plus a follow-up: *"we don't need a 'running…' message, the spinner is enough"* — so the spinner row's own text label is dropped too.

## What changed

**A. No interim status text in the bubble.** Two sites wrote interim `task-progress` status text (`p.message`) into the assistant bubble's content; both removed:

- **`ChatView.svelte`** — the `task-progress` listener existed *only* to write `p.message` into the bubble, so it is dropped entirely, along with its `unlistenProgress` variable, its `onDestroy` teardown, and the now-unused `ProgressPayload` interface.
- **`InputArea.svelte`** — the one-shot poll-reconcile handler's `updateMessageByTask(projectId, p.task_id, p.message)` write is removed, along with the now-unused `streamAccumulator` import that gated it.

**B. Spinner row is now icon-only.** The waiting indicator's `<span>Running…</span>` is removed, keeping the animated `Loader2` spinner (gated on `$isRunning`). The now-orphaned `gap-2`/`text-xs` classes are dropped. To avoid an a11y regression (the span was the busy state's only accessible name), the spinner container gets `role="status"` + `aria-label="Assistant is responding"` and the decorative icon is `aria-hidden="true"`.

**The pending→real id reconcile is kept** — `replaceMessageTaskId(pending → real)` + `activeTaskId.set(...)` still run on the first `task-progress` event. That swap is load-bearing for streamed-delta attribution (PR #3763 round-2 design), so only the *status-text write* was removed, not the reconcile.

## Spinner confirmation

The waiting spinner is the `{#if $isRunning}` row beneath the message thread, gated **purely on `$isRunning`** and independent of any message's content. It shows for the whole run and disappears on `task-complete`/`task-error` (which flip `isRunning` false). The empty bubble still renders its pre-existing `{msg.content || '…'}` placeholder glyph — a render fallback, not a written status string, left as-is (out of the stated scope). Say the word if you want the bare-empty bubble instead.

## Non-streaming path

Final text still lands: `task-complete` writes the narrative (`ChatView.svelte`), and the browser/Tauri fallback writes the resolved `result` (`InputArea.svelte`). Neither was touched, so a non-streaming provider still ends with the answer visible.

## Verification

- `pnpm test:unit` — **78 passed** (7 files). No test asserted the "Running…" string.
- `pnpm check` (svelte-check) — **0 errors** (2 warnings pre-existing in `ProjectsView.svelte`, untouched).
- `pnpm build` — bundle compiles clean.
- Frontend-only; no Rust crate touched. CHANGELOG updated under `## [Unreleased]`.

## Dependency

Branched off **`fix-chat-stream-bubble-flicker`** (PR #3763), which is still open, and this PR is based on that branch — the diff shows only this change. **Retarget this PR's base to `main` once #3763 lands.**

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools