### PR TITLE
fix(trusty-installer): auto-install tmux under -y; fail early in preflight when unautomatable (#3821)

### DIFF
--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -6,6 +6,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **`tctl install -y` dead-ended on a truly clean macOS box with no
+  Homebrew: tmux could never be auto-installed, and the install ran to
+  completion anyway before failing with an unexplained exit 2** (#3821,
+  demo-critical — reproduced piping `install.sh | sh -s -- -y` on a fresh
+  macOS 15.7.7 arm64 VM). Root cause: Phase 6's prereq-check correctly
+  detects that no auto-install command is safe when no package manager is
+  present (bootstrapping Homebrew itself needs sudo/CLT and can prompt, so
+  it is intentionally never auto-run), but the caller then only warned and
+  continued installing the rest of the stable set — the actual failure
+  only surfaced later, at the post-install verify tail, with no message
+  connecting it back to tmux. Fixed with a new pure decision gate
+  (`commands::tmux_gap::decide_tmux_gap_action`, mirroring
+  `install_gate::decide_install_gate`): under `--yes` with tmux still
+  missing after Phase 6, `tctl install` now fails EARLY — before installing
+  anything else — with one clear, actionable message (both human and
+  `--json` output). Brew-present machines are unaffected: `brew install
+  tmux` still auto-installs under `-y` exactly as before. Interactive TTY
+  behavior is unchanged (prompts to continue anyway). Issue #3823 (tm
+  needs a tmux *server* started) is separate and out of scope here.
+- The Phase 6 prereq auto-install command (`brew install tmux` and
+  friends) now runs through the same captured-output primitive
+  (`service_bootstrap::run_captured`, `.output()`-based) the rest of the
+  installer already uses post-#3830, instead of a bespoke
+  `Stdio::inherit()` call — removes a latent footgun where a future
+  reordering of the prereq phase relative to the live install checklist
+  could reintroduce #3830's interleaved-line corruption.
+
 ## [0.4.9] - 2026-07-24
 
 ### Fixed

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -30,12 +30,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   behavior is unchanged (prompts to continue anyway). Issue #3823 (tm
   needs a tmux *server* started) is separate and out of scope here.
 - The Phase 6 prereq auto-install command (`brew install tmux` and
-  friends) now runs through the same captured-output primitive
-  (`service_bootstrap::run_captured`, `.output()`-based) the rest of the
-  installer already uses post-#3830, instead of a bespoke
-  `Stdio::inherit()` call — removes a latent footgun where a future
-  reordering of the prereq phase relative to the live install checklist
-  could reintroduce #3830's interleaved-line corruption.
+  friends) now runs fully captured (never `Stdio::inherit()`, #3830) via a
+  new `prereqs::exec_heartbeat::run_captured_with_heartbeat` — removing a
+  latent footgun where a future reordering of the prereq phase relative to
+  the live install checklist could reintroduce #3830's interleaved-line
+  corruption.
+- **A first-run `brew install tmux` can legitimately take 1-5+ minutes
+  (Homebrew self-update, a non-bottled build) with zero output** — code
+  critic caught this on PR #3879: the fully-captured exec above would sit
+  silently for that entire span on the exact piped `curl | sh -s -- -y`
+  demo path, reading as a hang. `run_captured_with_heartbeat` now emits an
+  installer-owned `still running: ... (Ns elapsed)...` line every ~15s
+  while the child is still running — never child stdout passthrough, so
+  captured output discipline is unaffected.
+- **`tctl install --json`'s Phase-6 fail-early error dropped the real cause
+  when a package manager WAS present but the auto-install attempt itself
+  failed** (network/disk/permissions) — the JSON envelope carried only the
+  static "Homebrew required" hint, indistinguishable from "no package
+  manager found at all". The envelope now carries `hint` (the static,
+  platform-appropriate note) and `detail` (the actual captured stderr from
+  the failed attempt, `null` when no attempt was even possible) as
+  distinct fields.
 
 ## [0.4.9] - 2026-07-24
 

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -180,7 +180,9 @@ pub fn run(
     // Prints ✓ lines for found tools and offers interactive install for missing ones.
     {
         use super::prereqs::phase::{run_prereq_phase, PrereqPhaseConfig};
-        use super::tmux_gap::{decide_tmux_gap_action, TmuxGapAction, TmuxGapInputs};
+        use super::tmux_gap::{
+            decide_tmux_gap_action, fail_early_json_payload, TmuxGapAction, TmuxGapInputs,
+        };
         let crate_names: Vec<String> = selected.iter().map(|m| m.crate_name.clone()).collect();
         let phase_result = run_prereq_phase(&PrereqPhaseConfig {
             selected: &crate_names,
@@ -227,17 +229,23 @@ pub fn run(
                 let hint = tmux_missing
                     .map(|m| m.hint.as_str())
                     .unwrap_or("Install tmux, then re-run `tctl install`.");
+                // #3821 finding 2: `detail` is the REAL captured error from a
+                // failed auto-install attempt (network/disk/permissions),
+                // kept distinct from the static `hint` — `None` when no
+                // attempt was even possible (no package manager detected).
+                let detail = tmux_missing.and_then(|m| m.detail.as_deref());
+                let extra = detail
+                    .map(|d| format!(" Install attempt failed: {d}."))
+                    .unwrap_or_default();
                 let msg = format!(
                     "tctl install: tmux is required for trusty-mpm and could not be \
-                     auto-installed on this machine. {hint} Re-run `tctl install` once \
-                     tmux is available, or install without trusty-mpm's session \
+                     auto-installed on this machine.{extra} {hint} Re-run `tctl install` \
+                     once tmux is available, or install without trusty-mpm's session \
                      management by omitting it from the member list. Nothing has been \
                      installed."
                 );
                 if json {
-                    if render_json(&serde_json::json!({"command": "install", "error": msg}))
-                        .is_err()
-                    {
+                    if render_json(&fail_early_json_payload(&msg, hint, detail)).is_err() {
                         eprintln!("tctl install: failed to write JSON output");
                         return 1;
                     }

--- a/crates/trusty-installer/src/commands/install.rs
+++ b/crates/trusty-installer/src/commands/install.rs
@@ -180,6 +180,7 @@ pub fn run(
     // Prints ✓ lines for found tools and offers interactive install for missing ones.
     {
         use super::prereqs::phase::{run_prereq_phase, PrereqPhaseConfig};
+        use super::tmux_gap::{decide_tmux_gap_action, TmuxGapAction, TmuxGapInputs};
         let crate_names: Vec<String> = selected.iter().map(|m| m.crate_name.clone()).collect();
         let phase_result = run_prereq_phase(&PrereqPhaseConfig {
             selected: &crate_names,
@@ -187,24 +188,63 @@ pub fn run(
             json,
         });
         // If trusty-mpm is selected and tmux is still missing after the phase,
-        // give the user one final chance to abort the overall install or continue.
+        // decide (via the pure #3821 gate) whether to prompt, warn, or abort
+        // BEFORE installing anything else.
         let mpm_selected = selected.iter().any(|m| m.crate_name == "trusty-mpm");
-        let tmux_still_missing = phase_result
+        let tmux_missing = phase_result
             .still_missing
             .iter()
-            .any(|m| m.binary == "tmux");
-        if mpm_selected && tmux_still_missing {
-            if !json && super::progress_ui::is_tty() && !yes {
+            .find(|m| m.binary == "tmux");
+        let action = decide_tmux_gap_action(TmuxGapInputs {
+            mpm_selected,
+            tmux_still_missing: tmux_missing.is_some(),
+            yes,
+            json,
+            is_tty: super::progress_ui::is_tty(),
+        });
+        match action {
+            TmuxGapAction::None => {}
+            TmuxGapAction::PromptContinue => {
                 let q = "trusty-mpm requires tmux (still not installed). Continue install anyway?";
                 if !super::progress_ui::prompt_yes_no(q) {
                     eprintln!("tctl install: aborted (tmux not installed).");
                     return 3;
                 }
-            } else if !json {
+            }
+            TmuxGapAction::WarnAndContinue => {
                 eprintln!(
                     "tctl install: warning: trusty-mpm requires tmux which is not installed; \
                      managed sessions will not work until tmux is available."
                 );
+            }
+            TmuxGapAction::FailEarly => {
+                // #3821: `--yes` (piped `curl | sh -s -- -y`) with tmux still
+                // unmet after Phase 6 — never continue on to install the rest
+                // of the stable set only to fail later at the verify tail.
+                // Fail HERE, before any install side effect, with one clear,
+                // actionable message built from the platform-specific hint
+                // Phase 6 already computed.
+                let hint = tmux_missing
+                    .map(|m| m.hint.as_str())
+                    .unwrap_or("Install tmux, then re-run `tctl install`.");
+                let msg = format!(
+                    "tctl install: tmux is required for trusty-mpm and could not be \
+                     auto-installed on this machine. {hint} Re-run `tctl install` once \
+                     tmux is available, or install without trusty-mpm's session \
+                     management by omitting it from the member list. Nothing has been \
+                     installed."
+                );
+                if json {
+                    if render_json(&serde_json::json!({"command": "install", "error": msg}))
+                        .is_err()
+                    {
+                        eprintln!("tctl install: failed to write JSON output");
+                        return 1;
+                    }
+                } else {
+                    eprintln!("{msg}");
+                }
+                return 3;
             }
         }
     }

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -37,6 +37,7 @@ pub mod sign;
 pub mod stable_set;
 pub mod stack;
 pub mod status;
+pub mod tmux_gap;
 pub mod ui;
 pub mod up;
 pub mod update_engine;

--- a/crates/trusty-installer/src/commands/prereqs/exec_heartbeat.rs
+++ b/crates/trusty-installer/src/commands/prereqs/exec_heartbeat.rs
@@ -1,0 +1,219 @@
+//! Captured, heartbeat-emitting execution for long-running prereq
+//! auto-install commands (#3821, code-critic HIGH finding on PR #3879).
+//!
+//! Why: A first-run `brew install tmux` routinely takes 1-5+ minutes on a
+//! clean machine (Homebrew self-update, a non-bottled build) with ZERO
+//! output from a plain `.output()`-captured call for that entire span —
+//! exactly on the piped `curl | sh -s -- -y` demo path this crate exists to
+//! support. That silence reads as a hang. A periodic, INSTALLER-EMITTED
+//! heartbeat line fixes the perception without reintroducing #3830: the
+//! child's own stdout/stderr stay fully captured (never inherited) — the
+//! heartbeat text comes from the installer's own `on_tick` callback, never
+//! from child passthrough.
+//!
+//! What: [`run_captured_with_heartbeat`] spawns `cmd` with piped
+//! stdout/stderr, drains both on background threads so the child can never
+//! block on a full pipe, and polls `Child::try_wait()` on a short interval.
+//! Every time `heartbeat` elapses while the child is still running, it
+//! calls `on_tick(elapsed_secs)`. On exit it folds the captured stderr
+//! (trimmed) into the returned error, mirroring
+//! `service_bootstrap::run_captured`'s contract exactly — this is that same
+//! captured-not-inherited guarantee, extended with interim signal for
+//! long-running commands.
+//!
+//! Test: `tests::heartbeat_fires_while_child_runs` (a short interval + a
+//! sleeping child proves multiple, monotonically-increasing ticks before
+//! completion), `tests::no_heartbeat_when_child_exits_fast` (a large
+//! interval + an instant child proves zero ticks — no spam for the common
+//! case), `tests::captures_stderr_into_error` (the #3830-style proof: an
+//! error's message contains the child's exact stderr, only reachable via
+//! captured, non-inherited execution), `tests::success_returns_ok`.
+
+use std::io::Read;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Ceiling on how coarsely we poll `try_wait()` in production — far finer
+/// than [`DEFAULT_HEARTBEAT`] so a tick fires close to on-time without
+/// busy-looping.
+const POLL_INTERVAL_CAP: Duration = Duration::from_millis(200);
+/// Floor on the poll interval so a caller-supplied sub-millisecond heartbeat
+/// (only realistic in tests) can never busy-loop.
+const POLL_INTERVAL_FLOOR: Duration = Duration::from_millis(5);
+
+/// Production heartbeat cadence (#3821): long enough to never spam a fast
+/// install, short enough that a piped `-y` demo is never silent for more
+/// than ~20s while a package manager is still working.
+pub const DEFAULT_HEARTBEAT: Duration = Duration::from_secs(15);
+
+/// Run `cmd` with output captured, calling `on_tick(elapsed_secs)` every
+/// `heartbeat` while the child is still running.
+///
+/// Why/What/Test: see the module doc.
+pub fn run_captured_with_heartbeat(
+    mut cmd: Command,
+    label: &str,
+    heartbeat: Duration,
+    mut on_tick: impl FnMut(u64),
+) -> anyhow::Result<()> {
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child: Child = cmd
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("spawn {label}: {e}"))?;
+
+    // Drain both pipes on background threads so the child can never block
+    // writing to a full pipe while we're busy polling/sleeping — captured,
+    // never inherited (#3830).
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stderr_thread = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut p) = stderr_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        buf
+    });
+    let stdout_thread = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut p) = stdout_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    // Poll at a resolution proportional to the requested heartbeat — capped
+    // for production (never busier than every 200ms) and floored for tests
+    // (a 50ms test heartbeat must not be quantized by a 200ms production
+    // poll tick, or it can never fire more than once or twice — the #3821
+    // PR #3879 flake this fixes).
+    let poll_interval = heartbeat.min(POLL_INTERVAL_CAP).max(POLL_INTERVAL_FLOOR);
+
+    let start = Instant::now();
+    let mut next_tick = heartbeat;
+    let status = loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| anyhow::anyhow!("wait {label}: {e}"))?
+        {
+            break status;
+        }
+        if start.elapsed() >= next_tick {
+            on_tick(next_tick.as_secs());
+            next_tick += heartbeat;
+        }
+        std::thread::sleep(poll_interval);
+    };
+
+    // Captured, never printed here — the heartbeat above is the only output
+    // this function emits on the caller's behalf (#3830).
+    let _stdout = stdout_thread.join().unwrap_or_default();
+    let stderr_buf = stderr_thread.join().unwrap_or_default();
+
+    if status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&stderr_buf);
+        let stderr = stderr.trim();
+        if stderr.is_empty() {
+            anyhow::bail!("{label} exited with {status}")
+        } else {
+            anyhow::bail!("{label} exited with {status}: {stderr}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    fn sh(script: &str) -> Command {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(script);
+        cmd
+    }
+
+    /// Why: THE #3821 fix — a long-running child must produce interim,
+    /// installer-emitted signal rather than total silence.
+    /// What: A ~700ms-sleeping child polled with a 20ms heartbeat interval
+    /// (a generous ~35x margin over the 2-tick minimum this asserts, so the
+    /// test tolerates real scheduling jitter under a loaded/parallel `cargo
+    /// test` run without flaking); asserts `on_tick` fires at least twice
+    /// with non-decreasing elapsed-seconds arguments before the command
+    /// completes successfully.
+    /// Test: This is the test.
+    #[test]
+    fn heartbeat_fires_while_child_runs() {
+        let ticks: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+        let ticks_cb = ticks.clone();
+        let result = run_captured_with_heartbeat(
+            sh("sleep 0.7; exit 0"),
+            "`sleep test`",
+            Duration::from_millis(20),
+            move |elapsed| ticks_cb.lock().expect("lock ticks").push(elapsed),
+        );
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        let seen = ticks.lock().expect("lock ticks").clone();
+        assert!(
+            seen.len() >= 2,
+            "expected multiple heartbeat ticks over ~700ms at 20ms cadence, got: {seen:?}"
+        );
+        let mut sorted = seen.clone();
+        sorted.sort_unstable();
+        assert_eq!(seen, sorted, "ticks must be strictly increasing: {seen:?}");
+    }
+
+    /// Why: a fast command (the common case — most prereqs are already
+    /// satisfied, or install quickly) must never emit a spurious heartbeat.
+    /// What: An instantly-exiting child with a long heartbeat interval;
+    /// asserts `on_tick` is never called.
+    /// Test: This is the test.
+    #[test]
+    fn no_heartbeat_when_child_exits_fast() {
+        let ticks: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
+        let ticks_cb = ticks.clone();
+        let result = run_captured_with_heartbeat(
+            sh("exit 0"),
+            "`fast test`",
+            Duration::from_secs(30),
+            move |elapsed| ticks_cb.lock().expect("lock ticks").push(elapsed),
+        );
+        assert!(result.is_ok());
+        assert!(ticks.lock().expect("lock ticks").is_empty());
+    }
+
+    /// Why (#3830-style proof): the error path must be built from CAPTURED
+    /// stderr — only reachable via piped, non-inherited execution.
+    /// What: A child that writes a distinctive marker to stderr and exits
+    /// non-zero; asserts the returned error's message contains it.
+    /// Test: This is the test.
+    #[test]
+    fn captures_stderr_into_error() {
+        let err = run_captured_with_heartbeat(
+            sh("echo 'DISTINCTIVE_MARKER_3821_HEARTBEAT: brew failed' >&2; exit 7"),
+            "`fake failing install`",
+            Duration::from_secs(30),
+            |_| panic!("must not tick before this fast-failing child exits"),
+        )
+        .expect_err("expected Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("DISTINCTIVE_MARKER_3821_HEARTBEAT: brew failed"),
+            "error message did not fold in captured stderr: {msg}"
+        );
+    }
+
+    /// Why: the success path must be a plain `Ok(())`, matching the
+    /// pre-heartbeat `real_exec` contract exactly.
+    /// What: A trivially successful command; asserts `Ok(())`.
+    /// Test: This is the test.
+    #[test]
+    fn success_returns_ok() {
+        let result =
+            run_captured_with_heartbeat(sh("exit 0"), "`ok test`", Duration::from_secs(30), |_| {
+                panic!("must not tick")
+            });
+        assert!(result.is_ok());
+    }
+}

--- a/crates/trusty-installer/src/commands/prereqs/mod.rs
+++ b/crates/trusty-installer/src/commands/prereqs/mod.rs
@@ -10,11 +10,14 @@
 //! - `detect` — binary detection + version query (extra-path fallback for claude).
 //! - `hints` — platform/pkg-mgr detection and OS-specific install-command selection.
 //! - `phase` — full check-confirm-offer-install-reverify phase orchestration.
+//! - `exec_heartbeat` — captured, heartbeat-emitting command execution for
+//!   long-running auto-install commands (#3821).
 //!
 //! Test: `tests` validates the legacy `check_and_warn` relevance filtering and
 //! missing-tool detection; new sub-module tests live in their respective files.
 
 pub mod detect;
+pub mod exec_heartbeat;
 pub mod hints;
 pub mod phase;
 
@@ -47,7 +50,13 @@ pub struct Prereq {
 /// Why: Callers may want to block on some missing tools (trusty-mpm → tmux)
 /// while only warning for others; returning a typed list lets the caller decide.
 ///
-/// What: Holds the `binary` name and the `hint` string.
+/// What: Holds the `binary` name, the static `hint` string, and an optional
+/// `detail` — the ACTUAL captured error from a failed auto-install attempt
+/// (e.g. brew's stderr), kept distinct from `hint` so a `--json` consumer
+/// never has to guess whether "Homebrew required" is the real cause or just
+/// the generic fallback text (#3821 finding 2: a failed `brew install tmux`
+/// attempt — network/disk/permissions — was silently losing this detail in
+/// `--json` mode, leaving only the static hint).
 ///
 /// Test: `tests::check_returns_missing_for_injected_absent`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,6 +65,10 @@ pub struct Missing {
     pub binary: String,
     /// Install guidance for the missing binary.
     pub hint: String,
+    /// The captured error from a failed auto-install attempt, when one was
+    /// actually made (`None` when no auto-install was even possible, e.g.
+    /// no package manager was detected).
+    pub detail: Option<String>,
 }
 
 /// The canonical prerequisite table.
@@ -128,6 +141,7 @@ pub fn check_and_warn(
             let m = Missing {
                 binary: prereq.binary.to_owned(),
                 hint: prereq.hint.to_owned(),
+                detail: None,
             };
             if !json {
                 let _ = narr.info(&format!(

--- a/crates/trusty-installer/src/commands/prereqs/phase.rs
+++ b/crates/trusty-installer/src/commands/prereqs/phase.rs
@@ -208,6 +208,7 @@ pub fn run_prereq_phase_with(
                                     still_missing.push(Missing {
                                         binary: prereq.binary.to_owned(),
                                         hint: hint.manual_note.clone(),
+                                        detail: None,
                                     });
                                 }
                             }
@@ -219,9 +220,16 @@ pub fn run_prereq_phase_with(
                                     hint.manual_note
                                 ));
                             }
+                            // #3821 finding 2: keep the ACTUAL captured error
+                            // (e.g. brew's stderr — network/disk/permissions)
+                            // distinct from the static `hint` so a `--json`
+                            // consumer can tell "no auto-install was even
+                            // possible" apart from "an attempt was made and
+                            // failed".
                             still_missing.push(Missing {
                                 binary: prereq.binary.to_owned(),
                                 hint: hint.manual_note.clone(),
+                                detail: Some(e.to_string()),
                             });
                         }
                     }
@@ -237,6 +245,7 @@ pub fn run_prereq_phase_with(
                     still_missing.push(Missing {
                         binary: prereq.binary.to_owned(),
                         hint: hint.manual_note,
+                        detail: None,
                     });
                 }
             }
@@ -250,30 +259,33 @@ pub fn run_prereq_phase_with(
 }
 
 /// Run a prereq auto-install command (e.g. `brew install tmux`) with its
-/// output CAPTURED, never inherited.
+/// output CAPTURED, never inherited — AND a periodic heartbeat while it runs.
 ///
-/// Why (#3821, reusing the #3830 fix): an earlier version of this function
-/// inherited stdout/stderr so brew/apt progress streamed live. That is safe
-/// only as long as no [`trusty_progress::LiveChecklist`] is animating at the
-/// same time — true today (this phase runs before `install_all` starts one),
-/// but fragile: any future reordering would silently reintroduce the exact
-/// interleaved-line corruption #3830 fixed elsewhere in this same command
-/// (`install.rs`'s `perform_upgrade_captured` call, `service_bootstrap`'s
-/// `run_captured`). Delegating to the SAME shared `run_captured` primitive
-/// those call sites use removes that footgun entirely rather than relying on
-/// call-order discipline.
-/// What: Builds `sh -c <cmd>` and runs it via
-/// [`super::super::service_bootstrap::run_captured`], which uses
-/// `Command::output()` and folds captured stderr into the error on failure.
-/// Test: `tests::real_exec_captures_not_inherits` (asserts the failure path
-/// carries the child's captured stderr, which is only possible when the
-/// command was run via `.output()` — `.status()` has no access to it); the
-/// stdout-never-leaks-to-parent-fd guarantee itself is proven once, at the
-/// shared primitive, by `service_bootstrap::tests::run_captured_never_leaks_to_parent_stdio`.
+/// Why (#3821): a first-run `brew install tmux` can legitimately take
+/// several minutes (Homebrew self-update, a non-bottled build) with zero
+/// output — exactly on the piped `curl | sh -s -- -y` demo path this exists
+/// to support. A plain blocking captured call (this crate's #3830-safe
+/// default elsewhere) would sit silent that whole time, reading as a hang
+/// (code-critic HIGH finding on PR #3879). Delegating to
+/// [`super::exec_heartbeat::run_captured_with_heartbeat`] keeps the exact
+/// same captured-not-inherited guarantee while adding an installer-emitted
+/// "still running" line every [`super::exec_heartbeat::DEFAULT_HEARTBEAT`].
+/// What: Builds `sh -c <cmd>` and runs it with a heartbeat callback that
+/// prints one `eprintln!` line per tick (this function is only ever reached
+/// under `!json` — see `auto_yes`/`should_offer` above — so writing directly
+/// to stderr can never corrupt `--json` output).
+/// Test: The captured-exec + heartbeat primitive itself is exhaustively
+/// tested in `exec_heartbeat::tests`; this thin wrapper only needs to prove
+/// the command is actually built and run — see `tests::real_exec_*` below.
 fn real_exec(cmd: &str) -> anyhow::Result<()> {
     let mut command = std::process::Command::new("sh");
     command.arg("-c").arg(cmd);
-    super::super::service_bootstrap::run_captured(command, &format!("`{cmd}`"))
+    super::exec_heartbeat::run_captured_with_heartbeat(
+        command,
+        &format!("`{cmd}`"),
+        super::exec_heartbeat::DEFAULT_HEARTBEAT,
+        |elapsed| eprintln!("  still running: `{cmd}` ({elapsed}s elapsed)..."),
+    )
 }
 
 #[cfg(test)]
@@ -650,9 +662,12 @@ mod tests {
     }
 
     /// Why: under `--yes`, exec failure must still land the binary in
-    /// `still_missing` (not silently `installed`).
+    /// `still_missing` (not silently `installed`) — AND (#3821 finding 2)
+    /// the real captured error must be threaded onto `Missing.detail`,
+    /// distinct from the static `hint`, so `--json` consumers don't lose it.
     /// What: `yes: true, json: false`; exec_fn returns Err; asserts tmux ends
-    /// up in `still_missing`.
+    /// up in `still_missing` with `detail` carrying the exec error and
+    /// `hint` unchanged from the static manual note.
     /// Test: This is the test.
     #[test]
     fn phase_yes_exec_failure_adds_to_still_missing() {
@@ -671,39 +686,34 @@ mod tests {
             &|| false,
             &|_| false,
         );
-        assert!(result.still_missing.iter().any(|m| m.binary == "tmux"));
+        let tmux = result
+            .still_missing
+            .iter()
+            .find(|m| m.binary == "tmux")
+            .expect("tmux must be missing");
+        assert_eq!(tmux.detail.as_deref(), Some("fake failure"));
+        assert_ne!(Some(tmux.hint.as_str()), tmux.detail.as_deref());
     }
 
     /// Why (#3821): `real_exec` — the production `exec_fn` wired up by
-    /// `run_prereq_phase` for `brew install tmux` and friends — must run
-    /// CAPTURED, not inherited, mirroring the #3830 fix already applied to
-    /// every other shell-out in this crate. A `.status()`-based
-    /// implementation has no access to the child's stderr at all, so it
-    /// physically cannot satisfy this assertion; only a `.output()`-based
-    /// (captured) implementation can.
-    /// What: Runs a command that writes a distinctive marker to stderr and
-    /// exits non-zero through the real (non-injected) `real_exec`; asserts
-    /// the returned error's message contains that exact marker.
+    /// `run_prereq_phase` for `brew install tmux` and friends — is a thin
+    /// `sh -c` wrapper around `exec_heartbeat::run_captured_with_heartbeat`
+    /// (whose captured-not-inherited + heartbeat guarantees are exhaustively
+    /// tested in `exec_heartbeat::tests`); this only needs to prove the
+    /// wrapper itself round-trips both outcomes correctly.
+    /// What: A failing command's error carries the child's captured stderr
+    /// (proving `sh -c` + the shared primitive are actually wired up, not a
+    /// no-op); a trivially successful command returns `Ok(())`.
     /// Test: This is the test.
     #[test]
-    fn real_exec_captures_not_inherits() {
+    fn real_exec_wraps_command_and_captures_stderr() {
+        assert!(real_exec("exit 0").is_ok());
         let err = real_exec("echo 'DISTINCTIVE_MARKER_3821: brew install tmux failed' >&2; exit 7")
             .expect_err("expected Err");
-        let msg = err.to_string();
         assert!(
-            msg.contains("DISTINCTIVE_MARKER_3821: brew install tmux failed"),
-            "error message did not fold in captured stderr (implies inherited, \
-             not captured, execution): {msg}"
+            err.to_string()
+                .contains("DISTINCTIVE_MARKER_3821: brew install tmux failed"),
+            "error message did not fold in captured stderr: {err}"
         );
-    }
-
-    /// Why: the success path must also go through `real_exec` (not a
-    /// hand-rolled duplicate), proving the delegation to the shared captured
-    /// primitive round-trips correctly for the common case too.
-    /// What: Runs a trivially successful command; asserts `Ok(())`.
-    /// Test: This is the test.
-    #[test]
-    fn real_exec_success_returns_ok() {
-        assert!(real_exec("exit 0").is_ok());
     }
 }

--- a/crates/trusty-installer/src/commands/prereqs/phase.rs
+++ b/crates/trusty-installer/src/commands/prereqs/phase.rs
@@ -249,23 +249,31 @@ pub fn run_prereq_phase_with(
     }
 }
 
+/// Run a prereq auto-install command (e.g. `brew install tmux`) with its
+/// output CAPTURED, never inherited.
+///
+/// Why (#3821, reusing the #3830 fix): an earlier version of this function
+/// inherited stdout/stderr so brew/apt progress streamed live. That is safe
+/// only as long as no [`trusty_progress::LiveChecklist`] is animating at the
+/// same time — true today (this phase runs before `install_all` starts one),
+/// but fragile: any future reordering would silently reintroduce the exact
+/// interleaved-line corruption #3830 fixed elsewhere in this same command
+/// (`install.rs`'s `perform_upgrade_captured` call, `service_bootstrap`'s
+/// `run_captured`). Delegating to the SAME shared `run_captured` primitive
+/// those call sites use removes that footgun entirely rather than relying on
+/// call-order discipline.
+/// What: Builds `sh -c <cmd>` and runs it via
+/// [`super::super::service_bootstrap::run_captured`], which uses
+/// `Command::output()` and folds captured stderr into the error on failure.
+/// Test: `tests::real_exec_captures_not_inherits` (asserts the failure path
+/// carries the child's captured stderr, which is only possible when the
+/// command was run via `.output()` — `.status()` has no access to it); the
+/// stdout-never-leaks-to-parent-fd guarantee itself is proven once, at the
+/// shared primitive, by `service_bootstrap::tests::run_captured_never_leaks_to_parent_stdio`.
 fn real_exec(cmd: &str) -> anyhow::Result<()> {
-    // Inherit stdout/stderr so package-manager progress (brew, apt, etc.)
-    // is visible to the operator during potentially long installs.
-    let status = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
-        .stdout(std::process::Stdio::inherit())
-        .stderr(std::process::Stdio::inherit())
-        .status()?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(anyhow::anyhow!(
-            "command exited with code {:?}",
-            status.code()
-        ))
-    }
+    let mut command = std::process::Command::new("sh");
+    command.arg("-c").arg(cmd);
+    super::super::service_bootstrap::run_captured(command, &format!("`{cmd}`"))
 }
 
 #[cfg(test)]
@@ -664,5 +672,38 @@ mod tests {
             &|_| false,
         );
         assert!(result.still_missing.iter().any(|m| m.binary == "tmux"));
+    }
+
+    /// Why (#3821): `real_exec` — the production `exec_fn` wired up by
+    /// `run_prereq_phase` for `brew install tmux` and friends — must run
+    /// CAPTURED, not inherited, mirroring the #3830 fix already applied to
+    /// every other shell-out in this crate. A `.status()`-based
+    /// implementation has no access to the child's stderr at all, so it
+    /// physically cannot satisfy this assertion; only a `.output()`-based
+    /// (captured) implementation can.
+    /// What: Runs a command that writes a distinctive marker to stderr and
+    /// exits non-zero through the real (non-injected) `real_exec`; asserts
+    /// the returned error's message contains that exact marker.
+    /// Test: This is the test.
+    #[test]
+    fn real_exec_captures_not_inherits() {
+        let err = real_exec("echo 'DISTINCTIVE_MARKER_3821: brew install tmux failed' >&2; exit 7")
+            .expect_err("expected Err");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("DISTINCTIVE_MARKER_3821: brew install tmux failed"),
+            "error message did not fold in captured stderr (implies inherited, \
+             not captured, execution): {msg}"
+        );
+    }
+
+    /// Why: the success path must also go through `real_exec` (not a
+    /// hand-rolled duplicate), proving the delegation to the shared captured
+    /// primitive round-trips correctly for the common case too.
+    /// What: Runs a trivially successful command; asserts `Ok(())`.
+    /// Test: This is the test.
+    #[test]
+    fn real_exec_success_returns_ok() {
+        assert!(real_exec("exit 0").is_ok());
     }
 }

--- a/crates/trusty-installer/src/commands/service_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap.rs
@@ -450,12 +450,7 @@ impl ServiceEnv for RealServiceEnv {
 /// child's exact stderr text, which is only possible if that stderr was
 /// CAPTURED via `.output()`; `.status()`, the pre-fix call, gives no access
 /// to it at all).
-///
-/// `pub(crate)` (#3821): `prereqs::phase`'s prereq auto-installer (e.g.
-/// `brew install tmux`) reuses this SAME captured-exec primitive rather than
-/// re-implementing its own `.status()`-based runner — one call site fewer
-/// that could regress into the #3830 inherited-stdio bug.
-pub(crate) fn run_captured(mut cmd: std::process::Command, label: &str) -> anyhow::Result<()> {
+fn run_captured(mut cmd: std::process::Command, label: &str) -> anyhow::Result<()> {
     let output = cmd
         .output()
         .map_err(|e| anyhow::anyhow!("spawn {label}: {e}"))?;

--- a/crates/trusty-installer/src/commands/service_bootstrap.rs
+++ b/crates/trusty-installer/src/commands/service_bootstrap.rs
@@ -450,7 +450,12 @@ impl ServiceEnv for RealServiceEnv {
 /// child's exact stderr text, which is only possible if that stderr was
 /// CAPTURED via `.output()`; `.status()`, the pre-fix call, gives no access
 /// to it at all).
-fn run_captured(mut cmd: std::process::Command, label: &str) -> anyhow::Result<()> {
+///
+/// `pub(crate)` (#3821): `prereqs::phase`'s prereq auto-installer (e.g.
+/// `brew install tmux`) reuses this SAME captured-exec primitive rather than
+/// re-implementing its own `.status()`-based runner — one call site fewer
+/// that could regress into the #3830 inherited-stdio bug.
+pub(crate) fn run_captured(mut cmd: std::process::Command, label: &str) -> anyhow::Result<()> {
     let output = cmd
         .output()
         .map_err(|e| anyhow::anyhow!("spawn {label}: {e}"))?;

--- a/crates/trusty-installer/src/commands/tmux_gap.rs
+++ b/crates/trusty-installer/src/commands/tmux_gap.rs
@@ -1,0 +1,232 @@
+//! Decide what `tctl install` does when trusty-mpm is selected and tmux is
+//! still missing after the prereq-check phase (#3821).
+//!
+//! Why: On a truly clean macOS box (no Homebrew, no tmux) the piped
+//! `curl | sh -s -- -y` demo install had no way to auto-install tmux — Phase
+//! 6's `install_hint_for` correctly returns `auto_cmd: None` when no package
+//! manager is detected (there is nothing to safely run non-interactively:
+//! bootstrapping Homebrew itself needs sudo/CLT and can prompt) — but the
+//! caller (`install::run`) treated "still missing" as a soft warning and
+//! continued installing the rest of the stable set anyway, only to fail at
+//! the very end (exit 2, from the post-install verify tail finding
+//! trusty-mpm's session management unhealthy) with no single actionable
+//! message pointing at the real cause. Encoding the decision as one pure,
+//! exhaustively-testable function (mirroring [`super::install_gate`]) lets
+//! `install::run` fail EARLY — before any install side effect — with one
+//! clear message, instead of a confusing half-installed dead end.
+//!
+//! What: [`decide_tmux_gap_action`] takes whether trusty-mpm was selected,
+//! whether tmux is still missing after Phase 6, `--yes`, `--json`, and
+//! whether stdin is a TTY, and returns a [`TmuxGapAction`] verdict:
+//! - `None` — nothing to do (tmux present, or trusty-mpm not selected).
+//! - `FailEarly` — `--yes` was given (the piped/scripted/agent-driven path)
+//!   and tmux could not be made present; abort BEFORE installing anything
+//!   else, in both human and `--json` modes.
+//! - `PromptContinue` — an interactive TTY, no `--yes`: ask the operator
+//!   whether to continue anyway (they can see the warning and decide).
+//! - `WarnAndContinue` — non-interactive, no `--yes`, human output: print an
+//!   informational warning. In practice `install::run`'s later
+//!   `decide_install_gate` refuses this exact combination anyway (no
+//!   consent obtainable), so this is best-effort context for the log, not a
+//!   load-bearing gate.
+//!
+//! Test: `tests::decide_*` exhaustively covers the decision matrix.
+
+/// Inputs to the pure tmux-gap decision.
+///
+/// Why: A single-argument-struct keeps [`decide_tmux_gap_action`] trivial to
+/// call and exhaustively test.
+///
+/// What: `mpm_selected` — whether `trusty-mpm` is among the members being
+/// installed; `tmux_still_missing` — whether tmux remained absent after
+/// Phase 6's detect/auto-install/prompt attempt; `yes`/`json`/`is_tty` mirror
+/// the same global flags [`super::install_gate::GateInputs`] uses.
+///
+/// Test: `tests::decide_*` construct these inline.
+#[derive(Clone, Copy, Debug)]
+pub struct TmuxGapInputs {
+    /// Whether `trusty-mpm` is among the selected members.
+    pub mpm_selected: bool,
+    /// Whether tmux remained absent after the Phase 6 prereq-check phase.
+    pub tmux_still_missing: bool,
+    /// The `--yes` flag (explicit non-interactive consent).
+    pub yes: bool,
+    /// Whether `--json` mode is active.
+    pub json: bool,
+    /// Whether stdin is an interactive terminal we could prompt on.
+    pub is_tty: bool,
+}
+
+/// The verdict of the tmux-gap decision.
+///
+/// Why: Separates the *decision* from prompting/printing/exiting so
+/// `install::run` can be tested without a real terminal or process exit.
+///
+/// What: See the module doc for the meaning of each variant.
+///
+/// Test: `tests::decide_*`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TmuxGapAction {
+    /// Nothing to do.
+    None,
+    /// `--yes` given, tmux still missing: abort before installing anything
+    /// else, with one clear message (human and `--json`).
+    FailEarly,
+    /// Interactive TTY, no `--yes`: ask whether to continue anyway.
+    PromptContinue,
+    /// Non-interactive, no `--yes`, human output: print an informational
+    /// warning (the install_gate refuses this combination immediately
+    /// afterward regardless).
+    WarnAndContinue,
+}
+
+/// The pure tmux-gap decision (#3821 fail-early fix).
+///
+/// Why: THE property #3821 asks for: a non-interactive (`--yes`) install
+/// must never silently limp forward once it is clear trusty-mpm's tmux
+/// requirement cannot be met, only to report a confusing generic failure
+/// after installing everything else. Encoding the rule as one pure function
+/// makes it auditable and testable independent of any process side effect.
+///
+/// What:
+/// 1. `!mpm_selected || !tmux_still_missing` → [`TmuxGapAction::None`] (no
+///    gap to act on).
+/// 2. `yes` → [`TmuxGapAction::FailEarly`] (json or not — the caller shapes
+///    the message per output mode, but always aborts before installing).
+/// 3. `!json && is_tty` → [`TmuxGapAction::PromptContinue`].
+/// 4. `!json` (remaining case: no TTY, no `--yes`) →
+///    [`TmuxGapAction::WarnAndContinue`].
+/// 5. `json` (remaining case) → [`TmuxGapAction::None`] (machine output
+///    stays silent here; `decide_install_gate` refuses this combination
+///    immediately afterward).
+///
+/// Test: `tests::decide_yes_fails_early`, `tests::decide_tty_prompts`,
+/// `tests::decide_non_tty_warns`, `tests::decide_json_no_yes_is_silent`,
+/// `tests::decide_no_gap_when_present_or_unselected`.
+pub fn decide_tmux_gap_action(inputs: TmuxGapInputs) -> TmuxGapAction {
+    if !inputs.mpm_selected || !inputs.tmux_still_missing {
+        return TmuxGapAction::None;
+    }
+    if inputs.yes {
+        return TmuxGapAction::FailEarly;
+    }
+    if !inputs.json && inputs.is_tty {
+        return TmuxGapAction::PromptContinue;
+    }
+    if !inputs.json {
+        return TmuxGapAction::WarnAndContinue;
+    }
+    TmuxGapAction::None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> TmuxGapInputs {
+        TmuxGapInputs {
+            mpm_selected: true,
+            tmux_still_missing: true,
+            yes: false,
+            json: false,
+            is_tty: false,
+        }
+    }
+
+    /// Why: `--yes` (the piped `curl | sh -s -- -y` demo path, #3821's exact
+    /// repro) must always fail early, TTY or not, json or not — this is the
+    /// core fix.
+    /// What: `yes: true` across all json/is_tty combinations yields
+    /// `FailEarly`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_yes_fails_early() {
+        for json in [true, false] {
+            for is_tty in [true, false] {
+                let inputs = TmuxGapInputs {
+                    yes: true,
+                    json,
+                    is_tty,
+                    ..base()
+                };
+                assert_eq!(
+                    decide_tmux_gap_action(inputs),
+                    TmuxGapAction::FailEarly,
+                    "json={json} is_tty={is_tty}"
+                );
+            }
+        }
+    }
+
+    /// Why: an interactive operator without `--yes` can see and answer a
+    /// prompt — offer to continue anyway rather than aborting unconditionally.
+    /// What: `yes: false, json: false, is_tty: true` yields `PromptContinue`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_tty_prompts() {
+        let inputs = TmuxGapInputs {
+            is_tty: true,
+            ..base()
+        };
+        assert_eq!(
+            decide_tmux_gap_action(inputs),
+            TmuxGapAction::PromptContinue
+        );
+    }
+
+    /// Why: no TTY and no `--yes` (human output) still deserves a warning in
+    /// the log even though `decide_install_gate` refuses the overall install
+    /// moments later — best-effort context, never a hard gate here.
+    /// What: `yes: false, json: false, is_tty: false` yields
+    /// `WarnAndContinue`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_non_tty_warns() {
+        assert_eq!(
+            decide_tmux_gap_action(base()),
+            TmuxGapAction::WarnAndContinue
+        );
+    }
+
+    /// Why: `--json` without `--yes` must stay silent here — a human warning
+    /// line has no place in machine-readable output, and
+    /// `decide_install_gate` refuses this combination regardless.
+    /// What: `yes: false, json: true` (either `is_tty`) yields `None`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_json_no_yes_is_silent() {
+        for is_tty in [true, false] {
+            let inputs = TmuxGapInputs {
+                json: true,
+                is_tty,
+                ..base()
+            };
+            assert_eq!(decide_tmux_gap_action(inputs), TmuxGapAction::None);
+        }
+    }
+
+    /// Why: no gap exists when tmux is present, or when trusty-mpm was never
+    /// selected — the action must be a no-op even under `--yes`.
+    /// What: `tmux_still_missing: false` and `mpm_selected: false` (each with
+    /// `yes: true`) both yield `None`.
+    /// Test: This is the test.
+    #[test]
+    fn decide_no_gap_when_present_or_unselected() {
+        let tmux_present = TmuxGapInputs {
+            tmux_still_missing: false,
+            yes: true,
+            ..base()
+        };
+        assert_eq!(decide_tmux_gap_action(tmux_present), TmuxGapAction::None);
+
+        let mpm_not_selected = TmuxGapInputs {
+            mpm_selected: false,
+            yes: true,
+            ..base()
+        };
+        assert_eq!(
+            decide_tmux_gap_action(mpm_not_selected),
+            TmuxGapAction::None
+        );
+    }
+}

--- a/crates/trusty-installer/src/commands/tmux_gap.rs
+++ b/crates/trusty-installer/src/commands/tmux_gap.rs
@@ -119,6 +119,33 @@ pub fn decide_tmux_gap_action(inputs: TmuxGapInputs) -> TmuxGapAction {
     TmuxGapAction::None
 }
 
+/// Build the `--json` error payload for a [`TmuxGapAction::FailEarly`].
+///
+/// Why (#3821 finding 2, code-critic MEDIUM on PR #3879): when a package
+/// manager IS present but the auto-install attempt itself fails
+/// (network/disk/permissions), the static `hint` alone ("Homebrew
+/// required...") is misleading — it reads as "no brew found" even though
+/// brew ran and failed for some other reason. The captured error
+/// (`Missing.detail`) must reach `--json` consumers as a field DISTINCT from
+/// `hint`, never silently dropped.
+///
+/// What: `hint` is always the static, platform-appropriate manual note;
+/// `detail` is `Some(captured stderr)` only when an auto-install attempt was
+/// actually made and failed, `None` when no attempt was possible at all
+/// (e.g. no package manager detected) — serialised as JSON `null` in that
+/// case, never conflated with `hint`.
+///
+/// Test: `tests::fail_early_json_no_package_manager_has_null_detail`,
+/// `tests::fail_early_json_attempt_failed_carries_detail`.
+pub fn fail_early_json_payload(error: &str, hint: &str, detail: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "command": "install",
+        "error": error,
+        "hint": hint,
+        "detail": detail,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,6 +254,53 @@ mod tests {
         assert_eq!(
             decide_tmux_gap_action(mpm_not_selected),
             TmuxGapAction::None
+        );
+    }
+
+    /// Why (#3821 finding 2): the no-package-manager case must carry a
+    /// `null` `detail` — never a fabricated or reused-`hint` value — so a
+    /// `--json` consumer can tell "no attempt was possible" apart from "an
+    /// attempt was made and failed".
+    /// What: `detail: None` in; asserts `hint` is set and `detail` is JSON
+    /// `null`.
+    /// Test: This is the test.
+    #[test]
+    fn fail_early_json_no_package_manager_has_null_detail() {
+        let payload = fail_early_json_payload(
+            "tmux is required for trusty-mpm",
+            "Install tmux: `brew install tmux` (Homebrew required — https://brew.sh)",
+            None,
+        );
+        assert_eq!(
+            payload["hint"],
+            "Install tmux: `brew install tmux` (Homebrew required — https://brew.sh)"
+        );
+        assert!(
+            payload["detail"].is_null(),
+            "expected null detail, got: {payload}"
+        );
+    }
+
+    /// Why (#3821 finding 2 — the core fix): when an auto-install attempt
+    /// WAS made and failed, the real captured error must reach `--json`
+    /// output as a field distinct from the static `hint`, never dropped.
+    /// What: `detail: Some(captured stderr)` in; asserts `detail` carries it
+    /// verbatim and is NOT equal to `hint`.
+    /// Test: This is the test.
+    #[test]
+    fn fail_early_json_attempt_failed_carries_detail() {
+        let payload = fail_early_json_payload(
+            "tmux is required for trusty-mpm",
+            "Install tmux: `brew install tmux` (Homebrew required — https://brew.sh)",
+            Some("brew install tmux: Permission denied @ dir_s_mkdir - /usr/local/Cellar"),
+        );
+        assert_eq!(
+            payload["detail"],
+            "brew install tmux: Permission denied @ dir_s_mkdir - /usr/local/Cellar"
+        );
+        assert_ne!(
+            payload["detail"], payload["hint"],
+            "detail must never be conflated with the static hint"
         );
     }
 }


### PR DESCRIPTION
## Summary

On a clean macOS machine with no Homebrew, `curl install.sh | sh -s -- -y` detected tmux missing, printed only a static `Install tmux: brew install tmux (Homebrew required — https://brew.sh)` hint, then **continued installing the rest of the stable set anyway** — the actual failure only surfaced at the very end (exit 2, from the post-install verify tail finding trusty-mpm's session management unhealthy), with no message connecting it back to tmux. On a truly clean box (no brew either) this was a dead end.

## Decision tree implemented

Under `-y` (non-interactive / the piped `curl | sh -s -- -y` demo path):
- **brew present** → `brew install tmux` auto-installs, exactly as before (Phase 6's existing `has_auto_cmd` + `auto_yes` machinery — unchanged).
- **brew absent** → evaluated bootstrapping Homebrew non-interactively or a static tmux fallback, and rejected both honestly: the Homebrew installer needs sudo/CLT and can prompt, so auto-bootstrapping it under a piped, unattended `-y` is not safe, and this codebase has no existing static-binary tmux install path. → **FAIL EARLY**, before any install side effect, with one clear, platform-specific actionable message (reusing the hint Phase 6 already computes), instead of limping through the rest of the install only to exit 2 later.
- **auto-install attempted but the exec itself fails** (brew present, but e.g. permissions) → same fail-early path — "not automatable on this box" covers both "no package manager" and "attempted and failed".

Interactive mode (TTY, no `-y`): unchanged — Phase 6 already prompts `Install tmux now? (will run: brew install tmux)` with visible output when brew is present; when tmux remains missing after any attempt, the operator is asked "Continue install anyway?" (they can see the situation and decide, unlike an unattended `-y` run).

Implementation: a new pure decision function `commands::tmux_gap::decide_tmux_gap_action` (mirrors the existing `install_gate::decide_install_gate` pattern) takes `{mpm_selected, tmux_still_missing, yes, json, is_tty}` and returns `None | FailEarly | PromptContinue | WarnAndContinue`, called from `install::run`'s Phase 6 block before the confirmation gate / `install_all`.

**PM sign-off:** the fail-early-total-abort tradeoff (zero components installed when tmux is unmet under `-y`, rather than a partial install) is intentional — partial installs are exactly the incident class #3821 reported. Signed off by PM.

**Out of scope:** #3823 (tm needs a tmux *server* started) is a separate concern, not touched here.

## Code-critic round (WARN → both findings fixed on this branch)

1. **HIGH — silent multi-minute captured exec.** A first-run `brew install tmux` can legitimately take 1-5+ minutes (Homebrew self-update, a non-bottled build) with zero output from a plain captured `.output()` call — exactly on the piped `-y` demo path, reading as a hang. Fixed with a new `commands::prereqs::exec_heartbeat::run_captured_with_heartbeat`: spawns the child with piped (never inherited, #3830) stdout/stderr, drains both on background threads, polls `try_wait()`, and emits an installer-owned `still running: \`<cmd>\` (Ns elapsed)...` line every ~15s while the child is still running — never child stdout passthrough. `real_exec` in `prereqs/phase.rs` now delegates to this instead of a plain blocking captured call.
2. **MEDIUM — `--json` FailEarly lost the real error.** When a package manager WAS present but the install attempt itself failed (network/disk/permissions), the JSON envelope carried only the static hint ("Homebrew required"), indistinguishable from "no package manager found at all". `Missing` gained a `detail: Option<String>` field (the captured stderr, threaded from `phase.rs`'s exec `Err(e)` branch); `tmux_gap::fail_early_json_payload` now emits `hint` (static) and `detail` (attempt-specific, `null` when no attempt was possible) as distinct JSON fields.

## Test plan
- [x] `cargo test -p trusty-installer` — 478 passed, 0 failed, 4 ignored (live-network probes, pre-existing) — raw output confirmed across 3 repeated full-suite runs
- [x] New unit tests: `commands::tmux_gap::tests::*` (7 tests: the original 5-case decision matrix + 2 JSON-payload-shape tests for finding 2 — no-package-manager `detail: null` vs attempt-failed `detail: Some(...)`)
- [x] New unit tests: `commands::prereqs::exec_heartbeat::tests::*` (4 tests: `heartbeat_fires_while_child_runs` — ticks fire multiple times during a long-running child, re-run 10x clean to rule out flakiness after a poll-interval fix; `no_heartbeat_when_child_exits_fast`; `captures_stderr_into_error`; `success_returns_ok`)
- [x] `commands::prereqs::phase::tests::phase_yes_exec_failure_adds_to_still_missing` extended to assert `Missing.detail` carries the captured exec error, distinct from `Missing.hint`
- [x] `cargo clippy -p trusty-installer --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-installer --check` — clean
- [x] `scripts/check_line_cap.sh` — 0 violations (no file crossed the 500-SLOC production cap; `phase.rs` and `install.rs` are within ~15-20 lines of the cap after this change)
- [x] CHANGELOG `[Unreleased]` entries added for both findings

## Not merging
PM gates this — rides installer 0.4.10, per instructions. Do not merge.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
