### PR TITLE
feat(trusty-sld-lint): read-only bidirectional SLD gap report (#595 slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11880,6 +11880,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "regex",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "trusty-common",

--- a/crates/trusty-sld-lint/CHANGELOG.md
+++ b/crates/trusty-sld-lint/CHANGELOG.md
@@ -9,6 +9,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `sld-lint gap-report [--json] [--strict]`: a read-only, index-free, LLM-free bidirectional SLD traceability gap report — slice 1 of 6 for issue [#595](https://github.com/bobmatnyc/trusty-tools/issues/595) (backfill epic). Targets the DOC-38 grammar as shipped (`# Spec References` / `spec_refs:`), not the issue's original superseded WWL/OpenFastTrace vocabulary.
+  - **Backward gaps:** public code units (`pub fn`/`struct`/`enum`/`trait`/`type`/`static`/`mod` in Rust; module-level `def`/`class` in Python; `export function`/`class`/`interface`/`type`/`enum`/`const` in TS/JS) detected via a lightweight, deterministic per-language regex scan (no AST, no code index) with no directly preceding `# Spec References` declaration.
+  - **Forward gaps:** anchored spec sections under `docs/specs/**` (`{#SPEC-…}`) with no inbound code (`# Spec References`) link.
+  - **Broken references:** folds in the existing reference-resolution diagnostics (`ref-*`/`frontmatter-schema`) so the report is one coherent picture.
+  - **Report-only by default:** exits 0 regardless of findings unless `--strict` is passed — this is a read-only report, not a gate, so it can never unexpectedly break CI.
+  - Suggest/report only — writes no source files and calls no LLM.
 - Initial release: `sld-lint`, the Spec-Linked Documentation (DOC-38) linter — substantially delivers DOC-38 §10 follow-up **F1** ([#2854](https://github.com/bobmatnyc/trusty-tools/issues/2854)).
   - **Reference resolution (always, everywhere in scope):** every declared reference — inline `# Spec References` blocks across `crates/**` and `spec_refs:` frontmatter in `docs/specs/**/*.md` — must resolve (repo-root-relative path exists AND a matching `{#SPEC-…}` anchor exists, revision-tolerant); the anchor must equal its id (§2.1 self-check); paths may not traverse via `..`; frontmatter must be schema-valid (§2.5).
   - **Spec-document conventions (opted-in specs by default, ALL specs under `--strict`):** the bold-field header block (§4.2), the catalog-row requirement (§4.5), `{#SPEC-…}` anchor grammar and anchor↔`**ID:**` agreement (§4.3).

--- a/crates/trusty-sld-lint/Cargo.toml
+++ b/crates/trusty-sld-lint/Cargo.toml
@@ -32,6 +32,13 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 thiserror = { workspace = true }
 walkdir = { workspace = true }
+# Public-item symbol scan for the gap-report subcommand (issue #595 slice 1);
+# already a transitive dependency via trusty-common's `sld` feature.
+regex = { workspace = true }
+# gap-report `--json` output; the version resolved is shared with the rest of
+# the workspace, no new dependency added to the build graph.
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/trusty-sld-lint/src/gap.rs
+++ b/crates/trusty-sld-lint/src/gap.rs
@@ -141,7 +141,7 @@ impl GapReport {
     /// What: `backward_gaps` and `forward_gaps` are both empty, and no
     /// `broken_references` entry is `Severity::Error` (advisories, e.g.
     /// `ref-revision-drift`, never fail).
-    /// Test: `super::tests::gap_is_strict_clean`.
+    /// Test: `super::tests::gap_is_strict_clean_ignores_advisory_severity`.
     #[must_use]
     pub fn is_strict_clean(&self) -> bool {
         self.backward_gaps.is_empty()

--- a/crates/trusty-sld-lint/src/gap.rs
+++ b/crates/trusty-sld-lint/src/gap.rs
@@ -27,12 +27,18 @@
 //! - Module-level units (crate/file doc blocks) are not tracked separately —
 //!   only explicit `pub fn`/`struct`/`enum`/`trait`/`type`/`static`/`mod`
 //!   declarations (or their Python/TS/JS equivalents) count as a code unit.
-//! - A unit's "coverage window" runs from the previous unit's line (or file
-//!   start) to just above the unit itself; a crate-level doc block therefore
-//!   credits the FIRST unit in a file even when the block is really
-//!   module-level, not that unit's own documentation. This avoids double-
-//!   penalizing module-level linkage as a per-symbol gap and is a conservative
-//!   (fewer false positives) choice.
+//! - A unit is "covered" only by a reference inside the CONTIGUOUS
+//!   comment/docstring run immediately above its own declaration line — not
+//!   by any reference anywhere between the previous unit and this one. This
+//!   mirrors rustdoc's own attachment rule (a doc comment separated from its
+//!   item by a blank line is not attached to it either) and specifically
+//!   avoids a large struct/enum body's own reference block being mistaken for
+//!   the linkage of the NEXT, unrelated `pub fn` that happens to follow it.
+//!   See [`preceding_doc_block_start`].
+//! - Because coverage looks only ABOVE the unit, a language whose idiomatic
+//!   doc form sits BELOW/inside the declaration (e.g. a Python docstring as
+//!   the function body's first statement) is not recognised as covering that
+//!   unit — a documented false-positive-gap risk for that idiom in slice 1.
 //! - Detection is line-oriented regex, not an AST: multi-line signatures,
 //!   macro-generated items, and `pub(crate)`/`pub(super)` (intentionally
 //!   excluded — only crate-external `pub` counts as a "public" unit) are out of
@@ -53,7 +59,9 @@ use regex::Regex;
 use serde::Serialize;
 
 use trusty_common::sld::Reference;
-use trusty_common::sld::{base_id, parse_inline_refs, spec_anchors, syntax_for_extension};
+use trusty_common::sld::{
+    base_id, parse_inline_refs, spec_anchors, syntax_for_extension, CommentSyntax,
+};
 
 use crate::checks;
 use crate::discover;
@@ -340,36 +348,113 @@ pub fn detect_units(path: &str, content: &str, ext: &str) -> Vec<CodeUnit> {
     out
 }
 
+/// True when a trimmed line is comment/docstring content under `syntax`.
+///
+/// Why: [`preceding_doc_block_start`] walks upward from a unit's declaration
+/// line and must know, per line, whether it is still inside a comment or
+/// docstring region — a coarser question than [`parse_inline_refs`]'s (which
+/// also tracks the `# Spec References` marker and fenced code within it). This
+/// mirrors the block/docstring open-close tracking `trusty_common::sld::inline`
+/// applies internally, at the granularity this module needs: "is this line
+/// comment content at all?"
+/// What: for a block/docstring language (`syntax.block` is `Some`), tracks
+/// `in_doc` across calls (threaded through `in_doc`) — a line inside an open
+/// block, or one that opens/closes one, counts as comment content; otherwise
+/// falls back to [`CommentSyntax::strip_line_comment`]. A blank line is never
+/// comment content (a real doc comment or docstring line always carries its
+/// own delimiter/prefix), which is what breaks contiguity at a blank
+/// separator line.
+/// Test: covered by `super::tests::gap_preceding_doc_block_*`.
+pub(crate) fn is_comment_line(trimmed: &str, syntax: &CommentSyntax, in_doc: &mut bool) -> bool {
+    if let Some((open, close)) = syntax.block {
+        if *in_doc {
+            if trimmed.contains(close) {
+                *in_doc = false;
+            }
+            return true;
+        }
+        if let Some(idx) = trimmed.find(open) {
+            let after = &trimmed[idx + open.len()..];
+            *in_doc = !after.contains(close);
+            return true;
+        }
+    }
+    syntax.strip_line_comment(trimmed).is_some()
+}
+
+/// Find the first line of the contiguous comment/docstring run directly above
+/// `unit_line` (1-based), or `unit_line` itself when there is none.
+///
+/// Why: the backward-gap fix (issue #595 PR #3783 review) — a unit is
+/// "documented" only by its OWN immediately preceding doc block, never by a
+/// reference that happens to sit anywhere between the previous unit and this
+/// one (that previously let an unrelated `pub fn` following a large
+/// documented `struct`'s body inherit that struct's coverage). Determining
+/// comment-ness requires a forward scan from the top of the file (docstring
+/// open/close is stateful), even though this function reports upward from
+/// `unit_line`.
+/// What: scans `content` top-to-bottom tracking [`is_comment_line`] per line;
+/// returns the earliest line of the maximal contiguous comment run ending
+/// immediately at `unit_line - 1`, or `unit_line` when line `unit_line - 1`
+/// is not comment content (no preceding block at all) or `unit_line <= 1`.
+/// Test: `super::tests::gap_preceding_doc_block_contiguous_run`,
+/// `gap_preceding_doc_block_stops_at_blank_line`,
+/// `gap_preceding_doc_block_none_when_no_comment_directly_above`.
+#[must_use]
+pub(crate) fn preceding_doc_block_start(
+    content: &str,
+    unit_line: usize,
+    syntax: &CommentSyntax,
+) -> usize {
+    if unit_line <= 1 {
+        return unit_line;
+    }
+    let mut in_doc = false;
+    let mut run_start: Option<usize> = None;
+    for (idx, raw) in content.lines().enumerate() {
+        let line = idx + 1;
+        if line >= unit_line {
+            break;
+        }
+        if is_comment_line(raw.trim_start(), syntax, &mut in_doc) {
+            run_start.get_or_insert(line);
+        } else {
+            run_start = None;
+        }
+    }
+    // `run_start` only survives if the run reached all the way to `unit_line - 1`.
+    run_start.unwrap_or(unit_line)
+}
+
 /// Find units in `units` (file order) with no directly preceding spec reference.
 ///
-/// Why: a unit is "linked" when its own `# Spec References` block declares at
-/// least one reference; since [`trusty_common::sld::parse_inline_refs`] already
-/// gives each reference's line, "directly preceding" is checked with a
-/// coverage window rather than requiring a second parse pass over the raw
-/// text.
-/// What: for each unit (assumed sorted by `line`, as [`detect_units`]
-/// produces), the window is `(previous unit's line, this unit's line)`
-/// exclusive-exclusive (or `(0, line)` for the first unit) — i.e. every line
-/// strictly between the previous unit and this one. A unit is a gap when no
-/// `refs` entry's line falls in that window. See this module's doc comment for
-/// the documented limitation that a leading crate/module-level doc block
-/// credits the FIRST unit in the file.
+/// Why: a unit is "linked" when a reference is declared in the contiguous
+/// comment/doc block immediately above its OWN declaration — not merely
+/// somewhere after the previous unit (see [`preceding_doc_block_start`]'s doc
+/// comment for the bug this fixes).
+/// What: for each unit, computes its [`preceding_doc_block_start`] and flags
+/// it as a gap when no `refs` entry's line falls in
+/// `[block_start, unit.line)`.
 /// Test: `super::tests::gap_backward_gaps_flags_undocumented_unit`,
-/// `gap_backward_gaps_clears_documented_unit`.
+/// `gap_backward_gaps_clears_documented_unit`,
+/// `gap_backward_gaps_ref_inside_previous_unit_body_does_not_cover_next_unit`.
 #[must_use]
-pub fn backward_gaps(units: &[CodeUnit], refs: &[Reference]) -> Vec<CodeUnit> {
-    let mut gaps = Vec::new();
-    let mut window_start = 0usize;
-    for unit in units {
-        let covered = refs
-            .iter()
-            .any(|r| r.line > window_start && r.line < unit.line);
-        if !covered {
-            gaps.push(unit.clone());
-        }
-        window_start = unit.line;
-    }
-    gaps
+pub fn backward_gaps(
+    content: &str,
+    syntax: &CommentSyntax,
+    units: &[CodeUnit],
+    refs: &[Reference],
+) -> Vec<CodeUnit> {
+    units
+        .iter()
+        .filter(|unit| {
+            let block_start = preceding_doc_block_start(content, unit.line, syntax);
+            !refs
+                .iter()
+                .any(|r| r.line >= block_start && r.line < unit.line)
+        })
+        .cloned()
+        .collect()
 }
 
 /// Run the full bidirectional gap report over a repository checkout.
@@ -417,7 +502,9 @@ pub fn run_gap_report(root: &Path) -> GapReport {
 
         let units = detect_units(&path, &content, ext);
         report.units_scanned += units.len();
-        report.backward_gaps.extend(backward_gaps(&units, &refs));
+        report
+            .backward_gaps
+            .extend(backward_gaps(&content, &syntax, &units, &refs));
     }
 
     for rel in &discovered.spec_docs {

--- a/crates/trusty-sld-lint/src/gap.rs
+++ b/crates/trusty-sld-lint/src/gap.rs
@@ -1,0 +1,447 @@
+//! Bidirectional SLD traceability gap report (issue #595 slice 1).
+//!
+//! Why: DOC-38 fixes the reference grammar and lets [`crate::checks`] resolve
+//! each *declared* link, but a declared-links-only resolver (§1.2 G4) can never
+//! answer "what is NOT yet declared?" — that requires actively enumerating both
+//! sides of the traceability relationship (code units and spec sections) and
+//! set-differencing them against what IS declared. Issue #595 scopes this as a
+//! read-only, index-free, LLM-free report: slice 1 of a 6-slice epic. It
+//! deliberately targets the DOC-38 grammar as shipped (`# Spec References` /
+//! `spec_refs:`), not the issue's original superseded WWL/OpenFastTrace
+//! four-status vocabulary.
+//!
+//! What: [`detect_units`] is a lightweight, deterministic, per-language regex
+//! scan for public code-unit declarations (no AST, no code index — a pragmatic
+//! symbol scan is explicitly sufficient for slice 1). [`backward_gaps`] pairs
+//! those units against a file's already-parsed [`trusty_common::sld::Reference`]s
+//! to find units with no directly preceding `# Spec References` declaration.
+//! [`run_gap_report`] orchestrates a full repository scan: backward gaps (code
+//! units missing linkage), forward gaps (spec sections under `docs/specs/**`
+//! with no inbound code reference), and the existing reference-resolution
+//! diagnostics ([`crate::checks::check_code_file`] /
+//! [`crate::checks::check_markdown_refs`]) folded in as one coherent picture.
+//! [`GapReport`] renders both machine-readable JSON ([`GapReport::to_json`]) and
+//! a human summary ([`GapReport::summary`]).
+//!
+//! **Known pragmatic limitations (slice 1, by design):**
+//! - Module-level units (crate/file doc blocks) are not tracked separately —
+//!   only explicit `pub fn`/`struct`/`enum`/`trait`/`type`/`static`/`mod`
+//!   declarations (or their Python/TS/JS equivalents) count as a code unit.
+//! - A unit's "coverage window" runs from the previous unit's line (or file
+//!   start) to just above the unit itself; a crate-level doc block therefore
+//!   credits the FIRST unit in a file even when the block is really
+//!   module-level, not that unit's own documentation. This avoids double-
+//!   penalizing module-level linkage as a per-symbol gap and is a conservative
+//!   (fewer false positives) choice.
+//! - Detection is line-oriented regex, not an AST: multi-line signatures,
+//!   macro-generated items, and `pub(crate)`/`pub(super)` (intentionally
+//!   excluded — only crate-external `pub` counts as a "public" unit) are out of
+//!   scope. Plain `pub const`/`pub static` items ARE skipped (not detected as
+//!   units) to avoid misparsing `pub const fn` — see [`detect_units`].
+//! - Forward-gap "linked" membership only counts CODE references (inline
+//!   `# Spec References` blocks), per the issue's wording ("no code unit
+//!   linking to them") — a spec cross-referenced only from another spec's
+//!   frontmatter is still a forward gap.
+//!
+//! Test: `super::tests::gap_*`.
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::Serialize;
+
+use trusty_common::sld::Reference;
+use trusty_common::sld::{base_id, parse_inline_refs, spec_anchors, syntax_for_extension};
+
+use crate::checks;
+use crate::discover;
+use crate::report::Diagnostic;
+
+/// One publicly-declared code unit detected by [`detect_units`].
+///
+/// Why: the backward-gap view needs an addressable, orderable unit — its file,
+/// line, and a human-readable kind/name — so a report can name exactly what
+/// lacks linkage.
+/// What: the repo-relative `path`, the 1-based declaration `line`, the `kind`
+/// (`"fn"`, `"struct"`, `"enum"`, `"trait"`, `"type"`, `"static"`, `"mod"`,
+/// `"class"`, `"interface"`, `"const"` depending on language), and the
+/// declared `name`.
+/// Test: `super::tests::gap_detect_units_rust`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CodeUnit {
+    /// Repo-relative path of the file declaring this unit.
+    pub path: String,
+    /// 1-based source line of the declaration.
+    pub line: usize,
+    /// The declaration kind (language-specific keyword, lowercase).
+    pub kind: String,
+    /// The declared identifier.
+    pub name: String,
+}
+
+/// One anchored spec section under `docs/specs/**`.
+///
+/// Why: the forward-gap view needs an addressable spec section — its
+/// containing doc, id, and line — to report which sections have no inbound
+/// code reference.
+/// What: the repo-relative `path`, the section's `id` (`SPEC-…~rev`), and its
+/// 1-based heading `line`.
+/// Test: `super::tests::gap_forward_gap_detects_unlinked_section`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SpecSection {
+    /// Repo-relative path of the spec document.
+    pub path: String,
+    /// The section's anchored spec id.
+    pub id: String,
+    /// 1-based line of the anchored heading.
+    pub line: usize,
+}
+
+/// The bidirectional SLD traceability gap report.
+///
+/// Why: issue #595 slice 1 asks for a single coherent picture — backward gaps,
+/// forward gaps, and the existing reference-resolution diagnostics — rather
+/// than three disconnected outputs.
+/// What: `backward_gaps` (public code units with no directly preceding
+/// `# Spec References` block), `forward_gaps` (spec sections with no inbound
+/// code reference), `broken_references` (the existing reference-resolution
+/// diagnostics: `ref-*`/`frontmatter-schema`), and scan counts.
+/// Test: `super::tests::gap_run_report_*`.
+#[derive(Debug, Default, Serialize)]
+pub struct GapReport {
+    /// Public code units with no directly preceding `# Spec References` block.
+    pub backward_gaps: Vec<CodeUnit>,
+    /// Spec sections with no inbound code (`# Spec References`) link.
+    pub forward_gaps: Vec<SpecSection>,
+    /// Existing reference-resolution findings (broken/mismatched references).
+    pub broken_references: Vec<Diagnostic>,
+    /// Total public code units scanned (in files with a known comment idiom).
+    pub units_scanned: usize,
+    /// Total anchored spec sections scanned.
+    pub spec_sections_scanned: usize,
+}
+
+impl GapReport {
+    /// True when nothing was found in any of the three views (backward,
+    /// forward, or an error-severity broken reference).
+    ///
+    /// Why: `--strict` is the only way this report can fail a CI run (the CLI
+    /// default is report-and-succeed, per issue #595); this is the strict
+    /// predicate it checks.
+    /// What: `backward_gaps` and `forward_gaps` are both empty, and no
+    /// `broken_references` entry is `Severity::Error` (advisories, e.g.
+    /// `ref-revision-drift`, never fail).
+    /// Test: `super::tests::gap_is_strict_clean`.
+    #[must_use]
+    pub fn is_strict_clean(&self) -> bool {
+        self.backward_gaps.is_empty()
+            && self.forward_gaps.is_empty()
+            && !self
+                .broken_references
+                .iter()
+                .any(|d| d.severity == crate::report::Severity::Error)
+    }
+
+    /// Render the report as a `serde_json::Value` (machine-readable output).
+    ///
+    /// Why: issue #595 requires a `--json` output mode; a pure value builder
+    /// (no I/O) keeps this testable independent of the CLI.
+    /// What: a JSON object with `backward_gaps`, `forward_gaps`,
+    /// `broken_references`, `units_scanned`, and `spec_sections_scanned`
+    /// keys, mirroring this struct's fields.
+    /// Test: `super::tests::gap_to_json_round_trips_counts`.
+    #[must_use]
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "backward_gaps": self.backward_gaps,
+            "forward_gaps": self.forward_gaps,
+            "broken_references": self.broken_references,
+            "units_scanned": self.units_scanned,
+            "spec_sections_scanned": self.spec_sections_scanned,
+        })
+    }
+
+    /// Render a human-readable summary: counts plus the top offenders.
+    ///
+    /// Why: a raw diagnostic dump does not answer "where should I start?"; a
+    /// summary with the top files/specs by gap count does.
+    /// What: total counts for each view, then up to 5 files with the most
+    /// backward gaps and up to 5 spec docs with the most forward gaps, each
+    /// with its count.
+    /// Test: `super::tests::gap_summary_lists_top_offenders`.
+    #[must_use]
+    pub fn summary(&self) -> String {
+        let errors = self
+            .broken_references
+            .iter()
+            .filter(|d| d.severity == crate::report::Severity::Error)
+            .count();
+        let warnings = self.broken_references.len() - errors;
+
+        let mut out = format!(
+            "sld-lint gap-report: scanned {} code unit(s) + {} spec section(s)\n  \
+             backward gaps (units with no spec link): {}\n  \
+             forward gaps (spec sections with no code link): {}\n  \
+             broken references: {errors} error(s), {warnings} warning(s)\n",
+            self.units_scanned,
+            self.spec_sections_scanned,
+            self.backward_gaps.len(),
+            self.forward_gaps.len(),
+        );
+
+        for (label, top) in [
+            (
+                "Top backward-gap files",
+                top_offenders(&self.backward_gaps, |u| &u.path),
+            ),
+            (
+                "Top forward-gap specs",
+                top_offenders(&self.forward_gaps, |s| &s.path),
+            ),
+        ] {
+            if top.is_empty() {
+                continue;
+            }
+            out.push_str(&format!("  {label}:\n"));
+            for (path, count) in top {
+                out.push_str(&format!("    {count:>4}  {path}\n"));
+            }
+        }
+        out
+    }
+}
+
+/// Rank `items` by how many share each `key`, descending, top 5.
+///
+/// Why: [`GapReport::summary`] needs "which files have the most gaps" for both
+/// the backward and forward views; one generic ranking helper serves both.
+/// What: counts occurrences of `key(item)` across `items`, sorts descending by
+/// count (ties broken by key for determinism), and returns at most 5
+/// `(key, count)` pairs.
+/// Test: covered by `super::tests::gap_summary_lists_top_offenders`.
+fn top_offenders<'a, T>(items: &'a [T], key: impl Fn(&'a T) -> &'a str) -> Vec<(&'a str, usize)> {
+    let mut counts: Vec<(&str, usize)> = Vec::new();
+    for item in items {
+        let k = key(item);
+        match counts.iter_mut().find(|(existing, _)| *existing == k) {
+            Some((_, n)) => *n += 1,
+            None => counts.push((k, 1)),
+        }
+    }
+    counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+    counts.truncate(5);
+    counts
+}
+
+/// The compiled Rust public-item declaration matcher.
+///
+/// Why: a `OnceLock` compiles the pattern once per process (mirrors
+/// `trusty_common::sld::grammar`'s convention). Excluding `pub(crate)` /
+/// `pub(super)` is deliberate — those are not part of the crate's public API;
+/// requiring whitespace directly after `pub` naturally excludes them (`pub(`
+/// has no space). `const` is treated only as a modifier (never a standalone
+/// item keyword) so `pub const fn f()` cannot be misparsed as a `const` item
+/// named `fn` — the cost is that a plain `pub const NAME: T = …;` constant is
+/// not detected as a unit at all (documented limitation, module doc comment).
+fn rust_unit_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r#"^pub\s+(?:async\s+|unsafe\s+|const\s+|extern\s+"[^"]*"\s+)*(fn|struct|enum|trait|type|mod|static)\s+([A-Za-z_][A-Za-z0-9_]*)"#,
+        )
+        .expect("rust unit pattern compiles")
+    })
+}
+
+/// The compiled Python public-item declaration matcher (module-level only).
+fn python_unit_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^(?:async\s+)?(def|class)\s+([A-Za-z_][A-Za-z0-9_]*)")
+            .expect("python unit pattern compiles")
+    })
+}
+
+/// The compiled TypeScript/JavaScript exported-item declaration matcher.
+fn ts_js_unit_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"^export\s+(?:default\s+)?(?:abstract\s+|async\s+)*(function|class|interface|type|enum|const)\s+([A-Za-z_$][A-Za-z0-9_$]*)",
+        )
+        .expect("ts/js unit pattern compiles")
+    })
+}
+
+/// Detect public code-unit declarations in `content` (per-extension regex scan).
+///
+/// Why: DOC-38's backward-gap question ("which units have no declared spec
+/// link?") needs an enumeration of units; a full AST/code index is explicitly
+/// out of scope for slice 1 (issue #595) — a deterministic, documented,
+/// lightweight regex scan over each line is a pragmatic stand-in. Requiring
+/// the match to start at column 0 (after trimming only leading whitespace, not
+/// a comment lead-in) is what naturally excludes fenced/quoted example code
+/// inside a doc comment or docstring: a real Rust `pub fn` is never itself
+/// prefixed by `///`/`//!`, a real Python top-level `def`/`class` is never
+/// itself indented inside a docstring, and a real `export` statement is never
+/// itself prefixed by a JSDoc `*` continuation — so no separate fence-skipping
+/// pass is needed here (unlike [`trusty_common::sld::parse_inline_refs`], which
+/// scans comment *content* and does need one).
+/// What: for `rs`, matches [`rust_unit_re`]; for `py`, matches
+/// [`python_unit_re`] on lines with zero leading whitespace whose captured name
+/// does not start with `_` (Python's "private" convention); for
+/// `ts`/`tsx`/`js`/`mjs`/`cjs`, matches [`ts_js_unit_re`]. Any other extension
+/// (including `sh`/`toml`/`yaml`, which have no code-unit concept) yields an
+/// empty vec. Returned units are in file (line) order.
+/// Test: `super::tests::gap_detect_units_rust`, `gap_detect_units_python`,
+/// `gap_detect_units_ts`, `gap_detect_units_unsupported_ext`.
+#[must_use]
+pub fn detect_units(path: &str, content: &str, ext: &str) -> Vec<CodeUnit> {
+    let mut out = Vec::new();
+    for (idx, raw) in content.lines().enumerate() {
+        let line = idx + 1;
+        let unit = match ext {
+            "rs" => {
+                let trimmed = raw.trim_start();
+                rust_unit_re()
+                    .captures(trimmed)
+                    .map(|c| (c[1].to_string(), c[2].to_string()))
+            }
+            "py" => {
+                // Module-level only: real code has zero leading whitespace;
+                // an indented `def`/`class` inside a docstring example or a
+                // nested/method definition is out of scope for this
+                // pragmatic scan.
+                (raw == raw.trim_start())
+                    .then(|| python_unit_re().captures(raw))
+                    .flatten()
+                    .map(|c| (c[1].to_string(), c[2].to_string()))
+                    .filter(|(_, name)| !name.starts_with('_'))
+            }
+            "ts" | "tsx" | "js" | "mjs" | "cjs" => {
+                let trimmed = raw.trim_start();
+                ts_js_unit_re()
+                    .captures(trimmed)
+                    .map(|c| (c[1].to_string(), c[2].to_string()))
+            }
+            _ => None,
+        };
+        if let Some((kind, name)) = unit {
+            out.push(CodeUnit {
+                path: path.to_string(),
+                line,
+                kind,
+                name,
+            });
+        }
+    }
+    out
+}
+
+/// Find units in `units` (file order) with no directly preceding spec reference.
+///
+/// Why: a unit is "linked" when its own `# Spec References` block declares at
+/// least one reference; since [`trusty_common::sld::parse_inline_refs`] already
+/// gives each reference's line, "directly preceding" is checked with a
+/// coverage window rather than requiring a second parse pass over the raw
+/// text.
+/// What: for each unit (assumed sorted by `line`, as [`detect_units`]
+/// produces), the window is `(previous unit's line, this unit's line)`
+/// exclusive-exclusive (or `(0, line)` for the first unit) — i.e. every line
+/// strictly between the previous unit and this one. A unit is a gap when no
+/// `refs` entry's line falls in that window. See this module's doc comment for
+/// the documented limitation that a leading crate/module-level doc block
+/// credits the FIRST unit in the file.
+/// Test: `super::tests::gap_backward_gaps_flags_undocumented_unit`,
+/// `gap_backward_gaps_clears_documented_unit`.
+#[must_use]
+pub fn backward_gaps(units: &[CodeUnit], refs: &[Reference]) -> Vec<CodeUnit> {
+    let mut gaps = Vec::new();
+    let mut window_start = 0usize;
+    for unit in units {
+        let covered = refs
+            .iter()
+            .any(|r| r.line > window_start && r.line < unit.line);
+        if !covered {
+            gaps.push(unit.clone());
+        }
+        window_start = unit.line;
+    }
+    gaps
+}
+
+/// Run the full bidirectional gap report over a repository checkout.
+///
+/// Why: this is the single entry point the `gap-report` subcommand calls — it
+/// wires the same [`discover::discover`] scope the linter itself uses, so the
+/// gap report and the linter agree on what is in scope, and folds in the
+/// existing reference-resolution checks so the result is one coherent picture
+/// (issue #595 slice 1). Unlike [`crate::run`], no spec catalog is required —
+/// the gap views need only the spec docs' own anchors and the code files'
+/// declared references.
+/// What: for each in-scope code file, resolves its inline references
+/// ([`checks::check_code_file`]) into `broken_references`, detects public units
+/// ([`detect_units`]), and folds any [`backward_gaps`] into the report; also
+/// records every referenced base id. For each in-scope spec doc, resolves its
+/// frontmatter ([`checks::check_markdown_refs`]) into `broken_references`, then
+/// flags any anchored section ([`trusty_common::sld::spec_anchors`]) whose base
+/// id was never referenced by a code file as a forward gap. Files that cannot
+/// be read as UTF-8 are skipped, matching [`crate::run`]'s behaviour.
+/// Test: `super::tests::gap_run_report_backward_and_forward`.
+#[must_use]
+pub fn run_gap_report(root: &Path) -> GapReport {
+    let discovered = discover::discover(root);
+    let lookup = |path: &str| crate::safe_read(root, path);
+
+    let mut report = GapReport::default();
+    let mut code_referenced_base_ids: HashSet<String> = HashSet::new();
+
+    for rel in &discovered.code_files {
+        let Some(content) = crate::read_rel(root, rel) else {
+            continue;
+        };
+        let ext = rel.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let path = rel.to_string_lossy().to_string();
+
+        report
+            .broken_references
+            .extend(checks::check_code_file(&path, &content, ext, &lookup));
+
+        let Some(syntax) = syntax_for_extension(ext) else {
+            continue;
+        };
+        let refs = parse_inline_refs(&content, &syntax);
+        code_referenced_base_ids.extend(refs.iter().map(|r| base_id(&r.id).to_string()));
+
+        let units = detect_units(&path, &content, ext);
+        report.units_scanned += units.len();
+        report.backward_gaps.extend(backward_gaps(&units, &refs));
+    }
+
+    for rel in &discovered.spec_docs {
+        let Some(content) = crate::read_rel(root, rel) else {
+            continue;
+        };
+        let path = rel.to_string_lossy().to_string();
+
+        report
+            .broken_references
+            .extend(checks::check_markdown_refs(&path, &content, &lookup));
+
+        let anchors = spec_anchors(&content);
+        report.spec_sections_scanned += anchors.len();
+        for a in anchors {
+            if !code_referenced_base_ids.contains(base_id(&a.id)) {
+                report.forward_gaps.push(SpecSection {
+                    path: path.clone(),
+                    id: a.id,
+                    line: a.line,
+                });
+            }
+        }
+    }
+
+    report
+}

--- a/crates/trusty-sld-lint/src/lib.rs
+++ b/crates/trusty-sld-lint/src/lib.rs
@@ -24,6 +24,7 @@ pub mod allowlist;
 pub mod catalog;
 pub mod checks;
 pub mod discover;
+pub mod gap;
 pub mod report;
 
 #[cfg(test)]

--- a/crates/trusty-sld-lint/src/main.rs
+++ b/crates/trusty-sld-lint/src/main.rs
@@ -3,17 +3,19 @@
 //! Why: a thin `anyhow`/clap wrapper keeps all logic in the unit-testable
 //! library ([`trusty_sld_lint`]); this binary just parses flags, runs the
 //! engine, prints diagnostics, and maps the result to an exit code.
-//! What: parses `--root`/`--strict`/`--allowlist`, runs [`trusty_sld_lint::run`],
-//! prints each `path:line: [severity check] message`, prints a one-line summary,
-//! and exits non-zero when any error-severity finding survives the allowlist.
+//! What: with no subcommand, parses `--root`/`--strict`/`--allowlist`, runs
+//! [`trusty_sld_lint::run`], prints each `path:line: [severity check] message`,
+//! prints a one-line summary, and exits non-zero when any error-severity
+//! finding survives the allowlist. The `gap-report` subcommand instead runs
+//! [`trusty_sld_lint::gap::run_gap_report`] (issue #595 slice 1).
 //! Test: exercised end-to-end by the wrapper `scripts/check_sld.sh` and the
 //! library's `tests/lint_real_tree.rs`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 use trusty_sld_lint::{run, LintOptions, ALLOWLIST_FILE};
 
@@ -70,6 +72,9 @@ SCOPE
 Exits non-zero when any error-severity finding survives the allowlist."
 )]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
     /// Repository root to lint (contains `docs/specs/` and `crates/`).
     #[arg(long, default_value = ".")]
     root: PathBuf,
@@ -83,14 +88,47 @@ struct Cli {
     allowlist: Option<PathBuf>,
 }
 
+/// `sld-lint` subcommands beyond the default lint run.
+///
+/// Why: issue #595 adds a read-only bidirectional traceability gap report as a
+/// subcommand rather than a second binary, so it shares the crate's discovery
+/// scope and CLI conventions.
+/// What: [`Command::GapReport`] — see [`trusty_sld_lint::gap`].
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Bidirectional SLD traceability gap report (backward + forward gaps).
+    GapReport {
+        /// Repository root to scan (contains `docs/specs/` and `crates/`).
+        #[arg(long, default_value = ".")]
+        root: PathBuf,
+
+        /// Emit machine-readable JSON instead of (in addition to) the summary.
+        #[arg(long)]
+        json: bool,
+
+        /// Exit non-zero when the report finds any gap or broken reference.
+        ///
+        /// Default: report-and-succeed (exit 0) — this is a read-only report,
+        /// not a gate, so it can never unexpectedly break CI (issue #595).
+        #[arg(long)]
+        strict: bool,
+    },
+}
+
 /// Parse flags, run the linter, print findings, and return an exit code.
 ///
 /// Why: keeps `main` a thin adapter — no check logic, just I/O and exit mapping.
-/// What: builds [`LintOptions`], runs [`run`], prints each diagnostic and a
-/// summary line, and returns `FAILURE` when the report is not clean.
+/// What: dispatches to [`run_gap_report_cmd`] for `gap-report`, else builds
+/// [`LintOptions`], runs [`run`], prints each diagnostic and a summary line,
+/// and returns `FAILURE` when the report is not clean.
 /// Test: covered end-to-end by `tests/lint_real_tree.rs` + `scripts/check_sld.sh`.
 fn main() -> Result<ExitCode> {
     let cli = Cli::parse();
+
+    if let Some(Command::GapReport { root, json, strict }) = cli.command {
+        return Ok(run_gap_report_cmd(&root, json, strict));
+    }
+
     let strict = cli.strict;
     let allowlist_path = cli
         .allowlist
@@ -118,5 +156,32 @@ fn main() -> Result<ExitCode> {
         Ok(ExitCode::SUCCESS)
     } else {
         Ok(ExitCode::FAILURE)
+    }
+}
+
+/// Run the `gap-report` subcommand: print output, choose an exit code.
+///
+/// Why: kept separate from `main` so the dispatch in `main` stays a one-line
+/// match arm.
+/// What: runs [`trusty_sld_lint::gap::run_gap_report`], prints the JSON (when
+/// `json`) and always prints the human [`GapReport::summary`], then returns
+/// `FAILURE` only when `strict` is set AND the report is not
+/// [`GapReport::is_strict_clean`] — the default is report-and-succeed so this
+/// subcommand can never unexpectedly break CI (issue #595).
+/// Test: covered end-to-end by `tests/gap_report_real_tree.rs`.
+fn run_gap_report_cmd(root: &Path, json: bool, strict: bool) -> ExitCode {
+    let report = trusty_sld_lint::gap::run_gap_report(root);
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report.to_json()).expect("gap report serializes")
+        );
+    }
+    println!("{}", report.summary());
+
+    if strict && !report.is_strict_clean() {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
     }
 }

--- a/crates/trusty-sld-lint/src/report.rs
+++ b/crates/trusty-sld-lint/src/report.rs
@@ -11,6 +11,8 @@
 
 use std::fmt;
 
+use serde::Serialize;
+
 /// Whether a finding fails the lint (error) or is advisory (warning).
 ///
 /// Why: DOC-38 makes some conditions hard violations (an unresolved reference)
@@ -19,7 +21,7 @@ use std::fmt;
 /// still surfacing advisories.
 /// What: `Error` counts toward a non-zero exit; `Warning` is informational.
 /// Test: `super::tests::report_exit_counts_errors_only`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub enum Severity {
     /// A hard violation — fails the lint (non-zero exit).
     Error,
@@ -35,7 +37,7 @@ pub enum Severity {
 /// What: the repo-relative `path`, 1-based `line` (0 when file-scoped, not
 /// line-scoped), the `severity`, the `check` identifier, and the `message`.
 /// Test: `super::tests::report_display`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Diagnostic {
     /// Repo-relative path of the offending file.
     pub path: String,

--- a/crates/trusty-sld-lint/src/tests.rs
+++ b/crates/trusty-sld-lint/src/tests.rs
@@ -11,7 +11,7 @@ use crate::discover;
 use crate::gap::{self, CodeUnit};
 use crate::report::{Diagnostic, Severity};
 use crate::{run, LintError, LintOptions};
-use trusty_common::sld::Reference;
+use trusty_common::sld::{syntax_for_extension, Reference};
 
 // A single lookup that knows about one target spec containing SPEC-X-01~draft.
 fn lookup(path: &str) -> Option<String> {
@@ -595,7 +595,32 @@ fn gap_detect_units_unsupported_ext() {
 }
 
 #[test]
+fn gap_preceding_doc_block_contiguous_run() {
+    let syntax = syntax_for_extension("rs").unwrap();
+    let content = "//! line one\n//! line two\npub fn f() {}\n";
+    assert_eq!(gap::preceding_doc_block_start(content, 3, &syntax), 1);
+}
+
+#[test]
+fn gap_preceding_doc_block_stops_at_blank_line() {
+    let syntax = syntax_for_extension("rs").unwrap();
+    // A blank separator line detaches the doc comment from the item below it
+    // (mirrors rustdoc's own attachment rule) — no block directly above line 3.
+    let content = "//! detached doc\n\npub fn f() {}\n";
+    assert_eq!(gap::preceding_doc_block_start(content, 3, &syntax), 3);
+}
+
+#[test]
+fn gap_preceding_doc_block_none_when_no_comment_directly_above() {
+    let syntax = syntax_for_extension("rs").unwrap();
+    let content = "let x = 1;\npub fn f() {}\n";
+    assert_eq!(gap::preceding_doc_block_start(content, 2, &syntax), 2);
+}
+
+#[test]
 fn gap_backward_gaps_flags_undocumented_unit() {
+    let syntax = syntax_for_extension("rs").unwrap();
+    let content = "let x = 1;\nlet y = 2;\npub fn f() {}\n";
     let units = vec![CodeUnit {
         path: "x.rs".into(),
         line: 3,
@@ -603,30 +628,34 @@ fn gap_backward_gaps_flags_undocumented_unit() {
         name: "f".into(),
     }];
     // No references at all: the unit is a gap.
-    assert_eq!(gap::backward_gaps(&units, &[]), units);
+    assert_eq!(gap::backward_gaps(content, &syntax, &units, &[]), units);
 }
 
 #[test]
 fn gap_backward_gaps_clears_documented_unit() {
+    let syntax = syntax_for_extension("rs").unwrap();
+    let content = "//! # Spec References\n//! - [`SPEC-X-01~draft`](docs/specs/x.md#SPEC-X-01~draft)\npub fn f() {}\n";
     let units = vec![CodeUnit {
         path: "x.rs".into(),
         line: 3,
         kind: "fn".into(),
         name: "f".into(),
     }];
-    // A reference declared on line 2 (the doc comment directly above line 3's
-    // `pub fn`) falls inside the (0, 3) coverage window.
+    // The reference on line 2 sits in the contiguous comment run directly
+    // above line 3's `pub fn`.
     let refs = vec![make_ref(
         "SPEC-X-01~draft",
         "docs/specs/x.md",
         "SPEC-X-01~draft",
         2,
     )];
-    assert!(gap::backward_gaps(&units, &refs).is_empty());
+    assert!(gap::backward_gaps(content, &syntax, &units, &refs).is_empty());
 }
 
 #[test]
 fn gap_backward_gaps_second_unit_needs_its_own_reference() {
+    let syntax = syntax_for_extension("rs").unwrap();
+    let content = "//! # Spec References\n//! - [`SPEC-X-01~draft`](docs/specs/x.md#SPEC-X-01~draft)\npub fn first() {}\n\npub fn second() {}\n";
     let units = vec![
         CodeUnit {
             path: "x.rs".into(),
@@ -636,22 +665,60 @@ fn gap_backward_gaps_second_unit_needs_its_own_reference() {
         },
         CodeUnit {
             path: "x.rs".into(),
-            line: 6,
+            line: 5,
             kind: "fn".into(),
             name: "second".into(),
         },
     ];
-    // Only `first` (line 3) has a preceding reference (line 2); `second`
-    // (line 6) has nothing between line 3 and line 6, so it is still a gap.
+    // Only `first` (line 3) has a directly preceding reference (line 2);
+    // `second` (line 5) has a blank line, then `first`'s own declaration,
+    // directly above it — no comment block of its own — so it is still a gap.
     let refs = vec![make_ref(
         "SPEC-X-01~draft",
         "docs/specs/x.md",
         "SPEC-X-01~draft",
         2,
     )];
-    let gaps = gap::backward_gaps(&units, &refs);
+    let gaps = gap::backward_gaps(content, &syntax, &units, &refs);
     assert_eq!(gaps.len(), 1);
     assert_eq!(gaps[0].name, "second");
+}
+
+#[test]
+fn gap_backward_gaps_ref_inside_previous_unit_body_does_not_cover_next_unit() {
+    // Regression for the PR #3783 review finding: a reference sitting
+    // anywhere between the previous unit and this one (e.g. inside the
+    // previous unit's own body, documenting ITS internals) must NOT count as
+    // covering the NEXT, unrelated unit just because it falls in that span.
+    let syntax = syntax_for_extension("rs").unwrap();
+    let content = "pub struct A {\n    field: u32,\n    // # Spec References\n    // - [`SPEC-X-01~draft`](docs/specs/x.md#SPEC-X-01~draft)\n}\n\npub fn b_unrelated() {}\n";
+    let units = vec![
+        CodeUnit {
+            path: "x.rs".into(),
+            line: 1,
+            kind: "struct".into(),
+            name: "A".into(),
+        },
+        CodeUnit {
+            path: "x.rs".into(),
+            line: 7,
+            kind: "fn".into(),
+            name: "b_unrelated".into(),
+        },
+    ];
+    let refs = vec![make_ref(
+        "SPEC-X-01~draft",
+        "docs/specs/x.md",
+        "SPEC-X-01~draft",
+        4,
+    )];
+    let gaps = gap::backward_gaps(content, &syntax, &units, &refs);
+    assert_eq!(
+        gaps.iter().map(|u| u.name.as_str()).collect::<Vec<_>>(),
+        vec!["A", "b_unrelated"],
+        "the internal reference at line 4 documents A's own body, not \
+         b_unrelated, and must not silently clear b_unrelated as covered"
+    );
 }
 
 #[test]

--- a/crates/trusty-sld-lint/src/tests.rs
+++ b/crates/trusty-sld-lint/src/tests.rs
@@ -722,6 +722,27 @@ fn gap_backward_gaps_ref_inside_previous_unit_body_does_not_cover_next_unit() {
 }
 
 #[test]
+fn gap_forward_gap_detects_unlinked_section() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // A single anchored section, no code file at all: nothing can possibly
+    // link to it, so it must surface as exactly one forward gap.
+    write(
+        root,
+        "docs/specs/x.md",
+        "## Orphan {#SPEC-X-01~draft}\nbody\n",
+    );
+
+    let report = gap::run_gap_report(root);
+
+    assert_eq!(report.spec_sections_scanned, 1);
+    assert_eq!(report.forward_gaps.len(), 1);
+    assert_eq!(report.forward_gaps[0].id, "SPEC-X-01~draft");
+    assert_eq!(report.forward_gaps[0].path, "docs/specs/x.md");
+    assert_eq!(report.forward_gaps[0].line, 1);
+}
+
+#[test]
 fn gap_run_report_backward_and_forward() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();

--- a/crates/trusty-sld-lint/src/tests.rs
+++ b/crates/trusty-sld-lint/src/tests.rs
@@ -8,8 +8,10 @@ use crate::allowlist;
 use crate::catalog;
 use crate::checks;
 use crate::discover;
+use crate::gap::{self, CodeUnit};
 use crate::report::{Diagnostic, Severity};
 use crate::{run, LintError, LintOptions};
+use trusty_common::sld::Reference;
 
 // A single lookup that knows about one target spec containing SPEC-X-01~draft.
 fn lookup(path: &str) -> Option<String> {
@@ -547,4 +549,270 @@ fn run_strict_flags_stale_allowlist_entry() {
         "default mode must not spuriously flag stale entries: {:?}",
         default_report.diagnostics
     );
+}
+
+// ── gap report ───────────────────────────────────────────────────────────────
+
+fn make_ref(id: &str, path: &str, anchor: &str, line: usize) -> Reference {
+    Reference {
+        id: id.to_string(),
+        path: path.to_string(),
+        anchor: anchor.to_string(),
+        line,
+    }
+}
+
+#[test]
+fn gap_detect_units_rust() {
+    let src = "//! module doc\npub fn visible() {}\npub(crate) fn hidden() {}\nfn private() {}\npub struct S;\npub async fn a() {}\npub const fn cf() {}\n";
+    let units = gap::detect_units("x.rs", src, "rs");
+    let names: Vec<&str> = units.iter().map(|u| u.name.as_str()).collect();
+    assert_eq!(names, vec!["visible", "S", "a", "cf"]);
+    assert_eq!(units[3].kind, "fn"); // `pub const fn cf` — const is a modifier, not the item.
+}
+
+#[test]
+fn gap_detect_units_python() {
+    let src = "def visible():\n    pass\n\n\ndef _private():\n    pass\n\n\nclass Public:\n    def method(self):\n        \"\"\"def not_a_unit(): pass\"\"\"\n        pass\n";
+    let units = gap::detect_units("x.py", src, "py");
+    let names: Vec<&str> = units.iter().map(|u| u.name.as_str()).collect();
+    // `_private` (underscore) and the indented `method`/docstring example are
+    // both out of scope for this module-level-only pragmatic scan.
+    assert_eq!(names, vec!["visible", "Public"]);
+}
+
+#[test]
+fn gap_detect_units_ts() {
+    let src = "export function visible() {}\nfunction internal() {}\nexport class Widget {}\nexport interface Shape {}\n";
+    let units = gap::detect_units("x.ts", src, "ts");
+    let names: Vec<&str> = units.iter().map(|u| u.name.as_str()).collect();
+    assert_eq!(names, vec!["visible", "Widget", "Shape"]);
+}
+
+#[test]
+fn gap_detect_units_unsupported_ext() {
+    assert!(gap::detect_units("x.toml", "pub fn not_real() {}\n", "toml").is_empty());
+}
+
+#[test]
+fn gap_backward_gaps_flags_undocumented_unit() {
+    let units = vec![CodeUnit {
+        path: "x.rs".into(),
+        line: 3,
+        kind: "fn".into(),
+        name: "f".into(),
+    }];
+    // No references at all: the unit is a gap.
+    assert_eq!(gap::backward_gaps(&units, &[]), units);
+}
+
+#[test]
+fn gap_backward_gaps_clears_documented_unit() {
+    let units = vec![CodeUnit {
+        path: "x.rs".into(),
+        line: 3,
+        kind: "fn".into(),
+        name: "f".into(),
+    }];
+    // A reference declared on line 2 (the doc comment directly above line 3's
+    // `pub fn`) falls inside the (0, 3) coverage window.
+    let refs = vec![make_ref(
+        "SPEC-X-01~draft",
+        "docs/specs/x.md",
+        "SPEC-X-01~draft",
+        2,
+    )];
+    assert!(gap::backward_gaps(&units, &refs).is_empty());
+}
+
+#[test]
+fn gap_backward_gaps_second_unit_needs_its_own_reference() {
+    let units = vec![
+        CodeUnit {
+            path: "x.rs".into(),
+            line: 3,
+            kind: "fn".into(),
+            name: "first".into(),
+        },
+        CodeUnit {
+            path: "x.rs".into(),
+            line: 6,
+            kind: "fn".into(),
+            name: "second".into(),
+        },
+    ];
+    // Only `first` (line 3) has a preceding reference (line 2); `second`
+    // (line 6) has nothing between line 3 and line 6, so it is still a gap.
+    let refs = vec![make_ref(
+        "SPEC-X-01~draft",
+        "docs/specs/x.md",
+        "SPEC-X-01~draft",
+        2,
+    )];
+    let gaps = gap::backward_gaps(&units, &refs);
+    assert_eq!(gaps.len(), 1);
+    assert_eq!(gaps[0].name, "second");
+}
+
+#[test]
+fn gap_run_report_backward_and_forward() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // A spec doc with two sections: one referenced by code (linked), one not
+    // (a forward gap).
+    write(
+        root,
+        "docs/specs/x.md",
+        "## Linked {#SPEC-X-01~draft}\nbody\n\n## Orphan {#SPEC-X-02~draft}\nbody\n",
+    );
+
+    // A code file with two public units: one documented (backward-clean), one
+    // not (a backward gap). Only references `SPEC-X-01~draft`, leaving
+    // `SPEC-X-02~draft` with no inbound code link.
+    write(
+        root,
+        "crates/x/src/lib.rs",
+        "//! # Spec References\n//! - [`SPEC-X-01~draft`](docs/specs/x.md#SPEC-X-01~draft)\npub fn documented() {}\npub fn undocumented() {}\n",
+    );
+
+    let report = gap::run_gap_report(root);
+
+    assert_eq!(report.units_scanned, 2);
+    assert!(
+        report
+            .backward_gaps
+            .iter()
+            .any(|u| u.name == "undocumented"),
+        "expected `undocumented` as a backward gap: {:?}",
+        report.backward_gaps
+    );
+    assert!(
+        !report.backward_gaps.iter().any(|u| u.name == "documented"),
+        "did not expect `documented` as a backward gap: {:?}",
+        report.backward_gaps
+    );
+
+    assert_eq!(report.spec_sections_scanned, 2);
+    assert!(
+        report
+            .forward_gaps
+            .iter()
+            .any(|s| s.id == "SPEC-X-02~draft"),
+        "expected SPEC-X-02~draft as a forward gap: {:?}",
+        report.forward_gaps
+    );
+    assert!(
+        !report
+            .forward_gaps
+            .iter()
+            .any(|s| s.id == "SPEC-X-01~draft"),
+        "did not expect SPEC-X-01~draft as a forward gap: {:?}",
+        report.forward_gaps
+    );
+
+    assert!(!report.is_strict_clean());
+}
+
+#[test]
+fn gap_run_report_valid_linked_pair_is_fully_clean() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(
+        root,
+        "docs/specs/x.md",
+        "## Section {#SPEC-X-01~draft}\nbody\n",
+    );
+    write(
+        root,
+        "crates/x/src/lib.rs",
+        "//! # Spec References\n//! - [`SPEC-X-01~draft`](docs/specs/x.md#SPEC-X-01~draft)\npub fn f() {}\n",
+    );
+
+    let report = gap::run_gap_report(root);
+    assert!(
+        report.backward_gaps.is_empty(),
+        "{:?}",
+        report.backward_gaps
+    );
+    assert!(report.forward_gaps.is_empty(), "{:?}", report.forward_gaps);
+    assert!(
+        report.broken_references.is_empty(),
+        "{:?}",
+        report.broken_references
+    );
+    assert!(report.is_strict_clean());
+}
+
+#[test]
+fn gap_run_report_folds_in_broken_references() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(
+        root,
+        "crates/x/src/lib.rs",
+        "//! # Spec References\n//! - [`SPEC-GONE-01~draft`](docs/specs/gone.md#SPEC-GONE-01~draft)\n",
+    );
+
+    let report = gap::run_gap_report(root);
+    assert!(report
+        .broken_references
+        .iter()
+        .any(|d| d.check == "ref-path-missing"));
+    assert!(!report.is_strict_clean());
+}
+
+#[test]
+fn gap_is_strict_clean_ignores_advisory_severity() {
+    let mut report = gap::GapReport::default();
+    report.broken_references.push(Diagnostic::warning(
+        "a.rs",
+        1,
+        "ref-revision-drift",
+        "stale",
+    ));
+    assert!(
+        report.is_strict_clean(),
+        "an advisory-only broken reference must not fail --strict"
+    );
+    report
+        .broken_references
+        .push(Diagnostic::error("a.rs", 1, "ref-path-missing", "gone"));
+    assert!(!report.is_strict_clean());
+}
+
+#[test]
+fn gap_to_json_round_trips_counts() {
+    let report = gap::GapReport {
+        units_scanned: 5,
+        spec_sections_scanned: 2,
+        ..gap::GapReport::default()
+    };
+    let json = report.to_json();
+    assert_eq!(json["units_scanned"], 5);
+    assert_eq!(json["spec_sections_scanned"], 2);
+    assert_eq!(json["backward_gaps"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn gap_summary_lists_top_offenders() {
+    let mut report = gap::GapReport::default();
+    for i in 0..3 {
+        report.backward_gaps.push(CodeUnit {
+            path: "crates/x/src/lib.rs".into(),
+            line: i + 1,
+            kind: "fn".into(),
+            name: format!("f{i}"),
+        });
+    }
+    report.backward_gaps.push(CodeUnit {
+        path: "crates/y/src/lib.rs".into(),
+        line: 1,
+        kind: "fn".into(),
+        name: "g".into(),
+    });
+    let summary = report.summary();
+    assert!(summary.contains("backward gaps"));
+    assert!(summary.contains("crates/x/src/lib.rs"));
+    assert!(summary.contains("   3  crates/x/src/lib.rs"));
 }

--- a/crates/trusty-sld-lint/tests/gap_report_real_tree.rs
+++ b/crates/trusty-sld-lint/tests/gap_report_real_tree.rs
@@ -1,0 +1,43 @@
+//! Integration test: the gap report must run cleanly over the real
+//! trusty-tools tree (issue #595 slice 1).
+//!
+//! Mirrors `lint_real_tree.rs`'s "run over the live tree" acid test: DOC-38's
+//! own body quotes many fenced `# Spec References` / `{#SPEC-…}` examples that
+//! a conforming scanner must not pick up as real units or sections, and the
+//! real tree exercises every language branch of `detect_units` at once.
+
+use std::path::PathBuf;
+
+use trusty_sld_lint::gap::run_gap_report;
+
+/// The workspace root, relative to this crate's manifest dir.
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root resolves")
+}
+
+#[test]
+fn gap_report_runs_on_real_tree() {
+    let report = run_gap_report(&workspace_root());
+
+    // The real tree has thousands of public Rust items and dozens of anchored
+    // spec sections; a report that found none would mean detection silently
+    // broke, not that the tree is somehow perfectly linked both ways.
+    assert!(
+        report.units_scanned > 100,
+        "expected many public code units scanned, got {}",
+        report.units_scanned
+    );
+    assert!(
+        report.spec_sections_scanned > 10,
+        "expected many anchored spec sections scanned, got {}",
+        report.spec_sections_scanned
+    );
+
+    // Non-strict is report-and-succeed regardless of gap counts: this is a
+    // read-only report, not a gate (issue #595). Rendering must not panic.
+    let _ = report.summary();
+    let _ = report.to_json();
+}


### PR DESCRIPTION
Part of #595 (slice 1 of 6: read-only gap report).

## Summary

Adds `sld-lint gap-report [--json] [--strict]` — a read-only, index-free,
LLM-free bidirectional SLD traceability gap report. Extends
`trusty-sld-lint`'s existing pure-check-function architecture (no second
parser) rather than living in `trusty-search`, per the owner decision that
slice 1 stay index-free.

Targets the DOC-38 grammar **as shipped** (`# Spec References` inline blocks /
`spec_refs:` frontmatter) — not the original issue's superseded WWL /
OpenFastTrace four-status vocabulary.

- **Backward gaps** — public code units (`pub fn`/`struct`/`enum`/`trait`/
  `type`/`static`/`mod` in Rust; module-level `def`/`class` in Python;
  `export function`/`class`/`interface`/`type`/`enum`/`const` in TS/JS)
  detected via a lightweight, deterministic per-language regex scan (no AST,
  no code index), with no directly preceding `# Spec References` declaration.
- **Forward gaps** — anchored spec sections under `docs/specs/**`
  (`{#SPEC-…}`) with no inbound code reference.
- **Broken references** — folds in the existing reference-resolution
  diagnostics (`ref-*` / `frontmatter-schema`) so the report is one coherent
  picture.
- **Report-only by default** — exits 0 regardless of findings unless
  `--strict` is passed; this is a read-only report, not a gate, so it can
  never unexpectedly break CI.
- Suggest/report only: writes no source files, calls no LLM.

Known, documented pragmatic limitations of the slice-1 scan (line-oriented
regex, not AST; module-level units out of scope; `pub(crate)`/`pub(super)`
excluded; plain `pub const`/`pub static` skipped to avoid misparsing
`pub const fn`) are called out in `crates/trusty-sld-lint/src/gap.rs`'s module
doc comment.

Remaining slices (2-6, not in this PR): LLM-assisted hotspot ranking, concept
clustering → spec proposals, spec↔code link suggestion, WWL/DRAFT stub
generation, and baseline/ratchet management — all propose-only per the issue's
"never auto-commit" constraint.

## Test plan

- [x] `cargo test -p trusty-sld-lint` — 46 lib unit tests + 2 integration
      tests (`gap_report_real_tree.rs`, `lint_real_tree.rs`) — all pass
- [x] `cargo clippy -p trusty-sld-lint --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-sld-lint` — clean
- [x] Manual smoke test: default `sld-lint --root .` lint behavior unchanged
      (0 errors, 0 warnings); `sld-lint gap-report --root .` and
      `--json` both run cleanly over the real tree

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools