### PR TITLE
fix(trusty-installer): terse context-aware TCC guidance (fresh vs reinstall)

### DIFF
--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -59,7 +59,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   guidance is now ≤3 lines and points at
   `docs/reference/release-workflow.md` for full detail, and the
   `TRUSTY_SIGN_IDENTITY`/`tctl sign` tip prints once per install run instead
-  of once per component.
+  of once per component. Code-critic follow-up (same PR): the fresh-vs-reinstall
+  detection and the guidance's interpolated binary path now come from the
+  CONCRETE path `install_one` actually placed the binary at, rather than a
+  fixed `install_dir` guess — the guess named the wrong file/directory and
+  picked the wrong guidance variant whenever the `cargo install` fallback
+  (as opposed to the prebuilt-tarball path) placed the binary.
 
 ## [0.4.8] — 2026-07-24
 

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -48,6 +48,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   0.4.8, no code fix applied): `launchctl bootstrap gui/$(id -u)
   ~/Library/LaunchAgents/com.trusty.memory.plist && launchctl kickstart -k
   gui/$(id -u)/com.trusty.memory`.
+- Simplified the macOS Full-Disk-Access / App-Data TCC guidance `tctl install`
+  prints after `trusty-search` / `trusty-mpm` land (#3846). Three defects
+  fixed: (1) the guidance now detects whether a binary already sat at the
+  install path before this run and prints a first-install variant (grant
+  once, nothing to remove) instead of always showing reinstall-only
+  remove-then-re-add steps; (2) the preamble no longer says "Every
+  `cargo install`..." — it is installation-method-agnostic, matching the
+  prebuilt-tarball install path `tctl` actually uses; (3) each component's
+  guidance is now ≤3 lines and points at
+  `docs/reference/release-workflow.md` for full detail, and the
+  `TRUSTY_SIGN_IDENTITY`/`tctl sign` tip prints once per install run instead
+  of once per component.
 
 ## [0.4.8] — 2026-07-24
 

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -281,12 +281,24 @@ pub fn run(
 /// trusty-mpm supervisor bootstrap's candidate-version comparison, and the
 /// post-install shadow-detection warning. Threading the path through as data
 /// (rather than each downstream step re-resolving it) is what makes both
-/// immune to PATH order.
+/// immune to PATH order. `existed_before` (#3846 code-critic MEDIUM fix)
+/// exists for a third downstream step, the FDA/App-Data TCC guidance: it
+/// must be observed at the SAME concrete path per the SAME outcome branch
+/// (`install_dir` for the prebuilt path, the cargo bin dir for the
+/// `cargo install` fallback) — a caller re-deriving "did a binary already
+/// exist here" against a single fixed directory guesses wrong whenever the
+/// fallback branch fires, since that branch's real destination is a
+/// different directory.
 struct InstalledBinary {
     /// The concrete path the binary was health-gated at (never a bare name).
     path: PathBuf,
     /// The version that exact binary reported via `--version`.
     version: String,
+    /// Whether a file already existed at `path` immediately before THIS
+    /// call wrote to it — the "first install vs. reinstall" signal for the
+    /// TCC guidance. Captured before any write on the branch actually
+    /// taken (see [`install_one`]).
+    existed_before: bool,
 }
 
 /// Install every selected member in order, returning the aggregate report.
@@ -365,11 +377,6 @@ async fn install_all(
         if !live {
             let _ = narr.info(&format!("installing {}", m.crate_name));
         }
-        // #3846: capture whether a binary already sat at this member's
-        // install path BEFORE this call places a fresh copy — the only
-        // reliable "first install vs. reinstall" signal the TCC guidance
-        // below needs. Must be read here, before `install_one` overwrites it.
-        let existed_before = install_dir.join(&m.binary).exists();
         match install_one(m).await {
             Ok(installed) => {
                 checklist.set(&m.crate_name, ComponentState::Verifying);
@@ -421,11 +428,19 @@ async fn install_all(
                 // Hardened Runtime, also matching pre-PR behavior. Demo-critical
                 // fix: the guidance text is now collected, not printed inline —
                 // see `post_install_notes` above.
+                // #3846 code-critic MEDIUM fix: `existed_before` and the
+                // guidance's interpolated binary path now come from
+                // `installed` (the CONCRETE path/replace-state `install_one`
+                // observed on the actual outcome branch taken — prebuilt
+                // `install_dir` or the cargo-fallback bin dir), never a fixed
+                // `install_dir` guess that names the wrong file/directory
+                // whenever the cargo-install fallback fires.
                 if m.crate_name == "trusty-search" {
                     if let Some((note, needs_tip)) = super::macos_signing::post_install_search(
                         &install_dir,
                         json,
-                        existed_before,
+                        installed.existed_before,
+                        &installed.path,
                     ) {
                         post_install_notes.push(note);
                         show_signing_tip |= needs_tip;
@@ -441,9 +456,12 @@ async fn install_all(
                 // hook DOES sign with Hardened Runtime (low risk either way).
                 // Demo-critical fix: deferred, same as trusty-search above.
                 if m.crate_name == "trusty-mpm" {
-                    if let Some((note, needs_tip)) =
-                        super::macos_signing::post_install_mpm(&install_dir, json, existed_before)
-                    {
+                    if let Some((note, needs_tip)) = super::macos_signing::post_install_mpm(
+                        &install_dir,
+                        json,
+                        installed.existed_before,
+                        &installed.path,
+                    ) {
                         post_install_notes.push(note);
                         show_signing_tip |= needs_tip;
                     }
@@ -632,6 +650,28 @@ fn cargo_fallback_bin_path(binary: &str, install_dir: &Path) -> PathBuf {
         .join(binary)
 }
 
+/// Pre-check "did a binary already exist" at BOTH candidate install
+/// destinations (#3846 code-critic MEDIUM fix).
+///
+/// Why: `install_one` cannot know which `Outcome` branch will fire — prebuilt
+/// (writes to `preferred_bin_path`, inside `install_dir`) or cargo-install
+/// fallback (writes to `cargo_bin_path`, inside the cargo bin dir) — until
+/// AFTER `download::try_install_prebuilt` returns. Both directories can
+/// differ (they always do unless `install_dir` itself happens to equal the
+/// cargo bin dir), so re-deriving "existed before" from a single fixed
+/// directory after the fact silently picks the wrong answer whenever the
+/// fallback branch fires. Checking both concrete destinations up front — a
+/// cheap, side-effect-free `.exists()` each, before either write path can
+/// run — means the right answer for whichever branch actually fires is
+/// always on hand. Extracted as a pure function of two already-resolved
+/// paths (never touches `CARGO_HOME`/env itself) so it is directly
+/// unit-testable with tempdirs standing in for both destinations.
+///
+/// Test: `tests::existed_before_at_both_distinguishes_preferred_from_cargo_bin_dir`.
+fn existed_before_at_both(preferred_bin_path: &Path, cargo_bin_path: &Path) -> (bool, bool) {
+    (preferred_bin_path.exists(), cargo_bin_path.exists())
+}
+
 /// Install + health-gate a single member, prebuilt-first with cargo fallback.
 ///
 /// Why: Prebuilt binaries install in seconds without requiring a Rust toolchain;
@@ -684,6 +724,15 @@ async fn install_one(m: &StableMember) -> anyhow::Result<InstalledBinary> {
         }
     });
 
+    // #3846 code-critic MEDIUM fix: capture "did a binary already exist" at
+    // BOTH candidate destinations before EITHER write path below can run —
+    // see `existed_before_at_both`'s doc for why a single fixed directory
+    // guessed wrong whenever the cargo-install fallback fired.
+    let preferred_bin_path = install_dir.join(&m.binary);
+    let cargo_bin_path = cargo_fallback_bin_path(&m.binary, &install_dir);
+    let (existed_at_preferred, existed_at_cargo_bin) =
+        existed_before_at_both(&preferred_bin_path, &cargo_bin_path);
+
     let outcome = download::try_install_prebuilt(&m.crate_name, &install_dir).await;
     match outcome {
         Outcome::Installed { paths, version } => {
@@ -720,6 +769,7 @@ async fn install_one(m: &StableMember) -> anyhow::Result<InstalledBinary> {
             Ok(InstalledBinary {
                 path: bin_path,
                 version,
+                existed_before: existed_at_preferred,
             })
         }
         Outcome::Fallback { reason } => {
@@ -757,6 +807,7 @@ async fn install_one(m: &StableMember) -> anyhow::Result<InstalledBinary> {
             Ok(InstalledBinary {
                 path: bin_path,
                 version,
+                existed_before: existed_at_cargo_bin,
             })
         }
     }

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -355,12 +355,21 @@ async fn install_all(
     // the per-component loop (see this function's doc) so it never interrupts
     // the live checklist; printed once, after every row has settled.
     let mut post_install_notes: Vec<String> = Vec::new();
+    // #3846: whether the shared once-per-run signing tip (Developer ID /
+    // TRUSTY_SIGN_IDENTITY) should be printed — true as soon as ANY
+    // component's TCC guidance (not a signed-OK note) is collected below.
+    let mut show_signing_tip = false;
 
     for m in selected {
         checklist.set(&m.crate_name, ComponentState::Downloading);
         if !live {
             let _ = narr.info(&format!("installing {}", m.crate_name));
         }
+        // #3846: capture whether a binary already sat at this member's
+        // install path BEFORE this call places a fresh copy — the only
+        // reliable "first install vs. reinstall" signal the TCC guidance
+        // below needs. Must be read here, before `install_one` overwrites it.
+        let existed_before = install_dir.join(&m.binary).exists();
         match install_one(m).await {
             Ok(installed) => {
                 checklist.set(&m.crate_name, ComponentState::Verifying);
@@ -413,10 +422,13 @@ async fn install_all(
                 // fix: the guidance text is now collected, not printed inline —
                 // see `post_install_notes` above.
                 if m.crate_name == "trusty-search" {
-                    if let Some(note) =
-                        super::macos_signing::post_install_search(&install_dir, json)
-                    {
+                    if let Some((note, needs_tip)) = super::macos_signing::post_install_search(
+                        &install_dir,
+                        json,
+                        existed_before,
+                    ) {
                         post_install_notes.push(note);
+                        show_signing_tip |= needs_tip;
                     }
                 }
                 // Phase 8b: codesign + App-Data-TCC guidance for trusty-mpm.
@@ -429,8 +441,11 @@ async fn install_all(
                 // hook DOES sign with Hardened Runtime (low risk either way).
                 // Demo-critical fix: deferred, same as trusty-search above.
                 if m.crate_name == "trusty-mpm" {
-                    if let Some(note) = super::macos_signing::post_install_mpm(&install_dir, json) {
+                    if let Some((note, needs_tip)) =
+                        super::macos_signing::post_install_mpm(&install_dir, json, existed_before)
+                    {
                         post_install_notes.push(note);
+                        show_signing_tip |= needs_tip;
                     }
                 }
                 // Phase 7b (#2556): bootstrap the launchd plist for each shared
@@ -550,6 +565,12 @@ async fn install_all(
     // see this function's doc for why this is deferred rather than inline.
     for note in &post_install_notes {
         eprintln!("{note}");
+    }
+    // #3846: the Developer ID / TRUSTY_SIGN_IDENTITY signing tip prints
+    // ONCE per run, after every per-component guidance block, instead of once
+    // per component (a search+mpm install used to print it twice).
+    if show_signing_tip {
+        eprintln!("{}", super::macos_signing::signing_persistence_tip());
     }
     InstallReport::build(outcomes)
 }

--- a/crates/trusty-installer/src/commands/install_tests.rs
+++ b/crates/trusty-installer/src/commands/install_tests.rs
@@ -374,6 +374,45 @@ fn cargo_fallback_bin_path_joins_binary_onto_cargo_bin_dir() {
     assert_eq!(p.file_name().and_then(|f| f.to_str()), Some("tm"));
 }
 
+/// Why (#3846 code-critic MEDIUM): the pre-fix "existed_before" check
+/// resolved a SINGLE fixed directory (`install_dir`, where the prebuilt path
+/// writes) before `install_one` knew which `Outcome` branch would fire. That
+/// silently produced the WRONG "fresh install" verdict whenever the
+/// `cargo install` fallback branch actually landed the binary in a
+/// DIFFERENT directory (the cargo bin dir) — e.g. a REINSTALL where a prior
+/// `cargo install` run already placed the binary there, but nothing ever
+/// sat at the preferred dir.
+/// What: Simulates exactly that scenario with two tempdirs standing in for
+/// the preferred dir and the cargo bin dir: a file exists ONLY at the cargo
+/// bin path. Asserts `existed_before_at_both` reports `false` for the
+/// preferred path and `true` for the cargo bin path — i.e. the fallback
+/// branch's guidance would correctly select the reinstall variant instead
+/// of wrongly reporting a fresh install.
+/// Test: This is the test.
+#[test]
+fn existed_before_at_both_distinguishes_preferred_from_cargo_bin_dir() {
+    let preferred_dir = tempfile::tempdir().expect("tempdir");
+    let cargo_dir = tempfile::tempdir().expect("tempdir");
+    let binary = "trusty-search";
+
+    // Nothing was ever placed at the preferred dir; a prior `cargo install`
+    // already placed the binary at the cargo bin dir.
+    std::fs::write(cargo_dir.path().join(binary), b"stub").expect("write stub binary");
+
+    let (existed_preferred, existed_cargo) = existed_before_at_both(
+        &preferred_dir.path().join(binary),
+        &cargo_dir.path().join(binary),
+    );
+    assert!(
+        !existed_preferred,
+        "nothing was ever placed in the preferred dir"
+    );
+    assert!(
+        existed_cargo,
+        "a binary already sat at the cargo bin dir before this run"
+    );
+}
+
 /// Why: An unknown member must be a clean error (exit 3), not a silent skip.
 /// What: Calls `run` with a bogus member in `--json` mode; asserts exit 3.
 /// Test: This is the test.

--- a/crates/trusty-installer/src/commands/macos_signing/mod.rs
+++ b/crates/trusty-installer/src/commands/macos_signing/mod.rs
@@ -723,26 +723,37 @@ pub fn signing_persistence_tip() -> &'static str {
 /// multi-line guidance into the middle of the live per-component checklist —
 /// it is now data the caller can defer to a post-install summary instead).
 ///
-/// `existed_before` — whether a binary already sat at `set`'s primary path
-/// before THIS install call placed a fresh copy — selects the fresh-install
-/// vs. reinstall guidance variant (see [`fda_guidance`] / [`app_data_guidance`]).
-/// The `bool` half of the returned tuple is `true` only when the note is
-/// no-cert guidance (never for a signed-OK note or a codesign-warning note),
-/// so the caller can print [`signing_persistence_tip`] once, only when it is
-/// actually relevant.
+/// `existed_before` and `primary_path` (#3846 code-critic MEDIUM fix) MUST
+/// come from the caller's `install_one`/`InstalledBinary` result — the
+/// CONCRETE path/replace-state observed on the outcome branch actually
+/// taken (prebuilt `install_dir`, or the `cargo install` fallback's bin
+/// dir) — never re-derived here as `install_dir.join(primary)`. Re-deriving
+/// against a single fixed `install_dir` silently named/tested the wrong
+/// file whenever the fallback branch fired, since that branch's real
+/// destination is a different directory. `install_dir` is still used below,
+/// unchanged, for the SEPARATE signing loop that walks every binary in
+/// `set` when a cert IS found — that loop is unaffected by this fix.
+///
+/// `existed_before` selects the fresh-install vs. reinstall guidance variant
+/// (see [`fda_guidance`] / [`app_data_guidance`]). The `bool` half of the
+/// returned tuple is `true` only when the note is no-cert guidance (never
+/// for a signed-OK note or a codesign-warning note), so the caller can print
+/// [`signing_persistence_tip`] once, only when it is actually relevant.
 #[cfg(target_os = "macos")]
 fn post_install_signed_set(
     install_dir: &std::path::Path,
     set: &str,
     json: bool,
     existed_before: bool,
+    primary_path: &std::path::Path,
 ) -> Option<(String, bool)> {
     if json {
         return None;
     }
     let binaries = binaries_for_set(set);
-    let &primary = binaries.first()?;
-    let primary_path = install_dir.join(primary);
+    if binaries.is_empty() {
+        return None;
+    }
     let hardened = use_hardened_runtime(set, false);
 
     match has_developer_id_cert() {
@@ -798,7 +809,9 @@ fn post_install_signed_set(
 /// returning its note/guidance text instead of printing directly (see that
 /// function's doc), plus a `bool` telling the caller whether
 /// [`signing_persistence_tip`] should be printed. On non-macOS: `None`.
-/// `existed_before` — see [`post_install_signed_set`].
+/// `existed_before` / `primary_path` — see [`post_install_signed_set`]; both
+/// MUST come from the caller's `InstalledBinary` result for the CONCRETE
+/// outcome branch taken, never re-derived from `install_dir` alone.
 ///
 /// Test: `tests::fda_guidance_fresh_install_has_no_remove_step` /
 /// `tests::fda_guidance_reinstall_has_remove_and_readd` (pure); signing
@@ -808,14 +821,15 @@ pub fn post_install_search(
     install_dir: &std::path::Path,
     json: bool,
     existed_before: bool,
+    primary_path: &std::path::Path,
 ) -> Option<(String, bool)> {
     #[cfg(target_os = "macos")]
     {
-        post_install_signed_set(install_dir, SEARCH_SET, json, existed_before)
+        post_install_signed_set(install_dir, SEARCH_SET, json, existed_before, primary_path)
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (install_dir, json, existed_before); // suppress unused warnings on non-macOS
+        let _ = (install_dir, json, existed_before, primary_path); // suppress unused warnings on non-macOS
         None
     }
 }
@@ -830,7 +844,9 @@ pub fn post_install_search(
 /// returning its note/guidance text instead of printing directly (see that
 /// function's doc), plus a `bool` telling the caller whether
 /// [`signing_persistence_tip`] should be printed. On non-macOS: `None`.
-/// `existed_before` — see [`post_install_signed_set`].
+/// `existed_before` / `primary_path` — see [`post_install_signed_set`]; both
+/// MUST come from the caller's `InstalledBinary` result for the CONCRETE
+/// outcome branch taken, never re-derived from `install_dir` alone.
 ///
 /// Test: `tests::app_data_guidance_fresh_and_reinstall_variants` (pure);
 /// signing itself is not invoked in tests (side-effecting).
@@ -839,14 +855,15 @@ pub fn post_install_mpm(
     install_dir: &std::path::Path,
     json: bool,
     existed_before: bool,
+    primary_path: &std::path::Path,
 ) -> Option<(String, bool)> {
     #[cfg(target_os = "macos")]
     {
-        post_install_signed_set(install_dir, MPM_SET, json, existed_before)
+        post_install_signed_set(install_dir, MPM_SET, json, existed_before, primary_path)
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (install_dir, json, existed_before); // suppress unused warnings on non-macOS
+        let _ = (install_dir, json, existed_before, primary_path); // suppress unused warnings on non-macOS
         None
     }
 }

--- a/crates/trusty-installer/src/commands/macos_signing/mod.rs
+++ b/crates/trusty-installer/src/commands/macos_signing/mod.rs
@@ -611,59 +611,98 @@ pub fn cert_setup_guidance(target: &str) -> String {
     )
 }
 
-/// The 4-step FDA re-grant guidance (used when no Developer ID cert is found).
+/// Terse Full Disk Access guidance for `trusty-search` (used when no
+/// Developer ID cert is found). Selects the fresh-install or reinstall
+/// variant based on `existed_before`.
 ///
-/// Why: Extracted as a pure function so the exact guidance text can be unit-tested
-/// without any system calls.
+/// Why (#3846, Bob 2026-07-24 live `tctl` 0.4.8 run): the prior guidance
+/// was a fixed ~12-line block that always printed remove-then-re-add REINSTALL
+/// steps, even on a brand-new machine with no prior FDA entry to remove, and
+/// opened with "Every `cargo install`..." although this install path is
+/// prebuilt-tarball-based, not `cargo install`. Extracted as a pure function
+/// (no system calls) so both variants are unit-tested directly; the
+/// once-only Developer ID/`TRUSTY_SIGN_IDENTITY` tip moved out of here to
+/// [`signing_persistence_tip`] so it prints once per install run, not once
+/// per guidance block.
 ///
-/// What: Returns the formatted 4-step manual FDA re-grant instructions, with
-/// the actual binary path interpolated.
+/// What: `existed_before == false` (nothing was at this path before this
+/// install) prints the one-time initial-grant steps; `existed_before == true`
+/// (a prior binary was replaced) prints the remove/re-add + daemon-restart
+/// steps, since replacing the binary's code signature invalidated the
+/// existing grant regardless of install method. Both variants stay at 3
+/// lines and point at the full step-by-step doc for detail instead of
+/// inlining it.
 ///
-/// Test: `tests::fda_guidance_contains_steps`.
-pub fn fda_guidance(binary_path: &str) -> String {
-    format!(
-        "trusty-search FDA guidance (macOS):\n\
-         Every `cargo install` replaces the binary with a new cdhash, which invalidates\n\
-         the macOS TCC Full Disk Access grant. Re-grant it now:\n\
-         \n\
-         1. Open System Settings \u{2192} Privacy & Security \u{2192} Full Disk Access.\n\
-         2. Remove `{binary_path}` from the list (click the entry, then click -).\n\
-         3. Re-add it (click +, navigate to `{binary_path}`).\n\
-         4. Restart the daemon:\n\
-            launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist\n\
-            launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.trusty-search.plist\n\
-         \n\
-         Tip: install a Developer ID Application certificate and set TRUSTY_SIGN_IDENTITY\n\
-         to make this grant persist across all future reinstalls."
-    )
+/// Test: `tests::fda_guidance_fresh_install_has_no_remove_step`,
+/// `tests::fda_guidance_reinstall_has_remove_and_readd`.
+pub fn fda_guidance(binary_path: &str, existed_before: bool) -> String {
+    if existed_before {
+        format!(
+            "trusty-search: reinstalling replaced the binary's code signature, which \
+             invalidates its Full Disk Access grant.\n\
+             Re-grant it: remove `{binary_path}` from System Settings \u{2192} Privacy & \
+             Security \u{2192} Full Disk Access, then re-add it and restart the daemon.\n\
+             Full steps: docs/reference/release-workflow.md#one-time-fda-grant-after-first-signed-install"
+        )
+    } else {
+        format!(
+            "trusty-search: macOS Full Disk Access is required for `{binary_path}` to \
+             read other apps' files.\n\
+             Grant it once: System Settings \u{2192} Privacy & Security \u{2192} Full Disk \
+             Access \u{2192} + \u{2192} select the binary.\n\
+             Full steps: docs/reference/release-workflow.md#one-time-fda-grant-after-first-signed-install"
+        )
+    }
 }
 
-/// The App-Data TCC guidance for `trusty-mpm` (used when no Developer ID cert
-/// is found).
+/// Terse App-Data TCC guidance for `trusty-mpm` (used when no Developer ID
+/// cert is found). Selects the fresh-install or reinstall variant based on
+/// `existed_before`.
 ///
 /// Why: `tm` re-prompts "'trusty-mpm' would like to access data from other
-/// apps" after every ad-hoc-signed rebuild, for the same cdhash-identity reason
-/// FDA does for trusty-search — but it is a different TCC category (App Data,
-/// not Full Disk Access) with no `System Settings` list entry to remove/re-add,
-/// so the guidance differs from [`fda_guidance`].
+/// apps" after every ad-hoc-signed rebuild, for the same cdhash-identity
+/// reason FDA does for trusty-search — but it is a different TCC category
+/// (App Data, not Full Disk Access) with no `System Settings` list entry to
+/// remove/re-add, so the guidance differs from [`fda_guidance`]. See that
+/// function's doc for why `existed_before` exists and why the signing tip
+/// moved to [`signing_persistence_tip`].
 ///
-/// What: Returns guidance explaining that the next prompt must be approved once
-/// and that a Developer ID cert makes that approval persist.
+/// What: Returns guidance explaining that the (next, or re-triggered) prompt
+/// must be approved once; points at the full doc section for detail.
 ///
-/// Test: `tests::app_data_guidance_mentions_prompt`.
-pub fn app_data_guidance(binary_path: &str) -> String {
-    format!(
-        "trusty-mpm App Data TCC guidance (macOS):\n\
-         Every `cargo install` replaces the binary with a new cdhash, so macOS re-prompts\n\
-         \"'trusty-mpm' would like to access data from other apps\" (it reads other apps'\n\
-         $HOME containers — Claude config dirs, tmux state) after every reinstall.\n\
-         \n\
-         Approve the next prompt for `{binary_path}` when it appears — no manual\n\
-         System Settings step is required for this TCC category.\n\
-         \n\
-         Tip: install a Developer ID Application certificate and set TRUSTY_SIGN_IDENTITY\n\
-         to make that approval persist across all future reinstalls (run `tctl sign trusty-mpm`)."
-    )
+/// Test: `tests::app_data_guidance_fresh_and_reinstall_variants`.
+pub fn app_data_guidance(binary_path: &str, existed_before: bool) -> String {
+    if existed_before {
+        format!(
+            "trusty-mpm: reinstalling replaced the binary's code signature, so macOS \
+             will re-prompt for App Data access.\n\
+             Approve the \"'trusty-mpm' would like to access data from other apps\" \
+             prompt again for `{binary_path}` when it appears.\n\
+             Full steps: docs/reference/release-workflow.md#signed-install-trusty-mpm-2558-2721"
+        )
+    } else {
+        format!(
+            "trusty-mpm: macOS will prompt to let `{binary_path}` access data from \
+             other apps (it reads Claude/tmux config dirs).\n\
+             Approve that prompt when it appears — no System Settings step is needed.\n\
+             Full steps: docs/reference/release-workflow.md#signed-install-trusty-mpm-2558-2721"
+        )
+    }
+}
+
+/// The one-time signing-persistence tip — printed at most once per install
+/// run, after every per-component TCC guidance block, instead of being
+/// duplicated inside each of [`fda_guidance`] / [`app_data_guidance`].
+///
+/// Why (#3846): the pre-fix guidance repeated an identical
+/// `TRUSTY_SIGN_IDENTITY` tip inside every component's block; a two-component
+/// install (trusty-search + trusty-mpm) printed it twice back to back.
+///
+/// Test: `tests::signing_persistence_tip_mentions_sign_identity_and_tctl_sign`.
+pub fn signing_persistence_tip() -> &'static str {
+    "Tip: install a Developer ID Application certificate (or set TRUSTY_SIGN_IDENTITY) \
+     and run `tctl sign <trusty-search|trusty-mpm>` to make these grants persist across \
+     every future reinstall."
 }
 
 /// Run the fail-soft post-install signing hook for a named set.
@@ -683,8 +722,21 @@ pub fn app_data_guidance(binary_path: &str) -> String {
 /// (demo-critical fix: this used to `eprintln!` directly, interleaving noisy
 /// multi-line guidance into the middle of the live per-component checklist —
 /// it is now data the caller can defer to a post-install summary instead).
+///
+/// `existed_before` — whether a binary already sat at `set`'s primary path
+/// before THIS install call placed a fresh copy — selects the fresh-install
+/// vs. reinstall guidance variant (see [`fda_guidance`] / [`app_data_guidance`]).
+/// The `bool` half of the returned tuple is `true` only when the note is
+/// no-cert guidance (never for a signed-OK note or a codesign-warning note),
+/// so the caller can print [`signing_persistence_tip`] once, only when it is
+/// actually relevant.
 #[cfg(target_os = "macos")]
-fn post_install_signed_set(install_dir: &std::path::Path, set: &str, json: bool) -> Option<String> {
+fn post_install_signed_set(
+    install_dir: &std::path::Path,
+    set: &str,
+    json: bool,
+    existed_before: bool,
+) -> Option<(String, bool)> {
     if json {
         return None;
     }
@@ -713,22 +765,25 @@ fn post_install_signed_set(install_dir: &std::path::Path, set: &str, json: bool)
                 }
             }
             if signed_ok {
-                Some(format!(
-                    "{set}: signed with Developer ID. The macOS grant will persist across \
-                     all future reinstalls."
+                Some((
+                    format!(
+                        "{set}: signed with Developer ID. The macOS grant will persist across \
+                         all future reinstalls."
+                    ),
+                    false,
                 ))
             } else {
-                Some(warnings.join("\n"))
+                Some((warnings.join("\n"), false))
             }
         }
         None => {
             let path_str = primary_path.to_string_lossy();
             let guidance = if set == MPM_SET {
-                app_data_guidance(&path_str)
+                app_data_guidance(&path_str, existed_before)
             } else {
-                fda_guidance(&path_str)
+                fda_guidance(&path_str, existed_before)
             };
-            Some(guidance)
+            Some((guidance, true))
         }
     }
 }
@@ -741,19 +796,26 @@ fn post_install_signed_set(install_dir: &std::path::Path, set: &str, json: bool)
 ///
 /// What: On macOS delegates to [`post_install_signed_set`] for [`SEARCH_SET`],
 /// returning its note/guidance text instead of printing directly (see that
-/// function's doc). On non-macOS: `None`.
+/// function's doc), plus a `bool` telling the caller whether
+/// [`signing_persistence_tip`] should be printed. On non-macOS: `None`.
+/// `existed_before` — see [`post_install_signed_set`].
 ///
-/// Test: `tests::fda_guidance_contains_steps` (pure); signing itself is not
-/// invoked in tests (side-effecting).
+/// Test: `tests::fda_guidance_fresh_install_has_no_remove_step` /
+/// `tests::fda_guidance_reinstall_has_remove_and_readd` (pure); signing
+/// itself is not invoked in tests (side-effecting).
 #[must_use]
-pub fn post_install_search(install_dir: &std::path::Path, json: bool) -> Option<String> {
+pub fn post_install_search(
+    install_dir: &std::path::Path,
+    json: bool,
+    existed_before: bool,
+) -> Option<(String, bool)> {
     #[cfg(target_os = "macos")]
     {
-        post_install_signed_set(install_dir, SEARCH_SET, json)
+        post_install_signed_set(install_dir, SEARCH_SET, json, existed_before)
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (install_dir, json); // suppress unused warnings on non-macOS
+        let _ = (install_dir, json, existed_before); // suppress unused warnings on non-macOS
         None
     }
 }
@@ -766,19 +828,25 @@ pub fn post_install_search(install_dir: &std::path::Path, json: bool) -> Option<
 ///
 /// What: On macOS delegates to [`post_install_signed_set`] for [`MPM_SET`],
 /// returning its note/guidance text instead of printing directly (see that
-/// function's doc). On non-macOS: `None`.
+/// function's doc), plus a `bool` telling the caller whether
+/// [`signing_persistence_tip`] should be printed. On non-macOS: `None`.
+/// `existed_before` — see [`post_install_signed_set`].
 ///
-/// Test: `tests::app_data_guidance_mentions_prompt` (pure); signing itself is
-/// not invoked in tests (side-effecting).
+/// Test: `tests::app_data_guidance_fresh_and_reinstall_variants` (pure);
+/// signing itself is not invoked in tests (side-effecting).
 #[must_use]
-pub fn post_install_mpm(install_dir: &std::path::Path, json: bool) -> Option<String> {
+pub fn post_install_mpm(
+    install_dir: &std::path::Path,
+    json: bool,
+    existed_before: bool,
+) -> Option<(String, bool)> {
     #[cfg(target_os = "macos")]
     {
-        post_install_signed_set(install_dir, MPM_SET, json)
+        post_install_signed_set(install_dir, MPM_SET, json, existed_before)
     }
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = (install_dir, json); // suppress unused warnings on non-macOS
+        let _ = (install_dir, json, existed_before); // suppress unused warnings on non-macOS
         None
     }
 }

--- a/crates/trusty-installer/src/commands/macos_signing/tests.rs
+++ b/crates/trusty-installer/src/commands/macos_signing/tests.rs
@@ -117,17 +117,21 @@ fn identifier_migration_notice_silent_when_unchanged_or_absent() {
     assert!(identifier_migration_notice("trusty-search", "com.trusty.trusty-search").is_none());
 }
 
-/// Why: The FDA guidance must contain all 4 numbered steps and reference the
-/// binary path so the operator knows which file to re-add.
-/// What: Calls `fda_guidance` with a synthetic path and checks the output.
+/// Why (#3846): a first install has no prior FDA entry to remove — the
+/// fresh-install variant must NOT tell the operator to remove anything, only
+/// to grant FDA once, and must stay terse (≤3 lines) with a pointer to the
+/// full doc instead of inlining every step.
+/// What: Calls `fda_guidance` with `existed_before = false` and checks the
+/// output has no remove/re-add language, references the binary path, and
+/// points at the doc anchor.
 /// Test: This is the test.
 #[test]
-fn fda_guidance_contains_steps() {
-    let guidance = fda_guidance("/usr/local/bin/trusty-search");
-    assert!(guidance.contains("1."), "step 1 missing");
-    assert!(guidance.contains("2."), "step 2 missing");
-    assert!(guidance.contains("3."), "step 3 missing");
-    assert!(guidance.contains("4."), "step 4 missing");
+fn fda_guidance_fresh_install_has_no_remove_step() {
+    let guidance = fda_guidance("/usr/local/bin/trusty-search", false);
+    assert!(
+        !guidance.to_lowercase().contains("remove"),
+        "fresh-install guidance must not mention removing a prior entry: {guidance}"
+    );
     assert!(
         guidance.contains("/usr/local/bin/trusty-search"),
         "binary path not in guidance"
@@ -136,6 +140,57 @@ fn fda_guidance_contains_steps() {
         guidance.contains("Full Disk Access"),
         "FDA label not in guidance"
     );
+    assert!(
+        guidance.contains("docs/reference/release-workflow.md"),
+        "must point at the full-detail doc"
+    );
+    assert!(
+        guidance.lines().count() <= 3,
+        "fresh-install guidance must stay terse (<=3 lines): {guidance}"
+    );
+}
+
+/// Why (#3846): replacing an existing binary DOES invalidate its FDA
+/// grant (cdhash changed), so the reinstall variant must retain the
+/// remove-then-re-add + daemon-restart guidance the fresh variant omits.
+/// What: Calls `fda_guidance` with `existed_before = true` and checks for
+/// remove/re-add language, the binary path, and terseness.
+/// Test: This is the test.
+#[test]
+fn fda_guidance_reinstall_has_remove_and_readd() {
+    let guidance = fda_guidance("/usr/local/bin/trusty-search", true);
+    assert!(
+        guidance.to_lowercase().contains("re-grant") || guidance.to_lowercase().contains("remove"),
+        "reinstall guidance must mention re-granting/removing the stale entry: {guidance}"
+    );
+    assert!(
+        guidance.contains("/usr/local/bin/trusty-search"),
+        "binary path not in guidance"
+    );
+    assert!(
+        guidance.contains("docs/reference/release-workflow.md"),
+        "must point at the full-detail doc"
+    );
+    assert!(
+        guidance.lines().count() <= 3,
+        "reinstall guidance must stay terse (<=3 lines): {guidance}"
+    );
+}
+
+/// Why (#3846): the preamble must not claim `cargo install` specifically —
+/// this install path is prebuilt-tarball-based via `tctl`, and the guidance
+/// text must be installation-method-agnostic.
+/// What: Asserts neither guidance variant mentions `cargo install`.
+/// Test: This is the test.
+#[test]
+fn fda_guidance_is_install_method_agnostic() {
+    for existed_before in [false, true] {
+        let guidance = fda_guidance("/usr/local/bin/trusty-search", existed_before);
+        assert!(
+            !guidance.contains("cargo install"),
+            "guidance must not name a specific install method: {guidance}"
+        );
+    }
 }
 
 /// Why: `TRUSTY_SIGN_IDENTITY` env var must override the keychain probe.
@@ -247,34 +302,87 @@ fn parse_developer_id_identity_skips_malformed_line() {
     );
 }
 
-/// Why: `fda_guidance` must mention Developer ID as the permanent fix tip.
-/// What: Asserts the tip line is present.
+/// Why (#3846): the Developer ID / `TRUSTY_SIGN_IDENTITY` tip moved OUT of
+/// the per-component guidance into [`signing_persistence_tip`] so it prints
+/// once per run, not once per component — `fda_guidance` must no longer
+/// embed it.
+/// What: Asserts neither variant of `fda_guidance` mentions Developer ID,
+/// while `signing_persistence_tip` itself does.
 /// Test: This is the test.
 #[test]
-fn fda_guidance_mentions_developer_id_tip() {
-    let g = fda_guidance("/some/path/trusty-search");
-    assert!(
-        g.contains("Developer ID"),
-        "tip about Developer ID cert missing"
-    );
+fn fda_guidance_no_longer_embeds_signing_tip() {
+    for existed_before in [false, true] {
+        let g = fda_guidance("/some/path/trusty-search", existed_before);
+        assert!(
+            !g.contains("Developer ID"),
+            "the once-per-run signing tip must not be embedded per-component: {g}"
+        );
+    }
 }
 
 /// Why: The App-Data TCC guidance must reference the binary path and the
-/// actual macOS prompt wording so the operator recognises it.
-/// What: Calls `app_data_guidance` and checks the output.
+/// actual macOS prompt wording so the operator recognises it, in BOTH the
+/// fresh-install and reinstall variants, and must stay terse and
+/// method-agnostic (no "cargo install") like [`fda_guidance`].
+/// What: Calls `app_data_guidance` with both `existed_before` values and
+/// checks the output.
 /// Test: This is the test.
 #[test]
-fn app_data_guidance_mentions_prompt() {
-    let g = app_data_guidance("/usr/local/bin/trusty-mpm");
+fn app_data_guidance_fresh_and_reinstall_variants() {
+    for existed_before in [false, true] {
+        let g = app_data_guidance("/usr/local/bin/trusty-mpm", existed_before);
+        assert!(
+            g.contains("access data from other apps"),
+            "TCC prompt wording missing: {g}"
+        );
+        assert!(
+            g.contains("/usr/local/bin/trusty-mpm"),
+            "binary path missing: {g}"
+        );
+        assert!(
+            !g.contains("Developer ID"),
+            "signing tip must not be embedded per-component: {g}"
+        );
+        assert!(
+            !g.contains("cargo install"),
+            "guidance must not name a specific install method: {g}"
+        );
+        assert!(
+            g.contains("docs/reference/release-workflow.md"),
+            "must point at the full-detail doc: {g}"
+        );
+        assert!(
+            g.lines().count() <= 3,
+            "guidance must stay terse (<=3 lines): {g}"
+        );
+    }
+}
+
+/// Why (#3846): the fresh-install variant additionally must not carry any
+/// reinstall-specific wording ("reinstalling replaced").
+/// What: Asserts the `existed_before = false` variant has no reinstall
+/// language.
+/// Test: This is the test.
+#[test]
+fn app_data_guidance_fresh_install_has_no_reinstall_wording() {
+    let g = app_data_guidance("/usr/local/bin/trusty-mpm", false);
     assert!(
-        g.contains("access data from other apps"),
-        "TCC prompt wording missing"
+        !g.to_lowercase().contains("reinstall"),
+        "fresh-install guidance must not mention reinstalling: {g}"
     );
-    assert!(
-        g.contains("/usr/local/bin/trusty-mpm"),
-        "binary path missing"
-    );
-    assert!(g.contains("Developer ID"), "Developer ID tip missing");
+}
+
+/// Why (#3846): the signing tip must exist exactly once, be found via
+/// [`signing_persistence_tip`], and mention both the env-var override and the
+/// `tctl sign` invocation so it stands alone as a complete pointer.
+/// What: Asserts the returned string mentions `TRUSTY_SIGN_IDENTITY` and
+/// `tctl sign`.
+/// Test: This is the test.
+#[test]
+fn signing_persistence_tip_mentions_sign_identity_and_tctl_sign() {
+    let tip = signing_persistence_tip();
+    assert!(tip.contains("TRUSTY_SIGN_IDENTITY"));
+    assert!(tip.contains("tctl sign"));
 }
 
 /// Why: The cert-setup guidance must reference the exact `tctl sign`


### PR DESCRIPTION
## Summary

- `tctl install`'s post-install FDA / App-Data TCC guidance always printed reinstall-only remove-then-re-add steps, even on a brand-new machine with nothing to remove, and opened with "Every `cargo install`..." even when the binaries were placed via prebuilt tarballs through `tctl` — Bob hit this live installing `tctl` 0.4.8.
- `fda_guidance` / `app_data_guidance` now take `existed_before: bool` and print a first-install variant (grant once, nothing to remove) vs. a reinstall variant (remove/re-add + restart daemon), both capped at 3 lines, method-agnostic, and pointing at `docs/reference/release-workflow.md` for full detail instead of inlining every step.
- The `TRUSTY_SIGN_IDENTITY`/`tctl sign` tip moved out of each per-component block into a new `signing_persistence_tip()`, printed once per install run instead of once per component.

Closes #3846

## Test plan

- [x] `cargo test -p trusty-installer` — 458 passed, 0 failed (full suite, not `--lib`)
- [x] `cargo test -p trusty-installer macos_signing` — 20 passed, 0 failed (new fresh/reinstall/method-agnostic/tip tests included)
- [x] `cargo clippy -p trusty-installer --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-installer` — clean
- [x] `CHANGELOG.md` — `[Unreleased]` entry added (0.4.8 is already tagged/released)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools