### PR TITLE
fix(trusty-search): fold full warm_boot_degraded signal into /health status

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- **`GET /health`'s top-level `status` now reflects the FULL
+  `warm_boot_degraded` signal, not just corpus-open failure (issue #3706).**
+  `overall_status` previously downgraded to `"degraded"` only when
+  `indexes_corpus_failed > 0` or a watcher was network-degraded, ignoring
+  the other three conditions `warmboot_summary.warm_boot_degraded` itself
+  aggregates (per its own doc comment in `state.rs`): a TCC/FDA denial, a
+  scan timeout, and mass index loss (loaded < 80% of the prior-known
+  count). A daemon that was genuinely warm-boot-degraded purely from one of
+  those three still reported `status: "ok"` on `/health` — exactly the
+  silent-degradation gap `warm_boot_degraded` exists to close, and the
+  reason trusty-review's `is_serving()` (#3693/#3704) never got a chance to
+  catch it, since it only consults `warm_boot_degraded` once `status`
+  itself already reads `"degraded"`. `overall_status` now checks
+  `warmboot_summary.warm_boot_degraded` directly (a strict superset of the
+  old `indexes_corpus_failed > 0` check, since that count is already
+  folded into `warm_boot_degraded`), so all four conditions now flip the
+  top-level status.
+
+---
 ## [0.39.1] — 2026-07-24
 
 ### Fixed

--- a/crates/trusty-search/src/service/server/health.rs
+++ b/crates/trusty-search/src/service/server/health.rs
@@ -556,8 +556,21 @@ pub(super) async fn health_handler(
     // network-mounted root — the daemon is not silently broken, but it is
     // running with a real capability gap that the same `status != "ok"`
     // monitors should catch.
+    // Issue #3706: fold in the FULL `warm_boot_degraded` flag rather than only
+    // `indexes_corpus_failed`. `warm_boot_degraded` (see its doc comment in
+    // `state.rs`) already aggregates FOUR conditions — TCC/FDA denial, scan
+    // timeout, corpus-open failure, and mass index loss (< 80% of prior) —
+    // but only the corpus-open-failure case was previously reflected in the
+    // top-level `status` field. A daemon that was genuinely warm-boot-degraded
+    // purely from a TCC denial, a scan timeout, or a mass index loss still
+    // reported `status: "ok"`, which is exactly what `warmboot_summary.
+    // warm_boot_degraded` was supposed to make impossible to miss. Since
+    // `indexes_corpus_failed` is already OR'd into `warm_boot_degraded` above
+    // (and by `recompute_warm_boot_degraded`), checking `warm_boot_degraded`
+    // alone is a strict superset of the old condition — no case that used to
+    // report `"degraded"` stops doing so.
     let overall_status =
-        if warmboot_summary.indexes_corpus_failed > 0 || indexes_watcher_network_degraded > 0 {
+        if warmboot_summary.warm_boot_degraded || indexes_watcher_network_degraded > 0 {
             "degraded"
         } else {
             "ok"

--- a/crates/trusty-search/src/service/server/tests_health_degraded.rs
+++ b/crates/trusty-search/src/service/server/tests_health_degraded.rs
@@ -291,3 +291,163 @@ async fn recompute_does_not_flag_an_in_progress_tail_job_as_degraded() {
         "an InProgress (still embedding) tail job must not read as degraded (#3748)"
     );
 }
+
+/// Issue #3706: `overall_status` used to only inspect
+/// `indexes_corpus_failed` and the watcher-network-degraded count, ignoring
+/// the other three conditions `warm_boot_degraded` itself aggregates (see
+/// its doc comment in `state.rs`) — a TCC/FDA denial. A daemon that skipped
+/// loading a volume purely because of a TCC denial had
+/// `warm_boot_degraded: true` in the JSON body, yet the top-level `status`
+/// field consumers actually gate on (`HealthResponse::is_serving` in
+/// trusty-review, `status != "ok"` monitors) still read `"ok"`.
+/// What: seeds `warmboot_summary.indexes_skipped_tcc = 1` and
+/// `warm_boot_degraded = true` (exactly what `record_warm_boot_result` would
+/// have set at boot for a pure TCC-denial boot, with zero corpus failures
+/// and zero timeouts), registers one healthy index so `indexes_corpus_failed`
+/// stays `0`, and asserts `/health` still reports `status: "degraded"`.
+/// Test: this IS the test.
+#[tokio::test]
+async fn health_reports_degraded_when_tcc_skip_recorded() {
+    use crate::core::indexer::CodeIndexer;
+    use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let registry = IndexRegistry::new();
+    registry.register(IndexHandle::bare(
+        IndexId::new("healthy"),
+        Arc::new(RwLock::new(CodeIndexer::new("healthy", "/tmp/healthy"))),
+        "/tmp/healthy".into(),
+    ));
+
+    let state = Arc::new(SearchAppState::new(registry));
+    {
+        let mut summary = state.warmboot_summary.lock().expect("lock");
+        summary.indexes_skipped_tcc = 1;
+        summary.warm_boot_degraded = true;
+    }
+
+    let Json(resp) = health_handler(State(Arc::clone(&state))).await;
+
+    assert_eq!(
+        resp.status, "degraded",
+        "#3706: /health must report 'degraded' when warm_boot_degraded is true \
+         from a TCC skip alone, even though indexes_corpus_failed is 0"
+    );
+}
+
+/// Issue #3706: same gap as `health_reports_degraded_when_tcc_skip_recorded`
+/// but for the scan-timeout condition (`indexes_skipped_timeout > 0`, issue
+/// #1091) — the second of the three previously-ignored inputs.
+/// What: seeds `warmboot_summary.indexes_skipped_timeout = 1` and
+/// `warm_boot_degraded = true`, registers one healthy index (so
+/// `indexes_corpus_failed` stays `0`), and asserts `/health` reports
+/// `status: "degraded"`.
+/// Test: this IS the test.
+#[tokio::test]
+async fn health_reports_degraded_when_scan_timeout_recorded() {
+    use crate::core::indexer::CodeIndexer;
+    use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let registry = IndexRegistry::new();
+    registry.register(IndexHandle::bare(
+        IndexId::new("healthy"),
+        Arc::new(RwLock::new(CodeIndexer::new("healthy", "/tmp/healthy"))),
+        "/tmp/healthy".into(),
+    ));
+
+    let state = Arc::new(SearchAppState::new(registry));
+    {
+        let mut summary = state.warmboot_summary.lock().expect("lock");
+        summary.indexes_skipped_timeout = 1;
+        summary.warm_boot_degraded = true;
+    }
+
+    let Json(resp) = health_handler(State(Arc::clone(&state))).await;
+
+    assert_eq!(
+        resp.status, "degraded",
+        "#3706: /health must report 'degraded' when warm_boot_degraded is true \
+         from a scan timeout alone, even though indexes_corpus_failed is 0"
+    );
+}
+
+/// Issue #3706: same gap as the two tests above but for the mass-index-loss
+/// condition (`indexes_loaded` below 80% of the prior-known count) — the
+/// third of the three previously-ignored inputs.
+/// What: sets `state.prior_index_count = 10` and registers only 2 handles
+/// (2 < 10 * 80%), which is exactly the live signal
+/// `recompute_warm_boot_degraded` itself re-derives as `degraded_by_count`
+/// — so the assertion holds regardless of whether the deferred-embed-epoch
+/// recompute happens to fire during this call. Seeds `warm_boot_degraded =
+/// true` (what `record_warm_boot_result` would have set at boot) and asserts
+/// `/health` reports `status: "degraded"` even though `indexes_corpus_failed`
+/// stays `0` (neither registered handle has a failed stage).
+/// Test: this IS the test.
+#[tokio::test]
+async fn health_reports_degraded_on_mass_index_loss() {
+    use crate::core::indexer::CodeIndexer;
+    use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let registry = IndexRegistry::new();
+    for name in ["survivor-1", "survivor-2"] {
+        registry.register(IndexHandle::bare(
+            IndexId::new(name),
+            Arc::new(RwLock::new(CodeIndexer::new(name, "/tmp/does-not-exist"))),
+            "/tmp/does-not-exist".into(),
+        ));
+    }
+
+    let state = Arc::new(SearchAppState::new(registry));
+    state.prior_index_count.store(10, Ordering::Relaxed);
+    {
+        let mut summary = state.warmboot_summary.lock().expect("lock");
+        summary.warm_boot_degraded = true;
+    }
+
+    let Json(resp) = health_handler(State(Arc::clone(&state))).await;
+
+    assert_eq!(
+        resp.status, "degraded",
+        "#3706: /health must report 'degraded' on mass index loss (loaded < 80% \
+         of prior), even though indexes_corpus_failed is 0"
+    );
+}
+
+/// Issue #3706: the widened `overall_status` gate must not report degraded
+/// unconditionally — a boot with none of the four `warm_boot_degraded`
+/// inputs set (no TCC skip, no timeout, no corpus failure, no count drop)
+/// and no watcher-network degradation must still report `status: "ok"`.
+/// What: registers a single healthy index with a fresh `SearchAppState`
+/// (every `warmboot_summary` field at its zero/false default) and asserts
+/// `/health` reports `status: "ok"`.
+/// Test: this IS the test.
+#[tokio::test]
+async fn health_status_stays_ok_when_no_warm_boot_degraded_condition_holds() {
+    use crate::core::indexer::CodeIndexer;
+    use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+    use std::sync::Arc;
+    use tokio::sync::RwLock;
+
+    let registry = IndexRegistry::new();
+    registry.register(IndexHandle::bare(
+        IndexId::new("healthy"),
+        Arc::new(RwLock::new(CodeIndexer::new("healthy", "/tmp/healthy"))),
+        "/tmp/healthy".into(),
+    ));
+
+    let state = Arc::new(SearchAppState::new(registry));
+
+    let Json(resp) = health_handler(State(Arc::clone(&state))).await;
+
+    assert_eq!(
+        resp.status, "ok",
+        "#3706: folding warm_boot_degraded into overall_status must not report \
+         'degraded' when none of its inputs are set"
+    );
+}


### PR DESCRIPTION
## Summary

`GET /health`'s top-level `overall_status` (`crates/trusty-search/src/service/server/health.rs:559-564` pre-fix) only downgraded to `"degraded"` when `indexes_corpus_failed > 0` or a watcher was network-degraded — ignoring the other three conditions `warmboot_summary.warm_boot_degraded` itself aggregates (per its own doc comment at `crates/trusty-search/src/service/server/state.rs:535-546`):

- TCC/FDA denial (`indexes_skipped_tcc > 0`)
- scan timeout (`indexes_skipped_timeout > 0`)
- mass index loss (`indexes_loaded` < 80% of prior-known count)

A daemon genuinely warm-boot-degraded purely from one of those three still reported `status: "ok"` on `/health`, silently defeating the purpose of `warm_boot_degraded` and the reason trusty-review's `is_serving()` (#3693/#3704) never caught it — that consumer only inspects `warm_boot_degraded` once `status` itself already reads `"degraded"`.

Verified the issue's own suggested one-liner (fold `warmboot_summary.warm_boot_degraded` into the OR instead of `indexes_corpus_failed`) is correct and complete: `indexes_corpus_failed` is already OR'd into `warm_boot_degraded` earlier in the same handler (`health.rs:512-516`) before `overall_status` is computed, so checking `warm_boot_degraded` alone is a strict superset of the old condition — no case that used to report `"degraded"` stops doing so.

## Changes

- `crates/trusty-search/src/service/server/health.rs`: `overall_status` now checks `warmboot_summary.warm_boot_degraded || indexes_watcher_network_degraded > 0`.
- `crates/trusty-search/src/service/server/tests_health_degraded.rs`: 4 new tests — TCC-skip, scan-timeout, and mass-index-loss each written failing-first (confirmed `status: "ok"` pre-fix, `status: "degraded"` post-fix), plus a healthy-path guard (`status: "ok"` when no degraded condition holds).
- `crates/trusty-search/CHANGELOG.md`: `[Unreleased]` entry.

## Test plan

- [x] `cargo test -p trusty-search --no-fail-fast` (lib + all integration test binaries) — new tests failed pre-fix, pass post-fix; all integration binaries green. 12 pre-existing `create_index_*` failures in the lib target are an environmental artifact of this worktree living under `/private/tmp` (denylisted by `SENSITIVE_PATH_PREFIXES`, `allowlist/mod.rs:102-111`), unrelated to this change — matches the documented pre-existing flake.
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p trusty-search --check` — clean.

Closes #3706

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools