### PR TITLE
fix(trusty-agents): add Hastings-on-Hudson to Metro-North station table

### DIFF
--- a/crates/trusty-agents/src/tools/izzie/stations.rs
+++ b/crates/trusty-agents/src/tools/izzie/stations.rs
@@ -51,9 +51,19 @@ pub const STATIONS: &[Station] = &[
         aliases: &["greystone"],
     },
     Station {
+        name: "Hastings-on-Hudson",
+        stop_id: "22",
+        aliases: &["hastings-on-hudson", "hastings on hudson", "hastings"],
+    },
+    Station {
         name: "Dobbs Ferry",
         stop_id: "23",
         aliases: &["dobbs ferry", "dobbs"],
+    },
+    Station {
+        name: "Ardsley-on-Hudson",
+        stop_id: "24",
+        aliases: &["ardsley-on-hudson", "ardsley on hudson", "ardsley"],
     },
     Station {
         name: "Irvington",
@@ -259,6 +269,14 @@ mod tests {
         assert_eq!(match_station("haven").unwrap().stop_id, "149");
         assert!(match_station("Nonexistent Town").is_none());
         assert!(match_station("   ").is_none());
+    }
+
+    #[test]
+    fn match_station_hastings_and_ardsley() {
+        assert_eq!(match_station("hastings").unwrap().stop_id, "22");
+        assert_eq!(match_station("Hastings-on-Hudson").unwrap().stop_id, "22");
+        assert_eq!(match_station("ardsley").unwrap().stop_id, "24");
+        assert_eq!(match_station("Ardsley-on-Hudson").unwrap().stop_id, "24");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The curated `STATIONS` table in `crates/trusty-agents/src/tools/izzie/stations.rs` (shipped in #3703) covers the Hudson Line's Greystone (stop_id `20`) and Dobbs Ferry (stop_id `23`) neighbors but is missing **Hastings-on-Hudson** (stop_id `22`) — izzie's own home base for `get_train_schedule`.
- Also adds **Ardsley-on-Hudson** (stop_id `24`), which fills the same `20 → 23 → 25` gap and follows the identical alias pattern; confirming it was trivial once `stops.txt` was open.
- Both stop_ids were confirmed against MTA's published Metro-North GTFS static feed (`gtfsmnr.zip` / `stops.txt`), not guessed:
  ```
  20,0GY,Greystone,,40.972705,-73.889069,,https://new.mta.info/stations/greystone,0,,1
  22,0HS,Hastings-on-Hudson,,40.994109,-73.884512,,https://new.mta.info/stations/hastings-hudson,0,,1
  23,0DF,Dobbs Ferry,,41.012459,-73.87949,,https://new.mta.info/stations/dobbs-ferry,0,,1
  24,0AR,Ardsley-on-Hudson,,41.026198,-73.876543,,https://new.mta.info/stations/ardsley-hudson,0,,1
  ```
  Note: the prior investigation guessed stop_id `21` for Hastings-on-Hudson — the confirmed value is `22` (`21` does not exist for this pair in the feed).

## Held for demo-morning decision

**This PR is a draft and must NOT be merged** until Bob decides during demo-morning prep. It is intentionally scoped to the minimal curated-table fix; the durable fix (fall back to full GTFS static data) is filed as a separate follow-up issue.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test -p trusty-agents --lib izzie::stations` — 4 passed (incl. new `match_station_hastings_and_ardsley`)
- [x] `cargo test -p trusty-agents --lib izzie::metro_north` — 6 passed, 1 ignored (live-feed smoke test, pre-existing)
- [x] `cargo test -p trusty-agents --lib` (full crate suite) — 2291 passed, 0 failed, 12 ignored (pre-existing network-gated tests)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools