### PR TITLE
fix(trusty-installer): robust from-scratch curl|sh -y install for the demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11584,7 +11584,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -6,6 +6,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.4.6] — 2026-07-23
+
+### Fixed
+
+- The `-y`/`--yes` non-interactive prereq install path (`tctl install -y`, and the `curl | sh -s -- -y` one-liner it powers) now actually runs the auto-install command for a missing prereq (`tmux`, `claude`) instead of degrading to a manual-only hint — the auto-install offer previously required a real TTY (`tty_fn()`) even under `--yes`, so a piped install (stdin never a TTY) silently skipped installing tmux/Claude Code despite the operator's explicit unattended consent. `--json` mode is unaffected: it remains fully non-interactive/no-auto-install.
+- `tctl install tga` (and any transitive install that includes it) now resolves the correct release asset. `tga`'s release tag is `tga-v<version>`, but its release workflow names the tarball after the crate directory, `trusty-git-analytics-<version>-<target>.tar.gz` — the installer was building `tga-<version>-<target>.tar.gz` from the crate name alone, which 404s. Asset-filename construction now resolves through a small crate-name → asset-name alias table (tag resolution is unaffected).
+- A from-scratch `tctl install` (the single-URL installer's default path) on a host with no Rust toolchain no longer fails the whole run with `installed 4/7 … exit 2 … NOT VERIFIED` when an OPTIONAL stable-set member (`trusty-analyze`, `trusty-console`, `tga`) has no prebuilt for the platform and cannot fall back to `cargo install`. Stable-set members are now classified REQUIRED (trusty-mpm + trusty-search + trusty-memory + trusty-review) vs OPTIONAL; an OPTIONAL member's install/health failure is reported as "skipped (no prebuilt for this platform)" and never flips the overall `all_ok`/`verified` verdict or the process exit code — only a REQUIRED member's failure does.
+
 ## [0.4.5] — 2026-07-21
 
 ### Fixed

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-installer"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -31,10 +31,14 @@
 //! unknown-member handling, and the dry-run report shaping; the network /
 //! `cargo install` path and the confirmation gate's TTY plumbing are
 //! side-effecting / covered by `super::install_gate::tests`.
+//!
+//! Report/outcome types, the `--dry-run` preview, and human-summary
+//! rendering live in the sibling `install_report.rs` (mirrors the
+//! `install.rs` / `install_tests.rs` split) to keep this file under the
+//! 500-line production cap (CLAUDE.md / `scripts/check_line_cap.sh`).
 
 use std::path::{Path, PathBuf};
 
-use serde::Serialize;
 use trusty_progress::{Component, ComponentTracker};
 
 use super::dependency_graph::describe_added;
@@ -45,300 +49,15 @@ use super::service_bootstrap::{
     bootstrap_enabled, bootstrap_member_service, BootstrapAction, NO_SERVICE_ENV,
 };
 use super::shadow_check;
-use super::stable_set::{select_members_transitive, ManageStrategy, StableMember};
+use super::stable_set::{select_members_transitive, StableMember};
 use crate::output::render_json;
 
-/// One member's install outcome for the `--json` report.
-///
-/// Why: A typed per-member result keeps the machine output stable and testable.
-/// `service_ok` / `service_detail` were added after a review of #2566 found
-/// that a genuine `service install` failure was reported ONLY via an info-level
-/// narration line — `--json` output claimed `all_ok: true` / exit 0 even when
-/// every daemon's launchd bootstrap had failed, which is precisely the failure
-/// class #2557 existed because of (a broken daemon that LOOKS installed).
-/// What: `member` is the crate name; `ok` whether the binary install +
-/// health-gate succeeded; `detail` a human note (e.g. the error on binary
-/// failure). `service_ok` is `true` when the post-install launchd service
-/// bootstrap was not attempted (bootstrap disabled, non-service member, or a
-/// plist already present — none of those are failures) OR when it ran and
-/// succeeded; it is `false` ONLY when `service install` was attempted and
-/// genuinely errored. `service_detail` carries the human note for whichever
-/// case applied. `shadow_ok` / `shadow_detail` (#3554) are the analogous pair
-/// for PATH-shadow detection: `shadow_ok` is `false` ONLY when the
-/// just-installed binary is provably shadowed by a DIFFERENT, earlier-PATH
-/// copy of the same name (see `super::shadow_check`) — a genuine "the new
-/// version will not take effect" condition, never silently swallowed into a
-/// reported success. `required` (graceful-degrade, demo-critical fix) mirrors
-/// `StableMember::required`: an OPTIONAL member's failure is reported here
-/// (`ok: false`) but never flips [`InstallReport::all_ok`] / the exit code.
-/// Test: `tests::report_serialises`, `tests::report_all_ok_reflects_service_failure`,
-/// `tests::report_all_ok_reflects_shadow_failure`,
-/// `tests::report_all_ok_ignores_optional_failure`.
-#[derive(Clone, Debug, Serialize)]
-pub struct InstallOutcome {
-    /// Crate name installed.
-    pub member: String,
-    /// Whether install + health-gate succeeded.
-    pub ok: bool,
-    /// Human detail / error message.
-    pub detail: String,
-    /// Whether the post-install service bootstrap succeeded or was not
-    /// attempted (see field doc above for the false-only-on-genuine-failure
-    /// contract).
-    pub service_ok: bool,
-    /// Human note for the service bootstrap outcome.
-    pub service_detail: String,
-    /// `false` ONLY when the just-installed binary is shadowed on `$PATH` by
-    /// a different, stale copy (#3554); `true` when clear or not applicable.
-    pub shadow_ok: bool,
-    /// Human note for the shadow-detection outcome (the actionable
-    /// `ShadowReport::message`, or empty when `shadow_ok`).
-    pub shadow_detail: String,
-    /// Whether this member is REQUIRED for a verified overall run (mirrors
-    /// `StableMember::required`). Drives [`InstallReport::build`]'s `all_ok`
-    /// derivation and the human summary's skip-vs-fail wording.
-    pub required: bool,
-}
-
-impl InstallOutcome {
-    /// Build the `service_ok = true`, empty-detail outcome for a member whose
-    /// binary install failed (never reached the service-bootstrap step).
-    ///
-    /// Why: a binary-install failure and a service-bootstrap failure are
-    /// distinct failure classes; a binary that never installed cannot have a
-    /// "failed" service bootstrap — centralising this avoids a copy-pasted
-    /// `service_ok: true, service_detail: String::new()` at every call site.
-    /// What: returns `(true, "")`&nbsp;— not-applicable, not a failure.
-    /// Test: exercised via `tests::report_all_ok` (binary failure alone still
-    /// yields `all_ok == false` from `ok`, independent of this default).
-    fn service_not_attempted() -> (bool, String) {
-        (true, String::new())
-    }
-}
-
-/// The aggregate install report.
-///
-/// Why: `--json` consumers want the whole rollup in one object with an overall
-/// verdict; the human path renders the same data as a component table.
-/// What: Holds per-member outcomes and the computed `all_ok`.
-/// Test: `tests::report_serialises`, `tests::report_all_ok`,
-/// `tests::report_all_ok_reflects_service_failure`.
-#[derive(Clone, Debug, Serialize)]
-pub struct InstallReport {
-    /// Fixed command tag for JSON consumers.
-    pub command: &'static str,
-    /// Per-member install outcomes in install order.
-    pub members: Vec<InstallOutcome>,
-    /// Whether every REQUIRED member installed AND every attempted service
-    /// bootstrap on a REQUIRED member succeeded (see [`InstallOutcome`]'s
-    /// field docs for what counts as a service failure) AND, when the verify
-    /// tail ran, it reported verified. An OPTIONAL member's failure never
-    /// flips this (graceful-degrade, demo-critical fix).
-    pub all_ok: bool,
-    /// The post-install verify-tail result (#2560): `ensure` + health (with
-    /// the #2498 kickstart retry). `None` when `--no-verify` skipped it.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub verify: Option<super::verify_tail::VerifyTailReport>,
-}
-
-impl InstallReport {
-    /// Build a report from per-member outcomes.
-    ///
-    /// Why: Centralises the `all_ok` derivation so the exit code and JSON agree,
-    /// and so the report cannot claim success while a genuine service-bootstrap
-    /// failure occurred (#2566 review finding) OR a genuine PATH-shadow
-    /// condition (#3554) leaves the just-installed binary unreachable from a
-    /// plain shell invocation — both are "looks installed, actually not
-    /// live" failures the report must never paper over.
-    /// What: Sets `command = "install"`, `verify = None`, and
-    /// `all_ok = every REQUIRED outcome has ok == true AND service_ok == true
-    /// AND shadow_ok == true` (graceful-degrade, demo-critical fix: an
-    /// OPTIONAL member is excluded from this check entirely — its failure is
-    /// visible in `members` but never fails the run).
-    /// Test: `tests::report_all_ok`, `tests::report_all_ok_reflects_service_failure`,
-    /// `tests::report_all_ok_reflects_shadow_failure`,
-    /// `tests::report_all_ok_ignores_optional_failure`.
-    fn build(members: Vec<InstallOutcome>) -> Self {
-        let all_ok = members
-            .iter()
-            .filter(|m| m.required)
-            .all(|m| m.ok && m.service_ok && m.shadow_ok);
-        Self {
-            command: "install",
-            members,
-            all_ok,
-            verify: None,
-        }
-    }
-
-    /// Fold the post-install verify-tail result into this report (#2560).
-    ///
-    /// Why: `--json` consumers must see ONE object whose `all_ok` (and hence
-    /// exit code) already reflects the verify-tail outcome — a caller must
-    /// never read `all_ok: true` while the verify tail reported an unhealthy
-    /// stack (the exact "looks installed, actually broken" class #2557 /
-    /// #2498 existed because of).
-    /// What: attaches `verify`; if it reports `!verified`, flips `all_ok` to
-    /// `false` (binary + service success alone does not override a verify
-    /// failure).
-    /// Test: `tests::with_verify_failure_flips_all_ok`,
-    /// `tests::with_verify_success_preserves_all_ok`.
-    fn with_verify(mut self, verify: super::verify_tail::VerifyTailReport) -> Self {
-        if !verify.verified {
-            self.all_ok = false;
-        }
-        self.verify = Some(verify);
-        self
-    }
-
-    /// Process exit code: 0 when all installed, 2 when any failed.
-    ///
-    /// Why: A boot/automation script branches on this.
-    /// What: `0` if `all_ok`, else `2` (partial/total failure — stack degraded).
-    /// Test: `tests::exit_code_reflects_all_ok`.
-    fn exit_code(&self) -> i32 {
-        if self.all_ok {
-            0
-        } else {
-            2
-        }
-    }
-}
-
-/// One member's planned (not-yet-applied) install action for `--dry-run`.
-///
-/// Why: `--dry-run` (#2112) must show the operator the exact blast radius —
-/// what `tctl install` would do — without doing it; a typed row keeps that
-/// preview consistent with the real [`InstallOutcome`] shape it stands in for.
-/// What: `member` / `binary` mirror [`StableMember`]; `service_bootstrap` is
-/// `true` when a launchd `service install` would be attempted for this member
-/// (service bootstrap enabled AND the member is [`ManageStrategy::Launchd`]).
-/// Test: `tests::dry_run_report_shape`.
-#[derive(Clone, Debug, Serialize)]
-pub struct DryRunMember {
-    /// Crate name that would be installed.
-    pub member: String,
-    /// Binary name that would land on PATH.
-    pub binary: String,
-    /// Whether a post-install launchd service bootstrap would be attempted.
-    pub service_bootstrap: bool,
-}
-
-/// The `--dry-run` preview report (#2112).
-///
-/// Why: Mirrors [`InstallReport`]'s shape (`command`, per-member rows) so
-/// `--json` consumers get a familiar, stable envelope, with `dry_run: true`
-/// as the discriminator instead of an `all_ok` verdict (nothing was applied).
-/// What: `members` lists every member that WOULD be installed, in install
-/// order; `service_bootstrap_enabled` is the resolved `--no-service` /
-/// `TCTL_NO_SERVICE_BOOTSTRAP` state applied to the preview.
-/// Test: `tests::dry_run_report_shape`.
-#[derive(Clone, Debug, Serialize)]
-pub struct DryRunReport {
-    /// Fixed command tag for JSON consumers.
-    pub command: &'static str,
-    /// Always `true` — discriminates this envelope from [`InstallReport`].
-    pub dry_run: bool,
-    /// Members that would be installed, in install order.
-    pub members: Vec<DryRunMember>,
-    /// Whether the post-install service bootstrap step is enabled.
-    pub service_bootstrap_enabled: bool,
-}
-
-/// Whether an install (real or previewed) would attempt a launchd service
-/// bootstrap for `m`.
-///
-/// Why: The `--dry-run` preview (`build_dry_run_report`) and the real install
-/// loop (`install_all`) must never drift on this decision — a preview that
-/// disagrees with reality is worse than no preview at all. A single shared
-/// predicate is the only way to guarantee that.
-/// What: `true` when the post-install service-bootstrap step is enabled AND
-/// `m` is a [`ManageStrategy::Launchd`]-managed member.
-/// Test: `tests::dry_run_report_shape` (via `build_dry_run_report`);
-/// `install_all`'s use is exercised indirectly by the (side-effecting) install
-/// path.
-fn plans_service_bootstrap(m: &StableMember, service_enabled: bool) -> bool {
-    service_enabled && m.manage == ManageStrategy::Launchd
-}
-
-/// Whether an install would attempt the trusty-mpm launchd SUPERVISOR
-/// bootstrap for `m` (#3527).
-///
-/// Why: `install_mpm_supervisor()` used to run UNCONDITIONALLY whenever
-/// trusty-mpm installed — the one member exempt from the #2556
-/// `plans_service_bootstrap` opt-out, because trusty-mpm's
-/// [`ManageStrategy::OwnVerb`] makes that Launchd-only predicate always return
-/// `false` for it regardless of `service_enabled`. This mirrors
-/// `plans_service_bootstrap`'s *intent* (respect `--no-service` /
-/// `TCTL_NO_SERVICE_BOOTSTRAP`) for the supervisor specifically, so trusty-mpm
-/// is no longer the one member that ignores the opt-out.
-/// What: `true` iff `service_enabled` AND `m.crate_name == "trusty-mpm"`.
-/// Test: `tests::plans_mpm_supervisor_bootstrap_respects_flag`.
-fn plans_mpm_supervisor_bootstrap(m: &StableMember, service_enabled: bool) -> bool {
-    service_enabled && m.crate_name == "trusty-mpm"
-}
-
-/// Build the `--dry-run` preview report from the resolved member set.
-///
-/// Why: Extracted so the report's shaping is unit-testable without stdout.
-/// What: Maps each [`StableMember`] to a [`DryRunMember`], computing
-/// `service_bootstrap` via the shared [`plans_service_bootstrap`] predicate so
-/// the preview can never drift from what `install_all` actually does.
-/// Test: `tests::dry_run_report_shape`.
-fn build_dry_run_report(selected: &[StableMember], service_enabled: bool) -> DryRunReport {
-    let members = selected
-        .iter()
-        .map(|m| DryRunMember {
-            member: m.crate_name.clone(),
-            binary: m.binary.clone(),
-            service_bootstrap: plans_service_bootstrap(m, service_enabled),
-        })
-        .collect();
-    DryRunReport {
-        command: "install",
-        dry_run: true,
-        members,
-        service_bootstrap_enabled: service_enabled,
-    }
-}
-
-/// Print the `--dry-run` preview and return the process exit code.
-///
-/// Why: A dry run never fails on its own account — it only reports what WOULD
-/// happen; a resolution error (unknown member) is caught earlier in `run`.
-/// What: `--json` emits [`DryRunReport`] via `render_json`; otherwise prints a
-/// human blast-radius summary matching the wording the confirmation prompt
-/// used, one line per member noting whether it would bootstrap a service.
-/// Returns `0` unless the `--json` write itself fails, in which case `1`
-/// (mirrors the real install path's failed-JSON-write handling below).
-/// Test: Side-effect-only (stdout); the data it prints is covered by
-/// `tests::dry_run_report_shape`.
-fn print_dry_run(selected: &[StableMember], service_enabled: bool, json: bool) -> i32 {
-    let report = build_dry_run_report(selected, service_enabled);
-    if json {
-        if render_json(&report).is_err() {
-            eprintln!("tctl install: failed to write JSON output");
-            return 1;
-        }
-        return 0;
-    }
-    let names: Vec<&str> = report.members.iter().map(|m| m.member.as_str()).collect();
-    eprintln!(
-        "tctl install: DRY RUN — would install {} tool(s): {}",
-        report.members.len(),
-        names.join(", ")
-    );
-    for m in &report.members {
-        let svc = if m.service_bootstrap {
-            "would bootstrap launchd service"
-        } else {
-            "no service bootstrap"
-        };
-        eprintln!("tctl install:   {} -> {} ({svc})", m.member, m.binary);
-    }
-    eprintln!("tctl install: dry run complete — no changes made.");
-    0
-}
+#[path = "install_report.rs"]
+mod install_report;
+use install_report::{
+    plans_mpm_supervisor_bootstrap, plans_service_bootstrap, print_dry_run, print_human_summary,
+    InstallOutcome, InstallReport,
+};
 
 /// Handle `tctl install [<members>…]`.
 ///
@@ -960,54 +679,12 @@ fn cargo_bin_dir_from_env(cargo_home: Option<&str>) -> Option<std::path::PathBuf
     }
 }
 
-/// Print the human-readable install summary footer.
-///
-/// Why: After the component table, a one-line verdict tells the operator whether
-/// everything landed. Graceful-degrade (demo-critical fix): the headline count
-/// covers REQUIRED members only, so an optional component with no prebuilt for
-/// this platform never reads as a scary partial failure (e.g. the old
-/// `installed 4/7`); optional gaps are listed separately as skipped.
-/// What: Prints `installed N/M required component(s)`, lists REQUIRED failures
-/// as errors, and OPTIONAL failures as an informational "skipped" note.
-/// Test: Side-effect-only; the data it reads is tested via `InstallReport`.
-fn print_human_summary(report: &InstallReport) {
-    let narr = narrator(false);
-    let required: Vec<&InstallOutcome> = report.members.iter().filter(|m| m.required).collect();
-    let required_ok = required.iter().filter(|m| m.ok).count();
-    let _ = narr.info(&format!(
-        "installed {}/{} required component(s)",
-        required_ok,
-        required.len()
-    ));
-    for m in required.iter().filter(|m| !m.ok) {
-        let _ = narr.error(&format!("{}: {}", m.member, m.detail));
-    }
-    // #2566 review: a binary can install cleanly (`ok: true`) while its
-    // service bootstrap genuinely failed — surface that on the human path too,
-    // not just fold it silently into the exit code. Only meaningful for
-    // required members: all_ok already ignores optional service failures.
-    for m in required.iter().filter(|m| m.ok && !m.service_ok) {
-        let _ = narr.error(&format!("{}: {}", m.member, m.service_detail));
-    }
-    let optional_failed: Vec<&InstallOutcome> = report
-        .members
-        .iter()
-        .filter(|m| !m.required && !m.ok)
-        .collect();
-    if !optional_failed.is_empty() {
-        for m in &optional_failed {
-            let _ = narr.info(&format!(
-                "{}: skipped (no prebuilt for this platform)",
-                m.member
-            ));
-        }
-    }
-}
-
 // ── Unit tests ───────────────────────────────────────────────────────────────
 // Tests are in a sibling file to keep this definition file under the 500-line
 // production cap (CLAUDE.md / scripts/check_line_cap.sh) — mirrors the
-// `cli.rs` / `cli_tests.rs` split.
+// `cli.rs` / `cli_tests.rs` split. Report/outcome types, `--dry-run`, and
+// human-summary rendering live in the sibling `install_report.rs` (also
+// exercised by this same `tests` module via `use super::*;`).
 #[cfg(test)]
 #[path = "install_tests.rs"]
 mod tests;

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -68,9 +68,12 @@ use crate::output::render_json;
 /// just-installed binary is provably shadowed by a DIFFERENT, earlier-PATH
 /// copy of the same name (see `super::shadow_check`) — a genuine "the new
 /// version will not take effect" condition, never silently swallowed into a
-/// reported success.
+/// reported success. `required` (graceful-degrade, demo-critical fix) mirrors
+/// `StableMember::required`: an OPTIONAL member's failure is reported here
+/// (`ok: false`) but never flips [`InstallReport::all_ok`] / the exit code.
 /// Test: `tests::report_serialises`, `tests::report_all_ok_reflects_service_failure`,
-/// `tests::report_all_ok_reflects_shadow_failure`.
+/// `tests::report_all_ok_reflects_shadow_failure`,
+/// `tests::report_all_ok_ignores_optional_failure`.
 #[derive(Clone, Debug, Serialize)]
 pub struct InstallOutcome {
     /// Crate name installed.
@@ -91,6 +94,10 @@ pub struct InstallOutcome {
     /// Human note for the shadow-detection outcome (the actionable
     /// `ShadowReport::message`, or empty when `shadow_ok`).
     pub shadow_detail: String,
+    /// Whether this member is REQUIRED for a verified overall run (mirrors
+    /// `StableMember::required`). Drives [`InstallReport::build`]'s `all_ok`
+    /// derivation and the human summary's skip-vs-fail wording.
+    pub required: bool,
 }
 
 impl InstallOutcome {
@@ -122,9 +129,11 @@ pub struct InstallReport {
     pub command: &'static str,
     /// Per-member install outcomes in install order.
     pub members: Vec<InstallOutcome>,
-    /// Whether every member installed AND every attempted service bootstrap
-    /// succeeded (see [`InstallOutcome`]'s field docs for what counts as a
-    /// service failure) AND, when the verify tail ran, it reported verified.
+    /// Whether every REQUIRED member installed AND every attempted service
+    /// bootstrap on a REQUIRED member succeeded (see [`InstallOutcome`]'s
+    /// field docs for what counts as a service failure) AND, when the verify
+    /// tail ran, it reported verified. An OPTIONAL member's failure never
+    /// flips this (graceful-degrade, demo-critical fix).
     pub all_ok: bool,
     /// The post-install verify-tail result (#2560): `ensure` + health (with
     /// the #2498 kickstart retry). `None` when `--no-verify` skipped it.
@@ -142,12 +151,18 @@ impl InstallReport {
     /// plain shell invocation — both are "looks installed, actually not
     /// live" failures the report must never paper over.
     /// What: Sets `command = "install"`, `verify = None`, and
-    /// `all_ok = every outcome has ok == true AND service_ok == true AND
-    /// shadow_ok == true`.
+    /// `all_ok = every REQUIRED outcome has ok == true AND service_ok == true
+    /// AND shadow_ok == true` (graceful-degrade, demo-critical fix: an
+    /// OPTIONAL member is excluded from this check entirely — its failure is
+    /// visible in `members` but never fails the run).
     /// Test: `tests::report_all_ok`, `tests::report_all_ok_reflects_service_failure`,
-    /// `tests::report_all_ok_reflects_shadow_failure`.
+    /// `tests::report_all_ok_reflects_shadow_failure`,
+    /// `tests::report_all_ok_ignores_optional_failure`.
     fn build(members: Vec<InstallOutcome>) -> Self {
-        let all_ok = members.iter().all(|m| m.ok && m.service_ok && m.shadow_ok);
+        let all_ok = members
+            .iter()
+            .filter(|m| m.required)
+            .all(|m| m.ok && m.service_ok && m.shadow_ok);
         Self {
             command: "install",
             members,
@@ -707,10 +722,24 @@ async fn install_all(
                     service_detail,
                     shadow_ok,
                     shadow_detail,
+                    required: m.required,
                 });
             }
             Err(e) => {
-                let _ = narr.error(&format!("{}: {e}", m.crate_name));
+                // Graceful degrade (demo-critical fix): an OPTIONAL member's
+                // install failure (e.g. no prebuilt for this platform, no
+                // Rust toolchain to fall back to `cargo install`) is reported
+                // softly — never `narr.error` — so a from-scratch install
+                // never prints a scary FAILED line for a component the run
+                // does not need to succeed.
+                if m.required {
+                    let _ = narr.error(&format!("{}: {e}", m.crate_name));
+                } else {
+                    let _ = narr.info(&format!(
+                        "{}: skipped (optional, no prebuilt for this platform): {e}",
+                        m.crate_name
+                    ));
+                }
                 let (service_ok, service_detail) = InstallOutcome::service_not_attempted();
                 outcomes.push(InstallOutcome {
                     member: m.crate_name.clone(),
@@ -720,6 +749,7 @@ async fn install_all(
                     service_detail,
                     shadow_ok: true,
                     shadow_detail: String::new(),
+                    required: m.required,
                 });
             }
         }
@@ -933,21 +963,44 @@ fn cargo_bin_dir_from_env(cargo_home: Option<&str>) -> Option<std::path::PathBuf
 /// Print the human-readable install summary footer.
 ///
 /// Why: After the component table, a one-line verdict tells the operator whether
-/// everything landed.
-/// What: Prints `installed N/M` and lists any failures to stderr.
+/// everything landed. Graceful-degrade (demo-critical fix): the headline count
+/// covers REQUIRED members only, so an optional component with no prebuilt for
+/// this platform never reads as a scary partial failure (e.g. the old
+/// `installed 4/7`); optional gaps are listed separately as skipped.
+/// What: Prints `installed N/M required component(s)`, lists REQUIRED failures
+/// as errors, and OPTIONAL failures as an informational "skipped" note.
 /// Test: Side-effect-only; the data it reads is tested via `InstallReport`.
 fn print_human_summary(report: &InstallReport) {
-    let ok = report.members.iter().filter(|m| m.ok).count();
     let narr = narrator(false);
-    let _ = narr.info(&format!("installed {}/{}", ok, report.members.len()));
-    for m in report.members.iter().filter(|m| !m.ok) {
+    let required: Vec<&InstallOutcome> = report.members.iter().filter(|m| m.required).collect();
+    let required_ok = required.iter().filter(|m| m.ok).count();
+    let _ = narr.info(&format!(
+        "installed {}/{} required component(s)",
+        required_ok,
+        required.len()
+    ));
+    for m in required.iter().filter(|m| !m.ok) {
         let _ = narr.error(&format!("{}: {}", m.member, m.detail));
     }
     // #2566 review: a binary can install cleanly (`ok: true`) while its
     // service bootstrap genuinely failed — surface that on the human path too,
-    // not just fold it silently into the exit code.
-    for m in report.members.iter().filter(|m| m.ok && !m.service_ok) {
+    // not just fold it silently into the exit code. Only meaningful for
+    // required members: all_ok already ignores optional service failures.
+    for m in required.iter().filter(|m| m.ok && !m.service_ok) {
         let _ = narr.error(&format!("{}: {}", m.member, m.service_detail));
+    }
+    let optional_failed: Vec<&InstallOutcome> = report
+        .members
+        .iter()
+        .filter(|m| !m.required && !m.ok)
+        .collect();
+    if !optional_failed.is_empty() {
+        for m in &optional_failed {
+            let _ = narr.info(&format!(
+                "{}: skipped (no prebuilt for this platform)",
+                m.member
+            ));
+        }
     }
 }
 

--- a/crates/trusty-installer/src/commands/install_report.rs
+++ b/crates/trusty-installer/src/commands/install_report.rs
@@ -1,0 +1,365 @@
+//! Report/outcome types, `--dry-run` preview, and human-summary rendering
+//! for `tctl install` — split out of `install.rs` to keep that file under
+//! the 500-line production cap (CLAUDE.md / `scripts/check_line_cap.sh`);
+//! mirrors the `commands/up/report.rs` split for the same command family.
+//!
+//! Why: `install.rs`'s core (`run`, `install_all`, `install_one`) and this
+//! module's report-shaping/rendering are cohesive but separate concerns —
+//! one drives the install, the other describes and prints its outcome.
+//!
+//! What: [`InstallOutcome`] / [`InstallReport`] are the real-install
+//! `--json` envelope (with the graceful-degrade `required` derivation);
+//! [`DryRunMember`] / [`DryRunReport`] mirror that shape for `--dry-run`;
+//! [`plans_service_bootstrap`] / [`plans_mpm_supervisor_bootstrap`] are the
+//! shared predicates both the dry-run preview and the real install use so
+//! neither can drift from the other; [`print_dry_run`] and
+//! [`print_human_summary`] are the human-readable renderers.
+//!
+//! Test: `install_tests.rs` (a sibling of `install.rs`, `use super::*;`)
+//! covers this module's shaping and derivation logic directly.
+
+use serde::Serialize;
+
+use crate::commands::progress_ui::narrator;
+use crate::commands::stable_set::{ManageStrategy, StableMember};
+use crate::commands::verify_tail::VerifyTailReport;
+use crate::output::render_json;
+
+/// One member's install outcome for the `--json` report.
+///
+/// Why: A typed per-member result keeps the machine output stable and testable.
+/// `service_ok` / `service_detail` were added after a review of #2566 found
+/// that a genuine `service install` failure was reported ONLY via an info-level
+/// narration line — `--json` output claimed `all_ok: true` / exit 0 even when
+/// every daemon's launchd bootstrap had failed, which is precisely the failure
+/// class #2557 existed because of (a broken daemon that LOOKS installed).
+/// What: `member` is the crate name; `ok` whether the binary install +
+/// health-gate succeeded; `detail` a human note (e.g. the error on binary
+/// failure). `service_ok` is `true` when the post-install launchd service
+/// bootstrap was not attempted (bootstrap disabled, non-service member, or a
+/// plist already present — none of those are failures) OR when it ran and
+/// succeeded; it is `false` ONLY when `service install` was attempted and
+/// genuinely errored. `service_detail` carries the human note for whichever
+/// case applied. `shadow_ok` / `shadow_detail` (#3554) are the analogous pair
+/// for PATH-shadow detection: `shadow_ok` is `false` ONLY when the
+/// just-installed binary is provably shadowed by a DIFFERENT, earlier-PATH
+/// copy of the same name (see `super::shadow_check`) — a genuine "the new
+/// version will not take effect" condition, never silently swallowed into a
+/// reported success. `required` (graceful-degrade, demo-critical fix) mirrors
+/// `StableMember::required`: an OPTIONAL member's failure is reported here
+/// (`ok: false`) but never flips [`InstallReport::all_ok`] / the exit code.
+/// Test: `tests::report_serialises`, `tests::report_all_ok_reflects_service_failure`,
+/// `tests::report_all_ok_reflects_shadow_failure`,
+/// `tests::report_all_ok_ignores_optional_failure`.
+#[derive(Clone, Debug, Serialize)]
+pub struct InstallOutcome {
+    /// Crate name installed.
+    pub member: String,
+    /// Whether install + health-gate succeeded.
+    pub ok: bool,
+    /// Human detail / error message.
+    pub detail: String,
+    /// Whether the post-install service bootstrap succeeded or was not
+    /// attempted (see field doc above for the false-only-on-genuine-failure
+    /// contract).
+    pub service_ok: bool,
+    /// Human note for the service bootstrap outcome.
+    pub service_detail: String,
+    /// `false` ONLY when the just-installed binary is shadowed on `$PATH` by
+    /// a different, stale copy (#3554); `true` when clear or not applicable.
+    pub shadow_ok: bool,
+    /// Human note for the shadow-detection outcome (the actionable
+    /// `ShadowReport::message`, or empty when `shadow_ok`).
+    pub shadow_detail: String,
+    /// Whether this member is REQUIRED for a verified overall run (mirrors
+    /// `StableMember::required`). Drives [`InstallReport::build`]'s `all_ok`
+    /// derivation and the human summary's skip-vs-fail wording.
+    pub required: bool,
+}
+
+impl InstallOutcome {
+    /// Build the `service_ok = true`, empty-detail outcome for a member whose
+    /// binary install failed (never reached the service-bootstrap step).
+    ///
+    /// Why: a binary-install failure and a service-bootstrap failure are
+    /// distinct failure classes; a binary that never installed cannot have a
+    /// "failed" service bootstrap — centralising this avoids a copy-pasted
+    /// `service_ok: true, service_detail: String::new()` at every call site.
+    /// What: returns `(true, "")`&nbsp;— not-applicable, not a failure.
+    /// Test: exercised via `tests::report_all_ok` (binary failure alone still
+    /// yields `all_ok == false` from `ok`, independent of this default).
+    pub(super) fn service_not_attempted() -> (bool, String) {
+        (true, String::new())
+    }
+}
+
+/// The aggregate install report.
+///
+/// Why: `--json` consumers want the whole rollup in one object with an overall
+/// verdict; the human path renders the same data as a component table.
+/// What: Holds per-member outcomes and the computed `all_ok`.
+/// Test: `tests::report_serialises`, `tests::report_all_ok`,
+/// `tests::report_all_ok_reflects_service_failure`.
+#[derive(Clone, Debug, Serialize)]
+pub struct InstallReport {
+    /// Fixed command tag for JSON consumers.
+    pub command: &'static str,
+    /// Per-member install outcomes in install order.
+    pub members: Vec<InstallOutcome>,
+    /// Whether every REQUIRED member installed AND every attempted service
+    /// bootstrap on a REQUIRED member succeeded (see [`InstallOutcome`]'s
+    /// field docs for what counts as a service failure) AND, when the verify
+    /// tail ran, it reported verified. An OPTIONAL member's failure never
+    /// flips this (graceful-degrade, demo-critical fix).
+    pub all_ok: bool,
+    /// The post-install verify-tail result (#2560): `ensure` + health (with
+    /// the #2498 kickstart retry). `None` when `--no-verify` skipped it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify: Option<VerifyTailReport>,
+}
+
+impl InstallReport {
+    /// Build a report from per-member outcomes.
+    ///
+    /// Why: Centralises the `all_ok` derivation so the exit code and JSON agree,
+    /// and so the report cannot claim success while a genuine service-bootstrap
+    /// failure occurred (#2566 review finding) OR a genuine PATH-shadow
+    /// condition (#3554) leaves the just-installed binary unreachable from a
+    /// plain shell invocation — both are "looks installed, actually not
+    /// live" failures the report must never paper over.
+    /// What: Sets `command = "install"`, `verify = None`, and
+    /// `all_ok = every REQUIRED outcome has ok == true AND service_ok == true
+    /// AND shadow_ok == true` (graceful-degrade, demo-critical fix: an
+    /// OPTIONAL member is excluded from this check entirely — its failure is
+    /// visible in `members` but never fails the run).
+    /// Test: `tests::report_all_ok`, `tests::report_all_ok_reflects_service_failure`,
+    /// `tests::report_all_ok_reflects_shadow_failure`,
+    /// `tests::report_all_ok_ignores_optional_failure`.
+    pub(super) fn build(members: Vec<InstallOutcome>) -> Self {
+        let all_ok = members
+            .iter()
+            .filter(|m| m.required)
+            .all(|m| m.ok && m.service_ok && m.shadow_ok);
+        Self {
+            command: "install",
+            members,
+            all_ok,
+            verify: None,
+        }
+    }
+
+    /// Fold the post-install verify-tail result into this report (#2560).
+    ///
+    /// Why: `--json` consumers must see ONE object whose `all_ok` (and hence
+    /// exit code) already reflects the verify-tail outcome — a caller must
+    /// never read `all_ok: true` while the verify tail reported an unhealthy
+    /// stack (the exact "looks installed, actually broken" class #2557 /
+    /// #2498 existed because of).
+    /// What: attaches `verify`; if it reports `!verified`, flips `all_ok` to
+    /// `false` (binary + service success alone does not override a verify
+    /// failure).
+    /// Test: `tests::with_verify_failure_flips_all_ok`,
+    /// `tests::with_verify_success_preserves_all_ok`.
+    pub(super) fn with_verify(mut self, verify: VerifyTailReport) -> Self {
+        if !verify.verified {
+            self.all_ok = false;
+        }
+        self.verify = Some(verify);
+        self
+    }
+
+    /// Process exit code: 0 when all installed, 2 when any failed.
+    ///
+    /// Why: A boot/automation script branches on this.
+    /// What: `0` if `all_ok`, else `2` (partial/total failure — stack degraded).
+    /// Test: `tests::exit_code_reflects_all_ok`.
+    pub(super) fn exit_code(&self) -> i32 {
+        if self.all_ok {
+            0
+        } else {
+            2
+        }
+    }
+}
+
+/// One member's planned (not-yet-applied) install action for `--dry-run`.
+///
+/// Why: `--dry-run` (#2112) must show the operator the exact blast radius —
+/// what `tctl install` would do — without doing it; a typed row keeps that
+/// preview consistent with the real [`InstallOutcome`] shape it stands in for.
+/// What: `member` / `binary` mirror [`StableMember`]; `service_bootstrap` is
+/// `true` when a launchd `service install` would be attempted for this member
+/// (service bootstrap enabled AND the member is [`ManageStrategy::Launchd`]).
+/// Test: `tests::dry_run_report_shape`.
+#[derive(Clone, Debug, Serialize)]
+pub struct DryRunMember {
+    /// Crate name that would be installed.
+    pub member: String,
+    /// Binary name that would land on PATH.
+    pub binary: String,
+    /// Whether a post-install launchd service bootstrap would be attempted.
+    pub service_bootstrap: bool,
+}
+
+/// The `--dry-run` preview report (#2112).
+///
+/// Why: Mirrors [`InstallReport`]'s shape (`command`, per-member rows) so
+/// `--json` consumers get a familiar, stable envelope, with `dry_run: true`
+/// as the discriminator instead of an `all_ok` verdict (nothing was applied).
+/// What: `members` lists every member that WOULD be installed, in install
+/// order; `service_bootstrap_enabled` is the resolved `--no-service` /
+/// `TCTL_NO_SERVICE_BOOTSTRAP` state applied to the preview.
+/// Test: `tests::dry_run_report_shape`.
+#[derive(Clone, Debug, Serialize)]
+pub struct DryRunReport {
+    /// Fixed command tag for JSON consumers.
+    pub command: &'static str,
+    /// Always `true` — discriminates this envelope from [`InstallReport`].
+    pub dry_run: bool,
+    /// Members that would be installed, in install order.
+    pub members: Vec<DryRunMember>,
+    /// Whether the post-install service bootstrap step is enabled.
+    pub service_bootstrap_enabled: bool,
+}
+
+/// Whether an install (real or previewed) would attempt a launchd service
+/// bootstrap for `m`.
+///
+/// Why: The `--dry-run` preview (`build_dry_run_report`) and the real install
+/// loop (`install_all`) must never drift on this decision — a preview that
+/// disagrees with reality is worse than no preview at all. A single shared
+/// predicate is the only way to guarantee that.
+/// What: `true` when the post-install service-bootstrap step is enabled AND
+/// `m` is a [`ManageStrategy::Launchd`]-managed member.
+/// Test: `tests::dry_run_report_shape` (via `build_dry_run_report`);
+/// `install_all`'s use is exercised indirectly by the (side-effecting) install
+/// path.
+pub(super) fn plans_service_bootstrap(m: &StableMember, service_enabled: bool) -> bool {
+    service_enabled && m.manage == ManageStrategy::Launchd
+}
+
+/// Whether an install would attempt the trusty-mpm launchd SUPERVISOR
+/// bootstrap for `m` (#3527).
+///
+/// Why: `install_mpm_supervisor()` used to run UNCONDITIONALLY whenever
+/// trusty-mpm installed — the one member exempt from the #2556
+/// `plans_service_bootstrap` opt-out, because trusty-mpm's
+/// [`ManageStrategy::OwnVerb`] makes that Launchd-only predicate always return
+/// `false` for it regardless of `service_enabled`. This mirrors
+/// `plans_service_bootstrap`'s *intent* (respect `--no-service` /
+/// `TCTL_NO_SERVICE_BOOTSTRAP`) for the supervisor specifically, so trusty-mpm
+/// is no longer the one member that ignores the opt-out.
+/// What: `true` iff `service_enabled` AND `m.crate_name == "trusty-mpm"`.
+/// Test: `tests::plans_mpm_supervisor_bootstrap_respects_flag`.
+pub(super) fn plans_mpm_supervisor_bootstrap(m: &StableMember, service_enabled: bool) -> bool {
+    service_enabled && m.crate_name == "trusty-mpm"
+}
+
+/// Build the `--dry-run` preview report from the resolved member set.
+///
+/// Why: Extracted so the report's shaping is unit-testable without stdout.
+/// What: Maps each [`StableMember`] to a [`DryRunMember`], computing
+/// `service_bootstrap` via the shared [`plans_service_bootstrap`] predicate so
+/// the preview can never drift from what `install_all` actually does.
+/// Test: `tests::dry_run_report_shape`.
+pub(super) fn build_dry_run_report(
+    selected: &[StableMember],
+    service_enabled: bool,
+) -> DryRunReport {
+    let members = selected
+        .iter()
+        .map(|m| DryRunMember {
+            member: m.crate_name.clone(),
+            binary: m.binary.clone(),
+            service_bootstrap: plans_service_bootstrap(m, service_enabled),
+        })
+        .collect();
+    DryRunReport {
+        command: "install",
+        dry_run: true,
+        members,
+        service_bootstrap_enabled: service_enabled,
+    }
+}
+
+/// Print the `--dry-run` preview and return the process exit code.
+///
+/// Why: A dry run never fails on its own account — it only reports what WOULD
+/// happen; a resolution error (unknown member) is caught earlier in `run`.
+/// What: `--json` emits [`DryRunReport`] via `render_json`; otherwise prints a
+/// human blast-radius summary matching the wording the confirmation prompt
+/// used, one line per member noting whether it would bootstrap a service.
+/// Returns `0` unless the `--json` write itself fails, in which case `1`
+/// (mirrors the real install path's failed-JSON-write handling below).
+/// Test: Side-effect-only (stdout); the data it prints is covered by
+/// `tests::dry_run_report_shape`.
+pub(super) fn print_dry_run(selected: &[StableMember], service_enabled: bool, json: bool) -> i32 {
+    let report = build_dry_run_report(selected, service_enabled);
+    if json {
+        if render_json(&report).is_err() {
+            eprintln!("tctl install: failed to write JSON output");
+            return 1;
+        }
+        return 0;
+    }
+    let names: Vec<&str> = report.members.iter().map(|m| m.member.as_str()).collect();
+    eprintln!(
+        "tctl install: DRY RUN — would install {} tool(s): {}",
+        report.members.len(),
+        names.join(", ")
+    );
+    for m in &report.members {
+        let svc = if m.service_bootstrap {
+            "would bootstrap launchd service"
+        } else {
+            "no service bootstrap"
+        };
+        eprintln!("tctl install:   {} -> {} ({svc})", m.member, m.binary);
+    }
+    eprintln!("tctl install: dry run complete — no changes made.");
+    0
+}
+
+/// Print the human-readable install summary footer.
+///
+/// Why: After the component table, a one-line verdict tells the operator whether
+/// everything landed. Graceful-degrade (demo-critical fix): the headline count
+/// covers REQUIRED members only, so an optional component with no prebuilt for
+/// this platform never reads as a scary partial failure (e.g. the old
+/// `installed 4/7`); optional gaps are listed separately as skipped.
+/// What: Prints `installed N/M required component(s)`, lists REQUIRED failures
+/// as errors, and OPTIONAL failures as an informational "skipped" note.
+/// Test: Side-effect-only; the data it reads is tested via `InstallReport`.
+pub(super) fn print_human_summary(report: &InstallReport) {
+    let narr = narrator(false);
+    let required: Vec<&InstallOutcome> = report.members.iter().filter(|m| m.required).collect();
+    let required_ok = required.iter().filter(|m| m.ok).count();
+    let _ = narr.info(&format!(
+        "installed {}/{} required component(s)",
+        required_ok,
+        required.len()
+    ));
+    for m in required.iter().filter(|m| !m.ok) {
+        let _ = narr.error(&format!("{}: {}", m.member, m.detail));
+    }
+    // #2566 review: a binary can install cleanly (`ok: true`) while its
+    // service bootstrap genuinely failed — surface that on the human path too,
+    // not just fold it silently into the exit code. Only meaningful for
+    // required members: all_ok already ignores optional service failures.
+    for m in required.iter().filter(|m| m.ok && !m.service_ok) {
+        let _ = narr.error(&format!("{}: {}", m.member, m.service_detail));
+    }
+    let optional_failed: Vec<&InstallOutcome> = report
+        .members
+        .iter()
+        .filter(|m| !m.required && !m.ok)
+        .collect();
+    if !optional_failed.is_empty() {
+        for m in &optional_failed {
+            let _ = narr.info(&format!(
+                "{}: skipped (no prebuilt for this platform)",
+                m.member
+            ));
+        }
+    }
+}

--- a/crates/trusty-installer/src/commands/install_tests.rs
+++ b/crates/trusty-installer/src/commands/install_tests.rs
@@ -30,6 +30,16 @@ fn outcome(member: &str, ok: bool, detail: &str) -> InstallOutcome {
         service_detail: String::new(),
         shadow_ok: true,
         shadow_detail: String::new(),
+        required: true,
+    }
+}
+
+/// Like `outcome`, but marks the member OPTIONAL (graceful-degrade,
+/// demo-critical fix) so tests can build a failed-but-non-fatal outcome.
+fn optional_outcome(member: &str, ok: bool, detail: &str) -> InstallOutcome {
+    InstallOutcome {
+        required: false,
+        ..outcome(member, ok, detail)
     }
 }
 
@@ -55,6 +65,51 @@ fn report_all_ok() {
     assert!(!report.all_ok);
 }
 
+/// Why: THE demo-critical fix — an OPTIONAL member (e.g. `trusty-analyze` on
+/// a platform with no prebuilt and no Rust toolchain) failing to install must
+/// NOT fail the overall run; only a REQUIRED member's failure may.
+/// What: a required-ok + optional-failed report is still `all_ok`/exit 0; a
+/// required-failed + optional-ok report is not.
+/// Test: This is the test.
+#[test]
+fn report_all_ok_ignores_optional_failure() {
+    let degraded = InstallReport::build(vec![
+        outcome("trusty-search", true, "installed"),
+        optional_outcome(
+            "trusty-analyze",
+            false,
+            "no prebuilt for aarch64-apple-darwin",
+        ),
+    ]);
+    assert!(
+        degraded.all_ok,
+        "an optional member's failure must not fail the overall run"
+    );
+    assert_eq!(degraded.exit_code(), 0);
+
+    let genuinely_failed = InstallReport::build(vec![
+        outcome("trusty-search", false, "network error"),
+        optional_outcome("trusty-analyze", true, "installed"),
+    ]);
+    assert!(
+        !genuinely_failed.all_ok,
+        "a required member's failure must still fail the overall run"
+    );
+    assert_eq!(genuinely_failed.exit_code(), 2);
+}
+
+/// Why: an install selecting ONLY optional members (e.g. `tctl install tga`)
+/// must still be able to report success when that member installs fine —
+/// `all_ok` over an empty required-subset must not vacuously fail.
+/// What: a single optional, successful outcome yields `all_ok: true`.
+/// Test: This is the test.
+#[test]
+fn report_all_ok_true_for_optional_only_success() {
+    let report = InstallReport::build(vec![optional_outcome("tga", true, "installed")]);
+    assert!(report.all_ok);
+    assert_eq!(report.exit_code(), 0);
+}
+
 /// Why: #2566 review — a binary can install cleanly (`ok: true`) while its
 /// SERVICE bootstrap genuinely fails; the report must not claim
 /// `all_ok: true` in that case (the exact failure class #2557 existed
@@ -75,6 +130,7 @@ fn report_all_ok_reflects_service_failure() {
         service_detail: "service bootstrap failed (non-fatal): boom".to_owned(),
         shadow_ok: true,
         shadow_detail: String::new(),
+        required: true,
     }]);
     assert!(
         !failed.all_ok,
@@ -90,6 +146,7 @@ fn report_all_ok_reflects_service_failure() {
         service_detail: "launchd plist already present — left untouched".to_owned(),
         shadow_ok: true,
         shadow_detail: String::new(),
+        required: true,
     }]);
     assert!(
         skipped.all_ok,
@@ -117,6 +174,7 @@ fn report_all_ok_reflects_shadow_failure() {
         shadow_detail: "PATH SHADOWED: installed trusty-mpm 0.19.29 to /x/.local/bin/tm, but \
                          the shell resolves `tm` to /x/.cargo/bin/tm (0.19.26)"
             .to_owned(),
+        required: true,
     }]);
     assert!(
         !shadowed.all_ok,
@@ -423,5 +481,6 @@ fn stable_member_for_test(crate_name: &str, binary: &str, manage: ManageStrategy
         binary: binary.to_owned(),
         daemon: manage == ManageStrategy::Launchd,
         manage,
+        required: true,
     }
 }

--- a/crates/trusty-installer/src/commands/install_tests.rs
+++ b/crates/trusty-installer/src/commands/install_tests.rs
@@ -15,6 +15,10 @@
 //! Test: `cargo test -p trusty-installer` runs all tests in this file.
 
 use super::*;
+// Not re-exported by `install.rs` itself (only used internally by
+// `install_report.rs`'s own `print_dry_run`), so pulled in directly here.
+use super::install_report::build_dry_run_report;
+use crate::commands::stable_set::ManageStrategy;
 
 /// Build an `InstallOutcome` with the pre-#2566 default service state
 /// (not attempted — `service_ok: true`, empty detail) and the pre-#3554

--- a/crates/trusty-installer/src/commands/lifecycle.rs
+++ b/crates/trusty-installer/src/commands/lifecycle.rs
@@ -400,6 +400,7 @@ mod tests {
             binary: binary.to_owned(),
             daemon: manage != ManageStrategy::None,
             manage,
+            required: true,
         }
     }
 

--- a/crates/trusty-installer/src/commands/prereqs/phase.rs
+++ b/crates/trusty-installer/src/commands/prereqs/phase.rs
@@ -6,10 +6,12 @@
 //!
 //! What: `run_prereq_phase` iterates the prereq table for the selected crate
 //! names, prints ✓ for present tools (with version), and for missing tools either
-//! prompts the user to install (TTY, not `--yes`, not `--json`) or prints manual
-//! instructions and continues. After a consented install it re-probes and reports
-//! success or failure. Returns the set of prereqs that remain missing so the
-//! caller can decide whether to abort.
+//! auto-installs (`--yes`/`TRUSTY_YES` — no TTY required, since `-y` IS the
+//! consent; this is the piped `curl | sh -s -- -y` demo path), prompts the user
+//! to install (TTY, not `--yes`, not `--json`), or prints manual instructions
+//! and continues (non-interactive without `--yes`, or `--json`). After a
+//! consented install it re-probes and reports success or failure. Returns the
+//! set of prereqs that remain missing so the caller can decide whether to abort.
 //!
 //! Test: `tests::phase_*` inject fake detect/version/exec closures to exercise
 //! every branch of the decision table without spawning real OS processes.
@@ -143,12 +145,23 @@ pub fn run_prereq_phase_with(
                     ));
                 }
                 let hint = install_hint_for(prereq.binary, platform);
+                let has_auto_cmd = hint.auto_cmd.is_some();
 
-                // Offer interactive install only on a real TTY.
-                let can_offer = !config.json && !config.yes && tty_fn();
-                let should_offer = can_offer && hint.auto_cmd.is_some();
+                // `-y`/`TRUSTY_YES` is unattended CONSENT: run the auto-install
+                // command directly, with no TTY and no prompt required — the
+                // entire point of `--yes` is to authorize exactly this. This is
+                // the path a piped `curl | sh -s -- -y` install takes, where
+                // stdin is never a TTY (issue: prereq auto-install silently
+                // degrading to a manual hint under `-y`).
+                let auto_yes = !config.json && config.yes && has_auto_cmd;
+                // Interactive path: offer + prompt only on a real TTY, when not
+                // already auto-consented above.
+                let offer_interactive = !auto_yes && !config.json && !config.yes && tty_fn();
+                let should_offer = offer_interactive && has_auto_cmd;
 
-                let consented = if should_offer {
+                let consented = if auto_yes {
+                    true
+                } else if should_offer {
                     let cmd = hint.auto_cmd.as_deref().unwrap_or_default();
                     let prompt = format!("  Install {} now? (will run: `{}`)", prereq.binary, cmd);
                     prompt_fn(&prompt)
@@ -159,7 +172,12 @@ pub fn run_prereq_phase_with(
                 if consented {
                     let cmd = hint.auto_cmd.as_deref().unwrap_or_default();
                     if !config.json {
-                        let _ = narr.info(&format!("  running: {cmd}"));
+                        let verb = if auto_yes {
+                            "installing (--yes)"
+                        } else {
+                            "running"
+                        };
+                        let _ = narr.info(&format!("  {verb}: {cmd}"));
                     }
                     match exec_fn(cmd) {
                         Ok(()) => {
@@ -524,5 +542,127 @@ mod tests {
             "hint should reference apt or package manager, got: {}",
             tmux.hint
         );
+    }
+
+    /// Why: THE demo-critical fix — a piped `curl | sh -s -- -y` install has no
+    /// TTY on stdin, but `--yes` IS the operator's consent to auto-install.
+    /// Before this fix `can_offer` required `tty_fn()` even under `--yes`, so
+    /// missing prereqs silently degraded to a manual hint and never installed.
+    /// What: `yes: true`, `json: false`, `tty_fn: || false` (no TTY, exactly
+    /// the piped-script condition); check_fn absent-then-found (post-exec);
+    /// exec_fn Ok. Asserts the binary lands in `installed`, NOT
+    /// `still_missing`, and `prompt_fn` is never consulted (would panic/return
+    /// false but must not gate the decision).
+    /// Test: This is the test.
+    #[test]
+    fn phase_yes_auto_installs_without_tty() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+        let first_call = Arc::new(AtomicBool::new(true));
+        let fc = first_call.clone();
+        let check_fn = move |_bin: &str| !fc.swap(false, Ordering::SeqCst);
+        let config = PrereqPhaseConfig {
+            selected: &selected_mpm(),
+            yes: true,
+            json: false,
+        };
+        let result = run_prereq_phase_with(
+            &config,
+            &linux_apt(),
+            &[],
+            &check_fn,
+            &|_| Some("1.0".to_owned()),
+            &|_| Ok(()),
+            &|| false, // no TTY — the piped `curl | sh` condition
+            &|_| panic!("must not prompt under --yes"),
+        );
+        assert!(
+            !result.installed.is_empty(),
+            "at least one binary must auto-install under --yes with no TTY, got: {:?}",
+            result.installed
+        );
+        assert!(
+            result.still_missing.is_empty(),
+            "still_missing must be empty, got: {:?}",
+            result.still_missing
+        );
+    }
+
+    /// Why: `--json` must remain fully non-interactive/no-auto-install even
+    /// when `--yes` is also set — machine output must stay deterministic and
+    /// side-effect-free (unaffected by this fix).
+    /// What: `yes: true, json: true`; asserts nothing is installed and missing
+    /// binaries land in `still_missing`.
+    /// Test: This is the test.
+    #[test]
+    fn phase_json_yes_does_not_auto_install() {
+        let config = PrereqPhaseConfig {
+            selected: &selected_mpm(),
+            yes: true,
+            json: true,
+        };
+        let result = run_prereq_phase_with(
+            &config,
+            &linux_apt(),
+            &[],
+            &|_| false,
+            &|_| None,
+            &|_| panic!("must not exec under --json"),
+            &|| false,
+            &|_| panic!("must not prompt under --json"),
+        );
+        assert!(result.installed.is_empty());
+        assert!(result.still_missing.iter().any(|m| m.binary == "tmux"));
+    }
+
+    /// Why: under `--yes`, a binary with no known `auto_cmd` (e.g. `git`) must
+    /// still fall through to the manual-note path rather than panicking or
+    /// attempting a bogus exec.
+    /// What: selects tga (only `git` relevant); `yes: true`; asserts `git`
+    /// lands in `still_missing` and `exec_fn` is never called.
+    /// Test: This is the test.
+    #[test]
+    fn phase_yes_no_auto_cmd_falls_back_to_manual() {
+        let config = PrereqPhaseConfig {
+            selected: &selected_tga(),
+            yes: true,
+            json: false,
+        };
+        let result = run_prereq_phase_with(
+            &config,
+            &unknown_platform(),
+            &[],
+            &|_| false,
+            &|_| None,
+            &|_| panic!("must not exec when no auto_cmd exists"),
+            &|| false,
+            &|_| false,
+        );
+        assert!(result.still_missing.iter().any(|m| m.binary == "git"));
+    }
+
+    /// Why: under `--yes`, exec failure must still land the binary in
+    /// `still_missing` (not silently `installed`).
+    /// What: `yes: true, json: false`; exec_fn returns Err; asserts tmux ends
+    /// up in `still_missing`.
+    /// Test: This is the test.
+    #[test]
+    fn phase_yes_exec_failure_adds_to_still_missing() {
+        let config = PrereqPhaseConfig {
+            selected: &selected_mpm(),
+            yes: true,
+            json: false,
+        };
+        let result = run_prereq_phase_with(
+            &config,
+            &linux_apt(),
+            &[],
+            &|_| false,
+            &|_| None,
+            &|_| Err(anyhow::anyhow!("fake failure")),
+            &|| false,
+            &|_| false,
+        );
+        assert!(result.still_missing.iter().any(|m| m.binary == "tmux"));
     }
 }

--- a/crates/trusty-installer/src/commands/stable_set.rs
+++ b/crates/trusty-installer/src/commands/stable_set.rs
@@ -52,19 +52,26 @@ pub enum ManageStrategy {
 
 /// One member of the stable trusty tool set.
 ///
-/// Why: `tctl` keys four things off a member — the crates.io package name (for
+/// Why: `tctl` keys five things off a member — the crates.io package name (for
 /// `cargo install` / `check_crates_io`), the installed binary name (for presence
 /// and health probes), whether it is a supervised daemon (so upgrade can restart
-/// it cleanly), and HOW it is managed (launchd vs its own start/stop verb).
-/// Bundling them keeps every handler consistent.
+/// it cleanly), HOW it is managed (launchd vs its own start/stop verb), and
+/// whether the overall install run may fail/exit-nonzero when THIS member is
+/// missing on the host platform. Bundling them keeps every handler consistent.
 ///
 /// What: `crate_name` is the cargo package; `binary` is the installed binary
 /// (often equal, but `tga` differs); `daemon` marks members that run as a
 /// long-lived HTTP daemon and therefore need a connection-safe restart after an
 /// upgrade (`upgrade_and_restart`); `manage` is the lifecycle strategy
-/// (derived from `daemon` + binary by [`StableMember::new`]).
+/// (derived from `daemon` + binary by [`StableMember::new`]); `required` gates
+/// the graceful-degrade policy (demo-critical fix): a REQUIRED member failing
+/// to install fails the whole run (`exit 2`, `NOT VERIFIED`); an OPTIONAL
+/// member failing (e.g. no prebuilt for this platform, on a host with no Rust
+/// toolchain to fall back to `cargo install`) is reported as skipped and never
+/// flips the overall verdict.
 ///
-/// Test: `tests::stable_set_is_pinned`, `tests::mpm_uses_own_verb`.
+/// Test: `tests::stable_set_is_pinned`, `tests::mpm_uses_own_verb`,
+/// `tests::required_vs_optional_classification`.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct StableMember {
     /// The crates.io package name (`cargo install <crate_name> --locked`).
@@ -75,6 +82,10 @@ pub struct StableMember {
     pub daemon: bool,
     /// How `tctl start|stop|restart` controls this member's lifecycle.
     pub manage: ManageStrategy,
+    /// Whether this member is REQUIRED for a verified install (see the field
+    /// group doc above). `false` means OPTIONAL: install/verify failures for
+    /// this member degrade gracefully instead of failing the overall run.
+    pub required: bool,
 }
 
 impl StableMember {
@@ -86,9 +97,10 @@ impl StableMember {
     /// What: Builds a [`StableMember`]; a non-daemon gets
     /// [`ManageStrategy::None`]; trusty-mpm gets [`ManageStrategy::OwnVerb`]
     /// (it is process-managed, not launchd); every other daemon gets
-    /// [`ManageStrategy::Launchd`].
+    /// [`ManageStrategy::Launchd`]. `required` is passed straight through —
+    /// see [`stable_set`] for the current REQUIRED/OPTIONAL assignment.
     /// Test: Exercised by [`stable_set`] and `tests::mpm_uses_own_verb`.
-    fn new(crate_name: &str, binary: &str, daemon: bool) -> Self {
+    fn new(crate_name: &str, binary: &str, daemon: bool, required: bool) -> Self {
         let manage = if !daemon {
             ManageStrategy::None
         } else if binary == "trusty-mpm" {
@@ -101,6 +113,7 @@ impl StableMember {
             binary: binary.to_owned(),
             daemon,
             manage,
+            required,
         }
     }
 }
@@ -119,17 +132,31 @@ impl StableMember {
 /// brought up last, process-managed via its own `start`/`stop` verbs). Library
 /// crates resolve as cargo dependencies and are not listed.
 ///
+/// REQUIRED vs OPTIONAL (graceful-degrade policy, demo-critical fix): REQUIRED
+/// = trusty-mpm + its runtime deps trusty-search + trusty-memory +
+/// trusty-review — a from-scratch install on a Tier-1 platform must always be
+/// able to bring these up. OPTIONAL = trusty-analyze, trusty-console, tga —
+/// members that may lack a prebuilt for a given platform on a host with no
+/// Rust toolchain to fall back to; their absence must not fail the run or
+/// print a scary FAILED/exit-2 verdict.
+///
+/// NOTE for future editors: a separate lane may add `trusty-agents` to this
+/// set as REQUIRED — insert it with `required: true` in topological position;
+/// no other code needs to change (`install`/`verify_tail`'s all_ok/verified
+/// derivations already key off the `required` field, not a hardcoded list).
+///
 /// Test: `tests::stable_set_is_pinned`, `tests::tga_crate_and_binary_names`,
-/// `tests::daemon_flags_match_spec`, `tests::mpm_uses_own_verb`.
+/// `tests::daemon_flags_match_spec`, `tests::mpm_uses_own_verb`,
+/// `tests::required_vs_optional_classification`.
 pub fn stable_set() -> Vec<StableMember> {
     vec![
-        StableMember::new("trusty-search", "trusty-search", true),
-        StableMember::new("trusty-memory", "trusty-memory", true),
-        StableMember::new("trusty-analyze", "trusty-analyze", true),
-        StableMember::new("trusty-review", "trusty-review", true),
-        StableMember::new("tga", "tga", false),
-        StableMember::new("trusty-console", "trusty-console", true),
-        StableMember::new("trusty-mpm", "trusty-mpm", true),
+        StableMember::new("trusty-search", "trusty-search", true, true),
+        StableMember::new("trusty-memory", "trusty-memory", true, true),
+        StableMember::new("trusty-analyze", "trusty-analyze", true, false),
+        StableMember::new("trusty-review", "trusty-review", true, true),
+        StableMember::new("tga", "tga", false, false),
+        StableMember::new("trusty-console", "trusty-console", true, false),
+        StableMember::new("trusty-mpm", "trusty-mpm", true, true),
     ]
 }
 
@@ -348,6 +375,35 @@ mod tests {
             .expect("tga in set");
         assert_eq!(tga.binary, "tga");
         assert!(!tga.daemon);
+    }
+
+    /// Why: The graceful-degrade policy (demo-critical fix) reads `required`
+    /// off each member; pin the exact REQUIRED/OPTIONAL split so a future
+    /// edit here is a deliberate, reviewed decision, not an accidental drift.
+    /// What: Asserts trusty-mpm/trusty-search/trusty-memory/trusty-review are
+    /// `required: true` and trusty-analyze/trusty-console/tga are
+    /// `required: false`.
+    /// Test: This is the test.
+    #[test]
+    fn required_vs_optional_classification() {
+        let set = stable_set();
+        let required = |c: &str| {
+            set.iter()
+                .find(|m| m.crate_name == c)
+                .expect("present")
+                .required
+        };
+        for c in [
+            "trusty-mpm",
+            "trusty-search",
+            "trusty-memory",
+            "trusty-review",
+        ] {
+            assert!(required(c), "{c} must be REQUIRED");
+        }
+        for c in ["trusty-analyze", "trusty-console", "tga"] {
+            assert!(!required(c), "{c} must be OPTIONAL");
+        }
     }
 
     /// Why: Upgrade restarts only daemons; the daemon flags drive that.

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -39,7 +39,9 @@ use super::stable_set::{ManageStrategy, StableMember};
 /// Why: a typed row keeps the `--json` output stable + testable.
 /// What: `member` crate name; `health` the (possibly kickstart-retried) health
 /// verdict string; `kickstarted` whether a #2498 kickstart retry was attempted
-/// for this member.
+/// for this member; `required` (graceful-degrade, demo-critical fix) mirrors
+/// `StableMember::required` and gates whether a down/not-installed verdict for
+/// this member may fail the overall `verified` verdict.
 /// Test: `tests::report_serialises`.
 #[derive(Clone, Debug, Serialize)]
 pub struct VerifyRow {
@@ -49,6 +51,8 @@ pub struct VerifyRow {
     pub health: String,
     /// Whether a `launchctl kickstart -k` retry was attempted (#2498).
     pub kickstarted: bool,
+    /// Whether this member is REQUIRED for the overall `verified` verdict.
+    pub required: bool,
 }
 
 /// The aggregate verify-tail report (#2560).
@@ -67,8 +71,9 @@ pub struct VerifyTailReport {
     pub ensure_ok: bool,
     /// Per-daemon-member verify rows.
     pub members: Vec<VerifyRow>,
-    /// Overall verdict: `ensure_ok` AND every member healthy/stale/unknown
-    /// (never `down`/`not_installed`).
+    /// Overall verdict: `ensure_ok` AND every REQUIRED member
+    /// healthy/stale/unknown (never `down`/`not_installed`). An OPTIONAL
+    /// member never fails this (graceful-degrade, demo-critical fix).
     pub verified: bool,
 }
 
@@ -77,16 +82,19 @@ impl VerifyTailReport {
     ///
     /// Why: one place derives the verdict so the JSON and the folded
     /// `InstallReport.all_ok` can never disagree.
-    /// What: `verified = ensure_ok AND no member is `down`/`not_installed``. A
-    /// `stale` or `unknown` member does NOT fail verification — mirrors
-    /// `stack::health::HealthReport`'s degrade policy exactly (an
-    /// under-the-version-floor daemon is still up; an unprobeable
-    /// process-managed member is not a verified gap).
+    /// What: `verified = ensure_ok AND no REQUIRED member is
+    /// `down`/`not_installed`` (an OPTIONAL member's health never fails this
+    /// — demo-critical fix). A `stale` or `unknown` member does NOT fail
+    /// verification — mirrors `stack::health::HealthReport`'s degrade policy
+    /// exactly (an under-the-version-floor daemon is still up; an
+    /// unprobeable process-managed member is not a verified gap).
     /// Test: `tests::verified_requires_ensure_and_health`,
-    /// `tests::verified_tolerates_stale_and_unknown`.
+    /// `tests::verified_tolerates_stale_and_unknown`,
+    /// `tests::verified_ignores_optional_down_member`.
     fn build(ensure_ok: bool, members: Vec<VerifyRow>) -> Self {
         let health_ok = members
             .iter()
+            .filter(|m| m.required)
             .all(|m| m.health != health_str::DOWN && m.health != health_str::NOT_INSTALLED);
         Self {
             command: "install.verify",
@@ -153,6 +161,7 @@ fn verify_one(m: &StableMember) -> VerifyRow {
         member: m.crate_name.clone(),
         health,
         kickstarted,
+        required: m.required,
     }
 }
 
@@ -222,7 +231,13 @@ pub fn print_human(report: &VerifyTailReport) {
         if report.ensure_ok { "ok" } else { "FAILED" }
     );
     for m in &report.members {
-        let note = if m.kickstarted { " (kickstarted)" } else { "" };
+        let note = if m.kickstarted {
+            " (kickstarted)"
+        } else if !m.required && m.health == health_str::NOT_INSTALLED {
+            " (optional, skipped)"
+        } else {
+            ""
+        };
         println!("  {:<20} {}{}", m.member, m.health, note);
     }
     let verdict = if report.verified {
@@ -242,6 +257,16 @@ mod tests {
             member: member.to_owned(),
             health: health.to_owned(),
             kickstarted: false,
+            required: true,
+        }
+    }
+
+    /// Like `row`, but marks the member OPTIONAL (graceful-degrade,
+    /// demo-critical fix).
+    fn optional_row(member: &str, health: &str) -> VerifyRow {
+        VerifyRow {
+            required: false,
+            ..row(member, health)
         }
     }
 
@@ -312,6 +337,42 @@ mod tests {
             ],
         );
         assert!(report.verified);
+    }
+
+    /// Why: THE demo-critical fix — an OPTIONAL daemon member (e.g.
+    /// `trusty-console` never installed because it has no prebuilt for this
+    /// platform) being `down`/`not_installed` must NOT fail `verified`; only
+    /// a REQUIRED member's bad health may.
+    /// What: a report mixing a healthy REQUIRED member with a `down` and a
+    /// `not_installed` OPTIONAL member still verifies; a `down` REQUIRED
+    /// member alongside a healthy OPTIONAL one does not.
+    /// Test: This is the test.
+    #[test]
+    fn verified_ignores_optional_down_member() {
+        let degraded = VerifyTailReport::build(
+            true,
+            vec![
+                row("trusty-search", health_str::HEALTHY),
+                optional_row("trusty-console", health_str::DOWN),
+                optional_row("tga", health_str::NOT_INSTALLED),
+            ],
+        );
+        assert!(
+            degraded.verified,
+            "an optional member's bad health must not fail verification"
+        );
+
+        let genuinely_failed = VerifyTailReport::build(
+            true,
+            vec![
+                row("trusty-search", health_str::DOWN),
+                optional_row("trusty-console", health_str::HEALTHY),
+            ],
+        );
+        assert!(
+            !genuinely_failed.verified,
+            "a required member's bad health must still fail verification"
+        );
     }
 
     /// Why: `print_human`'s colour path must never panic regardless of the

--- a/crates/trusty-installer/src/download/release.rs
+++ b/crates/trusty-installer/src/download/release.rs
@@ -51,16 +51,43 @@ struct GhRelease {
     prerelease: bool,
 }
 
+/// Resolve the release-asset filename prefix for a crate, handling
+/// crate-name ⇄ asset-name aliases.
+///
+/// Why: A crate's Git tag prefix (used for release/tag resolution) does not
+/// always match the filename prefix baked into its release-workflow tarball
+/// name. `tga`'s package is named `tga` (and its tags are `tga-v*`), but its
+/// release workflow names the asset after the crate's directory,
+/// `trusty-git-analytics-<version>-<target>.tar.gz` — so a filename built
+/// from the crate name alone 404s even though the correct tag resolved fine.
+///
+/// What: A small table of known aliases; falls through to `crate_name`
+/// unchanged for every crate whose asset prefix matches its crate name (the
+/// common case). Add a new entry here if another crate's release workflow
+/// ever diverges the same way.
+///
+/// Test: `tests::asset_name_for_tag_resolves_tga_alias`,
+/// `tests::asset_name_for_tag_defaults_to_crate_name`.
+fn asset_name_for_tag(crate_name: &str) -> &str {
+    match crate_name {
+        "tga" => "trusty-git-analytics",
+        other => other,
+    }
+}
+
 /// Build the download URL for a prebuilt asset tarball.
 ///
-/// Why: The URL pattern is `<base>/<tag>/<crate>-<version>-<target>.tar.gz`;
+/// Why: The URL pattern is `<base>/<tag>/<asset-name>-<version>-<target>.tar.gz`;
 /// centralising construction avoids scatter and makes it trivially testable.
 ///
-/// What: Returns the HTTPS URL for the `.tar.gz` asset.
+/// What: Returns the HTTPS URL for the `.tar.gz` asset. `crate_name` selects
+/// the tag path (unaffected); the filename itself resolves through
+/// [`asset_name_for_tag`] so aliased crates (e.g. `tga`) build the correct
+/// asset filename.
 ///
-/// Test: `tests::asset_url_shape`.
+/// Test: `tests::asset_url_shape`, `tests::asset_url_shape_tga_alias`.
 pub fn asset_url(tag: &str, crate_name: &str, version: &str, target: &str) -> String {
-    let filename = asset_filename(crate_name, version, target);
+    let filename = asset_filename(asset_name_for_tag(crate_name), version, target);
     format!("{RELEASE_DL_BASE}/{tag}/{filename}")
 }
 
@@ -323,6 +350,45 @@ mod tests {
     fn asset_filename_shape() {
         let f = asset_filename("tga", "1.2.3", "x86_64-unknown-linux-gnu");
         assert_eq!(f, "tga-1.2.3-x86_64-unknown-linux-gnu.tar.gz");
+    }
+
+    /// Why: `tga`'s release workflow names its asset after the crate
+    /// directory (`trusty-git-analytics`), not the package name (`tga`); the
+    /// alias table must resolve this so `try_install_prebuilt("tga", ..)`
+    /// hits a real asset instead of 404ing.
+    /// What: Asserts `asset_name_for_tag("tga") == "trusty-git-analytics"`.
+    /// Test: This is the test.
+    #[test]
+    fn asset_name_for_tag_resolves_tga_alias() {
+        assert_eq!(asset_name_for_tag("tga"), "trusty-git-analytics");
+    }
+
+    /// Why: Every crate WITHOUT a known alias must build its asset name from
+    /// its own crate name unchanged — the common case must never regress.
+    /// What: Asserts a handful of unaliased crate names pass through as-is.
+    /// Test: This is the test.
+    #[test]
+    fn asset_name_for_tag_defaults_to_crate_name() {
+        for c in ["trusty-search", "trusty-memory", "trusty-installer"] {
+            assert_eq!(asset_name_for_tag(c), c);
+        }
+    }
+
+    /// Why: The end-to-end URL for `tga` must use the ALIASED asset filename
+    /// while keeping the crate's own tag in the URL path — this is the exact
+    /// #<tga-asset-mismatch> bug: tag resolution and filename resolution use
+    /// different names for this one crate.
+    /// What: Builds a `tga` asset URL; asserts it contains
+    /// `trusty-git-analytics-2.9.4-...` under the `tga-v2.9.4` tag path.
+    /// Test: This is the test.
+    #[test]
+    fn asset_url_shape_tga_alias() {
+        let url = asset_url("tga-v2.9.4", "tga", "2.9.4", "aarch64-apple-darwin");
+        assert_eq!(
+            url,
+            "https://github.com/bobmatnyc/trusty-tools/releases/download/\
+             tga-v2.9.4/trusty-git-analytics-2.9.4-aarch64-apple-darwin.tar.gz"
+        );
     }
 
     /// Why: Live integration proof that the GitHub API is reachable and returns a


### PR DESCRIPTION
## Summary

Three demo-blocking fixes to `trusty-installer` so a fresh macOS Apple
Silicon VM running `curl -sSf https://raw.githubusercontent.com/bobmatnyc/trusty-tools/main/install.sh | sh -s -- -y`
ends clean — no `4/7 … exit 2 … NOT VERIFIED` — with Claude Code + tmux
actually auto-configured.

- **FIX 1 (P0)** — `-y`/`TRUSTY_YES` now actually runs the prereq
  auto-install command (tmux via `brew install tmux`, Claude Code via
  `npm install -g @anthropic-ai/claude-code` or the native curl
  installer) without requiring a TTY. Previously
  `crates/trusty-installer/src/commands/prereqs/phase.rs` gated
  auto-install behind `!json && !yes && tty_fn()`, so a piped
  `curl | sh -s -- -y` (stdin never a TTY) silently degraded to a
  manual-only hint even under explicit `-y` consent. `--json` mode is
  unaffected (still fully non-interactive/no-auto-install); the
  interactive TTY-prompt path is unaffected.
- **FIX 2** — `tga`'s prebuilt download now resolves the correct
  release asset. Its release tag is `tga-v<version>` (tag resolution
  was already correct) but the release workflow names the tarball
  after the crate's directory, `trusty-git-analytics-<version>-<target>.tar.gz`,
  not the package name `tga` — so the old filename construction 404'd.
  `crates/trusty-installer/src/download/release.rs` now resolves the
  asset filename through a small crate-name → asset-name alias table.
- **FIX 3** — Stable-set members are now classified REQUIRED
  (`trusty-mpm`, `trusty-search`, `trusty-memory`, `trusty-review`) vs
  OPTIONAL (`trusty-analyze`, `trusty-console`, `tga`) via a new
  `StableMember::required` field. On a host with no Rust toolchain, an
  OPTIONAL member with no prebuilt for the platform is now reported as
  "skipped (no prebuilt for this platform)" in the summary and never
  fails the overall run (`InstallReport::all_ok` / `VerifyTailReport::verified`
  / exit code) — only a REQUIRED member's failure does. A doc comment
  at `stable_set()` marks where a future `trusty-agents` REQUIRED
  addition slots in without touching the derivation logic.

Version bump `0.4.5` → `0.4.6` + CHANGELOG entry. **Not releasing from
this PR** — Bob will cut the `trusty-installer` release after review.

## Test plan

- [x] `cargo test -p trusty-installer` — 431 passed, 0 failed, 3
      ignored (live-network tests, unchanged)
- [x] `cargo clippy -p trusty-installer --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-installer --check` — clean
- [x] New/adjusted unit tests: `-y` no-TTY auto-install (+ `--json`
      still non-interactive, no-auto-cmd fallback, exec-failure path),
      `tga` asset-name alias resolution, REQUIRED/OPTIONAL
      classification pinning, `InstallReport.all_ok` ignoring an
      optional failure (and an optional-only install still succeeding),
      `VerifyTailReport.verified` ignoring an optional down/not-installed
      daemon
- [x] `trusty-installer install --dry-run --yes` smoke-tested under a
      temp `$HOME` — safe, no real installs, confirms the CLI wiring
      still resolves the full stable set and prints correctly
- [ ] A full live `install.sh -s -- -y` re-run was **not** attempted —
      it would run `brew install tmux` / curl-install Claude Code, and
      bootstrap real `launchctl` services into this developer machine's
      live launchd domain, which is not safely reversible/isolated by a
      temp `$HOME` alone. The graceful-degrade and `-y` auto-install
      logic are instead covered by the targeted unit tests above,
      which exercise the exact decision points (no-TTY + `--yes`,
      optional-member failure) the demo run depends on.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools