### PR TITLE
fix(trusty-agents-ui): persona editor field sized for real editing (gear panel)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -204,6 +204,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Agent config gear panel's Personality/Tools textareas were unusably
+  cramped:** the `persona.md` editor on the Personality tab (and the tools
+  allowlist editor on the Tools tab) rendered as a ~2-line strip regardless
+  of content length, because their `flex-1` sizing had no definite height
+  floor. Both textareas now get a `min-h-[55vh]`/`max-h-[70vh]` range with
+  vertical resize (`resize-y`) and internal scroll; the Personality Save
+  button is now sticky so it stays visible below the taller field.
 - **Agent pickers list only assistant-role agents, not the 16 bundled
   coding/engineer/support agents:** the GUI/Tauri picker and MCP
   `list_agents` tool (both backed by `agent_roster`/`scan_agent_catalog`)

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
@@ -198,10 +198,9 @@
         {:else}
           <textarea
             bind:value={personaContent}
-            rows="12"
-            class="w-full flex-1 resize-none rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
+            class="w-full flex-1 min-h-[55vh] max-h-[70vh] resize-y overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
           ></textarea>
-          <div class="flex items-center gap-2 pt-1">
+          <div class="sticky bottom-0 flex items-center gap-2 bg-foundry-light-surface dark:bg-foundry-surface pt-1 pb-1">
             <button
               type="button"
               class="inline-flex items-center gap-1.5 rounded-md bg-foundry-light-primary dark:bg-foundry-primary px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-foundry-light-primary/80 dark:hover:bg-foundry-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
@@ -257,9 +256,8 @@
         </p>
         <textarea
           bind:value={toolsText}
-          rows="10"
           placeholder="gworkspace_*&#10;memory_*"
-          class="w-full flex-1 resize-none rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
+          class="w-full flex-1 min-h-[55vh] max-h-[70vh] resize-y overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
         ></textarea>
         <div class="flex items-center gap-2 pt-1">
           <button


### PR DESCRIPTION
## Summary
- The agent config gear panel's Personality tab (#3826) rendered the `persona.md` textarea as a ~2-line strip regardless of content length — `flex-1` had no definite height floor, so a multi-hundred-line persona clipped mid-heading right above the Save button.
- Fixed by giving the Personality (and Tools allowlist, same cramped pattern) textareas a `min-h-[55vh]`/`max-h-[70vh]` range, `resize-y` for user resizing, and internal scroll. The Personality Save button is now `sticky bottom-0` so it stays visible below the taller field (event-instructions scaffolding follows it in that tab).
- CSS/markup-only change, scoped to `crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte`. No other tabs (OKG Stores / Permissions / Listeners) use a textarea.

## Test plan
- [x] `pnpm run check` (svelte-check + tsc) — 0 errors (2 pre-existing unrelated a11y warnings in `ProjectsView.svelte`)
- [x] `pnpm run test:unit` (vitest) — 112/112 passed
- [x] `pnpm run build` (vite build) — clean
- [x] Manual review of diff — 3 insertions / 5 deletions in the component, changelog bullet added

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools