### PR TITLE
chore(release): trusty-mpm 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11668,7 +11668,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [1.0.1] - 2026-07-24
 
 ### Fixed
 

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.0.0"
+version = "1.0.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary
Bump trusty-mpm from 1.0.0 to 1.0.1. This release includes the Linux build fix from PR #3813 (teloxide rustls instead of native-tls to unblock Linux binary release, closes #3538).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools