### PR TITLE
feat(trusty-mpm): per-project worktree opt-out — launch sessions on main

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **Per-project "launch on main" worktree opt-out** (closes [#3455](https://github.com/bobmatnyc/trusty-tools/issues/3455)): a registered project's `worktree` field (`Project::worktree: Option<bool>`, default unset = `true`) can now disable per-session git worktree provisioning for that project — set it via `tm projects config <name> set worktree false` (round-trips through the existing `PATCH /api/v1/projects/{name}` configurator, `tm projects config <name>` shows the resolved state) or via `config.yaml`'s `projects[].worktree` (mirrored into the registry at seed time). When disabled, `daemon::managed_routes::lifecycle::spawn_managed_routed` skips the base-clone-plus-worktree path entirely — no `.base`/`.worktrees` directory, no `session/<name>` branch — and spawns the managed session directly in the project's resolved local checkout via the new `spawn_managed_on_main`, which is otherwise a normal managed session (agents/skills deployed, hooks written, tracked/reconnectable, front-gated) with `workspace_owned = false` so decommission never touches the operator's own directory. Running two sessions against the SAME main checkout is not isolated the way two worktrees are; a `warn!` (never a refusal) fires when a second `Active` session targets the identical path, which only a `--force-new` launch can produce (the normal reconnect pre-flight already prevents it otherwise).
+
 ---
 ## [0.21.0] — 2026-07-23
 

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/projects.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/projects.rs
@@ -162,6 +162,11 @@ pub(crate) enum SettableConfigField {
     StackHint,
     /// `gh_user` — preferred `gh` login (#2081), clearable.
     GhUser,
+    /// `worktree` — "launch on main" opt-out (#3455). Value must be
+    /// `true`/`false` (case-insensitive); any other value is rejected
+    /// client-side before it ever reaches the daemon (see
+    /// `commands::projects::registry::config`).
+    Worktree,
 }
 
 /// CLI value for a clearable config field (§6) — DELIBERATELY NARROWER than

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/convert.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/convert.rs
@@ -63,6 +63,7 @@ impl From<SettableConfigField> for ConfigField {
             SettableConfigField::Description => ConfigField::Description,
             SettableConfigField::StackHint => ConfigField::StackHint,
             SettableConfigField::GhUser => ConfigField::GhUser,
+            SettableConfigField::Worktree => ConfigField::Worktree,
         }
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/projects/registry.rs
@@ -83,6 +83,10 @@ pub(crate) async fn register(
         stack_hint: input.stack_hint,
         gh_user: input.gh_user,
         gh_account: input.gh_account,
+        // #3455: not a `register`-time flag — set via `tm projects config
+        // <name> set worktree true|false` instead (mirrors how the other
+        // configurator-only fields have no `register` flag either).
+        worktree: None,
     };
     let project = daemon(client, url).registry_register_project(&args).await?;
     println!(
@@ -222,6 +226,22 @@ pub(crate) async fn config(
 ) -> anyhow::Result<()> {
     match action {
         None => config_view(client, url, name, json).await,
+        Some(ConfigAction::Set {
+            field: crate::cli::SettableConfigField::Worktree,
+            value,
+        }) => {
+            // #3455: `worktree` is the one settable field with a non-string
+            // (bool) wire type; validate client-side so the daemon always
+            // receives exactly "true"/"false" — never free text.
+            let normalized = normalize_bool_flag(&value)?;
+            config_apply(
+                client,
+                url,
+                name,
+                ConfigEdit::Set(project_config::ConfigField::Worktree, normalized),
+            )
+            .await
+        }
         Some(ConfigAction::Set { field, value }) => {
             config_apply(client, url, name, ConfigEdit::Set(field.into(), value)).await
         }
@@ -308,8 +328,36 @@ fn render_config_view(p: &Project) -> String {
             "  gh_account: {}",
             p.gh_account.as_deref().unwrap_or("(unset)")
         ),
+        format!(
+            "  worktree: {}",
+            if p.worktree_enabled() {
+                "true (isolated per-session worktree)"
+            } else {
+                "false (launch on main — #3455)"
+            }
+        ),
     ];
     lines.join("\n")
+}
+
+/// Validate a `tm projects config <name> set worktree <value>` value (#3455).
+///
+/// Why: `worktree` is the one settable field with a `bool` wire type, not a
+/// `String` — reject anything but `true`/`false` HERE, client-side, so the
+/// daemon's `ConfigEdit::Set(ConfigField::Worktree, _)` handling can safely
+/// assume the string is always one of the two literals rather than doing its
+/// own silent best-effort parse.
+/// What: case-insensitively accepts `"true"`/`"false"`, returning the
+/// canonical lowercase form; any other input is an `anyhow::Error` naming the
+/// rejected value.
+/// Test: `normalize_bool_flag_accepts_true_false_case_insensitive`,
+/// `normalize_bool_flag_rejects_other_values`.
+fn normalize_bool_flag(value: &str) -> anyhow::Result<String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" => Ok("true".to_string()),
+        "false" => Ok("false".to_string()),
+        other => anyhow::bail!("worktree: expected 'true' or 'false', got {other:?}"),
+    }
 }
 
 /// Render one project as a compact `name  repo_url  (branch)` line.
@@ -378,6 +426,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         }
     }
 
@@ -387,6 +436,34 @@ mod tests {
         assert!(line.contains("widget"));
         assert!(line.contains("https://github.com/acme/widget"));
         assert!(line.contains("main"));
+    }
+
+    #[test]
+    fn normalize_bool_flag_accepts_true_false_case_insensitive() {
+        assert_eq!(normalize_bool_flag("true").unwrap(), "true");
+        assert_eq!(normalize_bool_flag("FALSE").unwrap(), "false");
+        assert_eq!(normalize_bool_flag("  True  ").unwrap(), "true");
+    }
+
+    #[test]
+    fn normalize_bool_flag_rejects_other_values() {
+        assert!(normalize_bool_flag("yes").is_err());
+        assert!(normalize_bool_flag("1").is_err());
+        assert!(normalize_bool_flag("").is_err());
+    }
+
+    #[test]
+    fn render_config_view_shows_worktree_status() {
+        let mut p = project();
+        assert!(
+            render_config_view(&p).contains("worktree: true"),
+            "default (unset) worktree must render as the true/isolated default"
+        );
+        p.worktree = Some(false);
+        assert!(
+            render_config_view(&p).contains("worktree: false"),
+            "an explicit opt-out must render as false"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/bin/tm/gh_identity.rs
+++ b/crates/trusty-mpm/src/bin/tm/gh_identity.rs
@@ -145,6 +145,7 @@ mod tests {
             commit_name: None,
             commit_email: None,
             untracked_sync: None,
+            worktree: None,
         }
     }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_projects_config_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_projects_config_tests.rs
@@ -67,6 +67,31 @@ fn cli_parses_projects_config_set() {
     }
 }
 
+/// `tm projects config <name> set worktree false` round-trips to
+/// `SettableConfigField::Worktree` with the raw (not-yet-normalized) value —
+/// normalization happens in `commands::projects::registry::config`, not
+/// clap parsing (#3455).
+#[test]
+fn cli_parses_projects_config_set_worktree() {
+    let (name, _json, action) = config_action(&[
+        "trusty-mpm",
+        "projects",
+        "config",
+        "widget",
+        "set",
+        "worktree",
+        "false",
+    ]);
+    assert_eq!(name, "widget");
+    match action.expect("action") {
+        ConfigAction::Set { field, value } => {
+            assert_eq!(field, SettableConfigField::Worktree);
+            assert_eq!(value, "false");
+        }
+        other => panic!("expected set, got {other:?}"),
+    }
+}
+
 #[test]
 fn cli_parses_projects_config_unset() {
     let (name, _json, action) = config_action(&[
@@ -101,6 +126,25 @@ fn cli_rejects_unset_default_branch_at_parse_time() {
         "default-branch",
     ])
     .expect_err("unset default-branch must fail to parse");
+    assert_eq!(err.exit_code(), 2);
+    assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
+}
+
+/// #3455: `unset worktree` is rejected AT PARSE TIME, mirroring
+/// `default_branch`'s precedent — `worktree`'s "clear" state (worktree-ON)
+/// is reachable via `set worktree true`, so `ClearableConfigField` has no
+/// `Worktree` variant.
+#[test]
+fn cli_rejects_unset_worktree_at_parse_time() {
+    let err = Cli::try_parse_from([
+        "trusty-mpm",
+        "projects",
+        "config",
+        "widget",
+        "unset",
+        "worktree",
+    ])
+    .expect_err("unset worktree must fail to parse");
     assert_eq!(err.exit_code(), 2);
     assert_eq!(err.kind(), clap::error::ErrorKind::InvalidValue);
 }
@@ -177,6 +221,7 @@ fn argv_for_case(edit: &trusty_mpm::project_config::ConfigEdit) -> Vec<String> {
                 ConfigField::Description => "description",
                 ConfigField::StackHint => "stack-hint",
                 ConfigField::GhUser => "gh-user",
+                ConfigField::Worktree => "worktree",
             };
             argv.push("set".to_string());
             argv.push(name.to_string());

--- a/crates/trusty-mpm/src/client/http_client/projects.rs
+++ b/crates/trusty-mpm/src/client/http_client/projects.rs
@@ -59,6 +59,11 @@ pub struct RegisterProjectArgs {
     /// GitHub account login pinned for this project's spawned sessions (#3025).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gh_account: Option<String>,
+    /// "Launch on main" opt-out (#3455): `None`/`Some(true)` → default
+    /// worktree isolation; `Some(false)` → sessions run directly in the
+    /// resolved local checkout, no worktree.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<bool>,
 }
 
 /// Serializable body for `PATCH /api/v1/projects/{name}` (registry-B partial
@@ -103,6 +108,12 @@ pub struct PatchProjectArgs {
     /// `gh` account (#3025).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gh_account: Option<Option<String>>,
+    /// "Launch on main" opt-out (#3455): `None` = unchanged; `Some(bool)` =
+    /// set. Plain (single) `Option`, unlike the double-`Option` string
+    /// fields above — see the daemon's `PatchProjectBody::worktree` doc for
+    /// why this field has no separate "clear" story.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<bool>,
     /// Tags to add, deduplicated server-side against the current set. A
     /// blank/whitespace-only entry rejects the whole PATCH with 400.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -357,6 +368,7 @@ mod tests {
             stack_hint: None,
             gh_user: None,
             gh_account: None,
+            worktree: None,
         };
         let v = serde_json::to_value(&args).unwrap();
         assert_eq!(v["name"], "widget");
@@ -419,6 +431,26 @@ mod tests {
         assert_eq!(
             serde_json::to_value(&set).unwrap()["gh_account"],
             "bobmatnyc"
+        );
+    }
+
+    /// `worktree` is a plain (single) `Option<bool>` — `Some(false)` must
+    /// serialize as the literal JSON `false`, not `null` (#3455).
+    #[test]
+    fn patch_args_serializes_worktree_plain_option() {
+        let args = PatchProjectArgs {
+            worktree: Some(false),
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&args).unwrap();
+        assert_eq!(v["worktree"], false);
+
+        let unchanged = PatchProjectArgs::default();
+        assert!(
+            serde_json::to_value(&unchanged)
+                .unwrap()
+                .get("worktree")
+                .is_none()
         );
     }
 

--- a/crates/trusty-mpm/src/core/gh_account_spawn_env_tests.rs
+++ b/crates/trusty-mpm/src/core/gh_account_spawn_env_tests.rs
@@ -112,6 +112,7 @@ fn project(name: &str, repo_url: &str, gh_account: Option<&str>) -> Project {
         github: None,
         commit_name: None,
         commit_email: None,
+        worktree: None,
     }
 }
 

--- a/crates/trusty-mpm/src/core/git_identity.rs
+++ b/crates/trusty-mpm/src/core/git_identity.rs
@@ -334,6 +334,7 @@ mod tests {
             commit_name: Some("Project Bot".into()),
             commit_email: Some("bot@project.example.com".into()),
             untracked_sync: None,
+            worktree: None,
         }
     }
 

--- a/crates/trusty-mpm/src/core/trusty_tools_config.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config.rs
@@ -491,6 +491,22 @@ pub struct ProjectConfig {
     /// Test: `untracked_sync_config_yaml_round_trip`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub untracked_sync: Option<UntrackedSyncConfig>,
+
+    /// Per-project "launch on main" opt-out (#3455), mirrored onto
+    /// [`crate::project::record::Project::worktree`] by `seed_from_config`.
+    ///
+    /// `None`/`Some(true)` → default, no regression: this project's managed
+    /// sessions each get their own `.worktrees/<session>` git worktree.
+    /// `Some(false)` → sessions run directly in the resolved local checkout
+    /// instead — no clone, no worktree, no dedicated branch. See
+    /// [`crate::project::record::Project::worktree_enabled`] for the
+    /// resolved default and `tm projects config <name> set worktree
+    /// true|false` for the runtime-registry equivalent (the registry, not
+    /// this static config, is what `spawn_managed_routed` actually consults
+    /// at spawn time — this field only seeds it).
+    /// Test: covered by `registry::seed_from_config` round-trip coverage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<bool>,
 }
 
 impl TrustyToolsConfig {
@@ -792,6 +808,7 @@ mod tests {
                 commit_name: None,
                 commit_email: None,
                 untracked_sync: None,
+                worktree: None,
             }],
             ..Default::default()
         };
@@ -816,6 +833,7 @@ mod tests {
                 commit_name: None,
                 commit_email: None,
                 untracked_sync: None,
+                worktree: None,
             }],
             ..Default::default()
         };
@@ -850,6 +868,7 @@ mod tests {
                 commit_name: Some("Bob (work bot)".into()),
                 commit_email: Some("bob@acme.example.com".into()),
                 untracked_sync: None,
+                worktree: None,
             }],
             ..Default::default()
         };
@@ -875,6 +894,7 @@ mod tests {
                 commit_name: None,
                 commit_email: None,
                 untracked_sync: None,
+                worktree: None,
             }],
             ..Default::default()
         };

--- a/crates/trusty-mpm/src/core/trusty_tools_config/untracked_sync/tests.rs
+++ b/crates/trusty-mpm/src/core/trusty_tools_config/untracked_sync/tests.rs
@@ -38,6 +38,7 @@ fn untracked_sync_config_yaml_round_trip() {
                 patterns: Some(vec![".env.widget".into()]),
                 enabled: Some(false),
             }),
+            worktree: None,
         }],
         ..Default::default()
     };
@@ -113,6 +114,7 @@ fn resolve_untracked_sync_project_overrides_global() {
                 patterns: Some(vec![".env.widget-only".into()]),
                 enabled: None,
             }),
+            worktree: None,
         }],
         ..Default::default()
     };
@@ -148,6 +150,7 @@ fn resolve_untracked_sync_disabled_by_project() {
                 patterns: None,
                 enabled: Some(false),
             }),
+            worktree: None,
         }],
         ..Default::default()
     };

--- a/crates/trusty-mpm/src/daemon/managed_routes/deliverable_link.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/deliverable_link.rs
@@ -186,6 +186,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/launch_on_main.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/launch_on_main.rs
@@ -1,0 +1,253 @@
+//! `#3455` "launch on main" opt-out — spawn a managed session directly in a
+//! project's main checkout, with NO per-session git worktree.
+//!
+//! Why: extracted from `lifecycle.rs` (which is grandfathered at a frozen
+//! SLOC budget on `.line-cap-allowlist.tsv`) to keep the opt-out's three
+//! pieces — the registry lookup that decides whether isolation is on, the
+//! pure concurrent-collision detector, and the `spawn_managed_on_main` flow —
+//! in one small sibling module, matching the existing `inproject.rs` split.
+//! The functions are `pub(super)` so `lifecycle::spawn_managed_routed` (the
+//! only caller) can route to them; the shared spawn helpers they reuse
+//! (`write_task_md`/`prepare_inproject_session`/`front_gate_or_escalate`/
+//! `resolve_gh_env`) stay owned by `lifecycle` and are called back into.
+//! What: [`worktree_enabled_for_origin`] (registry-keyed isolation decision),
+//! [`has_concurrent_main_checkout_session`] (pure collision detector), and
+//! [`spawn_managed_on_main`] (the no-worktree spawn flow).
+//! Test: `worktree_enabled_for_origin_*`,
+//! `spawn_managed_on_main_creates_record_without_worktree`, and
+//! `spawn_managed_on_main_warns_on_concurrent_main_checkout_session` in
+//! `lifecycle_tests.rs` (this module's tests live with `lifecycle`'s, since
+//! the opt-out is a branch of the same spawn surface).
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+use super::deployment_check::ensure_deployment_complete;
+use super::lifecycle::{
+    SpawnParams, front_gate_or_escalate, prepare_inproject_session, resolve_gh_env, write_task_md,
+};
+use crate::daemon::state::DaemonState;
+use crate::project::ProjectRegistry;
+use crate::runtime::RuntimeKind;
+use crate::session_manager::{ManagedSessionId, ManagedSessionState, SessionRecord};
+
+/// Resolve whether per-session worktree isolation is enabled for the
+/// registered project whose `repo_url` matches `origin` (#3455).
+///
+/// Why: mirrors `core::gh_account::find_pinned_gh_account` — the registry
+/// (not the static `config.yaml`, which only ever SEEDS the registry via
+/// `seed_from_config`) is the source of truth consulted at spawn time, keyed
+/// by `repo_url` identity so lookup works regardless of the registry's
+/// `name` key or how the project got registered (explicit `tm projects
+/// register`, config-seeded, or auto-registered from session history).
+/// What: `true` (worktree isolation ON, the default — no regression) when no
+/// registered project matches `origin`, the registry is unreachable, or the
+/// matched project's `worktree` field is unset/`Some(true)`; `false` only
+/// when a matched project has `worktree == Some(false)`.
+/// Test: `worktree_enabled_for_origin_defaults_true_when_unregistered`,
+/// `worktree_enabled_for_origin_honors_registered_false`.
+pub(super) async fn worktree_enabled_for_origin(registry: &ProjectRegistry, origin: &str) -> bool {
+    let Ok(projects) = registry.list().await else {
+        return true;
+    };
+    projects
+        .iter()
+        .find(|p| crate::project::record::repo_url_matches(&p.repo_url, origin))
+        .map(|p| p.worktree_enabled())
+        .unwrap_or(true)
+}
+
+/// Return the FIRST already-`Active` session whose cwd is EXACTLY
+/// `local_path`, if any (#3455 collision detector).
+///
+/// Why: pure, testable core of the "two sessions on one main checkout"
+/// warning. Extracted from `spawn_managed_on_main`'s inline `.any(...)` so
+/// the WARN path has direct unit coverage and so the caller can name the
+/// colliding session (its id + tmux name) in the log for diagnosability.
+/// What: returns `Some(&record)` for the first Active record sharing
+/// `local_path` as its cwd, else `None` — worktree sessions never match
+/// (their cwd is a `.worktrees/<name>` slice, never the bare main checkout).
+/// Test: `spawn_managed_on_main_warns_on_concurrent_main_checkout_session`.
+pub(super) fn has_concurrent_main_checkout_session<'a>(
+    existing: &'a [SessionRecord],
+    local_path: &std::path::Path,
+) -> Option<&'a SessionRecord> {
+    existing
+        .iter()
+        .find(|r| r.state == ManagedSessionState::Active && r.cwd == local_path)
+}
+
+/// Spawn a managed session directly in the project's main checkout, with NO
+/// per-session git worktree (#3455 "launch on main" opt-out).
+///
+/// Why: some projects have a direct-main workflow (no PR flow, no isolation
+/// requirement) where the standard per-session worktree is pure friction — a
+/// worktree sitting unused at a stale commit, a cwd the agent must `cd` out
+/// of on every command, and a stale-state misdiagnosis risk (issue #3455).
+/// `spawn_managed_routed` calls this INSTEAD of the worktree-provisioning
+/// branch when the matched registered project has `worktree ==
+/// Some(false)`. Otherwise this is a normal managed session in every other
+/// respect — agents/skills deployed, project hooks written, tracked in the
+/// session manager, front-gated, reconnectable — it just never clones a base
+/// checkout or adds a worktree; the session's cwd/workspace IS `local_path`.
+/// What: (1) logs (never refuses), naming the colliding session's id + tmux
+/// name via [`has_concurrent_main_checkout_session`], when a second Active
+/// session already targets this EXACT `local_path` — the caller only reaches
+/// this function after its own reconnect check found no live session for the
+/// repo, so this can only fire when `force_new` deliberately bypassed that
+/// check; running two sessions against ONE main checkout is not isolated the
+/// way two worktrees are (uncommitted-change races, concurrent git
+/// operations), so this is the collision caveat #3455 asks to surface; (2)
+/// resolves the semantic tmux name via `SessionManager::resolve_session_name`
+/// with no worktree-collision predicate (there is no worktree to collide
+/// with); (3) writes `TASK.md`; (4) runs `prepare_inproject_session` directly
+/// against `local_path` (mirrors `spawn_managed_inproject`'s #1913 fix — no
+/// clone step wraps this path either); (5) creates the session record with
+/// `workspace_owned = false` — the operator's own checkout must NEVER be
+/// auto-deleted by decommission (verified safe: `decommission_with_root`
+/// only ever removes a `workspace_owned = false` path when
+/// `is_session_worktree` recognises it as living under `.worktrees/`, which
+/// `local_path` never does); (6) sets `source_id`; (7) front gates; (8)
+/// marks `Active`; (9) spawns the runtime.
+/// Test: `spawn_managed_on_main_creates_record_without_worktree`,
+/// `spawn_managed_on_main_warns_on_concurrent_main_checkout_session` in
+/// `lifecycle_tests.rs`.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn spawn_managed_on_main(
+    state: &Arc<DaemonState>,
+    session_id: &ManagedSessionId,
+    params: &SpawnParams,
+    runtime: RuntimeKind,
+    local_path: &std::path::Path,
+    owner: &str,
+    repo: &str,
+) -> Result<SessionRecord, String> {
+    use crate::core::provisioning_stage::{ProvisioningStage, emit};
+
+    let mgr = state.session_manager().await;
+
+    // #3455 collision caveat: warn (never refuse) when a second Active
+    // session is already running against this EXACT main checkout — the
+    // caller's reconnect check already ruled out "same repo, some live
+    // session"; reaching here with a collision means `force_new` explicitly
+    // asked for a second session on the identical directory. Naming the
+    // colliding session lets an operator identify which other session shares
+    // the checkout.
+    {
+        let existing = mgr.list().await;
+        if let Some(other) = has_concurrent_main_checkout_session(&existing, local_path) {
+            warn!(
+                path = %local_path.display(),
+                colliding_session_id = %other.id,
+                colliding_session_name = %other.tmux_name,
+                "spawn_managed (launch-on-main): a second Active session is launching in \
+                 the SAME main checkout (#3455) — there is no worktree isolating them from \
+                 the colliding session; concurrent git operations or uncommitted-change \
+                 races are possible"
+            );
+        }
+    }
+
+    let reserved_name = mgr
+        .resolve_session_name(params.name_hint.as_deref(), Some(repo), local_path, |_| {
+            false
+        })
+        .await
+        .map_err(|e| format!("name resolution failed for session {session_id}: {e}"))?;
+
+    write_task_md(local_path, &params.task, session_id);
+
+    let synthetic_repo_url = format!("https://github.com/{owner}/{repo}");
+    let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(local_path);
+    prepare_inproject_session(&fw, session_id, local_path, &synthetic_repo_url);
+
+    emit(ProvisioningStage::CreatingTmuxSession);
+    let record = mgr
+        .create_with_reserved_name(
+            *session_id,
+            reserved_name,
+            params.task.clone(),
+            Some(local_path.to_path_buf()),
+            Some(local_path.to_path_buf()),
+            Some(synthetic_repo_url),
+            None,
+            runtime,
+            params.ephemeral.unwrap_or(false),
+            false, // workspace_owned: the operator's own main checkout, never auto-deletable
+        )
+        .await
+        .map_err(|e| {
+            warn!(id = %session_id, "spawn_managed (launch-on-main): create failed: {e}");
+            e.to_string()
+        })?;
+
+    let source_id = format!("{owner}/{repo}");
+    if let Err(e) = mgr.set_source_id(session_id, &source_id).await {
+        warn!(id = %session_id, "spawn_managed (launch-on-main): set_source_id failed: {e}");
+    }
+
+    if let Some(record) =
+        front_gate_or_escalate(&mgr, &record, &params.repo_url, &params.task).await?
+    {
+        return Ok(record);
+    }
+
+    if let Err(e) = mgr
+        .set_workspace(
+            session_id,
+            local_path.to_path_buf(),
+            ManagedSessionState::Active,
+        )
+        .await
+    {
+        warn!(id = %session_id, "spawn_managed (launch-on-main): set_workspace failed: {e}");
+    }
+
+    if let Err(reason) =
+        ensure_deployment_complete(&fw, local_path, record.repo_url.as_deref(), session_id)
+    {
+        warn!(
+            id = %session_id,
+            "spawn_managed (launch-on-main): deployment incomplete after auto-repair \
+             (non-blocking, launch proceeds): {reason}"
+        );
+    }
+
+    crate::core::session_launch::spawn_workstream_label_ensure(
+        record.repo_url.clone(),
+        local_path.to_path_buf(),
+        record.tmux_name.clone(),
+    );
+
+    emit(ProvisioningStage::LaunchingRuntime);
+    let tmux_arc = mgr.tmux_driver();
+    let adapter = crate::runtime::build_adapter(record.runtime, tmux_arc);
+    let gh_env = resolve_gh_env(state, local_path).await;
+    if let Err(e) = adapter.spawn(
+        &record.tmux_name,
+        local_path,
+        &params.task,
+        &record.id.to_string(),
+        &gh_env,
+    ) {
+        warn!(
+            id = %record.id,
+            name = %record.tmux_name,
+            "spawn_managed (launch-on-main): runtime adapter spawn failed: {e}"
+        );
+        let _ = mgr
+            .mark_errored(&record.id, &format!("spawn failed: {e}"))
+            .await;
+    } else {
+        info!(
+            id = %record.id,
+            name = %record.tmux_name,
+            path = %local_path.display(),
+            "managed session spawned successfully (launch-on-main, no worktree)"
+        );
+    }
+
+    emit(ProvisioningStage::Complete);
+    Ok(mgr.get(&record.id).await.unwrap_or(record))
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -63,6 +63,35 @@ async fn resolve_gh_env(state: &Arc<DaemonState>, cwd: &std::path::Path) -> Vec<
     crate::core::gh_account::resolve_gh_account_env_for_registry(&registry, cwd).await
 }
 
+/// Resolve whether per-session worktree isolation is enabled for the
+/// registered project whose `repo_url` matches `origin` (#3455).
+///
+/// Why: mirrors `core::gh_account::find_pinned_gh_account` — the registry
+/// (not the static `config.yaml`, which only ever SEEDS the registry via
+/// `seed_from_config`) is the source of truth consulted at spawn time, keyed
+/// by `repo_url` identity so lookup works regardless of the registry's
+/// `name` key or how the project got registered (explicit `tm projects
+/// register`, config-seeded, or auto-registered from session history).
+/// What: `true` (worktree isolation ON, the default — no regression) when no
+/// registered project matches `origin`, the registry is unreachable, or the
+/// matched project's `worktree` field is unset/`Some(true)`; `false` only
+/// when a matched project has `worktree == Some(false)`.
+/// Test: `worktree_enabled_for_origin_defaults_true_when_unregistered`,
+/// `worktree_enabled_for_origin_honors_registered_false`.
+async fn worktree_enabled_for_origin(
+    registry: &crate::project::ProjectRegistry,
+    origin: &str,
+) -> bool {
+    let Ok(projects) = registry.list().await else {
+        return true;
+    };
+    projects
+        .iter()
+        .find(|p| crate::project::record::repo_url_matches(&p.repo_url, origin))
+        .map(|p| p.worktree_enabled())
+        .unwrap_or(true)
+}
+
 /// Transport-agnostic inputs for spawning a managed session.
 ///
 /// Why: both the HTTP `POST /…/managed` handler and the MCP `session_new` tool
@@ -359,6 +388,59 @@ async fn spawn_managed_routed(
         // with a GitHub remote (no `.git`, no remote origin, non-GitHub URL), fall
         // through to the existing local-path spawn.
         let local_path = std::path::Path::new(&params.repo_url);
+
+        // #3455 "launch on main" opt-out: checked BEFORE `try_inproject_spawn`
+        // (which would otherwise establish a base clone as a side effect even
+        // when it's never going to be used) so a project with worktree
+        // isolation disabled never gets a base clone OR a worktree at all —
+        // the exact wasted-disk-space complaint the issue raises. Only a
+        // GitHub-remote-having local checkout can match a registered project
+        // (mirrors `try_inproject_spawn`'s own detection).
+        if let Some(origin_url) = super::inproject::get_origin_url(local_path)
+            && let Some(gh) = trusty_common::github_path::parse_github_path(&origin_url)
+        {
+            let registry = state.project_registry().await;
+            if !worktree_enabled_for_origin(&registry, &origin_url).await {
+                info!(
+                    id = %session_id,
+                    path = %local_path.display(),
+                    "spawn_managed: project has worktree isolation disabled (#3455); \
+                     launching directly in the main checkout"
+                );
+                // Same reconnect pre-flight the worktree branch runs below
+                // (#1707 + `force_new` opt-out, #2450): a live session for
+                // this repo reconnects instead of spawning a duplicate.
+                {
+                    let mgr = state.session_manager().await;
+                    let existing = mgr.list().await;
+                    let source_id = format!("{}/{}", gh.owner, gh.repo);
+                    if let Some(live) = reconnect_candidate(
+                        params.force_new,
+                        &existing,
+                        &source_id,
+                        &*mgr.tmux_driver(),
+                    ) {
+                        info!(
+                            id = %live.id,
+                            source_id = %source_id,
+                            "spawn_managed (launch-on-main): reconnecting to existing live session"
+                        );
+                        return Ok(live);
+                    }
+                }
+                return spawn_managed_on_main(
+                    state,
+                    &session_id,
+                    &params,
+                    runtime,
+                    local_path,
+                    &gh.owner,
+                    &gh.repo,
+                )
+                .await;
+            }
+        }
+
         match try_inproject_spawn(local_path) {
             Ok(Some((base, owner, repo))) => {
                 // Reconnect pre-flight (#1707), HOISTED AHEAD of worktree
@@ -1057,6 +1139,178 @@ fn prepare_inproject_session(
             );
         }
     }
+}
+
+/// Spawn a managed session directly in the project's main checkout, with NO
+/// per-session git worktree (#3455 "launch on main" opt-out).
+///
+/// Why: some projects have a direct-main workflow (no PR flow, no isolation
+/// requirement) where the standard per-session worktree is pure friction — a
+/// worktree sitting unused at a stale commit, a cwd the agent must `cd` out
+/// of on every command, and a stale-state misdiagnosis risk (issue #3455).
+/// `spawn_managed_routed` calls this INSTEAD of the worktree-provisioning
+/// branch when the matched registered project has `worktree ==
+/// Some(false)`. Otherwise this is a normal managed session in every other
+/// respect — agents/skills deployed, project hooks written, tracked in the
+/// session manager, front-gated, reconnectable — it just never clones a base
+/// checkout or adds a worktree; the session's cwd/workspace IS `local_path`.
+/// What: (1) logs (never refuses) when a second Active session already
+/// targets this EXACT `local_path` — the caller only reaches this function
+/// after its own reconnect check found no live session for the repo, so this
+/// can only fire when `force_new` deliberately bypassed that check; running
+/// two sessions against ONE main checkout is not isolated the way two
+/// worktrees are (uncommitted-change races, concurrent git operations), so
+/// this is the collision caveat #3455 asks to surface; (2) resolves the
+/// semantic tmux name via `SessionManager::resolve_session_name` with no
+/// worktree-collision predicate (there is no worktree to collide with); (3)
+/// writes `TASK.md`; (4) runs `prepare_inproject_session` directly against
+/// `local_path` (mirrors `spawn_managed_inproject`'s #1913 fix — no clone
+/// step wraps this path either); (5) creates the session record with
+/// `workspace_owned = false` — the operator's own checkout must NEVER be
+/// auto-deleted by decommission (verified safe: `decommission_with_root`
+/// only ever removes a `workspace_owned = false` path when
+/// `is_session_worktree` recognises it as living under `.worktrees/`, which
+/// `local_path` never does); (6) sets `source_id`; (7) front gates; (8)
+/// marks `Active`; (9) spawns the runtime.
+/// Test: `spawn_managed_on_main_creates_record_without_worktree`,
+/// `spawn_managed_on_main_warns_on_concurrent_main_checkout_session` in this
+/// module's `tests` submodule.
+#[allow(clippy::too_many_arguments)]
+async fn spawn_managed_on_main(
+    state: &Arc<DaemonState>,
+    session_id: &ManagedSessionId,
+    params: &SpawnParams,
+    runtime: RuntimeKind,
+    local_path: &std::path::Path,
+    owner: &str,
+    repo: &str,
+) -> Result<SessionRecord, String> {
+    use crate::core::provisioning_stage::{ProvisioningStage, emit};
+    use crate::session_manager::ManagedSessionState;
+
+    let mgr = state.session_manager().await;
+
+    // #3455 collision caveat: warn (never refuse) when a second Active
+    // session is already running against this EXACT main checkout — the
+    // caller's reconnect check already ruled out "same repo, some live
+    // session"; reaching here with a collision means `force_new` explicitly
+    // asked for a second session on the identical directory.
+    {
+        let existing = mgr.list().await;
+        if existing
+            .iter()
+            .any(|r| r.state == ManagedSessionState::Active && r.cwd == local_path)
+        {
+            warn!(
+                path = %local_path.display(),
+                "spawn_managed (launch-on-main): a second Active session is launching in \
+                 the SAME main checkout (#3455) — there is no worktree isolating them; \
+                 concurrent git operations or uncommitted-change races are possible"
+            );
+        }
+    }
+
+    let reserved_name = mgr
+        .resolve_session_name(params.name_hint.as_deref(), Some(repo), local_path, |_| {
+            false
+        })
+        .await
+        .map_err(|e| format!("name resolution failed for session {session_id}: {e}"))?;
+
+    write_task_md(local_path, &params.task, session_id);
+
+    let synthetic_repo_url = format!("https://github.com/{owner}/{repo}");
+    let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(local_path);
+    prepare_inproject_session(&fw, session_id, local_path, &synthetic_repo_url);
+
+    emit(ProvisioningStage::CreatingTmuxSession);
+    let record = mgr
+        .create_with_reserved_name(
+            *session_id,
+            reserved_name,
+            params.task.clone(),
+            Some(local_path.to_path_buf()),
+            Some(local_path.to_path_buf()),
+            Some(synthetic_repo_url),
+            None,
+            runtime,
+            params.ephemeral.unwrap_or(false),
+            false, // workspace_owned: the operator's own main checkout, never auto-deletable
+        )
+        .await
+        .map_err(|e| {
+            warn!(id = %session_id, "spawn_managed (launch-on-main): create failed: {e}");
+            e.to_string()
+        })?;
+
+    let source_id = format!("{owner}/{repo}");
+    if let Err(e) = mgr.set_source_id(session_id, &source_id).await {
+        warn!(id = %session_id, "spawn_managed (launch-on-main): set_source_id failed: {e}");
+    }
+
+    if let Some(record) =
+        front_gate_or_escalate(&mgr, &record, &params.repo_url, &params.task).await?
+    {
+        return Ok(record);
+    }
+
+    if let Err(e) = mgr
+        .set_workspace(
+            session_id,
+            local_path.to_path_buf(),
+            ManagedSessionState::Active,
+        )
+        .await
+    {
+        warn!(id = %session_id, "spawn_managed (launch-on-main): set_workspace failed: {e}");
+    }
+
+    if let Err(reason) =
+        ensure_deployment_complete(&fw, local_path, record.repo_url.as_deref(), session_id)
+    {
+        warn!(
+            id = %session_id,
+            "spawn_managed (launch-on-main): deployment incomplete after auto-repair \
+             (non-blocking, launch proceeds): {reason}"
+        );
+    }
+
+    crate::core::session_launch::spawn_workstream_label_ensure(
+        record.repo_url.clone(),
+        local_path.to_path_buf(),
+        record.tmux_name.clone(),
+    );
+
+    emit(ProvisioningStage::LaunchingRuntime);
+    let tmux_arc = mgr.tmux_driver();
+    let adapter = crate::runtime::build_adapter(record.runtime, tmux_arc);
+    let gh_env = resolve_gh_env(state, local_path).await;
+    if let Err(e) = adapter.spawn(
+        &record.tmux_name,
+        local_path,
+        &params.task,
+        &record.id.to_string(),
+        &gh_env,
+    ) {
+        warn!(
+            id = %record.id,
+            name = %record.tmux_name,
+            "spawn_managed (launch-on-main): runtime adapter spawn failed: {e}"
+        );
+        let _ = mgr
+            .mark_errored(&record.id, &format!("spawn failed: {e}"))
+            .await;
+    } else {
+        info!(
+            id = %record.id,
+            name = %record.tmux_name,
+            path = %local_path.display(),
+            "managed session spawned successfully (launch-on-main, no worktree)"
+        );
+    }
+
+    emit(ProvisioningStage::Complete);
+    Ok(mgr.get(&record.id).await.unwrap_or(record))
 }
 
 /// Spawn a managed session rooted at a local directory, redirecting to a managed

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -58,38 +58,12 @@ use crate::session_manager::ManagedError;
 /// `resume_managed_*` tests in `tests/session_manager_mvp.rs` (empty-registry
 /// case — no regression); the registry-matching logic itself is unit-tested
 /// in `core::gh_account_spawn_env_tests`.
-async fn resolve_gh_env(state: &Arc<DaemonState>, cwd: &std::path::Path) -> Vec<(String, String)> {
+pub(super) async fn resolve_gh_env(
+    state: &Arc<DaemonState>,
+    cwd: &std::path::Path,
+) -> Vec<(String, String)> {
     let registry = state.project_registry().await;
     crate::core::gh_account::resolve_gh_account_env_for_registry(&registry, cwd).await
-}
-
-/// Resolve whether per-session worktree isolation is enabled for the
-/// registered project whose `repo_url` matches `origin` (#3455).
-///
-/// Why: mirrors `core::gh_account::find_pinned_gh_account` — the registry
-/// (not the static `config.yaml`, which only ever SEEDS the registry via
-/// `seed_from_config`) is the source of truth consulted at spawn time, keyed
-/// by `repo_url` identity so lookup works regardless of the registry's
-/// `name` key or how the project got registered (explicit `tm projects
-/// register`, config-seeded, or auto-registered from session history).
-/// What: `true` (worktree isolation ON, the default — no regression) when no
-/// registered project matches `origin`, the registry is unreachable, or the
-/// matched project's `worktree` field is unset/`Some(true)`; `false` only
-/// when a matched project has `worktree == Some(false)`.
-/// Test: `worktree_enabled_for_origin_defaults_true_when_unregistered`,
-/// `worktree_enabled_for_origin_honors_registered_false`.
-async fn worktree_enabled_for_origin(
-    registry: &crate::project::ProjectRegistry,
-    origin: &str,
-) -> bool {
-    let Ok(projects) = registry.list().await else {
-        return true;
-    };
-    projects
-        .iter()
-        .find(|p| crate::project::record::repo_url_matches(&p.repo_url, origin))
-        .map(|p| p.worktree_enabled())
-        .unwrap_or(true)
 }
 
 /// Transport-agnostic inputs for spawning a managed session.
@@ -400,7 +374,7 @@ async fn spawn_managed_routed(
             && let Some(gh) = trusty_common::github_path::parse_github_path(&origin_url)
         {
             let registry = state.project_registry().await;
-            if !worktree_enabled_for_origin(&registry, &origin_url).await {
+            if !super::launch_on_main::worktree_enabled_for_origin(&registry, &origin_url).await {
                 info!(
                     id = %session_id,
                     path = %local_path.display(),
@@ -428,7 +402,7 @@ async fn spawn_managed_routed(
                         return Ok(live);
                     }
                 }
-                return spawn_managed_on_main(
+                return super::launch_on_main::spawn_managed_on_main(
                     state,
                     &session_id,
                     &params,
@@ -1104,7 +1078,7 @@ async fn spawn_managed_inproject(
 /// call, so a prep failure never blocks the session from spawning.
 /// Test: `prepare_inproject_session_writes_statusline` in this module's `tests`
 /// submodule.
-fn prepare_inproject_session(
+pub(super) fn prepare_inproject_session(
     fw: &crate::core::paths::FrameworkPaths,
     session_id: &ManagedSessionId,
     worktree: &std::path::Path,
@@ -1139,178 +1113,6 @@ fn prepare_inproject_session(
             );
         }
     }
-}
-
-/// Spawn a managed session directly in the project's main checkout, with NO
-/// per-session git worktree (#3455 "launch on main" opt-out).
-///
-/// Why: some projects have a direct-main workflow (no PR flow, no isolation
-/// requirement) where the standard per-session worktree is pure friction — a
-/// worktree sitting unused at a stale commit, a cwd the agent must `cd` out
-/// of on every command, and a stale-state misdiagnosis risk (issue #3455).
-/// `spawn_managed_routed` calls this INSTEAD of the worktree-provisioning
-/// branch when the matched registered project has `worktree ==
-/// Some(false)`. Otherwise this is a normal managed session in every other
-/// respect — agents/skills deployed, project hooks written, tracked in the
-/// session manager, front-gated, reconnectable — it just never clones a base
-/// checkout or adds a worktree; the session's cwd/workspace IS `local_path`.
-/// What: (1) logs (never refuses) when a second Active session already
-/// targets this EXACT `local_path` — the caller only reaches this function
-/// after its own reconnect check found no live session for the repo, so this
-/// can only fire when `force_new` deliberately bypassed that check; running
-/// two sessions against ONE main checkout is not isolated the way two
-/// worktrees are (uncommitted-change races, concurrent git operations), so
-/// this is the collision caveat #3455 asks to surface; (2) resolves the
-/// semantic tmux name via `SessionManager::resolve_session_name` with no
-/// worktree-collision predicate (there is no worktree to collide with); (3)
-/// writes `TASK.md`; (4) runs `prepare_inproject_session` directly against
-/// `local_path` (mirrors `spawn_managed_inproject`'s #1913 fix — no clone
-/// step wraps this path either); (5) creates the session record with
-/// `workspace_owned = false` — the operator's own checkout must NEVER be
-/// auto-deleted by decommission (verified safe: `decommission_with_root`
-/// only ever removes a `workspace_owned = false` path when
-/// `is_session_worktree` recognises it as living under `.worktrees/`, which
-/// `local_path` never does); (6) sets `source_id`; (7) front gates; (8)
-/// marks `Active`; (9) spawns the runtime.
-/// Test: `spawn_managed_on_main_creates_record_without_worktree`,
-/// `spawn_managed_on_main_warns_on_concurrent_main_checkout_session` in this
-/// module's `tests` submodule.
-#[allow(clippy::too_many_arguments)]
-async fn spawn_managed_on_main(
-    state: &Arc<DaemonState>,
-    session_id: &ManagedSessionId,
-    params: &SpawnParams,
-    runtime: RuntimeKind,
-    local_path: &std::path::Path,
-    owner: &str,
-    repo: &str,
-) -> Result<SessionRecord, String> {
-    use crate::core::provisioning_stage::{ProvisioningStage, emit};
-    use crate::session_manager::ManagedSessionState;
-
-    let mgr = state.session_manager().await;
-
-    // #3455 collision caveat: warn (never refuse) when a second Active
-    // session is already running against this EXACT main checkout — the
-    // caller's reconnect check already ruled out "same repo, some live
-    // session"; reaching here with a collision means `force_new` explicitly
-    // asked for a second session on the identical directory.
-    {
-        let existing = mgr.list().await;
-        if existing
-            .iter()
-            .any(|r| r.state == ManagedSessionState::Active && r.cwd == local_path)
-        {
-            warn!(
-                path = %local_path.display(),
-                "spawn_managed (launch-on-main): a second Active session is launching in \
-                 the SAME main checkout (#3455) — there is no worktree isolating them; \
-                 concurrent git operations or uncommitted-change races are possible"
-            );
-        }
-    }
-
-    let reserved_name = mgr
-        .resolve_session_name(params.name_hint.as_deref(), Some(repo), local_path, |_| {
-            false
-        })
-        .await
-        .map_err(|e| format!("name resolution failed for session {session_id}: {e}"))?;
-
-    write_task_md(local_path, &params.task, session_id);
-
-    let synthetic_repo_url = format!("https://github.com/{owner}/{repo}");
-    let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(local_path);
-    prepare_inproject_session(&fw, session_id, local_path, &synthetic_repo_url);
-
-    emit(ProvisioningStage::CreatingTmuxSession);
-    let record = mgr
-        .create_with_reserved_name(
-            *session_id,
-            reserved_name,
-            params.task.clone(),
-            Some(local_path.to_path_buf()),
-            Some(local_path.to_path_buf()),
-            Some(synthetic_repo_url),
-            None,
-            runtime,
-            params.ephemeral.unwrap_or(false),
-            false, // workspace_owned: the operator's own main checkout, never auto-deletable
-        )
-        .await
-        .map_err(|e| {
-            warn!(id = %session_id, "spawn_managed (launch-on-main): create failed: {e}");
-            e.to_string()
-        })?;
-
-    let source_id = format!("{owner}/{repo}");
-    if let Err(e) = mgr.set_source_id(session_id, &source_id).await {
-        warn!(id = %session_id, "spawn_managed (launch-on-main): set_source_id failed: {e}");
-    }
-
-    if let Some(record) =
-        front_gate_or_escalate(&mgr, &record, &params.repo_url, &params.task).await?
-    {
-        return Ok(record);
-    }
-
-    if let Err(e) = mgr
-        .set_workspace(
-            session_id,
-            local_path.to_path_buf(),
-            ManagedSessionState::Active,
-        )
-        .await
-    {
-        warn!(id = %session_id, "spawn_managed (launch-on-main): set_workspace failed: {e}");
-    }
-
-    if let Err(reason) =
-        ensure_deployment_complete(&fw, local_path, record.repo_url.as_deref(), session_id)
-    {
-        warn!(
-            id = %session_id,
-            "spawn_managed (launch-on-main): deployment incomplete after auto-repair \
-             (non-blocking, launch proceeds): {reason}"
-        );
-    }
-
-    crate::core::session_launch::spawn_workstream_label_ensure(
-        record.repo_url.clone(),
-        local_path.to_path_buf(),
-        record.tmux_name.clone(),
-    );
-
-    emit(ProvisioningStage::LaunchingRuntime);
-    let tmux_arc = mgr.tmux_driver();
-    let adapter = crate::runtime::build_adapter(record.runtime, tmux_arc);
-    let gh_env = resolve_gh_env(state, local_path).await;
-    if let Err(e) = adapter.spawn(
-        &record.tmux_name,
-        local_path,
-        &params.task,
-        &record.id.to_string(),
-        &gh_env,
-    ) {
-        warn!(
-            id = %record.id,
-            name = %record.tmux_name,
-            "spawn_managed (launch-on-main): runtime adapter spawn failed: {e}"
-        );
-        let _ = mgr
-            .mark_errored(&record.id, &format!("spawn failed: {e}"))
-            .await;
-    } else {
-        info!(
-            id = %record.id,
-            name = %record.tmux_name,
-            path = %local_path.display(),
-            "managed session spawned successfully (launch-on-main, no worktree)"
-        );
-    }
-
-    emit(ProvisioningStage::Complete);
-    Ok(mgr.get(&record.id).await.unwrap_or(record))
 }
 
 /// Spawn a managed session rooted at a local directory, redirecting to a managed
@@ -1593,7 +1395,7 @@ pub async fn spawn_runtime_for(
 /// Test: `front_gate_escalation_sets_pending_decision` /
 /// `front_gate_clean_match_spawns` in tests/session_manager_mvp.rs, plus the unit
 /// matrix in `managed_routes::front_gate::tests`.
-async fn front_gate_or_escalate(
+pub(super) async fn front_gate_or_escalate(
     mgr: &Arc<crate::session_manager::SessionManager>,
     record: &SessionRecord,
     repo_url: &str,

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
@@ -629,6 +629,14 @@ fn ensure_deployment_complete_does_not_abort_when_no_carrier_reachable() {
 }
 
 // ── #3455 "launch on main" opt-out ──────────────────────────────────────────
+//
+// The functions under test moved out of `lifecycle` into the sibling
+// `launch_on_main` module (500-SLOC cap on `lifecycle.rs`); their tests stay
+// here with the rest of the spawn-surface tests and reach them via the
+// managed_routes-scoped `pub(super)` path.
+use super::super::launch_on_main::{
+    has_concurrent_main_checkout_session, spawn_managed_on_main, worktree_enabled_for_origin,
+};
 
 /// A project with no registry entry (or no `worktree` field set) defaults to
 /// worktree isolation ON — the no-regression default #3455 requires.
@@ -764,5 +772,47 @@ async fn spawn_managed_on_main_creates_record_without_worktree() {
         record.source_id.as_deref(),
         Some("acme/writing"),
         "source_id must still be set so reconnect works normally"
+    );
+}
+
+/// The concurrent-collision detector `spawn_managed_on_main` warns on (#3455)
+/// fires ONLY for an already-`Active` session whose cwd is EXACTLY the same
+/// main checkout — a session on a different path, or a non-Active one on the
+/// same path, must not match. This is the pure core of the "two sessions on
+/// one main checkout, no worktree isolating them" WARN path.
+/// Test: itself.
+#[test]
+fn spawn_managed_on_main_warns_on_concurrent_main_checkout_session() {
+    let checkout = std::path::Path::new("/Users/op/projects/writing");
+    let other = std::path::Path::new("/Users/op/projects/other");
+
+    // An Active session already rooted at the SAME checkout → detected.
+    let mut same = stub_record(None, ManagedSessionState::Active, "tm-writing-01");
+    same.cwd = checkout.to_path_buf();
+    let found = has_concurrent_main_checkout_session(std::slice::from_ref(&same), checkout)
+        .expect("an Active session sharing the exact cwd must be detected");
+    assert_eq!(
+        found.tmux_name, "tm-writing-01",
+        "the detector must return the colliding record so the caller can name it"
+    );
+
+    // A DIFFERENT checkout path → no collision.
+    assert!(
+        has_concurrent_main_checkout_session(std::slice::from_ref(&same), other).is_none(),
+        "a session on a different checkout must never collide"
+    );
+
+    // Same path but NOT Active (e.g. Stopped) → no collision.
+    let mut stopped = stub_record(None, ManagedSessionState::Stopped, "tm-writing-02");
+    stopped.cwd = checkout.to_path_buf();
+    assert!(
+        has_concurrent_main_checkout_session(std::slice::from_ref(&stopped), checkout).is_none(),
+        "a non-Active session on the same checkout must not count as a live collision"
+    );
+
+    // Empty set → no collision.
+    assert!(
+        has_concurrent_main_checkout_session(&[], checkout).is_none(),
+        "no sessions means no collision"
     );
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
@@ -627,3 +627,142 @@ fn ensure_deployment_complete_does_not_abort_when_no_carrier_reachable() {
          (unrelated to the new carrier self-check); got {result:?}"
     );
 }
+
+// ── #3455 "launch on main" opt-out ──────────────────────────────────────────
+
+/// A project with no registry entry (or no `worktree` field set) defaults to
+/// worktree isolation ON — the no-regression default #3455 requires.
+/// Test: itself.
+#[tokio::test]
+async fn worktree_enabled_for_origin_defaults_true_when_unregistered() {
+    let data_root = tempfile::TempDir::new().expect("tmp data root");
+    let state = crate::daemon::state::DaemonState::with_root_isolated_managed(
+        data_root.path().to_path_buf(),
+    )
+    .await;
+    let registry = state.project_registry().await;
+
+    assert!(
+        worktree_enabled_for_origin(&registry, "https://github.com/acme/unregistered").await,
+        "an unregistered repo must default to worktree isolation ON"
+    );
+}
+
+/// A registered project with `worktree: Some(false)` disables isolation for
+/// its own `repo_url` only — a DIFFERENT repo is unaffected (#3455).
+/// Test: itself.
+#[tokio::test]
+async fn worktree_enabled_for_origin_honors_registered_false() {
+    let data_root = tempfile::TempDir::new().expect("tmp data root");
+    let state = crate::daemon::state::DaemonState::with_root_isolated_managed(
+        data_root.path().to_path_buf(),
+    )
+    .await;
+    let registry = state.project_registry().await;
+
+    registry
+        .register(crate::project::Project {
+            name: "writing".into(),
+            repo_url: "https://github.com/bobmatnyc/writing".into(),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            gh_account: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+            worktree: Some(false),
+        })
+        .await
+        .expect("register writing project");
+
+    assert!(
+        !worktree_enabled_for_origin(&registry, "https://github.com/bobmatnyc/writing.git").await,
+        "the registered project's opt-out must be honored (repo_url matching tolerates .git suffix)"
+    );
+    assert!(
+        worktree_enabled_for_origin(&registry, "https://github.com/bobmatnyc/trusty-tools").await,
+        "a DIFFERENT repo must be unaffected by another project's opt-out"
+    );
+}
+
+/// `spawn_managed_on_main` creates a normal `Active` session record rooted
+/// DIRECTLY at `local_path` — no worktree, no clone, `workspace_owned =
+/// false` so decommission never auto-deletes the operator's own checkout
+/// (#3455).
+/// Test: itself.
+#[tokio::test]
+async fn spawn_managed_on_main_creates_record_without_worktree() {
+    let data_root = tempfile::TempDir::new().expect("tmp data root");
+    let state = std::sync::Arc::new(
+        crate::daemon::state::DaemonState::with_root_isolated_managed(
+            data_root.path().to_path_buf(),
+        )
+        .await,
+    );
+
+    // The operator's own checkout — a real git repo, used directly, not cloned.
+    let checkout = tempfile::TempDir::new().expect("tmp checkout dir");
+    let local_path = checkout.path();
+    assert!(
+        std::process::Command::new("git")
+            .arg("init")
+            .current_dir(local_path)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false),
+        "git init must succeed in this test fixture"
+    );
+
+    let session_id = ManagedSessionId::new();
+    let params = SpawnParams {
+        repo_url: local_path.to_string_lossy().into_owned(),
+        git_ref: "main".into(),
+        task: "".into(),
+        name_hint: None,
+        runtime: None,
+        ephemeral: Some(true),
+        mcp_initiated: false,
+        inject_task: None,
+        deliverable_id: None,
+        force_new: false,
+    };
+
+    let record = spawn_managed_on_main(
+        &state,
+        &session_id,
+        &params,
+        crate::runtime::RuntimeKind::ClaudeCode,
+        local_path,
+        "acme",
+        "writing",
+    )
+    .await
+    .expect("spawn_managed_on_main must succeed against a real git repo");
+
+    assert_eq!(
+        record.cwd, local_path,
+        "the session cwd must be the main checkout itself, not a worktree"
+    );
+    assert_eq!(
+        record.workspace_path.as_deref(),
+        Some(local_path),
+        "workspace_path must point at the main checkout"
+    );
+    assert!(
+        !record.workspace_owned,
+        "workspace_owned must be false — decommission must never auto-delete \
+         the operator's own checkout"
+    );
+    assert!(
+        !local_path.join(".worktrees").exists(),
+        "no .worktrees/ directory must ever be created for a launch-on-main session"
+    );
+    assert_eq!(
+        record.source_id.as_deref(),
+        Some("acme/writing"),
+        "source_id must still be set so reconnect works normally"
+    );
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mcp_spawn_gate.rs
@@ -255,6 +255,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -33,6 +33,7 @@ mod fleet;
 pub mod front_gate;
 pub mod inproject;
 pub mod inproject_hygiene;
+mod launch_on_main;
 mod lifecycle;
 mod mcp_spawn_gate;
 mod project_registry_routes;

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_registry_routes.rs
@@ -73,6 +73,11 @@ pub struct RegisterProjectBody {
     /// resolved into `GH_TOKEN`/`GH_USER` at spawn time (#3025).
     #[serde(default)]
     pub gh_account: Option<String>,
+    /// "Launch on main" opt-out (#3455): `None`/`Some(true)` → default
+    /// worktree isolation; `Some(false)` → sessions run directly in the
+    /// resolved local checkout, no worktree.
+    #[serde(default)]
+    pub worktree: Option<bool>,
 }
 
 /// Response body for `GET /api/v1/projects`.
@@ -187,6 +192,12 @@ pub async fn register_project_registry_route(
         github: existing.as_ref().and_then(|p| p.github.clone()),
         commit_name: existing.as_ref().and_then(|p| p.commit_name.clone()),
         commit_email: existing.as_ref().and_then(|p| p.commit_email.clone()),
+        // #3455: mirrors the other optional fields' preserve-on-re-register
+        // fix (#3025 review item 4) — an absent body field never resets an
+        // existing worktree opt-out back to the default.
+        worktree: body
+            .worktree
+            .or_else(|| existing.as_ref().and_then(|p| p.worktree)),
     };
     if let Err(e) = registry.register(project.clone()).await {
         warn!(error = %e, project = %project.name, "register_project_registry_route: register failed");
@@ -310,6 +321,15 @@ pub struct PatchProjectBody {
     /// session spawn/relaunch — see [`crate::core::gh_account::resolve_gh_account_env`].
     #[serde(default, deserialize_with = "deserialize_double_option")]
     pub gh_account: Option<Option<String>>,
+    /// "Launch on main" opt-out (#3455): absent=unchanged, `true`/`false`=set.
+    /// Unlike the three `Option<String>` fields above this is a PLAIN
+    /// `Option<bool>` (single, not double) — there is no separate "clear"
+    /// story to express: the default state (`true`, worktree isolation ON)
+    /// is reachable by simply setting the value back to `true`, mirroring
+    /// `default_branch`'s "no clear story" precedent rather than adding an
+    /// `Unset` variant for a field with only two meaningful states.
+    #[serde(default)]
+    pub worktree: Option<bool>,
     /// Tags to add, deduplicated against the current set. Each entry is
     /// trimmed; a blank/whitespace-only entry rejects the WHOLE request with
     /// 400 (see [`trim_and_reject_blank_tags`]).
@@ -399,6 +419,7 @@ pub async fn patch_project_registry_route(
     let stack_hint = body.stack_hint;
     let gh_user = body.gh_user;
     let gh_account = body.gh_account;
+    let worktree = body.worktree;
 
     let registry = state.project_registry().await;
     let result = registry
@@ -420,6 +441,9 @@ pub async fn patch_project_registry_route(
             }
             if let Some(gh_account) = gh_account {
                 project.gh_account = gh_account;
+            }
+            if let Some(worktree) = worktree {
+                project.worktree = Some(worktree);
             }
             if let Some(add) = tags_add {
                 for tag in add {

--- a/crates/trusty-mpm/src/daemon/managed_routes/project_status/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/project_status/tests.rs
@@ -17,6 +17,7 @@ fn project(name: &str, repo_url: &str) -> Project {
         github: None,
         commit_name: None,
         commit_email: None,
+        worktree: None,
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/manager/route_task_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/route_task_tests.rs
@@ -18,6 +18,7 @@ fn project(name: &str) -> Project {
         github: None,
         commit_name: None,
         commit_email: None,
+        worktree: None,
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/manager/status_tests.rs
+++ b/crates/trusty-mpm/src/daemon/manager/status_tests.rs
@@ -33,6 +33,7 @@ fn project(name: &str) -> Project {
         github: None,
         commit_name: None,
         commit_email: None,
+        worktree: None,
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/mcp_console/tests.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_console/tests.rs
@@ -56,6 +56,7 @@ fn config_to_json_includes_github_and_projects() {
             commit_name: Some("Bot".into()),
             commit_email: None,
             untracked_sync: None,
+            worktree: None,
         }],
         ..Default::default()
     };
@@ -81,6 +82,7 @@ fn project(name: &str) -> trusty_tools_config::ProjectConfig {
         commit_name: None,
         commit_email: None,
         untracked_sync: None,
+        worktree: None,
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/mcp_project.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_project.rs
@@ -107,6 +107,10 @@ pub async fn project_register(
         github: existing.as_ref().and_then(|p| p.github.clone()),
         commit_name: existing.as_ref().and_then(|p| p.commit_name.clone()),
         commit_email: existing.as_ref().and_then(|p| p.commit_email.clone()),
+        // #3455: no param for this tool (set via `tm projects config` /
+        // `config_write` instead) — preserve any existing value rather than
+        // silently resetting it back to worktree-ON.
+        worktree: existing.as_ref().and_then(|p| p.worktree),
     };
     registry
         .register(project.clone())

--- a/crates/trusty-mpm/src/project/record.rs
+++ b/crates/trusty-mpm/src/project/record.rs
@@ -138,6 +138,44 @@ pub struct Project {
     /// Test: `project_serde_round_trip`, `project_without_optionals`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub commit_email: Option<String>,
+
+    /// Whether managed sessions for this project provision an isolated
+    /// per-session git worktree (#3455 — "launch on main" opt-out).
+    ///
+    /// Why: `tm` unconditionally provisions a `.worktrees/<session>` git
+    /// worktree on a `session/<name>` branch for every managed session,
+    /// which is exactly wrong for a project with a direct-main workflow (no
+    /// PR flow, no isolation requirement) — the worktree sits unused at a
+    /// stale commit, the session's cwd points away from the real checkout,
+    /// and agents must `cd` out of it on every command.
+    /// What: `None`/`Some(true)` → default, no regression: every session
+    /// gets its own worktree exactly as before. `Some(false)` → the matched
+    /// project's managed sessions run directly in the resolved local
+    /// checkout instead — no clone, no worktree, no dedicated branch. See
+    /// [`Self::worktree_enabled`] for the resolved-default accessor and
+    /// `daemon::managed_routes::lifecycle::spawn_managed_on_main` for the
+    /// runtime effect. **Caveat**: unlike a worktree, the live checkout is
+    /// NOT isolated — running more than one session against it concurrently
+    /// is a real hazard (uncommitted-change races, concurrent git
+    /// operations); the spawn path warns (never refuses) when a second
+    /// Active session targets the same checkout.
+    /// Test: `project_serde_round_trip`, `project_without_optionals`,
+    /// `worktree_enabled_defaults_true`, `worktree_enabled_honors_false`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<bool>,
+}
+
+impl Project {
+    /// Resolve this project's effective worktree-isolation setting (#3455).
+    ///
+    /// Why: the single place callers ask "should THIS project's sessions get
+    /// a per-session worktree?" so the `None` → `true` default (no
+    /// regression) is asserted in exactly one spot.
+    /// What: `self.worktree.unwrap_or(true)`.
+    /// Test: `worktree_enabled_defaults_true`, `worktree_enabled_honors_false`.
+    pub fn worktree_enabled(&self) -> bool {
+        self.worktree.unwrap_or(true)
+    }
 }
 
 /// Compare two repository URLs for identity, tolerating scheme/`.git`/
@@ -239,6 +277,7 @@ mod tests {
             }),
             commit_name: Some("Bob".into()),
             commit_email: Some("bob@example.com".into()),
+            worktree: Some(false),
         };
         let json = serde_json::to_string(&p).expect("serialize");
         assert!(json.contains("gh_user"), "json: {json}");
@@ -246,6 +285,7 @@ mod tests {
         assert!(json.contains("github"), "json: {json}");
         assert!(json.contains("commit_name"), "json: {json}");
         assert!(json.contains("commit_email"), "json: {json}");
+        assert!(json.contains("worktree"), "json: {json}");
         let back: Project = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(p, back);
     }
@@ -265,11 +305,16 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         };
         let json = serde_json::to_string(&p).expect("serialize");
         assert!(
             !json.contains("stack_hint"),
             "absent optional must not serialise: {json}"
+        );
+        assert!(
+            !json.contains("worktree"),
+            "absent worktree must not serialise: {json}"
         );
         assert!(
             !json.contains("gh_user"),
@@ -391,5 +436,37 @@ mod tests {
     fn derive_name_from_url_no_path() {
         // A bare host with no path segment has no valid name.
         assert_eq!(derive_name_from_url("https://github.com/"), None);
+    }
+
+    fn minimal_project() -> Project {
+        Project {
+            name: "widget".into(),
+            repo_url: "https://github.com/acme/widget".into(),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            gh_account: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+            worktree: None,
+        }
+    }
+
+    /// Why (#3455): a project that has never set `worktree` must keep the
+    /// pre-#3455 behaviour — every session gets its own worktree.
+    #[test]
+    fn worktree_enabled_defaults_true() {
+        assert!(minimal_project().worktree_enabled());
+    }
+
+    /// Why (#3455): `worktree: Some(false)` is the "launch on main" opt-out.
+    #[test]
+    fn worktree_enabled_honors_false() {
+        let mut p = minimal_project();
+        p.worktree = Some(false);
+        assert!(!p.worktree_enabled());
     }
 }

--- a/crates/trusty-mpm/src/project/registry.rs
+++ b/crates/trusty-mpm/src/project/registry.rs
@@ -164,6 +164,11 @@ impl ProjectRegistry {
                 github: entry.github.clone(),
                 commit_name: entry.commit_name.clone(),
                 commit_email: entry.commit_email.clone(),
+                // #3455: mirror the static "launch on main" opt-out so a
+                // project declared with `worktree: false` in config.yaml is
+                // seeded with the setting already in effect, no separate
+                // `tm projects config` call required.
+                worktree: entry.worktree,
             };
             let name = project.name.clone();
             if let Err(e) = self.register(project).await {
@@ -227,6 +232,8 @@ impl ProjectRegistry {
                 github: None,
                 commit_name: None,
                 commit_email: None,
+                // #3455: no declared preference; defaults to worktree-ON.
+                worktree: None,
             };
             if let Err(e) = self.register(project).await {
                 warn!(name = %name, "auto_register: failed to register: {e}");
@@ -320,6 +327,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         };
         registry.register(p.clone()).await.expect("register once");
         registry
@@ -348,6 +356,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         };
         registry.register(p.clone()).await.expect("register");
 
@@ -374,6 +383,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         }
     }
 
@@ -524,6 +534,7 @@ mod tests {
                 github: None,
                 commit_name: None,
                 commit_email: None,
+                worktree: None,
             };
             registry.register(p).await.expect("register");
         }
@@ -556,6 +567,7 @@ mod tests {
                 commit_name: Some("ML Bot".into()),
                 commit_email: Some("ml-bot@example.com".into()),
                 untracked_sync: None,
+                worktree: None,
             },
             ProjectConfig {
                 name: "from-config-b".into(),
@@ -570,6 +582,7 @@ mod tests {
                 commit_name: None,
                 commit_email: None,
                 untracked_sync: None,
+                worktree: None,
             },
         ];
 
@@ -656,6 +669,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         };
         registry.register(existing).await.expect("pre-register");
 

--- a/crates/trusty-mpm/src/project/resolver/tests.rs
+++ b/crates/trusty-mpm/src/project/resolver/tests.rs
@@ -27,6 +27,7 @@ fn proj(name: &str, repo_url: &str) -> Project {
         github: None,
         commit_name: None,
         commit_email: None,
+        worktree: None,
     }
 }
 
@@ -43,6 +44,7 @@ fn proj_tagged(name: &str, repo_url: &str, tags: &[&str], desc: &str) -> Project
         github: None,
         commit_name: None,
         commit_email: None,
+        worktree: None,
     }
 }
 

--- a/crates/trusty-mpm/src/project/store.rs
+++ b/crates/trusty-mpm/src/project/store.rs
@@ -253,6 +253,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         }
     }
 
@@ -373,6 +374,7 @@ mod tests {
             }),
             commit_name: Some("Full Bot".into()),
             commit_email: Some("full-bot@example.com".into()),
+            worktree: None,
         };
         store.upsert(full.clone()).await.expect("upsert full");
 

--- a/crates/trusty-mpm/src/project_config.rs
+++ b/crates/trusty-mpm/src/project_config.rs
@@ -55,6 +55,10 @@ pub enum ConfigField {
     /// `gh_user` — double-Option field, clearable (#2081; deep `gh auth
     /// status` validation deferred to #2121, out of scope here).
     GhUser,
+    /// `worktree` — plain `bool`, no clear story (#3455; mirrors
+    /// `DefaultBranch`'s precedent — see [`ClearableField`]'s doc). Value is
+    /// carried as the string `"true"`/`"false"`; [`apply_edit`] parses it.
+    Worktree,
 }
 
 /// A field that can be UNSET (cleared) via `tm projects config <name> unset
@@ -123,6 +127,13 @@ fn apply_edit(args: &mut PatchProjectArgs, edit: &ConfigEdit) {
         ConfigEdit::Set(ConfigField::Description, v) => args.description = Some(Some(v.clone())),
         ConfigEdit::Set(ConfigField::StackHint, v) => args.stack_hint = Some(Some(v.clone())),
         ConfigEdit::Set(ConfigField::GhUser, v) => args.gh_user = Some(Some(v.clone())),
+        // #3455: the CLI (`registry::config`) and the TUI form both
+        // guarantee `v` is exactly "true"/"false" before ever building this
+        // edit (see their own validation), so a case-insensitive compare
+        // against "true" is a safe, total conversion here.
+        ConfigEdit::Set(ConfigField::Worktree, v) => {
+            args.worktree = Some(v.eq_ignore_ascii_case("true"))
+        }
         ConfigEdit::Unset(ClearableField::Description) => args.description = Some(None),
         ConfigEdit::Unset(ClearableField::StackHint) => args.stack_hint = Some(None),
         ConfigEdit::Unset(ClearableField::GhUser) => args.gh_user = Some(None),
@@ -370,6 +381,17 @@ mod tests {
         assert_eq!(args.stack_hint, Some(Some("rust".to_string())));
         assert_eq!(args.description, Some(None));
         assert!(args.default_branch.is_none());
+    }
+
+    /// #3455: `Set(Worktree, "false"/"true")` builds a plain `Some(bool)` —
+    /// never the double-`Option` shape the string fields use.
+    #[test]
+    fn build_patch_args_worktree_set_true_false() {
+        let off = build_patch_args(&ConfigEdit::Set(ConfigField::Worktree, "false".to_string()));
+        assert_eq!(off.worktree, Some(false));
+
+        let on = build_patch_args(&ConfigEdit::Set(ConfigField::Worktree, "true".to_string()));
+        assert_eq!(on.worktree, Some(true));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/tui/project_ctl/events/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/events/tests.rs
@@ -43,6 +43,7 @@ fn full_project(name: &str) -> crate::project::Project {
         github: None,
         commit_name: None,
         commit_email: None,
+        worktree: None,
     }
 }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/panes/config_form.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/panes/config_form.rs
@@ -156,6 +156,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
@@ -190,6 +190,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         }
     }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/state/modals.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/state/modals.rs
@@ -455,6 +455,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         }
     }
 
@@ -609,6 +610,7 @@ mod tests {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         }
     }
 
@@ -643,6 +645,11 @@ mod tests {
             ConfigEdit::Set(ConfigField::Description, v) => form.description.value = v.clone(),
             ConfigEdit::Set(ConfigField::StackHint, v) => form.stack_hint.value = v.clone(),
             ConfigEdit::Set(ConfigField::GhUser, v) => form.gh_user.value = v.clone(),
+            // #3455: `worktree` has no TUI form row (CLI-only per the issue's
+            // scope) and `config_edit_cases()` carries no Worktree case, so
+            // this arm is unreachable from `config_form_shared_cases_match_tui_diff`
+            // today — present only so the match stays exhaustive.
+            ConfigEdit::Set(ConfigField::Worktree, _) => {}
             ConfigEdit::Unset(ClearableField::Description) => form.description.value.clear(),
             ConfigEdit::Unset(ClearableField::StackHint) => form.stack_hint.value.clear(),
             ConfigEdit::Unset(ClearableField::GhUser) => form.gh_user.value.clear(),

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -31,6 +31,7 @@ fn project(name: &str) -> Project {
         github: None,
         commit_name: None,
         commit_email: None,
+        worktree: None,
     }
 }
 

--- a/crates/trusty-mpm/tests/manager_cli_client.rs
+++ b/crates/trusty-mpm/tests/manager_cli_client.rs
@@ -87,6 +87,7 @@ async fn register_project(state: &Arc<DaemonState>, name: &str, repo_url: &str) 
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         })
         .await
         .expect("register project");

--- a/crates/trusty-mpm/tests/manager_inference.rs
+++ b/crates/trusty-mpm/tests/manager_inference.rs
@@ -69,6 +69,7 @@ async fn register_project(state: &Arc<DaemonState>, name: &str, repo_url: &str) 
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         })
         .await
         .expect("register project");

--- a/crates/trusty-mpm/tests/manager_routes.rs
+++ b/crates/trusty-mpm/tests/manager_routes.rs
@@ -52,6 +52,7 @@ async fn register_project(state: &Arc<DaemonState>, name: &str, repo_url: &str) 
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         })
         .await
         .expect("register project");

--- a/crates/trusty-mpm/tests/manager_routing.rs
+++ b/crates/trusty-mpm/tests/manager_routing.rs
@@ -69,6 +69,7 @@ async fn register_project(state: &Arc<DaemonState>, name: &str, tags: &[&str]) {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         })
         .await
         .expect("register project");

--- a/crates/trusty-mpm/tests/mcp_spawn_gate.rs
+++ b/crates/trusty-mpm/tests/mcp_spawn_gate.rs
@@ -193,6 +193,7 @@ async fn mcp_initiated_spawn_rejects_repo_name_impersonation() {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         })
         .await
         .expect("register legitimate project");
@@ -256,6 +257,7 @@ async fn mcp_initiated_spawn_allowed_for_registered_project_reaches_provisioning
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         })
         .await
         .expect("register project");

--- a/crates/trusty-mpm/tests/project_registry_routes.rs
+++ b/crates/trusty-mpm/tests/project_registry_routes.rs
@@ -78,6 +78,7 @@ async fn register_get_list_status_round_trip() {
         stack_hint: Some("rust".into()),
         gh_user: Some("acme-bot".into()),
         gh_account: None,
+        worktree: None,
     };
     let registered = client.registry_register_project(&args).await.unwrap();
     assert_eq!(registered.name, "widget");
@@ -131,6 +132,7 @@ async fn register_is_idempotent_upsert() {
         stack_hint: None,
         gh_user: None,
         gh_account: None,
+        worktree: None,
     };
     client.registry_register_project(&base).await.unwrap();
     // Re-register with a different branch — upsert on name, not a duplicate.
@@ -160,6 +162,7 @@ async fn register_preserves_unspecified_optional_fields_on_existing_project() {
             stack_hint: Some("rust".into()),
             gh_user: Some("bobmatnyc".into()),
             gh_account: None,
+            worktree: None,
         })
         .await
         .expect("initial register");
@@ -176,6 +179,7 @@ async fn register_preserves_unspecified_optional_fields_on_existing_project() {
             stack_hint: None,
             gh_user: None,
             gh_account: Some("bob-work".into()),
+            worktree: None,
         })
         .await
         .expect("gh_account-only re-register");
@@ -219,6 +223,7 @@ async fn register_explicit_fields_still_override_existing() {
             stack_hint: Some("rust".into()),
             gh_user: Some("bobmatnyc".into()),
             gh_account: Some("bobmatnyc".into()),
+            worktree: None,
         })
         .await
         .expect("initial register");
@@ -233,6 +238,7 @@ async fn register_explicit_fields_still_override_existing() {
             stack_hint: Some("python".into()),
             gh_user: Some("bob-work".into()),
             gh_account: Some("bob-work".into()),
+            worktree: None,
         })
         .await
         .expect("overriding re-register");
@@ -279,6 +285,7 @@ async fn register_preserves_identity_binding_not_expressible_in_body() {
             }),
             commit_name: Some("Bob".into()),
             commit_email: Some("bob@example.com".into()),
+            worktree: None,
         })
         .await
         .expect("seed project with identity binding");
@@ -295,6 +302,7 @@ async fn register_preserves_identity_binding_not_expressible_in_body() {
             stack_hint: None,
             gh_user: None,
             gh_account: None,
+            worktree: None,
         })
         .await
         .unwrap();
@@ -357,6 +365,7 @@ async fn patch_round_trip_updates_fields() {
             stack_hint: Some("rust".into()),
             gh_user: Some("acme-bot".into()),
             gh_account: None,
+            worktree: None,
         })
         .await
         .unwrap();
@@ -406,6 +415,7 @@ async fn patch_absent_fields_untouched() {
             stack_hint: Some("rust".into()),
             gh_user: Some("acme-bot".into()),
             gh_account: None,
+            worktree: None,
         })
         .await
         .unwrap();
@@ -477,6 +487,7 @@ async fn patch_rejects_blank_repo_url_surfaces_server_message() {
             stack_hint: None,
             gh_user: None,
             gh_account: None,
+            worktree: None,
         })
         .await
         .unwrap();
@@ -511,6 +522,7 @@ async fn patch_rejects_name_change() {
             stack_hint: None,
             gh_user: None,
             gh_account: None,
+            worktree: None,
         })
         .await
         .unwrap();
@@ -547,6 +559,7 @@ async fn patch_is_idempotent() {
             stack_hint: None,
             gh_user: None,
             gh_account: None,
+            worktree: None,
         })
         .await
         .unwrap();
@@ -591,6 +604,7 @@ async fn patch_rejects_blank_tags_add() {
             stack_hint: None,
             gh_user: None,
             gh_account: None,
+            worktree: None,
         })
         .await
         .unwrap();
@@ -622,6 +636,7 @@ async fn patch_rejects_blank_tags_remove() {
             stack_hint: None,
             gh_user: None,
             gh_account: None,
+            worktree: None,
         })
         .await
         .unwrap();
@@ -654,6 +669,7 @@ async fn patch_trims_tags_add_whitespace() {
             stack_hint: None,
             gh_user: None,
             gh_account: None,
+            worktree: None,
         })
         .await
         .unwrap();
@@ -669,6 +685,103 @@ async fn patch_trims_tags_add_whitespace() {
         .await
         .unwrap();
     assert_eq!(patched.tags, vec!["rust".to_string()]);
+}
+
+/// register → patch worktree:false → get round-trips the #3455 "launch on
+/// main" opt-out, and a follow-up patch back to `true` reflects the reversal
+/// too — the plain (single) `Option<bool>` field, unlike the double-Option
+/// string fields, has no separate "unset" wire form.
+#[tokio::test]
+async fn patch_round_trips_worktree_opt_out() {
+    let client = serve().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "writing".into(),
+            repo_url: "https://github.com/bobmatnyc/writing".into(),
+            default_branch: None,
+            description: None,
+            tags: None,
+            stack_hint: None,
+            gh_user: None,
+            gh_account: None,
+            worktree: None,
+        })
+        .await
+        .unwrap();
+
+    // Default (never set): worktree isolation is ON.
+    let fetched = client.registry_get_project("writing").await.unwrap();
+    assert!(fetched.worktree_enabled());
+
+    // PATCH to false — the "launch on main" opt-out.
+    let patched = client
+        .registry_patch_project(
+            "writing",
+            &PatchProjectArgs {
+                worktree: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(!patched.worktree_enabled());
+    let refetched = client.registry_get_project("writing").await.unwrap();
+    assert!(!refetched.worktree_enabled());
+
+    // PATCH back to true — reversible, not a one-way door.
+    let reverted = client
+        .registry_patch_project(
+            "writing",
+            &PatchProjectArgs {
+                worktree: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(reverted.worktree_enabled());
+}
+
+/// A `POST /api/v1/projects` re-register with no `worktree` field must
+/// PRESERVE an existing opt-out rather than silently resetting it (#3455,
+/// mirrors the #3025 review's identical fix for `gh_account`/etc.).
+#[tokio::test]
+async fn register_preserves_worktree_opt_out_when_absent() {
+    let client = serve().await;
+    client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "writing".into(),
+            repo_url: "https://github.com/bobmatnyc/writing".into(),
+            default_branch: None,
+            description: None,
+            tags: None,
+            stack_hint: None,
+            gh_user: None,
+            gh_account: None,
+            worktree: Some(false),
+        })
+        .await
+        .unwrap();
+
+    // Re-register WITHOUT worktree set — must not reset it back to ON.
+    let reregistered = client
+        .registry_register_project(&RegisterProjectArgs {
+            name: "writing".into(),
+            repo_url: "https://github.com/bobmatnyc/writing".into(),
+            default_branch: Some("develop".into()),
+            description: None,
+            tags: None,
+            stack_hint: None,
+            gh_user: None,
+            gh_account: None,
+            worktree: None,
+        })
+        .await
+        .unwrap();
+    assert!(
+        !reregistered.worktree_enabled(),
+        "an absent `worktree` field on re-register must preserve the existing opt-out"
+    );
 }
 
 /// Deliverable create → list → set-status legal → illegal-409 round-trips, and

--- a/crates/trusty-mpm/tests/project_status_route.rs
+++ b/crates/trusty-mpm/tests/project_status_route.rs
@@ -52,6 +52,7 @@ async fn register_project(
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         })
         .await
         .expect("register project");

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -2041,6 +2041,7 @@ async fn fleet_route_marks_dead_session_unresumable() {
             github: None,
             commit_name: None,
             commit_email: None,
+            worktree: None,
         })
         .await
         .expect("register project");


### PR DESCRIPTION
## Summary

- Adds a `worktree: Option<bool>` field to the registry-B `Project` record (default unset = worktree-ON, no regression). Resolved at spawn time by matching the local checkout's git origin against the registry (mirrors the existing `gh_account` pinning lookup), not the static `config.yaml` (which only ever seeds the registry).
- When disabled, `spawn_managed_routed` skips `try_inproject_spawn`'s base-clone-plus-worktree path entirely (checked BEFORE that call so no base clone is even created) and routes to a new `spawn_managed_on_main`: a normal managed session spawned directly in the resolved local checkout — no clone, no `.worktrees/`, no `session/<name>` branch, `workspace_owned = false` so decommission never touches the operator's directory.
- Settable via `tm projects config <name> set worktree true|false` (new PATCH field, view renders the resolved state) or declaratively via `config.yaml`'s `projects[].worktree` (mirrored into the registry by `seed_from_config`).
- Collision caveat: a second `Active` session landing on the identical main checkout (only reachable via `--force-new`, since the normal reconnect pre-flight already prevents it in the ordinary case) logs a `warn!` naming the hazard but is never refused.

## Design decisions (flagged per the issue for redirect)

1. **Field placement**: registry-B `Project` record (issue's Option 1), not a new session-config surface — WI-2's `trusty-common::Project`/`canonical_root` extraction (#1517) hasn't landed yet, so this lives in `trusty-mpm::project::registry` today and migrates with the struct when WI-2 does.
2. **Concurrent-session-on-main semantics**: WARN, never refuse — matches the existing `force_new` "operator explicitly asked for it" precedent rather than adding a new refusal path.

## Test plan

- [x] `cargo test -p trusty-mpm` (full suite, all binaries) — 3554 + 1213×2 + … all passing, 0 failed
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-mpm --check` — clean
- [x] New tests: `Project::worktree_enabled` defaults/override, `worktree_enabled_for_origin` registry resolution (unregistered → true, registered false → honored, doesn't leak to other repos), `spawn_managed_on_main_creates_record_without_worktree` (full spawn against a real git repo — asserts no `.worktrees/` dir, `workspace_owned=false`, cwd = the main checkout), CLI parse round-trip (`set worktree false` / `unset worktree` rejected at parse time), PATCH/register HTTP round-trip + preserve-on-re-register

Closes #3455

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools