### PR TITLE
docs(specs): universal OKG importer + trusty-agents-agents sync specs

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -70,6 +70,8 @@ normative grammar — this note does not restate it.
 | DOC-52 | `SPEC-SHAREDWS-01~draft` … `-04~draft` | [Shared Workstream Definition: Cross-Harness Session Binding and Resource Governance](./DOC-52-shared-workstream-definition.md) | trusty-mpm, trusty-code, trusty-agents — unified workstream semantics, 1:1 session binding, resource governance (caps, scope-overlap, reclamation) |
 | DOC-53 | `SPEC-WSCLAIM-01~draft` … `-04~draft` | [Workstream Claim-Drawer Convention: Cross-Workstream Coordination via trusty-memory](./DOC-53-workstream-claim-drawer-convention.md) | trusty-memory — attribution / drawer conventions; trusty-mpm — PM dispatch protocol |
 | DOC-54 | `SPEC-AGENTS-01~draft` … `-08~draft` | [Trusty Agents Product Specification](./trusty-agents-product-spec.md) | trusty-agents — product vision / agent model / eventstream processing / GUI |
+| DOC-55 | `SPEC-OKGIMPORT-01~draft` … `-07~draft` | [Universal OKG Importer: Any File Type, Any Connectable System, Assistant-Driven](./okg-universal-importer.md) | trusty-kb — format extraction / connector framework / ingest engine; trusty-agents — connector adapters, assistant-facing tools, deterministic CLI surface |
+| DOC-56 | `SPEC-AGENTSYNC-01~draft` … `-07~draft` | [Agent Configuration Sync: The `trusty-agents-agents` Private Monorepo](./trusty-agents-agents-sync.md) | trusty-agents — agent configuration lifecycle, provisioning merge (subsumes #3844), multi-machine sync |
 
 > **Catalog note — `DOC-34` gap.** `DOC-34` (`SPEC-CFGDIR-01~draft`…`-05~draft`,
 > [Managed sessions launch with a tm-owned `CLAUDE_CONFIG_DIR`](./managed-session-config-dir.md))
@@ -83,15 +85,16 @@ normative grammar — this note does not restate it.
 > file is **not** in this catalog. The collision is flagged here rather than resolved by
 > renumbering the file in-place (its self-label and any inbound references are left
 > untouched); a follow-up should assign it the next free `DOC-N` and add a catalog row.
-> **Next free `DOC-N` = `DOC-55`** (updated 2026-07-24 — DOC-54 claimed by
-> [Trusty Agents Product Specification](./trusty-agents-product-spec.md)):
-> the highest cataloged number is now **DOC-54**, which claimed the next free number after
-> **DOC-53** ([Workstream Claim-Drawer Convention](./DOC-53-workstream-claim-drawer-convention.md))
+> **Next free `DOC-N` = `DOC-57`** (updated 2026-07-25 — DOC-55 claimed by
+> [Universal OKG Importer](./okg-universal-importer.md) and DOC-56 by
+> [Agent Configuration Sync](./trusty-agents-agents-sync.md)):
+> the highest cataloged number is now **DOC-56**, which claimed the next free numbers after
+> **DOC-54** ([Trusty Agents Product Specification](./trusty-agents-product-spec.md))
 > per the scan-before-claim rule ([DOC-38 §4.1](./spec-linked-documentation.md) — a catalog's "next free"
 > note is a *hint, not authority*; the scan is authoritative). DOC-44/45 are claimed by the
 > unmerged `spec-twin-lead-architecture` branch ([DOC-44 Engineering Lead Twin Orchestration](https://github.com/bobmatnyc/trusty-tools/tree/spec-twin-lead-architecture));
 > DOC-34 is assigned ([`managed-session-config-dir.md`](./managed-session-config-dir.md),
-> #1999 — still a catalog gap), DOC-35/36/38/39/40/41/46/47/48/50/51/52/53/54 are cataloged (DOC-49 was pre-claimed by PR #3313), and **DOC-37** is
+> #1999 — still a catalog gap), DOC-35/36/38/39/40/41/46/47/48/50/51/52/53/54/55/56 are cataloged (DOC-49 was pre-claimed by PR #3313), and **DOC-37** is
 > self-labeled by [`trusty-search-managed-repo-awareness.md`](./trusty-search-managed-repo-awareness.md)
 > (`SPEC-SEARCHREPO-01~draft`…, uncataloged). What was open PR #2792 (Eve-style agent framework
 > for trusty-agents) previously also self-labeled `DOC-37` for this unrelated spec — that

--- a/docs/specs/okg-universal-importer.md
+++ b/docs/specs/okg-universal-importer.md
@@ -1,0 +1,640 @@
+# DOC-55 — Universal OKG Importer: Any File Type, Any Connectable System, Assistant-Driven
+
+**Status:** Draft  
+**Subsystem:** trusty-kb — format extraction / connector framework / ingest engine; trusty-agents — connector adapters, assistant-facing tools, deterministic CLI surface  
+**Owner:** Engineering (trusty-agents / trusty-kb) / Bob Matsuoka  
+**Last-updated:** 2026-07-25  
+**Spec ID:** `SPEC-OKGIMPORT-01~draft` … `SPEC-OKGIMPORT-07~draft` (DOC-55)  
+**Builds on:** DOC-54 [Trusty Agents Product Specification](./trusty-agents-product-spec.md) §5.1 (the `[[stores]]` config leg); the shipped OKG ingestion engine (#3881 / PR #3883); the OKG store binding (#3878)  
+**Related issues:** epic #3052 (Assistant M1), #3881 (ingestion layer, closed), #3892 (ingest→search gap, OPEN — see §7), #3816 (declarative templates), #3837 (git-backed per-agent content store)
+
+---
+
+## 1. Executive Summary
+
+The OKG ingestion engine shipped in PR #3883 already delivers the hard part: an
+idempotent, additive, crash-convergent pipeline that turns fetched items into KB
+entities behind a per-source append-only ledger. What it does **not** yet do is
+read the world. It ingests UTF-8 text files, Gmail message bodies, and whatever
+Drive hands back as text. A `.docx` in the corpus is skipped as binary. A `.xlsx`
+is skipped as binary. A PDF is skipped as binary. Slack and Confluence have no
+connector at all.
+
+This spec closes that gap along two orthogonal axes and then names the feature
+that makes both of them useful:
+
+- **Axis 1 — formats (§4).** A pure, network-free *extraction layer* sitting
+  immediately upstream of the existing `SourceItem` seam: bytes plus a type hint
+  in, normalized Markdown-ish text plus provenance fields out. Extractors are
+  deterministic functions; they never touch the network, never touch the ledger,
+  and never know which connector produced their bytes.
+- **Axis 2 — systems (§5).** A pluggable *connector framework*: a connector is
+  exactly `list` + `fetch` over any reachable data system, and it inherits the
+  ledger / watermark / idempotency contract **unchanged**. Adding Slack does not
+  get to reinvent deduplication.
+- **The defining feature — assistant-driven crawl (§6).** The assistant plans and
+  drives multi-source imports conversationally. "Import my Q3 folder" decomposes
+  into source registration, windowed ingestion, and progress reporting, with the
+  assistant choosing the decomposition. This is what distinguishes an importer
+  from a cron job, and it is the requirement Bob stated: *"any data system we can
+  connect to, we should be able to crawl and import that data into an OKG store
+  for an assistant, driven by the assistant."*
+
+**What this spec deliberately does not do:** it does not decide #3892 (whether an
+ingested entity reaches the bound search index, and how). §7 states the
+importer's position relative to that open decision explicitly rather than
+silently assuming one, because every additional format and connector multiplies
+the blast radius of getting it wrong.
+
+---
+
+## 2. SPEC-OKGIMPORT-01 — Ground Truth: What Already Exists {#SPEC-OKGIMPORT-01~draft}
+
+This section is normative only in the sense that everything below **must not
+break it**. It is a statement of the shipped design, not a proposal.
+
+### 2.1 The seam
+
+```
+trusty-kb::okg                       (pure, deterministic, network-free)
+  registry.rs   _sources/registry.toml   — SourceSpec rows, hand-editable TOML
+  ledger.rs     _sources/<id>.jsonl      — append-only per-item journal
+  ingest.rs     SourceItem -> entities + ledger lines (FETCHER-AGNOSTIC)
+  docstore.rs   the in-crate filesystem fetcher
+  policy.rs     DocStorePolicy — read-side confinement, re-checked every run
+
+trusty-agents::tools::okg             (network, credentials)
+  gapi.rs       Gmail/Drive JSON <-> SourceItem + paginated list calls
+  {docstore,gmail,drive,sources}.rs    the four LLM-invocable tools
+```
+
+`SourceItem` (`crates/trusty-kb/src/okg/ingest.rs:40`) is the seam. It carries
+`item_id`, `fingerprint`, `name`, `title`, `timestamp`, `body`, `fields`, and
+`volatile`. Everything upstream of it is a fetcher; everything downstream is the
+engine.
+
+### 2.2 The invariants every extension inherits
+
+| Invariant | Mechanism | Consequence for new code |
+|---|---|---|
+| **Idempotent** | `Ledger::is_current(item_id, fingerprint)` — one predicate decides skip vs write | A new connector supplies a stable `item_id` and an honest `fingerprint`; it writes no dedup logic of its own |
+| **Additive** | `SourceRegistry::upsert` appends a new id, updates a known id in place, preserving `added_at` and the ledger | Registering a new source or widening a window is the same call; never a rebuild |
+| **Crash-convergent** | Ledger journaled per item (`flush` + `sync_data`), entity written *before* its ledger line | A killed run re-converges; the reverse write order would lose data |
+| **Fail-closed reads** | `DocStorePolicy::permit` applied inside `docstore::scan`, at the point the filesystem is touched — not at the tool boundary | A hand-edited `registry.toml` row pointing at `~/.ssh` is refused on every later run |
+| **Deletions are never silent** | Absent items land in `IngestReport::missing`, or are tombstoned (`source_status: deleted`) with the body preserved | `detect_deletions` may be true only when the run enumerated the entire corpus |
+| **Volatile items never freeze** | `SourceItem::volatile` bypasses the skip test entirely | A source with no revision signal re-writes each run; `put_entity`'s byte-compare keeps it cheap |
+| **Chunked commit** | Network tools ingest in chunks (`CHUNK = 100` Gmail, `50` Drive) with detection off, then one `okg_sweep_deleted` | Partial progress survives a crash mid-backfill |
+| **Model input is clamped** | `MAX_MESSAGES_CEILING` / `MAX_FILES_CEILING` = 5000 | Any new connector declares its own ceiling |
+
+### 2.3 The gaps this spec addresses
+
+1. `docstore::scan` rejects any non-UTF-8 file as binary
+   (`crates/trusty-kb/src/okg/docstore.rs`) — `.docx`, `.xlsx`, `.pdf`, `.pptx`
+   are all reported as `skipped_binary`.
+2. `drive_content` returns `None` whenever the payload is base64
+   (`crates/trusty-agents/src/tools/okg/gapi.rs:348`) — so a native Google Doc
+   reaches us only if `trusty-gworkspace`'s wrapper happened to export it as
+   text, and everything else silently yields nothing.
+3. Gmail ingests the message body only; attachments are dropped entirely.
+4. `Locator` (`registry.rs:48`) is a **closed** three-variant enum. A new system
+   cannot be registered without editing `trusty-kb`.
+5. The four `okg_*` tools are LLM-invoked only. There is no deterministic,
+   scriptable invocation path — see §6.4.
+
+---
+
+## 3. SPEC-OKGIMPORT-02 — Scope, Non-Goals, and the Layering Rule {#SPEC-OKGIMPORT-02~draft}
+
+### 3.1 The layering rule (normative)
+
+> **`trusty-kb` stays pure, deterministic, and network-free.** Format extractors
+> live in `trusty-kb` because they are pure functions over bytes. Connectors that
+> need credentials or network live in `trusty-agents` (or a dedicated connector
+> crate), because that is where the authenticated clients already are. They meet
+> at `SourceItem`, exactly as Gmail and Drive already do.
+
+This is not a stylistic preference. It is what makes every idempotency property
+unit-testable with synthetic bytes and no network at all, and it is the reason
+PR #3883's test suite could assert re-run/widen/edit/delete semantics without a
+single live API call. A format extractor that reaches out to a conversion service
+would destroy that property and is out of scope (§3.3).
+
+### 3.2 In scope
+
+- A format-extraction trait plus a first-wave extractor set (§4).
+- A connector trait, its registry representation, and its policy/confinement
+  obligations (§5).
+- The assistant-driven crawl model and its deterministic counterpart (§6).
+- Phased delivery and the ticket decomposition (§9).
+
+### 3.3 Non-goals
+
+- **No OCR, no ASR, no image understanding.** A scanned PDF with no text layer
+  extracts to nothing and is reported as such. Model-based extraction is a
+  separate future capability precisely because it is neither pure nor
+  deterministic.
+- **No network access inside an extractor.** Ever. Including "just to fetch a
+  font" or "just to resolve an embedded link".
+- **No new OAuth path.** Google connectors continue to reuse
+  `trusty-gworkspace`'s `BaseClient` (#3883 constraint, restated). New providers
+  reuse whatever authenticated client the workspace already owns, or the
+  credential resolver (#2643), never a bespoke token store.
+- **No parallel KB format.** Entity writes continue through
+  `KbStore::put_entity`.
+- **No resolution of #3892.** See §7.
+- **No SQL / structured-database ingestion** (`cto.db`, `analytics.duckdb`) —
+  explicitly out of scope in #3881 and still out of scope here. A spreadsheet
+  read as a document (§4.4) is not the same thing as a database connector.
+- **No GUI work** beyond rendering the progress reports §6.3 defines.
+
+---
+
+## 4. SPEC-OKGIMPORT-03 — The Format-Extraction Layer {#SPEC-OKGIMPORT-03~draft}
+
+### 4.1 Position
+
+```
+   connector fetch  ──▶  raw bytes + type hint
+                             │
+                             ▼
+                    ┌────────────────────┐
+                    │  Extractor (PURE)  │   trusty-kb::okg::extract
+                    └────────────────────┘
+                             │
+                             ▼   normalized text + extracted fields
+                    ┌────────────────────┐
+                    │    SourceItem      │   ← the existing seam, unchanged
+                    └────────────────────┘
+                             │
+                             ▼
+                      ingest engine (ledger, entities, tombstones)
+```
+
+Extraction happens **after** fetch and **before** `SourceItem` construction. The
+engine is not modified at all by this axis.
+
+### 4.2 The contract
+
+An extractor is a pure function. Proposed shape (`trusty-kb::okg::extract`):
+
+```rust
+/// One extracted document: normalized text plus whatever structure survived.
+pub struct Extracted {
+    /// Markdown-ish plain text. Never base64, never raw XML.
+    pub text: String,
+    /// Provenance/structure fields merged into the entity frontmatter
+    /// (`page_count`, `sheet_names`, `author`, `docx_title`, …).
+    pub fields: BTreeMap<String, String>,
+    /// Non-fatal notes ("3 embedded images dropped", "sheet 4 truncated").
+    pub notes: Vec<String>,
+}
+
+pub trait Extractor: Send + Sync {
+    /// Stable lowercase id, e.g. `docx`. Part of the fingerprint (§4.5).
+    fn id(&self) -> &'static str;
+    /// Monotonic version; bump whenever output for identical input changes.
+    fn version(&self) -> u32;
+    /// Whether this extractor claims the given MIME type / extension.
+    fn claims(&self, hint: &TypeHint) -> bool;
+    /// Extract. MUST be pure: no network, no filesystem, no clock, no RNG.
+    fn extract(&self, bytes: &[u8], hint: &TypeHint) -> anyhow::Result<Extracted>;
+}
+```
+
+Normative obligations:
+
+- **E1 — Purity.** No I/O of any kind. Same bytes in, byte-identical `Extracted`
+  out, on every machine and every run. This is testable and MUST be tested with
+  a fixture-in / golden-out case per extractor.
+- **E2 — Bounded.** Every extractor respects a byte ceiling analogous to
+  `MAX_FILE_BYTES` (8 MiB) and an output-character ceiling; a zip-bomb `.xlsx`
+  must fail, not exhaust memory. Decompression ratios are checked, not assumed.
+- **E3 — Degrade, never abort.** An unparseable region yields a `notes` entry and
+  the text that *was* recoverable. An extractor error is a per-item error
+  (`IngestReport::errors`), never a run-ending one — matching
+  `per_item_errors_do_not_abort_the_run`.
+- **E4 — No secret leakage into notes.** `notes` and `fields` are written into a
+  KB entity that may be committed (#3837). They carry structure, never content
+  excerpts of anything the policy layer would have refused.
+- **E5 — Chunking is the engine's job.** An extractor returns one `text`; the
+  existing `DEFAULT_CHUNK_CHARS = 20_000` part-splitting continues to apply
+  downstream, unchanged, so an 800-page PDF still becomes readable part-entities.
+
+### 4.3 Type-hint resolution
+
+`TypeHint` carries whatever the connector knows: a MIME type (Drive, Slack, and
+Gmail all supply one), a filename extension, and the leading bytes for magic
+sniffing. Resolution order is **MIME → extension → magic bytes**, first claim
+wins, with a deterministic tiebreak on `Extractor::id()` so registration order
+cannot change behavior. An unclaimed hint falls through to the existing UTF-8
+text path, and then to `skipped_binary` — i.e. today's behavior is the floor.
+
+### 4.4 First-wave extractors
+
+| Extractor | Input | Output shape | Notes |
+|---|---|---|---|
+| `text` (exists) | UTF-8 text | verbatim | today's path, refactored behind the trait |
+| `html` | `text/html`, `.html` | text with headings/links preserved as Markdown | already in `DEFAULT_EXTENSIONS` but currently ingested as raw markup |
+| `docx` | OOXML wordprocessing | headings, paragraphs, lists, tables → Markdown | `fields`: core-properties (author, created) |
+| `xlsx` | OOXML spreadsheet | one Markdown table per sheet, header row detected | `fields`: `sheet_names`, `row_count`; formulas → computed value, else formula text |
+| `pdf` | PDF text layer | page-ordered text, page markers | no text layer ⇒ empty text + explicit note (§3.3) |
+| `gdoc-export` | Drive export of a native Doc/Sheet/Slide | Markdown | see §4.6 — the *export choice* is the connector's, the parse is the extractor's |
+| `pptx` (stretch) | OOXML presentation | slide-ordered title + body text | phase 3 |
+
+### 4.5 Fingerprints and the extractor-version trap
+
+**This is the subtle correctness issue in this axis, and it is normative.**
+
+`docstore` fingerprints on `sha256` of the **raw bytes**. That is correct and
+must stay correct — extracted text is derived, and hashing the derivation would
+make the fingerprint depend on extractor behavior in an uncontrolled way.
+
+But it creates a trap: improve the `docx` extractor, and every already-ingested
+`.docx` keeps its old fingerprint, so `Ledger::is_current` skips it forever and
+the improvement never reaches the corpus. The entity is silently frozen at its
+first-seen extraction — the *exact* failure mode `SourceItem::volatile` was
+introduced to prevent for Drive's unversioned files (code-critic HIGH 3 on
+#3883).
+
+**Rule: for any item whose body passed through a non-`text` extractor, the
+fingerprint MUST be `sha256:<hex>/<extractor-id>:<extractor-version>`.**
+
+Consequences, all intended:
+
+- Bumping `Extractor::version()` invalidates exactly the items that extractor
+  produced, and nothing else. They re-ingest on the next run; `put_entity`'s
+  byte-compare means an extraction that did not actually change costs no write.
+- The fingerprint remains a pure function of (bytes, extractor identity), so
+  crash-convergence is preserved.
+- `volatile` is **not** the mechanism here. Volatile means "re-write every run";
+  this needs "re-write when the extractor changes", which is strictly weaker and
+  cheaper.
+
+### 4.6 Interaction with Drive exports
+
+Native Google Docs/Sheets/Slides have no downloadable bytes — they are
+*exported*, and the export format is a connector-side choice made at fetch time
+(`files/export?mimeType=…`). The connector picks the export MIME; the extractor
+parses whatever came back. Recommended exports: Docs → `text/markdown` where
+available, else `text/html` (parsed by the `html` extractor, which preserves
+structure that `text/plain` destroys); Sheets → `text/csv` per sheet, or `xlsx`
+for multi-sheet fidelity; Slides → `text/plain` initially.
+
+The current `drive_content` base64 short-circuit (§2.3) becomes: base64 payload
+⇒ hand the decoded bytes to the extraction layer, and only report
+`skipped_binary` when no extractor claims them.
+
+---
+
+## 5. SPEC-OKGIMPORT-04 — The Connector Framework {#SPEC-OKGIMPORT-04~draft}
+
+### 5.1 What a connector is
+
+> A connector is `list` + `fetch` over a reachable data system. Nothing more. It
+> owns pagination, authentication, and its system's addressing; it owns **none**
+> of dedup, tombstoning, entity writing, or watermarking.
+
+```rust
+pub trait Connector: Send + Sync {
+    /// Stable lowercase kind, matching its registry sub-table name.
+    fn kind(&self) -> &'static str;
+
+    /// Enumerate item descriptors for a locator, honouring the window and the
+    /// caller's ceiling. Returns descriptors, NOT bodies — this is what makes
+    /// the ledger's pre-fetch consultation (exactly-once) possible.
+    async fn list(&self, loc: &Value, window: &Window, max: usize)
+        -> anyhow::Result<Listing>;
+
+    /// Fetch bodies for a chunk of descriptors. Called only for items the
+    /// ledger reports as not-current.
+    async fn fetch(&self, ids: &[ItemRef]) -> anyhow::Result<Vec<FetchedBlob>>;
+
+    /// Whether a completed `list` enumerated the ENTIRE corpus for this
+    /// locator. Gates deletion detection; a windowed source returns false.
+    fn enumerates_full_corpus(&self, loc: &Value) -> bool;
+
+    /// Hard ceiling on items per invocation. Mirrors MAX_*_CEILING.
+    fn ceiling(&self) -> usize { 5_000 }
+
+    /// Chunk size for fetch+commit. Mirrors gmail.rs CHUNK / drive.rs CHUNK.
+    fn chunk(&self) -> usize { 100 }
+}
+```
+
+`FetchedBlob` is `{ bytes, type_hint, fields }` — it feeds §4's extractor and
+then becomes a `SourceItem`. A connector whose system already returns text (e.g.
+a Slack message) supplies `type_hint = text/plain` and the `text` extractor is a
+pass-through.
+
+### 5.2 Normative obligations
+
+- **C1 — Stable `item_id`.** The system's own immutable id. If the system has
+  none, the connector MUST derive one deterministically and document it. An
+  `item_id` that changes across runs breaks every invariant at once.
+- **C2 — Honest `fingerprint`.** A real revision signal when the system has one
+  (Drive `version`, Confluence page version, Slack `edited.ts`). An immutable
+  item may use its id as its fingerprint (Gmail's "pull exactly once, ever"). If
+  there is genuinely no signal, set `volatile = true` — never invent a constant.
+- **C3 — Ledger consulted before body fetch.** `list` returns descriptors so the
+  exactly-once optimisation is real, not merely write-layer idempotency.
+- **C4 — Deletion honesty.** `enumerates_full_corpus` returns true only when the
+  listing genuinely covers everything the locator names. Gmail's windowed pull
+  returns false, permanently. A connector that lies here tombstones a user's
+  corpus.
+- **C5 — Chunked commit + one sweep.** Ingest per chunk with
+  `detect_deletions = false`, then call `okg_sweep_deleted` once with the full
+  observed id set — the pattern `drive.rs` already implements.
+- **C6 — Read-confinement is per connector.** `DocStorePolicy` is the filesystem
+  instance of a general obligation: any locator field that a **model** can supply
+  and that widens read scope must be gated by **operator** configuration,
+  re-checked at the point of access, failing closed. Slack: an allowed-channel or
+  allowed-workspace list. Confluence: allowed spaces. Filesystem: today's
+  `[okg] docstore_roots`. The gate lives where the fetch happens, not at the tool
+  boundary (the #3883 code-critic CRITICAL-2 lesson).
+- **C7 — Soft errors are errors.** `BaseClient`-style APIs that return 403/404 as
+  a 200-shaped body MUST be detected (`gapi::api_error`) and raised. Reporting
+  "0 new items" for a permission failure is a data-loss bug, not a no-op.
+- **C8 — No credential handling.** Tokens come from the existing authenticated
+  client or the credential resolver (#2643). A connector never reads a token file.
+
+### 5.3 Registry representation: opening the `Locator` enum
+
+`Locator` is externally tagged, so the TOML sub-table name *is* the kind and the
+two can never disagree — a property worth keeping. But it is closed: `Slack`
+today means editing `trusty-kb`, which contradicts "any data system we can
+connect to."
+
+**Recommendation:** keep the three existing variants verbatim (they are
+load-bearing, hand-editable, and already on disk) and add one open variant:
+
+```toml
+[[sources]]
+id = "eng-handbook"
+collection = "handbook"
+added_at = "2026-07-25T00:00:00Z"
+
+  [sources.locator.connector]
+  kind = "confluence"
+  params = { space = "ENG", updated_after = "2026-01-01" }
+```
+
+`Locator::Connector { kind: String, params: Json }` with `kind()` returning the
+declared string. Rules: `kind` is slugged; an unknown `kind` at ingest time is a
+clear "no connector registered for kind X" error, never a silent skip; `params`
+is opaque to `trusty-kb` and validated by the connector. Registry
+round-tripping, `upsert` additivity, and `save`'s write-if-changed behavior are
+unchanged. Migrating `gmail`/`drive`/`docstore` into the open form is explicitly
+**not** proposed — churn with no benefit.
+
+### 5.4 Near-term connector roster
+
+| Connector | Locator params | `item_id` | Fingerprint | Full corpus? | Notes |
+|---|---|---|---|---|---|
+| `docstore` (exists) | path, extensions, recursive | relative path | `sha256` (+ extractor tag, §4.5) | yes | gains every §4 extractor for free |
+| `gmail` (exists) | query, after, before | message id | message id (immutable) | **no** | windowed |
+| `gmail-attachments` | as gmail + MIME allow-list | `<msg-id>/<attachment-id>` | attachment id | no | first consumer of `docx`/`xlsx`/`pdf` |
+| `drive` (exists) | folder_id, recursive | file id | `version:` / `modified:` | yes, iff fully recursive | export choice per §4.6 |
+| `google-docs` | folder or doc ids | file id | `version:` | yes iff enumerable | a Drive locator specialised to native Docs |
+| `slack` | workspace, channel allow-list, after | `<channel>/<ts>` | `edited.ts` else `ts` | per-channel yes, windowed no | thread replies are items; files are attachments |
+| `confluence` | base URL, space allow-list, updated_after | page id | page `version.number` | per-space yes | native storage format → `html` extractor |
+| `filesystem-formats` | — | — | — | — | not a connector; the `docstore` connector + §4 extractors |
+
+Ordering rationale: `gmail-attachments` and `google-docs` come first because
+they need no new auth and immediately exercise the extraction layer against real
+user data. Slack and Confluence follow, and each needs its own C6 policy gate.
+
+---
+
+## 6. SPEC-OKGIMPORT-05 — Assistant-Driven Crawl {#SPEC-OKGIMPORT-05~draft}
+
+### 6.1 The requirement
+
+Bob, 2026-07-25: *"any data system we can connect to, we should be able to crawl
+and import that data into an OKG store for an assistant, **driven by the
+assistant**."*
+
+The emphasis is the feature. A cron-driven importer is a solved, boring problem.
+The claim here is that the **assistant** decomposes a vague human request into a
+concrete multi-source import plan, executes it incrementally, reports progress in
+the conversation, and adapts when a step returns something unexpected.
+
+### 6.2 The loop
+
+```
+"import my Q3 folder"
+        │
+        ▼
+  ┌─ PLAN ──────────────────────────────────────────────────────┐
+  │ resolve "Q3 folder" (drive search / prior context / ask)     │
+  │ inspect: 340 files — 120 native Docs, 90 docx, 40 xlsx, 90 … │
+  │ propose: 1 drive source + 1 window, est. 4 chunked passes    │
+  └──────────────────────────────────────────────────────────────┘
+        │  user confirms (or edits the plan)
+        ▼
+  ┌─ REGISTER ──────────────────────────────────────────────────┐
+  │ okg_register — additive upsert into _sources/registry.toml    │
+  └──────────────────────────────────────────────────────────────┘
+        │
+        ▼
+  ┌─ INGEST (windowed, resumable) ──────────────────────────────┐
+  │ repeat: ingest a bounded slice; ledger commits per chunk     │
+  │ report after each: N ingested / M skipped / E errors         │
+  └──────────────────────────────────────────────────────────────┘
+        │
+        ▼
+  ┌─ REPORT + ADAPT ────────────────────────────────────────────┐
+  │ "38 files had no text layer — want me to list them?"         │
+  │ "Coverage now 2026-07-01 → 2026-09-30. Reach further back?"  │
+  └──────────────────────────────────────────────────────────────┘
+```
+
+Everything except PLAN and ADAPT is mechanical and already exists in some form.
+The assistant's genuine contribution is: resolving fuzzy references to concrete
+locators, choosing a decomposition that fits within the per-call ceilings,
+deciding what deserves a question versus a note, and knowing when to stop.
+
+### 6.3 What the platform must add
+
+- **A `okg_plan_import` tool (read-only).** Given a fuzzy target, returns a
+  *proposed* plan as data: the resolved locators, an item-count estimate, a
+  format breakdown, the number of passes implied by the ceilings, and any policy
+  refusals. It registers nothing and ingests nothing. This is what makes the
+  conversation possible before the writes start.
+- **A `okg_register` tool split out from the ingest tools.** Registration is
+  currently folded into ingestion on purpose (#3883: "point at this directory"
+  and "reach further back" are the same call). That remains true for the
+  single-shot path, but a plan-then-execute flow needs to register a *set* of
+  sources before running any of them. Both paths must funnel through the same
+  `okg_register_source`.
+- **Resumable progress.** `IngestReport` already merges chunk reports and carries
+  a `watermark`. A multi-pass crawl needs the same at the *plan* level: which
+  sources in this plan are complete, which are partial, where the next pass
+  resumes. Recommendation: derive it from the existing per-source ledgers
+  (`okg_sources` already exposes coverage) rather than introducing a second piece
+  of durable state that can disagree with the ledger.
+- **Progress a human can watch.** The GUI renders the per-chunk report stream;
+  no new durable state.
+
+### 6.4 The determinism gap (must be stated, not papered over)
+
+Today the entire OKG surface is **LLM-invoked**. `okg_tools()`
+(`crates/trusty-agents/src/tools/okg/mod.rs:53`) returns four `ToolExecutor`s,
+reachable only through a model turn. Consequences:
+
+- A crawl cannot be scripted, cron'd, or run in CI.
+- A crawl cannot be reproduced exactly — the same request may decompose
+  differently on a different turn.
+- Debugging an ingestion is debugging a conversation.
+- A long backfill burns model tokens on mechanical paging.
+
+**This is a real gap and this spec does not pretend the assistant-driven model
+removes it.** The two are complements: the assistant is the right driver for
+*"import my Q3 folder"*; it is the wrong driver for *"re-run the nightly
+backfill."*
+
+**Recommendation: a `tagent okg` subcommand** as the deterministic invocation
+surface — `tagent okg sources`, `tagent okg register`, `tagent okg ingest <id>
+[--max N] [--since DATE]`, `tagent okg plan <target> --json`. Same engine, same
+registry, same ledgers, same policy gates; no model in the loop. The assistant's
+tools then become thin wrappers over the same internal API the subcommand calls,
+so there is exactly one implementation and the CLI is the reproducible one. A
+crawl plan produced by `okg_plan_import` should be serialisable to something
+`tagent okg` can execute verbatim — that is what makes an assistant-planned
+import auditable and re-runnable.
+
+**Open question (owner sign-off):** is the CLI in scope for the first wave, or
+does it follow after the extraction layer lands? §9 sequences it as phase 2 on
+the assumption that the first real backfill will immediately want it.
+
+---
+
+## 7. SPEC-OKGIMPORT-06 — Position Relative to the Ingest→Search Gap (#3892) {#SPEC-OKGIMPORT-06~draft}
+
+### 7.1 The open decision
+
+#3892 (OPEN) documents, with live evidence, that an OKG store's two facets do not
+meet: `okg_ingest_*` writes into
+`${KB_KNOWLEDGE_DIR:-$HOME/.trusty-agents/knowledge}/<agent>`, while the
+`[[stores]]` binding's `index` is a trusty-search index built over an unrelated
+root; `okg://<agent>` is never resolved to a filesystem path at all. A user can
+run an ingest, get a truthful "N entities ingested", and still get nothing from
+`vector_search`. Two coherent remediations are on the table — **(a)** ingest also
+feeds the bound index, or **(b)** the store's index is (re)built over the KB tree
+— and (b) collides with a deliberate operator choice (the 200,090-chunk
+`bob-duetto/cto` index), which is why the issue is flagged for owner sign-off.
+
+### 7.2 This spec's position (normative)
+
+1. **DOC-55 does not decide #3892, and must not be read as having decided it.**
+   Nothing in §§4–6 presumes either remediation.
+2. **DOC-55 makes #3892 strictly more urgent.** Every extractor and every
+   connector multiplies the volume of content that lands in a tree the assistant
+   cannot search. Shipping the importer without resolving #3892 produces a larger,
+   more convincing, still-invisible corpus — the worst outcome, because the
+   failure is silent by construction on both sides.
+3. **The importer is designed to be neutral to the outcome.** The extraction
+   layer is upstream of `SourceItem` and cannot care. The connector framework
+   ends at the ingest engine and cannot care. If (a) is chosen, the index push
+   attaches at exactly one place — after `write_item` succeeds, per item or
+   batched at end of run — and every connector inherits it with no per-connector
+   work. If (b) is chosen, nothing in this spec changes at all.
+4. **If (a) is chosen, the ledger's role must be settled deliberately.** #3892
+   already names the partial-failure mode (entity written, index push failed).
+   The importer's position: the ledger is the record of *KB-tree* truth and
+   should not be overloaded with index state; an index push failure belongs in
+   `IngestReport::errors` and is repaired by an index-level reconcile, not by
+   rolling back a ledger line. Recording index state in the ledger would make
+   ingestion non-convergent when the search daemon is merely down.
+5. **Sequencing recommendation:** #3892 should be decided before the connector
+   roster (§5.4) expands beyond the Google surface — i.e. before phase 3 in §9.
+   The extraction layer (phase 1) can land ahead of it safely, because it changes
+   only the *quality* of what already lands in the tree, not the volume of
+   sources.
+
+---
+
+## 8. SPEC-OKGIMPORT-07 — Security and Failure Posture {#SPEC-OKGIMPORT-07~draft}
+
+1. **Every new read scope is operator configuration.** C6 (§5.2). The model may
+   name *what* to import; the operator decides *what is reachable*. Defaults are
+   useful but never `/` — the `[okg] docstore_roots`-defaults-to-`$HOME`-minus-
+   hidden-paths pattern is the template.
+2. **Gates are re-checked at access time.** A registry row is data, and data can
+   be hand-edited or pre-date the gate.
+3. **Extractors are an attack surface.** They parse untrusted, user-supplied
+   binary formats. Obligations: memory ceilings and decompression-ratio checks
+   (E2); no shelling out to an external converter; prefer pure-Rust parsers with
+   a maintained dependency; extraction failures are per-item, never fatal.
+4. **Extracted content inherits the corpus's sensitivity.** A `.docx` from a
+   restricted Drive folder becomes a plaintext KB entity that may be committed by
+   #3837's git-backed store. Store confinement and `.gitignore` posture are the
+   controlling mechanisms; this spec adds no new exemption.
+5. **Fail closed on ambiguity.** An unreadable path segment, an undeterminable
+   type, an unknown connector kind: refuse and report. Never "assume text".
+
+---
+
+## 9. Phased Delivery
+
+Each phase is independently shippable and leaves the tree in a working state.
+
+**Phase 1 — Extraction layer + first extractors.**
+`trusty-kb::okg::extract` (trait, `TypeHint` resolution, ceilings, golden-fixture
+harness); `text` refactored behind the trait; `html`, `docx`, `xlsx`, `pdf`;
+fingerprint extractor-tagging (§4.5); `docstore::scan` routes through extraction
+before declaring a file binary. Net effect: **a `.docx` in a doc store ingests.**
+No new connector, no new auth, no network.
+
+**Phase 2 — Connector framework + deterministic surface.**
+The `Connector` trait; `Locator::Connector` open variant; existing fetchers
+refactored behind the trait *without* changing their registry rows; per-connector
+policy hook (C6); `tagent okg` subcommand (§6.4). Net effect: **adding a system
+no longer means editing the engine, and a crawl is scriptable.**
+
+**Phase 3 — Google surface completion.**
+`drive_content` routes base64 through extraction (§4.6); export-format selection
+for native Docs/Sheets/Slides; `gmail-attachments` connector. Net effect: **the
+data the user already has in Google lands in full fidelity.** *Gated on the #3892
+decision per §7.2.5.*
+
+**Phase 4 — Assistant-driven crawl.**
+`okg_plan_import`; `okg_register` split; plan-level progress derived from
+ledgers; GUI progress rendering; plan → `tagent okg` serialisation.
+
+**Phase 5 — Beyond Google (stretch).**
+`slack`, `confluence`, `pptx`. Each carries its own C6 policy gate and its own
+ticket.
+
+---
+
+## 10. Open Questions (owner sign-off)
+
+| # | Question | Recommendation |
+|---|---|---|
+| Q1 | Is `tagent okg` (§6.4) in the first wave or a follow-up? | Phase 2 — the first real backfill will want it immediately |
+| Q2 | #3892 remediation (a) or (b)? | Not decided here; §7.2.5 asks for it before phase 3 |
+| Q3 | Do extracted-format entities need a distinguishing marker in frontmatter (`extracted_by: docx@2`)? | Yes — it is free, and it makes an extractor-version re-ingest auditable |
+| Q4 | PDF parser dependency choice (pure-Rust vs. bindings) | Pure-Rust, per §8.3; the specific crate is an implementation ticket |
+| Q5 | Should `xlsx` become a *structured* source (rows as entities) rather than a document? | No — that is the SQL/database gap (#3881 out-of-scope), tracked separately |
+
+---
+
+## 11. References
+
+- `crates/trusty-kb/src/okg/` — engine: `mod.rs`, `ingest.rs`, `registry.rs`,
+  `ledger.rs`, `docstore.rs`, `policy.rs`
+- `crates/trusty-agents/src/tools/okg/` — `gapi.rs`, `docstore.rs`, `gmail.rs`,
+  `drive.rs`, `sources.rs`, `config.rs`
+- `crates/trusty-agents/src/stores/` — the `[[stores]]` binding (#3878)
+- [DOC-54 Trusty Agents Product Specification](./trusty-agents-product-spec.md) §5.1
+- Issues: #3052 (epic), #3881 / PR #3883 (engine), #3878 (binding), #3892
+  (ingest→search gap), #3816 (templates), #3837 (git-backed content store),
+  #2643 (credential resolver)
+
+---
+
+## 12. Change Log
+
+| Date | Change |
+|---|---|
+| 2026-07-25 | Initial draft — extraction layer, connector framework, assistant-driven crawl, #3892 position |

--- a/docs/specs/trusty-agents-agents-sync.md
+++ b/docs/specs/trusty-agents-agents-sync.md
@@ -7,7 +7,8 @@
 **Spec ID:** `SPEC-AGENTSYNC-01~draft` … `SPEC-AGENTSYNC-07~draft` (DOC-56)  
 **Builds on:** #3837 (git-backed per-agent content store — the local repo already exists); DOC-54 [Trusty Agents Product Specification](./trusty-agents-product-spec.md) §3.2/§3.3; #3816 (declarative templates)  
 **Supersedes:** DOC-54 §3.3 — see §2.4  
-**Subsumes:** #3844 (reprovision clobber) — see §6
+**Subsumes:** #3844 (reprovision clobber) — see §6  
+**Implements:** #3899 (tagent-native sync of agent config to the monorepo)
 
 ---
 
@@ -70,6 +71,29 @@ The rejected alternative — a separate repo synchronized by a copy/export step 
 was rejected because it introduces a second source of truth, a bidirectional
 copier, and its own conflict surface, to solve a problem `.gitignore` already
 solves. It also throws away the #3837 history.
+
+> **State of the world, 2026-07-25.** The repo now exists and carries an
+> **initial one-off manual sync** (#3899): `ctrl`, `izzie`, `cto-assistant`, and
+> `assistant`, each as `agents/<agent>/{agent.toml, persona.md, events/*.md}`
+> plus a `<agent>.toml.shadow` copy of the flat file where one existed, with a
+> root `README.md`. That pass was a **copy/export** from `~/.trusty-agents/agents/`
+> — the local #3837 repo was left untouched and nothing was pushed from it.
+>
+> That is the right call for a one-off (it got the content off a single machine
+> today) but it is the shape this section rejects for the *platform* feature.
+> Implementation should convert the remote into the working copy's origin rather
+> than perpetuate the copier. Two concrete follow-ons: the `.toml.shadow` files
+> are the flat/package ambiguity §3.2 requires normalizing away, not a durable
+> layout; and `user.toml`, excluded from the manual pass, is proposed for
+> inclusion here (§4.1) because a restore without it is not a restore — see Q7.
+
+> **PII posture.** #3899 records that several personas deliberately embed real
+> personal data (name, personal email, employer, coworkers, home region) as part
+> of how those assistants are instructed to behave. That is by design for named
+> per-user assistants and is the reason §2.1 fixes visibility at **private,
+> permanently**. It is also why §5.1's secret gate blocks rather than redacts:
+> the content is *supposed* to be personal, so the gate's job is credentials, and
+> the repo's job is never being public.
 
 **Consequence to accept explicitly:** the monorepo will contain a small amount of
 non-agent platform config (`config.toml`, `user.toml`, `skills/index.json`). That
@@ -499,6 +523,8 @@ auto-sync with the A1/A2 constraints; GUI conflict surfacing.
 | Q4 | Is the `templates`-branch merge (§6.2) too heavy vs. #3844's simpler marker? | Do #3844's visible warning now as a stopgap; the merge is the real fix | Recommendation stands |
 | Q5 | Who creates the repo, and with what account? | The `bobmatnyc` account (memory: never the work identity) | Assigned in parallel to a version-control agent |
 | Q6 | Listener-lease design for §8.3 | Separate ticket; do not bundle | Follow-up |
+| Q7 | Does `user.toml` sync? (#3899 excluded it from the manual pass) | Yes — small, stable, and a restore without owner identity is not a restore | Recommendation stands |
+| Q8 | Keep the `<agent>.toml.shadow` files the manual pass created? | No — they are the flat/package ambiguity §3.2 normalizes away | Recommendation stands |
 
 ---
 

--- a/docs/specs/trusty-agents-agents-sync.md
+++ b/docs/specs/trusty-agents-agents-sync.md
@@ -1,0 +1,520 @@
+# DOC-56 — Agent Configuration Sync: The `trusty-agents-agents` Private Monorepo
+
+**Status:** Draft — §5.3 requires owner sign-off before implementation  
+**Subsystem:** trusty-agents — agent configuration lifecycle, provisioning, multi-machine sync  
+**Owner:** Engineering (trusty-agents) / Bob Matsuoka  
+**Last-updated:** 2026-07-25  
+**Spec ID:** `SPEC-AGENTSYNC-01~draft` … `SPEC-AGENTSYNC-07~draft` (DOC-56)  
+**Builds on:** #3837 (git-backed per-agent content store — the local repo already exists); DOC-54 [Trusty Agents Product Specification](./trusty-agents-product-spec.md) §3.2/§3.3; #3816 (declarative templates)  
+**Supersedes:** DOC-54 §3.3 — see §2.4  
+**Subsumes:** #3844 (reprovision clobber) — see §6
+
+---
+
+## 1. Executive Summary
+
+Bob, 2026-07-25: *"Create a private repository `bobmatnyc/trusty-agents-agents`
+where we sync the agent configuration and store into a monorepo under
+`agents/<agent>`. This is a platform feature."*
+
+Three things make this more than a backup scheme:
+
+1. **The local half already exists.** #3837 initialized `~/.trusty-agents` as a
+   git repo on `main`, with a `.gitignore` that already excludes secrets,
+   backups, ephemeral runtime state, and regenerable index artifacts. Ninety
+   objects, 260 KiB packed, 34 tracked files under `agents/`. This spec adds the
+   *remote* half and the *merge* half; it does not re-litigate that baseline.
+2. **It fixes a live bug class, not just a convenience gap.** `#3844` — the
+   reprovision path clobbers hand-edits every `cargo install` — is unfixable in
+   its current framing because the mechanism has **no merge base**. It compares
+   two things (embedded bundle, live file) and can therefore only choose one.
+   Once configuration lives in git with the bundled template as a tracked
+   ancestor, the third input exists and the fix becomes an ordinary three-way
+   merge. §6 makes this the design's centrepiece rather than a side effect.
+3. **It contradicts a checked-in spec, deliberately.** DOC-54 §3.3 states agents
+   are "never version-controlled as repository artifacts." §2.4 records the
+   supersession explicitly so the two documents do not silently disagree.
+
+**Open for owner sign-off (§5.3):** whether OKG knowledge trees sync alongside
+configuration. Both options are specified with their real size and growth
+numbers; the recommendation is **config-only in the monorepo, knowledge trees in
+separate per-store repos**, because DOC-55 (the universal importer) makes the
+corpus's growth profile unbounded while configuration's stays flat.
+
+---
+
+## 2. SPEC-AGENTSYNC-01 — The Repository {#SPEC-AGENTSYNC-01~draft}
+
+### 2.1 Identity
+
+| Property | Value | Rationale |
+|---|---|---|
+| Name | `bobmatnyc/trusty-agents-agents` | Owner-specified |
+| Visibility | **Private**, permanently | Personas encode working style, contacts, and organizational context. Even with secrets excluded (§5.1) the content is personal. A public agent-config repo is a social-engineering corpus. |
+| Default branch | `main` | Matches the #3837 local baseline |
+| Shape | Monorepo, one directory per agent | Owner-specified; §3 |
+
+### 2.2 Relationship to the #3837 local repo
+
+`~/.trusty-agents` is already a git repo containing more than agents:
+`config.toml`, `projects.json`, `user.toml`, `skills/index.json`, `events/`,
+`sessions/`, `repl_history.txt`. The monorepo is **not** simply that repo pushed.
+
+**Recommended model — the content store is the working copy; the monorepo is its
+remote, filtered by `.gitignore`.** That is: add `origin` to the existing
+`~/.trusty-agents` repo, extend `.gitignore` to exclude the per-machine and
+ephemeral files §5.1 lists, and the pushed tree *is* the monorepo. Layout
+`agents/<agent>/` then already holds.
+
+The rejected alternative — a separate repo synchronized by a copy/export step —
+was rejected because it introduces a second source of truth, a bidirectional
+copier, and its own conflict surface, to solve a problem `.gitignore` already
+solves. It also throws away the #3837 history.
+
+**Consequence to accept explicitly:** the monorepo will contain a small amount of
+non-agent platform config (`config.toml`, `user.toml`, `skills/index.json`). That
+is correct — those files are part of what makes a machine's agents work, and a
+restore that omits them is not a restore. `projects.json`, `events/`, and
+`sessions/` are per-machine and are excluded (§5.1).
+
+### 2.3 Why this is a platform feature, not an ops script
+
+Stated as a normative requirement because it determines the whole design: **the
+sync must be reachable from `tagent` itself** (§7), must run without the user
+knowing git, and must be safe to invoke automatically. A documented
+`git push` runbook is not this feature. The user-visible contract is "my agents
+follow me between machines, and my edits are never lost" — a runbook delivers
+neither half.
+
+### 2.4 Supersession of DOC-54 §3.3 (normative)
+
+DOC-54 §3.3 currently reads:
+
+> Agent packages live in the user's local agent directory (e.g.,
+> `~/.trusty-agents/agents/`), **not** in the repository. They are user-specific,
+> account-specific… agents are never version-controlled as repository artifacts.
+
+**That paragraph is superseded by this spec**, with one distinction preserved
+intact: agent packages are still never committed to **`bobmatnyc/trusty-tools`**
+(the product repository). The prohibition was always about not shipping a user's
+personal agents inside the product source tree, and that remains absolute. What
+changes is that agent packages ARE version-controlled — in the user's own private
+content repository.
+
+The `backup-on-change` dated-snapshot convention DOC-54 §3.3 describes is
+likewise superseded by git-as-undo (#3837 already applied this: `backups/` is
+gitignored and Concierge's persona documents the new convention). Implementation
+must land a DOC-54 §3.3 amendment in the same wave, or the catalog carries two
+contradictory normative statements.
+
+---
+
+## 3. SPEC-AGENTSYNC-02 — Layout {#SPEC-AGENTSYNC-02~draft}
+
+### 3.1 Target layout
+
+```
+trusty-agents-agents/               (== ~/.trusty-agents, filtered)
+  README.md                         # what this repo is, how to restore
+  .gitignore                        # the §5.1 exclusion list
+  config.toml                       # platform config (secrets excluded, §5.1)
+  user.toml                         # owner identity/profile
+  skills/index.json                 # skill catalog pins
+  agents/
+    <agent>/
+      agent.toml                    # the manifest: [[stores]] / [tools] / [[listeners]]
+      persona.md                    # main instructions + frontmatter
+      events/                       # per-connector event instructions (DOC-54 §6.1)
+        gmail.md
+        calendar.md
+      attachments/                  # optional, per #3837(a)
+  .provisioning/
+    bundle-stamp                    # which bundled-template generation main descends from (§6)
+```
+
+### 3.2 The flat/package migration (blocking prerequisite)
+
+The live tree is **mixed**: `agents/izzie.toml` *and* `agents/izzie/agent.toml`
+both exist, for `izzie`, `cto-assistant`, and `ctrl`. It also carries
+provisioning debris that must not be synced: `*.lock`, `*.stale.bak`,
+`*.stale.bak.lock`, `*.bak-20260723`, `*.bak-20260724-pre-smoketest-fix`.
+
+Before the first push, the tree must be normalized to strict directory packages
+(#3837(a)) with `git mv`, preserving history. Pushing the mixed shape first would
+bake the ambiguity into the remote and into every clone.
+
+Debris classes and disposition:
+
+| Pattern | Disposition |
+|---|---|
+| `*.lock` | Never tracked — runtime lockfiles (already excluded by `.gitignore`'s `*.lock`) |
+| `*.stale.bak`, `*.stale.bak.*` | Never tracked — already excluded; obsoleted entirely by §6 |
+| `*.bak-<date>*` | Never tracked — already excluded; git is the undo mechanism |
+| `agents/<name>.toml` flat shadow | Migrated into `agents/<name>/agent.toml`, flat file removed |
+
+### 3.3 One agent per directory, no exceptions
+
+`agents/<agent>/` is the unit of everything downstream: the unit of merge (§6),
+the unit of selective sync, and the unit a future "share this agent" feature
+would operate on. An agent whose config is split across a flat file and a package
+directory has no well-defined merge unit, which is precisely how #3844's
+regressions became hard to reason about.
+
+---
+
+## 4. SPEC-AGENTSYNC-03 — What Syncs {#SPEC-AGENTSYNC-03~draft}
+
+### 4.1 Syncs
+
+| Path | Why |
+|---|---|
+| `agents/<agent>/agent.toml` | The manifest — the thing being synced |
+| `agents/<agent>/persona.md` | Instructions; the highest-value hand-edited artifact |
+| `agents/<agent>/events/*.md` | Per-connector instructions (DOC-54 §6.1) |
+| `agents/<agent>/attachments/**` | Small, agent-owned reference material (subject to a size gate, §5.2) |
+| `config.toml` | Platform config, minus any secret-bearing key (§5.1) |
+| `user.toml` | Owner identity/profile — small, stable, needed for a restore |
+| `skills/index.json` | Skill catalog pins |
+| `.provisioning/bundle-stamp` | The merge-base marker (§6) |
+
+### 4.2 Never syncs (normative)
+
+| Path / pattern | Class | Why |
+|---|---|---|
+| `.env`, `.env.*` | **Secret** | Already excluded by #3837. Non-negotiable. |
+| Any token/credential store, OAuth cache, keychain export | **Secret** | Credentials are machine-bound and resolver-owned (#2643). A synced token is a synced compromise. |
+| Any secret-bearing key inside `config.toml` | **Secret** | Requires a scrub gate, not just a path rule — §5.1 |
+| `events/`, `events.jsonl`, listener cursors | **Event state** | Per-machine stream position. Syncing a Gmail history cursor makes two machines fight over "already processed". |
+| `sessions/`, `repl_history.txt` | **Runtime** | Per-machine conversational state |
+| `projects.json` | **Machine-local** | Paths to local checkouts; meaningless on another machine |
+| `state/`, `logs/`, `sockets/`, `*.sock`, `*.lock` | **Ephemeral** | Regenerable or machine-bound |
+| `backups/`, `*.bak*`, `*.stale.bak*`, `agents-disabled-*/` | **Superseded** | Git is the undo mechanism |
+| `.trusty-search/`, `*.redb`, `*.usearch` | **Regenerable index** | Rebuildable from the corpus; large; binary; useless in diffs |
+| `knowledge/sources/` | **Bulk raw** | 3.1 MB of raw source docs today; the distilled tree is the artifact, not the input |
+| `demo-kit/` | **Binaries** | Not configuration |
+
+`repl_history.txt`, `sessions/`, `projects.json`, and `events/` are currently
+*tracked* in the #3837 baseline. Moving them to excluded is part of this spec's
+first implementation slice and is a deliberate change, not an oversight.
+
+### 4.3 The rule behind the table
+
+> Sync what a human authored or a template instantiated. Never sync what a
+> process derived, what a stream advanced, or what a credential store issued.
+
+Applied to a novel file, this rule decides it without a spec amendment.
+
+---
+
+## 5. SPEC-AGENTSYNC-04 — Secrets, Size, and the Knowledge-Tree Question {#SPEC-AGENTSYNC-04~draft}
+
+### 5.1 Secrets: a gate, not a path list (normative)
+
+Path-based exclusion is necessary and insufficient. `config.toml` is synced and
+is exactly the kind of file that accretes an API key. The sync path therefore
+runs a **pre-push scrub gate**:
+
+- **S1** — A deny-list of key names (`*_token`, `*_secret`, `*_key`,
+  `password`, `authorization`, `api_key`) checked against every synced TOML/JSON,
+  plus high-entropy-value and known-credential-prefix detection over synced text.
+- **S2** — The gate **blocks the push** and names the file and key. It never
+  auto-redacts: silently altering a user's config to make a push succeed is worse
+  than failing.
+- **S3** — Fails closed. Gate error ⇒ no push.
+- **S4** — Applies to `persona.md` and `events/*.md` too. Instructions are prose,
+  and prose is where a pasted token hides.
+- **S5** — A committed secret is treated as compromised. The runbook is: rotate
+  first, scrub history second. Documented in the repo README, because a private
+  repo is not an encrypted one.
+
+### 5.2 Size discipline
+
+`attachments/` is user-supplied and unbounded by nature. A per-file cap (e.g.
+1 MiB) and a per-agent total cap, enforced at commit time with a clear message,
+keeps a clone fast and keeps a config repo from becoming an asset store.
+
+### 5.3 OPEN QUESTION — do knowledge trees sync? {#SPEC-AGENTSYNC-04-Q1}
+
+**This is the one decision this spec does not make. It needs owner sign-off.**
+
+The directive says "the agent configuration **and store**". "Store" is genuinely
+ambiguous between the `[[stores]]` *binding* (a few lines of `agent.toml` —
+unambiguously synced) and the OKG *knowledge tree* the binding names.
+
+Measured today:
+
+| Artifact | Location | Size | Growth |
+|---|---|---|---|
+| All agent config | `~/.trusty-agents/agents/` | **516 KB** on disk, 34 tracked files, whole repo 260 KiB packed | Flat — bounded by agent count |
+| `bob-kb` distilled tree | `~/trusty-agents/bob-kb` *(a third location — see §5.4)* | **2.7 MB** | **Unbounded** — grows with every ingest |
+| Raw sources | `~/.trusty-agents/knowledge/sources/` | 3.1 MB | Unbounded; already excluded |
+| Search index | `.trusty-search/`, `*.usearch` | large, binary | Regenerable; already excluded |
+
+**Option A — Config only.** The monorepo holds `agents/<agent>/` plus the §4.1
+platform files. Knowledge trees stay out; a new machine re-ingests from the
+sources the registry names.
+
+- **For:** Repo stays ~0.5 MB and clones instantly. Growth is bounded by agent
+  count, not corpus size. No conflict semantics needed for machine-generated
+  markdown. `_sources/*.jsonl` ledgers are append-only journals — close to the
+  worst-case shape for git. No risk of a private corpus landing in a repo whose
+  sharing model may later loosen.
+- **Against:** A new machine must re-ingest, which costs API quota and wall-clock,
+  and for a Gmail backfill may not be fully reproducible (deleted messages).
+  Distilled entities — the ones a model wrote, which cost tokens — are lost work
+  if the machine dies.
+
+**Option B — Config plus distilled knowledge trees.** Adds
+`knowledge/<tree>/` (entities + `_sources/registry.toml` + `_sources/*.jsonl`),
+still excluding raw sources and indexes.
+
+- **For:** A clone is a complete, immediately-useful assistant. Distilled entities
+  are preserved. Ledgers travel, so a second machine's ingest correctly skips what
+  the first already pulled — genuinely valuable, since idempotency is per-ledger.
+- **Against:** DOC-55 (the universal importer) is explicitly designed to make this
+  grow fast — every new extractor and connector multiplies corpus volume, and
+  `xlsx`/`pdf` extraction produces large text bodies. Ledgers only ever append.
+  Entity writes are whole-file overwrites (`put_entity` overwrite mode), so a
+  re-ingest rewrites files wholesale rather than producing small deltas. Two
+  machines ingesting the same source concurrently produce conflicting ledger
+  appends with no merge strategy — a class of conflict Option A does not have.
+
+**Recommendation: Option A for the monorepo, with knowledge trees in separate
+per-store repositories** (e.g. `bobmatnyc/trusty-kb-<tree>`), opt-in per store,
+sharing the same `tagent sync` mechanics. Rationale:
+
+1. The two artifacts have opposite growth profiles and opposite conflict
+   semantics. Coupling them means every config clone pays the corpus's cost
+   forever, and the corpus's ledger-conflict problem blocks config sync.
+2. It preserves the option: a store repo can be added later without restructuring
+   the monorepo, whereas splitting a large history back out is painful.
+3. The `[[stores]]` binding already gives each store an identity (`name`,
+   `tree`, `index`), so "this store syncs to this remote" is a natural additional
+   field, not a new concept.
+
+**Sub-question if Option B is chosen:** ledger conflict strategy for concurrent
+multi-machine ingest. `_sources/<id>.jsonl` is append-only, so a union merge is
+*mechanically* correct (the ledger tolerates duplicate lines — `is_current`
+reads the latest record for an id) but must be verified against
+`Ledger::watermark()`, which counts. Do not assume; test it.
+
+### 5.4 Incidental finding: KB trees live in three places
+
+Worth recording because it affects any Option-B implementation. The `bob-kb`
+tree is at `~/trusty-agents/bob-kb` (no leading dot), the OKG tools resolve to
+`${KB_KNOWLEDGE_DIR:-$HOME/.trusty-agents/knowledge}/<agent>`, and
+`~/.trusty-agents/knowledge/` currently contains only `sources/`. This is the
+same disconnect #3892 documents from the search side. **Option B is not
+implementable until the tree location is single-valued.** Option A is unaffected.
+
+---
+
+## 6. SPEC-AGENTSYNC-05 — Sync Direction, Conflicts, and Subsuming #3844 {#SPEC-AGENTSYNC-05~draft}
+
+### 6.1 The problem, precisely
+
+`reprovision_bundled_agents_locked`
+(`crates/trusty-agents/src/agents/bundled/mod.rs:203`) compares exactly two
+things: the on-disk file and the binary-embedded bundle. When they differ it
+copies the on-disk version to `<dest>.stale.bak` (only if no backup exists) and
+overwrites. This is careful — atomic writes, a pass-level lock, no clobbering a
+prior backup, non-bundled files untouched — and still loses hand-edits, because
+**with two inputs the only available operations are "keep" and "replace".** #3844
+proposes a 3-way merge; the mechanism has nowhere to get the third input from.
+`.stale.bak` is not a merge base: it is whatever the file happened to be at some
+earlier overwrite, it is overwritten in some paths, and it is gitignored.
+
+### 6.2 The design: a vendor branch supplies the merge base
+
+Once configuration lives in git, the merge base is free.
+
+```
+  templates ──T1────────T2────────T3          (bundled templates, one commit
+                \         \         \          per bundle stamp — machine-written)
+                 \         \         \
+  main ──────A────M1───B────M2───C────M3──▶   (user edits A,B,C; merges M1..M3)
+```
+
+- The binary's embedded bundle is committed to a **`templates` branch**, one
+  commit per distinct bundle stamp, containing only bundled files.
+- User edits are ordinary commits on `main`.
+- Reprovision becomes `git merge templates` into `main`. Git supplies the true
+  common ancestor (the previously merged template commit), so a hand-edited
+  `role` and an upstream-changed `tools` list **both survive** — the outcome
+  #3844 asks for, obtained from a mechanism that already exists and is trusted.
+- `.provisioning/bundle-stamp` records which template generation `main` descends
+  from, so the "is the bundle stale?" test that today drives the clobber becomes
+  the "do I need to merge?" test.
+
+**Genuine conflicts** (the same key edited on both sides) are a normal git
+conflict. Handling, in order: leave the working tree conflicted and **refuse to
+start the affected agent** with a message naming the file; surface it in the GUI
+as "this agent needs attention"; offer take-mine / take-theirs / open-editor. A
+conflict must never resolve silently — that is the #3844 failure in a new costume.
+
+**#3844 disposition:** implemented-by rather than duplicated. #3844's "visible
+warning on `.stale.bak`" remains worth doing as a stopgap until this lands, since
+the merge design is a larger change than the bug's urgency warrants on its own.
+
+### 6.3 Remote sync direction
+
+Three-way is the same shape one level up. Local `main` and remote `main` diverge
+when two machines edit; git's merge handles it, and the same conflict policy
+(§6.2) applies. Normative rules:
+
+- **D1 — No force-push, ever.** A config repo's history is a user's undo stack.
+- **D2 — No auto-resolve on conflict.** Conflicts stop and ask.
+- **D3 — Pull is a merge, never a reset.** A `git reset --hard origin/main`
+  recovery path recreates the exact data-loss class this spec exists to end.
+- **D4 — Push is fail-safe.** A rejected push leaves the local repo intact and
+  reports; it never rewrites local history to make the push succeed.
+
+---
+
+## 7. SPEC-AGENTSYNC-06 — Platform Mechanics {#SPEC-AGENTSYNC-06~draft}
+
+### 7.1 `tagent sync`
+
+| Command | Behavior |
+|---|---|
+| `tagent sync init [--remote URL]` | Creates/attaches the private remote, normalizes layout (§3.2), applies the `.gitignore`, runs the secret gate, pushes the initial commit |
+| `tagent sync status` | Ahead/behind, uncommitted changes, unmerged template generation, conflicts — no network writes |
+| `tagent sync` | Commit pending changes → pull/merge → secret gate → push. The single verb a user needs |
+| `tagent sync pull` / `push` | The halves, for scripts |
+| `tagent sync resolve <agent>` | Guided conflict resolution for one agent package |
+
+Each is a thin wrapper over the same internal API the auto-sync path (§7.3) and
+the GUI use, so there is exactly one implementation of the merge policy.
+
+### 7.2 Auto-commit on write (#3837(c))
+
+Agent PATCH/create APIs and persona edits commit automatically. Without this,
+auto-sync has nothing to sync and the user's last hour of GUI edits is invisible
+to git. Commit messages are generated and specific
+(`config(izzie): update tools allow-list via GUI`), because a wall of "auto
+commit" defeats git-as-undo — the mechanism #3837 is explicitly buying.
+
+### 7.3 Auto-sync cadence
+
+Recommended default: **on-change, debounced, plus a periodic floor.** Push a few
+seconds after the last write settles; pull-merge on daemon start and every N
+minutes (default 15). Two constraints, both normative:
+
+- **A1 — Never auto-merge into a running agent's live config mid-turn.** Apply
+  the merge at a turn boundary or on next agent start. Swapping a persona under a
+  running conversation is a debugging nightmare.
+- **A2 — Auto-sync never resolves a conflict.** On conflict it stops, marks the
+  agent, and waits. (Same rule as §6.2, restated because auto-paths are where
+  "just pick one" gets added later.)
+
+Cadence is configurable and fully disableable (`[sync] auto = false`); a user who
+wants manual control gets it.
+
+### 7.4 Bootstrap on a new machine
+
+`tagent sync init --remote git@github.com:bobmatnyc/trusty-agents-agents.git`
+clones into `~/.trusty-agents`, merges the current binary's `templates` commit
+(so a newer binary's template changes apply cleanly on first run), and reports
+what is *not* synced and therefore needs local setup: credentials, listener
+cursors, project paths. That report is the feature — a restore that silently
+omits credentials and appears to work is worse than one that says what is missing.
+
+---
+
+## 8. SPEC-AGENTSYNC-07 — Multi-Machine Story {#SPEC-AGENTSYNC-07~draft}
+
+### 8.1 What "my agents follow me" means
+
+Machine A and Machine B share agent definitions and diverge on everything
+machine-bound. Editing Izzie's persona on A reaches B on B's next sync. Both
+machines authenticate independently (credentials never travel, §4.2). Both
+maintain independent listener cursors — otherwise they duplicate or drop events.
+
+### 8.2 The machine-identity boundary
+
+| Concern | Shared | Per-machine |
+|---|---|---|
+| Persona, manifest, event instructions | ✅ | |
+| Platform config (`config.toml`, `user.toml`) | ✅ | |
+| Credentials / OAuth tokens | | ✅ |
+| Listener cursors, event stream position | | ✅ |
+| Project paths (`projects.json`) | | ✅ |
+| Conversation history, sessions | | ✅ |
+| Search indexes | | ✅ (regenerated) |
+| Knowledge trees | *pending §5.3* | *pending §5.3* |
+
+### 8.3 The concurrent-listener hazard (must be designed for, not discovered)
+
+If two machines run the same `gmail-personal` listener with independent cursors,
+the event is delivered twice and the assistant may act twice. This is **not**
+solved by config sync — it is *created* by it, because before sync a second
+machine would not have had the listener configured at all.
+
+Minimum viable handling: `tagent sync status` reports when another machine's
+config declares the same listener, and the platform surfaces a warning. Proper
+handling — a listener lease, or a per-listener `active_on` machine binding — is
+follow-up work and should be filed as its own ticket rather than smuggled into
+this spec's implementation.
+
+### 8.4 Non-goals
+
+- No real-time/CRDT sync. Git-granularity is sufficient; anything finer is a
+  research project.
+- No cross-**user** sharing. This is one user, N machines. Publishing or sharing
+  an agent is a different feature with a different trust model.
+- No hosted service. The remote is a git host the user already has.
+
+---
+
+## 9. Phased Delivery
+
+**Phase 1 — Layout normalization.** `git mv` flat shadows into directory
+packages (#3837(a)); extend `.gitignore` per §4.2; untrack `projects.json`,
+`events/`, `sessions/`, `repl_history.txt`. Local only, no remote. *Blocks
+everything else.*
+
+**Phase 2 — Remote + secret gate.** Create the private repo; `tagent sync init`
+/ `status` / `pull` / `push`; the §5.1 scrub gate; the bootstrap report (§7.4).
+Delivers "my agents follow me" manually.
+
+**Phase 3 — The templates branch (subsumes #3844).** Commit the embedded bundle
+to `templates`; `.provisioning/bundle-stamp`; reprovision becomes a merge;
+conflict policy and `tagent sync resolve`; retire `.stale.bak`.
+
+**Phase 4 — Auto-commit + auto-sync.** #3837(c) write-path commits; debounced
+auto-sync with the A1/A2 constraints; GUI conflict surfacing.
+
+**Phase 5 — Knowledge trees, if Option B (§5.3) is chosen.** Blocked on the
+§5.4 tree-location unification and on a verified ledger merge strategy.
+
+---
+
+## 10. Open Questions
+
+| # | Question | Recommendation | Status |
+|---|---|---|---|
+| Q1 | Do knowledge trees sync? (§5.3) | Option A: config-only monorepo; per-store repos later | **Owner sign-off required** |
+| Q2 | Does `config.toml` sync wholesale, or a filtered subset? | Wholesale + the §5.1 blocking gate; a filtered subset invents a second config format | Recommendation stands |
+| Q3 | One repo for all machines of one user, or one per machine? | One per user — per-machine repos are backups, not sync | Recommendation stands |
+| Q4 | Is the `templates`-branch merge (§6.2) too heavy vs. #3844's simpler marker? | Do #3844's visible warning now as a stopgap; the merge is the real fix | Recommendation stands |
+| Q5 | Who creates the repo, and with what account? | The `bobmatnyc` account (memory: never the work identity) | Assigned in parallel to a version-control agent |
+| Q6 | Listener-lease design for §8.3 | Separate ticket; do not bundle | Follow-up |
+
+---
+
+## 11. References
+
+- `crates/trusty-agents/src/agents/bundled/mod.rs:203` — `reprovision_bundled_agents_locked`, the clobber path (#3844)
+- `crates/trusty-agents/src/stores/config.rs` — the `[[stores]]` binding (#3878)
+- `~/.trusty-agents/.gitignore` — the #3837 baseline exclusion list
+- [DOC-54 Trusty Agents Product Specification](./trusty-agents-product-spec.md) §3.2, §3.3, §6.1
+- [DOC-55 Universal OKG Importer](./okg-universal-importer.md) — §5.3's growth argument
+- Issues: #3837 (git-backed content store), #3844 (reprovision clobber), #3816 (templates), #3892 (tree/index disconnect), #2643 (credential resolver)
+
+---
+
+## 12. Change Log
+
+| Date | Change |
+|---|---|
+| 2026-07-25 | Initial draft — repo identity, layout, sync boundary, templates-branch merge subsuming #3844, multi-machine model, knowledge-tree question open for sign-off |


### PR DESCRIPTION
Docs-only. Two formal specs from the owner's 2026-07-25 "spec and ticket" directive, both grounded in the shipped code rather than sketched against it, plus the epic + child tickets for the first.

---

## DOC-55 — Universal OKG Importer

`docs/specs/okg-universal-importer.md` · `SPEC-OKGIMPORT-01~draft` … `-07~draft`

> *"An OKG importer for any file type — google docs, gmail, docx, xls, etc. … any data system we can connect to, we should be able to crawl and import that data into an OKG store for an assistant, **driven by the assistant**."*

PR #3883 shipped the hard part — an idempotent, additive, crash-convergent ingest engine behind a per-source append-only ledger, split at the `SourceItem` seam so the `trusty-kb` engine stays pure and network-free while the credentialed fetchers live in `trusty-agents`. Nothing in this spec changes those invariants; §2.2 tabulates all eight so every extension inherits them explicitly.

The spec extends that engine along two orthogonal axes and then names the feature that makes both useful:

- **Formats (§4)** — an `Extractor` trait immediately upstream of `SourceItem`: bytes + type hint in, normalized text + provenance out. Pure, bounded, degrade-never-abort. First wave `html` / `docx` / `xlsx` / `pdf` / Google-Docs export.
- **Systems (§5)** — a `Connector` = exactly `list` + `fetch`, inheriting the ledger/watermark/idempotency contract verbatim. Eight normative obligations (C1–C8) plus an open `Locator::Connector { kind, params }` variant so a new system stops meaning "edit `trusty-kb`". Near-term roster: Google Docs via Drive export, Gmail attachments, Slack, Confluence, filesystem formats.
- **Assistant-driven crawl (§6)** — plan → confirm → windowed ingest → report → adapt. `okg_plan_import` (read-only) is what makes the conversation possible *before* the writes start.

**Two things the spec insists on rather than glossing:**

1. **The extractor-version fingerprint trap (§4.5).** `docstore` fingerprints raw bytes, which is correct. But improve the `docx` extractor and every already-ingested `.docx` keeps its old fingerprint, so `Ledger::is_current` skips it forever and the entity is silently frozen at its first-seen extraction — the *same class* as the constant-fingerprint defect `SourceItem::volatile` exists to prevent (code-critic HIGH 3 on #3883). Rule: extractor-produced items fingerprint as `sha256:<hex>/<extractor-id>:<version>`.
2. **The determinism gap (§6.4).** Today's `okg_*` tools are LLM-invoked only — a crawl cannot be scripted, cron'd, reproduced, or debugged outside a conversation, and a long backfill burns tokens on mechanical paging. The assistant-driven model does not remove this; they are complements. Proposes a `tagent okg` subcommand over the *same internal API*, so there is one implementation and the CLI is the reproducible one.

**Position on #3892 (§7), stated rather than assumed.** #3892 (OPEN) documents that an ingested entity is invisible to `vector_search` — the KB tree and the bound index are two halves that do not meet. This spec **does not decide it**, is designed to be neutral to either remediation, and states plainly that the importer makes it *more* urgent: every extractor and connector multiplies the volume of content landing in a tree the assistant cannot search, with the failure silent on both sides. Recommended sequencing: decide #3892 before the connector roster expands past the Google surface.

---

## DOC-56 — Agent Configuration Sync: the `trusty-agents-agents` Private Monorepo

`docs/specs/trusty-agents-agents-sync.md` · `SPEC-AGENTSYNC-01~draft` … `-07~draft`

> *"Create a private repository `bobmatnyc/trusty-agents-agents` where we sync the agent configuration and store into a monorepo under `agents/<agent>`. This is a platform feature."*

Builds on #3837, which already made `~/.trusty-agents` a git repo on `main` with a `.gitignore` excluding secrets, backups, ephemeral state, and regenerable indexes. This spec adds the *remote* half and the *merge* half. Reconciled in a second commit against the one-off manual sync #3899 pushed while this was being written.

**It subsumes #3844 rather than working around it (§6).** `reprovision_bundled_agents_locked` (`bundled/mod.rs:203`) compares exactly two things — on-disk file and embedded bundle — so the only operations available to it are "keep" and "replace"; `.stale.bak` is not a merge base. Design: commit the embedded bundle to a **`templates` vendor branch**, one commit per bundle stamp, with `.provisioning/bundle-stamp` recording which generation `main` descends from. Reprovision becomes `git merge templates`, git supplies the true ancestor, and a hand-edited `role` plus an upstream-changed `tools` list both survive. Conflicts stop and refuse to start the affected agent — never silent resolution, which would be #3844 in a new costume.

**What syncs (§4).** Manifests, personas, per-connector event instructions, platform config, `user.toml`, skill pins. **Never:** secrets and tokens, listener cursors and event state, sessions, project paths, backups, regenerable indexes, bulk raw sources. §4.3 states the rule behind the table so a novel file is decided without a spec amendment: *sync what a human authored or a template instantiated; never what a process derived, a stream advanced, or a credential store issued.* §5.1 specifies the secret gate as **blocking, never auto-redacting**, fail-closed, and applied to `persona.md` prose — which is where a pasted token actually hides.

**One decision left open, flagged for owner sign-off (§5.3).** Do OKG knowledge trees sync? Measured: all agent config is **516 KB / 34 tracked files** (repo 260 KiB packed); the `bob-kb` tree is **2.7 MB** and unbounded. Both options costed. **Recommendation: config-only monorepo, knowledge trees in separate per-store repos, opt-in per store** — the two have opposite growth profiles and opposite conflict semantics, DOC-55 is explicitly designed to make the corpus grow fast, ledgers only append, and entity writes are whole-file overwrites.

**It records a supersession instead of creating a contradiction (§2.4).** DOC-54 §3.3 says agents are "never version-controlled as repository artifacts". That is superseded here, preserving the part that still holds — agent packages are never committed to `bobmatnyc/trusty-tools` itself. Without the amendment the catalog carries two contradictory normative statements; landing it is called out as required in the same wave.

Also surfaced: KB trees currently resolve to **three different locations** (§5.4), which blocks any knowledge-tree sync and is the same disconnect #3892 sees from the search side.

---

## Tickets

**Epic #3904** — Universal OKG importer — any file type, any connectable system, assistant-driven

- #3905 — Format-extraction layer (pure, network-free) at the `SourceItem` seam
- #3906 — Connector framework contract — list+fetch over any reachable system
- #3907 — First-wave extractors — docx, xlsx, html, pdf, Google Docs export *(depends on #3905)*
- #3908 — Assistant-driven crawl orchestration — plan, register, windowed ingest, progress
- #3910 — Deterministic invocation surface — `tagent okg` subcommand

**Spec B filed no new ticket by design.** #3899 was created in parallel for exactly this feature; DOC-56 is its design spec, and the spec path plus answers to all three of its open questions are [commented there](https://github.com/bobmatnyc/trusty-tools/issues/3899#issuecomment-5079215111) instead of duplicating the issue.

## Catalog

Claims DOC-55 and DOC-56 in `docs/specs/README.md`; next free bumped to DOC-57.

## Gates

```
bash scripts/check_sld.sh           → 0 errors, 0 warnings (45 spec docs + 2845 code files)
bash scripts/check_test_pointers.sh → 0 dangling pointers — OK
```

CHANGELOG not required — docs-only, no package source touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools