### PR TITLE
chore(release): trusty-installer 0.4.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11585,7 +11585,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [0.4.9] - 2026-07-24
 
 ### Fixed
 

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-installer"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"


### PR DESCRIPTION
Bump version 0.4.8 → 0.4.9, fixes #3846 and #3848.