### PR TITLE
fix(trusty-agents): raise persona chat max_turns default from 4 to 8

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -120,6 +120,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   subscribers. `InputArea`'s reconcile and `ChatView`'s progress handler both
   gate on the shared `streamAccumulator` so neither overwrites live streamed
   text.
+- **Persona chat turns no longer exhaust `max_turns` after a couple of tool
+  calls:** `run_pm_task_with_persona` (the `/agent`/`--direct` persona REPL
+  turn) hardcoded its `chat_with_tools_gated` ceiling to 2 turns (no tools) or
+  4 turns (with tools) since #254 and never consulted config, unlike the
+  general subagent tool loop's `[llm].max_turns`. A persona running a couple
+  of sequential tool calls (e.g. two `grep`s plus a summary) routinely
+  exhausted the 4-turn budget and failed with `chat_with_tools exceeded
+  max_turns`. The tool-using default is now 8 (raised from 4) and is
+  overridable per agent via the new `[llm].persona_max_turns` TOML field; the
+  no-tools case is unchanged (still 2).
 - **Izzie's own tools now reach the `--direct`/`--agent` dispatch path (#3745
   item C):** `tagent --direct izzie` loaded a tool registry of only
   `[git_log, git_status, web_search, delegate_to_agent]` and the model answered

--- a/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
@@ -75,6 +75,7 @@ fn test_agent_config(name: &str, model: &str, system_prompt: &str) -> AgentConfi
             model_override: None,
             enable_prompt_caching: true,
             max_turns: 5,
+            persona_max_turns: None,
             tool_choice: ToolChoice::Auto,
             use_finish_task: false,
             use_anthropic_direct: false,

--- a/crates/trusty-agents/src/agents/claude_mpm_loader.rs
+++ b/crates/trusty-agents/src/agents/claude_mpm_loader.rs
@@ -103,6 +103,7 @@ impl ClaudeMpmAgent {
                 model_override: None,
                 enable_prompt_caching: true,
                 max_turns: 20,
+                persona_max_turns: None,
                 tool_choice: ToolChoice::Auto,
                 use_finish_task: false,
                 use_anthropic_direct: false,

--- a/crates/trusty-agents/src/agents/params.rs
+++ b/crates/trusty-agents/src/agents/params.rs
@@ -235,6 +235,29 @@ pub struct LlmParams {
     #[serde(default = "default_max_turns")]
     pub max_turns: u32,
 
+    /// Max-turns override for the persona REPL chat loop specifically
+    /// (demo-day fix, 2026-07-24).
+    ///
+    /// Why: `run_pm_task_with_persona` (the `/agent <persona>` REPL turn) is a
+    /// separate call site from the subagent tool loop `max_turns` above — it
+    /// has hardcoded its own ceiling (2 turns with no tools, 4 with tools)
+    /// since #254 and never consulted this section at all. A persona doing a
+    /// couple of sequential tool calls (e.g. grep twice, then summarize)
+    /// routinely exhausted the 4-turn budget and failed with
+    /// `chat_with_tools exceeded max_turns`. This field lets an operator raise
+    /// the tool-using-persona ceiling per agent without a rebuild.
+    /// What: Only consulted by `dispatch::persona::persona_max_turns` for the
+    /// tool-using branch; the no-tools branch is unaffected (stays 2). When
+    /// `None` (default), that branch uses 8 turns — raised from the prior
+    /// hardcoded 4.
+    /// Test: `llm_params_persona_max_turns_defaults_to_none`,
+    /// `llm_params_persona_max_turns_parses_override` (`tests.rs`);
+    /// `persona_max_turns_with_tools_defaults_to_eight`,
+    /// `persona_max_turns_with_tools_honors_config_override`
+    /// (`ctrl::pm_task::dispatch::persona_tests`).
+    #[serde(default)]
+    pub persona_max_turns: Option<u32>,
+
     /// How to set the `tool_choice` field on chat requests (#57).
     ///
     /// Why: Some agents (plan, research, code) do their work entirely through

--- a/crates/trusty-agents/src/agents/registry/md_agent.rs
+++ b/crates/trusty-agents/src/agents/registry/md_agent.rs
@@ -184,6 +184,7 @@ pub(crate) fn parse_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
             model_override: None,
             enable_prompt_caching: true,
             max_turns: 20,
+            persona_max_turns: None,
             tool_choice: ToolChoice::Auto,
             use_finish_task: false,
             use_anthropic_direct: false,

--- a/crates/trusty-agents/src/agents/tests/params.rs
+++ b/crates/trusty-agents/src/agents/tests/params.rs
@@ -71,6 +71,47 @@ content = "base"
 }
 
 #[test]
+fn llm_params_persona_max_turns_defaults_to_none() {
+    let toml_str = r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert_eq!(cfg.llm.persona_max_turns, None);
+}
+
+#[test]
+fn llm_params_persona_max_turns_parses_override() {
+    let toml_str = r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+persona_max_turns = 12
+
+[system_prompt]
+content = "base"
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert_eq!(cfg.llm.persona_max_turns, Some(12));
+}
+
+#[test]
 fn llm_params_caching_can_be_disabled() {
     let toml_str = r#"
 [agent]

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -81,6 +81,40 @@ fn filter_persona_tool_names(
         .collect()
 }
 
+/// Default `max_turns` ceiling for a tool-using persona chat turn when
+/// `[llm].persona_max_turns` is not set in the agent's TOML.
+///
+/// Why: named separately from the literal so the demo-day rationale (raised
+/// from a hardcoded 4 after a persona doing two sequential tool calls plus a
+/// summary exhausted that budget) is documented once, at the definition, not
+/// re-explained at every read site.
+const DEFAULT_PERSONA_TOOL_MAX_TURNS: u32 = 8;
+
+/// Effective `max_turns` ceiling for a persona chat turn.
+///
+/// Why: `run_pm_task_with_persona` is a separate call site from the general
+/// subagent tool loop (`agents::in_process_runner` et al., which already
+/// honor `LlmParams::max_turns`) — it hardcoded its own ceiling (2 turns with
+/// no tools, 4 with tools) since #254 and never consulted config at all. A
+/// persona running a couple of sequential tool calls (e.g. grep twice, then
+/// summarize) routinely exhausted the 4-turn budget and failed with
+/// `chat_with_tools exceeded max_turns`. Pulled into its own function
+/// (mirroring `filter_persona_tool_names` above) so the default-vs-override
+/// behavior is unit-testable without a live LLM call.
+/// What: No tools -> 2 (unchanged current behavior). With tools ->
+/// `llm.persona_max_turns` when set, else [`DEFAULT_PERSONA_TOOL_MAX_TURNS`]
+/// (8, raised from the prior hardcoded 4).
+/// Test: `persona_max_turns_no_tools_is_two`,
+/// `persona_max_turns_with_tools_defaults_to_eight`,
+/// `persona_max_turns_with_tools_honors_config_override`.
+fn persona_max_turns(has_tools: bool, llm: &crate::agents::LlmParams) -> u32 {
+    if !has_tools {
+        return 2;
+    }
+    llm.persona_max_turns
+        .unwrap_or(DEFAULT_PERSONA_TOOL_MAX_TURNS)
+}
+
 /// Compute the `allowed_tools` argument passed to `chat_with_tools_gated` for
 /// a persona whose surface is gated by a declared `[tools].allow` list
 /// (#3208 regression guard).
@@ -500,7 +534,7 @@ pub async fn run_pm_task_with_persona(
     // `persona_allowed_tools` for why that would silently reopen the full
     // registered tool surface instead of denying dispatch.
     let allowed_tools = persona_allowed_tools(persona_tool_names.clone());
-    let max_turns = if persona_tool_names.is_empty() { 2 } else { 4 };
+    let max_turns = persona_max_turns(!persona_tool_names.is_empty(), &persona_cfg.llm);
     let (content, _usage) = llm::chat_with_tools_gated(
         &client,
         &persona_cfg.agent.model,

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -414,3 +414,54 @@ async fn persona_allowed_tools_permits_dispatch_when_non_empty() {
     assert!(!result.is_error(), "permitted tool must still dispatch");
     assert_eq!(result.content(), "search results");
 }
+
+/// Builds a minimal parsed `LlmParams`, optionally declaring
+/// `persona_max_turns`, for `persona_max_turns()` unit tests below.
+fn llm_params_with_persona_max_turns(persona_max_turns: Option<u32>) -> crate::agents::LlmParams {
+    let override_line = persona_max_turns
+        .map(|v| format!("persona_max_turns = {v}"))
+        .unwrap_or_default();
+    let toml_str = format!(
+        r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+{override_line}
+
+[system_prompt]
+content = "base"
+"#
+    );
+    let cfg: AgentConfig = toml::from_str(&toml_str).expect("parses");
+    cfg.llm
+}
+
+/// The no-tools branch is unaffected by this fix — pins current behavior.
+#[test]
+fn persona_max_turns_no_tools_is_two() {
+    let llm = llm_params_with_persona_max_turns(None);
+    assert_eq!(persona_max_turns(false, &llm), 2);
+}
+
+/// Demo-day fix (2026-07-24): a tool-using persona with no explicit
+/// `persona_max_turns` now gets 8 turns, not the prior hardcoded 4 that
+/// caused `chat_with_tools exceeded max_turns` failures on multi-tool turns.
+#[test]
+fn persona_max_turns_with_tools_defaults_to_eight() {
+    let llm = llm_params_with_persona_max_turns(None);
+    assert_eq!(persona_max_turns(true, &llm), 8);
+}
+
+/// An operator can raise (or lower) the ceiling further via
+/// `[llm].persona_max_turns` without a rebuild.
+#[test]
+fn persona_max_turns_with_tools_honors_config_override() {
+    let llm = llm_params_with_persona_max_turns(Some(12));
+    assert_eq!(persona_max_turns(true, &llm), 12);
+}


### PR DESCRIPTION
## Summary

- Demo-day fix: `run_pm_task_with_persona` (the `/agent` REPL persona turn) hardcoded its `chat_with_tools_gated` ceiling to 2 turns (no tools) / 4 turns (with tools) since #254, ignoring `[llm].max_turns` entirely — unlike the general subagent tool loop, which already honors that field.
- A persona doing a couple of sequential tool calls (e.g. two `grep`s plus a summary) exhausted the 4-turn budget and failed with: `chat_with_tools exceeded max_turns (4) without a final text response`.
- Pulls the computation into a new `persona_max_turns()` helper (mirroring the existing `filter_persona_tool_names` pattern) so the default-vs-override behavior is unit-testable without a live LLM call.
- Raises the tool-using default from 4 to 8, and exposes it as an overridable `[llm].persona_max_turns` TOML field (`Option<u32>`, default `None` → 8) for agents that need more.
- No-tools branch is unchanged (still 2).

## Root cause

`crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs:503` (before this change):
```rust
let max_turns = if persona_tool_names.is_empty() { 2 } else { 4 };
```
This was a call-site literal, never wired to `persona_cfg.llm.max_turns` (the config field other runners — `in_process_runner`, `claude_code_runner`, `subprocess::spawn` — already consult). No existing config knob reached this call site, so a config-only fix was not possible; this required a code change.

## Test plan

- [x] `cargo fmt --check -p trusty-agents`
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-agents --lib` — 2272 passed, 0 failed, 12 ignored
- [x] New unit tests: `persona_max_turns_no_tools_is_two`, `persona_max_turns_with_tools_defaults_to_eight`, `persona_max_turns_with_tools_honors_config_override`, `llm_params_persona_max_turns_defaults_to_none`, `llm_params_persona_max_turns_parses_override` — all pass
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations
- [ ] End-to-end verification against a rebuilt `~/.cargo/bin/tagent` binary — NOT done in this PR; the currently-installed demo binary was built from main before this fix and requires merge + `cargo install --path crates/trusty-agents-cli`-equivalent rebuild to pick this up. Flagging for the PM/Bob to decide on demo-morning risk before merging.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools