### PR TITLE
fix(trusty-search): eliminate doctor_data_dir_returns_non_empty_path flake at the source

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -33,6 +33,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   still counts as degraded) instead of remaining frozen at its boot-time
   value forever. No embedder-concurrency or worker-pool changes (tracked
   separately as slice B).
+- **`doctor_data_dir_returns_non_empty_path` deflaked at the source (issue
+  #3697).** An audit confirmed every `TRUSTY_DATA_DIR` mutation site in the
+  `--bin trusty-search` test binary already carried the crate's `#[serial]`
+  convention (from #3673/#3686), so the flake persisted for a different
+  reason: the test itself still read/wrote the shared process env var.
+  Split `doctor_data_dir()` into a pure, parameter-injectable
+  `doctor_data_dir_from(Option<String>)` core (mirrors the
+  `SearchAppState::with_registry_path` fix for the same flake class, issue
+  #2717) and pointed the test at it directly — it no longer touches process
+  env at all, so it can't race any sibling test regardless of tagging.
 - **`core::memguard_enforce::tests::test_anon_rss_for_self_pid_on_linux` deflaked
   (issue #3762, recurrence of #3716's flake class).** The test compared two
   genuinely independent, non-atomic `/proc` reads taken microseconds apart

--- a/crates/trusty-search/src/commands/doctor_checks/mod.rs
+++ b/crates/trusty-search/src/commands/doctor_checks/mod.rs
@@ -146,8 +146,11 @@ pub fn check_model_cache() -> CheckResult {
 /// running daemon when an isolated data dir is active (issue #281).
 /// What: returns `$TRUSTY_DATA_DIR` when set, otherwise the platform-default
 /// `<data_local_dir>/trusty-search`.
-/// Test: set `TRUSTY_DATA_DIR=/tmp/ts-x`; assert `doctor_data_dir()` returns
-/// `PathBuf::from("/tmp/ts-x")`.
+/// Test: `doctor_data_dir_reads_env_var` covers this wrapper's env-reading
+/// half end-to-end (`#[serial]`, sets `TRUSTY_DATA_DIR` and asserts the
+/// wrapper returns it); the pure core's branches are covered without env
+/// access by `doctor_data_dir_returns_non_empty_path` (unset/fallback) and
+/// `doctor_data_dir_from_honors_explicit_override` (override).
 pub fn doctor_data_dir() -> std::path::PathBuf {
     doctor_data_dir_from(std::env::var("TRUSTY_DATA_DIR").ok())
 }

--- a/crates/trusty-search/src/commands/doctor_checks/mod.rs
+++ b/crates/trusty-search/src/commands/doctor_checks/mod.rs
@@ -149,7 +149,35 @@ pub fn check_model_cache() -> CheckResult {
 /// Test: set `TRUSTY_DATA_DIR=/tmp/ts-x`; assert `doctor_data_dir()` returns
 /// `PathBuf::from("/tmp/ts-x")`.
 pub fn doctor_data_dir() -> std::path::PathBuf {
-    if let Ok(dir) = std::env::var("TRUSTY_DATA_DIR") {
+    doctor_data_dir_from(std::env::var("TRUSTY_DATA_DIR").ok())
+}
+
+/// Pure core of [`doctor_data_dir`] — takes the `TRUSTY_DATA_DIR` value as a
+/// parameter instead of reading the process-global env var directly.
+///
+/// Why (issue #3697): `doctor_data_dir()`'s own test previously had to
+/// `remove_var`/`set_var` the shared `TRUSTY_DATA_DIR` process env var and
+/// rely on `#[serial]` for mutual exclusion against the 40+ other tests in
+/// this test binary that also mutate it. Every such call site already
+/// carries the crate's bare `#[serial]` tag (audited across
+/// `commands/migrate_storage/*`, `commands/start/tests.rs`,
+/// `commands/daemon_utils.rs`, `service/data_dir.rs`,
+/// `service/daemon_tests.rs`, `service/server/*_tests.rs`,
+/// `service/reindex/root_hijack_tests.rs`, and
+/// `service/warm_boot/warm_boot_tests.rs`), so the logical race the
+/// `#3673`/`#3686` fix targeted is already closed — yet PR #3690's gate still
+/// observed a rare failure. Splitting out this parameter-injectable core
+/// (mirroring the `SearchAppState::with_registry_path` fix for the same
+/// class of flake in `service/server/list_repo_identity_tests.rs`, issue
+/// #2717) removes the test's dependency on process env entirely, so it can
+/// no longer race ANY other test regardless of `#[serial]` coverage.
+/// What: mirrors the `TRUSTY_DATA_DIR`-set / unset branches of
+/// `doctor_data_dir()` exactly, but reads the value from `data_dir_env`
+/// rather than `std::env::var`.
+/// Test: `doctor_data_dir_returns_non_empty_path` (passes `None` to
+/// deterministically exercise the platform-default fallback branch).
+fn doctor_data_dir_from(data_dir_env: Option<String>) -> std::path::PathBuf {
+    if let Some(dir) = data_dir_env {
         return std::path::PathBuf::from(dir);
     }
     dirs::data_local_dir()

--- a/crates/trusty-search/src/commands/doctor_checks/tests.rs
+++ b/crates/trusty-search/src/commands/doctor_checks/tests.rs
@@ -188,34 +188,44 @@ fn read_daemon_port_returns_some_u16() {
     let _ = p;
 }
 
-/// #3673: `doctor_data_dir()` reads the process-global `TRUSTY_DATA_DIR` env
-/// var, which 40+ other tests across this test binary also mutate (e.g.
-/// `service/data_dir.rs`, `commands/start/tests.rs`). Without `#[serial]`
-/// this test can observe a sibling test's tempdir value mid-flight and fail
-/// an assertion that has nothing to do with this test's own behaviour.
+/// Issue #3697: this test previously cleared the process-global
+/// `TRUSTY_DATA_DIR` env var under `#[serial]` and called `doctor_data_dir()`
+/// directly (the #3673/#3686 fix). An audit for #3697 confirmed every other
+/// `TRUSTY_DATA_DIR`-mutating test in this ~314-test binary already carries
+/// the same bare `#[serial]` tag (`commands/migrate_storage/*`,
+/// `commands/start/tests.rs`, `commands/daemon_utils.rs`,
+/// `service/data_dir.rs`, `service/daemon_tests.rs`,
+/// `service/server/*_tests.rs`, `service/reindex/root_hijack_tests.rs`,
+/// `service/warm_boot/warm_boot_tests.rs`) — so that logical race was
+/// already closed, yet PR #3690's gate still saw a rare failure. Rather than
+/// re-serialize around an already-fully-serialized set of call sites, this
+/// test now calls the parameter-injectable `doctor_data_dir_from(None)` core
+/// directly (mirrors the `SearchAppState::with_registry_path` fix for the
+/// same flake class in `service/server/list_repo_identity_tests.rs`, issue
+/// #2717): it never touches process env, so it cannot race any other test
+/// regardless of that test's own `#[serial]` coverage. `#[serial]` is kept
+/// for defense-in-depth in case a future edit reintroduces env access here.
 ///
-/// Why: `#[serial]` (bare — the crate-wide default lock, matching the
-/// convention in `service/data_dir.rs`'s `data_dir_override_yields_absolute_path`
-/// and `commands/daemon_utils.rs`) serializes this test against every other
-/// `TRUSTY_DATA_DIR`-mutating test in the crate. We additionally clear
-/// `TRUSTY_DATA_DIR` ourselves (rather than merely hoping no sibling left it
-/// set) so the assertion always exercises the platform-default fallback path
-/// — the one that actually contains `"trusty-search"` — deterministically,
-/// and restore whatever was there beforehand so we don't pollute later tests.
-/// What: clear `TRUSTY_DATA_DIR` under the lock, call `doctor_data_dir()`,
-/// assert the default fallback path contains `"trusty-search"`, restore.
+/// Why: eliminate the flake class at its source instead of serializing
+/// around it.
+/// What: call `doctor_data_dir_from(None)` (the unset branch), assert the
+/// platform-default fallback path contains `"trusty-search"`.
 /// Test: `doctor_data_dir_returns_non_empty_path`.
 #[test]
 #[serial]
 fn doctor_data_dir_returns_non_empty_path() {
-    let prev = std::env::var("TRUSTY_DATA_DIR").ok();
-    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
-    let p = doctor_data_dir();
-    match prev {
-        Some(v) => unsafe { std::env::set_var("TRUSTY_DATA_DIR", v) },
-        None => unsafe { std::env::remove_var("TRUSTY_DATA_DIR") },
-    }
+    let p = doctor_data_dir_from(None);
     assert!(p.to_string_lossy().contains("trusty-search"));
+}
+
+/// Companion to `doctor_data_dir_returns_non_empty_path`: the `Some` branch
+/// of `doctor_data_dir_from` (mirrors `doctor_data_dir()`'s
+/// `TRUSTY_DATA_DIR`-set path) returns the override verbatim, with no env
+/// access at all.
+#[test]
+fn doctor_data_dir_from_honors_explicit_override() {
+    let p = doctor_data_dir_from(Some("/tmp/ts-x".to_string()));
+    assert_eq!(p, std::path::PathBuf::from("/tmp/ts-x"));
 }
 
 #[test]

--- a/crates/trusty-search/src/commands/doctor_checks/tests.rs
+++ b/crates/trusty-search/src/commands/doctor_checks/tests.rs
@@ -228,6 +228,27 @@ fn doctor_data_dir_from_honors_explicit_override() {
     assert_eq!(p, std::path::PathBuf::from("/tmp/ts-x"));
 }
 
+/// Coverage for the PUBLIC `doctor_data_dir()` wrapper's env-reading half —
+/// the exact contract this PR (#3697) exists to protect. The two tests above
+/// exercise the pure `doctor_data_dir_from` core without touching process
+/// env, so this is the one test that must actually read `TRUSTY_DATA_DIR`:
+/// it is therefore the only `#[serial]` / env-mutating test in this file.
+/// `EnvVarGuard` save/restores the var so no sibling test is polluted, and
+/// `#[serial]` excludes it from the crate's other `TRUSTY_DATA_DIR` mutators.
+///
+/// Why: without this, the wrapper's `std::env::var("TRUSTY_DATA_DIR")` branch
+/// had zero coverage after the core was split out.
+/// What: set `TRUSTY_DATA_DIR=/tmp/ts-wrapper`, call `doctor_data_dir()`,
+/// assert it returns that path verbatim.
+/// Test: `doctor_data_dir_reads_env_var`.
+#[test]
+#[serial]
+fn doctor_data_dir_reads_env_var() {
+    let _g = EnvVarGuard::set("TRUSTY_DATA_DIR", "/tmp/ts-wrapper");
+    let p = doctor_data_dir();
+    assert_eq!(p, std::path::PathBuf::from("/tmp/ts-wrapper"));
+}
+
 #[test]
 fn fastembed_cache_dir_respects_env_override() {
     // Set a unique override value and assert the function returns exactly it.


### PR DESCRIPTION
## Summary

- Audited every `std::env::set_var("TRUSTY_DATA_DIR", ...)` / `remove_var("TRUSTY_DATA_DIR")` call site reachable from the `--bin trusty-search` test binary — all already carry the crate's `#[serial]` convention from #3673/#3686, so that logical race was already closed.
- Split `doctor_data_dir()` into a pure, parameter-injectable `doctor_data_dir_from(Option<String>) -> PathBuf` core plus a thin env-reading wrapper (mirrors the `SearchAppState::with_registry_path` fix for the identical flake class in `service/server/list_repo_identity_tests.rs`, issue #2717).
- `doctor_data_dir_returns_non_empty_path` now calls `doctor_data_dir_from(None)` directly — no process-env access at all, so it can no longer race any sibling test regardless of `#[serial]` coverage. Added a companion test for the `Some` (override) branch.

Closes #3697

## Root cause

`doctor_data_dir_returns_non_empty_path` flaked in PR #3690's gate run even though its base commit already included #3686's `#[serial]` fix. A full audit (per the issue's suggested-fix #1) across `commands/migrate_storage/{migrate,classify,handler_tests}.rs`, `commands/start/tests.rs`, `commands/daemon_utils.rs`, `service/data_dir.rs`, `service/persistence_tests.rs`, `service/daemon_tests.rs`, `service/server/{residency_sweep,tests_index_config,tests_components}.rs`, `service/reindex/root_hijack_tests.rs`, and `service/warm_boot/warm_boot_tests.rs` found every `TRUSTY_DATA_DIR` mutation site already tagged with the same bare `#[serial]` group — so re-serializing an already-fully-serialized set of call sites would add nothing. Went with the issue's suggested-fix #3 instead: remove this test's dependency on process-global env entirely.

## Test plan

- [x] `cargo test -p trusty-search --bin trusty-search doctor_data_dir` — both tests pass
- [x] `cargo test -p trusty-search --bin trusty-search -- --test-threads=32` x2 — 315 passed, 0 failed
- [x] `cargo test -p trusty-search` (full surface: lib + bin + all integration test binaries) — 1293 lib + 315 bin + integration tests, 0 failed
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-search` — clean

Note for the merge queue: `crates/trusty-search/CHANGELOG.md` may conflict with `fix-3689-env-race-tests` / recently-merged #3775 (both touch the same `[Unreleased]` section) — the bullet added here is minimal and self-contained per prior guidance.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools