### PR TITLE
feat(trusty-agents): Gmail eventstream listener + agent-wake (#3820)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11209,6 +11209,7 @@ dependencies = [
  "trusty-agents-common",
  "trusty-code",
  "trusty-common",
+ "trusty-gworkspace",
  "trusty-memory",
  "trusty-search",
  "usearch",

--- a/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
@@ -167,3 +167,18 @@ skills = [
     "izzie-metro-north",
     "cto-bob-voice",
 ]
+
+# --- Listeners (#3820, DOC-54 SPEC-AGENTS-04/06) — the third config-triple
+# leg: what Izzie REACTS to, distinct from `[tools]` (how she ACTS). This
+# binding is INERT until a matching `[[listeners]]` entry named
+# "gmail-personal" exists in `~/.trusty-agents/config.toml` AND that
+# listener is `enabled = true` — see the PR body / #3820 for the exact
+# stanza to paste into config.toml to turn this on live. `event_types`
+# narrows to new-mail-only (no other Gmail event types are emitted by this
+# slice yet); `filter.from` is intentionally broad (`*`) for the demo so any
+# inbound mail can wake her — tighten this once real usage patterns emerge
+# (DOC-54's own example narrows to `*@family.com`).
+[[listeners]]
+name = "gmail-personal"
+event_types = ["message.received"]
+filter = { from = ["*"] }

--- a/crates/trusty-agents/.trusty-agents/agents/izzie/events/gmail.md
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie/events/gmail.md
@@ -1,0 +1,30 @@
+<!--
+Per-connector event instructions for Izzie's Gmail listener (#3817, DOC-54
+SPEC-AGENTS-05 §6). Loaded into context IN ADDITION TO persona.md whenever a
+gmail event wakes Izzie (crate::listeners::wake, #3820) — never on its own.
+-->
+
+## Reacting to a new Gmail message
+
+You just woke up because a new email arrived in Masa's personal inbox and
+passed the listener's filters. This is a REACTION, not a request Masa typed —
+be clear about that in your first line so he isn't confused about why you're
+speaking.
+
+- **Always ask first.** Summarize the email (who it's from, subject, the
+  gist) and ask how he'd like to respond, if at all. Never send a reply,
+  archive it, apply a label, or take any other action on the message without
+  his explicit go-ahead in this turn or a previously learned standing
+  instruction for exactly this kind of message.
+- **Keep the summary tight.** One or two sentences — he can ask for the full
+  body if he wants it (`get_gmail_message_content` / the message id is
+  available to you via the event data above).
+- **Triage tone, not alarm.** Most inbound mail is not urgent. Reserve any
+  sense of urgency for messages that are actually time-sensitive (e.g. same-
+  day scheduling, a sender he's flagged as important).
+- **Learn preferences.** If Masa tells you "always just archive these" or
+  "let me know about anything from X but ignore the rest," treat that as a
+  standing instruction to remember (trusty-memory) for next time — this is
+  the Event → Ask → Learn → Adapt loop (DOC-54 §2.1).
+- **Never fabricate email content.** Only speak to what the event summary or
+  a tool call actually returned.

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -22,8 +22,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   include/exclude filter, and the stage-two wake dispatcher that reuses
   `run_pm_task_with_persona` (the same entry point `/agent` uses) so a wake
   reaction lands in the agent's chat history like an ordinary turn —
-  ask-first framing, rate-limited to one wake per poll cycle, every decision
-  logged. New API: `GET /api/listener-events`, `POST
+  ask-first framing, rate-limited to one wake per poll cycle (enforced by a
+  pure cycle-gate, `listeners::wake::gate_wake`, threaded through
+  `poll_once`'s per-event loop — every event is still durably stored
+  regardless of whether its wake was rate-limited), every decision logged.
+  `poll_interval_secs` is floored at 15s on config load (values below the
+  floor are clamped up with a warning, not silently accepted) since this
+  polls a real personal Gmail account. Cursor persistence
+  (`~/.trusty-agents/events/cursor-<listener>.json`) writes atomically
+  (temp-then-rename) and logs a warning on a malformed cursor read instead
+  of silently re-baselining. New API: `GET /api/listener-events`, `POST
   /api/listener-events/filter` (named apart from the pre-existing SSE
   `/api/events` telemetry stream). Listener events also publish onto the
   existing harness event bus (`Event::ListenerEventReceived`) so the Events

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -9,6 +9,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **First real eventstream listener: Gmail history-poll + agent wake (#3820,
+  DOC-54 SPEC-AGENTS-04/06):** the third leg of the agent-config triple
+  (stores / tools / **listeners**) lands with a working Gmail connector.
+  Declarative config: harness-level `[[listeners]]` in `~/.trusty-agents/
+  config.toml` (stage-one ingestion filter, `enabled = false` by default)
+  and per-agent `[[listeners]]` bindings in `agent.toml` (stage-two wake
+  filter — event types, sender globs). New `crate::listeners` module: a
+  Gmail `history.list` polling engine (cursor persistence, dedup, exponential
+  backoff, 410-GONE re-baseline — Pub/Sub-pull is deferred), an append-only
+  JSONL event store under `~/.trusty-agents/events/` with a per-event-type
+  include/exclude filter, and the stage-two wake dispatcher that reuses
+  `run_pm_task_with_persona` (the same entry point `/agent` uses) so a wake
+  reaction lands in the agent's chat history like an ordinary turn —
+  ask-first framing, rate-limited to one wake per poll cycle, every decision
+  logged. New API: `GET /api/listener-events`, `POST
+  /api/listener-events/filter` (named apart from the pre-existing SSE
+  `/api/events` telemetry stream). Listener events also publish onto the
+  existing harness event bus (`Event::ListenerEventReceived`) so the Events
+  pane (#3818) updates live via the same SSE/Tauri bridge; the pane's
+  `gmail` source bucket is now real data, not a concept placeholder. Per-
+  connector event instructions load from `agents/<name>/events/<connector>.md`
+  (#3817) when a listener wakes an agent. Izzie ships with a demo
+  `gmail-personal` binding + `events/gmail.md`; enabling the live listener
+  requires a `~/.trusty-agents/config.toml` stanza (never written by this
+  code) — see the PR body. Deferred: Pub/Sub-pull transport, the Calendar
+  connector, multi-agent fanout beyond the one-wake-per-cycle limit.
+
 - **GUI reshape: WORKSTREAMS-backed "Tasks" sidebar, CHAT/EVENTS nav, and an
   in-pane agent config gear panel (#3819, epic #3052):** replaces the
   `PROJECTS` sidebar section and the `Chat/Projects/Personality` top nav.

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -62,6 +62,15 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.21.0", default-features = false }
 trusty-search = { path = "../trusty-search", version = "0.39.0" }
+# Gmail/Calendar eventstream listeners (#3820, DOC-54 SPEC-AGENTS-06) call
+# trusty-gworkspace's connector layer (`api::client::BaseClient` +
+# `api::services::gmail::*`) DIRECTLY as library functions — the same code
+# `trusty-gworkspace-mcp`'s tool handlers call, reused here instead of routed
+# through MCP JSON-RPC. Not one of the `publish = false` "agent crate" deps
+# `install_plugins` exists to keep out of this Cargo.toml (see the
+# `trusty-agents-common` comment below) — trusty-gworkspace is a plain
+# connector library, no cargo-cycle concern.
+trusty-gworkspace = { path = "../trusty-gworkspace", version = "0.2.2" }
 tokio = { version = "1", features = ["full"] }
 async-openai = "0.30"
 serde = { version = "1", features = ["derive"] }

--- a/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
@@ -101,6 +101,7 @@ fn test_agent_config(name: &str, model: &str, system_prompt: &str) -> AgentConfi
         plugins: crate::agents::AgentPluginsConfig::default(),
         rbac: crate::agents::RbacConfig::default(),
         adapter: Arc::new(crate::llm::adapter::GenericAdapter),
+        listeners: Vec::new(),
     }
 }
 

--- a/crates/trusty-agents/src/agents/claude_mpm_loader.rs
+++ b/crates/trusty-agents/src/agents/claude_mpm_loader.rs
@@ -133,6 +133,7 @@ impl ClaudeMpmAgent {
             plugins: crate::agents::AgentPluginsConfig::default(),
             rbac: crate::agents::RbacConfig::default(),
             adapter,
+            listeners: Vec::new(),
         }
     }
 }

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -107,6 +107,22 @@ pub struct AgentConfig {
     /// Test: `agent_config_load_populates_adapter`.
     #[serde(skip, default = "default_adapter")]
     pub adapter: Arc<dyn ModelAdapter>,
+
+    /// Per-agent listener bindings (#3820, DOC-54 SPEC-AGENTS-04/06)  — the
+    /// third leg of the stores/tools/listeners config triple.
+    ///
+    /// Why: An agent REACTS to inbound events (Gmail, Calendar, …) via
+    /// listeners, distinct from how it ACTS via `[tools].allow`. Each entry
+    /// names a harness-level listener (defined in `~/.trusty-agents/config.toml`'s
+    /// `[[listeners]]`) and further narrows (stage-two filter) which of that
+    /// listener's events wake THIS agent. Absent = the agent never wakes for
+    /// any event (deny-by-default, matching `[tools].allow`'s posture).
+    /// What: `Vec<AgentListenerBinding>` parsed from repeated `[[listeners]]`
+    /// tables.
+    /// Test: `crate::listeners::config` unit tests cover the binding shape;
+    /// `crate::listeners::wake` tests cover matching semantics.
+    #[serde(default)]
+    pub listeners: Vec<crate::listeners::config::AgentListenerBinding>,
 }
 
 fn default_adapter() -> Arc<dyn ModelAdapter> {

--- a/crates/trusty-agents/src/agents/extends/mod.rs
+++ b/crates/trusty-agents/src/agents/extends/mod.rs
@@ -294,6 +294,11 @@ pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
         union_opt_vec(merged.system_prompt.skills, child.system_prompt.skills);
     merged.agent.capabilities =
         merge_capabilities(merged.agent.capabilities, child.agent.capabilities);
+    // `listeners` (#3820): base-first union keyed by binding `name`; a child
+    // that re-declares the same listener name overrides the base's filter
+    // for it (matches the child-wins-on-override intent of the scalar rules
+    // above), rather than appending a shadowing duplicate.
+    merged.listeners = union_listener_bindings(merged.listeners, child.listeners);
 
     // --- Prose: base-first concatenation ---
     merged.system_prompt.content =
@@ -348,6 +353,35 @@ fn union_opt_vec(base: Option<Vec<String>>, child: Option<Vec<String>>) -> Optio
             Some(b)
         }
     }
+}
+
+/// Union two `[[listeners]]` binding lists, base-first, keyed by `name` —
+/// a child binding with the same `name` as a base binding REPLACES it
+/// in-place (rather than appending a second, shadowing entry); a child
+/// binding with a new `name` is appended.
+///
+/// Why: `AgentListenerBinding` doesn't implement `PartialEq`-driven
+/// `contains` semantics the way `union_opt_vec`'s `String` union does — two
+/// bindings are "the same listener" iff their `name` matches, even if the
+/// child changed the `filter`. Mirrors DOC-54's binding semantics: an
+/// overlay agent may want to re-filter (not merely add to) an inherited
+/// listener binding.
+/// Test: `extends_unions_listener_bindings_by_name`,
+/// `extends_listener_binding_child_override_replaces_base_filter`
+/// (`extends/tests.rs`).
+fn union_listener_bindings(
+    base: Vec<crate::listeners::config::AgentListenerBinding>,
+    child: Vec<crate::listeners::config::AgentListenerBinding>,
+) -> Vec<crate::listeners::config::AgentListenerBinding> {
+    let mut merged = base;
+    for child_binding in child {
+        if let Some(existing) = merged.iter_mut().find(|b| b.name == child_binding.name) {
+            *existing = child_binding;
+        } else {
+            merged.push(child_binding);
+        }
+    }
+    merged
 }
 
 /// Union the four capability sub-lists of two optional [`AgentCapabilities`].

--- a/crates/trusty-agents/src/agents/extends/tests.rs
+++ b/crates/trusty-agents/src/agents/extends/tests.rs
@@ -437,6 +437,94 @@ scopes = ["memory.read", "search.read"]
 }
 
 #[test]
+fn extends_unions_listener_bindings_by_name() {
+    let base = cfg(r#"
+[agent]
+name = "base"
+role = "r"
+model = "m"
+description = "d"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "b"
+[[listeners]]
+name = "calendar-personal"
+event_types = ["event.created"]
+"#);
+    let ch = cfg(r#"
+[agent]
+name = "child"
+role = "agent"
+model = ""
+description = ""
+extends = "base"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "c"
+[[listeners]]
+name = "gmail-personal"
+event_types = ["message.received"]
+"#);
+    let merged = merge_extends(base, ch);
+    assert_eq!(merged.listeners.len(), 2, "distinct names both retained");
+    assert!(
+        merged
+            .listeners
+            .iter()
+            .any(|b| b.name == "calendar-personal")
+    );
+    assert!(merged.listeners.iter().any(|b| b.name == "gmail-personal"));
+}
+
+#[test]
+fn extends_listener_binding_child_override_replaces_base_filter() {
+    let base = cfg(r#"
+[agent]
+name = "base"
+role = "r"
+model = "m"
+description = "d"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "b"
+[[listeners]]
+name = "gmail-personal"
+event_types = ["message.received"]
+filter = { from = ["*@duetto.com"] }
+"#);
+    let ch = cfg(r#"
+[agent]
+name = "child"
+role = "agent"
+model = ""
+description = ""
+extends = "base"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "c"
+[[listeners]]
+name = "gmail-personal"
+event_types = ["message.received"]
+filter = { from = ["*@family.com"] }
+"#);
+    let merged = merge_extends(base, ch);
+    assert_eq!(
+        merged.listeners.len(),
+        1,
+        "same-name binding replaces, not appends"
+    );
+    assert_eq!(merged.listeners[0].filter.from, vec!["*@family.com"]);
+}
+
+#[test]
 fn extends_union_none_cases() {
     let base_no_tools = cfg(r#"
 [agent]

--- a/crates/trusty-agents/src/agents/registry/md_agent.rs
+++ b/crates/trusty-agents/src/agents/registry/md_agent.rs
@@ -215,5 +215,10 @@ pub(crate) fn parse_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
         plugins: crate::agents::AgentPluginsConfig::default(),
         rbac: crate::agents::RbacConfig::default(),
         adapter,
+        // Flat `.md` frontmatter has no `[[listeners]]` shape yet (#3820
+        // ships the binding only for directory-package `agent.toml`, DOC-54
+        // §5.3's primary format) — a `.md` overlay agent never wakes on a
+        // listener event until this parser grows frontmatter support.
+        listeners: Vec::new(),
     })
 }

--- a/crates/trusty-agents/src/api/server/listener_events.rs
+++ b/crates/trusty-agents/src/api/server/listener_events.rs
@@ -1,0 +1,83 @@
+//! `GET /api/listener-events` + `POST /api/listener-events/filter` (#3820,
+//! DOC-54 SPEC-AGENTS-06 §7.4, issue #3818).
+//!
+//! Why: The Events pane needs a durable, persisted view of every event that
+//! passed a listener's stage-one filter — independent of whether the
+//! browser was even open when the event arrived — plus a way to toggle a
+//! given event TYPE between included/excluded. Named `/api/listener-events`
+//! rather than `/api/events` deliberately: `/api/events` is ALREADY the SSE
+//! telemetry stream (`events_sse.rs`, a live GET-only route with unrelated
+//! semantics) that ships on the base branch this work stacks on — reusing
+//! that path would either collide or silently redefine it. See the PR body
+//! for the full naming rationale.
+//! What: `GET` returns `{ "events": [StoredEvent, ...] }`, newest first,
+//! `included` reflecting current filter state (`EventStore::read_events`).
+//! `POST` takes `{ "event_type": "...", "included": bool }` and persists it.
+//! Both are thin wrappers over `crate::listeners::store::EventStore` — no
+//! `AppState` field needed (the store is file-backed, not in-process state).
+//! Test: `list_listener_events_returns_empty_when_no_log`,
+//! `set_listener_event_filter_persists_and_reflects_in_list` (`super::tests`).
+
+use axum::{Json, extract::Query, http::StatusCode, response::IntoResponse};
+use serde::{Deserialize, Serialize};
+
+use crate::listeners::store::{EventStore, StoredEvent};
+
+#[derive(Debug, Deserialize)]
+pub struct ListListenerEventsQuery {
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListListenerEventsResponse {
+    pub events: Vec<StoredEvent>,
+}
+
+/// `GET /api/listener-events?limit=N` — newest-first, `included` reflecting
+/// live filter state.
+pub async fn list_listener_events(Query(q): Query<ListListenerEventsQuery>) -> impl IntoResponse {
+    match EventStore::read_events(q.limit).await {
+        Ok(events) => Json(ListListenerEventsResponse { events }).into_response(),
+        Err(e) => {
+            tracing::warn!(error = %e, "list_listener_events failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SetListenerEventFilterRequest {
+    pub event_type: String,
+    pub included: bool,
+}
+
+/// `POST /api/listener-events/filter` — set the include/exclude state for
+/// one event type (applies retroactively to already-persisted rows of that
+/// type, per the Events pane's "excluded rows stay visible, muted" spec).
+pub async fn set_listener_event_filter(
+    Json(body): Json<SetListenerEventFilterRequest>,
+) -> impl IntoResponse {
+    if body.event_type.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "event_type must not be empty" })),
+        )
+            .into_response();
+    }
+    match EventStore::set_filter(&body.event_type, body.included).await {
+        Ok(()) => Json(serde_json::json!({ "ok": true })).into_response(),
+        Err(e) => {
+            tracing::warn!(error = %e, "set_listener_event_filter failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    }
+}

--- a/crates/trusty-agents/src/api/server/mod.rs
+++ b/crates/trusty-agents/src/api/server/mod.rs
@@ -20,6 +20,8 @@
 //!   - `ctrl_sessions`→ CTRL session CRUD (`om session …`)
 //!   - `tm`           → tmux session management (`/api/tm/*`)
 //!   - `events_sse`   → SSE telemetry stream
+//!   - `listener_events` → durable eventstream-listener event list + filter
+//!     toggle (`/api/listener-events*`, #3820)
 //!   - `task_runner`  → subprocess workflow execution + recap dispatch
 //!   - `ui`           → embedded Vite bundle serving
 //!   - `workstreams`  → `GET /api/workstreams[/:name/history]` — resumable
@@ -34,6 +36,7 @@ mod cancel;
 mod ctrl_sessions;
 mod events_sse;
 mod handlers;
+mod listener_events;
 mod models;
 mod project_registration;
 mod projects;

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -34,6 +34,7 @@ use super::handlers::{
     clear_context, clear_recent_tasks, docs_search, get_session_recap, get_task, health,
     list_tasks, submit_task,
 };
+use super::listener_events::{list_listener_events, set_listener_event_filter};
 use super::models::get_models;
 use super::project_registration::{connect_project, get_project_config};
 use super::projects::{list_agents_route, list_projects, list_sessions_route};
@@ -195,6 +196,16 @@ pub fn build_router_with_origins(
         .route("/api/tm/tell", post(tm_tell))
         // #192 Phase B: SSE event stream — replaces 2s stderr polling.
         .route("/api/events", get(events_handler))
+        // #3820: durable, persisted eventstream-listener event list + the
+        // per-event-type include/exclude toggle (Events pane, #3818). Named
+        // `/api/listener-events` — NOT `/api/events` — because that path is
+        // already the SSE telemetry stream above; see `listener_events.rs`'s
+        // module doc for the full naming rationale.
+        .route("/api/listener-events", get(list_listener_events))
+        .route(
+            "/api/listener-events/filter",
+            post(set_listener_event_filter),
+        )
         // #3752: internal loopback relay — the separate `tagent --slack`
         // process POSTs its Slack-mirror events here so they reach this
         // process's bus (and the GUI's `/api/events` stream). Guarded by the
@@ -314,6 +325,18 @@ pub async fn serve_with_config(cfg: ApiConfig) -> Result<()> {
             }
         }
     });
+    // #3820: start any enabled eventstream listeners (Gmail history-poll
+    // today) as background tasks in this long-lived server process. Reads
+    // `~/.trusty-agents/config.toml`'s `[[listeners]]` — every entry defaults
+    // `enabled = false`, so an install with no listeners configured (the
+    // common case today) spawns nothing. Never fails server startup: a
+    // listener config problem is logged and that listener alone is skipped
+    // (see `listeners::poll::spawn_listeners`).
+    let listener_project_path =
+        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let global_config = crate::mcp::config::GlobalConfig::load().await;
+    crate::listeners::poll::spawn_listeners(global_config.listeners, listener_project_path);
+
     // #212: Load persisted task snapshot so restarts don't lose history.
     let state = AppState::with_persistence(None).await;
     let addr = std::net::SocketAddr::from((cfg.bind, cfg.port));

--- a/crates/trusty-agents/src/api/server/tests/listener_events.rs
+++ b/crates/trusty-agents/src/api/server/tests/listener_events.rs
@@ -1,0 +1,119 @@
+//! `GET /api/listener-events` + `POST /api/listener-events/filter` tests
+//! (#3820).
+//!
+//! Why: The route's whole job is to pass through `EventStore` faithfully —
+//! these tests pin the router-level JSON contract (shape, status codes) that
+//! `EventStore`'s own unit tests (`crate::listeners::store::tests`) don't
+//! cover, since those exercise the store directly, not the HTTP surface.
+//! What: `list_returns_empty_when_no_log`, `filter_post_persists_and_list_reflects_it`,
+//! `filter_post_rejects_empty_event_type`.
+//! Test: This module IS the test.
+#![allow(clippy::await_holding_lock)]
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::api::server::routes::build_router;
+use crate::api::server::state::AppState;
+use crate::test_env::HOME_LOCK;
+
+fn router() -> Router {
+    build_router(AppState::default())
+}
+
+fn set_test_home(dir: &std::path::Path) {
+    // SAFETY: caller holds `HOME_LOCK` for the duration of the test (see
+    // `crate::test_env`'s module doc) so no other thread observes `HOME`
+    // mid-mutation.
+    unsafe {
+        std::env::set_var("HOME", dir);
+    }
+}
+
+#[tokio::test]
+async fn list_returns_empty_when_no_log() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    set_test_home(tmp.path());
+
+    let req = Request::builder()
+        .uri("/api/listener-events")
+        .body(Body::empty())
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["events"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn filter_post_persists_and_list_reflects_it() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    set_test_home(tmp.path());
+
+    // Append one event directly via the store (the HTTP surface has no
+    // write path for events themselves — only the poller writes those).
+    crate::listeners::store::EventStore::append(&crate::listeners::store::StoredEvent {
+        id: "gmail-personal:m1".to_string(),
+        listener_id: "gmail-personal".to_string(),
+        provider: "gmail".to_string(),
+        event_type: "message.received".to_string(),
+        ts: "2026-07-24T12:00:00Z".to_string(),
+        from: Some("dad@family.com".to_string()),
+        subject: Some("Hi".to_string()),
+        snippet: Some("snippet".to_string()),
+        included: true,
+    })
+    .await
+    .unwrap();
+
+    let app = router();
+    let post_req = Request::builder()
+        .method("POST")
+        .uri("/api/listener-events/filter")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({ "event_type": "message.received", "included": false }).to_string(),
+        ))
+        .unwrap();
+    let post_resp = app.clone().oneshot(post_req).await.unwrap();
+    assert_eq!(post_resp.status(), StatusCode::OK);
+
+    let list_req = Request::builder()
+        .uri("/api/listener-events")
+        .body(Body::empty())
+        .unwrap();
+    let list_resp = app.oneshot(list_req).await.unwrap();
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(list_resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let events = body["events"].as_array().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["included"], false);
+}
+
+#[tokio::test]
+async fn filter_post_rejects_empty_event_type() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    set_test_home(tmp.path());
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/api/listener-events/filter")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({ "event_type": "", "included": true }).to_string(),
+        ))
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -10,6 +10,7 @@ mod agent_patch;
 mod cancel;
 mod ctrl_sessions;
 mod guard;
+mod listener_events;
 mod listing;
 mod models;
 mod relay;

--- a/crates/trusty-agents/src/events.rs
+++ b/crates/trusty-agents/src/events.rs
@@ -306,6 +306,31 @@ pub enum Event {
         identity: String,
     },
 
+    // -- Eventstream listeners (#3820, DOC-54 SPEC-AGENTS-06) --
+    /// Emitted by a listener's polling engine (`crate::listeners::poll`)
+    /// when a new event passes stage-one (listener-level) filtering and is
+    /// durably appended to the event log.
+    ///
+    /// Why: The Events pane (#3818) needs LIVE updates, not just a
+    /// page-load snapshot from `GET /api/listener-events` — mirroring onto
+    /// this existing bus reuses the SSE/Tauri bridge every other real-time
+    /// GUI surface already relies on, instead of the pane needing its own
+    /// polling loop. Carries no `session_id` — like the Slack-mirror
+    /// events, a listener event is not task-scoped.
+    /// What: `listener_id`/`provider`/`event_type` identify the source;
+    /// `summary` is a single glanceable line (from/subject/snippet folded
+    /// into one string so the GUI's generic event-row renderer needs no
+    /// per-provider knowledge); `included` is the event type's current
+    /// filter state at emission time.
+    /// Test: `listener_event_received_round_trips`.
+    ListenerEventReceived {
+        listener_id: String,
+        provider: String,
+        event_type: String,
+        summary: String,
+        included: bool,
+    },
+
     // -- Keepalive --
     Ping,
 }
@@ -343,10 +368,14 @@ impl Event {
             | Event::AgentStarted { session_id, .. }
             | Event::ReportGenerated { session_id, .. }
             | Event::RecapGenerated { session_id, .. } => Some(session_id),
-            // Slack-mirror events are conversation-scoped, not task-scoped:
-            // like `Ping` they carry no `session_id`, so they always pass the
-            // SSE session filter and reach the GUI's app-lifetime EventSource.
-            Event::SlackMessageReceived { .. } | Event::SlackReplySent { .. } | Event::Ping => None,
+            // Slack-mirror and listener events are conversation/harness-scoped,
+            // not task-scoped: like `Ping` they carry no `session_id`, so they
+            // always pass the SSE session filter and reach the GUI's
+            // app-lifetime EventSource.
+            Event::SlackMessageReceived { .. }
+            | Event::SlackReplySent { .. }
+            | Event::ListenerEventReceived { .. }
+            | Event::Ping => None,
         }
     }
 }
@@ -602,6 +631,39 @@ mod tests {
                 assert_eq!(channel, "C0123ABC");
                 assert_eq!(text, "Deploy is green.");
                 assert_eq!(identity, "CTO Bot (as itself)");
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn listener_event_received_round_trips() {
+        let ev = Event::ListenerEventReceived {
+            listener_id: "gmail-personal".into(),
+            provider: "gmail".into(),
+            event_type: "message.received".into(),
+            summary: "dad@family.com: Dinner Sunday?".into(),
+            included: true,
+        };
+        let s = serde_json::to_string(&ev).unwrap();
+        assert!(s.contains("\"type\":\"listener_event_received\""), "{s}");
+        assert!(s.contains("\"provider\":\"gmail\""), "{s}");
+        // Listener events must not carry a session_id (always pass the filter).
+        assert_eq!(ev.session_id(), None);
+        let back: Event = serde_json::from_str(&s).unwrap();
+        match back {
+            Event::ListenerEventReceived {
+                listener_id,
+                provider,
+                event_type,
+                summary,
+                included,
+            } => {
+                assert_eq!(listener_id, "gmail-personal");
+                assert_eq!(provider, "gmail");
+                assert_eq!(event_type, "message.received");
+                assert_eq!(summary, "dad@family.com: Dinner Sunday?");
+                assert!(included);
             }
             other => panic!("unexpected event: {other:?}"),
         }

--- a/crates/trusty-agents/src/lib.rs
+++ b/crates/trusty-agents/src/lib.rs
@@ -87,6 +87,7 @@ pub mod inspection;
 pub mod intent;
 pub mod interaction_log;
 pub mod ipc;
+pub mod listeners;
 pub mod llm;
 pub mod local_inference;
 pub mod logging;

--- a/crates/trusty-agents/src/listeners/config.rs
+++ b/crates/trusty-agents/src/listeners/config.rs
@@ -1,0 +1,210 @@
+//! Declarative listener config shapes (#3820, DOC-54 SPEC-AGENTS-04/06).
+//!
+//! Why: Listeners are the third leg of the agent-config triple (stores /
+//! tools / listeners) and use TWO-STAGE filtering: a harness-level
+//! `[[listeners]]` array in `~/.trusty-agents/config.toml` (stage one —
+//! what gets ingested from the provider at all) and a per-agent
+//! `[[listeners]]` array in each agent's `agent.toml` (stage two — which of
+//! the ingested events wake THAT agent). Both are pure serde data structs —
+//! per the standing "agents are declarative-only" rule (#2791), no behavior
+//! lives here, only shape + defaults.
+//! What: [`ListenerConfig`]/[`ListenerFilter`] mirror the `config.toml`
+//! sketch in DOC-54 §7.5; [`AgentListenerBinding`]/[`AgentBindingFilter`]
+//! mirror the `agent.toml` sketch. `ListenerConfig::enabled` defaults to
+//! `false` (safe-by-default — see `crate::listeners::poll`'s module doc for
+//! why this matters for a config file this code never writes itself).
+//! Test: `listener_config_parses_gmail_example`,
+//! `listener_config_defaults_disabled_and_poll_interval`,
+//! `agent_listener_binding_parses_filter`.
+
+use serde::{Deserialize, Serialize};
+
+fn default_poll_interval_secs() -> u64 {
+    // DOC-54 §7.3.1: history-poll fallback default (2-5 min band); 180s
+    // sits in the middle, quota-conscious without being sluggish for a demo.
+    180
+}
+
+fn default_transport() -> String {
+    "history-poll".to_string()
+}
+
+/// One harness-level listener definition (`config.toml` `[[listeners]]`,
+/// stage-one filter).
+///
+/// Why: `enabled` defaults to `false` so a config file that merely declares
+/// a listener (e.g. shipped as a documented example a user pastes in) never
+/// silently starts polling a live account until the operator opts in
+/// explicitly — the polling engine (`crate::listeners::poll`) skips every
+/// listener with `enabled = false`.
+/// What: `name` is the listener's stable id, referenced by `agent.toml`
+/// binding entries. `connector` selects the provider implementation
+/// (`"gmail"` is the only one wired to a real poller today; unrecognized
+/// values are logged and skipped, never a hard error, so a config with a
+/// forward-looking `"google-calendar"` entry doesn't crash the process).
+/// `identity` is the `trusty-gworkspace` profile/account name (e.g.
+/// `"bob-personal"`) — `None` uses that crate's default profile.
+/// Test: `listener_config_parses_gmail_example`.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct ListenerConfig {
+    pub name: String,
+    pub connector: String,
+    #[serde(default)]
+    pub identity: Option<String>,
+    #[serde(default = "default_transport")]
+    pub transport: String,
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_poll_interval_secs")]
+    pub poll_interval_secs: u64,
+    #[serde(default)]
+    pub filter: ListenerFilter,
+}
+
+/// Stage-one (listener-level) filter — narrows what is even fetched from
+/// the provider. DOC-54 §5.3 / §7.5.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct ListenerFilter {
+    /// Gmail label ids to scope `history.list` to (e.g. `["INBOX"]`).
+    /// Empty = no label restriction.
+    #[serde(default)]
+    pub label_ids: Vec<String>,
+}
+
+impl ListenerFilter {
+    /// The single Gmail label to pass to `history.list`'s `labelId` param,
+    /// if the filter names exactly one.
+    ///
+    /// Why: Gmail's `history.list` accepts at most one `labelId` query
+    /// param (unlike `messages.list`'s multi-label `labelIds`); a listener
+    /// filter naming zero or >1 labels can't be expressed as that one param,
+    /// so this returns `None` for those cases and the poller falls back to
+    /// fetching unfiltered history and filtering client-side (not yet
+    /// implemented — today an empty/multi-label filter just means "no
+    /// server-side label narrowing", which is a safe, just-more-verbose
+    /// degradation).
+    /// What: `Some(label)` only when exactly one label id is present.
+    /// Test: `listener_filter_single_label_returns_some`,
+    /// `listener_filter_empty_or_multi_label_returns_none`.
+    pub fn single_gmail_label(&self) -> Option<&str> {
+        match self.label_ids.as_slice() {
+            [only] => Some(only.as_str()),
+            _ => None,
+        }
+    }
+}
+
+/// A per-agent listener binding (`agent.toml` `[[listeners]]`, stage-two
+/// filter). DOC-54 §5.3 / §7.5.
+///
+/// Why: An agent opts INTO waking on a named harness listener by declaring
+/// one of these; absence means the agent never wakes for any event (safe
+/// default — matches `[tools].allow`'s deny-by-default posture).
+/// What: `name` must match a `ListenerConfig::name` from `config.toml`.
+/// `event_types` further narrows which normalized event types wake this
+/// agent (e.g. `["message.received"]`); empty means "any event type this
+/// listener emits". `filter` applies sender/label narrowing on top.
+/// Test: `agent_listener_binding_parses_filter`,
+/// `agent_listener_binding_defaults_event_types_empty`.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct AgentListenerBinding {
+    pub name: String,
+    #[serde(default)]
+    pub event_types: Vec<String>,
+    #[serde(default)]
+    pub filter: AgentBindingFilter,
+}
+
+/// Stage-two (per-agent-binding) filter — DOC-54 §5.3 / §7.5.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct AgentBindingFilter {
+    /// Sender glob patterns (`*` = suffix/prefix wildcard, matched via the
+    /// same `match_any_glob` semantics as `[tools].allow`). Empty = any
+    /// sender.
+    #[serde(default)]
+    pub from: Vec<String>,
+    /// Gmail label ids that, if present on the event, EXCLUDE it from
+    /// waking this agent (e.g. `["PROMOTIONS"]`). Empty = no exclusions.
+    #[serde(default)]
+    pub exclude_labels: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listener_config_parses_gmail_example() {
+        let toml_str = r#"
+name = "gmail-personal"
+connector = "gmail"
+identity = "bob-personal"
+transport = "history-poll"
+enabled = true
+poll_interval_secs = 120
+filter = { label_ids = ["INBOX"] }
+"#;
+        let cfg: ListenerConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.name, "gmail-personal");
+        assert_eq!(cfg.connector, "gmail");
+        assert_eq!(cfg.identity.as_deref(), Some("bob-personal"));
+        assert!(cfg.enabled);
+        assert_eq!(cfg.poll_interval_secs, 120);
+        assert_eq!(cfg.filter.label_ids, vec!["INBOX".to_string()]);
+    }
+
+    #[test]
+    fn listener_config_defaults_disabled_and_poll_interval() {
+        let toml_str = r#"
+name = "gmail-personal"
+connector = "gmail"
+"#;
+        let cfg: ListenerConfig = toml::from_str(toml_str).unwrap();
+        assert!(!cfg.enabled, "enabled must default to false");
+        assert_eq!(cfg.poll_interval_secs, 180);
+        assert_eq!(cfg.transport, "history-poll");
+        assert!(cfg.identity.is_none());
+    }
+
+    #[test]
+    fn agent_listener_binding_parses_filter() {
+        let toml_str = r#"
+name = "gmail-personal"
+event_types = ["message.received"]
+filter = { from = ["*@family.com"], exclude_labels = ["PROMOTIONS"] }
+"#;
+        let binding: AgentListenerBinding = toml::from_str(toml_str).unwrap();
+        assert_eq!(binding.name, "gmail-personal");
+        assert_eq!(binding.event_types, vec!["message.received".to_string()]);
+        assert_eq!(binding.filter.from, vec!["*@family.com".to_string()]);
+        assert_eq!(
+            binding.filter.exclude_labels,
+            vec!["PROMOTIONS".to_string()]
+        );
+    }
+
+    #[test]
+    fn agent_listener_binding_defaults_event_types_empty() {
+        let toml_str = r#"name = "gmail-personal""#;
+        let binding: AgentListenerBinding = toml::from_str(toml_str).unwrap();
+        assert!(binding.event_types.is_empty());
+        assert!(binding.filter.from.is_empty());
+    }
+
+    #[test]
+    fn listener_filter_single_label_returns_some() {
+        let f = ListenerFilter {
+            label_ids: vec!["INBOX".to_string()],
+        };
+        assert_eq!(f.single_gmail_label(), Some("INBOX"));
+    }
+
+    #[test]
+    fn listener_filter_empty_or_multi_label_returns_none() {
+        assert_eq!(ListenerFilter::default().single_gmail_label(), None);
+        let f = ListenerFilter {
+            label_ids: vec!["INBOX".to_string(), "IMPORTANT".to_string()],
+        };
+        assert_eq!(f.single_gmail_label(), None);
+    }
+}

--- a/crates/trusty-agents/src/listeners/config.rs
+++ b/crates/trusty-agents/src/listeners/config.rs
@@ -15,14 +15,56 @@
 //! why this matters for a config file this code never writes itself).
 //! Test: `listener_config_parses_gmail_example`,
 //! `listener_config_defaults_disabled_and_poll_interval`,
-//! `agent_listener_binding_parses_filter`.
+//! `agent_listener_binding_parses_filter`,
+//! `listener_config_clamps_poll_interval_below_floor`,
+//! `listener_config_leaves_poll_interval_above_floor_untouched`.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 fn default_poll_interval_secs() -> u64 {
     // DOC-54 §7.3.1: history-poll fallback default (2-5 min band); 180s
     // sits in the middle, quota-conscious without being sluggish for a demo.
     180
+}
+
+/// Floor for `poll_interval_secs` (#3820 code-critic MEDIUM-2).
+///
+/// Why: This listener runs against Bob's REAL personal Gmail account. A
+/// hand-edited (or copy-pasted-wrong) `config.toml` with e.g.
+/// `poll_interval_secs = 1` would hammer the Gmail API at up to 1 req/sec
+/// indefinitely — quota exhaustion at best, an account-level abuse flag at
+/// worst. 15s is well under even the aggressive Pub/Sub-pull band (DOC-54
+/// §7.3.1's "~20-30s") while still guarding against a pathological
+/// near-zero value; it is NOT a recommendation (the documented defaults —
+/// 60-180s for history-poll — remain the sane operating range).
+pub const MIN_POLL_INTERVAL_SECS: u64 = 15;
+
+/// Deserialize `poll_interval_secs`, clamping any value below
+/// [`MIN_POLL_INTERVAL_SECS`] up to the floor and logging a warning so the
+/// clamp is visible rather than a silent surprise.
+///
+/// Why: Clamping (rather than rejecting the whole config with a hard parse
+/// error) keeps a typo'd interval from taking down config loading entirely
+/// — `GlobalConfig::load()` already degrades to defaults on any outright
+/// parse error, which would be a worse failure mode here than "run a bit
+/// more conservatively than the operator typed."
+/// Test: `listener_config_clamps_poll_interval_below_floor`,
+/// `listener_config_leaves_poll_interval_above_floor_untouched`.
+fn deserialize_clamped_poll_interval<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = u64::deserialize(deserializer)?;
+    if value < MIN_POLL_INTERVAL_SECS {
+        tracing::warn!(
+            configured = value,
+            floor = MIN_POLL_INTERVAL_SECS,
+            "listener poll_interval_secs below floor; clamping up"
+        );
+        Ok(MIN_POLL_INTERVAL_SECS)
+    } else {
+        Ok(value)
+    }
 }
 
 fn default_transport() -> String {
@@ -55,7 +97,13 @@ pub struct ListenerConfig {
     pub transport: String,
     #[serde(default)]
     pub enabled: bool,
-    #[serde(default = "default_poll_interval_secs")]
+    /// Poll interval, floored at [`MIN_POLL_INTERVAL_SECS`] on parse (see
+    /// `deserialize_clamped_poll_interval`) — a value below the floor is
+    /// clamped up, not rejected.
+    #[serde(
+        default = "default_poll_interval_secs",
+        deserialize_with = "deserialize_clamped_poll_interval"
+    )]
     pub poll_interval_secs: u64,
     #[serde(default)]
     pub filter: ListenerFilter,
@@ -164,6 +212,40 @@ connector = "gmail"
         assert_eq!(cfg.poll_interval_secs, 180);
         assert_eq!(cfg.transport, "history-poll");
         assert!(cfg.identity.is_none());
+    }
+
+    #[test]
+    fn listener_config_clamps_poll_interval_below_floor() {
+        let toml_str = r#"
+name = "gmail-personal"
+connector = "gmail"
+poll_interval_secs = 1
+"#;
+        let cfg: ListenerConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            cfg.poll_interval_secs, MIN_POLL_INTERVAL_SECS,
+            "a below-floor value must be clamped up to the floor, not passed through"
+        );
+    }
+
+    #[test]
+    fn listener_config_leaves_poll_interval_above_floor_untouched() {
+        let toml_str = r#"
+name = "gmail-personal"
+connector = "gmail"
+poll_interval_secs = 20
+"#;
+        let cfg: ListenerConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.poll_interval_secs, 20);
+    }
+
+    #[test]
+    fn listener_config_poll_interval_exactly_at_floor_is_unchanged() {
+        let toml_str = format!(
+            "name = \"gmail-personal\"\nconnector = \"gmail\"\npoll_interval_secs = {MIN_POLL_INTERVAL_SECS}\n"
+        );
+        let cfg: ListenerConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(cfg.poll_interval_secs, MIN_POLL_INTERVAL_SECS);
     }
 
     #[test]

--- a/crates/trusty-agents/src/listeners/mod.rs
+++ b/crates/trusty-agents/src/listeners/mod.rs
@@ -1,0 +1,30 @@
+//! Eventstream listeners — inbound event API connections (#3820, DOC-54
+//! SPEC-AGENTS-04/06).
+//!
+//! Why: Listeners are the counterpart to MCP tools, not a variant of them.
+//! An agent ACTS on the world via MCP tools; an agent REACTS to the world
+//! via listeners — direct API connections to upstream event providers
+//! (Gmail today; Calendar/Slack are documented, deferred connectors) that
+//! surface events onto the harness. A listener is never registered as an
+//! MCP tool and never invoked by the model; it runs in the harness runtime
+//! and delivers events to bound agents. This module is the first real
+//! listener implementation landing on top of DOC-54's spec.
+//! What:
+//! - `config` — declarative shapes for `config.toml`'s `[[listeners]]`
+//!   (stage-one, harness-level) and `agent.toml`'s `[[listeners]]`
+//!   (stage-two, per-agent binding).
+//! - `store` — the append-only JSONL event log + per-event-type
+//!   include/exclude filter state under `~/.trusty-agents/events/`.
+//! - `poll` — the Gmail `history.list` polling engine: cursor persistence,
+//!   dedup, exponential backoff, 410-GONE re-baseline.
+//! - `wake` — stage-two filter matching + the agent-wake dispatch path,
+//!   reusing `ctrl::pm_task::run_pm_task_with_persona` (the same entry point
+//!   the `/agent` REPL command uses) so a wake reaction is indistinguishable
+//!   from an ordinary chat turn in the agent's history.
+//! Test: See each submodule's own test coverage. End-to-end (real Gmail
+//! account) verification is manual — see the PR body's proof plan.
+
+pub mod config;
+pub mod poll;
+pub mod store;
+pub mod wake;

--- a/crates/trusty-agents/src/listeners/poll.rs
+++ b/crates/trusty-agents/src/listeners/poll.rs
@@ -1,0 +1,435 @@
+//! Gmail history-poll engine (#3820, DOC-54 SPEC-AGENTS-06 §7.1.2/§7.3).
+//!
+//! Why: DOC-54's recommended Gmail transport is Pub/Sub-pull WHERE a GCP
+//! topic exists, falling back to `history.list` polling with a persisted
+//! `historyId` cursor everywhere else. This slice ships ONLY the polling
+//! fallback (Pub/Sub-pull is explicitly deferred — see the PR body) since it
+//! needs zero additional GCP setup and is what the demo's `bob-personal`
+//! profile can use today. `spawn_listeners` is the harness-runtime entry
+//! point: one background tokio task per `enabled = true` listener with
+//! `connector = "gmail"`.
+//! What: `poll_once` does ONE cursor-bootstrap-or-fetch cycle: no cursor yet
+//! -> bootstrap from `users.getProfile` (baseline to "now", no replay);
+//! cursor present -> `history.list(startHistoryId=cursor)`, dedup new
+//! message ids against an in-memory set seeded from the durable event log,
+//! fetch each new message's summary fields, append a `StoredEvent`, advance
+//! the cursor, and hand the event to `wake::wake_bound_agents` when it's
+//! event-type-included. `run_gmail_poll_loop` wraps that in exponential
+//! backoff-with-jitter on transient errors and an immediate cursor reset on
+//! `410 GONE`, per DOC-54 §7.3.4.
+//! Test: `next_backoff_doubles_and_caps`, `is_410_gone_detects_status_text`,
+//! `stored_event_from_message_extracts_summary_fields`. The network-calling
+//! path is exercised manually against a live `bob-personal` mailbox (see the
+//! PR body's proof plan) — no mock Gmail server exists in this crate.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::Mutex;
+use trusty_gworkspace::api::client::BaseClient;
+use trusty_gworkspace::api::services::gmail::history::{get_gmail_profile, list_gmail_history};
+
+use crate::listeners::config::ListenerConfig;
+use crate::listeners::store::{EventStore, StoredEvent, events_dir};
+use crate::listeners::wake;
+
+const MIN_BACKOFF_SECS: u64 = 2;
+const MAX_BACKOFF_SECS: u64 = 300;
+
+/// One entry in `~/.trusty-agents/events/cursor-<listener>.json`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct Cursor {
+    history_id: Option<String>,
+}
+
+fn cursor_path(listener_name: &str) -> Result<PathBuf> {
+    Ok(events_dir()?.join(format!("cursor-{listener_name}.json")))
+}
+
+async fn load_cursor(listener_name: &str) -> Cursor {
+    let Ok(path) = cursor_path(listener_name) else {
+        return Cursor::default();
+    };
+    match tokio::fs::read_to_string(&path).await {
+        Ok(raw) => serde_json::from_str(&raw).unwrap_or_default(),
+        Err(_) => Cursor::default(),
+    }
+}
+
+async fn save_cursor(listener_name: &str, cursor: &Cursor) -> Result<()> {
+    let path = cursor_path(listener_name)?;
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.ok();
+    }
+    let content = serde_json::to_string_pretty(cursor).context("serialize cursor")?;
+    tokio::fs::write(&path, content)
+        .await
+        .with_context(|| format!("write cursor {}", path.display()))?;
+    Ok(())
+}
+
+/// Spawn one background polling task per enabled `connector = "gmail"`
+/// listener in `listeners`. Non-gmail / disabled listeners are logged and
+/// skipped (DOC-54 §7.5: `google-calendar` is a documented-but-unimplemented
+/// connector in this slice).
+///
+/// Why: The harness-runtime entry point — called once from the API server's
+/// `serve_with_config` bootstrap so listeners only run inside the long-lived
+/// server process, never a one-shot CLI invocation.
+/// What: Fire-and-forget `tokio::task::spawn` per listener, mirroring the
+/// existing background-docs-index-build pattern in `api/server/routes.rs`.
+pub fn spawn_listeners(listeners: Vec<ListenerConfig>, project_path: PathBuf) {
+    for cfg in listeners {
+        if !cfg.enabled {
+            tracing::debug!(listener = %cfg.name, "listener disabled; skipping");
+            continue;
+        }
+        match cfg.connector.as_str() {
+            "gmail" => {
+                let project_path = project_path.clone();
+                tracing::info!(listener = %cfg.name, interval_secs = cfg.poll_interval_secs, "starting gmail listener poll loop");
+                tokio::task::spawn(run_gmail_poll_loop(cfg, project_path));
+            }
+            other => {
+                tracing::warn!(
+                    listener = %cfg.name,
+                    connector = %other,
+                    "listener connector not yet implemented; skipping (deferred — see PR body)"
+                );
+            }
+        }
+    }
+}
+
+/// Long-running poll loop for one Gmail listener. Never returns under
+/// normal operation; a `BaseClient::new()` construction failure logs and
+/// exits (nothing to retry — that's a local config problem, not transient).
+async fn run_gmail_poll_loop(cfg: ListenerConfig, project_path: PathBuf) {
+    let client = match BaseClient::new() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(listener = %cfg.name, error = %e, "gmail listener: failed to construct BaseClient; not starting");
+            return;
+        }
+    };
+    // Seed dedup from the durable log so a process restart doesn't replay
+    // events already appended (DOC-54 §7.3.3).
+    let dedup = Arc::new(Mutex::new(
+        EventStore::recent_ids(500).await.unwrap_or_default(),
+    ));
+    let mut backoff = Duration::from_secs(MIN_BACKOFF_SECS);
+
+    loop {
+        match poll_once(&client, &cfg, &dedup, &project_path).await {
+            Ok(n) => {
+                if n > 0 {
+                    tracing::info!(listener = %cfg.name, new_events = n, "gmail listener: poll cycle found new events");
+                }
+                backoff = Duration::from_secs(MIN_BACKOFF_SECS);
+            }
+            Err(e) if is_410_gone(&e) => {
+                tracing::warn!(listener = %cfg.name, "gmail listener: cursor invalid (410 GONE); re-baselining");
+                if let Ok(path) = cursor_path(&cfg.name) {
+                    let _ = tokio::fs::remove_file(&path).await;
+                }
+                backoff = Duration::from_secs(MIN_BACKOFF_SECS);
+            }
+            Err(e) => {
+                tracing::warn!(listener = %cfg.name, error = %e, backoff_secs = backoff.as_secs(), "gmail listener: poll error; backing off");
+                tokio::time::sleep(jittered(backoff)).await;
+                backoff = next_backoff(backoff);
+                continue;
+            }
+        }
+        tokio::time::sleep(Duration::from_secs(cfg.poll_interval_secs)).await;
+    }
+}
+
+fn next_backoff(current: Duration) -> Duration {
+    let doubled = current.saturating_mul(2);
+    let cap = Duration::from_secs(MAX_BACKOFF_SECS);
+    if doubled > cap { cap } else { doubled }
+}
+
+/// Add up to 20% jitter to a backoff duration so multiple listeners don't
+/// retry in lockstep.
+fn jittered(d: Duration) -> Duration {
+    let jitter_ms = (d.as_millis() as u64 / 5).max(1);
+    let extra = fastrand_like(jitter_ms);
+    d + Duration::from_millis(extra)
+}
+
+/// Tiny dependency-free jitter source (avoids pulling in a `rand` call for
+/// one non-cryptographic offset); seeded from the current time's
+/// sub-second nanos.
+fn fastrand_like(bound_ms: u64) -> u64 {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0);
+    if bound_ms == 0 { 0 } else { nanos % bound_ms }
+}
+
+/// Whether `e` (or anything in its `anyhow` context chain) represents an
+/// HTTP 410 Gone response.
+///
+/// Why: `anyhow::Error::to_string()` (via `Display`) shows only the
+/// OUTERMOST `.context(...)` message, not the full chain — `BaseClient`'s
+/// underlying `"google api error 410 Gone: ..."` would be invisible to a
+/// naive `to_string().contains("410")` check once wrapped by
+/// `.context("list_gmail_history")`. Walking `e.chain()` inspects every
+/// layer.
+/// Test: `is_410_gone_detects_status_text`.
+fn is_410_gone(e: &anyhow::Error) -> bool {
+    e.chain().any(|cause| cause.to_string().contains("410"))
+}
+
+/// One poll cycle: bootstrap-or-fetch, append new events, advance the
+/// cursor. Returns the number of new events appended.
+async fn poll_once(
+    client: &BaseClient,
+    cfg: &ListenerConfig,
+    dedup: &Arc<Mutex<HashSet<String>>>,
+    project_path: &Path,
+) -> Result<usize> {
+    let account = cfg.identity.as_deref();
+    let cursor = load_cursor(&cfg.name).await;
+
+    let Some(history_id) = cursor.history_id else {
+        // No cursor yet: baseline to "now" via the profile's current
+        // historyId (DOC-54 §7.1.2 — never replay the whole mailbox).
+        let profile = get_gmail_profile(client, account)
+            .await
+            .context("get_gmail_profile (cursor bootstrap)")?;
+        let history_id = profile
+            .get("historyId")
+            .and_then(|v| v.as_str())
+            .context("gmail profile response missing historyId")?
+            .to_string();
+        save_cursor(
+            &cfg.name,
+            &Cursor {
+                history_id: Some(history_id),
+            },
+        )
+        .await?;
+        tracing::info!(listener = %cfg.name, "gmail listener: cursor bootstrapped");
+        return Ok(0);
+    };
+
+    let label = cfg.filter.single_gmail_label();
+    let resp = list_gmail_history(client, account, &history_id, label)
+        .await
+        .context("list_gmail_history")?;
+
+    let next_history_id = resp
+        .get("historyId")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+
+    let mut new_count = 0usize;
+    if let Some(history) = resp.get("history").and_then(|v| v.as_array()) {
+        for record in history {
+            let Some(added) = record.get("messagesAdded").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for entry in added {
+                let Some(msg) = entry.get("message") else {
+                    continue;
+                };
+                let Some(msg_id) = msg.get("id").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                let event_id = format!("{}:{}", cfg.name, msg_id);
+                {
+                    let mut seen = dedup.lock().await;
+                    if seen.contains(&event_id) {
+                        continue;
+                    }
+                    seen.insert(event_id.clone());
+                }
+
+                let event = match fetch_event_summary(client, account, &cfg.name, msg_id, &event_id)
+                    .await
+                {
+                    Ok(ev) => ev,
+                    Err(e) => {
+                        tracing::warn!(listener = %cfg.name, message_id = %msg_id, error = %e, "gmail listener: failed to fetch message summary; skipping");
+                        continue;
+                    }
+                };
+
+                if let Err(e) = EventStore::append(&event).await {
+                    tracing::warn!(listener = %cfg.name, error = %e, "gmail listener: failed to persist event");
+                }
+                new_count += 1;
+
+                let included = EventStore::is_event_type_included(&event.event_type).await;
+                // Mirror onto the live harness event bus (#3820) so the GUI's
+                // Events pane updates in real time via the SAME SSE/Tauri
+                // bridge every other event type already uses — see
+                // `crate::events::Event::ListenerEventReceived`'s doc comment.
+                crate::events::publish(crate::events::Event::ListenerEventReceived {
+                    listener_id: event.listener_id.clone(),
+                    provider: event.provider.clone(),
+                    event_type: event.event_type.clone(),
+                    summary: listener_event_summary(&event),
+                    included,
+                });
+
+                if included {
+                    let outcome = wake::wake_bound_agents(project_path, &event).await;
+                    tracing::info!(listener = %cfg.name, event_id = %event.id, outcome = ?outcome, "wake decision recorded");
+                } else {
+                    tracing::debug!(listener = %cfg.name, event_id = %event.id, "event type excluded; no wake attempted");
+                }
+            }
+        }
+    }
+
+    if let Some(next_id) = next_history_id {
+        save_cursor(
+            &cfg.name,
+            &Cursor {
+                history_id: Some(next_id),
+            },
+        )
+        .await?;
+    }
+
+    Ok(new_count)
+}
+
+/// Fetch a new message's headers/snippet and build its `StoredEvent`.
+async fn fetch_event_summary(
+    client: &BaseClient,
+    account: Option<&str>,
+    listener_id: &str,
+    message_id: &str,
+    event_id: &str,
+) -> Result<StoredEvent> {
+    let msg = trusty_gworkspace::api::services::gmail::messages::get_gmail_message_content(
+        client,
+        serde_json::json!({ "message_id": message_id, "account": account }),
+    )
+    .await
+    .context("get_gmail_message_content")?;
+    Ok(stored_event_from_message(listener_id, event_id, &msg))
+}
+
+/// Fold a `StoredEvent`'s summary fields into one glanceable line for the
+/// live event bus (`Event::ListenerEventReceived::summary`).
+fn listener_event_summary(event: &StoredEvent) -> String {
+    match (&event.from, &event.subject) {
+        (Some(from), Some(subject)) => format!("{from}: {subject}"),
+        (Some(from), None) => from.clone(),
+        (None, Some(subject)) => subject.clone(),
+        (None, None) => event
+            .snippet
+            .clone()
+            .unwrap_or_else(|| event.event_type.clone()),
+    }
+}
+
+/// Pure extraction of summary fields from a Gmail `messages.get(format=full)`
+/// JSON response — split out for unit testing without a live client.
+fn stored_event_from_message(listener_id: &str, event_id: &str, msg: &Value) -> StoredEvent {
+    let headers = msg
+        .get("payload")
+        .and_then(|p| p.get("headers"))
+        .and_then(|h| h.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let header = |name: &str| -> Option<String> {
+        headers
+            .iter()
+            .find(|h| {
+                h.get("name")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|n| n.eq_ignore_ascii_case(name))
+            })
+            .and_then(|h| h.get("value").and_then(|v| v.as_str()))
+            .map(String::from)
+    };
+    StoredEvent {
+        id: event_id.to_string(),
+        listener_id: listener_id.to_string(),
+        provider: "gmail".to_string(),
+        event_type: "message.received".to_string(),
+        ts: chrono::Utc::now().to_rfc3339(),
+        from: header("From"),
+        subject: header("Subject"),
+        snippet: msg
+            .get("snippet")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        included: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_backoff_doubles_and_caps() {
+        let start = Duration::from_secs(MIN_BACKOFF_SECS);
+        let doubled = next_backoff(start);
+        assert_eq!(doubled, Duration::from_secs(MIN_BACKOFF_SECS * 2));
+
+        let near_cap = Duration::from_secs(MAX_BACKOFF_SECS - 1);
+        let capped = next_backoff(near_cap);
+        assert_eq!(capped, Duration::from_secs(MAX_BACKOFF_SECS));
+
+        let already_at_cap = Duration::from_secs(MAX_BACKOFF_SECS);
+        assert_eq!(
+            next_backoff(already_at_cap),
+            Duration::from_secs(MAX_BACKOFF_SECS)
+        );
+    }
+
+    #[test]
+    fn is_410_gone_detects_status_text() {
+        use anyhow::Context;
+        // Wrapped with an outer `.context(...)` exactly like `poll_once`
+        // does, so this pins the chain-walking behavior (not just the
+        // outermost message).
+        let e: anyhow::Error =
+            Err::<(), _>(anyhow::anyhow!("google api error 410 Gone: cursor expired"))
+                .context("list_gmail_history")
+                .unwrap_err();
+        assert!(is_410_gone(&e));
+
+        let other: anyhow::Error = Err::<(), _>(anyhow::anyhow!(
+            "google api error 500 Internal Server Error: oops"
+        ))
+        .context("list_gmail_history")
+        .unwrap_err();
+        assert!(!is_410_gone(&other));
+    }
+
+    #[test]
+    fn stored_event_from_message_extracts_summary_fields() {
+        let msg = serde_json::json!({
+            "snippet": "Want to come over Sunday?",
+            "payload": {
+                "headers": [
+                    { "name": "From", "value": "dad@family.com" },
+                    { "name": "Subject", "value": "Dinner Sunday?" },
+                ]
+            }
+        });
+        let event = stored_event_from_message("gmail-personal", "gmail-personal:m1", &msg);
+        assert_eq!(event.id, "gmail-personal:m1");
+        assert_eq!(event.provider, "gmail");
+        assert_eq!(event.event_type, "message.received");
+        assert_eq!(event.from.as_deref(), Some("dad@family.com"));
+        assert_eq!(event.subject.as_deref(), Some("Dinner Sunday?"));
+        assert_eq!(event.snippet.as_deref(), Some("Want to come over Sunday?"));
+    }
+}

--- a/crates/trusty-agents/src/listeners/poll.rs
+++ b/crates/trusty-agents/src/listeners/poll.rs
@@ -12,13 +12,23 @@
 //! -> bootstrap from `users.getProfile` (baseline to "now", no replay);
 //! cursor present -> `history.list(startHistoryId=cursor)`, dedup new
 //! message ids against an in-memory set seeded from the durable event log,
-//! fetch each new message's summary fields, append a `StoredEvent`, advance
-//! the cursor, and hand the event to `wake::wake_bound_agents` when it's
-//! event-type-included. `run_gmail_poll_loop` wraps that in exponential
-//! backoff-with-jitter on transient errors and an immediate cursor reset on
-//! `410 GONE`, per DOC-54 §7.3.4.
+//! fetch each new message's summary fields, append a `StoredEvent`
+//! (unconditionally — every event is durably stored regardless of wake
+//! outcome), and hand the event to `wake::wake_bound_agents` when it's
+//! event-type-included. A cycle-local `woke_this_cycle` flag threads through
+//! the per-event loop so at most ONE wake actually dispatches per
+//! `poll_once` call — every qualifying event after the first is rate-limited
+//! (`wake::WakeOutcome::RateLimited`), never dispatched. `run_gmail_poll_loop`
+//! wraps that in exponential backoff-with-jitter on transient errors and an
+//! immediate cursor reset on `410 GONE`, per DOC-54 §7.3.4. The cursor file
+//! itself is written atomically (temp-then-rename) and a parse failure on
+//! read is logged, not silently swallowed.
 //! Test: `next_backoff_doubles_and_caps`, `is_410_gone_detects_status_text`,
-//! `stored_event_from_message_extracts_summary_fields`. The network-calling
+//! `stored_event_from_message_extracts_summary_fields`,
+//! `load_cursor_warns_and_defaults_on_malformed_json`,
+//! `save_cursor_then_load_cursor_round_trips`. The wake-cycle cap itself is
+//! pinned in `wake::tests::gate_wake_caps_to_one_dispatch_per_cycle` (the
+//! pure decision `wake_bound_agents` delegates to). The network-calling
 //! path is exercised manually against a live `bob-personal` mailbox (see the
 //! PR body's proof plan) — no mock Gmail server exists in this crate.
 
@@ -51,25 +61,68 @@ fn cursor_path(listener_name: &str) -> Result<PathBuf> {
     Ok(events_dir()?.join(format!("cursor-{listener_name}.json")))
 }
 
+/// Load the persisted cursor for `listener_name`.
+///
+/// Why (#3820 code-critic MEDIUM-3): a missing cursor file is the expected,
+/// silent "first run" case (`Cursor::default()`, no log) — but a PRESENT
+/// file that fails to parse (truncated write, disk corruption, a manual
+/// edit gone wrong) is an anomaly the operator should see in the log rather
+/// than have silently swallowed into "treat as absent," which quietly
+/// re-baselines the cursor (and, on a Gmail listener, skips whatever
+/// history the corrupt file's cursor would have covered).
+/// What: `Cursor::default()` on both a missing file and a read error;
+/// `tracing::warn!` + `Cursor::default()` on a parse failure specifically.
 async fn load_cursor(listener_name: &str) -> Cursor {
     let Ok(path) = cursor_path(listener_name) else {
         return Cursor::default();
     };
     match tokio::fs::read_to_string(&path).await {
-        Ok(raw) => serde_json::from_str(&raw).unwrap_or_default(),
+        Ok(raw) => match serde_json::from_str(&raw) {
+            Ok(cursor) => cursor,
+            Err(e) => {
+                tracing::warn!(
+                    listener = %listener_name,
+                    path = %path.display(),
+                    error = %e,
+                    "cursor file failed to parse; re-baselining (treating as absent)"
+                );
+                Cursor::default()
+            }
+        },
         Err(_) => Cursor::default(),
     }
 }
 
+/// Persist the cursor for `listener_name`, atomically.
+///
+/// Why (#3820 code-critic MEDIUM-3): a direct `tokio::fs::write` to the
+/// live cursor path can be interrupted mid-write (process kill, power
+/// loss) leaving a truncated/malformed file — exactly the corruption case
+/// `load_cursor`'s parse-failure branch above now has to warn about
+/// instead of silently absorbing. Writing to a sibling `.tmp` path then
+/// renaming over the target makes the update atomic on POSIX filesystems:
+/// a crash mid-write leaves either the OLD cursor file intact or the fully-
+/// written NEW one, never a torn one.
+/// What: Write-then-rename; the temp file's name reuses the target's file
+/// name with a `.tmp` suffix appended (not a `with_extension` swap, so a
+/// `cursor-gmail-personal.json` target's temp file is
+/// `cursor-gmail-personal.json.tmp`, unambiguous even if a listener name
+/// itself contained a dot).
 async fn save_cursor(listener_name: &str, cursor: &Cursor) -> Result<()> {
     let path = cursor_path(listener_name)?;
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await.ok();
     }
     let content = serde_json::to_string_pretty(cursor).context("serialize cursor")?;
-    tokio::fs::write(&path, content)
+    let mut tmp_name = path.clone().into_os_string();
+    tmp_name.push(".tmp");
+    let tmp_path = PathBuf::from(tmp_name);
+    tokio::fs::write(&tmp_path, &content)
         .await
-        .with_context(|| format!("write cursor {}", path.display()))?;
+        .with_context(|| format!("write temp cursor {}", tmp_path.display()))?;
+    tokio::fs::rename(&tmp_path, &path)
+        .await
+        .with_context(|| format!("rename temp cursor into place {}", path.display()))?;
     Ok(())
 }
 
@@ -233,6 +286,12 @@ async fn poll_once(
         .map(str::to_string);
 
     let mut new_count = 0usize;
+    // #3820 code-critic CRITICAL fix: cycle-local gate enforcing "max one
+    // wake per poll cycle" — every qualifying event in THIS `poll_once` call
+    // after the first is rate-limited (see `wake::gate_wake`), never
+    // dispatched. Every event is still appended to the store above
+    // regardless of this flag — only the LLM dispatch is gated.
+    let mut woke_this_cycle = false;
     if let Some(history) = resp.get("history").and_then(|v| v.as_array()) {
         for record in history {
             let Some(added) = record.get("messagesAdded").and_then(|v| v.as_array()) else {
@@ -283,7 +342,11 @@ async fn poll_once(
                 });
 
                 if included {
-                    let outcome = wake::wake_bound_agents(project_path, &event).await;
+                    let outcome =
+                        wake::wake_bound_agents(project_path, &event, woke_this_cycle).await;
+                    if matches!(outcome, wake::WakeOutcome::Woke { .. }) {
+                        woke_this_cycle = true;
+                    }
                     tracing::info!(listener = %cfg.name, event_id = %event.id, outcome = ?outcome, "wake decision recorded");
                 } else {
                     tracing::debug!(listener = %cfg.name, event_id = %event.id, "event type excluded; no wake attempted");
@@ -373,6 +436,12 @@ fn stored_event_from_message(listener_id: &str, event_id: &str, msg: &Value) -> 
 }
 
 #[cfg(test)]
+// The cursor tests below deliberately hold `HOME_LOCK` across `.await`
+// points (the whole point of the lock — see `crate::test_env`'s module
+// doc); matches the existing `#[allow(clippy::await_holding_lock)]` used
+// for the identical pattern elsewhere in this crate
+// (`mcp::config::tests::mod`, `listeners::store::tests`).
+#[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
 
@@ -431,5 +500,76 @@ mod tests {
         assert_eq!(event.from.as_deref(), Some("dad@family.com"));
         assert_eq!(event.subject.as_deref(), Some("Dinner Sunday?"));
         assert_eq!(event.snippet.as_deref(), Some("Want to come over Sunday?"));
+    }
+
+    use crate::test_env::HOME_LOCK;
+
+    fn set_test_home(dir: &std::path::Path) {
+        // SAFETY: caller holds `HOME_LOCK` for the duration of the test (see
+        // `crate::test_env`'s module doc) so no other thread observes `HOME`
+        // mid-mutation.
+        unsafe {
+            std::env::set_var("HOME", dir);
+        }
+    }
+
+    /// #3820 code-critic MEDIUM-3: `save_cursor` writes atomically
+    /// (temp-then-rename) and `load_cursor` reads back exactly what was
+    /// written.
+    #[tokio::test]
+    async fn save_cursor_then_load_cursor_round_trips() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        set_test_home(tmp.path());
+
+        let cursor = Cursor {
+            history_id: Some("12345".to_string()),
+        };
+        save_cursor("gmail-personal", &cursor).await.unwrap();
+
+        let loaded = load_cursor("gmail-personal").await;
+        assert_eq!(loaded.history_id.as_deref(), Some("12345"));
+
+        // The temp file must not be left behind after a successful rename.
+        let tmp_path = events_dir().unwrap().join("cursor-gmail-personal.json.tmp");
+        assert!(
+            !tmp_path.exists(),
+            "temp cursor file should be renamed away"
+        );
+    }
+
+    /// #3820 code-critic MEDIUM-3: a present-but-malformed cursor file must
+    /// NOT be silently treated identically to "no cursor" without a trace —
+    /// this pins the fallback BEHAVIOR (defaults to no cursor, so the next
+    /// poll re-baselines); the `tracing::warn!` emission itself isn't
+    /// asserted here (no `tracing-test` dependency in this crate), but the
+    /// distinct code path is exercised.
+    #[tokio::test]
+    async fn load_cursor_warns_and_defaults_on_malformed_json() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        set_test_home(tmp.path());
+
+        let path = cursor_path("gmail-personal").unwrap();
+        tokio::fs::create_dir_all(path.parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(&path, b"{not valid json").await.unwrap();
+
+        let loaded = load_cursor("gmail-personal").await;
+        assert!(
+            loaded.history_id.is_none(),
+            "malformed cursor file must fall back to no-cursor, not panic or propagate"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_cursor_defaults_when_file_absent() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        set_test_home(tmp.path());
+
+        let loaded = load_cursor("never-seen-listener").await;
+        assert!(loaded.history_id.is_none());
     }
 }

--- a/crates/trusty-agents/src/listeners/store.rs
+++ b/crates/trusty-agents/src/listeners/store.rs
@@ -1,0 +1,332 @@
+//! Append-only JSONL event store + per-event-type include/exclude state
+//! (#3820, DOC-54 SPEC-AGENTS-06 §7.4).
+//!
+//! Why: The Events pane (#3818) must show every event that passed stage-one
+//! (listener-level) filtering, tagged by listener, REGARDLESS of whether any
+//! agent is bound to it — and let the user flip an event TYPE between
+//! included/excluded without losing history. A plain append-only JSONL file
+//! is the simplest structure that satisfies "durable, newest-first list,
+//! survives restarts" for a single-node desktop harness; a sled/redb store
+//! would be over-engineering for the event volumes an eventstream listener
+//! demo produces (dozens, not millions, of rows).
+//! What: [`StoredEvent`] is the normalized on-disk record. [`EventStore`]
+//! appends events, reads them back (newest first), and persists per-
+//! event-type `included` state to a sibling `filters.json`. Both live under
+//! `~/.trusty-agents/events/`.
+//! Test: `append_and_read_round_trips`, `dedup_seed_loads_recent_ids`,
+//! `filter_toggle_persists_and_applies_default_included`,
+//! `read_events_returns_newest_first`.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// One normalized event surfaced by a listener onto the harness event bus.
+///
+/// Why: Every connector (Gmail today, Calendar/Slack later) emits wildly
+/// different native payloads; the Events pane and the agent-wake path both
+/// need one small, stable shape rather than connector-specific structs.
+/// What: `id` is the STABLE IDEMPOTENT id used for dedup (DOC-54 §7.3.3) —
+/// `"{listener_id}:{provider_message_id}"`. `from`/`subject`/`snippet` are
+/// the summary fields DEADLINE-BUILD item 3 asks for; all `Option` since
+/// not every future connector/event type has all three (Calendar events
+/// have no `from`, for instance).
+/// Test: `append_and_read_round_trips`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StoredEvent {
+    pub id: String,
+    pub listener_id: String,
+    pub provider: String,
+    pub event_type: String,
+    pub ts: String,
+    #[serde(default)]
+    pub from: Option<String>,
+    #[serde(default)]
+    pub subject: Option<String>,
+    #[serde(default)]
+    pub snippet: Option<String>,
+    /// Snapshot of the include/exclude state AT INGEST TIME. The
+    /// authoritative, current state is `EventStore::is_included`
+    /// (evaluated live from `filters.json` against `event_type`) — this
+    /// field is a convenience for API responses that shouldn't need a
+    /// second lookup, and is refreshed by `EventStore::read_events`.
+    pub included: bool,
+}
+
+/// Root directory for listener event persistence: `~/.trusty-agents/events/`.
+///
+/// Why: Centralised so tests can override via `$HOME` exactly like
+/// `GlobalConfig::config_path` does, and so every reader/writer agrees on
+/// the layout.
+pub fn events_dir() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not determine $HOME directory")?;
+    Ok(home.join(".trusty-agents").join("events"))
+}
+
+fn events_log_path() -> Result<PathBuf> {
+    Ok(events_dir()?.join("events.jsonl"))
+}
+
+fn filters_path() -> Result<PathBuf> {
+    Ok(events_dir()?.join("filters.json"))
+}
+
+/// Append-only event log + include/exclude filter state.
+///
+/// Why: A thin, stateless-between-calls wrapper (no in-memory cache) keeps
+/// this correct across the polling engine (a background tokio task) and the
+/// API handlers (request-scoped) writing/reading the SAME files without
+/// coordinating through shared process state — the filesystem is the source
+/// of truth. Read/write volumes here are low enough (demo-scale event
+/// counts, on a local disk) that re-reading per call is not a measurable
+/// cost, and it trades a small amount of I/O for zero cross-task locking
+/// complexity, matching the code-reduction-first principle.
+/// Test: `append_and_read_round_trips`.
+pub struct EventStore;
+
+impl EventStore {
+    /// Append one event to the JSONL log. Creates `~/.trusty-agents/events/`
+    /// if absent.
+    ///
+    /// Why: Append-only means a torn write can corrupt at most the LAST
+    /// line, never earlier history — acceptable for a local demo store; a
+    /// production-grade store would fsync + checksum, out of scope here.
+    /// What: Serializes `event` as one JSON line, appended with `\n`.
+    /// Test: `append_and_read_round_trips`.
+    pub async fn append(event: &StoredEvent) -> Result<()> {
+        let path = events_log_path()?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("failed to create events dir {}", parent.display()))?;
+        }
+        let mut line = serde_json::to_string(event).context("serialize StoredEvent")?;
+        line.push('\n');
+        use tokio::io::AsyncWriteExt;
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await
+            .with_context(|| format!("failed to open events log {}", path.display()))?;
+        file.write_all(line.as_bytes())
+            .await
+            .context("append event line")?;
+        Ok(())
+    }
+
+    /// Read all events, newest first, with `included` refreshed from the
+    /// current `filters.json` state (so a filter toggle retroactively
+    /// re-labels past rows, matching the Events pane's "excluded rows stay
+    /// visible, muted" spec — DOC-54 §7.4 / issue #3818).
+    ///
+    /// Why: `limit` bounds the response for a long-lived demo/dev process;
+    /// `None` returns everything (fine at demo scale).
+    /// What: Missing log file returns an empty `Vec`, never an error (a
+    /// listener that has never fired yet is a valid, common state).
+    /// Test: `read_events_returns_newest_first`,
+    /// `filter_toggle_persists_and_applies_default_included`.
+    pub async fn read_events(limit: Option<usize>) -> Result<Vec<StoredEvent>> {
+        let path = events_log_path()?;
+        let raw = match tokio::fs::read_to_string(&path).await {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => {
+                return Err(e).with_context(|| format!("failed to read {}", path.display()));
+            }
+        };
+        let filters = Self::load_filters().await.unwrap_or_default();
+        let mut events: Vec<StoredEvent> = raw
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter_map(|l| match serde_json::from_str::<StoredEvent>(l) {
+                Ok(mut ev) => {
+                    ev.included = is_included(&filters, &ev.event_type);
+                    Some(ev)
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "skipping malformed event log line");
+                    None
+                }
+            })
+            .collect();
+        events.reverse(); // newest first
+        if let Some(n) = limit {
+            events.truncate(n);
+        }
+        Ok(events)
+    }
+
+    /// Seed a dedup set from the most recent `n` persisted event ids.
+    ///
+    /// Why: The polling engine's in-memory dedup cache (DOC-54 §7.3.3) must
+    /// not replay events already appended by a PRIOR process run — seeding
+    /// from the tail of the durable log on startup closes that gap cheaply
+    /// without needing a separate dedup index file.
+    /// What: Reads at most `n` most-recent ids (newest-first order from
+    /// `read_events`).
+    /// Test: `dedup_seed_loads_recent_ids`.
+    pub async fn recent_ids(n: usize) -> Result<HashSet<String>> {
+        let events = Self::read_events(Some(n)).await?;
+        Ok(events.into_iter().map(|e| e.id).collect())
+    }
+
+    /// Load the persisted event-type -> included map. Missing file = empty
+    /// map (every type defaults to included — see [`is_included`]).
+    pub async fn load_filters() -> Result<std::collections::HashMap<String, bool>> {
+        let path = filters_path()?;
+        match tokio::fs::read_to_string(&path).await {
+            Ok(raw) => {
+                serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Default::default()),
+            Err(e) => Err(e).with_context(|| format!("read {}", path.display())),
+        }
+    }
+
+    /// Set (and persist) the included/excluded state for one event type.
+    ///
+    /// Why: Backs `POST /api/listener-events/filter` — the Events pane's
+    /// per-type include/exclude toggle (#3818).
+    /// What: Read-modify-write of `filters.json`.
+    /// Test: `filter_toggle_persists_and_applies_default_included`.
+    pub async fn set_filter(event_type: &str, included: bool) -> Result<()> {
+        let path = filters_path()?;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("failed to create events dir {}", parent.display()))?;
+        }
+        let mut filters = Self::load_filters().await.unwrap_or_default();
+        filters.insert(event_type.to_string(), included);
+        let content = serde_json::to_string_pretty(&filters).context("serialize filters")?;
+        tokio::fs::write(&path, content)
+            .await
+            .with_context(|| format!("write {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Whether `event_type` is currently included, per persisted filter
+    /// state (default `true` — new event types are included until a user
+    /// explicitly excludes them).
+    ///
+    /// Why: Both the API list handler and the agent-wake stage-two check
+    /// (`crate::listeners::wake`) need the SAME answer for "is this type
+    /// currently on" — centralising avoids the two drifting.
+    /// Test: `filter_toggle_persists_and_applies_default_included`.
+    pub async fn is_event_type_included(event_type: &str) -> bool {
+        let filters = Self::load_filters().await.unwrap_or_default();
+        is_included(&filters, event_type)
+    }
+}
+
+fn is_included(filters: &std::collections::HashMap<String, bool>, event_type: &str) -> bool {
+    filters.get(event_type).copied().unwrap_or(true)
+}
+
+#[cfg(test)]
+// Every test here holds `HOME_LOCK` across `.await` points DELIBERATELY —
+// that's the whole point of the lock (serialize `$HOME`-mutating tests
+// across the crate, see `crate::test_env`'s module doc). Matches the
+// existing `#[allow(clippy::await_holding_lock)]` in
+// `mcp::config::tests::mod` for the identical pattern.
+#[allow(clippy::await_holding_lock)]
+mod tests {
+    use super::*;
+    use crate::test_env::HOME_LOCK;
+
+    fn set_test_home(dir: &std::path::Path) {
+        // SAFETY: caller holds `HOME_LOCK` for the duration of the test (see
+        // `crate::test_env`'s module doc) so no other thread observes `HOME`
+        // mid-mutation.
+        unsafe {
+            std::env::set_var("HOME", dir);
+        }
+    }
+
+    fn sample_event(id: &str, event_type: &str) -> StoredEvent {
+        StoredEvent {
+            id: id.to_string(),
+            listener_id: "gmail-personal".to_string(),
+            provider: "gmail".to_string(),
+            event_type: event_type.to_string(),
+            ts: "2026-07-24T12:00:00Z".to_string(),
+            from: Some("someone@example.com".to_string()),
+            subject: Some("Hello".to_string()),
+            snippet: Some("snippet text".to_string()),
+            included: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn append_and_read_round_trips() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        set_test_home(tmp.path());
+        let ev = sample_event("gmail-personal:msg1", "message.received");
+        EventStore::append(&ev).await.unwrap();
+        let events = EventStore::read_events(None).await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].id, "gmail-personal:msg1");
+        assert_eq!(events[0].subject.as_deref(), Some("Hello"));
+    }
+
+    #[tokio::test]
+    async fn read_events_returns_newest_first() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        set_test_home(tmp.path());
+        EventStore::append(&sample_event("id1", "message.received"))
+            .await
+            .unwrap();
+        EventStore::append(&sample_event("id2", "message.received"))
+            .await
+            .unwrap();
+        let events = EventStore::read_events(None).await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].id, "id2", "newest appended must be first");
+        assert_eq!(events[1].id, "id1");
+    }
+
+    #[tokio::test]
+    async fn dedup_seed_loads_recent_ids() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        set_test_home(tmp.path());
+        EventStore::append(&sample_event("id1", "message.received"))
+            .await
+            .unwrap();
+        EventStore::append(&sample_event("id2", "message.received"))
+            .await
+            .unwrap();
+        let ids = EventStore::recent_ids(10).await.unwrap();
+        assert!(ids.contains("id1"));
+        assert!(ids.contains("id2"));
+    }
+
+    #[tokio::test]
+    async fn filter_toggle_persists_and_applies_default_included() {
+        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        set_test_home(tmp.path());
+        // Default (no filters.json yet): included.
+        assert!(EventStore::is_event_type_included("message.received").await);
+
+        EventStore::set_filter("message.received", false)
+            .await
+            .unwrap();
+        assert!(!EventStore::is_event_type_included("message.received").await);
+
+        // A never-toggled type stays included.
+        assert!(EventStore::is_event_type_included("event.created").await);
+
+        // read_events reflects the retroactive exclusion.
+        EventStore::append(&sample_event("id1", "message.received"))
+            .await
+            .unwrap();
+        let events = EventStore::read_events(None).await.unwrap();
+        assert!(!events[0].included);
+    }
+}

--- a/crates/trusty-agents/src/listeners/wake.rs
+++ b/crates/trusty-agents/src/listeners/wake.rs
@@ -1,0 +1,373 @@
+//! Stage-two filtering + agent wake dispatch (#3820, DOC-54 SPEC-AGENTS-06
+//! §7.4, issue #3817).
+//!
+//! Why: Ingestion (stage one, `crate::listeners::poll`) is fully
+//! deterministic and spends no inference. Waking an agent is the ONLY place
+//! inference is spent, so this module is the single choke point that
+//! decides "does this specific event reach this specific agent's chat as a
+//! reaction" — matching every agent's declared `[[listeners]]` bindings
+//! against the event, then calling the SAME persona-chat entry point
+//! (`ctrl::pm_task::dispatch::persona::run_pm_task_with_persona`) the `/agent`
+//! REPL command uses, so a wake reaction is indistinguishable in history
+//! from a normal chat turn (speaker attribution = the agent).
+//! What: `wake_bound_agents` scans the agents directories for packages
+//! declaring a `[[listeners]]` binding to the firing listener, applies each
+//! binding's stage-two filter (`event_types` + `from`/`exclude_labels`), and
+//! for the first match (rate-limited to one wake per poll cycle per DEADLINE
+//! BUILD scope) builds a prompt combining the event summary with the
+//! agent's `events/<connector>.md` instructions (#3817) and dispatches it
+//! ask-first. Every wake DECISION (matched-and-woke, matched-but-rate-
+//! limited, no-binding-matched) is logged at info/debug level per the
+//! DEADLINE BUILD's "log every wake decision" requirement.
+//! Test: `sender_glob_matches_leading_and_trailing_wildcard`,
+//! `binding_matches_event_type_and_sender`,
+//! `binding_rejects_excluded_label`,
+//! `event_type_filter_empty_matches_any`.
+
+use std::path::Path;
+
+use crate::agents::AgentConfig;
+use crate::agents::agents_dir_candidates;
+use crate::ctrl::config::SessionOverrides;
+use crate::ctrl::pm_task::run_pm_task_with_persona;
+use crate::listeners::store::StoredEvent;
+
+/// Ask-first framing prepended to every wake turn (DOC-54 §2.1 "Ask" step).
+///
+/// Why: The product's core loop is Event -> Ask -> Learn -> Adapt; a woken
+/// agent must never silently act on an inbound event without first asking
+/// how to respond (unless it has separately LEARNED autonomy for that
+/// pattern, which is out of scope for this slice — every wake in this build
+/// is ask-first).
+const ASK_FIRST_PREAMBLE: &str = "A new event just arrived on one of your listeners. \
+Summarize it for the user and ASK how they'd like you to respond — do not take \
+any action (send email, modify calendar, etc.) without explicit confirmation, \
+unless you have previously been told you may act autonomously on exactly this \
+kind of event.";
+
+/// Simple glob matcher for sender patterns: a LEADING `*` is a suffix match
+/// (`"*@family.com"` matches any address ending in `@family.com`), a
+/// TRAILING `*` is a prefix match, no `*` is an exact match. Distinct from
+/// `ctrl::pm_task::helpers::match_any_glob` (tool-name globs, trailing-only)
+/// because DOC-54's own binding examples use a LEADING wildcard for sender
+/// patterns (`from = ["*@family.com"]`).
+fn sender_glob_matches(value: &str, pattern: &str) -> bool {
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        value.ends_with(suffix)
+    } else if let Some(prefix) = pattern.strip_suffix('*') {
+        value.starts_with(prefix)
+    } else {
+        value == pattern
+    }
+}
+
+/// Whether `binding` (an agent's stage-two filter) matches `event`.
+///
+/// Why: Pulled out as a pure function so the filter semantics (event-type
+/// allowlist, sender allowlist, label exclusion) are unit-testable without a
+/// live agent directory or LLM call.
+/// What: `event_types` empty = any type passes; non-empty = exact match
+/// required. `filter.from` empty = any sender passes; non-empty = at least
+/// one glob must match the event's `from` field (a `None` `from` fails a
+/// non-empty sender filter — DOC-54 gives listeners no way to match "unknown
+/// sender"). `filter.exclude_labels` is reserved for connectors that surface
+/// labels on the event; Gmail's `StoredEvent` doesn't carry labels yet in
+/// this slice, so it is currently a no-op guard (documented, not silently
+/// dropped) pending a `labels: Vec<String>` field on `StoredEvent`.
+/// Test: `binding_matches_event_type_and_sender`,
+/// `binding_rejects_excluded_label`, `event_type_filter_empty_matches_any`.
+pub fn binding_matches_event(
+    binding: &crate::listeners::config::AgentListenerBinding,
+    event: &StoredEvent,
+) -> bool {
+    if binding.name != event.listener_id {
+        return false;
+    }
+    if !binding.event_types.is_empty() && !binding.event_types.contains(&event.event_type) {
+        return false;
+    }
+    if !binding.filter.from.is_empty() {
+        let matches_sender = event.from.as_deref().is_some_and(|from| {
+            binding
+                .filter
+                .from
+                .iter()
+                .any(|pat| sender_glob_matches(from, pat))
+        });
+        if !matches_sender {
+            return false;
+        }
+    }
+    // exclude_labels: no-op today (see doc comment) — `StoredEvent` carries
+    // no label list yet.
+    true
+}
+
+/// Outcome of a single wake-matching pass over the agent roster, for
+/// logging/testing.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WakeOutcome {
+    /// No agent has a binding matching this event.
+    NoBindingMatched,
+    /// A match was found but skipped by the one-wake-per-poll-cycle limit.
+    RateLimited { agent: String },
+    /// The agent was dispatched successfully.
+    Woke { agent: String },
+    /// The agent was dispatched but the persona turn errored.
+    DispatchFailed { agent: String, error: String },
+}
+
+/// Scan the agents directories for a `[[listeners]]` binding matching
+/// `event`, and wake AT MOST ONE agent (DEADLINE BUILD scope: "max 1 wake
+/// per poll cycle").
+///
+/// Why: Centralising the roster scan here (rather than in `poll.rs`) keeps
+/// the polling loop's per-event work to "does anything care" without it
+/// needing to know how personas are dispatched.
+/// What: Enumerates directory-package agents across
+/// `agents_dir_candidates()` (mirrors the tiered resolution every other
+/// by-name lookup in this crate uses), loads each via
+/// `AgentConfig::by_name_async` (so `extends` chains resolve identically to
+/// every other dispatch path), and checks its `listeners` bindings against
+/// `event` via `binding_matches_event`. On the FIRST match it loads
+/// `agents/<name>/events/<connector>.md` (best-effort — missing file just
+/// means no extra instructions) and dispatches through
+/// `run_pm_task_with_persona`. Every branch is logged at info/debug so a
+/// demo run's wake decisions are auditable in the process log.
+/// Test: exercised end-to-end only via a live agent directory (manual demo
+/// script); the pure matching logic is covered by `binding_matches_event`'s
+/// tests.
+pub async fn wake_bound_agents(project_path: &Path, event: &StoredEvent) -> WakeOutcome {
+    let candidate_names = match candidate_agent_names().await {
+        Ok(names) => names,
+        Err(e) => {
+            tracing::warn!(error = %e, "wake_bound_agents: failed to enumerate agent directories");
+            return WakeOutcome::NoBindingMatched;
+        }
+    };
+
+    for name in candidate_names {
+        let cfg = match AgentConfig::by_name_async(&name).await {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if !cfg
+            .listeners
+            .iter()
+            .any(|b| binding_matches_event(b, event))
+        {
+            continue;
+        }
+        tracing::info!(
+            agent = %name,
+            listener = %event.listener_id,
+            event_id = %event.id,
+            event_type = %event.event_type,
+            "wake decision: binding matched"
+        );
+
+        let connector_instructions = load_connector_instructions(&name, &event.provider).await;
+        let user_input = build_wake_prompt(event, connector_instructions.as_deref());
+
+        return match run_pm_task_with_persona(
+            project_path,
+            &name,
+            &user_input,
+            &[],
+            None,
+            SessionOverrides::default(),
+        )
+        .await
+        {
+            Ok(_reply) => {
+                tracing::info!(agent = %name, event_id = %event.id, "wake decision: dispatched");
+                WakeOutcome::Woke { agent: name }
+            }
+            Err(e) => {
+                tracing::warn!(agent = %name, event_id = %event.id, error = %e, "wake decision: dispatch failed");
+                WakeOutcome::DispatchFailed {
+                    agent: name,
+                    error: e.to_string(),
+                }
+            }
+        };
+    }
+
+    tracing::debug!(
+        listener = %event.listener_id,
+        event_id = %event.id,
+        "wake decision: no agent binding matched"
+    );
+    WakeOutcome::NoBindingMatched
+}
+
+/// Enumerate directory-package agent names across the standard candidate
+/// dirs (project `.trusty-agents/agents/` then `$HOME/.trusty-agents/agents/`).
+///
+/// Why: `AgentListenerBinding` only lives on directory-package agents
+/// (`agent.toml` + `persona.md`) in this build's demo roster (izzie);
+/// scanning is a lightweight name enumeration, deferring the real parse (and
+/// `extends` resolution) to `AgentConfig::by_name_async` per name so this
+/// stays a thin directory listing, not a second config parser.
+async fn candidate_agent_names() -> anyhow::Result<Vec<String>> {
+    let mut names = Vec::new();
+    for dir in agents_dir_candidates() {
+        let Ok(mut entries) = tokio::fs::read_dir(&dir).await else {
+            continue;
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if name.starts_with('.') {
+                continue;
+            }
+            if tokio::fs::metadata(path.join("agent.toml")).await.is_ok() {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names.sort();
+    names.dedup();
+    Ok(names)
+}
+
+/// Best-effort load of `agents/<name>/events/<connector>.md` (#3817).
+///
+/// Why: Per-connector event instructions are optional — an agent bound to a
+/// listener without a matching `events/<connector>.md` file still wakes,
+/// just without the extra connector-specific guidance.
+async fn load_connector_instructions(agent_name: &str, connector: &str) -> Option<String> {
+    for dir in agents_dir_candidates() {
+        let path = dir
+            .join(agent_name)
+            .join("events")
+            .join(format!("{connector}.md"));
+        if let Ok(content) = tokio::fs::read_to_string(&path).await {
+            return Some(content);
+        }
+    }
+    None
+}
+
+/// Build the user-turn text for a wake dispatch: the ask-first preamble,
+/// optional connector-specific instructions, then the event summary.
+fn build_wake_prompt(event: &StoredEvent, connector_instructions: Option<&str>) -> String {
+    let mut out = String::new();
+    out.push_str(ASK_FIRST_PREAMBLE);
+    if let Some(instructions) = connector_instructions {
+        out.push_str("\n\n## Event-type instructions (");
+        out.push_str(&event.provider);
+        out.push_str(")\n");
+        out.push_str(instructions);
+    }
+    out.push_str("\n\n## Event\n");
+    out.push_str(&format!("- provider: {}\n", event.provider));
+    out.push_str(&format!("- type: {}\n", event.event_type));
+    if let Some(from) = &event.from {
+        out.push_str(&format!("- from: {from}\n"));
+    }
+    if let Some(subject) = &event.subject {
+        out.push_str(&format!("- subject: {subject}\n"));
+    }
+    if let Some(snippet) = &event.snippet {
+        out.push_str(&format!("- snippet: {snippet}\n"));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::listeners::config::{AgentBindingFilter, AgentListenerBinding};
+
+    fn sample_event() -> StoredEvent {
+        StoredEvent {
+            id: "gmail-personal:m1".to_string(),
+            listener_id: "gmail-personal".to_string(),
+            provider: "gmail".to_string(),
+            event_type: "message.received".to_string(),
+            ts: "2026-07-24T12:00:00Z".to_string(),
+            from: Some("dad@family.com".to_string()),
+            subject: Some("Dinner Sunday?".to_string()),
+            snippet: Some("Want to come over?".to_string()),
+            included: true,
+        }
+    }
+
+    #[test]
+    fn sender_glob_matches_leading_and_trailing_wildcard() {
+        assert!(sender_glob_matches("dad@family.com", "*@family.com"));
+        assert!(!sender_glob_matches("dad@work.com", "*@family.com"));
+        assert!(sender_glob_matches("bob@duetto.com", "bob@*"));
+        assert!(sender_glob_matches(
+            "exact@example.com",
+            "exact@example.com"
+        ));
+    }
+
+    #[test]
+    fn binding_matches_event_type_and_sender() {
+        let binding = AgentListenerBinding {
+            name: "gmail-personal".to_string(),
+            event_types: vec!["message.received".to_string()],
+            filter: AgentBindingFilter {
+                from: vec!["*@family.com".to_string()],
+                exclude_labels: vec![],
+            },
+        };
+        assert!(binding_matches_event(&binding, &sample_event()));
+    }
+
+    #[test]
+    fn binding_rejects_wrong_listener_name() {
+        let binding = AgentListenerBinding {
+            name: "calendar-personal".to_string(),
+            ..Default::default()
+        };
+        assert!(!binding_matches_event(&binding, &sample_event()));
+    }
+
+    #[test]
+    fn binding_rejects_non_matching_sender() {
+        let binding = AgentListenerBinding {
+            name: "gmail-personal".to_string(),
+            event_types: vec![],
+            filter: AgentBindingFilter {
+                from: vec!["*@duetto.com".to_string()],
+                exclude_labels: vec![],
+            },
+        };
+        assert!(!binding_matches_event(&binding, &sample_event()));
+    }
+
+    #[test]
+    fn binding_rejects_excluded_label() {
+        // Documented no-op today (StoredEvent carries no labels) — pinned so
+        // a future `labels` field addition has a test to update, not a
+        // silent behavior change.
+        let binding = AgentListenerBinding {
+            name: "gmail-personal".to_string(),
+            event_types: vec![],
+            filter: AgentBindingFilter {
+                from: vec![],
+                exclude_labels: vec!["PROMOTIONS".to_string()],
+            },
+        };
+        assert!(binding_matches_event(&binding, &sample_event()));
+    }
+
+    #[test]
+    fn event_type_filter_empty_matches_any() {
+        let binding = AgentListenerBinding {
+            name: "gmail-personal".to_string(),
+            event_types: vec![],
+            filter: AgentBindingFilter::default(),
+        };
+        assert!(binding_matches_event(&binding, &sample_event()));
+    }
+}

--- a/crates/trusty-agents/src/listeners/wake.rs
+++ b/crates/trusty-agents/src/listeners/wake.rs
@@ -13,16 +13,24 @@
 //! What: `wake_bound_agents` scans the agents directories for packages
 //! declaring a `[[listeners]]` binding to the firing listener, applies each
 //! binding's stage-two filter (`event_types` + `from`/`exclude_labels`), and
-//! for the first match (rate-limited to one wake per poll cycle per DEADLINE
-//! BUILD scope) builds a prompt combining the event summary with the
+//! for the first match builds a prompt combining the event summary with the
 //! agent's `events/<connector>.md` instructions (#3817) and dispatches it
-//! ask-first. Every wake DECISION (matched-and-woke, matched-but-rate-
-//! limited, no-binding-matched) is logged at info/debug level per the
-//! DEADLINE BUILD's "log every wake decision" requirement.
+//! ask-first. The one-wake-per-poll-cycle limit (DEADLINE BUILD scope) is
+//! enforced via `already_woke_this_cycle`, a flag the caller (`poll.rs`)
+//! threads through and sets once a dispatch actually succeeds within the
+//! current cycle — `gate_wake` is the pure decision function this enforces
+//! (code-critic #3820 CRITICAL fix: an earlier revision declared
+//! `WakeOutcome::RateLimited` but never constructed it, so every qualifying
+//! event in a cycle dispatched unconditionally). Every wake DECISION
+//! (matched-and-woke, matched-but-rate-limited, no-binding-matched,
+//! dispatch-failed) is logged at info/debug level per the DEADLINE BUILD's
+//! "log every wake decision" requirement.
 //! Test: `sender_glob_matches_leading_and_trailing_wildcard`,
 //! `binding_matches_event_type_and_sender`,
 //! `binding_rejects_excluded_label`,
-//! `event_type_filter_empty_matches_any`.
+//! `event_type_filter_empty_matches_any`,
+//! `gate_wake_caps_to_one_dispatch_per_cycle`,
+//! `gate_wake_no_match_is_never_rate_limited`.
 
 use std::path::Path;
 
@@ -117,88 +125,158 @@ pub enum WakeOutcome {
     DispatchFailed { agent: String, error: String },
 }
 
-/// Scan the agents directories for a `[[listeners]]` binding matching
-/// `event`, and wake AT MOST ONE agent (DEADLINE BUILD scope: "max 1 wake
-/// per poll cycle").
+/// Pure cycle-gate decision (#3820 code-critic CRITICAL fix): given whether
+/// this poll cycle has ALREADY dispatched a wake, and which agent (if any)
+/// matches the current event, decide what `wake_bound_agents` should do
+/// next.
 ///
-/// Why: Centralising the roster scan here (rather than in `poll.rs`) keeps
-/// the polling loop's per-event work to "does anything care" without it
-/// needing to know how personas are dispatched.
+/// Why: Split out from `wake_bound_agents` specifically so the
+/// one-wake-per-poll-cycle rule is pinned by a fast, deterministic unit
+/// test — the enumeration + dispatch machinery around it needs a live
+/// agent directory (and, for a real `Woke` outcome, live LLM credentials),
+/// neither of which this decision itself depends on.
+/// What: `None` matched agent -> `NoMatch` (never rate-limited — a
+/// non-matching event doesn't consume the cycle's one wake). `Some(name)`
+/// with the cycle already used -> `RateLimited(name)`. `Some(name)`
+/// otherwise -> `ShouldDispatch(name)`.
+/// Test: `gate_wake_caps_to_one_dispatch_per_cycle`,
+/// `gate_wake_no_match_is_never_rate_limited`.
+fn gate_wake(matched_agent: Option<String>, already_woke_this_cycle: bool) -> WakeGate {
+    match matched_agent {
+        None => WakeGate::NoMatch,
+        Some(name) if already_woke_this_cycle => WakeGate::RateLimited(name),
+        Some(name) => WakeGate::ShouldDispatch(name),
+    }
+}
+
+/// Result of [`gate_wake`] — an internal decision type, not the final
+/// [`WakeOutcome`] (dispatch can still fail after `ShouldDispatch`).
+#[derive(Debug, PartialEq, Eq)]
+enum WakeGate {
+    NoMatch,
+    RateLimited(String),
+    ShouldDispatch(String),
+}
+
+/// Scan the agents directories for the first `[[listeners]]` binding
+/// matching `event`, without dispatching anything.
+///
+/// Why: Split out from `wake_bound_agents` so the "does anything match"
+/// scan is a separate, awaitable step from the gate decision + dispatch —
+/// mirrors `gate_wake`'s separation-of-concerns rationale.
 /// What: Enumerates directory-package agents across
 /// `agents_dir_candidates()` (mirrors the tiered resolution every other
 /// by-name lookup in this crate uses), loads each via
 /// `AgentConfig::by_name_async` (so `extends` chains resolve identically to
-/// every other dispatch path), and checks its `listeners` bindings against
-/// `event` via `binding_matches_event`. On the FIRST match it loads
-/// `agents/<name>/events/<connector>.md` (best-effort — missing file just
-/// means no extra instructions) and dispatches through
-/// `run_pm_task_with_persona`. Every branch is logged at info/debug so a
-/// demo run's wake decisions are auditable in the process log.
-/// Test: exercised end-to-end only via a live agent directory (manual demo
-/// script); the pure matching logic is covered by `binding_matches_event`'s
-/// tests.
-pub async fn wake_bound_agents(project_path: &Path, event: &StoredEvent) -> WakeOutcome {
+/// every other dispatch path), and returns the first name whose `listeners`
+/// bindings match `event` via `binding_matches_event`.
+async fn find_matching_agent(event: &StoredEvent) -> Option<String> {
     let candidate_names = match candidate_agent_names().await {
         Ok(names) => names,
         Err(e) => {
-            tracing::warn!(error = %e, "wake_bound_agents: failed to enumerate agent directories");
-            return WakeOutcome::NoBindingMatched;
+            tracing::warn!(error = %e, "find_matching_agent: failed to enumerate agent directories");
+            return None;
         }
     };
-
     for name in candidate_names {
-        let cfg = match AgentConfig::by_name_async(&name).await {
-            Ok(c) => c,
-            Err(_) => continue,
+        let Ok(cfg) = AgentConfig::by_name_async(&name).await else {
+            continue;
         };
-        if !cfg
+        if cfg
             .listeners
             .iter()
             .any(|b| binding_matches_event(b, event))
         {
-            continue;
+            return Some(name);
         }
-        tracing::info!(
-            agent = %name,
-            listener = %event.listener_id,
-            event_id = %event.id,
-            event_type = %event.event_type,
-            "wake decision: binding matched"
-        );
-
-        let connector_instructions = load_connector_instructions(&name, &event.provider).await;
-        let user_input = build_wake_prompt(event, connector_instructions.as_deref());
-
-        return match run_pm_task_with_persona(
-            project_path,
-            &name,
-            &user_input,
-            &[],
-            None,
-            SessionOverrides::default(),
-        )
-        .await
-        {
-            Ok(_reply) => {
-                tracing::info!(agent = %name, event_id = %event.id, "wake decision: dispatched");
-                WakeOutcome::Woke { agent: name }
-            }
-            Err(e) => {
-                tracing::warn!(agent = %name, event_id = %event.id, error = %e, "wake decision: dispatch failed");
-                WakeOutcome::DispatchFailed {
-                    agent: name,
-                    error: e.to_string(),
-                }
-            }
-        };
     }
+    None
+}
 
-    tracing::debug!(
+/// Scan the agents directories for a `[[listeners]]` binding matching
+/// `event`, and wake AT MOST ONE agent per poll cycle (DEADLINE BUILD
+/// scope: "max 1 wake per poll cycle").
+///
+/// Why: Centralising the roster scan here (rather than in `poll.rs`) keeps
+/// the polling loop's per-event work to "does anything care" without it
+/// needing to know how personas are dispatched. The cycle cap itself lives
+/// in `gate_wake` (see its doc comment); `already_woke_this_cycle` is
+/// threaded in by the caller, which owns the per-`poll_once`-call state.
+/// What: Finds the first matching agent via `find_matching_agent`, then
+/// applies `gate_wake`. On `ShouldDispatch`, loads
+/// `agents/<name>/events/<connector>.md` (best-effort — missing file just
+/// means no extra instructions) and dispatches through
+/// `run_pm_task_with_persona`. On `RateLimited`, logs and returns WITHOUT
+/// dispatching — the event was already durably appended to the store by
+/// the caller before this function runs, so rate-limiting a wake never
+/// drops the event from the Events pane, only skips the LLM reaction.
+/// Every branch is logged at info/debug so a demo run's wake decisions are
+/// auditable in the process log.
+/// Test: `gate_wake_caps_to_one_dispatch_per_cycle` pins the cap logic this
+/// function delegates to; the full scan+dispatch path is exercised only via
+/// a live agent directory (manual demo script) since it needs live LLM
+/// credentials for a real `Woke` outcome.
+pub async fn wake_bound_agents(
+    project_path: &Path,
+    event: &StoredEvent,
+    already_woke_this_cycle: bool,
+) -> WakeOutcome {
+    let matched_agent = find_matching_agent(event).await;
+
+    let name = match gate_wake(matched_agent, already_woke_this_cycle) {
+        WakeGate::NoMatch => {
+            tracing::debug!(
+                listener = %event.listener_id,
+                event_id = %event.id,
+                "wake decision: no agent binding matched"
+            );
+            return WakeOutcome::NoBindingMatched;
+        }
+        WakeGate::RateLimited(name) => {
+            tracing::info!(
+                agent = %name,
+                listener = %event.listener_id,
+                event_id = %event.id,
+                "wake decision: rate-limited (one wake per poll cycle already used)"
+            );
+            return WakeOutcome::RateLimited { agent: name };
+        }
+        WakeGate::ShouldDispatch(name) => name,
+    };
+
+    tracing::info!(
+        agent = %name,
         listener = %event.listener_id,
         event_id = %event.id,
-        "wake decision: no agent binding matched"
+        event_type = %event.event_type,
+        "wake decision: binding matched"
     );
-    WakeOutcome::NoBindingMatched
+
+    let connector_instructions = load_connector_instructions(&name, &event.provider).await;
+    let user_input = build_wake_prompt(event, connector_instructions.as_deref());
+
+    match run_pm_task_with_persona(
+        project_path,
+        &name,
+        &user_input,
+        &[],
+        None,
+        SessionOverrides::default(),
+    )
+    .await
+    {
+        Ok(_reply) => {
+            tracing::info!(agent = %name, event_id = %event.id, "wake decision: dispatched");
+            WakeOutcome::Woke { agent: name }
+        }
+        Err(e) => {
+            tracing::warn!(agent = %name, event_id = %event.id, error = %e, "wake decision: dispatch failed");
+            WakeOutcome::DispatchFailed {
+                agent: name,
+                error: e.to_string(),
+            }
+        }
+    }
 }
 
 /// Enumerate directory-package agent names across the standard candidate
@@ -369,5 +447,41 @@ mod tests {
             filter: AgentBindingFilter::default(),
         };
         assert!(binding_matches_event(&binding, &sample_event()));
+    }
+
+    /// #3820 code-critic CRITICAL fix: pins the one-wake-per-poll-cycle cap.
+    /// Simulates `poll_once`'s loop over two qualifying events in the SAME
+    /// cycle by calling `gate_wake` twice with the cycle-state flag threaded
+    /// through exactly as `poll.rs` threads it (first call `false`, second
+    /// call `true` because the first produced a dispatch) — the first
+    /// qualifying event must dispatch, the second must rate-limit, never the
+    /// reverse and never both dispatching.
+    #[test]
+    fn gate_wake_caps_to_one_dispatch_per_cycle() {
+        let first = gate_wake(Some("izzie".to_string()), false);
+        assert_eq!(first, WakeGate::ShouldDispatch("izzie".to_string()));
+
+        // poll.rs only flips its cycle flag to `true` when the outcome of
+        // dispatching `first` was `Woke` — modeled here directly since this
+        // test targets the gate, not the dispatch call.
+        let woke_this_cycle = true;
+        let second = gate_wake(Some("izzie".to_string()), woke_this_cycle);
+        assert_eq!(second, WakeGate::RateLimited("izzie".to_string()));
+    }
+
+    #[test]
+    fn gate_wake_no_match_is_never_rate_limited() {
+        // A non-matching event must never consume (or be blocked by) the
+        // cycle's one-wake budget — `NoMatch` regardless of cycle state.
+        assert_eq!(gate_wake(None, false), WakeGate::NoMatch);
+        assert_eq!(gate_wake(None, true), WakeGate::NoMatch);
+    }
+
+    #[test]
+    fn gate_wake_first_match_dispatches_when_cycle_fresh() {
+        assert_eq!(
+            gate_wake(Some("cto-assistant".to_string()), false),
+            WakeGate::ShouldDispatch("cto-assistant".to_string())
+        );
     }
 }

--- a/crates/trusty-agents/src/mcp/config/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/mod.rs
@@ -107,6 +107,20 @@ pub struct GlobalConfig {
     /// `crate::tools::registry::tests::builder_with_no_endpoints_returns_empty`.
     #[serde(default)]
     pub tool_registry: Option<crate::tools::registry::config::ToolRegistryConfig>,
+
+    /// `[[listeners]]` — harness-level eventstream listener definitions
+    /// (#3820, DOC-54 SPEC-AGENTS-06 §7.5), stage-one (ingestion) filter.
+    ///
+    /// Why: Listeners are opt-in, account-specific, and never written by
+    /// this codebase — a listener declared here with `enabled = false`
+    /// (the field's default) is inert until an operator flips it on by hand.
+    /// Defaults to empty so every existing `config.toml` (which predates
+    /// this field) keeps parsing unchanged.
+    /// What: See `crate::listeners::config::ListenerConfig`.
+    /// Test: `listeners_section_defaults_empty`,
+    /// `listeners_section_round_trips`.
+    #[serde(default)]
+    pub listeners: Vec<crate::listeners::config::ListenerConfig>,
 }
 
 impl GlobalConfig {

--- a/crates/trusty-agents/src/mcp/config/tests/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/mod.rs
@@ -305,3 +305,52 @@ async fn enable_disable_toggles_flag() {
     assert!(!cfg.enable_service("missing").await.unwrap());
     assert!(!cfg.disable_service("missing").await.unwrap());
 }
+
+// --- [[listeners]] section (#3820, DOC-54 SPEC-AGENTS-06) ---------------
+
+#[tokio::test]
+async fn listeners_section_defaults_empty() {
+    // A `config.toml` with no `[[listeners]]` entries (every file that
+    // predates this field) must still parse, with an empty list.
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let cfg = GlobalConfig::from_toml_str("").expect("empty config parses");
+    assert!(cfg.listeners.is_empty());
+}
+
+#[tokio::test]
+async fn listeners_section_round_trips() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tempdir();
+    unsafe {
+        std::env::set_var("HOME", &home);
+    }
+    let mut cfg = GlobalConfig::default();
+    cfg.listeners
+        .push(crate::listeners::config::ListenerConfig {
+            name: "gmail-personal".to_string(),
+            connector: "gmail".to_string(),
+            identity: Some("bob-personal".to_string()),
+            transport: "history-poll".to_string(),
+            enabled: false,
+            poll_interval_secs: 180,
+            filter: crate::listeners::config::ListenerFilter {
+                label_ids: vec!["INBOX".to_string()],
+            },
+        });
+    cfg.save().await.expect("save should succeed");
+    let reloaded = GlobalConfig::load().await;
+    assert_eq!(reloaded.listeners.len(), 1);
+    assert_eq!(reloaded.listeners[0].name, "gmail-personal");
+    assert_eq!(
+        reloaded.listeners[0].identity.as_deref(),
+        Some("bob-personal")
+    );
+    assert!(
+        !reloaded.listeners[0].enabled,
+        "round-trips disabled-by-default"
+    );
+    assert_eq!(
+        reloaded.listeners[0].filter.label_ids,
+        vec!["INBOX".to_string()]
+    );
+}

--- a/crates/trusty-agents/src/repl/event_display.rs
+++ b/crates/trusty-agents/src/repl/event_display.rs
@@ -99,7 +99,11 @@ pub fn format_event(event: &Event) -> Option<String> {
         | Event::AstOperation { .. } => None,
         // #3752: Slack-mirror events are a GUI-only concern (injected onto the
         // `--api` bus via the relay endpoint); the REPL never surfaces them.
-        Event::SlackMessageReceived { .. } | Event::SlackReplySent { .. } => None,
+        // #3820: listener events are likewise a GUI-only (Events pane)
+        // concern — the REPL has no eventstream-listener view yet.
+        Event::SlackMessageReceived { .. }
+        | Event::SlackReplySent { .. }
+        | Event::ListenerEventReceived { .. } => None,
         // #371: render a one-line recap banner when a session recap is generated.
         Event::RecapGenerated { summary, .. } => {
             Some(dim.paint(format!("  ※ recap: {summary}")).to_string())

--- a/crates/trusty-agents/ui/src/components/EventsView.svelte
+++ b/crates/trusty-agents/ui/src/components/EventsView.svelte
@@ -15,6 +15,15 @@
    * part of the eventstream" without ripping out the plumbing that still
    * feeds it into `eventLog` — see `lib/events.ts`'s doc comment for the
    * full seam description.
+   *
+   * #3820 update: `gmail` is now a REAL listener bucket, not a placeholder —
+   * `crate::listeners::poll`'s Gmail history-poll engine publishes
+   * `listener_event_received` events onto the same bus this view already
+   * reads, so Gmail rows here are live data, not a concept mock. The
+   * "→ wakes Izzie" affordance for `gmail` is likewise real: a wake only
+   * actually fires when izzie's `agent.toml` `[[listeners]]` binding
+   * matches (stage two) — this badge is a simplified always-shown hint, not
+   * a guarantee every gmail row woke her.
    * What: `excludedSources` (not a single selected bucket) drives the
    * include/exclude toggle row; excluded rows render at reduced opacity
    * instead of disappearing. A free-text filter narrows further (applies
@@ -36,6 +45,7 @@
     task: 'Chat / Task',
     slack: 'Slack',
     system: 'System',
+    gmail: 'Gmail',
   };
 
   // #3819 concept affordance: which agent a listener source would wake, if
@@ -46,6 +56,7 @@
   // channel, and system rows are diagnostic).
   const WAKES_AGENT: Partial<Record<EventRow['source'], string>> = {
     slack: 'CTO Assistant',
+    gmail: 'Izzie',
   };
 
   // #3819: chat/task lifecycle events are excluded by default — "chat is a
@@ -76,6 +87,8 @@
     switch (source) {
       case 'slack':
         return 'bg-purple-500/15 text-purple-600 dark:text-purple-400';
+      case 'gmail':
+        return 'bg-red-500/15 text-red-600 dark:text-red-400';
       case 'system':
         return 'bg-foundry-light-border/50 dark:bg-black/30 text-foundry-light-muted dark:text-foundry-text/50';
       default:
@@ -121,9 +134,9 @@
   <div class="flex-1 overflow-y-auto px-2 py-2">
     {#if rows.length === 0}
       <p class="px-2 py-6 text-center text-sm text-foundry-light-muted dark:text-foundry-text/40">
-        No events yet — this fills in as connected listeners (Slack today; Gmail/Calendar once
-        the eventstream connector framework, #3798, lands) send activity. Chat/task turns are a
-        separate channel and are excluded by default.
+        No events yet — this fills in as connected listeners (Slack, Gmail today; Calendar once
+        the eventstream connector framework, #3798, extends to it) send activity. Chat/task turns
+        are a separate channel and are excluded by default.
       </p>
     {:else}
       <table class="w-full border-collapse text-left text-xs">

--- a/crates/trusty-agents/ui/src/lib/events.test.ts
+++ b/crates/trusty-agents/ui/src/lib/events.test.ts
@@ -50,6 +50,28 @@ describe('eventRowFromEvent', () => {
     const row = eventRowFromEvent({ type: 'pm_thinking' } as AppEvent);
     expect(row.summary).toBe('pm_thinking');
   });
+
+  it('classifies a gmail listener_event_received row as source "gmail" (#3820)', () => {
+    const row = eventRowFromEvent({
+      type: 'listener_event_received',
+      listener_id: 'gmail-personal',
+      provider: 'gmail',
+      event_type: 'message.received',
+      summary: 'dad@family.com: Dinner Sunday?',
+      included: true,
+    } as unknown as AppEvent);
+    expect(row.source).toBe('gmail');
+    expect(row.summary).toBe('dad@family.com: Dinner Sunday?');
+  });
+
+  it('falls back to "task" for a listener_event_received row from an unrecognized provider', () => {
+    const row = eventRowFromEvent({
+      type: 'listener_event_received',
+      provider: 'google-calendar',
+      summary: 'Standup at 9am',
+    } as unknown as AppEvent);
+    expect(row.source).toBe('task');
+  });
 });
 
 describe('eventLog store via pushEvent', () => {

--- a/crates/trusty-agents/ui/src/lib/events.ts
+++ b/crates/trusty-agents/ui/src/lib/events.ts
@@ -15,9 +15,11 @@
 // What: `eventRowFromEvent` maps one `AppEvent` to an `EventRow`;
 // `pushEvent` folds it into the bounded `eventLog` store. `EVENT_SOURCES`
 // classifies a row's `type` into a coarse source bucket for the source
-// filter (`task`, `slack`, `system`) — the seam a future #3798 connector
-// would extend with real per-connector sources (`gmail`, `google-calendar`,
-// …) without changing `EventRow`'s shape.
+// filter (`task`, `slack`, `system`, `gmail`) — `gmail` is the first real
+// per-connector source, landing with #3820's Gmail listener
+// (`Event::ListenerEventReceived`, wire type `listener_event_received`,
+// published by `crate::listeners::poll` onto the SAME bus this file
+// already taps — no new plumbing needed on this side).
 // Test: `events.test.ts`.
 
 import { writable } from 'svelte/store';
@@ -28,7 +30,7 @@ export interface EventRow {
   /** The raw `AppEvent.type` (`session_started`, `slack_message_received`, …). */
   type: string;
   /** Coarse bucket for the source filter — see `sourceOf`. */
-  source: 'task' | 'slack' | 'system';
+  source: 'task' | 'slack' | 'system' | 'gmail';
   /** A short, human-glanceable summary line — never empty. */
   summary: string;
   /** Client receive time (ms) — used for ordering + the time filter. */
@@ -39,12 +41,15 @@ export interface EventRow {
 export const EVENT_LOG_MAX = 300;
 
 /**
- * Why: classifies an event's `type` into the source filter's three buckets.
- * `slack` and `ping`/`lag` (diagnostic) are their own honest categories;
- * everything else — task/agent/workflow lifecycle events — is `task`, the
- * bucket that will most naturally split into per-connector sources once
- * #3798 lands.
- * What: Pure string-prefix classification.
+ * Why: classifies an event's `type` into the source filter's buckets.
+ * `slack`, `gmail`, and `ping`/`lag` (diagnostic) are their own honest
+ * categories; everything else — task/agent/workflow lifecycle events — is
+ * `task`, the bucket that will keep splitting into per-connector sources as
+ * more of #3798's listener family lands (Calendar next).
+ * What: Pure string-prefix classification. `listener_event_received` is
+ * NOT prefix-classified by type alone (the wire type is the same for every
+ * connector) — `eventRowFromEvent` reads the event's own `provider` field
+ * for that one case; see its `case` arm below.
  * Test: `sourceOf_classifies_*`.
  */
 export function sourceOf(type: string): EventRow['source'] {
@@ -65,6 +70,20 @@ export function sourceOf(type: string): EventRow['source'] {
  */
 export function eventRowFromEvent(ev: AppEvent): EventRow {
   const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+  // `listener_event_received` (#3820) carries its own source bucket via
+  // `provider` (`"gmail"` today) rather than a `type`-prefix rule, since the
+  // wire `type` is the same string for every connector. Handled before the
+  // switch below so it can `return` its own `source` instead of always
+  // falling through to `sourceOf`.
+  if (ev.type === 'listener_event_received') {
+    const provider = str(ev.provider);
+    return {
+      type: ev.type,
+      source: provider === 'gmail' ? 'gmail' : 'task',
+      summary: str(ev.summary) || ev.type,
+      received_at: Date.now(),
+    };
+  }
   let summary = '';
   switch (ev.type) {
     case 'pm_thinking':

--- a/crates/trusty-gworkspace/CHANGELOG.md
+++ b/crates/trusty-gworkspace/CHANGELOG.md
@@ -9,6 +9,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- New Gmail connector-layer functions for trusty-agents' eventstream
+  listener (#3820): `api::services::gmail::history::get_gmail_profile`
+  (bootstraps a `historyId` cursor) and `list_gmail_history` (incremental
+  `users.history.list` polling, optionally scoped to one label). Called as
+  direct library functions, not through the MCP tool-dispatch path — no new
+  MCP tools, scopes, or wire surface; existing OAuth scopes already cover
+  both calls.
 - Multi-account management is now exposed as MCP tools, not just the CLI
   (issue #3503): `set_default_account {name}`, `remove_account {name}`, and
   `add_account` (runs the native OAuth consent flow for a new or re-auth

--- a/crates/trusty-gworkspace/src/api/services/gmail/history.rs
+++ b/crates/trusty-gworkspace/src/api/services/gmail/history.rs
@@ -1,0 +1,96 @@
+//! Gmail `history.list` polling + profile bootstrap for eventstream listeners.
+//!
+//! Why: trusty-agents' listener polling engine (#3820, DOC-54
+//! SPEC-AGENTS-06 §7.1.2) needs to detect new inbound mail without a
+//! Pub/Sub subscription. Gmail's documented zero-setup path is
+//! `users.getProfile` (to bootstrap a starting `historyId` cursor) followed
+//! by repeated `users.history.list(startHistoryId=...)` calls, each of which
+//! returns only what changed since the last cursor.
+//! What: `get_gmail_profile` returns the account's current `historyId` (used
+//! once, to baseline a brand-new listener with no persisted cursor).
+//! `list_gmail_history` fetches changes since a cursor, optionally scoped to
+//! `messageAdded` history records and a single label (mirrors the listener's
+//! stage-one `label_ids` filter, DOC-54 §5.3). Both are called as direct
+//! library functions by trusty-agents' polling engine — never through the
+//! MCP JSON-RPC path (`server.rs`) that `trusty-gworkspace-mcp`'s tool
+//! handlers use.
+//! Test: `history_list_url_includes_label_and_cursor` covers URL
+//! construction; live API behavior (410 GONE on an expired cursor, real
+//! history records) is exercised manually per the listener's own tests.
+
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::api::client::BaseClient;
+use crate::api::constants::GMAIL_API_BASE;
+
+/// Fetch the authenticated user's Gmail profile, primarily for its current
+/// `historyId` (used to baseline a new listener's cursor).
+///
+/// Why: A listener with no persisted cursor must not replay the entire
+/// mailbox history on first run — it should start watching from "now".
+/// What: `GET users/me/profile`; the response's `historyId` field is a
+/// `history.list`-compatible starting cursor.
+/// Test: Live API only (an authenticated GET with no request body).
+pub async fn get_gmail_profile(client: &BaseClient, account: Option<&str>) -> Result<Value> {
+    let url = format!("{GMAIL_API_BASE}/users/me/profile");
+    client.get(&url, account).await
+}
+
+/// List Gmail history records since `start_history_id`.
+///
+/// Why: The incremental-sync primitive behind the `history-poll` transport
+/// (DOC-54 §7.1.2) — cheaper than re-searching the mailbox on every poll,
+/// and matches what a Pub/Sub-pull listener would do with the `historyId`
+/// carried in a push notification.
+/// What: `GET users/me/history?startHistoryId=...`, restricted to
+/// `messageAdded` records (new mail — the only history type this listener
+/// currently reacts to) and optionally further scoped to one Gmail label
+/// (mirrors a listener's `filter.label_ids`, applied here as the single
+/// `labelId` query param Gmail's API accepts). Returns the raw response —
+/// callers read `history[].messagesAdded[].message.id` for new message ids
+/// and `historyId` for the next cursor. On a `410 GONE` (cursor expired) the
+/// caller must drop the cursor and re-baseline via `get_gmail_profile`.
+/// Test: `history_list_url_includes_label_and_cursor`.
+pub async fn list_gmail_history(
+    client: &BaseClient,
+    account: Option<&str>,
+    start_history_id: &str,
+    label_id: Option<&str>,
+) -> Result<Value> {
+    let url = history_list_url(start_history_id, label_id);
+    client.get(&url, account).await
+}
+
+/// Pure URL builder for [`list_gmail_history`] — split out so query-string
+/// construction is unit-testable without a live client.
+fn history_list_url(start_history_id: &str, label_id: Option<&str>) -> String {
+    let mut url = format!(
+        "{GMAIL_API_BASE}/users/me/history?startHistoryId={start_history_id}&historyTypes=messageAdded"
+    );
+    if let Some(label) = label_id {
+        url.push_str("&labelId=");
+        url.push_str(label);
+    }
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_list_url_includes_label_and_cursor() {
+        let url = history_list_url("12345", Some("INBOX"));
+        assert!(url.contains("startHistoryId=12345"));
+        assert!(url.contains("historyTypes=messageAdded"));
+        assert!(url.contains("labelId=INBOX"));
+    }
+
+    #[test]
+    fn history_list_url_omits_label_when_absent() {
+        let url = history_list_url("999", None);
+        assert!(!url.contains("labelId"));
+        assert!(url.contains("startHistoryId=999"));
+    }
+}

--- a/crates/trusty-gworkspace/src/api/services/gmail/mod.rs
+++ b/crates/trusty-gworkspace/src/api/services/gmail/mod.rs
@@ -7,6 +7,7 @@
 //! Test: Each sub-module has its own tests where applicable.
 
 pub mod compose;
+pub mod history;
 pub mod labels;
 pub mod messages;
 pub mod organize;


### PR DESCRIPTION
## Summary

First real eventstream listener per DOC-54 SPEC-AGENTS-04/06 and issue
#3820 — the demo-morning eventstream slice. Scoped ruthlessly for the
5pm demo; deferrals are called out explicitly below.

Stacked on `feat-workstreams-sidebar` (PR #3826, still DRAFT/open) since
that branch carries the `EventsView`/`/api/workstreams` UI this slice
wires real data into. Rebase target: once #3826 merges to `main`, this
PR should be retargeted/rebased onto `main`.

**Code-critic fix round (this update):** a first-pass BLOCK caught one
CRITICAL and two MEDIUM findings, all fixed — see "Code-critic fix round"
below for the diff-level detail. Short version: the one-wake-per-poll-cycle
limit this PR body always claimed was NOT actually enforced in the first
push (`wake::WakeOutcome::RateLimited` was declared but never constructed);
it now is, pinned by a new test. `poll_interval_secs` now has a 15s floor.
Cursor persistence is now atomic (temp-then-rename) with a warn-on-parse-
failure instead of a silent fallback.

## What's built (demoable)

1. **Declarative listener config (DOC-54 §5.3/§7.5)** — `crate::listeners::config`:
   - `ListenerConfig` / `ListenerFilter` — harness-level `[[listeners]]`
     entries, parsed from `~/.trusty-agents/config.toml` (new `GlobalConfig.listeners`
     field, `#[serde(default)]` — every existing config.toml keeps parsing
     unchanged). `enabled` defaults to `false`.
   - `AgentListenerBinding` / `AgentBindingFilter` — per-agent `[[listeners]]`
     bindings, new `AgentConfig.listeners` field. Unioned across an `extends`
     chain keyed by binding `name` (child overrides base's filter for the
     same listener) — `agents/extends/mod.rs::union_listener_bindings`.

2. **Gmail history-poll engine** (`crate::listeners::poll`) — the
   zero-GCP-setup fallback transport (DOC-54 §7.1.2). Bootstraps a
   `historyId` cursor from `users.getProfile` on first run (never replays
   the whole mailbox), then polls `history.list(startHistoryId=...)` on
   `poll_interval_secs`. Cursor persisted to
   `~/.trusty-agents/events/cursor-<listener>.json`. Dedup via an in-memory
   set seeded from the durable event log (survives process restarts).
   Exponential backoff with jitter on transient errors; immediate
   cursor-drop + re-baseline on `410 GONE`. New trusty-gworkspace connector
   functions (`api::services::gmail::history::{get_gmail_profile,
   list_gmail_history}`), called as **direct library calls**, not through
   the MCP tool-dispatch path.

3. **Event store** (`crate::listeners::store`) — append-only JSONL under
   `~/.trusty-agents/events/events.jsonl`: `{id, listener_id, provider,
   event_type, ts, from, subject, snippet, included}`. Per-event-type
   include/exclude state persisted to `filters.json`, applied retroactively
   on read (matches the Events pane's "excluded rows stay visible, muted"
   spec, #3818).

4. **API**: `GET /api/listener-events` (newest-first, `?limit=`), `POST
   /api/listener-events/filter` (`{event_type, included}`). **Named apart
   from `/api/events`** — that path is already the SSE telemetry stream
   (`events_sse.rs`) shipped on the base branch; reusing it would collide.
   Listener events also `Event::publish` onto the **existing** harness bus
   (new `Event::ListenerEventReceived` variant) so the GUI's Events pane
   updates live via the same SSE/Tauri bridge every other event type uses —
   no new frontend plumbing needed, just a new `gmail` source bucket in
   `lib/events.ts` + `EventsView.svelte` (badge color, "→ wakes Izzie"
   affordance). The `gmail` bucket is now real data, not the PR #3826
   concept placeholder.

5. **Agent wake** (`crate::listeners::wake`) — stage-two filter match
   (event type + sender glob + listener name) against every directory-
   package agent's `[[listeners]]` bindings. On the first match: loads
   `agents/<name>/events/<connector>.md` (#3817, best-effort) and
   dispatches through `ctrl::pm_task::run_pm_task_with_persona` — **the
   same entry point `/agent` uses** — with an ask-first preamble + the
   event summary. The reaction lands in the agent's chat history with
   correct speaker attribution, indistinguishable from an ordinary turn.
   **Actually enforced** one-wake-per-poll-cycle limit: a pure decision
   function (`wake::gate_wake`) and a cycle-local flag threaded through
   `poll_once`'s per-event loop mean the first qualifying event in a cycle
   dispatches and every subsequent one is rate-limited — logged, never
   dispatched, but the event is still appended to the durable store either
   way (only the LLM call is gated). Every wake decision (`Woke` /
   `RateLimited` / `NoBindingMatched` / `DispatchFailed`) is logged.

6. **Izzie demo wiring** — `agents/izzie/agent.toml` gets a `[[listeners]]`
   binding to `gmail-personal` (`event_types = ["message.received"]`,
   `filter.from = ["*"]` — broad for the demo). New
   `agents/izzie/events/gmail.md` — ask-first Gmail reaction instructions
   (#3817).

## Exact config.toml stanza to enable the listener live

This code **never writes** `~/.trusty-agents/config.toml` (per the task's
explicit instruction). To turn the listener on for the live demo, append
this to `~/.trusty-agents/config.toml` and restart the `tagent --api`
process:

```toml
[[listeners]]
name = "gmail-personal"
connector = "gmail"
identity = "bob-personal"
transport = "history-poll"
enabled = true
poll_interval_secs = 60
filter = { label_ids = ["INBOX"] }
```

`identity = "bob-personal"` matches the profile already present in
`~/.gworkspace-mcp/tokens.json` on this machine — no new OAuth consent
needed. `poll_interval_secs = 60` is tightened from the 180s production
default for demo responsiveness (well above the new 15s floor).

## Code-critic fix round

Findings from the first review pass, all fixed in the second commit:

1. **CRITICAL — one-wake-per-poll-cycle limit was not enforced.**
   `poll_once` called `wake::wake_bound_agents` once per qualifying event in
   its `messagesAdded` loop with no cap; `WakeOutcome::RateLimited` was
   declared but no code path ever constructed it, so N qualifying events in
   one poll cycle produced N live LLM dispatches, not 1. Fixed by
   extracting a pure `gate_wake(matched_agent, already_woke_this_cycle)`
   decision function in `wake.rs` (`NoMatch` / `RateLimited(name)` /
   `ShouldDispatch(name)`) and threading a cycle-local `woke_this_cycle`
   bool through `poll_once`'s loop, flipped to `true` only after an actual
   `Woke` outcome. Every event is still durably appended to the store
   regardless of the wake outcome — rate-limiting only skips the LLM call.
   New test: `gate_wake_caps_to_one_dispatch_per_cycle` (plus
   `gate_wake_no_match_is_never_rate_limited`,
   `gate_wake_first_match_dispatches_when_cycle_fresh`).
2. **MEDIUM — no floor on `poll_interval_secs`.** This listener polls a
   real personal Gmail account; an unfloored interval (a config typo, e.g.
   `poll_interval_secs = 1`) could hammer the API indefinitely. Added
   `MIN_POLL_INTERVAL_SECS = 15`, enforced via a custom serde
   `deserialize_with` that clamps up (with a `tracing::warn!`) rather than
   silently accepting or hard-failing the whole config. New tests:
   `listener_config_clamps_poll_interval_below_floor`,
   `listener_config_leaves_poll_interval_above_floor_untouched`,
   `listener_config_poll_interval_exactly_at_floor_is_unchanged`.
3. **MEDIUM — cursor durability.** `save_cursor` now writes to a sibling
   `.tmp` path and renames over the target (atomic on POSIX — a crash
   mid-write leaves either the old cursor intact or the new one complete,
   never torn). `load_cursor` now `tracing::warn!`s on a parse failure
   (distinct from the expected "file absent" case, which stays silent) —
   previously both cases silently fell back to `Cursor::default()`,
   indistinguishable from "first run" in the log. New tests:
   `save_cursor_then_load_cursor_round_trips`,
   `load_cursor_warns_and_defaults_on_malformed_json`,
   `load_cursor_defaults_when_file_absent`.

## Deferred (flagged, not silently dropped)

- **Pub/Sub-pull transport** — history-poll only in this slice; Pub/Sub
  needs a GCP topic/subscription setup (DOC-54 §7.1.1), out of scope for
  today's train.
- **Google Calendar connector** — `spawn_listeners` recognizes
  `connector = "google-calendar"` in config shape terms but logs-and-skips
  it (no poller implemented); DOC-54 §7.2 spec exists, not built.
- **Multi-agent fanout** — only the FIRST matching agent wakes per poll
  cycle (DEADLINE BUILD's explicit "max 1 wake per poll cycle" scope); two
  agents both bound to the same firing event only one wakes.
- **`exclude_labels` stage-two filter** — accepted in the binding shape,
  documented as currently a no-op (`StoredEvent` carries no label list yet
  in this slice) rather than silently doing nothing unlabeled.
- **Learned autonomy** — every wake in this build is ask-first; the
  "adapt" step of DOC-54's Event→Ask→Learn→Adapt loop (skip asking once a
  pattern is learned) is not implemented.
- **Flat `.md` agent overlays** never get a `[[listeners]]` binding (only
  directory-package `agent.toml` — DOC-54's primary format).
- **JSONL event store + in-memory dedup set both grow unbounded.**
  `events.jsonl` is append-only forever and the polling engine's dedup
  `HashSet<String>` (seeded from the last 500 persisted ids, then grown
  per-process-lifetime) is never pruned. Fine at demo scale; needs log
  rotation / a bounded or TTL'd dedup structure before any unattended
  long-running deployment (code-critic follow-up, noted not fixed).
- **`is_410_gone` substring-matches the error chain for `"410"`** rather
  than parsing a real HTTP status code out of the `anyhow` error chain.
  Works today because `BaseClient`'s error text always embeds
  `reqwest::StatusCode`'s `Display` (`"410 Gone"`), but it's fragile to any
  future change in that error's wording. A structured status code (e.g. a
  typed error variant on the `trusty-gworkspace` side) would be more
  robust (code-critic follow-up, noted not fixed).

## Quality gates (raw output)

**Rust** (`cargo build`, `cargo test --lib`, `cargo clippy --all-targets
-- -D warnings`, `cargo fmt --check`) for both touched crates:

```
$ cargo test -p trusty-agents --lib
test result: ok. 2361 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 24.36s

$ cargo test -p trusty-gworkspace --lib
test result: ok. 259 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.52s

$ cargo clippy -p trusty-agents -p trusty-gworkspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 36.08s
(no warnings/errors)

$ cargo fmt -p trusty-agents -p trusty-gworkspace -- --check
(clean, no diff)
```

(2361 = 2352 from the first push + 9 new tests from the code-critic fix
round: 3 `gate_wake_*`, 3 `listener_config_*poll_interval*`, 3
cursor-durability tests.)

**Frontend** (`pnpm run test:unit`, `pnpm run check`, `pnpm run build`):

```
$ pnpm run test:unit
 Test Files  12 passed (12)
      Tests  111 passed (111)

$ pnpm run check
COMPLETED 1713 FILES 0 ERRORS 2 WARNINGS 1 FILES_WITH_PROBLEMS
(the 2 warnings are pre-existing, in ProjectsView.svelte, unrelated to this change)

$ pnpm run build
✓ 1691 modules transformed.
✓ built in 2.67s
```

## Proof plan (end-to-end)

Scripted plan for a live run on this machine, once the config.toml
stanza above is applied and `tagent --api` is restarted:

1. **Send a test email** — `bob-personal`'s Gmail account sends itself
   (or receives from an external sender) a message with subject e.g.
   "Dinner Sunday?". This can be scripted headlessly via
   `trusty-gworkspace`'s `compose_email` tool/service (`action: "send"`,
   `account: "bob-personal"`, `to: "bob@matsuoka.com"`) if allow-listed for
   this session — otherwise it's a one-line manual step (send yourself an
   email from any client).
2. **Poll picks it up** — within `poll_interval_secs` (60s in the stanza
   above), the background task's `poll_once` calls `history.list`, finds
   the new message, and logs `gmail listener: poll cycle found new
   events` at info level (`tagent --api` stdout/log).
3. **Event appears in the store/API** — `curl localhost:<port>/api/listener-events`
   returns the new event (newest first), `included: true`.
4. **Izzie wake produces a chat reaction** — the process log shows `wake
   decision: binding matched` then `wake decision: dispatched` for
   `agent = "izzie"`; the reaction (an ask-first summary + question) is
   queryable via the same conversation/session surface a normal `/agent
   izzie` turn uses.
5. **GUI** — the Events pane (Chat|Events nav, #3818/#3826) shows the row
   live under the `gmail` (red) badge with a "→ wakes Izzie" affordance.

Steps 2-4 were exercised structurally via this PR's unit tests (cursor
bootstrap/poll parsing logic, binding-match logic, event-store dedup/
filter round-trips) — the live network leg (steps 1-2 against a real
Gmail account) requires the config.toml stanza to be applied by
PM/local-ops per the task's instructions, then re-run headlessly or
observed via the log lines above.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
