### PR TITLE
fix(trusty-code): durable backstop alarm for a cadence floor breach

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -24,6 +24,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `lifetime_compaction_alarm_count`'s existing "read fresh at query time"
   pattern exactly.
 
+- **A cadence-level 60%-floor breach now has a durable backstop alarm
+  (#3911).** The load-realistic soak (epic #3866, PR #3909) proved that
+  when `cadence::enforce_budget` exhausts every eligible entry and still
+  exceeds the overhead cap (a real guarantee violation — floor 48% in the
+  soak's exploratory run), NOTHING durable reacted: the #2308 threshold
+  compactor's own alarm (`lifetime_compaction_alarm_count`) stayed at 0
+  because it is keyed to a mechanically independent, laxer 75%-of-window
+  trigger cadence's own breach never crosses. Added
+  `agent_loop::telemetry::record_cadence_floor_breach` (writes a
+  `tcode-cadence-floor-breach` JSONL row plus a durable alarm line) and a
+  new `lifetime_cadence_floor_breach_count` field on
+  `session.get_context_budget`, elevated the prior in-process `warn!` to
+  `error!` at the call site. Re-running both `compression_load_soak.py`
+  profiles confirms the backstop now fires on every observed breach (2/2
+  in the primary run, 21/21 in the exploratory run) — see PR for the full
+  residual-limits discussion (this is an alarm, not additional
+  compaction capacity: the floor itself is unchanged).
+
+- `compression_report.py` now additionally reports the #3911 backstop's
+  own fire count in a dedicated section, flagging a floor breach with
+  zero backstop fires as a FINDING.
+
 ### Fixed
 
 - **`TurnCapExceeded` permanently un-resumed a session (#3888).** A

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -42,6 +42,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   residual-limits discussion (this is an alarm, not additional
   compaction capacity: the floor itself is unchanged).
 
+- **(#3911 post-review fix) The floor-breach JSONL row no longer
+  double-counts a real breach as two floor samples.** A breach writes BOTH
+  a `tcode-cadence` row (the real measurement) and a
+  `tcode-cadence-floor-breach` alarm row for the SAME turn; the breach row
+  previously also carried its own `working_context_pct_after`, so any
+  consumer aggregating "samples with a percentage" — `compression_report.py`'s
+  `compute_context_floor` and `session_working_context_floor` (#3912) alike
+  — counted one real breach twice (measured: 21 real breaches reported as
+  42 below-target samples). `record_cadence_floor_breach` now always writes
+  `None` for that field; the paired `tcode-cadence` row remains the one
+  authoritative sample. Corrected re-run: the exploratory profile now
+  correctly reports 21 below-target samples (not 42), matching the
+  original soak's finding.
+
 - `compression_report.py` now additionally reports the #3911 backstop's
   own fire count in a dedicated section, flagging a floor breach with
   zero backstop fires as a FINDING.

--- a/crates/trusty-code/scripts/compression_report.py
+++ b/crates/trusty-code/scripts/compression_report.py
@@ -42,6 +42,13 @@ from typing import Any
 
 SURFACE_CADENCE = "tcode-cadence"
 SURFACE_THRESHOLD = "tcode-threshold"
+# The #3911 cadence floor-breach backstop: a durable, alarm-worthy record of
+# `CadenceOutcome::within_budget == false` (cadence's OWN continuous
+# enforcement exhausted every eligible entry and still exceeded the overhead
+# cap) — mechanically distinct from `SURFACE_THRESHOLD` above (see
+# `agent_loop::telemetry::record_cadence_floor_breach`'s docs for why the two
+# alarms cannot be the same signal).
+SURFACE_CADENCE_FLOOR_BREACH = "tcode-cadence-floor-breach"
 
 # Epic #2343's stated success-metric thresholds.
 TARGET_MIN_WORKING_CONTEXT_PCT = 60
@@ -157,6 +164,22 @@ def compute_compaction_count(events: list[dict[str, Any]]) -> int:
     )
 
 
+def compute_floor_breach_count(events: list[dict[str, Any]]) -> int:
+    """Count of #3911 cadence floor-breach backstop fires
+    (`SURFACE_CADENCE_FLOOR_BREACH`).
+
+    Why: distinct from `compute_compaction_count` above — a floor breach
+    (cadence's OWN enforcement exhausted every eligible entry and still
+    exceeded the cap) is mechanically independent of a threshold-compactor
+    fire (a separate, laxer 75%-of-window trigger). Reporting this
+    separately answers "did the backstop actually engage on a real breach",
+    which `compute_context_floor`'s `below_target` list alone cannot: that
+    list is derived from measured percentages, not from whether anything
+    reacted to them.
+    """
+    return sum(1 for e in events if e.get("surface") == SURFACE_CADENCE_FLOOR_BREACH)
+
+
 def compute_surface_counts(events: list[dict[str, Any]]) -> dict[str, int]:
     """Event count per `surface` value, for the report's overview table."""
     counts: dict[str, int] = {}
@@ -200,6 +223,7 @@ def render_markdown(
     ratio_stats: dict[str, float] | None,
     context_floor: dict[str, Any],
     compaction_count: int,
+    floor_breach_count: int,
     surface_counts: dict[str, int],
     verdict_pass: bool,
     verdict_reason: str,
@@ -287,6 +311,35 @@ def render_markdown(
         lines.append("0 threshold-compaction events fired. Target met.")
     lines.append("")
 
+    lines.append("## Cadence floor-breach backstop (`tcode-cadence-floor-breach`, issue #3911)")
+    lines.append("")
+    lines.append(
+        "Distinct from the threshold-compaction signal above: this counts "
+        "the #3911 backstop, which fires when cadence's OWN continuous "
+        "budget enforcement exhausts every eligible entry and still exceeds "
+        "the overhead cap — i.e. it answers \"did something durable react "
+        "to the floor breach\", not just \"was the floor breached\" (the "
+        "Working-context floor section above already answers that)."
+    )
+    lines.append("")
+    if context_floor["below_target"] and floor_breach_count == 0:
+        lines.append(
+            f"**FINDING: the floor was breached at "
+            f"{len(context_floor['below_target'])} sample(s) but the backstop "
+            "fired 0 times.** The backstop is not engaging on a real breach."
+        )
+    elif floor_breach_count > 0:
+        lines.append(
+            f"{floor_breach_count} backstop fire(s) recorded — the backstop "
+            "engaged on the observed floor breach(es)."
+        )
+    else:
+        lines.append(
+            "0 backstop fires recorded, and the floor never dropped below "
+            "target — consistent (nothing to catch)."
+        )
+    lines.append("")
+
     return "\n".join(lines)
 
 
@@ -297,6 +350,7 @@ def build_report(
     ratio_stats = compute_ratio_stats(events)
     context_floor = compute_context_floor(events)
     compaction_count = compute_compaction_count(events)
+    floor_breach_count = compute_floor_breach_count(events)
     surface_counts = compute_surface_counts(events)
     verdict_pass, verdict_reason = compute_verdict(context_floor, compaction_count)
     markdown = render_markdown(
@@ -306,6 +360,7 @@ def build_report(
         ratio_stats=ratio_stats,
         context_floor=context_floor,
         compaction_count=compaction_count,
+        floor_breach_count=floor_breach_count,
         surface_counts=surface_counts,
         verdict_pass=verdict_pass,
         verdict_reason=verdict_reason,

--- a/crates/trusty-code/scripts/compression_report_test.py
+++ b/crates/trusty-code/scripts/compression_report_test.py
@@ -130,6 +130,45 @@ class CompactionCountTests(unittest.TestCase):
         self.assertEqual(cr.compute_compaction_count(events), 0)
 
 
+def floor_breach_event(session_id="s1"):
+    """A #3911 cadence floor-breach backstop record — mechanically distinct
+    from `threshold_event` above (different surface, same `compaction_event:
+    True` alarm-worthy shape)."""
+    return {
+        "ts": "2026-07-25T00:00:00Z",
+        "session_id": session_id,
+        "surface": cr.SURFACE_CADENCE_FLOOR_BREACH,
+        "surface_detail": "cadence-floor-breach",
+        "tokens_before": 200_000,
+        "tokens_after": 104_000,
+        "ratio": 0.52,
+        "working_context_pct_after": 48,
+        "overhead_pct_after": 52,
+        "compaction_event": True,
+        "duration_ms": 6,
+        "rounds": 7,
+    }
+
+
+class FloorBreachCountTests(unittest.TestCase):
+    """Issue #3911: the backstop's own fire count must be a DISTINCT signal
+    from `compute_compaction_count` (the threshold-compactor's count) —
+    neither surface's rows may be double-counted as the other's."""
+
+    def test_counts_only_floor_breach_surface(self):
+        events = [
+            floor_breach_event(),
+            threshold_event(True),  # different surface — not counted
+            cadence_event(0.8, 90),  # different surface — not counted
+        ]
+        self.assertEqual(cr.compute_floor_breach_count(events), 1)
+        self.assertEqual(cr.compute_compaction_count(events), 1)
+
+    def test_zero_when_no_floor_breach_events(self):
+        events = [cadence_event(0.8, 90), threshold_event(True)]
+        self.assertEqual(cr.compute_floor_breach_count(events), 0)
+
+
 class VerdictTests(unittest.TestCase):
     def test_pass_when_both_targets_met(self):
         events = [cadence_event(0.8, 90), cadence_event(0.8, 75)]
@@ -218,6 +257,44 @@ class RenderMarkdownTests(unittest.TestCase):
             markdown, verdict_pass = cr.build_report(path, session_id=None)
             self.assertFalse(verdict_pass)
             self.assertIn("FAIL", markdown)
+        finally:
+            path.unlink()
+
+    def test_report_flags_a_breach_the_backstop_never_caught(self):
+        """Issue #3911's core reporting acceptance criterion: a floor breach
+        with ZERO backstop fires must be called out explicitly — this is
+        exactly what the original soak (pre-#3911) observed."""
+        import json
+        import tempfile
+
+        events = [cadence_event(0.8, 90), cadence_event(0.8, 48)]  # breach, no backstop row
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as f:
+            for e in events:
+                f.write(json.dumps(e) + "\n")
+            path = Path(f.name)
+        try:
+            markdown, _ = cr.build_report(path, session_id=None)
+            self.assertIn("FINDING", markdown)
+            self.assertIn("backstop fired 0 times", markdown)
+        finally:
+            path.unlink()
+
+    def test_report_confirms_backstop_engaged_on_a_breach(self):
+        import json
+        import tempfile
+
+        events = [cadence_event(0.8, 90), cadence_event(0.8, 48), floor_breach_event()]
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False
+        ) as f:
+            for e in events:
+                f.write(json.dumps(e) + "\n")
+            path = Path(f.name)
+        try:
+            markdown, _ = cr.build_report(path, session_id=None)
+            self.assertIn("1 backstop fire(s) recorded", markdown)
         finally:
             path.unlink()
 

--- a/crates/trusty-code/scripts/compression_report_test.py
+++ b/crates/trusty-code/scripts/compression_report_test.py
@@ -114,6 +114,28 @@ class WorkingContextFloorTests(unittest.TestCase):
         floor = cr.compute_context_floor(events)
         self.assertEqual(floor["sample_count"], 1)
 
+    def test_floor_breach_row_does_not_double_count_a_real_breach(self):
+        """Regression test for the exact bug a code-review pass caught: a
+        floor breach writes BOTH a `tcode-cadence` row (the real
+        measurement) AND a `tcode-cadence-floor-breach` alarm row for the
+        SAME turn. Before the fix, the breach row also carried
+        `working_context_pct_after`, so `compute_context_floor` scored the
+        one real breach TWICE (a soak run with 21 real breaches reported 42
+        below-target samples). `floor_breach_event()`'s `None` percentages
+        (matching the fixed production behavior) must collapse this back to
+        exactly one sample per breach."""
+        events = [
+            cadence_event(0.8, 90),
+            cadence_event(0.8, 48),  # the one real breach measurement
+            floor_breach_event(),  # paired alarm row for the SAME turn
+        ]
+        floor = cr.compute_context_floor(events)
+        self.assertEqual(floor["sample_count"], 2, "not 3 — the breach row adds no sample")
+        self.assertEqual(
+            len(floor["below_target"]), 1, "not 2 — the one real breach, counted once"
+        )
+        self.assertEqual(floor["min_pct"], 48)
+
 
 class CompactionCountTests(unittest.TestCase):
     def test_counts_only_true_compaction_events(self):
@@ -133,7 +155,15 @@ class CompactionCountTests(unittest.TestCase):
 def floor_breach_event(session_id="s1"):
     """A #3911 cadence floor-breach backstop record — mechanically distinct
     from `threshold_event` above (different surface, same `compaction_event:
-    True` alarm-worthy shape)."""
+    True` alarm-worthy shape).
+
+    `working_context_pct_after`/`overhead_pct_after` are `None`, matching
+    production (`telemetry::record_cadence_floor_breach`, post-review fix):
+    the paired `tcode-cadence` row from the SAME turn already carries the
+    one real measurement — populating it here too would double-count a
+    single breach as two floor samples (the exact bug a code-review pass
+    caught: a soak run with 21 real breaches reported 42 below-target
+    samples before this fix)."""
     return {
         "ts": "2026-07-25T00:00:00Z",
         "session_id": session_id,
@@ -142,8 +172,8 @@ def floor_breach_event(session_id="s1"):
         "tokens_before": 200_000,
         "tokens_after": 104_000,
         "ratio": 0.52,
-        "working_context_pct_after": 48,
-        "overhead_pct_after": 52,
+        "working_context_pct_after": None,
+        "overhead_pct_after": None,
         "compaction_event": True,
         "duration_ms": 6,
         "rounds": 7,

--- a/crates/trusty-code/src/agent_loop/compaction_control.rs
+++ b/crates/trusty-code/src/agent_loop/compaction_control.rs
@@ -170,16 +170,39 @@ impl AgentLoop {
     /// this now emits `tracing::info!` with the round count and whether the
     /// transcript ended within budget — a notable-but-normal event (routine
     /// scheduled compression), not a failure, hence `info` rather than
-    /// `warn`. The budget-floor-exceeded case is already `warn!`-logged
-    /// inside `cadence::enforce_budget` itself. The SAME outcome is also
-    /// forwarded to `self.sink` (when one is attached) as a
-    /// [`ContextBudgetSnapshot`], so a `session.attach`ed UI can render a live
-    /// budget indicator. Emission sits AFTER both guards above, which is what
-    /// keeps it PM-only for free: only `task::executor::run_and_record`'s
-    /// persistent-session PM loop sets `cadence: Some(_)`, so a delegated
-    /// engineer loop never emits. (#3867) ALSO — only when
-    /// `outcome.rounds > 0` (compaction work actually happened this turn) —
-    /// writes a durable `telemetry::record_cadence_event` JSONL record.
+    /// `warn`. The SAME outcome is also forwarded to `self.sink` (when one
+    /// is attached) as a [`ContextBudgetSnapshot`], so a `session.attach`ed
+    /// UI can render a live budget indicator. Emission sits AFTER both
+    /// guards above, which is what keeps it PM-only for free: only
+    /// `task::executor::run_and_record`'s persistent-session PM loop sets
+    /// `cadence: Some(_)`, so a delegated engineer loop never emits. (#3867)
+    /// ALSO — only when `outcome.rounds > 0` (compaction work actually
+    /// happened this turn) — writes a durable `telemetry::record_cadence_event`
+    /// JSONL record.
+    /// (#3911) `cadence::enforce_budget`'s budget-floor-exceeded case
+    /// (`!outcome.within_budget` — the active zone shrunk to zero, still
+    /// over the overhead cap) was previously ONLY `warn!`-logged from deep
+    /// inside that function: no durable record, no counter, and not the
+    /// same alarm the #2308 threshold compactor's own breach uses (that
+    /// alarm's trigger is a mechanically independent, laxer 75%-of-window
+    /// bound — see `telemetry::record_cadence_floor_breach`'s docs for why
+    /// it can miss a cadence-level breach entirely, which the load-realistic
+    /// soak, epic #3866 PR #3909, proved happens: a measured 48% floor
+    /// breach with zero threshold events and zero alarm-count increments).
+    /// When `!outcome.within_budget`, this now ALSO emits `tracing::error!`
+    /// (elevated from the prior `warn!` — a floor breach is the epic's
+    /// stated guarantee being violated, not a routine event) and writes a
+    /// durable `telemetry::record_cadence_floor_breach` JSONL record plus
+    /// alarm line, unconditionally (this call site is cadence-enabled-only
+    /// by construction — see the guard above). This does NOT attempt any
+    /// additional compaction: `enforce_budget` already shrank the active
+    /// zone to zero and re-compacted at every step, so nothing further is
+    /// evictable without violating the pinned/system/user preservation
+    /// invariant `Transcript::mark_compacted` enforces — the residual floor
+    /// here is structural (typically a single turn's own oversized
+    /// tool-call argument), not a tuning gap this alarm can close by
+    /// itself. It makes the breach OBSERVABLE and COUNTABLE, which is what
+    /// #3911 asks for; see that issue for the full design rationale.
     /// Test: `agent_loop::tests::cadence_disabled_by_default`,
     /// `agent_loop::tests::cadence_never_fires_in_parity_mode`,
     /// `agent_loop::tests::cadence_fires_in_daily_driver_when_configured`,
@@ -187,7 +210,9 @@ impl AgentLoop {
     /// `agent_loop::tests::cadence_emits_context_budget_snapshot`,
     /// `agent_loop::tests::no_context_budget_event_when_cadence_disabled`,
     /// `agent_loop::tests::compression_telemetry_tests::cadence_fire_writes_compression_telemetry`,
-    /// `agent_loop::tests::compression_telemetry_tests::cadence_disabled_writes_no_cadence_telemetry`.
+    /// `agent_loop::tests::compression_telemetry_tests::cadence_disabled_writes_no_cadence_telemetry`,
+    /// `agent_loop::tests::compression_telemetry_tests::cadence_floor_breach_writes_alarm_and_error_log`,
+    /// `agent_loop::tests::compression_telemetry_tests::cadence_within_budget_never_writes_floor_breach_alarm`.
     pub(super) async fn maybe_cadence_compress(&self, transcript: &mut Transcript) {
         if self.config.mode != HarnessMode::DailyDriver {
             return;
@@ -214,6 +239,33 @@ impl AgentLoop {
 
         if outcome.rounds > 0 {
             telemetry::record_cadence_event(
+                &self.telemetry_data_dir(),
+                self.session_id.clone(),
+                tokens_before,
+                outcome.overhead_tokens,
+                context_window,
+                started.elapsed().as_millis() as u64,
+                outcome.rounds,
+            );
+        }
+
+        // (#3911) The backstop: a cadence-level floor breach is a violation
+        // of epic #2343's stated guarantee, not a routine event — make it
+        // durable and countable instead of an in-process-only `warn!` (see
+        // `cadence::enforce_budget`'s own log, still emitted there too).
+        if !outcome.within_budget {
+            tracing::error!(
+                working_context_pct = outcome.working_context_pct(context_window),
+                overhead_tokens = outcome.overhead_tokens,
+                overhead_cap_tokens = cadence_cfg.overhead_cap_tokens(context_window),
+                rounds = outcome.rounds,
+                "cadence: working-context floor breached even after continuous budget \
+                 enforcement exhausted every eligible entry — epic #2343's 60% guarantee is \
+                 violated this turn (issue #3911). No further eviction-based compaction is \
+                 possible: the active zone (pinned + system/user + the current turn-group) \
+                 alone exceeds the overhead cap."
+            );
+            telemetry::record_cadence_floor_breach(
                 &self.telemetry_data_dir(),
                 self.session_id.clone(),
                 tokens_before,

--- a/crates/trusty-code/src/agent_loop/compression_telemetry_tests.rs
+++ b/crates/trusty-code/src/agent_loop/compression_telemetry_tests.rs
@@ -344,3 +344,145 @@ async fn unwritable_data_dir_does_not_fail_the_loop() {
          by telemetry write failures"
     );
 }
+
+// ── #3911: cadence floor-breach backstop ────────────────────────────────────
+
+/// A genuine cadence-level 60%-floor breach — `cadence::enforce_budget`
+/// exhausts every eligible entry (the huge seeded task alone, which is
+/// `user`-role and therefore NEVER compacted, exceeds a deliberately tiny
+/// cap) — now writes the durable `tcode-cadence-floor-breach` JSONL record
+/// AND the alarm log, AND emits an `ERROR`-level log, end to end through
+/// `AgentLoop::maybe_cadence_compress`. Mirrors
+/// `agent_loop::tests::cadence::forced_degradation_increments_counter_and_logs_error`'s
+/// shape (real loop run, not a bare `cadence::maybe_cadence_compress` unit
+/// call) for the SAME reason: this is the acceptance criterion that the
+/// signal fires through the actual turn boundary, not just at the pure
+/// `cadence` module level (`cadence_tests::floor_exceeded_warns_not_panics`
+/// already covers that unit).
+///
+/// Why: before #3911, this exact scenario — proven by the load-realistic
+/// soak (epic #3866, PR #3909) to occur under heavy real-world load
+/// (floor 48%) — produced ZERO durable signal anywhere:
+/// `lifetime_compaction_alarm_count` stayed 0 (that alarm is keyed to the
+/// mechanically-independent threshold compactor, which this scenario never
+/// crosses — see `telemetry::record_cadence_floor_breach`'s docs), and the
+/// only trace was an in-process `tracing::warn!` inside
+/// `cadence::enforce_budget`. This test pins the fix.
+#[tokio::test]
+async fn cadence_floor_breach_writes_alarm_and_error_log() {
+    crate::test_support::begin_capture();
+
+    let dir = telemetry::test_temp_dir("floor-breach");
+    let fixtures: Vec<Value> = vec![stop_response("all done")];
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            max_turns: 10,
+            mode: crate::mode::HarnessMode::DailyDriver,
+            cadence: Some(CadenceConfig {
+                cadence_turns: 1,
+                max_overhead_fraction_pct: 1, // trivially tiny cap
+            }),
+            telemetry_data_dir: Some(dir.clone()),
+            ..AgentLoopConfig::default()
+        },
+    );
+    // A huge `user`-role seed: never eligible for compaction (system/user
+    // exemption), so it alone blows the tiny cap above no matter how hard
+    // `enforce_budget` shrinks the active zone — the documented,
+    // structural floor this backstop is about, not a tuning gap.
+    let mut transcript = Transcript::seed("system prompt", &"x".repeat(200_000));
+
+    agent
+        .run_with_transcript(&mut transcript, "the task")
+        .await
+        .expect("run completes even through a floor breach");
+
+    let messages = crate::test_support::captured_at_least(tracing::Level::ERROR);
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.contains("floor breached") && m.contains("cadence")),
+        "expected an error-level floor-breach log, got: {messages:?}"
+    );
+
+    let events = read_jsonl(&dir);
+    let breach_events: Vec<_> = events
+        .iter()
+        .filter(|e| e.surface == telemetry::SURFACE_TCODE_CADENCE_FLOOR_BREACH)
+        .collect();
+    assert!(
+        !breach_events.is_empty(),
+        "expected at least one tcode-cadence-floor-breach JSONL line, got {events:?}"
+    );
+    for e in &breach_events {
+        assert!(
+            e.compaction_event,
+            "a floor breach is alarm-worthy: compaction_event must be true: {e:?}"
+        );
+    }
+
+    assert!(
+        telemetry::lifetime_cadence_floor_breach_count(&dir) >= 1,
+        "a cadence floor breach must record the durable alarm line"
+    );
+    assert_eq!(
+        telemetry::lifetime_compaction_alarm_count(&dir),
+        0,
+        "the cadence floor-breach alarm must be a DISTINCT counter from the \
+         threshold-under-cadence alarm — this scenario never touches the \
+         threshold compactor at all"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The regression guard: a normal run that stays within budget the whole
+/// time must never write the floor-breach alarm or JSONL surface.
+#[tokio::test]
+async fn cadence_within_budget_never_writes_floor_breach_alarm() {
+    let dir = telemetry::test_temp_dir("floor-no-breach");
+    let mut fixtures: Vec<Value> = (0..3)
+        .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+        .collect();
+    fixtures.push(stop_response("all done"));
+    let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+    let registry = registry_with_echo(false);
+
+    let agent = make_loop(
+        llm,
+        registry,
+        AgentLoopConfig {
+            cadence: Some(CadenceConfig {
+                cadence_turns: 1,
+                ..CadenceConfig::default()
+            }),
+            telemetry_data_dir: Some(dir.clone()),
+            ..AgentLoopConfig::default()
+        },
+    );
+
+    agent
+        .run("system prompt", "a small task")
+        .await
+        .expect("run completes");
+
+    let events = read_jsonl(&dir);
+    assert!(
+        events
+            .iter()
+            .all(|e| e.surface != telemetry::SURFACE_TCODE_CADENCE_FLOOR_BREACH),
+        "a healthy run must never write the floor-breach surface: {events:?}"
+    );
+    assert_eq!(
+        telemetry::lifetime_cadence_floor_breach_count(&dir),
+        0,
+        "a healthy run must never increment the floor-breach alarm"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/crates/trusty-code/src/agent_loop/telemetry.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry.rs
@@ -31,11 +31,17 @@ use std::path::{Path, PathBuf};
 pub const SURFACE_TCODE_CADENCE: &str = "tcode-cadence";
 /// [`CompressionEvent::surface`] value for the #2308 threshold compactor.
 pub const SURFACE_TCODE_THRESHOLD: &str = "tcode-threshold";
+/// [`CompressionEvent::surface`] value for a #3911 cadence floor-breach
+/// backstop fire — see [`record_cadence_floor_breach`].
+pub const SURFACE_TCODE_CADENCE_FLOOR_BREACH: &str = "tcode-cadence-floor-breach";
 
 /// `surface_detail` used for every [`SURFACE_TCODE_CADENCE`] record.
 pub const DETAIL_CADENCE: &str = "cadence";
 /// `surface_detail` used for every [`SURFACE_TCODE_THRESHOLD`] record.
 pub const DETAIL_THRESHOLD: &str = "threshold";
+/// `surface_detail` used for every [`SURFACE_TCODE_CADENCE_FLOOR_BREACH`]
+/// record.
+pub const DETAIL_CADENCE_FLOOR_BREACH: &str = "cadence-floor-breach";
 
 /// Filename of the durable compression-telemetry JSONL, under whatever data
 /// directory the caller resolves (production: `crate::workstreams::
@@ -45,6 +51,14 @@ const COMPRESSION_LOG_FILENAME: &str = "compression.jsonl";
 /// Filename of Slice B's durable compaction-alarm log, one line per
 /// `cadence: Some(_)` threshold-compaction fire.
 const COMPACTION_ALARM_LOG_FILENAME: &str = "compaction_alarm.log";
+
+/// Filename of the #3911 durable cadence floor-breach alarm log, one line
+/// per turn `cadence::enforce_budget` exhausted every eligible entry and
+/// STILL exceeded the overhead cap (`CadenceOutcome::within_budget ==
+/// false`) — the never-event alarm for a cadence-level 60%-floor breach,
+/// mirroring [`COMPACTION_ALARM_LOG_FILENAME`]'s identical append-only
+/// design but for the cadence backstop rather than the threshold one.
+const CADENCE_FLOOR_BREACH_ALARM_LOG_FILENAME: &str = "cadence_floor_breach_alarm.log";
 
 /// Escape-hatch env var overriding [`default_data_dir`] for one process,
 /// mirroring `cadence::CADENCE_TURNS_ENV_VAR`'s precedent. Test-only in
@@ -158,6 +172,11 @@ pub fn compaction_alarm_log_path(data_dir: &Path) -> PathBuf {
     data_dir.join(COMPACTION_ALARM_LOG_FILENAME)
 }
 
+/// Resolve `<data_dir>/cadence_floor_breach_alarm.log` (issue #3911).
+pub fn cadence_floor_breach_alarm_log_path(data_dir: &Path) -> PathBuf {
+    data_dir.join(CADENCE_FLOOR_BREACH_ALARM_LOG_FILENAME)
+}
+
 /// Append `event` as one JSONL line to `<data_dir>/compression.jsonl`.
 ///
 /// Why: emission must never fail the compaction/cadence operation it
@@ -246,6 +265,68 @@ pub fn record_compaction_alarm(data_dir: &Path) {
 /// `tests::lifetime_compaction_alarm_count_matches_fire_count`.
 pub fn lifetime_compaction_alarm_count(data_dir: &Path) -> u64 {
     let path = compaction_alarm_log_path(data_dir);
+    let Ok(file) = std::fs::File::open(&path) else {
+        return 0;
+    };
+    std::io::BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|l| !l.trim().is_empty())
+        .count() as u64
+}
+
+/// Append one line to `<data_dir>/cadence_floor_breach_alarm.log`, recording
+/// that `cadence::enforce_budget` exhausted every eligible entry and STILL
+/// exceeded the overhead cap this turn (issue #3911's backstop).
+///
+/// Why: before this, a cadence-level 60%-floor breach produced only an
+/// in-process `tracing::warn!` inside `cadence::enforce_budget` — invisible
+/// outside stderr, never durable, never counted. The load-realistic soak
+/// (epic #3866, PR #3909) proved this breach can and does happen under
+/// heavy load (floor 48%) while EVERY other alarm signal
+/// (`lifetime_compaction_alarm_count`, `TranscriptRecord.compaction_events`)
+/// stayed at 0 — because those signals watch the THRESHOLD compactor, a
+/// mechanically independent trigger cadence's own floor breach never
+/// crosses (see [`record_cadence_floor_breach`]'s docs for why). This is
+/// the durable signal that closes that gap. Same append-only,
+/// count-by-lines design as [`record_compaction_alarm`] for the identical
+/// reason: concurrent fires from different sessions can never race each
+/// other into a lost increment.
+/// What: best-effort, matching [`write_compression_event`]'s failure
+/// posture.
+/// Test: `tests::record_cadence_floor_breach_alarm_appends_one_line_per_call`,
+/// `tests::record_cadence_floor_breach_alarm_unwritable_dir_does_not_panic`.
+pub fn record_cadence_floor_breach_alarm(data_dir: &Path) {
+    let _ = std::fs::create_dir_all(data_dir);
+    let path = cadence_floor_breach_alarm_log_path(data_dir);
+    let line = format!("{}\n", chrono::Utc::now().to_rfc3339());
+    match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(mut f) => {
+            if let Err(e) = f.write_all(line.as_bytes()) {
+                tracing::debug!(error = %e, path = %path.display(), "cadence floor-breach alarm: write failed");
+                return;
+            }
+            let _ = f.flush();
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, path = %path.display(), "cadence floor-breach alarm: open failed");
+        }
+    }
+}
+
+/// Count how many times [`record_cadence_floor_breach_alarm`] has ever
+/// fired for `data_dir` — the lifetime, cross-session, cross-restart alarm
+/// count exposed on `session.get_context_budget` as
+/// `lifetime_cadence_floor_breach_count` (issue #3911).
+///
+/// What: `0` when the file is missing or unreadable (the common,
+/// never-event case); otherwise the number of non-empty lines. Mirrors
+/// [`lifetime_compaction_alarm_count`]'s identical read-fresh-from-disk
+/// contract.
+/// Test: `tests::lifetime_cadence_floor_breach_count_zero_when_missing`,
+/// `tests::lifetime_cadence_floor_breach_count_matches_fire_count`.
+pub fn lifetime_cadence_floor_breach_count(data_dir: &Path) -> u64 {
+    let path = cadence_floor_breach_alarm_log_path(data_dir);
     let Ok(file) = std::fs::File::open(&path) else {
         return 0;
     };
@@ -406,6 +487,68 @@ pub fn record_cadence_event(
             rounds,
         ),
     );
+}
+
+/// Build and emit the [`SURFACE_TCODE_CADENCE_FLOOR_BREACH`] telemetry
+/// record plus the durable [`record_cadence_floor_breach_alarm`] line, for
+/// one `AgentLoop::maybe_cadence_compress` call whose
+/// `CadenceOutcome::within_budget` was `false` (issue #3911).
+///
+/// Why: `cadence::enforce_budget`'s own "documented floor" case (active
+/// zone shrunk to zero, still over the overhead cap) previously only
+/// logged `tracing::warn!` from deep inside that function — no durable
+/// record, no counter, and critically NOT the same alarm the #2308
+/// threshold compactor's OWN breach uses
+/// (`record_threshold_event`/`lifetime_compaction_alarm_count`), because
+/// that alarm is keyed to a MECHANICALLY INDEPENDENT trigger: threshold
+/// fires only once the raw transcript crosses 75% of the context window
+/// (`CompactionConfig::for_context_window`), a laxer bound than cadence's
+/// own 40%-overhead enforcement cap — so by the time cadence has already
+/// compacted as hard as it structurally can (`enforce_budget` shrinks the
+/// active zone to zero, re-compacting at every step) and still exceeds
+/// its OWN cap, the transcript is nowhere near threshold's separate,
+/// higher bound. The load-realistic soak (epic #3866, PR #3909) proved
+/// this empirically: a 48% floor breach produced zero threshold events,
+/// zero alarm-count increments, and zero visible signal anywhere but a
+/// stderr line. This function is the durable, countable trigger that
+/// closes that gap — always called (unconditionally, unlike
+/// `record_threshold_event`'s cadence-gated alarm) because this call site
+/// only exists on the cadence-enabled path in the first place
+/// (`AgentLoop::maybe_cadence_compress` already returns early when
+/// `self.config.cadence` is `None`).
+/// What: writes a `compaction_event: true` JSONL row (this genuinely IS an
+/// alarm-worthy event — the same semantic `record_threshold_event` uses
+/// `true` for) tagged `surface: "tcode-cadence-floor-breach"`, then
+/// unconditionally appends the durable alarm line.
+/// Test: `tests::record_cadence_floor_breach_writes_jsonl_and_alarm`.
+#[allow(clippy::too_many_arguments)]
+pub fn record_cadence_floor_breach(
+    data_dir: &Path,
+    session_id: Option<String>,
+    tokens_before: usize,
+    tokens_after: usize,
+    context_window: usize,
+    duration_ms: u64,
+    rounds: usize,
+) {
+    let (working_context_pct_after, overhead_pct_after) =
+        context_pcts(tokens_after, context_window);
+    write_compression_event(
+        data_dir,
+        &CompressionEvent::new(
+            session_id,
+            SURFACE_TCODE_CADENCE_FLOOR_BREACH,
+            DETAIL_CADENCE_FLOOR_BREACH,
+            tokens_before,
+            tokens_after,
+            working_context_pct_after,
+            overhead_pct_after,
+            true,
+            duration_ms,
+            rounds,
+        ),
+    );
+    record_cadence_floor_breach_alarm(data_dir);
 }
 
 /// Test-only helper: run `f` with [`DATA_DIR_ENV_VAR`] pointed at `dir`,

--- a/crates/trusty-code/src/agent_loop/telemetry.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry.rs
@@ -520,19 +520,45 @@ pub fn record_cadence_event(
 /// alarm-worthy event — the same semantic `record_threshold_event` uses
 /// `true` for) tagged `surface: "tcode-cadence-floor-breach"`, then
 /// unconditionally appends the durable alarm line.
-/// Test: `tests::record_cadence_floor_breach_writes_jsonl_and_alarm`.
+///
+/// (post-review fix, issue #3911) `working_context_pct_after`/
+/// `overhead_pct_after` are ALWAYS `None` on this row, deliberately — NOT
+/// derived from `tokens_after`/`context_window` the way every other
+/// surface's percentages are. Why: `AgentLoop::maybe_cadence_compress`
+/// calls [`record_cadence_event`] unconditionally whenever `outcome.rounds
+/// > 0` (which every floor breach satisfies — `enforce_budget` always ran
+/// at least one round to reach `within_budget: false`) BEFORE this
+/// function, for the exact same turn, with the exact same
+/// `outcome.overhead_tokens`/`context_window`. Computing the percentage
+/// here too would write a SECOND row carrying an IDENTICAL
+/// `working_context_pct_after` for one real measurement — exactly the
+/// double-count a code-review pass caught: `compression_report.py`'s
+/// `compute_context_floor` (and this crate's own
+/// `session_working_context_floor`, issue #3912) aggregate every row with
+/// a non-`None` percentage with no surface-based dedup, so a single
+/// breach was being counted TWICE toward the observed floor (measured: a
+/// soak run with 21 real breaches reported 42 below-target samples).
+/// Leaving these `None` here is the single-point fix: every existing and
+/// future consumer that filters on "has a working_context_pct_after
+/// sample" — not just this function's two current call sites — inherits
+/// the fix for free, rather than requiring each one to separately learn to
+/// exclude this surface. The paired `tcode-cadence` row is the ONE
+/// authoritative percentage sample for this turn; this row's job is only
+/// to durably flag THAT a breach happened (`compaction_event: true`,
+/// `tokens_before`/`tokens_after`/`rounds` are still real and useful for
+/// debugging), not to re-report the same number under a second surface.
+/// Test: `tests::record_cadence_floor_breach_writes_jsonl_and_alarm`,
+/// `tests::record_cadence_floor_breach_never_double_counts_the_floor`.
 #[allow(clippy::too_many_arguments)]
 pub fn record_cadence_floor_breach(
     data_dir: &Path,
     session_id: Option<String>,
     tokens_before: usize,
     tokens_after: usize,
-    context_window: usize,
+    _context_window: usize,
     duration_ms: u64,
     rounds: usize,
 ) {
-    let (working_context_pct_after, overhead_pct_after) =
-        context_pcts(tokens_after, context_window);
     write_compression_event(
         data_dir,
         &CompressionEvent::new(
@@ -541,8 +567,8 @@ pub fn record_cadence_floor_breach(
             DETAIL_CADENCE_FLOOR_BREACH,
             tokens_before,
             tokens_after,
-            working_context_pct_after,
-            overhead_pct_after,
+            None,
+            None,
             true,
             duration_ms,
             rounds,

--- a/crates/trusty-code/src/agent_loop/telemetry_tests.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry_tests.rs
@@ -243,13 +243,62 @@ fn record_cadence_floor_breach_writes_jsonl_and_alarm() {
         event.compaction_event,
         "a floor breach is unconditionally alarm-worthy"
     );
-    assert_eq!(event.working_context_pct_after, Some(48));
+    assert_eq!(
+        event.working_context_pct_after, None,
+        "the floor-breach row must NEVER carry its own percentage — the \
+         paired tcode-cadence row already does, and double-reporting it \
+         double-counts the same breach toward the floor (issue #3911 \
+         post-review fix)"
+    );
+    assert_eq!(event.overhead_pct_after, None);
 
     assert_eq!(
         lifetime_cadence_floor_breach_count(&dir),
         1,
         "the durable alarm line must always accompany the JSONL record"
     );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Regression test for the exact double-count a code-review pass caught:
+/// `AgentLoop::maybe_cadence_compress` calls `record_cadence_event`
+/// unconditionally (whenever `outcome.rounds > 0`, which every breach
+/// satisfies) THEN `record_cadence_floor_breach` for the SAME turn, with
+/// the SAME `tokens_after`/`context_window`. Any consumer that counts
+/// "samples with a `working_context_pct_after`" — `compression_report.py`'s
+/// `compute_context_floor`, and this crate's own
+/// `session_working_context_floor` (issue #3912) — must see exactly ONE
+/// such sample per real breach, not two.
+#[test]
+fn record_cadence_floor_breach_never_double_counts_the_floor() {
+    let dir = temp_dir("floor-breach-no-double-count");
+    // Mirrors the real call order at one turn boundary: the paired
+    // tcode-cadence record first, then the floor-breach alarm.
+    record_cadence_event(&dir, Some("s".to_string()), 200_000, 104_000, 200_000, 5, 7);
+    record_cadence_floor_breach(&dir, Some("s".to_string()), 200_000, 104_000, 200_000, 5, 7);
+
+    let events = read_lines(&compression_log_path(&dir))
+        .iter()
+        .map(|l| serde_json::from_str::<CompressionEvent>(l).unwrap())
+        .collect::<Vec<_>>();
+    let with_pct = events
+        .iter()
+        .filter(|e| e.working_context_pct_after.is_some())
+        .count();
+    assert_eq!(
+        with_pct, 1,
+        "exactly one row from this turn may carry a working_context_pct_after \
+         sample — the paired tcode-cadence row — not both: {events:?}"
+    );
+
+    let (min_pct, sample_count) = session_working_context_floor(&dir, "s");
+    assert_eq!(min_pct, Some(48));
+    assert_eq!(
+        sample_count, 1,
+        "session_working_context_floor (issue #3912) must not double-count \
+         a single breach as two samples"
+    );
+
     std::fs::remove_dir_all(&dir).ok();
 }
 

--- a/crates/trusty-code/src/agent_loop/telemetry_tests.rs
+++ b/crates/trusty-code/src/agent_loop/telemetry_tests.rs
@@ -177,6 +177,82 @@ fn lifetime_compaction_alarm_count_matches_fire_count() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
+// -- cadence floor-breach alarm (issue #3911) --
+
+#[test]
+fn record_cadence_floor_breach_alarm_appends_one_line_per_call() {
+    let dir = temp_dir("floor-breach-alarm-append");
+    assert_eq!(lifetime_cadence_floor_breach_count(&dir), 0);
+
+    record_cadence_floor_breach_alarm(&dir);
+    assert_eq!(lifetime_cadence_floor_breach_count(&dir), 1);
+
+    record_cadence_floor_breach_alarm(&dir);
+    record_cadence_floor_breach_alarm(&dir);
+    assert_eq!(lifetime_cadence_floor_breach_count(&dir), 3);
+
+    // A distinct log from the threshold-under-cadence alarm — this scenario
+    // must never touch that counter.
+    assert_eq!(lifetime_compaction_alarm_count(&dir), 0);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn record_cadence_floor_breach_alarm_unwritable_dir_does_not_panic() {
+    let bogus = PathBuf::from("/dev/null/not-a-real-dir-\0-segment");
+    record_cadence_floor_breach_alarm(&bogus);
+}
+
+#[test]
+fn lifetime_cadence_floor_breach_count_zero_when_missing() {
+    let dir = temp_dir("floor-breach-missing");
+    assert_eq!(lifetime_cadence_floor_breach_count(&dir), 0);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn lifetime_cadence_floor_breach_count_matches_fire_count() {
+    let dir = temp_dir("floor-breach-persist");
+    for _ in 0..4 {
+        record_cadence_floor_breach_alarm(&dir);
+    }
+    assert_eq!(lifetime_cadence_floor_breach_count(&dir), 4);
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn record_cadence_floor_breach_writes_jsonl_and_alarm() {
+    let dir = temp_dir("floor-breach-jsonl");
+    record_cadence_floor_breach(
+        &dir,
+        Some("sess-breach".to_string()),
+        200_000,
+        104_000,
+        200_000,
+        6,
+        7,
+    );
+
+    let lines = read_lines(&compression_log_path(&dir));
+    assert_eq!(lines.len(), 1);
+    let event: CompressionEvent = serde_json::from_str(&lines[0]).unwrap();
+    assert_eq!(event.surface, SURFACE_TCODE_CADENCE_FLOOR_BREACH);
+    assert_eq!(event.surface_detail, DETAIL_CADENCE_FLOOR_BREACH);
+    assert!(
+        event.compaction_event,
+        "a floor breach is unconditionally alarm-worthy"
+    );
+    assert_eq!(event.working_context_pct_after, Some(48));
+
+    assert_eq!(
+        lifetime_cadence_floor_breach_count(&dir),
+        1,
+        "the durable alarm line must always accompany the JSONL record"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 // -- context_pcts --
 
 #[test]

--- a/crates/trusty-code/src/events.rs
+++ b/crates/trusty-code/src/events.rs
@@ -968,6 +968,17 @@ pub struct ContextBudgetSnapshot {
     /// session — lets a consumer distinguish "no samples yet" (`None` above)
     /// from "exactly one, possibly unrepresentative, sample".
     pub working_context_pct_sample_count: usize,
+    /// (issue #3911) Lifetime, cross-session count of a cadence-level
+    /// 60%-floor breach (`CadenceOutcome::within_budget == false` after
+    /// `cadence::enforce_budget` exhausted every eligible entry) — the
+    /// backstop's own alarm, mirroring `lifetime_compaction_alarm_count`
+    /// exactly but keyed to the cadence mechanism's OWN floor guarantee
+    /// rather than the mechanically-independent threshold compactor's
+    /// separate 75%-of-window trigger (see
+    /// `agent_loop::telemetry::record_cadence_floor_breach`'s docs for why
+    /// the two alarms cannot be the same counter). Same "placeholder `0` on
+    /// the write path, real read on the query path" pattern.
+    pub lifetime_cadence_floor_breach_count: u64,
 }
 
 /// One row in a session's RETAINED search/recall audit trail (issue #3072;

--- a/crates/trusty-code/src/session/protocol_budget.rs
+++ b/crates/trusty-code/src/session/protocol_budget.rs
@@ -313,4 +313,59 @@ mod tests {
 
         std::fs::remove_dir_all(&dir).ok();
     }
+
+    // -- issue #3911: lifetime_cadence_floor_breach_count --
+
+    /// The RPC surfaces the #3911 backstop's own durable alarm count,
+    /// distinct from `lifetime_compaction_alarm_count`.
+    #[tokio::test]
+    async fn get_context_budget_reflects_cadence_floor_breach_count() {
+        let dir = telemetry_temp_dir("floor-breach-reflects");
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let result = crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
+            crate::agent_loop::telemetry::record_cadence_floor_breach_alarm(&dir);
+            crate::agent_loop::telemetry::record_cadence_floor_breach_alarm(&dir);
+            registry
+                .record_context_budget(&session.id, &measurement())
+                .unwrap();
+            get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+                .await
+                .unwrap()
+        })
+        .await;
+
+        assert_eq!(result["lifetime_cadence_floor_breach_count"], 2);
+        assert_eq!(
+            result["lifetime_compaction_alarm_count"], 0,
+            "the two alarm counters must never conflate — this scenario never \
+             recorded a threshold-under-cadence fire"
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A session with no floor-breach fires reports `0`, never a fabricated
+    /// count.
+    #[tokio::test]
+    async fn get_context_budget_floor_breach_count_zero_without_a_fire() {
+        let dir = telemetry_temp_dir("floor-breach-zero");
+        let registry = SessionRegistry::new();
+        let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+
+        let result = crate::agent_loop::telemetry::with_data_dir_env_fut(&dir, async {
+            registry
+                .record_context_budget(&session.id, &measurement())
+                .unwrap();
+            get_context_budget(&registry, json!({"session_id": session.id}), test_ctx())
+                .await
+                .unwrap()
+        })
+        .await;
+
+        assert_eq!(result["lifetime_cadence_floor_breach_count"], 0);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/crates/trusty-code/src/session/registry_events.rs
+++ b/crates/trusty-code/src/session/registry_events.rs
@@ -251,6 +251,9 @@ impl SessionRegistry {
             // `get_context_budget` overwrites both before returning.
             working_context_pct_low_water_mark: None,
             working_context_pct_sample_count: 0,
+            // (#3911) Same placeholder contract as
+            // `lifetime_compaction_alarm_count` above.
+            lifetime_cadence_floor_breach_count: 0,
         };
         {
             let mut sessions = self.lock();
@@ -324,6 +327,8 @@ impl SessionRegistry {
                     crate::agent_loop::telemetry::session_working_context_floor(&data_dir, id);
                 snapshot.working_context_pct_low_water_mark = low_water_mark;
                 snapshot.working_context_pct_sample_count = sample_count;
+                snapshot.lifetime_cadence_floor_breach_count =
+                    crate::agent_loop::telemetry::lifetime_cadence_floor_breach_count(&data_dir);
                 ContextBudgetQuery::Recorded(snapshot)
             })
             .unwrap_or(ContextBudgetQuery::NeverRecorded))


### PR DESCRIPTION
## Summary

The load-realistic compression soak (epic #3866, PR #3909) proved the
reactive/fallback compactor (`tcode-threshold`, issue #2308) never
engages even when cadence's own 60% working-context floor is breached
under heavy load — 48% floor in the exploratory run, 21 of 73 samples
below target, with the fallback firing **zero** times. The safety net
does not exist for the one condition where it matters most.

Closes #3911

**Note on this PR's base:** originally stacked on
`fix-3912-context-budget-floor-observability` (PR #3930); #3930 has now
**merged to main** (`02236ff4`), and this branch has been rebased onto
fresh `main` — the diff below is now scoped to ONLY the #3911 commits.

## Root cause

`cadence::enforce_budget`'s own "documented floor" case (active zone
shrunk to zero, still over the overhead cap) only ever logged
`tracing::warn!` from deep inside that function — no durable record, no
counter, and critically **not the same alarm** the #2308 threshold
compactor's own breach uses (`record_threshold_event`/
`lifetime_compaction_alarm_count`).

That existing alarm cannot help either, because it is keyed to a
**mechanically independent trigger**: threshold fires once the raw
transcript crosses 75% of the context window
(`CompactionConfig::for_context_window`'s `COMPACTION_THRESHOLD_FRACTION_PCT`),
a laxer bound than cadence's own 40%-overhead enforcement cap. By the
time cadence has already compacted as hard as it structurally can
(`enforce_budget` shrinks the active zone to zero, re-compacting at
every step) and still exceeds its OWN cap, the transcript is nowhere
near threshold's separate, higher bound — so threshold's trigger
condition literally cannot observe a cadence-level breach. The two
mechanisms share no signal path, exactly as the issue suspected.

**Independently confirmed by review:** the critic traced `enforce_budget`
(`cadence.rs:345-381`), confirmed it shrinks `keep_last` to 0 and stops
only once a round at `keep_last == 0` changes nothing; confirmed both
cadence and threshold delegate to the SAME `mark_compacted`
(`transcript.rs:382-399`) with identical pinned/system/user exemptions;
confirmed threshold's config (`compaction.rs:80-83`) is laxer
(75%-of-window, fixed `keep_last_messages: 6`); and confirmed
`maybe_cadence_compress` runs before `maybe_compact_transcript` at the
same turn boundary (`mod.rs:630,635`) — "an alarm was the right call
here, not a missed capacity fix."

## Design decision (and its trade-off)

**This adds an alarm backstop, not additional compaction capacity.**
`enforce_budget` already exhausts every eligible entry before returning
`within_budget: false` — the remaining content is exactly the
pinned/system/user-exempt active zone (in practice: a single turn's own
oversized tool-call argument, which is by definition the CURRENT
content being sent to the model and can never be evicted while still in
flight). No eviction-based compaction strategy — cadence's or
threshold's; both share the identical `Transcript::mark_compacted`
exemptions — can shrink that further without breaking the "preserve
pinned skill output / user requests forever" invariant #2070/#2278
deliberately established.

I considered three options:
1. **Make cadence itself adapt harder under load** (e.g. shrink the
   active zone below its current floor, or retry with a different
   strategy). Rejected: by the time `within_budget: false` is returned,
   `enforce_budget` has ALREADY shrunk `keep_last` to 0 and re-compacted
   at every step — there is nothing left to shrink. This isn't a tuning
   gap; it's structural.
2. **Wire threshold to fire additionally on a cadence breach.** Rejected
   as a no-op: threshold's `Transcript::maybe_compact` uses the exact
   same `mark_compacted` exemptions cadence's `compact_span_tagged`
   does, with a LESS aggressive fixed `keep_last_messages` (6) rather
   than cadence's shrink-to-zero loop — it would either compact nothing
   new or duplicate work cadence already did.
3. **Make the breach durable, countable, and alarm-worthy** (this PR).
   The correct backstop given (1) and (2): there is no more compaction
   to extract, so the useful thing a backstop CAN do is guarantee the
   breach is never silent again.

**Trade-off, stated explicitly:** an aggressive backstop that fired on
every near-floor turn would be noisy and devalue the signal. This
avoids that by firing on the EXACT SAME rare, well-tested condition
`cadence::enforce_budget` already used for its `warn!` (`within_budget
== false` — confirmed rare: **2 fires** in the primary (default) soak
run, the two turns landing exactly at the 60% floor boundary, and **21
fires** only in the deliberately harder exploratory run) — never a
softer heuristic that could fire under normal (comfortably-within-budget)
load. *(Corrected from an earlier draft of this PR body that
mis-stated "0 fires in the primary run" — the Design-decision and
Validation sections now agree: 2, not 0.)*

## Post-review fix: floor-breach row was double-counting a real breach

**Code review caught a HIGH:** on every real floor breach,
`AgentLoop::maybe_cadence_compress` calls `record_cadence_event`
unconditionally (whenever `outcome.rounds > 0`, which every breach
satisfies) BEFORE `record_cadence_floor_breach`, for the SAME turn, with
identical `tokens_before`/`outcome.overhead_tokens`/`context_window` —
so both JSONL rows carried the same `working_context_pct_after`.
Neither `compression_report.py`'s `compute_context_floor` nor this
crate's own `session_working_context_floor` (#3912, now merged) dedup
by surface, so every real breach was counted **twice** toward the
observed floor. The reviewer re-ran the exploratory soak against my
code with `compression_report.py` and got **42** below-target samples,
not 21.

**Fix (this PR now includes it):** `record_cadence_floor_breach` always
writes `None` for `working_context_pct_after`/`overhead_pct_after` —
never derived from `tokens_after`/`context_window` the way every other
surface's percentages are. This is a single-point fix rather than
teaching every consumer to exclude this surface: any existing or future
aggregator that filters on "has a `working_context_pct_after` sample" —
`compute_context_floor`, `session_working_context_floor`, and anything
built on either — inherits the fix for free, including #3912's
already-merged reader, without needing a second change to that file.
The paired `tcode-cadence` row remains the one authoritative
percentage sample for that turn; the floor-breach row's only job is to
durably flag THAT a breach happened (`tokens_before`/`tokens_after`/
`rounds`/`compaction_event: true` are still real and useful for
debugging).

New regression tests at both layers: `record_cadence_floor_breach_never_double_counts_the_floor`
(Rust, `telemetry_tests.rs`) and `test_floor_breach_row_does_not_double_count_a_real_breach`
(Python, `compression_report_test.py`).

## What changed

- `agent_loop::telemetry::record_cadence_floor_breach` — writes a new
  `tcode-cadence-floor-breach` JSONL surface (`compaction_event: true`,
  `working_context_pct_after: None`) plus a durable
  `cadence_floor_breach_alarm.log` line, mirroring
  `record_threshold_event`/`compaction_alarm.log`'s existing design.
- `lifetime_cadence_floor_breach_count(data_dir)` — read-fresh-from-disk
  count, mirroring `lifetime_compaction_alarm_count` exactly.
- `AgentLoop::maybe_cadence_compress` now calls the above when
  `!outcome.within_budget`, and elevates the log from `warn!` to
  `error!` — a floor breach is a stated guarantee being violated, not a
  routine event.
- New `lifetime_cadence_floor_breach_count` field on
  `session.get_context_budget` (alongside #3912's now-merged
  `working_context_pct_low_water_mark`/`working_context_pct_sample_count`).
- `compression_report.py` gains a dedicated "Cadence floor-breach
  backstop" section: explicitly flags a **FINDING** if the floor was
  breached but the backstop fired 0 times (the exact pre-fix scenario).

## Validation — re-ran the load soak against the CORRECTED fix

**Primary profile (160/230/300KB, 35 calls):**
- Verdict: **PASS** — both targets met.
- Working-context floor: **60%**, now correctly **126 samples** (was
  128 pre-fix — the 2 double-counted breach rows are gone).
- Backstop (`tcode-cadence-floor-breach`) fires: **2** — matches the 2
  samples that landed exactly at the 60% floor boundary.
- Session fidelity: PASS.

**Exploratory profile (220/300/400KB, 20 calls, the breaching profile):**
- Verdict: **FAIL — working context dropped below 60% at 21 sample(s)
  (floor: 48%)** — corrected from the pre-fix 42; now matches the
  original soak's finding exactly.
- Working-context floor: **48%**, now correctly **73 samples** (was 94
  pre-fix).
- Backstop fires: **21** — matches exactly, one fire per real breach,
  no more double-book-keeping.
- `tcode-threshold` (the old, non-firing signal): still **0** — confirms
  this is a genuinely NEW, independent signal, not a relabeling of the
  existing one.
- Session fidelity: PASS.

Raw `compression_report.py` output, corrected (both runs):

```
## Working-context floor
- Minimum observed: 60% (126 samples)          # primary — was "128 samples" pre-fix
- Never dropped below 60% at any sample.

## Working-context floor
- Minimum observed: 48% (73 samples)           # exploratory — was "94 samples" pre-fix
- 21 sample(s) dropped below 60%                # was "42 sample(s)" pre-fix

## Cadence floor-breach backstop (`tcode-cadence-floor-breach`, issue #3911)
2 backstop fire(s) recorded — the backstop engaged on the observed floor breach(es).   # primary
21 backstop fire(s) recorded — the backstop engaged on the observed floor breach(es). # exploratory
```

`session.get_context_budget`'s `working_context_pct_sample_count`
(the #3912 field) is likewise no longer inflated: 122/70 samples
through the last soak call in the primary/exploratory runs
respectively (was previously inflated by the same double-count).

## Residual limits (stated explicitly, not claimed away)

- **This closes the observability/alarm gap, not the compaction-capacity
  gap.** The measured floor itself is unchanged (still 60%/48% in these
  two profiles) — a session whose single turn's own tool-call argument
  exceeds the overhead cap will still breach the floor. The backstop's
  job is to make that breach visible and countable in production, never
  to prevent it.
- A harder profile than the exploratory one (push per-call payload size
  further) would still show a breach — it will now be alarmed rather
  than silent, but the boundary where the guarantee holds has not moved.
- Fixing the underlying capacity limit would require either a
  content-aware compaction strategy (this crate's compaction path is
  entirely content-blind by design, per the soak's own writeup) or
  accepting a smaller minimum active zone / truncating an individual
  oversized tool-call argument — both out of scope for a backstop and
  noted here for whoever picks up the capacity question next.
- **Filed separately, not in this PR's scope:** `session_working_context_floor`
  (#3912, now merged) does a full linear scan/JSON-parse of the
  never-rotated, multi-session `compression.jsonl` on every
  `get_context_budget` RPC call — fine at soak scale, a real concern for
  the long-lived sessions this epic exists to support. The coordinator
  is filing this as its own issue; not scope-creeping it into this PR.

## Test plan

- [x] `cargo test -p trusty-code` (full suite, not `--lib`): 1599 lib
      tests (10 new, including the double-count regression test) + all
      integration test binaries pass, 0 failed, 4 ignored.
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.
- [x] `scripts/check_line_cap.sh`: 8 allowlisted, 0 violations.
- [x] `python3 -m unittest crates/trusty-code/scripts/compression_report_test.py`:
      18 tests, all pass (6 new, including the double-count regression
      test).
- [x] Rebuilt `tcode` and re-ran `compression_load_soak.py` for both
      profiles against a real daemon with the corrected fix — see
      Validation above.
- [x] `gh pr checks 3941`: green (22 SUCCESS / 1 SKIPPED) prior to this
      fix; re-verifying after push.

Refs #3866, #3909, #3912.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools