### PR TITLE
chore(release): bump trusty-memory 0.21.1 + trusty-search 0.39.1 for #3366 parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11629,7 +11629,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11803,7 +11803,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -60,8 +60,8 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      `default-features = false` drops the `axum-server` feature so we don't
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
-trusty-memory = { path = "../trusty-memory", version = "0.21.0", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.39.0" }
+trusty-memory = { path = "../trusty-memory", version = "0.21.1", default-features = false }
+trusty-search = { path = "../trusty-search", version = "0.39.1" }
 # Gmail/Calendar eventstream listeners (#3820, DOC-54 SPEC-AGENTS-06) call
 # trusty-gworkspace's connector layer (`api::client::BaseClient` +
 # `api::services::gmail::*`) DIRECTLY as library functions — the same code

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [0.21.1] — 2026-07-24
 
 ### Fixed
 

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [Unreleased]
+## [0.39.1] — 2026-07-24
 
 ### Fixed
 

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.39.0"
+version = "0.39.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"


### PR DESCRIPTION
## Summary

The fail-closed publish-guard from issue #3366 (`Version parity` workflow, `scripts/check-version-parity.sh` / `crates/trusty-publish-guard`) has been RED on main since d3bfcf8f. Two crates carry merged source drift under versions already published to crates.io:

- **trusty-memory 0.21.0** — drift in `src/commands/serve_stdio_bridge.rs`, `src/commands/service.rs` (the `service install` launchd-bootstrap fix, #3832)
- **trusty-search 0.39.0** — drift across ~30 files (EmbedPool priority lanes #3784, size-ordered defer-embed queue #3770, plus several `#[serial]` deflakes, among other Unreleased-section work)

This is pre-existing drift, **not caused by anything merged today** — it accumulated because these crates kept landing fixes/features on `main` under an already-published version number, which `cargo build`/`cargo test` can't catch (the workspace `[patch.crates-io]` table redirects sibling deps to local paths for in-repo builds; the gap only surfaces when `cargo publish` resolves standalone against the real registry).

Per the guard's own fix guidance, this PR bumps each crate's `Cargo.toml` version so the drifted source sits under an unpublished version:

- `trusty-memory` 0.21.0 -> 0.21.1 (patch)
- `trusty-search` 0.39.0 -> 0.39.1 (patch)

Mirrors the `a712d1ae` / `d3bfcf8f` bump convention exactly:
- Bumped both crates' `Cargo.toml` `version`.
- Updated the only intra-workspace pinned-version reference to either crate (`crates/trusty-agents/Cargo.toml`'s `trusty-memory`/`trusty-search` path deps — everything else in the workspace uses `workspace = true` and carries no version string to update).
- Regenerated `Cargo.lock` (2-line diff, versions only).
- Folded each crate's `CHANGELOG.md` `## [Unreleased]` section under the new version heading (`## [0.21.1] — 2026-07-24` / `## [0.39.1] — 2026-07-24`).

**This is a bump-only change — no crates.io publish happens in this PR.** Publishing is a separate, owner-driven step (see `cargo-publish` skill / `scripts/publish-dry-run-order.sh`).

## Verification

- `bash scripts/check-version-parity.sh` run locally against this branch: all 18 publishable crates report OK, including `trusty-memory 0.21.1` / `trusty-search 0.39.1` as "not yet published, nothing to compare" (raw output in PR discussion below).
- `cargo check -p trusty-memory -p trusty-search -p trusty-agents --offline`: all three compile clean at the bumped versions.
- Note: the `Version parity` GitHub Actions workflow itself only triggers on `push: branches: [main]` (by design — it compares against the live registry, so a feature branch's version isn't final yet) plus `workflow_dispatch`. It will run automatically once this merges to main; I also triggered it manually via `workflow_dispatch` against this branch to get a real CI signal ahead of merge.

## Test plan

- [x] `scripts/check-version-parity.sh` passes locally (0 drifted, 0 unverifiable)
- [x] `cargo check` on both bumped crates + their sole intra-workspace dependent (trusty-agents)
- [ ] CI `Test` job green on this PR
- [ ] `Version parity` workflow green (manual `workflow_dispatch` run against this branch, and again automatically after merge to main)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools