### PR TITLE
fix(trusty-search): honor --no-auto-discover in warm-boot colocated scan + harden dedup guard

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- **Warm-boot's colocated-root discovery scan now honors `--no-auto-discover`
+  / `TRUSTY_NO_AUTO_DISCOVER` (issue #3929).** Previously the flag only gated
+  the unrelated `auto_discover_and_index()` git-repo scan; `restore_indexes`
+  called `collect_colocated_entries` unconditionally on every boot, so a
+  restart with the flag set still walked every tracked root in `roots.toml`
+  and re-registered already-tracked indexes under a second, differently
+  derived id — both pointing at the same `<root>/.trusty-search/index.redb`.
+  redb is single-open, so the second registration failed with
+  `DatabaseAlreadyOpen` (188/222 indexes on the reporter's production box).
+  The scan is now gated by a new `collect_colocated_for_warmboot` helper in
+  `commands/start/restore.rs`.
+- **Hardened the warm-boot corpus dedup guard with file-identity (device,
+  inode) matching, on top of the existing root-path canonicalization (issue
+  #3929).** Two colocated entries whose `root_path` strings do not
+  canonicalize to the same value (e.g. two different mount-point aliases of
+  one backing NFS/EFS export) but whose resolved `index.redb` is the same
+  physical file are now still collapsed to one survivor — closing a gap in
+  `corpus_dedup_key` (`service/warm_boot/mod.rs`) where "same `colocated`
+  corpus" was determined purely by root-path string equality.
+
+---
 ## [0.39.1] — 2026-07-24
 
 ### Fixed

--- a/crates/trusty-search/src/commands/start/daemon.rs
+++ b/crates/trusty-search/src/commands/start/daemon.rs
@@ -37,7 +37,11 @@ use crate::commands::prior_index_count::load_prior_index_count;
 /// environment). When `no_auto_discover` is `true` (or
 /// `TRUSTY_NO_AUTO_DISCOVER=1` is set), the post-hydration auto-discovery scan
 /// is skipped entirely so the daemon serves only indexes already in
-/// `indexes.toml` or registered at runtime.
+/// `indexes.toml` or registered at runtime. Issue #3929: the flag also gates
+/// warm-boot's colocated-root discovery scan (`restore_indexes` →
+/// `collect_colocated_for_warmboot`) — previously that scan ran unconditionally
+/// even with `--no-auto-discover` set, re-registering already-tracked indexes
+/// under a second id and colliding on the shared `.redb` corpus.
 /// Test: run twice in a row — the second invocation must exit 1 with the
 /// "another daemon is already running" message. Run with `--data-dir /tmp/ts-x`
 /// and confirm the lockfile lands in `/tmp/ts-x/daemon.lock`. Unit coverage:
@@ -401,7 +405,10 @@ pub async fn handle_start(
                     .prior_index_count
                     .store(prior, std::sync::atomic::Ordering::Relaxed);
                 // Issue #85: restore every index recorded in `indexes.toml`.
-                restore_indexes(&install_state, &embedder).await;
+                // Issue #3929: `no_auto_discover` must also gate the warm-boot
+                // colocated-root discovery scan, not just `auto_discover_and_index`
+                // below — see `restore_indexes`'s doc comment.
+                restore_indexes(&install_state, &embedder, no_auto_discover).await;
                 // Issue #1670: boot-time stale-index reconciliation — for each
                 // restored index, compare the stored indexed_head_sha against
                 // the current git HEAD and reindex only what changed (or fall

--- a/crates/trusty-search/src/commands/start/restore.rs
+++ b/crates/trusty-search/src/commands/start/restore.rs
@@ -20,10 +20,54 @@ use crate::commands::start_restore::restore_one_index;
 use crate::service::SearchAppState;
 
 use crate::service::lazy_loader::{select_warmboot_entries, warmboot_max_indexes};
+use crate::service::persistence::PersistedIndex;
 use crate::service::warm_boot::{
     collect_colocated_entries, collect_legacy_entries, is_on_inaccessible_volume,
     probe_warmboot_volumes, probe_warmboot_volumes_from_paths, restore_one_index_bounded,
 };
+
+/// Collect colocated index entries for warm-boot, honoring
+/// `--no-auto-discover` / `TRUSTY_NO_AUTO_DISCOVER` (issue #3929).
+///
+/// Why: `restore_indexes` previously called `collect_colocated_entries`
+/// unconditionally. `--no-auto-discover`'s documented contract
+/// (`commands/start/daemon.rs::handle_start`) is that "the daemon serves only
+/// indexes already in `indexes.toml` or registered at runtime" — but the flag
+/// only gated the UNRELATED `auto_discover_and_index()` git-repo scan
+/// (`daemon.rs` ~line 436), not this one. The colocated-root scan IS a
+/// discovery mechanism in exactly the sense the flag promises to disable: it
+/// walks every tracked root in `roots.toml` looking for `.trusty-search/`
+/// directories and registers whatever it finds under a freshly-derived id —
+/// including a SECOND registration, under a different id, for a root that a
+/// legacy `indexes.toml` entry already owns. Both registrations resolve to
+/// the same `<root>/.trusty-search/index.redb`; redb is single-open, so the
+/// second one fails with `DatabaseAlreadyOpen` (issue #3929 — 188/222 indexes
+/// on the reporter's production box, despite `--no-auto-discover` being set).
+/// What: when `no_auto_discover` is `true`, returns an empty `Vec` without
+/// walking a single tracked root — a full no-op for the scan itself.
+/// `colocated_inaccessible` (the pre-computed per-volume probe result) is
+/// still accepted so the signature stays stable for the caller, which also
+/// reuses it for the restore-time TCC skip check on legacy colocated entries
+/// regardless of this flag. Otherwise (flag not set) delegates to
+/// `collect_colocated_entries` exactly as before the fix.
+/// Test: `collect_colocated_for_warmboot_skips_scan_when_no_auto_discover`,
+/// `collect_colocated_for_warmboot_scans_when_auto_discover_enabled`.
+async fn collect_colocated_for_warmboot(
+    no_auto_discover: bool,
+    seen_ids: &HashSet<String>,
+    seen_root_paths: &HashSet<std::path::PathBuf>,
+    colocated_inaccessible: &HashSet<std::path::PathBuf>,
+) -> Vec<PersistedIndex> {
+    if no_auto_discover {
+        tracing::info!(
+            "warm-boot: skipping colocated-root discovery scan — \
+             --no-auto-discover / TRUSTY_NO_AUTO_DISCOVER is set (issue #3929); \
+             serving only indexes already in indexes.toml"
+        );
+        return Vec::new();
+    }
+    collect_colocated_entries(seen_ids, seen_root_paths, colocated_inaccessible).await
+}
 
 /// Restore every index recorded in `indexes.toml` and in colocated roots by
 /// re-registering it on the in-memory registry.
@@ -33,14 +77,18 @@ use crate::service::warm_boot::{
 /// `spawn_blocking` + timeout. #723 adds probe-per-volume: each distinct
 /// volume is probed ONCE on a bare OS thread before any redb opens so a
 /// TCC-blocked volume costs at most one leaked thread (not one-per-index).
+/// Issue #3929: `no_auto_discover` must gate the colocated-root discovery
+/// scan too — see `collect_colocated_for_warmboot`.
 /// What: collects all entries (legacy + colocated), applies selective warm-boot
 /// (issue #993) to split into eager/cold slices, then restores only the eager
 /// slice via `restore_one_index_bounded`. Cold entries are registered into
 /// `state.cold_store` for lazy on-demand loading.
-/// Test: integration test in `tests/integration_tests.rs`.
+/// Test: integration test in `tests/integration_tests.rs`;
+///       `collect_colocated_for_warmboot_*` in this module (issue #3929).
 pub(super) async fn restore_indexes(
     state: &SearchAppState,
     embedder: &Arc<dyn crate::core::Embedder>,
+    no_auto_discover: bool,
 ) {
     // Issue #993: read TRUSTY_WARMBOOT_MAX_INDEXES once before collecting.
     let max_warmboot = warmboot_max_indexes();
@@ -88,8 +136,13 @@ pub(super) async fn restore_indexes(
             Err(_) => std::collections::HashSet::new(),
         }
     };
-    let colocated_entries =
-        collect_colocated_entries(&seen_ids, &seen_root_paths, &colocated_inaccessible).await;
+    let colocated_entries = collect_colocated_for_warmboot(
+        no_auto_discover,
+        &seen_ids,
+        &seen_root_paths,
+        &colocated_inaccessible,
+    )
+    .await;
 
     // Merge into a single pool then apply selective warm-boot split (issue #993).
     let all_entries: Vec<_> = legacy_entries
@@ -337,4 +390,93 @@ fn prune_and_persist_dedup_outcome(outcome: &crate::service::warm_boot::DedupOut
         outcome.dropped.len(),
         outcome.merged_survivor_ids.len(),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why (issue #3929 — the regression): before the fix,
+    /// `collect_colocated_for_warmboot` (like the `restore_indexes` call site
+    /// it replaced) ran the colocated-root discovery scan unconditionally,
+    /// ignoring `--no-auto-discover`. This is the reporter's exact production
+    /// repro: a real colocated root is tracked in `roots.toml`; with
+    /// `no_auto_discover = true`, warm-boot must NOT discover or return it.
+    /// What: register one real colocated root via `roots_registry::upsert_root`,
+    /// call `collect_colocated_for_warmboot(true, ..)`, assert the result is
+    /// empty.
+    /// Note: `serial` prevents parallel env-var mutation from other tests
+    /// (`TRUSTY_DATA_DIR` is shared global state), matching the pattern used
+    /// throughout `warm_boot_tests.rs`.
+    /// Test: this test.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn collect_colocated_for_warmboot_skips_scan_when_no_auto_discover() {
+        let data_tmp = tempfile::tempdir().unwrap();
+        let real_root = tempfile::tempdir().unwrap();
+        let ts_dir = real_root.path().join(".trusty-search");
+        std::fs::create_dir_all(&ts_dir).unwrap();
+
+        unsafe {
+            std::env::set_var("TRUSTY_DATA_DIR", data_tmp.path());
+        }
+        crate::service::roots_registry::upsert_root(real_root.path().to_path_buf()).unwrap();
+
+        let seen_ids: HashSet<String> = HashSet::new();
+        let seen_root_paths: HashSet<std::path::PathBuf> = HashSet::new();
+        let inaccessible: HashSet<std::path::PathBuf> = HashSet::new();
+
+        let results =
+            collect_colocated_for_warmboot(true, &seen_ids, &seen_root_paths, &inaccessible).await;
+
+        unsafe {
+            std::env::remove_var("TRUSTY_DATA_DIR");
+        }
+
+        assert!(
+            results.is_empty(),
+            "--no-auto-discover must suppress the colocated-root discovery scan \
+             entirely (issue #3929); got: {results:?}"
+        );
+    }
+
+    /// Why: the fix must not regress the default (flag NOT set) path — the
+    /// colocated scan must still discover tracked roots when
+    /// `no_auto_discover` is `false`, exactly as before issue #3929.
+    /// What: same setup as the skip test but with `no_auto_discover = false`;
+    /// assert the real root IS discovered.
+    /// Test: this test.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn collect_colocated_for_warmboot_scans_when_auto_discover_enabled() {
+        let data_tmp = tempfile::tempdir().unwrap();
+        let real_root = tempfile::tempdir().unwrap();
+        let ts_dir = real_root.path().join(".trusty-search");
+        std::fs::create_dir_all(&ts_dir).unwrap();
+
+        unsafe {
+            std::env::set_var("TRUSTY_DATA_DIR", data_tmp.path());
+        }
+        crate::service::roots_registry::upsert_root(real_root.path().to_path_buf()).unwrap();
+
+        let seen_ids: HashSet<String> = HashSet::new();
+        let seen_root_paths: HashSet<std::path::PathBuf> = HashSet::new();
+        let inaccessible: HashSet<std::path::PathBuf> = HashSet::new();
+
+        let results =
+            collect_colocated_for_warmboot(false, &seen_ids, &seen_root_paths, &inaccessible).await;
+
+        unsafe {
+            std::env::remove_var("TRUSTY_DATA_DIR");
+        }
+
+        assert_eq!(
+            results.len(),
+            1,
+            "with no_auto_discover=false the colocated scan must still discover \
+             tracked roots exactly as before issue #3929; got: {results:?}"
+        );
+        let canonical_root = real_root.path().canonicalize().unwrap();
+        assert_eq!(results[0].root_path, canonical_root);
+    }
 }

--- a/crates/trusty-search/src/service/warm_boot/mod.rs
+++ b/crates/trusty-search/src/service/warm_boot/mod.rs
@@ -170,34 +170,111 @@ pub fn is_on_inaccessible_volume(
     inaccessible_volumes.contains(&key)
 }
 
+/// Dedup key identifying the on-disk redb corpus a [`PersistedIndex`] resolves
+/// to (issue #2305; file-identity variant added for issue #3929).
+///
+/// Why: a plain canonicalized `root_path` string is not always a reliable
+/// proxy for "same redb file" — e.g. two mount-point aliases of the same
+/// backing NFS/EFS export canonicalize to two DIFFERENT absolute paths even
+/// though they resolve to the identical file server-side (issue #3929: this
+/// is the suspected reason a legacy `indexes.toml` entry and a freshly
+/// colocated-scanned entry for the "same" root slipped past the root-path
+/// equality check and both got registered against one physical `.redb`).
+/// [`Inode`] is the stronger signal — two entries whose resolved `index.redb`
+/// shares a `(device, inode)` pair are the same file on Unix, regardless of
+/// which path alias was used to reach it (symlinks, bind mounts, and — on
+/// filesystems where the client-side device id is stable across mounts of the
+/// same export — some NFS/EFS mount-alias cases too). [`Path`] is the
+/// pre-existing fallback used whenever the redb file cannot be stat'd (not
+/// created yet, permissions, non-Unix target).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum CorpusDedupKey {
+    /// `(st_dev, st_ino)` of the resolved `index.redb` file.
+    Inode(u64, u64),
+    /// Canonicalized `root_path`, used when file identity is unavailable.
+    Path(PathBuf),
+}
+
+impl std::fmt::Display for CorpusDedupKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CorpusDedupKey::Inode(dev, ino) => write!(f, "inode:{dev}:{ino}"),
+            CorpusDedupKey::Path(p) => write!(f, "path:{}", p.display()),
+        }
+    }
+}
+
+/// Read-only `(st_dev, st_ino)` identity of `entry`'s on-disk redb corpus
+/// file, when it exists (issue #3929).
+///
+/// Why: stat'ing the actual corpus file (rather than just its parent
+/// `root_path`) gives the strongest available "same file" signal without
+/// requiring the two entries' `root_path` strings to canonicalize identically
+/// — see [`CorpusDedupKey`]. Never creates the file or any parent directory.
+/// What: builds `<root_path>/.trusty-search/index.redb` directly (bypassing
+/// `colocated_storage_dir`'s `create_dir_all` side effect) and calls
+/// `std::fs::metadata` on it. Returns `None` when the file does not exist,
+/// cannot be stat'd, or the target platform is not Unix (no portable
+/// device/inode API elsewhere).
+/// Test: `dedup_by_corpus_path_collapses_hardlinked_redb_across_different_roots`
+/// in `warm_boot_tests.rs`.
+fn corpus_file_identity(entry: &PersistedIndex) -> Option<(u64, u64)> {
+    if !entry.colocated {
+        return None;
+    }
+    let redb_path = entry
+        .root_path
+        .join(crate::service::colocated_storage::COLOCATED_DIR_NAME)
+        .join("index.redb");
+    let meta = std::fs::metadata(&redb_path).ok()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Some((meta.dev(), meta.ino()))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = meta;
+        None
+    }
+}
+
 /// Resolve the dedup key for `entry` — the identity of its on-disk redb corpus
-/// file — WITHOUT any filesystem side effect (issue #2305).
+/// file — WITHOUT any filesystem side effect beyond a read-only `stat`
+/// (issue #2305; file-identity fallback added for issue #3929).
 ///
 /// Why: `corpus_redb_path_for_entry` routes through `colocated_storage_dir`,
 /// which calls `create_dir_all` and would materialise a ghost `.trusty-search/`
 /// directory for a moved/dead root at collection time (the exact hazard the
-/// #484 relocation guard avoids). Deduplication must therefore key on a pure
-/// path formula. Only colocated entries can collide: their corpus lives at
-/// `<root_path>/.trusty-search/index.redb`, so two entries sharing a
+/// #484 relocation guard avoids). Deduplication must therefore key on a pure,
+/// read-only formula. Only colocated entries can collide: their corpus lives
+/// at `<root_path>/.trusty-search/index.redb`, so two entries sharing a
 /// `root_path` share one redb file. Legacy (non-colocated) corpora are keyed by
 /// unique `index_id` in the global data dir and can never collide, so they are
 /// never merged (`None`).
-/// What: for a colocated entry returns `Some(canonicalize_best_effort(root_path))`
-/// (canonicalization resolves symlink / `/var`↔`/private/var` aliases so two
-/// aliased roots map to one key, matching the read-only canonicalization used
-/// for the `seen_root_paths` set in `restore_indexes`); returns `None` for a
-/// non-colocated entry. `canonicalize_best_effort` is read-only — it never
-/// creates directories.
+/// What: for a colocated entry, prefers [`CorpusDedupKey::Inode`] (the
+/// resolved redb file's `(device, inode)`, via `corpus_file_identity`) when
+/// the file exists; falls back to
+/// `CorpusDedupKey::Path(canonicalize_best_effort(root_path))` (canonicalization
+/// resolves symlink / `/var`↔`/private/var` aliases so two aliased roots map
+/// to one key, matching the read-only canonicalization used for the
+/// `seen_root_paths` set in `restore_indexes`). Returns `None` for a
+/// non-colocated entry.
 /// Test: `dedup_by_corpus_path_*` in `warm_boot_tests.rs`.
-fn corpus_dedup_key(entry: &PersistedIndex) -> Option<PathBuf> {
+fn corpus_dedup_key(entry: &PersistedIndex) -> Option<CorpusDedupKey> {
     if !entry.colocated {
         // Legacy corpora are id-keyed in the global data dir → never collide.
         return None;
     }
+    if let Some((dev, ino)) = corpus_file_identity(entry) {
+        return Some(CorpusDedupKey::Inode(dev, ino));
+    }
     // Same root ⟺ same `<root>/.trusty-search/index.redb`, so keying on the
     // canonical root is equivalent to keying on the redb path and avoids the
     // create_dir_all side effect of resolving the redb path directly.
-    Some(canonicalize_best_effort(&entry.root_path))
+    Some(CorpusDedupKey::Path(canonicalize_best_effort(
+        &entry.root_path,
+    )))
 }
 
 /// Outcome of [`dedup_entries_by_corpus_path_verbose`] (issue #2337).
@@ -282,7 +359,7 @@ pub fn dedup_entries_by_corpus_path_verbose(entries: Vec<PersistedIndex>) -> Ded
 
     // First pass: group entry indices by corpus-path key. Entries with no key
     // (non-colocated) are always retained and can never be a collision member.
-    let mut groups: HashMap<PathBuf, Vec<usize>> = HashMap::new();
+    let mut groups: HashMap<CorpusDedupKey, Vec<usize>> = HashMap::new();
     for (i, entry) in entries.iter().enumerate() {
         if let Some(key) = corpus_dedup_key(entry) {
             groups.entry(key).or_default().push(i);
@@ -336,7 +413,7 @@ pub fn dedup_entries_by_corpus_path_verbose(entries: Vec<PersistedIndex>) -> Ded
                  meant to be separate indexes.",
                 loser.id,
                 survivor_id,
-                key.display(),
+                key,
                 survivor_id,
                 loser.id,
                 loser.include_docs,

--- a/crates/trusty-search/src/service/warm_boot/warm_boot_tests.rs
+++ b/crates/trusty-search/src/service/warm_boot/warm_boot_tests.rs
@@ -446,6 +446,68 @@ fn dedup_by_corpus_path_keeps_most_recent() {
     );
 }
 
+/// Why (issue #3929 — the dedup-guard gap): a legacy `indexes.toml` entry and
+/// a freshly colocated-scanned entry for the "same" physical corpus can carry
+/// `root_path` strings that DO NOT canonicalize to the same value (e.g. two
+/// different mount-point aliases of the same backing NFS/EFS export), so the
+/// pre-#3929 path-only dedup key missed the collision and both entries
+/// survived — the reporter's production repro was 188/222 indexes failing
+/// with `DatabaseAlreadyOpen` because two IDs pointed at one `.redb`.
+/// What: two colocated entries at DISTINCT temp roots (so
+/// `canonicalize_best_effort` produces two different keys — this is exactly
+/// the case the old path-only key would miss) whose `index.redb` files are
+/// the SAME inode via a hard link (simulating "two path aliases, one
+/// physical file" without requiring a real NFS/EFS mount in a unit test).
+/// Assert the pair still collapses to one survivor because `corpus_dedup_key`
+/// now prefers the resolved file's `(device, inode)` identity over the
+/// root-path string.
+/// Test: this test.
+#[test]
+fn dedup_by_corpus_path_collapses_hardlinked_redb_across_different_roots() {
+    let root_a = tempfile::tempdir().unwrap();
+    let root_b = tempfile::tempdir().unwrap();
+
+    let ts_a = root_a.path().join(".trusty-search");
+    let ts_b = root_b.path().join(".trusty-search");
+    std::fs::create_dir_all(&ts_a).unwrap();
+    std::fs::create_dir_all(&ts_b).unwrap();
+
+    let redb_a = ts_a.join("index.redb");
+    let redb_b = ts_b.join("index.redb");
+    std::fs::write(&redb_a, b"redb-bytes").unwrap();
+    // Hard link, not a copy: `redb_b` now shares the SAME inode as `redb_a`,
+    // exactly like two mount-point aliases resolving to one server-side file.
+    std::fs::hard_link(&redb_a, &redb_b).unwrap();
+
+    // Sanity: the two roots must NOT canonicalize to the same path — otherwise
+    // this test would pass even with the pre-#3929 path-only key and prove
+    // nothing about the fix.
+    assert_ne!(
+        root_a.path().canonicalize().unwrap(),
+        root_b.path().canonicalize().unwrap(),
+        "test setup invalid: roots must be distinct paths"
+    );
+
+    let entries = vec![
+        colocated_entry("legacy-alias", root_a.path(), Some(10)),
+        colocated_entry("colocated-scan-alias", root_b.path(), Some(999)),
+    ];
+
+    let deduped = dedup_entries_by_corpus_path(entries);
+
+    assert_eq!(
+        deduped.len(),
+        1,
+        "two entries whose index.redb is the same inode must collapse to one \
+         survivor even when their root_path strings differ (issue #3929); \
+         got: {deduped:?}"
+    );
+    assert_eq!(
+        deduped[0].id, "colocated-scan-alias",
+        "the most-recently-active entry must be the survivor"
+    );
+}
+
 // ── dedup_entries_by_corpus_path_verbose (issue #2337) ────────────────────
 
 /// Why (#2337 part 1): callers need the dropped entries to prune their


### PR DESCRIPTION
## Summary

- Warm-boot's colocated-root discovery scan (`restore_indexes` → `collect_colocated_entries`) ran **unconditionally**, ignoring `--no-auto-discover` / `TRUSTY_NO_AUTO_DISCOVER`. The flag only ever gated the unrelated `auto_discover_and_index()` git-repo scan. A restart with the flag set still walked every tracked root in `roots.toml` and re-registered already-tracked indexes under a second, differently-derived id — both pointing at the same `<root>/.trusty-search/index.redb`. redb is single-open, so the second registration failed with `DatabaseAlreadyOpen` (the reporter's production box: 188/222 indexes).
- Adds `collect_colocated_for_warmboot()` in `commands/start/restore.rs` to gate the scan behind the (already env+CLI-resolved) `no_auto_discover` flag, threaded through from `handle_start` in `daemon.rs`.
- Hardens `corpus_dedup_key` (`service/warm_boot/mod.rs`) with a file-identity `(device, inode)` check on the resolved `index.redb`, layered on top of the existing root-path canonicalization. This closes a gap where two colocated entries whose `root_path` strings do not canonicalize identically (e.g. two different mount-point aliases of one backing NFS/EFS export) — but whose `index.redb` is the same physical file — previously were **not** deduped and both survived to the restore step.

## Root cause (confirmed)

`crates/trusty-search/src/commands/start/daemon.rs` only threaded `no_auto_discover` into the *second*, unrelated discovery mechanism (`auto_discover_and_index()`, line ~436). `restore_indexes` (`commands/start/restore.rs`) — the actual warm-boot path — had no `no_auto_discover` parameter at all and called `collect_colocated_entries` unconditionally. This is deterministic and 100% reproducible; the regression test (`collect_colocated_for_warmboot_skips_scan_when_no_auto_discover`) fails against the pre-fix code every time.

The dedup-guard gap (`corpus_dedup_key` in `service/warm_boot/mod.rs`) is real but its exact production trigger (mount-alias canonicalization asymmetry) could not be independently confirmed against a live NFS/EFS mount — see the PR description discussion in the linked issue. The fix is a strict improvement (adds a stronger signal on top of the existing one, never removes coverage) and is proven via a hard-link-based regression test that fails pre-fix and passes post-fix.

## Test plan

- [x] New regression tests genuinely fail before the fix and pass after (verified by temporarily reverting each fix in isolation and re-running):
  - `commands::start::restore::tests::collect_colocated_for_warmboot_skips_scan_when_no_auto_discover`
  - `commands::start::restore::tests::collect_colocated_for_warmboot_scans_when_auto_discover_enabled` (no-regression check for the flag-off path)
  - `service::warm_boot::tests::dedup_by_corpus_path_collapses_hardlinked_redb_across_different_roots`
- [x] `cargo test -p trusty-search` (all targets: lib + both bins + all 17 integration test binaries) — lib target has 12 pre-existing, deterministic, unrelated failures (see below); every other target is 100% green.
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check -p trusty-search` — clean.
- [x] `cargo test -p trusty-search --lib server::tests_2336 -- --test-threads=1` × 10 — deterministic `7 failed / 0 passed` every run (not a flake); same root cause as below.

### Known environmental artifact (not caused by this PR)

12 `--lib`-target tests in the `create_index_*` / `relocate_index_*` family (`tests_1073`, `tests_2336`, `tests_2984`, `tests_index`, `tests_state` — none touched by this diff) fail with HTTP 400 because `tempfile::tempdir()` resolves under `TMPDIR=/var/folders/...`, which is in `SENSITIVE_PATH_PREFIXES` (`allowlist/mod.rs`) — independently confirmed via direct inspection, not just asserted. All 17 integration test binaries and the `trusty-search` bin target (320 tests) are 100% green.

Closes #3929

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools