### PR TITLE
fix(trusty-code): make TurnCapExceeded sessions resumable, not permanently dead

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`TurnCapExceeded` permanently un-resumed a session (#3888).** A
+  session whose `task.run` call exhausted its per-call
+  `AgentLoopConfig::max_turns` budget fell through
+  `task::executor::run_and_record`'s terminal-status match into
+  `SessionStatus::Failed`, which `SessionRegistry::begin_execution`
+  permanently rejects — directly regressing epic #2343's infinite-sessions
+  goal. Added a new resumable `SessionStatus::TurnCapExceeded` status
+  (wire value `turn_cap_exceeded`), mapped `AgentLoopError::TurnCapExceeded`
+  onto it instead of the `Failed` catch-all, and extended
+  `begin_execution`'s resume condition to accept it exactly like
+  `Finished` — a capped session's PM transcript (already persisted
+  unconditionally) now continues on its next `task.run`.
+
 ### Added
 
 - **Compression-effectiveness soak harness + scored report (epic #3866,

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -281,15 +281,21 @@ fn humanize_age(at: chrono::DateTime<chrono::Utc>) -> String {
 /// `ExitCode::RunFailure`; `DeadlineExceeded` (#2207) -> its own distinct
 /// `ExitCode::DeadlineExceeded`, so a script can tell "timed out" from
 /// "errored" the same way the legacy path's `RunReport::exit` does;
-/// `Created`/`Running` (should never be passed here — the caller only calls
-/// this once a run has reached a terminal status) also map to `RunFailure`
-/// defensively rather than panicking.
+/// `TurnCapExceeded` (#3888) -> the pre-existing `ExitCode::Partial`, the
+/// same code the legacy `run_task::report` path already uses for "the PM's
+/// turn cap was exhausted" — this call didn't reach a natural stop, but the
+/// session is resumable (unlike `RunFailure`), matching that code's
+/// existing "not done, not dead" semantics; `Created`/`Running` (should
+/// never be passed here — the caller only calls this once a run has reached
+/// a terminal status) also map to `RunFailure` defensively rather than
+/// panicking.
 /// Test: `tests::exit_code_for_status_maps_terminal_states`.
 pub fn exit_code_for_status(status: SessionStatus) -> ExitCode {
     match status {
         SessionStatus::Finished => ExitCode::Success,
         SessionStatus::Cancelled | SessionStatus::Failed => ExitCode::RunFailure,
         SessionStatus::DeadlineExceeded => ExitCode::DeadlineExceeded,
+        SessionStatus::TurnCapExceeded => ExitCode::Partial,
         SessionStatus::Created | SessionStatus::Running => ExitCode::RunFailure,
     }
 }

--- a/crates/trusty-code/src/cli_client/render.rs
+++ b/crates/trusty-code/src/cli_client/render.rs
@@ -560,5 +560,10 @@ mod tests {
             exit_code_for_status(SessionStatus::DeadlineExceeded).code(),
             ExitCode::DeadlineExceeded.code()
         );
+        assert_eq!(
+            exit_code_for_status(SessionStatus::TurnCapExceeded).code(),
+            ExitCode::Partial.code(),
+            "a turn-cap-exceeded (resumable) session must exit Partial, not RunFailure (#3888)"
+        );
     }
 }

--- a/crates/trusty-code/src/session/model.rs
+++ b/crates/trusty-code/src/session/model.rs
@@ -25,13 +25,19 @@ use serde::{Deserialize, Serialize};
 /// What: `Created` -> `Running` happens immediately on `session.create` in
 /// M1 (there is no queue to sit in ahead of real task execution, which
 /// lands with `task.*` in #2056). `Cancelled`/`Finished`/`Failed`/
-/// `DeadlineExceeded` are the four terminal states; `session.cancel` is the
-/// only one #2054 can drive directly (`Finished`/`Failed`/`DeadlineExceeded`
-/// are set by `task::executor::run_and_record` when the PM's `AgentLoop`
-/// resolves). `DeadlineExceeded` (#2207) is distinct from `Failed`: it means
-/// the run's configured wall-clock budget elapsed before the PM reached a
-/// terminal state, NOT that the loop or LLM call errored — a run that hit
-/// this status may have made real, useful progress.
+/// `DeadlineExceeded`/`TurnCapExceeded` are the five terminal-per-call
+/// states; `session.cancel` is the only one #2054 can drive directly
+/// (`Finished`/`Failed`/`DeadlineExceeded`/`TurnCapExceeded` are set by
+/// `task::executor::run_and_record` when the PM's `AgentLoop` resolves).
+/// `DeadlineExceeded` (#2207) is distinct from `Failed`: it means the run's
+/// configured wall-clock budget elapsed before the PM reached a terminal
+/// state, NOT that the loop or LLM call errored — a run that hit this
+/// status may have made real, useful progress. `TurnCapExceeded` (#3888) is
+/// likewise distinct from `Failed`: it means this ONE `task.run` call
+/// exhausted its `AgentLoopConfig::max_turns` budget, not that the session
+/// itself failed — per epic #2343's infinite-sessions goal, the PM
+/// transcript is fully persisted and the session is resumable exactly like
+/// `Finished` (see `SessionRegistry::begin_execution`'s resume condition).
 /// Test: `model::tests::session_status_serialises_snake_case`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -42,6 +48,10 @@ pub enum SessionStatus {
     Finished,
     Failed,
     DeadlineExceeded,
+    /// This call's turn budget (`AgentLoopConfig::max_turns`) was exhausted
+    /// before the PM reached a natural stop. Not a failure — resumable via
+    /// `task.run` exactly like `Finished` (#3888).
+    TurnCapExceeded,
 }
 
 impl SessionStatus {
@@ -61,17 +71,24 @@ impl SessionStatus {
             SessionStatus::Finished => "finished",
             SessionStatus::Failed => "failed",
             SessionStatus::DeadlineExceeded => "deadline_exceeded",
+            SessionStatus::TurnCapExceeded => "turn_cap_exceeded",
         }
     }
 
-    /// Returns `true` when this status is terminal (the session will never
-    /// transition again).
+    /// Returns `true` when this status is terminal FOR THIS CALL (the
+    /// current `task.run` invocation will never transition again without a
+    /// fresh `begin_execution`).
     ///
     /// Why: `session.cancel` and any future completion handler need to
-    /// reject transitions out of a terminal state (e.g. cancelling an
-    /// already-finished session is a no-op error, not a silent overwrite).
-    /// What: `true` for `Cancelled`/`Finished`/`Failed`/`DeadlineExceeded`;
-    /// `false` otherwise.
+    /// reject transitions out of a terminal-per-call state (e.g. cancelling
+    /// an already-finished session is a no-op, not a silent overwrite).
+    /// This is deliberately a WIDER notion than "can never resume" —
+    /// `Finished` and `TurnCapExceeded` are both terminal here (this call is
+    /// over) yet both remain resumable via `SessionRegistry::begin_execution`,
+    /// whose own narrower reject-list (`Cancelled`/`Failed`/
+    /// `DeadlineExceeded`) is the actual "dead forever" gate (#3888).
+    /// What: `true` for `Cancelled`/`Finished`/`Failed`/`DeadlineExceeded`/
+    /// `TurnCapExceeded`; `false` otherwise.
     /// Test: `model::tests::is_terminal_covers_terminal_states`.
     pub fn is_terminal(&self) -> bool {
         matches!(
@@ -80,6 +97,7 @@ impl SessionStatus {
                 | SessionStatus::Finished
                 | SessionStatus::Failed
                 | SessionStatus::DeadlineExceeded
+                | SessionStatus::TurnCapExceeded
         )
     }
 }
@@ -171,6 +189,10 @@ mod tests {
             serde_json::to_value(SessionStatus::DeadlineExceeded).unwrap(),
             json!("deadline_exceeded")
         );
+        assert_eq!(
+            serde_json::to_value(SessionStatus::TurnCapExceeded).unwrap(),
+            json!("turn_cap_exceeded")
+        );
     }
 
     /// `as_str` must match the serde wire representation exactly.
@@ -183,6 +205,7 @@ mod tests {
             SessionStatus::Finished,
             SessionStatus::Failed,
             SessionStatus::DeadlineExceeded,
+            SessionStatus::TurnCapExceeded,
         ] {
             let via_str = status.as_str();
             let via_serde = serde_json::to_value(status).unwrap();
@@ -190,7 +213,10 @@ mod tests {
         }
     }
 
-    /// Only `Cancelled`/`Finished`/`Failed`/`DeadlineExceeded` are terminal.
+    /// `Cancelled`/`Finished`/`Failed`/`DeadlineExceeded`/`TurnCapExceeded`
+    /// are terminal-per-call; `Finished` and `TurnCapExceeded` remain
+    /// resumable through `SessionRegistry::begin_execution`'s narrower gate
+    /// (#3888) despite being terminal here.
     #[test]
     fn is_terminal_covers_terminal_states() {
         assert!(!SessionStatus::Created.is_terminal());
@@ -199,6 +225,7 @@ mod tests {
         assert!(SessionStatus::Finished.is_terminal());
         assert!(SessionStatus::Failed.is_terminal());
         assert!(SessionStatus::DeadlineExceeded.is_terminal());
+        assert!(SessionStatus::TurnCapExceeded.is_terminal());
     }
 
     /// A `Session` must round-trip through JSON with the expected shape.

--- a/crates/trusty-code/src/session/model.rs
+++ b/crates/trusty-code/src/session/model.rs
@@ -48,9 +48,7 @@ pub enum SessionStatus {
     Finished,
     Failed,
     DeadlineExceeded,
-    /// This call's turn budget (`AgentLoopConfig::max_turns`) was exhausted
-    /// before the PM reached a natural stop. Not a failure — resumable via
-    /// `task.run` exactly like `Finished` (#3888).
+    /// This call's turn budget was exhausted — see the enum doc above (#3888).
     TurnCapExceeded,
 }
 
@@ -81,12 +79,9 @@ impl SessionStatus {
     ///
     /// Why: `session.cancel` and any future completion handler need to
     /// reject transitions out of a terminal-per-call state (e.g. cancelling
-    /// an already-finished session is a no-op, not a silent overwrite).
-    /// This is deliberately a WIDER notion than "can never resume" —
-    /// `Finished` and `TurnCapExceeded` are both terminal here (this call is
-    /// over) yet both remain resumable via `SessionRegistry::begin_execution`,
-    /// whose own narrower reject-list (`Cancelled`/`Failed`/
-    /// `DeadlineExceeded`) is the actual "dead forever" gate (#3888).
+    /// an already-finished session is a no-op, not a silent overwrite). This
+    /// is deliberately WIDER than "can never resume" — see [`Self::is_resumable`]
+    /// for the narrower "dead forever" gate (#3888).
     /// What: `true` for `Cancelled`/`Finished`/`Failed`/`DeadlineExceeded`/
     /// `TurnCapExceeded`; `false` otherwise.
     /// Test: `model::tests::is_terminal_covers_terminal_states`.
@@ -98,6 +93,21 @@ impl SessionStatus {
                 | SessionStatus::Failed
                 | SessionStatus::DeadlineExceeded
                 | SessionStatus::TurnCapExceeded
+        )
+    }
+
+    /// Returns `true` when a session at this status may accept another
+    /// `task.run` via `SessionRegistry::begin_execution` — the single
+    /// authoritative "still resumable" gate (#2344 `Finished` + #3888
+    /// `TurnCapExceeded`): both mean only THIS CALL ended, not the session,
+    /// and `pm_transcript` is fully persisted either way, so the next call
+    /// continues the same conversation. `Cancelled`/`Failed`/
+    /// `DeadlineExceeded` are the genuinely dead-forever states.
+    /// Test: `model::tests::is_resumable_matches_finished_and_turn_cap_exceeded`.
+    pub fn is_resumable(&self) -> bool {
+        matches!(
+            self,
+            SessionStatus::Finished | SessionStatus::TurnCapExceeded
         )
     }
 }
@@ -226,6 +236,19 @@ mod tests {
         assert!(SessionStatus::Failed.is_terminal());
         assert!(SessionStatus::DeadlineExceeded.is_terminal());
         assert!(SessionStatus::TurnCapExceeded.is_terminal());
+    }
+
+    /// Only `Finished` and `TurnCapExceeded` are resumable (#3888) — the
+    /// authoritative gate `SessionRegistry::begin_execution` defers to.
+    #[test]
+    fn is_resumable_matches_finished_and_turn_cap_exceeded() {
+        assert!(!SessionStatus::Created.is_resumable());
+        assert!(!SessionStatus::Running.is_resumable());
+        assert!(!SessionStatus::Cancelled.is_resumable());
+        assert!(SessionStatus::Finished.is_resumable());
+        assert!(!SessionStatus::Failed.is_resumable());
+        assert!(!SessionStatus::DeadlineExceeded.is_resumable());
+        assert!(SessionStatus::TurnCapExceeded.is_resumable());
     }
 
     /// A `Session` must round-trip through JSON with the expected shape.

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -593,9 +593,16 @@ impl SessionRegistry {
     /// (#2344) A session that already `Finished` a previous run is NOT dead —
     /// per the infinite-sessions design, it is simply idle and ready for its
     /// next `task.run` to continue the SAME persistent conversation
-    /// (`Self::begin_pm_transcript`). Only `Cancelled`/`Failed`/
-    /// `DeadlineExceeded` remain genuinely terminal: those represent a broken
-    /// run, and resuming one still requires a fresh session.
+    /// (`Self::begin_pm_transcript`). (#3888) A session that hit
+    /// `TurnCapExceeded` is the SAME situation: that call's `max_turns`
+    /// budget ran out, not the session — `pm_transcript` is fully persisted
+    /// (`task::executor::run_and_record` stores it unconditionally), so it
+    /// is resumable exactly like `Finished`, matching epic #2343's
+    /// infinite-sessions goal (a session must never permanently die just
+    /// because one call used its whole per-call turn allowance). Only
+    /// `Cancelled`/`Failed`/`DeadlineExceeded` remain genuinely terminal:
+    /// those represent a broken run, and resuming one still requires a fresh
+    /// session.
     /// What: errors with `session_not_found` if `id` is unknown,
     /// `invalid_argument` if the session is `Cancelled`/`Failed`/
     /// `DeadlineExceeded`, or already has an execution in flight — this
@@ -607,13 +614,15 @@ impl SessionRegistry {
     /// `handle: None` — the caller attaches the real `JoinHandle` via
     /// [`Self::attach_execution_handle`] immediately after spawning, since
     /// the handle cannot exist before that — and returns the flag. If the
-    /// session was `Finished` (resuming), transitions it back to `Running`
-    /// and publishes `Event::SessionStatusChanged` — matching the transition
-    /// every other status change in this module publishes.
+    /// session was `Finished` or `TurnCapExceeded` (resuming), transitions
+    /// it back to `Running` and publishes `Event::SessionStatusChanged` —
+    /// matching the transition every other status change in this module
+    /// publishes.
     /// Test: `registry_tests::begin_execution_rejects_second_overlapping_run`,
     /// `registry_tests::begin_execution_rejects_terminal_session`,
     /// `registry_tests::begin_execution_unknown_session_errors`,
-    /// `registry_tests::begin_execution_resumes_a_finished_session`.
+    /// `registry_tests::begin_execution_resumes_a_finished_session`,
+    /// `registry_tests::begin_execution_resumes_a_turn_cap_exceeded_session`.
     pub fn begin_execution(&self, id: &str) -> Result<Arc<AtomicBool>, RpcError> {
         let (cancel, resumed) = {
             let mut sessions = self.lock();
@@ -633,7 +642,10 @@ impl SessionRegistry {
                     "session {id} already has a task running"
                 )));
             }
-            let resumed = entry.session.status == SessionStatus::Finished;
+            let resumed = matches!(
+                entry.session.status,
+                SessionStatus::Finished | SessionStatus::TurnCapExceeded
+            );
             if resumed {
                 entry.session.status = SessionStatus::Running;
             }

--- a/crates/trusty-code/src/session/registry.rs
+++ b/crates/trusty-code/src/session/registry.rs
@@ -590,19 +590,11 @@ impl SessionRegistry {
     /// Why: `task.run` (and `session.send` on an idle session) must not start
     /// a second overlapping run for the same session, and the returned flag
     /// is how the executor's `AgentLoop`(s) later observe cancellation.
-    /// (#2344) A session that already `Finished` a previous run is NOT dead —
-    /// per the infinite-sessions design, it is simply idle and ready for its
-    /// next `task.run` to continue the SAME persistent conversation
-    /// (`Self::begin_pm_transcript`). (#3888) A session that hit
-    /// `TurnCapExceeded` is the SAME situation: that call's `max_turns`
-    /// budget ran out, not the session — `pm_transcript` is fully persisted
-    /// (`task::executor::run_and_record` stores it unconditionally), so it
-    /// is resumable exactly like `Finished`, matching epic #2343's
-    /// infinite-sessions goal (a session must never permanently die just
-    /// because one call used its whole per-call turn allowance). Only
-    /// `Cancelled`/`Failed`/`DeadlineExceeded` remain genuinely terminal:
-    /// those represent a broken run, and resuming one still requires a fresh
-    /// session.
+    /// (#2344/#3888) A `Finished` or `TurnCapExceeded` session is NOT dead —
+    /// see [`SessionStatus::is_resumable`] for which statuses resume and why.
+    /// Only `Cancelled`/`Failed`/`DeadlineExceeded` remain genuinely
+    /// terminal: those represent a broken run, and resuming one still
+    /// requires a fresh session.
     /// What: errors with `session_not_found` if `id` is unknown,
     /// `invalid_argument` if the session is `Cancelled`/`Failed`/
     /// `DeadlineExceeded`, or already has an execution in flight — this
@@ -614,10 +606,9 @@ impl SessionRegistry {
     /// `handle: None` — the caller attaches the real `JoinHandle` via
     /// [`Self::attach_execution_handle`] immediately after spawning, since
     /// the handle cannot exist before that — and returns the flag. If the
-    /// session was `Finished` or `TurnCapExceeded` (resuming), transitions
-    /// it back to `Running` and publishes `Event::SessionStatusChanged` —
-    /// matching the transition every other status change in this module
-    /// publishes.
+    /// session was resumable (`is_resumable`), transitions it back to
+    /// `Running` and publishes `Event::SessionStatusChanged` — matching the
+    /// transition every other status change in this module publishes.
     /// Test: `registry_tests::begin_execution_rejects_second_overlapping_run`,
     /// `registry_tests::begin_execution_rejects_terminal_session`,
     /// `registry_tests::begin_execution_unknown_session_errors`,
@@ -642,10 +633,7 @@ impl SessionRegistry {
                     "session {id} already has a task running"
                 )));
             }
-            let resumed = matches!(
-                entry.session.status,
-                SessionStatus::Finished | SessionStatus::TurnCapExceeded
-            );
+            let resumed = entry.session.status.is_resumable();
             if resumed {
                 entry.session.status = SessionStatus::Running;
             }

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -864,6 +864,53 @@ async fn begin_execution_resumes_a_finished_session() {
     );
 }
 
+/// (#3888) A session whose call landed in `TurnCapExceeded` (this call's
+/// `AgentLoopConfig::max_turns` budget ran out, not a real failure) must be
+/// resumable via `begin_execution` exactly like a `Finished` session —
+/// mirrors `begin_execution_resumes_a_finished_session` above, proving the
+/// regression reported in #3888 ("TurnCapExceeded permanently un-resumes a
+/// session") is fixed: before this fix, `TurnCapExceeded` sessions fell
+/// through `task::executor::run_and_record`'s catch-all into
+/// `SessionStatus::Failed`, which `begin_execution` rejects outright.
+///
+/// Why: this is the concrete acceptance proof for #3888 — without the
+/// `SessionStatus::TurnCapExceeded` variant and `begin_execution`'s updated
+/// resume condition, this session would stay permanently unresumable,
+/// directly regressing epic #2343's infinite-sessions goal.
+#[tokio::test]
+async fn begin_execution_resumes_a_turn_cap_exceeded_session() {
+    let registry = SessionRegistry::new();
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+    let _first = registry.begin_execution(&session.id).unwrap();
+    registry.finish_execution(&session.id);
+    registry
+        .finish(&session.id, SessionStatus::TurnCapExceeded)
+        .unwrap();
+    assert_eq!(
+        registry.status(&session.id).unwrap().status,
+        SessionStatus::TurnCapExceeded,
+        "a session whose call exhausted its turn budget must land in TurnCapExceeded, not Failed"
+    );
+
+    let mut events = crate::events::subscribe();
+    assert!(
+        registry.begin_execution(&session.id).is_ok(),
+        "a TurnCapExceeded session must be resumable for its next task.run (#3888)"
+    );
+    assert_eq!(
+        registry.status(&session.id).unwrap().status,
+        SessionStatus::Running,
+        "resuming must transition the session back to Running"
+    );
+
+    let envelope = next_event_for(&mut events, &session.id).await;
+    assert!(
+        matches!(envelope.event, Event::SessionStatusChanged { status, .. } if status == "running"),
+        "resuming must publish the SAME SessionStatusChanged event other transitions do"
+    );
+}
+
 /// `begin_execution` must still reject `Cancelled`/`Failed`/
 /// `DeadlineExceeded` sessions even after the #2344 `Finished`-resumption
 /// change — only a successful finish is resumable.

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -523,19 +523,24 @@ async fn run_and_record(
     // (not a catch-all) so the compiler forces a decision the next time that
     // enum grows one — a catch-all is exactly how #3888 happened the first
     // time (`TurnCapExceeded` silently absorbed into `Failed`). `Llm` is a
-    // genuine failure. `Timeout`/`TurnCapExceeded`/`StoppedBySignal` are all
-    // cooperative pauses, not failures — `pm_transcript` was already
-    // persisted unconditionally above, so the next `task.run` continues
-    // right where this one left off; `DeadlineExceeded`/`TurnCapExceeded`
-    // are distinct resumable statuses so a consumer can tell "timed out" from
-    // "used its turn budget". `StoppedBySignal` is not wired into this
-    // `pm_loop` today (no `.with_stop_signal(...)` call below — only
-    // `run_task`'s PM loop wires a `RedelegationCapSignal` through it), but
-    // per its own doc it is the SAME "cooperative pause" class as
-    // `TurnCapExceeded` (an external caller decided continuing is pointless,
-    // not that anything errored) — so it maps to the SAME resumable
-    // `TurnCapExceeded` status rather than `Failed`, the instant it does get
-    // wired here.
+    // genuine failure. `Timeout`/`TurnCapExceeded` are cooperative pauses,
+    // not failures — `pm_transcript` was already persisted unconditionally
+    // above, so the next `task.run` continues right where this one left off;
+    // `DeadlineExceeded`/`TurnCapExceeded` are distinct resumable statuses so
+    // a consumer can tell "timed out" from "used its turn budget".
+    // `StoppedBySignal` is NOT wired into this `pm_loop` today (no
+    // `.with_stop_signal(...)` call below), so this arm is dead code for now
+    // — but its mapping still matters for whoever wires it in later.
+    // Deliberately grouped with `Llm` as `Failed` rather than assumed
+    // resumable: `AgentLoop::with_stop_signal` has exactly one caller in the
+    // crate today (`run_task::mod`, wired to
+    // `RedelegationCapSignal::is_cap_reached()`), and that signal's own doc
+    // (`run_task::redelegation`) is explicit that it fires for "a genuinely
+    // broken run whose delegations keep failing" and "stopping really is
+    // correct" at that point — a stop-and-stay-stopped condition, not a
+    // cooperative pause like the turn cap. Whoever wires a DIFFERENT signal
+    // into this loop must revisit this arm on its own merits rather than
+    // inherit this default.
     let terminal_status = match result {
         Ok(_output) => SessionStatus::Finished,
         Err(crate::agent_loop::AgentLoopError::Cancelled { .. }) => SessionStatus::Cancelled,
@@ -543,15 +548,15 @@ async fn run_and_record(
             let _ = registry.record_log(&session_id, "error", &format!("run failed: {e}"));
             SessionStatus::DeadlineExceeded
         }
-        Err(
-            e @ (crate::agent_loop::AgentLoopError::TurnCapExceeded { .. }
-            | crate::agent_loop::AgentLoopError::StoppedBySignal { .. }),
-        ) => {
+        Err(e @ crate::agent_loop::AgentLoopError::TurnCapExceeded { .. }) => {
             let _ =
                 registry.record_log(&session_id, "info", &format!("run paused (resumable): {e}"));
             SessionStatus::TurnCapExceeded
         }
-        Err(e @ crate::agent_loop::AgentLoopError::Llm(_)) => {
+        Err(
+            e @ (crate::agent_loop::AgentLoopError::Llm(_)
+            | crate::agent_loop::AgentLoopError::StoppedBySignal { .. }),
+        ) => {
             let _ = registry.record_log(&session_id, "error", &format!("run failed: {e}"));
             SessionStatus::Failed
         }

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -522,12 +522,25 @@ async fn run_and_record(
     // #2207: a wall-clock deadline is distinct from a genuine run failure —
     // `SessionStatus::DeadlineExceeded` lets a `session.status`/`task.run`
     // consumer tell "timed out, possibly close to done" from "errored".
+    // #3888: likewise, exhausting THIS call's turn budget
+    // (`AgentLoopError::TurnCapExceeded`) is a budget pause, not a genuine
+    // failure — `pm_transcript` was already persisted unconditionally above,
+    // so the next `task.run` on this session continues right where this one
+    // left off. Mapping it into the `Err(e) => Failed` catch-all (as it did
+    // before this fix) made `SessionRegistry::begin_execution` permanently
+    // reject the session, directly regressing epic #2343's infinite-sessions
+    // goal — see issue #3888.
     let terminal_status = match result {
         Ok(_output) => SessionStatus::Finished,
         Err(crate::agent_loop::AgentLoopError::Cancelled { .. }) => SessionStatus::Cancelled,
         Err(e @ crate::agent_loop::AgentLoopError::Timeout { .. }) => {
             let _ = registry.record_log(&session_id, "error", &format!("run failed: {e}"));
             SessionStatus::DeadlineExceeded
+        }
+        Err(e @ crate::agent_loop::AgentLoopError::TurnCapExceeded { .. }) => {
+            let _ =
+                registry.record_log(&session_id, "info", &format!("run paused (resumable): {e}"));
+            SessionStatus::TurnCapExceeded
         }
         Err(e) => {
             let _ = registry.record_log(&session_id, "error", &format!("run failed: {e}"));

--- a/crates/trusty-code/src/task/executor.rs
+++ b/crates/trusty-code/src/task/executor.rs
@@ -519,17 +519,23 @@ async fn run_and_record(
     let (usage, cost) = aggregate_usage_per_role(&turns, &pm_model, &engineer_model);
     registry.set_run_outcome(&session_id, turns, usage, Some(cost));
 
-    // #2207: a wall-clock deadline is distinct from a genuine run failure —
-    // `SessionStatus::DeadlineExceeded` lets a `session.status`/`task.run`
-    // consumer tell "timed out, possibly close to done" from "errored".
-    // #3888: likewise, exhausting THIS call's turn budget
-    // (`AgentLoopError::TurnCapExceeded`) is a budget pause, not a genuine
-    // failure — `pm_transcript` was already persisted unconditionally above,
-    // so the next `task.run` on this session continues right where this one
-    // left off. Mapping it into the `Err(e) => Failed` catch-all (as it did
-    // before this fix) made `SessionRegistry::begin_execution` permanently
-    // reject the session, directly regressing epic #2343's infinite-sessions
-    // goal — see issue #3888.
+    // #2207/#3888: matched EXHAUSTIVELY over every `AgentLoopError` variant
+    // (not a catch-all) so the compiler forces a decision the next time that
+    // enum grows one — a catch-all is exactly how #3888 happened the first
+    // time (`TurnCapExceeded` silently absorbed into `Failed`). `Llm` is a
+    // genuine failure. `Timeout`/`TurnCapExceeded`/`StoppedBySignal` are all
+    // cooperative pauses, not failures — `pm_transcript` was already
+    // persisted unconditionally above, so the next `task.run` continues
+    // right where this one left off; `DeadlineExceeded`/`TurnCapExceeded`
+    // are distinct resumable statuses so a consumer can tell "timed out" from
+    // "used its turn budget". `StoppedBySignal` is not wired into this
+    // `pm_loop` today (no `.with_stop_signal(...)` call below — only
+    // `run_task`'s PM loop wires a `RedelegationCapSignal` through it), but
+    // per its own doc it is the SAME "cooperative pause" class as
+    // `TurnCapExceeded` (an external caller decided continuing is pointless,
+    // not that anything errored) — so it maps to the SAME resumable
+    // `TurnCapExceeded` status rather than `Failed`, the instant it does get
+    // wired here.
     let terminal_status = match result {
         Ok(_output) => SessionStatus::Finished,
         Err(crate::agent_loop::AgentLoopError::Cancelled { .. }) => SessionStatus::Cancelled,
@@ -537,12 +543,15 @@ async fn run_and_record(
             let _ = registry.record_log(&session_id, "error", &format!("run failed: {e}"));
             SessionStatus::DeadlineExceeded
         }
-        Err(e @ crate::agent_loop::AgentLoopError::TurnCapExceeded { .. }) => {
+        Err(
+            e @ (crate::agent_loop::AgentLoopError::TurnCapExceeded { .. }
+            | crate::agent_loop::AgentLoopError::StoppedBySignal { .. }),
+        ) => {
             let _ =
                 registry.record_log(&session_id, "info", &format!("run paused (resumable): {e}"));
             SessionStatus::TurnCapExceeded
         }
-        Err(e) => {
+        Err(e @ crate::agent_loop::AgentLoopError::Llm(_)) => {
             let _ = registry.record_log(&session_id, "error", &format!("run failed: {e}"));
             SessionStatus::Failed
         }

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -645,11 +645,16 @@ async fn spawn_task_run_turn_cap_exceeded_is_resumable() {
     );
     wait_for_terminal(&registry, &session.id).await;
 
+    // `EchoLlmClient`'s script deterministically ends in a natural stop
+    // (`task::mock_llm::EchoLlmClient`'s own docs), so a correctly-resumed
+    // run must reach `Finished` exactly — not merely "not Failed", which
+    // would also pass if resumption silently regressed to e.g. another
+    // `TurnCapExceeded`/`DeadlineExceeded`/`Cancelled`.
     let final_status = registry.status(&session.id).unwrap().status;
-    assert_ne!(
+    assert_eq!(
         final_status,
-        SessionStatus::Failed,
-        "the resumed run must not itself be rejected/aborted"
+        SessionStatus::Finished,
+        "the resumed run must reach its own natural Finished terminal state"
     );
 }
 

--- a/crates/trusty-code/src/task/executor_tests.rs
+++ b/crates/trusty-code/src/task/executor_tests.rs
@@ -530,6 +530,129 @@ async fn spawn_task_run_deadline_exceeded_is_distinct_and_preserves_usage() {
     );
 }
 
+/// A response in which the assistant calls `set_goal` and never stops —
+/// used to drive a scripted LLM through `max_turns` consecutive tool-call
+/// turns without ever reaching a natural `stop`/`finish_task` terminal state
+/// (#3888's `TurnCapExceeded` regression test below).
+fn set_goal_tool_call_response(call_id: &str) -> Value {
+    json!({
+        "id": format!("gen-{call_id}"),
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": crate::tools::goals::SET_GOAL_TOOL_NAME,
+                        "arguments": json!({"slot": 1, "text": "keep going"}).to_string()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    })
+}
+
+/// An `LlmClientTrait` that replays a fixed script, erroring past the end —
+/// mirrors `agent_loop::tests::ScriptedLlm` but scoped to this module so the
+/// daemon-path executor tests don't need to reach into `agent_loop`'s
+/// `#[cfg(test)]`-private fixtures.
+struct ScriptedLlm {
+    responses: Vec<ChatResponse>,
+    cursor: AtomicUsize,
+}
+
+impl ScriptedLlm {
+    fn from_json(fixtures: &[Value]) -> Self {
+        let responses = fixtures
+            .iter()
+            .map(|v| serde_json::from_value(v.clone()).expect("valid ChatResponse fixture"))
+            .collect();
+        Self {
+            responses,
+            cursor: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmClientTrait for ScriptedLlm {
+    async fn chat(&self, _req: &ChatRequest) -> Result<ChatResponse, LlmError> {
+        let idx = self.cursor.fetch_add(1, Ordering::SeqCst);
+        match self.responses.get(idx) {
+            Some(resp) => Ok(resp.clone()),
+            None => Err(LlmError::MissingConfig(format!(
+                "scripted LLM exhausted at call {idx}"
+            ))),
+        }
+    }
+}
+
+/// (#3888) Exhausting the PM's per-call `max_turns` budget must map to
+/// `SessionStatus::TurnCapExceeded`, NOT `SessionStatus::Failed` — and the
+/// session must remain resumable via a SECOND `spawn_task_run` against the
+/// same `session_id`, exactly like a naturally `Finished` session (#2344).
+///
+/// Why: this is the exact regression reported in #3888 — before this fix,
+/// `task::executor::run_and_record`'s terminal-status match had no
+/// `TurnCapExceeded` arm, so `AgentLoopError::TurnCapExceeded` fell through
+/// the catch-all into `SessionStatus::Failed`, which
+/// `SessionRegistry::begin_execution` permanently rejects — directly
+/// regressing epic #2343's infinite-sessions goal (a session must never die
+/// just because one call used its whole per-call turn allowance).
+/// What: scripts `AgentLoopConfig::default().max_turns` (8) consecutive
+/// `set_goal` tool-call turns — the PM never calls `finish_task` or emits a
+/// bare `stop`, so the loop can only terminate via the turn cap. Asserts the
+/// session lands in `TurnCapExceeded` (not `Failed`), then issues a SECOND
+/// `spawn_task_run` against the SAME session and asserts it is accepted (not
+/// the `-32003` terminal-session rejection) and reaches a fresh terminal
+/// state.
+/// Test: this test.
+#[tokio::test]
+async fn spawn_task_run_turn_cap_exceeded_is_resumable() {
+    let registry = Arc::new(SessionRegistry::new());
+    let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let agents = agents_dir();
+    let project = tempfile::tempdir().expect("project tempdir");
+
+    // 8 responses = `AgentLoopConfig::default().max_turns`; none stop or
+    // call `finish_task`, so the PM loop can only end via `TurnCapExceeded`.
+    let scripts: Vec<Value> = (0..8)
+        .map(|i| set_goal_tool_call_response(&format!("call_{i}")))
+        .collect();
+    let llm: Arc<dyn LlmClientTrait> = Arc::new(ScriptedLlm::from_json(&scripts));
+
+    let p1 = params(&agents, &project, &session.id);
+    spawn_task_run(Arc::clone(&registry), llm, p1).expect("run 1 must start");
+    wait_for_terminal(&registry, &session.id).await;
+
+    assert_eq!(
+        registry.status(&session.id).unwrap().status,
+        SessionStatus::TurnCapExceeded,
+        "exhausting max_turns must map to TurnCapExceeded, not Failed (#3888)"
+    );
+
+    // The regression: a second `task.run` on this session must be ACCEPTED,
+    // not rejected with "session ... is already terminal" (-32003).
+    let llm2: Arc<dyn LlmClientTrait> = Arc::new(EchoLlmClient::new());
+    let p2 = params(&agents, &project, &session.id);
+    spawn_task_run(Arc::clone(&registry), llm2, p2).expect(
+        "a TurnCapExceeded session must accept a resuming task.run, \
+         not be permanently unresumable (#3888)",
+    );
+    wait_for_terminal(&registry, &session.id).await;
+
+    let final_status = registry.status(&session.id).unwrap().status;
+    assert_ne!(
+        final_status,
+        SessionStatus::Failed,
+        "the resumed run must not itself be rejected/aborted"
+    );
+}
+
 // ── #2344: persistent session-scoped transcript across task.run calls ──────────
 
 /// Poll `registry.status(id)` until it reaches a terminal state, bounded by


### PR DESCRIPTION
Closes #3888

## Root cause

`task::executor::run_and_record` (`crates/trusty-code/src/task/executor.rs`) mapped every non-success `AgentLoopError` onto `SessionStatus` via a catch-all match arm. `AgentLoopError::TurnCapExceeded` — hitting `AgentLoopConfig::max_turns` (default 8) — fell into that catch-all and became `SessionStatus::Failed`.

`SessionRegistry::begin_execution` (`crates/trusty-code/src/session/registry.rs`) permanently rejects further `task.run` calls once a session is `Failed`/`Cancelled`/`DeadlineExceeded` — only `Finished` sessions were resumable.

Net effect: any session whose PM loop legitimately used its whole per-call turn budget became **permanently unresumable**, even though the PM transcript was already fully persisted (`store_pm_transcript` is called unconditionally regardless of outcome). This directly regressed epic #2343's infinite-sessions goal.

## Fix

- Added a new `SessionStatus::TurnCapExceeded` variant (wire value `turn_cap_exceeded`), distinct from `Failed` — a budget pause, not a failure.
- `task::executor::run_and_record` now maps `AgentLoopError::TurnCapExceeded` onto this new status explicitly, instead of falling into the `Failed` catch-all.
- `SessionRegistry::begin_execution`'s resume condition now accepts `TurnCapExceeded` exactly like `Finished` — a capped session transitions back to `Running` on its next `task.run` and continues the same persistent PM conversation.
- `SessionStatus::is_terminal()` includes the new variant (terminal-per-call, matching `Finished`'s existing semantics — resumability is governed by `begin_execution`'s own narrower gate, not `is_terminal()`).
- `cli_client::render::exit_code_for_status` maps it to the pre-existing `ExitCode::Partial` (already used by the legacy `run_task` path for "turn cap hit, not a clean failure").

## Tests

- `session::registry::registry_tests::begin_execution_resumes_a_turn_cap_exceeded_session` — registry-level proof mirroring the existing `begin_execution_resumes_a_finished_session` test.
- `task::executor::tests::spawn_task_run_turn_cap_exceeded_is_resumable` — full daemon-path integration test: scripts 8 consecutive non-stop tool-call turns to force a real `TurnCapExceeded`, asserts the session lands in `TurnCapExceeded` (not `Failed`), then issues a SECOND `spawn_task_run` on the same session and asserts it is accepted (not `-32003` terminal-session rejection).

## Verification

```
cargo test -p trusty-code          # 1581 lib tests + full integration suite green (raw output in PR thread)
cargo clippy -p trusty-code --all-targets -- -D warnings   # clean
cargo fmt --check -p trusty-code   # clean
```

Two `agent_loop::tests::compression_telemetry_tests::*` tests are flaky under full-suite parallelism (pre-existing shared-global-state race, unrelated to this change — confirmed passing in isolation and on repeat full runs).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools