### PR TITLE
fix(trusty-agents): accept directory-package personas in Telegram /switch pre-check

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -63,6 +63,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `agent_response` (chat) envelopes — chat is not a workflow run — while keeping
   the pre-existing rule that hides the contentless running placeholder; the
   empty-state and Clear affordance now key off the visible count.
+- **Telegram `/switch assistant` now resolves the canonical package persona:**
+  the `/switch` pre-check validated FLAT persona files only
+  (`.trusty-agents/agents/<name>.toml` and the `$HOME` equivalent), so the
+  canonical `assistant` persona — which ships ONLY as a directory package
+  (`agents/assistant/agent.toml` + `persona.md`, no flat `assistant.toml`) —
+  was rejected with "Unknown persona: assistant" even though the real dispatch
+  resolver (`AgentConfig::by_name_async`) loads directory packages fine. The
+  pre-check (both the project-local tier and the `$HOME` fallback) now also
+  accepts a directory package (`agents/<name>/agent.toml`), mirroring the
+  resolver's order. No alias-table or migration changes.
 - **MCP tool results no longer collapse the live conversation to the system
   prompt:** an MCP tool result (e.g. `grep` via trusty-search) is shrunk by no
   `compress_tool_output` filter and can be multiple megabytes; the send-time

--- a/crates/trusty-agents/src/telegram/handlers.rs
+++ b/crates/trusty-agents/src/telegram/handlers.rs
@@ -24,7 +24,7 @@ use super::pairing::{
     PAIRING_CODE_TTL, PairOutcome, PairedChats, PendingPairs, SENTINEL_PAIRING_CHAT_ID,
     save_paired_chats, verify_pair_attempt,
 };
-use super::{ChatSession, SessionMap, home_persona_exists};
+use super::{ChatSession, SessionMap, home_persona_exists, project_persona_exists};
 use crate::ctrl::{self, ConversationTurn};
 
 /// Slash commands exposed to Telegram users.
@@ -444,11 +444,10 @@ async fn handle_switch(
             .map(|s| s.project_path.clone())
             .unwrap_or_else(|| (**project_path).clone())
     };
-    let persona_path = session_project_path
-        .join(".trusty-agents")
-        .join("agents")
-        .join(format!("{stem}.toml"));
-    if persona_path.exists() || home_persona_exists(&stem) {
+    // Accept both the flat `<stem>.toml` and the directory-package
+    // `<stem>/agent.toml` forms, mirroring `AgentConfig::by_name_async`, so a
+    // package-only persona (e.g. the canonical `assistant`) resolves here.
+    if project_persona_exists(&session_project_path, &stem) || home_persona_exists(&stem) {
         let mut map = sessions.lock().await;
         let entry = map
             .entry(chat_id)

--- a/crates/trusty-agents/src/telegram/mod.rs
+++ b/crates/trusty-agents/src/telegram/mod.rs
@@ -112,12 +112,22 @@ pub(super) type SessionMap = Arc<Mutex<HashMap<ChatId, ChatSession>>>;
 /// directory package (`agents/assistant/agent.toml` + `persona.md`, no flat
 /// `assistant.toml`), so the old flat-only pre-check rejected `/switch
 /// assistant` with "Unknown persona" even though dispatch resolves it fine.
-/// What: returns true iff either form exists directly under `agents_dir`.
+/// What: returns true iff either a flat `<name>.toml` exists, OR a COMPLETE
+/// directory package exists. `load_agent_package` reads `<name>/agent.toml`
+/// AND `<name>/persona.md` UNCONDITIONALLY (no `Ok(None)` fallback if the
+/// persona is missing), so the package branch requires BOTH — otherwise an
+/// incomplete package (agent.toml only) would pass the pre-check here and then
+/// hard-fail on the next turn's load, the exact failure this pre-check exists
+/// to prevent.
 /// Test: `persona_exists_in_accepts_directory_package`,
-/// `persona_exists_in_rejects_unknown_name`.
+/// `persona_exists_in_rejects_unknown_name`,
+/// `persona_exists_in_rejects_package_missing_persona_md`.
 fn persona_exists_in(agents_dir: &std::path::Path, name: &str) -> bool {
-    agents_dir.join(format!("{name}.toml")).exists()
-        || agents_dir.join(name).join("agent.toml").exists()
+    if agents_dir.join(format!("{name}.toml")).exists() {
+        return true;
+    }
+    let pkg = agents_dir.join(name);
+    pkg.join("agent.toml").exists() && pkg.join("persona.md").exists()
 }
 
 /// Whether a persona resolves under a project's `.trusty-agents/agents/` dir,

--- a/crates/trusty-agents/src/telegram/mod.rs
+++ b/crates/trusty-agents/src/telegram/mod.rs
@@ -102,24 +102,59 @@ impl ChatSession {
 /// Map of `ChatId` -> per-chat session, shared across handlers.
 pub(super) type SessionMap = Arc<Mutex<HashMap<ChatId, ChatSession>>>;
 
-/// Check whether a persona TOML exists under the user's home config dir.
+/// Whether a persona resolves under `<agents_dir>` — as a flat `<name>.toml`
+/// OR a directory package `<name>/agent.toml`.
+///
+/// Why: the `/switch` pre-check must mirror the real dispatch resolver
+/// `AgentConfig::by_name_async` (`agents/loader.rs`), which resolves a
+/// directory package (`load_agent_package`: `<name>/agent.toml`) BEFORE the
+/// flat `<name>.toml`. The canonical `assistant` persona ships ONLY as a
+/// directory package (`agents/assistant/agent.toml` + `persona.md`, no flat
+/// `assistant.toml`), so the old flat-only pre-check rejected `/switch
+/// assistant` with "Unknown persona" even though dispatch resolves it fine.
+/// What: returns true iff either form exists directly under `agents_dir`.
+/// Test: `persona_exists_in_accepts_directory_package`,
+/// `persona_exists_in_rejects_unknown_name`.
+fn persona_exists_in(agents_dir: &std::path::Path, name: &str) -> bool {
+    agents_dir.join(format!("{name}.toml")).exists()
+        || agents_dir.join(name).join("agent.toml").exists()
+}
+
+/// Whether a persona resolves under a project's `.trusty-agents/agents/` dir,
+/// in either the flat or directory-package form (see [`persona_exists_in`]).
+///
+/// Why (#457): the project-local tier of the `/switch` pre-check — checked
+/// before the `$HOME` fallback, mirroring ctrl's resolution order.
+/// What: delegates to [`persona_exists_in`] rooted at
+/// `<project_path>/.trusty-agents/agents/`.
+/// Test: `project_persona_exists_accepts_directory_package`,
+/// `project_persona_exists_rejects_unknown_name`.
+pub(super) fn project_persona_exists(project_path: &std::path::Path, name: &str) -> bool {
+    persona_exists_in(&project_path.join(".trusty-agents").join("agents"), name)
+}
+
+/// Check whether a persona exists under the user's home config dir.
 ///
 /// Why (#457): `/switch <name>` must validate that the persona actually
 /// resolves before storing it on the session — otherwise the next turn
 /// would fail in `run_pm_task_with_persona` with a load error. We check
-/// `~/.trusty-agents/agents/<name>.toml` as a fallback after the project-local
-/// path so user-level persona definitions also work.
-/// What: Returns `true` iff `$HOME/.trusty-agents/agents/<name>.toml` is a file.
-/// Test: Indirectly via the `/switch` handler.
+/// `~/.trusty-agents/agents/` as a fallback after the project-local path so
+/// user-level persona definitions also work.
+/// What: Returns `true` iff `$HOME/.trusty-agents/agents/<name>` resolves as a
+/// flat `<name>.toml` or a directory package `<name>/agent.toml` (see
+/// [`persona_exists_in`]).
+/// Test: the directory-package acceptance shared with the project tier is
+/// covered by `persona_exists_in_accepts_directory_package`.
 pub(super) fn home_persona_exists(name: &str) -> bool {
     std::env::var("HOME")
         .ok()
         .map(|h| {
-            std::path::PathBuf::from(h)
-                .join(".trusty-agents")
-                .join("agents")
-                .join(format!("{name}.toml"))
-                .exists()
+            persona_exists_in(
+                &std::path::PathBuf::from(h)
+                    .join(".trusty-agents")
+                    .join("agents"),
+                name,
+            )
         })
         .unwrap_or(false)
 }

--- a/crates/trusty-agents/src/telegram/tests.rs
+++ b/crates/trusty-agents/src/telegram/tests.rs
@@ -506,3 +506,74 @@ fn tempdir_for_test() -> PathBuf {
         .expect("create unique tempdir for telegram pid-guard test")
         .keep()
 }
+
+// ── `/switch` persona pre-check resolution (directory-package fix) ──────────
+//
+// Why: the Telegram `/switch <name>` pre-check must accept the SAME persona
+// forms the real dispatch resolver `AgentConfig::by_name_async` does — a
+// directory package (`<name>/agent.toml`) as well as a flat `<name>.toml`.
+// The canonical `assistant` persona ships package-only, so a flat-only
+// pre-check regressed `/switch assistant` to "Unknown persona".
+
+/// Create `<agents_dir>/<name>/agent.toml` (+ a minimal `persona.md`), the
+/// directory-package layout `load_agent_package` resolves.
+fn write_package_persona(agents_dir: &std::path::Path, name: &str) {
+    let pkg = agents_dir.join(name);
+    std::fs::create_dir_all(&pkg).unwrap();
+    std::fs::write(pkg.join("agent.toml"), "[agent]\nname = \"x\"\n").unwrap();
+    std::fs::write(pkg.join("persona.md"), "persona").unwrap();
+}
+
+/// Why: the shared core of BOTH `/switch` pre-check tiers (project + `$HOME`)
+/// must accept a directory package, not just a flat `.toml` — the exact gap
+/// that broke `/switch assistant`.
+/// What: a package-only persona and a flat persona each resolve `true`.
+#[test]
+fn persona_exists_in_accepts_directory_package() {
+    let agents_dir = tempdir_for_test();
+    write_package_persona(&agents_dir, "assistant");
+    std::fs::write(agents_dir.join("izzie.toml"), "[agent]\nname = \"izzie\"\n").unwrap();
+
+    assert!(
+        super::persona_exists_in(&agents_dir, "assistant"),
+        "directory-package persona (assistant/agent.toml) must resolve"
+    );
+    assert!(
+        super::persona_exists_in(&agents_dir, "izzie"),
+        "flat persona (izzie.toml) must still resolve"
+    );
+}
+
+/// Why: a genuinely unknown name must still be rejected so `/switch` reports
+/// "Unknown persona" rather than storing an unresolvable persona.
+/// What: neither a flat file nor a package dir exists → `false`.
+#[test]
+fn persona_exists_in_rejects_unknown_name() {
+    let agents_dir = tempdir_for_test();
+    assert!(!super::persona_exists_in(&agents_dir, "does-not-exist"));
+}
+
+/// Why: the project-local tier of the `/switch` pre-check (checked before the
+/// `$HOME` fallback) is the one that resolves a repo's canonical `assistant`
+/// package — the demo path.
+/// What: a project whose `.trusty-agents/agents/assistant/` is a package
+/// resolves `true`.
+#[test]
+fn project_persona_exists_accepts_directory_package() {
+    let project = tempdir_for_test();
+    let agents_dir = project.join(".trusty-agents").join("agents");
+    write_package_persona(&agents_dir, "assistant");
+
+    assert!(
+        super::project_persona_exists(&project, "assistant"),
+        "package-only assistant persona must validate for /switch"
+    );
+}
+
+/// Why: negative guard for the project tier — an unknown name is rejected.
+/// What: an empty project resolves `false`.
+#[test]
+fn project_persona_exists_rejects_unknown_name() {
+    let project = tempdir_for_test();
+    assert!(!super::project_persona_exists(&project, "nope"));
+}

--- a/crates/trusty-agents/src/telegram/tests.rs
+++ b/crates/trusty-agents/src/telegram/tests.rs
@@ -553,6 +553,24 @@ fn persona_exists_in_rejects_unknown_name() {
     assert!(!super::persona_exists_in(&agents_dir, "does-not-exist"));
 }
 
+/// Why: `load_agent_package` reads `persona.md` unconditionally, so a package
+/// with `agent.toml` but no `persona.md` would pass a naive pre-check and then
+/// hard-fail on the next turn's load — the exact failure the pre-check guards
+/// against. It must be rejected here.
+/// What: an `agent.toml`-only package (no `persona.md`) resolves `false`.
+#[test]
+fn persona_exists_in_rejects_package_missing_persona_md() {
+    let agents_dir = tempdir_for_test();
+    let pkg = agents_dir.join("assistant");
+    std::fs::create_dir_all(&pkg).unwrap();
+    std::fs::write(pkg.join("agent.toml"), "[agent]\nname = \"x\"\n").unwrap();
+    // No persona.md written.
+    assert!(
+        !super::persona_exists_in(&agents_dir, "assistant"),
+        "an incomplete package (agent.toml without persona.md) must NOT validate"
+    );
+}
+
 /// Why: the project-local tier of the `/switch` pre-check (checked before the
 /// `$HOME` fallback) is the one that resolves a repo's canonical `assistant`
 /// package — the demo path.


### PR DESCRIPTION
## Bug

The Telegram gateway's `/switch <name>` **pre-check** only validated FLAT persona files:
- `handle_switch` (`handlers.rs`) checked `.trusty-agents/agents/<stem>.toml`
- `home_persona_exists` (`telegram/mod.rs`) checked `$HOME/.trusty-agents/agents/<name>.toml`

The canonical **`assistant`** persona ships ONLY as a **directory package** (`agents/assistant/agent.toml` + `persona.md`, no flat `assistant.toml`), so `/switch assistant` returned **"Unknown persona: assistant"** — even though the real dispatch resolver `AgentConfig::by_name_async` (`agents/loader.rs` → `load_agent_package`) resolves directory packages fine. Only the Telegram pre-flight was stale.

## Fix (~10 lines of logic)

Extract a shared `persona_exists_in(agents_dir, name)` predicate that accepts **both** a flat `<name>.toml` **and** a directory package `<name>/agent.toml`, mirroring the resolver's resolution order, and route both pre-check tiers through it:
- new `project_persona_exists(project_path, name)` — the project-local tier, called by `handle_switch`
- `home_persona_exists` — the `$HOME` fallback, now package-aware

No alias-table changes; nothing else migrated.

## Tests (new, in `telegram/tests.rs`)

- `persona_exists_in_accepts_directory_package` — package-only AND flat persona both resolve
- `persona_exists_in_rejects_unknown_name` — negative
- `project_persona_exists_accepts_directory_package` — the demo path: a project's `assistant/` package validates
- `project_persona_exists_rejects_unknown_name` — negative

## Gates

- `cargo check -p trusty-agents`: clean
- `cargo clippy -p trusty-agents --all-targets -- -D warnings`: clean
- `cargo test -p trusty-agents`: **2315 passed / 0 failed**
- `cargo fmt --all --check`: clean
- `scripts/check_line_cap.sh`: `0 violations — OK`
- `scripts/check_test_pointers.sh`: `0 dangling pointers — OK`

Refs #457

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools