### PR TITLE
fix(trusty-mpm): teloxide rustls instead of native-tls to unblock Linux release (#3538)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,7 +218,13 @@ keyring = { version = "3", features = ["apple-native", "windows-native", "sync-s
 # CLI / TUI / Telegram (trusty-mpm-tui, trusty-mpm-telegram).
 ratatui = "0.29"
 crossterm = "0.28"
-teloxide = { version = "0.17", features = ["macros"] }
+# `default-features = false` + `rustls` (issue #3538): teloxide's default
+# feature set pulls in `native-tls` -> `openssl-sys`, which needs a system
+# OpenSSL the Linux release environment doesn't have. Swap to the rustls
+# backend and re-enable the other two default features the code actually
+# uses: `macros` (BotCommands derive, trusty-mpm/src/telegram) and
+# `ctrlc_handler` (Dispatcher::enable_ctrlc_handler(), same file).
+teloxide = { version = "0.17", default-features = false, features = ["rustls", "macros", "ctrlc_handler"] }
 # Slack Socket-Mode WebSocket client (trusty-mpm `slack` feature, DOC-20 #1294).
 # Same pin/features trusty-agents already uses, so the lockfile is unchanged.
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- **Linux release build no longer requires system OpenSSL** (closes [#3538](https://github.com/bobmatnyc/trusty-tools/issues/3538)): the workspace `teloxide` dependency (root `Cargo.toml`, inherited by `trusty-mpm`'s optional `telegram` feature — part of the default `cli` build) defaulted to teloxide's `native-tls` feature, which links `openssl-sys` against a system-installed OpenSSL. macOS builds were unaffected (`native-tls` uses Security.framework there), but the Linux release environment has no system OpenSSL dev headers, breaking the `tm` binary build/release. Switched to `default-features = false, features = ["rustls", "macros", "ctrlc_handler"]` — TLS now goes through `rustls` (no system OpenSSL dependency on any platform) while preserving the two other default features the code actually uses (`macros` for the `BotCommands` derive, `ctrlc_handler` for `Dispatcher::enable_ctrlc_handler()` in `telegram/mod.rs`). Verified: `cargo tree -p trusty-mpm -e normal,build -i openssl-sys` / `-i native-tls` are empty for the `trusty-mpm` release-binary dependency graph (both `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin` targets); git2's own (unrelated, pre-existing) `openssl-sys` usage is `vendored-openssl` and self-compiles rather than requiring a system install.
+
+---
 ## [1.0.0] - 2026-07-24
 
 **First stable release.** trusty-mpm (the `tm` harness/CLI/daemon) has been in


### PR DESCRIPTION
## Summary

`tm`'s Linux release build fails because the workspace `teloxide` dependency defaulted to teloxide's `native-tls` feature, which links `openssl-sys` against a system-installed OpenSSL. The Linux release environment has no system OpenSSL dev headers. macOS is unaffected — `native-tls` uses Security.framework there, not `openssl-sys`.

**git2 was previously suspected but is NOT the cause here.** trusty-tools' `git2` dependency already uses `default-features = false, features = ["vendored-libgit2", "vendored-openssl"]` (root `Cargo.toml`) / `["vendored-libgit2", "https", "vendored-openssl"]` (`trusty-git-analytics`) — `vendored-openssl` self-compiles OpenSSL from source and does not need a system install, so it was never the Linux blocker.

## File(s) changed

- `Cargo.toml` (workspace root, line ~221) — the only `teloxide` declaration in `trusty-mpm`'s (the `tm` binary's) dependency chain. `crates/trusty-mpm/Cargo.toml` inherits it via `teloxide = { workspace = true, optional = true }` under the `telegram` feature (part of the default `cli` feature set).
- `crates/trusty-mpm/CHANGELOG.md` — `## [Unreleased]` entry.

Note: `crates/trusty-agents/Cargo.toml` also declares its own separate (non-workspace) `teloxide = { version = "0.17", features = ["macros"] }`. `trusty-mpm` does **not** depend on the `trusty-agents` crate (only `trusty-agents-common`), so that declaration is outside this fix's scope — left untouched per the issue's scoping to the `tm` binary. Filing as a follow-up if `trusty-agents`' own Linux build hits the same wall.

## Feature-set before/after

Before (implicit `default-features = true`):
```
teloxide = { version = "0.17", features = ["macros"] }
```
Active features: `native-tls` (default) + `ctrlc_handler` (default) + `teloxide-core/default` (default, = `native-tls`) + `macros` (explicit).

After:
```
teloxide = { version = "0.17", default-features = false, features = ["rustls", "macros", "ctrlc_handler"] }
```
Active features: `rustls` (→ `teloxide-core/rustls` → `reqwest/rustls-tls`) + `macros` + `ctrlc_handler`. The two non-TLS default features the code actually uses are preserved explicitly:
- `macros` → `BotCommands` derive (`crates/trusty-mpm/src/telegram/mod.rs:30`, `use teloxide::utils::command::BotCommands;`)
- `ctrlc_handler` → `Dispatcher::enable_ctrlc_handler()` (`crates/trusty-mpm/src/telegram/mod.rs:270`)

`Cargo.lock` has **zero diff** — the rustls crate family was already resolved in the lockfile via other dependencies (e.g. `tokio-tungstenite`'s `rustls-tls-native-roots`), so no new lock entries were introduced.

## Verification (macOS — cannot build for Linux on this box)

**Build, green:**
```
$ cargo build -p trusty-mpm
   Compiling teloxide-macros v0.10.0
   ...
   Compiling teloxide-core v0.13.0
   Compiling teloxide v0.17.0
   Compiling trusty-mpm v1.0.0 (.../crates/trusty-mpm)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 49.79s
```

**`cargo tree -i openssl-sys` / `-i native-tls`, scoped to the actual release-binary dependency graph (`normal,build` edges only, excludes `dev-dependencies`), both targets — EMPTY (load-bearing evidence):**
```
$ cargo tree -p trusty-mpm -e normal,build -i openssl-sys --target x86_64-unknown-linux-gnu
warning: nothing to print.

$ cargo tree -p trusty-mpm -e normal,build -i native-tls --target x86_64-unknown-linux-gnu
warning: nothing to print.

$ cargo tree -p trusty-mpm -e normal,build -i openssl-sys --target aarch64-apple-darwin
warning: nothing to print.
```

Note on the *default* (dev-dependency-inclusive) `cargo tree -p trusty-mpm -i openssl-sys` / `-i native-tls`: these are **not** empty, but everything left is either (a) git2's `vendored-openssl` (self-compiling, not a system-OpenSSL requirement) reached through the `trusty-review` **dev**-dependency, or (b) `fastembed`'s explicit `hf-hub-native-tls` feature, reached only through the `embedder-test-support` **dev**-dependency (`cargo test`'s mock-embedder seam) — neither participates in `cargo build -p trusty-mpm` (confirmed: the build log above never compiles `openssl-sys`, `native-tls`, `hyper-tls`, `fastembed`, `hf-hub`, or `ort`). `cargo tree`'s inverted (`-i`) view without `-e normal,build` also displays `teloxide-core -> teloxide -> trusty-mpm` as a "parent" of `native-tls`, but that's a display artifact of Cargo's cross-graph feature unification on the single shared `reqwest` instance (driven by the dev-only `hf-hub` chain) — not a real feature requested by `teloxide` itself, which now asks for `rustls` only. The `-e normal,build` filtered command above is the one that reflects what the release binary actually needs and is unambiguous.

**Tests: green**
```
$ cargo test -p trusty-mpm --lib
test result: ok. 3555 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 10.06s

$ cargo test -p trusty-mpm --lib telegram
test result: ok. 98 passed; 0 failed; 0 ignored; 0 measured; 3463 filtered out; finished in 0.08s
```

## Scope / caveat

This is macOS-verified evidence only (dependency-tree proof that `openssl-sys`/`native-tls` are gone from the `trusty-mpm` release-binary graph, plus a green local build/test run). I cannot build for Linux on this box, so I'm not claiming the Linux release job itself is green — only that the specific system-OpenSSL requirement this issue describes is removed from the dependency graph feeding the `tm` binary.

Closes #3538

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
