### PR TITLE
fix(trusty-installer): run bootstrap postcondition on already-installed path + verify-tail fallback

### DIFF
--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -6,6 +6,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **The 0.4.8 defensive service-bootstrap postcondition never ran on the
+  already-installed / re-run path — exactly the machines it exists to repair**
+  (#3841, demo-critical; reproduced on a real demo MacBook minutes after
+  0.4.8 shipped). Root cause: `service_bootstrap::bootstrap_one` checked
+  `plist_present(binary)` FIRST and returned `Skipped` immediately whenever a
+  plist already existed on disk — before ever reaching the #3836 `is_loaded`
+  → `bootstrap_fallback` postcondition below it. A plist left behind by an
+  EARLIER, pre-0.4.8 run that hit #3832 (trusty-memory's `service install`
+  wrote the plist without loading it) is exactly "already present"; a 0.4.8
+  re-run over that state took the skip branch and the defensive fallback
+  never fired, leaving `com.trusty.memory` permanently absent from
+  `launchctl list` and `tctl install` exiting 2 / `NOT VERIFIED`. Fixed by
+  running the same `is_loaded` → `bootstrap_fallback` postcondition on the
+  already-present branch too (reported as the new
+  `BootstrapAction::LoadedByFallback`), never re-running `service install`
+  over an existing plist (the non-clobber guarantee is unchanged — only the
+  *load* is repaired, not the plist itself).
+- Belt-and-braces second layer: the post-install verify tail
+  (`verify_tail::verify_one`) now also attempts the installer's own
+  `launchctl bootstrap` fallback for any member it classifies
+  `DownState::NotLoaded` whose plist is present on disk, re-probing on
+  success (#3841). This means a future regression in the install-time
+  skip-path handling — or any member the install-time bootstrap didn't run
+  for this invocation — still self-heals at verify time instead of silently
+  reporting `NOT VERIFIED`.
+- Manual workaround for a machine already stuck in this state (installer
+  0.4.8, no code fix applied): `launchctl bootstrap gui/$(id -u)
+  ~/Library/LaunchAgents/com.trusty.memory.plist && launchctl kickstart -k
+  gui/$(id -u)/com.trusty.memory`.
+
 ## [0.4.8] — 2026-07-24
 
 ### Fixed

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -34,7 +34,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   success (#3841). This means a future regression in the install-time
   skip-path handling — or any member the install-time bootstrap didn't run
   for this invocation — still self-heals at verify time instead of silently
-  reporting `NOT VERIFIED`.
+  reporting `NOT VERIFIED`. Code-critic fix round on PR #3849 (APPROVE, 2
+  MEDIUM): the post-fallback re-probe now goes through the SAME bounded
+  `poll_until_not_down`/`bounded_attempts` machinery the #2498 kickstart
+  retry uses (respecting whatever of the aggregate poll budget the member's
+  own kickstart phase already spent) instead of a single instant re-probe
+  that could race a just-repaired but slow-starting daemon into a false
+  `NOT VERIFIED` — the same race class #3833 fixed for the kickstart path;
+  and the fallback attempt itself (`apply_not_loaded_fallback`) now takes an
+  injectable `ServiceEnv` (mirroring `bootstrap_one`), with new unit tests
+  covering both a successful and a failed fallback outcome.
 - Manual workaround for a machine already stuck in this state (installer
   0.4.8, no code fix applied): `launchctl bootstrap gui/$(id -u)
   ~/Library/LaunchAgents/com.trusty.memory.plist && launchctl kickstart -k

--- a/crates/trusty-installer/src/commands/service_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap.rs
@@ -37,6 +37,21 @@
 //! reported as [`BootstrapAction::InstalledByFallback`] rather than a silent
 //! `Installed`, so the narration is honest about what actually happened.
 //!
+//! 🔴 (#3841 root-cause fix, demo-critical) 0.4.8 shipped the #3836 check
+//! ONLY on the fresh-install branch (no plist yet). A machine already
+//! carrying a plist-present-but-unloaded state — e.g. left behind by an
+//! EARLIER pre-0.4.8 run that hit #3832 — hits `bootstrap_one`'s
+//! ALREADY-INSTALLED skip branch instead, which used to return `Skipped`
+//! unconditionally without EVER checking `is_loaded`, so the defensive
+//! postcondition never ran for exactly the machines it exists to repair.
+//! [`bootstrap_one`] now runs the same `is_loaded` → `bootstrap_fallback`
+//! postcondition on THAT branch too (reported as
+//! [`BootstrapAction::LoadedByFallback`]), still without ever re-running
+//! `service install` over an existing plist (non-clobbering, unchanged). The
+//! post-install verify tail (`verify_tail`) additionally attempts the same
+//! fallback at its own layer for a `NotLoaded` member — belt-and-braces, so a
+//! future skip-path regression still self-heals at verify time.
+//!
 //! Testability: every side effect is behind the [`ServiceEnv`] seam so the
 //! decision logic is unit-tested against an in-memory fake — the tests NEVER
 //! touch `~/Library/LaunchAgents` or invoke `launchctl` against the live
@@ -44,8 +59,8 @@
 //!
 //! Test: `tests` covers the member predicate, the opt-out truth table, every
 //! [`bootstrap_one`] branch — including the #3836 defensive-fallback branches
-//! — (via `FakeServiceEnv`), and the [`start_plan`] relaxation used by
-//! `lifecycle.rs`.
+//! and the #3841 already-installed-path branches — (via `FakeServiceEnv`),
+//! and the [`start_plan`] relaxation used by `lifecycle.rs`.
 
 /// Environment-variable opt-out for the post-install service bootstrap.
 ///
@@ -65,11 +80,16 @@ pub const NO_SERVICE_ENV: &str = "TCTL_NO_SERVICE_BOOTSTRAP";
 /// install` ran clean AND launchd confirmed the label loaded;
 /// `InstalledByFallback` (#3836) means `service install` exited clean but
 /// launchd did NOT have the label loaded, so the installer force-bootstrapped
-/// the plist directly; `Failed` carries the (non-fatal) error text.
+/// the plist directly; `LoadedByFallback` (#3841 — the already-installed
+/// skip-path gap) means a plist ALREADY EXISTED on disk (so `service install`
+/// was never re-run at all) but launchd did not have the label loaded, so the
+/// installer force-bootstrapped the existing plist directly; `Failed` carries
+/// the (non-fatal) error text.
 /// Test: `bootstrap_one_*` tests assert each variant.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum BootstrapAction {
-    /// Not attempted — opt-out, not a service member, or plist already present.
+    /// Not attempted — opt-out, not a service member, or plist already
+    /// present AND already loaded.
     Skipped(String),
     /// `<binary> service install` ran successfully AND launchd loaded it.
     Installed,
@@ -79,6 +99,12 @@ pub enum BootstrapAction {
     /// component binary whose own `service install` doesn't actually load
     /// the agent, e.g. an older already-published release).
     InstalledByFallback,
+    /// The plist already existed on disk (so `service install` was NOT
+    /// re-run — non-clobbering) but launchd did not have the label loaded;
+    /// the installer force-bootstrapped the existing plist directly (#3841 —
+    /// the same #3832 defense, extended to the already-installed/re-run
+    /// path, which previously skipped the postcondition check entirely).
+    LoadedByFallback,
     /// Shell-out failed; install continues (fail-soft) but this is surfaced.
     Failed(String),
 }
@@ -98,6 +124,10 @@ impl BootstrapAction {
             BootstrapAction::InstalledByFallback => format!(
                 "{binary}: launchd service installed; bootstrapped by installer \
                  (component binary did not load its service)"
+            ),
+            BootstrapAction::LoadedByFallback => format!(
+                "{binary}: launchd plist already present but was not loaded; \
+                 bootstrapped by installer"
             ),
             BootstrapAction::Skipped(reason) => {
                 format!("{binary}: service bootstrap skipped ({reason})")
@@ -172,15 +202,37 @@ pub trait ServiceEnv {
 /// Decide and (via the seam) execute the service bootstrap for one member.
 ///
 /// Why: this is the whole per-member policy — filter non-service members, honour
-/// idempotency / non-clobber by skipping when a plist already exists, delegate
-/// to `service install`, and (#3836) independently VERIFY the postcondition
-/// `service install` is supposed to establish (the label is loaded) rather
-/// than trusting its exit code alone — #3832 was exactly a component binary
-/// whose `service install` exited 0 without ever loading the agent.
+/// idempotency / non-clobber by never re-running `service install` over an
+/// existing plist, and (#3836, extended by #3841) independently VERIFY the
+/// postcondition `service install` is supposed to establish (the label is
+/// loaded) rather than trusting its exit code alone — #3832 was exactly a
+/// component binary whose `service install` exited 0 without ever loading the
+/// agent.
+///
+/// 🔴 (#3841 root-cause fix) The #3836 postcondition check originally lived
+/// ONLY on the fresh-install branch below (`plist_present == false`). On a
+/// machine already carrying a plist-present-but-never-loaded state — e.g. an
+/// EARLIER `tctl install` run that hit exactly the #3832 bug before 0.4.8
+/// shipped — a re-run's `plist_present(binary)` is `true`, so the OLD code
+/// returned `Skipped` immediately and the postcondition never ran at all.
+/// That is precisely the demo-critical reproduction: 0.4.8's defensive
+/// fallback existed, but the exact machines it was meant to repair (damaged
+/// by an older run) took the one code path that never reached it. The
+/// already-present branch now runs the SAME `is_loaded` check the fresh
+/// branch does, and force-bootstraps via [`ServiceEnv::bootstrap_fallback`]
+/// (never re-running `service install` — the non-clobber guarantee is
+/// unchanged) when the label is not loaded.
+///
 /// What: returns [`BootstrapAction::Skipped`] when the member has no `service
-/// install` subcommand or a plist is already present. Otherwise runs
-/// `run_service_install`; on success, checks [`ServiceEnv::is_loaded`] — if
-/// loaded, returns [`BootstrapAction::Installed`]; if NOT loaded, calls
+/// install` subcommand. When a plist is already present: if
+/// [`ServiceEnv::is_loaded`], returns `Skipped` (unchanged, non-clobbering
+/// behaviour); otherwise force-bootstraps the existing plist via
+/// [`ServiceEnv::bootstrap_fallback`] and returns
+/// [`BootstrapAction::LoadedByFallback`] (or `Failed` if the fallback itself
+/// fails) WITHOUT ever calling `run_service_install`. Otherwise (no plist
+/// yet) runs `run_service_install`; on success, checks
+/// [`ServiceEnv::is_loaded`] — if loaded, returns
+/// [`BootstrapAction::Installed`]; if NOT loaded, calls
 /// [`ServiceEnv::bootstrap_fallback`] and returns
 /// [`BootstrapAction::InstalledByFallback`] on success or
 /// [`BootstrapAction::Failed`] (with BOTH failure reasons folded in) if the
@@ -188,19 +240,38 @@ pub trait ServiceEnv {
 /// [`BootstrapAction::Failed`] directly (the fallback is only for a
 /// misleadingly-successful exit code, not a genuine failure).
 /// Test: `bootstrap_one_skips_non_service_member`,
-/// `bootstrap_one_skips_when_plist_present`, `bootstrap_one_installs_when_absent`,
-/// `bootstrap_one_reports_failure`, `bootstrap_one_falls_back_when_not_loaded`,
+/// `bootstrap_one_skips_when_plist_present_and_loaded`,
+/// `bootstrap_one_installs_when_absent`, `bootstrap_one_reports_failure`,
+/// `bootstrap_one_falls_back_when_not_loaded`,
 /// `bootstrap_one_installed_directly_when_loaded`,
-/// `bootstrap_one_reports_failure_when_fallback_also_fails`.
+/// `bootstrap_one_reports_failure_when_fallback_also_fails`,
+/// `bootstrap_one_loads_via_fallback_when_plist_present_but_not_loaded`
+/// (THE #3841 miss, pinned against current main),
+/// `bootstrap_one_reports_failure_when_present_but_fallback_fails`.
 pub fn bootstrap_one(env: &dyn ServiceEnv, binary: &str) -> BootstrapAction {
     if !member_has_service_install(binary) {
         return BootstrapAction::Skipped(format!("{binary} has no `service install` subcommand"));
     }
     if env.plist_present(binary) {
-        return BootstrapAction::Skipped(
-            "launchd plist already present — left untouched (re-run `service install` to refresh)"
-                .to_string(),
-        );
+        // #3841: a plist already existing on disk is NOT proof launchd has
+        // it loaded — this is the exact gap the skip path left open. Never
+        // re-run `service install` over an existing plist (non-clobbering,
+        // unchanged), but DO independently verify the load postcondition and
+        // repair it in place when it doesn't hold.
+        if env.is_loaded(binary) {
+            return BootstrapAction::Skipped(
+                "launchd plist already present and loaded — left untouched (re-run \
+                 `service install` to refresh)"
+                    .to_string(),
+            );
+        }
+        return match env.bootstrap_fallback(binary) {
+            Ok(()) => BootstrapAction::LoadedByFallback,
+            Err(e) => BootstrapAction::Failed(format!(
+                "launchd plist already present for {binary} but not loaded, and the \
+                 installer's fallback `launchctl bootstrap` failed: {e}"
+            )),
+        };
     }
     if let Err(e) = env.run_service_install(binary) {
         return BootstrapAction::Failed(e.to_string());
@@ -534,12 +605,14 @@ mod tests {
         assert!(env.installed.borrow().is_empty());
     }
 
-    /// Why: idempotency + non-clobber — an existing plist must be left untouched
-    /// with NO `service install` call (no needless restart, no overwrite).
-    /// What: with `present = true`, asserts `Skipped` and no recorded install.
+    /// Why: idempotency + non-clobber — an existing, ALREADY LOADED plist
+    /// must be left untouched with NO `service install` call and NO fallback
+    /// bootstrap (no needless restart, no overwrite).
+    /// What: with `present = true` and `loaded` at its default (`true`),
+    /// asserts `Skipped`, no recorded install, and no recorded fallback call.
     /// Test: this is the test.
     #[test]
-    fn bootstrap_one_skips_when_plist_present() {
+    fn bootstrap_one_skips_when_plist_present_and_loaded() {
         let env = FakeServiceEnv::new(true, false);
         let action = bootstrap_one(&env, "trusty-search");
         assert!(matches!(action, BootstrapAction::Skipped(_)));
@@ -547,6 +620,57 @@ mod tests {
             env.installed.borrow().is_empty(),
             "must not re-install over an existing plist"
         );
+        assert!(
+            env.fallback_calls.borrow().is_empty(),
+            "must not force-bootstrap an already-loaded label"
+        );
+    }
+
+    /// Why: THE #3841 root-cause fix — a plist already present on disk is NOT
+    /// proof launchd has it loaded (a prior run can leave exactly this state,
+    /// #3832's failure signature). Before the fix, `bootstrap_one` returned
+    /// `Skipped` here WITHOUT ever checking `is_loaded`, so the #3836
+    /// defensive postcondition never ran for exactly the damaged machines it
+    /// exists to repair. This test fails against the pre-fix code (it always
+    /// short-circuited to `Skipped` the instant `plist_present` was `true`).
+    /// What: with `present = true` AND `loaded = false` (via `.not_loaded()`),
+    /// asserts `LoadedByFallback`, exactly one recorded `bootstrap_fallback`
+    /// call, and NO `service install` call (non-clobbering — the plist itself
+    /// is never rewritten, only loaded).
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_one_loads_via_fallback_when_plist_present_but_not_loaded() {
+        let env = FakeServiceEnv::new(true, false).not_loaded();
+        let action = bootstrap_one(&env, "trusty-memory");
+        assert_eq!(action, BootstrapAction::LoadedByFallback);
+        assert_eq!(env.fallback_calls.borrow().as_slice(), ["trusty-memory"]);
+        assert!(
+            env.installed.borrow().is_empty(),
+            "an already-present plist must never be re-installed, only loaded"
+        );
+    }
+
+    /// Why: even on the already-installed path, a fallback failure must be
+    /// surfaced loudly (`Failed`) with a message naming BOTH the plist-not-
+    /// loaded state and the fallback's own failure reason — mirrors
+    /// `bootstrap_one_reports_failure_when_fallback_also_fails` for the
+    /// fresh-install branch.
+    /// What: with `present = true`, `loaded = false`, and the fallback set to
+    /// fail, asserts `Failed` whose message names both facts.
+    /// Test: this is the test.
+    #[test]
+    fn bootstrap_one_reports_failure_when_present_but_fallback_fails() {
+        let env = FakeServiceEnv::new(true, false)
+            .not_loaded()
+            .failing_fallback();
+        let action = bootstrap_one(&env, "trusty-review");
+        match action {
+            BootstrapAction::Failed(e) => {
+                assert!(e.contains("not loaded"), "message: {e}");
+                assert!(e.contains("simulated fallback failure"), "message: {e}");
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
     }
 
     /// Why: the core happy path — a service member with no plist yet gets
@@ -646,6 +770,9 @@ mod tests {
             .note("trusty-search")
             .contains("trusty-search"));
         assert!(BootstrapAction::InstalledByFallback
+            .note("trusty-memory")
+            .contains("trusty-memory"));
+        assert!(BootstrapAction::LoadedByFallback
             .note("trusty-memory")
             .contains("trusty-memory"));
         assert!(BootstrapAction::Skipped("x".into())

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -32,6 +32,15 @@
 //!    `down` (#3833; the diagnosis machinery itself lives in the sibling
 //!    `verify_launchd_state` module, shared with `service_bootstrap`'s #3836
 //!    defensive-fallback check).
+//! 5. (#3841 belt-and-braces, second layer) A member classified
+//!    [`DownState::NotLoaded`] whose plist is present on disk gets ONE more
+//!    repair attempt here — [`attempt_verify_fallback`] calls the exact same
+//!    `ServiceEnv::bootstrap_fallback` primitive
+//!    `service_bootstrap::bootstrap_one`'s install-time postcondition uses,
+//!    and re-probes on success. This exists so that even a FUTURE skip-path
+//!    regression in the install-time layer (or a member the install-time
+//!    bootstrap never touched this run, e.g. `--no-service`) still self-heals
+//!    at verify time instead of silently reporting `NOT VERIFIED`.
 //!
 //! Because `run_verify_tail` folds [`verify_one`] SEQUENTIALLY over every
 //! selected daemon member, and each member's poll wait can run up to
@@ -106,13 +115,17 @@ const AGGREGATE_POLL_BUDGET: Duration = Duration::from_secs(120);
 /// member after the wait, classifying WHY; `budget_exhausted` (#3836) is
 /// `true` iff this member needed a poll wait but the AGGREGATE poll budget
 /// had already run out, so NO poll was attempted for it (only the instant
-/// probe).
+/// probe); `verify_bootstrapped` (#3841) is `true` iff this row's `NotLoaded`
+/// diagnosis triggered the verify tail's own second-layer bootstrap-fallback
+/// attempt (regardless of whether that attempt succeeded — `down_state`/
+/// `health` reflect the outcome).
 /// Test: `tests::report_serialises`.
 #[derive(Clone, Debug, Serialize)]
 pub struct VerifyRow {
     /// Crate name.
     pub member: String,
-    /// Health verdict after any kickstart retry + poll wait.
+    /// Health verdict after any kickstart retry + poll wait + (#3841) verify-
+    /// tail bootstrap fallback.
     pub health: String,
     /// Whether a `launchctl kickstart -k` retry was attempted (#2498).
     pub kickstarted: bool,
@@ -122,10 +135,16 @@ pub struct VerifyRow {
     /// already exhausted by the time this member needed a poll wait, so it
     /// was skipped (#3836).
     pub budget_exhausted: bool,
-    /// Why a LAUNCHD member is still `down` after the poll wait, when it is
-    /// (#3833). `None` for a healthy/stale/unknown/not_installed member, or a
+    /// Why a LAUNCHD member is still `down` after the poll wait (and, when
+    /// applicable, the #3841 verify-tail fallback), when it is (#3833).
+    /// `None` for a healthy/stale/unknown/not_installed member, or a
     /// non-LAUNCHD member.
     pub down_state: Option<DownState>,
+    /// Whether [`attempt_verify_fallback`] was invoked for this member
+    /// (#3841 — the verify tail's own second-layer repair for a `NotLoaded`
+    /// diagnosis, independent of `service_bootstrap`'s install-time
+    /// postcondition).
+    pub verify_bootstrapped: bool,
 }
 
 /// The aggregate verify-tail report (#2560).
@@ -285,11 +304,55 @@ fn bounded_attempts(remaining: Duration) -> u32 {
     by_budget.clamp(1, POLL_MAX_ATTEMPTS)
 }
 
+/// Attempt the installer's own launchd bootstrap fallback for a member the
+/// verify tail has just diagnosed as [`DownState::NotLoaded`] (#3841
+/// belt-and-braces, second layer).
+///
+/// Why: `service_bootstrap::bootstrap_one`'s postcondition check is the FIRST
+/// line of defense against #3832's failure signature (a `service install`
+/// that writes a plist without loading it), but it only runs during install,
+/// on whichever code path THIS run's `install_all` loop actually took for the
+/// member. A future regression in that skip-path handling — or a member
+/// `--no-service` opted the install-time bootstrap out of entirely — would
+/// otherwise leave the verify tail reporting a `NotLoaded` diagnosis with no
+/// repair attempt at all. This is that second, independent attempt, reusing
+/// the EXACT same [`super::service_bootstrap::ServiceEnv::bootstrap_fallback`]
+/// primitive so the two layers can never disagree about how a label gets
+/// force-loaded.
+/// What: on macOS, if the member's plist exists on disk
+/// (`ServiceEnv::plist_present`), calls `ServiceEnv::bootstrap_fallback` and
+/// returns `Some(true)`/`Some(false)` for whether it succeeded. Returns
+/// `None` (nothing attempted) when the plist is not present at all — that is
+/// a genuine "never installed" state a `launchctl bootstrap` cannot repair
+/// (there is no plist to load), not this failure mode. Always `None` on
+/// non-macOS.
+/// Test: side-effecting (real `launchctl`); the trigger condition (`NotLoaded`
+/// only) and the resulting row shape are exercised by `verify_one`'s own
+/// side-effecting behaviour, which is validated manually — the pure pieces
+/// this composes with (`classify_down_state_from_entry`) are unit-tested in
+/// `verify_launchd_state`.
+#[cfg(target_os = "macos")]
+fn attempt_verify_fallback(binary: &str) -> Option<bool> {
+    use super::service_bootstrap::{RealServiceEnv, ServiceEnv};
+    let env = RealServiceEnv;
+    if !env.plist_present(binary) {
+        return None;
+    }
+    Some(env.bootstrap_fallback(binary).is_ok())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn attempt_verify_fallback(_binary: &str) -> Option<bool> {
+    None
+}
+
 /// Verify one daemon member, applying the #2498 kickstart retry + #3833 poll
-/// wait when needed, bounded by the #3836 aggregate poll budget.
+/// wait when needed (bounded by the #3836 aggregate poll budget), and the
+/// #3841 second-layer bootstrap-fallback attempt for a `NotLoaded` diagnosis.
 ///
 /// Why: isolates the per-member side effect (probe, maybe kickstart, poll,
-/// classify) so [`run_verify_tail`] stays a plain fold over `selected`.
+/// classify, maybe fallback-bootstrap) so [`run_verify_tail`] stays a plain
+/// fold over `selected`.
 /// What: probes health; if [`needs_kickstart`]:
 /// - and `remaining_budget` is already exhausted (#3836), skips the poll
 ///   entirely (only the instant probe already taken) and flags
@@ -304,7 +367,10 @@ fn bounded_attempts(remaining: Duration) -> u32 {
 /// If the member is STILL `down` after all that, classifies WHY via
 /// [`classify_down_state`] regardless of whether the budget was exhausted —
 /// that check is a single cheap `launchctl list`, not a poll, so it's never
-/// budget-gated.
+/// budget-gated. When the classification is [`DownState::NotLoaded`], calls
+/// [`attempt_verify_fallback`] (#3841); on a successful fallback, re-probes
+/// health and re-classifies so the returned row reflects the POST-repair
+/// state, not the stale diagnosis.
 /// Test: side-effecting (subprocess + sleep); the decision halves are
 /// `needs_kickstart`, `poll_until_not_down`, `bounded_attempts`,
 /// `classify_down_state_from_entry`.
@@ -327,11 +393,31 @@ fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
             health = polled_health;
         }
     }
-    let down_state = if health == health_str::DOWN && m.manage == ManageStrategy::Launchd {
+    let mut down_state = if health == health_str::DOWN && m.manage == ManageStrategy::Launchd {
         Some(classify_down_state(&m.binary))
     } else {
         None
     };
+
+    // #3841 belt-and-braces (layer 2): a `NotLoaded` diagnosis here means the
+    // label was never bootstrapped by ANY earlier step this run took. Try
+    // the installer's own fallback bootstrap one more time and, if it
+    // succeeds, re-probe so the row reports reality, not a stale diagnosis.
+    let mut verify_bootstrapped = false;
+    if matches!(down_state, Some(DownState::NotLoaded)) {
+        if let Some(succeeded) = attempt_verify_fallback(&m.binary) {
+            verify_bootstrapped = true;
+            if succeeded {
+                health = probe_member_health(&m.binary, m.manage);
+                down_state = if health == health_str::DOWN && m.manage == ManageStrategy::Launchd {
+                    Some(classify_down_state(&m.binary))
+                } else {
+                    None
+                };
+            }
+        }
+    }
+
     VerifyRow {
         member: m.crate_name.clone(),
         health,
@@ -339,6 +425,7 @@ fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
         required: m.required,
         budget_exhausted,
         down_state,
+        verify_bootstrapped,
     }
 }
 
@@ -419,21 +506,36 @@ fn colour(label: &str, ansi: &str) -> String {
 /// #3833: a member still `down` after the poll wait now carries a
 /// [`DownState`] diagnosis — that always wins (it is a DIAGNOSIS, not a
 /// reassurance, so it is shown for REQUIRED members too, just without the
-/// "optional" framing).
-/// What: `" (<down-state phrase>)"` (optionally `"optional, "`-prefixed) when
-/// `down_state` is `Some`; `" (kickstarted)"` when a retry fired and the
-/// member came back healthy; `" (optional, skipped)"` when the member is
-/// OPTIONAL and `not_installed`; otherwise empty.
+/// "optional" framing). #3841: `verify_bootstrapped` adds its own note —
+/// `", fallback attempted"` appended to a diagnosis that is STILL present
+/// (the second-layer repair also failed or the label remained unloaded), or
+/// `" (bootstrapped by installer)"` on its own when the fallback resolved the
+/// problem (`down_state` is `None` again).
+/// What: `" (<down-state phrase>[, fallback attempted])"` (optionally
+/// `"optional, "`-prefixed) when `down_state` is `Some`;
+/// `" (bootstrapped by installer)"` when `verify_bootstrapped` resolved the
+/// member; `" (kickstarted)"` when a retry fired and the member came back
+/// healthy; `" (optional, skipped)"` when the member is OPTIONAL and
+/// `not_installed`; otherwise empty.
 /// Test: `tests::optional_annotation_covers_not_installed_and_down`,
-/// `tests::optional_annotation_reports_down_state`.
+/// `tests::optional_annotation_reports_down_state`,
+/// `tests::optional_annotation_reports_verify_bootstrapped`.
 fn optional_annotation(m: &VerifyRow) -> String {
     if let Some(reason) = &m.down_state {
         let phrase = reason.phrase();
+        let phrase = if m.verify_bootstrapped {
+            format!("{phrase}, fallback attempted")
+        } else {
+            phrase
+        };
         return if m.required {
             format!(" ({phrase})")
         } else {
             format!(" (optional, {phrase})")
         };
+    }
+    if m.verify_bootstrapped {
+        return " (bootstrapped by installer)".to_owned();
     }
     if m.kickstarted {
         " (kickstarted)".to_owned()
@@ -504,6 +606,7 @@ mod tests {
             required: true,
             budget_exhausted: false,
             down_state: None,
+            verify_bootstrapped: false,
         }
     }
 
@@ -715,6 +818,49 @@ mod tests {
             optional_annotation(&kickstarted_but_still_down),
             " (still starting)",
             "an unresolved down_state must win over the plain kickstarted note"
+        );
+    }
+
+    /// Why: THE #3841 layer-2 safety property — the verify tail's own
+    /// bootstrap-fallback attempt must be visible in the human summary both
+    /// when it RESOLVED the member (down_state cleared back to `None`) and
+    /// when it was attempted but the diagnosis persists (fallback also
+    /// failed, or launchd still didn't pick up the label).
+    /// What: `verify_bootstrapped: true` with `down_state: None` reports
+    /// "(bootstrapped by installer)"; `verify_bootstrapped: true` with a
+    /// still-`Some` `down_state` appends ", fallback attempted" to the
+    /// existing diagnosis phrase; `verify_bootstrapped: false` (the default)
+    /// changes nothing versus the pre-#3841 behaviour.
+    /// Test: This is the test.
+    #[test]
+    fn optional_annotation_reports_verify_bootstrapped() {
+        let resolved = VerifyRow {
+            verify_bootstrapped: true,
+            health: health_str::HEALTHY.to_owned(),
+            ..row("trusty-memory", health_str::HEALTHY)
+        };
+        assert_eq!(
+            optional_annotation(&resolved),
+            " (bootstrapped by installer)"
+        );
+
+        let still_broken = VerifyRow {
+            verify_bootstrapped: true,
+            down_state: Some(DownState::NotLoaded),
+            ..row("trusty-memory", health_str::DOWN)
+        };
+        assert_eq!(
+            optional_annotation(&still_broken),
+            " (not loaded, fallback attempted)"
+        );
+
+        let optional_still_broken = VerifyRow {
+            required: false,
+            ..still_broken.clone()
+        };
+        assert_eq!(
+            optional_annotation(&optional_still_broken),
+            " (optional, not loaded, fallback attempted)"
         );
     }
 

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -34,13 +34,19 @@
 //!    defensive-fallback check).
 //! 5. (#3841 belt-and-braces, second layer) A member classified
 //!    [`DownState::NotLoaded`] whose plist is present on disk gets ONE more
-//!    repair attempt here — [`attempt_verify_fallback`] calls the exact same
+//!    repair attempt here — [`apply_not_loaded_fallback`] calls the exact same
 //!    `ServiceEnv::bootstrap_fallback` primitive
-//!    `service_bootstrap::bootstrap_one`'s install-time postcondition uses,
-//!    and re-probes on success. This exists so that even a FUTURE skip-path
-//!    regression in the install-time layer (or a member the install-time
-//!    bootstrap never touched this run, e.g. `--no-service`) still self-heals
-//!    at verify time instead of silently reporting `NOT VERIFIED`.
+//!    `service_bootstrap::bootstrap_one`'s install-time postcondition uses
+//!    (via [`attempt_verify_fallback`]), and on success re-probes through the
+//!    SAME [`poll_until_not_down`]/[`bounded_attempts`] machinery the #2498
+//!    kickstart retry uses (#3849 code-critic MEDIUM 1 fix — a single instant
+//!    re-probe here would race a just-repaired but slow-starting daemon
+//!    exactly like the #3833 kickstart race did) — bounded by whatever of
+//!    `remaining_budget` the member's earlier kickstart poll (if any) hasn't
+//!    already spent. This exists so that even a FUTURE skip-path regression
+//!    in the install-time layer (or a member the install-time bootstrap never
+//!    touched this run, e.g. `--no-service`) still self-heals at verify time
+//!    instead of silently reporting `NOT VERIFIED`.
 //!
 //! Because `run_verify_tail` folds [`verify_one`] SEQUENTIALLY over every
 //! selected daemon member, and each member's poll wait can run up to
@@ -319,31 +325,156 @@ fn bounded_attempts(remaining: Duration) -> u32 {
 /// the EXACT same [`super::service_bootstrap::ServiceEnv::bootstrap_fallback`]
 /// primitive so the two layers can never disagree about how a label gets
 /// force-loaded.
-/// What: on macOS, if the member's plist exists on disk
-/// (`ServiceEnv::plist_present`), calls `ServiceEnv::bootstrap_fallback` and
-/// returns `Some(true)`/`Some(false)` for whether it succeeded. Returns
-/// `None` (nothing attempted) when the plist is not present at all — that is
-/// a genuine "never installed" state a `launchctl bootstrap` cannot repair
-/// (there is no plist to load), not this failure mode. Always `None` on
-/// non-macOS.
-/// Test: side-effecting (real `launchctl`); the trigger condition (`NotLoaded`
-/// only) and the resulting row shape are exercised by `verify_one`'s own
-/// side-effecting behaviour, which is validated manually — the pure pieces
-/// this composes with (`classify_down_state_from_entry`) are unit-tested in
-/// `verify_launchd_state`.
-#[cfg(target_os = "macos")]
-fn attempt_verify_fallback(binary: &str) -> Option<bool> {
-    use super::service_bootstrap::{RealServiceEnv, ServiceEnv};
-    let env = RealServiceEnv;
+///
+/// 🔴 (#3849 code-critic MEDIUM 2 fix) Takes `env: &dyn ServiceEnv` — never
+/// hardcodes `RealServiceEnv` itself — mirroring `service_bootstrap::
+/// bootstrap_one`'s own seam so this whole decision is unit-testable against
+/// an in-memory fake, the same way `bootstrap_one`'s is. The real call site
+/// ([`apply_not_loaded_fallback_real`]) is the only place that names
+/// `RealServiceEnv`.
+/// What: if the member's plist exists on disk (`ServiceEnv::plist_present`),
+/// calls `ServiceEnv::bootstrap_fallback` and returns `Some(true)`/`Some(false)`
+/// for whether it succeeded. Returns `None` (nothing attempted) when the
+/// plist is not present at all — that is a genuine "never installed" state a
+/// `launchctl bootstrap` cannot repair (there is no plist to load), not this
+/// failure mode.
+/// Test: `tests::apply_not_loaded_fallback_*` (via `FakeServiceEnv`, composed
+/// through [`apply_not_loaded_fallback`] below).
+fn attempt_verify_fallback(
+    env: &dyn super::service_bootstrap::ServiceEnv,
+    binary: &str,
+) -> Option<bool> {
     if !env.plist_present(binary) {
         return None;
     }
     Some(env.bootstrap_fallback(binary).is_ok())
 }
 
+/// The complete #3841 second-layer repair: attempt the bootstrap fallback via
+/// `env`, and on success, re-probe through the SAME bounded
+/// [`poll_until_not_down`]/[`bounded_attempts`] machinery the #2498 kickstart
+/// retry uses — never a single racy instant probe — before re-classifying.
+///
+/// Why: extracted as its own generic function (rather than inlined in
+/// [`verify_one`]) so the WHOLE `NotLoaded -> fallback -> re-poll ->
+/// re-classify` wiring is directly unit-testable against fakes, not just
+/// [`attempt_verify_fallback`] in isolation (#3849 code-critic MEDIUM 2). Also
+/// fixes #3849 code-critic MEDIUM 1: the pre-fix code re-probed exactly once,
+/// instantly, after a successful fallback — racing a just-repaired but
+/// slow-starting daemon (trusty-search's first-boot embedding-model download
+/// notably) into a false `down`/`NOT VERIFIED`, the same race class #3833
+/// already fixed for the kickstart path. `probe`/`wait`/`classify` are kept
+/// generic (rather than calling `probe_member_health`/`std::thread::sleep`/
+/// `classify_down_state` directly) so this composes hermetically in tests,
+/// never sleeping or shelling out to `launchctl` in the test suite.
+///
+/// # Preconditions
+/// Caller has already established the member is currently diagnosed
+/// [`DownState::NotLoaded`] (`manage == ManageStrategy::Launchd`, health ==
+/// `down`) — this function does not re-derive that starting condition.
+/// # Postconditions
+/// Returns `(health, down_state, verify_bootstrapped)`.
+/// `verify_bootstrapped` is `true` iff [`attempt_verify_fallback`] found a
+/// plist and attempted the fallback bootstrap, REGARDLESS of whether it
+/// succeeded. When the fallback attempt did not run at all (no plist) or the
+/// `bootstrap_fallback` call itself failed, `health`/`down_state` are
+/// returned UNCHANGED (`health_str::DOWN` / `Some(DownState::NotLoaded)`) —
+/// only a SUCCESSFUL fallback triggers the re-poll and re-classification.
+/// When `remaining_budget` is already exhausted at the moment the fallback
+/// succeeds, falls back to a single instant `probe()` (never an unbounded
+/// wait) rather than skipping the re-probe entirely.
+/// Test: `tests::apply_not_loaded_fallback_heals_after_poll_when_fallback_succeeds`,
+/// `tests::apply_not_loaded_fallback_reports_still_not_loaded_when_fallback_fails`,
+/// `tests::apply_not_loaded_fallback_noop_when_no_plist`,
+/// `tests::apply_not_loaded_fallback_uses_instant_probe_when_budget_exhausted`.
+fn apply_not_loaded_fallback<F, W, C>(
+    env: &dyn super::service_bootstrap::ServiceEnv,
+    binary: &str,
+    manage: ManageStrategy,
+    remaining_budget: Duration,
+    mut probe: F,
+    mut wait: W,
+    classify: C,
+) -> (String, Option<DownState>, bool)
+where
+    F: FnMut() -> String,
+    W: FnMut(),
+    C: Fn() -> DownState,
+{
+    let Some(succeeded) = attempt_verify_fallback(env, binary) else {
+        return (
+            health_str::DOWN.to_owned(),
+            Some(DownState::NotLoaded),
+            false,
+        );
+    };
+    if !succeeded {
+        return (
+            health_str::DOWN.to_owned(),
+            Some(DownState::NotLoaded),
+            true,
+        );
+    }
+    // #3849 MEDIUM 1: bounded re-poll, never a single instant re-probe — the
+    // fallback just force-loaded the label, but the daemon behind it can
+    // still take real wall-clock time to report healthy.
+    let health = if remaining_budget.is_zero() {
+        probe()
+    } else {
+        let (polled, _attempts) =
+            poll_until_not_down(&mut probe, &mut wait, bounded_attempts(remaining_budget));
+        polled
+    };
+    let down_state = if health == health_str::DOWN && manage == ManageStrategy::Launchd {
+        Some(classify())
+    } else {
+        None
+    };
+    (health, down_state, true)
+}
+
+/// Real-wiring shell for [`apply_not_loaded_fallback`] — the only place that
+/// names `RealServiceEnv`/`probe_member_health`/`classify_down_state`
+/// (mirrors `service_bootstrap::bootstrap_member_service`'s split from
+/// `bootstrap_one`).
+///
+/// Why: keeps [`verify_one`] itself free of platform `cfg` noise; on
+/// non-macOS this is an unconditional no-op returning the SAME "untouched"
+/// triple [`apply_not_loaded_fallback`] returns for its own no-plist case, so
+/// callers never need to branch on platform.
+/// What: on macOS, delegates to [`apply_not_loaded_fallback`] with
+/// [`super::service_bootstrap::RealServiceEnv`] and the real probe/wait/
+/// classify closures; on non-macOS, always `(down, Some(NotLoaded), false)`.
+/// Test: side-effecting (real `launchctl` + sleep) on macOS; the decision
+/// logic it wraps is `apply_not_loaded_fallback`'s own test suite.
+#[cfg(target_os = "macos")]
+fn apply_not_loaded_fallback_real(
+    binary: &str,
+    manage: ManageStrategy,
+    remaining_budget: Duration,
+) -> (String, Option<DownState>, bool) {
+    apply_not_loaded_fallback(
+        &super::service_bootstrap::RealServiceEnv,
+        binary,
+        manage,
+        remaining_budget,
+        || probe_member_health(binary, manage),
+        || std::thread::sleep(POLL_INTERVAL),
+        || classify_down_state(binary),
+    )
+}
+
 #[cfg(not(target_os = "macos"))]
-fn attempt_verify_fallback(_binary: &str) -> Option<bool> {
-    None
+fn apply_not_loaded_fallback_real(
+    _binary: &str,
+    _manage: ManageStrategy,
+    _remaining_budget: Duration,
+) -> (String, Option<DownState>, bool) {
+    (
+        health_str::DOWN.to_owned(),
+        Some(DownState::NotLoaded),
+        false,
+    )
 }
 
 /// Verify one daemon member, applying the #2498 kickstart retry + #3833 poll
@@ -368,13 +499,18 @@ fn attempt_verify_fallback(_binary: &str) -> Option<bool> {
 /// [`classify_down_state`] regardless of whether the budget was exhausted —
 /// that check is a single cheap `launchctl list`, not a poll, so it's never
 /// budget-gated. When the classification is [`DownState::NotLoaded`], calls
-/// [`attempt_verify_fallback`] (#3841); on a successful fallback, re-probes
-/// health and re-classifies so the returned row reflects the POST-repair
-/// state, not the stale diagnosis.
+/// [`apply_not_loaded_fallback_real`] (#3841); on a successful fallback,
+/// re-probes (via the SAME bounded poll machinery, #3849 MEDIUM 1) and
+/// re-classifies so the returned row reflects the POST-repair state, not the
+/// stale diagnosis. `remaining_budget` for that second poll is recomputed
+/// from `start.elapsed()` rather than reusing the raw parameter, so it
+/// correctly reflects whatever the kickstart poll immediately above already
+/// spent within this SAME member's turn.
 /// Test: side-effecting (subprocess + sleep); the decision halves are
 /// `needs_kickstart`, `poll_until_not_down`, `bounded_attempts`,
-/// `classify_down_state_from_entry`.
+/// `classify_down_state_from_entry`, `apply_not_loaded_fallback`.
 fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
+    let start = Instant::now();
     let mut health = probe_member_health(&m.binary, m.manage);
     let mut kickstarted = false;
     let mut budget_exhausted = false;
@@ -401,21 +537,18 @@ fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
 
     // #3841 belt-and-braces (layer 2): a `NotLoaded` diagnosis here means the
     // label was never bootstrapped by ANY earlier step this run took. Try
-    // the installer's own fallback bootstrap one more time and, if it
-    // succeeds, re-probe so the row reports reality, not a stale diagnosis.
+    // the installer's own fallback bootstrap one more time; on success,
+    // `apply_not_loaded_fallback_real` re-polls (bounded by whatever of
+    // `remaining_budget` is left after the kickstart phase above) rather than
+    // a single racy instant probe (#3849 MEDIUM 1).
     let mut verify_bootstrapped = false;
     if matches!(down_state, Some(DownState::NotLoaded)) {
-        if let Some(succeeded) = attempt_verify_fallback(&m.binary) {
-            verify_bootstrapped = true;
-            if succeeded {
-                health = probe_member_health(&m.binary, m.manage);
-                down_state = if health == health_str::DOWN && m.manage == ManageStrategy::Launchd {
-                    Some(classify_down_state(&m.binary))
-                } else {
-                    None
-                };
-            }
-        }
+        let remaining_now = remaining_budget.saturating_sub(start.elapsed());
+        let (new_health, new_down_state, attempted) =
+            apply_not_loaded_fallback_real(&m.binary, m.manage, remaining_now);
+        verify_bootstrapped = attempted;
+        health = new_health;
+        down_state = new_down_state;
     }
 
     VerifyRow {
@@ -595,405 +728,5 @@ pub fn print_human(report: &VerifyTailReport) {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn row(member: &str, health: &str) -> VerifyRow {
-        VerifyRow {
-            member: member.to_owned(),
-            health: health.to_owned(),
-            kickstarted: false,
-            required: true,
-            budget_exhausted: false,
-            down_state: None,
-            verify_bootstrapped: false,
-        }
-    }
-
-    /// Like `row`, but marks the member OPTIONAL (graceful-degrade,
-    /// demo-critical fix).
-    fn optional_row(member: &str, health: &str) -> VerifyRow {
-        VerifyRow {
-            required: false,
-            ..row(member, health)
-        }
-    }
-
-    /// Why: only a `down` LAUNCHD daemon is the #2498 failure signature.
-    /// What: asserts the truth table across health x manage-strategy.
-    /// Test: This is the test.
-    #[test]
-    fn needs_kickstart_only_for_down_launchd() {
-        assert!(needs_kickstart(health_str::DOWN, ManageStrategy::Launchd));
-        assert!(!needs_kickstart(
-            health_str::HEALTHY,
-            ManageStrategy::Launchd
-        ));
-        assert!(!needs_kickstart(
-            health_str::NOT_INSTALLED,
-            ManageStrategy::Launchd
-        ));
-        assert!(!needs_kickstart(health_str::DOWN, ManageStrategy::OwnVerb));
-        assert!(!needs_kickstart(health_str::DOWN, ManageStrategy::None));
-    }
-
-    /// Why: the JSON envelope is a contract; pin its shape.
-    /// What: builds a report and asserts the keys.
-    /// Test: This is the test.
-    #[test]
-    fn report_serialises() {
-        let report = VerifyTailReport::build(true, vec![row("trusty-search", "healthy")]);
-        let v = serde_json::to_value(&report).expect("serialises");
-        assert_eq!(v["command"], "install.verify");
-        assert_eq!(v["ensure_ok"], true);
-        assert_eq!(v["verified"], true);
-        assert_eq!(v["members"][0]["member"], "trusty-search");
-    }
-
-    /// Why: THE #2560 safety property — a down/missing daemon OR a failed
-    /// ensure pass must both flip `verified` to `false`; only when BOTH are
-    /// clean is the install considered verified.
-    /// What: exercises each failure axis independently.
-    /// Test: This is the test.
-    #[test]
-    fn verified_requires_ensure_and_health() {
-        let ensure_failed = VerifyTailReport::build(false, vec![row("trusty-search", "healthy")]);
-        assert!(!ensure_failed.verified, "a failed ensure must not verify");
-
-        let health_failed = VerifyTailReport::build(true, vec![row("trusty-search", "down")]);
-        assert!(!health_failed.verified, "a down daemon must not verify");
-
-        let not_installed =
-            VerifyTailReport::build(true, vec![row("trusty-search", health_str::NOT_INSTALLED)]);
-        assert!(!not_installed.verified, "not_installed must not verify");
-
-        let both_ok = VerifyTailReport::build(true, vec![row("trusty-search", "healthy")]);
-        assert!(both_ok.verified);
-    }
-
-    /// Why: `stale` (running, below version floor) and `unknown`
-    /// (process-managed, unprobeable — trusty-mpm) must NOT fail verification
-    /// — mirrors `stack::health::HealthReport`'s degrade policy exactly.
-    /// What: a report with only stale/unknown members still verifies.
-    /// Test: This is the test.
-    #[test]
-    fn verified_tolerates_stale_and_unknown() {
-        let report = VerifyTailReport::build(
-            true,
-            vec![
-                row("trusty-search", health_str::STALE),
-                row("trusty-mpm", health_str::UNKNOWN),
-            ],
-        );
-        assert!(report.verified);
-    }
-
-    /// Why: THE demo-critical fix — an OPTIONAL daemon member (e.g.
-    /// `trusty-console` never installed because it has no prebuilt for this
-    /// platform) being `down`/`not_installed` must NOT fail `verified`; only
-    /// a REQUIRED member's bad health may.
-    /// What: a report mixing a healthy REQUIRED member with a `down` and a
-    /// `not_installed` OPTIONAL member still verifies; a `down` REQUIRED
-    /// member alongside a healthy OPTIONAL one does not.
-    /// Test: This is the test.
-    #[test]
-    fn verified_ignores_optional_down_member() {
-        let degraded = VerifyTailReport::build(
-            true,
-            vec![
-                row("trusty-search", health_str::HEALTHY),
-                optional_row("trusty-console", health_str::DOWN),
-                optional_row("tga", health_str::NOT_INSTALLED),
-            ],
-        );
-        assert!(
-            degraded.verified,
-            "an optional member's bad health must not fail verification"
-        );
-
-        let genuinely_failed = VerifyTailReport::build(
-            true,
-            vec![
-                row("trusty-search", health_str::DOWN),
-                optional_row("trusty-console", health_str::HEALTHY),
-            ],
-        );
-        assert!(
-            !genuinely_failed.verified,
-            "a required member's bad health must still fail verification"
-        );
-    }
-
-    /// Why: `print_human`'s colour path must never panic regardless of the
-    /// harness's stdout fd; this just confirms it is callable.
-    /// What: calls `use_color`, binds the result.
-    /// Test: This is the test.
-    #[test]
-    fn use_color_returns_bool() {
-        let _v: bool = use_color();
-    }
-
-    /// Why: #3797 critic finding (MEDIUM, demo-relevant) — an OPTIONAL daemon
-    /// that is `not_installed` must read as "(optional, skipped)", not a
-    /// bare, alarming `not_installed` right above the green `VERIFIED` line.
-    /// A REQUIRED member's `not_installed` must get NO such softening
-    /// annotation, and a successful `kickstarted` retry must win over it.
-    /// (#3833: a bare `down` health with no `down_state` set no longer
-    /// happens in production — `verify_one` always attaches a `down_state`
-    /// for a down LAUNCHD member — so the `down`-specific cases moved to
-    /// `optional_annotation_reports_down_state` below.)
-    /// What: exercises the `not_installed` + `kickstarted` truth table.
-    /// Test: This is the test.
-    #[test]
-    fn optional_annotation_covers_not_installed_and_down() {
-        assert_eq!(
-            optional_annotation(&optional_row("trusty-console", health_str::NOT_INSTALLED)),
-            " (optional, skipped)"
-        );
-        assert_eq!(
-            optional_annotation(&optional_row("trusty-console", health_str::HEALTHY)),
-            "",
-            "a healthy optional member needs no annotation"
-        );
-        assert_eq!(
-            optional_annotation(&row("trusty-search", health_str::NOT_INSTALLED)),
-            "",
-            "a REQUIRED member's not_installed health must not be softened"
-        );
-        let kickstarted = VerifyRow {
-            kickstarted: true,
-            health: health_str::HEALTHY.to_owned(),
-            ..optional_row("trusty-console", health_str::HEALTHY)
-        };
-        assert_eq!(
-            optional_annotation(&kickstarted),
-            " (kickstarted)",
-            "a kickstart retry that came back healthy is noted"
-        );
-    }
-
-    /// Why: #3833 — a member still `down` after the poll wait must report
-    /// WHICH of the three end states it is, for both REQUIRED (plain
-    /// diagnosis, no softening) and OPTIONAL (still prefixed `optional,` —
-    /// it is informational, not an alarm) members. This must take priority
-    /// over the plain `kickstarted` note, since `down_state` being `Some`
-    /// means the kickstart did NOT resolve the problem.
-    /// What: exercises all three `DownState` variants for both required and
-    /// optional members, and confirms `down_state` wins over `kickstarted`.
-    /// Test: This is the test.
-    #[test]
-    fn optional_annotation_reports_down_state() {
-        let with_state = |required: bool, state: DownState| VerifyRow {
-            required,
-            down_state: Some(state),
-            ..row("trusty-memory", health_str::DOWN)
-        };
-
-        assert_eq!(
-            optional_annotation(&with_state(true, DownState::NotLoaded)),
-            " (not loaded)"
-        );
-        assert_eq!(
-            optional_annotation(&with_state(false, DownState::NotLoaded)),
-            " (optional, not loaded)"
-        );
-        assert_eq!(
-            optional_annotation(&with_state(true, DownState::Crashed { exit_code: 2 })),
-            " (crashed, exit 2)"
-        );
-        assert_eq!(
-            optional_annotation(&with_state(false, DownState::Crashed { exit_code: -9 })),
-            " (optional, crashed, exit -9)"
-        );
-        assert_eq!(
-            optional_annotation(&with_state(true, DownState::StillStarting)),
-            " (still starting)"
-        );
-
-        let kickstarted_but_still_down = VerifyRow {
-            kickstarted: true,
-            ..with_state(true, DownState::StillStarting)
-        };
-        assert_eq!(
-            optional_annotation(&kickstarted_but_still_down),
-            " (still starting)",
-            "an unresolved down_state must win over the plain kickstarted note"
-        );
-    }
-
-    /// Why: THE #3841 layer-2 safety property — the verify tail's own
-    /// bootstrap-fallback attempt must be visible in the human summary both
-    /// when it RESOLVED the member (down_state cleared back to `None`) and
-    /// when it was attempted but the diagnosis persists (fallback also
-    /// failed, or launchd still didn't pick up the label).
-    /// What: `verify_bootstrapped: true` with `down_state: None` reports
-    /// "(bootstrapped by installer)"; `verify_bootstrapped: true` with a
-    /// still-`Some` `down_state` appends ", fallback attempted" to the
-    /// existing diagnosis phrase; `verify_bootstrapped: false` (the default)
-    /// changes nothing versus the pre-#3841 behaviour.
-    /// Test: This is the test.
-    #[test]
-    fn optional_annotation_reports_verify_bootstrapped() {
-        let resolved = VerifyRow {
-            verify_bootstrapped: true,
-            health: health_str::HEALTHY.to_owned(),
-            ..row("trusty-memory", health_str::HEALTHY)
-        };
-        assert_eq!(
-            optional_annotation(&resolved),
-            " (bootstrapped by installer)"
-        );
-
-        let still_broken = VerifyRow {
-            verify_bootstrapped: true,
-            down_state: Some(DownState::NotLoaded),
-            ..row("trusty-memory", health_str::DOWN)
-        };
-        assert_eq!(
-            optional_annotation(&still_broken),
-            " (not loaded, fallback attempted)"
-        );
-
-        let optional_still_broken = VerifyRow {
-            required: false,
-            ..still_broken.clone()
-        };
-        assert_eq!(
-            optional_annotation(&optional_still_broken),
-            " (optional, not loaded, fallback attempted)"
-        );
-    }
-
-    /// Why: THE #3833 safety property — polling must terminate the instant
-    /// health stops being `down`, without over-waiting or under-waiting.
-    /// What: a probe sequence [down, down, healthy] must return after
-    /// exactly 3 attempts with 2 waits.
-    /// Test: This is the test.
-    #[test]
-    fn poll_until_not_down_stops_when_healthy() {
-        let responses = std::cell::RefCell::new(vec![
-            health_str::HEALTHY.to_owned(),
-            health_str::DOWN.to_owned(),
-            health_str::DOWN.to_owned(),
-        ]);
-        let waits = std::cell::RefCell::new(0u32);
-        let (health, attempts) = poll_until_not_down(
-            || {
-                responses
-                    .borrow_mut()
-                    .pop()
-                    .expect("probe called too many times")
-            },
-            || *waits.borrow_mut() += 1,
-            10,
-        );
-        assert_eq!(health, health_str::HEALTHY);
-        assert_eq!(attempts, 3);
-        assert_eq!(*waits.borrow(), 2, "must wait exactly twice, not 3 times");
-    }
-
-    /// Why: against a genuinely dead daemon, the poll must still terminate —
-    /// never block `tctl install` forever.
-    /// What: a probe that always returns `down` must stop at exactly
-    /// `max_attempts`, waiting `max_attempts - 1` times (never after the
-    /// final attempt).
-    /// Test: This is the test.
-    #[test]
-    fn poll_until_not_down_stops_at_max_attempts() {
-        let waits = std::cell::RefCell::new(0u32);
-        let (health, attempts) = poll_until_not_down(
-            || health_str::DOWN.to_owned(),
-            || *waits.borrow_mut() += 1,
-            4,
-        );
-        assert_eq!(health, health_str::DOWN);
-        assert_eq!(attempts, 4);
-        assert_eq!(
-            *waits.borrow(),
-            3,
-            "must not wait after the final (4th) attempt"
-        );
-    }
-
-    /// Why: the common case — a daemon that is already healthy by the time
-    /// the retry fires — must return immediately with zero waits, not
-    /// needlessly sleep once.
-    /// What: a probe that is healthy on the first call triggers no wait.
-    /// Test: This is the test.
-    #[test]
-    fn poll_until_not_down_first_attempt_needs_no_wait() {
-        let waits = std::cell::RefCell::new(0u32);
-        let (health, attempts) = poll_until_not_down(
-            || health_str::HEALTHY.to_owned(),
-            || *waits.borrow_mut() += 1,
-            10,
-        );
-        assert_eq!(health, health_str::HEALTHY);
-        assert_eq!(attempts, 1);
-        assert_eq!(*waits.borrow(), 0);
-    }
-
-    /// Why: #3836 MEDIUM fix — with a generous remaining budget, a member
-    /// must still get its full [`POLL_MAX_ATTEMPTS`] ceiling, never MORE.
-    /// What: a large `remaining` (e.g. the full aggregate budget) clamps to
-    /// exactly `POLL_MAX_ATTEMPTS`.
-    /// Test: This is the test.
-    #[test]
-    fn bounded_attempts_clamped_to_max() {
-        assert_eq!(bounded_attempts(AGGREGATE_POLL_BUDGET), POLL_MAX_ATTEMPTS);
-        assert_eq!(
-            bounded_attempts(Duration::from_secs(3600)),
-            POLL_MAX_ATTEMPTS
-        );
-    }
-
-    /// Why: THE #3836 core safety property — a member turn late in the fold,
-    /// with little aggregate budget left, must get proportionally FEWER
-    /// attempts, not the full schedule (which is what let a single member
-    /// blow through the aggregate cap).
-    /// What: a small remaining budget yields fewer than `POLL_MAX_ATTEMPTS`
-    /// attempts, and a larger remaining budget yields a value in between.
-    /// Test: This is the test.
-    #[test]
-    fn bounded_attempts_shrinks_with_small_budget() {
-        // 12s remaining / 5s interval -> 1 + 2 = 3 attempts.
-        assert_eq!(bounded_attempts(Duration::from_secs(12)), 3);
-        // 30s remaining -> 1 + 6 = 7 attempts, strictly between 1 and the max.
-        let mid = bounded_attempts(Duration::from_secs(30));
-        assert!(
-            mid > 1 && mid < POLL_MAX_ATTEMPTS,
-            "expected a value strictly between 1 and {POLL_MAX_ATTEMPTS}, got {mid}"
-        );
-    }
-
-    /// Why: even a sliver of remaining budget must still attempt AT LEAST
-    /// one probe — never zero (a zero-attempt poll makes no sense; an
-    /// entirely exhausted budget is handled as its own separate case by
-    /// `verify_one`, not by this function receiving a zero `remaining`).
-    /// What: a 1-second remaining budget still yields `1`.
-    /// Test: This is the test.
-    #[test]
-    fn bounded_attempts_at_least_one() {
-        assert_eq!(bounded_attempts(Duration::from_secs(1)), 1);
-    }
-
-    /// Why: #3836 — the "budget exhausted" summary note must fire iff ANY
-    /// member's poll was skipped for that reason, and must NOT fire on an
-    /// all-clear report (avoids alarming an operator over nothing).
-    /// What: exercises both the empty/all-false case and a mixed case.
-    /// Test: This is the test.
-    #[test]
-    fn any_budget_exhausted_detects_any_row() {
-        assert!(!any_budget_exhausted(&[]));
-        assert!(!any_budget_exhausted(&[row("trusty-search", "healthy")]));
-
-        let exhausted = VerifyRow {
-            budget_exhausted: true,
-            ..row("trusty-memory", health_str::DOWN)
-        };
-        assert!(any_budget_exhausted(&[
-            row("trusty-search", "healthy"),
-            exhausted
-        ]));
-    }
-}
+#[path = "verify_tail_tests.rs"]
+mod tests;

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -340,6 +340,16 @@ fn bounded_attempts(remaining: Duration) -> u32 {
 /// failure mode.
 /// Test: `tests::apply_not_loaded_fallback_*` (via `FakeServiceEnv`, composed
 /// through [`apply_not_loaded_fallback`] below).
+///
+/// `#[cfg(any(test, target_os = "macos"))]`: the only PRODUCTION call site
+/// ([`apply_not_loaded_fallback_real`]'s macOS branch) is itself macOS-only —
+/// on a non-macOS build with `test` cfg off, nothing calls this function at
+/// all, and an un-gated `fn` here would be flagged `dead_code` under `-D
+/// warnings` (caught by Linux CI; mirrors the existing `kickstart` dual-cfg
+/// pattern just above, generalised to also stay compiled for the test target
+/// on every platform so `tests::apply_not_loaded_fallback_*` still run
+/// cross-platform).
+#[cfg(any(test, target_os = "macos"))]
 fn attempt_verify_fallback(
     env: &dyn super::service_bootstrap::ServiceEnv,
     binary: &str,
@@ -387,6 +397,10 @@ fn attempt_verify_fallback(
 /// `tests::apply_not_loaded_fallback_reports_still_not_loaded_when_fallback_fails`,
 /// `tests::apply_not_loaded_fallback_noop_when_no_plist`,
 /// `tests::apply_not_loaded_fallback_uses_instant_probe_when_budget_exhausted`.
+///
+/// `#[cfg(any(test, target_os = "macos"))]`: see [`attempt_verify_fallback`]'s
+/// doc — same reasoning, same non-macOS-production dead-code hazard.
+#[cfg(any(test, target_os = "macos"))]
 fn apply_not_loaded_fallback<F, W, C>(
     env: &dyn super::service_bootstrap::ServiceEnv,
     binary: &str,

--- a/crates/trusty-installer/src/commands/verify_tail_tests.rs
+++ b/crates/trusty-installer/src/commands/verify_tail_tests.rs
@@ -1,0 +1,584 @@
+//! Unit tests for the `verify_tail` module.
+//!
+//! Why: Keeping tests in a sibling file rather than inline in `verify_tail.rs`
+//! lets the definition file stay under the 500-SLOC production cap
+//! (CLAUDE.md / `scripts/check_line_cap.sh`) while retaining full coverage —
+//! mirrors the `install.rs` / `install_tests.rs` split. `verify_tail.rs`
+//! previously stayed under the cap by splitting `verify_launchd_state.rs`
+//! out of it (#3836 code-critic MEDIUM fix); it grew past the cap again once
+//! the #3849 code-critic MEDIUM 1 + MEDIUM 2 fixes (bounded post-fallback
+//! re-poll + an injectable `ServiceEnv` for the `NotLoaded` second-layer
+//! repair, plus their four new unit tests) landed, so tests move out here.
+//!
+//! Test: `cargo test -p trusty-installer` runs all tests in this file.
+
+use super::*;
+
+fn row(member: &str, health: &str) -> VerifyRow {
+    VerifyRow {
+        member: member.to_owned(),
+        health: health.to_owned(),
+        kickstarted: false,
+        required: true,
+        budget_exhausted: false,
+        down_state: None,
+        verify_bootstrapped: false,
+    }
+}
+
+/// Like `row`, but marks the member OPTIONAL (graceful-degrade,
+/// demo-critical fix).
+fn optional_row(member: &str, health: &str) -> VerifyRow {
+    VerifyRow {
+        required: false,
+        ..row(member, health)
+    }
+}
+
+/// Why: only a `down` LAUNCHD daemon is the #2498 failure signature.
+/// What: asserts the truth table across health x manage-strategy.
+/// Test: This is the test.
+#[test]
+fn needs_kickstart_only_for_down_launchd() {
+    assert!(needs_kickstart(health_str::DOWN, ManageStrategy::Launchd));
+    assert!(!needs_kickstart(
+        health_str::HEALTHY,
+        ManageStrategy::Launchd
+    ));
+    assert!(!needs_kickstart(
+        health_str::NOT_INSTALLED,
+        ManageStrategy::Launchd
+    ));
+    assert!(!needs_kickstart(health_str::DOWN, ManageStrategy::OwnVerb));
+    assert!(!needs_kickstart(health_str::DOWN, ManageStrategy::None));
+}
+
+/// Why: the JSON envelope is a contract; pin its shape.
+/// What: builds a report and asserts the keys.
+/// Test: This is the test.
+#[test]
+fn report_serialises() {
+    let report = VerifyTailReport::build(true, vec![row("trusty-search", "healthy")]);
+    let v = serde_json::to_value(&report).expect("serialises");
+    assert_eq!(v["command"], "install.verify");
+    assert_eq!(v["ensure_ok"], true);
+    assert_eq!(v["verified"], true);
+    assert_eq!(v["members"][0]["member"], "trusty-search");
+}
+
+/// Why: THE #2560 safety property — a down/missing daemon OR a failed
+/// ensure pass must both flip `verified` to `false`; only when BOTH are
+/// clean is the install considered verified.
+/// What: exercises each failure axis independently.
+/// Test: This is the test.
+#[test]
+fn verified_requires_ensure_and_health() {
+    let ensure_failed = VerifyTailReport::build(false, vec![row("trusty-search", "healthy")]);
+    assert!(!ensure_failed.verified, "a failed ensure must not verify");
+
+    let health_failed = VerifyTailReport::build(true, vec![row("trusty-search", "down")]);
+    assert!(!health_failed.verified, "a down daemon must not verify");
+
+    let not_installed =
+        VerifyTailReport::build(true, vec![row("trusty-search", health_str::NOT_INSTALLED)]);
+    assert!(!not_installed.verified, "not_installed must not verify");
+
+    let both_ok = VerifyTailReport::build(true, vec![row("trusty-search", "healthy")]);
+    assert!(both_ok.verified);
+}
+
+/// Why: `stale` (running, below version floor) and `unknown`
+/// (process-managed, unprobeable — trusty-mpm) must NOT fail verification
+/// — mirrors `stack::health::HealthReport`'s degrade policy exactly.
+/// What: a report with only stale/unknown members still verifies.
+/// Test: This is the test.
+#[test]
+fn verified_tolerates_stale_and_unknown() {
+    let report = VerifyTailReport::build(
+        true,
+        vec![
+            row("trusty-search", health_str::STALE),
+            row("trusty-mpm", health_str::UNKNOWN),
+        ],
+    );
+    assert!(report.verified);
+}
+
+/// Why: THE demo-critical fix — an OPTIONAL daemon member (e.g.
+/// `trusty-console` never installed because it has no prebuilt for this
+/// platform) being `down`/`not_installed` must NOT fail `verified`; only
+/// a REQUIRED member's bad health may.
+/// What: a report mixing a healthy REQUIRED member with a `down` and a
+/// `not_installed` OPTIONAL member still verifies; a `down` REQUIRED
+/// member alongside a healthy OPTIONAL one does not.
+/// Test: This is the test.
+#[test]
+fn verified_ignores_optional_down_member() {
+    let degraded = VerifyTailReport::build(
+        true,
+        vec![
+            row("trusty-search", health_str::HEALTHY),
+            optional_row("trusty-console", health_str::DOWN),
+            optional_row("tga", health_str::NOT_INSTALLED),
+        ],
+    );
+    assert!(
+        degraded.verified,
+        "an optional member's bad health must not fail verification"
+    );
+
+    let genuinely_failed = VerifyTailReport::build(
+        true,
+        vec![
+            row("trusty-search", health_str::DOWN),
+            optional_row("trusty-console", health_str::HEALTHY),
+        ],
+    );
+    assert!(
+        !genuinely_failed.verified,
+        "a required member's bad health must still fail verification"
+    );
+}
+
+/// Why: `print_human`'s colour path must never panic regardless of the
+/// harness's stdout fd; this just confirms it is callable.
+/// What: calls `use_color`, binds the result.
+/// Test: This is the test.
+#[test]
+fn use_color_returns_bool() {
+    let _v: bool = use_color();
+}
+
+/// Why: #3797 critic finding (MEDIUM, demo-relevant) — an OPTIONAL daemon
+/// that is `not_installed` must read as "(optional, skipped)", not a
+/// bare, alarming `not_installed` right above the green `VERIFIED` line.
+/// A REQUIRED member's `not_installed` must get NO such softening
+/// annotation, and a successful `kickstarted` retry must win over it.
+/// (#3833: a bare `down` health with no `down_state` set no longer
+/// happens in production — `verify_one` always attaches a `down_state`
+/// for a down LAUNCHD member — so the `down`-specific cases moved to
+/// `optional_annotation_reports_down_state` below.)
+/// What: exercises the `not_installed` + `kickstarted` truth table.
+/// Test: This is the test.
+#[test]
+fn optional_annotation_covers_not_installed_and_down() {
+    assert_eq!(
+        optional_annotation(&optional_row("trusty-console", health_str::NOT_INSTALLED)),
+        " (optional, skipped)"
+    );
+    assert_eq!(
+        optional_annotation(&optional_row("trusty-console", health_str::HEALTHY)),
+        "",
+        "a healthy optional member needs no annotation"
+    );
+    assert_eq!(
+        optional_annotation(&row("trusty-search", health_str::NOT_INSTALLED)),
+        "",
+        "a REQUIRED member's not_installed health must not be softened"
+    );
+    let kickstarted = VerifyRow {
+        kickstarted: true,
+        health: health_str::HEALTHY.to_owned(),
+        ..optional_row("trusty-console", health_str::HEALTHY)
+    };
+    assert_eq!(
+        optional_annotation(&kickstarted),
+        " (kickstarted)",
+        "a kickstart retry that came back healthy is noted"
+    );
+}
+
+/// Why: #3833 — a member still `down` after the poll wait must report
+/// WHICH of the three end states it is, for both REQUIRED (plain
+/// diagnosis, no softening) and OPTIONAL (still prefixed `optional,` —
+/// it is informational, not an alarm) members. This must take priority
+/// over the plain `kickstarted` note, since `down_state` being `Some`
+/// means the kickstart did NOT resolve the problem.
+/// What: exercises all three `DownState` variants for both required and
+/// optional members, and confirms `down_state` wins over `kickstarted`.
+/// Test: This is the test.
+#[test]
+fn optional_annotation_reports_down_state() {
+    let with_state = |required: bool, state: DownState| VerifyRow {
+        required,
+        down_state: Some(state),
+        ..row("trusty-memory", health_str::DOWN)
+    };
+
+    assert_eq!(
+        optional_annotation(&with_state(true, DownState::NotLoaded)),
+        " (not loaded)"
+    );
+    assert_eq!(
+        optional_annotation(&with_state(false, DownState::NotLoaded)),
+        " (optional, not loaded)"
+    );
+    assert_eq!(
+        optional_annotation(&with_state(true, DownState::Crashed { exit_code: 2 })),
+        " (crashed, exit 2)"
+    );
+    assert_eq!(
+        optional_annotation(&with_state(false, DownState::Crashed { exit_code: -9 })),
+        " (optional, crashed, exit -9)"
+    );
+    assert_eq!(
+        optional_annotation(&with_state(true, DownState::StillStarting)),
+        " (still starting)"
+    );
+
+    let kickstarted_but_still_down = VerifyRow {
+        kickstarted: true,
+        ..with_state(true, DownState::StillStarting)
+    };
+    assert_eq!(
+        optional_annotation(&kickstarted_but_still_down),
+        " (still starting)",
+        "an unresolved down_state must win over the plain kickstarted note"
+    );
+}
+
+/// Why: THE #3841 layer-2 safety property — the verify tail's own
+/// bootstrap-fallback attempt must be visible in the human summary both
+/// when it RESOLVED the member (down_state cleared back to `None`) and
+/// when it was attempted but the diagnosis persists (fallback also
+/// failed, or launchd still didn't pick up the label).
+/// What: `verify_bootstrapped: true` with `down_state: None` reports
+/// "(bootstrapped by installer)"; `verify_bootstrapped: true` with a
+/// still-`Some` `down_state` appends ", fallback attempted" to the
+/// existing diagnosis phrase; `verify_bootstrapped: false` (the default)
+/// changes nothing versus the pre-#3841 behaviour.
+/// Test: This is the test.
+#[test]
+fn optional_annotation_reports_verify_bootstrapped() {
+    let resolved = VerifyRow {
+        verify_bootstrapped: true,
+        health: health_str::HEALTHY.to_owned(),
+        ..row("trusty-memory", health_str::HEALTHY)
+    };
+    assert_eq!(
+        optional_annotation(&resolved),
+        " (bootstrapped by installer)"
+    );
+
+    let still_broken = VerifyRow {
+        verify_bootstrapped: true,
+        down_state: Some(DownState::NotLoaded),
+        ..row("trusty-memory", health_str::DOWN)
+    };
+    assert_eq!(
+        optional_annotation(&still_broken),
+        " (not loaded, fallback attempted)"
+    );
+
+    let optional_still_broken = VerifyRow {
+        required: false,
+        ..still_broken.clone()
+    };
+    assert_eq!(
+        optional_annotation(&optional_still_broken),
+        " (optional, not loaded, fallback attempted)"
+    );
+}
+
+/// In-memory [`ServiceEnv`](super::super::service_bootstrap::ServiceEnv)
+/// fake for [`apply_not_loaded_fallback`]'s own tests (#3849 code-critic
+/// MEDIUM 2) — records `bootstrap_fallback` calls and simulates plist
+/// presence, so these tests never touch launchd or the real
+/// `~/Library/LaunchAgents`. `is_loaded`/`run_service_install` are unused
+/// by this layer but required by the trait; stubbed to inert values.
+struct FakeServiceEnv {
+    present: bool,
+    fail_fallback: bool,
+    fallback_calls: std::cell::RefCell<Vec<String>>,
+}
+
+impl super::super::service_bootstrap::ServiceEnv for FakeServiceEnv {
+    fn plist_present(&self, _binary: &str) -> bool {
+        self.present
+    }
+    fn run_service_install(&self, _binary: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn is_loaded(&self, _binary: &str) -> bool {
+        false
+    }
+    fn bootstrap_fallback(&self, binary: &str) -> anyhow::Result<()> {
+        self.fallback_calls.borrow_mut().push(binary.to_owned());
+        if self.fail_fallback {
+            anyhow::bail!("simulated fallback failure");
+        }
+        Ok(())
+    }
+}
+
+/// Why: THE #3849 code-critic MEDIUM 2 core coverage gap — scenario (a):
+/// `NotLoaded` + plist present, fallback SUCCEEDS. Must re-poll (not a
+/// single instant probe — MEDIUM 1) until healthy, then clear
+/// `down_state` back to `None` so the row (and the exit code) reflect the
+/// repair. Asserting `waits > 0` is what proves the bounded POLL
+/// machinery ran, not a single instant re-probe.
+/// What: a probe sequence [down, down, healthy] must resolve to
+/// `HEALTHY`/`None`/`attempted: true`, with at least one recorded wait.
+/// Test: This is the test.
+#[test]
+fn apply_not_loaded_fallback_heals_after_poll_when_fallback_succeeds() {
+    let env = FakeServiceEnv {
+        present: true,
+        fail_fallback: false,
+        fallback_calls: std::cell::RefCell::new(Vec::new()),
+    };
+    let responses = std::cell::RefCell::new(vec![
+        health_str::HEALTHY.to_owned(),
+        health_str::DOWN.to_owned(),
+        health_str::DOWN.to_owned(),
+    ]);
+    let waits = std::cell::RefCell::new(0u32);
+    let (health, down_state, attempted) = apply_not_loaded_fallback(
+        &env,
+        "trusty-memory",
+        ManageStrategy::Launchd,
+        Duration::from_secs(30),
+        || responses.borrow_mut().pop().expect("probed too many times"),
+        || *waits.borrow_mut() += 1,
+        || panic!("classify must not be called once health is no longer down"),
+    );
+    assert_eq!(health, health_str::HEALTHY);
+    assert_eq!(down_state, None);
+    assert!(attempted);
+    assert_eq!(env.fallback_calls.borrow().as_slice(), ["trusty-memory"]);
+    assert!(
+        *waits.borrow() > 0,
+        "must poll (wait between probes), never a single instant re-probe"
+    );
+}
+
+/// Why: THE #3849 code-critic MEDIUM 2 core coverage gap — scenario (b):
+/// `NotLoaded` + plist present, but the fallback bootstrap ITSELF fails.
+/// Must report `verify_bootstrapped: true` (it WAS attempted) while
+/// `health`/`down_state` stay exactly `down`/`NotLoaded` — no poll, no
+/// classify call, no false "healed" signal — so `verified`/the exit code
+/// still reflects genuine failure.
+/// What: asserts `health == "down"`, `down_state == Some(NotLoaded)`,
+/// `attempted == true`, and that `probe`/`wait`/`classify` were never
+/// invoked (they panic if called).
+/// Test: This is the test.
+#[test]
+fn apply_not_loaded_fallback_reports_still_not_loaded_when_fallback_fails() {
+    let env = FakeServiceEnv {
+        present: true,
+        fail_fallback: true,
+        fallback_calls: std::cell::RefCell::new(Vec::new()),
+    };
+    let (health, down_state, attempted) = apply_not_loaded_fallback(
+        &env,
+        "trusty-review",
+        ManageStrategy::Launchd,
+        Duration::from_secs(30),
+        || panic!("probe must not run when the fallback bootstrap itself failed"),
+        || panic!("wait must not run when the fallback bootstrap itself failed"),
+        || panic!("classify must not run when the fallback bootstrap itself failed"),
+    );
+    assert_eq!(health, health_str::DOWN);
+    assert_eq!(down_state, Some(DownState::NotLoaded));
+    assert!(
+        attempted,
+        "the fallback WAS attempted, even though it failed"
+    );
+}
+
+/// Why: a `NotLoaded` diagnosis with NO plist on disk at all is a genuine
+/// "never installed" state `launchctl bootstrap` cannot repair (nothing
+/// to load) — must be a true no-op: `verify_bootstrapped: false`, health/
+/// down_state untouched, and neither the fallback nor probe/wait/classify
+/// ever invoked.
+/// What: `present: false` yields `attempted: false` and zero side effects.
+/// Test: This is the test.
+#[test]
+fn apply_not_loaded_fallback_noop_when_no_plist() {
+    let env = FakeServiceEnv {
+        present: false,
+        fail_fallback: false,
+        fallback_calls: std::cell::RefCell::new(Vec::new()),
+    };
+    let (health, down_state, attempted) = apply_not_loaded_fallback(
+        &env,
+        "trusty-console",
+        ManageStrategy::Launchd,
+        Duration::from_secs(30),
+        || panic!("probe must not run when there is no plist to bootstrap"),
+        || panic!("wait must not run when there is no plist to bootstrap"),
+        || panic!("classify must not run when there is no plist to bootstrap"),
+    );
+    assert_eq!(health, health_str::DOWN);
+    assert_eq!(down_state, Some(DownState::NotLoaded));
+    assert!(!attempted);
+    assert!(env.fallback_calls.borrow().is_empty());
+}
+
+/// Why: THE #3849 code-critic MEDIUM 1 edge case — an exhausted
+/// `remaining_budget` at the moment the fallback succeeds must still
+/// re-probe (never just trust the fallback's exit code), but as a SINGLE
+/// instant probe rather than an unbounded/over-budget poll.
+/// What: `remaining_budget: Duration::ZERO` with a probe that reports
+/// healthy immediately still resolves `HEALTHY`/`None`, but `wait` is
+/// never called.
+/// Test: This is the test.
+#[test]
+fn apply_not_loaded_fallback_uses_instant_probe_when_budget_exhausted() {
+    let env = FakeServiceEnv {
+        present: true,
+        fail_fallback: false,
+        fallback_calls: std::cell::RefCell::new(Vec::new()),
+    };
+    let waits = std::cell::RefCell::new(0u32);
+    let (health, down_state, attempted) = apply_not_loaded_fallback(
+        &env,
+        "trusty-memory",
+        ManageStrategy::Launchd,
+        Duration::ZERO,
+        || health_str::HEALTHY.to_owned(),
+        || *waits.borrow_mut() += 1,
+        || panic!("classify must not run once the instant probe reports healthy"),
+    );
+    assert_eq!(health, health_str::HEALTHY);
+    assert_eq!(down_state, None);
+    assert!(attempted);
+    assert_eq!(
+        *waits.borrow(),
+        0,
+        "an exhausted budget must use a single instant probe, never wait/poll"
+    );
+}
+
+/// Why: THE #3833 safety property — polling must terminate the instant
+/// health stops being `down`, without over-waiting or under-waiting.
+/// What: a probe sequence [down, down, healthy] must return after
+/// exactly 3 attempts with 2 waits.
+/// Test: This is the test.
+#[test]
+fn poll_until_not_down_stops_when_healthy() {
+    let responses = std::cell::RefCell::new(vec![
+        health_str::HEALTHY.to_owned(),
+        health_str::DOWN.to_owned(),
+        health_str::DOWN.to_owned(),
+    ]);
+    let waits = std::cell::RefCell::new(0u32);
+    let (health, attempts) = poll_until_not_down(
+        || {
+            responses
+                .borrow_mut()
+                .pop()
+                .expect("probe called too many times")
+        },
+        || *waits.borrow_mut() += 1,
+        10,
+    );
+    assert_eq!(health, health_str::HEALTHY);
+    assert_eq!(attempts, 3);
+    assert_eq!(*waits.borrow(), 2, "must wait exactly twice, not 3 times");
+}
+
+/// Why: against a genuinely dead daemon, the poll must still terminate —
+/// never block `tctl install` forever.
+/// What: a probe that always returns `down` must stop at exactly
+/// `max_attempts`, waiting `max_attempts - 1` times (never after the
+/// final attempt).
+/// Test: This is the test.
+#[test]
+fn poll_until_not_down_stops_at_max_attempts() {
+    let waits = std::cell::RefCell::new(0u32);
+    let (health, attempts) = poll_until_not_down(
+        || health_str::DOWN.to_owned(),
+        || *waits.borrow_mut() += 1,
+        4,
+    );
+    assert_eq!(health, health_str::DOWN);
+    assert_eq!(attempts, 4);
+    assert_eq!(
+        *waits.borrow(),
+        3,
+        "must not wait after the final (4th) attempt"
+    );
+}
+
+/// Why: the common case — a daemon that is already healthy by the time
+/// the retry fires — must return immediately with zero waits, not
+/// needlessly sleep once.
+/// What: a probe that is healthy on the first call triggers no wait.
+/// Test: This is the test.
+#[test]
+fn poll_until_not_down_first_attempt_needs_no_wait() {
+    let waits = std::cell::RefCell::new(0u32);
+    let (health, attempts) = poll_until_not_down(
+        || health_str::HEALTHY.to_owned(),
+        || *waits.borrow_mut() += 1,
+        10,
+    );
+    assert_eq!(health, health_str::HEALTHY);
+    assert_eq!(attempts, 1);
+    assert_eq!(*waits.borrow(), 0);
+}
+
+/// Why: #3836 MEDIUM fix — with a generous remaining budget, a member
+/// must still get its full [`POLL_MAX_ATTEMPTS`] ceiling, never MORE.
+/// What: a large `remaining` (e.g. the full aggregate budget) clamps to
+/// exactly `POLL_MAX_ATTEMPTS`.
+/// Test: This is the test.
+#[test]
+fn bounded_attempts_clamped_to_max() {
+    assert_eq!(bounded_attempts(AGGREGATE_POLL_BUDGET), POLL_MAX_ATTEMPTS);
+    assert_eq!(
+        bounded_attempts(Duration::from_secs(3600)),
+        POLL_MAX_ATTEMPTS
+    );
+}
+
+/// Why: THE #3836 core safety property — a member turn late in the fold,
+/// with little aggregate budget left, must get proportionally FEWER
+/// attempts, not the full schedule (which is what let a single member
+/// blow through the aggregate cap).
+/// What: a small remaining budget yields fewer than `POLL_MAX_ATTEMPTS`
+/// attempts, and a larger remaining budget yields a value in between.
+/// Test: This is the test.
+#[test]
+fn bounded_attempts_shrinks_with_small_budget() {
+    // 12s remaining / 5s interval -> 1 + 2 = 3 attempts.
+    assert_eq!(bounded_attempts(Duration::from_secs(12)), 3);
+    // 30s remaining -> 1 + 6 = 7 attempts, strictly between 1 and the max.
+    let mid = bounded_attempts(Duration::from_secs(30));
+    assert!(
+        mid > 1 && mid < POLL_MAX_ATTEMPTS,
+        "expected a value strictly between 1 and {POLL_MAX_ATTEMPTS}, got {mid}"
+    );
+}
+
+/// Why: even a sliver of remaining budget must still attempt AT LEAST
+/// one probe — never zero (a zero-attempt poll makes no sense; an
+/// entirely exhausted budget is handled as its own separate case by
+/// `verify_one`, not by this function receiving a zero `remaining`).
+/// What: a 1-second remaining budget still yields `1`.
+/// Test: This is the test.
+#[test]
+fn bounded_attempts_at_least_one() {
+    assert_eq!(bounded_attempts(Duration::from_secs(1)), 1);
+}
+
+/// Why: #3836 — the "budget exhausted" summary note must fire iff ANY
+/// member's poll was skipped for that reason, and must NOT fire on an
+/// all-clear report (avoids alarming an operator over nothing).
+/// What: exercises both the empty/all-false case and a mixed case.
+/// Test: This is the test.
+#[test]
+fn any_budget_exhausted_detects_any_row() {
+    assert!(!any_budget_exhausted(&[]));
+    assert!(!any_budget_exhausted(&[row("trusty-search", "healthy")]));
+
+    let exhausted = VerifyRow {
+        budget_exhausted: true,
+        ..row("trusty-memory", health_str::DOWN)
+    };
+    assert!(any_budget_exhausted(&[
+        row("trusty-search", "healthy"),
+        exhausted
+    ]));
+}


### PR DESCRIPTION
## Summary

DEMO-CRITICAL. Fixes #3848 — reproduced live on a demo MacBook minutes after installer 0.4.8 shipped (which itself shipped #3836, the fix for #3832).

**Root cause** (confirmed with a pinned regression test against unmodified `origin/main`, see below): `service_bootstrap::bootstrap_one`'s `#3836` postcondition (`ServiceEnv::is_loaded` → `ServiceEnv::bootstrap_fallback`) lived ONLY on the fresh-install branch (`plist_present == false`). The already-installed / idempotent-skip branch (`plist_present == true`) returned `BootstrapAction::Skipped` unconditionally, before ever reaching the postcondition. A machine already carrying a plist-present-but-never-loaded state — e.g. left behind by an EARLIER pre-0.4.8 run that hit #3832 (trusty-memory's `service install` wrote the plist without loading it) — is exactly "plist present" on the 0.4.8 re-run, so it took the one code path that skips the defense entirely. `com.trusty.memory` stayed permanently absent from `launchctl list`; `tctl install` exited 2 / printed `NOT VERIFIED`.

## Fix

1. `bootstrap_one`'s already-present branch now also checks `is_loaded`. When loaded: unchanged `Skipped` (non-clobbering). When NOT loaded: calls `bootstrap_fallback` directly — **never re-running `service install`** over an existing plist (the non-clobber guarantee is unchanged; only the *load* is repaired) — and reports the new `BootstrapAction::LoadedByFallback` variant.
2. Belt-and-braces second layer (per the task spec): `verify_tail::verify_one` now also attempts the SAME `ServiceEnv::bootstrap_fallback` primitive (`attempt_verify_fallback`) for any member it classifies `DownState::NotLoaded` whose plist is present on disk, re-probing health on success. This means a FUTURE regression in the install-time skip-path handling — or a member the install-time bootstrap didn't run for this invocation (e.g. `--no-service`) — still self-heals at verify time instead of silently reporting `NOT VERIFIED`.
3. New unit tests pin the actual miss:
   - `bootstrap_one_loads_via_fallback_when_plist_present_but_not_loaded` (service_bootstrap.rs) — **verified to FAIL against unmodified `origin/main`** (confirmed manually by adding the equivalent assertion there and running it: `got action=Skipped("launchd plist already present ...")`).
   - `bootstrap_one_reports_failure_when_present_but_fallback_fails`, `bootstrap_one_skips_when_plist_present_and_loaded` (renamed/extended from the old `bootstrap_one_skips_when_plist_present`).
   - `optional_annotation_reports_verify_bootstrapped` (verify_tail.rs) — pins the second-layer annotation behaviour.

## Manual workaround

For a machine already stuck in this exact state (no code fix needed, just repairs the live daemon):

```
launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.trusty.memory.plist && \
launchctl kickstart -k gui/$(id -u)/com.trusty.memory
```

## Verification

```
$ cargo test -p trusty-installer
test result: ok. 457 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out

$ cargo clippy -p trusty-installer --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) — zero warnings

$ cargo fmt --check -p trusty-installer
(clean)

$ bash scripts/check_line_cap.sh
line-cap: 8 allowlisted, 0 violations — OK.
```

## Test plan

- [x] `cargo test -p trusty-installer` — 457 passed, 0 failed
- [x] `cargo clippy -p trusty-installer --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check -p trusty-installer` — clean
- [x] `scripts/check_line_cap.sh` — 0 violations
- [x] Regression test verified to fail against unmodified `origin/main` before the fix
- [ ] CI green (do not merge until confirmed)

Closes #3848

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools