### PR TITLE
feat(trusty-agents): live OKG store bindings in agent config (#3816 slice)

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant.toml
@@ -33,6 +33,26 @@ use_anthropic_direct = false
 # outputs (tables, source-notes blocks) are still allowed when the user
 # explicitly requests them — those use distinct prefixes.
 stop_sequences = ["\n##", "\n* * *"]
+# OKG STORE BINDING (#3816/#3864, DOC-54 SPEC-AGENTS-04 §5.1) — the FIRST leg
+# of the stores/tools/listeners config triple: what this agent KNOWS, as
+# opposed to how it ACTS (`[tools].allow`) or REACTS (`[[listeners]]`).
+#
+# Exactly ONE store per agent (Bob, 2026-07-24). `index` is a trusty-search
+# index id (over /Users/masa/trusty-mpm-projects/bob-duetto/cto), `palace` a
+# trusty-memory palace; the harness resolves both against the live daemons at
+# boot and reports each as connected / not-connected with a reason
+# (`crate::stores::status`) — a missing index degrades the store, it never
+# blocks the agent from booting. `index` is also the DEFAULT target for an
+# unqualified `vector_search(query)` call, which is the #3864 fix: this
+# persona's `[tools].allow` grants `vector_search`, and before the binding
+# existed that call silently searched a hardcoded local code index instead of
+# the CTO corpus.
+[[stores]]
+name = "cto-assistant-kb"
+tree = "okg://cto-assistant"
+index = "cto-assistant"
+palace = "cto"
+
 # Note: "\n---\n" intentionally excluded — qwen3 uses HR dividers naturally in
 # conversational output; including it caused mid-sentence truncation (#eval-qwen3)
 

--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
@@ -41,6 +41,26 @@ temperature = 0.3
 # #469: Bumped from the base's 1024 to 4096 to leave room for GFA reports and
 # structured org data tables which were getting truncated.
 max_tokens = 4096
+# OKG STORE BINDING (#3816/#3864, DOC-54 SPEC-AGENTS-04 §5.1) — the FIRST leg
+# of the stores/tools/listeners config triple: what this agent KNOWS, as
+# opposed to how it ACTS (`[tools].allow`) or REACTS (`[[listeners]]`).
+#
+# Exactly ONE store per agent (Bob, 2026-07-24). `index` is a trusty-search
+# index id (over /Users/masa/trusty-mpm-projects/bob-duetto/cto), `palace` a
+# trusty-memory palace; the harness resolves both against the live daemons at
+# boot and reports each as connected / not-connected with a reason
+# (`crate::stores::status`) — a missing index degrades the store, it never
+# blocks the agent from booting. `index` is also the DEFAULT target for an
+# unqualified `vector_search(query)` call, which is the #3864 fix: this
+# persona's `[tools].allow` grants `vector_search`, and before the binding
+# existed that call silently searched a hardcoded local code index instead of
+# the CTO corpus.
+[[stores]]
+name = "cto-assistant-kb"
+tree = "okg://cto-assistant"
+index = "cto-assistant"
+palace = "cto"
+
 
 [tools]
 # CTO-specific DELTAS only — the base `assistant` already grants git_log,

--- a/crates/trusty-agents/.trusty-agents/agents/izzie.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie.toml
@@ -32,6 +32,24 @@ use_anthropic_direct = false
 # Conversational mode (#feature-A): block markdown headers and divider rules
 # from appearing mid-response so replies stay in plain prose.
 stop_sequences = ["\n##", "\n* * *"]
+# OKG STORE BINDING (#3816/#3864, DOC-54 SPEC-AGENTS-04 §5.1) — the FIRST leg
+# of the stores/tools/listeners config triple: what Izzie KNOWS, as opposed to
+# how she ACTS (`[tools].allow`) or REACTS (`[[listeners]]`).
+#
+# Exactly ONE store per agent (Bob, 2026-07-24). `index` is a trusty-search
+# index id, `palace` a trusty-memory palace; the harness resolves both against
+# the live daemons at boot and reports each as connected / not-connected with a
+# reason (`crate::stores::status`) — a missing index degrades the store, it
+# never blocks the agent from booting. `index` is also the DEFAULT target for
+# an unqualified `vector_search(query)` call (#3864), so Izzie's semantic
+# search hits her own knowledge tree rather than whatever code index happens to
+# sit under the process CWD.
+[[stores]]
+name = "bob-kb"
+tree = "okg://izzie"
+index = "bob-kb"
+palace = "owner-profile"
+
 # Note: "\n---\n" intentionally excluded — qwen3 uses HR dividers naturally in
 # conversational output; including it caused mid-sentence truncation (#eval-qwen3)
 
@@ -53,6 +71,10 @@ allow = [
   "granola_*",
   # web search
   "web_search",
+  # #3864: semantic search over Izzie's bound OKG store (`bob-kb`). An
+  # unqualified `vector_search(query)` defaults to that index; an explicit
+  # `index_id` can still target another corpus.
+  "vector_search",
   # gworkspace — Gmail
   "compose_email",
   "download_gmail_attachment",

--- a/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
@@ -59,6 +59,24 @@ temperature = 0.7
 max_tokens = 1024
 # Conversational mode: block markdown headers and divider rules mid-response.
 stop_sequences = ["\n##", "\n* * *"]
+# OKG STORE BINDING (#3816/#3864, DOC-54 SPEC-AGENTS-04 §5.1) — the FIRST leg
+# of the stores/tools/listeners config triple: what Izzie KNOWS, as opposed to
+# how she ACTS (`[tools].allow`) or REACTS (`[[listeners]]`).
+#
+# Exactly ONE store per agent (Bob, 2026-07-24). `index` is a trusty-search
+# index id, `palace` a trusty-memory palace; the harness resolves both against
+# the live daemons at boot and reports each as connected / not-connected with a
+# reason (`crate::stores::status`) — a missing index degrades the store, it
+# never blocks the agent from booting. `index` is also the DEFAULT target for
+# an unqualified `vector_search(query)` call (#3864), so Izzie's semantic
+# search hits her own knowledge tree rather than whatever code index happens to
+# sit under the process CWD.
+[[stores]]
+name = "bob-kb"
+tree = "okg://izzie"
+index = "bob-kb"
+palace = "owner-profile"
+
 
 [tools]
 # Redundant-but-harmless — see the header note. This mirrors the curated
@@ -76,6 +94,10 @@ allow = [
   "granola_*",
   # web search
   "web_search",
+  # #3864: semantic search over Izzie's bound OKG store (`bob-kb`). An
+  # unqualified `vector_search(query)` defaults to that index; an explicit
+  # `index_id` can still target another corpus.
+  "vector_search",
   # weather + Metro-North (epic #3052; skills izzie-weather / izzie-metro-north)
   "get_weather",
   "get_train_schedule",

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -34,10 +34,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `cto-assistant` binds `okg://cto-assistant` → trusty-search
   `cto-assistant` + palace `cto`. Seeded in the embedded provisioning source
   of truth (`.trusty-agents/agents/`), both the directory packages and their
-  flat shadows, with regression tests asserting the embedded bytes still
-  carry each binding and grant `vector_search` — a reprovision that dropped
-  either would otherwise fail silently. `izzie`'s `[tools].allow` now grants
-  `vector_search` so her binding is actually reachable.
+  flat shadows, with regression tests asserting that the embedded bytes of
+  EVERY seed spelling — package and flat shadow alike — still carry each
+  binding and grant `vector_search`. A reprovision that dropped either, or an
+  edit that updated the package but not its load-bearing `extends`-shadow
+  counterpart, would otherwise fail silently. `izzie`'s `[tools].allow` now
+  grants `vector_search` so her binding is actually reachable.
 
 ### Fixed
 

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -9,6 +9,62 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Live OKG store bindings — the FIRST leg of the agent-config triple
+  (#3816, DOC-54 SPEC-AGENTS-04 §5.1):** `agent.toml` gains `[[stores]]`,
+  declaring what an agent KNOWS alongside how it ACTS (`[tools]`) and REACTS
+  (`[[listeners]]`). A binding names an OKG knowledge tree (`okg://<agent>`),
+  the trusty-search index built over it, and optionally a trusty-memory
+  palace. Both spellings parse: the rich `[[stores]]` array-of-tables and the
+  product spec's `[stores] allow = [...]` shorthand (which derives tree and
+  index). New `crate::stores` module resolves each binding LIVE at request
+  time against `GET /indexes/{id}/status` and
+  `GET /api/v1/palaces/{id}/drawers`, reporting connected + chunk count /
+  root / readiness, or not-connected + a human-readable reason. Nothing here
+  is fatal: an unknown index, a down daemon, or a malformed binding degrades
+  to a reported disconnect — the agent still boots. Under `extends`, a
+  child's `[[stores]]` REPLACES the base's rather than unioning (exactly one
+  store per agent), so a personalization overlay's own index is the default
+  search target.
+- **`GET /api/agents/:name/stores`:** sidecar route returning each binding's
+  live status plus any non-fatal config `issues`. Malformed agent TOML
+  returns `200` with a `config_error` field rather than a 500, so one bad
+  hand-edit cannot blank the config panel.
+- **Bundled seed bindings for the demo personas:** `izzie` binds
+  `okg://izzie` → trusty-search `bob-kb` + palace `owner-profile`;
+  `cto-assistant` binds `okg://cto-assistant` → trusty-search
+  `cto-assistant` + palace `cto`. Seeded in the embedded provisioning source
+  of truth (`.trusty-agents/agents/`), both the directory packages and their
+  flat shadows, with regression tests asserting the embedded bytes still
+  carry each binding and grant `vector_search` — a reprovision that dropped
+  either would otherwise fail silently. `izzie`'s `[tools].allow` now grants
+  `vector_search` so her binding is actually reachable.
+
+### Fixed
+
+- **`vector_search` had no `index_id` parameter and silently searched the
+  wrong corpus (#3864):** personas documented `vector_search(index_id=…)`
+  while the tool advertised no such field and was hardwired to the
+  CWD-relative `.trusty-agents/state/code/` index, so index routing was a
+  no-op (the live workaround was to grant `grep` instead). The tool now takes
+  an optional `index_id`, defaulting to the agent's bound OKG store index, and
+  routes to the shared trusty-search daemon (`POST /indexes/{id}/search`) when
+  one resolves — an unqualified search hits the agent's OWN knowledge, an
+  explicit id still targets another corpus. Every failure (undiscoverable
+  daemon, missing index, transport error) degrades to the embedded index and
+  then to the regex fallback, never an errored turn. `vector_search` is also
+  now registered on the persona-chat dispatch path, where it previously was
+  not — the grant in `cto-assistant`'s allowlist had nothing behind it.
+
+### Changed
+
+- **GUI OKG Stores pane is real:** the gear panel's OKG Stores tab now fetches
+  `GET /api/agents/:name/stores` and renders observed state — CONNECTED with
+  the index name, chunk count, readiness and indexed root, or NOT CONNECTED
+  with the backend's reason (plus a separate line for palace health). The
+  "Scaffolding — `agent.toml` has no OKG store binding field yet" placeholder
+  and the client-side `scaffoldOkgStores()` fabricator are deleted; an agent
+  that binds nothing now says so explicitly instead of showing a fake row.
+
 - **First real eventstream listener: Gmail history-poll + agent wake (#3820,
   DOC-54 SPEC-AGENTS-04/06):** the third leg of the agent-config triple
   (stores / tools / **listeners**) lands with a working Gmail connector.

--- a/crates/trusty-agents/src/agents/bundled/tests.rs
+++ b/crates/trusty-agents/src/agents/bundled/tests.rs
@@ -420,3 +420,77 @@ fn ensure_deployed_blocks_on_externally_held_pass_lock() {
     // this establishes the baseline stamp without touching any file.
     assert_eq!(report, ReprovisionReport::default());
 }
+
+/// #3816/#3864: the embedded seed for each demo persona must carry its OKG
+/// store binding.
+///
+/// Why: the bindings are what make `vector_search` route to the agent's own
+/// corpus and what the GUI's OKG Stores card renders. They live in files that
+/// the reprovision path rewrites (#3556, and the reprovision-clobber class of
+/// bug generally), so a silent drop here would degrade both surfaces with no
+/// compile error anywhere — exactly the failure mode #3864 documented. Asserts
+/// against the EMBEDDED bytes (the provisioning source of truth), not against
+/// `~/.trusty-agents`, which this crate must never read in a test.
+/// Test: itself.
+#[test]
+fn bundled_personas_carry_their_okg_store_bindings() {
+    #[derive(serde::Deserialize)]
+    struct Partial {
+        #[serde(default)]
+        stores: crate::stores::StoresConfig,
+    }
+
+    for (file, index, palace, tree) in [
+        ("izzie/agent.toml", "bob-kb", "owner-profile", "okg://izzie"),
+        (
+            "cto-assistant/agent.toml",
+            "cto-assistant",
+            "cto",
+            "okg://cto-assistant",
+        ),
+    ] {
+        let raw =
+            BundledAgents::get(file).unwrap_or_else(|| panic!("bundled asset missing: {file}"));
+        let text = std::str::from_utf8(&raw.data).unwrap();
+        let parsed: Partial =
+            toml::from_str(text).unwrap_or_else(|e| panic!("{file} is not valid TOML: {e}"));
+        let binding = parsed
+            .stores
+            .primary()
+            .unwrap_or_else(|| panic!("{file} declares no [[stores]] binding"));
+        assert_eq!(binding.resolved_index(), index, "{file} index");
+        assert_eq!(binding.palace.as_deref(), Some(palace), "{file} palace");
+        let agent_name = file.split('/').next().unwrap();
+        assert_eq!(binding.resolved_tree(agent_name), tree, "{file} tree");
+        assert!(
+            parsed.stores.validate().is_empty(),
+            "{file} binding has config issues: {:?}",
+            parsed.stores.validate()
+        );
+    }
+}
+
+/// Both demo personas must actually be ABLE to call `vector_search` — a
+/// binding the persona's `[tools].allow` doesn't grant is inert.
+#[test]
+fn bundled_personas_grant_vector_search() {
+    #[derive(serde::Deserialize)]
+    struct Partial {
+        tools: Tools,
+    }
+    #[derive(serde::Deserialize)]
+    struct Tools {
+        #[serde(default)]
+        allow: Vec<String>,
+    }
+
+    for file in ["izzie/agent.toml", "cto-assistant/agent.toml"] {
+        let raw = BundledAgents::get(file).unwrap();
+        let text = std::str::from_utf8(&raw.data).unwrap();
+        let parsed: Partial = toml::from_str(text).unwrap();
+        assert!(
+            parsed.tools.allow.iter().any(|t| t == "vector_search"),
+            "{file} binds an OKG store but does not grant vector_search"
+        );
+    }
+}

--- a/crates/trusty-agents/src/agents/bundled/tests.rs
+++ b/crates/trusty-agents/src/agents/bundled/tests.rs
@@ -421,16 +421,52 @@ fn ensure_deployed_blocks_on_externally_held_pass_lock() {
     assert_eq!(report, ReprovisionReport::default());
 }
 
-/// #3816/#3864: the embedded seed for each demo persona must carry its OKG
-/// store binding.
+/// Every embedded seed spelling of a demo persona, as
+/// `(asset_path, agent_name)`.
+///
+/// Why: each persona ships TWO embedded files — the directory PACKAGE
+/// (`<name>/agent.toml`, the higher-ranked form `scan_agents_dir_tiered`
+/// actually dispatches) and the flat SHADOW (`<name>.toml`). The shadow is
+/// not dead weight: its own header documents it as the load-bearing
+/// `extends`-shadow fallback, so the two must stay in sync. Asserting only
+/// the package would let a future edit update one and silently leave the
+/// other behind — which is precisely the drift these seeds are most exposed
+/// to, since the reprovision path rewrites both. Driving the store/tool
+/// assertions off ONE shared table is what makes that drift mechanically
+/// impossible to miss (#3878 code-critic MEDIUM-1). The agent name is carried
+/// explicitly rather than derived from the path because the two layouts spell
+/// it differently (`izzie/agent.toml` vs `izzie.toml`).
+const SEED_SPELLINGS: &[(&str, &str)] = &[
+    ("izzie/agent.toml", "izzie"),
+    ("izzie.toml", "izzie"),
+    ("cto-assistant/agent.toml", "cto-assistant"),
+    ("cto-assistant.toml", "cto-assistant"),
+];
+
+/// The OKG store binding each persona's seeds must declare, keyed by agent
+/// name: `(agent_name, index, palace, tree)`.
+const EXPECTED_BINDINGS: &[(&str, &str, &str, &str)] = &[
+    ("izzie", "bob-kb", "owner-profile", "okg://izzie"),
+    (
+        "cto-assistant",
+        "cto-assistant",
+        "cto",
+        "okg://cto-assistant",
+    ),
+];
+
+/// #3816/#3864: every embedded seed spelling of each demo persona must carry
+/// its OKG store binding.
 ///
 /// Why: the bindings are what make `vector_search` route to the agent's own
 /// corpus and what the GUI's OKG Stores card renders. They live in files that
 /// the reprovision path rewrites (#3556, and the reprovision-clobber class of
 /// bug generally), so a silent drop here would degrade both surfaces with no
-/// compile error anywhere — exactly the failure mode #3864 documented. Asserts
-/// against the EMBEDDED bytes (the provisioning source of truth), not against
-/// `~/.trusty-agents`, which this crate must never read in a test.
+/// compile error anywhere — exactly the failure mode #3864 documented. Covers
+/// BOTH the package and the flat shadow (see [`SEED_SPELLINGS`]) so the two
+/// cannot drift apart. Asserts against the EMBEDDED bytes (the provisioning
+/// source of truth), not against `~/.trusty-agents`, which this crate must
+/// never read in a test.
 /// Test: itself.
 #[test]
 fn bundled_personas_carry_their_okg_store_bindings() {
@@ -440,15 +476,12 @@ fn bundled_personas_carry_their_okg_store_bindings() {
         stores: crate::stores::StoresConfig,
     }
 
-    for (file, index, palace, tree) in [
-        ("izzie/agent.toml", "bob-kb", "owner-profile", "okg://izzie"),
-        (
-            "cto-assistant/agent.toml",
-            "cto-assistant",
-            "cto",
-            "okg://cto-assistant",
-        ),
-    ] {
+    for (file, agent_name) in SEED_SPELLINGS {
+        let (_, index, palace, tree) = EXPECTED_BINDINGS
+            .iter()
+            .find(|(name, ..)| name == agent_name)
+            .unwrap_or_else(|| panic!("no expected binding declared for agent `{agent_name}`"));
+
         let raw =
             BundledAgents::get(file).unwrap_or_else(|| panic!("bundled asset missing: {file}"));
         let text = std::str::from_utf8(&raw.data).unwrap();
@@ -458,10 +491,9 @@ fn bundled_personas_carry_their_okg_store_bindings() {
             .stores
             .primary()
             .unwrap_or_else(|| panic!("{file} declares no [[stores]] binding"));
-        assert_eq!(binding.resolved_index(), index, "{file} index");
-        assert_eq!(binding.palace.as_deref(), Some(palace), "{file} palace");
-        let agent_name = file.split('/').next().unwrap();
-        assert_eq!(binding.resolved_tree(agent_name), tree, "{file} tree");
+        assert_eq!(binding.resolved_index(), *index, "{file} index");
+        assert_eq!(binding.palace.as_deref(), Some(*palace), "{file} palace");
+        assert_eq!(binding.resolved_tree(agent_name), *tree, "{file} tree");
         assert!(
             parsed.stores.validate().is_empty(),
             "{file} binding has config issues: {:?}",
@@ -471,7 +503,9 @@ fn bundled_personas_carry_their_okg_store_bindings() {
 }
 
 /// Both demo personas must actually be ABLE to call `vector_search` — a
-/// binding the persona's `[tools].allow` doesn't grant is inert.
+/// binding the persona's `[tools].allow` doesn't grant is inert. Checked on
+/// every seed spelling (package + flat shadow) for the same anti-drift reason
+/// as [`bundled_personas_carry_their_okg_store_bindings`].
 #[test]
 fn bundled_personas_grant_vector_search() {
     #[derive(serde::Deserialize)]
@@ -484,8 +518,9 @@ fn bundled_personas_grant_vector_search() {
         allow: Vec<String>,
     }
 
-    for file in ["izzie/agent.toml", "cto-assistant/agent.toml"] {
-        let raw = BundledAgents::get(file).unwrap();
+    for (file, _agent_name) in SEED_SPELLINGS {
+        let raw =
+            BundledAgents::get(file).unwrap_or_else(|| panic!("bundled asset missing: {file}"));
         let text = std::str::from_utf8(&raw.data).unwrap();
         let parsed: Partial = toml::from_str(text).unwrap();
         assert!(

--- a/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
@@ -103,6 +103,7 @@ fn test_agent_config(name: &str, model: &str, system_prompt: &str) -> AgentConfi
         workstreams: crate::agents::WorkstreamContextConfig::default(),
         adapter: Arc::new(crate::llm::adapter::GenericAdapter),
         listeners: Vec::new(),
+        stores: crate::stores::StoresConfig::default(),
     }
 }
 

--- a/crates/trusty-agents/src/agents/claude_mpm_loader.rs
+++ b/crates/trusty-agents/src/agents/claude_mpm_loader.rs
@@ -135,6 +135,9 @@ impl ClaudeMpmAgent {
             workstreams: crate::agents::WorkstreamContextConfig::default(),
             adapter,
             listeners: Vec::new(),
+            // #3816: claude-mpm agents carry no `[[stores]]` table — an
+            // unbound store is a valid state (see `AgentConfig::stores`).
+            stores: crate::stores::StoresConfig::default(),
         }
     }
 }

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -138,6 +138,31 @@ pub struct AgentConfig {
     /// `crate::listeners::wake` tests cover matching semantics.
     #[serde(default)]
     pub listeners: Vec<crate::listeners::config::AgentListenerBinding>,
+
+    /// Per-agent OKG store bindings (#3816/#3864, DOC-54 SPEC-AGENTS-04
+    /// §5.1) — the FIRST leg of the stores/tools/listeners config triple.
+    ///
+    /// Why: An agent KNOWS things via a bound OKG store (its knowledge tree
+    /// plus the trusty-search index over it, optionally plus a trusty-memory
+    /// palace), distinct from how it ACTS (`[tools].allow`) and REACTS
+    /// (`[[listeners]]`). Before this field existed there was no way to point
+    /// an agent's semantic search at its own corpus — `vector_search` was
+    /// hardwired to a CWD-relative local code index (#3864) — and the GUI's
+    /// OKG Stores pane could only render a placeholder. Bob's 2026-07-24
+    /// decision is exactly ONE store per agent; more than one parses but is
+    /// reported by `StoresConfig::validate` and only the first is used as the
+    /// default search target.
+    /// What: [`crate::stores::StoresConfig`], accepting either the
+    /// `[[stores]]` array-of-tables (rich: name/tree/index/palace) or the
+    /// product spec's `[stores] allow = [...]` shorthand. Absent = the agent
+    /// binds no store, which is valid and leaves every dependent behaviour on
+    /// its pre-existing default. Nothing here is fatal: an unresolvable or
+    /// malformed binding is surfaced as a disconnected store with a reason
+    /// (`crate::stores::status`), never a boot failure.
+    /// Test: `crate::stores::config` unit tests cover the binding shapes;
+    /// `crate::stores::status` covers live resolution.
+    #[serde(default)]
+    pub stores: crate::stores::StoresConfig,
 }
 
 fn default_adapter() -> Arc<dyn ModelAdapter> {

--- a/crates/trusty-agents/src/agents/extends/mod.rs
+++ b/crates/trusty-agents/src/agents/extends/mod.rs
@@ -300,6 +300,19 @@ pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
     // above), rather than appending a shadowing duplicate.
     merged.listeners = union_listener_bindings(merged.listeners, child.listeners);
 
+    // `stores` (#3816): child REPLACES rather than unions. Unlike listeners
+    // and tools — where "the base's surface plus my extras" is the intent —
+    // the spec allows exactly ONE OKG store per agent (DOC-54 §5.1). A
+    // personalization overlay declaring its own store (`izzie` → `bob-kb`,
+    // `cto-assistant` → `cto-assistant`) means "this is MY knowledge", not
+    // "add mine alongside the base's"; unioning would produce a two-store
+    // config whose default search target is the BASE's index, silently
+    // routing every unqualified `vector_search` to the wrong corpus. A child
+    // that declares no `[[stores]]` still inherits the base's.
+    if !child.stores.bindings.is_empty() {
+        merged.stores = child.stores.clone();
+    }
+
     // --- Prose: base-first concatenation ---
     merged.system_prompt.content =
         concat_prose(&merged.system_prompt.content, &child.system_prompt.content);

--- a/crates/trusty-agents/src/agents/extends/tests.rs
+++ b/crates/trusty-agents/src/agents/extends/tests.rs
@@ -856,3 +856,90 @@ fn registry_extends_error_surfaced_in_summary() {
         "error names the missing base: {err}"
     );
 }
+
+/// #3816: unlike listeners/tools (union), a child's `[[stores]]` REPLACES
+/// the base's. The spec allows exactly one OKG store per agent, so a
+/// personalization overlay declaring its own store must not end up with the
+/// BASE's index as the default `vector_search` target.
+#[test]
+fn extends_child_stores_replace_base_stores() {
+    let base = cfg(r#"
+[agent]
+name = "assistant"
+role = "assistant"
+model = "m"
+description = "d"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "b"
+[[stores]]
+name = "assistant-kb"
+index = "assistant"
+"#);
+    let ch = cfg(r#"
+[agent]
+name = "cto-assistant"
+role = "assistant"
+model = ""
+description = ""
+extends = "assistant"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "c"
+[[stores]]
+name = "cto-assistant-kb"
+index = "cto-assistant"
+palace = "cto"
+"#);
+    let merged = merge_extends(base, ch);
+    assert_eq!(
+        merged.stores.bindings.len(),
+        1,
+        "child replaces, not appends"
+    );
+    assert_eq!(
+        merged.stores.default_search_index(),
+        Some("cto-assistant"),
+        "the overlay's OWN index must be the default search target"
+    );
+    assert_eq!(merged.stores.bindings[0].palace.as_deref(), Some("cto"));
+}
+
+/// A child that declares no stores still inherits the base's binding.
+#[test]
+fn extends_child_without_stores_inherits_base_binding() {
+    let base = cfg(r#"
+[agent]
+name = "assistant"
+role = "assistant"
+model = "m"
+description = "d"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "b"
+[[stores]]
+name = "assistant-kb"
+index = "assistant"
+"#);
+    let ch = cfg(r#"
+[agent]
+name = "child"
+role = "assistant"
+model = ""
+description = ""
+extends = "assistant"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "c"
+"#);
+    let merged = merge_extends(base, ch);
+    assert_eq!(merged.stores.default_search_index(), Some("assistant"));
+}

--- a/crates/trusty-agents/src/agents/registry/md_agent.rs
+++ b/crates/trusty-agents/src/agents/registry/md_agent.rs
@@ -221,5 +221,8 @@ pub(crate) fn parse_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
         // §5.3's primary format) — a `.md` overlay agent never wakes on a
         // listener event until this parser grows frontmatter support.
         listeners: Vec::new(),
+        // #3816: markdown agents carry no `[[stores]]` table — an unbound
+        // store is a valid state (see `AgentConfig::stores`).
+        stores: crate::stores::StoresConfig::default(),
     })
 }

--- a/crates/trusty-agents/src/api/server/agent_patch.rs
+++ b/crates/trusty-agents/src/api/server/agent_patch.rs
@@ -92,7 +92,10 @@ use super::state::AppState;
 /// pre-#3819 behavior) would never resolve ANY bundled agent there, since
 /// every bundled agent lives in the `$HOME/.trusty-agents/agents` tier, not
 /// a nonexistent `/.trusty-agents/agents`.
-fn resolve_agent_paths(dirs: &[PathBuf], name: &str) -> Option<(PathBuf, Option<PathBuf>)> {
+pub(super) fn resolve_agent_paths(
+    dirs: &[PathBuf],
+    name: &str,
+) -> Option<(PathBuf, Option<PathBuf>)> {
     for dir in dirs {
         let package_dir = dir.join(name);
         let package_toml = package_dir.join("agent.toml");

--- a/crates/trusty-agents/src/api/server/agent_stores.rs
+++ b/crates/trusty-agents/src/api/server/agent_stores.rs
@@ -1,0 +1,168 @@
+//! `GET /api/agents/:name/stores` — the agent's OKG store bindings, resolved
+//! live against the running daemons (#3816/#3864, epic #3052).
+//!
+//! Why: The gear panel's "OKG Stores" tab previously rendered a hardcoded
+//! client-side placeholder ("agent.toml has no OKG store binding field yet")
+//! because there was neither a config field nor a route to read one. This is
+//! the read side of that field: it parses the agent's `[[stores]]` bindings
+//! off disk and asks trusty-search / trusty-memory whether each one actually
+//! exists, so the card can say CONNECTED with a chunk count or NOT CONNECTED
+//! with a reason instead of asserting the same thing for every agent.
+//! What: [`agent_stores_route`] is the axum shim; [`stores_at`] is the
+//! testable core taking the agents-dir list and both daemon base URLs
+//! explicitly (same injected-dependency convention as `agent_patch::*_at` and
+//! `workstreams::list_workstreams_at`). Response shape:
+//! `{"stores": [StoreStatus, …]}` — an empty array for an agent that binds
+//! nothing, which is a valid state, not an error. A daemon being down is
+//! likewise reported per-store, never as a route failure: this endpoint
+//! returns `200` whenever the agent resolves at all.
+//! Test: `super::tests::agent_stores`.
+
+use std::path::PathBuf;
+
+use axum::{
+    Json,
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+use super::agent_patch::resolve_agent_paths;
+use super::state::AppState;
+use crate::stores::{StoresConfig, resolve_store_statuses};
+
+/// `GET /api/agents/:name/stores` — HTTP entry point.
+///
+/// Why/What: see the module doc. Daemon base URLs are discovered here (via
+/// the shared `http_addr` convention every trusty-* daemon writes) and
+/// threaded into [`stores_at`] so tests can substitute a mock.
+/// Test: `super::tests::agent_stores::stores_route_reports_bindings`.
+pub(super) async fn agent_stores_route(
+    State(_state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+) -> Response {
+    stores_at(
+        &crate::agents::agents_dir_candidates(),
+        &name,
+        trusty_common::resolve_daemon_base_url("trusty-search").as_deref(),
+        trusty_common::resolve_daemon_base_url("trusty-memory").as_deref(),
+    )
+    .await
+}
+
+/// Core store-resolution logic against explicit agents dirs + daemon URLs.
+///
+/// Why: Same testability rationale as `agent_patch::patch_agent_at`.
+/// What: `400` for an invalid name, `404` for an unknown agent, `500` only
+/// when the resolved config file cannot be read. Malformed TOML is NOT a
+/// `500` here — it degrades to "no bindings" plus a `config_error` field, so
+/// a hand-edited file breaking the stores table still lets the panel render
+/// the rest of the agent. Every per-store failure is inside the `StoreStatus`
+/// entries, not the HTTP status.
+/// Test: `stores_route_reports_bindings`, `stores_route_unknown_agent_404`,
+/// `stores_route_empty_for_unbound_agent`,
+/// `stores_route_reports_config_error_without_failing`.
+pub(super) async fn stores_at(
+    dirs: &[PathBuf],
+    name: &str,
+    search_base: Option<&str>,
+    memory_base: Option<&str>,
+) -> Response {
+    if name.is_empty() || name.contains(['/', '\\']) || name == "." || name == ".." {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "invalid agent name" })),
+        )
+            .into_response();
+    }
+    let Some((path, _package_dir)) = resolve_agent_paths(dirs, name) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "unknown agent", "name": name })),
+        )
+            .into_response();
+    };
+    let raw = match tokio::fs::read_to_string(&path).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(?e, agent = name, path = %path.display(), "stores_at: read failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "failed to read agent config" })),
+            )
+                .into_response();
+        }
+    };
+
+    let (stores, config_error) = parse_stores(&raw);
+    let statuses = resolve_store_statuses(name, &stores, search_base, memory_base).await;
+    let mut body = serde_json::json!({
+        "stores": statuses,
+        "issues": stores.validate(),
+    });
+    if let Some(err) = config_error {
+        body["config_error"] = serde_json::Value::String(err);
+    }
+    (StatusCode::OK, Json(body)).into_response()
+}
+
+/// Parse just the `[[stores]]` table out of a raw `agent.toml`.
+///
+/// Why: Reading the whole file through `AgentConfig` would require `[llm]`
+/// and `[system_prompt]` to be present and valid — true for a flat agent but
+/// NOT for a directory package, whose `agent.toml` deliberately omits
+/// `system_prompt.content` (it lives in `persona.md`). Deserializing only the
+/// field this endpoint needs keeps the route working for both file layouts,
+/// matching `parse_agent_toml`'s partial-read precedent.
+/// What: `(bindings, None)` on success; `(empty, Some(message))` when the
+/// file isn't valid TOML or its `stores` value has an unusable shape.
+/// Test: `parse_stores_reads_array_form`, `parse_stores_reports_bad_toml`.
+fn parse_stores(raw: &str) -> (StoresConfig, Option<String>) {
+    #[derive(serde::Deserialize)]
+    struct Partial {
+        #[serde(default)]
+        stores: StoresConfig,
+    }
+    match toml::from_str::<Partial>(raw) {
+        Ok(p) => (p.stores, None),
+        Err(e) => (StoresConfig::default(), Some(e.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn parse_stores_reads_array_form() {
+        let raw = r#"
+[agent]
+name = "izzie"
+
+[[stores]]
+name = "bob-kb"
+index = "bob-kb"
+palace = "owner-profile"
+"#;
+        let (stores, err) = parse_stores(raw);
+        assert!(err.is_none());
+        assert_eq!(stores.default_search_index(), Some("bob-kb"));
+    }
+
+    #[test]
+    fn parse_stores_ignores_other_sections() {
+        // A package `agent.toml` has no `[system_prompt]` — parsing must not
+        // require one (see this fn's doc comment).
+        let raw = "[agent]\nname = \"x\"\n[tools]\nallow = [\"a\"]\n";
+        let (stores, err) = parse_stores(raw);
+        assert!(err.is_none());
+        assert!(stores.bindings.is_empty());
+    }
+
+    #[test]
+    fn parse_stores_reports_bad_toml() {
+        let (stores, err) = parse_stores("this is not = = toml");
+        assert!(stores.bindings.is_empty());
+        assert!(err.is_some());
+    }
+}

--- a/crates/trusty-agents/src/api/server/agent_stores.rs
+++ b/crates/trusty-agents/src/api/server/agent_stores.rs
@@ -36,7 +36,7 @@ use crate::stores::{StoresConfig, resolve_store_statuses};
 /// Why/What: see the module doc. Daemon base URLs are discovered here (via
 /// the shared `http_addr` convention every trusty-* daemon writes) and
 /// threaded into [`stores_at`] so tests can substitute a mock.
-/// Test: `super::tests::agent_stores::stores_route_reports_bindings`.
+/// Test: `super::tests::agent_stores::stores_route_reports_connected_binding_with_stats`.
 pub(super) async fn agent_stores_route(
     State(_state): State<AppState>,
     AxumPath(name): AxumPath<String>,
@@ -59,9 +59,9 @@ pub(super) async fn agent_stores_route(
 /// a hand-edited file breaking the stores table still lets the panel render
 /// the rest of the agent. Every per-store failure is inside the `StoreStatus`
 /// entries, not the HTTP status.
-/// Test: `stores_route_reports_bindings`, `stores_route_unknown_agent_404`,
+/// Test: `stores_route_reports_connected_binding_with_stats`, `stores_route_unknown_agent_404`,
 /// `stores_route_empty_for_unbound_agent`,
-/// `stores_route_reports_config_error_without_failing`.
+/// `stores_route_degrades_on_malformed_toml`.
 pub(super) async fn stores_at(
     dirs: &[PathBuf],
     name: &str,

--- a/crates/trusty-agents/src/api/server/mod.rs
+++ b/crates/trusty-agents/src/api/server/mod.rs
@@ -31,6 +31,7 @@
 
 mod agent_create;
 mod agent_patch;
+mod agent_stores;
 mod auth;
 mod cancel;
 mod ctrl_sessions;

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -23,6 +23,7 @@ use trusty_common::server::{SelfOrigins, with_guarded_middleware};
 
 use super::agent_create::create_agent_route;
 use super::agent_patch::{get_agent_persona_route, get_agent_route, patch_agent_route};
+use super::agent_stores::agent_stores_route;
 use super::auth::{ApiClientConfig, ApiConfig, AuthState, auth_middleware};
 use super::cancel::cancel_task;
 use super::ctrl_sessions::{
@@ -146,6 +147,14 @@ pub fn build_router_with_origins(
         .route(
             "/api/agents/{name}/persona",
             axum::routing::get(get_agent_persona_route),
+        )
+        // #3816/#3864: the gear-panel OKG Stores tab reads the agent's
+        // `[[stores]]` bindings resolved LIVE against trusty-search /
+        // trusty-memory (connected + chunk count, or not-connected + reason).
+        // Read-only in this slice — bindings are edited in `agent.toml`.
+        .route(
+            "/api/agents/{name}/stores",
+            axum::routing::get(agent_stores_route),
         )
         .route("/api/workstreams", get(list_workstreams_route))
         .route(

--- a/crates/trusty-agents/src/api/server/tests/agent_stores.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_stores.rs
@@ -1,0 +1,214 @@
+//! `GET /api/agents/:name/stores` handler tests (#3816/#3864).
+//!
+//! Why: This endpoint's whole point is to replace a hardcoded "not
+//! connected" placeholder with an OBSERVED status — a route that always
+//! reported the same thing would be the bug it was written to fix. These
+//! tests drive `stores_at` directly against a `tempfile::TempDir` (the
+//! `agent_patch.rs` pattern, so they don't race sibling tests on cwd/`$HOME`)
+//! with a mock trusty-search/-memory daemon, plus one full-router test
+//! proving the route is actually wired into `build_router`.
+//! What: connected-with-stats, missing-index → not-connected + reason,
+//! unbound agent → empty list, unknown agent → 404, invalid name → 400,
+//! malformed TOML → 200 with `config_error` (degrades, never 500), and
+//! router wiring.
+//! Test: This module IS the test.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::{Json, Router, extract::Path, http::StatusCode as AxumStatus, routing::get};
+use tokio::net::TcpListener;
+use tower::ServiceExt;
+
+use crate::api::server::agent_stores::stores_at;
+use crate::api::server::routes::build_router;
+use crate::api::server::state::AppState;
+
+const BOUND_FIXTURE: &str = r#"[agent]
+name = "izzie"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[[stores]]
+name = "bob-kb"
+tree = "okg://izzie"
+index = "bob-kb"
+palace = "owner-profile"
+"#;
+
+const UNBOUND_FIXTURE: &str = r#"[agent]
+name = "plain"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+"#;
+
+const MISSING_INDEX_FIXTURE: &str = r#"[agent]
+name = "ghosty"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[[stores]]
+name = "ghost-kb"
+"#;
+
+/// Mock daemon serving both the trusty-search status route and the
+/// trusty-memory drawers route. `bob-kb` / `owner-profile` exist; everything
+/// else 404s.
+async fn mock_daemon() -> String {
+    let app = Router::new()
+        .route(
+            "/indexes/{id}/status",
+            get(|Path(id): Path<String>| async move {
+                if id == "bob-kb" {
+                    (
+                        AxumStatus::OK,
+                        Json(serde_json::json!({
+                            "index_id": "bob-kb",
+                            "chunk_count": 552,
+                            "root_path": "/Users/masa/trusty-agents/bob-kb",
+                            "status": "ready",
+                        })),
+                    )
+                } else {
+                    (AxumStatus::NOT_FOUND, Json(serde_json::json!({})))
+                }
+            }),
+        )
+        .route(
+            "/api/v1/palaces/{id}/drawers",
+            get(|Path(id): Path<String>| async move {
+                if id == "owner-profile" {
+                    (AxumStatus::OK, Json(serde_json::json!({"drawers": []})))
+                } else {
+                    (AxumStatus::NOT_FOUND, Json(serde_json::json!({})))
+                }
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    format!("http://{addr}")
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn stores_route_reports_connected_binding_with_stats() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("izzie.toml"), BOUND_FIXTURE).unwrap();
+    let base = mock_daemon().await;
+
+    let resp = stores_at(
+        &[dir.path().to_path_buf()],
+        "izzie",
+        Some(&base),
+        Some(&base),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    let stores = body["stores"].as_array().unwrap();
+    assert_eq!(stores.len(), 1);
+    assert_eq!(stores[0]["connected"], true);
+    assert_eq!(stores[0]["index"], "bob-kb");
+    assert_eq!(stores[0]["tree"], "okg://izzie");
+    assert_eq!(stores[0]["chunk_count"], 552);
+    assert_eq!(stores[0]["palace_connected"], true);
+    assert!(body["issues"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn stores_route_reports_missing_index_with_reason() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("ghosty.toml"), MISSING_INDEX_FIXTURE).unwrap();
+    let base = mock_daemon().await;
+
+    let resp = stores_at(
+        &[dir.path().to_path_buf()],
+        "ghosty",
+        Some(&base),
+        Some(&base),
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a down store is not an HTTP error"
+    );
+    let body = body_json(resp).await;
+    let store = &body["stores"][0];
+    assert_eq!(store["connected"], false);
+    let reason = store["reason"].as_str().unwrap();
+    assert!(reason.contains("not registered"), "reason was: {reason}");
+    // Derived defaults must still be reported so the card can name what is
+    // disconnected: index defaults to the store name, tree to okg://<agent>.
+    assert_eq!(store["index"], "ghost-kb");
+    assert_eq!(store["tree"], "okg://ghosty");
+}
+
+#[tokio::test]
+async fn stores_route_empty_for_unbound_agent() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("plain.toml"), UNBOUND_FIXTURE).unwrap();
+
+    let resp = stores_at(&[dir.path().to_path_buf()], "plain", None, None).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert!(body["stores"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn stores_route_unknown_agent_404() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp = stores_at(&[dir.path().to_path_buf()], "nobody", None, None).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn stores_route_rejects_traversal_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp = stores_at(&[dir.path().to_path_buf()], "../etc", None, None).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn stores_route_degrades_on_malformed_toml() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("broken.toml"), "not = = toml").unwrap();
+
+    let resp = stores_at(&[dir.path().to_path_buf()], "broken", None, None).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a hand-edit typo must not 500 the panel"
+    );
+    let body = body_json(resp).await;
+    assert!(body["stores"].as_array().unwrap().is_empty());
+    assert!(body["config_error"].is_string());
+}
+
+/// Proves the route is wired into `build_router` (not just that the core
+/// function works). Unknown agent under the real agents dirs → 404, never a
+/// 405/404-from-no-such-route.
+#[tokio::test]
+async fn stores_route_is_wired_into_router() {
+    let app: Router = build_router(AppState::default());
+    let req = Request::builder()
+        .uri("/api/agents/definitely-not-an-agent-3816/stores")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = body_json(resp).await;
+    assert_eq!(
+        body["error"], "unknown agent",
+        "a 404 from the handler, not from an unrouted path"
+    );
+}

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::await_holding_lock)]
 
 mod agent_patch;
+mod agent_stores;
 mod cancel;
 mod ctrl_sessions;
 mod guard;

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -333,6 +333,27 @@ pub async fn run_pm_task_with_persona(
                 crate::tools::web_search::BraveSearchTool::from_env(),
             ));
 
+            // #3864 / #3816: `vector_search`, bound to THIS persona's OKG
+            // store index. Personas (cto-assistant, izzie) grant
+            // `vector_search` in `[tools].allow` but it was never registered
+            // on this path — the persona-documented `vector_search(index_id=…)`
+            // call shape resolved to nothing, which is the bug #3864 filed.
+            // Registering it here with the persona's bound store means an
+            // unqualified search hits the agent's OWN knowledge; an explicit
+            // `index_id` still overrides. Personas with no `[[stores]]`
+            // binding get `None` and the tool's pre-existing local-index
+            // behaviour. As with every tool above, registration alone grants
+            // nothing — `filter_persona_tool_names` against `patterns` still
+            // decides reachability.
+            registry.register(Arc::new(
+                crate::tools::memory::VectorSearchTool::new().with_default_index(
+                    persona_cfg
+                        .stores
+                        .default_search_index()
+                        .map(str::to_string),
+                ),
+            ));
+
             // system_status epic (#3052): lets a persona report on-demand
             // trusty-* subsystem health (daemons, MCP servers, credential
             // tiers, registry counts) without it being injected into every

--- a/crates/trusty-agents/src/lib.rs
+++ b/crates/trusty-agents/src/lib.rs
@@ -122,6 +122,7 @@ pub mod session_registry {
 pub mod skills;
 pub mod slack;
 pub mod state_writer;
+pub mod stores;
 pub mod subprocess;
 pub mod system_status;
 pub mod telegram;

--- a/crates/trusty-agents/src/stores/config.rs
+++ b/crates/trusty-agents/src/stores/config.rs
@@ -1,0 +1,410 @@
+//! Declarative OKG store-binding shapes (#3816/#3864, DOC-54 SPEC-AGENTS-04
+//! §5.1).
+//!
+//! Why: `agent.toml` needs to say WHICH knowledge the agent owns, in a form
+//! the harness can resolve against the live trusty-search / trusty-memory
+//! daemons at boot. Two spellings are accepted because two already exist in
+//! the project: the product spec (`docs/specs/trusty-agents-product-spec.md`
+//! §5.1) documents the shorthand `[stores] allow = ["izzie-personal-kb"]`,
+//! while the binding model actually needs an index id and an optional memory
+//! palace per store. Rejecting either spelling would have meant a checked-in
+//! spec that no parser honours, so [`StoresConfig`] accepts BOTH and
+//! normalises to one internal shape.
+//! What: [`AgentStoreBinding`] is one store — `name` plus optional `tree`
+//! (an `okg://…` URI), `index` (trusty-search index id) and `palace`
+//! (trusty-memory palace id). Omitted `tree`/`index` are DERIVED
+//! ([`AgentStoreBinding::resolved_tree`] / [`resolved_index`]) rather than
+//! rejected, which is what makes the `[stores] allow = [...]` shorthand work.
+//! [`StoresConfig::validate`] returns non-fatal problems as strings — a bad
+//! binding is surfaced as a disconnected store with a reason, never a parse
+//! error that would stop the agent booting.
+//! Test: the `mod tests` at the bottom of this file.
+//!
+//! [`resolved_index`]: AgentStoreBinding::resolved_index
+
+use serde::{Deserialize, Serialize};
+
+/// The URI scheme every OKG knowledge tree is addressed by.
+///
+/// Why: `okg://<agent>` is the tree identity the GUI renders and the
+/// md-KG builder writes under; pinning the scheme in one constant keeps the
+/// derivation ([`AgentStoreBinding::resolved_tree`]) and the validation
+/// ([`StoresConfig::validate`]) from drifting apart.
+pub const OKG_SCHEME: &str = "okg://";
+
+/// One OKG store bound to an agent (`agent.toml` `[[stores]]`).
+///
+/// Why: Bob's 2026-07-24 decision is ONE store per agent — the tree the
+/// agent owns, plus the search index built over it. `palace` is optional
+/// and separate because a memory palace is structured recall (facts,
+/// decisions), not the document corpus: `cto-assistant` binds the `cto`
+/// palace alongside the `cto-assistant` index, while a store that is purely
+/// a document tree binds none.
+/// What: `name` is the store's stable id (required, the only required
+/// field). `tree` defaults to `okg://<agent-name>` and `index` defaults to
+/// the store `name` — see [`Self::resolved_tree`] / [`Self::resolved_index`]
+/// — so the spec's name-only shorthand expands to a complete binding.
+/// Test: `store_binding_parses_full_form`,
+/// `store_binding_derives_tree_and_index_when_omitted`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct AgentStoreBinding {
+    pub name: String,
+    /// The OKG knowledge-tree URI (`okg://<agent-name>`). Absent = derived.
+    #[serde(default)]
+    pub tree: Option<String>,
+    /// The trusty-search index id built over the tree. Absent = `name`.
+    #[serde(default)]
+    pub index: Option<String>,
+    /// The trusty-memory palace holding this agent's structured recall.
+    /// Absent = the agent binds no palace (a document-only store).
+    #[serde(default)]
+    pub palace: Option<String>,
+}
+
+impl AgentStoreBinding {
+    /// The knowledge-tree URI for this binding, deriving `okg://<agent_name>`
+    /// when the TOML omitted `tree`.
+    ///
+    /// Why: The name-only shorthand must still produce the tree URI the GUI
+    /// renders and the md-KG builder writes under; deriving it here (rather
+    /// than at each call site) means the API response, the GUI card, and any
+    /// future KG writer all agree on one value.
+    /// What: The declared `tree` verbatim when present, else
+    /// `okg://<agent_name>`.
+    /// Test: `store_binding_derives_tree_and_index_when_omitted`.
+    pub fn resolved_tree(&self, agent_name: &str) -> String {
+        self.tree
+            .clone()
+            .unwrap_or_else(|| format!("{OKG_SCHEME}{agent_name}"))
+    }
+
+    /// The trusty-search index id for this binding, defaulting to the store
+    /// `name`.
+    ///
+    /// Why: A store and the index over it are usually named the same thing
+    /// (`bob-kb`, `cto-assistant`); requiring both to be typed out would make
+    /// the shorthand spelling unusable.
+    /// What: The declared `index` verbatim when present, else `name`.
+    /// Test: `store_binding_derives_tree_and_index_when_omitted`.
+    pub fn resolved_index(&self) -> &str {
+        self.index.as_deref().unwrap_or(&self.name)
+    }
+
+    /// Non-fatal problems with this binding, as human-readable reasons.
+    ///
+    /// Why: A hand-edited `agent.toml` with a typo'd tree scheme must not
+    /// take the agent down — the harness reports the store as disconnected
+    /// and boots anyway (see this module's doc comment). Returning strings
+    /// (not an error type) keeps the reason renderable straight into the GUI
+    /// card without a second mapping layer.
+    /// What: `Some(reason)` for the first problem found, `None` when the
+    /// binding is usable. Checks: non-blank `name`, non-blank `index`, and
+    /// an `okg://` scheme on any explicitly declared `tree`.
+    /// Test: `validate_flags_blank_name`, `validate_flags_bad_tree_scheme`,
+    /// `validate_accepts_good_binding`.
+    pub fn validate(&self) -> Option<String> {
+        if self.name.trim().is_empty() {
+            return Some("store binding has a blank `name`".to_string());
+        }
+        if self.resolved_index().trim().is_empty() {
+            return Some(format!(
+                "store `{}` resolves to a blank search index id",
+                self.name
+            ));
+        }
+        if let Some(tree) = &self.tree
+            && !tree.starts_with(OKG_SCHEME)
+        {
+            return Some(format!(
+                "store `{}` declares tree `{tree}`, which is not an `{OKG_SCHEME}` URI",
+                self.name
+            ));
+        }
+        None
+    }
+}
+
+/// The `stores` field of `agent.toml`, in either accepted spelling.
+///
+/// Why: See this module's doc comment — the product spec documents
+/// `[stores] allow = [...]` while the live binding model needs per-store
+/// index/palace fields, so both are accepted and normalised here rather than
+/// forcing a spec rewrite or a silently-ignored key.
+/// What: Deserializes from EITHER an array-of-tables (`[[stores]]`, the rich
+/// form) or a table with an `allow` list of names (`[stores]`, the
+/// shorthand), collapsing both into `bindings`. Absent = no bound store,
+/// which is a valid state (the agent simply knows nothing of its own).
+/// Test: `stores_config_parses_array_of_tables`,
+/// `stores_config_parses_allow_shorthand`,
+/// `stores_config_defaults_empty`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct StoresConfig {
+    pub bindings: Vec<AgentStoreBinding>,
+}
+
+impl StoresConfig {
+    /// The single bound store, per the one-store-per-agent decision.
+    ///
+    /// Why: Callers that need "the agent's own index" (notably
+    /// `vector_search`'s default target, #3864) want one value, not a list.
+    /// Extra bindings are a config mistake reported by [`Self::validate`],
+    /// not something to silently fan out over.
+    /// What: The first binding, or `None` when nothing is bound.
+    /// Test: `primary_returns_first_binding`.
+    pub fn primary(&self) -> Option<&AgentStoreBinding> {
+        self.bindings.first()
+    }
+
+    /// The trusty-search index id `vector_search` should search by default.
+    ///
+    /// Why: This is the #3864 fix's data source — an unqualified
+    /// `vector_search(query)` from an agent with a bound store must hit that
+    /// agent's OWN knowledge rather than whatever code index happens to be
+    /// under the process CWD.
+    /// What: The primary binding's [`AgentStoreBinding::resolved_index`], or
+    /// `None` when the agent binds no store (leaving the tool on its
+    /// pre-existing local-index behaviour).
+    /// Test: `default_search_index_uses_primary_binding`,
+    /// `default_search_index_none_without_bindings`.
+    pub fn default_search_index(&self) -> Option<&str> {
+        self.primary().map(AgentStoreBinding::resolved_index)
+    }
+
+    /// Non-fatal configuration problems across all bindings.
+    ///
+    /// Why: Reported, never fatal — see [`AgentStoreBinding::validate`].
+    /// What: One reason per problem: each binding's own validation, plus a
+    /// warning when more than one store is bound (the spec says exactly one)
+    /// and one per duplicated store name.
+    /// Test: `validate_flags_multiple_bindings`,
+    /// `validate_flags_duplicate_names`.
+    pub fn validate(&self) -> Vec<String> {
+        let mut issues: Vec<String> = self.bindings.iter().filter_map(|b| b.validate()).collect();
+        if self.bindings.len() > 1 {
+            issues.push(format!(
+                "{} stores bound; the spec allows exactly one OKG store per agent \
+                 (only the first is used as the default search target)",
+                self.bindings.len()
+            ));
+        }
+        let mut seen: Vec<&str> = Vec::new();
+        for b in &self.bindings {
+            if seen.contains(&b.name.as_str()) {
+                issues.push(format!("duplicate store name `{}`", b.name));
+            } else {
+                seen.push(&b.name);
+            }
+        }
+        issues
+    }
+}
+
+/// The two on-disk spellings `StoresConfig` normalises from.
+///
+/// Why: `#[serde(untagged)]` picks whichever matches the TOML value's actual
+/// shape — an array-of-tables deserializes as `Rich`, a table with `allow`
+/// as `Shorthand`. Keeping this private means the rest of the crate only
+/// ever sees the normalised [`StoresConfig`].
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StoresConfigRepr {
+    Rich(Vec<AgentStoreBinding>),
+    Shorthand {
+        #[serde(default)]
+        allow: Vec<String>,
+    },
+}
+
+impl<'de> Deserialize<'de> for StoresConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let bindings = match StoresConfigRepr::deserialize(deserializer)? {
+            StoresConfigRepr::Rich(bindings) => bindings,
+            StoresConfigRepr::Shorthand { allow } => allow
+                .into_iter()
+                .map(|name| AgentStoreBinding {
+                    name,
+                    ..Default::default()
+                })
+                .collect(),
+        };
+        Ok(StoresConfig { bindings })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct Wrapper {
+        #[serde(default)]
+        stores: StoresConfig,
+    }
+
+    #[test]
+    fn stores_config_parses_array_of_tables() {
+        let raw = r#"
+[[stores]]
+name = "cto-assistant-kb"
+tree = "okg://cto-assistant"
+index = "cto-assistant"
+palace = "cto"
+"#;
+        let w: Wrapper = toml::from_str(raw).unwrap();
+        assert_eq!(w.stores.bindings.len(), 1);
+        let b = &w.stores.bindings[0];
+        assert_eq!(b.name, "cto-assistant-kb");
+        assert_eq!(b.tree.as_deref(), Some("okg://cto-assistant"));
+        assert_eq!(b.resolved_index(), "cto-assistant");
+        assert_eq!(b.palace.as_deref(), Some("cto"));
+        assert!(w.stores.validate().is_empty());
+    }
+
+    #[test]
+    fn stores_config_parses_allow_shorthand() {
+        // The spelling documented in docs/specs/trusty-agents-product-spec.md
+        // §5.1 — name only, everything else derived.
+        let raw = r#"
+[stores]
+allow = ["izzie-personal-kb"]
+"#;
+        let w: Wrapper = toml::from_str(raw).unwrap();
+        assert_eq!(w.stores.bindings.len(), 1);
+        let b = &w.stores.bindings[0];
+        assert_eq!(b.name, "izzie-personal-kb");
+        assert_eq!(b.resolved_index(), "izzie-personal-kb");
+        assert_eq!(b.resolved_tree("izzie"), "okg://izzie");
+        assert!(b.palace.is_none());
+    }
+
+    #[test]
+    fn stores_config_defaults_empty() {
+        let w: Wrapper = toml::from_str("").unwrap();
+        assert!(w.stores.bindings.is_empty());
+        assert!(w.stores.primary().is_none());
+        assert!(w.stores.validate().is_empty());
+    }
+
+    #[test]
+    fn store_binding_parses_full_form() {
+        let raw = r#"
+name = "bob-kb"
+tree = "okg://izzie"
+index = "bob-kb"
+palace = "owner-profile"
+"#;
+        let b: AgentStoreBinding = toml::from_str(raw).unwrap();
+        assert_eq!(b.resolved_tree("izzie"), "okg://izzie");
+        assert_eq!(b.resolved_index(), "bob-kb");
+        assert_eq!(b.palace.as_deref(), Some("owner-profile"));
+        assert_eq!(b.validate(), None);
+    }
+
+    #[test]
+    fn store_binding_derives_tree_and_index_when_omitted() {
+        let b: AgentStoreBinding = toml::from_str(r#"name = "bob-kb""#).unwrap();
+        assert_eq!(
+            b.resolved_tree("izzie"),
+            "okg://izzie",
+            "tree must derive from the AGENT name, not the store name"
+        );
+        assert_eq!(b.resolved_index(), "bob-kb");
+    }
+
+    #[test]
+    fn validate_flags_blank_name() {
+        let b: AgentStoreBinding = toml::from_str(r#"name = "  ""#).unwrap();
+        assert!(b.validate().unwrap().contains("blank `name`"));
+    }
+
+    #[test]
+    fn validate_flags_bad_tree_scheme() {
+        let b: AgentStoreBinding =
+            toml::from_str("name = \"kb\"\ntree = \"https://example.com/kb\"").unwrap();
+        let reason = b.validate().unwrap();
+        assert!(reason.contains("okg://"), "reason was: {reason}");
+    }
+
+    #[test]
+    fn validate_accepts_good_binding() {
+        let b: AgentStoreBinding =
+            toml::from_str("name = \"kb\"\ntree = \"okg://izzie\"\nindex = \"bob-kb\"").unwrap();
+        assert_eq!(b.validate(), None);
+    }
+
+    #[test]
+    fn validate_flags_multiple_bindings() {
+        let raw = r#"
+[[stores]]
+name = "a"
+
+[[stores]]
+name = "b"
+"#;
+        let w: Wrapper = toml::from_str(raw).unwrap();
+        let issues = w.stores.validate();
+        assert!(
+            issues.iter().any(|i| i.contains("exactly one OKG store")),
+            "issues were: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn validate_flags_duplicate_names() {
+        let raw = r#"
+[[stores]]
+name = "dup"
+
+[[stores]]
+name = "dup"
+"#;
+        let w: Wrapper = toml::from_str(raw).unwrap();
+        let issues = w.stores.validate();
+        assert!(
+            issues.iter().any(|i| i.contains("duplicate store name")),
+            "issues were: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn primary_returns_first_binding() {
+        let raw = r#"
+[[stores]]
+name = "first"
+
+[[stores]]
+name = "second"
+"#;
+        let w: Wrapper = toml::from_str(raw).unwrap();
+        assert_eq!(w.stores.primary().unwrap().name, "first");
+    }
+
+    #[test]
+    fn default_search_index_uses_primary_binding() {
+        let raw = r#"
+[[stores]]
+name = "cto-assistant-kb"
+index = "cto-assistant"
+"#;
+        let w: Wrapper = toml::from_str(raw).unwrap();
+        assert_eq!(w.stores.default_search_index(), Some("cto-assistant"));
+    }
+
+    #[test]
+    fn default_search_index_none_without_bindings() {
+        let w: Wrapper = toml::from_str("").unwrap();
+        assert_eq!(w.stores.default_search_index(), None);
+    }
+
+    #[test]
+    fn unknown_keys_do_not_break_parsing() {
+        // Forward compat: a future field must degrade to "ignored", never a
+        // parse error that stops the agent booting.
+        let b: AgentStoreBinding =
+            toml::from_str("name = \"kb\"\nfuture_field = \"whatever\"").unwrap();
+        assert_eq!(b.name, "kb");
+    }
+}

--- a/crates/trusty-agents/src/stores/mod.rs
+++ b/crates/trusty-agents/src/stores/mod.rs
@@ -1,0 +1,29 @@
+//! OKG store bindings — what an agent KNOWS (#3816/#3864, DOC-54
+//! SPEC-AGENTS-04 §5.1).
+//!
+//! Why: Stores are the FIRST leg of the agent-config triple (stores / tools
+//! / listeners). An agent ACTS via `[tools]`, REACTS via `[[listeners]]`, and
+//! KNOWS via `[[stores]]`. Until this module landed the third leg existed
+//! (`crate::listeners::config`) and the first did not — the GUI's "OKG
+//! Stores" pane rendered a hardcoded placeholder and `vector_search` had no
+//! way to be pointed at the agent's own corpus (#3864). A binding names one
+//! OKG knowledge tree plus the trusty-search index built over it and,
+//! optionally, the trusty-memory palace that holds the agent's structured
+//! recall for the same domain.
+//! What:
+//! - `config` — declarative shapes parsed from `agent.toml` (`[[stores]]`
+//!   array-of-tables, or the spec's `[stores] allow = [...]` shorthand).
+//!   Pure serde data, per the standing "agents are declarative-only" rule
+//!   (#2791).
+//! - `status` — live resolution of a binding against the running
+//!   trusty-search / trusty-memory daemons, producing a per-store
+//!   connected/not-connected report. Every failure mode degrades to
+//!   `not_connected` with a human-readable reason; a bound store that
+//!   cannot be resolved NEVER blocks agent boot.
+//! Test: See each submodule's own unit tests.
+
+pub mod config;
+pub mod status;
+
+pub use config::{AgentStoreBinding, StoresConfig};
+pub use status::{StoreStatus, resolve_store_statuses};

--- a/crates/trusty-agents/src/stores/status.rs
+++ b/crates/trusty-agents/src/stores/status.rs
@@ -1,0 +1,435 @@
+//! Live resolution of OKG store bindings against the running daemons
+//! (#3816/#3864, DOC-54 SPEC-AGENTS-04 §5.1).
+//!
+//! Why: A binding in `agent.toml` is a claim, not a fact. The GUI's OKG
+//! Stores pane previously rendered a hardcoded "not connected" placeholder
+//! precisely because nothing checked whether the named index existed; this
+//! module turns the claim into an observed status by asking trusty-search
+//! (`GET /indexes/{id}/status`) and trusty-memory (`GET
+//! /api/v1/palaces/{id}/drawers?limit=1`) directly. Every failure mode —
+//! daemon undiscoverable, connection refused, 404, malformed body, timeout —
+//! collapses to `connected: false` plus a human-readable `reason`, mirroring
+//! `crate::system_status::daemons`' established "down is a normal, reportable
+//! state" contract. A bound store that cannot be resolved must never stop an
+//! agent booting.
+//! What: [`StoreStatus`] is the per-store report (serialized straight to the
+//! sidecar API and the GUI card). [`resolve_store_statuses`] resolves a whole
+//! [`StoresConfig`]; base URLs are injected so tests can point at a mock
+//! server rather than the developer's live daemons.
+//! Test: `super::status::tests` — a mock trusty-search/-memory router covers
+//! connected, 404, and unreachable; config-validation short-circuiting is
+//! covered without any network at all.
+
+use std::time::Duration;
+
+use serde::Serialize;
+
+use super::config::{AgentStoreBinding, StoresConfig};
+
+/// Per-probe timeout.
+///
+/// Why: Identical rationale (and value) to
+/// [`crate::system_status::daemons::PROBE_TIMEOUT`] — a daemon that accepts
+/// the TCP connection but never answers must degrade to "not connected"
+/// within a couple of seconds rather than stalling agent boot or an API
+/// request behind it.
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// One bound store's resolved, live status.
+///
+/// Why: The GUI card and the sidecar API need exactly one shape covering
+/// both "CONNECTED, here is the index and how big it is" and "NOT CONNECTED,
+/// here is why" — a client should never have to distinguish an absent field
+/// from a failed probe. `reason` is `Some` only when `connected` is false.
+/// What: `name`/`tree`/`index`/`palace` echo the resolved binding (defaults
+/// already applied); `connected` reflects the SEARCH INDEX only, since that
+/// is the corpus `vector_search` routes to. Palace health is reported
+/// separately in `palace_connected`/`palace_reason` so a missing palace
+/// downgrades one line of the card rather than the whole store.
+/// Test: `resolves_connected_store_with_stats`,
+/// `reports_missing_index_as_not_connected`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StoreStatus {
+    pub name: String,
+    pub tree: String,
+    pub index: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub palace: Option<String>,
+    pub connected: bool,
+    /// Why the store is not connected. `None` when `connected` is true.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Chunk count reported by the index, when the probe succeeded and the
+    /// daemon supplied one. Cheap — it comes from the same status call.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_count: Option<u64>,
+    /// The indexed root directory, when reported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_path: Option<String>,
+    /// The index's own readiness string (`"ready"`, `"indexing"`, …).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_status: Option<String>,
+    /// `None` when the binding declares no palace; otherwise whether the
+    /// palace was observed to exist.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub palace_connected: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub palace_reason: Option<String>,
+}
+
+impl StoreStatus {
+    /// A status carrying only the binding's identity and a disconnect reason.
+    ///
+    /// Why: Every not-connected path (invalid config, undiscoverable daemon,
+    /// 404, timeout) produces the same shape; building it in one place keeps
+    /// the `Option` fields from drifting out of sync.
+    fn disconnected(binding: &AgentStoreBinding, agent_name: &str, reason: String) -> Self {
+        Self {
+            name: binding.name.clone(),
+            tree: binding.resolved_tree(agent_name),
+            index: binding.resolved_index().to_string(),
+            palace: binding.palace.clone(),
+            connected: false,
+            reason: Some(reason),
+            chunk_count: None,
+            root_path: None,
+            index_status: None,
+            palace_connected: None,
+            palace_reason: None,
+        }
+    }
+}
+
+/// Resolve every binding in `stores` against the live daemons.
+///
+/// Why: One entry point for both the sidecar API (`GET
+/// /api/agents/:name/stores`) and any boot-time reporting, so the GUI and the
+/// logs can never disagree about whether a store is connected.
+/// What: `search_base`/`memory_base` are full base URLs (e.g.
+/// `http://127.0.0.1:7878`); `None` means the daemon was not discoverable and
+/// every store resolves to not-connected with that as the reason — injected
+/// rather than resolved internally so tests can drive a mock server. Returns
+/// one [`StoreStatus`] per binding, in declaration order. Never errors.
+/// Test: `resolves_connected_store_with_stats`,
+/// `reports_missing_index_as_not_connected`,
+/// `reports_undiscoverable_search_daemon`,
+/// `invalid_binding_short_circuits_without_network`.
+pub async fn resolve_store_statuses(
+    agent_name: &str,
+    stores: &StoresConfig,
+    search_base: Option<&str>,
+    memory_base: Option<&str>,
+) -> Vec<StoreStatus> {
+    let client = match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(e) => {
+            // Building a client cannot normally fail; if it does, report it
+            // rather than panicking an agent's boot path.
+            return stores
+                .bindings
+                .iter()
+                .map(|b| {
+                    StoreStatus::disconnected(
+                        b,
+                        agent_name,
+                        format!("HTTP client unavailable: {e}"),
+                    )
+                })
+                .collect();
+        }
+    };
+
+    let mut out = Vec::with_capacity(stores.bindings.len());
+    for binding in &stores.bindings {
+        out.push(resolve_one(&client, agent_name, binding, search_base, memory_base).await);
+    }
+    out
+}
+
+/// Resolve a single binding. See [`resolve_store_statuses`].
+async fn resolve_one(
+    client: &reqwest::Client,
+    agent_name: &str,
+    binding: &AgentStoreBinding,
+    search_base: Option<&str>,
+    memory_base: Option<&str>,
+) -> StoreStatus {
+    // Config problems short-circuit before any network call — an unusable
+    // binding has nothing meaningful to probe.
+    if let Some(issue) = binding.validate() {
+        return StoreStatus::disconnected(binding, agent_name, issue);
+    }
+
+    let index = binding.resolved_index().to_string();
+    let Some(search_base) = search_base else {
+        return StoreStatus::disconnected(
+            binding,
+            agent_name,
+            "trusty-search daemon not discoverable (no address file; is it running?)".to_string(),
+        );
+    };
+
+    let url = format!(
+        "{}/indexes/{}/status",
+        search_base.trim_end_matches('/'),
+        index
+    );
+    let mut status = match client.get(&url).send().await {
+        Err(e) => {
+            return StoreStatus::disconnected(
+                binding,
+                agent_name,
+                format!("trusty-search unreachable at {search_base}: {e}"),
+            );
+        }
+        Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
+            return StoreStatus::disconnected(
+                binding,
+                agent_name,
+                format!("search index `{index}` is not registered on the trusty-search daemon"),
+            );
+        }
+        Ok(resp) if !resp.status().is_success() => {
+            let code = resp.status();
+            return StoreStatus::disconnected(
+                binding,
+                agent_name,
+                format!("trusty-search returned HTTP {code} for index `{index}`"),
+            );
+        }
+        Ok(resp) => match resp.json::<serde_json::Value>().await {
+            Err(e) => {
+                return StoreStatus::disconnected(
+                    binding,
+                    agent_name,
+                    format!("trusty-search returned an unreadable status body: {e}"),
+                );
+            }
+            Ok(body) => StoreStatus {
+                name: binding.name.clone(),
+                tree: binding.resolved_tree(agent_name),
+                index: index.clone(),
+                palace: binding.palace.clone(),
+                connected: true,
+                reason: None,
+                chunk_count: body.get("chunk_count").and_then(serde_json::Value::as_u64),
+                root_path: body
+                    .get("root_path")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+                index_status: body
+                    .get("status")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string),
+                palace_connected: None,
+                palace_reason: None,
+            },
+        },
+    };
+
+    if let Some(palace) = &binding.palace {
+        let (ok, reason) = probe_palace(client, memory_base, palace).await;
+        status.palace_connected = Some(ok);
+        status.palace_reason = reason;
+    }
+
+    status
+}
+
+/// Probe whether `palace` exists on the trusty-memory daemon.
+///
+/// Why: `GET /api/v1/palaces/{id}/drawers?limit=1` is the cheapest existence
+/// check that does NOT create anything — the `POST /api/v1/palaces` route the
+/// rest of this crate uses (`memory::trusty_client`) is an ensure/create and
+/// would silently conjure a palace that a status probe has no business
+/// creating. This mirrors `api::server::workstreams::fetch_drawers`' existing
+/// read path.
+/// What: `(true, None)` when the daemon answers 2xx; `(false, Some(reason))`
+/// for every other outcome.
+/// Test: `reports_missing_palace_without_downgrading_index`.
+async fn probe_palace(
+    client: &reqwest::Client,
+    memory_base: Option<&str>,
+    palace: &str,
+) -> (bool, Option<String>) {
+    let Some(base) = memory_base else {
+        return (
+            false,
+            Some("trusty-memory daemon not discoverable (is it running?)".to_string()),
+        );
+    };
+    let url = format!(
+        "{}/api/v1/palaces/{}/drawers?limit=1",
+        base.trim_end_matches('/'),
+        palace
+    );
+    match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => (true, None),
+        Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => (
+            false,
+            Some(format!("memory palace `{palace}` does not exist")),
+        ),
+        Ok(resp) => (
+            false,
+            Some(format!(
+                "trusty-memory returned HTTP {} for palace `{palace}`",
+                resp.status()
+            )),
+        ),
+        Err(e) => (false, Some(format!("trusty-memory unreachable: {e}"))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Json, Router, extract::Path, http::StatusCode, routing::get};
+    use serde_json::json;
+    use tokio::net::TcpListener;
+
+    /// Spin up a mock daemon exposing both the trusty-search status route and
+    /// the trusty-memory drawers route, and return its base URL.
+    ///
+    /// Why: Testing against the developer's real daemons would make the suite
+    /// depend on machine state; a mock keeps the probe logic (status codes,
+    /// body parsing, reason strings) under test deterministically.
+    async fn mock_daemon() -> String {
+        let app = Router::new()
+            .route(
+                "/indexes/{id}/status",
+                get(|Path(id): Path<String>| async move {
+                    if id == "bob-kb" {
+                        (
+                            StatusCode::OK,
+                            Json(json!({
+                                "index_id": "bob-kb",
+                                "chunk_count": 552,
+                                "root_path": "/Users/masa/trusty-agents/bob-kb",
+                                "status": "ready",
+                            })),
+                        )
+                    } else {
+                        (
+                            StatusCode::NOT_FOUND,
+                            Json(json!({"error": "no such index"})),
+                        )
+                    }
+                }),
+            )
+            .route(
+                "/api/v1/palaces/{id}/drawers",
+                get(|Path(id): Path<String>| async move {
+                    if id == "owner-profile" {
+                        (StatusCode::OK, Json(json!({"drawers": []})))
+                    } else {
+                        (StatusCode::NOT_FOUND, Json(json!({"error": "no palace"})))
+                    }
+                }),
+            );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    fn stores_toml(raw: &str) -> StoresConfig {
+        #[derive(serde::Deserialize)]
+        struct W {
+            #[serde(default)]
+            stores: StoresConfig,
+        }
+        toml::from_str::<W>(raw).unwrap().stores
+    }
+
+    #[tokio::test]
+    async fn resolves_connected_store_with_stats() {
+        let base = mock_daemon().await;
+        let stores = stores_toml(
+            r#"
+[[stores]]
+name = "bob-kb"
+tree = "okg://izzie"
+index = "bob-kb"
+palace = "owner-profile"
+"#,
+        );
+        let out = resolve_store_statuses("izzie", &stores, Some(&base), Some(&base)).await;
+        assert_eq!(out.len(), 1);
+        let s = &out[0];
+        assert!(s.connected, "expected connected, got reason {:?}", s.reason);
+        assert_eq!(s.reason, None);
+        assert_eq!(s.chunk_count, Some(552));
+        assert_eq!(s.index_status.as_deref(), Some("ready"));
+        assert_eq!(s.tree, "okg://izzie");
+        assert_eq!(s.palace_connected, Some(true));
+        assert_eq!(s.palace_reason, None);
+    }
+
+    #[tokio::test]
+    async fn reports_missing_index_as_not_connected() {
+        let base = mock_daemon().await;
+        let stores = stores_toml("[[stores]]\nname = \"nope\"\n");
+        let out = resolve_store_statuses("izzie", &stores, Some(&base), Some(&base)).await;
+        assert!(!out[0].connected);
+        let reason = out[0].reason.as_deref().unwrap();
+        assert!(reason.contains("not registered"), "reason was: {reason}");
+        // The binding identity must still round-trip so the GUI can render
+        // WHAT is disconnected, not just that something is.
+        assert_eq!(out[0].index, "nope");
+        assert_eq!(out[0].tree, "okg://izzie");
+    }
+
+    #[tokio::test]
+    async fn reports_missing_palace_without_downgrading_index() {
+        let base = mock_daemon().await;
+        let stores = stores_toml(
+            "[[stores]]\nname = \"bob-kb\"\nindex = \"bob-kb\"\npalace = \"ghost-palace\"\n",
+        );
+        let out = resolve_store_statuses("izzie", &stores, Some(&base), Some(&base)).await;
+        assert!(
+            out[0].connected,
+            "index health must not depend on the palace"
+        );
+        assert_eq!(out[0].palace_connected, Some(false));
+        assert!(
+            out[0]
+                .palace_reason
+                .as_deref()
+                .unwrap()
+                .contains("does not exist")
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_undiscoverable_search_daemon() {
+        let stores = stores_toml("[[stores]]\nname = \"bob-kb\"\n");
+        let out = resolve_store_statuses("izzie", &stores, None, None).await;
+        assert!(!out[0].connected);
+        assert!(
+            out[0]
+                .reason
+                .as_deref()
+                .unwrap()
+                .contains("not discoverable")
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_binding_short_circuits_without_network() {
+        // A bad tree scheme must be reported as the reason WITHOUT any probe
+        // — note the deliberately unroutable base URL: if this test made a
+        // network call it would report a connection error instead.
+        let stores = stores_toml("[[stores]]\nname = \"kb\"\ntree = \"https://example.com\"\n");
+        let out = resolve_store_statuses("izzie", &stores, Some("http://127.0.0.1:1"), None).await;
+        assert!(!out[0].connected);
+        assert!(out[0].reason.as_deref().unwrap().contains("okg://"));
+    }
+
+    #[tokio::test]
+    async fn no_bindings_resolves_to_empty() {
+        let out = resolve_store_statuses("izzie", &StoresConfig::default(), None, None).await;
+        assert!(out.is_empty());
+    }
+}

--- a/crates/trusty-agents/src/tools/memory/tests.rs
+++ b/crates/trusty-agents/src/tools/memory/tests.rs
@@ -603,3 +603,142 @@ fn vector_search_schema_names_tool() {
     let s = t.schema();
     assert_eq!(s["function"]["name"], "vector_search");
 }
+
+/// #3864: the parameter whose ABSENCE was the bug — the persona documented
+/// `vector_search(index_id=…)` while the schema advertised no such field, so
+/// index routing silently no-op'd.
+#[test]
+fn vector_search_schema_advertises_index_id() {
+    let s = VectorSearchTool::new().schema();
+    let props = &s["function"]["parameters"]["properties"];
+    assert!(
+        props.get("index_id").is_some(),
+        "index_id must be advertised: {props}"
+    );
+    assert_eq!(props["index_id"]["type"], "string");
+    // Still optional — an agent with no bound store must keep working.
+    let required = s["function"]["parameters"]["required"].as_array().unwrap();
+    assert!(!required.iter().any(|v| v == "index_id"));
+}
+
+/// The bound-store id is named in the schema so the model can see which
+/// corpus an unqualified call actually searches.
+#[test]
+fn vector_search_schema_names_bound_default_index() {
+    let s = VectorSearchTool::new()
+        .with_default_index(Some("cto-assistant".to_string()))
+        .schema();
+    let desc = s["function"]["parameters"]["properties"]["index_id"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(desc.contains("cto-assistant"), "description was: {desc}");
+}
+
+#[test]
+fn vector_search_index_defaults_to_bound_store() {
+    let t = VectorSearchTool::new().with_default_index(Some("bob-kb".to_string()));
+    assert_eq!(
+        t.effective_index_id(&json!({"query": "q"})).as_deref(),
+        Some("bob-kb")
+    );
+}
+
+#[test]
+fn vector_search_prefers_explicit_index_over_default() {
+    let t = VectorSearchTool::new().with_default_index(Some("bob-kb".to_string()));
+    assert_eq!(
+        t.effective_index_id(&json!({"query": "q", "index_id": "cto-assistant"}))
+            .as_deref(),
+        Some("cto-assistant"),
+        "an explicit index_id must always win over the bound default"
+    );
+}
+
+#[test]
+fn vector_search_index_none_without_binding() {
+    let t = VectorSearchTool::new();
+    assert_eq!(t.effective_index_id(&json!({"query": "q"})), None);
+}
+
+/// A blank/whitespace id (from a malformed binding or a model emitting `""`)
+/// must be treated as absent — never used to build a `/indexes//search` URL.
+#[test]
+fn vector_search_blank_index_ids_are_treated_as_absent() {
+    let t = VectorSearchTool::new().with_default_index(Some("   ".to_string()));
+    assert_eq!(t.effective_index_id(&json!({"query": "q"})), None);
+    let t = VectorSearchTool::new().with_default_index(Some("bob-kb".to_string()));
+    assert_eq!(
+        t.effective_index_id(&json!({"query": "q", "index_id": "  "}))
+            .as_deref(),
+        Some("bob-kb"),
+        "a blank explicit id falls back to the bound default, not to an empty id"
+    );
+}
+
+/// End-to-end #3864: a bound store routes the query to that index on the
+/// trusty-search daemon and returns the normalized hit envelope.
+#[tokio::test]
+async fn vector_search_routes_to_daemon_index() {
+    use axum::{Json, Router, extract::Path, http::StatusCode, routing::post};
+    use tokio::net::TcpListener;
+
+    let app = Router::new().route(
+        "/indexes/{id}/search",
+        post(|Path(id): Path<String>| async move {
+            if id == "bob-kb" {
+                (
+                    StatusCode::OK,
+                    Json(json!({"results": [
+                        {"path": "notes/travel.md", "score": 0.87, "content": "flight to NYC"}
+                    ]})),
+                )
+            } else {
+                (StatusCode::NOT_FOUND, Json(json!({"error": "no index"})))
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let tmp = tempdir().unwrap();
+    let tool = VectorSearchTool::new()
+        .with_code_dir(tmp.path().join("no-index"))
+        .with_default_index(Some("bob-kb".to_string()))
+        .with_search_base_url(Some(format!("http://{addr}")));
+
+    let out = tool.execute(json!({"query": "travel"})).await;
+    assert!(!out.is_error());
+    let body = out.content();
+    assert!(body.contains("notes/travel.md"), "body was: {body}");
+    assert!(
+        !body.contains("grep_fallback"),
+        "daemon hit must not fall through: {body}"
+    );
+}
+
+/// A missing index on the daemon degrades to the local/grep path rather than
+/// erroring the agent turn.
+#[tokio::test]
+async fn vector_search_falls_back_when_daemon_index_missing() {
+    use axum::{Router, http::StatusCode, routing::post};
+    use tokio::net::TcpListener;
+
+    let app = Router::new().route(
+        "/indexes/{id}/search",
+        post(|| async { (StatusCode::NOT_FOUND, "no such index") }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let tmp = tempdir().unwrap();
+    let tool = VectorSearchTool::new()
+        .with_code_dir(tmp.path().join("no-index"))
+        .with_default_index(Some("ghost".to_string()))
+        .with_search_base_url(Some(format!("http://{addr}")));
+
+    let out = tool.execute(json!({"query": "anything"})).await;
+    assert!(!out.is_error(), "must degrade, not error");
+    assert!(out.content().contains("grep_fallback"));
+}

--- a/crates/trusty-agents/src/tools/memory/vector_search.rs
+++ b/crates/trusty-agents/src/tools/memory/vector_search.rs
@@ -1,17 +1,33 @@
-//! `vector_search` tool — semantic code search via the embedded code index.
+//! `vector_search` tool — semantic search over an agent's bound OKG store or
+//! the embedded local code index.
 //!
-//! Why: Research agents benefit from fuzzy, intent-based lookups over the
-//! codebase; the exact-regex `grep_files` tool complements it but doesn't
-//! match paraphrases. When no index exists yet (first run, or a project
-//! that hasn't run `--reindex`), the tool degrades to a regex fallback so
-//! the agent still gets useful results.
-//! What: `VectorSearchTool` opens `.trusty-agents/state/code/` if present, embeds
-//! the query via `FastEmbedder`, returns top-k hits; otherwise falls back to
-//! `GrepFilesTool` with the query treated as a regex.
-//! Test: See `super::tests` — `vector_search_returns_graceful_error_without_index`.
+//! Why: Research agents benefit from fuzzy, intent-based lookups; the
+//! exact-regex `grep_files` tool complements it but doesn't match
+//! paraphrases. Until #3864 this tool could ONLY search a CWD-relative
+//! embedded index (`.trusty-agents/state/code/`) — it advertised no way to
+//! name a corpus, so a persona whose knowledge lives in a trusty-search index
+//! (`cto-assistant`, `bob-kb`) silently searched the wrong thing and returned
+//! nothing. The documented `vector_search(index_id=…)` call shape had no
+//! implementation behind it; the live workaround was to grant `grep` instead.
+//! What: `VectorSearchTool` now takes an `index_id`:
+//!   1. explicit `index_id` argument, else
+//!   2. the agent's bound OKG store index (`default_index_id`, wired from
+//!      `AgentConfig::stores` at registry-build time), else
+//!   3. no index → the pre-#3864 behaviour, unchanged.
+//! When an index id resolves, the query is routed to the shared trusty-search
+//! daemon (`POST /indexes/{id}/search`, the same endpoint the index-aware
+//! `grep`/`search` tools use). Every failure — daemon undiscoverable, index
+//! missing, transport error — degrades to the embedded index and then to the
+//! regex fallback, so the tool never hard-fails an agent turn.
+//! Test: See `super::tests` — `vector_search_returns_graceful_error_without_index`,
+//! `vector_search_schema_advertises_index_id`,
+//! `vector_search_prefers_explicit_index_over_default`,
+//! `vector_search_routes_to_daemon_index`,
+//! `vector_search_falls_back_when_daemon_index_missing`.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -23,34 +39,63 @@ use crate::tools::traits::{ToolExecutor, ToolResult};
 
 use super::recall::{EMBED_DIM, HIT_MAX_CHARS};
 
-/// Tool: `vector_search` — semantic code search via embedded index.
+/// Per-call timeout for the trusty-search daemon round trip.
 ///
-/// Why: Research agents benefit from fuzzy, intent-based lookups over the
-/// codebase; the exact-regex `grep_files` tool complements it but doesn't
-/// match paraphrases. When no index exists yet (first run, or a project
-/// that hasn't run `--reindex`), the tool degrades to a regex fallback so
-/// the agent still gets useful results.
-/// What: Opens `.trusty-agents/code/` if present, embeds the query via
-/// `FastEmbedder`, returns top-k hits; otherwise falls back to
-/// `GrepFilesTool` with the query treated as a regex.
-/// Test: `vector_search_returns_graceful_error_without_index`.
+/// Why: A tool call must feel synchronous inside an agent turn. 5s matches
+/// `crate::search::service_client::REQUEST_TIMEOUT`'s budget for the same
+/// reason — generous for a cold query, short enough that a wedged daemon
+/// falls through to the local path instead of stalling the loop.
+const DAEMON_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Tool: `vector_search` — semantic search over a named index or the
+/// embedded local code index.
+///
+/// Why/What: see the module doc comment.
+/// Test: `vector_search_returns_graceful_error_without_index`,
+/// `vector_search_routes_to_daemon_index`.
 pub struct VectorSearchTool {
     code_dir: PathBuf,
     fallback: Arc<GrepFilesTool>,
+    /// The agent's bound OKG store index, used when the caller passes no
+    /// explicit `index_id` (#3864). `None` for agents with no `[[stores]]`
+    /// binding — those keep the pre-#3864 local-index behaviour exactly.
+    default_index_id: Option<String>,
+    /// trusty-search daemon base URL override. `None` = discover at call time
+    /// via `trusty_common::resolve_daemon_base_url` (tests inject a mock).
+    search_base_url: Option<String>,
 }
 
 impl VectorSearchTool {
-    /// Construct with the default index path (`.trusty-agents/state/code/`).
+    /// Construct with the default index path (`.trusty-agents/state/code/`)
+    /// and no bound store.
     ///
     /// Why: Matches the indexer's default output location so the tool finds
-    /// the embedded code without requiring explicit config.
+    /// the embedded code without requiring explicit config. Agents with no
+    /// OKG store binding behave exactly as they did before #3864.
     /// What: Plain struct literal with the bundled `GrepFilesTool` fallback.
     /// Test: `vector_search_returns_graceful_error_without_index`.
     pub fn new() -> Self {
         Self {
             code_dir: PathBuf::from(".trusty-agents").join("state").join("code"),
             fallback: Arc::new(GrepFilesTool::new()),
+            default_index_id: None,
+            search_base_url: None,
         }
+    }
+
+    /// Bind this tool to the agent's own OKG store index (#3864).
+    ///
+    /// Why: An unqualified `vector_search(query)` from a persona with a bound
+    /// store must search THAT persona's knowledge. Passing the id in at
+    /// registry-build time (where `AgentConfig` is in scope) keeps the tool
+    /// itself free of config loading.
+    /// What: Sets `default_index_id`; a blank/whitespace id is treated as
+    /// absent so a malformed binding can't produce a `/indexes//search` URL.
+    /// Test: `vector_search_routes_to_daemon_index`,
+    /// `vector_search_prefers_explicit_index_over_default`.
+    pub fn with_default_index(mut self, index_id: Option<String>) -> Self {
+        self.default_index_id = index_id.filter(|s| !s.trim().is_empty());
+        self
     }
 
     /// Override the on-disk index location (used by tests).
@@ -60,10 +105,36 @@ impl VectorSearchTool {
         self
     }
 
+    /// Override the trusty-search daemon base URL (used by tests).
+    #[allow(dead_code)]
+    pub fn with_search_base_url(mut self, base: Option<String>) -> Self {
+        self.search_base_url = base;
+        self
+    }
+
     /// Path accessor used by tests.
     #[allow(dead_code)]
     pub fn code_dir(&self) -> &Path {
         &self.code_dir
+    }
+
+    /// The index this call should target: explicit argument first, then the
+    /// agent's bound store, then none.
+    ///
+    /// Why: This precedence IS the #3864 contract — an unqualified search
+    /// hits the agent's own knowledge, and an explicit `index_id` always
+    /// wins so cross-index lookups stay possible.
+    /// What: Trims and discards blank strings at both levels.
+    /// Test: `vector_search_prefers_explicit_index_over_default`,
+    /// `vector_search_index_defaults_to_bound_store`,
+    /// `vector_search_index_none_without_binding`.
+    pub fn effective_index_id(&self, args: &Value) -> Option<String> {
+        args.get("index_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .or_else(|| self.default_index_id.clone())
     }
 }
 
@@ -80,17 +151,33 @@ impl ToolExecutor for VectorSearchTool {
     }
 
     fn schema(&self) -> Value {
+        // #3864: `index_id`'s description names the agent's bound default
+        // explicitly when there is one, so the model can see which corpus an
+        // unqualified call will actually search rather than guessing.
+        let index_desc = match &self.default_index_id {
+            Some(id) => format!(
+                "trusty-search index to search. Defaults to this agent's bound OKG store index \
+                 (`{id}`) when omitted. Pass an explicit id to search a different corpus."
+            ),
+            None => "trusty-search index to search. When omitted, searches the local embedded \
+                     project code index."
+                .to_string(),
+        };
         json!({
             "type": "function",
             "function": {
                 "name": "vector_search",
-                "description": "Semantic search over indexed project code (embedded vector index). Falls back to regex search when the index is unavailable. Returns JSON array of hits with path and snippet.",
+                "description": "Semantic search over an indexed corpus (trusty-search index, or the local embedded project code index). Falls back to regex search when no index is available. Returns JSON array of hits with path and snippet.",
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "query": {
                             "type": "string",
-                            "description": "Natural-language or keyword query describing the code to find."
+                            "description": "Natural-language or keyword query describing what to find."
+                        },
+                        "index_id": {
+                            "type": "string",
+                            "description": index_desc
                         },
                         "limit": {
                             "type": "integer",
@@ -115,6 +202,20 @@ impl ToolExecutor for VectorSearchTool {
             .and_then(Value::as_u64)
             .map(|n| n.clamp(1, 50) as usize)
             .unwrap_or(5);
+
+        // #3864 fast path: a named trusty-search index (explicit arg, or the
+        // agent's bound OKG store). Any failure falls through to the
+        // pre-existing local paths rather than erroring the turn.
+        if let Some(index_id) = self.effective_index_id(&args) {
+            match self.daemon_query(&index_id, query, limit).await {
+                Ok(payload) => return ToolResult::ok(payload),
+                Err(e) => tracing::warn!(
+                    error = %e,
+                    index_id = %index_id,
+                    "vector_search: trusty-search index query failed; falling back to local index"
+                ),
+            }
+        }
 
         // Fast path: embedded index available.
         if self.code_dir.exists() {
@@ -145,6 +246,87 @@ impl ToolExecutor for VectorSearchTool {
             serde_json::to_string(&body).unwrap_or_else(|_| "\"\"".to_string())
         ))
     }
+}
+
+impl VectorSearchTool {
+    /// Query a named index on the shared trusty-search daemon.
+    ///
+    /// Why: This is the routing #3864 asked for. `POST /indexes/{id}/search`
+    /// with `{text, top_k}` is the daemon's own contract (see
+    /// `trusty_common::monitor::search_client::SearchClient::search`) — going
+    /// straight to it keeps this tool independent of whether the trusty-search
+    /// MCP plugin happens to be spawned.
+    /// What: Returns the same `[{path, score, snippet}]` envelope the local
+    /// path emits, so the model sees ONE result shape regardless of which
+    /// backend answered. Errors (undiscoverable daemon, non-2xx, transport)
+    /// propagate to the caller, which falls back rather than failing.
+    /// Test: `vector_search_routes_to_daemon_index`,
+    /// `vector_search_falls_back_when_daemon_index_missing`.
+    async fn daemon_query(
+        &self,
+        index_id: &str,
+        query: &str,
+        limit: usize,
+    ) -> anyhow::Result<String> {
+        let base = match &self.search_base_url {
+            Some(b) => b.clone(),
+            None => trusty_common::resolve_daemon_base_url("trusty-search")
+                .ok_or_else(|| anyhow::anyhow!("trusty-search daemon not discoverable"))?,
+        };
+        let url = format!("{}/indexes/{}/search", base.trim_end_matches('/'), index_id);
+        let client = reqwest::Client::builder().timeout(DAEMON_TIMEOUT).build()?;
+        let resp = client
+            .post(&url)
+            .json(&json!({ "text": query, "top_k": limit }))
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            anyhow::bail!("trusty-search returned HTTP {} for {url}", resp.status());
+        }
+        let body: Value = resp.json().await?;
+        Ok(serde_json::to_string(&normalize_daemon_hits(&body, limit))?)
+    }
+}
+
+/// Reshape the daemon's search response into this tool's hit envelope.
+///
+/// Why: The daemon wraps hits under `results`/`hits` depending on the route
+/// version and names the text field `content`/`snippet`/`text`; collapsing
+/// that here means the model always sees `{path, score, snippet}` — the same
+/// shape `semantic_query` produces for the local index.
+/// What: Accepts either a bare array or an object with a `results`/`hits`
+/// array; truncates snippets to `HIT_MAX_CHARS`; caps at `limit`.
+/// Test: `normalize_daemon_hits_handles_wrapped_and_bare_arrays`.
+fn normalize_daemon_hits(body: &Value, limit: usize) -> Vec<Value> {
+    let arr = body
+        .as_array()
+        .or_else(|| body.get("results").and_then(Value::as_array))
+        .or_else(|| body.get("hits").and_then(Value::as_array))
+        .cloned()
+        .unwrap_or_default();
+    arr.into_iter()
+        .take(limit)
+        .map(|h| {
+            let path = h
+                .get("path")
+                .or_else(|| h.get("file_path"))
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            let snippet_raw = h
+                .get("content")
+                .or_else(|| h.get("snippet"))
+                .or_else(|| h.get("text"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| h.to_string());
+            let snippet = snippet_raw.chars().take(HIT_MAX_CHARS).collect::<String>();
+            json!({
+                "path": path,
+                "score": h.get("score").cloned().unwrap_or(Value::Null),
+                "snippet": snippet,
+            })
+        })
+        .collect()
 }
 
 /// Run a semantic query against the on-disk `CodeStore`.
@@ -186,4 +368,33 @@ async fn semantic_query(code_dir: &Path, query: &str, limit: usize) -> anyhow::R
         .collect();
 
     Ok(serde_json::to_string(&out)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_daemon_hits_handles_wrapped_and_bare_arrays() {
+        let bare = json!([{ "path": "a.rs", "score": 0.9, "content": "fn main() {}" }]);
+        let out = normalize_daemon_hits(&bare, 5);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0]["path"], "a.rs");
+        assert_eq!(out[0]["snippet"], "fn main() {}");
+
+        let wrapped = json!({ "results": [{ "path": "b.rs", "snippet": "x" }] });
+        assert_eq!(normalize_daemon_hits(&wrapped, 5)[0]["path"], "b.rs");
+
+        let hits_key = json!({ "hits": [{ "file_path": "c.rs", "text": "y" }] });
+        let out = normalize_daemon_hits(&hits_key, 5);
+        assert_eq!(out[0]["path"], "c.rs");
+        assert_eq!(out[0]["snippet"], "y");
+    }
+
+    #[test]
+    fn normalize_daemon_hits_respects_limit_and_missing_fields() {
+        let body = json!([{"path": "a"}, {"path": "b"}, {"path": "c"}]);
+        assert_eq!(normalize_daemon_hits(&body, 2).len(), 2);
+        assert_eq!(normalize_daemon_hits(&json!({"other": 1}), 5).len(), 0);
+    }
 }

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
@@ -7,9 +7,10 @@
    * currently active in the chat pane, opened via the gear icon in
    * `ChatHeader`. Five sections, in the order Bob specified: Personality
    * (main persona.md prose — real read/write), OKG Stores (the agent's bound
-   * knowledge trees/search indexes — no `agent.toml` field exists yet,
-   * confirmed by grep; rendered as honest structured scaffolding, not
-   * fabricated live numbers), Tools (the `[tools].allow` glob allowlist —
+   * knowledge trees/search indexes — REAL as of #3816/#3864: read from
+   * `agent.toml`'s `[[stores]]` and resolved live against trusty-search /
+   * trusty-memory by `GET /api/agents/:name/stores`), Tools (the
+   * `[tools].allow` glob allowlist —
    * real read/write), Permissions (`[agent].scopes` — real, READ-ONLY: no
    * write contract established yet), Listeners (gmail/google-calendar —
    * no backend yet, spec being filed; rendered from `DEFINED_LISTENERS` as
@@ -18,7 +19,8 @@
    * and whenever `agentName` changes. Personality and Tools are editable
    * with their own Save button (independent PATCH calls, so saving one
    * doesn't require the other to be valid). Permissions/OKG
-   * Stores/Listeners render read-only. Concierge (`ctrl`) gets a static
+   * Stores/Listeners render read-only — store bindings are edited in
+   * `agent.toml`, not here. Concierge (`ctrl`) gets a static
    * notice per Bob: editable by name, but not an add-agent template.
    * Test: `agentConfig.test.ts` covers the scaffolding data; this component
    * is exercised manually (`pnpm dev`, open the gear, edit + save
@@ -32,9 +34,10 @@
     fetchAgentDetail,
     fetchAgentPersona,
     patchAgent,
-    scaffoldOkgStores,
+    fetchAgentStores,
     DEFINED_LISTENERS,
     type AgentDetail,
+    type OkgStoreBinding,
   } from '../lib/agentConfig';
 
   export let agentName: string;
@@ -55,6 +58,12 @@
   let toolsText = ''; // one glob per line — simplest editable form of a string[]
   let savedToolsText = '';
 
+  /** Live OKG store bindings (#3816/#3864) — `null` until the first load
+   * resolves, so the pane can distinguish "loading" from "binds nothing". */
+  let okgStores: OkgStoreBinding[] | null = null;
+  let okgIssues: string[] = [];
+  let okgError = '';
+
   let saving = false;
   let saveError = '';
   let justSaved: Tab | null = null;
@@ -74,7 +83,14 @@
     loading = true;
     loadError = '';
     detail = null;
+    okgStores = null;
+    okgIssues = [];
+    okgError = '';
     try {
+      // Store resolution talks to two daemons and can be the slowest leg, but
+      // it must never block (or fail) the rest of the panel — hence
+      // `allSettled`-style isolation via its own catch rather than a shared
+      // `Promise.all` rejection path.
       const [d, p] = await Promise.all([fetchAgentDetail(name), fetchAgentPersona(name)]);
       detail = d;
       if (d) {
@@ -97,6 +113,15 @@
       loadError = `Failed to load agent config: ${e}`;
     } finally {
       loading = false;
+    }
+    try {
+      const s = await fetchAgentStores(name);
+      okgStores = s?.stores ?? [];
+      okgIssues = s?.issues ?? [];
+      if (s?.config_error) okgIssues = [...okgIssues, s.config_error];
+    } catch (e) {
+      okgStores = [];
+      okgError = `${e}`;
     }
   }
 
@@ -137,8 +162,6 @@
       saving = false;
     }
   }
-
-  $: okgStores = scaffoldOkgStores(agentName);
 
   onMount(() => () => {
     if (justSavedTimer) clearTimeout(justSavedTimer);
@@ -228,25 +251,60 @@
     {:else if tab === 'okg'}
       <div class="flex flex-col gap-2">
         <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
-          Knowledge trees + search indexes bound to this agent.
+          Knowledge trees + search indexes bound to this agent, resolved live against
+          trusty-search and trusty-memory. Edit bindings in
+          <code class="font-mono">agent.toml</code>'s <code class="font-mono">[[stores]]</code>.
         </p>
-        <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
-          Scaffolding — <code class="font-mono">agent.toml</code> has no OKG store binding field
-          yet. Shown here so the concept reads end to end; not yet connected to a live index.
-        </p>
-        {#each okgStores as store (store.name)}
+        {#if okgStores === null}
+          <div class="flex items-center gap-2 text-xs text-foundry-light-muted dark:text-foundry-text/60">
+            <Loader2 class="h-3.5 w-3.5 animate-spin" /> Resolving stores…
+          </div>
+        {:else if okgError}
+          <p class="flex items-center gap-1.5 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-[11px] text-red-500 dark:text-red-400">
+            <AlertCircle class="h-3.5 w-3.5 shrink-0" /> Could not read store bindings: {okgError}
+          </p>
+        {:else if okgStores.length === 0}
+          <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+            This agent binds no OKG store. Add a <code class="font-mono">[[stores]]</code> table to
+            its <code class="font-mono">agent.toml</code> to give it a knowledge tree.
+          </p>
+        {/if}
+        {#each okgStores ?? [] as store (store.name)}
           <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
-            <div class="flex items-center justify-between">
+            <div class="flex items-center justify-between gap-2">
               <span class="font-mono text-xs font-semibold text-foundry-light-text dark:text-foundry-text">{store.name}</span>
-              <span class="rounded-md bg-foundry-light-border/50 dark:bg-black/30 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50">
-                not connected
+              <span
+                class="shrink-0 rounded-md px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide {store.connected
+                  ? 'bg-foundry-teal/15 text-foundry-teal'
+                  : 'bg-foundry-light-border/50 dark:bg-black/30 text-foundry-light-muted dark:text-foundry-text/50'}"
+              >
+                {store.connected ? 'connected' : 'not connected'}
               </span>
             </div>
             <div class="mt-1 flex flex-col gap-0.5 font-mono text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
               <span>tree: {store.tree}</span>
-              <span>index: {store.index}</span>
+              <span>
+                index: {store.index}{#if store.connected && store.chunk_count !== undefined}
+                  &nbsp;· {store.chunk_count.toLocaleString()} chunks{/if}{#if store.connected && store.index_status}
+                  &nbsp;· {store.index_status}{/if}
+              </span>
+              {#if store.root_path}<span>root: {store.root_path}</span>{/if}
+              {#if store.palace}
+                <span>
+                  palace: {store.palace}
+                  {#if store.palace_connected === false}
+                    <span class="text-foundry-amber">— {store.palace_reason ?? 'not connected'}</span>
+                  {/if}
+                </span>
+              {/if}
             </div>
+            {#if !store.connected && store.reason}
+              <p class="mt-1.5 text-[11px] text-foundry-amber">{store.reason}</p>
+            {/if}
           </div>
+        {/each}
+        {#each okgIssues as issue (issue)}
+          <p class="text-[11px] text-foundry-amber">{issue}</p>
         {/each}
       </div>
     {:else if tab === 'tools'}

--- a/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
@@ -1,12 +1,29 @@
-// Unit tests for the pure parts of `agentConfig.ts` (#3819, epic #3052).
-// The fetch/patch wrappers are thin REST glue with no branching logic worth
-// unit-testing in isolation (mirrors `stores/app.ts`'s `fetchAgentCatalog`/
-// `fetchModelCatalog`, which are likewise doc-commented "Test: manual" — see
-// `agentConfig.ts`'s own doc comments); these tests cover the scaffolding
-// shapes the concept-demo config pane renders.
+// Unit tests for `agentConfig.ts` (#3819/#3816/#3864, epic #3052).
+// Most fetch/patch wrappers are thin REST glue with no branching worth
+// unit-testing in isolation (mirrors `stores/app.ts`'s `fetchAgentCatalog`,
+// likewise doc-commented "Test: manual"). `fetchAgentStores` is the
+// exception — it has a real 404→null branch the OKG Stores pane depends on
+// to distinguish a stale roster selection from an agent that simply binds
+// nothing, so it gets a mocked-fetch test.
 
-import { describe, expect, it } from 'vitest';
-import { DEFINED_LISTENERS, scaffoldOkgStores } from './agentConfig';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DEFINED_LISTENERS, fetchAgentStores, type AgentStores } from './agentConfig';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Stub `fetch` with a single canned response. */
+function stubFetch(status: number, body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    })),
+  );
+}
 
 describe('DEFINED_LISTENERS', () => {
   it('defines exactly the gmail and google-calendar listeners', () => {
@@ -21,15 +38,62 @@ describe('DEFINED_LISTENERS', () => {
   });
 });
 
-describe('scaffoldOkgStores', () => {
-  it('names the scaffold store after the agent', () => {
-    const stores = scaffoldOkgStores('izzie');
-    expect(stores).toHaveLength(1);
-    expect(stores[0].name).toBe('izzie-kb');
+describe('fetchAgentStores', () => {
+  it('parses a live connected binding with its stats', async () => {
+    const payload: AgentStores = {
+      stores: [
+        {
+          name: 'bob-kb',
+          tree: 'okg://izzie',
+          index: 'bob-kb',
+          palace: 'owner-profile',
+          connected: true,
+          chunk_count: 552,
+          index_status: 'ready',
+          palace_connected: true,
+        },
+      ],
+      issues: [],
+    };
+    stubFetch(200, payload);
+    const got = await fetchAgentStores('izzie');
+    expect(got?.stores).toHaveLength(1);
+    expect(got?.stores[0].connected).toBe(true);
+    expect(got?.stores[0].chunk_count).toBe(552);
+    expect(got?.stores[0].tree).toBe('okg://izzie');
   });
 
-  it('marks the scaffold store as not connected (honest, not fabricated)', () => {
-    const stores = scaffoldOkgStores('cto-assistant');
-    expect(stores[0].connected).toBe(false);
+  it('surfaces a not-connected binding with the backend reason', async () => {
+    stubFetch(200, {
+      stores: [
+        {
+          name: 'ghost-kb',
+          tree: 'okg://ghosty',
+          index: 'ghost-kb',
+          connected: false,
+          reason: 'search index `ghost-kb` is not registered on the trusty-search daemon',
+        },
+      ],
+      issues: [],
+    });
+    const got = await fetchAgentStores('ghosty');
+    expect(got?.stores[0].connected).toBe(false);
+    expect(got?.stores[0].reason).toContain('not registered');
+  });
+
+  it('returns an empty list for an agent that binds nothing', async () => {
+    stubFetch(200, { stores: [], issues: [] });
+    const got = await fetchAgentStores('plain');
+    expect(got?.stores).toEqual([]);
+  });
+
+  it('returns null on 404 rather than throwing (stale roster selection)', async () => {
+    stubFetch(404, { error: 'unknown agent' });
+    await expect(fetchAgentStores('nobody')).resolves.toBeNull();
+  });
+
+  it('throws on a non-404 error status', async () => {
+    stubFetch(500, { error: 'boom' });
+    await expect(fetchAgentStores('izzie')).rejects.toThrow(/500/);
   });
 });

--- a/crates/trusty-agents/ui/src/lib/agentConfig.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.ts
@@ -3,17 +3,15 @@
 //
 // Why: the chat-pane gear panel needs a single typed surface over the agent
 // config read/write routes (`GET/PATCH /api/agents/:name`,
-// `GET /api/agents/:name/persona`) plus the LIVE listener/OKG-store shape
-// Bob asked the concept demo to render even though there is no backend for
-// either yet (issue being filed for listeners; OKG store bindings have no
-// `agent.toml` field today — see `DEFINED_LISTENERS`/`describeOkgStores`'s
-// doc comments). Keeping the fetch/patch logic here (not inline in the
-// component) makes it independently testable, mirroring `stores/app.ts`'s
-// `fetchAgentCatalog` pattern.
-// What: `fetchAgentDetail`/`fetchAgentPersona`/`patchAgent` — thin REST
-// wrappers; `DEFINED_LISTENERS` — the two listener bindings from the (not
-// yet implemented) listener spec, rendered as honest scaffolding; a
-// `template-scaffolded-agent.toml`-shaped starter for the add-agent flow.
+// `GET /api/agents/:name/persona`), the LIVE OKG-store bindings
+// (`GET /api/agents/:name/stores`, #3816/#3864), and the listener shape Bob
+// asked the concept demo to render while its backend is still being built
+// (see `DEFINED_LISTENERS`' doc comment). Keeping the fetch/patch logic here
+// (not inline in the component) makes it independently testable, mirroring
+// `stores/app.ts`'s `fetchAgentCatalog` pattern.
+// What: `fetchAgentDetail`/`fetchAgentPersona`/`patchAgent`/`fetchAgentStores`
+// — thin REST wrappers; `DEFINED_LISTENERS` — the two listener bindings from
+// the (not yet implemented) listener spec, rendered as honest scaffolding.
 // Test: `agentConfig.test.ts`.
 
 import { apiBase } from './api-config';
@@ -138,33 +136,56 @@ export const DEFINED_LISTENERS: ListenerDefinition[] = [
 ];
 
 /**
- * Why: "OKG Stores" (the agent's bound knowledge trees + search indexes,
- * e.g. Izzie's `bob-kb`) has no representation in `agent.toml` today —
- * confirmed by grep against `crates/trusty-agents/src/agents/config.rs`
- * before choosing to scaffold rather than fabricate a live reading. Per
- * Bob's own escape valve ("render... as a structured placeholder... state
- * in the PR body which sections are live vs scaffolded"), this returns a
- * fixed, clearly-labeled scaffold shape rather than fake doc/chunk counts —
- * inventing believable-looking numbers here would be fabricated data
- * (BASE-ENGINEER "No Mock Data" — mock data belongs in test code only).
- * What: One scaffold row so the section isn't empty in the concept demo;
- * `connected: false` and the UI renders it as "not yet connected" rather
- * than implying a live reading.
+ * One OKG store binding, resolved LIVE by the backend (#3816/#3864).
+ *
+ * Why: this replaces the pre-#3816 client-side scaffold. The binding now
+ * exists in `agent.toml` as `[[stores]]` and
+ * `GET /api/agents/:name/stores` resolves each one against the running
+ * trusty-search / trusty-memory daemons, so the card reports an OBSERVED
+ * state instead of asserting "not connected" for every agent.
+ * What: mirrors `crate::stores::status::StoreStatus`'s serde shape.
+ * `connected` reflects the SEARCH INDEX (the corpus `vector_search` routes
+ * to); `reason` is present only when it is false. Palace health is separate
+ * so a missing palace downgrades one line, not the whole store. Every
+ * optional field is omitted by the server when absent — never guessed.
  */
 export interface OkgStoreBinding {
   name: string;
   tree: string;
   index: string;
+  palace?: string;
   connected: boolean;
+  reason?: string;
+  chunk_count?: number;
+  root_path?: string;
+  index_status?: string;
+  palace_connected?: boolean;
+  palace_reason?: string;
 }
 
-export function scaffoldOkgStores(agentName: string): OkgStoreBinding[] {
-  return [
-    {
-      name: `${agentName}-kb`,
-      tree: `okg://${agentName}`,
-      index: `trusty-search:${agentName}`,
-      connected: false,
-    },
-  ];
+/** `GET /api/agents/:name/stores`'s wire shape. */
+export interface AgentStores {
+  stores: OkgStoreBinding[];
+  /** Non-fatal config problems (e.g. more than one store bound). */
+  issues: string[];
+  /** Present only when the agent's TOML failed to parse. */
+  config_error?: string;
+}
+
+/**
+ * Why: an agent that binds no store is a normal state (empty list), and a
+ * daemon being down is reported per-store rather than as a request failure —
+ * so the only `null` case worth branching on is a stale roster selection.
+ * What: `GET /api/agents/:name/stores`. Returns `null` on 404; throws on any
+ * other network/HTTP error.
+ * Test: `fetchAgentStores_returns_null_on_404`,
+ * `fetchAgentStores_parses_live_status`.
+ */
+export async function fetchAgentStores(name: string): Promise<AgentStores | null> {
+  const r = await fetch(`${apiBase()}/api/agents/${encodeURIComponent(name)}/stores`, {
+    headers: authHeaders(),
+  });
+  if (r.status === 404) return null;
+  if (!r.ok) throw new Error(`GET /api/agents/${name}/stores failed: ${r.status}`);
+  return (await r.json()) as AgentStores;
 }


### PR DESCRIPTION
## What

Makes OKG store bindings **real**. Before this PR the GUI's OKG Stores pane rendered a hardcoded placeholder — *"Scaffolding — `agent.toml` has no OKG store binding field yet… not yet connected to a live index"* — for every agent, and `vector_search` had no way to be pointed at an agent's own corpus (#3864). Now the binding exists in config, resolves against the live daemons, and drives both the GUI and the agent's semantic search.

This is the **FIRST leg** of the stores/tools/listeners config triple (DOC-54 SPEC-AGENTS-04 §5.1). The third leg (`[[listeners]]`) landed in #3820; this one deliberately mirrors its module layout and its "declarative data only, degrade never fail" posture.

## Design

**Config (`crate::stores::config`).** `agent.toml` gains `[[stores]]` with `name` / `tree` (`okg://…`) / `index` (trusty-search id) / `palace` (trusty-memory id). Two spellings parse, because two already existed in the repo: the rich array-of-tables above, and the product spec's documented shorthand `[stores] allow = ["izzie-personal-kb"]` (name only, tree and index derived). Rejecting the shorthand would have left a checked-in spec no parser honours. `name` is the only required field; `tree` defaults to `okg://<agent-name>` and `index` to the store `name`.

**Nothing is fatal.** Validation returns human-readable reasons, not errors — a blank name, a non-`okg://` tree, a duplicate, or more than one store (the spec allows exactly one) is *reported* as a disconnect reason. A malformed binding must never stop an agent booting.

**Live resolution (`crate::stores::status`).** A binding is a claim, not a fact — that is exactly why the old pane could only render a placeholder. Each binding is probed against `GET /indexes/{id}/status` (trusty-search) and `GET /api/v1/palaces/{id}/drawers?limit=1` (trusty-memory, the cheapest existence check that does **not** create the palace — the `POST /api/v1/palaces` route this crate uses elsewhere is an ensure/create). Every failure mode — undiscoverable daemon, refused connection, 404, malformed body, 2s timeout — collapses to `connected: false` + `reason`, mirroring `system_status::daemons`' established "down is a normal, reportable state" contract. `connected` reflects the **search index only** (the corpus `vector_search` routes to); palace health is separate so a missing palace downgrades one line of the card, not the whole store.

**`extends` merges by REPLACE, not union.** Unlike tools/listeners, a child's `[[stores]]` replaces the base's. The spec allows exactly one store per agent, so an overlay declaring its own store means "this is MY knowledge" — unioning would produce a two-store config whose *default search target is the base's index*, silently routing every unqualified `vector_search` to the wrong corpus. A child declaring no stores still inherits the base's.

**#3864.** `vector_search` now advertises an optional `index_id`, resolved as: explicit argument → the agent's bound store index → none (pre-#3864 behaviour, unchanged). When an id resolves, the query routes to the shared trusty-search daemon (`POST /indexes/{id}/search`). Any failure degrades to the embedded index and then the regex fallback — never an errored turn. The schema's `index_id` description *names* the bound default so the model can see which corpus an unqualified call hits.

Second half of that bug: `vector_search` was **never registered on the persona-chat dispatch path** at all. `cto-assistant`'s `[tools].allow` granted it, but `filter_persona_tool_names` had nothing to filter — the grant was inert, which is why the live workaround swapped in `grep`. It is now registered there, bound to the persona's store.

**Seeds.** `izzie` → `okg://izzie` / index `bob-kb` / palace `owner-profile`; `cto-assistant` → `okg://cto-assistant` / index `cto-assistant` / palace `cto`. Written to the **embedded provisioning source of truth** (`crates/trusty-agents/.trusty-agents/agents/`, both the directory packages and their flat shadows) — not `~/.trusty-agents`, which this PR does not touch; installation is a separate ops step. Two regression tests assert the *embedded bytes* still carry each binding and still grant `vector_search`, so a reprovision that dropped either fails CI instead of silently degrading both surfaces. `izzie` also gains the `vector_search` grant her binding needs to be reachable.

## Live verification

Real daemons, real indexes, via the real router (`tagent --api`, `TAGENT_CONFIG_DIR` pointed at the seeded bundle):

```
GET /api/agents/izzie/stores
{"issues": [], "stores": [{"name": "bob-kb", "tree": "okg://izzie", "index": "bob-kb",
  "connected": true, "chunk_count": 552, "index_status": "ready",
  "root_path": "/Users/masa/trusty-agents/bob-kb",
  "palace": "owner-profile", "palace_connected": true}]}

GET /api/agents/cto-assistant/stores
{"issues": [], "stores": [{"name": "cto-assistant-kb", "tree": "okg://cto-assistant",
  "index": "cto-assistant", "connected": true, "chunk_count": 200090,
  "index_status": "ready", "root_path": "/Users/masa/trusty-mpm-projects/bob-duetto/cto",
  "palace": "cto", "palace_connected": true}]}
```

Negative paths, also live:

```
GET /api/agents/assistant/stores   → 200 {"issues": [], "stores": []}          (binds nothing)
GET /api/agents/nope/stores        → 404 {"error": "unknown agent", …}
GET /api/agents/broken/stores      → 200 {"connected": false,
    "reason": "search index `does-not-exist-kb` is not registered on the trusty-search daemon"}
```

## Gates

```
cargo test -p trusty-agents      → 2459 passed; 0 failed; 12 ignored (lib)
                                   + 26 passed across 9 integration targets
cargo clippy -p trusty-agents --all-targets -- -D warnings  → exit 0
cargo fmt -p trusty-agents --check                          → clean
pnpm run test:unit (ui)          → 12 files, 115 passed
pnpm run check (svelte-check)    → 0 errors (2 pre-existing warnings, ProjectsView.svelte)
pnpm run build (ui)              → built in 3.63s
```

New coverage: 15 config parse/validate/derive cases, 6 live-status cases against a mock trusty-search/-memory router (connected + stats, missing index, missing palace, undiscoverable daemon, no-network short-circuit), 7 API-route cases (connected, disconnected-with-reason, unbound, 404, traversal 400, malformed-TOML degradation, router wiring), 10 `index_id` cases including two end-to-end daemon-routing tests, 2 `extends` replace/inherit cases, 2 bundled-seed regression tests, and 5 UI fetch cases.

## Scope notes

- Store bindings are **read-only** in the GUI this slice — edited in `agent.toml`. No `PATCH` contract is established for them yet.
- The Listeners pane's scaffolding is untouched; only the OKG Stores placeholder is removed.
- `~/.trusty-agents` is deliberately not modified.

Closes #3864
Refs #3816, #3052

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
