### PR TITLE
fix(trusty-agents): close EventStore $HOME/HOME_LOCK cross-test race via DI (#3922)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -204,13 +204,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   behaviour is unchanged (the plain, non-`_at` methods still resolve
   `events_dir()` from `$HOME` exactly as before). A `#[cfg(test)]`-only guard
   in `events_dir()` now panics on the first run of any FUTURE test that
-  reaches it without holding `HOME_LOCK`, turning the next instance of this
-  omission into a deterministic failure instead of a flake. A new standing
-  regression guard, `concurrent_event_store_scenarios_survive_home_env_hammering`
-  (issue #3925), runs four `EventStore` scenarios concurrently against a
+  reaches it without the CALLING thread holding `HOME_LOCK`, turning the
+  next instance of this omission into a deterministic failure instead of a
+  flake. A new standing regression guard,
+  `concurrent_event_store_scenarios_survive_home_env_hammering` (issue
+  #3925), runs four `EventStore` scenarios concurrently against a
   background task that hammers `$HOME` with zero synchronization — the exact
   #3922 attack shape — and asserts none lose data; validated to fail
   deterministically (not probabilistically) when the DI seam is reverted.
+  **Code-critic follow-up (HIGH, fixed):** the guard's first version checked
+  `HOME_LOCK.try_lock().is_ok()` — global contention, not per-caller
+  ownership — so a background thread holding the lock for an unrelated
+  reason masked a genuinely unguarded caller on a different thread (the
+  critic reproduced this directly). New `crate::test_env::lock_home()` /
+  `home_lock_held_by_this_thread()` track ownership via a thread-local flag
+  instead (sound because every test in this crate uses the default
+  current-thread `#[tokio::test]` runtime), and `listeners::poll`'s cursor
+  tests plus the `api::server`/`slack` handler-level tests that still
+  sandbox `$HOME` directly were migrated to the new helper. A new test,
+  `events_dir_panics_when_a_different_thread_holds_home_lock`, pins the
+  exact masking scenario the critic found. Stress-testing this fix (60+
+  loop iterations of the full affected test set under `--test-threads=16`)
+  also surfaced an unrelated, pre-existing bug: `EventStore::append_at`
+  never called `.flush()` after `write_all`, so `tokio::fs::File`'s
+  background write could still be in flight when a separate `read_events_at`
+  call opened a fresh handle to the same path — observed as an intermittent
+  "0 events immediately after appending 1" under heavy concurrent test load.
+  Fixed with an explicit `.flush().await`.
 - **Instructions editor is a first-class editing surface (#3894, GUI).**
   #3862's `55vh`/`70vh` clamp fixed a 2-line strip by trading it for a field
   capped independently of the space available — dead area below it on a tall

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -182,6 +182,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`listeners::store::EventStore`'s `$HOME`/`HOME_LOCK` cross-test race
+  closed via dependency injection (issue #3922).**
+  `dedup_seed_loads_recent_ids` failed once in CI (run 30165303605) with
+  `assertion failed: ids.contains("id2")`, then passed on rerun. Root cause
+  (confirmed by local reproduction, not just inferred): `llm::http::tests`'s
+  five credential-resolution tests sandbox `$HOME` under
+  `#[serial_test::serial]` ALONE — a `std::sync::Mutex` (`HOME_LOCK`) can't
+  be held across `.await`, so they never take it — while `listeners::store`'s
+  own tests sandboxed `$HOME` under `HOME_LOCK` alone. The two groups never
+  actually excluded each other. Looping just these two test groups together
+  under maximised parallelism reproduced the failure at 2/5 runs, with a
+  captured panic (`ids.contains("id1")` / a spurious ENOENT opening another
+  test's already-removed tempdir) matching the CI failure's shape. New
+  `EventStore::append_at`/`read_events_at`/`recent_ids_at`/`load_filters_at`/
+  `set_filter_at`/`is_event_type_included_at` let a caller inject its target
+  directory directly instead of relying on the shared `$HOME`; every test in
+  `listeners::store::tests` now uses this seam and no longer touches the
+  process environment at all, so it can never again be a party to this race
+  regardless of what any other test in the crate does to `$HOME`. Production
+  behaviour is unchanged (the plain, non-`_at` methods still resolve
+  `events_dir()` from `$HOME` exactly as before). A `#[cfg(test)]`-only guard
+  in `events_dir()` now panics on the first run of any FUTURE test that
+  reaches it without holding `HOME_LOCK`, turning the next instance of this
+  omission into a deterministic failure instead of a flake. A new standing
+  regression guard, `concurrent_event_store_scenarios_survive_home_env_hammering`
+  (issue #3925), runs four `EventStore` scenarios concurrently against a
+  background task that hammers `$HOME` with zero synchronization — the exact
+  #3922 attack shape — and asserts none lose data; validated to fail
+  deterministically (not probabilistically) when the DI seam is reverted.
 - **Instructions editor is a first-class editing surface (#3894, GUI).**
   #3862's `55vh`/`70vh` clamp fixed a 2-line strip by trading it for a field
   capped independently of the space available — dead area below it on a tall

--- a/crates/trusty-agents/src/api/server/tests/listener_events.rs
+++ b/crates/trusty-agents/src/api/server/tests/listener_events.rs
@@ -17,16 +17,18 @@ use tower::ServiceExt;
 
 use crate::api::server::routes::build_router;
 use crate::api::server::state::AppState;
-use crate::test_env::HOME_LOCK;
 
 fn router() -> Router {
     build_router(AppState::default())
 }
 
 fn set_test_home(dir: &std::path::Path) {
-    // SAFETY: caller holds `HOME_LOCK` for the duration of the test (see
-    // `crate::test_env`'s module doc) so no other thread observes `HOME`
-    // mid-mutation.
+    // SAFETY: caller holds `HOME_LOCK` for the duration of the test (via
+    // `crate::test_env::lock_home()`, see `crate::test_env`'s module doc)
+    // so no other thread observes `HOME` mid-mutation. `lock_home()` also
+    // marks this thread as the current holder for
+    // `listeners::store::events_dir`'s per-caller recurrence guard (issue
+    // #3922 follow-up), which these tests reach via the routed handlers.
     unsafe {
         std::env::set_var("HOME", dir);
     }
@@ -34,7 +36,7 @@ fn set_test_home(dir: &std::path::Path) {
 
 #[tokio::test]
 async fn list_returns_empty_when_no_log() {
-    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::test_env::lock_home();
     let tmp = tempfile::tempdir().unwrap();
     set_test_home(tmp.path());
 
@@ -53,7 +55,7 @@ async fn list_returns_empty_when_no_log() {
 
 #[tokio::test]
 async fn filter_post_persists_and_list_reflects_it() {
-    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::test_env::lock_home();
     let tmp = tempfile::tempdir().unwrap();
     set_test_home(tmp.path());
 
@@ -102,7 +104,7 @@ async fn filter_post_persists_and_list_reflects_it() {
 
 #[tokio::test]
 async fn filter_post_rejects_empty_event_type() {
-    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let _guard = crate::test_env::lock_home();
     let tmp = tempfile::tempdir().unwrap();
     set_test_home(tmp.path());
 

--- a/crates/trusty-agents/src/listeners/poll.rs
+++ b/crates/trusty-agents/src/listeners/poll.rs
@@ -437,10 +437,11 @@ fn stored_event_from_message(listener_id: &str, event_id: &str, msg: &Value) -> 
 
 #[cfg(test)]
 // The cursor tests below deliberately hold `HOME_LOCK` across `.await`
-// points (the whole point of the lock — see `crate::test_env`'s module
-// doc); matches the existing `#[allow(clippy::await_holding_lock)]` used
-// for the identical pattern elsewhere in this crate
-// (`mcp::config::tests::mod`, `listeners::store::tests`).
+// points via `crate::test_env::lock_home()` (the whole point of the lock —
+// see `crate::test_env`'s module doc); `lock_home()` also marks this
+// thread as the current holder for `listeners::store::events_dir`'s
+// per-caller recurrence guard (issue #3922 follow-up), which these tests
+// reach via `events_dir()`/`cursor_path()`.
 #[allow(clippy::await_holding_lock)]
 mod tests {
     use super::*;
@@ -502,12 +503,10 @@ mod tests {
         assert_eq!(event.snippet.as_deref(), Some("Want to come over Sunday?"));
     }
 
-    use crate::test_env::HOME_LOCK;
-
     fn set_test_home(dir: &std::path::Path) {
-        // SAFETY: caller holds `HOME_LOCK` for the duration of the test (see
-        // `crate::test_env`'s module doc) so no other thread observes `HOME`
-        // mid-mutation.
+        // SAFETY: caller holds `HOME_LOCK` for the duration of the test (via
+        // `crate::test_env::lock_home()`, see `crate::test_env`'s module
+        // doc) so no other thread observes `HOME` mid-mutation.
         unsafe {
             std::env::set_var("HOME", dir);
         }
@@ -518,7 +517,11 @@ mod tests {
     /// written.
     #[tokio::test]
     async fn save_cursor_then_load_cursor_round_trips() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // `lock_home()` (not the raw `HOME_LOCK.lock()`) also marks this
+        // thread as the holder for `listeners::store::events_dir`'s
+        // per-caller recurrence guard (issue #3922 follow-up) — this test
+        // reaches that function via `events_dir()`/`cursor_path()` below.
+        let _guard = crate::test_env::lock_home();
         let tmp = tempfile::tempdir().unwrap();
         set_test_home(tmp.path());
 
@@ -546,7 +549,7 @@ mod tests {
     /// distinct code path is exercised.
     #[tokio::test]
     async fn load_cursor_warns_and_defaults_on_malformed_json() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::test_env::lock_home();
         let tmp = tempfile::tempdir().unwrap();
         set_test_home(tmp.path());
 
@@ -565,7 +568,7 @@ mod tests {
 
     #[tokio::test]
     async fn load_cursor_defaults_when_file_absent() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::test_env::lock_home();
         let tmp = tempfile::tempdir().unwrap();
         set_test_home(tmp.path());
 

--- a/crates/trusty-agents/src/listeners/store.rs
+++ b/crates/trusty-agents/src/listeners/store.rs
@@ -60,17 +60,58 @@ pub struct StoredEvent {
 /// Why: Centralised so tests can override via `$HOME` exactly like
 /// `GlobalConfig::config_path` does, and so every reader/writer agrees on
 /// the layout.
+///
+/// (#3922 recurrence guard) `#[cfg(test)]`-only: panics if a test reaches
+/// this `$HOME`-reading production path without holding
+/// `crate::test_env::HOME_LOCK` for the duration of the call. Why: this
+/// function used to be the ONLY seam `EventStore`'s tests had for
+/// isolation, so every test that wanted its own directory had to mutate the
+/// process-global `$HOME` under `HOME_LOCK` — but nothing stopped some
+/// OTHER test elsewhere in the crate from mutating `$HOME` under a
+/// DIFFERENT (or no) exclusion mechanism and racing it (issue #3922: a
+/// `listeners::store` test lost an appended event to exactly this race
+/// against `llm::http::tests`, which sandboxes `$HOME` under
+/// `#[serial_test::serial]` alone — a `std::sync::Mutex` can't be held
+/// across `.await`, so it never took `HOME_LOCK` at all — reproduced
+/// locally at 2/5 under deliberately maximised overlap, matching the CI
+/// failure's `ids.contains(..)` assertion shape byte-for-byte). The fix:
+/// `EventStore::*_at(dir, ..)` now lets a test inject its directory
+/// directly and never call this function at all — every test in THIS
+/// module was migrated to that seam and no longer touches `$HOME`.
+/// `listeners::poll`'s cursor tests and a few API/handler-level tests still
+/// call the plain `$HOME`-sandboxing path directly (no `AppState`/handler
+/// seam to inject through yet); they hold `HOME_LOCK` correctly, so this
+/// guard passes for them (a held lock makes `try_lock` fail, i.e. "busy" —
+/// exactly what this checks for). A held lock isn't proof the CURRENT
+/// thread is the holder, only that the crate's exclusion convention was
+/// followed; on the other hand `try_lock` succeeding removes ALL doubt —
+/// nobody is honouring the convention right now, so this is exactly the
+/// #3922 shape and must fail loud rather than silently race. Production
+/// builds are entirely unaffected — this whole check compiles out.
+/// Test: `listeners::store::tests::*` (migrated off `$HOME` entirely, so
+/// never reach this branch); `listeners::poll::tests::*` (still sandbox via
+/// `HOME_LOCK` and must keep passing under this guard).
 pub fn events_dir() -> Result<PathBuf> {
+    #[cfg(test)]
+    if crate::test_env::HOME_LOCK.try_lock().is_ok() {
+        panic!(
+            "listeners::store::events_dir(): about to resolve $HOME in a test with \
+             `crate::test_env::HOME_LOCK` NOT held (issue #3922) — either hold the lock for \
+             the duration of this test (see `listeners::poll`'s cursor tests) or, preferably, \
+             use `EventStore::*_at(dir, ..)` with an injected tempdir so this test never \
+             touches the process-global $HOME at all (see `listeners::store::tests`)."
+        );
+    }
     let home = dirs::home_dir().context("could not determine $HOME directory")?;
     Ok(home.join(".trusty-agents").join("events"))
 }
 
-fn events_log_path() -> Result<PathBuf> {
-    Ok(events_dir()?.join("events.jsonl"))
+fn events_log_path_at(dir: &std::path::Path) -> PathBuf {
+    dir.join("events.jsonl")
 }
 
-fn filters_path() -> Result<PathBuf> {
-    Ok(events_dir()?.join("filters.json"))
+fn filters_path_at(dir: &std::path::Path) -> PathBuf {
+    dir.join("filters.json")
 }
 
 /// Append-only event log + include/exclude filter state.
@@ -93,10 +134,34 @@ impl EventStore {
     /// Why: Append-only means a torn write can corrupt at most the LAST
     /// line, never earlier history — acceptable for a local demo store; a
     /// production-grade store would fsync + checksum, out of scope here.
-    /// What: Serializes `event` as one JSON line, appended with `\n`.
+    /// What: Resolves the write target via `events_dir()` (production:
+    /// `$HOME`-derived; see that function's `#[cfg(test)]` guard, issue
+    /// #3922) and delegates to [`Self::append_at`].
     /// Test: `append_and_read_round_trips`.
     pub async fn append(event: &StoredEvent) -> Result<()> {
-        let path = events_log_path()?;
+        Self::append_at(&events_dir()?, event).await
+    }
+
+    /// `append`, with the target directory injected directly instead of
+    /// resolved from `$HOME` (issue #3922).
+    ///
+    /// Why: `append`'s only prior seam for test isolation was mutating the
+    /// process-global `$HOME` under `crate::test_env::HOME_LOCK` — but a
+    /// lock only excludes callers that ALSO take it, and at least one other
+    /// test module in this crate (`llm::http::tests`, which can't hold a
+    /// `std::sync::Mutex` guard across `.await` and relies on `#[serial]`
+    /// instead) mutates `$HOME` without ever taking `HOME_LOCK`, so the two
+    /// groups could — and, reproduced locally, DID — race each other's
+    /// writes into the wrong directory. Taking `dir` as a parameter removes
+    /// the shared mutable global from the equation entirely for every
+    /// caller that uses this seam: two concurrently-running calls with
+    /// different `dir`s can never race, no lock required.
+    /// What: identical body to the pre-#3922 `append`, just reading `dir`
+    /// instead of re-deriving it from `events_dir()` each call.
+    /// Test: every test in `listeners::store::tests` now calls this instead
+    /// of sandboxing `$HOME`.
+    pub(crate) async fn append_at(dir: &std::path::Path, event: &StoredEvent) -> Result<()> {
+        let path = events_log_path_at(dir);
         if let Some(parent) = path.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
@@ -124,12 +189,23 @@ impl EventStore {
     ///
     /// Why: `limit` bounds the response for a long-lived demo/dev process;
     /// `None` returns everything (fine at demo scale).
-    /// What: Missing log file returns an empty `Vec`, never an error (a
-    /// listener that has never fired yet is a valid, common state).
+    /// What: Resolves the read target via `events_dir()` and delegates to
+    /// [`Self::read_events_at`]. Missing log file returns an empty `Vec`,
+    /// never an error (a listener that has never fired yet is a valid,
+    /// common state).
     /// Test: `read_events_returns_newest_first`,
     /// `filter_toggle_persists_and_applies_default_included`.
     pub async fn read_events(limit: Option<usize>) -> Result<Vec<StoredEvent>> {
-        let path = events_log_path()?;
+        Self::read_events_at(&events_dir()?, limit).await
+    }
+
+    /// `read_events`, with the source directory injected directly (issue
+    /// #3922) — see [`Self::append_at`]'s docs for why this seam exists.
+    pub(crate) async fn read_events_at(
+        dir: &std::path::Path,
+        limit: Option<usize>,
+    ) -> Result<Vec<StoredEvent>> {
+        let path = events_log_path_at(dir);
         let raw = match tokio::fs::read_to_string(&path).await {
             Ok(s) => s,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
@@ -137,7 +213,7 @@ impl EventStore {
                 return Err(e).with_context(|| format!("failed to read {}", path.display()));
             }
         };
-        let filters = Self::load_filters().await.unwrap_or_default();
+        let filters = Self::load_filters_at(dir).await.unwrap_or_default();
         let mut events: Vec<StoredEvent> = raw
             .lines()
             .filter(|l| !l.trim().is_empty())
@@ -169,14 +245,29 @@ impl EventStore {
     /// `read_events`).
     /// Test: `dedup_seed_loads_recent_ids`.
     pub async fn recent_ids(n: usize) -> Result<HashSet<String>> {
-        let events = Self::read_events(Some(n)).await?;
+        Self::recent_ids_at(&events_dir()?, n).await
+    }
+
+    /// `recent_ids`, with the source directory injected directly (issue
+    /// #3922) — see [`Self::append_at`]'s docs for why this seam exists.
+    /// Test: `dedup_seed_loads_recent_ids`.
+    pub(crate) async fn recent_ids_at(dir: &std::path::Path, n: usize) -> Result<HashSet<String>> {
+        let events = Self::read_events_at(dir, Some(n)).await?;
         Ok(events.into_iter().map(|e| e.id).collect())
     }
 
     /// Load the persisted event-type -> included map. Missing file = empty
     /// map (every type defaults to included — see [`is_included`]).
     pub async fn load_filters() -> Result<std::collections::HashMap<String, bool>> {
-        let path = filters_path()?;
+        Self::load_filters_at(&events_dir()?).await
+    }
+
+    /// `load_filters`, with the source directory injected directly (issue
+    /// #3922) — see [`Self::append_at`]'s docs for why this seam exists.
+    pub(crate) async fn load_filters_at(
+        dir: &std::path::Path,
+    ) -> Result<std::collections::HashMap<String, bool>> {
+        let path = filters_path_at(dir);
         match tokio::fs::read_to_string(&path).await {
             Ok(raw) => {
                 serde_json::from_str(&raw).with_context(|| format!("parse {}", path.display()))
@@ -190,16 +281,27 @@ impl EventStore {
     ///
     /// Why: Backs `POST /api/listener-events/filter` — the Events pane's
     /// per-type include/exclude toggle (#3818).
-    /// What: Read-modify-write of `filters.json`.
+    /// What: Resolves the write target via `events_dir()` and delegates to
+    /// [`Self::set_filter_at`].
     /// Test: `filter_toggle_persists_and_applies_default_included`.
     pub async fn set_filter(event_type: &str, included: bool) -> Result<()> {
-        let path = filters_path()?;
+        Self::set_filter_at(&events_dir()?, event_type, included).await
+    }
+
+    /// `set_filter`, with the target directory injected directly (issue
+    /// #3922) — see [`Self::append_at`]'s docs for why this seam exists.
+    pub(crate) async fn set_filter_at(
+        dir: &std::path::Path,
+        event_type: &str,
+        included: bool,
+    ) -> Result<()> {
+        let path = filters_path_at(dir);
         if let Some(parent) = path.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
                 .with_context(|| format!("failed to create events dir {}", parent.display()))?;
         }
-        let mut filters = Self::load_filters().await.unwrap_or_default();
+        let mut filters = Self::load_filters_at(dir).await.unwrap_or_default();
         filters.insert(event_type.to_string(), included);
         let content = serde_json::to_string_pretty(&filters).context("serialize filters")?;
         tokio::fs::write(&path, content)
@@ -217,7 +319,17 @@ impl EventStore {
     /// currently on" — centralising avoids the two drifting.
     /// Test: `filter_toggle_persists_and_applies_default_included`.
     pub async fn is_event_type_included(event_type: &str) -> bool {
-        let filters = Self::load_filters().await.unwrap_or_default();
+        match events_dir() {
+            Ok(dir) => Self::is_event_type_included_at(&dir, event_type).await,
+            Err(_) => true, // matches `load_filters().unwrap_or_default()`'s prior fallback.
+        }
+    }
+
+    /// `is_event_type_included`, with the source directory injected
+    /// directly (issue #3922) — see [`Self::append_at`]'s docs for why this
+    /// seam exists.
+    pub(crate) async fn is_event_type_included_at(dir: &std::path::Path, event_type: &str) -> bool {
+        let filters = Self::load_filters_at(dir).await.unwrap_or_default();
         is_included(&filters, event_type)
     }
 }
@@ -227,24 +339,14 @@ fn is_included(filters: &std::collections::HashMap<String, bool>, event_type: &s
 }
 
 #[cfg(test)]
-// Every test here holds `HOME_LOCK` across `.await` points DELIBERATELY —
-// that's the whole point of the lock (serialize `$HOME`-mutating tests
-// across the crate, see `crate::test_env`'s module doc). Matches the
-// existing `#[allow(clippy::await_holding_lock)]` in
-// `mcp::config::tests::mod` for the identical pattern.
-#[allow(clippy::await_holding_lock)]
+// (issue #3922) Every test in this module now injects its own tempdir via
+// `EventStore::*_at` instead of sandboxing the process-global `$HOME` — so
+// none of them touch `crate::test_env::HOME_LOCK` at all, and none of them
+// can race any OTHER test in the crate that mutates `$HOME` (with or
+// without that lock). See `events_dir`'s doc comment for the CI failure
+// this replaces and the local reproduction that pinned the mechanism.
 mod tests {
     use super::*;
-    use crate::test_env::HOME_LOCK;
-
-    fn set_test_home(dir: &std::path::Path) {
-        // SAFETY: caller holds `HOME_LOCK` for the duration of the test (see
-        // `crate::test_env`'s module doc) so no other thread observes `HOME`
-        // mid-mutation.
-        unsafe {
-            std::env::set_var("HOME", dir);
-        }
-    }
 
     fn sample_event(id: &str, event_type: &str) -> StoredEvent {
         StoredEvent {
@@ -262,12 +364,10 @@ mod tests {
 
     #[tokio::test]
     async fn append_and_read_round_trips() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
-        set_test_home(tmp.path());
         let ev = sample_event("gmail-personal:msg1", "message.received");
-        EventStore::append(&ev).await.unwrap();
-        let events = EventStore::read_events(None).await.unwrap();
+        EventStore::append_at(tmp.path(), &ev).await.unwrap();
+        let events = EventStore::read_events_at(tmp.path(), None).await.unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].id, "gmail-personal:msg1");
         assert_eq!(events[0].subject.as_deref(), Some("Hello"));
@@ -275,58 +375,168 @@ mod tests {
 
     #[tokio::test]
     async fn read_events_returns_newest_first() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
-        set_test_home(tmp.path());
-        EventStore::append(&sample_event("id1", "message.received"))
+        EventStore::append_at(tmp.path(), &sample_event("id1", "message.received"))
             .await
             .unwrap();
-        EventStore::append(&sample_event("id2", "message.received"))
+        EventStore::append_at(tmp.path(), &sample_event("id2", "message.received"))
             .await
             .unwrap();
-        let events = EventStore::read_events(None).await.unwrap();
+        let events = EventStore::read_events_at(tmp.path(), None).await.unwrap();
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].id, "id2", "newest appended must be first");
         assert_eq!(events[1].id, "id1");
     }
 
+    /// (#3922) Previously flaked under parallel `cargo test` scheduling: this
+    /// test sandboxed `$HOME` under `HOME_LOCK`, but `llm::http::tests`
+    /// mutates `$HOME` under `#[serial_test::serial]` ALONE (it can't hold a
+    /// `std::sync::Mutex` across `.await`), so the two never actually
+    /// excluded each other — reproduced locally (2 failures in 5 runs under
+    /// deliberately maximised overlap; see PR description for the exact
+    /// repro command and captured failure text, which matched this test's
+    /// own `ids.contains(..)` assertion). Injecting the tempdir directly
+    /// removes `$HOME` from this test's execution entirely, so it can no
+    /// longer be a party to that race regardless of what any other test in
+    /// the crate does to the process environment.
     #[tokio::test]
     async fn dedup_seed_loads_recent_ids() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
-        set_test_home(tmp.path());
-        EventStore::append(&sample_event("id1", "message.received"))
+        EventStore::append_at(tmp.path(), &sample_event("id1", "message.received"))
             .await
             .unwrap();
-        EventStore::append(&sample_event("id2", "message.received"))
+        EventStore::append_at(tmp.path(), &sample_event("id2", "message.received"))
             .await
             .unwrap();
-        let ids = EventStore::recent_ids(10).await.unwrap();
+        let ids = EventStore::recent_ids_at(tmp.path(), 10).await.unwrap();
         assert!(ids.contains("id1"));
         assert!(ids.contains("id2"));
     }
 
     #[tokio::test]
     async fn filter_toggle_persists_and_applies_default_included() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().unwrap();
-        set_test_home(tmp.path());
+        let dir = tmp.path();
         // Default (no filters.json yet): included.
-        assert!(EventStore::is_event_type_included("message.received").await);
+        assert!(EventStore::is_event_type_included_at(dir, "message.received").await);
 
-        EventStore::set_filter("message.received", false)
+        EventStore::set_filter_at(dir, "message.received", false)
             .await
             .unwrap();
-        assert!(!EventStore::is_event_type_included("message.received").await);
+        assert!(!EventStore::is_event_type_included_at(dir, "message.received").await);
 
         // A never-toggled type stays included.
-        assert!(EventStore::is_event_type_included("event.created").await);
+        assert!(EventStore::is_event_type_included_at(dir, "event.created").await);
 
         // read_events reflects the retroactive exclusion.
-        EventStore::append(&sample_event("id1", "message.received"))
+        EventStore::append_at(dir, &sample_event("id1", "message.received"))
             .await
             .unwrap();
-        let events = EventStore::read_events(None).await.unwrap();
+        let events = EventStore::read_events_at(dir, None).await.unwrap();
         assert!(!events[0].included);
+    }
+
+    /// (#3925) Standing regression guard for the #3922 race CLASS, not just
+    /// the one instance: rather than a brute-force N-iteration loop (only
+    /// catches the failure probabilistically, and only if it's `#[ignore]`d
+    /// and run nightly it might catch it days late), this test
+    /// DETERMINISTICALLY manufactures the exact attack shape that caused
+    /// #3922 — a concurrent task mutating the process-global `$HOME` env
+    /// var in a tight loop with NO synchronization at all, matching
+    /// `llm::http::tests`'s `#[serial_test::serial]`-only pattern (it can't
+    /// hold `HOME_LOCK`, a `std::sync::Mutex`, across `.await`) — running
+    /// for the FULL duration of several concurrent `EventStore` scenarios
+    /// that use the `_at` DI seam this fix introduced. Because `_at` never
+    /// reads `$HOME`, every scenario below MUST see exactly its own ids no
+    /// matter how aggressively `$HOME` churns concurrently; if a future
+    /// change makes any `_at` method (or one of its callers) fall back to
+    /// `events_dir()` again without an explicit override, this test starts
+    /// failing on the FIRST run under this hammering, deterministically,
+    /// rather than ~5% of the time.
+    /// What: Holds `HOME_LOCK` for its own entire body (exactly like every
+    /// other `$HOME`-touching test in this crate) so this test cannot
+    /// itself become a NEW unguarded attacker against some other
+    /// `HOME_LOCK`-respecting test — the hammering is fully internal to
+    /// this test's own scope. Spawns a background task that rewrites
+    /// `$HOME` on every `tokio::task::yield_now` while four scenarios each
+    /// append 8 events to their OWN tempdir via `EventStore::append_at`,
+    /// interleaved with `yield_now` points, then reads them back via
+    /// `EventStore::recent_ids_at`. Asserts each scenario's id set is
+    /// exactly its own 8 ids — nothing lost, nothing borrowed from a
+    /// sibling.
+    /// Test: itself.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn concurrent_event_store_scenarios_survive_home_env_hammering() {
+        let _guard = crate::test_env::HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let prev_home = std::env::var_os("HOME");
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+        let hammer_stop = stop.clone();
+        let hammer = tokio::spawn(async move {
+            let mut i: u64 = 0;
+            while !hammer_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                i += 1;
+                // SAFETY: deliberately UNSYNCHRONIZED — this reproduces the
+                // exact #3922 attack shape (a concurrent mutator that never
+                // takes any lock). Held HOME_LOCK (above) keeps this whole
+                // test's hammering from leaking into any OTHER test; the
+                // scenarios below must survive it regardless.
+                unsafe {
+                    std::env::set_var("HOME", format!("/tmp/home-hammer-{i}"));
+                }
+                tokio::task::yield_now().await;
+            }
+        });
+
+        async fn scenario(label: &'static str, n: usize) -> HashSet<String> {
+            let tmp = tempfile::tempdir().unwrap();
+            for i in 0..n {
+                EventStore::append_at(
+                    tmp.path(),
+                    &sample_event(&format!("{label}-{i}"), "message.received"),
+                )
+                .await
+                .unwrap();
+                tokio::task::yield_now().await;
+            }
+            EventStore::recent_ids_at(tmp.path(), n).await.unwrap()
+        }
+
+        let (a, b, c, d) = tokio::join!(
+            scenario("a", 8),
+            scenario("b", 8),
+            scenario("c", 8),
+            scenario("d", 8),
+        );
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        hammer.await.unwrap();
+
+        // SAFETY: still holding HOME_LOCK; restoring pre-test HOME before
+        // the guard drops at function end.
+        unsafe {
+            match prev_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+
+        for (label, ids) in [("a", a), ("b", b), ("c", c), ("d", d)] {
+            assert_eq!(
+                ids.len(),
+                8,
+                "scenario {label} lost or gained ids under $HOME hammering: {ids:?}"
+            );
+            for i in 0..8 {
+                let want = format!("{label}-{i}");
+                assert!(
+                    ids.contains(&want),
+                    "scenario {label} missing its own id {want}: {ids:?}"
+                );
+            }
+        }
     }
 }

--- a/crates/trusty-agents/src/listeners/store.rs
+++ b/crates/trusty-agents/src/listeners/store.rs
@@ -62,9 +62,9 @@ pub struct StoredEvent {
 /// the layout.
 ///
 /// (#3922 recurrence guard) `#[cfg(test)]`-only: panics if a test reaches
-/// this `$HOME`-reading production path without holding
-/// `crate::test_env::HOME_LOCK` for the duration of the call. Why: this
-/// function used to be the ONLY seam `EventStore`'s tests had for
+/// this `$HOME`-reading production path without the CALLING thread holding
+/// `crate::test_env::HOME_LOCK` via [`crate::test_env::lock_home`]. Why:
+/// this function used to be the ONLY seam `EventStore`'s tests had for
 /// isolation, so every test that wanted its own directory had to mutate the
 /// process-global `$HOME` under `HOME_LOCK` — but nothing stopped some
 /// OTHER test elsewhere in the crate from mutating `$HOME` under a
@@ -80,26 +80,40 @@ pub struct StoredEvent {
 /// module was migrated to that seam and no longer touches `$HOME`.
 /// `listeners::poll`'s cursor tests and a few API/handler-level tests still
 /// call the plain `$HOME`-sandboxing path directly (no `AppState`/handler
-/// seam to inject through yet); they hold `HOME_LOCK` correctly, so this
-/// guard passes for them (a held lock makes `try_lock` fail, i.e. "busy" —
-/// exactly what this checks for). A held lock isn't proof the CURRENT
-/// thread is the holder, only that the crate's exclusion convention was
-/// followed; on the other hand `try_lock` succeeding removes ALL doubt —
-/// nobody is honouring the convention right now, so this is exactly the
-/// #3922 shape and must fail loud rather than silently race. Production
-/// builds are entirely unaffected — this whole check compiles out.
+/// seam to inject through yet); they now acquire the lock via
+/// `crate::test_env::lock_home()` (not the raw `HOME_LOCK.lock()`), so this
+/// guard passes for them.
+///
+/// (code-critic HIGH on PR #3943, fixed) An EARLIER version of this guard
+/// checked `crate::test_env::HOME_LOCK.try_lock().is_ok()` — global
+/// contention, not per-caller ownership. The critic reproduced the gap
+/// directly: a background thread takes `HOME_LOCK` for an unrelated reason
+/// and holds it; a second, completely lock-less thread then calls this
+/// function, and the OLD check read `try_lock()` reporting "busy" as "the
+/// convention is honoured" — even though the ACTUAL caller was not
+/// participating at all. `crate::test_env::home_lock_held_by_this_thread()`
+/// answers the correct, narrower question (does the CALLING thread's own
+/// `lock_home()` guard exist right now?) via a thread-local flag — see that
+/// function's docs for why a thread-local is sound here (every test in this
+/// crate uses the default current-thread `#[tokio::test]` runtime, which
+/// pins a test's entire execution to one OS thread). Production builds are
+/// entirely unaffected — this whole check compiles out.
 /// Test: `listeners::store::tests::*` (migrated off `$HOME` entirely, so
-/// never reach this branch); `listeners::poll::tests::*` (still sandbox via
-/// `HOME_LOCK` and must keep passing under this guard).
+/// never reach this branch); `listeners::poll::tests::*` /
+/// `api::server::tests::listener_events::*` / `slack::tests::eventstream_tests::*`
+/// (migrated to `lock_home()`, must keep passing under this guard);
+/// `listeners::store::tests::events_dir_panics_when_a_different_thread_holds_home_lock`
+/// (pins the masking scenario the critic found, now fixed).
 pub fn events_dir() -> Result<PathBuf> {
     #[cfg(test)]
-    if crate::test_env::HOME_LOCK.try_lock().is_ok() {
+    if !crate::test_env::home_lock_held_by_this_thread() {
         panic!(
-            "listeners::store::events_dir(): about to resolve $HOME in a test with \
-             `crate::test_env::HOME_LOCK` NOT held (issue #3922) — either hold the lock for \
-             the duration of this test (see `listeners::poll`'s cursor tests) or, preferably, \
-             use `EventStore::*_at(dir, ..)` with an injected tempdir so this test never \
-             touches the process-global $HOME at all (see `listeners::store::tests`)."
+            "listeners::store::events_dir(): about to resolve $HOME in a test where THIS \
+             thread does not hold `crate::test_env::HOME_LOCK` (issue #3922) — either acquire \
+             it via `crate::test_env::lock_home()` for the duration of this test (see \
+             `listeners::poll`'s cursor tests) or, preferably, use `EventStore::*_at(dir, ..)` \
+             with an injected tempdir so this test never touches the process-global $HOME at \
+             all (see `listeners::store::tests`)."
         );
     }
     let home = dirs::home_dir().context("could not determine $HOME directory")?;
@@ -179,6 +193,20 @@ impl EventStore {
         file.write_all(line.as_bytes())
             .await
             .context("append event line")?;
+        // `tokio::fs::File` can report `write_all` complete before the
+        // background blocking write has actually landed — `flush` (not
+        // merely a buffering nicety here; it's what forces the pending
+        // write to finish) is required before any OTHER call site (e.g.
+        // `read_events_at`, opening a fresh handle to the same path) can
+        // rely on seeing this line. Found via stress-looping this exact
+        // function under heavy concurrent test load while validating the
+        // #3922 fix: `append_and_read_round_trips` intermittently observed
+        // 0 events immediately after appending 1, at ~2% under
+        // `--test-threads=16` with several other async-heavy test suites
+        // running concurrently (never observed at low background load,
+        // consistent with a background-task-completion race rather than a
+        // logic bug in the read path).
+        file.flush().await.context("flush appended event line")?;
         Ok(())
     }
 
@@ -468,9 +496,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn concurrent_event_store_scenarios_survive_home_env_hammering() {
-        let _guard = crate::test_env::HOME_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::test_env::lock_home();
         let prev_home = std::env::var_os("HOME");
         let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
 
@@ -538,5 +564,61 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// (code-critic HIGH on PR #3943) Pins the exact masking scenario the
+    /// critic found in the FIRST version of `events_dir`'s recurrence guard:
+    /// that version checked `crate::test_env::HOME_LOCK.try_lock().is_ok()`,
+    /// which only detects GLOBAL contention (is `HOME_LOCK` held by ANY
+    /// thread right now?), not whether the CALLING thread is the holder. The
+    /// critic showed a background thread taking `HOME_LOCK` for an unrelated
+    /// reason, held for the duration, while a second, completely lock-less
+    /// thread calls `events_dir()` — the old guard read `try_lock()`
+    /// reporting "busy" as "the convention is honoured" and did NOT panic,
+    /// even though the actual caller was not participating in the lock at
+    /// all. This test reproduces exactly that shape and asserts the FIXED
+    /// guard (`crate::test_env::home_lock_held_by_this_thread()`, a
+    /// thread-local ownership flag rather than a global contention check)
+    /// still panics.
+    ///
+    /// What: spawns a background thread that acquires the raw
+    /// `crate::test_env::HOME_LOCK` directly (deliberately NOT via
+    /// `crate::test_env::lock_home()` — simulating some OTHER, unrelated
+    /// test elsewhere in the crate that still uses the crate's long-standing
+    /// convention), holds it until signalled, and only THEN — from the
+    /// calling thread, which never acquired anything — calls `events_dir()`
+    /// inside `std::panic::catch_unwind`. Asserts it panics.
+    #[test]
+    fn events_dir_panics_when_a_different_thread_holds_home_lock() {
+        let (holder_ready_tx, holder_ready_rx) = std::sync::mpsc::channel::<()>();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+
+        let holder = std::thread::spawn(move || {
+            // Deliberately the RAW lock, not `crate::test_env::lock_home()`
+            // — this thread holds `HOME_LOCK` for a reason entirely
+            // unrelated to `events_dir()`, exactly like the critic's report.
+            let _guard = crate::test_env::HOME_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            holder_ready_tx.send(()).ok();
+            release_rx.recv().ok();
+        });
+
+        // Wait until the OTHER thread genuinely holds the lock before
+        // making the call under test — otherwise this test would race its
+        // own setup.
+        holder_ready_rx.recv().expect("holder thread ready");
+
+        let result = std::panic::catch_unwind(events_dir);
+
+        release_tx.send(()).ok();
+        holder.join().expect("holder thread joins cleanly");
+
+        assert!(
+            result.is_err(),
+            "events_dir() must panic when THIS thread does not hold HOME_LOCK, even \
+             while a DIFFERENT thread holds it for an unrelated reason — global \
+             contention must never be mistaken for per-caller ownership"
+        );
     }
 }

--- a/crates/trusty-agents/src/slack/tests.rs
+++ b/crates/trusty-agents/src/slack/tests.rs
@@ -303,12 +303,15 @@ fn default_rbac_users_includes_kartik_parity() {
 mod eventstream_tests {
     use crate::listeners::store::EventStore;
     use crate::slack::handlers::record_listener_event;
-    use crate::test_env::HOME_LOCK;
 
     fn set_test_home(dir: &std::path::Path) {
-        // SAFETY: caller holds `HOME_LOCK` for the duration of the test (see
-        // `crate::test_env`'s module doc) so no other thread observes `HOME`
-        // mid-mutation.
+        // SAFETY: caller holds `HOME_LOCK` for the duration of the test (via
+        // `crate::test_env::lock_home()`, see `crate::test_env`'s module
+        // doc) so no other thread observes `HOME` mid-mutation.
+        // `lock_home()` also marks this thread as the current holder for
+        // `listeners::store::events_dir`'s per-caller recurrence guard
+        // (issue #3922 follow-up), which these tests reach via
+        // `record_listener_event`.
         unsafe {
             std::env::set_var("HOME", dir);
         }
@@ -321,7 +324,7 @@ mod eventstream_tests {
     /// default).
     #[tokio::test]
     async fn slack_listener_event_appends_and_respects_filter() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::test_env::lock_home();
         let tmp = tempfile::tempdir().unwrap();
         set_test_home(tmp.path());
 
@@ -353,7 +356,7 @@ mod eventstream_tests {
     /// the append itself on the filter.
     #[tokio::test]
     async fn slack_listener_event_excluded_type_still_appended() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::test_env::lock_home();
         let tmp = tempfile::tempdir().unwrap();
         set_test_home(tmp.path());
 
@@ -406,7 +409,7 @@ mod eventstream_tests {
     /// and `create_dir_all` under a non-directory `HOME` component errors.
     #[tokio::test]
     async fn slack_listener_event_publishes_even_when_append_fails() {
-        let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::test_env::lock_home();
         let tmp = tempfile::tempdir().unwrap();
         let home_as_file = tmp.path().join("home_is_actually_a_file");
         std::fs::write(&home_as_file, b"not a directory").unwrap();

--- a/crates/trusty-agents/src/test_env.rs
+++ b/crates/trusty-agents/src/test_env.rs
@@ -22,9 +22,10 @@
 
 #![cfg(test)]
 
+use std::cell::Cell;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 /// Process-wide mutex serializing tests that mutate `$HOME`.
 ///
@@ -36,8 +37,84 @@ use std::sync::Mutex;
 /// What: Use `let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());`
 /// at the top of any test that calls `std::env::set_var("HOME", ...)`.
 /// `unwrap_or_else(into_inner)` ensures a panic in one test doesn't poison
-/// the lock for siblings.
+/// the lock for siblings. Prefer [`lock_home`] for any NEW test whose
+/// production code path is guarded by [`home_lock_held_by_this_thread`]
+/// (currently `listeners::store::events_dir`) — it does everything this
+/// raw acquisition does, plus marks per-thread ownership that guard needs.
 pub static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+thread_local! {
+    /// Set for the lifetime of THIS thread's own [`HomeLockGuard`]. See
+    /// [`home_lock_held_by_this_thread`]'s docs for why per-thread ownership,
+    /// not global contention, is the question a recurrence guard needs
+    /// answered (issue #3922 follow-up).
+    static HOME_LOCK_HELD_HERE: Cell<bool> = const { Cell::new(false) };
+}
+
+/// RAII guard returned by [`lock_home`]: holds `HOME_LOCK` for its scope AND
+/// marks this OS thread as the current holder, so
+/// [`home_lock_held_by_this_thread`] can answer "do *I* hold it?" instead of
+/// "is it contended by ANYONE?".
+pub struct HomeLockGuard {
+    _inner: MutexGuard<'static, ()>,
+}
+
+impl Drop for HomeLockGuard {
+    fn drop(&mut self) {
+        HOME_LOCK_HELD_HERE.with(|c| c.set(false));
+    }
+}
+
+/// Acquire [`HOME_LOCK`] AND mark this thread as the holder for
+/// [`home_lock_held_by_this_thread`].
+///
+/// Why (issue #3922 follow-up, code-critic HIGH on PR #3943): a
+/// `#[cfg(test)]` recurrence guard that wants to assert "the CALLING test
+/// currently honours the crate's `$HOME`-sandboxing convention" cannot
+/// answer that from `HOME_LOCK.try_lock()` alone — that only reports
+/// whether the mutex is CONTENDED, i.e. whether *some* thread holds it,
+/// which says nothing about whether the thread asking the question is that
+/// holder. The critic proved this concretely: a background thread takes
+/// `HOME_LOCK` for an unrelated reason and holds it; a second, completely
+/// lock-less thread then reaches the guarded code path, and
+/// `try_lock().is_ok()` reports `false` (busy) — read by the old guard as
+/// "the convention is being honoured" — even though the ACTUAL caller
+/// plainly is not participating at all. This function fixes that by
+/// marking per-thread ownership instead of relying on global contention.
+/// What: identical acquisition to the raw `HOME_LOCK.lock()` idiom used
+/// throughout this crate (`unwrap_or_else(into_inner)` so one test's panic
+/// never poisons the lock for siblings), wrapped in a guard that also flips
+/// a thread-local flag on acquire and clears it on drop.
+/// `cargo test`'s default current-thread `#[tokio::test]` runtime (used by
+/// every test in this crate — grep confirms no test opts into
+/// `flavor = "multi_thread"`) pins an async test's ENTIRE execution,
+/// including every `.await` point, to the one OS thread that `block_on`s
+/// it, so a thread-local set for this guard's lifetime correctly tracks
+/// "this test currently holds the lock" without needing a heavier
+/// `tokio::task_local!` (which would additionally force every call site to
+/// restructure its body into a `.scope(...)` future — a much larger,
+/// crate-wide change this fix does not need).
+/// Test: `listeners::store::tests::events_dir_panics_when_a_different_thread_holds_home_lock`
+/// (the exact masking scenario this seam exists to close) plus every
+/// migrated caller in `listeners::poll`, `api::server::tests::listener_events`,
+/// and `slack::tests::eventstream_tests`.
+pub fn lock_home() -> HomeLockGuard {
+    let guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    HOME_LOCK_HELD_HERE.with(|c| c.set(true));
+    HomeLockGuard { _inner: guard }
+}
+
+/// Whether THIS thread currently holds `HOME_LOCK` via [`lock_home`].
+///
+/// Why: see [`lock_home`]'s docs for the full story — this is the narrower,
+/// per-caller question a recurrence guard actually needs answered, in place
+/// of `HOME_LOCK.try_lock().is_ok()`'s global-contention signal.
+/// What: `true` only while the CURRENT thread's own `lock_home()` guard is
+/// still alive; `false` in every other case, INCLUDING "some other thread
+/// holds `HOME_LOCK`" — that distinction is the entire point.
+pub fn home_lock_held_by_this_thread() -> bool {
+    HOME_LOCK_HELD_HERE.with(|c| c.get())
+}
 
 /// Process-wide mutex serializing tests that mutate LLM credential env vars
 /// (#250). Same rationale as `HOME_LOCK` — `std::env::set_var` is global so


### PR DESCRIPTION
> **Update — addressed code-critic HIGH:** the recurrence guard's first
> version checked `HOME_LOCK.try_lock().is_ok()` — global contention, not
> per-caller ownership. The critic reproduced a masking scenario directly: a
> background thread holds `HOME_LOCK` for an unrelated reason; a second,
> completely lock-less thread then calls `events_dir()` and the old guard
> did NOT panic, because `try_lock()` reported 'busy' and the guard misread
> that as 'the convention is honoured'.
>
> Fixed with option (a) from the critic's note: `crate::test_env::lock_home()`
> / `home_lock_held_by_this_thread()` track ownership via a thread-local
> flag set for the lifetime of the guard, instead of asking whether the
> mutex is merely contended. This is sound for this crate specifically
> because every test uses the default current-thread `#[tokio::test]`
> runtime (grep confirms no test opts into `flavor = "multi_thread"`),
> which pins a test's entire execution — including every `.await` point —
> to the ONE OS thread that `block_on`s it. Migrated the 9 tests that
> reach `events_dir()` while properly holding the lock
> (`listeners::poll's` 3 cursor tests, `api::server::tests::listener_events's`
> 3 tests, `slack::tests::eventstream_tests's` 3 tests) to the new helper.
> Added `events_dir_panics_when_a_different_thread_holds_home_lock`, which
> reproduces the critic's exact scenario — validated to FAIL (not panic)
> against the old `try_lock()`-based guard before this fix, and to pass
> after it.
>
> Stress-testing this fix (100+ loop iterations of the full affected test
> set under `--test-threads=16`) also surfaced an unrelated, pre-existing
> bug: `EventStore::append_at` never called `.flush()` after `write_all`,
> so `tokio::fs::File's` background write could still be in flight when a
> separate `read_events_at` call opened a fresh handle to the same path —
> observed as an intermittent "0 events immediately after appending 1"
> under heavy concurrent test load (~2% over ~100 runs). Fixed with an
> explicit `.flush().await`; validated clean over 70+ subsequent
> iterations. This is unrelated to the $HOME race itself but was found
> while stress-validating this fix in the same function, so fixed in the
> same PR rather than filed separately.
>
> Also rebased onto fresh `origin/main` (through PR #3942) — clean, no
> conflicts.

## Summary

Closes #3922. `listeners::store::tests::dedup_seed_loads_recent_ids` failed
once in CI (run 30165303605, job 89697190403) with
`assertion failed: ids.contains("id2")`, then passed on rerun.

## Root cause: confirmed by local reproduction, not just inferred

The issue labelled the mechanism INFERRED. I reproduced it directly.

`listeners::store`'s tests sandbox `$HOME` under
`crate::test_env::HOME_LOCK` (a `std::sync::Mutex`, held across `.await`).
Meanwhile `llm::http::tests`'s five credential-resolution tests ALSO
sandbox `$HOME`, but only under `#[serial_test::serial]` — they explicitly
cannot hold `HOME_LOCK` across `.await` (clippy's `await_holding_lock`
correctly forbids that for a sync mutex), so they never take it at all.
The two groups were never mutually exclusive.

Looping just these two test groups together under deliberately maximised
parallelism (`cargo test -- listeners::store::tests::dedup_seed_loads_recent_ids
llm::http:: --test-threads=16`, looped) reproduced concrete failures at
**2 out of 5 runs**, with captured panics matching the CI failure's shape
byte-for-byte:
- `assertion failed: ids.contains("id1")` (a sibling of the CI's
  `ids.contains("id2")` failure — the same lost-event pattern)
- A spurious ENOENT opening an events log path that had just been removed
  by another test's `TempDir` drop

After the fix, the same 32-iteration loop (2×[10-min ceiling] batches)
produced **0 failures**.

## Fix: dependency injection, not serialization

`EventStore` gains `append_at`/`read_events_at`/`recent_ids_at`/
`load_filters_at`/`set_filter_at`/`is_event_type_included_at` — each takes
the target directory as a parameter instead of resolving it from `$HOME`.
The plain (non-`_at`) methods are unchanged for production (`events_dir()`
still resolves from `$HOME`, called by exactly one call site: the plain
wrapper, which then delegates to its `_at` sibling).

Every test in `listeners::store::tests` now injects a plain `tempfile::tempdir()`
via the `_at` seam and no longer touches `$HOME`, `HOME_LOCK`, or any
process-global state at all — so it can never again be a party to this
race, regardless of what any other test in the crate does to `$HOME`.

This mirrors PR #3920's fix for issue #3902 (`AgentLoopConfig::telemetry_data_dir`
in trusty-code) — same shape (a process-global env var mutated under a lock
only some callers honour), same fix (DI, not `#[serial]`/`#[ignore]`).

## Recurrence guard (#3922's own ask)

`events_dir()` gets a `#[cfg(test)]`-only guard: it panics on the first run
of any FUTURE test that reaches it (the `$HOME`-resolving path) without
holding `HOME_LOCK` — turning "someone forgot to inject or lock" into a
100%-reproducing failure instead of an occasional flake. Verified by
temporarily reverting one test to the old pattern and confirming a
deterministic failure (see PR discussion / commit history for the
before/after).

## Standing regression guard (issue #3925)

Also adds `concurrent_event_store_scenarios_survive_home_env_hammering`:
holds `HOME_LOCK` for its own body, then races four `EventStore` `_at`-based
scenarios against a background task that rewrites `$HOME` in a tight loop
with ZERO synchronization — the exact #3922 attack shape — via `tokio::join!`.
Asserts every scenario sees exactly its own ids. This is deterministic by
construction: the `_at` seam never reads `$HOME`, so it cannot lose data no
matter how aggressively `$HOME` churns concurrently. I validated this by
temporarily reverting the scenario helper to the plain (non-`_at`,
`$HOME`-resolving) methods — it failed on the FIRST run with
`scenario a lost or gained ids under $HOME hammering: {}` (0 ids instead of
8), confirming the guard actually catches the regression it's designed for,
not just decoration.

This satisfies option 2 from #3925 (a concurrent-scenarios test via
`tokio::join!`, not a brute-force `#[ignore]`d loop or nextest repeat
config) for the trusty-agents half of that issue. The trusty-code half
(the literal subject of #3925's title, `TCODE_TELEMETRY_DATA_DIR`) is
addressed in a separate, independent PR so the two issues can land/merge in
either order.

## Workspace-wide audit (both issues ask for this)

Grepped every `HOME_LOCK`/`set_var("HOME"`/`#[serial]` usage across
`trusty-agents`. Findings:

- **Dozens of test modules correctly hold `HOME_LOCK`** for their `$HOME`
  sandboxing (`listeners::poll`, `mcp::config::tests`, `mcp_json.rs`,
  `tools::mcp_tools`, `tools::okg::tests`, `agents::tests::loading`,
  `agents::prompt_builder::tests`, `agents::registry::tests`,
  `skills::global_cache::tests`, `skills::registry::tests(_persistence)`,
  `api::server::tests::{mod,ctrl_sessions,listener_events}`, `slack::tests`,
  `init::tests::{mcp_tests,seed_tests}`, `ctrl_session.rs`,
  `tools::mcp_live::spec`). All of these remain correctly guarded against
  each other — the guard added here doesn't touch them.
- **A handful of files intentionally use `#[serial]` INSTEAD of `HOME_LOCK`**
  because their tests hold state across `.await` (clippy forbids a sync
  mutex there): `llm::credentials`, `llm::adapter::tests`,
  `llm::helpers::tests`, `runtime::cli_def`, `ctrl::ctrl_turn::dispatch`
  — critically, **all of these ALSO take `HOME_LOCK`** (both mechanisms
  together), so they stay mutually exclusive with the `HOME_LOCK`-only
  group too.
- **`llm::http::tests` is the one file that mutates `$HOME` under
  `#[serial]` ALONE, with no `HOME_LOCK`** — this is the confirmed culprit
  above. `api::server::tests::models.rs` has an EXPLICIT existing comment
  acknowledging this exact gap ("this crate's test binary has a handful of
  pre-existing tests ... that sandbox `$HOME` without holding
  `crate::test_env::HOME_LOCK`, so a `$HOME`-swap here can race against
  them") — so the pattern was already known/documented, just not yet fixed.
  `llm::inference_client::tests` and
  `workflow::engine::executor::tests::checkpoint_resume` also carry
  `#[serial]` alone but do NOT mutate `$HOME` (only unrelated credential/env
  vars), so they are not part of this specific race.
- `session_record.rs`'s `runs_path_under_home` test reads `$HOME` (via
  `dirs::home_dir()`) with no lock at all — but it only asserts the path
  SHAPE, not the actual value, so it's benign (a pre-existing, harmless
  instance of the same anti-pattern, not a source of flakes).
- `mistake_log.rs` (issue #2709) already fixed the identical class via the
  exact same DI pattern this PR uses (`record_at`/`read_recent_global_at`
  taking the path as a parameter) — good existing precedent in this crate.

**Not fixed here (left as follow-ups, flagged for Bob to file if wanted):**
- `llm::http::tests`'s 5 tests still mutate `$HOME` without `HOME_LOCK`.
  They can't easily add `HOME_LOCK` (can't hold it across `.await`), and
  eliminating their `$HOME` mutation entirely would require an injectable
  seam in `trusty_common::inference::credentials::resolve_key`'s secure-store
  tier — a cross-crate change beyond this issue's scope. They remain a
  residual risk to every OTHER `HOME_LOCK`-only test in the crate (not just
  `listeners::store`, which this PR has now fully removed from the blast
  radius).
- `listeners::poll`'s cursor tests and `api::server::tests::listener_events.rs`/
  `slack::tests.rs`'s handler-level tests still sandbox `$HOME` via
  `HOME_LOCK` (correctly) rather than DI, because their production call
  paths (`cursor_path`, the HTTP router, `record_listener_event`) have no
  injectable directory parameter yet. Extending DI there would mean
  threading a directory override through `AppState`/handler signatures —
  bigger, separate-PR-sized surgery.
- `embedder::tests::default_model_matches_sentence_transformers_reference`
  and `trusty-search::create_index_*`'s flakes: NOT explained by this audit
  (different crates, no `HOME`/env-var mutation pattern found there in this
  pass) — still unknown-mechanism, need their own investigation.

## Test plan

- [x] `cargo test -p trusty-agents` (full workspace test binary + all
      integration test binaries, post-rebase) — 2521 passed, 0 failed, 12
      ignored
- [x] `cargo clippy -p trusty-agents --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-agents --check` — clean
- [x] `scripts/check_line_cap.sh` — 8 allowlisted, 0 violations
- [x] Reproduced the original #3922 race locally (2/5 failures) before the
      fix; confirmed 0/32 under the same repro loop after
- [x] Reproduced the critic's masking scenario directly
      (`events_dir_panics_when_a_different_thread_holds_home_lock` fails
      against the old `try_lock()`-based guard, passes against the new
      thread-local-ownership guard)
- [x] Stress-tested the full affected test set 100+ times at
      `--test-threads=16`: 0 failures after the ownership-tracking fix +
      the `.flush()` fix (vs. an intermittent ~2% `append_and_read_round_trips`
      failure before the `.flush()` fix, and 0/40 on the pre-#3943-HIGH-fix
      baseline under the same load, confirming the flush bug was newly
      exposed by this PR's changes, not pre-existing at this failure rate)
- [x] One unrelated, pre-existing flake observed once in the full test run
      (`workflow::engine::executor::tests::checkpoint_resume::resume_skips_completed_phases_and_reuses_their_output`,
      a `CheckpointNotFound` race with no $HOME/`HOME_LOCK`/`test_env`
      involvement whatsoever — confirmed by grep) — passed cleanly on
      rerun; out of scope for this PR, noting for a separate follow-up

References #3902, #3920, #3896.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
