### PR TITLE
fix(trusty-agents-ui): populate agent picker on api-ready; hide chat turns from Recent Tasks

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -42,6 +42,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Agent picker no longer loses Izzie / CTO Bot on a cold start:** the
+  `AgentSwitcher` (and `ModelSwitcher`) fetched their catalog exactly once in
+  `onMount`, but `<Header>` — and therefore both pickers — renders before
+  `apiReady`. On a packaged-app cold start the sidecar isn't listening yet, so
+  that first `GET /api/agents` fetch failed, `catalogAgents` stayed empty with
+  no retry, and the roster showed only the built-in "Assistant" for the whole
+  session (Izzie / CTO Bot never selectable). `App.svelte` now re-drives the
+  agent + model catalog loads (and the overlay refresh) whenever `apiReady`
+  flips true, backfilling the already-mounted pickers via their reactive stores
+  (and refetching on any later sidecar reconnect). The `GET /api/agents` roster
+  itself was already correct — it returns all bundled personas including the
+  `izzie`/`cto-assistant` directory packages.
+- **Recent Tasks no longer lists chat replies as junk "(empty)" rows:** every
+  chat turn (a Conversational/Research message) is finalized as a
+  `type: "agent_response"` `PmResponse` with an empty request field, so
+  `GET /api/tasks` returned them and the workflow-oriented Recent Tasks panel
+  rendered them as "(empty)" success rows. The panel now filters on a shared
+  pure predicate (`lib/taskHistory.ts::isDisplayableTask`) that excludes
+  `agent_response` (chat) envelopes — chat is not a workflow run — while keeping
+  the pre-existing rule that hides the contentless running placeholder; the
+  empty-state and Clear affordance now key off the visible count.
 - **MCP tool results no longer collapse the live conversation to the system
   prompt:** an MCP tool result (e.g. `grep` via trusty-search) is shrunk by no
   `compress_tool_output` filter and can be multiple megabytes; the send-time

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -14,6 +14,7 @@
   import { pushSlackEvent, slackMirror } from './lib/slack-mirror';
   import { invoke, isDesktop, connectEventSource, listenEvent, emitWebEvent, type AppEvent } from './lib/transport';
   import { bridgeDelta } from './lib/chatStream';
+  import { shouldRefetchCatalogs } from './lib/catalogRefetch';
   import {
     apiAuthRequired,
     getCurrentApiToken,
@@ -424,24 +425,31 @@
 
   // Agent-picker cold-start race (owner report 2026-07-23):
   // AgentSwitcher/ModelSwitcher fetch their catalogs in their own `onMount`,
-  // but `<Header>` — and therefore
-  // both pickers — renders unconditionally, before `apiReady`. On a cold
-  // start the sidecar isn't listening yet, so that first fetch fails, the
-  // catalog stores stay empty, and the pickers show only their built-in
-  // default ("Assistant" / "Default") for the whole session with no retry —
-  // Izzie/CTO Bot never become selectable. Re-driving the catalog loads the
-  // moment the API becomes healthy backfills the already-mounted pickers via
-  // their reactive stores (and refetches on any later reconnect, mirroring
-  // the event-stream block above).
-  $: if (apiReady) {
-    fetchAgentCatalog().catch((e) =>
-      console.error('[App] fetchAgentCatalog failed:', e),
-    );
-    fetchModelCatalog().catch((e) =>
-      console.error('[App] fetchModelCatalog failed:', e),
-    );
-    refreshOverlayAgents();
+  // but `<Header>` — and therefore both pickers — renders unconditionally,
+  // before `apiReady`. On a cold start the sidecar isn't listening yet, so
+  // that first fetch fails, the catalog stores stay empty, and the pickers
+  // show only their built-in default ("Assistant" / "Default") for the whole
+  // session with no retry — Izzie/CTO Bot never become selectable. Re-driving
+  // the catalog loads the moment the API becomes healthy backfills the
+  // already-mounted pickers via their reactive stores. `apiReady` is set true
+  // exactly once per app lifetime and never reset, so this fires once; the
+  // edge-detector (`shouldRefetchCatalogs`) keeps it from re-running on any
+  // unrelated reactive re-evaluation, and would correctly re-fire if a future
+  // change ever reset `apiReady` false→true on reconnect.
+  let prevApiReady = false;
+  function refetchPickerCatalogsOnReady(ready: boolean) {
+    if (shouldRefetchCatalogs(prevApiReady, ready)) {
+      fetchAgentCatalog().catch((e) =>
+        console.error('[App] fetchAgentCatalog failed:', e),
+      );
+      fetchModelCatalog().catch((e) =>
+        console.error('[App] fetchModelCatalog failed:', e),
+      );
+      refreshOverlayAgents();
+    }
+    prevApiReady = ready;
   }
+  $: refetchPickerCatalogsOnReady(apiReady);
 
   onMount(() => {
     bootstrap();

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -14,7 +14,15 @@
   import { pushSlackEvent, slackMirror } from './lib/slack-mirror';
   import { invoke, isDesktop, connectEventSource, listenEvent, emitWebEvent, type AppEvent } from './lib/transport';
   import { bridgeDelta } from './lib/chatStream';
-  import { apiAuthRequired, getCurrentApiToken, setApiToken, addMessage } from './stores/app';
+  import {
+    apiAuthRequired,
+    getCurrentApiToken,
+    setApiToken,
+    addMessage,
+    fetchAgentCatalog,
+    fetchModelCatalog,
+    refreshOverlayAgents,
+  } from './stores/app';
   import { setRecap, type Recap } from './stores/recap';
   // Why (#3217): parallel structured-data sink — see stores/workflow.ts doc
   // comment for the full rationale. Additive to the flattened webBus path
@@ -412,6 +420,27 @@
     startEventStream();
   } else {
     stopEventStream();
+  }
+
+  // Agent-picker cold-start race (owner report 2026-07-23):
+  // AgentSwitcher/ModelSwitcher fetch their catalogs in their own `onMount`,
+  // but `<Header>` — and therefore
+  // both pickers — renders unconditionally, before `apiReady`. On a cold
+  // start the sidecar isn't listening yet, so that first fetch fails, the
+  // catalog stores stay empty, and the pickers show only their built-in
+  // default ("Assistant" / "Default") for the whole session with no retry —
+  // Izzie/CTO Bot never become selectable. Re-driving the catalog loads the
+  // moment the API becomes healthy backfills the already-mounted pickers via
+  // their reactive stores (and refetches on any later reconnect, mirroring
+  // the event-stream block above).
+  $: if (apiReady) {
+    fetchAgentCatalog().catch((e) =>
+      console.error('[App] fetchAgentCatalog failed:', e),
+    );
+    fetchModelCatalog().catch((e) =>
+      console.error('[App] fetchModelCatalog failed:', e),
+    );
+    refreshOverlayAgents();
   }
 
   onMount(() => {

--- a/crates/trusty-agents/ui/src/components/TaskHistory.svelte
+++ b/crates/trusty-agents/ui/src/components/TaskHistory.svelte
@@ -3,6 +3,7 @@
   import { taskHistory } from '../stores/app';
   import type { TaskHistoryEntry } from '../stores/app';
   import { invoke, listenEvent, type UnlistenFn } from '../lib/transport';
+  import { visibleTaskHistory } from '../lib/taskHistory';
   import type { PmResponseLike } from '../stores/workflow';
 
   let unlistenComplete: UnlistenFn | null = null;
@@ -157,6 +158,13 @@
     if (c < 0.01) return `$${c.toFixed(4)}`;
     return `$${c.toFixed(2)}`;
   }
+
+  // The subset actually rendered — chat replies (`agent_response`) and the
+  // contentless running placeholder are excluded (see `lib/taskHistory.ts`).
+  // The Clear affordance and the "No tasks yet." empty state key off this so a
+  // panel that holds only hidden chat rows reads as empty rather than showing a
+  // Clear button over a blank list.
+  $: visibleTasks = visibleTaskHistory($taskHistory);
 </script>
 
 <section>
@@ -164,7 +172,7 @@
     <h2 class="text-xs font-semibold uppercase tracking-wide text-foundry-teal">
       Recent tasks
     </h2>
-    {#if $taskHistory.length > 0}
+    {#if visibleTasks.length > 0}
       <!-- #3737: two-step Clear affordance for the recent-tasks list. Styled
            to sit quietly beside the section heading (teal, matching the panel)
            until armed, then red to signal the confirm step — reusing the
@@ -187,12 +195,14 @@
 
   {#if errorMessage}
     <p class="px-2 text-xs text-red-500 dark:text-red-400">{errorMessage}</p>
-  {:else if $taskHistory.length === 0}
+  {:else if visibleTasks.length === 0}
     <p class="px-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">No tasks yet.</p>
   {/if}
 
   <ul class="flex flex-col gap-1">
-    {#each $taskHistory.filter(t => (t.task?.trim() || t.narrative?.trim()) || t.status !== 'running') as entry (entry.id)}
+    <!-- Chat replies (`agent_response`) are not workflow runs and are excluded
+         here; see `lib/taskHistory.ts` (owner report 2026-07-23). -->
+    {#each visibleTasks as entry (entry.id)}
       <li class="flex flex-col rounded-md px-2 py-1 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10">
         <span class="truncate text-xs font-medium text-foundry-light-text dark:text-foundry-text" title={entry.task}>
           {shortTask(entry.task)}

--- a/crates/trusty-agents/ui/src/lib/catalogRefetch.test.ts
+++ b/crates/trusty-agents/ui/src/lib/catalogRefetch.test.ts
@@ -1,0 +1,51 @@
+// Unit tests for the picker-catalog refetch edge-detector (agent-picker
+// cold-start race, owner report 2026-07-23).
+//
+// Why: `App.svelte` re-drives the agent/model catalog loads when `apiReady`
+// becomes true, fixing a cold-start race where the pickers fetched once (in
+// `onMount`, before the sidecar was up) and never retried. The trigger must be
+// EDGE-triggered — fire exactly on the false→true transition and NOT on any
+// later reactive re-evaluation while `apiReady` stays true — so it can't
+// hammer the sidecar. `shouldRefetchCatalogs` is the pure predicate that
+// encodes that contract; pinning it here guards the fix without mounting the
+// Svelte component.
+
+import { describe, expect, it } from 'vitest';
+import { shouldRefetchCatalogs } from './catalogRefetch';
+
+describe('shouldRefetchCatalogs (owner report 2026-07-23)', () => {
+  it('fires once on the false→true transition', () => {
+    expect(shouldRefetchCatalogs(false, true)).toBe(true);
+  });
+
+  it('does not fire on re-evaluation while already ready (true→true)', () => {
+    expect(shouldRefetchCatalogs(true, true)).toBe(false);
+  });
+
+  it('does not fire while the API is not ready', () => {
+    expect(shouldRefetchCatalogs(false, false)).toBe(false);
+    expect(shouldRefetchCatalogs(true, false)).toBe(false);
+  });
+
+  it('drives the App.svelte pattern to exactly one fire across a lifetime', () => {
+    // Simulate the reactive statement re-running on each apiReady value the
+    // component observes: false (init) → true (health ok) → true (later ticks).
+    let prev = false;
+    let fires = 0;
+    for (const ready of [false, true, true, true]) {
+      if (shouldRefetchCatalogs(prev, ready)) fires += 1;
+      prev = ready;
+    }
+    expect(fires).toBe(1);
+  });
+
+  it('re-fires if apiReady is ever reset false→true again (reconnect-safe)', () => {
+    let prev = false;
+    let fires = 0;
+    for (const ready of [true, false, true]) {
+      if (shouldRefetchCatalogs(prev, ready)) fires += 1;
+      prev = ready;
+    }
+    expect(fires).toBe(2);
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/catalogRefetch.ts
+++ b/crates/trusty-agents/ui/src/lib/catalogRefetch.ts
@@ -1,0 +1,33 @@
+// Picker-catalog refetch trigger (agent-picker cold-start race, owner report
+// 2026-07-23).
+//
+// Why: `AgentSwitcher`/`ModelSwitcher` fetch their catalog once in `onMount`,
+// but `<Header>` — and therefore both pickers — renders before `apiReady`. On
+// a cold start the sidecar isn't listening yet, so that first fetch fails, the
+// catalog stores stay empty, and the pickers show only their built-in default
+// for the whole session with no retry. `App.svelte` re-drives the catalog
+// loads when the API becomes healthy — but the trigger must be EDGE-triggered
+// (fire exactly on the false→true transition), not level-triggered, so it runs
+// at most once and never on an unrelated reactive re-evaluation. Extracted as a
+// pure function so that contract is unit-testable without mounting `App.svelte`
+// — mirroring `taskHistory.ts`/`roster.ts`.
+// Test: `catalogRefetch.test.ts`.
+
+/**
+ * Why: the reactive block in `App.svelte` re-evaluates whenever any of its
+ * dependencies change; we only want to (re)load the picker catalogs on the
+ * moment the API goes from not-ready to ready, not on every re-evaluation.
+ * What: Returns `true` iff `apiReady` just transitioned from `false` to
+ * `true` (i.e. `apiReady && !prevApiReady`). Pure — the caller owns the
+ * `prevApiReady` bookkeeping. As `apiReady` is set `true` exactly once per app
+ * lifetime and never reset to `false`, this fires at most once; if a future
+ * change ever resets it (e.g. an explicit disconnect), the same edge logic
+ * would correctly fire again on the next reconnect.
+ * Test: `catalogRefetch.test.ts`.
+ */
+export function shouldRefetchCatalogs(
+  prevApiReady: boolean,
+  apiReady: boolean,
+): boolean {
+  return apiReady && !prevApiReady;
+}

--- a/crates/trusty-agents/ui/src/lib/taskHistory.test.ts
+++ b/crates/trusty-agents/ui/src/lib/taskHistory.test.ts
@@ -67,6 +67,20 @@ describe('isDisplayableTask (owner report 2026-07-23)', () => {
     ).toBe(true);
   });
 
+  it('keeps a running task that has a title but no narrative yet (future request-text)', () => {
+    // Guards the pre-fix `task?.trim()` disjunct: once the backend populates a
+    // request-text `task` field (flagged as a follow-up), a running task with a
+    // title but not-yet-a-narrative must still show, not be silently hidden.
+    expect(
+      isDisplayableTask({
+        type: 'task_submitted',
+        status: 'running',
+        task: 'fix the auth bug',
+        narrative: '',
+      }),
+    ).toBe(true);
+  });
+
   it('shows a legacy row with no type as long as it is not an empty running placeholder', () => {
     // Older persisted snapshots predate the `type` surface; a terminal row with
     // content must still render.

--- a/crates/trusty-agents/ui/src/lib/taskHistory.test.ts
+++ b/crates/trusty-agents/ui/src/lib/taskHistory.test.ts
@@ -1,0 +1,88 @@
+// Unit tests for the Recent Tasks display filter (owner report 2026-07-23).
+//
+// Why: `GET /api/tasks` returns every persisted `PmResponse`, including the
+// per-turn envelope stored for ordinary chat replies (`type: agent_response`
+// with an empty `task`). Those rendered as junk "(empty)" success rows in the
+// Recent Tasks panel — the owner flagged them live ("I shouldn't see these").
+// `isDisplayableTask` is the pure predicate that keeps chat turns out of the
+// workflow-oriented panel while preserving the pre-fix visibility rules for
+// every other row; pinning its contract here guards the regression without
+// mounting the Svelte component or standing up a live sidecar.
+
+import { describe, expect, it } from 'vitest';
+import {
+  CHAT_RESPONSE_TYPE,
+  isDisplayableTask,
+  visibleTaskHistory,
+} from './taskHistory';
+
+describe('isDisplayableTask (owner report 2026-07-23)', () => {
+  it('hides chat replies (agent_response), the exact junk the owner reported', () => {
+    // The two live rows: empty task, status success, but an agent_response type.
+    expect(
+      isDisplayableTask({
+        type: CHAT_RESPONSE_TYPE,
+        status: 'success',
+        narrative: 'Hi Masa. How can I assist?',
+      }),
+    ).toBe(false);
+    expect(
+      isDisplayableTask({
+        type: 'agent_response',
+        status: 'success',
+        narrative: "I don't have specific information…",
+      }),
+    ).toBe(false);
+  });
+
+  it('shows a completed workflow run', () => {
+    expect(
+      isDisplayableTask({
+        type: 'workflow_result',
+        status: 'success',
+        narrative: 'Implemented the feature and all tests pass.',
+      }),
+    ).toBe(true);
+  });
+
+  it('shows a failed (error) run — errors are not chat noise', () => {
+    expect(isDisplayableTask({ type: 'error', status: 'error', narrative: 'boom' })).toBe(
+      true,
+    );
+  });
+
+  it('hides the contentless running placeholder, keeps a running run with content', () => {
+    expect(
+      isDisplayableTask({ type: 'task_submitted', status: 'running', narrative: '' }),
+    ).toBe(false);
+    expect(
+      isDisplayableTask({ type: 'task_submitted', status: 'running', narrative: '   ' }),
+    ).toBe(false);
+    expect(
+      isDisplayableTask({
+        type: 'workflow_result',
+        status: 'running',
+        narrative: 'Researching…',
+      }),
+    ).toBe(true);
+  });
+
+  it('shows a legacy row with no type as long as it is not an empty running placeholder', () => {
+    // Older persisted snapshots predate the `type` surface; a terminal row with
+    // content must still render.
+    expect(isDisplayableTask({ status: 'success', narrative: 'done' })).toBe(true);
+    expect(isDisplayableTask({ status: 'running', narrative: '' })).toBe(false);
+  });
+});
+
+describe('visibleTaskHistory', () => {
+  it('drops chat rows and preserves order for the rest', () => {
+    const rows = [
+      { id: 'a', task: '', status: 'success', type: 'workflow_result', narrative: 'built' },
+      { id: 'b', task: '', status: 'success', type: 'agent_response', narrative: 'hi' },
+      { id: 'c', task: '', status: 'error', type: 'error', narrative: 'boom' },
+      { id: 'd', task: '', status: 'running', type: 'task_submitted', narrative: '' },
+    ];
+    expect(visibleTaskHistory(rows).map((r) => r.id)).toEqual(['a', 'c']);
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/taskHistory.ts
+++ b/crates/trusty-agents/ui/src/lib/taskHistory.ts
@@ -1,0 +1,63 @@
+// Recent Tasks display filter (owner report 2026-07-23).
+//
+// Why: `GET /api/tasks` returns EVERY persisted `PmResponse` — including the
+// per-turn envelope stored for ordinary chat replies. A Conversational or
+// Research turn (e.g. "Hi Masa. How can I assist?") is finalized as a
+// `type: "agent_response"` record with an EMPTY `task` field (the backend's
+// `PmResponse` carries no request text — see
+// `crates/trusty-agents/src/api/server/handlers.rs::submit_task`, which builds
+// the chat result from `PmResponse::running` and only sets status/narrative).
+// Rendered verbatim, those turns show up in the Recent Tasks panel as junk
+// "(empty)" rows with status "success" — which the owner flagged live: "I
+// shouldn't see these." The panel is workflow-oriented (phase stamps, score,
+// cost); casual chat turns are not workflow runs and should not appear.
+// What: `isDisplayableTask` — the single predicate the panel filters on:
+//   - drop `agent_response` (chat) envelopes entirely, and
+//   - keep the pre-existing guard that hides the contentless running
+//     placeholder (a freshly-submitted task before it has any narrative)
+//     until it has something to show.
+// Extracted as a pure function (no Svelte/store deps) so the contract is
+// unit-testable without mounting the component — matching `pollIntervalMs`
+// (`transport.ts`) / `buildRoster` (`roster.ts`).
+// Test: `taskHistory.test.ts`.
+
+import type { TaskHistoryEntry } from '../stores/app';
+
+/**
+ * The wire `type` of a plain chat reply (Conversational/Research turn),
+ * mirroring `PmResponseType::AgentResponse`'s snake_case serialization in
+ * `crates/trusty-agents/src/api/types.rs`. These are not workflow runs.
+ */
+export const CHAT_RESPONSE_TYPE = 'agent_response';
+
+/**
+ * Why: Recent Tasks lists workflow runs, not chat. Chat turns are persisted
+ * so the frontend can poll their result, but they must not clutter the panel.
+ * What: Returns `false` for `agent_response` (chat) envelopes and for a
+ * still-running placeholder that has no narrative yet; `true` otherwise.
+ * Pure — depends only on the passed entry.
+ * Test: `taskHistory.test.ts`.
+ */
+export function isDisplayableTask(
+  entry: Pick<TaskHistoryEntry, 'type' | 'status' | 'narrative'>,
+): boolean {
+  // A plain chat reply is not a task — never list it here.
+  if (entry.type === CHAT_RESPONSE_TYPE) return false;
+  // Hide the contentless in-flight placeholder until it has content to show
+  // (preserves the pre-fix behavior for non-chat rows).
+  if (entry.status === 'running' && !entry.narrative?.trim()) return false;
+  return true;
+}
+
+/**
+ * Why: Convenience wrapper so the component can apply the predicate to the
+ * whole `taskHistory` store in one call.
+ * What: Returns the subset of `entries` for which `isDisplayableTask` holds,
+ * order preserved.
+ * Test: `taskHistory.test.ts`.
+ */
+export function visibleTaskHistory<
+  T extends Pick<TaskHistoryEntry, 'type' | 'status' | 'narrative'>,
+>(entries: T[]): T[] {
+  return entries.filter(isDisplayableTask);
+}

--- a/crates/trusty-agents/ui/src/lib/taskHistory.ts
+++ b/crates/trusty-agents/ui/src/lib/taskHistory.ts
@@ -39,13 +39,19 @@ export const CHAT_RESPONSE_TYPE = 'agent_response';
  * Test: `taskHistory.test.ts`.
  */
 export function isDisplayableTask(
-  entry: Pick<TaskHistoryEntry, 'type' | 'status' | 'narrative'>,
+  entry: Pick<TaskHistoryEntry, 'type' | 'status' | 'narrative'> & {
+    task?: string;
+  },
 ): boolean {
   // A plain chat reply is not a task — never list it here.
   if (entry.type === CHAT_RESPONSE_TYPE) return false;
-  // Hide the contentless in-flight placeholder until it has content to show
-  // (preserves the pre-fix behavior for non-chat rows).
-  if (entry.status === 'running' && !entry.narrative?.trim()) return false;
+  // Hide the contentless in-flight placeholder until it has content to show.
+  // `task` is unpopulated on the wire today (no `PmResponse` request-text
+  // field), but this PR flags backend request-text population as a follow-up —
+  // keeping the `task` disjunct means a future running task that has a title
+  // but not yet a narrative still shows, matching the pre-fix guard.
+  if (entry.status === 'running' && !entry.narrative?.trim() && !entry.task?.trim())
+    return false;
   return true;
 }
 
@@ -57,7 +63,9 @@ export function isDisplayableTask(
  * Test: `taskHistory.test.ts`.
  */
 export function visibleTaskHistory<
-  T extends Pick<TaskHistoryEntry, 'type' | 'status' | 'narrative'>,
+  T extends Pick<TaskHistoryEntry, 'type' | 'status' | 'narrative'> & {
+    task?: string;
+  },
 >(entries: T[]): T[] {
   return entries.filter(isDisplayableTask);
 }

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -73,6 +73,16 @@ export interface TaskHistoryEntry {
   id: string;
   task: string;
   status: string;
+  /**
+   * The server `PmResponse`'s response-envelope kind, on the wire as the
+   * `type` key (`workflow_result` | `agent_response` | `task_submitted` |
+   * `error`). `agent_response` marks a plain chat reply (a Conversational or
+   * Research turn) rather than a workflow run; the Recent Tasks panel uses
+   * this to exclude chat turns from the workflow-oriented list (see
+   * `lib/taskHistory.ts`). Optional so older persisted snapshots and the
+   * frontend's own placeholders still typecheck.
+   */
+  type?: string;
   score?: number;
   score_max?: number;
   cost_usd?: number;


### PR DESCRIPTION
Two demo-visible GUI regressions in the trusty-agents desktop app, reported live by the owner on the freshly installed build (main @ `09c2c9dd`). Both fixes are **frontend-only** (no Rust changed).

## BUG 1 — agent picker missing Izzie / CTO Bot

**Root cause is a cold-start race, not the roster data.** `AgentSwitcher` (and `ModelSwitcher`) fetch their catalog exactly once in `onMount`, but `<Header>` — and therefore both pickers — renders unconditionally, *before* `apiReady`. On a packaged-app cold start the sidecar isn't listening yet, so the single `GET /api/agents` fetch fails, `catalogAgents` stays `[]` with **no retry**, and the roster is just the built-in "Assistant" for the whole session — Izzie/CTO Bot never selectable. This is why the report didn't reproduce after the fact (once the sidecar is up, a fresh fetch returns everything, but the app only fetched once at mount).

**Fix:** `App.svelte` re-drives the agent + model catalog loads (and the overlay refresh) when `apiReady` goes true, via a pure **edge-detector** `lib/catalogRefetch.ts::shouldRefetchCatalogs(prevApiReady, apiReady)` (fires only on the false→true transition) invoked from a named `refetchPickerCatalogsOnReady`, backfilling the already-mounted pickers through their reactive stores. `apiReady` is set true once and never reset, so this fires at most once per app lifetime.

**Roster diff (verified against the live `.app` sidecar on :8765):**
- `GET /api/agents` returns **22** agents — including `izzie` and `cto-assistant` (both shipped as directory packages with `agent.toml` + `persona.md`).
- `buildRoster()` over that data renders **22** rows including **"Izzie"** and **"CTO Bot"** — i.e. **nothing is dropped**; the API/roster/loader were already correct.
- Tonight's `grep` edit to `~/.trusty-agents/agents/izzie/agent.toml` does **NOT** exclude izzie from the picker path — it still appears in `/api/agents`. No loader-tolerance change is needed, and the owner's config was not touched.

## BUG 2 — Recent Tasks showing junk "(empty)" success rows

Every chat turn (a Conversational/Research message) is finalized as a `type: "agent_response"` `PmResponse` with an empty request field (`handlers.rs::submit_task` builds the chat result from `PmResponse::running` and sets only status/narrative; `PmResponse` carries no request-text field). So `GET /api/tasks` returns these chat turns, and the workflow-oriented Recent Tasks panel rendered them as `(empty)` success rows. (Confirmed live: the two rows the owner saw were `agent_response`/`success` with empty `task` and narratives "Hi Masa. How can I assist?" / "I don't have specific…".)

**Fix:** the panel now filters on a shared pure predicate — `lib/taskHistory.ts::isDisplayableTask` — that **excludes `agent_response` (chat) envelopes** (chat is not a workflow run) while keeping the pre-existing rule that hides the contentless running placeholder (`running && no narrative && no task title`). The empty-state message and the Clear affordance key off the visible count. Judgment call per the brief: chat turns *shouldn't appear* in Recent Tasks at all, so this filters them out rather than merely relabeling untitled rows (every row is untitled today, since no `PmResponse` carries request text — filtering on empty title would hide everything).

## Files
- `App.svelte` — edge-triggered refetch of catalogs on `apiReady` (BUG 1)
- `lib/catalogRefetch.ts` (new) + `lib/catalogRefetch.test.ts` (new) — the pure `apiReady` edge-detector + tests
- `lib/taskHistory.ts` (new) + `components/TaskHistory.svelte` + `stores/app.ts` — display filter (BUG 2)
- `lib/taskHistory.test.ts` (new) — pins the predicate
- `CHANGELOG.md`

## Gates
- `pnpm test:unit` — **90 passed** (9 files, incl. `taskHistory.test.ts` + `catalogRefetch.test.ts`)
- `pnpm check` — **0 errors** (2 pre-existing a11y warnings in unrelated `ProjectsView.svelte`)
- `pnpm build` — **ok**
- Live verification: ran the real helper over the live `/api/tasks` — the two junk chat rows filter to **0 visible**.

No Rust files changed, so crate-scoped `cargo` gates and the `scripts/check_*` lint scripts don't apply.

## Review follow-up (critic APPROVE, 2 non-blocking findings — addressed in the 2nd commit)
- **MEDIUM** — the `apiReady` refetch block had no test coverage → extracted `shouldRefetchCatalogs` as a pure edge-detector with a vitest suite (fires once on false→true, not on re-eval; lifetime sim = 1 fire; reconnect sim = 2); corrected the comment (fires at most once, not "on any later reconnect").
- **LOW** — `isDisplayableTask` had dropped the pre-fix `task?.trim()` disjunct → restored it so a future running task with a title-but-no-narrative still shows once backend request-text population lands; added a regression test.

## Note (latent, not fixed — out of scope)
`PmResponse` has no request-text field, so any *workflow* run that does appear in Recent Tasks still renders its title as `(empty)`. Not the reported bug (the demo path is chat), but worth a follow-up to populate a title backend-side.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools