### PR TITLE
fix(test): eliminate 3 env/global-state-mutation-race flaky tests (#3689)

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -16,6 +16,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `room_to_uuid(&filter)`, the same deterministic hash `list_drawers` already
   uses to filter by room (no real Room table is wired yet, but the mapping
   was already available at this call site).
+- **`update::tests::cache_fresh_returns_some_when_newer` deflaked (issue
+  #3689).** `check_throttled_skips_when_no_update_check_set` /
+  `check_throttled_skips_when_ci_set` mutate `NO_UPDATE_CHECK_ENV`/`CI_ENV`
+  for the duration of their own `check_throttled(...).await` (deliberately
+  outliving the brief `ENV_LOCK` critical sections around the set/remove
+  calls), so a concurrently-scheduled `cache_fresh_returns_some_when_newer`
+  could observe the stray var and flip an expected `Some` to `None`. All
+  three tests now share `#[serial(update_check_throttled_env)]`, matching
+  the crate's existing named-group convention (#3608/#3629).
 
 ---
 ## [0.26.0] — 2026-07-23

--- a/crates/trusty-common/src/update/tests.rs
+++ b/crates/trusty-common/src/update/tests.rs
@@ -95,7 +95,26 @@ fn notice_formats_correctly() {
 
 // ── opt-out env var ────────────────────────────────────────────────────
 
+// Issue #3689: `check_throttled_skips_when_no_update_check_set` and
+// `check_throttled_skips_when_ci_set` mutate the process-global
+// `NO_UPDATE_CHECK_ENV`/`CI_ENV` vars for the DURATION of their own
+// `check_throttled(...).await` call (the env is set, THEN awaited, THEN
+// cleared — the mutation deliberately outlives the brief `ENV_LOCK` critical
+// sections around the set/remove calls, since `check_throttled` itself must
+// observe the var). `cache_fresh_returns_some_when_newer` also calls
+// `check_throttled` (via `run_cache_freshness_test`) without expecting either
+// var to be set; without `#[serial]` these two tests can race a THIRD,
+// concurrently-scheduled `check_throttled` call and have it observe a
+// spuriously-set `CI_ENV`/`NO_UPDATE_CHECK_ENV`, turning an expected
+// `Some(..)` into `None` (flaked under parallel `cargo test`: "expected
+// Some, got None"). `#[serial(update_check_throttled_env)]` (the crate's
+// existing named-group convention — see
+// `verify_installed_binary_finds_binary_via_path`'s
+// `update_verify_installed_binary_env`, #3608/#3629) gives the three
+// `check_throttled` callers mutual exclusion for their whole async body,
+// including the `.await`, which a bare `std::sync::Mutex` guard cannot span.
 #[tokio::test]
+#[serial(update_check_throttled_env)]
 async fn check_throttled_skips_when_no_update_check_set() {
     // Set the env var while holding the lock, then drop the lock before
     // the await so clippy::await-holding-lock is satisfied.
@@ -117,6 +136,7 @@ async fn check_throttled_skips_when_no_update_check_set() {
 }
 
 #[tokio::test]
+#[serial(update_check_throttled_env)]
 async fn check_throttled_skips_when_ci_set() {
     {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -170,7 +190,14 @@ async fn run_cache_freshness_test(
     let _ = std::fs::remove_file(cache_path(&unique_crate));
 }
 
+// Issue #3689: shares `update_check_throttled_env` with the two
+// `check_throttled_skips_when_*` tests above — see the doc comment there.
+// This test's own `check_throttled` call expects a live (non-throttled)
+// result (`Some`), so a sibling test's transient `CI_ENV`/
+// `NO_UPDATE_CHECK_ENV` mutation racing this `.await` was observed flipping
+// it to `None` under parallel `cargo test`.
 #[tokio::test]
+#[serial(update_check_throttled_env)]
 async fn cache_fresh_returns_some_when_newer() {
     // Cache written 1 h ago (well within 24 h) with a newer version.
     run_cache_freshness_test(now_unix_secs() - 3600, "1.0.0", "0.19.0", true).await;

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -43,6 +43,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `SearchAppState::with_registry_path` fix for the same flake class, issue
   #2717) and pointed the test at it directly — it no longer touches process
   env at all, so it can't race any sibling test regardless of tagging.
+- **`commands::start::embedder_fallback::tests::fallback_logs_build_failure_exactly_once`
+  deflaked (issue #3689).** This test counts `tracing` events via a
+  thread-local subscriber (`tracing::subscriber::with_default`); `tracing`'s
+  per-callsite interest cache is process-global, not per-thread, so a
+  concurrently-scheduled sibling test hitting the same `tracing::error!` call
+  sites with no subscriber installed could leave a call site cached as
+  "never interested," silently dropping an event this test expects to count.
+  All 7 tests in the module share those call sites and are now `#[serial]`,
+  matching the crate's existing isolation convention (#3629/#3673/#3608).
 - **`core::memguard_enforce::tests::test_anon_rss_for_self_pid_on_linux` deflaked
   (issue #3762, recurrence of #3716's flake class).** The test compared two
   genuinely independent, non-atomic `/proc` reads taken microseconds apart

--- a/crates/trusty-search/src/commands/start/embedder_fallback.rs
+++ b/crates/trusty-search/src/commands/start/embedder_fallback.rs
@@ -240,6 +240,7 @@ impl Embedder for FallbackEmbedderAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
     /// Test embedder that fails its first `fail_count` calls, then succeeds,
@@ -323,7 +324,17 @@ mod tests {
     /// the direct behavioural pin for the fix: the OLD threshold-counting
     /// design would have tripped this after `threshold` failures regardless
     /// of what the supervisor was actually doing.
+    ///
+    /// Issue #3689: `#[serial]` — every test in this module drives
+    /// `record_failure_and_maybe_trip`'s `tracing::error!` call sites, which
+    /// `fallback_logs_build_failure_exactly_once` counts via a thread-local
+    /// `tracing` subscriber. `tracing`'s per-callsite interest cache is
+    /// process-global, so an unrelated concurrently-running test hitting the
+    /// SAME call site with no subscriber installed can get it cached as
+    /// "never interested", silently dropping events the counting test
+    /// expects — see that test's doc comment for the full mechanism.
     #[tokio::test]
+    #[serial]
     async fn fallback_does_not_trip_while_supervisor_still_retrying() {
         let given_up = Arc::new(AtomicBool::new(false));
         let primary: Arc<dyn Embedder> = Arc::new(AlwaysFailEmbedder {
@@ -347,7 +358,10 @@ mod tests {
     /// Once `supervisor_gave_up()` flips to `true`, the VERY NEXT failing
     /// call must trip the latch and be served (transparently) by the
     /// fallback rather than surfacing the primary's error.
+    // Issue #3689: `#[serial]` — see
+    // `fallback_does_not_trip_while_supervisor_still_retrying`'s doc comment.
     #[tokio::test]
+    #[serial]
     async fn fallback_trips_once_supervisor_gave_up_signal_fires() {
         let given_up = Arc::new(AtomicBool::new(false));
         let primary: Arc<dyn Embedder> = Arc::new(AlwaysFailEmbedder {
@@ -382,7 +396,10 @@ mod tests {
     /// Once tripped, EVERY subsequent call — even if the primary would have
     /// started succeeding again, or if `supervisor_gave_up()` somehow flipped
     /// back to `false` — must go to the fallback. One-way latch.
+    // Issue #3689: `#[serial]` — see
+    // `fallback_does_not_trip_while_supervisor_still_retrying`'s doc comment.
     #[tokio::test]
+    #[serial]
     async fn fallback_latches_and_never_reverts() {
         let given_up = Arc::new(AtomicBool::new(true));
         // Primary fails exactly once then would succeed forever after —
@@ -423,7 +440,10 @@ mod tests {
     /// ORIGINAL primary error (not a fallback-construction error, and not a
     /// panic) — and the trip must be retried on the next call rather than
     /// wedging into a permanently-`None` state.
+    // Issue #3689: `#[serial]` — see
+    // `fallback_does_not_trip_while_supervisor_still_retrying`'s doc comment.
     #[tokio::test]
+    #[serial]
     async fn fallback_propagates_error_when_build_ort_fails() {
         let primary: Arc<dyn Embedder> = Arc::new(AlwaysFailEmbedder {
             given_up: Arc::new(AtomicBool::new(true)),
@@ -457,8 +477,30 @@ mod tests {
     /// gave up" trip log, plus the one-time "fallback build failed" log) even
     /// though `embed_batch` is called many times and the fallback builder is
     /// invoked on every one of them.
+    ///
+    /// Issue #3689: this test installs a thread-local `tracing` subscriber
+    /// via `tracing::subscriber::with_default` and asserts an EXACT count of
+    /// events dispatched through it. `tracing`'s per-callsite interest cache
+    /// is process-global, not per-thread: EVERY other test in this module
+    /// drives `record_failure_and_maybe_trip`'s SAME `tracing::error!` call
+    /// sites (the "supervisor gave up" / "fallback build failed" logs) with
+    /// no subscriber installed, and if one of them evaluates a call site's
+    /// interest concurrently with this test's subscriber install/teardown,
+    /// the cache can end up registering "never interested" — silently
+    /// dropping an event this test expects to count (flaked under
+    /// --test-threads=16 looping: "expected exactly 2 ... got 1", and
+    /// reproduced locally even with only THIS test `#[serial]`-tagged, until
+    /// every sibling in the module was too). `#[serial]` (the crate's
+    /// existing convention for isolating tests from cross-test shared
+    /// process state — see `service::reindex::root_hijack_tests`,
+    /// `commands::doctor_checks::tests::doctor_data_dir_returns_non_empty_path`
+    /// #3673/#3686), applied to every test in this module (they all share the
+    /// same call sites), gives this test exclusive execution so its
+    /// interest-cache-affecting subscriber install cannot race a
+    /// concurrently-running sibling.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn fallback_logs_build_failure_exactly_once() {
         use tracing_subscriber::layer::SubscriberExt;
 
@@ -513,7 +555,11 @@ mod tests {
 
     /// Search must keep returning results after the fallback trips — the
     /// end-to-end contract this whole module exists for.
+    ///
+    /// Issue #3689: `#[serial]` — see
+    /// `fallback_does_not_trip_while_supervisor_still_retrying`'s doc comment.
     #[tokio::test]
+    #[serial]
     async fn search_never_hard_fails_after_fallback_trip() {
         let primary: Arc<dyn Embedder> = Arc::new(AlwaysFailEmbedder {
             given_up: Arc::new(AtomicBool::new(true)),
@@ -589,8 +635,12 @@ mod tests {
     ///      supervisor has crossed its own `max_restarts` ceiling — then
     ///      asserts a subsequent call IS served by the fallback.
     /// Test: this test.
+    ///
+    /// Issue #3689: `#[serial]` — see
+    /// `fallback_does_not_trip_while_supervisor_still_retrying`'s doc comment.
     #[cfg(unix)]
     #[tokio::test]
+    #[serial]
     async fn fallback_does_not_trip_on_concurrent_failures_before_supervisor_gives_up() {
         use crate::commands::start::embedder::LazySlotEmbedderAdapter;
         use crate::service::embedder_supervisor::{LazyEmbedderHandle, SupervisorConfig};


### PR DESCRIPTION
## Summary

Same root-cause class as #3629/#3673/#3608: tests mutating shared process state (env vars, or `tracing`'s global callsite interest cache) race a concurrently-scheduled sibling test under parallel `cargo test`. Fixed with the identical established pattern already used in each crate — no new synchronization mechanism introduced.

- **`trusty-search`: `commands::start::embedder_fallback::tests::fallback_logs_build_failure_exactly_once`** — counts `tracing` events via a thread-local subscriber (`tracing::subscriber::with_default`). `tracing`'s per-callsite interest cache is process-global, not per-thread: every other test in the module drives the same `tracing::error!` call sites with no subscriber installed, and a concurrently-running sibling evaluating that call site's interest could leave it cached "never interested," silently dropping an event this test expects to count. All 7 tests in the module share those call sites and are now `#[serial]`-tagged for full mutual exclusion (tagging only the one named test was insufficient — reproduced and confirmed empirically).
- **`trusty-search`: `service::reindex::root_hijack_tests::reindex_refuses_untrusted_root_move_and_preserves_corpus`** — investigated with a stress loop and temporary instrumentation. Already carries the full established isolation pattern (`#[serial]` + its own isolated `TRUSTY_DATA_DIR` tempdir, present since the test's original introduction — not touched by #3673/#3686). Instability only reproduced at 2x-CPU-oversubscribed `--test-threads=32`, alongside unrelated tokio-internal timer panics and other unrelated test failures (system/scheduler overload signatures, not an application race). At `--test-threads=16` (matching this machine's core count and the issue's own repro method) it passed 25/25 stress-loop runs, and instrumentation confirmed the env var was read correctly at the failure point. **No code change applied** — verified already-compliant, mirroring #3686's own "no further change needed" finding for `verify_installed_binary_finds_binary_via_path`.
- **`trusty-common`: `update::tests::cache_fresh_returns_some_when_newer`** — races `check_throttled_skips_when_no_update_check_set` / `check_throttled_skips_when_ci_set`, which mutate `NO_UPDATE_CHECK_ENV`/`CI_ENV` for the duration of their own `check_throttled(...).await` (deliberately outliving the brief `ENV_LOCK` critical sections around the set/remove calls). All three tests now share `#[serial(update_check_throttled_env)]`, matching the crate's existing named-group convention (`update_verify_installed_binary_env`, #3608/#3629).

Closes #3689

## Test plan

- [x] `cargo test -p trusty-search --bin trusty-search embedder_fallback` — 7 passed
- [x] `cargo test -p trusty-search --lib root_hijack` — 2 passed
- [x] `cargo test -p trusty-common --lib --features update-check cache_fresh` — 2 passed
- [x] `cargo test -p trusty-search` (full suite) — all green, 0 failed
- [x] `cargo test -p trusty-common --features update-check` (full suite) — 205 passed, 0 failed
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p trusty-common --all-targets --features update-check -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-search -p trusty-common` — clean
- [x] Stress-verified: 25 runs of `embedder_fallback` module alone + 20 runs of full unfiltered `--bin trusty-search` suite (both `--test-threads=16`) — 0 failures
- [x] Stress-verified: 20 runs of full `trusty-common` suite (`--test-threads=16`) — 0 failures
- [x] Progress comment posted on #3689 with full root-cause writeup

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools