### PR TITLE
feat(trusty-agents-ui): full-pane agent configuration takeover + full-height instructions editor

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -9,6 +9,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Agent configuration takes over the pane (#3894, GUI):** opening the gear no
+  longer wedges the agent–OKG–tool–listener surface into a 320px strip above
+  the chat scrollback — it now takes over the entire content area (chat column
+  *and* recap rail), giving the concept centerpiece the room it needs. Chat is
+  covered, never unmounted: the takeover is an absolutely-positioned sibling of
+  a still-mounted, `inert` chat subtree, so leaving configuration returns to
+  chat exactly as it was — same scroll offset, same half-typed message in the
+  composer. Exits: a "Back to chat" button, a close button, and <kbd>Esc</kbd>
+  (unmodified only, so platform chords like Cmd+Esc are left alone); switching
+  to the Events tab also drops the takeover. Every existing section — OKG
+  Stores, Tools, Permissions, Listeners scaffolding, and the per-section save
+  flow — is unchanged.
+
 - **Live OKG store bindings — the FIRST leg of the agent-config triple
   (#3816, DOC-54 SPEC-AGENTS-04 §5.1):** `agent.toml` gains `[[stores]]`,
   declaring what an agent KNOWS alongside how it ACTS (`[tools]`) and REACTS
@@ -92,6 +105,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Instructions editor is a first-class editing surface (#3894, GUI).**
+  #3862's `55vh`/`70vh` clamp fixed a 2-line strip by trading it for a field
+  capped independently of the space available — dead area below it on a tall
+  window. In the full-pane takeover the persona editor now grows into every
+  remaining pixel (`flex-1`/`min-h-0`, no `rows`, no viewport clamp) and is the
+  only scroll container in its tab, so there are no nested double scrollbars.
+  Measured in a real browser: 26 visible lines at a 900px viewport, 52 at
+  1400px. The Tools allowlist textarea gets the same treatment.
 - **Bulk backfills are bounded and resumable.** `max_messages`/`max_files` were
   taken from the model with no ceiling, and every fetched item accumulated in
   memory with the ledger committed only after the whole batch — so a large pull

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -20,7 +20,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   (unmodified only, so platform chords like Cmd+Esc are left alone); switching
   to the Events tab also drops the takeover. Every existing section — OKG
   Stores, Tools, Permissions, Listeners scaffolding, and the per-section save
-  flow — is unchanged.
+  flow — is unchanged. Unsaved Personality/Tools edits are never discarded
+  silently: every exit path (Esc, Back, Close, and the Chat→Events tab switch)
+  stops on a confirm offering Save and close / Discard / Keep editing. The
+  agent being configured is pinned when the takeover opens, so a background
+  agent switch (the Sidebar's resume-workstream flow) can no longer retarget an
+  open panel or throw away what is typed in it.
 
 - **Live OKG store bindings — the FIRST leg of the agent-config triple
   (#3816, DOC-54 SPEC-AGENTS-04 §5.1):** `agent.toml` gains `[[stores]]`,
@@ -112,7 +117,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   remaining pixel (`flex-1`/`min-h-0`, no `rows`, no viewport clamp) and is the
   only scroll container in its tab, so there are no nested double scrollbars.
   Measured in a real browser: 26 visible lines at a 900px viewport, 52 at
-  1400px. The Tools allowlist textarea gets the same treatment.
+  1400px. The Tools allowlist textarea gets the same treatment, and a
+  Playwright spec (`ui/tests/config-takeover.spec.ts`) now measures the
+  rendered height at two viewports so a third regression cannot ship quietly.
+- **Chat no longer yanks you back to the newest message.** `ChatView` forced
+  `scrollTop = scrollHeight` after every render, so a streaming delta pulled a
+  reader who had scrolled up back to the bottom — and reset the scroll offset
+  of the chat sitting behind the config takeover, which is supposed to be left
+  exactly as it was. It now re-anchors only while the reader is already at the
+  bottom (`lib/chatScroll.ts`).
 - **Bulk backfills are bounded and resumable.** `max_messages`/`max_files` were
   taken from the model with no ceiling, and every fetched item accumulated in
   memory with the ledger committed only after the whole batch — so a large pull

--- a/crates/trusty-agents/ui/README.md
+++ b/crates/trusty-agents/ui/README.md
@@ -77,6 +77,29 @@ permissive CORS layer on the API server:
 VITE_TAGENT_API=https://tagent.example.com pnpm build
 ```
 
+## Testing
+
+```sh
+pnpm test:unit          # vitest — pure logic + mounted components (jsdom). Runs in CI.
+pnpm run check          # svelte-check. Runs in CI.
+pnpm test               # playwright e2e. NOT run in CI: needs a running server.
+```
+
+The Playwright specs need something serving the app at `TAGENT_URL`
+(default `http://127.0.0.1:7654`, i.e. a real `tagent --api`). All `/api/*`
+routes are stubbed inside the specs, so a plain Vite dev server works too and
+is the fastest loop:
+
+```sh
+pnpm dev --host 127.0.0.1                                    # shell 1
+TAGENT_URL=http://127.0.0.1:5173 pnpm test                   # shell 2
+```
+
+`tests/config-takeover.spec.ts` is the layout guard for the agent-config
+takeover: it MEASURES the instructions editor's rendered height at two
+viewports, because that sizing has regressed twice and jsdom (no layout
+engine) can only check the classes that are supposed to produce it.
+
 ## Production build
 
 ```sh

--- a/crates/trusty-agents/ui/package.json
+++ b/crates/trusty-agents/ui/package.json
@@ -25,6 +25,7 @@
     "@tauri-apps/cli": "^2.0.0",
     "@tsconfig/svelte": "^5.0.0",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^25.0.1",
     "postcss": "^8.4.47",
     "svelte": "^5.55.7",
     "svelte-check": "^4.7.2",

--- a/crates/trusty-agents/ui/pnpm-lock.yaml
+++ b/crates/trusty-agents/ui/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.4(postcss@8.5.19)
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       postcss:
         specifier: ^8.4.47
         version: 8.5.19
@@ -56,13 +59,44 @@ importers:
         version: 6.4.3(jiti@1.21.7)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(vite@6.4.3(jiti@1.21.7))
+        version: 4.1.10(jsdom@25.0.1)(vite@6.4.3(jiti@1.21.7))
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -549,6 +583,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
@@ -566,6 +604,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   autoprefixer@10.5.4:
     resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
@@ -596,6 +637,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
@@ -619,6 +664,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -631,6 +680,14 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -640,9 +697,16 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
@@ -653,8 +717,20 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   electron-to-chromium@1.5.393:
     resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
@@ -662,6 +738,14 @@ packages:
 
   es-module-lexer@2.3.1:
     resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -710,6 +794,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -726,6 +814,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -734,9 +830,37 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -758,12 +882,24 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -779,6 +915,9 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lucide-svelte@0.454.0:
     resolution: {integrity: sha512-TgW17HI7M8LeFZ3NpaDp1LwPGBGMVjx/x81TtK+AacEQvmJcqetqeJNeBT18NMEJP9+zi/Wt+Zc8mo44K5Uszw==}
     deprecated: Package deprecated. Please use @lucide/svelte instead.
@@ -788,6 +927,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -795,6 +938,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -819,6 +970,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -830,6 +984,9 @@ packages:
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -913,6 +1070,10 @@ packages:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -941,12 +1102,25 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -982,6 +1156,9 @@ packages:
     resolution: {integrity: sha512-p4HDLDogGHKRKCrgckQHNs5PEfXkju6JI5jTywueaKJI5hAdjPohEhRtQ0M1SWC/+TA73SPln+r7srr+7e4nZA==}
     engines: {node: '>=18'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
@@ -1009,9 +1186,24 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -1122,10 +1314,50 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
@@ -1133,6 +1365,34 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -1461,6 +1721,8 @@ snapshots:
 
   acorn@8.17.0: {}
 
+  agent-base@7.1.4: {}
+
   any-promise@1.3.0: {}
 
   anymatch@3.1.3:
@@ -1473,6 +1735,8 @@ snapshots:
   aria-query@5.3.1: {}
 
   assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
 
   autoprefixer@10.5.4(postcss@8.5.19):
     dependencies:
@@ -1501,6 +1765,11 @@ snapshots:
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001806: {}
@@ -1525,17 +1794,35 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@4.1.1: {}
 
   convert-source-map@2.0.0: {}
 
   cssesc@3.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deepmerge@4.3.1: {}
+
+  delayed-stream@1.0.0: {}
 
   devalue@5.8.1: {}
 
@@ -1543,11 +1830,32 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   electron-to-chromium@1.5.393: {}
+
+  entities@6.0.1: {}
+
+  es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
 
   es-module-lexer@2.3.1: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -1612,6 +1920,14 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   fraction.js@5.3.4: {}
 
   fsevents@2.3.2:
@@ -1622,6 +1938,24 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -1630,9 +1964,39 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   is-binary-path@2.1.0:
     dependencies:
@@ -1650,11 +2014,41 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
   jiti@1.21.7: {}
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.6
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   kleur@4.1.5: {}
 
@@ -1664,6 +2058,8 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  lru-cache@10.4.3: {}
+
   lucide-svelte@0.454.0(svelte@5.56.6):
     dependencies:
       svelte: 5.56.6
@@ -1672,12 +2068,20 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mri@1.2.0: {}
 
@@ -1695,11 +2099,17 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  nwsapi@2.2.24: {}
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
 
   obug@2.1.4: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-parse@1.0.7: {}
 
@@ -1760,6 +2170,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  punycode@2.3.1: {}
+
   queue-microtask@1.2.3: {}
 
   read-cache@1.0.0:
@@ -1812,6 +2224,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -1819,6 +2235,12 @@ snapshots:
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   siginfo@2.0.0: {}
 
@@ -1874,6 +2296,8 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript-eslint/types'
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@3.4.19:
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -1921,9 +2345,23 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-interface-checker@0.1.13: {}
 
@@ -1955,7 +2393,7 @@ snapshots:
     optionalDependencies:
       vite: 6.4.3(jiti@1.21.7)
 
-  vitest@4.1.10(vite@6.4.3(jiti@1.21.7)):
+  vitest@4.1.10(jsdom@25.0.1)(vite@6.4.3(jiti@1.21.7)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@6.4.3(jiti@1.21.7))
@@ -1977,12 +2415,37 @@ snapshots:
       tinyrainbow: 3.1.0
       vite: 6.4.3(jiti@1.21.7)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.21.1: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   zimmerframe@1.1.4: {}

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -2,13 +2,13 @@
   import { onMount } from 'svelte';
   import { get } from 'svelte/store';
   import Sidebar from './components/Sidebar.svelte';
-  import ChatView from './components/ChatView.svelte';
-  import InputArea from './components/InputArea.svelte';
-  import RecapPanel from './components/RecapPanel.svelte';
   import Header from './components/Header.svelte';
-  import ChatHeader from './components/ChatHeader.svelte';
+  // #3894: the Chat view's whole composition (chat column + recap rail +
+  // Slack mirror + the agent-configuration takeover that covers them) lives
+  // in `ChatPane` — see that component's doc comment for why the takeover
+  // has to be a sibling of the group rather than nested in the chat column.
+  import ChatPane from './components/ChatPane.svelte';
   import EventsView from './components/EventsView.svelte';
-  import SlackMirror from './components/SlackMirror.svelte';
   // #3819: `ProjectsView`/`PersonalityPanel` are no longer routed — Bob's
   // nav reshape drops the Projects/Personality top tabs entirely. Left
   // unimported/unrouted rather than deleted pending a decision on their
@@ -19,7 +19,7 @@
   // via `ChatHeader`'s gear icon).
   // #3752: live Slack conversation mirror — the SSE bridge feeds these two
   // event kinds into the store the SlackMirror pane renders.
-  import { pushSlackEvent, slackMirror } from './lib/slack-mirror';
+  import { pushSlackEvent } from './lib/slack-mirror';
   // #3819: the Events tab's rolling log — fed from the same bridge as
   // `pushSlackEvent`, additive, never a replacement for the existing
   // task-progress/webBus routing below.
@@ -37,6 +37,7 @@
     refreshOverlayAgents,
   } from './stores/app';
   import { setRecap, type Recap } from './stores/recap';
+  import { closeConfigPane } from './stores/configPane';
   // Why (#3217): parallel structured-data sink — see stores/workflow.ts doc
   // comment for the full rationale. Additive to the flattened webBus path
   // below, never a replacement.
@@ -58,6 +59,12 @@
   let activeView: 'chat' | 'events' = 'chat';
 
   function switchView(view: 'chat' | 'events') {
+    // #3894: leaving Chat abandons any open configuration takeover, so the
+    // top-level tabs always mean what they say — coming back to Chat shows
+    // chat, never a config surface the user left behind minutes ago. Config
+    // edits are saved per-section explicitly, so nothing is lost but the
+    // scroll position within the config form.
+    if (view !== 'chat') closeConfigPane();
     activeView = view;
   }
   let tokenInput = '';
@@ -559,27 +566,11 @@
       <!-- #3220: the top-level Chat/Events tab nav lives in <Header/>, which
            dispatches `switch-view` back up to `switchView()` above. #3819:
            the chat pane additionally gets its OWN header (`ChatHeader`) —
-           active-agent title + inline selector + gear config panel — since
+           active-agent title + inline selector + gear config button — since
            that state (which agent) is scoped to the chat view, not the
            whole app. -->
       {#if activeView === 'chat'}
-        <!-- #3219: RecapPanel is now a persistent right rail (own scroll,
-             AGENTS ACTIVE / FILES TOUCHED / TOKENS + folded recap summary),
-             so it sits beside the chat+input column rather than stacked
-             between them. -->
-        <div class="flex flex-1 min-h-0">
-          <div class="flex flex-1 flex-col min-w-0">
-            <ChatHeader />
-            <ChatView />
-            <InputArea />
-          </div>
-          <RecapPanel />
-          <!-- #3752: the live Slack mirror only mounts once there's activity,
-               so normal (non-Slack) usage is visually unchanged. -->
-          {#if $slackMirror.length > 0}
-            <SlackMirror />
-          {/if}
-        </div>
+        <ChatPane />
       {:else}
         <EventsView />
       {/if}

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -37,7 +37,7 @@
     refreshOverlayAgents,
   } from './stores/app';
   import { setRecap, type Recap } from './stores/recap';
-  import { closeConfigPane } from './stores/configPane';
+  import { requestExitConfigPane } from './stores/configPane';
   // Why (#3217): parallel structured-data sink — see stores/workflow.ts doc
   // comment for the full rationale. Additive to the flattened webBus path
   // below, never a replacement.
@@ -61,10 +61,12 @@
   function switchView(view: 'chat' | 'events') {
     // #3894: leaving Chat abandons any open configuration takeover, so the
     // top-level tabs always mean what they say — coming back to Chat shows
-    // chat, never a config surface the user left behind minutes ago. Config
-    // edits are saved per-section explicitly, so nothing is lost but the
-    // scroll position within the config form.
-    if (view !== 'chat') closeConfigPane();
+    // chat, never a config surface the user left behind minutes ago.
+    // PR #3895 code-critic HIGH-1: this is also an EXIT path — leaving Chat
+    // unmounts the panel — so it goes through the same guard. When the panel
+    // holds unsaved edits the request raises its confirm and returns false;
+    // we stay on Chat rather than tearing the edit out from under it.
+    if (view !== 'chat' && !requestExitConfigPane()) return;
     activeView = view;
   }
   let tokenInput = '';

--- a/crates/trusty-agents/ui/src/components/AgentConfigOverlay.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigOverlay.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  /**
+   * Why (#3894, epic #3052 — Bob: "when we're in agent configuration, let's
+   * take over that pane, we don't need chat when we're configuring"): the
+   * agent–OKG–tool–listener config surface is the concept centerpiece, and
+   * #3826 gave it a 320px strip wedged above the chat scrollback. This is the
+   * takeover layer that gives it the whole content area instead. It is
+   * deliberately a POSITIONING + EXIT shell only — every field, tab and save
+   * flow still lives in `AgentConfigPanel`, unchanged.
+   * What: An absolutely-positioned layer filling its (relative) parent — the
+   * chat area in `ChatPane` — so the chat column underneath stays MOUNTED and
+   * laid out rather than being `{#if}`-swapped away. That is the whole trick
+   * behind "leaving config returns to chat exactly as it was": an unmounted
+   * `ChatView`/`InputArea` would lose its scroll offset and the user's
+   * half-typed message; a covered one loses nothing. `ChatPane` marks the
+   * covered column `inert`, so nothing behind this layer is focusable or
+   * reachable by a screen reader. Esc exits (see `isConfigExitKey`), as do the
+   * panel's own Back/Close buttons.
+   * Test: `ChatPane.test.ts` (takeover mounts over a preserved chat, Esc and
+   * Back both exit) and `AgentConfigPanel.test.ts` (the exit affordances
+   * themselves).
+   */
+  import { onMount } from 'svelte';
+  import { activeAgentId, agentRoster } from '../stores/app';
+  import { CONCIERGE_LABEL, configAgentName, rosterDisplayName } from '../lib/roster';
+  import { closeConfigPane, isConfigExitKey } from '../stores/configPane';
+  import AgentConfigPanel from './AgentConfigPanel.svelte';
+
+  let container: HTMLElement | null = null;
+
+  $: isConcierge = $activeAgentId === null;
+  $: agentName = configAgentName($activeAgentId);
+  $: displayName = isConcierge
+    ? CONCIERGE_LABEL
+    : rosterDisplayName($agentRoster, $activeAgentId);
+
+  function onKeydown(event: KeyboardEvent) {
+    if (!isConfigExitKey(event)) return;
+    event.preventDefault();
+    closeConfigPane();
+  }
+
+  // Move focus into the takeover on open so a keyboard user isn't left with
+  // focus on the (now `inert`) gear button behind it.
+  onMount(() => {
+    container?.focus();
+  });
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<section
+  bind:this={container}
+  tabindex="-1"
+  aria-label="Agent configuration"
+  data-config-takeover
+  class="absolute inset-0 z-20 flex flex-col bg-foundry-light-surface dark:bg-foundry-surface focus:outline-none"
+>
+  <AgentConfigPanel {agentName} {isConcierge} {displayName} onExit={closeConfigPane} />
+</section>

--- a/crates/trusty-agents/ui/src/components/AgentConfigOverlay.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigOverlay.svelte
@@ -15,29 +15,49 @@
    * half-typed message; a covered one loses nothing. `ChatPane` marks the
    * covered column `inert`, so nothing behind this layer is focusable or
    * reachable by a screen reader. Esc exits (see `isConfigExitKey`), as do the
-   * panel's own Back/Close buttons.
+   * panel's own Back/Close buttons — all three through
+   * `requestExitConfigPane`, which stops to confirm when the panel holds
+   * unsaved edits.
    * Test: `ChatPane.test.ts` (takeover mounts over a preserved chat, Esc and
    * Back both exit) and `AgentConfigPanel.test.ts` (the exit affordances
    * themselves).
    */
   import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
   import { activeAgentId, agentRoster } from '../stores/app';
   import { CONCIERGE_LABEL, configAgentName, rosterDisplayName } from '../lib/roster';
-  import { closeConfigPane, isConfigExitKey } from '../stores/configPane';
+  import { closeConfigPane, isConfigExitKey, requestExitConfigPane } from '../stores/configPane';
   import AgentConfigPanel from './AgentConfigPanel.svelte';
 
   let container: HTMLElement | null = null;
 
-  $: isConcierge = $activeAgentId === null;
-  $: agentName = configAgentName($activeAgentId);
+  /**
+   * Why (PR #3895 code-critic HIGH-2): "we are configuring THIS agent" — the
+   * identity is fixed the moment the takeover opens, NOT followed reactively
+   * from `activeAgentId`. Surfaces outside the covered chat can still write
+   * that store (the Sidebar's resume-workstream flow does), and following it
+   * would silently retarget an open panel at a different agent's config,
+   * throwing away whatever the user had typed into it.
+   * What: Read once at mount — this component is `{#if}`-mounted per opening,
+   * so mount time IS open time. Only the human-facing LABEL stays reactive,
+   * since the roster can finish loading after the pane is already open.
+   */
+  const pinnedAgentId = get(activeAgentId);
+  const isConcierge = pinnedAgentId === null;
+  const agentName = configAgentName(pinnedAgentId);
   $: displayName = isConcierge
     ? CONCIERGE_LABEL
-    : rosterDisplayName($agentRoster, $activeAgentId);
+    : rosterDisplayName($agentRoster, pinnedAgentId);
 
   function onKeydown(event: KeyboardEvent) {
+    // Carry-forward (PR #3895 review): this does not consult
+    // `event.defaultPrevented`. Nothing inside the panel currently handles Esc
+    // itself, but the day a dropdown/combobox lands in there, its Esc must
+    // close the dropdown rather than the whole takeover — add the check then.
     if (!isConfigExitKey(event)) return;
     event.preventDefault();
-    closeConfigPane();
+    // Never closes directly: unsaved edits raise the panel's confirm instead.
+    requestExitConfigPane();
   }
 
   // Move focus into the takeover on open so a keyboard user isn't left with

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
@@ -22,13 +22,22 @@
    * Stores/Listeners render read-only — store bindings are edited in
    * `agent.toml`, not here. Concierge (`ctrl`) gets a static
    * notice per Bob: editable by name, but not an add-agent template.
-   * Test: `agentConfig.test.ts` covers the scaffolding data; this component
-   * is exercised manually (`pnpm dev`, open the gear, edit + save
-   * Personality/Tools, confirm a re-open shows the persisted value) per the
-   * project's existing convention for fetch-driven Svelte views (see
-   * `PersonalityPanel.svelte`'s own "Test: Manual" precedent).
+   *
+   * #3894 (Bob: "when we're in agent configuration, let's take over that
+   * pane"): this panel no longer shares the chat column as a 320px strip —
+   * `AgentConfigOverlay` mounts it as a full-pane takeover, so the layout here
+   * is now a height-filling flex column: header + tabs are `shrink-0` and the
+   * active tab takes the rest, with the instructions editor growing into every
+   * remaining pixel instead of #3862's `55vh/70vh` clamp. The header carries
+   * the takeover's exit affordances (Back / Close, plus an Esc hint —
+   * `AgentConfigOverlay` owns the key handler) via the `onExit` prop.
+   * Test: `AgentConfigPanel.test.ts` (exit affordances, instructions-editor
+   * sizing invariants, tab preservation) + `agentConfig.test.ts` (scaffolding
+   * data); the save round-trip stays manual (`pnpm dev`, open the gear, edit +
+   * save Personality/Tools, confirm a re-open shows the persisted value) per
+   * the project's convention for fetch-driven Svelte views.
    */
-  import { AlertCircle, Save, Loader2, Settings2 } from 'lucide-svelte';
+  import { AlertCircle, ArrowLeft, Save, Loader2, Settings2, X } from 'lucide-svelte';
   import { onMount } from 'svelte';
   import {
     fetchAgentDetail,
@@ -44,6 +53,19 @@
   /** True when the active pane is Concierge (`ctrl`) — fixed coordination
    * layer, no template derivations (Bob). Edits are still allowed. */
   export let isConcierge = false;
+  /**
+   * Why (#3894): the takeover covers `ChatHeader`, which used to be the thing
+   * naming the selected agent ("Concierge"), so this header is now the ONLY
+   * label on screen and must agree with the picker the user just used —
+   * including before `detail` has loaded and for Concierge, whose picker label
+   * is not derived from `agent.toml` at all.
+   * What: Optional display label; falls back to the fetched `display_name`,
+   * then the raw name, exactly as before.
+   */
+  export let displayName = '';
+  /** Leaves the config surface and returns to chat (#3894). Wired to the
+   * Back/Close affordances; Esc is handled by `AgentConfigOverlay`. */
+  export let onExit: () => void;
 
   type Tab = 'personality' | 'okg' | 'tools' | 'permissions' | 'listeners';
   let tab: Tab = 'personality';
@@ -169,21 +191,41 @@
 </script>
 
 <div class="flex h-full w-full flex-col overflow-hidden bg-foundry-light-surface dark:bg-foundry-surface">
-  <header class="flex items-center gap-2 border-b border-foundry-light-border dark:border-foundry-border px-4 py-3">
-    <Settings2 class="h-4 w-4 text-foundry-light-primary dark:text-foundry-primary" />
+  <header class="flex shrink-0 items-center gap-2 border-b border-foundry-light-border dark:border-foundry-border px-4 py-3">
+    <button
+      type="button"
+      class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10 hover:text-foundry-light-primary dark:hover:text-foundry-primary"
+      on:click={onExit}
+    >
+      <ArrowLeft class="h-3.5 w-3.5" /> Back to chat
+    </button>
+    <Settings2 class="ml-2 h-4 w-4 text-foundry-light-primary dark:text-foundry-primary" />
     <h2 class="font-mono text-xs font-semibold uppercase tracking-wide text-foundry-light-text dark:text-foundry-text">
-      Configure {detail?.display_name ?? agentName}
+      Configure {displayName || detail?.display_name || agentName}
     </h2>
+    <span class="ml-auto flex items-center gap-2">
+      <kbd class="rounded border border-foundry-light-border dark:border-foundry-border px-1.5 py-0.5 font-mono text-[10px] uppercase text-foundry-light-muted dark:text-foundry-text/40">
+        Esc
+      </kbd>
+      <button
+        type="button"
+        class="rounded-md p-1.5 text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10 hover:text-foundry-light-primary dark:hover:text-foundry-primary"
+        aria-label="Close agent configuration"
+        on:click={onExit}
+      >
+        <X class="h-4 w-4" />
+      </button>
+    </span>
   </header>
 
   {#if isConcierge}
-    <p class="mx-4 mt-3 rounded-md border border-foundry-amber/40 bg-foundry-amber/10 px-3 py-2 text-xs text-foundry-amber">
+    <p class="mx-4 mt-3 shrink-0 rounded-md border border-foundry-amber/40 bg-foundry-amber/10 px-3 py-2 text-xs text-foundry-amber">
       Concierge is trusty-agents' fixed coordination layer — editable here, but not offered as an
       add-agent template.
     </p>
   {/if}
 
-  <div class="flex flex-wrap gap-1 border-b border-foundry-light-border dark:border-foundry-border px-3 py-2" role="tablist">
+  <div class="flex shrink-0 flex-wrap gap-1 border-b border-foundry-light-border dark:border-foundry-border px-3 py-2" role="tablist">
     {#each [['personality', 'Personality'], ['okg', 'OKG Stores'], ['tools', 'Tools'], ['permissions', 'Permissions'], ['listeners', 'Listeners']] as [id, label] (id)}
       <button
         type="button"
@@ -199,7 +241,13 @@
     {/each}
   </div>
 
-  <div class="flex-1 overflow-y-auto px-4 py-3">
+  <!-- #3894: the body is a flex COLUMN with `min-h-0`, and each tab owns its
+       own scrolling. The editor tabs (Personality/Tools) grow their textarea
+       into the leftover space and scroll INSIDE it; the read-only tabs
+       (OKG/Permissions/Listeners) scroll as a whole. A single shared
+       `overflow-y-auto` here — what #3826 had — would put a second scrollbar
+       around an already-scrolling textarea. -->
+  <div class="flex min-h-0 flex-1 flex-col px-4 py-3">
     {#if loading}
       <div class="flex items-center gap-2 text-sm text-foundry-light-muted dark:text-foundry-text/60">
         <Loader2 class="h-4 w-4 animate-spin" /> Loading…
@@ -209,21 +257,31 @@
         <AlertCircle class="h-4 w-4" /> {loadError}
       </div>
     {:else if tab === 'personality'}
-      <div class="flex h-full flex-col gap-2">
-        <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+      <div class="flex min-h-0 flex-1 flex-col gap-2">
+        <p class="shrink-0 text-xs text-foundry-light-muted dark:text-foundry-text/60">
           Main instructions — this agent's <code class="font-mono">persona.md</code>.
         </p>
         {#if !personaEditable}
-          <p class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2 text-xs text-foundry-light-muted dark:text-foundry-text/50">
+          <p class="shrink-0 rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2 text-xs text-foundry-light-muted dark:text-foundry-text/50">
             This agent has no editable persona.md (flat-file agents don't carry a separate
             personality file).
           </p>
         {:else}
+          <!-- #3894 (supersedes #3862's vh clamp): the instructions editor is
+               the primary surface of this pane, so it takes EVERY remaining
+               pixel of the takeover — `flex-1 min-h-0`, no `rows`, no
+               `min-h-[55vh]/max-h-[70vh]` clamp (which capped it at 70% of the
+               viewport and left dead space below on a tall window, and could
+               overflow its container on a short one). It is the only scroll
+               container in this tab; `resize-none` because a drag handle can
+               only make a full-height field smaller. -->
           <textarea
             bind:value={personaContent}
-            class="w-full flex-1 min-h-[55vh] max-h-[70vh] resize-y overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
+            spellcheck="false"
+            data-instructions-editor
+            class="w-full min-h-0 flex-1 resize-none overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs leading-relaxed text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
           ></textarea>
-          <div class="sticky bottom-0 flex items-center gap-2 bg-foundry-light-surface dark:bg-foundry-surface pt-1 pb-1">
+          <div class="flex shrink-0 items-center gap-2 pt-1">
             <button
               type="button"
               class="inline-flex items-center gap-1.5 rounded-md bg-foundry-light-primary dark:bg-foundry-primary px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-foundry-light-primary/80 dark:hover:bg-foundry-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
@@ -237,19 +295,19 @@
             {/if}
           </div>
         {/if}
-        <p class="pt-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">
+        <p class="shrink-0 pt-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">
           Event-specific instructions (per-connector context loaded on an incoming event — e.g. a
           Gmail event loading Gmail-connector instructions) are a separate runtime epic. This
           section is scaffolding until that backend exists.
         </p>
-        <div class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">
+        <div class="shrink-0 rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">
           {#each DEFINED_LISTENERS as listener (listener.id)}
             <div class="py-0.5">{listener.label}: no event instructions configured</div>
           {/each}
         </div>
       </div>
     {:else if tab === 'okg'}
-      <div class="flex flex-col gap-2">
+      <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
         <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
           Knowledge trees + search indexes bound to this agent, resolved live against
           trusty-search and trusty-memory. Edit bindings in
@@ -308,16 +366,18 @@
         {/each}
       </div>
     {:else if tab === 'tools'}
-      <div class="flex h-full flex-col gap-2">
-        <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+      <div class="flex min-h-0 flex-1 flex-col gap-2">
+        <p class="shrink-0 text-xs text-foundry-light-muted dark:text-foundry-text/60">
           MCP tool allow-list — one glob pattern per line (e.g. <code class="font-mono">gworkspace_*</code>). Empty = no restriction.
         </p>
+        <!-- Same full-height treatment as the instructions editor above. -->
         <textarea
           bind:value={toolsText}
+          spellcheck="false"
           placeholder="gworkspace_*&#10;memory_*"
-          class="w-full flex-1 min-h-[55vh] max-h-[70vh] resize-y overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
+          class="w-full min-h-0 flex-1 resize-none overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs leading-relaxed text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
         ></textarea>
-        <div class="flex items-center gap-2 pt-1">
+        <div class="flex shrink-0 items-center gap-2 pt-1">
           <button
             type="button"
             class="inline-flex items-center gap-1.5 rounded-md bg-foundry-light-primary dark:bg-foundry-primary px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-foundry-light-primary/80 dark:hover:bg-foundry-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
@@ -332,7 +392,7 @@
         </div>
       </div>
     {:else if tab === 'permissions'}
-      <div class="flex flex-col gap-2">
+      <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
         <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
           RBAC / OpenRPC scopes claimed by this agent — read-only (no write path yet).
         </p>
@@ -349,7 +409,7 @@
         {/if}
       </div>
     {:else if tab === 'listeners'}
-      <div class="flex flex-col gap-3">
+      <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
         <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
           Inbound event bindings — API connections to upstream event providers, not MCP tools. No
           backend yet (spec being filed); shown as the two defined listener bindings.
@@ -376,7 +436,7 @@
     {/if}
 
     {#if saveError}
-      <p class="mt-2 text-xs text-red-500 dark:text-red-400">{saveError}</p>
+      <p class="mt-2 shrink-0 text-xs text-red-500 dark:text-red-400">{saveError}</p>
     {/if}
   </div>
 </div>

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
@@ -30,7 +30,9 @@
    * active tab takes the rest, with the instructions editor growing into every
    * remaining pixel instead of #3862's `55vh/70vh` clamp. The header carries
    * the takeover's exit affordances (Back / Close, plus an Esc hint —
-   * `AgentConfigOverlay` owns the key handler) via the `onExit` prop.
+   * `AgentConfigOverlay` owns the key handler) via the `onExit` prop, and no
+   * exit path reaches `onExit` without passing the unsaved-changes confirm
+   * (see `requestExit` / `configPaneDirty`).
    * Test: `AgentConfigPanel.test.ts` (exit affordances, instructions-editor
    * sizing invariants, tab preservation) + `agentConfig.test.ts` (scaffolding
    * data); the save round-trip stays manual (`pnpm dev`, open the gear, edit +
@@ -38,7 +40,9 @@
    * the project's convention for fetch-driven Svelte views.
    */
   import { AlertCircle, ArrowLeft, Save, Loader2, Settings2, X } from 'lucide-svelte';
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
+  import { get } from 'svelte/store';
+  import { configExitIntent, configPaneDirty } from '../stores/configPane';
   import {
     fetchAgentDetail,
     fetchAgentPersona,
@@ -93,6 +97,58 @@
 
   $: personalityDirty = personaContent !== savedPersonaContent;
   $: toolsDirty = toolsText !== savedToolsText;
+
+  /**
+   * Why (PR #3895 code-critic HIGH-1): before this, Esc/Back/Close unmounted
+   * the panel and took any unsaved persona edit with them — silently, with no
+   * confirmation, on a surface whose whole point is hand-writing long system
+   * prompts. Confirm-before-discard (with a save option) rather than
+   * auto-save-on-exit: auto-saving would persist a half-finished prompt to
+   * `persona.md` and change how the agent actually behaves, which is the worse
+   * failure of the two.
+   * What: `configPaneDirty` mirrors the panel's dirty state for the exit paths
+   * that live outside it (Esc, and App's Chat→Events switch); those raise
+   * `configExitIntent`, which this component turns into the confirm prompt.
+   * Test: `ChatPane.test.ts` — Esc / Back / Close / tab-switch with a dirty
+   * editor.
+   */
+  let confirmingExit = false;
+  let seenExitIntent = get(configExitIntent);
+
+  $: configPaneDirty.set(personalityDirty || toolsDirty);
+  $: if ($configExitIntent !== seenExitIntent) {
+    seenExitIntent = $configExitIntent;
+    confirmingExit = true;
+  }
+  $: dirtySections = [personalityDirty && 'Personality', toolsDirty && 'Tools']
+    .filter(Boolean)
+    .join(' and ');
+
+  onDestroy(() => configPaneDirty.set(false));
+
+  /** Exit affordances go through here, never straight to `onExit`. */
+  function requestExit() {
+    if (personalityDirty || toolsDirty) {
+      confirmingExit = true;
+      return;
+    }
+    onExit();
+  }
+
+  function discardAndExit() {
+    confirmingExit = false;
+    configPaneDirty.set(false);
+    onExit();
+  }
+
+  async function saveAndExit() {
+    saveError = '';
+    if (personalityDirty) await savePersonality();
+    if (!saveError && toolsDirty) await saveTools();
+    if (saveError) return; // stay put and show the error rather than lose the edit
+    confirmingExit = false;
+    onExit();
+  }
 
   function toolsArrayFromText(text: string): string[] {
     return text
@@ -190,12 +246,12 @@
   });
 </script>
 
-<div class="flex h-full w-full flex-col overflow-hidden bg-foundry-light-surface dark:bg-foundry-surface">
+<div class="relative flex h-full w-full flex-col overflow-hidden bg-foundry-light-surface dark:bg-foundry-surface">
   <header class="flex shrink-0 items-center gap-2 border-b border-foundry-light-border dark:border-foundry-border px-4 py-3">
     <button
       type="button"
       class="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10 hover:text-foundry-light-primary dark:hover:text-foundry-primary"
-      on:click={onExit}
+      on:click={requestExit}
     >
       <ArrowLeft class="h-3.5 w-3.5" /> Back to chat
     </button>
@@ -211,7 +267,7 @@
         type="button"
         class="rounded-md p-1.5 text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10 hover:text-foundry-light-primary dark:hover:text-foundry-primary"
         aria-label="Close agent configuration"
-        on:click={onExit}
+        on:click={requestExit}
       >
         <X class="h-4 w-4" />
       </button>
@@ -439,4 +495,53 @@
       <p class="mt-2 shrink-0 text-xs text-red-500 dark:text-red-400">{saveError}</p>
     {/if}
   </div>
+
+  <!-- Confirm-before-discard (code-critic HIGH-1). Rendered inside the panel
+       because only this component can save; every exit path — the header's
+       Back/Close, Esc, and the Chat→Events tab switch — arrives here. -->
+  {#if confirmingExit}
+    <div
+      role="alertdialog"
+      aria-modal="true"
+      aria-label="Unsaved configuration changes"
+      class="absolute inset-0 z-30 flex items-center justify-center bg-black/40 px-4"
+    >
+      <div class="w-full max-w-md rounded-lg border border-foundry-light-border dark:border-foundry-border bg-foundry-light-surface dark:bg-foundry-surface p-5 shadow-xl">
+        <h3 class="mb-1 text-sm font-semibold text-foundry-light-text dark:text-foundry-text">
+          Unsaved changes
+        </h3>
+        <p class="mb-4 text-xs leading-relaxed text-foundry-light-muted dark:text-foundry-text/60">
+          Your {dirtySections} {dirtySections.includes(' and ') ? 'edits have' : 'edit has'} not been
+          saved. Leaving configuration now discards {dirtySections.includes(' and ') ? 'them' : 'it'}.
+        </p>
+        <div class="flex flex-wrap items-center justify-end gap-2">
+          <button
+            type="button"
+            class="rounded-md px-3 py-1.5 text-xs font-medium text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10"
+            on:click={() => (confirmingExit = false)}
+          >
+            Keep editing
+          </button>
+          <button
+            type="button"
+            class="rounded-md border border-red-500/40 px-3 py-1.5 text-xs font-medium text-red-500 dark:text-red-400 hover:bg-red-500/10"
+            on:click={discardAndExit}
+          >
+            Discard changes
+          </button>
+          <button
+            type="button"
+            class="inline-flex items-center gap-1.5 rounded-md bg-foundry-light-primary dark:bg-foundry-primary px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-foundry-light-primary/80 dark:hover:bg-foundry-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={saving}
+            on:click={saveAndExit}
+          >
+            <Save class="h-3.5 w-3.5" /> {saving ? 'Saving…' : 'Save and close'}
+          </button>
+        </div>
+        {#if saveError}
+          <p class="mt-3 text-xs text-red-500 dark:text-red-400">{saveError}</p>
+        {/if}
+      </div>
+    </div>
+  {/if}
 </div>

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
@@ -1,0 +1,171 @@
+// Why (#3894): two regressions this component has already shipped twice are
+// pinned here. (1) The instructions editor keeps shrinking back to a strip —
+// #3862 fixed a 2-line field with a `55vh/70vh` clamp, which the full-pane
+// takeover then made wrong in the other direction (dead space below on a tall
+// window). The fix is "grow into whatever the pane gives you", which is a
+// structural property: a `flex-1`/`min-h-0` chain with no fixed `rows` and no
+// second scroll container wrapped around it. (2) The takeover needs exit
+// affordances that actually call back out. Neither is expressible without
+// mounting the component.
+// What: Mounts the real panel with `fetch` stubbed for the three routes it
+// loads (`/api/agents/:name`, `.../persona`, `.../stores`), then asserts the
+// sizing invariants and the Back/Close wiring. jsdom does no layout, so the
+// "grows with the viewport" half is asserted as the flex chain that produces
+// it rather than as a measured pixel height.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+import AgentConfigPanel from './AgentConfigPanel.svelte';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+const PERSONA = 'You are Izzie.\n'.repeat(300);
+
+function stubApi() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const json = url.includes('/persona')
+        ? { content: PERSONA, editable: true }
+        : url.includes('/stores')
+          ? { stores: [{ name: 'izzie-kb', tree: 'okg://izzie', index: 'izzie', connected: true }], issues: [] }
+          : {
+              name: 'izzie',
+              display_name: 'Izzie',
+              tools_allow: ['gworkspace_*'],
+              scopes: ['agents.read'],
+            };
+      return { ok: true, status: 200, json: async () => json } as Response;
+    }),
+  );
+}
+
+function mountPanel(onExit = vi.fn()) {
+  instance = mount(AgentConfigPanel, {
+    target,
+    props: { agentName: 'izzie', isConcierge: false, displayName: 'Izzie', onExit },
+  }) as unknown as Record<string, unknown>;
+  return onExit;
+}
+
+const editor = () => target.querySelector('[data-instructions-editor]') as HTMLTextAreaElement;
+const tabButton = (label: string) =>
+  Array.from(target.querySelectorAll('[role="tab"]')).find(
+    (b) => b.textContent?.trim() === label,
+  ) as HTMLButtonElement;
+
+beforeEach(() => {
+  stubApi();
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('AgentConfigPanel — exit affordances (#3894)', () => {
+  it('Back and Close both call onExit', async () => {
+    const onExit = mountPanel();
+    await waitFor(() => editor() !== null);
+
+    const back = Array.from(target.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Back to chat'),
+    ) as HTMLButtonElement;
+    back.click();
+    expect(onExit).toHaveBeenCalledTimes(1);
+
+    (target.querySelector('[aria-label="Close agent configuration"]') as HTMLButtonElement).click();
+    expect(onExit).toHaveBeenCalledTimes(2);
+  });
+
+  it('names the agent with the label the picker used, not the raw id', async () => {
+    mountPanel();
+    await waitFor(() => editor() !== null);
+    expect(target.querySelector('header')?.textContent).toContain('Izzie');
+  });
+});
+
+describe('AgentConfigPanel — instructions editor sizing (#3894)', () => {
+  it('grows into the pane instead of being clamped to a fixed or viewport height', async () => {
+    mountPanel();
+    await waitFor(() => editor() !== null);
+
+    const classes = editor().className;
+    // Grows with whatever height the takeover gives the pane…
+    expect(classes).toContain('flex-1');
+    // …with `min-h-0`, without which a flex child refuses to shrink below its
+    // content and the whole column overflows (the #3862 failure mode).
+    expect(classes).toContain('min-h-0');
+    // No fixed row count and no viewport clamp: both cap the editor
+    // independently of the space actually available.
+    expect(editor().hasAttribute('rows')).toBe(false);
+    expect(classes).not.toMatch(/min-h-\[\d+vh\]/);
+    expect(classes).not.toMatch(/max-h-\[\d+vh\]/);
+    // Monospace, per the directive — these are system prompts, not prose.
+    expect(classes).toContain('font-mono');
+  });
+
+  it('is the only scroll container in its tab — no nested double scrollbars', async () => {
+    mountPanel();
+    await waitFor(() => editor() !== null);
+
+    expect(editor().className).toContain('overflow-y-auto');
+
+    // Walk from the editor up to the panel root: every ancestor must be a
+    // height-passing flex box, never a second scroller wrapped around the
+    // first.
+    const root = target.firstElementChild as HTMLElement;
+    for (let el = editor().parentElement; el && el !== root; el = el.parentElement) {
+      expect(el.className).not.toContain('overflow-y-auto');
+      expect(el.className).toContain('min-h-0');
+      expect(el.className).toContain('flex-1');
+    }
+    expect(root.className).toContain('overflow-hidden');
+  });
+
+  it('the whole persona loads into the editor (multi-hundred-line prompts)', async () => {
+    mountPanel();
+    await waitFor(() => (editor()?.value.length ?? 0) > 0);
+    expect(editor().value).toBe(PERSONA);
+    expect(editor().value.split('\n').length).toBeGreaterThan(300);
+  });
+});
+
+describe('AgentConfigPanel — existing sections still render (#3826/#3816 regression guard)', () => {
+  it('keeps the OKG stores, Tools, Permissions and Listeners tabs', async () => {
+    mountPanel();
+    await waitFor(() => editor() !== null);
+
+    tabButton('OKG Stores').click();
+    await waitFor(() => target.textContent?.includes('izzie-kb') ?? false);
+    expect(target.textContent).toContain('okg://izzie');
+
+    tabButton('Tools').click();
+    await waitFor(() => target.querySelector('textarea') !== null);
+    expect((target.querySelector('textarea') as HTMLTextAreaElement).value).toBe('gworkspace_*');
+
+    tabButton('Permissions').click();
+    await waitFor(() => target.textContent?.includes('agents.read') ?? false);
+
+    tabButton('Listeners').click();
+    await waitFor(() => target.textContent?.includes('Gmail') ?? false);
+    expect(target.textContent).toContain('Google Calendar');
+  });
+});

--- a/crates/trusty-agents/ui/src/components/ChatHeader.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatHeader.svelte
@@ -25,13 +25,17 @@
    * Assistant; the base `assistant` template never appears here at all,
    * it's `hidden` server-side and only ever instantiated via Concierge or
    * the add-agent template flow, `AddAgentForm`); a "+ Add agent" row; and
-   * a gear button toggling `AgentConfigPanel` for whichever agent is
-   * selected.
-   * Test: Manual — open the app, confirm "Concierge" is the default title
-   * and appears exactly once in the open dropdown (System Tool section);
-   * switch to Izzie via the Assistants section, confirm the title updates;
-   * click the gear, confirm `AgentConfigPanel` opens scoped to the selected
-   * agent.
+   * a gear button toggling the agent-configuration takeover (#3894) for
+   * whichever agent is selected. The gear only flips
+   * `stores/configPane.ts`'s `configPaneOpen`: the config surface covers the
+   * recap rail as well as this column, so it is rendered by `ChatPane` as a
+   * SIBLING of the whole chat column rather than mounted here — which is
+   * also what lets the chat stay mounted (scroll offset + half-typed
+   * message) behind it instead of being unmounted and rebuilt on exit.
+   * Test: `ChatPane.test.ts` (the gear opens the takeover). Manual — open the
+   * app, confirm "Concierge" is the default title and appears exactly once in
+   * the open dropdown (System Tool section); switch to Izzie via the
+   * Assistants section, confirm the title updates.
    */
   import { onMount } from 'svelte';
   import { ChevronDown, Settings2, Plus, Bot } from 'lucide-svelte';
@@ -41,22 +45,19 @@
     fetchAgentCatalog,
     refreshOverlayAgents,
   } from '../stores/app';
-  import { rosterDisplayName } from '../lib/roster';
-  import AgentConfigPanel from './AgentConfigPanel.svelte';
+  // `CONCIERGE_AGENT_ID` — the one agent id Concierge's dedicated row
+  // represents — is excluded from the roster-driven "Assistants" section to
+  // avoid the duplicate. Both constants moved to `lib/roster.ts` in #3894 so
+  // the config takeover resolves the same identity from the same place.
+  import { CONCIERGE_AGENT_ID, CONCIERGE_LABEL, rosterDisplayName } from '../lib/roster';
+  import { configPaneOpen, toggleConfigPane } from '../stores/configPane';
   import AddAgentForm from './AddAgentForm.svelte';
 
-  const CONCIERGE_LABEL = 'Concierge';
-  /** The one agent id Concierge's dedicated row represents — excluded from
-   * the roster-driven "Assistants" section to avoid the duplicate. */
-  const CONCIERGE_AGENT_ID = 'ctrl';
-
   let open = false;
-  let configOpen = false;
   let addingAgent = false;
 
   $: isConcierge = $activeAgentId === null;
   $: title = isConcierge ? CONCIERGE_LABEL : rosterDisplayName($agentRoster, $activeAgentId);
-  $: configAgentName = isConcierge ? CONCIERGE_AGENT_ID : ($activeAgentId ?? 'assistant');
   // #3819 roster-typing: "Assistants" section is everything the roster
   // returns EXCEPT ctrl (Concierge has its own dedicated System Tool row).
   $: assistantEntries = $agentRoster.filter((e) => e.id !== CONCIERGE_AGENT_ID);
@@ -74,10 +75,6 @@
   function selectRosterEntry(id: string) {
     activeAgentId.set(id);
     open = false;
-  }
-
-  function toggleConfig() {
-    configOpen = !configOpen;
   }
 
   function handleWindowClick(event: MouseEvent) {
@@ -198,15 +195,9 @@
     type="button"
     class="rounded-md p-1.5 text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10 hover:text-foundry-light-primary dark:hover:text-foundry-primary"
     aria-label="Configure agent"
-    aria-pressed={configOpen}
-    on:click={toggleConfig}
+    aria-pressed={$configPaneOpen}
+    on:click={toggleConfigPane}
   >
     <Settings2 class="h-4 w-4" />
   </button>
 </div>
-
-{#if configOpen}
-  <div class="h-80 shrink-0 border-b border-foundry-light-border dark:border-foundry-border">
-    <AgentConfigPanel agentName={configAgentName} isConcierge={isConcierge} />
-  </div>
-{/if}

--- a/crates/trusty-agents/ui/src/components/ChatHeader.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatHeader.svelte
@@ -50,7 +50,7 @@
   // avoid the duplicate. Both constants moved to `lib/roster.ts` in #3894 so
   // the config takeover resolves the same identity from the same place.
   import { CONCIERGE_AGENT_ID, CONCIERGE_LABEL, rosterDisplayName } from '../lib/roster';
-  import { configPaneOpen, toggleConfigPane } from '../stores/configPane';
+  import { configPaneOpen, openConfigPane, requestExitConfigPane } from '../stores/configPane';
   import AddAgentForm from './AddAgentForm.svelte';
 
   let open = false;
@@ -65,6 +65,28 @@
   function toggleDropdown() {
     open = !open;
     if (open) addingAgent = false;
+  }
+
+  /**
+   * Why (PR #3895 re-review): the gear is an EXIT affordance too — pressing it
+   * while the takeover is up leaves configuration — so it must pass the same
+   * unsaved-edits guard as Esc/Back/Close. A plain `toggleConfigPane()` here
+   * flipped `configPaneOpen` straight to false, silently discarding a dirty
+   * panel. `inert` on the covered chat makes that click unreachable in a
+   * standards-compliant browser, but a data-loss guard cannot rest on a CSS/DOM
+   * property whose behavior in the Tauri WKWebView is unverified — it belongs
+   * in the state logic. (`toggleConfigPane` was deleted with this change so no
+   * future caller can reintroduce the bypass.)
+   * What: Opens directly; leaves via `requestExitConfigPane`, which raises the
+   * panel's confirm when there is something unsaved to lose.
+   * Test: `ChatPane.test.ts` — "the gear cannot silently discard a dirty panel".
+   */
+  function handleGear() {
+    if ($configPaneOpen) {
+      requestExitConfigPane();
+    } else {
+      openConfigPane();
+    }
   }
 
   function selectConcierge() {
@@ -196,7 +218,7 @@
     class="rounded-md p-1.5 text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10 hover:text-foundry-light-primary dark:hover:text-foundry-primary"
     aria-label="Configure agent"
     aria-pressed={$configPaneOpen}
-    on:click={toggleConfigPane}
+    on:click={handleGear}
   >
     <Settings2 class="h-4 w-4" />
   </button>

--- a/crates/trusty-agents/ui/src/components/ChatPane.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatPane.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  /**
+   * Why (#3894): the Chat view's composition — chat column + recap rail +
+   * conditional Slack mirror — moved out of `App.svelte` because the agent
+   * configuration takeover has to be a SIBLING of that whole group (it covers
+   * the recap rail, not just the chat column), and because the invariant Bob
+   * asked for ("leaving config returns to chat exactly as it was") is a
+   * property of this composition that is worth pinning in a test —
+   * `App.svelte` itself is not mountable in jsdom (sidecar bootstrap,
+   * EventSource, Tauri `invoke`).
+   * What: A positioned (`relative`) chat area. While `configPaneOpen` is set,
+   * `AgentConfigOverlay` is absolutely positioned over it and the chat group
+   * is marked `inert` — hidden and unreachable, but still MOUNTED, which is
+   * exactly what preserves the scrollback offset and any half-typed message
+   * in the composer. Unmounting it (an `{#if}`/`{:else}` swap) would rebuild
+   * both from scratch on exit and silently discard the draft.
+   * Test: `ChatPane.test.ts`.
+   */
+  import ChatHeader from './ChatHeader.svelte';
+  import ChatView from './ChatView.svelte';
+  import InputArea from './InputArea.svelte';
+  import RecapPanel from './RecapPanel.svelte';
+  import SlackMirror from './SlackMirror.svelte';
+  import AgentConfigOverlay from './AgentConfigOverlay.svelte';
+  import { slackMirror } from '../lib/slack-mirror';
+  import { configPaneOpen } from '../stores/configPane';
+</script>
+
+<div class="relative flex flex-1 min-h-0">
+  <!-- #3219: RecapPanel is a persistent right rail (own scroll, AGENTS ACTIVE
+       / FILES TOUCHED / TOKENS + folded recap summary), so it sits beside the
+       chat+input column rather than stacked between them. -->
+  <div class="flex flex-1 min-h-0" data-chat-surface inert={$configPaneOpen}>
+    <div class="flex flex-1 flex-col min-w-0">
+      <ChatHeader />
+      <ChatView />
+      <InputArea />
+    </div>
+    <RecapPanel />
+    <!-- #3752: the live Slack mirror only mounts once there's activity, so
+         normal (non-Slack) usage is visually unchanged. -->
+    {#if $slackMirror.length > 0}
+      <SlackMirror />
+    {/if}
+  </div>
+
+  {#if $configPaneOpen}
+    <AgentConfigOverlay />
+  {/if}
+</div>

--- a/crates/trusty-agents/ui/src/components/ChatPane.test.ts
+++ b/crates/trusty-agents/ui/src/components/ChatPane.test.ts
@@ -15,7 +15,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';
 import { mount, unmount } from 'svelte';
 import ChatPane from './ChatPane.svelte';
-import { closeConfigPane, configPaneOpen } from '../stores/configPane';
+import { closeConfigPane, configPaneDirty, configPaneOpen } from '../stores/configPane';
+import { activeAgentId, activeProjectId, addMessage } from '../stores/app';
 
 let target: HTMLDivElement;
 let instance: Record<string, unknown> | null = null;
@@ -76,6 +77,8 @@ function pressEscape() {
 
 beforeEach(() => {
   closeConfigPane();
+  configPaneDirty.set(false);
+  activeAgentId.set(null);
   stubApi();
   target = document.createElement('div');
   document.body.appendChild(target);
@@ -184,5 +187,155 @@ describe('ChatPane — agent configuration takeover (#3894)', () => {
     pressEscape();
     await waitFor(() => takeover() === null);
     expect(gearButton().getAttribute('aria-pressed')).toBe('false');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR #3895 code-critic follow-ups. Each block pins one HIGH finding.
+// ---------------------------------------------------------------------------
+
+const editor = () =>
+  target.querySelector('[data-instructions-editor]') as HTMLTextAreaElement | null;
+const confirmDialog = () => target.querySelector('[role="alertdialog"]');
+const button = (label: string) =>
+  Array.from(target.querySelectorAll('button')).find((b) =>
+    b.textContent?.trim().includes(label),
+  ) as HTMLButtonElement;
+
+/** Opens the takeover and dirties the Personality editor. */
+async function openAndDirty(text = 'a half-finished system prompt') {
+  gearButton().click();
+  await waitFor(() => (editor()?.value.length ?? 0) > 0);
+  const el = editor() as HTMLTextAreaElement;
+  el.value = text;
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  await waitFor(() => get(configPaneDirty));
+}
+
+describe('ChatPane — unsaved edits are never discarded silently (HIGH-1)', () => {
+  it('Esc on a dirty panel confirms instead of closing', async () => {
+    await openAndDirty();
+
+    pressEscape();
+    await waitFor(() => confirmDialog() !== null);
+
+    expect(takeover()).not.toBeNull();
+    expect(get(configPaneOpen)).toBe(true);
+    expect(editor()?.value).toBe('a half-finished system prompt');
+  });
+
+  it('Back and Close on a dirty panel confirm instead of closing', async () => {
+    await openAndDirty();
+
+    button('Back to chat').click();
+    await waitFor(() => confirmDialog() !== null);
+    expect(get(configPaneOpen)).toBe(true);
+
+    button('Keep editing').click();
+    await waitFor(() => confirmDialog() === null);
+
+    (target.querySelector('[aria-label="Close agent configuration"]') as HTMLButtonElement).click();
+    await waitFor(() => confirmDialog() !== null);
+    expect(get(configPaneOpen)).toBe(true);
+  });
+
+  it('"Keep editing" returns to the panel with the edit intact', async () => {
+    await openAndDirty();
+    pressEscape();
+    await waitFor(() => confirmDialog() !== null);
+
+    button('Keep editing').click();
+    await waitFor(() => confirmDialog() === null);
+
+    expect(takeover()).not.toBeNull();
+    expect(editor()?.value).toBe('a half-finished system prompt');
+  });
+
+  it('"Discard changes" is the only path that throws the edit away', async () => {
+    await openAndDirty();
+    pressEscape();
+    await waitFor(() => confirmDialog() !== null);
+
+    button('Discard changes').click();
+    await waitFor(() => takeover() === null);
+
+    expect(get(configPaneOpen)).toBe(false);
+    expect(get(configPaneDirty)).toBe(false);
+  });
+
+  it('"Save and close" persists the edit before leaving', async () => {
+    await openAndDirty('saved before exit');
+    pressEscape();
+    await waitFor(() => confirmDialog() !== null);
+
+    button('Save and close').click();
+    await waitFor(() => takeover() === null);
+
+    const patch = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => (c[1] as RequestInit | undefined)?.method === 'PATCH',
+    );
+    expect(patch).toBeDefined();
+    expect(JSON.parse(String((patch![1] as RequestInit).body))).toEqual({
+      personality: 'saved before exit',
+    });
+    expect(get(configPaneOpen)).toBe(false);
+  });
+
+  it('a clean panel still exits on the first press — the guard is not a nag', async () => {
+    gearButton().click();
+    await waitFor(() => takeover() !== null);
+
+    pressEscape();
+    await waitFor(() => takeover() === null);
+    expect(confirmDialog()).toBeNull();
+  });
+});
+
+describe('ChatPane — the configured agent is pinned at open time (HIGH-2)', () => {
+  it('a background agent switch cannot retarget the open panel or discard its edits', async () => {
+    await openAndDirty('edits for the pinned agent');
+    expect(target.querySelector('header')?.textContent).toContain('Concierge');
+
+    // The Sidebar's resume-workstream flow does exactly this while the
+    // takeover is up — it lives outside the inert chat.
+    activeAgentId.set('izzie');
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(target.querySelector('header')?.textContent).toContain('Concierge');
+    expect(editor()?.value).toBe('edits for the pinned agent');
+    // No refetch was triggered for the other agent.
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(calls.some((u) => u.includes('/api/agents/izzie'))).toBe(false);
+  });
+});
+
+describe('ChatPane — a covered chat keeps its scroll offset (HIGH-3)', () => {
+  it('a message arriving while the takeover is open leaves the scrolled-up chat where it was', async () => {
+    const scroller = target.querySelector('[data-chat-scroll]') as HTMLElement;
+    // jsdom does no layout, so give the container real metrics: 1000px of
+    // content in a 200px window, parked 100px from the top (i.e. scrolled up
+    // to read history — decidedly NOT pinned to the bottom).
+    Object.defineProperty(scroller, 'scrollHeight', { value: 1000, configurable: true });
+    Object.defineProperty(scroller, 'clientHeight', { value: 200, configurable: true });
+    Object.defineProperty(scroller, 'scrollTop', { value: 100, writable: true, configurable: true });
+    scroller.dispatchEvent(new Event('scroll'));
+
+    gearButton().click();
+    await waitFor(() => takeover() !== null);
+
+    // An SSE delta landing mid-configuration.
+    addMessage(get(activeProjectId), {
+      id: 'm-while-covered',
+      role: 'assistant',
+      content: 'a reply that arrived while you were configuring',
+      timestamp: Date.now(),
+    });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(scroller.scrollTop).toBe(100);
+
+    pressEscape();
+    await waitFor(() => takeover() === null);
+    expect(scroller.scrollTop).toBe(100);
   });
 });

--- a/crates/trusty-agents/ui/src/components/ChatPane.test.ts
+++ b/crates/trusty-agents/ui/src/components/ChatPane.test.ts
@@ -181,9 +181,10 @@ describe('ChatPane — agent configuration takeover (#3894)', () => {
     await waitFor(() => takeover() !== null);
     expect(gearButton().getAttribute('aria-pressed')).toBe('true');
 
-    // NB: the gear cannot be the way BACK — it sits inside the `inert` chat
-    // while the takeover is up, so a real browser ignores clicks on it. That
-    // is exactly why the takeover carries its own Back/Close/Esc exits.
+    // The gear does close a CLEAN panel (it routes through the exit guard,
+    // which finds nothing to lose) — though in a real browser it also sits
+    // inside the `inert` chat, so the takeover's own Back/Close/Esc are the
+    // reachable exits.
     pressEscape();
     await waitFor(() => takeover() === null);
     expect(gearButton().getAttribute('aria-pressed')).toBe('false');
@@ -279,6 +280,25 @@ describe('ChatPane — unsaved edits are never discarded silently (HIGH-1)', () 
       personality: 'saved before exit',
     });
     expect(get(configPaneOpen)).toBe(false);
+  });
+
+  it('the gear cannot silently discard a dirty panel', async () => {
+    // PR #3895 re-review: the gear is an exit affordance too. It used to bind a
+    // raw toggle, so a second press closed a dirty panel with no confirm — its
+    // only protection was `inert` on the covered chat, which is a rendering
+    // property, not a data-loss guard (and unverified in Tauri's WKWebView).
+    await openAndDirty('typed, then the gear was pressed again');
+
+    gearButton().click();
+    await waitFor(() => confirmDialog() !== null);
+
+    expect(takeover()).not.toBeNull();
+    expect(get(configPaneOpen)).toBe(true);
+
+    button('Keep editing').click();
+    await waitFor(() => confirmDialog() === null);
+    expect(takeover()).not.toBeNull();
+    expect(editor()?.value).toBe('typed, then the gear was pressed again');
   });
 
   it('a clean panel still exits on the first press — the guard is not a nag', async () => {

--- a/crates/trusty-agents/ui/src/components/ChatPane.test.ts
+++ b/crates/trusty-agents/ui/src/components/ChatPane.test.ts
@@ -1,0 +1,188 @@
+// Why (#3894): Bob's takeover directive carries a hard constraint that only a
+// mounted DOM can express — "leaving config returns to chat exactly as it
+// was". The tempting implementation ({#if configOpen} config {:else} chat
+// {/if}) satisfies the visible half of the directive and silently breaks this
+// half: the chat scrollback and the user's half-typed message are rebuilt from
+// scratch on exit. These tests pin the structural property that prevents that
+// regression — the chat subtree is the SAME DOM node before, during, and after
+// the takeover — plus both exit affordances (Esc and Back).
+// What: Mounts the real `ChatPane` with `fetch` stubbed (`ChatHeader` and the
+// config panel both fetch on mount), mirroring
+// `crates/trusty-code-gui/ui/src/components/ProjectPickerModal.test.ts`'s
+// stub-fetch mounting pattern.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { mount, unmount } from 'svelte';
+import ChatPane from './ChatPane.svelte';
+import { closeConfigPane, configPaneOpen } from '../stores/configPane';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+/** Answers every route the chat pane + config panel touch on mount. */
+function stubApi() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const json = url.includes('/persona')
+        ? { content: 'You are a careful assistant.', editable: true }
+        : url.includes('/stores')
+          ? { stores: [], issues: [] }
+          : url.endsWith('/api/agents')
+            ? { agents: [{ name: 'izzie', display_name: 'Izzie' }] }
+            : {
+                name: 'ctrl',
+                display_name: 'Concierge',
+                tools_allow: [],
+                scopes: [],
+              };
+      return { ok: true, status: 200, json: async () => json } as Response;
+    }),
+  );
+}
+
+const chatSurface = () =>
+  target.querySelector('[data-chat-surface]') as HTMLElement & { inert?: boolean };
+
+/** `inert` is one of Svelte's DOM_PROPERTIES — it is assigned as the IDL
+ * property (`node.inert = true`), which is what actually disables the subtree
+ * in a browser, rather than as a content attribute. */
+const chatIsInert = () => chatSurface().inert === true;
+const takeover = () => target.querySelector('[data-config-takeover]');
+const gearButton = () => target.querySelector('[aria-label="Configure agent"]') as HTMLButtonElement;
+const composer = () => target.querySelector('footer textarea') as HTMLTextAreaElement;
+
+/** Types into the composer the way a user would (Svelte binds on `input`). */
+function typeInComposer(text: string) {
+  const el = composer();
+  el.value = text;
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function pressEscape() {
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+}
+
+beforeEach(() => {
+  closeConfigPane();
+  stubApi();
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  instance = mount(ChatPane, { target }) as unknown as Record<string, unknown>;
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+  vi.unstubAllGlobals();
+  closeConfigPane();
+});
+
+describe('ChatPane — agent configuration takeover (#3894)', () => {
+  it('shows chat and no config surface by default', () => {
+    expect(chatSurface()).not.toBeNull();
+    expect(takeover()).toBeNull();
+    expect(chatIsInert()).toBe(false);
+  });
+
+  it('the gear button opens a full-pane takeover that covers the chat', async () => {
+    gearButton().click();
+    await waitFor(() => takeover() !== null);
+
+    const overlay = takeover() as HTMLElement;
+    // Covers the whole chat area — absolutely positioned over its (relative)
+    // parent, not a strip stacked inside the chat column (#3826's layout).
+    expect(overlay.className).toContain('absolute');
+    expect(overlay.className).toContain('inset-0');
+    // The chat is a SIBLING of the takeover, not an ancestor or descendant.
+    expect(overlay.contains(chatSurface())).toBe(false);
+    expect(chatSurface().contains(overlay)).toBe(false);
+  });
+
+  it('the covered chat stays mounted — same DOM node, still carrying the draft message', async () => {
+    typeInComposer('half-written thought');
+    const chatNodeBefore = chatSurface();
+
+    gearButton().click();
+    await waitFor(() => takeover() !== null);
+
+    // The single most important assertion in this file: the chat subtree was
+    // covered, not rebuilt. A same-identity node keeps its scroll offset and
+    // every child component's state (including the composer's draft) for free.
+    expect(chatSurface()).toBe(chatNodeBefore);
+    expect(document.body.contains(chatNodeBefore)).toBe(true);
+    expect(composer().value).toBe('half-written thought');
+    // …and is inert while covered, so nothing behind the takeover is
+    // focusable or exposed to assistive tech.
+    expect(chatIsInert()).toBe(true);
+  });
+
+  it('Esc exits the takeover and returns to the untouched chat', async () => {
+    typeInComposer('draft that must survive');
+    const chatNodeBefore = chatSurface();
+
+    gearButton().click();
+    await waitFor(() => takeover() !== null);
+
+    pressEscape();
+    await waitFor(() => takeover() === null);
+
+    expect(get(configPaneOpen)).toBe(false);
+    expect(chatSurface()).toBe(chatNodeBefore);
+    expect(chatIsInert()).toBe(false);
+    expect(composer().value).toBe('draft that must survive');
+  });
+
+  it('the Back button exits the takeover', async () => {
+    gearButton().click();
+    await waitFor(() => takeover() !== null);
+
+    const back = Array.from(target.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Back to chat'),
+    ) as HTMLButtonElement;
+    back.click();
+    await waitFor(() => takeover() === null);
+
+    expect(get(configPaneOpen)).toBe(false);
+    expect(chatSurface()).not.toBeNull();
+  });
+
+  it('the close button exits the takeover', async () => {
+    gearButton().click();
+    await waitFor(() => takeover() !== null);
+
+    (target.querySelector('[aria-label="Close agent configuration"]') as HTMLButtonElement).click();
+    await waitFor(() => takeover() === null);
+
+    expect(get(configPaneOpen)).toBe(false);
+  });
+
+  it('the gear reflects the takeover state via aria-pressed', async () => {
+    expect(gearButton().getAttribute('aria-pressed')).toBe('false');
+
+    gearButton().click();
+    await waitFor(() => takeover() !== null);
+    expect(gearButton().getAttribute('aria-pressed')).toBe('true');
+
+    // NB: the gear cannot be the way BACK — it sits inside the `inert` chat
+    // while the takeover is up, so a real browser ignores clicks on it. That
+    // is exactly why the takeover carries its own Back/Close/Esc exits.
+    pressEscape();
+    await waitFor(() => takeover() === null);
+    expect(gearButton().getAttribute('aria-pressed')).toBe('false');
+  });
+});

--- a/crates/trusty-agents/ui/src/components/ChatView.svelte
+++ b/crates/trusty-agents/ui/src/components/ChatView.svelte
@@ -14,6 +14,7 @@
   import { responderDisplayName } from '../lib/roster';
   import { listenEvent, type UnlistenFn } from '../lib/transport';
   import { streamAccumulator, type DeltaPayload } from '../lib/chatStream';
+  import { isPinnedToBottom } from '../lib/chatScroll';
   import ActionIcon from '../lib/icons/ActionIcon.svelte';
   import WorkflowPhaseCard from './WorkflowPhaseCard.svelte';
   import { workflowState } from '../stores/workflow';
@@ -127,15 +128,39 @@
     unlistenDelta?.();
   });
 
+  /**
+   * Why (PR #3895 code-critic HIGH-3): this used to force
+   * `scrollTop = scrollHeight` on EVERY render, unconditionally. That drags a
+   * reader who scrolled up to read history back to the newest message the
+   * instant a streaming delta arrives — and because the chat keeps rendering
+   * while the agent-config takeover covers it (#3894 deliberately leaves it
+   * mounted so its scroll offset survives), a delta arriving mid-configuration
+   * silently reset the covered chat's position, breaking the very thing the
+   * takeover promises. Anchoring to "was the reader already at the bottom?" is
+   * the generally-correct chat behavior and fixes both cases at once, without
+   * the takeover needing a special case.
+   * What: `pinnedToBottom` tracks the reader's intent from actual scroll
+   * events (it starts true — an empty chat is at its bottom); `afterUpdate`
+   * only re-anchors while that holds.
+   * Test: `lib/chatScroll.test.ts` (the predicate) and `ChatPane.test.ts`
+   * (a message appended while the takeover is open leaves the covered chat's
+   * offset alone).
+   */
+  let pinnedToBottom = true;
+
+  function onScroll() {
+    if (scrollEl) pinnedToBottom = isPinnedToBottom(scrollEl);
+  }
+
   afterUpdate(() => {
     // Why: afterUpdate fires after the DOM is already patched — tick() is
     // redundant here and creates an infinite microtask chain (afterUpdate →
     // tick() resolves → Svelte flushes → afterUpdate → …) that permanently
     // blocks V8's event loop, starving Playwright CDP and other async tasks.
-    // What: Scrolls the message list to the bottom after each render.
     // Test: Send a message that fills the chat — the view scrolls to the newest
-    // entry without any blank-screen or scroll freeze.
-    if (scrollEl) {
+    // entry without any blank-screen or scroll freeze; scroll up mid-stream and
+    // the view stays where you put it.
+    if (scrollEl && pinnedToBottom) {
       scrollEl.scrollTop = scrollEl.scrollHeight;
     }
   });
@@ -145,7 +170,12 @@
   }
 </script>
 
-<div bind:this={scrollEl} class="flex-1 overflow-y-auto px-6 py-4 bg-foundry-light-bg dark:bg-foundry-bg">
+<div
+  bind:this={scrollEl}
+  on:scroll={onScroll}
+  data-chat-scroll
+  class="flex-1 overflow-y-auto px-6 py-4 bg-foundry-light-bg dark:bg-foundry-bg"
+>
   {#if $activeMessages.length === 0}
     <div class="mt-10 text-center text-sm text-foundry-light-muted dark:text-foundry-text/50 font-sans">
       Start chatting. Messages will appear here.

--- a/crates/trusty-agents/ui/src/lib/chatScroll.test.ts
+++ b/crates/trusty-agents/ui/src/lib/chatScroll.test.ts
@@ -1,0 +1,33 @@
+// Unit tests for the chat scroll-anchoring predicate (PR #3895 code-critic
+// HIGH-3). See `chatScroll.ts` for why ChatView stopped forcing the scroll
+// unconditionally.
+
+import { describe, expect, it } from 'vitest';
+import { BOTTOM_EPSILON_PX, isPinnedToBottom } from './chatScroll';
+
+describe('isPinnedToBottom', () => {
+  it('is true when the reader is parked at the very bottom', () => {
+    expect(isPinnedToBottom({ scrollTop: 800, scrollHeight: 1000, clientHeight: 200 })).toBe(true);
+  });
+
+  it('is true within the epsilon of slack', () => {
+    // 10px short of the end — a reader here means "keep me at the newest".
+    expect(isPinnedToBottom({ scrollTop: 790, scrollHeight: 1000, clientHeight: 200 })).toBe(true);
+    expect(BOTTOM_EPSILON_PX).toBeGreaterThan(10);
+  });
+
+  it('is false once the reader has scrolled up to read history', () => {
+    expect(isPinnedToBottom({ scrollTop: 100, scrollHeight: 1000, clientHeight: 200 })).toBe(false);
+  });
+
+  it('is true for a container with nothing to scroll (an empty chat)', () => {
+    expect(isPinnedToBottom({ scrollTop: 0, scrollHeight: 0, clientHeight: 0 })).toBe(true);
+    expect(isPinnedToBottom({ scrollTop: 0, scrollHeight: 200, clientHeight: 200 })).toBe(true);
+  });
+
+  it('honours an explicit epsilon', () => {
+    const metrics = { scrollTop: 780, scrollHeight: 1000, clientHeight: 200 };
+    expect(isPinnedToBottom(metrics, 5)).toBe(false);
+    expect(isPinnedToBottom(metrics, 50)).toBe(true);
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/chatScroll.ts
+++ b/crates/trusty-agents/ui/src/lib/chatScroll.ts
@@ -1,0 +1,33 @@
+// Chat scroll-anchoring predicate (PR #3895 code-critic HIGH-3).
+//
+// Why: `ChatView` used to force `scrollTop = scrollHeight` after EVERY render.
+// That is wrong twice over: it yanks a user who scrolled up to read history
+// back to the newest message the moment a streaming delta lands, and — since
+// the chat keeps rendering while the agent-config takeover covers it — it
+// silently resets the covered chat's scroll offset, contradicting the whole
+// "leaving config returns to chat exactly as it was" contract. The
+// generally-correct chat behavior is to auto-scroll only while the reader is
+// already parked at the bottom, which is what this predicate decides.
+// What: A pure metrics check, so the rule is unit-testable without a layout
+// engine (jsdom has none). `epsilon` absorbs sub-pixel/fractional scroll
+// offsets and the last line's bottom padding — a reader within a few dozen
+// pixels of the end is "at the bottom" as far as intent goes.
+// Test: `chatScroll.test.ts`.
+
+/** The metrics subset of a scroll container this predicate needs. */
+export interface ScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+/** Default slack, in CSS pixels, for "close enough to the bottom". */
+export const BOTTOM_EPSILON_PX = 32;
+
+export function isPinnedToBottom(
+  metrics: ScrollMetrics,
+  epsilon: number = BOTTOM_EPSILON_PX,
+): boolean {
+  const distanceFromBottom = metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight;
+  return distanceFromBottom <= epsilon;
+}

--- a/crates/trusty-agents/ui/src/lib/roster.test.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.test.ts
@@ -6,8 +6,10 @@ import { describe, expect, it } from 'vitest';
 import {
   BASE_AGENT_ID,
   BASE_AGENT_LABEL,
+  CONCIERGE_AGENT_ID,
   buildOverlayMarkdown,
   buildRoster,
+  configAgentName,
   parseOverlayMarkdown,
   responderDisplayName,
   rosterDisplayName,
@@ -236,5 +238,19 @@ describe('parseOverlayMarkdown', () => {
       extends: '',
       instructions: 'Just some prose, no frontmatter.',
     });
+  });
+});
+
+describe('configAgentName', () => {
+  it('configAgentName_null_selection_is_concierge', () => {
+    // `activeAgentId === null` is the Concierge selection on the dispatch
+    // axis; the config surface addresses it by name (`ctrl`).
+    expect(configAgentName(null)).toBe(CONCIERGE_AGENT_ID);
+    expect(CONCIERGE_AGENT_ID).toBe('ctrl');
+  });
+
+  it('configAgentName_passes_through_a_selected_id', () => {
+    expect(configAgentName('izzie')).toBe('izzie');
+    expect(configAgentName('cto-assistant')).toBe('cto-assistant');
   });
 });

--- a/crates/trusty-agents/ui/src/lib/roster.ts
+++ b/crates/trusty-agents/ui/src/lib/roster.ts
@@ -207,6 +207,33 @@ export function rosterDisplayName(
 }
 
 /**
+ * Why (#3819): Concierge — the `ctrl` agent — is selected by
+ * `activeAgentId === null` (the tools-armed base PM/ctrl dispatch path; see
+ * `stores/app.ts`'s `activeAgentId` doc comment) but is CONFIGURED by name
+ * like any other agent. Two surfaces now need that mapping — `ChatHeader`'s
+ * picker and the full-pane `AgentConfigOverlay` (#3894) — so it lives here
+ * once instead of being re-derived in each.
+ */
+export const CONCIERGE_AGENT_ID = 'ctrl';
+
+/** Human-facing label for the Concierge selection (`activeAgentId === null`). */
+export const CONCIERGE_LABEL = 'Concierge';
+
+/**
+ * Why (#3894): the config surface addresses agents by NAME (`GET
+ * /api/agents/:name`), while chat dispatch addresses the active selection by
+ * `activeAgentId`, where `null` means Concierge. This is the one translation
+ * between the two axes.
+ * What: Returns the selected agent's name, or `CONCIERGE_AGENT_ID` when
+ * nothing is selected.
+ * Test: `configAgentName_null_selection_is_concierge`,
+ * `configAgentName_passes_through_a_selected_id`.
+ */
+export function configAgentName(activeAgentId: string | null): string {
+  return activeAgentId ?? CONCIERGE_AGENT_ID;
+}
+
+/**
  * Why (#3737): chat attribution must reflect who ANSWERED. When a turn
  * delegates (base "Assistant" → Izzie for a weather question), the server
  * reports the responder's agent NAME in `PmResponse.responder_agent`; the GUI

--- a/crates/trusty-agents/ui/src/stores/configPane.test.ts
+++ b/crates/trusty-agents/ui/src/stores/configPane.test.ts
@@ -10,7 +10,6 @@ import {
   isConfigExitKey,
   openConfigPane,
   requestExitConfigPane,
-  toggleConfigPane,
 } from './configPane';
 
 beforeEach(() => {
@@ -23,7 +22,7 @@ describe('configPaneOpen', () => {
     expect(get(configPaneOpen)).toBe(false);
   });
 
-  it('open/close/toggle move the takeover between its two states', () => {
+  it('open/close move the takeover between its two states', () => {
     openConfigPane();
     expect(get(configPaneOpen)).toBe(true);
 
@@ -34,11 +33,15 @@ describe('configPaneOpen', () => {
 
     closeConfigPane();
     expect(get(configPaneOpen)).toBe(false);
+  });
 
-    toggleConfigPane();
-    expect(get(configPaneOpen)).toBe(true);
-    toggleConfigPane();
-    expect(get(configPaneOpen)).toBe(false);
+  it('exposes no unguarded toggle — leaving always goes through the exit guard', async () => {
+    // PR #3895 re-review: a `toggleConfigPane()` used to exist and the gear
+    // bound to it, flipping the pane closed with no dirty check. Its absence
+    // is the invariant; a future re-add would resurrect the silent-discard
+    // bypass.
+    const mod = await import('./configPane');
+    expect(Object.keys(mod)).not.toContain('toggleConfigPane');
   });
 });
 

--- a/crates/trusty-agents/ui/src/stores/configPane.test.ts
+++ b/crates/trusty-agents/ui/src/stores/configPane.test.ts
@@ -1,0 +1,62 @@
+// Unit tests for the agent-configuration takeover state (#3894, epic #3052).
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import {
+  closeConfigPane,
+  configPaneOpen,
+  isConfigExitKey,
+  openConfigPane,
+  toggleConfigPane,
+} from './configPane';
+
+beforeEach(() => {
+  closeConfigPane();
+});
+
+describe('configPaneOpen', () => {
+  it('starts closed — chat is the default surface', () => {
+    expect(get(configPaneOpen)).toBe(false);
+  });
+
+  it('open/close/toggle move the takeover between its two states', () => {
+    openConfigPane();
+    expect(get(configPaneOpen)).toBe(true);
+
+    // Opening an already-open pane is a no-op, not a toggle: the gear button
+    // is not the only opener, and a second open must never close.
+    openConfigPane();
+    expect(get(configPaneOpen)).toBe(true);
+
+    closeConfigPane();
+    expect(get(configPaneOpen)).toBe(false);
+
+    toggleConfigPane();
+    expect(get(configPaneOpen)).toBe(true);
+    toggleConfigPane();
+    expect(get(configPaneOpen)).toBe(false);
+  });
+});
+
+describe('isConfigExitKey', () => {
+  const key = (
+    k: string,
+    mods: Partial<Pick<KeyboardEvent, 'ctrlKey' | 'metaKey' | 'altKey'>> = {},
+  ) => ({ key: k, ctrlKey: false, metaKey: false, altKey: false, ...mods });
+
+  it('isConfigExitKey_true_for_plain_escape', () => {
+    expect(isConfigExitKey(key('Escape'))).toBe(true);
+  });
+
+  it('isConfigExitKey_false_for_other_keys', () => {
+    for (const k of ['Enter', 'Esc', 'e', 'Tab', 'Backspace']) {
+      expect(isConfigExitKey(key(k))).toBe(false);
+    }
+  });
+
+  it('isConfigExitKey_false_when_chorded_with_a_platform_modifier', () => {
+    expect(isConfigExitKey(key('Escape', { metaKey: true }))).toBe(false);
+    expect(isConfigExitKey(key('Escape', { ctrlKey: true }))).toBe(false);
+    expect(isConfigExitKey(key('Escape', { altKey: true }))).toBe(false);
+  });
+});

--- a/crates/trusty-agents/ui/src/stores/configPane.test.ts
+++ b/crates/trusty-agents/ui/src/stores/configPane.test.ts
@@ -4,14 +4,18 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { get } from 'svelte/store';
 import {
   closeConfigPane,
+  configExitIntent,
+  configPaneDirty,
   configPaneOpen,
   isConfigExitKey,
   openConfigPane,
+  requestExitConfigPane,
   toggleConfigPane,
 } from './configPane';
 
 beforeEach(() => {
   closeConfigPane();
+  configPaneDirty.set(false);
 });
 
 describe('configPaneOpen', () => {
@@ -58,5 +62,43 @@ describe('isConfigExitKey', () => {
     expect(isConfigExitKey(key('Escape', { metaKey: true }))).toBe(false);
     expect(isConfigExitKey(key('Escape', { ctrlKey: true }))).toBe(false);
     expect(isConfigExitKey(key('Escape', { altKey: true }))).toBe(false);
+  });
+});
+
+describe('requestExitConfigPane (code-critic HIGH-1: no silent discard)', () => {
+  it('closes immediately when the panel has nothing unsaved', () => {
+    openConfigPane();
+    const intentBefore = get(configExitIntent);
+
+    expect(requestExitConfigPane()).toBe(true);
+    expect(get(configPaneOpen)).toBe(false);
+    // Nothing to confirm, so the panel is never asked.
+    expect(get(configExitIntent)).toBe(intentBefore);
+  });
+
+  it('refuses to close a dirty panel and raises the confirm instead', () => {
+    openConfigPane();
+    configPaneDirty.set(true);
+    const intentBefore = get(configExitIntent);
+
+    expect(requestExitConfigPane()).toBe(false);
+    expect(get(configPaneOpen)).toBe(true);
+    expect(get(configExitIntent)).toBe(intentBefore + 1);
+  });
+
+  it('every repeated request raises a fresh intent so a re-press is not swallowed', () => {
+    openConfigPane();
+    configPaneDirty.set(true);
+    const intentBefore = get(configExitIntent);
+
+    requestExitConfigPane();
+    requestExitConfigPane();
+    expect(get(configExitIntent)).toBe(intentBefore + 2);
+  });
+
+  it('is a no-op that reports success when the pane is already closed', () => {
+    configPaneDirty.set(true); // stale flag must not resurrect a closed pane
+    expect(requestExitConfigPane()).toBe(true);
+    expect(get(configPaneOpen)).toBe(false);
   });
 });

--- a/crates/trusty-agents/ui/src/stores/configPane.ts
+++ b/crates/trusty-agents/ui/src/stores/configPane.ts
@@ -15,10 +15,55 @@
 // config pane, which falls out for free when there is only one source).
 // Test: `configPane.test.ts`.
 
-import { writable } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 
 /** True while the agent-configuration surface has taken over the pane. */
 export const configPaneOpen = writable(false);
+
+/**
+ * Why (PR #3895 code-critic HIGH-1): Esc is habitual while editing text, and
+ * the config surface holds long, hand-written system prompts. Every exit path
+ * — Esc, Back, Close, and leaving the Chat tab — must therefore consult
+ * whether the open panel has unsaved Personality/Tools edits before it
+ * unmounts, or the takeover becomes a fresh data-loss path. The dirty bit is
+ * published here (rather than kept private to `AgentConfigPanel`) because two
+ * of those exit paths originate OUTSIDE the panel and need the answer
+ * synchronously.
+ * What: Mirrors `personalityDirty || toolsDirty`. Written by the panel while
+ * it is mounted, cleared on its destroy.
+ * Test: `ChatPane.test.ts` — every exit path with a dirty editor.
+ */
+export const configPaneDirty = writable(false);
+
+/**
+ * Why: a dirty exit has to be resolved by the panel (only it can save, and
+ * only it knows which section is dirty), but the request can come from
+ * anywhere. A monotonic nonce is the smallest thing that carries "someone
+ * asked to leave" to a component without the store needing a handle on it.
+ * What: Incremented by `requestExitConfigPane` when the pane is dirty; the
+ * panel watches for a change and raises its confirm-before-discard prompt.
+ */
+export const configExitIntent = writable(0);
+
+/**
+ * Why: the single entry point every exit path funnels through, so the
+ * dirty-check cannot be forgotten at one call site (it already was at three).
+ * What: Closes the pane immediately when there is nothing to lose and returns
+ * `true`. When the panel holds unsaved edits it instead raises the panel's
+ * confirm prompt and returns `false`, letting a caller that was going
+ * somewhere else (the Chat→Events tab switch) stay put.
+ * Test: `configPane.test.ts` (both branches) and `ChatPane.test.ts` (each
+ * exit affordance end to end).
+ */
+export function requestExitConfigPane(): boolean {
+  if (!get(configPaneOpen)) return true;
+  if (get(configPaneDirty)) {
+    configExitIntent.update((n) => n + 1);
+    return false;
+  }
+  closeConfigPane();
+  return true;
+}
 
 export function openConfigPane(): void {
   configPaneOpen.set(true);

--- a/crates/trusty-agents/ui/src/stores/configPane.ts
+++ b/crates/trusty-agents/ui/src/stores/configPane.ts
@@ -1,0 +1,54 @@
+// Agent-configuration takeover state (#3894, epic #3052).
+//
+// Why: Bob's directive — "when we're in agent configuration, let's take over
+// that pane, we don't need chat when we're configuring". The gear button that
+// opens the config surface lives in `ChatHeader`, INSIDE the chat column,
+// but the surface it opens must cover the whole content area (chat column +
+// recap rail). A component can't reach outside its own subtree, so the
+// open/closed bit lives here, in a module-level store: `ChatHeader` writes it,
+// `ChatPane` reads it to render `AgentConfigOverlay` as a SIBLING of the chat
+// column (and to `inert` that column while the takeover is up).
+// What: A boolean store plus the three mutations the UI needs and one pure
+// key predicate. Deliberately holds NO agent identity — which agent is being
+// configured is already `stores/app.ts`'s `activeAgentId`, and duplicating it
+// here would let the two drift (a switch in the picker must retarget an open
+// config pane, which falls out for free when there is only one source).
+// Test: `configPane.test.ts`.
+
+import { writable } from 'svelte/store';
+
+/** True while the agent-configuration surface has taken over the pane. */
+export const configPaneOpen = writable(false);
+
+export function openConfigPane(): void {
+  configPaneOpen.set(true);
+}
+
+export function closeConfigPane(): void {
+  configPaneOpen.set(false);
+}
+
+export function toggleConfigPane(): void {
+  configPaneOpen.update((open) => !open);
+}
+
+/**
+ * Why: Esc must exit the takeover (Bob: "provide an obvious exit
+ * affordance"), but a bare `event.key === 'Escape'` in the keydown handler
+ * would also swallow the Esc of a chorded shortcut (Cmd+Esc opens the macOS
+ * Force-Quit panel, Ctrl+Esc the Windows Start menu) — the OS handles those
+ * and the app should not additionally act on them. Keeping the decision in a
+ * pure predicate keeps the component handler a one-liner and makes the rule
+ * unit-testable without mounting anything.
+ * What: True only for an unmodified Escape press. Shift is ignored (Shift+Esc
+ * carries no platform meaning and users routinely leave Shift down).
+ * Test: `isConfigExitKey_true_for_plain_escape`,
+ * `isConfigExitKey_false_for_other_keys`,
+ * `isConfigExitKey_false_when_chorded_with_a_platform_modifier`.
+ */
+export function isConfigExitKey(
+  event: Pick<KeyboardEvent, 'key' | 'ctrlKey' | 'metaKey' | 'altKey'>,
+): boolean {
+  if (event.key !== 'Escape') return false;
+  return !event.ctrlKey && !event.metaKey && !event.altKey;
+}

--- a/crates/trusty-agents/ui/src/stores/configPane.ts
+++ b/crates/trusty-agents/ui/src/stores/configPane.ts
@@ -73,9 +73,11 @@ export function closeConfigPane(): void {
   configPaneOpen.set(false);
 }
 
-export function toggleConfigPane(): void {
-  configPaneOpen.update((open) => !open);
-}
+// NB (PR #3895 re-review): there is deliberately NO `toggleConfigPane()`. It
+// existed, the gear button bound to it, and it flipped `configPaneOpen` false
+// without consulting `configPaneDirty` — a silent-discard bypass around the
+// guard below. Leaving the pane goes through `requestExitConfigPane()`, always;
+// `ChatHeader.handleGear` shows the open-vs-leave split a toggle would hide.
 
 /**
  * Why: Esc must exit the takeover (Bob: "provide an obvious exit

--- a/crates/trusty-agents/ui/tests/config-takeover.spec.ts
+++ b/crates/trusty-agents/ui/tests/config-takeover.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from '@playwright/test';
+
+// Why (#3894; PR #3895 code-critic MEDIUM-4): the instructions editor's size
+// is the one property of this feature that has now shipped wrong twice — a
+// 2-line strip (#3826), then a `70vh` cap that left dead space in the
+// full-pane takeover (#3862). Both slipped through because nothing MEASURED
+// it: jsdom does no layout, so the unit tests can only assert the classes
+// that are supposed to produce the size. This spec measures the real rendered
+// pixel height in a real browser, at two viewport heights, and fails if the
+// editor stops tracking the space available.
+// What: Boots the real app with every `/api/*` route stubbed (same technique
+// and rationale as `smoke.spec.ts` — chunked responses and a live EventSource
+// both stall Playwright's CDP channel), opens the takeover from the chat
+// header's gear, and asserts the editor grows with the viewport, is the only
+// scroll container in its tab, and covers the full content area.
+// Test: `pnpm dev` in one shell, then
+//   `TAGENT_URL=http://127.0.0.1:5173 pnpm test tests/config-takeover.spec.ts`
+// It also runs unchanged against a real `tagent --api` on :7654 (the default
+// baseURL). Not wired into CI — `pnpm test` is excluded there by design (it
+// needs a running server plus browser binaries); see ci.yml's ui-checks
+// header.
+
+const PERSONA = Array.from(
+  { length: 400 },
+  (_, i) => `line ${i + 1}: you are a careful assistant.`,
+).join('\n');
+
+test.beforeEach(async ({ page }) => {
+  // See smoke.spec.ts: a real EventSource keeps Chromium's network layer
+  // non-idle and blocks CDP once the app reaches ready.
+  await page.addInitScript(() => {
+    class MockEventSource extends EventTarget {
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = 0;
+        this.onopen = null;
+        this.onmessage = null;
+        this.onerror = null;
+      }
+      close() {
+        this.readyState = 2;
+      }
+    }
+    window.EventSource = MockEventSource;
+  });
+
+  await page.route('**', (route) => {
+    // Match on the PATH, and only under `/api/` — against a Vite dev server
+    // the app's own modules are served from `/src/stores/…`, which a
+    // substring match on "/stores" would happily answer with JSON.
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown) =>
+      route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+    if (!path.startsWith('/api/')) {
+      route.continue(); // HTML, JS bundle, CSS, fonts
+    } else if (path.startsWith('/api/events')) {
+      route.fulfill({
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+        body: '',
+      });
+    } else if (path.startsWith('/api/health')) json({ status: 'ok' });
+    else if (path.startsWith('/api/config')) json({ auth_required: false });
+    else if (path.startsWith('/api/tasks')) json([]);
+    else if (path.endsWith('/persona')) json({ content: PERSONA, editable: true });
+    else if (path.endsWith('/stores')) json({ stores: [], issues: [] });
+    else if (path.match(/^\/api\/agents\/[^/]+$/))
+      json({ name: 'ctrl', display_name: 'Concierge', tools_allow: [], scopes: [] });
+    else if (path.startsWith('/api/agents'))
+      json({ agents: [{ name: 'izzie', display_name: 'Izzie' }] });
+    else json({});
+  });
+});
+
+/** Boots the app, opens the takeover, and returns the editor locator. */
+async function openTakeover(page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.locator('[aria-label="Configure agent"]').click({ timeout: 15_000 });
+  const editor = page.locator('[data-instructions-editor]');
+  await expect(editor).toHaveValue(/line 400/, { timeout: 10_000 });
+  return editor;
+}
+
+test.describe('agent configuration takeover (#3894)', () => {
+  for (const height of [900, 1400]) {
+    test(`instructions editor fills the pane at a ${height}px viewport`, async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height });
+      const editor = await openTakeover(page);
+
+      const measured = await editor.evaluate((el: HTMLTextAreaElement) => {
+        const style = getComputedStyle(el);
+        const column = el.parentElement!;
+        const last = column.lastElementChild!;
+        return {
+          height: el.getBoundingClientRect().height,
+          lineHeight: parseFloat(style.lineHeight),
+          scrolls: el.scrollHeight > el.clientHeight,
+          fontFamily: style.fontFamily,
+          maxHeight: style.maxHeight,
+          minHeight: style.minHeight,
+          // Free space left over at the bottom of the tab column. A growing
+          // editor consumes all of it; anything that caps the editor (a `vh`
+          // clamp, a fixed height, `rows`) leaves a dead band here.
+          deadSpaceBelow:
+            column.getBoundingClientRect().bottom - last.getBoundingClientRect().bottom,
+        };
+      });
+
+      // Half the viewport is a floor no "too small" report can survive.
+      expect(measured.height).toBeGreaterThan(height * 0.5);
+      expect(measured.height / measured.lineHeight).toBeGreaterThan(20);
+      // A 400-line persona must scroll INSIDE the editor.
+      expect(measured.scrolls).toBe(true);
+      expect(measured.fontFamily.toLowerCase()).toContain('mono');
+      // The exact regression #3862 introduced: a viewport clamp caps the
+      // editor independently of the space available. Resolved computed values
+      // — `70vh` shows up here as a pixel figure, `none` is the only pass.
+      expect(measured.maxHeight).toBe('none');
+      expect(measured.minHeight).toBe('0px');
+      expect(measured.deadSpaceBelow).toBeLessThan(4);
+    });
+  }
+
+  test('the editor tracks the viewport instead of being clamped', async ({ page }) => {
+    // The assertion that actually catches a `vh` clamp: at 70vh the editor
+    // would gain only ~350px across this 500px viewport change, and a fixed
+    // `rows`/height would gain none. Growing nearly 1:1 is the property the
+    // owner asked for.
+    await page.setViewportSize({ width: 1440, height: 900 });
+    const editor = await openTakeover(page);
+    const measure = () => editor.evaluate((el: HTMLElement) => el.getBoundingClientRect().height);
+
+    const short = await measure();
+    await page.setViewportSize({ width: 1440, height: 1400 });
+    await expect.poll(measure).toBeGreaterThan(short);
+    const tall = await measure();
+
+    expect(tall - short).toBeGreaterThan(450);
+  });
+
+  test('the editor is the only scroll container in its tab', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    const editor = await openTakeover(page);
+
+    const ancestorScrollers = await editor.evaluate((el: HTMLElement) => {
+      const found: string[] = [];
+      const stop = el.closest('[data-config-takeover]');
+      for (let n = el.parentElement; n && n !== stop; n = n.parentElement) {
+        const s = getComputedStyle(n);
+        if (['auto', 'scroll'].includes(s.overflowY) && n.scrollHeight > n.clientHeight + 1) {
+          found.push(n.className);
+        }
+      }
+      return found;
+    });
+    expect(ancestorScrollers).toEqual([]);
+  });
+
+  test('the takeover covers the full content area and Esc returns to an intact chat', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const composer = page.locator('footer textarea');
+    await composer.fill('half-written thought', { timeout: 15_000 });
+    const chatBox = await page.locator('[data-chat-surface]').boundingBox();
+
+    await page.locator('[aria-label="Configure agent"]').click();
+    const overlay = page.locator('[data-config-takeover]');
+    await expect(overlay).toBeVisible();
+
+    const overlayBox = await overlay.boundingBox();
+    // Covers the chat column AND the recap rail — the whole content area.
+    expect(Math.round(overlayBox!.width)).toBe(Math.round(chatBox!.width));
+    expect(Math.round(overlayBox!.height)).toBe(Math.round(chatBox!.height));
+
+    await page.keyboard.press('Escape');
+    await expect(overlay).toHaveCount(0);
+    await expect(composer).toHaveValue('half-written thought');
+  });
+});

--- a/crates/trusty-agents/ui/vitest.config.ts
+++ b/crates/trusty-agents/ui/vitest.config.ts
@@ -1,17 +1,33 @@
 import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
 
-// Why: Unit tests for framework-free pure functions (currently
-// `src/lib/retask.ts`, #3063 code-critic follow-up) need a fast runner that
-// doesn't require a live `trusty-agents --api` server or a browser — unlike
-// `tests/*.spec.ts`, which are Playwright e2e specs run via `pnpm test`
-// against a running server. Vitest pairs naturally with the existing Vite
-// build and needs no extra config beyond scoping `include` so the two
-// runners never pick up each other's files.
-// What: Only collects `src/**/*.test.ts`; Playwright's `tests/` directory is
-// untouched. No DOM/jsdom environment configured since the functions under
-// test today are plain string/array logic with no Svelte component mounting.
+// Why: Unit tests for framework-free pure functions (`src/lib/*.ts`,
+// `src/stores/*.ts`) need a fast runner that doesn't require a live
+// `trusty-agents --api` server or a browser — unlike `tests/*.spec.ts`, which
+// are Playwright e2e specs run via `pnpm test` against a running server.
+// Vitest pairs naturally with the existing Vite build and needs no extra
+// config beyond scoping `include` so the two runners never pick up each
+// other's files. #3894 additionally mounts real components: the config
+// takeover's "chat is covered, never unmounted" invariant is a DOM-structure
+// property no pure function can express. That needs a DOM plus the same
+// `svelte()` plugin the app build uses, so `.svelte` files compile
+// identically in tests and in the real bundle — mirroring
+// `crates/trusty-code-gui/ui/vitest.config.ts`, which already does this.
+// What: jsdom environment, svelte plugin, browser resolve conditions; still
+// only collects `src/**/*.test.ts`, leaving Playwright's `tests/` untouched.
+// Kept separate from `vite.config.ts` (the Tauri build entry) so vitest never
+// touches the app's build/proxy settings.
 export default defineConfig({
+  plugins: [svelte()],
+  // Without this, Vite's default SSR module resolution picks Svelte's
+  // server-side `mount` (which throws `lifecycle_function_unavailable`) even
+  // under `environment: 'jsdom'` — `resolve.conditions: ['browser']` forces
+  // the client build, matching the real app bundle.
+  resolve: {
+    conditions: ['browser'],
+  },
   test: {
+    environment: 'jsdom',
     include: ['src/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
Owner UX directive (epic #3052): *"When we're in agent configuration, let's take over that pane — we don't need chat when we're configuring"*, plus *"the instructions pane is still too small"* after #3862.

## Before

`ChatHeader`'s gear mounted `AgentConfigPanel` into a fixed `h-80` strip **inside** the chat column, above `ChatView` + `InputArea`. The agent–OKG–tool–listener surface — the concept centerpiece — got ~320px of a split pane, and the instructions editor lived inside that strip clamped to `min-h-[55vh] max-h-[70vh]` (#3862).

## After

**Takeover.** The gear now only flips `stores/configPane.ts`'s `configPaneOpen`. `ChatPane` (the Chat view's composition, extracted from `App.svelte`) renders `AgentConfigOverlay` as an absolutely-positioned **sibling** of the whole chat group, so the takeover covers the chat column *and* the recap rail.

**Chat is covered, never unmounted.** The obvious implementation (`{#if configOpen} config {:else} chat {/if}`) satisfies the visible half of the directive and silently breaks the other half — an unmounted `ChatView`/`InputArea` loses its scroll offset and the user's half-typed message. Instead the chat subtree stays mounted and laid out, marked `inert` (nothing behind the takeover is focusable or exposed to assistive tech). Exiting returns to the exact same DOM node.

**Exits.** "Back to chat" button, a close button (`aria-label="Close agent configuration"`), and <kbd>Esc</kbd> — unmodified only, so platform chords (Cmd+Esc / Ctrl+Esc) are left to the OS. Switching to the Events tab also drops the takeover. Focus moves into the takeover on open.

**Instructions editor.** `flex-1 min-h-0`, no `rows`, no viewport clamp, monospace, `resize-none`, and the only scroll container in its tab (the shared `overflow-y-auto` wrapper is gone; read-only tabs scroll themselves). The Tools allowlist textarea gets the same treatment.

Scoped to layout/visibility state — **no sidecar API change**. Every existing capability is preserved: OKG Stores card, Tools, Permissions, Listeners scaffolding, per-section save flow (regression-guarded by a test).

### Files

| File | What |
|---|---|
| `src/stores/configPane.ts` (new) | takeover open/close state + pure `isConfigExitKey` |
| `src/components/ChatPane.svelte` (new) | chat group + takeover sibling, extracted from `App.svelte` |
| `src/components/AgentConfigOverlay.svelte` (new) | positioning + Esc + focus shell |
| `src/components/AgentConfigPanel.svelte` | flex-column sizing, `onExit`/`displayName` props, exit chrome |
| `src/components/ChatHeader.svelte` | gear drives the store; inline `h-80` strip removed |
| `src/lib/roster.ts` | `CONCIERGE_AGENT_ID`/`CONCIERGE_LABEL`/`configAgentName` consolidated |
| `vitest.config.ts` | jsdom + `svelte()` plugin (mirrors `trusty-code-gui/ui`) |

## Test evidence

`pnpm test:unit` — 135 passed (was 122; +13 new), including the takeover invariants:

```
 RUN  v4.1.10 .../crates/trusty-agents/ui

 Test Files  15 passed (15)
      Tests  135 passed (135)
   Duration  3.74s
```

`pnpm run check` — 0 errors; the 2 warnings are pre-existing, in the unrouted `ProjectsView.svelte`:

```
COMPLETED 1719 FILES 0 ERRORS 2 WARNINGS 1 FILES_WITH_PROBLEMS
```

New tests: `ChatPane.test.ts` (gear opens a takeover that is a sibling, not an ancestor; the covered chat is the **same DOM node** and still holds the draft; Esc / Back / Close all exit; `aria-pressed` tracks state), `AgentConfigPanel.test.ts` (exit affordances call back out; editor grows with `flex-1`/`min-h-0`, no `rows`, no vh clamp; no ancestor scroller between editor and panel root; 300-line persona loads; all five tabs still render), `configPane.test.ts`, `roster.test.ts` (`configAgentName`).

jsdom does no layout, so the "grows with the viewport" half was additionally measured in a **real browser** (headless Chromium against a throwaway Vite harness, since the sizing bug has now shipped twice):

| viewport height | editor height | visible lines | ancestor scrollers |
|---|---|---|---|
| 900px | 514px | 26 | none |
| 1400px | 1014px | 52 | none |

Same run confirmed `overlayWidth == chatWidth` (1220px — it really does cover the recap rail), `chatStillInDom: true`, `chatInert: true`, and after Esc the composer still read `half-written thought`.

Also green: `pnpm build`, `pnpm check:tokens`, `scripts/check_test_pointers.sh`, `scripts/check_sld.sh`. No Rust touched.

Closes #3894

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
