### PR TITLE
test(trusty-code): standing concurrent-scenarios guard for TCODE_TELEMETRY_DATA_DIR race (#3925)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -23,6 +23,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   computed fresh on every `session.get_context_budget` query — mirroring
   `lifetime_compaction_alarm_count`'s existing "read fresh at query time"
   pattern exactly.
+- **Standing regression guard for the #3902 `TCODE_TELEMETRY_DATA_DIR` race
+  class (issue #3925).** PR #3920's fix for #3902 was verified only by the
+  author's local 40x loop (2/40 failures pre-fix, 0/40 post-fix) — a manual
+  process that lived nowhere in CI, so a FUTURE loop-integration test could
+  reintroduce the same "forgot to inject `telemetry_data_dir`" omission and
+  pass a single ordinary `cargo test` run before flaking later (exactly how
+  #3902 reached `main` in the first place). New
+  `agent_loop::tests::compression_telemetry_tests::concurrent_agent_loops_survive_data_dir_env_hammering`
+  deterministically manufactures the exact attack instead of hoping a
+  repeat-loop trips it: while holding `telemetry::DATA_DIR_ENV_LOCK` for its
+  own body, it races a background task that rewrites
+  `TCODE_TELEMETRY_DATA_DIR` with zero synchronization against four
+  concurrent scripted `AgentLoop` runs, each injecting its own
+  `telemetry_data_dir`. Because an injected loop never consults the env var,
+  every run must see exactly its own cadence records regardless of how
+  aggressively the global churns — validated to fail deterministically (not
+  probabilistically) when one scenario's injection is reverted. Mirrors the
+  identical pattern applied to trusty-agents' `EventStore`/`$HOME` race
+  (issue #3922); kept as two crate-local tests rather than one shared
+  harness since the two crates have no shared test-support crate and the
+  domain types differ enough that sharing code would cost more than it
+  saves.
 
 - **A cadence-level 60%-floor breach now has a durable backstop alarm
   (#3911).** The load-realistic soak (epic #3866, PR #3909) proved that

--- a/crates/trusty-code/src/agent_loop/compression_telemetry_tests.rs
+++ b/crates/trusty-code/src/agent_loop/compression_telemetry_tests.rs
@@ -486,3 +486,143 @@ async fn cadence_within_budget_never_writes_floor_breach_alarm() {
 
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// (#3925) Standing regression guard for the #3902 race CLASS, not just the
+/// five originally-affected call sites PR #3920 fixed.
+///
+/// Why: PR #3920's fix was verified only by the author's local 40x loop
+/// (2/40 failures pre-fix, 0/40 post-fix) — a manual process that lives
+/// nowhere in CI. At a ~5% per-run failure rate, an ordinary single-run
+/// `cargo test` has a good chance of missing a REINTRODUCTION of the same
+/// omission before it lands, exactly how #3902 reached `main` via PR #3896
+/// in the first place: a sixth loop-integration test could trigger a real
+/// cadence/threshold fire without injecting `telemetry_data_dir` and pass
+/// CI outright (the `#[cfg(test)]` guard in
+/// `AgentLoop::telemetry_data_dir()` only catches the "forgot to inject
+/// AND env var unset" case deterministically — it does NOT prove the
+/// injected path stays correct under concurrent load). Rather than a
+/// brute-force `#[ignore]`d N-iteration loop (only catches the historical
+/// rate probabilistically, and only if it's actually run), this test
+/// DETERMINISTICALLY manufactures the exact attack: a background task
+/// rewrites `TCODE_TELEMETRY_DATA_DIR` in a tight loop with NO
+/// synchronization per-write — exactly what an un-injected caller does by
+/// simply never touching `telemetry::DATA_DIR_ENV_LOCK` — for the FULL
+/// duration of four concurrent `AgentLoop` runs that all correctly inject
+/// `telemetry_data_dir`. Because an injected loop's
+/// `AgentLoop::telemetry_data_dir()` never consults the env var at all,
+/// every run below MUST see exactly its own cadence records no matter how
+/// aggressively the global churns concurrently; if a future change makes
+/// that resolution fall back to the env var again for an injected config,
+/// this test starts failing on the FIRST run, deterministically, rather
+/// than ~5% of the time. Mirrors the identical pattern applied to
+/// `trusty-agents`' `EventStore`/`$HOME` race (issue #3922) — see that
+/// crate's `listeners::store::tests::concurrent_event_store_scenarios_survive_home_env_hammering`;
+/// kept as two separate, crate-local tests rather than one shared harness
+/// since the two crates have no shared test-support crate today and the
+/// domain types (`AgentLoopConfig` vs. a bare directory parameter) differ
+/// enough that a literal shared abstraction would be more machinery than
+/// the ~40 lines it would save.
+/// What: Holds `telemetry::DATA_DIR_ENV_LOCK` for this test's ENTIRE body
+/// (same convention `session::protocol_budget`'s tests use) so the
+/// hammering below can never leak out and destabilize any OTHER
+/// lock-respecting test in this crate — the chaos is fully internal to
+/// this test's own scope. Spawns a background task that rewrites
+/// `TCODE_TELEMETRY_DATA_DIR` on every `tokio::task::yield_now` while four
+/// scripted loops (each `cadence: Some(cadence_turns: 1)`, guaranteeing a
+/// fire every turn) run concurrently via `tokio::join!`, each pointed at
+/// its own tempdir via `telemetry_data_dir`. Asserts each loop's own
+/// directory contains at least one `tcode-cadence` record — nothing lost
+/// to the concurrently-churning global.
+/// Test: itself. Validated to fail deterministically (not probabilistically)
+/// when one scenario's `telemetry_data_dir` injection is reverted to `None`
+/// (falling back to the raced env-var path) — see PR discussion for the
+/// before/after failure output.
+#[tokio::test]
+async fn concurrent_agent_loops_survive_data_dir_env_hammering() {
+    let _guard = telemetry::DATA_DIR_ENV_LOCK.lock().await;
+    let prev = std::env::var_os(telemetry::DATA_DIR_ENV_VAR);
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let hammer_stop = stop.clone();
+    let hammer = tokio::spawn(async move {
+        let mut i: u64 = 0;
+        while !hammer_stop.load(Ordering::Relaxed) {
+            i += 1;
+            // SAFETY: intentionally UNSYNCHRONIZED per-write — this
+            // reproduces the exact #3902 attack shape (a caller that never
+            // takes `DATA_DIR_ENV_LOCK`). Holding the lock for this whole
+            // test (above) keeps the hammering from leaking into any OTHER
+            // test; the injected scenarios below must survive it regardless.
+            unsafe {
+                std::env::set_var(
+                    telemetry::DATA_DIR_ENV_VAR,
+                    format!("/tmp/tcode-hammer-{i}"),
+                );
+            }
+            tokio::task::yield_now().await;
+        }
+    });
+
+    async fn scenario(
+        label: &'static str,
+    ) -> (std::path::PathBuf, Vec<telemetry::CompressionEvent>) {
+        let dir = temp_dir(label);
+        let mut fixtures: Vec<Value> = (0..4)
+            .map(|i| tool_call_response(&format!("call_{i}"), &format!("turn-{i}")))
+            .collect();
+        fixtures.push(stop_response("all done"));
+        let llm = Arc::new(ScriptedLlm::from_json(&fixtures));
+        let registry = registry_with_echo(false);
+
+        let agent = make_loop(
+            llm,
+            registry,
+            AgentLoopConfig {
+                cadence: Some(CadenceConfig {
+                    cadence_turns: 1,
+                    ..CadenceConfig::default()
+                }),
+                telemetry_data_dir: Some(dir.clone()),
+                ..AgentLoopConfig::default()
+            },
+        );
+        agent
+            .run("system prompt", "the task")
+            .await
+            .expect("run completes");
+        let events = read_jsonl(&dir);
+        (dir, events)
+    }
+
+    let (a, b, c, d) = tokio::join!(
+        scenario("hammer-a"),
+        scenario("hammer-b"),
+        scenario("hammer-c"),
+        scenario("hammer-d"),
+    );
+
+    stop.store(true, Ordering::Relaxed);
+    hammer.await.unwrap();
+
+    // SAFETY: still holding DATA_DIR_ENV_LOCK; restoring pre-test value
+    // before the guard drops at function end.
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var(telemetry::DATA_DIR_ENV_VAR, v),
+            None => std::env::remove_var(telemetry::DATA_DIR_ENV_VAR),
+        }
+    }
+
+    for (label, (dir, events)) in [("a", a), ("b", b), ("c", c), ("d", d)] {
+        let cadence_events: Vec<_> = events
+            .iter()
+            .filter(|e| e.surface == telemetry::SURFACE_TCODE_CADENCE)
+            .collect();
+        assert!(
+            !cadence_events.is_empty(),
+            "scenario {label} lost its own cadence records under \
+             TCODE_TELEMETRY_DATA_DIR hammering: {events:?}"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}


### PR DESCRIPTION
> **Update:** rebased onto fresh `origin/main` (through PR #3946) to resolve
> merge conflicts from #3941/#3946/#3911 landing since this branch was cut —
> conflicts were CHANGELOG-only plus an append/append conflict in
> `compression_telemetry_tests.rs` against #3911's new floor-breach tests
> (both kept, both pass). Also corrected a stale test count below (was
> 1585, now 1600 — main grew between when I first ran the gate and now).

## Summary

Closes #3925. PR #3920 fixed issue #3902's `TCODE_TELEMETRY_DATA_DIR` race
via dependency injection (`AgentLoopConfig::telemetry_data_dir`), but the
fix was verified only by the author's local 40x loop (2/40 failures
pre-fix, 0/40 post-fix) — a manual process that lives nowhere in CI. At a
~5% per-run failure rate, an ordinary single-run `cargo test` has a good
chance of missing a REINTRODUCTION of the same omission before it lands —
exactly how #3902 reached `main` via PR #3896 in the first place.

## Design choice: concurrent-scenarios test (option 2), not a stress loop or nextest repeat

#3925 laid out three options. I picked the concurrent-scenarios test
(`tokio::join!`, asserting no cross-contamination) and rejected the other
two:

- **`#[ignore]`d 20-50x stress loop**: only catches the historical ~5% rate
  probabilistically, and only if someone actually runs it — the exact gap
  #3925 is trying to close. A nightly-only job means a regression that
  lands Monday isn't caught until the nightly runs, hours or days late.
- **nextest retry/repeat config**: adds real wall-clock cost to EVERY CI
  run (2-5 min per #3925's own estimate) for the same probabilistic
  coverage, and doesn't target the actual failure mode — it just runs
  everything more times and hopes.
- **Concurrent-scenarios test (chosen)**: deterministic by construction
  once you understand why the race exists. An `AgentLoop` with
  `telemetry_data_dir: Some(dir)` injected NEVER reads
  `TCODE_TELEMETRY_DATA_DIR` — so if I make FOUR such loops run concurrently
  while a background task hammers that env var with zero synchronization
  (the exact #3902 attack shape), the injected loops literally cannot lose
  data unless something regresses the injection path itself. That means
  this test is fast (well under a second), runs on every ordinary CI
  invocation, and — critically — I validated it actually catches the
  regression it's designed for (see below), not just decoration that
  always passes.

## What was added

`agent_loop::tests::compression_telemetry_tests::concurrent_agent_loops_survive_data_dir_env_hammering`:

- Holds `telemetry::DATA_DIR_ENV_LOCK` (a `tokio::sync::Mutex`, so it CAN be
  held across `.await`, unlike trusty-agents' `std::sync::Mutex`-based
  `HOME_LOCK`) for the test's entire body — this keeps the internal chaos
  from leaking out and destabilizing `session::protocol_budget`'s tests,
  which also properly take this lock.
- Spawns a background task that rewrites `TCODE_TELEMETRY_DATA_DIR` on every
  `tokio::task::yield_now`, with NO per-write synchronization — reproducing
  exactly what an un-injected loop-integration test used to do by simply
  never touching the lock.
- Concurrently (`tokio::join!`) runs four scripted `AgentLoop`s, each
  `cadence: Some(cadence_turns: 1)` (guarantees a fire every turn) and each
  injecting its OWN `telemetry_data_dir`.
- Asserts every run's own directory has at least one `tcode-cadence`
  record — nothing lost to the concurrently-churning global.

## Validated the guard actually catches the regression

Temporarily reverted one scenario's `telemetry_data_dir` to `None` (the
"forgot to inject" case) and re-ran: **failed on the FIRST run**, via the
existing `#[cfg(test)]` fail-loud guard in
`AgentLoop::telemetry_data_dir()` (PR #3920's own recurrence guard) firing
deterministically — not the ~5% probabilistic flake this test is meant to
replace. Restored the real (all-four-injected) version before committing;
`cargo test` confirms it passes reliably.

## Why not one shared harness across trusty-code and trusty-agents

#3925 notes a shared stress harness could serve both this issue and #3922
(trusty-agents' `EventStore`/`$HOME` race, same structural pattern). I
looked at this and concluded a literal shared harness isn't justified:

- The two crates have no shared test-support crate today; introducing one
  just to host ~40 lines of test code on each side is more machinery than
  it saves.
- The domain types differ (`AgentLoopConfig` + a real scripted LLM loop
  here, vs. a bare directory parameter and a plain `EventStore` call over
  there) — a literal shared abstraction would need to paper over that
  difference, adding indirection without removing real duplication.

Instead, both tests follow the IDENTICAL pattern (hold the crate's lock for
the whole test → background-hammer the global with zero per-write sync →
run N properly-injected scenarios concurrently → assert no cross-
contamination), cross-referenced in each test's doc comment, so a future
third instance of this race class has an obvious template to copy from
either side. See trusty-agents PR #3943 (issue #3922) for the mirrored
test, `listeners::store::tests::concurrent_event_store_scenarios_survive_home_env_hammering`.

This PR is independent of PR #3943 and can merge in either order.

## Test plan

- [x] `cargo test -p trusty-code` (full workspace test binary + all
      integration test binaries) — 1600 lib tests passed, 0 failed, 4
      ignored; all integration test binaries green
- [x] `cargo clippy -p trusty-code --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-code --check` — clean
- [x] `scripts/check_line_cap.sh` — 8 allowlisted, 0 violations
- [x] Validated the new guard fails deterministically (not
      probabilistically) when the regression it targets is simulated

References #3902, #3920, #3896.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
