### PR TITLE
docs(trusty-installer): note dead-code-function-body gap in PATH-idempotency disclaimer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -377,6 +377,10 @@ confirm() {
 #      (harmless, still-idempotent-on-ITS-OWN-writes) export line gets
 #      appended, never a silently-skipped real fix — the failure mode this
 #      function exists to avoid is a false POSITIVE, not a false negative.
+#      One residual false-positive gap remains for the same reason (line-based
+#      text matching, not a shell interpreter): a `PATH=` line sitting inside
+#      a never-invoked function body reads as "present" too — an unusual,
+#      self-inflicted dotfile pattern, not worth chasing with more regex.
 # Test: appending twice via `_append_path_export` leaves exactly one line;
 #      a pre-existing differently-quoted entry is detected (no second entry
 #      appended); a commented-out entry is NOT detected (the real line still


### PR DESCRIPTION
## Summary

Trivial one-block comment-only follow-up to #3897 (merged). The round-3 code-critic APPROVE raised a residual observation it deliberately did NOT make a finding on: `_path_export_present_in` (install.sh) is line-based text matching, not a shell parser, so a `PATH=` line sitting inside a never-invoked function body reads as "present" — the same failure class as the already-documented commented-out-line case, via dead code instead. It's an unusual, self-inflicted dotfile pattern with no assessed >80% confidence of hitting a real user, and not worth a fourth round of regex changes (the pattern was already corrected twice in #3897).

This PR only extends the existing "What it does NOT guarantee" disclaimer comment at `install.sh:373` with that one observation — no behavior change.

No issue to close; this is process follow-through from #3897's review discussion.

## Test plan

- [x] `sh -n install.sh` — syntax OK
- [x] `shellcheck -s sh install.sh` — clean
- [x] `bash tests/test-install-path.sh` — 13/13 pass (unchanged, comment-only diff)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools