### PR TITLE
fix(trusty-installer): bootstrap every service unit + poll-based verify with distinct failure states

### DIFF
--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -34,6 +34,85 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   inherits its subprocess's stdout/stderr. Switched that call to the new
   `perform_upgrade_captured` (trusty-common 0.26.x) so it can never corrupt
   an active `LiveChecklist` either.
+- **Post-install verify raced daemon startup instead of waiting for it**
+  (#3833, demo-critical): `run_verify_tail`'s `launchctl kickstart -k` retry
+  re-probed health exactly once, immediately — trusty-search notably
+  downloads embedding models on first boot and can take tens of seconds, so a
+  perfectly healthy machine reported `verify: NOT VERIFIED` / exit code 2
+  moments before every daemon actually came up. `verify_one` now polls (new
+  `poll_until_not_down`) on a bounded ~55-60s per-member schedule (up to 12
+  attempts, 5s apart) instead of a single instant re-probe, printing a
+  "waiting for services to start..." indication while it does. A member
+  still `down` after the wait is now classified into one of three distinct
+  end states (`DownState::NotLoaded` / `Crashed { exit_code }` /
+  `StillStarting`, via `launchctl list <label>`) instead of a uniform,
+  undiagnosable `down` — the per-row human summary now says e.g.
+  `trusty-memory  down (not loaded)` or `trusty-search  down (crashed, exit
+  78)`. The exit code / `verified` verdict already derived from the (now
+  post-wait) `members` health, so both now reflect the FINAL state.
+  - **Code-critic fix round**: the per-member poll folds SEQUENTIALLY over up
+    to five launchd members, so five simultaneously-stuck daemons could stall
+    `tctl install` for ~4-5 minutes — exactly the scenario an operator most
+    needs a fast signal for. A new `AGGREGATE_POLL_BUDGET` (~120s total,
+    checked fresh before every member) now bounds the WHOLE poll-wait phase,
+    not just each member individually (`bounded_attempts` shrinks a late
+    member's own attempt ceiling to fit what's left); once exhausted, the
+    remaining members skip their poll (an instant probe only, flagged
+    `budget_exhausted` in the JSON row) and `tctl install` prints one summary
+    note — "poll budget exhausted — giving up on remaining members; re-run
+    `tctl install` to check them again" — instead of repeating it per row.
+- **`trusty-memory` was the only daemon member whose `service install` never
+  bootstrapped the plist** (#3832, demo-critical — root cause lived in
+  `trusty-memory`, see its CHANGELOG): `tctl install` shells out uniformly to
+  `<binary> service install` for every launchd-managed member expecting it to
+  write AND load the agent (matching `service_bootstrap`'s documented
+  contract); trusty-memory alone only wrote the plist, so a fresh-machine
+  install silently reported "trusty-memory: launchd service installed and
+  bootstrapped" while `com.trusty.memory` never appeared in `launchctl list`.
+  The verify tail's `down_state` classification above (`NotLoaded`) also
+  makes this failure mode immediately diagnosable if it recurs for any
+  member.
+  - **Code-critic fix round (HIGH)**: `tctl install` downloads a component's
+    LATEST PUBLISHED release binary, so the trusty-memory source fix above
+    only protects a demo once a new trusty-memory release ships — an
+    already-published (older) binary on a freshly-imaged machine would still
+    hit the bug. `bootstrap_one` (`service_bootstrap.rs`) no longer trusts a
+    clean `service install` exit code as proof of "loaded": it now
+    independently checks `launchctl list <label>` (`ServiceEnv::is_loaded`,
+    reusing the verify tail's own `launchctl list` primitive via the new
+    `verify_tail::is_label_loaded`) and, if the label is NOT loaded despite a
+    clean exit, force-bootstraps the already-written plist directly
+    (`ServiceEnv::bootstrap_fallback`, mirroring `lifecycle.rs`'s minimal-
+    `LaunchdConfig` pattern) — reported as the new
+    `BootstrapAction::InstalledByFallback` ("bootstrapped by installer
+    (component binary did not load its service)") rather than a silently
+    inaccurate `Installed`. This wraps the NEW captured `run_service_install`
+    (the `run_captured`-based call above, #3830) — the postcondition check
+    runs after that captured call returns `Ok`, regardless of which
+    implementation produced it. This makes the fix effective the moment
+    installer 0.4.8 ships, independent of any component binary's release
+    age, and guards the whole class of bug for every current and future
+    service member — not just trusty-memory. Both the fallback-success and
+    fallback-also-fails paths are unit-tested against `FakeServiceEnv`
+    (`bootstrap_one_falls_back_when_not_loaded`,
+    `bootstrap_one_reports_failure_when_fallback_also_fails`,
+    `bootstrap_one_installed_directly_when_loaded`).
+
+### Follow-up (tracked for a future release)
+
+- `trusty-memory`'s `service_install()` bootstrap call (the binary-side half
+  of #3832) has manual/integration verification only — there is no seam in
+  `trusty_common::launchd::LaunchdConfig` equivalent to `service_bootstrap`'s
+  `ServiceEnv` trait, so `install()` + `bootstrap()` sequencing across the
+  four daemon crates' `service.rs` files cannot be unit-tested in isolation
+  yet. (An earlier draft of this entry incorrectly claimed
+  `tests/path_shadow_e2e.rs` covered it — that test file exercises the
+  trusty-mpm supervisor bootstrap and PATH-shadow detection only, never
+  `trusty-memory service install`.) A `LaunchdOps`-style trait seam mirroring
+  `ServiceEnv`/`StubLaunchctl` would let this be unit-tested directly; left
+  as a follow-up since it touches all four daemon crates. The NEW
+  installer-side defensive fallback above IS fully unit-tested and is now the
+  demo-critical safety net regardless of this follow-up's timing.
 
 ## [0.4.7] — 2026-07-23
 

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -42,6 +42,7 @@ pub mod up;
 pub mod update_engine;
 pub mod updates;
 pub mod upgrade;
+pub mod verify_launchd_state;
 pub mod verify_tail;
 pub mod version;
 

--- a/crates/trusty-installer/src/commands/service_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap.rs
@@ -281,8 +281,8 @@ pub fn start_plan(plist_present: bool) -> StartPlan {
 /// `~/Library/LaunchAgents/<plist_label_for(binary)>.plist`;
 /// `run_service_install` spawns `<binary> service install` and maps a non-zero
 /// exit to an error; `is_loaded` (#3836) checks `launchctl list <label>` via
-/// [`super::verify_tail::is_label_loaded`] — the same `launchctl list`
-/// primitive `verify_tail`'s down-state classification is built on;
+/// [`super::verify_launchd_state::is_label_loaded`] — the same `launchctl
+/// list` primitive `verify_tail`'s down-state classification is built on;
 /// `bootstrap_fallback` (#3836) force-bootstraps the already-written plist
 /// directly, reusing the same minimal-`LaunchdConfig` (label only — the other
 /// fields are inert for `bootstrap`/`bootout`) pattern `lifecycle.rs`'s
@@ -308,7 +308,7 @@ impl ServiceEnv for RealServiceEnv {
 
     fn is_loaded(&self, binary: &str) -> bool {
         let label = super::plist_label::plist_label_for(binary);
-        super::verify_tail::is_label_loaded(&label)
+        super::verify_launchd_state::is_label_loaded(&label)
     }
 
     fn bootstrap_fallback(&self, binary: &str) -> anyhow::Result<()> {

--- a/crates/trusty-installer/src/commands/service_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap.rs
@@ -312,24 +312,41 @@ impl ServiceEnv for RealServiceEnv {
     }
 
     fn bootstrap_fallback(&self, binary: &str) -> anyhow::Result<()> {
-        use trusty_common::launchd::{KeepAlive, LaunchdConfig};
+        // `trusty_common::launchd` is itself `#[cfg(target_os = "macos")]`
+        // (it shells out to the real `launchctl` binary, which only exists
+        // on macOS) — this whole `RealServiceEnv` impl block is NOT
+        // platform-gated (its other methods are plain `std::process::Command`
+        // calls that degrade gracefully cross-platform), so referencing that
+        // module unconditionally fails to compile on Linux CI (the
+        // `Clippy`/`MSRV`/`Test` jobs). Gate this one body instead of the
+        // whole impl, mirroring `bootstrap_member_service`'s existing
+        // platform split just below.
+        #[cfg(target_os = "macos")]
+        {
+            use trusty_common::launchd::{KeepAlive, LaunchdConfig};
 
-        // Only `label` matters for `bootstrap` (it derives the plist path
-        // from it and the plist must already exist on disk — written by the
-        // `service install` that just ran); the rest are inert because we
-        // never render/write a plist here, mirroring `lifecycle.rs`'s
-        // `launchd_control`.
-        let cfg = LaunchdConfig {
-            label: super::plist_label::plist_label_for(binary),
-            exe_path: std::path::PathBuf::from(binary),
-            args: Vec::new(),
-            log_dir: std::path::PathBuf::from("/tmp"),
-            keep_alive: KeepAlive::Always,
-            throttle_interval: 0,
-            env_vars: Vec::new(),
-            fd_limit: None,
-        };
-        cfg.bootstrap()
+            // Only `label` matters for `bootstrap` (it derives the plist path
+            // from it and the plist must already exist on disk — written by
+            // the `service install` that just ran); the rest are inert
+            // because we never render/write a plist here, mirroring
+            // `lifecycle.rs`'s `launchd_control`.
+            let cfg = LaunchdConfig {
+                label: super::plist_label::plist_label_for(binary),
+                exe_path: std::path::PathBuf::from(binary),
+                args: Vec::new(),
+                log_dir: std::path::PathBuf::from("/tmp"),
+                keep_alive: KeepAlive::Always,
+                throttle_interval: 0,
+                env_vars: Vec::new(),
+                fd_limit: None,
+            };
+            cfg.bootstrap()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = binary;
+            anyhow::bail!("launchd is macOS-only")
+        }
     }
 }
 

--- a/crates/trusty-installer/src/commands/service_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap.rs
@@ -21,14 +21,31 @@
 //! healthy daemon. An opt-out ([`NO_SERVICE_ENV`] / the `--no-service` flag)
 //! disables the whole step.
 //!
+//! 🔴 (#3836 HIGH fix) [`bootstrap_one`] does NOT trust a clean
+//! `service install` exit code as proof the agent is actually loaded. #3832
+//! found that trusty-memory's `service install` used to write the plist
+//! WITHOUT loading it — a fresh install reported "installed and bootstrapped"
+//! while `launchctl list` never showed the label at all. Because `tctl
+//! install` downloads a component's LATEST PUBLISHED release binary
+//! (`download::release`), a source-level fix to one component's `service
+//! install` does not protect a demo running an OLDER already-published
+//! binary, and does not guard against the next component that ships the same
+//! bug. So after `run_service_install` returns `Ok`, [`bootstrap_one`] now
+//! independently checks whether launchd actually loaded the label
+//! ([`ServiceEnv::is_loaded`]) and, if not, force-bootstraps the
+//! already-written plist directly ([`ServiceEnv::bootstrap_fallback`]) —
+//! reported as [`BootstrapAction::InstalledByFallback`] rather than a silent
+//! `Installed`, so the narration is honest about what actually happened.
+//!
 //! Testability: every side effect is behind the [`ServiceEnv`] seam so the
 //! decision logic is unit-tested against an in-memory fake — the tests NEVER
 //! touch `~/Library/LaunchAgents` or invoke `launchctl` against the live
 //! daemons on the host (mirrors trusty-mpm's `FakeNoopTmuxDriver` pattern).
 //!
 //! Test: `tests` covers the member predicate, the opt-out truth table, every
-//! [`bootstrap_one`] branch (via `FakeServiceEnv`), and the [`start_plan`]
-//! relaxation used by `lifecycle.rs`.
+//! [`bootstrap_one`] branch — including the #3836 defensive-fallback branches
+//! — (via `FakeServiceEnv`), and the [`start_plan`] relaxation used by
+//! `lifecycle.rs`.
 
 /// Environment-variable opt-out for the post-install service bootstrap.
 ///
@@ -45,14 +62,23 @@ pub const NO_SERVICE_ENV: &str = "TCTL_NO_SERVICE_BOOTSTRAP";
 /// installed the service", "we intentionally skipped", and "it failed but we
 /// carried on" — a typed result keeps that reporting honest and testable.
 /// What: `Skipped` carries the human reason; `Installed` means `service
-/// install` ran clean; `Failed` carries the (non-fatal) error text.
+/// install` ran clean AND launchd confirmed the label loaded;
+/// `InstalledByFallback` (#3836) means `service install` exited clean but
+/// launchd did NOT have the label loaded, so the installer force-bootstrapped
+/// the plist directly; `Failed` carries the (non-fatal) error text.
 /// Test: `bootstrap_one_*` tests assert each variant.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BootstrapAction {
     /// Not attempted — opt-out, not a service member, or plist already present.
     Skipped(String),
-    /// `<binary> service install` ran successfully.
+    /// `<binary> service install` ran successfully AND launchd loaded it.
     Installed,
+    /// `<binary> service install` exited 0 but launchd never loaded the
+    /// label; the installer force-bootstrapped the plist directly instead
+    /// (#3836 — the #3832 defense-in-depth: protects the demo even against a
+    /// component binary whose own `service install` doesn't actually load
+    /// the agent, e.g. an older already-published release).
+    InstalledByFallback,
     /// Shell-out failed; install continues (fail-soft) but this is surfaced.
     Failed(String),
 }
@@ -69,6 +95,10 @@ impl BootstrapAction {
             BootstrapAction::Installed => {
                 format!("{binary}: launchd service installed and bootstrapped")
             }
+            BootstrapAction::InstalledByFallback => format!(
+                "{binary}: launchd service installed; bootstrapped by installer \
+                 (component binary did not load its service)"
+            ),
             BootstrapAction::Skipped(reason) => {
                 format!("{binary}: service bootstrap skipped ({reason})")
             }
@@ -108,35 +138,60 @@ pub fn bootstrap_enabled(no_service_flag: bool, env_opt_out: bool) -> bool {
 
 /// Side-effecting operations the bootstrap needs, behind a seam for testing.
 ///
-/// Why: the decision logic (skip vs install, idempotency, member filtering)
-/// must be unit-tested WITHOUT writing to `~/Library/LaunchAgents` or running
-/// `launchctl` against the host's live daemons. Abstracting the two effects —
-/// "does a plist already exist?" and "run `service install`" — lets a fake
-/// drive the logic hermetically (the `FakeNoopTmuxDriver` pattern).
-/// What: `plist_present` reports whether the member's LaunchAgent plist exists;
-/// `run_service_install` shells out to `<binary> service install`.
+/// Why: the decision logic (skip vs install, idempotency, member filtering,
+/// and the #3836 defensive-fallback check) must be unit-tested WITHOUT
+/// writing to `~/Library/LaunchAgents` or running `launchctl` against the
+/// host's live daemons. Abstracting the four effects — "does a plist already
+/// exist?", "run `service install`", "did launchd actually load it?", and
+/// "force-bootstrap the plist directly" — lets a fake drive the logic
+/// hermetically (the `FakeNoopTmuxDriver` pattern).
+/// What: `plist_present` reports whether the member's LaunchAgent plist
+/// exists; `run_service_install` shells out to `<binary> service install`;
+/// `is_loaded` (#3836) reports whether launchd currently has the label
+/// loaded at all; `bootstrap_fallback` (#3836) force-bootstraps the
+/// already-written plist directly via `launchctl`, bypassing the component
+/// binary's own (possibly broken) load step.
 /// Test: exercised via `RealServiceEnv` (production) and `FakeServiceEnv` (unit
 /// tests, `bootstrap_one_*`).
 pub trait ServiceEnv {
     /// Does a launchd plist already exist on disk for this member?
     fn plist_present(&self, binary: &str) -> bool;
-    /// Run `<binary> service install` (writes the plist and bootstraps it).
+    /// Run `<binary> service install` (expected to write the plist and
+    /// bootstrap it — but see [`bootstrap_one`]'s #3836 postcondition check,
+    /// which does not simply trust that expectation).
     fn run_service_install(&self, binary: &str) -> anyhow::Result<()>;
+    /// Does launchd currently have this member's label loaded at all
+    /// (#3836)?
+    fn is_loaded(&self, binary: &str) -> bool;
+    /// Force-bootstrap the member's already-written plist directly via
+    /// `launchctl`, independent of the component binary's own load logic
+    /// (#3836 defensive fallback).
+    fn bootstrap_fallback(&self, binary: &str) -> anyhow::Result<()>;
 }
 
 /// Decide and (via the seam) execute the service bootstrap for one member.
 ///
 /// Why: this is the whole per-member policy — filter non-service members, honour
-/// idempotency / non-clobber by skipping when a plist already exists, and
-/// otherwise delegate to `service install`. Keeping it seam-driven makes every
-/// branch testable with no real launchd contact.
+/// idempotency / non-clobber by skipping when a plist already exists, delegate
+/// to `service install`, and (#3836) independently VERIFY the postcondition
+/// `service install` is supposed to establish (the label is loaded) rather
+/// than trusting its exit code alone — #3832 was exactly a component binary
+/// whose `service install` exited 0 without ever loading the agent.
 /// What: returns [`BootstrapAction::Skipped`] when the member has no `service
-/// install` subcommand or a plist is already present; otherwise runs
-/// `run_service_install` and returns [`BootstrapAction::Installed`] or
-/// [`BootstrapAction::Failed`].
+/// install` subcommand or a plist is already present. Otherwise runs
+/// `run_service_install`; on success, checks [`ServiceEnv::is_loaded`] — if
+/// loaded, returns [`BootstrapAction::Installed`]; if NOT loaded, calls
+/// [`ServiceEnv::bootstrap_fallback`] and returns
+/// [`BootstrapAction::InstalledByFallback`] on success or
+/// [`BootstrapAction::Failed`] (with BOTH failure reasons folded in) if the
+/// fallback also fails. A `run_service_install` failure is
+/// [`BootstrapAction::Failed`] directly (the fallback is only for a
+/// misleadingly-successful exit code, not a genuine failure).
 /// Test: `bootstrap_one_skips_non_service_member`,
 /// `bootstrap_one_skips_when_plist_present`, `bootstrap_one_installs_when_absent`,
-/// `bootstrap_one_reports_failure`.
+/// `bootstrap_one_reports_failure`, `bootstrap_one_falls_back_when_not_loaded`,
+/// `bootstrap_one_installed_directly_when_loaded`,
+/// `bootstrap_one_reports_failure_when_fallback_also_fails`.
 pub fn bootstrap_one(env: &dyn ServiceEnv, binary: &str) -> BootstrapAction {
     if !member_has_service_install(binary) {
         return BootstrapAction::Skipped(format!("{binary} has no `service install` subcommand"));
@@ -147,9 +202,22 @@ pub fn bootstrap_one(env: &dyn ServiceEnv, binary: &str) -> BootstrapAction {
                 .to_string(),
         );
     }
-    match env.run_service_install(binary) {
-        Ok(()) => BootstrapAction::Installed,
-        Err(e) => BootstrapAction::Failed(e.to_string()),
+    if let Err(e) = env.run_service_install(binary) {
+        return BootstrapAction::Failed(e.to_string());
+    }
+    // #3836 HIGH fix: a clean exit is not proof launchd actually loaded the
+    // label (#3832's exact failure mode) — verify independently, and
+    // force-bootstrap directly if the component binary's own load step
+    // didn't take.
+    if env.is_loaded(binary) {
+        return BootstrapAction::Installed;
+    }
+    match env.bootstrap_fallback(binary) {
+        Ok(()) => BootstrapAction::InstalledByFallback,
+        Err(e) => BootstrapAction::Failed(format!(
+            "`{binary} service install` exited 0 but launchd never loaded the service, \
+             and the installer's fallback `launchctl bootstrap` also failed: {e}"
+        )),
     }
 }
 
@@ -212,7 +280,13 @@ pub fn start_plan(plist_present: bool) -> StartPlan {
 /// What: `plist_present` checks
 /// `~/Library/LaunchAgents/<plist_label_for(binary)>.plist`;
 /// `run_service_install` spawns `<binary> service install` and maps a non-zero
-/// exit to an error.
+/// exit to an error; `is_loaded` (#3836) checks `launchctl list <label>` via
+/// [`super::verify_tail::is_label_loaded`] — the same `launchctl list`
+/// primitive `verify_tail`'s down-state classification is built on;
+/// `bootstrap_fallback` (#3836) force-bootstraps the already-written plist
+/// directly, reusing the same minimal-`LaunchdConfig` (label only — the other
+/// fields are inert for `bootstrap`/`bootout`) pattern `lifecycle.rs`'s
+/// `launchd_control` uses.
 /// Test: side-effecting; never constructed in the test suite (the fake is used).
 pub struct RealServiceEnv;
 
@@ -230,6 +304,32 @@ impl ServiceEnv for RealServiceEnv {
         let mut cmd = std::process::Command::new(binary);
         cmd.args(["service", "install"]);
         run_captured(cmd, &format!("`{binary} service install`"))
+    }
+
+    fn is_loaded(&self, binary: &str) -> bool {
+        let label = super::plist_label::plist_label_for(binary);
+        super::verify_tail::is_label_loaded(&label)
+    }
+
+    fn bootstrap_fallback(&self, binary: &str) -> anyhow::Result<()> {
+        use trusty_common::launchd::{KeepAlive, LaunchdConfig};
+
+        // Only `label` matters for `bootstrap` (it derives the plist path
+        // from it and the plist must already exist on disk — written by the
+        // `service install` that just ran); the rest are inert because we
+        // never render/write a plist here, mirroring `lifecycle.rs`'s
+        // `launchd_control`.
+        let cfg = LaunchdConfig {
+            label: super::plist_label::plist_label_for(binary),
+            exe_path: std::path::PathBuf::from(binary),
+            args: Vec::new(),
+            log_dir: std::path::PathBuf::from("/tmp"),
+            keep_alive: KeepAlive::Always,
+            throttle_interval: 0,
+            env_vars: Vec::new(),
+            fd_limit: None,
+        };
+        cfg.bootstrap()
     }
 }
 
@@ -284,13 +384,24 @@ mod tests {
     use super::*;
     use std::cell::RefCell;
 
-    /// In-memory [`ServiceEnv`] fake — records `service install` calls and
-    /// simulates plist presence, so tests never touch launchd or the real
+    /// In-memory [`ServiceEnv`] fake — records `service install` /
+    /// `bootstrap_fallback` calls and simulates plist presence + launchd load
+    /// state, so tests never touch launchd or the real
     /// `~/Library/LaunchAgents`.
+    ///
+    /// Why the `loaded: true` default (#3836): the pre-existing
+    /// `bootstrap_one_*` tests below construct this via `new(present, fail)`
+    /// and assert the OLD `Installed` outcome — defaulting `loaded` to `true`
+    /// (the honest, common case: `service install` DID load the agent) keeps
+    /// those tests passing unchanged and expresses the #3832 failure mode
+    /// (loaded: false) as an opt-in builder instead.
     struct FakeServiceEnv {
         present: bool,
         fail: bool,
+        loaded: bool,
+        fail_fallback: bool,
         installed: RefCell<Vec<String>>,
+        fallback_calls: RefCell<Vec<String>>,
     }
 
     impl FakeServiceEnv {
@@ -298,8 +409,25 @@ mod tests {
             Self {
                 present,
                 fail,
+                loaded: true,
+                fail_fallback: false,
                 installed: RefCell::new(Vec::new()),
+                fallback_calls: RefCell::new(Vec::new()),
             }
+        }
+
+        /// Builder (#3836): simulate `service install` exiting 0 WITHOUT
+        /// launchd ever loading the label — #3832's exact failure mode.
+        fn not_loaded(mut self) -> Self {
+            self.loaded = false;
+            self
+        }
+
+        /// Builder (#3836): simulate the installer's own fallback
+        /// `launchctl bootstrap` also failing.
+        fn failing_fallback(mut self) -> Self {
+            self.fail_fallback = true;
+            self
         }
     }
 
@@ -311,6 +439,16 @@ mod tests {
             self.installed.borrow_mut().push(binary.to_string());
             if self.fail {
                 anyhow::bail!("simulated failure");
+            }
+            Ok(())
+        }
+        fn is_loaded(&self, _binary: &str) -> bool {
+            self.loaded
+        }
+        fn bootstrap_fallback(&self, binary: &str) -> anyhow::Result<()> {
+            self.fallback_calls.borrow_mut().push(binary.to_string());
+            if self.fail_fallback {
+                anyhow::bail!("simulated fallback failure");
             }
             Ok(())
         }
@@ -418,6 +556,68 @@ mod tests {
             BootstrapAction::Failed(e) => assert!(e.contains("simulated failure")),
             other => panic!("expected Failed, got {other:?}"),
         }
+        assert!(
+            env.fallback_calls.borrow().is_empty(),
+            "a genuine service-install failure must never trigger the fallback \
+             bootstrap — that's only for a misleadingly-successful exit code"
+        );
+    }
+
+    /// Why: #3836 HIGH fix — the common, honest case: `service install`
+    /// exited 0 AND launchd actually loaded the label. Must NOT invoke the
+    /// fallback bootstrap (it would be a needless extra `launchctl` call /
+    /// redundant restart).
+    /// What: with `loaded: true` (the default), asserts plain `Installed` and
+    /// zero fallback calls.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_one_installed_directly_when_loaded() {
+        let env = FakeServiceEnv::new(false, false);
+        let action = bootstrap_one(&env, "trusty-search");
+        assert_eq!(action, BootstrapAction::Installed);
+        assert!(
+            env.fallback_calls.borrow().is_empty(),
+            "must not force-bootstrap when launchd already loaded the label"
+        );
+    }
+
+    /// Why: THE #3836 HIGH fix's core safety property — #3832's exact
+    /// failure signature (`service install` exits 0 but launchd never loads
+    /// the label) must be caught and repaired, not silently reported as a
+    /// clean `Installed`.
+    /// What: with `loaded: false`, asserts `InstalledByFallback` and exactly
+    /// one recorded `bootstrap_fallback` call for the right binary.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_one_falls_back_when_not_loaded() {
+        let env = FakeServiceEnv::new(false, false).not_loaded();
+        let action = bootstrap_one(&env, "trusty-memory");
+        assert_eq!(action, BootstrapAction::InstalledByFallback);
+        assert_eq!(env.fallback_calls.borrow().as_slice(), ["trusty-memory"]);
+    }
+
+    /// Why: if EVEN the installer's own direct `launchctl bootstrap` fallback
+    /// fails, that must be surfaced loudly (`Failed`) — never silently
+    /// swallowed — and the error text must explain BOTH what happened (a
+    /// misleading exit code) and why the recovery attempt itself failed, so
+    /// an operator isn't left staring at a bare "Failed" for a
+    /// non-obvious reason.
+    /// What: with `loaded: false` AND the fallback set to fail, asserts
+    /// `Failed` whose message names the fallback failure.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_one_reports_failure_when_fallback_also_fails() {
+        let env = FakeServiceEnv::new(false, false)
+            .not_loaded()
+            .failing_fallback();
+        let action = bootstrap_one(&env, "trusty-review");
+        match action {
+            BootstrapAction::Failed(e) => {
+                assert!(e.contains("never loaded"), "message: {e}");
+                assert!(e.contains("simulated fallback failure"), "message: {e}");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
     }
 
     /// Why: the narration note must name the member for a scannable install log.
@@ -428,6 +628,9 @@ mod tests {
         assert!(BootstrapAction::Installed
             .note("trusty-search")
             .contains("trusty-search"));
+        assert!(BootstrapAction::InstalledByFallback
+            .note("trusty-memory")
+            .contains("trusty-memory"));
         assert!(BootstrapAction::Skipped("x".into())
             .note("trusty-memory")
             .contains("trusty-memory"));

--- a/crates/trusty-installer/src/commands/verify_launchd_state.rs
+++ b/crates/trusty-installer/src/commands/verify_launchd_state.rs
@@ -1,0 +1,335 @@
+//! Three-state launchd diagnosis for a `down` service member (#3833/#3836).
+//!
+//! Why: split out of `verify_tail.rs` (issue #3836 code-critic fix round —
+//! `verify_tail.rs` crossed the 500-SLOC production file cap once this
+//! diagnosis machinery + the #3836 defensive-fallback support landed).
+//! Distinguishing WHY a launchd-managed daemon is `down` — never loaded at
+//! all, loaded then crashed, or loaded and just still starting — is its own
+//! cohesive concern, independent of `verify_tail`'s polling/report-building
+//! logic, and is reused by BOTH `verify_tail::verify_one` (the #3833 poll
+//! wait's final diagnosis) and `service_bootstrap::bootstrap_one` (the #3836
+//! defensive fallback's "is it actually loaded?" check) — a natural module
+//! boundary.
+//!
+//! What: [`DownState`] is the three-variant diagnosis; [`classify_down_state`]
+//! derives it for a binary via `launchctl list <label>`; [`is_label_loaded`]
+//! answers the narrower "is it loaded at all?" question the #3836 fallback
+//! needs, off the SAME `launchctl list` primitive so the two call sites can
+//! never disagree about what "loaded" means.
+//!
+//! Test: the pure decision pieces (`classify_down_state_from_entry`,
+//! `parse_launchd_list_text`, `DownState::phrase`) are unit-tested; the
+//! `launchctl` subprocess call (`launchd_list_raw`) is side-effecting and
+//! validated manually.
+
+use serde::Serialize;
+
+/// Why a LAUNCHD daemon member is still reporting `down` after the #3833 poll
+/// wait — replaces a uniform, underspecified `down` with a diagnosis an
+/// operator can act on directly.
+///
+/// Why: "down" alone doesn't tell you whether launchd never loaded the job at
+/// all, loaded it and it crashed, or it is simply still coming up — three
+/// situations with three different next actions (re-run the bootstrap step,
+/// read the crash log, or just wait longer).
+/// What: [`DownState::NotLoaded`] — `launchctl list <label>` found no such
+/// service (never bootstrapped, or booted out). [`DownState::Crashed`] —
+/// loaded, no PID currently running, and the last recorded exit status was
+/// nonzero. [`DownState::StillStarting`] — loaded, and either a PID is
+/// currently running (health just hasn't caught up yet) or the last exit
+/// status was a clean `0` (about to be (re)launched, e.g. between
+/// `ThrottleInterval` respawns).
+/// Test: `tests::classify_down_state_from_entry_*`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum DownState {
+    /// `launchctl` has no record of this label at all.
+    NotLoaded,
+    /// Loaded, but not currently running, with a nonzero last exit status.
+    Crashed {
+        /// The `LastExitStatus` launchd recorded.
+        exit_code: i32,
+    },
+    /// Loaded and either currently running (health hasn't caught up) or
+    /// cleanly exited and awaiting its next (re)launch.
+    StillStarting,
+}
+
+impl DownState {
+    /// A short, human-readable phrase for `verify_tail`'s per-row annotation.
+    ///
+    /// Why: centralises the wording so the JSON `state` tag and the human
+    /// narration can never drift.
+    /// What: maps each variant to a lowercase phrase with no leading article.
+    /// Test: `tests::down_state_phrase_mapping`.
+    pub(super) fn phrase(&self) -> String {
+        match self {
+            DownState::NotLoaded => "not loaded".to_owned(),
+            DownState::Crashed { exit_code } => format!("crashed, exit {exit_code}"),
+            DownState::StillStarting => "still starting".to_owned(),
+        }
+    }
+}
+
+/// One `launchctl list <label>` observation, pre-parsed (#3833).
+///
+/// Why: separating the parse from the subprocess spawn lets
+/// [`classify_down_state_from_entry`] be exercised with fixed sample text —
+/// no live `launchctl` needed.
+/// What: `has_pid` — whether the dump has a `"PID" = N;` line (a process is
+/// currently running); `exit_status` — the `"LastExitStatus"` launchd last
+/// recorded (`0` when absent, matching launchd's own default).
+/// Test: `tests::parse_launchd_list_text_*`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LaunchdListEntry {
+    has_pid: bool,
+    exit_status: i32,
+}
+
+/// Parse `launchctl list <label>`'s property-list-style stdout dump.
+///
+/// Why: isolates the (pure) text parsing from the (side-effecting) subprocess
+/// spawn so the format assumptions are unit-testable.
+/// What: scans for a `"PID" = ...;` line (sets `has_pid`) and a
+/// `"LastExitStatus" = N;` line (sets `exit_status`, defaulting to `0` when
+/// absent — launchd omits the key before the job has ever exited). Never
+/// panics on malformed input.
+/// Test: `tests::parse_launchd_list_text_running`,
+/// `tests::parse_launchd_list_text_crashed`,
+/// `tests::parse_launchd_list_text_clean_exit`.
+fn parse_launchd_list_text(text: &str) -> LaunchdListEntry {
+    let has_pid = text.lines().any(|l| l.trim_start().starts_with("\"PID\""));
+    let exit_status = text
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("\"LastExitStatus\" ="))
+        .and_then(|rest| rest.trim().trim_end_matches(';').trim().parse::<i32>().ok())
+        .unwrap_or(0);
+    LaunchdListEntry {
+        has_pid,
+        exit_status,
+    }
+}
+
+/// Classify a parsed `launchctl list` observation into a [`DownState`].
+///
+/// Why: the pure decision half of [`classify_down_state`] — kept separate so
+/// every branch is unit-tested without a live `launchctl`.
+/// What: `None` (label not found) → [`DownState::NotLoaded`]; a running PID →
+/// [`DownState::StillStarting`] (loaded, health just hasn't caught up); a
+/// nonzero last exit status with no running PID → [`DownState::Crashed`];
+/// anything else (loaded, no PID, clean last exit) → [`DownState::StillStarting`]
+/// (about to be (re)launched).
+/// Test: `tests::classify_down_state_from_entry_not_loaded`,
+/// `tests::classify_down_state_from_entry_running`,
+/// `tests::classify_down_state_from_entry_crashed`,
+/// `tests::classify_down_state_from_entry_clean_exit_no_pid`.
+fn classify_down_state_from_entry(entry: Option<LaunchdListEntry>) -> DownState {
+    match entry {
+        None => DownState::NotLoaded,
+        Some(e) if e.has_pid => DownState::StillStarting,
+        Some(e) if e.exit_status != 0 => DownState::Crashed {
+            exit_code: e.exit_status,
+        },
+        Some(_) => DownState::StillStarting,
+    }
+}
+
+/// Run `launchctl list <label>` and return its raw stdout, or `None` when the
+/// label is not found (macOS only; #3833).
+///
+/// Why: isolated as its own thin side-effecting function so
+/// [`classify_down_state`] composes it with the pure
+/// [`parse_launchd_list_text`] / [`classify_down_state_from_entry`] pair.
+/// What: `Some(stdout)` on a successful `launchctl list <label>`; `None` when
+/// the command fails to spawn or exits non-zero (launchd's "no such service"
+/// signature).
+/// Test: side-effecting; not invoked in the test suite.
+#[cfg(target_os = "macos")]
+fn launchd_list_raw(label: &str) -> Option<String> {
+    let out = std::process::Command::new("launchctl")
+        .args(["list", label])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn launchd_list_raw(_label: &str) -> Option<String> {
+    None
+}
+
+/// Whether launchd currently has `label` loaded at all (#3836).
+///
+/// Why: `service_bootstrap::bootstrap_one`'s #3836 defensive fallback needs
+/// to know whether a component binary's own `service install` actually
+/// loaded the agent, not just that the subprocess exited 0 (#3832's root
+/// cause — trusty-memory's `service install` used to write the plist without
+/// loading it). Reuses the exact same `launchctl list <label>` primitive
+/// [`classify_down_state`] is built on ([`launchd_list_raw`]), so the two
+/// call sites can never disagree about what "loaded" means.
+/// What: `true` iff `launchctl list <label>` finds the label at all —
+/// regardless of whether a PID is currently running; a loaded-but-not-yet-
+/// running job is still "loaded" (launchd owns it and will start it).
+/// Test: side-effecting; not invoked in the test suite (mirrors
+/// `classify_down_state`) — the underlying `Option`-based decision is the
+/// SAME one `classify_down_state_from_entry`'s `None` branch already covers.
+pub(super) fn is_label_loaded(label: &str) -> bool {
+    launchd_list_raw(label).is_some()
+}
+
+/// Classify why a LAUNCHD member is still `down` after the poll wait (#3833).
+///
+/// Why: `verify_tail::verify_one` calls this once it has a final `down`
+/// verdict for a LAUNCHD member — composes the side-effecting `launchctl
+/// list` call with the pure parse + classify pair above.
+/// What: resolves the member's launchd label, runs `launchctl list <label>`,
+/// and classifies the result via [`classify_down_state_from_entry`].
+/// Test: side-effecting (subprocess); the decision half is
+/// `classify_down_state_from_entry`.
+pub(super) fn classify_down_state(binary: &str) -> DownState {
+    let label = super::plist_label::plist_label_for(binary);
+    let entry = launchd_list_raw(&label).map(|text| parse_launchd_list_text(&text));
+    classify_down_state_from_entry(entry)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: pins the exact wording each `DownState` variant renders, since
+    /// both the human summary and (transitively, via `serde`) the `--json`
+    /// `state` tag depend on it staying stable.
+    /// What: asserts the phrase for each variant.
+    /// Test: This is the test.
+    #[test]
+    fn down_state_phrase_mapping() {
+        assert_eq!(DownState::NotLoaded.phrase(), "not loaded");
+        assert_eq!(
+            DownState::Crashed { exit_code: 78 }.phrase(),
+            "crashed, exit 78"
+        );
+        assert_eq!(DownState::StillStarting.phrase(), "still starting");
+    }
+
+    /// Why: the running-PID branch must win regardless of last exit status —
+    /// a currently-running process means the daemon IS up; `down` health
+    /// just hasn't caught up yet (e.g. still loading models).
+    /// What: an entry with `has_pid: true` classifies as `StillStarting`
+    /// even when `exit_status` is nonzero (stale from a PRIOR crash).
+    /// Test: This is the test.
+    #[test]
+    fn classify_down_state_from_entry_running() {
+        let entry = LaunchdListEntry {
+            has_pid: true,
+            exit_status: 1,
+        };
+        assert_eq!(
+            classify_down_state_from_entry(Some(entry)),
+            DownState::StillStarting
+        );
+    }
+
+    /// Why: THE #3833 core diagnosis — no running PID plus a nonzero last
+    /// exit status is a genuine crash, not a startup race.
+    /// What: asserts `Crashed` carries the exact exit code.
+    /// Test: This is the test.
+    #[test]
+    fn classify_down_state_from_entry_crashed() {
+        let entry = LaunchdListEntry {
+            has_pid: false,
+            exit_status: 2,
+        };
+        assert_eq!(
+            classify_down_state_from_entry(Some(entry)),
+            DownState::Crashed { exit_code: 2 }
+        );
+    }
+
+    /// Why: no PID + a clean (`0`) last exit is ambiguous between "never
+    /// started yet" and "cleanly stopped, about to relaunch" — both read as
+    /// "still starting" rather than a false `Crashed`.
+    /// What: asserts `StillStarting`.
+    /// Test: This is the test.
+    #[test]
+    fn classify_down_state_from_entry_clean_exit_no_pid() {
+        let entry = LaunchdListEntry {
+            has_pid: false,
+            exit_status: 0,
+        };
+        assert_eq!(
+            classify_down_state_from_entry(Some(entry)),
+            DownState::StillStarting
+        );
+    }
+
+    /// Why: THE #3832/#3833 root-cause signature — a label `launchctl list`
+    /// cannot find at all (never bootstrapped, e.g. the #3832 trusty-memory
+    /// bug) must be reported as `NotLoaded`, not lumped in with a crash.
+    /// What: asserts `None` (label not found) classifies as `NotLoaded`.
+    /// Test: This is the test.
+    #[test]
+    fn classify_down_state_from_entry_not_loaded() {
+        assert_eq!(classify_down_state_from_entry(None), DownState::NotLoaded);
+    }
+
+    /// Why: `launchctl list <label>`'s dump format is `"Key" = value;` lines
+    /// inside a `{ ... }` block; the parser must find `PID`/`LastExitStatus`
+    /// regardless of surrounding whitespace/indentation and must not mistake
+    /// unrelated keys (e.g. `"PerJobMachServices"`) for them.
+    /// What: parses a realistic "running" dump; asserts `has_pid` and the
+    /// default `exit_status` (absent key → `0`).
+    /// Test: This is the test.
+    #[test]
+    fn parse_launchd_list_text_running() {
+        let text = r#"{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "com.trusty.trusty-search";
+	"OnDemand" = false;
+	"LastExitStatus" = 0;
+	"PID" = 4242;
+	"Program" = "/usr/local/bin/trusty-search";
+};
+"#;
+        let entry = parse_launchd_list_text(text);
+        assert!(entry.has_pid);
+        assert_eq!(entry.exit_status, 0);
+    }
+
+    /// Why: the crash signature — no `PID` line, a nonzero `LastExitStatus`.
+    /// What: parses a realistic "crashed" dump; asserts `has_pid` is false
+    /// and `exit_status` matches.
+    /// Test: This is the test.
+    #[test]
+    fn parse_launchd_list_text_crashed() {
+        let text = r#"{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "com.trusty.memory";
+	"LastExitStatus" = 78;
+};
+"#;
+        let entry = parse_launchd_list_text(text);
+        assert!(!entry.has_pid);
+        assert_eq!(entry.exit_status, 78);
+    }
+
+    /// Why: a loaded-but-never-yet-run (or cleanly stopped) job omits `PID`
+    /// and reports `LastExitStatus = 0` (or omits it entirely) — must not be
+    /// misparsed as a crash.
+    /// What: parses a dump with neither key; asserts `has_pid: false`,
+    /// `exit_status: 0` (the documented default).
+    /// Test: This is the test.
+    #[test]
+    fn parse_launchd_list_text_clean_exit() {
+        let text = r#"{
+	"Label" = "com.trusty.trusty-review";
+	"OnDemand" = false;
+};
+"#;
+        let entry = parse_launchd_list_text(text);
+        assert!(!entry.has_pid);
+        assert_eq!(entry.exit_status, 0);
+    }
+}

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -1,5 +1,5 @@
 //! Post-install verify tail: `ensure` + health, with the #2498 kickstart retry
-//! (#2560).
+//! (#2560) and the #3833 poll-until-ready wait.
 //!
 //! Why: `tctl install` placed binaries (and, when enabled, bootstrapped launchd
 //! services) but never confirmed the stack actually came up — an operator
@@ -19,40 +19,122 @@
 //! 2. Probes health for every selected daemon member.
 //! 3. For any `down` LAUNCHD daemon (the #2498 failure signature: `launchctl
 //!    bootstrap` succeeds but `RunAtLoad` doesn't fire), issues one
-//!    `launchctl kickstart -k gui/<uid>/<label>` and re-probes once before
-//!    accepting `down` as the final verdict for that member.
+//!    `launchctl kickstart -k gui/<uid>/<label>` and then, instead of a single
+//!    instant re-probe (#3833 — this raced trusty-search's first-boot
+//!    embedding-model download and reported a false `NOT VERIFIED`),
+//!    [`poll_until_not_down`] re-probes on a bounded ~60s schedule so a
+//!    slow-but-healthy daemon is given real wall-clock time to come up before
+//!    the verdict is finalised.
+//! 4. A member still `down` after that wait is classified into one of three
+//!    distinct end states via [`classify_down_state`] — [`DownState::NotLoaded`],
+//!    [`DownState::Crashed`], or [`DownState::StillStarting`] — instead of a
+//!    uniform, underspecified `down` (#3833).
 //!
 //! [`print_human`] renders the final green/red pass/fail summary — the last
-//! thing the installer prints.
+//! thing the installer prints. Because the health used to build the report is
+//! already the POST-wait value, the exit code CI/automation gates on
+//! ([`super::install::InstallReport`], folded from `verified`) reflects the
+//! final state, not the instant-after-kickstart snapshot.
 //!
-//! Test: the pure decision (`needs_kickstart`) and the report's `verified`
-//! derivation are unit-tested; the `ensure` phase and `launchctl kickstart` are
+//! Test: the pure decision pieces (`needs_kickstart`, `poll_until_not_down`,
+//! `classify_down_state_from_entry`, the report's `verified` derivation) are
+//! unit-tested; the `ensure` phase and the `launchctl` subprocess calls are
 //! side-effecting and validated manually.
+
+use std::time::Duration;
 
 use serde::Serialize;
 
 use super::probe::{health_str, probe_member_health};
 use super::stable_set::{ManageStrategy, StableMember};
 
+/// Total wall-clock budget [`poll_until_not_down`] spends waiting for a
+/// kickstarted daemon to report healthy (#3833).
+///
+/// Why: trusty-search downloads embedding models on first boot and can take
+/// tens of seconds; a single instant re-probe (the pre-#3833 behaviour) raced
+/// that window. ~60s covers a cold-start model download on a normal
+/// connection without holding up `tctl install` indefinitely on a genuinely
+/// dead daemon.
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Number of probe attempts [`poll_until_not_down`] makes (one immediately,
+/// then one every [`POLL_INTERVAL`]) — `12` attempts spread over 11 intervals
+/// is ~55s of total wait, within the ~30-60s budget.
+const POLL_MAX_ATTEMPTS: u32 = 12;
+
 /// One member's verify-tail outcome.
 ///
 /// Why: a typed row keeps the `--json` output stable + testable.
-/// What: `member` crate name; `health` the (possibly kickstart-retried) health
-/// verdict string; `kickstarted` whether a #2498 kickstart retry was attempted
-/// for this member; `required` (graceful-degrade, demo-critical fix) mirrors
-/// `StableMember::required` and gates whether a down/not-installed verdict for
-/// this member may fail the overall `verified` verdict.
+/// What: `member` crate name; `health` the (possibly kickstart-retried, POST
+/// wait) health verdict string; `kickstarted` whether a #2498 kickstart retry
+/// was attempted for this member; `required` (graceful-degrade, demo-critical
+/// fix) mirrors `StableMember::required` and gates whether a down/not-installed
+/// verdict for this member may fail the overall `verified` verdict;
+/// `down_state` (#3833) is `Some` iff `health` is still `down` for a LAUNCHD
+/// member after the wait, classifying WHY.
 /// Test: `tests::report_serialises`.
 #[derive(Clone, Debug, Serialize)]
 pub struct VerifyRow {
     /// Crate name.
     pub member: String,
-    /// Health verdict after any kickstart retry.
+    /// Health verdict after any kickstart retry + poll wait.
     pub health: String,
     /// Whether a `launchctl kickstart -k` retry was attempted (#2498).
     pub kickstarted: bool,
     /// Whether this member is REQUIRED for the overall `verified` verdict.
     pub required: bool,
+    /// Why a LAUNCHD member is still `down` after the poll wait, when it is
+    /// (#3833). `None` for a healthy/stale/unknown/not_installed member, or a
+    /// non-LAUNCHD member.
+    pub down_state: Option<DownState>,
+}
+
+/// Why a LAUNCHD daemon member is still reporting `down` after the #3833 poll
+/// wait — replaces a uniform, underspecified `down` with a diagnosis an
+/// operator can act on directly.
+///
+/// Why: "down" alone doesn't tell you whether launchd never loaded the job at
+/// all, loaded it and it crashed, or it is simply still coming up — three
+/// situations with three different next actions (re-run the bootstrap step,
+/// read the crash log, or just wait longer).
+/// What: [`DownState::NotLoaded`] — `launchctl list <label>` found no such
+/// service (never bootstrapped, or booted out). [`DownState::Crashed`] —
+/// loaded, no PID currently running, and the last recorded exit status was
+/// nonzero. [`DownState::StillStarting`] — loaded, and either a PID is
+/// currently running (health just hasn't caught up yet) or the last exit
+/// status was a clean `0` (about to be (re)launched, e.g. between
+/// `ThrottleInterval` respawns).
+/// Test: `tests::classify_down_state_from_entry_*`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "state")]
+pub enum DownState {
+    /// `launchctl` has no record of this label at all.
+    NotLoaded,
+    /// Loaded, but not currently running, with a nonzero last exit status.
+    Crashed {
+        /// The `LastExitStatus` launchd recorded.
+        exit_code: i32,
+    },
+    /// Loaded and either currently running (health hasn't caught up) or
+    /// cleanly exited and awaiting its next (re)launch.
+    StillStarting,
+}
+
+impl DownState {
+    /// A short, human-readable phrase for [`optional_annotation`]/`print_human`.
+    ///
+    /// Why: centralises the wording so the JSON `state` tag and the human
+    /// narration can never drift.
+    /// What: maps each variant to a lowercase phrase with no leading article.
+    /// Test: `tests::down_state_phrase_mapping`.
+    fn phrase(&self) -> String {
+        match self {
+            DownState::NotLoaded => "not loaded".to_owned(),
+            DownState::Crashed { exit_code } => format!("crashed, exit {exit_code}"),
+            DownState::StillStarting => "still starting".to_owned(),
+        }
+    }
 }
 
 /// The aggregate verify-tail report (#2560).
@@ -122,7 +204,14 @@ pub fn needs_kickstart(health: &str, manage: ManageStrategy) -> bool {
 /// Why: the #2498 recovery step — `launchctl bootstrap` can report success
 /// while `RunAtLoad` never actually fires; `kickstart -k` force-starts the job.
 /// What: resolves the uid + launchd label, spawns the command, returns whether
-/// it exited successfully. On non-macOS, always returns `false` (no-op).
+/// it exited successfully. On non-macOS, always returns `false` (no-op). A
+/// `false` return does not by itself mean the daemon is unreachable — see
+/// [`poll_until_not_down`], which is run regardless (#3833): a kickstart on a
+/// label that IS loaded but slow to accept the force-start can transiently
+/// fail here while the daemon still comes up moments later, and a kickstart
+/// on a label that was NEVER bootstrapped fails outright (there is nothing to
+/// force-start) — [`classify_down_state`] is what actually distinguishes
+/// those cases in the final report, not this return value.
 /// Test: side-effecting; not invoked in the test suite.
 #[cfg(target_os = "macos")]
 fn kickstart(binary: &str) -> bool {
@@ -140,28 +229,190 @@ fn kickstart(_binary: &str) -> bool {
     false
 }
 
-/// Verify one daemon member, applying the #2498 kickstart retry when needed.
+/// Poll `probe` until it stops reporting `down`, sleeping via `wait` between
+/// attempts, up to `max_attempts` total probes (#3833).
 ///
-/// Why: isolates the per-member side effect (probe, maybe kickstart, re-probe)
-/// so [`run_verify_tail`] stays a plain fold over `selected`.
-/// What: probes health; if [`needs_kickstart`], attempts one kickstart and
-/// re-probes; returns the (possibly updated) health plus whether a kickstart
-/// was attempted.
-/// Test: side-effecting (subprocess); the decision half is `needs_kickstart`.
+/// Why: a single instant re-probe right after `launchctl kickstart` races a
+/// daemon's real startup time — trusty-search notably downloads embedding
+/// models on first boot and can take tens of seconds. Replacing the instant
+/// check with a bounded poll gives a slow-but-healthy daemon real wall-clock
+/// time to come up before the verdict is finalised, while still terminating
+/// (never blocking `tctl install` indefinitely) against a genuinely dead
+/// daemon. Kept generic over `probe`/`wait` (rather than calling
+/// `probe_member_health`/`std::thread::sleep` directly) so the state machine
+/// is unit-testable with fakes and NEVER sleeps in the test suite.
+///
+/// # Preconditions
+/// `max_attempts >= 1`.
+/// # Postconditions
+/// Returns after at most `max_attempts` calls to `probe`; the returned
+/// `attempts` is in `1..=max_attempts`; `wait` is called exactly
+/// `attempts - 1` times (never after the final attempt); the returned health
+/// string is either not equal to `health_str::DOWN`, or `attempts ==
+/// max_attempts`.
+/// Test: `tests::poll_until_not_down_stops_when_healthy`,
+/// `tests::poll_until_not_down_stops_at_max_attempts`,
+/// `tests::poll_until_not_down_first_attempt_needs_no_wait`.
+fn poll_until_not_down<F, W>(mut probe: F, mut wait: W, max_attempts: u32) -> (String, u32)
+where
+    F: FnMut() -> String,
+    W: FnMut(),
+{
+    debug_assert!(max_attempts >= 1, "max_attempts must be at least 1");
+    let mut attempts = 0u32;
+    loop {
+        let health = probe();
+        attempts += 1;
+        if health != health_str::DOWN || attempts >= max_attempts {
+            return (health, attempts);
+        }
+        wait();
+    }
+}
+
+/// One `launchctl list <label>` observation, pre-parsed (#3833).
+///
+/// Why: separating the parse from the subprocess spawn lets
+/// [`classify_down_state_from_entry`] be exercised with fixed sample text —
+/// no live `launchctl` needed.
+/// What: `has_pid` — whether the dump has a `"PID" = N;` line (a process is
+/// currently running); `exit_status` — the `"LastExitStatus"` launchd last
+/// recorded (`0` when absent, matching launchd's own default).
+/// Test: `tests::parse_launchd_list_text_*`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct LaunchdListEntry {
+    has_pid: bool,
+    exit_status: i32,
+}
+
+/// Parse `launchctl list <label>`'s property-list-style stdout dump.
+///
+/// Why: isolates the (pure) text parsing from the (side-effecting) subprocess
+/// spawn so the format assumptions are unit-testable.
+/// What: scans for a `"PID" = ...;` line (sets `has_pid`) and a
+/// `"LastExitStatus" = N;` line (sets `exit_status`, defaulting to `0` when
+/// absent — launchd omits the key before the job has ever exited). Never
+/// panics on malformed input.
+/// Test: `tests::parse_launchd_list_text_running`,
+/// `tests::parse_launchd_list_text_crashed`,
+/// `tests::parse_launchd_list_text_clean_exit`.
+fn parse_launchd_list_text(text: &str) -> LaunchdListEntry {
+    let has_pid = text.lines().any(|l| l.trim_start().starts_with("\"PID\""));
+    let exit_status = text
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("\"LastExitStatus\" ="))
+        .and_then(|rest| rest.trim().trim_end_matches(';').trim().parse::<i32>().ok())
+        .unwrap_or(0);
+    LaunchdListEntry {
+        has_pid,
+        exit_status,
+    }
+}
+
+/// Classify a parsed `launchctl list` observation into a [`DownState`].
+///
+/// Why: the pure decision half of [`classify_down_state`] — kept separate so
+/// every branch is unit-tested without a live `launchctl`.
+/// What: `None` (label not found) → [`DownState::NotLoaded`]; a running PID →
+/// [`DownState::StillStarting`] (loaded, health just hasn't caught up); a
+/// nonzero last exit status with no running PID → [`DownState::Crashed`];
+/// anything else (loaded, no PID, clean last exit) → [`DownState::StillStarting`]
+/// (about to be (re)launched).
+/// Test: `tests::classify_down_state_from_entry_not_loaded`,
+/// `tests::classify_down_state_from_entry_running`,
+/// `tests::classify_down_state_from_entry_crashed`,
+/// `tests::classify_down_state_from_entry_clean_exit_no_pid`.
+fn classify_down_state_from_entry(entry: Option<LaunchdListEntry>) -> DownState {
+    match entry {
+        None => DownState::NotLoaded,
+        Some(e) if e.has_pid => DownState::StillStarting,
+        Some(e) if e.exit_status != 0 => DownState::Crashed {
+            exit_code: e.exit_status,
+        },
+        Some(_) => DownState::StillStarting,
+    }
+}
+
+/// Run `launchctl list <label>` and return its raw stdout, or `None` when the
+/// label is not found (macOS only; #3833).
+///
+/// Why: isolated as its own thin side-effecting function so
+/// [`classify_down_state`] composes it with the pure
+/// [`parse_launchd_list_text`] / [`classify_down_state_from_entry`] pair.
+/// What: `Some(stdout)` on a successful `launchctl list <label>`; `None` when
+/// the command fails to spawn or exits non-zero (launchd's "no such service"
+/// signature).
+/// Test: side-effecting; not invoked in the test suite.
+#[cfg(target_os = "macos")]
+fn launchd_list_raw(label: &str) -> Option<String> {
+    let out = std::process::Command::new("launchctl")
+        .args(["list", label])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn launchd_list_raw(_label: &str) -> Option<String> {
+    None
+}
+
+/// Classify why a LAUNCHD member is still `down` after the poll wait (#3833).
+///
+/// Why: the single entry point [`verify_one`] calls once it has a final
+/// `down` verdict for a LAUNCHD member — composes the side-effecting
+/// `launchctl list` call with the pure parse + classify pair above.
+/// What: resolves the member's launchd label, runs `launchctl list <label>`,
+/// and classifies the result via [`classify_down_state_from_entry`].
+/// Test: side-effecting (subprocess); the decision half is
+/// `classify_down_state_from_entry`.
+fn classify_down_state(binary: &str) -> DownState {
+    let label = super::plist_label::plist_label_for(binary);
+    let entry = launchd_list_raw(&label).map(|text| parse_launchd_list_text(&text));
+    classify_down_state_from_entry(entry)
+}
+
+/// Verify one daemon member, applying the #2498 kickstart retry + #3833 poll
+/// wait when needed.
+///
+/// Why: isolates the per-member side effect (probe, maybe kickstart, poll,
+/// classify) so [`run_verify_tail`] stays a plain fold over `selected`.
+/// What: probes health; if [`needs_kickstart`], attempts one kickstart,
+/// prints a one-line "waiting for services to start..." indication, then
+/// polls via [`poll_until_not_down`] on the [`POLL_INTERVAL`] /
+/// [`POLL_MAX_ATTEMPTS`] schedule (~60s total) instead of a single instant
+/// re-probe. If the member is STILL `down` after that wait, classifies WHY
+/// via [`classify_down_state`].
+/// Test: side-effecting (subprocess + sleep); the decision halves are
+/// `needs_kickstart`, `poll_until_not_down`, `classify_down_state_from_entry`.
 fn verify_one(m: &StableMember) -> VerifyRow {
     let mut health = probe_member_health(&m.binary, m.manage);
     let mut kickstarted = false;
     if needs_kickstart(&health, m.manage) {
-        kickstarted = kickstart(&m.binary);
-        if kickstarted {
-            health = probe_member_health(&m.binary, m.manage);
-        }
+        kickstarted = true;
+        let _ = kickstart(&m.binary);
+        eprintln!("  waiting for {} to start...", m.binary);
+        let (polled_health, _attempts) = poll_until_not_down(
+            || probe_member_health(&m.binary, m.manage),
+            || std::thread::sleep(POLL_INTERVAL),
+            POLL_MAX_ATTEMPTS,
+        );
+        health = polled_health;
     }
+    let down_state = if health == health_str::DOWN && m.manage == ManageStrategy::Launchd {
+        Some(classify_down_state(&m.binary))
+    } else {
+        None
+    };
     VerifyRow {
         member: m.crate_name.clone(),
         health,
         kickstarted,
         required: m.required,
+        down_state,
     }
 }
 
@@ -229,18 +480,31 @@ fn colour(label: &str, ansi: &str) -> String {
 /// [`VerifyTailReport::build`] already correctly excludes it from the
 /// verdict/exit code. Widening the condition to cover `down` (not just
 /// `not_installed`) makes the annotation match the verdict's own tolerance.
-/// What: `" (kickstarted)"` when a retry fired; `" (optional, skipped)"` when
-/// the member is OPTIONAL and its health is `not_installed` OR `down`;
-/// otherwise empty.
-/// Test: `tests::optional_annotation_covers_not_installed_and_down`.
-fn optional_annotation(m: &VerifyRow) -> &'static str {
+/// #3833: a member still `down` after the poll wait now carries a
+/// [`DownState`] diagnosis — that always wins (it is a DIAGNOSIS, not a
+/// reassurance, so it is shown for REQUIRED members too, just without the
+/// "optional" framing).
+/// What: `" (<down-state phrase>)"` (optionally `"optional, "`-prefixed) when
+/// `down_state` is `Some`; `" (kickstarted)"` when a retry fired and the
+/// member came back healthy; `" (optional, skipped)"` when the member is
+/// OPTIONAL and `not_installed`; otherwise empty.
+/// Test: `tests::optional_annotation_covers_not_installed_and_down`,
+/// `tests::optional_annotation_reports_down_state`.
+fn optional_annotation(m: &VerifyRow) -> String {
+    if let Some(reason) = &m.down_state {
+        let phrase = reason.phrase();
+        return if m.required {
+            format!(" ({phrase})")
+        } else {
+            format!(" (optional, {phrase})")
+        };
+    }
     if m.kickstarted {
-        " (kickstarted)"
-    } else if !m.required && (m.health == health_str::NOT_INSTALLED || m.health == health_str::DOWN)
-    {
-        " (optional, skipped)"
+        " (kickstarted)".to_owned()
+    } else if !m.required && m.health == health_str::NOT_INSTALLED {
+        " (optional, skipped)".to_owned()
     } else {
-        ""
+        String::new()
     }
 }
 
@@ -281,6 +545,7 @@ mod tests {
             health: health.to_owned(),
             kickstarted: false,
             required: true,
+            down_state: None,
         }
     }
 
@@ -408,12 +673,15 @@ mod tests {
     }
 
     /// Why: #3797 critic finding (MEDIUM, demo-relevant) — an OPTIONAL daemon
-    /// that installed but whose service bootstrap failed reports health
-    /// `down`; that must read as "(optional, skipped)" just like
-    /// `not_installed` does, not as a bare, alarming `down` right above the
-    /// green `VERIFIED` line. A REQUIRED member's `down`/`not_installed` must
-    /// get NO such softening annotation, and `kickstarted` must win over both.
-    /// What: exercises the full truth table.
+    /// that is `not_installed` must read as "(optional, skipped)", not a
+    /// bare, alarming `not_installed` right above the green `VERIFIED` line.
+    /// A REQUIRED member's `not_installed` must get NO such softening
+    /// annotation, and a successful `kickstarted` retry must win over it.
+    /// (#3833: a bare `down` health with no `down_state` set no longer
+    /// happens in production — `verify_one` always attaches a `down_state`
+    /// for a down LAUNCHD member — so the `down`-specific cases moved to
+    /// `optional_annotation_reports_down_state` below.)
+    /// What: exercises the `not_installed` + `kickstarted` truth table.
     /// Test: This is the test.
     #[test]
     fn optional_annotation_covers_not_installed_and_down() {
@@ -422,18 +690,9 @@ mod tests {
             " (optional, skipped)"
         );
         assert_eq!(
-            optional_annotation(&optional_row("trusty-console", health_str::DOWN)),
-            " (optional, skipped)"
-        );
-        assert_eq!(
             optional_annotation(&optional_row("trusty-console", health_str::HEALTHY)),
             "",
             "a healthy optional member needs no annotation"
-        );
-        assert_eq!(
-            optional_annotation(&row("trusty-search", health_str::DOWN)),
-            "",
-            "a REQUIRED member's down health must not be softened"
         );
         assert_eq!(
             optional_annotation(&row("trusty-search", health_str::NOT_INSTALLED)),
@@ -442,12 +701,265 @@ mod tests {
         );
         let kickstarted = VerifyRow {
             kickstarted: true,
-            ..optional_row("trusty-console", health_str::DOWN)
+            health: health_str::HEALTHY.to_owned(),
+            ..optional_row("trusty-console", health_str::HEALTHY)
         };
         assert_eq!(
             optional_annotation(&kickstarted),
             " (kickstarted)",
-            "a kickstart retry note takes priority over the optional softening"
+            "a kickstart retry that came back healthy is noted"
         );
+    }
+
+    /// Why: #3833 — a member still `down` after the poll wait must report
+    /// WHICH of the three end states it is, for both REQUIRED (plain
+    /// diagnosis, no softening) and OPTIONAL (still prefixed `optional,` —
+    /// it is informational, not an alarm) members. This must take priority
+    /// over the plain `kickstarted` note, since `down_state` being `Some`
+    /// means the kickstart did NOT resolve the problem.
+    /// What: exercises all three `DownState` variants for both required and
+    /// optional members, and confirms `down_state` wins over `kickstarted`.
+    /// Test: This is the test.
+    #[test]
+    fn optional_annotation_reports_down_state() {
+        let with_state = |required: bool, state: DownState| VerifyRow {
+            required,
+            down_state: Some(state),
+            ..row("trusty-memory", health_str::DOWN)
+        };
+
+        assert_eq!(
+            optional_annotation(&with_state(true, DownState::NotLoaded)),
+            " (not loaded)"
+        );
+        assert_eq!(
+            optional_annotation(&with_state(false, DownState::NotLoaded)),
+            " (optional, not loaded)"
+        );
+        assert_eq!(
+            optional_annotation(&with_state(true, DownState::Crashed { exit_code: 2 })),
+            " (crashed, exit 2)"
+        );
+        assert_eq!(
+            optional_annotation(&with_state(false, DownState::Crashed { exit_code: -9 })),
+            " (optional, crashed, exit -9)"
+        );
+        assert_eq!(
+            optional_annotation(&with_state(true, DownState::StillStarting)),
+            " (still starting)"
+        );
+
+        let kickstarted_but_still_down = VerifyRow {
+            kickstarted: true,
+            ..with_state(true, DownState::StillStarting)
+        };
+        assert_eq!(
+            optional_annotation(&kickstarted_but_still_down),
+            " (still starting)",
+            "an unresolved down_state must win over the plain kickstarted note"
+        );
+    }
+
+    /// Why: pins the exact wording each `DownState` variant renders, since
+    /// both the human summary and (transitively, via `serde`) the `--json`
+    /// `state` tag depend on it staying stable.
+    /// What: asserts the phrase for each variant.
+    /// Test: This is the test.
+    #[test]
+    fn down_state_phrase_mapping() {
+        assert_eq!(DownState::NotLoaded.phrase(), "not loaded");
+        assert_eq!(
+            DownState::Crashed { exit_code: 78 }.phrase(),
+            "crashed, exit 78"
+        );
+        assert_eq!(DownState::StillStarting.phrase(), "still starting");
+    }
+
+    /// Why: THE #3833 safety property — polling must terminate the instant
+    /// health stops being `down`, without over-waiting or under-waiting.
+    /// What: a probe sequence [down, down, healthy] must return after
+    /// exactly 3 attempts with 2 waits.
+    /// Test: This is the test.
+    #[test]
+    fn poll_until_not_down_stops_when_healthy() {
+        let responses = std::cell::RefCell::new(vec![
+            health_str::HEALTHY.to_owned(),
+            health_str::DOWN.to_owned(),
+            health_str::DOWN.to_owned(),
+        ]);
+        let waits = std::cell::RefCell::new(0u32);
+        let (health, attempts) = poll_until_not_down(
+            || {
+                responses
+                    .borrow_mut()
+                    .pop()
+                    .expect("probe called too many times")
+            },
+            || *waits.borrow_mut() += 1,
+            10,
+        );
+        assert_eq!(health, health_str::HEALTHY);
+        assert_eq!(attempts, 3);
+        assert_eq!(*waits.borrow(), 2, "must wait exactly twice, not 3 times");
+    }
+
+    /// Why: against a genuinely dead daemon, the poll must still terminate —
+    /// never block `tctl install` forever.
+    /// What: a probe that always returns `down` must stop at exactly
+    /// `max_attempts`, waiting `max_attempts - 1` times (never after the
+    /// final attempt).
+    /// Test: This is the test.
+    #[test]
+    fn poll_until_not_down_stops_at_max_attempts() {
+        let waits = std::cell::RefCell::new(0u32);
+        let (health, attempts) = poll_until_not_down(
+            || health_str::DOWN.to_owned(),
+            || *waits.borrow_mut() += 1,
+            4,
+        );
+        assert_eq!(health, health_str::DOWN);
+        assert_eq!(attempts, 4);
+        assert_eq!(
+            *waits.borrow(),
+            3,
+            "must not wait after the final (4th) attempt"
+        );
+    }
+
+    /// Why: the common case — a daemon that is already healthy by the time
+    /// the retry fires — must return immediately with zero waits, not
+    /// needlessly sleep once.
+    /// What: a probe that is healthy on the first call triggers no wait.
+    /// Test: This is the test.
+    #[test]
+    fn poll_until_not_down_first_attempt_needs_no_wait() {
+        let waits = std::cell::RefCell::new(0u32);
+        let (health, attempts) = poll_until_not_down(
+            || health_str::HEALTHY.to_owned(),
+            || *waits.borrow_mut() += 1,
+            10,
+        );
+        assert_eq!(health, health_str::HEALTHY);
+        assert_eq!(attempts, 1);
+        assert_eq!(*waits.borrow(), 0);
+    }
+
+    /// Why: the running-PID branch must win regardless of last exit status —
+    /// a currently-running process means the daemon IS up; `down` health
+    /// just hasn't caught up yet (e.g. still loading models).
+    /// What: an entry with `has_pid: true` classifies as `StillStarting`
+    /// even when `exit_status` is nonzero (stale from a PRIOR crash).
+    /// Test: This is the test.
+    #[test]
+    fn classify_down_state_from_entry_running() {
+        let entry = LaunchdListEntry {
+            has_pid: true,
+            exit_status: 1,
+        };
+        assert_eq!(
+            classify_down_state_from_entry(Some(entry)),
+            DownState::StillStarting
+        );
+    }
+
+    /// Why: THE #3833 core diagnosis — no running PID plus a nonzero last
+    /// exit status is a genuine crash, not a startup race.
+    /// What: asserts `Crashed` carries the exact exit code.
+    /// Test: This is the test.
+    #[test]
+    fn classify_down_state_from_entry_crashed() {
+        let entry = LaunchdListEntry {
+            has_pid: false,
+            exit_status: 2,
+        };
+        assert_eq!(
+            classify_down_state_from_entry(Some(entry)),
+            DownState::Crashed { exit_code: 2 }
+        );
+    }
+
+    /// Why: no PID + a clean (`0`) last exit is ambiguous between "never
+    /// started yet" and "cleanly stopped, about to relaunch" — both read as
+    /// "still starting" rather than a false `Crashed`.
+    /// What: asserts `StillStarting`.
+    /// Test: This is the test.
+    #[test]
+    fn classify_down_state_from_entry_clean_exit_no_pid() {
+        let entry = LaunchdListEntry {
+            has_pid: false,
+            exit_status: 0,
+        };
+        assert_eq!(
+            classify_down_state_from_entry(Some(entry)),
+            DownState::StillStarting
+        );
+    }
+
+    /// Why: THE #3832/#3833 root-cause signature — a label `launchctl list`
+    /// cannot find at all (never bootstrapped, e.g. the #3832 trusty-memory
+    /// bug) must be reported as `NotLoaded`, not lumped in with a crash.
+    /// What: asserts `None` (label not found) classifies as `NotLoaded`.
+    /// Test: This is the test.
+    #[test]
+    fn classify_down_state_from_entry_not_loaded() {
+        assert_eq!(classify_down_state_from_entry(None), DownState::NotLoaded);
+    }
+
+    /// Why: `launchctl list <label>`'s dump format is `"Key" = value;` lines
+    /// inside a `{ ... }` block; the parser must find `PID`/`LastExitStatus`
+    /// regardless of surrounding whitespace/indentation and must not mistake
+    /// unrelated keys (e.g. `"PerJobMachServices"`) for them.
+    /// What: parses a realistic "running" dump; asserts `has_pid` and the
+    /// default `exit_status` (absent key → `0`).
+    /// Test: This is the test.
+    #[test]
+    fn parse_launchd_list_text_running() {
+        let text = r#"{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "com.trusty.trusty-search";
+	"OnDemand" = false;
+	"LastExitStatus" = 0;
+	"PID" = 4242;
+	"Program" = "/usr/local/bin/trusty-search";
+};
+"#;
+        let entry = parse_launchd_list_text(text);
+        assert!(entry.has_pid);
+        assert_eq!(entry.exit_status, 0);
+    }
+
+    /// Why: the crash signature — no `PID` line, a nonzero `LastExitStatus`.
+    /// What: parses a realistic "crashed" dump; asserts `has_pid` is false
+    /// and `exit_status` matches.
+    /// Test: This is the test.
+    #[test]
+    fn parse_launchd_list_text_crashed() {
+        let text = r#"{
+	"LimitLoadToSessionType" = "Aqua";
+	"Label" = "com.trusty.memory";
+	"LastExitStatus" = 78;
+};
+"#;
+        let entry = parse_launchd_list_text(text);
+        assert!(!entry.has_pid);
+        assert_eq!(entry.exit_status, 78);
+    }
+
+    /// Why: a loaded-but-never-yet-run (or cleanly stopped) job omits `PID`
+    /// and reports `LastExitStatus = 0` (or omits it entirely) — must not be
+    /// misparsed as a crash.
+    /// What: parses a dump with neither key; asserts `has_pid: false`,
+    /// `exit_status: 0` (the documented default).
+    /// Test: This is the test.
+    #[test]
+    fn parse_launchd_list_text_clean_exit() {
+        let text = r#"{
+	"Label" = "com.trusty.trusty-review";
+	"OnDemand" = false;
+};
+"#;
+        let entry = parse_launchd_list_text(text);
+        assert!(!entry.has_pid);
+        assert_eq!(entry.exit_status, 0);
     }
 }

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -26,9 +26,12 @@
 //!    slow-but-healthy daemon is given real wall-clock time to come up before
 //!    the verdict is finalised.
 //! 4. A member still `down` after that wait is classified into one of three
-//!    distinct end states via [`classify_down_state`] — [`DownState::NotLoaded`],
-//!    [`DownState::Crashed`], or [`DownState::StillStarting`] — instead of a
-//!    uniform, underspecified `down` (#3833).
+//!    distinct end states via `super::verify_launchd_state::classify_down_state`
+//!    — [`DownState::NotLoaded`], [`DownState::Crashed`], or
+//!    [`DownState::StillStarting`] — instead of a uniform, underspecified
+//!    `down` (#3833; the diagnosis machinery itself lives in the sibling
+//!    `verify_launchd_state` module, shared with `service_bootstrap`'s #3836
+//!    defensive-fallback check).
 //!
 //! Because `run_verify_tail` folds [`verify_one`] SEQUENTIALLY over every
 //! selected daemon member, and each member's poll wait can run up to
@@ -48,9 +51,11 @@
 //! final state, not the instant-after-kickstart snapshot.
 //!
 //! Test: the pure decision pieces (`needs_kickstart`, `poll_until_not_down`,
-//! `bounded_attempts`, `classify_down_state_from_entry`, the report's
-//! `verified` derivation) are unit-tested; the `ensure` phase and the
-//! `launchctl` subprocess calls are side-effecting and validated manually.
+//! `bounded_attempts`, the report's `verified` derivation) are unit-tested
+//! here; `verify_launchd_state`'s own module doc covers its
+//! `classify_down_state_from_entry`/`parse_launchd_list_text` tests. The
+//! `ensure` phase and the `launchctl` subprocess calls are side-effecting and
+//! validated manually.
 
 use std::time::{Duration, Instant};
 
@@ -58,6 +63,7 @@ use serde::Serialize;
 
 use super::probe::{health_str, probe_member_health};
 use super::stable_set::{ManageStrategy, StableMember};
+use super::verify_launchd_state::{classify_down_state, DownState};
 
 /// Per-member poll interval — how long [`poll_until_not_down`] sleeps between
 /// re-probes (#3833).
@@ -120,53 +126,6 @@ pub struct VerifyRow {
     /// (#3833). `None` for a healthy/stale/unknown/not_installed member, or a
     /// non-LAUNCHD member.
     pub down_state: Option<DownState>,
-}
-
-/// Why a LAUNCHD daemon member is still reporting `down` after the #3833 poll
-/// wait — replaces a uniform, underspecified `down` with a diagnosis an
-/// operator can act on directly.
-///
-/// Why: "down" alone doesn't tell you whether launchd never loaded the job at
-/// all, loaded it and it crashed, or it is simply still coming up — three
-/// situations with three different next actions (re-run the bootstrap step,
-/// read the crash log, or just wait longer).
-/// What: [`DownState::NotLoaded`] — `launchctl list <label>` found no such
-/// service (never bootstrapped, or booted out). [`DownState::Crashed`] —
-/// loaded, no PID currently running, and the last recorded exit status was
-/// nonzero. [`DownState::StillStarting`] — loaded, and either a PID is
-/// currently running (health just hasn't caught up yet) or the last exit
-/// status was a clean `0` (about to be (re)launched, e.g. between
-/// `ThrottleInterval` respawns).
-/// Test: `tests::classify_down_state_from_entry_*`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case", tag = "state")]
-pub enum DownState {
-    /// `launchctl` has no record of this label at all.
-    NotLoaded,
-    /// Loaded, but not currently running, with a nonzero last exit status.
-    Crashed {
-        /// The `LastExitStatus` launchd recorded.
-        exit_code: i32,
-    },
-    /// Loaded and either currently running (health hasn't caught up) or
-    /// cleanly exited and awaiting its next (re)launch.
-    StillStarting,
-}
-
-impl DownState {
-    /// A short, human-readable phrase for [`optional_annotation`]/`print_human`.
-    ///
-    /// Why: centralises the wording so the JSON `state` tag and the human
-    /// narration can never drift.
-    /// What: maps each variant to a lowercase phrase with no leading article.
-    /// Test: `tests::down_state_phrase_mapping`.
-    fn phrase(&self) -> String {
-        match self {
-            DownState::NotLoaded => "not loaded".to_owned(),
-            DownState::Crashed { exit_code } => format!("crashed, exit {exit_code}"),
-            DownState::StillStarting => "still starting".to_owned(),
-        }
-    }
 }
 
 /// The aggregate verify-tail report (#2560).
@@ -300,130 +259,6 @@ where
         }
         wait();
     }
-}
-
-/// One `launchctl list <label>` observation, pre-parsed (#3833).
-///
-/// Why: separating the parse from the subprocess spawn lets
-/// [`classify_down_state_from_entry`] be exercised with fixed sample text —
-/// no live `launchctl` needed.
-/// What: `has_pid` — whether the dump has a `"PID" = N;` line (a process is
-/// currently running); `exit_status` — the `"LastExitStatus"` launchd last
-/// recorded (`0` when absent, matching launchd's own default).
-/// Test: `tests::parse_launchd_list_text_*`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct LaunchdListEntry {
-    has_pid: bool,
-    exit_status: i32,
-}
-
-/// Parse `launchctl list <label>`'s property-list-style stdout dump.
-///
-/// Why: isolates the (pure) text parsing from the (side-effecting) subprocess
-/// spawn so the format assumptions are unit-testable.
-/// What: scans for a `"PID" = ...;` line (sets `has_pid`) and a
-/// `"LastExitStatus" = N;` line (sets `exit_status`, defaulting to `0` when
-/// absent — launchd omits the key before the job has ever exited). Never
-/// panics on malformed input.
-/// Test: `tests::parse_launchd_list_text_running`,
-/// `tests::parse_launchd_list_text_crashed`,
-/// `tests::parse_launchd_list_text_clean_exit`.
-fn parse_launchd_list_text(text: &str) -> LaunchdListEntry {
-    let has_pid = text.lines().any(|l| l.trim_start().starts_with("\"PID\""));
-    let exit_status = text
-        .lines()
-        .find_map(|l| l.trim().strip_prefix("\"LastExitStatus\" ="))
-        .and_then(|rest| rest.trim().trim_end_matches(';').trim().parse::<i32>().ok())
-        .unwrap_or(0);
-    LaunchdListEntry {
-        has_pid,
-        exit_status,
-    }
-}
-
-/// Classify a parsed `launchctl list` observation into a [`DownState`].
-///
-/// Why: the pure decision half of [`classify_down_state`] — kept separate so
-/// every branch is unit-tested without a live `launchctl`.
-/// What: `None` (label not found) → [`DownState::NotLoaded`]; a running PID →
-/// [`DownState::StillStarting`] (loaded, health just hasn't caught up); a
-/// nonzero last exit status with no running PID → [`DownState::Crashed`];
-/// anything else (loaded, no PID, clean last exit) → [`DownState::StillStarting`]
-/// (about to be (re)launched).
-/// Test: `tests::classify_down_state_from_entry_not_loaded`,
-/// `tests::classify_down_state_from_entry_running`,
-/// `tests::classify_down_state_from_entry_crashed`,
-/// `tests::classify_down_state_from_entry_clean_exit_no_pid`.
-fn classify_down_state_from_entry(entry: Option<LaunchdListEntry>) -> DownState {
-    match entry {
-        None => DownState::NotLoaded,
-        Some(e) if e.has_pid => DownState::StillStarting,
-        Some(e) if e.exit_status != 0 => DownState::Crashed {
-            exit_code: e.exit_status,
-        },
-        Some(_) => DownState::StillStarting,
-    }
-}
-
-/// Run `launchctl list <label>` and return its raw stdout, or `None` when the
-/// label is not found (macOS only; #3833).
-///
-/// Why: isolated as its own thin side-effecting function so
-/// [`classify_down_state`] composes it with the pure
-/// [`parse_launchd_list_text`] / [`classify_down_state_from_entry`] pair.
-/// What: `Some(stdout)` on a successful `launchctl list <label>`; `None` when
-/// the command fails to spawn or exits non-zero (launchd's "no such service"
-/// signature).
-/// Test: side-effecting; not invoked in the test suite.
-#[cfg(target_os = "macos")]
-fn launchd_list_raw(label: &str) -> Option<String> {
-    let out = std::process::Command::new("launchctl")
-        .args(["list", label])
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    Some(String::from_utf8_lossy(&out.stdout).into_owned())
-}
-
-#[cfg(not(target_os = "macos"))]
-fn launchd_list_raw(_label: &str) -> Option<String> {
-    None
-}
-
-/// Whether launchd currently has `label` loaded at all (#3836).
-///
-/// Why: `service_bootstrap::bootstrap_one`'s #3836 defensive fallback needs
-/// to know whether a component binary's own `service install` actually
-/// loaded the agent, not just that the subprocess exited 0 (#3832's root
-/// cause — trusty-memory's `service install` used to write the plist without
-/// loading it). Reuses the exact same `launchctl list <label>` primitive
-/// [`classify_down_state`] is built on ([`launchd_list_raw`]), so the two
-/// call sites can never disagree about what "loaded" means.
-/// What: `true` iff `launchctl list <label>` finds the label at all —
-/// regardless of whether a PID is currently running; a loaded-but-not-yet-
-/// running job is still "loaded" (launchd owns it and will start it).
-/// Test: side-effecting; not invoked in the test suite (mirrors
-/// `classify_down_state`) — the underlying `Option`-based decision is the
-/// SAME one `classify_down_state_from_entry`'s `None` branch already covers.
-pub(super) fn is_label_loaded(label: &str) -> bool {
-    launchd_list_raw(label).is_some()
-}
-
-/// Classify why a LAUNCHD member is still `down` after the poll wait (#3833).
-///
-/// Why: the single entry point [`verify_one`] calls once it has a final
-/// `down` verdict for a LAUNCHD member — composes the side-effecting
-/// `launchctl list` call with the pure parse + classify pair above.
-/// What: resolves the member's launchd label, runs `launchctl list <label>`,
-/// and classifies the result via [`classify_down_state_from_entry`].
-/// Test: side-effecting (subprocess); the decision half is
-/// `classify_down_state_from_entry`.
-fn classify_down_state(binary: &str) -> DownState {
-    let label = super::plist_label::plist_label_for(binary);
-    let entry = launchd_list_raw(&label).map(|text| parse_launchd_list_text(&text));
-    classify_down_state_from_entry(entry)
 }
 
 /// Clamp the per-member poll attempt count to fit within a `remaining`
@@ -883,21 +718,6 @@ mod tests {
         );
     }
 
-    /// Why: pins the exact wording each `DownState` variant renders, since
-    /// both the human summary and (transitively, via `serde`) the `--json`
-    /// `state` tag depend on it staying stable.
-    /// What: asserts the phrase for each variant.
-    /// Test: This is the test.
-    #[test]
-    fn down_state_phrase_mapping() {
-        assert_eq!(DownState::NotLoaded.phrase(), "not loaded");
-        assert_eq!(
-            DownState::Crashed { exit_code: 78 }.phrase(),
-            "crashed, exit 78"
-        );
-        assert_eq!(DownState::StillStarting.phrase(), "still starting");
-    }
-
     /// Why: THE #3833 safety property — polling must terminate the instant
     /// health stops being `down`, without over-waiting or under-waiting.
     /// What: a probe sequence [down, down, healthy] must return after
@@ -1029,124 +849,5 @@ mod tests {
             row("trusty-search", "healthy"),
             exhausted
         ]));
-    }
-
-    /// Why: the running-PID branch must win regardless of last exit status —
-    /// a currently-running process means the daemon IS up; `down` health
-    /// just hasn't caught up yet (e.g. still loading models).
-    /// What: an entry with `has_pid: true` classifies as `StillStarting`
-    /// even when `exit_status` is nonzero (stale from a PRIOR crash).
-    /// Test: This is the test.
-    #[test]
-    fn classify_down_state_from_entry_running() {
-        let entry = LaunchdListEntry {
-            has_pid: true,
-            exit_status: 1,
-        };
-        assert_eq!(
-            classify_down_state_from_entry(Some(entry)),
-            DownState::StillStarting
-        );
-    }
-
-    /// Why: THE #3833 core diagnosis — no running PID plus a nonzero last
-    /// exit status is a genuine crash, not a startup race.
-    /// What: asserts `Crashed` carries the exact exit code.
-    /// Test: This is the test.
-    #[test]
-    fn classify_down_state_from_entry_crashed() {
-        let entry = LaunchdListEntry {
-            has_pid: false,
-            exit_status: 2,
-        };
-        assert_eq!(
-            classify_down_state_from_entry(Some(entry)),
-            DownState::Crashed { exit_code: 2 }
-        );
-    }
-
-    /// Why: no PID + a clean (`0`) last exit is ambiguous between "never
-    /// started yet" and "cleanly stopped, about to relaunch" — both read as
-    /// "still starting" rather than a false `Crashed`.
-    /// What: asserts `StillStarting`.
-    /// Test: This is the test.
-    #[test]
-    fn classify_down_state_from_entry_clean_exit_no_pid() {
-        let entry = LaunchdListEntry {
-            has_pid: false,
-            exit_status: 0,
-        };
-        assert_eq!(
-            classify_down_state_from_entry(Some(entry)),
-            DownState::StillStarting
-        );
-    }
-
-    /// Why: THE #3832/#3833 root-cause signature — a label `launchctl list`
-    /// cannot find at all (never bootstrapped, e.g. the #3832 trusty-memory
-    /// bug) must be reported as `NotLoaded`, not lumped in with a crash.
-    /// What: asserts `None` (label not found) classifies as `NotLoaded`.
-    /// Test: This is the test.
-    #[test]
-    fn classify_down_state_from_entry_not_loaded() {
-        assert_eq!(classify_down_state_from_entry(None), DownState::NotLoaded);
-    }
-
-    /// Why: `launchctl list <label>`'s dump format is `"Key" = value;` lines
-    /// inside a `{ ... }` block; the parser must find `PID`/`LastExitStatus`
-    /// regardless of surrounding whitespace/indentation and must not mistake
-    /// unrelated keys (e.g. `"PerJobMachServices"`) for them.
-    /// What: parses a realistic "running" dump; asserts `has_pid` and the
-    /// default `exit_status` (absent key → `0`).
-    /// Test: This is the test.
-    #[test]
-    fn parse_launchd_list_text_running() {
-        let text = r#"{
-	"LimitLoadToSessionType" = "Aqua";
-	"Label" = "com.trusty.trusty-search";
-	"OnDemand" = false;
-	"LastExitStatus" = 0;
-	"PID" = 4242;
-	"Program" = "/usr/local/bin/trusty-search";
-};
-"#;
-        let entry = parse_launchd_list_text(text);
-        assert!(entry.has_pid);
-        assert_eq!(entry.exit_status, 0);
-    }
-
-    /// Why: the crash signature — no `PID` line, a nonzero `LastExitStatus`.
-    /// What: parses a realistic "crashed" dump; asserts `has_pid` is false
-    /// and `exit_status` matches.
-    /// Test: This is the test.
-    #[test]
-    fn parse_launchd_list_text_crashed() {
-        let text = r#"{
-	"LimitLoadToSessionType" = "Aqua";
-	"Label" = "com.trusty.memory";
-	"LastExitStatus" = 78;
-};
-"#;
-        let entry = parse_launchd_list_text(text);
-        assert!(!entry.has_pid);
-        assert_eq!(entry.exit_status, 78);
-    }
-
-    /// Why: a loaded-but-never-yet-run (or cleanly stopped) job omits `PID`
-    /// and reports `LastExitStatus = 0` (or omits it entirely) — must not be
-    /// misparsed as a crash.
-    /// What: parses a dump with neither key; asserts `has_pid: false`,
-    /// `exit_status: 0` (the documented default).
-    /// Test: This is the test.
-    #[test]
-    fn parse_launchd_list_text_clean_exit() {
-        let text = r#"{
-	"Label" = "com.trusty.trusty-review";
-	"OnDemand" = false;
-};
-"#;
-        let entry = parse_launchd_list_text(text);
-        assert!(!entry.has_pid);
-        assert_eq!(entry.exit_status, 0);
     }
 }

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -30,6 +30,17 @@
 //!    [`DownState::Crashed`], or [`DownState::StillStarting`] — instead of a
 //!    uniform, underspecified `down` (#3833).
 //!
+//! Because `run_verify_tail` folds [`verify_one`] SEQUENTIALLY over every
+//! selected daemon member, and each member's poll wait can run up to
+//! [`POLL_MAX_ATTEMPTS`] * [`POLL_INTERVAL`] (~55s), an aggregate
+//! [`AGGREGATE_POLL_BUDGET`] (#3836 MEDIUM fix) caps the TOTAL time spent
+//! polling across ALL members (~120s) — without it, five simultaneously-stuck
+//! daemons would stall `tctl install` for ~4-5 minutes, exactly when a fast,
+//! actionable signal matters most. Once the aggregate budget is exhausted,
+//! remaining members skip their poll wait entirely (an instant probe only)
+//! and their row is flagged `budget_exhausted` — surfaced as one summary note
+//! in [`print_human`], not repeated per row.
+//!
 //! [`print_human`] renders the final green/red pass/fail summary — the last
 //! thing the installer prints. Because the health used to build the report is
 //! already the POST-wait value, the exit code CI/automation gates on
@@ -37,31 +48,45 @@
 //! final state, not the instant-after-kickstart snapshot.
 //!
 //! Test: the pure decision pieces (`needs_kickstart`, `poll_until_not_down`,
-//! `classify_down_state_from_entry`, the report's `verified` derivation) are
-//! unit-tested; the `ensure` phase and the `launchctl` subprocess calls are
-//! side-effecting and validated manually.
+//! `bounded_attempts`, `classify_down_state_from_entry`, the report's
+//! `verified` derivation) are unit-tested; the `ensure` phase and the
+//! `launchctl` subprocess calls are side-effecting and validated manually.
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 
 use super::probe::{health_str, probe_member_health};
 use super::stable_set::{ManageStrategy, StableMember};
 
-/// Total wall-clock budget [`poll_until_not_down`] spends waiting for a
-/// kickstarted daemon to report healthy (#3833).
+/// Per-member poll interval — how long [`poll_until_not_down`] sleeps between
+/// re-probes (#3833).
 ///
 /// Why: trusty-search downloads embedding models on first boot and can take
 /// tens of seconds; a single instant re-probe (the pre-#3833 behaviour) raced
-/// that window. ~60s covers a cold-start model download on a normal
-/// connection without holding up `tctl install` indefinitely on a genuinely
-/// dead daemon.
+/// that window.
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
 
-/// Number of probe attempts [`poll_until_not_down`] makes (one immediately,
-/// then one every [`POLL_INTERVAL`]) — `12` attempts spread over 11 intervals
-/// is ~55s of total wait, within the ~30-60s budget.
+/// Per-member cap on probe attempts (one immediately, then one every
+/// [`POLL_INTERVAL`]) when the AGGREGATE budget allows it in full — `12`
+/// attempts spread over 11 intervals is ~55s, within the ~30-60s per-member
+/// budget this crate's issue/CHANGELOG describe. [`bounded_attempts`] may
+/// return fewer when the aggregate budget is running low (#3836).
 const POLL_MAX_ATTEMPTS: u32 = 12;
+
+/// Aggregate wall-clock budget for the ENTIRE poll-wait phase across ALL
+/// members in one `run_verify_tail` call (#3836 MEDIUM fix).
+///
+/// Why: `verify_one`'s per-member poll (up to [`POLL_MAX_ATTEMPTS`] *
+/// [`POLL_INTERVAL`] ≈ 55s) folds SEQUENTIALLY over up to five launchd
+/// members in `run_verify_tail` — with every member simultaneously stuck,
+/// that is a ~4-5 minute worst-case stall, exactly when multiple daemons
+/// failing to start is the scenario an operator most needs a fast,
+/// actionable signal for. Capping the AGGREGATE budget (not just the
+/// per-member one) bounds the worst case while still giving a single
+/// genuinely slow-but-healthy daemon its full per-member window when it's
+/// the only one stuck.
+const AGGREGATE_POLL_BUDGET: Duration = Duration::from_secs(120);
 
 /// One member's verify-tail outcome.
 ///
@@ -72,7 +97,10 @@ const POLL_MAX_ATTEMPTS: u32 = 12;
 /// fix) mirrors `StableMember::required` and gates whether a down/not-installed
 /// verdict for this member may fail the overall `verified` verdict;
 /// `down_state` (#3833) is `Some` iff `health` is still `down` for a LAUNCHD
-/// member after the wait, classifying WHY.
+/// member after the wait, classifying WHY; `budget_exhausted` (#3836) is
+/// `true` iff this member needed a poll wait but the AGGREGATE poll budget
+/// had already run out, so NO poll was attempted for it (only the instant
+/// probe).
 /// Test: `tests::report_serialises`.
 #[derive(Clone, Debug, Serialize)]
 pub struct VerifyRow {
@@ -84,6 +112,10 @@ pub struct VerifyRow {
     pub kickstarted: bool,
     /// Whether this member is REQUIRED for the overall `verified` verdict.
     pub required: bool,
+    /// Whether the AGGREGATE poll budget ([`AGGREGATE_POLL_BUDGET`]) was
+    /// already exhausted by the time this member needed a poll wait, so it
+    /// was skipped (#3836).
+    pub budget_exhausted: bool,
     /// Why a LAUNCHD member is still `down` after the poll wait, when it is
     /// (#3833). `None` for a healthy/stale/unknown/not_installed member, or a
     /// non-LAUNCHD member.
@@ -360,6 +392,25 @@ fn launchd_list_raw(_label: &str) -> Option<String> {
     None
 }
 
+/// Whether launchd currently has `label` loaded at all (#3836).
+///
+/// Why: `service_bootstrap::bootstrap_one`'s #3836 defensive fallback needs
+/// to know whether a component binary's own `service install` actually
+/// loaded the agent, not just that the subprocess exited 0 (#3832's root
+/// cause — trusty-memory's `service install` used to write the plist without
+/// loading it). Reuses the exact same `launchctl list <label>` primitive
+/// [`classify_down_state`] is built on ([`launchd_list_raw`]), so the two
+/// call sites can never disagree about what "loaded" means.
+/// What: `true` iff `launchctl list <label>` finds the label at all —
+/// regardless of whether a PID is currently running; a loaded-but-not-yet-
+/// running job is still "loaded" (launchd owns it and will start it).
+/// Test: side-effecting; not invoked in the test suite (mirrors
+/// `classify_down_state`) — the underlying `Option`-based decision is the
+/// SAME one `classify_down_state_from_entry`'s `None` branch already covers.
+pub(super) fn is_label_loaded(label: &str) -> bool {
+    launchd_list_raw(label).is_some()
+}
+
 /// Classify why a LAUNCHD member is still `down` after the poll wait (#3833).
 ///
 /// Why: the single entry point [`verify_one`] calls once it has a final
@@ -375,32 +426,71 @@ fn classify_down_state(binary: &str) -> DownState {
     classify_down_state_from_entry(entry)
 }
 
+/// Clamp the per-member poll attempt count to fit within a `remaining`
+/// AGGREGATE budget (#3836 MEDIUM fix), never exceeding [`POLL_MAX_ATTEMPTS`].
+///
+/// Why: without this, one member's poll always runs its full
+/// [`POLL_MAX_ATTEMPTS`] schedule regardless of how much of the
+/// [`AGGREGATE_POLL_BUDGET`] earlier members already consumed — the LAST
+/// member in a fold of several simultaneously-stuck daemons could still
+/// overrun the aggregate budget by a full ~55s. Sizing this member's OWN
+/// attempt count to what's actually left keeps the aggregate fold close to
+/// its budget without needing a fully async/interruptible poll loop.
+///
+/// # Preconditions
+/// `remaining` is nonzero — callers must special-case an already-exhausted
+/// budget separately (skip the poll entirely; see [`verify_one`]).
+/// # Postconditions
+/// Returns a value in `1..=POLL_MAX_ATTEMPTS`.
+/// Test: `tests::bounded_attempts_*`.
+fn bounded_attempts(remaining: Duration) -> u32 {
+    debug_assert!(!remaining.is_zero(), "remaining budget must be nonzero");
+    let interval_secs = POLL_INTERVAL.as_secs().max(1);
+    let by_budget = 1 + (remaining.as_secs() / interval_secs) as u32;
+    by_budget.clamp(1, POLL_MAX_ATTEMPTS)
+}
+
 /// Verify one daemon member, applying the #2498 kickstart retry + #3833 poll
-/// wait when needed.
+/// wait when needed, bounded by the #3836 aggregate poll budget.
 ///
 /// Why: isolates the per-member side effect (probe, maybe kickstart, poll,
 /// classify) so [`run_verify_tail`] stays a plain fold over `selected`.
-/// What: probes health; if [`needs_kickstart`], attempts one kickstart,
-/// prints a one-line "waiting for services to start..." indication, then
-/// polls via [`poll_until_not_down`] on the [`POLL_INTERVAL`] /
-/// [`POLL_MAX_ATTEMPTS`] schedule (~60s total) instead of a single instant
-/// re-probe. If the member is STILL `down` after that wait, classifies WHY
-/// via [`classify_down_state`].
+/// What: probes health; if [`needs_kickstart`]:
+/// - and `remaining_budget` is already exhausted (#3836), skips the poll
+///   entirely (only the instant probe already taken) and flags
+///   `budget_exhausted: true` — no kickstart, no wait, no `launchctl` calls
+///   for this member;
+/// - otherwise, attempts one kickstart, prints a one-line "waiting for
+///   services to start..." indication, then polls via [`poll_until_not_down`]
+///   for [`bounded_attempts`]`(remaining_budget)` attempts (never more than
+///   [`POLL_MAX_ATTEMPTS`], and fewer when the aggregate budget is running
+///   low) instead of a single instant re-probe.
+///
+/// If the member is STILL `down` after all that, classifies WHY via
+/// [`classify_down_state`] regardless of whether the budget was exhausted —
+/// that check is a single cheap `launchctl list`, not a poll, so it's never
+/// budget-gated.
 /// Test: side-effecting (subprocess + sleep); the decision halves are
-/// `needs_kickstart`, `poll_until_not_down`, `classify_down_state_from_entry`.
-fn verify_one(m: &StableMember) -> VerifyRow {
+/// `needs_kickstart`, `poll_until_not_down`, `bounded_attempts`,
+/// `classify_down_state_from_entry`.
+fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
     let mut health = probe_member_health(&m.binary, m.manage);
     let mut kickstarted = false;
+    let mut budget_exhausted = false;
     if needs_kickstart(&health, m.manage) {
-        kickstarted = true;
-        let _ = kickstart(&m.binary);
-        eprintln!("  waiting for {} to start...", m.binary);
-        let (polled_health, _attempts) = poll_until_not_down(
-            || probe_member_health(&m.binary, m.manage),
-            || std::thread::sleep(POLL_INTERVAL),
-            POLL_MAX_ATTEMPTS,
-        );
-        health = polled_health;
+        if remaining_budget.is_zero() {
+            budget_exhausted = true;
+        } else {
+            kickstarted = true;
+            let _ = kickstart(&m.binary);
+            eprintln!("  waiting for {} to start...", m.binary);
+            let (polled_health, _attempts) = poll_until_not_down(
+                || probe_member_health(&m.binary, m.manage),
+                || std::thread::sleep(POLL_INTERVAL),
+                bounded_attempts(remaining_budget),
+            );
+            health = polled_health;
+        }
     }
     let down_state = if health == health_str::DOWN && m.manage == ManageStrategy::Launchd {
         Some(classify_down_state(&m.binary))
@@ -412,6 +502,7 @@ fn verify_one(m: &StableMember) -> VerifyRow {
         health,
         kickstarted,
         required: m.required,
+        budget_exhausted,
         down_state,
     }
 }
@@ -439,10 +530,20 @@ pub fn run_verify_tail(selected: &[StableMember]) -> VerifyTailReport {
     let ensure_report = EnsureReport::build(mcp_members, stages, false, false);
     let ensure_ok = ensure_report.all_ok;
 
+    // #3836 MEDIUM fix: `verify_one` folds sequentially over every daemon
+    // member, and each one's poll wait can run up to ~55s — an AGGREGATE
+    // budget (recomputed fresh from `budget_clock` before every member, so it
+    // shrinks in real time as earlier members consume it) caps the total
+    // time this loop can spend polling, so several simultaneously-stuck
+    // daemons stall the installer by ~2 minutes at worst, not ~4-5.
+    let budget_clock = Instant::now();
     let members: Vec<VerifyRow> = selected
         .iter()
         .filter(|m| m.daemon)
-        .map(verify_one)
+        .map(|m| {
+            let remaining = AGGREGATE_POLL_BUDGET.saturating_sub(budget_clock.elapsed());
+            verify_one(m, remaining)
+        })
         .collect();
 
     VerifyTailReport::build(ensure_ok, members)
@@ -508,16 +609,31 @@ fn optional_annotation(m: &VerifyRow) -> String {
     }
 }
 
+/// Whether any member in `members` had its poll wait skipped because the
+/// #3836 aggregate poll budget was already exhausted.
+///
+/// Why: extracted as a pure, unit-testable predicate so [`print_human`]'s
+/// "budget exhausted" summary note is driven by a tested decision, not
+/// inline logic only exercisable via stdout capture.
+/// What: `true` iff any row has `budget_exhausted: true`.
+/// Test: `tests::any_budget_exhausted_*`.
+fn any_budget_exhausted(members: &[VerifyRow]) -> bool {
+    members.iter().any(|m| m.budget_exhausted)
+}
+
 /// Print the final human-readable verify-tail summary — green/red pass/fail.
 ///
 /// Why: the last thing the `curl | sh` one-liner (via `install.sh` ->
 /// `tctl install`) prints must be an unambiguous verified/not-verified signal.
 /// What: prints the ensure verdict, one line per daemon member (noting a
-/// kickstart retry or an optional-and-tolerated bad health via
-/// [`optional_annotation`]), and a final colour-coded `VERIFIED`/`NOT
-/// VERIFIED` line.
+/// kickstart retry, a #3833 `down_state` diagnosis, or an optional-and-
+/// tolerated bad health via [`optional_annotation`]); when
+/// [`any_budget_exhausted`] (#3836), one summary note (not repeated per row)
+/// pointing the operator at re-running `tctl install`; and a final
+/// colour-coded `VERIFIED`/`NOT VERIFIED` line.
 /// Test: side-effect-only (stdout); the annotation text is unit-tested via
-/// `optional_annotation` and the data it reads via `VerifyTailReport::build`.
+/// `optional_annotation`/`any_budget_exhausted` and the data they read via
+/// `VerifyTailReport::build`.
 pub fn print_human(report: &VerifyTailReport) {
     println!("tctl install — verify");
     println!(
@@ -526,6 +642,12 @@ pub fn print_human(report: &VerifyTailReport) {
     );
     for m in &report.members {
         println!("  {:<20} {}{}", m.member, m.health, optional_annotation(m));
+    }
+    if any_budget_exhausted(&report.members) {
+        println!(
+            "  note: poll budget exhausted — giving up on remaining members; \
+             re-run `tctl install` to check them again"
+        );
     }
     let verdict = if report.verified {
         colour("VERIFIED", "32")
@@ -545,6 +667,7 @@ mod tests {
             health: health.to_owned(),
             kickstarted: false,
             required: true,
+            budget_exhausted: false,
             down_state: None,
         }
     }
@@ -842,6 +965,70 @@ mod tests {
         assert_eq!(health, health_str::HEALTHY);
         assert_eq!(attempts, 1);
         assert_eq!(*waits.borrow(), 0);
+    }
+
+    /// Why: #3836 MEDIUM fix — with a generous remaining budget, a member
+    /// must still get its full [`POLL_MAX_ATTEMPTS`] ceiling, never MORE.
+    /// What: a large `remaining` (e.g. the full aggregate budget) clamps to
+    /// exactly `POLL_MAX_ATTEMPTS`.
+    /// Test: This is the test.
+    #[test]
+    fn bounded_attempts_clamped_to_max() {
+        assert_eq!(bounded_attempts(AGGREGATE_POLL_BUDGET), POLL_MAX_ATTEMPTS);
+        assert_eq!(
+            bounded_attempts(Duration::from_secs(3600)),
+            POLL_MAX_ATTEMPTS
+        );
+    }
+
+    /// Why: THE #3836 core safety property — a member turn late in the fold,
+    /// with little aggregate budget left, must get proportionally FEWER
+    /// attempts, not the full schedule (which is what let a single member
+    /// blow through the aggregate cap).
+    /// What: a small remaining budget yields fewer than `POLL_MAX_ATTEMPTS`
+    /// attempts, and a larger remaining budget yields a value in between.
+    /// Test: This is the test.
+    #[test]
+    fn bounded_attempts_shrinks_with_small_budget() {
+        // 12s remaining / 5s interval -> 1 + 2 = 3 attempts.
+        assert_eq!(bounded_attempts(Duration::from_secs(12)), 3);
+        // 30s remaining -> 1 + 6 = 7 attempts, strictly between 1 and the max.
+        let mid = bounded_attempts(Duration::from_secs(30));
+        assert!(
+            mid > 1 && mid < POLL_MAX_ATTEMPTS,
+            "expected a value strictly between 1 and {POLL_MAX_ATTEMPTS}, got {mid}"
+        );
+    }
+
+    /// Why: even a sliver of remaining budget must still attempt AT LEAST
+    /// one probe — never zero (a zero-attempt poll makes no sense; an
+    /// entirely exhausted budget is handled as its own separate case by
+    /// `verify_one`, not by this function receiving a zero `remaining`).
+    /// What: a 1-second remaining budget still yields `1`.
+    /// Test: This is the test.
+    #[test]
+    fn bounded_attempts_at_least_one() {
+        assert_eq!(bounded_attempts(Duration::from_secs(1)), 1);
+    }
+
+    /// Why: #3836 — the "budget exhausted" summary note must fire iff ANY
+    /// member's poll was skipped for that reason, and must NOT fire on an
+    /// all-clear report (avoids alarming an operator over nothing).
+    /// What: exercises both the empty/all-false case and a mixed case.
+    /// Test: This is the test.
+    #[test]
+    fn any_budget_exhausted_detects_any_row() {
+        assert!(!any_budget_exhausted(&[]));
+        assert!(!any_budget_exhausted(&[row("trusty-search", "healthy")]));
+
+        let exhausted = VerifyRow {
+            budget_exhausted: true,
+            ..row("trusty-memory", health_str::DOWN)
+        };
+        assert!(any_budget_exhausted(&[
+            row("trusty-search", "healthy"),
+            exhausted
+        ]));
     }
 
     /// Why: the running-PID branch must win regardless of last exit status —

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -27,7 +27,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   plist, exactly like its siblings; a bootstrap failure now propagates as an
   `Err` (never swallowed) instead of being silently skipped. `service start`
   is kept as an idempotent alias of `service install` for backward
-  compatibility with existing scripts/docs.
+  compatibility with existing scripts/docs. Verified manually (`cargo run -p
+  trusty-memory -- service install` + `launchctl list`); there is no trait
+  seam in `trusty_common::launchd::LaunchdConfig` yet for unit-testing
+  install-then-bootstrap sequencing in isolation — tracked as a follow-up in
+  `trusty-installer`'s CHANGELOG. `trusty-installer` 0.4.8 adds an
+  independent installer-side defensive fallback (verifies `launchctl list`
+  itself and force-bootstraps if needed) so this fix is not the only thing
+  standing between a demo and #3832 recurring.
 - **`serve --stdio --palace <default>` never reached real MCP tool calls**: `inject_default_palace` (`commands::serve_stdio_bridge`) only wrote the default into top-level `params.palace`, but a real MCP client (Claude Code) sends the standard `tools/call` envelope (`method: "tools/call"`, `params: {name, arguments}`) and tool handlers read `arguments.palace` — so every real `tools/call` request reached the handler with no palace at all, surfacing as `-32603: memory_recall: missing 'palace' (no --palace default configured)` even with `--palace` supplied on the CLI. `inject_default_palace` now mirrors the sibling `inject_caller_context`'s dispatch-shape branching: it injects into `params.arguments` for `tools/call` requests, and keeps the pre-existing top-level `params.palace` injection for legacy direct method-per-tool requests. Caller-supplied palace values are never clobbered either way.
 
 ## [0.21.0] — 2026-07-23

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -10,6 +10,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`trusty-memory service install` wrote the LaunchAgent plist but never
+  loaded (bootstrapped) it** (#3832, demo-critical): every sibling daemon's
+  `service install` (`trusty-search`/`trusty-analyze`/`trusty-review`) both
+  writes AND loads the agent in one step, and `trusty-installer`'s
+  post-install bootstrap step depends on that uniform contract — it shells
+  out to `<binary> service install` for every launchd-managed member and
+  treats a clean exit as "installed and bootstrapped". trusty-memory alone
+  split "install" (write-only) from "start" (write+load), so a fresh-machine
+  `tctl install` reported success while `~/Library/LaunchAgents/com.trusty.memory.plist`
+  sat on disk unbootstrapped and absent from `launchctl list` — and the
+  installer's later `launchctl kickstart -k` recovery retry then failed
+  outright (kickstart cannot force-start a label that was never bootstrapped),
+  surfacing as a bare, undiagnosed `down` with no `(kickstarted)` qualifier.
+  `service install` now calls `LaunchdConfig::bootstrap()` after writing the
+  plist, exactly like its siblings; a bootstrap failure now propagates as an
+  `Err` (never swallowed) instead of being silently skipped. `service start`
+  is kept as an idempotent alias of `service install` for backward
+  compatibility with existing scripts/docs.
 - **`serve --stdio --palace <default>` never reached real MCP tool calls**: `inject_default_palace` (`commands::serve_stdio_bridge`) only wrote the default into top-level `params.palace`, but a real MCP client (Claude Code) sends the standard `tools/call` envelope (`method: "tools/call"`, `params: {name, arguments}`) and tool handlers read `arguments.palace` — so every real `tools/call` request reached the handler with no palace at all, surfacing as `-32603: memory_recall: missing 'palace' (no --palace default configured)` even with `--palace` supplied on the CLI. `inject_default_palace` now mirrors the sibling `inject_caller_context`'s dispatch-shape branching: it injects into `params.arguments` for `tools/call` requests, and keeps the pre-existing top-level `params.palace` injection for legacy direct method-per-tool requests. Caller-supplied palace values are never clobbered either way.
 
 ## [0.21.0] — 2026-07-23

--- a/crates/trusty-memory/src/commands/service.rs
+++ b/crates/trusty-memory/src/commands/service.rs
@@ -8,9 +8,25 @@
 //! [`trusty_common::launchd`] implementation so the two tools cannot drift.
 //! What: macOS routes to `service_install` / `service_start` / `service_stop`
 //! / `service_logs`. Non-macOS prints a "not supported" error and exits 1.
+//!
+//! 🔴 (issue #3832) `service install` MUST write AND load (bootstrap) the
+//! agent, exactly like `trusty-search`/`trusty-analyze`/`trusty-review
+//! service install` do. `trusty-installer`'s post-install service-bootstrap
+//! step (`service_bootstrap::bootstrap_member_service`) shells out uniformly
+//! to `<binary> service install` for every launchd-managed member and
+//! documents that contract explicitly ("writes the plist and bootstraps
+//! it"). trusty-memory used to be the ONE member that only wrote the plist
+//! here (loading was split out into the separate `start` action), silently
+//! violating that contract: `tctl install` reported "trusty-memory: launchd
+//! service installed and bootstrapped" (a lie — nothing was ever loaded), the
+//! plist sat on disk unbootstrapped, and the verify tail's `launchctl
+//! kickstart -k` retry then failed outright (kickstart cannot force-start a
+//! label that was never bootstrapped), surfacing as a bare, undiagnosed
+//! `down` instead of `down (kickstarted)`.
 //! Test: on Linux, every action returns Err with the platform message; on
-//! macOS, `service install` writes the plist without loading it, `start`
-//! bootstraps it, `stop` boots it out, and `logs` tails the log files.
+//! macOS, `service install` writes the plist AND bootstraps it (`start` is
+//! kept as an idempotent alias for the same operation), `stop` boots it out,
+//! and `logs` tails the log files.
 
 use anyhow::Result;
 use clap::Subcommand;
@@ -27,9 +43,11 @@ use colored::Colorize;
 /// `cargo run -p trusty-memory -- service --help`.
 #[derive(Debug, Clone, Subcommand)]
 pub enum ServiceAction {
-    /// Install the LaunchAgent plist (does not load it).
+    /// Install the LaunchAgent plist AND load it (issue #3832 — matches
+    /// `trusty-search`/`trusty-analyze`/`trusty-review service install`).
     Install,
-    /// Install and load the LaunchAgent (start the daemon).
+    /// Install and load the LaunchAgent (kept as an idempotent alias of
+    /// `install` — see issue #3832).
     Start,
     /// Unload the LaunchAgent (stop the daemon).
     Stop,
@@ -193,14 +211,22 @@ fn current_exe() -> Result<std::path::PathBuf> {
     std::env::current_exe().map_err(|e| anyhow::anyhow!("could not resolve current exe: {e}"))
 }
 
-/// `service install` — write the plist without loading it.
+/// `service install` — write the plist AND load (bootstrap) the agent.
 ///
-/// Why: operators sometimes want to inspect or hand-edit the plist before
-/// launchd takes ownership. Splitting "install" from "start" gives them that
-/// window without forcing a stop-start dance.
-/// What: resolves the binary path and log directory, then calls
-/// `LaunchdConfig::install()` which writes `~/Library/LaunchAgents/<label>.plist`
-/// and creates the log directory. Does not call `bootstrap`.
+/// Why (issue #3832): this MUST write and load in one step, matching every
+/// other launchd-managed member's `service install` — `trusty-installer`'s
+/// post-install bootstrap step depends on that uniform contract (it shells
+/// out to `<binary> service install` for every member and treats a clean
+/// exit as "installed and bootstrapped"). Previously this only wrote the
+/// plist, so `tctl install` reported success while trusty-memory's daemon
+/// was never actually loaded into launchd — a fresh-machine install left
+/// `com.trusty.memory` silently absent from `launchctl list`.
+/// What: resolves the binary path and log directory, writes
+/// `~/Library/LaunchAgents/<label>.plist` via `LaunchdConfig::install()`,
+/// then loads it into the `gui/<uid>` domain via `LaunchdConfig::bootstrap()`
+/// (idempotent — bootout-then-bootstrap). A bootstrap failure propagates as
+/// `Err` (never swallowed) so both the CLI exit code and
+/// `trusty-installer`'s `BootstrapAction::Failed` narration see it.
 /// Test: integration via `cargo run -p trusty-memory -- service install`.
 #[cfg(target_os = "macos")]
 fn service_install() -> Result<()> {
@@ -215,10 +241,19 @@ fn service_install() -> Result<()> {
         plist_path.display()
     );
     ensure_fastembed_cache_dir();
+
+    cfg.bootstrap()?;
+    let domain = format!("gui/{}", trusty_common::launchd::current_uid());
     println!(
-        "  Logs:    {}\n  Start:   {}",
+        "{} Loaded {} into {} — daemon will start automatically.",
+        "✓".green(),
+        LAUNCHD_LABEL,
+        domain
+    );
+    println!(
+        "  Logs:    {}\n  Stop:    {}",
         log_dir.display().to_string().dimmed(),
-        "trusty-memory service start".cyan(),
+        "trusty-memory service stop".cyan(),
     );
     Ok(())
 }
@@ -256,42 +291,18 @@ fn ensure_fastembed_cache_dir() {
     }
 }
 
-/// `service start` — install the plist (if needed) and bootstrap the agent.
+/// `service start` — alias of `service install` (issue #3832).
 ///
-/// Why: the common "I want it running" path should be one command, not two.
-/// `install` + `bootstrap` is idempotent under the shared launchd module
-/// (bootstrap calls bootout first), so calling start repeatedly is safe.
-/// What: writes the plist via `install()`, then loads it into the user's
-/// `gui/<uid>` domain via `bootstrap()`. The agent will start immediately
-/// and restart on non-zero exits per `KeepAlive::OnSuccess`.
+/// Why: `install` now writes AND bootstraps in one step (see
+/// [`service_install`]), so the two actions became identical; kept as a
+/// separate `ServiceAction` variant only so existing scripts/docs invoking
+/// `trusty-memory service start` keep working. `install` + `bootstrap` is
+/// idempotent under the shared launchd module (bootstrap calls bootout
+/// first), so calling either repeatedly is safe.
 /// Test: integration via `cargo run -p trusty-memory -- service start`.
 #[cfg(target_os = "macos")]
 fn service_start() -> Result<()> {
-    let exe = current_exe()?;
-    let log_dir = launchd_log_dir()?;
-    let cfg = build_launchd_config(exe, log_dir.clone());
-    let plist_path = cfg.plist_path()?;
-    cfg.install()?;
-    println!(
-        "{} Wrote LaunchAgent plist: {}",
-        "✓".green(),
-        plist_path.display()
-    );
-
-    cfg.bootstrap()?;
-    let domain = format!("gui/{}", trusty_common::launchd::current_uid());
-    println!(
-        "{} Loaded {} into {} — daemon will start automatically.",
-        "✓".green(),
-        LAUNCHD_LABEL,
-        domain
-    );
-    println!(
-        "  Logs:    {}\n  Stop:    {}",
-        log_dir.display().to_string().dimmed(),
-        "trusty-memory service stop".cyan(),
-    );
-    Ok(())
+    service_install()
 }
 
 /// `service stop` — boot out the agent (stop and unload).


### PR DESCRIPTION
## Code-critic fix round (WARN: 1 HIGH + 2 MEDIUM)

Applied on top of the original fix below:

1. **HIGH — defensive bootstrap in the installer itself.** `tctl install` downloads a component's LATEST PUBLISHED release binary, so the trusty-memory source fix (Bug A below) only protects a demo once a new trusty-memory release ships — an older, already-published binary would still hit the bug. `bootstrap_one` (`service_bootstrap.rs`) no longer trusts a clean `service install` exit code as proof launchd loaded the agent: it now independently checks `launchctl list <label>` (new `ServiceEnv::is_loaded`, backed by a new `verify_tail::is_label_loaded` that reuses the SAME `launchctl list` primitive `classify_down_state` is built on) and, if not loaded, force-bootstraps the already-written plist directly (new `ServiceEnv::bootstrap_fallback`, mirroring `lifecycle.rs`'s minimal-`LaunchdConfig` pattern) — reported as the new `BootstrapAction::InstalledByFallback` ("bootstrapped by installer (component binary did not load its service)") instead of a silently-inaccurate `Installed`. This makes the fix effective the moment installer 0.4.8 ships, independent of any component binary's age, and guards every current/future service member, not just trusty-memory.
2. **MEDIUM — aggregate poll budget.** `verify_one`'s ~55s per-member poll folded SEQUENTIALLY over up to five launchd members — five simultaneously-stuck daemons could stall `tctl install` ~4-5 minutes, exactly when a fast signal matters most. New `AGGREGATE_POLL_BUDGET` (~120s total, recomputed fresh before every member) caps the whole poll-wait phase; new `bounded_attempts` shrinks a late member's own attempt ceiling to fit what's left. Once exhausted, remaining members skip their poll entirely (an instant probe only, flagged `budget_exhausted` in the JSON row) and the human summary prints one note — "poll budget exhausted — giving up on remaining members; re-run `tctl install` to check them again" — instead of repeating it per row.
3. **MEDIUM — corrected a wrong test-coverage claim.** The original PR/CHANGELOG claimed `tests/path_shadow_e2e.rs` exercises trusty-memory's new `service_install()` bootstrap call — it does not (that file covers the trusty-mpm supervisor bootstrap + PATH-shadow detection only). Corrected the CHANGELOG to say honestly that the trusty-memory binary-side fix has manual/integration verification only, with a tracked follow-up (a `LaunchdOps`-style trait seam mirroring `ServiceEnv`/`StubLaunchctl`, deferred since it touches all four daemon crates' `service.rs`). The NEW installer-side defensive fallback (item 1) — now the demo-critical path — IS fully unit-tested against `FakeServiceEnv`: `bootstrap_one_installed_directly_when_loaded` (loaded → no fallback call), `bootstrap_one_falls_back_when_not_loaded` (not loaded → fallback called, `InstalledByFallback`), `bootstrap_one_reports_failure_when_fallback_also_fails` (fallback fails → `Failed`, both reasons folded into the message, surfaced loudly).

**Coordination with #3834**: `service_bootstrap.rs` is also being modified by the sibling PR #3834's fix round (`run_captured`/stdout-capture area, #3830). As of this push #3834 has NOT merged (`gh pr view 3834` → `state: OPEN`, `mergeStateStatus: BEHIND`), so per the coordinator's guidance this round's diff was written to minimize overlap: it touches only `bootstrap_one`/`ServiceEnv`/`RealServiceEnv`'s NEW methods/`FakeServiceEnv`/new tests — a disjoint region from #3834's `run_service_install` body rewrite (`.status()` → `run_captured(...)`) and its appended tests. A textual conflict is still possible at the `mod tests {}` insertion points and in both CHANGELOGs' `## [Unreleased]` anchor; **the PM sequences the merges (#3834 first)** — if #3834 merges before this PR, this branch will be rebased onto main and the CHANGELOG entries hand-folded under #3834's version heading before merge, per the coordinator's instruction.

Raw test/clippy/fmt output for this fix round is in the "Tests" section below (452 passed, up from 445 — 7 new tests, all clean).

---

## Summary

Two related service-lifecycle bugs found live on a brand-new Apple Silicon MacBook demo install (`curl install.sh | sh -s -- -y`, installer 0.4.7).

### Bug A (#3832) — trusty-memory LaunchAgent written but never bootstrapped

**Root cause**: every sibling daemon's `service install` (`trusty-search`/`trusty-analyze`/`trusty-review`) writes the LaunchAgent plist AND loads it (`cfg.bootstrap()`) in one step — the contract `trusty-installer`'s `service_bootstrap::bootstrap_member_service` depends on (it shells out uniformly to `<binary> service install` for every launchd-managed member and treats a clean exit as "installed and bootstrapped"). `trusty-memory`'s `service install` was the ONE outlier: it only wrote the plist ("does not load it" — split into a separate `start` action). So a fresh-machine `tctl install` ran `trusty-memory service install`, which exited 0 having only written the plist; the installer narrated "trusty-memory: launchd service installed and bootstrapped" (untrue — nothing was loaded); `com.trusty.memory` never appeared in `launchctl list`; and the verify tail's `launchctl kickstart -k` recovery retry then failed outright (kickstart cannot force-start a label that was never bootstrapped) — which is why the live verify table showed a bare `down` for trusty-memory with no `(kickstarted)` qualifier, unlike search/analyze/review.

**Fix**: `trusty-memory service install` now calls `cfg.bootstrap()` after writing the plist, matching its siblings exactly. `service start` is kept as an idempotent alias (existing scripts/docs keep working). A bootstrap failure now propagates as an `Err` (never swallowed) through to both the CLI exit code and `trusty-installer`'s existing `BootstrapAction::Failed` narration. **Plus (fix round item 1 above)**: the installer no longer depends on this source fix alone — it independently verifies + repairs the same failure mode for every service member, regardless of binary version.

### Bug B (#3833) — verify races daemon startup, reports uniform "down"

**Root cause**: `verify_tail::verify_one` did one health probe, one `launchctl kickstart -k` retry, and one immediate re-probe — no wait. trusty-search notably downloads embedding models on first boot and can take tens of seconds, so a perfectly healthy machine reported `verify: NOT VERIFIED` / exit 2 moments before every daemon actually came up (confirmed live: `launchctl list` showed live PIDs + exit code 0 for search/analyze/review/mpm moments after the installer had already given up).

**Fix**:
- New `poll_until_not_down` polls health on a bounded ~55-60s per-member schedule (up to 12 attempts, 5s apart) instead of one instant re-probe, printing a "waiting for `<binary>` to start..." indication. Pure/generic over `probe`/`wait` closures so it's unit-tested with fakes (no real sleeping in the test suite).
- A member still `down` after the wait is now classified into one of three distinct end states via `classify_down_state` (backed by `launchctl list <label>`, parsed by the pure `parse_launchd_list_text`/`classify_down_state_from_entry`): `DownState::NotLoaded` (no such service), `DownState::Crashed { exit_code }` (loaded, no running PID, nonzero last exit status), or `DownState::StillStarting` (loaded and either running or between clean respawns). The human summary now reads e.g. `trusty-memory  down (not loaded)` or `trusty-search  down (crashed, exit 78)` instead of a bare `down`.
- The exit code / `verified` verdict already derive from the (now post-wait) `members` health via the existing fold in `install.rs`, so both automatically reflect the FINAL state, not the instant-after-kickstart snapshot.
- **Plus (fix round item 2 above)**: bounded to an AGGREGATE ~120s across all members, not ~55s each unconditionally.

## Evidence (from the task)

```
$ launchctl list | grep -i trusty
<analyze, mpm.supervisor, trusty-review, trusty-search, logrotate helper — no com.trusty.memory line>

tctl install — verify
  trusty-search        down (kickstarted)
  trusty-analyze        down (kickstarted)
  trusty-review         down (kickstarted)
  trusty-memory         down
verify: NOT VERIFIED
```
moments later:
```
$ launchctl list | grep -i trusty
<PID>  0  com.trusty.analyze
<PID>  0  com.trusty.mpm.supervisor
<PID>  0  com.trusty.trusty-review
<PID>  0  com.trusty.trusty-search
```

## Tests

`cargo test -p trusty-installer -p trusty-memory` — raw output (post fix-round):

```
test result: ok. 452 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 10.21s   (trusty-installer lib)
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s      (tctl bin)
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s      (trusty-installer bin)
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.78s      (config_mount.rs)
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.99s      (path_shadow_e2e.rs)
test result: ok. 452 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 24.62s   (trusty-memory lib)
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.90s      (task_mcp.rs, one of several trusty-memory integration suites — all "ok", 0 failed)
```

`cargo clippy --all-targets -p trusty-installer -p trusty-memory -- -D warnings`: zero warnings. `cargo fmt --check -p trusty-installer -p trusty-memory`: clean.

New tests added (fix round, on top of the original PR's tests):
- `service_bootstrap`: `bootstrap_one_installed_directly_when_loaded`, `bootstrap_one_falls_back_when_not_loaded`, `bootstrap_one_reports_failure_when_fallback_also_fails`, plus `bootstrap_one_reports_failure` now also asserts the fallback is NEVER called on a genuine `service install` failure, and `note_mentions_binary` covers `InstalledByFallback`.
- `verify_tail`: `bounded_attempts_clamped_to_max`, `bounded_attempts_shrinks_with_small_budget`, `bounded_attempts_at_least_one`, `any_budget_exhausted_detects_any_row`.

New tests from the ORIGINAL PR (unchanged): `trusty-installer::verify_tail`: `poll_until_not_down_{stops_when_healthy,stops_at_max_attempts,first_attempt_needs_no_wait}`, `classify_down_state_from_entry_{running,crashed,clean_exit_no_pid,not_loaded}`, `parse_launchd_list_text_{running,crashed,clean_exit}`, `down_state_phrase_mapping`, `optional_annotation_reports_down_state` (+ updated `optional_annotation_covers_not_installed_and_down`).

`trusty-memory::commands::service`'s `service_install()` bootstrap call: manual verification only (`cargo run -p trusty-memory -- service install` + `launchctl list`) — see the CHANGELOG follow-up note; the fix-round's item 3 correction applies here (an earlier draft of this PR incorrectly claimed `path_shadow_e2e.rs` coverage).

Also ran `tctl install --dry-run --json` — confirms `service_bootstrap: true` for `trusty-memory` (unaffected preview logic) and exits clean.

## Sibling-PR scope note

PR #3834 (`fix-installer-progress-redraw`) also touches `service_bootstrap.rs` — its `run_captured`/stdout-capture change rewrites `run_service_install`'s body and appends its own tests. This PR's fix-round additions are scoped to `bootstrap_one`/`ServiceEnv`/`RealServiceEnv`'s new methods, minimizing overlap, but a conflict at the CHANGELOG anchor and/or the `mod tests {}` insertion point is still possible if #3834 merges first — **the PM sequences the merges (#3834 first)**; this branch will be rebased and the CHANGELOG hand-folded if that happens before this PR merges.

Closes #3832
Closes #3833

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
