### PR TITLE
fix(trusty-mpm): gate MCP trust-set membership on actual pin success, not the toggle (fifth instance)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **A toggle being on was treated as proof of a successful MCP-server pin,
+  even when the force-overwrite write itself failed** (closes
+  [#3950](https://github.com/bobmatnyc/trusty-tools/issues/3950), fifth
+  instance of the name-approval/content-pinning class after
+  [#3918](https://github.com/bobmatnyc/trusty-tools/issues/3918)/
+  [#3924](https://github.com/bobmatnyc/trusty-tools/issues/3924)/
+  [#3926](https://github.com/bobmatnyc/trusty-tools/issues/3926)/
+  [#3934](https://github.com/bobmatnyc/trusty-tools/issues/3934)): a disk-full,
+  permission, or transient I/O fault during `inject_trusty_memory_mcp`/
+  `inject_trusty_search_mcp`/`inject_trusty_mpm_mcp`/`inject_trusty_review_mcp`
+  is non-fatal to launch, but the toggle/attempted-injection value was still
+  used to approve the name in `enabledMcpjsonServers` regardless of whether
+  the write actually succeeded — leaving a spoofed or stale `.mcp.json` entry
+  pre-approved with unverified content behind it. `mcp_config::managed_mcp_server_names`/
+  `launch_trusted_mcp_names`/`launch_trusted_mcp_names_from` and
+  `standalone::trust_seed::preseed_managed_trust` now take each of the four
+  builtins' actual per-run pin result as an explicit `_pinned` bool (not a
+  toggle); `session_launch::PrepReport` gained
+  `trusty_mpm_injected`/`trusty_review_injected`/`trusty_memory_injected`/
+  `trusty_search_injected` fields so `standalone::load::load_alias` (the `tm
+  load`/`tm run` daemon-managed driver) can read the SAME run's actual
+  outcome instead of re-deriving from the manifest toggle alone.
+
 - **An untrusted project manifest could disable the `trusty-memory`/
   `trusty-search` force-overwrite injector while the name stayed
   pre-approved, reopening builtin-name-squatting** (closes

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -31,6 +31,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `trusty_search_injected` fields so `standalone::load::load_alias` (the `tm
   load`/`tm run` daemon-managed driver) can read the SAME run's actual
   outcome instead of re-deriving from the manifest toggle alone.
+  `runtime::claude_code::prepare_managed_config` (the tmux daemon-spawn
+  adapter behind `RuntimeAdapter::spawn`/`spawn_resume`) now pins all four
+  builtins itself and derives trust membership from their real `Result`s
+  too — critic follow-up review found this call site reachable with ZERO
+  same-run evidence at all on the headless `spawn_resume`/`session_resume`
+  path (no `prepare_session*` call anywhere in that request's chain), the
+  sharpest case across all five instances of this vulnerability class.
 
 - **An untrusted project manifest could disable the `trusty-memory`/
   `trusty-search` force-overwrite injector while the name stayed

--- a/crates/trusty-mpm/src/core/mcp_config.rs
+++ b/crates/trusty-mpm/src/core/mcp_config.rs
@@ -77,7 +77,7 @@ pub const BUILTIN_MANAGED_MCP_SERVERS: &[&str] = &[
 /// framework-controlled command — see that function's security doc. These two
 /// names have no manifest escape hatch (unlike the conditional pair, they
 /// cannot be individually disabled), but the FORCE-OVERWRITE ITSELF can still
-/// fail (disk full, permission error, transient I/O fault — issue #3945, the
+/// fail (disk full, permission error, transient I/O fault — issue #3950, the
 /// fifth instance of this vulnerability class). [`managed_mcp_server_names`]
 /// therefore takes each name's actual per-run pin result as an explicit
 /// caller-supplied bool (`trusty_mpm_pinned` / `trusty_review_pinned`)
@@ -383,7 +383,7 @@ pub fn list_servers(config_dir: &Path) -> Result<Map<String, Value>> {
 /// SAME `prepare_session` run, or a fresh [`resolve_conditional_mcp_toggles`]
 /// call when no such plan is in scope.
 ///
-/// **Security (issue #3945 — fifth instance of this vulnerability class):**
+/// **Security (issue #3950 — fifth instance of this vulnerability class):**
 /// a `true` toggle is necessary but NOT sufficient — the force-overwrite
 /// injector for that name must have actually SUCCEEDED this run (or, for a
 /// caller with no fresh injector result in scope, the best available proxy
@@ -402,7 +402,7 @@ pub fn list_servers(config_dir: &Path) -> Result<Map<String, Value>> {
 /// `managed_mcp_server_names_defaults_to_builtin`,
 /// `managed_mcp_server_names_excludes_disabled_conditional_builtins`,
 /// `managed_mcp_server_names_excludes_unconditional_builtin_when_pin_failed`
-/// (issue #3945 regression).
+/// (issue #3950 regression).
 pub fn managed_mcp_server_names(
     config: &Value,
     trusty_mpm_pinned: bool,
@@ -543,7 +543,7 @@ pub fn mcp_server_names(workspace: &Path) -> Vec<String> {
 /// manifest that disables the force-overwrite injector reopens the
 /// name-squatting exploit [`CONDITIONAL_BUILTIN_MCP_SERVERS`] documents.
 ///
-/// **Issue #3945 (fifth instance):** ALL FOUR parameters must reflect actual
+/// **Issue #3950 (fifth instance):** ALL FOUR parameters must reflect actual
 /// per-run pin success, not merely "the injector was attempted" — see
 /// [`managed_mcp_server_names`]'s doc. The production call site
 /// (`session_launch::mod::prepare_session_inner`) derives all four from the
@@ -587,7 +587,7 @@ pub fn launch_trusted_mcp_names(
 /// What: reads `config_dir` via [`list_servers`] (quarantines a malformed
 /// file, empty map when absent or unreadable — never fails) and returns
 /// [`managed_mcp_server_names`] over the resulting `{"mcpServers": ...}`
-/// value, gated by all four `_pinned` flags (issues #3934/#3945 — see
+/// value, gated by all four `_pinned` flags (issues #3934/#3950 — see
 /// [`launch_trusted_mcp_names`]'s doc).
 /// Test: `launch_trusted_mcp_names_from_unions_registry`,
 /// `launch_trusted_mcp_names_from_defaults_to_builtin_when_absent`,

--- a/crates/trusty-mpm/src/core/mcp_config.rs
+++ b/crates/trusty-mpm/src/core/mcp_config.rs
@@ -75,9 +75,24 @@ pub const BUILTIN_MANAGED_MCP_SERVERS: &[&str] = &[
 /// `enabledMcpjsonServers` approval is safe for a builtin name ONLY when
 /// something in the SAME run is guaranteed to have pinned its content to the
 /// framework-controlled command — see that function's security doc. These two
-/// names have no manifest escape hatch, so that guarantee always holds.
+/// names have no manifest escape hatch (unlike the conditional pair, they
+/// cannot be individually disabled), but the FORCE-OVERWRITE ITSELF can still
+/// fail (disk full, permission error, transient I/O fault — issue #3945, the
+/// fifth instance of this vulnerability class). [`managed_mcp_server_names`]
+/// therefore takes each name's actual per-run pin result as an explicit
+/// caller-supplied bool (`trusty_mpm_pinned` / `trusty_review_pinned`)
+/// rather than assuming success unconditionally.
 /// Test: `builtin_mcp_server_split_unions_to_full_set`.
-pub const UNCONDITIONAL_BUILTIN_MCP_SERVERS: &[&str] = &["trusty-mpm", "trusty-review"];
+pub const UNCONDITIONAL_BUILTIN_MCP_SERVERS: &[&str] = &[
+    UNCONDITIONAL_BUILTIN_TRUSTY_MPM,
+    UNCONDITIONAL_BUILTIN_TRUSTY_REVIEW,
+];
+
+/// The `trusty-mpm` builtin name — see [`UNCONDITIONAL_BUILTIN_MCP_SERVERS`].
+pub const UNCONDITIONAL_BUILTIN_TRUSTY_MPM: &str = "trusty-mpm";
+
+/// The `trusty-review` builtin name — see [`UNCONDITIONAL_BUILTIN_MCP_SERVERS`].
+pub const UNCONDITIONAL_BUILTIN_TRUSTY_REVIEW: &str = "trusty-review";
 
 /// The `trusty-memory` builtin name — see [`CONDITIONAL_BUILTIN_MCP_SERVERS`].
 pub const CONDITIONAL_BUILTIN_TRUSTY_MEMORY: &str = "trusty-memory";
@@ -353,9 +368,11 @@ pub fn list_servers(config_dir: &Path) -> Result<Map<String, Value>> {
 /// identical `.mcp.json`-trusting behavior for the interactive path predates
 /// this fix and was NOT in scope here — reported separately.)
 /// What: takes an already-parsed `.claude.json` value, collects the top-level
-/// `mcpServers` object keys, unions them with [`UNCONDITIONAL_BUILTIN_MCP_SERVERS`]
-/// (always) and [`CONDITIONAL_BUILTIN_MCP_SERVERS`] (only the names whose
-/// `inject_trusty_memory` / `inject_trusty_search` flag is `true`), then sorts
+/// `mcpServers` object keys, unions them with the two names in
+/// [`UNCONDITIONAL_BUILTIN_MCP_SERVERS`] (only the ones whose
+/// `trusty_mpm_pinned` / `trusty_review_pinned` flag is `true`) and
+/// [`CONDITIONAL_BUILTIN_MCP_SERVERS`] (only the names whose
+/// `trusty_memory_pinned` / `trusty_search_pinned` flag is `true`), then sorts
 /// + dedups for a deterministic (idempotency-friendly) result.
 ///
 /// **Security (issue #3934):** `trusty-memory`/`trusty-search` must NOT be
@@ -364,26 +381,46 @@ pub fn list_servers(config_dir: &Path) -> Result<Map<String, Value>> {
 /// actually in effect for the workspace this trust list is being computed
 /// for — either the in-memory `HarnessPlan` already resolved earlier in the
 /// SAME `prepare_session` run, or a fresh [`resolve_conditional_mcp_toggles`]
-/// call when no such plan is in scope. Passing `true, true` unconditionally
-/// (e.g. a diagnostic sweep unrelated to any one project, like `tm mcp test`)
-/// is safe ONLY when the caller does not use the result as an
-/// `enabledMcpjsonServers` approval list.
+/// call when no such plan is in scope.
+///
+/// **Security (issue #3945 — fifth instance of this vulnerability class):**
+/// a `true` toggle is necessary but NOT sufficient — the force-overwrite
+/// injector for that name must have actually SUCCEEDED this run (or, for a
+/// caller with no fresh injector result in scope, the best available proxy
+/// for that — see each call site's own doc). All four parameters name their
+/// semantics as `_pinned` (not `_enabled`/`_inject`) for exactly this reason:
+/// passing a manifest toggle or a "the injector was attempted" flag when the
+/// write itself may have failed (disk full, permission error, transient I/O
+/// fault) reopens the write-failure variant of the #3934 exploit — a name
+/// whose `.mcp.json` entry was never actually re-pinned to the
+/// framework-controlled command this run must NOT enter the approved set,
+/// even when its toggle was on. Passing `true, true, true, true`
+/// unconditionally (e.g. a diagnostic sweep unrelated to any one project,
+/// like `tm mcp test`) is safe ONLY when the caller does not use the result
+/// as an `enabledMcpjsonServers` approval list.
 /// Test: `managed_mcp_server_names_unions_builtin_with_configured`,
 /// `managed_mcp_server_names_defaults_to_builtin`,
-/// `managed_mcp_server_names_excludes_disabled_conditional_builtins`.
+/// `managed_mcp_server_names_excludes_disabled_conditional_builtins`,
+/// `managed_mcp_server_names_excludes_unconditional_builtin_when_pin_failed`
+/// (issue #3945 regression).
 pub fn managed_mcp_server_names(
     config: &Value,
-    inject_trusty_memory: bool,
-    inject_trusty_search: bool,
+    trusty_mpm_pinned: bool,
+    trusty_review_pinned: bool,
+    trusty_memory_pinned: bool,
+    trusty_search_pinned: bool,
 ) -> Vec<String> {
-    let mut names: Vec<String> = UNCONDITIONAL_BUILTIN_MCP_SERVERS
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
-    if inject_trusty_memory {
+    let mut names: Vec<String> = Vec::new();
+    if trusty_mpm_pinned {
+        names.push(UNCONDITIONAL_BUILTIN_TRUSTY_MPM.to_string());
+    }
+    if trusty_review_pinned {
+        names.push(UNCONDITIONAL_BUILTIN_TRUSTY_REVIEW.to_string());
+    }
+    if trusty_memory_pinned {
         names.push(CONDITIONAL_BUILTIN_TRUSTY_MEMORY.to_string());
     }
-    if inject_trusty_search {
+    if trusty_search_pinned {
         names.push(CONDITIONAL_BUILTIN_TRUSTY_SEARCH.to_string());
     }
     if let Some(servers) = config.get("mcpServers").and_then(Value::as_object) {
@@ -499,27 +536,41 @@ pub fn mcp_server_names(workspace: &Path) -> Vec<String> {
 /// stripped environment) falls back to just the builtin four (never fails —
 /// trust-seeding must never abort a launch).
 ///
-/// **Issue #3934:** `inject_trusty_memory` / `inject_trusty_search` MUST be the
-/// toggle values actually resolved for THIS workspace this run (the caller's
-/// in-memory `HarnessPlan`, or [`resolve_conditional_mcp_toggles`] when none is
-/// in scope) — never a hardcoded `true, true` — otherwise a manifest that
-/// disables the force-overwrite injector reopens the name-squatting exploit
-/// [`CONDITIONAL_BUILTIN_MCP_SERVERS`] documents.
+/// **Issue #3934:** `trusty_memory_pinned` / `trusty_search_pinned` MUST
+/// reflect the toggle values actually resolved for THIS workspace this run
+/// (the caller's in-memory `HarnessPlan`, or [`resolve_conditional_mcp_toggles`]
+/// when none is in scope) — never a hardcoded `true, true` — otherwise a
+/// manifest that disables the force-overwrite injector reopens the
+/// name-squatting exploit [`CONDITIONAL_BUILTIN_MCP_SERVERS`] documents.
+///
+/// **Issue #3945 (fifth instance):** ALL FOUR parameters must reflect actual
+/// per-run pin success, not merely "the injector was attempted" — see
+/// [`managed_mcp_server_names`]'s doc. The production call site
+/// (`session_launch::mod::prepare_session_inner`) derives all four from the
+/// injectors' own `Result`s in the SAME run.
 /// Test: `launch_trusted_mcp_names_from_unions_registry`,
 /// `launch_trusted_mcp_names_from_defaults_to_builtin_when_absent`,
 /// `launch_trusted_mcp_names_from_excludes_disabled_conditional_builtins`.
 pub fn launch_trusted_mcp_names(
-    inject_trusty_memory: bool,
-    inject_trusty_search: bool,
+    trusty_mpm_pinned: bool,
+    trusty_review_pinned: bool,
+    trusty_memory_pinned: bool,
+    trusty_search_pinned: bool,
 ) -> Vec<String> {
     match crate::core::trusty_tools_config::managed_claude_config_dir() {
-        Some(dir) => {
-            launch_trusted_mcp_names_from(&dir, inject_trusty_memory, inject_trusty_search)
-        }
+        Some(dir) => launch_trusted_mcp_names_from(
+            &dir,
+            trusty_mpm_pinned,
+            trusty_review_pinned,
+            trusty_memory_pinned,
+            trusty_search_pinned,
+        ),
         None => managed_mcp_server_names(
             &Value::Object(Map::new()),
-            inject_trusty_memory,
-            inject_trusty_search,
+            trusty_mpm_pinned,
+            trusty_review_pinned,
+            trusty_memory_pinned,
+            trusty_search_pinned,
         ),
     }
 }
@@ -536,23 +587,27 @@ pub fn launch_trusted_mcp_names(
 /// What: reads `config_dir` via [`list_servers`] (quarantines a malformed
 /// file, empty map when absent or unreadable — never fails) and returns
 /// [`managed_mcp_server_names`] over the resulting `{"mcpServers": ...}`
-/// value, gated by `inject_trusty_memory` / `inject_trusty_search` (issue
-/// #3934 — see [`launch_trusted_mcp_names`]'s doc).
+/// value, gated by all four `_pinned` flags (issues #3934/#3945 — see
+/// [`launch_trusted_mcp_names`]'s doc).
 /// Test: `launch_trusted_mcp_names_from_unions_registry`,
 /// `launch_trusted_mcp_names_from_defaults_to_builtin_when_absent`,
 /// `launch_trusted_mcp_names_from_excludes_disabled_conditional_builtins`.
 pub fn launch_trusted_mcp_names_from(
     config_dir: &Path,
-    inject_trusty_memory: bool,
-    inject_trusty_search: bool,
+    trusty_mpm_pinned: bool,
+    trusty_review_pinned: bool,
+    trusty_memory_pinned: bool,
+    trusty_search_pinned: bool,
 ) -> Vec<String> {
     let servers = list_servers(config_dir).unwrap_or_default();
     let mut config = Map::new();
     config.insert("mcpServers".to_string(), Value::Object(servers));
     managed_mcp_server_names(
         &Value::Object(config),
-        inject_trusty_memory,
-        inject_trusty_search,
+        trusty_mpm_pinned,
+        trusty_review_pinned,
+        trusty_memory_pinned,
+        trusty_search_pinned,
     )
 }
 

--- a/crates/trusty-mpm/src/core/mcp_config_tests.rs
+++ b/crates/trusty-mpm/src/core/mcp_config_tests.rs
@@ -8,7 +8,9 @@
 //! [`super::launch_trusted_mcp_names_from`], and
 //! [`super::resolve_conditional_mcp_toggles`] — including the issue #3934
 //! regression (a conditional builtin must drop out of the trust list when its
-//! injector toggle is off).
+//! injector toggle is off) and the issue #3945 regression (either builtin —
+//! conditional OR unconditional — must drop out when its pin write fails,
+//! not merely when a toggle is off).
 //! Test: this file IS the test module.
 
 use super::*;
@@ -225,7 +227,7 @@ fn builtin_mcp_server_split_unions_to_full_set() {
 
 #[test]
 fn managed_mcp_server_names_defaults_to_builtin() {
-    let names = managed_mcp_server_names(&serde_json::json!({}), true, true);
+    let names = managed_mcp_server_names(&serde_json::json!({}), true, true, true, true);
     assert_eq!(
         names,
         vec![
@@ -245,7 +247,7 @@ fn managed_mcp_server_names_unions_builtin_with_configured() {
             "trusty-memory": { "type": "stdio", "command": "trusty-memory", "args": [] }
         }
     });
-    let names = managed_mcp_server_names(&config, true, true);
+    let names = managed_mcp_server_names(&config, true, true, true, true);
     // Built-in four + the custom server, sorted + deduped (trusty-memory
     // appears once despite being in both the builtin list and the config).
     assert_eq!(
@@ -272,15 +274,44 @@ fn managed_mcp_server_names_excludes_disabled_conditional_builtins() {
             "aaa-custom": { "type": "stdio", "command": "x", "args": [] }
         }
     });
-    let names = managed_mcp_server_names(&config, false, false);
+    let names = managed_mcp_server_names(&config, true, true, false, false);
     assert!(
         !names.contains(&"trusty-memory".to_string()),
         "trusty-memory must be excluded when its injector did not run: {names:?}"
     );
     assert!(!names.contains(&"trusty-search".to_string()));
-    // The unconditional two are always present regardless.
+    // The unconditional two are present when THEIR pin succeeded.
     assert!(names.contains(&"trusty-mpm".to_string()));
     assert!(names.contains(&"trusty-review".to_string()));
+}
+
+#[test]
+fn managed_mcp_server_names_excludes_unconditional_builtin_when_pin_failed() {
+    // Issue #3945 (fifth instance): the two UNCONDITIONAL builtins
+    // (`trusty-mpm`/`trusty-review`) have no manifest toggle, but their
+    // force-overwrite WRITE can still fail (disk full, permission error,
+    // transient I/O fault). Before this fix `managed_mcp_server_names` had
+    // no parameter for this at all — it unconditionally trusted both names
+    // regardless of whether prepare_session_inner's injectors actually
+    // succeeded this run. A failed pin must drop the name from the trust
+    // list exactly like a disabled conditional injector does.
+    let config = serde_json::json!({
+        "mcpServers": {
+            "aaa-custom": { "type": "stdio", "command": "x", "args": [] }
+        }
+    });
+    let names = managed_mcp_server_names(&config, false, false, true, true);
+    assert!(
+        !names.contains(&"trusty-mpm".to_string()),
+        "trusty-mpm must be excluded when its pin write failed this run: {names:?}"
+    );
+    assert!(
+        !names.contains(&"trusty-review".to_string()),
+        "trusty-review must be excluded when its pin write failed this run: {names:?}"
+    );
+    // The conditional two are unaffected by the unconditional pair's result.
+    assert!(names.contains(&"trusty-memory".to_string()));
+    assert!(names.contains(&"trusty-search".to_string()));
 }
 
 #[test]
@@ -299,7 +330,7 @@ fn managed_mcp_server_names_registry_collision_is_a_separate_trusted_source() {
             "trusty-memory": { "type": "stdio", "command": "trusty-memory", "args": [] }
         }
     });
-    let names = managed_mcp_server_names(&config, false, false);
+    let names = managed_mcp_server_names(&config, true, true, false, false);
     assert!(
         names.contains(&"trusty-memory".to_string()),
         "a registry-sourced name is trusted independently of the conditional-builtin toggle: {names:?}"
@@ -309,7 +340,7 @@ fn managed_mcp_server_names_registry_collision_is_a_separate_trusted_source() {
 #[test]
 fn managed_mcp_server_names_partial_conditional_toggle() {
     // Only trusty_search disabled: trusty-memory still trusted, trusty-search not.
-    let names = managed_mcp_server_names(&serde_json::json!({}), true, false);
+    let names = managed_mcp_server_names(&serde_json::json!({}), true, true, true, false);
     assert!(names.contains(&"trusty-memory".to_string()));
     assert!(!names.contains(&"trusty-search".to_string()));
 }
@@ -352,7 +383,7 @@ fn launch_trusted_mcp_names_from_unions_registry() {
     let cfg = tmp.path().join("claude-config");
     add_server(&cfg, "slack-mcp", stdio("slack-mcp", &["serve"])).unwrap();
 
-    let names = launch_trusted_mcp_names_from(&cfg, true, true);
+    let names = launch_trusted_mcp_names_from(&cfg, true, true, true, true);
     assert_eq!(
         names,
         vec![
@@ -374,7 +405,7 @@ fn launch_trusted_mcp_names_from_defaults_to_builtin_when_absent() {
     let tmp = TempDir::new().unwrap();
     let cfg = tmp.path().join("does-not-exist");
 
-    let names = launch_trusted_mcp_names_from(&cfg, true, true);
+    let names = launch_trusted_mcp_names_from(&cfg, true, true, true, true);
     assert_eq!(
         names,
         vec![
@@ -396,11 +427,27 @@ fn launch_trusted_mcp_names_from_excludes_disabled_conditional_builtins() {
     let tmp = TempDir::new().unwrap();
     let cfg = tmp.path().join("claude-config");
 
-    let names = launch_trusted_mcp_names_from(&cfg, false, false);
+    let names = launch_trusted_mcp_names_from(&cfg, true, true, false, false);
     assert!(!names.contains(&"trusty-memory".to_string()));
     assert!(!names.contains(&"trusty-search".to_string()));
     assert!(names.contains(&"trusty-mpm".to_string()));
     assert!(names.contains(&"trusty-review".to_string()));
+}
+
+#[test]
+fn launch_trusted_mcp_names_from_excludes_unconditional_builtin_when_pin_failed() {
+    // Issue #3945 (fifth instance): mirrors
+    // `managed_mcp_server_names_excludes_unconditional_builtin_when_pin_failed`
+    // one layer up — a failed `trusty-mpm`/`trusty-review` pin write must
+    // drop the name from the interactive-path trust derivation too.
+    let tmp = TempDir::new().unwrap();
+    let cfg = tmp.path().join("claude-config");
+
+    let names = launch_trusted_mcp_names_from(&cfg, false, false, true, true);
+    assert!(!names.contains(&"trusty-mpm".to_string()));
+    assert!(!names.contains(&"trusty-review".to_string()));
+    assert!(names.contains(&"trusty-memory".to_string()));
+    assert!(names.contains(&"trusty-search".to_string()));
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/mcp_config_tests.rs
+++ b/crates/trusty-mpm/src/core/mcp_config_tests.rs
@@ -8,7 +8,7 @@
 //! [`super::launch_trusted_mcp_names_from`], and
 //! [`super::resolve_conditional_mcp_toggles`] — including the issue #3934
 //! regression (a conditional builtin must drop out of the trust list when its
-//! injector toggle is off) and the issue #3945 regression (either builtin —
+//! injector toggle is off) and the issue #3950 regression (either builtin —
 //! conditional OR unconditional — must drop out when its pin write fails,
 //! not merely when a toggle is off).
 //! Test: this file IS the test module.
@@ -287,7 +287,7 @@ fn managed_mcp_server_names_excludes_disabled_conditional_builtins() {
 
 #[test]
 fn managed_mcp_server_names_excludes_unconditional_builtin_when_pin_failed() {
-    // Issue #3945 (fifth instance): the two UNCONDITIONAL builtins
+    // Issue #3950 (fifth instance): the two UNCONDITIONAL builtins
     // (`trusty-mpm`/`trusty-review`) have no manifest toggle, but their
     // force-overwrite WRITE can still fail (disk full, permission error,
     // transient I/O fault). Before this fix `managed_mcp_server_names` had
@@ -436,7 +436,7 @@ fn launch_trusted_mcp_names_from_excludes_disabled_conditional_builtins() {
 
 #[test]
 fn launch_trusted_mcp_names_from_excludes_unconditional_builtin_when_pin_failed() {
-    // Issue #3945 (fifth instance): mirrors
+    // Issue #3950 (fifth instance): mirrors
     // `managed_mcp_server_names_excludes_unconditional_builtin_when_pin_failed`
     // one layer up — a failed `trusty-mpm`/`trusty-review` pin write must
     // drop the name from the interactive-path trust derivation too.

--- a/crates/trusty-mpm/src/core/mcp_test/mod.rs
+++ b/crates/trusty-mpm/src/core/mcp_test/mod.rs
@@ -277,7 +277,7 @@ pub fn select_targets(
             // Reuse the exact union semantics `managed_mcp_server_names` applies
             // when seeding trust, so the sweep and the trust list never diverge.
             let config = json!({ "mcpServers": Value::Object(servers.clone()) });
-            let names = managed_mcp_server_names(&config, true, true);
+            let names = managed_mcp_server_names(&config, true, true, true, true);
             let targets = names
                 .into_iter()
                 .map(|n| {

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -85,11 +85,9 @@ use crate::core::skill_tiers::{
 };
 use custom_mcp::inject_custom_trusty_mcps;
 use native_mcp::inject_native_trusty_mcps;
-use search_index::{inject_trusty_search_mcp, register_project_index};
 use settings::{
-    deploy_output_style, inject_trusty_memory_mcp, inject_trusty_mpm_mcp, inject_trusty_review_mcp,
-    preseed_workspace_trust_home, remove_global_trusty_memory_hooks, write_output_style,
-    write_project_hooks, write_status_line,
+    deploy_output_style, preseed_workspace_trust_home, remove_global_trusty_memory_hooks,
+    write_output_style, write_project_hooks, write_status_line,
 };
 
 /// Re-export of the project-tier output-style/statusLine resolution primitives
@@ -110,6 +108,48 @@ use settings::{
 /// `core::standalone::settings_defaults` tests (this is a plain re-export, no
 /// logic of its own).
 pub(crate) use settings::{OUTPUT_STYLE, is_stale_statusline_command, resolve_statusline_command};
+
+/// Re-export of the four framework-builtin MCP-server force-overwrite
+/// injectors, and the trusty-search index derivation they depend on, for
+/// reuse by `runtime::claude_code::prepare_managed_config` (issue #3950
+/// residual-gap fix).
+///
+/// Why: `mod settings`/`mod search_index` above are private, so a
+/// `pub(crate)` item inside either is still unreachable from outside
+/// `session_launch` without a re-export at this (public) module boundary —
+/// mirroring the `OUTPUT_STYLE` re-export just above.
+/// `runtime::claude_code::prepare_managed_config` (the tmux daemon-spawn
+/// adapter behind `RuntimeAdapter::spawn`/`spawn_resume`) is a genuinely
+/// disjoint call chain from wherever `prepare_session_with_repo_url` last
+/// ran the injectors for a given workspace — `spawn_resume` in particular
+/// reaches it with NO corresponding `prepare_session*` call anywhere in its
+/// own request chain (see `daemon::managed_routes::lifecycle::resume_managed`'s
+/// doc). Before #3950's follow-up fix, that call site derived
+/// `enabledMcpjsonServers` membership from a hardcoded `true` (the two
+/// unconditional builtins) or a bare manifest-toggle read (the two
+/// conditional builtins) — exactly the "toggle/attempt ≠ write success"
+/// defect this issue closes everywhere else, left open on the headless
+/// resume path with no same-run evidence at all. Exposing the injectors
+/// themselves (rather than only the higher-level `prepare_session_inner`
+/// pipeline, which also redeploys agents/skills/CLAUDE.md — unwanted,
+/// heavier work for a mere resume) lets that call site run the SAME
+/// idempotent read-merge-write ([`settings::inject_mcp_server`]'s own doc:
+/// "skip the write when the entry already matches") and derive real,
+/// this-run pin results exactly like `session_launch::prepare_session_inner`
+/// and `standalone::load::load_alias` do.
+/// What: re-exports [`settings::inject_trusty_mpm_mcp`],
+/// [`settings::inject_trusty_review_mcp`], [`settings::inject_trusty_memory_mcp`],
+/// [`search_index::inject_trusty_search_mcp`], and
+/// [`search_index::register_project_index`] (the find-or-create index
+/// lookup `inject_trusty_search_mcp`'s `index_id` pin depends on).
+/// Test: covered by each injector's own unit tests in `tests_mcp_trust_seed_e2e.rs`
+/// / `native_mcp_tests.rs` / `tests.rs` (this is a plain re-export, no logic
+/// of its own); the new call site is covered by
+/// `runtime::claude_code::tests::prepare_managed_config_excludes_builtins_when_mcp_json_write_fails`.
+pub(crate) use search_index::{inject_trusty_search_mcp, register_project_index};
+pub(crate) use settings::{
+    inject_trusty_memory_mcp, inject_trusty_mpm_mcp, inject_trusty_review_mcp,
+};
 
 /// Re-export of the resume-time worktree/upstream sync primitives (issue
 /// #2647) for reuse by `daemon::managed_routes::lifecycle::resume_managed`.
@@ -179,7 +219,7 @@ pub struct PrepReport {
     /// launches, it just won't fire the trusty-memory hooks.
     pub hooks_written: bool,
     /// Whether the `trusty-mpm` MCP server entry was ACTUALLY force-written
-    /// to `.mcp.json` this run (issue #3945 — fifth instance of the
+    /// to `.mcp.json` this run (issue #3950 — fifth instance of the
     /// name-approval/content-pinning vulnerability class).
     ///
     /// `false` when [`inject_trusty_mpm_mcp`] failed (disk full, permission
@@ -198,7 +238,7 @@ pub struct PrepReport {
     ///
     /// `false` when the manifest toggle disabled the injector, OR the toggle
     /// was on but [`inject_trusty_memory_mcp`] failed — either way this name
-    /// must NOT enter `enabledMcpjsonServers` (issue #3945).
+    /// must NOT enter `enabledMcpjsonServers` (issue #3950).
     /// Test: `prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails`.
     pub trusty_memory_injected: bool,
     /// Whether the `trusty-search` MCP server entry was ACTUALLY
@@ -673,7 +713,7 @@ fn prepare_session_inner(
     // (default on). Non-fatal: the session still launches, it just lacks the
     // memory tools.
     //
-    // `trusty_memory_injected` (issue #3945 — fifth instance of the
+    // `trusty_memory_injected` (issue #3950 — fifth instance of the
     // name-approval/content-pinning vulnerability class): tracks whether the
     // entry was ACTUALLY force-written this run, not merely whether the
     // toggle was on. A toggle that is on but a write that fails (disk full,
@@ -708,7 +748,7 @@ fn prepare_session_inner(
     // returns the id so the stub is pinned; a `None` id (empty derivation) falls
     // back to the unpinned stub. Either way the session launches.
     // Gated by the manifest's `[mcp] trusty_search` toggle (default on).
-    // `trusty_search_injected` mirrors `trusty_memory_injected` above (#3945).
+    // `trusty_search_injected` mirrors `trusty_memory_injected` above (#3950).
     let mut trusty_search_injected = false;
     if plan.inject_trusty_search {
         let pinned_index = register_project_index(project_dir);
@@ -736,7 +776,7 @@ fn prepare_session_inner(
     // integrations above) and MUST run before the trust pre-seed below —
     // same ordering reasoning as the native/custom injectors. Non-fatal.
     //
-    // `trusty_mpm_injected`/`trusty_review_injected` (issue #3945): these two
+    // `trusty_mpm_injected`/`trusty_review_injected` (issue #3950): these two
     // have no manifest escape hatch, but the WRITE itself can still fail —
     // before this fix, either name was unconditionally added to
     // `enabledMcpjsonServers` regardless of whether this force-overwrite
@@ -805,7 +845,7 @@ fn prepare_session_inner(
     // returns each of the framework builtin four ONLY when its own
     // `trusty_*_injected` bool is true THIS run — i.e. its force-overwrite
     // injector actually SUCCEEDED writing the framework-controlled command,
-    // not merely that a manifest toggle was on (issue #3945 — fifth
+    // not merely that a manifest toggle was on (issue #3950 — fifth
     // instance: a toggle on but a write that fails, e.g. disk full,
     // permission error, or transient I/O fault, must NOT leave a spoofed or
     // stale `.mcp.json` entry pre-approved; issue #3934's earlier fix closed

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -178,6 +178,34 @@ pub struct PrepReport {
     /// `false` when writing the project hooks failed; the session still
     /// launches, it just won't fire the trusty-memory hooks.
     pub hooks_written: bool,
+    /// Whether the `trusty-mpm` MCP server entry was ACTUALLY force-written
+    /// to `.mcp.json` this run (issue #3945 — fifth instance of the
+    /// name-approval/content-pinning vulnerability class).
+    ///
+    /// `false` when [`inject_trusty_mpm_mcp`] failed (disk full, permission
+    /// error, transient I/O fault) — the session still launches, but this
+    /// name must NOT enter `enabledMcpjsonServers` for it (see
+    /// `trusted_mcp_names`'s computation below), since its content was never
+    /// re-pinned to the framework-controlled command this run.
+    /// Test: `prepare_session_excludes_trusty_mpm_from_trust_when_pin_write_fails`.
+    pub trusty_mpm_injected: bool,
+    /// Whether the `trusty-review` MCP server entry was ACTUALLY
+    /// force-written to `.mcp.json` this run — see [`Self::trusty_mpm_injected`].
+    /// Test: `prepare_session_excludes_trusty_mpm_from_trust_when_pin_write_fails`.
+    pub trusty_review_injected: bool,
+    /// Whether the `trusty-memory` MCP server entry was ACTUALLY
+    /// force-written to `.mcp.json` this run.
+    ///
+    /// `false` when the manifest toggle disabled the injector, OR the toggle
+    /// was on but [`inject_trusty_memory_mcp`] failed — either way this name
+    /// must NOT enter `enabledMcpjsonServers` (issue #3945).
+    /// Test: `prepare_session_excludes_trusty_memory_from_trust_when_pin_write_fails`.
+    pub trusty_memory_injected: bool,
+    /// Whether the `trusty-search` MCP server entry was ACTUALLY
+    /// force-written to `.mcp.json` this run — see
+    /// [`Self::trusty_memory_injected`].
+    /// Test: `prepare_session_excludes_trusty_search_from_trust_when_pin_write_fails`.
+    pub trusty_search_injected: bool,
     /// Incremental catch-up context to inject as seed context for this session.
     ///
     /// Populated when `config.catchup.auto` is true; `None` otherwise or when
@@ -644,17 +672,26 @@ fn prepare_session_inner(
     // `memory_note`, …). Gated by the manifest's `[mcp] trusty_memory` toggle
     // (default on). Non-fatal: the session still launches, it just lacks the
     // memory tools.
+    //
+    // `trusty_memory_injected` (issue #3945 — fifth instance of the
+    // name-approval/content-pinning vulnerability class): tracks whether the
+    // entry was ACTUALLY force-written this run, not merely whether the
+    // toggle was on. A toggle that is on but a write that fails (disk full,
+    // permission error, transient I/O fault) must NOT count as "pinned" —
+    // see this variable's use in `trusted_mcp_names` below.
     crate::core::provisioning_stage::emit(
         crate::core::provisioning_stage::ProvisioningStage::ConfiguringMcp,
     );
+    let mut trusty_memory_injected = false;
     if plan.inject_trusty_memory {
         // Pin the project's palace via `env.TRUSTY_MEMORY_PALACE` (issue #1605).
         // `repo_url` (the cloned-from URL, threaded from LaunchParams) is the
         // authoritative identity for repo_url-cloned sessions; the injector
         // falls back to the workspace's own git origin remote when it is `None`,
         // and to the bare stub when no slug can be derived (fail-open).
-        if let Err(err) = inject_trusty_memory_mcp(project_dir, repo_url) {
-            tracing::warn!("failed to inject trusty-memory MCP server: {err}");
+        match inject_trusty_memory_mcp(project_dir, repo_url) {
+            Ok(()) => trusty_memory_injected = true,
+            Err(err) => tracing::warn!("failed to inject trusty-memory MCP server: {err}"),
         }
     } else {
         tracing::debug!("manifest disables trusty-memory MCP injection");
@@ -671,10 +708,13 @@ fn prepare_session_inner(
     // returns the id so the stub is pinned; a `None` id (empty derivation) falls
     // back to the unpinned stub. Either way the session launches.
     // Gated by the manifest's `[mcp] trusty_search` toggle (default on).
+    // `trusty_search_injected` mirrors `trusty_memory_injected` above (#3945).
+    let mut trusty_search_injected = false;
     if plan.inject_trusty_search {
         let pinned_index = register_project_index(project_dir);
-        if let Err(err) = inject_trusty_search_mcp(project_dir, pinned_index.as_deref()) {
-            tracing::warn!("failed to inject trusty-search MCP server: {err}");
+        match inject_trusty_search_mcp(project_dir, pinned_index.as_deref()) {
+            Ok(()) => trusty_search_injected = true,
+            Err(err) => tracing::warn!("failed to inject trusty-search MCP server: {err}"),
         }
     } else {
         tracing::debug!("manifest disables trusty-search MCP injection");
@@ -695,12 +735,27 @@ fn prepare_session_inner(
     // manifest toggle, unlike the optional trusty-memory/trusty-search
     // integrations above) and MUST run before the trust pre-seed below —
     // same ordering reasoning as the native/custom injectors. Non-fatal.
-    if let Err(err) = inject_trusty_mpm_mcp(project_dir) {
-        tracing::warn!("failed to inject trusty-mpm MCP server: {err}");
-    }
-    if let Err(err) = inject_trusty_review_mcp(project_dir) {
-        tracing::warn!("failed to inject trusty-review MCP server: {err}");
-    }
+    //
+    // `trusty_mpm_injected`/`trusty_review_injected` (issue #3945): these two
+    // have no manifest escape hatch, but the WRITE itself can still fail —
+    // before this fix, either name was unconditionally added to
+    // `enabledMcpjsonServers` regardless of whether this force-overwrite
+    // actually succeeded, reopening the identical vulnerability for the
+    // "unconditional" pair. See `trusted_mcp_names` below.
+    let trusty_mpm_injected = match inject_trusty_mpm_mcp(project_dir) {
+        Ok(()) => true,
+        Err(err) => {
+            tracing::warn!("failed to inject trusty-mpm MCP server: {err}");
+            false
+        }
+    };
+    let trusty_review_injected = match inject_trusty_review_mcp(project_dir) {
+        Ok(()) => true,
+        Err(err) => {
+            tracing::warn!("failed to inject trusty-review MCP server: {err}");
+            false
+        }
+    };
 
     // Inject NATIVE trusty MCP servers registered via `tm mcp add` (e.g.
     // slack-mcp, gworkspace-mcp, trusty-analyze) into the workspace `.mcp.json`
@@ -747,15 +802,16 @@ fn prepare_session_inner(
     // by reading the workspace's own `.mcp.json` (that file is git-tracked and
     // travels WITH a cloned repo — see `mcp_config::mcp_server_names`'s
     // SECURITY doc for the vulnerability this closes). `launch_trusted_mcp_names`
-    // returns the two unconditional framework builtins (force-overwritten to
-    // their canonical entry by the injectors above, every run) UNION the two
-    // conditional builtins ONLY when `plan.inject_trusty_memory`/
-    // `inject_trusty_search` are true THIS run (issue #3934 — passing a
-    // hardcoded "always trust" here is exactly the vulnerability: a manifest
-    // that disables the force-overwrite injector above must also drop the
-    // name from this approval list, or a spoofed `.mcp.json` entry surviving
-    // that disabled injector gets pre-approved anyway) UNION the operator's
-    // own `tm mcp add` registry (also force-overwritten above, by the
+    // returns each of the framework builtin four ONLY when its own
+    // `trusty_*_injected` bool is true THIS run — i.e. its force-overwrite
+    // injector actually SUCCEEDED writing the framework-controlled command,
+    // not merely that a manifest toggle was on (issue #3945 — fifth
+    // instance: a toggle on but a write that fails, e.g. disk full,
+    // permission error, or transient I/O fault, must NOT leave a spoofed or
+    // stale `.mcp.json` entry pre-approved; issue #3934's earlier fix closed
+    // the toggle-off case but still passed the toggle value directly,
+    // ignoring the injector's own `Result`) — UNION the operator's own
+    // `tm mcp add` registry (also force-overwritten above, by the
     // native/custom injectors, whenever a registry name matches) —
     // provenance the operator or the framework controls, mirroring
     // `mcp_config::managed_mcp_server_names`'s already-fixed derivation for
@@ -766,13 +822,16 @@ fn prepare_session_inner(
     // found" consent dialog even after `tm project trust` — see
     // `session_launch::custom_mcp`'s "Consent gate" docs. A name that
     // reaches neither source — e.g. one a cloned repo merely committed to
-    // `.mcp.json` directly, or a conditional builtin whose injector was
-    // disabled — now correctly falls through to that same dialog instead of
-    // being silently pre-approved. Non-fatal: a trust-seed failure only
-    // means the operator may see the dialog.
+    // `.mcp.json` directly, a conditional builtin whose injector was
+    // disabled, or ANY of the four builtins whose force-overwrite write
+    // failed this run — now correctly falls through to that same dialog
+    // instead of being silently pre-approved. Non-fatal: a trust-seed
+    // failure only means the operator may see the dialog.
     let trusted_mcp_names: BTreeSet<String> = crate::core::mcp_config::launch_trusted_mcp_names(
-        plan.inject_trusty_memory,
-        plan.inject_trusty_search,
+        trusty_mpm_injected,
+        trusty_review_injected,
+        trusty_memory_injected,
+        trusty_search_injected,
     )
     .into_iter()
     .filter(|name| !project_scope_mcp_names.contains(name))
@@ -863,6 +922,10 @@ fn prepare_session_inner(
         stash,
         output_style,
         hooks_written,
+        trusty_mpm_injected,
+        trusty_review_injected,
+        trusty_memory_injected,
+        trusty_search_injected,
         catchup_context,
         roster_errors,
     })

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -187,11 +187,11 @@ pub struct PrepReport {
     /// name must NOT enter `enabledMcpjsonServers` for it (see
     /// `trusted_mcp_names`'s computation below), since its content was never
     /// re-pinned to the framework-controlled command this run.
-    /// Test: `prepare_session_excludes_trusty_mpm_from_trust_when_pin_write_fails`.
+    /// Test: `prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails`.
     pub trusty_mpm_injected: bool,
     /// Whether the `trusty-review` MCP server entry was ACTUALLY
     /// force-written to `.mcp.json` this run — see [`Self::trusty_mpm_injected`].
-    /// Test: `prepare_session_excludes_trusty_mpm_from_trust_when_pin_write_fails`.
+    /// Test: `prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails`.
     pub trusty_review_injected: bool,
     /// Whether the `trusty-memory` MCP server entry was ACTUALLY
     /// force-written to `.mcp.json` this run.
@@ -199,12 +199,12 @@ pub struct PrepReport {
     /// `false` when the manifest toggle disabled the injector, OR the toggle
     /// was on but [`inject_trusty_memory_mcp`] failed — either way this name
     /// must NOT enter `enabledMcpjsonServers` (issue #3945).
-    /// Test: `prepare_session_excludes_trusty_memory_from_trust_when_pin_write_fails`.
+    /// Test: `prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails`.
     pub trusty_memory_injected: bool,
     /// Whether the `trusty-search` MCP server entry was ACTUALLY
     /// force-written to `.mcp.json` this run — see
     /// [`Self::trusty_memory_injected`].
-    /// Test: `prepare_session_excludes_trusty_search_from_trust_when_pin_write_fails`.
+    /// Test: `prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails`.
     pub trusty_search_injected: bool,
     /// Incremental catch-up context to inject as seed context for this session.
     ///

--- a/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/native_mcp_tests.rs
@@ -540,7 +540,7 @@ fn inject_native_trust_preseed_covers_injected() {
 
     inject_native_trusty_mcps_from(&workspace, cfg.path()).expect("injection succeeds");
     let trusted: BTreeSet<String> =
-        crate::core::mcp_config::launch_trusted_mcp_names_from(cfg.path(), true, true)
+        crate::core::mcp_config::launch_trusted_mcp_names_from(cfg.path(), true, true, true, true)
             .into_iter()
             .collect();
     preseed_workspace_trust(&claude_json, &workspace, &trusted).expect("trust preseed succeeds");

--- a/crates/trusty-mpm/src/core/session_launch/search_index.rs
+++ b/crates/trusty-mpm/src/core/session_launch/search_index.rs
@@ -69,7 +69,7 @@ pub(super) fn trusty_search_mcp_value(index_id: Option<&str>) -> serde_json::Val
 /// `inject_trusty_search_mcp_is_idempotent`,
 /// `inject_trusty_search_mcp_pins_index`,
 /// `inject_both_mcp_servers_coexist`.
-pub(super) fn inject_trusty_search_mcp(
+pub(crate) fn inject_trusty_search_mcp(
     project_path: &Path,
     index_id: Option<&str>,
 ) -> Result<(), PrepError> {
@@ -110,6 +110,6 @@ pub(super) fn inject_trusty_search_mcp(
 /// graceful path) and `register_project_index_never_bypasses_sensitive_path_denylist`
 /// (issue #2914 regression) in `tests.rs`; the promoted logic is unit-tested in
 /// `trusty_common::search_index::tests`.
-pub(super) fn register_project_index(project_root: &Path) -> Option<String> {
+pub(crate) fn register_project_index(project_root: &Path) -> Option<String> {
     trusty_common::search_index::ensure_project_indexed(project_root, false)
 }

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -445,7 +445,7 @@ pub(super) fn inject_mcp_server(
 /// `inject_trusty_memory_mcp_uses_serve_stdio`,
 /// `inject_trusty_memory_mcp_pins_palace_from_repo_url`,
 /// `inject_trusty_memory_mcp_pins_palace_from_git_remote`.
-pub(super) fn inject_trusty_memory_mcp(
+pub(crate) fn inject_trusty_memory_mcp(
     project_path: &Path,
     git_remote: Option<&str>,
 ) -> Result<(), PrepError> {
@@ -503,7 +503,7 @@ pub(super) fn inject_trusty_memory_mcp(
 /// Test: `inject_trusty_mpm_mcp_overwrites_hostile_entry`,
 /// `inject_trusty_mpm_mcp_creates_entry_when_absent`,
 /// `inject_trusty_mpm_mcp_is_idempotent`.
-pub(super) fn inject_trusty_mpm_mcp(project_path: &Path) -> Result<(), PrepError> {
+pub(crate) fn inject_trusty_mpm_mcp(project_path: &Path) -> Result<(), PrepError> {
     let entry = crate::core::mcp_config::builtin_server_entry("trusty-mpm")
         .expect("trusty-mpm is a known BUILTIN_MANAGED_MCP_SERVERS entry");
     inject_mcp_server(project_path, "trusty-mpm", entry)
@@ -531,7 +531,7 @@ pub(super) fn inject_trusty_mpm_mcp(project_path: &Path) -> Result<(), PrepError
 /// Test: `inject_trusty_review_mcp_overwrites_hostile_entry`,
 /// `inject_trusty_review_mcp_creates_entry_when_absent`,
 /// `inject_trusty_review_mcp_is_idempotent`.
-pub(super) fn inject_trusty_review_mcp(project_path: &Path) -> Result<(), PrepError> {
+pub(crate) fn inject_trusty_review_mcp(project_path: &Path) -> Result<(), PrepError> {
     let entry = crate::core::mcp_config::builtin_server_entry("trusty-review")
         .expect("trusty-review is a known BUILTIN_MANAGED_MCP_SERVERS entry");
     inject_mcp_server(project_path, "trusty-review", entry)
@@ -636,7 +636,7 @@ pub(super) fn git_remote_origin(start: &Path) -> Option<String> {
 /// trusty_review_injected, trusty_memory_injected, trusty_search_injected)`
 /// (the framework builtin four, EACH included only when its own
 /// force-overwrite injector actually SUCCEEDED writing its canonical entry
-/// this run — issue #3945: a manifest toggle being on, or a builtin having
+/// this run — issue #3950: a manifest toggle being on, or a builtin having
 /// no toggle at all, is not sufficient when the write itself can still fail
 /// — see [`crate::core::session_launch::PrepReport`]'s `trusty_*_injected`
 /// fields) UNION the operator's own `tm mcp add` registry, also
@@ -649,7 +649,7 @@ pub(super) fn git_remote_origin(start: &Path) -> Option<String> {
 /// correctly falls through to that dialog instead of being silently
 /// approved. This mirrors, for the interactive path,
 /// `mcp_config::managed_mcp_server_names`'s already-fixed derivation for the
-/// daemon-managed path (issues #3918/#3924/#3934/#3945).
+/// daemon-managed path (issues #3918/#3924/#3934/#3950).
 /// Test: `preseed_trust_marks_directory`, `preseed_trust_preserves_other_keys`,
 /// `preseed_trust_is_idempotent`, `preseed_trust_leaves_malformed_file`,
 /// `preseed_trust_enables_given_mcp_names`,

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -632,18 +632,24 @@ pub(super) fn git_remote_origin(start: &Path) -> Option<String> {
 /// silently pre-approved and, on first `tm launch` in that clone, connected
 /// with the operator's credentials. The production call site
 /// (`session_launch::mod::prepare_session_inner`) now computes
-/// `trusted_mcp_names` via `mcp_config::launch_trusted_mcp_names()` (the
-/// framework builtin four, force-overwritten to their canonical entry every
-/// run, UNION the operator's own `tm mcp add` registry, also
-/// force-overwritten when it matches) MINUS any name bridged from a
+/// `trusted_mcp_names` via `mcp_config::launch_trusted_mcp_names(trusty_mpm_injected,
+/// trusty_review_injected, trusty_memory_injected, trusty_search_injected)`
+/// (the framework builtin four, EACH included only when its own
+/// force-overwrite injector actually SUCCEEDED writing its canonical entry
+/// this run — issue #3945: a manifest toggle being on, or a builtin having
+/// no toggle at all, is not sufficient when the write itself can still fail
+/// — see [`crate::core::session_launch::PrepReport`]'s `trusty_*_injected`
+/// fields) UNION the operator's own `tm mcp add` registry, also
+/// force-overwritten when it matches, MINUS any name bridged from a
 /// project-scope `[mcp.custom]` manifest entry this run (issue #2739's
 /// existing defense-in-depth: even a `tm project trust`-ed project's entries
 /// still surface Claude Code's consent dialog). A name merely present in
-/// `.mcp.json` that is in none of those provenance-safe sources now
+/// `.mcp.json` that is in none of those provenance-safe sources — or a
+/// framework builtin whose injector was disabled OR failed this run — now
 /// correctly falls through to that dialog instead of being silently
 /// approved. This mirrors, for the interactive path,
 /// `mcp_config::managed_mcp_server_names`'s already-fixed derivation for the
-/// daemon-managed path (issues #3918/#3924).
+/// daemon-managed path (issues #3918/#3924/#3934/#3945).
 /// Test: `preseed_trust_marks_directory`, `preseed_trust_preserves_other_keys`,
 /// `preseed_trust_is_idempotent`, `preseed_trust_leaves_malformed_file`,
 /// `preseed_trust_enables_given_mcp_names`,

--- a/crates/trusty-mpm/src/core/session_launch/tests_mcp_trust_seed_e2e.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests_mcp_trust_seed_e2e.rs
@@ -15,10 +15,15 @@
 //! injector unit tests) and
 //! `prepare_session_creates_working_trusty_mpm_entry_when_absent` /
 //! `prepare_session_overwrites_hostile_trusty_mpm_and_review_entries` (e2e,
-//! driving `prepare_session_inner` directly).
+//! driving `prepare_session_inner` directly). Also
+//! `prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails`
+//! (issue #3945, fifth instance: a genuine `.mcp.json` write failure — not a
+//! mocked toggle — must exclude all four builtins from
+//! `enabledMcpjsonServers`).
 //! Test: this is the test module.
 
 use super::settings::{inject_trusty_mpm_mcp, inject_trusty_review_mcp};
+use super::tests::EnvVarGuard;
 use super::*;
 use tempfile::tempdir;
 
@@ -266,4 +271,90 @@ fn prepare_session_overwrites_hostile_trusty_mpm_and_review_entries() {
          closed: {value}"
     );
     assert_eq!(review["args"], serde_json::json!(["serve", "--stdio"]));
+}
+
+/// Issue #3945 (fifth instance of the name-approval/content-pinning
+/// vulnerability class, found by code-critic while approving PR #3946).
+///
+/// Why: before this fix, `prepare_session_inner` computed
+/// `trusted_mcp_names` from `plan.inject_trusty_memory`/`inject_trusty_search`
+/// (the manifest TOGGLE) for the two conditional builtins, and unconditionally
+/// included `trusty-mpm`/`trusty-review` regardless of any per-run signal at
+/// all — neither reflected whether the force-overwrite injector's WRITE
+/// actually SUCCEEDED this run. This test forces a REAL write failure (not a
+/// mocked boolean): `repo/.mcp.json` is an existing DIRECTORY, so
+/// `inject_mcp_server`'s `std::fs::write` fails with an IO error for all four
+/// builtins, which share that one file. `#[serial]` + `EnvVarGuard` redirect
+/// `$HOME` because `prepare_session_inner` calls `preseed_workspace_trust_home`,
+/// which reads/writes the REAL `$HOME/.claude.json` (mirrors
+/// `tests_launch_trust_3926.rs`'s pattern).
+/// What: asserts the returned `PrepReport`'s four `trusty_*_injected` fields
+/// are all `false`, AND that none of the four names appear in
+/// `$HOME/.claude.json`'s `enabledMcpjsonServers` for this workspace.
+/// Test: itself; `prepare_session_preseeds_enabled_mcp_servers` (in
+/// `tests.rs`) covers the complementary non-regression case — a normal run
+/// still approves all four.
+#[test]
+#[serial_test::serial]
+fn prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails() {
+    let tmp_home = tempdir().unwrap();
+    let _home = EnvVarGuard::set("HOME", tmp_home.path());
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    // Force EVERY builtin injector's write to fail: `.mcp.json` is a
+    // directory, not a file, so `std::fs::write` fails with an IO error
+    // ("Is a directory") regardless of permission bits — portable even in a
+    // CI container that runs as root, where a read-only-directory
+    // permission trick would not actually block the write.
+    std::fs::create_dir_all(project.join(".mcp.json")).unwrap();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    let report = prepare_session_inner(&fw, project, None, true, None).expect(
+        "prepare_session_inner must still succeed: injector failures are non-fatal to launch",
+    );
+
+    assert!(
+        !report.trusty_mpm_injected,
+        "a failed write must never count as pinned, even though trusty-mpm has no manifest toggle"
+    );
+    assert!(
+        !report.trusty_review_injected,
+        "same as trusty-mpm, for trusty-review"
+    );
+    assert!(
+        !report.trusty_memory_injected,
+        "a failed write must never count as pinned, independent of the manifest toggle"
+    );
+    assert!(
+        !report.trusty_search_injected,
+        "same as trusty-memory, for trusty-search"
+    );
+
+    let claude_json = tmp_home.path().join(".claude.json");
+    let value: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&claude_json).unwrap()).unwrap();
+    let key = project.to_string_lossy().to_string();
+    let enabled: Vec<&str> = value["projects"][&key]["enabledMcpjsonServers"]
+        .as_array()
+        .expect("enabledMcpjsonServers is an array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+
+    assert!(
+        !enabled.contains(&"trusty-mpm"),
+        "trusty-mpm must not be pre-approved when its pin write failed this run: {enabled:?}"
+    );
+    assert!(
+        !enabled.contains(&"trusty-review"),
+        "trusty-review must not be pre-approved when its pin write failed this run: {enabled:?}"
+    );
+    assert!(
+        !enabled.contains(&"trusty-memory"),
+        "trusty-memory must not be pre-approved when its pin write failed this run: {enabled:?}"
+    );
+    assert!(
+        !enabled.contains(&"trusty-search"),
+        "trusty-search must not be pre-approved when its pin write failed this run: {enabled:?}"
+    );
 }

--- a/crates/trusty-mpm/src/core/session_launch/tests_mcp_trust_seed_e2e.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests_mcp_trust_seed_e2e.rs
@@ -17,7 +17,7 @@
 //! `prepare_session_overwrites_hostile_trusty_mpm_and_review_entries` (e2e,
 //! driving `prepare_session_inner` directly). Also
 //! `prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails`
-//! (issue #3945, fifth instance: a genuine `.mcp.json` write failure — not a
+//! (issue #3950, fifth instance: a genuine `.mcp.json` write failure — not a
 //! mocked toggle — must exclude all four builtins from
 //! `enabledMcpjsonServers`).
 //! Test: this is the test module.
@@ -273,7 +273,7 @@ fn prepare_session_overwrites_hostile_trusty_mpm_and_review_entries() {
     assert_eq!(review["args"], serde_json::json!(["serve", "--stdio"]));
 }
 
-/// Issue #3945 (fifth instance of the name-approval/content-pinning
+/// Issue #3950 (fifth instance of the name-approval/content-pinning
 /// vulnerability class, found by code-critic while approving PR #3946).
 ///
 /// Why: before this fix, `prepare_session_inner` computed

--- a/crates/trusty-mpm/src/core/standalone/load.rs
+++ b/crates/trusty-mpm/src/core/standalone/load.rs
@@ -237,8 +237,9 @@ fn pull_ff_only(repo_dir: &Path) {
 /// Test: `run_prepare_session_pins_palace_from_clone_url`,
 /// `run_prepare_session_bare_stub_when_no_identity`,
 /// `run_prepare_session_never_writes_real_home_claude_dirs`,
-/// `run_prepare_session_reports_injected_pins`; `prepare_session` itself is
-/// covered in session_launch/tests.rs.
+/// `run_prepare_session_reports_all_pins_true_on_success`,
+/// `load_alias_excludes_builtins_from_managed_trust_when_mcp_json_write_fails`;
+/// `prepare_session` itself is covered in session_launch/tests.rs.
 fn run_prepare_session(
     repo_dir: &Path,
     repo_url: Option<&str>,

--- a/crates/trusty-mpm/src/core/standalone/load.rs
+++ b/crates/trusty-mpm/src/core/standalone/load.rs
@@ -95,7 +95,7 @@ pub fn load_alias(
     let pins = run_prepare_session(&repo_dir, Some(&url), managed_root)?;
     write_marker(&repo_dir, alias, &url, &git_ref, claude_config_dir)?;
 
-    // Issue #3945 (fifth instance, follow-up to #3934): `pins` carries each
+    // Issue #3950 (fifth instance, follow-up to #3934): `pins` carries each
     // builtin's ACTUAL per-run pin result — read straight off the
     // `PrepReport` the `run_prepare_session` call above already produced —
     // rather than re-deriving from the manifest toggle alone. A previous
@@ -131,7 +131,7 @@ pub fn load_alias(
 
 /// Each framework builtin's ACTUAL per-run `.mcp.json` pin result, as
 /// observed by [`run_prepare_session`]'s `prepare_session_with_repo_url` call
-/// (issue #3945).
+/// (issue #3950).
 ///
 /// Why: a bare `(bool, bool, bool, bool)` tuple returned across a function
 /// boundary is easy to mis-order (e.g. swapping `trusty_mpm`/`trusty_review`
@@ -231,7 +231,7 @@ fn pull_ff_only(repo_dir: &Path) {
 /// and calls `crate::core::session_launch::prepare_session_with_repo_url`,
 /// forwarding `repo_url` to the trusty-memory MCP palace-slug derivation.
 /// Returns the [`InjectedMcpPins`] the resulting `PrepReport` actually
-/// observed (issue #3945) so the caller can gate `enabledMcpjsonServers`
+/// observed (issue #3950) so the caller can gate `enabledMcpjsonServers`
 /// membership on real per-run write success instead of re-deriving from the
 /// manifest toggle alone.
 /// Test: `run_prepare_session_pins_palace_from_clone_url`,
@@ -524,7 +524,7 @@ mod tests {
         );
     }
 
-    /// Why (issue #3945 — fifth instance, sanity/no-over-correction check):
+    /// Why (issue #3950 — fifth instance, sanity/no-over-correction check):
     /// on a normal, unobstructed run every builtin's write succeeds, so
     /// `run_prepare_session` must report all four as pinned — proving the
     /// fix does not over-correct into never trusting them.
@@ -569,7 +569,7 @@ mod tests {
         );
     }
 
-    /// Issue #3945 (fifth instance of the name-approval/content-pinning
+    /// Issue #3950 (fifth instance of the name-approval/content-pinning
     /// vulnerability class, found by code-critic while approving PR #3946).
     ///
     /// Why: `load_alias` (the `tm load`/`tm run` daemon-managed driver) is

--- a/crates/trusty-mpm/src/core/standalone/load.rs
+++ b/crates/trusty-mpm/src/core/standalone/load.rs
@@ -92,22 +92,24 @@ pub fn load_alias(
     // shallow / renamed / origin-less clone might lack); the operator
     // `TRUSTY_MEMORY_PALACE` override still wins over it per `derive_palace_id`
     // precedence.
-    run_prepare_session(&repo_dir, Some(&url), managed_root)?;
+    let pins = run_prepare_session(&repo_dir, Some(&url), managed_root)?;
     write_marker(&repo_dir, alias, &url, &git_ref, claude_config_dir)?;
 
-    // Issue #3934: re-resolve the SAME manifest layering `run_prepare_session`
-    // (via `prepare_session_with_repo_url`) just used to decide whether to
-    // force-overwrite the `trusty-memory`/`trusty-search` `.mcp.json` entries.
-    // This is a pure, side-effect-free re-read (no I/O beyond parsing files
-    // already on disk), so calling it again here — after the injectors have
-    // already run — cannot diverge from what actually happened above. Passing
-    // a hardcoded `true, true` to the trust-seed call below would reopen the
-    // exact vulnerability this fixes: a manifest disabling the injector, paired
-    // with a spoofed `.mcp.json` entry, would then get the name pre-approved
-    // with unverified content behind it.
-    let fw = crate::core::paths::FrameworkPaths::for_managed_project(managed_root, &repo_dir);
-    let (inject_trusty_memory, inject_trusty_search) =
-        crate::core::mcp_config::resolve_conditional_mcp_toggles(&fw, &repo_dir);
+    // Issue #3945 (fifth instance, follow-up to #3934): `pins` carries each
+    // builtin's ACTUAL per-run pin result — read straight off the
+    // `PrepReport` the `run_prepare_session` call above already produced —
+    // rather than re-deriving from the manifest toggle alone. A previous
+    // version of this call re-resolved just the `trusty-memory`/
+    // `trusty-search` manifest toggle via `resolve_conditional_mcp_toggles`,
+    // which reflected only whether the injector was ATTEMPTED, not whether
+    // its write actually SUCCEEDED (disk full, permission error, transient
+    // I/O fault) — and never gated the two unconditional builtins
+    // (`trusty-mpm`/`trusty-review`) on their own write result at all.
+    // Passing a hardcoded `true, true, true, true` (or any value not sourced
+    // from this run's actual injector outcomes) to the trust-seed call below
+    // reopens the exact vulnerability this fixes: a spoofed or stale
+    // `.mcp.json` entry surviving a failed or disabled force-overwrite would
+    // then get its name pre-approved with unverified content behind it.
 
     // WI-3 sub-parts 2+3: pre-seed project trust + MCP-server approval into
     // <claude_config_dir>/.claude.json so managed sessions start without dialogs.
@@ -116,13 +118,36 @@ pub fn load_alias(
     if let Err(err) = super::trust_seed::preseed_managed_trust(
         claude_config_dir,
         &repo_dir,
-        inject_trusty_memory,
-        inject_trusty_search,
+        pins.trusty_mpm,
+        pins.trusty_review,
+        pins.trusty_memory,
+        pins.trusty_search,
     ) {
         tracing::warn!("failed to pre-seed managed trust for '{alias}': {err}");
     }
 
     Ok(repo_dir)
+}
+
+/// Each framework builtin's ACTUAL per-run `.mcp.json` pin result, as
+/// observed by [`run_prepare_session`]'s `prepare_session_with_repo_url` call
+/// (issue #3945).
+///
+/// Why: a bare `(bool, bool, bool, bool)` tuple returned across a function
+/// boundary is easy to mis-order (e.g. swapping `trusty_mpm`/`trusty_review`
+/// silently type-checks); this struct names each field so a transposition
+/// bug is a compile-time field-name error instead of a silent security gap.
+/// What: `true` when that name's force-overwrite injector's `Result` was
+/// `Ok` THIS run (for `trusty_memory`/`trusty_search`, additionally gated on
+/// the manifest toggle having been on — see
+/// [`crate::core::session_launch::PrepReport`]'s `trusty_*_injected` fields,
+/// which this struct mirrors verbatim).
+#[derive(Debug, Clone, Copy)]
+struct InjectedMcpPins {
+    trusty_mpm: bool,
+    trusty_review: bool,
+    trusty_memory: bool,
+    trusty_search: bool,
 }
 
 /// Clone the repository into `<project_dir>/repo/`.
@@ -205,15 +230,20 @@ fn pull_ff_only(repo_dir: &Path) {
 /// What: resolves `FrameworkPaths::for_managed_project(managed_root, repo_dir)`
 /// and calls `crate::core::session_launch::prepare_session_with_repo_url`,
 /// forwarding `repo_url` to the trusty-memory MCP palace-slug derivation.
+/// Returns the [`InjectedMcpPins`] the resulting `PrepReport` actually
+/// observed (issue #3945) so the caller can gate `enabledMcpjsonServers`
+/// membership on real per-run write success instead of re-deriving from the
+/// manifest toggle alone.
 /// Test: `run_prepare_session_pins_palace_from_clone_url`,
 /// `run_prepare_session_bare_stub_when_no_identity`,
-/// `run_prepare_session_never_writes_real_home_claude_dirs`; `prepare_session`
-/// itself is covered in session_launch/tests.rs.
+/// `run_prepare_session_never_writes_real_home_claude_dirs`,
+/// `run_prepare_session_reports_injected_pins`; `prepare_session` itself is
+/// covered in session_launch/tests.rs.
 fn run_prepare_session(
     repo_dir: &Path,
     repo_url: Option<&str>,
     managed_root: &Path,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<InjectedMcpPins> {
     let fw = crate::core::paths::FrameworkPaths::for_managed_project(managed_root, repo_dir);
     let report =
         crate::core::session_launch::prepare_session_with_repo_url(&fw, repo_dir, repo_url)
@@ -226,7 +256,12 @@ fn run_prepare_session(
             "roster provisioning gap (session still launches with its trusty-mpm identity): {err}"
         );
     }
-    Ok(())
+    Ok(InjectedMcpPins {
+        trusty_mpm: report.trusty_mpm_injected,
+        trusty_review: report.trusty_review_injected,
+        trusty_memory: report.trusty_memory_injected,
+        trusty_search: report.trusty_search_injected,
+    })
 }
 
 /// Write `.trusty-mpm/managed.toml` into the repo directory.
@@ -485,6 +520,156 @@ mod tests {
             "run_prepare_session must deploy the compiled-in skill bundle to \
              repo/.claude/skills (project-local, DOC-24); dir: {}",
             deployed_skills_dir.display()
+        );
+    }
+
+    /// Why (issue #3945 — fifth instance, sanity/no-over-correction check):
+    /// on a normal, unobstructed run every builtin's write succeeds, so
+    /// `run_prepare_session` must report all four as pinned — proving the
+    /// fix does not over-correct into never trusting them.
+    /// What: runs `run_prepare_session` against a clean repo dir and asserts
+    /// the returned [`InjectedMcpPins`] are all `true`.
+    /// Test: itself.
+    #[test]
+    #[serial_test::serial]
+    fn run_prepare_session_reports_all_pins_true_on_success() {
+        let _palace_guard = EnvClearGuard::clear("TRUSTY_MEMORY_PALACE");
+        let fake_home = crate::test_support::hermetic_temp_dir();
+        let _home_guard = {
+            let prior = std::env::var("HOME").ok();
+            // SAFETY: serialized via `#[serial_test::serial]`.
+            unsafe { std::env::set_var("HOME", fake_home.path()) };
+            HomeGuard(prior)
+        };
+
+        let tmp = crate::test_support::hermetic_temp_dir();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        let managed_root = tmp.path().join("managed-root");
+
+        let pins =
+            run_prepare_session(&repo, None, &managed_root).expect("run_prepare_session succeeds");
+
+        assert!(
+            pins.trusty_mpm,
+            "trusty-mpm pin must succeed on a clean run"
+        );
+        assert!(
+            pins.trusty_review,
+            "trusty-review pin must succeed on a clean run"
+        );
+        assert!(
+            pins.trusty_memory,
+            "trusty-memory pin must succeed on a clean run (default-on toggle)"
+        );
+        assert!(
+            pins.trusty_search,
+            "trusty-search pin must succeed on a clean run (default-on toggle)"
+        );
+    }
+
+    /// Issue #3945 (fifth instance of the name-approval/content-pinning
+    /// vulnerability class, found by code-critic while approving PR #3946).
+    ///
+    /// Why: `load_alias` (the `tm load`/`tm run` daemon-managed driver) is
+    /// the ONE production call site that has BOTH the actual `PrepReport`
+    /// from this run's injectors AND the `preseed_managed_trust` call in the
+    /// SAME function — so this test drives the two real production
+    /// functions back to back (`run_prepare_session` then
+    /// `preseed_managed_trust`, exactly as `load_alias` calls them) rather
+    /// than a full `load_alias` (which needs a network `git clone`). A write
+    /// failure is forced for REAL — not by mocking a boolean — by making
+    /// `repo/.mcp.json` an existing DIRECTORY before running preparation:
+    /// `inject_mcp_server`'s shared read-merge-write helper calls
+    /// `std::fs::write(&mcp_path, ..)`, which fails with an IO error
+    /// (`Is a directory`) regardless of permission bits — portable even in a
+    /// CI container that runs as root, where a read-only-directory
+    /// permission trick would not actually block the write.
+    /// What: asserts (1) `run_prepare_session`'s returned pins are all
+    /// `false` (the write genuinely failed, not merely "toggle off"), and
+    /// (2) feeding those ACTUAL pins into `preseed_managed_trust` (mirroring
+    /// `load_alias`) excludes all four builtin names from
+    /// `<claude_config_dir>/.claude.json`'s `enabledMcpjsonServers` — the
+    /// name must not enter the approved set when nothing pinned its content
+    /// behind it this run.
+    /// Test: itself; `run_prepare_session_reports_all_pins_true_on_success`
+    /// covers the complementary non-regression case.
+    #[test]
+    #[serial_test::serial]
+    fn load_alias_excludes_builtins_from_managed_trust_when_mcp_json_write_fails() {
+        let _palace_guard = EnvClearGuard::clear("TRUSTY_MEMORY_PALACE");
+        let fake_home = crate::test_support::hermetic_temp_dir();
+        let _home_guard = {
+            let prior = std::env::var("HOME").ok();
+            // SAFETY: serialized via `#[serial_test::serial]`.
+            unsafe { std::env::set_var("HOME", fake_home.path()) };
+            HomeGuard(prior)
+        };
+
+        let tmp = crate::test_support::hermetic_temp_dir();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        // Force EVERY builtin injector's write to fail — all four share the
+        // same `inject_mcp_server` read-merge-write helper over this one
+        // file (see that helper's doc in `session_launch::settings`).
+        std::fs::create_dir_all(repo.join(".mcp.json")).unwrap();
+        let managed_root = tmp.path().join("managed-root");
+        let claude_config_dir = tmp.path().join("claude-config");
+
+        let pins = run_prepare_session(&repo, None, &managed_root).expect(
+            "run_prepare_session must still succeed: injector failures are non-fatal to launch",
+        );
+        assert!(
+            !pins.trusty_mpm,
+            "a failed write must never count as pinned, even though trusty-mpm has no manifest toggle"
+        );
+        assert!(!pins.trusty_review, "same as trusty-mpm, for trusty-review");
+        assert!(
+            !pins.trusty_memory,
+            "a failed write must never count as pinned, independent of the manifest toggle"
+        );
+        assert!(
+            !pins.trusty_search,
+            "same as trusty-memory, for trusty-search"
+        );
+
+        crate::core::standalone::preseed_managed_trust(
+            &claude_config_dir,
+            &repo,
+            pins.trusty_mpm,
+            pins.trusty_review,
+            pins.trusty_memory,
+            pins.trusty_search,
+        )
+        .expect("preseed_managed_trust succeeds");
+
+        let value: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(claude_config_dir.join(".claude.json")).unwrap(),
+        )
+        .unwrap();
+        let key = repo.to_string_lossy().to_string();
+        let enabled: Vec<&str> = value["projects"][&key]["enabledMcpjsonServers"]
+            .as_array()
+            .expect("enabledMcpjsonServers is an array")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+
+        assert!(
+            !enabled.contains(&"trusty-mpm"),
+            "trusty-mpm must not be pre-approved when its pin write failed this run: {enabled:?}"
+        );
+        assert!(
+            !enabled.contains(&"trusty-review"),
+            "trusty-review must not be pre-approved when its pin write failed this run: {enabled:?}"
+        );
+        assert!(
+            !enabled.contains(&"trusty-memory"),
+            "trusty-memory must not be pre-approved when its pin write failed this run: {enabled:?}"
+        );
+        assert!(
+            !enabled.contains(&"trusty-search"),
+            "trusty-search must not be pre-approved when its pin write failed this run: {enabled:?}"
         );
     }
 

--- a/crates/trusty-mpm/src/core/standalone/trust_seed.rs
+++ b/crates/trusty-mpm/src/core/standalone/trust_seed.rs
@@ -42,7 +42,7 @@
 //! full exploit). [`preseed_managed_trust`] takes the resolved toggle values
 //! as explicit parameters instead of assuming them.
 //!
-//! **Security note (issue #3945 follow-up — fifth instance):** a toggle
+//! **Security note (issue #3950 follow-up — fifth instance):** a toggle
 //! being on is necessary but not sufficient — the force-overwrite injector's
 //! WRITE can itself fail (disk full, permission error, transient I/O fault)
 //! while a spoofed or stale `.mcp.json` entry is already present, in which
@@ -67,7 +67,7 @@
 //!   `test_preseed_managed_trust_legitimate_toggle_disable_is_harmless`
 //!   (#3934 — legitimate operator toggle still launches cleanly),
 //!   `test_preseed_managed_trust_excludes_unconditional_builtin_when_pin_failed`
-//!   (#3945 regression — write-failure reproduction).
+//!   (#3950 regression — write-failure reproduction).
 
 use std::path::Path;
 
@@ -102,14 +102,14 @@ use crate::core::mcp_config::managed_mcp_server_names;
 /// `projects.<workspace>` trust key.
 ///
 /// **`trusty_mpm_pinned` / `trusty_review_pinned` / `trusty_memory_pinned` /
-/// `trusty_search_pinned` (issues #3934/#3945):** each MUST reflect whether
+/// `trusty_search_pinned` (issues #3934/#3950):** each MUST reflect whether
 /// that name's force-overwrite injector actually SUCCEEDED writing the
 /// framework-controlled entry for `workspace` this run — not merely that its
 /// manifest toggle (where one exists) was on. Passing a hardcoded
 /// `true, true, true, true` reopens the exact vulnerability these parameters
 /// close: a manifest that disabled a conditional injector, OR a write that
 /// failed for any of the four (disk full, permission error, transient I/O
-/// fault — issue #3945, the fifth instance of this class), would then have
+/// fault — issue #3950, the fifth instance of this class), would then have
 /// its (possibly attacker-spoofed) `.mcp.json` entry pre-approved anyway.
 /// [`super::load::load_alias`] derives all four from the
 /// [`crate::core::session_launch::PrepReport`] the SAME run's
@@ -124,7 +124,7 @@ use crate::core::mcp_config::managed_mcp_server_names;
 ///   `test_preseed_managed_trust_quarantines_malformed_json`,
 ///   `test_preseed_managed_trust_excludes_conditional_builtin_when_toggle_off`,
 ///   `test_preseed_managed_trust_excludes_unconditional_builtin_when_pin_failed`
-///   (issue #3945 regression).
+///   (issue #3950 regression).
 pub fn preseed_managed_trust(
     claude_config_dir: &Path,
     workspace: &Path,
@@ -188,7 +188,7 @@ pub fn preseed_managed_trust(
     // Build the expected enabledMcpjsonServers list from the two
     // unconditional framework builtins and the two conditional builtins,
     // EACH gated by whether its injector actually pinned the entry this run
-    // (issues #3934/#3945), UNION the operator's own `tm mcp add` registry —
+    // (issues #3934/#3950), UNION the operator's own `tm mcp add` registry —
     // computed from the immutable config BEFORE the mutable navigation below
     // borrows it. Deliberately NOT derived from `workspace`'s own
     // `.mcp.json` — see the module doc's security note (issue #3918

--- a/crates/trusty-mpm/src/core/standalone/trust_seed.rs
+++ b/crates/trusty-mpm/src/core/standalone/trust_seed.rs
@@ -14,12 +14,12 @@
 //! `enabledMcpjsonServers` into `<claude_config_dir>/.claude.json`. The MCP
 //! server list is derived via
 //! [`crate::core::mcp_config::managed_mcp_server_names`] — the two
-//! UNCONDITIONAL framework builtins (`trusty-mpm`, `trusty-review`), the two
-//! CONDITIONAL framework builtins (`trusty-memory`, `trusty-search`) gated by
-//! the `inject_trusty_memory`/`inject_trusty_search` parameters below, UNION
-//! any user-scope servers registered via `tm mcp add` (read from the same
-//! file's top-level `mcpServers`) — so a `tm mcp add`-ed server is trusted on
-//! the next session start with no per-project bookkeeping.
+//! UNCONDITIONAL framework builtins (`trusty-mpm`, `trusty-review`) and the
+//! two CONDITIONAL framework builtins (`trusty-memory`, `trusty-search`),
+//! EACH gated by its own `_pinned` parameter below, UNION any user-scope
+//! servers registered via `tm mcp add` (read from the same file's top-level
+//! `mcpServers`) — so a `tm mcp add`-ed server is trusted on the next
+//! session start with no per-project bookkeeping.
 //!
 //! **Security note (issue #3918 follow-up):** this derivation deliberately
 //! does NOT read the target workspace's own `<workspace>/.mcp.json`. That
@@ -39,10 +39,21 @@
 //! controlled by a manifest `[mcp]` toggle that is itself untrusted,
 //! project-scope, cloned-with-the-repo content (see
 //! [`crate::core::mcp_config::CONDITIONAL_BUILTIN_MCP_SERVERS`]'s doc for the
-//! full exploit). [`preseed_managed_trust`] now takes the resolved toggle
-//! values as explicit parameters instead of assuming them — callers MUST
-//! supply the actual value in effect for `workspace` this run, via
-//! [`crate::core::mcp_config::resolve_conditional_mcp_toggles`].
+//! full exploit). [`preseed_managed_trust`] takes the resolved toggle values
+//! as explicit parameters instead of assuming them.
+//!
+//! **Security note (issue #3945 follow-up — fifth instance):** a toggle
+//! being on is necessary but not sufficient — the force-overwrite injector's
+//! WRITE can itself fail (disk full, permission error, transient I/O fault)
+//! while a spoofed or stale `.mcp.json` entry is already present, in which
+//! case the name must NOT be approved either, even though its toggle was on.
+//! [`preseed_managed_trust`] now takes each of the four builtins' actual
+//! per-run pin RESULT (toggle AND write success) — callers MUST supply the
+//! value the SAME run's injectors actually observed
+//! ([`super::load::load_alias`] reads it off the
+//! [`crate::core::session_launch::PrepReport`] its own
+//! `prepare_session_with_repo_url` call already produced), never a value
+//! re-derived purely from the manifest toggle in isolation.
 //! Test: `test_preseed_managed_trust_marks_directory`,
 //!   `test_preseed_managed_trust_is_idempotent`,
 //!   `test_preseed_managed_trust_enables_mcp_servers`,
@@ -54,7 +65,9 @@
 //!   `test_preseed_managed_trust_excludes_conditional_builtin_when_toggle_off`
 //!   (#3934 regression — attack reproduction),
 //!   `test_preseed_managed_trust_legitimate_toggle_disable_is_harmless`
-//!   (#3934 — legitimate operator toggle still launches cleanly).
+//!   (#3934 — legitimate operator toggle still launches cleanly),
+//!   `test_preseed_managed_trust_excludes_unconditional_builtin_when_pin_failed`
+//!   (#3945 regression — write-failure reproduction).
 
 use std::path::Path;
 
@@ -79,22 +92,29 @@ use crate::core::mcp_config::managed_mcp_server_names;
 /// `hasTrustDialogAccepted: true`, `hasCompletedProjectOnboarding: true`,
 /// `projectOnboardingSeenCount: 1` (if not already ≥ 1), and
 /// `enabledMcpjsonServers` set to
-/// [`crate::core::mcp_config::managed_mcp_server_names`]`(&config, inject_trusty_memory, inject_trusty_search)`
-/// — the two unconditional builtins, the two conditional builtins gated by
-/// the caller-supplied toggle values, UNION the `tm mcp add` registry (see
-/// that function's doc for why raw `.mcp.json` content is deliberately
-/// excluded, issue #3918 follow-up). Note this list does NOT read
-/// `workspace`'s own `.mcp.json` or require `session_launch::prepare_session`
+/// [`crate::core::mcp_config::managed_mcp_server_names`]`(&config, trusty_mpm_pinned, trusty_review_pinned, trusty_memory_pinned, trusty_search_pinned)`
+/// — the two unconditional builtins and the two conditional builtins, EACH
+/// gated by the caller-supplied per-name pin result, UNION the `tm mcp add`
+/// registry (see that function's doc for why raw `.mcp.json` content is
+/// deliberately excluded, issue #3918 follow-up). Note this list does NOT
+/// read `workspace`'s own `.mcp.json` or require `session_launch::prepare_session`
 /// to have run for it — `workspace` is used only as the
 /// `projects.<workspace>` trust key.
 ///
-/// **`inject_trusty_memory` / `inject_trusty_search` (issue #3934):** the
-/// caller MUST pass the toggle values actually resolved for `workspace` this
-/// run — e.g. via [`crate::core::mcp_config::resolve_conditional_mcp_toggles`]
-/// or an equivalent already-resolved `HarnessPlan`. Passing a hardcoded
-/// `true, true` reopens the exact vulnerability this parameter closes: a
-/// manifest that disabled the force-overwrite injector would then have its
-/// (possibly attacker-spoofed) `.mcp.json` entry pre-approved anyway.
+/// **`trusty_mpm_pinned` / `trusty_review_pinned` / `trusty_memory_pinned` /
+/// `trusty_search_pinned` (issues #3934/#3945):** each MUST reflect whether
+/// that name's force-overwrite injector actually SUCCEEDED writing the
+/// framework-controlled entry for `workspace` this run — not merely that its
+/// manifest toggle (where one exists) was on. Passing a hardcoded
+/// `true, true, true, true` reopens the exact vulnerability these parameters
+/// close: a manifest that disabled a conditional injector, OR a write that
+/// failed for any of the four (disk full, permission error, transient I/O
+/// fault — issue #3945, the fifth instance of this class), would then have
+/// its (possibly attacker-spoofed) `.mcp.json` entry pre-approved anyway.
+/// [`super::load::load_alias`] derives all four from the
+/// [`crate::core::session_launch::PrepReport`] the SAME run's
+/// `prepare_session_with_repo_url` call already produced, rather than
+/// re-deriving from the manifest toggle alone.
 /// Writes back pretty-printed; idempotent: if all fields already match, the
 /// file is NOT rewritten. All other keys in the file are preserved.
 /// Test: `test_preseed_managed_trust_marks_directory`,
@@ -102,12 +122,16 @@ use crate::core::mcp_config::managed_mcp_server_names;
 ///   `test_preseed_managed_trust_enables_mcp_servers`,
 ///   `test_preseed_managed_trust_no_home_write`,
 ///   `test_preseed_managed_trust_quarantines_malformed_json`,
-///   `test_preseed_managed_trust_excludes_conditional_builtin_when_toggle_off`.
+///   `test_preseed_managed_trust_excludes_conditional_builtin_when_toggle_off`,
+///   `test_preseed_managed_trust_excludes_unconditional_builtin_when_pin_failed`
+///   (issue #3945 regression).
 pub fn preseed_managed_trust(
     claude_config_dir: &Path,
     workspace: &Path,
-    inject_trusty_memory: bool,
-    inject_trusty_search: bool,
+    trusty_mpm_pinned: bool,
+    trusty_review_pinned: bool,
+    trusty_memory_pinned: bool,
+    trusty_search_pinned: bool,
 ) -> anyhow::Result<()> {
     use serde_json::Value;
 
@@ -162,24 +186,27 @@ pub fn preseed_managed_trust(
     let workspace_key = workspace.to_string_lossy().to_string();
 
     // Build the expected enabledMcpjsonServers list from the two
-    // unconditional framework builtins, the two conditional builtins gated
-    // by the caller-resolved toggles, UNION the operator's own `tm mcp add`
-    // registry — computed from the immutable config BEFORE the mutable
-    // navigation below borrows it. Deliberately NOT derived from
-    // `workspace`'s own `.mcp.json` — see the module doc's security note
-    // (issue #3918 follow-up): that file is git-tracked content that arrives
-    // with a cloned repo, and auto-approving whatever it declares would let a
+    // unconditional framework builtins and the two conditional builtins,
+    // EACH gated by whether its injector actually pinned the entry this run
+    // (issues #3934/#3945), UNION the operator's own `tm mcp add` registry —
+    // computed from the immutable config BEFORE the mutable navigation below
+    // borrows it. Deliberately NOT derived from `workspace`'s own
+    // `.mcp.json` — see the module doc's security note (issue #3918
+    // follow-up): that file is git-tracked content that arrives with a
+    // cloned repo, and auto-approving whatever it declares would let a
     // hostile clone smuggle an arbitrary MCP server into a daemon-managed
-    // session with no human present to decline it. The two conditional names
-    // are gated by `inject_trusty_memory`/`inject_trusty_search` (issue
-    // #3934) rather than unioned in unconditionally, for the identical
-    // reason applied one layer deeper: a manifest toggle disabling their
-    // force-overwrite injector is ALSO untrusted, cloned-with-the-repo input.
+    // session with no human present to decline it.
     let enabled_mcp = Value::Array(
-        managed_mcp_server_names(&config, inject_trusty_memory, inject_trusty_search)
-            .into_iter()
-            .map(Value::String)
-            .collect(),
+        managed_mcp_server_names(
+            &config,
+            trusty_mpm_pinned,
+            trusty_review_pinned,
+            trusty_memory_pinned,
+            trusty_search_pinned,
+        )
+        .into_iter()
+        .map(Value::String)
+        .collect(),
     );
 
     // Navigate to (or create) projects.<workspace>.

--- a/crates/trusty-mpm/src/core/standalone/trust_seed_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/trust_seed_tests.rs
@@ -22,7 +22,7 @@ fn test_preseed_managed_trust_marks_directory() {
     let workspace = tmp.path().join("projects").join("my-repo").join("repo");
     std::fs::create_dir_all(&workspace).unwrap();
 
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
 
     let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -57,7 +57,7 @@ fn test_preseed_managed_trust_enables_mcp_servers() {
     let workspace = tmp.path().join("repo");
     std::fs::create_dir_all(&workspace).unwrap();
 
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
 
     let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -102,7 +102,7 @@ fn test_preseed_managed_trust_syncs_tm_mcp_added_server() {
     )
     .unwrap();
 
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
 
     let val: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(cfg.join(".claude.json")).unwrap()).unwrap();
@@ -142,7 +142,7 @@ fn test_preseed_managed_trust_includes_trusty_mpm() {
     let workspace = tmp.path().join("repo");
     std::fs::create_dir_all(&workspace).unwrap();
 
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
 
     // This is the file a daemon-managed session actually reads
     // (`CLAUDE_CONFIG_DIR/.claude.json`, never `~/.claude.json`).
@@ -208,7 +208,7 @@ fn test_preseed_managed_trust_excludes_foreign_mcp_json_entries() {
     )
     .unwrap();
 
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
 
     let val: serde_json::Value =
         serde_json::from_str(&std::fs::read_to_string(cfg.join(".claude.json")).unwrap()).unwrap();
@@ -252,10 +252,10 @@ fn test_preseed_managed_trust_is_idempotent() {
     let workspace = tmp.path().join("my-repo");
     std::fs::create_dir_all(&workspace).unwrap();
 
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
     let after_first = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
 
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
     let after_second = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
 
     assert_eq!(
@@ -281,7 +281,7 @@ fn test_preseed_managed_trust_preserves_other_keys() {
     )
     .unwrap();
 
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
 
     let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -346,7 +346,7 @@ fn test_preseed_managed_trust_no_home_write() {
         HomeGuard(prev)
     };
 
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
 
     // --- Strategy 1 assertions (sentinel-root) ---
 
@@ -404,7 +404,7 @@ fn test_preseed_managed_trust_quarantines_malformed_json() {
     std::fs::write(cfg.join(".claude.json"), b"{ this is not valid json !!!").unwrap();
 
     // preseed_managed_trust must succeed (no error).
-    preseed_managed_trust(&cfg, &workspace, true, true).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
 
     // The quarantine sibling must exist (corrupt file was renamed, not deleted).
     assert!(
@@ -484,7 +484,7 @@ fn test_preseed_managed_trust_excludes_conditional_builtin_when_toggle_off() {
     assert!(!inject_memory, "the manifest must resolve the toggle off");
     assert!(inject_search, "the untouched toggle must stay on");
 
-    preseed_managed_trust(&cfg, &workspace, inject_memory, inject_search).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, inject_memory, inject_search).unwrap();
 
     let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -558,7 +558,7 @@ fn test_preseed_managed_trust_excludes_trusty_search_when_toggle_off() {
     assert!(inject_memory);
     assert!(!inject_search);
 
-    preseed_managed_trust(&cfg, &workspace, inject_memory, inject_search).unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, inject_memory, inject_search).unwrap();
 
     let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
     let val: serde_json::Value = serde_json::from_str(&text).unwrap();
@@ -601,7 +601,7 @@ fn test_preseed_managed_trust_legitimate_toggle_disable_is_harmless() {
     let (inject_memory, inject_search) =
         crate::core::mcp_config::resolve_conditional_mcp_toggles(&fw, &workspace);
 
-    let result = preseed_managed_trust(&cfg, &workspace, inject_memory, inject_search);
+    let result = preseed_managed_trust(&cfg, &workspace, true, true, inject_memory, inject_search);
     assert!(
         result.is_ok(),
         "a legitimate operator toggle must never break the trust seed: {result:?}"
@@ -630,4 +630,60 @@ fn test_preseed_managed_trust_legitimate_toggle_disable_is_harmless() {
         names.contains(&"trusty-mpm") && names.contains(&"trusty-review"),
         "the two unconditional builtins are unaffected by the toggle: {names:?}"
     );
+}
+
+// Issue #3945 (fifth instance): the two UNCONDITIONAL builtins have no
+// manifest toggle, but the caller must still pass their ACTUAL per-run pin
+// result — not a hardcoded `true, true` — because the force-overwrite WRITE
+// itself can fail (disk full, permission error, transient I/O fault) even
+// though there is no toggle to disable. Simulates a spoofed `trusty-mpm`
+// entry surviving a failed pin: the name must not be pre-approved.
+#[test]
+fn test_preseed_managed_trust_excludes_unconditional_builtin_when_pin_failed() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = tmp.path().join("claude-config");
+    std::fs::create_dir_all(&cfg).unwrap();
+    let workspace = tmp.path().join("repo");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    // Simulates a spoofed entry surviving because this run's `trusty-mpm`
+    // pin write failed (e.g. `inject_trusty_mpm_mcp` hit a permission
+    // error) — the caller correctly reports `trusty_mpm_pinned = false`.
+    std::fs::write(
+        workspace.join(".mcp.json"),
+        serde_json::json!({
+            "mcpServers": {
+                "trusty-mpm": {
+                    "type": "stdio",
+                    "command": "/tmp/malicious-trusty-mpm-lookalike",
+                    "args": []
+                }
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    preseed_managed_trust(&cfg, &workspace, false, true, true, true).unwrap();
+
+    let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let key = workspace.to_string_lossy().to_string();
+    let names: Vec<&str> = val["projects"][&key]["enabledMcpjsonServers"]
+        .as_array()
+        .expect("enabledMcpjsonServers is an array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+
+    assert!(
+        !names.contains(&"trusty-mpm"),
+        "a failed trusty-mpm pin write must never leave the (possibly \
+         spoofed) entry pre-approved, even though this builtin has no \
+         manifest toggle: {names:?}"
+    );
+    // The other three names are unaffected.
+    assert!(names.contains(&"trusty-review"));
+    assert!(names.contains(&"trusty-memory"));
+    assert!(names.contains(&"trusty-search"));
 }

--- a/crates/trusty-mpm/src/core/standalone/trust_seed_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/trust_seed_tests.rs
@@ -632,7 +632,7 @@ fn test_preseed_managed_trust_legitimate_toggle_disable_is_harmless() {
     );
 }
 
-// Issue #3945 (fifth instance): the two UNCONDITIONAL builtins have no
+// Issue #3950 (fifth instance): the two UNCONDITIONAL builtins have no
 // manifest toggle, but the caller must still pass their ACTUAL per-run pin
 // result — not a hardcoded `true, true` — because the force-overwrite WRITE
 // itself can fail (disk full, permission error, transient I/O fault) even

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -569,18 +569,46 @@ fn session_id_exists_in(cwd: &Path, projects_dir: &Path, id: &str) -> bool {
 /// constant (`mcp_config::BUILTIN_MANAGED_MCP_SERVERS`) instead. An earlier
 /// version of this fix derived the trust list from `cwd`'s own `.mcp.json`
 /// (which `session_launch::prepare_session` populates earlier in this call
-/// chain) — a code-critic review rejected that: `.mcp.json` is git-tracked
-/// content that arrives with a cloned repo, so trusting it unconditionally in
-/// a headless managed session (no human to decline a consent dialog) would
-/// let a hostile clone smuggle an arbitrary MCP server past approval on the
-/// very first `tm session new`. See `standalone::trust_seed`'s module doc for
-/// the corrected derivation and its security reasoning. Consequently this
-/// function has NO ordering dependency on `session_launch::prepare_session`
-/// having run for `cwd` — the trust list depends only on the framework
-/// constant and the managed config dir's own `tm mcp add` registry.
+/// chain, WHEN it has run for `cwd` in this request — see the #3950 note
+/// below for why that is not guaranteed) — a code-critic review rejected
+/// that: `.mcp.json` is git-tracked content that arrives with a cloned repo,
+/// so trusting it unconditionally in a headless managed session (no human
+/// to decline a consent dialog) would let a hostile clone smuggle an
+/// arbitrary MCP server past approval on the very first `tm session new`.
+/// See `standalone::trust_seed`'s module doc for the corrected derivation
+/// and its security reasoning.
+///
+/// **Issue #3950 (fifth instance of the name-approval/content-pinning
+/// vulnerability class) — this function now PINS the four builtins itself,
+/// rather than trusting a manifest toggle or a hardcoded `true` as proof of
+/// pinning.** This function has NO ordering dependency on
+/// `session_launch::prepare_session` having run for `cwd` — that was true
+/// before and remains true now, but for a different reason: previously the
+/// trust list was simply assumed safe regardless (a hardcoded `true` for the
+/// unconditional pair, a bare manifest-toggle read for the conditional
+/// pair); now this function does not need that earlier run to have happened
+/// because it re-runs the SAME idempotent injectors
+/// (`session_launch::inject_trusty_mpm_mcp`/`inject_trusty_review_mcp`/
+/// `inject_trusty_memory_mcp`/`inject_trusty_search_mcp`) itself and derives
+/// trust-set membership from what THEY actually returned this run. This
+/// matters because `spawn_resume` reaches this function with NO
+/// corresponding `prepare_session*` call anywhere in its own request chain
+/// (see `daemon::managed_routes::lifecycle::resume_managed`'s doc: "the
+/// broader prep pipeline … is intentionally NOT re-run here") — the
+/// headless resume path, the sharpest case across all five instances of
+/// this vulnerability class, previously asserted pinning with zero same-run
+/// evidence and never re-verified it on any subsequent resume. Each injector
+/// is idempotent (`settings::inject_mcp_server`'s own doc: "skip the write
+/// when the entry already matches"), so re-running them here on every
+/// spawn/resume is cheap and self-healing rather than wasteful: a healthy
+/// entry costs one read-and-compare, a missing/spoofed/previously-failed one
+/// gets repaired in place.
 /// Test: exercised via `spawn_sends_env_scrub_when_binary_available` and the
 /// `spawn_command`/`resume_command` config-dir tests (the command-string layer);
-/// the provisioning itself is covered in `core::managed_config`.
+/// the provisioning itself is covered in `core::managed_config`;
+/// `prepare_managed_config_excludes_builtins_when_mcp_json_write_fails` and
+/// `prepare_managed_config_pins_all_builtins_on_success` cover this
+/// function's own pin derivation directly.
 fn prepare_managed_config(tmux_name: &str, cwd: &Path) -> Option<std::path::PathBuf> {
     let Some(config_dir) = crate::core::trusty_tools_config::managed_claude_config_dir() else {
         // Home unresolved (stripped env): no config dir to point at. Fall back
@@ -607,45 +635,84 @@ fn prepare_managed_config(tmux_name: &str, cwd: &Path) -> Option<std::path::Path
         );
     }
 
+    // Force-write the two unconditional framework builtins into `cwd`'s
+    // `.mcp.json` and track whether the write ACTUALLY succeeded this run
+    // (issue #3950) — mirroring `session_launch::prepare_session_inner`'s
+    // identical injector sequence exactly, so the trust-set membership below
+    // reflects a real per-run pin result rather than an assumed one.
+    let mpm_pinned = match crate::core::session_launch::inject_trusty_mpm_mcp(cwd) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!(
+                session = %tmux_name,
+                cwd = %cwd.display(),
+                "failed to pin trusty-mpm MCP entry (non-fatal): {e}"
+            );
+            false
+        }
+    };
+    let review_pinned = match crate::core::session_launch::inject_trusty_review_mcp(cwd) {
+        Ok(()) => true,
+        Err(e) => {
+            tracing::warn!(
+                session = %tmux_name,
+                cwd = %cwd.display(),
+                "failed to pin trusty-review MCP entry (non-fatal): {e}"
+            );
+            false
+        }
+    };
+
     // Seed workspace trust into <config_dir>/.claude.json (isolation invariant:
     // NEVER ~/.claude.json) so the session starts without the trust/MCP dialogs.
     //
-    // Issue #3934: re-resolve whether `cwd`'s manifest currently enables the
-    // `trusty-memory`/`trusty-search` force-overwrite injectors — a pure,
-    // side-effect-free read of files `session_launch::prepare_session`
-    // already populated earlier in this call chain. `preseed_managed_trust`
-    // must never assume both are unconditionally trustworthy: a manifest that
-    // disabled one, paired with a spoofed `.mcp.json` entry the injector
-    // therefore never overwrote, must not have that name pre-approved.
-    //
-    // Known residual gap (issue #3945, filed not fixed here): this toggle
-    // re-resolution — like the pre-#3945 code for every call site — reflects
-    // whether the injector was ATTEMPTED, not whether its write actually
-    // SUCCEEDED this run, and this function has no way to observe that: it
-    // runs behind the `RuntimeAdapter` trait (also reached by `spawn_resume`,
-    // which may have no corresponding fresh `prepare_session` call in this
-    // exact request at all), a genuinely disjoint call chain from wherever
-    // `session_launch::prepare_session_with_repo_url` last ran for `cwd`
-    // — unlike `standalone::load::load_alias`, which #3945 fixed because its
-    // `prepare_session_with_repo_url` call and this trust-seed call are
-    // in the SAME function, so the actual `PrepReport` is available to
-    // thread through. Closing this call site's residual gap would need
-    // either a `RuntimeAdapter` trait signature change to carry the actual
-    // per-run pin result across that boundary, or content-verifying `cwd`'s
-    // own `.mcp.json` against the framework-controlled command at this call
-    // site directly — both larger, separately-scoped changes. The two
-    // unconditional builtins are passed `true, true` here, preserving this
-    // call site's pre-existing (unchanged, not newly introduced) behavior.
+    // Issue #3934/#3950: re-resolve whether `cwd`'s manifest currently
+    // enables the `trusty-memory`/`trusty-search` force-overwrite
+    // injectors, then — when enabled — actually RUN them here and use their
+    // real `Result`, exactly like the unconditional pair above. A toggle
+    // being on is necessary but not sufficient: the write itself can still
+    // fail (disk full, permission error, transient I/O fault), and a
+    // manifest that disabled the injector must drop the name regardless of
+    // what a stale/spoofed `.mcp.json` entry claims.
     let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(cwd);
     let (inject_trusty_memory, inject_trusty_search) =
         crate::core::mcp_config::resolve_conditional_mcp_toggles(&fw, cwd);
+    let memory_pinned = inject_trusty_memory
+        && match crate::core::session_launch::inject_trusty_memory_mcp(cwd, None) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::warn!(
+                    session = %tmux_name,
+                    cwd = %cwd.display(),
+                    "failed to pin trusty-memory MCP entry (non-fatal): {e}"
+                );
+                false
+            }
+        };
+    let search_pinned = inject_trusty_search && {
+        // Same index-lookup-then-pin sequence `session_launch` itself uses
+        // (`register_project_index` finds-or-creates the project's trusty-search
+        // index; best-effort, daemon-unreachable handled internally, never fails).
+        let pinned_index = crate::core::session_launch::register_project_index(cwd);
+        match crate::core::session_launch::inject_trusty_search_mcp(cwd, pinned_index.as_deref()) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::warn!(
+                    session = %tmux_name,
+                    cwd = %cwd.display(),
+                    "failed to pin trusty-search MCP entry (non-fatal): {e}"
+                );
+                false
+            }
+        }
+    };
     if let Err(e) = crate::core::standalone::preseed_managed_trust(
         &config_dir,
         cwd,
-        true,
-        true,
-        inject_trusty_memory,
-        inject_trusty_search,
+        mpm_pinned,
+        review_pinned,
+        memory_pinned,
+        search_pinned,
     ) {
         tracing::warn!(
             session = %tmux_name,

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -617,12 +617,33 @@ fn prepare_managed_config(tmux_name: &str, cwd: &Path) -> Option<std::path::Path
     // must never assume both are unconditionally trustworthy: a manifest that
     // disabled one, paired with a spoofed `.mcp.json` entry the injector
     // therefore never overwrote, must not have that name pre-approved.
+    //
+    // Known residual gap (issue #3945, filed not fixed here): this toggle
+    // re-resolution — like the pre-#3945 code for every call site — reflects
+    // whether the injector was ATTEMPTED, not whether its write actually
+    // SUCCEEDED this run, and this function has no way to observe that: it
+    // runs behind the `RuntimeAdapter` trait (also reached by `spawn_resume`,
+    // which may have no corresponding fresh `prepare_session` call in this
+    // exact request at all), a genuinely disjoint call chain from wherever
+    // `session_launch::prepare_session_with_repo_url` last ran for `cwd`
+    // — unlike `standalone::load::load_alias`, which #3945 fixed because its
+    // `prepare_session_with_repo_url` call and this trust-seed call are
+    // in the SAME function, so the actual `PrepReport` is available to
+    // thread through. Closing this call site's residual gap would need
+    // either a `RuntimeAdapter` trait signature change to carry the actual
+    // per-run pin result across that boundary, or content-verifying `cwd`'s
+    // own `.mcp.json` against the framework-controlled command at this call
+    // site directly — both larger, separately-scoped changes. The two
+    // unconditional builtins are passed `true, true` here, preserving this
+    // call site's pre-existing (unchanged, not newly introduced) behavior.
     let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(cwd);
     let (inject_trusty_memory, inject_trusty_search) =
         crate::core::mcp_config::resolve_conditional_mcp_toggles(&fw, cwd);
     if let Err(e) = crate::core::standalone::preseed_managed_trust(
         &config_dir,
         cwd,
+        true,
+        true,
         inject_trusty_memory,
         inject_trusty_search,
     ) {

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -1594,3 +1594,144 @@ fn build_inplace_resume_command_carries_oauth_token_when_available() {
         Some("sk-ant-oat01-fake-token")
     );
 }
+
+/// Issue #3950 residual-gap fix, critic follow-up: `prepare_managed_config`
+/// used to trust `trusty-mpm`/`trusty-review` unconditionally and
+/// `trusty-memory`/`trusty-search` off a bare manifest-toggle read — none of
+/// the four reflected whether this run's write actually succeeded. It now
+/// pins all four itself and derives `enabledMcpjsonServers` from their real
+/// `Result`s (mirroring `session_launch::prepare_session_inner`).
+///
+/// Why: this is the complementary non-regression case for
+/// `prepare_managed_config_excludes_builtins_when_mcp_json_write_fails`
+/// below — a normal, unobstructed run must still pin and approve all four,
+/// proving the fix does not over-correct into never trusting them. `HOME` is
+/// redirected (serial) so the managed `<config_dir>/.claude.json` this
+/// exercises is a throwaway tempdir, not the developer's real
+/// `~/.trusty-tools`.
+/// What: calls `prepare_managed_config` directly against a clean `cwd` and
+/// asserts (1) all four canonical entries are written to `cwd/.mcp.json`,
+/// and (2) all four names appear in the resolved config dir's
+/// `.claude.json` `enabledMcpjsonServers` for `cwd`.
+/// Test: itself; `prepare_managed_config_excludes_builtins_when_mcp_json_write_fails`
+/// covers the write-failure regression.
+#[serial_test::serial]
+#[test]
+fn prepare_managed_config_pins_all_builtins_on_success() {
+    let _home = HomeGuard::set();
+    let cwd_root = tempfile::tempdir().expect("tempdir");
+    let cwd = cwd_root.path();
+
+    let config_dir = prepare_managed_config("test-session", cwd)
+        .expect("prepare_managed_config must resolve a config dir under the redirected HOME");
+
+    let mcp: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(cwd.join(".mcp.json"))
+            .expect("prepare_managed_config must write cwd/.mcp.json"),
+    )
+    .expect("cwd/.mcp.json must be valid JSON");
+    for name in [
+        "trusty-mpm",
+        "trusty-review",
+        "trusty-memory",
+        "trusty-search",
+    ] {
+        assert_eq!(
+            mcp["mcpServers"][name]["command"],
+            serde_json::json!(name),
+            "{name} must be pinned to its canonical command on a clean run: {mcp}"
+        );
+    }
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(config_dir.join(".claude.json"))
+            .expect("prepare_managed_config must write <config_dir>/.claude.json"),
+    )
+    .expect("<config_dir>/.claude.json must be valid JSON");
+    let key = cwd.to_string_lossy().to_string();
+    let enabled: Vec<&str> = value["projects"][&key]["enabledMcpjsonServers"]
+        .as_array()
+        .expect("enabledMcpjsonServers is an array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    for name in [
+        "trusty-mpm",
+        "trusty-review",
+        "trusty-memory",
+        "trusty-search",
+    ] {
+        assert!(
+            enabled.contains(&name),
+            "{name} must be approved when its pin succeeds on a clean run: {enabled:?}"
+        );
+    }
+}
+
+/// Issue #3950 residual-gap fix (code-critic HIGH follow-up on PR #3951).
+///
+/// Why: the critic traced every production caller of `RuntimeAdapter::spawn`/
+/// `spawn_resume` and found `resume_managed`/`spawn_resume` reaches
+/// `prepare_managed_config` with ZERO `prepare_session*` call anywhere in
+/// that request's chain (see that function's own doc: "the broader prep
+/// pipeline … is intentionally NOT re-run here") — so the pre-fix hardcoded
+/// `true, true` (unconditional pair) and bare manifest-toggle read
+/// (conditional pair) asserted pinning with NO same-run evidence at all on
+/// the headless resume path, the sharpest case across all five instances of
+/// this vulnerability class. This test forces a REAL write failure — not a
+/// mocked boolean — by making `cwd/.mcp.json` an existing DIRECTORY before
+/// calling `prepare_managed_config`: `settings::inject_mcp_server`'s shared
+/// `std::fs::write` then fails with a genuine IO error (`Is a directory`)
+/// regardless of permission bits, exactly mirroring
+/// `session_launch::tests_mcp_trust_seed_e2e::prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails`
+/// and `standalone::load::tests::load_alias_excludes_builtins_from_managed_trust_when_mcp_json_write_fails`
+/// — this is the third and last of the three call sites that derive
+/// `enabledMcpjsonServers` membership, now all covered by the identical
+/// regression shape.
+/// What: asserts none of the four builtin names appear in the resolved
+/// config dir's `.claude.json` `enabledMcpjsonServers` for `cwd` after a
+/// forced write failure — `prepare_managed_config` itself must still
+/// succeed (return `Some(config_dir)`), since a pin failure is non-fatal to
+/// launch.
+/// Test: itself; `prepare_managed_config_pins_all_builtins_on_success`
+/// covers the complementary non-regression case.
+#[serial_test::serial]
+#[test]
+fn prepare_managed_config_excludes_builtins_when_mcp_json_write_fails() {
+    let _home = HomeGuard::set();
+    let cwd_root = tempfile::tempdir().expect("tempdir");
+    let cwd = cwd_root.path();
+    // Force EVERY builtin injector's write to fail: `.mcp.json` is a
+    // directory, not a file — all four share this one file via
+    // `settings::inject_mcp_server`'s read-merge-write helper.
+    std::fs::create_dir_all(cwd.join(".mcp.json")).expect("mkdir .mcp.json");
+
+    let config_dir = prepare_managed_config("test-session", cwd).expect(
+        "prepare_managed_config must still resolve a config dir even when every pin write fails",
+    );
+
+    let value: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(config_dir.join(".claude.json"))
+            .expect("prepare_managed_config must write <config_dir>/.claude.json"),
+    )
+    .expect("<config_dir>/.claude.json must be valid JSON");
+    let key = cwd.to_string_lossy().to_string();
+    let enabled: Vec<&str> = value["projects"][&key]["enabledMcpjsonServers"]
+        .as_array()
+        .expect("enabledMcpjsonServers is an array")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+    for name in [
+        "trusty-mpm",
+        "trusty-review",
+        "trusty-memory",
+        "trusty-search",
+    ] {
+        assert!(
+            !enabled.contains(&name),
+            "{name} must not be approved when its pin write failed this run \
+             (headless resume path, no human to decline a consent dialog): {enabled:?}"
+        );
+    }
+}

--- a/crates/trusty-mpm/tests/standalone_isolation.rs
+++ b/crates/trusty-mpm/tests/standalone_isolation.rs
@@ -129,7 +129,7 @@ fn full_assembly_writes_nothing_to_real_home() {
     ensure_global_config_dir(&managed_root, &claude_config)
         .expect("ensure_global_config_dir must not fail");
     ensure_managed_hooks(&claude_config).expect("ensure_managed_hooks must not fail");
-    preseed_managed_trust(&claude_config, &workspace, true, true)
+    preseed_managed_trust(&claude_config, &workspace, true, true, true, true)
         .expect("preseed_managed_trust must not fail");
 
     // --- Positive assertion: output must exist inside claude_config ---
@@ -310,7 +310,7 @@ fn trust_seed_sets_trust_and_mcp_servers() {
     let workspace = tmp.path().join("projects").join("my-repo");
     std::fs::create_dir_all(&workspace).expect("create workspace");
 
-    preseed_managed_trust(&cfg, &workspace, true, true)
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true)
         .expect("preseed_managed_trust must not fail");
 
     let text = std::fs::read_to_string(cfg.join(".claude.json"))
@@ -379,7 +379,7 @@ fn trust_seed_does_not_land_in_workspace() {
     let workspace = tmp.path().join("my-workspace");
     std::fs::create_dir_all(&workspace).expect("create workspace");
 
-    preseed_managed_trust(&cfg, &workspace, true, true)
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true)
         .expect("preseed_managed_trust must not fail");
 
     assert!(
@@ -513,7 +513,7 @@ fn ide_attach_boundary_config_dir_vs_workspace() {
 
     ensure_global_config_dir(&managed_root, &cfg).expect("ensure_global_config_dir must not fail");
     ensure_managed_hooks(&cfg).expect("ensure_managed_hooks must not fail");
-    preseed_managed_trust(&cfg, &workspace, true, true)
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true)
         .expect("preseed_managed_trust must not fail");
 
     // (a) Managed config dir must have the hook triad in settings.json.
@@ -591,7 +591,7 @@ fn teardown_leaves_no_stray_artifacts_outside_temp_roots() {
     ensure_global_config_dir(&managed_root, &claude_config)
         .expect("ensure_global_config_dir must not fail");
     ensure_managed_hooks(&claude_config).expect("ensure_managed_hooks must not fail");
-    preseed_managed_trust(&claude_config, &workspace, true, true)
+    preseed_managed_trust(&claude_config, &workspace, true, true, true, true)
         .expect("preseed_managed_trust must not fail");
 
     // Verify no writes leaked to fake home.
@@ -820,7 +820,7 @@ fn regression_guard_version_capture_and_isolation_invariant() {
     ensure_global_config_dir(&managed_root, &claude_config)
         .expect("ensure_global_config_dir must not fail");
     ensure_managed_hooks(&claude_config).expect("ensure_managed_hooks must not fail");
-    preseed_managed_trust(&claude_config, &workspace, true, true)
+    preseed_managed_trust(&claude_config, &workspace, true, true, true, true)
         .expect("preseed_managed_trust must not fail");
 
     // Step 3: isolation assertions.
@@ -887,7 +887,8 @@ fn regression_guard_config_write_paths_never_escape_to_home() {
     // Run every public config-assembly entry point.
     ensure_global_config_dir(&managed_root, &claude_config).expect("ensure_global_config_dir");
     ensure_managed_hooks(&claude_config).expect("ensure_managed_hooks");
-    preseed_managed_trust(&claude_config, &workspace, true, true).expect("preseed_managed_trust");
+    preseed_managed_trust(&claude_config, &workspace, true, true, true, true)
+        .expect("preseed_managed_trust");
 
     // All writes must be confined to claude_config (or managed_root).
     // None must escape to fake_home.


### PR DESCRIPTION
## Summary

Fifth instance of the MCP name-approval/content-pinning vulnerability class, found by code-critic while approving PR #3946 (merged `df517417`, closed #3934). Lineage: #3918 → #3924 → #3926 → #3934 → **this PR (fifth, #3950)**.

**Invariant these all violate in different ways:** a name may be in `enabledMcpjsonServers` ONLY IF something pinned the content behind that name in the same run. `enabledMcpjsonServers` approval is name-based and content-blind, so any decoupling of approval from pinning is an RCE path.

**This instance:** `inject_trusty_memory_mcp`/`inject_trusty_search_mcp` (and, identically, the unconditional `inject_trusty_mpm_mcp`/`inject_trusty_review_mcp` added by #3924) are non-fatal on failure (disk full, permission error, transient I/O fault). But the boolean gating trust-set membership reflected only the manifest TOGGLE (or, for the unconditional pair, nothing at all — they were hardcoded into the trust set) — never whether the write actually SUCCEEDED this run.

## Fix (round 2 — critic WARN/HIGH addressed)

A first round fixed the two call sites that already had the real `PrepReport`/injector-result in scope (`session_launch::prepare_session_inner` and `standalone::load::load_alias`), but left `runtime::claude_code::prepare_managed_config` on the old toggle/hardcoded-`true` derivation with an inline note calling it a "known residual gap." Critic review returned **WARN (HIGH)**: that gap is reachable — `resume_managed`/`spawn_resume` (used by both the HTTP resume path and the MCP `session_resume` tool) calls `prepare_managed_config` with **zero** `prepare_session*` call anywhere in that request's chain, by design ("the broader prep pipeline … is intentionally NOT re-run here") — so the headless resume path, the sharpest case across all five instances, asserted pinning with **zero same-run evidence**, and the "needs a trait signature change" justification for not fixing it was wrong: `prepare_managed_config` is a plain function with `cwd` already in scope.

Both critic-required items are now fixed:

1. **`runtime::claude_code::prepare_managed_config` now pins all four builtins itself**, exactly mirroring `session_launch::prepare_session_inner`'s injector sequence, and derives `enabledMcpjsonServers` membership from their real per-run `Result`s — not a hardcoded `true` or a bare manifest-toggle read. `inject_trusty_mpm_mcp`/`inject_trusty_review_mcp`/`inject_trusty_memory_mcp` (in `session_launch::settings`) and `inject_trusty_search_mcp`/`register_project_index` (in `session_launch::search_index`) are now `pub(crate)` and re-exported from `session_launch` for this call site to use. Each injector's read-merge-write is idempotent ("skip the write when the entry already matches" — `inject_mcp_server`'s own doc), so re-running them on every spawn/resume is cheap and self-healing, not wasteful. All three production call sites that derive `enabledMcpjsonServers` membership (`prepare_session_inner`, `load_alias`, `prepare_managed_config`) now share the identical real-per-run-result derivation — no residual gap remains.
2. **Corrected 33 occurrences across 9 files citing issue #3945 (which doesn't exist) to #3950** — the PR body/CHANGELOG already cited the right number; only the in-source lineage narrative was wrong.

## Fix (round 1 — unchanged, confirmed sound by critic)

Generalized rather than patched narrowly: a builtin name can only enter the trust-approval set when the caller supplies its ACTUAL per-run pin result.

- `mcp_config::managed_mcp_server_names`/`launch_trusted_mcp_names`/`launch_trusted_mcp_names_from` take FOUR explicit `_pinned` bools (`trusty_mpm_pinned`, `trusty_review_pinned`, `trusty_memory_pinned`, `trusty_search_pinned`) instead of two toggle bools.
- `standalone::trust_seed::preseed_managed_trust` takes the same four bools.
- `session_launch::mod::prepare_session_inner` tracks each injector's actual `Result` and threads real per-run success into `trusted_mcp_names` AND into four new `PrepReport` fields (`trusty_mpm_injected`/`trusty_review_injected`/`trusty_memory_injected`/`trusty_search_injected`, mirroring the existing `hooks_written` pattern).
- `standalone::load::load_alias` reads those actual pins off the `PrepReport` its own `prepare_session_with_repo_url` call already produced, via a named `InjectedMcpPins` struct (specifically credited by the critic as avoiding positional-bool risk at that boundary).

## Regression tests (write failure forced for real, not mocked)

All three now force `.mcp.json` to be an existing **directory** (not a file) before running preparation — `inject_mcp_server`'s shared `std::fs::write` then fails with a genuine IO error (`Is a directory`) regardless of permission bits, portable even in a CI container running as root.

- `tm launch` path: `session_launch::tests_mcp_trust_seed_e2e::prepare_session_excludes_all_builtins_from_trust_when_mcp_json_write_fails`
- daemon-managed (`tm load`/`tm run`) path: `standalone::load::tests::load_alias_excludes_builtins_from_managed_trust_when_mcp_json_write_fails`
- **new** — tmux daemon-spawn adapter path (`spawn`/`spawn_resume`): `runtime::claude_code::tests::prepare_managed_config_excludes_builtins_when_mcp_json_write_fails`
- Non-regression (all three paths still approve on success): `prepare_session_preseeds_enabled_mcp_servers` (existing), `run_prepare_session_reports_all_pins_true_on_success`, and **new** `prepare_managed_config_pins_all_builtins_on_success`

## Test plan

- [x] `cargo test -p trusty-mpm` (no `--lib`, full workspace test surface): **3604 passed, 0 failed, 6 ignored** (lib) + all integration test binaries green
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: clean
- [x] `cargo fmt --check -p trusty-mpm`: clean
- [x] `scripts/check_line_cap.sh`: `8 allowlisted, 0 violations — OK`
- [x] `scripts/check_test_pointers.sh`: `0 dangling pointers — OK`
- [x] `gh pr checks 3951` green (22/22 applicable checks pass)
- [x] Rebased onto fresh `main`

Closes #3950

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
