### PR TITLE
fix(trusty-installer): bounded health-probe timeout, PATH-independent verify, multi-file PATH install

### DIFF
--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -10,6 +10,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Post-install verify could hang indefinitely instead of failing fast when
+  a daemon was genuinely dead** (#3875). Root cause: the bounded poll-until-
+  ready loop bounded the *number* of health-probe attempts and the aggregate
+  wall-clock budget, but each individual `<binary> health --json` subprocess
+  call had no timeout of its own — a single hung child (e.g. blocked on a
+  half-open socket to a dead daemon) could block `Command::output()` forever,
+  defeating every bound above it. Fixed by wrapping every health-probe
+  subprocess call in a bounded (10s) timeout that kills and reaps a
+  still-running child rather than waiting on it forever.
+- **Verify table reported genuinely-installed binaries as `not_installed`
+  under an incomplete `PATH`** (#3876). Root cause: binary presence was
+  resolved via `which::which` alone, which depends entirely on `PATH`;
+  binaries installed to `~/.local/bin` were mis-reported `not_installed`
+  whenever that directory was missing from `PATH` (see #3874). Fixed by
+  falling back to probing the default install directory directly when
+  `which` fails, so the verdict is resilient to a broken `PATH`.
+- **`install.sh` only added `~/.local/bin` to `PATH` via `.zshrc`, which
+  non-interactive and non-login zsh invocations (e.g. a plain
+  `ssh host 'cmd'`) never source** (#3874), causing false "not found"
+  preflight warnings and bogus verify results on fresh machines. Fixed by
+  writing the PATH export to `.zshenv` (sourced unconditionally), `.zprofile`
+  (login shells), and `.zshrc` (interactive shells) for zsh, and to both
+  `.bashrc` and `.bash_profile` for bash — each write idempotent so repeat
+  installs never duplicate the export line.
+
 - **`tctl install -y` dead-ended on a truly clean macOS box with no
   Homebrew: tmux could never be auto-installed, and the install ran to
   completion anyway before failing with an unexplained exit 2** (#3821,

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -39,10 +39,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   sources all three) triple the install dir in `PATH` on a single fresh
   install. bash gets both `.bashrc` and `.bash_profile` (its interactive and
   login files respectively — a default bash session sources only one of the
-  two, not both). Each write skips itself when a `PATH=` line already names
-  the install dir in that file — in ANY quoting style, not only this
-  script's own — so repeat installs, or a machine with a pre-existing
-  hand-written PATH entry, never get a duplicate export line.
+  two, not both). Each write skips itself only when the file already
+  contains a genuine, live `PATH=` assignment (not a commented-out line, and
+  not a same-prefix sibling like `MANPATH=`/`FPATH=`) naming the install dir
+  as a `:`/quote/whitespace-delimited path segment (not merely as a
+  substring of a longer, different directory) — recognising any quoting
+  style, not only this script's own — so repeat installs, or a machine with
+  a pre-existing hand-written PATH entry, never get a duplicate export line,
+  while a commented-out or unrelated-variable entry never silently blocks
+  the real PATH export from being written.
 
 - **`tctl install -y` dead-ended on a truly clean macOS box with no
   Homebrew: tmux could never be auto-installed, and the install ran to

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -18,7 +18,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   half-open socket to a dead daemon) could block `Command::output()` forever,
   defeating every bound above it. Fixed by wrapping every health-probe
   subprocess call in a bounded (10s) timeout that kills and reaps a
-  still-running child rather than waiting on it forever.
+  still-running child rather than waiting on it forever; on timeout, the
+  probe's stdout/stderr reader threads are also reclaimed within a short
+  bounded grace period instead of being left to detach indefinitely.
 - **Verify table reported genuinely-installed binaries as `not_installed`
   under an incomplete `PATH`** (#3876). Root cause: binary presence was
   resolved via `which::which` alone, which depends entirely on `PATH`;
@@ -30,10 +32,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   non-interactive and non-login zsh invocations (e.g. a plain
   `ssh host 'cmd'`) never source** (#3874), causing false "not found"
   preflight warnings and bogus verify results on fresh machines. Fixed by
-  writing the PATH export to `.zshenv` (sourced unconditionally), `.zprofile`
-  (login shells), and `.zshrc` (interactive shells) for zsh, and to both
-  `.bashrc` and `.bash_profile` for bash — each write idempotent so repeat
-  installs never duplicate the export line.
+  writing the PATH export to `.zshenv`, which zsh sources unconditionally for
+  every invocation type (interactive, login, non-interactive, script) — so
+  one write covers the gap without also writing `.zprofile`/`.zshrc`, which
+  would make a normal login+interactive session (a fresh Terminal.app window
+  sources all three) triple the install dir in `PATH` on a single fresh
+  install. bash gets both `.bashrc` and `.bash_profile` (its interactive and
+  login files respectively — a default bash session sources only one of the
+  two, not both). Each write skips itself when a `PATH=` line already names
+  the install dir in that file — in ANY quoting style, not only this
+  script's own — so repeat installs, or a machine with a pre-existing
+  hand-written PATH entry, never get a duplicate export line.
 
 - **`tctl install -y` dead-ended on a truly clean macOS box with no
   Homebrew: tmux could never be auto-installed, and the install ran to

--- a/crates/trusty-installer/src/commands/probe.rs
+++ b/crates/trusty-installer/src/commands/probe.rs
@@ -19,11 +19,134 @@
 //! `validate_version_envelope`, and the strategy gating in `probe_member_health`
 //! (the parse/classify halves; the subprocess spawn itself is side-effecting).
 
+use std::io::Read;
+use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{Duration, Instant};
 
 use super::stable_set::ManageStrategy;
 use super::up::member::MemberHealth;
 use super::up::system_runner::classify_status;
+
+/// Bound on how long a single `<binary> health --json` subprocess may run
+/// before it is treated as a hung probe (#3875).
+///
+/// Why: [`super::verify_tail`]'s poll-until-ready loop bounds the NUMBER of
+/// probe attempts (`bounded_attempts`/`POLL_MAX_ATTEMPTS`) and the AGGREGATE
+/// wall-clock budget across all members, but every one of those bounds
+/// assumed a single probe call itself returns promptly. VM evidence (#3875)
+/// showed `tctl install` hanging >6 minutes at "waiting for trusty-search to
+/// start..." with a genuinely-dead daemon: the child `health --json` process
+/// itself never exited (e.g. blocked on a half-open socket to the dead
+/// daemon), so `Command::output()` — which blocks until EOF on both pipes —
+/// never returned, defeating every attempt/aggregate bound above it.
+/// What: 10s — generous for a live daemon's near-instant `health --json`
+/// reply, short enough that a single hung probe can never itself consume more
+/// than a small slice of `verify_tail`'s ~120s aggregate budget.
+const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Run `cmd`, killing it and returning a timeout error if it has not exited
+/// within `timeout` (#3875).
+///
+/// Why: `std::process::Command::output()` has no built-in timeout — a hung
+/// child (dead daemon, wedged health check) blocks the caller forever. This
+/// wraps spawn + a bounded `try_wait` poll, killing the child on expiry, so
+/// no caller of a subprocess health probe can hang indefinitely.
+/// What: spawns `cmd` with piped stdout/stderr, drains both pipes
+/// concurrently on background threads (so a chatty child can never deadlock
+/// on a full pipe buffer while we're only polling `try_wait`), and polls
+/// `try_wait` every 25ms. On timeout, kills + reaps the child and returns
+/// `Err(ErrorKind::TimedOut)`. On normal exit, joins the reader threads and
+/// returns the collected `Output`.
+/// Test: `tests::output_with_timeout_returns_output_for_fast_command`,
+/// `tests::output_with_timeout_kills_hung_command`.
+fn output_with_timeout(
+    mut cmd: Command,
+    timeout: Duration,
+) -> std::io::Result<std::process::Output> {
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+    let mut child = cmd.spawn()?;
+
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut p) = stdout_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        buf
+    });
+    let stderr_handle = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut p) = stderr_pipe {
+            let _ = p.read_to_end(&mut buf);
+        }
+        buf
+    });
+
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break status;
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("command timed out after {timeout:?}"),
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    };
+
+    let stdout = stdout_handle.join().unwrap_or_default();
+    let stderr = stderr_handle.join().unwrap_or_default();
+    Ok(std::process::Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+/// Whether `path` exists and is executable (unix) / a regular file (other
+/// platforms) — the concrete-file half of [`resolve_binary_path`]'s #3876
+/// PATH-independent fallback.
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.is_file()
+}
+
+/// Resolve `binary` to a concrete path, trying `PATH` first and falling back
+/// to the default install directory (#3876).
+///
+/// Why: the verify table classified genuinely-installed binaries as
+/// `not_installed` whenever `PATH` was incomplete (#3874 — a fresh
+/// non-login/non-interactive shell lacks `~/.local/bin`). Relying on `which`
+/// alone conflates "not on PATH" with "not installed", which are different
+/// facts; probing the install directory directly makes the verdict resilient
+/// to a broken PATH instead of cascading its failure into a false negative.
+/// What: returns `which::which(binary)`'s path when it resolves; otherwise
+/// probes `<default_install_dir>/<binary>` and returns it iff
+/// [`is_executable`]; otherwise `None` (genuinely not installed).
+/// Test: `tests::resolve_binary_path_install_dir_fallback_detects_executable`,
+/// `tests::resolve_binary_path_none_when_absent_everywhere`.
+fn resolve_binary_path(binary: &str) -> Option<PathBuf> {
+    if let Ok(p) = which::which(binary) {
+        return Some(p);
+    }
+    let candidate = crate::download::default_install_dir()?.join(binary);
+    is_executable(&candidate).then_some(candidate)
+}
 
 /// Coarse health verdict string vocabulary used across the rollup commands.
 ///
@@ -90,20 +213,24 @@ pub fn health_string(h: MemberHealth) -> &'static str {
 /// standard verb would always fail and falsely report `down`; returning a flat
 /// `unknown` string instead keeps the rollup honest without claiming a false
 /// verdict in either direction.
-/// What: returns `not_installed` when the binary is absent. For a `Launchd`
-/// member, spawns `<binary> health --json` and classifies the envelope. For an
-/// `OwnVerb` member, returns `unknown` (health is not probeable via the standard
-/// contract). For `None` (non-daemon), returns `unknown` too (callers should not
-/// ask, but it is a safe default).
+/// What: returns `not_installed` when [`resolve_binary_path`] finds the binary
+/// neither on `PATH` NOR in the default install directory (#3876). For a
+/// `Launchd` member, spawns `<resolved path> health --json` under a bounded
+/// timeout (#3875) and classifies the envelope. For an `OwnVerb` member,
+/// returns `unknown` (health is not probeable via the standard contract). For
+/// `None` (non-daemon), returns `unknown` too (callers should not ask, but it
+/// is a safe default).
 /// Test: `tests::own_verb_member_is_unknown`; the launchd spawn is side-effecting
 /// and its parse half is covered by `classify_health_json`.
 pub fn probe_member_health(binary: &str, manage: ManageStrategy) -> String {
-    if which::which(binary).is_err() {
+    let Some(bin_path) = resolve_binary_path(binary) else {
         return health_str::NOT_INSTALLED.to_owned();
-    }
+    };
     match manage {
         ManageStrategy::Launchd => {
-            let out = Command::new(binary).args(["health", "--json"]).output();
+            let mut cmd = Command::new(&bin_path);
+            cmd.args(["health", "--json"]);
+            let out = output_with_timeout(cmd, HEALTH_PROBE_TIMEOUT);
             let health = match out {
                 Ok(out) if out.status.success() => classify_health_json(&out.stdout),
                 Ok(_) | Err(_) => MemberHealth::Down,
@@ -245,6 +372,91 @@ mod tests {
         let h = probe_member_health("definitely-not-a-real-binary-xyz", ManageStrategy::OwnVerb);
         // Absent binary short-circuits to not_installed before the strategy arm.
         assert_eq!(h, health_str::NOT_INSTALLED);
+    }
+
+    /// Why (#3875): a fast, well-behaved command must return its real output
+    /// through the timeout wrapper — the wrapper must not alter normal
+    /// (non-hung) behaviour.
+    /// What: runs `/bin/echo hello` (or `cmd /C echo hello` on non-unix) under
+    /// a generous timeout; asserts success + the expected stdout.
+    /// Test: This is the test.
+    #[test]
+    fn output_with_timeout_returns_output_for_fast_command() {
+        let mut cmd = Command::new("echo");
+        cmd.arg("hello");
+        let out = output_with_timeout(cmd, Duration::from_secs(5)).expect("echo should run");
+        assert!(out.status.success());
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
+    }
+
+    /// Why (#3875): the entire point of the wrapper is that a hung child must
+    /// never block the caller past the bound — this is the regression test for
+    /// the VM hang (`tctl install` stuck >6 min at "waiting for trusty-search
+    /// to start...").
+    /// What: runs `sleep 60` under a 1s timeout; asserts the call returns
+    /// (rather than hanging) and yields a `TimedOut` error, well within a
+    /// generous wall-clock assertion.
+    /// Test: This is the test.
+    #[test]
+    fn output_with_timeout_kills_hung_command() {
+        let mut cmd = Command::new("sleep");
+        cmd.arg("60");
+        let start = Instant::now();
+        let err = output_with_timeout(cmd, Duration::from_secs(1))
+            .expect_err("a 60s sleep must not complete within a 1s timeout");
+        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        assert!(
+            start.elapsed() < Duration::from_secs(10),
+            "timeout wrapper took far longer than its 1s bound: {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// Why (#3876): the verify table must not report a genuinely-installed
+    /// binary as `not_installed` just because it is missing from `PATH` — the
+    /// exact false-negative the VM run hit under a broken (#3874) PATH.
+    /// What: creates a fake executable at a temp "install dir", monkeys
+    /// `resolve_binary_path`'s install-dir fallback by exercising
+    /// [`is_executable`] + the join logic it uses directly (since
+    /// `default_install_dir` is HOME-derived and not injectable here), proving
+    /// the executable-detection half of the fallback in isolation.
+    /// Test: This is the test.
+    #[test]
+    fn resolve_binary_path_install_dir_fallback_detects_executable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin_path = dir.path().join("fake-trusty-search");
+        std::fs::write(&bin_path, b"#!/bin/sh\necho hi\n").expect("write fake binary");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&bin_path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&bin_path, perms).unwrap();
+        }
+        assert!(is_executable(&bin_path));
+
+        let non_exec = dir.path().join("not-a-binary.txt");
+        std::fs::write(&non_exec, b"just text").expect("write plain file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&non_exec).unwrap().permissions();
+            perms.set_mode(0o644);
+            std::fs::set_permissions(&non_exec, perms).unwrap();
+        }
+        #[cfg(unix)]
+        assert!(!is_executable(&non_exec));
+    }
+
+    /// Why (#3876): a binary absent from both `PATH` and the install
+    /// directory must still resolve to `None` (genuinely not installed) — the
+    /// fallback must not turn every lookup into a false positive.
+    /// What: asserts `resolve_binary_path` returns `None` for an
+    /// unmistakably-fake binary name.
+    /// Test: This is the test.
+    #[test]
+    fn resolve_binary_path_none_when_absent_everywhere() {
+        assert!(resolve_binary_path("definitely-not-a-real-binary-xyz-3876").is_none());
     }
 
     /// Why: A fully-conformant envelope (contract_version + non-empty verbs)

--- a/crates/trusty-installer/src/commands/probe.rs
+++ b/crates/trusty-installer/src/commands/probe.rs
@@ -55,11 +55,15 @@ const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 /// What: spawns `cmd` with piped stdout/stderr, drains both pipes
 /// concurrently on background threads (so a chatty child can never deadlock
 /// on a full pipe buffer while we're only polling `try_wait`), and polls
-/// `try_wait` every 25ms. On timeout, kills + reaps the child and returns
-/// `Err(ErrorKind::TimedOut)`. On normal exit, joins the reader threads and
-/// returns the collected `Output`.
+/// `try_wait` every 25ms. On timeout, kills + reaps the child, then gives the
+/// reader threads a short (200ms) bounded grace period to observe EOF (killing
+/// the child closes our end of its pipes, so this is normally near-instant)
+/// before giving up and detaching them — a genuinely stuck grandchild-held
+/// pipe never turns a bounded probe into an unbounded one. On normal exit,
+/// joins the reader threads and returns the collected `Output`.
 /// Test: `tests::output_with_timeout_returns_output_for_fast_command`,
-/// `tests::output_with_timeout_kills_hung_command`.
+/// `tests::output_with_timeout_kills_hung_command`,
+/// `tests::output_with_timeout_repeated_timeouts_stay_bounded`.
 fn output_with_timeout(
     mut cmd: Command,
     timeout: Duration,
@@ -93,6 +97,33 @@ fn output_with_timeout(
         if start.elapsed() >= timeout {
             let _ = child.kill();
             let _ = child.wait();
+            // #3897 code-critic LOW: reclaim the reader threads on the
+            // timeout path too, not just the success path below — otherwise
+            // every timed-out probe silently detaches two threads. `kill` +
+            // `wait` above closes OUR end of the pipes; in the overwhelmingly
+            // common case (no grandchild inherited the fd) that alone makes
+            // the readers' `read_to_end` see EOF within microseconds, so a
+            // short bounded grace period reclaims them without making the
+            // timeout path itself block noticeably longer. If a grandchild
+            // somehow still holds the pipe open past the grace period, we
+            // deliberately stop waiting (never turn a bounded probe into an
+            // unbounded one) — the readers are dropped/detached and the
+            // process is short-lived (`tctl` exits once verify_tail
+            // finishes), so the worst case is a handful of stray threads for
+            // the remainder of THIS invocation, never an unbounded
+            // accumulation across probes.
+            let join_deadline = Instant::now() + Duration::from_millis(200);
+            while Instant::now() < join_deadline
+                && (!stdout_handle.is_finished() || !stderr_handle.is_finished())
+            {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            if stdout_handle.is_finished() {
+                let _ = stdout_handle.join();
+            }
+            if stderr_handle.is_finished() {
+                let _ = stderr_handle.join();
+            }
             return Err(std::io::Error::new(
                 std::io::ErrorKind::TimedOut,
                 format!("command timed out after {timeout:?}"),
@@ -408,6 +439,36 @@ mod tests {
         assert!(
             start.elapsed() < Duration::from_secs(10),
             "timeout wrapper took far longer than its 1s bound: {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// Why (#3897 code-critic LOW): a timed-out probe must reclaim its
+    /// reader threads within a small bounded grace period, not just detach
+    /// them forever — otherwise every kickstart/verify probe against a
+    /// genuinely-dead daemon leaks two threads. Killing the child closes our
+    /// end of its pipes, so (absent a grandchild inheriting the fd) the
+    /// readers see EOF almost immediately; running several timeouts back to
+    /// back proves the per-call grace period isn't itself compounding into
+    /// unbounded wall-clock growth.
+    /// What: runs 3 back-to-back 1s-bound timeouts against `sleep 60`;
+    /// asserts each is `TimedOut` and the TOTAL elapsed stays well under
+    /// `3 * (timeout + grace-period + overhead)`, i.e. no call is silently
+    /// blocking on the previous call's reader threads.
+    /// Test: This is the test.
+    #[test]
+    fn output_with_timeout_repeated_timeouts_stay_bounded() {
+        let start = Instant::now();
+        for _ in 0..3 {
+            let mut cmd = Command::new("sleep");
+            cmd.arg("60");
+            let err = output_with_timeout(cmd, Duration::from_secs(1))
+                .expect_err("a 60s sleep must not complete within a 1s timeout");
+            assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
+        }
+        assert!(
+            start.elapsed() < Duration::from_secs(15),
+            "3 sequential 1s timeouts took far longer than expected: {:?}",
             start.elapsed()
         );
     }

--- a/install.sh
+++ b/install.sh
@@ -339,15 +339,29 @@ confirm() {
 # PATH handling
 # ---------------------------------------------------------------------------
 
-# Why (#3874): a repeat install run must not accumulate duplicate `export
-#      PATH=...` lines in the same RC file.
+# Why (#3874; broadened per #3897 code-critic WARN): a repeat install run
+#      must not accumulate duplicate `export PATH=...` lines in the same RC
+#      file — but the original check only matched OUR OWN exact single-quote
+#      format (`PATH='<dir>'`), so a user's pre-existing hand-written entry in
+#      a different style (e.g. `export PATH="$HOME/.local/bin:$PATH"`, or no
+#      quotes at all) went undetected and got a redundant second entry
+#      appended anyway. Matching `PATH=` followed anywhere on the same line by
+#      the literal directory (regex-escaped; the caller's allowlist already
+#      restricts `_pdir` to `A-Za-z0-9/_.~-`, of which only `.` is an ERE
+#      metacharacter) catches any reasonable quoting/spacing style, not just
+#      this script's own.
 # What: returns 0 (already present) iff `_pfile` exists and already contains
-#      an export line for `_pdir`; 1 otherwise (including a missing file).
-# Test: appending twice via `_append_path_export` leaves exactly one line.
+#      a `PATH=` line naming `_pdir`, in ANY quoting style; 1 otherwise
+#      (including a missing file).
+# Test: appending twice via `_append_path_export` leaves exactly one line;
+#      a pre-existing differently-quoted entry is also detected (no second
+#      entry appended).
 _path_export_present_in() {
     _pdir="$1"
     _pfile="$2"
-    [ -f "${_pfile}" ] && grep -qF "PATH='${_pdir}'" "${_pfile}" 2>/dev/null
+    [ -f "${_pfile}" ] || return 1
+    _pdir_esc=$(printf '%s' "${_pdir}" | sed 's/[.]/\\&/g')
+    grep -Eq "PATH=.*${_pdir_esc}" "${_pfile}" 2>/dev/null
 }
 
 # Why (#3874): shared by every RC file `maybe_update_path` writes so the
@@ -402,18 +416,25 @@ maybe_update_path() {
 
     # Detect the RC file(s) from the login shell; default to ~/.profile.
     #
-    # Why (#3874): writing only to .zshrc misses non-interactive/non-login
-    # invocations (e.g. a plain `ssh host 'cmd'`), which zsh never sources
-    # .zshrc (or .zprofile) for — only .zshenv is sourced unconditionally on
-    # every zsh invocation. Writing PATH to all three covers interactive
-    # (.zshrc), login (.zprofile), and non-interactive/non-login (.zshenv)
-    # shells. bash similarly gets both its interactive (.bashrc) and login
-    # (.bash_profile) file.
+    # Why (#3874, revised per #3897 code-critic WARN): writing only to
+    # .zshrc misses non-interactive/non-login invocations (e.g. a plain
+    # `ssh host 'cmd'`), which zsh never sources .zshrc (or .zprofile) for.
+    # The FIRST fix here wrote all three of .zshenv/.zprofile/.zshrc, but a
+    # normal login+interactive session (the default for a new Terminal.app
+    # window) sources ALL THREE in one shell — .zshenv, then .zprofile (it's
+    # a login shell), then .zshrc (it's interactive) — so the install dir
+    # landed in PATH three times from a single fresh install. `.zshenv` is
+    # sourced UNCONDITIONALLY by every zsh invocation type (interactive,
+    # login, non-interactive, script), so it alone is sufficient to fix
+    # #3874's actual gap; writing the other two only added duplication risk
+    # without covering any invocation .zshenv doesn't already cover. Kept
+    # zsh on the same idempotent single-directory append machinery as
+    # bash/profile below, just pointed at one file.
     _shell_name="$(basename "${SHELL:-/bin/sh}")"
     case "${_shell_name}" in
         zsh)
-            _rc_files="${HOME}/.zshenv ${HOME}/.zprofile ${HOME}/.zshrc"
-            _rc_display="${HOME}/.zshenv, ${HOME}/.zprofile, and ${HOME}/.zshrc"
+            _rc_files="${HOME}/.zshenv"
+            _rc_display="${HOME}/.zshenv"
             ;;
         bash)
             _rc_files="${HOME}/.bashrc ${HOME}/.bash_profile"

--- a/install.sh
+++ b/install.sh
@@ -339,29 +339,56 @@ confirm() {
 # PATH handling
 # ---------------------------------------------------------------------------
 
-# Why (#3874; broadened per #3897 code-critic WARN): a repeat install run
-#      must not accumulate duplicate `export PATH=...` lines in the same RC
-#      file — but the original check only matched OUR OWN exact single-quote
-#      format (`PATH='<dir>'`), so a user's pre-existing hand-written entry in
-#      a different style (e.g. `export PATH="$HOME/.local/bin:$PATH"`, or no
-#      quotes at all) went undetected and got a redundant second entry
-#      appended anyway. Matching `PATH=` followed anywhere on the same line by
-#      the literal directory (regex-escaped; the caller's allowlist already
-#      restricts `_pdir` to `A-Za-z0-9/_.~-`, of which only `.` is an ERE
-#      metacharacter) catches any reasonable quoting/spacing style, not just
-#      this script's own.
-# What: returns 0 (already present) iff `_pfile` exists and already contains
-#      a `PATH=` line naming `_pdir`, in ANY quoting style; 1 otherwise
-#      (including a missing file).
+# Why (#3874; broadened per #3897 code-critic WARN, then CORRECTED per
+#      #3897 code-critic BLOCK — a first broadening was a free-substring
+#      match on "PATH=.*<dir>" with no anchoring, which produced FALSE
+#      positives that made `_append_path_export` silently skip writing the
+#      real export line — reproduced two ways: (a) a commented-out line
+#      naming the dir, e.g. `# export PATH="<dir>:$PATH"  (disabled)` —
+#      grep doesn't skip `#` lines by default; (b) `PATH=` is a substring of
+#      `MANPATH=`/`FPATH=`/`PYTHONPATH=`/`CLASSPATH=`, and with no
+#      right-hand boundary check, `.../.local/bin` also matched inside
+#      `.../.local/binaries`. Both left `.zshenv` with ZERO real
+#      `export PATH=` lines while the script exited reporting success —
+#      strictly worse than the cosmetic over-broadening it replaced, since
+#      that one still worked): a repeat install run must not accumulate
+#      duplicate `export PATH=...` lines in the same RC file, and a user's
+#      pre-existing hand-written entry in a different quoting style (e.g.
+#      `export PATH="$HOME/.local/bin:$PATH"`) must be recognised too — but
+#      ONLY when it is an actual, live `PATH=` assignment naming this exact
+#      directory as a `:`/quote/whitespace/end-of-line-delimited path
+#      segment.
+# What: returns 0 (already present) iff, after dropping full-line comments
+#      (lines whose first non-whitespace character is `#`), `_pfile`
+#      contains a line where: (i) `PATH=` is not itself the tail of a longer
+#      identifier (required not to be preceded by a word character, so
+#      `MANPATH=`/`FPATH=`/etc. can never match); (ii) `_pdir` is either
+#      immediately glued to `PATH=` (the unquoted `PATH=<dir>:$PATH` form)
+#      OR immediately preceded by one of `:`, `'`, `"` (so it can never
+#      match as a bare substring tacked onto an unrelated word, e.g.
+#      `PATH=FOO<dir>`); AND (iii) `_pdir` is immediately followed by one of
+#      `:`, `'`, `"`, whitespace, or end-of-line (so `.local/bin` can never
+#      match inside `.local/binaries`). Returns 1 otherwise (including a
+#      missing file, or a match found only in a commented-out line).
+# What it does NOT guarantee: this is not a shell parser — an assignment
+#      split across a `\`-continued line, or one hidden behind further
+#      indirection (`eval`, a sourced variable), will not be detected. That
+#      is an accepted, narrow gap; false-negative here just means a second
+#      (harmless, still-idempotent-on-ITS-OWN-writes) export line gets
+#      appended, never a silently-skipped real fix — the failure mode this
+#      function exists to avoid is a false POSITIVE, not a false negative.
 # Test: appending twice via `_append_path_export` leaves exactly one line;
-#      a pre-existing differently-quoted entry is also detected (no second
-#      entry appended).
+#      a pre-existing differently-quoted entry is detected (no second entry
+#      appended); a commented-out entry is NOT detected (the real line still
+#      gets written); a sibling `MANPATH=`/`FPATH=` line naming the same dir
+#      is NOT detected (the real `PATH=` line still gets written).
 _path_export_present_in() {
     _pdir="$1"
     _pfile="$2"
     [ -f "${_pfile}" ] || return 1
     _pdir_esc=$(printf '%s' "${_pdir}" | sed 's/[.]/\\&/g')
-    grep -Eq "PATH=.*${_pdir_esc}" "${_pfile}" 2>/dev/null
+    grep -v '^[[:space:]]*#' "${_pfile}" 2>/dev/null \
+        | grep -Eq "(^|[^A-Za-z0-9_])PATH=(.*[:='\"])?${_pdir_esc}(:|'|\"|[[:space:]]|\$)"
 }
 
 # Why (#3874): shared by every RC file `maybe_update_path` writes so the

--- a/install.sh
+++ b/install.sh
@@ -339,12 +339,45 @@ confirm() {
 # PATH handling
 # ---------------------------------------------------------------------------
 
+# Why (#3874): a repeat install run must not accumulate duplicate `export
+#      PATH=...` lines in the same RC file.
+# What: returns 0 (already present) iff `_pfile` exists and already contains
+#      an export line for `_pdir`; 1 otherwise (including a missing file).
+# Test: appending twice via `_append_path_export` leaves exactly one line.
+_path_export_present_in() {
+    _pdir="$1"
+    _pfile="$2"
+    [ -f "${_pfile}" ] && grep -qF "PATH='${_pdir}'" "${_pfile}" 2>/dev/null
+}
+
+# Why (#3874): shared by every RC file `maybe_update_path` writes so the
+#      idempotency check + append format stay in one place.
+# What: appends the marker comment + export line to `_afile` unless
+#      `_path_export_present_in` already finds it there.
+# Test: `_append_path_export "${dir}" "${file}"` called twice appends once.
+_append_path_export() {
+    _adir="$1"
+    _afile="$2"
+    if _path_export_present_in "${_adir}" "${_afile}"; then
+        return 0
+    fi
+    {
+        printf '\n# Added by trusty-tools install.sh\n'
+        # shellcheck disable=SC2016
+        # Single-quote _adir so it is written verbatim; $PATH expands at
+        # shell startup, not now. The allowlist guard in maybe_update_path
+        # already rejects single-quote characters from _adir.
+        printf "export PATH='%s':\$PATH\n" "${_adir}"
+    } >>"${_afile}"
+}
+
 # Why: Installing into ~/.local/bin is useless if it is not on PATH; help the
 #      user wire it up, but never modify their shell config without consent.
-# What: If install dir is not on PATH, append an export line to the detected
-#      shell RC file (after confirmation). Skipped when TRUSTY_NO_MODIFY_PATH=1.
+# What: If install dir is not on PATH, append an export line to every RC file
+#      relevant to the detected shell (after confirmation), idempotently.
+#      Skipped when TRUSTY_NO_MODIFY_PATH=1.
 # Test: With a dir already on PATH, returns immediately. With a dir not on PATH
-#      and ASSUME_YES=1, appends an export line to the detected RC file.
+#      and ASSUME_YES=1, appends an export line to each detected RC file, once.
 maybe_update_path() {
     _dir="$1"
 
@@ -367,31 +400,37 @@ maybe_update_path() {
         return 0
     fi
 
-    # Detect the RC file from the login shell; default to ~/.profile.
+    # Detect the RC file(s) from the login shell; default to ~/.profile.
+    #
+    # Why (#3874): writing only to .zshrc misses non-interactive/non-login
+    # invocations (e.g. a plain `ssh host 'cmd'`), which zsh never sources
+    # .zshrc (or .zprofile) for — only .zshenv is sourced unconditionally on
+    # every zsh invocation. Writing PATH to all three covers interactive
+    # (.zshrc), login (.zprofile), and non-interactive/non-login (.zshenv)
+    # shells. bash similarly gets both its interactive (.bashrc) and login
+    # (.bash_profile) file.
     _shell_name="$(basename "${SHELL:-/bin/sh}")"
     case "${_shell_name}" in
         zsh)
-            _rc="${HOME}/.zshrc"
+            _rc_files="${HOME}/.zshenv ${HOME}/.zprofile ${HOME}/.zshrc"
+            _rc_display="${HOME}/.zshenv, ${HOME}/.zprofile, and ${HOME}/.zshrc"
             ;;
         bash)
-            _rc="${HOME}/.bashrc"
+            _rc_files="${HOME}/.bashrc ${HOME}/.bash_profile"
+            _rc_display="${HOME}/.bashrc and ${HOME}/.bash_profile"
             ;;
         *)
-            _rc="${HOME}/.profile"
+            _rc_files="${HOME}/.profile"
+            _rc_display="${HOME}/.profile"
             ;;
     esac
 
     say ""
-    if confirm "Add ${_dir} to your PATH in ${_rc}?"; then
-        {
-            printf '\n# Added by trusty-tools install.sh\n'
-            # shellcheck disable=SC2016
-            # Single-quote _dir so it is written verbatim; $PATH expands at
-            # shell startup, not now. The allowlist guard above already rejects
-            # single-quote characters from _dir.
-            printf "export PATH='%s':\$PATH\n" "${_dir}"
-        } >>"${_rc}"
-        say "Added ${_dir} to PATH in ${_rc}. Restart your shell or run:"
+    if confirm "Add ${_dir} to your PATH in ${_rc_display}?"; then
+        for _rc in ${_rc_files}; do
+            _append_path_export "${_dir}" "${_rc}"
+        done
+        say "Added ${_dir} to PATH in ${_rc_display}. Restart your shell or run:"
         say "    export PATH=\"${_dir}:\$PATH\""
     else
         say "Skipped PATH modification. Add this to your shell config manually:"
@@ -683,4 +722,11 @@ main() {
     print_next_steps
 }
 
-main "$@"
+# Why: lets tests (tests/install_path_test.sh) source this file to exercise
+#      individual functions (e.g. maybe_update_path) without triggering the
+#      full network install flow. Unset (the curl|sh default) behaves exactly
+#      as before — main always runs.
+# What: skips the `main "$@"` call iff TRUSTY_INSTALL_SOURCE_ONLY=1.
+if [ "${TRUSTY_INSTALL_SOURCE_ONLY:-0}" != "1" ]; then
+    main "$@"
+fi

--- a/tests/test-install-path.sh
+++ b/tests/test-install-path.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # tests/test-install-path.sh — unit tests for install.sh's PATH handling
 # (#3874: write PATH idempotently to the file(s) each shell always sources;
-# #3897 code-critic follow-up: no PATH tripling in a normal login+interactive
-# session, and idempotency detects pre-existing differently-quoted entries).
+# #3897 code-critic follow-up round 1 [WARN]: no PATH tripling in a normal
+# login+interactive session, and idempotency detects pre-existing
+# differently-quoted entries; round 2 [BLOCK]: the round-1 idempotency
+# broadening was an unanchored substring match that silently matched
+# commented-out lines and sibling *PATH variables, causing the REAL export
+# line to be skipped while the script still exited reporting success).
 #
 # Why: install.sh previously wrote the PATH export only to `.zshrc`, which
 # neither non-interactive (`ssh host cmd`) nor login-but-not-interactive zsh
@@ -12,11 +16,18 @@
 # A first fix wrote all three of .zshenv/.zprofile/.zshrc, but a normal
 # login+interactive session (a fresh Terminal.app window) sources all three
 # in ONE shell, tripling the install dir in PATH on a single fresh install
-# (#3897 code-critic MEDIUM finding) — fixed by writing only `.zshenv`
-# (sufficient on its own; sourced unconditionally). A second finding showed
-# the idempotency check only recognised this script's own exact quoting
-# style, so a hand-written differently-quoted PATH entry got a redundant
-# second entry appended — fixed by broadening the match.
+# (round 1 MEDIUM finding) — fixed by writing only `.zshenv` (sufficient on
+# its own; sourced unconditionally). A round-1 second finding showed the
+# idempotency check only recognised this script's own exact quoting style,
+# so a hand-written differently-quoted PATH entry got a redundant second
+# entry appended — fixed by broadening the match to `PATH=.*<dir>`. THAT
+# broadening was itself unanchored (round 2 CRITICAL/BLOCK): it silently
+# matched a commented-out line naming the dir, and matched `PATH=` as a
+# substring of `MANPATH=`/`FPATH=`/etc. and the dir as a substring of a
+# longer sibling directory — in both cases the REAL export was never
+# written, and the script still exited 0. Fixed with a comment-stripping
+# pre-pass plus a properly anchored (word-boundary on `PATH=`, delimiter
+# boundary on both sides of the directory) match.
 #
 # What: sources install.sh with TRUSTY_INSTALL_SOURCE_ONLY=1 (skips the
 # network `main` flow) inside a synthetic $HOME, then drives
@@ -25,9 +36,18 @@
 # - bash: both .bashrc/.bash_profile get the export line
 # - repeat runs do not duplicate the export line in any file (idempotency)
 # - a real login+interactive zsh sourcing every file install.sh could have
-#   touched sees the install dir on PATH EXACTLY ONCE (the tripling regression)
+#   touched sees the install dir on PATH EXACTLY ONCE (the round-1 tripling
+#   regression)
 # - a pre-existing, differently-quoted PATH entry is recognised (no second
 #   entry appended)
+# - a pre-existing COMMENTED-OUT entry naming the dir does NOT block the
+#   real export line from being written (round-2 trigger a)
+# - a pre-existing sibling `MANPATH=` entry naming the dir does NOT block
+#   the real `PATH=` line from being written (round-2 trigger b, part 1)
+# - a pre-existing entry naming a longer directory that merely STARTS WITH
+#   the install dir (`.../.local/binaries`) does NOT block the real
+#   `.../.local/bin` export line from being written (round-2 trigger b,
+#   part 2)
 #
 # Test: This file *is* the test. Run with: tests/test-install-path.sh
 
@@ -176,6 +196,73 @@ test_differently_quoted_existing_entry_is_recognised() {
     rm -rf "$home"
 }
 
+# #3897 code-critic BLOCK finding, trigger (a): a broadened idempotency
+# match on a bare "PATH=.*<dir>" substring silently matched a COMMENTED-OUT
+# line naming the dir, so `_append_path_export` thought a real export was
+# already present and skipped writing one — leaving `.zshenv` with ZERO
+# live `export PATH=` lines while the script exited reporting success. The
+# real fix must strip full-line comments before matching, so a disabled
+# entry never blocks the real write.
+test_commented_out_entry_does_not_block_real_write() {
+    echo "--- test_commented_out_entry_does_not_block_real_write ---"
+    local home
+    home=$(mktemp -d -t install-path-test-XXXXXX)
+    mkdir -p "$home"
+    printf '# export PATH="%s/.local/bin:$PATH"  (disabled)\n' "$home" >"$home/.zshenv"
+
+    run_maybe_update_path "$home" "/bin/zsh" >/dev/null
+
+    local real_lines
+    real_lines=$(grep -Ec "^[[:space:]]*export PATH=" "$home/.zshenv")
+    assert_eq "$real_lines" "1" "a commented-out entry does not block the real export line from being written"
+
+    rm -rf "$home"
+}
+
+# #3897 code-critic BLOCK finding, trigger (b) part 1: "PATH=" is a
+# substring of MANPATH=/FPATH=/PYTHONPATH=/CLASSPATH=, so an unanchored
+# match on a sibling *PATH variable naming the install dir also silently
+# blocked the real PATH export from ever being written.
+test_sibling_path_var_does_not_block_real_write() {
+    echo "--- test_sibling_path_var_does_not_block_real_write ---"
+    local home
+    home=$(mktemp -d -t install-path-test-XXXXXX)
+    mkdir -p "$home"
+    printf 'export MANPATH="%s/.local/bin:$MANPATH"\n' "$home" >"$home/.zshenv"
+
+    run_maybe_update_path "$home" "/bin/zsh" >/dev/null
+
+    local real_lines
+    real_lines=$(grep -Ec "^[[:space:]]*export PATH=" "$home/.zshenv")
+    assert_eq "$real_lines" "1" "a sibling MANPATH= entry naming the dir does not block the real PATH= line from being written"
+
+    rm -rf "$home"
+}
+
+# #3897 code-critic BLOCK finding, trigger (b) part 2: with no right-hand
+# word-boundary check, ".../.local/bin" matched inside ".../.local/binaries"
+# — a different, longer directory that merely starts with the install dir's
+# path — also silently blocking the real write.
+test_dir_as_prefix_of_longer_path_does_not_block_real_write() {
+    echo "--- test_dir_as_prefix_of_longer_path_does_not_block_real_write ---"
+    local home
+    home=$(mktemp -d -t install-path-test-XXXXXX)
+    mkdir -p "$home"
+    printf 'export PATH="%s/.local/binaries:$PATH"\n' "$home" >"$home/.zshenv"
+
+    run_maybe_update_path "$home" "/bin/zsh" >/dev/null
+
+    local real_lines
+    real_lines=$(grep -Ec "^[[:space:]]*export PATH=" "$home/.zshenv")
+    assert_eq "$real_lines" "2" "an unrelated .../.local/binaries entry does not block the real .../.local/bin export line from being written (2 total export lines: the pre-existing unrelated one + the new real one)"
+
+    local dir_lines
+    dir_lines=$(grep -cF "PATH='${home}/.local/bin'" "$home/.zshenv")
+    assert_eq "$dir_lines" "1" "exactly one export line names the exact install dir (not the .../.local/binaries lookalike)"
+
+    rm -rf "$home"
+}
+
 echo "==========================================================="
 echo "install.sh PATH-handling test suite (#3874, #3897 follow-up)"
 echo "==========================================================="
@@ -185,6 +272,9 @@ test_repeat_install_is_idempotent
 test_already_on_path_is_noop
 test_login_interactive_zsh_sources_dir_exactly_once
 test_differently_quoted_existing_entry_is_recognised
+test_commented_out_entry_does_not_block_real_write
+test_sibling_path_var_does_not_block_real_write
+test_dir_as_prefix_of_longer_path_does_not_block_real_write
 
 echo "==========================================================="
 echo "Result: $PASS passed, $FAIL failed"

--- a/tests/test-install-path.sh
+++ b/tests/test-install-path.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# tests/test-install-path.sh — unit tests for install.sh's PATH handling
+# (#3874: write to .zshenv/.zprofile/.zshrc idempotently, not just .zshrc).
+#
+# Why: install.sh previously wrote the PATH export only to `.zshrc`, which
+# neither login (`ssh host cmd`, non-interactive) nor login-but-not-
+# interactive zsh invocations source — only `.zshenv` is sourced
+# unconditionally. This left `~/.local/bin` off PATH for those shells,
+# producing false "not found" preflight warnings and bogus verify results.
+#
+# What: sources install.sh with TRUSTY_INSTALL_SOURCE_ONLY=1 (skips the
+# network `main` flow) inside a synthetic $HOME, then drives
+# `maybe_update_path` directly under each detected-shell branch, asserting:
+# - zsh: all three of .zshenv/.zprofile/.zshrc get the export line
+# - bash: both .bashrc/.bash_profile get the export line
+# - repeat runs do not duplicate the export line in any file (idempotency)
+#
+# Test: This file *is* the test. Run with: tests/test-install-path.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local actual="$1" expected="$2" desc="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $desc"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# count_matches <file> <needle> — occurrences of an exact-substring line.
+count_matches() {
+    local file="$1" needle="$2"
+    [[ -f "$file" ]] || { echo 0; return; }
+    grep -cF "$needle" "$file" 2>/dev/null || echo 0
+}
+
+# Runs maybe_update_path("$FAKE_HOME/.local/bin") inside a fresh subshell
+# with $HOME/$SHELL overridden, sourcing install.sh in source-only mode.
+run_maybe_update_path() {
+    local home="$1" shell_path="$2"
+    HOME="$home" SHELL="$shell_path" ASSUME_YES=1 TRUSTY_INSTALL_SOURCE_ONLY=1 \
+        bash -c '. "$1"; maybe_update_path "$HOME/.local/bin"' _ "$INSTALL_SH"
+}
+
+test_zsh_writes_all_three_files() {
+    echo "--- test_zsh_writes_all_three_files ---"
+    local home
+    home=$(mktemp -d -t install-path-test-XXXXXX)
+    run_maybe_update_path "$home" "/bin/zsh" >/dev/null
+
+    local needle="PATH='${home}/.local/bin'"
+    assert_eq "$(count_matches "$home/.zshenv" "$needle")" "1" "zshenv gets the export line"
+    assert_eq "$(count_matches "$home/.zprofile" "$needle")" "1" "zprofile gets the export line"
+    assert_eq "$(count_matches "$home/.zshrc" "$needle")" "1" "zshrc gets the export line"
+
+    rm -rf "$home"
+}
+
+test_bash_writes_both_files() {
+    echo "--- test_bash_writes_both_files ---"
+    local home
+    home=$(mktemp -d -t install-path-test-XXXXXX)
+    run_maybe_update_path "$home" "/bin/bash" >/dev/null
+
+    local needle="PATH='${home}/.local/bin'"
+    assert_eq "$(count_matches "$home/.bashrc" "$needle")" "1" "bashrc gets the export line"
+    assert_eq "$(count_matches "$home/.bash_profile" "$needle")" "1" "bash_profile gets the export line"
+
+    rm -rf "$home"
+}
+
+test_repeat_install_is_idempotent() {
+    echo "--- test_repeat_install_is_idempotent ---"
+    local home
+    home=$(mktemp -d -t install-path-test-XXXXXX)
+    run_maybe_update_path "$home" "/bin/zsh" >/dev/null
+    run_maybe_update_path "$home" "/bin/zsh" >/dev/null
+    run_maybe_update_path "$home" "/bin/zsh" >/dev/null
+
+    local needle="PATH='${home}/.local/bin'"
+    assert_eq "$(count_matches "$home/.zshenv" "$needle")" "1" "zshenv has exactly one export line after 3 runs"
+    assert_eq "$(count_matches "$home/.zprofile" "$needle")" "1" "zprofile has exactly one export line after 3 runs"
+    assert_eq "$(count_matches "$home/.zshrc" "$needle")" "1" "zshrc has exactly one export line after 3 runs"
+
+    rm -rf "$home"
+}
+
+test_already_on_path_is_noop() {
+    echo "--- test_already_on_path_is_noop ---"
+    local home
+    home=$(mktemp -d -t install-path-test-XXXXXX)
+    mkdir -p "$home/.local/bin"
+    HOME="$home" SHELL="/bin/zsh" ASSUME_YES=1 TRUSTY_INSTALL_SOURCE_ONLY=1 \
+        PATH="$home/.local/bin:$PATH" \
+        bash -c '. "$1"; maybe_update_path "$HOME/.local/bin"' _ "$INSTALL_SH" >/dev/null
+
+    assert_eq "$([[ -f "$home/.zshrc" ]] && echo yes || echo no)" "no" "no RC file created when dir already on PATH"
+
+    rm -rf "$home"
+}
+
+echo "==========================================================="
+echo "install.sh PATH-handling test suite (#3874)"
+echo "==========================================================="
+test_zsh_writes_all_three_files
+test_bash_writes_both_files
+test_repeat_install_is_idempotent
+test_already_on_path_is_noop
+
+echo "==========================================================="
+echo "Result: $PASS passed, $FAIL failed"
+echo "==========================================================="
+
+[[ "$FAIL" -eq 0 ]] || exit 1
+exit 0

--- a/tests/test-install-path.sh
+++ b/tests/test-install-path.sh
@@ -1,19 +1,33 @@
 #!/usr/bin/env bash
 # tests/test-install-path.sh — unit tests for install.sh's PATH handling
-# (#3874: write to .zshenv/.zprofile/.zshrc idempotently, not just .zshrc).
+# (#3874: write PATH idempotently to the file(s) each shell always sources;
+# #3897 code-critic follow-up: no PATH tripling in a normal login+interactive
+# session, and idempotency detects pre-existing differently-quoted entries).
 #
 # Why: install.sh previously wrote the PATH export only to `.zshrc`, which
-# neither login (`ssh host cmd`, non-interactive) nor login-but-not-
-# interactive zsh invocations source — only `.zshenv` is sourced
-# unconditionally. This left `~/.local/bin` off PATH for those shells,
+# neither non-interactive (`ssh host cmd`) nor login-but-not-interactive zsh
+# invocations source — only `.zshenv` is sourced unconditionally by every zsh
+# invocation type. This left `~/.local/bin` off PATH for those shells,
 # producing false "not found" preflight warnings and bogus verify results.
+# A first fix wrote all three of .zshenv/.zprofile/.zshrc, but a normal
+# login+interactive session (a fresh Terminal.app window) sources all three
+# in ONE shell, tripling the install dir in PATH on a single fresh install
+# (#3897 code-critic MEDIUM finding) — fixed by writing only `.zshenv`
+# (sufficient on its own; sourced unconditionally). A second finding showed
+# the idempotency check only recognised this script's own exact quoting
+# style, so a hand-written differently-quoted PATH entry got a redundant
+# second entry appended — fixed by broadening the match.
 #
 # What: sources install.sh with TRUSTY_INSTALL_SOURCE_ONLY=1 (skips the
 # network `main` flow) inside a synthetic $HOME, then drives
 # `maybe_update_path` directly under each detected-shell branch, asserting:
-# - zsh: all three of .zshenv/.zprofile/.zshrc get the export line
+# - zsh: only .zshenv gets the export line (not .zprofile/.zshrc)
 # - bash: both .bashrc/.bash_profile get the export line
 # - repeat runs do not duplicate the export line in any file (idempotency)
+# - a real login+interactive zsh sourcing every file install.sh could have
+#   touched sees the install dir on PATH EXACTLY ONCE (the tripling regression)
+# - a pre-existing, differently-quoted PATH entry is recognised (no second
+#   entry appended)
 #
 # Test: This file *is* the test. Run with: tests/test-install-path.sh
 
@@ -54,16 +68,16 @@ run_maybe_update_path() {
         bash -c '. "$1"; maybe_update_path "$HOME/.local/bin"' _ "$INSTALL_SH"
 }
 
-test_zsh_writes_all_three_files() {
-    echo "--- test_zsh_writes_all_three_files ---"
+test_zsh_writes_only_zshenv() {
+    echo "--- test_zsh_writes_only_zshenv ---"
     local home
     home=$(mktemp -d -t install-path-test-XXXXXX)
     run_maybe_update_path "$home" "/bin/zsh" >/dev/null
 
     local needle="PATH='${home}/.local/bin'"
     assert_eq "$(count_matches "$home/.zshenv" "$needle")" "1" "zshenv gets the export line"
-    assert_eq "$(count_matches "$home/.zprofile" "$needle")" "1" "zprofile gets the export line"
-    assert_eq "$(count_matches "$home/.zshrc" "$needle")" "1" "zshrc gets the export line"
+    assert_eq "$([[ -f "$home/.zprofile" ]] && echo yes || echo no)" "no" "zprofile is NOT written (would double-source with .zshenv)"
+    assert_eq "$([[ -f "$home/.zshrc" ]] && echo yes || echo no)" "no" "zshrc is NOT written (would double-source with .zshenv)"
 
     rm -rf "$home"
 }
@@ -91,8 +105,6 @@ test_repeat_install_is_idempotent() {
 
     local needle="PATH='${home}/.local/bin'"
     assert_eq "$(count_matches "$home/.zshenv" "$needle")" "1" "zshenv has exactly one export line after 3 runs"
-    assert_eq "$(count_matches "$home/.zprofile" "$needle")" "1" "zprofile has exactly one export line after 3 runs"
-    assert_eq "$(count_matches "$home/.zshrc" "$needle")" "1" "zshrc has exactly one export line after 3 runs"
 
     rm -rf "$home"
 }
@@ -111,13 +123,68 @@ test_already_on_path_is_noop() {
     rm -rf "$home"
 }
 
+# #3897 code-critic MEDIUM finding 1 regression test: a normal Terminal.app
+# window is a login+interactive zsh shell, which sources .zshenv
+# unconditionally, THEN .zprofile (it's a login shell), THEN .zshrc (it's
+# interactive). If install.sh ever again writes the same export line to more
+# than one of those files, this test catches the resulting PATH tripling
+# directly (rather than asserting per-file line counts, which is exactly the
+# coverage gap that let the original regression through).
+test_login_interactive_zsh_sources_dir_exactly_once() {
+    echo "--- test_login_interactive_zsh_sources_dir_exactly_once ---"
+    if ! command -v zsh >/dev/null 2>&1; then
+        echo "  SKIP: zsh not available on this host"
+        return
+    fi
+    local home
+    home=$(mktemp -d -t install-path-test-XXXXXX)
+    run_maybe_update_path "$home" "/bin/zsh" >/dev/null
+
+    # A real login+interactive zsh sources EVERY startup file it finds for
+    # that invocation type (.zshenv always; .zprofile/.zshrc/.zlogin only if
+    # present — none of the latter exist here after the fix, so zsh silently
+    # skips them). ZDOTDIR pinned to the synthetic HOME so this is hermetic
+    # regardless of the outer environment's zsh config.
+    local result_path
+    result_path=$(HOME="$home" ZDOTDIR="$home" zsh -l -i -c 'print -r -- $PATH' 2>/dev/null)
+    local count
+    count=$(printf '%s' "$result_path" | tr ':' '\n' | grep -cF "${home}/.local/bin")
+    assert_eq "$count" "1" "install dir appears exactly once in PATH after a real login+interactive zsh sources every written file"
+
+    rm -rf "$home"
+}
+
+# #3897 code-critic MEDIUM finding 2 regression test: a pre-existing
+# hand-written PATH export in a different quoting style than this script's
+# own must be recognised, not duplicated.
+test_differently_quoted_existing_entry_is_recognised() {
+    echo "--- test_differently_quoted_existing_entry_is_recognised ---"
+    local home
+    home=$(mktemp -d -t install-path-test-XXXXXX)
+    mkdir -p "$home"
+    # Simulate a user's own hand-written entry, double-quoted with a $HOME
+    # reference expanded to the literal path (as a real shell would leave it
+    # once written) — NOT this script's own single-quoted format.
+    printf 'export PATH="%s/.local/bin:$PATH"\n' "$home" >"$home/.zshenv"
+
+    run_maybe_update_path "$home" "/bin/zsh" >/dev/null
+
+    local occurrences
+    occurrences=$(grep -cF "${home}/.local/bin" "$home/.zshenv")
+    assert_eq "$occurrences" "1" "pre-existing differently-quoted entry is not duplicated"
+
+    rm -rf "$home"
+}
+
 echo "==========================================================="
-echo "install.sh PATH-handling test suite (#3874)"
+echo "install.sh PATH-handling test suite (#3874, #3897 follow-up)"
 echo "==========================================================="
-test_zsh_writes_all_three_files
+test_zsh_writes_only_zshenv
 test_bash_writes_both_files
 test_repeat_install_is_idempotent
 test_already_on_path_is_noop
+test_login_interactive_zsh_sources_dir_exactly_once
+test_differently_quoted_existing_entry_is_recognised
 
 echo "==========================================================="
 echo "Result: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

Three installer bugs found during VM validation on 2026-07-24, all fixed in one PR (same crate: `trusty-installer`). Updated twice after code-critic review — see "Critic follow-up" below.

- **#3874 — PATH added to `.zshrc` only.** `install.sh`'s `maybe_update_path` wrote the PATH export to `.zshrc` only, which zsh never sources for non-interactive/non-login shells (e.g. a plain `ssh host 'cmd'`). Fixed by writing to `.zshenv`, which zsh sources unconditionally for every invocation type (interactive, login, non-interactive, script) — one file is sufficient to close the gap. bash gets both `.bashrc` (interactive) and `.bash_profile` (login), since a default bash session sources only one of the two, never both.
- **#3875 — post-install wait hangs indefinitely when the daemon is dead.** `verify_tail`'s poll-until-ready loop already bounds the attempt count and an aggregate ~120s budget (#3833/#3836), but each individual `<binary> health --json` subprocess call went through `Command::output()`, which has no timeout — a single hung child blocked forever, defeating every bound above it (the >6min VM hang). Added `output_with_timeout` (10s bound; kills + reaps a still-running child, and reclaims its reader threads within a bounded grace period on the timeout path too) and routed the health probe through it.
- **#3876 — verify table false `not_installed` rows.** `probe_member_health` resolved binary presence via `which::which` alone, so the broken PATH from #3874 caused genuinely-installed binaries to report `not_installed`. Added a PATH-independent fallback (`resolve_binary_path`) that probes the default install directory (`~/.local/bin/<binary>`) directly when `which` fails, and uses the resolved concrete path (not just the bare name) to spawn the health check.

Closes #3874
Closes #3875
Closes #3876

## Critic follow-up (both rounds addressed)

**Round 1 (WARN)** — two MEDIUM findings:
1. **PATH tripling on first install.** The first fix wrote the PATH export to all three of `.zshenv`/`.zprofile`/`.zshrc` for zsh. A normal login+interactive session (a fresh Terminal.app window) sources all three in one shell, so the install dir landed in `PATH` three times from a single fresh install — reproduced live by the critic. Fixed: zsh now writes **only** `.zshenv`.
2. **Idempotency check missed differently-quoted existing entries.** Fixed by broadening the match beyond this script's own exact `PATH='<dir>'` format.
3. **(LOW) Reader threads not reclaimed on the `output_with_timeout` timeout path.** Fixed with a bounded 200ms grace-period join.

**Round 2 (BLOCK, CRITICAL)** — the round-1 broadening of finding 2 introduced a regression: `grep -Eq "PATH=.*<dir>"` was an unanchored free-substring match that produced FALSE POSITIVES, causing `_append_path_export` to silently **skip writing the real export line** — reproducing the #3874 symptom while the script exited reporting success. Two triggers, both reproduced by the critic and independently re-reproduced here with an adversarial test driver (16 hand-constructed inputs) before landing the fix:
   - (a) a commented-out line naming the dir, e.g. `# export PATH="<dir>:$PATH"  (disabled)` — grep does not skip `#`-prefixed lines.
   - (b) `PATH=` is a substring of `MANPATH=`/`FPATH=`/`PYTHONPATH=`/`CLASSPATH=`, and with no right-hand boundary check, `.../.local/bin` also matched inside `.../.local/binaries`.

  Fixed by (1) stripping full-line comments before matching, (2) requiring `PATH=` not be preceded by a word character (excludes sibling `*PATH` vars), and (3) requiring the directory be delimited by `:`/quote/whitespace/end-of-line on the right AND by `=`/`:`/quote (or be glued directly to `PATH=`) on the left — the last one caught in my own adversarial testing beyond the critic's two named triggers (a bare `PATH=FOO<dir>` glued-word false positive).

The CHANGELOG and this PR body now describe the guarantee accurately: a write is skipped only when the file already contains a genuine, live `PATH=` assignment (not commented out, not a sibling `*PATH` variable) naming the install dir as a delimited path segment (not a substring of a longer, different directory) — any quoting style.

## Test plan

- [x] `cargo test -p trusty-installer` — 483 unit tests + 6 integration tests pass
- [x] `cargo clippy -p trusty-installer --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-installer --check` — clean
- [x] `bash tests/test-install-path.sh` — 13/13 assertions pass, including the round-1 and round-2 critic-driven regression tests
- [x] `shellcheck -s sh install.sh` — clean
- [x] `bash scripts/check_line_cap.sh` — clean (0 violations)
- [x] `gh pr checks 3897` — all CI jobs green (the one `Test` job failure on the first CI run was `listeners::store::tests::dedup_seed_loads_recent_ids` in `crates/trusty-agents` — unrelated to this diff, confirmed via `gh run rerun --failed`, which passed clean)

### Raw test output

```
$ cargo test -p trusty-installer
test result: ok. 483 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 10.15s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.86s   (config_mount.rs)
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.35s   (path_shadow_e2e.rs)

$ cargo clippy -p trusty-installer --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.47s

$ cargo fmt -p trusty-installer --check
(exit 0)

$ bash tests/test-install-path.sh
--- test_zsh_writes_only_zshenv ---                                            PASS x3
--- test_bash_writes_both_files ---                                            PASS x2
--- test_repeat_install_is_idempotent ---                                      PASS
--- test_already_on_path_is_noop ---                                           PASS
--- test_login_interactive_zsh_sources_dir_exactly_once ---                    PASS
--- test_differently_quoted_existing_entry_is_recognised ---                   PASS
--- test_commented_out_entry_does_not_block_real_write ---                     PASS
--- test_sibling_path_var_does_not_block_real_write ---                        PASS
--- test_dir_as_prefix_of_longer_path_does_not_block_real_write ---            PASS x2
Result: 13 passed, 0 failed

$ shellcheck -s sh install.sh
(exit 0, no output)

$ bash scripts/check_line_cap.sh
line-cap: 8 allowlisted, 0 violations — OK.

$ gh pr checks 3897
(22 checks, all pass; 1 skipping = "Notify on red main", expected on a non-main branch)
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools