### PR TITLE
feat(trusty-agents-ui): five-section agent config — Personality / Knowledge / Skills / Listeners / Permissions (#3932)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,46 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- **Agent configuration is five sections: Personality / Knowledge / Skills /
+  Listeners / Permissions (#3932, GUI):** per the owner's directive — *"Instead
+  of tools, let's show skills"* — the config takeover's tab strip is reshaped to
+  DOC-57's normative order and re-backed, not merely relabelled. **Knowledge**
+  widens the old OKG Stores tab from store bindings alone to one pane over three
+  sub-surfaces: the live bindings, the `vector_search`→store linkage resolved
+  from the agent's own allow-list, and the declared MCP knowledge endpoints
+  (which report `trusty-memory` and `trusty-search` as *disabled* — their
+  shipped default — rather than quietly omitting them). **Skills** replaces the
+  Tools tab's single monospace textarea of raw globs with capability cards
+  grouped by tool-name prefix, each badged `synthetic` because no skill manifest
+  wraps its tools yet — so the unwrapped surface stays visible and wrapping
+  progress becomes measurable. **Permissions** moves last and stops being a chip
+  list: each mechanism now carries an explicit *enforced* / *not enforced*
+  marker, states the deny-on-absent polarity of an empty allow-list, and names
+  what it cannot see (values inherited through `extends`, the reserved
+  `user_authority` field, and the tier/autonomy model with no read path).
+  Front-end only: no new HTTP route, no config-schema change, independently
+  revertable. The panel is split into one component per section with the persona
+  edit buffer and dirty aggregation kept in the shell, so an in-progress prompt
+  survives a section switch and every exit path still routes through the
+  unsaved-changes guard.
+
+### Removed
+
+- **The Tools tab's glob textarea, and with it GUI editing of
+  `[tools].allow` (#3932):** capability is now shown as skills, and editing
+  returns as `PATCH { skills_allow }` over skill names rather than over the
+  globs beneath them (DOC-57 §5.7). Until then `agent.toml` is the edit surface,
+  which the Skills pane says outright.
+- **The Listeners pane's hardcoded "not bound" badge (#3932):** it asserted a
+  per-agent binding state for every agent regardless of configuration, inventing
+  a listener that may not exist and hiding one that is quietly failing. The pane
+  now labels itself as connector scaffolding until `GET /api/agents/:name/listeners`
+  lands (#3937). The Personality pane's fabricated per-connector-instructions
+  list is gone for the same reason — it enumerated connectors it had never
+  looked at.
+
 ### Added
 
 - **Agent configuration takes over the pane (#3894, GUI):** opening the gear no

--- a/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  /**
+   * Why (#3932, DOC-57 §4 / §8.2): section 2 of the five-section agent config
+   * — "what the agent knows". This replaces the OKG Stores tab, and §8.2's G-2
+   * is explicit that the change is not a label swap: Knowledge is ONE pane over
+   * THREE sub-surfaces, because a user asking "what does this agent know?" must
+   * not have to correlate a store card, a tool glob and a harness endpoint
+   * table across three files.
+   *
+   * What: K-a store bindings (live, #3878 — the only sub-surface with a route
+   * in this phase); K-b the store-bound knowledge tool, resolved against the
+   * agent's own allow-list so the `vector_search`→store linkage §4.3 requires
+   * is visible; K-c the declared MCP knowledge endpoints. Read-only throughout
+   * — store editing is #3890's contract (§4.5, K-3).
+   *
+   * The pane's posture is #3878's, inherited by §4.2: declarative data only,
+   * degrade never fail, and never fabricate (G-4). K-a distinguishes loading /
+   * empty / error as three states. K-b states the classification gap rather
+   * than guessing at one — `kind = "knowledge"` manifests are Phase 2 (#3933).
+   * K-c reports the shipped defaults as declared-not-probed, and shows a
+   * disabled endpoint as DISABLED with its reason instead of hiding it
+   * (C-03.2).
+   * Test: `AgentConfigKnowledge.test.ts`.
+   */
+  import { AlertCircle, Loader2 } from 'lucide-svelte';
+  import { KNOWLEDGE_MCP_ENDPOINTS, type OkgStoreBinding } from '../lib/agentConfig';
+
+  /** `null` until the first load resolves — "loading", not "binds nothing". */
+  export let stores: OkgStoreBinding[] | null = null;
+  export let issues: string[] = [];
+  export let error = '';
+  /**
+   * Store-bound knowledge tools this agent's `[tools].allow` actually grants
+   * (DOC-57 §4.3). Resolved by the shell; empty is a real answer, not a gap.
+   */
+  export let storeBoundTools: string[] = [];
+
+  const heading =
+    'shrink-0 font-mono text-[10px] font-semibold uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50';
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+  <section class="flex flex-col gap-2">
+    <h3 class={heading}>Store bindings</h3>
+    <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+      Knowledge trees + search indexes bound to this agent, resolved live against trusty-search and
+      trusty-memory. Edit bindings in <code class="font-mono">agent.toml</code>'s
+      <code class="font-mono">[[stores]]</code>.
+    </p>
+    {#if stores === null}
+      <div class="flex items-center gap-2 text-xs text-foundry-light-muted dark:text-foundry-text/60">
+        <Loader2 class="h-3.5 w-3.5 animate-spin" /> Resolving stores…
+      </div>
+    {:else if error}
+      <p class="flex items-center gap-1.5 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-[11px] text-red-500 dark:text-red-400">
+        <AlertCircle class="h-3.5 w-3.5 shrink-0" /> Could not read store bindings: {error}
+      </p>
+    {:else if stores.length === 0}
+      <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+        This agent binds no OKG store. Add a <code class="font-mono">[[stores]]</code> table to its
+        <code class="font-mono">agent.toml</code> to give it a knowledge tree.
+      </p>
+    {/if}
+    {#each stores ?? [] as store (store.name)}
+      <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
+        <div class="flex items-center justify-between gap-2">
+          <span class="font-mono text-xs font-semibold text-foundry-light-text dark:text-foundry-text">{store.name}</span>
+          <span
+            class="shrink-0 rounded-md px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide {store.connected
+              ? 'bg-foundry-teal/15 text-foundry-teal'
+              : 'bg-foundry-light-border/50 dark:bg-black/30 text-foundry-light-muted dark:text-foundry-text/50'}"
+          >
+            {store.connected ? 'connected' : 'not connected'}
+          </span>
+        </div>
+        <div class="mt-1 flex flex-col gap-0.5 font-mono text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+          <span>tree: {store.tree}</span>
+          <span>
+            index: {store.index}{#if store.connected && store.chunk_count !== undefined}
+              &nbsp;· {store.chunk_count.toLocaleString()} chunks{/if}{#if store.connected && store.index_status}
+              &nbsp;· {store.index_status}{/if}
+          </span>
+          {#if store.root_path}<span>root: {store.root_path}</span>{/if}
+          {#if store.palace}
+            <span>
+              palace: {store.palace}
+              {#if store.palace_connected === false}
+                <span class="text-foundry-amber">— {store.palace_reason ?? 'not connected'}</span>
+              {/if}
+            </span>
+          {/if}
+        </div>
+        {#if !store.connected && store.reason}
+          <p class="mt-1.5 text-[11px] text-foundry-amber">{store.reason}</p>
+        {/if}
+        <!-- §4.3: `vector_search`'s default index IS this binding (#3864), so
+             the tool renders UNDER the store it reads, not as a free-floating
+             chip elsewhere in the pane. -->
+        {#if storeBoundTools.length > 0}
+          <div class="mt-2 flex flex-wrap items-center gap-1.5 border-t border-foundry-light-border/60 dark:border-foundry-border/60 pt-2">
+            <span class="font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
+              reads via
+            </span>
+            {#each storeBoundTools as tool (tool)}
+              <span class="rounded border border-foundry-light-border dark:border-foundry-border px-1.5 py-0.5 font-mono text-[10px] text-foundry-light-text dark:text-foundry-text">
+                {tool}
+              </span>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/each}
+    {#each issues as issue (issue)}
+      <p class="text-[11px] text-foundry-amber">{issue}</p>
+    {/each}
+  </section>
+
+  <section class="flex flex-col gap-2">
+    <h3 class={heading}>Knowledge tools</h3>
+    {#if storeBoundTools.length === 0}
+      <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+        This agent's allow-list grants no store-bound knowledge tool.
+      </p>
+    {:else}
+      <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+        Bound to the store above: <span class="font-mono">{storeBoundTools.join(', ')}</span>.
+      </p>
+    {/if}
+    <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+      A capability is knowledge-classified when the skill wrapping it declares
+      <code class="font-mono">kind = "knowledge"</code> (DOC-57 §4.3) — the only classification
+      mechanism there is, deliberately not a hardcoded tool list. No manifest carries that key yet
+      (#3933), so nothing is routed out of <strong>Skills</strong> — which still lists every
+      capability, including the one above — and nothing is guessed into this section.
+    </p>
+  </section>
+
+  <section class="flex flex-col gap-2">
+    <h3 class={heading}>MCP knowledge connections</h3>
+    <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+      Knowledge services reachable over MCP/OpenRPC, as <em>declared</em> in the shipped
+      <code class="font-mono">config.toml</code> defaults — not probed. Live status arrives with
+      <code class="font-mono">GET /api/agents/:name/knowledge</code> (DOC-57 §4.5).
+    </p>
+    {#each KNOWLEDGE_MCP_ENDPOINTS as endpoint (endpoint.name)}
+      <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
+        <div class="flex items-center justify-between gap-2">
+          <span class="font-mono text-xs font-semibold text-foundry-light-text dark:text-foundry-text">{endpoint.name}</span>
+          <span
+            class="shrink-0 rounded-md px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide {endpoint.enabled
+              ? 'bg-foundry-teal/15 text-foundry-teal'
+              : 'bg-foundry-light-border/50 dark:bg-black/30 text-foundry-light-muted dark:text-foundry-text/50'}"
+          >
+            {endpoint.enabled ? 'enabled' : 'disabled'}
+          </span>
+        </div>
+        <p class="mt-0.5 text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+          {endpoint.description}
+        </p>
+        <div class="mt-1.5 flex flex-wrap gap-1">
+          {#each endpoint.scopes as scope (scope)}
+            <span class="rounded border border-foundry-light-border dark:border-foundry-border px-1.5 py-0.5 font-mono text-[10px] text-foundry-light-muted dark:text-foundry-text/50">
+              {scope}
+            </span>
+          {/each}
+        </div>
+        {#if endpoint.reason}
+          <p class="mt-1.5 text-[11px] text-foundry-amber">{endpoint.reason}</p>
+        {/if}
+      </div>
+    {/each}
+  </section>
+</div>

--- a/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.svelte
@@ -20,6 +20,18 @@
    * K-c reports the shipped defaults as declared-not-probed, and shows a
    * disabled endpoint as DISABLED with its reason instead of hiding it
    * (C-03.2).
+   *
+   * K-b's linkage is a CORRELATION of two independent facts and must be
+   * rendered as one (PR #3945 code-critic HIGH-1). `storeBoundTools` says only
+   * that `[tools].allow` grants the tool; `stores` says what the tool would
+   * actually read. Asserting the linkage from the grant alone produced a
+   * self-contradicting pane — "binds no OKG store" above "bound to the store
+   * above" — which is precisely the fabrication class this section exists to
+   * eliminate. The correlation follows `AgentStoresConfig::default_search_index`
+   * (`stores/config.rs:170`): the tool's default index is the PRIMARY (first)
+   * binding, so with no binding it falls back to the tool's own shipped index,
+   * and with several only the first is the target — hence one chip on one card,
+   * never one per card.
    * Test: `AgentConfigKnowledge.test.ts`.
    */
   import { AlertCircle, Loader2 } from 'lucide-svelte';
@@ -32,8 +44,18 @@
   /**
    * Store-bound knowledge tools this agent's `[tools].allow` actually grants
    * (DOC-57 §4.3). Resolved by the shell; empty is a real answer, not a gap.
+   * On its own it says nothing about whether a store exists to read — see the
+   * component doc.
    */
   export let storeBoundTools: string[] = [];
+
+  /**
+   * The binding `vector_search` actually defaults to: the PRIMARY (first) one,
+   * mirroring `default_search_index`. `null` while loading and when the agent
+   * binds nothing — two states this pane must not conflate with "bound".
+   */
+  $: primaryStore = stores && stores.length > 0 ? stores[0] : null;
+  $: grantedTools = storeBoundTools.join(', ');
 
   const heading =
     'shrink-0 font-mono text-[10px] font-semibold uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50';
@@ -61,7 +83,7 @@
         <code class="font-mono">agent.toml</code> to give it a knowledge tree.
       </p>
     {/if}
-    {#each stores ?? [] as store (store.name)}
+    {#each stores ?? [] as store, index (store.name)}
       <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
         <div class="flex items-center justify-between gap-2">
           <span class="font-mono text-xs font-semibold text-foundry-light-text dark:text-foundry-text">{store.name}</span>
@@ -95,8 +117,10 @@
         {/if}
         <!-- §4.3: `vector_search`'s default index IS this binding (#3864), so
              the tool renders UNDER the store it reads, not as a free-floating
-             chip elsewhere in the pane. -->
-        {#if storeBoundTools.length > 0}
+             chip elsewhere in the pane. Only the PRIMARY binding is that
+             target (`default_search_index`) — repeating the chip under every
+             card would claim the tool reads all of them. -->
+        {#if index === 0 && storeBoundTools.length > 0}
           <div class="mt-2 flex flex-wrap items-center gap-1.5 border-t border-foundry-light-border/60 dark:border-foundry-border/60 pt-2">
             <span class="font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
               reads via
@@ -117,13 +141,31 @@
 
   <section class="flex flex-col gap-2">
     <h3 class={heading}>Knowledge tools</h3>
+    <!-- Four states, because the grant and the binding are independent facts:
+         not granted / granted-but-still-resolving / granted with a store to
+         read / granted with none. Collapsing the last two is the HIGH-1
+         fabrication. -->
     {#if storeBoundTools.length === 0}
       <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
         This agent's allow-list grants no store-bound knowledge tool.
       </p>
-    {:else}
+    {:else if stores === null}
       <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
-        Bound to the store above: <span class="font-mono">{storeBoundTools.join(', ')}</span>.
+        Grants <span class="font-mono">{grantedTools}</span> — resolving which store it reads…
+      </p>
+    {:else if primaryStore}
+      <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+        Grants <span class="font-mono">{grantedTools}</span>, reading
+        <span class="font-mono">{primaryStore.name}</span>.{#if stores.length > 1}
+          Only the first binding is the default search target; the
+          {stores.length - 1} other{stores.length > 2 ? 's are' : ' is'} reachable solely by an
+          explicit <code class="font-mono">index_id</code>.{/if}
+      </p>
+    {:else}
+      <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-amber">
+        Grants <span class="font-mono">{grantedTools}</span> but binds no
+        <code class="font-mono">[[stores]]</code>, so there is no agent-owned store for it to read
+        — searches fall back to the tool's shipped default index.
       </p>
     {/if}
     <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">

--- a/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.test.ts
@@ -1,0 +1,94 @@
+// Why (#3932, DOC-57 §4): the Knowledge pane widened the old OKG Stores tab
+// from one sub-surface to three, and the spec's conformance criteria are about
+// what it must NOT do: never collapse loading into empty (G-4's three states),
+// never omit a disabled knowledge endpoint (C-03.2), and never guess which
+// capabilities are knowledge-classified when no manifest declares `kind` yet
+// (§4.3). The one linkage it MUST show is `vector_search` under the store it
+// reads (§4.3, the #3864 seam).
+// What: Mounts the component directly with props — the shell owns the fetches.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import AgentConfigKnowledge from './AgentConfigKnowledge.svelte';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+const STORE = {
+  name: 'izzie-kb',
+  tree: 'okg://izzie',
+  index: 'izzie-kb',
+  connected: true,
+  chunk_count: 552,
+};
+
+function render(props: Record<string, unknown> = {}) {
+  instance = mount(AgentConfigKnowledge, {
+    target,
+    props: { stores: [STORE], issues: [], error: '', storeBoundTools: [], ...props },
+  }) as unknown as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+});
+
+describe('AgentConfigKnowledge — store bindings (K-a)', () => {
+  it('distinguishes loading from empty from error (G-4)', () => {
+    render({ stores: null });
+    expect(target.textContent).toContain('Resolving stores…');
+    unmount(instance!);
+
+    render({ stores: [] });
+    expect(target.textContent).toContain('binds no OKG store');
+    unmount(instance!);
+
+    render({ stores: [], error: 'GET /api/agents/izzie/stores failed: 503' });
+    expect(target.textContent).toContain('Could not read store bindings');
+    expect(target.textContent).not.toContain('binds no OKG store');
+  });
+
+  it('renders a resolved binding with its live stats', () => {
+    render();
+    expect(target.textContent).toContain('izzie-kb');
+    expect(target.textContent).toContain('okg://izzie');
+    expect(target.textContent).toContain('552');
+    expect(target.textContent).toContain('connected');
+  });
+});
+
+describe('AgentConfigKnowledge — knowledge tools (K-b)', () => {
+  it('shows the store-bound tool under the store it reads (§4.3)', () => {
+    render({ storeBoundTools: ['vector_search'] });
+    expect(target.textContent).toContain('reads via');
+    expect(target.textContent).toContain('vector_search');
+  });
+
+  it('names the classification gap rather than guessing a knowledge tool set', () => {
+    render({ storeBoundTools: [] });
+    expect(target.textContent).toContain('grants no store-bound knowledge tool');
+    expect(target.textContent).toContain('kind = "knowledge"');
+  });
+});
+
+describe('AgentConfigKnowledge — MCP connections (K-c)', () => {
+  it('lists a configured-but-disabled endpoint with its reason, never hidden (C-03.2)', () => {
+    render();
+    expect(target.textContent).toContain('trusty-memory');
+    expect(target.textContent).toContain('trusty-search');
+    expect(target.textContent).toContain('gworkspace');
+    expect(target.textContent).toContain('awaits `--rpc` mode');
+    // The list is the shipped declaration, not a probe — saying so is the
+    // difference between honest scaffolding and an invented status.
+    expect(target.textContent).toContain('not probed');
+  });
+});

--- a/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.test.ts
@@ -70,6 +70,7 @@ describe('AgentConfigKnowledge — knowledge tools (K-b)', () => {
   it('shows the store-bound tool under the store it reads (§4.3)', () => {
     render({ storeBoundTools: ['vector_search'] });
     expect(target.textContent).toContain('reads via');
+    expect(target.textContent).toContain('reading');
     expect(target.textContent).toContain('vector_search');
   });
 
@@ -77,6 +78,43 @@ describe('AgentConfigKnowledge — knowledge tools (K-b)', () => {
     render({ storeBoundTools: [] });
     expect(target.textContent).toContain('grants no store-bound knowledge tool');
     expect(target.textContent).toContain('kind = "knowledge"');
+  });
+
+  // PR #3945 code-critic HIGH-1. `storeBoundTools` is derived from
+  // `[tools].allow` alone, so before the fix the pane asserted a linkage from
+  // the GRANT without consulting whether any binding existed — rendering
+  // "binds no OKG store" and "bound to the store above" in the same view. Two
+  // independent facts must be correlated before either is claimed.
+  it('never claims a store linkage for an agent that binds nothing', () => {
+    render({ stores: [], storeBoundTools: ['vector_search'] });
+    expect(target.textContent).toContain('binds no OKG store');
+    // The contradicting half must be absent in every spelling it could take.
+    expect(target.textContent).not.toContain('the store above');
+    expect(target.textContent).not.toContain('reads via');
+    expect(target.textContent).not.toMatch(/reading\s/);
+    // …replaced by what actually happens: no agent-owned store, so the tool
+    // uses its own shipped index.
+    expect(target.textContent).toContain('binds no');
+    expect(target.textContent).toContain("shipped default index");
+  });
+
+  it('claims no linkage while the bindings are still resolving', () => {
+    render({ stores: null, storeBoundTools: ['vector_search'] });
+    expect(target.textContent).toContain('resolving which store it reads');
+    expect(target.textContent).not.toContain('reads via');
+    expect(target.textContent).not.toContain('shipped default index');
+  });
+
+  it('points a multi-store agent at the one binding the tool actually defaults to', () => {
+    render({
+      stores: [STORE, { ...STORE, name: 'second-kb', index: 'second-kb' }],
+      storeBoundTools: ['vector_search'],
+    });
+    // `default_search_index` is the PRIMARY binding — one chip, on one card,
+    // not one per card implying the tool reads all of them.
+    expect(target.textContent?.match(/reads via/g)).toHaveLength(1);
+    expect(target.textContent).toContain('izzie-kb');
+    expect(target.textContent).toContain('Only the first binding is the default search target');
   });
 });
 

--- a/crates/trusty-agents/ui/src/components/AgentConfigListeners.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigListeners.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  /**
+   * Why (#3932, DOC-57 §6 / §8.2): section 4 of the five-section agent config
+   * — "what the agent reacts to". An agent *acts* via skills and *reacts* via
+   * listeners; these are inbound API bindings, not MCP tools.
+   *
+   * This slice moves the section into its normative position (fourth, ahead of
+   * Permissions) and makes what it shows honest. Completing the pane is #3937 /
+   * #3891 and is deliberately NOT attempted here.
+   *
+   * What: the connector definitions this UI ships, under a banner saying
+   * plainly that they are UI scaffolding rather than this agent's `[[listeners]]`.
+   * The per-listener "not bound" badge is GONE: §6.2's L-1 names it as the
+   * defect — it was hardcoded, so it asserted a binding state for every agent
+   * regardless of configuration, inventing a listener that may not exist and
+   * hiding one that is quietly failing. A pane that says "I cannot see your
+   * bindings" is honest; one that says "you have none" when it never looked is
+   * not. `GET /api/agents/:name/listeners` replaces this constant outright
+   * (C-05.1).
+   * Test: `AgentConfigListeners.test.ts`.
+   */
+  import { AlertCircle } from 'lucide-svelte';
+  import { DEFINED_LISTENERS } from '../lib/agentConfig';
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
+  <p class="flex items-start gap-1.5 rounded-md border border-foundry-amber/40 bg-foundry-amber/10 px-3 py-2 text-[11px] text-foundry-amber">
+    <AlertCircle class="mt-0.5 h-3.5 w-3.5 shrink-0" />
+    <span>
+      Scaffolding, not configuration. No route reads an agent's
+      <code class="font-mono">[[listeners]]</code> yet (#3937), so nothing below reflects what
+      <em>this</em> agent is bound to — these are the connector definitions the UI ships.
+    </span>
+  </p>
+  <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+    Inbound event bindings — API connections to upstream event providers, not MCP tools. Bindings
+    live in <code class="font-mono">agent.toml</code>'s
+    <code class="font-mono">[[listeners]]</code>.
+  </p>
+  {#each DEFINED_LISTENERS as listener (listener.id)}
+    <div class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2">
+      <span class="text-sm font-semibold text-foundry-light-text dark:text-foundry-text">{listener.label}</span>
+      <p class="mt-0.5 text-[11px] text-foundry-light-muted dark:text-foundry-text/50">{listener.description}</p>
+      <div class="mt-1.5 flex flex-wrap gap-1">
+        {#each listener.eventTypes as eventType (eventType)}
+          <span class="rounded border border-dashed border-foundry-light-border dark:border-foundry-border px-1.5 py-0.5 font-mono text-[10px] text-foundry-light-muted dark:text-foundry-text/40">
+            {eventType}
+          </span>
+        {/each}
+      </div>
+    </div>
+  {/each}
+</div>

--- a/crates/trusty-agents/ui/src/components/AgentConfigListeners.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigListeners.test.ts
@@ -1,0 +1,49 @@
+// Why (#3932, DOC-57 §6.2, L-1): the Listeners pane's defect was never that it
+// was empty — it was that it stamped a hardcoded "not bound" badge on both
+// connectors for every agent, asserting a per-agent binding state it had never
+// read. That both invents a listener that may not exist and hides one that is
+// quietly failing. This slice moves the section to its normative position and
+// makes the pane say what it actually knows; #3937/#3891 replaces the constant
+// with `GET /api/agents/:name/listeners` (C-05.1).
+// What: Mounts the component (it takes no props — that is the point).
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import AgentConfigListeners from './AgentConfigListeners.svelte';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  instance = mount(AgentConfigListeners, { target }) as unknown as Record<string, unknown>;
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+});
+
+describe('AgentConfigListeners', () => {
+  it('labels itself scaffolding rather than this agent\'s configuration', () => {
+    expect(target.textContent).toContain('Scaffolding, not configuration');
+    expect(target.textContent).toContain('[[listeners]]');
+  });
+
+  it('claims no binding state for any connector (L-1)', () => {
+    // The hardcoded per-listener badge is gone. The banner may (and does) use
+    // the word "bound" to say the pane cannot see the bindings — asserting a
+    // binding STATE is the defect, discussing the gap is the fix.
+    expect(target.textContent).not.toContain('not bound');
+  });
+
+  it('still shows the connector definitions and their event kinds', () => {
+    expect(target.textContent).toContain('Gmail');
+    expect(target.textContent).toContain('Google Calendar');
+    expect(target.textContent).toContain('message.received');
+  });
+});

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
@@ -1,45 +1,49 @@
 <script lang="ts">
   /**
-   * Why (#3819, epic #3052 — Bob's concept-demo centerpiece: "this agent -
-   * OKG - tool - listener is the most revolutionary feature of trusty
-   * agents"): the old top-nav Personality tab (a separate overlay-creation
-   * flow) is replaced by an IN-PANE config form scoped to whichever agent is
-   * currently active in the chat pane, opened via the gear icon in
-   * `ChatHeader`. Five sections, in the order Bob specified: Personality
-   * (main persona.md prose — real read/write), OKG Stores (the agent's bound
-   * knowledge trees/search indexes — REAL as of #3816/#3864: read from
-   * `agent.toml`'s `[[stores]]` and resolved live against trusty-search /
-   * trusty-memory by `GET /api/agents/:name/stores`), Tools (the
-   * `[tools].allow` glob allowlist —
-   * real read/write), Permissions (`[agent].scopes` — real, READ-ONLY: no
-   * write contract established yet), Listeners (gmail/google-calendar —
-   * no backend yet, spec being filed; rendered from `DEFINED_LISTENERS` as
-   * structured concept scaffolding per Bob's explicit ask).
-   * What: Fetches `AgentDetail` + `AgentPersona` for `agentName` on mount
-   * and whenever `agentName` changes. Personality and Tools are editable
-   * with their own Save button (independent PATCH calls, so saving one
-   * doesn't require the other to be valid). Permissions/OKG
-   * Stores/Listeners render read-only — store bindings are edited in
-   * `agent.toml`, not here. Concierge (`ctrl`) gets a static
-   * notice per Bob: editable by name, but not an add-agent template.
+   * Why (#3819/#3932, epic #3052 — Bob's concept-demo centerpiece: "this agent
+   * - OKG - tool - listener is the most revolutionary feature of trusty
+   * agents"): agent configuration is an IN-PANE surface scoped to whichever
+   * agent is active in the chat pane, opened via `ChatHeader`'s gear.
    *
-   * #3894 (Bob: "when we're in agent configuration, let's take over that
-   * pane"): this panel no longer shares the chat column as a 320px strip —
-   * `AgentConfigOverlay` mounts it as a full-pane takeover, so the layout here
-   * is now a height-filling flex column: header + tabs are `shrink-0` and the
-   * active tab takes the rest, with the instructions editor growing into every
-   * remaining pixel instead of #3862's `55vh/70vh` clamp. The header carries
-   * the takeover's exit affordances (Back / Close, plus an Esc hint —
-   * `AgentConfigOverlay` owns the key handler) via the `onExit` prop, and no
-   * exit path reaches `onExit` without passing the unsaved-changes confirm
-   * (see `requestExit` / `configPaneDirty`).
-   * Test: `AgentConfigPanel.test.ts` (exit affordances, instructions-editor
-   * sizing invariants, tab preservation) + `agentConfig.test.ts` (scaffolding
-   * data); the save round-trip stays manual (`pnpm dev`, open the gear, edit +
-   * save Personality/Tools, confirm a re-open shows the persisted value) per
-   * the project's convention for fetch-driven Svelte views.
+   * #3932 reshapes it to DOC-57's five sections, in the owner's order:
+   * **Personality / Knowledge / Skills / Listeners / Permissions** — identity →
+   * knowledge → capability → reactivity → constraint. Bob: *"Instead of tools,
+   * let's show skills. Should be Personality, Knowledge (list knowledge tools
+   * including MCP connections to knowledge stores), Skills (each tool should be
+   * wrapped in a skill), Listeners, the Permissions."* Three of the five
+   * changed materially rather than in name: OKG Stores widened into Knowledge
+   * (§4), the raw-glob Tools textarea became read-only skill cards (§5), and
+   * Permissions moved last and gained per-mechanism `enforced` markers (§7).
+   *
+   * What: This component is now the SHELL — header, tab strip, the one data
+   * load, the one PATCH path, and the exit guard. Each section's body lives in
+   * its own `AgentConfig<Section>.svelte` (DOC-57 §8.4). Phase 1 adds no HTTP
+   * route and no config-schema change (§8.5, G-7): every pane maps onto data
+   * already served by `GET /api/agents/:name`, `.../persona` and `.../stores`,
+   * and a pane whose spec'd data source does not exist yet says so instead of
+   * fabricating it (G-4).
+   *
+   * The shell keeps the editable persona buffer (rather than letting
+   * `AgentConfigPersonality` own it) for two reasons that are easy to lose in
+   * a decomposition: section switching unmounts the inactive body, so a
+   * child-owned buffer would discard a half-written system prompt on every tab
+   * click; and `configPaneDirty` — which Esc, Back, Close and the Chat→Events
+   * switch all consult through `requestExitConfigPane` — needs one owner that
+   * outlives the tabs (§8.4, G-6a).
+   *
+   * #3894: the panel is a full-pane takeover mounted by `AgentConfigOverlay`,
+   * so the layout is a height-filling flex column — header + tabs `shrink-0`,
+   * the active section taking the rest, with the instructions editor growing
+   * into every remaining pixel (§8.4, G-6b).
+   * Test: `AgentConfigPanel.test.ts` (five-section tab strip, exit affordances,
+   * editor sizing invariants, edit survival across a section switch),
+   * `AgentConfig*.test.ts` per section, `agentConfig.test.ts` (the derivations),
+   * and `tests/config-takeover.spec.ts` (measured layout). The save round-trip
+   * stays manual (`pnpm dev`, open the gear, edit + save Personality, confirm a
+   * re-open shows the persisted value) per the project's convention for
+   * fetch-driven Svelte views.
    */
-  import { AlertCircle, ArrowLeft, Save, Loader2, Settings2, X } from 'lucide-svelte';
+  import { AlertCircle, ArrowLeft, Loader2, Save, Settings2, X } from 'lucide-svelte';
   import { onDestroy, onMount } from 'svelte';
   import { get } from 'svelte/store';
   import { configExitIntent, configPaneDirty } from '../stores/configPane';
@@ -48,10 +52,17 @@
     fetchAgentPersona,
     patchAgent,
     fetchAgentStores,
-    DEFINED_LISTENERS,
+    matchesToolGlob,
+    synthesizeSkills,
+    STORE_BOUND_KNOWLEDGE_TOOLS,
     type AgentDetail,
     type OkgStoreBinding,
   } from '../lib/agentConfig';
+  import AgentConfigPersonality from './AgentConfigPersonality.svelte';
+  import AgentConfigKnowledge from './AgentConfigKnowledge.svelte';
+  import AgentConfigSkills from './AgentConfigSkills.svelte';
+  import AgentConfigListeners from './AgentConfigListeners.svelte';
+  import AgentConfigPermissions from './AgentConfigPermissions.svelte';
 
   export let agentName: string;
   /** True when the active pane is Concierge (`ctrl`) — fixed coordination
@@ -71,7 +82,17 @@
    * Back/Close affordances; Esc is handled by `AgentConfigOverlay`. */
   export let onExit: () => void;
 
-  type Tab = 'personality' | 'okg' | 'tools' | 'permissions' | 'listeners';
+  /** DOC-57 §2.1: the order is NORMATIVE, and it is not the pre-#3932 order
+   * (which put Permissions before Listeners). */
+  const SECTIONS = [
+    ['personality', 'Personality'],
+    ['knowledge', 'Knowledge'],
+    ['skills', 'Skills'],
+    ['listeners', 'Listeners'],
+    ['permissions', 'Permissions'],
+  ] as const;
+
+  type Tab = (typeof SECTIONS)[number][0];
   let tab: Tab = 'personality';
 
   let loading = true;
@@ -81,9 +102,6 @@
   let personaEditable = false;
   let savedPersonaContent = '';
 
-  let toolsText = ''; // one glob per line — simplest editable form of a string[]
-  let savedToolsText = '';
-
   /** Live OKG store bindings (#3816/#3864) — `null` until the first load
    * resolves, so the pane can distinguish "loading" from "binds nothing". */
   let okgStores: OkgStoreBinding[] | null = null;
@@ -92,11 +110,22 @@
 
   let saving = false;
   let saveError = '';
-  let justSaved: Tab | null = null;
+  let justSavedPersonality = false;
   let justSavedTimer: ReturnType<typeof setTimeout> | null = null;
 
   $: personalityDirty = personaContent !== savedPersonaContent;
-  $: toolsDirty = toolsText !== savedToolsText;
+
+  /**
+   * DOC-57 §5.5/§8.5: Skills and the Knowledge pane's tool linkage are DERIVED
+   * from `AgentDetail.tools_allow` — the only capability data this phase has.
+   * Note `parse_agent_toml` reads a single file with no `extends` merge, so
+   * this is what the agent DECLARES; the panes say so rather than presenting it
+   * as the resolved effective set.
+   */
+  $: skills = synthesizeSkills(detail?.tools_allow ?? []);
+  $: storeBoundTools = STORE_BOUND_KNOWLEDGE_TOOLS.filter((tool) =>
+    (detail?.tools_allow ?? []).some((pattern) => matchesToolGlob(pattern, tool)),
+  );
 
   /**
    * Why (PR #3895 code-critic HIGH-1): before this, Esc/Back/Close unmounted
@@ -109,26 +138,27 @@
    * What: `configPaneDirty` mirrors the panel's dirty state for the exit paths
    * that live outside it (Esc, and App's Chat→Events switch); those raise
    * `configExitIntent`, which this component turns into the confirm prompt.
+   * Since #3932 the Skills pane is read-only (§5.7, S-12), so Personality is
+   * the only editable section and the only dirty source — but the aggregation
+   * deliberately stays here in the shell, because that is the seam a second
+   * editable section (Phase 3's `skills_allow`) plugs into.
    * Test: `ChatPane.test.ts` — Esc / Back / Close / tab-switch with a dirty
    * editor.
    */
   let confirmingExit = false;
   let seenExitIntent = get(configExitIntent);
 
-  $: configPaneDirty.set(personalityDirty || toolsDirty);
+  $: configPaneDirty.set(personalityDirty);
   $: if ($configExitIntent !== seenExitIntent) {
     seenExitIntent = $configExitIntent;
     confirmingExit = true;
   }
-  $: dirtySections = [personalityDirty && 'Personality', toolsDirty && 'Tools']
-    .filter(Boolean)
-    .join(' and ');
 
   onDestroy(() => configPaneDirty.set(false));
 
   /** Exit affordances go through here, never straight to `onExit`. */
   function requestExit() {
-    if (personalityDirty || toolsDirty) {
+    if (personalityDirty) {
       confirmingExit = true;
       return;
     }
@@ -144,17 +174,9 @@
   async function saveAndExit() {
     saveError = '';
     if (personalityDirty) await savePersonality();
-    if (!saveError && toolsDirty) await saveTools();
     if (saveError) return; // stay put and show the error rather than lose the edit
     confirmingExit = false;
     onExit();
-  }
-
-  function toolsArrayFromText(text: string): string[] {
-    return text
-      .split('\n')
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0);
   }
 
   async function load(name: string) {
@@ -168,13 +190,10 @@
       // Store resolution talks to two daemons and can be the slowest leg, but
       // it must never block (or fail) the rest of the panel — hence
       // `allSettled`-style isolation via its own catch rather than a shared
-      // `Promise.all` rejection path.
+      // `Promise.all` rejection path. DOC-57 §8.3's G-5 generalises this:
+      // one degraded backend darkens one pane, never the panel.
       const [d, p] = await Promise.all([fetchAgentDetail(name), fetchAgentPersona(name)]);
       detail = d;
-      if (d) {
-        savedToolsText = d.tools_allow.join('\n');
-        toolsText = savedToolsText;
-      }
       if (p) {
         personaEditable = p.editable;
         savedPersonaContent = p.content ?? '';
@@ -205,35 +224,17 @@
 
   $: load(agentName);
 
-  function flashSaved(which: Tab) {
-    justSaved = which;
-    if (justSavedTimer) clearTimeout(justSavedTimer);
-    justSavedTimer = setTimeout(() => {
-      justSaved = null;
-    }, 2000);
-  }
-
   async function savePersonality() {
     saving = true;
     saveError = '';
     try {
       detail = await patchAgent(agentName, { personality: personaContent });
       savedPersonaContent = personaContent;
-      flashSaved('personality');
-    } catch (e) {
-      saveError = `${e}`;
-    } finally {
-      saving = false;
-    }
-  }
-
-  async function saveTools() {
-    saving = true;
-    saveError = '';
-    try {
-      detail = await patchAgent(agentName, { tools_allow: toolsArrayFromText(toolsText) });
-      savedToolsText = toolsText;
-      flashSaved('tools');
+      justSavedPersonality = true;
+      if (justSavedTimer) clearTimeout(justSavedTimer);
+      justSavedTimer = setTimeout(() => {
+        justSavedPersonality = false;
+      }, 2000);
     } catch (e) {
       saveError = `${e}`;
     } finally {
@@ -281,8 +282,11 @@
     </p>
   {/if}
 
+  <!-- Switching sections keeps every edit: the persona buffer lives in this
+       shell, not in the unmounted body, so no exit guard is needed on the tab
+       strip itself (§8.4, G-6a). -->
   <div class="flex shrink-0 flex-wrap gap-1 border-b border-foundry-light-border dark:border-foundry-border px-3 py-2" role="tablist">
-    {#each [['personality', 'Personality'], ['okg', 'OKG Stores'], ['tools', 'Tools'], ['permissions', 'Permissions'], ['listeners', 'Listeners']] as [id, label] (id)}
+    {#each SECTIONS as [id, label] (id)}
       <button
         type="button"
         role="tab"
@@ -290,19 +294,18 @@
         class="rounded px-2.5 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide transition-colors {tab === id
           ? 'bg-foundry-light-primary/20 dark:bg-foundry-primary/20 text-foundry-light-primary dark:text-foundry-primary'
           : 'text-foundry-light-muted dark:text-foundry-text/60 hover:bg-foundry-light-primary/10 dark:hover:bg-foundry-primary/10'}"
-        on:click={() => (tab = id as Tab)}
+        on:click={() => (tab = id)}
       >
         {label}
       </button>
     {/each}
   </div>
 
-  <!-- #3894: the body is a flex COLUMN with `min-h-0`, and each tab owns its
-       own scrolling. The editor tabs (Personality/Tools) grow their textarea
-       into the leftover space and scroll INSIDE it; the read-only tabs
-       (OKG/Permissions/Listeners) scroll as a whole. A single shared
-       `overflow-y-auto` here — what #3826 had — would put a second scrollbar
-       around an already-scrolling textarea. -->
+  <!-- #3894: the body is a flex COLUMN with `min-h-0`, and each section owns
+       its own scrolling. Personality grows its textarea into the leftover space
+       and scrolls INSIDE it; the read-only sections scroll as a whole. A single
+       shared `overflow-y-auto` here — what #3826 had — would put a second
+       scrollbar around an already-scrolling textarea. -->
   <div class="flex min-h-0 flex-1 flex-col px-4 py-3">
     {#if loading}
       <div class="flex items-center gap-2 text-sm text-foundry-light-muted dark:text-foundry-text/60">
@@ -313,182 +316,27 @@
         <AlertCircle class="h-4 w-4" /> {loadError}
       </div>
     {:else if tab === 'personality'}
-      <div class="flex min-h-0 flex-1 flex-col gap-2">
-        <p class="shrink-0 text-xs text-foundry-light-muted dark:text-foundry-text/60">
-          Main instructions — this agent's <code class="font-mono">persona.md</code>.
-        </p>
-        {#if !personaEditable}
-          <p class="shrink-0 rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2 text-xs text-foundry-light-muted dark:text-foundry-text/50">
-            This agent has no editable persona.md (flat-file agents don't carry a separate
-            personality file).
-          </p>
-        {:else}
-          <!-- #3894 (supersedes #3862's vh clamp): the instructions editor is
-               the primary surface of this pane, so it takes EVERY remaining
-               pixel of the takeover — `flex-1 min-h-0`, no `rows`, no
-               `min-h-[55vh]/max-h-[70vh]` clamp (which capped it at 70% of the
-               viewport and left dead space below on a tall window, and could
-               overflow its container on a short one). It is the only scroll
-               container in this tab; `resize-none` because a drag handle can
-               only make a full-height field smaller. -->
-          <textarea
-            bind:value={personaContent}
-            spellcheck="false"
-            data-instructions-editor
-            class="w-full min-h-0 flex-1 resize-none overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs leading-relaxed text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
-          ></textarea>
-          <div class="flex shrink-0 items-center gap-2 pt-1">
-            <button
-              type="button"
-              class="inline-flex items-center gap-1.5 rounded-md bg-foundry-light-primary dark:bg-foundry-primary px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-foundry-light-primary/80 dark:hover:bg-foundry-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={saving || !personalityDirty}
-              on:click={savePersonality}
-            >
-              <Save class="h-3.5 w-3.5" /> {saving ? 'Saving…' : 'Save'}
-            </button>
-            {#if justSaved === 'personality'}
-              <span class="text-xs text-foundry-teal">Saved</span>
-            {/if}
-          </div>
-        {/if}
-        <p class="shrink-0 pt-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">
-          Event-specific instructions (per-connector context loaded on an incoming event — e.g. a
-          Gmail event loading Gmail-connector instructions) are a separate runtime epic. This
-          section is scaffolding until that backend exists.
-        </p>
-        <div class="shrink-0 rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">
-          {#each DEFINED_LISTENERS as listener (listener.id)}
-            <div class="py-0.5">{listener.label}: no event instructions configured</div>
-          {/each}
-        </div>
-      </div>
-    {:else if tab === 'okg'}
-      <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
-        <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
-          Knowledge trees + search indexes bound to this agent, resolved live against
-          trusty-search and trusty-memory. Edit bindings in
-          <code class="font-mono">agent.toml</code>'s <code class="font-mono">[[stores]]</code>.
-        </p>
-        {#if okgStores === null}
-          <div class="flex items-center gap-2 text-xs text-foundry-light-muted dark:text-foundry-text/60">
-            <Loader2 class="h-3.5 w-3.5 animate-spin" /> Resolving stores…
-          </div>
-        {:else if okgError}
-          <p class="flex items-center gap-1.5 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-[11px] text-red-500 dark:text-red-400">
-            <AlertCircle class="h-3.5 w-3.5 shrink-0" /> Could not read store bindings: {okgError}
-          </p>
-        {:else if okgStores.length === 0}
-          <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
-            This agent binds no OKG store. Add a <code class="font-mono">[[stores]]</code> table to
-            its <code class="font-mono">agent.toml</code> to give it a knowledge tree.
-          </p>
-        {/if}
-        {#each okgStores ?? [] as store (store.name)}
-          <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
-            <div class="flex items-center justify-between gap-2">
-              <span class="font-mono text-xs font-semibold text-foundry-light-text dark:text-foundry-text">{store.name}</span>
-              <span
-                class="shrink-0 rounded-md px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide {store.connected
-                  ? 'bg-foundry-teal/15 text-foundry-teal'
-                  : 'bg-foundry-light-border/50 dark:bg-black/30 text-foundry-light-muted dark:text-foundry-text/50'}"
-              >
-                {store.connected ? 'connected' : 'not connected'}
-              </span>
-            </div>
-            <div class="mt-1 flex flex-col gap-0.5 font-mono text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
-              <span>tree: {store.tree}</span>
-              <span>
-                index: {store.index}{#if store.connected && store.chunk_count !== undefined}
-                  &nbsp;· {store.chunk_count.toLocaleString()} chunks{/if}{#if store.connected && store.index_status}
-                  &nbsp;· {store.index_status}{/if}
-              </span>
-              {#if store.root_path}<span>root: {store.root_path}</span>{/if}
-              {#if store.palace}
-                <span>
-                  palace: {store.palace}
-                  {#if store.palace_connected === false}
-                    <span class="text-foundry-amber">— {store.palace_reason ?? 'not connected'}</span>
-                  {/if}
-                </span>
-              {/if}
-            </div>
-            {#if !store.connected && store.reason}
-              <p class="mt-1.5 text-[11px] text-foundry-amber">{store.reason}</p>
-            {/if}
-          </div>
-        {/each}
-        {#each okgIssues as issue (issue)}
-          <p class="text-[11px] text-foundry-amber">{issue}</p>
-        {/each}
-      </div>
-    {:else if tab === 'tools'}
-      <div class="flex min-h-0 flex-1 flex-col gap-2">
-        <p class="shrink-0 text-xs text-foundry-light-muted dark:text-foundry-text/60">
-          MCP tool allow-list — one glob pattern per line (e.g. <code class="font-mono">gworkspace_*</code>). Empty = no restriction.
-        </p>
-        <!-- Same full-height treatment as the instructions editor above. -->
-        <textarea
-          bind:value={toolsText}
-          spellcheck="false"
-          placeholder="gworkspace_*&#10;memory_*"
-          class="w-full min-h-0 flex-1 resize-none overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs leading-relaxed text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
-        ></textarea>
-        <div class="flex shrink-0 items-center gap-2 pt-1">
-          <button
-            type="button"
-            class="inline-flex items-center gap-1.5 rounded-md bg-foundry-light-primary dark:bg-foundry-primary px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-foundry-light-primary/80 dark:hover:bg-foundry-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={saving || !toolsDirty}
-            on:click={saveTools}
-          >
-            <Save class="h-3.5 w-3.5" /> {saving ? 'Saving…' : 'Save'}
-          </button>
-          {#if justSaved === 'tools'}
-            <span class="text-xs text-foundry-teal">Saved</span>
-          {/if}
-        </div>
-      </div>
-    {:else if tab === 'permissions'}
-      <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
-        <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
-          RBAC / OpenRPC scopes claimed by this agent — read-only (no write path yet).
-        </p>
-        {#if detail && detail.scopes.length > 0}
-          <ul class="flex flex-wrap gap-1.5">
-            {#each detail.scopes as scope (scope)}
-              <li class="rounded-md border border-foundry-light-border dark:border-foundry-border px-2 py-0.5 font-mono text-[11px] text-foundry-light-text dark:text-foundry-text">
-                {scope}
-              </li>
-            {/each}
-          </ul>
-        {:else}
-          <p class="text-xs text-foundry-light-muted dark:text-foundry-text/40">No scopes declared.</p>
-        {/if}
-      </div>
+      <AgentConfigPersonality
+        {personaEditable}
+        bind:content={personaContent}
+        dirty={personalityDirty}
+        {saving}
+        justSaved={justSavedPersonality}
+        onSave={savePersonality}
+      />
+    {:else if tab === 'knowledge'}
+      <AgentConfigKnowledge
+        stores={okgStores}
+        issues={okgIssues}
+        error={okgError}
+        {storeBoundTools}
+      />
+    {:else if tab === 'skills'}
+      <AgentConfigSkills {skills} />
     {:else if tab === 'listeners'}
-      <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
-        <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
-          Inbound event bindings — API connections to upstream event providers, not MCP tools. No
-          backend yet (spec being filed); shown as the two defined listener bindings.
-        </p>
-        {#each DEFINED_LISTENERS as listener (listener.id)}
-          <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
-            <div class="flex items-center justify-between">
-              <span class="text-sm font-semibold text-foundry-light-text dark:text-foundry-text">{listener.label}</span>
-              <span class="rounded-md bg-foundry-light-border/50 dark:bg-black/30 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50">
-                not bound
-              </span>
-            </div>
-            <p class="mt-0.5 text-[11px] text-foundry-light-muted dark:text-foundry-text/50">{listener.description}</p>
-            <div class="mt-1.5 flex flex-wrap gap-1">
-              {#each listener.eventTypes as eventType (eventType)}
-                <span class="rounded border border-dashed border-foundry-light-border dark:border-foundry-border px-1.5 py-0.5 font-mono text-[10px] text-foundry-light-muted dark:text-foundry-text/40">
-                  {eventType}
-                </span>
-              {/each}
-            </div>
-          </div>
-        {/each}
-      </div>
+      <AgentConfigListeners />
+    {:else if tab === 'permissions'}
+      <AgentConfigPermissions toolsAllow={detail?.tools_allow ?? []} scopes={detail?.scopes ?? []} />
     {/if}
 
     {#if saveError}
@@ -511,8 +359,7 @@
           Unsaved changes
         </h3>
         <p class="mb-4 text-xs leading-relaxed text-foundry-light-muted dark:text-foundry-text/60">
-          Your {dirtySections} {dirtySections.includes(' and ') ? 'edits have' : 'edit has'} not been
-          saved. Leaving configuration now discards {dirtySections.includes(' and ') ? 'them' : 'it'}.
+          Your Personality edit has not been saved. Leaving configuration now discards it.
         </p>
         <div class="flex flex-wrap items-center justify-end gap-2">
           <button

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
@@ -1,20 +1,27 @@
-// Why (#3894): two regressions this component has already shipped twice are
-// pinned here. (1) The instructions editor keeps shrinking back to a strip —
-// #3862 fixed a 2-line field with a `55vh/70vh` clamp, which the full-pane
-// takeover then made wrong in the other direction (dead space below on a tall
-// window). The fix is "grow into whatever the pane gives you", which is a
-// structural property: a `flex-1`/`min-h-0` chain with no fixed `rows` and no
-// second scroll container wrapped around it. (2) The takeover needs exit
-// affordances that actually call back out. Neither is expressible without
-// mounting the component.
+// Why (#3894/#3932): three properties of this shell have each shipped wrong at
+// least once, and none is expressible without mounting the component.
+// (1) The instructions editor keeps shrinking back to a strip — #3862 fixed a
+// 2-line field with a `55vh/70vh` clamp, which the full-pane takeover then made
+// wrong in the other direction (dead space below on a tall window). The fix is
+// "grow into whatever the pane gives you", a structural property: a
+// `flex-1`/`min-h-0` chain with no fixed `rows` and no second scroll container
+// wrapped around it — which the #3932 decomposition into per-section child
+// components must not break (DOC-57 §8.4, G-6b / C-07.3).
+// (2) The takeover needs exit affordances that actually call back out, and the
+// persona edit buffer must survive a SECTION SWITCH now that the body it lives
+// in is an unmounted-on-switch child (G-6a / C-07.4).
+// (3) The five sections and their order are normative (DOC-57 §2.1, C-07.1),
+// and every pane must render an explicit empty/error state rather than
+// fabricated content when its backend is absent or failing (G-4, C-07.2).
 // What: Mounts the real panel with `fetch` stubbed for the three routes it
 // loads (`/api/agents/:name`, `.../persona`, `.../stores`), then asserts the
-// sizing invariants and the Back/Close wiring. jsdom does no layout, so the
-// "grows with the viewport" half is asserted as the flex chain that produces
-// it rather than as a measured pixel height.
+// sizing invariants, the Back/Close wiring, the tab strip, and each pane's
+// degraded rendering. jsdom does no layout, so the "grows with the viewport"
+// half is asserted as the flex chain that produces it rather than as a measured
+// pixel height (`tests/config-takeover.spec.ts` measures the real thing).
 // Test: this file.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mount, unmount } from 'svelte';
+import { mount, tick, unmount } from 'svelte';
 import AgentConfigPanel from './AgentConfigPanel.svelte';
 
 let target: HTMLDivElement;
@@ -43,7 +50,7 @@ function stubApi() {
           : {
               name: 'izzie',
               display_name: 'Izzie',
-              tools_allow: ['gworkspace_*'],
+              tools_allow: ['gworkspace_*', 'vector_search', 'git_log', 'git_status'],
               scopes: ['agents.read'],
             };
       return { ok: true, status: 200, json: async () => json } as Response;
@@ -51,19 +58,46 @@ function stubApi() {
   );
 }
 
-function mountPanel(onExit = vi.fn()) {
+/**
+ * The C-07.2 fixture: an agent that declares nothing, with the stores route
+ * failing outright. Every pane must still render, each saying what it does not
+ * know rather than filling the gap.
+ */
+function stubBareApiWithFailingStores() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/stores')) return { ok: false, status: 503, json: async () => ({}) } as Response;
+      const json = url.includes('/persona')
+        ? { content: '', editable: false }
+        : { name: 'bare', display_name: 'Bare', tools_allow: [], scopes: [] };
+      return { ok: true, status: 200, json: async () => json } as Response;
+    }),
+  );
+}
+
+function mountPanel(onExit = vi.fn(), agentName = 'izzie') {
   instance = mount(AgentConfigPanel, {
     target,
-    props: { agentName: 'izzie', isConcierge: false, displayName: 'Izzie', onExit },
+    props: { agentName, isConcierge: false, displayName: 'Izzie', onExit },
   }) as unknown as Record<string, unknown>;
   return onExit;
 }
 
 const editor = () => target.querySelector('[data-instructions-editor]') as HTMLTextAreaElement;
+const tabLabels = () =>
+  Array.from(target.querySelectorAll('[role="tab"]')).map((b) => b.textContent?.trim());
 const tabButton = (label: string) =>
   Array.from(target.querySelectorAll('[role="tab"]')).find(
     (b) => b.textContent?.trim() === label,
   ) as HTMLButtonElement;
+
+/** Drives `bind:value` the way a keystroke would. */
+function typeInto(el: HTMLTextAreaElement, value: string) {
+  el.value = value;
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
 
 beforeEach(() => {
   stubApi();
@@ -100,6 +134,26 @@ describe('AgentConfigPanel — exit affordances (#3894)', () => {
     await waitFor(() => editor() !== null);
     expect(target.querySelector('header')?.textContent).toContain('Izzie');
   });
+
+  it('an unsaved persona edit blocks Back and raises the confirm dialog (C-07.4)', async () => {
+    const onExit = mountPanel();
+    await waitFor(() => editor() !== null);
+
+    typeInto(editor(), 'edited prompt');
+    // The child→shell binding propagates synchronously, but the shell's
+    // `personalityDirty` is a reactive statement and lands on the next flush.
+    // A real keystroke and a real click are always separate tasks; only the
+    // test needs to say so.
+    await tick();
+
+    const back = Array.from(target.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('Back to chat'),
+    ) as HTMLButtonElement;
+    back.click();
+
+    await waitFor(() => target.querySelector('[role="alertdialog"]') !== null);
+    expect(onExit).not.toHaveBeenCalled();
+  });
 });
 
 describe('AgentConfigPanel — instructions editor sizing (#3894)', () => {
@@ -130,7 +184,8 @@ describe('AgentConfigPanel — instructions editor sizing (#3894)', () => {
 
     // Walk from the editor up to the panel root: every ancestor must be a
     // height-passing flex box, never a second scroller wrapped around the
-    // first.
+    // first. Splitting the body into child components (#3932) adds no DOM
+    // node, so this chain is unchanged — which is exactly what it must prove.
     const root = target.firstElementChild as HTMLElement;
     for (let el = editor().parentElement; el && el !== root; el = el.parentElement) {
       expect(el.className).not.toContain('overflow-y-auto');
@@ -148,24 +203,92 @@ describe('AgentConfigPanel — instructions editor sizing (#3894)', () => {
   });
 });
 
-describe('AgentConfigPanel — existing sections still render (#3826/#3816 regression guard)', () => {
-  it('keeps the OKG stores, Tools, Permissions and Listeners tabs', async () => {
+describe('AgentConfigPanel — five sections (#3932, DOC-57 §8.2)', () => {
+  it('renders exactly five tabs in the normative order (C-07.1)', async () => {
+    mountPanel();
+    await waitFor(() => editor() !== null);
+    expect(tabLabels()).toEqual([
+      'Personality',
+      'Knowledge',
+      'Skills',
+      'Listeners',
+      'Permissions',
+    ]);
+  });
+
+  it('each section renders its own data', async () => {
     mountPanel();
     await waitFor(() => editor() !== null);
 
-    tabButton('OKG Stores').click();
+    tabButton('Knowledge').click();
     await waitFor(() => target.textContent?.includes('izzie-kb') ?? false);
     expect(target.textContent).toContain('okg://izzie');
+    // The vector_search→store seam (§4.3) and the declared MCP endpoints (§4.4).
+    expect(target.textContent).toContain('vector_search');
+    expect(target.textContent).toContain('trusty-memory');
 
-    tabButton('Tools').click();
-    await waitFor(() => target.querySelector('textarea') !== null);
-    expect((target.querySelector('textarea') as HTMLTextAreaElement).value).toBe('gworkspace_*');
-
-    tabButton('Permissions').click();
-    await waitFor(() => target.textContent?.includes('agents.read') ?? false);
+    // Skills replaced the raw-glob textarea with cards (G-3), grouped by tool
+    // prefix (S-8) and badged synthetic (S-10).
+    tabButton('Skills').click();
+    await waitFor(() => target.textContent?.includes('gworkspace') ?? false);
+    expect(target.querySelector('textarea')).toBeNull();
+    expect(target.textContent).toContain('git');
+    expect(target.textContent).toContain('synthetic');
 
     tabButton('Listeners').click();
     await waitFor(() => target.textContent?.includes('Gmail') ?? false);
     expect(target.textContent).toContain('Google Calendar');
+
+    tabButton('Permissions').click();
+    await waitFor(() => target.textContent?.includes('agents.read') ?? false);
+    expect(target.textContent).toContain('gworkspace_*');
+  });
+
+  it('keeps an in-progress persona edit across a section switch (G-6a)', async () => {
+    mountPanel();
+    await waitFor(() => editor() !== null);
+
+    typeInto(editor(), 'half-written system prompt');
+    tabButton('Skills').click();
+    await waitFor(() => editor() === null);
+
+    tabButton('Personality').click();
+    await waitFor(() => editor() !== null);
+    expect(editor().value).toBe('half-written system prompt');
+  });
+});
+
+describe('AgentConfigPanel — degraded backends (#3932, C-07.2)', () => {
+  it('renders every pane with an explicit empty/error state and no fabricated content', async () => {
+    vi.unstubAllGlobals();
+    stubBareApiWithFailingStores();
+    mountPanel(vi.fn(), 'bare');
+    await waitFor(() => tabLabels().length === 5);
+
+    // Personality: no editable persona.md is a stated fact, not a blank box.
+    await waitFor(() => target.textContent?.includes('no editable persona.md') ?? false);
+
+    tabButton('Knowledge').click();
+    await waitFor(() => target.textContent?.includes('Could not read store bindings') ?? false);
+    // The knowledge-classification gap is named rather than guessed at, and a
+    // disabled endpoint is shown as disabled rather than hidden (C-03.2).
+    expect(target.textContent).toContain('kind = "knowledge"');
+    expect(target.textContent).toContain('disabled');
+
+    tabButton('Skills').click();
+    await waitFor(() => target.textContent?.includes('declares no') ?? false);
+    // An absent allow-list denies; the pane must not read as "unrestricted".
+    expect(target.textContent).toContain('not "unrestricted"');
+
+    tabButton('Listeners').click();
+    await waitFor(() => target.textContent?.includes('Scaffolding, not configuration') ?? false);
+    // L-1: the hardcoded per-listener "not bound" badge is gone.
+    expect(target.textContent).not.toContain('not bound');
+
+    tabButton('Permissions').click();
+    await waitFor(() => target.textContent?.includes('No allow-list declared') ?? false);
+    expect(target.textContent).toContain('No scopes declared');
+    // PM-6: unenforced mechanisms are marked as such.
+    expect(target.textContent).toContain('not enforced');
   });
 });

--- a/crates/trusty-agents/ui/src/components/AgentConfigPermissions.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPermissions.svelte
@@ -1,0 +1,133 @@
+<script lang="ts">
+  /**
+   * Why (#3932, DOC-57 §7 / §8.2): section 5 of the five-section agent config
+   * — "what the agent is allowed to do, and on whose authority". This is the
+   * section the spec CREATES rather than relabels: an agent's permission
+   * posture is spread across four unrelated mechanisms in three locations with
+   * three different failure polarities (absent-denies, empty-denies,
+   * default-opens), two of which are invisible in config entirely. A chip list
+   * of scope strings, which is what this tab used to be, shows none of that.
+   *
+   * What: read-only rows over the config the sidecar already serves, each
+   * carrying an explicit ENFORCED / NOT ENFORCED marker. PM-6 makes that
+   * marker mandatory — displaying an unenforced control as if it constrained
+   * the agent is the permissions-surface equivalent of a fabricated listener
+   * pane — and PM-4 makes read-only permanent here, in every phase: granting
+   * capability from a GUI is a security-relevant write path needing its own
+   * review, and no route in DOC-57 adds one (C-06.4).
+   *
+   * The `enforced` values are stated from §7.1's mechanism table, with its
+   * qualifiers intact rather than rounded up to a green tick — scope
+   * enforcement is real but path-limited, and `user_authority` does not exist
+   * as a field at all yet (#3074). The pane also names its own blind spot:
+   * `parse_agent_toml` (`projects.rs:369`) reads ONE file and performs no
+   * `extends` merge, so what is shown is what this agent DECLARES, not its
+   * resolved effective set. PM-7's `source: declared | inherited:<base>`
+   * annotation — the thing that would make §7.3's cto-assistant defect visible
+   * — needs `GET /api/agents/:name/permissions` (§7.4, Phase 4).
+   * Test: `AgentConfigPermissions.test.ts`.
+   */
+
+  /** `[tools].allow` as declared in this agent's own `agent.toml`. */
+  export let toolsAllow: string[] = [];
+  /** `[tools].scopes` as declared in this agent's own `agent.toml`. */
+  export let scopes: string[] = [];
+
+  const heading =
+    'shrink-0 font-mono text-[10px] font-semibold uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50';
+  const enforcedChip =
+    'shrink-0 rounded-md bg-foundry-teal/15 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-foundry-teal';
+  const unenforcedChip =
+    'shrink-0 rounded-md bg-foundry-light-border/50 dark:bg-black/30 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50';
+  const chip =
+    'rounded-md border border-foundry-light-border dark:border-foundry-border px-2 py-0.5 font-mono text-[11px] text-foundry-light-text dark:text-foundry-text';
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
+  <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+    Read-only. Granting capability from the GUI is out of scope by design (DOC-57 §7.2, PM-4); edit
+    <code class="font-mono">agent.toml</code>. Values are as <strong>declared</strong> in this
+    agent's own file — anything inherited through <code class="font-mono">extends</code> is unioned
+    at load and is not visible here yet (§7.4, PM-7).
+  </p>
+
+  <section class="flex flex-col gap-2">
+    <div class="flex items-center justify-between gap-2">
+      <h3 class={heading}>Tool allow-list · <code class="font-mono">[tools].allow</code></h3>
+      <span class={enforcedChip}>enforced</span>
+    </div>
+    <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+      Glob patterns gating dispatch via
+      <code class="font-mono">filter_persona_tool_names</code>. Trailing
+      <code class="font-mono">*</code> only.
+    </p>
+    {#if toolsAllow.length > 0}
+      <ul class="flex flex-wrap gap-1.5">
+        {#each toolsAllow as pattern (pattern)}
+          <li class={chip}>{pattern}</li>
+        {/each}
+      </ul>
+    {:else}
+      <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-amber">
+        No allow-list declared. On the persona chat path this grants <strong>zero</strong> tools —
+        absent denies, it does not mean unrestricted (DOC-57 §7.1).
+      </p>
+    {/if}
+  </section>
+
+  <section class="flex flex-col gap-2">
+    <div class="flex items-center justify-between gap-2">
+      <h3 class={heading}>Scopes · <code class="font-mono">[tools].scopes</code></h3>
+      <span class={enforcedChip}>enforced · path-limited</span>
+    </div>
+    <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+      RBAC / OpenRPC scope patterns, checked by <code class="font-mono">agent_can_use</code> on the
+      persona-chat path. Tools discovered through the OpenRPC registry are gated; in-process tools
+      declare no scope and pass unconditionally, and the
+      <code class="font-mono">--direct</code> path applies no scope filtering at all (DOC-57 §7.1).
+    </p>
+    {#if scopes.length > 0}
+      <ul class="flex flex-wrap gap-1.5">
+        {#each scopes as scope (scope)}
+          <li class={chip}>{scope}</li>
+        {/each}
+      </ul>
+    {:else}
+      <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-amber">
+        No scopes declared here. The gate is fail-closed for scope-carrying tools — but this agent
+        may still inherit scopes from its <code class="font-mono">extends</code> base, which this
+        pane cannot yet see.
+      </p>
+    {/if}
+  </section>
+
+  <section class="flex flex-col gap-2">
+    <div class="flex items-center justify-between gap-2">
+      <h3 class={heading}>User authority</h3>
+      <span class={unenforcedChip}>not enforced</span>
+    </div>
+    <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+      DOC-41 §5.5's singleton — the one agent that may act on the user's own authority, never
+      inherited across <code class="font-mono">extends</code>. The field is
+      <strong>reserved and does not exist</strong> in
+      <code class="font-mono">AgentConfig</code> yet (#3074/#3075), so no value is shown: this pane
+      would have to invent one.
+    </p>
+  </section>
+
+  <section class="flex flex-col gap-2">
+    <div class="flex items-center justify-between gap-2">
+      <h3 class={heading}>Not surfaced yet</h3>
+      <span class={unenforcedChip}>phase 4</span>
+    </div>
+    <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+      Service tiers (<code class="font-mono">default_tier</code>,
+      <code class="font-mono">unauthenticated_tier</code>), autonomy posture
+      (<code class="font-mono">ask-first</code> / <code class="font-mono">learn-to-act</code>) and
+      per-skill grants are specified in DOC-57 §7.2 but have no read path today —
+      <code class="font-mono">[rbac]</code> parses with no read site at all. They arrive with
+      <code class="font-mono">GET /api/agents/:name/permissions</code> rather than being rendered
+      here as defaults nobody enforces.
+    </p>
+  </section>
+</div>

--- a/crates/trusty-agents/ui/src/components/AgentConfigPermissions.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPermissions.test.ts
@@ -1,0 +1,75 @@
+// Why (#3932, DOC-57 §7): Permissions is the section the spec creates rather
+// than relabels, and its one hard rendering rule is PM-6 — every element
+// carries an `enforced` marker, because displaying an unenforced control as if
+// it constrained the agent is the permissions-surface equivalent of a
+// fabricated listener pane. The second rule is polarity: an absent allow-list
+// DENIES on the persona path (§7.1), so an empty pane that reads as
+// "unrestricted" is actively misleading. The third is PM-4 — read-only, in
+// every phase.
+// What: Mounts the component directly with the two arrays `AgentDetail`
+// already serves.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import AgentConfigPermissions from './AgentConfigPermissions.svelte';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+function render(toolsAllow: string[], scopes: string[]) {
+  instance = mount(AgentConfigPermissions, {
+    target,
+    props: { toolsAllow, scopes },
+  }) as unknown as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+});
+
+describe('AgentConfigPermissions', () => {
+  it('renders the declared allow-list and scopes', () => {
+    render(['gworkspace_*'], ['memory.read', 'google.gmail.*']);
+    expect(target.textContent).toContain('gworkspace_*');
+    expect(target.textContent).toContain('memory.read');
+    expect(target.textContent).toContain('google.gmail.*');
+  });
+
+  it('marks every mechanism enforced or not enforced (PM-6)', () => {
+    render(['gworkspace_*'], ['memory.read']);
+    expect(target.textContent).toContain('enforced');
+    // Scope enforcement is real but path-limited — the qualifier is not
+    // decoration, it is the difference between the gate a user assumes and
+    // the gate that runs.
+    expect(target.textContent).toContain('path-limited');
+    // `user_authority` has no field yet (#3074) and no value is invented.
+    expect(target.textContent).toContain('not enforced');
+    expect(target.textContent).toContain('reserved and does not exist');
+  });
+
+  it('states the deny polarity of an absent allow-list rather than reading as unrestricted', () => {
+    render([], []);
+    expect(target.textContent).toContain('No allow-list declared');
+    expect(target.textContent).toContain('absent denies');
+    expect(target.textContent).toContain('No scopes declared');
+  });
+
+  it('discloses that inherited values are not visible (PM-7)', () => {
+    render(['gworkspace_*'], []);
+    expect(target.textContent).toContain('extends');
+  });
+
+  it('offers no write path (PM-4)', () => {
+    render(['gworkspace_*'], ['memory.read']);
+    expect(Array.from(target.querySelectorAll('button, input, textarea, select'))).toHaveLength(0);
+  });
+});

--- a/crates/trusty-agents/ui/src/components/AgentConfigPersonality.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPersonality.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  /**
+   * Why (#3932, DOC-57 §3 / §8.4): section 1 of the five-section agent config
+   * — "who the agent is". Split out of `AgentConfigPanel` so the shell keeps
+   * only tabs, header and the exit guard, per §8.4's decomposition.
+   *
+   * Two things this component deliberately does NOT own:
+   * (1) The persona TEXT. The shell owns `content` and binds it in, because
+   *     switching sections unmounts this component and a child-owned buffer
+   *     would silently drop a half-written system prompt on every tab click —
+   *     and would also strand the shell's `configPaneDirty` aggregation, which
+   *     every exit path (Esc, Back, Close, Chat→Events) depends on (§8.4, G-6a).
+   * (2) Saving. `onSave` calls back into the shell, which holds the one PATCH
+   *     path and the confirm-before-discard dialog.
+   *
+   * What: The full-height `persona.md` editor from #3895, unchanged in
+   * behavior and in its sizing invariants, plus an honest statement about
+   * per-connector event instructions. That block used to enumerate
+   * `DEFINED_LISTENERS` and assert "no event instructions configured" for each
+   * — a fabrication (§3.2, P-2: the block MUST be backed by the real
+   * `events/*.md` file set) and one no route can back in this phase, so it is
+   * replaced by a statement of the gap rather than a guess about its contents.
+   * Test: `AgentConfigPersonality.test.ts`; the editor's sizing invariants stay
+   * pinned by `AgentConfigPanel.test.ts` and `tests/config-takeover.spec.ts`.
+   */
+  import { Save } from 'lucide-svelte';
+
+  /** `false` for flat (non-package) agents — no `persona.md` to write. */
+  export let personaEditable = false;
+  /** Bound by the shell, which owns the edit buffer across section switches. */
+  export let content = '';
+  export let dirty = false;
+  export let saving = false;
+  export let justSaved = false;
+  export let onSave: () => void;
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col gap-2">
+  <p class="shrink-0 text-xs text-foundry-light-muted dark:text-foundry-text/60">
+    Main instructions — this agent's <code class="font-mono">persona.md</code>.
+  </p>
+  {#if !personaEditable}
+    <p class="shrink-0 rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2 text-xs text-foundry-light-muted dark:text-foundry-text/50">
+      This agent has no editable persona.md (flat-file agents don't carry a separate personality
+      file).
+    </p>
+  {:else}
+    <!-- #3894 (supersedes #3862's vh clamp): the instructions editor is the
+         primary surface of this pane, so it takes EVERY remaining pixel of the
+         takeover — `flex-1 min-h-0`, no `rows`, no `min-h-[55vh]/max-h-[70vh]`
+         clamp (which capped it at 70% of the viewport and left dead space
+         below on a tall window, and could overflow its container on a short
+         one). It is the only scroll container in this tab; `resize-none`
+         because a drag handle can only make a full-height field smaller. -->
+    <textarea
+      bind:value={content}
+      spellcheck="false"
+      data-instructions-editor
+      class="w-full min-h-0 flex-1 resize-none overflow-y-auto rounded-md border border-foundry-light-border dark:border-foundry-primary/30 bg-foundry-light-bg dark:bg-foundry-bg px-3 py-2 font-mono text-xs leading-relaxed text-foundry-light-text dark:text-foundry-text focus:border-foundry-light-primary dark:focus:border-foundry-primary focus:outline-none"
+    ></textarea>
+    <div class="flex shrink-0 items-center gap-2 pt-1">
+      <button
+        type="button"
+        class="inline-flex items-center gap-1.5 rounded-md bg-foundry-light-primary dark:bg-foundry-primary px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-foundry-light-primary/80 dark:hover:bg-foundry-primary/80 disabled:cursor-not-allowed disabled:opacity-50"
+        disabled={saving || !dirty}
+        on:click={onSave}
+      >
+        <Save class="h-3.5 w-3.5" /> {saving ? 'Saving…' : 'Save'}
+      </button>
+      {#if justSaved}
+        <span class="text-xs text-foundry-teal">Saved</span>
+      {/if}
+    </div>
+  {/if}
+  <p class="shrink-0 pt-2 text-xs text-foundry-light-muted dark:text-foundry-text/40">
+    Per-connector event instructions (<code class="font-mono">events/&lt;connector&gt;.md</code>) are
+    loaded at wake time, but no route lists which files an agent carries — so this pane cannot show
+    them and does not guess (DOC-57 §3.2, P-2).
+  </p>
+</div>

--- a/crates/trusty-agents/ui/src/components/AgentConfigPersonality.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPersonality.test.ts
@@ -1,0 +1,70 @@
+// Why (#3932): the Personality body moved out of `AgentConfigPanel` into its
+// own component, and two of its properties are easy to lose in that move —
+// the save button's disabled-until-dirty contract (the shell owns `dirty`, so
+// the wiring is now a prop, not a local `$:`), and DOC-57 §3.2's P-2, which
+// forbids the fabricated per-connector-instructions block this pane used to
+// render (a `DEFINED_LISTENERS` loop asserting "no event instructions
+// configured" for connectors it never looked at).
+// What: Mounts the component directly with props — no fetch, no shell.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mount, unmount } from 'svelte';
+import AgentConfigPersonality from './AgentConfigPersonality.svelte';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+function render(props: Record<string, unknown>) {
+  instance = mount(AgentConfigPersonality, {
+    target,
+    props: { personaEditable: true, content: '', dirty: false, saving: false, justSaved: false, onSave: vi.fn(), ...props },
+  }) as unknown as Record<string, unknown>;
+}
+
+const saveButton = () =>
+  Array.from(target.querySelectorAll('button')).find((b) =>
+    b.textContent?.includes('Save'),
+  ) as HTMLButtonElement;
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+});
+
+describe('AgentConfigPersonality', () => {
+  it('offers no editor for a flat agent that carries no persona.md', () => {
+    render({ personaEditable: false });
+    expect(target.querySelector('[data-instructions-editor]')).toBeNull();
+    expect(target.textContent).toContain('no editable persona.md');
+  });
+
+  it('disables Save until the shell reports the buffer dirty', () => {
+    render({ content: 'You are Izzie.', dirty: false });
+    expect(saveButton().disabled).toBe(true);
+  });
+
+  it('calls back to the shell to save a dirty buffer', () => {
+    const onSave = vi.fn();
+    render({ content: 'edited', dirty: true, onSave });
+    saveButton().click();
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('states the per-connector-instructions gap instead of enumerating connectors (P-2)', () => {
+    render({ content: 'You are Izzie.' });
+    // The block must be backed by the real `events/*.md` file set or say
+    // nothing about it. No route lists those files, so naming connectors here
+    // would assert a per-agent fact this pane never checked.
+    expect(target.textContent).toContain('events/<connector>.md');
+    expect(target.textContent).not.toContain('Gmail');
+    expect(target.textContent).not.toContain('Google Calendar');
+  });
+});

--- a/crates/trusty-agents/ui/src/components/AgentConfigSkills.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSkills.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  /**
+   * Why (#3932, DOC-57 §5 / §8.2): section 3 of the five-section agent config
+   * — "what the agent can do". Bob: *"Instead of tools, let's show skills…
+   * each tool should be wrapped in a skill."* The skill becomes the visible
+   * unit of capability; a raw tool name becomes an implementation detail
+   * beneath it. This replaces the Tools tab, whose entire body was one
+   * monospace `<textarea>` of raw globs with no catalog, no validation and no
+   * grouping — G-3 requires cards instead.
+   *
+   * What: One card per capability family, derived from `[tools].allow` by
+   * `synthesizeSkills` (§5.5, S-7/S-8) and badged `synthetic` (S-10), which is
+   * the point rather than an apology: no manifest declares `tools:` yet, so
+   * badging every card keeps the unwrapped surface VISIBLE and makes wrapping
+   * progress measurable as authored manifests land in Phase 2 (#3933).
+   *
+   * Read-only, and deliberately so: this pane drops the Tools textarea's write
+   * path because capability editing returns as `PATCH { skills_allow }` in
+   * Phase 3 (§5.7, S-12 — "Phase 1 is read-only"), on the skill names this
+   * pane shows rather than on the globs beneath them. Until then `agent.toml`
+   * is the edit surface, which the pane says outright.
+   *
+   * Availability is NOT rendered. §8.3 lists it on the card, but nothing in
+   * this phase resolves a pattern against the tool registry, and a green
+   * "available" chip nobody checked is exactly the fabrication G-4 forbids.
+   * Test: `AgentConfigSkills.test.ts`.
+   */
+  import type { SyntheticSkill } from '../lib/agentConfig';
+
+  /** Derived by the shell via `synthesizeSkills(detail.tools_allow)`. */
+  export let skills: SyntheticSkill[] = [];
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
+  <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+    What this agent can do. Each card is a capability family wrapping the tools beneath it, grouped
+    from the allow-list by tool-name prefix — a heuristic, not a taxonomy, which an authored
+    manifest supersedes. Edit the underlying allow-list in
+    <code class="font-mono">agent.toml</code>'s <code class="font-mono">[tools].allow</code> —
+    editing skills from here arrives with <code class="font-mono">[skills].allow</code> (DOC-57
+    §5.7, #3933).
+  </p>
+
+  {#if skills.length === 0}
+    <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+      This agent declares no <code class="font-mono">[tools].allow</code> entries. On the persona
+      chat path an absent allow-list grants <strong>no</strong> tools — it is not "unrestricted"
+      (DOC-57 §7.1).
+    </p>
+  {/if}
+
+  {#each skills as skill (skill.name)}
+    <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
+      <div class="flex items-center justify-between gap-2">
+        <span class="font-mono text-xs font-semibold text-foundry-light-text dark:text-foundry-text">
+          {skill.name}
+        </span>
+        {#if skill.synthetic}
+          <span
+            class="shrink-0 rounded-md bg-foundry-amber/15 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-foundry-amber"
+            title="Derived from [tools].allow — no skill manifest was authored for this family"
+          >
+            synthetic
+          </span>
+        {/if}
+      </div>
+      <!-- Tool list collapsed by default (§8.3, G-3): the card is the unit the
+           user reasons about; the patterns beneath it are the detail. -->
+      <details class="mt-1.5">
+        <summary class="cursor-pointer font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
+          {skill.patterns.length} allow-list {skill.patterns.length === 1 ? 'pattern' : 'patterns'}
+        </summary>
+        <div class="mt-1.5 flex flex-wrap gap-1">
+          {#each skill.patterns as pattern (pattern)}
+            <span class="rounded border border-foundry-light-border dark:border-foundry-border px-1.5 py-0.5 font-mono text-[10px] text-foundry-light-text dark:text-foundry-text">
+              {pattern}
+            </span>
+          {/each}
+        </div>
+      </details>
+    </div>
+  {/each}
+
+  {#if skills.length > 0}
+    <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+      Every card is <strong>synthetic</strong>: it was derived from
+      <code class="font-mono">[tools].allow</code>, not from an authored skill manifest. Whether each
+      wrapped pattern resolves to a live tool is not checked here — no route resolves the registry in
+      this phase (DOC-57 §5.7).
+    </p>
+  {/if}
+</div>

--- a/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
@@ -1,0 +1,68 @@
+// Why (#3932, DOC-57 §5/§8.3): this pane replaced the Tools tab's single
+// monospace textarea of raw globs, and G-3 is specific about the replacement —
+// cards, with the wrapped tool list COLLAPSED, and a `synthetic` badge (S-10)
+// whenever no manifest was authored. The badge is the measurable part: it is
+// how an unwrapped surface stays visible instead of being indistinguishable
+// from curated capability. The empty state matters just as much, because an
+// absent allow-list denies rather than permits (§7.1) and a pane that renders
+// blank there teaches the opposite.
+// What: Mounts the component directly with `synthesizeSkills` output shapes.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import AgentConfigSkills from './AgentConfigSkills.svelte';
+import { synthesizeSkills } from '../lib/agentConfig';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+function render(toolsAllow: string[]) {
+  instance = mount(AgentConfigSkills, {
+    target,
+    props: { skills: synthesizeSkills(toolsAllow) },
+  }) as unknown as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+});
+
+describe('AgentConfigSkills', () => {
+  it('renders capability cards, not a glob textarea (G-3)', () => {
+    render(['git_log', 'git_status', 'gworkspace_*']);
+    expect(target.querySelector('textarea')).toBeNull();
+    expect(target.textContent).toContain('git');
+    expect(target.textContent).toContain('gworkspace');
+  });
+
+  it('badges every derived card synthetic and keeps its patterns collapsed (S-10, G-3)', () => {
+    render(['git_log', 'git_status']);
+    expect(target.textContent).toContain('synthetic');
+    const details = target.querySelector('details') as HTMLDetailsElement;
+    expect(details).not.toBeNull();
+    expect(details.open).toBe(false);
+    expect(details.textContent).toContain('git_log');
+    expect(details.textContent).toContain('git_status');
+  });
+
+  it('states the deny polarity for an agent with no allow-list', () => {
+    render([]);
+    expect(target.textContent).toContain('declares no');
+    expect(target.textContent).toContain('not "unrestricted"');
+  });
+
+  it('offers no write path in this phase (S-12) and points at the real edit surface', () => {
+    render(['gworkspace_*']);
+    expect(Array.from(target.querySelectorAll('button'))).toHaveLength(0);
+    expect(target.textContent).toContain('agent.toml');
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
@@ -7,7 +7,15 @@
 // nothing, so it gets a mocked-fetch test.
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { DEFINED_LISTENERS, fetchAgentStores, type AgentStores } from './agentConfig';
+import {
+  DEFINED_LISTENERS,
+  KNOWLEDGE_MCP_ENDPOINTS,
+  STORE_BOUND_KNOWLEDGE_TOOLS,
+  fetchAgentStores,
+  matchesToolGlob,
+  synthesizeSkills,
+  type AgentStores,
+} from './agentConfig';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -95,5 +103,71 @@ describe('fetchAgentStores', () => {
   it('throws on a non-404 error status', async () => {
     stubFetch(500, { error: 'boom' });
     await expect(fetchAgentStores('izzie')).rejects.toThrow(/500/);
+  });
+});
+
+// --- DOC-57 Phase-1 derivations (#3932) -------------------------------------
+
+describe('matchesToolGlob', () => {
+  it('matches exact names', () => {
+    expect(matchesToolGlob('vector_search', 'vector_search')).toBe(true);
+    expect(matchesToolGlob('vector_search', 'vector_searchx')).toBe(false);
+  });
+
+  it('matches trailing wildcard prefixes, and only trailing ones', () => {
+    expect(matchesToolGlob('vector_*', 'vector_search')).toBe(true);
+    expect(matchesToolGlob('*', 'anything_at_all')).toBe(true);
+    // A leading wildcard is a listener-filter dialect, not an allow-list one
+    // — the server's `match_any_glob` treats it as a literal, and so must this.
+    expect(matchesToolGlob('*_search', 'vector_search')).toBe(false);
+  });
+});
+
+describe('synthesizeSkills', () => {
+  it('groups allow-list patterns by tool-name prefix (S-8)', () => {
+    const skills = synthesizeSkills(['git_status', 'gworkspace_*', 'git_log']);
+    expect(skills.map((s) => s.name)).toEqual(['git', 'gworkspace']);
+    expect(skills[0].patterns).toEqual(['git_log', 'git_status']);
+    expect(skills.every((s) => s.synthetic)).toBe(true);
+  });
+
+  it('keeps an unprefixed pattern as its own single-pattern skill (S-8)', () => {
+    const skills = synthesizeSkills(['*']);
+    expect(skills).toEqual([{ name: '*', synthetic: true, patterns: ['*'] }]);
+  });
+
+  it('drops blanks and collapses duplicates', () => {
+    const skills = synthesizeSkills(['  ', 'git_log', 'git_log', ' git_status ']);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].patterns).toEqual(['git_log', 'git_status']);
+  });
+
+  it('returns nothing for an empty allow-list', () => {
+    expect(synthesizeSkills([])).toEqual([]);
+  });
+});
+
+describe('KNOWLEDGE_MCP_ENDPOINTS', () => {
+  it('reports the shipped disabled defaults with a reason, never as connected (C-03.2)', () => {
+    const byName = Object.fromEntries(KNOWLEDGE_MCP_ENDPOINTS.map((e) => [e.name, e]));
+    expect(byName['trusty-memory'].enabled).toBe(false);
+    expect(byName['trusty-memory'].reason).toBeTruthy();
+    expect(byName['trusty-search'].enabled).toBe(false);
+    expect(byName['gworkspace'].enabled).toBe(true);
+    // A disabled endpoint carries a reason; an enabled one has nothing to
+    // explain. The invariant, not the individual flags, is what must hold.
+    for (const endpoint of KNOWLEDGE_MCP_ENDPOINTS) {
+      expect(Boolean(endpoint.reason)).toBe(!endpoint.enabled);
+      expect(endpoint.scopes.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('STORE_BOUND_KNOWLEDGE_TOOLS', () => {
+  it('is the vector_search seam and nothing more (§4.3)', () => {
+    // Widening this to §4.3's illustrative tool list would be the hardcoded
+    // taxonomy that same section warns against; classification belongs to
+    // `kind = "knowledge"` manifests (#3933).
+    expect([...STORE_BOUND_KNOWLEDGE_TOOLS]).toEqual(['vector_search']);
   });
 });

--- a/crates/trusty-agents/ui/src/lib/agentConfig.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.ts
@@ -1,5 +1,5 @@
 // Agent config API client + declarative scaffolding shapes for the
-// gear-panel config form (#3819, epic #3052).
+// gear-panel config form (#3819, epic #3052; five-section reshape #3932).
 //
 // Why: the chat-pane gear panel needs a single typed surface over the agent
 // config read/write routes (`GET/PATCH /api/agents/:name`,
@@ -11,8 +11,13 @@
 // `stores/app.ts`'s `fetchAgentCatalog` pattern.
 // What: `fetchAgentDetail`/`fetchAgentPersona`/`patchAgent`/`fetchAgentStores`
 // — thin REST wrappers; `DEFINED_LISTENERS` — the two listener bindings from
-// the (not yet implemented) listener spec, rendered as honest scaffolding.
+// the (not yet implemented) listener spec, rendered as honest scaffolding;
+// and the DOC-57 Phase-1 derivations the five-section panes read from
+// already-served data (`synthesizeSkills`, `matchesToolGlob`,
+// `KNOWLEDGE_MCP_ENDPOINTS`).
 // Test: `agentConfig.test.ts`.
+// Spec: docs/specs/agent-config-five-sections.md (DOC-57) §5.5 (synthetic
+// skills), §4.4 (MCP knowledge connections), §8.5 (Phase-1 data mapping).
 
 import { apiBase } from './api-config';
 import { getCurrentApiToken } from '../stores/app';
@@ -75,6 +80,13 @@ export interface PatchAgentBody {
   model_id?: string;
   provider_id?: string;
   personality?: string;
+  /**
+   * Mirrors the server's `PatchAgentRequest.tools_allow`. Unused by the GUI
+   * since #3932: the Tools textarea was replaced by the read-only Skills pane
+   * (DOC-57 §8.2/G-3), and capability editing returns as
+   * `PATCH { skills_allow }` in Phase 3 (§5.7, S-12). Kept because this type
+   * documents the route's body, not the panel's current usage of it.
+   */
   tools_allow?: string[];
 }
 
@@ -101,17 +113,20 @@ export async function patchAgent(name: string, body: PatchAgentBody): Promise<Ag
 
 /**
  * Why (Bob, concept-demo priority): the config pane's LISTENERS section has
- * no backend yet (spec being filed) — Bob explicitly asked for the two
- * DEFINED listeners (gmail, google-calendar) rendered as structured,
- * honestly-scaffolded bindings rather than lorem-ipsum placeholders, "so
- * it's honest scaffolding that will become live." This is UI-only data: no
- * fetch, no persistence — every agent shows the same two listener
- * definitions with per-agent event-type filter chips toggled from nothing
- * (all off) until a real backend exists.
- * What: `id`/`label` identify the listener; `eventTypes` are the
- * connector's defined event kinds a per-agent binding can filter to (empty
- * `enabledEventTypes` = "not bound" — the honest default, never
- * pre-checked).
+ * no backend yet — Bob explicitly asked for the two DEFINED listeners
+ * (gmail, google-calendar) rendered as structured, honestly-scaffolded
+ * bindings rather than lorem-ipsum placeholders, "so it's honest scaffolding
+ * that will become live." This is UI-only data: no fetch, no persistence.
+ *
+ * It is CONNECTOR DEFINITIONS, never an agent's `[[listeners]]` bindings, and
+ * DOC-57 §6.2 (L-1) is explicit that rendering it as per-agent state is a
+ * defect: the pane used to stamp a hardcoded "not bound" badge on both
+ * entries regardless of configuration, which both invents a binding that may
+ * not exist and hides one that is quietly failing. #3932 therefore drops the
+ * badge and labels the pane as UI scaffolding; `GET /api/agents/:name/listeners`
+ * (#3937 / #3891) replaces this constant outright (C-05.1).
+ * What: `id`/`label` identify the connector; `eventTypes` are the event kinds
+ * a per-agent binding could filter to.
  */
 export interface ListenerDefinition {
   id: 'gmail' | 'google-calendar';
@@ -188,4 +203,164 @@ export async function fetchAgentStores(name: string): Promise<AgentStores | null
   if (r.status === 404) return null;
   if (!r.ok) throw new Error(`GET /api/agents/${name}/stores failed: ${r.status}`);
   return (await r.json()) as AgentStores;
+}
+
+// ---------------------------------------------------------------------------
+// DOC-57 Phase-1 derivations (#3932)
+//
+// Everything below turns data the sidecar ALREADY serves (`AgentDetail`) into
+// the five-section view. Phase 1 adds no HTTP route and no config-schema
+// change (DOC-57 §8.5, G-7); `GET …/skills` (§5.7), `GET …/knowledge` (§4.5)
+// and `GET …/permissions` (§7.4) replace these derivations in Phases 2-4.
+// ---------------------------------------------------------------------------
+
+/**
+ * Why: `[tools].allow` is a glob allow-list, and the Knowledge pane has to
+ * answer "does this agent hold the store-bound knowledge tool?" from those
+ * patterns. Re-deriving the matcher client-side is the only option in a phase
+ * with no resolution route — so it mirrors the server's matcher exactly rather
+ * than inventing a fourth glob dialect (DOC-57 §5.2, S-1).
+ * What: Ports `match_any_glob` (`ctrl/pm_task/helpers.rs:146`): exact equality,
+ * or a trailing `*` matched as a prefix. No other wildcard position is
+ * supported, there and here.
+ * Test: `matchesToolGlob_matches_exact_names`,
+ * `matchesToolGlob_matches_trailing_wildcard_prefixes`.
+ */
+export function matchesToolGlob(pattern: string, tool: string): boolean {
+  if (pattern.endsWith('*')) return tool.startsWith(pattern.slice(0, -1));
+  return pattern === tool;
+}
+
+/**
+ * Why (DOC-57 §4.3): `vector_search`'s default index is the agent's own store
+ * binding (`persona.rs:346-355`, the #3864 fix), and the spec requires the
+ * Knowledge pane show that linkage rather than leave the tool as a
+ * free-floating chip. It is named here as the ONE store-bound knowledge tool
+ * the spec states normatively — deliberately not §4.3's broader illustrative
+ * tool list, which the same section marks "illustrative, not normative" and
+ * warns against hardcoding, because a hardcoded taxonomy drifts exactly the
+ * way the removed static `gworkspace` tool list drifted. Authoritative
+ * classification arrives with `kind = "knowledge"` skill manifests in Phase 2
+ * (#3933); until then the pane says so instead of guessing.
+ * What: Tool names whose availability the Knowledge pane resolves against the
+ * agent's own `[tools].allow`.
+ * Test: `storeBoundKnowledgeTools_is_the_vector_search_seam`.
+ */
+export const STORE_BOUND_KNOWLEDGE_TOOLS = ['vector_search'] as const;
+
+/**
+ * One MCP/OpenRPC endpoint that backs a knowledge service (DOC-57 §4.4, K-c).
+ *
+ * `enabled` is the SHIPPED DEFAULT from
+ * `crates/trusty-agents/assets/config/default-config.toml`, not a probe of the
+ * running harness — see `KNOWLEDGE_MCP_ENDPOINTS`.
+ */
+export interface KnowledgeEndpoint {
+  name: string;
+  description: string;
+  enabled: boolean;
+  scopes: string[];
+  /** Why the endpoint is not carrying traffic. Non-null iff `!enabled`. */
+  reason?: string;
+}
+
+/**
+ * Why (DOC-57 §8.5): Phase 1 maps the Knowledge pane's K-c sub-surface onto "a
+ * read-only, statically-declared MCP knowledge-endpoint list", because no
+ * route exposes `[[tool_registry.endpoints]]` yet. §4.4 is emphatic about WHAT
+ * such a list must say: the two endpoints most obviously "MCP connections to
+ * knowledge stores" ship `enabled = false` (awaiting `--rpc` on their
+ * binaries), so the agent's memory and search capability today flows through
+ * in-process tools, not through these endpoints. Rendering a
+ * configured-but-disabled endpoint as connected — or omitting it — is the same
+ * class of defect as the fabricated listener pane (C-03.2).
+ * What: The three knowledge endpoints declared in this crate's shipped
+ * `assets/config/default-config.toml:193-243`, verbatim including their
+ * `enabled` flags and scopes. This is the DEFAULT declaration; an operator who
+ * has edited `~/.trusty-agents/config.toml` may have flipped a flag, which is
+ * why the pane labels the list as declared-not-probed and Phase 3's
+ * `GET /api/agents/:name/knowledge` (§4.5) replaces it with resolved state.
+ * Test: `knowledgeEndpoints_report_the_shipped_disabled_defaults`.
+ */
+export const KNOWLEDGE_MCP_ENDPOINTS: KnowledgeEndpoint[] = [
+  {
+    name: 'trusty-memory',
+    description: 'Trusty memory service — recall/remember/forget',
+    enabled: false,
+    scopes: ['memory.read', 'memory.write'],
+    reason: 'disabled in the shipped config — awaits `--rpc` mode on the binary',
+  },
+  {
+    name: 'trusty-search',
+    description: 'Trusty search service — semantic + keyword code search',
+    enabled: false,
+    scopes: ['search.read'],
+    reason: 'disabled in the shipped config — awaits `--rpc` mode on the binary',
+  },
+  {
+    name: 'gworkspace',
+    description: 'Google Workspace — Gmail, Calendar, Drive, Docs, Sheets, Tasks',
+    enabled: true,
+    scopes: ['google.*'],
+  },
+];
+
+/**
+ * One synthetic skill card — a capability family derived from `[tools].allow`
+ * rather than from an authored manifest (DOC-57 §5.5).
+ */
+export interface SyntheticSkill {
+  /** S-8's grouping key: the pattern's prefix before the first `_`. */
+  name: string;
+  /**
+   * Always `true` here. Phase 1 has no manifest carrying `tools:`, so every
+   * card is synthetic and badged as such (S-10) — which is the point: the
+   * unwrapped surface stays visible, and wrapping progress is measurable.
+   */
+  synthetic: boolean;
+  /**
+   * The `[tools].allow` entries grouped under `name`, deduped and sorted.
+   * Deliberately NOT called `tools`: these are GLOBS, and a skill manifest's
+   * `tools:` are exact names (S-1). Calling them tools would assert a
+   * resolution this phase cannot perform.
+   */
+  patterns: string[];
+}
+
+/**
+ * Why (DOC-57 §5.5, S-7/S-8): the Skills pane must be complete on day one, and
+ * requiring an authored manifest for every tool before it renders anything
+ * would block the GUI slice on a large content project. So any capability not
+ * claimed by a skill is wrapped in a synthetic one, grouped by the tool-name
+ * prefix — the same heuristic S-8 specifies for the backend, applied here to
+ * the allow-list patterns Phase 1 actually has.
+ * What: Groups `[tools].allow` by the substring before the first `_`
+ * (`gworkspace_*` → `gworkspace`; `git_log` + `git_status` → `git`), falling
+ * back to the whole pattern when it carries no `_` (`*`, `web_search`'s
+ * unprefixed cousins). Blank entries are dropped, duplicates collapse, and
+ * both the groups and the patterns inside them come back sorted so the pane
+ * has a stable order. S-9 applies: this is a heuristic, never a taxonomy — an
+ * authored manifest supersedes it in Phase 2.
+ * Test: `synthesizeSkills_groups_by_tool_name_prefix`,
+ * `synthesizeSkills_keeps_unprefixed_patterns_as_their_own_skill`,
+ * `synthesizeSkills_returns_nothing_for_an_empty_allow_list`.
+ */
+export function synthesizeSkills(toolsAllow: string[]): SyntheticSkill[] {
+  const groups = new Map<string, Set<string>>();
+  for (const raw of toolsAllow) {
+    const pattern = raw.trim();
+    if (!pattern) continue;
+    const cut = pattern.indexOf('_');
+    const name = cut > 0 ? pattern.slice(0, cut) : pattern;
+    const bucket = groups.get(name) ?? new Set<string>();
+    bucket.add(pattern);
+    groups.set(name, bucket);
+  }
+  return Array.from(groups.entries())
+    .map(([name, patterns]) => ({
+      name,
+      synthetic: true,
+      patterns: Array.from(patterns).sort(),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 }


### PR DESCRIPTION
Implements **DOC-57 Phase 1** — `docs/specs/agent-config-five-sections.md`, `SPEC-AGENTCFG-07~draft` §8. Epic #3931.

Owner directive being implemented:

> *"Instead of tools, let's show skills. Should be Personality, Knowledge (list knowledge tools including MCP connections to knowledge stores), Skills (each tool should be wrapped in a skill), Listeners, the Permissions."*

**Front-end only.** No new HTTP route, no config-schema change, independently revertable (§8.5, G-7). Every pane maps onto data `GET /api/agents/:name`, `.../persona` and `.../stores` already serve; where the spec maps a section to data with no endpoint yet, the pane renders what exists and **states the gap** rather than filling it (G-4).

## Before / after

| # | Before | After | Change |
|---|---|---|---|
| 1 | `personality` — Personality | `personality` — Personality | unchanged behavior; fabricated per-connector list removed (P-2) |
| 2 | `okg` — OKG Stores | `knowledge` — **Knowledge** | rename + widen to three sub-surfaces (§4) |
| 3 | `tools` — Tools | `skills` — **Skills** | replace: glob textarea → synthetic skill cards (§5, G-3) |
| 4 | `permissions` — Permissions | `listeners` — **Listeners** | Listeners moves up; hardcoded badge removed (L-1) |
| 5 | `listeners` — Listeners | `permissions` — **Permissions** | reorder to last + re-back with `enforced` markers (§7) |

### What each pane actually shows now

- **Personality** — unchanged: #3895's full-height `persona.md` editor, same save path, same sizing invariants. The block that enumerated `DEFINED_LISTENERS` and asserted *"no event instructions configured"* for each connector is gone; §3.2's P-2 requires that block be backed by the real `events/*.md` file set, and no route lists those files, so the pane states the gap instead.
- **Knowledge** — K-a live store bindings (#3878, unchanged rendering); K-b the `vector_search`→store linkage §4.3 names normatively, resolved against the agent's own `[tools].allow` and rendered *under* the store it reads; K-c the declared MCP knowledge endpoints, carrying the shipped `enabled` flags — so `trusty-memory` and `trusty-search` read **DISABLED with their reason** rather than being omitted (C-03.2). Read-only; store editing stays #3890 (K-3).
  - K-b deliberately does **not** hardcode §4.3's illustrative knowledge-tool list — the same section calls it "illustrative, not normative" and warns that a hardcoded list drifts. The pane names `kind = "knowledge"` manifests (#3933) as the authority and says none exist yet.
- **Skills** — one card per capability family, grouped by tool-name prefix (S-8), patterns collapsed in a `<details>` (G-3), every card badged `synthetic` (S-10) because no manifest wraps its tools yet. Availability is **not** rendered: nothing in this phase resolves a pattern against the registry, and an unchecked green chip is the fabrication G-4 forbids.
- **Listeners** — same connector definitions, but the hardcoded per-listener **"not bound"** badge is removed: it asserted a per-agent binding state for every agent regardless of configuration (L-1). Pane completion is #3937/#3891.
- **Permissions** — per-mechanism `enforced` / `not enforced` markers (PM-6), with §7.1's qualifiers intact rather than rounded up (scope enforcement is real but path-limited); the **deny-on-absent** polarity of an empty allow-list stated explicitly; `user_authority` shown as reserved-with-no-field (#3074) rather than given an invented value; tiers/autonomy/grants named as Phase-4 rather than rendered as defaults nobody enforces. Read-only in every phase by design (PM-4, C-06.4).
  - It also discloses its own blind spot: `parse_agent_toml` (`projects.rs:369`) reads **one file with no `extends` merge**, so what is shown is what the agent *declares*, not its resolved effective set. PM-7's `source: declared | inherited:<base>` needs `GET …/permissions`.

### Deliberate capability removal

GUI editing of `[tools].allow` is dropped with the Tools textarea. Skills is read-only in Phase 1 (§5.7, S-12) and editing returns as `PATCH { skills_allow }` over skill *names* in Phase 3. Until then `agent.toml` is the edit surface, which the pane says outright. `PatchAgentBody.tools_allow` is retained as documentation of the route's body.

### Decomposition

Per §8.4, split into `AgentConfigPanel.svelte` (shell: header, tabs, the one load, the one PATCH, the exit guard) plus `AgentConfig{Personality,Knowledge,Skills,Listeners,Permissions}.svelte`, each with a colocated `.test.ts`. Both invariants survive:

- **G-6a dirty tracking** — the persona buffer and `configPaneDirty` aggregation stay in the *shell*. A child-owned buffer would discard a half-written system prompt on every tab click, since the inactive body unmounts. Section switching therefore needs no guard of its own: edits are preserved, and Esc/Back/Close/Chat→Events still funnel through `requestExitConfigPane`.
- **G-6b layout** — child components add no DOM node, so the `flex min-h-0 flex-1 flex-col` chain is byte-identical. `config-takeover.spec.ts` passes **unchanged** (C-07.3).

## Spec conformance

| ID | Covered by |
|---|---|
| C-07.1 five tabs in normative order | `AgentConfigPanel.test.ts` › *renders exactly five tabs in the normative order* |
| C-07.2 every pane degrades with explicit empty/error, no fabrication | `AgentConfigPanel.test.ts` › *degraded backends* (bare agent + 503 on `/stores`) |
| C-07.3 layout assertions pass unchanged | `tests/config-takeover.spec.ts`, run unmodified — 5 passed |
| C-07.4 dirty persona + exit raises the dialog | `AgentConfigPanel.test.ts` › *an unsaved persona edit blocks Back* |
| C-03.2 disabled endpoint shown, never omitted | `AgentConfigKnowledge.test.ts`, `agentConfig.test.ts` |
| G-3 / S-10 cards, collapsed tools, synthetic badge | `AgentConfigSkills.test.ts` |
| L-1 no fabricated binding state | `AgentConfigListeners.test.ts` |
| PM-4 / PM-6 read-only, enforced markers | `AgentConfigPermissions.test.ts` |
| P-2 no fabricated connector list | `AgentConfigPersonality.test.ts` |

## Test evidence

```
$ pnpm test:unit
 Test Files  21 passed (21)
      Tests  187 passed (187)

$ pnpm run check
COMPLETED 1731 FILES 0 ERRORS 2 WARNINGS 1 FILES_WITH_PROBLEMS
(both warnings pre-existing, ProjectsView.svelte)

$ pnpm run build
✓ 1698 modules transformed.  ✓ built in 3.40s

$ TAGENT_URL=http://127.0.0.1:5199 pnpm test tests/config-takeover.spec.ts
  5 passed (1.8s)     # unmodified spec — C-07.3

$ ./scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ ./scripts/check_sld.sh
sld-lint: scanned 46 spec doc(s) + 2862 code file(s); 0 error(s), 0 warning(s)

$ ./scripts/check_line_cap.sh
line-cap: 8 allowlisted, 0 violations — OK.
```

All five panes were also rendered and screenshotted against a real browser (`pnpm dev` + Playwright) to confirm the reshape end to end; the throwaway visual spec was removed before commit.

Closes #3932
References epic #3931

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools