### PR TITLE
fix(trusty-agents): repair 6 dangling Test: doc-comment pointers from #3838/#3840 rebase

### DIFF
--- a/crates/trusty-agents/src/api/server/listener_events.rs
+++ b/crates/trusty-agents/src/api/server/listener_events.rs
@@ -15,8 +15,9 @@
 //! `POST` takes `{ "event_type": "...", "included": bool }` and persists it.
 //! Both are thin wrappers over `crate::listeners::store::EventStore` — no
 //! `AppState` field needed (the store is file-backed, not in-process state).
-//! Test: `list_listener_events_returns_empty_when_no_log`,
-//! `set_listener_event_filter_persists_and_reflects_in_list` (`super::tests`).
+//! Test: `super::tests::listener_events` — `list_returns_empty_when_no_log`,
+//! `filter_post_persists_and_list_reflects_it`,
+//! `filter_post_rejects_empty_event_type`.
 
 use axum::{Json, extract::Query, http::StatusCode, response::IntoResponse};
 use serde::{Deserialize, Serialize};

--- a/crates/trusty-agents/src/api/server/workstreams/mod.rs
+++ b/crates/trusty-agents/src/api/server/workstreams/mod.rs
@@ -370,7 +370,7 @@ pub(crate) async fn list_workstream_labels_at(cwd: &Path, base_url: &str) -> Vec
 /// file); returns `[]` when no project root is found or the daemon is
 /// unreachable, mirroring [`list_workstreams_at`]'s safe-default posture.
 /// Test: `drawers_by_tag_at_no_project_root_is_empty`,
-/// `drawers_by_tag_at_against_mock_daemon`.
+/// `create_tagged_drawer_at_and_drawers_by_tag_at_round_trip`.
 pub(crate) async fn drawers_by_tag_at(
     cwd: &Path,
     base_url: &str,

--- a/crates/trusty-agents/src/api/server/workstreams/tests.rs
+++ b/crates/trusty-agents/src/api/server/workstreams/tests.rs
@@ -164,6 +164,10 @@ mod mock_daemon {
         drawers: StdMutex<Vec<MockDrawer>>,
     }
 
+    async fn mock_health() -> Json<serde_json::Value> {
+        Json(serde_json::json!({"status": "ok"}))
+    }
+
     async fn mock_create_palace(Json(_body): Json<serde_json::Value>) -> Json<serde_json::Value> {
         Json(serde_json::json!({"ok": true}))
     }
@@ -224,6 +228,7 @@ mod mock_daemon {
 
     async fn spawn(state: std::sync::Arc<MockState>) -> SocketAddr {
         let app = Router::new()
+            .route("/health", get(mock_health))
             .route("/api/v1/palaces", post(mock_create_palace))
             .route(
                 "/api/v1/palaces/{id}/drawers",
@@ -276,5 +281,48 @@ mod mock_daemon {
         assert_eq!(out.len(), 2);
         assert_eq!(out[0].content, "turn two", "newest-first ordering");
         assert_eq!(out[1].content, "turn one");
+    }
+
+    /// Why: `list_workstream_labels_at` is a thin bare-name projection over
+    /// `list_workstreams_at` (itself only unit-tested against an empty/
+    /// unreachable daemon above) — the classification block (DOC-54
+    /// §9.6.1, `ctrl::pm_task::dispatch::classification`) needs the CLOSED
+    /// label vocabulary as plain strings, so this is worth its own
+    /// happy-path guard against a real mock daemon rather than trusting the
+    /// composition untested.
+    /// What: seeds one `WS-CLAIM`-tagged drawer under `ws:feat-x` and one
+    /// under `ws:feat-y`; asserts the label list contains exactly both bare
+    /// names (order not asserted — `group_by_workstream`'s recency sort is
+    /// covered separately).
+    /// Test: this test.
+    #[tokio::test]
+    async fn list_workstream_labels_at_against_mock_daemon() {
+        let state = std::sync::Arc::new(MockState::default());
+        let addr = spawn(state).await;
+        let base_url = format!("http://{addr}");
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(tmp.path().join(".git")).expect("mkdir .git");
+
+        create_tagged_drawer_at(
+            tmp.path(),
+            &base_url,
+            "WS-CLAIM feat-x: does a thing",
+            vec!["ws-claim".into(), "ws:feat-x".into()],
+        )
+        .await
+        .expect("first write succeeds");
+        create_tagged_drawer_at(
+            tmp.path(),
+            &base_url,
+            "WS-CLAIM feat-y: does another thing",
+            vec!["ws-claim".into(), "ws:feat-y".into()],
+        )
+        .await
+        .expect("second write succeeds");
+
+        let labels = list_workstream_labels_at(tmp.path(), &base_url).await;
+        assert_eq!(labels.len(), 2);
+        assert!(labels.contains(&"feat-x".to_string()));
+        assert!(labels.contains(&"feat-y".to_string()));
     }
 }

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/classification.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/classification.rs
@@ -144,9 +144,9 @@ fn is_valid_label(label: &str) -> bool {
 /// `parse_marker_extracts_new_label`, `parse_marker_missing_is_none`,
 /// `parse_marker_strips_surrounding_whitespace`,
 /// `parse_marker_ignores_earlier_lookalike_text`,
-/// `parse_marker_ignores_trailing_syntax_echo`,
+/// `parse_marker_ignores_trailing_syntax_echo_mid_sentence`,
 /// `parse_marker_double_marker_strips_both_last_wins`,
-/// `parse_marker_invalid_label_stripped_but_unclassified`.
+/// `parse_marker_trailing_syntax_echo_is_stripped_but_unclassified`.
 pub(crate) fn parse_marker(raw: &str) -> (String, Option<Classification>) {
     let mut remaining = raw.trim_end();
     let mut classification: Option<Classification> = None;


### PR DESCRIPTION
## Summary

The `Test: doc-comment pointer lint` workflow (`scripts/check_test_pointers.sh`) was red on `main` (run 30109497987): 6 `Test:` doc-comment pointers in `crates/trusty-agents` cited test functions that don't exist. These went dangling because the FINAL REBASED heads of #3838 (Gmail eventstream listener, merge `ea49e0d1`) and #3840 (filterable-chat classification, merge `f4f095d3`) were admin-merged before CI ever ran on those exact heads — so the dangling-pointer lint (which would have caught this) never got a chance to fire.

## Per-pointer resolution

- **`src/api/server/listener_events.rs:18`** cited `list_listener_events_returns_empty_when_no_log` / `set_listener_event_filter_persists_and_reflects_in_list` — neither ever existed under those names. The real coverage is a full-router integration suite already in `src/api/server/tests/listener_events.rs` (`list_returns_empty_when_no_log`, `filter_post_persists_and_list_reflects_it`, `filter_post_rejects_empty_event_type`), introduced in the same PR. Corrected the citation to point at the real test module/names rather than writing duplicate unit tests.
- **`src/api/server/workstreams/mod.rs:372`** cited `drawers_by_tag_at_against_mock_daemon` — the real test exercising `drawers_by_tag_at` against a mock daemon is `create_tagged_drawer_at_and_drawers_by_tag_at_round_trip`. Corrected the citation.
- **`src/api/server/workstreams/mod.rs:356`** cited `list_workstream_labels_at_against_mock_daemon`, which had no real test under ANY name — `list_workstream_labels_at` was never actually exercised against a mock daemon (only its `list_workstreams_at` empty/unreachable-daemon edge cases were covered). Wrote that test, adding a `/health` route to the existing mock router since `list_workstreams_at`'s read path health-probes first (unlike the tag-scoped read path the existing round-trip test already covered).
- **`src/ctrl/pm_task/dispatch/classification.rs:143`** cited `parse_marker_ignores_trailing_syntax_echo` and `parse_marker_invalid_label_stripped_but_unclassified` — both were renamed during the PR's critic fix round to `parse_marker_ignores_trailing_syntax_echo_mid_sentence` and `parse_marker_trailing_syntax_echo_is_stripped_but_unclassified`. Corrected the citations.

No test pointer was deleted, no doc weakened, no lint allowlist added — every dangling citation now points at a real, passing test.

## Test plan

- [x] `scripts/check_test_pointers.sh` → `test-pointers: 0 dangling pointers — OK.`
- [x] `cargo test -p trusty-agents --lib listener_events::` → 6 passed (3 new-citation integration tests + the 3 pre-existing unit tests already there)
- [x] `cargo test -p trusty-agents --lib workstreams::` → 16 passed (incl. new `list_workstream_labels_at_against_mock_daemon` and the corrected-citation `create_tagged_drawer_at_and_drawers_by_tag_at_round_trip`)
- [x] `cargo test -p trusty-agents --lib parse_marker_` → 9 passed (incl. both corrected-citation tests)
- [x] `cargo clippy -p trusty-agents --all-targets` → clean
- [x] `cargo fmt --check -p trusty-agents` → clean

Scope: `crates/trusty-agents` only — no changes to `crates/trusty-memory` or `crates/trusty-search` (a concurrent version-bump PR touches those).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools