### PR TITLE
chore(release): trusty-common 0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,7 +6549,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11406,7 +11406,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [0.26.1] — 2026-07-24
 
 ### Added
 

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.26.0"
+version = "0.26.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Fold Unreleased entries into 0.26.1:
- `perform_upgrade_captured` from #3830 (needed by trusty-installer #3804/#3834)
- `room_filter` fix from #3274
- update test deflake from #3689

Enables cross-crate dependency chain: trusty-common 0.26.1 → trusty-installer 0.4.8.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools