### PR TITLE
chore(trusty-kb,trusty-agents): genericize private path literals in okg docs and tests

### DIFF
--- a/crates/trusty-agents/src/tools/okg/config.rs
+++ b/crates/trusty-agents/src/tools/okg/config.rs
@@ -3,7 +3,7 @@
 //! Why: `okg_ingest_docstore` takes a path from a MODEL, so the set of readable
 //! directories is a security boundary and therefore belongs to the OPERATOR,
 //! not to the model or to a hardcoded constant. Real corpora live in arbitrary
-//! places (`~/Duetto/cto-resources`), so the list has to be extensible; the
+//! places (`~/Corpora/research`), so the list has to be extensible; the
 //! default has to be useful without being `/`.
 //!
 //! What: [`OkgConfig`] is the `[okg]` section of `~/.trusty-agents/config.toml`.

--- a/crates/trusty-agents/src/tools/okg/tests.rs
+++ b/crates/trusty-agents/src/tools/okg/tests.rs
@@ -364,7 +364,7 @@ async fn docstore_tool_rejects_credential_dir() {
 }
 
 /// Why: the permitted roots are OPERATOR configuration, not a hardcoded home
-/// check — a real corpus lives at `~/Duetto/cto-resources`, and other users'
+/// check — a real corpus lives at `~/Corpora/research`, and other users'
 /// will live elsewhere entirely.
 /// What: asserts the default is home, that an explicit `[okg] docstore_roots`
 /// entry replaces it, and that `~` expands.
@@ -380,12 +380,12 @@ fn config_defaults_to_home() {
     );
 
     let configured = config::OkgConfig {
-        docstore_roots: vec!["~/Duetto/cto-resources".into(), "/srv/corpora".into()],
+        docstore_roots: vec!["~/Corpora/research".into(), "/srv/corpora".into()],
     };
     assert_eq!(
         configured.policy(home),
         trusty_kb::okg::policy::DocStorePolicy::new(vec![
-            home.join("Duetto/cto-resources"),
+            home.join("Corpora/research"),
             std::path::PathBuf::from("/srv/corpora"),
         ]),
         "configured roots replace the default and expand ~"
@@ -399,7 +399,7 @@ fn config_defaults_to_home() {
 #[test]
 fn config_roots_expand_tilde() {
     let with_section: toml::Value = toml::from_str(
-        "[okg]\ndocstore_roots = [\"~/Documents\", \"/Users/masa/Duetto/cto-resources\"]\n",
+        "[okg]\ndocstore_roots = [\"~/Documents\", \"/Users/example/Corpora/research\"]\n",
     )
     .unwrap();
     let parsed: config::OkgConfig = with_section["okg"].clone().try_into().unwrap();
@@ -407,7 +407,7 @@ fn config_roots_expand_tilde() {
         parsed.docstore_roots,
         vec![
             "~/Documents".to_string(),
-            "/Users/masa/Duetto/cto-resources".to_string()
+            "/Users/example/Corpora/research".to_string()
         ]
     );
 

--- a/crates/trusty-kb/src/okg/policy.rs
+++ b/crates/trusty-kb/src/okg/policy.rs
@@ -29,7 +29,7 @@
 //! directory inside `~/Library`) is taken at their word — explicit
 //! configuration beats the default heuristic. The roots are configuration, not
 //! a hardcoded list: real corpora live in arbitrary places
-//! (`~/Duetto/cto-resources`), so an operator must be able to extend them.
+//! (`~/Corpora/research`), so an operator must be able to extend them.
 //!
 //! Known limits, accepted deliberately:
 //!   - Loose non-hidden files sitting directly in `$HOME` (`~/private_key.pem`)
@@ -63,7 +63,7 @@ impl DocStorePolicy {
 
     /// The default policy: the user's home directory, minus every dot-path.
     ///
-    /// Why: ordinary corpora (`~/Documents`, `~/Duetto/cto-resources`) work out
+    /// Why: ordinary corpora (`~/Documents`, `~/Corpora/research`) work out
     /// of the box, while the credential and config directories that make an
     /// unconfined read dangerous are excluded by the dot-segment rule rather
     /// than by an enumeration that would inevitably fall behind.
@@ -223,7 +223,7 @@ mod tests {
         // every prefix comparison in these tests accidental.
         let home = tmp.path().canonicalize().unwrap();
         std::fs::create_dir_all(home.join("Documents/notes")).unwrap();
-        std::fs::create_dir_all(home.join("Duetto/cto-resources")).unwrap();
+        std::fs::create_dir_all(home.join("Corpora/research")).unwrap();
         std::fs::create_dir_all(home.join(".ssh")).unwrap();
         std::fs::create_dir_all(home.join(".config/gh")).unwrap();
         (tmp, home)


### PR DESCRIPTION
## What

PR #3883 used a real private corpus path as its doc-comment example and test
fixture: `~/Duetto/cto-resources`, and once with the full `/Users/masa/` prefix.

It is only a directory name — no content — but it puts an operator's username
and an employer-specific tree into a public repo for no benefit. The examples
exist to make one point ("real corpora live in arbitrary places, so the
allow-list must be extensible"), and a generic path makes it just as well.

Replaced throughout with `~/Corpora/research`, and `/Users/example/Corpora/research`
for the absolute form.

## Scope

Documentation and test fixtures only. 9 lines across 3 files. No logic, no
behaviour change, no assertion weakened — `config_roots_expand_tilde` still
round-trips an absolute path through the TOML parser, it is just no longer
someone's actual home directory.

```
crates/trusty-agents/src/tools/okg/config.rs |  2 +-
crates/trusty-agents/src/tools/okg/tests.rs  | 10 +++++-----
crates/trusty-kb/src/okg/policy.rs           |  6 +++---
```

No CHANGELOG entry: docs/test-only, no user-visible change.

## Verification

```
$ cargo test -p trusty-kb
test result: ok. 83 passed; 0 failed
test result: ok. 8 passed; 0 failed
test result: ok. 3 passed; 0 failed

$ cargo test -p trusty-agents
test result: ok. 2494 passed; 0 failed; 12 ignored

$ cargo clippy -p trusty-kb -p trusty-agents --all-targets -- -D warnings
(clean)

$ cargo fmt -p trusty-kb -p trusty-agents -- --check
(clean)

$ grep -rn "Duetto\|/Users/masa" crates/trusty-agents/src/tools/okg/ crates/trusty-kb/src/okg/
none — clean
```

Refs #3883, epic #3052.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
