### PR TITLE
chore(release): trusty-mpm 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11649,7 +11649,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "0.21.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ tga = { path = "crates/trusty-git-analytics", version = "2.9.4" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.
-trusty-mpm = { path = "crates/trusty-mpm", version = "0.21.0" }
+trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [1.0.0] - 2026-07-24
+
+**First stable release.** trusty-mpm (the `tm` harness/CLI/daemon) has been in
+daily driver use for several weeks across the maintainer's own projects; this
+release marks it semver-committed / stable rather than signaling any single
+breaking change. Sibling crates (trusty-common, trusty-search,
+trusty-memory, etc.) are unaffected and keep their own independent 0.x
+version lines.
 
 ### Added
 

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "0.21.0"
+version = "1.0.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

PHASE 1 (reversible) of the trusty-mpm 1.0.0 release: version bump + CHANGELOG
+ proven publish-safety. This PR does **not** tag or publish — Phase 2 (a
separate, later step) does the actual `cargo publish` from merged main once
this is merged.

- Bumps `trusty-mpm` (the `tm` harness/binary) from `0.21.0` → `1.0.0`.
  **Single-crate bump** — `trusty-mpm` declares its own `version` in
  `crates/trusty-mpm/Cargo.toml` (this repo removed the workspace-pinned
  `[workspace.package] version` per issue #343; every crate manages its own
  version independently). Sibling crates (trusty-common, trusty-search,
  trusty-memory, etc.) are **unaffected** and keep their own 0.x lines.
- Owner-authorized major bump ("used it every day for weeks, it's ready") —
  a deliberate stability signal, not driven by a breaking-change diff.
- `crates/trusty-mpm/CHANGELOG.md`: `[Unreleased]` entries moved under a new
  `## [1.0.0] - 2026-07-24` heading with a first-stable-release milestone note.
- `Cargo.toml` (`[workspace.dependencies]` `trusty-mpm` version pin) and
  `Cargo.lock` updated to match.
- `trusty-mpm` is a **leaf crate** in the workspace dependency graph — no
  other crate depends on it — so this bump has no downstream publish-ordering
  implications.

## Publish-safety proof (the critical deliverable)

`SKIP_UI_BUILD=1 cargo publish --dry-run -p trusty-mpm` **PASSED**: resolves
`trusty-common` (0.26.0) and `trusty-agents-common` (0.3.0) against the live
crates.io registry, packages (983 files, 13.2MiB / 3.5MiB compressed),
compiles, and verifies cleanly — aborts only at the final upload step (dry-run
behavior).

`scripts/publish-dry-run-order.sh --list-only trusty-mpm` confirms the
publish-order closure for Phase 2 is `trusty-mpm` alone — no sibling crate
needs to be republished first.

## Pre-flight gates (all green)

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — clean (GUI exclusions match this repo's own CI convention for the pnpm/Svelte-toolchain-dependent Tauri crates)
- `cargo test -p trusty-mpm` — full test surface (no `--lib`): 3555 lib tests + 1213 bin tests + all `tests/*.rs` integration suites, 0 failures
- `cargo check --workspace` (same GUI exclusions) — clean

## Test plan

- [x] Pre-flight gates captured with raw output (see PM report)
- [x] `cargo publish --dry-run -p trusty-mpm` passed
- [x] Publish-order closure computed and confirmed single-crate
- [ ] Phase 2 (separate step, after merge): tag `trusty-mpm-v1.0.0`, run `scripts/preflight-publish.sh trusty-mpm`, `cargo publish -p trusty-mpm`, verify live on crates.io

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools