### PR TITLE
fix(trusty-agents): agent pickers list only assistant-role agents

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -42,6 +42,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Agent pickers list only assistant-role agents, not the 16 bundled
+  coding/engineer/support agents:** the GUI/Tauri picker and MCP
+  `list_agents` tool (both backed by `agent_roster`/`scan_agent_catalog`)
+  and the REPL's `/agents` slash command (previously a flat, non-role-aware
+  `discover_agent_names` glob that disagreed with `/agent`) now filter to
+  `role == "assistant"` — a missing/unparseable role is treated as
+  NOT-assistant (fail-closed), so a malformed manifest can never leak a
+  coding agent back into a picker. `/agents` now delegates to the same
+  filtered listing `/agent` (no arg) already used, so the two can't drift
+  again. `*.stale.bak` directory-package backups (e.g. `izzie.stale.bak/`)
+  are additionally excluded from the REPL listing (the GUI/API catalog
+  already excluded them). Direct by-name resolution — `/agent <name>`,
+  `/switch`, and `delegate_to_agent` (which resolves targets directly via
+  `AgentConfig::by_name_in`, never through the roster) — is unaffected, so
+  ctrl/pm/coding agents remain fully dispatchable though no longer listed.
 - **Agent picker no longer loses Izzie / CTO Bot on a cold start:** the
   `AgentSwitcher` (and `ModelSwitcher`) fetched their catalog exactly once in
   `onMount`, but `<Header>` — and therefore both pickers — renders before

--- a/crates/trusty-agents/src/api/server/projects.rs
+++ b/crates/trusty-agents/src/api/server/projects.rs
@@ -260,24 +260,62 @@ pub(super) async fn list_agents_route(State(_state): State<AppState>) -> Json<se
     Json(agent_roster().await)
 }
 
+/// True when a parsed catalog entry's `role` field is exactly `"assistant"`.
+///
+/// Why (Bob directive, agent-picker role filter): the picker/roster surface
+/// must show ONLY assistant-type personas (Assistant, Izzie, CTO Bot,
+/// custom ones like `researcher`) — never the 16 bundled coding/engineer/
+/// support agents. `parse_agent_toml`/`md_agent_to_catalog_json` already
+/// default a missing/unparseable `role` to `""` (never `None`), so a plain
+/// equality check against the literal `"assistant"` — with no special-casing
+/// for absence — naturally treats any unparseable or missing role as
+/// NOT-assistant. That is a deliberate fail-closed default: it is the only
+/// way a bundled coding agent can never leak back into the picker through a
+/// malformed or role-less manifest.
+/// What: Reads `v["role"]` as a string and compares against `"assistant"`.
+/// Test: `agent_roster_filters_to_assistant_role_only`.
+pub(super) fn is_assistant_role(v: &serde_json::Value) -> bool {
+    v.get("role").and_then(|r| r.as_str()) == Some("assistant")
+}
+
 /// Shared agent-roster computation — the `{"agents": [...]}` envelope returned
 /// by both `GET /api/agents` ([`list_agents_route`]) and the `list_agents`
 /// MCP tool ([`crate::runtime::mcp_serve`], #3633 core).
 ///
 /// Why: the MCP `list_agents` tool must surface the EXACT same roster the HTTP
 /// route (and therefore the GUI picker) shows — Assistant, Izzie, CTO Bot, and
-/// the specialist personas resolved from [`crate::agents::agents_dir_candidates`].
-/// Extracting the computation out of the axum handler into one plain async fn
-/// keeps the two surfaces from drifting, exactly as [`parse_agent_toml`] keeps
-/// the GET and PATCH shapes aligned.
+/// custom assistant-role personas resolved from
+/// [`crate::agents::agents_dir_candidates`]. Extracting the computation out of
+/// the axum handler into one plain async fn keeps the two surfaces from
+/// drifting, exactly as [`parse_agent_toml`] keeps the GET and PATCH shapes
+/// aligned. Per Bob's directive this is a PICKER surface, so it is filtered to
+/// `role == "assistant"` — the 16 bundled coding/engineer/support agents must
+/// never appear here. This does NOT affect delegation: `delegate_to_agent`
+/// (`crate::tools::delegate`) resolves its target directly via
+/// `AgentConfig::by_name_in` against the candidate directories, never through
+/// this roster, so hidden-but-functional agents (ctrl, pm, coding agents)
+/// remain fully dispatchable by name even though they no longer list here.
+/// [`scan_agent_catalog`] itself stays UNFILTERED (and is exercised directly
+/// by its own raw-scan tests) — the role filter is applied only at this
+/// picker-facing envelope boundary, so a future consumer that legitimately
+/// needs the full catalog can call `scan_agent_catalog` directly instead of
+/// this fn.
 /// What: scans every candidate agents directory via [`scan_agent_catalog`]
-/// (package + flat resolution, deduped, name-sorted) and wraps the result in
-/// the `{"agents": [...]}` envelope. Read-only; no side effects.
+/// (package + flat resolution, deduped, name-sorted), filters to
+/// [`is_assistant_role`], and wraps the result in the `{"agents": [...]}`
+/// envelope. Read-only; no side effects.
 /// Test: covered indirectly by `scan_agent_catalog_dedupes_across_dirs` (the
-/// scan) and the `mcp_serve` dispatcher's `tools/call` unit test (the envelope).
+/// scan) and the `mcp_serve` dispatcher's `tools/call` unit test (the
+/// envelope); role filter itself by
+/// `agent_roster_filters_to_assistant_role_only`.
 pub(crate) async fn agent_roster() -> serde_json::Value {
     let dirs = crate::agents::agents_dir_candidates();
-    serde_json::json!({ "agents": scan_agent_catalog(&dirs).await })
+    let agents: Vec<serde_json::Value> = scan_agent_catalog(&dirs)
+        .await
+        .into_iter()
+        .filter(is_assistant_role)
+        .collect();
+    serde_json::json!({ "agents": agents })
 }
 
 /// Parse one agent TOML file's `[agent]` table into the JSON shape shared by

--- a/crates/trusty-agents/src/api/server/tests/listing.rs
+++ b/crates/trusty-agents/src/api/server/tests/listing.rs
@@ -9,7 +9,9 @@
 //! session history loaders.
 //! Test: This module IS the test.
 
-use crate::api::server::projects::{load_sessions_from, scan_agent_catalog, scan_agents_dir};
+use crate::api::server::projects::{
+    is_assistant_role, load_sessions_from, scan_agent_catalog, scan_agents_dir,
+};
 
 /// Why: Confirms `/api/agents` returns the `{"agents": [...]}` envelope
 /// with the spec-required fields (name, role, model, runner) parsed from
@@ -310,6 +312,86 @@ async fn scan_agent_catalog_dedupes_across_dirs() {
         .find(|a| a["name"] == "cto-assistant")
         .unwrap();
     assert_eq!(cto["display_name"], "CTO Bot");
+}
+
+/// Why (Bob directive, agent-picker role filter): [`is_assistant_role`] is
+/// the sole gate deciding what the GUI/MCP picker surface shows. It must
+/// treat a missing/unparseable role as NOT-assistant (fail-closed) so a
+/// malformed manifest can never leak a bundled coding agent back into the
+/// picker — pins that default alongside the ordinary positive/negative
+/// cases.
+/// What: Table of role values through [`is_assistant_role`] directly.
+#[test]
+fn is_assistant_role_treats_missing_or_non_assistant_as_excluded() {
+    assert!(is_assistant_role(&serde_json::json!({"role": "assistant"})));
+    assert!(!is_assistant_role(&serde_json::json!({"role": "engineer"})));
+    assert!(!is_assistant_role(
+        &serde_json::json!({"role": "orchestrator"})
+    ));
+    assert!(
+        !is_assistant_role(&serde_json::json!({"role": ""})),
+        "an unparseable manifest's default empty role must be excluded"
+    );
+    assert!(
+        !is_assistant_role(&serde_json::json!({})),
+        "a role-less entry must be excluded"
+    );
+}
+
+/// Why (Bob directive, agent-picker role filter): the picker surface
+/// (`GET /api/agents` / MCP `list_agents`, both backed by [`agent_roster`])
+/// must show ONLY assistant-role agents — never the 16 bundled
+/// coding/engineer/support agents — while a custom assistant-role package
+/// (e.g. the new `researcher`) still surfaces. `agent_roster` itself reads
+/// the global candidate dirs, so this drives the same
+/// scan-then-filter pipeline it uses (`scan_agent_catalog` +
+/// `is_assistant_role`) against a tempdir fixture, matching this file's
+/// existing `scan_agent_catalog_dedupes_across_dirs` style.
+/// What: A coding agent (`role = "engineer"`), a bundled-style assistant
+/// (`role = "assistant"`), and a custom directory-package assistant
+/// (`researcher`, `role = "assistant"`) all in one dir; asserts the filtered
+/// roster keeps exactly the two assistants and drops the coding agent.
+#[tokio::test]
+async fn agent_roster_filters_to_assistant_role_only() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+
+    std::fs::write(
+        root.join("engineer.toml"),
+        "[agent]\nname = \"engineer\"\nrole = \"engineer\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("assistant.toml"),
+        "[agent]\nname = \"assistant\"\nrole = \"assistant\"\n",
+    )
+    .unwrap();
+    std::fs::create_dir(root.join("researcher")).unwrap();
+    std::fs::write(
+        root.join("researcher").join("agent.toml"),
+        "[agent]\nname = \"researcher\"\nrole = \"assistant\"\ndisplay_name = \"Researcher\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("researcher").join("persona.md"),
+        "You are the researcher.",
+    )
+    .unwrap();
+
+    let dirs = vec![root.to_path_buf()];
+    let agents: Vec<serde_json::Value> = scan_agent_catalog(&dirs)
+        .await
+        .into_iter()
+        .filter(is_assistant_role)
+        .collect();
+    let names: Vec<&str> = agents.iter().filter_map(|a| a["name"].as_str()).collect();
+
+    assert_eq!(
+        names,
+        vec!["assistant", "researcher"],
+        "coding agent excluded; both assistant-role agents (bundled + custom \
+         directory package) kept: {agents:?}"
+    );
 }
 
 /// Why: When the agents directory is missing, the route must still

--- a/crates/trusty-agents/src/repl/agent_commands.rs
+++ b/crates/trusty-agents/src/repl/agent_commands.rs
@@ -12,7 +12,7 @@
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
-use super::{TrustyAgentsRepl, discover_agent_names};
+use super::TrustyAgentsRepl;
 
 impl TrustyAgentsRepl {
     /// Candidate agent directories for this REPL instance, primary first
@@ -198,6 +198,14 @@ impl TrustyAgentsRepl {
             };
             for entry in entries.flatten() {
                 let path = entry.path();
+                // Skip archived backups (`*.stale.bak`, produced by the bundled
+                // reprovision, e.g. `izzie.stale.bak/agent.toml`) so they never
+                // leak into the listing as a bogus separate agent — mirrors the
+                // GUI/API catalog's `scan_agents_dir_tiered` skip (projects.rs).
+                let entry_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+                if entry_name.contains(".stale.bak") || entry_name.ends_with(".bak") {
+                    continue;
+                }
                 let stem = if path.is_dir() {
                     if !path.join("agent.toml").is_file() {
                         continue;
@@ -241,16 +249,24 @@ impl TrustyAgentsRepl {
         );
     }
 
+    /// List agents for the `/agents` slash command.
+    ///
+    /// Why (Bob directive, agent-picker role filter): `/agents` used to call
+    /// [`discover_agent_names`] — a flat, non-recursive `*.toml` glob with no
+    /// role filter and no directory-package awareness — so it disagreed with
+    /// `/agent` (no arg, [`Self::list_assistant_agents_into`]) in three ways:
+    /// it printed hidden-but-functional agents (ctrl, pm) and the 16 bundled
+    /// coding/engineer/support agents, it never saw directory-package agents
+    /// (Izzie, CTO Bot, Assistant), and it did not exclude `*.stale.bak`
+    /// backups. Rather than reimplement package-aware role filtering a second
+    /// time, `/agents` now delegates to the SAME filtered listing `/agent`
+    /// uses — the two commands can never drift again — keeping only its own
+    /// header/format wrapping.
+    /// What: Delegates to [`Self::list_assistant_agents_into`] and returns its
+    /// output verbatim (that fn already handles the empty case).
+    /// Test: `print_agents_into_matches_list_assistant_agents_filtering`.
     pub(crate) fn print_agents_into(&self, out: &mut String) {
-        let names = discover_agent_names(&self.agents_dir);
-        if names.is_empty() {
-            let _ = writeln!(out, "no agents found in {}", self.agents_dir.display());
-        } else {
-            let _ = writeln!(out, "Agents ({}):", names.len());
-            for name in names {
-                let _ = writeln!(out, "  - {name}");
-            }
-        }
+        self.list_assistant_agents_into(out);
     }
 
     pub(crate) fn print_skills_into(&self, out: &mut String) {

--- a/crates/trusty-agents/src/repl/tests.rs
+++ b/crates/trusty-agents/src/repl/tests.rs
@@ -378,6 +378,123 @@ fn list_assistant_agents_into_surfaces_directory_package() {
     );
 }
 
+/// Why (Bob directive, agent-picker role filter): `/agent` (no arg) must
+/// exclude both a coding-role agent AND a `*.stale.bak` directory-package
+/// backup (produced by the bundled reprovision, e.g. `izzie.stale.bak/
+/// agent.toml`) — the latter previously leaked in as a bogus separate entry
+/// literally named `izzie.stale.bak` because the old scan only checked flat
+/// `<name>.toml` extensions, never a directory entry's full name, for the
+/// backup suffix.
+/// What: A tempdir with a real assistant package, a coding-role flat TOML,
+/// and a `izzie.stale.bak/agent.toml` backup package; asserts the listing
+/// keeps the assistant, and excludes both the coding agent and the
+/// `.stale.bak` entry by name.
+#[test]
+fn list_assistant_agents_into_excludes_coding_role_and_stale_bak() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package_fixture(tmp.path(), "izzie", "Izzie");
+
+    // Coding-role agent: must never surface in the assistant picker.
+    std::fs::write(
+        tmp.path().join("engineer.toml"),
+        "[agent]\nname = \"engineer\"\nrole = \"engineer\"\ndescription = \"coding\"\n",
+    )
+    .unwrap();
+
+    // Archived backup package: must never surface as a bogus separate agent.
+    let stale = tmp.path().join("izzie.stale.bak");
+    std::fs::create_dir(&stale).unwrap();
+    std::fs::write(
+        stale.join("agent.toml"),
+        "[agent]\nname = \"izzie\"\nrole = \"assistant\"\ndisplay_name = \"STALE\"\n",
+    )
+    .unwrap();
+
+    let mut repl = TrustyAgentsRepl::new(None).unwrap();
+    repl.agents_dir = tmp.path().to_path_buf();
+    let mut out = String::new();
+    repl.list_assistant_agents_into(&mut out);
+
+    assert!(
+        out.lines().any(|l| l.trim_start().starts_with("izzie")),
+        "the real assistant package must still be listed: {out:?}"
+    );
+    assert!(
+        !out.contains("engineer"),
+        "a coding-role agent must never appear in the assistant listing: {out:?}"
+    );
+    assert!(
+        !out.contains("stale.bak"),
+        "a *.stale.bak backup must never appear as a bogus separate agent: {out:?}"
+    );
+}
+
+/// Why (Bob directive, agent-picker role filter): `/agents` used to bypass
+/// role filtering entirely ([`discover_agent_names`], flat non-recursive
+/// glob) and disagree with `/agent`. It now delegates to the same filtered
+/// listing, so the two commands can never drift again.
+/// What: Same fixture as the `/agent` test above; asserts `/agents`
+/// (`print_agents_into`) produces byte-identical output to
+/// `list_assistant_agents_into` and excludes the coding agent.
+#[test]
+fn print_agents_into_matches_list_assistant_agents_filtering() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_package_fixture(tmp.path(), "izzie", "Izzie");
+    std::fs::write(
+        tmp.path().join("engineer.toml"),
+        "[agent]\nname = \"engineer\"\nrole = \"engineer\"\n",
+    )
+    .unwrap();
+
+    let mut repl = TrustyAgentsRepl::new(None).unwrap();
+    repl.agents_dir = tmp.path().to_path_buf();
+
+    let mut agents_out = String::new();
+    repl.list_assistant_agents_into(&mut agents_out);
+    let mut slash_agents_out = String::new();
+    repl.print_agents_into(&mut slash_agents_out);
+
+    assert_eq!(
+        agents_out, slash_agents_out,
+        "/agents must delegate to the same filtered listing as /agent"
+    );
+    assert!(!slash_agents_out.contains("engineer"));
+}
+
+/// Why (Bob directive, agent-picker role filter): filtering the PICKER/
+/// listing surface must never break direct by-name activation. A
+/// coding-role agent is invisible in `/agent` / `/agents` output but must
+/// still be reachable via `/agent <name>` for hidden-but-functional
+/// dispatch (mirrors ctrl/pm staying dispatchable though never listed).
+/// What: A coding-role flat TOML that `list_assistant_agents_into` excludes;
+/// asserts `handle_agent_command_into` still activates it by exact name.
+#[test]
+fn handle_agent_command_into_activates_non_assistant_role_by_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("engineer.toml"),
+        "[agent]\nname = \"engineer\"\nrole = \"engineer\"\ndisplay_name = \"Engineer\"\nmodel = \"anthropic/claude-haiku-4-5\"\ndescription = \"coding\"\n\n[llm]\ntemperature = 0.5\nmax_tokens = 1024\n\n[system_prompt]\ncontent = \"You are an engineer.\"\n",
+    )
+    .unwrap();
+
+    let mut repl = TrustyAgentsRepl::new(None).unwrap();
+    repl.agents_dir = tmp.path().to_path_buf();
+
+    // Confirm it's excluded from the listing first.
+    let mut listing = String::new();
+    repl.list_assistant_agents_into(&mut listing);
+    assert!(!listing.contains("engineer"));
+
+    // But by-name activation still works.
+    let mut out = String::new();
+    repl.handle_agent_command_into("engineer", &mut out);
+    assert!(
+        out.contains("Switched to: Engineer"),
+        "a filtered (non-assistant-role) agent must still activate by name: {out:?}"
+    );
+    assert_eq!(repl.active_persona, Some("engineer".to_string()));
+}
+
 #[test]
 fn discover_agent_names_reads_toml_stems() {
     let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Bob's directive: the agent pickers must show ONLY assistant-type agents
(role == "assistant": assistant, izzie, cto-assistant, personal-assistant,
custom ones like the new `researcher`) — NOT the 16 bundled
coding/engineer/support agents.

**HELD FOR PM/BOB SIGN-OFF — do not merge.** Demo is this morning; opening
for review only.

## Surfaces covered

- **GUI/Tauri picker + MCP `list_agents`** (both backed by `agent_roster` ->
  `scan_agent_catalog`, `crates/trusty-agents/src/api/server/projects.rs`):
  `agent_roster` now filters the scanned catalog to `role == "assistant"`
  via a new `is_assistant_role` predicate. `scan_agent_catalog`/
  `scan_agents_dir` themselves stay **unfiltered** — their own raw-scan
  tests rely on non-assistant roles appearing in output, and no other
  production consumer calls them directly — the role filter is applied
  only at the picker-facing `agent_roster` envelope boundary.
- **REPL `/agents`** (`crates/trusty-agents/src/repl/agent_commands.rs`):
  previously bypassed role filtering entirely via `discover_agent_names` (a
  flat, non-recursive `*.toml` glob with no package awareness), disagreeing
  with `/agent` (no arg). Now delegates to the same
  `list_assistant_agents_into` listing `/agent` already used, so the two
  commands can never drift again.
- **REPL `/agent` (no arg) listing**: additionally excludes `*.stale.bak`
  directory-package backups (e.g. `izzie.stale.bak/agent.toml`), which
  previously leaked in as a bogus separate `izzie.stale.bak` entry — the
  GUI/API catalog already excluded these via `scan_agents_dir_tiered`.

## Fail-closed default

A missing/unparseable `role` is treated as **NOT-assistant** — both
`is_assistant_role`'s plain equality check against the literal
`"assistant"`, and the existing `parse_agent_toml`/`md_agent_to_catalog_json`
`role` default of `""`. This is deliberate: it is the only way a malformed
or role-less manifest can never leak a bundled coding agent back into the
picker.

## Delegation unaffected

`delegate_to_agent` (`crates/trusty-agents/src/tools/delegate.rs`) resolves
its target directly via `AgentConfig::by_name_in` against the candidate
directories — it never goes through `agent_roster`/`scan_agent_catalog`.
So hidden-but-functional agents (ctrl, pm, the coding/engineer agents)
remain fully dispatchable by name via `/agent <name>`, `/switch`, and
`delegate_to_agent`, even though they no longer appear in any
picker/listing surface. No query param or second roster function was
needed since no existing consumer of `agent_roster` needs the unfiltered
list.

## Rebuild / rollout (once green-lit)

- `cargo install --path crates/trusty-agents --bin tagent` (or the repo's
  usual `tagent` install path) picks up the fix — the binary target is
  `tagent` (`crates/trusty-agents/Cargo.toml`).
- **The GUI `.app` bundle does NOT need to be rebuilt.** The Tauri shell
  (`crates/trusty-agents/ui/src-tauri`) has no `externalBin`/bundled
  sidecar in `tauri.conf.json` — at runtime it resolves an external
  `tagent` binary via `which` (checking `tagent` then legacy
  `trusty-agents`, or the `TRUSTY_AGENTS_SIDECAR_BIN` override env var;
  see `sidecar.rs::resolve_tagent_binary`) and spawns it as a subprocess
  (`tagent --api`). Reinstalling/rebuilding the `tagent` binary on PATH is
  sufficient; the `.app` picks it up on next launch.

## Behavior notes

- **GUI picker**: the 16 bundled coding/engineer/support agents disappear
  from the agent-switcher dropdown; Assistant/Izzie/CTO Bot/custom
  assistant-role agents (e.g. `researcher`) remain.
- **REPL `/agent` and `/agents`**: same — coding agents and any
  `*.stale.bak` backup entries disappear from both listings (now
  identical output modulo the `/agents` header wrapping already in place).
- **Unaffected**: `/agent <name>` / `/switch` direct activation of a
  non-assistant-role agent by exact name, and `delegate_to_agent` — both
  still work for every agent, listed or not.

## Test plan

- [x] `cargo fmt -p trusty-agents --check` — clean
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-agents --lib` — 2295 passed, 0 failed, 12 ignored
- [x] New tests: `agent_roster_filters_to_assistant_role_only`,
      `is_assistant_role_treats_missing_or_non_assistant_as_excluded`,
      `list_assistant_agents_into_excludes_coding_role_and_stale_bak`,
      `print_agents_into_matches_list_assistant_agents_filtering`,
      `handle_agent_command_into_activates_non_assistant_role_by_name`
      (by-name load of a filtered agent still works)
- [x] `delegate_to_agent`/`mcp_serve` test suites re-run in isolation —
      unaffected (18 + 9 passing)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
