### PR TITLE
fix(trusty-agents): Slack RBAC parity + bundled cto-assistant Slack events (#3852)

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant/events/slack.md
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant/events/slack.md
@@ -1,0 +1,46 @@
+<!--
+Per-connector event instructions for the CTO Assistant's Slack listener
+(#3852, DOC-54 SPEC-AGENTS-05/06). Loaded into context IN ADDITION TO
+persona.md whenever a slack event wakes this agent (crate::listeners::wake)
+— never on its own. Mirrors ../izzie/events/gmail.md's structure/tone for
+the Slack connector.
+
+NOTE (#3852 hybrid architecture): the Socket-Mode gateway
+(crate::slack::handlers::handle_message) already answers Slack DMs directly
+via ctrl::run_pm_task_with_persona — that conversational path is unchanged
+and is NOT what this file governs. This file documents the reaction any
+future stage-two wake binding on a `slack` listener should take if one is
+ever configured; no such binding exists yet, so today it has no runtime
+effect (see the #3852 ADR for the fork rationale).
+-->
+
+## Reacting to a Slack message
+
+You just woke up because a message arrived on a Slack channel/DM you're
+listening on and passed the listener's filters. If this is a wake-triggered
+reaction rather than a message you were dispatched to answer directly, say so
+plainly in your first line — don't let Kartik, Andrea, Alex, or Masa think
+you're responding to something they just said if you're actually reacting to
+an event.
+
+- **Reply in-thread, as yourself.** Post in the same thread the message
+  arrived in. You are the CTO Assistant bot, never Robert Matsuoka — there is
+  no "as-Bob" impersonation mode (that's blocked pending AUTH #3074-#3078,
+  explicitly out of scope here). Speak in your own voice.
+- **Ask before acting.** Answering in the thread is always fine. Anything
+  beyond that — filing a ticket, posting to another channel, changing a
+  Canvas, pinging someone — needs an explicit go-ahead in this thread, or a
+  standing instruction you've already learned for exactly this situation.
+  Never assume silence is consent.
+- **Respect RBAC.** The sender's access tier and persona allow-list (see
+  `crate::slack::rbac`) already gated whether this message reached you at
+  all — don't relitigate that here, but also don't expose data the sender's
+  tier wouldn't otherwise reach just because it arrived via a listener wake
+  instead of a direct DM.
+- **Keep it tight.** One or two sentences unless the person asks for detail —
+  Slack threads are for quick exchanges, not reports.
+- **Learn preferences.** If someone tells you "always summarize these" or
+  "only wake me for messages mentioning X," remember that via trusty-memory
+  for next time (the Event → Ask → Learn → Adapt loop, DOC-54 §2.1).
+- **Never fabricate channel content.** Only speak to what the event summary
+  or a tool call actually returned — don't guess at a message's contents.

--- a/crates/trusty-agents/src/slack/rbac.rs
+++ b/crates/trusty-agents/src/slack/rbac.rs
@@ -145,12 +145,18 @@ pub(super) fn parse_rbac_users(raw: &str) -> HashMap<String, SlackUserConfig> {
 /// Hardcoded default team RBAC table used when `SLACK_RBAC_USERS` is unset.
 ///
 /// Why: The bot should be usable without ops first setting an env var.
-/// Test: `rbac_config_parses_env_string` (indirectly via from_env fallback).
+/// `Kartik` is carried over from the custom `cto_bot`'s `BOT_ALLOWED_USERS`
+/// default table (#3852 parity — same Slack id, same ALL tier) so the native
+/// connector doesn't regress access for anyone the retiring bot already let
+/// in.
+/// Test: `rbac_config_parses_env_string` (indirectly via from_env fallback),
+/// `default_rbac_users_includes_kartik_parity`.
 pub(super) fn default_rbac_users() -> HashMap<String, SlackUserConfig> {
     parse_rbac_users(
         "U0A6V2W1M2R:Masa:ALL:*,\
          U0ALDQLBU79:Andrea:ALL:cto-assistant,\
-         U09331EP3MX:Alex:ANALYTICS:cto-assistant",
+         U09331EP3MX:Alex:ANALYTICS:cto-assistant,\
+         U09J5EFTSA3:Kartik:ALL:cto-assistant",
     )
 }
 

--- a/crates/trusty-agents/src/slack/tests.rs
+++ b/crates/trusty-agents/src/slack/tests.rs
@@ -272,3 +272,19 @@ fn switch_command_blocked_for_restricted_persona() {
         "unrestricted user may switch to any persona"
     );
 }
+
+/// Kartik Yellepeddi (U09J5EFTSA3) must be present in the default RBAC table
+/// with `ALL` tier and a `cto-assistant`-restricted persona allow-list —
+/// parity with the retiring custom `cto_bot`'s `BOT_ALLOWED_USERS` default
+/// table (#3852).
+#[test]
+fn default_rbac_users_includes_kartik_parity() {
+    let users = default_rbac_users();
+    let kartik = users.get("U09J5EFTSA3").expect("kartik entry present");
+    assert_eq!(kartik.name, "Kartik");
+    assert_eq!(kartik.tier, crate::rbac::ServiceTier::All);
+    assert_eq!(
+        kartik.allowed_personas.as_deref(),
+        Some(&["cto-assistant".to_string()][..])
+    );
+}


### PR DESCRIPTION
## Summary

Small parity slice of epic #3852 (CTO-Assistant Slack-connector replacement,
hybrid architecture — Socket-Mode gateway stays the transport, ADDITIONALLY
mirrors onto the eventstream; see #3852 for the owner's decisions and the
follow-up ADR in PR #TBD).

- **RBAC parity** (`slack/rbac.rs`): add Kartik Yellepeddi (`U09J5EFTSA3`,
  tier `ALL`, persona `cto-assistant`) to `default_rbac_users()` — parity
  with the retiring custom `cto_bot`'s `BOT_ALLOWED_USERS` default table
  (`~/Duetto/cto/app/cto_bot/config.py`), so the native connector doesn't
  regress access for anyone the old bot already let in. Table order/style
  unchanged; extended the existing `switch_command_blocked_for_restricted_persona`-adjacent
  test coverage with a new `default_rbac_users_includes_kartik_parity` test.
- **Bundled per-connector instructions**
  (`crates/trusty-agents/.trusty-agents/agents/cto-assistant/events/slack.md`):
  mirrors `../izzie/events/gmail.md`'s structure/tone — reply in-thread,
  bot-as-itself identity (no "as-Bob" impersonation; that's blocked on AUTH
  #3074-#3078, explicitly out of scope), ask-first for anything beyond
  replying, learn standing preferences via trusty-memory. This file is the
  source of truth for the repo bundle (post-3cefa7fa); today it has no
  runtime effect since no stage-two wake binding is wired for `slack` yet
  (see the hybrid-architecture ADR in the companion PR).

## ⚠️ Merge hold

Per the PM: **do not merge** — a demo build is being cut from `main` this
afternoon and must contain only demo-critical fixes. This PR is open for
CI/review only; the hold will be released after the demo cut.

## Test plan

- [x] `cargo test -p trusty-agents --lib slack::` — 26 passed (was 25; +1 new
      Kartik parity test), 0 failed
- [x] `cargo fmt --check -p trusty-agents` — clean
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean
- [x] `scripts/check_test_pointers.sh` — 6 pre-existing dangling pointers in
      `api/server/listener_events.rs`, `api/server/workstreams/mod.rs`, and
      `ctrl/pm_task/dispatch/classification.rs` (unrelated to this PR's
      files — confirmed via `git log` these predate this branch, from
      already-merged PR #3838; a concurrently-landing PR is fixing them).
      Zero new dangling pointers introduced by this PR's changes.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools