### PR TITLE
fix(trusty-search): deflake anon-RSS-vs-total-RSS non-atomic /proc race

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -9,6 +9,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`core::memguard_enforce::tests::test_anon_rss_for_self_pid_on_linux` deflaked
+  (issue #3762, recurrence of #3716's flake class).** The test compared two
+  genuinely independent, non-atomic `/proc` reads taken microseconds apart
+  (`anon_rss_mb_for_pid` parses `/proc/<pid>/status` directly;
+  `current_rss_mb_for_pid` re-reads via `sysinfo`), so concurrent
+  `cargo test --workspace` allocation churn could transiently make the anon
+  sample larger than the already-stale total sample (observed in CI: "anon RSS
+  (185 MB) must never exceed total RSS (116 MB)", passed on rerun). Mirrors
+  #3716's fix: replaced the strict `anon <= total` bound with a one-directional
+  structural check plus a generous sampling-skew headroom, rather than
+  tightening/loosening an exact-equality bound.
 - **`core::memguard_enforce::tests::enforcement_rss_mb_for_pid_matches_chosen_measure`
   deflaked for good (issue #3716).** Three successive rounds of calibrating a
   "two live RSS samples of the same measure agree" tolerance on this test

--- a/crates/trusty-search/src/core/memguard_enforce.rs
+++ b/crates/trusty-search/src/core/memguard_enforce.rs
@@ -361,11 +361,35 @@ mod tests {
 
     /// On Linux, sampling this test process's own `/proc/self/status` (via
     /// `pid = std::process::id()`) must return a sane, nonzero anon-RSS
-    /// reading that never exceeds the process's TOTAL RSS — anonymous pages
-    /// are a subset of total resident pages by definition.
+    /// reading that never exceeds the process's TOTAL RSS by more than a
+    /// generous sampling-skew headroom — anonymous pages are a subset of
+    /// total resident pages by definition, but the two figures come from two
+    /// genuinely independent `/proc` reads taken microseconds apart
+    /// ([`anon_rss_mb_for_pid`] parses `/proc/<pid>/status`'s `RssAnon`
+    /// directly; [`current_rss_mb_for_pid`] re-reads process state via
+    /// `sysinfo`), so they are not one atomic snapshot.
+    ///
+    /// Why the headroom instead of a strict `anon <= total` bound (issue
+    /// #3762, recurrence of #3716's flake class): this test panicked in CI
+    /// under `cargo test --workspace` load with "anon RSS (185 MB) must never
+    /// exceed total RSS (116 MB)" (run 30040058243 on PR #3750) and passed on
+    /// rerun — concurrent sibling-test allocation between the two
+    /// non-atomic reads pushed `anon`'s snapshot above `total`'s
+    /// already-stale one. This is the same structural class #3716 fixed for
+    /// `enforcement_rss_mb_for_pid_matches_chosen_measure`: comparing two live
+    /// samples of a real process is inherently racy, so the fix is a
+    /// one-directional structural bound with sampling-skew headroom, not a
+    /// two-sided closeness bound and not a tighter/looser exact-inequality
+    /// retry.
     #[test]
     #[cfg(target_os = "linux")]
     fn test_anon_rss_for_self_pid_on_linux() {
+        // Mirrors memguard_enforce's own
+        // `enforcement_rss_mb_for_pid_matches_chosen_measure` (#3716): absorbs
+        // the two readings being taken microseconds apart under concurrent
+        // `cargo test --workspace` churn, not a same-measure agreement bound.
+        const SAMPLING_SKEW_HEADROOM_MB: u64 = 512;
+
         let pid = std::process::id();
         let Some(anon) = anon_rss_mb_for_pid(pid) else {
             // Only plausible if /proc is hidden (unusual container profile);
@@ -378,9 +402,11 @@ mod tests {
         );
         if let Some(total) = current_rss_mb_for_pid(pid) {
             assert!(
-                anon <= total,
-                "anon RSS ({anon} MB) must never exceed total RSS ({total} MB) — anon is a \
-                 subset of total resident pages"
+                anon <= total + SAMPLING_SKEW_HEADROOM_MB,
+                "anon RSS ({anon} MB) exceeded total RSS ({total} MB) by more than the \
+                 {SAMPLING_SKEW_HEADROOM_MB}MB sampling-skew headroom — RssAnon is a subset of \
+                 VmRSS by kernel definition, so a larger gap suggests a real regression rather \
+                 than the two non-atomic /proc reads racing under concurrent test-binary churn"
             );
         }
     }


### PR DESCRIPTION
## Summary
- `test_anon_rss_for_self_pid_on_linux` compared two independently-sampled `/proc` reads taken microseconds apart (`anon_rss_mb_for_pid` parses `/proc/<pid>/status`'s `RssAnon` directly; `current_rss_mb_for_pid` re-samples via a separate `sysinfo` refresh), so concurrent `cargo test --workspace` allocation churn could make the (already-stale) total sample read lower than the anon sample, tripping the strict `anon <= total` assertion (observed in CI: anon 185 MB vs total 116 MB, passed on rerun).
- This is the same non-atomic-read flake class #3716 fixed for the sibling test `enforcement_rss_mb_for_pid_matches_chosen_measure` — same fix applied here: replace the strict two-sided bound with a one-directional structural check (anon RSS is a kernel-defined subset of total `VmRSS`) plus a generous 512 MB sampling-skew headroom, instead of inventing a new tolerance scheme.
- Added a `CHANGELOG.md` entry under `[Unreleased]`.

## Test plan
- [x] `cargo check -p trusty-search` — clean build
- [x] `cargo test -p trusty-search --lib memguard` — all 28 memguard/memguard_enforce tests pass on macOS (Linux-only test correctly filtered out here; non-Linux fallback test passes)
- [x] `cargo fmt --check -p trusty-search` — clean
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean
- [ ] `test_anon_rss_for_self_pid_on_linux` itself is `#[cfg(target_os = "linux")]`-gated and could NOT be exercised on this macOS dev machine — needs to run on Linux CI to confirm the fix in the actual failure path (logic mirrors the shipped #3716/#3729 precedent, and compiles clean under a Linux cfg check via `cargo check`)
- Ran the full `trusty-search` lib suite twice; one unrelated pre-existing flake in `service::server::tests_components` (different test failed each run, passes in isolation) — confirmed unrelated to this change

Closes #3762

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools