### PR TITLE
fix(trusty-common): enforce room_filter in retrieve_l2 instead of silently dropping it

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **`room_filter` silent no-op in `retrieve_l2`** (#3274): a caller-supplied
+  `room_filter` was accepted but never applied — an empty if-body silently
+  dropped it, so results always included every room regardless of the
+  filter. Now enforced: `drawer.room_id` is compared against
+  `room_to_uuid(&filter)`, the same deterministic hash `list_drawers` already
+  uses to filter by room (no real Room table is wired yet, but the mapping
+  was already available at this call site).
+
 ---
 ## [0.26.0] — 2026-07-23
 

--- a/crates/trusty-common/src/memory_core/retrieval/layers.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/layers.rs
@@ -8,7 +8,8 @@
 //! `recall_across_palaces`, `recall_across_palaces_with_default_embedder`,
 //! `room_to_uuid`, `uuid_prefix_eq`, `dedup_extend`.
 //! Test: `recall_ranks_by_similarity_over_importance`, `l0_l1_always_present`,
-//! `l2_returns_relevant_drawer`, `recall_across_palaces_merges_results`.
+//! `l2_returns_relevant_drawer`, `l2_room_filter_excludes_other_rooms`,
+//! `recall_across_palaces_merges_results`.
 
 use super::embedder::shared_embedder;
 use super::handle::PalaceHandle;
@@ -166,11 +167,15 @@ pub fn rescore_l1_by_similarity(
 /// known.
 /// What: Embeds the query, searches the vector store with `top_k * 3` to
 /// leave room for filtering, maps each hit back to a drawer via UUID-prefix
-/// match, applies the optional room filter (currently a TODO — see below),
+/// match, applies the optional room filter by comparing `drawer.room_id`
+/// against `room_to_uuid(&filter)` (issue #3274 — the same deterministic
+/// hash `list_drawers` already uses, since there is no real Room table yet),
 /// scores as `drawer.importance * hit.score`, and returns the top `top_k`
 /// drawers tagged with `layer: 2`.
 /// Test: `l2_returns_relevant_drawer` upserts a Rust-themed drawer and
 /// asserts a Rust-themed query retrieves it at rank 0.
+/// `l2_room_filter_excludes_other_rooms` (issue #3274) asserts a drawer from
+/// a non-matching room is dropped rather than silently included.
 pub async fn retrieve_l2(
     handle: &PalaceHandle,
     embedder: &dyn Embedder,
@@ -194,6 +199,15 @@ pub async fn retrieve_l2(
     let query_tokens: Vec<String> = extract_keywords(query);
     let mut results: Vec<RecallResult> = Vec::with_capacity(hits.len());
 
+    // Issue #3274: this used to be a silent no-op (empty if-body) — a
+    // caller-supplied `room_filter` was accepted but never applied, so
+    // results silently included every room. There is no real Room table yet,
+    // but `room_to_uuid` deterministically hashes a `RoomType` into the
+    // `Uuid` stamped on `Drawer::room_id` at creation time (see
+    // `PalaceHandle::upsert`), which is the exact mechanism `list_drawers`
+    // already uses to filter by room — so the filter IS enforceable now.
+    let target_room_id = room_filter.as_ref().map(room_to_uuid);
+
     for hit in hits {
         let Some(drawer) = drawers.iter().find(|d| uuid_prefix_eq(d.id, hit.drawer_id)) else {
             // Vector hit refers to a drawer we no longer have metadata for;
@@ -201,11 +215,10 @@ pub async fn retrieve_l2(
             continue;
         };
 
-        // TODO(room-filter): RoomType lives on Room, not Drawer. Once a Room
-        // table is wired into PalaceHandle (drawer.room_id -> RoomType), apply
-        // the filter here. For now, accept all drawers regardless of filter.
-        if room_filter.is_some() {
-            // Filter is acknowledged but not yet enforceable — see TODO above.
+        if let Some(rid) = target_room_id
+            && drawer.room_id != rid
+        {
+            continue;
         }
 
         let age_days = DecayConfig::age_days(drawer.created_at);

--- a/crates/trusty-common/src/memory_core/retrieval/tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/tests.rs
@@ -86,6 +86,73 @@ async fn l2_returns_relevant_drawer() {
     assert_eq!(results[0].layer, 2);
 }
 
+/// Why: Issue #3274 — `room_filter` used to be a silent no-op (an empty
+/// if-body in `retrieve_l2`), so a caller asking for one room's drawers
+/// silently got every room back. Asserts the filter is now enforced.
+/// What: Upserts two semantically-similar drawers stamped into different
+/// rooms (via `room_to_uuid`, the same deterministic hash `list_drawers`
+/// uses), queries with `room_filter` set to only one of them, and asserts
+/// the non-matching drawer never appears in the results while the matching
+/// one does.
+/// Test: This test itself.
+#[tokio::test]
+async fn l2_room_filter_excludes_other_rooms() {
+    init_embedder();
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let embedder = shared_embedder().await.unwrap();
+
+    let backend_room_id = super::layers::room_to_uuid(&RoomType::Backend);
+    let frontend_room_id = super::layers::room_to_uuid(&RoomType::Frontend);
+
+    let backend_drawer = Drawer::new(backend_room_id, "Rust is a systems programming language");
+    let backend_id = backend_drawer.id;
+    let frontend_drawer = Drawer::new(frontend_room_id, "Rust is a systems programming toolkit");
+    let frontend_id = frontend_drawer.id;
+
+    for d in [&backend_drawer, &frontend_drawer] {
+        let vecs = embedder
+            .embed_batch(std::slice::from_ref(&d.content))
+            .await
+            .unwrap();
+        handle
+            .vector_store
+            .upsert(d.id, vecs[0].clone())
+            .await
+            .unwrap();
+    }
+    handle.add_drawer(backend_drawer);
+    handle.add_drawer(frontend_drawer);
+
+    let results = retrieve_l2(
+        &handle,
+        embedder.as_ref(),
+        "systems programming Rust",
+        Some(RoomType::Backend),
+        5,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "L2 should return the matching-room drawer"
+    );
+    assert!(
+        results
+            .iter()
+            .all(|r| uuid_prefix_eq(r.drawer.id, backend_id)),
+        "room_filter must exclude drawers from other rooms, got: {:?}",
+        results.iter().map(|r| r.drawer.id).collect::<Vec<_>>()
+    );
+    assert!(
+        !results
+            .iter()
+            .any(|r| uuid_prefix_eq(r.drawer.id, frontend_id)),
+        "Frontend-room drawer leaked through a Backend room_filter"
+    );
+}
+
 /// Why: End-to-end confirmation that `remember` + `recall` round-trip
 /// through the embedder and vector store correctly.
 /// What: Build a palace handle backed by a tempdir, remember three


### PR DESCRIPTION
## Summary

- `retrieve_l2` (`crates/trusty-common/src/memory_core/retrieval/layers.rs:207-209`) had an empty `if room_filter.is_some() { }` body — the filter was accepted but never applied, silently returning drawers from every room regardless of the caller's `room_filter`. This is a silent correctness bug per #3274.
- **Option chosen: enforce the filter now** (not warn/error) — enforcing it turned out to be trivially possible at this call site. `PalaceHandle::upsert` already stamps each `Drawer.room_id` deterministically via `room_to_uuid(&RoomType)` (`handle.rs:494`), and `list_drawers` already filters using that exact same hash (`handle.rs:758-762`). `retrieve_l2` just wasn't wired to use it.
- Computes `target_room_id = room_filter.map(room_to_uuid)` once per call and skips any drawer whose `room_id` doesn't match — mirroring `list_drawers`'s existing enforcement mechanism.

## Test plan

- [x] Added `l2_room_filter_excludes_other_rooms` (`retrieval/tests.rs`): upserts a `Backend`-room drawer and a semantically-similar `Frontend`-room drawer, queries with `room_filter: Some(RoomType::Backend)`, asserts the Frontend drawer never appears and the Backend drawer does — i.e. the filter is enforced, not silently dropped.
- [x] `cargo test -p trusty-common --features memory-core` → `583 passed; 0 failed; 13 ignored`
- [x] `cargo clippy -p trusty-common --features memory-core --all-targets -- -D warnings` → clean
- [x] `cargo fmt --check -p trusty-common` → clean
- [x] Progress comment posted on #3274 with root cause + chosen option
- [x] `CHANGELOG.md` entry added under `[Unreleased]`

Closes #3274

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools