### PR TITLE
fix(trusty-search): stop panic on non-char-boundary query-log truncation

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -20,18 +20,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   #3716's fix: replaced the strict `anon <= total` bound with a one-directional
   structural check plus a generous sampling-skew headroom, rather than
   tightening/loosening an exact-equality bound.
-- **Panic on non-char-boundary query-log truncation (issue #3685).** The
-  `search` / `search_lexical` / `search_semantic` / `search_kg` /
-  `search_all` MCP tool handlers and the HTTP `search` endpoint logged the
-  query text truncated with a raw byte-index slice
+- **Panic on non-char-boundary truncation of free-form text in 4 sites
+  (issue #3685).** The `search` / `search_lexical` / `search_semantic` /
+  `search_kg` / `search_all` MCP tool handlers and the HTTP `search` endpoint
+  logged the query text truncated with a raw byte-index slice
   (`&query_text[..query_text.len().min(80)]`), which panics with "byte index
   is not a char boundary" whenever byte 80 lands mid-way through a
   multi-byte UTF-8 character (e.g. an emoji or CJK query), crashing the
-  request instead of just logging it. Replaced with a new
-  `trusty_search::truncate_at_char_boundary` helper that backs off to the
+  request instead of just logging it. `commands::index_status::truncate_reason`
+  had the same bug (`&msg[..79]` on free-form, non-ASCII-guaranteed
+  `JoinError`/embedder failure-reason text). Replaced all four sites with a
+  new `trusty_search::truncate_at_char_boundary` helper that backs off to the
   nearest valid char boundary (mirroring the existing backward-scan pattern
   in `core::extract::extract_text`'s byte-cap truncation), plus regression
-  tests covering an emoji split and a CJK split at the 80-byte boundary.
+  tests covering an emoji split and a CJK split at the query-log 80-byte
+  boundary and a separate emoji split at `truncate_reason`'s 79-byte
+  boundary.
 - **`core::memguard_enforce::tests::enforcement_rss_mb_for_pid_matches_chosen_measure`
   deflaked for good (issue #3716).** Three successive rounds of calibrating a
   "two live RSS samples of the same measure agree" tolerance on this test

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -20,6 +20,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   #3716's fix: replaced the strict `anon <= total` bound with a one-directional
   structural check plus a generous sampling-skew headroom, rather than
   tightening/loosening an exact-equality bound.
+- **Panic on non-char-boundary query-log truncation (issue #3685).** The
+  `search` / `search_lexical` / `search_semantic` / `search_kg` /
+  `search_all` MCP tool handlers and the HTTP `search` endpoint logged the
+  query text truncated with a raw byte-index slice
+  (`&query_text[..query_text.len().min(80)]`), which panics with "byte index
+  is not a char boundary" whenever byte 80 lands mid-way through a
+  multi-byte UTF-8 character (e.g. an emoji or CJK query), crashing the
+  request instead of just logging it. Replaced with a new
+  `trusty_search::truncate_at_char_boundary` helper that backs off to the
+  nearest valid char boundary (mirroring the existing backward-scan pattern
+  in `core::extract::extract_text`'s byte-cap truncation), plus regression
+  tests covering an emoji split and a CJK split at the 80-byte boundary.
 - **`core::memguard_enforce::tests::enforcement_rss_mb_for_pid_matches_chosen_measure`
   deflaked for good (issue #3716).** Three successive rounds of calibrating a
   "two live RSS samples of the same measure agree" tolerance on this test

--- a/crates/trusty-search/src/commands/index_status.rs
+++ b/crates/trusty-search/src/commands/index_status.rs
@@ -310,15 +310,22 @@ fn print_status_line_nontty(index_id: &str, body: &serde_json::Value) {
 
 /// Truncate a failure-reason string to at most 80 display characters.
 ///
-/// Why: raw failure reasons can be multi-kilobyte stack traces; rendering them
-/// verbatim breaks the terminal table layout.
-/// What: if `msg` exceeds 80 chars, returns the first 79 chars followed by `…`
-/// (Unicode ellipsis, one column wide), giving exactly 80 displayed columns.
-/// If `msg` fits, returns it unchanged as an owned `String`.
-/// Test: `failure_message_truncated_at_80_chars` in this module's tests.
+/// Why: raw failure reasons can be multi-kilobyte stack traces sourced from
+/// `JoinError`/embedder error text — not guaranteed ASCII — so rendering them
+/// verbatim breaks the terminal table layout, and a raw byte-index slice at
+/// byte 79 can land mid-multibyte-char and panic (the same class of bug as
+/// issue #3685's query-log truncation).
+/// What: if `msg` exceeds 80 bytes, returns the longest prefix that fits in
+/// 79 bytes without splitting a UTF-8 character (via
+/// [`trusty_search::truncate_at_char_boundary`]) followed by `…` (Unicode ellipsis,
+/// one column wide). If `msg` fits, returns it unchanged as an owned
+/// `String`.
+/// Test: `failure_message_truncated_at_80_chars` and
+/// `failure_message_truncation_handles_multibyte_split_at_79` in this
+/// module's tests.
 pub fn truncate_reason(msg: &str) -> String {
     if msg.len() > 80 {
-        format!("{}…", &msg[..79])
+        format!("{}…", trusty_search::truncate_at_char_boundary(msg, 79))
     } else {
         msg.to_string()
     }
@@ -469,6 +476,44 @@ mod tests {
         let exact_msg = "y".repeat(80);
         let result = truncate_reason(&exact_msg);
         assert_eq!(result, exact_msg, "80-char messages must not be truncated");
+    }
+
+    /// Regression test for the code-critic-flagged extension of issue #3685:
+    /// `truncate_reason` previously cut with a raw `&msg[..79]` byte slice,
+    /// the same panic class as the query-log truncation sites — failure
+    /// reasons are free-form (JoinError/embedder error text), not guaranteed
+    /// ASCII. This constructs a message whose byte 79 lands mid-way through
+    /// a 4-byte emoji, so a naive `[..79]` cut is guaranteed to split it and
+    /// panic with "byte index is not a char boundary".
+    #[test]
+    fn failure_message_truncation_handles_multibyte_split_at_79() {
+        // 78 ASCII bytes + a 4-byte emoji (🔥, U+1F525) puts the emoji's
+        // start at byte 78 and its end at byte 82 — byte index 79 sits
+        // squarely inside the emoji's UTF-8 encoding.
+        let msg = format!(
+            "{}{}",
+            "a".repeat(78),
+            "🔥 more failure text to push this past eighty bytes total"
+        );
+        assert_eq!(
+            msg.as_bytes()[79].leading_ones(),
+            1,
+            "sanity: byte 79 must be a UTF-8 continuation byte, not a boundary"
+        );
+        assert!(
+            msg.len() > 80,
+            "sanity: message must exceed the truncation threshold"
+        );
+
+        // Old behavior `format!("{}…", &msg[..79])` would panic here.
+        let truncated = truncate_reason(&msg);
+
+        assert!(truncated.ends_with('…'), "must end with ellipsis character");
+        assert_eq!(
+            truncated,
+            format!("{}…", "a".repeat(78)),
+            "must back off to the boundary before the split emoji"
+        );
     }
 
     /// `--watch` combined with `--json` must be rejected before any daemon

--- a/crates/trusty-search/src/core/extract/mod.rs
+++ b/crates/trusty-search/src/core/extract/mod.rs
@@ -176,10 +176,7 @@ pub fn extract_text(path: &Path) -> Result<Extracted, ExtractError> {
     };
 
     if extracted.text.len() > MAX_EXTRACTED_TEXT_BYTES {
-        let mut cut = MAX_EXTRACTED_TEXT_BYTES;
-        while cut > 0 && !extracted.text.is_char_boundary(cut) {
-            cut -= 1;
-        }
+        let cut = crate::truncate_at_char_boundary(&extracted.text, MAX_EXTRACTED_TEXT_BYTES).len();
         extracted.text.truncate(cut);
     }
 

--- a/crates/trusty-search/src/lib.rs
+++ b/crates/trusty-search/src/lib.rs
@@ -34,8 +34,100 @@ pub fn worker_thread_count(cpu_count: usize) -> usize {
     std::cmp::max(cpu_count, 16)
 }
 
+/// Truncate `s` to at most `max_bytes` bytes without splitting a multi-byte
+/// UTF-8 character.
+///
+/// Why (issue #3685): the query-log truncation sites used `&s[..n.min(80)]`,
+/// a raw byte-index slice. When byte 80 landed inside a multi-byte character
+/// (e.g. an emoji or CJK query), that slice panicked with "byte index is not
+/// a char boundary" and crashed the search request instead of just logging
+/// it.
+/// What: walks backward from `max_bytes` to the nearest char boundary (the
+/// same backward-scan pattern already used in
+/// `core::extract::extract_text`'s byte-cap truncation) and returns that
+/// prefix. Returns `s` unchanged when it already fits within `max_bytes`
+/// bytes.
+/// Test: `truncate_at_char_boundary_*` in this module — covers an ASCII
+/// string under/over the limit and a multibyte string whose raw byte 80 (or
+/// other cap) falls mid-character.
+pub fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut idx = max_bytes;
+    while idx > 0 && !s.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    &s[..idx]
+}
+
 // Regression tests for persistence data-integrity fixes (#1088, #1089, #1090).
 // Extracted from persistence.rs to keep that file under its line-cap budget.
 #[cfg(test)]
 #[path = "service/persistence_tests_1088.rs"]
 mod persistence_tests_1088;
+
+#[cfg(test)]
+mod truncate_at_char_boundary_tests {
+    use super::truncate_at_char_boundary;
+
+    /// Regression test for issue #3685: a query string whose 80th byte lands
+    /// mid-way through a multibyte emoji used to panic with the old
+    /// `&s[..80]` byte-slice truncation. This constructs a string that is
+    /// exactly 80 bytes long up through the middle of a 4-byte emoji, so a
+    /// naive `[..80]` cut is guaranteed to split it.
+    #[test]
+    fn truncate_at_char_boundary_handles_multibyte_split() {
+        // 79 ASCII bytes + a 4-byte emoji (🔥, U+1F525) pushes the emoji's
+        // start to byte 79 and its end to byte 83 — byte index 80 sits
+        // squarely inside the emoji's UTF-8 encoding.
+        let s = format!("{}{}", "a".repeat(79), "🔥 rest of the query text");
+        assert_eq!(
+            s.as_bytes()[80].leading_ones(),
+            1,
+            "sanity: byte 80 must be a UTF-8 continuation byte, not a boundary"
+        );
+
+        // Old behavior `&s[..s.len().min(80)]` would panic here.
+        let truncated = truncate_at_char_boundary(&s, 80);
+
+        assert!(s.is_char_boundary(truncated.len()));
+        assert!(truncated.len() <= 80);
+        assert_eq!(
+            truncated,
+            &s[..79],
+            "must back off to the boundary before the split emoji"
+        );
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_leaves_short_ascii_unchanged() {
+        let s = "short query";
+        assert_eq!(truncate_at_char_boundary(s, 80), s);
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_cuts_long_ascii_at_exactly_max() {
+        let s = "x".repeat(200);
+        let truncated = truncate_at_char_boundary(&s, 80);
+        assert_eq!(truncated.len(), 80);
+        assert_eq!(truncated, &s[..80]);
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_handles_cjk_at_limit() {
+        // Each CJK character below is 3 bytes in UTF-8; 27 repeats = 81 bytes,
+        // so the 80-byte cap lands mid-character (80 is not a multiple of 3).
+        let s = "検".repeat(27);
+        assert_eq!(s.len(), 81);
+
+        let truncated = truncate_at_char_boundary(&s, 80);
+
+        assert!(s.is_char_boundary(truncated.len()));
+        assert_eq!(
+            truncated,
+            &s[..78],
+            "must back off to the last full 3-byte char before byte 80"
+        );
+    }
+}

--- a/crates/trusty-search/src/mcp/tools/search.rs
+++ b/crates/trusty-search/src/mcp/tools/search.rs
@@ -173,7 +173,7 @@ pub(super) async fn dispatch_search_tool(
                 intent = %log_intent,
                 latency_ms = log_latency,
                 results = log_results,
-                query = %&query_text[..query_text.len().min(80)],
+                query = %crate::truncate_at_char_boundary(query_text, 80),
                 "search"
             );
             Some(Ok(resp))
@@ -356,7 +356,7 @@ impl McpServer {
             intent = %log_intent,
             latency_ms = log_latency,
             results = log_results,
-            query = %&query_text[..query_text.len().min(80)],
+            query = %crate::truncate_at_char_boundary(query_text, 80),
             "search"
         );
         Ok(resp)

--- a/crates/trusty-search/src/service/server/search.rs
+++ b/crates/trusty-search/src/service/server/search.rs
@@ -356,7 +356,7 @@ pub(super) async fn search_handler(
         intent = %format!("{intent:?}"),
         latency_ms = latency_ms,
         results = results.len(),
-        query = %&query.text[..query.text.len().min(80)],
+        query = %crate::truncate_at_char_boundary(&query.text, 80),
         "search"
     );
 


### PR DESCRIPTION
## Summary
- The `search` / `search_lexical` / `search_semantic` / `search_kg` / `search_all` MCP tool handlers (`mcp/tools/search.rs:176,359`) and the HTTP `search` endpoint (`service/server/search.rs:359`) logged the query text truncated with a raw byte-index slice `&s[..s.len().min(80)]`, which panics with "byte index is not a char boundary" whenever byte 80 lands mid-way through a multi-byte UTF-8 character — an emoji or CJK query would crash the request instead of just being logged.
- Adds `trusty_search::truncate_at_char_boundary(s, max_bytes)` in `lib.rs`, which backs off to the nearest valid char boundary (mirroring the existing backward-scan pattern already used in `core::extract::extract_text`'s byte-cap truncation), and swaps it in at all three truncation sites.
- Adds regression tests (`truncate_at_char_boundary_tests` in `lib.rs`) covering an emoji-split and a CJK-split string exactly at the 80-byte boundary — both panicked under the old `&s[..80]` slice and pass now.
- CHANGELOG entry added under `[Unreleased]`.

Closes #3685

## Test plan
- [x] `cargo test -p trusty-search` — 1297 passed, 0 failed (workspace binary target run separately: 314 passed, 0 failed)
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-search` — clean
- [x] New tests reproduce the pre-fix panic (verified failing against the old byte-slice logic before the fix, now passing)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools