### PR TITLE
fix(trusty-code): session.get_context_budget surfaces the real working-context floor

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`session.get_context_budget` now surfaces the real working-context
+  floor, not just a point-in-time snapshot (#3912).** The load-realistic
+  compression soak (epic #3866, PR #3909) proved the RPC's cached
+  `working_context_pct` can read 98-99% while the durable
+  `compression.jsonl` telemetry recorded a real floor of 48-60% for the
+  SAME session — a coarse once-per-`task.run`-call poll reliably misses
+  the turn where the floor was lowest. Added
+  `agent_loop::telemetry::session_working_context_floor` (scans the
+  durable JSONL, scoped to one session) and two new response fields,
+  `working_context_pct_low_water_mark` / `working_context_pct_sample_count`,
+  computed fresh on every `session.get_context_budget` query — mirroring
+  `lifetime_compaction_alarm_count`'s existing "read fresh at query time"
+  pattern exactly.
+
 ### Fixed
 
 - **`TurnCapExceeded` permanently un-resumed a session (#3888).** A

--- a/crates/trusty-code/src/agent_loop/telemetry.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry.rs
@@ -256,6 +256,51 @@ pub fn lifetime_compaction_alarm_count(data_dir: &Path) -> u64 {
         .count() as u64
 }
 
+/// Session-scoped working-context low-water mark, read fresh from the
+/// durable `compression.jsonl` log (issue #3912).
+///
+/// Why: `session.get_context_budget` cached only the MOST RECENT
+/// `ContextBudgetSnapshot` — a single point-in-time value that a coarse,
+/// once-per-`task.run`-call poll can easily miss the real dip on (the
+/// load-realistic soak, epic #3866, observed the RPC report 98-99% while
+/// the durable JSONL recorded a 48-60% floor for the SAME run). Every
+/// cadence/threshold fire already writes its `working_context_pct_after`
+/// to this log (issue #3867) — this is the query that turns "every sample
+/// this session ever produced" into the one number an operator actually
+/// needs: how low did it REALLY get.
+/// What: scans `<data_dir>/compression.jsonl` line by line (best-effort,
+/// matching every other reader in this module — a missing file, an
+/// unreadable line, or a record with no `working_context_pct_after` is
+/// silently skipped, never an error), keeping only rows whose `session_id`
+/// matches `session_id` exactly. Returns `(None, 0)` when the file is
+/// missing or no matching sample carries a percentage; otherwise
+/// `(Some(min), count)` — the lowest `working_context_pct_after` observed
+/// for this session and how many samples that minimum was computed over.
+/// Test: `tests::session_working_context_floor_missing_file_is_none`,
+/// `tests::session_working_context_floor_tracks_minimum_for_session`,
+/// `tests::session_working_context_floor_ignores_other_sessions`.
+pub fn session_working_context_floor(data_dir: &Path, session_id: &str) -> (Option<u8>, usize) {
+    let Ok(file) = std::fs::File::open(compression_log_path(data_dir)) else {
+        return (None, 0);
+    };
+    let mut min_pct: Option<u8> = None;
+    let mut count = 0usize;
+    for line in std::io::BufReader::new(file).lines().map_while(Result::ok) {
+        let Ok(event) = serde_json::from_str::<CompressionEvent>(&line) else {
+            continue;
+        };
+        if event.session_id.as_deref() != Some(session_id) {
+            continue;
+        }
+        let Some(pct) = event.working_context_pct_after else {
+            continue;
+        };
+        count += 1;
+        min_pct = Some(min_pct.map_or(pct, |m| m.min(pct)));
+    }
+    (min_pct, count)
+}
+
 /// Derive `(working_context_pct, overhead_pct)` from a raw token measurement
 /// against a model's context window, mirroring
 /// `cadence::CadenceOutcome::working_context_pct`/`overhead_pct`'s own

--- a/crates/trusty-code/src/agent_loop/telemetry_tests.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry_tests.rs
@@ -279,6 +279,89 @@ fn record_cadence_event_writes_jsonl() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
+// -- session_working_context_floor (issue #3912) --
+
+#[test]
+fn session_working_context_floor_missing_file_is_none() {
+    let dir = temp_dir("floor-missing");
+    assert_eq!(session_working_context_floor(&dir, "sess-a"), (None, 0));
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn session_working_context_floor_tracks_minimum_for_session() {
+    let dir = temp_dir("floor-tracks-min");
+    record_cadence_event(
+        &dir,
+        Some("sess-a".to_string()),
+        100_000,
+        90_000,
+        200_000,
+        5,
+        3,
+    );
+    record_cadence_event(
+        &dir,
+        Some("sess-a".to_string()),
+        100_000,
+        104_000,
+        200_000,
+        5,
+        4,
+    );
+    record_cadence_event(
+        &dir,
+        Some("sess-a".to_string()),
+        100_000,
+        52_000,
+        200_000,
+        5,
+        5,
+    );
+
+    // overhead_pct is tokens_after/context_window*100; working = 100 - that.
+    // 90_000/200_000 = 45% -> working 55; 104_000/200_000 = 52% -> working 48;
+    // 52_000/200_000 = 26% -> working 74. Floor must be 48.
+    assert_eq!(
+        session_working_context_floor(&dir, "sess-a"),
+        (Some(48), 3),
+        "must report the lowest working_context_pct_after across all samples, not the latest"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn session_working_context_floor_ignores_other_sessions() {
+    let dir = temp_dir("floor-ignores-others");
+    record_cadence_event(
+        &dir,
+        Some("sess-a".to_string()),
+        100_000,
+        190_000,
+        200_000,
+        5,
+        3,
+    );
+    record_cadence_event(
+        &dir,
+        Some("sess-b".to_string()),
+        100_000,
+        10_000,
+        200_000,
+        5,
+        3,
+    );
+
+    let (min_pct, count) = session_working_context_floor(&dir, "sess-a");
+    assert_eq!(count, 1, "only sess-a's own sample must be counted");
+    assert_eq!(
+        min_pct,
+        Some(5),
+        "sess-b's much lower reading must not leak in"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 // -- default_data_dir / DATA_DIR_ENV_VAR --
 
 #[tokio::test]

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -950,6 +950,24 @@ pub struct ContextBudgetSnapshot {
     /// for budget state (`session.get_context_budget`) instead of requiring
     /// a second `session.get_transcript` call.
     pub lifetime_compaction_alarm_count: u64,
+    /// (issue #3912) This SESSION's lowest-ever `working_context_pct`,
+    /// derived fresh from `agent_loop::telemetry::session_working_context_floor`
+    /// every time this RPC is queried — `None` when no durable sample for
+    /// this session exists yet. Same "read fresh at query time, `0`/`None`
+    /// placeholder on the write path" pattern as
+    /// `lifetime_compaction_alarm_count` immediately above, and for the same
+    /// reason: the load-realistic compression soak (epic #3866) proved the
+    /// single most-recent snapshot above (`working_context_pct`) can read
+    /// 98-99% while a durable per-turn sample this same session produced
+    /// moments earlier was 48-60% — a coarse once-per-`task.run`-call poll
+    /// reliably misses the turn where the floor was lowest. This field is
+    /// the fix: the real floor, not a snapshot that can miss it.
+    pub working_context_pct_low_water_mark: Option<u8>,
+    /// (issue #3912) How many durable telemetry samples
+    /// `working_context_pct_low_water_mark` was computed over for this
+    /// session — lets a consumer distinguish "no samples yet" (`None` above)
+    /// from "exactly one, possibly unrepresentative, sample".
+    pub working_context_pct_sample_count: usize,
 }
 
 /// One row in a session's RETAINED search/recall audit trail (issue #3072;

--- a/crates/trusty-code/src/session/protocol_budget.rs
+++ b/crates/trusty-code/src/session/protocol_budget.rs
@@ -224,4 +224,93 @@ mod tests {
 
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    // -- issue #3912: working_context_pct_low_water_mark --
+
+    /// The core #3912 acceptance criterion: `session.get_context_budget`
+    /// must surface the REAL floor this session's telemetry recorded, not
+    /// just the most-recent cached snapshot — reproducing the load-soak's
+    /// finding (RPC reads 98-99% while the durable JSONL floor was 48-60%)
+    /// with a small fixture instead of a full daemon soak.
+    #[tokio::test]
+    async fn get_context_budget_reflects_working_context_floor() {
+        let dir = telemetry_temp_dir("floor-reflects");
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let result = crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
+            // Two durable cadence samples for THIS session: one healthy
+            // (90% working), one a real dip (48% working) — simulating the
+            // exact gap the load soak found between a coarse snapshot and
+            // the true per-turn floor.
+            crate::agent_loop::telemetry::record_cadence_event(
+                &dir,
+                Some(session.id.clone()),
+                100_000,
+                20_000,
+                200_000,
+                5,
+                1,
+            ); // working = 90%
+            crate::agent_loop::telemetry::record_cadence_event(
+                &dir,
+                Some(session.id.clone()),
+                100_000,
+                104_000,
+                200_000,
+                5,
+                4,
+            ); // working = 48%
+
+            // The CACHED snapshot itself still only reflects the latest
+            // (healthy-looking) turn, exactly like the real
+            // `record_context_budget` write path.
+            let mut healthy = measurement();
+            healthy.working_context_pct = 90;
+            registry
+                .record_context_budget(&session.id, &healthy)
+                .unwrap();
+
+            get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+                .await
+                .unwrap()
+        })
+        .await;
+
+        assert_eq!(
+            result["working_context_pct"], 90,
+            "the point-in-time snapshot alone still reads the healthy-looking latest turn"
+        );
+        assert_eq!(
+            result["working_context_pct_low_water_mark"], 48,
+            "the low-water mark must surface the real floor the snapshot alone hides"
+        );
+        assert_eq!(result["working_context_pct_sample_count"], 2);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A session with no durable telemetry samples yet reports `None`/`0`,
+    /// never a fabricated floor.
+    #[tokio::test]
+    async fn get_context_budget_floor_none_without_samples() {
+        let dir = telemetry_temp_dir("floor-none");
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let result = crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
+            registry
+                .record_context_budget(&session.id, &measurement())
+                .unwrap();
+            get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+                .await
+                .unwrap()
+        })
+        .await;
+
+        assert!(result["working_context_pct_low_water_mark"].is_null());
+        assert_eq!(result["working_context_pct_sample_count"], 0);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -247,6 +247,10 @@ impl SessionRegistry {
             // `get_context_budget` reads this field back out, and it always
             // overwrites it first.
             lifetime_compaction_alarm_count: 0,
+            // (#3912) Same placeholder contract as the field above —
+            // `get_context_budget` overwrites both before returning.
+            working_context_pct_low_water_mark: None,
+            working_context_pct_sample_count: 0,
         };
         {
             let mut sessions = self.lock();
@@ -295,10 +299,17 @@ impl SessionRegistry {
     /// once per query, not once per turn per session. This is also why the
     /// count reflects fires from ANY session on this machine, not just this
     /// one: it is derived from a shared log, not a per-session cache.
+    /// (#3912) `working_context_pct_low_water_mark`/
+    /// `working_context_pct_sample_count` are likewise read fresh here, from
+    /// the SAME durable log filtered to THIS session — the fix for the
+    /// load-realistic soak's finding that the cached snapshot above
+    /// (`working_context_pct`) can read 98-99% while this session's real
+    /// floor (durably recorded) was 48-60%.
     /// Test: `registry_tests::record_context_budget_caches_snapshot_for_late_query`,
     /// `protocol_budget::tests::get_context_budget_never_recorded_session_returns_never_recorded`,
     /// `registry_tests::get_context_budget_unknown_session_errors`,
-    /// `protocol_budget::tests::get_context_budget_reflects_lifetime_compaction_alarm_count`.
+    /// `protocol_budget::tests::get_context_budget_reflects_lifetime_compaction_alarm_count`,
+    /// `protocol_budget::tests::get_context_budget_reflects_working_context_floor`.
     pub fn get_context_budget(&self, id: &str) -> Result<ContextBudgetQuery, RpcError> {
         self.ensure_exists(id)?;
         Ok(self
@@ -306,10 +317,13 @@ impl SessionRegistry {
             .get(id)
             .and_then(|e| e.context_budget)
             .map(|mut snapshot| {
+                let data_dir = crate::agent_loop::telemetry::default_data_dir();
                 snapshot.lifetime_compaction_alarm_count =
-                    crate::agent_loop::telemetry::lifetime_compaction_alarm_count(
-                        &crate::agent_loop::telemetry::default_data_dir(),
-                    );
+                    crate::agent_loop::telemetry::lifetime_compaction_alarm_count(&data_dir);
+                let (low_water_mark, sample_count) =
+                    crate::agent_loop::telemetry::session_working_context_floor(&data_dir, id);
+                snapshot.working_context_pct_low_water_mark = low_water_mark;
+                snapshot.working_context_pct_sample_count = sample_count;
                 ContextBudgetQuery::Recorded(snapshot)
             })
             .unwrap_or(ContextBudgetQuery::NeverRecorded))


### PR DESCRIPTION
## Summary

The load-realistic compression soak (epic #3866, PR #3909) proved
`session.get_context_budget`'s cached `working_context_pct` can read
98-99% while the durable `compression.jsonl` telemetry recorded a real
floor of 48-60% for the SAME session in the SAME run. The RPC is a
coarse once-per-`task.run`-call snapshot; it reliably misses the turn
where the floor was lowest. An operator monitoring compression health
via this RPC alone had no way to detect a near-floor or already-breached
session — this is the observability gap issue #3912 tracks.

Closes #3912

## Root cause

`SessionRegistry::record_context_budget` caches only the MOST RECENT
`ContextBudgetSnapshot` per session (last-writer-wins). Every
cadence/threshold fire already writes its own `working_context_pct_after`
to the durable `compression.jsonl` (issue #3867), but nothing ever read
that history back — `session.get_context_budget` only ever returned the
latest point-in-time value, which can look healthy even while a real dip
happened moments earlier in the same call.

## Fix

- `agent_loop::telemetry::session_working_context_floor(data_dir,
  session_id)` — scans `compression.jsonl`, scoped to one session, and
  returns `(min working_context_pct_after, sample_count)`.
- Two new fields on `session.get_context_budget`'s response:
  `working_context_pct_low_water_mark` (`Option<u8>`) and
  `working_context_pct_sample_count` (`usize`), computed fresh at query
  time in `SessionRegistry::get_context_budget` — mirroring
  `lifetime_compaction_alarm_count`'s (#3868) existing "placeholder on
  the write path, real read on the query path" pattern exactly, for the
  same performance reason (the write path fires once per turn; the query
  path fires once per client poll).

## Validation — re-ran the load soak against this fix

**Primary profile (160/230/300KB, 35 calls, shipped default):**
- `working_context_pct` (snapshot): 99% → 98% throughout — still looks
  healthy, exactly reproducing the soak's original finding.
- `working_context_pct_low_water_mark`: settles at **60%** by the final
  call (122 samples) — matches the soak's documented 60% floor exactly.

**Exploratory profile (220/300/400KB, 20 calls, the breaching profile):**
- `working_context_pct` (snapshot): 99% → 98% throughout — again looks
  healthy.
- `working_context_pct_low_water_mark`: settles at **48%** (70 samples)
  — matches the soak's documented 48% breach exactly.

In both runs the low-water mark reflects the real floor from the FIRST
call onward (e.g. primary run's call 1 already reports a 61% low-water
mark against a 99% snapshot) — it is not a lagging or eventually-consistent
signal.

## Residual limits

- This PR is pure observability — it does not change compaction/cadence
  behavior at all. The floor can still be breached; this only makes the
  breach visible via the RPC that's already the front door for budget
  state. See #3911 (stacked on top of this branch) for the fallback/alarm
  half.
- The low-water mark is derived from `compression.jsonl`, which only
  gets a row from a cadence/threshold *fire* — a session with cadence
  disabled, or one that never fires (e.g. very short-lived), reports
  `None`/`0`, which is correct (no samples exist), not a bug.

## Test plan

- [x] `cargo test -p trusty-code` (full suite, not `--lib`): 1589 lib
      tests + all integration test binaries pass, 0 failed, 4 ignored.
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.
- [x] `scripts/check_line_cap.sh`: 8 allowlisted, 0 violations.
- [x] Re-ran `compression_load_soak.py` for both the primary and
      exploratory (`--payload-bytes 220000,300000,400000`) profiles
      against a real daemon and inspected `context_budget_samples.json`
      — see Validation above.
- [ ] `gh pr checks` (CI) — pending.

Refs #3866, #3909. Related: #3911 (stacked on top of this branch).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools