### PR TITLE
feat(trusty-code): compression telemetry JSONL + durable compaction alarm (#3867, #3868)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Durable compression-effectiveness telemetry (epic #3866, Slice A #3867 +
+  Slice B #3868).** New `agent_loop::telemetry` module appends one JSONL
+  line per compression event to `~/.trusty-code/compression.jsonl` — one for
+  every `tcode-cadence` fire (`AgentLoop::maybe_cadence_compress`) and every
+  `tcode-threshold` fire (`AgentLoop::maybe_compact_transcript`), with
+  `ts`/`session_id`/`surface`/`tokens_before`/`tokens_after`/`ratio`/
+  `working_context_pct_after`/`overhead_pct_after`/`compaction_event`/
+  `duration_ms`/`rounds` fields. Emission is best-effort (never fails the
+  compaction it instruments). A threshold-compaction fire under
+  `cadence: Some(_)` also appends a durable line to
+  `~/.trusty-code/compaction_alarm.log` — the never-event alarm epic #2343
+  expects to stay empty in steady state — and `session.get_context_budget`'s
+  response gains an additive `lifetime_compaction_alarm_count` field
+  (`ContextBudgetSnapshot`) reflecting that log's lifetime, cross-session,
+  cross-restart line count, so the never-event check is reachable from the
+  one RPC that's already the front door for budget state instead of a
+  second `session.get_transcript` call.
+
 ### Fixed
 
 - **Test-only ambient-daemon leaks closed for two `run_task` tests (issue

--- a/crates/trusty-code/src/agent_loop/compaction_control.rs
+++ b/crates/trusty-code/src/agent_loop/compaction_control.rs
@@ -53,11 +53,12 @@ impl AgentLoop {
     /// derives from).
     /// Test: `agent_loop::tests::daily_driver_mode_compacts_long_running_loop`,
     /// `agent_loop::tests::parity_mode_never_compacts_even_past_threshold`,
-    /// `agent_loop::tests::forced_degradation_increments_counter_and_logs_error`,
-    /// `agent_loop::tests::cadence_none_threshold_fire_does_not_log_error`,
-    /// `agent_loop::tests::threshold_fire_writes_compression_telemetry`,
-    /// `agent_loop::tests::threshold_fire_under_cadence_records_compaction_alarm`,
-    /// `agent_loop::tests::threshold_fire_under_no_cadence_does_not_record_alarm`.
+    /// `agent_loop::tests::cadence::forced_degradation_increments_counter_and_logs_error`
+    /// (asserts the ERROR log AND both durable signals from one fire),
+    /// `agent_loop::tests::cadence::cadence_none_threshold_fire_does_not_log_error`,
+    /// `agent_loop::tests::compression_telemetry_tests::threshold_fire_under_cadence_writes_jsonl_and_alarm`,
+    /// `agent_loop::tests::compression_telemetry_tests::threshold_fire_under_no_cadence_writes_jsonl_but_no_alarm`,
+    /// `agent_loop::tests::compression_telemetry_tests::unwritable_data_dir_does_not_fail_the_loop`.
     pub(super) fn maybe_compact_transcript(&self, transcript: &mut Transcript) {
         if self.config.mode != HarnessMode::DailyDriver {
             return;
@@ -134,8 +135,8 @@ impl AgentLoop {
     /// `agent_loop::tests::cadence_fire_logs_info`,
     /// `agent_loop::tests::cadence_emits_context_budget_snapshot`,
     /// `agent_loop::tests::no_context_budget_event_when_cadence_disabled`,
-    /// `agent_loop::tests::cadence_fire_writes_compression_telemetry`,
-    /// `agent_loop::tests::cadence_tick_without_rounds_writes_no_telemetry`.
+    /// `agent_loop::tests::compression_telemetry_tests::cadence_fire_writes_compression_telemetry`,
+    /// `agent_loop::tests::compression_telemetry_tests::cadence_disabled_writes_no_cadence_telemetry`.
     pub(super) async fn maybe_cadence_compress(&self, transcript: &mut Transcript) {
         if self.config.mode != HarnessMode::DailyDriver {
             return;

--- a/crates/trusty-code/src/agent_loop/compaction_control.rs
+++ b/crates/trusty-code/src/agent_loop/compaction_control.rs
@@ -1,0 +1,190 @@
+//! `AgentLoop`'s two turn-boundary compaction entry points. Split out of
+//! `mod.rs` (issues #3867/#3868) purely to keep that production file under
+//! the crate's 500-SLOC cap as the compression-telemetry instrumentation
+//! grew it past the limit — this is a child module of `agent_loop`
+//! (declared via `#[path = ...] mod compaction_control;` in `mod.rs`), so it
+//! shares full access to `AgentLoop`'s private fields exactly as if these
+//! methods were still defined in that file. Mirrors the same split already
+//! used for `session::registry`/`registry_events.rs` and
+//! `session::protocol`/`protocol_budget.rs`.
+//! What: [`AgentLoop::maybe_compact_transcript`] (the #2308 threshold
+//! compactor's turn-boundary call, plus its #3867/#3868 telemetry) and
+//! [`AgentLoop::maybe_cadence_compress`] (the #2346 cadence compressor's
+//! turn-boundary call, plus its #3867 telemetry).
+//! Test: `agent_loop::tests::*` (unchanged — these are still `AgentLoop`
+//! methods, just physically relocated).
+
+use super::*;
+
+impl AgentLoop {
+    /// Apply non-destructive context compaction to `transcript`, gated on mode
+    /// (#2070, §5.4; reconciled with §5.9's D2 the same way `tool_definitions`
+    /// is).
+    ///
+    /// Why: The parity-spec (D2) requires `HarnessMode::Parity` runs to stay
+    /// byte-identical / full-history for cross-model benchmark fairness —
+    /// compacting would silently change what a Parity run sends after enough
+    /// turns, breaking that guarantee. `HarnessMode::DailyDriver` is
+    /// production's token-efficiency mode, so it is the only mode this method
+    /// ever calls `Transcript::maybe_compact` for. (#2349, epic #2343) Under
+    /// the #2346 cadence system a threshold fire is no longer expected in
+    /// steady state — it means cadence sizing / daemon-availability /
+    /// turn-size assumptions were violated — so this is also where that
+    /// regression signal is raised. Cadence-DISABLED contexts (`run_task`
+    /// one-shot, `Parity`, delegated sub-agent engineer loops — all
+    /// `cadence: None`) still use threshold compaction as their PRIMARY,
+    /// EXPECTED mechanism, so the error-level framing below must never apply
+    /// to them.
+    /// What: No-op under `HarnessMode::Parity`; under `HarnessMode::DailyDriver`,
+    /// delegates to `transcript.maybe_compact(&self.config.compaction)`. When
+    /// that returns `true` (a fire actually happened), unconditionally calls
+    /// `transcript.record_threshold_compaction()` (#2349's fact counter,
+    /// exposed via `session::TranscriptRecord.compaction_events` —
+    /// increments regardless of cadence), then — ONLY when
+    /// `self.config.cadence.is_some()` — emits `tracing::error!` with the
+    /// current estimated token count, the configured `token_threshold`, and
+    /// `cadence_enabled = true` for context. `cadence: None` keeps today's
+    /// existing behaviour exactly as it was before this ticket: no log at
+    /// this call site at all. (#3867/#3868) ALSO — regardless of cadence —
+    /// writes a durable `telemetry::record_threshold_event` JSONL record
+    /// (`compaction_event: true`), and, only when `cadence_enabled`, an
+    /// alongside durable alarm line (the never-event signal
+    /// `session.get_context_budget`'s `lifetime_compaction_alarm_count`
+    /// derives from).
+    /// Test: `agent_loop::tests::daily_driver_mode_compacts_long_running_loop`,
+    /// `agent_loop::tests::parity_mode_never_compacts_even_past_threshold`,
+    /// `agent_loop::tests::forced_degradation_increments_counter_and_logs_error`,
+    /// `agent_loop::tests::cadence_none_threshold_fire_does_not_log_error`,
+    /// `agent_loop::tests::threshold_fire_writes_compression_telemetry`,
+    /// `agent_loop::tests::threshold_fire_under_cadence_records_compaction_alarm`,
+    /// `agent_loop::tests::threshold_fire_under_no_cadence_does_not_record_alarm`.
+    pub(super) fn maybe_compact_transcript(&self, transcript: &mut Transcript) {
+        if self.config.mode != HarnessMode::DailyDriver {
+            return;
+        }
+        let started = Instant::now();
+        let tokens_before = compaction::estimate_total_tokens(&transcript.to_messages());
+        if !transcript.maybe_compact(&self.config.compaction) {
+            return;
+        }
+        transcript.record_threshold_compaction();
+
+        let estimated_tokens = compaction::estimate_total_tokens(&transcript.to_messages());
+        let cadence_enabled = self.config.cadence.is_some();
+        telemetry::record_threshold_event(
+            &telemetry::default_data_dir(),
+            self.session_id.clone(),
+            tokens_before,
+            estimated_tokens,
+            crate::provider::resolve_context_window(&self.config.model),
+            started.elapsed().as_millis() as u64,
+            cadence_enabled,
+        );
+
+        if cadence_enabled {
+            tracing::error!(
+                estimated_tokens,
+                token_threshold = self.config.compaction.token_threshold,
+                cadence_enabled = true,
+                "threshold compaction fired unexpectedly under cadence — this is a regression \
+                 signal: cadence sizing, daemon availability, or turn-size assumptions were \
+                 likely violated (epic #2343 expects compaction_events == 0 in steady state)"
+            );
+        }
+    }
+
+    /// Apply the #2346 cadence compressor to `transcript`, gated on mode the
+    /// SAME way [`Self::maybe_compact_transcript`] is, plus an explicit
+    /// per-run opt-in.
+    ///
+    /// Why: Cadence must respect the identical `HarnessMode::Parity` carve-out
+    /// as threshold compaction (byte-identical benchmark runs), AND must stay
+    /// off by default (`self.config.cadence == None`) so every call site that
+    /// doesn't explicitly opt in — the delegated engineer's own loop,
+    /// `run_task`'s legacy one-shot/bake-off path — sees zero behavioural
+    /// change from before this ticket. Only
+    /// `task::executor::run_and_record`'s persistent-session PM loop sets
+    /// `AgentLoopConfig.cadence = Some(_)`.
+    /// What: No-op unless `mode == HarnessMode::DailyDriver` AND
+    /// `self.config.cadence` is `Some`; otherwise resolves the model's real
+    /// context window (`crate::provider::resolve_context_window`, mirroring
+    /// `Self::maybe_compact_transcript`'s own model-aware sibling) and
+    /// delegates to `cadence::maybe_cadence_compress`, reusing
+    /// `self.config.compaction.keep_last_messages` as the shared active-zone
+    /// size rather than introducing a second, possibly-inconsistent knob.
+    /// (#2857) `cadence::maybe_cadence_compress`'s returned `CadenceOutcome`
+    /// was previously discarded entirely — its own doc says it exists "for
+    /// observability/tests", yet nothing observed it. When `outcome.fired`,
+    /// this now emits `tracing::info!` with the round count and whether the
+    /// transcript ended within budget — a notable-but-normal event (routine
+    /// scheduled compression), not a failure, hence `info` rather than
+    /// `warn`. The budget-floor-exceeded case is already `warn!`-logged
+    /// inside `cadence::enforce_budget` itself. The SAME outcome is also
+    /// forwarded to `self.sink` (when one is attached) as a
+    /// [`ContextBudgetSnapshot`], so a `session.attach`ed UI can render a live
+    /// budget indicator. Emission sits AFTER both guards above, which is what
+    /// keeps it PM-only for free: only `task::executor::run_and_record`'s
+    /// persistent-session PM loop sets `cadence: Some(_)`, so a delegated
+    /// engineer loop never emits. (#3867) ALSO — only when
+    /// `outcome.rounds > 0` (compaction work actually happened this turn) —
+    /// writes a durable `telemetry::record_cadence_event` JSONL record.
+    /// Test: `agent_loop::tests::cadence_disabled_by_default`,
+    /// `agent_loop::tests::cadence_never_fires_in_parity_mode`,
+    /// `agent_loop::tests::cadence_fires_in_daily_driver_when_configured`,
+    /// `agent_loop::tests::cadence_fire_logs_info`,
+    /// `agent_loop::tests::cadence_emits_context_budget_snapshot`,
+    /// `agent_loop::tests::no_context_budget_event_when_cadence_disabled`,
+    /// `agent_loop::tests::cadence_fire_writes_compression_telemetry`,
+    /// `agent_loop::tests::cadence_tick_without_rounds_writes_no_telemetry`.
+    pub(super) async fn maybe_cadence_compress(&self, transcript: &mut Transcript) {
+        if self.config.mode != HarnessMode::DailyDriver {
+            return;
+        }
+        let Some(cadence_cfg) = &self.config.cadence else {
+            return;
+        };
+        let started = Instant::now();
+        let tokens_before = compaction::estimate_total_tokens(&transcript.to_messages());
+        let context_window = crate::provider::resolve_context_window(&self.config.model);
+        let outcome = cadence::maybe_cadence_compress(
+            transcript,
+            cadence_cfg,
+            self.config.compaction.keep_last_messages,
+            context_window,
+        );
+        if outcome.fired {
+            tracing::info!(
+                rounds = outcome.rounds,
+                within_budget = outcome.within_budget,
+                "agent_loop: cadence compression fired (#2346)"
+            );
+        }
+
+        if outcome.rounds > 0 {
+            telemetry::record_cadence_event(
+                &telemetry::default_data_dir(),
+                self.session_id.clone(),
+                tokens_before,
+                outcome.overhead_tokens,
+                context_window,
+                started.elapsed().as_millis() as u64,
+                outcome.rounds,
+            );
+        }
+
+        let Some(sink) = &self.sink else {
+            return;
+        };
+        sink.context_budget(&ContextBudgetSnapshot {
+            context_window,
+            overhead_tokens: outcome.overhead_tokens,
+            overhead_cap_tokens: cadence_cfg.overhead_cap_tokens(context_window),
+            working_context_pct: outcome.working_context_pct(context_window),
+            overhead_pct: outcome.overhead_pct(context_window),
+            within_budget: outcome.within_budget,
+            fired: outcome.fired,
+            rounds: outcome.rounds,
+        })
+        .await;
+    }
+}

--- a/crates/trusty-code/src/agent_loop/compression_telemetry_tests.rs
+++ b/crates/trusty-code/src/agent_loop/compression_telemetry_tests.rs
@@ -1,0 +1,326 @@
+//! Loop-level integration tests for the #3867/#3868 compression-telemetry
+//! instrumentation. Split out of `tests.rs` per the crate's `_tests.rs`
+//! sibling-file convention (see `budget_tests.rs`/`cadence_tests.rs`
+//! precedent) to keep that file under the 1500-SLOC test cap. Declared as a
+//! CHILD of `agent_loop::tests` so it reuses that module's scripted-LLM/
+//! echo-tool harness (`ScriptedLlm`, `make_loop`, `registry_with_echo`,
+//! `aggressive_compaction`, …) via `use super::*` rather than duplicating it.
+//!
+//! Why: `telemetry_tests.rs` already proves the JSONL writer and the
+//! percentage/alarm helpers work in isolation; these tests prove the OTHER
+//! half — that `AgentLoop::maybe_compact_transcript`/`maybe_cadence_compress`
+//! actually call them at the right turn boundary with the right values,
+//! through a real (scripted) loop run, guarding
+//! `telemetry::DATA_DIR_ENV_VAR` with `telemetry::DATA_DIR_ENV_LOCK` for the
+//! whole async run so every write lands in an isolated temp directory
+//! instead of the real `~/.trusty-code`.
+
+use std::io::Read as _;
+
+use super::*;
+use crate::agent_loop::telemetry;
+
+fn temp_dir(label: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "tcode-compression-telemetry-loop-test-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn read_jsonl(dir: &std::path::Path) -> Vec<telemetry::CompressionEvent> {
+    let path = telemetry::compression_log_path(dir);
+    let Ok(mut f) = std::fs::File::open(&path) else {
+        return Vec::new();
+    };
+    let mut s = String::new();
+    f.read_to_string(&mut s).unwrap();
+    s.lines()
+        .map(|l| serde_json::from_str(l).expect("valid CompressionEvent JSONL line"))
+        .collect()
+}
+
+/// A threshold-compaction fire under `cadence: Some(_)` writes BOTH the
+/// existing `tracing::error!` alarm AND a durable `compaction_event: true`
+/// JSONL line, plus increments the Slice B lifetime alarm counter — pinning
+/// the exact acceptance criterion issue #3868 names: "a threshold-compaction
+/// event produces BOTH the ERROR log and the durable JSONL line."
+///
+/// Why: the ERROR log is exercised by the pre-existing
+/// `forced_degradation_increments_counter_and_logs_error`-style coverage;
+/// this test is the durability half — the JSONL record and the alarm log
+/// must exist on disk, independent of whether anyone was tailing stderr.
+/// What: runs a `DailyDriver` loop with an aggressive `CompactionConfig`
+/// (guarantees a threshold fire) AND `cadence: Some(_)` (the regression
+/// case), against an isolated `with_data_dir_env` temp dir. Asserts exactly
+/// one `tcode-threshold` JSONL line with `compaction_event: true`, and
+/// `lifetime_compaction_alarm_count >= 1`.
+#[tokio::test]
+async fn threshold_fire_under_cadence_writes_jsonl_and_alarm() {
+    let dir = temp_dir("threshold-cadence-some");
+    let mut fixtures: Vec<Value> = (0..5)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            max_turns: 10,
+            mode: crate::mode::HarnessMode::DailyDriver,
+            compaction: aggressive_compaction(),
+            cadence: Some(CadenceConfig {
+                // A huge cadence period + generous overhead fraction means
+                // cadence itself never fires, isolating this test to the
+                // threshold compactor's own behaviour while still exercising
+                // the `cadence.is_some()` branch that gates the ERROR log +
+                // alarm line.
+                cadence_turns: 1_000_000,
+                max_overhead_fraction_pct: 100,
+            }),
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    // `with_data_dir_env` (used by `telemetry_tests.rs`) only wraps a SYNC
+    // closure; running the loop is async, so this inlines the same
+    // set/run/clear sequence held across the whole async run instead.
+    {
+        let _guard = telemetry::DATA_DIR_ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
+        unsafe {
+            std::env::set_var(telemetry::DATA_DIR_ENV_VAR, &dir);
+        }
+        agent
+            .run("system prompt", "the original task")
+            .await
+            .expect("run completes");
+        unsafe {
+            std::env::remove_var(telemetry::DATA_DIR_ENV_VAR);
+        }
+    }
+
+    let events = read_jsonl(&dir);
+    let threshold_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.surface == telemetry::SURFACE_TCODE_THRESHOLD)
+        .collect();
+    assert!(
+        !threshold_events.is_empty(),
+        "expected at least one tcode-threshold JSONL line, got {events:?}"
+    );
+    for e in &threshold_events {
+        assert!(
+            e.compaction_event,
+            "every tcode-threshold record must have compaction_event: true: {e:?}"
+        );
+        // Note: unlike the cadence surface, a single threshold fire is not
+        // guaranteed to shrink the transcript below its PRE-fire size — the
+        // measurement here includes the turn just appended before this call,
+        // so `ratio` can legitimately exceed 1.0 on an aggressive-compaction
+        // test fixture. The invariant this test actually pins is
+        // `compaction_event: true` + the alarm line below, per issue #3868's
+        // acceptance criterion ("BOTH the ERROR log and the durable JSONL
+        // line").
+        let expected_ratio = if e.tokens_before == 0 {
+            0.0
+        } else {
+            e.tokens_after as f64 / e.tokens_before as f64
+        };
+        assert!((e.ratio - expected_ratio).abs() < f64::EPSILON, "{e:?}");
+    }
+
+    assert!(
+        telemetry::lifetime_compaction_alarm_count(&dir) >= 1,
+        "a threshold fire under cadence: Some(_) must record the durable alarm line"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The SAME threshold-fire scenario, but with `cadence: None` — the
+/// regression guard for issue #3868's "do not conflate the two" acceptance
+/// criterion: the JSONL record must still appear (Slice A is unconditional),
+/// but the alarm counter must stay at 0 (Slice B's alarm is
+/// `cadence: Some(_)`-only).
+#[tokio::test]
+async fn threshold_fire_under_no_cadence_writes_jsonl_but_no_alarm() {
+    let dir = temp_dir("threshold-cadence-none");
+    let mut fixtures: Vec<Value> = (0..5)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            max_turns: 10,
+            mode: crate::mode::HarnessMode::DailyDriver,
+            compaction: aggressive_compaction(),
+            cadence: None,
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    {
+        let _guard = telemetry::DATA_DIR_ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
+        unsafe {
+            std::env::set_var(telemetry::DATA_DIR_ENV_VAR, &dir);
+        }
+        agent
+            .run("system prompt", "the original task")
+            .await
+            .expect("run completes");
+        unsafe {
+            std::env::remove_var(telemetry::DATA_DIR_ENV_VAR);
+        }
+    }
+
+    let events = read_jsonl(&dir);
+    let threshold_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.surface == telemetry::SURFACE_TCODE_THRESHOLD)
+        .collect();
+    assert!(
+        !threshold_events.is_empty(),
+        "cadence: None still uses threshold compaction as its PRIMARY mechanism \
+         and must still be counted: {events:?}"
+    );
+    for e in &threshold_events {
+        assert!(e.compaction_event, "still true: {e:?}");
+    }
+
+    assert_eq!(
+        telemetry::lifetime_compaction_alarm_count(&dir),
+        0,
+        "cadence: None must never record the alarm line — it is the EXPECTED \
+         primary mechanism there, not a regression"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A cadence fire (`outcome.rounds > 0`) writes a `tcode-cadence` JSONL
+/// record with `tokens_before >= tokens_after` and a matching `ratio`.
+#[tokio::test]
+async fn cadence_fire_writes_compression_telemetry() {
+    let dir = temp_dir("cadence-fire");
+    let mut fixtures: Vec<Value> = (0..3)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            cadence: Some(CadenceConfig {
+                cadence_turns: 1,
+                ..CadenceConfig::default()
+            }),
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    {
+        let _guard = telemetry::DATA_DIR_ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
+        unsafe {
+            std::env::set_var(telemetry::DATA_DIR_ENV_VAR, &dir);
+        }
+        agent
+            .run("system prompt", "the task")
+            .await
+            .expect("run completes");
+        unsafe {
+            std::env::remove_var(telemetry::DATA_DIR_ENV_VAR);
+        }
+    }
+
+    let events = read_jsonl(&dir);
+    let cadence_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.surface == telemetry::SURFACE_TCODE_CADENCE)
+        .collect();
+    assert!(
+        !cadence_events.is_empty(),
+        "cadence_turns: 1 must fire on every turn, got {events:?}"
+    );
+    for e in &cadence_events {
+        assert!(
+            !e.compaction_event,
+            "cadence is never the alarm signal: {e:?}"
+        );
+        assert!(e.tokens_before >= e.tokens_after, "{e:?}");
+        let expected_ratio = if e.tokens_before == 0 {
+            0.0
+        } else {
+            e.tokens_after as f64 / e.tokens_before as f64
+        };
+        assert!((e.ratio - expected_ratio).abs() < f64::EPSILON, "{e:?}");
+        assert!(e.working_context_pct_after.is_some(), "{e:?}");
+        assert!(e.overhead_pct_after.is_some(), "{e:?}");
+    }
+
+    assert_eq!(
+        telemetry::lifetime_compaction_alarm_count(&dir),
+        0,
+        "a cadence fire must never touch the threshold-only alarm counter"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A cadence-DISABLED loop (`cadence: None`, the delegated engineer's
+/// default) must never write a `tcode-cadence` JSONL record.
+#[tokio::test]
+async fn cadence_disabled_writes_no_cadence_telemetry() {
+    let dir = temp_dir("cadence-disabled");
+    let mut fixtures: Vec<Value> = (0..3)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(llm, registry, AgentLoopConfig::default());
+
+    {
+        let _guard = telemetry::DATA_DIR_ENV_LOCK.lock().await;
+        // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
+        unsafe {
+            std::env::set_var(telemetry::DATA_DIR_ENV_VAR, &dir);
+        }
+        agent
+            .run("system prompt", "the task")
+            .await
+            .expect("run completes");
+        unsafe {
+            std::env::remove_var(telemetry::DATA_DIR_ENV_VAR);
+        }
+    }
+
+    let events = read_jsonl(&dir);
+    assert!(
+        events
+            .iter()
+            .all(|e| e.surface != telemetry::SURFACE_TCODE_CADENCE),
+        "cadence: None must emit no tcode-cadence records: {events:?}"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/crates/trusty-code/src/agent_loop/compression_telemetry_tests.rs
+++ b/crates/trusty-code/src/agent_loop/compression_telemetry_tests.rs
@@ -10,10 +10,9 @@
 //! percentage/alarm helpers work in isolation; these tests prove the OTHER
 //! half — that `AgentLoop::maybe_compact_transcript`/`maybe_cadence_compress`
 //! actually call them at the right turn boundary with the right values,
-//! through a real (scripted) loop run, guarding
-//! `telemetry::DATA_DIR_ENV_VAR` with `telemetry::DATA_DIR_ENV_LOCK` for the
-//! whole async run so every write lands in an isolated temp directory
-//! instead of the real `~/.trusty-code`.
+//! through a real (scripted) loop run, using
+//! `telemetry::with_data_dir_env_fut` to point every write at an isolated
+//! temp directory instead of the real `~/.trusty-code`.
 
 use std::io::Read as _;
 
@@ -51,14 +50,14 @@ fn read_jsonl(dir: &std::path::Path) -> Vec<telemetry::CompressionEvent> {
 /// the exact acceptance criterion issue #3868 names: "a threshold-compaction
 /// event produces BOTH the ERROR log and the durable JSONL line."
 ///
-/// Why: the ERROR log is exercised by the pre-existing
-/// `forced_degradation_increments_counter_and_logs_error`-style coverage;
-/// this test is the durability half — the JSONL record and the alarm log
-/// must exist on disk, independent of whether anyone was tailing stderr.
+/// Why: `agent_loop::tests::cadence::forced_degradation_increments_counter_and_logs_error`
+/// pins the ERROR-log half of this exact scenario; this test is the
+/// durability half — the JSONL record and the alarm log must exist on disk,
+/// independent of whether anyone was tailing stderr.
 /// What: runs a `DailyDriver` loop with an aggressive `CompactionConfig`
 /// (guarantees a threshold fire) AND `cadence: Some(_)` (the regression
-/// case), against an isolated `with_data_dir_env` temp dir. Asserts exactly
-/// one `tcode-threshold` JSONL line with `compaction_event: true`, and
+/// case), against an isolated `with_data_dir_env_fut` temp dir. Asserts at
+/// least one `tcode-threshold` JSONL line with `compaction_event: true`, and
 /// `lifetime_compaction_alarm_count >= 1`.
 #[tokio::test]
 async fn threshold_fire_under_cadence_writes_jsonl_and_alarm() {
@@ -90,23 +89,13 @@ async fn threshold_fire_under_cadence_writes_jsonl_and_alarm() {
         },
     );
 
-    // `with_data_dir_env` (used by `telemetry_tests.rs`) only wraps a SYNC
-    // closure; running the loop is async, so this inlines the same
-    // set/run/clear sequence held across the whole async run instead.
-    {
-        let _guard = telemetry::DATA_DIR_ENV_LOCK.lock().await;
-        // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
-        unsafe {
-            std::env::set_var(telemetry::DATA_DIR_ENV_VAR, &dir);
-        }
+    telemetry::with_data_dir_env_fut(&dir, async {
         agent
             .run("system prompt", "the original task")
             .await
             .expect("run completes");
-        unsafe {
-            std::env::remove_var(telemetry::DATA_DIR_ENV_VAR);
-        }
-    }
+    })
+    .await;
 
     let events = read_jsonl(&dir);
     let threshold_events: Vec<_> = events
@@ -173,20 +162,13 @@ async fn threshold_fire_under_no_cadence_writes_jsonl_but_no_alarm() {
         },
     );
 
-    {
-        let _guard = telemetry::DATA_DIR_ENV_LOCK.lock().await;
-        // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
-        unsafe {
-            std::env::set_var(telemetry::DATA_DIR_ENV_VAR, &dir);
-        }
+    telemetry::with_data_dir_env_fut(&dir, async {
         agent
             .run("system prompt", "the original task")
             .await
             .expect("run completes");
-        unsafe {
-            std::env::remove_var(telemetry::DATA_DIR_ENV_VAR);
-        }
-    }
+    })
+    .await;
 
     let events = read_jsonl(&dir);
     let threshold_events: Vec<_> = events
@@ -236,20 +218,13 @@ async fn cadence_fire_writes_compression_telemetry() {
         },
     );
 
-    {
-        let _guard = telemetry::DATA_DIR_ENV_LOCK.lock().await;
-        // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
-        unsafe {
-            std::env::set_var(telemetry::DATA_DIR_ENV_VAR, &dir);
-        }
+    telemetry::with_data_dir_env_fut(&dir, async {
         agent
             .run("system prompt", "the task")
             .await
             .expect("run completes");
-        unsafe {
-            std::env::remove_var(telemetry::DATA_DIR_ENV_VAR);
-        }
-    }
+    })
+    .await;
 
     let events = read_jsonl(&dir);
     let cadence_events: Vec<_> = events
@@ -299,20 +274,13 @@ async fn cadence_disabled_writes_no_cadence_telemetry() {
 
     let agent = make_loop(llm, registry, AgentLoopConfig::default());
 
-    {
-        let _guard = telemetry::DATA_DIR_ENV_LOCK.lock().await;
-        // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
-        unsafe {
-            std::env::set_var(telemetry::DATA_DIR_ENV_VAR, &dir);
-        }
+    telemetry::with_data_dir_env_fut(&dir, async {
         agent
             .run("system prompt", "the task")
             .await
             .expect("run completes");
-        unsafe {
-            std::env::remove_var(telemetry::DATA_DIR_ENV_VAR);
-        }
-    }
+    })
+    .await;
 
     let events = read_jsonl(&dir);
     assert!(
@@ -323,4 +291,70 @@ async fn cadence_disabled_writes_no_cadence_telemetry() {
     );
 
     std::fs::remove_dir_all(&dir).ok();
+}
+
+/// An unwritable telemetry data directory must never fail the loop itself
+/// (issue #3867 acceptance criteria: "a broken/unwritable log directory
+/// must not fail the compression/summarization operation itself"). This is
+/// the LOOP-level contract — `telemetry_tests.rs` already proves the
+/// writer function alone doesn't panic; this proves `AgentLoop::run` still
+/// returns `Ok` with a normal compaction/cadence outcome when telemetry
+/// emission can't land anywhere.
+///
+/// Why: `/dev/null` is a character device, never a directory, on every
+/// platform this crate targets — appending a path segment under it makes
+/// EVERY `create_dir_all`/`open` call underneath fail with `ENOTDIR`,
+/// simulating "every telemetry write fails" without touching real
+/// filesystem permissions bits (unreliable to assert portably in CI) or an
+/// embedded NUL byte (which `std::env::set_var` itself rejects with a
+/// panic, since this path must round-trip through `TCODE_TELEMETRY_DATA_DIR`
+/// — unlike `telemetry_tests.rs`'s writer-only tests, which never go
+/// through the env var and can use a NUL-byte path directly).
+/// What: runs the SAME aggressive-compaction + cadence:Some(_) scenario as
+/// `threshold_fire_under_cadence_writes_jsonl_and_alarm`, but points
+/// `TCODE_TELEMETRY_DATA_DIR` at an unwritable path. Asserts `agent.run`
+/// still completes `Ok`, and that the loop's own state (turn count via
+/// `llm.calls()`) reflects a normal run — the compaction/cadence outcome
+/// itself must be unaffected by telemetry's failure.
+#[tokio::test]
+async fn unwritable_data_dir_does_not_fail_the_loop() {
+    let bogus = std::path::PathBuf::from("/dev/null/not-a-real-dir-segment");
+    let mut fixtures: Vec<Value> = (0..5)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm.clone(),
+        registry,
+        AgentLoopConfig {
+            max_turns: 10,
+            mode: crate::mode::HarnessMode::DailyDriver,
+            compaction: aggressive_compaction(),
+            cadence: Some(CadenceConfig {
+                cadence_turns: 1,
+                ..CadenceConfig::default()
+            }),
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    let output = telemetry::with_data_dir_env_fut(&bogus, async {
+        agent.run("system prompt", "the original task").await
+    })
+    .await
+    .expect("an unwritable telemetry dir must not fail the run");
+
+    assert!(
+        !output.content.is_empty() || output.summary.is_some(),
+        "the loop must still produce a normal completed output: {output:?}"
+    );
+    assert_eq!(
+        llm.calls(),
+        6,
+        "the loop must still run its full scripted turn sequence, unaffected \
+         by telemetry write failures"
+    );
 }

--- a/crates/trusty-code/src/agent_loop/mod.rs
+++ b/crates/trusty-code/src/agent_loop/mod.rs
@@ -36,9 +36,12 @@
 
 mod cadence;
 mod compaction;
+#[path = "compaction_control.rs"]
+mod compaction_control;
 mod error;
 mod goals;
 mod sink;
+pub mod telemetry;
 mod transcript;
 
 #[cfg(test)]
@@ -50,7 +53,7 @@ mod tests;
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
@@ -215,6 +218,17 @@ pub struct AgentLoop {
     /// is the correlation key a UI must use instead. `None` falls back to
     /// `events::UNATTRIBUTED_AGENT_ID` — see [`Self::with_agent_id`].
     agent_id: Option<String>,
+    /// (#3867) This loop's session id, stamped on every durable compression-
+    /// telemetry JSONL record this loop emits (`agent_loop::telemetry`).
+    /// Separate from `agent_id`: `agent_id` is a per-SPAWN identity shared by
+    /// no other loop, while `session_id` is the session this loop's
+    /// transcript persists against — the id `session.get_context_budget`
+    /// and the rest of the daemon-facing API key off. `None` for call sites
+    /// with no session (the delegated engineer's own loop, `run_task`'s
+    /// one-shot path) — telemetry then records `session_id: null` rather
+    /// than fabricating one, per issue #3867's field notes.
+    /// Test: `agent_loop::tests::cadence_fire_writes_compression_telemetry`.
+    session_id: Option<String>,
     cancel: Option<Arc<AtomicBool>>,
     stop_signal: Option<Arc<dyn Fn() -> bool + Send + Sync>>,
     finish_gate: Option<FinishGate>,
@@ -254,6 +268,7 @@ impl AgentLoop {
             sink: None,
             agent: None,
             agent_id: None,
+            session_id: None,
             cancel: None,
             stop_signal: None,
             finish_gate: None,
@@ -338,6 +353,27 @@ impl AgentLoop {
         self.agent_id
             .as_deref()
             .unwrap_or(crate::events::UNATTRIBUTED_AGENT_ID)
+    }
+
+    /// Declare this loop's session id, stamped on every durable
+    /// compression-telemetry JSONL record it emits (issue #3867).
+    ///
+    /// Why: `telemetry::CompressionEvent.session_id` needs "tcode's real
+    /// session id" per the issue's schema notes, but `AgentLoop` itself is
+    /// deliberately session-agnostic everywhere else (see `sink.rs`'s doc
+    /// note: "a session id the engine layer must not know about") — this
+    /// mirrors [`Self::with_agent_id`]'s existing precedent of accepting a
+    /// caller-supplied identity as an explicit opt-in rather than reaching
+    /// into a session layer this crate's lower engine module must not
+    /// depend on.
+    /// What: Builder-style setter; returns `self` for chaining. Unset loops
+    /// emit `session_id: None` on every telemetry record — never a
+    /// fabricated id (issue #3867: "`null` is acceptable when no natural id
+    /// exists, but never fabricate one").
+    /// Test: `agent_loop::tests::cadence_fire_writes_compression_telemetry`.
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
     }
 
     /// Attach a cancellation flag checked once per turn boundary (#2056).
@@ -772,138 +808,6 @@ impl AgentLoop {
                 .await;
         }
         transcript.push_tool_result(call_id, tool, &message);
-    }
-
-    /// Apply non-destructive context compaction to `transcript`, gated on mode
-    /// (#2070, §5.4; reconciled with §5.9's D2 the same way `tool_definitions`
-    /// is).
-    ///
-    /// Why: The parity-spec (D2) requires `HarnessMode::Parity` runs to stay
-    /// byte-identical / full-history for cross-model benchmark fairness —
-    /// compacting would silently change what a Parity run sends after enough
-    /// turns, breaking that guarantee. `HarnessMode::DailyDriver` is
-    /// production's token-efficiency mode, so it is the only mode this method
-    /// ever calls `Transcript::maybe_compact` for. (#2349, epic #2343) Under
-    /// the #2346 cadence system a threshold fire is no longer expected in
-    /// steady state — it means cadence sizing / daemon-availability /
-    /// turn-size assumptions were violated — so this is also where that
-    /// regression signal is raised. Cadence-DISABLED contexts (`run_task`
-    /// one-shot, `Parity`, delegated sub-agent engineer loops — all
-    /// `cadence: None`) still use threshold compaction as their PRIMARY,
-    /// EXPECTED mechanism, so the error-level framing below must never apply
-    /// to them.
-    /// What: No-op under `HarnessMode::Parity`; under `HarnessMode::DailyDriver`,
-    /// delegates to `transcript.maybe_compact(&self.config.compaction)`. When
-    /// that returns `true` (a fire actually happened), unconditionally calls
-    /// `transcript.record_threshold_compaction()` (#2349's fact counter,
-    /// exposed via `session::TranscriptRecord.compaction_events` —
-    /// increments regardless of cadence), then — ONLY when
-    /// `self.config.cadence.is_some()` — emits `tracing::error!` with the
-    /// current estimated token count, the configured `token_threshold`, and
-    /// `cadence_enabled = true` for context. `cadence: None` keeps today's
-    /// existing behaviour exactly as it was before this ticket: no log at
-    /// this call site at all.
-    /// Test: `agent_loop::tests::daily_driver_mode_compacts_long_running_loop`,
-    /// `agent_loop::tests::parity_mode_never_compacts_even_past_threshold`,
-    /// `agent_loop::tests::forced_degradation_increments_counter_and_logs_error`,
-    /// `agent_loop::tests::cadence_none_threshold_fire_does_not_log_error`.
-    fn maybe_compact_transcript(&self, transcript: &mut Transcript) {
-        if self.config.mode != HarnessMode::DailyDriver {
-            return;
-        }
-        if !transcript.maybe_compact(&self.config.compaction) {
-            return;
-        }
-        transcript.record_threshold_compaction();
-
-        if self.config.cadence.is_some() {
-            let estimated_tokens = compaction::estimate_total_tokens(&transcript.to_messages());
-            tracing::error!(
-                estimated_tokens,
-                token_threshold = self.config.compaction.token_threshold,
-                cadence_enabled = true,
-                "threshold compaction fired unexpectedly under cadence — this is a regression \
-                 signal: cadence sizing, daemon availability, or turn-size assumptions were \
-                 likely violated (epic #2343 expects compaction_events == 0 in steady state)"
-            );
-        }
-    }
-
-    /// Apply the #2346 cadence compressor to `transcript`, gated on mode the
-    /// SAME way [`Self::maybe_compact_transcript`] is, plus an explicit
-    /// per-run opt-in.
-    ///
-    /// Why: Cadence must respect the identical `HarnessMode::Parity` carve-out
-    /// as threshold compaction (byte-identical benchmark runs), AND must stay
-    /// off by default (`self.config.cadence == None`) so every call site that
-    /// doesn't explicitly opt in — the delegated engineer's own loop,
-    /// `run_task`'s legacy one-shot/bake-off path — sees zero behavioural
-    /// change from before this ticket. Only
-    /// `task::executor::run_and_record`'s persistent-session PM loop sets
-    /// `AgentLoopConfig.cadence = Some(_)`.
-    /// What: No-op unless `mode == HarnessMode::DailyDriver` AND
-    /// `self.config.cadence` is `Some`; otherwise resolves the model's real
-    /// context window (`crate::provider::resolve_context_window`, mirroring
-    /// `Self::maybe_compact_transcript`'s own model-aware sibling) and
-    /// delegates to `cadence::maybe_cadence_compress`, reusing
-    /// `self.config.compaction.keep_last_messages` as the shared active-zone
-    /// size rather than introducing a second, possibly-inconsistent knob.
-    /// (#2857) `cadence::maybe_cadence_compress`'s returned `CadenceOutcome`
-    /// was previously discarded entirely — its own doc says it exists "for
-    /// observability/tests", yet nothing observed it. When `outcome.fired`,
-    /// this now emits `tracing::info!` with the round count and whether the
-    /// transcript ended within budget — a notable-but-normal event (routine
-    /// scheduled compression), not a failure, hence `info` rather than
-    /// `warn`. The budget-floor-exceeded case is already `warn!`-logged
-    /// inside `cadence::enforce_budget` itself. The SAME outcome is also
-    /// forwarded to `self.sink` (when one is attached) as a
-    /// [`ContextBudgetSnapshot`], so a `session.attach`ed UI can render a live
-    /// budget indicator. Emission sits AFTER both guards above, which is what
-    /// keeps it PM-only for free: only `task::executor::run_and_record`'s
-    /// persistent-session PM loop sets `cadence: Some(_)`, so a delegated
-    /// engineer loop never emits.
-    /// Test: `agent_loop::tests::cadence_disabled_by_default`,
-    /// `agent_loop::tests::cadence_never_fires_in_parity_mode`,
-    /// `agent_loop::tests::cadence_fires_in_daily_driver_when_configured`,
-    /// `agent_loop::tests::cadence_fire_logs_info`,
-    /// `agent_loop::tests::cadence_emits_context_budget_snapshot`,
-    /// `agent_loop::tests::no_context_budget_event_when_cadence_disabled`.
-    async fn maybe_cadence_compress(&self, transcript: &mut Transcript) {
-        if self.config.mode != HarnessMode::DailyDriver {
-            return;
-        }
-        let Some(cadence_cfg) = &self.config.cadence else {
-            return;
-        };
-        let context_window = crate::provider::resolve_context_window(&self.config.model);
-        let outcome = cadence::maybe_cadence_compress(
-            transcript,
-            cadence_cfg,
-            self.config.compaction.keep_last_messages,
-            context_window,
-        );
-        if outcome.fired {
-            tracing::info!(
-                rounds = outcome.rounds,
-                within_budget = outcome.within_budget,
-                "agent_loop: cadence compression fired (#2346)"
-            );
-        }
-
-        let Some(sink) = &self.sink else {
-            return;
-        };
-        sink.context_budget(&ContextBudgetSnapshot {
-            context_window,
-            overhead_tokens: outcome.overhead_tokens,
-            overhead_cap_tokens: cadence_cfg.overhead_cap_tokens(context_window),
-            working_context_pct: outcome.working_context_pct(context_window),
-            overhead_pct: outcome.overhead_pct(context_window),
-            within_budget: outcome.within_budget,
-            fired: outcome.fired,
-            rounds: outcome.rounds,
-        })
-        .await;
     }
 
     /// Build a `ChatRequest` from the running transcript and tool schemas.

--- a/crates/trusty-code/src/agent_loop/telemetry.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry.rs
@@ -387,6 +387,31 @@ pub(crate) async fn with_data_dir_env<T>(dir: &Path, f: impl FnOnce() -> T) -> T
     result
 }
 
+/// Async twin of [`with_data_dir_env`] for loop-level tests that must await
+/// an `AgentLoop::run`/`run_with_transcript` call WHILE the env var is set
+/// (a plain `FnOnce() -> T` closure cannot itself `.await`).
+///
+/// Why: without this, every loop-integration test needed to hand-inline the
+/// lock/set/run/clear sequence, duplicating the `unsafe` env mutation at
+/// each call site. Centralising it here keeps that `unsafe` block in exactly
+/// one place, matching [`with_data_dir_env`]'s same rationale.
+#[cfg(test)]
+pub(crate) async fn with_data_dir_env_fut<T>(
+    dir: &Path,
+    fut: impl std::future::Future<Output = T>,
+) -> T {
+    let _guard = DATA_DIR_ENV_LOCK.lock().await;
+    // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
+    unsafe {
+        std::env::set_var(DATA_DIR_ENV_VAR, dir);
+    }
+    let result = fut.await;
+    unsafe {
+        std::env::remove_var(DATA_DIR_ENV_VAR);
+    }
+    result
+}
+
 #[cfg(test)]
 #[path = "telemetry_tests.rs"]
 mod tests;

--- a/crates/trusty-code/src/agent_loop/telemetry.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry.rs
@@ -1,0 +1,392 @@
+//! Durable compression-effectiveness telemetry (epic #3866, Slice A #3867 +
+//! Slice B #3868).
+//!
+//! Why: `cadence::CadenceOutcome` and the #2308 threshold compactor both
+//! compute real token/ratio numbers every time they fire, and — before this
+//! module — every one of those numbers was thrown away past a
+//! `tracing::info!`/`tracing::error!` line (stderr-only, never aggregated)
+//! or an in-memory-only cache that resets on session end. Owner directive:
+//! "measure compression effectiveness, and use logging to track it." This
+//! module is the durable, structured, cross-session, machine-aggregable
+//! third channel `crate::logging`'s own "logs vs. events" doc note says
+//! `tracing`/`crate::events` cannot serve — see `crates/trusty-code/src/
+//! logging/mod.rs`.
+//! What: [`CompressionEvent`] is one JSONL record per compression/
+//! summarization event, appended (best-effort, mirroring
+//! `trusty-agents::usage::append_usage`'s failure posture exactly) to
+//! `~/.trusty-code/compression.jsonl` via [`write_compression_event`].
+//! [`record_compaction_alarm`]/[`lifetime_compaction_alarm_count`] are
+//! Slice B's durable "has threshold compaction EVER fired under cadence"
+//! never-event alarm: a dedicated append-only log
+//! (`~/.trusty-code/compaction_alarm.log`), one line per fire, counted by
+//! line rather than read-modify-write so concurrent fires can never race
+//! each other into a lost increment.
+//! Test: `telemetry::tests::*`.
+
+use std::fs::OpenOptions;
+use std::io::{BufRead, Write as _};
+use std::path::{Path, PathBuf};
+
+/// [`CompressionEvent::surface`] value for the #2346 cadence compressor.
+pub const SURFACE_TCODE_CADENCE: &str = "tcode-cadence";
+/// [`CompressionEvent::surface`] value for the #2308 threshold compactor.
+pub const SURFACE_TCODE_THRESHOLD: &str = "tcode-threshold";
+
+/// `surface_detail` used for every [`SURFACE_TCODE_CADENCE`] record.
+pub const DETAIL_CADENCE: &str = "cadence";
+/// `surface_detail` used for every [`SURFACE_TCODE_THRESHOLD`] record.
+pub const DETAIL_THRESHOLD: &str = "threshold";
+
+/// Filename of the durable compression-telemetry JSONL, under whatever data
+/// directory the caller resolves (production: `crate::workstreams::
+/// default_data_dir()`, i.e. `~/.trusty-code`).
+const COMPRESSION_LOG_FILENAME: &str = "compression.jsonl";
+
+/// Filename of Slice B's durable compaction-alarm log, one line per
+/// `cadence: Some(_)` threshold-compaction fire.
+const COMPACTION_ALARM_LOG_FILENAME: &str = "compaction_alarm.log";
+
+/// Escape-hatch env var overriding [`default_data_dir`] for one process,
+/// mirroring `cadence::CADENCE_TURNS_ENV_VAR`'s precedent. Test-only in
+/// practice (production never sets it) — lets a test point every telemetry
+/// write/read at an isolated temp directory instead of the real
+/// `~/.trusty-code`.
+pub const DATA_DIR_ENV_VAR: &str = "TCODE_TELEMETRY_DATA_DIR";
+
+/// Serializes tests that mutate [`DATA_DIR_ENV_VAR`], mirroring
+/// `cadence_env_helper::CADENCE_ENV_LOCK`'s identical rationale. `pub(crate)`
+/// (not private) so other test modules mutating the SAME env var
+/// (`agent_loop::compression_telemetry_tests`) share ONE lock —
+/// `mode::MODE_ENV_LOCK`'s identical cross-module rationale. `#[cfg(test)]`
+/// since production never touches this var at all.
+#[cfg(test)]
+pub(crate) static DATA_DIR_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// Resolve the data directory every telemetry read/write in this module
+/// uses: [`DATA_DIR_ENV_VAR`] when set (test isolation), otherwise
+/// `crate::workstreams::default_data_dir()` (`~/.trusty-code`, production).
+pub fn default_data_dir() -> PathBuf {
+    std::env::var(DATA_DIR_ENV_VAR)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| crate::workstreams::default_data_dir())
+}
+
+/// One JSONL line: a single compression/summarization event (issue #3867).
+///
+/// Why: a flat, all-primitive shape keeps the log trivially grep-able and
+/// loadable into jq/pandas/DuckDB for Slice C's report, and lets every field
+/// be asserted individually in tests without a custom deserializer.
+/// What: field names and semantics match issue #3867's schema exactly — see
+/// the issue body for the authoritative field-by-field spec. `ratio` is
+/// `tokens_after / tokens_before`, `0.0` when `tokens_before == 0` (never a
+/// divide-by-zero or NaN, mirroring `tm compress`'s `log_compression_stats`
+/// guard). `working_context_pct_after`/`overhead_pct_after` are `None` for
+/// surfaces with no `CadenceOutcome` to derive them from (`agents-ws-summary`
+/// per the issue; this crate never emits that surface).
+/// Test: `tests::compression_event_serializes_expected_schema`,
+/// `tests::ratio_guards_divide_by_zero`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct CompressionEvent {
+    pub ts: String,
+    pub session_id: Option<String>,
+    pub surface: String,
+    pub surface_detail: String,
+    pub tokens_before: usize,
+    pub tokens_after: usize,
+    pub ratio: f64,
+    pub working_context_pct_after: Option<u8>,
+    pub overhead_pct_after: Option<u8>,
+    pub compaction_event: bool,
+    pub duration_ms: u64,
+    pub rounds: usize,
+}
+
+impl CompressionEvent {
+    /// Build a record with `ts` set to "now" (RFC3339 UTC, matching
+    /// `trusty-agents::usage::UsageRecord.ts`'s convention) and `ratio`
+    /// derived via [`compute_ratio`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        session_id: Option<String>,
+        surface: &str,
+        surface_detail: &str,
+        tokens_before: usize,
+        tokens_after: usize,
+        working_context_pct_after: Option<u8>,
+        overhead_pct_after: Option<u8>,
+        compaction_event: bool,
+        duration_ms: u64,
+        rounds: usize,
+    ) -> Self {
+        Self {
+            ts: chrono::Utc::now().to_rfc3339(),
+            session_id,
+            surface: surface.to_string(),
+            surface_detail: surface_detail.to_string(),
+            tokens_before,
+            tokens_after,
+            ratio: compute_ratio(tokens_before, tokens_after),
+            working_context_pct_after,
+            overhead_pct_after,
+            compaction_event,
+            duration_ms,
+            rounds,
+        }
+    }
+}
+
+/// `tokens_after / tokens_before`, `0.0` when `tokens_before == 0`.
+///
+/// Why: never divide by zero, never produce NaN — a JSONL consumer (Slice
+/// C's report, or a human `jq`-ing the file) must never have to guard
+/// against either.
+/// Test: `tests::ratio_guards_divide_by_zero`, `tests::ratio_is_after_over_before`.
+pub fn compute_ratio(tokens_before: usize, tokens_after: usize) -> f64 {
+    if tokens_before == 0 {
+        return 0.0;
+    }
+    tokens_after as f64 / tokens_before as f64
+}
+
+/// Resolve `<data_dir>/compression.jsonl`.
+pub fn compression_log_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(COMPRESSION_LOG_FILENAME)
+}
+
+/// Resolve `<data_dir>/compaction_alarm.log`.
+pub fn compaction_alarm_log_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(COMPACTION_ALARM_LOG_FILENAME)
+}
+
+/// Append `event` as one JSONL line to `<data_dir>/compression.jsonl`.
+///
+/// Why: emission must never fail the compaction/cadence operation it
+/// instruments — this is observability, not control flow.
+/// What: best-effort `mkdir -p` of `data_dir`, then opens the file in
+/// `create + append` mode and writes one `serde_json::to_string(event)` line
+/// followed by `\n`, flushing so the bytes are visible to a concurrent
+/// reader. Any I/O or serialization failure logs at `debug!` and returns —
+/// mirrors `trusty-agents::usage::append_usage`'s failure posture exactly
+/// (issue #3867 acceptance criteria: "a broken/unwritable log directory must
+/// not fail the compression/summarization operation itself").
+/// Test: `tests::write_compression_event_creates_and_appends`,
+/// `tests::write_compression_event_unwritable_dir_does_not_panic`.
+pub fn write_compression_event(data_dir: &Path, event: &CompressionEvent) {
+    let _ = std::fs::create_dir_all(data_dir);
+    let line = match serde_json::to_string(event) {
+        Ok(s) => format!("{s}\n"),
+        Err(e) => {
+            tracing::debug!(error = %e, "compression telemetry: serialize failed");
+            return;
+        }
+    };
+    let path = compression_log_path(data_dir);
+    match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(mut f) => {
+            if let Err(e) = f.write_all(line.as_bytes()) {
+                tracing::debug!(error = %e, path = %path.display(), "compression telemetry: write failed");
+                return;
+            }
+            let _ = f.flush();
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, path = %path.display(), "compression telemetry: open failed");
+        }
+    }
+}
+
+/// Append one line to `<data_dir>/compaction_alarm.log`, recording that a
+/// `cadence: Some(_)` threshold-compaction fire just happened (issue #3868).
+///
+/// Why: a durable, cross-session, cheap-to-query answer to "has threshold
+/// compaction ever fired under cadence" needs a signal that survives past
+/// the `tracing::error!` at the call site and the in-memory `Transcript`
+/// counter, both of which reset on session end. Append-only (one line per
+/// fire, never read-modify-write) so concurrent fires from different
+/// sessions can never race each other into a lost increment — the count is
+/// always "number of lines", never a stored integer that can be
+/// clobbered by two writers reading the same stale value.
+/// What: best-effort, matching [`write_compression_event`]'s failure
+/// posture. `cadence: None` runs must NEVER call this — see
+/// `agent_loop::AgentLoop::maybe_compact_transcript`'s call site, which only
+/// reaches this function inside its `self.config.cadence.is_some()` branch.
+/// Test: `tests::record_compaction_alarm_appends_one_line_per_call`,
+/// `tests::record_compaction_alarm_unwritable_dir_does_not_panic`.
+pub fn record_compaction_alarm(data_dir: &Path) {
+    let _ = std::fs::create_dir_all(data_dir);
+    let path = compaction_alarm_log_path(data_dir);
+    let line = format!("{}\n", chrono::Utc::now().to_rfc3339());
+    match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(mut f) => {
+            if let Err(e) = f.write_all(line.as_bytes()) {
+                tracing::debug!(error = %e, path = %path.display(), "compaction alarm: write failed");
+                return;
+            }
+            let _ = f.flush();
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, path = %path.display(), "compaction alarm: open failed");
+        }
+    }
+}
+
+/// Count how many times [`record_compaction_alarm`] has ever fired for
+/// `data_dir` — the lifetime, cross-session, cross-restart alarm count
+/// exposed on `session.get_context_budget` as `lifetime_compaction_alarm_count`
+/// (issue #3868).
+///
+/// Why: reading a line count from disk on every query is cheap (this is
+/// meant to stay a NEVER-event — the file should almost always be empty or
+/// absent) and trivially correct — no separate stored counter that could
+/// drift from the log it's supposedly summarizing.
+/// What: `0` when the file is missing or unreadable (never an error — a
+/// fresh install with no alarm history is the common case, not a fault);
+/// otherwise the number of non-empty lines.
+/// Test: `tests::lifetime_compaction_alarm_count_zero_when_missing`,
+/// `tests::lifetime_compaction_alarm_count_matches_fire_count`.
+pub fn lifetime_compaction_alarm_count(data_dir: &Path) -> u64 {
+    let path = compaction_alarm_log_path(data_dir);
+    let Ok(file) = std::fs::File::open(&path) else {
+        return 0;
+    };
+    std::io::BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|l| !l.trim().is_empty())
+        .count() as u64
+}
+
+/// Derive `(working_context_pct, overhead_pct)` from a raw token measurement
+/// against a model's context window, mirroring
+/// `cadence::CadenceOutcome::working_context_pct`/`overhead_pct`'s own
+/// saturating arithmetic (never a divide-by-zero, never > 100).
+///
+/// Why: shared by both `AgentLoop::maybe_compact_transcript` (which has no
+/// `CadenceOutcome` to read these from) and callers that already have one,
+/// so the two call sites' percentages can never drift apart from cadence's
+/// own formula.
+/// What: `(None, None)` for a zero `context_window` (percentages are
+/// meaningless without a real window); otherwise `overhead_pct =
+/// (tokens * 100 / context_window).min(100)`, `working_context_pct = 100 -
+/// overhead_pct`.
+/// Test: `tests::context_pcts_zero_window_is_none`,
+/// `tests::context_pcts_matches_saturating_formula`.
+pub fn context_pcts(tokens: usize, context_window: usize) -> (Option<u8>, Option<u8>) {
+    if context_window == 0 {
+        return (None, None);
+    }
+    let overhead_pct = (tokens.saturating_mul(100) / context_window).min(100) as u8;
+    (Some(100 - overhead_pct), Some(overhead_pct))
+}
+
+/// Build and emit the [`SURFACE_TCODE_THRESHOLD`] telemetry record for one
+/// `AgentLoop::maybe_compact_transcript` fire, and — when `cadence_enabled`
+/// — the Slice B durable alarm line alongside it (issues #3867, #3868).
+///
+/// Why: keeps `AgentLoop::maybe_compact_transcript` a thin call rather than
+/// inlining the event construction + percentage derivation at that call
+/// site (this crate's 500-SLOC production file cap).
+/// What: `compaction_event` is always `true` (issue #3867: `true` only for
+/// `tcode-threshold` fires — this function is only ever called on one).
+/// `cadence_enabled` gates the alarm line only — the JSONL record itself is
+/// unconditional, per issue #3867's spec.
+/// Test: `tests::record_threshold_event_writes_jsonl_and_alarm_when_cadence_enabled`,
+/// `tests::record_threshold_event_no_alarm_when_cadence_disabled`.
+#[allow(clippy::too_many_arguments)]
+pub fn record_threshold_event(
+    data_dir: &Path,
+    session_id: Option<String>,
+    tokens_before: usize,
+    tokens_after: usize,
+    context_window: usize,
+    duration_ms: u64,
+    cadence_enabled: bool,
+) {
+    let (working_context_pct_after, overhead_pct_after) =
+        context_pcts(tokens_after, context_window);
+    write_compression_event(
+        data_dir,
+        &CompressionEvent::new(
+            session_id,
+            SURFACE_TCODE_THRESHOLD,
+            DETAIL_THRESHOLD,
+            tokens_before,
+            tokens_after,
+            working_context_pct_after,
+            overhead_pct_after,
+            true,
+            duration_ms,
+            1,
+        ),
+    );
+    if cadence_enabled {
+        record_compaction_alarm(data_dir);
+    }
+}
+
+/// Build and emit the [`SURFACE_TCODE_CADENCE`] telemetry record for one
+/// `AgentLoop::maybe_cadence_compress` call whose `outcome.rounds > 0`
+/// (issue #3867).
+///
+/// Why: same file-size rationale as [`record_threshold_event`].
+/// What: `compaction_event` is always `false` (cadence fires are never the
+/// Slice B alarm signal). Caller must only invoke this when
+/// `outcome.rounds > 0` — see the issue's "only emit when something
+/// actually happened" note.
+/// Test: `tests::record_cadence_event_writes_jsonl`.
+#[allow(clippy::too_many_arguments)]
+pub fn record_cadence_event(
+    data_dir: &Path,
+    session_id: Option<String>,
+    tokens_before: usize,
+    tokens_after: usize,
+    context_window: usize,
+    duration_ms: u64,
+    rounds: usize,
+) {
+    let (working_context_pct_after, overhead_pct_after) =
+        context_pcts(tokens_after, context_window);
+    write_compression_event(
+        data_dir,
+        &CompressionEvent::new(
+            session_id,
+            SURFACE_TCODE_CADENCE,
+            DETAIL_CADENCE,
+            tokens_before,
+            tokens_after,
+            working_context_pct_after,
+            overhead_pct_after,
+            false,
+            duration_ms,
+            rounds,
+        ),
+    );
+}
+
+/// Test-only helper: run `f` with [`DATA_DIR_ENV_VAR`] pointed at `dir`,
+/// serialized on [`DATA_DIR_ENV_LOCK`] so parallel `cargo test` threads never
+/// race each other's env mutation — mirrors
+/// `cadence_env_helper::with_cadence_env`'s identical rationale.
+///
+/// Why: production telemetry always writes/reads real `~/.trusty-code`; any
+/// test exercising `AgentLoop::maybe_compact_transcript`/
+/// `maybe_cadence_compress` or `SessionRegistry::record_context_budget` end
+/// to end needs an isolated directory instead, without a second production
+/// code path.
+#[cfg(test)]
+pub(crate) async fn with_data_dir_env<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
+    let _guard = DATA_DIR_ENV_LOCK.lock().await;
+    // SAFETY: test-only env mutation, serialized by `DATA_DIR_ENV_LOCK`.
+    unsafe {
+        std::env::set_var(DATA_DIR_ENV_VAR, dir);
+    }
+    let result = f();
+    unsafe {
+        std::env::remove_var(DATA_DIR_ENV_VAR);
+    }
+    result
+}
+
+#[cfg(test)]
+#[path = "telemetry_tests.rs"]
+mod tests;

--- a/crates/trusty-code/src/agent_loop/telemetry_tests.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry_tests.rs
@@ -1,0 +1,314 @@
+//! Tests for `agent_loop::telemetry` (issues #3867, #3868).
+
+use super::*;
+use std::io::Read as _;
+
+fn temp_dir(label: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "tcode-telemetry-test-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn read_lines(path: &Path) -> Vec<String> {
+    let mut s = String::new();
+    std::fs::File::open(path)
+        .unwrap()
+        .read_to_string(&mut s)
+        .unwrap();
+    s.lines().map(str::to_string).collect()
+}
+
+// -- CompressionEvent / ratio --
+
+#[test]
+fn ratio_guards_divide_by_zero() {
+    assert_eq!(compute_ratio(0, 0), 0.0);
+    assert_eq!(compute_ratio(0, 500), 0.0);
+}
+
+#[test]
+fn ratio_is_after_over_before() {
+    let r = compute_ratio(100, 55);
+    assert!((r - 0.55).abs() < f64::EPSILON);
+}
+
+#[test]
+fn compression_event_serializes_expected_schema() {
+    let event = CompressionEvent::new(
+        Some("sess-1".to_string()),
+        SURFACE_TCODE_CADENCE,
+        DETAIL_CADENCE,
+        1000,
+        400,
+        Some(72),
+        Some(28),
+        false,
+        3,
+        1,
+    );
+    let value: serde_json::Value = serde_json::to_value(&event).unwrap();
+    for key in [
+        "ts",
+        "session_id",
+        "surface",
+        "surface_detail",
+        "tokens_before",
+        "tokens_after",
+        "ratio",
+        "working_context_pct_after",
+        "overhead_pct_after",
+        "compaction_event",
+        "duration_ms",
+        "rounds",
+    ] {
+        assert!(value.get(key).is_some(), "missing field {key}");
+    }
+    assert_eq!(value["surface"], "tcode-cadence");
+    assert_eq!(value["tokens_before"], 1000);
+    assert_eq!(value["tokens_after"], 400);
+    assert_eq!(value["ratio"], 0.4);
+}
+
+#[test]
+fn compression_event_round_trips_through_serde() {
+    let event = CompressionEvent::new(
+        None,
+        SURFACE_TCODE_THRESHOLD,
+        DETAIL_THRESHOLD,
+        900,
+        900,
+        None,
+        None,
+        true,
+        7,
+        1,
+    );
+    let json = serde_json::to_string(&event).unwrap();
+    let back: CompressionEvent = serde_json::from_str(&json).unwrap();
+    assert_eq!(event, back);
+}
+
+// -- write_compression_event --
+
+#[test]
+fn write_compression_event_creates_and_appends() {
+    let dir = temp_dir("write-append");
+    let event = CompressionEvent::new(
+        Some("s".to_string()),
+        SURFACE_TCODE_CADENCE,
+        DETAIL_CADENCE,
+        100,
+        50,
+        Some(60),
+        Some(40),
+        false,
+        1,
+        1,
+    );
+    write_compression_event(&dir, &event);
+    write_compression_event(&dir, &event);
+
+    let lines = read_lines(&compression_log_path(&dir));
+    assert_eq!(lines.len(), 2, "one JSONL line per emitted event");
+    for line in &lines {
+        let parsed: CompressionEvent = serde_json::from_str(line).unwrap();
+        assert_eq!(parsed.surface, SURFACE_TCODE_CADENCE);
+    }
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn write_compression_event_unwritable_dir_does_not_panic() {
+    // A path with a NUL byte can never be created/opened by the OS; this
+    // simulates an unwritable log directory without touching real
+    // filesystem permissions bits (which are unreliable to assert on CI).
+    let bogus = PathBuf::from("/dev/null/not-a-real-dir-\0-segment");
+    let event = CompressionEvent::new(
+        None,
+        SURFACE_TCODE_THRESHOLD,
+        DETAIL_THRESHOLD,
+        10,
+        10,
+        None,
+        None,
+        true,
+        1,
+        1,
+    );
+    // Must not panic — best-effort emission swallows the failure.
+    write_compression_event(&bogus, &event);
+}
+
+// -- compaction alarm --
+
+#[test]
+fn record_compaction_alarm_appends_one_line_per_call() {
+    let dir = temp_dir("alarm-append");
+    assert_eq!(lifetime_compaction_alarm_count(&dir), 0);
+
+    record_compaction_alarm(&dir);
+    assert_eq!(lifetime_compaction_alarm_count(&dir), 1);
+
+    record_compaction_alarm(&dir);
+    record_compaction_alarm(&dir);
+    assert_eq!(lifetime_compaction_alarm_count(&dir), 3);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn record_compaction_alarm_unwritable_dir_does_not_panic() {
+    let bogus = PathBuf::from("/dev/null/not-a-real-dir-\0-segment");
+    record_compaction_alarm(&bogus);
+}
+
+#[test]
+fn lifetime_compaction_alarm_count_zero_when_missing() {
+    let dir = temp_dir("alarm-missing");
+    assert_eq!(lifetime_compaction_alarm_count(&dir), 0);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn lifetime_compaction_alarm_count_matches_fire_count() {
+    let dir = temp_dir("alarm-persist");
+    for _ in 0..5 {
+        record_compaction_alarm(&dir);
+    }
+    // A fresh read (simulating a new process / daemon restart reading the
+    // same durable file) must see the same count, not reset to 0.
+    assert_eq!(lifetime_compaction_alarm_count(&dir), 5);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// -- context_pcts --
+
+#[test]
+fn context_pcts_zero_window_is_none() {
+    assert_eq!(context_pcts(1000, 0), (None, None));
+}
+
+#[test]
+fn context_pcts_matches_saturating_formula() {
+    // 50_000 / 200_000 = 25% overhead, 75% working.
+    assert_eq!(context_pcts(50_000, 200_000), (Some(75), Some(25)));
+}
+
+#[test]
+fn context_pcts_saturates_at_100() {
+    // Tokens far exceeding the window must never overflow/panic and must
+    // saturate at 100/0, mirroring `CadenceOutcome::overhead_pct`'s own
+    // saturating arithmetic.
+    assert_eq!(context_pcts(10_000_000, 1000), (Some(0), Some(100)));
+}
+
+// -- record_threshold_event / record_cadence_event --
+
+#[test]
+fn record_threshold_event_writes_jsonl_and_alarm_when_cadence_enabled() {
+    let dir = temp_dir("threshold-cadence-enabled");
+    record_threshold_event(
+        &dir,
+        Some("sess-x".to_string()),
+        1000,
+        900,
+        200_000,
+        5,
+        true,
+    );
+
+    let lines = read_lines(&compression_log_path(&dir));
+    assert_eq!(lines.len(), 1);
+    let event: CompressionEvent = serde_json::from_str(&lines[0]).unwrap();
+    assert_eq!(event.surface, SURFACE_TCODE_THRESHOLD);
+    assert_eq!(event.surface_detail, DETAIL_THRESHOLD);
+    assert!(
+        event.compaction_event,
+        "threshold events are always compaction_event: true"
+    );
+    assert_eq!(event.tokens_before, 1000);
+    assert_eq!(event.tokens_after, 900);
+
+    assert_eq!(
+        lifetime_compaction_alarm_count(&dir),
+        1,
+        "cadence_enabled=true must also record the durable alarm line"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn record_threshold_event_no_alarm_when_cadence_disabled() {
+    let dir = temp_dir("threshold-cadence-disabled");
+    record_threshold_event(&dir, None, 1000, 900, 200_000, 5, false);
+
+    let lines = read_lines(&compression_log_path(&dir));
+    assert_eq!(lines.len(), 1, "the JSONL record is unconditional");
+    let event: CompressionEvent = serde_json::from_str(&lines[0]).unwrap();
+    assert!(
+        event.compaction_event,
+        "compaction_event is still true — it marks a tcode-threshold fire, not the cadence-alarm gate"
+    );
+
+    assert_eq!(
+        lifetime_compaction_alarm_count(&dir),
+        0,
+        "cadence: None must never record the alarm line (issue #3868 acceptance criteria)"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn record_cadence_event_writes_jsonl() {
+    let dir = temp_dir("cadence-event");
+    record_cadence_event(&dir, Some("sess-y".to_string()), 2000, 800, 200_000, 3, 2);
+
+    let lines = read_lines(&compression_log_path(&dir));
+    assert_eq!(lines.len(), 1);
+    let event: CompressionEvent = serde_json::from_str(&lines[0]).unwrap();
+    assert_eq!(event.surface, SURFACE_TCODE_CADENCE);
+    assert_eq!(event.surface_detail, DETAIL_CADENCE);
+    assert!(
+        !event.compaction_event,
+        "cadence fires are never the Slice B alarm signal"
+    );
+    assert_eq!(event.rounds, 2);
+    assert!((event.ratio - 0.4).abs() < f64::EPSILON);
+
+    assert_eq!(
+        lifetime_compaction_alarm_count(&dir),
+        0,
+        "a cadence fire must never increment the threshold-only alarm counter"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+// -- default_data_dir / DATA_DIR_ENV_VAR --
+
+#[tokio::test]
+async fn default_data_dir_honors_env_override() {
+    let dir = temp_dir("default-data-dir-override");
+    let observed = with_data_dir_env(&dir, default_data_dir).await;
+    assert_eq!(observed, dir);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn default_data_dir_falls_back_to_workstreams_default_when_unset() {
+    // Not wrapped in `with_data_dir_env` — the var must be unset here for
+    // this assertion to be meaningful; guarded by not running in parallel
+    // with the override test via `DATA_DIR_ENV_LOCK` in practice, but this
+    // check only reads, so a stray leaked override would only make it fail
+    // loudly rather than silently pass.
+    if std::env::var(DATA_DIR_ENV_VAR).is_ok() {
+        return;
+    }
+    assert_eq!(default_data_dir(), crate::workstreams::default_data_dir());
+}

--- a/crates/trusty-code/src/agent_loop/tests.rs
+++ b/crates/trusty-code/src/agent_loop/tests.rs
@@ -1947,3 +1947,6 @@ async fn run_with_transcript_does_not_clobber_finish_task_summary() {
 
 #[path = "budget_tests.rs"]
 mod budget_tests;
+
+#[path = "compression_telemetry_tests.rs"]
+mod compression_telemetry_tests;

--- a/crates/trusty-code/src/agent_loop/tests/cadence.rs
+++ b/crates/trusty-code/src/agent_loop/tests/cadence.rs
@@ -222,18 +222,28 @@ fn overwhelmed_cadence() -> CadenceConfig {
 /// schedules a fire (`overwhelmed_cadence`), while `aggressive_compaction`'s
 /// `token_threshold: 1` trips the #2308 threshold compactor on the very
 /// first turn boundary. This must increment
-/// `Transcript::compaction_events()` AND emit an ERROR-level log — the
+/// `Transcript::compaction_events()`, emit an ERROR-level log — the
 /// "cadence sizing / daemon-availability / turn-size assumptions violated"
-/// regression signal.
+/// regression signal — AND (issues #3867/#3868) durably record BOTH a
+/// `compaction_event: true` JSONL line and the alarm-log line, from the SAME
+/// fire.
 ///
 /// Why: This is #2349's core acceptance criterion — proving the signal
 /// actually fires end-to-end through `AgentLoop::maybe_compact_transcript`,
-/// not just at the `Transcript` unit level.
+/// not just at the `Transcript` unit level. #3868's acceptance criterion is
+/// explicit that a threshold-compaction fire must produce BOTH the ERROR log
+/// and the durable JSONL line — asserting both signals in this ONE test
+/// (rather than splitting them across separate tests) is what makes
+/// reordering or dropping either signal at the `compaction_control.rs` call
+/// site fail a test, instead of two independently-passable partial checks.
 /// What: Runs a 3-tool-call-then-stop script under `mode: DailyDriver` with
 /// both `compaction: aggressive_compaction()` and
-/// `cadence: Some(overwhelmed_cadence())` attached. Asserts
-/// `transcript.compaction_events() > 0` and that the captured ERROR-level
-/// log messages contain the expected "regression signal" text.
+/// `cadence: Some(overwhelmed_cadence())` attached, with
+/// `telemetry::DATA_DIR_ENV_VAR` pointed at an isolated temp dir for the
+/// whole run. Asserts `transcript.compaction_events() > 0`, the captured
+/// ERROR-level log text, a `tcode-threshold`/`compaction_event: true` JSONL
+/// line, AND `lifetime_compaction_alarm_count >= 1` — all from this one
+/// fire.
 /// Test: this test.
 #[tokio::test]
 async fn forced_degradation_increments_counter_and_logs_error() {
@@ -258,10 +268,24 @@ async fn forced_degradation_increments_counter_and_logs_error() {
         },
     );
     let mut transcript = Transcript::seed("system prompt", "the task");
-    agent
-        .run_with_transcript(&mut transcript, "the task")
-        .await
-        .expect("run completes");
+
+    let dir = std::env::temp_dir().join(format!(
+        "tcode-forced-degradation-telemetry-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+
+    crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
+        agent
+            .run_with_transcript(&mut transcript, "the task")
+            .await
+            .expect("run completes");
+    })
+    .await;
 
     assert!(
         transcript.compaction_events() > 0,
@@ -274,6 +298,33 @@ async fn forced_degradation_increments_counter_and_logs_error() {
             .any(|m| m.contains("regression signal") && m.contains("cadence")),
         "expected an error-level regression-signal log, got: {messages:?}"
     );
+
+    // (#3867/#3868) The durable signals, from the SAME fire that produced
+    // the ERROR log above.
+    let jsonl_path = crate::agent_loop::telemetry::compression_log_path(&dir);
+    let jsonl_contents = std::fs::read_to_string(&jsonl_path)
+        .unwrap_or_else(|e| panic!("expected {jsonl_path:?} to exist: {e}"));
+    let threshold_events: Vec<crate::agent_loop::telemetry::CompressionEvent> = jsonl_contents
+        .lines()
+        .map(|l| serde_json::from_str(l).expect("valid CompressionEvent JSONL line"))
+        .filter(|e: &crate::agent_loop::telemetry::CompressionEvent| {
+            e.surface == crate::agent_loop::telemetry::SURFACE_TCODE_THRESHOLD
+        })
+        .collect();
+    assert!(
+        !threshold_events.is_empty(),
+        "expected a tcode-threshold JSONL line from the same fire, got: {jsonl_contents:?}"
+    );
+    assert!(
+        threshold_events.iter().all(|e| e.compaction_event),
+        "every tcode-threshold record must have compaction_event: true: {threshold_events:?}"
+    );
+    assert!(
+        crate::agent_loop::telemetry::lifetime_compaction_alarm_count(&dir) >= 1,
+        "the same cadence: Some(_) fire must also record the durable alarm line"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
 }
 
 /// The cadence-`None` counterpart: threshold compaction firing is the

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -915,6 +915,19 @@ pub struct IndexReadinessSnapshot {
 /// `IndexReadinessSnapshot`) since every field is a primitive.
 /// Test: `session::registry_tests::record_context_budget_caches_snapshot_for_late_query`,
 /// `session::protocol_budget::tests::get_context_budget_returns_recorded_snapshot_after_recording`.
+///
+/// (issue #3868) `lifetime_compaction_alarm_count` is additive and, unlike
+/// every other field here, has NO twin on `Event::ContextBudget` — it is
+/// deliberately absent from the per-turn stream. Why: the stream event is
+/// derived once, at the moment a turn's cadence measurement lands, from
+/// values the caller already computed; the alarm count is read fresh from
+/// `agent_loop::telemetry::lifetime_compaction_alarm_count`'s durable,
+/// cross-session log every time `record_context_budget` runs, so a session
+/// that never fires threshold compaction still gets an accurate (`0`) count
+/// rather than a stale one baked in at some earlier turn. It answers "has
+/// threshold compaction EVER fired under cadence, cumulative across every
+/// session on this machine" — a fact with no natural single-turn "stream"
+/// moment to attach to.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ContextBudgetSnapshot {
     pub context_window_tokens: usize,
@@ -925,6 +938,12 @@ pub struct ContextBudgetSnapshot {
     pub within_budget: bool,
     pub compaction_fired: bool,
     pub compaction_rounds: usize,
+    /// (#3868) Lifetime, cross-session count of `cadence: Some(_)`
+    /// threshold-compaction fires — epic #2343's never-event alarm, made
+    /// durable and reachable from the ONE RPC that's already the front door
+    /// for budget state (`session.get_context_budget`) instead of requiring
+    /// a second `session.get_transcript` call.
+    pub lifetime_compaction_alarm_count: u64,
 }
 
 /// One row in a session's RETAINED search/recall audit trail (issue #3072;

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -920,14 +920,20 @@ pub struct IndexReadinessSnapshot {
 /// every other field here, has NO twin on `Event::ContextBudget` — it is
 /// deliberately absent from the per-turn stream. Why: the stream event is
 /// derived once, at the moment a turn's cadence measurement lands, from
-/// values the caller already computed; the alarm count is read fresh from
-/// `agent_loop::telemetry::lifetime_compaction_alarm_count`'s durable,
-/// cross-session log every time `record_context_budget` runs, so a session
-/// that never fires threshold compaction still gets an accurate (`0`) count
-/// rather than a stale one baked in at some earlier turn. It answers "has
-/// threshold compaction EVER fired under cadence, cumulative across every
-/// session on this machine" — a fact with no natural single-turn "stream"
-/// moment to attach to.
+/// values the caller already computed; the alarm count instead needs a
+/// `File::open` + line-scan of `agent_loop::telemetry`'s durable,
+/// cross-session alarm log, which is too expensive to pay on the EVERY-TURN
+/// write path (`record_context_budget`, called once per cadence tick). It is
+/// therefore read fresh only in `SessionRegistry::get_context_budget` — the
+/// actual RPC query path, called once per client poll — which overwrites
+/// the field on the cached snapshot right before returning it; the copy
+/// `record_context_budget` stores is a `0` placeholder never observed by a
+/// caller. This also means a session that never fires threshold compaction
+/// still gets an accurate count reflecting fires from ANY session on this
+/// machine, not a stale per-session value baked in at some earlier turn. It
+/// answers "has threshold compaction EVER fired under cadence, cumulative
+/// across every session on this machine" — a fact with no natural
+/// single-turn "stream" moment to attach to.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ContextBudgetSnapshot {
     pub context_window_tokens: usize,

--- a/crates/trusty-code/src/session/protocol_budget.rs
+++ b/crates/trusty-code/src/session/protocol_budget.rs
@@ -109,4 +109,119 @@ mod tests {
             .unwrap_err();
         assert_eq!(err.code, -32007);
     }
+
+    // -- issue #3868: lifetime_compaction_alarm_count --
+
+    fn telemetry_temp_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "tcode-protocol-budget-alarm-test-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// A recorded threshold-compaction alarm fire is reflected on
+    /// `session.get_context_budget`'s `lifetime_compaction_alarm_count`
+    /// field (issue #3868's core acceptance criterion).
+    #[tokio::test]
+    async fn get_context_budget_reflects_lifetime_compaction_alarm_count() {
+        let dir = telemetry_temp_dir("reflects");
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        crate::agent_loop::telemetry::with_data_dir_env(&dir, || {
+            crate::agent_loop::telemetry::record_compaction_alarm(&dir);
+            registry
+                .record_context_budget(&session.id, &measurement())
+                .unwrap();
+        })
+        .await;
+
+        let result = get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result["status"], "recorded");
+        assert!(
+            result["lifetime_compaction_alarm_count"].as_u64().unwrap() >= 1,
+            "expected a non-zero alarm count, got {result:?}"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A session that never records an alarm fire has
+    /// `lifetime_compaction_alarm_count == 0` — the `cadence: None`
+    /// regression guard (issue #3868 acceptance criteria: "cadence: None
+    /// runs never increment this counter").
+    #[tokio::test]
+    async fn get_context_budget_alarm_count_zero_without_a_fire() {
+        let dir = telemetry_temp_dir("zero");
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        crate::agent_loop::telemetry::with_data_dir_env(&dir, || {
+            registry
+                .record_context_budget(&session.id, &measurement())
+                .unwrap();
+        })
+        .await;
+
+        let result = get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+            .await
+            .unwrap();
+
+        assert_eq!(result["lifetime_compaction_alarm_count"], 0);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The alarm count is read fresh from the durable log every time, so a
+    /// BRAND NEW `SessionRegistry` (simulating a daemon restart) querying a
+    /// brand new session still sees fires recorded by an earlier registry
+    /// instance — the durability requirement the old in-memory `Transcript`
+    /// counter failed (issue #3868: "persists across a session restart").
+    #[tokio::test]
+    async fn get_context_budget_alarm_count_survives_fresh_registry() {
+        let dir = telemetry_temp_dir("survives-restart");
+
+        crate::agent_loop::telemetry::with_data_dir_env(&dir, || {
+            crate::agent_loop::telemetry::record_compaction_alarm(&dir);
+            crate::agent_loop::telemetry::record_compaction_alarm(&dir);
+        })
+        .await;
+
+        // A FRESH registry — nothing in-memory carried over from whatever
+        // recorded the fires above.
+        let fresh_registry = SessionRegistry::new();
+        let session =
+            fresh_registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        crate::agent_loop::telemetry::with_data_dir_env(&dir, || {
+            fresh_registry
+                .record_context_budget(&session.id, &measurement())
+                .unwrap();
+        })
+        .await;
+
+        let result = get_context_budget(
+            &fresh_registry,
+            json!({"session_id": session.id}),
+            test_ctx(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            result["lifetime_compaction_alarm_count"], 2,
+            "a fresh registry must read the SAME durable count, not reset to 0"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/crates/trusty-code/src/session/protocol_budget.rs
+++ b/crates/trusty-code/src/session/protocol_budget.rs
@@ -128,23 +128,28 @@ mod tests {
     /// A recorded threshold-compaction alarm fire is reflected on
     /// `session.get_context_budget`'s `lifetime_compaction_alarm_count`
     /// field (issue #3868's core acceptance criterion).
+    ///
+    /// (#3868 fix) The alarm-log read now happens in `get_context_budget`
+    /// itself (the query path), not `record_context_budget` (the every-turn
+    /// write path) — so the RPC call, not just the record call, must run
+    /// with the data-dir env var still set. `with_data_dir_env_fut` wraps
+    /// the WHOLE async sequence for exactly that reason.
     #[tokio::test]
     async fn get_context_budget_reflects_lifetime_compaction_alarm_count() {
         let dir = telemetry_temp_dir("reflects");
         let registry = SessionRegistry::new();
         let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
-        crate::agent_loop::telemetry::with_data_dir_env(&dir, || {
+        let result = crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
             crate::agent_loop::telemetry::record_compaction_alarm(&dir);
             registry
                 .record_context_budget(&session.id, &measurement())
                 .unwrap();
+            get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+                .await
+                .unwrap()
         })
         .await;
-
-        let result = get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
-            .await
-            .unwrap();
 
         assert_eq!(result["status"], "recorded");
         assert!(
@@ -165,16 +170,15 @@ mod tests {
         let registry = SessionRegistry::new();
         let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
 
-        crate::agent_loop::telemetry::with_data_dir_env(&dir, || {
+        let result = crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
             registry
                 .record_context_budget(&session.id, &measurement())
                 .unwrap();
+            get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+                .await
+                .unwrap()
         })
         .await;
-
-        let result = get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
-            .await
-            .unwrap();
 
         assert_eq!(result["lifetime_compaction_alarm_count"], 0);
 
@@ -190,32 +194,28 @@ mod tests {
     async fn get_context_budget_alarm_count_survives_fresh_registry() {
         let dir = telemetry_temp_dir("survives-restart");
 
-        crate::agent_loop::telemetry::with_data_dir_env(&dir, || {
+        let result = crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
             crate::agent_loop::telemetry::record_compaction_alarm(&dir);
             crate::agent_loop::telemetry::record_compaction_alarm(&dir);
-        })
-        .await;
 
-        // A FRESH registry — nothing in-memory carried over from whatever
-        // recorded the fires above.
-        let fresh_registry = SessionRegistry::new();
-        let session =
-            fresh_registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-
-        crate::agent_loop::telemetry::with_data_dir_env(&dir, || {
+            // A FRESH registry — nothing in-memory carried over from
+            // whatever recorded the fires above.
+            let fresh_registry = SessionRegistry::new();
+            let session =
+                fresh_registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
             fresh_registry
                 .record_context_budget(&session.id, &measurement())
                 .unwrap();
+
+            get_context_budget(
+                &fresh_registry,
+                json!({"session_id": session.id}),
+                test_ctx(),
+            )
+            .await
+            .unwrap()
         })
         .await;
-
-        let result = get_context_budget(
-            &fresh_registry,
-            json!({"session_id": session.id}),
-            test_ctx(),
-        )
-        .await
-        .unwrap();
 
         assert_eq!(
             result["lifetime_compaction_alarm_count"], 2,

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -218,6 +218,14 @@ impl SessionRegistry {
     /// disagree; every value is already computed by the caller, so this adds
     /// no arithmetic of its own. Errors with `session_not_found` if `id` is
     /// unknown.
+    /// (#3868) `lifetime_compaction_alarm_count` is stored as a `0`
+    /// placeholder here — this method runs on the EVERY-TURN write path
+    /// (`AgentLoop::maybe_cadence_compress` forwards to it once per cadence
+    /// tick), so a `File::open` + line-scan here would pay the durable-log
+    /// read cost once per turn per session. [`Self::get_context_budget`]
+    /// (the actual RPC query path — called far less often, once per client
+    /// poll) overwrites this field with a fresh read before returning, so no
+    /// caller ever observes the placeholder.
     /// Test: `registry_tests::record_context_budget_publishes_event`,
     /// `registry_tests::record_context_budget_caches_snapshot_for_late_query`.
     pub fn record_context_budget(
@@ -226,14 +234,6 @@ impl SessionRegistry {
         measurement: &crate::agent_loop::ContextBudgetSnapshot,
     ) -> Result<(), RpcError> {
         self.ensure_exists(id)?;
-        // (#3868) Read fresh from the durable, cross-session alarm log every
-        // time — never cached/stale — so a query reflects fires from ANY
-        // session on this machine, not just this one. See
-        // `ContextBudgetSnapshot::lifetime_compaction_alarm_count`'s docs.
-        let lifetime_compaction_alarm_count =
-            crate::agent_loop::telemetry::lifetime_compaction_alarm_count(
-                &crate::agent_loop::telemetry::default_data_dir(),
-            );
         let snapshot = ContextBudgetSnapshot {
             context_window_tokens: measurement.context_window,
             overhead_tokens: measurement.overhead_tokens,
@@ -243,7 +243,10 @@ impl SessionRegistry {
             within_budget: measurement.within_budget,
             compaction_fired: measurement.fired,
             compaction_rounds: measurement.rounds,
-            lifetime_compaction_alarm_count,
+            // (#3868) Placeholder — see doc note above. Never observed: only
+            // `get_context_budget` reads this field back out, and it always
+            // overwrites it first.
+            lifetime_compaction_alarm_count: 0,
         };
         {
             let mut sessions = self.lock();
@@ -285,16 +288,30 @@ impl SessionRegistry {
     /// `record_context_budget` call has happened yet (e.g. a session queried
     /// before its first PM turn completes, or a delegated sub-agent session,
     /// which never emits cadence budget events at all).
+    /// (#3868) `lifetime_compaction_alarm_count` is read fresh from the
+    /// durable, cross-session alarm log HERE — the query path, called once
+    /// per client poll — rather than in [`Self::record_context_budget`] (the
+    /// every-turn write path), so the `File::open` + line-scan cost is paid
+    /// once per query, not once per turn per session. This is also why the
+    /// count reflects fires from ANY session on this machine, not just this
+    /// one: it is derived from a shared log, not a per-session cache.
     /// Test: `registry_tests::record_context_budget_caches_snapshot_for_late_query`,
     /// `protocol_budget::tests::get_context_budget_never_recorded_session_returns_never_recorded`,
-    /// `registry_tests::get_context_budget_unknown_session_errors`.
+    /// `registry_tests::get_context_budget_unknown_session_errors`,
+    /// `protocol_budget::tests::get_context_budget_reflects_lifetime_compaction_alarm_count`.
     pub fn get_context_budget(&self, id: &str) -> Result<ContextBudgetQuery, RpcError> {
         self.ensure_exists(id)?;
         Ok(self
             .lock()
             .get(id)
             .and_then(|e| e.context_budget)
-            .map(ContextBudgetQuery::Recorded)
+            .map(|mut snapshot| {
+                snapshot.lifetime_compaction_alarm_count =
+                    crate::agent_loop::telemetry::lifetime_compaction_alarm_count(
+                        &crate::agent_loop::telemetry::default_data_dir(),
+                    );
+                ContextBudgetQuery::Recorded(snapshot)
+            })
             .unwrap_or(ContextBudgetQuery::NeverRecorded))
     }
 

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -226,6 +226,14 @@ impl SessionRegistry {
         measurement: &crate::agent_loop::ContextBudgetSnapshot,
     ) -> Result<(), RpcError> {
         self.ensure_exists(id)?;
+        // (#3868) Read fresh from the durable, cross-session alarm log every
+        // time — never cached/stale — so a query reflects fires from ANY
+        // session on this machine, not just this one. See
+        // `ContextBudgetSnapshot::lifetime_compaction_alarm_count`'s docs.
+        let lifetime_compaction_alarm_count =
+            crate::agent_loop::telemetry::lifetime_compaction_alarm_count(
+                &crate::agent_loop::telemetry::default_data_dir(),
+            );
         let snapshot = ContextBudgetSnapshot {
             context_window_tokens: measurement.context_window,
             overhead_tokens: measurement.overhead_tokens,
@@ -235,6 +243,7 @@ impl SessionRegistry {
             within_budget: measurement.within_budget,
             compaction_fired: measurement.fired,
             compaction_rounds: measurement.rounds,
+            lifetime_compaction_alarm_count,
         };
         {
             let mut sessions = self.lock();

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -458,6 +458,10 @@ async fn run_and_record(
     // new "spawn" on every run. Namespaced with a `pm-` prefix so it reads
     // distinctly from an engineer's bare UUID in a raw event dump.
     .with_agent_id(format!("pm-{session_id}"))
+    // (#3867) Stamps this session's real id onto every durable
+    // compression-telemetry JSONL record this loop's cadence/threshold
+    // instrumentation emits — see `AgentLoop::with_session_id`'s docs.
+    .with_session_id(session_id.clone())
     .with_cancel_flag(Arc::clone(&cancel))
     // #2279: mirrors `run_task::execute_run_task`'s own wiring — the PM
     // never calls `bash` itself, so its verify-before-finish gate scans the


### PR DESCRIPTION
## Summary

Implements Slice A (#3867, tcode surfaces) and Slice B (#3868) of epic #3866, scoped to `crates/trusty-code` only — the `trusty-agents` `agents-ws-summary` surface named in #3867's body is being re-routed to the Slice-D engineer (orphaned between slices) and is **not touched** in this PR. See "Closes / Refs" below.

- **Slice A (#3867, tcode surfaces only):** new `agent_loop::telemetry` module appends one JSONL line per compression event to `~/.trusty-code/compression.jsonl`:
  - `tcode-cadence` — `AgentLoop::maybe_cadence_compress`, emitted only when `outcome.rounds > 0`.
  - `tcode-threshold` — `AgentLoop::maybe_compact_transcript`, emitted unconditionally on every fire (regardless of `cadence`), with `compaction_event: true`.
  - Schema matches the issue exactly: `ts, session_id, surface, surface_detail, tokens_before, tokens_after, ratio, working_context_pct_after, overhead_pct_after, compaction_event, duration_ms, rounds`.
  - Emission is best-effort (mirrors `trusty-agents::usage::append_usage`'s failure posture) — an unwritable log directory never fails the compaction/cadence operation itself (now covered by a loop-level test, not just a writer-level one — see Fixes below).
  - `AgentLoop` gained an optional `session_id` field + `with_session_id` builder (mirroring the existing `with_agent_id` pattern) so telemetry records carry the real session id; wired at the one production call site (`task::executor::run_and_record`).

- **Slice B (#3868):** a threshold-compaction fire under `cadence: Some(_)` also appends a line to a dedicated durable log, `~/.trusty-code/compaction_alarm.log` (one line per fire, counted by line rather than read-modify-write, so concurrent fires can never race into a lost increment). `session.get_context_budget`'s response (`ContextBudgetSnapshot`) gains an additive `lifetime_compaction_alarm_count: u64` field, read fresh from that log **at query time** (see Fixes below) — durable across session restarts, and correctly `0` for `cadence: None` runs (which use threshold compaction as their expected primary mechanism, not a regression).

### Structural note

`AgentLoop::maybe_compact_transcript`/`maybe_cadence_compress` were moved into a new `agent_loop/compaction_control.rs` child module (`#[path = ...]`, mirroring the existing `session/registry_events.rs` / `session/protocol_budget.rs` convention already in this crate) to keep `agent_loop/mod.rs` under the crate's 500-SLOC production cap after adding the instrumentation.

### Test-only escape hatch

`telemetry::DATA_DIR_ENV_VAR` (`TCODE_TELEMETRY_DATA_DIR`) lets tests point every telemetry read/write at an isolated temp directory instead of the real `~/.trusty-code`, mirroring `cadence::CADENCE_TURNS_ENV_VAR`'s existing precedent. Production never sets it. `telemetry::with_data_dir_env`/`with_data_dir_env_fut` serialize on `telemetry::DATA_DIR_ENV_LOCK` (`#[cfg(test)]`) so parallel `cargo test` threads never race the env mutation, mirroring `mode::MODE_ENV_LOCK`.

## Fixes from code-critic review (WARN → addressed on this branch)

1. **HIGH — moved the `lifetime_compaction_alarm_count` disk read off the every-turn write path.** `record_context_budget` (called once per cadence tick) no longer touches disk; it stores a `0` placeholder. `get_context_budget` (the actual RPC query path, called once per client poll) now performs the `File::open` + line-scan and overwrites the field before returning. No caller ever observes the placeholder.
2. **MEDIUM — added the loop-level unwritable-dir test.** `compression_telemetry_tests::unwritable_data_dir_does_not_fail_the_loop` points `TCODE_TELEMETRY_DATA_DIR` at a path under `/dev/null` (a character device, so every write underneath fails `ENOTDIR`) and asserts a scripted `AgentLoop::run` with `cadence: Some(_)` + aggressive compaction still completes `Ok` with a full turn sequence — the loop-contract half issue #3867's acceptance criteria requires, on top of the writer-only no-panic tests already covering `telemetry::write_compression_event`/`record_compaction_alarm` in isolation.
3. **MEDIUM — added a single-fire, both-signals-together test.** `agent_loop::tests::cadence::forced_degradation_increments_counter_and_logs_error` (the existing `crate::test_support::begin_capture()`-based ERROR-log test) now ALSO asserts the durable `tcode-threshold`/`compaction_event: true` JSONL line and `lifetime_compaction_alarm_count >= 1` from the SAME fire, in the same test function — reordering or dropping either signal at the `compaction_control.rs` call site now fails one test instead of two independently-passable partial checks.
4. **SCOPE** — see "Closes / Refs" below: #3867 is no longer auto-closed by this PR since its `agents-ws-summary` surface is being re-routed to Slice D.

Not changed (per PM guidance): the LOW double-token-estimation note (spec-mandated capture-before-call) and the dedicated-alarm-log-vs-derived-count design choice (within the issue's own stated latitude).

## Test plan

- [x] `cargo test -p trusty-code` (full suite, not `--lib`) — **1578 passed, 0 failed, 4 ignored** in the lib target, plus every integration-test binary green.
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p trusty-code --check` — clean.
- [x] `scripts/check_line_cap.sh` — 0 violations.
- [x] New unit tests: JSONL writer schema/append semantics, ratio divide-by-zero guard, best-effort I/O-failure swallowing (`telemetry_tests.rs`, 18 tests).
- [x] New loop-integration tests: `compaction_event: true` + the durable alarm line together for a `cadence: Some(_)` threshold fire, the `cadence: None` non-alarm regression guard, cadence-fire JSONL emission, and the unwritable-dir loop-contract test (`compression_telemetry_tests.rs`, 5 tests).
- [x] New RPC-level tests: `session.get_context_budget` reflects a recorded alarm count, stays `0` without a fire, and survives a fresh `SessionRegistry` (simulated daemon restart) reading the same durable log — now exercised through the query path itself, matching the fixed read location (`protocol_budget.rs`, 3 tests).
- [x] Extended `forced_degradation_increments_counter_and_logs_error` to assert the ERROR log AND both durable signals from one fire (`agent_loop/tests/cadence.rs`).
- [x] `CHANGELOG.md` `[Unreleased]` entry added.

## Closes / Refs

- Closes #3868
- Refs #3867 (partial — tcode surfaces; `agents-ws-summary` lands separately via Slice D)

## Not in this PR

- `trusty-agents` `agents-ws-summary` surface (Slice D, re-routed per PM).
- Slice C (evaluation harness/report) — separate issue.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
