### PR TITLE
docs: reconcile stale crate references and license claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,7 @@ documentation.
 | Crate | Description |
 |---|---|
 | `trusty-common` | Tracing, daemon helpers, OpenRouter chat client, shared utilities |
-| `trusty-embedder` | fastembed wrapper — all-MiniLM-L6-v2 INT8 quantised, 384-dim output |
-| `trusty-mcp-core` | MCP primitives, JSON-RPC 2.0 types, stdio/HTTP transport |
-| `trusty-symgraph` | Symbol graph engine — tree-sitter AST parser + knowledge graph |
-| `trusty-rpc` | RPC helpers and service descriptors |
-| `trusty-tickets` | GitHub Issues integration |
+| `trusty-embedderd` | fastembed wrapper — all-MiniLM-L6-v2 INT8 quantised, 384-dim output |
 | `trusty-gworkspace` | Google Workspace client (Calendar, Tasks, Drive) |
 | `trusty-cto-db` | SQLite schema + rusqlite bindings for ops data |
 | `tc-services` | Service adapters (CTO DB, Granola, GWorkspace) |

--- a/docs/reference/crate-map.md
+++ b/docs/reference/crate-map.md
@@ -48,9 +48,9 @@ Detailed implementation information for each crate lives in its own documentatio
 - **trusty-common** — see `crates/trusty-common/README.md` and `docs/trusty-common/`
 - **trusty-embedderd** — see `crates/trusty-embedderd/README.md` and `docs/trusty-embedderd/` (fastembed sidecar daemon)
 - **trusty-bm25-daemon** — see `crates/trusty-bm25-daemon/README.md` and `docs/trusty-bm25-daemon/` (BM25 index sidecar)
-- **trusty-memory** — see `crates/trusty-memory/README.md` and `docs/trusty-memory/` (licensed MIT, not Elastic-2.0; storage engine lives in `trusty-common`'s `memory-core` feature)
+- **trusty-memory** — see `crates/trusty-memory/README.md` and `docs/trusty-memory/` (storage engine lives in `trusty-common`'s `memory-core` feature)
 - **trusty-search** — see `crates/trusty-search/README.md` and **`docs/trusty-search/`** (primary worked example with regression testing, research, sessions)
-- **trusty-analyze** — see `crates/trusty-analyze/README.md` and `docs/trusty-analyze/` (licensed MIT, not Elastic-2.0)
+- **trusty-analyze** — see `crates/trusty-analyze/README.md` and `docs/trusty-analyze/`
 - **trusty-mpm** — see `crates/trusty-mpm/README.md` and `docs/trusty-mpm/` (unified platform: CLI binaries `tm`/`trusty-mpm`, daemon, MCP server, TUI, Telegram)
 - **trusty-mpm-gui** — see `crates/trusty-mpm-gui/README.md` (Tauri desktop GUI, publish=false)
 - **trusty-agents** — see `crates/trusty-agents/README.md` and `docs/trusty-agents/` (agent orchestration platform, bin: `tagent`)
@@ -59,4 +59,4 @@ Detailed implementation information for each crate lives in its own documentatio
 - **trusty-git-analytics** — see `crates/trusty-git-analytics/README.md` and `docs/trusty-git-analytics/`
 - **trusty-installer** — see `crates/trusty-installer/README.md` and `docs/trusty-installer/` (install/upgrade orchestrator, bins: `trusty-installer` + `tctl` transitional alias; ADR-0013; RFC #920; renamed from `trusty-controller` in #1757)
 
-For license details, check each crate's `Cargo.toml`: most are **Elastic License 2.0**, but `trusty-memory`, `trusty-analyze`, and a few others are **MIT**.
+For license details, check each crate's `Cargo.toml`: all 27 `crates/*` glob members are **MIT**, inherited from the workspace root `[workspace.package]` section via `license.workspace = true`. The nested internal (unpublished) Tauri crate `trusty-agents-ui` (`crates/trusty-agents/ui/src-tauri`) does not declare a license field.


### PR DESCRIPTION
## Summary

This PR fixes two documentation issues in #3276:

1. **README.md**: Remove four phantom crates from the "Shared Libraries" table that no longer exist as separate workspace members:
   - trusty-mcp-core (absorbed into trusty-common)
   - trusty-symgraph (absorbed into trusty-common)
   - trusty-rpc (absorbed into trusty-common)
   - trusty-tickets (absorbed into trusty-common)

2. **docs/reference/crate-map.md**: Correct stale license claims that incorrectly stated the workspace used Elastic License 2.0. The entire workspace is MIT as declared in root `Cargo.toml` and inherited by all crates via `license.workspace = true`.
   - Updated main license statement on line 62
   - Removed outdated "not Elastic-2.0" qualifications from trusty-memory and trusty-analyze references

## Verification

- sld-lint: 0 errors, 0 warnings
- All changes verified against actual workspace structure

Closes #3276

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools